### PR TITLE
perf(agents): reduce work in verbose tool descriptions

### DIFF
--- a/src/agents/tool-description-summary.test.ts
+++ b/src/agents/tool-description-summary.test.ts
@@ -106,4 +106,16 @@ describe("tool description summaries", () => {
     expect(description).toBe("abcd...");
     expect(hasDanglingSurrogate(description)).toBe(false);
   });
+
+  it.each<[string, number, string]>([
+    ["ab\n\ncd\nef", 6, "ab\n\ncd"],
+    ["ab\n \n\t\ncd\nef", 6, "ab\n\ncd"],
+    ["  ab  \r\n\r\n  cd  \r\nef", 6, "ab\n\ncd"],
+    ["ab\n\nACTIONS:\nLater detail.", 320, "ab"],
+  ])(
+    "preserves verbose paragraph spacing and stopping for %j",
+    (rawDescription, maxLen, expected) => {
+      expect(describeToolForVerbose({ rawDescription, maxLen, fallback: "Tool" })).toBe(expected);
+    },
+  );
 });

--- a/src/agents/tool-description-summary.ts
+++ b/src/agents/tool-description-summary.ts
@@ -96,13 +96,15 @@ export function describeToolForVerbose(params: {
     return params.fallback;
   }
 
-  const lines = raw.split("\n").map((line) => line.trimEnd());
   const kept: string[] = [];
-  for (const line of lines) {
+  let keptLength = 0;
+  for (const line of raw.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed) {
       if (kept.length > 0 && kept.at(-1) !== "") {
         kept.push("");
+        // A paragraph gap contributes a separator even before the next line arrives.
+        keptLength += 1;
       }
       continue;
     }
@@ -114,16 +116,14 @@ export function describeToolForVerbose(params: {
     ) {
       break;
     }
+    keptLength += trimmed.length + (kept.length > 0 ? 1 : 0);
     kept.push(trimmed);
-    if (kept.join(" ").length >= (params.maxLen ?? 320)) {
+    if (keptLength >= (params.maxLen ?? 320)) {
       break;
     }
   }
 
-  const normalized = kept
-    .join("\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
+  const normalized = kept.join("\n").trim();
   if (!normalized) {
     return params.fallback;
   }


### PR DESCRIPTION
## What Problem This Solves

`/tools verbose` repeatedly assembles the growing description prefix just to check its length, and trims every line even when an early schema heading discards the rest. Long descriptions and larger tool inventories do unnecessary string work.

## Why This Change Was Made

Track the retained prefix length while visiting lines, remove the redundant preliminary trim pass, and drop a newline-collapse pass that the existing paragraph logic makes unnecessary. Preserve paragraph spacing, heading exclusion, fallback text, truncation boundaries and complete command output. Production LOC is neutral; no API or configuration changes.

## User Impact

In the fixed comparison, complete verbose inventories with 8–128 tools improved 39–47% in both orders. The many-line description case improved 62–64%, and a description with a long excluded schema tail improved 44–45%. These are formatter measurements, not Gateway or provider latency claims. All adverse observations remain: 21/76 medians, 26/76 means and 28/76 maxima worsened. One forward short-row sample raised its mean 325% and maximum 2,219% despite an improved median. Reverse process RSS rose about 15%, so no memory improvement is claimed. No samples were excluded.

## Evidence

The unchanged candidate has 33 focused tests, passing normal changed-file checks, and a fresh independent Codex review through P2. Added table rows protect paragraph gaps, repeated blank lines, CRLF and stopping at a schema heading.

A fixed B0/C0/C1/B1 comparison calls the actual description helpers and complete `buildToolsMessage` export across 38 cases. The cohort made 311,752 calls, including 304,000 timed calls. Repeated successful strings were checked against phase references; all 152 retained complete reference strings and inputs matched across variants and independent fixture expectations. All 1,216 batch observations are retained. Repeated successful bodies are not individually serialized.

Two local harness failures are retained separately. The first review stopped before contacting the reviewer because Python selected shared scratch; recovery used the OS private temp directory without changing isolation. The first numeric baseline completed, but its reader split a literal Unicode line separator inside a JSON string. The corrected reader uses LF framing and ran the same full fixed cohort in a separate namespace; the earlier baseline was not pooled. The successful cohort restored candidate source and closed its processes.
