### PR TITLE
refactor(fleet): share strict inspect response decoding

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -560,7 +560,6 @@ src/daemon/launchd.test.ts
 src/daemon/schtasks.startup-fallback.test.ts
 src/daemon/systemd.test.ts
 src/fleet/backup.runtime.ts
-src/fleet/containers.runtime.ts
 src/fleet/service.runtime.ts
 src/flows/channel-setup.test.ts
 src/flows/channel-setup.ts

--- a/src/fleet/containers.runtime.ts
+++ b/src/fleet/containers.runtime.ts
@@ -144,21 +144,6 @@ function readOptionalInspectString(value: unknown): string | undefined {
   return value;
 }
 
-function readLabels(value: unknown): Record<string, string> {
-  if (value === undefined || value === null) {
-    return {};
-  }
-  const record = requireRecord(value);
-  const labels: Record<string, string> = {};
-  for (const [key, label] of Object.entries(record)) {
-    if (typeof label !== "string") {
-      throw new InvalidInspectOutputError();
-    }
-    labels[key] = label;
-  }
-  return labels;
-}
-
 function readStringRecord(value: unknown): Record<string, string> {
   if (value === undefined || value === null) {
     return {};
@@ -238,14 +223,8 @@ function readNetworkAttachments(value: unknown): Array<{ id: string; name?: stri
 }
 
 function readEnvironment(value: unknown): Record<string, string> {
-  if (value === undefined || value === null) {
-    return {};
-  }
-  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) {
-    throw new InvalidInspectOutputError();
-  }
   const environment: Record<string, string> = {};
-  for (const assignment of value) {
+  for (const assignment of readStringArray(value)) {
     const separator = assignment.indexOf("=");
     if (separator <= 0) {
       throw new InvalidInspectOutputError();
@@ -265,7 +244,7 @@ function readPidsLimit(value: unknown): number | undefined {
   return value;
 }
 
-function parseInspectOutput(stdout: string): Extract<FleetContainerInspectResult, { kind: "ok" }> {
+function parseInspectRecord(stdout: string): Record<string, unknown> {
   let parsed: unknown;
   try {
     parsed = JSON.parse(stdout);
@@ -275,7 +254,11 @@ function parseInspectOutput(stdout: string): Extract<FleetContainerInspectResult
   if (!Array.isArray(parsed) || parsed.length !== 1) {
     throw new InvalidInspectOutputError();
   }
-  const inspected = requireRecord(parsed[0]);
+  return requireRecord(parsed[0]);
+}
+
+function parseInspectOutput(stdout: string): Extract<FleetContainerInspectResult, { kind: "ok" }> {
+  const inspected = parseInspectRecord(stdout);
   const state = requireRecord(inspected.State);
   const config = requireRecord(inspected.Config);
   const hostConfig = requireRecord(inspected.HostConfig);
@@ -288,7 +271,8 @@ function parseInspectOutput(stdout: string): Extract<FleetContainerInspectResult
     containerId: requireString(inspected.Id),
     state: requireString(state.Status),
     running: requireBoolean(state.Running),
-    labels: readLabels(config.Labels),
+    // Preserve ordinary-object assignment semantics for JSON "__proto__" labels.
+    labels: Object.assign({}, readStringRecord(config.Labels)),
     environment: readEnvironment(config.Env),
     imageId: requireString(inspected.Image),
     memory: String(requireNonNegativeNumber(hostConfig.Memory)),
@@ -310,37 +294,18 @@ function parseInspectOutput(stdout: string): Extract<FleetContainerInspectResult
 function parseNetworkInspectOutput(
   stdout: string,
 ): Extract<FleetNetworkInspectResult, { kind: "ok" }> {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(stdout);
-  } catch {
-    throw new InvalidInspectOutputError();
-  }
-  if (!Array.isArray(parsed) || parsed.length !== 1) {
-    throw new InvalidInspectOutputError();
-  }
-
-  const inspected = requireRecord(parsed[0]);
+  const inspected = parseInspectRecord(stdout);
   return {
     kind: "ok",
-    labels: readLabels(inspected.Labels ?? inspected.labels),
+    labels: Object.assign({}, readStringRecord(inspected.Labels ?? inspected.labels)),
     attachedContainers: readNetworkAttachments(inspected.Containers ?? inspected.containers),
     internal: readOptionalBoolean(inspected.Internal ?? inspected.internal) ?? false,
   };
 }
 
 function parseDockerContextEndpoint(stdout: string): string {
-  let parsed: unknown;
   try {
-    parsed = JSON.parse(stdout);
-  } catch {
-    throw new Error("docker context inspect returned an invalid response");
-  }
-  if (!Array.isArray(parsed) || parsed.length !== 1) {
-    throw new Error("docker context inspect returned an invalid response");
-  }
-  try {
-    const context = requireRecord(parsed[0]);
+    const context = parseInspectRecord(stdout);
     const endpoints = requireRecord(context.Endpoints);
     const docker = requireRecord(endpoints.docker);
     return requireString(docker.Host);
@@ -364,20 +329,10 @@ function isLocalDockerEndpoint(endpoint: string): boolean {
 }
 
 function parsePodmanServiceIsRemote(stdout: string): boolean {
-  let parsed: unknown;
   try {
-    parsed = JSON.parse(stdout);
-  } catch {
-    throw new Error("podman info returned an invalid response");
-  }
-  try {
-    const info = requireRecord(parsed);
+    const info = requireRecord(JSON.parse(stdout));
     const host = requireRecord(info.host);
-    const serviceIsRemote = host.serviceIsRemote;
-    if (typeof serviceIsRemote !== "boolean") {
-      throw new Error();
-    }
-    return serviceIsRemote;
+    return requireBoolean(host.serviceIsRemote);
   } catch {
     throw new Error("podman info returned an invalid response");
   }
@@ -798,4 +753,3 @@ export function createFleetContainerRuntime(
     },
   };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Fleet's container inspection owner repeats strict JSON and field decoding in several paths and exceeds the repository's normal file-size limit. This maintainer-requested cleanup removes that duplication while preserving the inspection facts used by status, doctor, upgrades, backup, and removal.

## Why This Change Was Made

Reuse the existing strict string-record/array readers, share singleton inspect-record decoding across container, network, and Docker-context responses, and simplify Podman's identical failure handling. Label copying deliberately uses ordinary-object assignment so JSON `__proto__` strings retain their existing behavior. Docker rootless parsing keeps its distinct strict array contract.

This is an independent clean-broad companion to the #135868 split (decision brief §1 concern map and §5 stack order); no feature-stage content is extracted.

## User Impact

No user-visible behavior change. Ownership labels, environment values, runtime locality, malformed-response confidentiality, and exact missing/unavailable/error results remain unchanged. The owner now fits the normal max-lines rule without an exemption.

## Evidence

- The full decoder section before this change is byte-identical to stable `v2026.9.2`. Pickaxe history for the private readers points to `e357203be57`; this preserves the shipped inspection contract rather than retiring compatibility.
- Labels and environment values originate in JSON parsed inside the owner. Existing `readStringRecord` uses canonical `isStringRecord`, rejecting invalid values rather than filtering them. `Object.assign` retains the old string-key assignment semantics; direct return or spread would expose an own `__proto__` label. Storage options retain their existing direct validated-record result.
- 138 existing tests pass before and after across container runtime, service, doctor, backup and removal suites. After rebasing onto #137211, the expanded six-suite run passes 207 tests, including cell-profile and new cache/provenance coverage.
- 1,352 differential cases (2,704 executions) traverse the full factory via its existing injected executor and the actual normalization guards in the same VM realm. Exact values, undefined fields, key order, descriptors, prototypes, error names/messages and executor calls match. Coverage includes malformed and singleton roots, labels/environment arrays, casing/fallbacks, three-platform Docker locality, strict Podman booleans and rootless-null rejection. Six Docker/Podman cases explicitly preserve the new cache/provenance values, including empty provenance labels. Wrong spread/direct-return mutations are detected. Inputs are synthetic; no real Docker/Podman service is used.
- Imports, public type aliases and thirty unaffected runtime declarations—including the complete public factory and default executors—emit identical JavaScript. No process/streaming, redaction, storage, schema, dependency or public API change.
- Independent Codex review is clean through P2. The initial full selected core/core-test/tooling check plan passed locally, including production/test types, full core and script lint, three zero-entry dead-export scans, exact max-lines ratchet, storage/boundary guards and zero runtime import cycles. The full plan passed again after rebasing onto the related main change. No full build is required because import, lazy, package and public surfaces are unchanged.

| Judged class | Added | Deleted | Net | Before → after |
| --- | ---: | ---: | ---: | --- |
| Production | 14 | 60 | −46 | `containers.runtime.ts`: 801 → 755 physical lines; 724 → 679 counted |
| Tests | 0 | 0 | 0 | unchanged |
| Tooling | 0 | 1 | −1 | exact max-lines baseline row removed |
| Docs | 0 | 0 | 0 | unchanged |

The remaining 679 counted lines are below the existing 700-line limit. No suppression or baseline was added or weakened.


ClawSweeper reviewed `4dac2356d03` at 2026-09-06T16:02:20Z: no code or security findings, no before-merge requests, and no rank-up moves to apply. Its source review independently confirmed strict decoding, the ordinary-object label contract, unchanged lifecycle consumers, and the stable-release comparison.


Initial exact-head [CI34043838696](https://github.com/openclaw/openclaw/actions/runs/34043838696) passed on `4dac2356d0309691714801a52feb3bf61edf5696`, with no failed jobs.


Final freshness head `8358f6326ff86ecacba8f7da6346a9017dfd7ac8` preserves all 23 recorded proof inputs and the lockfile. Fresh final-head Codex review is clean through P2; [final CI34044340715](https://github.com/openclaw/openclaw/actions/runs/34044340715) passed on that exact head, with no failed jobs and a green canonical watcher. Native prepare also passed without changing the remote head.
