### PR TITLE
fix(ui): show stale memory search warnings and recovery guidance

### DIFF
--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -164,6 +164,9 @@ output warns that matches may be incomplete. With `--json`, the response adds
 `stale: true`, plus `warning` and `action` fields. Treat an empty `results`
 array as authoritative only when `stale` is absent.
 
+The Control UI's Memories tab shows the same warning and recovery guidance
+alongside stale search results, and clears them after a fresh search.
+
 ## `memory forget`
 
 Remove identifiable memory artifacts derived from selected sessions and record

--- a/ui/src/pages/config/memory-memories.test.ts
+++ b/ui/src/pages/config/memory-memories.test.ts
@@ -298,4 +298,55 @@ describe("MemoryMemoriesElement", () => {
       element.remove();
     }
   });
+
+  it.each([false, true])(
+    "shows stale guidance alongside results and clears it after a fresh search (hits=%s)",
+    async (hasHits) => {
+      const warning =
+        "Memory index is stale: index scope changed (owner: configuration, code: scope). Search results may be incomplete.";
+      const action =
+        "Run: openclaw memory status --index --agent main. Rebuilding uses keyword indexing only and does not call an embedding provider.";
+      const fresh = { ...result, snippet: "Freshly indexed Ada prefers careful reviews." };
+      const request = vi
+        .fn<Request>()
+        .mockResolvedValueOnce({
+          agentId: "main",
+          provider: "none",
+          searchMode: "fts-only",
+          results: hasHits ? [result] : [],
+          stale: true,
+          warning,
+          action,
+        })
+        .mockResolvedValueOnce({
+          agentId: "main",
+          provider: "none",
+          searchMode: "fts-only",
+          results: [fresh],
+        });
+      const element = createElement(request);
+      const readText = () => (element.textContent ?? "").replace(/\s+/gu, " ").trim();
+      try {
+        await typeQuery(element, "Ada");
+        submit(element);
+        await waitForFast(() =>
+          expect(element.querySelector(".memory-memories__results-heading")).not.toBeNull(),
+        );
+        expect(element.querySelectorAll("article")).toHaveLength(hasHits ? 1 : 0);
+        expect.soft(readText(), "stale result warning").toContain(warning);
+        expect.soft(readText(), "agent-scoped recovery guidance").toContain(action);
+        if (hasHits) {
+          expect(readText()).toContain(result.snippet);
+        }
+
+        await typeQuery(element, "Ada fresh");
+        submit(element);
+        await waitForFast(() => expect(readText()).toContain(fresh.snippet));
+        expect(readText()).not.toContain(warning);
+        expect(readText()).not.toContain(action);
+      } finally {
+        element.remove();
+      }
+    },
+  );
 });

--- a/ui/src/pages/config/memory-memories.ts
+++ b/ui/src/pages/config/memory-memories.ts
@@ -191,6 +191,14 @@ class MemoryMemoriesElement extends OpenClawLightDomElement {
         ? t("memoryPage.memories.hybridSearch")
         : t("memoryPage.memories.keywordSearch");
     return html`
+      ${
+        ready.stale
+          ? html`<div class="callout warn" role="status">
+              ${ready.warning ? html`<p>${ready.warning}</p>` : nothing}
+              ${ready.action ? html`<p>${ready.action}</p>` : nothing}
+            </div>`
+          : nothing
+      }
       <div class="memory-memories__results-heading">
         <span>${t("memoryPage.memories.results", { count: String(ready.results.length) })}</span>
         <span class="memory-memories__mode">${mode}</span>


### PR DESCRIPTION
Closes #140349

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled when applicable.

</details>

## What Problem This Solves

Fixes an issue where users searching the Control UI's Memories tab see an ordinary zero-results state when the memory index is stale. The Gateway already supplies a warning and recovery action, but the UI hides both, making incomplete results look authoritative.

## Why This Change Was Made

The ready-state renderer now displays the existing `warning` and `action` in the shared `callout warn` style when `stale` is set. The callout appears alongside empty or nonempty results and disappears on a fresh search. The response already contains these fields, so the fix adds no state, response fields, permissions, storage changes, or configuration options.

## User Impact

Operators see why results may be incomplete and the existing command to rebuild the index. Search results, source labels, result expansion, and error handling retain their existing behavior. The memory CLI reference now documents that Memories shows the same warning and recovery guidance.

## Evidence

The current signed head is `e3d26e3ac93b99544e5df1fd40028fc194ace220`, mechanically rebased onto `add29edb0b648d70907bb42014fc162fcab78385` to include the upstream CI repair. The same three-file fix was tested and built at `5605eaa1bc1e269ff7abaf2eb988d038ae9016f6` on base `3c6e8d4c82912a7afc9ee7635434bab7690b2e1b`; range-diff and all 34 audited source/dependency inputs are unchanged. A fresh independent review of the rebased head also passed with no findings.

| Proof | Observed result |
| --- | --- |
| Real historical baseline | Sealed source build `37e46d48fadabb8eaebbec44bb154128dfd32439`, qualified for the affected memory/UI scope. A real CLI index and later `memory.search.extraPaths` change produce a real scope mismatch. Both CLI and Gateway report stale-empty results with warning/action, while the UI shows 0 results without either message. |
| Recovery control on the same baseline | The documented `memory status --index --agent main` rebuild restores the note on a fresh search in the same mounted component. This is not a candidate after-fix screenshot. |
| Baseline visual/build evidence | Two inspected screenshots and an inspected 12.68-second video; 66 served assets matched to the sealed build. Source/build/browser identities remained unchanged, and recorded process cleanup was verified. Before-fix screenshot is attached below. |
| Source regression before the fix | Two intended renderer failures; eight controls passed. |
| Focused candidate suites | **51 passed, 0 failed, 0 skipped**: 10 Memories renderer cases and 41 parent-page cases. Controlled coverage includes stale-empty, stale-nonempty, and a fresh response clearing the warning. |
| Current/source release context | Renderer source on main `492db86e9335bf5f784a058d26d544e275d24c24` and release tag `v2026.9.2` is byte-identical to the affected baseline. The release Gateway response already exposes the same fields. This is source comparison, not a packaged-release runtime test. |
| Required changed-file gate and fresh review | All 20 required checks passed; fresh independent Codex P0–P2 review passed with no findings. |
| Candidate build and actual UI proof | One uncached `ciArtifacts` build passed in 141.794 seconds. Real Gateway/browser flow displayed the complete stale warning and recovery action; documented CLI rebuild restored the note and cleared the guidance in the same mounted component. Two actual `memory.search` requests, 66 matching served assets, 35 verified raw artifacts, and unchanged source/build/browser seals. Both screenshots and the 5.44-second video were inspected; all content is synthetic. Recorded processes are absent and private fixture state was removed. |
| Published-head CI | [CI run 34051069056](https://github.com/openclaw/openclaw/actions/runs/34051069056) passed on exact head `e3d26e3ac93b99544e5df1fd40028fc194ace220`. The earlier unrelated failure and upstream fix are documented below. |

The first browser attempt (v4) made zero UI search requests due to startup/input readiness and is retained as failed setup. The corrected v5 driver waits for the normal component-ready state before interacting; the accepted run then observes real requests and replies. No stale response or index metadata was injected.

Production grows by eight template lines to display existing response data using the existing warning component style; tests add 51 lines and documentation adds three. No backend, protocol, database, permission, dependency, or configuration change is included.

The images below are, in order: before-fix stale search; patched stale search with guidance; patched fresh search after rebuilding. The video shows the patched stale-to-fresh flow. No embedding or model provider was used; the UI may fetch its anonymous public plugin catalog.

![Before: stale search hides warning and rebuild guidance](https://github.com/user-attachments/assets/90bb4807-c906-44bf-9ca8-cbd024c4d85e)

![After: stale search shows warning and rebuild guidance](https://github.com/user-attachments/assets/d23a35dc-8c0e-4a1e-a042-025077eb1ac5)

![After rebuilding: note returns and stale guidance clears](https://github.com/user-attachments/assets/07bdcd60-09f1-472c-b8b2-663e776ba9a6)

https://github.com/user-attachments/assets/2763f50d-29c7-494b-a3d9-de594d6fca67

## Maintainer verification and CI recovery

The maintainer independently inspected all attached screenshots and the full sequence in the video contact sheet. The before-fix image omits guidance; the candidate image shows the complete warning and rebuild command; the recovery image restores the note and clears both messages. The captures contain only the synthetic fixture. This resolves the review environment’s inability to retrieve attachments; no visual-proof waiver is needed.

CI run 34050382300 failed in the unrelated docs-navigation test because release subpages did not match its old route pattern. The existing upstream repair is #140337 (`96bf3652adabc25d86af15a950a72be63575acc5`). The candidate was mechanically rebased onto current main containing that fix. The sealed `5605eaa1` build and browser proof remain preserved; they are not described as a runtime execution of the rebased whole tree.
