### PR TITLE
refactor(ui): reuse shared requirement records

### DIFF
--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -28,6 +28,7 @@ import type { SessionAgentStatus } from "../../../packages/gateway-protocol/src/
 import type { SessionGoal } from "../../../src/config/sessions/types.js";
 import type { ConfigUiHints } from "../../../src/shared/config-ui-hints-types.js";
 import type { FastModeSource } from "../../../src/shared/fast-mode.js";
+import type { RequirementConfigCheck, Requirements } from "../../../src/shared/requirements.js";
 import type {
   GatewayAgentRuntime,
   GatewayAgentRow as SharedGatewayAgentRow,
@@ -451,11 +452,6 @@ export type CronRunsResult = {
   hasMore?: boolean;
 };
 
-type SkillsStatusConfigCheck = {
-  path: string;
-  satisfied: boolean;
-};
-
 type SkillInstallOption = {
   id: string;
   kind: "brew" | "node" | "go" | "uv" | "download";
@@ -513,21 +509,9 @@ export type SkillStatusEntry = {
   modelVisible?: boolean;
   userInvocable?: boolean;
   commandVisible?: boolean;
-  requirements: {
-    anyBins: string[];
-    bins: string[];
-    env: string[];
-    config: string[];
-    os: string[];
-  };
-  missing: {
-    anyBins: string[];
-    bins: string[];
-    env: string[];
-    config: string[];
-    os: string[];
-  };
-  configChecks: SkillsStatusConfigCheck[];
+  requirements: Requirements;
+  missing: Requirements;
+  configChecks: RequirementConfigCheck[];
   install: SkillInstallOption[];
   clawhub?: SkillClawHubLink;
   skillCard?: SkillCardStatus;


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

The Skills UI repeats requirement and configuration-check records already owned by the shared requirements module. Those copies create avoidable maintenance debt in the maintainer-directed deletion campaign.

## Why This Change Was Made

Use the existing `Requirements` and `RequirementConfigCheck` types for the UI's required, missing, and configuration-check fields. Keep the broader UI status model because its field requirements intentionally differ from the server model.

## User Impact

No behavior or appearance change. Production delta is −16 (+4/−20), with zero test/tooling/docs change. Every existing UI status field retains its type and optionality.

## Evidence

- Compiler comparison of the complete `SkillStatusEntry` and `SkillStatusReport` shapes against real shared types: identical, including nested records and arrays.
- Full-file emitted JavaScript is byte-identical; the new import is type-only.
- `node scripts/run-vitest.mjs --config ui/vitest.config.ts ui/src/lib/skills ui/src/pages/skills`: 3 files, 69 tests passed.
- Full `node scripts/check-changed.mjs`: passed, including core-test/UI types, i18n, dead exports, and lint.
- Independent Codex P0–P2 autoreview: scoped-clean, no accepted/actionable findings.
- No test removal, new dependency, schema/configuration change, runtime import, lazy boundary, or published API change. No build or visual capture is needed for erased type-only code.
