### PR TITLE
fix(cli): make bare telemetry help succeed

### DIFF
--- a/src/cli/telemetry-cli.test.ts
+++ b/src/cli/telemetry-cli.test.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, CommanderError } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { registerTelemetryCli } from "./telemetry-cli.js";
@@ -43,9 +43,22 @@ const payload = {
   },
 };
 
-async function runTelemetryCli(args: string[]): Promise<void> {
-  const program = new Command().exitOverride();
+function createTelemetryProgram() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const program = new Command()
+    .name("openclaw")
+    .exitOverride()
+    .configureOutput({
+      writeOut: (text) => stdout.push(text),
+      writeErr: (text) => stderr.push(text),
+    });
   registerTelemetryCli(program);
+  return { program, stdout, stderr };
+}
+
+async function runTelemetryCli(args: string[]): Promise<void> {
+  const { program } = createTelemetryProgram();
   await program.parseAsync(["telemetry", ...args], { from: "user" });
 }
 
@@ -179,16 +192,47 @@ describe("telemetry cli", () => {
   it("prints parent help with a successful exit when no subcommand is given", async () => {
     const previousExitCode = process.exitCode;
     process.exitCode = undefined;
-    const program = new Command().exitOverride();
-    registerTelemetryCli(program);
-    const telemetry = program.commands.find((command) => command.name() === "telemetry");
-    const helpSpy = vi.spyOn(telemetry!, "outputHelp").mockImplementation(() => {});
+    const { program, stdout, stderr } = createTelemetryProgram();
 
     try {
-      await program.parseAsync(["telemetry"], { from: "user" });
+      let exitCode: number;
+      try {
+        await program.parseAsync(["telemetry"], { from: "user" });
+        exitCode = process.exitCode ?? 0;
+      } catch (error) {
+        if (!(error instanceof CommanderError) || error.code !== "commander.help") {
+          throw error;
+        }
+        exitCode = error.exitCode;
+      }
 
-      expect(helpSpy).toHaveBeenCalledTimes(1);
-      expect(process.exitCode).toBe(0);
+      expect(exitCode).toEqual(0);
+      expect(stdout.join("")).toContain("Usage: openclaw telemetry [options] [command]");
+      expect(stdout.join("")).toContain("Inspect and manage anonymous usage telemetry");
+      expect(stderr).toEqual([]);
+      expect(mocks.getRuntimeConfig).not.toHaveBeenCalled();
+      expect(mocks.transformConfigFileWithRetry).not.toHaveBeenCalled();
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
+  it.each([
+    { name: "explicit help", args: ["--help"], usage: "telemetry [options] [command]" },
+    { name: "implicit help", args: ["help"], usage: "telemetry [options] [command]" },
+    { name: "nested help", args: ["help", "show"], usage: "telemetry show [options]" },
+  ])("preserves $name without reading or changing telemetry", async ({ args, usage }) => {
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const { program, stdout, stderr } = createTelemetryProgram();
+    try {
+      await expect(
+        program.parseAsync(["telemetry", ...args], { from: "user" }),
+      ).rejects.toMatchObject({ exitCode: 0 });
+      expect(stdout.join("")).toContain(`Usage: openclaw ${usage}`);
+      expect(stderr).toEqual([]);
+      expect(mocks.getRuntimeConfig).not.toHaveBeenCalled();
+      expect(mocks.transformConfigFileWithRetry).not.toHaveBeenCalled();
     } finally {
       process.exitCode = previousExitCode;
     }

--- a/src/cli/telemetry-cli.test.ts
+++ b/src/cli/telemetry-cli.test.ts
@@ -175,4 +175,22 @@ describe("telemetry cli", () => {
       );
     },
   );
+
+  it("prints parent help with a successful exit when no subcommand is given", async () => {
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const program = new Command().exitOverride();
+    registerTelemetryCli(program);
+    const telemetry = program.commands.find((command) => command.name() === "telemetry");
+    const helpSpy = vi.spyOn(telemetry!, "outputHelp").mockImplementation(() => {});
+
+    try {
+      await program.parseAsync(["telemetry"], { from: "user" });
+
+      expect(helpSpy).toHaveBeenCalledTimes(1);
+      expect(process.exitCode).toBe(0);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
 });

--- a/src/cli/telemetry-cli.ts
+++ b/src/cli/telemetry-cli.ts
@@ -93,15 +93,12 @@ export function registerTelemetryCli(program: Command): void {
       runCommandWithRuntime(defaultRuntime, () => showTelemetry(options)),
     );
 
-  telemetry
-    .command("on")
-    .description("Enable anonymous feature statistics")
-    .action(async () => runCommandWithRuntime(defaultRuntime, () => setTelemetryEnabled(true)));
-
-  telemetry
-    .command("off")
-    .description("Disable anonymous feature statistics")
-    .action(async () => runCommandWithRuntime(defaultRuntime, () => setTelemetryEnabled(false)));
-
-  applyParentDefaultHelpAction(telemetry);
+  for (const [name, enabled] of Object.entries({ on: true, off: false })) {
+    telemetry
+      .command(name)
+      .description(`${enabled ? "Enable" : "Disable"} anonymous feature statistics`)
+      .action(() => runCommandWithRuntime(defaultRuntime, () => setTelemetryEnabled(enabled)));
+  }
+  // Preserve the shipped help subcommand when adding a parent action.
+  applyParentDefaultHelpAction(telemetry.helpCommand(true));
 }

--- a/src/cli/telemetry-cli.ts
+++ b/src/cli/telemetry-cli.ts
@@ -7,6 +7,7 @@ import {
 } from "../infra/telemetry.js";
 import { defaultRuntime } from "../runtime.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
+import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
 
 const TELEMETRY_REASON_LABELS = {
   enabled: "enabled in configuration",
@@ -101,4 +102,6 @@ export function registerTelemetryCli(program: Command): void {
     .command("off")
     .description("Disable anonymous feature statistics")
     .action(async () => runCommandWithRuntime(defaultRuntime, () => setTelemetryEnabled(false)));
+
+  applyParentDefaultHelpAction(telemetry);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where invoking `openclaw telemetry` without a subcommand displayed help but exited with status 1. That made a normal help request look like a failure and stopped shell `&&` chains.

## Why This Change Was Made

The command now uses the shared parent-help action, including its startup bypass, and explicitly retains the existing implicit `help` command. The fixed on/off registration loop preserves order, descriptions, Boolean arguments and asynchronous completion. The show and consent handlers are unchanged. Production is +9/−9 (net 0); tests +65/−3 (+62).

## User Impact

Bare `openclaw telemetry` prints help and succeeds. Explicit, implicit and nested help remain available; invalid options and commands still fail. Showing telemetry information and recording an operator’s on/off choice keep their existing behavior.

## Evidence

The [installed-package baseline](https://github.com/steipete/openclaw/actions/runs/34082447285/job/101620266889) observed bare telemetry exit 1 after the healthy controls passed. An earlier harness-only capitalization assertion failed before reaching that case; its successfully built package was retained and verified for the remaining baseline calls. No product failure is inferred from that reader mistake.

The [fresh native-parent candidate run](https://github.com/steipete/openclaw/actions/runs/34094232133/job/101654153564) captured the intended unit failure before repair, then passed 290 tests across six complete suites and all 13 installed CLI calls. The canonical package build, normal installation, archive/installed-entry hashes, dependency graph, version and help behavior, synthetic consent/config preservation and cleanup passed. Bare telemetry exited 0 with the exact help block and no startup banner. This job later failed a test-only lint check for an unnecessary numeric conversion; its overall failure remains recorded.

The [remaining-check run](https://github.com/steipete/openclaw/actions/runs/34105938729/job/101695512971) removed only that conversion, passed all 13 affected tests, formatting, lint and all eight previously unrun checks, and verified the final two candidate files plus 71 unchanged owner hashes. Its complete final patch matches the native candidate. The earlier 290-test, package and installed-CLI results are explicitly reused because production is unchanged; they were not rerun or relabeled as new results. Independent source and artifact reviews and full autoreview are clean. Normal commit `5e2870f00e80` and its separate exact-head review preserve the verified source. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34112464220) and the required `openclaw/ci-gate` passed.

The baseline package used protected main `0a55c7c0`; the candidate package uses native parent `b8cbece8` and its pinned dependencies. The source differences were reviewed explicitly. Current main separately updates the show-command description and removes a startup-context wrapper; those changes must remain in the final merge. This repair does not alter telemetry collection or operator settings outside the synthetic proof state.

Thanks @Grynn for the original contribution.
