### PR TITLE
fix: use the bundle-compatible Proxyline runtime under Bun

### DIFF
--- a/package.json
+++ b/package.json
@@ -2137,7 +2137,7 @@
     "@mozilla/readability": "0.6.0",
     "@openclaw/ai": "workspace:*",
     "@openclaw/fs-safe": "0.8.1",
-    "@openclaw/proxyline": "0.3.7",
+    "@openclaw/proxyline": "0.3.10",
     "@silvia-odwyer/photon-node": "0.3.4",
     "@trycua/cua-driver": "0.22.2",
     "acorn": "8.18.0",

--- a/package.json
+++ b/package.json
@@ -2137,7 +2137,7 @@
     "@mozilla/readability": "0.6.0",
     "@openclaw/ai": "workspace:*",
     "@openclaw/fs-safe": "0.8.1",
-    "@openclaw/proxyline": "0.3.10",
+    "@openclaw/proxyline": "0.3.11",
     "@silvia-odwyer/photon-node": "0.3.4",
     "@trycua/cua-driver": "0.22.2",
     "acorn": "8.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,8 +205,8 @@ importers:
         specifier: 0.8.1
         version: 0.8.1
       '@openclaw/proxyline':
-        specifier: 0.3.10
-        version: 0.3.10(undici@8.10.2)
+        specifier: 0.3.11
+        version: 0.3.11(undici@8.10.2)
       '@silvia-odwyer/photon-node':
         specifier: 0.3.4
         version: 0.3.4
@@ -4189,8 +4189,8 @@ packages:
       node-pty:
         optional: true
 
-  '@openclaw/proxyline@0.3.10':
-    resolution: {integrity: sha512-k/BRhrefE7kbVnGKokAGt7PjwDxZVMpM3IgkUahpwZ7gm9Emri3PyimhEk5WLkBTL7gdiBoHyP7oTQEhOPIZkQ==}
+  '@openclaw/proxyline@0.3.11':
+    resolution: {integrity: sha512-XDlrrQE0fapfTpqCBK9WB+U4W+/0lsrRIXI2nZ74W/lWMF+X4T5t2dfj8Ms250Th4qjnNi6WuSX5OZJqyLoZ3g==}
     engines: {node: '>=22.19.0'}
     peerDependencies:
       undici: '>=8.5.0 <9'
@@ -11487,7 +11487,7 @@ snapshots:
     dependencies:
       ghostty-web: 0.4.0
 
-  '@openclaw/proxyline@0.3.10(undici@8.10.2)':
+  '@openclaw/proxyline@0.3.11(undici@8.10.2)':
     dependencies:
       undici: 8.10.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,8 +205,8 @@ importers:
         specifier: 0.8.1
         version: 0.8.1
       '@openclaw/proxyline':
-        specifier: 0.3.7
-        version: 0.3.7(undici@8.10.2)
+        specifier: 0.3.10
+        version: 0.3.10(undici@8.10.2)
       '@silvia-odwyer/photon-node':
         specifier: 0.3.4
         version: 0.3.4
@@ -4189,8 +4189,8 @@ packages:
       node-pty:
         optional: true
 
-  '@openclaw/proxyline@0.3.7':
-    resolution: {integrity: sha512-RWkt4mPcBOj7E8euyeqynkIFXvEIxVStYH0YHDC08feq5qFyBXGmfdWC+MTMVJXfHN2ituoxLlrIyjpyJpW7ew==}
+  '@openclaw/proxyline@0.3.10':
+    resolution: {integrity: sha512-k/BRhrefE7kbVnGKokAGt7PjwDxZVMpM3IgkUahpwZ7gm9Emri3PyimhEk5WLkBTL7gdiBoHyP7oTQEhOPIZkQ==}
     engines: {node: '>=22.19.0'}
     peerDependencies:
       undici: '>=8.5.0 <9'
@@ -11487,7 +11487,7 @@ snapshots:
     dependencies:
       ghostty-web: 0.4.0
 
-  '@openclaw/proxyline@0.3.7(undici@8.10.2)':
+  '@openclaw/proxyline@0.3.10(undici@8.10.2)':
     dependencies:
       undici: 8.10.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,8 @@ minimumReleaseAgeStrict: true
 
 # Trusted Codex runtimes are outside the dependency cooldown.
 minimumReleaseAgeExclude:
+  # Reviewed Proxyline Bun runtime fix; remove after 2026-09-13 19:19 UTC.
+  - "@openclaw/proxyline@0.3.10"
   # GHSA-vp8m-p9jh-q5pm / GHSA-w293-vg96-wgc3 security fixes; remove after 2026-09-12.
   - "undici@8.10.2"
   - "undici@7.29.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,8 +10,8 @@ minimumReleaseAgeStrict: true
 
 # Trusted Codex runtimes are outside the dependency cooldown.
 minimumReleaseAgeExclude:
-  # Reviewed Proxyline Bun runtime fix; remove after 2026-09-13 19:19 UTC.
-  - "@openclaw/proxyline@0.3.10"
+  # Reviewed Proxyline Bun runtime fix; remove after 2026-09-13 20:51 UTC.
+  - "@openclaw/proxyline@0.3.11"
   # GHSA-vp8m-p9jh-q5pm / GHSA-w293-vg96-wgc3 security fixes; remove after 2026-09-12.
   - "undici@8.10.2"
   - "undici@7.29.1"

--- a/test/scripts/worker-deploy-build-plugin.test.ts
+++ b/test/scripts/worker-deploy-build-plugin.test.ts
@@ -110,6 +110,7 @@ console.log("relocated worker WebSocket and transcription passed");
       const result = await promisify(execFile)(
         process.execPath,
         [
+          ...(process.versions.bun ? ["--no-install"] : []),
           "--input-type=module",
           "--eval",
           probe,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Bun selects its built-in Undici compatibility module instead of OpenClaw's installed peer for Proxyline fetch classes and dispatcher cleanup. The update also preserves standalone worker bundling: the initial 0.3.10 candidate left a runtime package lookup in relocated worker output, and the upstream 0.3.11 repair removes that lookup.

## Why This Change Was Made

Update `@openclaw/proxyline` from 0.3.7 to the reviewed and published 0.3.11 release, retaining Undici 8.10.2. Proxyline now statically imports the explicit `undici/index.js` entry, which selects the installed peer under Bun and lets the existing worker bundler include it. No OpenClaw bundler transform or runtime workaround is added. The existing relocated-worker fixture adds `--no-install` only to its Bun child so its no-installed-dependency assertion cannot auto-install a package.

Immediate adoption is explicitly approved. The only release-age exception is `@openclaw/proxyline@0.3.11`, with removal after **2026-09-13 20:51 UTC**. The prior 0.3.10 exception is removed. The 10,080-minute cooldown, strict enforcement, and other exclusions are unchanged.

## User Impact

OpenClaw retains a shared Undici runtime with Proxyline under Bun, including restoration of fetch globals and the original dispatcher. Standalone workers keep their bundled transport dependency. This does not establish full OpenClaw, Matrix, or every networking surface's compatibility with Bun.

## Evidence

### Upstream review and publication

- [Upstream PR #31](https://github.com/openclaw/proxyline/pull/31) introduced installed-peer selection. [PR #32](https://github.com/openclaw/proxyline/pull/32) makes the entry statically bundleable and preserves caller-provided errors in both Node HTTP-forward and CONNECT request cleanup. The latter PR contains the regression proof and final review context.
- Independent source review covered the **complete production delta from 0.3.7 to 0.3.11**, including `src/env.ts`, `src/node-http.ts`, and `src/runtime.ts`; see the [published comparison](https://github.com/openclaw/proxyline/compare/v0.3.7...v0.3.11) and [changelog](https://github.com/openclaw/proxyline/blob/v0.3.11/CHANGELOG.md). The normalization change uses a bounded linear scan while retaining matching semantics. Request ownership follows Node's selected pooled request, and temporary ownership tags are removed before retention. Pending sockets, timers, and temporary request hooks are cleaned by their owner; hook restoration checks continued ownership. Omitted timeouts retain the documented default and explicit zero remains unbounded. Observer exceptions cannot strand installed globals.
- That review found a real regression in the intermediate cancellation hooks: a caller's supplied `Error` could be replaced. The 0.3.11 correction retains the supplied error through the existing single-settlement path, while preserving absent-error and timeout behavior. Two ordinary owned-loopback regression cases failed before that correction and passed on Node and Bun afterward; reinspection found no remaining issue.
- Upstream's relocated-bundle regression passed on Node and Bun, covering initialization, data-URL fetch, global restoration, and clean exit. The complete Node platform/version matrix, package checks, CodeQL, and final-head hosted review passed.
- [0.3.11 release](https://github.com/openclaw/proxyline/releases/tag/v0.3.11) and [trusted OIDC publication run](https://github.com/openclaw/proxyline/actions/runs/34059116307). Registry publication was **2026-09-06 20:50:12.378 UTC**. The [published tarball](https://registry.npmjs.org/@openclaw/proxyline/-/proxyline-0.3.11.tgz) SHA512 was verified, and all three shipped production files matched merged commit `a8dafd8d6a146763898e027b1473862fc37380b0`. The lockfile records that verified integrity.

### OpenClaw consumer proof

- Pinned pnpm 12.3.4 resolution and the final frozen install passed with actual Proxyline 0.3.11 / Undici 8.10.2. During resolution, pnpm first rejected the existing 0.3.10 lock entry after its exception had been replaced. Retaining that previously approved exact exception solely while regenerating the lock, then removing it and passing the frozen install, completed the transition without changing global policy or hand-editing the lockfile.
- Installed consumer probes passed on **Node 26.8.1 and Bun 1.4.2**: shared peer/global identity, data-URL fetch including a pre-install Request, and restoration of all globals and the original dispatcher.
- The exact existing relocated-worker test passed under **Node and Bun**, clearing the prior `MODULE_NOT_FOUND: undici/package.json` failure. It bundles and relocates the real transport entry, then verifies ordinary loopback WebSocket echo, lazy transcription, headers, and cleanup. All original assertions and timeouts remain unchanged; nine other cases were unselected in each runtime.
- The first Bun attempt stopped at the existing no-installed-ws negative control because `require.resolve("ws/package.json")` auto-installed/resolved ws from Bun’s cache. The earlier builtin attribution was incorrect. A Bun-only `--no-install` child argument preserves and enforces the original `MODULE_NOT_FOUND` assertion, including when Bun has a cached copy. Both runtime cases passed after that single fixture correction.
- Full local `pnpm build` passed, including declarations and runtime packaging. Fresh independent P0–P2 review of the complete four-file candidate passed with no actionable findings. New-head hosted required type, lint, and test checks must pass before landing. Earlier local monolithic validation attempts stopped at an external memory cap; completed local types/guards and equivalent previous-head hosted full lint were recorded separately, never as a passing monolithic local gate.
