### PR TITLE
refactor(ui): consolidate update acceptance tests

### DIFF
--- a/ui/src/app/update-confirmation.runtime.test.ts
+++ b/ui/src/app/update-confirmation.runtime.test.ts
@@ -64,7 +64,6 @@ function installNativeBridge(): ReturnType<typeof vi.fn> {
 
 function startUpdate(
   overrides: {
-    startGatewayUpdate?: () => void;
     updateAvailable?: UpdateAvailable | null;
     updateSchedule?: UpdateScheduleState | null;
     viaNativeApp?: boolean;
@@ -76,7 +75,7 @@ function startUpdate(
     ...(overrides.watchUpdateProgress
       ? { watchUpdateProgress: overrides.watchUpdateProgress }
       : {}),
-    startGatewayUpdate: overrides.startGatewayUpdate ?? startGatewayUpdate,
+    startGatewayUpdate,
     updateAvailable:
       overrides.updateAvailable === undefined ? UPDATE_AVAILABLE : overrides.updateAvailable,
     updateSchedule: overrides.updateSchedule ?? null,
@@ -355,73 +354,27 @@ it("keeps the failure visible until the operator explicitly opens its review act
   expect(stream.stopped).toBe(true);
 });
 
-/**
- * Retry after a failure: the shell keeps the previous attempt's banner until an
- * accepted run clears it, and producers replay the current snapshot as their
- * subscribe-time emit. `accepted: false` models `overlays.runUpdate` refusing
- * the request (disconnected, already running, no admin), which leaves the
- * banner in place.
- */
-function createRetryStream(options: { accepted: boolean }) {
-  let progress: UpdateProgress = {
-    run: null,
-    busy: false,
-    connected: true,
+it.each([
+  { name: "an empty snapshot", failure: null },
+  {
+    name: "a retained failure",
     failure: "The update failed at install: ENOSPC: no space left on device, write.",
-  };
-  let emit: ((next: UpdateProgress) => void) | null = null;
-  return {
-    startGatewayUpdate: () => {
-      if (!options.accepted) {
-        return;
-      }
-      progress = { run: null, busy: true, connected: true, failure: null };
-      emit?.(progress);
-    },
-    watchUpdateProgress: (listener: (next: UpdateProgress) => void) => {
-      emit = listener;
-      listener(progress);
-      return () => {};
-    },
-  };
-}
-
-it("reports a refused retry as unanswered rather than as the old failure", async () => {
+  },
+])("reports an unaccepted update after $name as unanswered", async ({ failure }) => {
+  // Auto-advance lets the modal animate while the admission deadline is fast-forwarded.
   vi.useFakeTimers({ shouldAdvanceTime: true });
   try {
-    const stream = createRetryStream({ accepted: false });
-    const { settled } = startUpdate({
-      startGatewayUpdate: stream.startGatewayUpdate,
-      watchUpdateProgress: stream.watchUpdateProgress,
-    });
-    const { modal } = await getRenderedModalDialog(document.body);
-
-    findButton("Update and restart").click();
-    await Promise.resolve();
-    // The refused request must not inherit the previous error as its outcome.
-    expect(modal.textContent).not.toContain("ENOSPC");
-
-    await vi.advanceTimersByTimeAsync(5_000);
-    expect(modal.textContent).toContain("The update request went unanswered");
-    findButton("Close").click();
-    await settled;
-  } finally {
-    vi.useRealTimers();
-  }
-});
-
-it("reports a request the Gateway never accepted instead of spinning forever", async () => {
-  // Auto-advancing keeps the modal's own animation frames running while the
-  // grace deadline is fast-forwarded.
-  vi.useFakeTimers({ shouldAdvanceTime: true });
-  try {
-    const stream = createProgressStream();
+    const stream = createProgressStream({ run: null, busy: false, connected: true, failure });
     const { settled } = startUpdate({ watchUpdateProgress: stream.watchUpdateProgress });
     const { modal } = await getRenderedModalDialog(document.body);
 
     findButton("Update and restart").click();
-    await vi.advanceTimersByTimeAsync(5_000);
+    await Promise.resolve();
+    if (failure) {
+      expect(modal.textContent).not.toContain("ENOSPC");
+    }
 
+    await vi.advanceTimersByTimeAsync(5_000);
     expect(modal.textContent).toContain("The update request went unanswered");
     findButton("Close").click();
     await settled;


### PR DESCRIPTION
## What Problem This Solves

The update-confirmation suite repeated the same unanswered-request boundary with two different progress fixtures. One fixture also retained an acceptance branch with no callers. This test-debt follow-up to the #135868 stage-4 split reduces the setup while retaining both failure histories.

## Why This Change Was Made

The two unaccepted-request cases now share one table and the existing synchronous progress stream. The only old retry-stream caller used `accepted: false`; its tested behavior is identical to the existing stream plus the default no-op start spy. The now-unused private callback override is removed as well.

Every removal retains coverage at these locations:

| Removed duplication | Surviving coverage |
|---|---|
| Single-consumer `createRetryStream` and its unexercised accepted branch | `ui/src/app/update-confirmation.runtime.test.ts:14` supplies the same synchronous replay; `:363` retains the refused-retry row. Accepted progress/failure and success remain unchanged at `:173` and `:208`. |
| Separate refused-retry and never-accepted test bodies, repeated timer setup/cleanup | `ui/src/app/update-confirmation.runtime.test.ts:357` retains both initial states. The old-error exclusion remains at `:374`, the same 5,000ms advance at `:377`, and unanswered outcome/close/settlement at `:378`. |
| Unused `startUpdate.startGatewayUpdate` override | The same default spy remains in `ui/src/app/update-confirmation.runtime.test.ts:65`; native handoff/fallback and duplicate-confirmation cases remain at `:103`, `:116`, and `:159`. Custom integration callbacks continue to call the production entry directly at `:426`. |

## User Impact

No production or user-visible change. Both original timeout scenarios remain; no receipt-shape, service-ownership, JSON-output, or live-behavior proof was changed.

## Evidence

- All 18 update-confirmation runtime cases passed.
- Full `node scripts/check-changed.mjs` passed.
- Independent Codex review: scoped-clean, no actionable P0–P2 findings.
- Tests/support: +13 / −60 = **−47 lines** (521 → 474). Production, tooling and docs unchanged.
- Rebase preserved the test file byte-for-byte and did not change the lockfile.

ClawSweeper reviewed the exact head and found no actionable findings or before-merge requests; there are no rank-up changes to apply. Exact-head CI is green.
