### PR TITLE
perf(browser): assemble iframe snapshot lines in one pass

### DIFF
--- a/extensions/browser/src/browser/cdp.internal.test.ts
+++ b/extensions/browser/src/browser/cdp.internal.test.ts
@@ -420,49 +420,79 @@ describe("cdp internal", () => {
       });
     });
 
-    it("expands one level of iframe snapshots with frame metadata", async () => {
+    it("expands frames in capture order after their first rendered occurrence", async () => {
+      const frameRequests: string[] = [];
+      const frameIds = new Map([
+        [44, "FIRST"],
+        [45, "SECOND"],
+        [46, "EMPTY"],
+        [47, "FAILED"],
+        [48, "NESTED"],
+      ]);
+      const mainNodes: RawAXNode[] = [
+        {
+          nodeId: "root",
+          role: { value: "RootWebArea" },
+          childIds: ["group", "empty", "failed", "after"],
+        },
+        {
+          nodeId: "second",
+          role: { value: "Iframe" },
+          name: { value: "Second" },
+          backendDOMNodeId: 45,
+        },
+        { nodeId: "group", role: { value: "generic" }, childIds: ["first", "second", "first"] },
+        {
+          nodeId: "first",
+          role: { value: "Iframe" },
+          name: { value: "First" },
+          backendDOMNodeId: 44,
+        },
+        {
+          nodeId: "empty",
+          role: { value: "Iframe" },
+          name: { value: "Empty" },
+          backendDOMNodeId: 46,
+        },
+        {
+          nodeId: "failed",
+          role: { value: "Iframe" },
+          name: { value: "Failed" },
+          backendDOMNodeId: 47,
+        },
+        { nodeId: "after", role: { value: "button" }, name: { value: "After" } },
+      ];
       const server = await startMockWsServer((msg) => {
         if (msg.method === "Runtime.evaluate") {
           return runtimeValueResult([]);
         }
         if (msg.method === "Accessibility.getFullAXTree") {
           const frameId = msg.params?.frameId;
-          return axTreeResult(
-            frameId
-              ? [
-                  {
-                    nodeId: "c1",
-                    role: { value: "RootWebArea" },
-                    name: { value: "" },
-                    childIds: ["c2"],
-                  },
-                  {
-                    nodeId: "c2",
-                    role: { value: "button" },
-                    name: { value: "Inside" },
-                    backendDOMNodeId: 55,
-                    childIds: [],
-                  },
-                ]
-              : [
-                  {
-                    nodeId: "1",
-                    role: { value: "RootWebArea" },
-                    name: { value: "" },
-                    childIds: ["2"],
-                  },
-                  {
-                    nodeId: "2",
-                    role: { value: "Iframe" },
-                    name: { value: "Child" },
-                    backendDOMNodeId: 44,
-                    childIds: [],
-                  },
-                ],
-          );
+          if (!frameId) {
+            return axTreeResult(mainNodes);
+          }
+          if (typeof frameId !== "string") {
+            return cdpError("Expected a frame ID string");
+          }
+          frameRequests.push(frameId);
+          if (frameId === "EMPTY") {
+            return axTreeResult([]);
+          }
+          if (frameId === "FAILED") {
+            return cdpError("Frame detached");
+          }
+          return axTreeResult([
+            { nodeId: "child-root", role: { value: "RootWebArea" }, childIds: ["child", "nested"] },
+            { nodeId: "child", role: { value: "button" }, name: { value: `${frameId} child` } },
+            ...(frameId === "SECOND"
+              ? [{ nodeId: "nested", role: { value: "Iframe" }, backendDOMNodeId: 48 }]
+              : []),
+          ]);
         }
         if (msg.method === "DOM.describeNode") {
-          return cdpResult({ node: { contentDocument: { frameId: "FRAME_1" } } });
+          return cdpResult({
+            node: { contentDocument: { frameId: frameIds.get(Number(msg.params?.backendNodeId)) } },
+          });
         }
         return undefined;
       });
@@ -473,10 +503,22 @@ describe("cdp internal", () => {
         options: { interactive: true },
       });
 
-      expect(snap.snapshot).toContain('- Iframe "Child" [ref=e1]');
-      expect(snap.snapshot).toContain('  - button "Inside" [ref=e2]');
-      expect(snap.refs.e1?.frameId).toBe("FRAME_1");
-      expect(snap.refs.e2?.frameId).toBe("FRAME_1");
+      expect(frameRequests).toEqual(["SECOND", "FIRST", "EMPTY", "FAILED"]);
+      expect(snap.snapshot.split("\n")).toEqual([
+        '- Iframe "First" [ref=e2]',
+        '    - button "FIRST child" [ref=e8]',
+        '    - Iframe "Second" [ref=e1]',
+        '    - button "SECOND child" [ref=e6]',
+        "    - Iframe [ref=e7]",
+        '    - Iframe "First" [ref=e2]',
+        '  - Iframe "Empty" [ref=e3]',
+        '  - Iframe "Failed" [ref=e4]',
+        '  - button "After" [ref=e5]',
+      ]);
+      expect(Object.keys(snap.refs)).toEqual(["e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8"]);
+      expect(snap.refs.e6).toEqual({ role: "button", name: "SECOND child", frameId: "SECOND" });
+      expect(snap.refs.e7).toEqual({ role: "iframe", backendDOMNodeId: 48, frameId: "NESTED" });
+      expect(snap.refs.e8).toEqual({ role: "button", name: "FIRST child", frameId: "FIRST" });
 
       const mainFrameOnly = await snapshotRoleViaCdp({
         wsUrl: server.wsUrl,
@@ -484,9 +526,10 @@ describe("cdp internal", () => {
         recurseIframes: false,
       });
 
-      expect(mainFrameOnly.snapshot).toContain('- Iframe "Child" [ref=e1]');
-      expect(mainFrameOnly.snapshot).not.toContain('button "Inside"');
-      expect(mainFrameOnly.refs.e2).toBeUndefined();
+      expect(frameRequests).toEqual(["SECOND", "FIRST", "EMPTY", "FAILED"]);
+      expect(mainFrameOnly.snapshot).toContain('- Iframe "First" [ref=e2]');
+      expect(mainFrameOnly.snapshot).not.toContain("child");
+      expect(mainFrameOnly.refs.e6).toBeUndefined();
     });
   });
 

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -28,11 +28,7 @@ import {
   withCdpSocket,
 } from "./cdp.helpers.js";
 import { assertBrowserNavigationAllowed, withBrowserNavigationPolicy } from "./navigation-guard.js";
-import {
-  finalizeRoleSnapshot,
-  findRoleSnapshotLineRef,
-  type RoleSnapshotIdentityMode,
-} from "./pw-role-snapshot.js";
+import { finalizeRoleSnapshot, type RoleSnapshotIdentityMode } from "./pw-role-snapshot.js";
 import {
   appendRoleSnapshotDepthTruncationMarker,
   ROLE_SNAPSHOT_MAX_DEPTH,
@@ -423,6 +419,7 @@ type RoleTreeNode = {
   url?: string;
   cursorInfo?: CursorInteractiveInfo;
   frameId?: string;
+  iframeLineIndex?: number;
 };
 
 function buildRoleTree(nodes: RawAXNode[]): { tree: RoleTreeNode[]; roots: number[] } {
@@ -508,7 +505,7 @@ function renderRoleTree(
   index: number,
   output: string[],
   options: CdpRoleSnapshotOptions,
-  state: { truncated: boolean },
+  state: { truncated: boolean; recordIframePositions?: boolean },
   indentOffset = 0,
 ): void {
   const node = tree[index];
@@ -530,6 +527,10 @@ function renderRoleTree(
     const nth = node.nth !== undefined && node.nth > 0 ? ` [nth=${node.nth}]` : "";
     const value = node.value ? ` value=${JSON.stringify(node.value)}` : "";
     const url = node.url ? ` [url=${node.url}]` : "";
+    if (state.recordIframePositions && node.ref && node.frameId) {
+      // A repeated AX child still expands after its first rendered occurrence.
+      node.iframeLineIndex ??= output.length;
+    }
     output.push(
       `${indent}- ${node.role}${name}${ref}${nth}${value}${url}${cursorSuffix(node.cursorInfo)}`,
     );
@@ -796,17 +797,16 @@ async function buildCdpRoleSnapshot(params: {
     }
   }
 
-  const lines: string[] = [];
-  const renderState = { truncated: false };
+  let lines: string[] = [];
+  const renderState = { truncated: false, recordIframePositions: params.recurseIframes };
   for (const root of roots) {
     renderRoleTree(tree, root, lines, params.options, renderState);
   }
 
   if (params.recurseIframes) {
-    const iframeNodes = tree.filter((node) => node.ref && node.frameId);
-    for (const iframe of iframeNodes) {
-      const lineIndex = lines.findIndex((line) => findRoleSnapshotLineRef(line) === iframe.ref);
-      if (lineIndex < 0 || !iframe.frameId) {
+    let childLinesByIndex: Map<number, string[]> | undefined;
+    for (const iframe of tree) {
+      if (iframe.iframeLineIndex === undefined || !iframe.frameId) {
         continue;
       }
       const child = await buildCdpRoleSnapshot({
@@ -822,7 +822,20 @@ async function buildCdpRoleSnapshot(params: {
         continue;
       }
       Object.assign(refs, child.refs);
-      lines.splice(lineIndex + 1, 0, ...child.lines.map((line) => `  ${line}`));
+      (childLinesByIndex ??= new Map()).set(iframe.iframeLineIndex, child.lines);
+    }
+    if (childLinesByIndex) {
+      const expanded: string[] = [];
+      for (let index = 0; index < lines.length; index++) {
+        expanded.push(lines[index]!);
+        const childLines = childLinesByIndex.get(index);
+        if (childLines) {
+          for (const childLine of childLines) {
+            expanded.push(`  ${childLine}`);
+          }
+        }
+      }
+      lines = expanded;
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Raw-CDP browser snapshots repeatedly scan and shift the accumulated text while expanding child frames, making iframe-heavy captures do unnecessary temporary work.

## Why This Change Was Made

Record each iframe's first emitted line position, keep child captures serial in raw accessibility-tree order, then merge successful child blocks into rendered order once. Preserve shared ref numbering, metadata order, repeated-node placement, literal ref-looking text, error/empty-child handling, depth, truncation, and the managed no-recursion path. The explicit ordering adds 13 production lines.

## User Impact

Iframe-heavy snapshots return the same text, refs, metadata, and command order with less repeated parsing and array shifting. There is no cross-call cache or new public option.

## Evidence

- **16 deterministic fixtures and four real Chromium CDP cases** preserve complete serialized results and ordered command parameters. Cases cover AX/render-order differences, repeated nodes, failed/empty/filtered children, nested frames, depth bounds, interactive/compact options, budgets/deltas, and disabled recursion.
- **62 focused tests** pass; after a fixture-only typed-lint correction, the affected 24-test suite and full changed gate passed again. The final gate took 149.46 seconds. Independent source/test/proof reviews and fresh managed autoreview at its default P0 threshold found no actionable issues.
- The 160-frame fixture yields 1,761 lines: parser calls **142,641 → 1,761**, splice shifts **63,600 → 0**, median measured owner time **33.89 → 5.39 ms**, and mean sampled Node/V8 allocation **148.13 → 8.94 MB**. Small no-frame/no-recursion controls are approximately flat. These are descriptive synthetic owner samples, not general production or Gateway/RSS estimates.
- Temporary retention increases: just before the final child, candidate holds 159 completed child arrays / 954 line slots; baseline holds at most one / six. The final parent and expanded arrays briefly coexist. Both variants release tracked child and AX arrays after completion, but lower cumulative allocation does **not** establish lower peak heap.
- **Maintainer decision:** accept this quantified per-capture staging cost for the demonstrated reduction in parsing and shifting while preserving capture/ref order and rendered placement. This does not establish lower peak live heap.
- Real Chromium proof bridges the exact owner's CDP sends through an owned Playwright session. It does not cover outer Gateway routing, target discovery, WebSocket policy/reconnect, or actor actions. All browser/context/CDP processes were joined and closed.
- The attached inspected synthetic scene shows the 12 child frames and nested fixture used for browser proof. It is context, not a before/after snapshot-output claim; paired full snapshot results provide that evidence.
- Required hosted CI passed on the exact reviewed head ([run 34047353222](https://github.com/openclaw/openclaw/actions/runs/34047353222)).

![Synthetic Chromium scene used for iframe snapshot proof; not before/after output](https://github.com/user-attachments/assets/d18c3c83-1ea2-4885-82a0-c764b55d1d08)
