### PR TITLE
test(ollama): declare the failed-response fixture content type

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1875,7 +1875,7 @@ describe("createOllamaStreamFn streaming events", () => {
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response("rate limited", {
         status: 429,
-        headers: { "Retry-After": "30" },
+        headers: { "Content-Type": "text/plain;charset=UTF-8", "Retry-After": "30" },
       }),
       release: vi.fn(async () => undefined),
     });


### PR DESCRIPTION
## What Problem This Solves

The Ollama failed-response fixture expects a Content-Type header that Node supplies implicitly for its string-body Response, while Bun omits it.

## Why This Change Was Made

Set the expected Content-Type explicitly on the synthetic 429 response. Keep the strict header, Retry-After, response-before-error ordering, and structured error assertions unchanged.

## User Impact

One fixture line changes; production streaming and error handling are unchanged.

## Evidence

- The exact existing mocked-fetch case passed on Node and failed on Bun before the change solely on the missing header.
- The same case passed once on each runtime afterward. All other cases were unselected locally; no network or guard scenarios were executed.
- Complete changed-file checks and fresh independent P0–P2 review passed; formatting and diff checks are clean.
- Hosted CI is tracked separately from this selected local proof.
