### PR TITLE
test(docs): accept nested release section navigation

### DIFF
--- a/test/scripts/docs-sync-publish.test.ts
+++ b/test/scripts/docs-sync-publish.test.ts
@@ -367,14 +367,12 @@ fs.writeFileSync('package-lock.json', JSON.stringify(lock));
       "Release process",
       "Testing and CI",
     ]);
-    // Every release adds a releases/<version> page, so read the published versions from the
-    // navigation rather than pinning them here; only the index-first ordering and the version
-    // route shape are invariant. Pinning the list makes this assertion fail on release PRs whose
-    // change classification never selects this lane, so the break first lands on main.
+    // Releases can add version pages and nested section pages. Read their routes from
+    // navigation rather than pinning a list that docs-only releases cannot validate here.
     expect(releaseNotes[0]).toBe("releases/index");
     expect(releaseNotes.length).toBeGreaterThan(1);
     for (const page of releaseNotes.slice(1)) {
-      expect(page).toMatch(/^releases\/\d{4}\.\d{1,2}\.\d+$/);
+      expect(page).toMatch(/^releases\/\d{4}\.\d{1,2}\.\d+(?:\/[a-z0-9]+(?:-[a-z0-9]+)*)*$/);
     }
     const releaseRoutes = [
       ...releaseNotes,


### PR DESCRIPTION
## What Problem This Solves

The split release page in #140319 adds valid nested release-note routes. The docs publisher already preserves and prefixes them correctly, but its navigation test accepts only the root version route. This breaks unrelated PR CI, including #140329.

## Why This Change Was Made

Allow dated release routes to contain nested kebab-case sections. Keep the existing index-first ordering, duplicate detection, full release-tab equality and every generated locale parity assertion. No pinned versions or section lists, and no production or publishing behavior changes.

## Evidence

The original focused locale-navigation case fails on the newly published section route. The updated complete file passes all 10 tests, all 15 selected checks pass, and fresh independent Codex review found no actionable P0–P2 findings.

An initial full-file run failed because the task temporary directory sat inside this ESM checkout, changing the scope of synthetic CommonJS executables. That failure is retained; moving only task temporary files to a private OS-temp directory restored their ordinary execution context. No source or assertion was changed for that apparatus correction.
