### PR TITLE
perf(hooks): release invoked factory captures

### DIFF
--- a/src/hooks/fire-and-forget.test.ts
+++ b/src/hooks/fire-and-forget.test.ts
@@ -1,6 +1,7 @@
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 // Fire-and-forget hook tests cover async hook execution without blocking callers.
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { fireAndForgetBoundedHook, fireAndForgetHook } from "./fire-and-forget.js";
 
 function requireFirstLog(logger: ReturnType<typeof vi.fn>): string {
@@ -48,58 +49,71 @@ describe("fireAndForgetHook", () => {
 });
 
 describe("fireAndForgetBoundedHook", () => {
-  it("limits queued fire-and-forget hooks", async () => {
-    const logger = vi.fn();
-    let resolveFirst: (() => void) | undefined;
-    const first = new Promise<void>((resolve) => {
-      resolveFirst = resolve;
-    });
-    const starts: string[] = [];
+  it.each(["resolve", "reject"] as const)(
+    "holds queue capacity until timed-out hooks %s",
+    async (settlement) => {
+      vi.useFakeTimers();
+      const logger = vi.fn();
+      const first = createDeferred();
+      const starts: string[] = [];
+      try {
+        fireAndForgetBoundedHook(
+          function (this: unknown) {
+            expect(this).toBeUndefined();
+            starts.push("first");
+            return first.promise;
+          },
+          "hook failed",
+          logger,
+          { maxConcurrency: 1, maxQueue: 1, timeoutMs: 10_000 },
+        );
+        fireAndForgetBoundedHook(
+          async () => {
+            starts.push("second");
+          },
+          "hook failed",
+          logger,
+          { maxConcurrency: 1, maxQueue: 1, timeoutMs: 10_000 },
+        );
+        fireAndForgetBoundedHook(
+          async () => {
+            starts.push("third");
+          },
+          "hook failed",
+          logger,
+          { maxConcurrency: 1, maxQueue: 1, timeoutMs: 10_000 },
+        );
 
-    fireAndForgetBoundedHook(
-      async () => {
-        starts.push("first");
-        await first;
-      },
-      "hook failed",
-      logger,
-      { maxConcurrency: 1, maxQueue: 1, timeoutMs: 10_000 },
-    );
-    fireAndForgetBoundedHook(
-      async () => {
-        starts.push("second");
-      },
-      "hook failed",
-      logger,
-      { maxConcurrency: 1, maxQueue: 1, timeoutMs: 10_000 },
-    );
-    fireAndForgetBoundedHook(
-      async () => {
-        starts.push("third");
-      },
-      "hook failed",
-      logger,
-      { maxConcurrency: 1, maxQueue: 1, timeoutMs: 10_000 },
-    );
-
-    await vi.waitFor(() => {
-      expect(starts).toEqual(["first"]);
-    });
-    expect(logger).toHaveBeenCalledWith("hook failed: queue full; dropping hook");
-
-    resolveFirst?.();
-    await vi.waitFor(() => {
-      expect(starts).toEqual(["first", "second"]);
-    });
-  });
+        expect(starts).toEqual([]);
+        expect(logger).toHaveBeenCalledWith("hook failed: queue full; dropping hook");
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(starts).toEqual(["first"]);
+        expect(logger).toHaveBeenCalledWith("hook failed: timed out after 10000ms");
+        if (settlement === "reject") {
+          first.reject(new Error("late hook failure"));
+        } else {
+          first.resolve();
+        }
+        await vi.advanceTimersByTimeAsync(0);
+        expect(starts).toEqual(["first", "second"]);
+        expect(logger).toHaveBeenCalledTimes(2);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        first.resolve();
+        await vi.advanceTimersByTimeAsync(0);
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("caps oversized hook timeout timers", async () => {
     vi.useFakeTimers();
+    const pending = createDeferred();
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
-      const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
       const logger = vi.fn();
 
-      fireAndForgetBoundedHook(async () => new Promise(() => {}), "hook failed", logger, {
+      fireAndForgetBoundedHook(() => pending.promise, "hook failed", logger, {
         timeoutMs: Number.MAX_SAFE_INTEGER,
       });
 
@@ -107,6 +121,9 @@ describe("fireAndForgetBoundedHook", () => {
       await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
       expect(logger).toHaveBeenCalledWith(`hook failed: timed out after ${MAX_TIMER_TIMEOUT_MS}ms`);
     } finally {
+      pending.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      timeoutSpy.mockRestore();
       vi.useRealTimers();
     }
   });

--- a/src/hooks/fire-and-forget.ts
+++ b/src/hooks/fire-and-forget.ts
@@ -89,9 +89,10 @@ export function fireAndForgetHook(
 
 function runFireAndForgetHookJob(
   state: FireAndForgetHookState,
-  job: FireAndForgetHookJob,
+  { task, ...job }: FireAndForgetHookJob,
   limits: { maxConcurrency: number },
 ): void {
+  // Pending observers need logging metadata, not the invoked factory's captured inputs.
   state.active += 1;
   let didLogTimeout = false;
   const timeout =
@@ -105,7 +106,7 @@ function runFireAndForgetHookJob(
       : undefined;
 
   void Promise.resolve()
-    .then(job.task)
+    .then(task)
     .catch((err: unknown) => {
       if (!didLogTimeout) {
         job.logger(`${job.label}: ${formatHookErrorForLog(err)}`);


### PR DESCRIPTION
## What Problem This Solves

A running fire-and-forget hook observer retains its complete queued job, including the already-invoked factory. That factory can keep unused inbound context alive while the promise it returned is still pending.

## Why This Change Was Made

Separate the factory from the logging metadata retained by pending observers. Invocation stays in the same Promise microtask with unbound `this`; queue admission, informational timeout logging, late-error suppression, and capacity release on actual settlement keep their current behavior. The change adds one small metadata object per dispatch.

## User Impact

Slow observation hooks can release inputs captured only by their invoked factory. Their actual pending work continues to own any input it still needs, and a timeout does not release queue capacity early.

## Evidence

- All **six focused tests** and the final full changed-code gate pass. The existing queue test covers asynchronous/unbound invocation, queue-full dropping, timeout, late resolve/reject, a queued successor, suppressed duplicate logs, and timer cleanup.
- A pre-existing oversized-timeout fixture now settles its owned job during cleanup. Initial redundant test type arguments were corrected, then the full final gate and fresh review passed.
- Four fresh actual-owner probes cover baseline/candidate with late resolution and rejection. An **8 MiB factory-only Buffer stays alive before and after the informational timeout in the baseline, and is released in the candidate**. The successor remains queued until actual settlement in every arm; invocation facts, logs, and final cleanup match.
- The difference is 8,388,608 bytes in both `arrayBuffers` and `external`; these overlap and must not be added. This is a synthetic factory-lifetime experiment, not a real-plugin or whole-Gateway memory measurement. No CPU, latency, RSS, or typical-message saving is claimed.
- Independent source/test/probe review and final managed autoreview found no actionable issues. All proof processes joined; `git diff --check` passes.
- Required hosted CI passed on the exact reviewed head ([run 34043827461](https://github.com/openclaw/openclaw/actions/runs/34043827461)). The first attempt hit a 120-second timeout in the unchanged custom-runner rejection test in `test/scripts/run-vitest-profile.test.ts`; one failed-job rerun passed with no source, timeout, or assertion changes.
