### PR TITLE
docs(releases): keep the release-notes nav group to version routes

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2185,33 +2185,9 @@
                   {
                     "group": "v2026.8.1 sections",
                     "pages": [
-                      "releases/2026.8.1/installation-and-onboarding",
-                      "releases/2026.8.1/the-new-web-ui",
-                      "releases/2026.8.1/updates-and-maintenance",
-                      "releases/2026.8.1/messaging",
-                      "releases/2026.8.1/memory",
-                      "releases/2026.8.1/skills",
-                      "releases/2026.8.1/native-apps",
-                      "releases/2026.8.1/models-and-providers",
-                      "releases/2026.8.1/automations-and-scheduling",
-                      "releases/2026.8.1/browser-and-computer-use",
-                      "releases/2026.8.1/plugins-and-integrations",
-                      "releases/2026.8.1/security-and-privacy",
-                      "releases/2026.8.1/quality-of-life-improvements",
-                      "releases/2026.8.1/other-bug-fixes",
-                      "releases/2026.8.1/maintainer-and-internal-changes",
                       {
                         "group": "Maintenance changes",
-                        "pages": [
-                          "releases/2026.8.1/maintenance-changes-part-1",
-                          "releases/2026.8.1/maintenance-changes-part-2",
-                          "releases/2026.8.1/maintenance-changes-part-3",
-                          "releases/2026.8.1/maintenance-changes-part-4",
-                          "releases/2026.8.1/maintenance-changes-part-5",
-                          "releases/2026.8.1/maintenance-changes-part-6",
-                          "releases/2026.8.1/maintenance-changes-part-7",
-                          "releases/2026.8.1/maintenance-changes-part-8"
-                        ]
+                        "pages": []
                       }
                     ]
                   },


### PR DESCRIPTION
## What

Removes 23 `releases/2026.8.1/<area>` child routes from the **Release notes** nav group. The pages stay published and reachable.

## Why

[#140319](https://github.com/openclaw/openclaw/pull/140319) split the 2.17 MB `v2026.8.1` page into 23 child pages and added each to the nav. That breaks an invariant asserted in `test/scripts/docs-sync-publish.test.ts`:

```js
for (const page of releaseNotes.slice(1)) {
  expect(page).toMatch(/^releases\/\d{4}\.\d{1,2}\.\d+$/);
}
```

`releases/2026.8.1/messaging` does not match, so **keeps generated locale navigation aligned with English routes** started failing on `main`.

The docs-only change classification skips that test lane, so the break landed on main instead of on the PR — exactly what the comment above the assertion warns about:

> Pinning the list makes this assertion fail on release PRs whose change classification never selects this lane, so the break first lands on main.

## Reachability

All 23 children keep an inbound link — 15 from the parent index, the rest from sibling pagination — verified by scanning every `/releases/2026.8.1/<slug>` reference in `docs/`. Removing them from nav also stops the sidebar listing 23 sub-pages under a single release.

## Validation

```
node scripts/check-docs-mdx.mjs docs README.md   # passed, 775 files
node scripts/docs-link-audit.mjs                 # 8292 links, 0 broken
node scripts/docs-link-audit.mjs --anchors       # 0 broken
node scripts/format-docs.mts --check             # clean, 762 files
```