### PR TITLE
fix(images): distinguish requested settings from returned output

### DIFF
--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -198,9 +198,13 @@ Not all providers support all parameters. When a fallback provider supports a
 nearby geometry option instead of the exact requested one, OpenClaw remaps to
 the closest supported size, aspect ratio, or resolution before submission.
 Unsupported output hints are dropped for providers that do not declare
-support and reported in the tool result. Tool results report the applied
-settings; `details.normalization` captures any requested-to-applied
-translation.
+support and reported in the tool result. Completed tool results separate
+`details.requested` hints from per-image `details.outputs`. Output size is
+read from the returned image headers; quality is reported only when the
+provider supplies a concrete value. Missing output fields remain unknown.
+`details.normalization` describes adjustments before submission, not proof
+of the settings the service ultimately used. Completion messages include
+the requested hints and each image's actual dimensions and reported quality.
 </Note>
 
 ## Configuration
@@ -322,6 +326,13 @@ and ComfyUI support 1.
     between 655,360 and 8,294,400 pixels. For example, `1024x640` is
     valid. When only `aspectRatio` is specified, OpenClaw still selects
     the closest supported size.
+
+    Codex subscription responses can report size or quality values that differ
+    from the request. OpenClaw preserves usable images and those reported
+    values, including images supplied by completed output-item events. A
+    requested size or quality is not a guarantee of the returned result;
+    public Images API geometry limits do not establish subscription-route
+    parity. This reporting does not upscale images or retry generation.
 
     OpenAI-specific options live under the `openai` object:
 

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -1635,11 +1635,11 @@ describe("openai image generation provider", () => {
     mockCodexAuthOnly();
     const buffer = Buffer.from("image bytes");
     const output = [{}, { size: "0x-1", quality: "not-quality", output_format: "bogus" }].map(
-      (settings) => ({
-        type: "image_generation_call",
-        result: buffer.toString("base64"),
-        ...settings,
-      }),
+      (settings) =>
+        Object.assign(
+          { type: "image_generation_call", result: buffer.toString("base64") },
+          settings,
+        ),
     );
     mockCodexRawStream(
       `data: ${JSON.stringify({ type: "response.completed", response: { output } })}\n\n`,

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -1589,6 +1589,68 @@ describe("openai image generation provider", () => {
     expect(result.images[0]?.buffer).toEqual(Buffer.from("framed-image"));
   });
 
+  it.each(["completed", "output-item"])(
+    "preserves returned settings from %s images",
+    async (source) => {
+      mockCodexAuthOnly();
+      const buffer = Buffer.from("89504e470d0a1a0a", "hex");
+      const item = {
+        type: "image_generation_call",
+        status: "completed",
+        result: buffer.toString("base64"),
+        size: "941x1672",
+        quality: "medium",
+        output_format: "png",
+      };
+      const events = [
+        { type: "response.output_item.done", item: { ...item, quality: "low" } },
+        { type: "response.completed", response: { output: source === "completed" ? [item] : [] } },
+      ];
+      mockCodexRawStream(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""));
+      const result = await generateOpenAIImage("Draw a portrait", {
+        size: "2160x3840",
+        quality: "high",
+        outputFormat: "jpeg",
+        count: 2,
+      });
+      expect(result.images).toEqual(
+        [1, 2].map((index) => ({
+          buffer,
+          mimeType: "image/png",
+          fileName: `image-${index}.png`,
+          metadata: {
+            size: "941x1672",
+            quality: source === "completed" ? "medium" : "low",
+            outputFormat: "png",
+          },
+        })),
+      );
+      expect(jsonRequestCall().body.tools[0]).toMatchObject({
+        size: "2160x3840",
+        quality: "high",
+        output_format: "jpeg",
+      });
+    },
+  );
+
+  it("ignores absent or malformed returned settings without discarding image bytes", async () => {
+    mockCodexAuthOnly();
+    const buffer = Buffer.from("image bytes");
+    const output = [{}, { size: "0x-1", quality: "not-quality", output_format: "bogus" }].map(
+      (settings) => ({
+        type: "image_generation_call",
+        result: buffer.toString("base64"),
+        ...settings,
+      }),
+    );
+    mockCodexRawStream(
+      `data: ${JSON.stringify({ type: "response.completed", response: { output } })}\n\n`,
+    );
+    const result = await generateOpenAIImage("Draw two icons", { quality: "high" });
+    expect(result.images.map((image) => image.metadata ?? {})).toEqual([{}, {}]);
+    expect(result.images.map((image) => image.buffer)).toEqual([buffer, buffer]);
+  });
+
   it("surfaces the authoritative nested Codex response failure", async () => {
     mockCodexAuthOnly();
     mockCodexRawStream(

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -1625,10 +1625,8 @@ describe("openai image generation provider", () => {
           },
         })),
       );
-      expect(jsonRequestCall().body.tools[0]).toMatchObject({
-        size: "2160x3840",
-        quality: "high",
-        output_format: "jpeg",
+      expect(jsonRequestCall().body).toMatchObject({
+        tools: [{ size: "2160x3840", quality: "high", output_format: "jpeg" }],
       });
     },
   );

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -6,6 +6,7 @@ import type {
   ImageGenerationOutputFormat,
   ImageGenerationProvider,
   ImageGenerationResult,
+  sniffImageMimeType,
 } from "openclaw/plugin-sdk/image-generation";
 import type { resolveClosestSize } from "openclaw/plugin-sdk/media-generation-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
@@ -454,6 +455,9 @@ type OpenAICodexImageGenerationItem = {
   type?: string;
   result?: string | null;
   revised_prompt?: string;
+  size?: unknown;
+  quality?: unknown;
+  output_format?: unknown;
   status?: "in_progress" | "completed" | "generating" | "failed";
 };
 
@@ -582,6 +586,7 @@ function decodeCodexImagePayload(payload: string): Buffer {
 function toCodexImage(
   entry: OpenAICodexImageGenerationItem,
   index: number,
+  sniffMime: typeof sniffImageMimeType,
   outputFormat?: ImageGenerationOutputFormat,
 ): ImageGenerationResult["images"][number] | null {
   if (entry.status && entry.status !== "completed") {
@@ -590,20 +595,36 @@ function toCodexImage(
   if (typeof entry.result !== "string" || entry.result.length === 0) {
     return null;
   }
-  const output = resolveOutputMime(outputFormat);
+  const quality = OPENAI_QUALITIES.find((value) => value === entry.quality);
+  const returnedFormat = OPENAI_OUTPUT_FORMATS.find((value) => value === entry.output_format);
+  const metadata = {
+    ...(typeof entry.size === "string" && /^[1-9]\d{0,5}x[1-9]\d{0,5}$/.test(entry.size)
+      ? { size: entry.size }
+      : {}),
+    ...(quality ? { quality } : {}),
+    ...(returnedFormat ? { outputFormat: returnedFormat } : {}),
+  };
+  const buffer = decodeCodexImagePayload(entry.result);
+  // Returned bytes own the file format; request hints may differ from the result.
+  const output = sniffMime(
+    buffer,
+    resolveOutputMime(metadata.outputFormat ?? outputFormat).mimeType,
+  );
   return Object.assign(
     {
-      buffer: decodeCodexImagePayload(entry.result),
+      buffer,
       mimeType: output.mimeType,
       fileName: `image-${index + 1}.${output.extension}`,
     },
     entry.revised_prompt ? { revisedPrompt: entry.revised_prompt } : {},
+    Object.keys(metadata).length > 0 ? { metadata } : {},
   );
 }
 
 function extractCodexImageGenerationResult(params: {
   body: string;
   model: string;
+  sniffMime: typeof sniffImageMimeType;
   outputFormat?: ImageGenerationOutputFormat;
 }): ImageGenerationResult {
   const events = parseCodexImageGenerationEvents(params.body);
@@ -644,7 +665,7 @@ function extractCodexImageGenerationResult(params: {
   // compatible streams that omit their image from the terminal output.
   const selectedOutputItems = completedOutputItems.length > 0 ? completedOutputItems : outputItems;
   const images = selectedOutputItems
-    .map((item, index) => toCodexImage(item, index, params.outputFormat))
+    .map((item, index) => toCodexImage(item, index, params.sniffMime, params.outputFormat))
     .filter((image): image is NonNullable<typeof image> => image !== null);
   if (images.length === 0) {
     throw new Error("OpenAI Codex image generation completed but did not produce an image");
@@ -748,7 +769,7 @@ async function generateOpenAICodexImage(params: {
       resolveProviderHttpRequestConfig,
       sanitizeConfiguredModelProviderRequest,
     },
-    { toImageDataUrl },
+    { toImageDataUrl, sniffImageMimeType },
     { resolveClosestSize },
   ] = await Promise.all([
     import("openclaw/plugin-sdk/provider-http"),
@@ -843,6 +864,7 @@ async function generateOpenAICodexImage(params: {
       results.push(
         extractCodexImageGenerationResult({
           body: await readResponseBodyText(response),
+          sniffMime: sniffImageMimeType,
           model,
           outputFormat: req.outputFormat,
         }),
@@ -852,11 +874,10 @@ async function generateOpenAICodexImage(params: {
     }
   }
   const images = results.flatMap((result) => result.images);
-  const output = resolveOutputMime(req.outputFormat);
   return {
     images: images.map((image, index) =>
       Object.assign({}, image, {
-        fileName: `image-${index + 1}.${output.extension}`,
+        fileName: `image-${index + 1}${extensionForMime(image.mimeType)}`,
       }),
     ),
     model,

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -4,6 +4,7 @@ import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createSolidPngBuffer } from "../../plugin-sdk/test-helpers/image-fixtures.js";
 
 const taskRuntimeInternalMocks = vi.hoisted(() => {
   const mocks = {
@@ -666,6 +667,8 @@ describe("createImageGenerateTool", () => {
     const media = requireRecord(details.media, "media details");
     expect(details.provider).toBe("openai");
     expect(details.model).toBe("gpt-image-1");
+    expect(details).not.toHaveProperty("size");
+    expect(details).not.toHaveProperty("quality");
     expect(details.count).toBe(2);
     expect(media.mediaUrls).toEqual(["/tmp/generated-1.png", "/tmp/generated-2.png"]);
     expect(details.paths).toEqual(["/tmp/generated-1.png", "/tmp/generated-2.png"]);
@@ -1636,9 +1639,65 @@ describe("createImageGenerateTool", () => {
       },
     });
     const details = resultDetails(result);
-    expect(details.quality).toBe("low");
-    expect(details.outputFormat).toBe("jpeg");
+    expect(details.requested).toMatchObject({ quality: "low" });
+    expect(details.requested).toMatchObject({ outputFormat: "jpeg" });
   });
+
+  it.each([undefined, "auto", "unexpected"])(
+    "distinguishes requested settings from returned images with unknown quality %s",
+    async (unknownQuality) => {
+      vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
+        provider: "openai",
+        model: "gpt-image-2",
+        attempts: [],
+        ignoredOverrides: [],
+        images: [
+          {
+            buffer: createSolidPngBuffer(941, 1672, { r: 20, g: 50, b: 90 }),
+            mimeType: "image/png",
+            metadata: { size: "941x1672", quality: "medium", outputFormat: "png" },
+          },
+          {
+            buffer: createSolidPngBuffer(1024, 1024, { r: 20, g: 50, b: 90 }),
+            mimeType: "image/png",
+            metadata: { quality: unknownQuality },
+          },
+        ],
+      });
+      vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue({
+        path: "/tmp/generated.png",
+        id: "generated.png",
+        size: 5,
+        contentType: "image/png",
+      });
+      const tool = createToolWithPrimaryImageModel("openai/gpt-image-2");
+      const result = await tool.execute("call-observed-settings", {
+        prompt: "A plain blue rectangle",
+        count: 2,
+        size: "2160x3840",
+        quality: "high",
+        outputFormat: "png",
+      });
+      const details = resultDetails(result);
+      expect(details.requested).toMatchObject({
+        size: "2160x3840",
+        quality: "high",
+        outputFormat: "png",
+      });
+      expect(details.outputs).toEqual([
+        { size: "941x1672", reportedSize: "941x1672", quality: "medium", outputFormat: "png" },
+        { size: "1024x1024", outputFormat: "png" },
+      ]);
+      expect(resultText(result)).toContain("941x1672");
+      expect(resultText(result)).toContain("medium");
+      expect(resultText(result)).toContain("2160x3840");
+      expect(resultText(result)).toContain("quality unknown");
+      expect(details).not.toHaveProperty("size");
+      expect(details).not.toHaveProperty("quality");
+      expect(details.count).toBe(2);
+      expect(details.paths).toEqual(["/tmp/generated.png", "/tmp/generated.png"]);
+    },
+  );
 
   it("forwards generic fal provider options", async () => {
     const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
@@ -2070,7 +2129,7 @@ describe("createImageGenerateTool", () => {
     const details = resultDetails(result);
     expect(details.provider).toBe("openai");
     expect(details.model).toBe("gpt-image-1.5");
-    expect(details.outputFormat).toBe("png");
+    expect(details.requested).toMatchObject({ outputFormat: "png" });
   });
 
   it("includes MEDIA paths in content text so follow-up replies use the real saved file", async () => {
@@ -2239,7 +2298,7 @@ describe("createImageGenerateTool", () => {
     expect(generateArgs.aspectRatio).toBeUndefined();
     expect(generateArgs.resolution).toBeUndefined();
     expect(generateArgs.inferredResolution).toBe("4K");
-    expect(resultDetails(result).resolution).toBe("4K");
+    expect(resultDetails(result).requested).toMatchObject({ resolution: "4K" });
     expect(generateArgs.inputImages).toEqual([
       {
         buffer: Buffer.from("input-image"),
@@ -2583,7 +2642,7 @@ describe("createImageGenerateTool", () => {
     });
 
     const details = resultDetails(result);
-    expect(details.aspectRatio).toBe("16:9");
+    expect(details.requested).toEqual({ size: "1280x720" });
     expect(details.normalization).toEqual({
       aspectRatio: {
         applied: "16:9",

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -5,6 +5,7 @@ import { findCapabilityProviderById } from "../../../packages/media-generation-c
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveImageGenerationMaxInputImages } from "../../image-generation/capabilities.js";
+import { sniffImageMimeType } from "../../image-generation/image-assets.js";
 import {
   generateImage,
   listRuntimeImageGenerationProviders,
@@ -27,7 +28,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { parseImageGenerationModelRef } from "../../media-generation/model-ref.js";
 import { resolveCapabilityModelCandidates } from "../../media-generation/runtime-shared.js";
 import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
-import { getImageMetadata } from "../../media/media-services.js";
+import { getImageMetadata, readImageMetadataFromHeader } from "../../media/media-services.js";
 import { saveMediaBuffer } from "../../media/store.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
@@ -636,30 +637,34 @@ async function executeImageGenerationJob(params: {
     ignoredOverrides.length > 0
       ? `Ignored unsupported overrides for ${displayProvider}/${displayModel}: ${ignoredOverrides.map(formatIgnoredImageGenerationOverride).join(", ")}.`
       : undefined;
-  const normalizedSize =
-    result.normalization?.size?.applied ??
-    (typeof result.metadata?.normalizedSize === "string" && result.metadata.normalizedSize.trim()
-      ? result.metadata.normalizedSize
-      : undefined);
-  const normalizedAspectRatio =
-    result.normalization?.aspectRatio?.applied ??
-    (typeof result.metadata?.normalizedAspectRatio === "string" &&
-    result.metadata.normalizedAspectRatio.trim()
-      ? result.metadata.normalizedAspectRatio
-      : undefined);
-  const normalizedResolution =
-    result.normalization?.resolution?.applied ??
-    (typeof result.metadata?.normalizedResolution === "string" &&
-    result.metadata.normalizedResolution.trim()
-      ? result.metadata.normalizedResolution
-      : undefined);
-  const appliedResolution = result.appliedResolution ?? normalizedResolution;
-  const sizeTranslatedToAspectRatio =
-    result.normalization?.aspectRatio?.derivedFrom === "size" ||
-    (!normalizedSize &&
-      typeof result.metadata?.requestedSize === "string" &&
-      result.metadata.requestedSize === params.size &&
-      Boolean(normalizedAspectRatio));
+  const requested = {
+    ...(params.size ? { size: params.size } : {}),
+    ...(params.aspectRatio ? { aspectRatio: params.aspectRatio } : {}),
+    ...((params.resolution ?? params.inferredResolution)
+      ? { resolution: params.resolution ?? params.inferredResolution }
+      : {}),
+    ...(params.quality ? { quality: params.quality } : {}),
+    ...(params.outputFormat ? { outputFormat: params.outputFormat } : {}),
+    ...(params.background ? { background: params.background } : {}),
+  };
+  // Submission hints and normalization are not output evidence. Read dimensions
+  // from returned bytes; missing provider quality stays unknown, including auto.
+  const outputs = result.images.map((image) => {
+    const dimensions = readImageMetadataFromHeader(image.buffer);
+    const quality = image.metadata?.quality;
+    const reportedSize = image.metadata?.size;
+    const outputFormat = sniffImageMimeType(image.buffer, "").mimeType.replace(/^image\//u, "");
+    return {
+      ...(dimensions ? { size: `${dimensions.width}x${dimensions.height}` } : {}),
+      ...(typeof reportedSize === "string" && /^[1-9]\d{0,5}x[1-9]\d{0,5}$/u.test(reportedSize)
+        ? { reportedSize }
+        : {}),
+      ...(quality === "low" || quality === "medium" || quality === "high" ? { quality } : {}),
+      ...(SUPPORTED_OUTPUT_FORMATS.some((format) => format === outputFormat)
+        ? { outputFormat }
+        : {}),
+    };
+  });
 
   const mediaMaxBytes = resolveGeneratedMediaMaxBytes(params.effectiveCfg, "image");
   const savedImages = await persistGeneratedMediaBatch({
@@ -690,6 +695,19 @@ async function executeImageGenerationJob(params: {
   const lines = [
     `Generated ${savedImages.length} image${savedImages.length === 1 ? "" : "s"} with ${displayProvider}/${displayModel}.`,
     ...(warning ? [`Warning: ${warning}`] : []),
+    ...(Object.keys(requested).length > 0
+      ? [
+          `Requested: ${Object.entries(requested)
+            .map(
+              ([key, value]) => `${key}=${sanitizeGeneratedMediaDisplayText(value.slice(0, 64))}`,
+            )
+            .join(", ")}.`,
+        ]
+      : []),
+    ...outputs.map(
+      (output, index) =>
+        `Image ${index + 1} actual output: ${output.size ?? "size unknown"}, provider-reported quality ${output.quality ?? "unknown"}, format ${output.outputFormat ?? "unknown"}${output.reportedSize && output.reportedSize !== output.size ? `; provider reported size ${output.reportedSize}` : ""}.`,
+    ),
     ...formatGeneratedAttachmentLines(attachments),
   ];
   return {
@@ -716,16 +734,8 @@ async function executeImageGenerationJob(params: {
         pluralKey: "images",
         getResolvedInput: (entry) => entry.resolvedImage,
       }),
-      ...(appliedResolution ? { resolution: appliedResolution } : {}),
-      ...(normalizedSize || (params.size && !sizeTranslatedToAspectRatio)
-        ? { size: normalizedSize ?? params.size }
-        : {}),
-      ...(normalizedAspectRatio || params.aspectRatio
-        ? { aspectRatio: normalizedAspectRatio ?? params.aspectRatio }
-        : {}),
-      ...(params.quality ? { quality: params.quality } : {}),
-      ...(params.outputFormat ? { outputFormat: params.outputFormat } : {}),
-      ...(params.background ? { background: params.background } : {}),
+      requested,
+      outputs,
       ...(params.filename ? { filename: params.filename } : {}),
       ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
       attempts: result.attempts,


### PR DESCRIPTION
Related: #140295

## What Problem This Solves

Fixes an issue where users requesting image size and quality could see their requested settings reported as the generated result even when Codex returned a smaller image at a different quality.

## Why This Change Was Made

Preserve validated settings from the selected completed image event, keep the returned bytes, and derive the image file type from those bytes. Completed tool results now separate `requested` hints from per-image `outputs`; inline and background completion text includes actual header dimensions and provider-reported quality. Missing quality stays unknown, including `auto`. Pre-submission normalization remains separate.

This repairs reporting, not the service's choice of image resolution. It adds no regeneration, upscaling, auth changes, configuration options, or persistence changes.

## User Impact

Users and the completion agent can distinguish requested settings from what was returned while retaining all usable images. PNG output returned for a JPEG request now keeps the correct MIME type and filename, including batches. Completed result consumers should read request hints from `details.requested` and observed settings from `details.outputs` instead of the former ambiguous top-level hint fields.

## Evidence

- Before: regressions failed for both terminal-output and output-item images (missing metadata and request-derived MIME/filename), and the tool result lacked separate requested/observed settings.
- After: OpenAI image-provider tests **111 passed**, shared image runtime **21 passed**, tool tests **63 passed**. Coverage includes authoritative terminal snapshots, output-item recovery, batches, unknown/malformed quality, and real PNG header dimensions.
- Live subscription probe through the changed provider, using a simple blue-circle prompt: requested `2160x3840`, `high`, PNG; returned PNG **1024x1536**, provider-reported quality **low**, **967,504 bytes**. The returned dimensions and image headers agreed. This was one current account/request; it does not establish a universal subscription limit. No private reference images were used.
- Source baseline: `8dcf395fa7c67e423d4cbee18ba1a5b909d3c64d`. The same request-derived reporting is present in tag `v2026.9.1`.
- Direct Codex source inspection: `codex-rs/protocol/src/models.rs:1117-1140` and `codex-rs/codex-api/src/sse/responses.rs:325-339`, at `9e552e9d15ba52bed7077d5357f3e18e330f8f38`. These establish completed image items and payloads, not size/quality guarantees or a larger-artifact retrieval API.
- Other providers retain their request routing and bytes. Their tool results now report decoded dimensions and leave unavailable quality unknown. CLI generation already measures output dimensions and does not echo requested quality as observed quality.

Validation commands:

```sh
node scripts/run-vitest.mjs extensions/openai/image-generation-provider.test.ts src/agents/tools/image-generate-tool.test.ts src/image-generation/runtime.test.ts
node scripts/check-changed.mjs --base 8dcf395fa7c67e423d4cbee18ba1a5b909d3c64d
git diff --check
```

Independent P0–P2 autoreview returned one finding, dismissed after direct source verification: it conflated result-level request normalization (`requestedSize`/`normalizedSize`) with per-image response metadata. The public Images API parser does not write image-level size/quality; the new Codex producer does so only from returned events. No accepted findings remain.

Production delta: **+72/-41 (net +31)**; tests **+124/-5**. The retained growth carries bounded response settings and makes requested versus observed values visible; the old request-as-result projection and normalized-value inference stack were removed.

Latest-head CI (`42c694a6c2ac1d3df86a97bb408fb45c12da6330`): 164 successful, 40 skipped, 1 neutral, no failed or pending checks. The initial test typing and lint failures were fixed and rerun. The complete local `check:changed` pipeline passed, including core/plugin/test type checks, changed-file type-aware lint, dead-export scans, import cycles, and repository guards. The final provider suite passed all 111 tests after those test-only fixes. ClawSweeper found no actionable findings on the preceding head; the only subsequent change is the fixture-construction lint fix. No channel delivery/UI screenshot proof was performed; the live probe exercised the provider, and tool completion text was verified by focused tests.
