### PR TITLE
fix(cron): keep system monitor convergence responsive

### DIFF
--- a/src/commands/doctor/cron/legacy-delivery.test.ts
+++ b/src/commands/doctor/cron/legacy-delivery.test.ts
@@ -3,6 +3,17 @@ import { describe, expect, it } from "vitest";
 import { normalizeLegacyDeliveryInput } from "./legacy-delivery.js";
 
 describe("legacy delivery threadId support", () => {
+  it("preserves false and zero legacy delivery hints", () => {
+    expect(
+      normalizeLegacyDeliveryInput({
+        payload: { deliver: false, bestEffortDeliver: false, threadId: 0 },
+      }),
+    ).toEqual({
+      delivery: { mode: "none", threadId: "0", bestEffort: false },
+      mutated: true,
+    });
+  });
+
   it("treats threadId as a legacy delivery hint", () => {
     expect(normalizeLegacyDeliveryInput({ payload: { threadId: "42" } })).toEqual({
       delivery: { mode: "announce", threadId: "42" },

--- a/src/cron/delivery-field-schemas.ts
+++ b/src/cron/delivery-field-schemas.ts
@@ -52,8 +52,8 @@ export function parseDeliveryInput(input: Record<string, unknown>): ParsedDelive
   };
 }
 
-/** Returns a parsed field value only when the supplied schema accepts it. */
+/** Parses present optional fields, returning undefined for missing or invalid values. */
 export function parseOptionalField<T>(schema: ZodType<T>, value: unknown): T | undefined {
-  const parsed = schema.safeParse(value);
-  return parsed.success ? parsed.data : undefined;
+  const parsed = value === undefined ? undefined : schema.safeParse(value);
+  return parsed?.success ? parsed.data : undefined;
 }

--- a/src/cron/heartbeat-monitor.ts
+++ b/src/cron/heartbeat-monitor.ts
@@ -1,4 +1,5 @@
 /** Canonical projection from heartbeat config to system-owned cron monitor jobs. */
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import { isDeepStrictEqual } from "node:util";
 import { DEFAULT_HEARTBEAT_EVERY } from "../auto-reply/heartbeat.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -171,6 +172,10 @@ export async function applyHeartbeatMonitorJobs(params: {
   const applied: HeartbeatMonitorChange[] = [];
   const failures: HeartbeatMonitorReconcileResult["failures"] = [];
   for (const change of changes) {
+    // Settled CRUD promises do not yield to I/O; reject a superseded pass
+    // after the event-loop turn, before entering its next mutation wrapper.
+    await yieldToEventLoop();
+    params.commitGuard?.();
     try {
       if (change.kind === "remove") {
         await params.cron.remove(change.job.id, {

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -1,9 +1,14 @@
 // Cron normalization tests cover job config normalization and defaults.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   validateCronAddParams,
   validateCronUpdateParams,
 } from "../../packages/gateway-protocol/src/index.js";
+import {
+  DeliveryThreadIdFieldSchema,
+  LowercaseNonEmptyStringFieldSchema,
+  TrimmedNonEmptyStringFieldSchema,
+} from "./delivery-field-schemas.js";
 import { normalizeCronJobCreate, normalizeCronJobPatch } from "./normalize.js";
 
 type UnknownRecord = Record<string, unknown>;
@@ -98,6 +103,40 @@ function expectAnnounceDeliveryTarget(
   expect(delivery.to).toBe(params.to);
 }
 describe("normalizeCronJobCreate", () => {
+  it.each(["create", "patch"] as const)(
+    "does not validate absent delivery fields during %s normalization",
+    (mode) => {
+      const parsers = [
+        vi.spyOn(LowercaseNonEmptyStringFieldSchema, "safeParse"),
+        vi.spyOn(TrimmedNonEmptyStringFieldSchema, "safeParse"),
+        vi.spyOn(DeliveryThreadIdFieldSchema, "safeParse"),
+      ];
+      try {
+        for (const delivery of [
+          { mode: "none" },
+          {
+            mode: "none",
+            channel: undefined,
+            to: undefined,
+            threadId: undefined,
+            accountId: undefined,
+          },
+        ]) {
+          const normalized =
+            mode === "create" ? createAgent({ delivery }) : normalizePatch({ delivery });
+          expect(normalized.delivery).toEqual({ mode: "none" });
+        }
+        for (const parser of parsers) {
+          expect(parser).not.toHaveBeenCalled();
+        }
+      } finally {
+        for (const parser of parsers) {
+          parser.mockRestore();
+        }
+      }
+    },
+  );
+
   it.each(["create", "patch"] as const)(
     "does not promote prototype-only schedule fields during %s normalization",
     (mode) => {

--- a/src/gateway/server-cron-heartbeat-jobs.test.ts
+++ b/src/gateway/server-cron-heartbeat-jobs.test.ts
@@ -51,13 +51,13 @@ describe("reconcileHeartbeatMonitorJobs", () => {
         if (mutation === "remove") recordAttempt(id);
         return { ok: true, removed: true };
       });
-      const cfg = {
+      const cfg: OpenClawConfig = {
         agents: {
           ownership: "explicit",
           defaults: { heartbeat: { every: "30m" } },
           entries: mutation === "add" ? { a: {}, b: {}, c: {} } : { main: {} },
         },
-      } satisfies OpenClawConfig;
+      };
       try {
         const result = await reconcileHeartbeatMonitorJobs({
           cron: {

--- a/src/gateway/server-cron-heartbeat-jobs.test.ts
+++ b/src/gateway/server-cron-heartbeat-jobs.test.ts
@@ -34,21 +34,25 @@ describe("reconcileHeartbeatMonitorJobs", () => {
       const recordAttempt = (id: string) => {
         observed.push({ id, progressed });
         if (observed.length === 1) {
-          checkpoint = new Promise((resolve) =>
+          checkpoint = new Promise((resolve) => {
             setImmediate(() => {
               progressed = true;
               resolve();
-            }),
-          );
+            });
+          });
           throw new Error("first mutation failed");
         }
       };
       const add = vi.fn(async (input: { agentId: string }) => {
-        if (mutation === "add") recordAttempt(input.agentId);
+        if (mutation === "add") {
+          recordAttempt(input.agentId);
+        }
         return monitorJob(input.agentId);
       });
       const remove = vi.fn(async (id: string) => {
-        if (mutation === "remove") recordAttempt(id);
+        if (mutation === "remove") {
+          recordAttempt(id);
+        }
         return { ok: true, removed: true };
       });
       const cfg: OpenClawConfig = {
@@ -88,17 +92,19 @@ describe("reconcileHeartbeatMonitorJobs", () => {
     let current = true;
     let checkpoint: Promise<void> | undefined;
     const commitGuard = () => {
-      if (!current) throw revoked;
+      if (!current) {
+        throw revoked;
+      }
     };
     const add = vi.fn(
       async (input: { agentId: string }, options?: { commitGuard?: () => void }) => {
         options?.commitGuard?.();
-        checkpoint ??= new Promise((resolve) =>
+        checkpoint ??= new Promise((resolve) => {
           setImmediate(() => {
             current = false;
             resolve();
-          }),
-        );
+          });
+        });
         return monitorJob(input.agentId);
       },
     );

--- a/src/gateway/server-cron-heartbeat-jobs.test.ts
+++ b/src/gateway/server-cron-heartbeat-jobs.test.ts
@@ -25,6 +25,104 @@ function monitorJob(agentId: string, id = `job-${agentId}`): CronJob {
 }
 
 describe("reconcileHeartbeatMonitorJobs", () => {
+  it.each(["add", "remove"] as const)(
+    "lets the event loop progress between %s attempts, including a failed attempt",
+    async (mutation) => {
+      let progressed = false;
+      let checkpoint: Promise<void> | undefined;
+      const observed: Array<{ id: string; progressed: boolean }> = [];
+      const recordAttempt = (id: string) => {
+        observed.push({ id, progressed });
+        if (observed.length === 1) {
+          checkpoint = new Promise((resolve) =>
+            setImmediate(() => {
+              progressed = true;
+              resolve();
+            }),
+          );
+          throw new Error("first mutation failed");
+        }
+      };
+      const add = vi.fn(async (input: { agentId: string }) => {
+        if (mutation === "add") recordAttempt(input.agentId);
+        return monitorJob(input.agentId);
+      });
+      const remove = vi.fn(async (id: string) => {
+        if (mutation === "remove") recordAttempt(id);
+        return { ok: true, removed: true };
+      });
+      const cfg = {
+        agents: {
+          ownership: "explicit",
+          defaults: { heartbeat: { every: "30m" } },
+          entries: mutation === "add" ? { a: {}, b: {}, c: {} } : { main: {} },
+        },
+      } satisfies OpenClawConfig;
+      try {
+        const result = await reconcileHeartbeatMonitorJobs({
+          cron: {
+            add,
+            remove,
+            list: vi.fn(async () =>
+              mutation === "remove" ? [monitorJob("a"), monitorJob("b"), monitorJob("c")] : [],
+            ),
+          } as never,
+          cfg,
+          logger,
+        });
+        expect(result).toEqual({ ok: false });
+        expect(observed).toEqual(
+          (mutation === "add" ? ["a", "b", "c"] : ["job-a", "job-b", "job-c"]).map((id, index) => ({
+            id,
+            progressed: index > 0,
+          })),
+        );
+      } finally {
+        await checkpoint;
+      }
+    },
+  );
+
+  it("rejects stale authority after yielding before another mutation is invoked", async () => {
+    const revoked = new Error("reconciliation revoked");
+    let current = true;
+    let checkpoint: Promise<void> | undefined;
+    const commitGuard = () => {
+      if (!current) throw revoked;
+    };
+    const add = vi.fn(
+      async (input: { agentId: string }, options?: { commitGuard?: () => void }) => {
+        options?.commitGuard?.();
+        checkpoint ??= new Promise((resolve) =>
+          setImmediate(() => {
+            current = false;
+            resolve();
+          }),
+        );
+        return monitorJob(input.agentId);
+      },
+    );
+    try {
+      await expect(
+        reconcileHeartbeatMonitorJobs({
+          cron: { add, remove: vi.fn(), list: vi.fn(async () => []) } as never,
+          cfg: {
+            agents: {
+              ownership: "explicit",
+              defaults: { heartbeat: { every: "30m" } },
+              entries: { a: {}, b: {} },
+            },
+          },
+          logger,
+          commitGuard,
+        }),
+      ).rejects.toBe(revoked);
+      expect(add).toHaveBeenCalledTimes(1);
+    } finally {
+      await checkpoint;
+    }
+  });
+
   it("converges one monitor per heartbeat agent and prunes unconfigured ones", async () => {
     const add = vi.fn(async (input: { declarationKey?: string }, _options?: AddOptions) => ({
       job: input,

--- a/src/gateway/server-cron-skill-review-jobs.test.ts
+++ b/src/gateway/server-cron-skill-review-jobs.test.ts
@@ -45,22 +45,25 @@ describe("reconcileSkillCollectionReviewJobs", () => {
       const recordAttempt = (id: string) => {
         observed.push({ id, progressed });
         if (observed.length === 1) {
-          checkpoint = new Promise((resolve) =>
+          checkpoint = new Promise((resolve) => {
             setImmediate(() => {
               progressed = true;
               resolve();
-            }),
-          );
+            });
+          });
           throw new Error("first mutation failed");
         }
       };
       const add = vi.fn(async (input: { agentId: string }) => {
-        if (phase === "add") recordAttempt(input.agentId);
+        if (phase === "add") {
+          recordAttempt(input.agentId);
+        }
         return monitorJob(input.agentId);
       });
       const remove = vi.fn(async (id: string) => {
-        if ((phase === "duplicate" && id.startsWith("duplicate-")) || phase === "stale")
+        if ((phase === "duplicate" && id.startsWith("duplicate-")) || phase === "stale") {
           recordAttempt(id);
+        }
         return { ok: true, removed: true };
       });
       const jobs =
@@ -97,16 +100,18 @@ describe("reconcileSkillCollectionReviewJobs", () => {
     let current = true;
     let checkpoint: Promise<void> | undefined;
     const commitGuard = () => {
-      if (!current) throw revoked;
+      if (!current) {
+        throw revoked;
+      }
     };
     const remove = vi.fn(async (_id: string, options?: { commitGuard?: () => void }) => {
       options?.commitGuard?.();
-      checkpoint ??= new Promise((resolve) =>
+      checkpoint ??= new Promise((resolve) => {
         setImmediate(() => {
           current = false;
           resolve();
-        }),
-      );
+        });
+      });
       return { ok: true, removed: true };
     });
     try {

--- a/src/gateway/server-cron-skill-review-jobs.test.ts
+++ b/src/gateway/server-cron-skill-review-jobs.test.ts
@@ -36,6 +36,98 @@ function monitorJob(agentId: string, id = `job-${agentId}`): CronJob {
 }
 
 describe("reconcileSkillCollectionReviewJobs", () => {
+  it.each(["duplicate", "add", "stale"] as const)(
+    "lets the event loop progress between %s attempts after a row failure",
+    async (phase) => {
+      let progressed = false;
+      let checkpoint: Promise<void> | undefined;
+      const observed: Array<{ id: string; progressed: boolean }> = [];
+      const recordAttempt = (id: string) => {
+        observed.push({ id, progressed });
+        if (observed.length === 1) {
+          checkpoint = new Promise((resolve) =>
+            setImmediate(() => {
+              progressed = true;
+              resolve();
+            }),
+          );
+          throw new Error("first mutation failed");
+        }
+      };
+      const add = vi.fn(async (input: { agentId: string }) => {
+        if (phase === "add") recordAttempt(input.agentId);
+        return monitorJob(input.agentId);
+      });
+      const remove = vi.fn(async (id: string) => {
+        if ((phase === "duplicate" && id.startsWith("duplicate-")) || phase === "stale")
+          recordAttempt(id);
+        return { ok: true, removed: true };
+      });
+      const jobs =
+        phase === "duplicate"
+          ? [
+              monitorJob("a"),
+              ...["one", "two", "three"].map((id) => monitorJob("a", `duplicate-${id}`)),
+            ]
+          : phase === "stale"
+            ? [monitorJob("old-a"), monitorJob("old-b"), monitorJob("old-c")]
+            : [];
+      try {
+        const result = await reconcileSkillCollectionReviewJobs({
+          cron: { add, remove, list: vi.fn(async () => jobs) } as never,
+          cfg: { agents: { ownership: "explicit", entries: { a: {}, b: {}, c: {} } } },
+          logger,
+        });
+        expect(result).toEqual({ ok: false });
+        const ids =
+          phase === "duplicate"
+            ? ["duplicate-one", "duplicate-two", "duplicate-three"]
+            : phase === "stale"
+              ? ["job-old-a", "job-old-b", "job-old-c"]
+              : ["a", "b", "c"];
+        expect(observed).toEqual(ids.map((id, index) => ({ id, progressed: index > 0 })));
+      } finally {
+        await checkpoint;
+      }
+    },
+  );
+
+  it("rejects stale authority after yielding before another cleanup call", async () => {
+    const revoked = new Error("reconciliation revoked");
+    let current = true;
+    let checkpoint: Promise<void> | undefined;
+    const commitGuard = () => {
+      if (!current) throw revoked;
+    };
+    const remove = vi.fn(async (_id: string, options?: { commitGuard?: () => void }) => {
+      options?.commitGuard?.();
+      checkpoint ??= new Promise((resolve) =>
+        setImmediate(() => {
+          current = false;
+          resolve();
+        }),
+      );
+      return { ok: true, removed: true };
+    });
+    try {
+      await expect(
+        reconcileSkillCollectionReviewJobs({
+          cron: {
+            remove,
+            add: vi.fn(async () => monitorJob("main")),
+            list: vi.fn(async () => [monitorJob("stale-a"), monitorJob("stale-b")]),
+          } as never,
+          cfg: { agents: { entries: { main: {} } } },
+          logger,
+          commitGuard,
+        }),
+      ).rejects.toBe(revoked);
+      expect(remove).toHaveBeenCalledTimes(1);
+    } finally {
+      await checkpoint;
+    }
+  });
+
   it("adds desired monitors, keeps disabled rows, and prunes stale monitors", async () => {
     const add = vi.fn(
       async (

--- a/src/gateway/server-cron-skill-review-jobs.ts
+++ b/src/gateway/server-cron-skill-review-jobs.ts
@@ -1,4 +1,5 @@
 // Converges the system-owned skill collection review jobs at startup and reload.
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   resolveSkillCollectionReviewMonitorSpecs,
@@ -32,7 +33,11 @@ export async function reconcileSkillCollectionReviewJobs(params: {
     jobs,
     skillCollectionReviewMonitorAgentId,
   );
+  // Let I/O run between mutations, then fence stale passes before wrappers
+  // that can stop process owners ahead of their database commit guard.
   for (const { agentId, job } of duplicates) {
+    await yieldToEventLoop();
+    params.commitGuard?.();
     try {
       await params.cron.remove(job.id, {
         systemOwned: true,
@@ -48,6 +53,8 @@ export async function reconcileSkillCollectionReviewJobs(params: {
     }
   }
   for (const spec of specs) {
+    await yieldToEventLoop();
+    params.commitGuard?.();
     try {
       await params.cron.add(spec.input, {
         enabledExplicit: true,
@@ -69,6 +76,8 @@ export async function reconcileSkillCollectionReviewJobs(params: {
     if (desired.has(agentId)) {
       continue;
     }
+    await yieldToEventLoop();
+    params.commitGuard?.();
     try {
       await params.cron.remove(job.id, {
         systemOwned: true,

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -716,16 +716,19 @@ describe("buildGatewayCronService", () => {
           everyMs: input.schedule.kind === "every" ? input.schedule.everyMs : undefined,
           enabled: input.enabled,
         });
-        checkpoint ??= new Promise((resolve) =>
+        checkpoint ??= new Promise((resolve) => {
           setImmediate(() => {
-            if (action === "stop") state.cron.stop();
-            else {
+            if (action === "stop") {
+              state.cron.stop();
+            } else {
               loadConfigMock.mockReturnValue(replacement);
-              if (action === "supersede") nextPass = state.reconcileSystemJobs();
+              if (action === "supersede") {
+                nextPass = state.reconcileSystemJobs();
+              }
             }
             resolve();
-          }),
-        );
+          });
+        });
       }
       return result;
     });
@@ -737,7 +740,9 @@ describe("buildGatewayCronService", () => {
         expect(committed.map(({ agentId }) => agentId)).toEqual(["a"]);
       } else {
         expect(result).toBe(action === "replace" ? "converged" : "superseded");
-        if (nextPass) await expect(nextPass).resolves.toBe("converged");
+        if (nextPass) {
+          await expect(nextPass).resolves.toBe("converged");
+        }
         expect(committed).not.toContainEqual(
           expect.objectContaining(
             family === "heartbeat"
@@ -748,11 +753,14 @@ describe("buildGatewayCronService", () => {
         const jobs = (await state.cron.list({ includeDisabled: true })).filter((job) =>
           job.declarationKey?.startsWith(`${family}:`),
         );
-        expect(jobs.map((job) => job.agentId).toSorted()).toEqual(["a", "b"]);
-        for (const job of jobs)
+        expect(
+          jobs.map((job) => job.agentId).toSorted((a, b) => String(a).localeCompare(String(b))),
+        ).toEqual(["a", "b"]);
+        for (const job of jobs) {
           expect(job).toMatchObject(
             family === "heartbeat" ? { schedule: { everyMs: 7_200_000 } } : { enabled: true },
           );
+        }
       }
     } finally {
       try {

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -745,9 +745,9 @@ describe("buildGatewayCronService", () => {
               : { agentId: "b", enabled: false },
           ),
         );
-        const jobs = state.cron
-          .getLoadedJobs()
-          .filter((job) => job.declarationKey?.startsWith(`${family}:`));
+        const jobs = (await state.cron.list({ includeDisabled: true })).filter((job) =>
+          job.declarationKey?.startsWith(`${family}:`),
+        );
         expect(jobs.map((job) => job.agentId).toSorted()).toEqual(["a", "b"]);
         for (const job of jobs)
           expect(job).toMatchObject(

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -682,6 +682,88 @@ describe("buildGatewayCronService", () => {
     },
   );
 
+  it.each(
+    (["heartbeat", "skill-collection-review"] as const).flatMap((family) =>
+      (["stop", "replace", "supersede"] as const).map((action) => ({ family, action })),
+    ),
+  )("observes $action between committed $family monitor mutations", async ({ family, action }) => {
+    const baseConfig = createCronConfig(`server-cron-fairness-${family}-${action}`);
+    const cfg = {
+      ...baseConfig,
+      cron: { ...baseConfig.cron, enabled: false },
+      agents: {
+        ownership: "explicit",
+        defaults: { heartbeat: { every: "1h" } },
+        entries: { a: {}, b: {} },
+      },
+      skills: { workshop: { autonomous: { mode: "off" } } },
+    } satisfies OpenClawConfig;
+    const replacement = {
+      ...cfg,
+      agents: { ...cfg.agents, defaults: { heartbeat: { every: "2h" } } },
+      skills: { workshop: { autonomous: { mode: "auto" } } },
+    } satisfies OpenClawConfig;
+    const state = loadCronService(cfg);
+    const addJob = state.cron.add.bind(state.cron);
+    let checkpoint: Promise<void> | undefined;
+    let nextPass: ReturnType<typeof state.reconcileSystemJobs> | undefined;
+    const committed: Array<{ agentId?: string; everyMs?: number; enabled?: boolean }> = [];
+    vi.spyOn(state.cron, "add").mockImplementation(async (input, options) => {
+      const result = await addJob(input, options);
+      if (input.declarationKey?.startsWith(`${family}:`)) {
+        committed.push({
+          agentId: input.agentId,
+          everyMs: input.schedule.kind === "every" ? input.schedule.everyMs : undefined,
+          enabled: input.enabled,
+        });
+        checkpoint ??= new Promise((resolve) =>
+          setImmediate(() => {
+            if (action === "stop") state.cron.stop();
+            else {
+              loadConfigMock.mockReturnValue(replacement);
+              if (action === "supersede") nextPass = state.reconcileSystemJobs();
+            }
+            resolve();
+          }),
+        );
+      }
+      return result;
+    });
+    try {
+      const result = await state.reconcileSystemJobs();
+      await checkpoint;
+      if (action === "stop") {
+        expect(result).toBe("superseded");
+        expect(committed.map(({ agentId }) => agentId)).toEqual(["a"]);
+      } else {
+        expect(result).toBe(action === "replace" ? "converged" : "superseded");
+        if (nextPass) await expect(nextPass).resolves.toBe("converged");
+        expect(committed).not.toContainEqual(
+          expect.objectContaining(
+            family === "heartbeat"
+              ? { agentId: "b", everyMs: 3_600_000 }
+              : { agentId: "b", enabled: false },
+          ),
+        );
+        const jobs = state.cron
+          .getLoadedJobs()
+          .filter((job) => job.declarationKey?.startsWith(`${family}:`));
+        expect(jobs.map((job) => job.agentId).toSorted()).toEqual(["a", "b"]);
+        for (const job of jobs)
+          expect(job).toMatchObject(
+            family === "heartbeat" ? { schedule: { everyMs: 7_200_000 } } : { enabled: true },
+          );
+      }
+    } finally {
+      try {
+        await checkpoint;
+        await nextPass;
+      } finally {
+        state.cron.stop();
+      }
+    }
+  });
+
   it("converges Workshop after a heartbeat inventory failure and cancels its retry on stop", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const cfg = {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -2680,12 +2680,19 @@ describe("gateway hot reload model state", () => {
           ).resolves.toBe("applied");
         }
         await vi.advanceTimersByTimeAsync(30_000);
-        expect(await readIntervals()).toEqual([7_200_000, 7_200_000]);
-        expect(
-          (await loadCronJobsStore(cronState.storePath)).jobs
-            .filter((job) => skillCollectionReviewMonitorAgentId(job) !== undefined)
-            .map((job) => job.enabled),
-        ).toEqual([false, false]);
+        // The retry spans real event-loop turns; keep fake time fixed so this
+        // observes that retry's result without starting another retry.
+        await waitForFast(
+          async () => {
+            expect(await readIntervals()).toEqual([7_200_000, 7_200_000]);
+            expect(
+              (await loadCronJobsStore(cronState.storePath)).jobs
+                .filter((job) => skillCollectionReviewMonitorAgentId(job) !== undefined)
+                .map((job) => job.enabled),
+            ).toEqual([false, false]);
+          },
+          { interval: 0 },
+        );
       } finally {
         db.exec("DROP TRIGGER IF EXISTS monitor_publication_failure");
         handlers.stopRestartRetries();

--- a/test/scripts/docs-sync-publish.test.ts
+++ b/test/scripts/docs-sync-publish.test.ts
@@ -367,15 +367,18 @@ fs.writeFileSync('package-lock.json', JSON.stringify(lock));
       "Release process",
       "Testing and CI",
     ]);
-    // Every release adds a releases/<version> page, so read the published versions from the
+    // Releases may have a version page or subpages, so read the published routes from the
     // navigation rather than pinning them here; only the index-first ordering and the version
     // route shape are invariant. Pinning the list makes this assertion fail on release PRs whose
     // change classification never selects this lane, so the break first lands on main.
     expect(releaseNotes[0]).toBe("releases/index");
     expect(releaseNotes.length).toBeGreaterThan(1);
+    const releaseRoutePattern = /^releases\/\d{4}\.\d{1,2}\.\d+(?:\/[a-z0-9]+(?:-[a-z0-9]+)*)?$/;
     for (const page of releaseNotes.slice(1)) {
-      expect(page).toMatch(/^releases\/\d{4}\.\d{1,2}\.\d+$/);
+      expect(page).toMatch(releaseRoutePattern);
     }
+    expect("releases/not-a-version").not.toMatch(releaseRoutePattern);
+    expect("releases/2026.8.1/memory/nested").not.toMatch(releaseRoutePattern);
     const releaseRoutes = [
       ...releaseNotes,
       "maturity/scorecard",


### PR DESCRIPTION
## Problem and change

Large configured cron stores can delay Gateway responses while startup or reload converges heartbeat and skill-review monitor jobs. Awaiting an already-settled CRUD promise does not let pending I/O progress, and normalizing absent optional delivery fields repeatedly constructs discarded Zod errors.

Skip parsing only `undefined` optional fields, and yield one event-loop turn before each system-monitor mutation. Recheck the existing reconciliation guard after every yield, before entering a mutation wrapper. Preserve duplicate removal, upsert and stale removal order, per-row failure isolation, and final mutation guards. Present values, explicit null clears, false and zero retain their existing normalization behavior. No configuration, database, dependency, public API, or shutdown-policy change.

## Validation

- Native normalization/Doctor coverage: 153 passing tests; representative actual-Zod characterization preserved 171 input/schema outcomes. The synthetic 13,130-job seed avoids 52,520 failed parses of absent fields.
- Native reconciliation coverage: 150 passing tests, including 13 regressions that fail on the pre-fairness source. Covers I/O progress, row failures, duplicate/upsert/stale phases, and stop/configuration replacement/supersession guards.
- Existing rejected/noop reload successor cases exposed an early assertion after the retry timer fired. Both failures reproduce on `3353ae2e3757`; `f4ec6af980cc` waits for the same persisted results with fake time fixed. It does not invoke reconciliation or schedule another retry. All 278 reload tests and the explicit changed-file gate pass.
- Changed-path production types, test types, lint and guards completed across the retained native runs and successful standard PR merge-ref type jobs. Earlier test-type and style failures were corrected and their failed checks rerun. Final-head [CI](https://github.com/openclaw/openclaw/actions/runs/34050863344) and [CodeQL](https://github.com/openclaw/openclaw/actions/runs/34050863374) are green for `ec668abd96c4`.
- Independent reviews found no actionable P2-or-higher issue in the combined change or final test correction.

### Configured Gateway proof

A fresh Linux build using Node 26.7.0 ran the actual Gateway without profiling hooks or observer patches. The unchanged synthetic workload has 65 configured agents, 13,130 disabled jobs, four full/compact `cron.list` requests, and a 20-second deadline per response. Baseline and field-only builds timed out on the first response. The combined build returned all four exact sets of 200 authorized IDs in **2.739, 3.463, 2.421, and 2.344 seconds**. Cold-store physical-FD checks, status/readiness checks, source/build identity, and before/after source/dist/runtime/harness seals passed.

The original combined run returned all four responses but failed its private 30-second shutdown observation; it then exited cleanly after 30.757 seconds. That failure remains recorded. Source and stable-release inspection established the unchanged shipped supervisor budget of 330 seconds (`TimeoutStopSec=330`, 325-second internal stop budget, 315-second active-work drain). Only the private stop observation was corrected to that contract; request deadlines and workload stayed fixed. The corrected run exited naturally after **30.057 seconds**, code 0, with no cleanup signal or forced socket close, no remaining process group, and fixture cleanup complete.

Gateway proof used `3353ae2e3757` (tree `96c6a27233ed55124bce720d48f5f42b125631d6`), compiled from carrier `53ad5bab78808e13509bff1d3d71a6fe916891bf`. All 38,692 tracked entries were independently checked. The native reload candidate tree matches `f4ec6af980cc` exactly. Final head `ec668abd96c4` additionally picks up the already-landed test-only docs-route correction from `96bf3652adab` (#140337), after its inherited merge-target CI assertion failed. Both later changes are test-only; the newer GitHub merge target is qualified separately by final-head CI. This is a bounded synthetic responsiveness result, not a production-wide latency claim.

A second unchanged-fixture run tested the actual GitHub merge target `1deb9f39adab` (`add29edb0b64` + `ec668abd96c4`), including main's longer monitor prompts and newer cron cleanup behavior. It returned the four exact 200-ID results in **2.696, 3.474, 2.390, and 2.272 seconds**, and exited naturally in **29.569 seconds** without cleanup signals. All 38,743 tracked entries, build/runtime identity, cold-FD checks and source/dist/runtime/harness seals passed. The three successful type jobs and the corrected reload/docs test jobs also checked out this exact merge target. Specific inherited cleanup and placement unit/handler tests passed there; the separate placement E2E was not counted as executed.


## Review follow-through and remaining work

The latest ClawSweeper review's combined-fixture and validation-status requests, including its rank-up move, are addressed above. Individual store mutations and inventory/planning remain synchronous. The two active root requests observed during shutdown were not attributed, and readiness can still report CPU degradation during convergence; those remain measured follow-up work rather than claims solved here. Doctor scratch-monitor reconciliation fairness is also a separate follow-up.

Production delta: +17/-3, net +14 across the existing normalization and two reconciliation owners. The growth is the four necessary scheduling/currentness boundaries and their imports/comments; no queue, cache or parallel implementation is introduced. Tests: +360/-9, net +351 (including the existing main docs-route correction). Release-note context: keep Gateway requests responsive during system-monitor convergence and avoid unnecessary cron delivery validation work. Changelog generation remains release-owned.
