### PR TITLE
refactor(ui): simplify media readiness polling

### DIFF
--- a/ui/src/pages/chat/components/chat-media-playback.test.ts
+++ b/ui/src/pages/chat/components/chat-media-playback.test.ts
@@ -1,7 +1,17 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { appendChatMediaPlaybackParam, waitForChatMediaPlayback } from "./chat-media-playback.ts";
 
 const EXPECTED_RETRY_DELAYS_MS = [2_000, 4_000, 8_000, 16_000, 30_000, 30_000, 20_000];
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(0));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
 
 describe("chat media playback renditions", () => {
   it("appends playback=1 without dropping assistant or managed media tickets", () => {
@@ -27,32 +37,30 @@ describe("chat media playback renditions", () => {
     );
   });
 
-  it("reports preparing and retries until the rendition is ready", async () => {
-    const fetchImpl = vi
+  it("retries at the default delays until the rendition is ready", async () => {
+    const fetchMock = vi
       .fn<typeof fetch>()
       .mockResolvedValueOnce(new Response(null, { status: 202 }))
       .mockResolvedValueOnce(new Response(null, { status: 202 }))
       .mockResolvedValueOnce(new Response(null, { status: 200 }));
-    const waitImpl = vi.fn<(delayMs: number, signal: AbortSignal) => Promise<void>>(
-      async () => undefined,
-    );
-    const onPreparing = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const pending = waitForChatMediaPlayback({
+      source: "/media?playback=1",
+      authToken: "secret-token",
+      signal: new AbortController().signal,
+    });
 
-    await expect(
-      waitForChatMediaPlayback({
-        source: "/media?playback=1",
-        authToken: "secret-token",
-        signal: new AbortController().signal,
-        fetchImpl,
-        waitImpl,
-        onPreparing,
-      }),
-    ).resolves.toBe("ready");
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(3_999);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(pending).resolves.toBe("ready");
 
-    expect(onPreparing).toHaveBeenCalledTimes(2);
-    expect(waitImpl.mock.calls.map(([delay]) => delay)).toEqual([2_000, 4_000]);
-    expect(fetchImpl).toHaveBeenCalledTimes(3);
-    const firstRequest = fetchImpl.mock.calls[0];
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const firstRequest = fetchMock.mock.calls[0];
     expect(firstRequest?.[0]).toBe("/media?playback=1");
     expect(firstRequest?.[1]?.method).toBe("HEAD");
     expect(new Headers(firstRequest?.[1]?.headers).get("Authorization")).toBe(
@@ -61,89 +69,70 @@ describe("chat media playback renditions", () => {
   });
 
   it("stops after the bounded two-minute retry schedule", async () => {
-    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(null, { status: 202 }));
-    const waitImpl = vi.fn<(delayMs: number, signal: AbortSignal) => Promise<void>>(
-      async () => undefined,
-    );
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const pending = waitForChatMediaPlayback({
+      source: "/media?playback=1",
+      signal: new AbortController().signal,
+    });
 
-    await expect(
-      waitForChatMediaPlayback({
-        source: "/media?playback=1",
-        signal: new AbortController().signal,
-        fetchImpl,
-        waitImpl,
-      }),
-    ).resolves.toBe("unavailable");
-
-    expect(waitImpl.mock.calls.map(([delay]) => delay)).toEqual(EXPECTED_RETRY_DELAYS_MS);
-    expect(fetchImpl).toHaveBeenCalledTimes(EXPECTED_RETRY_DELAYS_MS.length + 1);
-    expect(EXPECTED_RETRY_DELAYS_MS.reduce((sum, delay) => sum + delay, 0)).toBe(110_000);
+    for (const [attempt, delay] of EXPECTED_RETRY_DELAYS_MS.entries()) {
+      await vi.advanceTimersByTimeAsync(delay - 1);
+      expect(fetchMock).toHaveBeenCalledTimes(attempt + 1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(fetchMock).toHaveBeenCalledTimes(attempt + 2);
+    }
+    await expect(pending).resolves.toBe("unavailable");
+    expect(Date.now()).toBe(110_000);
   });
 
   it("performs a definitive final HEAD after the last backoff", async () => {
-    vi.useFakeTimers();
-    try {
-      const fetchImpl = vi.fn<typeof fetch>();
-      for (let attempt = 0; attempt < 7; attempt += 1) {
-        fetchImpl.mockResolvedValueOnce(new Response(null, { status: 202 }));
-      }
-      fetchImpl.mockResolvedValueOnce(new Response(null, { status: 200 }));
-      const pending = waitForChatMediaPlayback({
-        source: "/media?playback=1",
-        signal: new AbortController().signal,
-        fetchImpl,
-      });
-
-      await vi.runAllTimersAsync();
-      await expect(pending).resolves.toBe("ready");
-      expect(fetchImpl).toHaveBeenCalledTimes(8);
-    } finally {
-      vi.useRealTimers();
+    const fetchMock = vi.fn<typeof fetch>();
+    for (let attempt = 0; attempt < 7; attempt += 1) {
+      fetchMock.mockResolvedValueOnce(new Response(null, { status: 202 }));
     }
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const pending = waitForChatMediaPlayback({
+      source: "/media?playback=1",
+      signal: new AbortController().signal,
+    });
+
+    await vi.runAllTimersAsync();
+    await expect(pending).resolves.toBe("ready");
+    expect(fetchMock).toHaveBeenCalledTimes(8);
   });
 
   it("fails a stalled readiness request at its request deadline", async () => {
-    vi.useFakeTimers();
-    try {
-      const pending = waitForChatMediaPlayback({
-        source: "/media?playback=1",
-        signal: new AbortController().signal,
-        requestTimeoutMs: 10,
-        fetchImpl: vi.fn<typeof fetch>(async () => await new Promise<Response>(() => {})),
-      });
-      await vi.advanceTimersByTimeAsync(10);
-      await expect(pending).resolves.toBe("unavailable");
-    } finally {
-      vi.useRealTimers();
-    }
+    const fetchMock = vi.fn<typeof fetch>(async () => await new Promise<Response>(() => {}));
+    vi.stubGlobal("fetch", fetchMock);
+    const pending = waitForChatMediaPlayback({
+      source: "/media?playback=1",
+      signal: new AbortController().signal,
+    });
+    await vi.advanceTimersByTimeAsync(30_000);
+    await expect(pending).resolves.toBe("unavailable");
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
   });
 
   it("clamps a retry sleep to the remaining overall deadline", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(0));
-    try {
-      const fetchImpl = vi
-        .fn<typeof fetch>()
-        .mockImplementationOnce(async () => {
-          vi.setSystemTime(new Date(119_000));
-          return new Response(null, { status: 202 });
-        })
-        .mockResolvedValueOnce(new Response(null, { status: 500 }));
-      const waitImpl = vi.fn<(delayMs: number, signal: AbortSignal) => Promise<void>>(
-        async () => undefined,
-      );
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      vi.setSystemTime(new Date(119_000));
+      return new Response(null, { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const pending = waitForChatMediaPlayback({
+      source: "/media?playback=1",
+      signal: new AbortController().signal,
+    });
+    let settled = false;
+    void pending.then(() => (settled = true));
 
-      await expect(
-        waitForChatMediaPlayback({
-          source: "/media?playback=1",
-          signal: new AbortController().signal,
-          fetchImpl,
-          waitImpl,
-        }),
-      ).resolves.toBe("unavailable");
-      expect(waitImpl).toHaveBeenCalledWith(1_000, expect.any(AbortSignal));
-    } finally {
-      vi.useRealTimers();
-    }
+    await vi.advanceTimersByTimeAsync(999);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(pending).resolves.toBe("unavailable");
+    expect(Date.now()).toBe(120_000);
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 });

--- a/ui/src/pages/chat/components/chat-media-playback.ts
+++ b/ui/src/pages/chat/components/chat-media-playback.ts
@@ -51,9 +51,7 @@ async function fetchPlaybackHead(params: {
   headers: Headers;
   signal: AbortSignal;
   timeoutMs: number;
-  fetchImpl: typeof fetch;
 }): Promise<Response> {
-  const { fetchImpl } = params;
   const controller = new AbortController();
   let rejectDeadline: ((error: Error) => void) | undefined;
   const deadline = new Promise<never>((_resolve, reject) => {
@@ -75,7 +73,7 @@ async function fetchPlaybackHead(params: {
   }, params.timeoutMs);
   try {
     return await Promise.race([
-      fetchImpl(params.source, {
+      fetch(params.source, {
         method: "HEAD",
         headers: params.headers,
         credentials: "same-origin",
@@ -93,15 +91,7 @@ export async function waitForChatMediaPlayback(params: {
   source: string;
   authToken?: string | null;
   signal: AbortSignal;
-  onPreparing?: () => void;
-  fetchImpl?: typeof fetch;
-  retryDelaysMs?: readonly number[];
-  waitImpl?: (delayMs: number, signal: AbortSignal) => Promise<void>;
-  requestTimeoutMs?: number;
 }): Promise<ChatMediaPlaybackReadiness> {
-  const fetchImpl = params.fetchImpl ?? fetch;
-  const retryDelaysMs = params.retryDelaysMs ?? CHAT_MEDIA_PLAYBACK_RETRY_DELAYS_MS;
-  const waitImpl = params.waitImpl ?? waitForRetry;
   const headers = buildChatMediaFetchHeaders(params.authToken);
   headers.set("Accept", "audio/*, video/*");
   const deadline = Date.now() + CHAT_MEDIA_PLAYBACK_MAX_WAIT_MS;
@@ -119,17 +109,12 @@ export async function waitForChatMediaPlayback(params: {
         source: params.source,
         headers,
         signal: params.signal,
-        timeoutMs: Math.min(
-          params.requestTimeoutMs ?? CHAT_MEDIA_PLAYBACK_REQUEST_TIMEOUT_MS,
-          remainingMs,
-        ),
-        fetchImpl,
+        timeoutMs: Math.min(CHAT_MEDIA_PLAYBACK_REQUEST_TIMEOUT_MS, remainingMs),
       });
       if (response.status !== 202) {
         return response.ok ? "ready" : "unavailable";
       }
-      params.onPreparing?.();
-      const retryDelay = retryDelaysMs[attempt];
+      const retryDelay = CHAT_MEDIA_PLAYBACK_RETRY_DELAYS_MS[attempt];
       if (retryDelay === undefined) {
         return "unavailable";
       }
@@ -137,7 +122,7 @@ export async function waitForChatMediaPlayback(params: {
       if (remainingAfterResponseMs <= 0) {
         return "unavailable";
       }
-      await waitImpl(Math.min(retryDelay, remainingAfterResponseMs), params.signal);
+      await waitForRetry(Math.min(retryDelay, remainingAfterResponseMs), params.signal);
     } catch {
       return params.signal.aborted ? "aborted" : "unavailable";
     }


### PR DESCRIPTION
## What Problem This Solves

Media-readiness tests should verify the timing policy used by the application, and preparation state should stay with the playback source controller.

## Why This Change Was Made

Remove the obsolete preparation callback and test-only fetch/timing overrides. The existing tests now exercise the normal fetch boundary and fixed polling policy under controlled time. Playback preparation and completion remain owned by the source controller.

## User Impact

Media timing, status, cancellation and playback behavior are unchanged. The cleanup removes 15 production lines and 11 test lines without adding test cases.

## Evidence

The same 45 cases across the readiness helper, source controller, audio player and video player passed before and after, using identical adapted test source. They retain the existing retry schedule, 30-second request ceiling, two-minute overall deadline and final HEAD attempt, plus source replacement and cancellation behavior.

All 20 final canonical checks and the independent P2 review passed. These tests use mocked fetch and jsdom.

Additional isolated Chromium component checks exercised native fetch against a local synthetic HTTP endpoint: HEAD 202 then 200 at the unchanged two-second retry, preparing text then enabled controls, with the silent WAV paused at zero. Baseline 37aaf073 and head c9bd7014 were source-bound; the 76 loaded sibling files matched. Corresponding before/after preparing and ready frames are byte-identical, as expected for preserved behavior. This is component/HTTP-readiness proof; no playback, installed-app or operating-system integration claim is made. All four full synthetic frames were inspected before upload.

![before-preparing](https://github.com/user-attachments/assets/5e374d8c-373c-4936-9ea9-1f7c231b11d0)

![before-ready](https://github.com/user-attachments/assets/062654b2-129d-4a00-aa6b-48349928b789)

![after-preparing](https://github.com/user-attachments/assets/b96a544c-6aba-4489-8a15-d9364952704f)

![after-ready](https://github.com/user-attachments/assets/dc5d482d-a45a-4e21-b836-4581e33c886b)