### PR TITLE
feat(onboarding): require explicit AI choice in desktop and Control UI

### DIFF
--- a/apps/linux/README.md
+++ b/apps/linux/README.md
@@ -94,15 +94,36 @@ to loopback when possible. See the
 [remote access guide](https://docs.openclaw.ai/gateway/remote) for Gateway
 authentication and network requirements.
 
-After connecting, Model Setup checks existing credentials and verifies a real
-model response before continuing. If no existing credentials work, choose a
-provider and either sign in or enter an API key. The selected Gateway owns the
-provider credentials and model configuration. A working existing model opens
-the normal dashboard; newly configured AI access continues into guided
-onboarding. In-progress model setup and guided onboarding survive Gateway
-restarts. If the app closes while model activation is in progress, reopening it
-resumes the same Gateway, agent, and model without activating the provider
-twice.
+After connecting, Model Setup discovers AI access available to the selected
+Gateway and shows it as a choice. Discovery never imports or copies an account,
+and the companion never selects, tests, installs, or saves a provider until you
+click its action. The list includes supported installed providers and official
+provider plugins available from OpenClaw's managed plugin catalog. Installing a
+provider plugin shows its capabilities for review and continues directly to
+that provider's authentication form. Successful verification may require a
+Gateway restart before the new model becomes available.
+
+The custom endpoint option supports OpenAI- and Anthropic-compatible services.
+For a local Gateway, it opens the canonical guided endpoint setup. For a remote
+Gateway, run `openclaw onboard --auth-choice custom-api-key` on the Gateway host as directed by the setup
+message; custom-provider secrets must be entered on their owning host. The
+desktop companion does not copy remote provider secrets to this computer.
+
+On a fresh install, setup also asks whether existing native Claude and Codex
+conversations should appear in OpenClaw. This is discovery only, not an import
+or copy. The option starts unchecked; declining disables both native session
+catalogs. Existing installations keep their current catalog behavior during an
+upgrade.
+
+Once you choose AI access, Model Setup follows the provider's normal review and
+verification flow. A temporary connection loss resumes the admitted setup
+wizard on the same Gateway and account without repeating installation or the last answer.
+After a completed activation requests a restart, setup can resume verification
+of that same model. If an unfinished wizard is no longer available, setup shows
+a recovery message instead of repeating authentication automatically. **Check again**
+refreshes the current setup; if a model was saved, you can explicitly verify and use it. Gateway
+failures retain their detailed recovery message so setup can identify
+authentication, network, service, or restart problems.
 
 For OpenAI, **ChatGPT Login** uses a ChatGPT or Codex subscription, while
 **OpenAI API Key** uses API billing. When the Gateway runs on another host and

--- a/apps/linux/src-tauri/src/gateway_ws.rs
+++ b/apps/linux/src-tauri/src/gateway_ws.rs
@@ -1869,7 +1869,11 @@ esac
                     .prepare_dashboard_url(&ready.dashboard_url)
                     .expect("first-run dashboard");
                 assert_eq!(first_run.path(), "/control/settings/model-setup", "{mode}");
-                assert_eq!(first_run.query(), Some("keep=yes&firstRun=explicit"), "{mode}");
+                assert_eq!(
+                    first_run.query(),
+                    Some("keep=yes&firstRun=explicit"),
+                    "{mode}"
+                );
                 assert_eq!(
                     first_run.fragment(),
                     Some("bootstrapToken=fixture%2Bbrowser%2Fgrant%3D&bootstrapProfile=owner"),

--- a/apps/linux/src-tauri/src/gateway_ws.rs
+++ b/apps/linux/src-tauri/src/gateway_ws.rs
@@ -1869,7 +1869,7 @@ esac
                     .prepare_dashboard_url(&ready.dashboard_url)
                     .expect("first-run dashboard");
                 assert_eq!(first_run.path(), "/control/settings/model-setup", "{mode}");
-                assert_eq!(first_run.query(), Some("keep=yes&firstRun=1"), "{mode}");
+                assert_eq!(first_run.query(), Some("keep=yes&firstRun=explicit"), "{mode}");
                 assert_eq!(
                     first_run.fragment(),
                     Some("bootstrapToken=fixture%2Bbrowser%2Fgrant%3D&bootstrapProfile=owner"),

--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -1036,7 +1036,10 @@ mod navigation_tests {
     fn only_active_onboarding_preserves_the_dashboard_during_reconnect() {
         for (url, preserve) in [
             ("http://127.0.0.1/settings/model-setup?firstRun=1", true),
-            ("http://127.0.0.1/settings/model-setup?firstRun=explicit", true),
+            (
+                "http://127.0.0.1/settings/model-setup?firstRun=explicit",
+                true,
+            ),
             (
                 "http://127.0.0.1/openclaw/settings/model-setup/?tab=ai&firstRun=1#token=redacted",
                 true,

--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -107,7 +107,7 @@ fn is_active_onboarding_url(url: &Url) -> bool {
         .find(|(key, _)| key == query_key)
         .is_some_and(|(_, value)| {
             if query_key == "firstRun" {
-                return value == "1";
+                return value == "1" || value == "explicit";
             }
             matches!(
                 value.trim().to_ascii_lowercase().as_str(),
@@ -344,11 +344,20 @@ impl NavigationState {
             Url::parse(target).map_err(|_| "Dashboard returned an invalid URL.".to_string())?;
         if self.onboarding_pending {
             // Setup owns inference before chat; preserve Gateway base paths and fragment auth.
+            // Saved first-run links may use either marker; new links use explicit.
             url.path_segments_mut()
                 .map_err(|_| "Dashboard returned an invalid URL.".to_string())?
                 .pop_if_empty()
                 .extend(["settings", "model-setup"]);
-            url.query_pairs_mut().append_pair("firstRun", "1");
+            let existing_query = url
+                .query_pairs()
+                .filter(|(key, _)| key != "firstRun")
+                .map(|(key, value)| (key.into_owned(), value.into_owned()))
+                .collect::<Vec<_>>();
+            url.query_pairs_mut()
+                .clear()
+                .extend_pairs(existing_query)
+                .append_pair("firstRun", "explicit");
             self.onboarding_pending = false;
         }
         Ok(url)
@@ -1027,6 +1036,7 @@ mod navigation_tests {
     fn only_active_onboarding_preserves_the_dashboard_during_reconnect() {
         for (url, preserve) in [
             ("http://127.0.0.1/settings/model-setup?firstRun=1", true),
+            ("http://127.0.0.1/settings/model-setup?firstRun=explicit", true),
             (
                 "http://127.0.0.1/openclaw/settings/model-setup/?tab=ai&firstRun=1#token=redacted",
                 true,
@@ -1120,11 +1130,13 @@ mod navigation_tests {
         navigation.mark_onboarding_pending();
 
         let url = navigation
-            .prepare_dashboard_url("http://127.0.0.1:18789/openclaw/?foo=bar#token=secret")
+            .prepare_dashboard_url(
+                "http://127.0.0.1:18789/openclaw/?foo=bar&firstRun=1#token=secret",
+            )
             .expect("dashboard URL");
 
         assert_eq!(url.path(), "/openclaw/settings/model-setup");
-        assert_eq!(url.query(), Some("foo=bar&firstRun=1"));
+        assert_eq!(url.query(), Some("foo=bar&firstRun=explicit"));
         assert_eq!(url.fragment(), Some("token=secret"));
     }
 
@@ -1141,7 +1153,7 @@ mod navigation_tests {
             .expect("second dashboard URL");
 
         assert_eq!(first.path(), "/settings/model-setup");
-        assert_eq!(first.query(), Some("firstRun=1"));
+        assert_eq!(first.query(), Some("firstRun=explicit"));
         assert!(is_active_onboarding_url(&first));
         assert_eq!(second.path(), "/");
         assert_eq!(second.query(), None);

--- a/src/gateway/server-methods/system-agent-setup-control-ui.test.ts
+++ b/src/gateway/server-methods/system-agent-setup-control-ui.test.ts
@@ -1,25 +1,26 @@
 /* @vitest-environment jsdom */
+import "../../../ui/src/test-helpers/lit-warnings.setup.ts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { applyWizardMetadata } from "../../../../src/commands/onboard-helpers.js";
-import { createConfigFileSnapshot } from "../../../../src/config/io.snapshot-shared.js";
-import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
-import { systemAgentHandlers } from "../../../../src/gateway/server-methods/system-agent.js";
-import { initializeNativeSessionCatalogPreferences } from "../../../../src/plugins/native-session-catalog-config.js";
-import { createPluginMetadataSnapshotFixture } from "../../../../src/plugins/plugin-metadata.test-support.js";
-import { i18n } from "../../i18n/index.ts";
-import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
-import { createStorageMock } from "../../test-helpers/storage.ts";
-import { waitForFast } from "../../test-helpers/wait-for.ts";
-import { createFirstRunContext } from "./model-setup-first-run.test-support.ts";
-import { ModelSetupPage } from "./model-setup-page.ts";
+import { i18n } from "../../../ui/src/i18n/index.ts";
+import { createFirstRunContext } from "../../../ui/src/pages/model-setup/model-setup-first-run.test-support.ts";
+import { ModelSetupPage } from "../../../ui/src/pages/model-setup/model-setup-page.ts";
+import { createApplicationContextProvider } from "../../../ui/src/test-helpers/application-context.ts";
+import { createStorageMock } from "../../../ui/src/test-helpers/storage.ts";
+import { waitForFast } from "../../../ui/src/test-helpers/wait-for.ts";
+import { applyWizardMetadata } from "../../commands/onboard-helpers.js";
+import { createConfigFileSnapshot } from "../../config/io.snapshot-shared.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { initializeNativeSessionCatalogPreferences } from "../../plugins/native-session-catalog-config.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { systemAgentHandlers } from "./system-agent.js";
 
 const fixture = vi.hoisted(() => ({
   config: {} as OpenClawConfig,
   exists: false,
   additionalCatalog: false,
 }));
-vi.mock("../../../../src/config/config.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../../../../src/config/config.js")>()),
+vi.mock("../../config/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../config/config.js")>()),
   readConfigFileSnapshotWithPluginMetadata: async () => ({
     snapshot: createConfigFileSnapshot({
       path: "/tmp/synthetic-onboarding/openclaw.json",
@@ -47,16 +48,15 @@ vi.mock("../../../../src/config/config.js", async (importOriginal) => ({
     }),
   }),
 }));
-vi.mock("../../../../src/plugins/provider-install-catalog.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../../../../src/plugins/provider-install-catalog.js")>()),
+vi.mock("../../plugins/provider-install-catalog.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../plugins/provider-install-catalog.js")>()),
   resolveProviderInstallCatalogEntries: () => [],
 }));
-vi.mock("../../../../src/system-agent/setup-inference-detection.js", () => ({
+vi.mock("../../system-agent/setup-inference-detection.js", () => ({
   // Replace worker/process discovery only. Actual handler parameters, authored
   // config interpretation, consent decision, RPC client and UI all compose here.
   detectSetupInferenceIsolated: async (params: { agentId?: string }) => {
-    const { detectSetupInference } =
-      await import("../../../../src/system-agent/setup-inference-detect.js");
+    const { detectSetupInference } = await import("../../system-agent/setup-inference-detect.js");
     return detectSetupInference(
       {
         resolveManifestProviderAuthChoices: () => [],
@@ -73,8 +73,9 @@ describe("selected-agent Gateway detection and Model Setup consent", () => {
     vi.stubGlobal("localStorage", createStorageMock());
     await i18n.setLocale("en");
   });
-  afterEach(() => {
+  afterEach(async () => {
     document.body.replaceChildren();
+    await vi.dynamicImportSettled();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });

--- a/test/vitest-projects-config.test.ts
+++ b/test/vitest-projects-config.test.ts
@@ -55,6 +55,7 @@ const patternFiles = createPatternFileHelper("openclaw-vitest-projects-config-")
 const scopedGatewayMethodsIsolatedTestFiles = [
   "server-methods/agent.test.ts",
   "server-methods/board.runtime-boundaries.test.ts",
+  "server-methods/system-agent-setup-control-ui.test.ts",
   "server-methods/usage.test.ts",
   "server-methods/usage.sessions-usage.test.ts",
 ];
@@ -116,8 +117,12 @@ describe("projects vitest config", () => {
     expect(serverIsolatedConfig.include).toEqual(gatewayServerIsolatedTestFiles);
     expect(methodsConfig.exclude).toContain("server-methods/agent.test.ts");
     expect(methodsConfig.exclude).toContain("server-methods/board.runtime-boundaries.test.ts");
+    expect(methodsConfig.exclude).toContain("server-methods/system-agent-setup-control-ui.test.ts");
     expect(gatewayFallback.exclude).toContain("server-methods/agent.test.ts");
     expect(gatewayFallback.exclude).toContain("server-methods/board.runtime-boundaries.test.ts");
+    expect(gatewayFallback.exclude).toContain(
+      "server-methods/system-agent-setup-control-ui.test.ts",
+    );
     expect(gatewayFallback.exclude).toContain("server.sessions.compaction-read-errors.test.ts");
   });
 

--- a/test/vitest/vitest.gateway-server-paths.mjs
+++ b/test/vitest/vitest.gateway-server-paths.mjs
@@ -12,6 +12,7 @@ export const gatewayServerBackedHttpTestFiles = [
 export const gatewayMethodsIsolatedTestFiles = [
   "src/gateway/server-methods/agent.test.ts",
   "src/gateway/server-methods/board.runtime-boundaries.test.ts",
+  "src/gateway/server-methods/system-agent-setup-control-ui.test.ts",
   "src/gateway/server-methods/usage.test.ts",
   "src/gateway/server-methods/usage.sessions-usage.test.ts",
 ];

--- a/test/vitest/vitest.ui-isolated-paths.mjs
+++ b/test/vitest/vitest.ui-isolated-paths.mjs
@@ -34,7 +34,6 @@ export const uiIsolatedTestFiles = [
   "ui/src/pages/config/config-page.custom-theme.test.ts",
   "ui/src/pages/config/memory-mutation-owner.test.ts",
   "ui/src/pages/config/memory-page.test.ts",
-  "ui/src/pages/model-setup/model-setup-server-consent.test.ts",
   "ui/src/pages/new-session/draft-persistence.test.ts",
   "ui/src/pages/sessions/sessions-page.archived.test.ts",
 ];

--- a/test/vitest/vitest.ui-isolated-paths.mjs
+++ b/test/vitest/vitest.ui-isolated-paths.mjs
@@ -34,6 +34,7 @@ export const uiIsolatedTestFiles = [
   "ui/src/pages/config/config-page.custom-theme.test.ts",
   "ui/src/pages/config/memory-mutation-owner.test.ts",
   "ui/src/pages/config/memory-page.test.ts",
+  "ui/src/pages/model-setup/model-setup-server-consent.test.ts",
   "ui/src/pages/new-session/draft-persistence.test.ts",
   "ui/src/pages/sessions/sessions-page.archived.test.ts",
 ];

--- a/ui/src/e2e/custodian-channel-onboarding.e2e.test.ts
+++ b/ui/src/e2e/custodian-channel-onboarding.e2e.test.ts
@@ -129,6 +129,13 @@ describeControlUiE2e("Control UI Custodian channel onboarding mocked Gateway E2E
     try {
       const response = await page.goto(`${server.baseUrl}settings/model-setup?firstRun=1`);
       expect(response?.status()).toBe(200);
+      const providerChoice = page
+        .locator('[data-candidate-kind="openai-api-key"]')
+        .getByRole("button", { name: "Test & use", exact: true });
+      await providerChoice.waitFor();
+      expect(await gateway.getRequests("openclaw.setup.activate.start")).toHaveLength(0);
+      await providerChoice.click();
+      await gateway.waitForRequest("openclaw.setup.activate.start");
       await waitForControlUiRoute(page, {
         pathname: "/custodian",
         routeId: "custodian",
@@ -136,7 +143,7 @@ describeControlUiE2e("Control UI Custodian channel onboarding mocked Gateway E2E
       });
       await page.screenshot({
         animations: "disabled",
-        path: path.join(artifactDir, "01-after-automatic-model-setup.png"),
+        path: path.join(artifactDir, "01-after-explicit-model-setup.png"),
       });
       await gateway.waitForRequest("channels.status");
       await gateway.rejectDeferred("channels.status", {

--- a/ui/src/e2e/initial-connect-splash.e2e.test.ts
+++ b/ui/src/e2e/initial-connect-splash.e2e.test.ts
@@ -338,7 +338,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     const sectionTitles = [
       "Found on this Gateway",
       "Run a model locally",
-      "Sign in with a provider",
+      "Connect an AI provider",
       "Connect with an API key or token",
     ];
     const loadingSectionTops = await Promise.all(

--- a/ui/src/e2e/model-setup-activation-feedback.e2e.test.ts
+++ b/ui/src/e2e/model-setup-activation-feedback.e2e.test.ts
@@ -191,6 +191,10 @@ suite.define(() => {
             page.locator(".content").evaluate((element) => {
               element.scrollTo({ top: element.scrollHeight, behavior: "instant" });
             });
+          if (entry === "manual") {
+            await setup.locator(".model-setup-provider-select__trigger").click();
+            await setup.locator('[data-manual-provider="openai"]').click();
+          }
           await input.fill("invalid-test-key");
           const activate =
             entry === "manual"

--- a/ui/src/e2e/model-setup-cancel.e2e.test.ts
+++ b/ui/src/e2e/model-setup-cancel.e2e.test.ts
@@ -1,7 +1,9 @@
 // Real routing and browser storage; Gateway/provider sign-in is mocked.
 import path from "node:path";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import type { Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
+import type { ApplicationContext } from "../app/context.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -45,6 +47,21 @@ const gatewayOptions = {
     "wizard.cancel": { status: "cancelled" },
   },
 };
+
+async function openFirstRunWithBackNavigation(page: Page): Promise<void> {
+  await page.goto(`${suite.server.baseUrl}settings/connection`);
+  await page.locator('.settings-sidebar__item[href="/settings/connection"]').waitFor();
+  await page.evaluate(() => {
+    const app = document.querySelector("openclaw-app") as HTMLElement & {
+      runtime?: { context: Pick<ApplicationContext, "navigate"> };
+    };
+    if (!app.runtime) {
+      throw new Error("Control UI runtime is unavailable");
+    }
+    app.runtime.context.navigate("model-setup", { search: "?firstRun=1" });
+  });
+  await page.waitForURL((url) => url.pathname === "/settings/model-setup");
+}
 
 suite.define(() => {
   it.each(["Yes", "No", "Cancel"] as const)(
@@ -135,6 +152,9 @@ suite.define(() => {
             },
           });
           await page.goto(`${suite.server.baseUrl}settings/model-setup?firstRun=1`);
+          await page.locator('[data-candidate-kind="openai-api-key"] button').waitFor();
+          expect(await gateway.getRequests("openclaw.setup.activate.start")).toHaveLength(0);
+          await page.locator('[data-candidate-kind="openai-api-key"] button').click();
           const start = await gateway.waitForRequest("openclaw.setup.activate.start");
           const sessionId = asOptionalRecord(start.params)?.sessionId;
           expect(start.params).toEqual({
@@ -214,7 +234,7 @@ suite.define(() => {
         { locale: "en-US", serviceWorkers: "block", viewport: { width: 1280, height: 800 } },
         async ({ page }) => {
           const gateway = await installMockGateway(page, gatewayOptions);
-          await page.goto(`${suite.server.baseUrl}settings/model-setup?firstRun=1`);
+          await openFirstRunWithBackNavigation(page);
           const signIn = page.locator('[data-auth-choice="provider-login"] button');
           await signIn.click();
           await page.getByText("Complete provider sign-in").waitFor();
@@ -226,14 +246,15 @@ suite.define(() => {
             .getByRole("button", { name: "Cancel", exact: true })
             .click();
           await gateway.waitForRequest("wizard.cancel");
-          await expect.poll(() => page.locator("openclaw-modal-dialog").count()).toBe(0);
-          await page.locator('.settings-sidebar__item[href="/settings/connection"]').click();
+          expect(await page.locator("openclaw-modal-dialog").count()).toBe(1);
+          // Browser navigation remains available while cancellation is unconfirmed.
+          await page.goBack();
           await expect.poll(() => page.locator("openclaw-model-setup-page").count()).toBe(0);
           expect(await readReceipt()).not.toBeNull();
           if (acknowledgement === "before return") {
             await gateway.resolveDeferred("wizard.cancel");
           }
-          await page.goBack();
+          await page.goForward();
           await signIn.waitFor();
           if (acknowledgement === "after return") {
             await gateway.resolveDeferred("wizard.cancel");
@@ -260,7 +281,7 @@ suite.define(() => {
       { locale: "en-US", serviceWorkers: "block" },
       async ({ page, context }) => {
         const gateway = await installMockGateway(page, gatewayOptions);
-        await page.goto(`${suite.server.baseUrl}settings/model-setup?firstRun=1`);
+        await openFirstRunWithBackNavigation(page);
         await page.locator('[data-auth-choice="provider-login"] button').click();
         await page.getByText("Complete provider sign-in").waitFor();
         await gateway.deferNext("wizard.cancel");
@@ -269,25 +290,34 @@ suite.define(() => {
           .getByRole("button", { name: "Cancel", exact: true })
           .click();
         await gateway.waitForRequest("wizard.cancel");
-        await page.locator('.settings-sidebar__item[href="/settings/connection"]').click();
+        expect(await page.locator("openclaw-modal-dialog").count()).toBe(1);
+        await page.goBack();
         await expect.poll(() => page.locator("openclaw-model-setup-page").count()).toBe(0);
 
         const replacement = await context.newPage();
         const nextGateway = await installMockGateway(replacement, gatewayOptions);
-        // Opening ordinary Model Setup explicitly leaves first-run intent. A
-        // later onboarding visit can start a separate operation in this tab.
-        await replacement.goto(`${suite.server.baseUrl}settings/model-setup`);
+        await replacement.goto(`${suite.server.baseUrl}settings/model-setup?firstRun=1`);
         await replacement.locator('[data-auth-choice="provider-login"] button').waitFor();
+        const deadlineMs = await replacement.evaluate(
+          (key) => JSON.parse(localStorage.getItem(key)!).deadlineMs as number,
+          receiptKey,
+        );
+        // The existing receipt deadline, followed by an explicit retry, admits
+        // another intent. No ordinary settings visit may clear another tab's receipt.
+        await replacement.clock.setFixedTime(new Date(deadlineMs + 1));
+        await replacement
+          .locator(".model-setup__recovery")
+          .getByRole("button", { name: "Check again", exact: true })
+          .click();
         await expect
           .poll(() => replacement.evaluate((key) => localStorage.getItem(key), receiptKey))
           .toBeNull();
-        await replacement.goto(`${suite.server.baseUrl}settings/model-setup?firstRun=1`);
         await replacement.locator('[data-auth-choice="provider-login"] button').click();
         await replacement.getByText("Complete provider sign-in").waitFor();
         const receipt = await replacement.evaluate((key) => localStorage.getItem(key), receiptKey);
         expect(receipt).not.toBeNull();
         await gateway.resolveDeferred("wizard.cancel");
-        await page.goBack();
+        await page.goForward();
         await page.locator('[data-auth-choice="provider-login"] button').waitFor();
         expect(await replacement.evaluate((key) => localStorage.getItem(key), receiptKey)).toBe(
           receipt,

--- a/ui/src/e2e/model-setup-explicit.e2e.test.ts
+++ b/ui/src/e2e/model-setup-explicit.e2e.test.ts
@@ -1,0 +1,405 @@
+// Real Control UI rendering and routing; provider/Gateway replies are controlled fixtures.
+import path from "node:path";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Explicit AI onboarding",
+  startServerBeforeBrowser: true,
+});
+const detection = {
+  candidates: [
+    {
+      kind: "codex-cli",
+      label: "Codex",
+      detail: "Available credentials",
+      modelRef: "openai/gpt-5",
+      credentials: true,
+      recommended: true,
+    },
+    {
+      kind: "anthropic-api-key",
+      label: "Anthropic",
+      detail: "Available credentials",
+      modelRef: "anthropic/claude-sonnet-4-6",
+      credentials: true,
+      recommended: false,
+    },
+  ],
+  manualProviders: [{ id: "openai", label: "OpenAI" }],
+  authOptions: [
+    { id: "meta-api-key", label: "Meta", kind: "install", featured: false },
+    { id: "custom-api-key", label: "Custom compatible endpoint", kind: "custom", featured: false },
+  ],
+  nativeSessionCatalogs: [
+    { pluginId: "anthropic", label: "Claude" },
+    { pluginId: "codex", label: "Codex" },
+  ],
+  nativeSessionCatalogPreferenceRequired: true,
+  setupComplete: false,
+  workspace: "/tmp/onboarding-fixture",
+};
+
+suite.define(() => {
+  it.each(["", "?firstRun=1", "?firstRun=explicit"])(
+    "waits for an explicit choice on %s and preserves provider failure details",
+    async (query) => {
+      await suite.withPage(
+        {
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { width: 1080, height: 850 },
+          recordVideo: { dir: suite.artifactDir, size: { width: 1080, height: 850 } },
+        },
+        async ({ page }) => {
+          const gateway = await installMockGateway(page, {
+            featureMethods: [
+              "openclaw.setup.detect",
+              "openclaw.setup.activate.start",
+              "openclaw.setup.auth.start",
+              "wizard.next",
+            ],
+            methodResponses: {
+              "openclaw.setup.detect": detection,
+              "openclaw.setup.activate.start": {
+                done: true,
+                status: "error",
+                error: "HTTP 401: review this provider credential and try again.",
+                activationRejection: { disposition: "rejected-before-promotion", status: "auth" },
+              },
+            },
+          });
+          await page.goto(suite.server.baseUrl + "settings/model-setup" + query);
+          await page.getByRole("heading", { name: "Found on this Gateway" }).waitFor();
+          const choices = page.locator("[data-candidate-kind]");
+          expect(await choices.first().textContent()).toContain("Anthropic");
+          expect(await page.getByLabel("Show existing native conversations").isChecked()).toBe(
+            false,
+          );
+          expect(await page.locator("[data-selected]").count()).toBe(0);
+          await page.getByRole("button", { name: "Check again", exact: true }).click();
+          await gateway.waitForRequest("openclaw.setup.detect", { after: 1 });
+          await page.getByRole("heading", { name: "Found on this Gateway" }).waitFor();
+          for (const method of [
+            "openclaw.setup.activate.start",
+            "openclaw.setup.auth.start",
+            "plugins.install",
+            "openclaw.setup.verify",
+            "config.set",
+            "config.patch",
+            "config.apply",
+          ]) {
+            expect(await gateway.getRequests(method)).toHaveLength(0);
+          }
+          await page.screenshot({
+            path: path.join(
+              suite.artifactDir,
+              query ? "first-run-choices.png" : "settings-choices.png",
+            ),
+          });
+          await page.locator('[data-candidate-kind="anthropic-api-key"] button').click();
+          const activated = await gateway.waitForRequest("openclaw.setup.activate.start");
+          expect(activated.params).toMatchObject({
+            kind: "anthropic-api-key",
+            nativeSessionCatalogsEnabled: false,
+          });
+          await page
+            .getByText("HTTP 401: review this provider credential and try again.", { exact: false })
+            .waitFor();
+          expect(await gateway.getRequests("openclaw.setup.activate.start")).toHaveLength(1);
+          await page.screenshot({
+            path: path.join(
+              suite.artifactDir,
+              query ? "first-run-error.png" : "settings-error.png",
+            ),
+          });
+        },
+      );
+    },
+  );
+
+  it("starts managed provider installation only after a click and waits at capability consent", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { width: 1080, height: 850 },
+        recordVideo: { dir: suite.artifactDir, size: { width: 1080, height: 850 } },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: [
+            "openclaw.setup.detect",
+            "openclaw.setup.auth.start",
+            "wizard.next",
+            "wizard.cancel",
+          ],
+          methodResponses: {
+            "openclaw.setup.detect": detection,
+            "openclaw.setup.auth.start": { done: false, status: "running" },
+            "wizard.next": {
+              done: false,
+              status: "running",
+              step: {
+                id: "capabilities",
+                type: "confirm",
+                message: "Allow this provider plugin to call its inference endpoint?",
+                initialValue: false,
+              },
+            },
+            "wizard.cancel": { status: "cancelled" },
+          },
+        });
+        await page.goto(suite.server.baseUrl + "settings/model-setup?firstRun=1");
+        const install = page
+          .locator('[data-auth-choice="meta-api-key"]')
+          .getByRole("button", { name: "Review & install" });
+        await install.waitFor();
+        expect(await gateway.getRequests("openclaw.setup.auth.start")).toHaveLength(0);
+        expect(
+          await page
+            .locator('[data-auth-choice="custom-api-key"]')
+            .getByRole("button", { name: "Set up endpoint" })
+            .isVisible(),
+        ).toBe(true);
+        await page.getByLabel("Show existing native conversations").check();
+        await install.click();
+        expect((await gateway.waitForRequest("openclaw.setup.auth.start")).params).toMatchObject({
+          authChoice: "meta-api-key",
+          nativeSessionCatalogsEnabled: true,
+        });
+        const dialog = page.locator("openclaw-modal-dialog");
+        await dialog
+          .getByText("Allow this provider plugin to call its inference endpoint?", { exact: true })
+          .waitFor();
+        const next = await gateway.getRequests("wizard.next");
+        expect(next).toHaveLength(1);
+        expect(next[0]!.params).not.toHaveProperty("answer");
+        await page.screenshot({
+          path: path.join(suite.artifactDir, "provider-capability-consent.png"),
+        });
+        await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
+        await gateway.waitForRequest("wizard.cancel");
+        expect(await gateway.getRequests("openclaw.setup.auth.start")).toHaveLength(1);
+      },
+    );
+  });
+
+  it("continues Meta capability review into its auth form, then relaunches without replay", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { width: 1080, height: 850 },
+        recordVideo: { dir: suite.artifactDir, size: { width: 1080, height: 850 } },
+      },
+      async ({ page, context }) => {
+        const modelRef = "meta/fixture-model";
+        const gateway = await installMockGateway(page, {
+          featureMethods: [
+            "openclaw.setup.detect",
+            "openclaw.setup.auth.start",
+            "wizard.next",
+            "wizard.cancel",
+            "openclaw.setup.verify",
+          ],
+          methodResponses: {
+            "openclaw.setup.detect": detection,
+            "openclaw.setup.auth.start": { done: false, status: "running" },
+            "wizard.next": {
+              done: false,
+              status: "running",
+              step: {
+                id: "meta-capabilities",
+                type: "confirm",
+                message: "Accept Meta provider capabilities?",
+                initialValue: false,
+              },
+            },
+          },
+        });
+        await page.goto(suite.server.baseUrl + "settings/model-setup");
+        await page.locator('[data-auth-choice="meta-api-key"] button').click();
+        const start = await gateway.waitForRequest("openclaw.setup.auth.start");
+        expect(start.params).toMatchObject({
+          agentId: "main",
+          authChoice: "meta-api-key",
+          nativeSessionCatalogsEnabled: false,
+        });
+        const dialog = page.locator("openclaw-modal-dialog");
+        await dialog.getByText("Accept Meta provider capabilities?", { exact: true }).waitFor();
+        await page.screenshot({ path: path.join(suite.artifactDir, "meta-capability-review.png") });
+        await gateway.setMethodResponse("wizard.next", {
+          done: false,
+          status: "running",
+          step: {
+            id: "meta-api-key",
+            type: "text",
+            message: "Meta API key",
+            sensitive: true,
+          },
+        });
+        await dialog.getByRole("button", { name: "Yes", exact: true }).click();
+        const key = dialog.getByLabel("Meta API key", { exact: true });
+        await key.waitFor();
+        await page.screenshot({ path: path.join(suite.artifactDir, "meta-auth-form.png") });
+        await key.fill("synthetic-meta-api-key");
+        await gateway.setMethodResponse("wizard.next", {
+          done: true,
+          status: "done",
+          modelActivation: { modelRef },
+        });
+        await dialog.getByRole("button", { name: "Submit", exact: true }).click();
+        await page.locator(".model-setup-success").waitFor();
+        const nextRequests = await gateway.getRequests("wizard.next");
+        expect(nextRequests.map(({ params }) => params)).toEqual([
+          { sessionId: expect.any(String) },
+          { sessionId: expect.any(String), answer: { stepId: "meta-capabilities", value: true } },
+          {
+            sessionId: expect.any(String),
+            answer: { stepId: "meta-api-key", value: "synthetic-meta-api-key" },
+          },
+        ]);
+        await page.screenshot({ path: path.join(suite.artifactDir, "meta-selected.png") });
+        const relaunched = await context.newPage();
+        const afterRelaunch = await installMockGateway(relaunched, {
+          featureMethods: [
+            "openclaw.setup.detect",
+            "openclaw.setup.auth.start",
+            "openclaw.setup.activate.start",
+            "openclaw.setup.verify",
+          ],
+          methodResponses: {
+            "openclaw.setup.detect": {
+              ...detection,
+              configuredModel: modelRef,
+              setupComplete: true,
+              nativeSessionCatalogPreferenceRequired: false,
+            },
+          },
+        });
+        await relaunched.goto(suite.server.baseUrl + "settings/model-setup?firstRun=explicit");
+        await relaunched.locator(".model-setup__current").waitFor();
+        expect(await afterRelaunch.getRequests("openclaw.setup.auth.start")).toHaveLength(0);
+        expect(await afterRelaunch.getRequests("openclaw.setup.activate.start")).toHaveLength(0);
+        expect(await afterRelaunch.getRequests("openclaw.setup.verify")).toHaveLength(0);
+        await relaunched.screenshot({ path: path.join(suite.artifactDir, "meta-relaunched.png") });
+      },
+    );
+  });
+
+  it.each(["success", "failure", "cancel", "remote"] as const)(
+    "keeps custom endpoint %s on the selected provider",
+    async (outcome) => {
+      await suite.withPage(
+        {
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { width: 1080, height: 850 },
+          recordVideo: { dir: suite.artifactDir, size: { width: 1080, height: 850 } },
+        },
+        async ({ page }) => {
+          const gateway = await installMockGateway(page, {
+            featureMethods: [
+              "openclaw.setup.detect",
+              "openclaw.setup.auth.start",
+              "wizard.next",
+              "wizard.cancel",
+            ],
+            methodResponses: {
+              "openclaw.setup.detect": detection,
+              "openclaw.setup.auth.start":
+                outcome === "remote"
+                  ? {
+                      done: true,
+                      status: "error",
+                      error:
+                        "Run openclaw onboard on the Gateway host to configure this custom endpoint.",
+                      activationRejection: {
+                        disposition: "rejected-before-promotion",
+                        status: "unavailable",
+                      },
+                    }
+                  : { done: false, status: "running" },
+              "wizard.cancel": { status: "cancelled" },
+              "wizard.next": {
+                done: false,
+                status: "running",
+                step: {
+                  id: "endpoint",
+                  type: "text",
+                  message: "API base URL",
+                },
+              },
+            },
+          });
+          await page.goto(suite.server.baseUrl + "settings/model-setup");
+          await page.locator('[data-auth-choice="custom-api-key"] button').click();
+          expect((await gateway.waitForRequest("openclaw.setup.auth.start")).params).toMatchObject({
+            authChoice: "custom-api-key",
+            agentId: "main",
+          });
+          const dialog = page.locator("openclaw-modal-dialog");
+          if (outcome === "remote") {
+            await dialog
+              .getByText(
+                "Run openclaw onboard on the Gateway host to configure this custom endpoint.",
+                { exact: false },
+              )
+              .waitFor();
+            expect(await gateway.getRequests("wizard.next")).toHaveLength(0);
+            expect(await gateway.getRequests("openclaw.setup.auth.start")).toHaveLength(1);
+            await page.screenshot({
+              path: path.join(suite.artifactDir, "custom-remote-handoff.png"),
+            });
+            return;
+          }
+          await dialog.getByLabel("API base URL", { exact: true }).fill("http://127.0.0.1:9876/v1");
+          await page.screenshot({
+            path: path.join(suite.artifactDir, "custom-endpoint-input.png"),
+          });
+          if (outcome === "cancel") {
+            await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
+            await gateway.waitForRequest("wizard.cancel");
+            expect(await gateway.getRequests("wizard.next")).toHaveLength(1);
+          } else {
+            await gateway.setMethodResponse(
+              "wizard.next",
+              outcome === "success"
+                ? {
+                    done: true,
+                    status: "done",
+                    modelActivation: { modelRef: "custom/fixture-model" },
+                  }
+                : {
+                    done: true,
+                    status: "error",
+                    error: "The selected endpoint could not be reached. Check its address.",
+                    activationRejection: {
+                      disposition: "rejected-before-promotion",
+                      status: "unavailable",
+                    },
+                  },
+            );
+            await dialog.getByRole("button", { name: "Submit", exact: true }).click();
+            if (outcome === "success") {
+              await page.locator(".model-setup-success").waitFor();
+            } else {
+              await dialog
+                .getByText("The selected endpoint could not be reached. Check its address.", {
+                  exact: false,
+                })
+                .waitFor();
+            }
+          }
+          expect(await gateway.getRequests("openclaw.setup.auth.start")).toHaveLength(1);
+          expect(await gateway.getRequests("openclaw.setup.activate.start")).toHaveLength(0);
+          await page.screenshot({
+            path: path.join(suite.artifactDir, "custom-endpoint-outcome.png"),
+          });
+        },
+      );
+    },
+  );
+});

--- a/ui/src/e2e/model-setup-reconnect.e2e.test.ts
+++ b/ui/src/e2e/model-setup-reconnect.e2e.test.ts
@@ -97,6 +97,8 @@ suite.define(() => {
         );
         const firstConnect = connectParams((await gateway.waitForRequest("connect")).params);
         expect(firstConnect.auth).toMatchObject({ bootstrapToken: "e2e-first-grant" });
+        await page.locator(".model-setup-provider-select__trigger").click();
+        await page.locator('[data-manual-provider="openai"]').click();
         const apiKey = page.locator('.model-setup__manual input[type="password"]');
         await apiKey.fill("invalid-test-key");
         await page.getByRole("button", { name: "Connect & verify" }).click();

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -180,6 +180,9 @@ suite.define(() => {
 
         const detect = await gateway.waitForRequest("openclaw.setup.detect");
         expect(detect.params).toEqual({ agentId: "main" });
+        await page.locator('[data-candidate-kind="openai-api-key"] button').waitFor();
+        expect(await gateway.getRequests("openclaw.setup.activate.start")).toHaveLength(0);
+        await page.locator('[data-candidate-kind="openai-api-key"] button').click();
         const activate = await gateway.waitForRequest("openclaw.setup.activate.start");
         expect(activate.params).toEqual({
           sessionId: expect.any(String),
@@ -780,8 +783,11 @@ suite.define(() => {
         await expect.poll(() => manualProviderHasFocus(lastProviderId)).toBe(true);
         await page.keyboard.press("Home");
         await expect.poll(() => manualProviderHasFocus(firstProviderId)).toBe(true);
-        await page.keyboard.press("ArrowDown");
-        await page.keyboard.press("ArrowDown");
+        const zaiIndex = providerIds.indexOf("zai-cn");
+        expect(zaiIndex).toBeGreaterThan(0);
+        for (let index = 0; index < zaiIndex; index += 1) {
+          await page.keyboard.press("ArrowDown");
+        }
         await expect.poll(() => manualProviderHasFocus("zai-cn")).toBe(true);
         await armProviderHide();
         await page.keyboard.press("Enter");

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2460,7 +2460,7 @@ export const en: TranslationMap & {
     missingAuth: "No provider credential is configured for this model. Set it up in Model Setup.",
     heading: "Connect a verified AI model",
     intro:
-      "OpenClaw checks the AI access available on this Gateway and verifies the exact model before it enables conversations.",
+      "OpenClaw discovers AI access on this Gateway. Choose a provider to begin; nothing is selected, tested, installed, or saved automatically.",
     required: {
       title: "No AI provider configured",
       body: "We couldn't find a provider and model configured for this agent. Choose a supported connection; OpenClaw will test it before enabling chat.",
@@ -2472,8 +2472,8 @@ export const en: TranslationMap & {
     checkAgain: "Check again",
     recovery: {
       unknown:
-        "The previous activation is unresolved. You can verify and use the selected model, or check again after the setup attempt has finished. No activation will be repeated automatically.",
-      wait: "The previous setup attempt may still be running. Wait for its bounded setup window to finish, then choose Check again to retry.",
+        "The previous activation is unresolved. Check again refreshes the current setup without repeating it. If a model is available, you can verify and use it.",
+      wait: "The previous setup attempt may still be running. Check again can refresh its result. If no model appears, check again after {time} to choose a provider.",
       useCurrent: "Verify & use selected model",
     },
     verify: {
@@ -2501,6 +2501,13 @@ export const en: TranslationMap & {
       retry: "Retry test",
       testingButton: "Testing…",
     },
+    nativeDiscovery: {
+      title: "Discover existing conversations",
+      body: "Show native assistant conversations from this Gateway host in OpenClaw. This is discovery, not an import or copy.",
+      enable: "Show existing native conversations",
+      decline:
+        "Leave unchecked to keep native session catalogs off when you connect your AI provider. Existing installations are not changed.",
+    },
     empty: {
       title: "Recommended installs",
       intro: "No existing AI access was detected. Install one of these tools, then check again.",
@@ -2511,7 +2518,9 @@ export const en: TranslationMap & {
       useApiKey: "Use API key",
     },
     signIn: {
-      title: "Sign in with a provider",
+      title: "Connect an AI provider",
+      install: "Review & install",
+      custom: "Set up endpoint",
       signIn: "Sign in",
       pair: "Pair",
       more: "More sign-in options",
@@ -2586,8 +2595,10 @@ export const en: TranslationMap & {
       copy: "Copy",
       expires: "Expires in {count} minutes",
       cancelled: "Provider sign-in was cancelled.",
+      finishingStep: "Setup is finishing the current step. You can cancel when it finishes.",
+      cancelFailed: "Could not confirm cancellation: {error}",
       sessionExpired:
-        "This setup session expired after the Gateway restarted. Close this dialog, then start model setup again.",
+        "The Gateway no longer has this setup session. It may already have finished. Close this dialog and choose Check again to review the current setup.",
       notComplete: "Sign-in finished, but model setup is not complete yet.",
     },
   },

--- a/ui/src/pages/model-setup/first-run-setup.ts
+++ b/ui/src/pages/model-setup/first-run-setup.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
+import { formatDateTimeMs } from "../../lib/format.ts";
 import {
   clearFirstRunActivationReceipt,
   persistFirstRunActivationReceipt,
@@ -16,7 +17,6 @@ import {
 } from "./first-run-activation-receipt.ts";
 import { formatModelSetupError, type ModelSetupTaskResult } from "./model-setup-task-result.ts";
 import {
-  activationTargetId,
   mapVerifyResult,
   type ModelSetupActivationState,
   type ModelSetupPageState,
@@ -30,14 +30,35 @@ export type ModelSetupConnection = Pick<
   agentId: string | null;
 };
 
+export function captureModelSetupConnection(
+  context: ApplicationContext,
+  firstRun: boolean,
+  previousRecoveryScope: string | null = null,
+) {
+  const snapshot = context.gateway.snapshot;
+  return {
+    client: snapshot.client,
+    hello: snapshot.hello,
+    agentId: context.agentSelection.state.selectedId,
+    connected: snapshot.phase === "connected",
+    firstRun,
+    connectionRevision: context.gateway.connectionRevision,
+    // Hello owns authentication; retain its scope only while disconnected.
+    recoveryScope:
+      snapshot.phase === "connected"
+        ? (snapshot.hello?.auth?.recoveryScope ?? null)
+        : previousRecoveryScope,
+  };
+}
+
 export type ModelSetupRouteData = { firstRun: boolean };
 
-type Candidate = SystemAgentSetupDetectResult["candidates"][number];
 type SetupOutcome<T> = ModelSetupTaskResult<T> | undefined;
 
 type FirstRunOwner = {
   generation: number;
   connectionRevision: number;
+  recoveryScope: string | null;
   firstRun: boolean;
   connection: ModelSetupConnection;
 };
@@ -59,7 +80,6 @@ type FirstRunSetupHost = {
   canUseSetup: (client: GatewayBrowserClient | null) => boolean;
   canVerify: (client: GatewayBrowserClient | null) => boolean;
   verify: () => Promise<SetupOutcome<SystemAgentSetupVerifyResult>>;
-  activate: (candidate: Candidate, targetId: string) => Promise<void>;
   setVerifyState: (state: ModelSetupVerifyState) => void;
   setActivationState: (state: ModelSetupActivationState) => void;
   setRefreshWarning: (warning: string | null) => void;
@@ -93,11 +113,12 @@ export class FirstRunSetup {
   }
 
   routeChanged(): void {
+    const receipt = this.pending?.receipt ?? null;
     this.reset();
     this.readyConnection = null;
     this.pending = null;
     if (this.host.routeData()?.firstRun === false) {
-      clearFirstRunActivationReceipt();
+      clearFirstRunActivationReceipt(receipt);
     }
   }
 
@@ -106,12 +127,34 @@ export class FirstRunSetup {
     this.readyConnection = null;
     if (
       this.pending &&
-      (connection.client !== this.pending.owner.connection.client ||
+      (!this.pending.owner.recoveryScope ||
         connection.agentId !== this.pending.owner.connection.agentId ||
-        this.host.context().gateway.connectionRevision !== this.pending.owner.connectionRevision)
+        this.host.context().gateway.connectionRevision !== this.pending.owner.connectionRevision ||
+        (this.host.context().gateway.snapshot.phase === "connected" &&
+          (connection.hello?.auth?.recoveryScope ?? null) !== this.pending.owner.recoveryScope))
     ) {
+      const receipt = this.pending.receipt;
       this.pending = null;
+      clearFirstRunActivationReceipt(receipt);
     }
+  }
+
+  reconnectActivation(connection: ModelSetupConnection): void {
+    const activation = this.pending;
+    if (!activation) {
+      return;
+    }
+    const context = this.host.context();
+    if (
+      !activation.owner.recoveryScope ||
+      activation.owner.connectionRevision !== context.gateway.connectionRevision ||
+      activation.owner.recoveryScope !== (connection.hello?.auth?.recoveryScope ?? null) ||
+      activation.owner.connection.agentId !== connection.agentId ||
+      activation.owner.firstRun !== this.host.routeData()?.firstRun
+    ) {
+      return;
+    }
+    activation.owner = this.owner(activation.owner.firstRun);
   }
 
   retryDetection(): boolean {
@@ -119,8 +162,12 @@ export class FirstRunSetup {
       return false;
     }
     if (this.pending && Date.now() < this.pending.deadlineMs) {
-      this.host.setRefreshWarning(t("modelSetup.recovery.wait"));
-      return false;
+      this.host.setRefreshWarning(
+        t("modelSetup.recovery.wait", { time: formatDateTimeMs(this.pending.deadlineMs) }),
+      );
+      // A read-only refresh can reveal a committed model without retiring the
+      // unresolved activation receipt or permitting another provider mutation.
+      return true;
     }
     if (this.host.routeData()?.firstRun) {
       const page = this.host.pageState();
@@ -189,6 +236,13 @@ export class FirstRunSetup {
         receipt,
         outcome: "pending",
       };
+    }
+    // Detection is not consent. Only an existing, owner-bound activation receipt
+    // may resume verification after reconnect; a fresh visit never tests or
+    // activates even a configured or recommended model.
+    if (!this.pending) {
+      this.started = true;
+      return;
     }
     const configured = pageState.result.setupComplete && pageState.result.configuredModel;
     if (this.pending && (!configured || !this.pending.modelRef)) {
@@ -305,16 +359,13 @@ export class FirstRunSetup {
   // Equivalent router data can be republished mid-activation. The mounted
   // lifecycle and mode/connection changes, not that object, own this generation.
   private owner(firstRun: boolean): FirstRunOwner {
-    const context = this.host.context();
+    const connection = captureModelSetupConnection(this.host.context(), firstRun);
     return {
       generation: this.generation,
       firstRun,
-      connectionRevision: context.gateway.connectionRevision,
-      connection: {
-        client: context.gateway.snapshot.client,
-        hello: context.gateway.snapshot.hello,
-        agentId: context.agentSelection.state.selectedId,
-      },
+      connectionRevision: connection.connectionRevision,
+      recoveryScope: connection.recoveryScope,
+      connection,
     };
   }
 
@@ -400,6 +451,7 @@ export class FirstRunSetup {
     return (
       owner.generation === this.generation &&
       owner.connectionRevision === context.gateway.connectionRevision &&
+      owner.recoveryScope === (snapshot.hello?.auth?.recoveryScope ?? null) &&
       owner.firstRun === this.host.routeData()?.firstRun &&
       snapshot.phase === "connected" &&
       snapshot.client === owner.connection.client &&
@@ -420,28 +472,7 @@ export class FirstRunSetup {
       }
       if (outcome.value.ok) {
         this.finishVerified(outcome.value.modelRef);
-        return;
       }
-      if (this.pending || outcome.value.status === "unavailable") {
-        return;
-      }
-    }
-    for (const candidate of detection.candidates) {
-      const targetId = activationTargetId(candidate.kind, candidate.modelRef);
-      if (
-        candidate.credentials === false ||
-        (detection.configuredModel &&
-          (candidate.kind === "existing-model" || candidate.modelRef === detection.configuredModel))
-      ) {
-        continue;
-      }
-      if (!this.owns(owner)) {
-        return;
-      }
-      // Activation now owns an interactive review. A declined or cancelled
-      // review must never authorize another candidate's setup automatically.
-      await this.host.activate(candidate, targetId);
-      return;
     }
   }
 

--- a/ui/src/pages/model-setup/model-setup-activation.test.ts
+++ b/ui/src/pages/model-setup/model-setup-activation.test.ts
@@ -13,6 +13,8 @@ import {
 import { FirstRunSetup } from "./first-run-setup.ts";
 import {
   candidate,
+  clickCandidate,
+  selectManualProvider,
   createFirstRunContext,
   detection,
   mountPage,
@@ -33,6 +35,106 @@ describe("ModelSetupPage first-run activation ownership", () => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
+  it.each([false, true])(
+    "refreshes a missing wizard without replay when a committed model exists: %s",
+    async (configured) => {
+      const { context, client, request } = createFirstRunContext();
+      request.mockImplementation(async (method) => {
+        if (method === "openclaw.setup.auth.start") {
+          return { done: false, status: "running" };
+        }
+        if (method === "wizard.next") {
+          throw new GatewayRequestError({
+            code: "INVALID_REQUEST",
+            message: "wizard not found",
+            details: { code: "WIZARD_NOT_FOUND" },
+          });
+        }
+        if (method === "openclaw.setup.detect") {
+          return {
+            ...detection,
+            authOptions: [
+              { id: "provider-login", label: "Provider", kind: "oauth", featured: true },
+            ],
+            ...(configured ? { configuredModel: "provider/selected", setupComplete: true } : {}),
+          };
+        }
+        if (method === "openclaw.setup.verify") {
+          return { ok: true, modelRef: "provider/selected", latencyMs: 12 };
+        }
+        throw new Error(`Unexpected setup request: ${method}`);
+      });
+      const { page } = await mountPage(context, {
+        client,
+        firstRun: true,
+        state: {
+          phase: "ready",
+          result: {
+            ...detection,
+            authOptions: [
+              { id: "provider-login", label: "Provider", kind: "oauth", featured: true },
+            ],
+          },
+        },
+      });
+      page.querySelector<HTMLButtonElement>('[data-auth-choice="provider-login"] button')!.click();
+      await waitForFast(() =>
+        expect(page.textContent).toContain("Gateway no longer has this setup session"),
+      );
+      const receipt = localStorage.getItem("openclaw.modelSetup.pendingActivation.v1");
+      expect(receipt).not.toBeNull();
+      [...page.querySelectorAll<HTMLButtonElement>("openclaw-modal-dialog button")]
+        .find((button) => button.textContent?.trim() === "Close")!
+        .click();
+      await page.updateComplete;
+      const checkAgain = () =>
+        [...page.querySelectorAll<HTMLButtonElement>(".model-setup__recovery button")].find(
+          (button) => button.textContent?.trim() === "Check again",
+        )!;
+      checkAgain().click();
+      await waitForFast(() =>
+        expect(request.mock.calls.map(([method]) => method)).toEqual([
+          "openclaw.setup.auth.start",
+          "wizard.next",
+          "openclaw.setup.detect",
+        ]),
+      );
+      await waitForFast(() => expect(page.querySelector(".model-setup__loading")).toBeNull());
+      expect(localStorage.getItem("openclaw.modelSetup.pendingActivation.v1")).toBe(receipt);
+      expect(context.navigate).not.toHaveBeenCalled();
+      if (configured) {
+        page.querySelector<HTMLButtonElement>(".model-setup__recovery .btn.primary")!.click();
+        await waitForFast(() =>
+          expect(context.navigate).toHaveBeenCalledWith("custodian", { search: "?onboarding=1" }),
+        );
+        expect(request.mock.calls.map(([method]) => method)).toEqual([
+          "openclaw.setup.auth.start",
+          "wizard.next",
+          "openclaw.setup.detect",
+          "openclaw.setup.verify",
+        ]);
+      } else {
+        expect(
+          page.querySelector<HTMLButtonElement>('[data-auth-choice="provider-login"] button')!
+            .disabled,
+        ).toBe(true);
+        const deadline = JSON.parse(receipt!).deadlineMs;
+        vi.spyOn(Date, "now").mockReturnValue(deadline + 1);
+        checkAgain().click();
+        await waitForFast(() =>
+          expect(
+            page.querySelector<HTMLButtonElement>('[data-auth-choice="provider-login"] button')!
+              .disabled,
+          ).toBe(false),
+        );
+        expect(
+          request.mock.calls.filter(([method]) => method === "openclaw.setup.auth.start"),
+        ).toHaveLength(1);
+        expect(localStorage.getItem("openclaw.modelSetup.pendingActivation.v1")).toBeNull();
+      }
+    },
+  );
+
   it("keeps first-run activation owned through an equivalent route-data refresh", async () => {
     const { context, client, request } = createFirstRunContext();
     const response = createDeferred<unknown>();
@@ -56,6 +158,8 @@ describe("ModelSetupPage first-run activation ownership", () => {
       client,
       firstRun: true,
     });
+    expect(request).not.toHaveBeenCalled();
+    await clickCandidate(page, "openai-api-key");
     const success = {
       done: true,
       status: "done",
@@ -91,6 +195,13 @@ describe("ModelSetupPage first-run activation ownership", () => {
           return { sessionId: "auth", done: false, status: "running" };
         }
         if (method === activatedMethod) {
+          if (entry === "provider sign-in" && releaseActivation) {
+            throw new GatewayRequestError({
+              code: "INVALID_REQUEST",
+              message: "wizard not found",
+              details: { code: "WIZARD_NOT_FOUND" },
+            });
+          }
           return await new Promise((resolve) => {
             releaseActivation = resolve;
           });
@@ -123,6 +234,7 @@ describe("ModelSetupPage first-run activation ownership", () => {
         firstRun: true,
       });
       if (entry === "manual key") {
+        await selectManualProvider(page, "provider-key");
         const input = page.querySelector<HTMLInputElement>('input[type="password"]')!;
         input.value = "test-only-provider-key";
         input.dispatchEvent(new Event("input", { bubbles: true }));
@@ -140,6 +252,18 @@ describe("ModelSetupPage first-run activation ownership", () => {
       publishGatewaySnapshot({ ...snapshot, phase: "reconnecting", hello: null });
       await page.updateComplete;
       publishGatewaySnapshot({ ...snapshot, hello: { ...snapshot.hello } });
+      if (entry === "provider sign-in") {
+        await waitForFast(() =>
+          expect(page.textContent).toContain("Gateway no longer has this setup session"),
+        );
+        [...page.querySelectorAll<HTMLButtonElement>("openclaw-modal-dialog button")]
+          .find((button) => button.textContent?.trim() === "Close")!
+          .click();
+        await page.updateComplete;
+        [...page.querySelectorAll<HTMLButtonElement>(".model-setup__recovery button")]
+          .find((button) => button.textContent?.trim() === "Check again")!
+          .click();
+      }
       await waitForFast(() => expect(page.textContent).toContain("Verify & use selected model"));
       expect(
         request.mock.calls.filter(([method]) => method === "openclaw.setup.verify"),
@@ -155,7 +279,10 @@ describe("ModelSetupPage first-run activation ownership", () => {
         modelActivation: { modelRef: "provider/late-other" },
       });
       await page.updateComplete;
-      expect(request.mock.calls.filter(([method]) => method === activatedMethod)).toHaveLength(1);
+      expect(request.mock.calls.filter(([method]) => method === activatedMethod)).toHaveLength(
+        entry === "provider sign-in" ? 2 : 1,
+      );
+      expect(request.mock.calls.filter(([method]) => method.endsWith(".start"))).toHaveLength(1);
       expect(context.navigate).toHaveBeenCalledOnce();
       expect(localStorage.getItem("openclaw.modelSetup.pendingActivation.v1")).toBeNull();
     },
@@ -269,7 +396,14 @@ describe("ModelSetupPage first-run activation ownership", () => {
       )!
       .click();
     await page.updateComplete;
-    expect(page.querySelector("openclaw-modal-dialog")).toBeNull();
+    if (outcome === "validation error") {
+      await waitForFast(() =>
+        expect(page.textContent).toContain("Setup is finishing the current step"),
+      );
+      expect(page.querySelector("openclaw-modal-dialog")).not.toBeNull();
+    } else {
+      expect(page.querySelector("openclaw-modal-dialog")).toBeNull();
+    }
     const terminal =
       (mode === "prepare" && outcome === "terminal error") ||
       outcome === "rejected test" ||
@@ -429,7 +563,6 @@ describe("ModelSetupPage first-run activation ownership", () => {
       canUseSetup: () => true,
       canVerify: () => true,
       verify: async () => undefined,
-      activate: async () => undefined,
       setVerifyState: () => undefined,
       setActivationState: () => undefined,
       setRefreshWarning: () => undefined,
@@ -514,6 +647,7 @@ describe("ModelSetupPage first-run activation ownership", () => {
         firstRun: true,
       });
       if (entry === "manual key") {
+        await selectManualProvider(page, "provider");
         const input = page.querySelector<HTMLInputElement>('input[type="password"]')!;
         input.value = "test-only-key";
         input.dispatchEvent(new Event("input", { bubbles: true }));
@@ -633,10 +767,13 @@ describe("ModelSetupPage first-run activation ownership", () => {
         firstRun: true,
       });
       if (entry === "manual") {
+        await selectManualProvider(page, "provider-key");
         const input = page.querySelector<HTMLInputElement>('input[type="password"]')!;
         input.value = "test-only-provider-key";
         input.dispatchEvent(new Event("input", { bubbles: true }));
         page.querySelector<HTMLButtonElement>(".model-setup__manual .btn.primary")!.click();
+      } else {
+        await clickCandidate(page, "openai-api-key");
       }
       await waitForFast(() => expect(request).toHaveBeenCalledOnce());
       const originalReceipt = localStorage.getItem("openclaw.modelSetup.pendingActivation.v1");
@@ -728,6 +865,7 @@ describe("ModelSetupPage first-run activation ownership", () => {
       const { context, client, request, snapshot, publishGatewaySnapshot } =
         createFirstRunContext();
       const cancelled = createDeferred<unknown>();
+      let serverStatus: "running" | "cancelled" | "error" = "running";
       const result = {
         ...detection,
         authOptions: [
@@ -742,6 +880,9 @@ describe("ModelSetupPage first-run activation ownership", () => {
           return { sessionId: "auth", done: false, status: "running" };
         }
         if (method === "wizard.next") {
+          if (serverStatus !== "running") {
+            return { done: true, status: serverStatus };
+          }
           return {
             done: false,
             status: "running",
@@ -750,7 +891,16 @@ describe("ModelSetupPage first-run activation ownership", () => {
         }
         if (method === "wizard.cancel") {
           if (cancelStatus === "busy") {
-            throw new Error("wizard not found");
+            throw new GatewayRequestError({
+              code: "INVALID_REQUEST",
+              message: "wizard not found",
+              details: { code: "WIZARD_NOT_FOUND" },
+            });
+          }
+          // The server settles its status before sending the reply. A resumed
+          // next request sees that outcome even while this transport is delayed.
+          if (cancelStatus === "cancelled" || cancelStatus === "error") {
+            serverStatus = cancelStatus;
           }
           return await cancelled.promise;
         }
@@ -784,7 +934,7 @@ describe("ModelSetupPage first-run activation ownership", () => {
         ),
       );
       await page.updateComplete;
-      expect(page.querySelector("openclaw-modal-dialog")).toBeNull();
+      expect(page.querySelector("openclaw-modal-dialog")).not.toBeNull();
       expect(localStorage.getItem("openclaw.modelSetup.pendingActivation.v1")).not.toBeNull();
       if (lifecycle === "route refresh") {
         page.routeData = { ...page.routeData! };
@@ -805,7 +955,13 @@ describe("ModelSetupPage first-run activation ownership", () => {
           }),
         );
       } else if (cancelStatus === "absent") {
-        cancelled.reject(new Error("wizard not found"));
+        cancelled.reject(
+          new GatewayRequestError({
+            code: "INVALID_REQUEST",
+            message: "wizard not found",
+            details: { code: "WIZARD_NOT_FOUND" },
+          }),
+        );
       } else {
         cancelled.resolve(cancelStatus === "unknown" ? {} : { status: cancelStatus });
       }
@@ -818,6 +974,22 @@ describe("ModelSetupPage first-run activation ownership", () => {
           cancelStatus === "absent" || cancelStatus === "busy" ? "rejected" : "fulfilled",
         );
       });
+      if (lifecycle !== "unmount" && ["cancelled", "error", "busy"].includes(cancelStatus)) {
+        const terminalClose = () =>
+          [...page.querySelectorAll<HTMLButtonElement>("openclaw-modal-dialog button")].find(
+            (button) => button.textContent?.trim() === "Close",
+          );
+        await waitForFast(() =>
+          expect(
+            page.querySelector("openclaw-modal-dialog") === null || terminalClose() !== undefined,
+          ).toBe(true),
+        );
+        terminalClose()?.click();
+        await page.updateComplete;
+        expect(page.querySelector("openclaw-modal-dialog")).toBeNull();
+      } else if (lifecycle === "in place" && cancelStatus === "running") {
+        expect(page.querySelector("openclaw-modal-dialog")).not.toBeNull();
+      }
       if (lifecycle === "unmount") {
         ({ page } = await mountPage(context, {
           state: { phase: "ready", result },

--- a/ui/src/pages/model-setup/model-setup-consent.test.ts
+++ b/ui/src/pages/model-setup/model-setup-consent.test.ts
@@ -5,6 +5,7 @@ import { createStorageMock } from "../../test-helpers/storage.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import {
   candidate,
+  clickCandidate,
   createFirstRunContext,
   detection,
   mountPage,
@@ -92,6 +93,8 @@ describe("ModelSetupPage activation consent", () => {
         client,
         firstRun: true,
       });
+      expect(request).not.toHaveBeenCalled();
+      await clickCandidate(page, "openai-api-key");
       await waitForFast(() => expect(page.textContent).toContain("Review model setup"));
       expect(context.navigate).not.toHaveBeenCalled();
       const button = (label: string) =>

--- a/ui/src/pages/model-setup/model-setup-discovery.test.ts
+++ b/ui/src/pages/model-setup/model-setup-discovery.test.ts
@@ -1,0 +1,492 @@
+/* @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WizardNextParams } from "../../../../packages/gateway-protocol/src/schema/wizard.ts";
+import { WizardSession } from "../../../../src/wizard/session.js";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import { GatewayRequestError } from "../../api/gateway.ts";
+import { i18n } from "../../i18n/index.ts";
+import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import {
+  candidate,
+  clickCandidate,
+  createFirstRunContext,
+  detection,
+  mountPage,
+  selectManualProvider,
+} from "./model-setup-first-run.test-support.ts";
+import { ModelSetupPage } from "./model-setup-page.ts";
+
+describe("Model Setup explicit discovery", () => {
+  beforeEach(async () => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    localStorage.setItem(
+      "openclaw-device-identity-v1",
+      JSON.stringify({ version: 1, privateKey: "test-device-key" }),
+    );
+    await i18n.setLocale("en");
+  });
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("detects an existing first-run route without testing it until a click", async () => {
+    const { context, request } = createFirstRunContext();
+    request.mockImplementation(async (method) => {
+      if (method === "openclaw.setup.detect") {
+        return { ...detection, configuredModel: "openai/existing", setupComplete: true };
+      }
+      if (method === "openclaw.setup.verify") {
+        return { ok: true, modelRef: "openai/existing", latencyMs: 12 };
+      }
+      throw new Error(`Unexpected setup request: ${method}`);
+    });
+    const provider = createApplicationContextProvider(context);
+    const page = new ModelSetupPage();
+    page.routeData = { firstRun: true };
+    provider.append(page);
+    document.body.append(provider);
+    await waitForFast(() =>
+      expect(page.querySelector(".model-setup__current button")).not.toBeNull(),
+    );
+    await page.updateComplete;
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["openclaw.setup.detect"]);
+    expect(context.navigate).not.toHaveBeenCalled();
+    expect(localStorage.getItem("openclaw.modelSetup.pendingActivation.v1")).toBeNull();
+    page.querySelector<HTMLButtonElement>(".model-setup__current button")!.click();
+    await waitForFast(() => expect(page.querySelector(".model-setup__verified")).not.toBeNull());
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "openclaw.setup.detect",
+      "openclaw.setup.verify",
+    ]);
+  });
+
+  it.each(["cancel at credentials", "finish final commit"] as const)(
+    "retains the admitted wizard after protected cancellation: %s",
+    async (outcome) => {
+      const { context, client, request } = createFirstRunContext();
+      const installed = createDeferred();
+      const allowInstall = createDeferred();
+      const committed = createDeferred();
+      const allowCommit = createDeferred();
+      const terminal = createDeferred();
+      const answers: unknown[] = [];
+      let session: WizardSession | undefined;
+      let sessionId: string | undefined;
+      let starts = 0;
+      request.mockImplementation(async (method, params) => {
+        if (method === "openclaw.setup.activate.start") {
+          starts += 1;
+          sessionId = (params as { sessionId: string }).sessionId;
+          session = new WizardSession(async (prompter, _signal, owner) => {
+            try {
+              await prompter.confirm({ message: "Install provider?", initialValue: false });
+              owner.lockCancellationForPreparation();
+              installed.resolve();
+              await allowInstall.promise;
+              await prompter.text({ message: "Provider API key", sensitive: true });
+              owner.finishPreparation();
+              owner.lockCancellation();
+              committed.resolve();
+              await allowCommit.promise;
+              owner.setModelActivation({ modelRef: "openai/selected" });
+            } finally {
+              terminal.resolve();
+            }
+          });
+          return { done: false, status: "running" };
+        }
+        if (method === "wizard.next") {
+          const next = params as WizardNextParams;
+          expect(next.sessionId).toBe(sessionId);
+          if (next.answer) {
+            answers.push(next.answer.value);
+            await session!.answer(next.answer.stepId, next.answer.value);
+          }
+          return await session!.next();
+        }
+        if (method === "wizard.cancel") {
+          expect(params).toEqual({ sessionId });
+          session!.cancel();
+          return { status: session!.getStatus(), error: session!.getError() };
+        }
+        if (method === "openclaw.setup.detect") {
+          return { ...detection, configuredModel: "openai/selected", setupComplete: true };
+        }
+        if (method === "openclaw.setup.verify") {
+          return { ok: true, modelRef: "openai/selected", latencyMs: 12 };
+        }
+        throw new Error(`Unexpected setup request: ${method}`);
+      });
+      const { page } = await mountPage(context, {
+        client,
+        firstRun: true,
+        state: {
+          phase: "ready",
+          result: {
+            ...detection,
+            candidates: [candidate("openai-api-key", "openai/selected", true)],
+          },
+        },
+      });
+      const cancel = () =>
+        page.querySelector("openclaw-modal-dialog")!.dispatchEvent(new CustomEvent("modal-cancel"));
+      try {
+        await clickCandidate(page, "openai-api-key");
+        await waitForFast(() => expect(page.textContent).toContain("Install provider?"));
+        const confirm = [
+          ...page.querySelectorAll<HTMLButtonElement>("openclaw-modal-dialog button"),
+        ].find((button) => button.textContent?.trim() === "Yes")!;
+        confirm.click();
+        await installed.promise;
+        cancel();
+        await waitForFast(() =>
+          expect(page.textContent).toContain("Setup is finishing the current step"),
+        );
+        expect(page.querySelector("openclaw-modal-dialog")).not.toBeNull();
+        expect(localStorage.getItem("openclaw.modelSetup.pendingActivation.v1")).not.toBeNull();
+        expect(session!.getStatus()).toBe("running");
+        expect(answers).toEqual([true]);
+        expect(starts).toBe(1);
+        allowInstall.resolve();
+        await waitForFast(() => expect(page.textContent).toContain("Provider API key"));
+        if (outcome === "cancel at credentials") {
+          cancel();
+          await terminal.promise;
+          await waitForFast(() =>
+            expect(localStorage.getItem("openclaw.modelSetup.pendingActivation.v1")).toBeNull(),
+          );
+          expect(session!.getStatus()).toBe("cancelled");
+          expect(answers).toEqual([true]);
+        } else {
+          const input = page.querySelector<HTMLInputElement>(
+            'openclaw-modal-dialog input[type="password"]',
+          )!;
+          input.value = "synthetic-key";
+          input.dispatchEvent(new Event("input", { bubbles: true }));
+          await page.updateComplete;
+          page
+            .querySelector<HTMLFormElement>("openclaw-modal-dialog form")!
+            .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+          await committed.promise;
+          cancel();
+          await waitForFast(() =>
+            expect(page.textContent).toContain("Setup is finishing the current step"),
+          );
+          expect(session!.getStatus()).toBe("running");
+          allowCommit.resolve();
+          await terminal.promise;
+          await waitForFast(() => expect(page.textContent).toContain("Connection verified"));
+          expect(answers).toEqual([true, "synthetic-key"]);
+        }
+        expect(starts).toBe(1);
+      } finally {
+        allowInstall.resolve();
+        allowCommit.resolve();
+        session?.close(new Error("test cleanup"));
+        if (session) {
+          await terminal.promise;
+        }
+      }
+    },
+  );
+
+  it.each(["network", "denied", "missing wizard"] as const)(
+    "shows an explicit cancellation %s failure without discarding the clicked receipt",
+    async (failure) => {
+      const { context, client, request } = createFirstRunContext();
+      let cancels = 0;
+      const error =
+        failure === "missing wizard"
+          ? new GatewayRequestError({
+              code: "INVALID_REQUEST",
+              message: "wizard not found",
+              details: { code: "WIZARD_NOT_FOUND" },
+            })
+          : failure === "denied"
+            ? new GatewayRequestError({ code: "FORBIDDEN", message: "Cancel permission denied" })
+            : new Error("Cancellation transport failed");
+      request.mockImplementation(async (method) => {
+        if (method === "openclaw.setup.activate.start") {
+          return { done: false, status: "running" };
+        }
+        if (method === "wizard.next") {
+          return {
+            done: false,
+            status: "running",
+            step: {
+              id: "credential",
+              type: "text",
+              message: "Provider credential",
+              sensitive: true,
+              executor: "client",
+            },
+          };
+        }
+        if (method === "wizard.cancel") {
+          if (++cancels === 1) {
+            throw error;
+          }
+          return { status: "cancelled" };
+        }
+        throw new Error(`Unexpected setup request: ${method}`);
+      });
+      const { page } = await mountPage(context, {
+        client,
+        firstRun: true,
+        state: {
+          phase: "ready",
+          result: {
+            ...detection,
+            candidates: [candidate("openai-api-key", "openai/selected", true)],
+          },
+        },
+      });
+      await clickCandidate(page, "openai-api-key");
+      await waitForFast(() => expect(page.textContent).toContain("Provider credential"));
+      const receiptKey = "openclaw.modelSetup.pendingActivation.v1";
+      const receipt = localStorage.getItem(receiptKey);
+      expect(receipt).not.toBeNull();
+      const cancel = () =>
+        page.querySelector("openclaw-modal-dialog")!.dispatchEvent(new CustomEvent("modal-cancel"));
+      cancel();
+      if (failure === "missing wizard") {
+        await waitForFast(() => expect(page.textContent).toContain("It may already have finished"));
+        expect(cancels).toBe(1);
+        expect(localStorage.getItem(receiptKey)).toBe(receipt);
+        const close = [
+          ...page.querySelectorAll<HTMLButtonElement>("openclaw-modal-dialog button"),
+        ].find((button) => button.textContent?.trim() === "Close");
+        expect(close).toBeDefined();
+        close!.click();
+        await waitForFast(() => expect(page.querySelector("openclaw-modal-dialog")).toBeNull());
+        expect(page.querySelector(".model-setup__recovery")).not.toBeNull();
+        expect(localStorage.getItem(receiptKey)).toBe(receipt);
+      } else {
+        await waitForFast(() =>
+          expect(page.querySelector(".model-setup-wizard .callout.warning")?.textContent).toContain(
+            "Could not confirm cancellation",
+          ),
+        );
+        expect(page.textContent).toContain(error.message);
+        expect(page.textContent).toContain("Provider credential");
+        expect(localStorage.getItem(receiptKey)).toBe(receipt);
+        expect(cancels).toBe(1);
+        cancel();
+        await waitForFast(() => expect(page.querySelector("openclaw-modal-dialog")).toBeNull());
+        expect(localStorage.getItem(receiptKey)).toBeNull();
+        expect(cancels).toBe(2);
+      }
+      expect(
+        request.mock.calls.filter(([method]) => method === "openclaw.setup.activate.start"),
+      ).toHaveLength(1);
+      expect(context.navigate).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([false, true])(
+    "sends only an explicit fresh-install discovery choice (%s)",
+    async (enabled) => {
+      const { context, client, request } = createFirstRunContext();
+      request.mockResolvedValue({ done: true, status: "cancelled" });
+      const { page } = await mountPage(context, {
+        client,
+        firstRun: true,
+        state: {
+          phase: "ready",
+          result: {
+            ...detection,
+            nativeSessionCatalogPreferenceRequired: true,
+            nativeSessionCatalogs: [
+              { pluginId: "anthropic", label: "Claude" },
+              { pluginId: "codex", label: "Codex" },
+            ],
+            candidates: [candidate("codex-cli", "openai/available", true)],
+            manualProviders: [{ id: "api-key", label: "API provider" }],
+          },
+        },
+      });
+      const checkbox = page.querySelector<HTMLInputElement>(
+        ".model-setup__native-discovery input",
+      )!;
+      expect(checkbox.checked).toBe(false);
+      expect(page.querySelector("[data-selected]")).toBeNull();
+      expect(request).not.toHaveBeenCalled();
+      expect(localStorage.getItem("openclaw.modelSetup.pendingActivation.v1")).toBeNull();
+      if (enabled) {
+        checkbox.click();
+        await page.updateComplete;
+      }
+      expect(request).not.toHaveBeenCalled();
+      await clickCandidate(page, "codex-cli");
+      await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+      expect(request.mock.calls[0]).toEqual([
+        "openclaw.setup.activate.start",
+        expect.objectContaining({
+          kind: "codex-cli",
+          modelRef: "openai/available",
+          nativeSessionCatalogsEnabled: enabled,
+        }),
+        { timeoutMs: null },
+      ]);
+    },
+  );
+
+  it.each(["install", "custom"] as const)(
+    "offers %s choices without installing or starting auth on discovery",
+    async (kind) => {
+      const { context, client, request } = createFirstRunContext();
+      request.mockResolvedValue({ done: true, status: "cancelled" });
+      const { page } = await mountPage(context, {
+        client,
+        firstRun: true,
+        state: {
+          phase: "ready",
+          result: {
+            ...detection,
+            nativeSessionCatalogPreferenceRequired: true,
+            nativeSessionCatalogs: [{ pluginId: "catalog-plugin", label: "Native conversations" }],
+            authOptions: [
+              {
+                id: "manifest-auth",
+                label: kind === "install" ? "Meta" : "Compatible endpoint",
+                kind,
+                featured: false,
+              },
+            ],
+          },
+        },
+      });
+      expect(request).not.toHaveBeenCalled();
+      const button = page.querySelector<HTMLButtonElement>(
+        '[data-auth-choice="manifest-auth"] button',
+      )!;
+      expect(button.closest("details")).toBeNull();
+      expect(button.textContent).toContain(
+        kind === "install" ? "Review & install" : "Set up endpoint",
+      );
+      button.click();
+      await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+      expect(request.mock.calls[0]).toEqual([
+        "openclaw.setup.auth.start",
+        expect.objectContaining({
+          authChoice: "manifest-auth",
+          nativeSessionCatalogsEnabled: false,
+        }),
+        { timeoutMs: null },
+      ]);
+    },
+  );
+
+  it("does not change upgrade catalog choices or select a manual provider implicitly", async () => {
+    const { context, client, request } = createFirstRunContext();
+    request.mockResolvedValue({ done: true, status: "cancelled" });
+    const { page } = await mountPage(context, {
+      client,
+      firstRun: true,
+      state: {
+        phase: "ready",
+        result: {
+          ...detection,
+          configuredModel: "openai/existing",
+          setupComplete: true,
+          nativeSessionCatalogPreferenceRequired: false,
+          nativeSessionCatalogs: [{ pluginId: "codex", label: "Codex" }],
+          manualProviders: [{ id: "provider-key", label: "API provider" }],
+        },
+      },
+    });
+    expect(request).not.toHaveBeenCalled();
+    expect(page.querySelector(".model-setup__native-discovery")).toBeNull();
+    expect(page.querySelector("[data-selected]")).toBeNull();
+    await selectManualProvider(page, "provider-key");
+    const input = page.querySelector<HTMLInputElement>(".model-setup__manual input")!;
+    input.value = "test-only-key";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    page.querySelector<HTMLButtonElement>(".model-setup__manual .btn.primary")!.click();
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+    expect(request.mock.calls[0]![1]).not.toHaveProperty("nativeSessionCatalogsEnabled");
+  });
+  it("clears a pending credential and native discovery opt-in when the Gateway identity changes", async () => {
+    const { context, client, request, snapshot, publishGatewaySnapshot } = createFirstRunContext();
+    const fresh = {
+      ...detection,
+      nativeSessionCatalogPreferenceRequired: true,
+      nativeSessionCatalogs: [{ pluginId: "codex", label: "Codex" }],
+      manualProviders: [{ id: "provider-key", label: "API provider" }],
+    };
+    request.mockResolvedValue(fresh);
+    const { page } = await mountPage(context, {
+      client,
+      firstRun: true,
+      state: { phase: "ready", result: fresh },
+    });
+    page.querySelector<HTMLInputElement>(".model-setup__native-discovery input")!.click();
+    await selectManualProvider(page, "provider-key");
+    const input = page.querySelector<HTMLInputElement>(".model-setup__manual input")!;
+    input.value = "test-only-pending-key";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await page.updateComplete;
+    expect(request).not.toHaveBeenCalled();
+    Object.assign(context.gateway, { connectionRevision: context.gateway.connectionRevision + 1 });
+    publishGatewaySnapshot({ ...snapshot });
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith(
+        "openclaw.setup.detect",
+        { agentId: "main" },
+        expect.objectContaining({ timeoutMs: expect.any(Number), signal: expect.any(AbortSignal) }),
+      ),
+    );
+    await waitForFast(() =>
+      expect(page.querySelector(".model-setup__native-discovery input")).not.toBeNull(),
+    );
+    expect(
+      page.querySelector<HTMLInputElement>(".model-setup__native-discovery input")!.checked,
+    ).toBe(false);
+    expect(page.querySelector<HTMLInputElement>(".model-setup__manual input")!.value).toBe("");
+    expect(page.querySelector("[data-selected]")).toBeNull();
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["openclaw.setup.detect"]);
+  });
+
+  it.each(["same client", "replacement client"])(
+    "keeps explicit discovery opt-in across a same-Gateway reconnect (%s)",
+    async (replacement) => {
+      const { context, client, request, snapshot, publishGatewaySnapshot } =
+        createFirstRunContext();
+      const fresh = {
+        ...detection,
+        nativeSessionCatalogPreferenceRequired: true,
+        nativeSessionCatalogs: [{ pluginId: "codex", label: "Codex" }],
+      };
+      request.mockResolvedValue(fresh);
+      const { page } = await mountPage(context, {
+        client,
+        firstRun: true,
+        state: { phase: "ready", result: fresh },
+      });
+      page.querySelector<HTMLInputElement>(".model-setup__native-discovery input")!.click();
+      await page.updateComplete;
+      publishGatewaySnapshot({ ...snapshot, phase: "reconnecting", hello: null });
+      await page.updateComplete;
+      publishGatewaySnapshot({
+        ...snapshot,
+        client: replacement === "same client" ? client : createTestGatewayClient(request),
+        hello: { ...snapshot.hello },
+      });
+      await waitForFast(() =>
+        expect(page.querySelector(".model-setup__native-discovery input")).not.toBeNull(),
+      );
+      expect(
+        page.querySelector<HTMLInputElement>(".model-setup__native-discovery input")!.checked,
+      ).toBe(true);
+      expect(request.mock.calls.map(([method]) => method)).toEqual([
+        "config.get",
+        "openclaw.setup.detect",
+      ]);
+    },
+  );
+});

--- a/ui/src/pages/model-setup/model-setup-first-run-recovery.test.ts
+++ b/ui/src/pages/model-setup/model-setup-first-run-recovery.test.ts
@@ -1,0 +1,258 @@
+/* @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import { i18n } from "../../i18n/index.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import {
+  clearFirstRunActivationReceipt,
+  readFirstRunActivationReceipt,
+} from "./first-run-activation-receipt.ts";
+import {
+  candidate,
+  clickCandidate,
+  createFirstRunContext,
+  detection,
+  mountPage,
+} from "./model-setup-first-run.test-support.ts";
+import { MODEL_SETUP_VERIFY_TIMEOUT_MS } from "./state.ts";
+
+describe("ModelSetupPage first-run application recovery", () => {
+  beforeEach(async () => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    localStorage.setItem(
+      "openclaw-device-identity-v1",
+      JSON.stringify({ version: 1, privateKey: "durable-device-private-key-for-testing" }),
+    );
+    await i18n.setLocale("en");
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it.each(["valid", "expiry", "removal", "auth"])(
+    "accepts only a current restored verification after application recreation (%s)",
+    async (receiptState) => {
+      const original = createFirstRunContext();
+      original.request.mockResolvedValue({
+        done: true,
+        status: "done",
+        modelActivation: { modelRef: "openai/relaunch", gatewayRestartRequired: true },
+      });
+      const { page, provider } = await mountPage(original.context, {
+        state: {
+          phase: "ready",
+          result: {
+            ...detection,
+            candidates: [candidate("openai-api-key", "openai/relaunch", true)],
+          },
+        },
+        client: original.client,
+        firstRun: true,
+      });
+      expect(original.request).not.toHaveBeenCalled();
+      await clickCandidate(page, "openai-api-key");
+      await waitForFast(() => expect(page.textContent).toContain("The Gateway is restarting"));
+      provider.remove();
+
+      const relaunched = createFirstRunContext();
+      const verification = createDeferred<unknown>();
+      relaunched.request.mockReturnValue(verification.promise);
+      const { page: restored } = await mountPage(relaunched.context, {
+        state: {
+          phase: "ready",
+          result: { ...detection, configuredModel: "openai/relaunch", setupComplete: true },
+        },
+        client: relaunched.client,
+        firstRun: true,
+      });
+
+      await waitForFast(() => expect(relaunched.request).toHaveBeenCalledOnce());
+      if (receiptState === "expiry") {
+        const receipt = readFirstRunActivationReceipt(relaunched.context)!;
+        vi.spyOn(Date, "now").mockReturnValue(receipt.deadlineMs + 1);
+      } else if (receiptState === "removal") {
+        clearFirstRunActivationReceipt();
+      } else if (receiptState === "auth") {
+        relaunched.context.gateway.connection.token = "replacement-auth";
+      }
+      verification.resolve({ ok: true, modelRef: "openai/relaunch", latencyMs: 31 });
+      await waitForFast(() => expect(relaunched.request).toHaveResolved());
+      await restored.updateComplete;
+      if (receiptState === "valid") {
+        expect(relaunched.context.navigate).toHaveBeenCalledWith("custodian", {
+          search: "?onboarding=1",
+        });
+      } else {
+        expect(relaunched.context.navigate).not.toHaveBeenCalled();
+        expect(restored.querySelector(".model-setup__verified")).toBeNull();
+        expect(restored.textContent).not.toContain("Continue setup");
+        expect(restored.textContent).not.toContain("Cannot read properties");
+      }
+      expect(original.request).toHaveBeenCalledOnce();
+      expect(relaunched.request).toHaveBeenCalledOnce();
+      expect(relaunched.request).toHaveBeenCalledWith(
+        "openclaw.setup.verify",
+        { agentId: "main" },
+        { timeoutMs: MODEL_SETUP_VERIFY_TIMEOUT_MS, signal: expect.any(AbortSignal) },
+      );
+    },
+  );
+
+  it("never repeats an ambiguous activation after app recreation until explicitly retried", async () => {
+    const original = createFirstRunContext();
+    original.request.mockResolvedValue({
+      done: true,
+      status: "done",
+      modelActivation: { modelRef: "openai/relaunch", gatewayRestartRequired: true },
+    });
+    const { page: previous, provider } = await mountPage(original.context, {
+      state: {
+        phase: "ready",
+        result: {
+          ...detection,
+          candidates: [candidate("openai-api-key", "openai/relaunch", true)],
+        },
+      },
+      client: original.client,
+      firstRun: true,
+    });
+    expect(original.request).not.toHaveBeenCalled();
+    await clickCandidate(previous, "openai-api-key");
+    await waitForFast(() => expect(previous.textContent).toContain("The Gateway is restarting"));
+    provider.remove();
+
+    const relaunched = createFirstRunContext();
+    relaunched.request.mockImplementation(async (method) => {
+      if (method === "openclaw.setup.detect") {
+        return {
+          ...detection,
+          candidates: [candidate("openai-api-key", "openai/relaunch", true)],
+        };
+      }
+      if (method === "openclaw.setup.activate.start") {
+        return { done: true, status: "done", modelActivation: { modelRef: "openai/relaunch" } };
+      }
+      throw new Error(`Unexpected method ${method}`);
+    });
+    const { page } = await mountPage(relaunched.context, {
+      state: {
+        phase: "ready",
+        result: {
+          ...detection,
+          candidates: [candidate("openai-api-key", "openai/relaunch", true)],
+        },
+      },
+      client: relaunched.client,
+      firstRun: true,
+    });
+
+    await waitForFast(() => {
+      expect(page.textContent).toContain("previous activation is unresolved");
+      expect(page.textContent).toContain("Check again");
+    });
+    expect(relaunched.request).not.toHaveBeenCalled();
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 500_000);
+    page.querySelector<HTMLButtonElement>(".model-setup__intro .btn")?.click();
+    await waitForFast(() => expect(page.querySelector(".model-setup__loading")).toBeNull());
+    expect(relaunched.request.mock.calls.map(([method]) => method)).toEqual([
+      "openclaw.setup.detect",
+    ]);
+    await clickCandidate(page, "openai-api-key");
+
+    await waitForFast(() => {
+      expect(relaunched.request.mock.calls.map(([method]) => method)).toEqual([
+        "openclaw.setup.detect",
+        "openclaw.setup.activate.start",
+      ]);
+      expect(relaunched.context.navigate).toHaveBeenCalledWith("custodian", {
+        search: "?onboarding=1",
+      });
+    });
+    expect(original.request).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a different committed model after full application recreation", async () => {
+    const original = createFirstRunContext();
+    original.request.mockResolvedValue({
+      done: true,
+      status: "done",
+      modelActivation: { modelRef: "openai/expected", gatewayRestartRequired: true },
+    });
+    const { page: previous, provider } = await mountPage(original.context, {
+      state: {
+        phase: "ready",
+        result: {
+          ...detection,
+          candidates: [candidate("openai-api-key", "openai/expected", true)],
+        },
+      },
+      client: original.client,
+      firstRun: true,
+    });
+    expect(original.request).not.toHaveBeenCalled();
+    await clickCandidate(previous, "openai-api-key");
+    await waitForFast(() => expect(previous.textContent).toContain("The Gateway is restarting"));
+    provider.remove();
+
+    const relaunched = createFirstRunContext();
+    const { page } = await mountPage(relaunched.context, {
+      state: {
+        phase: "ready",
+        result: { ...detection, configuredModel: "anthropic/different", setupComplete: true },
+      },
+      client: relaunched.client,
+      firstRun: true,
+    });
+
+    await waitForFast(() => {
+      expect(page.textContent).toContain("The model could not be activated");
+      expect(page.textContent).toContain("openai/expected");
+    });
+    expect(relaunched.request).not.toHaveBeenCalled();
+    expect(relaunched.context.navigate).not.toHaveBeenCalled();
+  });
+
+  it("never resumes another Gateway owner's activation after full application recreation", async () => {
+    const original = createFirstRunContext();
+    original.request.mockResolvedValue({
+      done: true,
+      status: "done",
+      modelActivation: { modelRef: "openai/expected", gatewayRestartRequired: true },
+    });
+    const { page: previous, provider } = await mountPage(original.context, {
+      state: {
+        phase: "ready",
+        result: {
+          ...detection,
+          candidates: [candidate("openai-api-key", "openai/expected", true)],
+        },
+      },
+      client: original.client,
+      firstRun: true,
+    });
+    expect(original.request).not.toHaveBeenCalled();
+    await clickCandidate(previous, "openai-api-key");
+    await waitForFast(() => expect(previous.textContent).toContain("The Gateway is restarting"));
+    provider.remove();
+
+    const relaunched = createFirstRunContext();
+    relaunched.context.gateway.connection.token = "different-gateway-owner";
+    relaunched.request.mockResolvedValue({ ok: true, modelRef: "openai/expected", latencyMs: 31 });
+    await mountPage(relaunched.context, {
+      state: {
+        phase: "ready",
+        result: { ...detection, configuredModel: "openai/expected", setupComplete: true },
+      },
+      client: relaunched.client,
+      firstRun: true,
+    });
+
+    expect(relaunched.context.navigate).not.toHaveBeenCalled();
+    expect(relaunched.request).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/pages/model-setup/model-setup-first-run.test-support.ts
+++ b/ui/src/pages/model-setup/model-setup-first-run.test-support.ts
@@ -38,7 +38,11 @@ export function createFirstRunContext(refreshError?: string, beforeRefresh?: () 
     hello: {
       type: "hello-ok",
       protocol: 1,
-      auth: { role: "operator", scopes: ["operator.read", "operator.admin"] },
+      auth: {
+        role: "operator",
+        scopes: ["operator.read", "operator.admin"],
+        recoveryScope: "synthetic-setup-owner",
+      },
       features: {
         methods: [
           "config.set",
@@ -165,4 +169,23 @@ export function requestParameters(params: unknown) {
     throw new Error("Expected Gateway request parameters.");
   }
   return params;
+}
+
+export async function clickCandidate(page: ModelSetupPage, kind: string) {
+  await waitForFast(() =>
+    expect(page.querySelector(`[data-candidate-kind="${kind}"] button`)).not.toBeNull(),
+  );
+  const button = page.querySelector<HTMLButtonElement>(`[data-candidate-kind="${kind}"] button`);
+  expect(button).not.toBeNull();
+  expect(button!.disabled).toBe(false);
+  button!.click();
+  await page.updateComplete;
+}
+
+export async function selectManualProvider(page: ModelSetupPage, providerId: string) {
+  const picker = page.querySelector(".model-setup-provider-select")!;
+  const item = picker.querySelector(`[data-manual-provider="${providerId}"]`);
+  expect(item).not.toBeNull();
+  picker.dispatchEvent(new CustomEvent("wa-select", { detail: { item }, bubbles: true }));
+  await page.updateComplete;
 }

--- a/ui/src/pages/model-setup/model-setup-first-run.test.ts
+++ b/ui/src/pages/model-setup/model-setup-first-run.test.ts
@@ -6,18 +6,15 @@ import type { WizardNextResult } from "../../api/types.ts";
 import { i18n } from "../../i18n/index.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
-import {
-  clearFirstRunActivationReceipt,
-  readFirstRunActivationReceipt,
-} from "./first-run-activation-receipt.ts";
+import { clearFirstRunActivationReceipt } from "./first-run-activation-receipt.ts";
 import {
   candidate,
+  clickCandidate,
   createFirstRunContext,
   detection,
   mountPage,
   requestParameters,
 } from "./model-setup-first-run.test-support.ts";
-import { MODEL_SETUP_VERIFY_TIMEOUT_MS } from "./state.ts";
 
 describe("ModelSetupPage first-run inference", () => {
   beforeEach(async () => {
@@ -63,12 +60,16 @@ describe("ModelSetupPage first-run inference", () => {
         client,
         firstRun: true,
       });
+      expect(request).not.toHaveBeenCalled();
+      await clickCandidate(page, "openai-api-key");
       await waitForFast(() =>
         expect(page.textContent).toContain("The model could not finish setup"),
       );
       expect(request).toHaveBeenCalledOnce();
       expect(context.navigate).not.toHaveBeenCalled();
-      const retry = page.querySelector<HTMLButtonElement>("[data-candidate-kind] button")!;
+      const retry = page.querySelector<HTMLButtonElement>(
+        '[data-candidate-kind="openai-api-key"] button',
+      )!;
       expect(retry.disabled).toBe(outcome === "uncertain");
       expect(localStorage.getItem("openclaw.modelSetup.pendingActivation.v1") === null).toBe(
         outcome === "rejected",
@@ -84,7 +85,7 @@ describe("ModelSetupPage first-run inference", () => {
     },
   );
 
-  it("automatically activates newly discovered credentials when first-run setup is checked again", async () => {
+  it("requires a click to activate newly discovered credentials after checking again", async () => {
     const { context, client, request } = createFirstRunContext();
     request.mockImplementation(async (method) => {
       if (method === "openclaw.setup.detect") {
@@ -111,6 +112,9 @@ describe("ModelSetupPage first-run inference", () => {
     const checkAgain = page.querySelector<HTMLButtonElement>(".model-setup__intro .btn");
     expect(checkAgain?.textContent).toContain("Check again");
     checkAgain?.click();
+    await waitForFast(() => expect(page.textContent).toContain("openai/newly-available"));
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["openclaw.setup.detect"]);
+    await clickCandidate(page, "openai-api-key");
 
     await waitForFast(() => {
       expect(request.mock.calls.map(([method, params]) => [method, params])).toEqual([
@@ -130,7 +134,7 @@ describe("ModelSetupPage first-run inference", () => {
   });
 
   it.each(["transport", "unavailable", "busy", "not dispatched"])(
-    "stops automatic candidates after %s and only retries known non-admission explicitly",
+    "stops the selected candidate after %s and only retries known non-admission explicitly",
     async (failure) => {
       const { context, client, request } = createFirstRunContext();
       const message = "Setup request could not finish";
@@ -166,6 +170,8 @@ describe("ModelSetupPage first-run inference", () => {
         client,
         firstRun: true,
       });
+      expect(request).not.toHaveBeenCalled();
+      await clickCandidate(page, "openai-api-key");
 
       await waitForFast(() => {
         expect(page.textContent).toContain(message);
@@ -179,7 +185,9 @@ describe("ModelSetupPage first-run inference", () => {
       );
       expect(page.textContent).not.toContain("Connection verified");
       expect(context.navigate).not.toHaveBeenCalled();
-      const retry = page.querySelector<HTMLButtonElement>("[data-candidate-kind] button")!;
+      const retry = page.querySelector<HTMLButtonElement>(
+        '[data-candidate-kind="openai-api-key"] button',
+      )!;
       expect(retry.disabled).toBe(!retryable);
       if (retryable) {
         [...page.querySelectorAll<HTMLButtonElement>("openclaw-modal-dialog button")]
@@ -224,16 +232,23 @@ describe("ModelSetupPage first-run inference", () => {
       firstRun: true,
     });
 
+    expect(request).not.toHaveBeenCalled();
+    page.querySelector<HTMLButtonElement>(".model-setup__current button")!.click();
     await waitForFast(() => expect(resolveVerification).toBeTypeOf("function"));
     expect(page.textContent).not.toContain("Continue setup");
     expect(context.navigate).not.toHaveBeenCalled();
     resolveVerification?.({ ok: true, modelRef: "openai/existing", latencyMs: 42 });
 
-    await waitForFast(() => expect(context.navigate).toHaveBeenCalledWith("chat"));
+    await waitForFast(() => expect(page.querySelector(".model-setup__verified")).not.toBeNull());
+    expect(context.navigate).not.toHaveBeenCalled();
+    [...page.querySelectorAll<HTMLButtonElement>("button")]
+      .find((button) => button.textContent?.includes("Continue setup"))!
+      .click();
+    expect(context.navigate).toHaveBeenCalledWith("chat");
     expect(request).toHaveBeenCalledOnce();
   });
 
-  it("explains how to recover when an existing model cannot be verified by this Gateway", async () => {
+  it("does not offer verification when the Gateway does not advertise it", async () => {
     const { context, client, request, snapshot } = createFirstRunContext();
     snapshot.hello.features.methods = snapshot.hello.features.methods.filter(
       (method) => method !== "openclaw.setup.verify",
@@ -248,11 +263,7 @@ describe("ModelSetupPage first-run inference", () => {
       firstRun: true,
     });
 
-    await waitForFast(() => {
-      expect(page.textContent).toContain("The Gateway is running an older OpenClaw version");
-      expect(page.textContent).toContain("Update");
-      expect(page.textContent).toContain("Reconnect");
-    });
+    expect(page.querySelector(".model-setup__current button")).toBeNull();
     expect(page.textContent).not.toContain("Continue setup");
     expect(request).not.toHaveBeenCalled();
     expect(context.navigate).not.toHaveBeenCalled();
@@ -274,7 +285,7 @@ describe("ModelSetupPage first-run inference", () => {
       throw new Error(`Unexpected method ${method}`);
     });
 
-    await mountPage(context, {
+    const { page } = await mountPage(context, {
       state: {
         phase: "ready",
         result: {
@@ -291,6 +302,12 @@ describe("ModelSetupPage first-run inference", () => {
       client,
       firstRun: true,
     });
+
+    expect(request).not.toHaveBeenCalled();
+    page.querySelector<HTMLButtonElement>(".model-setup__current button")!.click();
+    await waitForFast(() => expect(page.textContent).toContain("The saved login expired"));
+    expect(request).toHaveBeenCalledOnce();
+    await clickCandidate(page, "anthropic-api-key");
 
     await waitForFast(() => {
       expect(request.mock.calls.map(([method, params]) => [method, params])).toEqual([
@@ -334,6 +351,8 @@ describe("ModelSetupPage first-run inference", () => {
         firstRun: true,
       });
 
+      expect(request).not.toHaveBeenCalled();
+      page.querySelector<HTMLButtonElement>(".model-setup__current button")!.click();
       await waitForFast(() => {
         expect(page.textContent).toContain(error);
       });
@@ -378,6 +397,8 @@ describe("ModelSetupPage first-run inference", () => {
       client,
       firstRun: true,
     });
+    expect(request).not.toHaveBeenCalled();
+    await clickCandidate(page, "openai-api-key");
 
     await waitForFast(() => {
       expect(page.textContent).toContain("Connection verified");
@@ -421,6 +442,8 @@ describe("ModelSetupPage first-run inference", () => {
       client,
       firstRun: true,
     });
+    expect(request).not.toHaveBeenCalled();
+    await clickCandidate(page, "openai-api-key");
 
     await waitForFast(() => {
       expect(page.textContent).toContain("The Gateway is restarting");
@@ -454,216 +477,6 @@ describe("ModelSetupPage first-run inference", () => {
     });
   });
 
-  it.each(["valid", "expiry", "removal", "auth"])(
-    "accepts only a current restored verification after application recreation (%s)",
-    async (receiptState) => {
-      const original = createFirstRunContext();
-      original.request.mockResolvedValue({
-        done: true,
-        status: "done",
-        modelActivation: { modelRef: "openai/relaunch", gatewayRestartRequired: true },
-      });
-      const { page, provider } = await mountPage(original.context, {
-        state: {
-          phase: "ready",
-          result: {
-            ...detection,
-            candidates: [candidate("openai-api-key", "openai/relaunch", true)],
-          },
-        },
-        client: original.client,
-        firstRun: true,
-      });
-      await waitForFast(() => expect(page.textContent).toContain("The Gateway is restarting"));
-      provider.remove();
-
-      const relaunched = createFirstRunContext();
-      const verification = createDeferred<unknown>();
-      relaunched.request.mockReturnValue(verification.promise);
-      const { page: restored } = await mountPage(relaunched.context, {
-        state: {
-          phase: "ready",
-          result: { ...detection, configuredModel: "openai/relaunch", setupComplete: true },
-        },
-        client: relaunched.client,
-        firstRun: true,
-      });
-
-      await waitForFast(() => expect(relaunched.request).toHaveBeenCalledOnce());
-      if (receiptState === "expiry") {
-        const receipt = readFirstRunActivationReceipt(relaunched.context)!;
-        vi.spyOn(Date, "now").mockReturnValue(receipt.deadlineMs + 1);
-      } else if (receiptState === "removal") {
-        clearFirstRunActivationReceipt();
-      } else if (receiptState === "auth") {
-        relaunched.context.gateway.connection.token = "replacement-auth";
-      }
-      verification.resolve({ ok: true, modelRef: "openai/relaunch", latencyMs: 31 });
-      await waitForFast(() => expect(relaunched.request).toHaveResolved());
-      await restored.updateComplete;
-      if (receiptState === "valid") {
-        expect(relaunched.context.navigate).toHaveBeenCalledWith("custodian", {
-          search: "?onboarding=1",
-        });
-      } else {
-        expect(relaunched.context.navigate).not.toHaveBeenCalled();
-        expect(restored.querySelector(".model-setup__verified")).toBeNull();
-        expect(restored.textContent).not.toContain("Continue setup");
-        expect(restored.textContent).not.toContain("Cannot read properties");
-      }
-      expect(original.request).toHaveBeenCalledOnce();
-      expect(relaunched.request).toHaveBeenCalledOnce();
-      expect(relaunched.request).toHaveBeenCalledWith(
-        "openclaw.setup.verify",
-        { agentId: "main" },
-        { timeoutMs: MODEL_SETUP_VERIFY_TIMEOUT_MS, signal: expect.any(AbortSignal) },
-      );
-    },
-  );
-
-  it("never repeats an ambiguous activation after app recreation until explicitly retried", async () => {
-    const original = createFirstRunContext();
-    original.request.mockResolvedValue({
-      done: true,
-      status: "done",
-      modelActivation: { modelRef: "openai/relaunch", gatewayRestartRequired: true },
-    });
-    const { page: previous, provider } = await mountPage(original.context, {
-      state: {
-        phase: "ready",
-        result: {
-          ...detection,
-          candidates: [candidate("openai-api-key", "openai/relaunch", true)],
-        },
-      },
-      client: original.client,
-      firstRun: true,
-    });
-    await waitForFast(() => expect(previous.textContent).toContain("The Gateway is restarting"));
-    provider.remove();
-
-    const relaunched = createFirstRunContext();
-    relaunched.request.mockImplementation(async (method) => {
-      if (method === "openclaw.setup.detect") {
-        return {
-          ...detection,
-          candidates: [candidate("openai-api-key", "openai/relaunch", true)],
-        };
-      }
-      if (method === "openclaw.setup.activate.start") {
-        return { done: true, status: "done", modelActivation: { modelRef: "openai/relaunch" } };
-      }
-      throw new Error(`Unexpected method ${method}`);
-    });
-    const { page } = await mountPage(relaunched.context, {
-      state: {
-        phase: "ready",
-        result: {
-          ...detection,
-          candidates: [candidate("openai-api-key", "openai/relaunch", true)],
-        },
-      },
-      client: relaunched.client,
-      firstRun: true,
-    });
-
-    await waitForFast(() => {
-      expect(page.textContent).toContain("previous activation is unresolved");
-      expect(page.textContent).toContain("Check again");
-    });
-    expect(relaunched.request).not.toHaveBeenCalled();
-    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 500_000);
-    page.querySelector<HTMLButtonElement>(".model-setup__intro .btn")?.click();
-
-    await waitForFast(() => {
-      expect(relaunched.request.mock.calls.map(([method]) => method)).toEqual([
-        "openclaw.setup.detect",
-        "openclaw.setup.activate.start",
-      ]);
-      expect(relaunched.context.navigate).toHaveBeenCalledWith("custodian", {
-        search: "?onboarding=1",
-      });
-    });
-    expect(original.request).toHaveBeenCalledOnce();
-  });
-
-  it("rejects a different committed model after full application recreation", async () => {
-    const original = createFirstRunContext();
-    original.request.mockResolvedValue({
-      done: true,
-      status: "done",
-      modelActivation: { modelRef: "openai/expected", gatewayRestartRequired: true },
-    });
-    const { page: previous, provider } = await mountPage(original.context, {
-      state: {
-        phase: "ready",
-        result: {
-          ...detection,
-          candidates: [candidate("openai-api-key", "openai/expected", true)],
-        },
-      },
-      client: original.client,
-      firstRun: true,
-    });
-    await waitForFast(() => expect(previous.textContent).toContain("The Gateway is restarting"));
-    provider.remove();
-
-    const relaunched = createFirstRunContext();
-    const { page } = await mountPage(relaunched.context, {
-      state: {
-        phase: "ready",
-        result: { ...detection, configuredModel: "anthropic/different", setupComplete: true },
-      },
-      client: relaunched.client,
-      firstRun: true,
-    });
-
-    await waitForFast(() => {
-      expect(page.textContent).toContain("The model could not be activated");
-      expect(page.textContent).toContain("openai/expected");
-    });
-    expect(relaunched.request).not.toHaveBeenCalled();
-    expect(relaunched.context.navigate).not.toHaveBeenCalled();
-  });
-
-  it("never resumes another Gateway owner's activation after full application recreation", async () => {
-    const original = createFirstRunContext();
-    original.request.mockResolvedValue({
-      done: true,
-      status: "done",
-      modelActivation: { modelRef: "openai/expected", gatewayRestartRequired: true },
-    });
-    const { page: previous, provider } = await mountPage(original.context, {
-      state: {
-        phase: "ready",
-        result: {
-          ...detection,
-          candidates: [candidate("openai-api-key", "openai/expected", true)],
-        },
-      },
-      client: original.client,
-      firstRun: true,
-    });
-    await waitForFast(() => expect(previous.textContent).toContain("The Gateway is restarting"));
-    provider.remove();
-
-    const relaunched = createFirstRunContext();
-    relaunched.context.gateway.connection.token = "different-gateway-owner";
-    relaunched.request.mockResolvedValue({ ok: true, modelRef: "openai/expected", latencyMs: 31 });
-    await mountPage(relaunched.context, {
-      state: {
-        phase: "ready",
-        result: { ...detection, configuredModel: "openai/expected", setupComplete: true },
-      },
-      client: relaunched.client,
-      firstRun: true,
-    });
-
-    await waitForFast(() => expect(relaunched.context.navigate).toHaveBeenCalledWith("chat"));
-    expect(relaunched.context.navigate).not.toHaveBeenCalledWith("custodian", expect.anything());
-    expect(relaunched.request).toHaveBeenCalledOnce();
-  });
-
   it("finishes onboarding when the Gateway reconnects before its activation response", async () => {
     const { context, client, request, snapshot, publishGatewaySnapshot } = createFirstRunContext();
     let resolveActivation: ((result: WizardNextResult) => void) | undefined;
@@ -693,6 +506,8 @@ describe("ModelSetupPage first-run inference", () => {
       client,
       firstRun: true,
     });
+    expect(request).not.toHaveBeenCalled();
+    await clickCandidate(page, "openai-api-key");
     await waitForFast(() => expect(resolveActivation).toBeTypeOf("function"));
 
     publishGatewaySnapshot({
@@ -761,6 +576,8 @@ describe("ModelSetupPage first-run inference", () => {
       client,
       firstRun: true,
     });
+    expect(request).not.toHaveBeenCalled();
+    await clickCandidate(page, "openai-api-key");
     await waitForFast(() => expect(resolveFirstActivation).toBeTypeOf("function"));
 
     publishGatewaySnapshot({
@@ -796,6 +613,9 @@ describe("ModelSetupPage first-run inference", () => {
     await waitForFast(() => expect(page.textContent).toContain("may still be running"));
     vi.spyOn(Date, "now").mockReturnValue(Date.now() + 500_000);
     retry.click();
+    await waitForFast(() => expect(page.querySelector(".model-setup__loading")).toBeNull());
+    expect(activationCount).toBe(1);
+    await clickCandidate(page, "openai-api-key");
 
     await waitForFast(() => {
       expect(activationCount).toBe(2);
@@ -847,6 +667,8 @@ describe("ModelSetupPage first-run inference", () => {
       client,
       firstRun: true,
     });
+    expect(request).not.toHaveBeenCalled();
+    await clickCandidate(page, "openai-api-key");
     await waitForFast(() => expect(resolveFirstActivation).toBeTypeOf("function"));
 
     publishGatewaySnapshot({
@@ -909,6 +731,8 @@ describe("ModelSetupPage first-run inference", () => {
       client,
       firstRun: true,
     });
+    expect(request).not.toHaveBeenCalled();
+    await clickCandidate(page, "openai-api-key");
     await waitForFast(() => expect(page.textContent).toContain("The Gateway is restarting"));
 
     publishGatewaySnapshot({
@@ -979,6 +803,8 @@ describe("ModelSetupPage first-run inference", () => {
       client,
       firstRun: true,
     });
+    expect(request).not.toHaveBeenCalled();
+    await clickCandidate(page, "openai-api-key");
     await waitForFast(() => expect(request).toHaveBeenCalledOnce());
 
     page.routeData = { firstRun: false };
@@ -1029,6 +855,9 @@ describe("ModelSetupPage first-run inference", () => {
 
     page.routeData = { firstRun: true };
     await page.updateComplete;
+    await waitForFast(() => expect(page.textContent).toContain("anthropic/fresh"));
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["openclaw.setup.detect"]);
+    await clickCandidate(page, "anthropic-api-key");
 
     await waitForFast(() => {
       expect(request.mock.calls.map(([method, params]) => [method, params])).toEqual([
@@ -1044,6 +873,8 @@ describe("ModelSetupPage first-run inference", () => {
         ],
       ]);
     });
-    expect(context.navigate).toHaveBeenCalledWith("custodian", { search: "?onboarding=1" });
+    await waitForFast(() =>
+      expect(context.navigate).toHaveBeenCalledWith("custodian", { search: "?onboarding=1" }),
+    );
   });
 });

--- a/ui/src/pages/model-setup/model-setup-gateway-owner.test.ts
+++ b/ui/src/pages/model-setup/model-setup-gateway-owner.test.ts
@@ -1,0 +1,295 @@
+/* @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { GatewayHelloOk } from "../../api/gateway.ts";
+import type { WizardNextResult } from "../../api/types.ts";
+import { createGatewayStoreTestStore } from "../../app/gateway-store.test-support.ts";
+import { loadSettings } from "../../app/settings.ts";
+import { i18n } from "../../i18n/index.ts";
+import { createRuntimeConfigCapability } from "../../lib/config/runtime-config-capability.ts";
+import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { persistFirstRunActivationReceipt } from "./first-run-activation-receipt.ts";
+import { createFirstRunContext, detection } from "./model-setup-first-run.test-support.ts";
+import { ModelSetupPage } from "./model-setup-page.ts";
+
+describe("first-run wizard ownership through the real Gateway store", () => {
+  beforeEach(async () => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    localStorage.setItem(
+      "openclaw-device-identity-v1",
+      JSON.stringify({ version: 1, privateKey: "synthetic-gateway-owner-device-key" }),
+    );
+    await i18n.setLocale("en");
+  });
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  const ownerChanges = [
+    "same target",
+    "token change",
+    "admin access lost",
+    "same-client admin access lost",
+    "authenticated owner change",
+    "same-client authenticated owner change",
+    "authenticated scope missing",
+    "authenticated scope missing from start",
+    "authenticated owner change with another receipt",
+  ] as const;
+
+  it.each(ownerChanges)(
+    "%s preserves or retires the clicked receipt without replay",
+    async (change) => {
+      const { gateway, current } = createGatewayStoreTestStore({
+        settings: {
+          ...loadSettings(),
+          gatewayUrl: "wss://synthetic-gateway.example.test",
+          token: "synthetic-initial-token",
+        },
+      });
+      const hello = (recoveryScope = "synthetic-owner-a"): GatewayHelloOk => ({
+        type: "hello-ok",
+        protocol: 1,
+        auth: {
+          role: "operator",
+          scopes: ["operator.read", "operator.admin"],
+          deviceToken: "synthetic-device-grant",
+          recoveryScope,
+        },
+        features: {
+          methods: [
+            "config.get",
+            "config.set",
+            "openclaw.setup.detect",
+            "openclaw.setup.auth.start",
+            "openclaw.setup.verify",
+            "wizard.next",
+            "wizard.cancel",
+          ],
+        },
+      });
+      const originalAnswer = createDeferred<WizardNextResult>();
+      const answerStarted = createDeferred();
+      const inventory = {
+        ...detection,
+        authOptions: [
+          {
+            id: "selected-provider",
+            label: "Selected provider",
+            kind: "oauth" as const,
+            featured: true,
+          },
+        ],
+      };
+      gateway.start();
+      const original = current();
+      const sharedResponse = (method: string) => {
+        if (method === "openclaw.setup.detect") {
+          return inventory;
+        }
+        if (method === "config.get") {
+          return {
+            config: {},
+            sourceConfig: {},
+            raw: "{}",
+            hash: "synthetic-config",
+            valid: true,
+            issues: [],
+          };
+        }
+        if (method === "wizard.cancel") {
+          return { status: "cancelled" };
+        }
+        throw new Error(`Unexpected fixture request: ${method}`);
+      };
+      original.request.mockImplementation(async (method, params) => {
+        if (method === "openclaw.setup.auth.start") {
+          return { done: false, status: "running" };
+        }
+        if (method === "wizard.next") {
+          if ((params as { answer?: unknown }).answer) {
+            answerStarted.resolve();
+            return await originalAnswer.promise;
+          }
+          return {
+            done: false,
+            status: "running",
+            step: {
+              id: "provider-key",
+              type: "text",
+              message: "Enter selected provider key",
+              sensitive: true,
+            },
+          };
+        }
+        return sharedResponse(method);
+      });
+      const initialHello = hello();
+      if (change === "authenticated scope missing from start") {
+        delete initialHello.auth!.recoveryScope;
+      }
+      original.opts.onHello?.(initialHello);
+      const runtimeConfig = createRuntimeConfigCapability(gateway);
+      const fixture = createFirstRunContext();
+      const context = { ...fixture.context, gateway, runtimeConfig };
+      const provider = createApplicationContextProvider(context);
+      const page = new ModelSetupPage();
+      page.routeData = { firstRun: true };
+      provider.append(page);
+      document.body.append(provider);
+      try {
+        await waitForFast(() =>
+          expect(
+            page.querySelector('[data-auth-choice="selected-provider"] button'),
+          ).not.toBeNull(),
+        );
+        page
+          .querySelector<HTMLButtonElement>('[data-auth-choice="selected-provider"] button')!
+          .click();
+        await waitForFast(() =>
+          expect(page.querySelector("#model-setup-wizard-text-input")).not.toBeNull(),
+        );
+        const input = page.querySelector<HTMLInputElement>("#model-setup-wizard-text-input")!;
+        input.value = "synthetic-provider-key";
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        await page.updateComplete;
+        page
+          .querySelector<HTMLFormElement>("openclaw-modal-dialog form")!
+          .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+        await answerStarted.promise;
+        const receipt = localStorage.getItem("openclaw.modelSetup.pendingActivation.v1");
+        expect(receipt).not.toBeNull();
+        const originalRevision = gateway.connectionRevision;
+        const originalStart = original.request.mock.calls.find(
+          ([method]) => method === "openclaw.setup.auth.start",
+        )!;
+        const sessionId = (originalStart[1] as { sessionId: string }).sessionId;
+
+        let replacementReceipt: string | null = null;
+        if (change === "authenticated owner change with another receipt") {
+          persistFirstRunActivationReceipt(context, {
+            kind: "provider-auth",
+            modelRef: "provider/another-choice",
+          });
+          replacementReceipt = localStorage.getItem("openclaw.modelSetup.pendingActivation.v1");
+          expect(replacementReceipt).not.toBe(receipt);
+        }
+        // Exercise both actual client replacement and the store's socket-close
+        // callback; neither path fabricates revision or snapshot state.
+        if (change.startsWith("same-client")) {
+          original.opts.onClose?.({ code: 1006, reason: "synthetic reconnect", willRetry: true });
+        } else {
+          gateway.connect(
+            change === "token change" ? { token: "synthetic-replacement-token" } : {},
+          );
+        }
+        const replacement = current();
+        const requestOffset = replacement.request.mock.calls.length;
+        const replacementRequests = () => replacement.request.mock.calls.slice(requestOffset);
+        replacement.request.mockImplementation(async (method) => {
+          if (method === "wizard.next") {
+            return {
+              done: false,
+              status: "running",
+              step: { id: "provider-review", type: "note", message: "Review selected provider" },
+            };
+          }
+          return sharedResponse(method);
+        });
+        const reconnectedHello = hello(
+          change.includes("authenticated owner change") ? "synthetic-owner-b" : undefined,
+        );
+        if (change.startsWith("authenticated scope missing")) {
+          delete reconnectedHello.auth!.recoveryScope;
+        }
+        const authorityLost = change.includes("admin access lost");
+        if (authorityLost) {
+          reconnectedHello.auth!.scopes = ["operator.read"];
+          replacementReceipt = receipt;
+        }
+        replacement.opts.onHello?.(reconnectedHello);
+        expect(gateway.connectionRevision).toBe(
+          originalRevision + (change === "token change" ? 1 : 0),
+        );
+
+        if (change === "same target") {
+          await waitForFast(() => expect(page.textContent).toContain("Review selected provider"));
+          expect(localStorage.getItem("openclaw.modelSetup.pendingActivation.v1")).toBe(receipt);
+          expect(
+            replacementRequests()
+              .filter(([method]) => method === "wizard.next")
+              .map(([, params]) => params),
+          ).toEqual([{ sessionId }]);
+          expect(
+            original.request.mock.calls.filter(([method]) => method === "wizard.cancel"),
+          ).toHaveLength(0);
+        } else {
+          await waitForFast(() => expect(page.querySelector("openclaw-modal-dialog")).toBeNull());
+          expect(
+            replacementRequests().filter(([method]) => method.startsWith("wizard.")),
+          ).toHaveLength(0);
+          expect(localStorage.getItem("openclaw.modelSetup.pendingActivation.v1")).toBe(
+            replacementReceipt,
+          );
+          if (authorityLost) {
+            expect(page.textContent).toContain("operator.admin");
+            expect(
+              replacementRequests().filter(([method]) => method.startsWith("openclaw.setup.")),
+            ).toHaveLength(0);
+          }
+        }
+        originalAnswer.resolve({
+          done: true,
+          status: "done",
+          modelActivation: { modelRef: "provider/original" },
+        });
+        await waitForFast(() =>
+          expect(
+            original.request.mock.settledResults.filter((result) => result.type === "incomplete"),
+          ).toHaveLength(0),
+        );
+        if (authorityLost) {
+          // Reauthorizing the same principal restores discovery, not a discarded
+          // wizard handle or permission to replay its prior answer.
+          replacement.opts.onHello?.(hello());
+          await waitForFast(() =>
+            expect(page.querySelector(".model-setup__recovery")).not.toBeNull(),
+          );
+          expect(page.querySelector("openclaw-modal-dialog")).toBeNull();
+          expect(
+            replacementRequests().filter(([method]) => method.startsWith("wizard.")),
+          ).toHaveLength(0);
+        }
+        if (change !== "same target") {
+          expect(localStorage.getItem("openclaw.modelSetup.pendingActivation.v1")).toBe(
+            replacementReceipt,
+          );
+        }
+        expect(context.navigate).not.toHaveBeenCalled();
+        expect(
+          original.request.mock.calls.filter(([method]) => method === "openclaw.setup.auth.start"),
+        ).toHaveLength(1);
+        expect(
+          replacementRequests().filter(([method]) => method === "openclaw.setup.auth.start"),
+        ).toHaveLength(0);
+        expect(
+          original.request.mock.calls.filter(
+            ([method, params]) =>
+              method === "wizard.next" && Boolean((params as { answer?: unknown }).answer),
+          ),
+        ).toHaveLength(1);
+      } finally {
+        originalAnswer.resolve({ done: true, status: "cancelled" });
+        page.remove();
+        runtimeConfig.dispose();
+        fixture.context.runtimeConfig.dispose();
+        gateway.stop();
+      }
+    },
+  );
+});

--- a/ui/src/pages/model-setup/model-setup-page.test.ts
+++ b/ui/src/pages/model-setup/model-setup-page.test.ts
@@ -902,6 +902,7 @@ describe("ModelSetupPage catalog icons", () => {
         runExternalMutation,
       },
     } as ApplicationContext;
+    let cancellationAttempt = 0;
     request.mockImplementation(async (method: string) => {
       if (method === "openclaw.setup.auth.start") {
         return { sessionId: "wizard-session", done: false, status: "running" };
@@ -912,6 +913,16 @@ describe("ModelSetupPage catalog icons", () => {
           status: "running",
           step: { id: "token", type: "text", message: "Paste token" },
         };
+      }
+      if (method === "wizard.cancel") {
+        cancellationAttempt += 1;
+        if (cancellationAttempt === 1) {
+          return { status: "running" };
+        }
+        if (cancellationAttempt === 2) {
+          throw new Error("Cancellation request disconnected");
+        }
+        return { status: "cancelled" };
       }
       return {};
     });
@@ -935,7 +946,28 @@ describe("ModelSetupPage catalog icons", () => {
       expect(page.textContent).toContain("Paste token");
     });
     page.querySelector<HTMLButtonElement>("openclaw-modal-dialog .btn")?.click();
-    await page.updateComplete;
-    expect(page.textContent).toContain("config.get failed after wizard commit");
+    await waitForFast(() => {
+      const modal = page.querySelector("openclaw-modal-dialog");
+      expect(modal?.textContent).toContain("config.get failed after wizard commit");
+      expect(modal?.textContent).toContain("Setup is finishing the current step.");
+    });
+
+    page.querySelector<HTMLButtonElement>("openclaw-modal-dialog .btn")?.click();
+    await waitForFast(() => {
+      const modal = page.querySelector("openclaw-modal-dialog");
+      expect(modal?.textContent).toContain("config.get failed after wizard commit");
+      expect(modal?.textContent).toContain(
+        "Could not confirm cancellation: Cancellation request disconnected",
+      );
+      expect(modal?.textContent).not.toContain("Setup is finishing the current step.");
+    });
+    expect(cancellationAttempt).toBe(2);
+
+    page.querySelector<HTMLButtonElement>("openclaw-modal-dialog .btn")?.click();
+    await waitForFast(() => {
+      expect(page.querySelector("openclaw-modal-dialog")).toBeNull();
+      expect(page.textContent).toContain("config.get failed after wizard commit");
+    });
+    expect(cancellationAttempt).toBe(3);
   });
 });

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -17,6 +17,7 @@ import { readSessionDefaults } from "../../lib/sessions/session-key.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import {
+  captureModelSetupConnection,
   FirstRunSetup,
   type ModelSetupConnection,
   type ModelSetupRouteData,
@@ -66,12 +67,12 @@ export class ModelSetupPage extends OpenClawLightDomElement {
   @state() private manualApiKey = "";
   @state() private manualError: string | null = null;
   @state() private moreSignInOpen = false;
+  @state() private nativeSessionCatalogsEnabled = false;
   @state() private iconUrls: Record<string, string> = {};
   @state() private setupRefreshWarning: string | null = null;
+  @state() private cancellationNotice: string | null = null;
 
-  private observedConnection:
-    | (ModelSetupConnection & { connected: boolean; firstRun: boolean })
-    | null = null;
+  private observedConnection: ReturnType<typeof captureModelSetupConnection> | null = null;
   private pendingPrepareOption: ModelSetupPrepareOption | null = null;
   private wizardMutationGeneration = 0;
   private wizardMutationActive = false;
@@ -84,8 +85,6 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     canUseSetup: (client) => this.canUseSetup(client),
     canVerify: (client) => this.canVerify(client),
     verify: () => this.verifyConnection().then(() => this.verifyTask.value),
-    activate: (candidate, targetId) =>
-      this.activate({ kind: candidate.kind, modelRef: candidate.modelRef }, targetId),
     setVerifyState: (next) => (this.verifyState = next),
     setActivationState: (next) => (this.activationState = next),
     setRefreshWarning: (warning) => (this.setupRefreshWarning = warning),
@@ -122,6 +121,9 @@ export class ModelSetupPage extends OpenClawLightDomElement {
         next.phase === "step" && this.wizardMutationActive ? { ...next, busy: true } : next;
       if (next.phase === "step" && next.step.id !== previousStep) {
         this.wizardValue = initialWizardValue(next.step);
+      } else if (next.phase === "idle") {
+        this.wizardValue = undefined;
+        this.cancellationNotice = null;
       }
     },
     onStart: (method, intent) => {
@@ -201,7 +203,11 @@ export class ModelSetupPage extends OpenClawLightDomElement {
         agentId: outcome.agentId,
       });
       this.pageState = { phase: "ready", result: outcome.value };
-      this.syncManualProvider(this.pageState);
+      if (
+        !outcome.value.manualProviders.some((provider) => provider.id === this.manualProviderId)
+      ) {
+        this.manualProviderId = "";
+      }
     },
   });
 
@@ -252,25 +258,58 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     if (!this.isConnected || !routeData) {
       return;
     }
-    const connection = {
-      client: snapshot.client,
-      hello: snapshot.hello,
-      agentId: this.context.agentSelection.state.selectedId,
-      connected: snapshot.phase === "connected",
-      firstRun: routeData.firstRun,
-    };
     const previous = this.observedConnection;
+    const connection = captureModelSetupConnection(
+      this.context,
+      routeData.firstRun,
+      previous?.recoveryScope,
+    );
     if (
       previous &&
       connection.client === previous.client &&
       connection.hello === previous.hello &&
       connection.agentId === previous.agentId &&
       connection.connected === previous.connected &&
-      connection.firstRun === previous.firstRun
+      connection.firstRun === previous.firstRun &&
+      connection.connectionRevision === previous.connectionRevision &&
+      connection.recoveryScope === previous.recoveryScope
     ) {
       return;
     }
     this.observedConnection = connection;
+    const authenticatedOwnerLost =
+      previous &&
+      (!connection.recoveryScope || connection.recoveryScope !== previous.recoveryScope);
+    const ownerChanged =
+      previous &&
+      (connection.agentId !== previous.agentId ||
+        connection.firstRun !== previous.firstRun ||
+        connection.connectionRevision !== previous.connectionRevision ||
+        authenticatedOwnerLost);
+    const setupAuthorityLost =
+      connection.connected && !hasOperatorAdminAccess(snapshot.hello?.auth ?? null);
+    if (authenticatedOwnerLost || setupAuthorityLost) {
+      // A changed identity or reduced authority cannot cancel the old wizard.
+      // Retire local handles and expose the existing access/recovery state.
+      this.wizard.close({ retireOwner: true });
+    }
+    if (ownerChanged) {
+      this.nativeSessionCatalogsEnabled = false;
+      this.manualProviderId = "";
+      this.manualApiKey = "";
+      this.manualError = null;
+    }
+    const sameWizardOwner = previous && Boolean(connection.recoveryScope) && !ownerChanged;
+    if (sameWizardOwner && this.wizard.hasAdmittedSession) {
+      this.wizardMutationGeneration += 1;
+      this.wizardMutationActive = false;
+      this.wizard.suspend();
+      if (this.canUseSetup(connection.client)) {
+        this.firstRun.reconnectActivation(connection);
+        void this.runWizardMutation(() => this.wizard.resume());
+      }
+      return;
+    }
     // The router refreshes cached loader objects during the same visit. Only
     // a mode change or mounted/connection lifecycle can retire setup ownership.
     if (connection.firstRun !== previous?.firstRun) {
@@ -290,8 +329,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     this.wizardMutationActive = false;
     void this.detectTask.run([null, null, null]);
     this.activationState = { phase: "idle" };
-    this.verifyState = { phase: "idle" };
-    void this.verifyTask.run([null, null]);
+    this.resetVerify();
     this.iconLoader.reset();
     this.pendingPrepareOption = null;
     void this.wizard.cancel();
@@ -305,17 +343,6 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       hasOperatorAdminAccess(snapshot.hello?.auth ?? null) &&
       isGatewayMethodAdvertised(snapshot, "openclaw.setup.detect") === true,
     );
-  }
-
-  private syncManualProvider(pageState: ModelSetupPageState): void {
-    if (pageState.phase !== "ready") {
-      return;
-    }
-    if (
-      !pageState.result.manualProviders.some((provider) => provider.id === this.manualProviderId)
-    ) {
-      this.manualProviderId = pageState.result.manualProviders[0]?.id ?? "";
-    }
   }
 
   private async detect(): Promise<SystemAgentSetupDetectResult | null> {
@@ -362,7 +389,16 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     this.activationState = { phase: "testing", targetId };
     this.pendingPrepareOption = null;
     this.wizardMode = "activate";
-    await this.runWizardMutation(() => this.wizard.activate(params, targetId));
+    await this.runWizardMutation(() =>
+      this.wizard.activate({ ...params, ...this.nativeSessionCatalogPreference() }, targetId),
+    );
+  }
+
+  private nativeSessionCatalogPreference(): { nativeSessionCatalogsEnabled?: boolean } {
+    return this.pageState.phase === "ready" &&
+      this.pageState.result.nativeSessionCatalogPreferenceRequired === true
+      ? { nativeSessionCatalogsEnabled: this.nativeSessionCatalogsEnabled }
+      : {};
   }
 
   private finishActivation(
@@ -429,12 +465,13 @@ export class ModelSetupPage extends OpenClawLightDomElement {
   }: ModelSetupWizardCompletion): Promise<void> {
     const prepareOption =
       startMethod === "openclaw.setup.prepare.start" ? this.pendingPrepareOption : null;
+    const nativeSessionCatalogPreference = this.nativeSessionCatalogPreference();
     this.pendingPrepareOption = null;
     if (prepareOption && preparedModelRef) {
       const kind = providerAutoSetupKind(prepareOption.id);
       this.wizard.close();
       void this.activate(
-        { kind, modelRef: preparedModelRef },
+        { kind, modelRef: preparedModelRef, ...nativeSessionCatalogPreference },
         activationTargetId(kind, preparedModelRef),
       );
       return;
@@ -482,7 +519,10 @@ export class ModelSetupPage extends OpenClawLightDomElement {
         return;
       }
       this.wizard.close();
-      this.activateCandidate(candidate);
+      void this.activate(
+        { kind: candidate.kind, modelRef: candidate.modelRef, ...nativeSessionCatalogPreference },
+        activationTargetId(candidate.kind, candidate.modelRef),
+      );
       return;
     }
     this.wizard.close();
@@ -567,14 +607,35 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     }
   }
 
-  private cancelWizard(): void {
-    this.wizardMutationGeneration += 1;
-    this.wizardMutationActive = false;
-    this.pendingPrepareOption = null;
-    this.activationState = { phase: "idle" };
-    // A Gateway-owned step can commit while cancellation is being handled.
-    // Hide this generation now, but let its mutation lane settle and refresh.
-    void this.wizard.cancel({ settleActiveRequest: true });
+  private async cancelWizard(): Promise<void> {
+    const generation = this.wizardMutationGeneration;
+    this.cancellationNotice = null;
+    try {
+      const outcome = await this.wizard.requestCancellation();
+      if (generation !== this.wizardMutationGeneration) {
+        return;
+      }
+      if (outcome === "running") {
+        this.cancellationNotice = t("modelSetup.wizard.finishingStep");
+        return;
+      }
+      if (outcome !== "cancelled") {
+        return;
+      }
+      this.wizardMutationGeneration += 1;
+      this.wizardMutationActive = false;
+      this.pendingPrepareOption = null;
+      this.activationState = { phase: "idle" };
+    } catch (error) {
+      if (
+        generation === this.wizardMutationGeneration &&
+        (this.wizardState.phase === "starting" || this.wizardState.phase === "step")
+      ) {
+        this.cancellationNotice = t("modelSetup.wizard.cancelFailed", {
+          error: formatModelSetupError(error),
+        });
+      }
+    }
   }
 
   private actionsDisabled(): boolean {
@@ -614,6 +675,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       modelConfigured: readSessionDefaults(snapshot)?.modelConfigured === true,
       gatewayTooOld,
       refreshWarning: this.setupRefreshWarning,
+      cancellationNotice: this.cancellationNotice,
       activationUnresolved: this.firstRun.unresolved,
       onUseCurrentModel: () => void this.firstRun.useCurrentModel(),
       actionsDisabled: this.actionsDisabled(),
@@ -621,6 +683,8 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       manualApiKey: this.manualApiKey,
       manualError: this.manualError,
       moreSignInOpen: this.moreSignInOpen,
+      nativeSessionCatalogsEnabled: this.nativeSessionCatalogsEnabled,
+      onNativeSessionCatalogsChange: (enabled) => (this.nativeSessionCatalogsEnabled = enabled),
       firstRun: this.routeData?.firstRun === true,
       iconUrls: this.iconUrls,
       onDetect: () => {
@@ -633,7 +697,13 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       onStartAuth: (option) => {
         this.pendingPrepareOption = null;
         this.wizardMode = "auth";
-        void this.runWizardMutation(() => this.wizard.start(option.id));
+        void this.runWizardMutation(() =>
+          this.wizard.start(
+            option.id,
+            "openclaw.setup.auth.start",
+            this.nativeSessionCatalogPreference(),
+          ),
+        );
       },
       onStartPrepare: (option: ModelSetupPrepareOption) => {
         this.pendingPrepareOption = option;
@@ -659,7 +729,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       onWizardValueChange: (value) => (this.wizardValue = value),
       onWizardAnswer: (value, includeValue) =>
         void this.runWizardMutation(() => this.wizard.answer(value, includeValue)),
-      onWizardCancel: () => this.cancelWizard(),
+      onWizardCancel: () => void this.cancelWizard(),
       onWizardClose: () => this.closeWizard(),
     });
   }

--- a/ui/src/pages/model-setup/model-setup-reconnect.test.ts
+++ b/ui/src/pages/model-setup/model-setup-reconnect.test.ts
@@ -39,7 +39,11 @@ function createFixture() {
     hello: {
       type: "hello-ok" as const,
       protocol: 1,
-      auth: { role: "operator", scopes: ["operator.read", "operator.admin"] },
+      auth: {
+        role: "operator",
+        scopes: ["operator.read", "operator.admin"],
+        recoveryScope: "synthetic-setup-owner",
+      },
       features: { methods: ["openclaw.setup.detect", "openclaw.setup.verify"] },
     },
     canvasPluginSurfaceUrl: null,
@@ -243,14 +247,28 @@ describe("ModelSetupPage detection ownership", () => {
     },
   );
 
-  it("cancels a stale wizard when reconnect phases resolve before Lit renders", async () => {
+  it("recovers the selected provider wizard across a same-Gateway reconnect", async () => {
     const { context, request, runtimeConfig, setGatewayPhase } = createFixture();
     let oldWizardSignal: AbortSignal | undefined;
+    let nextCalls = 0;
     request.mockImplementation(async (method, _params, options) => {
       if (method === "openclaw.setup.auth.start") {
-        return { sessionId: "wizard-before-reconnect", done: false, status: "running" };
+        return { done: false, status: "running" };
       }
       if (method === "wizard.next") {
+        nextCalls += 1;
+        if (nextCalls > 1) {
+          return {
+            done: false,
+            status: "running",
+            step: {
+              id: "provider-key",
+              type: "text",
+              message: "Enter the selected provider key",
+              sensitive: true,
+            },
+          };
+        }
         oldWizardSignal = options?.signal;
         return await new Promise((_resolve, reject) => {
           options?.signal?.addEventListener("abort", () => reject(new Error("aborted")), {
@@ -258,28 +276,34 @@ describe("ModelSetupPage detection ownership", () => {
           });
         });
       }
+      if (method === "config.get") {
+        return { config: {}, sourceConfig: {}, raw: "{}", hash: "hash-1", valid: true, issues: [] };
+      }
       return method === "openclaw.setup.detect" ? detection : {};
     });
     const page = await mountPage(context);
     await vi.waitFor(() =>
       expect(page.querySelector('[data-auth-choice="provider-auth"]')).not.toBeNull(),
     );
-    page.querySelector<HTMLButtonElement>('[data-auth-choice="provider-auth"] button')?.click();
+    page.querySelector<HTMLButtonElement>('[data-auth-choice="provider-auth"] button')!.click();
     await vi.waitFor(() => expect(oldWizardSignal).toBeInstanceOf(AbortSignal));
+    const start = request.mock.calls.find(([method]) => method === "openclaw.setup.auth.start")!;
 
     setGatewayPhase("reconnecting");
     setGatewayPhase("connected");
-    await vi.waitFor(() => {
-      expect(
-        request.mock.calls.filter(([method]) => method === "openclaw.setup.detect"),
-      ).toHaveLength(2);
-    });
+    await vi.waitFor(() => expect(page.textContent).toContain("Enter the selected provider key"));
     expect(oldWizardSignal?.aborted).toBe(true);
-    expect(page.querySelector("openclaw-modal-dialog")).toBeNull();
+    expect(
+      request.mock.calls.filter(([method]) => method === "openclaw.setup.auth.start"),
+    ).toHaveLength(1);
+    expect(request.mock.calls.filter(([method]) => method === "wizard.cancel")).toHaveLength(0);
+    expect(request.mock.calls.findLast(([method]) => method === "wizard.next")?.[1]).toEqual({
+      sessionId: (start[1] as { sessionId: string }).sessionId,
+    });
     runtimeConfig.dispose();
   });
 
-  it("suppresses a late wizard completion but retains its reconnect refresh warning", async () => {
+  it("suppresses a late wizard completion after Gateway credentials change", async () => {
     const { context, request, runtimeConfig, setGatewayPhase } = createFixture();
     let releaseWizard: ((value: unknown) => void) | undefined;
     request.mockImplementation(async (method) => {
@@ -308,6 +332,7 @@ describe("ModelSetupPage detection ownership", () => {
     page.querySelector<HTMLButtonElement>('[data-auth-choice="provider-auth"] button')?.click();
     await vi.waitFor(() => expect(releaseWizard).toBeTypeOf("function"));
 
+    Object.assign(context.gateway, { connectionRevision: context.gateway.connectionRevision + 1 });
     setGatewayPhase("reconnecting");
     setGatewayPhase("connected");
     releaseWizard?.({ done: true, status: "done" });

--- a/ui/src/pages/model-setup/model-setup-server-consent.test.ts
+++ b/ui/src/pages/model-setup/model-setup-server-consent.test.ts
@@ -1,0 +1,175 @@
+/* @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { applyWizardMetadata } from "../../../../src/commands/onboard-helpers.js";
+import { createConfigFileSnapshot } from "../../../../src/config/io.snapshot-shared.js";
+import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
+import { systemAgentHandlers } from "../../../../src/gateway/server-methods/system-agent.js";
+import { initializeNativeSessionCatalogPreferences } from "../../../../src/plugins/native-session-catalog-config.js";
+import { createPluginMetadataSnapshotFixture } from "../../../../src/plugins/plugin-metadata.test-support.js";
+import { i18n } from "../../i18n/index.ts";
+import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { createFirstRunContext } from "./model-setup-first-run.test-support.ts";
+import { ModelSetupPage } from "./model-setup-page.ts";
+
+const fixture = vi.hoisted(() => ({
+  config: {} as OpenClawConfig,
+  exists: false,
+  additionalCatalog: false,
+}));
+vi.mock("../../../../src/config/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../../src/config/config.js")>()),
+  readConfigFileSnapshotWithPluginMetadata: async () => ({
+    snapshot: createConfigFileSnapshot({
+      path: "/tmp/synthetic-onboarding/openclaw.json",
+      exists: fixture.exists,
+      valid: true,
+      raw: null,
+      parsed: fixture.config,
+      sourceConfig: fixture.config,
+      runtimeConfig: fixture.config,
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+    }),
+    pluginMetadataSnapshot: createPluginMetadataSnapshotFixture({
+      plugins: fixture.additionalCatalog
+        ? [
+            {
+              id: "fixture-catalog",
+              setup: {
+                nativeSessionCatalog: { label: "Fixture archive", legacyDefaultEnabled: true },
+              },
+            },
+          ]
+        : [],
+    }),
+  }),
+}));
+vi.mock("../../../../src/plugins/provider-install-catalog.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../../src/plugins/provider-install-catalog.js")>()),
+  resolveProviderInstallCatalogEntries: () => [],
+}));
+vi.mock("../../../../src/system-agent/setup-inference-detection.js", () => ({
+  // Replace worker/process discovery only. Actual handler parameters, authored
+  // config interpretation, consent decision, RPC client and UI all compose here.
+  detectSetupInferenceIsolated: async (params: { agentId?: string }) => {
+    const { detectSetupInference } =
+      await import("../../../../src/system-agent/setup-inference-detect.js");
+    return detectSetupInference(
+      {
+        resolveManifestProviderAuthChoices: () => [],
+        detectInferenceBackends: async () => [],
+        probeLocalCommand: async (command) => ({ command, found: false }),
+      },
+      params.agentId,
+    );
+  },
+}));
+
+describe("selected-agent Gateway detection and Model Setup consent", () => {
+  beforeEach(async () => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    await i18n.setLocale("en");
+  });
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    "unwritten",
+    "initialized",
+    "doctor",
+    "onboard",
+    "upgrade",
+    "authored",
+    "additional-catalog",
+  ] as const)(
+    "uses server-owned first-install evidence for %s selected-agent setup",
+    async (state) => {
+      const authored: OpenClawConfig = {
+        agents: { ownership: "explicit", entries: { main: {}, research: {} } },
+      };
+      fixture.exists = state !== "unwritten";
+      fixture.additionalCatalog = state === "additional-catalog";
+      fixture.config =
+        state === "unwritten"
+          ? {}
+          : state === "upgrade"
+            ? authored
+            : initializeNativeSessionCatalogPreferences(authored);
+      if (state === "doctor" || state === "onboard") {
+        fixture.config = applyWizardMetadata(fixture.config, { command: state, mode: "local" });
+      }
+      if (state === "authored") {
+        fixture.config.plugins!.entries!.codex!.config = { sessionCatalog: { enabled: true } };
+      }
+      const { context, request } = createFirstRunContext();
+      const agentId = state === "unwritten" ? "main" : "research";
+      Object.assign(context.agentSelection.state, { selectedId: agentId, scopeId: agentId });
+      request.mockImplementation(async (method, params) => {
+        if (method === "openclaw.setup.detect") {
+          const handler = systemAgentHandlers[method]!;
+          return await new Promise((resolve, reject) => {
+            const response = handler({
+              params,
+              respond: (ok, payload, error) =>
+                ok ? resolve(payload) : reject(new Error(error?.message, { cause: error })),
+            } as Parameters<typeof handler>[0]);
+            void Promise.resolve(response).catch(reject);
+          });
+        }
+        if (method === "openclaw.setup.auth.start") {
+          return { done: true, status: "cancelled" };
+        }
+        throw new Error(`Unexpected setup RPC: ${method}`);
+      });
+      const provider = createApplicationContextProvider(context);
+      const page = new ModelSetupPage();
+      page.routeData = { firstRun: true };
+      provider.append(page);
+      document.body.append(provider);
+      await waitForFast(() =>
+        expect(page.querySelector('[data-auth-choice="custom-api-key"] button')).not.toBeNull(),
+      );
+      expect(request.mock.calls).toEqual([
+        [
+          "openclaw.setup.detect",
+          { agentId },
+          expect.objectContaining({
+            timeoutMs: expect.any(Number),
+            signal: expect.any(AbortSignal),
+          }),
+        ],
+      ]);
+      const checkbox = page.querySelector<HTMLInputElement>(".model-setup__native-discovery input");
+      const required = state !== "upgrade" && state !== "authored";
+      if (required) {
+        expect(checkbox?.checked).toBe(false);
+      } else {
+        expect(checkbox).toBeNull();
+      }
+      if (fixture.additionalCatalog) {
+        expect(page.textContent).toContain("Fixture archive");
+      }
+      page.querySelector<HTMLButtonElement>('[data-auth-choice="custom-api-key"] button')!.click();
+      await waitForFast(() =>
+        expect(request.mock.calls.some(([method]) => method === "openclaw.setup.auth.start")).toBe(
+          true,
+        ),
+      );
+      const activation = request.mock.calls.find(
+        ([method]) => method === "openclaw.setup.auth.start",
+      )![1];
+      expect(activation).toMatchObject({ authChoice: "custom-api-key", agentId });
+      if (required) {
+        expect(activation).toHaveProperty("nativeSessionCatalogsEnabled", false);
+      } else {
+        expect(activation).not.toHaveProperty("nativeSessionCatalogsEnabled");
+      }
+    },
+  );
+});

--- a/ui/src/pages/model-setup/provider-picker.ts
+++ b/ui/src/pages/model-setup/provider-picker.ts
@@ -152,35 +152,37 @@ export function renderManualProviderPicker(
           ${icons.chevronDown}
         </span>
       </button>
-      ${result.manualProviders.map((entry) => {
-        const selected = entry.id === props.manualProviderId;
-        const entryMethod = manualProviderMethod(entry);
-        const accessibleLabel = [manualProviderName(entry), entryMethod, entry.hint]
-          .filter(Boolean)
-          .join(", ");
-        return html`
-          <wa-dropdown-item
-            class="model-setup-provider-select__option"
-            data-manual-provider=${entry.id}
-            ?data-selected=${selected}
-            aria-label=${accessibleLabel}
-            .value=${entry.id}
-            type="checkbox"
-            .checked=${selected}
-            ?disabled=${props.actionsDisabled}
-            ${ref((element) => syncDropdownItemRadio(element, selected))}
-          >
-            <span slot="icon">
-              ${renderProviderIcon(props, entry, "model-setup__icon--picker")}
-            </span>
-            <span class="model-setup-provider-select__copy">
-              <strong>${manualProviderName(entry)}</strong>
-              ${entryMethod ? html`<span>${entryMethod}</span>` : nothing}
-              ${entry.hint ? html`<small>${entry.hint}</small>` : nothing}
-            </span>
-          </wa-dropdown-item>
-        `;
-      })}
+      ${result.manualProviders
+        .toSorted((a, b) => manualProviderName(a).localeCompare(manualProviderName(b)))
+        .map((entry) => {
+          const selected = entry.id === props.manualProviderId;
+          const entryMethod = manualProviderMethod(entry);
+          const accessibleLabel = [manualProviderName(entry), entryMethod, entry.hint]
+            .filter(Boolean)
+            .join(", ");
+          return html`
+            <wa-dropdown-item
+              class="model-setup-provider-select__option"
+              data-manual-provider=${entry.id}
+              ?data-selected=${selected}
+              aria-label=${accessibleLabel}
+              .value=${entry.id}
+              type="checkbox"
+              .checked=${selected}
+              ?disabled=${props.actionsDisabled}
+              ${ref((element) => syncDropdownItemRadio(element, selected))}
+            >
+              <span slot="icon">
+                ${renderProviderIcon(props, entry, "model-setup__icon--picker")}
+              </span>
+              <span class="model-setup-provider-select__copy">
+                <strong>${manualProviderName(entry)}</strong>
+                ${entryMethod ? html`<span>${entryMethod}</span>` : nothing}
+                ${entry.hint ? html`<small>${entry.hint}</small>` : nothing}
+              </span>
+            </wa-dropdown-item>
+          `;
+        })}
     </wa-dropdown>
   `;
 }

--- a/ui/src/pages/model-setup/route.test.ts
+++ b/ui/src/pages/model-setup/route.test.ts
@@ -12,6 +12,22 @@ const location: RouteLocation = {
 };
 
 describe("model setup route", () => {
+  it.each([
+    ["?firstRun=1", true],
+    ["?firstRun=explicit", true],
+    ["?firstRun=0", false],
+    ["?firstRun=0&firstRun=explicit", false],
+    ["", false],
+  ])("interprets first-run link %s without starting provider setup", async (search, expected) => {
+    const context = {} as ApplicationContext;
+    const router = createRouter({ routes: [{ ...page, component: () => null }] });
+    try {
+      await router.navigate("model-setup", context, {}, { ...location, search });
+      expect(router.getState().matches[0]?.data).toEqual({ firstRun: expected });
+    } finally {
+      router.stop();
+    }
+  });
   it("keys loader data by the first-run query", () => {
     const context = {
       agentSelection: { state: { selectedId: "main" } },

--- a/ui/src/pages/model-setup/route.ts
+++ b/ui/src/pages/model-setup/route.ts
@@ -11,7 +11,10 @@ export const page = definePage({
   // action cannot retain a cached destination from the previous visit.
   loaderDeps: (_context: ApplicationContext, location: RouteLocation) => location.search,
   loader: (_context: ApplicationContext, { location }): ModelSetupRouteData => ({
-    firstRun: new URLSearchParams(location.search).get("firstRun") === "1",
+    // Preserve saved first-run URLs; both markers use the same explicit-choice UI.
+    firstRun: ["1", "explicit"].includes(
+      new URLSearchParams(location.search).get("firstRun") ?? "",
+    ),
   }),
   component: () =>
     import("./model-setup-page.ts").then(() => ({

--- a/ui/src/pages/model-setup/view.test.ts
+++ b/ui/src/pages/model-setup/view.test.ts
@@ -54,7 +54,7 @@ describe("renderModelSetup", () => {
     expect(text(container)).toContain("openai/gpt-5 · Signed in locally");
     expect(text(container)).toContain("Found, but needs attention");
     expect(text(container)).toContain("This local runtime must be configured outside OpenClaw");
-    expect(text(container)).toContain("Sign in with a provider");
+    expect(text(container)).toContain("Connect an AI provider");
     expect(text(container)).toContain("Run a model locally");
     expect(text(container)).toContain("LM Studio");
     expect(text(container)).toContain("Connect with an API key or token");

--- a/ui/src/pages/model-setup/view.ts
+++ b/ui/src/pages/model-setup/view.ts
@@ -38,6 +38,7 @@ type ModelSetupViewProps = {
   modelConfigured?: boolean;
   gatewayTooOld: boolean;
   refreshWarning: string | null;
+  cancellationNotice?: string | null;
   activationUnresolved?: boolean;
   onUseCurrentModel?: () => void;
   actionsDisabled: boolean;
@@ -46,6 +47,8 @@ type ModelSetupViewProps = {
   manualError: string | null;
   moreSignInOpen: boolean;
   firstRun: boolean;
+  nativeSessionCatalogsEnabled?: boolean;
+  onNativeSessionCatalogsChange?: (enabled: boolean) => void;
   iconUrls: Readonly<Record<string, string>>;
   onDetect: () => void;
   onVerify: () => void;
@@ -97,48 +100,50 @@ function renderCandidateRows(props: ModelSetupViewProps, result: SystemAgentSetu
         <h2>${t("modelSetup.candidates.title")}</h2>
       </div>
       <div class="model-setup__rows">
-        ${candidates.map((candidate) => {
-          const testing =
-            props.activation.phase === "testing" &&
-            props.activation.targetId === activationTargetId(candidate.kind, candidate.modelRef);
-          const failure =
-            props.activation.phase === "failure" &&
-            props.activation.targetId === activationTargetId(candidate.kind, candidate.modelRef)
-              ? props.activation
-              : null;
-          return html`
-            <div class="model-setup__row" data-candidate-kind=${candidate.kind}>
-              <div class="model-setup__row-main">
-                <div class="model-setup__row-title">
-                  ${renderProviderIcon(props, candidate)}
-                  <strong>${candidate.label}</strong>
-                  <span class="model-setup__chip">${candidateStatus(candidate)}</span>
+        ${candidates
+          .toSorted((a, b) => a.label.localeCompare(b.label))
+          .map((candidate) => {
+            const testing =
+              props.activation.phase === "testing" &&
+              props.activation.targetId === activationTargetId(candidate.kind, candidate.modelRef);
+            const failure =
+              props.activation.phase === "failure" &&
+              props.activation.targetId === activationTargetId(candidate.kind, candidate.modelRef)
+                ? props.activation
+                : null;
+            return html`
+              <div class="model-setup__row" data-candidate-kind=${candidate.kind}>
+                <div class="model-setup__row-main">
+                  <div class="model-setup__row-title">
+                    ${renderProviderIcon(props, candidate)}
+                    <strong>${candidate.label}</strong>
+                    <span class="model-setup__chip">${candidateStatus(candidate)}</span>
+                  </div>
+                  <div class="muted">
+                    ${candidate.modelRef} · ${formatUiExternalText(candidate.detail)}
+                  </div>
                 </div>
-                <div class="muted">
-                  ${candidate.modelRef} · ${formatUiExternalText(candidate.detail)}
+                <div class="model-setup__row-actions">
+                  <button
+                    type="button"
+                    class=${`btn ${failure ? "" : "primary"}`}
+                    ?disabled=${props.actionsDisabled}
+                    @click=${() => props.onActivateCandidate(candidate)}
+                  >
+                    <span>
+                      ${
+                        testing
+                          ? t("modelSetup.candidates.testingButton")
+                          : failure
+                            ? t("modelSetup.candidates.retry")
+                            : t("modelSetup.candidates.testAndUse")
+                      }
+                    </span>
+                  </button>
                 </div>
               </div>
-              <div class="model-setup__row-actions">
-                <button
-                  type="button"
-                  class=${`btn ${failure ? "" : "primary"}`}
-                  ?disabled=${props.actionsDisabled}
-                  @click=${() => props.onActivateCandidate(candidate)}
-                >
-                  <span>
-                    ${
-                      testing
-                        ? t("modelSetup.candidates.testingButton")
-                        : failure
-                          ? t("modelSetup.candidates.retry")
-                          : t("modelSetup.candidates.testAndUse")
-                    }
-                  </span>
-                </button>
-              </div>
-            </div>
-          `;
-        })}
+            `;
+          })}
       </div>
     </section>
   `;
@@ -272,7 +277,11 @@ function renderAuthRow(props: ModelSetupViewProps, option: AuthOption) {
         ${
           option.kind === "device-code"
             ? t("modelSetup.signIn.pair")
-            : t("modelSetup.signIn.signIn")
+            : option.kind === "install"
+              ? t("modelSetup.signIn.install")
+              : option.kind === "custom"
+                ? t("modelSetup.signIn.custom")
+                : t("modelSetup.signIn.signIn")
         }
       </button>
     </div>
@@ -280,14 +289,14 @@ function renderAuthRow(props: ModelSetupViewProps, option: AuthOption) {
 }
 
 function renderSignIn(props: ModelSetupViewProps, result: SystemAgentSetupDetectResult) {
-  const options = (result.authOptions ?? []).toSorted(
-    (left, right) => Number(right.featured) - Number(left.featured),
-  );
+  const options = (result.authOptions ?? []).toSorted((a, b) => a.label.localeCompare(b.label));
   if (options.length === 0) {
     return nothing;
   }
-  const featured = options.filter((option) => option.featured);
-  const more = options.filter((option) => !option.featured);
+  const featured = options.filter(
+    (option) => option.featured || option.kind === "install" || option.kind === "custom",
+  );
+  const more = options.filter((option) => !featured.includes(option));
   return html`
     <section class="settings-section">
       <div class="settings-section__header">
@@ -432,6 +441,39 @@ function renderActivationFeedback(activation: ModelSetupActivationState) {
     : nothing;
 }
 
+function renderNativeSessionDiscovery(
+  props: ModelSetupViewProps,
+  result: SystemAgentSetupDetectResult,
+) {
+  if (
+    result.nativeSessionCatalogPreferenceRequired !== true ||
+    !result.nativeSessionCatalogs?.length
+  ) {
+    return nothing;
+  }
+  return html`
+    <section class="settings-section model-setup__native-discovery">
+      <div class="settings-section__header"><h2>${t("modelSetup.nativeDiscovery.title")}</h2></div>
+      <p class="muted">${t("modelSetup.nativeDiscovery.body")}</p>
+      <p>${result.nativeSessionCatalogs.map((option) => option.label).join(", ")}</p>
+      <label>
+        <input
+          type="checkbox"
+          .checked=${props.nativeSessionCatalogsEnabled === true}
+          ?disabled=${props.actionsDisabled}
+          @change=${(event: Event) => {
+            // SAFETY: This listener is attached directly to the checkbox input above.
+            const input = event.currentTarget as HTMLInputElement;
+            props.onNativeSessionCatalogsChange?.(input.checked);
+          }}
+        />
+        ${t("modelSetup.nativeDiscovery.enable")}
+      </label>
+      <p class="muted">${t("modelSetup.nativeDiscovery.decline")}</p>
+    </section>
+  `;
+}
+
 function renderReady(props: ModelSetupViewProps, result: SystemAgentSetupDetectResult) {
   const onContinue =
     props.firstRun && result.setupComplete && props.activation.phase !== "success"
@@ -456,9 +498,9 @@ function renderReady(props: ModelSetupViewProps, result: SystemAgentSetupDetectR
       <div class="callout warning" role="note">${t("modelSetup.access.gatewayTooOld")}</div>`;
   }
   return html`
-    ${current} ${renderEmptyState(props, result)} ${renderCandidateRows(props, result)}
-    ${renderUnavailable(props, result)} ${renderPrepare(props, result)}
-    ${renderSignIn(props, result)} ${renderManual(props, result)}
+    ${current} ${renderNativeSessionDiscovery(props, result)} ${renderEmptyState(props, result)}
+    ${renderCandidateRows(props, result)} ${renderUnavailable(props, result)}
+    ${renderPrepare(props, result)} ${renderSignIn(props, result)} ${renderManual(props, result)}
   `;
 }
 
@@ -618,6 +660,7 @@ export function renderModelSetup(props: ModelSetupViewProps): TemplateResult {
       mode: props.wizardMode,
       state: props.wizard,
       refreshWarning: props.refreshWarning,
+      cancellationNotice: props.cancellationNotice,
       value: props.wizardValue,
       onValueChange: props.onWizardValueChange,
       onAnswer: props.onWizardAnswer,

--- a/ui/src/pages/model-setup/wizard-runner.test.ts
+++ b/ui/src/pages/model-setup/wizard-runner.test.ts
@@ -1,9 +1,214 @@
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
+import type { WizardNextResult } from "../../api/types.ts";
 import { ModelSetupWizardRunner } from "./wizard-runner.ts";
 
 describe("ModelSetupWizardRunner", () => {
+  it.each(["cancelled", "failed"] as const)(
+    "shares an in-flight explicit cancellation with teardown when it is %s",
+    async (outcome) => {
+      const pending = createDeferred<unknown>();
+      const request = vi.fn(async (method: string) => {
+        if (method === "openclaw.setup.auth.start") {
+          return { done: false, status: "running" };
+        }
+        if (method === "wizard.cancel") {
+          return await pending.promise;
+        }
+        return { done: false, status: "running", step: { id: "key", type: "text" } };
+      });
+      const terminal = vi.fn();
+      const runner = new ModelSetupWizardRunner({
+        getClient: () => ({ request }) as unknown as GatewayBrowserClient,
+        getAgentId: () => "main",
+        onChange: () => undefined,
+        onStart: () => terminal,
+        requestFailedMessage: () => "failed",
+        cancelledMessage: () => "cancelled",
+        sessionExpiredMessage: () => "expired",
+      });
+      await runner.start("provider-auth");
+      const explicit = runner.requestCancellation();
+      const teardown = runner.cancel();
+      const callsBeforeAcknowledgment = request.mock.calls.filter(
+        ([method]) => method === "wizard.cancel",
+      );
+      if (outcome === "failed") {
+        pending.reject(new Error("Cancellation transport disconnected"));
+      } else {
+        pending.resolve({ status: "cancelled" });
+      }
+      await expect(Promise.all([explicit, teardown])).resolves.toEqual([undefined, undefined]);
+      expect(callsBeforeAcknowledgment).toHaveLength(1);
+      expect(runner.state).toEqual({ phase: "idle" });
+      expect(terminal).toHaveBeenCalledTimes(outcome === "cancelled" ? 1 : 0);
+    },
+  );
+
+  it("cancels independently after transport rebind and retries settled cancellation attempts", async () => {
+    const oldCancellation = createDeferred<unknown>();
+    const originalRequest = vi.fn(async (method: string) => {
+      if (method === "openclaw.setup.auth.start") {
+        return { done: false, status: "running" };
+      }
+      if (method === "wizard.cancel") {
+        return await oldCancellation.promise;
+      }
+      return { done: false, status: "running", step: { id: "key", type: "text" } };
+    });
+    let cancellations = 0;
+    const replacementRequest = vi.fn(async (method: string) => {
+      if (method === "wizard.next") {
+        return { done: false, status: "running", step: { id: "key", type: "text" } };
+      }
+      if (method === "wizard.cancel") {
+        cancellations += 1;
+        if (cancellations === 1) {
+          return { status: "running" };
+        }
+        if (cancellations === 2) {
+          throw new Error("Cancellation transport disconnected");
+        }
+        return { status: "cancelled" };
+      }
+      throw new Error(`Unexpected wizard request: ${method}`);
+    });
+    let client = { request: originalRequest } as unknown as GatewayBrowserClient;
+    const terminal = vi.fn();
+    const runner = new ModelSetupWizardRunner({
+      getClient: () => client,
+      getAgentId: () => "main",
+      onChange: () => undefined,
+      onStart: () => terminal,
+      requestFailedMessage: () => "failed",
+      cancelledMessage: () => "cancelled",
+      sessionExpiredMessage: () => "expired",
+    });
+    await runner.start("provider-auth");
+    const pending = runner.requestCancellation();
+    runner.suspend();
+    client = { request: replacementRequest } as unknown as GatewayBrowserClient;
+    await runner.resume();
+    await expect(runner.requestCancellation()).resolves.toBe("running");
+    await expect(runner.requestCancellation()).rejects.toThrow(
+      "Cancellation transport disconnected",
+    );
+    expect(runner.state).toMatchObject({ phase: "step", authChoice: "provider-auth" });
+    await expect(runner.requestCancellation()).resolves.toBe("cancelled");
+    expect(cancellations).toBe(3);
+    expect(terminal).toHaveBeenCalledExactlyOnceWith({ done: true, status: "cancelled" });
+    oldCancellation.resolve({ status: "cancelled" });
+    await expect(pending).resolves.toBeUndefined();
+    expect(terminal).toHaveBeenCalledOnce();
+    expect(runner.state).toEqual({ phase: "idle" });
+    expect(
+      originalRequest.mock.calls.filter(([method]) => method === "wizard.cancel"),
+    ).toHaveLength(1);
+    expect(replacementRequest.mock.calls.map(([method]) => method)).toEqual([
+      "wizard.next",
+      "wizard.cancel",
+      "wizard.cancel",
+      "wizard.cancel",
+    ]);
+  });
+
+  it("ignores a retired owner's cancellation failure and keeps teardown best effort", async () => {
+    const failedCancel = createDeferred<unknown>();
+    let cancellations = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "openclaw.setup.auth.start") {
+        return { done: false, status: "running" };
+      }
+      if (method === "wizard.cancel") {
+        if (++cancellations === 1) {
+          return await failedCancel.promise;
+        }
+        throw new Error("Cleanup transport failed");
+      }
+      return { done: false, status: "running", step: { id: "key", type: "text" } };
+    });
+    const terminal = vi.fn();
+    const runner = new ModelSetupWizardRunner({
+      getClient: () => ({ request }) as unknown as GatewayBrowserClient,
+      getAgentId: () => "main",
+      onChange: () => undefined,
+      onStart: () => terminal,
+      requestFailedMessage: () => "failed",
+      cancelledMessage: () => "cancelled",
+      sessionExpiredMessage: () => "expired",
+    });
+    await runner.start("original");
+    const cancellation = runner.requestCancellation();
+    runner.close({ retireOwner: true });
+    await runner.start("replacement");
+    failedCancel.reject(new Error("Original transport failed"));
+    await expect(cancellation).resolves.toBeUndefined();
+    expect(runner.state).toMatchObject({ phase: "step", authChoice: "replacement" });
+    expect(terminal).not.toHaveBeenCalled();
+    await expect(runner.cancel()).resolves.toBeUndefined();
+    expect(runner.state).toEqual({ phase: "idle" });
+    expect(cancellations).toBe(2);
+  });
+
+  it.each(["late admission", "late terminal", "late cancellation"] as const)(
+    "retires detached %s authority before a client can represent another owner",
+    async (caseName) => {
+      const lateReply = createDeferred<WizardNextResult>();
+      const request = vi.fn(async (method: string) => {
+        if (method === "openclaw.setup.auth.start") {
+          return caseName === "late admission"
+            ? await lateReply.promise
+            : { done: false, status: "running" };
+        }
+        if (method === "wizard.next") {
+          return caseName === "late terminal"
+            ? await lateReply.promise
+            : { done: false, status: "running", step: { id: "key", type: "text" } };
+        }
+        if (method === "wizard.cancel") {
+          return await lateReply.promise;
+        }
+        throw new Error(`Unexpected wizard request: ${method}`);
+      });
+      const client = { request } as unknown as GatewayBrowserClient;
+      const onTerminal = vi.fn();
+      const runner = new ModelSetupWizardRunner({
+        getClient: () => client,
+        getAgentId: () => "main",
+        onChange: () => undefined,
+        onStart: () => onTerminal,
+        requestFailedMessage: () => "failed",
+        cancelledMessage: () => "cancelled",
+        sessionExpiredMessage: () => "expired",
+      });
+      let pending: Promise<unknown> = runner.start("original-provider");
+      if (caseName === "late terminal") {
+        await vi.waitFor(() =>
+          expect(request.mock.calls.some(([method]) => method === "wizard.next")).toBe(true),
+        );
+      }
+      if (caseName === "late cancellation") {
+        await pending;
+        pending = runner.cancel();
+        await vi.waitFor(() =>
+          expect(request.mock.calls.some(([method]) => method === "wizard.cancel")).toBe(true),
+        );
+      }
+      runner.close({ retireOwner: true });
+      const requestsAtRetirement = request.mock.calls.length;
+      lateReply.resolve(
+        caseName === "late admission"
+          ? { done: false, status: "running" }
+          : { done: true, status: "cancelled" },
+      );
+      await pending;
+      expect(request).toHaveBeenCalledTimes(requestsAtRetirement);
+      expect(onTerminal).not.toHaveBeenCalled();
+      expect(runner.state).toEqual({ phase: "idle" });
+    },
+  );
+
   it.each(["cancelled", "error", "done"])(
     "binds cancellation to the original client and fences late %s after repeated resets",
     async (terminal) => {
@@ -79,6 +284,102 @@ describe("ModelSetupWizardRunner", () => {
       });
     },
   );
+
+  it("reconciles an interrupted answer without replaying it or cancelling the resumed wizard", async () => {
+    const interrupted = createDeferred<unknown>();
+    let nextCalls = 0;
+    const originalRequest = vi.fn(async (method: string) => {
+      if (method === "openclaw.setup.auth.start") {
+        return { done: false, status: "running" };
+      }
+      nextCalls += 1;
+      if (nextCalls === 1) {
+        return { done: false, status: "running", step: { id: "key", type: "text" } };
+      }
+      return interrupted.promise;
+    });
+    const replacementRequest = vi.fn(
+      async (_method: string, _params?: unknown, _options?: unknown) => ({
+        done: false,
+        status: "running",
+        step: { id: "model-review", type: "note" },
+      }),
+    );
+    let client = { request: originalRequest } as unknown as GatewayBrowserClient;
+    const terminal = vi.fn();
+    const runner = new ModelSetupWizardRunner({
+      getClient: () => client,
+      getAgentId: () => "research",
+      onChange: () => undefined,
+      onStart: () => terminal,
+      requestFailedMessage: () => "failed",
+      cancelledMessage: () => "cancelled",
+      sessionExpiredMessage: () => "expired",
+    });
+    await runner.start("meta-api-key");
+    const answer = runner.answer("synthetic-key");
+    runner.suspend();
+    client = { request: replacementRequest } as unknown as GatewayBrowserClient;
+    await runner.resume();
+    expect(replacementRequest).toHaveBeenCalledExactlyOnceWith(
+      "wizard.next",
+      { sessionId: expect.any(String) },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    interrupted.resolve({ done: true, status: "cancelled" });
+    await answer;
+    expect(terminal).not.toHaveBeenCalled();
+    expect(runner.state).toMatchObject({
+      phase: "step",
+      authChoice: "meta-api-key",
+      step: { id: "model-review" },
+    });
+    expect(
+      originalRequest.mock.calls.filter(([method]) => method === "wizard.cancel"),
+    ).toHaveLength(0);
+  });
+
+  it("uses a terminal reply received while disconnected without repeating a Gateway request", async () => {
+    const terminalReply = createDeferred<unknown>();
+    let nextCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "openclaw.setup.auth.start") {
+        return { done: false, status: "running" };
+      }
+      if (++nextCalls === 1) {
+        return { done: false, status: "running", step: { id: "key", type: "text" } };
+      }
+      return terminalReply.promise;
+    });
+    const afterReconnect = vi.fn();
+    let client = { request } as unknown as GatewayBrowserClient;
+    const onTerminal = vi.fn();
+    const runner = new ModelSetupWizardRunner({
+      getClient: () => client,
+      getAgentId: () => "research",
+      onChange: () => undefined,
+      onStart: () => onTerminal,
+      requestFailedMessage: () => "failed",
+      cancelledMessage: () => "cancelled",
+      sessionExpiredMessage: () => "expired",
+    });
+    await runner.start("meta-api-key");
+    const answer = runner.answer("synthetic-key");
+    runner.suspend();
+    terminalReply.resolve({
+      done: true,
+      status: "done",
+      modelActivation: { modelRef: "meta/fixture-model" },
+    });
+    await answer;
+    expect(onTerminal).not.toHaveBeenCalled();
+    client = { request: afterReconnect } as unknown as GatewayBrowserClient;
+    expect(await runner.resume()).toMatchObject({
+      modelActivation: { modelRef: "meta/fixture-model" },
+    });
+    expect(afterReconnect).not.toHaveBeenCalled();
+    expect(onTerminal).toHaveBeenCalledOnce();
+  });
 
   it("starts, advances an unbounded note step, and guards duplicate answers", async () => {
     let resolveDone: ((value: unknown) => void) | null = null;

--- a/ui/src/pages/model-setup/wizard-runner.ts
+++ b/ui/src/pages/model-setup/wizard-runner.ts
@@ -48,6 +48,13 @@ type WizardRunnerOptions = {
 type WizardSession = {
   client: GatewayBrowserClient;
   sessionId: string;
+  authChoice: string;
+  admitted?: boolean;
+  suspended?: boolean;
+  retired?: boolean;
+  retirementGeneration: number;
+  terminalResult?: WizardNextResult;
+  cancellationPromise?: Promise<WizardStatusResult>;
   abortController: AbortController;
   startMethod: ModelSetupWizardStartMethod;
   activationTargetId?: string;
@@ -58,11 +65,59 @@ type WizardSession = {
 export class ModelSetupWizardRunner {
   private currentState: ModelSetupWizardState = { phase: "idle" };
   private session: WizardSession | null = null;
+  private retirementGeneration = 0;
 
   constructor(private readonly options: WizardRunnerOptions) {}
 
   get state(): ModelSetupWizardState {
     return this.currentState;
+  }
+
+  get hasAdmittedSession(): boolean {
+    return this.session?.admitted === true;
+  }
+
+  suspend(): void {
+    const session = this.session;
+    if (!session) {
+      return;
+    }
+    session.suspended = true;
+    session.abortController.abort();
+    this.setState({ phase: "starting", authChoice: session.authChoice });
+  }
+
+  async resume(): Promise<ModelSetupWizardCompletion | null> {
+    const previous = this.session;
+    const client = this.options.getClient();
+    if (!previous?.admitted || !client) {
+      return null;
+    }
+    // Retire the old request handle, not its Gateway-owned wizard. A reply or
+    // timeout from the old transport must not cancel the resumed operation.
+    previous.retired = true;
+    previous.abortController.abort();
+    const session: WizardSession = {
+      ...previous,
+      client,
+      abortController: new AbortController(),
+      cancellationPromise: undefined,
+      suspended: false,
+      retired: false,
+    };
+    this.session = session;
+    this.setState({ phase: "starting", authChoice: session.authChoice });
+    try {
+      if (session.terminalResult) {
+        return this.applyResult(session, session.authChoice, session.terminalResult);
+      }
+      // Never repeat start or the last answer: either may have committed before
+      // the socket closed. The existing wizard owns the next visible step.
+      return await this.requestNext(session, session.authChoice);
+    } catch (error) {
+      this.handleError(error, session);
+      return null;
+    }
   }
 
   async start(
@@ -71,8 +126,9 @@ export class ModelSetupWizardRunner {
       ModelSetupWizardStartMethod,
       "openclaw.setup.activate.start"
     > = "openclaw.setup.auth.start",
+    preferences: Pick<SystemAgentSetupActivateParams, "nativeSessionCatalogsEnabled"> = {},
   ): Promise<ModelSetupWizardCompletion | null> {
-    return this.startSession(authChoice, startMethod, { authChoice });
+    return this.startSession(authChoice, startMethod, { authChoice, ...preferences });
   }
 
   activate(
@@ -100,6 +156,8 @@ export class ModelSetupWizardRunner {
     const session: WizardSession = {
       client,
       sessionId: generateUUID(),
+      retirementGeneration: this.retirementGeneration,
+      authChoice,
       abortController: new AbortController(),
       startMethod,
       activationTargetId,
@@ -134,6 +192,9 @@ export class ModelSetupWizardRunner {
           };
         });
       const started = await this.awaitWizardStart(session, request);
+      if (!started.done) {
+        session.admitted = true;
+      }
       if (session !== this.session && !started.done) {
         // Admission can finish after cancellation; release only its original session.
         await this.cancelSession(session);
@@ -177,7 +238,46 @@ export class ModelSetupWizardRunner {
     }
   }
 
-  close(): void {
+  async requestCancellation(): Promise<"cancelled" | "running" | undefined> {
+    const session = this.session;
+    if (!session) {
+      this.close();
+      return "cancelled";
+    }
+    let result: WizardStatusResult | undefined;
+    try {
+      result = await this.sendCancellation(session);
+    } catch (error) {
+      if (session !== this.session || this.isRetired(session) || session.suspended) {
+        return undefined;
+      }
+      if (isWizardNotFoundError(error)) {
+        this.handleError(error, session);
+        return undefined;
+      }
+      throw error;
+    }
+    if (session !== this.session || this.isRetired(session) || session.suspended) {
+      return undefined;
+    }
+    if (result?.status === "cancelled" || result?.status === "error") {
+      this.close();
+      return "cancelled";
+    }
+    // Protected preparation may decline cancellation. Keep the admitted wizard
+    // and its outstanding next request so the same auth flow can reach a checkpoint.
+    if (result?.status === "running") {
+      return "running";
+    }
+    return undefined;
+  }
+
+  close(options: { retireOwner?: boolean } = {}): void {
+    // Only owner loss retires detached cleanup. Ordinary close still lets a
+    // late same-owner admission be cancelled and its exact receipt be cleared.
+    if (options.retireOwner) {
+      this.retirementGeneration += 1;
+    }
     this.session?.abortController.abort();
     this.session = null;
     this.setState({ phase: "idle" });
@@ -229,6 +329,9 @@ export class ModelSetupWizardRunner {
     authChoice: string,
     answer?: { stepId: string; value?: unknown },
   ): Promise<ModelSetupWizardCompletion | null> {
+    if (session.suspended || this.isRetired(session)) {
+      return null;
+    }
     const { client, sessionId, abortController } = session;
     const signal = abortController.signal;
     let nextAnswer = answer;
@@ -257,8 +360,12 @@ export class ModelSetupWizardRunner {
     authChoice: string,
     result: WizardNextResult,
   ): ModelSetupWizardCompletion | null {
+    if (session === this.session && session.suspended && result.done) {
+      session.terminalResult = result;
+      return null;
+    }
     const isCurrent = this.reportTerminalResult(session, result);
-    if (session !== this.session) {
+    if (session !== this.session || session.suspended) {
       return null;
     }
     if (isCurrent?.() === false) {
@@ -289,7 +396,7 @@ export class ModelSetupWizardRunner {
   }
 
   private handleError(error: unknown, session: WizardSession): void {
-    if (session !== this.session) {
+    if (session !== this.session || session.suspended) {
       return;
     }
     this.session = null;
@@ -304,19 +411,38 @@ export class ModelSetupWizardRunner {
     this.setState({ phase: "error", message });
   }
 
-  private async cancelSession(session: WizardSession): Promise<void> {
+  private async cancelSession(session: WizardSession): Promise<WizardStatusResult | undefined> {
     try {
-      const result = await session.client.request<WizardStatusResult>(
-        "wizard.cancel",
-        { sessionId: session.sessionId },
-        { timeoutMs: MODEL_SETUP_AUTH_START_TIMEOUT_MS },
-      );
-      if (result.status === "cancelled" || result.status === "error") {
-        this.reportTerminalResult(session, { done: true, ...result });
-      }
+      return await this.sendCancellation(session);
     } catch {
-      // The Gateway may already have completed or purged the session.
+      // Detached cleanup is best effort; explicit cancellation surfaces failures.
+      return undefined;
     }
+  }
+
+  private async sendCancellation(session: WizardSession): Promise<WizardStatusResult | undefined> {
+    if (this.isRetired(session)) {
+      return undefined;
+    }
+    if (!session.cancellationPromise) {
+      // Explicit cancellation and detached cleanup share only the pending request.
+      session.cancellationPromise = session.client
+        .request<WizardStatusResult>(
+          "wizard.cancel",
+          { sessionId: session.sessionId },
+          { timeoutMs: MODEL_SETUP_AUTH_START_TIMEOUT_MS },
+        )
+        .then((result) => {
+          if (result.status === "cancelled" || result.status === "error") {
+            this.reportTerminalResult(session, { done: true, ...result });
+          }
+          return result;
+        })
+        .finally(() => {
+          session.cancellationPromise = undefined;
+        });
+    }
+    return session.cancellationPromise;
   }
 
   private reportTerminalResult(
@@ -325,12 +451,19 @@ export class ModelSetupWizardRunner {
   ): (() => boolean) | void {
     // Confirmed failure/cancellation owns exact receipt cleanup after presentation retires.
     // Success and visible state still require this runner's live session.
+    if (this.isRetired(session) || session.suspended) {
+      return;
+    }
     const failed = result.status === "cancelled" || result.status === "error";
     if (result.done && (session === this.session || failed)) {
       return session.admissionRejected
         ? session.onTerminalResult?.(result, true)
         : session.onTerminalResult?.(result);
     }
+  }
+
+  private isRetired(session: WizardSession): boolean {
+    return session.retired === true || session.retirementGeneration !== this.retirementGeneration;
   }
 
   private setState(state: ModelSetupWizardState): void {

--- a/ui/src/pages/model-setup/wizard-view.ts
+++ b/ui/src/pages/model-setup/wizard-view.ts
@@ -10,6 +10,7 @@ type WizardViewProps = {
   mode: "auth" | "prepare" | "activate";
   state: ModelSetupWizardState;
   refreshWarning: string | null;
+  cancellationNotice?: string | null;
   value: unknown;
   onValueChange: (value: unknown) => void;
   onAnswer: (value: unknown, includeValue?: boolean) => void;
@@ -53,11 +54,9 @@ export function renderModelSetupWizard(props: WizardViewProps): TemplateResult |
           </h2>
         </div>
         <div class="model-setup-wizard__body">
-          ${
-            props.refreshWarning
-              ? html`<div class="callout warning" role="alert">${props.refreshWarning}</div>`
-              : nothing
-          }
+          ${[props.refreshWarning, props.cancellationNotice].map((warning) =>
+            warning ? html`<div class="callout warning" role="alert">${warning}</div>` : nothing,
+          )}
           ${
             props.state.phase === "starting"
               ? html`<div role="status">


### PR DESCRIPTION
Related: #139675

## What Problem This Solves

Fixes an issue where opening first-run setup in the desktop companion or Control UI would start the first detected provider before the user selected it. Fresh installations also lacked clear install/custom-endpoint actions and native-conversation consent in the shared Web UI. This completes the companion half of the onboarding repair prompted by community reports of missing provider choices.

## Why This Change Was Made

Model Setup now consumes the shared setup contract landed in #139675: read-only detection, explicit typed provider actions, and an unchecked native discovery choice when the server requires it. Tauri opens this actual shared page; both saved `firstRun=1` links and new `firstRun=explicit` links preserve the intended flow.

The old automatic-selection owner was `ui/src/pages/model-setup/first-run-setup.ts`. The provider view did not distinguish install/custom actions or render server consent metadata. Recovery also discarded admitted wizards on disconnect and treated cancellation as complete before the Gateway acknowledged it. The repair keeps the admitted wizard bound to the authenticated hello scope, agent, connection revision and setup visit. Reconnect reads its next step without repeating authentication or its last answer; uncertain cancellation retains its receipt and visible recovery action.

A URL-only change would leave automatic work in the shared page. Replaying authentication after a disconnect could repeat an already committed operation. Clearing the receipt when Cancel is clicked would mistake a request for acknowledgment. Those approaches are deliberately avoided; no new receipt fields, storage semantics, recovery deadlines, provider list or installer were introduced.

## User Impact

- Opening setup only detects available access. Selecting, testing, installing or saving requires a click, and failure/cancellation never picks another provider.
- Official installable providers, including Meta, expose **Review & install** and continue into their own capability review/authentication flow. Custom endpoints expose **Set up endpoint**, with the existing local-Gateway check and precise host-side remote handoff.
- Fresh installations show native conversation discovery unchecked and send the explicit choice to the server. Configured upgrades keep their existing preferences.
- Connection loss can resume the same admitted wizard. Account or authority changes retire old UI requests. Missing sessions and unconfirmed cancellation remain visible and recoverable; late cancellation cannot clear another tab's newer request.

## Evidence

Final head: `6f6f9b67ddec03494baa145e13ee9e26800c1173`, based on landed prerequisite `64bf824613261007a3f452974d63f83d6db7f512`.

- Focused Model Setup proof: **322 passed** (315 UI cases plus seven actual Gateway-handler/UI compositions). Command: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs ui/src/pages/model-setup src/gateway/server-methods/system-agent-setup-control-ui.test.ts`.
- Real-browser Model Setup suites: **37 passed** across eight files. The initial-connect splash and explicit Custodian-to-Channels handoff also passed. Command: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner <focused file or model-setup filter>`.
- Test-lane ownership: **24 passed** in `test/vitest-projects-config.test.ts`, retaining exact membership and exclusion assertions. Scope replacement, protected cancellation, missing-session recovery and cancellation coalescing regressions failed at their intended boundaries before repair.
- `pnpm check:changed`: **passed** for the full candidate and each subsequent test-only correction, including all applicable type, export, lint and policy guards. Testbox runs: [full candidate](https://github.com/openclaw/openclaw/actions/runs/34048448509), [runner and formatting corrections](https://github.com/openclaw/openclaw/actions/runs/34050297129), [inventory](https://github.com/openclaw/openclaw/actions/runs/34051893033), [explicit handoff](https://github.com/openclaw/openclaw/actions/runs/34052908180). Each wrapper exited 0 and its lease completed; the backing workflow may show cancellation after the successful one-shot lease closes.
- `pnpm protocol:check`, `pnpm ui:i18n:verify`, focused UI test type graphs, and `git diff --check`: **passed**. Fresh independent autoreview before every commit: **clean at P0/P1**, no accepted/actionable findings. Native review artifacts validate for the final head.
- **Packaged real-Gateway/browser proof passed all nine checks and six phases** on `9c4826e0bbd4b3d55b7b2043e449e92999002962` ([run](https://github.com/openclaw/openclaw/actions/runs/34052244235)). A fresh candidate built with the normal public-package pipeline starts without Meta; the actual selected-agent Web UI displays unchecked consent and sends only setup detection before the click. It then performs managed capability approval, installation, authentication, model testing, exact route/profile persistence and onboarding handoff. Both first-run link forms survive restart/relaunch without replaying setup or inference. Installing Codex later preserves both catalog opt-outs and the selected route. Gateway HTTP/WebSocket traffic is real; provider HTTP is synthetic. The final head differs only in the Custodian E2E fixture, verified by an otherwise-empty Git diff. No live Meta account or native Tauri window launch is claimed.
- Rust tools are unavailable locally and were not installed. **Final exact-head CI is green** ([CI](https://github.com/openclaw/openclaw/actions/runs/34053207228), [Linux/macOS companion](https://github.com/openclaw/openclaw/actions/runs/34053207213)). Current-head ClawSweeper review is ready with no remaining items.

CI found stale fixture assumptions, a UI-only runner receiving a Node-backed composition test, and Rust formatting differences. These are corrected with assertions intact. An unrelated release-navigation failure from main was repaired by its existing owner in #140337; its merge ancestry is verified. Two package-harness gaps—a passive brand icon fixture and the configured-page button name—were corrected without relaxing egress, authentication, persistence or no-replay assertions.

Actual source UI in isolated Chromium, with the same synthetic Gateway fixture and viewport on both revisions. Before: opening the page already started provider activation. After: detection stops at the unchecked discovery choice and provider buttons; Meta/custom actions are visible. The after flow explicitly clicked one provider, cancelled it, and observed no fallback. Captures were inspected for secrets, private data and unrelated desktop content before upload. The after flow was recaptured on the final head; its report records detection only before the click and no fallback after cancellation. Published image downloads were independently verified against the inspected SHA-256 hashes.

| Before startup | After startup |
| --- | --- |
| ![Provider activation started on load](https://github.com/user-attachments/assets/2bc6ecf8-37d0-413a-9c62-6c71b627acac) | ![Detection only with unchecked discovery consent](https://github.com/user-attachments/assets/9a53b4bf-757f-4f48-b87b-a1fa0942487e) |

<details>
<summary>Provider action comparison</summary>

| Before | After |
| --- | --- |
| ![Generic sign-in actions hidden under more options](https://github.com/user-attachments/assets/403eb73f-9f5b-4a98-b4fa-1a12f2900491) | ![Visible custom endpoint and managed install actions](https://github.com/user-attachments/assets/953227f4-c90f-4b0c-b032-347ee2d0bd64) |

</details>

<details>
<summary>Actual packaged Gateway: capability review and authentication form</summary>

The credential field was empty and masked before entry. Captures contain only the isolated fixture's data.

| Capability review | Provider authentication form |
| --- | --- |
| ![Meta package capabilities before approval](https://github.com/user-attachments/assets/752cbc4a-4e02-4a85-a128-95009124d9fb) | ![Meta credential form before entering the synthetic key](https://github.com/user-attachments/assets/1f8d1147-c2e2-4d29-8451-b472f25760e4) |

</details>

Production/test delta against the landed base: **+301 production** (+481/-180; shared UI +292, native Rust +9), **+2,094 tests/fixtures** (+2,362/-268, including colocated Rust tests), and **+21 docs** (+30/-9). Total: 33 files, +2,873/-457. Feature growth is explicitly authorized. Consent presentation and lifecycle recovery are partly funded by removing automatic candidate activation, its host callback, the obsolete fallback tail, duplicate verification reset, the one-call provider-reset wrapper, and implicit credential selection. No baseline, snapshot, assertion or dependency-policy weakening.

Credits: builds on RoboClaw's recovered desktop/shared-UI draft and Peter Steinberger's requested behavior. The recovered commit retains RoboClaw's original author and Peter's human contribution trailers.
