### PR TITLE
fix(sessions): guard validateSessionId against a non-string session id

### DIFF
--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -13,7 +13,10 @@ import {
 } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { appendSqliteTrajectoryRuntimeEvents } from "../trajectory/runtime-store.sqlite.js";
 import type { TrajectoryEvent } from "../trajectory/types.js";
@@ -451,6 +454,49 @@ describe("sessionsTailCommand", () => {
     const output = runtimeOutput(runtime);
     expect(output).toContain("current ok");
     expect(output).not.toContain("stale ok");
+  });
+
+  it("does not let a sessionId-less store row poison an unrelated --session-key request (#140261)", async () => {
+    const runtime = makeRuntime();
+    await writeSessionEntry();
+    await appendEvents([
+      makeEvent({
+        type: "tool.result",
+        ts: "2026-05-18T12:04:21.000Z",
+        data: { name: "healthy", success: true },
+      }),
+    ]);
+
+    // Regression pin for #140261: a legacy/corrupted row (e.g. a cron entry where only
+    // a system message was ever queued, so no live session -- and thus no sessionId --
+    // was ever established) must not crash selection-building for the whole store, even
+    // when the request targets a different, healthy --session-key. Every accessor write
+    // path now refuses to persist an entry lacking a sessionId (hasValidSessionEntryIdentity)
+    // and always defaults one (createFallbackSessionEntry), so this inserts straight into
+    // session_nodes to reproduce the on-disk shape a pre-existing corrupted/legacy row would
+    // have. On current main the read path already excludes such rows before sessions-tail
+    // ever sees them (parseSqliteSessionEntryRecord requires a string sessionId), and
+    // buildTailSelection's own sessionId check is a second, independent guard -- this test
+    // pins that combined behavior rather than exercising a fix made on this branch.
+    const database = openOpenClawAgentDatabase({ agentId: "main", path: storePath });
+    database.db
+      .prepare(
+        "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at) VALUES (?, ?, ?, ?)",
+      )
+      .run(
+        "agent:main:cron:orphaned",
+        "orphaned-placeholder",
+        JSON.stringify({ updatedAt: 5, systemSent: true }),
+        5,
+      );
+
+    await expect(
+      sessionsTailCommand({ agent: "main", store: storePath, sessionKey }, runtime),
+    ).resolves.toBeUndefined();
+
+    const output = runtimeOutput(runtime);
+    expect(output).toContain("healthy ok");
+    expect(runtime.error).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/config/sessions/paths.test.ts
+++ b/src/config/sessions/paths.test.ts
@@ -7,6 +7,7 @@ import {
   resolveSessionFilePathCore,
   resolveSessionStorePathCore,
   SessionStoreAgentIdRequiredError,
+  validateSessionId,
 } from "./paths.js";
 
 const tempDirs: string[] = [];
@@ -51,6 +52,18 @@ describe("resolveSessionFilePath cross-root reroot", () => {
     );
 
     expect(resolved).toBe(foreign);
+  });
+});
+
+describe("validateSessionId", () => {
+  it("rejects a non-string session id with a diagnosable error instead of throwing on .trim()", () => {
+    // Legacy/corrupted store entries (e.g. a cron entry that never established
+    // a live session) can reach this function without a sessionId at runtime,
+    // even though the type declares it required. Regression coverage for
+    // https://github.com/openclaw/openclaw/issues/140261.
+    expect(() => validateSessionId(undefined as unknown as string)).toThrow(
+      "Invalid session ID: undefined",
+    );
   });
 });
 

--- a/src/config/sessions/paths.ts
+++ b/src/config/sessions/paths.ts
@@ -61,7 +61,7 @@ export function resolveSessionFilePathOptions(params: {
 const SAFE_SESSION_ID_RE = /^[\p{L}\p{N}][\p{L}\p{N}\p{M}._-]{0,127}$/u;
 
 export function validateSessionId(sessionId: string): string {
-  const trimmed = sessionId.trim();
+  const trimmed = typeof sessionId === "string" ? sessionId.trim() : "";
   if (
     trimmed !== trimmed.normalize("NFC") ||
     !SAFE_SESSION_ID_RE.test(trimmed) ||


### PR DESCRIPTION
Related: #140261

## What Problem This Solves

Resolves a problem where `validateSessionId` (`src/config/sessions/paths.ts`) crashes with an uncaught `TypeError: Cannot read properties of undefined (reading 'trim')` instead of its own diagnosable `Invalid session ID` error, whenever a caller passes a missing/non-string `sessionId` despite the `sessionId: string` type annotation.

That shape is still reachable today through the deprecated `resolveSessionFilePath()` bridge in `src/plugin-sdk/session-store-runtime.ts`, kept for beta.5-era plugins (its own doc comment names the Feishu doctor) until 2026-10-12: when an entry has no `sessionFile` and an undefined/non-string `sessionId`, `resolveSessionFilePathCore` falls through to `resolveSessionTranscriptPathInDir` → `validateSessionId`. Legacy/corrupted session records — e.g. a cron-created entry where only a system message was ever queued, so no live session (and thus no `sessionId`) was ever established — can carry exactly that shape.

**Scope note on #140261 itself:** the issue's headline symptom — `openclaw sessions tail` crashing for any agent with a `sessionId`-less store entry, poisoning unrelated `--session-key` requests — is already fixed on current `main`. That crash chain was closed months ago by #89122 ("route command session reads through seam"), confirmed against the canonical duplicate report #112355. On `main` today, `sessionsTailCommand` excludes a `sessionId`-less row before it can poison a tail selection, at two independent layers:
- the SQLite read layer (`parseSqliteSessionEntryRecord` / `hasValidSessionEntryIdentity`) requires a string `sessionId` and drops rows that fail that check before `sessions-tail.ts` ever sees them, and
- `buildTailSelection`'s own `entry.sessionId?.trim()` check.

I verified this by inserting a `sessionId`-less row directly into `session_nodes` (bypassing the accessor API, which now refuses to persist such a row) and confirming `sessionsTailCommand` renders the healthy, requested session and never touches the malformed one. `validateSessionId` is no longer even in that call path — `sessions-tail.ts` resolves trajectory rows straight from the SQLite trajectory store using a pre-validated `sessionId`, not from a resolved transcript file path.

So this PR narrows to the part of the original report that is still live: `validateSessionId` itself, reachable via the legacy plugin bridge above.

## Why This Change Was Made

Guard the same way the codebase already handles this exact shape of bug elsewhere: default to an empty string when the value isn't a string, so the existing `SAFE_SESSION_ID_RE` validation rejects it with a diagnosable `Invalid session ID: undefined` instead of throwing on `.trim()`. One-line change, no behavior change for any valid caller.

## User Impact

A legacy/beta.5 plugin (or any other caller) that reaches `resolveSessionFilePath`/`validateSessionId` with a missing session id now gets a clear `Invalid session ID: undefined` error instead of an opaque `TypeError`, which is directly diagnosable instead of requiring source-level tracing.

## Evidence

Added tests:
- `src/config/sessions/paths.test.ts`: direct regression test — `validateSessionId(undefined)` now throws `Invalid session ID: undefined` instead of a raw `TypeError`.
- `src/commands/sessions-tail.test.ts`: pinning regression test — a session store with a healthy entry plus a `sessionId`-less row (inserted directly into `session_nodes` to reproduce a legacy/corrupted row's on-disk shape) still renders the healthy `--session-key` request and never touches the malformed row. This documents the existing (already-shipped) protection described above; it is not exercising a fix made in this PR.

Test output:

```
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.runtime-config.config.ts src/config/sessions/paths.test.ts
✓ |runtime-config| src/config/sessions/paths.test.ts > validateSessionId > rejects a non-string session id with a diagnosable error instead of throwing on .trim()
 Test Files  1 passed (1)
      Tests  6 passed (6)

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/sessions-tail.test.ts
✓ |commands| src/commands/sessions-tail.test.ts > sessionsTailCommand > does not let a sessionId-less store row poison an unrelated --session-key request (#140261)
 Test Files  1 passed (1)
      Tests  38 passed (38)
```

Also ran the full `src/config/sessions/**` suite (`vitest.runtime-config.config.ts`, 304 files / 4456 tests): 4 pre-existing failures in `session-accessor.creation-snapshot.test.ts` and `session-sharing-store.test.ts`/`session-suggestion-store.test.ts`, confirmed unrelated and already failing at this branch's merge-base with `main` (reproduced identically with this PR's changes stashed out).

Typecheck: `pnpm tsgo:core` (production `src/**`) passes clean. Lint: scoped `oxlint` run against the changed files reports no issues.
