### PR TITLE
fix(tts): preserve channel delivery decisions

### DIFF
--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -817,6 +817,9 @@ whether voice-style TTS should ask providers for a native `voice-note` target or
 keep normal `audio-file` synthesis, and whether the channel transcodes
 non-native output before sending.
 
+One-off speech requests from the agent tool and `/tts` commands use the same
+channel delivery rules as automatic replies.
+
 Telegram also advertises captioned final TTS. With `tts.mode: "final"` and
 Auto-TTS set to `always` (or eligible `inbound` mode), streamed text is held
 until synthesis finishes and sent as the voice-note caption. Text beyond

--- a/src/agents/tools/tts-tool.test.ts
+++ b/src/agents/tools/tts-tool.test.ts
@@ -44,6 +44,7 @@ describe("createTtsTool", () => {
       audioPath: "/tmp/reply.opus",
       provider: "test",
       voiceCompatible: true,
+      audioAsVoice: true,
     });
 
     const tool = createTtsTool();
@@ -62,22 +63,41 @@ describe("createTtsTool", () => {
     expect(getCoreTtsToolResultMediaUrls(result)).toEqual(["/tmp/reply.opus"]);
   });
 
-  it("uses audioAsVoice from the TTS runtime even when the provider output is not native", async () => {
-    textToSpeechSpy.mockResolvedValue({
-      success: true,
-      audioPath: "/tmp/reply.mp3",
-      provider: "test",
-      voiceCompatible: false,
+  it.each([
+    {
       audioAsVoice: true,
-    });
+      voiceCompatible: false,
+      audioPath: "/tmp/reply.mp3",
+      channel: "feishu",
+    },
+    {
+      audioAsVoice: false,
+      voiceCompatible: true,
+      audioPath: "/tmp/reply.ogg",
+      channel: undefined,
+    },
+  ])(
+    "preserves runtime voice delivery $audioAsVoice with provider compatibility $voiceCompatible",
+    async ({ audioAsVoice, voiceCompatible, audioPath, channel }) => {
+      textToSpeechSpy.mockResolvedValue({
+        success: true,
+        audioPath,
+        provider: "test",
+        voiceCompatible,
+        audioAsVoice,
+      });
 
-    const tool = createTtsTool();
-    const result = await tool.execute("call-1", { text: "hello", channel: "feishu" });
+      const tool = createTtsTool();
+      const result = await tool.execute("call-1", { text: "hello", channel });
 
-    const media = requireRecord(requireRecord(result.details, "TTS result details").media, "media");
-    expect(media.mediaUrl).toBe("/tmp/reply.mp3");
-    expect(media.audioAsVoice).toBe(true);
-  });
+      const media = requireRecord(
+        requireRecord(result.details, "TTS result details").media,
+        "media",
+      );
+      expect(media.mediaUrl).toBe(audioPath);
+      expect(media.audioAsVoice).toBe(audioAsVoice ? true : undefined);
+    },
+  );
 
   it("passes an optional timeout to speech generation", async () => {
     textToSpeechSpy.mockResolvedValue({

--- a/src/agents/tools/tts-tool.ts
+++ b/src/agents/tools/tts-tool.ts
@@ -87,7 +87,7 @@ export function createTtsTool(opts?: {
               media: {
                 mediaUrl: result.audioPath,
                 trustedLocalMedia: true,
-                ...(result.audioAsVoice || result.voiceCompatible ? { audioAsVoice: true } : {}),
+                ...(result.audioAsVoice ? { audioAsVoice: true } : {}),
               },
             },
           },

--- a/src/auto-reply/reply/commands-tts.test.ts
+++ b/src/auto-reply/reply/commands-tts.test.ts
@@ -228,21 +228,27 @@ describe("handleTtsCommands status fallback reporting", () => {
     );
   });
 
-  it("uses the channel-derived audioAsVoice decision for /tts audio", async () => {
-    ttsMocks.textToSpeech.mockResolvedValue({
-      success: true,
-      audioPath: "/tmp/channel-voice.ogg",
-      provider: PRIMARY_TTS_PROVIDER,
-      voiceCompatible: false,
-      audioAsVoice: true,
-    });
+  it.each([
+    { audioAsVoice: true, voiceCompatible: false },
+    { audioAsVoice: false, voiceCompatible: true },
+  ])(
+    "preserves runtime voice delivery $audioAsVoice for /tts audio with provider compatibility $voiceCompatible",
+    async ({ audioAsVoice, voiceCompatible }) => {
+      ttsMocks.textToSpeech.mockResolvedValue({
+        success: true,
+        audioPath: "/tmp/channel-voice.ogg",
+        provider: PRIMARY_TTS_PROVIDER,
+        voiceCompatible,
+        audioAsVoice,
+      });
 
-    const result = await handleTtsCommands(buildTtsParams("/tts audio hello channel"), true);
-    const reply = expectReply(result);
+      const result = await handleTtsCommands(buildTtsParams("/tts audio hello channel"), true);
+      const reply = expectReply(result);
 
-    expect(reply.mediaUrl).toBe("/tmp/channel-voice.ogg");
-    expect(reply.audioAsVoice).toBe(true);
-  });
+      expect(reply.mediaUrl).toBe("/tmp/channel-voice.ogg");
+      expect(reply.audioAsVoice).toBe(audioAsVoice);
+    },
+  );
 
   it("treats bare /tts as status", async () => {
     const result = await handleTtsCommands(
@@ -335,78 +341,87 @@ describe("handleTtsCommands status fallback reporting", () => {
     expect(ttsMocks.setTtsPersona).toHaveBeenCalledWith("/tmp/tts-prefs.json", "alfred");
   });
 
-  it("reads the latest assistant transcript reply once", async () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-tts-latest-"));
-    const storePath = path.join(tempDir, "sessions.json");
-    const sessionKey = "agent:other:tts-latest";
-    const sessionEntry: SessionEntry = { sessionId: "s1", updatedAt: 1 };
-    const sessionStore = { [sessionKey]: sessionEntry };
-    await replaceSessionEntry({ agentId: "other", sessionKey, storePath }, sessionEntry);
-    const transcriptScope = {
-      agentId: "other",
-      sessionId: "s1",
-      sessionKey,
-      storePath,
-    };
-    appendTranscriptMessageSync(transcriptScope, {
-      message: { role: "assistant", content: [{ type: "text", text: "older reply" }] },
-    });
-    Object.assign(sessionEntry, loadSessionEntry({ agentId: "other", sessionKey, storePath }));
-    appendTranscriptMessageSync(transcriptScope, {
-      message: {
-        role: "assistant",
-        content: [
-          {
-            type: "text",
-            text: "internal note",
-            textSignature: JSON.stringify({
-              v: 1,
-              id: "item_commentary",
-              phase: "commentary",
-            }),
-          },
-          {
-            type: "text",
-            text: "latest visible reply",
-            textSignature: JSON.stringify({
-              v: 1,
-              id: "item_final",
-              phase: "final_answer",
-            }),
-          },
-        ],
-      },
-    });
-    ttsMocks.textToSpeech.mockResolvedValue({
-      success: true,
-      audioPath: "/tmp/latest.ogg",
-      provider: PRIMARY_TTS_PROVIDER,
-      voiceCompatible: true,
-    });
-    const beforeTtsRead = Date.now();
-    const initialSessionEntry = structuredClone(sessionEntry);
-    const result = await handleTtsCommands(
-      buildTtsParams("/tts read latest", {}, "main", {
-        initialSessionEntry,
-        sessionEntry,
-        sessionStore,
+  it.each([
+    { command: "/tts latest", audioAsVoice: true },
+    { command: "/tts read latest", audioAsVoice: true },
+    { command: "/tts latest", audioAsVoice: false },
+    { command: "/tts read latest", audioAsVoice: false },
+  ])(
+    "reads the latest assistant reply via $command with voice delivery $audioAsVoice",
+    async ({ command, audioAsVoice }) => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-tts-latest-"));
+      const storePath = path.join(tempDir, "sessions.json");
+      const sessionKey = "agent:other:tts-latest";
+      const sessionEntry: SessionEntry = { sessionId: "s1", updatedAt: 1 };
+      const sessionStore = { [sessionKey]: sessionEntry };
+      await replaceSessionEntry({ agentId: "other", sessionKey, storePath }, sessionEntry);
+      const transcriptScope = {
+        agentId: "other",
+        sessionId: "s1",
         sessionKey,
         storePath,
-      }),
-      true,
-    );
+      };
+      appendTranscriptMessageSync(transcriptScope, {
+        message: { role: "assistant", content: [{ type: "text", text: "older reply" }] },
+      });
+      Object.assign(sessionEntry, loadSessionEntry({ agentId: "other", sessionKey, storePath }));
+      appendTranscriptMessageSync(transcriptScope, {
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "internal note",
+              textSignature: JSON.stringify({
+                v: 1,
+                id: "item_commentary",
+                phase: "commentary",
+              }),
+            },
+            {
+              type: "text",
+              text: "latest visible reply",
+              textSignature: JSON.stringify({
+                v: 1,
+                id: "item_final",
+                phase: "final_answer",
+              }),
+            },
+          ],
+        },
+      });
+      ttsMocks.textToSpeech.mockResolvedValue({
+        success: true,
+        audioPath: "/tmp/latest.ogg",
+        provider: PRIMARY_TTS_PROVIDER,
+        voiceCompatible: true,
+        audioAsVoice,
+      });
+      const beforeTtsRead = Date.now();
+      const initialSessionEntry = structuredClone(sessionEntry);
+      const result = await handleTtsCommands(
+        buildTtsParams(command, {}, "main", {
+          initialSessionEntry,
+          sessionEntry,
+          sessionStore,
+          sessionKey,
+          storePath,
+        }),
+        true,
+      );
 
-    const reply = expectReply(result);
-    expect(reply.mediaUrl).toBe("/tmp/latest.ogg");
-    expect(reply.audioAsVoice).toBe(true);
-    expect(reply.spokenText).toBe("latest visible reply");
-    const speechCall = lastMockCall(ttsMocks.textToSpeech, "textToSpeech")[0] as {
-      text?: string;
-    };
-    expect(speechCall.text).toBe("latest visible reply");
-    expect(sessionEntry.lastTtsReadLatestHash).toMatch(/^[a-f0-9]{64}$/);
-    expect(sessionEntry.lastTtsReadLatestAt).toBeGreaterThanOrEqual(beforeTtsRead);
-  });
+      const reply = expectReply(result);
+      expect(reply.mediaUrl).toBe("/tmp/latest.ogg");
+      expect(reply.audioAsVoice).toBe(audioAsVoice);
+      expect(reply.spokenText).toBe("latest visible reply");
+      const speechCall = lastMockCall(ttsMocks.textToSpeech, "textToSpeech")[0] as {
+        text?: string;
+      };
+      expect(speechCall.text).toBe("latest visible reply");
+      expect(sessionEntry.lastTtsReadLatestHash).toMatch(/^[a-f0-9]{64}$/);
+      expect(sessionEntry.lastTtsReadLatestAt).toBeGreaterThanOrEqual(beforeTtsRead);
+    },
+  );
 
   it("reads the latest assistant reply from the incognito transcript store", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-tts-incognito-"));

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -158,7 +158,7 @@ async function buildTtsAudioReply(params: {
     return {
       reply: {
         mediaUrl: result.audioPath,
-        audioAsVoice: result.audioAsVoice === true || result.voiceCompatible === true,
+        audioAsVoice: result.audioAsVoice === true,
         trustedLocalMedia: true,
         spokenText: params.text,
       },

--- a/src/tts/tts-entry-delivery.test.ts
+++ b/src/tts/tts-entry-delivery.test.ts
@@ -1,0 +1,256 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { detectMime } from "@openclaw/media-core/mime";
+import { asRecord } from "@openclaw/normalization-core/record-coerce";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTtsTool } from "../agents/tools/tts-tool.js";
+import { handleTtsCommands } from "../auto-reply/reply/commands-tts.js";
+import type { HandleCommandsParams } from "../auto-reply/reply/commands-types.js";
+import { parseInlineSessionDirectives } from "../auto-reply/reply/directive-handling.parse.js";
+import { resolveChannelTtsVoiceDelivery } from "../channels/plugins/tts-capabilities.js";
+import type { ChannelTtsVoiceDeliveryCapabilities } from "../channels/plugins/types.core.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import type { SpeechProviderPlugin } from "../plugins/types.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { listSpeechProviders } from "./provider-registry.js";
+import { maybeApplyTtsToPayload, textToSpeech } from "./tts.js";
+
+// Constructed Ogg/Opus metadata fixture; no provider or decoder has been run.
+// One synthetic silence packet; use external decoder proof before claiming playable audio.
+const SYNTHETIC_OGG_OPUS = Buffer.from(
+  "T2dnUwACAAAAAAAAAAAxU1RUAAAAAHiu4UMBE09wdXNIZWFkAQEAAIC7AAAAAABPZ2dTAAAAAAAAAAAAADFTVFQBAAAAB6hLcAE3T3B1c1RhZ3MnAAAAT3BlbkNsYXcgc3ludGhldGljIFRUUyBtZXRhZGF0YSBmaXh0dXJlAAAAAE9nZ1MABMADAAAAAAAAMVNUVAIAAADuHqTAAQP4//4=",
+  "base64",
+);
+const SYNTHETIC_OGG_OPUS_SHA256 =
+  "08bf258f524277fa0b07e6334ebffb1eb600871d8d86ae3db139c2b968ddfb27";
+
+const converter = vi.hoisted(() => ({ requests: [] as Array<{ source: string; target: string }> }));
+
+vi.mock("../media/media-services.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../media/media-services.js")>();
+  return {
+    ...actual,
+    transcodeAudioBuffer: async (params: Parameters<typeof actual.transcodeAudioBuffer>[0]) => {
+      converter.requests.push({ source: params.sourceExtension, target: params.targetExtension });
+      if (params.sourceExtension !== "ogg" || params.targetExtension !== "caf") {
+        throw new Error("Unexpected conversion in the TTS metadata fixture");
+      }
+      // On macOS this is an explicit converter-failure fixture, not host capability proof.
+      // Other platforms execute the real early platform-unsupported path without a subprocess.
+      return process.platform === "darwin"
+        ? {
+            ok: false as const,
+            reason: "transcoder-failed" as const,
+            detail: "synthetic unavailable converter",
+          }
+        : actual.transcodeAudioBuffer(params);
+    },
+  };
+});
+
+const PROVIDER = "synthetic-tts-metadata";
+const CHANNEL = "imessage";
+const SPOKEN = "This synthetic audio should keep its channel delivery decision.";
+const requests: Array<{ target: string; text: string }> = [];
+let state: OpenClawTestState;
+let cfg: OpenClawConfig;
+
+function installFixture(voice: ChannelTtsVoiceDeliveryCapabilities, compatible = true): void {
+  const provider: SpeechProviderPlugin = {
+    id: PROVIDER,
+    label: "Synthetic TTS metadata fixture",
+    isConfigured: () => true,
+    synthesize: async (request) => {
+      requests.push({ target: request.target, text: request.text });
+      return {
+        audioBuffer: await fs.readFile(state.path("provider.ogg")),
+        fileExtension: ".ogg",
+        outputFormat: "ogg-24khz-16bit-mono-opus",
+        voiceCompatible: compatible,
+      };
+    },
+  };
+  const registry = createTestRegistry([
+    {
+      pluginId: CHANNEL,
+      source: "synthetic-tts-metadata-fixture",
+      plugin: createChannelTestPluginBase({
+        id: CHANNEL,
+        capabilities: { chatTypes: ["direct"], media: true, tts: { voice } },
+      }),
+    },
+  ]);
+  registry.speechProviders.push({ pluginId: PROVIDER, source: "synthetic", provider });
+  setActivePluginRegistry(registry);
+  expect(listSpeechProviders(cfg).map((entry) => entry.id)).toEqual([PROVIDER]);
+  expect(resolveChannelTtsVoiceDelivery(CHANNEL)).toEqual(voice);
+}
+
+function commandParams(): HandleCommandsParams {
+  const body = `/tts audio ${SPOKEN}`;
+  return {
+    cfg,
+    ctx: {},
+    agentId: "main",
+    command: {
+      surface: CHANNEL,
+      channel: CHANNEL,
+      senderId: "synthetic-owner",
+      ownerList: ["synthetic-owner"],
+      senderIsOwner: true,
+      isAuthorizedSender: true,
+      rawBodyNormalized: body,
+      commandBodyNormalized: body,
+    },
+    directives: parseInlineSessionDirectives(""),
+    elevated: { enabled: false, allowed: false, failures: [] },
+    sessionKey: "agent:main:tts-metadata-proof",
+    workspaceDir: state.workspaceDir,
+    defaultGroupActivation: () => "always",
+    resolvedVerboseLevel: "off",
+    resolvedReasoningLevel: "off",
+    resolveDefaultThinkingLevel: async () => undefined,
+    provider: PROVIDER,
+    model: "synthetic",
+    contextTokens: 4096,
+    isGroup: false,
+  };
+}
+
+async function assertStoredAudio(filePath: unknown): Promise<string> {
+  if (typeof filePath !== "string") {
+    throw new Error("Expected an actual persisted audio path");
+  }
+  expect(path.dirname(filePath)).toBe(state.statePath("media", "tool-speech-synthesis"));
+  const buffer = await fs.readFile(filePath);
+  expect(crypto.createHash("sha256").update(buffer).digest("hex")).toBe(SYNTHETIC_OGG_OPUS_SHA256);
+  expect(await detectMime({ buffer, filePath })).toBe("audio/ogg");
+  // The canonical media store preserves the supplied audio/ogg header extension.
+  expect(path.extname(filePath)).toBe(".ogg");
+  return filePath;
+}
+
+async function observeEntries(expectedVoice: boolean): Promise<void> {
+  const core = await textToSpeech({ text: SPOKEN, cfg, channel: CHANNEL, disableFallback: true });
+  expect(core).toMatchObject({ success: true, audioAsVoice: expectedVoice, provider: PROVIDER });
+  expect(core.voiceCompatible).toBe(!expectedVoice);
+  await assertStoredAudio(core.audioPath);
+
+  const tool = createTtsTool({ config: cfg, agentChannel: CHANNEL });
+  const result = await tool.execute("synthetic-tts", { text: SPOKEN });
+  const media = asRecord(asRecord(result.details)?.media);
+  await assertStoredAudio(media?.mediaUrl);
+
+  const command = await handleTtsCommands(commandParams(), true);
+  expect(command?.shouldContinue).toBe(false);
+  await assertStoredAudio(command?.reply?.mediaUrl);
+
+  const automatic = await maybeApplyTtsToPayload({
+    payload: { text: SPOKEN },
+    cfg,
+    channel: CHANNEL,
+    kind: "final",
+  });
+  await assertStoredAudio(automatic.mediaUrl);
+
+  process.stdout.write(
+    `${JSON.stringify({
+      proof: "tts-entry-delivery",
+      platform: process.platform,
+      converter:
+        converter.requests.length === 0
+          ? "not-requested"
+          : process.platform === "darwin"
+            ? "controlled-failure"
+            : "real-platform-unsupported",
+      provider: PROVIDER,
+      providerCompatible: core.voiceCompatible,
+      coreVoice: core.audioAsVoice,
+      toolVoice: media?.audioAsVoice === true,
+      commandVoice: command?.reply?.audioAsVoice === true,
+      automaticVoice: automatic.audioAsVoice === true,
+      byteHash: SYNTHETIC_OGG_OPUS_SHA256,
+      requests,
+      converterRequests: converter.requests,
+    })}\n`,
+  );
+
+  expect(requests).toHaveLength(4);
+  expect.soft(media?.audioAsVoice === true, "tool preserves core decision").toBe(expectedVoice);
+  expect
+    .soft(command?.reply?.audioAsVoice === true, "/tts audio preserves core decision")
+    .toBe(expectedVoice);
+  expect
+    .soft(automatic.audioAsVoice === true, "automatic sibling preserves core decision")
+    .toBe(expectedVoice);
+}
+
+describe("TTS real synthesis owner to public output entries", () => {
+  beforeEach(async () => {
+    state = await createOpenClawTestState({
+      layout: "home",
+      prefix: "openclaw-tts-entry-proof-",
+    });
+    vi.stubEnv("OPENCLAW_TTS_PREFS", state.path("tts-prefs.json"));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => {
+        throw new Error("Network is forbidden in the TTS metadata fixture");
+      }),
+    );
+    cfg = { tts: { auto: "always", provider: PROVIDER } };
+    await fs.writeFile(state.path("provider.ogg"), SYNTHETIC_OGG_OPUS);
+    requests.length = 0;
+    converter.requests.length = 0;
+  });
+
+  afterEach(async () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    await state.cleanup();
+  });
+
+  it("keeps incompatible audio-file output nonvoice despite provider compatibility", async () => {
+    installFixture({
+      synthesisTarget: "audio-file",
+      audioFileFormats: ["mp3", "caf", "audio/mpeg", "audio/x-caf"],
+      preferAudioFileFormat: "caf",
+    });
+    await observeEntries(false);
+    expect(requests.every((entry) => entry.target === "audio-file")).toBe(true);
+    expect(converter.requests).toHaveLength(4);
+  });
+
+  it("retains the opposite-polarity decision for a channel that transcodes voice output", async () => {
+    installFixture({ synthesisTarget: "voice-note", transcodesAudio: true }, false);
+    await observeEntries(true);
+    expect(requests.every((entry) => entry.target === "voice-note")).toBe(true);
+    expect(converter.requests).toHaveLength(0);
+  });
+
+  it("preserves a separate explicit automatic-payload voice request", async () => {
+    installFixture({
+      synthesisTarget: "audio-file",
+      audioFileFormats: ["mp3", "caf"],
+      preferAudioFileFormat: "caf",
+    });
+    const core = await textToSpeech({ text: SPOKEN, cfg, channel: CHANNEL, disableFallback: true });
+    expect(core).toMatchObject({ success: true, audioAsVoice: false, voiceCompatible: true });
+    const automatic = await maybeApplyTtsToPayload({
+      payload: { text: SPOKEN, audioAsVoice: true },
+      cfg,
+      channel: CHANNEL,
+      kind: "final",
+    });
+    await assertStoredAudio(automatic.mediaUrl);
+    expect(automatic.audioAsVoice).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #140287
Related prior work: #82174.

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled when applicable.

</details>

## What Problem This Solves

Fixes an issue where users requesting one-off speech through the TTS agent tool or `/tts` commands can have audio marked for voice delivery after synthesis has explicitly selected ordinary audio delivery. The mismatch occurs when provider output is voice-compatible but its final format does not satisfy the destination channel's voice rules.

## Why This Change Was Made

Both output builders now use the synthesis owner's final `audioAsVoice` decision without combining it with provider-level `voiceCompatible` metadata. This keeps channel format checks and conversion outcomes under one owner and aligns one-off speech with automatic TTS. No new option, fallback, public result type, or storage schema is introduced.

## User Impact

The tool, `/tts audio`, `/tts latest`, and `/tts read latest` preserve a non-voice result. Channel-selected voice delivery remains intact even when provider compatibility is false, preserving @xuruiray's earlier command fix in #82174. The TTS documentation now explicitly states that one-off requests follow the same channel delivery rules as automatic replies.

## Evidence

Candidate: signed commit `37e46d48fadabb8eaebbec44bb154128dfd32439`, based on `64bf824613261007a3f452974d63f83d6db7f512`.

| Proof | Observed result |
| --- | --- |
| Composed source reproduction before the repair | Real synthesis returns `audioAsVoice: false` for incompatible Ogg/Opus output after a controlled conversion failure, while provider compatibility stays true. Both tool and `/tts audio` incorrectly produce voice=true; automatic TTS stays false. One case fails with two intended assertions; two controls pass. |
| Focused unit regressions before the repair | Four intended failures cover the tool, `/tts audio`, `/tts latest`, and `/tts read latest`; four selected controls pass. |
| Full focused candidate suites | **55 passed, 0 failed, 0 skipped**: 14 tool cases, 18 command cases, 20 routing cases, and 3 composed-entry cases. Tool and command output preserve false, and true/false voice-delivery controls stay green. |
| Changed-file gate | Passed all required stages, including core/test typechecks, lint, dead-export and owner guards; 17m33s. |
| Independent review | Fresh managed review completed both passes with no P0–P2 findings. |
| Build | One uncached runtime/SDK/UI build passed in 112.16s on the signed candidate; source, dependency manifest and artifact identities verified. |
| Built-Gateway before/after | 13 cases per build: the baseline reproduced four incorrect explicit voice flags while nine controls held; the candidate preserves all 13 expected delivery decisions. Actual authenticated `/tools/invoke`, normal synthetic channel ingress/dispatch for three commands, real scripted agent replies for latest/automatic paths, and an explicit automatic-payload control. Six localhost Responses requests per build. |
| Published-head CI | [CI 34046426606](https://github.com/openclaw/openclaw/actions/runs/34046426606) completed successfully on exact `37e46d48fadabb8eaebbec44bb154128dfd32439`. |

The source fixture exercises a controlled converter failure; the built Gateway fixture independently exercises an ordinary nonvoice channel and a voice channel with channel-owned transcoding. The synthetic 20ms Opus fixture was decoded to PCM. Both runs retain raw results/media, recorded request and lifecycle facts, source/build seals and independent process cleanup checks. The recording transport proves delivery selection, not recipient-app playback or actual channel transcoding. No external speech provider or external model service is used.

The first built setup attempt stopped at readiness before any TTS case ran because the fixture lacked normal account startup lifecycle. That failed attempt was retained; after implementing the fixture lifecycle, baseline and candidate runs passed. The initial attempt also refreshed the public model catalog; successful runs disable that optional refresh through existing isolated configuration. No production code, assertion, readiness gate, or build was changed for this setup recovery.

The six-file patch composes unchanged onto main `7b39a827fef340125491b00f711c6441e35eecbf`; this is source-composition evidence, not an executed merged-main runtime.

Production changes are two replacements (+2/−2, net 0). Tests are +391/−100 (net +291), and documentation is +3. No lockfile, generated-file, or snapshot change is included.

The September 6, 16:48 UTC ClawSweeper review on the exact candidate reports no findings or before-merge actions. All 49 review context paths remain unchanged from the prior composition snapshot to the native main snapshot `3c6e8d4c82912a7afc9ee7635434bab7690b2e1b`.
