### PR TITLE
test(android): use inbox snapshot for approval readiness

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
@@ -209,7 +209,6 @@ class SettingsScreensContrastTest {
       observe("cron-help", "Open an automation to inspect its configuration and run history.", substring = true)
     }
     composeRule.runOnIdle { route.value = SettingsRoute.Approvals }
-    // Rows can render before the independently propagated refreshing flag settles.
     composeRule.waitUntil(10_000) {
       composeRule.onAllNodesWithText("echo ok").fetchSemanticsNodes().isNotEmpty() &&
         !model.execApprovalInbox.value.refreshing && model.execApprovalInbox.value.approvals
@@ -231,8 +230,9 @@ class SettingsScreensContrastTest {
     gateway.terminal = true
     composeRule.onNodeWithText("Refresh").performScrollTo().performClick()
     composeRule.waitUntil(10_000) {
+      val inbox = model.execApprovalInbox.value
       composeRule.onAllNodesWithText("Approval approval-1").fetchSemanticsNodes().isNotEmpty() &&
-        model.execApprovals.value.isEmpty() && model.execApprovalsNotice.value?.approvalId == "approval-1"
+        inbox.approvals.isEmpty() && inbox.notice?.approvalId == "approval-1"
     }
     assertTrue(
       model.execApprovalInbox.value.approvals


### PR DESCRIPTION
Follow-up to #140111. Test-only: production +0/-0; tests +2/-2.

## What this fixes

Post-merge verification found that moving main had added an approval-readiness predicate using two getters which #140111 removed. Git combined the patches without a text conflict, leaving `SettingsScreensContrastTest` unable to compile.

Read approvals and the notice from one existing `execApprovalInbox` snapshot inside that wait, and remove the obsolete comment about independently propagated refresh state. The rendered-notice check, pending/readback/dismissal assertions, 10-second timeout, and fixture cleanup are unchanged. No compatibility getters, production changes, or new tests are added.

## Verification

- The exact merged source `149433b2604759c9dbfc3e06d5a8ec003a68de00` failed `compilePlayDebugUnitTestKotlin` on the two removed references before this edit.
- With this patch, compilation, both existing UI suites (30 tests), and scoped ktlint pass.
- On the fresh main-based checkout (`796a9ff4036cd569729463e5f528a7018e4d0d81` plus this patch), compilation, the same 30 UI tests, scoped ktlint and the complete changed-file gate also passed. Codex autoreview found no actionable P0–P2 issue. Exact-head hosted [CI34043874946](https://github.com/openclaw/openclaw/actions/runs/34043874946) passed all selected Android tests/builds, lint and the required gate.

This repairs test integration, not the approval implementation. The installed approval flow and its evidence remain documented in #140111; no new installed-app proof is claimed for this test-only change.
