### PR TITLE
fix(plugins): preserve exact installed-index mutation receipts

### DIFF
--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -121,13 +121,34 @@ const writePersistedInstalledPluginIndexInstallRecords: Mock<WritePersistedInsta
   });
 export const readPersistedInstalledPluginIndexMock: Mock<ReadPersistedInstalledPluginIndexFn> =
   vi.fn<ReadPersistedInstalledPluginIndexFn>(async () => null);
-export const writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock: Mock<WritePersistedInstalledPluginIndexInstallRecordsWithLeaseFn> =
-  vi.fn<WritePersistedInstalledPluginIndexInstallRecordsWithLeaseFn>(async (records) => {
+const writeMockInstalledIndexWithLease: WritePersistedInstalledPluginIndexInstallRecordsWithLeaseFn =
+  async (records) => {
     const previous = await readPersistedInstalledPluginIndexMock();
+    const row = (index: InstalledPluginIndex, revision: number) => ({
+      state_key: "plugins.installedIndex",
+      value_json: JSON.stringify({ index, revision }),
+      updated_at_ms: revision,
+    });
+    const before = previous ? row(previous, mockInstalledPluginIndexRevision) : null;
     mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(records);
     mockInstalledPluginIndexRevision += 1;
-    return { previous, revision: mockInstalledPluginIndexRevision };
-  });
+    return {
+      previous,
+      revision: mockInstalledPluginIndexRevision,
+      mutation: {
+        databasePath: "/tmp/openclaw-state/openclaw.sqlite",
+        before,
+        after: row(
+          createTestInstalledPluginIndex({ policyHash: "test-policy", installRecords: records }),
+          mockInstalledPluginIndexRevision,
+        ),
+      },
+    };
+  };
+export const writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock: Mock<WritePersistedInstalledPluginIndexInstallRecordsWithLeaseFn> =
+  vi.fn<WritePersistedInstalledPluginIndexInstallRecordsWithLeaseFn>(
+    writeMockInstalledIndexWithLease,
+  );
 export const restorePersistedInstalledPluginIndexIfCurrentMock: Mock<RestorePersistedInstalledPluginIndexIfCurrentFn> =
   vi.fn<RestorePersistedInstalledPluginIndexIfCurrentFn>(async (index, expectedRevision) => {
     if (mockInstalledPluginIndexRevision !== expectedRevision) {
@@ -974,12 +995,7 @@ export function resetPluginsCliTestState() {
   });
   readPersistedInstalledPluginIndexMock.mockResolvedValue(null);
   writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock.mockImplementation(
-    async (records) => {
-      const previous = await readPersistedInstalledPluginIndexMock();
-      mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(records);
-      mockInstalledPluginIndexRevision += 1;
-      return { previous, revision: mockInstalledPluginIndexRevision };
-    },
+    writeMockInstalledIndexWithLease,
   );
   restorePersistedInstalledPluginIndexIfCurrentMock.mockImplementation(
     async (index, expectedRevision) => {

--- a/src/plugins/install-record-commit.test.ts
+++ b/src/plugins/install-record-commit.test.ts
@@ -131,6 +131,11 @@ describe("commitConfigWithPendingPluginInstalls", () => {
     mocks.writePersistedInstalledPluginIndexInstallRecordsWithLease.mockResolvedValue({
       previous: null,
       revision: 1,
+      mutation: {
+        databasePath: "/tmp/openclaw.sqlite",
+        before: null,
+        after: { state_key: "plugins.installedIndex", value_json: "{}", updated_at_ms: 1 },
+      },
     });
   });
 
@@ -915,6 +920,11 @@ describe("commitConfigWithPendingPluginInstalls", () => {
     mocks.writePersistedInstalledPluginIndexInstallRecordsWithLease.mockResolvedValue({
       previous: previousPersistedIndex,
       revision: 17,
+      mutation: {
+        databasePath: "/tmp/openclaw.sqlite",
+        before: null,
+        after: { state_key: "plugins.installedIndex", value_json: "{}", updated_at_ms: 17 },
+      },
     });
     mocks.replaceConfigFile.mockRejectedValue(new Error("config changed"));
 

--- a/src/plugins/install-record-commit.ts
+++ b/src/plugins/install-record-commit.ts
@@ -448,6 +448,7 @@ async function commitPluginInstallRecordsWithWriter(params: {
 }): Promise<{
   committed: ConfigReplaceResult | void;
   nextInstallRecords: Record<string, PluginInstallRecord>;
+  indexWrite: InstalledPluginIndexWriteReceipt;
 }> {
   return await withPluginLifecycleLease({}, async (lease) => {
     let tentativeWrite: InstalledPluginIndexWriteReceipt | undefined;
@@ -518,7 +519,11 @@ async function commitPluginInstallRecordsWithWriter(params: {
         ]),
       });
       const committed = await params.commit(params.nextConfig, writeOptions);
-      return { committed, nextInstallRecords: prepared.nextInstallRecords };
+      return {
+        committed,
+        nextInstallRecords: prepared.nextInstallRecords,
+        indexWrite: tentativeWrite,
+      };
     } catch (error) {
       const tentative = tentativeWrite;
       if (tentative) {
@@ -557,8 +562,8 @@ export async function commitPluginInstallRecordsWithConfig(params: {
   baseHash?: string;
   writeOptions?: ConfigWriteOptions;
   beforePersistentEffect?: () => void | Promise<void>;
-}): Promise<void> {
-  await commitPluginInstallRecordsWithWriter({
+}): Promise<InstalledPluginIndexWriteReceipt> {
+  const result = await commitPluginInstallRecordsWithWriter({
     prepareInstallRecords: async (storeOptions) => ({
       previousInstallRecords:
         params.previousInstallRecords ??
@@ -576,6 +581,7 @@ export async function commitPluginInstallRecordsWithConfig(params: {
       });
     },
   });
+  return result.indexWrite;
 }
 
 /** Persist plugin install records without rewriting the user-authored config file. */
@@ -584,8 +590,8 @@ export async function commitPluginInstallRecordsOnly(params: {
   nextInstallRecords: Record<string, PluginInstallRecord>;
   nextConfig: OpenClawConfig;
   verifyConfigFresh?: () => Promise<void>;
-}): Promise<void> {
-  await commitPluginInstallRecordsWithWriter({
+}): Promise<InstalledPluginIndexWriteReceipt> {
+  const result = await commitPluginInstallRecordsWithWriter({
     prepareInstallRecords: async (storeOptions) => ({
       previousInstallRecords:
         params.previousInstallRecords ??
@@ -598,6 +604,7 @@ export async function commitPluginInstallRecordsOnly(params: {
       return undefined;
     },
   });
+  return result.indexWrite;
 }
 
 /** Commit config while migrating any pending install records into the install index. */

--- a/src/plugins/installed-plugin-index-store-write.receipt.test.ts
+++ b/src/plugins/installed-plugin-index-store-write.receipt.test.ts
@@ -1,0 +1,190 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { commitPluginInstallRecordsOnly } from "./install-record-commit.js";
+import { writePersistedInstalledPluginIndexInstallRecordsWithLease } from "./installed-plugin-index-records.js";
+import { withPluginLifecycleLease } from "./plugin-lifecycle-lease.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+
+const tempDirs: string[] = [];
+const stateKey = "plugins.installedIndex";
+const priorJson = `{ "revision": 41, "index": {
+  "version": 1, "hostContractVersion": "2026.4.25", "compatRegistryVersion": "compat-v1",
+  "migrationVersion": 1, "policyHash": "prior", "generatedAtMs": 123,
+  "installRecords": {}, "plugins": [], "diagnostics": []
+} }`;
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  cleanupTrackedTempDirs(tempDirs);
+});
+
+function makeEnv() {
+  return {
+    ...process.env,
+    OPENCLAW_STATE_DIR: makeTrackedTempDir("openclaw-plugin-row-receipt", tempDirs),
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+  };
+}
+
+// An independent connection sees only committed rows, not the writer's projections.
+function readRow(databasePath: string) {
+  const { DatabaseSync } = requireNodeSqlite();
+  const db = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    return (
+      db
+        .prepare(
+          "SELECT state_key, value_json, updated_at_ms FROM config_machine_state WHERE state_key = ?",
+        )
+        .get(stateKey) ?? null
+    );
+  } finally {
+    db.close();
+  }
+}
+
+describe("installed plugin index mutation receipts", () => {
+  it.each([null, priorJson, "true"])(
+    "retains exact predecessor and committed row for %s",
+    async (valueJson) => {
+      const env = makeEnv();
+      const otherEnv = makeEnv();
+      await withPluginLifecycleLease({ env }, async (lease) => {
+        if (valueJson !== null) {
+          runOpenClawStateWriteTransaction(
+            ({ db }) => {
+              db.prepare(
+                "INSERT INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES (?, ?, ?)",
+              ).run(stateKey, valueJson, 9_007);
+            },
+            { path: lease.databasePath, env },
+          );
+        }
+        const before = readRow(lease.databasePath);
+        const receipt = await writePersistedInstalledPluginIndexInstallRecordsWithLease(
+          {},
+          {
+            env: otherEnv,
+            filePath: lease.databasePath,
+            candidates: [],
+            lease,
+          },
+        );
+        const after = readRow(lease.databasePath);
+        expect(receipt.mutation).toEqual({ databasePath: lease.databasePath, before, after });
+        expect(receipt.mutation.before).toEqual(
+          valueJson === null
+            ? null
+            : {
+                state_key: stateKey,
+                value_json: valueJson,
+                updated_at_ms: 9_007,
+              },
+        );
+        expect(receipt.mutation.after.updated_at_ms).toBe(receipt.revision);
+        expect(JSON.parse(receipt.mutation.after.value_json).revision).toBe(receipt.revision);
+        expect(receipt.previous?.policyHash ?? null).toBe(valueJson === priorJson ? "prior" : null);
+        expect(lease.databasePath).toBe(
+          path.join(env.OPENCLAW_STATE_DIR, "state", "openclaw.sqlite"),
+        );
+        const captured = JSON.stringify(receipt.mutation);
+        await writePersistedInstalledPluginIndexInstallRecordsWithLease(
+          {},
+          {
+            env,
+            filePath: lease.databasePath,
+            candidates: [],
+            lease,
+          },
+        );
+        expect(readRow(lease.databasePath)).not.toEqual(after);
+        expect(JSON.stringify(receipt.mutation)).toBe(captured);
+      });
+    },
+  );
+
+  it.each([false, true])(
+    "returns the row receipt only after caller settlement (fail=%s)",
+    async (fail) => {
+      const env = makeEnv();
+      await withEnvAsync(env, async () => {
+        await withPluginLifecycleLease({}, async (lease) => {
+          let after;
+          const pending = commitPluginInstallRecordsOnly({
+            nextInstallRecords: {},
+            nextConfig: {},
+            verifyConfigFresh: async () => {
+              after = readRow(lease.databasePath);
+              expect(after).not.toBeNull();
+              if (fail) {
+                throw new Error("config no longer current");
+              }
+            },
+          });
+          if (fail) {
+            await expect(pending).rejects.toThrow("config no longer current");
+            expect(readRow(lease.databasePath)).toBeNull();
+          } else {
+            const receipt = await pending;
+            expect(receipt?.mutation).toEqual({
+              databasePath: lease.databasePath,
+              before: null,
+              after,
+            });
+          }
+        });
+      });
+    },
+  );
+
+  it("rejects a failed SQLite commit without returning a receipt or publishing its row", async () => {
+    const env = makeEnv();
+    await withPluginLifecycleLease({ env }, async (lease) => {
+      let receipt;
+      try {
+        await expect(
+          (async () => {
+            receipt = await writePersistedInstalledPluginIndexInstallRecordsWithLease(
+              {},
+              {
+                env,
+                filePath: lease.databasePath,
+                candidates: [],
+                lease: {
+                  assertOwnedInTransaction(db) {
+                    lease.assertOwnedInTransaction(db);
+                    // A deferred constraint fails at COMMIT, after the index write and receipt capture.
+                    db.exec(`CREATE TEMP TABLE receipt_parent (id INTEGER PRIMARY KEY);
+                  CREATE TEMP TABLE receipt_child (
+                    parent_id INTEGER REFERENCES receipt_parent(id) DEFERRABLE INITIALLY DEFERRED
+                  );
+                  CREATE TEMP TRIGGER receipt_commit_failure AFTER INSERT ON main.config_machine_state
+                    WHEN NEW.state_key = 'plugins.installedIndex'
+                    BEGIN INSERT INTO receipt_child VALUES (1); END;`);
+                  },
+                },
+              },
+            );
+          })(),
+        ).rejects.toThrow(/FOREIGN KEY constraint failed/);
+        expect(receipt).toBeUndefined();
+        expect(readRow(lease.databasePath)).toBeNull();
+      } finally {
+        runOpenClawStateWriteTransaction(
+          ({ db }) => {
+            db.exec(`DROP TRIGGER IF EXISTS temp.receipt_commit_failure;
+            DROP TABLE IF EXISTS temp.receipt_child;
+            DROP TABLE IF EXISTS temp.receipt_parent;`);
+          },
+          { path: lease.databasePath, env },
+        );
+      }
+    });
+  });
+});

--- a/src/plugins/installed-plugin-index-store-write.ts
+++ b/src/plugins/installed-plugin-index-store-write.ts
@@ -11,7 +11,11 @@ import {
 } from "../config/plugin-install-record-map.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { resolveUserPath } from "../infra/home-dir.js";
-import { compileSqliteQueryBindings, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import {
+  compileSqliteQueryBindings,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
@@ -58,25 +62,34 @@ export type InstalledPluginIndexWriteLease = {
 export type InstalledPluginIndexWriteReceipt = {
   previous: InstalledPluginIndex | null;
   revision: number;
+  /** Exact transaction-owned facts, not permission to restore or proof of current state. */
+  mutation: {
+    databasePath: string;
+    before: InstalledPluginIndexRow | null;
+    after: InstalledPluginIndexRow;
+  };
 };
 
 type InstalledPluginIndexDatabase = Pick<OpenClawStateKyselyDatabase, "config_machine_state">;
+type InstalledPluginIndexRow = Pick<
+  InstalledPluginIndexDatabase["config_machine_state"],
+  "state_key" | "value_json" | "updated_at_ms"
+>;
 type PersistedInstalledPluginIndexValue = { revision: number; index: unknown };
 
-function readInstalledPluginIndexRow(
-  database: DatabaseSync,
-): PersistedInstalledPluginIndexValue | undefined {
-  const { compiled, bind } = compileSqliteQueryBindings<void>(() =>
+function readInstalledPluginIndexRow(database: DatabaseSync): InstalledPluginIndexRow | undefined {
+  return executeSqliteQueryTakeFirstSync(
+    database,
     getNodeSqliteKysely<InstalledPluginIndexDatabase>(database)
       .selectFrom("config_machine_state")
-      .select("value_json")
+      .select(["state_key", "value_json", "updated_at_ms"])
       .where("state_key", "=", INSTALLED_PLUGIN_INDEX_STATE_KEY),
   );
-  // sqlite-allow-raw: Compiled SQL keeps the transaction's native point-read errors.
-  // SAFETY: The compiled query selects the canonical STRICT table's TEXT column.
-  const row = database.prepare(compiled.sql).get(...bind()) as
-    | Pick<InstalledPluginIndexDatabase["config_machine_state"], "value_json">
-    | undefined;
+}
+
+function parseInstalledPluginIndexRow(
+  row: InstalledPluginIndexRow | undefined,
+): PersistedInstalledPluginIndexValue | undefined {
   if (!row) {
     return undefined;
   }
@@ -184,8 +197,9 @@ function writePersistedInstalledPluginIndexToSqlite(
 ): InstalledPluginIndexWriteReceipt {
   assertWritableInstalledPluginIndexStoreOptions(options);
   const persisted = preparePersistedInstalledPluginIndex(index);
-  return runOpenClawStateWriteTransaction(({ db }) => {
-    const previousRow = readInstalledPluginIndexRow(db);
+  return runOpenClawStateWriteTransaction(({ db, path: databasePath }) => {
+    const before = readInstalledPluginIndexRow(db);
+    const previousRow = parseInstalledPluginIndexRow(before);
     if (previousRow) {
       // SAFETY: field probe on the stored value; inspectPluginInstallRecordMap validates it.
       const previousInstallRecords = (previousRow.index as { installRecords?: unknown } | null)
@@ -204,9 +218,15 @@ function writePersistedInstalledPluginIndexToSqlite(
       previousRow ? previousRow.revision : null,
     );
     writePersistedInstalledPluginIndexRow(db, persisted, revision);
+    // Capture inside the same transaction; later reads could include another writer's work.
+    const after = readInstalledPluginIndexRow(db);
+    if (!after) {
+      throw new Error("Installed plugin index write did not persist its row");
+    }
     return {
       previous: previousRow ? parseInstalledPluginIndex(previousRow.index) : null,
       revision,
+      mutation: { databasePath, before: before ?? null, after },
     };
   }, resolveInstalledPluginIndexStateDatabaseOptions(options));
 }
@@ -241,7 +261,7 @@ export async function restorePersistedInstalledPluginIndexIfCurrent(
   }
   const restored = runOpenClawStateWriteTransaction(({ db }) => {
     lease.assertOwnedInTransaction(db);
-    const currentRow = readInstalledPluginIndexRow(db);
+    const currentRow = parseInstalledPluginIndexRow(readInstalledPluginIndexRow(db));
     const currentRevision = currentRow ? currentRow.revision : null;
     if (currentRevision !== expectedRevision) {
       return false;


### PR DESCRIPTION
Related: #124396

## What Problem This Solves

Atomic update recovery needs to distinguish plugin metadata changed by an update from newer operator or plugin work. The existing installed-index receipt retains a parsed predecessor and revision, but loses the original serialized bytes, row timestamp, absence, and selected database identity.

## Why This Change Was Made

Extend the existing leased SQLite writer receipt with exact before/after row facts and the acquired database path, captured in the same transaction. Preserve the existing parsed predecessor and revision used by tentative rollback. Forward the receipt from successful install-record/config commits only after caller settlement; a failed transaction or config commit still rejects and rolls back through the existing owner.

No schema, table, writer, or authority mechanism is added. The receipt is evidence, not permission to replace live state.

## User Impact

This supplies the canonical row provenance needed by checkpoint preservation. It does not itself enable checkpoint restore, durable replay, retention selection, or cross-writer exclusion, and is not a claim of completed atomic updates.

## Evidence

- Exact-row regressions failed before the change for missing receipts; successful caller forwarding failed separately before its fix.
- 85 writer/rollback controls passed, including exact serialized predecessor bytes/timestamps, absence, invalid-but-present data, selected DB precedence, later-write stability, and an actual deferred SQLite COMMIT failure.
- Final caller suite: 54 tests passed, including six receipt controls and the real two-process config rollback case.
- Additional CLI install/update fixture controls: 305 tests passed. Production typechecking passed after updating the typed receipt test double.
- Full changed-file checks passed, including production/test typechecking, lint, formatting, all dead-export scans, and repository guards. Final independent P0-P2 review and exact-head native review passed with no findings. Hosted CI is running on the published head.
