### PR TITLE
refactor(config): reuse parent lookup for unset operations

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2279,7 +2279,7 @@ src/cli/command-secret-gateway.ts	2
 src/cli/command-secret-targets.ts	2
 src/cli/completion-runtime.ts	4
 src/cli/config-cli-input.ts	2
-src/cli/config-cli-path.ts	6
+src/cli/config-cli-path.ts	5
 src/cli/config-cli-runner.ts	3
 src/cli/config-cli.ts	8
 src/cli/config-model-validation.ts	7

--- a/src/cli/config-cli-path.ts
+++ b/src/cli/config-cli-path.ts
@@ -518,25 +518,7 @@ export function unsetAtPath(root: Record<string, unknown>, path: PathSegment[]):
   if (last === undefined) {
     return { removed: false };
   }
-  let current: unknown = root;
-  for (const segment of path.slice(0, -1)) {
-    if (!current || typeof current !== "object") {
-      return { removed: false };
-    }
-    if (Array.isArray(current)) {
-      const index = parseIndexSegment(segment);
-      if (index === undefined || index >= current.length) {
-        return { removed: false };
-      }
-      current = current[index];
-      continue;
-    }
-    const record = current as Record<string, unknown>;
-    if (!hasOwnPathKey(record, segment)) {
-      return { removed: false };
-    }
-    current = record[segment];
-  }
+  const current = getAtPath(root, path.slice(0, -1)).value;
 
   if (Array.isArray(current)) {
     const index = parseIndexSegment(last);


### PR DESCRIPTION
## What Problem This Solves

Config get and unset need the same interpretation of parent paths, including nested arrays, quoted keys and missing parents.

## Why This Change Was Made

Reuse the existing getter for unset's parent lookup and delete the duplicate traversal. Keep the leaf deletion branches and their array/object receipt unchanged; the writer uses that receipt to avoid deleting an array element twice. The assertion allowance decreases with the removed cast.

## User Impact

Command behavior, configuration shape and persistence rules are unchanged. Production code decreases by 18 lines; existing tests are unchanged.

## Evidence

The same 12 selected cases pass before and after, including ordinary CLI behavior, missing authored targets in temporary real files and indexed roster deletion. All 29 canonical checks and the managed P2 review pass. Only the measured assertion-baseline row shrinks from six to five.
