### PR TITLE
fix(test): accept release subpages in docs route shape

### DIFF
--- a/test/scripts/docs-sync-publish.test.ts
+++ b/test/scripts/docs-sync-publish.test.ts
@@ -367,15 +367,18 @@ fs.writeFileSync('package-lock.json', JSON.stringify(lock));
       "Release process",
       "Testing and CI",
     ]);
-    // Every release adds a releases/<version> page, so read the published versions from the
+    // Releases may have a version page or subpages, so read the published routes from the
     // navigation rather than pinning them here; only the index-first ordering and the version
     // route shape are invariant. Pinning the list makes this assertion fail on release PRs whose
     // change classification never selects this lane, so the break first lands on main.
     expect(releaseNotes[0]).toBe("releases/index");
     expect(releaseNotes.length).toBeGreaterThan(1);
+    const releaseRoutePattern = /^releases\/\d{4}\.\d{1,2}\.\d+(?:\/[a-z0-9]+(?:-[a-z0-9]+)*)?$/;
     for (const page of releaseNotes.slice(1)) {
-      expect(page).toMatch(/^releases\/\d{4}\.\d{1,2}\.\d+$/);
+      expect(page).toMatch(releaseRoutePattern);
     }
+    expect("releases/not-a-version").not.toMatch(releaseRoutePattern);
+    expect("releases/2026.8.1/memory/nested").not.toMatch(releaseRoutePattern);
     const releaseRoutes = [
       ...releaseNotes,
       "maturity/scorecard",


### PR DESCRIPTION
Related: #140319, #140331

## What Problem This Solves

Fixes the docs navigation test failure after #140319 split the v2026.8.1 release page into subpages. The existing guard accepts only a bare version route and rejects valid routes such as `releases/2026.8.1/installation-and-onboarding`, making unrelated main-based CI fail.

## Why This Change Was Made

Accept either a version route or that route plus one lowercase alphanumeric/hyphenated slug. Preserve the unpinned release list, index-first ordering, minimum length, locale alignment, and duplicate-route checks. Explicitly reject an invalid version and a second subpage level with the same pattern used for actual navigation.

## User Impact

Restores the intended release-navigation check without changing published docs or runtime behavior. This is a maintainer-assigned CI repair. Production/tooling/docs delta is zero; test delta is +3 (+5/−2).

## Evidence

- Before the repair, `node scripts/run-vitest.mjs test/scripts/docs-sync-publish.test.ts` reproduced the real navigation failure: 1 failed, 9 passed.
- After the repair, the same command passed all 10 tests.
- Bogus `releases/not-a-version` and deeper `releases/2026.8.1/memory/nested` routes remain rejected.
- `pnpm check:changed`: passed the complete selected gate.
- Independent Codex P0–P2 autoreview: scoped-clean, no accepted/actionable findings.
- No production, snapshot, inventory, suppression, dependency, or lockfile changes. No build required for this test-only fix.
