### PR TITLE
refactor(daemon): remove unreachable launchd alias recovery

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2690,7 +2690,7 @@ src/cron/store/quarantine.ts	1
 src/cron/store/row-codec.ts	4
 src/cron/task-run-detail.ts	2
 src/daemon/arg-split.ts	2
-src/daemon/launchd-install.ts	7
+src/daemon/launchd-install.ts	6
 src/daemon/launchd-lifecycle.ts	4
 src/daemon/launchd-service-files.ts	1
 src/daemon/launchd-stop.ts	2

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -56,11 +56,6 @@ export function resolveGatewayLaunchAgentLabel(profile?: string): string {
   return `ai.openclaw.${normalized}`;
 }
 
-export function resolveLegacyGatewayLaunchAgentLabels(profile?: string): string[] {
-  void profile;
-  return [];
-}
-
 export function resolveGatewaySystemdServiceName(profile?: string): string {
   const suffix = resolveGatewayProfileSuffix(profile);
   if (!suffix) {

--- a/src/daemon/launchd-install.ts
+++ b/src/daemon/launchd-install.ts
@@ -2,7 +2,6 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { resolveLegacyGatewayLaunchAgentLabels } from "./constants.js";
 import { isCurrentProcessInsideLaunchdService } from "./launchd-current-service.js";
 import {
   execLaunchctl,
@@ -18,13 +17,11 @@ import {
 import {
   LAUNCH_AGENT_ENV_FILE_MODE,
   LAUNCH_AGENT_ENV_WRAPPER_MODE,
-  LAUNCH_AGENT_PLIST_MODE,
   publishLaunchAgentPlist,
   readExistingLaunchAgentPlist,
   resolveLaunchAgentEnvFilePath,
   resolveLaunchAgentEnvWrapperPath,
   resolveLaunchAgentPlistPath,
-  resolveLaunchAgentPlistPathForLabel,
   writeLaunchAgentPlist,
 } from "./launchd-service-files.js";
 import { assertNoSystemLaunchDaemonOwnership } from "./launchd-system.js";
@@ -140,12 +137,6 @@ type LaunchAgentInstallSnapshot = {
   plistContents: Buffer | null;
   envFileContents: Buffer | null;
   wrapperContents: Buffer | null;
-  legacy: Array<{
-    label: string;
-    plistPath: string;
-    contents: Buffer | null;
-    loaded: boolean;
-  }>;
   loaded: boolean;
 };
 
@@ -212,13 +203,6 @@ async function restoreLaunchAgentInstallArtifacts(params: {
     contents: params.snapshot.wrapperContents,
     mode: LAUNCH_AGENT_ENV_WRAPPER_MODE,
   });
-  for (const legacy of params.snapshot.legacy) {
-    await restoreLaunchAgentOwnedFile({
-      path: legacy.plistPath,
-      contents: legacy.contents,
-      mode: LAUNCH_AGENT_PLIST_MODE,
-    });
-  }
   if (params.snapshot.plistContents === null) {
     await fs.unlink(params.plistPath).catch((error: unknown) => {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
@@ -271,18 +255,6 @@ async function restoreLaunchAgentInstall(params: {
       retryPendingTeardown: true,
     });
   }
-  for (const legacy of params.snapshot.legacy) {
-    if (!legacy.loaded || legacy.contents === null) {
-      continue;
-    }
-    await bootstrapLaunchAgentOrThrow({
-      domain: params.domain,
-      serviceTarget: `${params.domain}/${legacy.label}`,
-      plistPath: legacy.plistPath,
-      actionHint: "openclaw gateway start",
-      retryPendingTeardown: true,
-    });
-  }
 }
 
 async function deactivateLaunchAgentDefinition(domain: string, plistPath: string): Promise<void> {
@@ -310,11 +282,6 @@ async function activateLaunchAgent(params: {
     // Recheck immediately before activation so a system daemon installed after
     // the plist write cannot race us into two KeepAlive managers.
     await assertNoSystemLaunchDaemonOwnership(label);
-    for (const legacy of params.snapshot.legacy) {
-      if (legacy.loaded) {
-        await deactivateLaunchAgentDefinition(domain, legacy.plistPath);
-      }
-    }
     // Plist-form bootout reports EIO for a valid definition that was never loaded.
     // The pre-publication snapshot is the authoritative cutover fact.
     if (params.snapshot.loaded) {
@@ -328,13 +295,6 @@ async function activateLaunchAgent(params: {
       actionHint: "openclaw gateway install --force",
       retryPendingTeardown: true,
     });
-    for (const legacy of params.snapshot.legacy) {
-      await fs.unlink(legacy.plistPath).catch((error: unknown) => {
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-          throw error;
-        }
-      });
-    }
   } catch (error) {
     try {
       await restoreLaunchAgentInstall({
@@ -364,18 +324,6 @@ export async function installLaunchAgent(
   const domain = resolveLaunchAgentGuiDomain();
   // Plist, generated environment files, and launchd registration form one cutover.
   // Capture every prior owner before publication so any later failure can restore it.
-  const legacy = await Promise.all(
-    resolveLegacyGatewayLaunchAgentLabels(args.env.OPENCLAW_PROFILE).map(async (legacyLabel) => {
-      const plistPath = resolveLaunchAgentPlistPathForLabel(args.env, legacyLabel);
-      const contents = await readExistingLaunchAgentPlist(plistPath);
-      return {
-        label: legacyLabel,
-        plistPath,
-        contents,
-        loaded: await snapshotLaunchAgentLoadedState(contents, `${domain}/${legacyLabel}`),
-      };
-    }),
-  );
   const snapshot: LaunchAgentInstallSnapshot = {
     plistContents: previousContents,
     envFileContents: await readExistingLaunchAgentPlist(
@@ -384,7 +332,6 @@ export async function installLaunchAgent(
     wrapperContents: await readExistingLaunchAgentPlist(
       resolveLaunchAgentEnvWrapperPath(args.env, label),
     ),
-    legacy,
     loaded: await snapshotLaunchAgentLoadedState(previousContents, `${domain}/${label}`),
   };
   let plistPath: string;

--- a/src/daemon/launchd-service-files.ts
+++ b/src/daemon/launchd-service-files.ts
@@ -20,7 +20,7 @@ import type { GatewayServiceEnv, GatewayServiceInstallArgs } from "./service-typ
 const LAUNCH_AGENT_DIR_MODE = 0o755;
 // launchd rejects user LaunchAgent plists without group/other read access on
 // current macOS. Secrets stay in the separate 0600 environment file.
-export const LAUNCH_AGENT_PLIST_MODE = 0o644;
+const LAUNCH_AGENT_PLIST_MODE = 0o644;
 const LAUNCH_AGENT_PRIVATE_DIR_MODE = 0o700;
 export const LAUNCH_AGENT_ENV_FILE_MODE = 0o600;
 export const LAUNCH_AGENT_ENV_WRAPPER_MODE = 0o700;

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -79,9 +79,6 @@ const launchdRestartHandoffState = vi.hoisted(() => ({
     (_params: unknown) => { ok: true; value: Promise<boolean> } | { ok: false; error: string }
   >(() => ({ ok: true, value: Promise.resolve(true) })),
 }));
-const launchdConstantsState = vi.hoisted(() => ({
-  legacyGatewayLabels: [] as string[],
-}));
 const launchdSystemState = vi.hoisted(() => ({
   assertNoSystemLaunchDaemonOwnership: vi.fn<(label: string) => Promise<void>>(async () => {}),
   inspectSystemLaunchDaemonOwnership: vi.fn<
@@ -523,14 +520,6 @@ vi.mock("./launchd-restart-handoff.js", () => ({
     launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff(params),
 }));
 
-vi.mock("./constants.js", async () => {
-  const actual = await vi.importActual<typeof import("./constants.js")>("./constants.js");
-  return {
-    ...actual,
-    resolveLegacyGatewayLaunchAgentLabels: () => [...launchdConstantsState.legacyGatewayLabels],
-  };
-});
-
 vi.mock("./launchd-system.js", () => ({
   assertNoSystemLaunchDaemonOwnership: (label: string) =>
     launchdSystemState.assertNoSystemLaunchDaemonOwnership(label),
@@ -699,7 +688,6 @@ beforeEach(() => {
   state.cleanupProtectedPids.length = 0;
   state.realExecFile = false;
   state.serviceStates.clear();
-  launchdConstantsState.legacyGatewayLabels.length = 0;
   launchctlSpawnSync.mockReset();
   launchctlSpawnSync.mockImplementation((file: string, args: string[]) => {
     const result = executeLaunchctlMock(file, args);
@@ -1939,48 +1927,6 @@ describe("launchd install", () => {
     expect(state.launchctlCalls).toEqual([["print", `${domain}/ai.openclaw.gateway`]]);
   });
 
-  it("restores an external legacy-label owner when canonical bootstrap fails", async () => {
-    const env = createDefaultLaunchdEnv();
-    const legacyLabel = "ai.openclaw.legacy-gateway";
-    const legacyPlistPath = `${env.HOME}/Library/LaunchAgents/${legacyLabel}.plist`;
-    const targetPlistPath = resolveLaunchAgentPlistPath(env);
-    const previousLegacy = createTestLaunchAgentPlist({
-      label: legacyLabel,
-      programArguments: ["/legacy/node", "/legacy/openclaw.mjs", "gateway"],
-    });
-    launchdConstantsState.legacyGatewayLabels.push(legacyLabel);
-    state.files.set(legacyPlistPath, previousLegacy);
-    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-    state.serviceStates.set(`${domain}/${legacyLabel}`, "running");
-    state.bootstrapError = "Operation not permitted";
-    state.bootstrapTransient = true;
-
-    await expect(
-      installLaunchAgent({
-        env,
-        stdout: new PassThrough(),
-        programArguments: defaultProgramArguments,
-      }),
-    ).rejects.toThrow("launchctl bootstrap failed: Operation not permitted");
-
-    expect(state.files.get(legacyPlistPath)).toBe(previousLegacy);
-    expect(state.files.has(targetPlistPath)).toBe(false);
-    expect(state.serviceLoaded).toBe(true);
-    expect(state.serviceRunning).toBe(true);
-    expect(launchctlCommandNames()).toEqual([
-      "print",
-      "print",
-      "print",
-      "bootout",
-      "unload",
-      "enable",
-      "bootstrap",
-      "print",
-      "enable",
-      "bootstrap",
-    ]);
-  });
-
   it("stages a canonical plist without retiring a legacy LaunchAgent", async () => {
     const env = createDefaultLaunchdEnv();
     const legacyLabel = "ai.openclaw.legacy-gateway";
@@ -1989,7 +1935,6 @@ describe("launchd install", () => {
       label: legacyLabel,
       programArguments: ["/legacy/node", "/legacy/openclaw.mjs", "gateway"],
     });
-    launchdConstantsState.legacyGatewayLabels.push(legacyLabel);
     state.files.set(legacyPlistPath, previousLegacy);
 
     await stageLaunchAgent(defaultLaunchAgentFixture(env));


### PR DESCRIPTION
## What Problem This Solves

LaunchAgent installation retained an alias snapshot and rollback path that no shipped caller can enter. Its test replaced the real empty alias producer with invented labels, keeping 58 production lines and 55 test lines alive without protecting reachable behavior. This is a deletion follow-up to the #135868 campaign.

## Why This Change Was Made

`resolveLegacyGatewayLaunchAgentLabels` unconditionally returns an empty array in both the reviewed main baseline and stable `v2026.9.2`; its only runtime caller is `installLaunchAgent`. The install snapshot and its consumers are private, so no other caller can supply a nonempty list. Remove that producer and its unreachable snapshot/restore/deactivate/unlink/bootstrap branches. The actual target's transactional rollback, loaded-state observation and system-owner checks remain unchanged.

The plist-mode constant loses its export because only its existing local chmod/write operations now use it (`src/daemon/launchd-service-files.ts:23`, `:229`, `:253`, `:271`); the value and behavior are unchanged.

No documented or SDK alias-migration contract was found. `git log -S resolveLegacyGatewayLaunchAgentLabels` traces the installer move to #121929 and reaches the shallow history boundary at `e357203be57`; this PR makes no claim about older introduction/removal history. Real legacy systemd names, updater jobs and old plist/wrapper readers are separate and remain intact.

Every test/support removal maps to surviving coverage:

| Removal | Surviving coverage |
|---|---|
| Mock-only `restores an external legacy-label owner when canonical bootstrap fails` | Reachable exact prior plist, environment, wrapper and supervision rollback remains unchanged in `src/daemon/launchd.test.ts:2070`. The deleted scenario required replacing the stable empty producer. |
| Mutable legacy-label list, constants-module mock, per-test reset | Tests now use the real constants owner; native naming contracts remain in `src/daemon/constants.test.ts:14`. Canonical rollback remains at `src/daemon/launchd.test.ts:2070`. |
| Inert mock-list push in staging test | `src/daemon/launchd.test.ts:1930` keeps every fixture and assertion proving staging leaves an unselected LaunchAgent alone; staging never consulted that list. |
| Empty producer and four unreachable legacy loops | Canonical activation/rollback remains at `src/daemon/launchd.test.ts:2070`; unselected-owner preservation remains at `:1930`; loaded system-owner observation remains at `:1065`. No new runtime path or fallback replaces them. |

## User Impact

No user-visible behavior change. Service ownership, self-mutation refusal, real rollback, JSON/receipt contracts and existing live process proofs are preserved. No schema, stored representation, migration, retention rule or reachable recovery semantics change.

## Evidence

- Full launchd and constants suites: 202 tests passed.
- Full `node scripts/check-changed.mjs` passed, including Knip and all selected type/lint lanes.
- Independent Codex review: scoped-clean, no actionable P0–P2 findings.
- Production: +1 / −59 = **−58** (one additional file only narrows an export).
- Tests/support: +0 / −55 (4,013 → 3,958).
- Tooling: +1 / −1; exact assertion baseline reduction from seven to six after deleting one unreachable assertion. Docs: unchanged.

- Full `pnpm build` passed, including runtime closures, package declarations and Control UI production build.

ClawSweeper reviewed the exact head and found no actionable findings or before-merge requests. It independently verified the empty producer in v2026.9.2 and preservation of selected-service rollback; there are no rank-up changes to apply.
