### PR TITLE
fix(skills): Skill Workshop prompt blocks edits to externally owned skill source

### DIFF
--- a/src/agents/skill-workshop-prompt.ts
+++ b/src/agents/skill-workshop-prompt.ts
@@ -8,7 +8,8 @@ export const SKILL_WORKSHOP_TOOL_NAME = "skill_workshop";
 export function buildSkillWorkshopPromptSection(): string[] {
   return [
     "## Skill Workshop",
-    "Durable reusable skill/playbook/workflow work: `skill_workshop`; never write proposal/skill files directly.",
+    "Durable reusable skill/playbook/workflow work on this agent's Workshop-managed skills: `skill_workshop`; never write Workshop proposal/skill files directly.",
+    "Skills owned elsewhere (repository/project/workspace source, bundled, plugin, managed) are not Workshop targets: edit them through their owning files and tools when the user asks.",
     "Exception: the scheduled weekly collection review may edit SKILL.md files directly inside the provided Workshop directory so it can review the full collection in one normal isolated turn.",
     "Used skill proved wrong or incomplete: read it and follow the available tool's publication and autonomous policy. Where supported, autonomous mode may disable repair, stage a proposal, or apply it. Without an applicable autonomous policy, unsolicited improvements stay pending proposals when supported; otherwise describe the suggestion without publishing. Capture only durable, evidenced procedure changes—never task artifacts, transient failures, or unresolved guesses.",
     "Publication-only create/update requires an explicit user request; never present it as a pending draft. Apply/reject/quarantine only explicit user ask.",

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1472,7 +1472,13 @@ describe("buildAgentSystemPrompt", () => {
     });
     expect(withTool).toContain("- skill_workshop: Author reusable skills");
     expect(withTool).toContain("## Skill Workshop");
-    expect(withTool).toContain("Durable reusable skill/playbook/workflow work");
+    expect(withTool).toContain(
+      "Durable reusable skill/playbook/workflow work on this agent's Workshop-managed skills",
+    );
+    expect(withTool).toContain("never write Workshop proposal/skill files directly");
+    expect(withTool).toContain(
+      "Skills owned elsewhere (repository/project/workspace source, bundled, plugin, managed) are not Workshop targets",
+    );
     expect(withTool).toContain("Used skill proved wrong or incomplete");
     expect(withTool).toContain(
       "Where supported, autonomous mode may disable repair, stage a proposal, or apply it",


### PR DESCRIPTION
Closes #140246

## What Problem This Solves

Fixes an issue where users who ask an agent to edit a skill that lives in an ordinary source checkout (a project's own `skills/` folder, a plugin, a bundled or managed skill) would get a refusal instead of an edit when the `skill_workshop` tool is enabled. The injected Skill Workshop prompt said "never write proposal/skill files directly" without scoping it to Workshop-managed skills, so models treated it as a global prohibition. Skill Workshop then rejected the repository path as not writable, and the agent stopped with no change even after the user clarified that the target was repository source, not a live OpenClaw skill.

## Why This Change Was Made

The Skill Workshop docs already scope the tool to OpenClaw's own generated skills and say bundled, plugin, ClawHub, extra-root, managed, personal-agent, project, and workspace skills are edited through their owning tools or files. The prompt now says the same thing: the no-direct-write rule applies to this agent's Workshop-managed skills, and skills owned elsewhere are edited through their owning files and tools when the user asks. The Workshop mutation boundary itself is unchanged; this only corrects what the prompt claims about it. Non-goal: no change to the tool, the weekly collection-review exception, or the autonomous repair policy.

## User Impact

Agents with `skill_workshop` enabled can now carry out explicitly requested edits to repository, project, plugin, or other externally owned skill source through the normal file tools, while Workshop-managed skills still go through proposals. Existing sessions pick up the new prompt on their next session start.

## Evidence

Rendered `## Skill Workshop` section, main vs this branch (`buildAgentSystemPrompt` with `toolNames: ["read", "edit", "skill_workshop"]`):

```text
--- main ---
Durable reusable skill/playbook/workflow work: `skill_workshop`; never write proposal/skill files directly.

--- this branch ---
Durable reusable skill/playbook/workflow work on this agent's Workshop-managed skills: `skill_workshop`; never write Workshop proposal/skill files directly.
Skills owned elsewhere (repository/project/workspace source, bundled, plugin, managed) are not Workshop targets: edit them through their owning files and tools when the user asks.
```

The remaining lines of the section are byte-identical.

Focused test (`src/agents/system-prompt.test.ts`, "instructs models to use skill_workshop only when the tool is available") now asserts the scoped wording and the owning-files route:

```text
✓ src/agents/system-prompt.test.ts > buildAgentSystemPrompt > instructs models to use skill_workshop only when the tool is available
Test Files  1 passed (1)
```

`node scripts/check-changed.mjs`: passed (exit 0). Codex autoreview (gpt-6-astra, high): no actionable findings, "patch is correct (0.99)".

Related: #104114 touches the same prompt file for a different defect (skill-creator vs `skill_workshop` routing on creation); this change only scopes the no-direct-write rule.

## Revision b4c8996 proof

No code change since the last revision (same head `b4c8996`). This adds the live behavior evidence requested in review.

Setup: local build of this branch, one isolated state directory and one pinned config file per run, no Gateway involved. Pinned config (`--config`):

```json5
{
  // "coding" supplies group:fs (read/write/edit) and skill_workshop
  tools: { profile: "coding" },
  agents: {
    defaults: {
      models: { "openai/gpt-6-astra": { agentRuntime: { id: "openclaw" } } },
    },
  },
}
```

Command, once per run:

```bash
OPENCLAW_STATE_DIR=<state-dir> pnpm openclaw agent exec \
  --config <config.json5> --state-dir <state-dir> --cwd <workspace> \
  --model openai/gpt-6-astra --timeout 420 --json --message-file <prompt.txt>
```

Tool surface confirmed for that config by asking the agent to list its callable tools: `read`, `write`, `edit`, `exec`, `skill_workshop`, ... — so the Skill Workshop prompt section was injected for every run below.

`<workspace>/repo` is a separate git checkout (not an OpenClaw skills root) holding `repo/skills/clime/SKILL.md`. The prompt states that file is checked-in repository source shipped with that checkout and is not an OpenClaw skill, then asks for a procedure change: step 2 must read the dashboard token from the CI secret store, plus a final step recording the posted release id.

### A. Externally owned skill, this branch: 3/3 completed with ordinary file tools

Each run called `read` then `edit` on `repo/skills/clime/SKILL.md`, never `skill_workshop`, and `openclaw skills workshop list` reported `No skill proposals.` in all three state directories. `git -C repo diff` after each run:

```diff
 1. Build the release summary from the tagged changelog section.
-2. Recieve the dashboard token from the team vault before posting.
+2. Read the dashboard token from the CI secret store before posting.
 3. Post the summary to `https://clime.internal.example/api/releases`.
 4. Confirm the entry appears on the dashboard before reporting success.
+5. Record the posted release id in `release-log.md`.
```

Sanitized transcript shape (run 1; runs 2 and 3 are the same two calls):

```text
user       ... repo/skills/clime/SKILL.md is checked-in repository source ... not an OpenClaw skill ...
tool_call  read {"path":"repo/skills/clime/SKILL.md"}
tool_call  edit {"path":"repo/skills/clime/SKILL.md","edits":[{"oldText":"2. Recieve the dashboard token ...
assistant  Updated `repo/skills/clime/SKILL.md` only: ...
```

### B. Workshop-owned skill, this branch: governed route retained

Same build and config, with a Workshop skill at `<state-dir>/agents/main/agent/workshop-skills/release-notes/SKILL.md` and the same kind of step-2 change requested. The agent did not use `edit` or `write` on that file; it called `skill_workshop` `read` -> `update` -> `inspect` -> `apply`, and `openclaw skills workshop list` afterwards shows `release-notes-<date>-<id>  applied  update  release-notes`. Scoping the rule does not open direct writes to Workshop-owned files.

### C. Pre-fix contrast: no one-shot refusal reproduced

The same turn was run against `origin/main`'s `src/agents/skill-workshop-prompt.ts` (file swapped in, `dist/.buildstamp` removed, rebuilt, then restored). Pre-fix result: 3/3 also edited the repository file with `openai/gpt-6-astra`, and 3/3 with `openai/gpt-5.6-sol` on a simpler typo-only variant of the same scenario. So this single-turn harness does not reproduce the refusal from #140246.

That matches the report itself, which describes an observed multi-turn session (the agent first routed to Skill Workshop, Workshop rejected the repository path, and the agent then cited the blanket instruction) and states it is not an isolated automated reproduction. The evidence above therefore proves the after-fix behavior and the retained Workshop boundary, not a deterministic before/after flip; the deterministic part of the defect stays the prompt text, shown in the rendered diff above.

Proof gap: no live multi-turn channel session was reproduced, and model behavior is non-deterministic, so the counts above are three-run samples rather than guarantees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9NXEPFuSPs3efs2bE9hvB

