### PR TITLE
fix(cli): reject blank numeric options across inference and scans

### DIFF
--- a/docs/cli/infer.md
+++ b/docs/cli/infer.md
@@ -101,6 +101,7 @@ A good infer-based skill maps common user intents to the right subcommand, inclu
 
 - Use `--json` when the output feeds another command or script; text output otherwise.
 - Use `--provider` or `--model provider/model` to pin a specific backend.
+- Explicitly empty or whitespace-only values for `--limit`, `--count`, `--duration`, and `--timeout-ms` are errors. Omit the flag to retain its default behavior.
 - `image edit` and `image describe-many` require at least one `--file`; `embedding create` requires at least one `--text`. Repeat the flag for multiple inputs. Omitting it is a usage error, not an empty successful result, and no inference request is sent.
 - Use `model run --thinking <level>` for a one-shot thinking/reasoning override: `off`, `minimal`, `low`, `medium`, `high`, `adaptive`, `xhigh`, or `max`.
 - For `image describe`, `audio transcribe`, and `video describe`, `--model` must use the form `<provider/model>`.

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -131,6 +131,8 @@ Options:
 - `--set-image`
 - `--json`
 
+Numeric scan options reject empty and whitespace-only values. Omit a flag to retain its default behavior.
+
 `--set-default` and `--set-image` require live probes; metadata-only scan results are informational and are not applied to config.
 
 ## Aliases

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -3186,119 +3186,62 @@ describe("capability cli", () => {
     expect(mocks.generateImage).not.toHaveBeenCalled();
   });
 
-  it.each([
-    ["web search limit", ["capability", "web", "search", "--query", "ping", "--limit", ""]],
-    [
-      "image generate count",
-      ["capability", "image", "generate", "--prompt", "portrait", "--count", ""],
-    ],
-    [
-      "video generate duration",
-      ["capability", "video", "generate", "--prompt", "clip", "--duration", ""],
-    ],
-  ] as const)("rejects explicit blank %s before provider dispatch", async (_name, argv) => {
-    const webSearchRuntime = await import("../web-search/runtime.js");
-    vi.mocked(webSearchRuntime.runWebSearch).mockClear();
+  describe.each(["infer", "capability"])("%s numeric options", (command) => {
+    describe.each(["", "   "])("blank value %j", (raw) => {
+      it.each([
+        [
+          "web search limit",
+          ["web", "search", "--query", "ping", "--limit"],
+          "--limit must be a positive integer",
+        ],
+        [
+          "image generate count",
+          ["image", "generate", "--prompt", "portrait", "--count"],
+          "--count must be a positive integer",
+        ],
+        [
+          "image edit count",
+          ["image", "edit", "--file", "photo.png", "--prompt", "crop it", "--count"],
+          "--count must be a positive integer",
+        ],
+        [
+          "video generate duration",
+          ["video", "generate", "--prompt", "clip", "--duration"],
+          "--duration must be a finite number",
+        ],
+      ] as const)("rejects %s before provider dispatch", async (_name, argv, message) => {
+        const webSearchRuntime = await import("../web-search/runtime.js");
+        vi.mocked(webSearchRuntime.runWebSearch).mockClear();
 
-    await expect(runCap(...argv)).rejects.toThrow("exit 1");
+        await expect(runCap(command, ...argv, raw)).rejects.toThrow("exit 1");
 
-    expectRuntimeErrorContains(
-      argv.includes("--limit")
-        ? "--limit must be a positive integer"
-        : argv.includes("--count")
-          ? "--count must be a positive integer"
-          : "--duration must be a finite number",
-    );
-    expect(webSearchRuntime.runWebSearch).not.toHaveBeenCalled();
-    expect(mocks.generateImage).not.toHaveBeenCalled();
-    expect(mocks.generateVideo).not.toHaveBeenCalled();
-  });
+        expectRuntimeErrorContains(message);
+        expect(mocks.resolveCommandConfigWithSecrets).not.toHaveBeenCalled();
+        expect(webSearchRuntime.runWebSearch).not.toHaveBeenCalled();
+        expect(mocks.generateImage).not.toHaveBeenCalled();
+        expect(mocks.generateVideo).not.toHaveBeenCalled();
+      });
+    });
 
-  it("rejects partial image generate timeout before provider dispatch", async () => {
-    await expect(
-      runCapability("image", "generate", "--prompt", "portrait", "--timeout-ms", "1000ms"),
-    ).rejects.toThrow("exit 1");
-    expectRuntimeErrorContains("Invalid --timeout. Use a positive millisecond value");
-    expect(mocks.generateImage).not.toHaveBeenCalled();
-  });
+    describe.each(["", "   ", "1000ms"])("invalid timeout %j", (raw) => {
+      it.each([
+        ["image generate", ["image", "generate", "--prompt", "portrait"]],
+        ["image edit", ["image", "edit", "--file", "photo.png", "--prompt", "crop it"]],
+        ["image describe", ["image", "describe", "--file", "photo.png"]],
+        ["image describe-many", ["image", "describe-many", "--file", "photo.png"]],
+        ["video generate", ["video", "generate", "--prompt", "clip"]],
+      ] as const)("rejects %s before provider dispatch", async (_name, argv) => {
+        await expect(runCap(command, ...argv, "--timeout-ms", raw)).rejects.toThrow("exit 1");
 
-  it.each([
-    [
-      "image generate",
-      ["capability", "image", "generate", "--prompt", "portrait", "--timeout-ms", "1000ms"],
-    ],
-    [
-      "image edit",
-      [
-        "capability",
-        "image",
-        "edit",
-        "--file",
-        "photo.png",
-        "--prompt",
-        "crop it",
-        "--timeout-ms",
-        "1000ms",
-      ],
-    ],
-    [
-      "image describe",
-      ["capability", "image", "describe", "--file", "photo.png", "--timeout-ms", "1000ms"],
-    ],
-    [
-      "image describe-many",
-      ["capability", "image", "describe-many", "--file", "photo.png", "--timeout-ms", "1000ms"],
-    ],
-    [
-      "video generate",
-      ["capability", "video", "generate", "--prompt", "clip", "--timeout-ms", "1000ms"],
-    ],
-  ])("rejects malformed %s timeout before provider dispatch", async (_name, argv) => {
-    await expect(runCap(...argv)).rejects.toThrow("exit 1");
-
-    expectRuntimeErrorContains("Invalid --timeout. Use a positive millisecond value");
-    expect(mocks.generateImage).not.toHaveBeenCalled();
-    expect(mocks.generateVideo).not.toHaveBeenCalled();
-    expect(mocks.describeImageFile).not.toHaveBeenCalled();
-    expect(mocks.describeImageFileWithModel).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    [
-      "image generate",
-      ["capability", "image", "generate", "--prompt", "portrait", "--timeout-ms", ""],
-    ],
-    [
-      "image edit",
-      [
-        "capability",
-        "image",
-        "edit",
-        "--file",
-        "photo.png",
-        "--prompt",
-        "crop it",
-        "--timeout-ms",
-        "",
-      ],
-    ],
-    [
-      "image describe",
-      ["capability", "image", "describe", "--file", "photo.png", "--timeout-ms", ""],
-    ],
-    [
-      "image describe-many",
-      ["capability", "image", "describe-many", "--file", "photo.png", "--timeout-ms", ""],
-    ],
-    ["video generate", ["capability", "video", "generate", "--prompt", "clip", "--timeout-ms", ""]],
-  ] as const)("rejects explicit blank %s timeout before provider dispatch", async (_name, argv) => {
-    await expect(runCap(...argv)).rejects.toThrow("exit 1");
-
-    expectRuntimeErrorContains("Invalid --timeout. Use a positive millisecond value");
-    expect(mocks.generateImage).not.toHaveBeenCalled();
-    expect(mocks.generateVideo).not.toHaveBeenCalled();
-    expect(mocks.describeImageFile).not.toHaveBeenCalled();
-    expect(mocks.describeImageFileWithModel).not.toHaveBeenCalled();
+        expectRuntimeErrorContains("Invalid --timeout. Use a positive millisecond value");
+        expect(mocks.resolveCommandConfigWithSecrets).not.toHaveBeenCalled();
+        expect(mocks.generateImage).not.toHaveBeenCalled();
+        expect(mocks.generateVideo).not.toHaveBeenCalled();
+        expect(mocks.describeImageFile).not.toHaveBeenCalled();
+        expect(mocks.prepareImageDescriptionInput).not.toHaveBeenCalled();
+        expect(mocks.describePreparedImageWithModel).not.toHaveBeenCalled();
+      });
+    });
   });
 
   it("routes audio transcribe through transcription, not realtime", async () => {

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -3186,6 +3186,34 @@ describe("capability cli", () => {
     expect(mocks.generateImage).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["web search limit", ["capability", "web", "search", "--query", "ping", "--limit", ""]],
+    [
+      "image generate count",
+      ["capability", "image", "generate", "--prompt", "portrait", "--count", ""],
+    ],
+    [
+      "video generate duration",
+      ["capability", "video", "generate", "--prompt", "clip", "--duration", ""],
+    ],
+  ] as const)("rejects explicit blank %s before provider dispatch", async (_name, argv) => {
+    const webSearchRuntime = await import("../web-search/runtime.js");
+    vi.mocked(webSearchRuntime.runWebSearch).mockClear();
+
+    await expect(runCap(...argv)).rejects.toThrow("exit 1");
+
+    expectRuntimeErrorContains(
+      argv.includes("--limit")
+        ? "--limit must be a positive integer"
+        : argv.includes("--count")
+          ? "--count must be a positive integer"
+          : "--duration must be a finite number",
+    );
+    expect(webSearchRuntime.runWebSearch).not.toHaveBeenCalled();
+    expect(mocks.generateImage).not.toHaveBeenCalled();
+    expect(mocks.generateVideo).not.toHaveBeenCalled();
+  });
+
   it("rejects partial image generate timeout before provider dispatch", async () => {
     await expect(
       runCapability("image", "generate", "--prompt", "portrait", "--timeout-ms", "1000ms"),
@@ -3226,6 +3254,44 @@ describe("capability cli", () => {
       ["capability", "video", "generate", "--prompt", "clip", "--timeout-ms", "1000ms"],
     ],
   ])("rejects malformed %s timeout before provider dispatch", async (_name, argv) => {
+    await expect(runCap(...argv)).rejects.toThrow("exit 1");
+
+    expectRuntimeErrorContains("Invalid --timeout. Use a positive millisecond value");
+    expect(mocks.generateImage).not.toHaveBeenCalled();
+    expect(mocks.generateVideo).not.toHaveBeenCalled();
+    expect(mocks.describeImageFile).not.toHaveBeenCalled();
+    expect(mocks.describeImageFileWithModel).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "image generate",
+      ["capability", "image", "generate", "--prompt", "portrait", "--timeout-ms", ""],
+    ],
+    [
+      "image edit",
+      [
+        "capability",
+        "image",
+        "edit",
+        "--file",
+        "photo.png",
+        "--prompt",
+        "crop it",
+        "--timeout-ms",
+        "",
+      ],
+    ],
+    [
+      "image describe",
+      ["capability", "image", "describe", "--file", "photo.png", "--timeout-ms", ""],
+    ],
+    [
+      "image describe-many",
+      ["capability", "image", "describe-many", "--file", "photo.png", "--timeout-ms", ""],
+    ],
+    ["video generate", ["capability", "video", "generate", "--prompt", "clip", "--timeout-ms", ""]],
+  ] as const)("rejects explicit blank %s timeout before provider dispatch", async (_name, argv) => {
     await expect(runCap(...argv)).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("Invalid --timeout. Use a positive millisecond value");

--- a/src/cli/capability-cli/shared.test.ts
+++ b/src/cli/capability-cli/shared.test.ts
@@ -1,0 +1,33 @@
+// Capability CLI shared option tests cover omitted, explicit empty, and valid numeric values.
+import { describe, expect, it } from "vitest";
+import {
+  parseOptionalFiniteNumber,
+  parseOptionalPositiveInteger,
+  parseOptionalTimeoutMs,
+} from "./shared.js";
+
+describe("capability CLI numeric option parsing", () => {
+  it("keeps omitted optional values absent and parses valid values", () => {
+    expect(parseOptionalFiniteNumber(undefined, "--duration")).toBeUndefined();
+    expect(parseOptionalFiniteNumber("2.5", "--duration")).toBe(2.5);
+
+    expect(parseOptionalPositiveInteger(undefined, "--limit")).toBeUndefined();
+    expect(parseOptionalPositiveInteger("3", "--limit")).toBe(3);
+
+    expect(parseOptionalTimeoutMs(undefined)).toBeUndefined();
+    expect(parseOptionalTimeoutMs("1200")).toBe(1200);
+  });
+
+  it.each([
+    ["--duration", () => parseOptionalFiniteNumber("", "--duration")],
+    ["--duration", () => parseOptionalFiniteNumber("  ", "--duration")],
+    ["--limit", () => parseOptionalPositiveInteger("", "--limit")],
+    ["--limit", () => parseOptionalPositiveInteger("  ", "--limit")],
+  ])("rejects explicit blank %s values", (label, parse) => {
+    expect(parse).toThrow(`${label} must be`);
+  });
+
+  it.each(["", "  "])("rejects explicit blank --timeout-ms value %j", (raw) => {
+    expect(() => parseOptionalTimeoutMs(raw)).toThrow("Invalid --timeout");
+  });
+});

--- a/src/cli/capability-cli/shared.test.ts
+++ b/src/cli/capability-cli/shared.test.ts
@@ -1,4 +1,3 @@
-// Capability CLI shared option tests cover omitted, explicit empty, and valid numeric values.
 import { describe, expect, it } from "vitest";
 import {
   parseOptionalFiniteNumber,

--- a/src/cli/capability-cli/shared.ts
+++ b/src/cli/capability-cli/shared.ts
@@ -205,7 +205,7 @@ export function parseOptionalFiniteNumber(
   raw: string | number | undefined,
   label: string,
 ): number | undefined {
-  if (raw === undefined || (typeof raw === "string" && raw.trim() === "")) {
+  if (raw === undefined) {
     return undefined;
   }
   const value = parseStrictFiniteNumber(raw);
@@ -216,7 +216,7 @@ export function parseOptionalFiniteNumber(
 }
 
 export function parseOptionalPositiveInteger(raw: unknown, label: string): number | undefined {
-  if (raw === undefined || (typeof raw === "string" && raw.trim() === "")) {
+  if (raw === undefined) {
     return undefined;
   }
   const value = parseStrictPositiveInteger(raw);
@@ -227,7 +227,7 @@ export function parseOptionalPositiveInteger(raw: unknown, label: string): numbe
 }
 
 export function parseOptionalTimeoutMs(raw: string | number | undefined): number | undefined {
-  if (raw === undefined || (typeof raw === "string" && raw.trim() === "")) {
+  if (raw === undefined) {
     return undefined;
   }
   return parseTimeoutMsWithFallback(raw, 0, { invalidType: "error" });

--- a/src/commands/models/scan.test.ts
+++ b/src/commands/models/scan.test.ts
@@ -196,18 +196,24 @@ describe("models scan command", () => {
     });
   });
 
-  it.each([
-    [{ minParams: "7b" }, "--min-params"],
-    [{ maxAgeDays: "30d" }, "--max-age-days"],
-    [{ maxCandidates: "2.5" }, "--max-candidates"],
-    [{ timeout: "1000ms" }, "--timeout"],
-    [{ concurrency: "2x" }, "--concurrency"],
-  ])("rejects partial numeric option %s", async (opts, label) => {
-    const runtime = createRuntime();
+  describe.each([
+    ["minParams", "--min-params", "7b"],
+    ["maxAgeDays", "--max-age-days", "30d"],
+    ["maxCandidates", "--max-candidates", "2.5"],
+    ["timeout", "--timeout", "1000ms"],
+    ["concurrency", "--concurrency", "2x"],
+  ] as const)("%s numeric value", (key, label, partial) => {
+    it.each(["", "   ", partial])("rejects %j before scanning", async (raw) => {
+      const runtime = createRuntime();
 
-    await expect(modelsScanCommand(opts, runtime)).rejects.toThrow(label);
+      await expect(
+        modelsScanCommand({ [key]: raw, probe: false, setDefault: true }, runtime),
+      ).rejects.toThrow(label);
 
-    expect(mocks.scanOpenRouterModels).not.toHaveBeenCalled();
+      expect(mocks.loadModelsConfig).not.toHaveBeenCalled();
+      expect(mocks.resolveApiKeyForProviderCore).not.toHaveBeenCalled();
+      expect(mocks.scanOpenRouterModels).not.toHaveBeenCalled();
+    });
   });
 
   it("rejects applying auto-downgraded metadata-only scan results before scanning", async () => {

--- a/src/commands/models/scan.test.ts
+++ b/src/commands/models/scan.test.ts
@@ -210,6 +210,34 @@ describe("models scan command", () => {
     expect(mocks.scanOpenRouterModels).not.toHaveBeenCalled();
   });
 
+  it.each([
+    [{ minParams: "" }, "--min-params"],
+    [{ maxAgeDays: "" }, "--max-age-days"],
+    [{ maxCandidates: "" }, "--max-candidates"],
+    [{ timeout: "" }, "--timeout"],
+    [{ concurrency: "" }, "--concurrency"],
+  ])("rejects explicitly blank numeric option %s", async (opts, label) => {
+    const runtime = createRuntime();
+
+    await expect(modelsScanCommand(opts, runtime)).rejects.toThrow(label);
+
+    expect(mocks.scanOpenRouterModels).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [{ minParams: "   " }, "--min-params"],
+    [{ maxAgeDays: "   " }, "--max-age-days"],
+    [{ maxCandidates: "   " }, "--max-candidates"],
+    [{ timeout: "   " }, "--timeout"],
+    [{ concurrency: "   " }, "--concurrency"],
+  ])("rejects whitespace-only numeric option %s", async (opts, label) => {
+    const runtime = createRuntime();
+
+    await expect(modelsScanCommand(opts, runtime)).rejects.toThrow(label);
+
+    expect(mocks.scanOpenRouterModels).not.toHaveBeenCalled();
+  });
+
   it("rejects applying auto-downgraded metadata-only scan results before scanning", async () => {
     await withOpenRouterApiKey(undefined, async () => {
       const runtime = createRuntime();

--- a/src/commands/models/scan.ts
+++ b/src/commands/models/scan.ts
@@ -151,7 +151,7 @@ function printScanTable(results: ModelScanResult[], runtime: RuntimeEnv) {
 }
 
 function parseOptionalNonNegativeFiniteOption(raw: unknown, label: string): number | undefined {
-  if (raw === undefined || raw === null || raw === "") {
+  if (raw === undefined || raw === null) {
     return undefined;
   }
   const parsed = parseStrictFiniteNumber(raw);
@@ -162,7 +162,7 @@ function parseOptionalNonNegativeFiniteOption(raw: unknown, label: string): numb
 }
 
 function parseOptionalPositiveFiniteOption(raw: unknown, label: string): number | undefined {
-  if (raw === undefined || raw === null || raw === "") {
+  if (raw === undefined || raw === null) {
     return undefined;
   }
   const parsed = parseStrictFiniteNumber(raw);
@@ -173,7 +173,7 @@ function parseOptionalPositiveFiniteOption(raw: unknown, label: string): number 
 }
 
 function parsePositiveIntegerOption(raw: unknown, label: string, fallback: number): number {
-  if (raw === undefined || raw === null || raw === "") {
+  if (raw === undefined || raw === null) {
     return fallback;
   }
   const parsed = parseStrictPositiveInteger(raw);


### PR DESCRIPTION
## What Problem This Solves

Explicit empty numeric arguments were silently treated as omitted options. For example, `infer image generate --count ''` continued toward provider selection, and `models scan --timeout ''` continued with an omitted timeout. This can hide a missing shell variable and use defaults the operator did not intend.

This combines the shared inference CLI repair with #140232. Both original contributor commits are preserved, and the combined scope is one numeric-validation fix.

## Why This Change Was Made

Remove six blank-as-omitted conditions from the two existing parser owners. Explicit values now reach the existing strict number and timeout validators. Inference commands reject empty and whitespace-only values; model scanning adds rejection of empty strings while preserving its existing whitespace rejection.

Omitted/null handling, valid values, integer-versus-finite grammar, ranges, defaults and option-specific errors stay with their existing owners. No new validator, option, provider API, configuration or persistence policy is introduced.

Production is **+6/−6, net 0**. Repeated regression tables were consolidated while adding both aliases, all five timeout leaves and the shared image-edit count path. Tests are **+102/−55, net +47**, reduced from the incoming +127. Documentation adds three lines explaining omission and explicit blank values.

## User Impact

Invalid numeric input fails with the relevant option error before provider dispatch. Omitted and legal arguments keep their previous behavior across `infer`, its `capability` alias and `models scan`.

## Evidence

[Combined hosted proof](https://github.com/steipete/openclaw/actions/runs/34068979058) uses Node 24.20.0, the pinned pnpm version, the actual packaged CLI entry and the exact reviewed source:

- **399 tests passed** across six owner/sibling files, with no failures or skips.
- Both normal builds passed. All seven source/test/doc hashes match before and after execution.
- **82 baseline and 82 candidate CLI invocations** cover affected leaves, aliases, empty/whitespace inputs, omitted/legal values and numeric grammar/range controls. All are controlled error outcomes: 29 invalid-input cases move to their intended parser error; 53 controls preserve identical messages. Canonical config files remain absent throughout.
- The completed unit baseline contains **47 intended failures and 21 passing controls**, bound through the retained source/receipt chain. Two earlier comparison attempts stopped in strict evidence readers—Vitest's async stack type and a predicted source column—not in unexpected product behavior. Source-backed corrections revalidated the saved reports; those original runs remain recorded as failures, and completed unit stages were not repeated.
- Source review, autoreview and independent verification of raw results found no actionable issues. A separate review of the published commit also found no actionable issues. [Required CI](https://github.com/openclaw/openclaw/actions/runs/34071410373) passed at `77fda79abf73af3899e91a9ca8c68d2c0ed366e2`.

CLI output captures combine stdout/stderr and prove operator-visible error envelopes, not exclusive stdout placement. The controls deliberately stop before successful external provider work; no live provider success is claimed.

Original contributions by @Alix-007, with human credit and both commit ancestries retained. Related Gateway-port repair #139613 is already landed and is not part of this diff.

The review’s compatibility note describes the intended repair: scripts requesting defaults must omit numeric flags, as the updated docs explain. The reviewer could not retrieve raw hosted artifacts; maintainer and independent verification inspected the raw CLI outcomes, complete test reports and their source/receipt hashes.
