### PR TITLE
fix(update): recover when managed-wrapper retirement fails

### DIFF
--- a/src/cli/update-cli/update-command-post-update.test-support.ts
+++ b/src/cli/update-cli/update-command-post-update.test-support.ts
@@ -1,0 +1,29 @@
+import os from "node:os";
+import { vi } from "vitest";
+import { GATEWAY_SERVICE_SELECTOR_ENV_KEYS } from "../../daemon/constants.js";
+import { captureEnv } from "../../test-utils/env.js";
+
+export function createManagedServiceIdentityFixture(home: string) {
+  const keys = [
+    "HOME",
+    "USERPROFILE",
+    "OPENCLAW_HOME",
+    "OPENCLAW_SUPERVISOR_MODE",
+    ...GATEWAY_SERVICE_SELECTOR_ENV_KEYS,
+  ];
+  const env = captureEnv(keys);
+  // A private HOME does not change the OS account home checked by the real service guard.
+  const userInfo = vi.spyOn(os, "userInfo").mockReturnValue({ ...os.userInfo(), homedir: home });
+  for (const key of keys) {
+    delete process.env[key];
+  }
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  return {
+    home,
+    restore: () => {
+      userInfo.mockRestore();
+      env.restore();
+    },
+  };
+}

--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -1,9 +1,7 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import { GATEWAY_SERVICE_SELECTOR_ENV_KEYS } from "../../daemon/constants.js";
 import type { GatewayServiceCommandConfig } from "../../daemon/service.js";
 import {
   createUpdateRun,
@@ -13,7 +11,7 @@ import {
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { defaultRuntime } from "../../runtime.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { captureEnv } from "../../test-utils/env.js";
+import { createManagedServiceIdentityFixture } from "./update-command-post-update.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const mocks = vi.hoisted(() => ({
@@ -193,32 +191,6 @@ const successfulPluginUpdate = {
   integrityDrifts: [],
   warnings: [],
 };
-
-function createManagedServiceIdentityFixture() {
-  const home = tempDirs.make("openclaw-post-update-service-home-");
-  const keys = [
-    "HOME",
-    "USERPROFILE",
-    "OPENCLAW_HOME",
-    "OPENCLAW_SUPERVISOR_MODE",
-    ...GATEWAY_SERVICE_SELECTOR_ENV_KEYS,
-  ];
-  const env = captureEnv(keys);
-  // A private HOME does not change the OS account home checked by the real service guard.
-  const userInfo = vi.spyOn(os, "userInfo").mockReturnValue({ ...os.userInfo(), homedir: home });
-  for (const key of keys) {
-    delete process.env[key];
-  }
-  process.env.HOME = home;
-  process.env.USERPROFILE = home;
-  return {
-    home,
-    restore: () => {
-      userInfo.mockRestore();
-      env.restore();
-    },
-  };
-}
 
 async function finishSuccessfulPackageSwitch(
   params: {
@@ -487,7 +459,7 @@ describe("successful update finalization ordering", () => {
   it.each([
     { name: "retires the wrapper before persisting and printing success", denied: false },
     {
-      name: "marks and prints an error without persisting success when retirement fails",
+      name: "recovers and retains the package before reporting failed wrapper retirement",
       denied: true,
     },
   ])("$name", async ({ denied }) => {
@@ -505,13 +477,34 @@ describe("successful update finalization ordering", () => {
     if (denied) {
       unlink.mockRejectedValueOnce(new Error("unlink denied"));
     }
-    const finishing = finishSuccessfulPackageSwitch({
-      previousRoot,
-      packageRoot: path.join(home, "package"),
-    });
+    const rollback = vi
+      .spyOn(rollbackModule, "rollbackFailedUpdate")
+      .mockImplementationOnce(async ({ result }) => ({ result, rolledBack: false }));
+    const retained = {
+      name: "package backup retained",
+      command: "openclaw update",
+      cwd: previousRoot,
+      durationMs: 0,
+      exitCode: 0,
+      stderrTail: "Retained previous package for recovery.",
+    };
+    const complete = vi.fn<NonNullable<FinishUpdateParams["packageTransaction"]>["complete"]>(
+      async ({ activationVerified }) => (activationVerified ? undefined : retained),
+    );
+    const finishing = finishSuccessfulPackageSwitch(
+      { previousRoot, packageRoot: path.join(home, "package") },
+      { packageTransaction: { backupRoot: previousRoot, rollback: vi.fn(), complete } },
+    );
     if (denied) {
       await expectUpdateFailure(finishing, "wrapper-retirement-failed", {
         detail: expect.stringContaining("unlink denied"),
+      });
+      expect(rollback).toHaveBeenCalledOnce();
+      expect(complete).toHaveBeenCalledExactlyOnceWith({ activationVerified: false });
+      expect(mocks.printResult).toHaveBeenCalledOnce();
+      expect(mocks.printResult.mock.lastCall?.[0]).toMatchObject({
+        status: "error",
+        steps: expect.arrayContaining([retained]),
       });
       expect(mocks.writeSentinel).toHaveBeenCalledOnce();
       expectFailureReport("wrapper-retirement-failed");
@@ -582,7 +575,9 @@ describe("successful update finalization ordering", () => {
   });
 
   it("removes operator overrides and process identity from the managed install environment", async () => {
-    const identity = createManagedServiceIdentityFixture();
+    const identity = createManagedServiceIdentityFixture(
+      tempDirs.make("openclaw-post-update-service-home-"),
+    );
     const managedEnvironment = {
       ANTHROPIC_API_KEY: "managed-provider",
       MANAGED_VALUE: "base",
@@ -662,7 +657,9 @@ describe("successful update finalization ordering", () => {
   describe("managed service finalization", () => {
     let identity: ReturnType<typeof createManagedServiceIdentityFixture>;
     beforeEach(() => {
-      identity = createManagedServiceIdentityFixture();
+      identity = createManagedServiceIdentityFixture(
+        tempDirs.make("openclaw-post-update-service-home-"),
+      );
     });
     afterEach(() => {
       vi.unstubAllEnvs();

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -666,12 +666,15 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
           reason: "wrapper-retirement-failed",
           jsonMode: Boolean(params.opts.json),
         });
-        const reported = printFinalResult(
-          completedResult({
+        const reported = await reportResult(
+          {
             ...resultWithPostUpdate,
             status: "error",
             reason: "wrapper-retirement-failed",
-          }),
+          },
+          false,
+          undefined,
+          false,
         );
         throw new UpdateCommandFailure(reported, 1, retirement.error);
       }


### PR DESCRIPTION
Related: #124396

## What Problem This Solves

Fixes an issue where users updating OpenClaw would skip the normal recovery and package-retention handling when managed-wrapper retirement failed after activation. The failure was printed directly instead of passing through the existing finalization path.

## Why This Change Was Made

Route the failure through the existing awaited result handler. Preserve the consumed-sentinel failure guard and suppress duplicate notification. This is a narrow finalizer correction; it does not implement durable checkpoint restoration, retained-generation selection, or served-and-persisted turn verification.

## User Impact

A wrapper-retirement failure now receives the same recovery, package completion, task settlement, and final reporting as other update failures, with one failure notification.

## Evidence

- Regression failed before the fix: recovery was expected once but called zero times; the wrapper-retirement success control passed.
- Four focused finalizer, repair, rollback, and wrapper suites passed: 69 tests. The required runtime build passed.
- After extracting the existing service-identity fixture to stay within the test-file limit, all 31 finalizer tests passed again; type-aware lint passed.
- The full changed-file check for the final three-file patch passed, including core/core-test typechecks and dead-export analysis.
- Fresh independent review of the final patch and fixture found no actionable P0–P2 findings.

No live installation or service was modified. The complete older-installed-version to newer-artifact journey remains separate and is not claimed by these focused checks.
