### PR TITLE
fix(gateway): release initial cron stream job snapshots

### DIFF
--- a/src/gateway/cron-stream-output.ts
+++ b/src/gateway/cron-stream-output.ts
@@ -104,6 +104,7 @@ async function waitForInFlightBatch(
 
 /** Owns one stream source's bounded output and dispatch cadence. */
 export class CronStreamOutput {
+  private readonly params: Omit<CronStreamOutputParams, "job" | "scheduleKey" | "sourceIdentity">;
   private job: CronStreamJob;
   private scheduleKey: string;
   private sourceIdentity: string;
@@ -132,14 +133,15 @@ export class CronStreamOutput {
   private lastFireStartedAtMs: number;
   private nextEligibleAttemptAtMs: number;
 
-  constructor(private readonly params: CronStreamOutputParams) {
-    this.job = params.job;
-    this.scheduleKey = params.scheduleKey;
-    this.sourceIdentity = params.sourceIdentity;
-    this.matcher = this.compileMatcher(params.job.schedule);
-    this.lastFireStartedAtMs = params.job.state.lastRunAtMs ?? 0;
-    this.nextEligibleAttemptAtMs = params.job.state.lastRunAtMs
-      ? params.job.state.lastRunAtMs + params.minIntervalMs
+  constructor({ job, scheduleKey, sourceIdentity, ...params }: CronStreamOutputParams) {
+    this.params = params;
+    this.job = job;
+    this.scheduleKey = scheduleKey;
+    this.sourceIdentity = sourceIdentity;
+    this.matcher = this.compileMatcher(job.schedule);
+    this.lastFireStartedAtMs = job.state.lastRunAtMs ?? 0;
+    this.nextEligibleAttemptAtMs = job.state.lastRunAtMs
+      ? job.state.lastRunAtMs + params.minIntervalMs
       : 0;
   }
 


### PR DESCRIPTION
## What Problem This Solves

A cron stream output owner keeps the complete constructor argument object after copying its initial job and source identifiers into current fields. Later source updates replace those fields, but the constructor object still retains the obsolete initial job graph.

## Why This Change Was Made

Separate initial job/source inputs from the retained dependency and timing settings. Current job, schedule key, and source identity continue through the existing `updateSource` path. Batching, matching, callback references, authority/generation checks, stop behavior, and persistence keep their existing owners.

## User Impact

Updated stream jobs can release obsolete initial job snapshots while current jobs and legitimate in-flight dispatch inputs remain available. The small production change adds two lines to make that retention boundary explicit.

## Evidence

- All **62 existing owner, interleaving, and watcher tests** pass on original and candidate source. Full changed-code checks, formatting, and `git diff --check` pass. Independent source/probe review and fresh managed autoreview are clean.
- The actual `CronStreamOutput` probe keeps 24 owners alive across multiple job/source revisions. Baseline retains **24 initial jobs** during and after dispatch; candidate retains **one needed by the in-flight dispatch, then zero after that dispatch releases it**.
- Both arms retain all 24 current jobs, collect middle/previous-current revisions, and produce the same **25 independently expected dispatch records**, including payload markers, matching, source identity, and schedule key.
- Final paired probes use identical fixtures and source hashes. A fixture source-identity correction was followed by complete paired reruns; all proof processes joined.
- This is bounded object-reachability evidence. No heap-byte, RSS, unbounded-leak, or whole-Gateway savings amount is claimed, and no GC assertion was added to the regular test suite.
- Required hosted CI passed on the exact reviewed head ([run 34044444137](https://github.com/openclaw/openclaw/actions/runs/34044444137)).
