### PR TITLE
chore(tests): speed up large upload byte checks

### DIFF
--- a/src/skills/lifecycle/upload-store.test.ts
+++ b/src/skills/lifecycle/upload-store.test.ts
@@ -411,7 +411,9 @@ describe("skill upload store", () => {
       );
       expect(archiveReads).toEqual([]);
       await store.withCommittedUpload(begin.uploadId, async (record) => {
-        expect(await fs.readFile(record.archivePath)).toEqual(archive);
+        const materialized = await fs.readFile(record.archivePath);
+        expect(materialized).toHaveLength(archive.length);
+        expect(materialized.equals(archive), "materialized archive bytes").toBe(true);
       });
       expect(archiveReads).toEqual([{ bytes: archive.length, inTransaction: true }]);
       const copiedBytes = bufferFrom.mock.calls.reduce((total, [value]) => {


### PR DESCRIPTION
## What Problem This Solves

The large upload regression spent most of its test time deeply comparing an 8 MiB buffer. The existing case took 9.417 seconds in the controlled local run, with about 3.91 GB peak process memory.

## Why This Change Was Made

Compare the materialized file with exact native Buffer equality and retain an explicit length assertion. The two 4 MiB chunks, SHA-256 checks, SQLite state, deferred archive reads, transactional install claim, zero redundant native-byte copies, and cleanup checks remain unchanged. Smaller archive comparisons retain their existing diagnostics.

## User Impact

Test-only performance improvement; no production, schema, upload-limit, or behavior change. The test still checks every byte, including same-length corruption.

## Evidence

Both original and candidate full-file runs passed all 23 cases on the same Node 24.19.0/pnpm 12.3.4 frozen install, with separate fresh compiler caches. The selected case improved **9.417 → 0.327 seconds**; peak process RSS improved **3.91 → 2.14 GB**. Total command wall time was noisy (**18.66 → 19.59 seconds**), so this is a scoped case/memory improvement, not a claimed whole-CI speedup.

A temporary control changed only the final materialized byte: the length assertion passed and byte equality failed as expected. The control was then removed and exact candidate bytes verified. Node's comparator implementation was inspected; this uses full byte equality rather than sampling or digest-only comparison.

The changed-file gate passed, including core test types, all three dead-code scans, lint and formatting. Independent P2 review passed with no findings. One test file changes by +3/-1 lines; production is unchanged. Exact-head CI remains the landing gate.
