### PR TITLE
test(process): share relay startup fixtures

### DIFF
--- a/src/process/supervisor/service-child-relay-host.test.ts
+++ b/src/process/supervisor/service-child-relay-host.test.ts
@@ -42,7 +42,6 @@ async function createRelay(platform: "linux" | "darwin" | "win32") {
     throw Object.assign(new Error("synthetic missing process group"), { code: "ESRCH" });
   });
   const stub = createStubChild();
-  stub.child.unref = vi.fn();
   const cancellations: Array<(error: Error) => void> = [];
   // Keep channel closure independently controlled from cancellation write completion.
   const control = new Duplex({
@@ -140,10 +139,8 @@ async function createRelay(platform: "linux" | "darwin" | "win32") {
   };
 }
 
-it("reports cleanup uncertainty when construction aborts before ready", async () => {
-  platformMock = mockProcessPlatform("linux");
+function createWritableRelayChild() {
   const stub = createStubChild();
-  stub.child.unref = vi.fn();
   const control = new Duplex({
     autoDestroy: false,
     read() {},
@@ -156,52 +153,28 @@ it("reports cleanup uncertainty when construction aborts before ready", async ()
     configurable: true,
   });
   mocks.spawn.mockReturnValue(stub.child);
-  const abort = new AbortController();
-  const starting = createServiceChildRelayAdapter({
-    command: "synthetic-command",
-    args: [],
-    stdinMode: "pipe-closed",
-    oomScoreWrapperSelected: false,
-    abortSignal: abort.signal,
-  });
-  await nextTurn();
-  expect(mocks.spawn).toHaveBeenCalled();
-  expect(stub.killMock).not.toHaveBeenCalled();
+  return { ...stub, control };
+}
 
-  abort.abort();
-  await expect(starting).rejects.toThrow("service child cleanup identity lost");
-  expect(stub.killMock).toHaveBeenCalledWith("SIGKILL");
-  control.destroy();
-  stub.emitExit(null, "SIGKILL");
-});
-
-it("reports cleanup loss when deferred start delivery fails after abort", async () => {
+it.each([
+  { name: "construction aborts before ready", deferredStart: false },
+  { name: "deferred start delivery fails after abort", deferredStart: true },
+])("reports cleanup uncertainty when $name", async ({ deferredStart }) => {
   platformMock = mockProcessPlatform("linux");
-  const stub = createStubChild();
-  stub.child.unref = vi.fn();
-  const control = new Duplex({
-    autoDestroy: false,
-    read() {},
-    write(_chunk, _encoding, callback) {
-      callback();
-    },
-  });
-  Object.defineProperty(stub.child, "stdio", {
-    value: [stub.child.stdin, stub.child.stdout, stub.child.stderr, control],
-    configurable: true,
-  });
+  const stub = createWritableRelayChild();
   const startCallbacks: Array<(error: Error | null) => void> = [];
-  stub.sendMock.mockImplementation((_message, ...args) => {
-    const callback = args.findLast((value) => typeof value === "function") as
-      | ((error: Error | null) => void)
-      | undefined;
-    if (!callback) {
-      throw new Error("Expected a start delivery callback");
-    }
-    startCallbacks.push(callback);
-    return true;
-  });
-  mocks.spawn.mockReturnValue(stub.child);
+  if (deferredStart) {
+    stub.sendMock.mockImplementation((_message, ...args) => {
+      const callback = args.findLast(
+        (value): value is (error: Error | null) => void => typeof value === "function",
+      );
+      if (!callback) {
+        throw new Error("Expected a start delivery callback");
+      }
+      startCallbacks.push(callback);
+      return true;
+    });
+  }
   const abort = new AbortController();
   const starting = createServiceChildRelayAdapter({
     command: "synthetic-command",
@@ -210,16 +183,21 @@ it("reports cleanup loss when deferred start delivery fails after abort", async 
     oomScoreWrapperSelected: false,
     abortSignal: abort.signal,
   });
-
   await nextTurn();
-  expect(startCallbacks).toHaveLength(1);
+  expect(stub.killMock).not.toHaveBeenCalled();
+  if (deferredStart) {
+    expect(startCallbacks).toHaveLength(1);
+  }
+
   abort.abort();
   const rejected = expect(starting).rejects.toThrow("service child cleanup identity lost");
-  startCallbacks[0]!(new Error("synthetic start delivery failed"));
+  if (deferredStart) {
+    startCallbacks[0]!(new Error("synthetic start delivery failed"));
+  }
   await rejected;
   expect(stub.killMock).toHaveBeenCalledWith("SIGKILL");
   await nextTurn();
-  control.destroy();
+  stub.control.destroy();
   stub.emitExit(null, "SIGKILL");
 });
 
@@ -227,19 +205,7 @@ it.each(["linux", "win32"] as const)(
   "keeps rejected construction ownership failures visible to supervisor joins (%s)",
   async (platform) => {
     platformMock = mockProcessPlatform(platform);
-    const stub = createStubChild();
-    const control = new Duplex({
-      autoDestroy: false,
-      read() {},
-      write(_chunk, _encoding, callback) {
-        callback();
-      },
-    });
-    Object.defineProperty(stub.child, "stdio", {
-      value: [stub.child.stdin, stub.child.stdout, stub.child.stderr, control],
-      configurable: true,
-    });
-    mocks.spawn.mockReturnValue(stub.child);
+    const stub = createWritableRelayChild();
     const supervisor = createProcessSupervisor();
     const scopeKey = "scope:rejected-construction";
     const cleanupScope = supervisor.acquireScopeCleanup(scopeKey, { processTree: "required-all" });
@@ -254,7 +220,7 @@ it.each(["linux", "win32"] as const)(
     const run = await pending;
     await expect(run.wait()).resolves.toMatchObject({ reason: "manual-cancel" });
     const outcomes = Promise.allSettled([cleanupScope(), supervisor.shutdown()]);
-    control.destroy();
+    stub.control.destroy();
     stub.disconnectMock();
     stub.emitExit(null, "SIGKILL");
 


### PR DESCRIPTION
Related: #135868, #139517

## What Problem This Solves

The Stage 3 process cleanup tests repeat relay startup fixtures across two abort timings and the supervisor cleanup joins. This is the maintainer-requested test compression pass for concern C of the #135868 split, after reviewing #139937 and #139953.

## Why This Change Was Made

Table-drive the two startup timings and share their immediately writable relay fixture with the existing Linux/Windows supervisor cases. Keep the independent deferred cancellation writer, the abort → deferred delivery failure → rejection observation order, and all repeated cleanup joins.

## User Impact

No runtime behavior changes. All test cases remain. Tests shrink by 34 lines (+31/−65); production, tooling, and docs each change by zero.

## Evidence

| Removed repetition or assertion | Surviving coverage |
| --- | --- |
| Separate startup-abort body | `src/process/supervisor/service-child-relay-host.test.ts:162`, “reports cleanup uncertainty when construction aborts before ready” |
| Separate deferred-start-failure body and callback cast | Same table at `:162`, “reports cleanup uncertainty when deferred start delivery fails after abort”; a typed callback retains the same delivery ordering |
| Repeated writable Duplex/stdio fixtures | Startup table at `:162` and `src/process/supervisor/service-child-relay-host.test.ts:205`, “keeps rejected construction ownership failures visible to supervisor joins (%s)”, both Linux and Windows rows |
| Spawn mock call assertion | Startup table at `:162` requires the spawned child's SIGKILL and the original cleanup-identity rejection |
| Three unused `unref` mock assignments | Relay owner never invokes them; actual referenced-host lifetime remains covered by `src/process/supervisor/supervisor.anchored-shell.real.test.ts:240`, “completes an otherwise idle host with %s command environment” |

Real process groups, owned stdio, output flushing, scope extinction, retained descendants, kernel census, and relay-reaping/deadline tests remain unchanged. This patch does not revisit the distinct ownership cases retained by the previous Stage 3 compression pass.

Full `src/process` suite before: 44 files, 634 passed / 63 skipped, 35.06 s. After: the same 44 files and case counts, 40.57 s. Real-process cases ran on macOS; Windows cases retain their fixtures. Full `node scripts/check-changed.mjs` passed, including test types, lint, guards, and all three dead-export scans. Independent Codex autoreview is scoped-clean through P2; `git diff --check` passed. File size: 592 → 558 lines.

Exact-head CI is green for `087c0000f9ba546ebeb8dc397d27676b732055c4`: https://github.com/openclaw/openclaw/actions/runs/34050481521 . ClawSweeper reviewed that head with no findings, before-merge requests, or rank-up moves.
