### PR TITLE
test(exec): inline one-shot cleanup fixture

### DIFF
--- a/src/agents/bash-tools.exec-runtime.cleanup.test.ts
+++ b/src/agents/bash-tools.exec-runtime.cleanup.test.ts
@@ -22,27 +22,6 @@ afterEach(() => {
   resetProcessRegistryForTests();
 });
 
-function runtimeManagedRun(input: SpawnInput): ManagedRun {
-  return {
-    activity: { resultSettled: true, lastOutputAtMs: Date.now() },
-    runId: input.runId ?? "test-run",
-    pid: 1234,
-    startedAtMs: Date.now(),
-    stdin: { write: vi.fn(), end: vi.fn(), destroy: vi.fn() },
-    cancel: vi.fn(),
-    wait: vi.fn(async () => ({
-      reason: "exit" as const,
-      exitCode: 0,
-      exitSignal: null,
-      durationMs: 1,
-      stdout: "",
-      stderr: "",
-      timedOut: false,
-      noOutputTimedOut: false,
-    })),
-  };
-}
-
 it.each([
   { fails: false, beforeJoin: false, commandCode: 0 },
   { fails: true, beforeJoin: false, commandCode: 0 },
@@ -55,13 +34,24 @@ it.each([
     const entered = createDeferred();
     const cleanupScope = createAgentCleanupScope();
     const scopeKey = "scope:sandbox-artifact-cleanup";
-    supervisorMock.spawn.mockImplementationOnce(async (input: SpawnInput) => {
-      const managed = runtimeManagedRun(input);
-      return {
-        ...managed,
-        wait: async () => ({ ...(await managed.wait()), exitCode: commandCode }),
-      };
-    });
+    supervisorMock.spawn.mockImplementationOnce(async (input: SpawnInput): Promise<ManagedRun> => ({
+      activity: { resultSettled: true, lastOutputAtMs: Date.now() },
+      runId: input.runId ?? "test-run",
+      pid: 1234,
+      startedAtMs: Date.now(),
+      stdin: { write: vi.fn(), end: vi.fn(), destroy: vi.fn() },
+      cancel: vi.fn(),
+      wait: async () => ({
+        reason: "exit",
+        exitCode: commandCode,
+        exitSignal: null,
+        durationMs: 1,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    }));
     let run: Awaited<ReturnType<typeof runExecProcess>> | undefined;
     const finalizeExec = vi.fn(async () => {
       entered.resolve();


### PR DESCRIPTION
Related: #135868, #139948

## What Problem This Solves

The one-shot exec cleanup suite built a managed-run fixture whose only consumer immediately replaced its mocked wait result. This is the maintainer-requested Stage 3 test compression pass for concern C of the #135868 split, after reviewing #139937 and #139953.

## Why This Change Was Made

Inline the typed fixture at its sole consumer and return the row's command exit code directly. Keep all four finalization/cleanup timing cases and their deferred handshakes, stdin retirement, finalization-once assertion, and originating cleanup outcome.

## User Impact

No runtime behavior changes. All cases remain. Tests shrink by 10 lines (+18/−28); production, tooling, and docs each change by zero.

## Evidence

| Removed repetition | Surviving coverage |
| --- | --- |
| Single-consumer `runtimeManagedRun` helper | `src/agents/bash-tools.exec-runtime.cleanup.test.ts:31`, “joins sandbox artifacts and retains cleanup failure (fails=$fails, beforeJoin=$beforeJoin, commandCode=$commandCode)”, all four rows |
| Mocked wait returning zero, then replacement wait overriding the exit code | Same table at `:31`: successful finalization with a pending join; failed finalization with a pending join; failed finalization before joining; command exit 127 with failed finalization |

No one-shot cleanup cases were deleted. Codex completed/cancelled and retirement variants, supervisor ownership, and real-process shutdown suites remain unchanged.

Focused test: all four cases passed in 7.24 s. Full local changed checks passed, including test types, lint, guards, and all three dead-export scans. Independent Codex review is scoped-clean through P2. File size: 125 → 115 lines.

Full standard agents baseline passed on Blacksmith Testbox: 1,496 files across 11 canonical owner groups, 28,564 passed / 28 skipped, 794.34 s wall time (2,555.79 aggregate Vitest seconds). The executed file set matches the complete standard directory plan; the existing 41 optional live/E2E files remain outside that plan.

An initial aggregate directory invocation placed an existing isolation-sensitive OAuth suite into a shared worker. Repeating the full baseline through the declared owner groups passed without changing any source, assertion, or routing configuration. The candidate uses the same owner groups for its full after-run.

Full after-run passed on the identical file set: 1,496 files, 28,564 passed / 28 skipped, 767.85 s wall time (2,502.77 aggregate Vitest seconds). Before/after file sets and totals match exactly. Both one-shot Testbox leases stopped successfully.

Testbox proof: [before](https://github.com/openclaw/openclaw/actions/runs/34052703174), [after](https://github.com/openclaw/openclaw/actions/runs/34053579824). Delegated commands exited 0; their backing Actions jobs can show cancellation when Testbox stops the lease. Exact-head PR CI is green for `b956cc1002005a1a94df6e8e13f81a45a54218ac`: https://github.com/openclaw/openclaw/actions/runs/34054629888 . ClawSweeper reviewed the same head with no findings, before-merge requests, or rank-up moves.
