### PR TITLE
perf(matrix): avoid account loading for empty Doctor scans

### DIFF
--- a/extensions/matrix/doctor-contract-api.credentials.test.ts
+++ b/extensions/matrix/doctor-contract-api.credentials.test.ts
@@ -34,7 +34,7 @@ function createContext(env?: NodeJS.ProcessEnv): PluginDoctorStateMigrationConte
       importPluginStateEntriesForDoctorForTests("matrix", options, entries);
     },
     openPluginStateKeyedStore: <T>(options: OpenKeyedStoreOptions): PluginStateKeyedStore<T> =>
-      createPluginStateKeyedStoreForTests<T>("matrix", options),
+      createPluginStateKeyedStoreForTests<T>("matrix", { ...options, env: options.env ?? env }),
   };
 }
 
@@ -69,44 +69,68 @@ describe("matrix doctor credential state migrations", () => {
     resetPluginStateStoreForTests();
   });
 
-  it("imports account credentials into SQLite before archiving the JSON", async () => {
-    const stateDir = tempDirs.make("openclaw-matrix-doctor-");
-    const credentialsDir = path.join(stateDir, "credentials", "matrix");
-    const filePath = path.join(credentialsDir, "credentials-ops.json");
-    const credentials = {
-      homeserver: "https://matrix.example.org",
-      userId: "@bot:example.org",
-      accessToken: "secret-token",
-      deviceId: "DEVICE123",
-      createdAt: "2026-07-01T12:00:00.000Z",
-      lastUsedAt: "2026-07-02T12:00:00.000Z",
-    };
-    fs.mkdirSync(credentialsDir, { recursive: true });
-    fs.writeFileSync(filePath, JSON.stringify(credentials));
-    const migration = migrationById("matrix-credentials-json-to-plugin-state");
-    const params = createMigrationParams(stateDir);
+  it.each([
+    ["credentials-ops.json", [], "ops"],
+    ["credentials.json", ["ops"], "ops"],
+    ["credentials.json", ["ops", "alerts"], null],
+  ] as const)(
+    "preserves credential migration for %s with accounts %j",
+    async (filename, accountIds, accountId) => {
+      const stateDir = tempDirs.make("openclaw-matrix-doctor-");
+      const credentialsDir = path.join(stateDir, "credentials", "matrix");
+      const filePath = path.join(credentialsDir, filename);
+      const credentials = {
+        homeserver: "https://matrix.example.org",
+        userId: "@bot:example.org",
+        accessToken: "secret-token",
+        deviceId: "DEVICE123",
+        createdAt: "2026-07-01T12:00:00.000Z",
+        lastUsedAt: "2026-07-02T12:00:00.000Z",
+      };
+      fs.mkdirSync(credentialsDir, { recursive: true });
+      fs.writeFileSync(filePath, JSON.stringify(credentials));
+      const migration = migrationById("matrix-credentials-json-to-plugin-state");
+      const params = createMigrationParams(stateDir);
+      if (accountIds.length > 0) {
+        params.config = {
+          channels: {
+            matrix: { accounts: Object.fromEntries(accountIds.map((id) => [id, {}])) },
+          },
+        };
+      }
 
-    await expect(migration.detectLegacyState(params)).resolves.toEqual({
-      preview: ["Matrix credential JSON can migrate to SQLite (1 file)"],
-    });
-    const result = await migration.migrateLegacyState(params);
+      await expect(migration.detectLegacyState(params)).resolves.toEqual({
+        preview: ["Matrix credential JSON can migrate to SQLite (1 file)"],
+      });
+      const result = await migration.migrateLegacyState(params);
 
-    expect(result.warnings).toEqual([]);
-    expect(result.changes).toEqual([
-      "Migrated Matrix credentials for account ops to SQLite",
-      expect.stringContaining("Archived Matrix credentials legacy source"),
-    ]);
-    const store = params.context.openPluginStateKeyedStore<MatrixStoredCredentialRecord>({
-      namespace: MATRIX_CREDENTIALS_NAMESPACE,
-      maxEntries: MATRIX_CREDENTIALS_MAX_ENTRIES,
-      overflowPolicy: "reject-new",
-    });
-    await expect(store.lookup(matrixCredentialsStoreKey("ops"))).resolves.toEqual({
-      accountId: "ops",
-      ...credentials,
-    });
-    expect(fs.existsSync(`${filePath}.migrated`)).toBe(true);
-  });
+      const store = params.context.openPluginStateKeyedStore<MatrixStoredCredentialRecord>({
+        namespace: MATRIX_CREDENTIALS_NAMESPACE,
+        maxEntries: MATRIX_CREDENTIALS_MAX_ENTRIES,
+        overflowPolicy: "reject-new",
+      });
+      if (accountId === null) {
+        expect(result.changes).toEqual([]);
+        expect(result.warnings).toEqual([
+          `Left ambiguous Matrix credential legacy source in place because no default account is selected: ${filePath}`,
+        ]);
+        await expect(store.entries()).resolves.toEqual([]);
+        expect(fs.existsSync(filePath)).toBe(true);
+        expect(fs.existsSync(`${filePath}.migrated`)).toBe(false);
+        return;
+      }
+      expect(result.warnings).toEqual([]);
+      expect(result.changes).toEqual([
+        `Migrated Matrix credentials for account ${accountId} to SQLite`,
+        expect.stringContaining("Archived Matrix credentials legacy source"),
+      ]);
+      await expect(store.lookup(matrixCredentialsStoreKey(accountId))).resolves.toEqual({
+        accountId,
+        ...credentials,
+      });
+      expect(fs.existsSync(`${filePath}.migrated`)).toBe(true);
+    },
+  );
 
   it("archives legacy credentials without restoring an explicitly cleared account", async () => {
     const stateDir = tempDirs.make("openclaw-matrix-doctor-");

--- a/extensions/matrix/doctor-contract-api.import.test.ts
+++ b/extensions/matrix/doctor-contract-api.import.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "./test-support.js";
@@ -14,6 +15,9 @@ vi.mock("openclaw/plugin-sdk/doctor-repair-runtime", () => {
 });
 vi.mock("./src/matrix/client/storage.js", () => {
   throw new Error("Client storage loaded by an absent-state Doctor migration");
+});
+vi.mock("./src/account-selection.js", () => {
+  throw new Error("Account topology loaded without legacy credential sources");
 });
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -47,5 +51,18 @@ it("completes absent legacy-state checks without loading client runtimes", async
       warnings: [],
     });
   }
+  const credentials = stateMigrations.find(
+    (entry) => entry.id === "matrix-credentials-json-to-plugin-state",
+  );
+  if (!credentials) {
+    throw new Error("Missing credential migration");
+  }
+  await expect(credentials.detectLegacyState(params)).resolves.toBeNull();
+  const credentialsDir = path.join(stateDir, "credentials", "matrix");
+  fs.mkdirSync(credentialsDir, { recursive: true });
+  await expect(credentials.detectLegacyState(params)).resolves.toBeNull();
+  fs.writeFileSync(path.join(credentialsDir, "unrelated.json"), "{}");
+  fs.mkdirSync(path.join(credentialsDir, "credentials-ops.json"));
+  await expect(credentials.detectLegacyState(params)).resolves.toBeNull();
   expect(openPluginStateKeyedStore).not.toHaveBeenCalled();
 });

--- a/extensions/matrix/doctor-contract-api.ts
+++ b/extensions/matrix/doctor-contract-api.ts
@@ -8,10 +8,6 @@ import {
   type PluginDoctorStateMigration,
 } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import {
-  requiresExplicitMatrixDefaultAccount,
-  resolveMatrixDefaultOrOnlyAccountId,
-} from "./src/account-selection.js";
 import { matrixAccountStateSchemaMigration } from "./src/matrix/account-state-schema-doctor.js";
 import {
   hasMatrixStorageMetaStateInStore,
@@ -103,6 +99,12 @@ async function collectLegacyMatrixCredentialSources(params: {
       }
       return left.name.localeCompare(right.name);
     });
+  if (files.length === 0) {
+    return [];
+  }
+  // Empty-state Doctor scans do not need account topology.
+  const { requiresExplicitMatrixDefaultAccount, resolveMatrixDefaultOrOnlyAccountId } =
+    await import("./src/account-selection.js");
   return files.map((entry) => {
     const match = /^credentials(?:-([a-z0-9._-]+))?\.json$/iu.exec(entry.name);
     const namedAccount = match?.[1];


### PR DESCRIPTION
## What Problem This Solves

Matrix Doctor scans prepare account topology even when no legacy credential files exist. That pulls account-selection work into module loading for the normal empty-state path.

## Why This Change Was Made

Load the existing account-selection module only after directory enumeration finds matching credential files. Keep the same file filtering, deterministic order, account selection, detection output and migration behavior. The change adds two production lines; no configuration, dependency, schema or persistence contract changes.

The credential test fixture now passes its own environment into its store context, preserving explicit overrides. This fixes test state leaking between rows exposed by the added account-selection coverage.

## User Impact

In the measured development source-loading path, Matrix Doctor module preparation improved 11–15% in both orders, saving roughly 34–46 ms. Median empty-state detection stayed below 0.6 ms. Nonempty detection pays the deferred import: roughly 38 ms moved from preparation into detection. All 90 median/mean/maximum comparisons are retained, including 30 adverse results (10 for each metric). This is a localized module-loading result, not a compiled Gateway readiness or per-turn latency claim.

## Evidence

The fixed comparison used the real built plugin loader and actual source Doctor module: 176 fresh child processes across eight scenarios, with 160 preparation timings and 140 complete detector timings. Full outputs, inputs and export/migration inventories matched across both variants. Each timing cell has five observations; no population-tail claim. Synthetic files contain no credentials, and detection did not open a state store.

All 21 focused tests, 25 selected normal checks, a full build and independent Codex review through P2 passed. The empty-state import guard fails on the original implementation. Real migration tests cover named, unnamed and ambiguous account handling separately from the detector timings. Earlier fixture and local harness failures remain recorded: the validation campaign's attempted cross-process aggregate clock was invalid, while its observed 207-second envelope was within the original allowance; no claim of working aggregate enforcement is made for that earlier validation. The numeric comparison uses one parent clock and completed within its fixed budget. An initial disk-floor admission stopped before any numeric child or source placement.
