### PR TITLE
fix(ui): preserve literal source previews and copied whitespace

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -1012,6 +1012,12 @@ Chat error banners, including cloud runner failures, show short messages in full
   </Accordion>
 </AccordionGroup>
 
+### Source previews and copying code
+
+**View Raw Text** keeps Markdown notation literal, including nested code fences.
+Decoded text artifacts use the same literal preview. **Copy code** preserves the
+code's leading whitespace and final newline when present.
+
 ### Markdown tables
 
 Markdown tables scroll horizontally within the conversation. **Copy table** copies

--- a/ui/src/components/markdown-code-blocks.test.ts
+++ b/ui/src/components/markdown-code-blocks.test.ts
@@ -18,8 +18,8 @@ afterEach(() => {
   document.body.innerHTML = "";
 });
 
-function renderCodeCopyButton(): HTMLButtonElement {
-  document.body.innerHTML = toSanitizedMarkdownHtml("```ts\nconst answer = 42;\n```");
+function renderCodeCopyButton(text = "const answer = 42;"): HTMLButtonElement {
+  document.body.innerHTML = toSanitizedMarkdownHtml(`\`\`\`ts\n${text}\n\`\`\``);
   const button = document.querySelector<HTMLButtonElement>(".code-block-copy");
   if (!button) {
     throw new Error("Expected Markdown code-copy button");
@@ -85,6 +85,22 @@ it("reobserves reused Markdown DOM while fencing scans queued before disconnect"
 });
 
 describe("Markdown code-block clipboard feedback", () => {
+  it.each([
+    { name: "indentation and a final newline", source: "  const answer = 42;\n" },
+    { name: "boundary blank lines", source: "\n\nconst answer = 42;\n\n" },
+    { name: "whitespace-only content", source: " \n\t " },
+  ])("preserves $name when copying ordinary code", async ({ source }) => {
+    vi.useFakeTimers();
+    const writeText = vi.fn(async () => undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const button = renderCodeCopyButton(source);
+
+    button.click();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(writeText).toHaveBeenCalledWith(source);
+  });
+
   it("visibly reports both denied clipboard paths and restores the idle state", async () => {
     vi.useFakeTimers();
     const writeText = vi.fn(async () => {

--- a/ui/src/components/markdown-code-blocks.ts
+++ b/ui/src/components/markdown-code-blocks.ts
@@ -58,7 +58,7 @@ function shouldRenderCodeBlockInteraction(env: unknown): boolean {
   return codeBlockRenderEnv(env)?.codeBlockInteraction === "interactive";
 }
 
-function encodeBlockArtCodeBlockCopyPayload(value: string): string {
+function encodeCodeBlockCopyPayload(value: string): string {
   return `${blockArtCopyPayloadPrefix}${JSON.stringify(value)}`;
 }
 
@@ -200,18 +200,10 @@ function renderCodeBlockHeader(lang: string, actions: string): string {
   return `<div class="code-block-header"><span class="code-block-lang">${language}</span><div class="code-block-actions">${actions}</div></div>`;
 }
 
-function renderCodeBlockCopyButton(
-  text: string,
-  blockArt: boolean,
-  copyTextOverride: string | undefined,
-): string {
-  const copyText = copyTextOverride ?? text;
-  const copyPayload = blockArt ? encodeBlockArtCodeBlockCopyPayload(copyText) : copyText;
-  const attrSafe = escapeMarkdownHtml(copyPayload);
-  const encodingAttr = blockArt
-    ? ` data-code-encoding="${blockArtCodeBlockCopyPayloadEncoding}"`
-    : "";
-  return `<button type="button" class="code-block-copy" data-code="${attrSafe}"${encodingAttr} aria-label="${escapeMarkdownHtml(t("common.copyCode"))}"><span class="code-block-copy__idle" aria-hidden="true"></span><span class="code-block-copy__done" aria-hidden="true"></span><span class="code-block-copy__failed" aria-hidden="true">!</span></button>`;
+function renderCodeBlockCopyButton(text: string): string {
+  // Attribute sanitization trims plain values; encode copied whitespace with the text.
+  const attrSafe = escapeMarkdownHtml(encodeCodeBlockCopyPayload(text));
+  return `<button type="button" class="code-block-copy" data-code="${attrSafe}" data-code-encoding="${blockArtCodeBlockCopyPayloadEncoding}" aria-label="${escapeMarkdownHtml(t("common.copyCode"))}"><span class="code-block-copy__idle" aria-hidden="true"></span><span class="code-block-copy__done" aria-hidden="true"></span><span class="code-block-copy__failed" aria-hidden="true">!</span></button>`;
 }
 
 export function renderMarkdownCodeBlock(
@@ -226,7 +218,7 @@ export function renderMarkdownCodeBlock(
     return codeBlock;
   }
   const copyButton = shouldRenderCodeBlockCopy(env)
-    ? renderCodeBlockCopyButton(text, blockArt, options.copyText)
+    ? renderCodeBlockCopyButton(options.copyText ?? text)
     : "";
   // Reveal and wrap controls are inert without a host that runs the code-block
   // lifecycle, so only interaction-owning hosts get the collapsible markup.

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -289,6 +289,37 @@ describe("toSanitizedMarkdownHtml", () => {
       return `\`\`\`json\n[\n${values.join("\n")}\n]\n\`\`\``;
     };
 
+    async function expectCodeCopy(fragment: HTMLElement, text: string) {
+      const writeText = vi.fn(async () => undefined);
+      const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+      const schedule = vi.spyOn(globalThis, "setTimeout");
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: { writeText },
+      });
+      fragment.addEventListener("click", handleMarkdownCodeBlockClick);
+      try {
+        const button = fragment.querySelector<HTMLButtonElement>(".code-block-copy");
+        expect(button).toBeInstanceOf(HTMLButtonElement);
+        button!.click();
+        await vi.waitFor(() => expect(button!.getAttribute("aria-label")).toBe("Copied!"));
+        expect(writeText).toHaveBeenCalledWith(text);
+      } finally {
+        fragment.removeEventListener("click", handleMarkdownCodeBlockClick);
+        for (const [index, [, delay]] of schedule.mock.calls.entries()) {
+          if (delay === 1_500) {
+            globalThis.clearTimeout(schedule.mock.results[index]?.value);
+          }
+        }
+        schedule.mockRestore();
+        if (originalClipboard) {
+          Object.defineProperty(navigator, "clipboard", originalClipboard);
+        } else {
+          Reflect.deleteProperty(navigator, "clipboard");
+        }
+      }
+    }
+
     it("renders raw block art as a whitespace-preserving code block", () => {
       const html = toSanitizedMarkdownHtml(blockArt);
       const fragment = htmlFragment(html);
@@ -317,33 +348,11 @@ describe("toSanitizedMarkdownHtml", () => {
     });
 
     it("copies fenced block art with its quiet-zone whitespace intact", async () => {
-      const writeText = vi.fn(async () => undefined);
-      const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
-      Object.defineProperty(navigator, "clipboard", {
-        configurable: true,
-        value: { writeText },
-      });
-      try {
-        const fragment = htmlFragment(toSanitizedMarkdownHtml(`\`\`\`\n${blockArt}\n\`\`\``));
-        const button = fragment.querySelector<HTMLButtonElement>(".code-block-copy");
-        if (!button) {
-          throw new Error("expected code copy button");
-        }
-
-        fragment.addEventListener("click", handleMarkdownCodeBlockClick);
-        button.click();
-
-        await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith(blockArt));
-      } finally {
-        if (originalClipboard) {
-          Object.defineProperty(navigator, "clipboard", originalClipboard);
-        } else {
-          Reflect.deleteProperty(navigator, "clipboard");
-        }
-      }
+      const fragment = htmlFragment(toSanitizedMarkdownHtml(`\`\`\`\n${blockArt}\n\`\`\``));
+      await expectCodeCopy(fragment, blockArt);
     });
 
-    it("renders indented code blocks", () => {
+    it("renders indented code blocks", async () => {
       // markdown-it requires a blank line before indented code
       const html = toSanitizedMarkdownHtml("text\n\n    indented code");
       const fragment = htmlFragment(html);
@@ -351,18 +360,16 @@ describe("toSanitizedMarkdownHtml", () => {
       expect(fragment.querySelector("p")?.textContent).toBe("text");
       expect(fragment.querySelector(".code-block-lang")?.textContent).toBe("Code");
       expect(fragment.querySelector("pre code")?.textContent).toBe("indented code\n");
-      expect(fragment.querySelector(".code-block-copy")?.getAttribute("data-code")).toBe(
-        "indented code",
-      );
+      await expectCodeCopy(fragment, "indented code");
     });
 
-    it("includes copy button", () => {
+    it("includes copy button", async () => {
       const html = toSanitizedMarkdownHtml("```\ncode\n```");
       const fragment = htmlFragment(html);
 
       expect(fragment.querySelector(".code-block-lang")?.textContent).toBe("Code");
       expect(fragment.querySelector(".code-block-copy__idle")).toBeInstanceOf(HTMLSpanElement);
-      expect(fragment.querySelector(".code-block-copy")?.getAttribute("data-code")).toBe("code");
+      await expectCodeCopy(fragment, "code");
     });
 
     it("omits copy chrome when rendering user-preserved code blocks", () => {

--- a/ui/src/pages/chat/components/chat-session-workspace.test.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.test.ts
@@ -371,6 +371,65 @@ describe("session workspace artifacts", () => {
     return { handleOpenSidebar, request, state };
   }
 
+  it("keeps nested code literal in a decoded text artifact preview", async () => {
+    const source = [
+      "Résumé 東京 🦀",
+      "",
+      "```ts",
+      "const x = 1;",
+      "```",
+      "",
+      "**literal after**",
+    ].join("\n");
+    const { handleOpenSidebar, state } = createArtifactHost({
+      data: btoa(String.fromCharCode(...new TextEncoder().encode(source))),
+      mimeType: "text/markdown",
+      title: "Source notes",
+    });
+    createSessionWorkspaceProps(state).onOpenArtifact("artifact-1");
+    const content = await loadedSidebarContent(handleOpenSidebar);
+    expect(content).toMatchObject({ kind: "markdown", rawText: source });
+    const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
+      content: SidebarContent;
+      updateComplete: Promise<unknown>;
+    };
+    panel.content = content;
+    document.body.append(panel);
+    const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+    const schedule = vi.spyOn(globalThis, "setTimeout");
+    const writeText = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    try {
+      await panel.updateComplete;
+      const reader = panel.querySelector(".sidebar-markdown-reader");
+      expect(reader?.querySelector("h1")?.textContent).toBe("Source notes");
+      expect.soft(reader?.querySelectorAll("pre code")).toHaveLength(1);
+      expect.soft(reader?.querySelector("pre code")?.textContent).toBe(`${source}\n`);
+      expect.soft(reader?.querySelector("strong")).toBeNull();
+      const copyButton = reader?.querySelector<HTMLButtonElement>(".code-block-copy");
+      expect(copyButton).toBeInstanceOf(HTMLButtonElement);
+      copyButton!.click();
+      await vi.waitFor(() => expect(copyButton!.getAttribute("aria-label")).toBe("Copied!"));
+      expect(writeText).toHaveBeenCalledWith(source);
+    } finally {
+      for (const [index, [, delay]] of schedule.mock.calls.entries()) {
+        if (delay === 1_500) {
+          globalThis.clearTimeout(schedule.mock.results[index]?.value);
+        }
+      }
+      schedule.mockRestore();
+      if (originalClipboard) {
+        Object.defineProperty(navigator, "clipboard", originalClipboard);
+      } else {
+        Reflect.deleteProperty(navigator, "clipboard");
+      }
+      panel.remove();
+    }
+  });
+
   it.each([
     {
       content: "Résumé 東京 🦀",

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -1,4 +1,5 @@
 import type { SessionsDiffResult } from "../../../../../packages/gateway-protocol/src/index.js";
+import { formatFencedCodeBlock } from "../../../../../src/shared/markdown-code.js";
 import { GatewayRequestError } from "../../../api/gateway.ts";
 import type { ArtifactDownloadResult, SessionWorkspaceGetResult } from "../../../api/types.ts";
 import { hasOperatorAdminAccess } from "../../../app/operator-access.ts";
@@ -140,7 +141,7 @@ function artifactSidebarContent(params: {
     const language = mimeType === "application/json" ? "json" : "";
     return {
       kind: "markdown",
-      content: `# ${title}\n\n\`\`\`${language}\n${decoded}\n\`\`\``,
+      content: `# ${title}\n\n${formatFencedCodeBlock(decoded, language)}`,
       rawText: decoded,
     };
   }

--- a/ui/src/pages/chat/components/chat-sidebar-content.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-content.ts
@@ -1,6 +1,7 @@
 import { html, nothing } from "lit";
 import { keyed } from "lit/directives/keyed.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { formatFencedCodeBlock } from "../../../../../src/shared/markdown-code.js";
 import { isStaleChunkImportError } from "../../../app/stale-chunk-reload.ts";
 import { icons } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
@@ -122,10 +123,6 @@ function renderSidebarAttachment(
     downloadHref: src,
   });
 }
-function toPlainTextCodeFence(value: string, language = ""): string {
-  const fenceHeader = language ? `\`\`\`${language}` : "```";
-  return `${fenceHeader}\n${value}\n\`\`\``;
-}
 
 export function buildRawContent(
   content: ChatDetailPanelContent | null | undefined,
@@ -137,7 +134,7 @@ export function buildRawContent(
     const rawText = content.rawText ?? content.content;
     return {
       kind: "markdown",
-      content: toPlainTextCodeFence(rawText),
+      content: formatFencedCodeBlock(rawText),
       rawText,
     };
   }
@@ -145,14 +142,14 @@ export function buildRawContent(
     const rawText = content.rawText ?? content.content;
     return {
       kind: "markdown",
-      content: toPlainTextCodeFence(rawText, content.language),
+      content: formatFencedCodeBlock(rawText, content.language),
       rawText,
     };
   }
   if (content.rawText?.trim()) {
     return {
       kind: "markdown",
-      content: toPlainTextCodeFence(content.rawText, "json"),
+      content: formatFencedCodeBlock(content.rawText, "json"),
       rawText: content.rawText,
     };
   }

--- a/ui/src/pages/chat/components/chat-sidebar.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.test.ts
@@ -167,6 +167,60 @@ describe("file sidebar editor locality", () => {
 });
 
 describe("markdown sidebar", () => {
+  it.each([
+    { kind: "markdown", trailingNewline: false },
+    { kind: "file", trailingNewline: true },
+  ] as const)("keeps nested code literal when viewing raw $kind text", async (testCase) => {
+    const source =
+      ["Intro", "", "```ts", "const x = 1;", "```", "", "**literal after**"].join("\n") +
+      (testCase.trailingNewline ? "\n" : "");
+    const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
+      content: unknown;
+      ensureFileEditor: () => Promise<void>;
+      updateComplete: Promise<unknown>;
+    };
+    const editorLoad =
+      testCase.kind === "file" ? vi.spyOn(panel, "ensureFileEditor").mockResolvedValue() : null;
+    panel.content =
+      testCase.kind === "markdown"
+        ? { kind: "markdown", content: "Rendered summary", rawText: source }
+        : { kind: "file", path: "notes.md", name: "notes.md", language: "md", content: source };
+    document.body.append(panel);
+    const schedule = vi.spyOn(globalThis, "setTimeout");
+    try {
+      await panel.updateComplete;
+      const rawButton = Array.from(panel.querySelectorAll<HTMLButtonElement>("button")).find(
+        (button) => button.textContent?.trim() === "View Raw Text",
+      );
+      expect(rawButton).toBeDefined();
+      rawButton!.click();
+      await panel.updateComplete;
+
+      const reader = panel.querySelector(".sidebar-markdown-reader");
+      const copyButton = reader?.querySelector<HTMLButtonElement>(".code-block-copy");
+      expect(copyButton).toBeInstanceOf(HTMLButtonElement);
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      vi.stubGlobal("navigator", { clipboard: { writeText } });
+      copyButton!.click();
+      await vi.waitFor(() => expect(copyButton!.getAttribute("aria-label")).toBe("Copied!"));
+      expect(writeText).toHaveBeenCalledOnce();
+
+      expect.soft(reader?.querySelectorAll("pre code")).toHaveLength(1);
+      expect.soft(reader?.querySelector("pre code")?.textContent).toBe(`${source}\n`);
+      expect.soft(reader?.querySelector("strong")).toBeNull();
+      expect.soft(writeText).toHaveBeenCalledWith(source);
+    } finally {
+      for (const [index, [, delay]] of schedule.mock.calls.entries()) {
+        if (delay === 1_500) {
+          globalThis.clearTimeout(schedule.mock.results[index]?.value);
+        }
+      }
+      schedule.mockRestore();
+      editorLoad?.mockRestore();
+      panel.remove();
+    }
+  });
+
   it("opens workspace files from markdown preview clicks", async () => {
     const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
       content: unknown;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where View Raw Text and decoded text-artifact previews stopped showing literal source at an embedded code fence. Following text could render as Markdown, and Copy code returned only part of the source. Ordinary code copying could also strip leading whitespace and the final newline.

## Why This Change Was Made

Both preview producers now use the existing variable-length fence formatter. All code-copy buttons use the existing marked JSON transport, which preserves whitespace through attribute sanitization. The decoder, marker values, sanitizer policy, shared formatter and separate inline-span behavior are preserved.

## User Impact

Source previews retain nested Markdown notation, and copies retain the complete code text and intentional whitespace within the existing Markdown line-ending normalization. Production code decreases by 10 lines. The Control UI guide documents the behavior.

## Evidence

The original preview regressions failed before the fence repair; separate ordinary whitespace-copy cases confirmed the attribute-transport defect. All 125 distinct selected cases pass, along with 20 source checks and 10 documentation-only checks. The final eight-file managed P2 review is clean.

Before/after browser captures use actual production components, synthetic text/artifact data and real Raw/Copy actions with a mocked clipboard. They verify component behavior, not an installed-app or operating-system clipboard workflow. Both full captures were inspected before upload.

![before-raw-markdown-preview](https://github.com/user-attachments/assets/4ea9c3cb-1a03-4655-9036-34b94b87f99b)

![after-raw-markdown-preview](https://github.com/user-attachments/assets/619b7947-4514-43dd-9334-02ab12b6c4af)