### PR TITLE
refactor: reuse model normalization for provider setup

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3293,7 +3293,7 @@ src/plugin-sdk/migration.ts	8
 src/plugin-sdk/plugin-test-api.ts	1
 src/plugin-sdk/provider-auth-copilot-cache.ts	1
 src/plugin-sdk/provider-auth-login-flow-runtime.ts	6
-src/plugin-sdk/provider-auth-result.ts	4
+src/plugin-sdk/provider-auth-result.ts	3
 src/plugin-sdk/provider-auth-runtime.ts	1
 src/plugin-sdk/provider-auth.ts	1
 src/plugin-sdk/provider-catalog-shared.ts	1

--- a/src/plugin-sdk/provider-auth-result.test.ts
+++ b/src/plugin-sdk/provider-auth-result.test.ts
@@ -93,6 +93,15 @@ describe("buildOauthProviderAuthResult", () => {
         },
       },
     });
+
+    expect(
+      buildOauthProviderAuthResult({
+        providerId: "google",
+        defaultModel: "google/gemini-3.1-pro-preview",
+        access: "access-token",
+        configPatch: result.configPatch,
+      }).configPatch,
+    ).toBe(result.configPatch);
   });
 
   it("omits OAuth expiry values outside the Date timestamp range", () => {

--- a/src/plugin-sdk/provider-auth-result.ts
+++ b/src/plugin-sdk/provider-auth-result.ts
@@ -6,40 +6,11 @@ import { normalizeConfiguredProviderCatalogModelId } from "../agents/model-ref-s
 import {
   normalizeAgentModelMapForConfig,
   normalizeAgentModelRefForConfig,
+  normalizeAgentModelSelectionForConfig,
 } from "../config/model-input.js";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderAuthResult } from "../plugins/types.js";
-
-function normalizeAgentModelConfigForAuthResult(value: unknown): unknown {
-  if (typeof value === "string") {
-    return normalizeAgentModelRefForConfig(value);
-  }
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return value;
-  }
-
-  let mutated = false;
-  const next: Record<string, unknown> = { ...(value as Record<string, unknown>) };
-  if (typeof next.primary === "string") {
-    const primary = normalizeAgentModelRefForConfig(next.primary);
-    if (primary !== next.primary) {
-      next.primary = primary;
-      mutated = true;
-    }
-  }
-  if (Array.isArray(next.fallbacks)) {
-    const originalFallbacks = next.fallbacks;
-    const fallbacks = originalFallbacks.map((fallback) =>
-      typeof fallback === "string" ? normalizeAgentModelRefForConfig(fallback) : fallback,
-    );
-    if (fallbacks.some((fallback, index) => fallback !== originalFallbacks[index])) {
-      next.fallbacks = fallbacks;
-      mutated = true;
-    }
-  }
-  return mutated ? next : value;
-}
 
 function normalizeProviderConfigModelIdsForAuthResult(
   provider: string,
@@ -72,7 +43,7 @@ function normalizeProviderAuthConfigPatchModelRefs(
     // legacy model refs here instead of letting retired ids leak into persisted defaults.
     let nextDefaults = defaults;
     if (defaults.model !== undefined) {
-      const model = normalizeAgentModelConfigForAuthResult(defaults.model);
+      const model = normalizeAgentModelSelectionForConfig(defaults.model);
       if (model !== defaults.model) {
         nextDefaults = { ...nextDefaults, model: model as typeof defaults.model };
       }


### PR DESCRIPTION
## What Problem This Solves

Provider setup and regular config writes need consistent model-name normalization and unchanged-value behavior.

## Why This Change Was Made

Reuse the existing config normalizer for primary and fallback model selections, deleting the SDK's duplicate implementation. Actual setup producers supply supported config data records. The credential builder, provider-catalog normalization, public exports and module import boundary remain unchanged. The assertion allowance shrinks to match the deleted cast.

## User Impact

Setup behavior and generated config values are unchanged. Production code is reduced by 29 lines; the existing result test gains an unchanged-patch identity assertion.

## Evidence

The same 29 focused cases passed before and after. The added identity assertion also passed against the original implementation. All 35 final canonical checks and the independent P2 review passed, including core/plugin types and SDK surface checks. The initial check requested the required assertion-baseline reduction from four to three; the final run includes that exact shrink.

Validation uses synthetic setup results; no live login or credential-store change was required for this internal refactor.
