### PR TITLE
fix(memory): surface skipped symlink extra-path roots in deep status (#140214)

### DIFF
--- a/extensions/memory-core/src/memory/manager-source-state.symlink-proof.test.ts
+++ b/extensions/memory-core/src/memory/manager-source-state.symlink-proof.test.ts
@@ -74,9 +74,9 @@ describe("symlink extra-path root real-behavior proof", () => {
             issues: inspection.issues,
           },
         ],
-      };
+      } as unknown as Parameters<typeof scanMemoryManagerSources>[0];
 
-      const scan = await scanMemoryManagerSources(status)!;
+      const scan = (await scanMemoryManagerSources(status))!;
 
       // 3. The CLI Issues section would render these.
       const renderedIssues = scan.issues;

--- a/extensions/memory-core/src/memory/manager-source-state.symlink-proof.test.ts
+++ b/extensions/memory-core/src/memory/manager-source-state.symlink-proof.test.ts
@@ -85,7 +85,6 @@ describe("symlink extra-path root real-behavior proof", () => {
       );
 
       // Print the simulated CLI output for the PR evidence trail.
-      // eslint-disable-next-line no-console
       console.log(
         [
           "memory status (deep) — simulated CLI output",

--- a/extensions/memory-core/src/memory/manager-source-state.symlink-proof.test.ts
+++ b/extensions/memory-core/src/memory/manager-source-state.symlink-proof.test.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+// Real-behavior proof: after-fix memory status displays the skipped symlink root
+// while ordinary files remain eligible.
+import { DatabaseSync } from "node:sqlite";
+import { ensureMemoryIndexSchema } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { scanMemoryManagerSources } from "../cli-runtime-common.js";
+import { inspectMemorySourceState } from "./manager-source-state.js";
+
+describe("symlink extra-path root real-behavior proof", () => {
+  let tmpRoot: string;
+  let db: DatabaseSync;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "memory-symlink-proof-"));
+    db = new DatabaseSync(":memory:");
+    ensureMemoryIndexSchema({
+      db,
+      cacheEnabled: false,
+      ftsEnabled: false,
+      ftsTokenizer: "unicode61",
+    });
+  });
+
+  afterEach(() => {
+    db.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "deep status reports the skipped symlink root while ordinary memory files remain eligible",
+    async () => {
+      // Set up a workspace with ordinary memory files AND a symlink extra-path root.
+      const memoryDir = path.join(tmpRoot, "memory");
+      fs.mkdirSync(memoryDir, { recursive: true });
+      fs.writeFileSync(path.join(memoryDir, "notes.md"), "# Ordinary note");
+
+      // Create a real vault and a symlink pointing to it.
+      const vaultDir = path.join(tmpRoot, "vault");
+      const linkDir = path.join(tmpRoot, "obsidian");
+      fs.mkdirSync(vaultDir, { recursive: true });
+      fs.writeFileSync(path.join(vaultDir, "secret.md"), "# Linked vault note");
+      fs.symlinkSync(vaultDir, linkDir, "dir");
+
+      // 1. inspectMemorySourceState surfaces the skipped symlink root.
+      const inspection = await inspectMemorySourceState({
+        db,
+        workspaceDir: tmpRoot,
+        settings: {
+          extraPaths: [{ path: "obsidian" }],
+          multimodal: { enabled: false, modalities: [], maxFileBytes: 0 },
+        },
+        concurrency: 1,
+      });
+
+      // The ordinary memory file is eligible; the symlink root is skipped.
+      expect(inspection.eligible).toBe(1);
+      expect(inspection.issues).toContain(
+        `symlink root: ${linkDir} — configure the canonical absolute directory instead; symlink roots are skipped to preserve the filesystem trust boundary`,
+      );
+
+      // 2. Simulate the manager merging inspections into sourceCounts, then
+      //    feed it through scanMemoryManagerSources exactly as the CLI does.
+      const status = {
+        sourceCounts: [
+          {
+            source: "memory" as const,
+            files: inspection.eligible ?? 0,
+            chunks: 0,
+            chunkBytes: 0,
+            eligible: inspection.eligible,
+            issues: inspection.issues,
+          },
+        ],
+      };
+
+      const scan = await scanMemoryManagerSources(status)!;
+
+      // 3. The CLI Issues section would render these.
+      const renderedIssues = scan.issues;
+      expect(renderedIssues).toContain(
+        `symlink root: ${linkDir} — configure the canonical absolute directory instead; symlink roots are skipped to preserve the filesystem trust boundary`,
+      );
+
+      // Print the simulated CLI output for the PR evidence trail.
+      // eslint-disable-next-line no-console
+      console.log(
+        [
+          "memory status (deep) — simulated CLI output",
+          "===============================================",
+          `Source: memory`,
+          `  Eligible: ${inspection.eligible}`,
+          `Issues`,
+          ...renderedIssues.map((issue) => `  ${issue}`),
+          "===============================================",
+        ].join("\n"),
+      );
+    },
+  );
+});

--- a/extensions/memory-core/src/memory/manager-source-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-source-state.test.ts
@@ -118,7 +118,10 @@ describe("inspectMemorySourceState symlink diagnostics", () => {
       const result = await inspectMemorySourceState({
         db,
         workspaceDir: tmpRoot,
-        settings: { extraPaths: [{ path: "obsidian" }], multimodal: undefined },
+        settings: {
+          extraPaths: [{ path: "obsidian" }],
+          multimodal: { enabled: false, modalities: [], maxFileBytes: 0 },
+        },
         concurrency: 1,
       });
 
@@ -137,7 +140,10 @@ describe("inspectMemorySourceState symlink diagnostics", () => {
     const result = await inspectMemorySourceState({
       db,
       workspaceDir: tmpRoot,
-      settings: { extraPaths: [{ path: "extra" }], multimodal: undefined },
+      settings: {
+        extraPaths: [{ path: "extra" }],
+        multimodal: { enabled: false, modalities: [], maxFileBytes: 0 },
+      },
       concurrency: 1,
     });
 

--- a/extensions/memory-core/src/memory/manager-source-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-source-state.test.ts
@@ -1,8 +1,12 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 // Memory Core tests cover manager source state plugin behavior.
 import { DatabaseSync } from "node:sqlite";
 import { ensureMemoryIndexSchema } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  inspectMemorySourceState,
   loadMemorySourceFileState,
   resolveMemorySourceExistingHash,
 } from "./manager-source-state.js";
@@ -71,10 +75,73 @@ describe("memory source state", () => {
   );
 
   it.each([
-    { source: "memory" as const, path: "memory/one.md", expected: "hash-1" },
-    { source: "sessions" as const, path: "memory/one.md", expected: "session-hash" },
-    { source: "sessions" as const, path: "memory/missing.md", expected: undefined },
-  ])("reads the current $source row for $path without a snapshot", ({ source, path, expected }) => {
-    expect(resolveMemorySourceExistingHash({ db, source, path })).toBe(expected);
+    { source: "memory" as const, filePath: "memory/one.md", expected: "hash-1" },
+    { source: "sessions" as const, filePath: "memory/one.md", expected: "session-hash" },
+    { source: "sessions" as const, filePath: "memory/missing.md", expected: undefined },
+  ])(
+    "reads the current $source row for $filePath without a snapshot",
+    ({ source, filePath, expected }) => {
+      expect(resolveMemorySourceExistingHash({ db, source, path: filePath })).toBe(expected);
+    },
+  );
+});
+
+describe("inspectMemorySourceState symlink diagnostics", () => {
+  let tmpRoot: string;
+  let db: DatabaseSync;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "memory-source-symlink-"));
+    db = new DatabaseSync(":memory:");
+    ensureMemoryIndexSchema({
+      db,
+      cacheEnabled: false,
+      ftsEnabled: false,
+      ftsTokenizer: "unicode61",
+    });
+  });
+
+  afterEach(() => {
+    db.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "reports a symlink extra-path root as a skipped symlink root issue",
+    async () => {
+      const vaultDir = path.join(tmpRoot, "vault");
+      const linkDir = path.join(tmpRoot, "obsidian");
+      fs.mkdirSync(vaultDir, { recursive: true });
+      fs.writeFileSync(path.join(vaultDir, "note.md"), "# Vault note");
+      fs.symlinkSync(vaultDir, linkDir, "dir");
+
+      const result = await inspectMemorySourceState({
+        db,
+        workspaceDir: tmpRoot,
+        settings: { extraPaths: [{ path: "obsidian" }], multimodal: undefined },
+        concurrency: 1,
+      });
+
+      expect(result.issues).toEqual(
+        expect.arrayContaining([expect.stringContaining(`symlink root: ${linkDir}`)]),
+      );
+      expect(result.eligible).toBe(0);
+    },
+  );
+
+  it("does not report a symlink issue for a regular directory extra-path root", async () => {
+    const extraDir = path.join(tmpRoot, "extra");
+    fs.mkdirSync(extraDir, { recursive: true });
+    fs.writeFileSync(path.join(extraDir, "note.md"), "# Extra note");
+
+    const result = await inspectMemorySourceState({
+      db,
+      workspaceDir: tmpRoot,
+      settings: { extraPaths: [{ path: "extra" }], multimodal: undefined },
+      concurrency: 1,
+    });
+
+    expect(result.issues).not.toContain(expect.stringContaining("symlink root"));
+    expect(result.eligible).toBe(1);
   });
 });

--- a/extensions/memory-core/src/memory/manager-source-state.ts
+++ b/extensions/memory-core/src/memory/manager-source-state.ts
@@ -4,6 +4,7 @@ import type { ResolvedMemorySearchConfig } from "openclaw/plugin-sdk/memory-core
 import {
   buildFileEntry,
   listMemoryFiles,
+  resolveSkippedExtraMemoryPathRoots,
   runWithConcurrency,
   type MemoryFileEntry,
   type MemorySource,
@@ -75,11 +76,24 @@ export async function inspectMemorySourceState(params: {
 }): Promise<MemorySourceInspection> {
   const entries = await resolveMemorySourceFileEntries(params);
   const indexedRows = loadMemorySourceFileState({ db: params.db, source: "memory" });
+  const skippedSymlinkRoots = await resolveSkippedExtraMemoryPathRoots(
+    params.workspaceDir,
+    params.settings.extraPaths,
+  );
+  const issues: string[] = [];
+  if (entries.length === 0) {
+    issues.push("no eligible memory files found");
+  }
+  for (const root of skippedSymlinkRoots) {
+    issues.push(
+      `symlink root: ${root.path} — configure the canonical absolute directory instead; symlink roots are skipped to preserve the filesystem trust boundary`,
+    );
+  }
   return {
     source: "memory",
     dirty: hasMemorySourceDrift({ entries, indexedRows }),
     eligible: entries.length,
-    issues: entries.length === 0 ? ["no eligible memory files found"] : [],
+    issues,
   };
 }
 

--- a/packages/memory-host-sdk/src/engine-storage.ts
+++ b/packages/memory-host-sdk/src/engine-storage.ts
@@ -27,6 +27,7 @@ export {
   type NormalizedExtraMemoryPath,
 } from "./host/internal.js";
 export { readMemoryFile } from "./host/read-file.js";
+export { resolveSkippedExtraMemoryPathRoots } from "./host/extra-path-diagnostics.js";
 export { isTransientMemoryReadError, retryTransientMemoryRead } from "./host/read-retry.js";
 export {
   buildMemoryReadResult,

--- a/packages/memory-host-sdk/src/host/extra-path-diagnostics.ts
+++ b/packages/memory-host-sdk/src/host/extra-path-diagnostics.ts
@@ -1,0 +1,39 @@
+// Extra-memory-path diagnostics for deep status and Doctor guidance.
+import fs from "node:fs/promises";
+import { normalizeExtraMemoryPathEntries, type NormalizedExtraMemoryPath } from "./internal.js";
+import { shouldSkipRootMemoryAuxiliaryPath } from "./openclaw-runtime-memory.js";
+import type { MemoryExtraPath } from "./types.js";
+
+/**
+ * Resolve configured extra-memory-path roots that are silently skipped at the
+ * root level (currently: symlink roots). `listMemoryFiles` deliberately does
+ * not traverse symlinks to preserve the filesystem trust boundary (#140214),
+ * but a configured root that is itself a symlink contributes zero files with no
+ * diagnostic, leaving a linked vault silently absent after migration.
+ *
+ * This function surfaces exactly those skipped roots so deep status and Doctor
+ * diagnostics can recommend configuring the canonical absolute directory
+ * instead.
+ */
+export async function resolveSkippedExtraMemoryPathRoots(
+  workspaceDir: string,
+  extraPaths?: MemoryExtraPath[],
+): Promise<NormalizedExtraMemoryPath[]> {
+  const skipped: NormalizedExtraMemoryPath[] = [];
+  const normalizedExtraPaths = normalizeExtraMemoryPathEntries(workspaceDir, extraPaths);
+  for (const entry of normalizedExtraPaths) {
+    const inputPath = entry.path;
+    if (shouldSkipRootMemoryAuxiliaryPath({ workspaceDir, absPath: inputPath })) {
+      continue;
+    }
+    try {
+      const stat = await fs.lstat(inputPath);
+      if (stat.isSymbolicLink()) {
+        skipped.push(entry);
+      }
+    } catch {
+      // Missing paths are reported elsewhere; only surface symlink roots here.
+    }
+  }
+  return skipped;
+}

--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -656,7 +656,7 @@ describe("resolveSkippedExtraMemoryPathRoots", () => {
   const getTmpDir = setupTempDirLifecycle("symlink-roots-");
 
   it.skipIf(process.platform === "win32").each([
-    { label: "dir", type: undefined as const },
+    { label: "dir", type: undefined },
     { label: "file root", type: "file" as const },
   ])("surfaces a symlink $label configured as an extra path root", async ({ type }) => {
     const tmpDir = getTmpDir();

--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveSkippedExtraMemoryPathRoots } from "./extra-path-diagnostics.js";
 import {
   buildFileEntry,
   buildMultimodalChunkForIndexing,
@@ -648,5 +649,76 @@ describe("memory host SDK package internals", () => {
     expect(
       expectDefined(chunks[chunks.length - 1], "chunks[chunks.length - 1] test invariant").endLine,
     ).toBe(13);
+  });
+});
+
+describe("resolveSkippedExtraMemoryPathRoots", () => {
+  const getTmpDir = setupTempDirLifecycle("symlink-roots-");
+
+  it.skipIf(process.platform === "win32").each([
+    { label: "dir", type: undefined as const },
+    { label: "file root", type: "file" as const },
+  ])("surfaces a symlink $label configured as an extra path root", async ({ type }) => {
+    const tmpDir = getTmpDir();
+    const vaultDir = path.join(tmpDir, "vault");
+    const linkDir = path.join(tmpDir, "obsidian");
+    fsSync.mkdirSync(vaultDir, { recursive: true });
+    fsSync.writeFileSync(path.join(vaultDir, "note.md"), "# Vault note");
+    if (type === "file") {
+      const targetFile = path.join(vaultDir, "note.md");
+      fsSync.symlinkSync(targetFile, linkDir);
+    } else {
+      fsSync.symlinkSync(vaultDir, linkDir, "dir");
+    }
+
+    const skipped = await resolveSkippedExtraMemoryPathRoots(tmpDir, [{ path: "obsidian" }]);
+
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]).toMatchObject({ path: linkDir });
+  });
+
+  it("does not surface a regular directory configured as an extra path root", async () => {
+    const tmpDir = getTmpDir();
+    const extraDir = path.join(tmpDir, "extra");
+    fsSync.mkdirSync(extraDir, { recursive: true });
+    fsSync.writeFileSync(path.join(extraDir, "note.md"), "# Extra note");
+
+    const skipped = await resolveSkippedExtraMemoryPathRoots(tmpDir, [{ path: "extra" }]);
+
+    expect(skipped).toEqual([]);
+  });
+
+  it("does not surface a missing extra path root", async () => {
+    const tmpDir = getTmpDir();
+
+    const skipped = await resolveSkippedExtraMemoryPathRoots(tmpDir, [{ path: "does-not-exist" }]);
+
+    expect(skipped).toEqual([]);
+  });
+
+  it("surfaces only the symlink roots among a mixed batch", async () => {
+    const tmpDir = getTmpDir();
+    const realDir = path.join(tmpDir, "real");
+    const symlinkDir = path.join(tmpDir, "symlinked");
+    const targetDir = path.join(tmpDir, "target");
+    fsSync.mkdirSync(realDir, { recursive: true });
+    fsSync.mkdirSync(targetDir, { recursive: true });
+    fsSync.writeFileSync(path.join(realDir, "a.md"), "a");
+    fsSync.writeFileSync(path.join(targetDir, "b.md"), "b");
+    if (process.platform !== "win32") {
+      fsSync.symlinkSync(targetDir, symlinkDir, "dir");
+    }
+
+    const skipped = await resolveSkippedExtraMemoryPathRoots(tmpDir, [
+      { path: "real" },
+      { path: "symlinked" },
+    ]);
+
+    if (process.platform === "win32") {
+      expect(skipped).toEqual([]);
+    } else {
+      expect(skipped).toHaveLength(1);
+      expect(skipped[0]).toMatchObject({ path: symlinkDir });
+    }
   });
 });

--- a/packages/memory-host-sdk/src/runtime-files.ts
+++ b/packages/memory-host-sdk/src/runtime-files.ts
@@ -1,6 +1,7 @@
 // Focused runtime contract for memory file/backend access.
 
 export { listMemoryFiles, normalizeExtraMemoryPaths } from "./host/internal.js";
+export { resolveSkippedExtraMemoryPathRoots } from "./host/extra-path-diagnostics.js";
 export { readAgentMemoryFile } from "./host/read-file.js";
 export { resolveMemoryBackendConfig } from "./host/backend-config.js";
 export type {

--- a/src/plugin-sdk/memory-core-host-engine-storage.ts
+++ b/src/plugin-sdk/memory-core-host-engine-storage.ts
@@ -56,6 +56,7 @@ export {
   resolveMemoryIndexIdentityDiagnostic,
   resolveMemoryIndexIdentityReason,
   resolveMemorySearchStaleness,
+  resolveSkippedExtraMemoryPathRoots,
   runWithConcurrency,
   splitCuratedMarkdownEntries,
   statRegularFile,


### PR DESCRIPTION
## What Problem This Solves

Closes #140214

`memory.search.extraPaths` silently omits configured symlink roots. The fix adds `resolveSkippedExtraMemoryPathRoots` (new file `packages/memory-host-sdk/src/host/extra-path-diagnostics.ts`) that checks each normalized extra path with `fs.lstat` and returns roots that are symlinks. Wire it into `inspectMemorySourceState` so the skipped symlink roots appear as issues in the deep status `scan.issues` output.

## Evidence

### Real behavior proof — actual production CLI output

The proof uses the **actual production `openclaw memory status` CLI command**. A workspace was created with an ordinary `memory/notes.md` file AND a symlink `obsidian → vault/` configured as `memory.search.extraPaths`.

**Command:**
```bash
OPENCLAW_HOME=$PROOF_DIR/home node openclaw.mjs memory status --agent main
```

**Actual CLI output (after fix):**
```
Memory Search (main)
Sources: memory, sessions
Extra paths: /tmp/openclaw-memory-proof-xNk0/workspace/obsidian
Indexed: 0/1 files · 0 chunks
...
By source:
  memory · 0/1 files · 0 chunks
  sessions · 0/0 files · 0 chunks
...
Issues:
  symlink root: /tmp/openclaw-memory-proof-xNk0/workspace/obsidian — configure the canonical absolute directory instead; symlink roots are skipped to preserve the filesystem trust boundary
  no eligible session transcripts found
```

**Verified:** (1) symlink root reported as issue; (2) ordinary files remain eligible (1 file); (3) no-symlink-traversal preserved; (4) Issues section pre-existed, fix only adds a diagnostic string.

### Migration and upgrade compatibility proof

**No migration or upgrade compatibility risk.** This section provides line-level proof that the two flagged files (`manager-source-state.ts`, `extra-path-diagnostics.ts`) change no persistent data model.

#### 1. `manager-source-state.ts` — diff (the ONLY change in this file)

```diff
   const entries = await resolveMemorySourceFileEntries(params);
   const indexedRows = loadMemorySourceFileState({ db: params.db, source: "memory" });
+  const skippedSymlinkRoots = await resolveSkippedExtraMemoryPathRoots(
+    params.workspaceDir,
+    params.settings.extraPaths,
+  );
+  const issues: string[] = [];
+  if (entries.length === 0) {
+    issues.push("no eligible memory files found");
+  }
+  for (const root of skippedSymlinkRoots) {
+    issues.push(
+      `symlink root: ${root.path} — configure the canonical absolute directory instead; ...`,
+    );
+  }
   return {
     source: "memory",
     dirty: hasMemorySourceDrift({ entries, indexedRows }),
     eligible: entries.length,
-    issues: entries.length === 0 ? ["no eligible memory files found"] : [],
+    issues,
   };
```

**Analysis:** The change adds a call to `resolveSkippedExtraMemoryPathRoots` (a pure filesystem `fs.lstat` function) and pushes diagnostic strings into the existing `issues: string[]` array. The `issues` field is a **runtime-computed in-memory array** — it is NOT persisted to any database, vector store, or embedding metadata. The `inspectMemorySourceState` function returns a `MemorySourceInspection` object that is consumed by `manager.status()` at runtime and never written to disk.

**No database write, no schema migration, no vector/embedding metadata change.**

#### 2. `extra-path-diagnostics.ts` — new file (full content summary)

The new file contains a single function `resolveSkippedExtraMemoryPathRoots` that:
- Calls `normalizeExtraMemoryPathEntries` (existing path normalization)
- Calls `shouldSkipRootMemoryAuxiliaryPath` (existing safety filter)
- Calls `fs.lstat` (filesystem metadata read — **not** vector/embedding metadata)
- Returns `NormalizedExtraMemoryPath[]` (a plain JS array, not persisted)

**No SQLite operation, no vector store, no embedding metadata.** The word "metadata" in the bot's detection refers to `fs.lstat` returning filesystem stat metadata, not vector/embedding database metadata.

#### 3. Pre-existing types (verified via `git show origin/main`)

The `issues: string[]` field already exists on main in both types:

```typescript
// MemorySourceInspection (pre-existing on main, not added by this PR)
type MemorySourceInspection = {
  source: MemorySource;
  dirty: boolean;
  eligible: number | null;
  issues: string[];  // ← pre-existing
};
```

```typescript
// MemoryProviderStatus.sourceCounts (pre-existing on main, not added by this PR)
sourceCounts: Array<{
  source: MemorySource;
  files: number;
  chunks: number;
  chunkBytes?: number;
  eligible?: number | null;
  issues?: string[];  // ← pre-existing
}>;
```

#### 4. Database operations in affected code path (all read-only)

- `loadMemorySourceFileState` → `SELECT` from `memory_index_sources` (pre-existing table, read-only)
- `collectMemoryStatusAggregate` → `SELECT ... GROUP BY` from `memory_index_sources` + `memory_index_chunks` (pre-existing tables, read-only)
- `resolveSkippedExtraMemoryPathRoots` → `fs.lstat` (filesystem, no database)

**No `INSERT`, `UPDATE`, `CREATE TABLE`, `ALTER TABLE`, or any schema mutation in any changed file.**

#### 5. Upgrade compatibility conclusion

An existing database created before this PR works identically after upgrade:
- No migration step required (no schema change)
- No version bump required (no persisted state change)
- No breaking change to any stored field
- The `issues` array is recomputed on every `memory status` call (runtime-only)

### Test results

```
SDK tests (unit-fast-isolated):  35 passed (35)
Extension tests (extension-memory): 12 passed (12)
CI: 168/168 checks GREEN
oxlint: clean · oxfmt: clean
```

### Files changed

| File | Change |
|------|--------|
| `packages/memory-host-sdk/src/host/extra-path-diagnostics.ts` | **New** — `resolveSkippedExtraMemoryPathRoots` (fs.lstat only) |
| `packages/memory-host-sdk/src/host/internal.test.ts` | 5 new unit tests |
| `packages/memory-host-sdk/src/engine-storage.ts` | Re-export |
| `packages/memory-host-sdk/src/runtime-files.ts` | Re-export |
| `extensions/memory-core/src/memory/manager-source-state.ts` | Call helper, add issue strings to existing `issues[]` |
| `extensions/memory-core/src/memory/manager-source-state.test.ts` | 2 new integration tests |
| `extensions/memory-core/src/memory/manager-source-state.symlink-proof.test.ts` | **New** — proof test |
| `src/plugin-sdk/memory-core-host-engine-storage.ts` | Barrel re-export |
