### PR TITLE
perf(browser): bound full-page label geometry reads

### DIFF
--- a/extensions/browser/src/browser/pw-tools-core.annotate.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.annotate.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  getPwToolsCoreSessionMocks,
   installPwToolsCoreTestHooks,
   setPwToolsCoreCurrentPage,
   setPwToolsCoreCurrentRefLocator,
@@ -127,6 +128,71 @@ describe("screenshotWithLabelsViaPlaywright (fullpage)", () => {
     // doc-space: scroll y=1000 + bbox y=200 = 1200
     expect(result.annotations[0]?.box.y).toBe(1200);
     expect(result.annotations[0]?.box.x).toBe(10);
+  });
+
+  it("stops reading geometry after filling the label budget and counts remaining refs as skipped", async () => {
+    const evaluate = evaluateMockReturning({ x: 0, y: 1000 });
+    const screenshot = vi.fn(async () => Buffer.from("FULL"));
+    setPwToolsCoreCurrentPage({ evaluate, screenshot });
+    const boundingBox = vi
+      .fn<() => Promise<{ x: number; y: number; width: number; height: number } | null>>()
+      .mockRejectedValueOnce(new Error("detached"))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ x: 10, y: 20, width: 30, height: 40 })
+      .mockResolvedValueOnce({ x: 50, y: 60, width: 70, height: 80 })
+      .mockResolvedValueOnce({ x: 90, y: 100, width: 30, height: 40 })
+      .mockRejectedValueOnce(new Error("detached tail"));
+    setPwToolsCoreCurrentRefLocator({ boundingBox });
+
+    const result = await mod.screenshotWithLabelsViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      refs: Object.fromEntries(
+        ["e1", "e2", "e3", "e4", "e5", "e6"].map((ref) => [ref, { role: "button" }]),
+      ),
+      fullPage: true,
+      maxLabels: 2,
+    });
+
+    expect(result.annotations).toEqual([
+      {
+        ref: "e3",
+        number: 3,
+        role: "button",
+        box: { x: 10, y: 1020, width: 30, height: 40 },
+      },
+      {
+        ref: "e4",
+        number: 4,
+        role: "button",
+        box: { x: 50, y: 1060, width: 70, height: 80 },
+      },
+    ]);
+    expect(result.labels).toBe(2);
+    expect(result.skipped).toBe(4);
+    expect(boundingBox).toHaveBeenCalledTimes(4);
+    expect(screenshot).toHaveBeenCalledWith(expect.objectContaining({ fullPage: true }));
+  });
+
+  it("still rejects unknown refs after filling the full-page label budget", async () => {
+    const screenshot = vi.fn(async () => Buffer.from("FULL"));
+    setPwToolsCoreCurrentPage({ evaluate: evaluateMockReturning({ x: 0, y: 0 }), screenshot });
+    getPwToolsCoreSessionMocks()
+      .refLocator.mockImplementationOnce(() => ({
+        boundingBox: async () => ({ x: 0, y: 0, width: 10, height: 10 }),
+      }))
+      .mockImplementationOnce(() => {
+        throw new Error('Unknown ref "e2". Run a new snapshot.');
+      });
+
+    await expect(
+      mod.screenshotWithLabelsViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        refs: { e1: { role: "button" }, e2: { role: "button" } },
+        fullPage: true,
+        maxLabels: 1,
+      }),
+    ).rejects.toThrow('Unknown ref "e2"');
+    expect(screenshot).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/browser/src/browser/pw-tools-core.interactions.content.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.content.ts
@@ -454,17 +454,21 @@ async function screenshotWithLabelsOnPage(
 
   const refKeys = Object.keys(opts.refs ?? {});
   const inputs: RawAnnotationInput[] = [];
-  let bboxFailures = 0;
+  let skippedRefs = 0;
   for (const ref of refKeys) {
     const refInfo = opts.refs[ref];
     if (refInfo === undefined) {
       continue;
     }
-    const box = await refLocator(page, ref)
-      .boundingBox()
-      .catch(() => null);
+    const target = refLocator(page, ref);
+    // Full-page tail refs cannot contribute annotations after the label budget fills.
+    if (space === "fullpage" && inputs.length >= maxLabels) {
+      skippedRefs += 1;
+      continue;
+    }
+    const box = await target.boundingBox().catch(() => null);
     if (!box) {
-      bboxFailures += 1;
+      skippedRefs += 1;
       continue;
     }
     inputs.push({
@@ -502,7 +506,7 @@ async function screenshotWithLabelsOnPage(
       // `annotations` but not drawn, and are reflected in `skipped`.
       buffer,
       labels: plan.overlayItems.length,
-      skipped: plan.skipped + bboxFailures,
+      skipped: plan.skipped + skippedRefs,
       annotations: plan.annotations,
     };
   } finally {


### PR DESCRIPTION
## What Problem This Solves

Full-page labeled browser screenshots keep requesting element geometry after the existing label budget is full, creating work and temporary inputs that cannot appear in the screenshot.

## Why This Change Was Made

Stop full-page bounding-box requests after enough successful boxes fill the budget, while still validating every defined ref synchronously. Failed/missing boxes before the cap leave room, and unread tail refs retain the same skipped count. Viewport and element captures keep complete collection for their visibility metadata. The production change adds four lines.

## User Impact

Full-page label captures use fewer browser geometry requests while preserving label order, coordinates, skipped counts, stale-ref errors, and image output. Label limits, overlay cleanup, viewport behavior, and element behavior are unchanged.

## Evidence

- **37 owner/planner tests** pass. The new regression fails on baseline for the intended reason: six geometry calls instead of four, with annotation/count assertions already passing. Full changed checks pass, including plugin/type/lint guards. Independent source/test/proof reviews and fresh managed autoreview at its default P0 threshold found no actionable issues.
- A real Chromium fixture with 300 valid refs, one hidden/null box, and one strict-locator rejection reduces full-page attempts **302 → 152** and planner inputs **300 → 150**. The result still contains 150 labels and 152 skipped refs. Viewport/element attempts remain 302/303, and a stale tail ref still fails before capture.
- Full-page, viewport, and element baseline/candidate images are byte-identical, with identical decoded pixels and returned metadata. The attached full-page pair was inspected and contains synthetic data only.
- The proof executes the exact extracted screenshot-owner functions with real ref resolution, annotation helpers, Playwright geometry, overlays, and capture. Page-state lookup/ref-cache setup is injected; outer target routing, Gateway/deadline serialization, and device-metrics ownership are outside this boundary.
- Two observations per variant in A/B/B/A order show descriptive owner latency **46.31% lower** and sampled Node/V8 allocation **46.62% lower**. These fixed-fixture observations do not establish statistical significance, retained heap, native Buffer/Chromium memory, or whole-Gateway RSS gains.
- Every run clears overlays; browser/context/connection processes were joined and closed. Required hosted CI passed on the exact reviewed head ([run 34047258833](https://github.com/openclaw/openclaw/actions/runs/34047258833)).

![Before: full-page labels on the synthetic Chromium fixture](https://github.com/user-attachments/assets/f48bb004-eb71-46a4-bf1b-db4213812009)

![After: identical full-page labels with bounded geometry work](https://github.com/user-attachments/assets/53c386f8-3969-4469-bd6c-95344ee84c40)
