### PR TITLE
refactor(doctor): inline GitHub skill discovery inputs

### DIFF
--- a/src/commands/doctor-skills.ts
+++ b/src/commands/doctor-skills.ts
@@ -11,7 +11,6 @@ import {
   detectGhConfigDirMismatch,
   formatGhConfigDirMismatchHint,
   type GhConfigDiscoveryInput,
-  type GhConfigDiscoveryResult,
 } from "../skills/lifecycle/gh-config-discovery.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 import {
@@ -19,37 +18,23 @@ import {
   disableUnavailableSkillsInConfig,
 } from "./doctor-skills-core.js";
 
-function defaultGhConfigDiscoveryInput(): GhConfigDiscoveryInput {
-  return {
-    platform: process.platform,
-    env: process.env as GhConfigDiscoveryInput["env"],
-    fileExists: (absolutePath) => existsSync(absolutePath),
-  };
-}
-
 /** Builds a GitHub CLI config-dir hint for eligible GitHub skill setups. */
 function describeGhConfigDirHint(skills: SkillStatusEntry[]): string[] {
-  return describeGhConfigDirHintFromDiscovery(skills, defaultGhConfigDiscoveryInput());
-}
-
-/** Builds a GitHub CLI config-dir hint from injected discovery inputs for tests. */
-function describeGhConfigDirHintFromDiscovery(
-  skills: SkillStatusEntry[],
-  discoveryInput: GhConfigDiscoveryInput,
-): string[] {
+  const discoveryInput: GhConfigDiscoveryInput = {
+    platform: process.platform,
+    env: process.env as GhConfigDiscoveryInput["env"],
+    fileExists: existsSync,
+  };
   const githubSkill = skills.find((skill) => skill.name === "github");
-  if (!githubSkill) {
-    return [];
-  }
   if (
-    !githubSkill.eligible ||
+    !githubSkill?.eligible ||
     githubSkill.blockedByAgentFilter ||
     githubSkill.disabled ||
     githubSkill.blockedByAllowlist
   ) {
     return [];
   }
-  const result: GhConfigDiscoveryResult = detectGhConfigDirMismatch(discoveryInput);
+  const result = detectGhConfigDirMismatch(discoveryInput);
   if (result.kind !== "mismatch") {
     return [];
   }


### PR DESCRIPTION
## What Problem This Solves

Doctor's GitHub CLI hint path went through two private wrappers for default inputs and a purported test injection seam. Neither has another caller; tests use the real Doctor entry and the canonical discovery owner. This production-deletion follow-up to #135868 removes that indirection.

## Why This Change Was Made

Construct the same discovery input directly in the hint owner, before the existing eligibility checks. Pass the existing filesystem predicate directly, combine the identical missing/ineligible early returns, and infer the detector result type.

| Removal | Surviving owner and coverage |
|---|---|
| Private `defaultGhConfigDiscoveryInput` and `describeGhConfigDirHintFromDiscovery` wrappers | `src/commands/doctor-skills.ts:22` owns the same inputs and detection. Real Doctor hint output remains covered by `src/commands/doctor-skills.test.ts:207`. |
| Filesystem forwarding closure and redundant result annotation/import | The canonical `detectGhConfigDirMismatch` still receives the same platform, environment and existence check; `src/skills/lifecycle/gh-config-discovery.test.ts:28` retains its 18 platform/discovery cases unchanged. |
| Separate missing-skill early return | The same empty outcome is shared with the existing ineligible branch. `src/commands/doctor-skills.test.ts:230` protects ineligible suppression; non-GitHub skill cases at `:102` continue through the same real Doctor entry. |

Whole-repository search finds no external caller of the deleted private functions. `git log -S defaultGhConfigDiscoveryInput` reaches the shallow history boundary `e357203be57`; no older introduction claim is made. No public or shipped injection contract is removed.

## User Impact

No observable behavior change. Discovery input construction order, eligibility, configuration hints and displayed output remain unchanged. No tests were edited or removed.

## Evidence

- Doctor skills and canonical GitHub config discovery suites: all 28 tests passed before and after.
- Independent Codex review: scoped-clean, no actionable P0–P2 findings.
- Production +6 / −21 = **−15 lines**. Tests/support, tooling and docs: unchanged.

- Full `node scripts/check-changed.mjs` passed, including typechecking, Knip, lint and runtime import-cycle checks.

Rebased onto the main-side docs route repair #140337. Earlier source validation remains byte-identical; the lockfile is unchanged.

ClawSweeper disposition: its [technical re-review](https://github.com/openclaw/openclaw/pull/140343#issuecomment-5561071098) confirms that configuration repair, persistence and authorization code are unchanged, and says the earlier migration-proof blocker is unsupported. The rendered “Add data-model compatibility proof” checklist is therefore skipped: this diff changes no schema, stored representation, migration, retention, concurrency, recovery or projection semantics. The same 28 existing tests and identical discovery inputs/output protect the actual contract. Exact-head CI run 34050729824 is green.
