### PR TITLE
fix(errors): preserve diagnostics and successful tool results

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -1,5 +1,8 @@
 // Codex tests cover dynamic tool execution plugin behavior.
-import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  embeddedAgentLog,
+  type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   handleDynamicToolCallWithTimeout,
@@ -759,6 +762,52 @@ describe("dynamic tool execution helpers", () => {
     });
   });
 
+  it("preserves a successful bridge result when its observer throws an unreadable error", async () => {
+    const observerError = Object.defineProperty(new Error(), "message", {
+      get() {
+        throw new Error("observer message getter escaped");
+      },
+    });
+    const onAgentToolResult = vi.fn(() => {
+      throw observerError;
+    });
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => {});
+    warn.mockClear();
+    const successful = {
+      success: true,
+      contentItems: [{ type: "inputText" as const, text: "committed effect" }],
+      executionStarted: true,
+      sideEffectEvidence: true,
+    };
+    const completedAction = vi.fn(async () => successful);
+    const result = await handleDynamicToolCallWithTimeout({
+      call: { ...dynamicCallContext, callId: "observer-success", tool: "exec", arguments: {} },
+      toolBridge: {
+        handleToolCall: async (_call, options) => {
+          const response = await completedAction();
+          options?.onAgentToolResult?.({
+            toolName: "exec",
+            result: { content: [{ type: "text", text: "committed effect" }], details: {} },
+            isError: false,
+          });
+          return response;
+        },
+      },
+      signal: new AbortController().signal,
+      timeoutMs: 1000,
+      onAgentToolResult,
+    });
+    expect(completedAction).toHaveBeenCalledOnce();
+    expect(onAgentToolResult).toHaveBeenCalledOnce();
+    expect(result).toBe(successful);
+    expect(result.success).toBe(true);
+    expect(result.sideEffectEvidence).toBe(true);
+    expect(result.diagnosticTerminalReason).toBeUndefined();
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      "onAgentToolResult handler failed: tool=exec error=Error",
+    );
+  });
+
   it("contains hostile rejected values while notifying the private observer", async () => {
     const hostileError = Object.defineProperty(new Error(), "message", {
       get() {
@@ -784,12 +833,26 @@ describe("dynamic tool execution helpers", () => {
       onAgentToolResult,
     });
 
-    expect(result).toMatchObject({
+    const protocolResponse = {
       success: false,
-      diagnosticTerminalReason: "failed",
-      contentItems: [{ type: "inputText", text: "OpenClaw dynamic tool call failed." }],
+      contentItems: [{ type: "inputText", text: "Error" }],
+    };
+    expect(result.diagnosticTerminalReason).toBe("failed");
+    expect(result).toMatchObject({
+      ...protocolResponse,
+      diagnosticTerminalType: "error",
+      executionStarted: true,
+      sideEffectEvidence: true,
     });
-    expect(onAgentToolResult).toHaveBeenCalledOnce();
+    expect(toCodexDynamicToolProtocolResponse(result)).toEqual(protocolResponse);
+    expect(onAgentToolResult).toHaveBeenCalledExactlyOnceWith({
+      toolName: "memory_search",
+      result: {
+        content: [{ type: "text", text: "Error" }],
+        details: { status: "failed", error: "Error" },
+      },
+      isError: true,
+    });
   });
 
   it("contains hostile abort reasons while notifying the private observer", async () => {

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -210,8 +210,9 @@ export async function handleDynamicToolCallWithTimeout(params: {
     try {
       params.onAgentToolResult?.(event);
     } catch (error) {
+      const message = formatToolExecutionErrorMessage(error, "Unknown error");
       embeddedAgentLog.warn(
-        `onAgentToolResult handler failed: tool=${params.call.tool} error=${String(error)}`,
+        `onAgentToolResult handler failed: tool=${params.call.tool} error=${message}`,
       );
     }
   };

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -3718,6 +3718,60 @@ describe("createCodexDynamicToolBridge", () => {
     });
   });
 
+  it("preserves successful execution when its observer throws an unreadable error", async () => {
+    const observerError = Object.defineProperty(new Error(), "message", {
+      get() {
+        throw new Error("observer message getter escaped");
+      },
+    });
+    const onAgentToolResult = vi.fn(() => {
+      throw observerError;
+    });
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => {});
+    warn.mockClear();
+    const rawResult = textToolResult("committed effect", { receipt: "effect-1" });
+    const execute = vi.fn(async () => rawResult);
+    const bridge = createCodexDynamicToolBridge({
+      tools: [createTool({ name: "exec", execute })],
+      signal: new AbortController().signal,
+    });
+    const outcome = await bridge
+      .handleToolCall(
+        {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "observer-success",
+          namespace: null,
+          tool: "exec",
+          arguments: { command: "write synthetic effect" },
+        },
+        { onAgentToolResult },
+      )
+      .then(
+        (result) => ({ result }),
+        (error: unknown) => ({ error }),
+      );
+    expect(execute).toHaveBeenCalledOnce();
+    expect(outcome).toMatchObject({
+      result: {
+        success: true,
+        diagnosticTerminalType: "completed",
+        executionStarted: true,
+        sideEffectEvidence: true,
+        contentItems: [{ type: "inputText", text: "committed effect" }],
+      },
+    });
+    expect(onAgentToolResult).toHaveBeenCalledExactlyOnceWith({
+      toolName: "exec",
+      result: rawResult,
+      isError: false,
+    });
+    expect(rawResult).toEqual(textToolResult("committed effect", { receipt: "effect-1" }));
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      "onAgentToolResult handler failed: tool=exec error=Error",
+    );
+  });
+
   it("reports thrown dynamic tool failures to the private result observer", async () => {
     const onAgentToolResult = vi.fn();
     const bridge = createCodexDynamicToolBridge({
@@ -4718,12 +4772,26 @@ describe("createCodexDynamicToolBridge", () => {
       { onAgentToolResult },
     );
 
-    expect(result).toMatchObject({
+    const protocolResponse = {
       success: false,
-      diagnosticTerminalReason: "failed",
-      contentItems: [{ type: "inputText", text: "OpenClaw dynamic tool call failed." }],
+      contentItems: [{ type: "inputText", text: "Error" }],
+    };
+    expect(result.diagnosticTerminalReason).toBe("failed");
+    expect(result).toMatchObject({
+      ...protocolResponse,
+      diagnosticTerminalType: "error",
+      executionStarted: true,
+      sideEffectEvidence: true,
     });
-    expect(onAgentToolResult).toHaveBeenCalledOnce();
+    expect(toCodexDynamicToolProtocolResponse(result)).toEqual(protocolResponse);
+    expect(onAgentToolResult).toHaveBeenCalledExactlyOnceWith({
+      toolName: "exec",
+      result: {
+        content: [{ type: "text", text: "Error" }],
+        details: { status: "failed", error: "Error" },
+      },
+      isError: true,
+    });
   });
 
   it("preserves report-only approval blocks for the outer lifecycle owner", async () => {

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -1085,9 +1085,8 @@ function notifyAgentToolResult(
       isError,
     });
   } catch (error) {
-    embeddedAgentLog.warn(
-      `onAgentToolResult handler failed: tool=${toolName} error=${String(error)}`,
-    );
+    const message = formatToolExecutionErrorMessage(error, "Unknown error");
+    embeddedAgentLog.warn(`onAgentToolResult handler failed: tool=${toolName} error=${message}`);
   }
 }
 

--- a/packages/normalization-core/src/error-coercion.test.ts
+++ b/packages/normalization-core/src/error-coercion.test.ts
@@ -1,4 +1,5 @@
 // Normalization core tests cover shared error coercion and formatting behavior.
+import { runInNewContext } from "node:vm";
 import { describe, expect, it, vi } from "vitest";
 import {
   coerceErrorMessage,
@@ -13,6 +14,75 @@ const keepText = (text: string): string => text;
 const format = (value: unknown): string => formatErrorMessage(value, { redact: keepText });
 
 describe("formatErrorMessage", () => {
+  it("retains both failures from actual async disposal", async () => {
+    const body = new Error("body secret");
+    const cleanup = new Error("cleanup secret");
+    const run = async () => {
+      await using resource = {
+        [Symbol.asyncDispose]: async () => {
+          throw cleanup;
+        },
+      };
+      void resource;
+      throw body;
+    };
+    const failure: unknown = await run().catch((error: unknown) => error);
+    const redact = vi.fn((text: string) => text.replaceAll("secret", "[REDACTED]"));
+
+    expect(formatErrorMessage(failure, { redact })).toContain(
+      "cleanup [REDACTED] | body [REDACTED]",
+    );
+    expect(redact).toHaveBeenCalledOnce();
+  });
+
+  it.each([0, false, null, undefined])("retains a downlevel suppressed value %s", (suppressed) => {
+    const failure = Object.assign(new Error("disposal failed"), {
+      name: "SuppressedError",
+      error: new Error("cleanup failed"),
+      suppressed,
+    });
+
+    expect(format(failure)).toBe(`disposal failed | cleanup failed | ${String(suppressed)}`);
+  });
+
+  it.each(
+    ["native", "vm", "tagged"].flatMap((kind) =>
+      ["message", "name"].map((field) => ({ kind, field })),
+    ),
+  )("isolates inaccessible $field on $kind errors", ({ kind, field }) => {
+    const error: unknown =
+      kind === "vm"
+        ? runInNewContext("new Error('')")
+        : kind === "native"
+          ? new Error("")
+          : { [Symbol.toStringTag]: "Error" };
+    Object.defineProperty(error, field, {
+      get() {
+        throw new Error("diagnostic field unavailable");
+      },
+    });
+    const redact = vi.fn(keepText);
+
+    expect(formatErrorMessage(error, { redact })).toBe("Error");
+    expect(redact).toHaveBeenCalledExactlyOnceWith("Error");
+    expect(format(new Error("outer failure", { cause: error }))).toBe("outer failure");
+  });
+
+  it("retains VM error messages, causes and aggregate branches", () => {
+    const foreign: unknown = runInNewContext(`
+      const leaf = Object.assign(new Error("native close failed"), {
+        code: "EIO",
+        name: "AggregateError",
+        errors: [new Error("display-only metadata")],
+      });
+      Object.assign(new AggregateError([leaf], "cleanup failed", {
+        cause: new Error("primary failure"),
+      }), { name: "CustomCleanupError" });
+    `);
+
+    expect(format(foreign)).toBe("cleanup failed | primary failure | native close failed | EIO");
+  });
+
   it("retains aggregate branches, nested causes and codes once despite cycles", () => {
     const native = Object.assign(new Error("native close failed"), { code: "EIO" });
     const cleanup = new AggregateError([native, native, "second failure"], "cleanup failed");

--- a/packages/normalization-core/src/error-coercion.ts
+++ b/packages/normalization-core/src/error-coercion.ts
@@ -8,12 +8,49 @@ export type FormatErrorMessageOptions = {
 const STRUCTURED_ERROR_OWNED_FIELDS = new Set(["cause", "message", "name", "stack"]);
 const STRUCTURED_ERROR_PROTOTYPE_FIELDS = new Set(["__proto__", "constructor", "prototype"]);
 
-function readProperty(value: object, key: "cause" | "code" | "status" | "errors"): unknown {
+function isErrorObject(value: unknown): value is Error {
+  try {
+    if (value instanceof Error) {
+      return true;
+    }
+    // VM and worker realms have distinct Error constructors; retain their diagnostic fields.
+    return Object.prototype.toString.call(value) === "[object Error]";
+  } catch {
+    return false;
+  }
+}
+
+function isAggregateErrorObject(error: Error): boolean {
+  try {
+    if (error instanceof AggregateError) {
+      return true;
+    }
+    for (let proto = Object.getPrototypeOf(error); proto; proto = Object.getPrototypeOf(proto)) {
+      const constructor: unknown = Object.getOwnPropertyDescriptor(proto, "constructor")?.value;
+      if (typeof constructor === "function" && constructor.name === "AggregateError") {
+        return true;
+      }
+    }
+  } catch {
+    // An opaque prototype must not promote arbitrary errors-array metadata into causes.
+  }
+  return false;
+}
+
+function readProperty(
+  value: object,
+  key: "cause" | "code" | "status" | "errors" | "message" | "name" | "error" | "suppressed",
+): unknown {
   try {
     return (value as Record<string, unknown>)[key];
   } catch {
     return undefined;
   }
+}
+
+function readErrorText(value: object, key: "message" | "name"): string | undefined {
+  const field = readProperty(value, key);
+  return typeof field === "string" ? field : undefined;
 }
 
 function formatStatusAndCode(value: unknown): string | undefined {
@@ -75,8 +112,8 @@ function stringifyUnknown(value: unknown): string {
 /** Formats unknown errors with cause/aggregate details, structured codes, and secret redaction. */
 export function formatErrorMessage(value: unknown, options: FormatErrorMessageOptions): string {
   let formatted: string;
-  if (value instanceof Error) {
-    formatted = value.message || value.name || "Error";
+  if (isErrorObject(value)) {
+    formatted = readErrorText(value, "message") || readErrorText(value, "name") || "Error";
     const seenMessages = new Set<string>([formatted]);
     const appendCauseMessage = (message: string | undefined): void => {
       if (!message || seenMessages.has(message)) {
@@ -103,17 +140,23 @@ export function formatErrorMessage(value: unknown, options: FormatErrorMessageOp
       }
     }
     const causes = collectErrorGraphCandidates(value, (current) => {
-      if (!(current instanceof Error)) {
+      if (!isErrorObject(current)) {
         return [];
       }
       const cause = readProperty(current, "cause");
-      const errors =
-        current instanceof AggregateError ? readProperty(current, "errors") : undefined;
-      return [cause || undefined, ...(Array.isArray(errors) ? errors : [])];
+      const errors = isAggregateErrorObject(current) ? readProperty(current, "errors") : undefined;
+      // Downlevel await-using emits a named Error; both failure fields exist even for nullish throws.
+      const suppressed =
+        readErrorText(current, "name") === "SuppressedError"
+          ? [readProperty(current, "error"), readProperty(current, "suppressed")].map((failure) =>
+              failure == null ? String(failure) : failure,
+            )
+          : [];
+      return [cause || undefined, ...(Array.isArray(errors) ? errors : []), ...suppressed];
     });
     for (const cause of causes.slice(1)) {
-      if (cause instanceof Error) {
-        appendCauseErrorMessage(cause.message);
+      if (isErrorObject(cause)) {
+        appendCauseErrorMessage(readErrorText(cause, "message"));
         const code = readProperty(cause, "code");
         if (typeof code === "string" || typeof code === "number") {
           appendCauseMessage(String(code));

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -8,6 +8,7 @@ import {
   resetGatewayWorkAdmission,
   tryBeginGatewayRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
+import * as errorFormatting from "./errors.js";
 type RestartModule = typeof import("./restart.js");
 const managedSuccessorOwner = {
   kind: "managed-update-handoff",
@@ -837,40 +838,62 @@ describe("infra runtime", () => {
       }
     });
 
-    it("rolls back prepared restart state when emission is rejected", async () => {
-      const beforeEmit = vi.fn(async () => {});
-      const unformattableFailure = new Error();
-      Object.defineProperty(unformattableFailure, "message", {
-        get() {
-          throw new Error("message read failed");
-        },
-      });
-      const afterEmitRejected = vi.fn(async () => {
-        throw unformattableFailure;
-      });
-      const afterEmitFailed = vi.fn(async () => {});
-      vi.spyOn(process, "kill").mockImplementation(() => {
-        throw new Error("no signal");
-      });
+    it.each([
+      { failure: "message getter", expectedError: "Error" },
+      { failure: "formatter", expectedError: "Unknown error" },
+      { failure: "logger", expectedError: "Error" },
+    ])(
+      "rolls back prepared restart state when emission is rejected despite $failure failure",
+      async ({ failure, expectedError }) => {
+        const beforeEmit = vi.fn(async () => {});
+        const hookFailure = new Error();
+        Object.defineProperty(hookFailure, "message", {
+          get() {
+            throw new Error("message read failed");
+          },
+        });
+        const formatter = vi.spyOn(errorFormatting, "formatErrorMessage");
+        if (failure === "formatter") {
+          formatter.mockImplementationOnce(() => {
+            throw new Error("formatting failed");
+          });
+        }
+        if (failure === "logger") {
+          restartLogWarnMock.mockImplementationOnce(() => {
+            throw new Error("logging failed");
+          });
+        }
+        const afterEmitRejected = vi.fn(async () => {
+          throw hookFailure;
+        });
+        const afterEmitFailed = vi.fn(async () => {});
+        vi.spyOn(process, "kill").mockImplementation(() => {
+          throw new Error("no signal");
+        });
 
-      scheduleGatewaySigusr1Restart({
-        delayMs: 0,
-        emitHooks: { beforeEmit, afterEmitRejected, afterEmitFailed },
-      });
-      await vi.advanceTimersByTimeAsync(0);
+        scheduleGatewaySigusr1Restart({
+          delayMs: 0,
+          emitHooks: { beforeEmit, afterEmitRejected, afterEmitFailed },
+        });
+        await vi.advanceTimersByTimeAsync(0);
 
-      expect(beforeEmit).toHaveBeenCalledTimes(1);
-      expect(afterEmitRejected).toHaveBeenCalledTimes(1);
-      expect(afterEmitFailed).toHaveBeenCalledTimes(1);
-      expect(restartLogWarnMock).toHaveBeenCalledWith(
-        "restart hook callback failed; restart will continue",
-        {
-          hook: "afterEmitRejected",
-          error: "Unknown error",
-        },
-      );
-      expect(isGatewayWorkAdmissionClosed()).toBe(false);
-    });
+        expect(beforeEmit).toHaveBeenCalledTimes(1);
+        expect(afterEmitRejected).toHaveBeenCalledTimes(1);
+        expect(afterEmitFailed).toHaveBeenCalledTimes(1);
+        expect(formatter).toHaveBeenCalledExactlyOnceWith(hookFailure);
+        expect(restartLogWarnMock).toHaveBeenCalledExactlyOnceWith(
+          "restart hook callback failed; restart will continue",
+          {
+            hook: "afterEmitRejected",
+            error: expectedError,
+          },
+        );
+        expect(isGatewayWorkAdmissionClosed()).toBe(false);
+        const root = tryBeginGatewayRootWorkAdmission();
+        expect(root).not.toBeNull();
+        root?.release();
+      },
+    );
 
     it("drains parked emit hooks when a hooked deferral wins the emission race", async () => {
       // Gateway-tool parks sentinel/continuation hooks; config-reload deferral


### PR DESCRIPTION
VM-created errors could lose their messages and causes, async disposal could hide both failures, and throwing diagnostic getters could interrupt error reporting. In the Codex tool bridge, an observer’s unreadable error could also escape logging after a tool succeeded, discard the response, and notify the observer again.

Recognize cross-realm errors and suppressed disposal failures in the shared formatter, retaining its existing graph traversal, deduplication and caller-owned redaction. Route the two Codex observer diagnostics through the existing safe formatter so successful results and execution evidence survive reporting failure. Native response fields, retry and authority rules stay unchanged. Restart and Codex consumer tests distinguish safe getter handling from actual reporting failures and verify exact observer, completion and protocol facts.

Validation: all 12 formatter regressions failed before repair, then 81 formatter/adapter tests passed. The restart follow-up passed 91 tests; the Codex follow-up passed 243 tests. Independent P0–P2 reviews, changed-code gates, typed lint and the existing line-limit ratchet passed. CI exposed the obsolete consumer expectations; those are repaired without weakening cleanup or failure assertions.

Four direct Node 24.19 VM/native-disposal scenarios passed with the fix. A separate plain Node source probe drove the actual bridge and watchdog with an exclusive temporary-file write: all four current ordinary/hostile-observer cases kept one write, one notification and the successful response. The baseline direct bridge wrote once but notified twice and rejected; the baseline combined watchdog remained a passing sibling control. Processes exited naturally with no unhandled rejection, and loaded source hashes differed only in the two baseline producer substitutions. This is source-level tool-host proof, without a native Codex app-server or external provider/authentication run. The unchanged wire contract was checked in the pinned official Codex [response schema](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/protocol/src/dynamic_tools.rs#L58) and [dynamic tool handler](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/core/src/tools/handlers/dynamic.rs#L153).

Extracted from #135599. Production +43 lines for the demonstrated error-formatting contracts; the two observer repairs are net zero. Tests +224. No plugin lifecycle implementation dependency, new public API, configuration or storage schema.
