### PR TITLE
perf(cli): deduplicate diagnostic issues by exact key

### DIFF
--- a/src/commands/status-all/diagnosis.test.ts
+++ b/src/commands/status-all/diagnosis.test.ts
@@ -106,6 +106,50 @@ describe("status-all diagnosis port checks", () => {
     gatewayMocks.summarizeLogTail.mockImplementation((lines: string[]) => lines);
   });
 
+  it("keeps first config issue locations and exact pairs before applying the display cap", async () => {
+    const params = createBaseParams([]);
+    const first = { path: "a", message: "b:c", sourceFile: "legacy.json", line: 7 };
+    const repeated = { ...first, sourceFile: "current.json", line: 9 };
+    params.snap = {
+      exists: true,
+      valid: false,
+      path: "config.json",
+      legacyIssues: [first, { path: "a:b", message: "c" }, first],
+      issues: [
+        repeated,
+        { path: "a", message: "different" },
+        ...Array.from({ length: 11 }, (_, index) => ({
+          path: `field${index}`,
+          message: "invalid",
+        })),
+        repeated,
+      ],
+    };
+    const original = structuredClone(params.snap);
+
+    await appendStatusAllDiagnosis(params);
+
+    const start = params.lines.indexOf("! Config: config.json");
+    const end = params.lines.indexOf("✓ Secret diagnostics (0)");
+    expect(params.lines.slice(start, end)).toEqual([
+      "! Config: config.json",
+      "  - legacy.json:7 — a: b:c",
+      "  - a:b: c",
+      "  - a: different",
+      "  - field0: invalid",
+      "  - field1: invalid",
+      "  - field2: invalid",
+      "  - field3: invalid",
+      "  - field4: invalid",
+      "  - field5: invalid",
+      "  - field6: invalid",
+      "  - field7: invalid",
+      "  - field8: invalid",
+      "  … +2 more",
+    ]);
+    expect(params.snap).toEqual(original);
+  });
+
   it("retains queue warnings from a successful gateway health snapshot", async () => {
     const params = createBaseParams([]);
     params.health = {

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -26,6 +26,7 @@ import {
   formatPluginCompatibilityNotice,
   type PluginCompatibilityNotice,
 } from "../../plugins/status.js";
+import { dedupeByKey } from "../../shared/dedupe-by-key.js";
 import { formatDeliveryQueueHealthLine } from "../health-format.js";
 import type {
   resolveStatusGatewayHealthSafe,
@@ -202,11 +203,10 @@ export async function appendStatusAllDiagnosis(params: {
   if (params.snap) {
     const status = !params.snap.exists ? "fail" : params.snap.valid ? "ok" : "warn";
     emitCheck(`Config: ${params.snap.path ?? "(unknown)"}`, status);
-    const issues = [...(params.snap.legacyIssues ?? []), ...(params.snap.issues ?? [])];
-    // Legacy and current schema checks can report the same path/message pair.
-    const uniqueIssues = issues.filter(
-      (issue, index) =>
-        issues.findIndex((x) => x.path === issue.path && x.message === issue.message) === index,
+    // Length-prefix the path to keep arbitrary path/message pairs distinct.
+    const uniqueIssues = dedupeByKey(
+      [...(params.snap.legacyIssues ?? []), ...(params.snap.issues ?? [])],
+      (issue) => `${issue.path.length}:${issue.path}${issue.message}`,
     );
     for (const issue of uniqueIssues.slice(0, 12)) {
       lines.push(`  ${formatConfigIssueLine(issue, "-")}`);


### PR DESCRIPTION
## What Problem This Solves

`status --all` combines legacy and current config issues, then repeatedly scans the combined list to remove duplicate path/message pairs. Large distinct lists pay quadratic work even though the report displays only 12 items; the complete distinct count is still needed for the hidden-item summary.

## Why This Change Was Made

Use the existing first-wins keyed dedupe helper with a length-prefixed path/message key. The prefix keeps arbitrary string pairs distinct while preserving the first issue object and source location, insertion order, terminal formatting, the 12-item cap and hidden count. Production LOC stays neutral; no config, dependency, schema or validation policy changes.

## User Impact

The gain is localized. Median full-appender time improved 31–35% for 100 distinct issues and about 85% for 1,000 distinct issues in both orders. For 1,000 entries collapsing to 12 pairs, it regressed 22–43% (+26–45 µs). Smaller rows and controls were mixed: 13 of 22 paired row medians were adverse, including movement in the unchanged null-snapshot control. All outcomes are retained; this is not an overall status or Gateway latency claim. The earlier JSON-key experiment is preserved separately and was not pooled into these results.

## Evidence

Validation: 22 diagnosis tests, including the pair/order/cap preservation case, all 29 selected changed-file checks, and independent Codex review through P2 passed. A fixed four-phase comparison exercised the complete async appender with real synthetic log I/O: all 4,444 full results matched their expected outputs, and all 528 batch means were independently recomputed.
