### PR TITLE
perf(usage): reduce chart sampling overhead

### DIFF
--- a/src/infra/session-cost-usage-reporting.ts
+++ b/src/infra/session-cost-usage-reporting.ts
@@ -219,7 +219,7 @@ export async function loadSessionUsageTimeSeries(params: {
     }
   }
 
-  const points: Array<Omit<SessionUsageTimePoint, "cumulativeTokens" | "cumulativeCost">> = [];
+  let points: Array<Omit<SessionUsageTimePoint, "cumulativeTokens" | "cumulativeCost">> = [];
   const agentDir = resolveUsageCostAgentDir(params.config, params.agentId);
   const resolveCost = createUsageCostResolver({ config: params.config, agentDir });
 
@@ -243,65 +243,51 @@ export async function loadSessionUsageTimeSeries(params: {
     });
   }
 
-  // Sort by timestamp
+  points.sort((a, b) => a.timestamp - b.timestamp);
+
+  const maxPoints = params.maxPoints ?? 100;
+  if (points.length > maxPoints) {
+    const step = Math.ceil(points.length / maxPoints);
+    const downsampled: typeof points = [];
+    let bucket: (typeof points)[number] | undefined;
+    let bucketSize = 0;
+    for (const point of points) {
+      if (!bucket || bucketSize === step) {
+        bucket = {
+          timestamp: point.timestamp,
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: 0,
+        };
+        downsampled.push(bucket);
+        bucketSize = 0;
+      }
+      bucket.timestamp = point.timestamp;
+      bucket.input += point.input;
+      bucket.output += point.output;
+      bucket.cacheRead += point.cacheRead;
+      bucket.cacheWrite += point.cacheWrite;
+      bucket.totalTokens += point.totalTokens;
+      bucket.cost += point.cost;
+      bucketSize += 1;
+    }
+    points = downsampled;
+  }
+
+  // Accumulate after sampling to preserve the bucket-based floating-point sums.
   let cumulativeTokens = 0;
   let cumulativeCost = 0;
-  const sortedPoints: SessionUsageTimePoint[] = points
-    .toSorted((a, b) => a.timestamp - b.timestamp)
-    .map((point) => {
+  return {
+    sessionId: params.sessionId,
+    points: points.map((point) => {
       cumulativeTokens += point.totalTokens;
       cumulativeCost += point.cost;
       return Object.assign(point, { cumulativeTokens, cumulativeCost });
-    });
-
-  // Optionally downsample if too many points
-  const maxPoints = params.maxPoints ?? 100;
-  if (sortedPoints.length > maxPoints) {
-    const step = Math.ceil(sortedPoints.length / maxPoints);
-    const downsampled: SessionUsageTimePoint[] = [];
-    let downsampledCumulativeTokens = 0;
-    let downsampledCumulativeCost = 0;
-    for (let i = 0; i < sortedPoints.length; i += step) {
-      const bucket = sortedPoints.slice(i, i + step);
-      const bucketLast = bucket[bucket.length - 1];
-      if (!bucketLast) {
-        continue;
-      }
-
-      let bucketInput = 0;
-      let bucketOutput = 0;
-      let bucketCacheRead = 0;
-      let bucketCacheWrite = 0;
-      let bucketTotalTokens = 0;
-      let bucketCost = 0;
-      for (const point of bucket) {
-        bucketInput += point.input;
-        bucketOutput += point.output;
-        bucketCacheRead += point.cacheRead;
-        bucketCacheWrite += point.cacheWrite;
-        bucketTotalTokens += point.totalTokens;
-        bucketCost += point.cost;
-      }
-
-      downsampledCumulativeTokens += bucketTotalTokens;
-      downsampledCumulativeCost += bucketCost;
-
-      downsampled.push({
-        timestamp: bucketLast.timestamp,
-        input: bucketInput,
-        output: bucketOutput,
-        cacheRead: bucketCacheRead,
-        cacheWrite: bucketCacheWrite,
-        totalTokens: bucketTotalTokens,
-        cost: bucketCost,
-        cumulativeTokens: downsampledCumulativeTokens,
-        cumulativeCost: downsampledCumulativeCost,
-      });
-    }
-    return { sessionId: params.sessionId, points: downsampled };
-  }
-
-  return { sessionId: params.sessionId, points: sortedPoints };
+    }),
+  };
 }
 
 export async function loadSessionLogs(params: {

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -3053,58 +3053,61 @@ describe("session cost usage", () => {
     expect(series?.points.map((point) => point.cumulativeCost)).toEqual([0.01, 0.03]);
   });
 
-  it("preserves totals and cumulative values when downsampling timeseries", async () => {
-    const root = await makeSessionCostRoot("timeseries-downsample");
-    const sessionsDir = path.join(root, "agents", "main", "sessions");
-    await fs.mkdir(sessionsDir, { recursive: true });
-    const sessionFile = path.join(sessionsDir, "sess-downsample.jsonl");
-
-    const entries = Array.from({ length: 10 }, (_, i) => {
-      const idx = i + 1;
-      return {
+  it.each([3, 2.5, 0.5])(
+    "preserves sampled fields, stable ties, and cumulative values with maxPoints=%s",
+    async (maxPoints) => {
+      const root = await makeSessionCostRoot("timeseries-downsample");
+      const sessionFile = path.join(root, "session.jsonl");
+      // The tied points cross a bucket boundary and must retain transcript order.
+      const entries = [8, 3, 1, 5, 2, 4, 10, 6, 9, 7].map((idx) => ({
         type: "message",
-        timestamp: new Date(Date.UTC(2026, 1, 12, 10, idx, 0)).toISOString(),
+        timestamp: new Date(Date.UTC(2026, 1, 12, 10, idx === 5 ? 4 : idx)).toISOString(),
         message: {
           role: "assistant",
-          provider: "openai",
-          model: "gpt-5.4",
           usage: {
             input: idx,
             output: idx * 2,
-            cacheRead: 0,
-            cacheWrite: 0,
-            totalTokens: idx * 3,
-            cost: { total: idx * 0.001 },
+            cacheRead: idx * 3,
+            cacheWrite: idx * 4,
+            totalTokens: idx * 11,
+            cost: { total: idx * 0.001, totalOrigin: "provider-billed" },
           },
         },
-      };
-    });
+      }));
+      await fs.writeFile(
+        sessionFile,
+        entries.map((entry) => JSON.stringify(entry)).join("\n"),
+        "utf-8",
+      );
 
-    await fs.writeFile(
-      sessionFile,
-      entries.map((entry) => JSON.stringify(entry)).join("\n"),
-      "utf-8",
-    );
-
-    const timeseries = await loadSessionUsageTimeSeries({
-      sessionFile,
-      maxPoints: 3,
-    });
-
-    const series = requireValue(timeseries, "session usage timeseries missing");
-    expect(series.points).toHaveLength(3);
-
-    const points = series.points;
-    const totalTokens = points.reduce((sum, point) => sum + point.totalTokens, 0);
-    const totalCost = points.reduce((sum, point) => sum + point.cost, 0);
-    const lastPoint = points[points.length - 1];
-
-    // Full-series totals: sum(1..10)*3 = 165 tokens, sum(1..10)*0.001 = 0.055 cost.
-    expect(totalTokens).toBe(165);
-    expect(totalCost).toBeCloseTo(0.055, 8);
-    expect(lastPoint?.cumulativeTokens).toBe(165);
-    expect(lastPoint?.cumulativeCost).toBeCloseTo(0.055, 8);
-  });
+      const series = requireValue(
+        await loadSessionUsageTimeSeries({ sessionFile, maxPoints }),
+        "session usage timeseries missing",
+      );
+      // Chronological groups are [1,2,3,5], [4,6,7,8], [9,10], or one complete bucket.
+      const expected =
+        maxPoints < 1
+          ? [{ weight: 55, cumulativeWeight: 55, minute: 10 }]
+          : [
+              { weight: 11, cumulativeWeight: 11, minute: 4 },
+              { weight: 25, cumulativeWeight: 36, minute: 8 },
+              { weight: 19, cumulativeWeight: 55, minute: 10 },
+            ];
+      expect(series.points).toEqual(
+        expected.map(({ weight, cumulativeWeight, minute }) => ({
+          timestamp: Date.UTC(2026, 1, 12, 10, minute),
+          input: weight,
+          output: weight * 2,
+          cacheRead: weight * 3,
+          cacheWrite: weight * 4,
+          totalTokens: weight * 11,
+          cost: expect.closeTo(weight * 0.001, 12),
+          cumulativeTokens: cumulativeWeight * 11,
+          cumulativeCost: expect.closeTo(cumulativeWeight * 0.001, 12),
+        })),
+      );
+    },
+  );
 
   it("returns empty points for zero, negative, and non-finite maxPoints", async () => {
     const root = await makeSessionCostRoot("timeseries-invalid-max-points");


### PR DESCRIPTION
## What Problem This Solves

Large Usage histories do unnecessary chart preparation before returning their bounded set of points, creating temporary objects that the sampled result will discard.

## Why This Change Was Made

Sort the loader's privately collected points, sum sampling buckets directly, and add cumulative totals once after sampling. Preserve stable timestamp ties, the last timestamp in each bucket, explicit token totals, cache fields, and bucket-first floating-point accumulation. Production code shrinks by 14 lines.

## User Impact

Usage charts return the same points with less temporary preparation for large sampled histories. Transcript reading, pricing, storage/cache behavior, configuration, and public response fields are unchanged.

## Evidence

- **360 exact comparisons** through the actual baseline/candidate loaders cover empty/singleton histories, unordered and tied timestamps, filtered records, invalid and fractional limits, division overflow, and rounding-sensitive costs. Frozen inputs and transcript bytes remain unchanged.
- All **96 focused reporting, pricing, and Gateway Usage tests** pass. The full changed-code gate passed in 330.09 seconds. Independent source/test review and fresh managed autoreview found no actionable issues.
- Actual-loader A/B/B/A samples with **50,000 points reduced to 200** show **6.54% lower sampled allocation** and **6.17% lower elapsed time**. Canonical file reading and pricing normalization remain in the measurement.
- There are two fresh process observations per arm with warm filesystem cache. Controls are mixed: small unsampled allocation rises 0.108%, and medium unsampled elapsed time rises 1.436%. These descriptive synthetic results do not establish a universal speedup, retained-memory/RSS reduction, statistical significance, or whole-Gateway improvement.
- All points still need collection and sorting because timestamps may be unordered. No live Gateway or provider experiment is claimed.
- Required hosted CI passed on the exact reviewed head ([run 34046334647](https://github.com/openclaw/openclaw/actions/runs/34046334647)).
