### PR TITLE
refactor(plugins): share uninstall mutation ownership

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2329,7 +2329,6 @@ src/cli/plugin-install-plan.ts	1
 src/cli/plugins-authoring-command.ts	8
 src/cli/plugins-command-helpers.ts	1
 src/cli/plugins-install-config.ts	2
-src/cli/plugins-uninstall-command.ts	4
 src/cli/plugins-update-command.ts	5
 src/cli/ports.ts	9
 src/cli/precomputed-help.ts	1

--- a/src/cli/plugins-cli.uninstall.test.ts
+++ b/src/cli/plugins-cli.uninstall.test.ts
@@ -33,34 +33,10 @@ import {
 } from "./plugins-cli-test-helpers.js";
 
 const CLI_STATE_ROOT = "/tmp/openclaw-state";
-const ALPHA_INSTALL_PATH = installedPluginRoot(CLI_STATE_ROOT, "alpha");
+let alphaInstallPath: string;
+let readInstallRecords: (typeof import("../plugins/installed-plugin-index-record-reader.js"))["loadInstalledPluginIndexInstallRecordsSync"];
 const ORIGINAL_OPENCLAW_NIX_MODE = process.env.OPENCLAW_NIX_MODE;
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-
-function primeUninstallPlan(
-  config: OpenClawConfig,
-  overrides: {
-    actions?: Record<string, boolean>;
-    directoryRemoval?: { target: string } | null;
-  } = {},
-): void {
-  planPluginUninstallMock.mockReturnValue({
-    ok: true,
-    config,
-    actions: {
-      entry: true,
-      install: true,
-      allowlist: false,
-      denylist: false,
-      loadPath: false,
-      memorySlot: false,
-      contextEngineSlot: false,
-      ...overrides.actions,
-      directory: overrides.actions?.directory ?? false,
-    },
-    directoryRemoval: overrides.directoryRemoval ?? null,
-  });
-}
 
 function expectRuntimeLogIncludes(fragment: string) {
   expect(pluginsCliRuntimeLogs.join("\n")).toContain(fragment);
@@ -77,27 +53,34 @@ function expectInstallRecordsWrittenWithLease(records: unknown, config: unknown)
   );
 }
 
-function expectLatestUninstallPlanParams(expected: {
-  pluginId: string;
-  deleteFiles: boolean;
-  channelIds?: unknown;
-}) {
-  const params = planPluginUninstallMock.mock.calls[
-    planPluginUninstallMock.mock.calls.length - 1
-  ]?.[0] as { pluginId?: string; deleteFiles?: boolean; channelIds?: unknown } | undefined;
-  if (params === undefined) {
-    throw new Error("expected latest plugin uninstall plan params");
-  }
-  expect(params.pluginId).toBe(expected.pluginId);
-  expect(params.deleteFiles).toBe(expected.deleteFiles);
-  if ("channelIds" in expected) {
-    expect(params.channelIds).toEqual(expected.channelIds);
-  }
-}
-
 describe("plugins cli uninstall", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     resetPluginsCliTestState();
+    ({ loadInstalledPluginIndexInstallRecordsSync: readInstallRecords } =
+      await import("../plugins/installed-plugin-index-record-reader.js"));
+    alphaInstallPath = installedPluginRoot(tempDirs.make("openclaw-cli-uninstall-owned-"), "alpha");
+    await fs.mkdir(alphaInstallPath, { recursive: true });
+    await fs.writeFile(path.join(alphaInstallPath, "keep.txt"), "owned plugin files");
+    const actual =
+      await vi.importActual<typeof import("../plugins/uninstall.js")>("../plugins/uninstall.js");
+    planPluginUninstallMock.mockImplementation((params) =>
+      actual.planPluginUninstall(params as Parameters<typeof actual.planPluginUninstall>[0]),
+    );
+    applyPluginUninstallDirectoryRemovalMock.mockImplementation((removal) =>
+      actual.applyPluginUninstallDirectoryRemoval(
+        removal as Parameters<typeof actual.applyPluginUninstallDirectoryRemoval>[0],
+      ),
+    );
+    configWriteMock.mockImplementation(async (config) => {
+      pluginCliConfigMock.mockReturnValue(config as OpenClawConfig);
+    });
+    replaceConfigFileMock.mockImplementation(async (input) => {
+      const params = input as Parameters<
+        (typeof import("../config/config.js"))["replaceConfigFile"]
+      >[0];
+      params.writeOptions?.assertConfigPathForWrite?.();
+      await configWriteMock(params.nextConfig);
+    });
   });
 
   afterEach(() => {
@@ -124,7 +107,6 @@ describe("plugins cli uninstall", () => {
       }
     }
 
-    expect(planPluginUninstallMock).not.toHaveBeenCalled();
     expect(applyPluginUninstallDirectoryRemovalMock).not.toHaveBeenCalled();
     expect(configWriteMock).not.toHaveBeenCalled();
   });
@@ -141,8 +123,8 @@ describe("plugins cli uninstall", () => {
         installs: {
           alpha: {
             source: "path",
-            sourcePath: ALPHA_INSTALL_PATH,
-            installPath: ALPHA_INSTALL_PATH,
+            sourcePath: alphaInstallPath,
+            installPath: alphaInstallPath,
           },
         },
         slots: {
@@ -155,90 +137,117 @@ describe("plugins cli uninstall", () => {
       diagnostics: [],
     });
     setInstalledPluginIndexInstallRecords({
-      alpha: { source: "path", sourcePath: ALPHA_INSTALL_PATH, installPath: ALPHA_INSTALL_PATH },
+      alpha: { source: "path", sourcePath: alphaInstallPath, installPath: alphaInstallPath },
     });
-    primeUninstallPlan({} as OpenClawConfig, { actions: { contextEngineSlot: true } });
 
     await runPluginsCommand(["plugins", "uninstall", "alpha", "--dry-run"]);
 
     expect(buildPluginSnapshotReportMock).toHaveBeenCalledTimes(1);
     expect(buildPluginDiagnosticsReportMock).not.toHaveBeenCalled();
-    expect(planPluginUninstallMock).toHaveBeenCalledTimes(1);
+
     expect(configWriteMock).not.toHaveBeenCalled();
     expect(refreshPluginRegistryMock).not.toHaveBeenCalled();
     expectRuntimeLogIncludes("Dry run, no changes made.");
     expectRuntimeLogIncludes("context engine slot");
   });
 
-  it("uninstalls with --force and --keep-files without prompting", async () => {
-    const baseConfig = {
-      plugins: {
-        entries: {
-          alpha: { enabled: true },
-        },
-        installs: {
-          alpha: {
-            source: "path",
-            sourcePath: ALPHA_INSTALL_PATH,
-            installPath: ALPHA_INSTALL_PATH,
+  it.each([
+    { keepFilesFlag: "--keep-files", inheritedLease: false },
+    { keepFilesFlag: "--keep-config", inheritedLease: false },
+    { keepFilesFlag: "--keep-files", inheritedLease: true },
+  ])(
+    "uninstalls with --force and $keepFilesFlag without prompting (inherited lease=$inheritedLease)",
+    async ({ keepFilesFlag, inheritedLease }) => {
+      const baseConfig = {
+        plugins: {
+          entries: {
+            alpha: { enabled: true },
+          },
+          installs: {
+            alpha: {
+              source: "path",
+              sourcePath: alphaInstallPath,
+              installPath: alphaInstallPath,
+            },
           },
         },
-      },
-    } as OpenClawConfig;
-    const nextConfig = {
-      plugins: {
-        entries: { alpha: { enabled: false } },
-        installs: {},
-      },
-    } as OpenClawConfig;
+      } as OpenClawConfig;
 
-    pluginCliConfigMock.mockReturnValue(baseConfig);
-    setInstalledPluginIndexInstallRecords(baseConfig.plugins?.installs ?? {});
-    buildPluginSnapshotReportMock.mockReturnValue({
-      plugins: [{ id: "alpha", name: "alpha" }],
-      diagnostics: [],
-    });
-    primeUninstallPlan(nextConfig);
+      pluginCliConfigMock.mockReturnValue(baseConfig);
+      setInstalledPluginIndexInstallRecords(baseConfig.plugins?.installs ?? {});
+      buildPluginSnapshotReportMock.mockReturnValue({
+        plugins: [{ id: "alpha", name: "alpha" }],
+        diagnostics: [],
+      });
 
-    await runPluginsCommand(["plugins", "uninstall", "alpha", "--force", "--keep-files"]);
+      const uninstall = () =>
+        runPluginsCommand(["plugins", "uninstall", "alpha", "--force", keepFilesFlag]);
+      if (inheritedLease) {
+        const { withPluginLifecycleLease } = await import("../plugins/plugin-lifecycle-lease.js");
+        const databasePath = path.join(
+          tempDirs.make("openclaw-cli-uninstall-parent-lease-"),
+          "state.sqlite",
+        );
+        await withPluginLifecycleLease({ path: databasePath }, async (lease) => {
+          await uninstall();
+          lease.assertOwned();
+          expect(readInstallRecords()).toEqual({});
+          expect(pluginCliConfigMock().plugins?.entries?.alpha).toEqual({ enabled: false });
+          expect(
+            writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock,
+          ).toHaveBeenCalledWith({}, expect.objectContaining({ lease }));
+        });
+      } else {
+        await uninstall();
+      }
 
-    expect(promptYesNoMock).not.toHaveBeenCalled();
-    expectLatestUninstallPlanParams({ pluginId: "alpha", deleteFiles: false });
-    expectInstallRecordsWrittenWithLease(
-      {},
-      {
-        plugins: { entries: { alpha: { enabled: false } } },
-      },
-    );
-    expect(configWriteMock).toHaveBeenCalledWith({
-      plugins: {
-        entries: { alpha: { enabled: false } },
-      },
-    });
-    expect(replaceConfigFileMock).toHaveBeenCalledWith({
-      baseHash: "mock",
-      nextConfig: {
+      expect(promptYesNoMock).not.toHaveBeenCalled();
+      expect(await fs.readFile(path.join(alphaInstallPath, "keep.txt"), "utf8")).toBe(
+        "owned plugin files",
+      );
+      if (keepFilesFlag === "--keep-config") {
+        expectRuntimeLogIncludes("--keep-config");
+        expectRuntimeLogIncludes("deprecated");
+      }
+
+      expectInstallRecordsWrittenWithLease(
+        {},
+        {
+          plugins: { entries: { alpha: { enabled: false } } },
+        },
+      );
+      expect(configWriteMock).toHaveBeenCalledWith({
         plugins: {
           entries: { alpha: { enabled: false } },
         },
-      },
-      writeOptions: expect.objectContaining({
-        allowConfigSizeDrop: true,
-        auditOrigin: "plugin-install",
-        afterWrite: { mode: "restart", reason: "plugin source changed" },
-        unsetPaths: [["plugins", "installs"]],
-      }),
-    });
-    expect(refreshPluginRegistryMock).toHaveBeenCalledWith({
-      config: {
-        plugins: {
-          entries: { alpha: { enabled: false } },
+      });
+      expect(replaceConfigFileMock).toHaveBeenCalledWith({
+        baseHash: "mock",
+        nextConfig: {
+          plugins: {
+            entries: { alpha: { enabled: false } },
+          },
         },
-      },
-      installRecords: {},
-      reason: "source-changed",
-    });
-  });
+        writeOptions: expect.objectContaining({
+          allowConfigSizeDrop: true,
+          auditOrigin: "plugin-install",
+          afterWrite: { mode: "restart", reason: "plugin source changed" },
+          unsetPaths: [["plugins", "installs"]],
+        }),
+      });
+      expect(refreshPluginRegistryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: {
+            plugins: {
+              entries: { alpha: { enabled: false } },
+            },
+          },
+          installRecords: {},
+          reason: "source-changed",
+        }),
+      );
+    },
+  );
 
   it("uninstalls the exact plugin id when an earlier plugin uses it as a display name", async () => {
     const baseConfig = {
@@ -253,14 +262,6 @@ describe("plugins cli uninstall", () => {
         },
       },
     } as OpenClawConfig;
-    const nextConfig = {
-      plugins: {
-        entries: { "unrelated-plugin": { enabled: true } },
-        installs: {
-          "unrelated-plugin": { source: "npm", spec: "unrelated-plugin@1.0.0" },
-        },
-      },
-    } as OpenClawConfig;
 
     pluginCliConfigMock.mockReturnValue(baseConfig);
     setInstalledPluginIndexInstallRecords(baseConfig.plugins?.installs ?? {});
@@ -271,18 +272,16 @@ describe("plugins cli uninstall", () => {
       ],
       diagnostics: [],
     });
-    primeUninstallPlan(nextConfig);
 
     await runPluginsCommand(["plugins", "uninstall", "calendar", "--force", "--keep-files"]);
 
-    expectLatestUninstallPlanParams({ pluginId: "calendar", deleteFiles: false });
     expectInstallRecordsWrittenWithLease(
       {
         "unrelated-plugin": { source: "npm", spec: "unrelated-plugin@1.0.0" },
       },
       {
         plugins: {
-          entries: { "unrelated-plugin": { enabled: true } },
+          entries: { "unrelated-plugin": { enabled: true }, calendar: { enabled: false } },
         },
       },
     );
@@ -317,7 +316,7 @@ describe("plugins cli uninstall", () => {
     ).rejects.toThrow("__exit__:1");
 
     expect(runtimeErrors.at(-1)).toContain('Plugin uninstall target "calendar" is ambiguous');
-    expect(planPluginUninstallMock).not.toHaveBeenCalled();
+
     expect(promptYesNoMock).not.toHaveBeenCalled();
     expect(applyPluginUninstallDirectoryRemovalMock).not.toHaveBeenCalled();
     expect(writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock).not.toHaveBeenCalled();
@@ -338,7 +337,7 @@ describe("plugins cli uninstall", () => {
         source: "clawhub" as const,
         spec: "clawhub:@owner/audit",
         version: "2.0.1",
-        installPath: ALPHA_INSTALL_PATH,
+        installPath: alphaInstallPath,
       };
       const baseConfig = {
         plugins: {
@@ -352,9 +351,7 @@ describe("plugins cli uninstall", () => {
         plugins: [{ id: "alpha", name: "alpha" }],
         diagnostics: [],
       });
-      primeUninstallPlan({ plugins: { entries: {}, installs: {} } } as OpenClawConfig, {
-        actions: { channelConfig: false },
-      });
+
       persistClawPackageRef(
         {
           agent: { finalId: "audit-agent" },
@@ -374,7 +371,10 @@ describe("plugins cli uninstall", () => {
 
       expectRuntimeLogIncludes('Warning: plugin "alpha" is referenced by Claw: @owner/audit-claw.');
       expectRuntimeLogIncludes("Uninstalling it may break those Claws");
-      expectInstallRecordsWrittenWithLease({}, { plugins: { entries: {} } });
+      expectInstallRecordsWrittenWithLease(
+        {},
+        { plugins: { entries: { alpha: { enabled: false } } } },
+      );
     } finally {
       if (previousStateDir === undefined) {
         delete process.env.OPENCLAW_STATE_DIR;
@@ -385,49 +385,72 @@ describe("plugins cli uninstall", () => {
     }
   });
 
-  it("exits cleanly when confirmation input closes before an answer", async () => {
-    const baseConfig = {
-      plugins: {
-        entries: {
-          alpha: { enabled: true },
-        },
-        installs: {
-          alpha: {
-            source: "path",
-            sourcePath: ALPHA_INSTALL_PATH,
-            installPath: ALPHA_INSTALL_PATH,
+  it.each(["closed", "declined", "accepted after config edit"])(
+    "handles confirmation that is %s without stale mutations",
+    async (confirmation) => {
+      const baseConfig = {
+        plugins: {
+          entries: {
+            alpha: { enabled: true },
+          },
+          installs: {
+            alpha: {
+              source: "path",
+              sourcePath: alphaInstallPath,
+              installPath: alphaInstallPath,
+            },
           },
         },
-      },
-    } as OpenClawConfig;
-    pluginCliConfigMock.mockReturnValue(baseConfig);
-    setInstalledPluginIndexInstallRecords(baseConfig.plugins?.installs ?? {});
-    buildPluginSnapshotReportMock.mockReturnValue({
-      plugins: [{ id: "alpha", name: "alpha" }],
-      diagnostics: [],
-    });
-    primeUninstallPlan({ plugins: { entries: {}, installs: {} } } as OpenClawConfig);
-    promptYesNoMock.mockRejectedValueOnce(new PromptInputClosedError());
+      } as OpenClawConfig;
+      pluginCliConfigMock.mockReturnValue(baseConfig);
+      setInstalledPluginIndexInstallRecords(baseConfig.plugins?.installs ?? {});
+      buildPluginSnapshotReportMock.mockReturnValue({
+        plugins: [{ id: "alpha", name: "alpha" }],
+        diagnostics: [],
+      });
 
-    await expect(runPluginsCommand(["plugins", "uninstall", "alpha"])).rejects.toThrow(
-      "__exit__:1",
-    );
-
-    expect(runtimeErrors).toContain(
-      "Error: plugins uninstall requires confirmation input. Re-run in an interactive TTY or pass --force.",
-    );
-    expect(writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock).not.toHaveBeenCalled();
-    expect(configWriteMock).not.toHaveBeenCalled();
-    expect(refreshPluginRegistryMock).not.toHaveBeenCalled();
-    expect(applyPluginUninstallDirectoryRemovalMock).not.toHaveBeenCalled();
-  });
+      if (confirmation === "closed") {
+        promptYesNoMock.mockRejectedValueOnce(new PromptInputClosedError());
+        await expect(runPluginsCommand(["plugins", "uninstall", "alpha"])).rejects.toThrow(
+          "__exit__:1",
+        );
+        expect(runtimeErrors).toContain(
+          "Error: plugins uninstall requires confirmation input. Re-run in an interactive TTY or pass --force.",
+        );
+      } else if (confirmation === "declined") {
+        promptYesNoMock.mockResolvedValueOnce(false);
+        await runPluginsCommand(["plugins", "uninstall", "alpha"]);
+        expectRuntimeLogIncludes("Cancelled.");
+      } else {
+        promptYesNoMock.mockImplementationOnce(async () => {
+          expect(configWriteMock).not.toHaveBeenCalled();
+          expect(applyPluginUninstallDirectoryRemovalMock).not.toHaveBeenCalled();
+          pluginCliConfigMock.mockReturnValue({ ...baseConfig, logging: { level: "debug" } });
+          return true;
+        });
+        await runPluginsCommand(["plugins", "uninstall", "alpha"]);
+        expect(pluginCliConfigMock().logging).toEqual({ level: "debug" });
+        expect(readInstallRecords()).toEqual({});
+        expect(promptYesNoMock).toHaveBeenCalledOnce();
+        return;
+      }
+      expect(readInstallRecords()).toEqual(baseConfig.plugins?.installs);
+      expect(await fs.readFile(path.join(alphaInstallPath, "keep.txt"), "utf8")).toBe(
+        "owned plugin files",
+      );
+      expect(writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock).not.toHaveBeenCalled();
+      expect(configWriteMock).not.toHaveBeenCalled();
+      expect(refreshPluginRegistryMock).not.toHaveBeenCalled();
+      expect(applyPluginUninstallDirectoryRemovalMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("restores install records when the config write rejects during uninstall", async () => {
     const installRecords = {
       alpha: {
         source: "path",
-        sourcePath: ALPHA_INSTALL_PATH,
-        installPath: ALPHA_INSTALL_PATH,
+        sourcePath: alphaInstallPath,
+        installPath: alphaInstallPath,
       },
     } as const;
     const baseConfig = {
@@ -436,12 +459,6 @@ describe("plugins cli uninstall", () => {
           alpha: { enabled: true },
         },
         installs: installRecords,
-      },
-    } as OpenClawConfig;
-    const nextConfig = {
-      plugins: {
-        entries: {},
-        installs: {},
       },
     } as OpenClawConfig;
     const previousPersistedIndex = createTestInstalledPluginIndex({
@@ -456,14 +473,17 @@ describe("plugins cli uninstall", () => {
       plugins: [{ id: "alpha", name: "alpha" }],
       diagnostics: [],
     });
-    primeUninstallPlan(nextConfig);
+
     replaceConfigFileMock.mockRejectedValueOnce(new Error("config changed"));
 
     await expect(
       runPluginsCommand(["plugins", "uninstall", "alpha", "--force", "--keep-files"]),
     ).rejects.toThrow("config changed");
 
-    expectInstallRecordsWrittenWithLease({}, { plugins: { entries: {} } });
+    expectInstallRecordsWrittenWithLease(
+      {},
+      { plugins: { entries: { alpha: { enabled: false } } } },
+    );
     expect(restorePersistedInstalledPluginIndexIfCurrentMock).toHaveBeenCalledWith(
       previousPersistedIndex,
       expect.any(Number),
@@ -476,12 +496,12 @@ describe("plugins cli uninstall", () => {
     expect(applyPluginUninstallDirectoryRemovalMock).not.toHaveBeenCalled();
   });
 
-  it("removes plugin files only after config and index commit succeeds", async () => {
+  it("disables and retains tracking before file removal, then commits and refreshes", async () => {
     const installRecords = {
       alpha: {
         source: "npm",
         spec: "alpha@1.0.0",
-        installPath: ALPHA_INSTALL_PATH,
+        installPath: alphaInstallPath,
       },
     } as const;
     const baseConfig = {
@@ -492,12 +512,6 @@ describe("plugins cli uninstall", () => {
         installs: installRecords,
       },
     } as OpenClawConfig;
-    const nextConfig = {
-      plugins: {
-        entries: {},
-        installs: {},
-      },
-    } as OpenClawConfig;
 
     pluginCliConfigMock.mockReturnValue(baseConfig);
     setInstalledPluginIndexInstallRecords(installRecords);
@@ -505,35 +519,38 @@ describe("plugins cli uninstall", () => {
       plugins: [{ id: "alpha", name: "alpha" }],
       diagnostics: [],
     });
-    primeUninstallPlan(nextConfig, { directoryRemoval: { target: ALPHA_INSTALL_PATH } });
-    applyPluginUninstallDirectoryRemovalMock.mockResolvedValue({
-      directoryRemoved: true,
-      warnings: [],
+
+    const actual =
+      await vi.importActual<typeof import("../plugins/uninstall.js")>("../plugins/uninstall.js");
+    let observedRemoval = false;
+    applyPluginUninstallDirectoryRemovalMock.mockImplementation(async (removal) => {
+      expect(pluginCliConfigMock().plugins?.entries?.alpha).toEqual({ enabled: false });
+      expect(readInstallRecords()).toEqual(installRecords);
+      expect(writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock).not.toHaveBeenCalled();
+      expect(await fs.readFile(path.join(alphaInstallPath, "keep.txt"), "utf8")).toBe(
+        "owned plugin files",
+      );
+      observedRemoval = true;
+      return actual.applyPluginUninstallDirectoryRemoval(
+        removal as Parameters<typeof actual.applyPluginUninstallDirectoryRemoval>[0],
+      );
+    });
+    refreshPluginRegistryMock.mockImplementation(async () => {
+      expect(readInstallRecords()).toEqual({});
+      expect(pluginCliConfigMock().plugins?.entries?.alpha).toEqual({ enabled: false });
+      await expect(fs.stat(alphaInstallPath)).rejects.toMatchObject({ code: "ENOENT" });
     });
 
     await runPluginsCommand(["plugins", "uninstall", "alpha", "--force"]);
 
-    const configWriteOrder = configWriteMock.mock.invocationCallOrder[0] ?? 0;
-    const deleteOrder =
-      applyPluginUninstallDirectoryRemovalMock.mock.invocationCallOrder[0] ??
-      Number.MAX_SAFE_INTEGER;
-    const finalConfigWriteOrder =
-      configWriteMock.mock.invocationCallOrder[1] ?? Number.MAX_SAFE_INTEGER;
-    const refreshOrder =
-      refreshPluginRegistryMock.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER;
-    expect(configWriteMock).toHaveBeenCalledTimes(2);
-    expect(applyPluginUninstallDirectoryRemovalMock).toHaveBeenCalledTimes(1);
-    expect(refreshPluginRegistryMock).toHaveBeenCalledTimes(1);
-    expect(deleteOrder).toBeGreaterThan(configWriteOrder);
-    expect(finalConfigWriteOrder).toBeGreaterThan(deleteOrder);
-    expect(refreshOrder).toBeGreaterThan(finalConfigWriteOrder);
-    expect(applyPluginUninstallDirectoryRemovalMock).toHaveBeenCalledWith({
-      target: ALPHA_INSTALL_PATH,
-    });
+    expect(observedRemoval).toBe(true);
+    expect(readInstallRecords()).toEqual({});
+    expect(refreshPluginRegistryMock).toHaveBeenCalledOnce();
+    await expect(fs.stat(alphaInstallPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("keeps the install tracked and disabled when directory removal fails", async () => {
-    const installPath = tempDirs.make("openclaw-plugin-uninstall-failure-");
+    const installPath = alphaInstallPath;
     const installRecords = {
       alpha: {
         source: "npm",
@@ -555,9 +572,7 @@ describe("plugins cli uninstall", () => {
       plugins: [{ id: "alpha", name: "alpha" }],
       diagnostics: [],
     });
-    primeUninstallPlan({ plugins: { entries: {}, installs: {} } } as OpenClawConfig, {
-      directoryRemoval: { target: installPath },
-    });
+
     applyPluginUninstallDirectoryRemovalMock.mockResolvedValue({
       directoryRemoved: false,
       warnings: ["simulated removal failure"],
@@ -578,6 +593,70 @@ describe("plugins cli uninstall", () => {
     expect(writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock).not.toHaveBeenCalled();
     expect(refreshPluginRegistryMock).not.toHaveBeenCalled();
   });
+
+  it.each(["disable", "delete", "final commit"])(
+    "rechecks persistent authority before %s",
+    async (stopAt) => {
+      const records = {
+        alpha: { source: "npm" as const, spec: "alpha@1.0.0", installPath: alphaInstallPath },
+      };
+      const config: OpenClawConfig = { plugins: { entries: { alpha: { enabled: true } } } };
+      pluginCliConfigMock.mockReturnValue(config);
+      setInstalledPluginIndexInstallRecords(records);
+      readPersistedInstalledPluginIndexMock.mockResolvedValue(
+        createTestInstalledPluginIndex({
+          policyHash: "before-uninstall",
+          installRecords: records,
+        }),
+      );
+      buildPluginSnapshotReportMock.mockReturnValue({
+        plugins: [{ id: "alpha", name: "alpha" }],
+        diagnostics: [],
+      });
+      const failure = new Error("persistent authority closed");
+      let removed = false;
+      const actual =
+        await vi.importActual<typeof import("../plugins/uninstall.js")>("../plugins/uninstall.js");
+      applyPluginUninstallDirectoryRemovalMock.mockImplementation(async (removal) => {
+        const result = await actual.applyPluginUninstallDirectoryRemoval(
+          removal as Parameters<typeof actual.applyPluginUninstallDirectoryRemoval>[0],
+        );
+        removed = result.directoryRemoved;
+        return result;
+      });
+      const { runPluginUninstallCommand } = await import("./plugins-uninstall-command.js");
+      await expect(
+        runPluginUninstallCommand("alpha", {
+          force: true,
+          beforePersistentApply: () => {
+            if (
+              stopAt === "disable" ||
+              (stopAt === "delete" &&
+                pluginCliConfigMock().plugins?.entries?.alpha?.enabled === false) ||
+              (stopAt === "final commit" && removed)
+            ) {
+              throw failure;
+            }
+          },
+        }),
+      ).rejects.toBe(failure);
+
+      expect(readInstallRecords()).toEqual(records);
+      expect(pluginCliConfigMock().plugins?.entries?.alpha).toEqual({
+        enabled: stopAt === "disable",
+      });
+      expect(refreshPluginRegistryMock).not.toHaveBeenCalled();
+      if (stopAt === "final commit") {
+        expect(removed).toBe(true);
+        await expect(fs.stat(alphaInstallPath)).rejects.toMatchObject({ code: "ENOENT" });
+      } else {
+        expect(removed).toBe(false);
+        expect(await fs.readFile(path.join(alphaInstallPath, "keep.txt"), "utf8")).toBe(
+          "owned plugin files",
+        );
+      }
+    },
+  );
 
   it.each([false, true])(
     "removes owned aliases before deleting files and preserves later edits (retry=%s)",
@@ -621,9 +700,6 @@ describe("plugins cli uninstall", () => {
       });
       const actual =
         await vi.importActual<typeof import("../plugins/uninstall.js")>("../plugins/uninstall.js");
-      planPluginUninstallMock.mockImplementation((params) =>
-        actual.planPluginUninstall(params as Parameters<typeof actual.planPluginUninstall>[0]),
-      );
       let failRemoval = retry;
       applyPluginUninstallDirectoryRemovalMock.mockImplementation(async (removal) => {
         expect(currentConfig.plugins?.load?.paths).toEqual([unrelatedPath]);
@@ -693,7 +769,7 @@ describe("plugins cli uninstall", () => {
     ).rejects.toThrow("__exit__:1");
 
     expect(runtimeErrors.at(-1)).toContain('Plugin "pack/one"');
-    expect(planPluginUninstallMock).not.toHaveBeenCalled();
+
     expect(configWriteMock).not.toHaveBeenCalled();
   });
 
@@ -713,7 +789,7 @@ describe("plugins cli uninstall", () => {
     await expect(runPluginsCommand(["plugins", "uninstall", "alpha", "--force"])).rejects.toThrow(
       "__exit__:1",
     );
-    expect(planPluginUninstallMock).not.toHaveBeenCalled();
+
     expect(configWriteMock).not.toHaveBeenCalled();
   });
 
@@ -734,7 +810,7 @@ describe("plugins cli uninstall", () => {
     await expect(runPluginsCommand(["plugins", "uninstall", "alpha", "--force"])).rejects.toThrow(
       "__exit__:1",
     );
-    expect(planPluginUninstallMock).not.toHaveBeenCalled();
+
     expect(configWriteMock).not.toHaveBeenCalled();
     expect(refreshPluginRegistryMock).not.toHaveBeenCalled();
   });
@@ -786,17 +862,9 @@ describe("plugins cli uninstall", () => {
       ],
       diagnostics: [],
     });
-    const actualUninstall =
-      await vi.importActual<typeof import("../plugins/uninstall.js")>("../plugins/uninstall.js");
-    planPluginUninstallMock.mockImplementation((params) =>
-      actualUninstall.planPluginUninstall(
-        params as Parameters<typeof actualUninstall.planPluginUninstall>[0],
-      ),
-    );
 
     await runPluginsCommand(["plugins", "uninstall", pluginId, "--force", "--keep-files"]);
 
-    expectLatestUninstallPlanParams({ pluginId, channelIds, deleteFiles: false });
     expectInstallRecordsWrittenWithLease(
       {},
       expect.objectContaining({
@@ -840,13 +908,6 @@ describe("plugins cli uninstall", () => {
         plugins: [],
         diagnostics: [],
       });
-      const actualUninstall =
-        await vi.importActual<typeof import("../plugins/uninstall.js")>("../plugins/uninstall.js");
-      planPluginUninstallMock.mockImplementation((params) =>
-        actualUninstall.planPluginUninstall(
-          params as Parameters<typeof actualUninstall.planPluginUninstall>[0],
-        ),
-      );
       const installedIndexModule = await import("../plugins/installed-plugin-index.js");
       const indexSpy = vi.spyOn(installedIndexModule, "loadInstalledPluginIndex").mockReturnValue(
         createTestInstalledPluginIndex({
@@ -872,11 +933,6 @@ describe("plugins cli uninstall", () => {
       try {
         await runPluginsCommand(["plugins", "uninstall", pluginId, "--force", "--keep-files"]);
 
-        expectLatestUninstallPlanParams({
-          pluginId,
-          channelIds: claimed ? [] : undefined,
-          deleteFiles: false,
-        });
         expectInstallRecordsWrittenWithLease(
           {},
           {
@@ -912,13 +968,6 @@ describe("plugins cli uninstall", () => {
         plugins: [{ id: "pack/one", name: "One", status: "loaded", channelIds: ["chat"] }],
         diagnostics: [],
       });
-      const actualUninstall =
-        await vi.importActual<typeof import("../plugins/uninstall.js")>("../plugins/uninstall.js");
-      planPluginUninstallMock.mockImplementation((params) =>
-        actualUninstall.planPluginUninstall(
-          params as Parameters<typeof actualUninstall.planPluginUninstall>[0],
-        ),
-      );
       const installedIndexModule = await import("../plugins/installed-plugin-index.js");
       const indexSpy = vi.spyOn(installedIndexModule, "loadInstalledPluginIndex").mockReturnValue(
         createTestInstalledPluginIndex({
@@ -967,16 +1016,11 @@ describe("plugins cli uninstall", () => {
       plugins: [{ id: "alpha", name: "alpha" }],
       diagnostics: [],
     });
-    planPluginUninstallMock.mockReturnValue({
-      ok: false,
-      error: "Plugin not found: alpha",
-    });
 
     await expect(runPluginsCommand(["plugins", "uninstall", "alpha", "--force"])).rejects.toThrow(
       "__exit__:1",
     );
 
     expect(runtimeErrors.at(-1)).toContain("is not associated with a tracked package install");
-    expect(planPluginUninstallMock).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/plugins-uninstall-command.ts
+++ b/src/cli/plugins-uninstall-command.ts
@@ -1,20 +1,9 @@
-// Plugin uninstall command implementation and confirmation-driven removal plan execution.
+// Terminal preview and confirmation for the shared plugin uninstall owner.
 import { theme } from "../../packages/terminal-core/src/theme.js";
-import {
-  assertConfigWriteAllowedInCurrentMode,
-  readConfigFileSnapshotForWrite,
-  replaceConfigFile,
-} from "../config/config.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
-import { resolveDefaultPluginExtensionsDir } from "../plugins/install-paths.js";
+import { assertConfigWriteAllowedInCurrentMode } from "../config/config.js";
+import type { PreparedPluginUninstall } from "../plugins/management-uninstall.js";
 import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
-import {
-  tracePluginLifecyclePhase,
-  tracePluginLifecyclePhaseAsync,
-} from "../plugins/plugin-lifecycle-trace.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
-import { withClawPackageLifecycleLease } from "../state/claw-package-lifecycle-lease.js";
 import { shortenHomePath } from "../utils.js";
 
 type PluginUninstallOptions = {
@@ -30,395 +19,120 @@ type PluginUninstallOptions = {
   beforePersistentApply?: () => void;
 };
 
-function isPromptInputClosedError(
-  error: unknown,
-  PromptInputClosedError: typeof import("./prompt.js").PromptInputClosedError,
-): error is InstanceType<typeof PromptInputClosedError> {
-  return error instanceof PromptInputClosedError;
-}
-
 export async function runPluginUninstallCommand(
   id: string,
   opts: PluginUninstallOptions = {},
   runtime: RuntimeEnv = defaultRuntime,
 ): Promise<void> {
-  if (opts.dryRun) {
-    return await runPluginUninstallCommandUnlocked(id, opts, runtime);
-  }
-  assertConfigWriteAllowedInCurrentMode();
-  if (!opts.force) {
-    return await runPluginUninstallCommandUnlocked(id, opts, runtime);
-  }
-  return await withPluginLifecycleLease(
-    {},
-    async () => await runPluginUninstallCommandUnlocked(id, opts, runtime),
-  );
-}
-
-async function runPluginUninstallCommandUnlocked(
-  id: string,
-  opts: PluginUninstallOptions,
-  runtime: RuntimeEnv,
-  skipPreview = false,
-): Promise<void> {
-  // Dry-run only reads state; real uninstalls fail before any lifecycle lease or mutation.
   if (!opts.dryRun) {
     assertConfigWriteAllowedInCurrentMode();
   }
-
-  const { loadInstalledPluginIndex } = await import("../plugins/installed-plugin-index.js");
-  const { createInstalledPluginIndexScopeLookup } =
-    await import("../plugins/installed-plugin-index-scope-lookup.js");
-  const { createInstalledPluginOwnershipResolver } =
-    await import("../plugins/installed-plugin-package-ownership.js");
-  const {
-    loadInstalledPluginIndexInstallRecords,
-    removePluginInstallRecordFromRecords,
-    withoutPluginInstallRecords,
-    withPluginInstallRecords,
-  } = await import("../plugins/installed-plugin-index-records.js");
-  const { buildPluginSnapshotReport } = await import("../plugins/status.js");
-  const {
-    applyPluginUninstallDirectoryRemoval,
-    formatUninstallActionLabels,
-    formatUninstallSlotResetPreview,
-    planPluginUninstall,
-    pluginUninstallTargetExists,
-    resolveUninstallChannelConfigKeys,
-    UNINSTALL_ACTION_LABELS,
-  } = await import("../plugins/uninstall.js");
-  const { prepareConfigForDisabledPluginSet, recordPluginPackageUninstallPlan } =
-    await import("../plugins/uninstall-package-plan.js");
-  const { commitPluginInstallRecordsWithConfig } =
-    await import("../plugins/install-record-commit.js");
-  const { selectInstallMutationWriteOptions } = await import("../plugins/install-persistence.js");
-  const { refreshPluginRegistryAfterConfigMutation } =
-    await import("../plugins/registry-refresh.js");
-  const { resolvePluginUninstallId } = await import("./plugins-uninstall-selection.js");
+  const { preparePluginUninstall, uninstallPluginWithPolicy } =
+    await import("../plugins/management-uninstall.js");
+  const { formatUninstallActionLabels, resolveUninstallChannelConfigKeys } =
+    await import("../plugins/uninstall.js");
+  const { collectClawPluginUninstallWarnings } =
+    await import("../plugins/uninstall-claw-references.js");
   const { PromptInputClosedError, promptYesNo } = await import("./prompt.js");
-  const prepared = await tracePluginLifecyclePhaseAsync(
-    "config read",
-    () => readConfigFileSnapshotForWrite(),
-    { command: "uninstall" },
-  );
-  const { snapshot } = prepared;
-  const mutationWriteOptions = selectInstallMutationWriteOptions(prepared.writeOptions);
-  const sourceConfig = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
-  const installRecords = await tracePluginLifecyclePhaseAsync(
-    "install records load",
-    () => loadInstalledPluginIndexInstallRecords(),
-    { command: "uninstall" },
-  );
-  const cfg = withPluginInstallRecords(sourceConfig, installRecords);
-  const installedIndex = loadInstalledPluginIndex({ config: cfg, installRecords });
-  const report = tracePluginLifecyclePhase(
-    "plugin registry snapshot",
-    () => buildPluginSnapshotReport({ config: cfg }),
-    { command: "uninstall" },
-  );
-  const extensionsDir = resolveDefaultPluginExtensionsDir();
-  const keepFiles = Boolean(opts.keepFiles || opts.keepConfig);
-
-  if (opts.keepConfig) {
-    runtime.log(theme.warn("`--keep-config` is deprecated, use `--keep-files`."));
-  }
-
-  const selection = resolvePluginUninstallId({
-    rawId: id,
-    config: cfg,
-    plugins: report.plugins,
-  });
-  if (!selection.ok) {
-    runtime.error(selection.error);
-    runtime.exit(1);
-    return;
-  }
-  const { plugin } = selection.value;
-  const requestedPluginId = selection.value.pluginId;
-  const ownership =
-    createInstalledPluginOwnershipResolver(installedIndex).resolveLifecycle(requestedPluginId);
-  if (!ownership.ok) {
-    runtime.error(ownership.error);
-    runtime.exit(1);
-    return;
-  }
-  const { installOwner: pluginId, pluginIds: ownedPluginIds } = ownership.value;
-  const policyPluginIds = ownedPluginIds.length > 0 ? ownedPluginIds : [pluginId];
-  let channelIds: string[] | undefined;
-  if (ownedPluginIds.length === 1 && ownedPluginIds[0] === requestedPluginId) {
-    channelIds = plugin?.channelIds;
-  } else if (ownedPluginIds.length > 0) {
-    channelIds = [
-      ...new Set(
-        ownedPluginIds.flatMap(
-          (entryId) => report.plugins.find((entry) => entry.id === entryId)?.channelIds ?? [],
-        ),
-      ),
-    ];
-  } else if (
-    createInstalledPluginIndexScopeLookup(installedIndex).hasChannelContributionOwners([pluginId])
-  ) {
-    // An orphan's owner-key fallback cannot remove another discovered plugin's channel policy.
-    channelIds = [];
-  }
-  const initialPlan = planPluginUninstall(
-    recordPluginPackageUninstallPlan(
-      {
-        config: cfg,
-        pluginId,
-        ...(channelIds !== undefined ? { channelIds } : {}),
-        deleteFiles: !keepFiles,
-        extensionsDir,
-      },
-      {
-        runtimePluginIds: policyPluginIds,
-        runtimeLoadPaths: ownedPluginIds.flatMap(
-          (entryId) => report.plugins.find((entry) => entry.id === entryId)?.source ?? [],
-        ),
-      },
-    ),
-  );
-  if (!initialPlan.ok) {
-    if (plugin) {
-      runtime.error(
-        `Plugin "${pluginId}" is not managed by plugins config/install records and cannot be uninstalled.`,
-      );
-    } else {
-      runtime.error(initialPlan.error);
+  const request = { pluginId: id, keepFiles: Boolean(opts.keepFiles || opts.keepConfig) };
+  const warnKeepConfig = () => {
+    if (opts.keepConfig) {
+      runtime.log(theme.warn("`--keep-config` is deprecated, use `--keep-files`."));
     }
-    runtime.exit(1);
-    return;
-  }
-  let plan = initialPlan;
-  const hasInstall = Object.hasOwn(cfg.plugins?.installs ?? {}, pluginId);
-
-  const preview: string[] = [];
-  if (plan.actions.entry) {
-    preview.push(UNINSTALL_ACTION_LABELS.entry);
-  }
-  if (plan.actions.install) {
-    preview.push(UNINSTALL_ACTION_LABELS.install);
-  }
-  if (plan.actions.allowlist) {
-    preview.push(UNINSTALL_ACTION_LABELS.allowlist);
-  }
-  if (plan.actions.denylist) {
-    preview.push(UNINSTALL_ACTION_LABELS.denylist);
-  }
-  if (plan.actions.loadPath) {
-    preview.push(UNINSTALL_ACTION_LABELS.loadPath);
-  }
-  if (plan.actions.memorySlot) {
-    preview.push(formatUninstallSlotResetPreview("memory"));
-  }
-  if (plan.actions.contextEngineSlot) {
-    preview.push(formatUninstallSlotResetPreview("contextEngine"));
-  }
-  const channels = cfg.channels as Record<string, unknown> | undefined;
-  if (plan.actions.channelConfig && hasInstall && channels) {
-    for (const key of resolveUninstallChannelConfigKeys(pluginId, { channelIds })) {
-      if (Object.hasOwn(channels, key)) {
-        preview.push(`${UNINSTALL_ACTION_LABELS.channelConfig} (channels.${key})`);
-      }
+  };
+  const printPreview = (preview: PreparedPluginUninstall) => {
+    const channelConfigKeys =
+      preview.plan.actions.channelConfig && Object.hasOwn(preview.installRecords, preview.pluginId)
+        ? resolveUninstallChannelConfigKeys(preview.pluginId, {
+            channelIds: preview.channelIds,
+          }).filter((key) => Object.hasOwn(preview.snapshot.config.channels ?? {}, key))
+        : [];
+    const labels = formatUninstallActionLabels(preview.plan.actions, { channelConfigKeys });
+    if (preview.plan.directoryRemoval) {
+      labels.push(`directory: ${shortenHomePath(preview.plan.directoryRemoval.target)}`);
     }
-  }
-  if (plan.directoryRemoval) {
-    preview.push(`directory: ${shortenHomePath(plan.directoryRemoval.target)}`);
-  }
-
-  if (!skipPreview) {
-    const pluginName = plugin?.name || pluginId;
     runtime.log(
-      `Plugin: ${theme.command(pluginName)}${pluginName !== pluginId ? theme.muted(` (${pluginId})`) : ""}`,
+      `Plugin: ${theme.command(preview.name)}${preview.name !== preview.pluginId ? theme.muted(` (${preview.pluginId})`) : ""}`,
     );
-    if (ownedPluginIds.length > 1 || requestedPluginId !== pluginId) {
+    if (preview.pluginIds.length > 1 || preview.requestedPluginId !== preview.pluginId) {
       runtime.log(
-        `Package owner: ${theme.command(pluginId)}; all entries will be removed: ${ownedPluginIds.join(", ")}`,
+        `Package owner: ${theme.command(preview.pluginId)}; all entries will be removed: ${preview.pluginIds.join(", ")}`,
       );
     }
-    runtime.log(`Will remove: ${preview.length > 0 ? preview.join(", ") : "(nothing)"}`);
-
-    const { collectClawPluginUninstallWarnings } =
-      await import("../plugins/uninstall-claw-references.js");
+    runtime.log(`Will remove: ${labels.length ? labels.join(", ") : "(nothing)"}`);
     for (const warning of collectClawPluginUninstallWarnings({
-      pluginId,
-      installRecord: cfg.plugins?.installs?.[pluginId],
+      pluginId: preview.pluginId,
+      installRecord: preview.installRecords[preview.pluginId],
     })) {
       runtime.log(theme.warn(warning));
     }
+  };
+  const execute = async (skipPreview: boolean) => {
+    warnKeepConfig();
+    // Keep errors/output inside the plugin lease; the owner emits success inside any package lease.
+    const result = await uninstallPluginWithPolicy({
+      ...request,
+      caller: "cli",
+      clawManaged: opts.clawManaged,
+      beforePersistentApply: opts.beforePersistentApply,
+      invalidateRuntimeCache: opts.invalidateRuntimeCache,
+      ...(skipPreview ? {} : { onPreview: printPreview }),
+      onWarning: (message) => runtime.log(theme.warn(message)),
+      onComplete: ({ pluginId, requestedPluginId, pluginIds, removed }) => {
+        const subject =
+          pluginIds.length > 1 || requestedPluginId !== pluginId
+            ? `plugin package "${pluginId}" and entries ${pluginIds.join(", ")}`
+            : `plugin "${pluginId}"`;
+        runtime.log(
+          `Uninstalled ${subject}. Removed: ${removed.length ? removed.join(", ") : "nothing"}.`,
+        );
+        runtime.log("Restart the gateway to apply changes.");
+      },
+    });
+    if (!result.ok) {
+      runtime.error(result.error);
+      runtime.exit(1);
+    }
+  };
+  if (opts.force && !opts.dryRun) {
+    return await withPluginLifecycleLease({}, async () => await execute(false));
   }
-
-  let nextConfig = withoutPluginInstallRecords(plan.config);
-
+  if (!opts.dryRun) {
+    assertConfigWriteAllowedInCurrentMode();
+  }
+  const prepared = await preparePluginUninstall({ ...request, caller: "cli" });
+  warnKeepConfig();
+  if (!prepared.ok) {
+    runtime.error(prepared.error);
+    runtime.exit(1);
+    return;
+  }
+  const preview = prepared.value;
+  printPreview(preview);
   if (opts.dryRun) {
     runtime.log(theme.muted("Dry run, no changes made."));
     return;
   }
-
-  if (!opts.force) {
-    let confirmed: boolean;
-    try {
-      confirmed = await promptYesNo(
-        ownedPluginIds.length > 1
-          ? `Uninstall plugin package "${pluginId}" and all entries?`
-          : `Uninstall plugin "${pluginId}"?`,
-      );
-    } catch (error) {
-      if (isPromptInputClosedError(error, PromptInputClosedError)) {
-        runtime.error(
-          "Error: plugins uninstall requires confirmation input. Re-run in an interactive TTY or pass --force.",
-        );
-        runtime.exit(1);
-        return;
-      }
+  let confirmed: boolean;
+  try {
+    confirmed = await promptYesNo(
+      preview.pluginIds.length > 1
+        ? `Uninstall plugin package "${preview.pluginId}" and all entries?`
+        : `Uninstall plugin "${preview.pluginId}"?`,
+    );
+  } catch (error) {
+    if (!(error instanceof PromptInputClosedError)) {
       throw error;
     }
-    if (!confirmed) {
-      runtime.log("Cancelled.");
-      return;
-    }
-    return await withPluginLifecycleLease(
-      {},
-      async () =>
-        await runPluginUninstallCommandUnlocked(id, { ...opts, force: true }, runtime, true),
+    runtime.error(
+      "Error: plugins uninstall requires confirmation input. Re-run in an interactive TTY or pass --force.",
     );
+    runtime.exit(1);
+    return;
   }
-
-  const uninstall = async () => {
-    const guardedWriteOptions = (writeOptions: typeof mutationWriteOptions) =>
-      opts.beforePersistentApply
-        ? {
-            ...writeOptions,
-            assertConfigPathForWrite: () => {
-              writeOptions.assertConfigPathForWrite?.();
-              opts.beforePersistentApply?.();
-            },
-          }
-        : writeOptions;
-    let finalBaseHash = snapshot.hash;
-    let finalWriteOptions = mutationWriteOptions;
-    let directoryResult = { directoryRemoved: false, warnings: [] as string[] };
-    if (plan.directoryRemoval) {
-      const disabledConfig = prepareConfigForDisabledPluginSet(
-        sourceConfig,
-        policyPluginIds,
-        plan.config,
-      );
-      const disabledCommit = await tracePluginLifecyclePhaseAsync(
-        "config disable",
-        () =>
-          replaceConfigFile({
-            nextConfig: disabledConfig,
-            ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
-            writeOptions: {
-              ...guardedWriteOptions(mutationWriteOptions),
-              afterWrite: { mode: "auto" },
-            },
-          }),
-        { command: "uninstall" },
-      );
-      finalBaseHash = disabledCommit?.persistedHash ?? snapshot.hash;
-      opts.beforePersistentApply?.();
-      directoryResult = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
-      for (const warning of directoryResult.warnings) {
-        runtime.log(theme.warn(warning));
-      }
-      if (pluginUninstallTargetExists(plan.directoryRemoval.target)) {
-        throw new Error(
-          `Failed to remove plugin directory ${shortenHomePath(plan.directoryRemoval.target)}; the plugin remains disabled and tracked so uninstall can be retried.`,
-        );
-      }
-      const refreshedPrepared = await tracePluginLifecyclePhaseAsync(
-        "config reread",
-        () => readConfigFileSnapshotForWrite(),
-        { command: "uninstall" },
-      );
-      const refreshedSnapshot = refreshedPrepared.snapshot;
-      const refreshedSourceConfig = (refreshedSnapshot.sourceConfig ??
-        refreshedSnapshot.config) as OpenClawConfig;
-      const refreshedPlan = planPluginUninstall(
-        recordPluginPackageUninstallPlan(
-          {
-            config: withPluginInstallRecords(refreshedSourceConfig, installRecords),
-            pluginId,
-            ...(channelIds !== undefined ? { channelIds } : {}),
-            deleteFiles: true,
-            extensionsDir,
-          },
-          {
-            runtimePluginIds: policyPluginIds,
-            runtimeLoadPaths: ownedPluginIds.flatMap(
-              (entryId) => report.plugins.find((entry) => entry.id === entryId)?.source ?? [],
-            ),
-          },
-        ),
-      );
-      if (!refreshedPlan.ok) {
-        throw new Error(refreshedPlan.error);
-      }
-      plan = refreshedPlan;
-      nextConfig = withoutPluginInstallRecords(plan.config);
-      finalBaseHash = refreshedSnapshot.hash;
-      finalWriteOptions = selectInstallMutationWriteOptions(refreshedPrepared.writeOptions);
-    }
-
-    const nextInstallRecords = removePluginInstallRecordFromRecords(installRecords, pluginId);
-    await tracePluginLifecyclePhaseAsync(
-      "config mutation",
-      () =>
-        commitPluginInstallRecordsWithConfig({
-          previousInstallRecords: installRecords,
-          nextInstallRecords,
-          nextConfig,
-          ...(finalBaseHash !== undefined ? { baseHash: finalBaseHash } : {}),
-          writeOptions: {
-            ...guardedWriteOptions(finalWriteOptions),
-            allowConfigSizeDrop: true,
-            afterWrite: { mode: "restart", reason: "plugin source changed" },
-          },
-        }),
-      { command: "uninstall" },
-    );
-    if (!plan.directoryRemoval) {
-      directoryResult = await applyPluginUninstallDirectoryRemoval(null);
-    }
-    await refreshPluginRegistryAfterConfigMutation({
-      config: nextConfig,
-      reason: "source-changed",
-      installRecords: nextInstallRecords,
-      invalidateRuntimeCache: opts.invalidateRuntimeCache,
-      traceCommand: "uninstall",
-      logger: {
-        warn: (message) => runtime.log(theme.warn(message)),
-      },
-    });
-
-    const removed = formatUninstallActionLabels({
-      ...plan.actions,
-      loadPath: initialPlan.actions.loadPath || plan.actions.loadPath,
-      directory: directoryResult.directoryRemoved,
-    });
-
-    const uninstalledSubject =
-      ownedPluginIds.length > 1 || requestedPluginId !== pluginId
-        ? `plugin package "${pluginId}" and entries ${ownedPluginIds.join(", ")}`
-        : `plugin "${pluginId}"`;
-    runtime.log(
-      `Uninstalled ${uninstalledSubject}. Removed: ${removed.length > 0 ? removed.join(", ") : "nothing"}.`,
-    );
-    runtime.log("Restart the gateway to apply changes.");
-  };
-  const installRecord = cfg.plugins?.installs?.[pluginId];
-  const clawhubPackage =
-    installRecord?.source === "clawhub"
-      ? (installRecord.clawhubPackage ?? parseClawHubPluginSpec(installRecord.spec ?? "")?.name)
-      : undefined;
-  if (opts.clawManaged || !clawhubPackage) {
-    return await uninstall();
+  if (!confirmed) {
+    runtime.log("Cancelled.");
+    return;
   }
-  await withClawPackageLifecycleLease(
-    { kind: "plugin", source: "clawhub", ref: clawhubPackage },
-    uninstall,
-    { required: true },
-  );
+  await withPluginLifecycleLease({}, async () => await execute(true));
 }

--- a/src/cli/plugins-uninstall-selection.test.ts
+++ b/src/cli/plugins-uninstall-selection.test.ts
@@ -1,7 +1,7 @@
 // Plugin uninstall selection tests cover CLI uninstall target matching.
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { resolvePluginUninstallId } from "./plugins-uninstall-selection.js";
+import { resolvePluginUninstallId } from "../plugins/uninstall-selection.js";
 
 describe("resolvePluginUninstallId", () => {
   it("prefers an exact plugin id over an earlier plugin display name", () => {

--- a/src/plugins/management-config.ts
+++ b/src/plugins/management-config.ts
@@ -1,0 +1,49 @@
+// Captures source config and write ownership for administrative plugin mutations.
+import { asRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  assertConfigWriteAllowedInCurrentMode,
+  readConfigFileSnapshotForWrite,
+} from "../config/config.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import {
+  resolveInstallConfigMutationPreflights,
+  selectInstallMutationWriteOptions,
+  type ConfigSnapshotForInstallPersist,
+} from "./install-persistence.js";
+import { ManagedPluginLifecycleError } from "./management-lifecycle-error.js";
+
+function assertValidConfigSnapshot(
+  prepared: Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>,
+): ConfigSnapshotForInstallPersist {
+  const { snapshot, writeOptions } = prepared;
+  if (!snapshot.valid) {
+    throw new ManagedPluginLifecycleError(
+      "Config invalid; run `openclaw doctor --fix` before managing plugins.",
+    );
+  }
+  const mutationWriteOptions = selectInstallMutationWriteOptions(writeOptions);
+  const { pluginMutation } = resolveInstallConfigMutationPreflights({
+    parsed: asRecord(snapshot.parsed),
+    snapshotPath: snapshot.path,
+    writeOptions: mutationWriteOptions,
+  });
+  if (pluginMutation.mode === "blocked") {
+    throw new ManagedPluginLifecycleError(pluginMutation.reason);
+  }
+  return {
+    config: snapshot.sourceConfig,
+    baseHash: snapshot.hash,
+    writeOptions: mutationWriteOptions,
+  };
+}
+
+export async function readPluginMutationSnapshot(
+  env: NodeJS.ProcessEnv,
+): Promise<ConfigSnapshotForInstallPersist> {
+  try {
+    assertConfigWriteAllowedInCurrentMode({ env });
+  } catch (error) {
+    throw new ManagedPluginLifecycleError(formatErrorMessage(error), { cause: error });
+  }
+  return assertValidConfigSnapshot(await readConfigFileSnapshotForWrite());
+}

--- a/src/plugins/management-mutations.ts
+++ b/src/plugins/management-mutations.ts
@@ -1,17 +1,13 @@
 // Owns managed plugin install, policy and uninstall mutations under the lifecycle lease.
-import { asRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { collectChangedPaths } from "../config/config-change-paths.js";
 import {
   assertConfigWriteAllowedInCurrentMode,
   readConfigFileSnapshot,
-  readConfigFileSnapshotForWrite,
   replaceConfigFile,
 } from "../config/config.js";
 import { ensurePluginAllowlisted } from "../config/plugins-allowlist.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
-import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   resolvePluginCapabilityConsent,
@@ -23,27 +19,14 @@ import { normalizePluginId } from "./config-state.js";
 import { resolvePluginControlPlaneWorkspace } from "./control-plane-workspace.js";
 import { getProcessGatewayPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 import { enableExplicitlySelectedPluginInConfig } from "./enable.js";
-import { resolveDefaultPluginExtensionsDir } from "./install-paths.js";
-import {
-  resolveInstallConfigMutationPreflights,
-  selectInstallMutationWriteOptions,
-  type ConfigSnapshotForInstallPersist,
-} from "./install-persistence.js";
-import { commitPluginInstallRecordsWithConfig } from "./install-record-commit.js";
 import type { InstallPolicyWarningDetails } from "./install-security-scan.types.js";
-import {
-  loadInstalledPluginIndexInstallRecords,
-  removePluginInstallRecordFromRecords,
-  withPluginInstallRecords,
-  withoutPluginInstallRecords,
-} from "./installed-plugin-index-records.js";
-import { createInstalledPluginIndexScopeLookup } from "./installed-plugin-index-scope-lookup.js";
 import { createInstalledPluginOwnershipResolver } from "./installed-plugin-package-ownership.js";
 import {
   type ManagedPluginCatalogEntry,
   loadOfficialCatalog,
   resolveOfficialEntryById,
 } from "./management-catalog.js";
+import { readPluginMutationSnapshot } from "./management-config.js";
 import {
   type ManagedPluginSourceInstallRequest,
   installManagedPluginSource,
@@ -66,17 +49,6 @@ import { withPluginLifecycleLease } from "./plugin-lifecycle-lease.js";
 import { refreshPluginRegistryAfterConfigMutation } from "./registry-refresh.js";
 import { applySlotSelectionForPlugin } from "./slot-selection.js";
 import { setPluginEnabledInConfig } from "./toggle-config.js";
-import { collectClawPluginUninstallWarnings } from "./uninstall-claw-references.js";
-import {
-  prepareConfigForDisabledPluginSet,
-  recordPluginPackageUninstallPlan,
-} from "./uninstall-package-plan.js";
-import {
-  applyPluginUninstallDirectoryRemoval,
-  formatUninstallActionLabels,
-  planPluginUninstall,
-  pluginUninstallTargetExists,
-} from "./uninstall.js";
 
 type ManagedPluginInstallRequest =
   | {
@@ -92,42 +64,6 @@ type ManagedPluginInstallRequest =
       acknowledgeInstallPolicyWarning?: true;
       acknowledgeCapabilities?: PluginCapabilityConsentAcknowledgment;
     };
-
-function assertValidConfigSnapshot(
-  prepared: Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>,
-): ConfigSnapshotForInstallPersist {
-  const { snapshot, writeOptions } = prepared;
-  if (!snapshot.valid) {
-    throw new ManagedPluginLifecycleError(
-      "Config invalid; run `openclaw doctor --fix` before managing plugins.",
-    );
-  }
-  const mutationWriteOptions = selectInstallMutationWriteOptions(writeOptions);
-  const { pluginMutation } = resolveInstallConfigMutationPreflights({
-    parsed: asRecord(snapshot.parsed),
-    snapshotPath: snapshot.path,
-    writeOptions: mutationWriteOptions,
-  });
-  if (pluginMutation.mode === "blocked") {
-    throw new ManagedPluginLifecycleError(pluginMutation.reason);
-  }
-  return {
-    config: snapshot.sourceConfig,
-    baseHash: snapshot.hash,
-    writeOptions: mutationWriteOptions,
-  };
-}
-
-async function readPluginMutationSnapshot(
-  env: NodeJS.ProcessEnv,
-): Promise<ConfigSnapshotForInstallPersist> {
-  try {
-    assertConfigWriteAllowedInCurrentMode({ env });
-  } catch (error) {
-    throw new ManagedPluginLifecycleError(formatErrorMessage(error), { cause: error });
-  }
-  return assertValidConfigSnapshot(await readConfigFileSnapshotForWrite());
-}
 
 function createSilentRuntime(): RuntimeEnv {
   return {
@@ -515,165 +451,4 @@ export async function setManagedPluginEnabled(params: ManagedPluginEnableRequest
   });
 }
 
-/** Remove an installed plugin: config references, install record, and managed files. */
-export async function uninstallManagedPlugin(params: {
-  pluginId: string;
-  env?: NodeJS.ProcessEnv;
-}): Promise<{ pluginId: string; removed: string[]; warnings?: string[] }> {
-  const env = params.env ?? process.env;
-  return await withPluginLifecycleLease({ env }, async () => {
-    const snapshot = await readPluginMutationSnapshot(env);
-    const installRecords = await loadInstalledPluginIndexInstallRecords({ env });
-    // Mirror the CLI uninstall flow: plan against config carrying install records
-    // so managed npm/git directories resolve, then persist the stripped config.
-    const configWithRecords = withPluginInstallRecords(snapshot.config, installRecords);
-    const metadata = loadFreshManagedPluginMetadata(configWithRecords, env);
-    const pluginId = metadata.normalizePluginId(params.pluginId.trim());
-    const record = metadata.index.plugins.find((plugin) => plugin.pluginId === pluginId);
-    if (record?.origin === "bundled") {
-      throw new ManagedPluginLifecycleError(
-        `bundled plugin cannot be uninstalled: ${pluginId}; disable it instead`,
-      );
-    }
-    if (!record && !Object.hasOwn(installRecords, pluginId)) {
-      throw new ManagedPluginLifecycleError(`Plugin not found: ${pluginId}`);
-    }
-    const ownership = createInstalledPluginOwnershipResolver(metadata.index, env).resolveLifecycle(
-      pluginId,
-    );
-    if (!ownership.ok) {
-      throw new ManagedPluginLifecycleError(ownership.error);
-    }
-    const { installOwner, pluginIds: ownedPluginIds } = ownership.value;
-    const policyPluginIds = ownedPluginIds.length > 0 ? ownedPluginIds : [installOwner];
-    const ownedManifests = ownedPluginIds.flatMap((entryId) => {
-      const manifest = metadata.byPluginId.get(entryId);
-      return manifest ? [manifest] : [];
-    });
-    const channelIds =
-      ownedManifests.length > 0
-        ? uniqueStrings(ownedManifests.flatMap((manifest) => manifest.channels))
-        : ownership.value.kind === "orphan" &&
-            createInstalledPluginIndexScopeLookup(metadata.index).hasChannelContributionOwners([
-              installOwner,
-            ])
-          ? []
-          : undefined;
-    const extensionsDir = resolveDefaultPluginExtensionsDir(env);
-    const initialPlan = planPluginUninstall(
-      recordPluginPackageUninstallPlan(
-        {
-          config: configWithRecords,
-          pluginId: installOwner,
-          ...(channelIds !== undefined ? { channelIds } : {}),
-          deleteFiles: true,
-          extensionsDir,
-        },
-        {
-          runtimePluginIds: policyPluginIds,
-          runtimeLoadPaths: ownedPluginIds.flatMap(
-            (entryId) => metadata.byPluginId.get(entryId)?.source ?? [],
-          ),
-        },
-      ),
-    );
-    if (!initialPlan.ok) {
-      throw new ManagedPluginLifecycleError(initialPlan.error);
-    }
-    let plan = initialPlan;
-    let finalSnapshot = snapshot;
-    let directoryResult: Awaited<ReturnType<typeof applyPluginUninstallDirectoryRemoval>> = {
-      directoryRemoved: false,
-      warnings: [],
-    };
-    if (plan.directoryRemoval) {
-      const disabledConfig = prepareConfigForDisabledPluginSet(
-        snapshot.config,
-        policyPluginIds,
-        plan.config,
-      );
-      await replaceConfigFile({
-        nextConfig: disabledConfig,
-        baseHash: snapshot.baseHash,
-        writeOptions: {
-          ...snapshot.writeOptions,
-          afterWrite: { mode: "auto" },
-        },
-      });
-      directoryResult = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
-      if (pluginUninstallTargetExists(plan.directoryRemoval.target)) {
-        throw new ManagedPluginLifecycleError(
-          `Failed to remove plugin directory ${plan.directoryRemoval.target}; the plugin remains disabled and tracked so uninstall can be retried.`,
-          { kind: "unavailable" },
-        );
-      }
-      finalSnapshot = await readPluginMutationSnapshot(env);
-      const refreshedConfigWithRecords = withPluginInstallRecords(
-        finalSnapshot.config,
-        installRecords,
-      );
-      const refreshedPlan = planPluginUninstall(
-        recordPluginPackageUninstallPlan(
-          {
-            config: refreshedConfigWithRecords,
-            pluginId: installOwner,
-            ...(channelIds !== undefined ? { channelIds } : {}),
-            deleteFiles: true,
-            extensionsDir,
-          },
-          {
-            runtimePluginIds: policyPluginIds,
-            runtimeLoadPaths: ownedPluginIds.flatMap(
-              (entryId) => metadata.byPluginId.get(entryId)?.source ?? [],
-            ),
-          },
-        ),
-      );
-      if (!refreshedPlan.ok) {
-        throw new ManagedPluginLifecycleError(refreshedPlan.error);
-      }
-      plan = refreshedPlan;
-    }
-    const nextConfig = withoutPluginInstallRecords(plan.config);
-    const nextInstallRecords = removePluginInstallRecordFromRecords(installRecords, installOwner);
-    await commitPluginInstallRecordsWithConfig({
-      previousInstallRecords: installRecords,
-      nextInstallRecords,
-      nextConfig,
-      baseHash: finalSnapshot.baseHash,
-      writeOptions: finalSnapshot.writeOptions,
-    });
-    const warnings = [
-      ...collectClawPluginUninstallWarnings({
-        pluginId: installOwner,
-        installRecord: installRecords[installOwner],
-        env,
-      }),
-      ...(pluginId !== installOwner || ownedPluginIds.length > 1
-        ? [
-            `Uninstalled package "${installOwner}" and all owned plugin entries: ${ownedPluginIds.join(", ")}.`,
-          ]
-        : []),
-      ...directoryResult.warnings,
-    ];
-    await refreshPluginRegistryAfterConfigMutation({
-      config: nextConfig,
-      env,
-      reason: "source-changed",
-      installRecords: nextInstallRecords,
-      invalidateRuntimeCache: false,
-      logger: { warn: (message) => warnings.push(message) },
-    });
-    refreshManagedPluginMetadata({ config: nextConfig, env });
-    const removed = formatUninstallActionLabels({
-      ...plan.actions,
-      loadPath: initialPlan.actions.loadPath || plan.actions.loadPath,
-      directory: directoryResult.directoryRemoved,
-    });
-    return {
-      pluginId: installOwner,
-      removed,
-      ...(warnings.length > 0 ? { warnings: [...new Set(warnings)] } : {}),
-    };
-  });
-}
+export { uninstallManagedPlugin } from "./management-uninstall.js";

--- a/src/plugins/management-uninstall.ts
+++ b/src/plugins/management-uninstall.ts
@@ -1,0 +1,400 @@
+// Plans and commits package-owned uninstall state for CLI and management callers.
+import { ok, err, type Result } from "@openclaw/normalization-core/result";
+import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import {
+  assertConfigWriteAllowedInCurrentMode,
+  readConfigFileSnapshotForWrite,
+  replaceConfigFile,
+} from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
+import { withClawPackageLifecycleLease } from "../state/claw-package-lifecycle-lease.js";
+import { shortenHomePath } from "../utils.js";
+import { resolveDefaultPluginExtensionsDir } from "./install-paths.js";
+import {
+  selectInstallMutationWriteOptions,
+  type ConfigSnapshotForInstallPersist,
+} from "./install-persistence.js";
+import { commitPluginInstallRecordsWithConfig } from "./install-record-commit.js";
+import {
+  loadInstalledPluginIndexInstallRecords,
+  removePluginInstallRecordFromRecords,
+  withPluginInstallRecords,
+  withoutPluginInstallRecords,
+} from "./installed-plugin-index-records.js";
+import { createInstalledPluginIndexScopeLookup } from "./installed-plugin-index-scope-lookup.js";
+import { loadInstalledPluginIndex } from "./installed-plugin-index.js";
+import { createInstalledPluginOwnershipResolver } from "./installed-plugin-package-ownership.js";
+import { readPluginMutationSnapshot } from "./management-config.js";
+import { ManagedPluginLifecycleError } from "./management-lifecycle-error.js";
+import {
+  loadFreshManagedPluginMetadata,
+  refreshManagedPluginMetadata,
+} from "./management-service.js";
+import { withPluginLifecycleLease } from "./plugin-lifecycle-lease.js";
+import {
+  tracePluginLifecyclePhase,
+  tracePluginLifecyclePhaseAsync,
+} from "./plugin-lifecycle-trace.js";
+import { refreshPluginRegistryAfterConfigMutation } from "./registry-refresh.js";
+import { buildPluginSnapshotReport } from "./status.js";
+import { collectClawPluginUninstallWarnings } from "./uninstall-claw-references.js";
+import {
+  prepareConfigForDisabledPluginSet,
+  recordPluginPackageUninstallPlan,
+} from "./uninstall-package-plan.js";
+import { resolvePluginUninstallId } from "./uninstall-selection.js";
+import {
+  applyPluginUninstallDirectoryRemoval,
+  formatUninstallActionLabels,
+  planPluginUninstall,
+  pluginUninstallTargetExists,
+} from "./uninstall.js";
+
+type UninstallRequest = { pluginId: string; env?: NodeJS.ProcessEnv; keepFiles?: boolean };
+type UninstallPolicy = UninstallRequest & { caller: "cli" | "management" };
+export type PreparedPluginUninstall = {
+  snapshot: ConfigSnapshotForInstallPersist;
+  installRecords: Awaited<ReturnType<typeof loadInstalledPluginIndexInstallRecords>>;
+  pluginId: string;
+  requestedPluginId: string;
+  pluginIds: string[];
+  policyPluginIds: string[];
+  name: string;
+  channelIds: string[] | undefined;
+  plan: Extract<ReturnType<typeof planPluginUninstall>, { ok: true }>;
+  planForConfig: (config: OpenClawConfig) => ReturnType<typeof planPluginUninstall>;
+};
+
+type PluginUninstallOutcome = Pick<
+  PreparedPluginUninstall,
+  "pluginId" | "requestedPluginId" | "pluginIds"
+> & {
+  removed: string[];
+  warnings: string[];
+};
+
+function runUninstallPhase<T>(
+  params: UninstallPolicy,
+  phase: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  return params.caller === "cli"
+    ? tracePluginLifecyclePhaseAsync(phase, run, { command: "uninstall" })
+    : run();
+}
+
+async function readUninstallSnapshot(
+  params: UninstallPolicy,
+  phase: string,
+): Promise<ConfigSnapshotForInstallPersist> {
+  return await runUninstallPhase(params, phase, async () => {
+    if (params.caller === "management") {
+      return await readPluginMutationSnapshot(params.env ?? process.env);
+    }
+    const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+    return {
+      config: snapshot.sourceConfig,
+      baseHash: snapshot.hash,
+      writeOptions: selectInstallMutationWriteOptions(writeOptions),
+    };
+  });
+}
+
+/** Read-only plan; execution always replans under its lease after confirmation. */
+export async function preparePluginUninstall(
+  params: UninstallPolicy,
+): Promise<Result<PreparedPluginUninstall, string>> {
+  const env = params.env ?? process.env;
+  const cli = params.caller === "cli";
+  const snapshot = await readUninstallSnapshot(params, "config read");
+  const installRecords = await runUninstallPhase(params, "install records load", () =>
+    loadInstalledPluginIndexInstallRecords(cli ? {} : { env }),
+  );
+  const config = withPluginInstallRecords(snapshot.config, installRecords);
+  // CLI selection uses its status projection; management retains its broader metadata aliases.
+  const metadata = cli ? undefined : loadFreshManagedPluginMetadata(config, env);
+  const index = metadata?.index ?? loadInstalledPluginIndex({ config, installRecords });
+  const plugins = metadata
+    ? metadata.index.plugins.map((record) => {
+        const manifest = metadata.byPluginId.get(record.pluginId);
+        return {
+          id: record.pluginId,
+          name: manifest?.name ?? record.pluginId,
+          origin: record.origin,
+          source: manifest?.source,
+          channelIds: manifest?.channels,
+        };
+      })
+    : tracePluginLifecyclePhase(
+        "plugin registry snapshot",
+        () => buildPluginSnapshotReport({ config }),
+        { command: "uninstall" },
+      ).plugins;
+  const requestedId = metadata
+    ? metadata.normalizePluginId(params.pluginId.trim())
+    : params.pluginId;
+  const selection: Result<{ pluginId: string; plugin?: (typeof plugins)[number] }, string> = cli
+    ? resolvePluginUninstallId({ rawId: requestedId, config, plugins })
+    : ok({ pluginId: requestedId, plugin: plugins.find((plugin) => plugin.id === requestedId) });
+  if (!selection.ok) {
+    return selection;
+  }
+  const { pluginId: requestedPluginId, plugin } = selection.value;
+  if (!cli) {
+    if (plugin?.origin === "bundled") {
+      return err(`bundled plugin cannot be uninstalled: ${requestedPluginId}; disable it instead`);
+    }
+    if (!plugin && !Object.hasOwn(installRecords, requestedPluginId)) {
+      return err(`Plugin not found: ${requestedPluginId}`);
+    }
+  }
+  const ownership = createInstalledPluginOwnershipResolver(index, env).resolveLifecycle(
+    requestedPluginId,
+  );
+  if (!ownership.ok) {
+    return ownership;
+  }
+  const { installOwner: pluginId, pluginIds } = ownership.value;
+  const policyPluginIds = pluginIds.length ? pluginIds : [pluginId];
+  let channelIds: string[] | undefined;
+  if (cli) {
+    if (pluginIds.length === 1 && pluginIds[0] === requestedPluginId) {
+      channelIds = plugin?.channelIds;
+    } else if (pluginIds.length) {
+      channelIds = uniqueStrings(
+        pluginIds.flatMap((id) => plugins.find((entry) => entry.id === id)?.channelIds ?? []),
+      );
+    } else if (
+      createInstalledPluginIndexScopeLookup(index).hasChannelContributionOwners([pluginId])
+    ) {
+      channelIds = [];
+    }
+  } else {
+    const manifests = pluginIds.flatMap((id) => metadata?.byPluginId.get(id) ?? []);
+    channelIds = manifests.length
+      ? uniqueStrings(manifests.flatMap((manifest) => manifest.channels))
+      : ownership.value.kind === "orphan" &&
+          createInstalledPluginIndexScopeLookup(index).hasChannelContributionOwners([pluginId])
+        ? []
+        : undefined;
+  }
+  const runtimeLoadPaths = pluginIds.flatMap(
+    (id) => plugins.find((entry) => entry.id === id)?.source ?? [],
+  );
+  const extensionsDir = resolveDefaultPluginExtensionsDir(cli ? undefined : env);
+  const planForConfig = (source: OpenClawConfig) =>
+    planPluginUninstall(
+      recordPluginPackageUninstallPlan(
+        {
+          config: withPluginInstallRecords(source, installRecords),
+          pluginId,
+          ...(channelIds !== undefined ? { channelIds } : {}),
+          deleteFiles: !params.keepFiles,
+          extensionsDir,
+        },
+        { runtimePluginIds: policyPluginIds, runtimeLoadPaths },
+      ),
+    );
+  const plan = planForConfig(snapshot.config);
+  if (!plan.ok) {
+    return err(
+      cli && plugin
+        ? `Plugin "${pluginId}" is not managed by plugins config/install records and cannot be uninstalled.`
+        : plan.error,
+    );
+  }
+  return ok({
+    snapshot,
+    installRecords,
+    pluginId,
+    requestedPluginId,
+    pluginIds,
+    policyPluginIds,
+    name: plugin?.name || pluginId,
+    channelIds,
+    plan,
+    planForConfig,
+  });
+}
+
+/** Shared leased removal; callbacks preserve CLI output at its original mutation boundaries. */
+export async function uninstallPluginWithPolicy(
+  params: UninstallPolicy & {
+    clawManaged?: boolean;
+    invalidateRuntimeCache?: boolean;
+    beforePersistentApply?: () => void;
+    onPreview?: (preview: PreparedPluginUninstall) => void;
+    onWarning?: (warning: string) => void;
+    onComplete?: (result: PluginUninstallOutcome) => void;
+  },
+): Promise<Result<PluginUninstallOutcome, string>> {
+  const env = params.env ?? process.env;
+  const cli = params.caller === "cli";
+  // Nested CLI calls inherit a Claw owner's exact database lease.
+  return await withPluginLifecycleLease(cli ? {} : { env }, async () => {
+    if (cli) {
+      assertConfigWriteAllowedInCurrentMode();
+    }
+    const preparation = await preparePluginUninstall(params);
+    if (!preparation.ok) {
+      return preparation;
+    }
+    const prepared = preparation.value;
+    params.onPreview?.(prepared);
+    const uninstall = async (): Promise<Result<PluginUninstallOutcome, string>> => {
+      const {
+        pluginId,
+        requestedPluginId,
+        pluginIds,
+        policyPluginIds,
+        installRecords,
+        plan: initialPlan,
+      } = prepared;
+      let plan = initialPlan;
+      let snapshot = prepared.snapshot;
+      const guardedWriteOptions = (options: ConfigSnapshotForInstallPersist["writeOptions"]) =>
+        params.beforePersistentApply
+          ? {
+              ...options,
+              assertConfigPathForWrite: () => {
+                options.assertConfigPathForWrite?.();
+                params.beforePersistentApply?.();
+              },
+            }
+          : options;
+      let directoryResult: Awaited<ReturnType<typeof applyPluginUninstallDirectoryRemoval>> = {
+        directoryRemoved: false,
+        warnings: [],
+      };
+      if (plan.directoryRemoval) {
+        // Remove owned aliases while their realpath still exists; failed deletion remains retryable.
+        await runUninstallPhase(params, "config disable", () =>
+          replaceConfigFile({
+            nextConfig: prepareConfigForDisabledPluginSet(
+              snapshot.config,
+              policyPluginIds,
+              plan.config,
+            ),
+            baseHash: snapshot.baseHash,
+            writeOptions: {
+              ...guardedWriteOptions(snapshot.writeOptions),
+              afterWrite: { mode: "auto" },
+            },
+          }),
+        );
+        params.beforePersistentApply?.();
+        directoryResult = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
+        for (const warning of directoryResult.warnings) {
+          params.onWarning?.(warning);
+        }
+        if (pluginUninstallTargetExists(plan.directoryRemoval.target)) {
+          const message = `Failed to remove plugin directory ${cli ? shortenHomePath(plan.directoryRemoval.target) : plan.directoryRemoval.target}; the plugin remains disabled and tracked so uninstall can be retried.`;
+          throw cli
+            ? new Error(message)
+            : new ManagedPluginLifecycleError(message, { kind: "unavailable" });
+        }
+        snapshot = await readUninstallSnapshot(params, "config reread");
+        const refreshed = prepared.planForConfig(snapshot.config);
+        if (!refreshed.ok) {
+          throw cli ? new Error(refreshed.error) : new ManagedPluginLifecycleError(refreshed.error);
+        }
+        plan = refreshed;
+      }
+      const nextConfig = withoutPluginInstallRecords(plan.config);
+      const nextInstallRecords = removePluginInstallRecordFromRecords(installRecords, pluginId);
+      await runUninstallPhase(params, "config mutation", () =>
+        commitPluginInstallRecordsWithConfig({
+          previousInstallRecords: installRecords,
+          nextInstallRecords,
+          nextConfig,
+          baseHash: snapshot.baseHash,
+          writeOptions: {
+            ...guardedWriteOptions(snapshot.writeOptions),
+            ...(cli
+              ? {
+                  allowConfigSizeDrop: true,
+                  afterWrite: { mode: "restart" as const, reason: "plugin source changed" },
+                }
+              : {}),
+          },
+        }),
+      );
+      const warnings = [
+        ...(!cli
+          ? collectClawPluginUninstallWarnings({
+              pluginId,
+              installRecord: installRecords[pluginId],
+              env,
+            })
+          : []),
+        ...(!cli && (requestedPluginId !== pluginId || pluginIds.length > 1)
+          ? [
+              `Uninstalled package "${pluginId}" and all owned plugin entries: ${pluginIds.join(", ")}.`,
+            ]
+          : []),
+        ...directoryResult.warnings,
+      ];
+      await refreshPluginRegistryAfterConfigMutation({
+        config: nextConfig,
+        env,
+        reason: "source-changed",
+        installRecords: nextInstallRecords,
+        invalidateRuntimeCache: cli ? params.invalidateRuntimeCache : false,
+        ...(cli ? { traceCommand: "uninstall" } : {}),
+        logger: {
+          warn: (message) => {
+            warnings.push(message);
+            params.onWarning?.(message);
+          },
+        },
+      });
+      if (!cli) {
+        refreshManagedPluginMetadata({ config: nextConfig, env });
+      }
+      const result = {
+        pluginId,
+        requestedPluginId,
+        pluginIds,
+        removed: formatUninstallActionLabels({
+          ...plan.actions,
+          loadPath: initialPlan.actions.loadPath || plan.actions.loadPath,
+          directory: directoryResult.directoryRemoved,
+        }),
+        warnings: [...new Set(warnings)],
+      };
+      // Report committed work before either lease fence can raise a late ownership error.
+      params.onComplete?.(result);
+      return ok(result);
+    };
+    const record = prepared.installRecords[prepared.pluginId];
+    const packageName =
+      record?.source === "clawhub"
+        ? (record.clawhubPackage ?? parseClawHubPluginSpec(record.spec ?? "")?.name)
+        : undefined;
+    if (!cli || params.clawManaged || !packageName) {
+      return await uninstall();
+    }
+    return await withClawPackageLifecycleLease(
+      { kind: "plugin", source: "clawhub", ref: packageName },
+      uninstall,
+      { required: true },
+    );
+  });
+}
+
+/** Preserve the management API's canonical-id admission and response shape. */
+export async function uninstallManagedPlugin(params: {
+  pluginId: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<{ pluginId: string; removed: string[]; warnings?: string[] }> {
+  const env = params.env ?? process.env;
+  return await withPluginLifecycleLease({ env }, async () => {
+    const result = await uninstallPluginWithPolicy({ ...params, caller: "management" });
+    if (!result.ok) {
+      throw new ManagedPluginLifecycleError(result.error);
+    }
+    const { pluginId, removed, warnings } = result.value;
+    return { pluginId, removed, ...(warnings.length ? { warnings } : {}) };
+  });
+}

--- a/src/plugins/uninstall-selection.ts
+++ b/src/plugins/uninstall-selection.ts
@@ -2,7 +2,7 @@
 import { err as resultError, ok, type Result } from "@openclaw/normalization-core/result";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
-import type { PluginRecord } from "../plugins/registry.js";
+import type { PluginRecord } from "./registry.js";
 
 /** Resolve user input to the plugin id that should be removed from config/install records. */
 export function resolvePluginUninstallId<

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -39,7 +39,7 @@ type UninstallActions = PluginConfigUninstallActions & {
   directory: boolean;
 };
 
-export const UNINSTALL_ACTION_LABELS = {
+const UNINSTALL_ACTION_LABELS = {
   entry: "plugin settings",
   install: "install record",
   allowlist: "allowlist entry",
@@ -63,19 +63,31 @@ const UNINSTALL_ACTION_ORDER = [
   "directory",
 ] as const satisfies ReadonlyArray<keyof UninstallActions>;
 
-export function formatUninstallActionLabels(actions: UninstallActions): string[] {
-  return UNINSTALL_ACTION_ORDER.flatMap((key) =>
-    actions[key] ? [UNINSTALL_ACTION_LABELS[key]] : [],
-  );
+export function formatUninstallActionLabels(
+  actions: UninstallActions,
+  preview?: { channelConfigKeys: readonly string[] },
+): string[] {
+  return UNINSTALL_ACTION_ORDER.flatMap((key) => {
+    if (!actions[key]) {
+      return [];
+    }
+    if (preview) {
+      if (key === "memorySlot" || key === "contextEngineSlot") {
+        const slot = key === "memorySlot" ? "memory" : "contextEngine";
+        return [`${UNINSTALL_ACTION_LABELS[key]} (will reset to "${defaultSlotIdForKey(slot)}")`];
+      }
+      if (key === "channelConfig") {
+        return preview.channelConfigKeys.map(
+          (id) => `${UNINSTALL_ACTION_LABELS.channelConfig} (channels.${id})`,
+        );
+      }
+    }
+    return [UNINSTALL_ACTION_LABELS[key]];
+  });
 }
 
 function hasUninstallAction(actions: PluginConfigUninstallActions): boolean {
   return Object.values(actions).some(Boolean);
-}
-
-export function formatUninstallSlotResetPreview(slotKey: "memory" | "contextEngine"): string {
-  const actionKey = slotKey === "memory" ? "memorySlot" : "contextEngineSlot";
-  return `${UNINSTALL_ACTION_LABELS[actionKey]} (will reset to "${defaultSlotIdForKey(slotKey)}")`;
 }
 
 export type PluginUninstallDirectoryRemoval = {


### PR DESCRIPTION
The CLI and management API separately planned plugin removal and implemented its disable, file-removal and final config/index writes. Share that operation in one owner, with fresh preparation after confirmation and one plan factory for the post-removal config reread. Keep CLI presentation and management response shaping in their adapters.

Preserve existing selection, include/hash, write and cache policies. Owned aliases leave config in the guarded disable write while their realpaths still exist; failed removal stays disabled and tracked for retry, and the final reread preserves intervening edits. Claw callers retain their active database lease, package-lease ownership and clawManaged behavior. Synchronous authority checks remain at disable, deletion and final commit; warnings and completion remain inside the relevant lease boundaries. The strict snapshot reader and selection resolver move to shared owners, and preview action formatting removes obsolete helper exports.

Validation: 208 distinct owner and upstream tests passed, including a RED/GREEN inherited-lease regression, real deletion-boundary assertions, package siblings, aliases, retry, confirmation changes and three authority checks. The final formatter/CLI subset passed 112 cases. The complete changed-code gate, both unused-file scans and an independent P0–P2 review passed. Fourteen real CLI scenarios (31 CLI/build commands) matched the baseline’s outputs, exits, config, records and files; source/build/dependency hashes and the compiled CLI-to-owner import chain are bound to the evidence. These runs used generated local packages and isolated state.

Rebased onto landed toggle main `3b90108d098eaf445a57f8081b3b483cbfc97148`. Fresh composition validation passed 99 owner tests, core and test types, focused lint, import-cycle checks and an independent P0–P2 review. The earlier live CLI proof is reused only for byte-identical uninstall/config code and its immediate caller/callee closure; the rebase retains main’s new toggle bodies and required imports. Dependency declarations and the lockfile are unchanged. No new live run is claimed for this mechanical integration.

Production LOC: 563 added, 613 removed, net −50; tests +44; assertion metadata −1. Moves are counted on both sides. Part of the smaller refactors extracted from #135599.

Follow-up investigation: establish config ownership for differently named standalone file aliases that change discovery identity. Baseline observations are retained without labeling them a confirmed bug; the entry-alias parity fixture preserves the original basename and follows the standalone-file schema contract.

Review follow-through: the latest ClawSweeper technical review identifies no correctness findings and explicitly calls the migration-proof blocker unsupported. Its generated checklist still asks for data-model compatibility proof; that item is skipped because `management-config.ts` extracts the existing strict reader unchanged. The PR adds no schema, migration, persisted representation or persistence semantics. The real CLI parity cases already compare the resulting config, install records and files.

CI investigation: the first run hit a 120-second timeout in an unchanged profiler help test. The exact 14-file shard order passed 480 cases on isolated Linux, followed by 340 profiler replay cases; instrumentation observed all 264 child processes exit and close. The intermittent cause remains unattributed. No timeout increase or assertion weakening was applied; only the failed CI jobs were retried.
