### PR TITLE
refactor(agents): share harness context-engine input types

### DIFF
--- a/src/agents/harness/context-engine-lifecycle.ts
+++ b/src/agents/harness/context-engine-lifecycle.ts
@@ -27,8 +27,6 @@ import {
 import { stripRuntimeContextCustomMessages } from "../internal-runtime-context.js";
 import type { AgentMessage } from "../runtime/index.js";
 
-type HarnessContextEngine = ContextEngine;
-
 function preparePreTurnRuntimeContext(
   runtimeContext: ContextEngineRuntimeContext | undefined,
 ): ContextEngineRuntimeContext | undefined {
@@ -37,13 +35,6 @@ function preparePreTurnRuntimeContext(
   }
   const { rewriteTranscriptEntries: _rewriteTranscriptEntries, ...fenced } = runtimeContext;
   return fenced;
-}
-
-function runWithHarnessContextEngineTranscriptFence<T>(
-  transcriptReadFence: UserTurnTranscriptAdmissionReceipt | undefined,
-  run: () => T,
-): T {
-  return runWithSessionTranscriptReadFence(transcriptReadFence, run);
 }
 
 type HarnessRuntimeSettingsParams = {
@@ -59,7 +50,7 @@ type HarnessRuntimeSettingsParams = {
   maxOutputTokens?: number | null;
   fallbackReason?: string | null;
   degradedReason?: string | null;
-  contextEngine?: HarnessContextEngine;
+  contextEngine?: ContextEngine;
 };
 
 function buildHarnessContextEngineRuntimeSettings(
@@ -95,30 +86,21 @@ function buildHarnessContextEngineRuntimeSettings(
 /**
  * Run optional bootstrap + bootstrap maintenance for a harness-owned context engine.
  */
-export async function bootstrapHarnessContextEngine(params: {
-  hadSessionFile: boolean;
-  contextEngine?: HarnessContextEngine;
-  sessionId: string;
-  sessionKey?: string;
-  sessionTarget?: ContextEngineSessionTarget;
-  sessionFile: string;
-  sessionManager?: unknown;
-  runtimeContext?: ContextEngineRuntimeContext;
-  transcriptReadFence?: UserTurnTranscriptAdmissionReceipt;
-  runtimeSettings?: ContextEngineRuntimeSettings;
-  contextEngineHostSupport?: ContextEngineHostSupport;
-  harnessId?: string | null;
-  runtimeId?: string | null;
-  providerId?: string | null;
-  requestedModelId?: string | null;
-  modelId?: string | null;
-  maxOutputTokens?: number | null;
-  fallbackReason?: string | null;
-  degradedReason?: string | null;
-  runMaintenance?: typeof runHarnessContextEngineMaintenance;
-  config?: OpenClawConfig;
-  warn: (message: string) => void;
-}): Promise<void> {
+export async function bootstrapHarnessContextEngine(
+  params: Omit<HarnessRuntimeSettingsParams, "modelFamily" | "tokenBudget"> & {
+    hadSessionFile: boolean;
+    sessionId: string;
+    sessionKey?: string;
+    sessionTarget?: ContextEngineSessionTarget;
+    sessionFile: string;
+    sessionManager?: unknown;
+    runtimeContext?: ContextEngineRuntimeContext;
+    transcriptReadFence?: UserTurnTranscriptAdmissionReceipt;
+    runMaintenance?: typeof runHarnessContextEngineMaintenance;
+    config?: OpenClawConfig;
+    warn: (message: string) => void;
+  },
+): Promise<void> {
   if (
     !params.hadSessionFile ||
     !(params.contextEngine?.bootstrap || params.contextEngine?.maintain)
@@ -128,7 +110,7 @@ export async function bootstrapHarnessContextEngine(params: {
   try {
     const runtimeSettings = buildHarnessContextEngineRuntimeSettings(params);
     const runtimeContext = preparePreTurnRuntimeContext(params.runtimeContext);
-    await runWithHarnessContextEngineTranscriptFence(params.transcriptReadFence, async () => {
+    await runWithSessionTranscriptReadFence(params.transcriptReadFence, async () => {
       if (typeof params.contextEngine?.bootstrap === "function") {
         await params.contextEngine.bootstrap({
           sessionId: params.sessionId,
@@ -160,32 +142,23 @@ export async function bootstrapHarnessContextEngine(params: {
 /**
  * Assemble model context through the active harness-owned context engine.
  */
-export async function assembleHarnessContextEngine(params: {
-  contextEngine?: HarnessContextEngine;
-  sessionId: string;
-  sessionKey?: string;
-  agentId?: string;
-  appendOnlyRuntimeContext?: boolean;
-  messages: AgentMessage[];
-  tokenBudget?: number;
-  availableTools?: Set<string>;
-  citationsMode?: MemoryCitationsMode;
-  sandboxed?: boolean;
-  modelId: string;
-  prompt?: string;
-  runtimeSettings?: ContextEngineRuntimeSettings;
-  contextEngineHostSupport?: ContextEngineHostSupport;
-  harnessId?: string | null;
-  runtimeId?: string | null;
-  providerId?: string | null;
-  requestedModelId?: string | null;
-  modelFamily?: string | null;
-  maxOutputTokens?: number | null;
-  fallbackReason?: string | null;
-  degradedReason?: string | null;
-  runtimeContext?: ContextEngineRuntimeContext;
-  transcriptReadFence?: UserTurnTranscriptAdmissionReceipt;
-}) {
+export async function assembleHarnessContextEngine(
+  params: Omit<HarnessRuntimeSettingsParams, "modelId" | "tokenBudget"> & {
+    sessionId: string;
+    sessionKey?: string;
+    agentId?: string;
+    appendOnlyRuntimeContext?: boolean;
+    messages: AgentMessage[];
+    tokenBudget?: number;
+    availableTools?: Set<string>;
+    citationsMode?: MemoryCitationsMode;
+    sandboxed?: boolean;
+    modelId: string;
+    prompt?: string;
+    runtimeContext?: ContextEngineRuntimeContext;
+    transcriptReadFence?: UserTurnTranscriptAdmissionReceipt;
+  },
+) {
   if (!params.contextEngine) {
     return undefined;
   }
@@ -212,21 +185,19 @@ export async function assembleHarnessContextEngine(params: {
       runtimeContext,
       ...(params.prompt !== undefined ? { prompt: params.prompt } : {}),
     });
-  const result = await runWithHarnessContextEngineTranscriptFence(
-    params.transcriptReadFence,
-    async () =>
-      contextEngine.info.id === "legacy"
-        ? await assemble()
-        : await runWithPreparedMemoryPromptSection(
-            {
-              availableTools: params.availableTools ?? new Set(),
-              citationsMode: params.citationsMode,
-              agentId: params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey),
-              agentSessionKey: params.sessionKey,
-              sandboxed: params.sandboxed,
-            },
-            assemble,
-          ),
+  const result = await runWithSessionTranscriptReadFence(params.transcriptReadFence, async () =>
+    contextEngine.info.id === "legacy"
+      ? await assemble()
+      : await runWithPreparedMemoryPromptSection(
+          {
+            availableTools: params.availableTools ?? new Set(),
+            citationsMode: params.citationsMode,
+            agentId: params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey),
+            agentSessionKey: params.sessionKey,
+            sandboxed: params.sandboxed,
+          },
+          assemble,
+        ),
   );
   return ensureAssembleResultShape(result, contextEngine.info.id);
 }
@@ -269,36 +240,27 @@ function describeAssembleResultType(value: unknown): string {
 /**
  * Finalize a completed harness turn via afterTurn or ingest fallbacks.
  */
-export async function finalizeHarnessContextEngineTurn(params: {
-  contextEngine?: HarnessContextEngine;
-  promptError: boolean;
-  aborted: boolean;
-  yieldAborted: boolean;
-  sessionIdUsed: string;
-  sessionKey?: string;
-  sessionTarget?: ContextEngineSessionTarget;
-  sessionFile: string;
-  messagesSnapshot: AgentMessage[];
-  prePromptMessageCount: number;
-  tokenBudget?: number;
-  runtimeContext?: ContextEngineRuntimeContext;
-  runtimeSettings?: ContextEngineRuntimeSettings;
-  contextEngineHostSupport?: ContextEngineHostSupport;
-  harnessId?: string | null;
-  runtimeId?: string | null;
-  providerId?: string | null;
-  requestedModelId?: string | null;
-  modelId?: string | null;
-  maxOutputTokens?: number | null;
-  fallbackReason?: string | null;
-  degradedReason?: string | null;
-  runMaintenance?: typeof runHarnessContextEngineMaintenance;
-  sessionManager?: unknown;
-  config?: OpenClawConfig;
-  warn: (message: string) => void;
-  /** True when this turn belongs to a heartbeat run. */
-  isHeartbeat?: boolean;
-}) {
+export async function finalizeHarnessContextEngineTurn(
+  params: Omit<HarnessRuntimeSettingsParams, "modelFamily" | "tokenBudget"> & {
+    promptError: boolean;
+    aborted: boolean;
+    yieldAborted: boolean;
+    sessionIdUsed: string;
+    sessionKey?: string;
+    sessionTarget?: ContextEngineSessionTarget;
+    sessionFile: string;
+    messagesSnapshot: AgentMessage[];
+    prePromptMessageCount: number;
+    tokenBudget?: number;
+    runtimeContext?: ContextEngineRuntimeContext;
+    runMaintenance?: typeof runHarnessContextEngineMaintenance;
+    sessionManager?: unknown;
+    config?: OpenClawConfig;
+    warn: (message: string) => void;
+    /** True when this turn belongs to a heartbeat run. */
+    isHeartbeat?: boolean;
+  },
+) {
   if (!params.contextEngine) {
     return { postTurnFinalizationSucceeded: true };
   }
@@ -427,31 +389,21 @@ export function buildHarnessContextEngineRuntimeContextFromUsage(
 /**
  * Run optional transcript maintenance for a harness-owned context engine.
  */
-export async function runHarnessContextEngineMaintenance(params: {
-  contextEngine?: HarnessContextEngine;
-  sessionId: string;
-  sessionKey?: string;
-  sessionTarget?: ContextEngineSessionTarget;
-  sessionFile: string;
-  reason: "bootstrap" | "compaction" | "turn";
-  sessionManager?: unknown;
-  runtimeContext?: ContextEngineRuntimeContext;
-  runtimeSettings?: ContextEngineRuntimeSettings;
-  contextEngineHostSupport?: ContextEngineHostSupport;
-  harnessId?: string | null;
-  runtimeId?: string | null;
-  providerId?: string | null;
-  requestedModelId?: string | null;
-  modelId?: string | null;
-  tokenBudget?: number | null;
-  maxOutputTokens?: number | null;
-  fallbackReason?: string | null;
-  degradedReason?: string | null;
-  executionMode?: "foreground" | "background";
-  onDeferredMaintenance?: (promise: Promise<void>) => void;
-  withSessionManagerRewriteLock?: <T>(operation: () => Promise<T> | T) => Promise<T>;
-  config?: OpenClawConfig;
-}) {
+export async function runHarnessContextEngineMaintenance(
+  params: Omit<HarnessRuntimeSettingsParams, "modelFamily"> & {
+    sessionId: string;
+    sessionKey?: string;
+    sessionTarget?: ContextEngineSessionTarget;
+    sessionFile: string;
+    reason: "bootstrap" | "compaction" | "turn";
+    sessionManager?: unknown;
+    runtimeContext?: ContextEngineRuntimeContext;
+    executionMode?: "foreground" | "background";
+    onDeferredMaintenance?: (promise: Promise<void>) => void;
+    withSessionManagerRewriteLock?: <T>(operation: () => Promise<T> | T) => Promise<T>;
+    config?: OpenClawConfig;
+  },
+) {
   const runtimeSettings = buildHarnessContextEngineRuntimeSettings(params);
   return await runContextEngineMaintenance({
     contextEngine: params.contextEngine,

--- a/src/commands/doctor-session-sqlite.memory.test.ts
+++ b/src/commands/doctor-session-sqlite.memory.test.ts
@@ -35,6 +35,8 @@ beforeAll(async () => {
     // preserve function/class names used by runtime dispatch and diagnostics.
     minify: true,
     keepNames: true,
+    // Preserve lazy imports so unrelated runtime modules do not consume the child heap.
+    splitting: true,
     outdir: outDir,
     external: Object.entries(packageJson.dependencies)
       .filter(([, version]) => !version.startsWith("workspace:"))


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Four harness context-engine lifecycle inputs repeat the runtime/model settings already owned by their shared builder. A private transcript-fence relay and a one-use type alias add indirection without defining a separate contract. This maintainer-requested cleanup removes that duplication.

## Why This Change Was Made

Reuse the existing settings input type with explicit exclusions for each lifecycle method, preserving required model ids, nullable versus nonnullable budgets, session fields and generic callbacks. Call the same transcript-read-fence owner directly. The SDK's independent public `HarnessContextEngine` alias and all public function names remain unchanged.

This is an independent clean-broad companion to the #135868 split (decision brief §1 concern map and §5 stack order); no feature-stage content is extracted.

## User Impact

No user-visible behavior change. Lifecycle ordering, runtime settings, transcript read fencing, history isolation, callback results/errors, and SDK parameter contracts remain unchanged. No audit collection, reader scope, receipt fields, storage schema or native protocol changes.

## Evidence

- The pre-change owner is byte-identical to stable `v2026.9.2`; the same lifecycle functions and public SDK alias are exported there. The removed relay and local alias are private implementation details.
- 54 existing tests pass before and after across lifecycle hooks, runtime settings, maintenance and real SQLite transcript-read fencing.
- 22 symbolic type assertions pass in both optional-property modes. A separate 32-assertion compiler bridge imports the actual changed source under the repository configuration; it does not rely on old build output. Nine deliberately incompatible type mutations are detected, including requiredness, nullable budgets, extra fields and generic rewrite-lock callbacks.
- The complete emitted program is identical after normalizing exactly the private relay deletion and its two direct call replacements. The relay was synchronous and returned the existing helper's result without adaptation.
- The canonical AsyncLocalStorage fence module passes 12 direct and 42 lifecycle comparison scenarios, covering nested/concurrent async receipts and callback value/error/promise identity. Dropped-receipt and async-wrapper mutations are detected. Storage operations are forbidden in this synthetic probe; retained SQLite tests separately cover durable admission checks.
- Current Codex consumers and pinned sibling source `rust-v0.153.4` were inspected (`protocol/v2/thread.rs:62–127`, `turn.rs:156–217`). This generic SDK cleanup changes no native request shape or Codex behavior.
- Full selected changed checks passed, including production/core-test types, all three dead-export scans, targeted lint and architecture/storage guards; runtime import cycles are zero. Local independent Codex review is clean through P2. The full build passed in 6m52s on committed head `a34ae87c979`, verified all 152 public SDK subpaths, and left tracked files unchanged. A fresh built-SDK consumer probe passes in both optional-property modes, including the retained public alias and wrappers; development source aliases were removed from that temporary consumer configuration so it resolves published declarations. Branch Codex review is also clean through P2.

| Judged class | Added | Deleted | Net | Before → after |
| --- | ---: | ---: | ---: | --- |
| Production | 83 | 131 | −48 | `context-engine-lifecycle.ts`: 482 → 434 |
| Tests | 2 | 0 | +2 | Memory-test lazy bundle configuration |
| Tooling | 0 | 0 | 0 | unchanged |
| Docs | 0 | 0 | 0 | unchanged |

No baseline, dependency, config option, environment variable or public SDK export is added or removed.


The pre-publication main refresh preserved all 24 recorded proof inputs and the lockfile. No dependency reinstall was needed.

### Exact-head CI repair

The public Doctor memory case failed in [CI run 34046977418](https://github.com/openclaw/openclaw/actions/runs/34046977418/job/101523769844). The same Node 24.19.0 Linux failure reproduced on Blacksmith Testbox `tbx_01m1vtydffekxjr9932bd9ger2`: batch and deep passed, then public Doctor exceeded its 256 MiB heap. This was a real budget failure, not a timeout or presumed flake.

The fixture bundled lazy runtime imports into one module, loading unrelated provider SDKs into the child before importing transcript data. Bundle analysis measured 23.4 MB of initial static code versus 4.2 MB with splitting; 43 external imports remain behind their original lazy boundaries. Diagnostic phase measurements on macOS showed about 206 MiB before public import, reduced to 77 MiB with splitting. Public Doctor still executes plugin contract validation and repairs.

Enable esbuild splitting, matching the existing canonical-key memory fixture. Preserve all three scenarios, real maintenance worker entries, 100,000-event deep/public inputs, payload hashes, branch projections, idempotence, backup checks, timeout and heap cap. All three cases now pass on the same Linux Testbox (73.1s suite duration) and locally. The test's original minification change in #134252 explicitly excluded generated-source overhead from the transcript-data budget; no production loader policy or storage behavior changes.

The initial Testbox capsule lacked `tsx/esm`; installing its frozen dependencies resolved that setup failure before the reproduced test failure and successful repair run. The task-owned lease was stopped after proof. Independent Codex review of the combined diff is clean through P2.

ClawSweeper reviewed head `157626a07415` with no findings and no before-merge or rank-up requests. Its source review agrees that the shared input and direct fence calls preserve contracts. The subsequent two-line memory-fixture repair is covered by the additional Linux/local proof and independent review above.

After the CI repair, the full selected changed-check plan passed, including all core-test typing and all three dead-export scans. Rebase preserved all 24 recorded harness proof inputs and the lockfile; no reinstall was needed.

The repaired head `653313d690e6` passed exact-head CI run [34048237282](https://github.com/openclaw/openclaw/actions/runs/34048237282), including the previously failing Doctor shard; the canonical watcher returned GREEN. The final pre-land main refresh is patch-identical by range-diff, preserves all 24 proof inputs and the lockfile, and has a fresh clean branch review.
