### PR TITLE
refactor(update): simplify transaction candidate bookkeeping

### DIFF
--- a/src/cli/update-cli/update-command-execution.ts
+++ b/src/cli/update-cli/update-command-execution.ts
@@ -334,7 +334,6 @@ export async function executeMutableUpdate(params: {
     let validation = await validate();
     if (validation.status === "error") {
       candidateFailureReason = validation.reason;
-      const failedValidation = validation;
       const repair = await runUpdateCommandRepair({
         root: params.root,
         candidateRoot: root,
@@ -349,14 +348,14 @@ export async function executeMutableUpdate(params: {
               ? "git"
               : (params.packageInstallTarget?.manager ?? "unknown"),
           root,
-          reason: failedValidation.reason,
+          reason: validation.reason,
           before: { version: await readPackageVersion(params.root) },
           after: { version: await readPackageVersion(root) },
-          steps: failedValidation.steps,
-          durationMs: failedValidation.durationMs,
+          steps: validation.steps,
+          durationMs: validation.durationMs,
         },
         validate: async (signal, assertCurrent, rehearsal) => {
-          validation = await validate(signal, rehearsal, assertCurrent);
+          const validation = await validate(signal, rehearsal, assertCurrent);
           return {
             ok: validation.status === "ok",
             score: validation.steps.filter((step) => step.exitCode === 0).length,
@@ -374,7 +373,7 @@ export async function executeMutableUpdate(params: {
         ) {
           candidateFailureReason = repair.reason;
         }
-        return failedValidation.steps;
+        return validation.steps;
       }
       candidateFailureReason = undefined;
       // Repair's disposable state is gone; only surviving candidate changes may authorize activation.

--- a/src/cli/update-cli/update-command-execution.ts
+++ b/src/cli/update-cli/update-command-execution.ts
@@ -355,14 +355,14 @@ export async function executeMutableUpdate(params: {
           durationMs: validation.durationMs,
         },
         validate: async (signal, assertCurrent, rehearsal) => {
-          const validation = await validate(signal, rehearsal, assertCurrent);
+          const repairValidation = await validate(signal, rehearsal, assertCurrent);
           return {
-            ok: validation.status === "ok",
-            score: validation.steps.filter((step) => step.exitCode === 0).length,
+            ok: repairValidation.status === "ok",
+            score: repairValidation.steps.filter((step) => step.exitCode === 0).length,
             summary:
-              validation.status === "ok"
+              repairValidation.status === "ok"
                 ? "Candidate validation passed."
-                : validation.logTail.join("\n"),
+                : repairValidation.logTail.join("\n"),
           };
         },
       });

--- a/src/cli/update-cli/update-command-migrated.ts
+++ b/src/cli/update-cli/update-command-migrated.ts
@@ -161,7 +161,6 @@ export async function continueMigratedUpdateInFreshProcess(
               : {}),
           },
         },
-        result,
         rollbackBlockedReason: params.rollbackBlockedReason ?? "state-migrated-no-rollback",
         ...(preManagedServiceStop ? { preManagedServiceStop: stopState } : {}),
       },

--- a/src/cli/update-cli/update-command-rollback.ts
+++ b/src/cli/update-cli/update-command-rollback.ts
@@ -66,20 +66,18 @@ export async function rollbackFailedUpdate(params: {
   const port = before?.stopped
     ? await resolveUpdatedGatewayRestartPort({ config: params.config, serviceEnv: env })
     : undefined;
-  const failed = (reason: string) => {
-    return {
-      result: {
-        ...result,
-        status: "error" as const,
-        reason:
-          result.recovery?.serviceRestartSafe === true && result.recovery.packageRollbackVerified
-            ? (params.result.reason ?? reason)
-            : reason,
-      },
-      rolledBack: false,
-      stoppedForRollback,
-    };
-  };
+  const failed = (reason: string) => ({
+    result: {
+      ...result,
+      status: "error" as const,
+      reason:
+        result.recovery?.serviceRestartSafe === true && result.recovery.packageRollbackVerified
+          ? (params.result.reason ?? reason)
+          : reason,
+    },
+    rolledBack: false,
+    stoppedForRollback,
+  });
   const stateUnchanged = async () => {
     const baseline = params.schemaVersions;
     const current = await readUpdateStateSchemaVersions({

--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -599,7 +599,7 @@ async function prepareStagedPackageInstall(
       const packageRoot = path.join(native.globalRoot, packageName);
       return {
         stagedInstall: {
-          prefix: native.prefix,
+          prefix: native.projectRoot,
           layout: {
             prefix: native.projectRoot,
             globalRoot: native.globalRoot,

--- a/src/infra/update-candidate-canary.ts
+++ b/src/infra/update-candidate-canary.ts
@@ -154,7 +154,7 @@ export async function validateUpdateCandidateCanary(params: {
     });
     let stdout = "";
     let outputExceeded = false;
-    child.stdout?.on("data", (chunk: Buffer) => {
+    child.stdout.on("data", (chunk: Buffer) => {
       if (stdout.length + chunk.length <= 1024 * 1024) {
         stdout += chunk.toString("utf8");
       } else {
@@ -164,7 +164,7 @@ export async function validateUpdateCandidateCanary(params: {
     const flushers = [child.stdout, child.stderr].map((stream) => {
       let pending = "";
       let droppingLine = false;
-      stream?.on("data", (chunk: Buffer) => {
+      stream.on("data", (chunk: Buffer) => {
         let text = chunk.toString("utf8");
         if (droppingLine) {
           const newline = text.indexOf("\n");
@@ -433,8 +433,9 @@ export async function validateUpdateCandidateCanary(params: {
     capture(
       `${phase}: ${error instanceof Error ? error.message : String(error)} (${Date.now() - started}ms)`,
     );
-    if (!steps.length || steps.at(-1)?.exitCode === 0 || steps.at(-1)?.advisory) {
-      steps.push({
+    let failed = steps.at(-1);
+    if (!failed || failed.exitCode === 0 || failed.advisory) {
+      failed = {
         name:
           phase === "startup" || phase === "readiness"
             ? "candidate gateway canary"
@@ -443,13 +444,11 @@ export async function validateUpdateCandidateCanary(params: {
         cwd: params.root,
         durationMs: Date.now() - started,
         exitCode: 1,
-      });
+      };
+      steps.push(failed);
     }
-    const failed = steps.at(-1);
-    if (failed) {
-      failed.stderrTail = logTail.join("\n");
-      params.onStep?.(failed);
-    }
+    failed.stderrTail = logTail.join("\n");
+    params.onStep?.(failed);
     return {
       status: "error",
       reason:

--- a/src/infra/update-candidate-rehearsal.ts
+++ b/src/infra/update-candidate-rehearsal.ts
@@ -82,9 +82,7 @@ function isolatedConfig(
   // Copy effective config, never its include graph or ambient shell overrides.
   delete copied.env;
   delete copied.diagnostics;
-  if (copied.session) {
-    delete copied.session.store;
-  }
+  delete copied.session?.store;
   copied.logging = { ...copied.logging, file: path.join(stateDir, "canary.log") };
   copied.gateway = {
     ...copied.gateway,
@@ -124,6 +122,8 @@ export async function prepareUpdateCandidateRehearsal(params: {
   };
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-canary-"));
   const sourceEnv = params.env ?? process.env;
+  const configPath = path.join(tempDir, "openclaw.json");
+  const workspaceDir = path.join(tempDir, "workspace");
   const copiedAgentDir = (directory: string | undefined) =>
     directory?.trim()
       ? resolveUpdateCandidateStatePath(
@@ -145,8 +145,8 @@ export async function prepareUpdateCandidateRehearsal(params: {
     XDG_STATE_HOME: path.join(tempDir, "state"),
     OPENCLAW_HOME: tempDir,
     OPENCLAW_STATE_DIR: tempDir,
-    OPENCLAW_CONFIG_PATH: path.join(tempDir, "openclaw.json"),
-    OPENCLAW_WORKSPACE_DIR: path.join(tempDir, "workspace"),
+    OPENCLAW_CONFIG_PATH: configPath,
+    OPENCLAW_WORKSPACE_DIR: workspaceDir,
     OPENCLAW_AGENT_DIR: copiedAgentDir(sourceEnv.OPENCLAW_AGENT_DIR),
     PI_CODING_AGENT_DIR: copiedAgentDir(sourceEnv.PI_CODING_AGENT_DIR),
     OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
@@ -237,26 +237,25 @@ export async function prepareUpdateCandidateRehearsal(params: {
       isolatedConfig(params.config, path.resolve(params.stateDir), tempDir, port, sourceEnv),
     );
     const baseline: Record<string, unknown> = JSON.parse(serialized);
-    await fs.writeFile(env.OPENCLAW_CONFIG_PATH!, serialized, { mode: 0o600 });
-    await fs.mkdir(env.OPENCLAW_WORKSPACE_DIR!, { recursive: true, mode: 0o700 });
+    await fs.writeFile(configPath, serialized, { mode: 0o600 });
+    await fs.mkdir(workspaceDir, { recursive: true, mode: 0o700 });
     return {
       sourceConfig: params.config,
       sourceConfigHash: params.sourceConfigHash,
       stateDir: tempDir,
-      configPath: env.OPENCLAW_CONFIG_PATH!,
-      workspaceDir: env.OPENCLAW_WORKSPACE_DIR!,
+      configPath,
+      workspaceDir,
       env,
       port,
       changedConfigKeys: async () => {
-        const current: unknown = JSON5.parse(await fs.readFile(env.OPENCLAW_CONFIG_PATH!, "utf8"));
+        const current: unknown = JSON5.parse(await fs.readFile(configPath, "utf8"));
         if (!isRecord(current)) {
           throw new Error("Rehearsal config is not an object.");
         }
         // Compare against the same live config projection: private paths, the
         // canary token and disabled background services are isolation, not repairs.
-        const before = baseline;
-        return [...new Set([...Object.keys(before), ...Object.keys(current)])]
-          .filter((key) => !isDeepStrictEqual(before[key], current[key]))
+        return [...new Set([...Object.keys(baseline), ...Object.keys(current)])]
+          .filter((key) => !isDeepStrictEqual(baseline[key], current[key]))
           .toSorted();
       },
       cleanup: () => fs.rm(tempDir, { recursive: true, force: true }),

--- a/src/infra/update-native-package-stage.ts
+++ b/src/infra/update-native-package-stage.ts
@@ -18,7 +18,6 @@ import {
 } from "./update-runtime-relocation.js";
 
 export type NativePackageStage = {
-  prefix: string;
   projectRoot: string;
   liveProjectRoot: string;
   binDir: string;
@@ -141,7 +140,7 @@ export async function prepareNativePackageStage(params: {
   const fingerprint = await nativeProjectFingerprint(liveProjectRoot);
   // pnpm cleans unreferenced children of its global layout. Keep both the stage and
   // retained project backup outside that layout so validation cannot race its cleaner.
-  const prefix = await fs.mkdtemp(
+  const projectRoot = await fs.mkdtemp(
     path.join(
       path.dirname(liveProjectRoot),
       `.${path.basename(params.packageName)}-update-native-`,
@@ -149,10 +148,9 @@ export async function prepareNativePackageStage(params: {
   );
   // A sibling project preserves the depth of relative file:/link: dependency specs.
   // Its separate bin directory is disposable even after activation moves the project.
-  const projectRoot = prefix;
   let binDir: string | undefined;
   try {
-    binDir = await fs.mkdtemp(`${prefix}.bin-`);
+    binDir = await fs.mkdtemp(`${projectRoot}.bin-`);
     await fs.cp(liveProjectRoot, projectRoot, { recursive: true, verbatimSymlinks: true });
     await fs.chmod(projectRoot, (await fs.stat(liveProjectRoot)).mode);
     const relocations: RuntimeRelocation[] = [
@@ -203,7 +201,6 @@ export async function prepareNativePackageStage(params: {
     const pathKey = Object.keys(env).find((key) => key.toUpperCase() === "PATH") ?? "PATH";
     env[pathKey] = mergePathPrepend(env[pathKey], [binDir]);
     return {
-      prefix,
       projectRoot,
       liveProjectRoot,
       binDir,
@@ -220,7 +217,7 @@ export async function prepareNativePackageStage(params: {
       },
     };
   } catch (error) {
-    await fs.rm(prefix, { recursive: true, force: true });
+    await fs.rm(projectRoot, { recursive: true, force: true });
     if (binDir) {
       await fs.rm(binDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Related: #138839, #139495.

## What Problem This Solves

Maintainer-requested, behavior-neutral deslop of the landed update-flow campaign's transaction core. The campaign left duplicate staged-path state, redundant validation aliases, and guards around output streams already guaranteed by their owner.

## Why This Change Was Made

Use the native stage's existing project root as its single path identity and keep rehearsal paths as typed strings. Narrow the canary's failing step once, keep repair validation local to its callback, and remove redundant recovery-result wrapping and an obsolete serialization override.

The pre-swap mutation seam, pre-move inventory capture, verified backup retirement, older-target advisory, rehearsal isolation, requester predicates, and Windows recovery ownership remain intact. Changes are limited to campaign-introduced code from #138839 and #139495.

## User Impact

None. Update behavior, recovery, protocol, configuration, schemas, CLI output, and error text are unchanged. No tests, documentation, changelogs, snapshots, or baselines changed.

## Evidence

- Before and after: the same 48 test files, **910 passed and 3 skipped** each. Saved per-test identities and outcomes compare identically. Both staged-repair isolation E2E cases passed.
- `pnpm build`: passed before and after; the final build passed in 2m16s with zero `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings. Helper lifecycle tests used fresh build output; the test runner also prepared its private QA runtime.
- Full `pnpm check:changed`: passed, including production/test types, all three Knip scans, lint, and zero runtime import cycles. The check used a separate Vitest cache. An initial run found a shadowed local; it was renamed, and the complete gate was rerun successfully. The interrupted intermediate test run is excluded from the before/after proof.
- Codex autoreview: final committed branch against `origin/main`, high reasoning, scoped clean at P0/P1.
- Exact-head CI: [run 34047959274](https://github.com/openclaw/openclaw/actions/runs/34047959274) passed at `fc114f7cb890334b56ba56721ba2e33323e1ba65`; the repository PR CI watcher reported `GREEN` with zero pending checks.
- `git diff --check`: passed.
- `git diff --numstat origin/main...HEAD`: production **+46 / −55 (net -9)**; tests **0 / 0**; docs **0 / 0**. No suppressions or baseline changes.

<details>
<summary>Identical before/after test files and results</summary>

| Test file | Before | After |
| --- | --- | --- |
| `src/cli/update-cli/progress.test.ts` | 4 passed | 4 passed |
| `src/cli/update-cli/restart-helper.launchd-system.test.ts` | 1 passed | 1 passed |
| `src/cli/update-cli/restart-helper.test.ts` | 53 passed, 1 skipped | 53 passed, 1 skipped |
| `src/cli/update-cli/schema-preflight.test.ts` | 4 passed | 4 passed |
| `src/cli/update-cli/shared.command-runner.test.ts` | 12 passed | 12 passed |
| `src/cli/update-cli/update-command-config-snapshot.test.ts` | 4 passed | 4 passed |
| `src/cli/update-cli/update-command-fresh-doctor.test.ts` | 8 passed | 8 passed |
| `src/cli/update-cli/update-command-handoff.test.ts` | 6 passed | 6 passed |
| `src/cli/update-cli/update-command-inference.test.ts` | 3 passed | 3 passed |
| `src/cli/update-cli/update-command-lease.test.ts` | 29 passed | 29 passed |
| `src/cli/update-cli/update-command-lifecycle.test.ts` | 4 passed | 4 passed |
| `src/cli/update-cli/update-command-migrated-windows.test.ts` | 4 passed | 4 passed |
| `src/cli/update-cli/update-command-migrated.test.ts` | 3 passed | 3 passed |
| `src/cli/update-cli/update-command-post-core.test.ts` | 17 passed | 17 passed |
| `src/cli/update-cli/update-command-post-update-recovery.test.ts` | 42 passed | 42 passed |
| `src/cli/update-cli/update-command-post-update-repair.test.ts` | 14 passed | 14 passed |
| `src/cli/update-cli/update-command-post-update.test.ts` | 31 passed | 31 passed |
| `src/cli/update-cli/update-command-repair-isolation.e2e.test.ts` | 2 passed | 2 passed |
| `src/cli/update-cli/update-command-report.test.ts` | 8 passed | 8 passed |
| `src/cli/update-cli/update-command-rollback.test.ts` | 22 passed | 22 passed |
| `src/cli/update-cli/update-command-run.test.ts` | 2 passed | 2 passed |
| `src/cli/update-cli/update-command-service-command.process.test.ts` | 3 passed | 3 passed |
| `src/cli/update-cli/update-command-service-maintenance.test.ts` | 23 passed | 23 passed |
| `src/cli/update-cli/update-command-service.integration.test.ts` | 123 passed | 123 passed |
| `src/cli/update-cli/update-command-service.test.ts` | 8 passed | 8 passed |
| `src/cli/update-cli/update-command-triage.test.ts` | 24 passed | 24 passed |
| `src/cli/update-cli/update-command-windows-task.test.ts` | 2 passed | 2 passed |
| `src/cli/update-cli/update-command-wrapper-retirement.test.ts` | 2 passed | 2 passed |
| `src/cli/update-cli/update-command.test.ts` | 51 passed | 51 passed |
| `src/cli/update-cli/update-execution.runtime.test.ts` | 1 passed | 1 passed |
| `src/cli/update-cli/update-package-executor.test.ts` | 8 passed | 8 passed |
| `src/infra/package-update-steps.native-transaction.test.ts` | 23 passed | 23 passed |
| `src/infra/package-update-steps.pnpm11-guard.test.ts` | 15 passed | 15 passed |
| `src/infra/package-update-steps.recovery.test.ts` | 35 passed | 35 passed |
| `src/infra/package-update-steps.source-checkout.test.ts` | 39 passed | 39 passed |
| `src/infra/package-update-steps.staging.test.ts` | 2 passed | 2 passed |
| `src/infra/package-update-steps.test.ts` | 28 passed | 28 passed |
| `src/infra/package-update-swap.test.ts` | 5 passed | 5 passed |
| `src/infra/package-update-utils.test.ts` | 7 passed | 7 passed |
| `src/infra/update-candidate-canary.integration.test.ts` | 1 passed | 1 passed |
| `src/infra/update-candidate-canary.test.ts` | 13 passed | 13 passed |
| `src/infra/update-candidate-state.test.ts` | 6 passed | 6 passed |
| `src/infra/update-managed-service-handoff-command.test.ts` | 5 passed | 5 passed |
| `src/infra/update-managed-service-handoff-cross-process.test.ts` | 14 passed, 1 skipped | 14 passed, 1 skipped |
| `src/infra/update-managed-service-handoff-lifecycle.test.ts` | 164 passed | 164 passed |
| `src/infra/update-managed-service-handoff-ownership.test.ts` | 10 passed, 1 skipped | 10 passed, 1 skipped |
| `src/infra/update-managed-service-handoff-single-flight.test.ts` | 21 passed | 21 passed |
| `src/infra/update-native-package-stage.test.ts` | 4 passed | 4 passed |

Command: `pnpm test` with the identical explicit file list above.

</details>
