### PR TITLE
refactor(delivery): reuse the canonical rendered batch plan type

### DIFF
--- a/src/infra/outbound/delivery-queue-types.ts
+++ b/src/infra/outbound/delivery-queue-types.ts
@@ -4,7 +4,7 @@ import type { ReplyPayload } from "../../auto-reply/types.js";
 import type {
   ChannelMessageUnknownSendReconciliationResult,
   OutboundReplyFacts,
-  RenderedMessageBatchPlanItem,
+  RenderedMessageBatchPlan,
 } from "../../channels/message/types.js";
 import type { ReplyToMode } from "../../config/types.js";
 import type { PluginHookReplyPayloadSendingContext } from "../../plugins/hook-types.js";
@@ -17,16 +17,7 @@ import type { IndexedOutboundAuditTerminal } from "./outbound-audit.js";
 import type { PreparedOutboundBatch } from "./prepared-batch.js";
 import type { OutboundSessionContext } from "./session-context.js";
 
-export type QueuedRenderedMessageBatchPlan = {
-  payloadCount: number;
-  textCount: number;
-  mediaCount: number;
-  voiceCount: number;
-  presentationCount: number;
-  interactiveCount: number;
-  channelDataCount: number;
-  items: readonly RenderedMessageBatchPlanItem[];
-};
+export type QueuedRenderedMessageBatchPlan = RenderedMessageBatchPlan;
 
 export type QueuedReplyPayloadSendingHook = {
   kind: ReplyDispatchKind;


### PR DESCRIPTION
## What Problem This Solves

The outbound queue repeated the renderer's full batch-plan type while already importing its item type. The two declarations describe the same data, leaving an unnecessary second copy to maintain.

## Why This Change Was Made

Keep the exported queue type name and alias the canonical `RenderedMessageBatchPlan`. Its seven counters and readonly item array remain identical, and the module already has the same type-only dependency.

Deletion evidence: the repeated declaration in `src/infra/outbound/delivery-queue-types.ts:20` is replaced by the canonical type at `src/channels/message/types.ts:129`. `rendered-batch.test.ts:5` and `:23` retain normalized media/item and presentation-heading coverage. `git log -S QueuedRenderedMessageBatchPlan` locates the types split at `7026cf2f21d` (#123410).

## User Impact

No executable, schema, stored-format or delivery behavior change. The exported type name and all of its fields remain available.

## Evidence

- Whole-module TypeScript transpilation produces byte-identical JavaScript before and after.
- Production: **−9 lines**. Tests/support, tooling and docs unchanged.

- Five existing rendered-batch contract cases passed before and after.
- Full `node scripts/check-changed.mjs` passed.
- Independent Codex review: scoped-clean, no actionable P0–P2 findings.
- ClawSweeper reviewed this exact head and found no actionable correctness/security findings or before-merge work.
- Initial CI hit the unchanged agent-command timeout assertion (`599999` versus `600000` ms); the command budget subtracts real elapsed time. The one targeted same-head shard retry passed; exact-head CI is green. No timeout or assertion was changed.
