### PR TITLE
test(signal): preserve native handles in timeout-cap fixture

### DIFF
--- a/extensions/signal/src/client.test.ts
+++ b/extensions/signal/src/client.test.ts
@@ -264,10 +264,7 @@ describe("signalRpcRequest", () => {
   });
 
   it("caps oversized RPC request timeouts before scheduling", async () => {
-    const timeoutSpy = vi
-      .spyOn(globalThis, "setTimeout")
-      .mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>);
-    vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined);
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const baseUrl = await withSignalServer((_req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ jsonrpc: "2.0", result: { version: "0.13.22" }, id: "test-id" }));


### PR DESCRIPTION
## What Problem This Solves

The Signal RPC timeout-cap fixture replaces native timer handles with a fabricated number and disables clearTimeout. Bun's HTTP implementation expects a real handle and fails before the fixture reaches its intended assertion.

## Why This Change Was Made

Let the setTimeout spy call through and retain the native clearTimeout implementation. The fixture still verifies the exact MAX_TIMER_TIMEOUT_MS scheduling argument while using real handles and cleanup.

## User Impact

One test file changes. Production timeout limits, client behavior, and protocol handling are unchanged.

## Evidence

- The exact immediate, valid loopback response case passed on Node and failed on Bun before the repair with the timer-handle error.
- The same case passes on Node and Bun afterward; 24 other cases were unselected locally. The timeout-cap assertion is unchanged.
- Complete changed-file checks and fresh independent P0–P2 review passed; formatting and diff checks are clean.
- No other socket, size-limit, delayed-response, malformed-input, or security cases were run locally. Hosted CI is tracked separately.

## Review input qualification

The unchanged synthetic fixtures are covered by the narrowly scoped, explicitly approved host-policy correction in [ClawSweeper #1469](https://github.com/openclaw/clawsweeper/pull/1469), merged as `ff0156fb8628cbf9f22d00864810dea56e83122b`. It qualifies only the two reviewed fixture occurrences; scanner and review guards remain enabled. The native pinned scanner preserved its output and changed classification from refusal to the two expected notices under that exact policy. No fixture value is reproduced here.

The PR source and the runtime-proof limits above are unchanged. A fresh hosted review is still required; policy qualification itself is not a review verdict or an approval of application behavior.
