### PR TITLE
fix: show Code Mode execution budgets

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -391,6 +391,14 @@ Provider-owned tools such as remote Python sandboxes are separate tools. See
 | `searchDefaultLimit`  | `8`                            | clamped to `maxSearchLimit`                     |
 | `maxSearchLimit`      | `50`                           | `1`-`50`                                        |
 
+`timeoutMs` is a wall-clock budget per `exec` or `wait` call. Worker preparation, guest
+computation, and inline tool waits share that budget; approval waits pause it.
+The model-facing `exec` description includes the effective limit. Blocking guest
+computation that exhausts the budget fails with `timeout`. Unfinished tool calls
+can instead return `waiting`, so a later `wait` can resume them with a fresh call
+budget. When the shell `exec` tool is available, use it for heavier computation
+and keep guest JavaScript focused on coordinating tools and processing results.
+
 If code mode is enabled but QuickJS-WASI cannot load, OpenClaw fails closed
 for that run; it does not silently expose normal tools as a fallback. This
 holds for `true` and for `"auto"` runs where the model resolves as preferred:

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import * as codeModeExecution from "./code-mode-execution.js";
 import {
+  addClientToolsToCodeModeCatalog,
   applyCodeModeCatalog,
   CODE_MODE_EXEC_TOOL_NAME,
   CODE_MODE_WAIT_TOOL_NAME,
@@ -106,6 +107,36 @@ describe("Code Mode catalog and model-visible surface", () => {
       CODE_MODE_WAIT_TOOL_NAME,
     ]);
     expect(compacted.catalogToolCount).toBe(2);
+    expect(compacted.tools[0]?.description).toContain(
+      "Use the shell tool `exec` for heavier computation",
+    );
+  });
+
+  it("removes shell-computation guidance when a client shadows the shell tool", () => {
+    const { ctx, tools } = createCodeModeHarness();
+    const compacted = applyCodeModeCatalog({
+      ...ctx,
+      tools: [...tools, fakeTool("exec", "Run shell command")],
+    });
+    const execTool = expectDefined(compacted.tools[0], "exec tool test invariant");
+    expect(execTool.description).toContain("Use the shell tool `exec` for heavier computation");
+
+    addClientToolsToCodeModeCatalog({
+      ...ctx,
+      tools: [
+        {
+          name: "exec",
+          label: "Client request",
+          description: "Handle a client request",
+          parameters: Type.Object({ request: Type.String() }),
+          execute: async () => jsonResult({ accepted: true }),
+        },
+      ],
+    });
+
+    expect(execTool.description).toContain("- exec unknown -> ?");
+    expect(execTool.description).not.toContain("heavier computation");
+    expect(execTool.description).toContain("10000 ms wall-clock budget");
   });
 
   it("keeps direct-only tools model-visible and out of the guest catalog", () => {
@@ -350,33 +381,80 @@ describe("Code Mode catalog and model-visible surface", () => {
     expect(execTool.description).not.toContain("paired Gateway nodes");
   });
 
-  it("keeps code-mode exec guidance compact without advertising unavailable namespaces", () => {
-    const { config, catalogRef, tools } = createCodeModeHarness();
-    const compacted = applyCodeModeCatalog({
-      tools: [...tools, pluginTool("fake_noop", "Noop")],
-      config,
-      sessionId: "session-code-mode",
-      sessionKey: "agent:main:main",
-      runId: "run-code-mode",
-      catalogRef,
-    });
+  it.each([
+    {
+      name: "default budget",
+      config: { tools: { codeMode: true } },
+      expectedBudgetMs: 10_000,
+      pluginName: "fake_noop",
+    },
+    {
+      name: "configured budget with a plugin named exec",
+      config: { tools: { codeMode: { enabled: true, timeoutMs: 2_750 } } },
+      expectedBudgetMs: 2_750,
+      pluginName: "exec",
+    },
+    {
+      name: "agent budget override",
+      config: {
+        tools: { codeMode: { enabled: true, timeoutMs: 2_750 } },
+        agents: { entries: { ops: { tools: { codeMode: { timeoutMs: 4_250 } } } } },
+      },
+      expectedBudgetMs: 4_250,
+      pluginName: "fake_noop",
+    },
+    {
+      name: "clamped effective budget",
+      config: { tools: { codeMode: { enabled: true, timeoutMs: 90_000 } } },
+      expectedBudgetMs: 60_000,
+      pluginName: "fake_noop",
+    },
+  ] satisfies {
+    name: string;
+    config: OpenClawConfig;
+    expectedBudgetMs: number;
+    pluginName: string;
+  }[])(
+    "keeps exec guidance compact and scoped to $name",
+    ({ config, expectedBudgetMs, pluginName }) => {
+      const catalogRef = createToolSearchCatalogRef();
+      const ctx = {
+        config,
+        agentId: "ops",
+        sessionId: "session-code-mode",
+        sessionKey: "agent:ops:main",
+        runId: "run-code-mode",
+        catalogRef,
+      };
+      const tools = createCodeModeTools({ ...ctx, runtimeConfig: config });
+      const compacted = applyCodeModeCatalog({
+        ...ctx,
+        tools: [...tools, pluginTool(pluginName, "Noop")],
+      });
 
-    const execTool = expectDefined(compacted.tools[0], "exec tool test invariant");
-    const parameters = execTool.parameters as {
-      properties?: Record<string, Record<string, unknown>>;
-    };
-    const codeDescription = parameters.properties?.code?.description;
+      const execTool = expectDefined(compacted.tools[0], "exec tool test invariant");
+      const parameters = execTool.parameters as {
+        properties?: Record<string, Record<string, unknown>>;
+      };
+      const codeDescription = parameters.properties?.code?.description;
 
-    expect(execTool.description.length).toBeLessThan(2_400);
-    expect(execTool.description).toContain("independent calls may run with Promise.all");
-    expect(execTool.description).toContain("`setTimeout` and `clearTimeout`");
-    expect(execTool.description).toContain("65536 bytes");
-    expect(execTool.description).toContain("rerun with narrower args");
-    expect(codeDescription).toEqual(expect.any(String));
-    expect(String(codeDescription).length).toBeLessThan(620);
-    expect(codeDescription).not.toContain("MCP namespace globals");
-    expect(codeDescription).not.toContain("`API` virtual declaration files");
-  });
+      expect(execTool.description.length).toBeLessThan(2_400);
+      expect(execTool.description).toContain("independent calls may run with Promise.all");
+      expect(execTool.description).toContain("`setTimeout` and `clearTimeout`");
+      expect(execTool.description).toContain("65536 bytes");
+      expect(execTool.description).toContain("rerun with narrower args");
+      expect(execTool.description).toContain(`${expectedBudgetMs} ms wall-clock budget`);
+      expect(execTool.description).toContain("per `exec`/`wait`");
+      expect(execTool.description).toContain("approvals pause");
+      expect(execTool.description).toContain("Guest computation over this budget times out");
+      expect(execTool.description).toContain("`waiting` for `wait`");
+      expect(execTool.description).not.toContain("heavier computation");
+      expect(codeDescription).toEqual(expect.any(String));
+      expect(String(codeDescription).length).toBeLessThan(620);
+      expect(codeDescription).not.toContain("MCP namespace globals");
+      expect(codeDescription).not.toContain("`API` virtual declaration files");
+    },
+  );
 
   it("primes the exec schema with callable names and compact contracts", () => {
     const { config, catalogRef, tools } = createCodeModeHarness();

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -161,22 +161,27 @@ function createCodeModeExecDescription(
   const skillsGuidance = ctx.codeModeSkills?.length
     ? " Skills are available through the async `skills` global: use `await skills.list()` and `await skills.read(name)`."
     : "";
-  const { maxOutputBytes } = config;
+  const { maxOutputBytes, timeoutMs } = config;
   // The catalog already reserves built-in namespace globals without constructing their runtimes.
   const bindings = catalog
     ? createCodeModeCatalogBindings(catalog.map((entry) => compactToolSearchCatalogEntry(entry)))
     : undefined;
   const catalogIndex = bindings ? formatCodeModeCatalogIndex(bindings) : "";
+  // Only the effective core binding proves shell capability after client overrides.
+  const shellTool = bindings?.find((entry) => entry.id === "openclaw:core:exec");
+  const shellGuidance = shellTool
+    ? ` Use the shell tool \`${shellTool.callableName}\` for heavier computation.`
+    : "";
   return (
-    `Run JavaScript or TypeScript in OpenClaw code mode. Enabled tools are async global functions listed in the quick index. Await dependent calls in order; independent calls may run with Promise.all. Declared output fields may feed later calls in the same program; do not spend another \`exec\` merely inspecting them. Emit output with \`text(value)\` or \`json(value)\`. Return the final value; otherwise the result is \`null\`. \`-> ?\` means unknown output: do not feed it into guessed field-dependent logic in the same program. Return the raw value first, observe it, then use a later \`exec\` for dependent composition. If a tool is omitted from the bounded index, use \`catalog.search(query)\`; results are callable: \`const [tool] = await catalog.search("..."); return await tool({...});\`. Handles expose \`describe()\` when a schema is needed. \`setTimeout\` and \`clearTimeout\` work. Nested calls enforce normal tool policy and approvals. Tool failures are catchable JavaScript errors; otherwise, use the failed result to correct your code or choose another tool. If an action may have started, inspect its outcome without repeating mutations. Never replay actions that already ran. Each nested result is bounded separately to ${maxOutputBytes} bytes. Cumulative output and the final value or error share ${maxOutputBytes} bytes across waits. Model-facing results may use a smaller allowance to preserve complete status and continuation within model context limits. Output/value truncation reports a prefix and omitted bytes of the original normalized JSON; rerun with narrower args. Ordinary output is incremental; unchanged summaries are suppressed, changed cumulative summaries replace earlier ones. Node.js modules and \`require\`/\`import\` are NOT available; use enabled globals for shell, file, network, or external actions.` +
+    `Run JavaScript or TypeScript in OpenClaw code mode. Guest work and inline tool waits share a ${timeoutMs} ms wall-clock budget per \`exec\`/\`wait\`; approvals pause it. Guest computation over this budget times out; pending tools may return \`waiting\` for \`wait\`.` +
+    shellGuidance +
+    ` Enabled tools are async global functions listed in the quick index. Await dependent calls in order; independent calls may run with Promise.all. Declared output fields may feed later calls in the same program; do not spend another \`exec\` merely inspecting them. Emit output with \`text(value)\` or \`json(value)\`. Return the final value; otherwise the result is \`null\`. \`-> ?\` means unknown output: do not feed it into guessed field-dependent logic in the same program. Return the raw value first, observe it, then use a later \`exec\` for dependent composition. If a tool is omitted from the bounded index, use \`catalog.search(query)\`; results are callable: \`const [tool] = await catalog.search("..."); return await tool({...});\`. Handles expose \`describe()\` when a schema is needed. \`setTimeout\` and \`clearTimeout\` work. Nested calls enforce normal tool policy and approvals. Tool failures are catchable JavaScript errors; correct your code or choose another tool. If an action may have started, inspect its outcome without replaying it. Each nested result is bounded separately to ${maxOutputBytes} bytes. Cumulative output and the final value or error share ${maxOutputBytes} bytes across waits. Model context may further limit results while preserving complete status and continuation. Output/value truncation reports a prefix and omitted bytes of the original normalized JSON; rerun with narrower args. Ordinary output is incremental; unchanged summaries are suppressed, changed cumulative summaries replace earlier ones. Node.js modules and \`require\`/\`import\` are NOT available; use enabled globals for shell, file, network, or external actions.` +
     apiGuidance +
     mcpGuidance +
     swarmGuidance +
     nodesGuidance +
     skillsGuidance +
-    ' The `language` field accepts only "javascript" or "typescript"; do not pass "bash", "shell", or other values.' +
-    " The `code` field contains JavaScript or TypeScript, never a shell command. " +
-    "For shell or file operations, call an enabled global from guest JavaScript; do not retry failed shell source." +
+    ' `language` must be "javascript" or "typescript"; `code` is JS/TS, never a shell command; do not retry failed shell source.' +
     (namespacePrompt ? `\n\n${namespacePrompt}` : "") +
     (catalogIndex ? `\n\n${catalogIndex}` : "")
   );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents running long calculations inside Code Mode could hit an execution timeout without being told the configured limit or directed to an available shell tool.

## Why This Change Was Made

The tool description now states the resolved wall-clock budget shared by each exec/wait call, explains timeout versus waiting behavior, and names the effective core shell callable for heavier computation. Shell advice disappears when a client shadows that capability. Runtime limits, execution semantics, configuration, and dependencies are unchanged.

## User Impact

Agents can keep guest code focused on short orchestration and choose the existing shell tool for heavier work. Concise wording preserves the existing description limits and output guidance.

## Evidence

Six new or extended surface cases failed against the original descriptions. All 42 focused surface and catalog-lifetime tests pass, including configured/agent/clamped budgets and absent, plugin-named, or client-shadowed shell tools. Final rendered descriptions remain within the unchanged caps. Changed-file checks, final type-aware lint, and fresh independent review passed. The canonical build passed.
