### PR TITLE
runtime.gateway.request refusal names neither the plugin nor the cause

### DIFF
--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1534,7 +1534,11 @@ describe("loadGatewayPlugins", () => {
     expect(getLastDispatchedClientInternal().pluginRuntimeOwnerId).toBe("google-meet");
   });
 
-  test("names the refused plugin when it is not bundled or trusted official", async () => {
+  test.each([
+    { pluginId: "community-plugin", reason: /Plugin "community-plugin" is neither\./ },
+    { pluginId: "missing-plugin", reason: /Plugin "missing-plugin" is neither\./ },
+    { pluginId: undefined, reason: /This call carries no plugin identity\./ },
+  ])("explains the Gateway refusal for plugin identity $pluginId", async ({ pluginId, reason }) => {
     loadOpenClawPlugins.mockReturnValue(
       addLoadedPlugin(createRegistry([]), { id: "community-plugin", origin: "global" }),
     );
@@ -1542,26 +1546,19 @@ describe("loadGatewayPlugins", () => {
     serverPluginsModule.setFallbackGatewayContext(createTestContext("plugin-gateway-refused"));
     const runtime = createRuntimeFromLastGatewayLoad();
 
-    await expect(
-      gatewayRequestScopeModule.withPluginRuntimePluginScope(
-        { pluginId: "community-plugin", pluginOrigin: "global" },
-        () => runtime.gateway.request("voicecall.start", { to: "+15550001234" }),
-      ),
-    ).rejects.toThrow(/community-plugin/);
-  });
+    const request = pluginId
+      ? gatewayRequestScopeModule.withPluginRuntimePluginScope(
+          { pluginId, pluginOrigin: "global" },
+          () => runtime.gateway.request("sessions.list", {}),
+        )
+      : runtime.gateway.request("sessions.list", {});
 
-  test("reports a missing plugin identity distinctly from an untrusted plugin", async () => {
-    loadOpenClawPlugins.mockReturnValue(createRegistry([]));
-    loadGatewayStartupPluginsForTest();
-    serverPluginsModule.setFallbackGatewayContext(createTestContext("plugin-gateway-unscoped"));
-    const runtime = createRuntimeFromLastGatewayLoad();
-    const attempt = () => runtime.gateway.request("voicecall.start", { to: "+15550001234" });
-
-    await expect(attempt()).rejects.toThrow(/carries no plugin identity/i);
-    // Plugin authors install from npm and have no docs/ directory, so cite the published page.
-    await expect(attempt()).rejects.toThrow(
-      /https:\/\/docs\.openclaw\.ai\/plugins\/sdk-runtime#api-runtime-gateway/,
+    await expect(request).rejects.toThrow(reason);
+    await expect(request).rejects.toThrow("bundled or trusted official plugins");
+    await expect(request).rejects.toThrow(
+      "https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-gateway",
     );
+    expect(handleGatewayRequest).not.toHaveBeenCalled();
   });
 
   test("lets trusted official plugins request explicit Gateway scopes", async () => {

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1536,7 +1536,7 @@ describe("loadGatewayPlugins", () => {
 
   test("names the refused plugin when it is not bundled or trusted official", async () => {
     loadOpenClawPlugins.mockReturnValue(
-      addLoadedPlugin(createRegistry([]), { id: "community-plugin", origin: "external" }),
+      addLoadedPlugin(createRegistry([]), { id: "community-plugin", origin: "global" }),
     );
     loadGatewayStartupPluginsForTest();
     serverPluginsModule.setFallbackGatewayContext(createTestContext("plugin-gateway-refused"));
@@ -1544,21 +1544,24 @@ describe("loadGatewayPlugins", () => {
 
     await expect(
       gatewayRequestScopeModule.withPluginRuntimePluginScope(
-        { pluginId: "community-plugin", pluginOrigin: "external" },
+        { pluginId: "community-plugin", pluginOrigin: "global" },
         () => runtime.gateway.request("voicecall.start", { to: "+15550001234" }),
       ),
     ).rejects.toThrow(/community-plugin/);
   });
 
-  test("reports a missing plugin runtime scope distinctly from an untrusted plugin", async () => {
+  test("reports a missing plugin identity distinctly from an untrusted plugin", async () => {
     loadOpenClawPlugins.mockReturnValue(createRegistry([]));
     loadGatewayStartupPluginsForTest();
     serverPluginsModule.setFallbackGatewayContext(createTestContext("plugin-gateway-unscoped"));
     const runtime = createRuntimeFromLastGatewayLoad();
+    const attempt = () => runtime.gateway.request("voicecall.start", { to: "+15550001234" });
 
-    await expect(
-      runtime.gateway.request("voicecall.start", { to: "+15550001234" }),
-    ).rejects.toThrow(/no plugin runtime scope is active/i);
+    await expect(attempt()).rejects.toThrow(/carries no plugin identity/i);
+    // Plugin authors install from npm and have no docs/ directory, so cite the published page.
+    await expect(attempt()).rejects.toThrow(
+      /https:\/\/docs\.openclaw\.ai\/plugins\/sdk-runtime#api-runtime-gateway/,
+    );
   });
 
   test("lets trusted official plugins request explicit Gateway scopes", async () => {

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1534,6 +1534,33 @@ describe("loadGatewayPlugins", () => {
     expect(getLastDispatchedClientInternal().pluginRuntimeOwnerId).toBe("google-meet");
   });
 
+  test("names the refused plugin when it is not bundled or trusted official", async () => {
+    loadOpenClawPlugins.mockReturnValue(
+      addLoadedPlugin(createRegistry([]), { id: "community-plugin", origin: "external" }),
+    );
+    loadGatewayStartupPluginsForTest();
+    serverPluginsModule.setFallbackGatewayContext(createTestContext("plugin-gateway-refused"));
+    const runtime = createRuntimeFromLastGatewayLoad();
+
+    await expect(
+      gatewayRequestScopeModule.withPluginRuntimePluginScope(
+        { pluginId: "community-plugin", pluginOrigin: "external" },
+        () => runtime.gateway.request("voicecall.start", { to: "+15550001234" }),
+      ),
+    ).rejects.toThrow(/community-plugin/);
+  });
+
+  test("reports a missing plugin runtime scope distinctly from an untrusted plugin", async () => {
+    loadOpenClawPlugins.mockReturnValue(createRegistry([]));
+    loadGatewayStartupPluginsForTest();
+    serverPluginsModule.setFallbackGatewayContext(createTestContext("plugin-gateway-unscoped"));
+    const runtime = createRuntimeFromLastGatewayLoad();
+
+    await expect(
+      runtime.gateway.request("voicecall.start", { to: "+15550001234" }),
+    ).rejects.toThrow(/no plugin runtime scope is active/i);
+  });
+
   test("lets trusted official plugins request explicit Gateway scopes", async () => {
     loadOpenClawPlugins.mockReturnValue(addLoadedPlugin(createRegistry([]), { id: "google-meet" }));
     loadGatewayStartupPluginsForTest();

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -87,7 +87,15 @@ export async function dispatchTrustedPluginGatewayMethod<T>(
   const scope = getPluginRuntimeGatewayRequestScope();
   const pluginId = scope?.pluginId?.trim();
   if (!canTrustedOfficialPluginRequestScopes(scope ?? {})) {
-    throw new Error("Gateway requests are only available to bundled or trusted official plugins.");
+    // Refusal has two distinct causes. Name which one so an author is not left
+    // guessing whether the plugin is untrusted or the call escaped its scope.
+    throw new Error(
+      `Gateway requests are only available to bundled or trusted official plugins. ${
+        pluginId
+          ? `Plugin "${pluginId}" is neither.`
+          : "No plugin runtime scope is active for this call."
+      } See docs/plugins/sdk-runtime.md (api.runtime.gateway).`,
+    );
   }
   const syntheticScopes = normalizeOperatorScopeList(options?.scopes);
   return await dispatchGatewayMethodInProcess<T>(method, params, {

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -88,13 +88,11 @@ export async function dispatchTrustedPluginGatewayMethod<T>(
   const pluginId = scope?.pluginId?.trim();
   if (!canTrustedOfficialPluginRequestScopes(scope ?? {})) {
     // Refusal has two distinct causes. Name which one so an author is not left
-    // guessing whether the plugin is untrusted or the call escaped its scope.
+    // guessing whether the plugin is untrusted or the call carries no identity.
     throw new Error(
       `Gateway requests are only available to bundled or trusted official plugins. ${
-        pluginId
-          ? `Plugin "${pluginId}" is neither.`
-          : "No plugin runtime scope is active for this call."
-      } See docs/plugins/sdk-runtime.md (api.runtime.gateway).`,
+        pluginId ? `Plugin "${pluginId}" is neither.` : "This call carries no plugin identity."
+      } See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-gateway`,
     );
   }
   const syntheticScopes = normalizeOperatorScopeList(options?.scopes);

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -87,8 +87,6 @@ export async function dispatchTrustedPluginGatewayMethod<T>(
   const scope = getPluginRuntimeGatewayRequestScope();
   const pluginId = scope?.pluginId?.trim();
   if (!canTrustedOfficialPluginRequestScopes(scope ?? {})) {
-    // Refusal has two distinct causes. Name which one so an author is not left
-    // guessing whether the plugin is untrusted or the call carries no identity.
     throw new Error(
       `Gateway requests are only available to bundled or trusted official plugins. ${
         pluginId ? `Plugin "${pluginId}" is neither.` : "This call carries no plugin identity."


### PR DESCRIPTION
Closes #140351.

## What Problem This Solves

Plugin authors received the same generic Gateway refusal whether their call lacked a plugin identity or came from a named plugin that was neither bundled nor trusted official. The error did not identify the caller or point to the restriction documentation.

## Why This Change Was Made

The existing rejection boundary now names an unsupported plugin when its identity is known, distinguishes a call without identity, and links the published `api.runtime.gateway` restriction. Trust eligibility and successful dispatch are unchanged.

This retains @Colton-Harris's repair and consolidates its regression tests around the same rejection boundary.

## User Impact

A refused plugin call now explains which identity condition failed. Unsupported calls remain blocked.

## Evidence

- Real prebuilt Gateway runs with an active external JavaScript plugin reproduce the original generic refusal and both distinct candidate messages.
- Bundled and verified trusted-official fixture requests work on baseline and candidate. Real disable/re-enable rejects retained old callbacks while the replacement plugin remains usable.
- Baseline and candidate preserve requested scopes, synthetic operator clients, missing-scope errors, structured downstream errors, and request timeouts.
- All 90 focused Gateway plugin tests pass. The three new identity cases fail on the original refusal and pass on the candidate; they also verify that rejected calls never reach method dispatch.
- Targeted lint and pinned formatting pass. A source-blind validator exercised the candidate runtime and compared the baseline controls; source-only claims are covered separately by tests and code review.
