### PR TITLE
fix(chat): fence delayed history at terminal retirement

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
@@ -123,18 +123,20 @@ extension OpenClawChatViewModel {
     }
 
     @discardableResult
-    func applyLiveRunLifecycle(runID: String, sequence: Int, terminal: Bool) -> Bool {
+    func acceptLiveRunSequence(runID: String, sequence: Int) -> Bool {
         guard sequence > 0, self.ownsLiveTelemetryRun(runID) else { return false }
         var state = self.liveRunStateByRunID[runID] ?? ChatLiveRunState()
         guard sequence > state.sequence, !state.terminal else { return false }
         state.sequence = sequence
-        state.terminal = terminal
         self.liveRunStateByRunID[runID] = state
         return true
     }
 
     func retireTerminalRun(_ runID: String?) {
         guard let runID = Self.normalizedRunID(runID) else { return }
+        // Advertised-only runs must fence earlier history even after a later
+        // session snapshot releases their terminal tombstone.
+        self.invalidateRunSnapshots()
         let previous = self.liveRunStateByRunID[runID]
         self.liveRunStateByRunID[runID] = ChatLiveRunState(
             sequence: previous?.sequence ?? 0,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -219,13 +219,9 @@ extension OpenClawChatViewModel {
 
         if isTerminal, ownsCurrentRun, let runID {
             let wasSelectedRun = self.liveUsageRunID == runID
-            if self.pendingRuns.contains(runID) {
-                self.retirePendingRun(
-                    runID,
-                    hapticEvent: phase == "error" ? .runFailed : .runCompleted)
-            } else {
-                self.retireTerminalRun(runID)
-            }
+            self.retirePendingRun(
+                runID,
+                hapticEvent: phase == "error" ? .runFailed : .runCompleted)
             if wasSelectedRun {
                 self.pendingToolCallsById = [:]
                 self.updateStreamingAssistantText(nil)
@@ -780,14 +776,14 @@ extension OpenClawChatViewModel {
 
         if phase == "start" {
             guard let sequence = evt.seq else { return }
-            _ = self.applyLiveRunLifecycle(runID: evt.runId, sequence: sequence, terminal: false)
+            _ = self.acceptLiveRunSequence(runID: evt.runId, sequence: sequence)
             return
         }
         guard isTerminalPhase || isFailure || aborted || isSuccessfulStatus else { return }
         let acceptedLifecycle = if isLegacySessionStream {
             true
         } else if let sequence = evt.seq {
-            self.applyLiveRunLifecycle(runID: evt.runId, sequence: sequence, terminal: true)
+            self.acceptLiveRunSequence(runID: evt.runId, sequence: sequence)
         } else {
             isPendingRun || isAdvertisedRun || isSelectedRun
         }
@@ -798,7 +794,8 @@ extension OpenClawChatViewModel {
             self.retirePendingRun(
                 evt.runId,
                 hapticEvent: isFailure || aborted ? .runFailed : .runCompleted)
-        } else if evt.seq == nil {
+        } else if !isLegacySessionStream || evt.seq == nil {
+            // Sequenced legacy streams carry a session ID.
             self.retireTerminalRun(evt.runId)
         }
         guard isSelectedRun || isLegacySessionStream else {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -3384,6 +3384,7 @@ struct ChatViewModelTests {
         let viewModel = OpenClawChatViewModel(
             sessionKey: "main",
             transport: TestChatTransport(historyResponses: []))
+        defer { viewModel.detachTransport() }
         var running = sessionEntry(key: "main", updatedAt: 1)
         running.status = "running"
         running.lastRunError = "previous failure"
@@ -3394,6 +3395,10 @@ struct ChatViewModelTests {
             runId: "remote-run",
             outputTokens: 8,
             seq: 1)))
+        viewModel.input = "next message"
+        let request = viewModel.beginHistoryRequest()
+        let activeHistory = historyPayload(
+            inFlightRun: OpenClawChatInFlightRun(runId: "remote-run", text: "older working text"))
 
         viewModel.handleTransportEvent(.sessionsChanged(.init(
             sessionKey: "main",
@@ -3418,6 +3423,15 @@ struct ChatViewModelTests {
         #expect(merged?.activeRunIds == [])
         #expect(viewModel.liveRunOutputTokens == nil)
         #expect(!viewModel.hasBlockingRunActivity)
+
+        _ = viewModel.applyHistoryPayload(
+            activeHistory,
+            for: request,
+            preservingOptimisticLocalMessages: true)
+
+        #expect(viewModel.pendingRunCount == 0)
+        #expect(viewModel.streamingAssistantText == nil)
+        #expect(viewModel.canSend)
     }
 
     @Test @MainActor func `terminal lifecycle retires matching pending run despite stale snapshot`() {


### PR DESCRIPTION
## What Problem This Solves

A completed run advertised by another client could reappear as active when older chat history arrived after its terminal session update. The native composer then disabled sending and restored stale streaming text.

## Why This Change Was Made

Invalidate run snapshots at the existing terminal-retirement owner and route accepted lifecycle terminals through it. Preserve sequence rejection, pending cleanup, local request failures and the legacy session-stream distinction. This removes a duplicate terminal assignment and branch, reducing production code by one line.

## User Impact

Completed runs stay settled when delayed history arrives in native chat. The existing recap test gains 14 lines while retaining every prior assertion.

## Evidence

[Hosted BEFORE proof](https://github.com/openclaw/openclaw/actions/runs/34051076905/job/101534811986) compiled the unchanged production and failed only the three new assertions: pending count 1, stale streaming text and disabled sending. The shared suite ran 1,670 Swift Testing cases in 126 suites; XCTest reported 60 cases, two live-audio skips and no failures.

Both production files pass formatting and strict lint. All 14 local canonical checks pass. One managed source-review invocation returned no findings across three automatic passes; its first pass withheld confidence pending the later evidence. [Native AFTER](https://github.com/openclaw/openclaw/actions/runs/34053656491/job/101541690273) passes the exact unchanged regression method and all 1,670 shared Swift Testing cases. The macOS app suite also passes 2,074 tests; its separate two-case isolation supplement and one-case health render are recorded independently from skipped probes. Exact-head PR CI passed 20 jobs with 21 skipped. BEFORE used serial execution and AFTER parallel; Xcode/Swift matched, while runner macOS versions differed. No live-audio or skipped-probe coverage is claimed. The test-only baseline workflow also exposed unrelated locale, cron-picker and docs-test failures, retained separately; its overall run was not green. No local native application or saved user state was used.
