### PR TITLE
fix(slack): cron command output renders italic subjects and loses angle-bracket text

### DIFF
--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -97,6 +97,38 @@ describe("slackOutbound", () => {
     );
   });
 
+  it("sends pre-rendered mrkdwn verbatim and escapes only Slack's reserved characters", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-mrkdwn" });
+
+    await slackOutbound.sendText!({
+      cfg,
+      to: "C123",
+      text: "*job* failed · <https://example.com/run/1|run>\nin <module> a & b",
+      accountId: "default",
+      formatting: { preRendered: "slack-mrkdwn" },
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledWith(
+      "C123",
+      "*job* failed · <https://example.com/run/1|run>\nin &lt;module&gt; a &amp; b",
+      expect.objectContaining({ textIsSlackMrkdwn: true }),
+    );
+  });
+
+  it("leaves the markdown pass in charge without the pre-rendered hint", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-markdown" });
+
+    await slackOutbound.sendText!({
+      cfg,
+      to: "C123",
+      text: "in <module>",
+      accountId: "default",
+    });
+
+    expect(sendMessageSlackMock.mock.calls[0]?.[1]).toBe("in <module>");
+    expect(sendMessageSlackMock.mock.calls[0]?.[2]).not.toHaveProperty("textIsSlackMrkdwn");
+  });
+
   it("renders channelData Slack blocks on payload sends", async () => {
     sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-blocks" });
 

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -30,6 +30,7 @@ import {
 import { assertSlackDetachedTargetAllowed } from "./detached-target-admission.js";
 import { SLACK_TEXT_LIMIT } from "./limits.js";
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
+import { readSlackPreRenderedText, slackPreRenderedText } from "./pre-rendered-text.js";
 import { SLACK_PRESENTATION_CAPABILITIES } from "./presentation.js";
 import {
   resolveSlackQuestionActionIds,
@@ -235,6 +236,7 @@ async function prepareSlackOutboundSend(ctx: ChannelOutboundContext) {
         ? { nativeDataFallbackBaseText: params.nativeDataFallbackBaseText }
         : {}),
       ...(params.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
+      ...(readSlackPreRenderedText(params.formatting) ? { textIsSlackMrkdwn: true } : {}),
       ...(slackIdentity ? { identity: slackIdentity } : {}),
       ...(params.deliveryQueueId ? { deliveryQueueId: params.deliveryQueueId } : {}),
       ...(params.onPlatformSendDispatch
@@ -248,7 +250,7 @@ async function prepareSlackOutboundSend(ctx: ChannelOutboundContext) {
           }
         : {}),
     };
-    return await send(params.to, params.text, sendOptions);
+    return await send(params.to, slackPreRenderedText(params.text, params.formatting), sendOptions);
   };
 }
 

--- a/extensions/slack/src/pre-rendered-text.test.ts
+++ b/extensions/slack/src/pre-rendered-text.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { escapeSlackReservedKeepingLinks, slackPreRenderedText } from "./pre-rendered-text.js";
+
+describe("slack pre-rendered text", () => {
+  it("escapes Slack's reserved characters outside the writer's own links and mentions", () => {
+    const authored = [
+      "*job* failed: exit 1",
+      "do: <https://github.com/x/y/actions/runs/1|run> then <#C123|ops>",
+      'cause: File "<stdin>", in <module> a & b, already &gt;1m and &amp; kept, <@U123> asked',
+    ].join("\n");
+    expect(escapeSlackReservedKeepingLinks(authored)).toBe(
+      [
+        "*job* failed: exit 1",
+        "do: <https://github.com/x/y/actions/runs/1|run> then <#C123|ops>",
+        'cause: File "&lt;stdin&gt;", in &lt;module&gt; a &amp; b, already &gt;1m and &amp; kept, <@U123> asked',
+      ].join("\n"),
+    );
+  });
+
+  it("leaves text alone without the hint and escapes it with the hint", () => {
+    expect(slackPreRenderedText("in <module>")).toBe("in <module>");
+    expect(slackPreRenderedText("in <module>", { preRendered: "other" })).toBe("in <module>");
+    expect(slackPreRenderedText("in <module>", { preRendered: "slack-mrkdwn" })).toBe(
+      "in &lt;module&gt;",
+    );
+  });
+});

--- a/extensions/slack/src/pre-rendered-text.ts
+++ b/extensions/slack/src/pre-rendered-text.ts
@@ -1,0 +1,38 @@
+/**
+ * A payload stamped `preRendered: "slack-mrkdwn"` skips the markdown pass: the
+ * writer typed Slack mrkdwn (one star for bold, `<url|label>` links), and the
+ * pass would turn `*subject*` into `_subject_`. The pass also escaped `&`, `<`
+ * and `>` for the writer; the bypass does that itself, outside Slack's own
+ * control tokens, because text such as a traceback's `in <module>` would
+ * otherwise be read by Slack as a token and dropped.
+ */
+
+/** `<url|label>`, `<url>`, `<@user>`, `<#channel|name>`, `<!here>`: Slack's tokens, kept as written. */
+const SLACK_CONTROL_TOKEN_RE = /<(?:https?:\/\/[^>]*|[@#!][^>]*)>/g;
+/** An entity the writer already wrote stays as it is. */
+const SLACK_ENTITY_RE = /&(?!amp;|lt;|gt;)/g;
+
+function escapeSegment(segment: string): string {
+  return segment.replace(SLACK_ENTITY_RE, "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+export function escapeSlackReservedKeepingLinks(text: string): string {
+  const out: string[] = [];
+  let last = 0;
+  for (const match of text.matchAll(SLACK_CONTROL_TOKEN_RE)) {
+    out.push(escapeSegment(text.slice(last, match.index)), match[0]);
+    last = match.index + match[0].length;
+  }
+  out.push(escapeSegment(text.slice(last)));
+  return out.join("");
+}
+
+/** A payload pre-rendered for another channel is not Slack's to interpret. */
+export function readSlackPreRenderedText(formatting?: { preRendered?: string }): boolean {
+  return formatting?.preRendered === "slack-mrkdwn";
+}
+
+/** The text the bypass sends: escaped when pre-rendered, untouched otherwise. */
+export function slackPreRenderedText(text: string, formatting?: { preRendered?: string }): string {
+  return readSlackPreRenderedText(formatting) ? escapeSlackReservedKeepingLinks(text) : text;
+}

--- a/src/cron/delivery.failure-notify.test.ts
+++ b/src/cron/delivery.failure-notify.test.ts
@@ -46,6 +46,26 @@ describe("sendCronAnnouncePayloadStrict", () => {
     mocks.deliverOutboundPayloads.mockResolvedValue([{ ok: true }]);
   });
 
+  it("forwards the formatting hint to delivery", async () => {
+    await sendCronAnnouncePayloadStrict({
+      deps: {} as never,
+      cfg: {} as never,
+      agentId: "main",
+      jobId: "job-1",
+      target: { channel: "slack", to: "C123" },
+      payload: { text: "*job* done" },
+      formatting: { preRendered: "slack-mrkdwn" },
+      abortSignal: new AbortController().signal,
+    });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payloads: [{ text: "*job* done" }],
+        formatting: { preRendered: "slack-mrkdwn" },
+      }),
+    );
+  });
+
   it("delivers the payload through the resolved target with strict send settings", async () => {
     await sendCronAnnouncePayloadStrict({
       deps: {} as never,

--- a/src/cron/delivery.test.ts
+++ b/src/cron/delivery.test.ts
@@ -4,6 +4,7 @@ import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { resolveCronDeliveryPlan, resolveFailureDestination } from "./delivery-plan.js";
+import { cronAnnounceFormatting } from "./delivery.js";
 import { makeCronJob } from "./delivery.test-helpers.js";
 
 function createPrefixOnlyChannelPlugin(
@@ -764,5 +765,13 @@ describe("resolveFailureDestination", () => {
       to: "slack:U123",
       accountId: undefined,
     });
+  });
+});
+
+describe("cronAnnounceFormatting", () => {
+  it("marks command output as pre-rendered Slack mrkdwn and leaves agent turns to markdown", () => {
+    expect(cronAnnounceFormatting("command")).toEqual({ preRendered: "slack-mrkdwn" });
+    expect(cronAnnounceFormatting("agentTurn")).toBeUndefined();
+    expect(cronAnnounceFormatting("systemEvent")).toBeUndefined();
   });
 });

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -8,6 +8,7 @@ import {
 import type { CliDeps } from "../cli/deps.types.js";
 import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../config/types.js";
+import type { OutboundDeliveryFormattingOptions } from "../infra/outbound/formatting.js";
 import { resolveAgentOutboundIdentity } from "../infra/outbound/identity.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { resolveCronDeliveryPlan } from "./delivery-plan.js";
@@ -16,7 +17,7 @@ import {
   type DeliveryTargetResolution,
 } from "./isolated-agent/delivery-target.js";
 import { resolveCronNotificationSessionKey } from "./session-target.js";
-import type { CronMessageChannel } from "./types.js";
+import type { CronMessageChannel, CronPayload } from "./types.js";
 
 export { resolveCronDeliveryPlan };
 
@@ -89,6 +90,18 @@ async function resolveCronAnnounceDelivery(params: {
   };
 }
 
+/**
+ * Command output is text the operator wrote for the channel it targets, not
+ * markdown for the outbound pass to convert: on Slack the pass turned the
+ * `*subject*` of every command announce into italic. An agent turn is the
+ * model's markdown and keeps the pass.
+ */
+export function cronAnnounceFormatting(
+  payloadKind: CronPayload["kind"],
+): OutboundDeliveryFormattingOptions | undefined {
+  return payloadKind === "command" ? { preRendered: "slack-mrkdwn" } : undefined;
+}
+
 /** Sends a cron announce payload and throws if target resolution or delivery fails. */
 export async function sendCronAnnouncePayloadStrict(params: {
   deps: CliDeps;
@@ -97,6 +110,7 @@ export async function sendCronAnnouncePayloadStrict(params: {
   jobId: string;
   target: CronAnnounceTarget;
   payload: ReplyPayload;
+  formatting?: OutboundDeliveryFormattingOptions;
   abortSignal: AbortSignal;
   onDeliveryAttempt?: (reachedRecipient: boolean) => void;
 }): Promise<CronAnnounceDeliveryOutcome> {
@@ -118,6 +132,7 @@ export async function sendCronAnnouncePayloadStrict(params: {
     accountId: delivery.resolvedTarget.accountId,
     threadId: delivery.resolvedTarget.threadId,
     payloads: [params.payload],
+    formatting: params.formatting,
     session: delivery.session,
     identity: delivery.identity,
     bestEffort: false,

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -40,7 +40,11 @@ import {
 } from "../cron/command-output-summary.js";
 import { runCronCommandJob } from "../cron/command-runner.js";
 import { resolveCronStoredDeliveryContext } from "../cron/delivery-context.js";
-import { resolveCronDeliveryPlan, sendCronAnnouncePayloadStrict } from "../cron/delivery.js";
+import {
+  cronAnnounceFormatting,
+  resolveCronDeliveryPlan,
+  sendCronAnnouncePayloadStrict,
+} from "../cron/delivery.js";
 import { reconcileHeartbeatMonitorJobs } from "../cron/heartbeat-monitor.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { retryTransientDirectCronDelivery } from "../cron/isolated-agent/delivery-dispatch-policy.js";
@@ -339,6 +343,7 @@ async function finalizeCronCompletionAnnouncement(params: {
             sessionKey: resolveCronDeliverySessionKey(params.job),
           },
           payload: { text },
+          formatting: cronAnnounceFormatting(params.job.payload.kind),
           abortSignal,
           onDeliveryAttempt: (reachedRecipient) => {
             deliveryMayHaveReachedRecipient ||= reachedRecipient;

--- a/src/infra/outbound/formatting.ts
+++ b/src/infra/outbound/formatting.ts
@@ -12,4 +12,11 @@ export type OutboundDeliveryFormattingOptions = {
   tableMode?: MarkdownTableMode;
   chunkMode?: ChunkMode;
   parseMode?: "HTML";
+  /**
+   * The text is already written in the target channel's own dialect and must
+   * skip the markdown pass. `"slack-mrkdwn"`: Slack mrkdwn as authored (one
+   * star for bold, `<url|label>` links). Adapters for other channels ignore a
+   * hint that is not theirs.
+   */
+  preRendered?: "slack-mrkdwn";
 };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a cron job with a `command` payload announcing to a Slack channel would have its output rewritten by the outbound markdown pass: `*subject*` arrives in Slack as italic, and any angle-bracket text that is not a Slack token (a Python traceback's `in <module>`, a `<stdin>` filename) is preserved as a token and dropped by Slack. Operators who write their command output in Slack mrkdwn on purpose, with one star for bold and `<url|label>` links, cannot get it to the channel as written.

## Why This Change Was Made

Outbound delivery gains a `preRendered: "slack-mrkdwn"` formatting hint next to the existing `parseMode: "HTML"`. Cron delivery stamps it on `command` announces only; agent turns are the model's markdown and keep the pass. The Slack adapter maps the hint to its existing `textIsSlackMrkdwn` send option and, because the markdown pass no longer escapes for it, escapes `&`, `<` and `>` itself outside Slack's own `<url|label>`, `<@user>`, `<#channel|name>` and `<!here>` tokens, keeping entities the writer already wrote. Adapters for other channels ignore a hint that is not theirs. Failure alerts and agent-turn announces are unchanged.

## User Impact

Command output announced to Slack renders as the operator wrote it: bold subjects, working links, and stderr tails with their angle brackets intact. Nothing changes for Telegram, Discord or any other channel, nor for agent-turn announces on Slack.

## Evidence

Observed on a production gateway on 2026-09-06: every command-job announce in an ops channel rendered `_portfolio provenance_` (italic) for text authored as `*portfolio provenance*`, because the Slack plugin parses outbound text as CommonMark, where one star is emphasis.

Focused tests, all green in this branch:

- `extensions/slack/src/pre-rendered-text.test.ts`: the escape keeps links, mentions and existing entities, and does nothing without the hint.
- `extensions/slack/src/outbound-adapter.test.ts`: a pre-rendered send reaches `sendMessageSlack` verbatim with `textIsSlackMrkdwn: true`; a send without the hint keeps the markdown pass in charge.
- `src/cron/delivery.failure-notify.test.ts`: `sendCronAnnouncePayloadStrict` forwards the hint to delivery.
- `src/cron/delivery.test.ts`: `cronAnnounceFormatting` marks `command` only.

```
node_modules/.bin/vitest run extensions/slack/src/pre-rendered-text.test.ts extensions/slack/src/outbound-adapter.test.ts src/cron/delivery.failure-notify.test.ts src/cron/delivery.test.ts
 Test Files  4 passed (4)
      Tests  98 passed (98)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
