### PR TITLE
fix(tooling): omit Codex machine squash credit

### DIFF
--- a/scripts/pr-lib/merge-body.mjs
+++ b/scripts/pr-lib/merge-body.mjs
@@ -58,7 +58,7 @@ function trailers(body) {
 function isMachineCredit(line) {
   // Match published machine addresses, never names or provider domains that
   // can also identify human contributors.
-  return /^Co-authored-by:\s*[^<>]+<(?:noreply@anthropic\.com|cursoragent@cursor\.com|amp@ampcode\.com)>$/i.test(
+  return /^Co-authored-by:\s*[^<>]+<(?:noreply@anthropic\.com|cursoragent@cursor\.com|amp@ampcode\.com|codex@openai\.com)>$/i.test(
     line,
   );
 }

--- a/test/scripts/pr-merge.test.ts
+++ b/test/scripts/pr-merge.test.ts
@@ -276,6 +276,26 @@ describePosix("native squash attribution", () => {
     expect(result.mergeBody).toBe(`Repair summary\n\n${previewCredit}\n`);
   });
 
+  it("omits machine author preview credit from a reviewed body while retaining human authors", () => {
+    const humanCredit = "Co-authored-by: Contributor <contributor@example.com>";
+    const result = prepareBody({
+      sourceCommits: [
+        {
+          message: "Repair",
+          author: { name: "Contributor", email: "contributor@example.com" },
+        },
+        {
+          message: "Test fixture",
+          author: { name: "Codex", email: "codex@openai.com" },
+        },
+      ],
+      previewBody: `Repair summary\n\nCo-authored-by: Codex <codex@openai.com>\n${humanCredit}`,
+      overrideBody: "Reviewed correction.\n",
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mergeBody).toBe(`Reviewed correction.\n\n${humanCredit}\n`);
+  });
+
   it("does not trust an unpublished local fixup author for preview credit", () => {
     const previewCredit = "Co-authored-by: Local Fixup <local@example.com>";
     const result = prepareBody({
@@ -325,6 +345,9 @@ describePosix("native squash attribution", () => {
     "Co-authored-by: Amp <amp@ampcode.com>",
     "co-authored-by: Amp <AMP@AMPCODE.COM>",
     "Co-Authored-By: Amp\n <amp@ampcode.com>",
+    "Co-authored-by: Codex <codex@openai.com>",
+    "co-authored-by: Codex <CODEX@OPENAI.COM>",
+    "Co-Authored-By: Codex\n <codex@openai.com>",
   ])("omits imported machine credit while preserving human credit: %j", (machineCredit) => {
     const humanCredit = [
       "Co-authored-by: Claude <claude@example.com>",
@@ -336,6 +359,9 @@ describePosix("native squash attribution", () => {
       "Co-authored-by: Amp <amp@example.com>",
       "Co-authored-by: Human <person@ampcode.com>",
       "Co-authored-by: Other <amp@ampcode.com.example.org>",
+      "Co-authored-by: Codex <codex@example.com>",
+      "Co-authored-by: Human <person@openai.com>",
+      "Co-authored-by: Other <codex@openai.com.example.org>",
     ].join("\n");
     const server = "Co-authored-by: Server <server@example.com>";
     const result = prepareBody({
@@ -357,6 +383,7 @@ describePosix("native squash attribution", () => {
     "Reviewed correction.\n\nCo-authored-by: Claude <noreply@anthropic.com>\n",
     "Reviewed correction.\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\n",
     "Reviewed correction.\n\nCo-authored-by: Amp <amp@ampcode.com>\n",
+    "Reviewed correction.\n\nCo-authored-by: Codex <codex@openai.com>\n",
   ])(
     "requires a reviewed body when the chosen message contains machine credit: %j",
     (overrideBody) => {
@@ -376,6 +403,7 @@ describePosix("native squash attribution", () => {
     "Claude <noreply@anthropic.com>",
     "Cursor <cursoragent@cursor.com>",
     "Amp <amp@ampcode.com>",
+    "Codex <codex@openai.com>",
   ])("rejects machine credit present only in the default server preview: %s", (identity) => {
     const result = prepareBody({
       sourceMessages: ["Repair"],


### PR DESCRIPTION
## What Problem This Solves

Native PR landing can force a Codex coauthor trailer back into a reviewed squash message when an incoming non-merge commit has the Codex machine author address. This blocks the existing requirement to preserve human credit without adding agent attribution. The issue surfaced while preparing #138345; no merge request was sent.

## Why This Change Was Made

Add the exact Codex machine address to the existing shared classifier. Reviewed messages now omit that machine credit while retaining eligible human contributors. Default previews and explicit messages containing machine credit still require the existing reviewed-body correction; names, provider domains and lookalike addresses are not excluded.

Production LOC: +1/-1 (net 0). Tests: +28/-0. No ancestry, merge-admission, queue or attribution-policy change.

## Evidence

- On unchanged main, the complete native attribution suite reported exactly six intended regression failures and 52 passes. With the fix, all 58 tests passed under Node 24.20.0 and Vitest 5.0.0.
- Tests run the real Bash compositor path and synthetic Git histories. The incident regression includes a machine-authored commit with no machine coauthor trailer, preserving the distinction between commit authors and imported trailers.
- The actual captured #138345 preview, source credit and published authors reproduced the unwanted Codex insertion. The repaired helper's output differs only by removal of that trailer; all remaining eligible credits and the reviewed prose remain intact.
- Formatter and whitespace checks passed. Full candidate, separate published-head and independent source/artifact reviews found no actionable issues. [Required CI](https://github.com/openclaw/openclaw/actions/runs/34057924168) passed on `6a1d9c9f36f70c796c87674104e2eebe32d11654`.

Proof used an isolated local environment with no credentials, target network requests or GitHub merge dispatch. GitHub preview transport was supplied from the retained incident capture. Existing checks cover human name/domain lookalikes, folded/case-varied machine trailers, explicit-body bytes, source/merge-author distinctions and queue refusal.
