### PR TITLE
test(gateway): table-drive device token lifecycle checks

### DIFF
--- a/src/gateway/server-methods/devices.lifecycle.test.ts
+++ b/src/gateway/server-methods/devices.lifecycle.test.ts
@@ -505,51 +505,36 @@ describe("device lifecycle", () => {
     );
   });
 
-  it("invalidates an in-flight node wake when the node token rotates", async () => {
-    rotateDeviceTokenMock.mockResolvedValue({
-      ok: true,
-      entry: {
-        token: "new-node-token",
-        role: "node",
-        scopes: [],
-        createdAtMs: 456,
-        rotatedAtMs: 789,
-      },
-    });
-    const lifecycle = captureNodeWakeLifecycle("device-1");
-    const opts = createOptions(
-      "device.token.rotate",
-      { deviceId: "device-1", role: "node" },
-      { client: createClient(["operator.admin"], "admin-device", { isDeviceTokenAuth: true }) },
-    );
+  it.each(["device.token.rotate", "device.token.revoke"] as const)(
+    "invalidates an in-flight node wake after %s",
+    async (method) => {
+      const mutation =
+        method === "device.token.rotate" ? rotateDeviceTokenMock : revokeDeviceTokenMock;
+      mutation.mockResolvedValue({
+        ok: true,
+        entry:
+          method === "device.token.rotate"
+            ? {
+                token: "new-node-token",
+                role: "node",
+                scopes: [],
+                createdAtMs: 456,
+                rotatedAtMs: 789,
+              }
+            : { role: "node", revokedAtMs: 789 },
+      });
+      const lifecycle = captureNodeWakeLifecycle("device-1");
+      const opts = createOptions(
+        method,
+        { deviceId: "device-1", role: "node" },
+        { client: createClient(["operator.admin"], "admin-device", { isDeviceTokenAuth: true }) },
+      );
 
-    await expectDefined(
-      deviceHandlers["device.token.rotate"],
-      'deviceHandlers["device.token.rotate"] test invariant',
-    )(opts);
+      await expectDefined(deviceHandlers[method], method)(opts);
 
-    expect(lifecycle.aborted).toBe(true);
-  });
-
-  it("invalidates an in-flight node wake when the node token is revoked", async () => {
-    revokeDeviceTokenMock.mockResolvedValue({
-      ok: true,
-      entry: { role: "node", revokedAtMs: 789 },
-    });
-    const lifecycle = captureNodeWakeLifecycle("device-1");
-    const opts = createOptions(
-      "device.token.revoke",
-      { deviceId: "device-1", role: "node" },
-      { client: createClient(["operator.admin"], "admin-device", { isDeviceTokenAuth: true }) },
-    );
-
-    await expectDefined(
-      deviceHandlers["device.token.revoke"],
-      'deviceHandlers["device.token.revoke"] test invariant',
-    )(opts);
-
-    expect(lifecycle.aborted).toBe(true);
-  });
+      expect(lifecycle.aborted).toBe(true);
+    },
+  );
 
   it("keeps node wake ownership across unrelated operator token rotation", async () => {
     mockRotateOperatorTokenSuccess();
@@ -569,67 +554,47 @@ describe("device lifecycle", () => {
     releaseNodeWakeLifecycle("device-1", lifecycle);
   });
 
-  it("invalidates affected clients synchronously before responding to device.token.rotate", async () => {
-    mockPairedOperatorDevice();
-    mockRotateOperatorTokenSuccess();
-    const opts = createOptions(
-      "device.token.rotate",
-      { deviceId: "device-1", role: "operator", scopes: ["operator.pairing"] },
-      { client: createClient(["operator.pairing"], "device-1", { isDeviceTokenAuth: true }) },
-    );
-    const respond = vi.mocked(opts.respond);
-    const invalidate = vi.mocked(opts.context.invalidateClientsForDevice!);
-    const disconnect = vi.mocked(opts.context.disconnectClientsForDevice!);
+  it.each(["device.token.rotate", "device.token.revoke"] as const)(
+    "invalidates affected clients synchronously before responding to %s",
+    async (method) => {
+      const rotating = method === "device.token.rotate";
+      if (rotating) {
+        mockPairedOperatorDevice();
+        mockRotateOperatorTokenSuccess();
+      } else {
+        revokeDeviceTokenMock.mockResolvedValue({
+          ok: true,
+          entry: { role: "operator", revokedAtMs: 456 },
+        });
+      }
+      const opts = createOptions(
+        method,
+        {
+          deviceId: "device-1",
+          role: "operator",
+          ...(rotating ? { scopes: ["operator.pairing"] } : {}),
+        },
+        { client: createClient(["operator.pairing"], "device-1", { isDeviceTokenAuth: true }) },
+      );
+      const respond = vi.mocked(opts.respond);
+      const invalidate = vi.mocked(opts.context.invalidateClientsForDevice!);
+      const disconnect = vi.mocked(opts.context.disconnectClientsForDevice!);
 
-    respond.mockImplementation(() => {
-      expect(invalidate).toHaveBeenCalledWith("device-1", {
-        role: "operator",
-        reason: "device-token-rotated",
+      respond.mockImplementation(() => {
+        expect(invalidate).toHaveBeenCalledWith("device-1", {
+          role: "operator",
+          reason: rotating ? "device-token-rotated" : "device-token-revoked",
+        });
+        expect(disconnect).not.toHaveBeenCalled();
       });
-      expect(disconnect).not.toHaveBeenCalled();
-    });
 
-    await expectDefined(
-      deviceHandlers["device.token.rotate"],
-      'deviceHandlers["device.token.rotate"] test invariant',
-    )(opts);
-    await Promise.resolve();
+      await expectDefined(deviceHandlers[method], method)(opts);
+      await Promise.resolve();
 
-    expect(respond).toHaveBeenCalled();
-    expect(disconnect).toHaveBeenCalledWith("device-1", { role: "operator" });
-  });
-
-  it("invalidates affected clients synchronously before responding to device.token.revoke", async () => {
-    revokeDeviceTokenMock.mockResolvedValue({
-      ok: true,
-      entry: { role: "operator", revokedAtMs: 456 },
-    });
-    const opts = createOptions(
-      "device.token.revoke",
-      { deviceId: "device-1", role: "operator" },
-      { client: createClient(["operator.pairing"], "device-1", { isDeviceTokenAuth: true }) },
-    );
-    const respond = vi.mocked(opts.respond);
-    const invalidate = vi.mocked(opts.context.invalidateClientsForDevice!);
-    const disconnect = vi.mocked(opts.context.disconnectClientsForDevice!);
-
-    respond.mockImplementation(() => {
-      expect(invalidate).toHaveBeenCalledWith("device-1", {
-        role: "operator",
-        reason: "device-token-revoked",
-      });
-      expect(disconnect).not.toHaveBeenCalled();
-    });
-
-    await expectDefined(
-      deviceHandlers["device.token.revoke"],
-      'deviceHandlers["device.token.revoke"] test invariant',
-    )(opts);
-    await Promise.resolve();
-
-    expect(respond).toHaveBeenCalled();
-    expect(disconnect).toHaveBeenCalledWith("device-1", { role: "operator" });
-  });
+      expect(respond).toHaveBeenCalled();
+      expect(disconnect).toHaveBeenCalledWith("device-1", { role: "operator" });
+    },
+  );
 
   it("treats normalized device ids as self-owned for token rotation", async () => {
     mockPairedOperatorDevice();


### PR DESCRIPTION
Related: #135868, #139421

## What Problem This Solves

The pairing lifecycle suite repeats setup for token rotation and revocation around the same wake-cancellation and response-ordering boundaries. This is the maintainer-requested test compression pass in concern F of the #135868 split, following #139421.

## Why This Change Was Made

Use two rotate/revoke tables while preserving all four cases in their original order. Each method keeps its own result fields, request parameters, caller permissions, and invalidation reason. The response callback still proves synchronous invalidation and defers disconnection until afterward.

## User Impact

No runtime behavior changes. Tests shrink by 35 lines (+65/−100), from 838 to 803 lines; production, tooling, and docs each change by zero. No cases or assertions are removed.

## Evidence

| Removed standalone body | Surviving coverage |
| --- | --- |
| Node wake invalidation after token rotation | `src/gateway/server-methods/devices.lifecycle.test.ts:509`, “invalidates an in-flight node wake after device.token.rotate” |
| Node wake invalidation after token revocation | Same table at `:509`, “invalidates an in-flight node wake after device.token.revoke” |
| Synchronous client invalidation before the rotation reply | `src/gateway/server-methods/devices.lifecycle.test.ts:558`, “invalidates affected clients synchronously before responding to device.token.rotate” |
| Synchronous client invalidation before the revocation reply | Same table at `:558`, “invalidates affected clients synchronously before responding to device.token.revoke” |

Seeded node teardown, caller-retirement and worker-cleanup failures, operator/node role distinctions, normalized identities, and same-device/cross-device response contracts remain separate and unchanged. The response-called assertion remains because it prevents the callback assertions from passing without a reply.

Full standard `src/gateway/server-methods` baseline: 281 files, 5,428 passed / 2 skipped, 297.08 s. Full after-run: the identical 281 files and 5,428 passed / 2 skipped, 283.90 s. The complete before/after file sets match, including all 28 lifecycle cases. Full `node scripts/check-changed.mjs` passed, including test types, lint, guards, and all three dead-export scans. Independent Codex review is scoped-clean through P2; `git diff --check` passed. The rebase changed neither the lockfile nor the tested owners.

Exact-head CI is green for `08b272dc9e2a567fb8f431701e42c3bf6ee26c0c`: https://github.com/openclaw/openclaw/actions/runs/34056519770 . ClawSweeper reviewed the same head with no findings, before-merge requests, or rank-up moves.
