### PR TITLE
fix(models): reject blank scan numeric options

### DIFF
--- a/src/commands/models/scan.test.ts
+++ b/src/commands/models/scan.test.ts
@@ -210,6 +210,34 @@ describe("models scan command", () => {
     expect(mocks.scanOpenRouterModels).not.toHaveBeenCalled();
   });
 
+  it.each([
+    [{ minParams: "" }, "--min-params"],
+    [{ maxAgeDays: "" }, "--max-age-days"],
+    [{ maxCandidates: "" }, "--max-candidates"],
+    [{ timeout: "" }, "--timeout"],
+    [{ concurrency: "" }, "--concurrency"],
+  ])("rejects explicitly blank numeric option %s", async (opts, label) => {
+    const runtime = createRuntime();
+
+    await expect(modelsScanCommand(opts, runtime)).rejects.toThrow(label);
+
+    expect(mocks.scanOpenRouterModels).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [{ minParams: "   " }, "--min-params"],
+    [{ maxAgeDays: "   " }, "--max-age-days"],
+    [{ maxCandidates: "   " }, "--max-candidates"],
+    [{ timeout: "   " }, "--timeout"],
+    [{ concurrency: "   " }, "--concurrency"],
+  ])("rejects whitespace-only numeric option %s", async (opts, label) => {
+    const runtime = createRuntime();
+
+    await expect(modelsScanCommand(opts, runtime)).rejects.toThrow(label);
+
+    expect(mocks.scanOpenRouterModels).not.toHaveBeenCalled();
+  });
+
   it("rejects applying auto-downgraded metadata-only scan results before scanning", async () => {
     await withOpenRouterApiKey(undefined, async () => {
       const runtime = createRuntime();

--- a/src/commands/models/scan.ts
+++ b/src/commands/models/scan.ts
@@ -151,7 +151,7 @@ function printScanTable(results: ModelScanResult[], runtime: RuntimeEnv) {
 }
 
 function parseOptionalNonNegativeFiniteOption(raw: unknown, label: string): number | undefined {
-  if (raw === undefined || raw === null || raw === "") {
+  if (raw === undefined || raw === null) {
     return undefined;
   }
   const parsed = parseStrictFiniteNumber(raw);
@@ -162,7 +162,7 @@ function parseOptionalNonNegativeFiniteOption(raw: unknown, label: string): numb
 }
 
 function parseOptionalPositiveFiniteOption(raw: unknown, label: string): number | undefined {
-  if (raw === undefined || raw === null || raw === "") {
+  if (raw === undefined || raw === null) {
     return undefined;
   }
   const parsed = parseStrictFiniteNumber(raw);
@@ -173,7 +173,7 @@ function parseOptionalPositiveFiniteOption(raw: unknown, label: string): number 
 }
 
 function parsePositiveIntegerOption(raw: unknown, label: string, fallback: number): number {
-  if (raw === undefined || raw === null || raw === "") {
+  if (raw === undefined || raw === null) {
     return fallback;
   }
   const parsed = parseStrictPositiveInteger(raw);


### PR DESCRIPTION
## What Problem This Solves

Fixes the empty-string case where `openclaw models scan` treated an explicitly empty numeric option as omitted and continued to its metadata-only outcome. Whitespace-only input already rejected on the baseline; this change preserves that existing behavior while making explicit `""` fail at the parser boundary too.

## Why This Change Was Made

The three existing numeric parser owners in `src/commands/models/scan.ts` now treat only `undefined`/`null` as omitted and send explicit empty values through the existing strict validators. The explicit-value validation invariant is covered as one coherent models-scan owner rather than duplicating parser policy across commands.

Existing-solutions preflight: `parseStrictFiniteNumber` and `parseStrictPositiveInteger` already provide the repository validation contract; no new library, plugin, config, protocol, or fallback is needed. Sibling coverage spans `--min-params`, `--max-age-days`, `--max-candidates`, `--timeout`, and `--concurrency`, with both empty and whitespace-only cases added before the OpenRouter scan call.

Production delta: `+3/-3` (net 0) in `src/commands/models/scan.ts`. Test delta: `+28` in `src/commands/models/scan.test.ts`.

## User Impact

Explicit `""` values now fail with the existing option-specific validation errors before `scanOpenRouterModels` is called. Whitespace-only values retain the baseline rejection; omitted options retain their current defaults/undefined state; valid values retain their current behavior. No configuration, default, protocol, persistence, migration, permission, or dependency contract changes are intended.

## Evidence

- Exact implementation commit: `472e76d628118fdc0641bc7ac4c3430b8bb33846`; parent/current batch base: `07d5b2409af0bee1ceb30b785ad75711ee0cf63a`.
- Owner anchors: `src/commands/models/scan.ts:153`, `:164`, `:175`, and call sites `:204-211`; tests assert the external scan mock is untouched on invalid input.
- Exact-head receipt: workflow run `34042266492` (run head `0eb9ad8bca6918d42578bef629dacbf36cf92dc1`), product head `472e76d628118fdc0641bc7ac4c3430b8bb33846`; [downloadable CLI proof artifact](https://github.com/Alix-007/openclaw/actions/runs/34042266492/artifacts/9992123209).
- Focused tests: `113` passed (`91 + 22`). Root-CLI proof made `32` invocations across `--min-params`, `--max-age-days`, `--max-candidates`, `--timeout`, and `--concurrency`, with blank, whitespace-only, legal, and omitted controls.
- Red/green readback: `pnpm openclaw models scan --no-probe --set-default --no-input --json --timeout ''` exits nonzero with baseline `Cannot apply metadata-only OpenRouter scan results`, while the product head exits nonzero with `--timeout must be > 0`; the baseline whitespace control already rejects and the product whitespace control retains that parser rejection. Legal `--timeout 1000` and omitted `--timeout` both retain the metadata-only rejection on baseline and product, confirming no provider scan was attempted and no legal/default behavior changed.
- Recorder/cleanup: the artifact stores exact argv, per-command output/status logs, `HEADS.txt`, `FOCUSED-SUMMARY.txt`, `index.txt`, and output hashes; the workflow removes both detached source worktrees and uses isolated temporary state/home/config directories.
- Limitations: this is parser and metadata-only CLI proof; it does not exercise a successful OpenRouter scan or a real provider call. Autoreview scope was Luna P0-only; no broader rating or maintainer-review conclusion is claimed.
- AI-assisted: Codex assisted with source inspection, implementation, test authoring, and review; the contributor owns the final scope. No transcript is attached.