### PR TITLE
refactor(ui): reuse Workshop protocol types

### DIFF
--- a/ui/src/lib/skill-workshop/index.ts
+++ b/ui/src/lib/skill-workshop/index.ts
@@ -1,13 +1,10 @@
-import type { SkillsProposalsListResultSchema } from "@openclaw/gateway-protocol";
-import type { Static } from "typebox";
+import type {
+  SkillProposalEvaluation,
+  SkillsProposalsListResult,
+} from "@openclaw/gateway-protocol";
 import type { computeLineDiff } from "../chat/tool-call-diff.ts";
 
-export type SkillWorkshopProposalStatus =
-  | "pending"
-  | "applied"
-  | "rejected"
-  | "quarantined"
-  | "stale";
+export type SkillWorkshopProposalStatus = SkillsProposalsListResult["proposals"][number]["status"];
 
 type SkillWorkshopFile = {
   path: string;
@@ -15,23 +12,14 @@ type SkillWorkshopFile = {
   contents: string;
 };
 
-export type SkillWorkshopEvaluationFinding = {
-  ruleId: string;
-  severity: "info" | "warn" | "critical";
-  message: string;
-  file?: string;
-  line?: number;
-};
+type SkillWorkshopEvaluationResult = Extract<
+  SkillProposalEvaluation["outcomes"][number],
+  { status: "completed" }
+>["result"];
 
-type SkillWorkshopEvaluationResult = {
-  summary?: string;
-  findings?: SkillWorkshopEvaluationFinding[];
-  metrics?: Record<string, string | number | boolean>;
-  evaluatorVersion?: string;
-  mode?: string;
-  decision?: "pass" | "revise" | "block";
-  decisionReason?: string;
-};
+export type SkillWorkshopEvaluationFinding = NonNullable<
+  SkillWorkshopEvaluationResult["findings"]
+>[number];
 
 export type SkillWorkshopEvaluationOutcome = {
   pluginId: string;
@@ -42,15 +30,7 @@ export type SkillWorkshopEvaluationOutcome = {
   error?: string;
 };
 
-export type SkillWorkshopEvaluation = {
-  id: string;
-  proposedVersion: string;
-  revisionHash: string;
-  trigger: "manual" | "apply";
-  startedAt: string;
-  completedAt: string;
-  correlationId?: string;
-  targetTreeSha256?: string;
+export type SkillWorkshopEvaluation = Omit<SkillProposalEvaluation, "outcomes"> & {
   outcomes: SkillWorkshopEvaluationOutcome[];
 };
 
@@ -87,9 +67,9 @@ export type SkillWorkshopProposal = {
 export type SkillWorkshopAction = "apply" | "evaluate" | "revise" | "reject";
 export type SkillWorkshopMode = "skills" | "suggestions";
 
-export type SkillWorkshopInstalledSkill = Static<
-  typeof SkillsProposalsListResultSchema
->["installedSkills"][number] & { read?: SkillWorkshopInstalledSelection };
+export type SkillWorkshopInstalledSkill = SkillsProposalsListResult["installedSkills"][number] & {
+  read?: SkillWorkshopInstalledSelection;
+};
 
 export type SkillWorkshopInstalledSelection =
   | { status: "idle" }


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

The Control UI maintains duplicate Skill Workshop status and evaluation definitions already owned by the Gateway protocol. Keeping both copies in sync adds maintenance debt in the maintainer-directed deletion campaign.

## Why This Change Was Made

Derive proposal status, evaluation metadata/results/findings, and installed-skill rows from existing exported protocol types. Preserve the UI's intentionally looser outcome type and its local view/read state. All exported UI aliases retain the same structural shapes.

## User Impact

No behavior or appearance change. This removes 20 production lines (+16/−36) from one file, with no tests, tooling, or docs delta. No tests or coverage are removed.

## Evidence

- Compiler comparison against the real protocol exports: all 14 aliases retain identical recursive shapes, including optionality, nested fields, arrays, and primitive unions.
- Before/after full-file JavaScript transpilation is byte-identical; both runtime functions are unchanged.
- `node scripts/run-vitest.mjs --config ui/vitest.config.ts ui/src/lib/skill-workshop ui/src/pages/skill-workshop`: 7 suites, 72 tests passed.
- Full `node scripts/check-changed.mjs`: passed (core-test types, UI types, i18n, dead exports, lint).
- Independent Codex P0–P2 autoreview of the one-file patch: scoped-clean, no accepted/actionable findings.
- No new runtime imports, published API, dependency, lockfile, baseline, or schema changes. Erased type-only declarations do not require visual captures or a separate build.
