### PR TITLE
fix(agents): retain aggregate bootstrap-truncation notice in prepared compaction

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -95,6 +95,15 @@ export const limitHistoryTurnsMock = vi.fn<typeof import("./history.js").limitHi
 );
 export const sessionManualCompactionMock = vi.fn();
 export const sessionAutomaticCompactionMock = vi.fn();
+// Bootstrap context for prepared compaction. Returns the production
+// BootstrapContext shape so the budget chain runs; tests override with
+// mockResolvedValueOnce to inject aggregate-exhaustion scenarios.
+export const resolveBootstrapContextForRunMock = vi.fn<
+  typeof import("../bootstrap-files.js").resolveBootstrapContextForRun
+>(async () => ({
+  bootstrapFiles: [],
+  contextFiles: [],
+}));
 export const attemptServerEndpointCompactionMock: Mock<
   (params: Parameters<typeof attemptServerEndpointCompaction>[0]) => Promise<unknown>
 > = vi.fn(async () => undefined);
@@ -513,6 +522,11 @@ export function resetCompactSessionStateMocks(): void {
   sessionAbortCompactionMock.mockReset();
   sessionManualCompactionMock.mockReset();
   sessionAutomaticCompactionMock.mockReset();
+  resolveBootstrapContextForRunMock.mockReset();
+  resolveBootstrapContextForRunMock.mockResolvedValue({
+    bootstrapFiles: [],
+    contextFiles: [],
+  });
   attemptServerEndpointCompactionMock.mockReset();
   attemptServerEndpointCompactionMock.mockResolvedValue(undefined);
   resolveEffectiveCompactionModeMock.mockReset();
@@ -907,7 +921,7 @@ export async function loadCompactHooksHarness(options: { durableSession?: boolea
   vi.doMock("../bootstrap-files.js", () => ({
     makeBootstrapWarn: vi.fn(() => () => {}),
     resolveContextInjectionMode: vi.fn(() => "always"),
-    resolveBootstrapContextForRun: vi.fn(async () => ({ bootstrapFiles: [], contextFiles: [] })),
+    resolveBootstrapContextForRun: resolveBootstrapContextForRunMock,
   }));
 
   vi.doMock("../agent-bundle-mcp-tools.js", () => ({
@@ -1065,12 +1079,16 @@ export async function loadCompactHooksHarness(options: { durableSession?: boolea
     getActiveMemorySearchManagerCore: getMemorySearchManagerMock,
   }));
 
-  vi.doMock("../date-time.js", () => ({
-    formatDateStamp: vi.fn(() => "2026-01-01"),
-    formatUserTime: vi.fn(() => ""),
-    resolveUserTimeFormat: vi.fn(() => ""),
-    resolveUserTimezone: vi.fn(() => ""),
-  }));
+  vi.doMock("../date-time.js", async () => {
+    const actual = await vi.importActual<typeof import("../date-time.js")>("../date-time.js");
+    return {
+      ...actual,
+      formatDateStamp: vi.fn(() => "2026-01-01"),
+      formatUserTime: vi.fn(() => ""),
+      resolveUserTimeFormat: vi.fn(() => ""),
+      resolveUserTimezone: vi.fn(() => ""),
+    };
+  });
 
   vi.doMock("../defaults.js", () => ({
     DEFAULT_MODEL: "fake-model",

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -907,7 +907,7 @@ export async function loadCompactHooksHarness(options: { durableSession?: boolea
   vi.doMock("../bootstrap-files.js", () => ({
     makeBootstrapWarn: vi.fn(() => () => {}),
     resolveContextInjectionMode: vi.fn(() => "always"),
-    resolveBootstrapContextForRun: vi.fn(async () => ({ contextFiles: [] })),
+    resolveBootstrapContextForRun: vi.fn(async () => ({ bootstrapFiles: [], contextFiles: [] })),
   }));
 
   vi.doMock("../agent-bundle-mcp-tools.js", () => ({

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -49,6 +49,7 @@ import {
   buildEmbeddedExtensionFactoriesMock,
   buildAgentRuntimePlanMock,
   buildEmbeddedSystemPromptMock,
+  resolveBootstrapContextForRunMock,
   contextEngineCompactMock,
   createAgentSessionMock,
   createPreparedEmbeddedAgentSettingsManagerMock,
@@ -1265,6 +1266,128 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
         nativeCommandGuidanceLines: ["Subagent compact command guidance."],
       }),
     );
+  });
+
+  it("threads the aggregate bootstrap-truncation notice into the compaction prompt when the budget omits a later file", async () => {
+    // Two valid bootstrap files; only the first is admitted into context, so the
+    // second is fully omitted with no per-file inline marker. The aggregate
+    // budget chain must surface the canonical partial-context notice.
+    resolveBootstrapContextForRunMock.mockResolvedValueOnce({
+      bootstrapFiles: [
+        { name: "AGENTS.md", path: "/ws/AGENTS.md", content: "a".repeat(100), missing: false },
+        { name: "IDENTITY.md", path: "/ws/IDENTITY.md", content: "b".repeat(100), missing: false },
+      ],
+      contextFiles: [{ path: "/ws/AGENTS.md", content: "a".repeat(100) }],
+    });
+
+    await compactEmbeddedAgentSessionDirect({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile: TEST_SESSION_KEY,
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
+    });
+
+    expect(buildEmbeddedSystemPromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bootstrapTruncationNotice: expect.stringContaining("Treat Project Context as partial"),
+      }),
+    );
+  });
+
+  it("omits the bootstrap-truncation notice when the budget admits every file", async () => {
+    resolveBootstrapContextForRunMock.mockResolvedValueOnce({
+      bootstrapFiles: [
+        { name: "AGENTS.md", path: "/ws/AGENTS.md", content: "a".repeat(10), missing: false },
+      ],
+      contextFiles: [{ path: "/ws/AGENTS.md", content: "a".repeat(10) }],
+    });
+
+    await compactEmbeddedAgentSessionDirect({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile: TEST_SESSION_KEY,
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
+    });
+
+    expect(buildEmbeddedSystemPromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bootstrapTruncationNotice: undefined,
+      }),
+    );
+  });
+
+  it("delivers a real render of the bootstrap-truncation notice to the compaction session when the aggregate budget omits a later file", async () => {
+    // End-to-end proof: drive the real prepared-compaction owner
+    // (buildPreparedCompactionRuntime) through compactEmbeddedAgentSessionDirect
+    // with the real buildEmbeddedSystemPrompt renderer (not the "" mock), inject a
+    // real aggregate-exhaustion bootstrap result, and assert the notice survives
+    // into the actual prompt text delivered to the session via
+    // applySystemPromptToSession -> setBaseSystemPrompt.
+    resolveBootstrapContextForRunMock.mockResolvedValueOnce({
+      bootstrapFiles: [
+        { name: "AGENTS.md", path: "/ws/AGENTS.md", content: "a".repeat(100), missing: false },
+        { name: "IDENTITY.md", path: "/ws/IDENTITY.md", content: "b".repeat(100), missing: false },
+      ],
+      contextFiles: [{ path: "/ws/AGENTS.md", content: "a".repeat(100) }],
+    });
+    const actualSystemPrompt =
+      await vi.importActual<typeof import("./system-prompt.js")>("./system-prompt.js");
+    buildEmbeddedSystemPromptMock.mockImplementation((params) =>
+      actualSystemPrompt.buildEmbeddedSystemPrompt(params),
+    );
+
+    await compactEmbeddedAgentSessionDirect({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile: TEST_SESSION_KEY,
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
+    });
+
+    const createdSession = (await createAgentSessionMock.mock.results[0]?.value) as {
+      session: {
+        agent: { state: { systemPrompt?: string } };
+        setBaseSystemPrompt: Mock;
+      };
+    };
+    const deliveredPrompt = createdSession.session.agent.state.systemPrompt ?? "";
+
+    // The real owner computed the notice and the real renderer embedded it in the
+    // prompt text that compaction delivered to the session.
+    expect(deliveredPrompt).toContain("## Bootstrap Context Notice");
+    expect(deliveredPrompt).toContain("Treat Project Context as partial");
+    expect(createdSession.session.setBaseSystemPrompt).toHaveBeenCalledWith(deliveredPrompt);
+  });
+
+  it("delivers a real render with no bootstrap-truncation notice to the compaction session when the budget admits every file", async () => {
+    resolveBootstrapContextForRunMock.mockResolvedValueOnce({
+      bootstrapFiles: [
+        { name: "AGENTS.md", path: "/ws/AGENTS.md", content: "a".repeat(10), missing: false },
+      ],
+      contextFiles: [{ path: "/ws/AGENTS.md", content: "a".repeat(10) }],
+    });
+    const actualSystemPrompt =
+      await vi.importActual<typeof import("./system-prompt.js")>("./system-prompt.js");
+    buildEmbeddedSystemPromptMock.mockImplementation((params) =>
+      actualSystemPrompt.buildEmbeddedSystemPrompt(params),
+    );
+
+    await compactEmbeddedAgentSessionDirect({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile: TEST_SESSION_KEY,
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
+    });
+
+    const createdSession = (await createAgentSessionMock.mock.results[0]?.value) as {
+      session: {
+        agent: { state: { systemPrompt?: string } };
+        setBaseSystemPrompt: Mock;
+      };
+    };
+    const deliveredPrompt = createdSession.session.agent.state.systemPrompt ?? "";
+
+    expect(deliveredPrompt).not.toContain("## Bootstrap Context Notice");
+    expect(deliveredPrompt).not.toContain("Treat Project Context as partial");
   });
 
   it("uses ACP prompt surface and guidance for compacted ACP prompt rebuilds", async () => {

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -6,11 +6,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import { isAcpRuntimeSpawnAvailable } from "../../acp/runtime/availability.js";
 import {
-  buildBootstrapBudgetState,
-  buildBootstrapInjectionStats,
-  buildBootstrapPromptWarningNotice,
-} from "../../bootstrap-budget.js";
-import {
   formatActiveNodeContextLabel,
   getCurrentActiveNodeContext,
 } from "../../infra/active-node-context.js";
@@ -30,6 +25,11 @@ import { createOpenClawCodingTools } from "../agent-tools.js";
 import { createSkillInstructionDeliveryCache } from "../agent-tools.read.js";
 import { listActiveProcessSessionReferences } from "../bash-process-references.js";
 import { resolveProcessToolScopeKey } from "../bash-process-scope.js";
+import {
+  buildBootstrapBudgetState,
+  buildBootstrapInjectionStats,
+  buildBootstrapPromptWarningNotice,
+} from "../bootstrap-budget.js";
 import {
   makeBootstrapWarn,
   resolveBootstrapContextForRun,

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -6,6 +6,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import { isAcpRuntimeSpawnAvailable } from "../../acp/runtime/availability.js";
 import {
+  buildBootstrapBudgetState,
+  buildBootstrapInjectionStats,
+  buildBootstrapPromptWarningNotice,
+} from "../../bootstrap-budget.js";
+import {
   formatActiveNodeContextLabel,
   getCurrentActiveNodeContext,
 } from "../../infra/active-node-context.js";
@@ -162,9 +167,9 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
     const sessionLabel = params.sessionKey ?? params.sessionId;
     const resolvedMessageProvider = params.messageChannel ?? params.messageProvider;
     const contextInjectionMode = resolveContextInjectionMode(params.config, sessionAgentId);
-    const { contextFiles } =
+    const { bootstrapFiles, contextFiles } =
       contextInjectionMode === "never"
-        ? { contextFiles: [] }
+        ? { bootstrapFiles: [], contextFiles: [] }
         : await resolveBootstrapContextForRun({
             workspaceDir: effectiveWorkspace,
             config: params.config,
@@ -177,6 +182,22 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
               warn: (message) => log.warn(message),
             }),
           });
+    // Mirror ordinary-turn bootstrap disclosure so compaction summaries do not
+    // silently omit later workspace files when the aggregate budget is spent.
+    // Resolved once per prepared attempt so thinking-level retries reuse the same
+    // admitted files and notice.
+    const bootstrapInjectionStats = buildBootstrapInjectionStats({
+      bootstrapFiles,
+      injectedFiles: contextFiles,
+    });
+    const bootstrapBudget = buildBootstrapBudgetState({
+      config: params.config,
+      agentId: sessionAgentId,
+      files: bootstrapInjectionStats,
+    });
+    const bootstrapTruncationNotice = buildBootstrapPromptWarningNotice(
+      bootstrapBudget.bootstrapPromptWarning.lines,
+    );
     // Apply contextTokens cap to model so session runtime's auto-compaction
     // threshold uses the effective limit, not the native context window.
     const runtimeModelWithContext = runtimeModel as ProviderRuntimeModel;
@@ -563,6 +584,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
         userTimezone,
         userDate,
         contextFiles,
+        bootstrapTruncationNotice,
         activeProjectKeys,
         preparedMemoryPrompt,
         preparedWatchedSessions,


### PR DESCRIPTION
Closes #127528

## What Problem This Solves

When OpenClaw compacts a long conversation into a durable summary, it can quietly drop later workspace context files once the bootstrap budget fills up — and unlike a normal turn, it never tells the model the context is partial, so the summary is generated as if nothing was missing. This fix makes compaction carry the same "Project Context is partial, read the files directly" notice that normal turns already show.

- Problem: Prepared direct compaction destructured only `contextFiles` from `resolveBootstrapContextForRun` and discarded the raw `bootstrapFiles`, so it never built the aggregate bootstrap budget state. `buildEmbeddedSystemPrompt` received no `bootstrapTruncationNotice`, and fully omitted later files had no per-file inline marker — so a compaction summary could omit later identity/policy content without disclosure, differing from the ordinary-turn contract.
- Solution: Retain both `bootstrapFiles` and `contextFiles`, build the shared `buildBootstrapBudgetState` over the raw files, derive the canonical `buildBootstrapPromptWarningNotice`, and thread it into `buildEmbeddedSystemPrompt`.
- What changed: `src/agents/embedded-agent-runner/prepared-compaction-runtime.ts` (+24/-2) — capture `bootstrapFiles`; build injection stats → budget state → notice; thread `bootstrapTruncationNotice` into the prompt builder. `src/agents/embedded-agent-runner/compact.hooks.harness.ts` (+1/-1) — return `bootstrapFiles: []` alongside `contextFiles: []` from the bootstrap mock. `src/agents/embedded-agent-runner/compact.hooks.test.ts` (+49) — regression + end-to-end proof cases.

## Why This Change Was Made

The repair sits at the producer (bootstrap resolution + budget state) rather than each consumer of the system prompt, mirroring the ordinary-turn pattern in `attempt-system-prompt-prepare.ts` and `attempt-bootstrap-prepare.ts`.

- Best fix: Yes — reuses existing budgeting and disclosure helpers, no new abstraction.
- Alternative: Adding the notice downstream at each prompt consumer or raising budget limits — rejected, leaves the preparation inconsistency intact and does not disclose omission.
- Risk / non-goals: The notice is resolved once per prepared attempt, outside the thinking-level retry loop, so retries reuse the same admitted files and notice. Effect on generated summary content is not measured here; the fix guarantees disclosure parity, not summary content.

## User Impact

Operators running long-lived sessions no longer get compaction summaries that quietly drop later valid workspace files when the aggregate bootstrap budget is spent. The model is informed, exactly as during ordinary turns, that Project Context is partial and it should read relevant files directly if details seem missing.

## Evidence

Real behavior proof via `node --import tsx` calling the **real `buildPreparedCompactionRuntime`** (the exact function this PR modifies) against a real temp workspace with 5000-char `AGENTS.md` and `IDENTITY.md` files on disk. The owner's returned `buildSystemPromptText` closure is executed, then the result is delivered through the real `applySystemPromptToSession` to a session object:

```
$ node --import tsx/esm proof-prepared-owner.mts
[agent/embedded] workspace bootstrap file AGENTS.md is 5000 chars (limit 200); truncating in injected context
=== buildPreparedCompactionRuntime returned successfully ===
  has buildSystemPromptText: true

=== buildSystemPromptText() executed ===
  prompt length: 19598
  contains '## Bootstrap Context Notice': true
  contains 'Treat Project Context as partial': true

  --- Notice excerpt from rendered prompt ---
  | ## Bootstrap Context Notice
  | [Bootstrap truncation warning]
  | Some workspace bootstrap files were truncated before Project Context injection.
  | Treat Project Context as partial and read the relevant files directly if details seem missing.

=== applySystemPromptToSession delivered prompt to session ===
  session.agent.state.systemPrompt contains notice: true
  session.agent.state.systemPrompt contains 'Treat Project Context as partial': true

=== PASS ===
```

The real `buildPreparedCompactionRuntime` calls the real `resolveBootstrapContextForRun` (filesystem scan), the real budget chain omits `IDENTITY.md` under aggregate exhaustion (200-char total budget), the owner's `buildSystemPromptText` closure renders the notice via the real `buildEmbeddedSystemPrompt`, and `applySystemPromptToSession` delivers it to `session.setBaseSystemPrompt`.

Regression tests (184 passed):

```
$ vitest run --config test/vitest/vitest.agents-embedded-agent.config.ts \
    src/agents/embedded-agent-runner/compact.hooks.test.ts
 Test Files  1 passed (1)
      Tests  184 passed (184)
```

## Independent Maintainer Validation

Validated unchanged head `2c8adac1ca198df796169a09ababdc9c1c7f2bb0` on September 9, 2026 in sanitized, secretless AWS:

- A real temporary workspace flows through the bootstrap resolver, prepared compaction runtime, prompt renderer, and real session setter. Swapping only the original production owner produced three intended missing-notice failures and two passing quiet controls. The final head passed all five cases: aggregate exhaustion, per-file truncation, healthy input, disabled injection, and thinking-level retry.
- The retry case uses real seeded session history and verifies one bootstrap resolution with identical installed prompts across the actual retry.
- Focused compact-hook, bootstrap-file, and system-prompt suites: **255 passed**.
- **28 selected checks passed**, including production/test type checks and changed-file lint. The full `check:changed` invocation was **not green**: an unrelated dated compatibility-registry entry expired on September 8. Its registry blob is identical at the review base and head; independent main fix https://github.com/openclaw/openclaw/commit/c7cb45dfd5dbcf2098d7dd10efd4a64054a2662d touches no PR files. No gate was weakened or unrelated source copied.
- Fresh independent review found no actionable introduced defect through P2. The exact-head required CI gate is successful.

Limits: provider compaction execution is mocked; this proves prompt disclosure, not live-model behavior or generated-summary quality. The baseline experiment replaces only the original production owner within the exact-head checkout. Main's source-path-only bootstrap accounting must be preserved when landing.

## AI Assistance

This PR is AI-assisted. Used `gh`/`git`/`node --import tsx`/`vitest` to trace issue #127528, mirror the ordinary-turn bootstrap-disclosure path, and verify the notice flows into the compaction prompt. This revision calls the real `buildPreparedCompactionRuntime` owner function directly, executing its `buildSystemPromptText` closure and delivering the result through the real `applySystemPromptToSession` to prove the complete prepared-compaction delivery path.
