### PR TITLE
fix: restart Gateway after verified package rollback

### DIFF
--- a/src/cli/update-cli/update-command-rollback.test.ts
+++ b/src/cli/update-cli/update-command-rollback.test.ts
@@ -41,6 +41,7 @@ vi.mock("./update-command-service.js", () => ({
 vi.mock("../daemon-cli/restart-health-probe.js", () => ({
   confirmGatewayReachable: mocks.reachable,
 }));
+import * as packageModule from "./update-command-package.js";
 import { rollbackFailedUpdate } from "./update-command-rollback.js";
 import { completeUpdateCommandRun } from "./update-command-run.js";
 import { resolveUpdateResultNextAction } from "./update-recovery-guidance.js";
@@ -48,7 +49,10 @@ import { resolveUpdateResultNextAction } from "./update-recovery-guidance.js";
 const dirs = useAutoCleanupTempDirTracker(afterEach);
 let candidateRoot: string;
 let previousRoot: string;
-afterEach(() => vi.unstubAllEnvs());
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
 async function readPreviousConfig(env: NodeJS.ProcessEnv) {
   const snapshot = await createConfigIO({ env, pluginValidation: "skip" }).readConfigFileSnapshot();
   return snapshot.sourceConfigBeforeMigrations ?? snapshot.sourceConfig;
@@ -298,6 +302,7 @@ describe("verified package rollback", () => {
   );
   it.each([
     { change: "none", previousVerified: true, restored: true, service: "stopped" },
+    { change: "identity-read-failed", previousVerified: true, restored: true, service: "stopped" },
     { change: "shared", previousVerified: true, restored: false, service: "stopped" },
     { change: "agent", previousVerified: true, restored: false, service: "stopped" },
     { change: "during-stop", previousVerified: true, restored: false, service: "stopped" },
@@ -346,6 +351,11 @@ describe("verified package rollback", () => {
         exitCode: 0,
         durationMs: 1,
       }));
+      if (change === "identity-read-failed") {
+        vi.spyOn(packageModule, "readPackageUpdateIdentity").mockRejectedValueOnce(
+          new Error("Diagnostic identity read failed after verified restoration"),
+        );
+      }
       const outcome = await rollbackFailedUpdate({
         result,
         previousRoot,
@@ -375,7 +385,9 @@ describe("verified package rollback", () => {
         timeoutMs: 1_000,
       });
       expect(outcome.rolledBack).toBe(restored);
-      expect(rollback, JSON.stringify(outcome)).toHaveBeenCalledTimes(change === "none" ? 1 : 0);
+      expect(rollback, JSON.stringify(outcome)).toHaveBeenCalledTimes(
+        change === "none" || change === "identity-read-failed" ? 1 : 0,
+      );
       expect(mocks.restart).toHaveBeenCalledTimes(restored ? 1 : 0);
       if (service !== "stopped") {
         expect(mocks.stop).not.toHaveBeenCalled();

--- a/src/cli/update-cli/update-command-rollback.ts
+++ b/src/cli/update-cli/update-command-rollback.ts
@@ -179,16 +179,17 @@ export async function rollbackFailedUpdate(params: {
       after: undefined,
       steps: [...result.steps, restored],
     };
-    if (activePackageRoot) {
-      result.after = await readPackageUpdateIdentity(activePackageRoot);
-    }
     if (restored.exitCode === 0) {
+      // The transaction verified the previous package. Do not gate its restart
+      // on an extra diagnostic read whose result would be discarded.
       result.after = result.before;
       result.recovery = {
         serviceRestartSafe: false,
         packageRollbackVerified: true,
         reason: "runtime-verification-failed",
       };
+    } else if (activePackageRoot) {
+      result.after = await readPackageUpdateIdentity(activePackageRoot);
     }
     if (opts.run) {
       recordUpdateRunStep(


### PR DESCRIPTION
Related: #124396

## What Problem This Solves

Fixes an issue where users recovering from a failed update could be left without a restarted Gateway even after the package transaction successfully restored and verified the previous installation, if a subsequent diagnostic package read failed.

## Why This Change Was Made

Use the transaction-verified previous identity on successful rollback. Continue reading the observed package identity after failed or partial restoration. This changes the existing rollback caller only; package integrity, checkpoint restoration, and durable retention remain separate work.

## User Impact

Successful verified package restoration can proceed to the existing service restart and verification path without depending on a discarded diagnostic read. Failed restorations retain their actual observed identity.

## Evidence

- Regression reproduced: the discarded read threw after successful restoration and prevented the existing restart path from reporting verified rollback.
- 23 focused rollback tests passed, including partial/failed restoration identity and Windows suspension controls.
- Independent review found no actionable P0–P2 issues.
- Full isolated changed-file checks passed, including production/test typechecks, lint, unused-export scans, and repository guards.
- This scoped caller fix does not establish complete atomic-update journey or checkpoint/retention correctness.
