### PR TITLE
refactor(doctor): remove redundant config writebacks

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrations.audio.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.audio.ts
@@ -72,8 +72,6 @@ export const LEGACY_CONFIG_MIGRATIONS_AUDIO: LegacyConfigMigrationSpec[] = [
       delete audio.transcription;
       if (Object.keys(audio).length === 0) {
         delete raw.audio;
-      } else {
-        raw.audio = audio;
       }
     },
   }),

--- a/src/commands/doctor/shared/legacy-config-migrations.channels.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.channels.ts
@@ -88,8 +88,6 @@ function migrateRoutingAllowFrom(raw: Record<string, unknown>, changes: string[]
   }
 
   delete routing.allowFrom;
-  channels.whatsapp = whatsapp;
-  raw.channels = channels;
   cleanupEmptyRecord(raw, "routing");
 }
 
@@ -123,8 +121,6 @@ function migrateRoutingGroupChatMessages(params: {
 
   if (Object.keys(params.groupChat).length === 0) {
     delete params.routing.groupChat;
-  } else {
-    params.routing.groupChat = params.groupChat;
   }
 }
 
@@ -154,9 +150,7 @@ function migrateRoutingGroupChatRequireMention(params: {
         requireMention,
         changes: params.changes,
       });
-      channels[channelId] = section;
     }
-    params.raw.channels = channels;
   }
 
   if (!matchedChannel) {
@@ -194,8 +188,6 @@ function migrateTelegramRequireMention(raw: Record<string, unknown>, changes: st
     changes,
   });
   delete telegram.requireMention;
-  channels.telegram = telegram;
-  raw.channels = channels;
 }
 
 function hasLegacyFeishuAccountBotName(value: unknown): boolean {
@@ -232,12 +224,7 @@ function migrateFeishuAccountBotName(raw: Record<string, unknown>, changes: stri
       changes.push(`Removed ${legacyPath} (${currentPath} already set).`);
     }
     delete account.botName;
-    accounts[accountId] = account;
   }
-
-  feishu.accounts = accounts;
-  channels.feishu = feishu;
-  raw.channels = channels;
 }
 
 function hasLegacyThreadBindingTtl(value: unknown): boolean {
@@ -271,7 +258,6 @@ function migrateThreadBindingsTtlHoursForPath(params: ThreadBindingMigrationPara
     threadBindings.idleHours = threadBindings.ttlHours;
   }
   delete threadBindings.ttlHours;
-  params.owner.threadBindings = threadBindings;
 
   if (hadIdleHours) {
     params.changes.push(
@@ -316,7 +302,6 @@ function migrateThreadBindingsSpawnSessionsForPath(params: ThreadBindingMigratio
   if (!hadSpawnSessions && resolved !== undefined) {
     threadBindings.spawnSessions = resolved;
   }
-  params.owner.threadBindings = threadBindings;
 
   if (hadSpawnSessions) {
     params.changes.push(
@@ -443,7 +428,6 @@ function migrateRetiredWebchatChannelConfig(raw: Record<string, unknown>, change
   }
 
   delete channels.webchat;
-  raw.channels = channels;
   cleanupEmptyRecord(raw, "channels");
   changes.push("Removed retired channels.webchat config.");
 }

--- a/src/commands/doctor/shared/legacy-config-migrations.queue.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.queue.ts
@@ -79,7 +79,6 @@ export const LEGACY_CONFIG_MIGRATIONS_QUEUE: LegacyConfigMigrationSpec[] = [
             changes,
           });
         }
-        queue.byChannel = byChannel;
       }
     },
   }),

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
@@ -385,9 +385,6 @@ function mergeLegacyIntoDefaults(params: {
     defaults[params.fieldKey] = merged;
     params.changes.push(params.mergedMessage);
   }
-
-  root.defaults = defaults;
-  params.raw[params.rootKey] = root;
 }
 
 function hasLegacySandboxPerSession(value: unknown): boolean {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.cron.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.cron.ts
@@ -41,9 +41,7 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_CRON: LegacyConfigMigrationSpec[] 
         return;
       }
       delete cron.runLog;
-      if (Object.keys(cron).length > 0) {
-        raw.cron = cron;
-      } else {
+      if (Object.keys(cron).length === 0) {
         delete raw.cron;
       }
       changes.push("Removed retired cron.runLog config; cron history now keeps 2000 runs per job.");

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
@@ -116,8 +116,6 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
       if (wasManagedService) {
         tailscale.mode = "off";
       }
-      gateway.tailscale = tailscale;
-      raw.gateway = gateway;
       changes.push(
         wasManagedService
           ? "Removed gateway.tailscale.serviceName and set gateway.tailscale.mode=off because named Services cannot use lifecycle-owned routes. " +
@@ -138,8 +136,6 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
       }
       const cleanupWasEnabled = tailscale.resetOnExit === true;
       delete tailscale.resetOnExit;
-      gateway.tailscale = tailscale;
-      raw.gateway = gateway;
       changes.push(
         cleanupWasEnabled
           ? "Removed gateway.tailscale.resetOnExit; managed Tailscale routes now end automatically with the Gateway lifecycle."
@@ -171,9 +167,7 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
         return;
       }
       delete gateway.webchat;
-      if (Object.keys(gateway).length > 0) {
-        raw.gateway = gateway;
-      } else {
+      if (Object.keys(gateway).length === 0) {
         delete raw.gateway;
       }
       changes.push("Removed retired gateway.webchat config.");
@@ -193,9 +187,7 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
         return;
       }
       delete gateway.port;
-      if (Object.keys(gateway).length > 0) {
-        raw.gateway = gateway;
-      } else {
+      if (Object.keys(gateway).length === 0) {
         delete raw.gateway;
       }
       changes.push(
@@ -234,7 +226,6 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
           typeof gateway.customBindHost === "string" ? gateway.customBindHost : undefined,
       });
       gateway.controlUi = { ...controlUi, allowedOrigins: origins };
-      raw.gateway = gateway;
       changes.push(
         `Seeded gateway.controlUi.allowedOrigins ${JSON.stringify(origins)} for bind=${bind}. ` +
           "Required since v2026.2.26. Add other machine origins to gateway.controlUi.allowedOrigins if needed.",
@@ -266,7 +257,6 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
       }
 
       gateway.bind = mapped;
-      raw.gateway = gateway;
       changes.push(`Normalized gateway.bind "${escapeControlForLog(bindRaw)}" → "${mapped}".`);
     },
   }),

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.codex.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.codex.ts
@@ -481,7 +481,6 @@ export function migrateLegacyOpenAICodexProvider(
   if (!models || !providers) {
     return;
   }
-  let providersChanged = false;
   const wildcardPaths = collectLegacyModelPolicyWildcardPaths(raw);
   for (const [providerId, providerValue] of Object.entries({ ...providers })) {
     const provider = getRecord(providers[providerId]) ?? getRecord(providerValue);
@@ -495,7 +494,6 @@ export function migrateLegacyOpenAICodexProvider(
     if (!isLegacyCodexProviderId(providerId)) {
       if (normalized.changed) {
         providers[providerId] = normalized.value;
-        providersChanged = true;
       }
       continue;
     }
@@ -538,7 +536,6 @@ export function migrateLegacyOpenAICodexProvider(
       if (modelCollisions.length > 0 || mergeBlockers.length > 0) {
         if (normalized.changed) {
           providers[providerId] = normalized.value;
-          providersChanged = true;
           changes.push(
             modelCollisions.length > 0
               ? `Skipped merging models.providers.${providerId} into models.providers.${OPENAI_PROVIDER_ID} because colliding model definitions differ for: ${modelCollisions.join(", ")}.`
@@ -575,10 +572,6 @@ export function migrateLegacyOpenAICodexProvider(
       }
     }
     delete providers[providerId];
-    providersChanged = true;
-  }
-  if (providersChanged) {
-    models.providers = providers;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Doctor's legacy configuration migrations repeat parent assignments after mutating records that already belong to the working configuration. This makes it harder to distinguish real object replacement from redundant writeback.

Related: #135868 cleanup campaign (clean-broad lane; no feature content extracted).

## Why This Change Was Made

Remove only reattachments of borrowed records and the provider-change flag whose sole purpose was to trigger one such reattachment. `src/config/legacy.shared.ts` establishes the ownership contract: `getRecord` returns the same object and `ensureRecord` attaches a new record before returning it. The canonical runner in `legacy-config-compat.ts` first clones the authored config. Actual fresh-object assignments, empty-parent removal, migration order, diagnostics, and provider/auth/wildcard blockers remain unchanged.

This preserves the shipped migration contract. Pickaxe history traces the queue/defaults writebacks through #105355; they are present in stable v2026.9.2. No legacy key, supported upgrade, schema, option, dependency, public API, or native Codex behavior is retired or changed. The existing oversized agent-migration exemption is unchanged; this PR does not claim to retire it.

## User Impact

No behavior change. Users receive the same migrated configuration, validation result, and ordered repair messages. Seven production files shrink from 3,075 to 3,034 lines.

| Class | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 3 | 44 | −41 |
| Tests | 0 | 0 | 0 |
| Tooling | 0 | 0 | 0 |
| Docs | 0 | 0 | 0 |

## Evidence

- All 328 existing tests pass before and after across the migration, validation, provider-shape, Gateway, retired-key, and channel migration suites, run through `node scripts/run-vitest.mjs`. No assertion or test was changed.
- Independent comparison of 110 synthetic configurations through the actual canonical migration runner with plugin contracts enabled and the real plugin-aware validator: complete outputs, ordered diagnostics, repeated-pass results, input/context immutability, and existing-object identities match. This includes all seven changed families, malformed parents, canonical-value precedence, provider merge blockers, and a combined configuration. Results include 59 fully validated migrated configurations, 41 intentionally partial-valid cases, and 10 unchanged cases.
- Exact before/current source overlays and observed loader hashes were verified. A negative control removing the required new `gateway.controlUi` assignment changes both migration and validation output in nine cases. The probe ran on Node 26.8.1 with isolated synthetic HOME/state; all fixture directories were removed. This is config-object parity, not a live Codex, CLI persistence, or populated third-party plugin-registry claim.
- Codex autoreview is scoped-clean through P2 with no accepted/actionable findings.
- The full `node scripts/check-changed.mjs` plan passed: core and core-test typing, lint, all three Knip scans, migration/deprecation, storage/architecture guards, and zero runtime import cycles. All 19 recorded proof inputs, including the lockfile, are unchanged after rebasing onto current main.

ClawSweeper disposition: the completed review found no correctness or security findings. Its automated `unknown-data-model-change` checklist for the channel/Gateway filenames does not identify a changed persisted field or migration rule. The compatibility request is addressed by the before/current canonical-runner and validating-wrapper comparison above: all 110 full outputs and diagnostics match, including channel/Gateway creation, sibling retention, precedence, and empty-parent removal. Required new-object assignments remain and the negative control detects their loss. No schema or data-model migration is introduced; an additional application-upgrade claim would exceed this patch's scope. The maintainer verified the proof inputs and results; no extra source change or relaxed gate is needed for that filename-based classification.
