### PR TITLE
fix(telegram): honor bot ID mentions in text and photo captions

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-media.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media.ts
@@ -218,7 +218,7 @@ export function createTelegramInboundMedia({
       },
     );
     const hasAnyMention = textParts.entities.some((entity) => entity.type === "mention");
-    const explicitlyMentioned = botUsername ? hasBotMention(msg, botUsername) : false;
+    const explicitlyMentioned = botUsername ? hasBotMention(msg, botUsername, ctx.me?.id) : false;
     const wasMentioned = matchesMentionWithExplicit({
       text: textParts.text,
       mentionRegexes,

--- a/extensions/telegram/src/bot-message-context.body.test.ts
+++ b/extensions/telegram/src/bot-message-context.body.test.ts
@@ -347,6 +347,52 @@ describe("resolveTelegramInboundBody", () => {
     },
   );
 
+  groupBodyTest(
+    "routes group updates that tag the bot via a text_mention (display-name tap)",
+    {
+      message: {
+        text: "Assistant please read this",
+        entities: [
+          {
+            type: "text_mention",
+            offset: 0,
+            length: 9,
+            user: { id: 7, is_bot: true, first_name: "Assistant" },
+          },
+        ],
+      },
+    },
+    (result, logger) => {
+      // The bot (primaryCtx.me.id === 7) is tagged by display name — no `@bot`
+      // text and no `mention` entity — so this reaches the caller as a mention
+      // only via the text_mention branch, and must be dispatched, not skipped.
+      expect(logger.info).not.toHaveBeenCalledWith(SKIPPED_GROUP, "skipping group message");
+      expect(result?.effectiveWasMentioned).toBe(true);
+    },
+  );
+
+  groupBodyTest(
+    "skips group text_mention entities that target a different user id",
+    {
+      message: {
+        text: "Eve please read this",
+        entities: [
+          {
+            type: "text_mention",
+            offset: 0,
+            length: 3,
+            user: { id: 999, is_bot: false, first_name: "Eve" },
+          },
+        ],
+      },
+    },
+    (result, logger) => {
+      // A text_mention of someone other than the bot is not a mention of us.
+      expect(logger.info).toHaveBeenCalledWith(SKIPPED_GROUP, "skipping group message");
+      expect(result).toBeNull();
+    },
+  );
+
   privateBodyTest(
     "renders Telegram text entities before building the agent body",
     {

--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -324,7 +324,7 @@ export async function resolveTelegramInboundBody(params: {
 
   const hasAnyMention = messageTextParts.entities.some((ent) => ent.type === "mention");
   const explicitlyMentioned = botUsername
-    ? hasBotMention(msg, botUsername) ||
+    ? hasBotMention(msg, botUsername, primaryCtx.me?.id) ||
       (richText ? hasBotMentionInText(richText, botUsername) : false)
     : false;
   const computedWasMentioned = matchesMentionWithExplicit({

--- a/extensions/telegram/src/bot/body-helpers.text-mention.test.ts
+++ b/extensions/telegram/src/bot/body-helpers.text-mention.test.ts
@@ -1,0 +1,76 @@
+import type { Message } from "grammy/types";
+import { describe, expect, it } from "vitest";
+import { hasBotMention } from "./body-helpers.js";
+
+function asTelegramMessage(message: unknown): Message {
+  return message as Message;
+}
+
+const BOT_ID = 42;
+
+describe("hasBotMention text_mention resolution", () => {
+  it("matches a text_mention entity that resolves to this bot id", () => {
+    // Tapping the bot's display name yields a text_mention (entity text is the
+    // display name, not @username), which the `mention` branch never matches.
+    expect(
+      hasBotMention(
+        asTelegramMessage({
+          text: "Gaian what is the group id?",
+          entities: [
+            {
+              type: "text_mention",
+              offset: 0,
+              length: 5,
+              user: { id: BOT_ID, is_bot: true, first_name: "Gaian" },
+            },
+          ],
+          chat: { id: 1, type: "supergroup" },
+        }),
+        "gaian",
+        BOT_ID,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match a text_mention entity for a different user id", () => {
+    expect(
+      hasBotMention(
+        asTelegramMessage({
+          text: "Alice what is the group id?",
+          entities: [
+            {
+              type: "text_mention",
+              offset: 0,
+              length: 5,
+              user: { id: 999, is_bot: false, first_name: "Alice" },
+            },
+          ],
+          chat: { id: 1, type: "supergroup" },
+        }),
+        "gaian",
+        BOT_ID,
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores text_mention resolution when no bot id is provided", () => {
+    // Back-compat: callers that do not pass a bot id keep the previous behaviour.
+    expect(
+      hasBotMention(
+        asTelegramMessage({
+          text: "Gaian what is the group id?",
+          entities: [
+            {
+              type: "text_mention",
+              offset: 0,
+              length: 5,
+              user: { id: BOT_ID, is_bot: true, first_name: "Gaian" },
+            },
+          ],
+          chat: { id: 1, type: "supergroup" },
+        }),
+        "gaian",
+      ),
+    ).toBe(false);
+  });
+});

--- a/extensions/telegram/src/bot/body-helpers.text-mention.test.ts
+++ b/extensions/telegram/src/bot/body-helpers.text-mention.test.ts
@@ -73,4 +73,57 @@ describe("hasBotMention text_mention resolution", () => {
       ),
     ).toBe(false);
   });
+
+  it("still matches an @username mention entity when a bot id is also provided", () => {
+    // Passing a bot id must not regress the existing @username mention path.
+    expect(
+      hasBotMention(
+        asTelegramMessage({
+          text: "@gaian hello",
+          entities: [{ type: "mention", offset: 0, length: 6 }],
+          chat: { id: 1, type: "supergroup" },
+        }),
+        "gaian",
+        BOT_ID,
+      ),
+    ).toBe(true);
+  });
+
+  it("matches a text_mention that targets the bot in a caption", () => {
+    // getTelegramTextParts falls back to caption + caption_entities, so a
+    // display-name tag on a media message must be recognized too.
+    expect(
+      hasBotMention(
+        asTelegramMessage({
+          caption: "Gaian look at this",
+          caption_entities: [
+            {
+              type: "text_mention",
+              offset: 0,
+              length: 5,
+              user: { id: BOT_ID, is_bot: true, first_name: "Gaian" },
+            },
+          ],
+          chat: { id: 1, type: "supergroup" },
+        }),
+        "gaian",
+        BOT_ID,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match (and does not throw) a text_mention entity with no user", () => {
+    // Defensive: a malformed text_mention without a user object must be ignored.
+    expect(
+      hasBotMention(
+        asTelegramMessage({
+          text: "Gaian hello",
+          entities: [{ type: "text_mention", offset: 0, length: 5 }],
+          chat: { id: 1, type: "supergroup" },
+        }),
+        "gaian",
+        BOT_ID,
+      ),
+    ).toBe(false);
+  });
 });

--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -364,7 +364,7 @@ export function hasBotMention(msg: Message, botUsername: string, botId?: number)
     // A `text_mention` entity tags a user by id (the entity text is the display
     // name, not `@username`), so the `mention` branch above never matches it.
     // When it resolves to this bot, it is still an explicit mention of us.
-    if (ent.type === "text_mention" && botId !== undefined && ent.user.id === botId) {
+    if (ent.type === "text_mention" && botId !== undefined && ent.user?.id === botId) {
       return true;
     }
   }

--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -347,7 +347,7 @@ function isBotCommandAddressedToMention(command: string, mention: string): boole
   return atIndex > 1;
 }
 
-export function hasBotMention(msg: Message, botUsername: string) {
+export function hasBotMention(msg: Message, botUsername: string, botId?: number) {
   const { text, entities } = getTelegramTextParts(msg);
   const mention = normalizeLowercaseStringOrEmpty(`@${botUsername}`);
   if (hasStandaloneTelegramMention(normalizeLowercaseStringOrEmpty(text), mention)) {
@@ -359,6 +359,12 @@ export function hasBotMention(msg: Message, botUsername: string) {
       return true;
     }
     if (ent.type === "bot_command" && isBotCommandAddressedToMention(slice, mention)) {
+      return true;
+    }
+    // A `text_mention` entity tags a user by id (the entity text is the display
+    // name, not `@username`), so the `mention` branch above never matches it.
+    // When it resolves to this bot, it is still an explicit mention of us.
+    if (ent.type === "text_mention" && botId !== undefined && ent.user.id === botId) {
       return true;
     }
   }


### PR DESCRIPTION
Closes #140265

## What Problem This Solves

Fixes mention-required Telegram groups ignoring messages that address the bot through a `text_mention` entity. The same failure affects photo captions: the bot receives the message but does not reply.

## Why This Change Was Made

The shared mention detector now compares the entity's user ID with the current bot ID. Both the message body and media prefilter supply that identity. The optional argument preserves existing two-argument helper calls.

## User Impact

Bot-targeted identity mentions activate the bot in text and photo captions. Mentions of another user and plain display labels remain subject to the existing mention policy.

## Evidence

Real Telegram Test Server proof used one leased bot/user pair, mention-required groups, and a deterministic local model endpoint. Raw incoming updates, user-side events, model requests, and outgoing receipts were checked by an independent validator.

| Scenario | Baseline `efa6acb1aea2` | Candidate `78da2dcb50b7` |
| --- | --- | --- |
| Bot-ID text mention | Skipped; no turn or reply | One turn and one reply |
| Bot-ID photo caption | Skipped before download | One image-bearing turn and one reply |
| Same label targeting another user | No turn or reply | No turn or reply |
| Plain display label | No turn or reply | No turn or reply |
| Username control | One turn and reply | One turn and reply |

- Real text/caption controls passed with emoji prefixes and correct UTF-16 offsets. Username mentions, replies to the bot, configured patterns, and addressed native commands retained their behavior; commands addressed to another bot were ignored.
- Replies stayed in the actual non-general forum topic. Excluded-sender and disabled-group messages produced no turn or reply.
- 115 focused tests passed. They include optional-argument compatibility, malformed helper input, group allowlist denial, and self-message filtering. The identity text/caption helper regressions fail on the baseline for the expected reason.
- Exact-head CI is green: [run 34049217537](https://github.com/openclaw/openclaw/actions/runs/34049217537).
- All 53 run-owned server messages and the created topic were removed. Persistent groups were preserved; the credential lease was released.

Scope: this proves real protocol-level identity mentions. It does not claim every Telegram client's display-name-tap gesture. Missing-group allowlist denial is covered by focused handler tests; the live group-denial case used a disabled group. Incoming-bot filtering and combined-message offsets use source/focused proof, and no real album or alternate outbound reply mode was claimed.
