### PR TITLE
refactor(update): consolidate native profile tests

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -930,34 +930,20 @@ Write-Output "OPENCLAW_RESTART_POLICY_OK"
       await cleanupScript(scriptPath);
     });
 
-    it("uses custom profile in service names", async () => {
-      Object.defineProperty(process, "platform", { value: "linux" });
-      const { scriptPath, content } = await prepareAndReadScript({
-        OPENCLAW_PROFILE: "production",
-      });
-      expect(content).toContain("openclaw-gateway-production.service");
-      await cleanupScript(scriptPath);
-    });
-
-    it("uses custom profile in macOS launchd label", async () => {
-      Object.defineProperty(process, "platform", { value: "darwin" });
-      process.getuid = () => 502;
-
-      const { scriptPath, content } = await prepareAndReadScript({
-        OPENCLAW_PROFILE: "staging",
-      });
-      expect(content).toContain("gui/502/ai.openclaw.staging");
-      await cleanupScript(scriptPath);
-    });
-
-    it("uses custom profile in Windows task name", async () => {
-      Object.defineProperty(process, "platform", { value: "win32" });
-
-      const { scriptPath, content } = await prepareAndReadScript({
-        OPENCLAW_PROFILE: "production",
-      });
-      expect(content).toContain("$taskName = 'OpenClaw Gateway (production)'");
-      expectWindowsRestartWaitOrdering(content);
+    it.each([
+      ["linux", "production", "openclaw-gateway-production.service"],
+      ["darwin", "staging", "gui/502/ai.openclaw.staging"],
+      ["win32", "production", "$taskName = 'OpenClaw Gateway (production)'"],
+    ])("uses the %s service identity for profile %s", async (platform, profile, expected) => {
+      Object.defineProperty(process, "platform", { value: platform });
+      if (platform === "darwin") {
+        process.getuid = () => 502;
+      }
+      const { scriptPath, content } = await prepareAndReadScript({ OPENCLAW_PROFILE: profile });
+      expect(content).toContain(expected);
+      if (platform === "win32") {
+        expectWindowsRestartWaitOrdering(content);
+      }
       await cleanupScript(scriptPath);
     });
 


### PR DESCRIPTION
## What Problem This Solves

The update restart-helper suite repeated platform selection, script generation and cleanup for three variants of the same native profile-name contract. This test-debt follow-up to the #135868 split consolidates that setup without dropping a scenario.

## Why This Change Was Made

A three-row table retains the original platform order and exact profile names and expected service identifiers. Each row still runs the existing per-test reset and cleanup hooks.

Every removal retains coverage in `src/cli/update-cli/restart-helper.test.ts`:

| Replaced test body | Surviving coverage |
|---|---|
| Linux custom-profile service name | Literal Linux/production row at `:934`, generated script assertion at `:943`. |
| macOS custom-profile launchd label | Literal Darwin/staging row at `:935`, the same UID 502 assignment at `:940`, and assertion at `:943`. |
| Windows custom-profile task name | Literal Windows/production row at `:936`, assertion at `:943`, and the unchanged full wait/ownership ordering helper call at `:945`. |
| Repeated platform setup and script cleanup | Common per-row setup at `:938`, generation at `:942`, and cleanup at `:947`; existing afterEach restoration remains unchanged. |

## User Impact

No production or user-visible change. All service identity expectations, Windows ordering assertions, live shell/process proofs, and PowerShell policy cases are preserved.

## Evidence

- Full restart-helper suite: 53 tests passed, one existing skip; no new skip or removed case.
- Full `node scripts/check-changed.mjs` passed.
- Independent Codex review: scoped-clean, no actionable P0–P2 findings.
- Tests/support: +14 / −28 = **−14 lines**. Production, tooling and docs unchanged.
- Rebase preserved the test file byte-for-byte and left the lockfile unchanged.

ClawSweeper reviewed the exact head and found no actionable findings or before-merge requests; there are no rank-up changes to apply. Exact-head CI run 34045750621 is green.
