### PR TITLE
fix(discord): preserve fenced code after marker lines with trailing text

### DIFF
--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -275,6 +275,32 @@ describe("chunkDiscordText", () => {
     expect(expectDefined(chunks[1], "second Discord chunk").trimStart().startsWith("_")).toBe(true);
   });
 
+  it.each([
+    ["Reasoning:", "_hello_", "emphasis"],
+    ["Thinking...", "_hello_", "emphasis"],
+    ["Reasoning:", "__hello__", "strong"],
+    ["Thinking...", "__hello__", "strong"],
+  ])(
+    "restores %s %s formatting when trailing blank lines leave one chunk",
+    (prefix, wrapped, type) => {
+      const chunks = chunkDiscordText(`${prefix}\n${wrapped}${"\n".repeat(17)}`);
+      expect(chunks).toHaveLength(1);
+      const nodes = fromMarkdown(chunks[0] ?? "").children;
+      expect(nodes).toEqual([
+        expect.objectContaining({
+          type: "paragraph",
+          children: [
+            expect.objectContaining({ type: "text", value: `${prefix}\n` }),
+            expect.objectContaining({
+              type,
+              children: [expect.objectContaining({ type: "text", value: "hello" })],
+            }),
+          ],
+        }),
+      ]);
+    },
+  );
+
   it("keeps reasoning italic markers outside synthetic closing fences", () => {
     const body = Array.from({ length: 12 }, (_, i) => `code-${i}`).join("\n");
     const chunks = chunkDiscordText(`Reasoning:\n_Intro\n\`\`\`txt\n${body}\n\`\`\`_`, {

--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -116,9 +116,41 @@ describe("chunkDiscordText", () => {
     }
   });
 
-  it("keeps chunks within maxChars when a closing fence line carries trailing text", () => {
-    // A line that both closes the fence and carries a long tail must still reserve closing-fence
-    // space; otherwise a mid-line flush appended "```" and overflowed maxChars (e.g. 2004 > 2000).
+  it.each([
+    { marker: "```", suffix: "not-a-close", indent: "", newline: "\n", closing: "```" },
+    { marker: "~~~", suffix: "not-a-close", indent: "", newline: "\n", closing: "~~~~" },
+    { marker: "```", suffix: " not a close", indent: "   ", newline: "\n", closing: "``` \t" },
+    { marker: "```", suffix: "\u00a0", indent: "", newline: "\n", closing: "````" },
+    { marker: "~~~", suffix: "\u00a0", indent: "  ", newline: "\r\n", closing: "~~~\t " },
+    { marker: "```", suffix: "not-a-close", indent: "", newline: "\r\n", closing: "``` \t" },
+  ])(
+    "keeps trailing-text fence lines inside code: %j",
+    ({ marker, suffix, indent, newline, closing }) => {
+      const body = [
+        "before",
+        `${indent}${marker}${suffix}`,
+        ...Array.from({ length: 14 }, (_, i) => `# code-${i}`),
+      ];
+      const text = [`${indent}${marker}txt`, ...body, `${indent}${closing}`, "After"].join(newline);
+      const expected = fromMarkdown(text).children;
+      for (const chunkMode of ["length", "newline"] as const) {
+        const chunks = chunkDiscordTextWithMode(text, { chunkMode });
+        const nodes = chunks.flatMap((chunk) => fromMarkdown(chunk).children);
+        const blocks = nodes.filter((node) => node.type === "code");
+        expect(chunks.length).toBeGreaterThan(1);
+        expect(blocks.map((node) => node.value.replaceAll("\r\n", "\n")).join("\n")).toBe(
+          expected[0]?.type === "code" ? expected[0].value.replaceAll("\r\n", "\n") : undefined,
+        );
+        expect(nodes.filter((node) => node.type !== "code")).toMatchObject([
+          { type: "paragraph", children: [{ type: "text", value: "After" }] },
+        ]);
+        expect(chunks.every((chunk) => chunk.length <= 2000 && countLines(chunk) <= 17)).toBe(true);
+      }
+    },
+  );
+
+  it("keeps chunks within maxChars when a code-content fence line carries trailing text", () => {
+    // Trailing text leaves the block open, so a mid-line flush must reserve its synthetic closer.
     for (let pad = 1990; pad <= 2000; pad++) {
       const text = "hi\n```lang\n```" + "z".repeat(pad);
       for (const chunk of chunkDiscordText(text, { maxChars: 2000, maxLines: 100 })) {
@@ -241,6 +273,20 @@ describe("chunkDiscordText", () => {
     expect(expectDefined(chunks[0], "first Discord chunk")).toContain("_1. line");
     // Second chunk should reopen italics at the start
     expect(expectDefined(chunks[1], "second Discord chunk").trimStart().startsWith("_")).toBe(true);
+  });
+
+  it("keeps reasoning italic markers outside synthetic closing fences", () => {
+    const body = Array.from({ length: 12 }, (_, i) => `code-${i}`).join("\n");
+    const chunks = chunkDiscordText(`Reasoning:\n_Intro\n\`\`\`txt\n${body}\n\`\`\`_`, {
+      maxLines: 6,
+      maxChars: 50,
+    });
+    const blocks = chunks
+      .flatMap((chunk) => fromMarkdown(chunk).children)
+      .filter((node) => node.type === "code");
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(blocks.map((node) => node.value).join("\n")).toBe(body);
+    expect(chunks.every((chunk) => chunk.length <= 50)).toBe(true);
   });
 
   it("keeps reasoning italics balanced when chunks split by char limit", () => {
@@ -380,6 +426,11 @@ describe("chunkDiscordText", () => {
     ],
     ["inline code across a blank line", ["`one", "", "two`", "more"], "`one\n\ntwo`\n_more_"],
     ["a CRLF code fence", ["```ts\r", "body\r", "```\r", "more"], "```ts\r\nbody\r\n```\r\n_more_"],
+    [
+      "a CRLF tilde fence",
+      ["~~~ts\r", "body\r", "~~~\r", "more"],
+      "~~~ts\r\nbody\r\n~~~\r\n_more_",
+    ],
     [
       "consecutive leading code spans",
       ["```js", "one()", "```", "~~~sh", "two", "~~~", "more reasoning"],

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -27,9 +27,9 @@ type OpenFence = {
 
 const DEFAULT_MAX_CHARS = 2000;
 const DEFAULT_MAX_LINES = 17;
-const REASONING_ITALICS_MARKER_CHARS = 2;
+const REASONING_ITALICS_MARKER_CHARS = 3;
 const MIN_REASONING_ITALICS_CHUNK_CHARS = 4;
-const FENCE_RE = /^( {0,3})(`{3,}|~{3,})(.*)$/;
+const FENCE_RE = /^( {0,3})(`{3,}|~{3,})(.*)\r?$/;
 
 function hasReasoningItalics(text: string): boolean {
   return /^(?:Reasoning:|Thinking\.{0,3})\n+_/u.test(text) && text.trimEnd().endsWith("_");
@@ -50,11 +50,11 @@ function countLines(text: string) {
   return count;
 }
 
-// Keep Discord's existing fence grammar. Tiny caps retain original source when a synthetic
+// Tiny caps retain original source when a synthetic
 // marker pair cannot fit; otherwise drop an oversized language hint only on continuation fences.
 function parseFenceLine(line: string, maxChars = Number.POSITIVE_INFINITY): OpenFence | null {
   const match = line.match(FENCE_RE);
-  if (!match) {
+  if (!match || (match[2]?.startsWith("`") && match[3]?.includes("`"))) {
     return null;
   }
   const marker = match[2] ?? "";
@@ -64,24 +64,25 @@ function parseFenceLine(line: string, maxChars = Number.POSITIVE_INFINITY): Open
   return { marker, closeLine, reopenLine: canBalance ? reopenLine : null };
 }
 
-function closesFence(open: OpenFence, close: OpenFence): boolean {
-  return open.marker[0] === close.marker[0] && close.marker.length >= open.marker.length;
+function closesFence(open: OpenFence, line: string): boolean {
+  return new RegExp(`^ {0,3}${open.marker[0]}{${open.marker.length},}[ \\t]*\\r?$`).test(line);
 }
 
 type DiscordFrame = { start: number; end: number };
-function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}): string[] {
+function chunkDiscordText(source: string, opts: ChunkDiscordTextOpts = {}): string[] {
   const hardMaxChars = resolveDiscordChunkLimit(opts.maxChars, DEFAULT_MAX_CHARS);
   const maxLines = resolveDiscordChunkLimit(opts.maxLines, DEFAULT_MAX_LINES);
-  if (!text) {
+  if (!source) {
     return [];
   }
-  if (text.length <= hardMaxChars && countLines(text) <= maxLines) {
-    return [text];
+  if (source.length <= hardMaxChars && countLines(source) <= maxLines) {
+    return [source];
   }
-  const maxChars =
-    hardMaxChars >= MIN_REASONING_ITALICS_CHUNK_CHARS && hasReasoningItalics(text)
-      ? hardMaxChars - REASONING_ITALICS_MARKER_CHARS
-      : hardMaxChars;
+  const reasoning =
+    hardMaxChars >= MIN_REASONING_ITALICS_CHUNK_CHARS && hasReasoningItalics(source);
+  // The outer reasoning italic marker is presentation, not a suffix on the final code fence.
+  const text = reasoning ? source.replace(/_(\s*)$/, "$1") : source;
+  const maxChars = reasoning ? hardMaxChars - REASONING_ITALICS_MARKER_CHARS : hardMaxChars;
   const ranges = createDiscordRanges(text, maxChars, maxLines);
   const chunks: string[] = [];
   let current: DiscordFrame | undefined;
@@ -189,7 +190,7 @@ function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}): string
   while (current) {
     current = flush(current);
   }
-  return rebalanceReasoningItalics(text, chunks, hardMaxChars);
+  return rebalanceReasoningItalics(source, chunks, hardMaxChars);
 }
 
 export function chunkDiscordTextWithMode(
@@ -223,10 +224,10 @@ function leadingCodePrefixEnd(body: string): number {
     if (!marker) {
       return prefixEnd;
     }
-    // Fence continuations keep the legacy close rule; inline runs must match exactly,
+    // Fence closers allow only spaces/tabs after the marker; inline runs must match exactly,
     // including spans across CRLF or blank lines that CommonMark treats as blocks.
     const pattern = fence
-      ? `\\n( {0,3}${marker[0]}{${marker.length},} *)(?=[\\t ]*_?[\\t ]*(?:\\n|$))`
+      ? `\\n( {0,3}${marker[0]}{${marker.length},} *)(?=[\\t ]*_?[\\t ]*\\r?(?:\\n|$))`
       : "(?<!`)`{" + marker.length + "}(?!`)";
     const delimiter = new RegExp(pattern, "g");
     delimiter.lastIndex = fence ? 0 : marker.length;
@@ -274,7 +275,8 @@ function rebalanceReasoningItalics(source: string, chunks: string[], maxChars: n
       !body.trimEnd().endsWith("_") &&
       /^(?:_|(?:Reasoning:|Thinking\.{0,3})\n+_)/u.test(body.trimStart())
     ) {
-      body += "_";
+      // A closing italic marker must not turn a generated fence closer into code content.
+      body += parseFenceLine(body.split("\n").at(-1) ?? "") ? "\n_" : "_";
     }
     return prefix + body;
   });
@@ -320,7 +322,7 @@ type FenceRange = DiscordFrame &
     bodyStart: number;
     closeStart: number;
   };
-// Inline spans are collected only between Discord fences, using the existing close grammar.
+// Inline spans are collected only between Discord fences, never after a false closing marker.
 function createDiscordRanges(source: string, maxChars: number, maxLines: number) {
   const spans: InlineSpan[] = [];
   const fences: FenceRange[] = [];
@@ -373,7 +375,7 @@ function createDiscordRanges(source: string, maxChars: number, maxLines: number)
         ...info,
       };
       fences.push(fence);
-    } else if (info && fence && closesFence(fence, info)) {
+    } else if (info && fence && closesFence(fence, line)) {
       fence.closeStart = offset;
       fence.end = offset + line.length;
       fence = undefined;

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -249,11 +249,9 @@ function leadingCodePrefixEnd(body: string): number {
 // When Discord chunking splits the message, we close italics at the end of
 // each chunk and reopen at the start of the next. Code-leading continuations reopen after code.
 function rebalanceReasoningItalics(source: string, chunks: string[], maxChars: number): string[] {
-  if (
-    chunks.length <= 1 ||
-    maxChars < MIN_REASONING_ITALICS_CHUNK_CHARS ||
-    !hasReasoningItalics(source)
-  ) {
+  // Whitespace-only chunks may be discarded after the outer delimiter was removed.
+  // Restore it even when splitting leaves just one nonempty message.
+  if (maxChars < MIN_REASONING_ITALICS_CHUNK_CHARS || !hasReasoningItalics(source)) {
     return chunks;
   }
   return chunks.map((chunk, index) => {
@@ -271,12 +269,15 @@ function rebalanceReasoningItalics(source: string, chunks: string[], maxChars: n
         body = `${body.slice(0, body.length - content.length)}_${content}`;
       }
     }
+    // The final source delimiter was removed before splitting, even if content ends in `_`.
     if (
-      !body.trimEnd().endsWith("_") &&
+      (index === chunks.length - 1 || !body.trimEnd().endsWith("_")) &&
       /^(?:_|(?:Reasoning:|Thinking\.{0,3})\n+_)/u.test(body.trimStart())
     ) {
       // A closing italic marker must not turn a generated fence closer into code content.
-      body += parseFenceLine(body.split("\n").at(-1) ?? "") ? "\n_" : "_";
+      const content = body.trimEnd();
+      const closing = parseFenceLine(content.split("\n").at(-1) ?? "") ? "\n_" : "_";
+      body = content + closing + body.slice(content.length);
     }
     return prefix + body;
   });

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -5,6 +5,7 @@ import {
   Routes,
   type APIMessageTopLevelComponent,
 } from "discord-api-types/v10";
+import { fromMarkdown } from "mdast-util-from-markdown";
 // Discord tests cover send.sends basic channel messages plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -216,6 +217,34 @@ describe("resolveDiscordTargetChannelId", () => {
 });
 
 describe("sendMessageDiscord", () => {
+  it("keeps false closing fences inside code in channel HTTP payloads", async () => {
+    const loopback = await createDiscordLoopbackRest();
+    const body = [
+      "before",
+      "```not-a-close",
+      ...Array.from({ length: 14 }, (_, i) => `# code-${i}`),
+    ].join("\n");
+    try {
+      await sendMessageDiscord("channel:789", `\`\`\`txt\n${body}\n\`\`\``, {
+        rest: loopback.rest,
+        token: "t",
+        cfg: DISCORD_TEST_CFG,
+      });
+      const contents = loopback.requests
+        .filter((request) => request.method === "POST")
+        .map((request) => (JSON.parse(request.body) as { content: string }).content);
+      const nodes = contents.flatMap((content) => fromMarkdown(content).children);
+      expect(contents.length).toBeGreaterThan(1);
+      expect(contents.every((content) => content.length <= 2000)).toBe(true);
+      expect(nodes.every((node) => node.type === "code")).toBe(true);
+      expect(nodes.flatMap((node) => (node.type === "code" ? [node.value] : [])).join("\n")).toBe(
+        body,
+      );
+    } finally {
+      await loopback.close();
+    }
+  });
+
   it("keeps missing platform identity ambiguous in progress and final results", async () => {
     const { rest, postMock, getMock } = makeDiscordRest();
     getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });

--- a/extensions/discord/src/send.webhook.chunk-limit.test.ts
+++ b/extensions/discord/src/send.webhook.chunk-limit.test.ts
@@ -1,3 +1,4 @@
+import { fromMarkdown } from "mdast-util-from-markdown";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { withServer } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -68,6 +69,37 @@ describe("Discord webhook delivery", () => {
     resetDiscordOutboundMocks(hoisted);
     hoisted.sendWebhookMessageDiscordMock.mockImplementation((...args) =>
       realWebhookSend(...(args as Parameters<typeof realWebhookSend>)),
+    );
+  });
+
+  it("keeps false closing fences inside code in webhook HTTP payloads", async () => {
+    const body = [
+      "before",
+      "```not-a-close",
+      ...Array.from({ length: 30 }, (_, i) => `# code-${i} ${"x".repeat(100)}`),
+    ].join("\n");
+    await withWebhookServer(
+      (_content, index) => ({ body: { id: String(index), channel_id: "thread-1" } }),
+      async (contents) => {
+        await realWebhookSend(`\`\`\`txt\n${body}\n\`\`\``, {
+          cfg,
+          webhookId: "123",
+          webhookToken: "test-token",
+          threadId: "thread-1",
+          wait: true,
+        });
+        const nodes = contents.flatMap((content) => fromMarkdown(content).children);
+        expect(contents.length).toBeGreaterThan(1);
+        expect(contents.every((content) => content.length <= 2000)).toBe(true);
+        expect(nodes.every((node) => node.type === "code")).toBe(true);
+        // Character-limited chunks can split a code line, adding a display newline on reassembly.
+        expect(
+          nodes
+            .flatMap((node) => (node.type === "code" ? [node.value] : []))
+            .join("")
+            .replaceAll("\n", ""),
+        ).toBe(body.replaceAll("\n", ""));
+      },
     );
   });
 


### PR DESCRIPTION
Closes #127656

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled.

</details>

## What Problem This Solves

Fixes an issue where users receiving long Discord code blocks would see later code rendered as prose when the block contained a fence-like line with trailing text, such as ` ```not-a-close`. The same defect affects ordinary channel messages and webhook replies.

## Why This Change Was Made

Discord's chunker closed a block after checking only the fence marker and its length. Its closing rule now matches the existing shared Markdown contract: the marker must match, be at least as long as the opener, and have only spaces or tabs after it. CRLF fence lines are recognized, while backtick-containing info strings are not misclassified as block openers. The outer reasoning italic marker is separated before scanning, and generated closing italics are placed on a separate line after code fences with space reserved in the transport budget.

The repair stays in the Discord chunk owner; no SDK, dependency, or configuration changes. Separating the existing reasoning wrapper preserves its formatting contract while enforcing actual fence endings. Wrapper restoration also runs when only one nonempty message survives, placing the closing delimiter before trailing whitespace.

## User Impact

Code remains fenced across Discord message boundaries, including code that looks like a Markdown heading. Actual closing fences still return following text to prose, and outgoing messages remain within the transport limit.

## Evidence

- September 12 integration: rebased onto main `366335ad9cd6`, preserving the allocation improvements from #142447 and all upstream webhook tests. The only manual conflict joined independent test additions; `git range-diff` confirms unchanged repair logic. **237 tests passed across four suites**, covering chunking, ordinary sends, webhooks, and native-command replies. Targeted formatting, typed lint, `git diff --check`, and a fresh independent branch review passed for the rebased candidate `e211bb56f01b`. [GitHub CI passed on this head](https://github.com/openclaw/openclaw/actions/runs/34673184167).

- Before the repair: the three affected suites reported **9 failed, 193 passed**. The new failures cover false closers, CRLF, channel HTTP payloads, and webhook HTTP payloads.
- At the previously reviewed head `8a07c53835eb`: three suites reported **207 passed** under Vitest 5.0.0, including an additional regression for reasoning markers after synthetic closing fences. The tests use `mdast-util-from-markdown` as an independent semantic oracle and capture requests through local HTTP servers using the real Discord send paths.
- Review follow-up: the single-surviving-chunk regression failed for both `Reasoning:` and `Thinking...` before correction (**2 failed, 103 passed** in the chunk suite). Both now parse as actual emphasis, including when trailing blank lines are discarded. A further pair of cases for `__hello__` also failed before correction (**2 failed, 105 passed**) and now preserve strong emphasis rather than losing a content-adjacent underscore. The final 207-test run covers this correction.
- The initial repair passed full Discord plugin validation with isolated fork workers: **246 files, 3,343 tests passed**. A subsequent review found the synthetic-fence reasoning edge case; its new test failed before correction, and the final focused run above includes the correction. The default worker run previously exited unexpectedly after 2,812 passing tests; the isolated rerun completed without failures.
- Before the September 12 rebase, changed-scope formatting, lint, production/test typechecks, plugin boundaries, dead-export checks, and runtime import-cycle checks passed; that head also passed [GitHub CI](https://github.com/openclaw/openclaw/actions/runs/34071825635).
- Independent `autoreview --mode branch --base origin/main --max-priority P2`: **scoped-clean**, with no actionable findings.

```sh
node scripts/run-vitest.mjs extensions/discord/src/chunk.test.ts extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/send.webhook.chunk-limit.test.ts extensions/discord/src/monitor/native-command-reply.test.ts
pnpm test:extension discord --pool=forks --isolate --maxWorkers=1
node scripts/check-changed.mjs -- extensions/discord/src/chunk.ts extensions/discord/src/chunk.test.ts extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/send.webhook.chunk-limit.test.ts
git diff --check
```

Validation used Node 24.19.0 on macOS arm64. Live Discord client screenshots were not captured: this environment has no dedicated test bot/channel credentials. Local HTTP payload evidence does not claim a live Discord round trip.

Related follow-up: the shared `hasBalancedFences` test helper still uses the old marker-only closing rule. These regressions deliberately use the independent Markdown parser instead of that helper.


