### PR TITLE
refactor: simplify queue state and infrastructure dispatch

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3477,7 +3477,6 @@ src/plugins/update-summary.ts	2
 src/plugins/web-search-credential-presence.ts	1
 src/plugins/web-search-install-catalog.ts	2
 src/poll-params.ts	1
-src/process/command-queue.state.ts	1
 src/process/command-queue.ts	2
 src/process/exec-spawn.ts	4
 src/process/exec.ts	3

--- a/src/infra/fs-safe-remove.test.ts
+++ b/src/infra/fs-safe-remove.test.ts
@@ -111,6 +111,35 @@ describe("removePathWithinRoot", () => {
     );
   });
 
+  it.each([undefined, false, true])("handles a missing parent with force=%s", async (force) => {
+    const root = await tempDirs.make("openclaw-fs-safe-root-");
+    const parentPath = path.join(root, "missing-parent");
+    const removal = removePathWithinRoot({
+      rootDir: root,
+      relativePath: path.join("missing-parent", "target.txt"),
+      recursive: true,
+      force,
+    });
+
+    if (force === false) {
+      await expectRejectCode(removal, "not-found");
+    } else {
+      await expect(removal).resolves.toBeUndefined();
+    }
+    await expectRejectCode(fs.stat(parentPath), "ENOENT");
+  });
+
+  it.each([undefined, false, true])("rejects a missing root with force=%s", async (force) => {
+    const parent = await tempDirs.make("openclaw-fs-safe-root-");
+    const root = path.join(parent, "missing-root");
+
+    await expectRejectCode(
+      removePathWithinRoot({ rootDir: root, relativePath: "target.txt", force }),
+      "not-found",
+    );
+    await expectRejectCode(fs.stat(root), "ENOENT");
+  });
+
   it("rejects symlink and junction targets", async () => {
     const root = await tempDirs.make("openclaw-fs-safe-root-");
     const realDir = path.join(root, "real");

--- a/src/infra/fs-safe-remove.ts
+++ b/src/infra/fs-safe-remove.ts
@@ -89,6 +89,7 @@ async function removeDirectoryEntry(
   root: Root,
   relativePath: string,
   suppressNotFound: boolean,
+  recursive: boolean,
 ): Promise<void> {
   const entry = await findDirectoryEntry(root, relativePath).catch((error: unknown) => {
     if (suppressNotFound && isNotFoundError(error)) {
@@ -101,7 +102,7 @@ async function removeDirectoryEntry(
     return;
   }
   assertNotSymbolicLink(relativePath, entry);
-  if (entry.isDirectory) {
+  if (recursive && entry.isDirectory) {
     const children = (
       await listDirectoryEntries(root, relativePath).catch((error: unknown) => {
         if (suppressNotFound && isNotFoundError(error)) {
@@ -119,6 +120,7 @@ async function removeDirectoryEntry(
         root,
         joinRootRelativePath(relativePath, child.name),
         suppressNotFound,
+        true,
       );
     }
   }
@@ -134,20 +136,5 @@ export async function removePathWithinRoot(params: {
   const root = await fsSafeRoot(params.rootDir);
   const suppressNotFound = params.force !== false;
   const recursive = params.recursive === true;
-  const entry = await findDirectoryEntry(root, params.relativePath).catch((error: unknown) => {
-    if (suppressNotFound && isNotFoundError(error)) {
-      return undefined;
-    }
-    throw error;
-  });
-  if (!entry) {
-    await removeRootRelativePath(root, params.relativePath, suppressNotFound);
-    return;
-  }
-  if (!recursive || !entry.isDirectory) {
-    assertNotSymbolicLink(params.relativePath, entry);
-    await removeRootRelativePath(root, params.relativePath, suppressNotFound);
-    return;
-  }
-  await removeDirectoryEntry(root, params.relativePath, suppressNotFound);
+  await removeDirectoryEntry(root, params.relativePath, suppressNotFound, recursive);
 }

--- a/src/infra/net/proxy/proxy-validation.ts
+++ b/src/infra/net/proxy/proxy-validation.ts
@@ -516,22 +516,7 @@ export async function runProxyValidation(
   options: RunProxyValidationOptions,
 ): Promise<ProxyValidationResult> {
   const config = resolveProxyValidationConfig(options);
-  if (config.errors.length > 0) {
-    return { ok: false, config, checks: [] };
-  }
-  if (!config.proxyUrl) {
-    if (!config.enabled && config.source === "disabled") {
-      return {
-        ok: false,
-        config: {
-          ...config,
-          errors: [
-            "Proxy validation is disabled. Configure proxy.proxyUrl, OPENCLAW_PROXY_URL, or pass --proxy-url to run validation.",
-          ],
-        },
-        checks: [],
-      };
-    }
+  if (config.errors.length > 0 || !config.proxyUrl) {
     return { ok: false, config, checks: [] };
   }
 

--- a/src/process/background-work.ts
+++ b/src/process/background-work.ts
@@ -1,9 +1,10 @@
-import { getGroupRegistry, getLaneGroup } from "./command-queue.capacity-groups.js";
+import { getLaneGroup } from "./command-queue.capacity-groups.js";
 import {
   enqueueCommandInLane,
   getCommandLaneSnapshot,
   publishLaneConfiguration,
 } from "./command-queue.js";
+import { getQueueState } from "./command-queue.state.js";
 import type { CommandLaneSnapshot, CommandQueueEnqueueOptions } from "./command-queue.types.js";
 import { getGatewayRestartDrainSignal } from "./gateway-work-admission.js";
 import { CommandLane } from "./lanes.js";
@@ -37,7 +38,7 @@ export function createBackgroundWorkOwner(params: { owner: string; maxConcurrent
         );
       }
     } else {
-      const group = getGroupRegistry().groups.get(BACKGROUND_WORK_GROUP);
+      const group = getQueueState().laneGroups.get(BACKGROUND_WORK_GROUP);
       publishLaneConfiguration({
         lanes: { [lane]: params.maxConcurrent },
         groups: {
@@ -79,7 +80,7 @@ export function isBackgroundWorkLane(lane: string): boolean {
 }
 
 export function getBackgroundWorkSnapshot(): CommandLaneSnapshot {
-  const group = getGroupRegistry().groups.get(BACKGROUND_WORK_GROUP);
+  const group = getQueueState().laneGroups.get(BACKGROUND_WORK_GROUP);
   const members = [...(group?.members ?? [])].map((lane) => getCommandLaneSnapshot(lane));
   const activeCount = members.reduce((sum, member) => sum + member.activeCount, 0);
   return {

--- a/src/process/command-queue.capacity-groups.ts
+++ b/src/process/command-queue.capacity-groups.ts
@@ -3,7 +3,12 @@ import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 // lanes, with per-member reservations. Split out of command-queue.ts to keep
 // that file within its size budget; the queue supplies its own `drainLane` so
 // this module never has to import the queue runtime.
-import { getQueueState, normalizeLane, peekLaneQueue } from "./command-queue.state.js";
+import {
+  getQueueState,
+  normalizeLane,
+  peekLaneQueue,
+  type LaneGroupState,
+} from "./command-queue.state.js";
 import type { CommandLaneBlockReason, CommandLaneSnapshot } from "./command-queue.types.js";
 import { CommandLane } from "./lanes.js";
 
@@ -25,13 +30,6 @@ export type CommandLaneGroupSpec = {
    * siblings while its owner cannot claim it.
    */
   reservations?: Readonly<Record<string, number>>;
-};
-
-export type LaneGroupState = {
-  group: string;
-  budget: number;
-  members: Set<string>;
-  reservations: Map<string, number>;
 };
 
 /** Shared across fresh module instances so one group cannot re-enter its arbiter. */
@@ -73,29 +71,8 @@ function assertGroupEligibleLane(lane: string): void {
   }
 }
 
-/** Group registry, keyed by group id and by member lane name. */
-export function getGroupRegistry(): {
-  groups: Map<string, LaneGroupState>;
-  groupByLane: Map<string, string>;
-} {
-  const state: ReturnType<typeof getQueueState> & {
-    laneGroups?: Map<string, LaneGroupState>;
-    laneGroupByLane?: Map<string, string>;
-  } = getQueueState();
-  // Migration: an older singleton (pre-upgrade, inherited via globalThis after
-  // a SIGUSR1 in-process restart) has neither field. Active counts are derived,
-  // so a late-initialized registry cannot desynchronize from lane state.
-  if (!state.laneGroups) {
-    state.laneGroups = new Map<string, LaneGroupState>();
-  }
-  if (!state.laneGroupByLane) {
-    state.laneGroupByLane = new Map<string, string>();
-  }
-  return { groups: state.laneGroups, groupByLane: state.laneGroupByLane };
-}
-
 export function getLaneGroup(lane: string): LaneGroupState | undefined {
-  const { groups, groupByLane } = getGroupRegistry();
+  const { laneGroups: groups, laneGroupByLane: groupByLane } = getQueueState();
   const groupId = groupByLane.get(lane);
   return groupId ? groups.get(groupId) : undefined;
 }
@@ -202,7 +179,7 @@ export function validateCommandLaneGroupSpec(
 
 /** Install a validated group, detaching its members from any previous owner. */
 export function installCommandLaneGroup(next: LaneGroupState): void {
-  const { groups, groupByLane } = getGroupRegistry();
+  const { laneGroups: groups, laneGroupByLane: groupByLane } = getQueueState();
   const previous = groups.get(next.group);
   if (previous) {
     for (const member of previous.members) {
@@ -275,7 +252,7 @@ export function drainCommandLaneGroup(lane: string, drainLane: BoundedDrainLaneF
   }
   DRAINING_GROUPS.add(group);
   try {
-    while (getGroupRegistry().groups.get(group.group) === group) {
+    while (getQueueState().laneGroups.get(group.group) === group) {
       const selectedLane = resolveNextGroupLane(group);
       if (!selectedLane || drainLane(selectedLane, 1) === 0) {
         return;

--- a/src/process/command-queue.scoped-lanes.test.ts
+++ b/src/process/command-queue.scoped-lanes.test.ts
@@ -8,6 +8,7 @@ import {
   resetCommandLane,
   setCommandLaneConcurrency,
 } from "./command-queue.js";
+import { createLaneQueue, type LaneState } from "./command-queue.state.js";
 import { resetCommandQueueStateForTest } from "./command-queue.test-support.js";
 import { CommandLane } from "./lanes.js";
 
@@ -243,12 +244,12 @@ describe("scoped command lane lifecycle", () => {
     });
     const replacementState = {
       lane,
-      queue: [],
+      queue: createLaneQueue(),
       activeTaskIds: new Set<number>(),
       maxConcurrent: 1,
       draining: false,
       generation: 0,
-    };
+    } satisfies LaneState;
 
     lanes.set(lane, replacementState);
     staleGate.resolve();

--- a/src/process/command-queue.state.ts
+++ b/src/process/command-queue.state.ts
@@ -56,6 +56,13 @@ export type LaneState = {
   generation: number;
 };
 
+export type LaneGroupState = {
+  group: string;
+  budget: number;
+  members: Set<string>;
+  reservations: Map<string, number>;
+};
+
 const INITIAL_QUEUE_RING_CAPACITY = 16;
 
 function createQueueRing(): QueueRing {
@@ -179,56 +186,13 @@ export function removeLaneQueueEntry(queue: LaneQueue, entry: QueueEntry): boole
 const COMMAND_QUEUE_STATE_KEY = Symbol.for("openclaw.commandQueueState");
 
 export function getQueueState() {
-  const state = resolveGlobalSingleton(COMMAND_QUEUE_STATE_KEY, () => ({
+  return resolveGlobalSingleton(COMMAND_QUEUE_STATE_KEY, () => ({
     lanes: new Map<string, LaneState>(),
     nextTaskId: 1,
     nextQueueSequence: 1,
-    queueFormatVersion: 1,
+    laneGroups: new Map<string, LaneGroupState>(),
+    laneGroupByLane: new Map<string, string>(),
   }));
-  if (!state.nextQueueSequence) {
-    state.nextQueueSequence = 1;
-  }
-  // SIGUSR1 restarts can preserve the singleton created by the shipped array-backed queue.
-  // Convert it once so steady-state state reads do not rescan every queued entry.
-  if (state.queueFormatVersion !== 1) {
-    let maxQueueSequence = state.nextQueueSequence - 1;
-    type LegacyQueueEntry = QueueEntry & {
-      activeAheadAtEnqueue?: number;
-      priority?: number;
-      queuedAheadAtEnqueue?: number;
-      sequence?: number;
-    };
-    type LegacyLaneState = Omit<LaneState, "queue"> & {
-      queue: LaneQueue | LegacyQueueEntry[];
-    };
-    for (const lane of state.lanes.values() as Iterable<LegacyLaneState>) {
-      if (!Array.isArray(lane.queue)) {
-        continue;
-      }
-      const legacyQueue = lane.queue;
-      const queue = createLaneQueue();
-      for (const [index, entry] of legacyQueue.entries()) {
-        entry.priority = entry.priority === 1 || entry.priority === -1 ? entry.priority : 0;
-        if (typeof entry.sequence !== "number") {
-          entry.sequence = state.nextQueueSequence++;
-        }
-        maxQueueSequence = Math.max(maxQueueSequence, entry.sequence);
-        if (typeof entry.queuedAheadAtEnqueue !== "number") {
-          entry.queuedAheadAtEnqueue = index;
-        }
-        if (typeof entry.activeAheadAtEnqueue !== "number") {
-          entry.activeAheadAtEnqueue = lane.activeTaskIds.size;
-        }
-        enqueueLaneQueue(queue, entry);
-      }
-      lane.queue = queue;
-    }
-    if (state.nextQueueSequence <= maxQueueSequence) {
-      state.nextQueueSequence = maxQueueSequence + 1;
-    }
-    state.queueFormatVersion = 1;
-  }
-  return state;
 }
 
 export function normalizeLane(lane: string): string {

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -1011,64 +1011,6 @@ describe("command queue", () => {
     await expect(task).rejects.toBeInstanceOf(GatewayDrainingError);
   });
 
-  it("migrates legacy queued entries missing priority and wait diagnostics", async () => {
-    const key = Symbol.for("openclaw.commandQueueState");
-    const globalStore = globalThis as Record<PropertyKey, unknown>;
-    const original = globalStore[key];
-    let queuedAhead: number | null = null;
-    const legacyTask = new Promise<string>((resolve, reject) => {
-      globalStore[key] = {
-        gatewayDraining: false,
-        lanes: new Map([
-          [
-            CommandLane.Main,
-            {
-              lane: CommandLane.Main,
-              queue: [
-                {
-                  task: async () => "done",
-                  resolve,
-                  reject,
-                  enqueuedAt: Date.now() - 10,
-                  warnAfterMs: 0,
-                  onWait: (_ms: number, ahead: number) => {
-                    queuedAhead = ahead;
-                  },
-                },
-              ],
-              activeTaskIds: new Set(),
-              maxConcurrent: 1,
-              draining: false,
-              generation: 0,
-            },
-          ],
-        ]),
-        activeTaskWaiters: new Set(),
-        nextTaskId: 1,
-        nextQueueSequence: 1,
-      };
-    });
-
-    try {
-      resetAllLanes();
-
-      await expect(legacyTask).resolves.toBe("done");
-      expect(queuedAhead).toBe(0);
-      const waitWarning = diagnosticMocks.diag.warn.mock.calls.find(
-        ([message]) =>
-          typeof message === "string" && message.includes("lane wait exceeded: lane=main"),
-      );
-      expect(waitWarning?.[0]).toContain("queueAhead=0 activeAhead=0");
-    } finally {
-      if (original !== undefined) {
-        globalStore[key] = original;
-      } else {
-        delete globalStore[key];
-      }
-      resetCommandQueueStateForTest();
-    }
-  });
-
   it("shares lane state across distinct module instances", async () => {
     const commandQueueA = await importFreshModule<typeof import("./command-queue.js")>(
       import.meta.url,

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -12,10 +12,8 @@ import {
   canAdmitInGroup,
   type CommandLaneGroupSpec,
   drainCommandLaneGroup,
-  getGroupRegistry,
   getLaneGroup,
   installCommandLaneGroup,
-  type LaneGroupState,
   validateCommandLaneGroupSpec,
 } from "./command-queue.capacity-groups.js";
 import {
@@ -24,6 +22,7 @@ import {
   enqueueLaneQueue,
   type CommandLaneTaskMarker,
   getQueueState,
+  type LaneGroupState,
   type LaneState,
   normalizeLane,
   removeLaneQueueEntry,
@@ -494,7 +493,7 @@ export function publishLaneConfiguration(config: {
     touched.add(lane);
   }
   for (const group of config.clearGroups ?? []) {
-    const { groups, groupByLane } = getGroupRegistry();
+    const { laneGroups: groups, laneGroupByLane: groupByLane } = getQueueState();
     const existing = groups.get(group);
     if (existing) {
       for (const member of existing.members) {
@@ -505,7 +504,7 @@ export function publishLaneConfiguration(config: {
     }
   }
   for (const next of validated) {
-    const { groups, groupByLane } = getGroupRegistry();
+    const { laneGroups: groups, laneGroupByLane: groupByLane } = getQueueState();
     const previous = groups.get(next.group);
     for (const member of previous?.members ?? []) {
       touched.add(member);


### PR DESCRIPTION
## What Problem This Solves

Queue state has two initialization owners and retains a private array-to-ring upgrade path that supported code updates never use. Filesystem removal repeats the same dispatch, and proxy validation retains an unreachable diagnostic branch.

Related: #139597

## Why This Change Was Made

Initialize the existing lane-group maps in the queue singleton and let all readers use that owner directly. Remove the registry adapter, legacy format marker/conversion, and missing-sequence repair. Keep the singleton key, ring algorithms, queue identities, sequence ordering, reset behavior, cancellation, deadlines, group arbitration, and background-work lifetime intact.

Array queues did ship, but both historical and current in-process restart code reuse captured core functions. Supported code activation crosses a process boundary; private queues containing callbacks and promises are not an upgrade format. Same-version module copies still share the existing singleton. No public API, config, persistent schema, or dependency changes.

Use the existing filesystem removal traversal for recursive and nonrecursive entry points, preserving strict option defaults and fs-safe guards. Collapse the adjacent proxy guards while preserving all reachable diagnostic text and probe decisions.

Production is **87 lines smaller**; tests are **28 lines smaller**. Remove only the synthetic legacy-format test, retain modern lifecycle coverage, correct a replacement-lane fixture to use the existing queue constructor, and add six missing-parent/root filesystem cases. Prune the now-zero assertion baseline entry.

## User Impact

No intended user-visible behavior change. Queue fairness, cancellation and restart behavior, filesystem results, and proxy diagnostics remain the same with fewer internal paths.

## Evidence

- Baseline and candidate each pass **140 tests in 10 files**, with the same Windows-only junction-race skip. Coverage includes priority/FIFO, distinct module instances, lane replacement, reset, deadlines, capacity groups, atomic publication, background owners, filesystem operations, proxy validation, CLI parsing, and MXC directory reads.
- All 19 proxy CLI runtime cases pass. Complete changed checks pass, including core/test types, lint, dead exports, and zero runtime import cycles. The exact committed candidate passes the CI-artifact build, SDK declarations/exports, bundled runtime loading, and UI packaging (1m57s).
- Independent P0–P2 review of the expanded batch is scoped-clean, with no findings. Exact fs-safe 0.8.1 implementation, supported loader/restart behavior, and stable-tag upgrade documentation were inspected.
- Ring algorithms, resetAllLanes, and the group-draining singleton initializer remain byte-identical. Queue owner import graph is acyclic.

The local MXC cases cover directory reads, not removal. Exact-head Windows CI passes the junction-removal suite and MXC writable-removal/read-only-protection cases. This refactor makes no stronger claim about filesystem races than the existing guards and tests establish.

### Dependency and restart review follow-up

The maintainer inspection covers the source that ClawSweeper could not retrieve. All 14 captured fs-safe files match the installed, pinned 0.8.1 package by SHA-256. In the [published implementation](https://unpkg.com/@openclaw/fs-safe@0.8.1/dist/root-impl.js), `RootHandle.list` (line 356), `removePathInRoot` (674), pinned root resolution (929), and removal guards (955 onward) retain root identity, containment, and parent identity checks. The removed OpenClaw preflight carried no identity receipt into the existing traversal. Its retained final entry check and guarded removal remain the operative boundary. This does not claim universal protection against hostile concurrent filesystem mutation.

Historical source was also checked directly: the array-queue-era [server capture](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/cli/gateway-cli/run.ts#L630) and [restart loop](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/cli/gateway-cli/run-loop.ts#L878) reuse the captured start callback. Its [update documentation](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/docs/cli/update.md#L148) already requires external activation and states that `--no-restart` keeps old code running. Current source preserves that boundary.

[Exact-head Windows CI](https://github.com/openclaw/openclaw/actions/runs/34047521198/job/101525246118) passed all 13 filesystem-removal cases, including the rebound-junction regression, and the MXC backend suite. The MXC writable-bridge case removes an actual file; its protected-skill case rejects removal. The existing parent-alias case also reports pass but has capability-based early returns, so it is not counted alone as proof of executing those assertions. All required CI passed on 052df819bc2bb1f6d0aae522cbfbe89ba2b58de7. This closes the review’s source/platform evidence item without a code change.
