### PR TITLE
refactor(plugins): table CLI metadata load modes

### DIFF
--- a/src/plugins/loader.cli-metadata.test.ts
+++ b/src/plugins/loader.cli-metadata.test.ts
@@ -650,101 +650,32 @@ module.exports = {
     );
   });
 
-  it("collects channel CLI metadata during full plugin loads", () => {
+  it.each([
+    { mode: "full", title: "Full" },
+    { mode: "discovery", title: "Discovery" },
+  ])("collects channel CLI metadata during $mode plugin loads", ({ mode, title }) => {
     useNoBundledPlugins();
     const pluginDir = makePluginLoaderTempDir();
-    const modeMarker = path.join(pluginDir, "registration-mode.txt");
-    const fullMarker = path.join(pluginDir, "full-loaded.txt");
-
-    writePluginMetadata({
-      dir: pluginDir,
-      id: "full-cli-metadata-channel",
-      configSchema: EMPTY_PLUGIN_SCHEMA,
-      channels: ["full-cli-metadata-channel"],
-      packageJson: {
-        name: "@openclaw/full-cli-metadata-channel",
-        openclaw: { extensions: ["./index.cjs"] },
-      },
-    });
-    fs.writeFileSync(
-      path.join(pluginDir, "index.cjs"),
-      `${inlineChannelPluginEntryFactorySource()}
-module.exports = {
-  ...defineChannelPluginEntry({
-    id: "full-cli-metadata-channel",
-    name: "Full CLI Metadata Channel",
-    description: "full cli metadata channel",
-    plugin: {
-      id: "full-cli-metadata-channel",
-      meta: {
-        id: "full-cli-metadata-channel",
-        label: "Full CLI Metadata Channel",
-        selectionLabel: "Full CLI Metadata Channel",
-        docsPath: "/channels/full-cli-metadata-channel",
-        blurb: "full cli metadata channel",
-      },
-      capabilities: { chatTypes: ["direct"] },
-      config: {
-        listAccountIds: () => [],
-        resolveAccount: () => ({ accountId: "default" }),
-      },
-      outbound: { deliveryMode: "direct" },
-    },
-    registerCliMetadata(api) {
-      require("node:fs").writeFileSync(
-        ${JSON.stringify(modeMarker)},
-        String(api.registrationMode),
-        "utf-8",
-      );
-      api.registerCli(() => {}, {
-        descriptors: [
-          {
-            name: "full-cli-metadata-channel",
-            description: "Full-load channel CLI metadata",
-            hasSubcommands: true,
-          },
-        ],
-      });
-    },
-    registerFull() {
-      require("node:fs").writeFileSync(${JSON.stringify(fullMarker)}, "loaded", "utf-8");
-    },
-  }),
-};`,
-      "utf-8",
-    );
-
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      config: {
-        plugins: {
-          load: { paths: [pluginDir] },
-          allow: ["full-cli-metadata-channel"],
-        },
-      },
-    });
-
-    expect(fs.readFileSync(modeMarker, "utf-8")).toBe("full");
-    expect(fs.existsSync(fullMarker)).toBe(true);
-    expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).toContain(
-      "full-cli-metadata-channel",
-    );
-  });
-
-  it("collects channel CLI metadata during discovery plugin loads", () => {
-    useNoBundledPlugins();
-    const pluginDir = makePluginLoaderTempDir();
+    const id = `${mode}-cli-metadata-channel`;
+    const label = `${title} CLI Metadata Channel`;
+    const description = `${mode} cli metadata channel`;
     const modeMarker = path.join(pluginDir, "registration-mode.txt");
     const fullMarker = path.join(pluginDir, "full-loaded.txt");
     const runtimeMarker = path.join(pluginDir, "runtime-set.txt");
+    const runtimeSetter =
+      mode === "discovery"
+        ? `setRuntime() {
+      require("node:fs").writeFileSync(${JSON.stringify(runtimeMarker)}, "loaded", "utf-8");
+    },`
+        : "";
 
     writePluginMetadata({
       dir: pluginDir,
-      id: "discovery-cli-metadata-channel",
+      id,
       configSchema: EMPTY_PLUGIN_SCHEMA,
-      channels: ["discovery-cli-metadata-channel"],
+      channels: [id],
       packageJson: {
-        name: "@openclaw/discovery-cli-metadata-channel",
+        name: `@openclaw/${id}`,
         openclaw: { extensions: ["./index.cjs"] },
       },
     });
@@ -753,20 +684,18 @@ module.exports = {
       `${inlineChannelPluginEntryFactorySource()}
 module.exports = {
   ...defineChannelPluginEntry({
-    id: "discovery-cli-metadata-channel",
-    name: "Discovery CLI Metadata Channel",
-    description: "discovery cli metadata channel",
-    setRuntime() {
-      require("node:fs").writeFileSync(${JSON.stringify(runtimeMarker)}, "loaded", "utf-8");
-    },
+    id: ${JSON.stringify(id)},
+    name: ${JSON.stringify(label)},
+    description: ${JSON.stringify(description)},
+    ${runtimeSetter}
     plugin: {
-      id: "discovery-cli-metadata-channel",
+      id: ${JSON.stringify(id)},
       meta: {
-        id: "discovery-cli-metadata-channel",
-        label: "Discovery CLI Metadata Channel",
-        selectionLabel: "Discovery CLI Metadata Channel",
-        docsPath: "/channels/discovery-cli-metadata-channel",
-        blurb: "discovery cli metadata channel",
+        id: ${JSON.stringify(id)},
+        label: ${JSON.stringify(label)},
+        selectionLabel: ${JSON.stringify(label)},
+        docsPath: ${JSON.stringify(`/channels/${id}`)},
+        blurb: ${JSON.stringify(description)},
       },
       capabilities: { chatTypes: ["direct"] },
       config: {
@@ -784,8 +713,8 @@ module.exports = {
       api.registerCli(() => {}, {
         descriptors: [
           {
-            name: "discovery-cli-metadata-channel",
-            description: "Discovery-load channel CLI metadata",
+            name: ${JSON.stringify(id)},
+            description: ${JSON.stringify(`${title}-load channel CLI metadata`)},
             hasSubcommands: true,
           },
         ],
@@ -800,27 +729,23 @@ module.exports = {
     );
 
     const registry = loadOpenClawPlugins({
-      activate: false,
+      ...(mode === "discovery" ? { activate: false } : {}),
       cache: false,
       config: {
         plugins: {
           load: { paths: [pluginDir] },
-          allow: ["discovery-cli-metadata-channel"],
-          entries: {
-            "discovery-cli-metadata-channel": {
-              enabled: true,
-            },
-          },
+          allow: [id],
+          ...(mode === "discovery" ? { entries: { [id]: { enabled: true } } } : {}),
         },
       },
     });
 
-    expect(fs.readFileSync(modeMarker, "utf-8")).toBe("discovery");
-    expect(fs.existsSync(fullMarker)).toBe(false);
-    expect(fs.existsSync(runtimeMarker)).toBe(true);
-    expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).toContain(
-      "discovery-cli-metadata-channel",
-    );
+    expect(fs.readFileSync(modeMarker, "utf-8")).toBe(mode);
+    expect(fs.existsSync(fullMarker)).toBe(mode === "full");
+    if (mode === "discovery") {
+      expect(fs.existsSync(runtimeMarker)).toBe(true);
+    }
+    expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).toContain(id);
   });
 
   it("can force channel runtime entries for CLI registration when setup entries exist", () => {


### PR DESCRIPTION
## What Problem This Solves

The plugin loader CLI-metadata suite repeats a full generated channel fixture for full and discovery registration. This is maintainer-requested test-debt cleanup following the #135868 split campaign.

## Why This Change Was Made

Run the two existing cases as independent table rows. Preserve full-mode defaults and discovery's explicit enablement, activate:false option, runtime setter, and runtime-marker assertion. Reuse the common generated fixture without introducing another helper or changing runtime code.

Production 0; tests −75; tooling/docs 0. Total diff: 149 changed lines. The existing line-budget exception remains.

## User Impact

No behavior change. Both tests still load real temporary CommonJS plugin files through the real loader and check registration mode, full-registration execution, and registered CLI commands. Discovery still checks runtime initialization without full registration.

## Evidence

- All 30 focused CLI-metadata and register-once tests passed on macOS.
- All 16 untouched standalone test bodies are byte-identical.
- Independent capture confirms metadata, filenames, encodings and generated plugin AST are identical before/after for both rows. Original ids, labels, descriptions and marker filenames remain.
- Independent Codex P0–P2 review is scoped-clean.
- Full local `node scripts/check-changed.mjs` passed with exit 0, including plugin boundaries, typechecking, all dead-export scans and targeted lint.
- No build needed for a test-only change with identical generated fixture programs.

The original cases survive under their exact names at `src/plugins/loader.cli-metadata.test.ts:654` (full row) and `:655` (discovery row). Both retain the existing per-test loader reset and final fixture cleanup. Adjacent bundled-entry ordering, metadata-only loading, forced runtime entry, admission, async registration and memory-slot cases remain unchanged.

Exact-head [CI run 34044686477](https://github.com/openclaw/openclaw/actions/runs/34044686477) is green. ClawSweeper reviewed `b9e8fc1d394c23cbc902c710f3f93338bc4f6948` with no findings, before-merge requests, or rank-up moves. Both rebases were patch-identical and left the lockfile unchanged.
