### PR TITLE
fix: avoid loading saved prompts for session sharing

### DIFF
--- a/src/gateway/server-methods/sessions-sharing.test.ts
+++ b/src/gateway/server-methods/sessions-sharing.test.ts
@@ -698,7 +698,7 @@ describe("session sharing handlers", () => {
     });
   });
 
-  it("lists profile ids and authorizes a selected profile as a member", async () => {
+  it("lists current identities and adds members without decoding unrelated saved prompts", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       const sessionKey = "agent:main:profile-member";
       const profile = ensureProfileForEmail("member@example.com");
@@ -716,21 +716,53 @@ describe("session sharing handlers", () => {
           visibility: "read-only",
         },
       );
-      const requestContext = context(vi.fn());
-
-      const listed = await call("session.members.list", { sessionKey }, requestContext);
-      expect(listed[0]?.[1]).toMatchObject({
-        identities: expect.arrayContaining([
-          expect.objectContaining({ type: "human", id: profile.id, label: "Member" }),
-        ]),
+      const savedPrompt = "unrelated saved sharing prompt".repeat(512);
+      for (const [agentId, createdActor] of [
+        ["main", { type: "human", source: "profile", id: profile.id, label: "Old member name" }],
+        ["research", { type: "agent", id: "research", label: "Alpha Research" }],
+      ] as const) {
+        await upsertSessionEntryCore(
+          { agentId, sessionKey: `agent:${agentId}:unrelated-sharing` },
+          {
+            sessionId: `unrelated-sharing-${agentId}`,
+            updatedAt: 1,
+            createdActor,
+            skillsSnapshot: { prompt: savedPrompt, skills: [] },
+          },
+        );
+      }
+      const requestContext = context(vi.fn(), {
+        agents: { ownership: "explicit", entries: { main: {}, research: {} } },
       });
-      expect(
-        await call(
-          "session.members.add",
-          { sessionKey, identityId: selectable.id },
-          requestContext,
-        ),
-      ).toEqual([[true, { ok: true, sessionKey, identityId: profile.id }, undefined]]);
+      await call("session.members.list", { sessionKey }, requestContext);
+      const parse = JSON.parse;
+      let unrelatedDecodes = 0;
+      const parsed = vi.spyOn(JSON, "parse").mockImplementation((value, reviver) => {
+        if (typeof value === "string" && value.includes(savedPrompt)) {
+          unrelatedDecodes++;
+        }
+        return parse(value, reviver);
+      });
+      try {
+        for (const method of ["session.members.list", "session.members.listEvidence"] as const) {
+          const listed = await call(method, { sessionKey }, requestContext);
+          expect(listed[0]?.[1]).toMatchObject({
+            identities: [
+              { type: "agent", id: "research", label: "Alpha Research" },
+              { type: "human", id: profile.id, label: "Member" },
+            ],
+          });
+        }
+        expect(
+          await call(
+            "session.members.add",
+            { sessionKey, identityId: selectable.id },
+            requestContext,
+          ),
+        ).toEqual([[true, { ok: true, sessionKey, identityId: profile.id }, undefined]]);
+      } finally {
+        parsed.mockRestore();
+      }
       expect(
         authorizeResolvedSessionMutation({
           cfg: {},
@@ -739,6 +771,7 @@ describe("session sharing handlers", () => {
           agentId: "main",
         }),
       ).toBeNull();
+      expect(unrelatedDecodes).toBe(0);
     });
   });
 

--- a/src/gateway/server-methods/sessions-sharing.ts
+++ b/src/gateway/server-methods/sessions-sharing.ts
@@ -237,7 +237,8 @@ function knownSessionIdentities(params: {
   if (params.actor.state === "present") {
     remember(params.actor.actor);
   }
-  for (const entry of Object.values(loadCombinedSessionStoreForGatewayCore(params.cfg).store)) {
+  const { store } = loadCombinedSessionStoreForGatewayCore(params.cfg, { projection: "list" });
+  for (const entry of Object.values(store)) {
     remember(entry.createdActor ?? null);
   }
   for (const profile of listProfiles()) {
@@ -247,11 +248,7 @@ function knownSessionIdentities(params: {
       ...(profile.displayName ? { label: profile.displayName } : {}),
     });
   }
-  return [...identities.values()].toSorted(
-    (left, right) =>
-      (left.label ?? left.id).localeCompare(right.label ?? right.id) ||
-      left.id.localeCompare(right.id),
-  );
+  return [...identities.values()];
 }
 
 function publishSharingChange(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where listing session-sharing identities or adding a member repeatedly decoded saved prompts from unrelated sessions. The amount of unnecessary work grew with those sessions' saved prompt payloads.

## Why This Change Was Made

Identity discovery now requests the existing session-list projection, which retains creator and federation metadata while excluding saved prompt payloads. The final sharing-list response remains the sole sorting owner; the redundant earlier sort is removed.

## User Impact

Sharing identity discovery avoids unrelated prompt materialization while preserving current profile labels, identity ordering, membership and authorization behavior. This adds no cache, schema, configuration, dependency, persistence-policy or RPC change. Production delta: +3/-6 lines.

## Evidence

- Canonical SQLite regression: the final test fails on the original implementation after its behavior assertions with six unrelated saved-prompt decodes; the repair produces zero. Coverage includes both list dialects, multiple agents, current profile label precedence, deterministic ordering, member addition and subsequent authorization.
- 93 tests in seven owner/sibling suites and the full changed-file gate passed on Linux Node 24.19.0.
- Independent Codex review: no actionable P0–P2 findings.
- Synthetic built-Gateway/WebSocket comparison on Linux Node 26.7.0: each variant completed 20 sharing and 20 paired health requests. Complete public responses matched after explicitly mapping the isolated fixtures' canonical profile IDs; all 83 stored rows and saved-prompt hashes were preserved. Authentication, process/socket cleanup and isolated-state removal were checked.

Both variants used canonical full private-QA package builds. An initial fixture bootstrap failed because its two-agent config omitted explicit ownership; that attempt supplied no RPC proof. After correcting only the fixture, the candidate build was reused with its original commit and full output fingerprints verified, and the baseline was freshly built. The final unit fixture carries the same explicit ownership setting; production bytes match the built-Gateway proof.

The proof establishes avoided decoding and response/state parity, not a production latency or event-loop speedup. Initial introduction provenance has not been established.
