### PR TITLE
refactor(daemon): reuse the port status summary type

### DIFF
--- a/src/cli/daemon-cli/status.gateway.ts
+++ b/src/cli/daemon-cli/status.gateway.ts
@@ -30,7 +30,7 @@ export type GatewayStatusSummary = {
   windowsFirewall?: WindowsGatewayFirewallDiagnostic;
 };
 
-type PortStatusSummary = {
+export type PortStatusSummary = {
   port: number;
   status: PortUsageStatus;
   listeners: PortListener[];

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -37,7 +37,7 @@ import {
 import { isGatewayExternallySupervised } from "../../infra/gateway-supervision.js";
 import { formatPortDiagnostics } from "../../infra/ports-format.js";
 import { inspectPortConnections } from "../../infra/ports-inspect.js";
-import type { PortConnection, PortListener, PortUsageStatus } from "../../infra/ports-types.js";
+import type { PortConnection } from "../../infra/ports-types.js";
 import {
   readGatewayRestartHandoffSync,
   type GatewayRestartHandoff,
@@ -60,6 +60,7 @@ import {
   inspectDaemonPortStatuses,
   resolveGatewayStatusSummary,
   type GatewayStatusSummary,
+  type PortStatusSummary,
 } from "./status.gateway.js";
 import type { GatewayRpcOpts } from "./types.js";
 
@@ -223,18 +224,8 @@ export type DaemonStatus = {
   };
   gateway?: GatewayStatusSummary;
   hostDesktop?: HostDesktopStatus;
-  port?: {
-    port: number;
-    status: PortUsageStatus;
-    listeners: PortListener[];
-    hints: string[];
-  };
-  portCli?: {
-    port: number;
-    status: PortUsageStatus;
-    listeners: PortListener[];
-    hints: string[];
-  };
+  port?: PortStatusSummary;
+  portCli?: PortStatusSummary;
   connections?: {
     port: number;
     established: PortConnection[];


### PR DESCRIPTION
## What Problem This Solves

The status producer and its native-service/CLI-port consumers repeated the same four-field port summary shape. This small follow-up to #140189 removes that duplication so the declarations stay aligned.

## Why This Change Was Made

`DaemonStatus.port` and `portCli` now reuse the producer's existing `PortStatusSummary` type. Both outer properties remain optional, and the same port, status, mutable listener array and hints fields remain required inside the summary. The producer exports the existing type, and gather imports it as a type.

Deletion evidence: both removed inline declarations exactly match the producer's type; their `PortListener` and `PortUsageStatus` imports then have no remaining consumers in gather and are removed. Indexed-access consumers such as Gateway readiness retain the same structural type. No runtime edge or public SDK surface changes.

## User Impact

No runtime or JSON-output change. This also gives the status collector more room below its line limit without changing its behavior.

## Evidence

- 120 status-gather, status-print and Gateway-readiness tests passed; one existing skip.
- Full `node scripts/check-changed.mjs` passed. Rebase preserved both source files byte-for-byte and left the lockfile unchanged.
- Independent Codex review: scoped-clean, no actionable P0–P2 findings.
- Production: +5 / −14 = **−9 lines**. Tests/support, tooling and docs unchanged. 19 changed lines across two files.
