### PR TITLE
refactor(doctor): share compaction config traversal

### DIFF
--- a/src/commands/doctor/shared/codex-route-compaction-scan.ts
+++ b/src/commands/doctor/shared/codex-route-compaction-scan.ts
@@ -22,7 +22,7 @@ import type {
 export const COMPACTION_OVERRIDE_KEYS: readonly CompactionOverrideKey[] = ["model", "provider"];
 export const LOSSLESS_CONTEXT_ENGINE_ID = "lossless-claw";
 
-function collectUnsupportedCodexCompactionOverridesForAgent(params: {
+type AgentCompactionScanParams = {
   cfg: OpenClawConfig;
   agent: unknown;
   path: string;
@@ -32,7 +32,17 @@ function collectUnsupportedCodexCompactionOverridesForAgent(params: {
   inheritedCompaction?: unknown;
   inheritedCompactionPath?: string;
   env?: NodeJS.ProcessEnv;
-}): UnsupportedCodexCompactionOverride[] {
+};
+
+type CompactionScanParams = {
+  cfg: OpenClawConfig;
+  ignoreLegacyAgentRuntimePins?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+function collectUnsupportedCodexCompactionOverridesForAgent(
+  params: AgentCompactionScanParams,
+): UnsupportedCodexCompactionOverride[] {
   const agent = asMutableRecord(params.agent);
   const compaction = asMutableRecord(agent?.compaction);
   const inheritedCompaction = asMutableRecord(params.inheritedCompaction);
@@ -70,17 +80,9 @@ function collectUnsupportedCodexCompactionOverridesForAgent(params: {
   );
 }
 
-function collectLegacyLosslessCompactionForAgent(params: {
-  cfg: OpenClawConfig;
-  agent: unknown;
-  path: string;
-  agentId?: string;
-  currentRuntime?: string;
-  inheritedModelRef?: string;
-  inheritedCompaction?: unknown;
-  inheritedCompactionPath?: string;
-  env?: NodeJS.ProcessEnv;
-}): LegacyLosslessCompactionConfig[] {
+function collectLegacyLosslessCompactionForAgent(
+  params: AgentCompactionScanParams,
+): LegacyLosslessCompactionConfig[] {
   const agent = asMutableRecord(params.agent);
   const compaction = asMutableRecord(agent?.compaction);
   const inheritedCompaction = asMutableRecord(params.inheritedCompaction);
@@ -128,18 +130,17 @@ function collectLegacyLosslessCompactionForAgent(params: {
   ];
 }
 
-export function collectLegacyLosslessCompactionConfigs(params: {
-  cfg: OpenClawConfig;
-  ignoreLegacyAgentRuntimePins?: boolean;
-  env?: NodeJS.ProcessEnv;
-}): LegacyLosslessCompactionConfig[] {
+function collectCompactionConfigs<T>(
+  params: CompactionScanParams,
+  collectForAgent: (params: AgentCompactionScanParams) => T[],
+): T[] {
   const defaults = params.cfg.agents?.defaults;
   const defaultsRuntime = params.ignoreLegacyAgentRuntimePins
     ? undefined
     : readLegacyDefaultsRuntime(defaults);
   const defaultModelRef = readAgentPrimaryModelRef(defaults);
   const defaultCompaction = asMutableRecord(defaults?.compaction);
-  const hits = collectLegacyLosslessCompactionForAgent({
+  const hits = collectForAgent({
     cfg: params.cfg,
     agent: defaults,
     path: "agents.defaults",
@@ -150,7 +151,7 @@ export function collectLegacyLosslessCompactionConfigs(params: {
     params.cfg,
   )) {
     hits.push(
-      ...collectLegacyLosslessCompactionForAgent({
+      ...collectForAgent({
         cfg: params.cfg,
         agent: agentRecord,
         path,
@@ -168,57 +169,28 @@ export function collectLegacyLosslessCompactionConfigs(params: {
       }),
     );
   }
-  return dedupeLegacyLosslessCompactionConfigs(hits);
+  return hits;
 }
 
-export function collectUnsupportedCodexCompactionOverrides(params: {
-  cfg: OpenClawConfig;
-  ignoreLegacyAgentRuntimePins?: boolean;
-  env?: NodeJS.ProcessEnv;
-}): UnsupportedCodexCompactionOverride[] {
-  const defaults = params.cfg.agents?.defaults;
-  const defaultsRuntime = params.ignoreLegacyAgentRuntimePins
-    ? undefined
-    : readLegacyDefaultsRuntime(defaults);
-  const defaultModelRef = readAgentPrimaryModelRef(defaults);
-  const defaultCompaction = asMutableRecord(defaults?.compaction);
-  const hits = collectUnsupportedCodexCompactionOverridesForAgent({
-    cfg: params.cfg,
-    agent: defaults,
-    path: "agents.defaults",
-    currentRuntime: resolveRuntime({ defaultsRuntime }),
-    env: params.env,
-  });
-  for (const { agent: agentRecord, agentId: id, path } of listMutableCodexRouteAgentEntries(
-    params.cfg,
-  )) {
-    hits.push(
-      ...collectUnsupportedCodexCompactionOverridesForAgent({
-        cfg: params.cfg,
-        agent: agentRecord,
-        path,
-        agentId: id,
-        currentRuntime: resolveRuntime({
-          agentRuntime: params.ignoreLegacyAgentRuntimePins
-            ? undefined
-            : asAgentRuntimePolicyConfig(agentRecord.agentRuntime),
-          defaultsRuntime,
-        }),
-        inheritedModelRef: defaultModelRef,
-        inheritedCompaction: defaultCompaction,
-        inheritedCompactionPath: "agents.defaults.compaction",
-        env: params.env,
-      }),
-    );
-  }
-  return dedupeUnsupportedCompactionOverrides(hits);
+export function collectLegacyLosslessCompactionConfigs(
+  params: CompactionScanParams,
+): LegacyLosslessCompactionConfig[] {
+  return dedupeLegacyLosslessCompactionConfigs(
+    collectCompactionConfigs(params, collectLegacyLosslessCompactionForAgent),
+  );
 }
 
-export function getSharedDefaultCompactionOverrideConsumers(params: {
-  cfg: OpenClawConfig;
-  ignoreLegacyAgentRuntimePins?: boolean;
-  env?: NodeJS.ProcessEnv;
-}): SharedDefaultCompactionOverrideConsumers {
+export function collectUnsupportedCodexCompactionOverrides(
+  params: CompactionScanParams,
+): UnsupportedCodexCompactionOverride[] {
+  return dedupeUnsupportedCompactionOverrides(
+    collectCompactionConfigs(params, collectUnsupportedCodexCompactionOverridesForAgent),
+  );
+}
+
+export function getSharedDefaultCompactionOverrideConsumers(
+  params: CompactionScanParams,
+): SharedDefaultCompactionOverrideConsumers {
   const consumers: SharedDefaultCompactionOverrideConsumers = { model: false, provider: false };
   const defaults = params.cfg.agents?.defaults;
   const defaultCompaction = asMutableRecord(defaults?.compaction);
@@ -284,11 +256,9 @@ export function getSharedDefaultCompactionOverrideConsumers(params: {
   return consumers;
 }
 
-export function sharedDefaultLosslessCompactionHasNonCodexConsumer(params: {
-  cfg: OpenClawConfig;
-  ignoreLegacyAgentRuntimePins?: boolean;
-  env?: NodeJS.ProcessEnv;
-}): boolean {
+export function sharedDefaultLosslessCompactionHasNonCodexConsumer(
+  params: CompactionScanParams,
+): boolean {
   const defaults = params.cfg.agents?.defaults;
   const defaultCompaction = asMutableRecord(defaults?.compaction);
   const hasDefaultLosslessProvider =


### PR DESCRIPTION
## What Problem This Solves

Doctor repeated the same defaults-and-agent traversal for legacy Lossless compaction settings and ignored Codex compaction overrides. Each copy carried the same inheritance, runtime-pin and environment inputs. This production-deletion follow-up to #135868 gives the two collectors one traversal without changing their decisions.

## Why This Change Was Made

Share the traversal and identical parameter shapes in the existing scan owner. Each exported collector keeps its own classifier and deduper. The classifier, deduper and shared-default consumer function bodies remain byte-for-byte unchanged; calls still visit defaults first and then the same agent sequence.

| Removed duplication | Canonical replacement and surviving coverage |
|---|---|
| Second defaults/agent traversal | `src/commands/doctor/shared/codex-route-compaction-scan.ts:133`; both exports delegate at `:175` and `:183`. `codex-route-warnings.test.ts:575` protects unsupported-override warnings, `:696` protects Lossless migration, and `:873` protects conflicting per-agent models. |
| Repeated collector parameter declarations | Same field shapes at `codex-route-compaction-scan.ts:25` and `:37`. Environment routing remains covered at `codex-route-warnings.test.ts:553`; cleared runtime-pin behavior at `:1190`, `:1218` and `:1245`. |
| Repeated shared-default parameter declarations | Shared type at `codex-route-compaction-scan.ts:37`; consumer bodies unchanged at `:191` and `:259`. Mixed/inherited configurations remain covered at `codex-route-warnings.test.ts:731`, `:954`, `:1090` and `:1265`. |

`git log -S collectUnsupportedCodexCompactionOverrides` reaches the diagnostics split `aac4c16f84c` (#107955). The existing documented contract remains: native Codex owns compaction; Doctor retains its current handling of ignored local summarizer overrides and legacy Lossless configuration. No migration, config, model-routing or runtime contract changes.

## User Impact

No observable behavior change. Warning order, inheritance, runtime-pin handling, environment inputs, repair decisions and deduplication keys are preserved. No tests were changed or removed.

## Evidence

- Full Codex-route warning/repair suite: all 132 cases passed before and after.
- AST/source comparison confirms unchanged classification, deduplication and shared-default consumer bodies.
- Production +42 / −72 = **−30 lines**. Tests/support, tooling and docs: unchanged.

- Full `node scripts/check-changed.mjs` passed, including typechecking, Knip, lint and runtime import-cycle checks.
- Independent Codex review: scoped-clean, no actionable P0–P2 findings.

ClawSweeper’s current technical review found no actionable introduced defects and confirmed unchanged warning/repair behavior. The mechanically rebased branch retains the same scan source, and fresh independent review is clean. Its stored-data category is a path classification: this change preserves both migration classifiers, their inputs and deduplication bodies, and changes no schema, stored representation or repair outcome.

The first CI attempt failed in the unrelated docs route assertion introduced by #140319. Rebased onto its main-side repair #140337 for fresh exact-head CI.

The Discord/IRC extension bundle then hit five missed post-import WAV-spy injections in `transcripts-recording.test.ts` (four authorization-loss cases and one cleanup-failure case). The suite, WAV owner, shared mock/harness and non-isolated runner are byte-identical between the failed head and current main; this PR changes only the Doctor scan. Fresh main passed all 43 recording cases and all 659 cases across 44 voice files. The one targeted retry of the original exact head passed the same Linux/Node24 job (run 34050646695, attempt 2, job 101553616943), confirming an inherited intermittent test-injection failure. No production/test workaround or assertion change was made.

The refreshed branch preserves the scan source and lock exactly; all 132 compaction cases and fresh independent P0-P2 review pass.

The full changed-file gate also passed again on the refreshed candidate, including core/test type lanes, all three dead-export scans and repository guards.

Exact-head CI is green on the refreshed head `8e404081533ac1c151cac91a899870149ef9fe08`, including the Discord extension bundle.

ClawSweeper disposition: the repeated data-model compatibility checkbox is a path classification. Compatibility proof is already recorded: the classifier, deduper, and shared-consumer bodies are unchanged; traversal inputs/order are equivalent; all 132 warning/repair cases pass. Its current technical review confirms no stored representation, migration outcome, plugin API, or authority change. No storage operation or migration is added or changed, so an additional migration scenario is not applicable.
