### PR TITLE
perf(agents): reuse Code Mode JSON within result fitting

### DIFF
--- a/src/agents/code-mode-json.test.ts
+++ b/src/agents/code-mode-json.test.ts
@@ -4,6 +4,7 @@ import {
   boundCodeModeValue,
   captureCodeModeOutput,
   captureCodeModeValue,
+  CodeModeOutputState,
   toCodeModeJsonSafe,
 } from "./code-mode-json.js";
 
@@ -58,7 +59,7 @@ describe("Code Mode JSON normalization", () => {
     });
   });
 
-  it("keeps structured values detached from later mutation", () => {
+  it("keeps captured and delivered structured values detached from later mutation", async () => {
     const input = { nested: { label: "before" }, items: ["before"] };
     const normalized = toCodeModeJsonSafe(input);
     const captured = captureCodeModeValue(input, 1_024);
@@ -69,6 +70,25 @@ describe("Code Mode JSON normalization", () => {
       kind: "complete",
       json: '{"nested":{"label":"before"},"items":["before"]}',
     });
+
+    const state = new CodeModeOutputState(65_536, { maxChars: 2_048, maxContextChars: 4_096 });
+    state.append(captureCodeModeOutput([{ type: "text", text: "x".repeat(10_000) }], 65_536));
+    const first = state.takeResult({ status: "completed" }, { value: captured });
+    expect(first.value).toEqual(normalized);
+    expect(first.output).toEqual([expect.objectContaining({ truncated: true })]);
+    if (!first.value || typeof first.value !== "object") {
+      throw new Error("Expected a structured delivered value");
+    }
+    Object.assign(first.value, { nested: { label: "changed after delivery" } });
+    await Promise.resolve();
+
+    const second = state.takeResult({ status: "completed" }, { value: captured });
+    expect(second).toMatchObject({ value: normalized, output: [] });
+    state.append(captureCodeModeOutput([{ type: "text", text: "next" }], 65_536));
+    expect(
+      state.takeResult({ status: "completed" }, { value: captureCodeModeValue(null, 65_536) })
+        .value,
+    ).toBeNull();
   });
 
   it("retains cycle fallbacks and normalizes each output entry with the root toJSON key", () => {

--- a/src/agents/code-mode-json.ts
+++ b/src/agents/code-mode-json.ts
@@ -268,6 +268,9 @@ export class CodeModeOutputState {
     const outputBytes = count === 0 ? 0 : sourceBytes(source);
     const valueBytes = value === undefined ? 0 : sourceBytes(value);
     const errorBytes = fullError === undefined ? 0 : jsonUtf8Bytes(fullError);
+    // Reuse decoded channels only within this fit; later deliveries need fresh objects.
+    let completeOutput: unknown[] | undefined;
+    let completeValue: { value: unknown } | undefined;
     let outputMarker: ReturnType<typeof createTruncationMarker> | undefined;
     let valueMarker: ReturnType<typeof createTruncationMarker> | undefined;
     let errorFitter: ReturnType<typeof createErrorFitter> | undefined;
@@ -287,8 +290,7 @@ export class CodeModeOutputState {
       if (outputBytes <= outputAllowance) {
         // A retained prefix has originalBytes > maxBytes and cannot fit this allowance.
         // SAFETY: Complete output sources encode normalized arrays, never guest metadata.
-        const entries = JSON.parse(source.json) as unknown[];
-        output = entries;
+        output = completeOutput ??= JSON.parse(source.json) as unknown[];
         chargedOutputBytes = outputBytes;
         receipt = { kind: "entries", count };
       } else {
@@ -306,14 +308,13 @@ export class CodeModeOutputState {
           output,
           ...(value === undefined
             ? {}
-            : {
-                value:
-                  value.kind === "complete" && valueBytes <= remaining - chargedOutputBytes
-                    ? (JSON.parse(value.json) as unknown)
-                    : (valueMarker ??= createTruncationMarker(value, this.maxBytes))(
-                        remaining - chargedOutputBytes,
-                      ),
-              }),
+            : value.kind === "complete" && valueBytes <= remaining - chargedOutputBytes
+              ? (completeValue ??= { value: JSON.parse(value.json) as unknown })
+              : {
+                  value: (valueMarker ??= createTruncationMarker(value, this.maxBytes))(
+                    remaining - chargedOutputBytes,
+                  ),
+                }),
           ...(error === undefined ? {} : { error }),
         },
       };


### PR DESCRIPTION
## What Problem This Solves

Code Mode may try several result sizes while fitting model-visible output. Each trial reparses the same complete JSON output and value channels, rebuilding temporary object graphs within one synchronous fit.

## Why This Change Was Made

Lazily reuse complete parsed channels inside that one projector call. A value envelope allows `null`, false, zero, and empty text to be cached correctly. Every later delivery creates a fresh projector, preserving mutation isolation, JSON bytes/order, truncation markers, and receipt acknowledgement/slicing.

## User Impact

Result-fitting paths avoid repeated complete-channel parsing while later deliveries continue to receive fresh objects. The reuse does not live on the retained output state or cross calls.

## Evidence

- **145 focused tests** and the final full changed-code gate pass. The existing detachment test now exercises a bounded fit, delivered-object mutation, a microtask boundary, repeated delivery, appended output, and a null value.
- **126 cases with three deliveries each** preserve complete envelopes. Separate instrumentation freezes parsed graphs during fitting and verifies unchanged results; complete channels fall from as many as **17 parses to one**, null parses once, and both-prefix paths parse zero times.
- Mutation-isolation and WeakRef/GC controls verify that delivered graphs can be collected while encoded state remains alive. Independent review and fresh managed autoreview found no actionable issues.
- Two fresh process samples per arm, each with 200 projections, show sampled JavaScript allocation reductions of **21.8%**, **6.7%**, and **7.3%** for complete-output, complete-value, and null-value fitting. The both-prefix control is effectively unchanged.
- The small full-fit control increases from **0.752 to 0.908 MiB over 200 calls (+20.8%)**. These limited component observations do not support a universal allocation win, statistical significance, or whole-Gateway/RSS claim. Capture occurs before measurement; result serialization/hashing remains in the timed loop.
- An initial baseline control used inconsistent status metadata; it was corrected before production edits. Final hashes, source, tests, and all joined processes are recorded; `git diff --check` passes.
- Required hosted CI passed on the exact reviewed head ([run 34043776834](https://github.com/openclaw/openclaw/actions/runs/34043776834)).
