### PR TITLE
fix: keep macOS Dashboard usable when downloading attachments

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardDownloads.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardDownloads.swift
@@ -1,0 +1,242 @@
+import AppKit
+import Foundation
+import WebKit
+
+@MainActor
+final class DashboardDownloads: NSObject, WKDownloadDelegate {
+    private weak var controller: DashboardWindowController?
+    private var generation: UInt64 = 0
+    private var pending: [ObjectIdentifier: WKNavigationAction] = [:]
+    private var active: [ObjectIdentifier: Transfer] = [:]
+    private var failureSheets: [NSWindow] = []
+
+    init(controller: DashboardWindowController) {
+        self.controller = controller
+    }
+
+    func admit(_ action: WKNavigationAction) -> Bool {
+        guard let controller, controller.canDownloadAttachments,
+              action.sourceFrame.isMainFrame,
+              DashboardWindowController.isTrustedLinkSource(
+                  action.sourceFrame.request.url, dashboardURL: controller.currentURL),
+              let scheme = action.request.url?.scheme?.lowercased(),
+              ["http", "https", "blob", "data"].contains(scheme)
+        else { return false }
+        // WebKit returns this action when it becomes a download. Retaining it
+        // binds conversion to admission, including while a replacement is queued.
+        self.pending[ObjectIdentifier(action)] = action
+        return true
+    }
+
+    func start(_ download: WKDownload, for action: WKNavigationAction) {
+        guard self.pending.removeValue(forKey: ObjectIdentifier(action)) != nil,
+              let controller, controller.canDownloadAttachments,
+              download.webView === controller.webView, let window = controller.window
+        else {
+            download.cancel { _ in }
+            return
+        }
+        self.active[ObjectIdentifier(download)] = Transfer(
+            download: download, window: window, generation: self.generation)
+        download.delegate = self
+    }
+
+    func retire() {
+        self.generation &+= 1
+        self.pending.removeAll()
+        let transfers = Array(self.active.values)
+        self.active.removeAll()
+        for transfer in transfers {
+            transfer.cancel()
+        }
+        // Gateway replacement reuses this window; terminal error sheets must
+        // retire with their originating document just like pending Save panels.
+        let sheets = self.failureSheets
+        self.failureSheets.removeAll()
+        for sheet in sheets {
+            sheet.sheetParent?.endSheet(sheet)
+            sheet.orderOut(nil)
+        }
+    }
+
+    private func isCurrent(_ transfer: Transfer) -> Bool {
+        guard let controller else { return false }
+        return transfer.generation == self.generation && controller.window === transfer.window &&
+            controller.canDownloadAttachments
+    }
+
+    private func currentTransfer(_ download: WKDownload) -> Transfer? {
+        guard let transfer = self.active[ObjectIdentifier(download)] else { return nil }
+        guard self.isCurrent(transfer) else {
+            self.cancel(transfer)
+            return nil
+        }
+        return transfer
+    }
+
+    private func cancel(_ transfer: Transfer) {
+        self.active.removeValue(forKey: ObjectIdentifier(transfer.download))
+        transfer.cancel()
+    }
+
+    func download(
+        _ download: WKDownload,
+        decideDestinationUsing _: URLResponse,
+        suggestedFilename: String,
+        completionHandler: @escaping @MainActor @Sendable (URL?) -> Void)
+    {
+        guard let transfer = self.currentTransfer(download) else {
+            completionHandler(nil)
+            return
+        }
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = suggestedFilename
+        transfer.panel = panel
+        transfer.destinationCompletion = completionHandler
+        panel.beginSheetModal(for: transfer.window) { [weak self] response in
+            transfer.panel = nil
+            panel.orderOut(nil)
+            guard let self, self.active[ObjectIdentifier(download)] === transfer,
+                  self.isCurrent(transfer), response == .OK, let destination = panel.url
+            else {
+                if let self { self.cancel(transfer) } else { transfer.cancel() }
+                return
+            }
+            do {
+                let replaceExisting = FileManager.default.fileExists(atPath: destination.path)
+                // WebKit requires a nonexistent file. Stage on the destination's
+                // volume so cancellation never truncates an existing saved file.
+                let directory = try FileManager.default.url(
+                    for: .itemReplacementDirectory,
+                    in: .userDomainMask,
+                    appropriateFor: destination,
+                    create: true)
+                transfer.stagingDirectory = directory
+                let staged = directory.appendingPathComponent(destination.lastPathComponent)
+                transfer.destination = (destination, staged, replaceExisting)
+                transfer.respond(with: staged)
+            } catch {
+                self.showFailure(error, for: transfer)
+                self.cancel(transfer)
+            }
+        }
+    }
+
+    func download(
+        _ download: WKDownload,
+        willPerformHTTPRedirection _: HTTPURLResponse,
+        newRequest request: URLRequest,
+        decisionHandler: @escaping @MainActor @Sendable (WKDownload.RedirectPolicy) -> Void)
+    {
+        guard self.currentTransfer(download) != nil,
+              let scheme = request.url?.scheme?.lowercased(), ["http", "https"].contains(scheme)
+        else {
+            decisionHandler(.cancel)
+            return
+        }
+        decisionHandler(.allow)
+    }
+
+    func download(
+        _ download: WKDownload,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping @MainActor @Sendable (
+            URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
+    {
+        guard self.currentTransfer(download) != nil, let controller else {
+            completionHandler(.cancelAuthenticationChallenge, nil)
+            return
+        }
+        // The existing owner applies Gateway trust only to its configured
+        // authority; external attachments keep ordinary WebKit authentication.
+        controller.webView(controller.webView, didReceive: challenge, completionHandler: completionHandler)
+    }
+
+    func downloadDidFinish(_ download: WKDownload) {
+        guard let transfer = self.active.removeValue(forKey: ObjectIdentifier(download)) else { return }
+        defer { transfer.removeStaging() }
+        guard self.isCurrent(transfer), let destination = transfer.destination else { return }
+        do {
+            // A file created during the transfer was not approved for overwrite.
+            if destination.replaceExisting {
+                _ = try FileManager.default.replaceItemAt(
+                    destination.final,
+                    withItemAt: destination.staged,
+                    options: .usingNewMetadataOnly)
+            } else {
+                try FileManager.default.moveItem(at: destination.staged, to: destination.final)
+            }
+            NSWorkspace.shared.activateFileViewerSelecting([destination.final])
+        } catch {
+            self.showFailure(error, for: transfer)
+        }
+    }
+
+    func download(_ download: WKDownload, didFailWithError error: Error, resumeData _: Data?) {
+        guard let transfer = self.active.removeValue(forKey: ObjectIdentifier(download)) else { return }
+        transfer.cancel()
+        guard (error as NSError).domain != NSURLErrorDomain || (error as NSError).code != NSURLErrorCancelled else {
+            return
+        }
+        self.showFailure(error, for: transfer)
+    }
+
+    private func showFailure(_ error: Error, for transfer: Transfer) {
+        guard self.isCurrent(transfer) else { return }
+        let alert = NSAlert(error: error)
+        alert.messageText = "Attachment download failed"
+        alert.informativeText = "\(error.localizedDescription)\n\nTry downloading the attachment again."
+        let sheet = alert.window
+        self.failureSheets.append(sheet)
+        alert.beginSheetModal(for: transfer.window) { [weak self] _ in
+            self?.failureSheets.removeAll { $0 === sheet }
+        }
+    }
+
+    @MainActor
+    private final class Transfer {
+        let download: WKDownload
+        let window: NSWindow
+        let generation: UInt64
+        var panel: NSSavePanel?
+        var destinationCompletion: (@MainActor @Sendable (URL?) -> Void)?
+        var destination: (final: URL, staged: URL, replaceExisting: Bool)?
+        var stagingDirectory: URL?
+        private var cancelled = false
+
+        init(download: WKDownload, window: NSWindow, generation: UInt64) {
+            self.download = download
+            self.window = window
+            self.generation = generation
+        }
+
+        func respond(with url: URL?) {
+            let completion = self.destinationCompletion
+            self.destinationCompletion = nil
+            completion?(url)
+        }
+
+        func cancel() {
+            guard !self.cancelled else { return }
+            self.cancelled = true
+            let panel = self.panel
+            self.panel = nil
+            self.respond(with: nil)
+            panel?.cancel(nil)
+            // A late finish callback can still arrive after cancellation. The
+            // owner has already retired us; release staging only after WebKit stops.
+            self.download.cancel { [self] _ in self.removeStaging() }
+        }
+
+        func removeStaging() {
+            guard let directory = self.stagingDirectory else { return }
+            self.stagingDirectory = nil
+            do {
+                try FileManager.default.removeItem(at: directory)
+            } catch {
+                dashboardWindowLogger
+                    .error("dashboard download cleanup failed: \(error.localizedDescription, privacy: .private)")
+            }
+        }
+    }
+}

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -143,6 +143,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     private var nativeCommandsReady = false
     private(set) var isShowingFailurePage = false
     private var navigationGeneration: UInt64 = 0
+    private lazy var downloads = DashboardDownloads(controller: self)
     private var loadGeneration: UInt64 = 0
     private var pendingLoad: Task<Void, Never>?
     private var pendingNativeCommands: [DashboardNativeCommand] = []
@@ -520,6 +521,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     }
 
     private func retirePendingLoad() {
+        self.downloads.retire()
         self.loadGeneration &+= 1
         self.pendingLoad?.cancel()
         self.pendingLoad = nil
@@ -1105,6 +1107,10 @@ extension DashboardWindowController {
         Self.isTrustedLinkSource(self.webView.url, dashboardURL: self.currentURL)
     }
 
+    var canDownloadAttachments: Bool {
+        self.hasLiveContent && self.isTrustedDashboardDocument && self.hasCurrentBrowserSession
+    }
+
     private var canDispatchNativeCommands: Bool {
         // Older shared-credential Gateways predate the shell-ready signal.
         // Personal browser sign-in requires the current Control UI's listener-owned fact.
@@ -1383,6 +1389,10 @@ extension DashboardWindowController {
             decisionHandler(.cancel)
             return
         }
+        if navigationAction.shouldPerformDownload {
+            decisionHandler(self.downloads.admit(navigationAction) ? .download : .cancel)
+            return
+        }
         if navigationAction.targetFrame == nil {
             let allowEditorURLs = Self.shouldAllowEditorURLLaunch(
                 from: navigationAction.sourceFrame.request.url,
@@ -1445,11 +1455,24 @@ extension DashboardWindowController {
         }
     }
 
+    func webView(
+        _ webView: WKWebView,
+        navigationAction: WKNavigationAction,
+        didBecome download: WKDownload)
+    {
+        guard webView === self.webView else {
+            download.cancel { _ in }
+            return
+        }
+        self.downloads.start(download, for: navigationAction)
+    }
+
     /// The displayed document is replaced at commit, not at provisional start.
     /// Clearing here covers page/WebKit-initiated main-frame navigations that
     /// never pass through `load(_:)`, so commands queue for the new document.
     func webView(_ webView: WKWebView, didCommit _: WKNavigation!) {
         guard webView === self.webView else { return }
+        self.downloads.retire()
         self.notificationSourceID = UUID().uuidString
         self.deviceSettingsMessageHandler.cancelRequests()
         self.hasLiveContent = false

--- a/apps/macos/Sources/OpenClaw/PermissionManager.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionManager.swift
@@ -30,7 +30,8 @@ enum PermissionManager {
     /// `swift build` dev binaries. Every notification-center call must check this
     /// first so unbundled invocations degrade to not-granted instead of crashing.
     static var notificationCenterAvailable: Bool {
-        Bundle.main.bundleIdentifier != nil
+        // Command-line executables can embed an identifier without an app bundle.
+        Bundle.main.bundleURL.pathExtension == "app" && Bundle.main.bundleIdentifier != nil
     }
 
     static func isNotificationAuthorized(status: UNAuthorizationStatus) -> Bool {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardDownloadTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardDownloadTests.swift
@@ -1,0 +1,146 @@
+import AppKit
+import Foundation
+import WebKit
+import XCTest
+@testable import OpenClaw
+
+/// XCTest pumps the AppKit run loop across sheet dismissal; Swift Testing's
+/// standalone async main exits when NSSavePanel stops that run loop.
+@MainActor
+final class DashboardDownloadTests: XCTestCase {
+    enum Source: String, CaseIterable, Sendable {
+        case http, blob, data
+    }
+
+    enum Retirement: CaseIterable {
+        case reload, close, replace
+    }
+
+    func testCancellingAttachmentsKeepsDashboardUsable() async throws {
+        for source in Source.allCases {
+            try await self.checkCancellation(source: source)
+        }
+    }
+
+    private func checkCancellation(source: Source) async throws {
+        try await self.withDownload(source: source) { controller, window, dashboardURL in
+            XCTAssertTrue(!controller.isShowingFailurePage)
+            let panel = try XCTUnwrap(window.sheets.compactMap { $0 as? NSSavePanel }.first)
+            panel.cancel(nil)
+            try await self.waitUntil("Save sheet dismissed") { !window.sheets.contains(panel) }
+            XCTAssertTrue(controller.webView.url == dashboardURL)
+            XCTAssertTrue(!controller.isShowingFailurePage)
+            let documentIntact = try await controller.webView.evaluateJavaScript(
+                "document.getElementById('attachment') !== null") as? Bool
+            XCTAssertEqual(documentIntact, true)
+        }
+    }
+
+    func testRetiringDashboardDismissesPendingSavePanel() async throws {
+        for retirement in Retirement.allCases {
+            try await self.checkRetirement(retirement)
+        }
+    }
+
+    private func checkRetirement(_ retirement: Retirement) async throws {
+        try await self.withDownload { controller, window, _ in
+            let panel = try XCTUnwrap(window.sheets.compactMap { $0 as? NSSavePanel }.first)
+            switch retirement {
+            case .reload:
+                _ = controller.webView.reload()
+            case .close:
+                controller.closeDashboard()
+            case .replace:
+                XCTAssertTrue(controller.detachWindowForReplacement() === window)
+            }
+            try await self.waitUntil("retired Save sheet dismissed") { !window.sheets.contains(panel) }
+            XCTAssertTrue(!controller.isShowingFailurePage)
+        }
+    }
+
+    func testReplacingDashboardDismissesOldDownloadError() async throws {
+        try await self.withDownload(invalidResponse: true) { controller, window, _ in
+            XCTAssertTrue(!controller.isShowingFailurePage)
+            let failure = try XCTUnwrap(window.sheets.first)
+            XCTAssertTrue(!(failure is NSSavePanel))
+            XCTAssertTrue(controller.detachWindowForReplacement() === window)
+            try await self.waitUntil("retired download error dismissed") { !window.sheets.contains(failure) }
+        }
+    }
+
+    private func withDownload(
+        source: Source = .http,
+        invalidResponse: Bool = false,
+        body: @MainActor (DashboardWindowController, NSWindow, URL) async throws -> Void) async throws
+    {
+        _ = AppKitTestSupport.application
+        let payload = "attachment download fixture"
+        let filename = "attachment.docx"
+        let server = try await DashboardHTTPFixture.start(
+            html: """
+            <!doctype html><html><head></head><body>
+            <a id="attachment" href="/attachment?mediaTicket=fixture"
+               download="\(filename)" target="_blank" rel="noreferrer">Download</a>
+            </body></html>
+            """,
+            requestHandler: { request in
+                guard request.hasPrefix("GET /attachment?") else { return nil }
+                if invalidResponse { return "invalid HTTP response\r\n\r\n" }
+                return [
+                    "HTTP/1.1 200 OK",
+                    "Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    "Content-Disposition: attachment; filename=\(filename)",
+                    "Content-Length: \(payload.utf8.count)",
+                    "Connection: close",
+                    "",
+                    payload,
+                ].joined(separator: "\r\n")
+            })
+        defer { server.stop() }
+        let dashboardURL = server.url("/control/")
+        let controller = DashboardWindowController(
+            url: dashboardURL,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
+        controller.show(url: dashboardURL, auth: controller.auth)
+        let window = try XCTUnwrap(controller.window)
+        try await self.waitUntil("Dashboard document loaded") {
+            guard controller.webView.url == dashboardURL, !controller.webView.isLoading else { return false }
+            return try await controller.webView.evaluateJavaScript(
+                "document.getElementById('attachment') !== null") as? Bool == true
+        }
+        if source == .blob {
+            _ = try await controller.webView.evaluateJavaScript("""
+            document.getElementById('attachment').href = URL.createObjectURL(new Blob(
+              ['attachment download fixture'],
+              {type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'}));
+            null
+            """)
+        } else if source == .data {
+            _ = try await controller.webView.evaluateJavaScript("""
+            document.getElementById('attachment').href =
+              'data:application/octet-stream;base64,' + btoa('attachment download fixture');
+            null
+            """)
+        }
+        _ = try await controller.webView.evaluateJavaScript("document.getElementById('attachment').click(); null")
+        try await self.waitUntil("download response presented") {
+            controller.isShowingFailurePage || !window.sheets.isEmpty
+        }
+        defer { window.close() }
+        try await body(controller, window, dashboardURL)
+    }
+
+    private func waitUntil(_ description: String, _ condition: @MainActor () async throws -> Bool) async throws {
+        let deadline = ContinuousClock.now + .seconds(10)
+        while ContinuousClock.now < deadline {
+            if try await condition() { return }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        XCTFail("The Dashboard download did not reach: \(description)")
+        throw URLError(.timedOut)
+    }
+}

--- a/docs/platforms/mac/webchat.md
+++ b/docs/platforms/mac/webchat.md
@@ -136,6 +136,14 @@ for the intended Gateway. **Settings…** (Cmd-,) opens Dashboard settings;
 Dashboard window. **Connection…** remains native so you can repair connectivity
 without a working Dashboard.
 
+### Download attachments
+
+In an embedded Dashboard, choose an attachment's download action and select a
+destination in the macOS Save dialog. Finder reveals the file after the download
+finishes. Cancelling or failing a download leaves the Dashboard open; an existing
+destination file is replaced only after a successful transfer. Reloading the
+Dashboard, switching its Gateway, or closing its window cancels pending downloads.
+
 ## Quick Chat bar
 
 Press Option-Space (⌥Space) or choose **Quick Chat** from the menu bar menu to open a floating composer for the main session. Open **Dashboard → Settings → This Mac → App** to change the global shortcut in a native recorder panel, then choose **Done**.


### PR DESCRIPTION
Related: #139262

## What Problem This Solves

Fixes an issue where users downloading an attachment from the macOS Dashboard would see “Dashboard unavailable” instead of a save destination. HTTP and blob attachments reproduce the failure in the original Dashboard controller.

## Why This Change Was Made

The Dashboard now hands attachment downloads to WebKit's native download flow and presents a Save panel. A single owner binds downloads to the live Dashboard document and window, stages files until transfer completion, reuses Gateway TLS handling, and retires pending Save/error sheets when their document is replaced. Cancellation or failure keeps the Dashboard usable; completion reveals the saved file in Finder.

Also fixes the notification-availability check for command-line binaries carrying a bundle identifier, which otherwise call an app-only notification API and abort. There are no new settings, database changes, or dependencies.

## User Impact

Operators can save HTTP, blob, and data attachments from the native Dashboard. Closing, reloading, or replacing the Dashboard retires its download UI. The existing lightweight sidebar continues its browser handoff behavior.

## Evidence

- Before patch: real controller HTTP/blob attachment tests reproduce the failure page and missing Save panel.
- Isolated macOS VM, actual native Save UI: eight HTTP/blob/data/pinned-HTTPS Save/Cancel scenarios pass; saved bytes match the synthetic fixture. Inspectable before/after runtime output is included below.
- Retained XCTest regression: three methods pass with no failures, covering cancellation, reload/close/replacement, and retirement of failure sheets.
- Canonical changed checks, Swift formatting/lint, and native i18n verification pass.
- Independent autoreview through P2: scoped-clean, no findings.
- Broad Dashboard suite: baseline 112 tests/43 issues; candidate repeat 112/42. All 42 candidate issues match the baseline at the same test/argument/location. This suite remains failing; document-readiness failures are recorded as a separate follow-up. An initial extra cookie timeout passes separately on both binaries and in the candidate repeat.

The initial fixture was synthetic text named `.docx`, not a valid Office document; the new eight-scenario proof uses `.txt`. Native pinned HTTPS with a fixture ticket now passes. Reporter-specific reverse proxy, authenticated Gateway login/cookies, real media-ticket signing/validation, lease revocation, destination overwrite races, and retirement during an active transfer remain unverified end-to-end. The fixture ticket is an exact-match server check, and its synthetic Gateway token is not consumed: this is not authenticated remote-Gateway proof. These limits remain visible for review.

Production delta is +267/-1 (net +266); tests add 146 lines and docs add 8. Growth implements the missing native download/file-save lifecycle; no existing owner could absorb that capability.


## Inspectable native proof (review follow-up)

Production head remains `f93baeabf9f1f9de4bcbd206acfe08a631d39913`. The following output comes from an isolated macOS VM using the real `DashboardWindowController`, WebKit, native `NSSavePanel`, and Finder. It uses a diagnostic fixture page matching the production attachment anchor (`download`, `target=_blank`, `rel=noreferrer`), not the full chat/Gateway application.

The fixture programmatically activates the anchor; the UI driver physically clicks Save/Cancel and then Check Dashboard. Save verification reads the published file and compares every byte and SHA-256. Cancel verifies the destination stays absent both after dismissal and after the post-cancel click/capture. Every scenario keeps the same Dashboard URL, shows no failure page, and records actual clicks received by the page. `httpsTicket` uses the existing certificate fixture with its exact SHA-256 pin, `required=true`, `allowTOFU=false`, and no browser-session profile. HTTP(S) serves the attachment only for the exact fixture ticket and observes one request.

The eight scenarios run inside one diagnostic Swift Testing test; the retained regression suite separately has three XCTest methods. The diagnostic runner is not added to production or CI. Its binary SHA-256, verified identical in the guest, is `440e36aa54a9980305ba210c9ff4345c16a8f9ffa9d9d13d4b08d718fb73adc9`.

<details>
<summary>Before: original controller with the retained regression test fails (same command-line notification guard)</summary>

```text
Test Suite 'Selected tests' started at 2026-09-06 16:18:48.916.
Test Suite 'OpenClawPackageTests.xctest' started at 2026-09-06 16:18:48.922.
Test Suite 'DashboardDownloadTests' started at 2026-09-06 16:18:48.922.
Test Case '-[OpenClawIPCTests.DashboardDownloadTests testCancellingAttachmentsKeepsDashboardUsable]' started.
apps/macos/Tests/OpenClawIPCTests/DashboardDownloadTests.swift:27: error: -[OpenClawIPCTests.DashboardDownloadTests testCancellingAttachmentsKeepsDashboardUsable] : XCTAssertTrue failed
apps/macos/Tests/OpenClawIPCTests/DashboardDownloadTests.swift:28: error: -[OpenClawIPCTests.DashboardDownloadTests testCancellingAttachmentsKeepsDashboardUsable] : XCTUnwrap failed: expected non-nil value of type "NSSavePanel"
Test Case '-[OpenClawIPCTests.DashboardDownloadTests testCancellingAttachmentsKeepsDashboardUsable]' failed (5.201 seconds).
Test Suite 'DashboardDownloadTests' failed at 2026-09-06 16:18:54.124.
	 Executed 1 test, with 2 failures (0 unexpected) in 5.201 (5.202) seconds
Test Suite 'OpenClawPackageTests.xctest' failed at 2026-09-06 16:18:54.124.
	 Executed 1 test, with 2 failures (0 unexpected) in 5.201 (5.202) seconds
Test Suite 'Selected tests' failed at 2026-09-06 16:18:54.124.
	 Executed 1 test, with 2 failures (0 unexpected) in 5.201 (5.208) seconds
```

</details>

<details>
<summary>After: retained native regression suite, 3 tests / 0 failures</summary>

```text
Test Suite 'Selected tests' started at 2026-09-06 15:54:56.114.
Test Suite 'OpenClawPackageTests.xctest' started at 2026-09-06 15:54:56.120.
Test Suite 'DashboardDownloadTests' started at 2026-09-06 15:54:56.120.
Test Case '-[OpenClawIPCTests.DashboardDownloadTests testCancellingAttachmentsKeepsDashboardUsable]' started.
Test Case '-[OpenClawIPCTests.DashboardDownloadTests testCancellingAttachmentsKeepsDashboardUsable]' passed (11.804 seconds).
Test Case '-[OpenClawIPCTests.DashboardDownloadTests testReplacingDashboardDismissesOldDownloadError]' started.
Test Case '-[OpenClawIPCTests.DashboardDownloadTests testReplacingDashboardDismissesOldDownloadError]' passed (1.512 seconds).
Test Case '-[OpenClawIPCTests.DashboardDownloadTests testRetiringDashboardDismissesPendingSavePanel]' started.
Test Case '-[OpenClawIPCTests.DashboardDownloadTests testRetiringDashboardDismissesPendingSavePanel]' passed (4.322 seconds).
Test Suite 'DashboardDownloadTests' passed at 2026-09-06 15:55:13.762.
	 Executed 3 tests, with 0 failures (0 unexpected) in 17.638 (17.642) seconds
Test Suite 'OpenClawPackageTests.xctest' passed at 2026-09-06 15:55:13.762.
	 Executed 3 tests, with 0 failures (0 unexpected) in 17.638 (17.642) seconds
Test Suite 'Selected tests' passed at 2026-09-06 15:55:13.762.
	 Executed 3 tests, with 0 failures (0 unexpected) in 17.638 (17.648) seconds
```

</details>

<details>
<summary>After: eight native Save/Cancel scenarios, exact saved bytes, and Dashboard click results</summary>

```text
◇ Test run started.
↳ Testing Library Version: 1902
↳ Target Platform: arm64e-apple-macos14.0
◇ Suite DashboardDownloadReviewProof started.
◇ Test testNativeDownloadEvidence() started.
PROOF PANEL source=http action=cancel expectedBytes=27 expectedSHA256=5cd7bc95e283d9888c8f58d7f94716320f8beaee43430ac4c7d3d27dfa740469
PROOF CANCELLED source=http destinationExists=false
PROOF CHECK_DASHBOARD source=http action=cancel
PROOF USABLE source=http action=cancel sameDocument=true failurePage=false clickCount=1 ticketRequests=1
PROOF PANEL source=http action=save expectedBytes=27 expectedSHA256=5cd7bc95e283d9888c8f58d7f94716320f8beaee43430ac4c7d3d27dfa740469
PROOF SAVED source=http bytes=27 sha256=5cd7bc95e283d9888c8f58d7f94716320f8beaee43430ac4c7d3d27dfa740469 exactMatch=true
PROOF CHECK_DASHBOARD source=http action=save
PROOF USABLE source=http action=save sameDocument=true failurePage=false clickCount=1 ticketRequests=1
PROOF PANEL source=blob action=cancel expectedBytes=27 expectedSHA256=5cd7bc95e283d9888c8f58d7f94716320f8beaee43430ac4c7d3d27dfa740469
PROOF CANCELLED source=blob destinationExists=false
PROOF CHECK_DASHBOARD source=blob action=cancel
PROOF USABLE source=blob action=cancel sameDocument=true failurePage=false clickCount=1 ticketRequests=0
PROOF PANEL source=blob action=save expectedBytes=27 expectedSHA256=5cd7bc95e283d9888c8f58d7f94716320f8beaee43430ac4c7d3d27dfa740469
PROOF SAVED source=blob bytes=27 sha256=5cd7bc95e283d9888c8f58d7f94716320f8beaee43430ac4c7d3d27dfa740469 exactMatch=true
PROOF CHECK_DASHBOARD source=blob action=save
PROOF USABLE source=blob action=save sameDocument=true failurePage=false clickCount=2 ticketRequests=0
PROOF PANEL source=data action=cancel expectedBytes=27 expectedSHA256=5cd7bc95e283d9888c8f58d7f94716320f8beaee43430ac4c7d3d27dfa740469
PROOF CANCELLED source=data destinationExists=false
PROOF CHECK_DASHBOARD source=data action=cancel
PROOF USABLE source=data action=cancel sameDocument=true failurePage=false clickCount=1 ticketRequests=0
PROOF PANEL source=data action=save expectedBytes=27 expectedSHA256=5cd7bc95e283d9888c8f58d7f94716320f8beaee43430ac4c7d3d27dfa740469
PROOF SAVED source=data bytes=27 sha256=5cd7bc95e283d9888c8f58d7f94716320f8beaee43430ac4c7d3d27dfa740469 exactMatch=true
PROOF CHECK_DASHBOARD source=data action=save
PROOF USABLE source=data action=save sameDocument=true failurePage=false clickCount=1 ticketRequests=0
PROOF PANEL source=httpsTicket action=cancel expectedBytes=27 expectedSHA256=5cd7bc95e283d9888c8f58d7f94716320f8beaee43430ac4c7d3d27dfa740469
PROOF CANCELLED source=httpsTicket destinationExists=false
PROOF CHECK_DASHBOARD source=httpsTicket action=cancel
PROOF USABLE source=httpsTicket action=cancel sameDocument=true failurePage=false clickCount=1 ticketRequests=1
PROOF PANEL source=httpsTicket action=save expectedBytes=27 expectedSHA256=5cd7bc95e283d9888c8f58d7f94716320f8beaee43430ac4c7d3d27dfa740469
PROOF SAVED source=httpsTicket bytes=27 sha256=5cd7bc95e283d9888c8f58d7f94716320f8beaee43430ac4c7d3d27dfa740469 exactMatch=true
PROOF CHECK_DASHBOARD source=httpsTicket action=save
PROOF USABLE source=httpsTicket action=save sameDocument=true failurePage=false clickCount=2 ticketRequests=1
✔ Test testNativeDownloadEvidence() passed after 596.880 seconds.
✔ Suite DashboardDownloadReviewProof passed after 596.881 seconds.
✔ Test run with 1 test in 1 suite passed after 596.893 seconds.
```

</details>

### Remaining review scope

The requested runtime output is now directly inspectable above. Native screenshots of the Save panel, saved content, and post-cancel Dashboard were also captured and inspected locally, but GitHub's attachment upload returned HTTP 404 and the prescribed Crabbox uploader is unavailable in this environment; no public screenshot link is claimed. This records the remaining optional Rank-up media item explicitly.

The authenticated remote-Gateway risk remains open: the pinned HTTPS fixture narrows native transport coverage but does not reproduce the reporter's Gateway 2026.9.1 login, real signed media ticket, browser-profile cookies, or reverse proxy. No claim is made that the reporter-specific deployment is verified or that merge readiness is cleared.
