### PR TITLE
refactor: simplify diagnostic, backup, and runtime ownership

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2384,7 +2384,6 @@ src/commands/auth-choice.apply.api-providers.ts	1
 src/commands/backup-git.ts	1
 src/commands/backup-restore.ts	1
 src/commands/backup-schedule.ts	1
-src/commands/backup-shared.ts	1
 src/commands/backup-verify.ts	2
 src/commands/channel-setup/config-compatibility.ts	2
 src/commands/channel-setup/discovery.ts	11

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3081,7 +3081,7 @@ src/infra/provider-usage.fetch.deepseek.ts	1
 src/infra/provider-usage.fetch.minimax.ts	2
 src/infra/push-apns-http2.ts	1
 src/infra/push-apns.relay.ts	1
-src/infra/push-apns.ts	7
+src/infra/push-apns.ts	3
 src/infra/push-web.ts	2
 src/infra/question-gateway-resolver.ts	3
 src/infra/question-reaction-runtime.ts	3

--- a/extensions/migrate-claude/memory.ts
+++ b/extensions/migrate-claude/memory.ts
@@ -1,5 +1,4 @@
 // Migrate Claude plugin module implements memory behavior.
-import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -11,6 +10,7 @@ import type { MigrationItem } from "openclaw/plugin-sdk/plugin-entry";
 import {
   CLAUDE_AUTO_MEMORY_MAX_FILES,
   CLAUDE_AUTO_MEMORY_MAX_SCAN_ENTRIES,
+  readMemoryDir,
   type ClaudeSource,
 } from "./source.js";
 import type { PlannedTargets } from "./targets.js";
@@ -57,16 +57,6 @@ async function addInstructionItem(params: {
       details: { sourceLabel: params.sourceLabel },
     }),
   );
-}
-
-async function readMemoryDir(dir: string): Promise<Dirent[]> {
-  try {
-    return await fs.readdir(dir, { withFileTypes: true });
-  } catch (error) {
-    throw new Error(`Unable to read Claude Code auto-memory directory: ${dir}`, {
-      cause: error,
-    });
-  }
 }
 
 type MarkdownFileScan = {

--- a/extensions/migrate-claude/source.ts
+++ b/extensions/migrate-claude/source.ts
@@ -95,7 +95,7 @@ async function safeReadDir(dir: string): Promise<Dirent[]> {
   }
 }
 
-async function readMemoryDir(dir: string): Promise<Dirent[]> {
+export async function readMemoryDir(dir: string): Promise<Dirent[]> {
   try {
     return await fs.readdir(dir, { withFileTypes: true });
   } catch (error) {

--- a/extensions/ollama/src/web-search-provider-registration.ts
+++ b/extensions/ollama/src/web-search-provider-registration.ts
@@ -11,7 +11,9 @@ const loadOllamaWebSearchProvider = createLazyRuntimeModule(
 );
 
 export function createLazyOllamaWebSearchProvider(): WebSearchProviderPlugin {
-  let providerPromise: Promise<WebSearchProviderPlugin> | undefined;
+  let providerPromise:
+    | Promise<Pick<WebSearchProviderPlugin, "runSetup" | "createTool">>
+    | undefined;
   const loadProvider = () =>
     (providerPromise ??= loadOllamaWebSearchProvider().then((runtime) =>
       runtime.createOllamaWebSearchProvider(),

--- a/extensions/ollama/src/web-search-provider.runtime.ts
+++ b/extensions/ollama/src/web-search-provider.runtime.ts
@@ -10,7 +10,6 @@ import {
   redactProviderResponseErrorText,
 } from "openclaw/plugin-sdk/provider-http";
 import {
-  enablePluginInConfig,
   readPositiveIntegerParam,
   readResponseText,
   readStringParam,
@@ -335,22 +334,11 @@ async function warnOllamaWebSearchPrereqs(params: {
   return params.config;
 }
 
-export function createOllamaWebSearchProvider(): WebSearchProviderPlugin {
+export function createOllamaWebSearchProvider(): Pick<
+  WebSearchProviderPlugin,
+  "runSetup" | "createTool"
+> {
   return {
-    id: "ollama",
-    label: "Ollama Web Search",
-    hint: "Local Ollama host · requires ollama signin",
-    onboardingScopes: ["text-inference"],
-    requiresCredential: false,
-    envVars: [],
-    placeholder: "(run ollama signin)",
-    signupUrl: "https://ollama.com/",
-    docsUrl: "https://docs.openclaw.ai/tools/web",
-    autoDetectOrder: 110,
-    credentialPath: "",
-    getCredentialValue: () => undefined,
-    setCredentialValue: () => {},
-    applySelectionConfig: (config) => enablePluginInConfig(config, "ollama").config,
     runSetup: async (ctx) => await warnOllamaWebSearchPrereqs(ctx),
     createTool: (ctx) => ({
       description: OLLAMA_WEB_SEARCH_TOOL_DESCRIPTION,

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -424,12 +424,6 @@ async function resolveBackupPlanFromPaths(params: {
   };
 }
 
-if (process.env.VITEST || process.env.NODE_ENV === "test") {
-  (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.backupPlanTestApi")] = {
-    resolveBackupPlanFromPaths,
-  };
-}
-
 function compareCandidates(left: BackupAssetCandidate, right: BackupAssetCandidate): number {
   const depthDelta = left.canonicalPath.length - right.canonicalPath.length;
   if (depthDelta !== 0) {

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -8,10 +8,18 @@ import * as tar from "tar";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { runCommandWithRuntime } from "../cli/cli-utils.js";
+import * as diskSpace from "../infra/disk-space.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { buildBackupArchivePath, buildBackupArchiveRoot } from "./backup-shared.js";
 import type { BackupManifest } from "./backup-verify-manifest.js";
-import { backupVerifyCommand, testApi, verifyBackupArchive } from "./backup-verify.js";
+import { backupVerifyCommand, verifyBackupArchive } from "./backup-verify.js";
+
+vi.mock("tar", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("tar")>();
+  return { ...actual, t: vi.fn(actual.t), x: vi.fn(actual.x) };
+});
+
+const actualTar = await vi.importActual<typeof import("tar")>("tar");
 
 const TEST_ARCHIVE_ROOT = "2026-03-09T00-00-00.000Z-openclaw-backup";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -200,6 +208,8 @@ async function createSqlitePayload(setup: (database: DatabaseSync) => void): Pro
 describe("backupVerifyCommand", () => {
   afterEach(async () => {
     vi.restoreAllMocks();
+    vi.mocked(tar.t).mockReset().mockImplementation(actualTar.t);
+    vi.mocked(tar.x).mockReset().mockImplementation(actualTar.x);
   });
 
   it("verifies a valid backup archive", async () => {
@@ -1140,46 +1150,87 @@ describe("backupVerifyCommand", () => {
     );
   });
 
-  it("rejects SQLite extraction before writing when temporary space is insufficient", () => {
-    expect(() =>
-      testApi.assertSqliteExtractionBudget({
-        entries: [
-          {
-            raw: "backup/payload/state/openclaw.sqlite",
-            normalized: "backup/payload/state/openclaw.sqlite",
-            stateAssetRoot: "backup/payload",
-            type: "File",
-            size: 2 * 1024 * 1024,
-          },
-        ],
-        tempRoot: "/tmp",
-        readDiskSpace: () => ({
-          targetPath: "/tmp",
-          checkedPath: "/tmp",
-          availableBytes: 128 * 1024 * 1024,
-          totalBytes: 1024 * 1024 * 1024,
-        }),
-      }),
-    ).toThrow(/only 128 MiB is available/iu);
-  });
+  it.each([
+    {
+      name: "temporary space is insufficient",
+      availableBytes: 128 * 1024 * 1024,
+      simulatedSize: undefined,
+      error: /only 128 MiB is available/iu,
+    },
+    {
+      name: "the simulated snapshot size exceeds the hard limit",
+      availableBytes: null,
+      simulatedSize: 64 * 1024 * 1024 * 1024 + 1,
+      error: /verification limit is 64 GiB/iu,
+    },
+  ])(
+    "rejects SQLite extraction before writing when $name",
+    async ({ availableBytes, simulatedSize, error }) => {
+      const stateAssetArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/tmp/.openclaw`;
+      const sqliteArchivePath = `${stateAssetArchivePath}/state/openclaw.sqlite`;
+      const sqlitePayload = await createSqlitePayload((database) => {
+        database.exec(`
+          CREATE TABLE schema_meta (meta_key TEXT NOT NULL PRIMARY KEY, role TEXT NOT NULL);
+          INSERT INTO schema_meta (meta_key, role) VALUES ('primary', 'global');
+        `);
+      });
 
-  it("rejects SQLite extraction beyond the verification hard limit", () => {
-    expect(() =>
-      testApi.assertSqliteExtractionBudget({
-        entries: [
-          {
-            raw: "backup/payload/state/openclaw.sqlite",
-            normalized: "backup/payload/state/openclaw.sqlite",
-            stateAssetRoot: "backup/payload",
-            type: "File",
-            size: 64 * 1024 * 1024 * 1024 + 1,
-          },
-        ],
-        tempRoot: "/tmp",
-        readDiskSpace: () => null,
-      }),
-    ).toThrow(/verification limit is 64 GiB/iu);
-  });
+      await withBrokenArchiveFixture(
+        {
+          tempPrefix: "openclaw-backup-extraction-budget-",
+          manifestAssetArchivePath: stateAssetArchivePath,
+          payloads: [
+            {
+              fileName: "openclaw.sqlite",
+              contents: sqlitePayload,
+              archivePath: sqliteArchivePath,
+            },
+          ],
+        },
+        async (archivePath) => {
+          vi.spyOn(diskSpace, "tryReadDiskSpace").mockImplementation((targetPath) =>
+            availableBytes === null
+              ? null
+              : {
+                  targetPath,
+                  checkedPath: targetPath,
+                  availableBytes,
+                  totalBytes: 1024 * 1024 * 1024,
+                },
+          );
+          if (simulatedSize !== undefined) {
+            vi.mocked(tar.t).mockImplementation((options) => {
+              if (options.filter) {
+                return actualTar.t(options);
+              }
+              return actualTar.t({
+                ...options,
+                onReadEntry: (entry) => {
+                  const originalSize = entry.size;
+                  if (entry.path === sqliteArchivePath) {
+                    entry.size = simulatedSize;
+                  }
+                  try {
+                    options.onReadEntry?.(entry);
+                  } finally {
+                    entry.size = originalSize;
+                  }
+                },
+              });
+            });
+          }
+          const mkdtemp = vi.spyOn(fs, "mkdtemp");
+          const extract = vi.mocked(tar.x).mockClear();
+
+          await expect(
+            backupVerifyCommand(createBackupVerifyRuntime(), { archive: archivePath }),
+          ).rejects.toThrow(error);
+          expect(mkdtemp).not.toHaveBeenCalled();
+          expect(extract).not.toHaveBeenCalled();
+        },
+      );
+    },
+  );
 
   it("ignores package-owned and transient SQLite-shaped state files", async () => {
     const stateAssetArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/tmp/.openclaw`;

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -370,7 +370,6 @@ function resolveSqliteExtractionBytes(entries: SqliteSnapshotEntry[]): number {
 function assertSqliteExtractionBudget(params: {
   entries: SqliteSnapshotEntry[];
   tempRoot: string;
-  readDiskSpace?: typeof tryReadDiskSpace;
 }): void {
   const totalBytes = resolveSqliteExtractionBytes(params.entries);
   if (totalBytes > MAX_SQLITE_SNAPSHOT_EXTRACT_BYTES) {
@@ -379,7 +378,7 @@ function assertSqliteExtractionBudget(params: {
     );
   }
 
-  const diskSpace = (params.readDiskSpace ?? tryReadDiskSpace)(params.tempRoot);
+  const diskSpace = tryReadDiskSpace(params.tempRoot);
   if (
     diskSpace &&
     totalBytes + SQLITE_SNAPSHOT_FREE_SPACE_RESERVE_BYTES > diskSpace.availableBytes
@@ -687,7 +686,3 @@ export async function backupVerifyCommand(
   }
   return result;
 }
-
-export const testApi = {
-  assertSqliteExtractionBudget,
-};

--- a/src/commands/backup.atomic.test.ts
+++ b/src/commands/backup.atomic.test.ts
@@ -1,5 +1,5 @@
 // Backup atomicity tests cover temp-file writes, rollback behavior, and backup archive consistency.
-import fsSync from "node:fs";
+import fsSync, { type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -99,6 +99,10 @@ describe("backupCreateCommand atomic archive write", () => {
     const { archiveDir, outputPath, runtime } = await prepareAtomicBackupScenario({
       archivePrefix: "openclaw-backup-retry-cleanup-",
     });
+    const volatilePath = path.join(tempHome.home, ".openclaw", "logs", "gateway.log");
+    await fs.mkdir(path.dirname(volatilePath), { recursive: true });
+    await fs.writeFile(volatilePath, "volatile log\n", "utf8");
+    const volatileStat = await fs.stat(volatilePath);
     const originalUnlinkSync = fsSync.unlinkSync.bind(fsSync);
     let blockedPartialPath: string | undefined;
     let blockedPartialCleanupAttempts = 0;
@@ -117,25 +121,31 @@ describe("backupCreateCommand atomic archive write", () => {
     });
     try {
       let tarAttempt = 0;
-      tarCreateMock.mockImplementation(() => {
-        tarAttempt += 1;
-        return createMockTarStream({
-          contents: `archive-attempt-${tarAttempt}`,
-          ...(tarAttempt < 3
-            ? {
-                error: Object.assign(new Error("did not encounter expected EOF"), {
-                  path: path.join(tempHome.home, ".openclaw", "state.txt"),
-                }),
-              }
-            : {}),
-        });
-      });
+      tarCreateMock.mockImplementation(
+        (options: { filter: (entryPath: string, entryStat: Stats) => boolean }) => {
+          tarAttempt += 1;
+          return createMockTarStream({
+            beforeRead: () => {
+              expect(options.filter(volatilePath, volatileStat)).toBe(false);
+            },
+            contents: `archive-attempt-${tarAttempt}`,
+            ...(tarAttempt < 3
+              ? {
+                  error: Object.assign(new Error("did not encounter expected EOF"), {
+                    path: path.join(tempHome.home, ".openclaw", "state.txt"),
+                  }),
+                }
+              : {}),
+          });
+        },
+      );
 
       const result = await backupCreateCommand(runtime, {
         output: outputPath,
       });
 
       expect(result.archivePath).toBe(outputPath);
+      expect(result.skippedVolatileCount).toBe(1);
       expect(sleepMock.mock.calls).toStrictEqual([[10_000], [20_000]]);
       expect(blockedPartialCleanupAttempts).toBeGreaterThanOrEqual(2);
       expect((await fs.readdir(archiveDir)).toSorted()).toStrictEqual([path.basename(outputPath)]);

--- a/src/commands/backup.test-support.ts
+++ b/src/commands/backup.test-support.ts
@@ -7,34 +7,6 @@ import type { RuntimeEnv } from "../runtime.js";
 import { deleteTestEnvValue } from "../test-utils/env.js";
 import * as backupShared from "./backup-shared.js";
 
-type BackupPlan = Awaited<ReturnType<typeof backupShared.resolveBackupPlanFromDisk>>;
-
-type ResolveBackupPlanFromPathsParams = {
-  stateDir: string;
-  configPath: string;
-  oauthDir: string;
-  workspaceDirs?: string[];
-  includeWorkspace?: boolean;
-  onlyConfig?: boolean;
-  nowMs?: number;
-};
-
-type BackupPlanTestApi = {
-  resolveBackupPlanFromPaths(params: ResolveBackupPlanFromPathsParams): Promise<BackupPlan>;
-};
-
-function getBackupPlanTestApi(): BackupPlanTestApi {
-  return (globalThis as Record<PropertyKey, unknown>)[
-    Symbol.for("openclaw.backupPlanTestApi")
-  ] as BackupPlanTestApi;
-}
-
-export async function resolveBackupPlanFromPaths(
-  params: ResolveBackupPlanFromPathsParams,
-): Promise<BackupPlan> {
-  return await getBackupPlanTestApi().resolveBackupPlanFromPaths(params);
-}
-
 const backupTestMocks = vi.hoisted(() => ({
   backupVerifyCommandMock: vi.fn(),
   tarCreateMock: vi.fn(),
@@ -83,14 +55,14 @@ export async function resetBackupTempHome(tempHome: { home: string }) {
 }
 
 export async function mockStateOnlyBackupPlan(stateDir: string) {
-  await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
-  vi.spyOn(backupShared, "resolveBackupPlanFromDisk").mockResolvedValue(
-    await resolveBackupPlanFromPaths({
-      stateDir,
-      configPath: path.join(stateDir, "openclaw.json"),
-      oauthDir: path.join(stateDir, "credentials"),
-      includeWorkspace: false,
-      nowMs: 123,
-    }),
+  await fs.writeFile(
+    path.join(stateDir, "openclaw.json"),
+    JSON.stringify({ agents: { ownership: "explicit", entries: {} } }),
+    "utf8",
   );
+  const plan = await backupShared.resolveBackupPlanFromDisk({
+    includeWorkspace: false,
+    nowMs: 123,
+  });
+  vi.spyOn(backupShared, "resolveBackupPlanFromDisk").mockResolvedValue(plan);
 }

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -8,7 +8,6 @@ import { formatCliOperatorError } from "../cli/failure-output.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
-import * as backupShared from "./backup-shared.js";
 import {
   buildBackupArchivePath,
   buildBackupArchiveRoot,
@@ -21,7 +20,6 @@ import {
   createBackupTestRuntime,
   mockStateOnlyBackupPlan,
   resetBackupTempHome,
-  resolveBackupPlanFromPaths,
   tarCreateMock,
 } from "./backup.test-support.js";
 
@@ -50,16 +48,13 @@ type CapturedBackupManifest = {
 describe("backup commands", () => {
   let tempHome: TempHomeEnv;
 
-  async function mockWorkspaceBackupPlan(stateDir: string, workspaceDir: string, nowMs: number) {
-    vi.spyOn(backupShared, "resolveBackupPlanFromDisk").mockResolvedValue(
-      await resolveBackupPlanFromPaths({
-        stateDir,
-        configPath: path.join(stateDir, "openclaw.json"),
-        oauthDir: path.join(stateDir, "credentials"),
-        workspaceDirs: [workspaceDir],
-        includeWorkspace: true,
-        nowMs,
+  async function writeWorkspaceBackupConfig(stateDir: string, workspaceDir: string) {
+    await fs.writeFile(
+      path.join(stateDir, "openclaw.json"),
+      JSON.stringify({
+        agents: { ownership: "explicit", entries: { main: { workspace: workspaceDir } } },
       }),
+      "utf8",
     );
   }
 
@@ -172,23 +167,15 @@ describe("backup commands", () => {
 
   it("collapses default config, credentials, and workspace into the state backup root", async () => {
     const stateDir = path.join(tempHome.home, ".openclaw");
-    const configPath = path.join(stateDir, "openclaw.json");
     const oauthDir = path.join(stateDir, "credentials");
     const workspaceDir = path.join(stateDir, "workspace");
-    await fs.writeFile(configPath, JSON.stringify({}), "utf8");
+    await writeWorkspaceBackupConfig(stateDir, workspaceDir);
     await fs.mkdir(oauthDir, { recursive: true });
     await fs.writeFile(path.join(oauthDir, "oauth.json"), "{}", "utf8");
     await fs.mkdir(workspaceDir, { recursive: true });
     await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "# soul\n", "utf8");
 
-    const plan = await resolveBackupPlanFromPaths({
-      stateDir,
-      configPath,
-      oauthDir,
-      workspaceDirs: [workspaceDir],
-      includeWorkspace: true,
-      nowMs: 123,
-    });
+    const plan = await resolveBackupPlanFromDisk({ includeWorkspace: true, nowMs: 123 });
     expectWorkspaceCoveredByState(plan);
   });
 
@@ -205,14 +192,8 @@ describe("backup commands", () => {
       await fs.mkdir(workspaceDir, { recursive: true });
       await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "# soul\n", "utf8");
       await fs.symlink(workspaceDir, workspaceLink);
-      const plan = await resolveBackupPlanFromPaths({
-        stateDir,
-        configPath: path.join(stateDir, "openclaw.json"),
-        oauthDir: path.join(stateDir, "credentials"),
-        workspaceDirs: [workspaceLink],
-        includeWorkspace: true,
-        nowMs: 123,
-      });
+      await writeWorkspaceBackupConfig(stateDir, workspaceLink);
+      const plan = await resolveBackupPlanFromDisk({ includeWorkspace: true, nowMs: 123 });
       expectWorkspaceCoveredByState(plan);
     } finally {
       await fs.rm(symlinkDir, { recursive: true, force: true });
@@ -234,9 +215,8 @@ describe("backup commands", () => {
         configPath,
         JSON.stringify({
           agents: {
-            defaults: {
-              workspace: externalWorkspace,
-            },
+            ownership: "explicit",
+            entries: { main: { workspace: externalWorkspace } },
           },
         }),
         "utf8",
@@ -247,16 +227,6 @@ describe("backup commands", () => {
       const runtime = createBackupTestRuntime();
 
       const nowMs = Date.UTC(2026, 2, 9, 0, 0, 0);
-      vi.spyOn(backupShared, "resolveBackupPlanFromDisk").mockResolvedValue(
-        await resolveBackupPlanFromPaths({
-          stateDir,
-          configPath,
-          oauthDir: path.join(stateDir, "credentials"),
-          workspaceDirs: [externalWorkspace],
-          includeWorkspace: true,
-          nowMs,
-        }),
-      );
       tarCreateMock.mockImplementationOnce(
         (options: { onWriteEntry?: (entry: { path: string }) => void }, entryPaths: string[]) =>
           createMockTarStream({
@@ -297,7 +267,12 @@ describe("backup commands", () => {
         configPath,
         oauthDir: path.join(stateDir, "credentials"),
         workspaceDirs: [externalWorkspace],
-        agentRoots: [],
+        agentRoots: [
+          {
+            agentId: "main",
+            sourcePath: path.join(await fs.realpath(stateDir), "agents", "main", "agent"),
+          },
+        ],
       });
       expect(manifest.assets).toEqual(
         result.assets.map((asset) => ({
@@ -521,7 +496,7 @@ describe("backup commands", () => {
     await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "# soul\n", "utf8");
     vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
     const nowMs = Date.UTC(2026, 2, 9, 1, 2, 3);
-    await mockWorkspaceBackupPlan(stateDir, workspaceDir, nowMs);
+    await writeWorkspaceBackupConfig(stateDir, workspaceDir);
 
     const runtime = createBackupTestRuntime();
 
@@ -539,7 +514,6 @@ describe("backup commands", () => {
         await fs.symlink(workspaceDir, workspaceLink);
         vi.mocked(process["cwd"]).mockReturnValue(workspaceLink);
         const symlinkNowMs = Date.UTC(2026, 2, 9, 1, 3, 4);
-        await mockWorkspaceBackupPlan(stateDir, workspaceDir, symlinkNowMs);
         const symlinkResult = await backupCreateCommand(createBackupTestRuntime(), {
           nowMs: symlinkNowMs,
         });
@@ -558,15 +532,7 @@ describe("backup commands", () => {
     const existingArchive = path.join(tempHome.home, "existing-backup.tar.gz");
     await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
     await fs.writeFile(existingArchive, "already here", "utf8");
-    vi.spyOn(backupShared, "resolveBackupPlanFromDisk").mockResolvedValue(
-      await resolveBackupPlanFromPaths({
-        stateDir,
-        configPath: path.join(stateDir, "openclaw.json"),
-        oauthDir: path.join(stateDir, "credentials"),
-        includeWorkspace: false,
-        nowMs: 123,
-      }),
-    );
+    await mockStateOnlyBackupPlan(stateDir);
 
     const runtime = createBackupTestRuntime();
 
@@ -660,16 +626,6 @@ describe("backup commands", () => {
     await fs.writeFile(configPath, JSON.stringify({ theme: "config-only" }), "utf8");
     await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
     await fs.writeFile(path.join(stateDir, "credentials", "oauth.json"), "{}", "utf8");
-    vi.spyOn(backupShared, "resolveBackupPlanFromDisk").mockResolvedValue(
-      await resolveBackupPlanFromPaths({
-        stateDir,
-        configPath,
-        oauthDir: path.join(stateDir, "credentials"),
-        includeWorkspace: false,
-        onlyConfig: true,
-        nowMs: 123,
-      }),
-    );
 
     const runtime = createBackupTestRuntime();
 

--- a/src/commands/doctor-platform-notes.launchctl-env-overrides.test.ts
+++ b/src/commands/doctor-platform-notes.launchctl-env-overrides.test.ts
@@ -1,16 +1,24 @@
 // Doctor launchctl environment tests cover macOS gateway platform warnings for env overrides.
 import fs from "node:fs";
 import { expectDefined } from "@openclaw/normalization-core/expect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 
-const processMocks = vi.hoisted(() => ({
+const mocks = vi.hoisted(() => ({
   runExec: vi.fn(),
+  note: vi.fn(),
+  readCommand: vi.fn(),
+  findJobs: vi.fn(),
 }));
 
 vi.mock("../process/exec.js", () => ({
-  runExec: processMocks.runExec,
+  runExec: mocks.runExec,
 }));
+vi.mock("../../packages/terminal-core/src/note.js", () => ({ note: mocks.note }));
+vi.mock("../daemon/service.js", () => ({
+  resolveGatewayService: () => ({ readCommand: mocks.readCommand }),
+}));
+vi.mock("../daemon/launchd.js", () => ({ findStaleOpenClawUpdateLaunchdJobs: mocks.findJobs }));
 
 import {
   collectMacGatewayPlatformWarnings,
@@ -18,55 +26,72 @@ import {
   noteMacStaleOpenClawUpdateLaunchdJobs,
 } from "./doctor-platform-notes.js";
 
-describe("noteMacLaunchctlGatewayEnvOverrides", () => {
-  beforeEach(() => {
-    processMocks.runExec.mockReset().mockResolvedValue({ stdout: "", stderr: "" });
-  });
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
 
+beforeEach(() => {
+  vi.resetAllMocks();
+  Object.defineProperty(process, "platform", { ...platformDescriptor, value: "darwin" });
+  vi.stubEnv("HOME", "/tmp/openclaw-doctor-host");
+  vi.stubEnv("OPENCLAW_STATE_DIR", "/tmp/openclaw-doctor-host-state");
+  vi.spyOn(fs, "existsSync").mockReturnValue(false);
+  mocks.runExec.mockResolvedValue({ stdout: "", stderr: "" });
+  mocks.readCommand.mockResolvedValue(null);
+  mocks.findJobs.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  if (platformDescriptor) {
+    Object.defineProperty(process, "platform", platformDescriptor);
+  }
+});
+
+describe("noteMacLaunchctlGatewayEnvOverrides", () => {
   it("prints clear unsetenv instructions for token override", async () => {
-    const noteFn = vi.fn();
-    const getenv = vi.fn(async (name: string) =>
-      name === "OPENCLAW_GATEWAY_TOKEN" ? "launchctl-token" : undefined,
-    );
-    const cfg = {
+    mocks.runExec.mockImplementation(async (_command, [, name]) => ({
+      stdout: name === "OPENCLAW_GATEWAY_TOKEN" ? " \tlaunchctl-token\n" : " \n",
+      stderr: "",
+    }));
+    const cfg: OpenClawConfig = {
       gateway: {
         auth: {
           token: "config-token",
         },
       },
-    } as OpenClawConfig;
+    };
 
-    await noteMacLaunchctlGatewayEnvOverrides(cfg, { platform: "darwin", getenv, noteFn });
+    await noteMacLaunchctlGatewayEnvOverrides(cfg);
 
-    expect(noteFn).toHaveBeenCalledTimes(1);
-    expect(getenv).toHaveBeenCalledTimes(2);
+    expect(mocks.note).toHaveBeenCalledTimes(1);
+    expect(mocks.runExec).toHaveBeenCalledTimes(2);
 
-    const [message, title] = expectDefined<unknown[]>(noteFn.mock.calls[0], "note call 0");
+    const [message, title] = expectDefined<unknown[]>(mocks.note.mock.calls[0], "note call 0");
     expect(title).toBe("Gateway (macOS)");
     expect(message).toContain("Host-wide launchctl gateway auth overrides detected");
     expect(message).toContain("Current managed Gateway installs do not need these values");
     expect(message).toContain("OPENCLAW_GATEWAY_TOKEN");
     expect(message).toContain("launchctl unsetenv OPENCLAW_GATEWAY_TOKEN");
     expect(message).not.toContain("OPENCLAW_GATEWAY_PASSWORD");
+    expect(message).not.toContain("launchctl-token");
+    expect(message).not.toContain("config-token");
   });
 
   it("does nothing when config has no gateway credentials", async () => {
-    const noteFn = vi.fn();
-    const getenv = vi.fn(async () => "launchctl-token");
-    const cfg = {} as OpenClawConfig;
+    mocks.runExec.mockResolvedValue({ stdout: "launchctl-token", stderr: "" });
 
-    await noteMacLaunchctlGatewayEnvOverrides(cfg, { platform: "darwin", getenv, noteFn });
+    await noteMacLaunchctlGatewayEnvOverrides({});
 
-    expect(getenv).not.toHaveBeenCalled();
-    expect(noteFn).not.toHaveBeenCalled();
+    expect(mocks.runExec).not.toHaveBeenCalled();
+    expect(mocks.note).not.toHaveBeenCalled();
   });
 
   it("treats SecretRef-backed credentials as configured", async () => {
-    const noteFn = vi.fn();
-    const getenv = vi.fn(async (name: string) =>
-      name === "OPENCLAW_GATEWAY_PASSWORD" ? "launchctl-password" : undefined,
-    );
-    const cfg = {
+    mocks.runExec.mockImplementation(async (_command, [, name]) => ({
+      stdout: name === "OPENCLAW_GATEWAY_PASSWORD" ? " \tlaunchctl-password\n" : " \n",
+      stderr: "",
+    }));
+    const cfg: OpenClawConfig = {
       gateway: {
         auth: {
           password: { source: "env", provider: "default", id: "OPENCLAW_GATEWAY_PASSWORD" },
@@ -77,58 +102,59 @@ describe("noteMacLaunchctlGatewayEnvOverrides", () => {
           default: { source: "env" },
         },
       },
-    } as OpenClawConfig;
+    };
 
-    await noteMacLaunchctlGatewayEnvOverrides(cfg, { platform: "darwin", getenv, noteFn });
+    await noteMacLaunchctlGatewayEnvOverrides(cfg);
 
-    expect(noteFn).toHaveBeenCalledTimes(1);
-    const [message] = expectDefined<unknown[]>(noteFn.mock.calls[0], "note call 0");
+    expect(mocks.note).toHaveBeenCalledTimes(1);
+    const [message] = expectDefined<unknown[]>(mocks.note.mock.calls[0], "note call 0");
     expect(message).toContain("OPENCLAW_GATEWAY_PASSWORD");
+    expect(message).not.toContain("OPENCLAW_GATEWAY_TOKEN");
+    expect(message).not.toContain("launchctl-password");
   });
 
   it("does nothing on non-darwin platforms", async () => {
-    const noteFn = vi.fn();
-    const getenv = vi.fn(async () => "launchctl-token");
-    const cfg = {
+    Object.defineProperty(process, "platform", { ...platformDescriptor, value: "linux" });
+    mocks.runExec.mockResolvedValue({ stdout: "launchctl-token", stderr: "" });
+    const cfg: OpenClawConfig = {
       gateway: {
         auth: {
           token: "config-token",
         },
       },
-    } as OpenClawConfig;
+    };
 
-    await noteMacLaunchctlGatewayEnvOverrides(cfg, { platform: "linux", getenv, noteFn });
+    await noteMacLaunchctlGatewayEnvOverrides(cfg);
 
-    expect(getenv).not.toHaveBeenCalled();
-    expect(noteFn).not.toHaveBeenCalled();
+    expect(mocks.runExec).not.toHaveBeenCalled();
+    expect(mocks.note).not.toHaveBeenCalled();
   });
 
   it("bounds launchctl getenv calls and ignores timeout failures", async () => {
-    const noteFn = vi.fn();
-    processMocks.runExec.mockRejectedValue(new Error("timed out"));
-    const cfg = {
+    mocks.runExec.mockRejectedValue(new Error("timed out"));
+    const cfg: OpenClawConfig = {
       gateway: {
         auth: {
           token: "config-token",
         },
       },
-    } as OpenClawConfig;
+    };
 
-    await noteMacLaunchctlGatewayEnvOverrides(cfg, { platform: "darwin", noteFn });
+    await noteMacLaunchctlGatewayEnvOverrides(cfg);
 
-    expect(processMocks.runExec).toHaveBeenNthCalledWith(
+    expect(mocks.runExec).toHaveBeenNthCalledWith(
       1,
       "/bin/launchctl",
       ["getenv", "OPENCLAW_GATEWAY_TOKEN"],
       { logOutput: false, timeoutMs: 5_000 },
     );
-    expect(processMocks.runExec).toHaveBeenNthCalledWith(
+    expect(mocks.runExec).toHaveBeenNthCalledWith(
       2,
       "/bin/launchctl",
       ["getenv", "OPENCLAW_GATEWAY_PASSWORD"],
       { logOutput: false, timeoutMs: 5_000 },
     );
-    expect(noteFn).not.toHaveBeenCalled();
+    expect(mocks.note).not.toHaveBeenCalled();
   });
 });
 
@@ -138,23 +164,17 @@ describe("noteMacStaleOpenClawUpdateLaunchdJobs", () => {
       OPENCLAW_STATE_DIR: "/tmp/openclaw-daemon",
       OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.manual-update.gateway",
     };
-    const service = {
-      readCommand: vi.fn(async () => ({
-        programArguments: ["/bin/node", "cli", "gateway"],
-        environment: serviceEnv,
-      })),
-    };
-    const findJobs = vi.fn(async () => []);
-
-    await collectMacGatewayPlatformWarnings({} as OpenClawConfig, {
-      platform: "darwin",
-      service,
-      findJobs,
+    mocks.readCommand.mockResolvedValue({
+      programArguments: ["/bin/node", "cli", "gateway"],
+      environment: serviceEnv,
     });
 
-    expect(service.readCommand).toHaveBeenCalledTimes(1);
-    expect(findJobs).toHaveBeenCalledWith(
+    await collectMacGatewayPlatformWarnings({});
+
+    expect(mocks.readCommand).toHaveBeenCalledTimes(1);
+    expect(mocks.findJobs).toHaveBeenCalledWith(
       expect.objectContaining({
+        HOME: "/tmp/openclaw-doctor-host",
         OPENCLAW_STATE_DIR: "/tmp/openclaw-daemon",
         OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.manual-update.gateway",
       }),
@@ -166,23 +186,17 @@ describe("noteMacStaleOpenClawUpdateLaunchdJobs", () => {
       OPENCLAW_STATE_DIR: "/tmp/openclaw-daemon",
       OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.manual-update.gateway",
     };
-    const service = {
-      readCommand: vi.fn(async () => ({
-        programArguments: ["/bin/node", "cli", "doctor"],
-        environment: serviceEnv,
-      })),
-    };
-    const findJobs = vi.fn(async () => []);
-
-    await noteMacStaleOpenClawUpdateLaunchdJobs({
-      platform: "darwin",
-      service,
-      findJobs,
+    mocks.readCommand.mockResolvedValue({
+      programArguments: ["/bin/node", "cli", "doctor"],
+      environment: serviceEnv,
     });
 
-    expect(service.readCommand).toHaveBeenCalledTimes(1);
-    expect(findJobs).toHaveBeenCalledWith(
+    await noteMacStaleOpenClawUpdateLaunchdJobs();
+
+    expect(mocks.readCommand).toHaveBeenCalledTimes(1);
+    expect(mocks.findJobs).toHaveBeenCalledWith(
       expect.objectContaining({
+        HOME: "/tmp/openclaw-doctor-host",
         OPENCLAW_STATE_DIR: "/tmp/openclaw-daemon",
         OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.manual-update.gateway",
       }),
@@ -190,11 +204,7 @@ describe("noteMacStaleOpenClawUpdateLaunchdJobs", () => {
   });
 
   it("prints stale updater job cleanup guidance on macOS", async () => {
-    const noteFn = vi.fn();
-    const service = {
-      readCommand: vi.fn(async () => null),
-    };
-    const findJobs = vi.fn(async () => [
+    mocks.findJobs.mockResolvedValue([
       {
         label: "ai.openclaw.update.2026.5.12",
         lastExitStatus: 127,
@@ -205,15 +215,10 @@ describe("noteMacStaleOpenClawUpdateLaunchdJobs", () => {
       },
     ]);
 
-    await noteMacStaleOpenClawUpdateLaunchdJobs({
-      platform: "darwin",
-      service,
-      findJobs,
-      noteFn,
-    });
+    await noteMacStaleOpenClawUpdateLaunchdJobs();
 
-    expect(findJobs).toHaveBeenCalledTimes(1);
-    const [message, title] = expectDefined<unknown[]>(noteFn.mock.calls[0], "note call 0");
+    expect(mocks.findJobs).toHaveBeenCalledTimes(1);
+    const [message, title] = expectDefined<unknown[]>(mocks.note.mock.calls[0], "note call 0");
     expect(title).toBe("Gateway (macOS)");
     expect(message).toContain("Stale OpenClaw updater launchd job(s) detected");
     expect(message).toContain("ai.openclaw.update.2026.5.12");
@@ -223,54 +228,25 @@ describe("noteMacStaleOpenClawUpdateLaunchdJobs", () => {
   });
 
   it("does nothing when no stale updater jobs exist", async () => {
-    const noteFn = vi.fn();
-    const service = {
-      readCommand: vi.fn(async () => null),
-    };
-    const findJobs = vi.fn(async () => []);
+    await noteMacStaleOpenClawUpdateLaunchdJobs();
 
-    await noteMacStaleOpenClawUpdateLaunchdJobs({
-      platform: "darwin",
-      service,
-      findJobs,
-      noteFn,
-    });
-
-    expect(noteFn).not.toHaveBeenCalled();
+    expect(mocks.note).not.toHaveBeenCalled();
   });
 });
 
 describe("collectMacGatewayPlatformWarnings", () => {
   it("collects guidance when launch agent writes are disabled", async () => {
-    const exists = vi
-      .spyOn(fs, "existsSync")
-      .mockImplementation((candidate) => String(candidate).includes("disable-launchagent"));
-    try {
-      const warnings = await collectMacGatewayPlatformWarnings({} as OpenClawConfig, {
-        platform: "darwin",
-        service: { readCommand: vi.fn(async () => null) },
-        findJobs: vi.fn(async () => []),
-      });
+    vi.mocked(fs.existsSync).mockImplementation(
+      (candidate) => candidate === "/tmp/openclaw-doctor-host/.openclaw/disable-launchagent",
+    );
+    mocks.readCommand.mockResolvedValue({ environment: { HOME: "/tmp/openclaw-doctor-service" } });
+    const warnings = await collectMacGatewayPlatformWarnings({});
 
-      expect(warnings).toEqual([expect.stringContaining("LaunchAgent writes are disabled")]);
-      expect(warnings[0]).toContain("disable-launchagent");
-    } finally {
-      exists.mockRestore();
-    }
+    expect(warnings).toEqual([expect.stringContaining("LaunchAgent writes are disabled")]);
+    expect(warnings[0]).toContain("disable-launchagent");
   });
 
   it("does nothing when launch agent writes are not disabled", async () => {
-    const exists = vi.spyOn(fs, "existsSync").mockReturnValue(false);
-    try {
-      await expect(
-        collectMacGatewayPlatformWarnings({} as OpenClawConfig, {
-          platform: "darwin",
-          service: { readCommand: vi.fn(async () => null) },
-          findJobs: vi.fn(async () => []),
-        }),
-      ).resolves.toEqual([]);
-    } finally {
-      exists.mockRestore();
-    }
+    await expect(collectMacGatewayPlatformWarnings({})).resolves.toEqual([]);
   });
 });

--- a/src/commands/doctor-platform-notes.startup-optimization.test.ts
+++ b/src/commands/doctor-platform-notes.startup-optimization.test.ts
@@ -1,35 +1,45 @@
 // Doctor platform note tests cover startup optimization hints and note output.
+import os from "node:os";
 import { expectDefined } from "@openclaw/normalization-core/expect";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { noteStartupOptimizationHints } from "./doctor-platform-notes.js";
+
+const { note } = vi.hoisted(() => ({ note: vi.fn() }));
+vi.mock("../../packages/terminal-core/src/note.js", () => ({ note }));
+
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
+beforeEach(() => {
+  note.mockReset();
+  Object.defineProperty(process, "platform", { ...platformDescriptor, value: "linux" });
+  vi.spyOn(os, "arch").mockReturnValue("arm64");
+  vi.spyOn(os, "totalmem").mockReturnValue(4 * 1024 ** 3);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (platformDescriptor) {
+    Object.defineProperty(process, "platform", platformDescriptor);
+  }
+});
 
 describe("noteStartupOptimizationHints", () => {
   it("does not warn when compile cache and no-respawn are configured", () => {
-    const noteFn = vi.fn();
+    noteStartupOptimizationHints({
+      NODE_COMPILE_CACHE: "/var/tmp/openclaw-compile-cache",
+      OPENCLAW_NO_RESPAWN: "1",
+    });
 
-    noteStartupOptimizationHints(
-      {
-        NODE_COMPILE_CACHE: "/var/tmp/openclaw-compile-cache",
-        OPENCLAW_NO_RESPAWN: "1",
-      },
-      { platform: "linux", arch: "arm64", totalMemBytes: 4 * 1024 ** 3, noteFn },
-    );
-
-    expect(noteFn).not.toHaveBeenCalled();
+    expect(note).not.toHaveBeenCalled();
   });
 
   it("warns when compile cache is under /tmp and no-respawn is not set", () => {
-    const noteFn = vi.fn();
+    noteStartupOptimizationHints({
+      NODE_COMPILE_CACHE: "/tmp/openclaw-compile-cache",
+    });
 
-    noteStartupOptimizationHints(
-      {
-        NODE_COMPILE_CACHE: "/tmp/openclaw-compile-cache",
-      },
-      { platform: "linux", arch: "arm64", totalMemBytes: 4 * 1024 ** 3, noteFn },
-    );
-
-    expect(noteFn).toHaveBeenCalledTimes(1);
-    const [message, title] = expectDefined<unknown[]>(noteFn.mock.calls[0], "note call 0");
+    expect(note).toHaveBeenCalledTimes(1);
+    const [message, title] = expectDefined<unknown[]>(note.mock.calls[0], "note call 0");
     expect(title).toBe("Startup optimization");
     expect(message).toBe(
       [
@@ -44,19 +54,14 @@ describe("noteStartupOptimizationHints", () => {
   });
 
   it("warns when compile cache is disabled via env override", () => {
-    const noteFn = vi.fn();
+    noteStartupOptimizationHints({
+      NODE_COMPILE_CACHE: "/var/tmp/openclaw-compile-cache",
+      OPENCLAW_NO_RESPAWN: "1",
+      NODE_DISABLE_COMPILE_CACHE: "1",
+    });
 
-    noteStartupOptimizationHints(
-      {
-        NODE_COMPILE_CACHE: "/var/tmp/openclaw-compile-cache",
-        OPENCLAW_NO_RESPAWN: "1",
-        NODE_DISABLE_COMPILE_CACHE: "1",
-      },
-      { platform: "linux", arch: "arm64", totalMemBytes: 4 * 1024 ** 3, noteFn },
-    );
-
-    expect(noteFn).toHaveBeenCalledTimes(1);
-    const [message] = expectDefined<unknown[]>(noteFn.mock.calls[0], "note call 0");
+    expect(note).toHaveBeenCalledTimes(1);
+    const [message] = expectDefined<unknown[]>(note.mock.calls[0], "note call 0");
     expect(message).toBe(
       [
         "- NODE_DISABLE_COMPILE_CACHE is set; startup compile cache is disabled.",
@@ -70,28 +75,23 @@ describe("noteStartupOptimizationHints", () => {
   });
 
   it("skips startup optimization note on win32", () => {
-    const noteFn = vi.fn();
+    Object.defineProperty(process, "platform", { ...platformDescriptor, value: "win32" });
 
-    noteStartupOptimizationHints(
-      {
-        NODE_COMPILE_CACHE: "/tmp/openclaw-compile-cache",
-      },
-      { platform: "win32", arch: "arm64", totalMemBytes: 4 * 1024 ** 3, noteFn },
-    );
+    noteStartupOptimizationHints({
+      NODE_COMPILE_CACHE: "/tmp/openclaw-compile-cache",
+    });
 
-    expect(noteFn).not.toHaveBeenCalled();
+    expect(note).not.toHaveBeenCalled();
   });
 
   it("skips startup optimization note on non-target linux hosts", () => {
-    const noteFn = vi.fn();
+    vi.mocked(os.arch).mockReturnValue("x64");
+    vi.mocked(os.totalmem).mockReturnValue(32 * 1024 ** 3);
 
-    noteStartupOptimizationHints(
-      {
-        NODE_COMPILE_CACHE: "/tmp/openclaw-compile-cache",
-      },
-      { platform: "linux", arch: "x64", totalMemBytes: 32 * 1024 ** 3, noteFn },
-    );
+    noteStartupOptimizationHints({
+      NODE_COMPILE_CACHE: "/tmp/openclaw-compile-cache",
+    });
 
-    expect(noteFn).not.toHaveBeenCalled();
+    expect(note).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/doctor-platform-notes.ts
+++ b/src/commands/doctor-platform-notes.ts
@@ -14,30 +14,23 @@ import {
   launchAgentPlistExists,
   resolveLaunchAgentLabel,
 } from "../daemon/launchd.js";
-import { resolveGatewayService, type GatewayService } from "../daemon/service.js";
+import { resolveGatewayService } from "../daemon/service.js";
 import { runExec } from "../process/exec.js";
 import { shortenHomePath } from "../utils.js";
 
 const DOCTOR_LAUNCHCTL_TIMEOUT_MS = 5_000;
 
-function resolveHomeDir(): string {
-  return process.env.HOME ?? os.homedir();
-}
-
 /** Returns the macOS marker warning when LaunchAgent writes are locally disabled. */
-function collectMacLaunchAgentOverrideWarning(deps?: {
-  platform?: NodeJS.Platform;
-  homeDir?: string;
-  exists?: (candidate: string) => boolean;
-}): string | null {
-  if ((deps?.platform ?? process.platform) !== "darwin") {
+function collectMacLaunchAgentOverrideWarning(): string | null {
+  if (process.platform !== "darwin") {
     return null;
   }
-  const home = deps?.homeDir ?? resolveHomeDir();
-  const markerCandidates = [path.join(home, ".openclaw", "disable-launchagent")];
-  const exists = deps?.exists ?? fs.existsSync;
-  const markerPath = markerCandidates.find((candidate) => exists(candidate));
-  if (!markerPath) {
+  const markerPath = path.join(
+    process.env.HOME ?? os.homedir(),
+    ".openclaw",
+    "disable-launchagent",
+  );
+  if (!fs.existsSync(markerPath)) {
     return null;
   }
 
@@ -81,19 +74,12 @@ export async function noteMacDisabledGatewayLaunchAgent(env: NodeJS.ProcessEnv =
 }
 
 /** Returns a warning for stale OpenClaw updater launchd jobs left after interrupted updates. */
-async function collectMacStaleOpenClawUpdateLaunchdJobsWarning(deps?: {
-  platform?: NodeJS.Platform;
-  findJobs?: typeof findStaleOpenClawUpdateLaunchdJobs;
-  env?: NodeJS.ProcessEnv;
-}): Promise<string | null> {
-  const platform = deps?.platform ?? process.platform;
-  if (platform !== "darwin") {
+async function collectMacStaleOpenClawUpdateLaunchdJobsWarning(): Promise<string | null> {
+  if (process.platform !== "darwin") {
     return null;
   }
-  const scanEnv = deps?.env ?? process.env;
-  const jobs = await (deps?.findJobs ?? findStaleOpenClawUpdateLaunchdJobs)(scanEnv).catch(
-    () => [],
-  );
+  const scanEnv = await resolveGatewayServiceEnvForPlatformNotes();
+  const jobs = await findStaleOpenClawUpdateLaunchdJobs(scanEnv).catch(() => []);
   if (jobs.length === 0) {
     return null;
   }
@@ -113,23 +99,10 @@ async function collectMacStaleOpenClawUpdateLaunchdJobsWarning(deps?: {
 }
 
 /** Emits stale updater launchd job notes using the gateway service environment when available. */
-export async function noteMacStaleOpenClawUpdateLaunchdJobs(deps?: {
-  platform?: NodeJS.Platform;
-  findJobs?: typeof findStaleOpenClawUpdateLaunchdJobs;
-  env?: NodeJS.ProcessEnv;
-  service?: Pick<GatewayService, "readCommand">;
-  noteFn?: typeof note;
-}) {
-  const platform = deps?.platform ?? process.platform;
-  const serviceEnv =
-    platform === "darwin" ? await resolveGatewayServiceEnvForPlatformNotes(deps) : deps?.env;
-  const warning = await collectMacStaleOpenClawUpdateLaunchdJobsWarning({
-    env: serviceEnv,
-    findJobs: deps?.findJobs,
-    platform,
-  });
+export async function noteMacStaleOpenClawUpdateLaunchdJobs() {
+  const warning = await collectMacStaleOpenClawUpdateLaunchdJobsWarning();
   if (warning) {
-    (deps?.noteFn ?? note)(warning, "Gateway (macOS)");
+    note(warning, "Gateway (macOS)");
   }
 }
 
@@ -139,8 +112,7 @@ async function launchctlGetenv(name: string): Promise<string | undefined> {
       logOutput: false,
       timeoutMs: DOCTOR_LAUNCHCTL_TIMEOUT_MS,
     });
-    const value = normalizeOptionalString(result.stdout) ?? "";
-    return value.length > 0 ? value : undefined;
+    return normalizeOptionalString(result.stdout);
   } catch {
     return undefined;
   }
@@ -161,32 +133,16 @@ function hasConfigGatewayCreds(cfg: OpenClawConfig): boolean {
 /** Returns a warning for host-wide launchctl gateway auth env overrides. */
 async function collectMacLaunchctlGatewayEnvOverrideWarning(
   cfg: OpenClawConfig,
-  deps?: {
-    platform?: NodeJS.Platform;
-    getenv?: (name: string) => Promise<string | undefined>;
-  },
 ): Promise<string | null> {
-  const platform = deps?.platform ?? process.platform;
-  if (platform !== "darwin") {
+  if (process.platform !== "darwin") {
     return null;
   }
   if (!hasConfigGatewayCreds(cfg)) {
     return null;
   }
 
-  const getenv = deps?.getenv ?? launchctlGetenv;
-  const tokenEntries = [
-    ["OPENCLAW_GATEWAY_TOKEN", await getenv("OPENCLAW_GATEWAY_TOKEN")],
-  ] as const;
-  const passwordEntries = [
-    ["OPENCLAW_GATEWAY_PASSWORD", await getenv("OPENCLAW_GATEWAY_PASSWORD")],
-  ] as const;
-  const tokenEntry = tokenEntries.find(([, value]) => normalizeOptionalString(value));
-  const passwordEntry = passwordEntries.find(([, value]) => normalizeOptionalString(value));
-  const envToken = normalizeOptionalString(tokenEntry?.[1]) ?? "";
-  const envPassword = normalizeOptionalString(passwordEntry?.[1]) ?? "";
-  const envTokenKey = tokenEntry?.[0];
-  const envPasswordKey = passwordEntry?.[0];
+  const envToken = await launchctlGetenv("OPENCLAW_GATEWAY_TOKEN");
+  const envPassword = await launchctlGetenv("OPENCLAW_GATEWAY_PASSWORD");
   if (!envToken && !envPassword) {
     return null;
   }
@@ -194,77 +150,54 @@ async function collectMacLaunchctlGatewayEnvOverrideWarning(
   return [
     "- Host-wide launchctl gateway auth overrides detected.",
     "- Current managed Gateway installs do not need these values unless config intentionally references the env var.",
-    envToken && envTokenKey
-      ? `- \`${envTokenKey}\` is set; explicit environment URL or node-host targets can use a different token than gateway.auth.token.`
+    envToken
+      ? "- `OPENCLAW_GATEWAY_TOKEN` is set; explicit environment URL or node-host targets can use a different token than gateway.auth.token."
       : undefined,
     envPassword
-      ? `- \`${envPasswordKey ?? "OPENCLAW_GATEWAY_PASSWORD"}\` is set; explicit environment URL or node-host targets can use a different password than gateway.auth.password.`
+      ? "- `OPENCLAW_GATEWAY_PASSWORD` is set; explicit environment URL or node-host targets can use a different password than gateway.auth.password."
       : undefined,
     "- Clear overrides and restart the app/gateway:",
-    envTokenKey ? `  launchctl unsetenv ${envTokenKey}` : undefined,
-    envPasswordKey ? `  launchctl unsetenv ${envPasswordKey}` : undefined,
+    envToken ? "  launchctl unsetenv OPENCLAW_GATEWAY_TOKEN" : undefined,
+    envPassword ? "  launchctl unsetenv OPENCLAW_GATEWAY_PASSWORD" : undefined,
   ]
     .filter((line): line is string => Boolean(line))
     .join("\n");
 }
 
 /** Emits macOS launchctl gateway auth override warnings. */
-export async function noteMacLaunchctlGatewayEnvOverrides(
-  cfg: OpenClawConfig,
-  deps?: {
-    platform?: NodeJS.Platform;
-    getenv?: (name: string) => Promise<string | undefined>;
-    noteFn?: typeof note;
-  },
-) {
-  const warning = await collectMacLaunchctlGatewayEnvOverrideWarning(cfg, deps);
+export async function noteMacLaunchctlGatewayEnvOverrides(cfg: OpenClawConfig) {
+  const warning = await collectMacLaunchctlGatewayEnvOverrideWarning(cfg);
   if (warning) {
-    (deps?.noteFn ?? note)(warning, "Gateway (macOS)");
+    note(warning, "Gateway (macOS)");
   }
 }
 
-async function resolveGatewayServiceEnvForPlatformNotes(deps?: {
-  env?: NodeJS.ProcessEnv;
-  service?: Pick<GatewayService, "readCommand">;
-}): Promise<NodeJS.ProcessEnv> {
-  const baseEnv = deps?.env ?? process.env;
-  const service = deps?.service ?? resolveGatewayService();
+async function resolveGatewayServiceEnvForPlatformNotes(): Promise<NodeJS.ProcessEnv> {
+  const baseEnv = process.env;
+  const service = resolveGatewayService();
   const command = await service.readCommand(baseEnv).catch(() => null);
   return command?.environment
-    ? ({
+    ? {
         ...baseEnv,
         ...command.environment,
-      } satisfies NodeJS.ProcessEnv)
+      }
     : baseEnv;
 }
 
 /** Collects all macOS gateway platform warnings without emitting notes. */
 export async function collectMacGatewayPlatformWarnings(
   cfg: OpenClawConfig,
-  deps?: {
-    platform?: NodeJS.Platform;
-    env?: NodeJS.ProcessEnv;
-    service?: Pick<GatewayService, "readCommand">;
-    findJobs?: typeof findStaleOpenClawUpdateLaunchdJobs;
-  },
 ): Promise<readonly string[]> {
-  const platform = deps?.platform ?? process.platform;
   const warnings: string[] = [];
-  const launchAgentWarning = collectMacLaunchAgentOverrideWarning({ platform });
+  const launchAgentWarning = collectMacLaunchAgentOverrideWarning();
   if (launchAgentWarning) {
     warnings.push(launchAgentWarning);
   }
-  const serviceEnv =
-    platform === "darwin" ? await resolveGatewayServiceEnvForPlatformNotes(deps) : deps?.env;
-  const staleUpdateWarning = await collectMacStaleOpenClawUpdateLaunchdJobsWarning({
-    env: serviceEnv,
-    findJobs: deps?.findJobs,
-    platform,
-  });
+  const staleUpdateWarning = await collectMacStaleOpenClawUpdateLaunchdJobsWarning();
   if (staleUpdateWarning) {
     warnings.push(staleUpdateWarning);
   }
-  const launchctlWarning = await collectMacLaunchctlGatewayEnvOverrideWarning(cfg, { platform });
+  const launchctlWarning = await collectMacLaunchctlGatewayEnvOverrideWarning(cfg);
   if (launchctlWarning) {
     warnings.push(launchctlWarning);
   }
@@ -282,21 +215,13 @@ function isTmpCompileCachePath(cachePath: string): boolean {
 }
 
 /** Emits startup tuning hints for low-power Linux hosts when env settings are suboptimal. */
-export function noteStartupOptimizationHints(
-  env: NodeJS.ProcessEnv = process.env,
-  deps?: {
-    platform?: NodeJS.Platform;
-    arch?: string;
-    totalMemBytes?: number;
-    noteFn?: typeof note;
-  },
-) {
-  const platform = deps?.platform ?? process.platform;
+export function noteStartupOptimizationHints(env: NodeJS.ProcessEnv = process.env) {
+  const platform = process.platform;
   if (platform === "win32") {
     return;
   }
-  const arch = deps?.arch ?? os.arch();
-  const totalMemBytes = deps?.totalMemBytes ?? os.totalmem();
+  const arch = os.arch();
+  const totalMemBytes = os.totalmem();
   const isArmHost = arch === "arm" || arch === "arm64";
   const isLowMemoryLinux =
     platform === "linux" && totalMemBytes > 0 && totalMemBytes <= 8 * 1024 ** 3;
@@ -305,7 +230,6 @@ export function noteStartupOptimizationHints(
     return;
   }
 
-  const noteFn = deps?.noteFn ?? note;
   const compileCache = normalizeOptionalString(env.NODE_COMPILE_CACHE) ?? "";
   const disableCompileCache = normalizeOptionalString(env.NODE_DISABLE_COMPILE_CACHE) ?? "";
   const noRespawn = normalizeOptionalString(env.OPENCLAW_NO_RESPAWN) ?? "";
@@ -343,5 +267,5 @@ export function noteStartupOptimizationHints(
     disableCompileCache ? "  unset NODE_DISABLE_COMPILE_CACHE" : undefined,
   ].filter((line): line is string => Boolean(line));
 
-  noteFn([...lines, ...suggestions].join("\n"), "Startup optimization");
+  note([...lines, ...suggestions].join("\n"), "Startup optimization");
 }

--- a/src/gateway/server-methods/chat-send-reply-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.ts
@@ -262,9 +262,6 @@ export function createChatSendReplyDispatch(params: {
       mediaMessage?.transcriptText ??
       extractAssistantDisplayTextFromContent(assistantContent) ??
       buildTranscriptReplyText([transcriptPayload]);
-    if (!transcriptReply && !persistedAssistantContent?.length && !assistantContent?.length) {
-      return;
-    }
     const payloadMetadata = getReplyPayloadMetadata(payload);
     const sourceMediaUrls = Array.from(
       new Set(
@@ -383,7 +380,7 @@ export function createChatSendReplyDispatch(params: {
     const appended = await appendAssistantTranscriptMessage({
       sessionKey,
       message: transcriptReply,
-      ...(persistedContentForAppend.length ? { content: persistedContentForAppend } : {}),
+      content: persistedContentForAppend,
       sessionId,
       storePath: latestStorePath,
       agentId,
@@ -461,25 +458,17 @@ export function createChatSendReplyDispatch(params: {
   };
   const finalizeAgentMediaTranscript = async () => {
     const latestPayloadByKey = new Map<string, ReplyPayload>();
-    const orderedKeys: string[] = [];
     for (const { payload } of deliveredReplies) {
       if (!needsAgentMediaTranscriptFinalization(payload)) {
         continue;
       }
-      const key = agentMediaTranscriptKey(payload);
-      if (!latestPayloadByKey.has(key)) {
-        orderedKeys.push(key);
-      }
-      latestPayloadByKey.set(key, payload);
+      latestPayloadByKey.set(agentMediaTranscriptKey(payload), payload);
     }
-    for (const key of orderedKeys) {
-      const payload = latestPayloadByKey.get(key);
-      if (payload) {
-        try {
-          await appendWebchatAgentMediaTranscriptIfNeeded(payload);
-        } catch (error) {
-          logGateway.warn(`webchat media finalization failed: ${formatForLog(error)}`);
-        }
+    for (const payload of latestPayloadByKey.values()) {
+      try {
+        await appendWebchatAgentMediaTranscriptIfNeeded(payload);
+      } catch (error) {
+        logGateway.warn(`webchat media finalization failed: ${formatForLog(error)}`);
       }
     }
   };

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -3491,7 +3491,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
   });
 
-  it("materializes each distinct assistant media row once", async () => {
+  it("materializes latest media payloads once in first-seen order", async () => {
     await withTranscriptFixtureState(
       "openclaw-chat-send-multiple-assistant-media-",
       async (fixtureDir) => {
@@ -3512,7 +3512,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           {
             kind: "block",
             payload: setReplyPayloadMetadata(
-              { text: "First image", mediaUrl: firstMediaUrl, mediaUrls: [firstMediaUrl] },
+              { text: "Draft first image", mediaUrl: firstMediaUrl, mediaUrls: [firstMediaUrl] },
               {
                 assistantMessageIndex: 1,
                 assistantTranscriptMediaUrls: [firstMediaUrl],
@@ -3526,6 +3526,16 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
               {
                 assistantMessageIndex: 2,
                 assistantTranscriptMediaUrls: [secondMediaUrl],
+              },
+            ),
+          },
+          {
+            kind: "final",
+            payload: setReplyPayloadMetadata(
+              { text: "First image", mediaUrl: firstMediaUrl, mediaUrls: [firstMediaUrl] },
+              {
+                assistantMessageIndex: 1,
+                assistantTranscriptMediaUrls: [firstMediaUrl],
               },
             ),
           },
@@ -3553,6 +3563,15 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           expect(JSON.stringify(content)).not.toContain("MEDIA:");
         }
         expect(JSON.stringify(messages)).not.toContain(":assistant-media");
+        const mediaMessageIds = readTranscriptJsonLines(mockState.transcriptPath)
+          .filter((entry) => asOptionalRecord(entry.message)?.role === "assistant")
+          .slice(1)
+          .map((entry) => entry.id);
+        expect(
+          mockState.emittedTranscriptUpdates
+            .filter((update) => mediaMessageIds.includes(update.messageId))
+            .map((update) => update.messageId),
+        ).toEqual(mediaMessageIds);
       },
     );
   });

--- a/src/gateway/server-methods/sessions-sharing.ts
+++ b/src/gateway/server-methods/sessions-sharing.ts
@@ -247,11 +247,7 @@ function knownSessionIdentities(params: {
       ...(profile.displayName ? { label: profile.displayName } : {}),
     });
   }
-  return [...identities.values()].toSorted(
-    (left, right) =>
-      (left.label ?? left.id).localeCompare(right.label ?? right.id) ||
-      left.id.localeCompare(right.id),
-  );
+  return [...identities.values()];
 }
 
 function publishSharingChange(params: {

--- a/src/gateway/worker-environments/workspace-reconcile-recovery.ts
+++ b/src/gateway/worker-environments/workspace-reconcile-recovery.ts
@@ -190,11 +190,7 @@ export async function createWorkspacePatch(params: {
     if (packed.stdout.byteLength > MAX_RECONCILIATION_TOTAL_BYTES) {
       throw new Error("Cloud workspace recovery snapshot exceeds its byte limit");
     }
-    for (const name of await fs.readdir(temporary)) {
-      if (name !== ".git") {
-        await fs.rm(path.join(temporary, name), { recursive: true, force: true });
-      }
-    }
+    await clearTemporaryWorkspace(temporary);
     for (const entry of params.appliedEntries) {
       await materializeSnapshotEntry({
         root: temporary,

--- a/src/infra/backup-archive-publication.test.ts
+++ b/src/infra/backup-archive-publication.test.ts
@@ -40,6 +40,9 @@ async function prepareArchive(
   const preparedPromise = writeArchiveStreamToFile({
     archivePath: plan.tempArchivePath,
     createArchiveStream: () => archiveStream,
+    onPartialArchive: (receipt) => {
+      plan.pendingCleanupArchives.push(receipt);
+    },
   });
   archiveStream.end(content);
   return await preparedPromise;

--- a/src/infra/backup-create-stream.ts
+++ b/src/infra/backup-create-stream.ts
@@ -73,13 +73,11 @@ export async function writeArchiveStreamToFile(params: {
   createArchiveStream: (
     reportProgress: (progress?: BackupArchiveProgress) => void,
   ) => DestroyableArchiveStream;
-  idleTimeoutMs?: number;
-  onPartialArchive?: (receipt: BackupArchiveCleanupReceipt) => void;
+  onPartialArchive: (receipt: BackupArchiveCleanupReceipt) => void;
 }): Promise<PreparedBackupArchive> {
   // Own both stream lifecycles so a tar read error closes the output handle
   // before retry cleanup touches the partial archive. Exclusive creation also
   // refuses a pre-existing path instead of following a symlink.
-  const idleTimeoutMs = params.idleTimeoutMs ?? BACKUP_ARCHIVE_IDLE_TIMEOUT_MS;
   const controller = new AbortController();
   let archiveStream: DestroyableArchiveStream | undefined;
   let openedIdentity: Stats | undefined;
@@ -116,11 +114,11 @@ export async function writeArchiveStreamToFile(params: {
           ? `, entry=${JSON.stringify(sliceUtf16Safe(lastEntryPath, -512))}`
           : "";
         idleTimeoutError = new Error(
-          `Backup archive write stalled: no progress observed for ${idleTimeoutMs}ms (phase=${lastProgress?.phase ?? "starting"}${entrySuffix}, rawBytes=${producerBytes}, outputBytes=${outputBytes})`,
+          `Backup archive write stalled: no progress observed for ${BACKUP_ARCHIVE_IDLE_TIMEOUT_MS}ms (phase=${lastProgress?.phase ?? "starting"}${entrySuffix}, rawBytes=${producerBytes}, outputBytes=${outputBytes})`,
         );
         archiveStream?.destroy(idleTimeoutError);
         controller.abort(idleTimeoutError);
-      }, idleTimeoutMs);
+      }, BACKUP_ARCHIVE_IDLE_TIMEOUT_MS);
   };
   const progress = new Transform({
     transform(chunk, _encoding, callback) {
@@ -184,24 +182,7 @@ export async function writeArchiveStreamToFile(params: {
       (!cleanupReceipt.identity ||
         !removePreparedBackupArchive(cleanupReceipt as PreparedBackupArchive))
     ) {
-      params.onPartialArchive?.(cleanupReceipt);
-    }
-    if (cleanupReceipt && !cleanupReceipt.identity) {
-      // The outer cleanup owns the retry because this scope cannot safely
-      // unlink a pathname whose identity is temporarily unavailable.
-      if (!params.onPartialArchive) {
-        try {
-          const currentIdentity = fsSync.lstatSync(cleanupReceipt.archivePath);
-          if (currentIdentity.isFile()) {
-            removePreparedBackupArchive({
-              archivePath: cleanupReceipt.archivePath,
-              identity: currentIdentity,
-            });
-          }
-        } catch {
-          // No outer owner was provided; preserve the original write error.
-        }
-      }
+      params.onPartialArchive(cleanupReceipt);
     }
     throw idleTimeoutError ?? err;
   } finally {

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -506,43 +506,6 @@ describe("writeTarArchiveWithRetry", () => {
     expect(runTar).toHaveBeenCalledTimes(3);
   });
 
-  it("lets callers reset per-attempt counters so retries report the final attempt's count, not a running sum", async () => {
-    // Simulate the caller's pattern: a closure counter populated by a filter
-    // that tar.c invokes while walking the tree. Each attempt re-walks the
-    // same tree, so the runTar closure must reset the counter before calling
-    // tar.c -- otherwise the reported count accumulates across attempts.
-    let skippedVolatileCount = 0;
-    const volatileFilesSeenPerAttempt = 5;
-    let attempt = 0;
-
-    const eofErr = Object.assign(new Error("did not encounter expected EOF"), {
-      path: "/state/sessions/s-abc/transcript.jsonl",
-    });
-
-    const runTar = vi.fn<() => Promise<void>>().mockImplementation(async () => {
-      attempt += 1;
-      skippedVolatileCount = 0;
-      for (let i = 0; i < volatileFilesSeenPerAttempt; i += 1) {
-        skippedVolatileCount += 1;
-      }
-      if (attempt < 3) {
-        throw eofErr;
-      }
-    });
-    const sleep = vi.fn<(ms: number) => Promise<void>>().mockResolvedValue(undefined);
-
-    await writeTarArchiveWithRetry({
-      tempArchivePath: "/tmp/backup.tar.gz.tmp",
-      runTar,
-      sleepMs: sleep,
-    });
-
-    expect(runTar).toHaveBeenCalledTimes(3);
-    // Without the reset, this would be 15 (5 * 3 attempts). With the reset,
-    // it equals the count from the final (successful) attempt.
-    expect(skippedVolatileCount).toBe(volatileFilesSeenPerAttempt);
-  });
-
   it("does not retry on non-EOF errors", async () => {
     const runTar = vi.fn<() => Promise<void>>().mockRejectedValue(new Error("permission denied"));
     const sleep = vi.fn<(ms: number) => Promise<void>>().mockResolvedValue(undefined);

--- a/src/infra/backup-create.windows.test.ts
+++ b/src/infra/backup-create.windows.test.ts
@@ -24,6 +24,7 @@ describe("writeArchiveStreamToFile", () => {
       const writePromise = writeArchiveStreamToFile({
         archivePath,
         createArchiveStream: () => archiveStream,
+        onPartialArchive: vi.fn(),
       });
       archiveStream.end("partial archive");
 
@@ -41,6 +42,7 @@ describe("writeArchiveStreamToFile", () => {
     const writePromise = writeArchiveStreamToFile({
       archivePath,
       createArchiveStream: () => archiveStream,
+      onPartialArchive: vi.fn(),
     });
     archiveStream.write("partial archive");
     archiveStream.destroy(new Error("injected tar read failure"));
@@ -58,14 +60,14 @@ describe("writeArchiveStreamToFile", () => {
       const writePromise = writeArchiveStreamToFile({
         archivePath,
         createArchiveStream: () => archiveStream,
-        idleTimeoutMs: 50,
+        onPartialArchive: vi.fn(),
       });
       archiveStream.write("partial archive");
 
       const rejection = expect(writePromise).rejects.toThrow(
-        "Backup archive write stalled: no progress observed for 50ms",
+        "Backup archive write stalled: no progress observed for 300000ms",
       );
-      await vi.advanceTimersByTimeAsync(60);
+      await vi.advanceTimersByTimeAsync(300_001);
       await rejection;
       expect(archiveStream.destroyed).toBe(true);
       await expect(fs.lstat(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
@@ -83,13 +85,13 @@ describe("writeArchiveStreamToFile", () => {
       const writePromise = writeArchiveStreamToFile({
         archivePath,
         createArchiveStream: () => archiveStream,
-        idleTimeoutMs: 50,
+        onPartialArchive: vi.fn(),
       });
 
       archiveStream.write("first");
-      await vi.advanceTimersByTimeAsync(40);
+      await vi.advanceTimersByTimeAsync(240_000);
       archiveStream.write("second");
-      await vi.advanceTimersByTimeAsync(40);
+      await vi.advanceTimersByTimeAsync(240_000);
       archiveStream.end("third");
 
       await expect(writePromise).resolves.toMatchObject({ archivePath });
@@ -112,6 +114,7 @@ describe("writeArchiveStreamToFile", () => {
           reportProgress = progress;
           return archiveStream;
         },
+        onPartialArchive: vi.fn(),
       });
 
       for (let elapsed = 0; elapsed < 360_000; elapsed += 60_000) {
@@ -141,6 +144,7 @@ describe("writeArchiveStreamToFile", () => {
           reportProgress = progress;
           return archiveStream;
         },
+        onPartialArchive: vi.fn(),
       });
       observeBackupTarEntryProgress(entry, (bytes) => {
         reportProgress?.({ phase: "raw", entryPath: "/source/large.pack", bytes });
@@ -204,6 +208,7 @@ describe("writeArchiveStreamToFile", () => {
             reportProgress = progress;
             return archiveStream;
           },
+          onPartialArchive: vi.fn(),
         });
         observeBackupTarEntryProgress(entry, (bytes) => {
           reportProgress?.({ phase: "raw", entryPath, bytes });

--- a/src/infra/diagnostic-llm-content.ts
+++ b/src/infra/diagnostic-llm-content.ts
@@ -43,19 +43,6 @@ export function cloneDiagnosticContentValue(value: unknown): unknown {
   }
 }
 
-function withDerivedFields(
-  policy: Omit<DiagnosticModelContentCapturePolicy, "anyModelContent">,
-): DiagnosticModelContentCapturePolicy {
-  return {
-    ...policy,
-    anyModelContent:
-      policy.inputMessages ||
-      policy.outputMessages ||
-      policy.systemPrompt ||
-      policy.toolDefinitions,
-  };
-}
-
 /** Resolves model-content diagnostic capture from config, defaulting to no content capture. */
 export function resolveDiagnosticModelContentCapturePolicy(
   config: unknown,
@@ -74,14 +61,15 @@ export function resolveDiagnosticModelContentCapturePolicy(
 
   const captureContent = otel.captureContent;
   if (captureContent === true) {
-    return withDerivedFields({
+    return {
       inputMessages: true,
       outputMessages: true,
       toolInputs: true,
       toolOutputs: true,
       systemPrompt: false,
       toolDefinitions: true,
-    });
+      anyModelContent: true,
+    };
   }
   return NO_MODEL_CONTENT_CAPTURE;
 }

--- a/src/infra/push-apns-dispatch.test.ts
+++ b/src/infra/push-apns-dispatch.test.ts
@@ -1,0 +1,170 @@
+import { generateKeyPairSync } from "node:crypto";
+import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
+import { describe, expect, it, vi } from "vitest";
+import {
+  sendApnsAlert,
+  sendApnsBackgroundWake,
+  sendApnsExecApprovalAlert,
+  sendApnsExecApprovalResolvedWake,
+  sendApnsPluginApprovalAlert,
+  sendApnsPluginApprovalResolvedWake,
+} from "./push-apns.js";
+
+const apnsPrivateKey = generateKeyPairSync("ec", { namedCurve: "prime256v1" }).privateKey.export({
+  format: "pem",
+  type: "pkcs8",
+});
+const relayPrivateKey = generateKeyPairSync("ed25519").privateKey.export({
+  format: "pem",
+  type: "pkcs8",
+});
+
+const senderOptionKeys = {
+  direct: [
+    "token",
+    "topic",
+    "environment",
+    "bearerToken",
+    "payload",
+    "timeoutMs",
+    "pushType",
+    "priority",
+  ],
+  relay: [
+    "relayConfig",
+    "sendGrant",
+    "relayHandle",
+    "gatewayDeviceId",
+    "signature",
+    "signedAtMs",
+    "bodyJson",
+    "pushType",
+    "priority",
+    "payload",
+  ],
+};
+
+function createApnsTransportFixture(transport: "direct" | "relay") {
+  const registration = {
+    nodeId: "ios-dispatch",
+    topic: "ai.openclaw.ios",
+    environment: "sandbox" as const,
+    updatedAtMs: 1,
+  };
+  if (transport === "direct") {
+    const send = vi.fn().mockResolvedValue({ status: 200, apnsId: "dispatch-result", body: "" });
+    return {
+      send,
+      params: {
+        registration: {
+          ...registration,
+          transport: "direct" as const,
+          token: "abcd1234abcd1234abcd1234abcd1234",
+        },
+        auth: { teamId: "TEAM123", keyId: "KEY123", privateKey: apnsPrivateKey },
+        requestSender: send,
+      },
+    };
+  }
+  const send = vi.fn().mockResolvedValue({ ok: true, status: 202, environment: "sandbox" });
+  return {
+    send,
+    params: {
+      registration: {
+        ...registration,
+        transport: "relay" as const,
+        relayHandle: "relay-dispatch",
+        sendGrant: "grant-dispatch",
+        installationId: "installation-dispatch",
+        distribution: "official" as const,
+      },
+      relayConfig: { baseUrl: "https://relay.example.test", timeoutMs: 2_500 },
+      relayGatewayIdentity: { deviceId: "gateway-dispatch", privateKeyPem: relayPrivateKey },
+      relayRequestSender: send,
+    },
+  };
+}
+
+const requireRecord = createRequireRecord("object", "label-not-object");
+
+function requireSendRequest(send: ReturnType<typeof vi.fn>) {
+  expect(send).toHaveBeenCalledTimes(1);
+  return requireRecord(send.mock.calls[0]?.[0], "APNs send request");
+}
+
+describe("APNs dispatch", () => {
+  it.each([
+    ["direct", "alert"],
+    ["direct", "background"],
+    ["relay", "alert"],
+    ["relay", "background"],
+  ] as const)(
+    "preserves %s %s lifecycle forwarding and option omission",
+    async (transport, kind) => {
+      const { send, params } = createApnsTransportFixture(transport);
+      const controller = new AbortController();
+      const isCurrent = vi.fn().mockResolvedValue(true);
+      const sendPush = (controls: { signal?: AbortSignal; isCurrent?: () => Promise<boolean> }) => {
+        const common = { ...params, nodeId: "ios-dispatch", timeoutMs: 2_700, ...controls };
+        return kind === "alert"
+          ? sendApnsAlert({ ...common, title: "Wake", body: "Ping" })
+          : sendApnsBackgroundWake({ ...common, wakeReason: "node.invoke" });
+      };
+
+      await sendPush({ signal: controller.signal, isCurrent });
+      const controlled = requireSendRequest(send);
+      expect(Object.keys(controlled)).toEqual([
+        ...senderOptionKeys[transport],
+        "signal",
+        "isCurrent",
+      ]);
+      expect(controlled.signal).toBe(controller.signal);
+      expect(controlled.isCurrent).toBe(isCurrent);
+      expect(controlled.pushType).toBe(kind);
+      expect(controlled.priority).toBe(kind === "alert" ? "10" : "5");
+      expect(isCurrent).toHaveBeenCalledTimes(1);
+
+      send.mockClear();
+      await sendPush({});
+      expect(Object.keys(requireSendRequest(send))).toEqual(senderOptionKeys[transport]);
+      expect(isCurrent).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(["direct", "relay"] as const)(
+    "ignores extraneous lifecycle controls for %s approval notifications",
+    async (transport) => {
+      const { send, params } = createApnsTransportFixture(transport);
+      const readControl = vi.fn(() => {
+        throw new Error("approval notifications must not read lifecycle controls");
+      });
+      const approval = Object.defineProperties(
+        {
+          ...params,
+          nodeId: "ios-dispatch",
+          approvalId: "approval-dispatch",
+          gatewayDeviceId: "gateway-dispatch",
+          title: "Approval",
+          description: "Review this request.",
+          timeoutMs: 2_700,
+        },
+        {
+          signal: { enumerable: true, get: readControl },
+          isCurrent: { enumerable: true, get: readControl },
+        },
+      );
+
+      for (const sendApproval of [
+        sendApnsExecApprovalAlert,
+        sendApnsPluginApprovalAlert,
+        sendApnsExecApprovalResolvedWake,
+        sendApnsPluginApprovalResolvedWake,
+      ]) {
+        send.mockClear();
+        await sendApproval(approval);
+        expect(Object.keys(requireSendRequest(send))).toEqual(senderOptionKeys[transport]);
+      }
+      expect(readControl).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/src/infra/push-apns.ts
+++ b/src/infra/push-apns.ts
@@ -431,16 +431,12 @@ async function sendRelayApnsPush(params: {
   return toPushResult({ registration: params.registration, response });
 }
 
-type ApnsAlertCommonParams = {
+type ApnsTransportCommonParams = {
   nodeId: string;
-  title: string;
-  body: string;
   timeoutMs?: number;
-  signal?: AbortSignal;
-  isCurrent?: () => Promise<boolean>;
 };
 
-type DirectApnsAlertParams = ApnsAlertCommonParams & {
+type DirectApnsTransportParams = ApnsTransportCommonParams & {
   registration: DirectApnsRegistration;
   auth: ApnsAuthConfig;
   requestSender?: ApnsRequestSender;
@@ -448,7 +444,7 @@ type DirectApnsAlertParams = ApnsAlertCommonParams & {
   relayRequestSender?: never;
 };
 
-type RelayApnsAlertParams = ApnsAlertCommonParams & {
+type RelayApnsTransportParams = ApnsTransportCommonParams & {
   registration: RelayApnsRegistration;
   relayConfig: ApnsRelayConfig;
   relayRequestSender?: ApnsRelayRequestSender;
@@ -457,56 +453,24 @@ type RelayApnsAlertParams = ApnsAlertCommonParams & {
   requestSender?: never;
 };
 
-type ApnsBackgroundWakeCommonParams = {
-  nodeId: string;
-  wakeReason?: string;
-  timeoutMs?: number;
-  signal?: AbortSignal;
-  isCurrent?: () => Promise<boolean>;
-};
+type ApnsTransportParams = DirectApnsTransportParams | RelayApnsTransportParams;
+type ApnsLifecycleControls = Pick<ApnsRequestParams, "signal" | "isCurrent">;
 
-type DirectApnsBackgroundWakeParams = ApnsBackgroundWakeCommonParams & {
-  registration: DirectApnsRegistration;
-  auth: ApnsAuthConfig;
-  requestSender?: ApnsRequestSender;
-  relayConfig?: never;
-  relayRequestSender?: never;
-};
+type ApnsAlertParams = ApnsTransportParams &
+  ApnsLifecycleControls & {
+    title: string;
+    body: string;
+  };
 
-type RelayApnsBackgroundWakeParams = ApnsBackgroundWakeCommonParams & {
-  registration: RelayApnsRegistration;
-  relayConfig: ApnsRelayConfig;
-  relayRequestSender?: ApnsRelayRequestSender;
-  relayGatewayIdentity?: Pick<DeviceIdentity, "deviceId" | "privateKeyPem">;
-  auth?: never;
-  requestSender?: never;
-};
+type ApnsBackgroundWakeParams = ApnsTransportParams &
+  ApnsLifecycleControls & {
+    wakeReason?: string;
+  };
 
-type ApnsApprovalCommonParams = {
-  nodeId: string;
+type ApnsApprovalParams = ApnsTransportParams & {
   approvalId: string;
   gatewayDeviceId: string;
-  timeoutMs?: number;
 };
-
-type DirectApnsApprovalParams = ApnsApprovalCommonParams & {
-  registration: DirectApnsRegistration;
-  auth: ApnsAuthConfig;
-  requestSender?: ApnsRequestSender;
-  relayConfig?: never;
-  relayRequestSender?: never;
-};
-
-type RelayApnsApprovalParams = ApnsApprovalCommonParams & {
-  registration: RelayApnsRegistration;
-  relayConfig: ApnsRelayConfig;
-  relayRequestSender?: ApnsRelayRequestSender;
-  relayGatewayIdentity?: Pick<DeviceIdentity, "deviceId" | "privateKeyPem">;
-  auth?: never;
-  requestSender?: never;
-};
-
-type ApnsApprovalParams = DirectApnsApprovalParams | RelayApnsApprovalParams;
 
 type ApnsPluginApprovalAlertParams = ApnsApprovalParams & {
   title?: string | null;
@@ -514,89 +478,47 @@ type ApnsPluginApprovalAlertParams = ApnsApprovalParams & {
 };
 
 /** Sends a visible APNs alert via direct APNs token or relay registration. */
-export async function sendApnsAlert(
-  params: DirectApnsAlertParams | RelayApnsAlertParams,
-): Promise<ApnsPushAlertResult> {
+export async function sendApnsAlert(params: ApnsAlertParams): Promise<ApnsPushAlertResult> {
   const payload = createApnsAlertPayload({
     nodeId: params.nodeId,
     title: params.title,
     body: params.body,
   });
 
-  if (params.registration.transport === "relay") {
-    const relayParams = params as RelayApnsAlertParams;
-    return await sendRelayApnsPush({
-      relayConfig: relayParams.relayConfig,
-      registration: relayParams.registration,
-      payload,
-      pushType: "alert",
-      priority: "10",
-      gatewayIdentity: relayParams.relayGatewayIdentity,
-      requestSender: relayParams.relayRequestSender,
-      ...(relayParams.signal ? { signal: relayParams.signal } : {}),
-      ...(relayParams.isCurrent ? { isCurrent: relayParams.isCurrent } : {}),
-    });
-  }
-  const directParams = params as DirectApnsAlertParams;
-  return await sendDirectApnsPush({
-    auth: directParams.auth,
-    registration: directParams.registration,
-    payload,
-    timeoutMs: directParams.timeoutMs,
-    requestSender: directParams.requestSender,
-    pushType: "alert",
-    priority: "10",
-    ...(directParams.signal ? { signal: directParams.signal } : {}),
-    ...(directParams.isCurrent ? { isCurrent: directParams.isCurrent } : {}),
-  });
+  return await sendApnsPush(
+    { transport: params, payload, pushType: "alert", priority: "10" },
+    params,
+  );
 }
 
 /** Sends a silent background wake via direct APNs token or relay registration. */
 export async function sendApnsBackgroundWake(
-  params: DirectApnsBackgroundWakeParams | RelayApnsBackgroundWakeParams,
+  params: ApnsBackgroundWakeParams,
 ): Promise<ApnsPushWakeResult> {
   const payload = createApnsBackgroundPayload({
     nodeId: params.nodeId,
     wakeReason: params.wakeReason,
   });
 
-  if (params.registration.transport === "relay") {
-    const relayParams = params as RelayApnsBackgroundWakeParams;
-    return await sendRelayApnsPush({
-      relayConfig: relayParams.relayConfig,
-      registration: relayParams.registration,
-      payload,
-      pushType: "background",
-      priority: "5",
-      gatewayIdentity: relayParams.relayGatewayIdentity,
-      requestSender: relayParams.relayRequestSender,
-      ...(relayParams.signal ? { signal: relayParams.signal } : {}),
-      ...(relayParams.isCurrent ? { isCurrent: relayParams.isCurrent } : {}),
-    });
-  }
-  const directParams = params as DirectApnsBackgroundWakeParams;
-  return await sendDirectApnsPush({
-    auth: directParams.auth,
-    registration: directParams.registration,
-    payload,
-    timeoutMs: directParams.timeoutMs,
-    requestSender: directParams.requestSender,
-    pushType: "background",
-    priority: "5",
-    ...(directParams.signal ? { signal: directParams.signal } : {}),
-    ...(directParams.isCurrent ? { isCurrent: directParams.isCurrent } : {}),
-  });
+  return await sendApnsPush(
+    { transport: params, payload, pushType: "background", priority: "5" },
+    params,
+  );
 }
 
-async function sendApnsApprovalPush(params: {
-  transport: ApnsApprovalParams;
-  payload: object;
-  pushType: ApnsPushType;
-  priority: "10" | "5";
-}): Promise<ApnsPushResult> {
+async function sendApnsPush(
+  params: {
+    transport: ApnsTransportParams;
+    payload: object;
+    pushType: ApnsPushType;
+    priority: "10" | "5";
+  },
+  // Approval notifications have no lifecycle controls, including extra JS input fields.
+  controls?: ApnsLifecycleControls,
+): Promise<ApnsPushResult> {
   const transport = params.transport;
   if (transport.registration.transport === "relay") {
-    const relayParams = transport as RelayApnsApprovalParams;
+    const relayParams = transport as RelayApnsTransportParams;
     return await sendRelayApnsPush({
       relayConfig: relayParams.relayConfig,
       registration: relayParams.registration,
@@ -605,9 +527,11 @@ async function sendApnsApprovalPush(params: {
       priority: params.priority,
       gatewayIdentity: relayParams.relayGatewayIdentity,
       requestSender: relayParams.relayRequestSender,
+      ...(controls?.signal ? { signal: controls.signal } : {}),
+      ...(controls?.isCurrent ? { isCurrent: controls.isCurrent } : {}),
     });
   }
-  const directParams = transport as DirectApnsApprovalParams;
+  const directParams = transport as DirectApnsTransportParams;
   return await sendDirectApnsPush({
     auth: directParams.auth,
     registration: directParams.registration,
@@ -616,6 +540,8 @@ async function sendApnsApprovalPush(params: {
     requestSender: directParams.requestSender,
     pushType: params.pushType,
     priority: params.priority,
+    ...(controls?.signal ? { signal: controls.signal } : {}),
+    ...(controls?.isCurrent ? { isCurrent: controls.isCurrent } : {}),
   });
 }
 
@@ -623,7 +549,7 @@ async function sendApnsApprovalPush(params: {
 export async function sendApnsExecApprovalAlert(
   params: ApnsApprovalParams,
 ): Promise<ApnsPushAlertResult> {
-  return await sendApnsApprovalPush({
+  return await sendApnsPush({
     transport: params,
     payload: createApnsApprovalAlertPayload({
       kind: "exec",
@@ -642,7 +568,7 @@ export async function sendApnsExecApprovalAlert(
 export async function sendApnsPluginApprovalAlert(
   params: ApnsPluginApprovalAlertParams,
 ): Promise<ApnsPushAlertResult> {
-  return await sendApnsApprovalPush({
+  return await sendApnsPush({
     transport: params,
     payload: createApnsApprovalAlertPayload({
       kind: "plugin",
@@ -661,7 +587,7 @@ async function sendApnsApprovalResolvedWake(params: {
   transport: ApnsApprovalParams;
   kind: ChannelApprovalKind;
 }): Promise<ApnsPushWakeResult> {
-  return await sendApnsApprovalPush({
+  return await sendApnsPush({
     transport: params.transport,
     payload: createApnsApprovalResolvedPayload({
       kind: params.kind,

--- a/src/process/exec-runner.ts
+++ b/src/process/exec-runner.ts
@@ -36,7 +36,6 @@ import {
 } from "./exec-result.js";
 import { COMMAND_PROCESS_TREE_KILL_GRACE_MS, spawnCommandWithInvocation } from "./exec-spawn.js";
 import { createCommandTerminationController } from "./exec-termination.js";
-import { resolveCommandStdio } from "./spawn-utils.js";
 
 const WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS = 250;
 const WINDOWS_CLOSE_STATE_POLL_MS = 10;
@@ -108,7 +107,6 @@ async function runCommandWithOutputEncoding(
   const resolvedTimeoutMs =
     typeof timeoutMs === "number" ? resolveTimerTimeoutMs(timeoutMs, 1) : undefined;
   const hasInput = input !== undefined;
-  const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
   const resolvedKillGraceMs = resolveTimerTimeoutMs(
     killGraceMs,
     COMMAND_PROCESS_TREE_KILL_GRACE_MS,
@@ -180,7 +178,7 @@ async function runCommandWithOutputEncoding(
     killSignal,
     ...(hasInput ? { input } : {}),
     reject: false,
-    stdio,
+    stdio: [hasInput ? "pipe" : "inherit", "pipe", "pipe"],
     stripFinalNewline: false,
     windowsVerbatimArguments: options.windowsVerbatimArguments,
   });

--- a/src/process/spawn-utils.ts
+++ b/src/process/spawn-utils.ts
@@ -17,14 +17,6 @@ type SpawnWithFallbackParams = {
   spawnImpl?: (command: string, args: string[], options: SpawnOptions) => ChildProcess;
 };
 
-export function resolveCommandStdio(params: {
-  hasInput: boolean;
-  preferInherit: boolean;
-}): ["pipe" | "inherit" | "ignore", "pipe", "pipe"] {
-  const stdin = params.hasInput ? "pipe" : params.preferInherit ? "inherit" : "pipe";
-  return [stdin, "pipe", "pipe"];
-}
-
 function shouldRetry(err: unknown): boolean {
   const code =
     err && typeof err === "object" && "code" in err ? String((err as { code?: unknown }).code) : "";

--- a/test/non-isolated-runner.test-api-fixtures.ts
+++ b/test/non-isolated-runner.test-api-fixtures.ts
@@ -13,27 +13,24 @@ export function testApiLifecycleFixtureFiles(repoRoot: string): Record<string, s
 // Check during collection before imports can overwrite the previous generation.
 const remainingKeys = [
   "openclaw.beforeToolCallBlockedErrorTestApi",
-  "openclaw.backupPlanTestApi",
   "openclaw.staleAuthOrderTestApi",
   "openclaw.bashProcessRegistryTestApi",
   "openclaw.diagnosticRunActivityTestApi",
 ].filter((key) => Object.hasOwn(globalThis, Symbol.for(key)));
 expect(remainingKeys, "completed-file test API publications").toEqual([]);
 expect(Object.hasOwn(globalThis, "openclawOpenAIResponsesTransportTestApi")).toBe(false);
-for (const key of [Symbol.for("fixture.foreignTestApi"), Symbol.for("openclaw.google.vertexAdcTestApi"), "openclaw.backupPlanTestApi"]) {
+for (const key of [Symbol.for("fixture.foreignTestApi"), Symbol.for("openclaw.google.vertexAdcTestApi"), "openclaw.staleAuthOrderTestApi"]) {
   expect(Reflect.get(globalThis, key)).toBe("foreign");
   Reflect.deleteProperty(globalThis, key);
 }
 `
         : "";
     files[`${prefix}-test-api-${generation}.test.ts`] = `
-import path from "node:path";
 import { createRequire } from "node:module";
 import { afterAll, describe, expect, it } from "vitest";
 ${observeCleanup}
 const { createBeforeToolCallBlockedError } = await import(${sourcePath("agents/agent-tools.before-tool-call.test-support.ts")});
 const { isBeforeToolCallBlockedError } = await import(${sourcePath("agents/agent-tools.before-tool-call.wrapper.ts")});
-const { resolveBackupPlanFromPaths } = await import(${sourcePath("commands/backup.test-support.ts")});
 const { repairStaleConfiguredAuthOrders } = await import(${sourcePath("commands/doctor/shared/stale-auth-order.test-support.ts")});
 const { testing: responses } = await import(${sourcePath("agents/openai-transport-stream.test-support.ts")});
 const registry = await import(${sourcePath("agents/bash-process-registry.ts")});
@@ -51,8 +48,6 @@ expect(nativeCron.registerActiveCronTaskRun).toBe(native.register);
 const { resetDiagnosticRunActivityForTest, getDiagnosticSessionActivitySnapshot } = await import(${sourcePath("logging/diagnostic-run-activity.ts")});
 const { markDiagnosticToolStartedForTest } = await import(${sourcePath("logging/diagnostic-run-activity.test-support.ts")});
 const { resolveGlobalSingleton } = await import(${sourcePath("shared/global-singleton.ts")});
-const stateDir = path.join(import.meta.dirname, "test-api-state");
-const configPath = path.join(stateDir, "missing-openclaw.json");
 describe("${generation} test API consumers", () => {
   async function verifyConsumers(message: string): Promise<void> {
     const blocked = createBeforeToolCallBlockedError(message);
@@ -76,17 +71,6 @@ describe("${generation} test API consumers", () => {
     native.api.resetActiveCronTaskRunsForTests();
     expect(nativeCron.cancelActiveCronTaskRun({ runId: "native-fixture" })).toBe(false);
     expect(controller.signal.aborted).toBe(false);
-    const plan = await resolveBackupPlanFromPaths({
-      stateDir,
-      configPath,
-      oauthDir: path.join(stateDir, "credentials"),
-      onlyConfig: true,
-    });
-    expect(plan).toMatchObject({
-      included: [],
-      workspaceDirs: [],
-      skipped: [{ kind: "config", sourcePath: configPath, reason: "missing" }],
-    });
     const cfg = { auth: { order: { "fixture-provider": [] } } };
     expect(repairStaleConfiguredAuthOrders({ cfg, stores: [] })).toEqual({
       config: cfg,
@@ -126,7 +110,7 @@ const cron = require(${sourcePath("cron/service/active-run-cancellation.ts")});
 module.exports = { register: cron.registerActiveCronTaskRun, api: globalThis[Symbol.for("openclaw.activeCronTaskRunTestApi")] };
 `;
   files["foreign/extensions/google/vertex-adc.ts"] = `
-for (const key of [Symbol.for("fixture.foreignTestApi"), Symbol.for("openclaw.google.vertexAdcTestApi"), "openclaw.backupPlanTestApi"]) {
+for (const key of [Symbol.for("fixture.foreignTestApi"), Symbol.for("openclaw.google.vertexAdcTestApi"), "openclaw.staleAuthOrderTestApi"]) {
   Reflect.set(globalThis, key, "foreign");
 }
 `;

--- a/test/repository-test-api-publications.ts
+++ b/test/repository-test-api-publications.ts
@@ -79,7 +79,6 @@ const publications: Record<string, string | symbol> = {
   "src/auto-reply/usage-bar/template.ts": Symbol.for("openclaw.usageBarTemplateTestApi"),
   "src/cli/command-secret-gateway.ts": Symbol.for("openclaw.commandSecretGatewayTestApi"),
   "src/cli/gateway-cli/run.ts": Symbol.for("openclaw.gatewayRunTestApi"),
-  "src/commands/backup-shared.ts": Symbol.for("openclaw.backupPlanTestApi"),
   "src/commands/doctor-auth-migration-receipts.ts": Symbol.for(
     "openclaw.authProfileMigrationReceiptsTestApi",
   ),


### PR DESCRIPTION
## What Problem This Solves

Diagnostic, push, backup, and session paths repeat transport selection, value construction, and ordering logic. Several private options and fallback branches survive only for tests. This cleanup gives those decisions one owner while preserving their observable behavior.

Related: #139597

## Why This Change Was Made

| Owner | Production lines removed | Preserved behavior |
| --- | ---: | --- |
| Doctor platform notes | 76 | Warning text/order, platform guards, service-environment precedence, and bounded probes |
| APNs dispatch | 74 | Payloads, transport selection, exact sender options, cancellation/currentness, and approval-specific control omission |
| Plugin runtime helpers | 20 | Ollama's public metadata and lazy hooks; Claude memory-read errors and causes |
| Backup stream and test interfaces | 30 | Partial-file cleanup, idle deadline, real plan discovery, extraction budgets, and retry counts |
| Session projections | 15 | Latest media payload in first-seen row order; final enriched identity-picker order |
| Diagnostic capture policy | 12 | Fresh positive policy object, default-off capture, all gates/fields, and system-prompt exclusion |
| Workspace scratch cleanup | 4 | Git metadata retention, sequential removal, and errors |
| Process stdin | 10 | Explicit piping for supplied input, including empty values; inherited stdin when omitted |

**Production is 241 lines smaller.** Tests/support grow by 108 lines, retaining existing cases and strengthening actual boundary coverage. No public API, configuration option, schema, dependency, retention policy, or authorization change is introduced.

The APNs dispatcher accepts lifecycle controls separately from transport data, so approval notifications continue ignoring even extraneous JavaScript control fields. Its signing, HTTP/2, relay, registration, and result owners stay unchanged. Backup's existing publication owner remains responsible for unidentified or delayed cleanup receipts; only the unused ownerless branch is removed.

## User Impact

No intended change to user-visible behavior. Existing diagnostics, pushes, backups, media history, search setup, migration, and subprocess I/O retain their current outcomes with less internal plumbing.

## Evidence

- Original-compatible tests preserve all existing cases and add latest-media ordering, real warning-probe normalization, direct/relay dispatch controls, and default-deadline coverage.
- Baseline suites passed before applying production changes. Dedicated APNs cases also passed independently after moving them to generated-key fixtures; existing TLS suites remain unchanged.
- Actual subprocess proof covers inherited stdin and explicit empty text/byte input through the real command runner.
- Independent P0–P2 reviews cover every implementation scope; no accepted/actionable findings remain. All review scanners and isolation stayed enabled.
- The core batch passes 873 tests across 25 files and its full changed/build gates. Added backup-boundary and sibling coverage passes 252 tests across 12 files, including the real shared-runner child’s completion/teardown and malformed-receipt checks. Existing platform skips remain unchanged.
- Mutation controls prove the new tests reject a removed budget check, a check moved after scratch creation, and removal of the real retry-count reset. The hard-cap case uses a small real archive with simulated reported size.
- Workspace scratch cleanup passes all 53 original and candidate reconciliation tests, including actual Git patch/rollback flows.
- Final combined changed checks passed, including core/plugin/test types, lint, assertion budgets, dead exports, database guards, and zero runtime import cycles. The final 29-file candidate builds with `pnpm build:ci-artifacts`; build metadata identifies commit `4a83819421621ab742c40473710e20250bc46eb8`.

Filesystem, loopback transport, and subprocess checks use owned synthetic fixtures. The cleanup does not change external provider wire behavior or require operator-state changes. The complete change removes 134 lines overall, including tests/support and one retired assertion-budget entry.


## Review follow-up

The data-model compatibility item in the ClawSweeper review is a path-classification false positive. No stored representation, schema, migration, backfill, embedding/vector metadata, retention, or upgrade behavior changes:

- `doctor-platform-notes.ts` only reads platform/service/environment state and builds or emits warnings. The removed arguments are private test injection; service-environment precedence, bounded probes, warning text, and ordering remain covered by the baseline/candidate suites. Suggested repair commands are warning text, not executed mutations.
- `extensions/migrate-claude/memory.ts` replaces a duplicate `readMemoryDir` with the existing identical reader at [`source.ts:98`](https://github.com/openclaw/openclaw/blob/4a83819421621ab742c40473710e20250bc46eb8/extensions/migrate-claude/source.ts#L98). Both use the same `readdir` options and error/cause. The item IDs, targets, scan limits, metadata fields, plan construction, and import executor are unchanged. Existing provider tests pass, including actual project imports, overwrite backups, source disappearance, path boundaries, unreadable memory, and oversized scans.
- No migration or upgrade transformation is needed for this unchanged data contract. The before-merge request is therefore resolved by the source equivalence and existing command/provider behavior proof, without adding a migration.
