### PR TITLE
test(openai): keep RTC offer smoke offline and plugin-scoped

### DIFF
--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { openAIRealtimeHost } from "./realtime-host.js";
 import {
@@ -518,9 +519,19 @@ describe("GPT-Live werift audio peer", () => {
       "bun",
       [
         "--eval",
-        'const { RTCPeerConnection, useOPUS } = await import("werift"); const peer = new RTCPeerConnection({ codecs: { audio: [useOPUS({ payloadType: 111 })], video: [] }, iceServers: [] }); peer.addTransceiver("audio", { direction: "sendrecv" }); const offer = await peer.createOffer(); await peer.setLocalDescription(offer); const sdp = peer.localDescription?.sdp ?? ""; if (!sdp.includes("a=sendrecv") || !sdp.includes("OPUS/48000/2")) throw new Error("invalid offer"); await peer.close();',
+        `const { RTCPeerConnection, useOPUS } = await import("werift");
+const peer = new RTCPeerConnection({ codecs: { audio: [useOPUS({ payloadType: 111 })], video: [] }, iceServers: [] });
+try {
+  peer.addTransceiver("audio", { direction: "sendrecv" });
+  const offer = await peer.createOffer();
+  const sdp = offer.sdp ?? "";
+  if (!sdp.includes("a=sendrecv") || !sdp.includes("OPUS/48000/2")) throw new Error("invalid offer");
+  if (peer.iceGatheringState !== "new") throw new Error("offer construction started ICE gathering");
+} finally {
+  await peer.close();
+}`,
       ],
-      { cwd: process.cwd(), encoding: "utf8", timeout: 30_000 },
+      { cwd: fileURLToPath(new URL(".", import.meta.url)), encoding: "utf8", timeout: 30_000 },
     );
     expect(result.stderr).toBe("");
     expect(result.status).toBe(0);


### PR DESCRIPTION
## What Problem This Solves

The offline RTC offer smoke launches its Bun child from the repository root, where the plugin-owned werift dependency is not available. It also sets the local description even though that starts ICE gathering and is unnecessary for inspecting the offer.

## Why This Change Was Made

Run the child from the plugin directory and inspect createOffer().sdp directly. Keep the send/receive, OPUS, stderr, and exit-status assertions, assert that ICE gathering remains unstarted, and always close the peer in finally.

## User Impact

One test file changes. Production RTC behavior, dependencies, and timeouts are unchanged; the selected smoke now follows its existing offline-offer contract.

## Evidence

- The retained original report records the missing plugin dependency failure.
- One existing offline case passed with both Node and Bun test runners. It launches a real Bun child in both runs; 29 other cases were unselected locally.
- Complete changed-file checks and fresh independent P0–P2 review passed; formatting and diff checks are clean.
- No network gathering or broader RTC/session tests were run locally. Hosted CI is tracked separately.
