### PR TITLE
refactor(plugin-sdk): reuse native approval input contracts

### DIFF
--- a/src/plugin-sdk/approval-native-helpers.ts
+++ b/src/plugin-sdk/approval-native-helpers.ts
@@ -123,19 +123,8 @@ type NativeApprovalForwardingFallbackSuppressorParams<TTarget extends NativeAppr
     approvalKind?: ChannelApprovalKind;
     request: ApprovalRequest;
   }) => ChannelApprovalKind;
-  isSessionRouteEligible: (params: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-    approvalKind: ChannelApprovalKind;
-    request: ApprovalRequest;
-  }) => boolean;
-  isExplicitTargetEligible?: (params: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-    approvalKind: ChannelApprovalKind;
-    request: ApprovalRequest;
-    target: NativeApprovalForwardTarget;
-  }) => boolean;
+  isSessionRouteEligible: (params: ChannelApprovalForwardingEligibilityParams) => boolean;
+  isExplicitTargetEligible?: (params: ChannelApprovalExplicitTargetEligibilityParams) => boolean;
   resolveForwardingTargetForMatch?: (params: {
     forwardingTarget: TTarget;
     accountId?: string | null;
@@ -143,18 +132,10 @@ type NativeApprovalForwardingFallbackSuppressorParams<TTarget extends NativeAppr
     approvalKind: ChannelApprovalKind;
     request: ApprovalRequest;
   }) => TTarget | null;
-  resolveOriginTarget: (params: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-    approvalKind: ChannelApprovalKind;
-    request: ApprovalRequest;
-  }) => TTarget | null;
-  resolveApproverDmTargets: (params: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-    approvalKind: ChannelApprovalKind;
-    request: ApprovalRequest;
-  }) => readonly TTarget[];
+  resolveOriginTarget: (params: ChannelApprovalForwardingEligibilityParams) => TTarget | null;
+  resolveApproverDmTargets: (
+    params: ChannelApprovalForwardingEligibilityParams,
+  ) => readonly TTarget[];
   targetsMatch?: (left: TTarget, right: TTarget) => boolean;
 };
 
@@ -170,12 +151,7 @@ type NativeApprovalChannelRouteGateParams<TTarget extends NativeApprovalTarget> 
 };
 
 type NativeApprovalChannelRouteGates = {
-  canApprovalPotentiallyRouteToChannel: (params: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-    approvalKind: ChannelApprovalKind;
-    nativeSessionOnly?: boolean;
-  }) => boolean;
+  canApprovalPotentiallyRouteToChannel: (params: ChannelApprovalPotentialRouteParams) => boolean;
   canAnyApprovalPotentiallyRouteToChannel: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;
@@ -185,25 +161,9 @@ type NativeApprovalChannelRouteGates = {
     cfg: OpenClawConfig;
     accountId?: string | null;
   }) => boolean;
-  isSessionApprovalEligible: (params: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-    approvalKind: ChannelApprovalKind;
-    request: ApprovalRequest;
-  }) => boolean;
-  isExplicitTargetEligible: (params: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-    approvalKind: ChannelApprovalKind;
-    request: ApprovalRequest;
-    target: NativeApprovalForwardTarget;
-  }) => boolean;
-  shouldHandleApprovalRequest: (params: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-    approvalKind?: ChannelApprovalKind;
-    request: ApprovalRequest;
-  }) => boolean;
+  isSessionApprovalEligible: (params: ChannelApprovalForwardingEligibilityParams) => boolean;
+  isExplicitTargetEligible: (params: ChannelApprovalExplicitTargetEligibilityParams) => boolean;
+  shouldHandleApprovalRequest: (params: ApprovalResolverParams) => boolean;
 };
 
 type BaseOriginResolverParams<TTarget> = {
@@ -629,12 +589,7 @@ export function createChannelApprovalForwardingEvaluator(
       approvalKind: "plugin",
     });
 
-  const shouldHandleRequest = (input: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-    approvalKind?: ChannelApprovalKind;
-    request: ApprovalRequest;
-  }): boolean =>
+  const shouldHandleRequest = (input: ApprovalResolverParams): boolean =>
     isSessionEligible({
       ...input,
       approvalKind: resolveApprovalKind(input.request, input.approvalKind),
@@ -740,12 +695,9 @@ export function createNativeApprovalChannelRouteGates<TTarget extends NativeAppr
     );
   };
 
-  const canApprovalPotentiallyRouteToChannel = (input: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-    approvalKind: ChannelApprovalKind;
-    nativeSessionOnly?: boolean;
-  }): boolean => {
+  const canApprovalPotentiallyRouteToChannel = (
+    input: ChannelApprovalPotentialRouteParams,
+  ): boolean => {
     return canApprovalPotentiallyRoute({
       ...input,
       isTransportEnabled: params.isTransportEnabled,
@@ -772,12 +724,9 @@ export function createNativeApprovalChannelRouteGates<TTarget extends NativeAppr
       approvalKind: "system-agent",
     });
 
-  const isSessionApprovalEligible = (input: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-    approvalKind: ChannelApprovalKind;
-    request: ApprovalRequest;
-  }): boolean => {
+  const isSessionApprovalEligible = (
+    input: ChannelApprovalForwardingEligibilityParams,
+  ): boolean => {
     // Per-account runtimes report raw candidates here. The route coordinator rejects
     // unbound multi-account groups as ambiguous before any runtime can deliver.
     const accountId = input.accountId ?? params.resolveDefaultAccountId(input.cfg);
@@ -805,13 +754,9 @@ export function createNativeApprovalChannelRouteGates<TTarget extends NativeAppr
     });
   };
 
-  const isExplicitTargetEligible = (input: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-    approvalKind: ChannelApprovalKind;
-    request: ApprovalRequest;
-    target: NativeApprovalForwardTarget;
-  }): boolean => {
+  const isExplicitTargetEligible = (
+    input: ChannelApprovalExplicitTargetEligibilityParams,
+  ): boolean => {
     return isExplicitTargetApprovalEligibleViaForwarding({
       ...input,
       isTransportEnabled: params.isTransportEnabled,
@@ -820,12 +765,7 @@ export function createNativeApprovalChannelRouteGates<TTarget extends NativeAppr
     });
   };
 
-  const shouldHandleApprovalRequest = (input: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-    approvalKind?: ChannelApprovalKind;
-    request: ApprovalRequest;
-  }): boolean =>
+  const shouldHandleApprovalRequest = (input: ApprovalResolverParams): boolean =>
     isSessionApprovalEligible({
       ...input,
       approvalKind: resolveApprovalKind(input.request, input.approvalKind),


### PR DESCRIPTION
## What Problem This Solves

Native approval routing repeats the same input contracts in callbacks and their implementations even though this SDK owner already defines names for those contracts. Keeping the copies aligned obscures which checks require an approval family and which infer it from the request.

Related: #135868 cleanup campaign (clean-broad lane; no feature content extracted).

## Why This Change Was Made

Reuse four existing aliases at thirteen repeated declarations in `approval-native-helpers.ts`. Required versus optional approval kind, nullable account ID, all three request families, explicit targets, generic returns, and readonly DM arrays keep their existing types. The two target aliases already refer to the same delivery input field.

The complete prior owner matches stable v2026.9.2. This preserves its published SDK contract and existing entrypoints. No executable statement, runtime import, export, routing/authorization decision, schema, option, dependency, or compatibility window changes. The existing oversized-file exemption remains; this cleanup does not claim to retire it.

## User Impact

No behavior or API change. Developers maintain each shared parameter contract in its existing owner. The file shrinks from 1,035 to 975 lines.

| Class | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 21 | 81 | −60 |
| Tests | 0 | 0 | 0 |
| Tooling | 0 | 0 | 0 |
| Docs | 0 | 0 | 0 |

## Evidence

- All 86 existing tests pass before and after across the SDK native/delivery helpers and Slack, Google Chat, and Microsoft Teams native-approval suites, run through `node scripts/run-vitest.mjs`. The tests protect account binding, approval-family distinctions, target matching, and suppression only when native delivery owns the prompt. No test or assertion changed.
- Local and final branch Codex autoreviews are scoped-clean through P2 with no accepted/actionable findings.
- An independent actual-source comparison passes 280 contract assertions in each optional-property mode and rejects six deliberate source mutations in both. Emitted JavaScript is byte-identical. The strict optional mode retains the same 21 preexisting implementation diagnostics on each side; its comparison assertions are all clean. This is not a claim that the whole repository enables that compiler option.
- The full changed-check plan passed on isolated Linux Testbox, including core/extension production and test types, lint, all three Knip scans, SDK surface checks, and architecture/storage guards. The local attempt had stopped because a compiler-input probe reached the enclosing user-managed checkout's install; no guard, dependency, or install was changed to suppress it.
- Full `pnpm build` passed on that same captured source in 3m13s, including 152 public SDK subpaths, 53 built control-plane module loads, and the Control UI build. Testbox run: https://github.com/openclaw/openclaw/actions/runs/34054594402. The delegated command results are authoritative; the backing run represents the retained lease lifecycle.
- The actual built SDK passes 261 consumer assertions per optionality mode, including all 257 original checks and four config-binding checks. Both public entrypoints and all 14 inspected public declarations resolve into `dist`. A virtual mutation removing `agents` from the helper's config type triggers 16 original exact-identity failures per mode; generated files remain unchanged.

The first additional consumer probe accidentally removed private workspace compiler mappings along with public SDK overrides. Its retained failure records and A/B diagnostic show four missing-module errors in the captured source baseline; preserving private mappings restored exact equality while public SDK resolution stayed in `dist`. The correction changed only the probe's resolver setup: every original assertion and the captured source imports were retained. No repository compiler setting or production source was changed for the probe.

The publication rebase is patch-identical. All 18 direct approval-proof inputs and the lockfile are unchanged; unrelated transitive main changes were inspected separately. Exact-head CI will provide the final merge gate.

ClawSweeper reviewed the initial patch-identical head and found no correctness or security issue, with no before-merge requests. Its existing-type and stable-baseline checks agree with the source and compiled-contract evidence above. The first exact-head CI run (34057301063) passed; final-head CI is required after the pre-land rebase.
