### PR TITLE
fix(ios): refresh location status after authorization changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5040,6 +5040,8 @@ jobs:
             -only-testing:OpenClawTests/IOSGatewayChatTransportTests \
             -only-testing:OpenClawTests/LocationServiceCallbackTests \
             -only-testing:OpenClawTests/LocationServiceOrderingTests \
+            -only-testing:OpenClawTests/LocationPermissionSummaryTests \
+            -only-testing:OpenClawTests/GatewayConnectionControllerTests \
             -only-testing:OpenClawTests/NodeAppModelInvokeTests \
             -only-testing:OpenClawTests/WatchMessagingInboundTransportTests \
             -only-testing:OpenClawTests/WatchSessionActivationGateTests \

--- a/apps/ios/Sources/Gateway/GatewayConnectionController+Capabilities.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController+Capabilities.swift
@@ -205,11 +205,10 @@ extension GatewayConnectionController {
         permissions["camera"] = AVCaptureDevice.authorizationStatus(for: .video) == .authorized
         permissions["microphone"] = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
         permissions["speechRecognition"] = SFSpeechRecognizer.authorizationStatus() == .authorized
-        let locationStatus = self.locationAuthorizationSnapshot.authorizationStatus
         let locationServicesEnabled = await Self.locationServicesEnabled()
         permissions["location"] = Self.isLocationAvailable(
             servicesEnabled: locationServicesEnabled,
-            status: locationStatus)
+            status: self.locationAuthorizationSnapshot.authorizationStatus)
         permissions["screenRecording"] = RPScreenRecorder.shared().isAvailable
 
         permissions["photos"] = PhotoLibraryAccess.canRead(PhotoLibraryAccess.authorizationStatus())

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -708,6 +708,11 @@ final class GatewayConnectionController {
 
     private func refreshActiveGatewayRegistrationFromSettingsAsync() async {
         guard let appModel else { return }
+        // A queued handoff owns transport recovery; registration must not restart its paused sessions.
+        while self.pendingAutoConnectTask != nil || appModel.hasGatewaySessionResetInFlight {
+            await self.pendingAutoConnectTask?.value
+            await appModel.waitForGatewaySessionResetIfNeeded()
+        }
         guard let cfg = appModel.activeGatewayConnectConfig else { return }
         guard appModel.gatewayAutoReconnectEnabled else { return }
         let generation = appModel.gatewayConnectGeneration
@@ -716,6 +721,7 @@ final class GatewayConnectionController {
             stableID: cfg.stableID,
             deviceAuthGatewayID: cfg.nodeOptions.deviceAuthGatewayID,
             allowStoredDeviceAuth: cfg.nodeOptions.allowStoredDeviceAuth)
+        await appModel.waitForGatewaySessionResetIfNeeded()
         // A replacement route can commit within the same connect generation while permissions are sampled.
         guard appModel.gatewayAutoReconnectEnabled,
               appModel.activeGatewayConnectConfig?.hasSameConnectionInputs(as: cfg) == true
@@ -728,12 +734,16 @@ final class GatewayConnectionController {
             bootstrapToken: cfg.bootstrapToken,
             password: cfg.password,
             nodeOptions: nodeOptions)
+        // Unchanged registration is not a request to recover deliberately stopped transport loops.
+        guard !cfg.hasSameConnectionInputs(as: refreshedConfig) else { return }
         appModel.applyGatewayConnectConfig(refreshedConfig, expectedGeneration: generation)
     }
 
     private func observeGatewayRegistration() {
         withObservationTracking {
             _ = self.appModel?.locationAuthorizationSnapshot
+            // An attempt can invalidate a sampled refresh without replacing the route (for example, cancellation).
+            _ = self.appModel?.gatewayConnectGeneration
             // Startup and target-review resume may install options captured before authorization changed.
             _ = self.appModel?.activeGatewayConnectConfig
         } onChange: { [weak self] in

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -134,6 +134,7 @@ final class GatewayConnectionController {
 
         self.updateFromDiscovery()
         self.observeDiscovery()
+        self.observeGatewayRegistration()
 
         if self.discoveryEnabled, self.localNetworkAccessRequested {
             self.discovery.start()
@@ -715,6 +716,10 @@ final class GatewayConnectionController {
             stableID: cfg.stableID,
             deviceAuthGatewayID: cfg.nodeOptions.deviceAuthGatewayID,
             allowStoredDeviceAuth: cfg.nodeOptions.allowStoredDeviceAuth)
+        // A replacement route can commit within the same connect generation while permissions are sampled.
+        guard appModel.gatewayAutoReconnectEnabled,
+              appModel.activeGatewayConnectConfig?.hasSameConnectionInputs(as: cfg) == true
+        else { return }
         let refreshedConfig = GatewayConnectConfig(
             url: cfg.url,
             stableID: cfg.stableID,
@@ -724,6 +729,20 @@ final class GatewayConnectionController {
             password: cfg.password,
             nodeOptions: nodeOptions)
         appModel.applyGatewayConnectConfig(refreshedConfig, expectedGeneration: generation)
+    }
+
+    private func observeGatewayRegistration() {
+        withObservationTracking {
+            _ = self.appModel?.locationAuthorizationSnapshot
+            // Startup and target-review resume may install options captured before authorization changed.
+            _ = self.appModel?.activeGatewayConnectConfig
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                self.observeGatewayRegistration()
+                await self.refreshActiveGatewayRegistrationFromSettingsAsync()
+            }
+        }
     }
 
     func clearPendingTrustPrompt() {

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -470,7 +470,7 @@ final class NodeAppModel {
     @ObservationIgnored private var operatorTalkConnectionGeneration: UInt64 = 0
     @ObservationIgnored private var operatorTalkHydrationGeneration: UInt64?
     @ObservationIgnored private var credentialHandoffFailureGeneration: UInt64?
-    @ObservationIgnored private(set) var gatewayConnectGeneration: UInt64 = 0
+    private(set) var gatewayConnectGeneration: UInt64 = 0
     private var forceOperatorTalkPermissionUpgradeRequest = false
     @ObservationIgnored private var talkPermissionUpgradeTask: Task<Void, Never>?
     @ObservationIgnored private var talkPermissionUpgradeReconnectTask: Task<Void, Never>?

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 import Foundation
 import Network
 import OpenClawChatUI
@@ -169,7 +170,8 @@ private func waitUntil(
 {
     let deadline = ContinuousClock().now.advanced(by: timeout)
     while !condition(), ContinuousClock().now < deadline {
-        await Task.yield()
+        // Yield can immediately resume this task and starve the asynchronous work being observed.
+        try? await Task.sleep(for: .milliseconds(10))
     }
 }
 
@@ -1683,12 +1685,8 @@ private func waitUntil(
 
         let resetFinished = AsyncStream<Void>.makeStream()
         let resetRelease = AsyncStream<Void>.makeStream()
-        let appModel = NodeAppModel()
+        let appModel = NodeAppModel(locationService: MockLocationService(authorizationStatus: .denied))
         defer { appModel.disconnectGateway() }
-        let currentConfig = try Self.makeGatewayConnectConfig(
-            url: #require(URL(string: "wss://127.0.0.1:1")),
-            stableID: "manual|current.gateway.invalid|443")
-        appModel.applyGatewayConnectConfig(currentConfig)
         let controller = GatewayConnectionController(
             appModel: appModel,
             startDiscovery: false,
@@ -1699,6 +1697,13 @@ private func waitUntil(
                     return
                 }
             })
+        // Use the current registration so lifecycle refresh does not replace a synthetic capability fixture.
+        let currentStableID = "manual|current.gateway.invalid|443"
+        let currentConfig = try Self.makeGatewayConnectConfig(
+            url: #require(URL(string: "wss://127.0.0.1:1")),
+            stableID: currentStableID,
+            nodeOptions: await controller.makeConnectOptions(stableID: currentStableID, deviceAuthGatewayID: nil))
+        appModel.applyGatewayConnectConfig(currentConfig)
         var finishedIterator = resetFinished.stream.makeAsyncIterator()
 
         await controller.connectManual(host: host, port: 443, useTLS: true, forceReconnect: true)
@@ -2174,13 +2179,14 @@ private func waitUntil(
             port: 443,
             useTLS: true,
             lastConnectedAtMs: nil))
-        let appModel = NodeAppModel()
+        let appModel = NodeAppModel(locationService: MockLocationService(authorizationStatus: .denied))
         defer { appModel.disconnectGateway() }
+        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
         let connectedConfig = try Self.makeGatewayConnectConfig(
             url: #require(URL(string: "wss://connected.example.com")),
-            stableID: connectedID)
+            stableID: connectedID,
+            nodeOptions: await controller.makeConnectOptions(stableID: connectedID, deviceAuthGatewayID: nil))
         appModel.applyGatewayConnectConfig(connectedConfig)
-        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
 
         await controller.forgetGateway(stableID: selectedID)
 
@@ -2402,14 +2408,16 @@ private func waitUntil(
         ]
         try await withUserDefaults(updates) {
             let defaults = UserDefaults.standard
-            let appModel = NodeAppModel()
+            let appModel = NodeAppModel(locationService: MockLocationService(authorizationStatus: .denied))
             defer { appModel.disconnectGateway() }
+            let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
             let suspendedConfig = try Self.makeGatewayConnectConfig(
                 url: #require(URL(string: "ws://127.0.0.1:1")),
-                stableID: "manual|127.0.0.1|1")
+                stableID: "manual|127.0.0.1|1",
+                nodeOptions: await controller.makeConnectOptions(
+                    stableID: "manual|127.0.0.1|1", deviceAuthGatewayID: nil))
             appModel.applyGatewayConnectConfig(suspendedConfig)
             appModel.gatewayAutoReconnectEnabled = true
-            let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
             _ = controller.cancelPendingConnectionAttempts(suspendCurrentGateway: true)
 
             await controller.connectManual(host: "invalid.example.com", port: 70000, useTLS: true)
@@ -2674,7 +2682,8 @@ private func waitUntil(
     private static func makeGatewayConnectConfig(
         // Fail locally instead of making lifecycle tests depend on DNS or external network timing.
         url: URL = URL(string: "wss://127.0.0.1:1")!,
-        stableID: String = "manual|gateway.example.com|443") -> GatewayConnectConfig
+        stableID: String = "manual|gateway.example.com|443",
+        nodeOptions: GatewayConnectOptions? = nil) -> GatewayConnectConfig
     {
         GatewayConnectConfig(
             url: url,
@@ -2687,7 +2696,7 @@ private func waitUntil(
             token: "token",
             bootstrapToken: nil,
             password: nil,
-            nodeOptions: self.makeNodeOptions(
+            nodeOptions: nodeOptions ?? self.makeNodeOptions(
                 caps: ["screen", "camera"],
                 commands: ["notify", "location.get"],
                 permissions: ["screen": true]))

--- a/apps/ios/Tests/LocationPermissionSummaryTests.swift
+++ b/apps/ios/Tests/LocationPermissionSummaryTests.swift
@@ -328,6 +328,71 @@ import Testing
         #expect(locationService.stopMonitoringCallCount == 1)
     }
 
+    @MainActor @Test(arguments: [CLAuthorizationStatus.notDetermined, .denied], [false, true])
+    func `location authorization refreshes registration without settings`(
+        initialStatus: CLAuthorizationStatus,
+        authorizationBeforeRegistration: Bool) async throws
+    {
+        let isolation = GatewayRegistryTestIsolation()
+        defer { isolation.restore() }
+        try await withUserDefaults(["location.enabledMode": "whileUsing", "gateway.autoconnect": false]) {
+            let locationService = MockLocationService(authorizationStatus: initialStatus)
+            let appModel = NodeAppModel(locationService: locationService)
+            defer { appModel.disconnectGateway() }
+            let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+            let options = await controller.makeConnectOptions(
+                stableID: "manual|127.0.0.1|1",
+                deviceAuthGatewayID: nil,
+                allowStoredDeviceAuth: false)
+            let config = try GatewayConnectConfig(
+                url: #require(URL(string: "ws://127.0.0.1:1")),
+                stableID: "manual|127.0.0.1|1",
+                tls: nil,
+                token: nil,
+                bootstrapToken: nil,
+                password: nil,
+                nodeOptions: options)
+            if authorizationBeforeRegistration {
+                // Startup and target-review resume can apply options captured before an asynchronous reset.
+                locationService.simulateAuthorizationChange(.authorizedWhenInUse)
+                _ = await controller.makeConnectOptions(stableID: config.stableID, deviceAuthGatewayID: nil)
+                #expect(appModel.activeGatewayConnectConfig == nil)
+            }
+            appModel.applyGatewayConnectConfig(config)
+            #expect(appModel.activeGatewayConnectConfig?.nodeOptions.permissions["location"] == false)
+
+            // The system callback must refresh the advertised permission even when no Settings view exists.
+            if !authorizationBeforeRegistration {
+                locationService.simulateAuthorizationChange(.authorizedWhenInUse)
+            }
+            let granted = await Self.waitForLocationRegistration(true, appModel: appModel)
+            try #require(granted)
+            #expect(appModel.activeGatewayConnectConfig?.stableID == config.stableID)
+            #expect(appModel.activeGatewayConnectConfig?.nodeOptions.allowStoredDeviceAuth == false)
+
+            locationService.simulateAuthorizationChange(.denied)
+            #expect(await Self.waitForLocationRegistration(false, appModel: appModel))
+            appModel.suspendGatewayForTargetReview()
+            locationService.simulateAuthorizationChange(.authorizedAlways)
+            await appModel.waitForGatewaySessionResetIfNeeded()
+            _ = await controller.makeConnectOptions(stableID: config.stableID, deviceAuthGatewayID: nil)
+            #expect(appModel.activeGatewayConnectConfig == nil)
+            #expect(!appModel.gatewayAutoReconnectEnabled)
+            withExtendedLifetime(controller) {}
+        }
+    }
+
+    @MainActor
+    private static func waitForLocationRegistration(_ granted: Bool, appModel: NodeAppModel) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(3))
+        while appModel.activeGatewayConnectConfig?.nodeOptions.permissions["location"] != granted,
+              ContinuousClock.now < deadline
+        {
+            await Task.yield()
+        }
+        return appModel.activeGatewayConnectConfig?.nodeOptions.permissions["location"] == granted
+    }
+
     @MainActor @Test func `node model publishes cached location authorization changes`() {
         let locationService = MockLocationService(
             authorizationStatus: .authorizedWhenInUse,

--- a/apps/ios/Tests/LocationPermissionSummaryTests.swift
+++ b/apps/ios/Tests/LocationPermissionSummaryTests.swift
@@ -382,13 +382,158 @@ import Testing
         }
     }
 
+    @MainActor @Test(arguments: [false, true])
+    func `authorization change waits for forced reset ownership before restoring registration`(
+        supersedingHandoff: Bool) async throws
+    {
+        let isolation = GatewayRegistryTestIsolation()
+        defer { isolation.restore() }
+        try await withUserDefaults(["location.enabledMode": "whileUsing", "gateway.autoconnect": false]) {
+            let replacementHost = "replacement.gateway.invalid"
+            let replacementID = "manual|\(replacementHost)|443"
+            let supersedingHost = "superseding.gateway.invalid"
+            let supersedingID = "manual|\(supersedingHost)|443"
+            GatewayTLSStore.saveFingerprint("replacement-fingerprint", stableID: replacementID)
+            GatewayTLSStore.saveFingerprint("superseding-fingerprint", stableID: supersedingID)
+            defer {
+                GatewayTLSStore.clearFingerprint(stableID: replacementID)
+                GatewayTLSStore.clearFingerprint(stableID: supersedingID)
+            }
+            let resetFinished = AsyncStream<Void>.makeStream()
+            let resetRelease = AsyncStream<Void>.makeStream()
+            let supersedingResetRelease = AsyncStream<Void>.makeStream()
+            defer {
+                resetRelease.continuation.finish()
+                supersedingResetRelease.continuation.finish()
+                resetFinished.continuation.finish()
+            }
+            let locationService = MockLocationService(authorizationStatus: .denied)
+            let appModel = NodeAppModel(locationService: locationService)
+            defer { appModel.disconnectGateway() }
+            var resetCount = 0
+            let controller = GatewayConnectionController(
+                appModel: appModel,
+                startDiscovery: false,
+                forceReconnectReset: { appModel in
+                    await appModel.resetGatewaySessionsForForcedReconnect()
+                    resetCount += 1
+                    let release = resetCount == 1 ? resetRelease.stream : supersedingResetRelease.stream
+                    resetFinished.continuation.yield()
+                    for await _ in release {
+                        return
+                    }
+                })
+            let currentID = "manual|127.0.0.1|1"
+            let options = await controller.makeConnectOptions(
+                stableID: currentID,
+                deviceAuthGatewayID: currentID,
+                allowStoredDeviceAuth: false)
+            let config = try GatewayConnectConfig(
+                url: #require(URL(string: "ws://127.0.0.1:1")),
+                stableID: currentID,
+                tls: nil,
+                token: nil,
+                bootstrapToken: nil,
+                password: nil,
+                nodeOptions: options)
+            appModel.applyGatewayConnectConfig(config)
+            var finishedIterator = resetFinished.stream.makeAsyncIterator()
+            await controller.connectManual(host: replacementHost, port: 443, useTLS: true, forceReconnect: true)
+            _ = await finishedIterator.next()
+
+            locationService.simulateAuthorizationChange(.authorizedWhenInUse)
+            // Hold the handoff beyond the registration deadline: a grant must not recover its stopped loops.
+            #expect(await Self.waitForLocationRegistration(true, appModel: appModel) == false)
+            #expect(!appModel._test_hasGatewayLoopTasks().node)
+            #expect(!appModel._test_hasGatewayLoopTasks().operator)
+
+            if supersedingHandoff {
+                await controller.connectManual(host: supersedingHost, port: 443, useTLS: true, forceReconnect: true)
+                resetRelease.continuation.yield()
+                resetRelease.continuation.finish()
+                _ = await finishedIterator.next()
+                // Completing the captured handoff must not bypass the replacement's reset ownership.
+                #expect(await Self.waitForLocationRegistration(true, appModel: appModel) == false)
+                #expect(!appModel._test_hasGatewayLoopTasks().node)
+                #expect(!appModel._test_hasGatewayLoopTasks().operator)
+            }
+
+            let cancellation = controller.cancelPendingConnectionAttempts()
+            resetRelease.continuation.yield()
+            resetRelease.continuation.finish()
+            supersedingResetRelease.continuation.yield()
+            supersedingResetRelease.continuation.finish()
+            #expect(await Self.waitForLocationRegistration(true, appModel: appModel))
+            #expect(appModel.activeGatewayConnectConfig?.stableID == currentID)
+            #expect(appModel.activeGatewayConnectConfig?.url == config.url)
+            #expect(appModel.activeGatewayConnectConfig?.nodeOptions.deviceAuthGatewayID == currentID)
+            #expect(appModel.activeGatewayConnectConfig?.nodeOptions.allowStoredDeviceAuth == false)
+            #expect(appModel._test_hasGatewayLoopTasks().node)
+            controller.releaseAutoConnectSuppression(after: cancellation)
+            appModel.disconnectGateway()
+            await appModel.waitForGatewaySessionResetIfNeeded()
+            withExtendedLifetime(controller) {}
+        }
+    }
+
+    @MainActor @Test func `connect generation reconciles authorization when the route remains unchanged`() async throws {
+        let isolation = GatewayRegistryTestIsolation()
+        defer { isolation.restore() }
+        try await withUserDefaults(["location.enabledMode": "whileUsing", "gateway.autoconnect": false]) {
+            let locationService = MockLocationService(authorizationStatus: .denied)
+            let appModel = NodeAppModel(locationService: locationService)
+            defer { appModel.disconnectGateway() }
+            let stableID = "manual|127.0.0.1|1"
+            var sourceController: GatewayConnectionController? = GatewayConnectionController(
+                appModel: appModel,
+                startDiscovery: false)
+            weak var sourceLifetime = sourceController
+            let options = try await #require(sourceController).makeConnectOptions(
+                stableID: stableID,
+                deviceAuthGatewayID: stableID,
+                allowStoredDeviceAuth: false)
+            sourceController = nil
+            #expect(sourceLifetime == nil)
+            let config = try GatewayConnectConfig(
+                url: #require(URL(string: "ws://127.0.0.1:1")),
+                stableID: stableID,
+                tls: nil,
+                token: nil,
+                bootstrapToken: nil,
+                password: nil,
+                nodeOptions: options)
+            // Model a grant whose previous refresh was invalidated: neither its callback nor a route change remains.
+            locationService.simulateAuthorizationChange(.authorizedWhenInUse)
+            appModel.applyGatewayConnectConfig(config)
+            let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+            #expect(appModel.activeGatewayConnectConfig?.hasSameConnectionInputs(as: config) == true)
+
+            let generation = appModel.beginGatewayConnectAttempt()
+            #expect(await Self.waitForLocationRegistration(true, appModel: appModel))
+            let refreshed = try #require(appModel.activeGatewayConnectConfig)
+            #expect(refreshed.stableID == config.stableID)
+            #expect(refreshed.url == config.url)
+            #expect(refreshed.tls == nil)
+            #expect(refreshed.token == config.token)
+            #expect(refreshed.bootstrapToken == config.bootstrapToken)
+            #expect(refreshed.password == config.password)
+            #expect(refreshed.nodeOptions.deviceAuthGatewayID == stableID)
+            #expect(refreshed.nodeOptions.allowStoredDeviceAuth == false)
+            #expect(appModel.gatewayConnectGeneration == generation)
+            appModel.disconnectGateway()
+            await appModel.waitForGatewaySessionResetIfNeeded()
+            withExtendedLifetime(controller) {}
+        }
+    }
+
     @MainActor
     private static func waitForLocationRegistration(_ granted: Bool, appModel: NodeAppModel) async -> Bool {
         let deadline = ContinuousClock.now.advanced(by: .seconds(3))
         while appModel.activeGatewayConnectConfig?.nodeOptions.permissions["location"] != granted,
               ContinuousClock.now < deadline
         {
-            await Task.yield()
+            // Yield alone need not let lower-priority permission sampling make progress.
+            try? await Task.sleep(for: .milliseconds(10))
         }
         return appModel.activeGatewayConnectConfig?.nodeOptions.permissions["location"] == granted
     }
@@ -414,7 +559,7 @@ import Testing
 }
 
 @MainActor
-private final class MockLocationService: LocationServicing, @unchecked Sendable {
+final class MockLocationService: LocationServicing, @unchecked Sendable {
     private var status: CLAuthorizationStatus
     private var accuracy: CLAccuracyAuthorization
     private var authorizationChangeHandler: (@MainActor @Sendable (LocationAuthorizationSnapshot) -> Void)?


### PR DESCRIPTION
Closes #138936 (iOS reports location denied while precise location requests succeed).

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled.

</details>

## What Problem This Solves

Fixes an issue where iPhone users granting location access could leave the gateway with an outdated location permission declaration, even while location requests succeeded. Changes made outside OpenClaw Settings were not propagated to registration, and startup or target-review resume could install options captured before authorization changed.

## Why This Change Was Made

The gateway connection controller now observes authorization and active registration changes and uses its existing refresh flow. It samples authorization after the asynchronous services check and discards a refresh if reconnect was disabled or its captured route/config was superseded. Registration waits for current and superseding connection handoffs/resets and skips unchanged options, so it does not restart deliberately paused transport loops. Connection-generation invalidation schedules a fresh reconciliation even when a canceled attempt leaves the active route unchanged.

The change preserves gateway approval rules: a corrected false-to-true declaration may still require the existing permission-upgrade approval. It neither silently grants permissions nor changes pairing policy. Production delta is +28 lines: lifecycle observation, route fencing, and coordination with the existing handoff/reset barriers reuse the canonical refresh path; no new setting, protocol, permission manager, or test-only production seam.

## User Impact

The iPhone keeps its advertised location permission current after grants, revocations, and delayed installation of connection options. An intentionally disconnected phone stays disconnected. This PR requires a future iOS app build; it has not been deployed to the reporting phone.

## Evidence

Base: `f9b94860bd73b4061ee92319b149ed1abb517665`. Final head: `13e587f7a7c89fbf42281015590757a71b6eb419`. The initial regression proof used native commit `7476029fc3ea5c361ab3b074e13ad9c6e36de3fb`; the final follow-up adds CI coverage, cooperative test waits with unchanged deadlines, and reset-owner coordination.

- **Before:** added regression test against unmodified production base fails for all four combinations of initial `.notDetermined`/`.denied` and grant before/after registration: `Expectation failed: granted`. The 23-test suite reports four issues.
- **After:** the original identical suite passes all 23 tests. The initial broader location and connection run passes **105 tests across three suites**. The regression also covers revocation, preserving gateway identity/auth choice, and keeping target-review suspension disconnected.
- The exact combined CI native selection also passes locally: **427 app Swift tests plus 6 logic tests**, with Xcode reporting TEST SUCCEEDED. This checks the newly selected suites together with the existing lifecycle suites.
- Existing gateway approval tests separately pass **4 tests** covering widening/reapproval, false-only metadata, downgrades, and the connection-declared ceiling.
- Required `check:changed` gate passes for all five touched Swift files, including pinned Swift lint/format and native schema guard.
- Independent repository `autoreview`, pinned base/local candidate, P0–P2: **scoped-clean, no findings**.
- Release device build: **passed**, including optimized main app and embedded Watch targets.
- CI now includes the location regression and connection suites in its existing native lifecycle command. Workflow validation passes **437 tests** (2 intentional skips), workflow changed checks pass, and the complete updated patch again passes independent P0–P2 autoreview with no findings.

Focused native command (Xcode 26.6, iOS 26.5 simulator):

```sh
xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw \
  -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
  -parallel-testing-enabled NO \
  -only-testing:OpenClawTests/LocationPermissionSummaryTests \
  -only-testing:OpenClawTests/GatewayConnectionControllerTests \
  -only-testing:OpenClawTests/GatewayReconnectErrorRetentionTests test
```

The before run selects only `LocationPermissionSummaryTests`; the after run adds the connection suites. Actual local invocations pin the simulator UUID and use dedicated DerivedData/SwiftPM directories and separate `.xcresult` bundles.

Release command:

```sh
xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw \
  -configuration Release -destination 'generic/platform=iOS' \
  CODE_SIGNING_ALLOWED=NO build
```

Changed gate:

```sh
node scripts/check-changed.mjs -- \
  apps/ios/Sources/Gateway/GatewayConnectionController.swift \
  apps/ios/Sources/Gateway/GatewayConnectionController+Capabilities.swift \
  apps/ios/Sources/Model/NodeAppModel.swift \
  apps/ios/Tests/LocationPermissionSummaryTests.swift \
  apps/ios/Tests/GatewayConnectionControllerTests.swift
```

**Version/device boundary:** the reporting phone says 2026.8.11; gateway is 2026.9.1. The [current public App Store version](https://apps.apple.com/us/app/openclaw/id6780396132) is 2026.8.11, and immutable mobile ref `refs/openclaw/mobile-releases/ios/2026.8.11-1` resolves to `93706992214eae5785e8dbf9ea9020a3c2bd7511`. The affected registration pattern is present there and on the tested upstream base. Installed phone build number was not independently recovered.

**Live app-to-gateway proof:** the patched Debug app ran through normal onboarding on iPhone 17 Pro Simulator (iOS 26.5), paired with a real isolated OpenClaw 2026.9.1 gateway. No MockLocationService, fake gateway, or screenshot fixture was used. After establishing OS denial and approving the initial node surface, the app stayed on Chat throughout the OS grant, gateway approval, and OS revocation. There was no manual reconnect or return to OpenClaw Settings during those transitions. Apple's `simctl privacy` changed the Simulator's OS authorization for the running app.

Sanitized gateway status receipt:

| Step | Connected | Effective location | Approval state | Pending declared location |
| --- | --- | --- | --- | --- |
| Initially denied, fresh pairing approved | true | false | approved | none |
| OS location grant, automatic registration | true | false | pending-reapproval | true |
| Existing permission-upgrade request approved | true | true | approved | none |
| OS location revoked, automatic registration | true | false | approved | none |

The final revocation leaves zero pending requests. This demonstrates recovery for a previously approved false declaration while preserving the existing approval ceiling. This complete sequence was repeated on the exact final production source, whose three native-file SHA-256 hashes were verified against the committed files. Only the disposable local gateway's requests were approved; it was stopped after proof. Node identifiers, credentials, and endpoints are omitted from this receipt; no coordinates were requested.

**CI follow-up:** [the initial native job](https://github.com/openclaw/openclaw/actions/runs/33953142656/job/101271637979) failed asynchronous completion assertions. Both affected polling helpers now actually suspend between checks instead of spinning on `Task.yield()`; their three-second deadlines and assertions are unchanged. Three synthetic capability fixtures now use the real registration builder with the existing deterministic location service while retaining full-config equality checks; initial OS authorization callbacks must not silently mutate route-stability fixtures. This stronger execution exposed a premature transport restart during forced reset. A new regression fails against `99d719ce` on both premature permission publication and restarted-loop assertions; the owner fix waits for current and superseding handoff/reset ownership and skips identical options. Additional red/green regressions cover a replacement handoff and generation-only invalidation with an unchanged route; neither may strand stale permissions or restart a paused route.

**Physical-device boundary:** `xcrun devicectl list devices` reports no developer-paired devices. The patch has not been installed on the reporting iPhone. The live proof above covers real Simulator OS authorization and gateway pairing/status; physical hardware, Always/background behavior, and the reporting phone's precise initiating timing remain unproven. These limits also explain why the reporting phone has no before/after screenshot pair. The issue contains its earlier successful precise location request and contradictory status observation.

### Final review and CI follow-through

Final-head follow-through for `13e587f7a7c89fbf42281015590757a71b6eb419`:

The final ClawSweeper review accepts the real app-to-Gateway proof and reports no blocking code findings. I independently retrieved the primary sources that its environment could not fetch:

- Apple’s [authorization callback contract (Markdown)](https://developer.apple.com/documentation/corelocation/cllocationmanagerdelegate/locationmanagerdidchangeauthorization%28_%3A%29.md) returned HTTP 200. It documents notification at manager creation and authorization changes, consistent with the startup and later-change regressions here.
- The immutable mobile release commit `93706992214eae5785e8dbf9ea9020a3c2bd7511` has the affected [authorization callback](https://github.com/openclaw/openclaw/blob/93706992214eae5785e8dbf9ea9020a3c2bd7511/apps/ios/Sources/Model/NodeAppModel.swift#L1068), [pre-await authorization sampling](https://github.com/openclaw/openclaw/blob/93706992214eae5785e8dbf9ea9020a3c2bd7511/apps/ios/Sources/Gateway/GatewayConnectionController%2BCapabilities.swift#L208), and [controller initialization](https://github.com/openclaw/openclaw/blob/93706992214eae5785e8dbf9ea9020a3c2bd7511/apps/ios/Sources/Gateway/GatewayConnectionController.swift#L136). GitHub’s blob API returned matching local/remote object hashes for all three files: `ff2a23c11add5cf09c68b1fd5c836d153a76704c`, `61252294a57c836724522a23f26a4e3cc9666714`, and `2c13f0e6501dc705b7ceb8c6f96692d0e25b8432`, respectively. This supplements the review’s fetch limitation; it does not claim the reviewer independently retrieved them.

**Maintainer action needed:** please rerun [checks-ui-e2e (4/13), job 101281308791](https://github.com/openclaw/openclaw/actions/runs/33956702942/job/101281308791). Its failure is `external-session-catalogs.e2e.test.ts:135`, “keeps external transcript authors independent of viewer Morgan”: the uploader-profile link count was 0. The preceding author-name and decoded-avatar assertions passed. This UI test and its harness are unchanged between the previous passing head `99d719ce` and this head; the same shard passed in the previous run. That suggests an unrelated intermittent failure, but the cause is not established. My targeted job rerun was rejected with HTTP 403, “Must have admin rights to Repository.” I have not changed UI tests or pushed an empty commit to restart CI.

Native iOS checks are still running. Exact-head local native tests (427 app Swift tests plus 6 logic tests), Release build, changed checks, independent autoreview, and live Simulator-to-Gateway permission transitions all passed as documented above. Physical-phone installation remains unverified.

