### PR TITLE
refactor(agents): retire legacy tool execution argument decoding

### DIFF
--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -9,6 +9,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import type { AgentTool } from "openclaw/plugin-sdk/agent-core";
 import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
+import { withTestTimeout } from "../../test/helpers/promise.js";
 import {
   createClientToolNameConflictError,
   findClientToolNameConflicts,
@@ -19,6 +20,7 @@ import {
 import { wrapToolWithBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
 import { createExecTool } from "./bash-tools.exec-run.js";
 import type { ClientToolDefinition } from "./embedded-agent-runner/run/params.js";
+import { wrapToolDefinition } from "./sessions/tools/tool-definition-wrapper.js";
 
 type ToolExecute = ReturnType<typeof toToolDefinitions>[number]["execute"];
 const extensionContext = {} as Parameters<ToolExecute>[4];
@@ -53,6 +55,73 @@ async function executeTool(tool: AgentTool, callId: string) {
 }
 
 describe("agent tool definition adapter", () => {
+  it.each(["direct", "wrapped", "composed"] as const)(
+    "preserves signal and update identity through %s execution",
+    async (route) => {
+      const caller = new AbortController();
+      const run = new AbortController();
+      const partial = {
+        content: [{ type: "text" as const, text: "partial receipt" }],
+        details: {},
+      };
+      const result = { content: [{ type: "text" as const, text: "final receipt" }], details: {} };
+      const onUpdate = vi.fn();
+      const execute = vi.fn<AgentTool["execute"]>(async (_id, _args, _signal, update) => {
+        update?.(partial);
+        return result;
+      });
+      const [definition] = toToolDefinitions(
+        [
+          {
+            name: "receipt",
+            label: "Receipt",
+            description: "Receipt",
+            parameters: Type.Object({}),
+            execute,
+          },
+        ],
+        undefined,
+        route === "composed" ? run.signal : undefined,
+      );
+      const def = expectDefined(definition, "receipt definition");
+      const invoke = (id: string) =>
+        route === "wrapped"
+          ? wrapToolDefinition(def).execute(id, {}, caller.signal, onUpdate)
+          : def.execute(id, {}, caller.signal, onUpdate, extensionContext);
+
+      try {
+        expect(await withTestTimeout(invoke("receipt-call"), 2_000, "receipt did not settle")).toBe(
+          result,
+        );
+        expect(execute).toHaveBeenCalledOnce();
+        const call = expectDefined(execute.mock.calls[0], "receipt invocation");
+        expect(call[0]).toBe("receipt-call");
+        expect(call[1]).toEqual({});
+        expect(call[3]).toBe(onUpdate);
+        expect(onUpdate).toHaveBeenCalledExactlyOnceWith(partial);
+        expect(onUpdate.mock.calls[0]?.[0]).toBe(partial);
+        if (route === "composed") {
+          expect(call[2]).not.toBe(caller.signal);
+          expect(call[2]).not.toBe(run.signal);
+        } else {
+          expect(call[2]).toBe(caller.signal);
+        }
+
+        const reason = new Error("operator cancelled receipt");
+        (route === "composed" ? run : caller).abort(reason);
+        expect(call[2]?.aborted).toBe(true);
+        expect(call[2]?.reason).toBe(reason);
+        await expect(
+          withTestTimeout(invoke("cancelled-receipt"), 2_000, "cancelled receipt did not settle"),
+        ).rejects.toBe(reason);
+        expect(execute).toHaveBeenCalledOnce();
+      } finally {
+        caller.abort();
+        run.abort();
+      }
+    },
+    10_000,
+  );
   it("preserves argument preparation and execution mode contracts", () => {
     const prepareArguments = vi.fn((args: unknown) => args as Record<string, never>);
     const tool = {

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -32,7 +32,7 @@ import {
 } from "./code-mode-control-tools.js";
 import { sanitizeForConsole } from "./console-sanitize.js";
 import type { ClientToolDefinition } from "./embedded-agent-runner/run/params.js";
-import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "./runtime/index.js";
+import type { AgentTool, AgentToolResult } from "./runtime/index.js";
 import {
   attachInternalToolExecutionPreparer,
   getInternalToolExecutionPreparer,
@@ -43,24 +43,7 @@ import { jsonResult, payloadTextResult, ToolInputError } from "./tools/common.js
 
 type AnyAgentTool = AgentTool;
 
-type ToolExecuteArgsCurrent = [
-  string,
-  unknown,
-  AbortSignal | undefined,
-  AgentToolUpdateCallback | undefined,
-  unknown,
-];
-type ToolExecuteArgsLegacy = [
-  string,
-  unknown,
-  AgentToolUpdateCallback | undefined,
-  unknown,
-  AbortSignal | undefined,
-];
-type ToolExecuteArgs = ToolDefinition["execute"] extends (...args: infer P) => unknown
-  ? P
-  : ToolExecuteArgsCurrent;
-type ToolExecuteArgsAny = ToolExecuteArgs | ToolExecuteArgsLegacy | ToolExecuteArgsCurrent;
+type ToolExecuteArgs = Parameters<ToolDefinition["execute"]>;
 const TOOL_ERROR_PARAM_PREVIEW_MAX_CHARS = 600;
 const TOOL_ERROR_EXEC_COMMAND_HASH_CHARS = 16;
 const SENSITIVE_EXEC_ENV_VALUE = "[omitted exec env value]";
@@ -73,19 +56,6 @@ type ClientToolCallRecorder =
       complete: (toolCallId: string, toolName: string, params: Record<string, unknown>) => void;
       discard?: (toolCallId: string, toolName: string) => void;
     };
-
-function isAbortSignal(value: unknown): value is AbortSignal {
-  return typeof value === "object" && value !== null && "aborted" in value;
-}
-
-function isLegacyToolExecuteArgs(args: ToolExecuteArgsAny): args is ToolExecuteArgsLegacy {
-  const third = args[2];
-  const fifth = args[4];
-  if (typeof third === "function") {
-    return true;
-  }
-  return isAbortSignal(fifth);
-}
 
 function describeToolExecutionError(err: unknown): {
   message: string;
@@ -307,30 +277,6 @@ async function executeAdaptedToolOperation(params: {
   }
 }
 
-function splitToolExecuteArgs(args: ToolExecuteArgsAny): {
-  toolCallId: string;
-  params: unknown;
-  onUpdate: AgentToolUpdateCallback | undefined;
-  signal: AbortSignal | undefined;
-} {
-  if (isLegacyToolExecuteArgs(args)) {
-    const [toolCallId, params, onUpdate, _ctx, signal] = args;
-    return {
-      toolCallId,
-      params,
-      onUpdate,
-      signal,
-    };
-  }
-  const [toolCallId, params, signal, onUpdate] = args;
-  return {
-    toolCallId,
-    params,
-    onUpdate,
-    signal,
-  };
-}
-
 function attachAdapterExecutionPreparer<T extends ToolDefinition>(definition: T): T {
   return attachInternalToolExecutionPreparer(
     definition,
@@ -418,7 +364,7 @@ export function toToolDefinitions(
       prepareArguments: tool.prepareArguments,
       executionMode: tool.executionMode,
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
-        const { toolCallId, params, onUpdate, signal: callSignal } = splitToolExecuteArgs(args);
+        const [toolCallId, params, callSignal, onUpdate] = args;
         const signal = resolveAbortSignal(callSignal);
         signal?.throwIfAborted();
         const control = readInternalExecutionControl(args[4]);
@@ -634,7 +580,7 @@ export function toClientToolDefinitions(
       description: func.description ?? "",
       parameters: func.parameters as ToolDefinition["parameters"],
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
-        const { toolCallId, params, signal } = splitToolExecuteArgs(args);
+        const [toolCallId, params, signal] = args;
         const control = readInternalExecutionControl(args[4]);
         if (onClientToolCall && typeof onClientToolCall !== "function") {
           onClientToolCall.reserve?.(toolCallId, func.name);

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -8,7 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createDeferred } from "../../test/helpers/promise.js";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
@@ -642,49 +642,75 @@ describe("before_tool_call hook deduplication (#15502)", () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
-  it("commits final rewritten args immediately before private implementation", async () => {
-    beforeToolCallHook = installBeforeToolCallHook({
-      runBeforeToolCallImpl: async () => ({ params: { value: "rewritten" } }),
-    });
-    const order: string[] = [];
-    const execute = vi.fn(async () => {
-      order.push("body");
-      return { content: [], details: { ok: true } };
-    });
-    const source = wrapToolWithBeforeToolCallHook(asAgentTool({ name: "read", execute }));
-    const tool = wrapToolDefinition(
-      expectDefined(toToolDefinitions([source])[0], "rewritten private tool definition"),
-    );
-    const preparer = expectDefined(
-      getInternalToolExecutionPreparer(tool),
-      "rewritten private execution preparer",
-    );
-    const prepared = await preparer({
-      toolCallId: "call-rewritten",
-      args: { value: "original" },
-    });
-    expect(prepared.kind).toBe("ready");
-    if (prepared.kind !== "ready") {
-      return;
-    }
-    const onImplementationStart = vi.fn(() => {
-      order.push("commit");
-      queueMicrotask(() => order.push("gap"));
-    });
+  it.each(["source", "adapter"] as const)(
+    "commits final rewritten args immediately before private %s implementation",
+    async (owner) => {
+      beforeToolCallHook = installBeforeToolCallHook({
+        runBeforeToolCallImpl: async () => ({ params: { value: "rewritten" } }),
+      });
+      const order: string[] = [];
+      const execute = vi.fn(async () => {
+        order.push("body");
+        return { content: [], details: { ok: true } };
+      });
+      const base = asAgentTool({ name: "read", execute });
+      const source = owner === "source" ? wrapToolWithBeforeToolCallHook(base) : base;
+      const tool = wrapToolDefinition(
+        expectDefined(toToolDefinitions([source])[0], "rewritten private tool definition"),
+      );
+      const preparer = expectDefined(
+        getInternalToolExecutionPreparer(tool),
+        "rewritten private execution preparer",
+      );
+      let closed = false;
+      let prepared: Awaited<ReturnType<typeof preparer>> | undefined;
+      const preparation = preparer({
+        toolCallId: "call-rewritten",
+        args: { value: "original" },
+      }).then((value) => {
+        prepared = value;
+        if (closed) {
+          value.dispose();
+        }
+        return value;
+      });
+      const pending: Promise<unknown>[] = [Promise.allSettled([preparation])];
 
-    await prepared.execute(onImplementationStart);
-    prepared.dispose();
+      try {
+        prepared = await withTestTimeout(preparation, 2_000, "private preparation did not finish");
+        expect(prepared.kind).toBe("ready");
+        expect(execute).not.toHaveBeenCalled();
+        if (prepared.kind !== "ready") {
+          return;
+        }
+        const onImplementationStart = vi.fn(() => {
+          order.push("commit");
+          queueMicrotask(() => order.push("gap"));
+        });
+        const execution = prepared.execute(onImplementationStart);
+        pending.push(Promise.allSettled([execution]));
+        await withTestTimeout(execution, 2_000, "private implementation did not finish");
 
-    expect(prepared.args).toEqual({ value: "rewritten" });
-    expect(onImplementationStart).toHaveBeenCalledOnce();
-    expect(execute).toHaveBeenCalledWith(
-      "call-rewritten",
-      { value: "rewritten" },
-      undefined,
-      undefined,
-    );
-    expect(order).toEqual(["commit", "body", "gap"]);
-  });
+        expect(prepared.args).toEqual({ value: "rewritten" });
+        expect(onImplementationStart).toHaveBeenCalledOnce();
+        expect(execute).toHaveBeenCalledWith(
+          "call-rewritten",
+          { value: "rewritten" },
+          undefined,
+          undefined,
+        );
+        expect(order).toEqual(["commit", "body", "gap"]);
+      } finally {
+        closed = true;
+        try {
+          prepared?.dispose();
+        } finally {
+          await withTestTimeout(Promise.all(pending), 2_000, "private cleanup did not settle");
+        }
+      }
+    },
+    10_000,
+  );
 
   it("rechecks a private source guard after asynchronous before-tool policy", async () => {
     let releaseHook: (() => void) | undefined;

--- a/src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts
@@ -1,5 +1,7 @@
+import { expectDefined } from "@openclaw/normalization-core";
 import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
+import { withTestTimeout } from "../../../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { isEmbeddedMode, setEmbeddedMode } from "../../../infra/embedded-mode.js";
 import {
@@ -117,6 +119,60 @@ function prepare(input: {
 }
 
 describe("prepareEmbeddedAttemptClientTools", () => {
+  it("keeps authoritative client slots in source order across delayed hooks", async () => {
+    const previousRegistry = getGlobalPluginRegistry();
+    const firstHook = createDeferredCore();
+    const pending: Promise<unknown>[] = [];
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_tool_call",
+          matcher: ["first_tool"],
+          handler: async () => {
+            await firstHook.promise;
+          },
+        },
+      ]),
+    );
+    try {
+      const prepared = prepare({
+        codeModeControlsEnabledForRun: false,
+        attemptConfig: CATALOGS_DISABLED_CONFIG,
+        toolSearchRuntimeConfig: CATALOGS_DISABLED_CONFIG,
+        catalogRef: createToolSearchCatalogRef(),
+        clientTools: [clientTool("first_tool"), clientTool("second_tool")],
+      });
+      const tools = prepared.clientToolDefs.map((definition) => wrapToolDefinition(definition));
+      const firstTool = expectDefined(tools[0], "first client tool");
+      const secondTool = expectDefined(tools[1], "second client tool");
+      const first = firstTool.execute("first-call", { value: 1 });
+      pending.push(Promise.allSettled([first]));
+      const second = secondTool.execute("second-call", { value: 2 });
+      pending.push(Promise.allSettled([second]));
+      await withTestTimeout(second, 2_000, "second client tool did not finish");
+      expect(prepared.clientToolCallSlots).toEqual([
+        { toolCallId: "first-call", name: "first_tool", completed: false },
+        { toolCallId: "second-call", name: "second_tool", completed: true, params: { value: 2 } },
+      ]);
+      firstHook.resolve();
+      await withTestTimeout(first, 2_000, "first client tool did not finish");
+      expect(prepared.clientToolCallSlots).toEqual([
+        { toolCallId: "first-call", name: "first_tool", completed: true, params: { value: 1 } },
+        { toolCallId: "second-call", name: "second_tool", completed: true, params: { value: 2 } },
+      ]);
+    } finally {
+      firstHook.resolve();
+      try {
+        await withTestTimeout(Promise.all(pending), 2_000, "client cleanup did not settle");
+      } finally {
+        resetGlobalHookRunner();
+        if (previousRegistry) {
+          initializeGlobalHookRunner(previousRegistry);
+        }
+      }
+    }
+  }, 10_000);
+
   it.each(["execute", "prepare"] as const)(
     "removes an adapted MCP tool's pending approval when its permission generation ends during %s",
     async (executionPath) => {

--- a/src/agents/sessions/agent-session-runtime-projection.test.ts
+++ b/src/agents/sessions/agent-session-runtime-projection.test.ts
@@ -1,11 +1,20 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import type { AgentTool } from "openclaw/plugin-sdk/agent-core";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { withTestTimeout } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
-import { toClientToolDefinitions } from "../agent-tool-definition-adapter.js";
+import { toClientToolDefinitions, toToolDefinitions } from "../agent-tool-definition-adapter.js";
+import { wrapToolWithBeforeToolCallHook } from "../agent-tools.before-tool-call.js";
+import {
+  attachInternalToolExecutionPreparer,
+  getInternalToolExecutionPreparer,
+  type InternalToolExecutionPreparer,
+} from "../runtime/internal-hooks.js";
 import { guardSessionManager } from "../session-tool-result-guard-wrapper.js";
 import {
   createAssistant,
@@ -27,6 +36,196 @@ registerAgentSessionLoopTestLifecycle();
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("AgentSession runtime and transcript projections", () => {
+  it.each([
+    { owner: "adapter", abortBeforeLaunch: false },
+    { owner: "source", abortBeforeLaunch: false },
+    { owner: "adapter", abortBeforeLaunch: true },
+    { owner: "source", abortBeforeLaunch: true },
+    { owner: "client", abortBeforeLaunch: true },
+  ])(
+    "settles the real $owner preparer with abortBeforeLaunch=$abortBeforeLaunch",
+    async ({ owner, abortBeforeLaunch }) => {
+      const directory = tempDirs.make("openclaw-adapter-lifecycle-");
+      const output = path.join(directory, "receipt.txt");
+      const args = { value: "local receipt" };
+      const partial = {
+        content: [{ type: "text" as const, text: "writing receipt" }],
+        details: {},
+      };
+      const order: string[] = [];
+      const preparations: Parameters<InternalToolExecutionPreparer>[0][] = [];
+      const updates: unknown[] = [];
+      const outcomes: unknown[] = [];
+      const recorder = {
+        reserve: vi.fn(() => order.push("reserve")),
+        complete: vi.fn(() => order.push("complete")),
+        discard: vi.fn(() => order.push("discard")),
+      };
+      const execute = vi.fn<AgentTool["execute"]>(async (_id, input, _signal, onUpdate) => {
+        order.push("implementation");
+        onUpdate?.(partial);
+        await fs.writeFile(output, JSON.stringify(input));
+        return {
+          content: [{ type: "text", text: await fs.readFile(output, "utf8") }],
+          details: { written: true },
+        };
+      });
+      const tool = {
+        name: "receipt",
+        label: "Receipt",
+        description: "Write a local receipt.",
+        parameters: Type.Object({ value: Type.String() }),
+        execute,
+      } satisfies AgentTool;
+      const definitions =
+        owner === "client"
+          ? toClientToolDefinitions(
+              [
+                {
+                  type: "function",
+                  function: { name: tool.name, parameters: { ...tool.parameters } },
+                },
+              ],
+              recorder,
+            )
+          : toToolDefinitions([owner === "source" ? wrapToolWithBeforeToolCallHook(tool) : tool]);
+      const definition = expectDefined(definitions[0], "receipt definition");
+      const prepare = expectDefined(
+        getInternalToolExecutionPreparer(definition),
+        "real receipt preparer",
+      );
+      let cancelAtReady = () => {};
+      // Observe the real preparer's returned handle; never substitute its launch/disposal work.
+      attachInternalToolExecutionPreparer(definition, async (params) => {
+        preparations.push(params);
+        const prepared = await prepare(params);
+        order.push(prepared.kind);
+        if (prepared.kind === "ready" && abortBeforeLaunch) {
+          cancelAtReady();
+        }
+        return {
+          ...prepared,
+          dispose() {
+            order.push("dispose");
+            prepared.dispose();
+          },
+        };
+      });
+      streamMocks.streamSimple
+        .mockImplementationOnce((model: Model) =>
+          createAssistantResultStream(
+            createAssistant(
+              model,
+              [{ type: "toolCall", id: "receipt-call", name: "receipt", arguments: args }],
+              "toolUse",
+            ),
+          ),
+        )
+        .mockImplementation((model: Model) =>
+          createAssistantResultStream(
+            createAssistant(model, [{ type: "text", text: "Receipt observed." }]),
+          ),
+        );
+      const { session } = await createTestSession({ customTools: definitions });
+      cancelAtReady = () => session.agent.abort(new Error("cancelled after preparation"));
+      const unsubscribe = session.subscribe((event) => {
+        if (event.type === "tool_execution_start") {
+          order.push("start");
+        } else if (event.type === "tool_execution_update") {
+          order.push("update");
+          updates.push(event.partialResult);
+        } else if (event.type === "tool_execution_end") {
+          order.push("end");
+          outcomes.push(event);
+        } else if (event.type === "message_end" && event.message.role === "toolResult") {
+          order.push("result");
+        } else if (event.type === "agent_end" || event.type === "agent_settled") {
+          order.push(event.type);
+        }
+      });
+      const prompt = session.prompt("Write one receipt.");
+      try {
+        await withTestTimeout(prompt, 2_000, "receipt session did not settle");
+        expect(preparations).toHaveLength(1);
+        expect(order.filter((entry) => entry === "dispose")).toHaveLength(1);
+        expect(session.isStreaming).toBe(false);
+        expect(session.agent.state.pendingToolCalls.size).toBe(0);
+        if (abortBeforeLaunch) {
+          expect(execute).not.toHaveBeenCalled();
+          expect(recorder.complete).not.toHaveBeenCalled();
+          expect(updates).toEqual([]);
+          expect(outcomes).toMatchObject([
+            { toolCallId: "receipt-call", isError: true, executionStarted: false },
+          ]);
+          expect(
+            order.filter((entry) => ["start", "ready", "dispose", "end", "result"].includes(entry)),
+          ).toEqual(["start", "ready", "dispose", "end", "result"]);
+          expect(streamMocks.streamSimple).toHaveBeenCalledOnce();
+          await expect(fs.stat(output)).rejects.toMatchObject({ code: "ENOENT" });
+          if (owner === "client") {
+            expect(recorder.reserve).toHaveBeenCalledExactlyOnceWith("receipt-call", "receipt");
+            expect(recorder.discard).toHaveBeenCalledExactlyOnceWith("receipt-call", "receipt");
+          }
+        } else {
+          expect(execute).toHaveBeenCalledOnce();
+          const call = expectDefined(execute.mock.calls[0], "receipt implementation");
+          expect(call.slice(0, 2)).toEqual(["receipt-call", args]);
+          expect(call[2]).toBe(preparations[0]?.signal);
+          expect(call[3]).toBe(preparations[0]?.onUpdate);
+          expect(updates).toEqual([partial]);
+          expect(updates[0]).toBe(partial);
+          expect(await fs.readFile(output, "utf8")).toBe(JSON.stringify(args));
+          expect(outcomes).toMatchObject([
+            {
+              toolCallId: "receipt-call",
+              isError: false,
+              executionStarted: true,
+              result: {
+                content: [{ type: "text", text: JSON.stringify(args) }],
+                details: { written: true },
+              },
+            },
+          ]);
+          expect(order).toEqual([
+            "start",
+            "ready",
+            "implementation",
+            "update",
+            "dispose",
+            "end",
+            "result",
+            "agent_end",
+            "agent_settled",
+          ]);
+          expect(streamMocks.streamSimple).toHaveBeenCalledTimes(2);
+          expect(streamMocks.streamSimple.mock.calls[1]?.[1]).toMatchObject({
+            messages: expect.arrayContaining([
+              expect.objectContaining({
+                role: "toolResult",
+                toolCallId: "receipt-call",
+                content: [{ type: "text", text: JSON.stringify(args) }],
+              }),
+            ]),
+          });
+        }
+        expect(order.slice(-2)).toEqual(["agent_end", "agent_settled"]);
+      } finally {
+        session.agent.abort();
+        try {
+          await withTestTimeout(
+            Promise.allSettled([prompt, session.agent.waitForIdle()]),
+            2_000,
+            "receipt session cleanup did not settle",
+          );
+        } finally {
+          unsubscribe();
+          session.dispose();
+        }
+      }
+    },
+    10_000,
+  );
+
   it("keeps grep-only truncation results free of unavailable read-tool instructions", async () => {
     const cwd = await fs.realpath(tempDirs.make("openclaw-sdk-grep-guidance-"));
     const line = `needle ${"x".repeat(600)} OMITTED_END`;
@@ -221,6 +420,22 @@ describe("AgentSession runtime and transcript projections", () => {
 
       expect(calls.mock.calls).toEqual(values.map((value) => ["lookup", { [field]: value }]));
       expect(streamMocks.streamSimple).toHaveBeenCalledOnce();
+      expect(
+        session.state.messages.filter((message) => message.role === "toolResult"),
+      ).toMatchObject(
+        values.map((_value, index) => ({
+          toolCallId: `call_${index}`,
+          toolName: "lookup",
+          isError: false,
+          details: {
+            status: "pending",
+            tool: "lookup",
+            message: "Tool execution delegated to client",
+          },
+        })),
+      );
+      expect(session.isStreaming).toBe(false);
+      expect(session.agent.state.pendingToolCalls.size).toBe(0);
       const live = session.state.messages.find((message) => message.role === "assistant");
       expect(live).toMatchObject({
         content: [


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Agent tool dispatch still carries compatibility behavior for a retired private calling convention that current callers no longer use. That leaves cancellation, hooks and client-tool execution harder to audit and maintain. This is a maintainer-requested refactor, not a fix for the separate live-test failure described below.

## Why This Change Was Made

Use the existing `ToolDefinition.execute` signature directly in the source and client-tool adapters, removing the legacy tuple classifier and its intermediate argument projection. Preserve signal/update forwarding, private fifth-slot preparation control, hooks, and reservation/launch/disposal ordering without adding another compatibility path.

## User Impact

No intended user-visible behavior, public tool API, configuration, dependency or persistence change. Supported tool calls retain their existing callback, cancellation and execution semantics.

The five-file diff is **54 fewer production lines** (+4/−58) and **366 additional net test lines** (+409/−43). Test-support reductions are not counted as production savings.

## Evidence

- **Focused behavior:** on base `208aab3aa6f054fd5eb01218284f898d0863478e`, the original ten-file suite passed **151 tests** and the candidate passed **161**, with no failures or skips. Coverage includes actual preparer/cancellation and client-recorder ordering, plus the current SDK tool-outcome sibling. Native inter-file scheduling differed; this is not a claim of whole-run order equivalence.
- **Final projection fixture:** the first normal changed gate exposed a real `TS2322` schema-type error in the new test. `satisfies AgentTool` alone was insufficient. The final fixture preserves its concrete TypeBox schema and shallow-spreads only the client JSON-record boundary. This changes top-level identity and drops the non-enumerable TypeBox marker while preserving the enumerable schema and nested values; it is not a type-only or whole-JavaScript-identical change. The complete projection file then passed **10 tests**, without weakening assertions or deadlines.
- **Normal changed gate:** `node scripts/check-changed.mjs --timed` passed **all 29 actions** on the final source tree, including core/core-test typechecking and changed-file lint. [Delegated gate environment](https://github.com/openclaw/openclaw/actions/runs/34039634482).
- **Full builds and real Code Mode flow:** both configured full-product builds completed all **16 phases** on the unchanged production candidate, before the final test-fixture-only schema adjustment. The [first build/live invocation](https://github.com/openclaw/openclaw/actions/runs/34033426489) had **one live failure after 301.058 seconds**, not a pass. A separately reviewed failure-diagnostics-only test change kept the prompt, environment, provider/model, deadlines, cleanup and success assertions unchanged. Its [second build/live invocation](https://github.com/openclaw/openclaw/actions/runs/34036314026) passed the named case in **7.345 seconds**, with one pass and no skips. The diagnostic catch did not execute. The ordinary success path verified JSON success, Code Mode engagement, outer execution and dependent bridge calls, final `DONE`, exact output-file contents and subprocess completion. The original default test was restored after cleanup. This proves that invocation's package-shaped OpenAI flow, not native Codex or all-provider parity.
- **Independent review:** the local/precommit review and the separate authenticated review of signed commit `5b2b2eb857c0bb683899523be00d7c0aa34d4b99` each completed four Codex passes, scoped-clean at P2 with no actionable findings. Both retained the original live failure as an explicit limitation. One exact-head launch was refused before inference by the unchanged disk-capacity guard; the authorized launch after capacity recovery completed without a reviewer fallback.

The Testbox links identify delegated proof environments. Their cancelled workflow conclusions reflect lease shutdown and are **not** claimed as passing exact-head GitHub CI checks; the results above are the retained native payload outcomes.

**Known limitation:** the first live failure remains unexplained. Its terminal agent diagnostic did not establish final CLI output or process completion, and the original catch lost subprocess failure details. The later success neither explains that failure nor proves a hang fix or causal exoneration. The named follow-up is the subprocess failure-evidence/finalization boundary; no production stage markers, timeout extension or retry loop is added here.

**Exact-head CI:** [run 34045812043](https://github.com/openclaw/openclaw/actions/runs/34045812043) completed successfully for signed head `5b2b2eb857c0bb683899523be00d7c0aa34d4b99`. Normal native review, hosted prepare and merge remain pending.


## Maintainer disposition of the live-test risk

The unresolved incident and safe-diagnostics work are tracked in #140314; neither will be declared fixed by this cleanup. The first run remains failed and unexplained. The later real application run reached every original success assertion on the same production afterimage, but is not a causal explanation.

Direct source inspection and an independent challenge confirm that current producers already supply signal third, updates fourth, and an absent/context/private-control fifth value without an `aborted` member. The old decoder takes its canonical branch for those inputs, yielding exactly the identities now destructured. No await, hook, cancellation composition, preparation control, callback, reservation/launch/disposal or post-result finalizer changes. This evidence and the actual successful application path support landing the bounded retirement under the normal gates; CI or review counts alone would not resolve the concern. Any new failure or supported legacy-order caller reopens this disposition.

The follow-up specifically requires a deterministic failing synthetic subprocess test for the sanitized diagnostic projection. The successful diagnostic invocation never entered its catch, so it does not prove that failure path. No raw streams, credentials, timeout increase, runtime marker or retry loop is added to this PR.

