### PR TITLE
refactor(ai): share native OpenAI client construction

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1,5 +1,5 @@
 // OpenAI completions provider adapts chat completions to the agent runtime.
-import OpenAI from "openai";
+import type OpenAI from "openai";
 import type {
   ChatCompletionAssistantMessageParam,
   ChatCompletionContentPartText,
@@ -8,7 +8,6 @@ import type {
   ChatCompletionSystemMessageParam,
 } from "openai/resources/chat/completions.js";
 import { getEnvApiKey } from "../env-api-keys.js";
-import { getAiTransportHost } from "../host.js";
 import { clampThinkingLevel } from "../model-utils.js";
 import { convertMessages, hasToolCallHistory } from "../openai-completions-messages.js";
 import { reasoningTagTextPolicy, type OpenAICompletionsOptions } from "../provider-options.js";
@@ -21,7 +20,6 @@ import { resolveOpenAIReasoningEffortMap } from "../transports/openai-reasoning-
 import {
   createOpenAIProviderAcceptanceHook,
   isOpenAICompletionsThinkingEnabled,
-  resolveOpenAIClientBaseUrl,
 } from "../transports/openai-transport-shared.js";
 import { resolveOpencodeSessionHeaders } from "../transports/session-affinity.js";
 import {
@@ -52,10 +50,10 @@ import {
 } from "../utils/stream-first-event-timeout.js";
 import { splitSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
 import { resolveCacheRetention } from "./cache-retention.js";
-import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { finalizeOpenAICompletionsToolCalls } from "./openai-completions-tool-calls.js";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.js";
+import { createOpenAIProviderClient } from "./openai-provider-client.js";
 import {
   resolveOpenAICompletionsResponseFormat,
   shouldOmitOllamaCompatResponseFormat,
@@ -329,32 +327,7 @@ function createClient(
     }
   }
 
-  // Merge options headers last so they can override defaults
-  if (optionsHeaders) {
-    Object.assign(headers, optionsHeaders);
-  }
-
-  const defaultHeaders =
-    model.provider === "cloudflare-ai-gateway"
-      ? {
-          ...headers,
-          Authorization: headers.Authorization ?? null,
-          "cf-aig-authorization": `Bearer ${apiKey}`,
-        }
-      : headers;
-
-  const baseUrl = isCloudflareProvider(model.provider)
-    ? resolveCloudflareBaseUrl(model)
-    : model.baseUrl;
-  return new OpenAI({
-    apiKey,
-    baseURL: resolveOpenAIClientBaseUrl(model, baseUrl),
-    dangerouslyAllowBrowser: true,
-    defaultHeaders,
-    maxRetries: 0,
-    // OpenAI supports custom fetch, so sentinels stay opaque until guarded egress.
-    fetch: getAiTransportHost().buildModelFetch(model),
-  });
+  return createOpenAIProviderClient(model, apiKey, headers, optionsHeaders);
 }
 
 function buildParams(

--- a/packages/ai/src/providers/openai-provider-client.ts
+++ b/packages/ai/src/providers/openai-provider-client.ts
@@ -1,0 +1,39 @@
+import OpenAI from "openai";
+import { getAiTransportHost } from "../host.js";
+import { resolveOpenAIClientBaseUrl } from "../transports/openai-transport-shared.js";
+import type { Model } from "../types.js";
+import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
+
+export function createOpenAIProviderClient(
+  model: Model<"openai-completions" | "openai-responses">,
+  apiKey: string,
+  headers: Record<string, string>,
+  optionsHeaders?: Record<string, string>,
+): OpenAI {
+  // Merge options headers last so they can override defaults
+  if (optionsHeaders) {
+    Object.assign(headers, optionsHeaders);
+  }
+
+  const defaultHeaders =
+    model.provider === "cloudflare-ai-gateway"
+      ? {
+          ...headers,
+          Authorization: headers.Authorization ?? null,
+          "cf-aig-authorization": `Bearer ${apiKey}`,
+        }
+      : headers;
+
+  const baseUrl = isCloudflareProvider(model.provider)
+    ? resolveCloudflareBaseUrl(model)
+    : model.baseUrl;
+  return new OpenAI({
+    apiKey,
+    baseURL: resolveOpenAIClientBaseUrl(model, baseUrl),
+    dangerouslyAllowBrowser: true,
+    defaultHeaders,
+    maxRetries: 0,
+    // OpenAI supports custom fetch, so sentinels stay opaque until guarded egress.
+    fetch: getAiTransportHost().buildModelFetch(model),
+  });
+}

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -1,12 +1,9 @@
 // OpenAI Responses provider adapts OpenAI response streams to the agent runtime.
-import OpenAI from "openai";
 import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
 import { getEnvApiKey } from "../env-api-keys.js";
-import { getAiTransportHost } from "../host.js";
 import type { BaseOpenAIStreamOptions } from "../provider-options.js";
 import type { OpenAIResponsesReplayMode } from "../transports/openai-responses-compaction-replay.js";
 import type { OpenAIResponsesRequestParams } from "../transports/openai-responses-contracts.js";
-import { resolveOpenAIClientBaseUrl } from "../transports/openai-transport-shared.js";
 import { resolveOpencodeSessionHeaders } from "../transports/session-affinity.js";
 import type {
   Context,
@@ -17,12 +14,12 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { resolveCacheRetention } from "./cache-retention.js";
-import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import {
   clampOpenAIPromptCacheKey,
   resolveOpenAIResponsesCacheParams,
 } from "./openai-prompt-cache.js";
+import { createOpenAIProviderClient } from "./openai-provider-client.js";
 import { supportsOpenAITemperature } from "./openai-reasoning-effort.js";
 import {
   applyCommonResponsesParams,
@@ -149,32 +146,7 @@ function createClient(
     headers["x-client-request-id"] = sessionId;
   }
 
-  // Merge options headers last so they can override defaults
-  if (optionsHeaders) {
-    Object.assign(headers, optionsHeaders);
-  }
-
-  const defaultHeaders =
-    model.provider === "cloudflare-ai-gateway"
-      ? {
-          ...headers,
-          Authorization: headers.Authorization ?? null,
-          "cf-aig-authorization": `Bearer ${apiKey}`,
-        }
-      : headers;
-
-  const baseUrl = isCloudflareProvider(model.provider)
-    ? resolveCloudflareBaseUrl(model)
-    : model.baseUrl;
-  return new OpenAI({
-    apiKey,
-    baseURL: resolveOpenAIClientBaseUrl(model, baseUrl),
-    dangerouslyAllowBrowser: true,
-    defaultHeaders,
-    maxRetries: 0,
-    // OpenAI supports custom fetch, so sentinels stay opaque until guarded egress.
-    fetch: getAiTransportHost().buildModelFetch(model),
-  });
+  return createOpenAIProviderClient(model, apiKey, headers, optionsHeaders);
 }
 
 function buildParams(


### PR DESCRIPTION
## What Problem This Solves

The native OpenAI Completions and Responses adapters duplicated their SDK client-construction policy. This production-deletion follow-up to #135868 gives that shared policy one owner while retaining the protocol-specific header decisions.

## Why This Change Was Made

Move the identical construction tails into an internal provider client factory. Each caller still rejects missing keys and prepares its existing Copilot/session headers, including the recent OpenCode session-header routing. The shared owner preserves options-header precedence, Cloudflare authentication and URL expansion, endpoint validation, zero SDK retries and the host's guarded fetch.

The removed tails were compared byte-for-byte before extraction. `git log -S 'Authorization: headers.Authorization ?? null'` reaches the shallow history boundary `e357203be57`; no older introduction claim is made. Managed transport constructors are intentionally unchanged because their query, retry and timeout policies differ.

| Removed duplicate | Surviving owner and coverage |
|---|---|
| Completions client-construction tail and its now-unused imports | `packages/ai/src/providers/openai-provider-client.ts:7`; authorization-header precedence remains covered at `openai-completions.test.ts:319`, with the full Completions compatibility suite retained. |
| Responses client-construction tail and its now-unused imports | Same factory; guarded fetch and retry configuration remain covered at `openai-responses.test.ts:73`, explicit-endpoint rejection at `:87`, and opaque Cloudflare auth at `:120`. |

## User Impact

No request or output behavior change. All caller-specific header policy remains in place; no dependency, endpoint default, retry, timeout or credential policy changes. No tests were changed or removed.

## Evidence

- 157 provider/header tests passed before and after.
- Full `node scripts/check-changed.mjs` passed.
- Full `pnpm build` passed, including package declarations, SDK export checks and Control UI build.
- Independent Codex review: scoped-clean, no actionable P0–P2 findings.
- Production +44 / −60 = **−16 lines**. Tests/support, tooling and docs: unchanged.
- Rebase onto the docs route repair preserved affected source and the lockfile.

ClawSweeper reviewed the exact head with no actionable findings or before-merge requests; no rank-up changes were needed. Exact-head CI run 34051242859 is green on attempt 2. The first attempt had a 120-second timeout in the unrelated CLI profile argument-validation case at `test/scripts/run-vitest-profile.test.ts:301`; one targeted same-head job retry passed without changing the test or timeout.
