### PR TITLE
fix(doctor): session SQLite import drops Codex assistant messages from legacy transcripts

### DIFF
--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -1776,6 +1776,48 @@ describe("runDoctorSessionSqlite", () => {
     }
   });
 
+  it("imports every legacy Codex assistant message, not only the last one", async () => {
+    const codexReply = (id: string, parentId: string, content: string) =>
+      JSON.stringify({
+        type: "message",
+        id,
+        parentId,
+        message: { role: "assistant", provider: "codex", api: "openai-chatgpt-responses", content },
+      });
+    const userMessage = (id: string, parentId: string | null, content: string) =>
+      JSON.stringify({ type: "message", id, parentId, message: { role: "user", content } });
+    const store = createLegacyStore({
+      transcriptLines: [
+        JSON.stringify({ type: "session", id: "session-1", version: 3 }),
+        userMessage("user-1", null, "hi"),
+        codexReply("reply-1", "user-1", "a"),
+        userMessage("user-2", "reply-1", "b"),
+        codexReply("reply-2", "user-2", "c"),
+        userMessage("user-3", "reply-2", "d"),
+      ],
+    });
+
+    const imported = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+
+    expect(imported.targets[0]?.issues).toEqual([]);
+    expect(imported.totals).toMatchObject({ importedTranscriptEvents: 6 });
+    expect(
+      loadTranscriptEventsSync({
+        agentId: "main",
+        storePath: store.storePath,
+        sessionId: "session-1",
+      }),
+    ).toEqual(
+      ["session-1", "user-1", "reply-1", "user-2", "reply-2", "user-3"].map((id) =>
+        expect.objectContaining({ id }),
+      ),
+    );
+  });
+
   it("retires verified exact originals while preserving current SQLite and unknown archives", async () => {
     const store = createLegacyStore({
       transcriptLines: [

--- a/src/config/sessions/session-accessor.sqlite-import-stage.ts
+++ b/src/config/sessions/session-accessor.sqlite-import-stage.ts
@@ -45,6 +45,7 @@ export function withSqliteSessionImportStage<T>(run: (stage: SqliteSessionImport
       CREATE TABLE selected (id TEXT PRIMARY KEY, seq INTEGER NOT NULL, parent_id TEXT, visible INTEGER NOT NULL) WITHOUT ROWID;
       CREATE TABLE user_keys (id TEXT PRIMARY KEY, visible_key TEXT, stripped_key TEXT) WITHOUT ROWID;
       CREATE INDEX user_keys_visible ON user_keys(visible_key);
+      CREATE TABLE normalized (seq INTEGER PRIMARY KEY, event_json TEXT NOT NULL) WITHOUT ROWID;
       BEGIN;
     `);
     return run(new SqliteSessionImportStage(database));
@@ -126,7 +127,7 @@ export class SqliteSessionImportStage {
     recognized: boolean;
   } {
     this.database.exec(
-      "DELETE FROM tree; DELETE FROM tree_sets; DELETE FROM selected; DELETE FROM user_keys;",
+      "DELETE FROM tree; DELETE FROM tree_sets; DELETE FROM selected; DELETE FROM user_keys; DELETE FROM normalized;",
     );
     type Node = SessionTranscriptTreeNode<Record<string, unknown>>;
     const put = this.database.prepare("INSERT OR REPLACE INTO tree VALUES (?, ?)");
@@ -153,6 +154,10 @@ export class SqliteSessionImportStage {
     const readRow = this.database.prepare(
       "SELECT event_json FROM rows WHERE source = ? AND seq = ?",
     );
+    const readNormalized = this.database.prepare("SELECT event_json FROM normalized WHERE seq = ?");
+    const stashNormalized = this.database.prepare(
+      "INSERT OR REPLACE INTO normalized VALUES (?, ?)",
+    );
     const update = this.database.prepare(
       "UPDATE rows SET event_json = ? WHERE source = ? AND seq = ?",
     );
@@ -172,7 +177,10 @@ export class SqliteSessionImportStage {
         }
         if (normalizeLegacyOpenAICodexTranscriptMetadata([entry]) > 0) {
           eventJson = JSON.stringify(entry);
-          update.run(eventJson, source, row.seq);
+          // Rewriting `rows` while its cursor is open re-delivers the row, and the replay
+          // guard below would then discard the re-delivered copy as a duplicate. Stash the
+          // normalized bytes aside and apply them once the scan has finished.
+          stashNormalized.run(row.seq, eventJson);
           changed = true;
         }
         if (entry.type === "session") {
@@ -200,7 +208,8 @@ export class SqliteSessionImportStage {
         if (typeof entry.id === "string" && (indexed || leafControl)) {
           const previous = lookup(entry.id);
           if (previous) {
-            const previousRow = readRow.get(source, Number(previous.entry.importSeq));
+            const previousSeq = Number(previous.entry.importSeq);
+            const previousRow = readNormalized.get(previousSeq) ?? readRow.get(source, previousSeq);
             if (previousRow && String(previousRow.event_json) === eventJson) {
               repeatedRows.add(String(row.seq));
               changed = true;
@@ -241,6 +250,12 @@ export class SqliteSessionImportStage {
       resetDescendantIds: diskSet("reset"),
       invalidLeafControlIds: diskSet("invalid"),
     });
+    this.database
+      .prepare(
+        `UPDATE rows SET event_json = (SELECT event_json FROM normalized WHERE normalized.seq = rows.seq)
+          WHERE source = ? AND seq IN (SELECT seq FROM normalized)`,
+      )
+      .run(source);
     this.database
       .prepare(
         `DELETE FROM rows WHERE source = ? AND CAST(seq AS TEXT) IN (

--- a/src/config/sessions/session-accessor.sqlite-import-stage.ts
+++ b/src/config/sessions/session-accessor.sqlite-import-stage.ts
@@ -45,7 +45,6 @@ export function withSqliteSessionImportStage<T>(run: (stage: SqliteSessionImport
       CREATE TABLE selected (id TEXT PRIMARY KEY, seq INTEGER NOT NULL, parent_id TEXT, visible INTEGER NOT NULL) WITHOUT ROWID;
       CREATE TABLE user_keys (id TEXT PRIMARY KEY, visible_key TEXT, stripped_key TEXT) WITHOUT ROWID;
       CREATE INDEX user_keys_visible ON user_keys(visible_key);
-      CREATE TABLE normalized (seq INTEGER PRIMARY KEY, event_json TEXT NOT NULL) WITHOUT ROWID;
       BEGIN;
     `);
     return run(new SqliteSessionImportStage(database));
@@ -127,7 +126,7 @@ export class SqliteSessionImportStage {
     recognized: boolean;
   } {
     this.database.exec(
-      "DELETE FROM tree; DELETE FROM tree_sets; DELETE FROM selected; DELETE FROM user_keys; DELETE FROM normalized;",
+      "DELETE FROM tree; DELETE FROM tree_sets; DELETE FROM selected; DELETE FROM user_keys;",
     );
     type Node = SessionTranscriptTreeNode<Record<string, unknown>>;
     const put = this.database.prepare("INSERT OR REPLACE INTO tree VALUES (?, ?)");
@@ -154,13 +153,30 @@ export class SqliteSessionImportStage {
     const readRow = this.database.prepare(
       "SELECT event_json FROM rows WHERE source = ? AND seq = ?",
     );
-    const readNormalized = this.database.prepare("SELECT event_json FROM normalized WHERE seq = ?");
-    const stashNormalized = this.database.prepare(
-      "INSERT OR REPLACE INTO normalized VALUES (?, ?)",
-    );
     const update = this.database.prepare(
       "UPDATE rows SET event_json = ? WHERE source = ? AND seq = ?",
     );
+    // Rewriting `rows` while its cursor is open re-delivers the row, and the replay guard
+    // would then discard the re-delivered copy as a duplicate. Rows that need normalized
+    // provider metadata are recorded here and rewritten once the scan has finished; until
+    // then their stored bytes are still legacy, so readers normalize on the way out.
+    const normalizedRows = diskSet("normalized");
+    const storedEventJson = (seq: number): string | undefined => {
+      const row = readRow.get(source, seq);
+      if (!row) {
+        return undefined;
+      }
+      const eventJson = String(row.event_json);
+      if (!normalizedRows.has(String(seq))) {
+        return eventJson;
+      }
+      const entry: unknown = JSON.parse(eventJson);
+      if (!isRecord(entry)) {
+        return eventJson;
+      }
+      normalizeLegacyOpenAICodexTranscriptMetadata([entry]);
+      return JSON.stringify(entry);
+    };
     let changed = false;
     let recognized = true;
     let headerSeq: number | undefined;
@@ -177,10 +193,7 @@ export class SqliteSessionImportStage {
         }
         if (normalizeLegacyOpenAICodexTranscriptMetadata([entry]) > 0) {
           eventJson = JSON.stringify(entry);
-          // Rewriting `rows` while its cursor is open re-delivers the row, and the replay
-          // guard below would then discard the re-delivered copy as a duplicate. Stash the
-          // normalized bytes aside and apply them once the scan has finished.
-          stashNormalized.run(row.seq, eventJson);
+          normalizedRows.add(String(row.seq));
           changed = true;
         }
         if (entry.type === "session") {
@@ -208,9 +221,7 @@ export class SqliteSessionImportStage {
         if (typeof entry.id === "string" && (indexed || leafControl)) {
           const previous = lookup(entry.id);
           if (previous) {
-            const previousSeq = Number(previous.entry.importSeq);
-            const previousRow = readNormalized.get(previousSeq) ?? readRow.get(source, previousSeq);
-            if (previousRow && String(previousRow.event_json) === eventJson) {
+            if (storedEventJson(Number(previous.entry.importSeq)) === eventJson) {
               repeatedRows.add(String(row.seq));
               changed = true;
               continue;
@@ -250,12 +261,15 @@ export class SqliteSessionImportStage {
       resetDescendantIds: diskSet("reset"),
       invalidLeafControlIds: diskSet("invalid"),
     });
-    this.database
-      .prepare(
-        `UPDATE rows SET event_json = (SELECT event_json FROM normalized WHERE normalized.seq = rows.seq)
-          WHERE source = ? AND seq IN (SELECT seq FROM normalized)`,
-      )
-      .run(source);
+    for (const pending of this.database
+      .prepare("SELECT id FROM tree_sets WHERE kind = 'normalized'")
+      .iterate()) {
+      const seq = Number(pending.id);
+      const eventJson = storedEventJson(seq);
+      if (eventJson !== undefined) {
+        update.run(eventJson, source, seq);
+      }
+    }
     this.database
       .prepare(
         `DELETE FROM rows WHERE source = ? AND CAST(seq AS TEXT) IN (

--- a/src/config/sessions/session-accessor.sqlite-import.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.test.ts
@@ -206,6 +206,61 @@ it("deduplicates existing and incoming bytes and identities, preserves aliases, 
   });
 });
 
+it("keeps legacy Codex assistant rows that precede later transcript rows during repair", async () => {
+  await withOpenClawTestState({ label: "import-codex-rows" }, async (state) => {
+    const params = target(state, "codex");
+    const codexReply = (id: string, parentId: string, content: string) => ({
+      type: "message",
+      id,
+      parentId,
+      message: { role: "assistant", provider: "codex", api: "openai-chatgpt-responses", content },
+    });
+    const events = [
+      { type: "session", id: "codex", version: 3 },
+      { type: "message", id: "user-1", parentId: null, message: { role: "user", content: "hi" } },
+      codexReply("reply-1", "user-1", "a"),
+      {
+        type: "message",
+        id: "user-2",
+        parentId: "reply-1",
+        message: { role: "user", content: "b" },
+      },
+      codexReply("reply-2", "user-2", "c"),
+      {
+        type: "message",
+        id: "user-3",
+        parentId: "reply-2",
+        message: { role: "user", content: "d" },
+      },
+    ];
+
+    expect(
+      await importSqliteSessionRows({
+        ...params,
+        repairLegacyTranscript: true,
+        readTranscriptEvents: (append) => events.forEach(append),
+      }),
+    ).toMatchObject({ transcriptEvents: events.length });
+
+    // Every row survives in order, and the Codex replies carry normalized provider metadata.
+    expect(loadTranscriptEventsSync({ ...params, sessionId: "codex" })).toEqual(
+      events.map((event) =>
+        expect.objectContaining(
+          event.id.startsWith("reply-")
+            ? {
+                id: event.id,
+                message: expect.objectContaining({
+                  provider: "openai",
+                  api: "openai-chatgpt-responses",
+                }),
+              }
+            : { id: event.id },
+        ),
+      ),
+    );
+  });
+});
+
 it("hands off exact SQLite bytes, duplicate IDs, timestamps and owner without append normalization", async () => {
   await withOpenClawTestState({ label: "import-exact" }, async (state) => {
     const params = target(state, "exact");


### PR DESCRIPTION
Closes #140100

## What Problem This Solves

Fixes an issue where users running `openclaw doctor --session-sqlite import` on a legacy `sessions.json` + transcript JSONL store would lose every assistant message the agent had produced on the Codex runtime (`message.provider: "codex"`), except the last one in the file, while user messages, tool results, and assistant messages from other providers imported normally. The receipt still reported the import as complete, `validate` and `inspect` stayed green, and the archived JSONL was classified as generic unknown history, so operators migrated with half a conversation and nothing pointed at the gap.

## Why This Change Was Made

The legacy repair pass normalizes Codex provider metadata while streaming the staged transcript rows from a SQLite cursor, and it wrote the normalized bytes back into the same table it was iterating. `node:sqlite` re-delivers an updated row from an open cursor, and the identical-replay guard then saw the second delivery as a duplicate of itself and scheduled the only copy of that row for deletion. The provider check is only the trigger; there was never an intended exclusion. The rows whose bytes need normalizing are now recorded in the spool's existing per-repair scratch set (`tree_sets`, the same `diskSet` the repair already uses for repeated and reset rows) and rewritten after the scan completes, so the cursor never observes a rewrite. Until that rewrite the stored bytes are still legacy, so the replay guard normalizes a recorded row on the way out before comparing, and genuine duplicates of a normalized row still deduplicate. The spool is a private temp database that is discarded after every import; no persistent store or schema changes, and no new table.

## Data-model compatibility

No persisted table changes, and no `CREATE TABLE`, `ALTER TABLE`, or new column anywhere: the scratch bookkeeping uses the spool's existing `tree_sets` table inside `transcripts.sqlite`, a private temp database that `withSqliteSessionImportStage` creates for one import in a private temp directory and removes in `finally`; nothing else opens it. The agent database (`agents/<id>/agent/openclaw-agent.sqlite`), migration-run manifest, archive layout, `restore`, and `validate` are untouched: `git diff --stat ce174871076..3fa839c8810` is `session-accessor.sqlite-import-stage.ts` (+32/-3) plus two test files. Verified against an existing database in the recovery run below: an agent database written by the `main` build accepts the fixed importer with no migration, and the byte-exact seen-set dedupe matched the rows the older build had written. No upgrade step; downgrade remains the existing `restore` flow.

## User Impact

`openclaw doctor --session-sqlite import` now imports every Codex-runtime assistant message from a legacy transcript, in order, with the provider metadata normalized as before. Operators who already migrated on an affected version still have the complete transcript in `session-sqlite-import-archive/`; `restore` followed by `validate` on this build reports the missing rows, and a re-run `import` appends them to the SQLite transcript (see the recovery run below for what that does and does not restore). Other providers and non-legacy stores are unaffected.

## Evidence

Root cause reproduced directly against `node:sqlite` on Node v24.18.0: iterating `SELECT ... FROM rows ORDER BY seq` and updating the current row's `event_json` inside the loop delivers each updated row twice (`1:codex 1:openai 2:openai 3:codex 3:openai ...`).

Regression tests fail on `main` and pass on this branch. Both use a six-row transcript where the Codex assistant replies are not the last row, which is the shape the existing coverage happened not to exercise:

- `src/config/sessions/session-accessor.sqlite-import.test.ts` "keeps legacy Codex assistant rows that precede later transcript rows during repair". On `main`:

```text
AssertionError: expected { sessionId: 'codex', …(3) } to match object { transcriptEvents: 6 }
```

- `src/commands/doctor-session-sqlite.test.ts` "imports every legacy Codex assistant message, not only the last one" (real `runDoctorSessionSqlite` import against a legacy store on disk). On `main`:

```text
AssertionError: expected { archivedLegacyStoreFiles: 1, …(12) } to match object { importedTranscriptEvents: 6 }
```

On this branch both pass and `loadTranscriptEventsSync` returns all six ids with `provider: "openai"` on the normalized replies.

`node scripts/check-changed.mjs`: passed (exit 0). Codex autoreview (gpt-6-astra, high): no actionable findings, "patch is correct (0.98)".

Follow-up (not in this PR): the pre-archive event count check at `src/commands/doctor-session-sqlite.ts` compares SQLite against the post-repair spool count rather than the source JSONL line count, so a repair that drops rows can certify itself. Worth a separate fix.

## Revision 33837db2f08

Answers the two red lanes on `82fbc57e81d`: the `check-test-types-core-2` TS18046 (`'event' is of type 'unknown'`) by asserting the stored rows with `expect.objectContaining` in one pass instead of narrowing opaque `TranscriptEvent` rows, and `checks-node-compact-small-2` (the `public` memory scenario seeds 100,000 `toolResult` events with no `message.provider`, so the new normalization path is a no-op there). CI on this head is green, including `checks-node-compact-small-2`.

## Real CLI proof on `33837db2f08`

Environment: Linux devbox, Node v24.18.0, no Gateway running, isolated `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` (`{}`) per run. Two built checkouts: `main` at `dbf7b06342d` (before the fix) and this branch at `33837db2f08` (`dist/.buildstamp` checked before each run). The legacy store is the shape from the issue, written by hand: `agents/main/sessions/sessions.json` with one `agent:main:main` entry pointing at `session-1.jsonl`, and a six-line transcript (`session` header, `user-1`, `reply-1` [codex], `user-2`, `reply-2` [codex], `user-3`; the two Codex replies are not the last row.)

Rows are read back with `sqlite3 -readonly <state>/agents/main/agent/openclaw-agent.sqlite` as `seq | id | role | provider` from `transcript_events`. Temp paths are shortened to `<state>`.

### Before the fix (`main` build `dbf7b06342d`), first import into an empty destination

```text
$ openclaw doctor --session-sqlite import --json        # 2026-09-06T20:16:11Z
"importedEntries": 1,
"importedTranscriptEvents": 4,
"issues": [],
"archivedTranscriptFiles": ["<state>/agents/main/session-sqlite-import-archive/agent_main_main.session-1.jsonl.imported-1788725777055"],
"archivedLegacyStoreFiles": ["<state>/agents/main/session-sqlite-import-archive/legacy-store.sessions.json.imported-1788725777105"]
$ sqlite3 ... transcript_events
0|session-1|-|-
1|user-1|user|-
2|user-2|user|-
3|user-3|user|-
rows: 4
$ openclaw doctor --session-sqlite validate --session-sqlite-agent main --json
{"mode":"validate","targets":0,"totals":{"issues":0}}      # exit 0
```

Both Codex replies are gone, the receipt reports no issue, the legacy files are archived, and `validate` selects nothing afterwards. The archived JSONL still holds all six lines.

### After the fix (this branch, build `33837db2f08`), first import into an empty destination

```text
$ openclaw doctor --session-sqlite import --json        # 2026-09-06T20:27:45Z
"importedEntries": 1,
"importedTranscriptEvents": 6,
"issues": [],
$ sqlite3 ... transcript_events
0|session-1|-|-
1|user-1|user|-
2|reply-1|assistant|openai
3|user-2|user|-
4|reply-2|assistant|openai
5|user-3|user|-
rows: 6
reply-1 / reply-2 event_json: "provider":"openai","api":"openai-chatgpt-responses", content as a text block
```

All six rows import in file order; the Codex replies carry the same normalized `provider`/`api` bytes the legacy normalizer produced before this change. `session_transcript_active_events` lists five active messages (event_seq 1..5).

### Recovery into an already-partial SQLite destination (one state directory, both builds)

This is the situation of an operator who already migrated on an affected version. Step 1 ran the `main` build, steps 2-4 ran this branch's build.

```text
1. main  $ openclaw doctor --session-sqlite import --session-sqlite-agent main --json
         "importedTranscriptEvents": 4          -> SQLite has user-1, user-2, user-3; legacy archived
2. branch $ openclaw doctor --session-sqlite restore --session-sqlite-agent main --json
         "restoredFiles": ["<state>/agents/main/sessions/session-1.jsonl", "<state>/agents/main/sessions/sessions.json"], "conflicts": []
3. branch $ openclaw doctor --session-sqlite validate --session-sqlite-agent main --json   # exit 1
         {"code":"sqlite_transcript_count_mismatch","message":"SQLite transcript has 4 events; source has 6.","sessionKey":"agent:main:main"}
         {"code":"active_sqlite_transcript_jsonl","message":"SQLite-backed session still has an active JSONL transcript file: <state>/agents/main/sessions/session-1.jsonl","sessionKey":"agent:main:main"}
4. branch $ openclaw doctor --session-sqlite import --session-sqlite-agent main --json
         "importedEntries": 1, "importedTranscriptEvents": 2, "issues": [], "archivedTranscriptFiles": 1
$ sqlite3 ... transcript_events
0|session-1|-|-
1|user-1|user|-
2|user-2|user|-
3|user-3|user|-
4|reply-1|assistant|openai
5|reply-2|assistant|openai
rows: 6
```

What this shows, and what it does not:

- `restore` returns the archived JSONL and `sessions.json` to their original paths (documented downgrade path, unchanged by this PR), and `validate` on the fixed build now names the gap instead of staying green.
- The re-run `import` takes the existing-destination path (`session-accessor.sqlite-import.ts`, `readTranscriptEvents` branch): the seen-set matched the four rows already in SQLite byte for byte and appended only the two missing Codex replies. Nothing is duplicated and nothing existing is rewritten.
- The recovered replies are appended after the existing rows (seq 4 and 5), not at their original positions. The transcript is complete on disk, but `session_transcript_active_events` then lists three active messages (event_seq 1, 2, 5) instead of five, so the active-branch projection of a recovered session does not match a fresh import. Restoring original order for an already-migrated session needs a separate repair; the User Impact wording above has been narrowed accordingly.

## Revision 3fa839c8810

Rebased onto `main` (`ce174871076`) and reworked the deferral so the fix adds no table. The previous head stashed the normalized bytes in a new `normalized` table inside the spool; the review flagged that `CREATE TABLE` as a stored-data-model change even though the spool is disposable. The repair now records the affected row numbers in the spool's existing `tree_sets` scratch set and rewrites those rows after the scan, normalizing a recorded row on read when the replay guard compares against it. Same fix, same regression tests, one table fewer.

Re-verified on this head, Linux, Node v24.18.0: `session-accessor.sqlite-import.test.ts` 14 passed, `doctor-session-sqlite.test.ts` 230 passed (2 skipped), `tsgo` core lane clean, `oxfmt` clean.

## Real CLI proof on `3fa839c8810`

Same setup as the earlier proof: isolated `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` (`{}`), the six-line legacy store from the issue (`session` header, `user-1`, `reply-1` [codex], `user-2`, `reply-2` [codex], `user-3`), built checkouts with `dist/.buildstamp` checked before each run: `main` at `dbf7b06342d` (before the fix) and this branch at `3fa839c8810`. Rows read back with `sqlite3 -readonly` as `seq | id | role | provider`.

### Before the fix (`main` build `dbf7b06342d`), first import into an empty destination

```text
$ openclaw doctor --session-sqlite import --session-sqlite-agent main --json
"importedEntries": 1,
"importedTranscriptEvents": 4,
"issues": [],
$ sqlite3 ... transcript_events
0|session-1|-|-
1|user-1|user|-
2|user-2|user|-
3|user-3|user|-
rows: 4
```

Same loss as before: both Codex replies are gone and the receipt reports no issue.

### After the fix (this branch, build `3fa839c8810`), first import into an empty destination

```text
$ openclaw doctor --session-sqlite import --json        # 2026-09-07T07:49:55Z
"importedEntries": 1,
"importedTranscriptEvents": 6,
"issues": [],
$ sqlite3 ... transcript_events
0|session-1|-|-
1|user-1|user|-
2|reply-1|assistant|openai
3|user-2|user|-
4|reply-2|assistant|openai
5|user-3|user|-
rows: 6
reply-1 | openai | openai-chatgpt-responses
reply-2 | openai | openai-chatgpt-responses
session_transcript_active_events: 5 rows (event_seq 1,2,3,4,5)
$ openclaw doctor --session-sqlite validate --session-sqlite-agent main --json   # exit 0
```

All six rows import in file order with the normalized `provider`/`api` bytes, exactly as on the previous head.

### Recovery into an already-partial SQLite destination (one state directory, both builds)

```text
1. main   $ openclaw doctor --session-sqlite import --session-sqlite-agent main --json
          "importedTranscriptEvents": 4          -> SQLite has user-1, user-2, user-3; legacy archived
2. branch $ openclaw doctor --session-sqlite restore --session-sqlite-agent main --json
          "restoredFiles": [<state>/agents/main/sessions/session-1.jsonl, <state>/agents/main/sessions/sessions.json], "conflicts": []
3. branch $ openclaw doctor --session-sqlite validate --session-sqlite-agent main --json   # exit 1
          {"code":"sqlite_transcript_count_mismatch","message":"SQLite transcript has 4 events; source has 6."}
          {"code":"active_sqlite_transcript_jsonl","message":"SQLite-backed session still has an active JSONL transcript file: ..."}
4. branch $ openclaw doctor --session-sqlite import --session-sqlite-agent main --json
          "importedEntries": 1, "importedTranscriptEvents": 2, "issues": []
$ sqlite3 ... transcript_events
0|session-1|-|-
1|user-1|user|-
2|user-2|user|-
3|user-3|user|-
4|reply-1|assistant|openai
5|reply-2|assistant|openai
rows: 6
session_transcript_active_events: 3 rows (event_seq 1,2,5)
```

Identical to the recovery run on the previous head: an agent database written by the `main` build accepts the reworked importer with no migration, the seen-set matches the four existing rows byte for byte, only the two missing replies are appended, and the recovery-order limitation described above is unchanged.

