### PR TITLE
refactor(doctor): remove dormant sandbox image rewrites

### DIFF
--- a/src/commands/doctor-sandbox.ts
+++ b/src/commands/doctor-sandbox.ts
@@ -225,50 +225,11 @@ function resolveSandboxBrowserImage(cfg: OpenClawConfig): string {
   return image ? image : DEFAULT_SANDBOX_BROWSER_IMAGE;
 }
 
-function updateSandboxDockerImage(cfg: OpenClawConfig, image: string): OpenClawConfig {
-  return {
-    ...cfg,
-    agents: {
-      ...cfg.agents,
-      defaults: {
-        ...cfg.agents?.defaults,
-        sandbox: {
-          ...cfg.agents?.defaults?.sandbox,
-          docker: {
-            ...cfg.agents?.defaults?.sandbox?.docker,
-            image,
-          },
-        },
-      },
-    },
-  };
-}
-
-function updateSandboxBrowserImage(cfg: OpenClawConfig, image: string): OpenClawConfig {
-  return {
-    ...cfg,
-    agents: {
-      ...cfg.agents,
-      defaults: {
-        ...cfg.agents?.defaults,
-        sandbox: {
-          ...cfg.agents?.defaults?.sandbox,
-          browser: {
-            ...cfg.agents?.defaults?.sandbox?.browser,
-            image,
-          },
-        },
-      },
-    },
-  };
-}
-
 type SandboxImageCheck = {
   engineCommand: "docker" | "podman";
   kind: string;
   image: string;
   buildScript?: string;
-  updateConfig: (image: string) => void;
 };
 
 async function handleMissingSandboxImage(
@@ -353,9 +314,6 @@ export async function maybeRepairSandboxImages(
   await validateSandboxContainerEngineTarget(containerEngine);
   await noteCodexBwrapNamespaceWarning(cfg, containerEngine.displayName);
 
-  let next = cfg;
-  const changes: string[] = [];
-
   const dockerImage = resolveSandboxDockerImage(cfg);
   await handleMissingSandboxImage(
     {
@@ -370,10 +328,6 @@ export async function maybeRepairSandboxImages(
             : dockerImage === DEFAULT_SANDBOX_IMAGE
               ? "scripts/sandbox-setup.sh"
               : undefined,
-      updateConfig: (image) => {
-        next = updateSandboxDockerImage(next, image);
-        changes.push(`Updated agents.defaults.sandbox.docker.image → ${image}`);
-      },
     },
     runtime,
     prompter,
@@ -386,10 +340,6 @@ export async function maybeRepairSandboxImages(
         kind: "browser",
         image: resolveSandboxBrowserImage(cfg),
         buildScript: "scripts/sandbox-browser-setup.sh",
-        updateConfig: (image) => {
-          next = updateSandboxBrowserImage(next, image);
-          changes.push(`Updated agents.defaults.sandbox.browser.image → ${image}`);
-        },
       },
       runtime,
       prompter,
@@ -401,11 +351,7 @@ export async function maybeRepairSandboxImages(
     );
   }
 
-  if (changes.length > 0) {
-    note(changes.join("\n"), "Doctor changes");
-  }
-
-  return next;
+  return cfg;
 }
 
 function formatLegacyRegistryInspectionLine(file: LegacySandboxRegistryInspection): string {


### PR DESCRIPTION
## What Problem This Solves

Doctor retained a sandbox-image config rewrite path that could never execute. The private image-check consumer accepted `updateConfig` callbacks but never called or exposed them, leaving two rewrite helpers and change-reporting bookkeeping dormant. This is a production-deletion follow-up to #135868.

## Why This Change Was Made

Remove the unused callback field, both callback bodies and helper functions, the unchanged `next` alias, the always-empty change list and its unreachable note. `maybeRepairSandboxImages` continues returning the original config object. The consumer still inspects configured images and optionally runs the existing build scripts.

| Removal | Evidence and surviving behavior |
|---|---|
| `updateSandboxDockerImage` and `updateSandboxBrowserImage` | Their only references were the two uncalled callbacks. The private `handleMissingSandboxImage` at `src/commands/doctor-sandbox.ts:235` never invokes or exposes a callback. Current main and stable `v2026.9.2` share that consumer. |
| Private `SandboxImageCheck.updateConfig` field and callback bodies | The live consumer retains image inspection, prompts and build-script execution. Existing script resolution coverage remains in `src/commands/doctor-sandbox.test.ts:93`; Docker availability and explicit Podman validation remain in `doctor-sandbox.warns-sandbox-enabled-without-docker.test.ts:128` and `:175`. |
| `next`, `changes`, and unreachable “Doctor changes” note | `next` was assigned only in uncalled callbacks and `changes` had no reachable append. The original config return contract remains at `src/commands/doctor-sandbox.ts:267` and `:354`; its health-flow caller still receives the same object. Existing engine and namespace checks remain covered at `doctor-sandbox.warns-sandbox-enabled-without-docker.test.ts:197`, `:227` and `:260`. |

Whole-repository search finds no other callback consumer. `git log -S 'updateConfig:'` reaches the shallow boundary `e357203be57`; available history has no `params.updateConfig` invocation. No older introduction/removal claim is made. This private dormant path has no shipped injection contract, and the stable consumer proves no working rewrite behavior is lost.

## User Impact

No observable change. Configured images, missing-image hints, optional build prompts/scripts, Docker/Podman validation, namespace diagnostics and the config return identity are preserved. No tests were changed or removed.

## Evidence

- Both Doctor sandbox suites: 22 cases passed before and after.
- Independent Codex review: scoped-clean, no actionable P0–P2 findings.
- Production +1 / −55 = **−54 lines**. Tests/support, tooling and docs: unchanged.

- Full `node scripts/check-changed.mjs` passed, including typechecking, Knip, lint and runtime import-cycle checks.

Rebased onto the main-side docs route repair #140337. Earlier source validation remains byte-identical; the lockfile is unchanged.

ClawSweeper disposition: its [technical re-review](https://github.com/openclaw/openclaw/pull/140342#issuecomment-5561066028) finds no actionable defects and explicitly says the earlier migration-proof blocker does not apply because these callbacks were unreachable on both main and the latest release. The rendered “Add data-model compatibility proof” checklist is skipped on that source evidence: no schema, stored representation, migration, retention, concurrency, recovery or projection behavior changes. The existing 22 tests passed again after rebase, and exact-head CI run 34050653593 is green.
