### PR TITLE
refactor(cron): share runtime feedback schema fields

### DIFF
--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -421,27 +421,7 @@ const CronAutoDisabledSchema = closedObject({
   consecutiveErrors: Type.Integer({ minimum: 1 }),
 });
 
-/** Scheduler-maintained state for the latest run/delivery outcome. */
-export const CronJobStateSchema = closedObject({
-  nextRunAtMs: Type.Optional(CronDateTimestampMsSchema),
-  scheduleActivatedAtMs: Type.Optional(CronDateTimestampMsSchema),
-  runningAtMs: Type.Optional(CronDateTimestampMsSchema),
-  lastRunAtMs: Type.Optional(CronDateTimestampMsSchema),
-  lastRunStatus: Type.Optional(CronRunStatusSchema),
-  lastStatus: Type.Optional(DeprecatedCronRunStatusSchema),
-  lastError: Type.Optional(Type.String()),
-  lastDiagnostics: Type.Optional(CronRunDiagnosticsSchema),
-  lastDiagnosticSummary: Type.Optional(Type.String()),
-  lastErrorReason: Type.Optional(FailoverReasonSchema),
-  lastDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),
-  consecutiveErrors: Type.Optional(Type.Integer({ minimum: 0 })),
-  // Report-only scheduler ownership fact; callers cannot patch this field.
-  autoDisabled: Type.Optional(CronAutoDisabledSchema),
-  consecutiveSkipped: Type.Optional(Type.Integer({ minimum: 0 })),
-  lastDelivered: Type.Optional(Type.Boolean()),
-  lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
-  lastDeliveryError: Type.Optional(Type.String()),
-  deliverySuppressionReason: Type.Optional(Type.String()),
+const CronJobRuntimeFeedbackProperties = {
   lastFailureNotificationDelivered: Type.Optional(Type.Boolean()),
   lastFailureNotificationDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
   lastFailureNotificationDeliveryError: Type.Optional(Type.String()),
@@ -463,6 +443,30 @@ export const CronJobStateSchema = closedObject({
   streamError: Type.Optional(Type.String()),
   streamConsecutiveFailures: Type.Optional(Type.Integer({ minimum: 0 })),
   streamRestartExhausted: Type.Optional(Type.Boolean()),
+};
+
+/** Scheduler-maintained state for the latest run/delivery outcome. */
+export const CronJobStateSchema = closedObject({
+  nextRunAtMs: Type.Optional(CronDateTimestampMsSchema),
+  scheduleActivatedAtMs: Type.Optional(CronDateTimestampMsSchema),
+  runningAtMs: Type.Optional(CronDateTimestampMsSchema),
+  lastRunAtMs: Type.Optional(CronDateTimestampMsSchema),
+  lastRunStatus: Type.Optional(CronRunStatusSchema),
+  lastStatus: Type.Optional(DeprecatedCronRunStatusSchema),
+  lastError: Type.Optional(Type.String()),
+  lastDiagnostics: Type.Optional(CronRunDiagnosticsSchema),
+  lastDiagnosticSummary: Type.Optional(Type.String()),
+  lastErrorReason: Type.Optional(FailoverReasonSchema),
+  lastDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  consecutiveErrors: Type.Optional(Type.Integer({ minimum: 0 })),
+  // Report-only scheduler ownership fact; callers cannot patch this field.
+  autoDisabled: Type.Optional(CronAutoDisabledSchema),
+  consecutiveSkipped: Type.Optional(Type.Integer({ minimum: 0 })),
+  lastDelivered: Type.Optional(Type.Boolean()),
+  lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
+  lastDeliveryError: Type.Optional(Type.String()),
+  deliverySuppressionReason: Type.Optional(Type.String()),
+  ...CronJobRuntimeFeedbackProperties,
   // Internal logical-source identity used for cron.run admission fencing. It is
   // reported for diagnostics but intentionally absent from the writable patch
   // schema so external callers cannot spoof source ownership.
@@ -487,27 +491,7 @@ const CronJobStatePatchSchema = closedObject({
   lastDelivered: Type.Optional(Type.Boolean()),
   lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
   lastDeliveryError: Type.Optional(Type.String()),
-  lastFailureNotificationDelivered: Type.Optional(Type.Boolean()),
-  lastFailureNotificationDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
-  lastFailureNotificationDeliveryError: Type.Optional(Type.String()),
-  lastFailureAlertAtMs: Type.Optional(CronDateTimestampMsSchema),
-  lastTriggerEvalAtMs: Type.Optional(CronDateTimestampMsSchema),
-  triggerEvalCount: Type.Optional(Type.Integer({ minimum: 0 })),
-  lastTriggerFireAtMs: Type.Optional(CronDateTimestampMsSchema),
-  triggerState: Type.Optional(Type.Unknown()),
-  streamStatus: Type.Optional(
-    Type.Union([
-      Type.Literal("starting"),
-      Type.Literal("running"),
-      Type.Literal("restarting"),
-      Type.Literal("stopped"),
-      Type.Literal("disabled"),
-      Type.Literal("error"),
-    ]),
-  ),
-  streamError: Type.Optional(Type.String()),
-  streamConsecutiveFailures: Type.Optional(Type.Integer({ minimum: 0 })),
-  streamRestartExhausted: Type.Optional(Type.Boolean()),
+  ...CronJobRuntimeFeedbackProperties,
   streamDroppedBatches: Type.Optional(Type.Integer({ minimum: 0 })),
   streamCoalescedBatches: Type.Optional(Type.Integer({ minimum: 0 })),
   streamLastStartedAtMs: Type.Optional(CronDateTimestampMsSchema),


### PR DESCRIPTION
## What Problem This Solves

Cron read-state and writable-state schemas repeated the same failure-notification, trigger, and stream-feedback field declarations. Keeping separate copies made this shared contract needlessly easy to drift.

## Why This Change Was Made

Share one contiguous field block at its existing position in both schemas. The writable patch remains an explicit whitelist: scheduler-owned diagnostics, auto-disable facts, source identity, and schedule activation remain report-only. Both closed-object schemas retain their independent identity.

Deletion evidence: the identical blocks in `packages/gateway-protocol/src/schema/cron.ts` now use the private `CronJobRuntimeFeedbackProperties` definition. Property order is preserved for generated clients. `git log -S streamSourceIdentity` identifies `98742bc2c7f` (#112387), and schedule-activation ownership traces to `82af1bf7d40` (#115779); neither contract changes.

## User Impact

No behavior, protocol, schema, or stored-representation change. Cron clients receive and may patch exactly the same fields with the same constraints and optionality.

## Evidence

- Production: **+26/−42 = −16 lines**. Tests/support, tooling, and docs unchanged.
- Complete order-sensitive serialized read-state and update schemas are byte-identical before and after.
- All 40 existing cases across `cron-validators.test.ts` and `cron-protocol-schema.test.ts` pass before and after.
- Retained executable coverage: `cron-validators.test.ts:73` rejects report-only auto-disable state in updates, and `:200` enforces timestamp bounds. The existing `cron-protocol-schema.test.ts:32` and `:43` retain read-state metadata checks. Their patch-side property inspection does not traverse the current update union, so it is not claimed as write-boundary proof; complete serialized update-schema identity preserves that boundary for this refactor.
- Swift and Kotlin generation checks pass with no generated-file changes.
- Independent Codex review: scoped-clean, no actionable P0–P2 findings.
- Full `pnpm build` passed (6m 24s).
- Full `node scripts/check-changed.mjs` passed, including core/test types, all three dead-export scans, zero runtime import cycles, and repository guards. Rebase preserved the schema owner and dependency lock exactly.

ClawSweeper disposition: its technical review reports no findings and confirms unchanged optionality, constraints, field order, writable whitelist, and independent closed-object identities. The rendered `unknown-data-model-change` item is a path-classification false positive. No database schema/version/table, migration, stored representation, retention, recovery, or protocol contract changes. The compatibility proof is exact representation identity: serializing the complete `{ state: CronJobStateSchema, update: CronUpdateParamsSchema }` yields the same 24,307 bytes and SHA-256 `f4c3d2645eb9366ccc5b13bba74d5fbd5a2f58a5b3b9b0dda5be812c81e03013` before and after. Swift/Kotlin outputs also remain byte-identical. An additional migration scenario is therefore not applicable; no schema checkpoint exception or suppression is requested.
