### PR TITLE
refactor(feishu): drop inert comment upload policy

### DIFF
--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -3583,19 +3583,13 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
     expectFeishuResult(result, "text_msg");
   });
 
-  // Regression for #112244 (fourteenth-review P1): the direct `send` action
-  // stamps the propagation marker on channelData.feishu before routing an
-  // attachment through sendPayload. The document-comment sendPayload branch
-  // preserves the marker (so the fallback helper requests propagation), but a
-  // comment target must NOT throw on the strength of that marker alone: the
-  // comment-target media-link fallback renders the media URL as a visible
-  // clickable link, which is established main behavior and NOT the silent
-  // text-only `ok:true` drop issue #112244 removes. Propagation is reserved for
-  // actual media-upload failures (the `sendMediaFeishu` catch), which a comment
-  // target never reaches because it never uploads. With the marker set, the
-  // comment target still renders the visible media-link fallback and returns a
-  // success receipt — the same outcome as the marker-absent case below.
-  it("renders the visible media-link fallback on a document-comment target even when the propagation marker is set", async () => {
+  it.each([
+    [
+      "renders the visible media-link fallback on a document-comment target even when the propagation marker is set",
+      true,
+    ],
+    ["still degrades a comment attachment to text when the propagation marker is absent", false],
+  ] as const)("%s", async (_name, propagate) => {
     const result = await feishuOutbound.sendPayload?.({
       cfg: emptyConfig,
       to: "comment:docx:doxcn123:7623358762119646411",
@@ -3604,37 +3598,19 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
       payload: {
         text: "see attachment",
         mediaUrl: "https://example.com/pipeline.png",
-        channelData: {
-          feishu: { [FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER]: true },
-        },
+        ...(propagate
+          ? {
+              channelData: {
+                feishu: { [FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER]: true },
+              },
+            }
+          : {}),
       },
     });
 
-    // The media URL is delivered as a visible comment text link (not a silent
-    // text-only ok), and a success receipt is returned — comment targets keep
-    // their established media-link fallback regardless of the propagation flag.
     expect(commentThreadParams()?.content).toBe("https://example.com/pipeline.png");
     expectFeishuResult(result, "reply_msg");
-    // No media upload is attempted for a comment target.
     expect(sendMediaFeishuMock).not.toHaveBeenCalled();
-  });
-
-  it("still degrades a comment attachment to text when the propagation marker is absent", async () => {
-    const result = await feishuOutbound.sendPayload?.({
-      cfg: emptyConfig,
-      to: "comment:docx:doxcn123:7623358762119646411",
-      text: "see attachment",
-      accountId: "main",
-      payload: {
-        text: "see attachment",
-        mediaUrl: "https://example.com/pipeline.png",
-      },
-    });
-
-    // Default comment behavior is unchanged: the media link is rendered as a
-    // fallback text comment and a success receipt is returned.
-    expect(commentThreadParams()?.content).toBe("https://example.com/pipeline.png");
-    expectFeishuResult(result, "reply_msg");
   });
 });
 

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -206,24 +206,6 @@ function readFeishuPropagateMediaUploadFailure(payload: FeishuOutboundPayload): 
   return feishuData?.[FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER] === true;
 }
 
-// Builds a `channelData.feishu` that carries only the direct-send upload-failure
-// policy marker. The document-comment branch strips native card / interactive
-// channelData before fallback delivery (those cannot render in comments), but
-// it must not drop the propagation marker the direct `send` action stamped —
-// otherwise a media-upload failure on a comment target degrades to a
-// fallback-text `ok:true` receipt again (issue #112244, ClawSweeper P1).
-function buildFeishuPropagationOnlyChannelData(
-  payload: FeishuOutboundPayload,
-): { feishu: Record<string, unknown> } | undefined {
-  const feishuData = isRecord(payload.channelData?.feishu) ? payload.channelData.feishu : undefined;
-  if (feishuData?.[FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER] !== true) {
-    return undefined;
-  }
-  return {
-    feishu: { [FEISHU_PROPAGATE_MEDIA_UPLOAD_FAILURE_MARKER]: true },
-  };
-}
-
 type FeishuReplyMode =
   | { normalizedReplyToId: string; replyToMessageId: string; replyInThread: false }
   | { normalizedReplyToId: undefined; replyToMessageId: string; replyInThread: true }
@@ -547,12 +529,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         text,
         interactive: undefined,
         presentation: undefined,
-        // Strip native card / interactive channelData (comments cannot render
-        // them) but preserve the direct-send upload-failure propagation marker
-        // so a media-upload failure on a comment target stays visible instead
-        // of degrading to a fallback-text `ok:true` receipt (issue #112244,
-        // ClawSweeper P1).
-        channelData: buildFeishuPropagationOnlyChannelData(payload),
+        channelData: undefined,
       };
       return await sendFeishuFallbackPayload({
         ctx,
@@ -840,18 +817,8 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       };
       const deliveryOptions = { replyToIdSource, replyToMode, onDeliveryResult };
       if (parseFeishuCommentTarget(to)) {
-        // Feishu document comments cannot host a media attachment; the mediaUrl
-        // is rendered as a fallback text link instead. This visible-link
-        // fallback is the established comment-target behavior on main and is
-        // NOT the silent text-only `ok:true` drop issue #112244 removes — the
-        // recipient sees the media URL as a clickable link, so the attachment
-        // intent is visibly delivered even though the comment cannot render the
-        // media inline. The direct-send upload-failure propagation policy
-        // therefore does not apply here: it targets actual media-upload failures
-        // (the `sendMediaFeishu` catch below), and a comment target never
-        // reaches that upload path. Keep the fallback for both `send` and
-        // thread-reply so comment targets retain their visible media-link
-        // delivery (issue #112244, ClawSweeper fourteenth-review P1).
+        // Document comments deliver media as visible links; they never enter
+        // the upload path or use its failure-propagation policy.
         const commentText = mediaUrl?.trim()
           ? await buildFeishuMediaFallbackText({
               text,


### PR DESCRIPTION
Related: #135868, #125664

## What Problem This Solves

Feishu carries an upload-failure policy through document-comment delivery even though document comments never upload media. The inert helper and contradictory comments obscure the boundary between visible comment links and actual IM uploads.

## Why This Change Was Made

Remove the comment-only marker copier and strip channel data as before. Comment payloads already force separate media/text delivery, and their media handler returns a visible link before reaching either the upload or its failure policy. Keep the IM propagation marker, upload failure handling, and partial-delivery receipts unchanged. Consolidate the two comment-marker scenarios while preserving their inputs and full names.

## User Impact

No behavior change: document comments still deliver safe visible media links; IM upload failures still follow the existing direct-send policy. Net delta: production −33 (+3/−36), tests −24 (+14/−38), tooling/docs zero. The production reduction includes 11 executable helper lines and 22 lines of obsolete/repetitive review narration.

## Evidence

- Before and after: `node scripts/run-vitest.mjs extensions/feishu/src/outbound.test.ts extensions/feishu/src/outbound-delivery.test.ts extensions/feishu/src/channel.outbound.test.ts` — 3 files, 164 tests passed.
- Surviving marked-comment case: `extensions/feishu/src/outbound.test.ts:3588`; unmarked-comment case: `:3591`. Both retain the original visible-link and success-receipt expectations and now assert that no upload occurs. No scenario was removed.
- The same pure comment parser gates both paths; the target passes unchanged. Both possible marker effects are bypassed or already forced by the comment path.
- History `f94eb160fbb8` introduced the copier and the early no-upload return together, while claiming contradictory propagation requirements.
- Full `node scripts/check-changed.mjs --base origin/main`: passed in clean Blacksmith Testbox [34055131145](https://github.com/openclaw/openclaw/actions/runs/34055131145), command exit 0 and lease completed. The local run hit the existing nested-checkout `punycode` declaration-boundary failure; no guard or parent install was changed.
- Independent Codex P0–P2 autoreview: scoped-clean, no accepted/actionable findings.
- No live Feishu send was performed. No SDK, import, lazy-loading, dependency, schema, configuration, or build-output boundary changes.
