### PR TITLE
perf(ui): reuse the sidebar session row map

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation-logic.test.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.test.ts
@@ -5,6 +5,7 @@ import { gatewayHelloForMethods } from "../test-helpers/gateway-methods.ts";
 import { collectKnownSessionRows, fetchSessionLineage } from "./app-sidebar-child-session-data.ts";
 import {
   buildSidebarSessionNavigationState,
+  collectSidebarSessionRowsByKey,
   compareSidebarSessionRowsByMode,
   resolveSidebarMainSessionKey,
 } from "./app-sidebar-session-navigation-logic.ts";
@@ -370,8 +371,10 @@ describe("sidebar navigation lineage ownership", () => {
   it("projects a known child exactly once under its explicit navigation parent", () => {
     const projected = projectSessionTree({
       roots: [navigationParent, controlParent],
-      agentRows: [navigationParent, controlParent, child],
-      childRowsByParent: {},
+      rowsByKey: collectSidebarSessionRowsByKey({
+        rows: [navigationParent, controlParent, child],
+        childRowsByParent: {},
+      }),
       loadingChildKeys: new Set(),
       knownSessionAttention: [],
       toSidebarSession: (row, isChild) =>
@@ -392,12 +395,55 @@ describe("sidebar navigation lineage ownership", () => {
     ]);
   });
 
+  it("keeps exact-key insertion order while newer rows replace cached child values", () => {
+    const parent: GatewaySessionRow = {
+      key: "agent:main:parent",
+      kind: "direct",
+      updatedAt: 1,
+    };
+    const first: GatewaySessionRow = {
+      key: "agent:main:child",
+      kind: "direct",
+      spawnedBy: parent.key,
+      label: "Old child",
+    };
+    const caseVariant = { ...first, key: "agent:main:Child", label: "Distinct child" };
+    const sibling = { ...first, key: "agent:main:sibling", label: "Sibling" };
+    const current = { ...first, label: "Current child", hasActiveRun: true };
+    const rowsByKey = collectSidebarSessionRowsByKey({
+      rows: [parent, current],
+      childRowsByParent: {
+        firstCache: [first, caseVariant],
+        secondCache: [{ ...first, label: "Later cached child" }, sibling],
+      },
+    });
+    const [tree] = projectSessionTree({
+      roots: [parent],
+      rowsByKey,
+      loadingChildKeys: new Set(),
+      knownSessionAttention: [],
+      toSidebarSession: (row, isChild) => ({
+        ...projectSidebarSession(row),
+        isChild: isChild === true,
+      }),
+    });
+
+    expect(tree?.children.map((row) => [row.key, row.label, row.hasActiveRun])).toEqual([
+      [first.key, "Current child", true],
+      [caseVariant.key, "Distinct child", false],
+      [sibling.key, "Sibling", false],
+    ]);
+    expect(tree?.runningChildCount).toBe(1);
+  });
+
   it("promotes an explicitly categorized child to a sidebar section root", () => {
     const categorizedChild = { ...child, category: "P1 issues from beta feedback" };
     const projected = projectSessionTree({
       roots: [navigationParent, categorizedChild],
-      agentRows: [navigationParent, categorizedChild],
-      childRowsByParent: {},
+      rowsByKey: collectSidebarSessionRowsByKey({
+        rows: [navigationParent, categorizedChild],
+        childRowsByParent: {},
+      }),
       loadingChildKeys: new Set(),
       knownSessionAttention: [],
       toSidebarSession: (row, isChild) =>
@@ -439,8 +485,10 @@ describe("sidebar navigation lineage ownership", () => {
       const childRow = { ...child, ...runState };
       const projected = projectSessionTree({
         roots: [navigationParent],
-        agentRows: [navigationParent, childRow],
-        childRowsByParent: {},
+        rowsByKey: collectSidebarSessionRowsByKey({
+          rows: [navigationParent, childRow],
+          childRowsByParent: {},
+        }),
         loadingChildKeys: new Set(),
         knownSessionAttention: [],
         toSidebarSession: (row, isChild) => ({
@@ -475,8 +523,10 @@ describe("sidebar navigation lineage ownership", () => {
     const childWithBlankParent = { ...child, parentSessionKey: "  \t  " };
     const projected = projectSessionTree({
       roots: [controlParent],
-      agentRows: [controlParent, childWithBlankParent],
-      childRowsByParent: {},
+      rowsByKey: collectSidebarSessionRowsByKey({
+        rows: [controlParent, childWithBlankParent],
+        childRowsByParent: {},
+      }),
       loadingChildKeys: new Set(),
       knownSessionAttention: [],
       toSidebarSession: (row, isChild) =>

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -401,17 +401,20 @@ export function resolveLatestSidebarAgentSession(input: {
   });
 }
 
-export function collectSidebarSessionCandidateRows(input: {
+export function collectSidebarSessionRowsByKey(input: {
   rows: readonly GatewaySessionRow[];
   childRowsByParent: Readonly<Record<string, readonly GatewaySessionRow[]>>;
-}): GatewaySessionRow[] {
-  return [
-    ...new Map(
-      [...Object.values(input.childRowsByParent).flat(), ...input.rows].map(
-        (row) => [row.key, row] as const,
-      ),
-    ).values(),
-  ];
+}): ReadonlyMap<string, GatewaySessionRow> {
+  const rowsByKey = new Map<string, GatewaySessionRow>();
+  for (const rows of Object.values(input.childRowsByParent)) {
+    for (const row of rows) {
+      rowsByKey.set(row.key, row);
+    }
+  }
+  for (const row of input.rows) {
+    rowsByKey.set(row.key, row);
+  }
+  return rowsByKey;
 }
 
 /**

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -38,7 +38,7 @@ import {
   buildSidebarSessionNavigationState,
   collectCategorizedChildRootRows,
   collectPromotedMainChildRows,
-  collectSidebarSessionCandidateRows,
+  collectSidebarSessionRowsByKey,
   compareSidebarSessionRowsByMode,
   collectKnownSidebarSessionCatalogIds,
   collectKnownSidebarSessionGroups,
@@ -659,10 +659,11 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     ) {
       scopedRootRows.push(lineageRoot);
     }
-    const sessionCandidateRows = collectSidebarSessionCandidateRows({
+    const sessionRowsByKey = collectSidebarSessionRowsByKey({
       rows,
       childRowsByParent: childSessionRowsByParent,
     });
+    const sessionCandidateRows = [...sessionRowsByKey.values()];
     const categorizedChildRows = collectCategorizedChildRootRows({
       rows: sessionCandidateRows,
       scopedRoots: scopedRootRows,
@@ -692,8 +693,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     // renders as its live row inside the Coding catalog, never as a thread.
     const projected = projectSessionTree({
       roots: orderedRootRows.filter((row) => !adopted.has(row.key)),
-      agentRows: rows,
-      childRowsByParent: childSessionRowsByParent,
+      rowsByKey: sessionRowsByKey,
       loadingChildKeys: this.sessionData.loadingChildSessionKeys,
       knownSessionAttention: this.attention.knownSessionAttention(),
       toSidebarSession: navigationState.toSidebarSession,

--- a/ui/src/components/app-sidebar-session-tree.ts
+++ b/ui/src/components/app-sidebar-session-tree.ts
@@ -20,29 +20,12 @@ import {
  */
 export function projectSessionTree(params: {
   roots: readonly GatewaySessionRow[];
-  agentRows: readonly GatewaySessionRow[];
-  childRowsByParent: Readonly<Record<string, readonly GatewaySessionRow[]>>;
+  rowsByKey: ReadonlyMap<string, GatewaySessionRow>;
   loadingChildKeys: ReadonlySet<string>;
   knownSessionAttention: readonly SidebarKnownSessionAttention[];
   toSidebarSession: (row: GatewaySessionRow, isChild?: boolean) => SidebarRecentSession;
 }): SidebarRecentSession[] {
-  const {
-    roots,
-    agentRows,
-    childRowsByParent,
-    loadingChildKeys,
-    knownSessionAttention,
-    toSidebarSession,
-  } = params;
-  const rowsByKey = new Map<string, GatewaySessionRow>();
-  for (const rows of Object.values(childRowsByParent)) {
-    for (const row of rows) {
-      rowsByKey.set(row.key, row);
-    }
-  }
-  for (const row of agentRows) {
-    rowsByKey.set(row.key, row);
-  }
+  const { roots, rowsByKey, loadingChildKeys, knownSessionAttention, toSidebarSession } = params;
   const childKeysByParent = new Map<string, string[]>();
   const hasExplicitCategory = (row: GatewaySessionRow | undefined) =>
     typeof row?.category === "string" && row.category.trim().length > 0;

--- a/ui/src/test-helpers/app-sidebar-cases/categorized-child-sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/categorized-child-sessions.ts
@@ -65,6 +65,41 @@ describe("AppSidebar categorized child sessions", () => {
       ),
     ).not.toBeNull();
     expect(sidebar.querySelector(`[data-session-key="${archivedKey}"]`)).toBeNull();
+
+    harness.publishList({
+      result: {
+        ...harness.sessions.state.result!,
+        count: 2,
+        sessions: [
+          parent!,
+          {
+            key: categorizedKey,
+            kind: "direct",
+            label: "Current ordinary child",
+            spawnedBy: parentKey,
+            updatedAt: 4,
+          },
+        ],
+      },
+    });
+    await waitForFast(() => {
+      const rows = sidebar.querySelectorAll(`[data-session-key="${categorizedKey}"]`);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.textContent).toContain("Current ordinary child");
+      expect(rows[0]?.closest(`[data-session-tree="${parentKey}"]`)).not.toBeNull();
+    });
+    expect(sidebar.textContent).not.toContain("Cached categorized child");
+    expect(
+      sidebar.querySelector(
+        `[data-session-section="category:Research"] [data-session-key="${categorizedKey}"]`,
+      ),
+    ).toBeNull();
+    expect(
+      sidebar.querySelector(
+        `[data-session-tree="${parentKey}"] [data-session-key="${ordinaryKey}"]`,
+      ),
+    ).not.toBeNull();
+    expect(sidebar.querySelector(`[data-session-key="${archivedKey}"]`)).toBeNull();
   });
 
   it("places a categorized child in its section while keeping ordinary siblings nested", async () => {


### PR DESCRIPTION
## What Problem This Solves

Sidebar navigation collects cached children and current agent rows into an exact-key lookup, converts it to an array, and then rebuilds the same lookup for tree projection. Every sidebar update repeats that preparation.

## Why This Change Was Made

Keep the collector's native keyed form and pass the existing map into the tree projector. Materialize ordered values once for category and main-child promotion. Preserve exact keys, first insertion order, current-agent row precedence, archive/deletion-projected inputs, separate lineage roots, and ancestor-cycle handling. Production code shrinks by 14 lines with no cross-render cache.

## User Impact

Sidebar updates do less duplicate lookup work while keeping the same row order, labels, nesting, liveness, filtering, and navigation requests. Each update still derives fresh display, draft, locale, and attention facts.

## Evidence

- **368 focused tests**, the complete changed-code gate, independent production/test review, and fresh managed autoreview pass. Expanded existing cases protect exact-key/case-variant order, current-row labels/liveness, canonical replacement, ordinary siblings, and archive filtering.
- The actual collector, promotion helpers, tree projector, and row callback produce identical full trees for 24 roots, 576 cached children, and 192 canonical overrides. Two 240-projection samples per arm show **6.3% lower sampled allocation** and 4.4% lower derivation time under Node Inspector.
- Those small component samples are descriptive. They do not establish paint/navigation latency, retained heap/RSS, significance, or whole-app/Gateway savings.
- The **full real Control UI app**, built once per arm with normal Vite configuration, runs against a synthetic mocked Gateway. Exact visible-row tuples and `sessions.list` request parameters match before and after a canonical replacement changes a child's label/category. Built source-map hashes and post-build asset budgets pass.
- The attached approved screenshots show that same replacement state before and after the optimization. They contain only synthetic sidebar data and the app's normal public UI; they are not live operator/Gateway captures.
- Two baseline capture-harness issues were corrected by waiting on the actual route component and capturing the real sidebar element. Existing builds were reused; production bytes, assertions, and timeouts stayed unchanged.
- Required hosted CI passed on the exact reviewed head ([run 34045441194](https://github.com/openclaw/openclaw/actions/runs/34045441194)).

Before and after optimization: the same synthetic canonical-row replacement state.

![Before optimization: updated synthetic sidebar](https://github.com/user-attachments/assets/d7b7d0ee-1e63-40f2-a96e-ae5b0cd77eb7)

![After optimization: updated synthetic sidebar](https://github.com/user-attachments/assets/d9109f12-6edd-4894-abbc-5b33b3c1bb52)
