### PR TITLE
fix(update): preserve rollback and truthful serving reports

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -479,6 +479,22 @@ artifact version/build. Unavailable inference, timeout, failed turns, or missing
 persistence fail verification and enter the existing repair or rollback flow.
 Health or readiness alone cannot pass verification.
 
+The saved assistant reply may contain punctuation or a short sentence, but must
+include the run-specific verification token as a whole word. The check still
+requires the matching run, transcript lineage, provider/model metadata, and a
+successful stop reason. Reports, chat notices, and `openclaw update status` retain
+the failed check and its next action:
+
+| Reason                | Meaning and next action                                                                                                       |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `response-mismatch`   | The completed turn was saved, but the reply did not contain the token. Run `openclaw triage` to inspect the configured agent. |
+| `turn-incomplete`     | Saved transcript evidence did not prove a complete, valid turn. Run `openclaw triage` to inspect the turn and its lineage.    |
+| `persistence-missing` | No committed request/response pair was found. Run `openclaw triage` to inspect session persistence.                           |
+
+A candidate can be running while verification fails. Recovery guidance uses the
+latest observed service state and names the running version when known; an
+earlier activation stop does not mean the service remains stopped.
+
 Plugin packages download and sync after the core Gateway is serving. When the
 plugin snapshot changes, the updater stops the service for a second measured
 activation window, runs the required full Doctor migration pass under exclusive
@@ -490,14 +506,19 @@ is verified. If activation fails before a working package is confirmed and rollb
 cannot be verified, finalization retains the backup and reports its location. Keep
 that backup and repair the installation before restarting, including for older
 targets without migration continuation. Automatic rollback requires that retained package, its pre-update verification, unchanged
-configuration content, and unchanged shared and affected per-agent SQLite
-`user_version` values. The updater restores the previous generation and verifies
+configuration content, and unchanged pre-existing shared and affected per-agent
+SQLite `user_version` values. A database first created during activation or
+verification is schema-neutral only at the candidate's supported version for its
+database kind; a missing pre-existing database or a new database at a foreign
+version blocks rollback. Newly created databases must also be readable by the
+previous package; unknown or incompatible support refuses rollback with
+`rollback-state-unverified`. The updater restores the previous generation and verifies
 it running before finishing `rolled-back`, preserving the failing check as its
 reason. See [Automatic rollback](/install/updating#automatic-schema-neutral-rollback)
 for the restoration and package-manager guards. A failure alone does not
 authorize restarting the candidate.
 
-If configuration content or a schema version changed, automatic rollback is refused with
+If configuration content changed or the databases are not schema-neutral, automatic rollback is refused with
 `state-migrated-no-rollback`. The updater enters `repairing` on the installed
 candidate, also used if rollback itself fails. If the previous package was
 already restored, repair targets that version. Between repair attempts, the

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -173,8 +173,9 @@ Installer-driven switches verify the replacement before the working owner is ret
 
 Candidate validation failures leave the old Gateway serving. After activation,
 package recovery can restore the retained previous package only when the shared
-and affected per-agent database schema versions and configuration content are
-unchanged. The restored
+and affected pre-existing per-agent database schema versions and configuration
+content are unchanged. A database first created by the candidate is neutral only
+at its supported schema version for that database kind. The restored
 Gateway must pass the same runtime checks before recovery is reported as
 complete. A schema migration prevents automatic package rollback; replacing
 code cannot undo migrated state. Incomplete file rollback retains its backups
@@ -660,6 +661,12 @@ made after the backup.
 If a newly activated package fails verification, `openclaw update` compares the
 shared and affected per-agent SQLite `user_version` values with their
 pre-activation values and checks that configuration content is unchanged.
+Databases first created during activation or serving verification are
+schema-neutral when their version matches the candidate's supported version for
+that database kind. A changed schema version or missing pre-existing database,
+or a new database at a foreign version, still blocks rollback. Before restoring
+code, the updater also checks that the previous package supports any new database;
+unknown or incompatible support refuses rollback with `rollback-state-unverified`.
 When both checks pass and the retained previous package was verified before the
 update, it stops the candidate and restores the previous generation: package,
 command shim, service definition, and config writer stamp. Owned, writable
@@ -681,12 +688,20 @@ verification failure. The command still exits nonzero; recovery does not turn a
 rejected candidate into a successful update.
 
 Serving verification is required, not advisory. It uses configured inference and
-has a 60-second budget. Unavailable inference, timeout, a failed turn, or missing
-saved messages fails verification. A restored Gateway must pass its own serving
+has a 60-second budget. The saved reply must include the run-specific verification
+token as a whole word; punctuation or a short sentence around it is accepted.
+Unavailable inference, timeout, an incomplete turn, a non-matching response, or
+missing saved messages fails verification. `response-mismatch` means the turn was
+saved but its reply did not contain the token; `persistence-missing` means no
+committed request/response pair was found. Use `openclaw update status` for the
+recorded reason and `openclaw triage` to diagnose a failed check. Recovery guidance
+reports whether the Gateway is running or stopped from the latest service
+observation, even when a running candidate did not pass verification.
+A restored Gateway must pass its own serving
 check before the run can finish as `rolled-back`; candidate proof cannot be reused
 after a restart or restoration.
 
-If configuration content or a schema version changed, rollback is refused with
+If configuration content changed or the databases are not schema-neutral, rollback is refused with
 `state-migrated-no-rollback`. The updater attempts
 [bounded unattended repair](/install/updating#unattended-repair-on-your-own-inference)
 on the installed candidate, preserving migrated state. The same repair slot can

--- a/src/cli/update-cli/update-command-execution.ts
+++ b/src/cli/update-cli/update-command-execution.ts
@@ -1,9 +1,11 @@
+import path from "node:path";
 import { readConfigFileSnapshot } from "../../config/config.js";
 import { resolveStateDir } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { ScheduledTaskAutoStartRecoveryError } from "../../daemon/schtasks-update-recovery.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { tryReadJson } from "../../infra/json-files.js";
 import type { PackageUpdateTransaction } from "../../infra/package-update-steps.js";
 import { validateUpdateCandidateCanary } from "../../infra/update-candidate-canary.js";
 import type { UpdateCandidateRehearsal } from "../../infra/update-candidate-rehearsal.js";
@@ -20,7 +22,10 @@ import { recordUpdateRunPhase, recordUpdateRunStep } from "../../infra/update-ru
 import { readCurrentGitUpdateRecovery } from "../../infra/update-runner-git-recovery.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { defaultRuntime } from "../../runtime.js";
-import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-versions.js";
+import {
+  parsePackageOpenClawSchemaVersions,
+  type OpenClawSchemaVersions,
+} from "../../state/openclaw-schema-versions.js";
 import { replaceCliName, resolveCliName } from "../cli-name.js";
 import { formatCliCommand } from "../command-format.js";
 import {
@@ -80,6 +85,7 @@ type MutableUpdateExecutionResult = {
   packageTransaction?: PackageUpdateTransaction;
   schemaVersions?: Awaited<ReturnType<typeof readUpdateStateSchemaVersions>>;
   candidateSchemaVersions?: OpenClawSchemaVersions;
+  previousSchemaVersions?: OpenClawSchemaVersions;
   previousVerified?: boolean;
 };
 
@@ -146,6 +152,7 @@ export async function executeMutableUpdate(params: {
   let packageTransaction: PackageUpdateTransaction | undefined;
   let schemaVersions: Awaited<ReturnType<typeof readUpdateStateSchemaVersions>> | undefined;
   let candidateSchemaVersions: OpenClawSchemaVersions | undefined;
+  let previousSchemaVersions: OpenClawSchemaVersions | undefined;
   let previousVerified = false;
   let candidateFailureReason: string | undefined;
   let validatedConfigSnapshot: { config: OpenClawConfig; hash?: string | null } | undefined;
@@ -400,6 +407,9 @@ export async function executeMutableUpdate(params: {
     }
     const config = snapshot.config;
     await recheckSchemas(admittedTargetSchemaVersions);
+    previousSchemaVersions = parsePackageOpenClawSchemaVersions(
+      await tryReadJson<unknown>(path.join(params.root, "package.json")),
+    );
     schemaVersions = candidateSchemaVersions
       ? await readUpdateStateSchemaVersions({
           stateDir: resolveStateDir(env),
@@ -651,6 +661,7 @@ export async function executeMutableUpdate(params: {
     packageTransaction,
     schemaVersions,
     candidateSchemaVersions,
+    previousSchemaVersions,
     previousVerified,
   };
 }

--- a/src/cli/update-cli/update-command-migrated.test.ts
+++ b/src/cli/update-cli/update-command-migrated.test.ts
@@ -4,8 +4,15 @@ import { DatabaseSync } from "node:sqlite";
 import { afterEach, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { asResolvedSourceConfig, asRuntimeConfig } from "../../config/materialize.js";
+import { appendTranscriptEventsInTransaction } from "../../config/sessions/session-accessor.sqlite-transcript-store.js";
+import { readUpdateStateSchemaVersions } from "../../infra/update-candidate-state.js";
 import { createUpdateRun, recordUpdateRunStep } from "../../infra/update-run-ledger.js";
 import { defaultRuntime } from "../../runtime.js";
+import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../../state/openclaw-agent-db-contract.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  runOpenClawAgentWriteTransaction,
+} from "../../state/openclaw-agent-db.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../../state/openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -34,8 +41,90 @@ afterEach(() => {
   vi.clearAllTimers();
   vi.useRealTimers();
   vi.restoreAllMocks();
+  closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
 });
+
+it.each([
+  { agentId: "main", changed: "none", blocked: undefined },
+  { agentId: "verification", changed: "none", blocked: undefined },
+  { agentId: "main", changed: "shared", blocked: "state-migrated-no-rollback" },
+  { agentId: "main", changed: "agent", blocked: "state-migrated-no-rollback" },
+])(
+  "classifies activation after a first serving turn (agent=$agentId, changed=$changed)",
+  async ({ agentId, changed, blocked }) => {
+    const stateDir = await fs.realpath(dirs.make("update-first-serving-turn-"));
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const shared = openOpenClawStateDatabase({ env });
+    const schemaVersions = await readUpdateStateSchemaVersions({ stateDir, config: {}, env });
+    const agentPath = path.join(stateDir, "agents", agentId, "agent", "openclaw-agent.sqlite");
+    expect(
+      schemaVersions.find((entry) => entry.path === agentPath)?.userVersion ?? null,
+    ).toBeNull();
+
+    runOpenClawAgentWriteTransaction(
+      (database) => {
+        appendTranscriptEventsInTransaction(
+          database,
+          { agentId, sessionKey: `agent:${agentId}:update-check`, sessionId: "serving-check" },
+          [
+            {
+              type: "message",
+              id: "request",
+              parentId: null,
+              message: { role: "user", content: "Reply with update-verified-run" },
+            },
+            {
+              type: "message",
+              id: "reply",
+              parentId: "request",
+              message: {
+                role: "assistant",
+                content: "update-verified-run",
+                provider: "openai",
+                model: "gpt-4.1-mini",
+                stopReason: "stop",
+                __openclaw: { runId: "run" },
+              },
+            },
+          ],
+        );
+      },
+      { agentId, env },
+    );
+    closeOpenClawAgentDatabasesForTest();
+    if (changed !== "none") {
+      const db = new DatabaseSync(changed === "shared" ? shared.path : agentPath);
+      try {
+        db.exec(
+          `PRAGMA user_version = ${changed === "shared" ? OPENCLAW_STATE_SCHEMA_VERSION + 1 : OPENCLAW_AGENT_SCHEMA_VERSION + 1}`,
+        );
+      } finally {
+        db.close();
+      }
+    }
+    const result = {
+      status: "ok" as const,
+      mode: "npm" as const,
+      root: process.cwd(),
+      steps: [],
+      durationMs: 0,
+    };
+    await expect(
+      inspectActivatedUpdateState({
+        result,
+        root: process.cwd(),
+        schemaVersions,
+        candidateSchemaVersions: {
+          state: OPENCLAW_STATE_SCHEMA_VERSION + Number(changed === "shared"),
+          agent: OPENCLAW_AGENT_SCHEMA_VERSION,
+        },
+        config: {},
+        env,
+      }),
+    ).resolves.toBe(blocked);
+  },
+);
 
 it("refuses state inspection when activation leaves no known runtime root", async () => {
   const result = { status: "error" as const, mode: "npm" as const, steps: [], durationMs: 0 };

--- a/src/cli/update-cli/update-command-migrated.ts
+++ b/src/cli/update-cli/update-command-migrated.ts
@@ -72,7 +72,10 @@ export async function inspectActivatedUpdateState(
         stderrTail: `Shared state migration did not finish: expected schema ${candidateSchemaVersions.state}, found ${sharedVersion ?? "missing"}.`,
       });
     }
-    return updateStateSchemaVersionsMatch(schemaVersions, current)
+    return updateStateSchemaVersionsMatch(schemaVersions, current, {
+      sharedPath: resolveOpenClawStateSqlitePath(env),
+      candidateSchemaVersions,
+    })
       ? undefined
       : "state-migrated-no-rollback";
   } catch (error) {

--- a/src/cli/update-cli/update-command-post-update-recovery.test.ts
+++ b/src/cli/update-cli/update-command-post-update-recovery.test.ts
@@ -7,12 +7,21 @@ import { ScheduledTaskAutoStartRecoveryError } from "../../daemon/schtasks-updat
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createRetainedPackageSwap } from "../../infra/package-update-swap.test-support.js";
 import { readUpdateStateSchemaVersions } from "../../infra/update-candidate-state.js";
-import { createUpdateRun, getUpdateRun } from "../../infra/update-run-ledger.js";
+import {
+  createUpdateRun,
+  getUpdateRun,
+  recordUpdateRunStep,
+  recordUpdateRunVerification,
+} from "../../infra/update-run-ledger.js";
+import { renderUpdateRunNotice, renderUpdateRunReport } from "../../infra/update-run-report.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { defaultRuntime } from "../../runtime.js";
 
 const mocks = vi.hoisted(() => ({
   printResult: vi.fn(),
+  readRuntime: vi.fn(async (): Promise<{ status: string; pid?: number }> => ({
+    status: "unknown",
+  })),
   restartCandidate: vi.fn<typeof import("./update-command-service.js").maybeRestartService>(
     async () => "ok",
   ),
@@ -47,6 +56,7 @@ vi.mock("../../config/config.js", async (importOriginal) => ({
 }));
 vi.mock("../../daemon/service.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../daemon/service.js")>()),
+  resolveGatewayService: () => ({ readRuntime: mocks.readRuntime }),
   readGatewayServiceState: async () => ({
     installed: true,
     loadState: { status: "loaded" },
@@ -489,6 +499,7 @@ describe("failed update recovery restart", () => {
         OPENCLAW_PROFILE: "work",
       };
       const run = { runId: createUpdateRun({ trigger: "cli" }, { env }).runId, env };
+      mocks.readRuntime.mockResolvedValue({ status: stopped ? "stopped" : "unknown" });
       await finishFailedUpdate(
         failedResult({ serviceRestartSafe: false, reason: "rollback-checkout-dirty" }),
         { stopped, run },
@@ -499,6 +510,61 @@ describe("failed update recovery restart", () => {
       expect(nextAction).toContain("Run `openclaw --profile work triage`");
       expect(nextAction?.includes("Keep the gateway stopped")).toBe(stopped);
       expect(mocks.printResult.mock.lastCall?.[2]).toEqual({ nextAction });
+    },
+  );
+
+  it.each([7376, 7377])(
+    "reports the latest running process after the activation stop (pid=%s)",
+    async (pid) => {
+      const env = {
+        ...process.env,
+        OPENCLAW_STATE_DIR: tempDirs.make("update-running-unverified-"),
+      };
+      const run = { runId: createUpdateRun({ trigger: "cli" }, { env }).runId, env };
+      recordUpdateRunVerification(
+        run.runId,
+        { serviceRunning: true, pid: 7376, runningVersion: "2026.9.3", inferenceProbe: "failed" },
+        { env },
+      );
+      recordUpdateRunStep(
+        run.runId,
+        { step: "gateway verification", status: "failed", detail: "response-mismatch" },
+        { env },
+      );
+      mocks.readRuntime.mockResolvedValue({ status: "running", pid });
+
+      await finishFailedUpdate(
+        {
+          ...failedResult({ serviceRestartSafe: false, reason: "runtime-verification-failed" }),
+          reason: "state-migrated-no-rollback",
+        },
+        { stopped: true, run },
+      );
+
+      const recorded = getUpdateRun(run.runId, { env });
+      if (!recorded) {
+        throw new Error("Expected the failed update run to remain recorded");
+      }
+      const version = pid === 7376 ? "2026.9.3" : undefined;
+      expect(recorded.origin.nextAction).toContain(
+        `The gateway is running${version ? ` ${version}` : ""} but did not pass verification (response-mismatch)`,
+      );
+      expect(recorded.origin.nextAction).not.toContain("gateway stopped");
+      expect(recorded.origin.nextAction).not.toContain("remains stopped");
+      expect(recorded.origin.nextAction).toContain("triage");
+      expect(recorded.verification).toMatchObject({ serviceRunning: true, pid });
+      expect(recorded.verification.runningVersion).toBe(version);
+      expect(mocks.printResult.mock.lastCall?.[2]).toEqual({
+        nextAction: recorded.origin.nextAction,
+      });
+      for (const report of [
+        renderUpdateRunReport(recorded).markdown,
+        renderUpdateRunNotice(recorded, "finished"),
+      ]) {
+        expect(report).toContain("response-mismatch");
+        expect(report).toContain("triage");
+        expect(report).not.toContain("remains stopped");
+      }
     },
   );
 

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -20,6 +20,7 @@ import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { loadInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-records.js";
 import { defaultRuntime } from "../../runtime.js";
 import { classifyUpdateOutcome } from "../../shared/update-outcome.js";
+import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-versions.js";
 import { replaceCliName, resolveCliName } from "../cli-name.js";
 import { formatCliCommand } from "../command-format.js";
 import { printResult } from "./progress.js";
@@ -75,6 +76,8 @@ export type FinishUpdateParams = UpdateRestartParams & {
   packageUpdateNodeRunner?: string;
   packageTransaction?: PackageUpdateTransaction;
   schemaVersions?: UpdateStateSchemaVersion[];
+  candidateSchemaVersions?: OpenClawSchemaVersions;
+  previousSchemaVersions?: OpenClawSchemaVersions;
   previousVerified?: boolean;
   rollbackBlockedReason?: "state-migrated-no-rollback" | "rollback-state-unverified";
 };
@@ -109,12 +112,16 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
   });
   const recordNextAction = (result: UpdateRunResult) => {
     const run = params.opts.run;
+    const active = run ? getUpdateRun(run.runId, { env: run.env }) : undefined;
     const nextAction = resolveUpdateResultNextAction({
       result,
-      managedGatewayStopped: params.preManagedServiceStop?.stopped === true,
+      serviceRunning: active?.verification.serviceRunning,
+      runningVersion: active?.verification.runningVersion,
+      verificationFailure: active?.steps.findLast(
+        (step) => step.step === "gateway verification" && step.status === "failed",
+      )?.detail,
       env: run?.env ?? params.ownedManagedUpdateEnv ?? process.env,
     });
-    const active = run ? getUpdateRun(run.runId, { env: run.env }) : undefined;
     if (run && active?.status === "running" && active.origin.nextAction !== nextAction) {
       recordUpdateRunPhase(run.runId, active.phase, { origin: { nextAction } }, { env: run.env });
     }
@@ -158,6 +165,8 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
           packageTransaction: params.packageTransaction,
           rollbackBlockedReason: params.rollbackBlockedReason,
           schemaVersions: params.schemaVersions,
+          candidateSchemaVersions: params.candidateSchemaVersions,
+          previousSchemaVersions: params.previousSchemaVersions,
           previousVerified: params.previousVerified,
           config:
             params.configSnapshot.sourceConfigBeforeMigrations ??
@@ -304,6 +313,12 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
         finalResult.steps = [...finalResult.steps, retained];
       }
     }
+    if (finalResult.status === "error" && !rolledBack && params.preManagedServiceStop?.stopped) {
+      await recordFailedUpdateGatewayState(
+        params.opts.run,
+        currentServiceStop()?.serviceEnv ?? process.env,
+      );
+    }
     recordNextAction(finalResult);
     if (notify) {
       await writeControlPlaneUpdateRestartSentinelBestEffort({
@@ -311,12 +326,6 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
         result: finalResult,
         jsonMode: Boolean(params.opts.json),
       });
-    }
-    if (finalResult.status === "error" && !rolledBack && params.preManagedServiceStop?.stopped) {
-      await recordFailedUpdateGatewayState(
-        params.opts.run,
-        params.preManagedServiceStop.serviceEnv ?? process.env,
-      );
     }
     // The recovering Gateway reads this notification at startup. Persist once
     // before restarting; rewriting a consumed sentinel could deliver it twice.

--- a/src/cli/update-cli/update-command-rollback.test.ts
+++ b/src/cli/update-cli/update-command-rollback.test.ts
@@ -181,7 +181,7 @@ describe("verified package rollback", () => {
       });
       const nextAction = resolveUpdateResultNextAction({
         result: outcome.result,
-        managedGatewayStopped: !reachable,
+        serviceRunning: reachable,
         env,
       });
       expect(renderUpdateRunReport(row, { nextAction }).markdown).toContain(
@@ -302,6 +302,20 @@ describe("verified package rollback", () => {
   );
   it.each([
     { change: "none", previousVerified: true, restored: true, service: "stopped" },
+    { change: "new-agent", previousVerified: true, restored: true, service: "stopped" },
+    { change: "new-agent-foreign", previousVerified: true, restored: false, service: "stopped" },
+    {
+      change: "new-agent-previous-incompatible",
+      previousVerified: true,
+      restored: false,
+      service: "stopped",
+    },
+    {
+      change: "new-agent-previous-unknown",
+      previousVerified: true,
+      restored: false,
+      service: "stopped",
+    },
     { change: "identity-read-failed", previousVerified: true, restored: true, service: "stopped" },
     { change: "shared", previousVerified: true, restored: false, service: "stopped" },
     { change: "agent", previousVerified: true, restored: false, service: "stopped" },
@@ -319,8 +333,13 @@ describe("verified package rollback", () => {
       const shared = path.join(stateDir, "state/openclaw.sqlite");
       const agent = path.join(stateDir, "agents/main/agent/openclaw-agent.sqlite");
       setVersion(shared, 7);
-      setVersion(agent, 3);
+      if (!change.startsWith("new-agent")) {
+        setVersion(agent, 3);
+      }
       const schemaVersions = await readUpdateStateSchemaVersions({ stateDir, config: {} });
+      if (change.startsWith("new-agent")) {
+        setVersion(agent, change === "new-agent-foreign" ? 4 : 3);
+      }
       if (change === "shared") {
         setVersion(shared, 8);
       }
@@ -361,6 +380,14 @@ describe("verified package rollback", () => {
         previousRoot,
         nodeRunner: process.execPath,
         schemaVersions,
+        candidateSchemaVersions: { state: 7, agent: 3 },
+        previousSchemaVersions:
+          change === "new-agent-previous-unknown"
+            ? undefined
+            : {
+                state: 7,
+                agent: change === "new-agent-previous-incompatible" ? 2 : 3,
+              },
         previousVerified,
         packageTransaction: { backupRoot: "/backup", rollback, complete: vi.fn() },
         config,
@@ -386,7 +413,7 @@ describe("verified package rollback", () => {
       });
       expect(outcome.rolledBack).toBe(restored);
       expect(rollback, JSON.stringify(outcome)).toHaveBeenCalledTimes(
-        change === "none" || change === "identity-read-failed" ? 1 : 0,
+        change === "none" || change === "identity-read-failed" || change === "new-agent" ? 1 : 0,
       );
       expect(mocks.restart).toHaveBeenCalledTimes(restored ? 1 : 0);
       if (service !== "stopped") {
@@ -418,7 +445,7 @@ describe("verified package rollback", () => {
         );
       } else {
         expect(outcome.result.reason).toBe(
-          change === "unknown-runtime"
+          change === "unknown-runtime" || change.startsWith("new-agent-previous-")
             ? "rollback-state-unverified"
             : previousVerified
               ? "state-migrated-no-rollback"
@@ -426,6 +453,10 @@ describe("verified package rollback", () => {
         );
         if (!previousVerified) {
           expect(outcome.result).toMatchObject({ root: previousRoot, after: result.before });
+        }
+        if (change.startsWith("new-agent-previous-")) {
+          expect(outcome.result).toMatchObject({ root: candidateRoot, after: result.after });
+          expect(mocks.stop).not.toHaveBeenCalled();
         }
       }
     },

--- a/src/cli/update-cli/update-command-rollback.ts
+++ b/src/cli/update-cli/update-command-rollback.ts
@@ -13,6 +13,8 @@ import {
 import { NativePackageRollbackError } from "../../infra/update-native-package-stage.js";
 import { recordUpdateRunStep } from "../../infra/update-run-ledger.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
+import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-versions.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import { confirmGatewayReachable } from "../daemon-cli/restart-health-probe.js";
 import type { UpdateCommandOptions } from "./shared.js";
 import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
@@ -46,6 +48,8 @@ export async function rollbackFailedUpdate(params: {
   packageTransaction?: PackageUpdateTransaction;
   rollbackBlockedReason?: "state-migrated-no-rollback" | "rollback-state-unverified";
   schemaVersions?: UpdateStateSchemaVersion[];
+  candidateSchemaVersions?: OpenClawSchemaVersions;
+  previousSchemaVersions?: OpenClawSchemaVersions;
   previousVerified?: boolean;
   config: OpenClawConfig;
   opts: UpdateCommandOptions;
@@ -87,8 +91,30 @@ export async function rollbackFailedUpdate(params: {
       root: result.root ?? null,
       nodeRunner: params.nodeRunner,
     });
-    if (baseline === undefined || !updateStateSchemaVersionsMatch(baseline, current)) {
+    const sharedPath = resolveOpenClawStateSqlitePath(env);
+    if (
+      baseline === undefined ||
+      !updateStateSchemaVersionsMatch(baseline, current, {
+        sharedPath,
+        candidateSchemaVersions: params.candidateSchemaVersions,
+      })
+    ) {
       return false;
+    }
+    const baselineVersions = new Map(baseline.map((entry) => [entry.path, entry.userVersion]));
+    for (const entry of current) {
+      if (entry.userVersion === null || baselineVersions.get(entry.path) != null) {
+        continue;
+      }
+      // First-use creation is not migration, but the retained runtime must still
+      // support that new store before replacing a reachable candidate.
+      const kind = entry.path === sharedPath ? "state" : "agent";
+      const supported = params.previousSchemaVersions?.[kind];
+      if (supported === undefined || entry.userVersion > supported) {
+        throw new Error(
+          `Automatic rollback refused: newly created ${kind} database ${entry.path} uses schema ${entry.userVersion}; retained previous package support is ${supported ?? "unknown"}. Keep the candidate installed.`,
+        );
+      }
     }
     const snapshot = await withOwnedManagedUpdateEnv(env, () =>
       readConfigFileSnapshot({

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -10,6 +10,7 @@ import {
 import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
+  getUpdateRun,
   recordUpdateRunPhase,
   recordUpdateRunVerification,
 } from "../../infra/update-run-ledger.js";
@@ -164,6 +165,16 @@ export async function recordFailedUpdateGatewayState(
   const runtime = await resolveGatewayService()
     .readRuntime(env)
     .catch(() => undefined);
+  const verified = getUpdateRun(run.runId, { env: run.env })?.verification;
+  // A failed serving turn does not invalidate health/version facts for the same process.
+  if (
+    runtime?.status === "running" &&
+    typeof runtime.pid === "number" &&
+    verified?.serviceRunning === true &&
+    verified.pid === runtime.pid
+  ) {
+    return;
+  }
   recordUpdateRunVerification(
     run.runId,
     {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -704,6 +704,8 @@ async function updateCommandInternal(
     invocationCwd,
     packageTransaction: execution.packageTransaction,
     schemaVersions: execution.schemaVersions,
+    candidateSchemaVersions: execution.candidateSchemaVersions,
+    previousSchemaVersions: execution.previousSchemaVersions,
     previousVerified: execution.previousVerified,
   };
   const rollbackBlockedReason = await inspectActivatedUpdateState({

--- a/src/cli/update-cli/update-recovery-guidance.ts
+++ b/src/cli/update-cli/update-recovery-guidance.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveStateDir } from "../../config/paths.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { replaceCliName, resolveCliName } from "../cli-name.js";
@@ -22,7 +23,9 @@ export function resolveUnsafeUpdateRecoveryGuidance(
 
 export function resolveUpdateResultNextAction(params: {
   result: UpdateRunResult;
-  managedGatewayStopped: boolean;
+  serviceRunning?: boolean;
+  runningVersion?: string;
+  verificationFailure?: string;
   env: NodeJS.ProcessEnv;
 }): string | undefined {
   const { result, env } = params;
@@ -32,8 +35,15 @@ export function resolveUpdateResultNextAction(params: {
     }
     const reason =
       result.recovery?.serviceRestartSafe === false ? result.recovery.reason : undefined;
+    const failure = truncateUtf16Safe(
+      params.verificationFailure ?? result.reason ?? reason ?? "",
+      240,
+    );
+    const runningVersion = truncateUtf16Safe(params.runningVersion ?? "", 120);
     const state = reason
-      ? `${params.managedGatewayStopped ? "Managed gateway remains stopped because update recovery" : "Update recovery"} could not prove a runnable installation (${reason}). ${params.managedGatewayStopped ? "Keep the gateway stopped until the update succeeds. " : ""}`
+      ? params.serviceRunning === true
+        ? `The gateway is running${runningVersion ? ` ${runningVersion}` : ""} but did not pass verification (${failure}). `
+        : `${params.serviceRunning === false ? "Managed gateway remains stopped because update recovery" : "Update recovery"} could not prove a runnable installation (${failure}). ${params.serviceRunning === false ? "Keep the gateway stopped until the update succeeds. " : ""}`
       : "";
     return `${state}${resolveUnsafeUpdateRecoveryGuidance(reason, env)}`;
   }

--- a/src/infra/update-candidate-state.test.ts
+++ b/src/infra/update-candidate-state.test.ts
@@ -192,8 +192,18 @@ it("keeps absent stores explicit and observes newly created databases for rollba
   await createDatabase(main);
   const after = await readUpdateStateSchemaVersions({ stateDir, config: {} });
   expect(after.find((entry) => entry.path === main)?.userVersion).toBe(3);
-  expect(updateStateSchemaVersionsMatch(before, after)).toBe(false);
-  expect(updateStateSchemaVersionsMatch(after, after.toReversed())).toBe(true);
+  const sharedPath = path.join(stateDir, "state", "openclaw.sqlite");
+  expect(updateStateSchemaVersionsMatch(before, after, { sharedPath })).toBe(false);
+  const candidate = { sharedPath, candidateSchemaVersions: { state: 7, agent: 3 } };
+  expect(updateStateSchemaVersionsMatch(before, after, candidate)).toBe(true);
+  expect(
+    updateStateSchemaVersionsMatch(before, after, {
+      sharedPath,
+      candidateSchemaVersions: { state: 3, agent: 4 },
+    }),
+  ).toBe(false);
+  expect(updateStateSchemaVersionsMatch(after, before, candidate)).toBe(false);
+  expect(updateStateSchemaVersionsMatch(after, after.toReversed(), candidate)).toBe(true);
 });
 
 it("inspects with the installed candidate and selected Node after the old package is removed", async () => {

--- a/src/infra/update-candidate-state.ts
+++ b/src/infra/update-candidate-state.ts
@@ -5,6 +5,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { z } from "zod";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runCommandBuffered } from "../process/exec.js";
+import type { OpenClawSchemaVersions } from "../state/openclaw-schema-versions.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import type { DB } from "../state/openclaw-state-db.generated.js";
 import { resolveOpenClawRegisteredAgentDatabasePath } from "../state/openclaw-state-db.paths.js";
@@ -31,11 +32,30 @@ type CandidateStateDatabase = Pick<
 export function updateStateSchemaVersionsMatch(
   before: readonly UpdateStateSchemaVersion[],
   after: readonly UpdateStateSchemaVersion[],
+  params: { sharedPath: string; candidateSchemaVersions?: OpenClawSchemaVersions },
 ): boolean {
   const versions = new Map(after.map((entry) => [entry.path, entry.userVersion]));
+  const candidate = params.candidateSchemaVersions;
+  if (!candidate) {
+    return (
+      before.length === after.length &&
+      before.every((entry) => versions.get(entry.path) === entry.userVersion)
+    );
+  }
+  const baseline = new Map(before.map((entry) => [entry.path, entry.userVersion]));
   return (
-    before.length === after.length &&
-    before.every((entry) => versions.get(entry.path) === entry.userVersion)
+    before.every(
+      (entry) => entry.userVersion === null || versions.get(entry.path) === entry.userVersion,
+    ) &&
+    after.every((entry) => {
+      if (entry.userVersion === null || baseline.get(entry.path) === entry.userVersion) {
+        return true;
+      }
+      // Verification can create a store for the first time. All collected paths
+      // except the shared database are configured or registered agent stores.
+      const supported = entry.path === params.sharedPath ? candidate.state : candidate.agent;
+      return baseline.get(entry.path) == null && entry.userVersion === supported;
+    })
   );
 }
 
@@ -117,7 +137,7 @@ async function collectStateDatabasePaths(input: StateInput): Promise<string[]> {
   return [...files].toSorted();
 }
 
-/** Missing databases stay explicit so creation or loss cannot authorize rollback. */
+/** Missing databases stay explicit so creation is schema-checked and loss blocks rollback. */
 export async function readUpdateStateSchemaVersionsInProcess(
   input: StateInput,
 ): Promise<UpdateStateSchemaVersion[]> {

--- a/src/infra/update-serving-verification-readback.ts
+++ b/src/infra/update-serving-verification-readback.ts
@@ -7,11 +7,16 @@ import {
 } from "../config/sessions/session-accessor.sqlite-scope.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { extractAssistantPhaseText } from "../shared/chat-message-content.js";
+import { escapeRegExp } from "../shared/regexp.js";
 import { openOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
 import { executeSqliteQuerySync, executeSqliteQueryTakeFirstSync } from "./kysely-sync.js";
 import type { UpdateServingReceipt } from "./update-serving-verification-receipt.js";
 
 type TranscriptProof = UpdateServingReceipt["transcript"];
+
+type UpdateServingTranscriptResult =
+  | { status: "persisted"; sessionId: string; transcript: TranscriptProof }
+  | { status: "not-found" | "response-mismatch" | "turn-incomplete" };
 
 /** A fresh read-only snapshot; never borrows the Gateway/writer's cached handle. */
 export function readUpdateServingTranscript(params: {
@@ -22,7 +27,7 @@ export function readUpdateServingTranscript(params: {
   agentRunId: string;
   prompt: string;
   response: string;
-}): { sessionId: string; transcript: TranscriptProof } | undefined {
+}): UpdateServingTranscriptResult {
   const scope = resolveSqliteScope({
     agentId: params.agentId,
     sessionKey: params.sessionKey,
@@ -34,7 +39,7 @@ export function readUpdateServingTranscript(params: {
   });
   const opened = openOpenClawAgentDatabaseReadOnly(toDatabaseOptions(scope));
   if (!opened.found) {
-    return undefined;
+    return { status: "not-found" };
   }
   const { db, close } = opened.database;
   try {
@@ -57,8 +62,11 @@ export function readUpdateServingTranscript(params: {
         .where("node.entry_valid", "=", 1)
         .where("node.archived_at", "is", null),
     );
-    if (!owner || ["failed", "killed", "timeout"].includes(owner.status ?? "")) {
-      return undefined;
+    if (!owner) {
+      return { status: "not-found" };
+    }
+    if (["failed", "killed", "timeout"].includes(owner.status ?? "")) {
+      return { status: "turn-incomplete" };
     }
     // The verifier creates a new session for one tiny turn. Bound bytes in SQLite
     // before crossing into JS, and reject overflow instead of searching partial history.
@@ -80,22 +88,32 @@ export function readUpdateServingTranscript(params: {
         .orderBy("seq", "asc")
         .limit(33),
     ).rows;
-    if (rows.length === 0 || rows.length > 32) {
-      return undefined;
+    if (rows.length === 0) {
+      return { status: "not-found" };
+    }
+    if (rows.length > 32) {
+      return { status: "turn-incomplete" };
     }
     let user: TranscriptProof["user"] | undefined;
     let assistant: TranscriptProof["assistant"] | undefined;
+    let assistantComplete = false;
+    let responseMatches = false;
+    // Allow prose and punctuation without accepting an extended or partial token.
+    const responsePattern = new RegExp(
+      `(?:^|[^\\p{L}\\p{N}_-])${escapeRegExp(params.response)}(?=$|[^\\p{L}\\p{N}_-])`,
+      "u",
+    );
     const parents = new Map<string, string | null>();
     for (const row of rows) {
       if (!row.event_json) {
-        return undefined;
+        return { status: "turn-incomplete" };
       }
       const event: unknown = JSON.parse(row.event_json);
       if (!isRecord(event) || typeof event.id !== "string") {
-        return undefined;
+        return { status: "turn-incomplete" };
       }
       if (event.type === "reset" || event.type === "compaction") {
-        return undefined;
+        return { status: "turn-incomplete" };
       }
       parents.set(event.id, typeof event.parentId === "string" ? event.parentId : null);
       if (event.type !== "message" || !isRecord(event.message)) {
@@ -116,30 +134,32 @@ export function readUpdateServingTranscript(params: {
               : undefined;
         // Exactly one newly persisted request, not a historical or concurrent turn.
         if (user || text !== params.prompt) {
-          return undefined;
+          return { status: "turn-incomplete" };
         }
         user = { entryId: event.id, seq: row.seq };
       }
       // A trailing tool result or other message is not a completed assistant turn.
-      assistant = undefined;
+      assistantComplete = false;
       if (message.role === "assistant") {
         const metadata = isRecord(message["__openclaw"]) ? message["__openclaw"] : undefined;
-        assistant =
-          user &&
+        assistant = { entryId: event.id, seq: row.seq };
+        assistantComplete =
+          user !== undefined &&
           metadata?.runId === params.agentRunId &&
           message.stopReason === "stop" &&
           typeof message.provider === "string" &&
           message.provider.length > 0 &&
           typeof message.model === "string" &&
           message.model.length > 0 &&
-          !message.errorMessage &&
-          extractAssistantPhaseText(message)?.trim() === params.response
-            ? { entryId: event.id, seq: row.seq }
-            : undefined;
+          !message.errorMessage;
+        responseMatches = responsePattern.test(extractAssistantPhaseText(message)?.trim() ?? "");
       }
     }
     if (!user || !assistant || assistant.seq <= user.seq) {
-      return undefined;
+      return { status: "not-found" };
+    }
+    if (!assistantComplete) {
+      return { status: "turn-incomplete" };
     }
     // Raw events are canonical. Prove the terminal assistant descends from the
     // exact request rather than accepting an unrelated abandoned transcript branch.
@@ -150,9 +170,13 @@ export function readUpdateServingTranscript(params: {
       parent = parents.get(parent);
     }
     if (parent !== user.entryId) {
-      return undefined;
+      return { status: "turn-incomplete" };
+    }
+    if (!responseMatches) {
+      return { status: "response-mismatch" };
     }
     return {
+      status: "persisted",
       sessionId: owner.current_session_id,
       transcript: {
         generation: owner.generation,

--- a/src/infra/update-serving-verification-receipt.ts
+++ b/src/infra/update-serving-verification-receipt.ts
@@ -51,6 +51,8 @@ export type UpdateServingVerificationResult =
         | "runtime-changed"
         | "aborted"
         | "turn-failed"
+        | "turn-incomplete"
+        | "response-mismatch"
         | "persistence-missing"
         | "persistence-changed";
     }

--- a/src/infra/update-serving-verification.test.ts
+++ b/src/infra/update-serving-verification.test.ts
@@ -127,9 +127,23 @@ async function fixture(
         parentId: variation === "wrong-branch" ? null : "user-entry",
         message: {
           role: "assistant",
-          content: [{ type: "text", text: `update-verified-${request.idempotencyKey}` }],
-          provider: "openai",
-          model: "gpt-4.1-mini",
+          content: [
+            {
+              type: "text",
+              text:
+                variation === "response-mismatch"
+                  ? "The service is healthy."
+                  : variation === "response-punctuation"
+                    ? `Verified: update-verified-${request.idempotencyKey}.`
+                    : variation === "response-prefix"
+                      ? `not-update-verified-${request.idempotencyKey}`
+                      : variation === "response-suffix"
+                        ? `update-verified-${request.idempotencyKey}extra`
+                        : `update-verified-${request.idempotencyKey}`,
+            },
+          ],
+          provider: variation === "missing-provider" ? "" : "openai",
+          model: variation === "missing-model" ? "" : "gpt-4.1-mini",
           stopReason:
             variation === "failed-assistant"
               ? "error"
@@ -143,7 +157,20 @@ async function fixture(
         appendTranscriptEventsInTransaction(
           database,
           { ...scope, sessionId },
-          variation === "missing-assistant" ? [user] : [user, assistant],
+          variation === "missing-assistant"
+            ? [user]
+            : variation === "trailing-tool"
+              ? [
+                  user,
+                  assistant,
+                  {
+                    type: "message",
+                    id: "tool-entry",
+                    parentId: "assistant-entry",
+                    message: { role: "toolResult", content: "pending tool result" },
+                  },
+                ]
+              : [user, assistant],
         );
       }, toDatabaseOptions(scope));
       return readbackParams(request);
@@ -210,9 +237,22 @@ describe("update serving verification", () => {
     },
   );
 
-  it.each(["missing-assistant", "failed-assistant", "tool-only", "wrong-run", "wrong-branch"])(
-    "rejects successful RPC/readiness without durable terminal evidence: %s",
-    async (variation) => {
+  it.each([
+    ["missing-assistant", { status: "failed", reason: "persistence-missing" }],
+    ["failed-assistant", { status: "failed", reason: "turn-incomplete" }],
+    ["tool-only", { status: "failed", reason: "turn-incomplete" }],
+    ["trailing-tool", { status: "failed", reason: "turn-incomplete" }],
+    ["missing-provider", { status: "failed", reason: "turn-incomplete" }],
+    ["missing-model", { status: "failed", reason: "turn-incomplete" }],
+    ["wrong-run", { status: "failed", reason: "turn-incomplete" }],
+    ["wrong-branch", { status: "failed", reason: "turn-incomplete" }],
+    ["response-mismatch", { status: "failed", reason: "response-mismatch" }],
+    ["response-prefix", { status: "failed", reason: "response-mismatch" }],
+    ["response-suffix", { status: "failed", reason: "response-mismatch" }],
+    ["response-punctuation", { status: "verified" }],
+  ] as const)(
+    "reports the persisted serving outcome after successful RPC/readiness: %s",
+    async (variation, expected) => {
       await fixture(async ({ verify, seed }) => {
         rpc.mockImplementation(async (options: CallOptions) => {
           options.onHelloOk?.(hello());
@@ -227,7 +267,7 @@ describe("update serving verification", () => {
             result: { meta: { agentMeta: { sessionId: proof.sessionId } } },
           };
         });
-        expect(await verify()).toEqual({ status: "failed", reason: "persistence-missing" });
+        expect(await verify()).toMatchObject(expected);
       });
     },
   );
@@ -287,11 +327,12 @@ describe("update serving verification", () => {
             },
           },
         ]);
-        expect(readUpdateServingTranscript(proof)).toBeUndefined();
+        expect(readUpdateServingTranscript(proof)).toEqual({ status: "not-found" });
       }, toDatabaseOptions(scope));
-      expect(readUpdateServingTranscript(proof)?.transcript.assistant.entryId).toBe(
-        "pending-assistant",
-      );
+      expect(readUpdateServingTranscript(proof)).toMatchObject({
+        status: "persisted",
+        transcript: { assistant: { entryId: "pending-assistant" } },
+      });
     });
   });
 

--- a/src/infra/update-serving-verification.ts
+++ b/src/infra/update-serving-verification.ts
@@ -191,8 +191,11 @@ export async function verifyUpdateServing(
       response,
     };
     const readback = readUpdateServingTranscript(readbackParams);
-    if (!readback) {
-      return { status: "failed", reason: "persistence-missing" };
+    if (readback.status !== "persisted") {
+      return {
+        status: "failed",
+        reason: readback.status === "not-found" ? "persistence-missing" : readback.status,
+      };
     }
     stage = "gateway";
     // The original call closes after its final response. Reconnect explicitly to
@@ -227,7 +230,7 @@ export async function verifyUpdateServing(
     });
     return receipt.success
       ? { status: "verified", receipt: receipt.data }
-      : { status: "failed", reason: "persistence-missing" };
+      : { status: "failed", reason: "turn-incomplete" };
   } catch (error) {
     if (identityFailure) {
       return identityFailure;


### PR DESCRIPTION
Related: #140274

<details>
<summary>Additional instructions</summary>

This is a same-repository branch; maintainers can push updates.

</details>

## What Problem This Solves

Fixes an issue where operators updating a fresh installation could lose automatic rollback and receive misleading verification and recovery reports. In the AWS packaged update lane on `7d95c2f50bb`, the candidate reached verification and persisted its agent turn, but the report called the failure `persistence-missing`, treated the first agent database as migrated state, and told the operator the healthy running candidate remained stopped.

## Why This Change Was Made

The schema comparison now distinguishes first-use database creation from changes to existing databases. New stores at the candidate's supported schema are neutral; real migrations, lost databases, and foreign versions still block rollback. A separate guard checks the previous package's recorded schema support before stopping the candidate or restoring code, so neutral creation cannot authorize an incompatible rollback.

Fresh transcript readback distinguishes absent persistence, incomplete evidence, and a completed response that does not match. It accepts the run-specific token as a whole word within punctuation or a short sentence while preserving run identity, lineage, provider/model metadata, stop reason, bounded reads, and the final snapshot checks. Final recovery guidance uses the latest service observation and retains the verified version only while the same process remains running.

The served-and-persisted check remains mandatory with its existing time budget. No configuration keys, database schemas, or release files change.

## User Impact

Fresh installations retain rollback when both generations support the new database. Operators see the actual serving failure and an actionable repair command in the report, completion notice, and update status. A running but unverified candidate is identified as running, with its version when known.

## Evidence

- Reproduced all three defects before production edits: first persisted agent turn blocked rollback, saved mismatched/punctuated replies reported missing persistence, and running-candidate guidance claimed the service remained stopped. Real shared migrations and foreign-schema controls continued to reject rollback.
- Independent review found the previous-package compatibility edge case. Two additional regressions reproduced incompatible/unknown prior schema support incorrectly permitting rollback; the guard now refuses before stopping the candidate.
- `pnpm test src/cli/update-cli src/infra/update-serving-verification.test.ts src/infra/update-candidate-state.test.ts src/infra/update-run-report.test.ts`: 587 passed, one existing skip. The test runner rebuilt the runtime for fresh-process proof.
- Full `pnpm check:changed` passed, including production/test types, lint, all three unused-export scans, schema/import guards, and unchanged ratchets.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34057644614) passed for `8554c94630d09c68092dd411c9017651048b84ab`.
- Both edited documentation pages pass MDX validation. Fresh independent Codex P0/P1 review is clean after the compatibility repair.
- The separate AWS lane supplied the packaged journey observation. This PR's proof uses isolated real SQLite, fresh-process checks, and controlled service/provider responses; it does not claim a repeated packaged live journey.
