### PR TITLE
refactor(doctor): reuse shared cron migration receipt writes

### DIFF
--- a/src/commands/doctor/cron/legacy-repair.ts
+++ b/src/commands/doctor/cron/legacy-repair.ts
@@ -23,6 +23,7 @@ import {
 } from "../../../cron/store.js";
 import type { CronJob } from "../../../cron/types.js";
 import { formatErrorMessage as errorMessage } from "../../../infra/errors.js";
+import { markLegacyMigrationSourceRemoved } from "../../../infra/state-migrations.receipts.js";
 import { parseAgentSessionKey } from "../../../routing/session-key.js";
 import { shortenHomePath } from "../../../utils.js";
 import type { LegacyCodexModelIdentity } from "../shared/codex-route-model-ref.js";
@@ -52,7 +53,6 @@ import {
   acquireLegacyCronMigrationReceipt,
   hasLegacyCronMigrationReceipt,
   hasLegacyCronMigrationReceiptReadOnly,
-  markLegacyCronMigrationSourceRemoved,
 } from "./migration-ledger.js";
 import { mergeLegacyCronJobs, mergeRuntimeEntryIntoConfigJob } from "./repair-plan.js";
 import { planCronCodexRefRewriteAgainstPersistedConfig } from "./runtime-policy-migration.js";
@@ -449,7 +449,7 @@ export async function applyLegacyCronStoreRepair(params: {
     if (archiveResult.ok) {
       if (state.legacyMigrationSource) {
         try {
-          markLegacyCronMigrationSourceRemoved(state.legacyMigrationSource);
+          markLegacyMigrationSourceRemoved(state.legacyMigrationSource.sourceKey, process.env);
         } catch (err) {
           rethrowSqliteSchemaVersionError(err);
           warnings.push(

--- a/src/commands/doctor/cron/migration-ledger.ts
+++ b/src/commands/doctor/cron/migration-ledger.ts
@@ -7,19 +7,13 @@ import {
   getNodeSqliteKysely,
 } from "../../../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../../../infra/node-sqlite.js";
+import { recordLegacyMigrationRun } from "../../../infra/state-migrations.receipts.js";
 import type { DB as OpenClawStateDatabase } from "../../../state/openclaw-state-db.generated.js";
-import {
-  openOpenClawStateDatabase,
-  runOpenClawStateWriteTransaction,
-} from "../../../state/openclaw-state-db.js";
+import { openOpenClawStateDatabase } from "../../../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
 import type { LegacyCronMigrationSource } from "./legacy-store-migration.js";
 
-type CronMigrationDatabase = Pick<OpenClawStateDatabase, "migration_runs" | "migration_sources">;
-
-function migrationRunId(source: LegacyCronMigrationSource): string {
-  return `cron-legacy:${source.sourceKey}`;
-}
+type CronMigrationDatabase = Pick<OpenClawStateDatabase, "migration_sources">;
 
 function hasLegacyCronMigrationReceiptInDatabase(
   db: DatabaseSync,
@@ -71,36 +65,24 @@ export function acquireLegacyCronMigrationReceipt(
     return false;
   }
   const now = Date.now();
-  const runId = migrationRunId(source);
+  const runId = `cron-legacy:${source.sourceKey}`;
   const reportJson = JSON.stringify({
     source: "legacy-cron-json",
     target: "cron_jobs",
     statePath: source.stateSha256 ? source.statePath : undefined,
     stateSha256: source.stateSha256,
   });
-  const kysely = getNodeSqliteKysely<CronMigrationDatabase>(db);
+  recordLegacyMigrationRun(db, {
+    runId,
+    startedAt: now,
+    finishedAt: now,
+    status: "completed",
+    reportJson,
+    upsert: true,
+  });
   executeSqliteQuerySync(
     db,
-    kysely
-      .insertInto("migration_runs")
-      .values({
-        id: runId,
-        started_at: now,
-        finished_at: now,
-        status: "completed",
-        report_json: reportJson,
-      })
-      .onConflict((conflict) =>
-        conflict.column("id").doUpdateSet({
-          finished_at: now,
-          status: "completed",
-          report_json: reportJson,
-        }),
-      ),
-  );
-  executeSqliteQuerySync(
-    db,
-    kysely
+    getNodeSqliteKysely<CronMigrationDatabase>(db)
       .insertInto("migration_sources")
       .values({
         source_key: source.sourceKey,
@@ -127,16 +109,4 @@ export function acquireLegacyCronMigrationReceipt(
       ),
   );
   return true;
-}
-
-export function markLegacyCronMigrationSourceRemoved(source: LegacyCronMigrationSource): void {
-  runOpenClawStateWriteTransaction(({ db }) => {
-    executeSqliteQuerySync(
-      db,
-      getNodeSqliteKysely<CronMigrationDatabase>(db)
-        .updateTable("migration_sources")
-        .set({ removed_source: 1 })
-        .where("source_key", "=", source.sourceKey),
-    );
-  });
 }


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Legacy Cron migration duplicates durable receipt writes already implemented by the shared migration owner. This maintainer-requested cleanup removes that duplicate bookkeeping while preserving Cron's recovery behavior.

## Why This Change Was Made

Use the existing run-record writer with explicit upsert behavior and the existing source-removal helper. Keep Cron's completed-status check, source fingerprint, and distinct source-conflict update policy. Run acquisition still uses the database supplied by the existing job-write transaction, after its snapshot check; source removal still follows successful archival.

This is an independent clean-broad companion to the #135868 split (decision brief §1 concern map and §5 stack order), with no feature-stage content extracted.

## User Impact

No user-visible behavior change. Retried migration still avoids resurrecting jobs already removed by runtime, preserves the original run start time, refuses changed sources and concurrent stores, and leaves future-schema databases untouched. Existing legacy upgrade support remains available.

## Evidence

- The pre-change ledger matches stable `v2026.9.2`. The shared receipt owner exists since #117142. This removes duplicated implementation, not a shipped upgrade contract.
- The removed run upsert inserts the same five columns and updates only finished time, status and report on conflict; the canonical helper has the same behavior with `upsert: true`. Both preserve the original start time.
- The removed source-removal wrapper has one core caller. The shared helper updates the same source key through the same synchronous transaction owner and environment; no additional transaction, connection, await or authority boundary is introduced.
- Cron's source upsert intentionally stays local: the generic source writer also updates hash, byte count and record count on conflict. Its generic reader also accepts statuses that Cron must reject. Neither is substituted.
- 87 existing tests pass before and after across the Cron index, legacy repair, schema safety and canonical receipt suites. These retain real SQLite and filesystem boundaries, including failed archive retry after runtime deletion, changed-source refusal, concurrent-row changes, future-schema/WAL preservation and resumed-run timestamp behavior.
- Independent Codex review is clean through P2. The full selected changed-check plan passed, including core/core-test typing, all three dead-export scans, lint, and architecture/storage guards.

| Judged class | Added | Deleted | Net | Before → after |
| --- | ---: | ---: | ---: | --- |
| Production | 15 | 45 | −30 | Ledger 142→112; repair caller 582→582 |
| Tests | 0 | 0 | 0 | unchanged |
| Tooling | 0 | 0 | 0 | unchanged |
| Docs | 0 | 0 | 0 | unchanged |

No schema, configuration option, protocol, dependency, baseline or public SDK contract changes.

The pre-publication rebase preserved all 14 recorded proof inputs and the lockfile; no dependency reinstall was needed. Fresh branch Codex review is also clean through P2.

The first exact-head CI run [34050259536](https://github.com/openclaw/openclaw/actions/runs/34050259536/job/101532644429) failed the docs locale-navigation assertion after main added release section pages. The failure reproduced locally. Main already contained #140337; after rebasing onto that fix, all 10 docs-publisher tests pass. The 14 recorded Cron proof inputs and lockfile are unchanged. This PR adds no docs or test changes for that independently landed repair.


### Existing-database compatibility proof

ClawSweeper's compatibility-evidence request is addressed. Its automated schema/table-change classification does not apply: this patch adds no DDL, schema version, table definition or persisted field. The relevant upgrade boundary is the prior receipt writer's existing data being consumed by the new writer.

An ephemeral real-SQLite probe ran the prior ledger from `3967d9b6df1f` and the current ledger at `acedb6ad5321` through the canonical database, transaction and Cron store owners. The prior ledger blob `9d1f70ea77c9` also matches `v2026.9.2`. Each variant used isolated state, closed and reopened the database, and compared complete receipt rows and schema definitions.

| Protected behavior | Observed result |
| --- | --- |
| Existing completed receipt after runtime job deletion | New writer rejected reimport through the real store callback; job list stayed empty and receipt rows were unchanged. |
| Resume an existing run | Original `started_at=101` remained; finish/import times matched and fell within independently measured before/after bounds. |
| Conflict with an incomplete source receipt | Original path/hash/size/count stayed intact even with different incoming metadata; only the intended completion/report fields changed. |
| Source-removal marking | Only the selected source's `removed_source` changed; every other run/source column and an unrelated receipt remained unchanged after reopening. |
| Schema compatibility | Version 16 and all 323 `sqlite_master` entries were identical before/after and across both writers. |
| Negative controls | Disabling run upsert failed on the existing run's unique key; overwriting historical metadata failed its preservation assertion. |

Both old/current implementations passed all seven behavior groups on macOS arm64 with Node 24.20.0 and Node 26.8.1, SQLite 3.53.4. Full row comparisons normalized only independently checked live timestamp fields. Both negative controls failed for the intended reason on both runtimes. Probe source/results were personally reviewed and all eight fixture directories were removed.

This is prior-ledger compatibility on the unchanged canonical schema, not a claim of running a complete old-release application upgrade. Physical archive failure/retry remains covered by the existing 87-test boundary suite. No additional production or test changes were needed for this proof.
