### PR TITLE
chore(tooling): remove stale docs layout ignores

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -30,7 +30,6 @@
     "CLAUDE.md",
     "docker-compose.yml",
     "dist/",
-    "docs/_layouts/",
     "extensions/diffs/assets/viewer-runtime.js",
     "extensions/browser/chrome-extension/modules/copilot-runtime.js",
     "**/*.json",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -226,7 +226,6 @@
   "ignorePatterns": [
     "dist/",
     "dist-runtime/",
-    "docs/_layouts/",
     // Intentional negative-test corpora contain parser and lint violations by contract.
     ".agents/skills/autoreview/tests/fixtures/**",
     "test/fixtures/oxlint-boundary-guards/**",

--- a/test/scripts/oxlint-config.test.ts
+++ b/test/scripts/oxlint-config.test.ts
@@ -398,7 +398,6 @@ describe("oxlint config", () => {
     expect(ignorePatterns).toEqual([
       "dist/",
       "dist-runtime/",
-      "docs/_layouts/",
       ".agents/skills/autoreview/tests/fixtures/**",
       "test/fixtures/oxlint-boundary-guards/**",
       "**/a2ui.bundle.js",


### PR DESCRIPTION
Related: #8885

## What Problem This Solves

Removes an obsolete tooling exclusion for `docs/_layouts/` after the legacy docs layout path was removed.

## Why This Change Was Made

The docs layout path no longer needs special handling. This removes the stale ignore entry from the oxlint and oxfmt configs and updates the oxlint config test expectation so the tooling contract stays honest.

## User Impact

No runtime behavior change. Maintainers get tighter lint and format coverage if a docs layout path is reintroduced.

## Evidence

- `git diff --check`
- exact reviewed static diff: 3 deletions across `.oxlintrc.json`, `.oxfmtrc.jsonc`, and `test/scripts/oxlint-config.test.ts`
- full-index patch SHA-256: `8d1a79e22d42fba80cadf4c51672be7aa2afb683737d823c31bad71cbba09a61`
- local tests/build not run: this is a trivial config/test expectation removal, and the available local checkout dependency closure intentionally lacks the pinned `oxlint@1.80.0` / `oxfmt@0.65.0` toolchain
- CI should run the authoritative `test/scripts/oxlint-config.test.ts` coverage on the exact PR head
