### PR TITLE
docs: split oversized navigation groups and sort service lists

### DIFF
--- a/docs/.i18n/zh-Hans-navigation.json
+++ b/docs/.i18n/zh-Hans-navigation.json
@@ -115,21 +115,23 @@
       "tab": "代理",
       "groups": [
         {
-          "group": "基础",
+          "group": "代理运行时",
           "pages": [
             "zh-CN/pi",
             "zh-CN/concepts/architecture",
             "zh-CN/concepts/agent",
             "zh-CN/concepts/agent-loop",
             "zh-CN/concepts/system-prompt",
-            "zh-CN/concepts/context",
-            "zh-CN/concepts/agent-workspace",
-            "zh-CN/concepts/oauth"
+            "zh-CN/concepts/context"
           ]
         },
         {
-          "group": "引导",
-          "pages": ["zh-CN/start/bootstrapping"]
+          "group": "代理工作区",
+          "pages": [
+            "zh-CN/concepts/agent-workspace",
+            "zh-CN/concepts/oauth",
+            "zh-CN/start/bootstrapping"
+          ]
         },
         {
           "group": "会话与记忆",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1256,25 +1256,40 @@
               {
                 "group": "Hosting",
                 "pages": [
-                  "install/azure",
-                  "install/cloudflare",
-                  "install/daytona",
-                  "install/digitalocean",
-                  "install/docker-vm-runtime",
-                  "install/exe-dev",
-                  "install/fly",
-                  "install/gcp",
-                  "install/hetzner",
-                  "install/hostinger",
-                  "install/kubernetes",
                   "vps",
-                  "install/macos-vm",
-                  "install/northflank",
-                  "install/oracle",
-                  "install/railway",
-                  "install/raspberry-pi",
-                  "install/render",
-                  "install/upstash"
+                  {
+                    "group": "App platforms",
+                    "pages": [
+                      "install/cloudflare",
+                      "install/daytona",
+                      "install/exe-dev",
+                      "install/fly",
+                      "install/northflank",
+                      "install/railway",
+                      "install/render",
+                      "install/upstash"
+                    ]
+                  },
+                  {
+                    "group": "Cloud servers",
+                    "pages": [
+                      "install/azure",
+                      "install/digitalocean",
+                      "install/gcp",
+                      "install/hetzner",
+                      "install/hostinger",
+                      "install/oracle"
+                    ]
+                  },
+                  {
+                    "group": "Self-hosted and local",
+                    "pages": [
+                      "install/docker-vm-runtime",
+                      "install/kubernetes",
+                      "install/macos-vm",
+                      "install/raspberry-pi"
+                    ]
+                  }
                 ]
               },
               {
@@ -1299,21 +1314,36 @@
               {
                 "group": "Mainstream messaging",
                 "pages": [
-                  "channels/discord",
-                  "channels/discord-activities",
+                  {
+                    "group": "Discord",
+                    "pages": [
+                      "channels/discord",
+                      "channels/discord-activities"
+                    ]
+                  },
+                  "channels/googlechat",
+                  {
+                    "group": "iMessage",
+                    "pages": [
+                      "channels/imessage",
+                      "channels/imessage-from-bluebubbles"
+                    ]
+                  },
+                  {
+                    "group": "Matrix",
+                    "pages": [
+                      "channels/matrix",
+                      "channels/matrix-migration",
+                      "channels/matrix-presentation",
+                      "channels/matrix-push-rules"
+                    ]
+                  },
+                  "channels/msteams",
+                  "channels/signal",
                   "channels/slack",
                   "channels/sms",
                   "channels/telegram",
-                  "channels/whatsapp",
-                  "channels/signal",
-                  "channels/msteams",
-                  "channels/googlechat",
-                  "channels/imessage",
-                  "channels/imessage-from-bluebubbles",
-                  "channels/matrix",
-                  "channels/matrix-migration",
-                  "channels/matrix-presentation",
-                  "channels/matrix-push-rules"
+                  "channels/whatsapp"
                 ]
               },
               {
@@ -1326,21 +1356,21 @@
                   "channels/mattermost",
                   "channels/nextcloud-talk",
                   "channels/nostr",
-                  "channels/reef",
                   "channels/raft",
-                  "channels/tlon",
+                  "channels/reef",
                   "channels/synology-chat",
+                  "channels/tlon",
                   "channels/twitch"
                 ]
               },
               {
                 "group": "Regional platforms",
                 "pages": [
+                  "channels/feishu",
                   "channels/line",
+                  "channels/qqbot",
                   "channels/wechat",
                   "channels/wecom",
-                  "channels/qqbot",
-                  "channels/feishu",
                   "channels/yuanbao",
                   "channels/zalo",
                   "channels/zaloclawbot",
@@ -1367,7 +1397,7 @@
             "tab": "Agents",
             "groups": [
               {
-                "group": "Fundamentals",
+                "group": "Agent runtime",
                 "pages": [
                   "concepts/architecture",
                   "concepts/agent",
@@ -1376,14 +1406,17 @@
                   "concepts/system-prompt",
                   "concepts/context",
                   "concepts/context-engine",
+                  "concepts/soul"
+                ]
+              },
+              {
+                "group": "Agent workspace",
+                "pages": [
                   "concepts/agent-workspace",
                   "concepts/managed-worktrees",
-                  "concepts/soul",
                   "concepts/oauth",
                   "start/bootstrapping",
-                  "concepts/experimental-features",
-                  "concepts/qa-e2e-automation",
-                  "concepts/personal-agent-benchmark-pack"
+                  "concepts/experimental-features"
                 ]
               },
               {
@@ -1459,28 +1492,53 @@
               {
                 "group": "Plugin guides",
                 "pages": [
-                  "plugins/codex-harness",
-                  "plugins/codex-supervision",
-                  "plugins/codex-native-plugins",
-                  "plugins/codex-computer-use",
-                  "plugins/logbook",
-                  "plugins/meeting-plugins",
-                  "plugins/google-meet",
-                  "plugins/teams-meetings",
-                  "plugins/zoom-meetings",
-                  "plugins/workboard",
-                  "plugins/webhooks",
-                  "plugins/admin-http-rpc",
-                  "plugins/geolocation",
-                  "plugins/beam",
-                  "plugins/voice-call",
-                  "plugins/vault",
-                  "plugins/onepassword",
-                  "plugins/memory-wiki",
-                  "plugins/llama-cpp",
-                  "plugins/memory-lancedb",
-                  "plugins/oc-path",
-                  "plugins/zalouser"
+                  {
+                    "group": "Codex",
+                    "pages": [
+                      "plugins/codex-computer-use",
+                      "plugins/codex-harness",
+                      "plugins/codex-native-plugins",
+                      "plugins/codex-supervision"
+                    ]
+                  },
+                  {
+                    "group": "Meetings and calls",
+                    "pages": [
+                      "plugins/meeting-plugins",
+                      "plugins/google-meet",
+                      "plugins/teams-meetings",
+                      "plugins/voice-call",
+                      "plugins/zoom-meetings"
+                    ]
+                  },
+                  {
+                    "group": "Models and memory",
+                    "pages": [
+                      "plugins/llama-cpp",
+                      "plugins/memory-lancedb",
+                      "plugins/memory-wiki"
+                    ]
+                  },
+                  {
+                    "group": "Secrets and vaults",
+                    "pages": [
+                      "plugins/onepassword",
+                      "plugins/vault"
+                    ]
+                  },
+                  {
+                    "group": "Automation and integrations",
+                    "pages": [
+                      "plugins/admin-http-rpc",
+                      "plugins/beam",
+                      "plugins/geolocation",
+                      "plugins/logbook",
+                      "plugins/oc-path",
+                      "plugins/webhooks",
+                      "plugins/workboard",
+                      "plugins/zalouser"
+                    ]
+                  }
                 ]
               },
               {
@@ -1525,56 +1583,81 @@
               {
                 "group": "Tools",
                 "pages": [
-                  "tools/apply-patch",
-                  "tools/ask-user",
-                  "tools/btw",
-                  "tools/code-execution",
-                  "tools/code-mode",
-                  "tools/diffs",
-                  "tools/screen",
-                  "tools/progress-card",
-                  "tools/show-widget",
-                  "tools/elevated",
-                  "tools/permission-modes",
-                  "tools/exec-approvals",
-                  "tools/exec-approvals-advanced",
-                  "tools/exec",
-                  "tools/image-generation",
-                  "tools/llm-task",
-                  "tools/lobster",
-                  "tools/media-overview",
-                  "tools/mcp",
-                  "tools/music-generation",
-                  "tools/pdf",
-                  "tools/reactions",
-                  "tools/secrets",
-                  "tools/thinking",
-                  "tools/tokenjuice",
-                  "tools/tool-search",
-                  "tools/loop-detection",
-                  "tools/trajectory",
-                  "tools/tts",
-                  "tools/video-generation",
                   {
-                    "group": "Web browser",
+                    "group": "Running code and approvals",
                     "pages": [
-                      "tools/browser",
-                      "tools/chrome-extension",
-                      "tools/browser-control",
-                      "tools/browser-login",
-                      "tools/browser-linux-troubleshooting",
-                      "tools/browser-wsl2-windows-remote-cdp-troubleshooting"
+                      "tools/apply-patch",
+                      "tools/code-execution",
+                      "tools/diffs",
+                      "tools/elevated",
+                      "tools/exec",
+                      "tools/exec-approvals",
+                      "tools/exec-approvals-advanced",
+                      "tools/permission-modes",
+                      "tools/secrets"
                     ]
                   },
                   {
-                    "group": "Web tools",
+                    "group": "Media and documents",
                     "pages": [
-                      "tools/web-fetch",
+                      "tools/media-overview",
+                      "tools/image-generation",
+                      "tools/music-generation",
+                      "tools/pdf",
+                      "tools/tts",
+                      "tools/video-generation"
+                    ]
+                  },
+                  {
+                    "group": "Tool catalogs and workflows",
+                    "pages": [
+                      "tools/code-mode",
+                      "tools/llm-task",
+                      "tools/lobster",
+                      "tools/mcp",
+                      "tools/tool-search"
+                    ]
+                  },
+                  {
+                    "group": "Context and reasoning",
+                    "pages": [
+                      "tools/loop-detection",
+                      "tools/thinking",
+                      "tools/tokenjuice",
+                      "tools/trajectory"
+                    ]
+                  },
+                  {
+                    "group": "Chat and UI tools",
+                    "pages": [
+                      "tools/ask-user",
+                      "tools/btw",
+                      "tools/progress-card",
+                      "tools/reactions",
+                      "tools/screen",
+                      "tools/show-widget"
+                    ]
+                  },
+                  {
+                    "group": "Browsing and fetching pages",
+                    "pages": [
+                      "tools/browser",
+                      "tools/browser-control",
+                      "tools/browser-linux-troubleshooting",
+                      "tools/browser-login",
+                      "tools/browser-wsl2-windows-remote-cdp-troubleshooting",
+                      "tools/chrome-extension",
+                      "tools/firecrawl",
+                      "tools/web-fetch"
+                    ]
+                  },
+                  {
+                    "group": "Web search",
+                    "pages": [
                       "tools/web",
                       "tools/brave-search",
                       "tools/duckduckgo-search",
                       "tools/exa-search",
-                      "tools/firecrawl",
                       "tools/gemini-search",
                       "tools/grok-search",
                       "tools/kimi-search",
@@ -1658,71 +1741,96 @@
               {
                 "group": "Providers",
                 "pages": [
-                  "providers/alibaba",
-                  "providers/bedrock",
-                  "providers/bedrock-mantle",
-                  "providers/anthropic",
-                  "providers/arcee",
-                  "providers/azure-speech",
-                  "providers/cerebras",
-                  "providers/chutes",
-                  "providers/clawrouter",
-                  "providers/cohere",
-                  "providers/claude-max-api-proxy",
-                  "providers/cloudflare-ai-gateway",
-                  "providers/comfy",
-                  "providers/deepgram",
-                  "providers/deepinfra",
-                  "providers/deepseek",
-                  "providers/ds4",
-                  "providers/elevenlabs",
-                  "providers/fish-audio",
-                  "providers/fal",
-                  "providers/featherless",
-                  "providers/fireworks",
-                  "providers/github-copilot",
-                  "providers/gmi",
-                  "providers/google",
-                  "providers/gradium",
-                  "providers/groq",
-                  "providers/huggingface",
-                  "providers/inworld",
-                  "providers/kilocode",
-                  "providers/litellm",
-                  "providers/llmman",
-                  "providers/lmstudio",
-                  "providers/longcat",
-                  "providers/meta",
-                  "providers/minimax",
-                  "providers/mistral",
-                  "providers/moonshot",
-                  "providers/novita",
-                  "providers/nvidia",
-                  "providers/ollama",
-                  "providers/ollama-cloud",
-                  "providers/openai",
-                  "providers/opencode",
-                  "providers/opencode-go",
-                  "providers/openrouter",
-                  "providers/perplexity-provider",
-                  "providers/pixverse",
-                  "providers/qianfan",
-                  "providers/qwen",
-                  "providers/runway",
-                  "providers/senseaudio",
-                  "providers/sglang",
-                  "providers/stepfun",
-                  "providers/synthetic",
-                  "providers/tencent",
-                  "providers/together",
-                  "providers/venice",
-                  "providers/vercel-ai-gateway",
-                  "providers/vllm",
-                  "providers/volcengine",
-                  "providers/vydra",
-                  "providers/xai",
-                  "providers/xiaomi",
-                  "providers/zai"
+                  {
+                    "group": "Chat and coding models",
+                    "pages": [
+                      "providers/alibaba",
+                      "providers/anthropic",
+                      "providers/arcee",
+                      "providers/bedrock",
+                      "providers/bedrock-mantle",
+                      "providers/cerebras",
+                      "providers/chutes",
+                      "providers/cohere",
+                      "providers/deepinfra",
+                      "providers/deepseek",
+                      "providers/featherless",
+                      "providers/fireworks",
+                      "providers/github-copilot",
+                      "providers/gmi",
+                      "providers/google",
+                      "providers/groq",
+                      "providers/huggingface",
+                      "providers/longcat",
+                      "providers/meta",
+                      "providers/minimax",
+                      "providers/mistral",
+                      "providers/moonshot",
+                      "providers/novita",
+                      "providers/nvidia",
+                      "providers/ollama-cloud",
+                      "providers/openai",
+                      "providers/opencode",
+                      "providers/opencode-go",
+                      "providers/perplexity-provider",
+                      "providers/qianfan",
+                      "providers/qwen",
+                      "providers/stepfun",
+                      "providers/synthetic",
+                      "providers/tencent",
+                      "providers/together",
+                      "providers/venice",
+                      "providers/volcengine",
+                      "providers/xai",
+                      "providers/xiaomi",
+                      "providers/zai"
+                    ]
+                  },
+                  {
+                    "group": "Speech and audio",
+                    "pages": [
+                      "providers/azure-speech",
+                      "providers/deepgram",
+                      "providers/elevenlabs",
+                      "providers/fish-audio",
+                      "providers/gradium",
+                      "providers/inworld",
+                      "providers/senseaudio"
+                    ]
+                  },
+                  {
+                    "group": "Image, video, and music",
+                    "pages": [
+                      "providers/comfy",
+                      "providers/fal",
+                      "providers/pixverse",
+                      "providers/runway",
+                      "providers/vydra"
+                    ]
+                  },
+                  {
+                    "group": "Gateways and routers",
+                    "pages": [
+                      "providers/claude-max-api-proxy",
+                      "providers/clawrouter",
+                      "providers/cloudflare-ai-gateway",
+                      "providers/kilocode",
+                      "providers/litellm",
+                      "providers/openrouter",
+                      "providers/vercel-ai-gateway"
+                    ]
+                  },
+                  {
+                    "group": "Local runtimes",
+                    "pages": [
+                      "providers/ds4",
+                      "providers/llmman",
+                      "providers/lmstudio",
+                      "providers/ollama",
+                      "providers/sglang",
+                      "providers/vllm"
+                    ]
+                  }
                 ]
               }
             ]
@@ -1952,44 +2060,59 @@
                 "pages": [
                   "cli/index",
                   {
-                    "group": "Gateway and service",
+                    "group": "Running the service",
                     "pages": [
-                      "cli/backup",
                       "cli/openclaw",
                       "cli/daemon",
-                      "cli/doctor",
                       "cli/fleet",
                       "cli/gateway",
                       "cli/health",
                       "cli/logs",
+                      "cli/status"
+                    ]
+                  },
+                  {
+                    "group": "Setup and maintenance",
+                    "pages": [
+                      "cli/backup",
                       "cli/migrate",
                       "cli/onboard",
                       "cli/reset",
-                      "cli/secrets",
-                      "cli/security",
                       "cli/setup",
-                      "cli/status",
-                      "cli/triage",
                       "cli/uninstall",
                       "cli/update"
                     ]
                   },
                   {
-                    "group": "Agents and sessions",
+                    "group": "Diagnostics and security",
+                    "pages": [
+                      "cli/doctor",
+                      "cli/secrets",
+                      "cli/security",
+                      "cli/triage"
+                    ]
+                  },
+                  {
+                    "group": "Agents, models, and sessions",
                     "pages": [
                       "cli/agent",
                       "cli/agents",
                       "cli/claws",
-                      "cli/audit",
-                      "cli/hooks",
                       "cli/infer",
                       "cli/memory",
-                      "cli/message",
                       "cli/models",
                       "cli/promos",
                       "cli/sessions",
-                      "cli/system",
                       "cli/tasks"
+                    ]
+                  },
+                  {
+                    "group": "Events and audit records",
+                    "pages": [
+                      "cli/audit",
+                      "cli/hooks",
+                      "cli/message",
+                      "cli/system"
                     ]
                   },
                   {
@@ -2215,7 +2338,9 @@
                 "pages": [
                   "reference/test",
                   "ci",
-                  "help/scripts"
+                  "help/scripts",
+                  "concepts/qa-e2e-automation",
+                  "concepts/personal-agent-benchmark-pack"
                 ]
               }
             ]

--- a/test/scripts/docs-sync-publish.test.ts
+++ b/test/scripts/docs-sync-publish.test.ts
@@ -389,6 +389,8 @@ fs.writeFileSync('package-lock.json', JSON.stringify(lock));
       "reference/test",
       "ci",
       "help/scripts",
+      "concepts/qa-e2e-automation",
+      "concepts/personal-agent-benchmark-pack",
     ];
     expect(collectPages(releaseTab)).toEqual(releaseRoutes);
     expect(new Set(releaseRoutes)).toHaveLength(releaseRoutes.length);


### PR DESCRIPTION
## What

Regroups and reorders `docs/docs.json` navigation entries only. **No page is added, removed, renamed, moved on disk, or re-routed.**

Combines five navigation findings that all edit the same file: **PR-015, PR-016, PR-017, PR-018, PR-021**.

## Page set is unchanged

The navigation page list was dumped recursively (walking `tabs` / `groups` / `pages` / `page`) before and after the change and diffed:

```
$ python3 dump-pages.py > pages-before.txt   # 598 entries
$ python3 dump-pages.py > pages-after.txt    # 598 entries
$ diff pages-before.txt pages-after.txt
PAGE SETS IDENTICAL (598 entries)
```

The transform script itself asserts set equality and aborts if it ever differs.

## Sibling counts, before -> after

| Group | Before | After | New subgroups |
|---|---|---|---|
| Models > Providers | 65 | 5 subgroups | Chat and coding models (40), Speech and audio (7), Image, video, and music (5), Gateways and routers (7), Local runtimes (6) |
| Capabilities > Tools | 30 direct + 2 subgroups (32) | 7 subgroups | Running code and approvals (9), Media and documents (6), Tool catalogs and workflows (5), Context and reasoning (4), Chat and UI tools (6), Browsing and fetching pages (8), Web search (13) |
| Agents > Fundamentals | 15 | split into 2 groups | Agent runtime (8), Agent workspace (5); 2 QA pages moved out |
| Release & CI > Testing and CI | 3 | 5 | gains `concepts/qa-e2e-automation`, `concepts/personal-agent-benchmark-pack` |
| Reference > CLI commands > Gateway and service | 18 | 3 subgroups | Running the service (7), Setup and maintenance (7), Diagnostics and security (4) |
| Reference > CLI commands > Agents and sessions | 13 | 2 subgroups | Agents, models, and sessions (9), Events and audit records (4) |
| Install > Hosting | 19 | 1 page + 3 subgroups | `vps` first (it is the "Linux server" provider picker), App platforms (8), Cloud servers (6), Self-hosted and local (4) |
| Capabilities > Plugin guides | 22 | 5 subgroups | Codex (4), Meetings and calls (5), Models and memory (3), Secrets and vaults (2), Automation and integrations (8) |
| Channels > Mainstream messaging | 15 | 10 | Discord (2), iMessage (2), Matrix (4) nested under their parent service; rest alphabetical |
| Channels > Developer and self-hosted | 12 | 12 | sorted alphabetically |
| Channels > Regional platforms | 9 | 9 | sorted alphabetically |

Overview pages stay first in their group (`tools/media-overview`, `tools/web`, `plugins/meeting-plugins`, `cli/openclaw`, `vps`).

Sorting follows the existing convention in these lists: alphabetical by route slug (the lists were already slug-ordered apart from the entries the audit flagged), per the ordering rule in `docs/AGENTS.md`.

## Test lane that docs-only CI skips

`test/scripts/docs-sync-publish.test.ts` pins the exact route list for the **Release & CI** tab and asserts every English page has a `zh-CN/` counterpart in the generated locale navigation. **The docs-only CI classification does not select this test's lane**, so a navigation change can go green on the PR and break `main`. It has been run locally against this change.

Note: the command shape in the audit playbook (`--config test/vitest/vitest.unit-fast.config.ts`) does **not** run this file — it is not a unit-fast shard member (`classifyUnitFastTestFileContent` disqualifies it for `dynamic-import` and `filesystem-state`), and vitest exits 0 with "No test files found". The file belongs to the **tooling** shard:

```
$ npx vitest run --config test/vitest/vitest.tooling.config.ts \
    test/scripts/docs-sync-publish.test.ts

 Test Files  1 passed (1)
      Tests  10 passed (10)
```

Assertions this change touches:

1. `expect(collectPages(releaseTab)).toEqual(releaseRoutes)` — **changed deliberately.** Moving the two QA pages into `Testing and CI` adds two routes to the Release & CI tab, and the test failed on it (39 vs 37) before the expectation was updated. The invariant (the tab holds exactly this route list, mirrored into every locale) still holds; only its membership moved, which is the point of finding PR-017. The two routes are appended to `releaseRoutes`; the locale mirrors derive from that list, so no other edit was needed.
2. `releaseTab.groups.map(g => g.group) === ["Release notes","Maturity","Release process","Testing and CI"]` — unchanged; no group in that tab was renamed.
3. `english.tabs.slice(-4)` tab names — unchanged; no tab was added, removed, or renamed.
4. `collectPages(simplifiedChinese) === every English page prefixed zh-CN/`, and the German page-count check — unchanged and passing; locale navs are cloned from English, so the regrouping mirrors automatically.
5. `releaseNotes[0] === "releases/index"` and the release route-shape regex — untouched.

## i18n mirror

`applyLocaleNavLabelOverlay` only overlays **tab** and **top-level group** labels, matching by page overlap. The only top-level group label this PR changes is `Agents > Fundamentals`, which becomes `Agent runtime` + `Agent workspace`. `docs/.i18n/zh-Hans-navigation.json` is updated so the overlay still lands correctly (`代理运行时` and `代理工作区`, with `concepts/agent-workspace` / `concepts/oauth` moved into the second entry). Verified:

```
zh: [ '代理运行时', '代理工作区', '会话与记忆', '多代理', '消息与投递' ]
en: [ 'Agent runtime', 'Agent workspace', 'Sessions and memory', 'Multi-agent', 'Messages and delivery' ]
```

The other `docs/.i18n/*-navigation.json` files only carry the "Get started" tab and need no change. New **subgroup** labels are never overlaid (that is pre-existing behaviour — `Web browser` and `Web tools` were already untranslated), so no glossary entries are required; `pnpm docs:check-i18n-glossary` passes.

## Validators

```
$ npx vitest run --config test/vitest/vitest.tooling.config.ts test/scripts/docs-sync-publish.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)

$ node scripts/check-docs-mdx.mjs docs README.md
Docs MDX check passed (775 files, 4510ms).

$ OPENCLAW_DOCS_SYNC_CLAWHUB_REPO=... node scripts/docs-link-audit.mjs
checked_internal_links=8291
broken_links=0

$ OPENCLAW_DOCS_SYNC_CLAWHUB_REPO=... node scripts/docs-link-audit.mjs --anchors
checked_internal_links=8660
broken_links=0
omitted_compatibility_aliases=1

$ node scripts/format-docs.mts --check
Docs formatting clean (762 files).

$ node --import ./scripts/tsx.mjs scripts/check-docs-i18n-glossary.mts
(exit 0)

$ npx oxfmt --check test/scripts/docs-sync-publish.test.ts
All matched files use the correct format.
```

## Deliberately not changed

- **`Chat and coding models` is still 40 siblings.** Modality is the only non-arbitrary axis for a provider directory; splitting it further (frontier lab vs inference platform vs regional cloud, or by alphabet range) means 40 judgement calls that belong in their own PR with maintainer input.
- **`Web search` is 13** (an overview plus 12 search backends). Splitting a flat list of interchangeable search providers would not help a reader.
- **`Release notes > v2026.8.1 sections`** is left alone. On current `main` it is an empty group wrapping another empty group (leftover from #140353) — worth cleaning up, but it is not one of these findings and it does not affect the page set.
- **`tools/tts` appears twice in the nav** (`Capabilities > Tools > Media and documents` and `Gateway & Ops > Nodes and media > Media capabilities`). Pre-existing duplicate, preserved exactly; deduplicating it would change the page set this PR promises to leave alone.
- **No routes were renamed.** PR-016's finding r5-0257 also proposes moving `gateway/background-process` to `/tools/background-process` with a redirect. That is a route change, out of scope here.

Closes audit findings: PR-015 (r3-0911), PR-016, PR-017 (r3-0916), PR-018, PR-021 (r3-0908, r3-0912, r3-0913, r3-0914, r3-0915, r3-0917)
