### PR TITLE
perf(plugins): reuse metadata owners during SDK imports

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -241,6 +241,8 @@ const rootEntries = [
   "src/mcp/plugin-tools-serve.ts!",
   // Dedicated tsdown entry exercised against built plugin singletons.
   "src/plugins/build-smoke-entry.ts!",
+  // Required metadata readers load this tsdown entry by computed source/dist path.
+  "src/plugins/plugin-metadata-readers.runtime.ts!",
   // Released Gateways still import this stable entry after an on-disk update.
   "src/gateway/plugin-channel-reload-targets.ts!",
   // Package-script owners invoke these generated-artifact modules directly.

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -71,10 +71,8 @@ import {
   type PreparedModelRuntimeStores,
 } from "./prepared-model-runtime.js";
 import { applyPreparedRuntimeAuthToModel } from "./provider-request-config.js";
-import {
-  protectPreparedProviderRuntimeAuth,
-  unwrapSecretSentinelsForProviderEgress,
-} from "./provider-secret-egress.js";
+import { protectPreparedProviderRuntimeAuth } from "./provider-runtime-auth-protection.js";
+import { unwrapSecretSentinelsForProviderEgress } from "./provider-secret-egress.js";
 import { registerProviderStreamForModel } from "./provider-stream.js";
 import { materializePreparedRuntimeModel } from "./runtime-plan/materialize-model.js";
 import { prepareAgentRuntimeAuth } from "./runtime-plan/prepare-auth.js";

--- a/src/agents/embedded-agent-runner/direct-compaction-preparation.ts
+++ b/src/agents/embedded-agent-runner/direct-compaction-preparation.ts
@@ -20,10 +20,8 @@ import { MissingProviderAuthError } from "../model-auth.js";
 import { projectModelThinkingCompat } from "../model-catalog-lookup.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
 import { applyPreparedRuntimeAuthToModel } from "../provider-request-config.js";
-import {
-  protectPreparedProviderRuntimeAuth,
-  unwrapSecretSentinelsForProviderEgress,
-} from "../provider-secret-egress.js";
+import { protectPreparedProviderRuntimeAuth } from "../provider-runtime-auth-protection.js";
+import { unwrapSecretSentinelsForProviderEgress } from "../provider-secret-egress.js";
 import { materializePreparedRuntimeModel } from "../runtime-plan/materialize-model.js";
 import {
   resolvePreparedRuntimeAuthAttempts,

--- a/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
+++ b/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
@@ -151,8 +151,11 @@ vi.mock("../../plugins/provider-runtime.js", () => ({
   prepareProviderRuntimeAuth: vi.fn(async () => undefined),
 }));
 
-vi.mock("../provider-secret-egress.js", () => ({
+vi.mock("../provider-runtime-auth-protection.js", () => ({
   protectPreparedProviderRuntimeAuth: (value: unknown) => value,
+}));
+
+vi.mock("../provider-secret-egress.js", () => ({
   unwrapSecretSentinelsForProviderEgress: (value: unknown) => value,
 }));
 

--- a/src/agents/embedded-agent-runner/model.provider-hooks.test.ts
+++ b/src/agents/embedded-agent-runner/model.provider-hooks.test.ts
@@ -2,6 +2,8 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { Model } from "../../llm/types.js";
+import { setCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata.test-support.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import { resolveAgentToolSurfacePlan } from "../tool-surface-plan.js";
 import { DEFAULT_PROVIDER_RUNTIME_HOOKS, normalizeResolvedModel } from "./model.provider-hooks.js";
 
@@ -13,13 +15,6 @@ vi.mock("../../plugins/provider-runtime.js", () => ({
   prepareProviderDynamicModel: async () => {},
   runProviderDynamicModel: () => undefined,
   shouldPreferProviderRuntimeResolvedModel: () => false,
-}));
-
-vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
-  getCurrentPluginMetadataSnapshot: () => ({
-    manifestRegistry: { plugins: [] },
-    owners: { providerEndpoints: [], providerRequests: new Map() },
-  }),
 }));
 
 function model(overrides: Partial<Model> = {}): Model {
@@ -53,8 +48,12 @@ function toolSearchEnabled(resolvedModel: Model, config: OpenClawConfig = {}): b
 describe("resolved model Tool Search policy", () => {
   beforeAll(() => {
     vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", path.resolve("extensions"));
+    setCurrentPluginMetadataSnapshot(createPluginMetadataSnapshotFixture());
   });
-  afterAll(() => vi.unstubAllEnvs());
+  afterAll(() => {
+    setCurrentPluginMetadataSnapshot(undefined);
+    vi.unstubAllEnvs();
+  });
 
   it.each([
     { provider: "ollama", api: "ollama", id: "qwen3.5:4b", expected: true },

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -35,10 +35,8 @@ import {
   applyPreparedRuntimeAuthToModel,
   type ModelProviderRequestTransportOverrides,
 } from "../../provider-request-config.js";
-import {
-  protectPreparedProviderRuntimeAuth,
-  unwrapSecretSentinelsForProviderEgress,
-} from "../../provider-secret-egress.js";
+import { protectPreparedProviderRuntimeAuth } from "../../provider-runtime-auth-protection.js";
+import { unwrapSecretSentinelsForProviderEgress } from "../../provider-secret-egress.js";
 import { clampRuntimeAuthRefreshDelayMs } from "../../runtime-auth-refresh.js";
 import { resolveAuthProfileFailureReason } from "./auth-profile-failure-policy.js";
 import type { AuthProfileFailurePolicy } from "./auth-profile-failure-policy.types.js";

--- a/src/agents/provider-attribution.catalog-endpoints.test.ts
+++ b/src/agents/provider-attribution.catalog-endpoints.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, it, vi } from "vitest";
 
 // Simulates a built dist tree: externalized provider metadata comes from the
 // catalog, while one installed manifest proves first-match precedence.
-vi.mock("../plugins/current-plugin-metadata-snapshot.js", async (importOriginal) => {
+vi.mock("../plugins/plugin-metadata-snapshot-required.js", async (importOriginal) => {
   const { buildPluginMetadataProviderFacts } =
     await import("../plugins/plugin-metadata-provider-facts.js");
   return {
-    ...(await importOriginal<typeof import("../plugins/current-plugin-metadata-snapshot.js")>()),
-    getCurrentPluginMetadataSnapshot: () => ({
+    ...(await importOriginal<typeof import("../plugins/plugin-metadata-snapshot-required.js")>()),
+    getCurrentPluginMetadataSnapshotRequiredRuntime: () => ({
       owners: buildPluginMetadataProviderFacts([
         {
           id: "installed-conflict-fixture",

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -137,9 +137,10 @@ const loadPluginMetadataSnapshot = vi.hoisted(() =>
   })),
 );
 
-vi.mock("../plugins/current-plugin-metadata-snapshot.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../plugins/current-plugin-metadata-snapshot.js")>()),
-  getCurrentPluginMetadataSnapshot: (params?: {
+vi.mock("../plugins/plugin-metadata-snapshot-required.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/plugin-metadata-snapshot-required.js")>()),
+  loadPluginMetadataSnapshotRuntime: loadPluginMetadataSnapshot,
+  getCurrentPluginMetadataSnapshotRequiredRuntime: (params?: {
     allowScopedSnapshot?: boolean;
     requireDefaultDiscoveryContext?: boolean;
   }) =>
@@ -167,10 +168,6 @@ vi.mock("../plugins/current-plugin-metadata-snapshot.js", async (importOriginal)
             ),
           },
         }),
-}));
-
-vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
-  loadPluginMetadataSnapshot,
 }));
 
 import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -3,13 +3,15 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import type {
   PluginManifestProviderEndpoint,
   PluginManifestProviderRequestProvider,
 } from "../plugins/manifest.js";
 import { normalizePluginProviderBaseUrl } from "../plugins/plugin-metadata-provider-facts.js";
-import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import {
+  getCurrentPluginMetadataSnapshotRequiredRuntime as getCurrentPluginMetadataSnapshot,
+  loadPluginMetadataSnapshotRuntime as loadPluginMetadataSnapshot,
+} from "../plugins/plugin-metadata-snapshot-required.js";
 import type { PluginMetadataSnapshotOwnerMaps } from "../plugins/plugin-metadata-snapshot.types.js";
 import { asBoolean } from "../utils/boolean.js";
 import type { RuntimeVersionEnv } from "../version.js";

--- a/src/agents/provider-auth-aliases.test.ts
+++ b/src/agents/provider-auth-aliases.test.ts
@@ -56,6 +56,7 @@ import type { InstalledPluginIndexRecord } from "../plugins/installed-plugin-ind
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { createPluginCache, getPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { snapshotReaderSlot } from "../plugins/plugin-metadata-snapshot-readers.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { createProviderAuthResolver } from "./models-config.providers.secrets.js";
 import { resolveProviderAuthAliasMap, resolveProviderIdForAuth } from "./provider-auth-aliases.js";
@@ -145,14 +146,24 @@ function createPluginMetadataSnapshot(params: {
 }
 
 async function prepareAliasSnapshot(plugins: PluginManifestRecord[]) {
-  const metadata = await vi.importActual<typeof import("../plugins/plugin-metadata-snapshot.js")>(
-    "../plugins/plugin-metadata-snapshot.js",
-  );
-  const source = createPluginMetadataSnapshot({ plugins });
-  const snapshot = metadata.restorePluginMetadataSnapshot(
-    metadata.rebasePluginMetadataSnapshotManifestRegistry(source, source.manifestRegistry),
-  );
-  return { metadata, snapshot };
+  const readers = Object.getOwnPropertyDescriptors(snapshotReaderSlot);
+  try {
+    const metadata = await vi.importActual<typeof import("../plugins/plugin-metadata-snapshot.js")>(
+      "../plugins/plugin-metadata-snapshot.js",
+    );
+    const source = createPluginMetadataSnapshot({ plugins });
+    const snapshot = metadata.restorePluginMetadataSnapshot(
+      metadata.rebasePluginMetadataSnapshotManifestRegistry(source, source.manifestRegistry),
+    );
+    return { metadata, snapshot };
+  } finally {
+    // importActual retains this fixture's mocked dependencies. Its readers must
+    // not outlive the fixture or replace another file's provider metadata.
+    for (const key of Reflect.ownKeys(snapshotReaderSlot)) {
+      Reflect.deleteProperty(snapshotReaderSlot, key);
+    }
+    Object.defineProperties(snapshotReaderSlot, readers);
+  }
 }
 
 describe("provider auth aliases", () => {

--- a/src/agents/provider-runtime-auth-protection.ts
+++ b/src/agents/provider-runtime-auth-protection.ts
@@ -1,0 +1,73 @@
+// Protects provider auth exchange output before it enters retained runtime state.
+import { looksLikeSecretSentinel, mintSecretSentinel } from "../secrets/sentinel.js";
+import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
+import type { ModelProviderRequestTransportOverrides } from "./provider-request-config.js";
+
+type PreparedProviderRuntimeAuth = {
+  apiKey: string;
+  baseUrl?: string;
+  request?: ModelProviderRequestTransportOverrides;
+  expiresAt?: number;
+};
+
+function protectRuntimeAuthValue(params: {
+  value: string;
+  provider: string;
+  label: string;
+}): string {
+  if (!params.value) {
+    return params.value;
+  }
+  return looksLikeSecretSentinel(params.value)
+    ? params.value
+    : mintSecretSentinel(params.value, {
+        label: `model-auth:${params.provider}:${params.label}`,
+      });
+}
+
+/** Re-sentinels credentials returned by a provider auth exchange. */
+export function protectPreparedProviderRuntimeAuth(params: {
+  provider: string;
+  preparedAuth: PreparedProviderRuntimeAuth | null | undefined;
+}): PreparedProviderRuntimeAuth | undefined {
+  const { preparedAuth } = params;
+  if (!preparedAuth) {
+    return undefined;
+  }
+  const protect = (value: string, label: string): string =>
+    !value || isNonSecretApiKeyMarker(value)
+      ? value
+      : protectRuntimeAuthValue({ value, provider: params.provider, label });
+  const request = preparedAuth.request;
+  const headers = request?.headers
+    ? Object.fromEntries(
+        Object.entries(request.headers).map(([name, value]) => [
+          name,
+          protect(value, `runtime-header:${name.toLowerCase()}`),
+        ]),
+      )
+    : undefined;
+  const auth = request?.auth;
+  const protectedAuth =
+    auth?.mode === "authorization-bearer"
+      ? { ...auth, token: protect(auth.token, "runtime-bearer") }
+      : auth?.mode === "header"
+        ? {
+            ...auth,
+            value: protect(auth.value, `runtime-auth-header:${auth.headerName.toLowerCase()}`),
+          }
+        : auth;
+  return {
+    ...preparedAuth,
+    apiKey: protect(preparedAuth.apiKey, "runtime-api-key"),
+    ...(request
+      ? {
+          request: {
+            ...request,
+            ...(headers ? { headers } : {}),
+            ...(protectedAuth ? { auth: protectedAuth } : {}),
+          },
+        }
+      : {}),
+  };
+}

--- a/src/agents/provider-secret-egress.test.ts
+++ b/src/agents/provider-secret-egress.test.ts
@@ -5,10 +5,8 @@ import {
   attachModelProviderRequestTransport,
   getModelProviderRequestTransport,
 } from "./provider-request-config.js";
-import {
-  protectPreparedProviderRuntimeAuth,
-  unwrapModelHeaderSentinelsForProviderEgress,
-} from "./provider-secret-egress.js";
+import { protectPreparedProviderRuntimeAuth } from "./provider-runtime-auth-protection.js";
+import { unwrapModelHeaderSentinelsForProviderEgress } from "./provider-secret-egress.js";
 
 describe("protectPreparedProviderRuntimeAuth", () => {
   it("sentinels a real credential returned by the auth exchange and registers it for redaction", () => {

--- a/src/agents/provider-secret-egress.ts
+++ b/src/agents/provider-secret-egress.ts
@@ -1,83 +1,9 @@
-import {
-  looksLikeSecretSentinel,
-  mintSecretSentinel,
-  swapSecretSentinelsInText,
-} from "../secrets/sentinel.js";
-import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
+import { swapSecretSentinelsInText } from "../secrets/sentinel.js";
 import {
   attachModelProviderRequestTransport,
   getModelProviderRequestTransport,
   type ModelProviderRequestTransportOverrides,
 } from "./provider-request-config.js";
-
-type PreparedProviderRuntimeAuth = {
-  apiKey: string;
-  baseUrl?: string;
-  request?: ModelProviderRequestTransportOverrides;
-  expiresAt?: number;
-};
-
-function protectRuntimeAuthValue(params: {
-  value: string;
-  provider: string;
-  label: string;
-}): string {
-  if (!params.value) {
-    return params.value;
-  }
-  return looksLikeSecretSentinel(params.value)
-    ? params.value
-    : mintSecretSentinel(params.value, {
-        label: `model-auth:${params.provider}:${params.label}`,
-      });
-}
-
-/** Re-sentinels credentials returned by a provider auth exchange. */
-export function protectPreparedProviderRuntimeAuth(params: {
-  provider: string;
-  preparedAuth: PreparedProviderRuntimeAuth | null | undefined;
-}): PreparedProviderRuntimeAuth | undefined {
-  const { preparedAuth } = params;
-  if (!preparedAuth) {
-    return undefined;
-  }
-  const protect = (value: string, label: string): string =>
-    !value || isNonSecretApiKeyMarker(value)
-      ? value
-      : protectRuntimeAuthValue({ value, provider: params.provider, label });
-  const request = preparedAuth.request;
-  const headers = request?.headers
-    ? Object.fromEntries(
-        Object.entries(request.headers).map(([name, value]) => [
-          name,
-          protect(value, `runtime-header:${name.toLowerCase()}`),
-        ]),
-      )
-    : undefined;
-  const auth = request?.auth;
-  const protectedAuth =
-    auth?.mode === "authorization-bearer"
-      ? { ...auth, token: protect(auth.token, "runtime-bearer") }
-      : auth?.mode === "header"
-        ? {
-            ...auth,
-            value: protect(auth.value, `runtime-auth-header:${auth.headerName.toLowerCase()}`),
-          }
-        : auth;
-  return {
-    ...preparedAuth,
-    apiKey: protect(preparedAuth.apiKey, "runtime-api-key"),
-    ...(request
-      ? {
-          request: {
-            ...request,
-            ...(headers ? { headers } : {}),
-            ...(protectedAuth ? { auth: protectedAuth } : {}),
-          },
-        }
-      : {}),
-  };
-}
 
 export function unwrapSecretSentinelsForProviderEgress(value: string, boundary: string): string {
   const swapped = swapSecretSentinelsInText(value);

--- a/src/agents/simple-completion-runtime.plugin-scope.test.ts
+++ b/src/agents/simple-completion-runtime.plugin-scope.test.ts
@@ -354,6 +354,9 @@ module.exports = {
             if (mode !== "acquired") {
               activateAmbient();
             }
+            // Loading the public SDK must retain the host's registered metadata owners.
+            const metadataReaders = readHostMetadataReaders();
+            expect(metadataReaders.every((reader) => typeof reader === "function")).toBe(true);
             const prepared = await prepareSimpleCompletionModel({
               cfg,
               agentId: "main",
@@ -388,6 +391,10 @@ module.exports = {
             }
             expect(prepared.model.api).toBe("openai-completions");
             expect(isColdPluginRuntimeLoaded(unrelated)).toBe(false);
+            expect(
+              readHostMetadataReaders(),
+              "public SDK loading must preserve registered host metadata readers",
+            ).toEqual(metadataReaders);
           } finally {
             lease?.release();
           }
@@ -544,3 +551,10 @@ module.exports = {
     }
   });
 });
+
+function readHostMetadataReaders(): readonly unknown[] {
+  const readers = Reflect.get(globalThis, Symbol.for("openclaw.pluginMetadataSnapshotReaders")) as
+    | Record<string, unknown>
+    | undefined;
+  return [readers?.getCurrentPluginMetadataSnapshot, readers?.resolvePluginMetadataSnapshot];
+}

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -57,7 +57,7 @@ import {
   buildProviderModelAuthSourcePlan,
 } from "./provider-model-auth-source-plan.js";
 import { applyPreparedRuntimeAuthToModel } from "./provider-request-config.js";
-import { protectPreparedProviderRuntimeAuth } from "./provider-secret-egress.js";
+import { protectPreparedProviderRuntimeAuth } from "./provider-runtime-auth-protection.js";
 import { buildAgentRuntimeAuthPlan } from "./runtime-plan/auth.js";
 import { materializePreparedRuntimeModel } from "./runtime-plan/materialize-model.js";
 import { getModelRegistryRuntime } from "./sessions/model-registry-runtime.js";

--- a/src/media-understanding/image-model-runtime.ts
+++ b/src/media-understanding/image-model-runtime.ts
@@ -14,7 +14,7 @@ import {
 } from "../agents/prepared-model-runtime.js";
 import { resolveProviderModelMaterializationAuthMode } from "../agents/provider-model-route-auth.js";
 import { applyPreparedRuntimeAuthToModel } from "../agents/provider-request-config.js";
-import { protectPreparedProviderRuntimeAuth } from "../agents/provider-secret-egress.js";
+import { protectPreparedProviderRuntimeAuth } from "../agents/provider-runtime-auth-protection.js";
 import { providerUsesCredentialScopedModelMetadata } from "../agents/runtime-plan/credential-scoped-model.js";
 import { getModelRegistryRuntime } from "../agents/sessions/model-registry-runtime.js";
 import { bindModelLlmRuntime } from "../llm/model-runtime-binding.js";

--- a/src/plugins/current-plugin-metadata-snapshot.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.ts
@@ -22,7 +22,7 @@ import {
   type ResolvePluginControlPlaneContextParams,
 } from "./plugin-control-plane-context.js";
 import { resolvePluginMetadataEnvFingerprint } from "./plugin-metadata-env.js";
-import { registerPluginMetadataSnapshotReaders } from "./plugin-metadata-snapshot.runtime.js";
+import { registerPluginMetadataSnapshotReaders } from "./plugin-metadata-snapshot-readers.js";
 import type {
   PluginMetadataSnapshot,
   PluginMetadataSnapshotPluginIdScope,

--- a/src/plugins/plugin-metadata-readers.runtime.ts
+++ b/src/plugins/plugin-metadata-readers.runtime.ts
@@ -1,0 +1,3 @@
+// Required synchronous metadata entry for cold source and built policy readers.
+export { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
+export { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";

--- a/src/plugins/plugin-metadata-snapshot-readers.ts
+++ b/src/plugins/plugin-metadata-snapshot-readers.ts
@@ -1,0 +1,29 @@
+// Shares the canonical metadata owner functions across source and built module graphs.
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+
+export type CurrentSnapshotModule = Pick<
+  typeof import("./current-plugin-metadata-snapshot.js"),
+  "adoptCurrentPluginMetadataSnapshotIfAbsent" | "getCurrentPluginMetadataSnapshot"
+>;
+export type SnapshotLoaderModule = Pick<
+  typeof import("./plugin-metadata-snapshot.js"),
+  "resolvePluginMetadataSnapshot" | "loadPluginMetadataSnapshot"
+>;
+
+type SnapshotReaderSlot = {
+  adoptCurrentPluginMetadataSnapshotIfAbsent?: CurrentSnapshotModule["adoptCurrentPluginMetadataSnapshotIfAbsent"];
+  getCurrentPluginMetadataSnapshot?: CurrentSnapshotModule["getCurrentPluginMetadataSnapshot"];
+  resolvePluginMetadataSnapshot?: SnapshotLoaderModule["resolvePluginMetadataSnapshot"];
+  loadPluginMetadataSnapshot?: SnapshotLoaderModule["loadPluginMetadataSnapshot"];
+};
+
+// globalThis-keyed so a require-loaded second module instance shares the slot.
+export const snapshotReaderSlot = resolveGlobalSingleton<SnapshotReaderSlot>(
+  Symbol.for("openclaw.pluginMetadataSnapshotReaders"),
+  () => ({}),
+);
+
+/** Called by the snapshot modules at eval time; last registration wins. */
+export function registerPluginMetadataSnapshotReaders(readers: SnapshotReaderSlot): void {
+  Object.assign(snapshotReaderSlot, readers);
+}

--- a/src/plugins/plugin-metadata-snapshot-required.test.ts
+++ b/src/plugins/plugin-metadata-snapshot-required.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { snapshotReaderSlot } from "./plugin-metadata-snapshot-readers.js";
+import {
+  getCurrentPluginMetadataSnapshotRequiredRuntime,
+  loadPluginMetadataSnapshotRuntime,
+} from "./plugin-metadata-snapshot-required.js";
+
+const { loadSource, createSourceLoader } = vi.hoisted(() => {
+  const sourceLoader = vi.fn();
+  return { loadSource: sourceLoader, createSourceLoader: vi.fn(() => sourceLoader) };
+});
+vi.mock("./plugin-module-loader-cache.js", () => ({
+  getCachedPluginSourceModuleLoader: createSourceLoader,
+}));
+
+const readerKeys = ["getCurrentPluginMetadataSnapshot", "loadPluginMetadataSnapshot"] as const;
+let previousReaders: PropertyDescriptorMap;
+beforeEach(() => {
+  previousReaders = Object.getOwnPropertyDescriptors(snapshotReaderSlot);
+  for (const key of readerKeys) {
+    delete snapshotReaderSlot[key];
+  }
+  loadSource.mockReset();
+  createSourceLoader.mockClear();
+});
+afterEach(() => {
+  for (const key of readerKeys) {
+    const descriptor = previousReaders[key];
+    if (descriptor) {
+      Object.defineProperty(snapshotReaderSlot, key, descriptor);
+    } else {
+      delete snapshotReaderSlot[key];
+    }
+  }
+});
+
+const reads = [
+  {
+    name: "current snapshot",
+    run: () => getCurrentPluginMetadataSnapshotRequiredRuntime({}),
+  },
+  { name: "snapshot load", run: () => loadPluginMetadataSnapshotRuntime({ config: {} }) },
+];
+
+function captureFailure(run: () => unknown): unknown {
+  try {
+    run();
+  } catch (error) {
+    return error;
+  }
+  return undefined;
+}
+
+describe("required plugin metadata readers", () => {
+  it("keeps a registered missing-current result distinct from an unavailable runtime", () => {
+    snapshotReaderSlot.getCurrentPluginMetadataSnapshot = () => undefined;
+    expect(getCurrentPluginMetadataSnapshotRequiredRuntime({})).toBeUndefined();
+    expect(createSourceLoader).not.toHaveBeenCalled();
+  });
+
+  it.each(reads)("preserves the original registered $name error", ({ run }) => {
+    const failure = new Error("registered metadata owner failed");
+    const fail = () => {
+      throw failure;
+    };
+    snapshotReaderSlot.getCurrentPluginMetadataSnapshot = fail;
+    snapshotReaderSlot.loadPluginMetadataSnapshot = fail;
+    expect(captureFailure(run)).toBe(failure);
+    expect(createSourceLoader).not.toHaveBeenCalled();
+  });
+
+  it.each(reads)("propagates the required source-loader error for $name", ({ run }) => {
+    const failure = new Error("required metadata module failed to load");
+    loadSource.mockImplementation(() => {
+      throw failure;
+    });
+    expect(captureFailure(run)).toBe(failure);
+  });
+});

--- a/src/plugins/plugin-metadata-snapshot-required.ts
+++ b/src/plugins/plugin-metadata-snapshot-required.ts
@@ -1,0 +1,48 @@
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { isPluginSourceModulePath } from "./native-module-require.js";
+import {
+  snapshotReaderSlot,
+  type CurrentSnapshotModule,
+  type SnapshotLoaderModule,
+} from "./plugin-metadata-snapshot-readers.js";
+import { getCachedPluginSourceModuleLoader } from "./plugin-module-loader-cache.js";
+
+const require = createRequire(import.meta.url);
+
+// Required policy readers must preserve loader failures. Source and built code
+// select one owner entry; neither falls back to optional/empty policy on error.
+function loadRequiredSnapshotReaders(): typeof import("./plugin-metadata-readers.runtime.js") {
+  const source = isPluginSourceModulePath(fileURLToPath(import.meta.url));
+  const modulePath = fileURLToPath(
+    new URL(
+      source ? "./plugin-metadata-readers.runtime.ts" : "./plugin-metadata-readers.runtime.js",
+      import.meta.url,
+    ),
+  );
+  const loaded: unknown = source
+    ? getCachedPluginSourceModuleLoader({ modulePath, importerUrl: import.meta.url })(modulePath)
+    : require(modulePath);
+  // SAFETY: Both fixed targets expose the typed metadata owner exports through the same entry.
+  return loaded as typeof import("./plugin-metadata-readers.runtime.js");
+}
+
+/** Reads current policy through its canonical owner, requiring a working runtime. */
+export function getCurrentPluginMetadataSnapshotRequiredRuntime(
+  params: Parameters<CurrentSnapshotModule["getCurrentPluginMetadataSnapshot"]>[0],
+): ReturnType<CurrentSnapshotModule["getCurrentPluginMetadataSnapshot"]> {
+  const reader =
+    snapshotReaderSlot.getCurrentPluginMetadataSnapshot ??
+    loadRequiredSnapshotReaders().getCurrentPluginMetadataSnapshot;
+  return reader(params);
+}
+
+/** Loads metadata through its canonical owner without suppressing discovery errors. */
+export function loadPluginMetadataSnapshotRuntime(
+  params: Parameters<SnapshotLoaderModule["loadPluginMetadataSnapshot"]>[0],
+): ReturnType<SnapshotLoaderModule["loadPluginMetadataSnapshot"]> {
+  const reader =
+    snapshotReaderSlot.loadPluginMetadataSnapshot ??
+    loadRequiredSnapshotReaders().loadPluginMetadataSnapshot;
+  return reader(params);
+}

--- a/src/plugins/plugin-metadata-snapshot.runtime.ts
+++ b/src/plugins/plugin-metadata-snapshot.runtime.ts
@@ -9,33 +9,11 @@
  * the metadata system (built code loads .js; source/jiti paths resolve .ts).
  */
 import { createRequire } from "node:module";
-import { resolveGlobalSingleton } from "../shared/global-singleton.js";
-
-type CurrentSnapshotModule = Pick<
-  typeof import("./current-plugin-metadata-snapshot.js"),
-  "adoptCurrentPluginMetadataSnapshotIfAbsent" | "getCurrentPluginMetadataSnapshot"
->;
-type SnapshotLoaderModule = Pick<
-  typeof import("./plugin-metadata-snapshot.js"),
-  "resolvePluginMetadataSnapshot"
->;
-
-type SnapshotReaderSlot = {
-  adoptCurrentPluginMetadataSnapshotIfAbsent?: CurrentSnapshotModule["adoptCurrentPluginMetadataSnapshotIfAbsent"];
-  getCurrentPluginMetadataSnapshot?: CurrentSnapshotModule["getCurrentPluginMetadataSnapshot"];
-  resolvePluginMetadataSnapshot?: SnapshotLoaderModule["resolvePluginMetadataSnapshot"];
-};
-
-// globalThis-keyed so a require-loaded second module instance shares the slot.
-const snapshotReaderSlot = resolveGlobalSingleton<SnapshotReaderSlot>(
-  Symbol.for("openclaw.pluginMetadataSnapshotReaders"),
-  () => ({}),
-);
-
-/** Called by the snapshot modules at eval time; last registration wins. */
-export function registerPluginMetadataSnapshotReaders(readers: SnapshotReaderSlot): void {
-  Object.assign(snapshotReaderSlot, readers);
-}
+import {
+  snapshotReaderSlot,
+  type CurrentSnapshotModule,
+  type SnapshotLoaderModule,
+} from "./plugin-metadata-snapshot-readers.js";
 
 const require = createRequire(import.meta.url);
 

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -32,10 +32,8 @@ import {
 import { resolvePluginControlPlaneFingerprint } from "./plugin-control-plane-context.js";
 import { resolvePluginMetadataEnvFingerprint } from "./plugin-metadata-env.js";
 import { buildPluginMetadataProviderFacts } from "./plugin-metadata-provider-facts.js";
-import {
-  adoptCurrentPluginMetadataSnapshotIfAbsentRuntime,
-  registerPluginMetadataSnapshotReaders,
-} from "./plugin-metadata-snapshot.runtime.js";
+import { registerPluginMetadataSnapshotReaders } from "./plugin-metadata-snapshot-readers.js";
+import { adoptCurrentPluginMetadataSnapshotIfAbsentRuntime } from "./plugin-metadata-snapshot.runtime.js";
 import type {
   LoadPluginMetadataSnapshotParams,
   PluginMetadataSnapshot,
@@ -632,4 +630,7 @@ function loadPluginMetadataSnapshotImpl(
 // Light bridges (plugin-metadata-snapshot.runtime.ts) serve loads through this
 // instance whenever the metadata system is loaded; the require fallback only
 // covers cold processes.
-registerPluginMetadataSnapshotReaders({ resolvePluginMetadataSnapshot });
+registerPluginMetadataSnapshotReaders({
+  resolvePluginMetadataSnapshot,
+  loadPluginMetadataSnapshot,
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -438,6 +438,7 @@ function buildCoreDistEntries(): Record<string, string> {
     "plugins/loader": "src/plugins/loader.ts",
     "plugins/sdk-alias": "src/plugins/sdk-alias.ts",
     "facade-activation-check.runtime": "src/plugin-sdk/facade-activation-check.runtime.ts",
+    "plugin-metadata-readers.runtime": "src/plugins/plugin-metadata-readers.runtime.ts",
     "infra/warning-filter": "src/infra/warning-filter.ts",
     "telegram-ingress-worker.runtime": bundledPluginFile(
       "telegram",


### PR DESCRIPTION
## What Problem This Solves

Loading the public LLM SDK from plugin source reevaluated the host's metadata modules even when their readers were already registered. In the existing real transport test, the first SDK load replaced those registered readers and dominated an otherwise small completion request.

## Why This Change Was Made

Provider attribution now reads through the existing registered metadata owners. Required cold reads use the existing source loader or a named internal built entry, preserving loader and discovery failures. The optional metadata bridge keeps its existing behavior and stays independent of the source-loader graph.

The unchanged prepared-auth protection helper moves to its preparation owner. Transport unwrapping no longer imports auth-marker discovery merely to unwrap sentinels. All five production callers move with the helper; no compatibility export remains at the old internal path.

There is no new public SDK export, configuration option, dependency, schema, or provider policy. Prepared/current/loaded metadata precedence, auth handling, and request guards remain unchanged.

## Validation

A matched source-only comparison on base `3d602cd4172fb9abdef8070eb2f8e80ae24c3fbe`, using Node 24.19.0 and the same frozen dependency install, passed all seven original transport cases on both sides:

| Measurement | Original | Candidate |
|---|---:|---:|
| First acquired transport case | 17.193s | 7.931s |
| Whole test command | 30.54s | 18.70s |

These are one controlled local pair with fresh test caches and matching artifact conditions, not a statistical benchmark or whole-CI claim. Peak RSS stayed about 2.1 GB on both sides.

The existing transport case now checks that SDK loading preserves registered host readers, after retaining its real HTTP/SSE assertions. That regression failed on original production code at the intended owner-replacement assertion and passed with the fix. Five cheap boundary cases preserve original registered-reader and cold-loader errors. A separate expensive cold-source probe was executed and retained as proof rather than added as another recurring CI bootstrap.

The refreshed branch passed 190 affected tests, the full build, and cold built-entry, missing-entry, and evaluation-error probes. Worker first-turn import ordering was checked against source and the emitted bundle; a prewarm-only probe does not establish that ordering by itself. The isolated built OpenAI entrypoint import also passed, with 105.8 MiB peak RSS.

The full changed-file gate passed, including type checks, all three dead-code scans, lint, and import-cycle guards. Independent P2 review passed with no findings; exact-head CI remains a landing gate.

Production net: +54 lines beyond moves; build/tooling: +3; tests: +101. The additional production code provides the required synchronous source/built boundary while keeping optional readers independent of that loader.

The first CI run exposed two fixture-lifetime failures in shared Node workers. The provider-hook test mocked an incomplete metadata owner; it now installs and clears the existing complete snapshot fixture through the real owner. The alias test imported a real loader over mocked dependencies and left its registered callbacks available to later files; its preparation helper now restores the prior reader slot in place, including on failure. These repairs change only test setup and cleanup. All existing case bodies, assertions and production request policy remain unchanged.

Both original failure orders were reproduced before repair. The repaired provider-hook pair passes all 22 cases; the complete alias/Minimax pair passes all 41 cases in the observed order. Isolated file passes alone were not treated as sufficient evidence for these shared-worker failures.
