### PR TITLE
fix: truncated OpenCode Go completions stream after tools reports a generic agent failure

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-result.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.test.ts
@@ -28,6 +28,7 @@ function createResultFixture(params?: {
   didSendViaMessagingTool?: boolean;
   yieldDetected?: boolean;
   yieldAcknowledgment?: string;
+  assistantTexts?: readonly string[];
   toolMetas?: Array<{
     toolName: string;
     toolCallId?: string;
@@ -71,7 +72,7 @@ function createResultFixture(params?: {
     messagesSnapshot: settled.messagesSnapshot,
   };
   const subscription = {
-    assistantTexts: [],
+    assistantTexts: [...(params?.assistantTexts ?? [])],
     didSendDeterministicApprovalPrompt: () => false,
     didSendViaMessagingTool: () => params?.didSendViaMessagingTool ?? false,
     getAcceptedSessionSpawns: () => [],
@@ -316,6 +317,12 @@ describe("attempt result projection", () => {
       expected: false,
     },
     {
+      label: "openai-completions truncated stream",
+      source: "prompt" as const,
+      error: new Error("Stream ended without finish_reason"),
+      expected: true,
+    },
+    {
       label: "precheck socket failure",
       source: "precheck" as const,
       error: Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }),
@@ -361,6 +368,12 @@ describe("attempt result projection", () => {
       errorCode: undefined,
       expected: false,
     },
+    {
+      label: "an incomplete completions stream",
+      errorMessage: "Stream ended without finish_reason",
+      errorCode: undefined,
+      expected: true,
+    },
   ])(
     "captures settled-turn context from $label reported by the provider assistant=$expected",
     ({ errorMessage, errorCode, expected }) => {
@@ -371,6 +384,67 @@ describe("attempt result projection", () => {
           ...(errorCode ? { errorCode } : {}),
         }),
         messagesSnapshot: settledToolMessages(),
+      });
+
+      expect(Boolean(result.settledTurnFinalizationContext)).toBe(expected);
+    },
+  );
+
+  it.each([
+    {
+      label: "only pre-tool commentary",
+      assistantTexts: ["Checking the post-reboot state."],
+      messagesSnapshot: [
+        makeAssistantMessageFixture({
+          stopReason: "toolUse",
+          errorMessage: undefined,
+          timestamp: 1,
+          content: [
+            { type: "text", text: "Checking the post-reboot state." },
+            { type: "toolCall", id: "call-read", name: "read", arguments: {} },
+          ],
+        }),
+        ...settledToolMessages(),
+        makeAssistantMessageFixture({
+          stopReason: "error",
+          errorMessage: "Stream ended without finish_reason",
+          timestamp: 3,
+          content: [],
+        }),
+      ],
+      expected: true,
+    },
+    {
+      label: "unattributed visible text",
+      assistantTexts: ["here is the answer"],
+      messagesSnapshot: settledToolMessages(),
+      expected: false,
+    },
+    {
+      label: "post-tool authored text",
+      assistantTexts: ["here is the answer"],
+      messagesSnapshot: [
+        ...settledToolMessages(),
+        makeAssistantMessageFixture({
+          stopReason: "stop",
+          errorMessage: undefined,
+          timestamp: 2,
+          content: [{ type: "text", text: "here is the answer" }],
+        }),
+      ],
+      expected: false,
+    },
+  ])(
+    "keeps truncated-stream settled recovery for $label=$expected",
+    ({ assistantTexts, messagesSnapshot, expected }) => {
+      const result = completeResult({
+        terminal: {
+          kind: "failed",
+          source: "prompt",
+          error: new Error("Stream ended without finish_reason"),
+        },
+        assistantTexts,
+        messagesSnapshot,
       });
 
       expect(Boolean(result.settledTurnFinalizationContext)).toBe(expected);

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -3,7 +3,6 @@
  */
 import { freezeDiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
 import { isTransientNetworkError } from "../../../infra/retryable-network-errors.js";
-import type { AssistantMessage } from "../../../llm/types.js";
 import {
   buildAgentHookContextChannelFields,
   buildAgentHookContextIdentityFields,
@@ -11,7 +10,6 @@ import {
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
 import { isCloudCodeAssistFormatError } from "../../embedded-agent-helpers.js";
 import type { subscribeEmbeddedAgentSession } from "../../embedded-agent-subscribe.js";
-import { extractEmbeddedAssistantText } from "../../embedded-agent-utils.js";
 import { INCOMPLETE_ASSISTANT_STREAM_RE } from "../../failover/message-patterns.js";
 import type { AgentRuntimeModelAttempt } from "../../runtime-plan/types.js";
 import { markCoreTtsAttemptResult } from "../../tools/tts-tool-result-provenance.js";
@@ -27,6 +25,7 @@ import {
   buildAttemptReplayMetadata,
   hasAttemptTerminalState,
 } from "./attempt-terminal-evidence.js";
+import { hasComposedVisibleAnswerAfterSettledTools } from "./incomplete-turn-classification.js";
 import { shouldTreatEmptyAssistantReplyAsSilent } from "./incomplete-turn-recovery.js";
 import { resolveSilentToolResultReplyPayload } from "./incomplete-turn-resolution.js";
 import type { EmbeddedAttemptClientToolCallSlot, EmbeddedRunAttemptResult } from "./types.js";
@@ -118,50 +117,7 @@ function isTransientSettledTurnFailure(failure: unknown): boolean {
     typeof failure.message === "string"
       ? failure.message.trim()
       : "";
-  return message.length > 0 && INCOMPLETE_ASSISTANT_STREAM_RE.test(message);
-}
-
-function isAssistantSnapshotMessage(
-  message: EmbeddedRunAttemptResult["messagesSnapshot"][number],
-): message is AssistantMessage {
-  return message.role === "assistant";
-}
-
-function readAssistantSnapshotText(
-  message: EmbeddedRunAttemptResult["messagesSnapshot"][number],
-): string {
-  if (!isAssistantSnapshotMessage(message)) {
-    return "";
-  }
-  return extractEmbeddedAssistantText(message).trim();
-}
-
-function hasComposedVisibleAnswerAfterSettledTools(params: {
-  assistantTexts: readonly string[];
-  messagesSnapshot: EmbeddedRunAttemptResult["messagesSnapshot"];
-}): boolean {
-  const lastToolResultIndex = params.messagesSnapshot.findLastIndex(
-    (message) => message.role === "toolResult",
-  );
-  if (lastToolResultIndex < 0) {
-    return params.assistantTexts.some((text) => text.trim().length > 0);
-  }
-  if (
-    params.messagesSnapshot
-      .slice(lastToolResultIndex + 1)
-      .some((message) => readAssistantSnapshotText(message).length > 0)
-  ) {
-    return true;
-  }
-  const preToolText = params.messagesSnapshot
-    .slice(0, lastToolResultIndex)
-    .map((message) => readAssistantSnapshotText(message))
-    .filter((text) => text.length > 0)
-    .join("\n");
-  return params.assistantTexts.some((text) => {
-    const trimmed = text.trim();
-    return trimmed.length > 0 && !preToolText.includes(trimmed);
-  });
+  return INCOMPLETE_ASSISTANT_STREAM_RE.test(message);
 }
 
 function normalizeEmbeddedAttemptToolMetas(

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -3,6 +3,7 @@
  */
 import { freezeDiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
 import { isTransientNetworkError } from "../../../infra/retryable-network-errors.js";
+import type { AssistantMessage } from "../../../llm/types.js";
 import {
   buildAgentHookContextChannelFields,
   buildAgentHookContextIdentityFields,
@@ -10,6 +11,8 @@ import {
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
 import { isCloudCodeAssistFormatError } from "../../embedded-agent-helpers.js";
 import type { subscribeEmbeddedAgentSession } from "../../embedded-agent-subscribe.js";
+import { extractEmbeddedAssistantText } from "../../embedded-agent-utils.js";
+import { INCOMPLETE_ASSISTANT_STREAM_RE } from "../../failover/message-patterns.js";
 import type { AgentRuntimeModelAttempt } from "../../runtime-plan/types.js";
 import { markCoreTtsAttemptResult } from "../../tools/tts-tool-result-provenance.js";
 import { log } from "../logger.js";
@@ -85,13 +88,14 @@ function resolveSettledTurnFinalizationContext(params: {
     terminal.timedOutDuringCompaction ||
     terminal.timedOutDuringToolExecution ||
     (terminal.promptErrorSource !== null && terminal.promptErrorSource !== "prompt") ||
-    !isTransientNetworkError(failure)
+    !isTransientSettledTurnFailure(failure)
   ) {
     return undefined;
   }
-  // A turn that already produced visible text has nothing to finalize, and a
-  // turn without a tool result never settled one.
-  if (!params.assistantTexts.every((text) => !text.trim())) {
+  // Pre-tool commentary is not a final answer. Only text after the last tool
+  // result, or subscription text that cannot be attributed to that commentary,
+  // means the turn already composed something to keep.
+  if (hasComposedVisibleAnswerAfterSettledTools(params)) {
     return undefined;
   }
   if (!params.messagesSnapshot.some((message) => message.role === "toolResult")) {
@@ -101,6 +105,63 @@ function resolveSettledTurnFinalizationContext(params: {
     source: "openclaw-transcript",
     messages: Object.freeze([...params.messagesSnapshot]),
   };
+}
+
+function isTransientSettledTurnFailure(failure: unknown): boolean {
+  if (isTransientNetworkError(failure)) {
+    return true;
+  }
+  const message =
+    typeof failure === "object" &&
+    failure !== null &&
+    "message" in failure &&
+    typeof failure.message === "string"
+      ? failure.message.trim()
+      : "";
+  return message.length > 0 && INCOMPLETE_ASSISTANT_STREAM_RE.test(message);
+}
+
+function isAssistantSnapshotMessage(
+  message: EmbeddedRunAttemptResult["messagesSnapshot"][number],
+): message is AssistantMessage {
+  return message.role === "assistant";
+}
+
+function readAssistantSnapshotText(
+  message: EmbeddedRunAttemptResult["messagesSnapshot"][number],
+): string {
+  if (!isAssistantSnapshotMessage(message)) {
+    return "";
+  }
+  return extractEmbeddedAssistantText(message).trim();
+}
+
+function hasComposedVisibleAnswerAfterSettledTools(params: {
+  assistantTexts: readonly string[];
+  messagesSnapshot: EmbeddedRunAttemptResult["messagesSnapshot"];
+}): boolean {
+  const lastToolResultIndex = params.messagesSnapshot.findLastIndex(
+    (message) => message.role === "toolResult",
+  );
+  if (lastToolResultIndex < 0) {
+    return params.assistantTexts.some((text) => text.trim().length > 0);
+  }
+  if (
+    params.messagesSnapshot
+      .slice(lastToolResultIndex + 1)
+      .some((message) => readAssistantSnapshotText(message).length > 0)
+  ) {
+    return true;
+  }
+  const preToolText = params.messagesSnapshot
+    .slice(0, lastToolResultIndex)
+    .map((message) => readAssistantSnapshotText(message))
+    .filter((text) => text.length > 0)
+    .join("\n");
+  return params.assistantTexts.some((text) => {
+    const trimmed = text.trim();
+    return trimmed.length > 0 && !preToolText.includes(trimmed);
+  });
 }
 
 function normalizeEmbeddedAttemptToolMetas(

--- a/src/agents/embedded-agent-runner/run/attempt.settled-turn-finalization-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.settled-turn-finalization-context.test.ts
@@ -67,6 +67,11 @@ describe("settled post-tool turn finalization context", () => {
   it.each([
     { kind: "transient", error: transientFinalCallFailure(), captures: true },
     { kind: "non-transient", error: new Error("invalid api key"), captures: false },
+    {
+      kind: "incomplete-completions-stream",
+      error: new Error("Stream ended without finish_reason"),
+      captures: true,
+    },
   ])("$kind final provider failure captures context=$captures", async ({ error, captures }) => {
     const result = await runSettledTurnWithFailedFinalCall(
       "agent:main:telegram:direct:settled",

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-classification.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-classification.ts
@@ -2,6 +2,7 @@
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
+import { extractEmbeddedAssistantText } from "../../embedded-agent-utils.js";
 import {
   isStrictAgenticSupportedProviderModel,
   stripProviderPrefix,
@@ -40,6 +41,43 @@ export type IncompleteTurnAttempt = Pick<
   | "toolMetas"
 > &
   Partial<Pick<EmbeddedRunAttemptResult, "acceptedSessionSpawns">>;
+
+function readAssistantSnapshotText(message: AgentMessage): string {
+  return message.role === "assistant" ? extractEmbeddedAssistantText(message).trim() : "";
+}
+
+/** Keeps pre-tool commentary distinct from a composed answer at both recovery gates. */
+export function hasComposedVisibleAnswerAfterSettledTools(params: {
+  assistantTexts: readonly string[];
+  messagesSnapshot: EmbeddedRunAttemptResult["messagesSnapshot"];
+}): boolean {
+  // Prior turns cannot explain this attempt's visible subscription text.
+  const latestUserIndex = params.messagesSnapshot.findLastIndex(
+    (message) => message.role === "user",
+  );
+  const currentMessages = params.messagesSnapshot.slice(latestUserIndex + 1);
+  const lastToolResultIndex = currentMessages.findLastIndex(
+    (message) => message.role === "toolResult",
+  );
+  if (lastToolResultIndex < 0) {
+    return params.assistantTexts.some((text) => text.trim().length > 0);
+  }
+  if (
+    currentMessages
+      .slice(lastToolResultIndex + 1)
+      .some((message) => readAssistantSnapshotText(message).length > 0)
+  ) {
+    return true;
+  }
+  // A repeated fragment is ambiguous; only whole commentary messages explain text.
+  const preToolTexts = new Set(
+    currentMessages.slice(0, lastToolResultIndex).map(readAssistantSnapshotText),
+  );
+  return params.assistantTexts.some((text) => {
+    const trimmed = text.trim();
+    return trimmed.length > 0 && !preToolTexts.has(trimmed);
+  });
+}
 
 export function hasPositiveOutputTokenUsage(message: AgentMessage | null): boolean {
   if (!message || typeof message !== "object") {

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.provider-error.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.provider-error.test.ts
@@ -72,6 +72,37 @@ describe("prepared provider errors after settled tools", () => {
     );
   });
 
+  it.each(["earlier user turn", "current commentary substring"])(
+    "does not attribute current output to %s",
+    (source) => {
+      const base = createSettledProviderFailureAttempt({
+        assistantTexts: ["The note is already saved."],
+      });
+      const earlierAssistant = {
+        ...base.lastAssistant!,
+        stopReason: "stop" as const,
+        content: [
+          {
+            type: "text" as const,
+            text:
+              source === "earlier user turn"
+                ? "The note is already saved."
+                : "The note is already saved. I will verify it.",
+          },
+        ],
+      };
+      base.messagesSnapshot.splice(source === "earlier user turn" ? 0 : 1, 0, earlierAssistant);
+      base.terminal = {
+        kind: "failed",
+        source: "prompt",
+        error: new Error("Stream ended without finish_reason"),
+      };
+      const attempt = projectSettledProviderFailureAttempt(base);
+      expect(attempt.settledTurnFinalizationContext).toBeUndefined();
+      expect(resolveSettledTurnFinalizationRequest(prepareRequest(attempt))).toBeNull();
+    },
+  );
+
   it.each([
     { name: "missing recovery context", change: { settledTurnFinalizationContext: undefined } },
     {

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test-support.ts
@@ -175,7 +175,7 @@ export function projectSettledProviderFailureAttempt(
     messagesSnapshot: base.messagesSnapshot,
   };
   const subscription = {
-    assistantTexts: [],
+    assistantTexts: base.assistantTexts,
     didSendDeterministicApprovalPrompt: () => false,
     didSendViaMessagingTool: () => false,
     getAcceptedSessionSpawns: () => [],

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
@@ -362,7 +362,7 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
       const commentary = "I am saving the note.";
       const base = createSettledProviderFailureAttempt({ assistantTexts: [commentary] });
       const toolAssistant = base.messagesSnapshot[1];
-      if (toolAssistant.role !== "assistant" || !base.currentAttemptCompletedAssistant) {
+      if (toolAssistant?.role !== "assistant" || !base.currentAttemptCompletedAssistant) {
         throw new Error("Missing assistant fixture");
       }
       toolAssistant.content.unshift({ type: "text", text: commentary });

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
@@ -15,7 +15,11 @@ import type { EmbeddedRunAttemptWithReceiptEvidence } from "./attempt-result.js"
 import { EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS } from "./lane-runtime.js";
 import { buildEmbeddedRunPayloads } from "./payloads.js";
 import { prepareTerminalWithSettledTurnFinalization } from "./settled-turn-finalization.js";
-import { createSettledFinalizationTestInput } from "./settled-turn-finalization.test-support.js";
+import {
+  createSettledFinalizationTestInput,
+  createSettledProviderFailureAttempt,
+  projectSettledProviderFailureAttempt,
+} from "./settled-turn-finalization.test-support.js";
 import { resolveEmbeddedRunAttemptTerminalState } from "./terminal-outcome.js";
 import { resolveSettledTurnFinalizationRequest } from "./terminal-resolution.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
@@ -344,6 +348,69 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
           expect.objectContaining({ text: "The tool run finished." }),
         ]);
       }
+    },
+  );
+
+  it.each([
+    { reported: false, outcome: "answered" },
+    { reported: true, outcome: "answered" },
+    { reported: false, outcome: "empty" },
+    { reported: true, outcome: "empty" },
+  ] as const)(
+    "recovers truncated completions after commentary (reported: $reported, finalizer: $outcome)",
+    async ({ reported, outcome }) => {
+      const commentary = "I am saving the note.";
+      const base = createSettledProviderFailureAttempt({ assistantTexts: [commentary] });
+      const toolAssistant = base.messagesSnapshot[1];
+      if (toolAssistant.role !== "assistant" || !base.currentAttemptCompletedAssistant) {
+        throw new Error("Missing assistant fixture");
+      }
+      toolAssistant.content.unshift({ type: "text", text: commentary });
+      base.currentAttemptCompletedAssistant.errorMessage = "Stream ended without finish_reason";
+      base.terminal = reported
+        ? { kind: "ok" }
+        : {
+            kind: "failed",
+            source: "prompt",
+            error: new Error("Stream ended without finish_reason"),
+          };
+      const attempt = projectSettledProviderFailureAttempt(base);
+      expect(attempt.settledTurnFinalizationContext).toBeDefined();
+      const finalText = "The note was saved.";
+      backendMocks.runSettledFinalization.mockResolvedValue({
+        outcome,
+        result: {
+          assistant: buildEmbeddedRunnerAssistant({
+            content: outcome === "answered" ? [{ type: "text", text: finalText }] : [],
+          }),
+        },
+      });
+      const input = finalizationInput(attempt);
+      input.terminalBase.runParams.trigger = "user";
+      input.finalization.modelApi = "openai-completions";
+
+      const result = await prepareTerminalWithSettledTurnFinalization(input);
+
+      expect(result.finalizationOutcome).toBe(
+        outcome === "answered" ? "answered" : "completed-empty",
+      );
+      expect(backendMocks.runSettledFinalization).toHaveBeenCalledTimes(
+        outcome === "answered" ? 1 : 2,
+      );
+      for (const [preparedAttempt, settledAttempt] of backendMocks.runSettledFinalization.mock
+        .calls) {
+        expect(preparedAttempt).toMatchObject({
+          operation: "settled-tool-finalization",
+          disableTools: true,
+        });
+        expect(settledAttempt).toBe(attempt);
+      }
+      expect(result.prepared.payloadsWithToolMedia).toEqual([
+        expect.objectContaining({
+          text: outcome === "answered" ? finalText : SETTLED_TOOL_FINALIZATION_FALLBACK_TEXT,
+        }),
+      ]);
+      expect(result.prepared.payloadsWithToolMedia?.[0]?.isError).not.toBe(true);
     },
   );
 

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -34,6 +34,7 @@ import {
 } from "./auth-profile-success.js";
 import type { EmbeddedRunContextRecoveryState } from "./context-recovery-state.js";
 import { resolveFinalAssistantVisibleText } from "./helpers.js";
+import { hasComposedVisibleAnswerAfterSettledTools } from "./incomplete-turn-classification.js";
 import {
   resolveEmptyResponseRetryInstruction,
   resolveReasoningOnlyRetryInstruction,
@@ -128,19 +129,21 @@ export function resolveSettledTurnFinalizationRequest(input: {
   // Generated errors are fallback surfaces, not authored answers. Trust their
   // producer provenance; the recovery owner still requires exact settlement,
   // transient-failure context, and no delivery or asynchronous work.
-  const hasOnlySyntheticErrorPayload = Boolean(
-    input.attempt.assistantTexts.every((text) => text.trim().length === 0) &&
+  const hasNoAssistantText = input.attempt.assistantTexts.every((text) => !text.trim());
+  const canFinalizeProviderError =
+    input.attempt.settledTurnFinalizationContext &&
+    !hasComposedVisibleAnswerAfterSettledTools(input.attempt);
+  const hasOnlySyntheticErrorPayload =
     (input.payloadsWithToolMedia?.length ?? 0) > 0 &&
     input.payloadsWithToolMedia?.every((payload) => {
       const metadata = getReplyPayloadMetadata(payload);
       return (
         payload.isError === true &&
         Object.keys(payload).every((key) => key === "text" || key === "isError") &&
-        (metadata?.toolErrorWarning ||
-          (input.attempt.settledTurnFinalizationContext && metadata?.terminalProviderError))
+        ((hasNoAssistantText && metadata?.toolErrorWarning) ||
+          (canFinalizeProviderError && metadata?.terminalProviderError))
       );
-    }),
-  );
+    });
   const preparedPayloadCount = hasOnlySyntheticErrorPayload
     ? 0
     : (input.payloadsWithToolMedia?.length ?? 0);

--- a/src/agents/failover/failover-classification.overflow-server-misc.cases.ts
+++ b/src/agents/failover/failover-classification.overflow-server-misc.cases.ts
@@ -44,6 +44,15 @@ export const overflowServerMiscCases = [
     expected: reason("timeout"),
   },
   {
+    id: "openai-completions-incomplete-terminal-stream",
+    source: "packages/ai/src/transports/openai-completions-stream.ts",
+    signal: {
+      provider: "opencode-go",
+      message: "Stream ended without finish_reason",
+    },
+    expected: reason("timeout"),
+  },
+  {
     id: "openai-responses-incomplete-terminal-stream",
     source: "packages/ai/src/transports/openai-responses-stream-internal.ts",
     signal: {

--- a/src/agents/failover/failover-retry.expected.test-support.ts
+++ b/src/agents/failover/failover-retry.expected.test-support.ts
@@ -4,6 +4,7 @@ export const failoverRetryExpectations = {
   "anthropic-incomplete-terminal-stream": true,
   "google-incomplete-terminal-stream": true,
   "mistral-incomplete-terminal-stream": true,
+  "openai-completions-incomplete-terminal-stream": true,
   "openai-responses-incomplete-terminal-stream": true,
   "proxy-incomplete-terminal-stream": true,
   "billing-context-input-length-model-limit": false,

--- a/src/agents/failover/message-patterns.ts
+++ b/src/agents/failover/message-patterns.ts
@@ -35,8 +35,12 @@ export function isProviderRequestSizeCeilingError(errorMessage?: string): boolea
 
 // First-party model transports use these terminal-contract forms when EOF arrives
 // before a response is complete; keep non-model stream lifecycle errors out.
+// The completions transport throws `Stream ended without finish_reason` (no
+// "terminal" wording); Mistral/Google keep the longer form. Plugin lifecycle
+// strings such as `opencode-go stream ended without a terminal event` must not
+// match — those are not assistant-stream contracts.
 export const INCOMPLETE_ASSISTANT_STREAM_RE =
-  /^[\w -]*stream ended (?:before (?:message_?stop|(?:a )?terminal (?:finish reason|response event|event))|without a terminal finish reason)[.!]?$/i;
+  /^[\w -]*stream ended (?:before (?:message_?stop|(?:a )?terminal (?:finish reason|response event|event))|without (?:a terminal )?finish[_ ]reason)[.!]?$/i;
 const PERIODIC_USAGE_LIMIT_RE =
   /\b(?:daily|weekly|monthly)(?:\/(?:daily|weekly|monthly))* (?:usage )?limit(?:s)?(?: (?:exhausted|reached|exceeded))?\b/i;
 


### PR DESCRIPTION
Related: #128368, #127538, #137887, #126404, #138645, #124176, #138204

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users sending a follow-up in a Telegram topic session would see a generic `⚠️ Agent run failed (model: opencode-go/glm-5.3).` after the model had already run tools and delivered pre-tool commentary, when OpenCode Go's openai-completions SSE closed without `finish_reason` or `[DONE]`.

The sibling user-visible copy `The tool run finished, but no final summary was produced. I did not repeat any completed actions.` is the intentional host fallback after settled tools when isolated finalization is empty. This incident never reached that path: the truncated stream was unclassified, and pre-tool commentary was treated as if the turn had already composed a final answer.

## Why This Change Was Made

Classify the completions-transport producer string `Stream ended without finish_reason` as the same incomplete assistant-stream timeout already used for Mistral/Bedrock/Anthropic/Google/OpenAI Responses. After tools have settled, capture settled-turn finalization context for that failure even when commentary was delivered before the last tool result. Do not treat that commentary as a composed final answer. Do not classify the plugin lifecycle string `opencode-go stream ended without a terminal event` (different owner, corpus forbids it).

Without prior tools, the timeout classification lets replay-safe failover/retry use the same path as the sibling incomplete-stream producers. After tools (replay-unsafe), the host can attempt a tool-free summary instead of unclassified "Agent run failed". If that summary is also empty, the existing honest fallback remains.

## User Impact

- After a truncated OpenCode Go / openai-completions stream **with settled tools**, OpenClaw can still produce a tool-free summary, or the existing honest "no final summary" fallback, instead of a generic agent-run failure.
- After a truncated completions stream **without tools**, failover/retry copy matches other incomplete assistant streams (`timeout`) instead of an unclassified failure.
- Session model overrides that disable fallbacks still get the post-tool recovery path rather than a dead end.
- Plugin-owned `opencode-go stream ended without a terminal event` behavior is unchanged.

## Evidence

### Live incident (redacted, 2026-09-06 UTC)

Telegram **group topic session** (chat IDs, user IDs, usernames, hostnames, and personal content omitted).

- User follow-up after a device power cycle; session model override `opencode-go/glm-5.3` **disabled configured fallbacks**.
- API: `openai-completions`. Endpoint: `https://opencode.ai/zen/go/v1/chat/completions`.
- First POST: HTTP 200 SSE (~2.6s). Tool call succeeded (operator-owned SSH/exec-style tool). Commentary and tool cards were delivered to the topic.
- Second completions request: HTTP 200 SSE (~2.8s), then the stream closed ~32s later with **no `finish_reason` and no `[DONE]`**.
- Producer error: `Stream ended without finish_reason`.
- `failoverReason: null`, `providerRuntimeFailureKind: unclassified`.
- User-facing copy: `⚠️ Agent run failed (model: opencode-go/glm-5.3).`
- Transcript: empty assistant, `stopReason: error`, 0 tokens.

Why settled-turn recovery did not run:

1. `resolveSettledTurnFinalizationContext` only treated `isTransientNetworkError` as eligible. Incomplete-stream text is not a network errno.
2. Any non-empty `assistantTexts` omitted context. Pre-tool commentary ("checking post-reboot state…") filled that list even though no post-tool answer existed.

### Same-topic observations (not claimed as the same root cause)

- Minutes earlier, a different `glm-5.3` cloud route returned **HTTP 429 session usage limit** (`you have reached your session usage limit`; account identifier redacted). Retries 1–9 then rate-limit user copy. Provider name was already log-redacted.
- A prior reply on the same topic was aborted by a new inbound (`Reply operation aborted by user`).
- Earlier the same day: `restart recovery claim changed before agent adoption` on the same topic (operational noise).
- Overnight, the same group hit `Session transcript keyed user is outside the current turn` on `openai/gpt-5.6-sol` (separate defect).

### Classification contract

Producer in `packages/ai/src/transports/openai-completions-stream.ts` still throws `Stream ended without finish_reason` (tests already expect that string). Classification is the owner fix.

Pre-fix `INCOMPLETE_ASSISTANT_STREAM_RE` match results:

| Message | Old regex | New regex |
| --- | --- | --- |
| `Stream ended without finish_reason` | no | yes (`timeout`) |
| `Mistral stream ended without a terminal finish reason` | yes | yes |
| `Bedrock stream ended before messageStop` | yes | yes |
| `opencode-go stream ended without a terminal event` | no | no (intentional) |

### Local proof

- Focused Vitest: `attempt-result`, settled-turn context (including `incomplete-completions-stream` capture), failover corpus (639), retry freeze. Exit 0.
- `node scripts/check-changed.mjs` on the six touched files: exit 0 (core + coreTests), including tsgo and oxlint.
- `git diff --check`: clean.
- Autoreview (`--mode local --base origin/main --max-priority P1`) reported three P1s in `src/cli/update-cli/*` and `src/commands/doctor-update.ts`. Those files are **not in this diff**. Rejected as out of scope / wrong-patch hallucination.

### Review follow-up (2026-09-06)

Runtime repair: `af5690cec24d51b189229d7d5f086265eed3c67f`; final head: `43b605dc99d6ba5520922a25f5d3ceb2ba666c44`.

Addressed ClawSweeper’s P2: context capture and the synthetic terminal-provider-error gate now use the same commentary-aware classifier. Matching is restricted to the current user turn and exact whole commentary messages; prior-turn text and substring collisions cannot hide a composed answer. The tool-warning gate remains blank-text-only; settlement, cancellation, async work, delivered replies/media, explicit silence, refusals, and structured errors retain their existing guards.

Regression proof uses real attempt-result projection through terminal preparation and isolated finalization. Four cases failed before repair with `not-attempted` and pass afterward: thrown versus assistant-reported truncated streams, each with a returned summary or empty-finalizer honest fallback. Separate historical-text and current-commentary-substring regressions also failed before their repairs. Finalization requests keep tools disabled and retain the settled attempt.

Validation:
- 774 focused tests passed: attempt-result (37), terminal-resolution (48), settled-turn-finalization (26), provider-error (19), stream-capture integration (5), and failover corpus (639).
- `node scripts/run-vitest.mjs` on those six files; final affected scopes rerun after refinements.
- Targeted `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json`: 0 warnings/errors; formatting and `git diff --check` clean.
- Conflict markers, max-lines and assertion-safety ratchets passed.
- Fresh autoreview of the complete staged candidate through P2: scoped-clean, no accepted/actionable findings.
- Follow-up production delta: -3 lines; tests/test support: +98 lines. No new config, schema, dependency or protocol surfaces.

Proof limitations: no new live Telegram/provider run. Testbox warmup was blocked by missing host authentication. Local full changed checks hit the pinned pnpm package-age restriction; standalone typechecking rejected shared dependency links. Neither safeguard was changed. Exact-head hosted CI subsequently passed on `43b605dc99d6ba5520922a25f5d3ceb2ba666c44`: run 34055207990, including the required `openclaw/ci-gate`.

## Related work (do not close as duplicates)

These overlap recovery, GLM, or truncated streams, but they do not own this completions `finish_reason` classification gap:

- #128368 Settled-tool-no-answer turns skip the tools-enabled continuation retries that empty-response turns already have. Adjacent product gap; this PR uses the existing tool-free finalizer rather than tools-enabled continuation.
- #127538 Model-call diagnostics report truncated EOF as completed. Diagnostics surface, not this user-facing agent-failure path.
- #137887 Finalize settled turns when harness callback is absent. Missing `finalizeSettledTurn` → host fallback. Overlaps the fallback copy, not the unclassified completions throw.
- #126404 Retry transient settled finalization.
- #138645 Keep tool-finalizer placeholders private in message-only groups.
- #124176 Skip settled-turn finalization capture after `sessions_yield`.
- #138204 GLM `<tool_call>` shadow text still reaches chat. GLM-related, different defect.
- #129794 Report interrupted local-model streams instead of empty success (merged).
- #98575 Preserve streaming tool_calls when provider omits `finish_reason` (closed; different owner).
- Cron / `NO_REPLY` issues that mention the same fallback sentence (#135658, #137024, #139253) are heartbeat/cron silence, not this truncated-stream path.

No existing open PR classifies `Stream ended without finish_reason`.

## Test plan

- [x] Corpus classifies `Stream ended without finish_reason` as `timeout` and still leaves `opencode-go stream ended without a terminal event` unclassified
- [x] Settled-turn context is captured for that truncated stream after tools
- [x] Pre-tool commentary does not block recovery; unattributed or post-tool visible text still does
- [x] Auth/quota/policy and non-prompt sources still omit context
- [x] CI on final head `43b605dc99d6ba5520922a25f5d3ceb2ba666c44` (run 34055207990; required `openclaw/ci-gate` passed)



### CI and review follow-up

ClawSweeper refreshed again at 19:38 UTC on September 6, 2026 for exact final head `43b605dc99d6ba5520922a25f5d3ceb2ba666c44`: ready for maintainer review, no actionable findings, no before-merge items. The test-only optional-entry narrowing correction (`toolAssistant?.role`) fixes the TypeScript failure in earlier CI run 34054819853, job 101544853652. Its 26-test file passes after correction. Final-head CI run 34055207990 completed successfully, including required `openclaw/ci-gate` job 101546748326. PR remains open and unmerged for the maintainer.

Worked on by:
- @VACInc

