### PR TITLE
fix: exclude macOS AppleDouble SQLite sidecars from backups

### DIFF
--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -607,6 +607,27 @@ describe("createBackupVolatileStatCache", () => {
 });
 
 describe("createBackupArchive", () => {
+  it("excludes macOS AppleDouble SQLite sidecars without weakening database validation", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-appledouble-sqlite-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        await state.writeText("._cron.sqlite", "AppleDouble metadata\n");
+        await expect(
+          createBackupArchive({
+            output: state.path("backup.tar.gz"),
+            includeWorkspace: false,
+          }),
+        ).resolves.toEqual(expect.objectContaining({ archivePath: state.path("backup.tar.gz") }));
+        const entries = await listArchiveEntries(state.path("backup.tar.gz"));
+        expect(entries.some((entry) => entry.endsWith("/._cron.sqlite"))).toBe(false);
+      },
+    );
+  });
+
   it.each<{
     configRelativePath: string;
     onlyConfig: boolean;

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -628,6 +628,27 @@ describe("createBackupArchive", () => {
     );
   });
 
+  it("preserves ordinary files inside directories named like AppleDouble SQLite sidecars", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-appledouble-directory-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        await state.writeText("._archive.sqlite/notes.txt", "ordinary content\n");
+        const result = await createBackupArchive({
+          output: state.path("backup.tar.gz"),
+          includeWorkspace: false,
+        });
+        const entries = await listArchiveEntries(result.archivePath);
+        expect(entries.some((entry) => entry.endsWith("/state/._archive.sqlite/notes.txt"))).toBe(
+          true,
+        );
+      },
+    );
+  });
+
   it.each<{
     configRelativePath: string;
     onlyConfig: boolean;

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -582,7 +582,9 @@ export async function createBackupArchive(
       }
       const sqliteSourceKind = onlyConfig
         ? undefined
-        : classifyBackupSqliteSource(resolvedEntryPath, plan.inventory);
+        : classifyBackupSqliteSource(resolvedEntryPath, plan.inventory, {
+            isRegularFile: !isDirectory && isBackupTarFilterFile(entryStat),
+          });
       if (sqliteSourceKind === "excluded") {
         return false;
       }

--- a/src/infra/backup-sqlite-snapshot.ts
+++ b/src/infra/backup-sqlite-snapshot.ts
@@ -102,6 +102,10 @@ function resolveSqliteBackupDatabasePath(sourcePath: string): string | undefined
   return sourcePath.endsWith(".sqlite") ? sourcePath : undefined;
 }
 
+function isAppleDoubleSqliteSidecar(sourcePath: string): boolean {
+  return path.basename(sourcePath).startsWith("._") && sourcePath.endsWith(".sqlite");
+}
+
 export function classifyBackupSqliteSource(
   sourcePath: string,
   inventory: BackupResourceInventory,
@@ -119,6 +123,9 @@ export function classifyBackupSqliteSource(
     );
   if (!withinOwnedRoot || inventory.isPackageContent(resolvedSourcePath)) {
     return undefined;
+  }
+  if (isAppleDoubleSqliteSidecar(resolvedSourcePath)) {
+    return "excluded";
   }
   if (transient) {
     return "excluded";

--- a/src/infra/backup-sqlite-snapshot.ts
+++ b/src/infra/backup-sqlite-snapshot.ts
@@ -109,6 +109,7 @@ function isAppleDoubleSqliteSidecar(sourcePath: string): boolean {
 export function classifyBackupSqliteSource(
   sourcePath: string,
   inventory: BackupResourceInventory,
+  options: { isRegularFile?: boolean } = {},
 ): "excluded" | "sqlite" | undefined {
   const resolvedSourcePath = path.resolve(sourcePath);
   const transient = isTransientSqliteBackupPath(resolvedSourcePath);
@@ -124,7 +125,7 @@ export function classifyBackupSqliteSource(
   if (!withinOwnedRoot || inventory.isPackageContent(resolvedSourcePath)) {
     return undefined;
   }
-  if (isAppleDoubleSqliteSidecar(resolvedSourcePath)) {
+  if (options.isRegularFile !== false && isAppleDoubleSqliteSidecar(resolvedSourcePath)) {
     return "excluded";
   }
   if (transient) {


### PR DESCRIPTION
Related: #140193

## What Problem This Solves

Fixes an issue where users running verified backups on macOS would fail to create an archive when AppleDouble metadata was present in the state directory under a `.sqlite`-suffixed filename.

## Why This Change Was Made

Classify regular AppleDouble `._*.sqlite` files as excluded backup metadata before SQLite snapshot discovery. Ordinary `.sqlite` databases continue through the existing ownership, snapshot, and integrity validation paths.

## User Impact

Verified backups no longer abort on macOS AppleDouble SQLite-shaped sidecars, while malformed ordinary SQLite databases remain fail-closed.

## Evidence

- `pnpm exec vitest run --config test/vitest/vitest.infra.config.ts src/infra/backup-create.test.ts -t 'excludes macOS AppleDouble' --pool=threads --maxWorkers=1` — passed.
- `pnpm exec oxfmt --check src/infra/backup-sqlite-snapshot.ts src/infra/backup-create.test.ts` — passed.
- `git diff --check` — passed.
- `pnpm check:changed --dry-run -- src/infra/backup-sqlite-snapshot.ts src/infra/backup-create.test.ts` — classified the production and core-test lanes; the full changed gate remains for CI.

The broader backup test invocation also exercised 112 passing tests before hitting an unrelated pre-existing timeout in the canonical agent SQLite alias test; the focused regression passes independently.

## Updated verification at head `58b892580c4840698d8c389e77d21d3d803fe839`

- Real CLI: `openclaw backup create --no-include-workspace --output <temp>/backup.tar.gz --verify` exited 0; archive verification passed. The archive omitted the regular `._cron.sqlite` AppleDouble metadata file and preserved ordinary content under the directory `._archive.sqlite/notes.txt`.
- Real CLI control: the same command with an ordinary malformed `plugins/dedicated/malformed.sqlite` exited 1 with `file is not a database`; unsafe raw-copy fallback remained refused.
- Corrected the archive-filter boundary so only regular files receive the AppleDouble exclusion; matching directories remain traversable. Added a regression test for that directory case.
- Focused backup suite: 114 tests passed.
