### PR TITLE
fix: avoid full-history work during precheck recovery

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -73,6 +73,7 @@ type SessionManagerMocks = {
   getLeafId: Mock<() => string | null>;
   getLeafEntry: UnknownMock;
   getEntry: UnknownMock;
+  getEntries: UnknownMock;
   getBoundaryCount: UnknownMock;
   branch: UnknownMock;
   resetLeaf: UnknownMock;
@@ -283,6 +284,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     getLeafId: vi.fn<() => string | null>(() => null),
     getLeafEntry: vi.fn(() => null),
     getEntry: vi.fn(() => undefined),
+    getEntries: vi.fn(() => []),
     getBoundaryCount: vi.fn(() => 0),
     branch: vi.fn(),
     resetLeaf: vi.fn(),
@@ -1145,6 +1147,7 @@ export function resetEmbeddedAttemptHarness(
   hoisted.sessionManager.getLeafId.mockReset().mockReturnValue(null);
   hoisted.sessionManager.getLeafEntry.mockReset().mockReturnValue(null);
   hoisted.sessionManager.getEntry.mockReset().mockReturnValue(undefined);
+  hoisted.sessionManager.getEntries.mockReset().mockReturnValue([]);
   hoisted.sessionManager.getBoundaryCount.mockReset().mockReturnValue(0);
   hoisted.sessionManager.branch.mockReset();
   hoisted.sessionManager.resetLeaf.mockReset();

--- a/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.ts
@@ -15,7 +15,7 @@ import type { AgentMessage } from "../../runtime/index.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import { log } from "../logger.js";
 import { canContinueFromMessage, trimToContinuableTail } from "./compaction-timeout.js";
-import { MID_TURN_PRECHECK_ERROR_MESSAGE } from "./midturn-precheck.js";
+import { isMidTurnPrecheckAssistantError } from "./midturn-precheck.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
 type AttemptSessionManager = ReturnType<typeof guardSessionManager>;
@@ -24,34 +24,35 @@ export function flushSessionManagerTranscript(sessionManager: AttemptSessionMana
   sessionManager.flushPendingPersistence();
 }
 
-function isMidTurnPrecheckAssistantError(message: AgentMessage | undefined): boolean {
-  if (!message || message.role !== "assistant") {
-    return false;
-  }
-  return message.stopReason === "error" && message.errorMessage === MID_TURN_PRECHECK_ERROR_MESSAGE;
-}
-
 export function removeTrailingMidTurnPrecheckAssistantError(params: {
   activeSession: { agent: { state: { messages: AgentMessage[] } } };
   sessionManager: AttemptSessionManager;
 }): void {
   const messages = params.activeSession.agent.state.messages;
   const removedActiveError = isMidTurnPrecheckAssistantError(messages.at(-1));
+  const preserveTrailing = (entry: ReturnType<AttemptSessionManager["getEntries"]>[number]) =>
+    entry.type === "custom" ||
+    entry.type === "label" ||
+    entry.type === "session_info" ||
+    (entry.type === "message" && isTranscriptOnlyOpenClawAssistantMessage(entry.message));
+  const persistedTail = params.sessionManager
+    .getEntries()
+    .findLast((entry) => !preserveTrailing(entry));
+  // New guarded writes omit the signal. Retain cleanup for an already-persisted legacy error.
+  const hasPersistedError =
+    persistedTail?.type === "message" && isMidTurnPrecheckAssistantError(persistedTail.message);
   const removedPersistedError =
+    hasPersistedError &&
     params.sessionManager.removeTrailingEntries(
       (entry) => entry.type === "message" && isMidTurnPrecheckAssistantError(entry.message),
       {
-        preserveTrailing: (entry) =>
-          entry.type === "custom" ||
-          entry.type === "label" ||
-          entry.type === "session_info" ||
-          (entry.type === "message" && isTranscriptOnlyOpenClawAssistantMessage(entry.message)),
+        preserveTrailing,
       },
     ) > 0;
   if (removedActiveError) {
     params.activeSession.agent.state.messages = messages.slice(0, -1);
   }
-  if (removedActiveError && !removedPersistedError) {
+  if (hasPersistedError && removedActiveError && !removedPersistedError) {
     log.warn(
       "[context-overflow-midturn-precheck] removed synthetic assistant error from active session but could not locate matching persisted SessionManager entry",
     );

--- a/src/agents/embedded-agent-runner/run/attempt-transcript-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-transcript-recovery.test.ts
@@ -3,6 +3,7 @@ import { expect, it } from "vitest";
 import { openOpenClawAgentDatabase } from "../../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
 import type { AgentMessage } from "../../runtime/index.js";
+import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import { SessionManager } from "../../sessions/session-manager.js";
 import { createZeroUsageFixture } from "../../test-helpers/usage-fixtures.js";
 import { stripSessionsYieldArtifacts } from "./attempt-sessions-yield.js";
@@ -10,7 +11,16 @@ import {
   normalizeCompactionRecoveryTranscriptTail,
   removeTrailingMidTurnPrecheckAssistantError,
 } from "./attempt-transcript-helpers.js";
-import { MID_TURN_PRECHECK_ERROR_MESSAGE } from "./midturn-precheck.js";
+import { MidTurnPrecheckSignal } from "./midturn-precheck.js";
+
+const MID_TURN_PRECHECK_ERROR_MESSAGE = new MidTurnPrecheckSignal({
+  route: "compact_only",
+  estimatedPromptTokens: 1100,
+  promptBudgetBeforeReserve: 1000,
+  overflowTokens: 100,
+  toolResultReducibleChars: 0,
+  effectiveReserveTokens: 100,
+}).message;
 
 it.each(["yield", "precheck", "compaction"])(
   "publishes %s recovery only after the transcript rewrite commits",
@@ -67,3 +77,44 @@ it.each(["yield", "precheck", "compaction"])(
     });
   },
 );
+
+it("keeps a mid-turn routing error out of durable history and resumes without a rewrite", async () => {
+  await withOpenClawTestState({ label: "precheck-no-rewrite" }, async (state) => {
+    const target = {
+      agentId: "main",
+      sessionId: "precheck-no-rewrite",
+      sessionKey: "agent:main:precheck-no-rewrite",
+      storePath: path.join(state.agentDir(), "openclaw-agent.sqlite"),
+    };
+    const sessionManager = guardSessionManager(SessionManager.open(target, state.workspaceDir));
+    const user: AgentMessage = { role: "user", content: "continue", timestamp: 1 };
+    sessionManager.appendMessage(user);
+    const before = SessionManager.open(target).getEntries();
+    const error: AgentMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "" }],
+      api: "openai-responses",
+      provider: "openai",
+      model: "test-model",
+      stopReason: "error",
+      errorMessage: MID_TURN_PRECHECK_ERROR_MESSAGE,
+      timestamp: 2,
+      usage: createZeroUsageFixture(),
+    };
+    sessionManager.appendMessage(error);
+    expect(SessionManager.open(target).getEntries()).toEqual(before);
+    const database = openOpenClawAgentDatabase({ agentId: "main", path: target.storePath });
+    database.db.exec(`CREATE TRIGGER reject_recovery BEFORE INSERT ON transcript_events
+      BEGIN SELECT RAISE(ABORT, 'unexpected recovery write'); END;`);
+    const activeSession = { agent: { state: { messages: [user, error] } } };
+    removeTrailingMidTurnPrecheckAssistantError({ activeSession, sessionManager });
+    expect(activeSession.agent.state.messages).toEqual([user]);
+    expect(SessionManager.open(target).getEntries()).toEqual(before);
+    database.db.exec("DROP TRIGGER reject_recovery");
+    sessionManager.appendMessage({ ...error, errorMessage: "provider unavailable" });
+    expect(SessionManager.open(target).buildSessionContext().messages.at(-1)).toMatchObject({
+      role: "assistant",
+      errorMessage: "provider unavailable",
+    });
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -2819,7 +2819,7 @@ describe("runEmbeddedAttempt context engine mid-turn precheck integration", () =
     expect(loopHookParams.midTurnPrecheck).toBeUndefined();
   });
 
-  it("recovers when the runtime persists the mid-turn precheck as an assistant error", async () => {
+  it("recovers when the runtime emits the mid-turn precheck as an assistant error", async () => {
     hoisted.installToolResultContextGuardMock.mockImplementation((...args: unknown[]) => {
       const params = args[0] as ToolResultGuardInstallParams;
       params.midTurnPrecheck?.onMidTurnPrecheck?.({

--- a/src/agents/embedded-agent-runner/run/midturn-precheck.ts
+++ b/src/agents/embedded-agent-runner/run/midturn-precheck.ts
@@ -1,6 +1,7 @@
 /**
  * Signals mid-turn prechecks that require preemptive compaction routing.
  */
+import type { AgentMessage } from "../../runtime/index.js";
 import type { PreemptiveCompactionRoute } from "./preemptive-compaction.types.js";
 
 /**
@@ -17,7 +18,7 @@ export type MidTurnPrecheckRequest = {
 };
 
 /** Stable message used to identify synthetic mid-turn overflow errors in session cleanup. */
-export const MID_TURN_PRECHECK_ERROR_MESSAGE =
+const MID_TURN_PRECHECK_ERROR_MESSAGE =
   "Context overflow: prompt too large for the model (mid-turn precheck).";
 
 /**
@@ -38,4 +39,13 @@ export class MidTurnPrecheckSignal extends Error {
 /** Narrows unknown errors to the mid-turn overflow signal used by attempt cleanup. */
 export function isMidTurnPrecheckSignal(error: unknown): error is MidTurnPrecheckSignal {
   return error instanceof MidTurnPrecheckSignal;
+}
+
+/** This local routing signal is not a provider response or durable conversation item. */
+export function isMidTurnPrecheckAssistantError(message: AgentMessage | undefined): boolean {
+  return (
+    message?.role === "assistant" &&
+    message.stopReason === "error" &&
+    message.errorMessage === MID_TURN_PRECHECK_ERROR_MESSAGE
+  );
 }

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -22,6 +22,7 @@ import {
   type UserTurnTranscriptRecorder,
 } from "../sessions/user-turn-transcript.js";
 import type { AssistantErrorTranscript } from "./assistant-error-transcript.js";
+import { isMidTurnPrecheckAssistantError } from "./embedded-agent-runner/run/midturn-precheck.js";
 import type { EmbeddedRunTrigger } from "./embedded-agent-runner/run/params.js";
 import { resolveLiveToolResultMaxChars } from "./embedded-agent-runner/tool-result-truncation.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "./harness/hook-helpers.js";
@@ -127,6 +128,10 @@ export function guardSessionManager(
     event: { message: AgentMessage },
     sourceAppend?: CodeModeSourceAppend,
   ) => {
+    // Persisting a routing signal would force recovery to rewrite the whole archive to remove it.
+    if (isMidTurnPrecheckAssistantError(event.message)) {
+      return { block: true };
+    }
     const runtimeUserMessage = runtimeUserMessageByPersistedMessage.get(event.message);
     let message = event.message;
     let changed = false;


### PR DESCRIPTION
## Summary

### High Level TLDR

Context-overflow recovery could synchronously load an entire session archive just to check for a synthetic error, and replace that archive when the error had been persisted. Keep the internal mid-turn precheck signal out of transcript writes and bypass durable cleanup when the loaded tail contains no such error.

Related to #119720 and #138984. This is a separate recovery-path fix, not a replacement for the atomic rewrite/ancestry repair in #138984.

## What Problem This Solves

Fixes an issue where a tool-heavy turn reaching its context budget could stall the Gateway during synthetic-error cleanup, particularly with a large retained transcript. This work does not repair existing amplified histories or eliminate every compaction cost.

## Root Cause

`MidTurnPrecheckSignal` is converted by agent-core into an error-shaped assistant message. `removeTrailingMidTurnPrecheckAssistantError` unconditionally called `SessionManager.removeTrailingEntries`, which hydrates the complete persisted history even when nothing matches, and uses full transcript replacement when a match exists.

Current upstream's deferred assistant-error recorder reduces persistence of ordinary failed-attempt text, but does not remove that unconditional cleanup hydration. Guarded managers without the deferred recorder, including the affected older runtime path, also persisted this internal signal before deleting it again.

The regression fails on base `64bf8246132` because the guarded manager stores the routing signal. The fix leaves the durable transcript unchanged, removes the in-memory signal, and preserves ordinary provider errors. Existing tests still exercise rollback and recovery of already-persisted errors, including trailing metadata.

## Why This Change Was Made

The transcript guard rejects the reserved precheck message before write hooks and deferred error recording. Both guard and recovery use the same predicate. Recovery inspects the loaded tail first and retains the existing durable removal path only for an already-persisted matching error.

Changing SQLite timeouts would not remove the full-history work. Reworking generic transcript deletion or changing stored navigation would broaden the persistence contract unnecessarily. No schema, configuration, retention, or provider protocol changes.

## User Impact

New precheck recovery avoids unnecessary archive hydration/replacement. Runtime error/recovery signaling remains available; ordinary provider-error persistence and legacy recovery remain supported.

## Verification

### Real behavior proof

- Failing/passing regression through the real guarded SessionManager and SQLite. A rejecting insert trigger proves recovery needs no rewrite in the new case; reopening verifies unchanged history and normal provider-error persistence.
- Focused recovery, prompt-phase, and transcript-event tests: 45 passed. Final focused rerun after export cleanup passed.
- CI exposed a missing `getEntries()` method in the shared integration-test SessionManager mock. Reproduced locally (1 failed, 59 passed), then completed the mock contract and clarified that the test models a runtime-emitted error. The context-engine integration and real SQLite recovery suites now pass (64 tests); production behavior and assertions are unchanged.
- `npm_config_manage_package_manager_versions=false node scripts/check-changed.mjs`: passed (core and test typechecks, lint, unused-export scans, and repository safety guards). This uses the already-installed pnpm without downloading a newer package-manager binary; dependency safeguards were preserved.
- Personal exact-diff review covered the producer, guard, deferred error recorder, recovery caller, tail matching, and legacy rollback path. No delegated review was run under the user's explicit no-subagent policy.

### Performance

Local synthetic component benchmark on Linux x64 / Node v25.9.0: 1,001 user messages, 1,000 with 8,192-character bodies; two warmups and five measured append-signal/cleanup cycles. Session open is outside the timed interval. Same fixture and command on base `64bf8246132` and candidate.

- Base samples (ms): 45.39, 55.76, 47.84, 48.16, 47.01; median **47.84 ms**.
- Candidate samples (ms): 0.219, 0.266, 0.140, 0.142, 0.115; median **0.142 ms**.
- Whole Vitest process RSS at sample completion: base 1.14 GB; candidate 1.11 GB. These include the test harness; no isolated memory improvement claim.

A second run used current upstream's deferred error recorder with a bounded manager (two loaded events, 20,000-byte bound) over the same archive. No synthetic error was persisted in either version; the remaining defect was unconditional archive hydration:

- Base samples (ms): 7.911, 7.601, 8.915, 7.362, 7.727; median **7.727 ms**.
- Candidate samples (ms): 0.0193, 0.0524, 0.0316, 0.0192, 0.0145; median **0.0193 ms**.
- Whole-process RSS: base 1.06 GB; candidate 1.07 GB. No memory-improvement claim.

Benchmark command: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/precheck-benchmark.test.ts`. The temporary fixture seeds the archive once, opens a fresh manager outside each measured interval, appends the same error produced by `MidTurnPrecheckSignal`, runs `removeTrailingMidTurnPrecheckAssistantError`, and asserts the live message tail is restored. Two warmups are discarded before collecting five samples.

This measures the targeted cleanup, not full Gateway latency, provider inference, or an existing multi-gigabyte archive.

### What was not tested

No production deployment/restart, live provider or Telegram recovery after this patch, contended multi-session Gateway soak, or repair/deletion of existing history. Other compaction and transcript projection work can still be expensive. No merge is requested.

<details>
<summary>Reproducible synthetic benchmark fixture (deferred recorder)</summary>

Save at the benchmark path in the command above on each revision. For the non-deferred/full-manager variant, replace the loop manager with `guardSessionManager(SessionManager.open(target, state.workspaceDir))`.

```ts
import path from "node:path";
import { createAssistantErrorTranscript } from "../../assistant-error-transcript.js";
import { expect, it } from "vitest";
import { openOpenClawAgentDatabase } from "../../../state/openclaw-agent-db.js";
import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
import type { AgentMessage } from "../../runtime/index.js";
import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
import { SessionManager } from "../../sessions/session-manager.js";
import { createZeroUsageFixture } from "../../test-helpers/usage-fixtures.js";
import { stripSessionsYieldArtifacts } from "./attempt-sessions-yield.js";
import {
  normalizeCompactionRecoveryTranscriptTail,
  removeTrailingMidTurnPrecheckAssistantError,
} from "./attempt-transcript-helpers.js";
import { MidTurnPrecheckSignal } from "./midturn-precheck.js";

const MID_TURN_PRECHECK_ERROR_MESSAGE = new MidTurnPrecheckSignal({route:"compact_only",estimatedPromptTokens:1100,promptBudgetBeforeReserve:1000,overflowTokens:100,toolResultReducibleChars:0,effectiveReserveTokens:100}).message;
it("benchmarks precheck recovery", async () => {
  await withOpenClawTestState({ label: "precheck-no-rewrite" }, async (state) => {
    const target = {
      agentId: "main",
      sessionId: "precheck-no-rewrite",
      sessionKey: "agent:main:precheck-no-rewrite",
      storePath: path.join(state.agentDir(), "openclaw-agent.sqlite"),
    };
    const sessionManager = guardSessionManager(SessionManager.open(target, state.workspaceDir));
    const user: AgentMessage = { role: "user", content: "continue", timestamp: 1 };
    sessionManager.appendMessage(user);
    for (let i=0;i<1000;i++) sessionManager.appendMessage({role:"user",content:"x".repeat(8192),timestamp:i+10});
    const error: AgentMessage = {
      role: "assistant",
      content: [{ type: "text", text: "" }],
      api: "openai-responses",
      provider: "openai",
      model: "test-model",
      stopReason: "error",
      errorMessage: MID_TURN_PRECHECK_ERROR_MESSAGE,
      timestamp: 2,
      usage: {
        input: 0,
        output: 0,
        cacheRead: 0,
        cacheWrite: 0,
        totalTokens: 0,
        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
      },
    };
    const times=[];
    for(let i=0;i<7;i++) {
      const manager=guardSessionManager(SessionManager.openBounded(target,{cwd:state.workspaceDir,maxBytes:20000,maxEvents:2}),{assistantErrorTranscript:createAssistantErrorTranscript({runId:"benchmark"})});
      const activeSession={agent:{state:{messages:[user,error]}}};
      const started=performance.now();
      manager.appendMessage(error);
      removeTrailingMidTurnPrecheckAssistantError({activeSession,sessionManager:manager});
      const elapsed=performance.now()-started;
      expect(activeSession.agent.state.messages).toEqual([user]);
      if(i>=2)times.push(elapsed);
    }
    console.log("PRECHECK_BENCH",JSON.stringify({samplesMs:times,rss:process.memoryUsage().rss}));
  });
},120000);

```

</details>

