### PR TITLE
perf(usage): accumulate dated family summaries once

### DIFF
--- a/src/gateway/server-methods/usage-session-loading.ts
+++ b/src/gateway/server-methods/usage-session-loading.ts
@@ -1,8 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { mergeSessionCostSummaryInto } from "../../infra/session-cost-usage-rollup.js";
-import { createEmptyCostUsageTotals } from "../../infra/session-cost-usage-totals.js";
+import { createSessionCostSummaryAccumulator } from "../../infra/session-cost-usage-rollup.js";
 import {
   discoverAllSessions,
   loadSessionCostSummariesFromCache,
@@ -142,21 +141,25 @@ export async function loadUsageSessionSummaries(params: {
   );
   for (const { agentSessions, loaded } of agentLoads) {
     cacheStatus = mergeUsageCacheStatus(cacheStatus, loaded.cacheStatus);
+    let usage: ReturnType<typeof createSessionCostSummaryAccumulator> | undefined;
     for (const [index, summary] of loaded.summaries.entries()) {
-      if (!summary) {
-        continue;
-      }
       const session = expectDefined(agentSessions[index], "agent sessions entry at index");
-      const merged = expectDefined(
-        mergedEntries[session.entryIndex],
-        "merged entries entry at session.entry index",
-      );
-      const usage: SessionCostSummary =
-        usageByEntryIndex[session.entryIndex] ?? createEmptyCostUsageTotals();
-      usage.sessionId = merged.sessionId;
-      usage.sessionFile = merged.sessionFile;
-      mergeSessionCostSummaryInto(usage, summary);
-      usageByEntryIndex[session.entryIndex] = usage;
+      if (summary) {
+        const merged = expectDefined(
+          mergedEntries[session.entryIndex],
+          "merged entries entry at session.entry index",
+        );
+        usage ??= createSessionCostSummaryAccumulator({
+          sessionId: merged.sessionId,
+          sessionFile: merged.sessionFile,
+        });
+        usage.add(summary);
+      }
+      // Construction above keeps each family's instances contiguous within its agent batch.
+      if (usage && agentSessions[index + 1]?.entryIndex !== session.entryIndex) {
+        usageByEntryIndex[session.entryIndex] = usage.finish();
+        usage = undefined;
+      }
     }
   }
 

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -7,6 +7,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createEmptyCostUsageTotals } from "../../infra/session-cost-usage-totals.js";
+import type { SessionCostSummary } from "../../infra/session-cost-usage.types.js";
+import type { SessionsUsageResult } from "../../shared/usage-types.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 
@@ -112,53 +114,27 @@ const TEST_RUNTIME_CONFIG = {
   session: {},
 };
 
-async function runSessionsUsage(
+async function runSessionsUsageMethod(
+  method: "sessions.usage" | "sessions.usage.timeseries" | "sessions.usage.logs",
   params: Record<string, unknown>,
   config: OpenClawConfig = TEST_RUNTIME_CONFIG,
 ) {
   const respond = vi.fn();
-  await expectDefined(
-    usageHandlers["sessions.usage"],
-    'usageHandlers["sessions.usage"] test invariant',
-  )({
+  const handler = expectDefined(usageHandlers[method], `${method} test invariant`);
+  await handler({
     respond,
     params,
     context: { getRuntimeConfig: () => config },
-  } as unknown as Parameters<(typeof usageHandlers)["sessions.usage"]>[0]);
+  } as unknown as Parameters<typeof handler>[0]);
   return respond;
 }
 
-async function runSessionsUsageTimeseries(
-  params: Record<string, unknown>,
-  config: OpenClawConfig = TEST_RUNTIME_CONFIG,
-) {
-  const respond = vi.fn();
-  await expectDefined(
-    usageHandlers["sessions.usage.timeseries"],
-    'usageHandlers["sessions.usage.timeseries"] test invariant',
-  )({
-    respond,
-    params,
-    context: { getRuntimeConfig: () => config },
-  } as unknown as Parameters<(typeof usageHandlers)["sessions.usage.timeseries"]>[0]);
-  return respond;
-}
-
-async function runSessionsUsageLogs(
-  params: Record<string, unknown>,
-  config: OpenClawConfig = TEST_RUNTIME_CONFIG,
-) {
-  const respond = vi.fn();
-  await expectDefined(
-    usageHandlers["sessions.usage.logs"],
-    'usageHandlers["sessions.usage.logs"] test invariant',
-  )({
-    respond,
-    params,
-    context: { getRuntimeConfig: () => config },
-  } as unknown as Parameters<(typeof usageHandlers)["sessions.usage.logs"]>[0]);
-  return respond;
-}
+const runSessionsUsage = (params: Record<string, unknown>, config?: OpenClawConfig) =>
+  runSessionsUsageMethod("sessions.usage", params, config);
+const runSessionsUsageTimeseries = (params: Record<string, unknown>, config?: OpenClawConfig) =>
+  runSessionsUsageMethod("sessions.usage.timeseries", params, config);
+const runSessionsUsageLogs = (params: Record<string, unknown>, config?: OpenClawConfig) =>
+  runSessionsUsageMethod("sessions.usage.logs", params, config);
 
 const BASE_USAGE_RANGE = {
   startDate: "2026-02-01",
@@ -362,11 +338,7 @@ describe("sessions.usage", () => {
     // All three sessions belong to one agent, so the whole cache is read exactly once.
     expect(vi.mocked(loadSessionCostSummariesFromCache)).toHaveBeenCalledTimes(1);
     expect(respond).toHaveBeenCalledTimes(1);
-    const result = mockArg(respond, 0, 1) as {
-      cacheStatus?: { status: string };
-      sessions: Array<{ sessionId: string; usage?: { totalTokens: number } | null }>;
-      totals: { totalTokens: number };
-    };
+    const result = mockArg(respond, 0, 1) as SessionsUsageResult;
     expect(result.cacheStatus?.status).toBe("refreshing");
     expect(result.sessions.map((session) => session.sessionId)).toEqual(["s-a", "s-b", "s-c"]);
     expect(result.sessions.map((session) => session.usage?.totalTokens ?? null)).toEqual([
@@ -704,13 +676,16 @@ describe("sessions.usage", () => {
 
   it("rolls up known session family ids when historical usage is requested", async () => {
     const storeKey = "agent:opus:main";
-    const dailySources: Array<{ missingCostByModel: Record<string, number> }> = [];
+    const sources: SessionCostSummary[] = [];
+    const sourceSnapshots: SessionCostSummary[] = [];
 
     await withUsageState(async (writeSessionFile) => {
       const oldSessionFile = writeSessionFile("old.jsonl.reset.2026-02-01T00-00-00.000Z");
+      const oldestSessionFile = writeSessionFile("oldest.jsonl.reset.2026-01-31T00-00-00.000Z");
       mockStoredSession(storeKey, "current");
       vi.mocked(discoverAllSessions).mockResolvedValueOnce([
         { sessionId: "old", sessionFile: oldSessionFile, mtime: 1_000 },
+        { sessionId: "oldest", sessionFile: oldestSessionFile, mtime: 900 },
       ]);
 
       mockCombinedStore(
@@ -719,7 +694,7 @@ describe("sessions.usage", () => {
             sessionId: "current",
             updatedAt: 1_000,
             usageFamilyKey: storeKey,
-            usageFamilySessionIds: ["old", "current"],
+            usageFamilySessionIds: ["old", "current", "oldest"],
           },
         },
         [[storeKey, "opus"]],
@@ -727,8 +702,23 @@ describe("sessions.usage", () => {
       vi.mocked(loadSessionCostSummariesFromCache).mockImplementation(async ({ sessions }) => ({
         summaries: sessions.map((session) => {
           const historical = session.sessionId === "old";
-          const totalTokens = historical ? 10 : 20;
-          const totalCost = historical ? 0.02 : 0.01;
+          const oldest = session.sessionId === "oldest";
+          const totalTokens = oldest ? 30 : historical ? 10 : 20;
+          const totalCost = oldest ? 0.03 : historical ? 0.02 : 0.01;
+          const date = oldest ? "2026-02-02" : "2026-02-01";
+          const messageCounts = {
+            total: 1,
+            user: 1,
+            assistant: 0,
+            toolCalls: 0,
+            toolResults: 0,
+            errors: 0,
+          };
+          const latency = oldest
+            ? { count: 3, avgMs: 7, p95Ms: 9, minMs: 5, maxMs: 9 }
+            : historical
+              ? { count: 2, avgMs: 25, p95Ms: 30, minMs: 20, maxMs: 30 }
+              : { count: 1, avgMs: 10, p95Ms: 10, minMs: 10, maxMs: 10 };
           const totals = {
             ...createEmptyCostUsageTotals(),
             input: totalTokens,
@@ -738,24 +728,22 @@ describe("sessions.usage", () => {
           };
           const daily = {
             ...totals,
-            date: "2026-02-01",
+            date,
             tokens: totalTokens,
             cost: totalCost,
             missingCostEntries: 1,
             missingCostByModel: { "fixture/unpriced": 1 },
           };
-          dailySources.push(daily);
-          return {
+          const summary: SessionCostSummary = {
             ...totals,
+            activityDates: [date],
             dailyBreakdown: [daily],
-            messageCounts: {
-              total: 1,
-              user: 1,
-              assistant: 0,
-              toolCalls: 0,
-              toolResults: 0,
-              errors: 0,
-            },
+            messageCounts,
+            dailyMessageCounts: [{ date, ...messageCounts }],
+            utcQuarterHourMessageCounts: [{ date, quarterIndex: 2, ...messageCounts }],
+            utcQuarterHourTokenUsage: [{ date, quarterIndex: 2, ...totals }],
+            latency,
+            dailyLatency: [{ date, ...latency }],
             modelUsage: [
               {
                 provider: historical ? "fixture::bedrock" : "fixture",
@@ -765,13 +753,20 @@ describe("sessions.usage", () => {
               },
             ],
             toolUsage: {
-              totalCalls: 1,
-              uniqueTools: 1,
-              tools: [{ name: historical ? "a-second" : "z-first", count: 1 }],
+              totalCalls: oldest ? 1 : historical ? 2 : 3,
+              uniqueTools: historical || oldest ? 1 : 2,
+              tools: oldest
+                ? [{ name: "z-first", count: 1 }]
+                : historical
+                  ? [{ name: "a-second", count: 2 }]
+                  : [
+                      { name: "z-first", count: 2 },
+                      { name: "a-second", count: 1 },
+                    ],
             },
             dailyModelUsage: [
               {
-                date: "2026-02-01",
+                date,
                 provider: historical ? "fixture:bedrock" : "fixture",
                 model: historical ? "arn" : "bedrock:arn",
                 tokens: totalTokens,
@@ -780,6 +775,9 @@ describe("sessions.usage", () => {
               },
             ],
           };
+          sources.push(summary);
+          sourceSnapshots.push(structuredClone(summary));
+          return summary;
         }),
         cacheStatus: {
           status: "fresh",
@@ -798,38 +796,13 @@ describe("sessions.usage", () => {
 
       expect(respond).toHaveBeenCalledTimes(1);
       expect(mockArg(respond, 0, 0)).toBe(true);
-      const result = mockArg(respond, 0, 1) as {
-        sessions: Array<{
-          key: string;
-          scope?: string;
-          includedSessionIds?: string[];
-          usage?: {
-            totalTokens: number;
-            totalCost: number;
-            dailyBreakdown?: Array<{
-              totalTokens: number;
-              totalCost: number;
-              missingCostEntries: number;
-              missingCostByModel?: Record<string, number>;
-            }>;
-            messageCounts?: { total: number };
-            modelUsage?: Array<{ provider?: string; model?: string }>;
-            dailyModelUsage?: Array<{ provider?: string; model?: string }>;
-            toolUsage?: { tools: Array<{ name: string }> };
-          };
-        }>;
-        totals: { totalTokens: number; totalCost: number };
-        aggregates: {
-          byModel: Array<{ provider?: string; model?: string }>;
-          modelDaily: Array<{ provider?: string; model?: string }>;
-        };
-      };
+      const result = mockArg(respond, 0, 1) as SessionsUsageResult;
       expect(result.sessions).toHaveLength(1);
       expect(result.sessions[0]?.key).toBe(storeKey);
       expect(result.sessions[0]?.scope).toBe("family");
-      expect(result.sessions[0]?.includedSessionIds).toEqual(["current", "old"]);
-      expect(result.sessions[0]?.usage?.totalTokens).toBe(30);
-      expect(result.sessions[0]?.usage?.totalCost).toBeCloseTo(0.03);
+      expect(result.sessions[0]?.includedSessionIds).toEqual(["current", "old", "oldest"]);
+      expect(result.sessions[0]?.usage?.totalTokens).toBe(60);
+      expect(result.sessions[0]?.usage?.totalCost).toBeCloseTo(0.06);
       expect(result.sessions[0]?.usage?.dailyBreakdown).toMatchObject([
         {
           date: "2026-02-01",
@@ -842,16 +815,38 @@ describe("sessions.usage", () => {
           missingCostEntries: 2,
           missingCostByModel: { "fixture/unpriced": 2 },
         },
+        {
+          date: "2026-02-02",
+          totalTokens: 30,
+          totalCost: 0.03,
+          missingCostByModel: { "fixture/unpriced": 1 },
+        },
       ]);
-      expect(dailySources).toHaveLength(2);
-      expect(dailySources.map((day) => day.missingCostByModel)).toEqual([
-        { "fixture/unpriced": 1 },
-        { "fixture/unpriced": 1 },
+      expect(sources).toEqual(sourceSnapshots);
+      const usage = result.sessions[0]?.usage;
+      expect(usage?.activityDates).toEqual(["2026-02-01", "2026-02-02"]);
+      expect(usage?.messageCounts?.total).toBe(3);
+      expect(usage?.dailyMessageCounts).toMatchObject([
+        { date: "2026-02-01", total: 2 },
+        { date: "2026-02-02", total: 1 },
       ]);
-      expect(result.sessions[0]?.usage?.messageCounts?.total).toBe(2);
-      expect(result.sessions[0]?.usage?.toolUsage?.tools.map((tool) => tool.name)).toEqual([
-        "z-first",
-        "a-second",
+      expect(usage?.utcQuarterHourMessageCounts).toMatchObject([
+        { date: "2026-02-01", quarterIndex: 2, total: 2 },
+        { date: "2026-02-02", quarterIndex: 2, total: 1 },
+      ]);
+      expect(usage?.utcQuarterHourTokenUsage).toMatchObject([
+        { date: "2026-02-01", quarterIndex: 2, totalTokens: 30, totalCost: 0.03 },
+        { date: "2026-02-02", quarterIndex: 2, totalTokens: 30, totalCost: 0.03 },
+      ]);
+      expect(usage?.dailyLatency).toEqual([
+        { date: "2026-02-01", count: 3, avgMs: 20, p95Ms: 30, minMs: 10, maxMs: 30 },
+        { date: "2026-02-02", count: 3, avgMs: 7, p95Ms: 9, minMs: 5, maxMs: 9 },
+      ]);
+      expect(usage?.latency).toEqual({ count: 6, avgMs: 13.5, p95Ms: 30, minMs: 5, maxMs: 30 });
+      // a-second overtakes z-first before the final instance brings their counts level.
+      expect(usage?.toolUsage?.tools).toEqual([
+        { name: "a-second", count: 3 },
+        { name: "z-first", count: 3 },
       ]);
       expect(result.sessions[0]?.usage?.modelUsage).toMatchObject([
         { provider: "fixture", model: "bedrock::arn" },
@@ -860,17 +855,19 @@ describe("sessions.usage", () => {
       expect(result.sessions[0]?.usage?.dailyModelUsage).toMatchObject([
         { provider: "fixture", model: "bedrock:arn" },
         { provider: "fixture:bedrock", model: "arn" },
+        { provider: "fixture", model: "bedrock:arn" },
       ]);
       expect(result.aggregates.byModel).toMatchObject([
-        { provider: "fixture::bedrock", model: "arn" },
         { provider: "fixture", model: "bedrock::arn" },
+        { provider: "fixture::bedrock", model: "arn" },
       ]);
       expect(result.aggregates.modelDaily).toMatchObject([
         { provider: "fixture:bedrock", model: "arn" },
         { provider: "fixture", model: "bedrock:arn" },
+        { provider: "fixture", model: "bedrock:arn" },
       ]);
-      expect(result.totals.totalTokens).toBe(30);
-      expect(result.totals.totalCost).toBeCloseTo(0.03);
+      expect(result.totals.totalTokens).toBe(60);
+      expect(result.totals.totalCost).toBeCloseTo(0.06);
     });
   });
 
@@ -1086,11 +1083,7 @@ describe("sessions.usage", () => {
 
     expect(respond).toHaveBeenCalledTimes(1);
     expect(mockArg(respond, 0, 0)).toBe(true);
-    const result = mockArg(respond, 0, 1) as {
-      sessions: Array<{ key: string }>;
-      totals: { totalCost: number; totalTokens: number };
-      aggregates: { sessionCount?: number; longestSessionDurationMs?: number };
-    };
+    const result = mockArg(respond, 0, 1) as SessionsUsageResult;
 
     // Only the most-recent session (s-a, mtime=300) appears in the page
     expect(result.sessions).toHaveLength(1);

--- a/src/infra/session-cost-usage-rollup.ts
+++ b/src/infra/session-cost-usage-rollup.ts
@@ -344,27 +344,38 @@ function buildToolUsage(
   };
 }
 
-function mergeDatedRows<T extends { date: string; quarterIndex?: number }>(
-  left: T[] | undefined,
-  right: T[] | undefined,
+function createDatedRowsAccumulator<T extends { date: string; quarterIndex?: number }>(
   add: (target: T, source: T) => void,
-  clone: (row: T) => T = (row) => ({ ...row }),
-): T[] | undefined {
+  options?: {
+    key?: (row: T) => string;
+    clone?: (row: T) => T;
+  },
+) {
   const rows = new Map<string, T>();
-  for (const row of [...(left ?? []), ...(right ?? [])]) {
-    const key = row.quarterIndex === undefined ? row.date : `${row.date}:${row.quarterIndex}`;
-    const existing = rows.get(key);
-    if (existing) {
-      add(existing, row);
-    } else {
-      rows.set(key, clone(row));
-    }
-  }
-  return rows.size
-    ? Array.from(rows.values()).toSorted(
-        (a, b) => a.date.localeCompare(b.date) || (a.quarterIndex ?? 0) - (b.quarterIndex ?? 0),
-      )
-    : undefined;
+  const keyOf =
+    options?.key ??
+    ((row: T) => (row.quarterIndex === undefined ? row.date : `${row.date}:${row.quarterIndex}`));
+  const clone = options?.clone ?? ((row: T) => ({ ...row }));
+  return {
+    add(source: T[] | undefined): void {
+      for (const row of source ?? []) {
+        const key = keyOf(row);
+        const existing = rows.get(key);
+        if (existing) {
+          add(existing, row);
+        } else {
+          rows.set(key, clone(row));
+        }
+      }
+    },
+    finish(): T[] | undefined {
+      return rows.size
+        ? Array.from(rows.values()).toSorted(
+            (a, b) => a.date.localeCompare(b.date) || (a.quarterIndex ?? 0) - (b.quarterIndex ?? 0),
+          )
+        : undefined;
+    },
+  };
 }
 
 function mergeMessageCountSummaries(
@@ -404,99 +415,26 @@ function mergeLatencyStats(
   };
 }
 
-function mergeDailyLatencyStats(
-  left: SessionDailyLatency[] | undefined,
-  right: SessionDailyLatency[] | undefined,
-): SessionDailyLatency[] | undefined {
-  const rows = new Map<string, SessionDailyLatency>();
-  for (const row of [...(left ?? []), ...(right ?? [])]) {
-    const existing = rows.get(row.date);
-    if (!existing) {
-      rows.set(row.date, { ...row });
-      continue;
-    }
-    const count = existing.count + row.count;
-    existing.avgMs =
-      count > 0 ? (existing.avgMs * existing.count + row.avgMs * row.count) / count : 0;
-    existing.count = count;
-    existing.p95Ms = Math.max(existing.p95Ms, row.p95Ms);
-    existing.minMs = Math.min(existing.minMs, row.minMs);
-    existing.maxMs = Math.max(existing.maxMs, row.maxMs);
-  }
-  return rows.size
-    ? Array.from(rows.values()).toSorted((a, b) => a.date.localeCompare(b.date))
-    : undefined;
-}
-
-function mergeDailyModels(
-  left: SessionDailyModelUsage[] | undefined,
-  right: SessionDailyModelUsage[] | undefined,
-): SessionDailyModelUsage[] | undefined {
-  const rows = new Map<string, SessionDailyModelUsage>();
-  for (const row of [...(left ?? []), ...(right ?? [])]) {
-    const key = usageDailyModelIdentity(row.date, row.provider, row.model);
-    const existing = rows.get(key);
-    if (!existing) {
-      rows.set(key, { ...row });
-      continue;
-    }
-    existing.tokens += row.tokens;
-    existing.cost += row.cost;
-    existing.count += row.count;
-  }
-  return rows.size
-    ? Array.from(rows.values()).toSorted((a, b) => a.date.localeCompare(b.date))
-    : undefined;
-}
-
-export function mergeSessionCostSummaryInto(
-  target: SessionCostSummary,
-  source: SessionCostSummary,
-): void {
-  addCostUsageTotals(target, source);
-  target.firstActivity =
-    target.firstActivity === undefined
-      ? source.firstActivity
-      : source.firstActivity === undefined
-        ? target.firstActivity
-        : Math.min(target.firstActivity, source.firstActivity);
-  target.lastActivity =
-    target.lastActivity === undefined
-      ? source.lastActivity
-      : source.lastActivity === undefined
-        ? target.lastActivity
-        : Math.max(target.lastActivity, source.lastActivity);
-  if (target.firstActivity !== undefined && target.lastActivity !== undefined) {
-    target.durationMs = Math.max(0, target.lastActivity - target.firstActivity);
-  }
-
-  const activityDates = new Set([...(target.activityDates ?? []), ...(source.activityDates ?? [])]);
-  if (activityDates.size) {
-    target.activityDates = Array.from(activityDates).toSorted();
-  }
-  target.dailyBreakdown = mergeDatedRows(
-    target.dailyBreakdown,
-    source.dailyBreakdown,
+export function createSessionCostSummaryAccumulator(
+  identity: Pick<SessionCostSummary, "sessionId" | "sessionFile">,
+) {
+  const target: SessionCostSummary = { ...createEmptyCostUsageTotals(), ...identity };
+  const activityDates = new Set<string>();
+  const dailyBreakdown = createDatedRowsAccumulator<
+    NonNullable<SessionCostSummary["dailyBreakdown"]>[number]
+  >(
     (current, row) => {
       addCostUsageTotals(current, row);
       current.tokens += row.tokens;
       current.cost += row.cost;
     },
-    (row) => ({ ...row, ...cloneCostUsageTotals(row) }),
+    { clone: (row) => ({ ...row, ...cloneCostUsageTotals(row) }) },
   );
-  target.dailyMessageCounts = mergeDatedRows(
-    target.dailyMessageCounts,
-    source.dailyMessageCounts,
-    addMessageCounts,
-  );
-  target.utcQuarterHourMessageCounts = mergeDatedRows(
-    target.utcQuarterHourMessageCounts,
-    source.utcQuarterHourMessageCounts,
-    addMessageCounts,
-  );
-  target.utcQuarterHourTokenUsage = mergeDatedRows(
-    target.utcQuarterHourTokenUsage,
-    source.utcQuarterHourTokenUsage,
+  const dailyMessageCounts =
+    createDatedRowsAccumulator<SessionDailyMessageCounts>(addMessageCounts);
+  const quarterMessages =
+    createDatedRowsAccumulator<SessionUtcQuarterHourMessageCounts>(addMessageCounts);
+  const quarterTokens = createDatedRowsAccumulator<SessionUtcQuarterHourTokenUsage>(
     (current, row) => {
       current.input += row.input;
       current.output += row.output;
@@ -506,20 +444,76 @@ export function mergeSessionCostSummaryInto(
       current.totalCost += row.totalCost;
     },
   );
-  target.dailyLatency = mergeDailyLatencyStats(target.dailyLatency, source.dailyLatency);
-  target.dailyModelUsage = mergeDailyModels(target.dailyModelUsage, source.dailyModelUsage);
-  target.messageCounts = mergeMessageCountSummaries(target.messageCounts, source.messageCounts);
+  const dailyLatency = createDatedRowsAccumulator<SessionDailyLatency>((current, row) => {
+    const count = current.count + row.count;
+    current.avgMs = count > 0 ? (current.avgMs * current.count + row.avgMs * row.count) / count : 0;
+    current.count = count;
+    current.p95Ms = Math.max(current.p95Ms, row.p95Ms);
+    current.minMs = Math.min(current.minMs, row.minMs);
+    current.maxMs = Math.max(current.maxMs, row.maxMs);
+  });
+  const dailyModels = createDatedRowsAccumulator<SessionDailyModelUsage>(
+    (current, row) => {
+      current.tokens += row.tokens;
+      current.cost += row.cost;
+      current.count += row.count;
+    },
+    { key: (row) => usageDailyModelIdentity(row.date, row.provider, row.model) },
+  );
 
-  // Family rows retain first-seen/tie order; response-wide aggregates sort independently later.
-  const tools = new Map<string, number>();
-  mergeTools(tools, target.toolUsage?.tools ?? []);
-  mergeTools(tools, source.toolUsage?.tools ?? []);
-  target.toolUsage = buildToolUsage(tools, false);
-  const models = new Map<string, SessionModelUsage>();
-  mergeModels(models, target.modelUsage ?? []);
-  mergeModels(models, source.modelUsage ?? []);
-  target.modelUsage = sortedModelUsage(models, false);
-  target.latency = mergeLatencyStats(target.latency, source.latency);
+  return {
+    add(source: SessionCostSummary): void {
+      addCostUsageTotals(target, source);
+      target.firstActivity =
+        target.firstActivity === undefined
+          ? source.firstActivity
+          : source.firstActivity === undefined
+            ? target.firstActivity
+            : Math.min(target.firstActivity, source.firstActivity);
+      target.lastActivity =
+        target.lastActivity === undefined
+          ? source.lastActivity
+          : source.lastActivity === undefined
+            ? target.lastActivity
+            : Math.max(target.lastActivity, source.lastActivity);
+      if (target.firstActivity !== undefined && target.lastActivity !== undefined) {
+        target.durationMs = Math.max(0, target.lastActivity - target.firstActivity);
+      }
+      for (const date of source.activityDates ?? []) {
+        activityDates.add(date);
+      }
+      dailyBreakdown.add(source.dailyBreakdown);
+      dailyMessageCounts.add(source.dailyMessageCounts);
+      quarterMessages.add(source.utcQuarterHourMessageCounts);
+      quarterTokens.add(source.utcQuarterHourTokenUsage);
+      dailyLatency.add(source.dailyLatency);
+      dailyModels.add(source.dailyModelUsage);
+      target.messageCounts = mergeMessageCountSummaries(target.messageCounts, source.messageCounts);
+
+      // Later count ties inherit the preceding ranking, so tools still fold after each instance.
+      const tools = new Map<string, number>();
+      mergeTools(tools, target.toolUsage?.tools ?? []);
+      mergeTools(tools, source.toolUsage?.tools ?? []);
+      target.toolUsage = buildToolUsage(tools, false);
+      const models = new Map<string, SessionModelUsage>();
+      mergeModels(models, target.modelUsage ?? []);
+      mergeModels(models, source.modelUsage ?? []);
+      target.modelUsage = sortedModelUsage(models, false);
+      target.latency = mergeLatencyStats(target.latency, source.latency);
+    },
+    finish(): SessionCostSummary {
+      if (activityDates.size) {
+        target.activityDates = Array.from(activityDates).toSorted();
+      }
+      target.dailyBreakdown = dailyBreakdown.finish();
+      target.dailyMessageCounts = dailyMessageCounts.finish();
+      target.utcQuarterHourMessageCounts = quarterMessages.finish();
+      target.utcQuarterHourTokenUsage = quarterTokens.finish();
+      target.dailyLatency = dailyLatency.finish();
+      target.dailyModelUsage = dailyModels.finish();
+      return target;
+    },
+  };
 }
 
 function usageBucketsInRange(


### PR DESCRIPTION
## What Problem This Solves

Historical session-family Usage rebuilds, clones, and sorts accumulated dated rows after every instance, so families with many historical instances repeat increasing amounts of aggregation work.

## Why This Change Was Made

Keep request-local dated-row maps until each contiguous family finishes, then project and sort once and release the accumulator. Preserve source ownership, nullable/empty distinctions, sequential latency arithmetic, model identities, and the tool ranking inherited by later count ties. Existing per-agent batching and ordered cache results define the family boundary. Production shrinks three lines.

## User Impact

Historical family summaries keep the same totals, row order, ranking, and metadata while allocating less temporary data for repeated instances. Selection, cache loading/scheduling, transcript/pricing/storage behavior, configuration, and protocol stay unchanged.

## Evidence

- **60 exact full-loader comparisons** cover 0/1/2/3/10/100 instances, multiple families/agents, and full/null/empty/sparse summaries. Deeply frozen inputs retain their values; property presence, undefined/empty/null distinctions, array order, exact numbers, and cache-call order match. Comparisons treat object-property order as insignificant.
- The expanded handler fixture passes **27 tests on baseline production**. Final candidate passes **107 focused tests** and the full changed gate in 208.03 seconds. Independent source/probe review and fresh managed autoreview through P2 found no actionable issues.
- Actual-loader A/B/B/A with frozen synthetic cache results samples **1.85%, 76.79%, and 97.21% less allocation** for 1, 10, and 100 instances. Each instance has twelve dated rows, with shared and distinct dates; storage/cache I/O is excluded.
- Two fresh process observations per arm are descriptive. The one-instance case is about **0.005 ms slower per call** (+18.89%), and post-GC growth is mixed (higher at 1 and 100 instances, lower at 10). This supports reduced repeated allocation/work, not a universal speedup, retained-heap/RSS benefit, statistical significance, or whole-Gateway claim.
- Initial lint and test-helper cleanup issues were corrected with existing assertions/limits preserved. Baseline tests, parity, measurements, focused tests, reviews, and the full final gate were rerun; first-attempt receipts remain recorded.
- Required hosted CI passed on the exact reviewed head ([run 34047745463](https://github.com/openclaw/openclaw/actions/runs/34047745463)).
