### PR TITLE
refactor(channels): inline one-use discovery selectors

### DIFF
--- a/src/channels/plugins/read-only.ts
+++ b/src/channels/plugins/read-only.ts
@@ -579,25 +579,6 @@ function addManifestChannelPlugins(
   }
 }
 
-function resolveReadOnlyWorkspaceDir(
-  cfg: OpenClawConfig,
-  options: ReadOnlyChannelPluginOptions,
-): string | undefined {
-  return options.workspaceDir ?? tryResolveConfiguredAgentWorkspaceDir(cfg, options.env);
-}
-
-function listExternalChannelManifestRecords(
-  records: readonly PluginManifestRecord[],
-): PluginManifestRecord[] {
-  return records.filter((plugin) => plugin.origin !== "bundled" && plugin.channels.length > 0);
-}
-
-function listBundledChannelManifestRecords(
-  records: readonly PluginManifestRecord[],
-): PluginManifestRecord[] {
-  return records.filter((plugin) => plugin.origin === "bundled" && plugin.channels.length > 0);
-}
-
 function resolveExternalReadOnlyChannelPluginIds(params: {
   cfg: OpenClawConfig;
   activationSourceConfig?: OpenClawConfig;
@@ -645,7 +626,8 @@ export function resolveReadOnlyChannelPluginsForConfig(
   options: ReadOnlyChannelPluginOptions = {},
 ): ReadOnlyChannelPluginResolution {
   const env = options.env ?? process.env;
-  const workspaceDir = resolveReadOnlyWorkspaceDir(cfg, options);
+  const workspaceDir =
+    options.workspaceDir ?? tryResolveConfiguredAgentWorkspaceDir(cfg, options.env);
   const includeSetupFallbackPlugins = options.includeSetupFallbackPlugins === true;
   const loadedChannelPlugins = listChannelPlugins();
   const manifestRecords =
@@ -663,8 +645,12 @@ export function resolveReadOnlyChannelPluginsForConfig(
           stateDir: options.stateDir,
           env,
         }).plugins);
-  const bundledManifestRecords = listBundledChannelManifestRecords(manifestRecords);
-  const externalManifestRecords = listExternalChannelManifestRecords(manifestRecords);
+  const bundledManifestRecords = manifestRecords.filter(
+    (plugin) => plugin.origin === "bundled" && plugin.channels.length > 0,
+  );
+  const externalManifestRecords = manifestRecords.filter(
+    (plugin) => plugin.origin !== "bundled" && plugin.channels.length > 0,
+  );
   const activationSourceConfig = options.activationSourceConfig ?? cfg;
   const configuredChannelIds = uniqueStrings([
     ...listConfiguredChannelIdsForReadOnlyScope({


### PR DESCRIPTION
## What Problem This Solves

Read-only channel discovery sends three simple, single-use expressions through private wrapper functions, making the workspace choice and record selection harder to follow. This is maintainer-requested deletion work following the #135868 split campaign.

## Why This Change Was Made

Inline the workspace fallback and bundled/external manifest filters into their only caller. Keep the exact nullish selection, original environment argument, nonempty-channel requirement, origin predicates, ordering, and separate result arrays.

Production −14; tests/tooling/docs 0. Total diff: 30 changed lines. The account adapters, config/secret rebinding, cache lifetime, setup loading, and public entrypoints are unchanged. The existing line-budget exception remains.

## User Impact

No behavior change. Read-only inventory and channel setup keep the same selection and loading rules.

## Evidence

- Targeted references show each deleted private helper had exactly one caller, now inlined.
- All 48 read-only channel and legacy-workspace tests passed on macOS.
- Independent Codex P0–P2 review is scoped-clean.
- Full changed gate passed on [clean Blacksmith Testbox run 34042216016](https://github.com/openclaw/openclaw/actions/runs/34042216016), exit 0, including core/extension typechecks, dead-export scans, lint and import-cycle checks. Lease confirmed completed. The clean route avoids the previously reproduced ancestor-install declaration-resolution problem.
- No import, export, build, or lazy-module boundary changes; no build or new implementation-mirroring tests are needed for this private inlining.

Exact-head [CI run 34043394303](https://github.com/openclaw/openclaw/actions/runs/34043394303) is green. ClawSweeper reviewed `ea2611acc95941eda59e30e84f8fce615196504f` with no findings, before-merge requests, or rank-up moves. Both main rebases were patch-identical and left the lockfile unchanged.
