### PR TITLE
refactor(ui): share channel status type definitions

### DIFF
--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -98,148 +98,71 @@ export type WhatsAppStatus = {
   lastError?: string | null;
 };
 
-type TelegramBot = {
-  id?: number | null;
-  username?: string | null;
-};
-
-type TelegramWebhook = {
-  url?: string | null;
-  hasCustomCert?: boolean | null;
-};
-
-type TelegramProbe = {
+type ChannelProbe = {
   ok: boolean;
   status?: number | null;
   error?: string | null;
   elapsedMs?: number | null;
-  bot?: TelegramBot | null;
-  webhook?: TelegramWebhook | null;
 };
 
-export type TelegramStatus = {
+type ChannelStatus<Probe = ChannelProbe> = {
   configured: boolean;
-  tokenSource?: string | null;
   running: boolean;
+  lastStartAt?: number | null;
+  lastStopAt?: number | null;
+  lastError?: string | null;
+  probe?: Probe | null;
+  lastProbeAt?: number | null;
+};
+
+type TelegramProbe = ChannelProbe & {
+  bot?: { id?: number | null; username?: string | null } | null;
+  webhook?: { url?: string | null; hasCustomCert?: boolean | null } | null;
+};
+
+export type TelegramStatus = ChannelStatus<TelegramProbe> & {
+  tokenSource?: string | null;
   mode?: string | null;
-  lastStartAt?: number | null;
-  lastStopAt?: number | null;
-  lastError?: string | null;
-  probe?: TelegramProbe | null;
-  lastProbeAt?: number | null;
 };
 
-type DiscordBot = {
-  id?: string | null;
-  username?: string | null;
+type DiscordProbe = ChannelProbe & {
+  bot?: { id?: string | null; username?: string | null } | null;
 };
 
-type DiscordProbe = {
-  ok: boolean;
-  status?: number | null;
-  error?: string | null;
-  elapsedMs?: number | null;
-  bot?: DiscordBot | null;
-};
-
-export type DiscordStatus = {
-  configured: boolean;
+export type DiscordStatus = ChannelStatus<DiscordProbe> & {
   tokenSource?: string | null;
-  running: boolean;
-  lastStartAt?: number | null;
-  lastStopAt?: number | null;
-  lastError?: string | null;
-  probe?: DiscordProbe | null;
-  lastProbeAt?: number | null;
 };
 
-type GoogleChatProbe = {
-  ok: boolean;
-  status?: number | null;
-  error?: string | null;
-  elapsedMs?: number | null;
-};
-
-export type GoogleChatStatus = {
-  configured: boolean;
+export type GoogleChatStatus = ChannelStatus & {
   credentialSource?: string | null;
   audienceType?: string | null;
   audience?: string | null;
   webhookPath?: string | null;
   webhookUrl?: string | null;
-  running: boolean;
-  lastStartAt?: number | null;
-  lastStopAt?: number | null;
-  lastError?: string | null;
-  probe?: GoogleChatProbe | null;
-  lastProbeAt?: number | null;
 };
 
-type SlackBot = {
+type SlackIdentity = {
   id?: string | null;
   name?: string | null;
 };
 
-type SlackTeam = {
-  id?: string | null;
-  name?: string | null;
+type SlackProbe = ChannelProbe & {
+  bot?: SlackIdentity | null;
+  team?: SlackIdentity | null;
 };
 
-type SlackProbe = {
-  ok: boolean;
-  status?: number | null;
-  error?: string | null;
-  elapsedMs?: number | null;
-  bot?: SlackBot | null;
-  team?: SlackTeam | null;
-};
-
-export type SlackStatus = {
-  configured: boolean;
+export type SlackStatus = ChannelStatus<SlackProbe> & {
   botTokenSource?: string | null;
   appTokenSource?: string | null;
-  running: boolean;
-  lastStartAt?: number | null;
-  lastStopAt?: number | null;
-  lastError?: string | null;
-  probe?: SlackProbe | null;
-  lastProbeAt?: number | null;
 };
 
-type SignalProbe = {
-  ok: boolean;
-  status?: number | null;
-  error?: string | null;
-  elapsedMs?: number | null;
-  version?: string | null;
-};
-
-export type SignalStatus = {
-  configured: boolean;
+export type SignalStatus = ChannelStatus<ChannelProbe & { version?: string | null }> & {
   baseUrl: string;
-  running: boolean;
-  lastStartAt?: number | null;
-  lastStopAt?: number | null;
-  lastError?: string | null;
-  probe?: SignalProbe | null;
-  lastProbeAt?: number | null;
 };
 
-type IMessageProbe = {
-  ok: boolean;
-  error?: string | null;
-};
-
-export type IMessageStatus = {
-  configured: boolean;
-  running: boolean;
-  lastStartAt?: number | null;
-  lastStopAt?: number | null;
-  lastError?: string | null;
+export type IMessageStatus = ChannelStatus<Pick<ChannelProbe, "ok" | "error">> & {
   cliPath?: string | null;
   dbPath?: string | null;
-  probe?: IMessageProbe | null;
-  lastProbeAt?: number | null;
 };
 
 export type NostrProfile = {


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

The Control UI repeats the same lifecycle and probe fields across six channel status types. This creates avoidable maintenance debt in the maintainer-directed deletion campaign following the #135868 split.

## Why This Change Was Made

Share the common lifecycle/probe definitions and the identical Slack bot/team identity shape. Keep all six exported channel types and every existing field, requiredness, nullability, and channel-specific probe detail. The types are actively read through the detail renderer's computed channel key, so none of those runtime projections are removed.

## User Impact

No user-visible change. This removes 77 production lines (+21/−98) from one file, with no test, tooling, or documentation delta. No tests or coverage are removed. UI rendering, styles, requests, and emitted JavaScript are unchanged.

## Evidence

- TypeScript-checker comparison recursively expanded all six before/after status types, including nested property keys, primitive unions, optional and readonly flags: identical.
- Full-file before/after JavaScript transpilation: byte-identical.
- `node scripts/run-vitest.mjs --config ui/vitest.config.ts ui/src/pages/channels ui/src/lib/channels`: 8 files, 120 tests passed. Existing localized status/probe cases remain in `ui/src/pages/channels/view.test.ts:507`; missing-status distinctions remain at `:557`.
- `node scripts/check-changed.mjs`: passed the full selected gate (core-test types, UI types, i18n, dead exports, lint).
- Independent Codex P0–P2 autoreview: scoped-clean, no accepted/actionable findings.
- No visual change; this is erased type-only source, so screenshots would show identical output. No build, published API, packaging, or lazy boundary changed.

### Resolved CI blocker

The first head exposed an unrelated main failure in `test/scripts/docs-sync-publish.test.ts:377`, where the route guard rejected release subpages from #140319. The separate repair #140337 is now merged. Landing this unchanged type refactor requires fresh exact-head CI against the repaired main.

ClawSweeper reviewed the original type patch with no actionable findings, before-merge requests, or rank-up moves. The rebased patch remains identical. All 120 focused channel tests and the 10 docs-sync tests pass on the repaired-main branch.
