### PR TITLE
refactor(gateway): reuse protocol handshake credential types

### DIFF
--- a/src/gateway/server/ws-connection/auth-context.ts
+++ b/src/gateway/server/ws-connection/auth-context.ts
@@ -1,6 +1,7 @@
 // WebSocket auth context resolves handshake credentials before device pairing and capability checks run.
 import type { IncomingMessage } from "node:http";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { ConnectParams } from "../../../../packages/gateway-protocol/src/index.js";
 import {
   AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN,
   AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
@@ -15,15 +16,6 @@ import {
 } from "../../auth.js";
 import { PROXY_ATTRIBUTION_REQUIRED_REASON } from "../../ingress-attribution.js";
 import { withSerializedRateLimitAttempt } from "../../rate-limit-attempt-serialization.js";
-
-type HandshakeConnectAuth = {
-  token?: string;
-  bootstrapToken?: string;
-  deviceToken?: string;
-  password?: string;
-  approvalRuntimeToken?: string;
-  agentRuntimeIdentityToken?: string;
-};
 
 type DeviceTokenCandidateSource = "explicit-device-token" | "shared-token-fallback";
 
@@ -100,7 +92,7 @@ function mapDeviceTokenAuthFailureReason(params: {
 }
 
 function resolveSharedConnectAuth(
-  connectAuth: HandshakeConnectAuth | null | undefined,
+  connectAuth: ConnectParams["auth"] | null,
 ): { token?: string; password?: string } | undefined {
   const token = normalizeOptionalString(connectAuth?.token);
   const password = normalizeOptionalString(connectAuth?.password);
@@ -110,7 +102,7 @@ function resolveSharedConnectAuth(
   return { token, password };
 }
 
-function resolveDeviceTokenCandidate(connectAuth: HandshakeConnectAuth | null | undefined): {
+function resolveDeviceTokenCandidate(connectAuth: ConnectParams["auth"] | null): {
   token?: string;
   source?: DeviceTokenCandidateSource;
 } {
@@ -127,7 +119,7 @@ function resolveDeviceTokenCandidate(connectAuth: HandshakeConnectAuth | null | 
 
 export async function resolveConnectAuthState(params: {
   resolvedAuth: ResolvedGatewayAuth;
-  connectAuth: HandshakeConnectAuth | null | undefined;
+  connectAuth: ConnectParams["auth"] | null;
   hasDeviceIdentity: boolean;
   req: IncomingMessage;
   trustedProxies: string[];

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -34,15 +34,6 @@ type HandshakeBrowserSecurityContext = {
   authRateLimiter?: AuthRateLimiter;
 };
 
-type HandshakeConnectAuth = {
-  token?: string;
-  bootstrapToken?: string;
-  deviceToken?: string;
-  password?: string;
-  approvalRuntimeToken?: string;
-  agentRuntimeIdentityToken?: string;
-};
-
 export function isNativeAppUiClient(client: ConnectParams["client"]): boolean {
   return (
     client.mode === GATEWAY_CLIENT_MODES.UI &&
@@ -333,9 +324,7 @@ export function resolveDeviceSignaturePayloadVersion(params: {
   return null;
 }
 
-function resolveAuthProvidedKind(
-  connectAuth: HandshakeConnectAuth | null | undefined,
-): AuthProvidedKind {
+function resolveAuthProvidedKind(connectAuth: ConnectParams["auth"] | null): AuthProvidedKind {
   return connectAuth?.password
     ? "password"
     : connectAuth?.token
@@ -348,7 +337,7 @@ function resolveAuthProvidedKind(
 }
 
 export function resolveUnauthorizedHandshakeContext(params: {
-  connectAuth: HandshakeConnectAuth | null | undefined;
+  connectAuth: ConnectParams["auth"] | null;
   failedAuth: GatewayAuthResult;
   hasDeviceIdentity: boolean;
 }): {


### PR DESCRIPTION
## What Problem This Solves

Gateway handshake helpers maintained two private copies of the protocol's credential shape. Each repeated the same six optional strings, making future protocol maintenance unnecessarily easy to get out of sync.

## Why This Change Was Made

Use `ConnectParams["auth"]` in both helpers. The protocol's optional auth property already includes `undefined`; retaining `| null` preserves the existing helper inputs. No authentication logic or protocol schema changes.

Deletion evidence: the two private `HandshakeConnectAuth` declarations are exactly represented by `packages/gateway-protocol/src/schema/frames.ts:65`. Their history starts at `e357203be57`. Both helpers now consume that canonical shape; no exported type name is removed.

## User Impact

No user-visible change. Credential normalization, shared/device/bootstrap token precedence, rate limits, pairing, and retry advice remain unchanged.

## Evidence

- Production: **+6/−25 = −19 lines**; tests/support, tooling, and docs unchanged.
- Both complete modules emit byte-identical JavaScript before and after.
- All 63 existing cases across the two auth-context and two handshake-auth-helper suites passed before and after (7.37s → 5.69s Vitest time).
- Surviving coverage includes `auth-context.test.ts:265` (proxy-attribution failure blocks credential fallbacks), `:341` (valid device tokens), `:355` (bootstrap precedence), `auth-context.state.test.ts:125` (device auth does not reset shared-secret limits), and `handshake-auth-helpers.linux.test.ts:23` (local versus remote pairing).
- Independent Codex review: scoped-clean, no actionable P0–P2 findings.
- Full `node scripts/check-changed.mjs` passed, including core/test types, all three dead-export scans, and repository guards. Rebase preserved both edited modules and the dependency lock exactly.
- ClawSweeper reviewed this exact head: no correctness/security findings or before-merge work. Exact-head CI is green.
