### PR TITLE
fix: avoid duplicate cloud worker teardown during recovery

### DIFF
--- a/extensions/vydra/shared.test.ts
+++ b/extensions/vydra/shared.test.ts
@@ -114,6 +114,32 @@ describe("downloadVydraAsset", () => {
     expect(elapsedMs).toBeLessThan(timeoutMs + 1_500);
   });
 
+  it.each([200, 500])(
+    "preserves the request timeout when wall-clock time trails its timer (HTTP %i)",
+    async (statusCode) => {
+      // The request timer can fire before Date reaches the absolute deadline.
+      // Keep real HTTP and timers while making that clock ordering deterministic.
+      vi.useFakeTimers({ toFake: ["Date"] });
+      const timeoutMs = 250;
+      const port = await listenDripServer({
+        statusCode,
+        contentType: statusCode === 200 ? "image/png" : "text/plain",
+        chunk: "e",
+      });
+
+      await expect(
+        downloadVydraAsset({
+          url: `http://127.0.0.1:${port}/generated/test.png`,
+          kind: "image",
+          timeoutMs,
+          fetchFn: fetch,
+          maxBytes: 1024 * 1024,
+          requestPolicy: requestPolicyFor(`http://127.0.0.1:${port}`, true),
+        }),
+      ).rejects.toThrow(`Vydra image download timed out after ${timeoutMs}ms`);
+    },
+  );
+
   // Completed-response semantics must not race host time; real drip tests above own deadlines.
   it("preserves normalized and redacted provider errors after the bounded read", async () => {
     vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });

--- a/extensions/vydra/shared.ts
+++ b/extensions/vydra/shared.ts
@@ -293,9 +293,8 @@ export async function downloadVydraAsset(params: {
         fileName: `${fileStem}-1.${extension}`,
       };
     } catch (error) {
-      // The guarded request signal remains active through body consumption and
-      // can win the same absolute-deadline race. Keep timeout precedence stable.
-      if (typeof deadline.deadlineAtMs === "number" && Date.now() >= deadline.deadlineAtMs) {
+      // The request timer can fire before wall-clock time reaches the operation deadline.
+      if (error instanceof Error && error.name === "TimeoutError") {
         throw createVydraTimeoutError(deadline);
       }
       throw error;

--- a/src/agents/provider-http-errors.test.ts
+++ b/src/agents/provider-http-errors.test.ts
@@ -204,6 +204,22 @@ describe("provider error utils", () => {
     }
   });
 
+  it("preserves the request timeout that interrupts an error body", async () => {
+    const timeout = Object.assign(new Error("request timed out"), { name: "TimeoutError" });
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.error(timeout);
+        },
+      }),
+      { status: 503 },
+    );
+
+    await expect(assertOkOrThrowProviderError(response, "Provider API error")).rejects.toBe(
+      timeout,
+    );
+  });
+
   it("propagates an already-expired lazy error-body deadline", async () => {
     const cancel = vi.fn();
     const response = new Response(

--- a/src/agents/provider-http-errors.ts
+++ b/src/agents/provider-http-errors.ts
@@ -274,6 +274,10 @@ async function extractProviderErrorInfo(
     if (error instanceof ProviderErrorBodyTimeout) {
       throw error.timeoutError;
     }
+    // Fetch keeps its request deadline active while the response body is consumed.
+    if (error instanceof Error && error.name === "TimeoutError") {
+      throw error;
+    }
     return undefined;
   });
   const rawRequestId = extractProviderRequestId(response);

--- a/src/gateway/server-worker-placement-provision-cancellation.test.ts
+++ b/src/gateway/server-worker-placement-provision-cancellation.test.ts
@@ -804,6 +804,15 @@ describe("dispatch Stop before provider allocation", () => {
           request.onCancellationStarted?.();
         },
       );
+      if (mode === "late-sweep") {
+        // Recovery captures service methods when its runtime is created.
+        const reconcileOnce = environments.reconcileOnce.bind(environments);
+        vi.spyOn(environments, "reconcileOnce").mockImplementationOnce(async () => {
+          sweepEntered.resolve();
+          await enterSweep.promise;
+          await reconcileOnce();
+        });
+      }
       const runtime = createGatewayWorkerPlacementRuntime({
         placements,
         environments,
@@ -823,14 +832,6 @@ describe("dispatch Stop before provider allocation", () => {
       await environments.reconcileEnvironment(intent.environmentId);
       expect(provisionCalls).toBe(2);
       expect(placements.get(REQUEST.sessionId)?.state).toBe("provisioning");
-      if (mode === "late-sweep") {
-        const reconcileOnce = environments.reconcileOnce.bind(environments);
-        vi.spyOn(environments, "reconcileOnce").mockImplementationOnce(async () => {
-          sweepEntered.resolve();
-          await enterSweep.promise;
-          await reconcileOnce();
-        });
-      }
       const recovery =
         mode === "idle"
           ? Promise.resolve()

--- a/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
@@ -249,20 +249,28 @@ describe("worker placement restart recovery", () => {
         await recovery.reconcileActive(ready.environmentId);
       }
 
+      expect.soft(destroy).toHaveBeenCalledOnce();
       expect(environments.get(ready.environmentId)).toMatchObject({
         state: "destroying",
         leaseId: ready.leaseId,
         destroyRequestedAtMs: support.testState.nowMs,
       });
+      destroy.mockClear();
+      await recovery.reconcileActive(ready.environmentId);
+      expect.soft(destroy).toHaveBeenCalledOnce();
+
+      destroy.mockClear();
       await expect(recovery.reclaim(REQUEST)).rejects.toThrow("provider deletion unavailable");
+      expect(destroy).toHaveBeenCalledOnce();
       expect(placements.get(REQUEST.sessionId)).toMatchObject({
         state: "failed",
         environmentId: ready.environmentId,
         recoveryError: expect.stringContaining("teardown failed"),
       });
 
-      destroy.mockResolvedValue(undefined);
+      destroy.mockClear().mockResolvedValue(undefined);
       await expect(recovery.reclaim(REQUEST)).resolves.toMatchObject({ state: "local" });
+      expect(destroy).toHaveBeenCalledOnce();
       expect(environments.get(ready.environmentId)).toMatchObject({
         state: "failed",
         leaseId: null,
@@ -369,9 +377,9 @@ describe("worker placement restart recovery", () => {
       ...(scenario.nodeBacked ? { nodeDeviceId: "durable-node", sshEndpoint: null } : {}),
     };
     vi.mocked(harness.environments.get).mockReturnValue(environment);
-    Object.assign(harness.environments, {
-      supportsProviderExecutionMode: vi.fn(() => scenario.providerSupportsMode),
-    });
+    vi.mocked(harness.environments.supportsProviderExecutionMode).mockReturnValue(
+      scenario.providerSupportsMode,
+    );
     harness.placements.seedActive(environment.ownerEpoch, scenario.executionMode);
 
     if (scenario.sweep) {
@@ -415,12 +423,9 @@ describe("worker placement restart recovery", () => {
         ...(nodeBacked ? { nodeDeviceId: "durable-node", sshEndpoint: null } : {}),
       };
       vi.mocked(harness.environments.get).mockReturnValue(environment);
-      const supportsProviderExecutionMode = vi.fn(() => true);
-      const supportsExecutionMode = vi.fn(() => false);
-      Object.assign(harness.environments, {
-        supportsExecutionMode,
-        supportsProviderExecutionMode,
-      });
+      const supportsProviderExecutionMode = vi.mocked(
+        harness.environments.supportsProviderExecutionMode,
+      );
       harness.placements.seedActive(environment.ownerEpoch, "remote-exec");
 
       await harness.service.reconcile();
@@ -430,7 +435,6 @@ describe("worker placement restart recovery", () => {
         executionMode: "remote-exec",
       });
       expect(supportsProviderExecutionMode).toHaveBeenCalledWith("durable-provider", "remote-exec");
-      expect(supportsExecutionMode).not.toHaveBeenCalled();
       expect(harness.environments.destroy).not.toHaveBeenCalled();
       if (nodeBacked) {
         expect(harness.environments.startTunnel).not.toHaveBeenCalled();

--- a/src/gateway/worker-environments/placement-dispatch-staged-results.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-staged-results.test.ts
@@ -191,8 +191,10 @@ describe("staged worker placement result recovery", () => {
     async (refState) => {
       const workspacePath = path.join(root, "accepted-result-cleanup");
       const publishAcceptedWorkspace = vi.fn(async () => undefined);
-      const harness = createHarness(placementStore, { workspacePath, publishAcceptedWorkspace });
-      const fixtureStart = vi.mocked(harness.environments.startTunnel).getMockImplementation()!;
+      const fixtureHarness = createHarness(placementStore, { workspacePath });
+      const fixtureStart = vi
+        .mocked(fixtureHarness.environments.startTunnel)
+        .getMockImplementation()!;
       const tunnels = createWorkerTunnelManager();
       let claim: ReturnType<PlacementStore["claimTurn"]> | undefined;
       vi.spyOn(tunnels, "start").mockImplementation(async (request) => ({
@@ -259,8 +261,12 @@ describe("staged worker placement result recovery", () => {
         ownerEpoch: attached.ownerEpoch,
         executionMode: "remote-exec",
       });
-      harness.markEnvironmentOwnerEpoch(attached.ownerEpoch);
-      Object.assign(harness.environments, environments);
+      fixtureHarness.markEnvironmentOwnerEpoch(attached.ownerEpoch);
+      const harness = createHarness(placementStore, {
+        workspacePath,
+        publishAcceptedWorkspace,
+        environmentService: environments,
+      });
 
       await expect(harness.service.reclaim(REQUEST)).rejects.toThrow(
         "provider deletion unavailable",
@@ -293,11 +299,25 @@ describe("staged worker placement result recovery", () => {
         ).toMatchObject({ code: 0 });
         const restartedStore = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
         restartedStore.clearLocalTurnClaimsAfterRestart();
-        recovery = createHarness(restartedStore, { workspacePath, publishAcceptedWorkspace });
-        Object.assign(recovery.environments, environments);
+        recovery = createHarness(restartedStore, {
+          workspacePath,
+          publishAcceptedWorkspace,
+          environmentService: environments,
+        });
       }
 
+      destroy.mockClear();
       await recovery.service.reconcileActive(ready.environmentId);
+      expect(destroy).toHaveBeenCalledOnce();
+      expect(recovery.placements.current()).toMatchObject({
+        state: "draining",
+        environmentId: ready.environmentId,
+        activeOwnerEpoch: attached.ownerEpoch,
+        turnClaim:
+          refState === "retained"
+            ? expect.objectContaining({ claimId: pending.claimId, runId: pending.runId })
+            : null,
+      });
 
       await expect(recovery.service.reclaim(REQUEST)).rejects.toThrow(
         refState === "retained"
@@ -305,8 +325,9 @@ describe("staged worker placement result recovery", () => {
           : "Active cloud worker does not match its session placement",
       );
       expect(placementStore.listPendingWorkspaceResults()).toMatchObject([pending]);
-      destroy.mockResolvedValue(undefined);
+      destroy.mockClear().mockResolvedValue(undefined);
       await recovery.service.reconcileActive(ready.environmentId);
+      expect(destroy).toHaveBeenCalledOnce();
       await expect(recovery.service.reclaim(REQUEST)).resolves.toMatchObject({
         state: "reclaimed",
       });

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -38,6 +38,7 @@ import {
 export function createHarness(
   placementStore: PlacementStore,
   options: {
+    environmentService?: WorkerEnvironmentService;
     runReclaimPreparation?: Parameters<
       typeof createWorkerPlacementDispatchService
     >[0]["runReclaimPreparation"];
@@ -356,7 +357,7 @@ export function createHarness(
     expiresAtMs: 10_000,
   };
   const environments: WorkerDispatchEnvironmentService &
-    Pick<WorkerEnvironmentService, "recordError"> = {
+    Pick<WorkerEnvironmentService, "recordError" | "requestDestroy"> = {
     recordError: vi.fn((record) => record),
     supportsProviderExecutionMode: vi.fn(() => true),
     create: vi.fn(async () => {
@@ -404,6 +405,7 @@ export function createHarness(
       await options.afterDestroy?.();
       return destroyed;
     }),
+    requestDestroy: (requestedEnvironmentId) => environments.destroy(requestedEnvironmentId),
     reconcileOnce: vi.fn(async () => {
       log.push("environment:reconcile");
     }),
@@ -411,6 +413,9 @@ export function createHarness(
       log.push("environment:reconcile");
     }),
   };
+  if (options.environmentService) {
+    Object.assign(environments, options.environmentService);
+  }
   const service = createWorkerPlacementDispatchService({
     placements,
     environments,

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -65,7 +65,7 @@ type WorkerPlacementDispatchOptions = WorkerPlacementReclaimBarriers &
     | "publishAcceptedWorkspace"
   > & {
     environments: WorkerDispatchEnvironmentService &
-      Pick<WorkerEnvironmentService, "recordError"> &
+      Pick<WorkerEnvironmentService, "recordError" | "requestDestroy"> &
       Partial<Pick<WorkerEnvironmentService, "requiresNodeEnrollment">>;
     isShuttingDown?: () => boolean;
     runnerAvailability: WorkerPlacementRunnerAvailabilityReader;
@@ -93,9 +93,13 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
     reportTransition: reportPlacementTransition,
   });
 
+  // Background recovery observes previously requested cleanup; explicit Stop and
+  // Move retain their retry contract. Pending-result recovery must inherit this too.
+  const recoveryEnvironments = { ...environments, destroy: environments.requestDestroy };
   const recovery = createPlacementRecoveryActions({
     ...options,
-    failure,
+    environments: recoveryEnvironments,
+    failure: createPlacementFailureActions({ environments: recoveryEnvironments, placements }),
     recoverPlacementMoves: (environmentId) => moveService.recoverAll(environmentId),
   });
 

--- a/src/gateway/worker-environments/provider-destroy-timeout.test.ts
+++ b/src/gateway/worker-environments/provider-destroy-timeout.test.ts
@@ -151,6 +151,13 @@ describe("worker provider teardown deadlines", () => {
         "Worker provider operation timed out after 20ms",
       );
 
+      await expect(service.requestDestroy(initial.environmentId)).rejects.toMatchObject({
+        code: "invalid_state",
+        message: expect.stringContaining("Worker provider operation timed out after 20ms"),
+      });
+      expect(resolveDestroyTimeoutMs).toHaveBeenCalledOnce();
+      expect(destroy).toHaveBeenCalledOnce();
+
       second = service.destroy(initial.environmentId).catch((error: unknown) => error);
       await vi.advanceTimersByTimeAsync(0);
       expect(resolveDestroyTimeoutMs).toHaveBeenCalledTimes(2);

--- a/src/gateway/worker-environments/provider-node-teardown.test.ts
+++ b/src/gateway/worker-environments/provider-node-teardown.test.ts
@@ -122,7 +122,7 @@ describe("worker provider node teardown", () => {
         expect(support.testState.store.getCredential(environmentId)).toEqual(credential);
         expect(destroy).not.toHaveBeenCalled();
         await start();
-        await expect(service.destroy(environmentId)).rejects.toMatchObject({
+        await expect(service.requestDestroy(environmentId)).rejects.toMatchObject({
           code: "provider_failure",
         });
         expect(nodeTunnels.status(environmentId)).toBe("stopped");
@@ -133,6 +133,13 @@ describe("worker provider node teardown", () => {
           destroyRequestedAtMs: support.testState.nowMs,
         });
         expect(support.testState.store.getCredential(environmentId)).toBeUndefined();
+
+        const pending = support.testState.store.get(environmentId);
+        await expect(service.requestDestroy(environmentId)).rejects.toThrow(
+          "provider destruction is indeterminate",
+        );
+        expect(support.testState.store.get(environmentId)).toEqual(pending);
+        expect(destroy).toHaveBeenCalledOnce();
 
         if (retry === "destroy") {
           await service.destroy(environmentId);

--- a/src/gateway/worker-environments/provider-owner-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-owner-lifecycle.ts
@@ -215,6 +215,7 @@ export function createWorkerProviderOwnerLifecycle(
     destroyOptions: {
       requireUnattached?: boolean;
       abandonment?: WorkerEnvironmentAbandonment;
+      retryRequested?: boolean;
     } = {},
   ) => {
     const stopping = options.isStopping();
@@ -254,6 +255,14 @@ export function createWorkerProviderOwnerLifecycle(
         throw serviceError(
           "invalid_state",
           "Attached cloud workers must be stopped through sessions.reclaim",
+        );
+      }
+      // Environment reconciliation owns retries of accepted cleanup. A background
+      // placement projection must not replay its failed provider call or claim success.
+      if (destroyOptions.retryRequested === false && record.destroyRequestedAtMs !== null) {
+        throw serviceError(
+          "invalid_state",
+          `Worker environment cleanup is still pending: ${record.lastError ?? record.state}`,
         );
       }
       record = store.requestDestroy({

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -595,6 +595,10 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     },
     destroy: async (environmentId: string, abandonment?: WorkerEnvironmentAbandonment) =>
       environmentAccess.project(await providerLifecycle.destroy(environmentId, { abandonment })),
+    requestDestroy: async (environmentId: string) =>
+      environmentAccess.project(
+        await providerLifecycle.destroy(environmentId, { retryRequested: false }),
+      ),
     destroyUnattached: async (environmentId: string) =>
       environmentAccess.project(
         await providerLifecycle.destroy(environmentId, { requireUnattached: true }),

--- a/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
@@ -425,6 +425,7 @@ describe("worker turn launcher failure recovery", () => {
       }),
       stopTunnel,
       destroy,
+      requestDestroy: destroy,
       attachSession: vi.fn(async () => {
         throw new Error("unexpected worker session attachment");
       }),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateway shutdown waits for a second physical cloud-worker Stop after background recovery has already tried to clean up the same lease. A failed deletion can add tens of seconds to shutdown and repeats provider work without gaining new evidence.

Related: #138900 and the requested cloud-session performance follow-ups.

## Why This Change Was Made

Environment reconciliation performed the first teardown attempt, then placement recovery unconditionally called destruction again. Background recovery now requests cleanup through the same environment owner, which checks the existing destroy intent under its existing lock. Already-requested, unfinished cleanup reports pending instead of invoking the provider again. Explicit Stop and Move retain their retry behavior.

Pending-result recovery receives the same background service view, so a pending deletion cannot be mistaken for successful cleanup or release an accepted checkpoint/turn fence. No schema, stored representation, public protocol, configuration option, provider deadline, or physical-operation join changes.

## User Impact

Failed cleanup is attempted once per background recovery sweep. Operators can still explicitly retry Stop and receive the current provider error. The Gateway continues to wait for admitted physical cleanup; an unknown lease is not treated as proof that resources are gone.

## Evidence

- Before fix on main `ff930fa95e359b59960b7c911f549c1bb79f2a6f` with temporary timing instrumentation: a real periodic recovery sweep held an in-flight Crabbox Stop through SIGINT, then started a second Stop for the same historical task lease. The first took approximately 47.8s and the duplicate another 36.6s. Natural Gateway shutdown took 84.738s, with 84.209s in placement reconciliation. Every owned process was joined; no allocation or state rewrite was requested.
- Existing real-service regression cases failed before the repair: two provider destroy calls per startup/active sweep and per subsequent failed-placement sweep, while explicit Stop retried exactly once. They now pass.
- 148 focused and sibling tests pass, including timed-out but physically live provider work, queued stale-owner retry, dedicated-node attachment/epoch preservation, accepted checkpoint fencing, later successful cleanup, startup ownership and dispatch/recovery concurrency.
- Changed-file typechecks and guards passed; final targeted lint passed after correcting a fixture method and removing temporary diagnostic spans. Independent P0–P2 reviews found no actionable issues.
- Full build passed on candidate `aaa7957e8d0ec48adb770525bda5b5b5fca5a930` in 3m56.7s. The matched live periodic-shutdown probe passed: 84.738s before → 46.639s after, and two physical Stops → one. The provider call remained joined; the Gateway exited naturally with code 0, all owned processes were absent, the test port was closed, and the unresolved historical lease remained recorded as destroying. Provider latency varies; the independent command count proves duplicate elimination.
- Healthy paired-native lifecycle passed on the same candidate: creation83ms, dispatch8.057s, real write/read10.362s, accepted editor save, Stop/checkpoint readback, new-environment restore2.405s, exact restored read7.810s and finalStop. Pairing was removed, prior owners preserved, all owned processes absent, and the test port closed. Gateway shutdown exited naturally with code0 in14.864s.
- CI exposed a late-sweep fixture that installed its spy after the recovery runtime captured service methods. The fixture now installs the same interception before construction; the original case hung and all 26 corrected provisioning-cancellation tests pass. The earlier Discord backlog failure passed its exact retry unchanged; its cause remains unproven. npm audit remains non-blocking at the maintainer's request.
- A subsequent CI run exposed a separate provider timeout race. The guarded request aborts with `TimeoutError`, but shared HTTP error extraction swallowed it, and Vydra guessed timeout from wall-clock time. The shared extractor now preserves the actual timeout; Vydra labels that cause and removes the clock inference. Real loopback HTTP regressions for 200 and 500 responses fail before this fix and pass afterward, with native timers and unchanged deadlines. Another regression preserves the exact error identity. All 133 owner and media-provider sibling cases pass, including ordinary broken-body metadata and custom body-timeout labels; independent P2 review is clean.

The normal Move recovery path already rejects a destroy-requested attachment at its reclaim admission check. Paired-device abandonment replay retains its separate, explicit durable-decision contract. No background retry behavior is inferred from a missing authorization callback.

Production: +20 net lines: +17 for the cloud request-versus-retry boundary and +3 to preserve the existing transport timeout through shared error handling. Tests/support: +88 net lines. Temporary diagnostic instrumentation used to isolate the delay is excluded from the patch.

Build and live cloud proof remain attributed to `aaa7957e8d0ec48adb770525bda5b5b5fca5a930`. Later changes fix the captured-method fixture and the separately reproduced HTTP timeout race; earlier proof is not relabeled. Exact-head CI on `6d0ad0487fc667e662b0c189cb14ad4a2042c983` passed: 107 successful jobs, 17 skipped, including every previously failing job. Fresh ClawSweeper review on that head reports no findings or before-merge requirements.
