### PR TITLE
perf(ai): skip discarded text assembly for image tool results

### DIFF
--- a/packages/ai/src/transports/anthropic-messages.ts
+++ b/packages/ai/src/transports/anthropic-messages.ts
@@ -68,14 +68,13 @@ async function convertContentBlocks(
   profile: "provider" | "transport",
   isError: boolean,
 ) {
-  const text = extractToolResultText(content);
   const mediaPlaceholder = describeToolResultMediaPlaceholder(content);
   const hasImages =
     (profile === "provider" || model.input.includes("image")) &&
     content.some(isImageWithMediaPayload);
   if (!hasImages) {
     return sanitizeNonEmptyTransportPayloadText(
-      text,
+      extractToolResultText(content),
       mediaPlaceholder ??
         (profile === "transport" ? "(no output)" : isError ? "[tool error with no output]" : ""),
     );


### PR DESCRIPTION
## What Problem This Solves

Anthropic tool results containing images assemble an aggregate text result that the image branch never uses, then extract and sanitize each block again. Structured results also repeat serialization and redaction unnecessarily.

## Why This Change Was Made

Move aggregate text extraction into its existing text-only consumer. Keep the image branch's per-block extraction, redaction, ordering, normalization and image budget unchanged. This removes one production line and needs no new API, cache, configuration or dependency.

## User Impact

In the checksum-corrected R2 comparison, structured/resource image-result medians improved 45–52%, and 20-result histories improved 42–45%, across both orders on image-emitting paths. Provider and transport capability differences remain unchanged, including non-vision transport behavior.

All adverse observations remain: 47/128 medians, 50/128 means and 49/128 maximum batch means worsened. The provider-vision image-only case was +32% (+11.8 µs) forward, while its 64 KiB text/image case was +11.3%/+6.8% (+3.1/+2.0 µs). Peak process RSS increased slightly in both orders. These are payload-conversion measurements, not provider, Gateway, memory-reduction or native-image-codec claims.

## Evidence

All 257 existing tests across provider, transport, generic extraction and image-budget suites passed. All 27 normal changed-file checks and fresh independent Codex review through P2 passed; no tests were weakened or added merely to assert a call count.

The fixed B0/C0/C1/B1 cohort calls the actual shared converter with real core redaction and image normalization. Its 64 cases cover all four provider/transport and vision/non-vision combinations. All 9,472 complete input/wire records match both independent fixture expectations and the other variants. All 2,048 retained batch means remain available; individual call timings were not separately recorded. Process closure, restored candidate bytes and selected runtime/source pins were independently verified. No provider request or real credential was used in this projection-only comparison.

R1 remains retained separately: its tiny PNG had an incorrect IDAT checksum, although the compressed data inflated and the actual MIME/normalization route accepted it. R2 corrected only three checksum bytes; file length, compressed pixels, cases, order and timing settings stayed unchanged. All three R2 chunk CRCs validate. R1's measurements and regressions are preserved and were not pooled into or replaced by R2. This proves fixture structure/checksum/inflation, not native codec rendering.
