### PR TITLE
fix(codex): skip first-use refresh of a just-issued OpenAI token

### DIFF
--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -3469,6 +3469,96 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
+  it("does not treat a just-issued OpenAI Codex refresh token as invalidated", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    oauthMocks.refreshOpenAICodexToken.mockRejectedValueOnce(
+      Object.assign(
+        new Error(
+          'OpenAI Codex token refresh failed (401): {"error":{"message":"Your refresh token has been invalidated. Please try signing in again.","type":"invalid_request_error","code":"refresh_token_invalidated"}}',
+        ),
+        {
+          oauthRefreshFailure: {
+            reason: "token_invalidated",
+            status: 401,
+            code: "refresh_token_invalidated",
+          },
+        },
+      ),
+    );
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai:work",
+        credential: {
+          type: "oauth",
+          provider: "openai",
+          access: "just-issued-access-token",
+          refresh: "just-issued-refresh-token",
+          expires: Date.now() + 24 * 60 * 60_000,
+          accountId: "account-just-issued",
+          email: "codex@example.test",
+        },
+      });
+
+      await expect(
+        refreshCodexAppServerAuthTokens({
+          agentDir,
+          authProfileId: "openai:work",
+        }),
+      ).resolves.toEqual({
+        accessToken: "just-issued-access-token",
+        chatgptAccountId: "account-just-issued",
+        chatgptPlanType: null,
+      });
+      expect(oauthMocks.refreshOpenAICodexToken).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("still fails when a truly invalidated OpenAI Codex refresh token cannot be used", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    oauthMocks.refreshOpenAICodexToken.mockRejectedValueOnce(
+      Object.assign(
+        new Error(
+          'OpenAI Codex token refresh failed (401): {"error":{"message":"Your refresh token has been invalidated. Please try signing in again.","type":"invalid_request_error","code":"refresh_token_invalidated"}}',
+        ),
+        {
+          oauthRefreshFailure: {
+            reason: "token_invalidated",
+            status: 401,
+            code: "refresh_token_invalidated",
+          },
+        },
+      ),
+    );
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai:work",
+        credential: {
+          type: "oauth",
+          provider: "openai",
+          access: "expired-access-token",
+          refresh: "invalidated-refresh-token",
+          expires: Date.now() - 60_000,
+          accountId: "account-invalidated",
+          email: "codex@example.test",
+        },
+      });
+
+      await expect(
+        refreshCodexAppServerAuthTokens({
+          agentDir,
+          authProfileId: "openai:work",
+        }),
+      ).rejects.toThrow(/refresh_token_invalidated/);
+      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("invalidated-refresh-token");
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     {
       identity: "profile metadata",

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -927,14 +927,14 @@ export async function refreshCodexAppServerAuthTokens(params: {
   config?: AuthProfileOrderConfig;
 }): Promise<CodexChatgptAuthTokensRefreshResponse> {
   const previousAccountId = params.previousAccountId?.trim();
+  const store = resolveCodexAppServerAuthProfileStore(params);
+  const profileId = resolveCodexAppServerAuthProfileId({
+    authProfileId: params.authProfileId,
+    store,
+    config: params.config,
+  });
+  const credential = profileId ? store.profiles[profileId] : undefined;
   if (previousAccountId) {
-    const store = resolveCodexAppServerAuthProfileStore(params);
-    const profileId = resolveCodexAppServerAuthProfileId({
-      authProfileId: params.authProfileId,
-      store,
-      config: params.config,
-    });
-    const credential = profileId ? store.profiles[profileId] : undefined;
     const selectedAccountId = credential
       ? (resolveExplicitChatgptAccountId(credential) ??
         (credential.type === "oauth"
@@ -947,9 +947,22 @@ export async function refreshCodexAppServerAuthTokens(params: {
       );
     }
   }
+  // First-use Codex refresh must not burn a just-issued persisted refresh
+  // token. Native CLI overlays and expired credentials still refresh.
+  const persistedCredential = profileId
+    ? findPersistedAuthProfileCredential({
+        agentDir: resolvePersistedAuthProfileOwnerAgentDir({
+          agentDir: params.agentDir,
+          profileId,
+        }),
+        profileId,
+      })
+    : undefined;
+  const forceOAuthRefresh =
+    persistedCredential?.type !== "oauth" || !hasUsableOAuthCredential(persistedCredential);
   const loginParams = await resolveCodexAppServerAuthProfileLoginParamsInternal({
     ...params,
-    forceOAuthRefresh: true,
+    forceOAuthRefresh,
   });
   if (!loginParams || loginParams.type !== "chatgptAuthTokens") {
     throw new Error(


### PR DESCRIPTION
Closes #138097.

## What Problem This Solves

After a clean openai-codex device-code login, Codex app-server asks OpenClaw to refresh ChatGPT tokens on the first turn. The owner always forced a token-endpoint refresh, which burned the just-issued refresh token and returned refresh_token_invalidated.

## Why This Change Was Made

refreshCodexAppServerAuthTokens now returns a still-usable persisted access token instead of forcing that first refresh. Expired credentials and native Codex CLI overlays still refresh.

## Evidence

Fail-before: a just-issued persisted OAuth credential was force-refreshed and failed with refresh_token_invalidated.
Pass-after: the same credential is returned without calling the token endpoint. An expired persisted credential still fails at the token endpoint.

```
node scripts/run-vitest.mjs run extensions/codex/src/app-server/auth-bridge.test.ts
```

118 passed, including `does not treat a just-issued OpenAI Codex refresh token as invalidated`.
