### PR TITLE
refactor(plugins): consolidate disabled metadata coverage

### DIFF
--- a/src/plugins/installed-plugin-index.test.ts
+++ b/src/plugins/installed-plugin-index.test.ts
@@ -524,26 +524,37 @@ describe("installed plugin index", () => {
     },
   );
 
-  it("evaluates current enablement without retaining removed startup policy", () => {
+  it("retains disabled plugin metadata while evaluating live enablement", () => {
     const enabledFixture = createRichPluginFixture({ id: "enabled-demo" });
     const disabledFixture = createRichPluginFixture({ id: "disabled-demo" });
-    const index = loadInstalledPluginIndex({
-      candidates: [enabledFixture.candidate, disabledFixture.candidate],
-      config: {
-        plugins: {
-          entries: {
-            "disabled-demo": {
-              enabled: false,
-            },
+    const config = {
+      plugins: {
+        entries: {
+          "disabled-demo": {
+            enabled: false,
           },
         },
       },
+    };
+    const index = loadInstalledPluginIndex({
+      candidates: [enabledFixture.candidate, disabledFixture.candidate],
+      config,
       env: hermeticEnv(),
     });
 
-    expect(index.plugins.find((plugin) => plugin.pluginId === "disabled-demo")?.enabled).toBe(
-      false,
+    const disabled = index.plugins.find((plugin) => plugin.pluginId === "disabled-demo");
+    expect(disabled?.enabled).toBe(false);
+    expect(disabled?.contributions).toEqual(
+      expect.objectContaining({
+        channels: ["demo-chat"],
+        channelConfigs: ["demo-chat"],
+        providers: ["demo"],
+        modelCatalogProviders: ["demo"],
+        commandAliases: ["demo-command"],
+        contracts: { tools: ["demo-tool"] },
+      }),
     );
+    expect(isInstalledPluginEnabled(index, "disabled-demo", config)).toBe(false);
     expect(
       isInstalledPluginEnabled(index, "disabled-demo", {
         plugins: {
@@ -1024,37 +1035,6 @@ describe("installed plugin index", () => {
     expect(diffInstalledPluginIndexInvalidationReasons(migratedEnabledOnly, current)).toStrictEqual(
       [],
     );
-  });
-
-  it("marks disabled plugins without dropping their cold contributions", () => {
-    const fixture = createRichPluginFixture();
-
-    const index = loadInstalledPluginIndex({
-      candidates: [fixture.candidate],
-      config: {
-        plugins: {
-          entries: {
-            demo: {
-              enabled: false,
-            },
-          },
-        },
-      },
-      env: hermeticEnv(),
-    });
-
-    expect(
-      isInstalledPluginEnabled(index, "demo", {
-        plugins: {
-          entries: {
-            demo: {
-              enabled: false,
-            },
-          },
-        },
-      }),
-    ).toBe(false);
-    expect(index.plugins[0]?.enabled).toBe(false);
   });
 
   it("tracks refresh reason without using the manifest cache", () => {


### PR DESCRIPTION
## What Problem This Solves

The installed-index test named for retaining disabled plugins' cold metadata only checked enablement. It duplicated an existing live-enablement test while leaving its promised metadata invariant untested. This is maintainer-requested test-debt cleanup following the #135868 split campaign.

## Why This Change Was Made

Consolidate the enablement cases and assert the disabled fixture's channel, provider, model-catalog, command and tool-contract metadata. Retain the explicit entries.enabled=false query, cached status, live default-policy re-evaluation and denylist checks in the surviving real index test.

Production/tooling/docs 0; tests −20. Total diff: 64 changed lines. No runtime or baseline change.

## User Impact

No runtime change. The suite now detects loss of cold metadata from a disabled plugin while preserving all existing enablement coverage.

## Evidence

- All 32 installed-index and compatibility tests passed on macOS after restoring production.
- Mutation proof: dropping provider contributions only for disabled records failed the strengthened test; both original enablement-only tests passed the same mutation. The record builder was restored byte-for-byte before final validation.
- Twenty untouched standalone test bodies are byte-identical.
- Independent Codex P0–P2 review is scoped-clean.
- Full local `node scripts/check-changed.mjs` passed with exit 0, including typechecking, all three dead-export scans and targeted lint.
- No build needed for this test-only change.

Both original cases are covered by `src/plugins/installed-plugin-index.test.ts:527`, “retains disabled plugin metadata while evaluating live enablement.” It keeps the original two real plugin fixtures and adds the explicit disabling-config query from the deleted standalone case. The new metadata assertion checks the fixture's nonempty declared contributions rather than incidental empty defaults. All filesystem, persistence, prototype-name, startup-classification and invalidation cases remain unchanged.

Exact-head [CI run 34045896636](https://github.com/openclaw/openclaw/actions/runs/34045896636) is green. ClawSweeper reviewed `b09b228214873046a19791c4e344b69fc40f7b98` with no findings, before-merge requests, or rank-up moves. The rebase was patch-identical and left the lockfile unchanged.
