### PR TITLE
fix: clear stale progress cards when resetting a conversation

### DIFF
--- a/docs/tools/progress-card.md
+++ b/docs/tools/progress-card.md
@@ -83,6 +83,8 @@ Call `progress_card` with both parts absent or empty to remove the current card:
 
 An empty plan plus empty or whitespace-only Markdown also clears it. A successful clear returns `Progress card cleared`. Channel previews remove the checklist and its status, keep other activity, and delete an otherwise empty draft. A later card update can create a new draft.
 
+A successful `/new` or `/reset` also clears the previous task’s card. Automatic resets that preserve recent conversation context keep the card.
+
 ## Where the card appears
 
 Channels with progress drafts show the latest checklist in active `partial`, `block`, and `progress` previews, subject to their preview settings and line limits. Card updates supply a completion count, or `Progress updated` for a note without steps; they do not copy the note's Markdown or HTML into tool summaries. Telegram uses native checkboxes with `channels.telegram.richMessages: true` and readable HTML checklists otherwise. See [Streaming and chunking](/concepts/streaming#progress-draft-rendering).

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -50,7 +50,6 @@ import {
   readReferencedSessionIdsAfterTargetMutation,
 } from "./session-accessor.sqlite-lifecycle-state.js";
 import { refreshSqliteSessionPlannerStatisticsBestEffort } from "./session-accessor.sqlite-maintenance.js";
-import { loadTranscriptEventsFromDatabase } from "./session-accessor.sqlite-read.js";
 import {
   createHistoricalGenerationReclamationPlan,
   createLifecycleArtifactReclamationPlan,
@@ -59,6 +58,7 @@ import {
   runSqliteSessionReclamation,
   shouldDeleteSqliteSessionEntryLifecycle,
 } from "./session-accessor.sqlite-reclamation.js";
+import { appendSessionResetBoundaryInTransaction } from "./session-accessor.sqlite-reset.js";
 import {
   cloneSessionEntry,
   resolveSqliteReadScope,
@@ -68,15 +68,9 @@ import {
   toDatabaseOptions,
 } from "./session-accessor.sqlite-scope.js";
 import {
-  appendTranscriptEventsInTransaction,
-  ensureTranscriptHeader,
-} from "./session-accessor.sqlite-transcript-store.js";
-import {
   collectAdmissionProtectedSessionIds,
   kickSessionHistoryDiskBudgetMaintenance,
 } from "./session-history-eviction.js";
-import { buildSessionResetBoundaryEvent } from "./session-reset-boundary-event.js";
-import { resolveResetBoundaryHeaderCwd } from "./transcript-header.js";
 import type { InternalSessionEntry as SessionEntry } from "./types.js";
 
 // Single-target lifecycle owner: cleanup, reset, guarded delete, and trusted rollback.
@@ -232,25 +226,12 @@ export async function resetSessionEntryLifecycle(
               sessionId: current.entry.sessionId,
               sessionKey: current.sessionKey,
             };
-            // Reset can be the first append. Write the header in this guarded
-            // transaction, or the next turn rejects the new transcript as legacy.
-            ensureTranscriptHeader(
+            appendSessionResetBoundaryInTransaction(
               transactionDb,
               boundaryScope,
-              resolveResetBoundaryHeaderCwd(current.entry, params.resetBoundary.cwd),
+              current.entry,
+              params.resetBoundary,
             );
-            const event = buildSessionResetBoundaryEvent({
-              events: loadTranscriptEventsFromDatabase(transactionDb, current.entry.sessionId, {
-                projection: "reset-boundary",
-              }),
-              ...params.resetBoundary,
-            });
-            const appended = appendTranscriptEventsInTransaction(transactionDb, boundaryScope, [
-              event,
-            ]);
-            if (appended !== 1) {
-              throw new Error(`Failed to append reset boundary for ${current.sessionKey}`);
-            }
           }
           writeSessionEntry(transactionDb, params.target.canonicalKey, nextEntry, {
             previousEntry: current?.entry ?? null,

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -71,8 +71,8 @@ import {
   applySessionEntryMaintenance,
   finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort,
 } from "./session-accessor.sqlite-maintenance.js";
-import { loadTranscriptEventsFromDatabase } from "./session-accessor.sqlite-read.js";
 import { applySessionEntryExactReplacements } from "./session-accessor.sqlite-replacement-projection.js";
+import { appendSessionResetBoundaryInTransaction } from "./session-accessor.sqlite-reset.js";
 import {
   cloneSessionEntry,
   resolveSqliteScope,
@@ -80,14 +80,8 @@ import {
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
 } from "./session-accessor.sqlite-scope.js";
-import {
-  appendTranscriptEventsInTransaction,
-  ensureTranscriptHeader,
-} from "./session-accessor.sqlite-transcript-store.js";
-import { buildSessionResetBoundaryEvent } from "./session-reset-boundary-event.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import type { ResolvedSessionMaintenanceConfig } from "./store-maintenance.js";
-import { resolveResetBoundaryHeaderCwd } from "./transcript-header.js";
 import type { SessionEntry } from "./types.js";
 
 type SessionArchiveRuntime = typeof import("../../gateway/session-archive.runtime.js");
@@ -408,25 +402,12 @@ export async function applySessionEntryLifecycleMutation(params: {
         }
         if (resetBoundary && expectedEntry?.sessionId) {
           const boundaryScope = { ...resolved, sessionId: expectedEntry.sessionId, sessionKey };
-          // The batched reset must initialize an empty transcript before its
-          // boundary, just like the single-target lifecycle writer.
-          ensureTranscriptHeader(
+          appendSessionResetBoundaryInTransaction(
             transactionDb,
             boundaryScope,
-            resolveResetBoundaryHeaderCwd(expectedEntry, resetBoundary.cwd),
+            expectedEntry,
+            resetBoundary,
           );
-          const event = buildSessionResetBoundaryEvent({
-            events: loadTranscriptEventsFromDatabase(transactionDb, expectedEntry.sessionId, {
-              projection: "reset-boundary",
-            }),
-            ...resetBoundary,
-          });
-          const appended = appendTranscriptEventsInTransaction(transactionDb, boundaryScope, [
-            event,
-          ]);
-          if (appended !== 1) {
-            throw new Error(`Failed to append reset boundary for ${sessionKey}`);
-          }
         }
         writeSessionEntry(transactionDb, sessionKey, entry, {
           allowStoredAliases: params.allowCanonicalRepair === true,

--- a/src/config/sessions/session-accessor.sqlite-reset-progress-card.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-progress-card.test.ts
@@ -1,0 +1,182 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { onProgressCardReset } from "../../session-cards/progress-card-events.js";
+import {
+  readSessionProgressCard,
+  writeSessionProgressCard,
+} from "../../session-cards/progress-card-store.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import {
+  applySessionEntryLifecycleMutation,
+  loadSessionEntry,
+  loadTranscriptEvents,
+  replaceSessionEntry,
+  resetSessionEntryLifecycle,
+} from "./session-accessor.js";
+import type { SessionResetBoundaryRequest } from "./session-reset-boundary-event.js";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+
+describe("SQLite reset progress-card lifecycle", () => {
+  let testState: OpenClawTestState;
+  let storePath: string;
+  let stopObserving: () => void;
+  const observedReset = vi.fn();
+  const sessionKey = "agent:main:reset-progress";
+  const sessionId = "reset-progress-window";
+  const initialEntry = { sessionId, updatedAt: 10, lifecycleRevision: "original" };
+
+  beforeEach(async () => {
+    testState = await createOpenClawTestState({
+      prefix: "openclaw-reset-progress-",
+      layout: "state-only",
+    });
+    fs.mkdirSync(testState.sessionsDir(), { recursive: true });
+    storePath = path.join(testState.sessionsDir(), "sessions.json");
+    await replaceSessionEntry({ sessionKey, storePath }, initialEntry);
+    observedReset.mockReset();
+    stopObserving = onProgressCardReset((event) => {
+      observedReset(event, readSessionProgressCard(database().db, sessionKey));
+    });
+  });
+
+  afterEach(async () => {
+    stopObserving();
+    closeOpenClawAgentDatabasesForTest();
+    await testState.cleanup();
+  });
+
+  function database() {
+    const target = resolveSqliteTargetFromSessionStorePath(storePath);
+    if (!target.path) {
+      throw new Error("expected SQLite database path");
+    }
+    return openOpenClawAgentDatabase({ agentId: target.agentId ?? "main", path: target.path });
+  }
+
+  async function reset(kind: "single" | "projection", boundary: SessionResetBoundaryRequest) {
+    const entry = { sessionId, updatedAt: 20, lifecycleRevision: "reset" };
+    if (kind === "single") {
+      return resetSessionEntryLifecycle({
+        storePath,
+        target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+        resetBoundary: { ...boundary, cwd: "/tmp/reset-progress-workspace" },
+        buildNextEntry: () => entry,
+      });
+    }
+    return applySessionEntryLifecycleMutation({
+      storePath,
+      upserts: [
+        { sessionKey, entry, resetBoundary: { ...boundary, cwd: "/tmp/reset-progress-workspace" } },
+      ],
+      skipMaintenance: true,
+    });
+  }
+
+  it.each(
+    (["single", "projection"] as const).flatMap((kind) =>
+      [
+        { shape: "markdown", input: { markdown: "Previous work" } },
+        {
+          shape: "active plan",
+          input: { steps: [{ step: "Previous task", status: "in_progress" as const }] },
+        },
+        {
+          shape: "completed plan and markdown",
+          input: {
+            markdown: "Previous work",
+            steps: [{ step: "Previous task", status: "completed" as const }],
+          },
+        },
+      ].map(({ shape, input }) => ({ kind, shape, input })),
+    ),
+  )(
+    "clears $shape through $kind reset and preserves revision ordering after reopen",
+    async ({ kind, input }) => {
+      const db = database();
+      writeSessionProgressCard(db.db, sessionKey, input);
+      await replaceSessionEntry(
+        { sessionKey: "agent:main:other-progress", storePath },
+        { sessionId: "other-window", updatedAt: 10 },
+      );
+      writeSessionProgressCard(db.db, "agent:main:other-progress", { markdown: "Other task" });
+
+      await reset(kind, { context: "clear", reason: "reset" });
+
+      expect(observedReset).toHaveBeenCalledExactlyOnceWith({ agentId: "main", sessionKey }, null);
+      closeOpenClawAgentDatabasesForTest();
+      const reopened = database();
+      expect(readSessionProgressCard(reopened.db, sessionKey)).toBeNull();
+      expect(readSessionProgressCard(reopened.db, "agent:main:other-progress")?.markdown).toBe(
+        "Other task",
+      );
+      const replacement = writeSessionProgressCard(reopened.db, sessionKey, {
+        steps: [{ step: "New task", status: "completed" }],
+      });
+      expect(replacement).toMatchObject({ card: { revision: 3 } });
+      expect(writeSessionProgressCard(reopened.db, sessionKey, { expectedRevision: 1 })).toEqual(
+        replacement,
+      );
+    },
+  );
+
+  it.each(["single", "projection"] as const)(
+    "does not provision progress-card storage for a %s reset without a card",
+    async (kind) => {
+      database().db.exec("DROP TABLE IF EXISTS session_progress_cards");
+      await reset(kind, { context: "clear", reason: "new" });
+      expect(
+        database()
+          .db.prepare("SELECT name FROM sqlite_master WHERE name = 'session_progress_cards'")
+          .get(),
+      ).toBeUndefined();
+      expect(observedReset).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["single", "projection"] as const)(
+    "preserves the card across a %s continuity reset",
+    async (kind) => {
+      writeSessionProgressCard(database().db, sessionKey, {
+        markdown: "Work continues",
+        steps: [{ step: "Finish task", status: "in_progress" }],
+      });
+      const before = readSessionProgressCard(database().db, sessionKey);
+      await reset(kind, { context: "preserve-tail", reason: "idle" });
+      expect(readSessionProgressCard(database().db, sessionKey)).toEqual(before);
+      expect(observedReset).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["single", "projection"] as const)(
+    "rolls back the card together with a failed %s reset",
+    async (kind) => {
+      const db = database();
+      writeSessionProgressCard(db.db, sessionKey, { markdown: "Uncommitted reset" });
+      const before = readSessionProgressCard(db.db, sessionKey);
+      // Fail the entry write after the boundary append, inside the same transaction.
+      db.db.exec(`CREATE TEMP TRIGGER reject_reset BEFORE UPDATE OF entry_json ON session_nodes
+        BEGIN SELECT RAISE(ABORT, 'injected reset commit failure'); END;`);
+      try {
+        await expect(reset(kind, { context: "clear", reason: "new" })).rejects.toThrow(
+          "injected reset commit failure",
+        );
+      } finally {
+        db.db.exec("DROP TRIGGER reject_reset");
+      }
+      expect(readSessionProgressCard(db.db, sessionKey)).toEqual(before);
+      expect(observedReset).not.toHaveBeenCalled();
+      expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject(initialEntry);
+      expect(await loadTranscriptEvents({ sessionKey, sessionId, storePath })).not.toContainEqual(
+        expect.objectContaining({ type: "reset" }),
+      );
+    },
+  );
+});

--- a/src/config/sessions/session-accessor.sqlite-reset.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset.ts
@@ -1,0 +1,47 @@
+import { emitProgressCardReset } from "../../session-cards/progress-card-events.js";
+import {
+  readSessionProgressCard,
+  writeSessionProgressCard,
+} from "../../session-cards/progress-card-store.js";
+import {
+  deferOpenClawAgentPostCommitPublication,
+  type OpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import type { SessionResetBoundaryWrite } from "./session-accessor.lifecycle-types.js";
+import { loadTranscriptEventsFromDatabase } from "./session-accessor.sqlite-read.js";
+import type { ResolvedTranscriptScope } from "./session-accessor.sqlite-scope.js";
+import {
+  appendTranscriptEventsInTransaction,
+  ensureTranscriptHeader,
+} from "./session-accessor.sqlite-transcript-store.js";
+import { buildSessionResetBoundaryEvent } from "./session-reset-boundary-event.js";
+import { resolveResetBoundaryHeaderCwd } from "./transcript-header.js";
+import type { InternalSessionEntry } from "./types.js";
+
+export function appendSessionResetBoundaryInTransaction(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  entry: InternalSessionEntry,
+  boundary: SessionResetBoundaryWrite,
+): void {
+  // Reset may be the first append; initialize its header in the same guarded
+  // transaction so the resulting transcript is readable even before another turn.
+  ensureTranscriptHeader(database, scope, resolveResetBoundaryHeaderCwd(entry, boundary.cwd));
+  const event = buildSessionResetBoundaryEvent({
+    events: loadTranscriptEventsFromDatabase(database, scope.sessionId, {
+      projection: "reset-boundary",
+    }),
+    ...boundary,
+  });
+  if (appendTranscriptEventsInTransaction(database, scope, [event]) !== 1) {
+    throw new Error(`Failed to append reset boundary for ${scope.sessionKey}`);
+  }
+  // Explicit context clearing retires the task card atomically with the reset.
+  // Continuity resets preserve it; unused stores must not gain a companion table.
+  if (boundary.context === "clear" && readSessionProgressCard(database.db, scope.sessionKey)) {
+    writeSessionProgressCard(database.db, scope.sessionKey, {});
+    deferOpenClawAgentPostCommitPublication(database, () =>
+      emitProgressCardReset({ agentId: scope.agentId, sessionKey: scope.sessionKey }),
+    );
+  }
+}

--- a/src/gateway/server-methods/progress-card.authorization.test.ts
+++ b/src/gateway/server-methods/progress-card.authorization.test.ts
@@ -3,6 +3,7 @@ import { setRuntimeConfigSnapshot } from "../../config/io.js";
 import {
   deleteSessionEntryLifecycle,
   loadSessionEntry,
+  resetSessionEntryLifecycle,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -21,6 +22,95 @@ import { createProgressCardHandlers } from "./progress-card.js";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
 
 describe("progress card request authorization", () => {
+  it("rejects a retained run write after reset while lazy preparation is pending", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const cfg = rolePolicyConfig();
+      setRuntimeConfigSnapshot(cfg, cfg);
+      const target = { sessionKey: "agent:main:progress-reset", agentId: "main" };
+      const client = { ...roleClient("view", "owner"), connId: "owner" };
+      const entry = {
+        sessionId: "preserved-session-id",
+        updatedAt: 1,
+        visibility: "draft" as const,
+        createdActor: {
+          type: "human" as const,
+          source: "profile" as const,
+          id: client.authenticatedUserProfile!.profileId,
+        },
+      };
+      await upsertSessionEntryCore(target, entry);
+      progressCardStore.put(target.sessionKey, { markdown: "original card" }, target.agentId);
+      const resolved = resolveSessionSharingTarget({ cfg, ...target });
+      if (!resolved) {
+        throw new Error("expected the admitted persisted session");
+      }
+      const broadcast = vi.fn();
+      const context = {
+        getRuntimeConfig: () => cfg,
+        broadcast,
+        logGateway: { warn: vi.fn() },
+        resolveGatewayContext: (): GatewayRequestContext => context,
+      } as unknown as GatewayRequestContext;
+      const loaded = createDeferredCore();
+      const release = createDeferredCore();
+      let callerActive = true;
+      const respond = vi.fn<RespondFn>();
+      const pending = handleGatewayRequest({
+        req: {
+          type: "req",
+          id: "retained-progress-write",
+          method: "progressCard.put",
+          params: { ...target, markdown: "late old-run update" },
+        },
+        client,
+        context,
+        isWebchatConnect: () => false,
+        respond,
+        // Model the host-owned closure carried by in-process tool dispatch.
+        sessionMutationCommitGuard: () => {
+          if (!callerActive) {
+            throw new Error("agent tool caller authority is no longer active");
+          }
+        },
+        extraHandlers: createLazyCoreHandlers({
+          methods: ["progressCard.put"],
+          loadHandlers: async () => {
+            loaded.resolve();
+            await release.promise;
+            return createProgressCardHandlers();
+          },
+        }),
+      });
+      const rejected = expect(pending).rejects.toThrow("caller authority is no longer active");
+      try {
+        await Promise.race([
+          loaded.promise,
+          pending.then(() => {
+            throw new Error("request completed before lazy preparation");
+          }),
+        ]);
+        // Run liveness is independent of the session ID retained by explicit reset.
+        callerActive = false;
+        await resetSessionEntryLifecycle({
+          storePath: resolved.storePath,
+          target: { canonicalKey: resolved.canonicalKey, storeKeys: resolved.storeKeys },
+          resetBoundary: { context: "clear", reason: "reset", cwd: "/tmp/progress-reset" },
+          buildNextEntry: () => ({ ...entry, updatedAt: 2 }),
+        });
+        expect(loadSessionEntry(target)?.sessionId).toBe(entry.sessionId);
+        expect(progressCardStore.get(target.sessionKey, target.agentId)).toBeNull();
+        release.resolve();
+        await rejected;
+        expect(progressCardStore.get(target.sessionKey, target.agentId)).toBeNull();
+        expect(respond).not.toHaveBeenCalled();
+        expect(broadcast).not.toHaveBeenCalled();
+      } finally {
+        release.resolve();
+        await rejected;
+      }
+    });
+  });
+
   it.each(
     (["global", "agent:work:progress-authorization"] as const).flatMap((sessionKey) =>
       (["progressCard.get", "progressCard.put"] as const).flatMap((method) =>

--- a/src/gateway/server-runtime-subscriptions.test-helpers.ts
+++ b/src/gateway/server-runtime-subscriptions.test-helpers.ts
@@ -1,0 +1,29 @@
+import { vi } from "vitest";
+import type { SubsystemLogger } from "../logging/subsystem.js";
+import {
+  createChatRunState,
+  createSessionEventSubscriberRegistry,
+  createSessionMessageSubscriberRegistry,
+} from "./server-chat-state.js";
+import type { startGatewayEventSubscriptions } from "./server-runtime-subscriptions.js";
+
+type SubscriptionParams = Parameters<typeof startGatewayEventSubscriptions>[0];
+
+export function createSubscriptionParams(log: SubsystemLogger): SubscriptionParams {
+  return {
+    log,
+    broadcast: vi.fn(),
+    broadcastToConnIds: vi.fn(),
+    nodeSendToSession: vi.fn(),
+    agentRunSeq: new Map(),
+    ...(() => {
+      const chatRunState = createChatRunState();
+      return { chatRunState, toolEventRecipients: chatRunState.toolEventRecipients };
+    })(),
+    sessionEventSubscribers: createSessionEventSubscriberRegistry(),
+    sessionMessageSubscribers: createSessionMessageSubscriberRegistry(),
+    chatAbortControllers: new Map(),
+    restartRecoveryCandidates: new Map(),
+    terminalSessions: { closeTaskSessions: vi.fn() },
+  };
+}

--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -47,12 +47,8 @@ import {
   registerChatAbortController,
   type ChatAbortControllerEntry,
 } from "./chat-abort.js";
-import {
-  createChatRunState,
-  createSessionEventSubscriberRegistry,
-  createSessionMessageSubscriberRegistry,
-} from "./server-chat-state.js";
 import type { TaskEventPayload } from "./server-methods/task-summary.js";
+import { createSubscriptionParams } from "./server-runtime-subscriptions.test-helpers.js";
 import { TerminalSessionManager } from "./terminal/session-manager.js";
 import {
   agentTerminalOwner,
@@ -228,24 +224,7 @@ const sessionTaskDefaults = {
   notifyPolicy: "silent",
 } as const;
 
-function createParams(): SubscriptionParams {
-  return {
-    log: mockLog,
-    broadcast: vi.fn(),
-    broadcastToConnIds: vi.fn(),
-    nodeSendToSession: vi.fn(),
-    agentRunSeq: new Map(),
-    ...(() => {
-      const chatRunState = createChatRunState();
-      return { chatRunState, toolEventRecipients: chatRunState.toolEventRecipients };
-    })(),
-    sessionEventSubscribers: createSessionEventSubscriberRegistry(),
-    sessionMessageSubscribers: createSessionMessageSubscriberRegistry(),
-    chatAbortControllers: new Map(),
-    restartRecoveryCandidates: new Map(),
-    terminalSessions: { closeTaskSessions: vi.fn() },
-  };
-}
+const createParams = () => createSubscriptionParams(mockLog);
 
 describe("startGatewayEventSubscriptions", () => {
   let unsubs: ReturnType<typeof startGatewayEventSubscriptions> | undefined;

--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -27,6 +27,7 @@ import {
   resetGatewayWorkAdmission,
   tryBeginGatewaySuspendAdmission,
 } from "../process/gateway-work-admission.js";
+import { emitProgressCardReset } from "../session-cards/progress-card-events.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import {
   emitSessionTranscriptUpdate,
@@ -280,6 +281,21 @@ describe("startGatewayEventSubscriptions", () => {
     resetAgentEventsForTest();
     resetTaskRegistryForTests({ persist: false });
     configureExecutionIdentityAdmissionSink(() => false)();
+  });
+
+  it("invalidates reset cards for their owner and stops on unsubscribe", () => {
+    const params = createParams();
+    unsubs = startGatewayEventSubscriptions(params);
+    emitProgressCardReset({ sessionKey: "global", agentId: "work" });
+    expect(params.broadcast).toHaveBeenCalledExactlyOnceWith(
+      "progressCard.changed",
+      { sessionKey: "agent:work:global", revision: null },
+      { sessionKeys: ["global"], agentId: "work" },
+    );
+    unsubs.lifecycleUnsub();
+    vi.mocked(params.broadcast).mockClear();
+    emitProgressCardReset({ sessionKey: "global", agentId: "work" });
+    expect(params.broadcast).not.toHaveBeenCalled();
   });
 
   it("broadcasts suspension immediately and stops with the gateway lifecycle", () => {

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -26,6 +26,7 @@ import { onTrustedToolExecutionEvent } from "../infra/diagnostic-events.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import type { SubsystemLogger } from "../logging/subsystem.js";
 import { onGatewaySuspendAdmissionChange } from "../process/gateway-work-admission.js";
+import { onProgressCardReset } from "../session-cards/progress-card-events.js";
 import { onSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { onInternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { createLazyPromise, createLazyPromiseLoader } from "../shared/lazy-runtime.js";
@@ -50,6 +51,7 @@ import { mapTaskSummary, type TaskEventPayload } from "./server-methods/task-sum
 import { defaultSessionCompanionContextReader } from "./session-companion-context.js";
 import { createSessionCompanion } from "./session-companion.js";
 import { createSessionLifecyclePersistenceOwner } from "./session-lifecycle-persistence-owner.js";
+import { sessionObserverScopeKey } from "./session-observer-model.js";
 import { createSessionObserver } from "./session-observer.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "./session-request-agent.js";
 import { resolveTaskRequesterSessionTarget } from "./task-session-access.js";
@@ -529,10 +531,18 @@ export function startGatewayEventSubscriptions(params: {
       context: { sessionKey: evt.sessionKey },
     });
   });
+  const unsubscribeCardReset = onProgressCardReset(({ sessionKey, agentId }) => {
+    params.broadcast(
+      "progressCard.changed",
+      { sessionKey: sessionObserverScopeKey(sessionKey, agentId), revision: null },
+      { sessionKeys: [sessionKey], agentId },
+    );
+  });
   const unsubscribeSuspension = onGatewaySuspendAdmissionChange((phase) => {
     params.broadcast("gateway.suspension", { phase });
   });
   const lifecycleUnsub = () => {
+    unsubscribeCardReset();
     unsubscribeSuspension();
     unsubscribeProfileChanges();
     unsubscribeLifecycle();

--- a/src/session-cards/progress-card-events.ts
+++ b/src/session-cards/progress-card-events.ts
@@ -1,0 +1,17 @@
+import { resolveGlobalSet } from "../shared/global-singleton.js";
+import { notifyListeners, registerListener } from "../shared/listeners.js";
+
+type ProgressCardReset = { agentId: string; sessionKey: string };
+const listeners = resolveGlobalSet<(event: ProgressCardReset) => void>(
+  Symbol.for("openclaw.progressCardResetListeners"),
+  "close-and-restart",
+);
+
+export function onProgressCardReset(listener: (event: ProgressCardReset) => void): () => void {
+  return registerListener(listeners, listener);
+}
+
+/** Reset owners publish only after their card and context changes commit together. */
+export function emitProgressCardReset(event: ProgressCardReset): void {
+  notifyListeners(listeners, event);
+}


### PR DESCRIPTION
Closes #140356

## What Problem This Solves

Fixes an issue where users resetting a conversation would still see the previous task’s progress card, even after reloading the Control UI.

## Why This Change Was Made

Both chat and RPC resets now share the same transactional reset-boundary operation. Explicit context clearing reuses the existing card-clear contract, retaining its monotonically increasing revision, and publishes an owner-scoped refresh notification only after commit. Failed resets roll back both changes. Continuity resets preserve the card, and sessions without cards do not create the lazy companion table.

This follows the reset lifecycle requested in the issue. No schema, migration, protocol, or configuration changes. Existing run-authority checks continue to reject writes from closed pre-reset work; no additional writer identity or fallback was introduced.

## User Impact

After a successful `/new` or `/reset`, the previous task’s card disappears from connected clients and stays cleared after reload. Other sessions and automatic continuity resets retain their cards.

## Evidence

- Reproduced on base `3d602cd4172fb9abdef8070eb2f8e80ae24c3fbe`: both reset-owner regressions failed because a fresh database read returned the old card.
- **62 focused tests passed**, covering Markdown-only, unfinished/completed plans, both reset owners, fresh reads, revision ordering, rollback/no notification on failure, untouched sessions, lazy storage, retained-run writes, and scoped notification cleanup.
- **Live isolated Gateway + Chromium:** submitted `/reset` through the composer, observed the reset acknowledgment and card removal, reloaded the page, and confirmed `progressCard.get` returned `null` from another client. Repeated with a Markdown-only card through `sessions.reset`; the open UI refreshed and the fresh read returned `null`. No model/provider call was required.
- Runtime build and all locally planned changed-file checks passed across the initial run and follow-up reruns. The initial run stopped on the subscription test file’s 1000-line lint limit; its unchanged parameter fixture was extracted, all 26 subscription tests were rerun successfully, and the affected checks plus every remaining planned check passed. Production and all core-test typechecks, changed-file lint, unused-export scans, and database/runtime guards passed. Exact-head GitHub CI is still running.
- Fresh autoreview: scoped-clean, no actionable P0–P2 findings. The subsequent test-fixture extraction was reviewed separately and also scoped-clean.
- Production delta: **+36 lines**; tests/test support: **+296**; docs: **+2**. The duplicated reset append paths were consolidated; remaining growth provides atomic card retirement and post-commit notification with Gateway-lifetime cleanup.

The video shows the fixed flow, including page reload; the pre-fix failure is captured by the regression tests above. All displayed data is synthetic.

https://github.com/user-attachments/assets/05c10bd3-654c-4006-b52a-ac673bde4540

<details>
<summary>Focused validation commands and dependency boundary</summary>

```sh
node scripts/run-vitest.mjs \
  src/config/sessions/session-accessor.sqlite-reset-progress-card.test.ts \
  src/config/sessions/session-accessor.sqlite-reset-header.test.ts \
  src/gateway/server-methods/progress-card.authorization.test.ts \
  src/gateway/server-runtime-subscriptions.test.ts \
  src/session-cards/progress-card-store.test.ts
```

The expanded reset-card table was rerun separately after the initial combined pass (12 cases passed). Other focused suites were unchanged.

The retained-run test explicitly models the host authority closure; it does not claim to test the complete run-interruption implementation. Directly inspected OpenClaw’s in-process commit guard and native/harness caller binding, plus sibling Codex `codex-rs/core/src/tools/handlers/dynamic.rs:171–244`: Codex transports dynamic calls; the OpenClaw host owns write fencing. No Codex code changes.

Telegram-specific delivery was not exercised; the shared persistence owner and the actual Control UI/RPC flows were exercised.
</details>

## Review follow-up

ClawSweeper found no actionable correctness or security findings. Its requested secops-owner involvement for the authorization regression test remains a maintainer step before merge. The attached video URL was rechecked successfully (HTTP 200); the automated reviewer could not retrieve it in its environment. No merge is requested by this change submission.
