### PR TITLE
refactor(gateway): share empty workspace directory cleanup

### DIFF
--- a/src/gateway/worker-environments/workspace-reconcile-core.ts
+++ b/src/gateway/worker-environments/workspace-reconcile-core.ts
@@ -22,6 +22,7 @@ import {
   entryMatches,
   localPath,
   readWorkspaceFileSnapshot,
+  removeEmptyWorkspaceDirectory,
 } from "./workspace-reconcile-fs.js";
 export {
   MAX_RECONCILIATION_ENTRIES,
@@ -307,32 +308,7 @@ export async function applyWorkspaceDirectoryChanges(params: {
       // A concurrent local replacement or chmod wins and becomes a conflict.
       continue;
     }
-    let children: string[];
-    try {
-      children = await workspaceRoot.list(entryPath);
-    } catch (error) {
-      if (error instanceof FsSafeError && ["not-found", "path-alias"].includes(error.code)) {
-        continue;
-      }
-      throw error;
-    }
-    if (children.length > 0) {
-      // Conflicted descendants deliberately keep their containing directory
-      // even when the cloud result removed that directory.
-      continue;
-    }
-    try {
-      await workspaceRoot.remove(entryPath);
-    } catch (error) {
-      if (error instanceof FsSafeError && ["not-found", "path-alias"].includes(error.code)) {
-        continue;
-      }
-      const racedChildren = await workspaceRoot.list(entryPath).catch(() => undefined);
-      if (racedChildren?.length) {
-        continue;
-      }
-      throw error;
-    }
+    await removeEmptyWorkspaceDirectory(workspaceRoot, entryPath);
   }
 }
 

--- a/src/gateway/worker-environments/workspace-reconcile-fs.ts
+++ b/src/gateway/worker-environments/workspace-reconcile-fs.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { FsSafeError, type Root } from "../../infra/fs-safe.js";
 import type { createStagedInputPathMatcher } from "../../media/staged-inputs.js";
 import { runCommandBuffered } from "../../process/exec.js";
 import { readWorkspaceFileSnapshotWithLimit } from "./workspace-actual-manifest.js";
@@ -13,6 +14,35 @@ const PATCH_TIMEOUT_MS = 10 * 60_000;
 
 export function localPath(root: string, relative: string): string {
   return path.join(root, ...relative.split("/"));
+}
+
+export async function removeEmptyWorkspaceDirectory(root: Root, entryPath: string): Promise<void> {
+  let children: string[];
+  try {
+    children = await root.list(entryPath);
+  } catch (error) {
+    if (error instanceof FsSafeError && ["not-found", "path-alias"].includes(error.code)) {
+      return;
+    }
+    throw error;
+  }
+  if (children.length > 0) {
+    // Conflicted descendants deliberately keep their containing directory
+    // even when the cloud result removed that directory.
+    return;
+  }
+  try {
+    await root.remove(entryPath);
+  } catch (error) {
+    if (error instanceof FsSafeError && ["not-found", "path-alias"].includes(error.code)) {
+      return;
+    }
+    const racedChildren = await root.list(entryPath).catch(() => undefined);
+    if (racedChildren?.length) {
+      return;
+    }
+    throw error;
+  }
 }
 
 type WorkspaceFileSnapshot =

--- a/src/gateway/worker-environments/workspace-reconcile-recovery.ts
+++ b/src/gateway/worker-environments/workspace-reconcile-recovery.ts
@@ -1,7 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { FsSafeError, root as openFsSafeRoot } from "../../infra/fs-safe.js";
+import { root as openFsSafeRoot } from "../../infra/fs-safe.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import {
   createStagedInputPathMatcher,
@@ -34,6 +34,7 @@ import {
   entryMatches,
   localPath,
   readWorkspaceTreeFile,
+  removeEmptyWorkspaceDirectory,
 } from "./workspace-reconcile-fs.js";
 
 const PATCH_TIMEOUT_MS = 10 * 60_000;
@@ -552,30 +553,7 @@ async function restoreWorkspaceJournalDirectories(params: WorkspaceRecoveryConte
     if (baseDirectoryPaths.has(entryPath) || baseEntryPaths.has(entryPath)) {
       continue;
     }
-    let children: string[];
-    try {
-      children = await workspaceRoot.list(entryPath);
-    } catch (error) {
-      if (error instanceof FsSafeError && ["not-found", "path-alias"].includes(error.code)) {
-        continue;
-      }
-      throw error;
-    }
-    if (children.length > 0) {
-      continue;
-    }
-    try {
-      await workspaceRoot.remove(entryPath);
-    } catch (error) {
-      if (error instanceof FsSafeError && ["not-found", "path-alias"].includes(error.code)) {
-        continue;
-      }
-      const racedChildren = await workspaceRoot.list(entryPath).catch(() => undefined);
-      if (racedChildren?.length) {
-        continue;
-      }
-      throw error;
-    }
+    await removeEmptyWorkspaceDirectory(workspaceRoot, entryPath);
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Workspace application and rollback duplicated the same empty-directory cleanup policy. Maintaining two copies risks divergent handling of local children, removed paths and filesystem races. This is a production-deletion follow-up to the #135868 split campaign.

## Why This Change Was Made

Both callers now use the existing workspace filesystem module's shared removal helper. Each keeps its own path selection, ordering, stat checks and already-open FsSafe root. The helper preserves the exact list/remove/relist sequence, ignored error codes and propagated failures; helper returns replace the former loop continues.

Deletion evidence:

| Removed copy | Canonical replacement and retained proof |
|---|---|
| Apply-side empty-directory list/remove/error block | `src/gateway/worker-environments/workspace-reconcile-fs.ts:18`; caller selection/stat checks stay in `workspace-reconcile-core.ts:271`. Real filesystem addition/removal remains in `workspace-reconcile.test.ts:873`, and local-only directory preservation at `:978`. |
| Recovery-side duplicate and unused FsSafeError import | Same helper, called only after the existing journal selection. Rejected-acceptance rollback remains in `workspace-reconcile.test.ts:1036`; symlinked-ancestor safety remains in `workspace-reconcile-recovery.test.ts:116`. |

`git log -S 'const racedChildren'` traces the duplicated race handling to `8631832048c` (#111244). This consolidates that existing contract rather than deleting compatibility behavior. No journal format, schema, retained state, authority check or recovery policy changes.

## User Impact

No observable behavior change. Nonempty/conflicted directories remain, missing or aliased paths retain their existing treatment, and unexpected removal failures still propagate. All existing tests remain byte-for-byte unchanged.

## Evidence

- Both workspace reconciliation suites: 53 tests passed before and after (5.30s and 4.71s Vitest duration; not a performance claim).
- Independent Codex review: scoped-clean, no actionable P0–P2 findings.
- Production +35 / −51 = **−16 lines**. Tests/support, tooling and docs: unchanged.

- Full `node scripts/check-changed.mjs` passed, including typechecking, Knip, lint and runtime import-cycle checks.

ClawSweeper reviewed the exact head and found no actionable findings or before-merge requests; no rank-up changes are needed.
