### PR TITLE
fix(heartbeat): keep policy warnings out of MCP completeness notices

### DIFF
--- a/qa/scenarios/scheduling/heartbeat-isolated-group-mcp-policy-note.yaml
+++ b/qa/scenarios/scheduling/heartbeat-isolated-group-mcp-policy-note.yaml
@@ -1,0 +1,156 @@
+title: Isolated group heartbeat keeps configured MCP after a policy note
+
+scenario:
+  id: heartbeat-isolated-group-mcp-policy-note
+  surface: cron
+  category: automation.heartbeat
+  coverage:
+    secondary:
+      - automation.wake-and-cooldown-handling
+      - channels.qa-channel-final-reply
+  regressionRefs:
+    - openclaw/openclaw#140279
+  gatewayConfigPatch:
+    tools:
+      # Keep MCP tools directly visible in the provider request instead of behind
+      # tool search, and route exec to a node host so the Codex harness drops its
+      # native tool surface and materializes configured MCP through OpenClaw.
+      toolSearch: false
+      exec:
+        host: node
+    channels:
+      qa-channel:
+        # A provider-qualified sender makes the isolated heartbeat carry the caller
+        # group id that the final policy pass drops, which is the reported trigger.
+        allowFrom:
+          - qa-channel:group:qa-heartbeat-mcp-room
+    agents:
+      defaults:
+        heartbeat:
+          every: 5m
+          target: qa-channel
+          to: group:qa-heartbeat-mcp-room
+          directPolicy: block
+          isolatedSession: true
+          prompt: "Isolated group heartbeat MCP proof. Reply exactly: QA-HEARTBEAT-MCP-OK"
+  objective: Verify an isolated heartbeat addressed to a group keeps its configured MCP tool and does not receive the incomplete-MCP blocker when the only policy input is the dropped caller-provided group id.
+  successCriteria:
+    - The heartbeat monitor job runs the isolated group heartbeat through a real Gateway, the Codex app-server harness, a real stdio MCP server, and the mock provider boundary.
+    - The heartbeat provider request offers the configured MCP server's tool.
+    - That request carries no "Configured MCP is incomplete" blocker in its developer instructions or input.
+    - The heartbeat reply is delivered to the configured qa-channel group.
+  docsRefs:
+    - docs/gateway/heartbeat.md
+    - docs/tools/mcp.md
+  codeRefs:
+    - src/agents/agent-bundle-mcp-harness.ts
+    - src/infra/heartbeat-runner-execution.ts
+    - extensions/codex/src/app-server/run-attempt-tool-setup.ts
+  execution:
+    kind: flow
+    runtime: codex
+    suiteIsolation: isolated
+    isolationReason: Configures an isolated group heartbeat with an MCP server and forces the heartbeat monitor job on the real Gateway.
+    channel: qa-channel
+    retryCount: 0
+    timeoutMs: 300000
+    summary: Prove an isolated group heartbeat with configured MCP reaches its normal assessment instead of a warning-only MCP blocker.
+    config:
+      requiredProviderMode: mock-openai
+      heartbeatPromptNeedle: Isolated group heartbeat MCP proof
+      heartbeatRoom: qa-heartbeat-mcp-room
+      heartbeatMarker: QA-HEARTBEAT-MCP-OK
+      heartbeatJobName: heartbeat-qa
+      mcpServerName: proof
+      mcpServerScript: scripts/e2e/mcp-app-conformance-server.mjs
+      bridgedToolName: heartbeat_respond
+      blockerNeedle: Configured MCP is incomplete
+
+flow:
+  steps:
+    - name: runs the isolated group heartbeat with its MCP tool and no warning-only blocker
+      actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message: isolated group heartbeat MCP proof requires mock-openai
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 60000
+        - call: reset
+        - call: patchConfig
+          saveAs: mcpPatchResult
+          args:
+            - env:
+                ref: env
+              patch:
+                mcp:
+                  servers:
+                    expr: "({ [config.mcpServerName]: { command: 'node', args: [path.join(env.repoRoot, config.mcpServerScript)], transport: 'stdio' } })"
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 60000
+        - call: waitForCondition
+          saveAs: heartbeatJob
+          args:
+            - lambda:
+                expr: "(async () => { const listed = await env.gateway.call('cron.list', { includeDisabled: true }, { timeoutMs: 30000 }); const jobs = Array.isArray(listed) ? listed : (listed?.jobs ?? []); return jobs.find((job) => job?.name === config.heartbeatJobName || job?.payload?.kind === 'heartbeat'); })()"
+            - 60000
+            - 500
+        - set: heartbeatRequestCursor
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor"
+        - call: env.gateway.call
+          saveAs: runResponse
+          args:
+            - cron.run
+            - id:
+                expr: heartbeatJob.id
+              mode: force
+            - timeoutMs: 30000
+        - assert:
+            expr: "runResponse?.ok === true && runResponse?.ran !== false"
+            message:
+              expr: "`expected cron.run to start the heartbeat monitor job, got ${JSON.stringify(runResponse)}`"
+        - call: waitForCondition
+          saveAs: heartbeatRequest
+          args:
+            - lambda:
+                expr: "(async () => (await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${heartbeatRequestCursor}`)).find((request) => String(request.allInputText ?? '').includes(config.heartbeatPromptNeedle) && JSON.stringify(request.body?.tools ?? []).includes(config.bridgedToolName)))()"
+            - expr: "liveTurnTimeoutMs(env, 150000)"
+            - 200
+        - set: heartbeatToolNames
+          value:
+            expr: "(heartbeatRequest.body?.tools ?? []).map((tool) => tool.name ?? tool.type)"
+        - set: mcpToolNames
+          value:
+            expr: "heartbeatToolNames.filter((name) => String(name).startsWith(`${config.mcpServerName}__`))"
+        - set: blockerText
+          value:
+            expr: "[String(heartbeatRequest.instructions ?? ''), String(heartbeatRequest.allInputText ?? '')].map((text) => { const index = text.indexOf(config.blockerNeedle); return index >= 0 ? text.slice(index, index + 320) : null; }).find((text) => text !== null) ?? null"
+        - assert:
+            expr: "mcpToolNames.length > 0"
+            message:
+              expr: "`heartbeat request did not offer the configured MCP tool. job=${JSON.stringify({ id: heartbeatJob.id, name: heartbeatJob.name })} tools=${JSON.stringify(heartbeatToolNames)}`"
+        - assert:
+            expr: "blockerText === null"
+            message:
+              expr: "`heartbeat received the warning-only MCP blocker although its MCP tools ${JSON.stringify(mcpToolNames)} were kept: ${JSON.stringify(blockerText)}`"
+        - call: waitForOutboundMessage
+          saveAs: heartbeatOutbound
+          args:
+            - ref: state
+            - lambda:
+                params: [candidate]
+                expr: "candidate.direction === 'outbound' && candidate.conversation.kind === 'group' && candidate.conversation.id === config.heartbeatRoom && String(candidate.text ?? '').trim() === config.heartbeatMarker"
+            - expr: "liveTurnTimeoutMs(env, 150000)"
+      detailsExpr: "JSON.stringify({ verdict: 'PASS', gateway: 'ephemeral-child', provider: env.providerMode, runtime: 'codex', job: { id: heartbeatJob.id, name: heartbeatJob.name }, mcpTools: mcpToolNames, blockerText, deliveredTo: `${heartbeatOutbound.conversation.kind}:${heartbeatOutbound.conversation.id}`, deliveredText: heartbeatOutbound.text, toolCount: heartbeatToolNames.length })"

--- a/src/agents/agent-bundle-mcp-harness.test.ts
+++ b/src/agents/agent-bundle-mcp-harness.test.ts
@@ -586,6 +586,73 @@ describe("materializeStaticMcpToolsForHarnessRunCore", () => {
     await result.dispose();
   });
 
+  it("does not report incomplete MCP for a policy note that removed no tool", async () => {
+    const runtime = makeRuntime({ sessionId: "scheduled-group-note", requesterSenderId: "unused" });
+    delete runtime.requesterScope;
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({
+      runtime,
+      releaseLease: runtime.acquireLease?.() ?? (() => {}),
+    });
+    const warnings: string[] = [];
+
+    // Isolated heartbeat session key with a caller-provided Telegram group id: the final
+    // policy pass drops the group id (and says so) but keeps every configured tool.
+    const result = await materializeStaticMcpToolsForHarnessRunCore({
+      sessionId: "scheduled-group-note",
+      workspaceDir: "/workspace",
+      toolsAllow: ["user-mail__inbox"],
+      autoApproveCodexAppServerApprovals: true,
+      policyContext: {
+        config: { agents: { entries: { demo: {} } } },
+        agentId: "demo",
+        sessionKey: "agent:demo:main:heartbeat",
+        groupId: "-1000000000001",
+        messageProvider: "telegram",
+        modelProvider: "openai",
+      },
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(result.tools.map((tool) => tool.name)).toEqual(["user-mail__inbox"]);
+    expect(warnings).toContain(
+      "effective tool policy: dropping caller-provided groupId that does not match session-derived group context",
+    );
+    expect(result.diagnosticNotice).toBeUndefined();
+    await result.dispose();
+  });
+
+  it("keeps policy notes in the notice when the final policy pass removed tools", async () => {
+    const runtime = makeRuntime({ sessionId: "scheduled-group-deny", requesterSenderId: "unused" });
+    delete runtime.requesterScope;
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({
+      runtime,
+      releaseLease: runtime.acquireLease?.() ?? (() => {}),
+    });
+
+    const result = await materializeStaticMcpToolsForHarnessRunCore({
+      sessionId: "scheduled-group-deny",
+      workspaceDir: "/workspace",
+      toolsAllow: ["user-mail__inbox"],
+      autoApproveCodexAppServerApprovals: true,
+      policyContext: {
+        config: { agents: { entries: { demo: {} } } },
+        agentId: "demo",
+        sessionKey: "agent:demo:main:heartbeat",
+        groupId: "-1000000000001",
+        messageProvider: "telegram",
+        modelProvider: "openai",
+        conversationToolPolicy: { deny: ["user-mail__inbox"] },
+      },
+    });
+
+    expect(result.tools).toEqual([]);
+    expect(result.diagnosticNotice).toContain(
+      "Configured MCP is incomplete for this scheduled run",
+    );
+    expect(result.diagnosticNotice).toContain("dropping caller-provided groupId");
+    await result.dispose();
+  });
+
   it("omits prompt-approved MCP tools from unattended execution", async () => {
     const runtime = makeRuntime({ sessionId: "scheduled-prompt", requesterSenderId: "unused" });
     delete runtime.requesterScope;

--- a/src/agents/agent-bundle-mcp-harness.ts
+++ b/src/agents/agent-bundle-mcp-harness.ts
@@ -29,6 +29,7 @@ import {
   requiresMcpCodexToolApproval,
   resolveProjectedMcpCodexToolApprovalMode,
 } from "./mcp-codex-tool-approval.js";
+import type { ToolPolicyFilterEvent } from "./tool-policy-pipeline.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 type RequesterScopedHarnessMcpTools = {
@@ -185,7 +186,9 @@ function notConnectedToolResult(serverName: string, toolName: string) {
 
 function applyHarnessToolPolicy(
   tools: AnyAgentTool[],
-  params: MaterializeRequesterScopedMcpToolsForHarnessRunParams,
+  params: MaterializeRequesterScopedMcpToolsForHarnessRunParams & {
+    onFilter?: (event: ToolPolicyFilterEvent) => void;
+  },
 ): AnyAgentTool[] {
   if (tools.length === 0) {
     return tools;
@@ -209,6 +212,7 @@ function applyHarnessToolPolicy(
     config: params.policyContext?.config ?? params.cfg,
     conversationCapabilityProfile: profile,
     warn: params.warn ?? (() => undefined),
+    onFilter: params.onFilter,
   });
 }
 
@@ -281,12 +285,22 @@ export async function materializeStaticMcpToolsForHarnessRunCore(
     throw error;
   }
   try {
-    const policyWarnings: string[] = [];
+    // Conversation-policy notes (for example a dropped caller-provided groupId) describe the
+    // policy inputs, not MCP availability; they only join the blocker notice when the final
+    // policy pass actually removed a configured tool. Approval omissions always join it.
+    const policyNotes: string[] = [];
+    const omittedTools: string[] = [];
+    let policyDroppedTools = false;
     const policyParams = {
       ...params,
       warn: (message: string) => {
-        policyWarnings.push(message);
+        policyNotes.push(message);
         params.warn?.(message);
+      },
+      onFilter: (event: ToolPolicyFilterEvent) => {
+        if (event.after.length < event.before.length) {
+          policyDroppedTools = true;
+        }
       },
     };
     const fullPermission = params.autoApproveCodexAppServerApprovals === true;
@@ -300,7 +314,7 @@ export async function materializeStaticMcpToolsForHarnessRunCore(
       ...(params.requestInteractiveCodexApproval
         ? { requestApproval: params.requestInteractiveCodexApproval }
         : {}),
-      onOmitted: (message) => policyWarnings.push(message),
+      onOmitted: (message) => omittedTools.push(message),
     });
     // App views outlive this attempt, so bind their callable surface to the
     // same complete catalog and final policy before any model tool can mint one.
@@ -312,7 +326,7 @@ export async function materializeStaticMcpToolsForHarnessRunCore(
           ...projectedApproval,
           ...(params.requestInteractiveCodexApproval
             ? {}
-            : { onOmitted: (message: string) => policyWarnings.push(message) }),
+            : { onOmitted: (message: string) => omittedTools.push(message) }),
         },
       ),
     );
@@ -321,7 +335,8 @@ export async function materializeStaticMcpToolsForHarnessRunCore(
         ...(liveRuntime.diagnostics ?? []).map(
           (diagnostic) => `${diagnostic.serverName}: ${diagnostic.message}`,
         ),
-        ...policyWarnings,
+        ...omittedTools,
+        ...(policyDroppedTools ? policyNotes : []),
       ],
       params.requestInteractiveCodexApproval ? "this run" : "this scheduled run",
     );


### PR DESCRIPTION
Closes #140279

## What Problem This Solves
Isolated group heartbeats reported incomplete configured tools when every tool remained available. A policy warning caused the false blocker.

## Why This Change Was Made
This state has one writer: the configured-tool materializer. It now records actual policy omissions independently of warnings, which still reach logs.

Production: +9 lines in the materializer for the filter callback and omission reason. Growth accepted under the owner's standing acceptance (2026-09-15).

## User Impact
Group heartbeats can use complete tool sets. Missing tools and failed discovery still produce a blocker.

## Evidence
Real Gateway: main retained all three tools with a false blocker. The fix retained all three, removed that blocker, and delivered one reply in the QA group. Removed-tool, failed-server, and non-group controls passed.

```sh
pnpm openclaw qa suite --provider-mode mock-openai --scenario heartbeat-isolated-group-mcp-policy-note --concurrency 1 --output-dir .artifacts/heartbeat-proof
```

## Compatibility
Group trust, tool caps, approvals, and public types stay unchanged.

## Consumers
Run instructions and automation tool snapshots share the corrected notice.

## Invalidation
Completeness is recomputed for each run.

## Tests
74 tests passed on the merge with main. Lint, types, and protocol checks passed.
```sh
node scripts/run-vitest.mjs run src/agents/agent-bundle-mcp-harness.test.ts src/agents/embedded-agent-runner/effective-tool-policy.test.ts extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
```
