### PR TITLE
perf(tui): skip hidden thinking presentation work

### DIFF
--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -447,20 +447,31 @@ describe("extractTextFromMessage", () => {
     expect(text).toBe("Line 1\nLine 2\nLine 3");
   });
 
-  it("places thinking before content when included", () => {
-    const text = extractTextFromMessage(
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: "hello" },
-          { type: "thinking", thinking: "ponder" },
-        ],
-      },
-      { includeThinking: true },
-    );
+  it.each([
+    [undefined, "ponder", "hello", "hello"],
+    [false, "ponder", "hello", "hello"],
+    [true, "ponder", "hello", "[thinking]\nponder\n\nhello"],
+    [true, "ponder", "", "[thinking]\nponder"],
+    [true, "", "hello", "hello"],
+    [true, "", "", ""],
+    [false, "ponder", "", ""],
+  ] as const)(
+    "renders thinking=%s, thought=%j, content=%j",
+    (includeThinking, thought, content, expected) => {
+      const text = extractTextFromMessage(
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: ` \n${content}\t ` },
+            { type: "thinking", thinking: ` \t${thought}\n ` },
+          ],
+        },
+        { includeThinking },
+      );
 
-    expect(text).toBe("[thinking]\nponder\n\nhello");
-  });
+      expect(text).toBe(expected);
+    },
+  );
 
   it("sanitizes ANSI and control chars from string content", () => {
     const text = extractTextFromMessage({

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -331,18 +331,11 @@ export function composeThinkingAndContent(params: {
   contentText?: string;
   showThinking?: boolean;
 }) {
-  const thinkingText = params.thinkingText?.trim() ?? "";
+  const thinkingText = params.showThinking ? (params.thinkingText?.trim() ?? "") : "";
   const contentText = params.contentText?.trim() ?? "";
-  const parts: string[] = [];
-
-  if (params.showThinking && thinkingText) {
-    parts.push(`[thinking]\n${thinkingText}`);
-  }
-  if (contentText) {
-    parts.push(contentText);
-  }
-
-  return parts.join("\n\n").trim();
+  return thinkingText
+    ? `[thinking]\n${thinkingText}${contentText ? `\n\n${contentText}` : ""}`
+    : contentText;
 }
 
 type TuiAttachmentKind = "image" | "audio" | "video" | "file" | "media";
@@ -654,7 +647,8 @@ export function extractTextFromMessage(
   if (record.role === "assistant") {
     const contentText = extractAssistantRenderableContent(record);
     return composeThinkingAndContent({
-      thinkingText: extractThinkingFromMessage(record),
+      // History is stateless; the stream assembler retains hidden thinking for later toggles.
+      thinkingText: opts?.includeThinking ? extractThinkingFromMessage(record) : "",
       contentText:
         opts?.includeAttachments !== false
           ? formatTuiAssistantContent(record, contentText)

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -81,7 +81,7 @@ describe("TuiStreamAssembler", () => {
     );
   });
 
-  it("omits thinking when showThinking is false", () => {
+  it("retains hidden thinking across display toggles", () => {
     const assembler = new TuiStreamAssembler();
     const output = assembler.ingestDelta(
       "run-2",
@@ -89,6 +89,10 @@ describe("TuiStreamAssembler", () => {
       false,
     );
     expect(output).toBe("Visible");
+    expect(assembler.ingestDelta("run-2", messageWithContent([]), true)).toBe(
+      "[thinking]\nHidden\n\nVisible",
+    );
+    expect(assembler.ingestDelta("run-2", messageWithContent([]), false)).toBe("Visible");
   });
 
   it("tracks literal placeholder text as real displayable content until finalization", () => {


### PR DESCRIPTION
## What Problem This Solves

TUI history formatting currently collects, joins and trims thinking blocks even when thinking is hidden. The shared composer also allocates an array to join two already-trimmed optional sections.

## Why This Change Was Made

This skips hidden thinking preparation in the stateless formatter and composes the visible sections directly, removing six production lines. The stream assembler still eagerly retains thinking so later visibility toggles work. Text ordering, whitespace, errors and attachment output are preserved.

## User Impact

The fixed B0/C0/C1/B1 corpus retained and checked all 6,068 complete outcomes, including every 200-row array and public stream-state observation. Local median changes were 55–66% lower for large hidden-thinking fixtures and 9–13% lower for mixed 200-row hidden formatting. Mixed visible history improved 11–12%.

The tradeoffs remain visible: 14/82 medians, 13/82 means and 23/82 maxima worsened. The 32-block visible-thinking case regressed 20.55%/54.38% (+1.08/+2.65 µs). Plain history's forward mean rose 2.50% and maximum rose 85.88% despite its better median. These are descriptive local measurements from eight batches per case, not a universal TUI or Gateway speedup. Whole-child wall time was −15.72%/+0.42%, and sampled tree RSS increased in both directions; no memory or startup claim is made.

## Evidence

Validation passed: 132 focused tests, two existing real fake-backend PTY cases, all 29 changed checks and fresh managed P2 review with no findings. The PTY cases cover settings/history reload and history-gap rendering; the focused stream test covers hidden→visible→hidden retention. All measurement children and the parent are closed, source is restored, and all raw data—including adverse controls—is retained. No live provider or Gateway latency is claimed.
