### PR TITLE
test(ui): consolidate ClawHub trust-error cases

### DIFF
--- a/ui/src/lib/skills/index.test.ts
+++ b/ui/src/lib/skills/index.test.ts
@@ -1259,21 +1259,21 @@ describe("skill mutations", () => {
   });
 
   it.each([
-    {
-      name: "shows ClawHub trust warnings from failed skill install error details",
-      message: "ClawHub blocked this release; install was not started.",
-      details: { warning: "BLOCKED - ClawHub flagged this release as malicious" },
-    },
-    {
-      name: "shows a ClawHub trust error without an acknowledgement retry",
-      message: "ClawHub requires acknowledgement before installing.",
-      details: {
+    [
+      "shows ClawHub trust warnings from failed skill install error details",
+      "ClawHub blocked this release; install was not started.",
+      { warning: "BLOCKED - ClawHub flagged this release as malicious" },
+    ],
+    [
+      "shows a ClawHub trust error without an acknowledgement retry",
+      "ClawHub requires acknowledgement before installing.",
+      {
         clawhubTrustCode: "clawhub_risk_acknowledgement_required",
         version: "1.2.3",
         warning: "REVIEW REQUIRED - ClawHub found suspicious behavior.",
       },
-    },
-  ])("$name", async ({ message, details }) => {
+    ],
+  ] as const)("%s", async (_name, message, details) => {
     const { state, request } = createState();
     request.mockRejectedValue(Object.assign(new Error(message), { details }));
 

--- a/ui/src/lib/skills/index.test.ts
+++ b/ui/src/lib/skills/index.test.ts
@@ -1258,45 +1258,31 @@ describe("skill mutations", () => {
     });
   });
 
-  it("shows ClawHub trust warnings from failed skill install error details", async () => {
+  it.each([
+    {
+      name: "shows ClawHub trust warnings from failed skill install error details",
+      message: "ClawHub blocked this release; install was not started.",
+      details: { warning: "BLOCKED - ClawHub flagged this release as malicious" },
+    },
+    {
+      name: "shows a ClawHub trust error without an acknowledgement retry",
+      message: "ClawHub requires acknowledgement before installing.",
+      details: {
+        clawhubTrustCode: "clawhub_risk_acknowledgement_required",
+        version: "1.2.3",
+        warning: "REVIEW REQUIRED - ClawHub found suspicious behavior.",
+      },
+    },
+  ])("$name", async ({ message, details }) => {
     const { state, request } = createState();
-    const error = new Error("ClawHub blocked this release; install was not started.") as Error & {
-      details?: unknown;
-    };
-    error.details = {
-      warning: "BLOCKED - ClawHub flagged this release as malicious",
-    };
-    request.mockRejectedValue(error);
+    request.mockRejectedValue(Object.assign(new Error(message), { details }));
 
     await installFromClawHub(state, "github");
 
+    expect(request).toHaveBeenCalledOnce();
     expect(state.clawhubInstallMessage).toEqual({
       kind: "error",
-      text:
-        "ClawHub blocked this release; install was not started.\n\n" +
-        "BLOCKED - ClawHub flagged this release as malicious",
-    });
-  });
-
-  it("shows a ClawHub trust error without an acknowledgement retry", async () => {
-    const { state, request } = createState();
-    const error = new Error("ClawHub requires acknowledgement before installing.") as Error & {
-      details?: unknown;
-    };
-    error.details = {
-      clawhubTrustCode: "clawhub_risk_acknowledgement_required",
-      version: "1.2.3",
-      warning: "REVIEW REQUIRED - ClawHub found suspicious behavior.",
-    };
-    request.mockRejectedValue(error);
-
-    await installFromClawHub(state, "github");
-
-    expect(state.clawhubInstallMessage).toEqual({
-      kind: "error",
-      text:
-        "ClawHub requires acknowledgement before installing.\n\n" +
-        "REVIEW REQUIRED - ClawHub found suspicious behavior.",
+      text: `${message}\n\n${details.warning}`,
     });
   });
 


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Two Skills UI tests repeat the same rejected-install setup and banner assertion. Consolidating them reduces test maintenance while preserving their distinct trust-error inputs and the retired acknowledgement-flow regression.

## Why This Change Was Made

Keep both original named cases as table rows, with unchanged error messages, warnings, legacy code/version metadata, and exact banner objects. Share fixture construction without the duplicated Error casts, using tuple titles to preserve both complete case names. Add a one-request assertion to catch an unintended second install attempt after rejection. Keep the successful-install warning case separate because it refreshes skills.

## User Impact

No runtime behavior change. Net test delta is −14 (+19/−33); production/tooling/docs zero. Both original scenarios remain, with stronger one-attempt coverage.

## Evidence

- Surviving coverage for the first removed standalone body: “shows ClawHub trust warnings from failed skill install error details” at `ui/src/lib/skills/index.test.ts:1263`.
- Surviving coverage for the second: “shows a ClawHub trust error without an acknowledgement retry” at `ui/src/lib/skills/index.test.ts:1268`.
- Shared one-attempt and exact banner assertions remain at `:1282` and `:1283`. Neither case, payload, or banner expectation is dropped.
- `node scripts/run-vitest.mjs --config ui/vitest.config.ts ui/src/lib/skills/index.test.ts ui/src/pages/skills/view.clawhub.test.ts`: 2 files, 54 tests passed.
- Retry mutation proof: an injected second install request passed both original cases, then failed both consolidated cases with “expected once, got 2 times.” Runtime was restored byte-identically; all 54 focused tests passed afterward.
- Full `node scripts/check-changed.mjs`: passed on the final tuple form.
- Independent Codex P0–P2 autoreview: scoped-clean on the final patch.

The history in #131233 removed the protocol acknowledgement code and UI retry affordance. The legacy-input row remains as a regression check for the generic error response. No production retry defect or policy change is claimed.
