### PR TITLE
refactor(workers): share current access eligibility checks

### DIFF
--- a/src/gateway/worker-environments/environment-access.ts
+++ b/src/gateway/worker-environments/environment-access.ts
@@ -58,6 +58,33 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
   const serviceError = options.serviceError;
   const withLock = options.withLock;
 
+  const requireCurrentRecord = (environmentId: string) => {
+    if (options.isStopping()) {
+      throw serviceError("invalid_state", "Worker environment service is stopping");
+    }
+    const record = store.get(environmentId);
+    if (!record) {
+      throw serviceError("environment_not_found", `Unknown worker environment: ${environmentId}`);
+    }
+    return record;
+  };
+
+  const requireDesktopRecord = (environmentId: string) => {
+    const record = requireCurrentRecord(environmentId);
+    if (
+      !inState(record, "ready", "idle", "attached") ||
+      record.destroyRequestedAtMs !== null ||
+      !record.leaseId ||
+      !record.desktop
+    ) {
+      throw serviceError(
+        "invalid_state",
+        "environment has no desktop; desktop is a warm-time capability of the profile",
+      );
+    }
+    return { record, desktop: record.desktop, leaseId: record.leaseId };
+  };
+
   const project = (record: WorkerEnvironmentRecord) => {
     const desktopAvailable =
       inState(record, "ready", "idle", "attached") && record.desktop !== null;
@@ -79,7 +106,7 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
   };
 
   const startTunnel = async (request: WorkerTunnelRequest): Promise<WorkerTunnelHandle> => {
-    let stopping = options.isStopping();
+    const stopping = options.isStopping();
     if (stopping) {
       throw serviceError("invalid_state", "Worker environment service is stopping");
     }
@@ -97,17 +124,7 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
     let startup: Promise<WorkerTunnelHandle> | undefined;
     let stopStartup: (() => Promise<void>) | undefined;
     await withLock(request.environmentId, async () => {
-      stopping = options.isStopping();
-      if (stopping) {
-        throw serviceError("invalid_state", "Worker environment service is stopping");
-      }
-      const record = store.get(request.environmentId);
-      if (!record) {
-        throw serviceError(
-          "environment_not_found",
-          `Unknown worker environment: ${request.environmentId}`,
-        );
-      }
+      const record = requireCurrentRecord(request.environmentId);
       if (
         !inState(record, "ready", "idle", "attached") ||
         record.destroyRequestedAtMs !== null ||
@@ -211,7 +228,7 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
     environmentId: string;
     control: boolean;
   }): Promise<WorkerDesktopObserveResult> => {
-    let stopping = options.isStopping();
+    const stopping = options.isStopping();
     if (options.getConfig().cloudWorkers?.desktop !== true) {
       throw serviceError(
         "invalid_state",
@@ -225,28 +242,7 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
     let nodeStartup: ReturnType<WorkerNodeDesktopCarrier["observe"]> | undefined;
     let ownerEpoch: number | undefined;
     await withLock(request.environmentId, async () => {
-      stopping = options.isStopping();
-      if (stopping) {
-        throw serviceError("invalid_state", "Worker environment service is stopping");
-      }
-      const record = store.get(request.environmentId);
-      if (!record) {
-        throw serviceError(
-          "environment_not_found",
-          `Unknown worker environment: ${request.environmentId}`,
-        );
-      }
-      if (
-        !inState(record, "ready", "idle", "attached") ||
-        record.destroyRequestedAtMs !== null ||
-        !record.leaseId ||
-        !record.desktop
-      ) {
-        throw serviceError(
-          "invalid_state",
-          "environment has no desktop; desktop is a warm-time capability of the profile",
-        );
-      }
+      const { record, desktop, leaseId } = requireDesktopRecord(request.environmentId);
       ownerEpoch = record.ownerEpoch;
       if (record.sshEndpoint) {
         if (!tunnels) {
@@ -257,8 +253,8 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
           environmentId: record.environmentId,
           ownerEpoch: record.ownerEpoch,
           ssh: record.sshEndpoint,
-          desktop: record.desktop,
-          resolveIdentity: identityResolverFor(record, provider, record.leaseId),
+          desktop,
+          resolveIdentity: identityResolverFor(record, provider, leaseId),
         });
         return;
       }
@@ -303,7 +299,7 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
     environmentId: string;
     app: "browser" | "terminal";
   }): Promise<WorkerDesktopLaunchResult> => {
-    let stopping = options.isStopping();
+    const stopping = options.isStopping();
     if (options.getConfig().cloudWorkers?.desktop !== true) {
       throw serviceError(
         "invalid_state",
@@ -314,42 +310,21 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
       throw serviceError("invalid_state", "Worker environment service is stopping");
     }
     const requireLaunchable = () => {
-      stopping = options.isStopping();
-      if (stopping) {
-        throw serviceError("invalid_state", "Worker environment service is stopping");
-      }
-      const record = store.get(request.environmentId);
-      if (!record) {
-        throw serviceError(
-          "environment_not_found",
-          `Unknown worker environment: ${request.environmentId}`,
-        );
-      }
-      if (
-        !inState(record, "ready", "idle", "attached") ||
-        record.destroyRequestedAtMs !== null ||
-        !record.leaseId ||
-        !record.desktop
-      ) {
-        throw serviceError(
-          "invalid_state",
-          "environment has no desktop; desktop is a warm-time capability of the profile",
-        );
-      }
-      const app = record.desktop.apps?.find((candidate) => candidate.id === request.app);
+      const { record, desktop, leaseId } = requireDesktopRecord(request.environmentId);
+      const app = desktop.apps?.find((candidate) => candidate.id === request.app);
       if (!app) {
         throw serviceError(
           "desktop_app_not_found",
           `environment does not advertise desktop app: ${request.app}`,
         );
       }
-      return { app, record };
+      return { app, record, leaseId };
     };
 
     let startup: Promise<void> | undefined;
     let launchEpoch: number | undefined;
     await withLock(request.environmentId, async () => {
-      const { app, record } = requireLaunchable();
+      const { app, record, leaseId } = requireLaunchable();
       launchEpoch = record.ownerEpoch;
       if (record.sshEndpoint) {
         if (!tunnels) {
@@ -361,7 +336,7 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
           ownerEpoch: record.ownerEpoch,
           ssh: record.sshEndpoint,
           app,
-          resolveIdentity: identityResolverFor(record, provider, record.leaseId),
+          resolveIdentity: identityResolverFor(record, provider, leaseId),
         });
         return;
       }


### PR DESCRIPTION
## What Problem This Solves

Worker tunnel and desktop access repeated the same stopping/current-record checks in three places and desktop eligibility checks in two. Keeping copies increases the maintenance cost of preserving the same access rules.

## Why This Change Was Made

Share synchronous current-record and desktop-record checks inside the existing access owner. Every call remains inside its original environment lock and rereads the canonical store. The helper returns the narrowed desktop and lease ID alongside the original record, without casts or a copied record.

Deletion evidence: the repeated blocks in `environment-access.ts` are replaced by the private `requireCurrentRecord` and `requireDesktopRecord` helpers. Initial stopping/config checks, bundle preparation, credential validation, error messages, and all post-launch lifecycle/epoch checks remain unchanged. `service.ts:293` remains the sole constructor caller and still supplies its tracked operation lock.

The post-launch checks trace to `b5d5ec340fe` (#121475), preserved by `2d6a5d7356b` (#122138); this change preserves those checks at each existing call site. Adjacent worker teardown work in #140377 is outside this diff.

## User Impact

No behavior change. Desktop access still requires a current eligible lease with a desktop capability; missing apps and stopped, draining, destroyed, or replaced owners retain their existing outcomes. No storage, schema, public API, transport, or lazy-loading changes.

## Evidence

- Production: **+39/−64 = −25 lines**. Tests/support, tooling, and docs unchanged.
- All 49 existing tests across `environment-access.test.ts`, `desktop-tunnel.test.ts`, and `node-desktop-carrier.test.ts` passed before and after (14.25s → 11.28s Vitest time).
- Surviving coverage: `environment-access.test.ts:459` (advertised SSH app), `:489` (missing apps and typed launch failures), `:580` (durable node carrier), `:643` (invalid lifecycle/stopped service), and `:729` (lock released during connection). Sibling suites retain transport cleanup and authority fencing.
- Independent Codex review: scoped-clean, no actionable P0–P2 findings. Review included the complete owner and unchanged post-launch epoch comparisons.
- Full `node scripts/check-changed.mjs` passed, including core/test types, all three dead-export scans, zero runtime import cycles, and repository guards. Rebase preserved the edited owner and dependency lock exactly.
- ClawSweeper reviewed the exact head with no correctness/security findings or before-merge work. Exact-head CI is green.
