### PR TITLE
fix(cli): reject blank pairing account selectors

### DIFF
--- a/docs/cli/pairing.md
+++ b/docs/cli/pairing.md
@@ -28,6 +28,12 @@ openclaw pairing approve telegram <code>
 openclaw pairing approve --channel telegram --account work <code> --notify
 ```
 
+Use `--account <accountId>` to restrict either command to one channel account.
+If you omit `--account`, `list` shows pending requests across the channel's accounts,
+and `approve` uses the account belonging to the matching request. Explicitly empty
+or whitespace-only values, such as `--account ""`, are rejected with
+`--account must not be blank`.
+
 ## `pairing list`
 
 List pending pairing requests for one channel.

--- a/src/cli/pairing-cli.test.ts
+++ b/src/cli/pairing-cli.test.ts
@@ -229,6 +229,14 @@ describe("pairing cli", () => {
     expect(listChannelPairingRequests).toHaveBeenCalledWith("telegram", process.env, "yy");
   });
 
+  it.each(["", "   "])("rejects an explicitly empty --account for list", async (account) => {
+    await expect(
+      runPairing(["pairing", "list", "--channel", "telegram", "--account", account]),
+    ).rejects.toThrow("--account must not be blank");
+
+    expect(listChannelPairingRequests).not.toHaveBeenCalled();
+  });
+
   it("normalizes channel aliases", async () => {
     listChannelPairingRequests.mockResolvedValueOnce([]);
 
@@ -347,6 +355,16 @@ describe("pairing cli", () => {
       code: "ABCDEFGH",
       accountId: "yy",
     });
+  });
+
+  it.each(["", "   "])("rejects an explicitly empty --account for approve", async (account) => {
+    await expect(
+      runPairing(["pairing", "approve", "--channel", "telegram", "--account", account, "ABCDEFGH"]),
+    ).rejects.toThrow("--account must not be blank");
+
+    expect(approveChannelPairingCode).not.toHaveBeenCalled();
+    expect(readConfigFileSnapshotForWrite).not.toHaveBeenCalled();
+    expect(replaceConfigFile).not.toHaveBeenCalled();
   });
 
   it("defaults approve to the sole available channel when only code is provided", async () => {

--- a/src/cli/pairing-cli.ts
+++ b/src/cli/pairing-cli.ts
@@ -63,8 +63,8 @@ async function notifyApproved(
 
 function resolveAccountId(raw: unknown): string | undefined {
   const accountId = normalizeStringifiedOptionalString(raw);
-  // Only omission selects the default account; an explicit blank must not widen
-  // list/approve to unscoped pairing state or the default allowlist.
+  // Omission intentionally leaves pairing unscoped; an explicit blank must not
+  // silently remove the account restriction.
   if (raw !== undefined && !accountId) {
     throw new Error("--account must not be blank");
   }

--- a/src/cli/pairing-cli.ts
+++ b/src/cli/pairing-cli.ts
@@ -61,6 +61,16 @@ async function notifyApproved(
   });
 }
 
+function resolveAccountId(raw: unknown): string | undefined {
+  const accountId = normalizeStringifiedOptionalString(raw);
+  // Only omission selects the default account; an explicit blank must not widen
+  // list/approve to unscoped pairing state or the default allowlist.
+  if (raw !== undefined && !accountId) {
+    throw new Error("--account must not be blank");
+  }
+  return accountId;
+}
+
 export function registerPairingCli(program: Command) {
   const channels = listPairingChannels();
   // Avoid rendering a bare "()" enum when no channels are configured.
@@ -103,7 +113,7 @@ export function registerPairingCli(program: Command) {
           );
         }
       }
-      const accountId = normalizeStringifiedOptionalString(opts.account) ?? "";
+      const accountId = resolveAccountId(opts.account);
       const requests = accountId
         ? await listChannelPairingRequests(channel, process.env, accountId)
         : await listChannelPairingRequests(channel);
@@ -172,7 +182,7 @@ export function registerPairingCli(program: Command) {
         );
       }
       const channel = parseChannel(channelRaw, channels);
-      const accountId = normalizeStringifiedOptionalString(opts.account) ?? "";
+      const accountId = resolveAccountId(opts.account);
       const approved = accountId
         ? await approveChannelPairingCode({
             channel,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users passing an explicitly empty or whitespace-only `--account` to `openclaw pairing list` or `openclaw pairing approve` would silently fall back to unscoped/default pairing behavior. That could query or mutate the wrong account boundary instead of stopping at the operator input.

## Why This Change Was Made

The pairing CLI now has one `resolveAccountId` owner that preserves omission as the existing default-selection path but rejects an explicit blank before pairing-store reads or config writes. The explicit-value validation invariant is kept coherent across both pairing subcommands at their shared owner boundary.

Existing-solutions preflight: `normalizeStringifiedOptionalString` already defines string normalization, so this change adds only the missing explicitness check and no new dependency, plugin, config, protocol, persistence, or fallback layer. Sibling coverage includes both `list` and `approve`; tests assert no pairing-store call and no config read/write on invalid input.

Production delta: `+12/-2` (net +10) in `src/cli/pairing-cli.ts`. Test delta: `+18` in `src/cli/pairing-cli.test.ts`. The positive production delta is the canonical owner guard and its short contract comment, which prevents silent account-scope widening.

## User Impact

Explicit `""` and whitespace-only `--account` values now fail with `--account must not be blank` before pairing reads or approval/config mutation. Omitted `--account` keeps the current channel/default-account behavior, and valid explicit accounts keep normal resolution. No configuration schema, default, protocol, persistence, migration, permission, or dependency contract changes are intended.

## Evidence

- Exact implementation commit: `153182a2038de39df3bbe48a9901e6140646a0e1`; parent/current batch base: `07d5b2409af0bee1ceb30b785ad75711ee0cf63a`.
- Owner anchors: `src/cli/pairing-cli.ts:64`, with callers at `:116` (`list`) and `:185` (`approve`); tests cover both empty and whitespace-only values.
- Exact-head receipt: workflow run `34042266492` (run head `0eb9ad8bca6918d42578bef629dacbf36cf92dc1`), product head `153182a2038de39df3bbe48a9901e6140646a0e1`; [downloadable CLI proof artifact](https://github.com/Alix-007/openclaw/actions/runs/34042266492/artifacts/9992117910).
- Focused tests: `22` passed. Root-CLI proof made `16` invocations across `pairing list` and `pairing approve`, with blank, whitespace-only, legal, and omitted account controls.
- Red/green readback: `pnpm openclaw pairing list --channel telegram --account '' --json` and the whitespace control return baseline `{"channel":"telegram","requests":[]}` but product `--account must not be blank`; legal `--account proof-account` and omitted `--account` return `{"channel":"telegram","requests":[]}` on both heads. The approve command `pnpm openclaw pairing approve --channel telegram proof-no-such-code --account ''` uses a deliberately nonexistent code, never a real request: baseline blank/whitespace/legal/omitted controls reach `No pending pairing request found for code "proof-no-such-code"`, while product blank/whitespace stop at `--account must not be blank`; no approval mutation is claimed.
- Recorder/cleanup: the artifact stores exact argv, per-command output/status logs, `HEADS.txt`, `FOCUSED-SUMMARY.txt`, `index.txt`, and output hashes; the workflow removes both detached source worktrees and uses isolated temporary state/home/config directories.
- Limitations: the receipt uses an empty Telegram pairing table and a deliberately nonexistent approval code, so it proves account-selector parsing and safe no-pending handling, not a successful approval or notification of a real sender. Autoreview scope was Luna P0-only; no broader rating or maintainer-review conclusion is claimed.
- AI-assisted: Codex assisted with source inspection, implementation, test authoring, and review; the contributor owns the final scope. No transcript is attached.