### PR TITLE
fix(gateway): reduce repeated model work when listing sessions

### DIFF
--- a/src/gateway/session-utils-model.acp-owner.test.ts
+++ b/src/gateway/session-utils-model.acp-owner.test.ts
@@ -40,12 +40,13 @@ describe("resolveGatewaySessionThinkingProjectionInternal", () => {
     { api: true, baseUrl: false, levels: ["Off"] },
     { api: false, baseUrl: false, levels: ["Off"] },
   ])("uses catalog-only runtime route facts (api=$api, baseUrl=$baseUrl)", (scenario) => {
+    const api = "openai-responses" as const;
     const baseUrl = "https://catalog-route.example.test/v1";
     registerAgentHarness({
       id: "catalog-route",
       label: "Catalog route",
       supports: ({ modelProvider }) =>
-        modelProvider?.api === "openai-responses" && modelProvider.baseUrl === baseUrl
+        modelProvider?.api === api && modelProvider.baseUrl === baseUrl
           ? { supported: true }
           : { supported: false, fallbackRuntime: "openclaw" },
       runAttempt: async () => {
@@ -81,7 +82,7 @@ describe("resolveGatewaySessionThinkingProjectionInternal", () => {
           id: "route-model",
           name: "Route model",
           reasoning: true,
-          ...(scenario.api ? { api: "openai-responses" } : {}),
+          ...(scenario.api ? { api } : {}),
           ...(scenario.baseUrl ? { baseUrl } : {}),
         },
       ],

--- a/src/gateway/session-utils-model.acp-owner.test.ts
+++ b/src/gateway/session-utils-model.acp-owner.test.ts
@@ -6,6 +6,7 @@ import {
   registerAgentHarness,
 } from "../agents/harness/registry.js";
 import { restoreRegisteredAgentHarnesses } from "../agents/harness/registry.test-support.js";
+import * as thinking from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 const { readAcpSessionMeta, readAcpSessionMetaForEntry } = vi.hoisted(() => ({
@@ -19,7 +20,10 @@ vi.mock("../acp/runtime/session-meta.js", () => ({
   readAcpSessionMetaForEntry,
 }));
 
-import { resolveGatewaySessionThinkingProjectionInternal } from "./session-utils-model.js";
+import {
+  resolveGatewayModelThinkingProfile,
+  resolveGatewaySessionThinkingProjectionInternal,
+} from "./session-utils-model.js";
 
 describe("resolveGatewaySessionThinkingProjectionInternal", () => {
   const registeredHarnesses = listRegisteredAgentHarnesses();
@@ -29,6 +33,73 @@ describe("resolveGatewaySessionThinkingProjectionInternal", () => {
     readAcpSessionMetaForEntry.mockReset();
   });
   afterAll(() => restoreRegisteredAgentHarnesses(registeredHarnesses));
+
+  it.each([
+    { api: true, baseUrl: true, levels: ["Off", "High"] },
+    { api: false, baseUrl: true, levels: ["Off"] },
+    { api: true, baseUrl: false, levels: ["Off"] },
+    { api: false, baseUrl: false, levels: ["Off"] },
+  ])("uses catalog-only runtime route facts (api=$api, baseUrl=$baseUrl)", (scenario) => {
+    const baseUrl = "https://catalog-route.example.test/v1";
+    registerAgentHarness({
+      id: "catalog-route",
+      label: "Catalog route",
+      supports: ({ modelProvider }) =>
+        modelProvider?.api === "openai-responses" && modelProvider.baseUrl === baseUrl
+          ? { supported: true }
+          : { supported: false, fallbackRuntime: "openclaw" },
+      runAttempt: async () => {
+        throw new Error("projection must not execute");
+      },
+    });
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          thinkingDefault: "off",
+          models: { "route-provider/route-model": { agentRuntime: { id: "catalog-route" } } },
+        },
+      },
+    };
+    const profile = vi.spyOn(thinking, "resolveThinkingProfile").mockImplementation((params) => ({
+      levels: [
+        { id: "off", label: "Off", rank: 0 },
+        ...(params.agentRuntime === "catalog-route"
+          ? [{ id: "high" as const, label: "High", rank: 3 }]
+          : []),
+      ],
+      defaultLevel: "off",
+    }));
+    const params = {
+      cfg,
+      agentId: "main",
+      provider: "route-provider",
+      model: "route-model",
+      sessionKey: "agent:main:catalog-route",
+      modelCatalog: [
+        {
+          provider: "route-provider",
+          id: "route-model",
+          name: "Route model",
+          reasoning: true,
+          ...(scenario.api ? { api: "openai-responses" } : {}),
+          ...(scenario.baseUrl ? { baseUrl } : {}),
+        },
+      ],
+    };
+    try {
+      expect(
+        resolveGatewayModelThinkingProfile(params).thinkingLevels.map(({ label }) => label),
+      ).toEqual(scenario.levels);
+      expect(
+        resolveGatewaySessionThinkingProjectionInternal({
+          ...params,
+          entry: { sessionId: "catalog-route", updatedAt: 1 },
+        }).thinkingOptions,
+      ).toEqual(scenario.levels);
+    } finally {
+      profile.mockRestore();
+    }
+  });
 
   it.each([false, true])(
     "projects the effective model runtime with authored transport=%s",

--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -169,12 +169,13 @@ export function resolveGatewayModelThinkingProfile(params: {
   sessionKey?: string;
   providerPolicySource?: ThinkingProviderPolicySource;
 }): GatewayModelThinkingProfile {
-  const catalogEntry = params.modelCatalog
-    ? findModelCatalogEntry(params.modelCatalog, {
-        provider: params.provider,
-        modelId: params.model,
-      })
-    : undefined;
+  const catalogEntry =
+    params.agentRuntime == null && params.modelCatalog
+      ? findModelCatalogEntry(params.modelCatalog, {
+          provider: params.provider,
+          modelId: params.model,
+        })
+      : undefined;
   const agentRuntime =
     params.agentRuntime ??
     resolveEffectiveAgentRuntime({
@@ -265,12 +266,13 @@ export function resolveGatewaySessionThinkingProjectionInternal(
   params: GatewaySessionThinkingProjectionParams,
 ) {
   const { acpMeta, agentRuntime } = resolveGatewaySessionRuntimeProjection(params);
-  const catalogEntry = params.modelCatalog
-    ? findModelCatalogEntry(params.modelCatalog, {
-        provider: params.provider,
-        modelId: params.model,
-      })
-    : undefined;
+  const catalogEntry =
+    !acpMeta && params.modelCatalog
+      ? findModelCatalogEntry(params.modelCatalog, {
+          provider: params.provider,
+          modelId: params.model,
+        })
+      : undefined;
   const thinkingRuntime = acpMeta
     ? concretizeAgentRuntime(acpMeta.backend ?? agentRuntime.id)
     : resolveEffectiveAgentRuntime({

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -9,7 +9,7 @@ import {
   readAcpSessionMetaForEntry,
   writeAcpSessionMetaForMigration,
 } from "../acp/runtime/session-meta.js";
-import * as modelCatalog from "../agents/model-catalog.js";
+import * as modelCatalogLookup from "../agents/model-catalog-lookup.js";
 import * as thinking from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
@@ -122,7 +122,7 @@ describe("session list resolver cache", () => {
       reasoning: true,
     }));
     const rowContext = buildSessionListRowMetadataContext({ now });
-    const catalogSpy = vi.spyOn(modelCatalog, "findModelCatalogEntry");
+    const catalogSpy = vi.spyOn(modelCatalogLookup, "findModelCatalogEntry");
     const thinkingSpy = vi
       .spyOn(thinking, "resolveThinkingProfile")
       .mockReturnValue({ levels: [{ id: "off", label: "Off", rank: 0 }], defaultLevel: "off" });

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -9,6 +9,7 @@ import {
   readAcpSessionMetaForEntry,
   writeAcpSessionMetaForMigration,
 } from "../acp/runtime/session-meta.js";
+import * as modelCatalog from "../agents/model-catalog.js";
 import * as thinking from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
@@ -114,7 +115,14 @@ describe("session list resolver cache", () => {
     ];
     const now = Date.now();
     const rowCount = 30;
+    const catalog = tuples.map(({ modelProvider, model }) => ({
+      provider: modelProvider,
+      id: model,
+      name: model,
+      reasoning: true,
+    }));
     const rowContext = buildSessionListRowMetadataContext({ now });
+    const catalogSpy = vi.spyOn(modelCatalog, "findModelCatalogEntry");
     const thinkingSpy = vi
       .spyOn(thinking, "resolveThinkingProfile")
       .mockReturnValue({ levels: [{ id: "off", label: "Off", rank: 0 }], defaultLevel: "off" });
@@ -169,6 +177,7 @@ describe("session list resolver cache", () => {
             model: tuple.model,
             sessionKey,
             entry,
+            modelCatalog: catalog,
             rowContext,
           }).thinkingOptions,
         ).toEqual(["Off"]);
@@ -188,9 +197,11 @@ describe("session list resolver cache", () => {
 
       // Recorded prices bypass lookup; legacy fallback still scales by model, not row.
       expect(thinkingSpy).toHaveBeenCalledTimes(tuples.length);
+      expect(catalogSpy.mock.calls.length).toBeLessThanOrEqual(tuples.length);
       expect(costSpy).toHaveBeenCalledTimes(recorded !== undefined ? 0 : tuples.length);
     } finally {
       thinkingSpy.mockRestore();
+      catalogSpy.mockRestore();
       costSpy.mockRestore();
     }
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where listing many sessions repeats model-catalog work even when the session runtime is already known. Lists with repeated model choices keep scanning the catalog before reaching their existing thinking-metadata cache.

## Why This Change Was Made

Resolve catalog metadata only when its runtime-selection branch needs it: when the thinking-profile caller omitted a runtime, or when ACP metadata does not already own the session runtime. Preserve the existing nullish and ACP conditions, catalog identity rules, cache keys, provider policies, and response fields. No new cache, configuration, dependency, persistence or public API is introduced.

## User Impact

Session-list thinking metadata avoids unnecessary work while retaining the same model-specific options and defaults. Ordinary model/runtime selection still receives catalog API and base-URL facts when those facts are needed.

## Evidence

- Extended the existing 30-row, five-model resolver-scaling fixture with a nonempty matching catalog. On unchanged production code all four cases fail with **65 lookups versus a budget of five**, after their expected output assertions pass. The candidate passes the same bound.
- **288 tests pass** across resolver performance, ACP ownership, session utilities, thinking handler integration, and models-list route coverage. Added generic controls require catalog-only API and base URL to select the supported runtime, exercising both omitted-runtime and non-ACP paths.
- Independent P2 review is clean. The 288-test candidate is `2f42275e3db8`; later commits preserve all production bytes. The first changed check caught a test API literal widening error. After that correction, production types and all 16 core test type graphs passed; the unused-export scanner then flagged a broad test namespace import. The final test imports the canonical lookup owner, and all four baseline cases again fail with **65 lookups versus five**. Both original failures are retained. Final `de7e614321cd` passes all 17 focused tests, the corrected canonical test-path check, and every originally unrun lint/guard.
- CI [34059167457](https://github.com/openclaw/openclaw/actions/runs/34059167457) and [CodeQL](https://github.com/openclaw/openclaw/actions/runs/34059167462) pass at `de7e614321cd`. The actual CI checkout is merge `4cadf59cd1a7` (main `008f508b755f` plus this head).
- Actual uninstrumented built Gateway WebSocket proof passes on baseline `79474a759428` and that exact merge tree under Node 26.7. A restricted viewer and separate admin mutator exercise initial/warm lists, denied viewer writes, positive patch, and clear/readback. All five stages return byte-identical ordered thinking/runtime/model/context projections and defaults across builds. Both runs preserve the 20-second RPC deadline and exit naturally with no forced socket/process cleanup; source/build/runtime identity and unchanged seals are independently verified. This is projection equivalence, not a full-response or elapsed-speedup claim. The existing thinking “e2e” suite invokes handlers directly and is described here as handler integration.

The lookup-count result establishes reduced redundant work, not a production-wide latency or event-loop-stall claim. Production delta is +14/-12 (net +2 formatting lines for the two branch conditions); tests are +84/-1. Release-note context: reduce repeated model metadata work in session lists while preserving thinking options and runtime policy. Changelog generation remains release-owned.

