### PR TITLE
refactor(plugins): use canonical runtime type contracts

### DIFF
--- a/src/plugins/runtime/runtime-agent.ts
+++ b/src/plugins/runtime/runtime-agent.ts
@@ -48,38 +48,16 @@ import { resolveRuntimeThinkingCatalog } from "./runtime-agent-thinking.js";
 import { defineCachedValue } from "./runtime-cache.js";
 import type { PluginRuntime } from "./types.js";
 
-type RuntimeSessionStoreReadParams = {
-  agentId?: string;
-  env?: NodeJS.ProcessEnv;
-  hydrateSkillPromptRefs?: boolean;
-  sessionKey: string;
-  readConsistency?: "latest";
-  storePath?: string;
-};
-
-type RuntimeSessionStoreListParams = Partial<Omit<RuntimeSessionStoreReadParams, "sessionKey">> & {
-  readOnly?: boolean;
-};
-
-type RuntimeSessionStoreEntrySummary = {
-  sessionKey: string;
-  entry: SessionEntry;
-};
-
-type RuntimeSessionStoreEntryUpdateParams = {
-  storePath: string;
-  sessionKey: string;
-  update: (
-    entry: SessionEntry,
-  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null;
-  skipMaintenance?: boolean;
-  takeCacheOwnership?: boolean;
-  requireWriteSuccess?: boolean;
-};
-
-type RuntimeUpsertSessionEntryParams = RuntimeSessionStoreReadParams & {
-  entry: SessionEntry;
-};
+type RuntimeSession = PluginRuntime["agent"]["session"];
+type RuntimeSessionStoreReadParams = Parameters<RuntimeSession["getSessionEntry"]>[0];
+type RuntimeSessionStoreListParams = NonNullable<
+  Parameters<RuntimeSession["listSessionEntries"]>[0]
+>;
+type RuntimeSessionStoreEntrySummary = ReturnType<RuntimeSession["listSessionEntries"]>[number];
+type RuntimeSessionStoreEntryUpdateParams = Parameters<
+  RuntimeSession["updateSessionStoreEntry"]
+>[0];
+type RuntimeUpsertSessionEntryParams = Parameters<RuntimeSession["upsertSessionEntry"]>[0];
 
 const loadEmbeddedAgentRuntime = createLazyRuntimeModule(
   () => import("./runtime-embedded-agent.runtime.js"),

--- a/src/plugins/runtime/types-channel.ts
+++ b/src/plugins/runtime/types-channel.ts
@@ -17,6 +17,7 @@ import type {
   MatchesMentionWithExplicit,
 } from "../../auto-reply/reply/mentions.types.js";
 import type { CreateReplyDispatcherWithTyping } from "../../auto-reply/reply/reply-dispatcher.runtime-types.js";
+import type { ChannelRuntimeContextRegistry } from "../../channels/plugins/channel-runtime-surface.types.js";
 import type { LoadChannelOutboundAdapter } from "../../channels/plugins/outbound/load.types.js";
 import type { ResolveMarkdownTableMode } from "../../config/markdown-tables.types.js";
 import type {
@@ -42,39 +43,6 @@ type RuntimeThreadBindingLifecycleRecord =
       idleTimeoutMs?: number;
       maxAgeMs?: number;
     };
-
-type PluginRuntimeChannelContextKey = {
-  channelId: string;
-  accountId?: string | null;
-  capability: string;
-};
-
-type PluginRuntimeChannelContextEvent = {
-  type: "registered" | "unregistered";
-  key: {
-    channelId: string;
-    accountId?: string;
-    capability: string;
-  };
-  context?: unknown;
-};
-
-type PluginRuntimeChannelContextRegistry = {
-  register: (
-    params: PluginRuntimeChannelContextKey & {
-      context: unknown;
-      abortSignal?: AbortSignal;
-    },
-  ) => { dispose: () => void };
-  // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Runtime context values are caller-typed by key.
-  get: <T = unknown>(params: PluginRuntimeChannelContextKey) => T | undefined;
-  watch: (params: {
-    channelId?: string;
-    accountId?: string | null;
-    capability?: string;
-    onEvent: (event: PluginRuntimeChannelContextEvent) => void;
-  }) => () => void;
-};
 
 export type PluginRuntimeChannel = {
   text: {
@@ -205,5 +173,5 @@ export type PluginRuntimeChannel = {
       maxAgeMs: number;
     }) => RuntimeThreadBindingLifecycleRecord[];
   };
-  runtimeContexts: PluginRuntimeChannelContextRegistry;
+  runtimeContexts: ChannelRuntimeContextRegistry;
 };

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -253,7 +253,6 @@ describe("production lint suppressions", () => {
         "src/plugins/public-surface-loader.ts|typescript/no-unnecessary-type-parameters|3",
         "src/plugins/registry-state.ts|unicorn/no-array-sort|1",
         "src/plugins/runtime/runtime-plugin-boundary.ts|typescript/no-unnecessary-type-parameters|1",
-        "src/plugins/runtime/types-channel.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/trusted-tool-policy.ts|typescript/no-unnecessary-type-parameters|1",
         // The queue ring reserves sparse capacity and reads only its occupied slots.
         "src/process/command-queue.state.ts|unicorn/no-new-array|1",


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Plugin runtime typings duplicated contracts already owned by the channel-context registry and public agent-session surface. Maintaining both copies could let internal and SDK-facing definitions drift.

## Why This Change Was Made

Reuse the canonical channel registry type and derive the five existing private session aliases from `PluginRuntime.agent.session`. This removes the duplicate declarations without adding compatibility layers or changing implementation code, exports, dependencies, configuration, storage, or lifecycle behavior. The follow-up removes the obsolete lint-suppression inventory row for the deleted duplicate; its canonical owner's row and all four test cases remain intact.

Production: **+12/-66, net -54 lines** across two files. Tests: **+0/-1**.

## User Impact

No user-visible or public API change. Plugin developers retain the same generic callbacks, optional arguments, nullable fields, and SDK contracts; their definitions now have one authoritative owner.

## Evidence

Production cleanup `af5b7c3b62fd0f33c4c913a46089f34b15e5b800` retains its tested production bytes. Signed follow-up `9d2e950003852b78e3b742e22132cfb0551f62be` changes only the obsolete test expectation; its full tree matches the corrected test/check proof. Exact-commit reviews ran after the respective saves.

- Original strict checks covered both optionality modes and discriminating negative controls; original and candidate actual-property checks passed. Real compiler JavaScript emission is byte-identical for both production modules. The agent declaration is identical; the channel declaration only replaces its private duplicate with the canonical imported type. Proof-only fixture corrections remain recorded.
- The normal default production gate passed all **28 checks**: [run 34040667203](https://github.com/openclaw/openclaw/actions/runs/34040667203). One normal full build passed all **16 phases**, including executed declaration builds, SDK checks, and UI build: [run 34043466714](https://github.com/openclaw/openclaw/actions/runs/34043466714). Local build attempts stopped before launch on disk capacity; the configured remote route and normal settings were preserved. Bounded postbuild metadata corroborated package closure; no complete output-corpus retrieval or strict packed-release install is claimed.
- [Initial PR CI 34048408532](https://github.com/openclaw/openclaw/actions/runs/34048408532) caught our missed inventory update: the deleted suppression left one stale expected row. The normal four-case test reproduced exactly **3 passed / 1 failed**; removing only that row made **all 4 pass**. The full **15-check** targeted follow-through then passed on configured Linux Node 24: [run 34050573859](https://github.com/openclaw/openclaw/actions/runs/34050573859). No collector, assertion, other row, or test case was changed, and the production build/compiler proof was not repeated.
- Codex reviews through P2 found no actionable issues, including the separate exact-commit review of `9d2e9500`. An earlier precommit review had an unresolved CLI-selection provenance gap; it was retained, not relabeled. Later exact-commit reviews freshly bound the normally resolved absolute CLI and verified observed native arguments/hashes.

All owned proof leases and reviewer processes are closed. [Exact-head PR CI 34053169801](https://github.com/openclaw/openclaw/actions/runs/34053169801) completed successfully on `9d2e950003852b78e3b742e22132cfb0551f62be` (107 successful jobs, 17 skipped), including the previously failing suppression-inventory job. The latest completed ClawSweeper review reports no findings or before-merge actions. Native metadata, artifact validation and source qualification are complete; normal hosted preparation and merge remain separate steps. This evidence does not claim the PR is landed.
