### PR TITLE
fix(signal): use the declared WebSocket runtime under Bun

### DIFF
--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -272,8 +272,8 @@ function expectMockLogNotContains(mock: ReturnType<typeof vi.fn>, expected: stri
 }
 
 // Minimal WebSocket mock for connection-log assertions.
-vi.mock("ws", () => ({
-  default: class MockWebSocket {
+vi.mock("./ws-runtime.js", () => ({
+  WebSocket: class MockWebSocket {
     private handlers = new Map<string, Array<(...args: unknown[]) => void>>();
     private bufferedMessageFlushed = false;
 

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -22,7 +22,7 @@ import {
   readResponseWithLimit,
 } from "openclaw/plugin-sdk/response-limit-runtime";
 import { readRegularFile } from "openclaw/plugin-sdk/security-runtime";
-import WebSocket from "ws";
+import { WebSocket } from "./ws-runtime.js";
 
 type ContainerRpcOptions = {
   baseUrl: string;

--- a/extensions/signal/src/ws-runtime.ts
+++ b/extensions/signal/src/ws-runtime.ts
@@ -1,0 +1,11 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import type WebSocketClient from "ws";
+
+const require = createRequire(import.meta.url);
+
+// Use the declared transport so Bun preserves ws payload and handshake options.
+export type WebSocket = WebSocketClient;
+export const WebSocket: typeof WebSocketClient = require(
+  path.join(path.dirname(require.resolve("ws/package.json")), "index.js"),
+);


### PR DESCRIPTION
## What Problem This Solves

Bun substitutes its builtin WebSocket constructor for a bare ws import, while the Signal plugin declares the ws package and supplies that package's transport options.

## Why This Change Was Made

Load the declared installed package through a Signal-local adapter using the existing plugin-relative pattern. Move the client import and its existing fixture mock to that boundary. Constructor arguments, options, drain behavior, and lifecycle logic remain unchanged.

## User Impact

Signal uses its declared WebSocket transport consistently under Bun. No dependency version, global alias, configuration, or protocol change is introduced.

## Evidence

- Pure import-binding checks reproduced the Node/Bun constructor-selection difference without constructing a WebSocket. After the change, the adapter matched the declared installed package under both runtimes.
- Adapter mock identity passed under both runtimes, followed by six approved ordinary mocked lifecycle cases on each; 77 other cases were unselected locally.
- Complete changed-file checks, a full build, and fresh independent P0–P2 review passed. The declared package and option-consumer source contracts were inspected.
- No actual WebSocket construction, network connection, real Signal service, payload-limit, malformed-input, or deadline-enforcement test was run locally. This proves constructor selection and mocked lifecycle compatibility, not live enforcement. Hosted CI is tracked separately.

## Review input qualification

The unchanged synthetic fixtures are covered by the narrowly scoped, explicitly approved host-policy correction in [ClawSweeper #1469](https://github.com/openclaw/clawsweeper/pull/1469), merged as `ff0156fb8628cbf9f22d00864810dea56e83122b`. It qualifies only the two reviewed fixture occurrences; scanner and review guards remain enabled. The native pinned scanner preserved its output and changed classification from refusal to the two expected notices under that exact policy. No fixture value is reproduced here.

The PR source and the runtime-proof limits above are unchanged. A fresh hosted review is still required; policy qualification itself is not a review verdict or an approval of application behavior.
