### PR TITLE
refactor(plugins): return self-hosted auth results directly

### DIFF
--- a/src/plugins/provider-self-hosted-setup.interactive.test.ts
+++ b/src/plugins/provider-self-hosted-setup.interactive.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import { createWizardPrompter } from "../../test/helpers/wizard-prompter.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { promptAndConfigureOpenAICompatibleSelfHostedProviderAuth } from "./provider-self-hosted-setup.js";
+
+const { fetchWithSsrFGuardMock, upsertAuthProfileWithLock } = vi.hoisted(() => ({
+  fetchWithSsrFGuardMock: vi.fn(),
+  upsertAuthProfileWithLock: vi.fn(async () => null),
+}));
+
+vi.mock("../infra/net/fetch-guard.js", () => ({
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+vi.mock("../agents/auth-profiles/upsert-with-lock.js", () => ({
+  upsertAuthProfileWithLock,
+}));
+
+describe("promptAndConfigureOpenAICompatibleSelfHostedProviderAuth", () => {
+  it("returns normalized interactive setup results", async () => {
+    const prompter = createWizardPrompter();
+    vi.mocked(prompter.text)
+      .mockResolvedValueOnce(" https://fixture.example.invalid/v1/// ")
+      .mockResolvedValueOnce(" synthetic-setup-key ")
+      .mockResolvedValueOnce(" org/demo-model ");
+    const cfg = {
+      agents: { defaults: { model: "existing/model" } },
+      models: {
+        mode: "replace",
+        providers: { existing: { baseUrl: "https://existing.example.invalid/v1", models: [] } },
+      },
+    } satisfies OpenClawConfig;
+
+    const result = await promptAndConfigureOpenAICompatibleSelfHostedProviderAuth({
+      cfg,
+      prompter,
+      providerId: "fixture",
+      providerLabel: "Fixture",
+      defaultBaseUrl: "http://127.0.0.1:8000/v1",
+      defaultApiKeyEnvVar: "FIXTURE_API_KEY",
+      modelPlaceholder: "org/example",
+      input: ["text", "image"],
+      reasoning: true,
+      contextWindow: 8192,
+      maxTokens: 1024,
+    });
+
+    expect(result).toEqual({
+      profiles: [
+        {
+          profileId: "fixture:default",
+          credential: { type: "api_key", provider: "fixture", key: "synthetic-setup-key" },
+        },
+      ],
+      configPatch: {
+        ...cfg,
+        models: {
+          ...cfg.models,
+          providers: {
+            ...cfg.models.providers,
+            fixture: {
+              baseUrl: "https://fixture.example.invalid/v1",
+              api: "openai-completions",
+              apiKey: "FIXTURE_API_KEY",
+              models: [
+                {
+                  id: "org/demo-model",
+                  name: "org/demo-model",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 1024,
+                },
+              ],
+            },
+          },
+        },
+      },
+      defaultModel: "fixture/org/demo-model",
+    });
+    expect(vi.mocked(prompter.text).mock.calls).toEqual([
+      [
+        {
+          message: "Fixture base URL",
+          initialValue: "http://127.0.0.1:8000/v1",
+          placeholder: "http://127.0.0.1:8000/v1",
+          validate: expect.any(Function),
+        },
+      ],
+      [
+        {
+          message: "Fixture API key",
+          placeholder: "sk-... (or any non-empty string)",
+          validate: expect.any(Function),
+          sensitive: true,
+        },
+      ],
+      [{ message: "Fixture model", placeholder: "org/example", validate: expect.any(Function) }],
+    ]);
+    for (const [prompt] of vi.mocked(prompter.text).mock.calls) {
+      expect(prompt.validate?.(" ")).toBe("Required");
+      expect(prompt.validate?.(" value ")).toBeUndefined();
+    }
+    expect(upsertAuthProfileWithLock).not.toHaveBeenCalled();
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/plugins/provider-self-hosted-setup.ts
+++ b/src/plugins/provider-self-hosted-setup.ts
@@ -66,7 +66,7 @@ function buildOpenAICompatibleSelfHostedProviderConfig(params: {
   reasoning?: boolean;
   contextWindow?: number;
   maxTokens?: number;
-}): { config: OpenClawConfig; modelId: string; modelRef: string; profileId: string } {
+}): { config: OpenClawConfig; modelRef: string; profileId: string } {
   const modelRef = `${params.providerId}/${params.modelId}`;
   const profileId = `${params.providerId}:default`;
   return {
@@ -96,7 +96,6 @@ function buildOpenAICompatibleSelfHostedProviderConfig(params: {
         },
       },
     },
-    modelId: params.modelId,
     modelRef,
     profileId,
   };
@@ -116,17 +115,9 @@ type OpenAICompatibleSelfHostedProviderSetupParams = {
   maxTokens?: number;
 };
 
-type OpenAICompatibleSelfHostedProviderPromptResult = {
-  config: OpenClawConfig;
-  credential: AuthProfileCredential;
-  modelId: string;
-  modelRef: string;
-  profileId: string;
-};
-
-async function promptAndConfigureOpenAICompatibleSelfHostedProvider(
+export async function promptAndConfigureOpenAICompatibleSelfHostedProviderAuth(
   params: OpenAICompatibleSelfHostedProviderSetupParams,
-): Promise<OpenAICompatibleSelfHostedProviderPromptResult> {
+): Promise<ProviderAuthResult> {
   const baseUrlRaw = await params.prompter.text({
     message: `${params.providerLabel} base URL`,
     initialValue: params.defaultBaseUrl,
@@ -166,22 +157,9 @@ async function promptAndConfigureOpenAICompatibleSelfHostedProvider(
   });
 
   return {
-    config: configured.config,
-    credential,
-    modelId: configured.modelId,
-    modelRef: configured.modelRef,
-    profileId: configured.profileId,
-  };
-}
-
-export async function promptAndConfigureOpenAICompatibleSelfHostedProviderAuth(
-  params: OpenAICompatibleSelfHostedProviderSetupParams,
-): Promise<ProviderAuthResult> {
-  const result = await promptAndConfigureOpenAICompatibleSelfHostedProvider(params);
-  return {
-    profiles: [{ profileId: result.profileId, credential: result.credential }],
-    configPatch: result.config,
-    defaultModel: result.modelRef,
+    profiles: [{ profileId: configured.profileId, credential }],
+    configPatch: configured.config,
+    defaultModel: configured.modelRef,
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Self-hosted provider setup retains an intermediate result layer left behind after its former public consumer was removed.

## Why This Change Was Made

Return the existing public auth result directly from the interactive prompt flow. Delete the private result type, forwarding function and unused returned model ID while preserving the three prompts, normalization, model metadata and shared configuration builder.

## User Impact

The public setup API, prompts and generated configuration remain unchanged. Production code decreases by 22 lines.

## Evidence

The same three selected interactive/noninteractive cases pass before and after using synthetic prompt values. All 29 canonical checks and the managed P2 review pass. The new characterization lives in a focused sibling test file; the original test file is unchanged, and the existing line limit is preserved. No live provider or credential-store operation was exercised.
