### PR TITLE
perf(cli): keep inference metadata and domain help lazy

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2265,7 +2265,7 @@ src/cli/capability-cli/audio.ts	3
 src/cli/capability-cli/embedding.ts	3
 src/cli/capability-cli/image.ts	17
 src/cli/capability-cli/model.ts	4
-src/cli/capability-cli/shared.ts	6
+src/cli/capability-cli/shared.ts	4
 src/cli/capability-cli/tts.ts	6
 src/cli/capability-cli/video.ts	7
 src/cli/capability-cli/web.ts	6

--- a/src/cli/capability-cli.lazy.test.ts
+++ b/src/cli/capability-cli.lazy.test.ts
@@ -7,9 +7,15 @@ const loaded = vi.hoisted(() => {
     modules,
     mock(name: string, exportName: string) {
       modules.add(name);
-      return { [exportName]: vi.fn() };
+      return {
+        [exportName]: (capability: Command) => capability.command(name).description(name),
+      };
     },
   };
+});
+
+vi.mock("../agents/auth-profiles.js", () => {
+  throw new Error("Inference metadata must not import provider auth runtime");
 });
 
 vi.mock("./capability-cli/audio.js", () => loaded.mock("audio", "registerAudioCapabilityCommands"));
@@ -22,24 +28,67 @@ vi.mock("./capability-cli/tts.js", () => loaded.mock("tts", "registerTtsCapabili
 vi.mock("./capability-cli/video.js", () => loaded.mock("video", "registerVideoCapabilityCommands"));
 vi.mock("./capability-cli/web.js", () => loaded.mock("web", "registerWebCapabilityCommands"));
 
-it("loads only the selected capability command domain", async () => {
+it("keeps metadata and selected-domain help behind the inference import boundary", async () => {
   const { registerCapabilityCli } = await import("./capability-cli.js");
-  const metadataProgram = new Command();
+  for (const args of [
+    ["infer", "list", "--json"],
+    ["capability", "inspect", "--name", "image.generate", "--help"],
+  ]) {
+    const metadataProgram = new Command().enablePositionalOptions();
+    await registerCapabilityCli(metadataProgram, ["node", "openclaw", ...args]);
+    const capability = metadataProgram.commands.find((command) => command.name() === "infer");
+    expect(capability?.commands.map((command) => command.name())).toEqual(["list", "inspect"]);
+    expect(loaded.modules).toEqual(new Set());
+  }
 
-  await registerCapabilityCli(metadataProgram, ["node", "openclaw", "infer", "list", "--json"]);
-
-  const capability = metadataProgram.commands.find((command) => command.name() === "infer");
-  expect(capability?.commands.map((command) => command.name())).toEqual(["list", "inspect"]);
-  expect(loaded.modules).toEqual(new Set());
-
-  await registerCapabilityCli(new Command(), [
-    "node",
-    "openclaw",
-    "infer",
-    "image",
-    "providers",
-    "--json",
-  ]);
+  await registerCapabilityCli(new Command(), ["node", "openclaw", "infer", "image", "--help"]);
 
   expect(loaded.modules).toEqual(new Set(["image"]));
+});
+
+const allDomains = ["model", "image", "audio", "tts", "video", "web", "embedding"];
+
+it.each([
+  { args: ["infer", "--help"], domains: allDomains },
+  { args: ["infer", "--help", "image"], domains: allDomains },
+  { args: ["infer", "--bad", "image", "--help"], domains: allDomains },
+  { args: ["infer", "imgae"], domains: allDomains },
+  { args: ["infer", "help", "image"], domains: allDomains },
+  { args: ["completion", "--shell", "image"], domains: allDomains },
+  { args: ["infer", "--", "image"], domains: allDomains },
+  { args: ["--profile", "image", "infer", "list", "--help"], domains: [] },
+  { args: ["capability", "image", "--help"], domains: ["image"] },
+  { args: ["infer", "image", "providers", "--json"], domains: ["image"] },
+  { args: ["infer", "model", "run", "--prompt", "--help"], domains: ["model"] },
+])("preserves the command inventory for $args", async ({ args, domains }) => {
+  const { registerCapabilityCli } = await import("./capability-cli.js");
+  const program = new Command().enablePositionalOptions();
+  await registerCapabilityCli(program, ["node", "openclaw", ...args]);
+  const capability = program.commands.find((command) => command.name() === "infer");
+  expect(capability?.commands.map((command) => command.name())).toEqual([
+    "list",
+    "inspect",
+    ...domains,
+  ]);
+});
+
+it.each([
+  ["--help", "image"],
+  ["--bad", "image", "--help"],
+])("prints complete parent help when options precede the domain: %j", async (...args) => {
+  const { registerCapabilityCli } = await import("./capability-cli.js");
+  let output = "";
+  const program = new Command()
+    .name("openclaw")
+    .enablePositionalOptions()
+    .exitOverride()
+    .configureOutput({ writeOut: (value) => (output += value) });
+  await registerCapabilityCli(program, ["node", "openclaw", "infer", ...args]);
+  await expect(program.parseAsync(["infer", ...args], { from: "user" })).rejects.toMatchObject({
+    code: "commander.helpDisplayed",
+    exitCode: 0,
+  });
+  for (const domain of allDomains) {
+    expect(output).toContain(`${domain} `);
+  }
 });

--- a/src/cli/capability-cli.lazy.test.ts
+++ b/src/cli/capability-cli.lazy.test.ts
@@ -41,7 +41,15 @@ it("keeps metadata and selected-domain help behind the inference import boundary
     expect(loaded.modules).toEqual(new Set());
   }
 
-  await registerCapabilityCli(new Command(), ["node", "openclaw", "infer", "image", "--help"]);
+  await registerCapabilityCli(new Command(), [
+    "node",
+    "openclaw",
+    "infer",
+    "--log-level",
+    "debug",
+    "image",
+    "providers",
+  ]);
 
   expect(loaded.modules).toEqual(new Set(["image"]));
 });
@@ -56,7 +64,16 @@ it.each([
   { args: ["infer", "help", "image"], domains: allDomains },
   { args: ["completion", "--shell", "image"], domains: allDomains },
   { args: ["infer", "--", "image"], domains: allDomains },
+  { args: ["infer", "--", "--log-level", "debug", "image"], domains: allDomains },
+  { args: ["--", "infer", "image", "providers"], domains: ["image"] },
+  { args: ["--", "infer", "--log-level", "debug", "image"], domains: allDomains },
   { args: ["--profile", "image", "infer", "list", "--help"], domains: [] },
+  { args: ["infer", "--log-level", "debug", "list", "--json"], domains: [] },
+  { args: ["infer", "--log-level", "debug", "image", "providers"], domains: ["image"] },
+  { args: ["capability", "--log-level=debug", "image", "--help"], domains: ["image"] },
+  { args: ["infer", "--log-level", "--help", "image"], domains: allDomains },
+  { args: ["infer", "--log-level=", "image", "--help"], domains: allDomains },
+  { args: ["infer", "--log-level", "debug", "--help", "image"], domains: allDomains },
   { args: ["capability", "image", "--help"], domains: ["image"] },
   { args: ["infer", "image", "providers", "--json"], domains: ["image"] },
   { args: ["infer", "model", "run", "--prompt", "--help"], domains: ["model"] },
@@ -75,6 +92,8 @@ it.each([
 it.each([
   ["--help", "image"],
   ["--bad", "image", "--help"],
+  ["--log-level", "--help", "image"],
+  ["--log-level=", "image", "--help"],
 ])("prints complete parent help when options precede the domain: %j", async (...args) => {
   const { registerCapabilityCli } = await import("./capability-cli.js");
   let output = "";

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -2,10 +2,11 @@
 import type { Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
+import { getCommandArgsWithRootOptions } from "../infra/cli-root-options.js";
 import { defaultRuntime } from "../runtime.js";
-import { resolveCliArgvInvocation } from "./argv-invocation.js";
+import { getPrimaryCommand } from "./argv.js";
 import { CAPABILITY_METADATA, findCapabilityMetadata } from "./capability-cli/metadata.js";
-import { emitJsonOrText, providerSummaryText } from "./capability-cli/shared.js";
+import { emitJsonOrText, providerSummaryText } from "./capability-cli/output.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
 import { removeCommandByName } from "./program/command-tree.js";
 
@@ -72,18 +73,23 @@ async function registerCapabilityDomainCommands(
   capability: Command,
   argv: string[],
 ): Promise<void> {
-  const invocation = resolveCliArgvInvocation(argv);
-  if (!invocation.hasHelpOrVersion) {
-    const selectedName = invocation.commandPath[1];
-    if (selectedName === "list" || selectedName === "inspect") {
-      return;
-    }
-    const selected = capabilityCommandGroups.find(([name]) => name === selectedName);
-    if (selected) {
-      const register = await selected[1]();
-      register(capability);
-      return;
-    }
+  const primary = getPrimaryCommand(argv);
+  // Options before a domain can request parent help, which needs the complete command tree.
+  const selectedName =
+    primary === "infer" || primary === "capability"
+      ? getCommandArgsWithRootOptions(argv, {
+          commandPath: [primary],
+          mode: "command-path",
+        })?.[0]
+      : undefined;
+  if (selectedName === "list" || selectedName === "inspect") {
+    return;
+  }
+  const selected = capabilityCommandGroups.find(([name]) => name === selectedName);
+  if (selected) {
+    const register = await selected[1]();
+    register(capability);
+    return;
   }
 
   const registrars = await Promise.all(capabilityCommandGroups.map(([, load]) => load()));

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -2,9 +2,9 @@
 import type { Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
-import { getCommandArgsWithRootOptions } from "../infra/cli-root-options.js";
+import { FLAG_TERMINATOR, getCommandArgsWithRootOptions } from "../infra/cli-root-options.js";
 import { defaultRuntime } from "../runtime.js";
-import { getPrimaryCommand } from "./argv.js";
+import { getCommandPathWithRootOptions, normalizeRootLogLevelArgv } from "./argv.js";
 import { CAPABILITY_METADATA, findCapabilityMetadata } from "./capability-cli/metadata.js";
 import { emitJsonOrText, providerSummaryText } from "./capability-cli/output.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
@@ -73,15 +73,20 @@ async function registerCapabilityDomainCommands(
   capability: Command,
   argv: string[],
 ): Promise<void> {
-  const primary = getPrimaryCommand(argv);
-  // Options before a domain can request parent help, which needs the complete command tree.
-  const selectedName =
+  // Root log levels are normalized after registration. Reuse that view for selection,
+  // leaving help and unknown options ahead of a domain on the complete-tree path.
+  const selectionArgv = normalizeRootLogLevelArgv(argv);
+  const commandPath = getCommandPathWithRootOptions(selectionArgv, 2);
+  const primary = commandPath[0];
+  const commandArgs =
     primary === "infer" || primary === "capability"
-      ? getCommandArgsWithRootOptions(argv, {
+      ? getCommandArgsWithRootOptions(selectionArgv, {
           commandPath: [primary],
           mode: "command-path",
-        })?.[0]
+        })
       : undefined;
+  // The raw tail marks both leading and post-parent `--`; only the former retains a domain.
+  const selectedName = commandArgs?.[0] === FLAG_TERMINATOR ? commandPath[1] : commandArgs?.[0];
   if (selectedName === "list" || selectedName === "inspect") {
     return;
   }

--- a/src/cli/capability-cli/audio.ts
+++ b/src/cli/capability-cli/audio.ts
@@ -11,11 +11,9 @@ import { runCommandWithRuntime } from "../cli-utils.js";
 import { getModelsCommandSecretTargetIds } from "../command-secret-targets.js";
 import { isMissingMediaUnderstandingProvider } from "./media-understanding-result.js";
 import type { CapabilityEnvelope } from "./metadata.js";
+import { emitJsonOrText, formatEnvelopeForText, providerSummaryText } from "./output.js";
 import {
-  emitJsonOrText,
-  formatEnvelopeForText,
   providerHasGenericConfig,
-  providerSummaryText,
   requireProviderModelOverride,
   resolveCapabilityAgentOption,
   resolveCapabilityProviderAgentId,

--- a/src/cli/capability-cli/embedding.ts
+++ b/src/cli/capability-cli/embedding.ts
@@ -11,11 +11,9 @@ import { runCommandWithRuntime } from "../cli-utils.js";
 import { getMemoryEmbeddingCommandSecretTargetIds } from "../command-secret-targets.js";
 import { collectOption } from "../program/helpers.js";
 import type { CapabilityEnvelope } from "./metadata.js";
+import { emitJsonOrText, formatEnvelopeForText, providerSummaryText } from "./output.js";
 import {
-  emitJsonOrText,
-  formatEnvelopeForText,
   providerHasGenericConfig,
-  providerSummaryText,
   requireProviderModelOverride,
   resolveCapabilityAgentOption,
   resolveCapabilityProviderAgentId,

--- a/src/cli/capability-cli/image.ts
+++ b/src/cli/capability-cli/image.ts
@@ -32,13 +32,11 @@ import { readInputFiles, writeOutputAsset } from "../media-output.js";
 import { collectOption } from "../program/helpers.js";
 import { isMissingMediaUnderstandingProvider } from "./media-understanding-result.js";
 import type { CapabilityEnvelope } from "./metadata.js";
+import { emitJsonOrText, formatEnvelopeForText, providerSummaryText } from "./output.js";
 import {
-  emitJsonOrText,
-  formatEnvelopeForText,
   parseOptionalPositiveInteger,
   parseOptionalTimeoutMs,
   providerHasGenericConfig,
-  providerSummaryText,
   requireProviderModelOverride,
   resolveCapabilityAgentOption,
   resolveCapabilityProviderAgentId,

--- a/src/cli/capability-cli/model.ts
+++ b/src/cli/capability-cli/model.ts
@@ -39,11 +39,9 @@ import { runCommandWithRuntime } from "../cli-utils.js";
 import { getModelsCommandSecretTargetIds } from "../command-secret-targets.js";
 import { collectOption } from "../program/helpers.js";
 import type { CapabilityEnvelope, CapabilityTransport } from "./metadata.js";
+import { emitJsonOrText, formatEnvelopeForText, providerSummaryText } from "./output.js";
 import {
-  emitJsonOrText,
-  formatEnvelopeForText,
   providerHasGenericConfig,
-  providerSummaryText,
   requireProviderModelOverride,
   resolveCapabilityAgentOption,
   resolveCapabilityProviderAgentId,

--- a/src/cli/capability-cli/output.ts
+++ b/src/cli/capability-cli/output.ts
@@ -1,0 +1,44 @@
+import { writeRuntimeJson, type RuntimeEnv } from "../../runtime.js";
+import type { CapabilityEnvelope } from "./metadata.js";
+
+export function emitJsonOrText<T>(
+  runtime: RuntimeEnv,
+  json: boolean | undefined,
+  value: T,
+  textFormatter: (value: T) => string,
+) {
+  if (json) {
+    writeRuntimeJson(runtime, value);
+    return;
+  }
+  runtime.log(textFormatter(value));
+}
+
+export function formatEnvelopeForText(envelope: CapabilityEnvelope): string {
+  if (!envelope.ok) {
+    return `${envelope.capability} failed: ${envelope.error ?? "unknown error"}`;
+  }
+  const lines = [
+    `${envelope.capability} via ${envelope.transport}`,
+    ...(envelope.provider ? [`provider: ${envelope.provider}`] : []),
+    ...(envelope.model ? [`model: ${envelope.model}`] : []),
+    ...(envelope.ignoredOverrides && envelope.ignoredOverrides.length > 0
+      ? [`ignoredOverrides: ${JSON.stringify(envelope.ignoredOverrides)}`]
+      : []),
+    `outputs: ${String(envelope.outputs.length)}`,
+  ];
+  for (const output of envelope.outputs) {
+    const pathValue = typeof output.path === "string" ? output.path : undefined;
+    const textValue = typeof output.text === "string" ? output.text : undefined;
+    if (pathValue || textValue) {
+      lines.push(...[pathValue, textValue].filter((entry): entry is string => Boolean(entry)));
+    } else {
+      lines.push(JSON.stringify(output));
+    }
+  }
+  return lines.join("\n");
+}
+
+export function providerSummaryText(providers: readonly unknown[]): string {
+  return providers.map((entry) => JSON.stringify(entry)).join("\n") || "No results found.";
+}

--- a/src/cli/capability-cli/shared.ts
+++ b/src/cli/capability-cli/shared.ts
@@ -18,12 +18,12 @@ import {
   setRuntimeConfigSnapshot,
 } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { writeRuntimeJson, defaultRuntime, type RuntimeEnv } from "../../runtime.js";
+import { defaultRuntime } from "../../runtime.js";
 import { getProviderEnvVars } from "../../secrets/provider-env-vars.js";
 import { resolveCommandConfigWithSecrets } from "../command-config-resolution.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import { parseTimeoutMsWithFallback } from "../parse-timeout.js";
-import type { CapabilityEnvelope, CapabilityTransport } from "./metadata.js";
+import type { CapabilityTransport } from "./metadata.js";
 
 export function resolveTransport(opts: {
   local?: boolean;
@@ -47,50 +47,6 @@ export function resolveTransport(opts: {
     return "gateway";
   }
   return opts.defaultTransport;
-}
-
-export function emitJsonOrText(
-  runtime: RuntimeEnv,
-  json: boolean | undefined,
-  value: unknown,
-  textFormatter: (value: unknown) => string,
-) {
-  if (json) {
-    writeRuntimeJson(runtime, value);
-    return;
-  }
-  runtime.log(textFormatter(value));
-}
-
-export function formatEnvelopeForText(value: unknown): string {
-  const envelope = value as CapabilityEnvelope;
-  if (!envelope.ok) {
-    return `${envelope.capability} failed: ${envelope.error ?? "unknown error"}`;
-  }
-  const lines = [
-    `${envelope.capability} via ${envelope.transport}`,
-    ...(envelope.provider ? [`provider: ${envelope.provider}`] : []),
-    ...(envelope.model ? [`model: ${envelope.model}`] : []),
-    ...(envelope.ignoredOverrides && envelope.ignoredOverrides.length > 0
-      ? [`ignoredOverrides: ${JSON.stringify(envelope.ignoredOverrides)}`]
-      : []),
-    `outputs: ${String(envelope.outputs.length)}`,
-  ];
-  for (const output of envelope.outputs) {
-    const pathValue = typeof output.path === "string" ? output.path : undefined;
-    const textValue = typeof output.text === "string" ? output.text : undefined;
-    if (pathValue || textValue) {
-      lines.push(...[pathValue, textValue].filter((entry): entry is string => Boolean(entry)));
-    } else {
-      lines.push(JSON.stringify(output));
-    }
-  }
-  return lines.join("\n");
-}
-
-export function providerSummaryText(value: unknown): string {
-  const providers = value as Array<Record<string, unknown>>;
-  return providers.map((entry) => JSON.stringify(entry)).join("\n") || "No results found.";
 }
 
 function hasOwnKeys(value: unknown): boolean {

--- a/src/cli/capability-cli/tts.ts
+++ b/src/cli/capability-cli/tts.ts
@@ -3,13 +3,8 @@ import { callGateway } from "../../gateway/call.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeSpeechProviderId } from "../../tts/provider-registry.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
-import {
-  emitJsonOrText,
-  formatEnvelopeForText,
-  providerSummaryText,
-  resolveModelRefOverride,
-  resolveTransport,
-} from "./shared.js";
+import { emitJsonOrText, formatEnvelopeForText, providerSummaryText } from "./output.js";
+import { resolveModelRefOverride, resolveTransport } from "./shared.js";
 import {
   runTtsConvert,
   runTtsPersonas,
@@ -18,11 +13,11 @@ import {
   runTtsVoices,
 } from "./tts-runtime.js";
 
-function registerTransportTtsCommand(
+function registerTransportTtsCommand<T>(
   command: Command,
   defaultTransport: "local" | "gateway",
-  run: (opts: Record<string, unknown>, transport: "local" | "gateway") => Promise<unknown>,
-  formatText: (value: unknown) => string = (value) => JSON.stringify(value, null, 2),
+  run: (opts: Record<string, unknown>, transport: "local" | "gateway") => Promise<T>,
+  formatText: (value: T) => string = (value) => JSON.stringify(value, null, 2),
 ): void {
   command
     .option("--local", "Force local execution", false)

--- a/src/cli/capability-cli/video.ts
+++ b/src/cli/capability-cli/video.ts
@@ -32,9 +32,8 @@ import { runCommandWithRuntime } from "../cli-utils.js";
 import { getModelsCommandSecretTargetIds } from "../command-secret-targets.js";
 import { publishOutputFileAtomically, writeOutputAsset } from "../media-output.js";
 import type { CapabilityEnvelope } from "./metadata.js";
+import { emitJsonOrText, formatEnvelopeForText } from "./output.js";
 import {
-  emitJsonOrText,
-  formatEnvelopeForText,
   parseOptionalFiniteNumber,
   parseOptionalTimeoutMs,
   providerHasGenericConfig,

--- a/src/cli/capability-cli/web.ts
+++ b/src/cli/capability-cli/web.ts
@@ -19,9 +19,8 @@ import {
   getCapabilityWebSearchCommandSecretTargets,
 } from "../command-secret-targets.js";
 import type { CapabilityEnvelope } from "./metadata.js";
+import { emitJsonOrText, formatEnvelopeForText } from "./output.js";
 import {
-  emitJsonOrText,
-  formatEnvelopeForText,
   parseOptionalPositiveInteger,
   resolveCapabilityProviderAgentId,
   resolveLocalCapabilityRuntimeConfig,


### PR DESCRIPTION
## What Problem This Solves

Inference metadata and selected-domain help load unrelated provider/auth runtime and command domains, adding unnecessary startup work to simple CLI inspection.

## Why This Change Was Made

Move pure JSON/text formatting into a small output owner and register only the selected inference domain when the command path permits it. Keep complete parent help and malformed/unknown-option behavior on the full command-tree path. Generic producer types remove two casts; the assertion baseline shrinks exactly from six to four for the changed file. The full production change removes four lines.

## User Impact

Metadata help avoids provider-auth runtime, and domain help loads the selected domain. Existing command outputs, provider behavior, aliases, root options, and literal-argument boundaries remain intact.

## Evidence

- Prepublication combined review caught a selector regression: `infer --log-level debug image providers` kept the root flag until after registration and loaded all domains. Selection now uses the existing log-level normalization on a copy and the canonical root-aware path for leading terminators. Commander receives the original argument flow.
- Final **345 focused tests**, changed-code checks, independent review, fresh managed autoreview through P2, and the full build on corrected head `3111512f21e3ea74e3f666c039db03ababe5c111` pass. The original selector and an intermediate log-level-only correction fail the intended new cases; both failure receipts remain recorded.
- **11 targeted built CLI before/after cases** preserve stdout and exit behavior relative to the previous built feature, normalizing only revision headers and timing diagnostics. **14 import assertions** pass, with extra no-color, leading-terminator, and literal-flag controls. Parent help, malformed values, aliases, and post-parent terminators retain their established inventories.
- On the corrected build, metadata help loads **741 modules and no inference domain**, web help loads **2,422 modules with only web**, and root-log-level image commands load only image. Profile/dev/container/no-color handling was traced through its existing startup owners; container execution was not invoked.
- Command proof uses isolated state, an environment allowlist, network denial, and per-process tracing through launcher respawns. No operator configuration or provider service was used. These are final behavior/import facts; earlier timing/RSS samples remain attributed to the original feature head and are not measurements of this correction.
- Required hosted CI passed on this corrected head ([run 34048830412](https://github.com/openclaw/openclaw/actions/runs/34048830412)). The corrected combined-change P2 review joined cleanly with zero findings and confirmed the selector regression is resolved.
