### PR TITLE
fix(transcription): release gracefully closed socket state

### DIFF
--- a/src/realtime-transcription/websocket-session.test.ts
+++ b/src/realtime-transcription/websocket-session.test.ts
@@ -494,18 +494,21 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
     session.close();
   });
 
-  it("delivers graceful provider finals and sends the close signal only once", async () => {
+  it("delivers graceful provider finals before natural close and finalizes only once", async () => {
     const finalizedFrames: unknown[] = [];
     const transcripts: string[] = [];
+    const closed = createDeferred();
     let providerSocket: WebSocket | undefined;
     const server = await createRealtimeServer({
       onConnection: (socket) => {
         providerSocket = socket;
+        socket.once("close", () => closed.resolve());
       },
       onText: (payload) => {
         finalizedFrames.push(payload);
         if (finalizedFrames.length === 1) {
           providerSocket?.send(JSON.stringify({ text: "final provider transcript" }));
+          providerSocket?.close(1000, "finished");
         }
       },
     });
@@ -532,8 +535,8 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
     session.close();
     session.close();
 
-    await vi.waitFor(() => expect(transcripts).toEqual(["final provider transcript"]));
-    await delay(20);
+    await withTestTimeout(closed.promise, 1_000, "Graceful provider close not received");
+    expect(transcripts).toEqual(["final provider transcript"]);
     expect(finalizedFrames).toEqual([{ type: "finalize" }]);
   });
 

--- a/src/realtime-transcription/websocket-session.ts
+++ b/src/realtime-transcription/websocket-session.ts
@@ -404,6 +404,7 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
             this.closeTimer = undefined;
           }
           if (this.closed) {
+            this.forceClose(socket);
             return;
           }
           if (!opened || !settled) {


### PR DESCRIPTION
## What Problem This Solves

Retaining a realtime transcription session after graceful provider shutdown also retains its completed WebSocket and transport, even though the network connection is already closed.

## Why This Change Was Made

Use the existing captured-socket cleanup in the natural terminal-close branch, after final transcript delivery and close diagnostics. The installed WebSocket dependency marks the socket closed before emitting the event, so its termination method performs no additional handshake. Current-generation checks, reconnect/failure behavior, and protocol handling remain unchanged.

## User Impact

Completed transcription connections can be collected while callers retain reusable session handles. Final transcripts and single-finalization behavior stay the same. The change is one production line and does not address queued-audio retention.

## Evidence

- All **29 owner tests** and the full final changed-code gate pass. The graceful-final fixture waits for an actual peer close instead of a fixed sleep and still checks the final transcript and one finalization frame.
- Four real-owner loopback probes retain **16 closed session handles** per process. Baseline keeps all 16 closed socket/transport pairs reachable; candidate keeps zero. All final transcripts and 18 actual closes per process match, and a live control remains reachable until it is closed.
- The exact evidence is object reachability. The approximately 128 KiB difference across 16 owners is descriptive post-GC heap accounting, not a general saving estimate. No live-network leak, queued-audio, CPU, latency, RSS, or whole-Gateway claim is made.
- Independent source/dependency/test/probe review and fresh managed autoreview through P2 found no actionable issues. An initial test line-limit failure was resolved by removing redundant fixture scaffolding; the existing limit and substantive coverage were preserved, then the full gate was rerun successfully in 186.94 seconds.
- All loopback servers and proof processes joined. This is a local real-WebSocket owner experiment, not a live provider transcription run.
- Required hosted CI passed on the exact reviewed head ([run 34047261379](https://github.com/openclaw/openclaw/actions/runs/34047261379)).
