### PR TITLE
perf(tui): reduce terminal hyperlink rendering overhead

### DIFF
--- a/src/tui/osc8-hyperlinks.test.ts
+++ b/src/tui/osc8-hyperlinks.test.ts
@@ -133,15 +133,14 @@ describe("addOsc8Hyperlinks", () => {
     expect(addOsc8Hyperlinks(lines, [])).toEqual(lines);
   });
 
-  it("wraps a single-line URL with OSC 8", () => {
-    const url = "https://example.com";
-    const lines = [`Visit ${url} for info`];
-    const result = addOsc8Hyperlinks(lines, [url]);
-
-    expect(result[0]).toContain(`\x1b]8;;${url}\x07`);
-    expect(result[0]).toContain(`\x1b]8;;\x07`);
-    // The URL text should be between open and close
-    expect(result[0]).toBe(`Visit \x1b]8;;${url}\x07${url}\x1b]8;;\x07 for info`);
+  it.each([
+    { prefix: "Visit ", url: "https://example.com", suffix: " for info" },
+    { prefix: "🦞 東京 ", url: "https://example.com/😀/e\u0301", suffix: " 🧑‍💻" },
+    { prefix: "\ud800 ", url: "https://example.com/\udfff", suffix: " \udc00" },
+  ])("wraps a single-line URL with OSC 8 ($url)", ({ prefix, url, suffix }) => {
+    expect(addOsc8Hyperlinks([`${prefix}${url}${suffix}`], [url])).toEqual([
+      `${prefix}\x1b]8;;${url}\x07${url}\x1b]8;;\x07${suffix}`,
+    ]);
   });
 
   it.each([".", ",", ";", "!", "?", ":", "*", "_", "~", ".?!"])(
@@ -195,6 +194,16 @@ describe("addOsc8Hyperlinks", () => {
     expect(result[0]).toContain(`\x1b]8;;${fullUrl}\x07`);
     // Line 2: continuation should also be wrapped
     expect(result[1]).toContain(`\x1b]8;;${fullUrl}\x07`);
+  });
+
+  it("keeps a whole code point when a wrapped continuation matches only its high surrogate", () => {
+    const prefix = "https://example.com/";
+    const url = `${prefix}😀/path`;
+
+    expect(addOsc8Hyperlinks([prefix, "😁 next"], [url])).toEqual([
+      `\x1b]8;;${url}\x07${prefix}\x1b]8;;\x07`,
+      `\x1b]8;;${url}\x07😁\x1b]8;;\x07 next`,
+    ]);
   });
 
   it("wraps a URL with a bracketed IPv6 authority", () => {

--- a/src/tui/osc8-hyperlinks.ts
+++ b/src/tui/osc8-hyperlinks.ts
@@ -232,7 +232,8 @@ function applyOsc8Ranges(line: string, ranges: UrlRange[]): string {
       continue;
     }
 
-    for (const char of segment.value) {
+    let offset = 0;
+    while (offset < segment.value.length) {
       while (range && visiblePos >= range.end) {
         range = ranges[++rangeIndex];
       }
@@ -246,8 +247,23 @@ function applyOsc8Ranges(line: string, ranges: UrlRange[]): string {
         }
         activeUrl = targetUrl;
       }
-      result += char;
-      visiblePos += char.length;
+      let end =
+        rendererLink || !range
+          ? segment.value.length
+          : Math.min(
+              segment.value.length,
+              offset + (visiblePos < range.start ? range.start : range.end) - visiblePos,
+            );
+      // UTF-16 range boundaries must keep whole code points, even when a wrapped
+      // continuation matched only a leading surrogate.
+      const last = segment.value.charCodeAt(end - 1);
+      const next = segment.value.charCodeAt(end);
+      if (last >= 0xd800 && last <= 0xdbff && next >= 0xdc00 && next <= 0xdfff) {
+        end += 1;
+      }
+      result += segment.value.slice(offset, end);
+      visiblePos += end - offset;
+      offset = end;
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Long linked terminal output creates unnecessary per-character temporary strings while adding clickable links, even when large spans share the same link state.

## Why This Change Was Made

Copy contiguous text up to the next URL transition. Preserve the existing ANSI sequence handling, renderer-authored link targets, range discovery, and cache ownership. Keep whole Unicode code points when a wrapped match ends between surrogate halves. The localized span arithmetic adds 16 production lines.

## User Impact

Terminal Markdown keeps the same visible text, wrapping, styles, and clickable targets while doing less temporary work on changed linked output. Authored links retain precedence, and terminals without hyperlink support keep their existing fallback.

## Evidence

- **751 direct fixtures and 64 actual HyperlinkMarkdown frames** match baseline/candidate raw bytes, visible strings, widths, and column-level link targets. Both explicitly enabled and disabled capability modes pass; the direct fixtures are shared between modes, not counted twice. Cached renders retain identity.
- All **78 focused tests** and the full changed-code gate pass. Existing exact-output coverage includes Unicode and lone surrogates; a distinct wrapped-continuation case protects whole-code-point output. Independent source/evidence review and fresh managed autoreview found no actionable issues.
- Synthetic changed Markdown rendering samples **20.0% less allocation** with **6.4% lower median batch time**; direct long prose around a link samples **96.4% less allocation**. No-URL, no-range, and cached controls are roughly flat, with timing variation up to +3.2%.
- These are warmed component observations with five timed batches and a separate allocation sample in one process per arm. They do not establish retained heap, RSS, whole-Gateway improvement, live-provider latency, or an asymptotic whole-render gain.
- A removed Node loader mode failed before measurement; the working loader uses supported type stripping. The first capability setting exercised fallback unexpectedly; final measurements explicitly use the dependency's accepted enabled value, with a separate disabled-mode parity pass. Source and assertions were unchanged by those harness corrections.
- Required hosted CI passed on the exact reviewed head ([run 34046504089](https://github.com/openclaw/openclaw/actions/runs/34046504089)).

Before/after captures below replay two recorded actual HyperlinkMarkdown frames through Ghostty 0.4.0. Terminal panes are pixel-identical; the capture font/theme are local presentation settings. These are static component-output captures, not a full TUI or Gateway session, and clickable targets are established by the original parity checks rather than the PNGs.

![Before: recorded HyperlinkMarkdown component output](https://github.com/user-attachments/assets/ef72755e-f0ec-4bc6-9296-23d94b689354)

![After: recorded HyperlinkMarkdown component output](https://github.com/user-attachments/assets/2630645d-48b7-4a00-80db-840d816f6acf)
