### PR TITLE
fix(apple): preserve local message order across history refreshes

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+HistoryReconciliation.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+HistoryReconciliation.swift
@@ -707,7 +707,12 @@ extension OpenClawChatViewModel {
                 continue
             }
 
-            let insertIndex = reconciled.firstIndex { existing in
+            // Reconciled IDs retain known transcript predecessors. Clock skew must
+            // not move an echo before those anchors and out of the next refresh's tail.
+            let precedingMessageIDs = Set(previous.prefix { $0.id != message.id }.map(\.id))
+            let insertionStart = reconciled.lastIndex(where: { precedingMessageIDs.contains($0.id) })
+                .map { reconciled.index(after: $0) } ?? reconciled.startIndex
+            let insertIndex = reconciled[insertionStart...].firstIndex { existing in
                 guard let existingTimestamp = existing.timestamp else { return false }
                 return existingTimestamp > messageTimestamp
             } ?? reconciled.endIndex

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -6690,6 +6690,31 @@ struct ChatViewModelTests {
         #expect(await transport.sentRunIds().count == 1)
     }
 
+    @Test @MainActor func `repeated refresh preserves an unconfirmed same text turn after pending retirement`() {
+        let firstUser = chatTextModelMessage(
+            role: "user", text: "retry", timestamp: 5000, idempotencyKey: "first:user")
+        let firstAnswer = chatTextModelMessage(
+            role: "assistant", text: "first answer", timestamp: 6000)
+        let secondUser = chatTextModelMessage(
+            role: "user", text: "retry", timestamp: 1000, idempotencyKey: "second:user")
+        let previous = [firstUser, firstAnswer, secondUser]
+        let canonicalHistory = [firstUser, firstAnswer]
+        let expectedIDs = previous.map(\.id)
+
+        let whilePending = OpenClawChatViewModel.reconcileRunRefreshMessages(
+            previous: previous,
+            incoming: canonicalHistory,
+            pendingLocalUserEchoIDs: [secondUser.id])
+        #expect(whilePending.map(\.id) == expectedIDs)
+
+        // Terminal retirement can precede canonical adoption of the second user row.
+        let afterRetirement = OpenClawChatViewModel.reconcileRunRefreshMessages(
+            previous: whilePending,
+            incoming: canonicalHistory,
+            pendingLocalUserEchoIDs: [])
+        #expect(afterRetirement.map(\.id) == expectedIDs)
+    }
+
     @Test func `preserves repeated optimistic user messages with identical content during refresh`() async throws {
         let sessionId = "sess-main"
         let now = Date().timeIntervalSince1970 * 1000


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

Related: #136293

## What Problem This Solves

Fixes an issue where native chat could move a newly sent user message before already-confirmed conversation rows, then remove it on a later history refresh when client and server clocks differ.

The inherited Swift CI failure in #136293 exposed the same repeated-message path. This supporting repair is independent of that PR's performance change.

## Why This Change Was Made

Reconciliation now starts its timestamp-based insertion search after known preceding rows already present in the refreshed transcript. Those rows retain their established message IDs, so clock skew cannot move a local echo before its known conversation context.

The existing pending/trailing retention selection, canonical identity adoption, no-anchor timestamp fallback, and pending-run cleanup remain intact. There is no new stored state, configuration, protocol, workflow, timeout, or production test seam.

## User Impact

Two distinct messages with identical text retain their identity and order through successive refreshes, including after the pending run retires. Confirmed older messages are not duplicated, and bounded history can still omit older turns normally.

## Evidence

- **Observed deterministic red before production edits:** [CI 34044396222](https://github.com/openclaw/openclaw/actions/runs/34044396222), macOS Swift test job `101516857459`, ran test-only head `af2595700ed9a273322bbc5854f733395ae2c84a` using Swift 6.3.3. Its immutable merge was `ab8305e3b88f5acf6edfb897189fa9f32dfb4d53` against main `7e9a8414d30b4c68b6bc3af8e7fac6a5d8fc5a0d`.
- The new synchronous test failed in **0.001 seconds** with exactly two assertion issues: the first refresh returned `[second user, first user, first answer]`; the second returned only `[first user, first answer]`. Both assertions require `[first user, first answer, second user]`, checking exact ordered IDs rather than a polling deadline.
- That Swift run reported **1,670 tests / 126 suites**, with only the two expected issues from the new case. The original asynchronous repeated-message test, assistant-only/no-anchor case, foreign identical-text case, bounded-history omission case, and stale-refresh case passed.
- Fresh independent P0–P2 review is scoped-clean for the complete repair and regression (0.94 confidence). Diff checks pass. Production is **+6/-1 (net +5)**; tests are **+25/-0**.
- **Observed fixed-head Swift green:** [CI 34045932333](https://github.com/openclaw/openclaw/actions/runs/34045932333), macOS job `101521216516`, tested head `de68d1702865a81996e2c49c30f0b8c258841a1d` through immutable merge `b6d2869442c75fae946bd97afbdcfe80a6957b5f` against main `e8a2a369a326c8375eb03409124aa24496d14b20`, using Swift 6.3.3. The new exact-order regression passed in **0.001 seconds**; the original asynchronous repeated-message case passed in **0.178 seconds**. Canonical timestamp adoption, assistant-only/no-anchor, foreign identical text, bounded-history omission, and stale-refresh siblings all passed. **1,670 OpenClawKit tests / 126 suites and 2,074 macOS tests / 226 suites passed.**
- The fixed head also passes all Android test jobs. The earlier test-only Android failures are not treated as evidence about the Swift defect. **[CI 34045932333](https://github.com/openclaw/openclaw/actions/runs/34045932333) completed successfully on this exact head, including all required checks and `openclaw/ci-gate`.**
- Swift proof runs on the existing disposable macOS CI route. No operator app, Gateway, or operator Keychain was accessed, and no Swift test/build ran locally.
