### PR TITLE
docs(i18n): fix glossary duplicates and the missing ru term

### DIFF
--- a/docs/.i18n/README.md
+++ b/docs/.i18n/README.md
@@ -44,6 +44,44 @@ Generated locale trees and live translation memory now live in the publish repo:
 - `ar-navigation.json`, `de-navigation.json`, `es-navigation.json`, `fr-navigation.json`, `id-navigation.json`, `it-navigation.json`, `ja-navigation.json`, `ko-navigation.json`, `pl-navigation.json`, `pt-BR-navigation.json`, and `tr-navigation.json` — starter locale labels kept alongside the source repo. Publish sync clones the full English navigation tree, prefixes locale routes, and overlays translated labels by matching shared page anchors.
 - `<lang>.tm.jsonl` — translation memory keyed by workflow, prompt version, language, and text hash.
 
+### Locale code mapping
+
+Three different code families are in play and they do not always match. Mintlify
+`navigation.languages` uses the language code, the generated locale tree and the
+glossary/TM files use the directory code, and the navigation overlay file is named
+after the language code. `GENERATED_LOCALES` in `scripts/docs-sync-publish.mjs` is
+the source of truth for this mapping.
+
+| Mintlify language | Locale directory | Navigation file | Glossary file | TM file | Nav mode |
+| --- | --- | --- | --- | --- | --- |
+| `zh-Hans` | `docs/zh-CN/` | `zh-Hans-navigation.json` | `glossary.zh-CN.json` | `zh-CN.tm.jsonl` | overlay |
+| `zh-Hant` | `docs/zh-TW/` | `zh-Hant-navigation.json` (not present) | `glossary.zh-TW.json` | `zh-TW.tm.jsonl` | clone-en |
+| `ja` | `docs/ja-JP/` | `ja-navigation.json` | `glossary.ja-JP.json` | `ja-JP.tm.jsonl` | clone-en |
+| `es` | `docs/es/` | `es-navigation.json` | `glossary.es.json` | `es.tm.jsonl` | clone-en |
+| `pt-BR` | `docs/pt-BR/` | `pt-BR-navigation.json` | `glossary.pt-BR.json` | `pt-BR.tm.jsonl` | clone-en |
+| `ko` | `docs/ko/` | `ko-navigation.json` | `glossary.ko.json` | `ko.tm.jsonl` | clone-en |
+| `de` | `docs/de/` | `de-navigation.json` | `glossary.de.json` | `de.tm.jsonl` | clone-en |
+| `fr` | `docs/fr/` | `fr-navigation.json` | `glossary.fr.json` | `fr.tm.jsonl` | clone-en |
+| `hi` | `docs/hi/` | `hi-navigation.json` (not present) | `glossary.hi.json` | `hi.tm.jsonl` | clone-en |
+| `ar` | `docs/ar/` | `ar-navigation.json` | `glossary.ar.json` | `ar.tm.jsonl` | clone-en |
+| `it` | `docs/it/` | `it-navigation.json` | `glossary.it.json` | `it.tm.jsonl` | clone-en |
+| `vi` | `docs/vi/` | `vi-navigation.json` (not present) | `glossary.vi.json` | `vi.tm.jsonl` | clone-en |
+| `nl` | `docs/nl/` | `nl-navigation.json` (not present) | `glossary.nl.json` | `nl.tm.jsonl` | clone-en |
+| `fa` | `docs/fa/` | `fa-navigation.json` (not present) | `glossary.fa.json` | `fa.tm.jsonl` | clone-en |
+| `tr` | `docs/tr/` | `tr-navigation.json` | `glossary.tr.json` | `tr.tm.jsonl` | clone-en |
+| `uk` | `docs/uk/` | `uk-navigation.json` (not present) | `glossary.uk.json` | `uk.tm.jsonl` | clone-en |
+| `id` | `docs/id/` | `id-navigation.json` | `glossary.id.json` | `id.tm.jsonl` | clone-en |
+| `pl` | `docs/pl/` | `pl-navigation.json` | `glossary.pl.json` | `pl.tm.jsonl` | clone-en |
+| `th` | `docs/th/` | `th-navigation.json` (not present) | `glossary.th.json` | `th.tm.jsonl` | clone-en |
+| `ru` | `docs/ru/` | `ru-navigation.json` (not present) | `glossary.ru.json` | `ru.tm.jsonl` | clone-en |
+
+Only three locales differ between the two code families: `zh-Hans`/`zh-CN`,
+`zh-Hant`/`zh-TW`, and `ja`/`ja-JP`. Every other locale uses the same code in both
+places. `scripts/docs-i18n` builds the glossary path from the
+directory code (`-lang`), so a glossary must be named `glossary.<dir>.json`, not
+`glossary.<language>.json`. Locales without a navigation file fall back to the
+cloned English tree with route prefixes only.
+
 In this repo, generated locale TM files such as `docs/.i18n/zh-CN.tm.jsonl`, `docs/.i18n/zh-TW.tm.jsonl`, `docs/.i18n/ja-JP.tm.jsonl`, `docs/.i18n/es.tm.jsonl`, `docs/.i18n/pt-BR.tm.jsonl`, `docs/.i18n/ko.tm.jsonl`, `docs/.i18n/de.tm.jsonl`, `docs/.i18n/fr.tm.jsonl`, `docs/.i18n/ar.tm.jsonl`, `docs/.i18n/it.tm.jsonl`, `docs/.i18n/vi.tm.jsonl`, `docs/.i18n/nl.tm.jsonl`, `docs/.i18n/fa.tm.jsonl`, `docs/.i18n/tr.tm.jsonl`, `docs/.i18n/uk.tm.jsonl`, `docs/.i18n/id.tm.jsonl`, `docs/.i18n/pl.tm.jsonl`, and `docs/.i18n/th.tm.jsonl` are intentionally no longer committed.
 
 ## Glossary format

--- a/docs/.i18n/README.md
+++ b/docs/.i18n/README.md
@@ -52,28 +52,28 @@ glossary/TM files use the directory code, and the navigation overlay file is nam
 after the language code. `GENERATED_LOCALES` in `scripts/docs-sync-publish.mjs` is
 the source of truth for this mapping.
 
-| Mintlify language | Locale directory | Navigation file | Glossary file | TM file | Nav mode |
-| --- | --- | --- | --- | --- | --- |
-| `zh-Hans` | `docs/zh-CN/` | `zh-Hans-navigation.json` | `glossary.zh-CN.json` | `zh-CN.tm.jsonl` | overlay |
-| `zh-Hant` | `docs/zh-TW/` | `zh-Hant-navigation.json` (not present) | `glossary.zh-TW.json` | `zh-TW.tm.jsonl` | clone-en |
-| `ja` | `docs/ja-JP/` | `ja-navigation.json` | `glossary.ja-JP.json` | `ja-JP.tm.jsonl` | clone-en |
-| `es` | `docs/es/` | `es-navigation.json` | `glossary.es.json` | `es.tm.jsonl` | clone-en |
-| `pt-BR` | `docs/pt-BR/` | `pt-BR-navigation.json` | `glossary.pt-BR.json` | `pt-BR.tm.jsonl` | clone-en |
-| `ko` | `docs/ko/` | `ko-navigation.json` | `glossary.ko.json` | `ko.tm.jsonl` | clone-en |
-| `de` | `docs/de/` | `de-navigation.json` | `glossary.de.json` | `de.tm.jsonl` | clone-en |
-| `fr` | `docs/fr/` | `fr-navigation.json` | `glossary.fr.json` | `fr.tm.jsonl` | clone-en |
-| `hi` | `docs/hi/` | `hi-navigation.json` (not present) | `glossary.hi.json` | `hi.tm.jsonl` | clone-en |
-| `ar` | `docs/ar/` | `ar-navigation.json` | `glossary.ar.json` | `ar.tm.jsonl` | clone-en |
-| `it` | `docs/it/` | `it-navigation.json` | `glossary.it.json` | `it.tm.jsonl` | clone-en |
-| `vi` | `docs/vi/` | `vi-navigation.json` (not present) | `glossary.vi.json` | `vi.tm.jsonl` | clone-en |
-| `nl` | `docs/nl/` | `nl-navigation.json` (not present) | `glossary.nl.json` | `nl.tm.jsonl` | clone-en |
-| `fa` | `docs/fa/` | `fa-navigation.json` (not present) | `glossary.fa.json` | `fa.tm.jsonl` | clone-en |
-| `tr` | `docs/tr/` | `tr-navigation.json` | `glossary.tr.json` | `tr.tm.jsonl` | clone-en |
-| `uk` | `docs/uk/` | `uk-navigation.json` (not present) | `glossary.uk.json` | `uk.tm.jsonl` | clone-en |
-| `id` | `docs/id/` | `id-navigation.json` | `glossary.id.json` | `id.tm.jsonl` | clone-en |
-| `pl` | `docs/pl/` | `pl-navigation.json` | `glossary.pl.json` | `pl.tm.jsonl` | clone-en |
-| `th` | `docs/th/` | `th-navigation.json` (not present) | `glossary.th.json` | `th.tm.jsonl` | clone-en |
-| `ru` | `docs/ru/` | `ru-navigation.json` (not present) | `glossary.ru.json` | `ru.tm.jsonl` | clone-en |
+| Mintlify language | Locale directory | Navigation file                         | Glossary file         | TM file          | Nav mode |
+| ----------------- | ---------------- | --------------------------------------- | --------------------- | ---------------- | -------- |
+| `zh-Hans`         | `docs/zh-CN/`    | `zh-Hans-navigation.json`               | `glossary.zh-CN.json` | `zh-CN.tm.jsonl` | overlay  |
+| `zh-Hant`         | `docs/zh-TW/`    | `zh-Hant-navigation.json` (not present) | `glossary.zh-TW.json` | `zh-TW.tm.jsonl` | clone-en |
+| `ja`              | `docs/ja-JP/`    | `ja-navigation.json`                    | `glossary.ja-JP.json` | `ja-JP.tm.jsonl` | clone-en |
+| `es`              | `docs/es/`       | `es-navigation.json`                    | `glossary.es.json`    | `es.tm.jsonl`    | clone-en |
+| `pt-BR`           | `docs/pt-BR/`    | `pt-BR-navigation.json`                 | `glossary.pt-BR.json` | `pt-BR.tm.jsonl` | clone-en |
+| `ko`              | `docs/ko/`       | `ko-navigation.json`                    | `glossary.ko.json`    | `ko.tm.jsonl`    | clone-en |
+| `de`              | `docs/de/`       | `de-navigation.json`                    | `glossary.de.json`    | `de.tm.jsonl`    | clone-en |
+| `fr`              | `docs/fr/`       | `fr-navigation.json`                    | `glossary.fr.json`    | `fr.tm.jsonl`    | clone-en |
+| `hi`              | `docs/hi/`       | `hi-navigation.json` (not present)      | `glossary.hi.json`    | `hi.tm.jsonl`    | clone-en |
+| `ar`              | `docs/ar/`       | `ar-navigation.json`                    | `glossary.ar.json`    | `ar.tm.jsonl`    | clone-en |
+| `it`              | `docs/it/`       | `it-navigation.json`                    | `glossary.it.json`    | `it.tm.jsonl`    | clone-en |
+| `vi`              | `docs/vi/`       | `vi-navigation.json` (not present)      | `glossary.vi.json`    | `vi.tm.jsonl`    | clone-en |
+| `nl`              | `docs/nl/`       | `nl-navigation.json` (not present)      | `glossary.nl.json`    | `nl.tm.jsonl`    | clone-en |
+| `fa`              | `docs/fa/`       | `fa-navigation.json` (not present)      | `glossary.fa.json`    | `fa.tm.jsonl`    | clone-en |
+| `tr`              | `docs/tr/`       | `tr-navigation.json`                    | `glossary.tr.json`    | `tr.tm.jsonl`    | clone-en |
+| `uk`              | `docs/uk/`       | `uk-navigation.json` (not present)      | `glossary.uk.json`    | `uk.tm.jsonl`    | clone-en |
+| `id`              | `docs/id/`       | `id-navigation.json`                    | `glossary.id.json`    | `id.tm.jsonl`    | clone-en |
+| `pl`              | `docs/pl/`       | `pl-navigation.json`                    | `glossary.pl.json`    | `pl.tm.jsonl`    | clone-en |
+| `th`              | `docs/th/`       | `th-navigation.json` (not present)      | `glossary.th.json`    | `th.tm.jsonl`    | clone-en |
+| `ru`              | `docs/ru/`       | `ru-navigation.json` (not present)      | `glossary.ru.json`    | `ru.tm.jsonl`    | clone-en |
 
 Only three locales differ between the two code families: `zh-Hans`/`zh-CN`,
 `zh-Hant`/`zh-TW`, and `ja`/`ja-JP`. Every other locale uses the same code in both

--- a/docs/.i18n/glossary.ru.json
+++ b/docs/.i18n/glossary.ru.json
@@ -56,6 +56,10 @@
     "target": "Pi"
   },
   {
+    "source": "Plugin",
+    "target": "Plugin"
+  },
+  {
     "source": "Skills",
     "target": "Skills"
   },

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1337,11 +1337,11 @@
   },
   {
     "source": "Building Plugins",
-    "target": "Building Plugins"
+    "target": "构建插件"
   },
   {
     "source": "Plugin Manifest",
-    "target": "Plugin Manifest"
+    "target": "插件清单"
   },
   {
     "source": "Workboard plugin",


### PR DESCRIPTION
## What this fixes

`docs/.i18n/glossary.<locale>.json` holds 20 per-locale glossaries that steer the
translation pipeline. This PR lands only the changes that are mechanically
unambiguous — nothing here authors a new translation.

### 1. `glossary.ru.json` — restore the missing `Plugin` term

16 of the 20 glossaries share an identical 22-key starter set. `ru` had 21: `Plugin`
was the only key missing, so the term got no guidance for Russian. All 16 peers map
it identity (`Plugin` -> `Plugin`, i.e. do not translate), so the added entry matches
them exactly and sits in the same position in the file.

### 2. `glossary.zh-CN.json` — two case variants pointed at two different outputs

| source | was | now |
| --- | --- | --- |
| `Building plugins` | 构建插件 | unchanged |
| `Building Plugins` | `Building Plugins` (left English) | 构建插件 |
| `Plugin manifest` | 插件清单 | unchanged |
| `Plugin Manifest` | `Plugin Manifest` (left English) | 插件清单 |

Both casings are link labels for the same two pages (`/plugins/building-plugins`,
`/plugins/manifest`), so the same page title rendered in Chinese or English depending
on how an author capitalised the link. The Title Case entries now reuse the Chinese
target the same file already assigns to the identical term. No new Chinese was written.

### 3. `docs/.i18n/README.md` — locale code mapping table

Three code families are in play and they do not match: Mintlify
`navigation.languages` uses the language code (`zh-Hans`, `ja`), while the generated
locale tree and the glossary/TM filenames use the directory code (`zh-CN`, `ja-JP`).
The README named the files but never gave the mapping. The new table is generated
from `GENERATED_LOCALES` in `scripts/docs-sync-publish.mjs` and lists, per locale, the
Mintlify language code, locale directory, navigation file (flagging the four that do
not exist), glossary file, TM file, and nav mode.

## Deliberately left for a native speaker

Two zh-CN case-variant pairs are genuine Chinese word choices, not mechanical
duplicates, and the file gives no majority to break the tie:

| pair | targets | evidence |
| --- | --- | --- |
| `troubleshooting` / `Troubleshooting` | 故障排除 vs 故障排查 | 故障排除 used by 2 entries, 故障排查 by 4; the README's own glossary example uses 故障排除 |
| `Channel routing` / `Channel Routing` | 渠道路由 vs 频道路由 | the whole glossary is split: 11 entries render "channel" as 频道, 10 as 渠道 |

The second is the visible edge of a larger decision — zh-CN has no settled word for
"channel" — and resolving it means retranslating ~21 entries. Not attempted here.

Four further case pairs (`Cohere`/`cohere`, `Meta`/`meta`, `Baseten`/`baseten`,
`ClawRouter`/`clawrouter`) map each casing to itself. These are passthrough entries
that deliberately preserve the source casing, not translation conflicts, so they are
untouched.

## Case-variant pairs left intact on purpose

25 of the 33 case-variant groups across all 20 glossaries already map both casings to
one identical target, so they do not violate one-term-one-meaning. They are also load
bearing: `exactGlossaryMappings` (`scripts/docs-i18n/translator.go:97`) is a
**case-sensitive** whole-segment map, and both casings occur as real English doc
titles and nav labels — `Getting started` is a nav label 11 times and `Getting Started`
5 times; `Agent runtimes` 7 times; `Skills config` 8 times. Deleting either casing
would drop its deterministic translation and push that segment to the model. That is a
regression, not a cleanup, so no entries were removed.

De-duplicating them safely requires making the matcher case-insensitive first, which
cannot be done while conflicting pairs remain (map iteration order would decide the
winner). Follow-up below.

## Follow-ups (not in this PR)

1. **One shared source term list (audit r3-0994).** Measured on this commit: the 20
   glossaries hold 918 entries over a union of 483 source terms, but only **12** terms
   are common to all 20 — `CI pipeline`, `ClawHub`, `Compaction`, `Dreaming`,
   `Gateway`, `Heartbeat`, `LINE`, `OpenClaw`, `Pi`, `Pull request review flow`,
   `Skills`, `Tailscale`. Per-locale source counts: zh-CN 474, zh-TW 43, ja-JP 27, and
   17 locales at 22 (ru was 21 before this PR). zh-CN is missing 9 of the 22 starter
   terms every other locale has (`ACP`, `Active Memory`, `Cron`, `Mintlify`, `Node`,
   `Plugin`, `TUI`, `TaskFlow`, `Webhook`). Generating every locale from one source
   list with a check that fails on a missing key is a pipeline design change.

2. **Full-tree glossary check (audit r3-0997).** `scripts/check-docs-i18n-glossary.mts`
   hard-codes `glossary.zh-CN.json` (line 10) and only diffs changed docs against a
   merge base (lines 69-80), exiting 0 with a warning when no merge base exists (lines
   187-192). A full-tree mode was scoped and **not** built, because the numbers make it
   a redesign rather than a flag: the English tree (752 files) yields **1,232** distinct
   title/link-label terms, of which **881** are absent from the zh-CN glossary and
   **1,218** from `ru`. An opt-in `--all` today would emit roughly 24,000 findings
   across 20 glossaries — a report, not a gate. It only becomes a usable check after
   follow-up 1 defines what each glossary is supposed to contain.

3. **Case-insensitive glossary matching.** Fold `exactGlossaryMappings` keys to
   lowercase and de-duplicate the 25 redundant pairs — but only after the 2 conflicting
   pairs above are resolved, otherwise the fold is order-dependent.

4. **Competing English spellings (audit r3-0996).** The source docs use both
   `TaskFlow` and `Task Flow`, `QQBot`/`QQ Bot`/`QQ bot`, `subagent`/`sub-agent`,
   `hot reload`/`hot-reload`. The glossaries encode the competition instead of
   resolving it. Fixing this is an English-docs edit, not a glossary edit.

## Validation

All run from the worktree root on this branch:

```
$ python3 -c "parse all 20 glossary files"
OK: 20 files parsed, 918 entries total

$ node scripts/check-docs-mdx.mjs docs README.md
Docs MDX check passed (753 files, 10222ms).

$ OPENCLAW_DOCS_SYNC_CLAWHUB_REPO=... node scripts/docs-link-audit.mjs
Synced 22 ClawHub doc asset(s).
checked_internal_links=8252
broken_links=0

$ node --import ./scripts/tsx.mjs scripts/check-docs-i18n-glossary.mts
exit=0
```

`scripts/check-docs-i18n-glossary.mts` is unchanged and still exits 0 on this branch
(it resolves `origin/main` as its merge base and finds no new uncovered doc terms).
