### PR TITLE
fix: clear stale diagnostics after Gateway changes

### DIFF
--- a/docs/web/control-ui/feature-reference.md
+++ b/docs/web/control-ui/feature-reference.md
@@ -94,6 +94,7 @@ Control UI capabilities grouped by area, each with the Gateway RPC methods behin
     - Debug: status/health/models snapshots, event log, manual RPC calls, and a System busyness overlay with live CPU, memory, event-loop delay, and per-disk free-space graphs (`status`, `health`, `models.list`, `system.info`). Connection also shows each mounted local storage volume separately, labeled by its mount path. Disk snapshots refresh every ten seconds; memory-backed filesystems and hidden macOS system volumes are excluded.
     - Lane tables omit disabled, empty lanes, including `hook-dispatch` when HTTP hooks are off. Disabled lanes remain visible while work is running or queued.
     - The event log includes Control UI refresh/RPC timings, slow chat/config render timings, and browser responsiveness entries for long animation frames or long tasks when the browser exposes those PerformanceObserver entry types.
+    - Diagnostic event history belongs to the selected Gateway and authentication context. Applying a different Gateway URL or credential clears the previous history immediately, even if the new connection fails. A reconnect authenticated as a different account also clears it. Reconnects with unchanged authentication preserve history for troubleshooting.
     - Logs: live tail of gateway file logs with filter/export (`logs.tail`).
     - Update: run a package/git update plus restart (`update.run`) with a restart report, then poll `update.status` after reconnect to verify the running gateway version.
 

--- a/docs/web/control-ui/settings.md
+++ b/docs/web/control-ui/settings.md
@@ -322,7 +322,7 @@ The Sessions view owns its query independently of the sidebar. Its people filter
 
 The Sessions view batches bursts of session-change events into a refresh. Event-driven refreshes pause while the browser tab is hidden and catch up once when you return. Changing filters or retrying a failed request still loads immediately.
 
-Live activity entries keep only sanitized summaries and redacted, truncated output previews. Tool argument values are not stored in Activity state; the UI shows that arguments are hidden and records only the argument field count. The in-memory list follows the current browser tab, survives navigation within the Control UI, and resets on page reload, session switch, Gateway switch, or **Clear**.
+Live activity entries keep only sanitized summaries and redacted, truncated output previews. Tool argument values are not stored in Activity state; the UI shows that arguments are hidden and records only the argument field count. The in-memory list follows the current browser tab, survives navigation within the Control UI, and resets on page reload, session switch, Gateway or authentication-context change, or **Clear**. Ordinary reconnects preserve the list and expanded entries.
 
 The Run inspector shows the retained trust domain, ingress, invoker, represented subject, sponsor, agent definition and principal, runtime instance, applicable grants, assurance evidence, lineage, and a bounded decision-receipt list. Every fact has a text evidence state. **Absent** means the owning boundary explicitly recorded no value; **unattributed** means a supported path had no usable invoker; **unknown** means expected evidence is missing or unreadable; and **unsupported** means the path has no Phase 0 evidence contract. Color is supplemental only.
 

--- a/ui/src/app/gateway-observers.ts
+++ b/ui/src/app/gateway-observers.ts
@@ -1,0 +1,57 @@
+import type { EventLogEntry } from "../api/event-log.ts";
+import type { GatewayEventFrame } from "../api/gateway.ts";
+
+export function notifyGatewayObservers<T>(
+  listeners: ReadonlySet<(value: T) => void>,
+  value: T,
+  errorLabel: string,
+  isCurrent?: (value: T) => boolean,
+): void {
+  // Snapshot membership because callbacks may mutate subscriptions or replace their owner.
+  for (const listener of Array.from(listeners)) {
+    if (isCurrent && !isCurrent(value)) {
+      return;
+    }
+    try {
+      listener(value);
+    } catch (error) {
+      console.error(`[gateway] ${errorLabel} handler error:`, error);
+    }
+  }
+}
+
+export function createGatewayEventLog() {
+  let entries: EventLogEntry[] = [];
+  let revision = 0;
+  let recoveryScope: string | null = null;
+  const retire = () => {
+    revision += 1;
+    entries = [];
+    return entries;
+  };
+  return {
+    get entries(): readonly EventLogEntry[] {
+      return entries;
+    },
+    get revision() {
+      return revision;
+    },
+    resetConnection() {
+      recoveryScope = null;
+      return retire();
+    },
+    bindRecoveryScope(value: string | undefined) {
+      const nextScope = value ?? "";
+      const changed = recoveryScope !== null && recoveryScope !== nextScope;
+      recoveryScope = nextScope;
+      return changed ? retire() : null;
+    },
+    record(event: GatewayEventFrame) {
+      entries = [{ ts: Date.now(), event: event.event, payload: event.payload }, ...entries].slice(
+        0,
+        250,
+      );
+      return entries;
+    },
+  };
+}

--- a/ui/src/app/gateway-store.event-log.test.ts
+++ b/ui/src/app/gateway-store.event-log.test.ts
@@ -1,0 +1,246 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EventLogEntry } from "../api/event-log.ts";
+import type { GatewayHelloOk } from "../api/gateway.ts";
+import { setAvatarGatewayOrigin } from "../lib/identity-avatar-context.ts";
+import {
+  createGatewayEvent,
+  createGatewayStoreTestStore,
+  GATEWAY_STORE_TEST_HELLO,
+  stubGatewayStoreTestGlobals,
+} from "./gateway-store.test-support.ts";
+import type { ApplicationGatewayConnectOptions } from "./gateway.ts";
+
+function hello(recoveryScope: string): GatewayHelloOk {
+  return {
+    ...GATEWAY_STORE_TEST_HELLO,
+    auth: { role: "operator", scopes: [], recoveryScope },
+  };
+}
+
+const A_EVENT = createGatewayEvent("chat", { text: "Gateway A message" });
+const B_EVENT = createGatewayEvent("chat", { text: "Gateway B message" });
+const B_URL = "wss://gateway-b.example.test";
+const C_URL = "wss://gateway-c.example.test";
+
+describe("application gateway diagnostic history ownership", () => {
+  let store: ReturnType<typeof createGatewayStoreTestStore>;
+
+  beforeEach(() => {
+    stubGatewayStoreTestGlobals();
+    store = createGatewayStoreTestStore();
+    store.gateway.start();
+    store.current().opts.onHello?.(hello("account-a"));
+    store.current().opts.onEvent?.(A_EVENT);
+  });
+
+  afterEach(() => {
+    store.gateway.stop();
+    setAvatarGatewayOrigin(null);
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["Gateway origin", { gatewayUrl: B_URL }],
+    ["Gateway path", { gatewayUrl: "ws://127.0.0.1:18789/other" }],
+    ["Gateway query", { gatewayUrl: "ws://127.0.0.1:18789/?target=other" }],
+    ["shared token", { token: "synthetic-replacement-token" }],
+    ["password", { password: "synthetic-replacement-password" }],
+    ["bootstrap handoff", { bootstrapToken: "synthetic-bootstrap", bootstrapProfile: "owner" }],
+  ] satisfies Array<[string, ApplicationGatewayConnectOptions]>)(
+    "retires old payloads before connecting with a changed %s",
+    (_name, overrides) => {
+      const { gateway, current } = store;
+      const oldClient = current();
+      const observed = vi.fn<(events: readonly EventLogEntry[]) => void>();
+      gateway.subscribeEventLog(observed);
+
+      gateway.connect(overrides);
+
+      expect(gateway.eventLog).toEqual([]);
+      expect(observed).toHaveBeenLastCalledWith([]);
+      expect(gateway.eventLogRevision).toBe(1);
+      oldClient.opts.onEvent?.(A_EVENT);
+      expect(gateway.eventLog).toEqual([]);
+
+      current().opts.onClose?.({ code: 4008, reason: "rejected", willRetry: false });
+      expect(gateway.eventLog).toEqual([]);
+    },
+  );
+
+  it("publishes each retirement even when the raw log is already empty", () => {
+    const { gateway } = store;
+    const revisions: number[] = [];
+    gateway.subscribeEventLog(() => revisions.push(gateway.eventLogRevision));
+
+    gateway.connect({ gatewayUrl: B_URL });
+    gateway.connect({ gatewayUrl: C_URL });
+
+    expect(revisions).toEqual([1, 2]);
+    expect(gateway.eventLog).toEqual([]);
+  });
+
+  it.each(["transport reconnect", "manual retry", "event gap", "stop/start", "session selection"])(
+    "preserves same-account history through %s",
+    (transition) => {
+      const { gateway, current } = store;
+      const history = gateway.eventLog;
+      switch (transition) {
+        case "transport reconnect":
+          current().opts.onClose?.({ code: 1006, reason: "lost", willRetry: true });
+          break;
+        case "manual retry":
+          gateway.connect({ ...gateway.connection });
+          break;
+        case "event gap":
+          current().opts.onGap?.({ expected: 1, received: 3 });
+          break;
+        case "stop/start":
+          gateway.stop();
+          gateway.start();
+          break;
+        case "session selection":
+          gateway.setSessionKey("agent:main:another");
+          break;
+      }
+      current().opts.onHello?.(hello("account-a"));
+      current().opts.onRecoveryScopeChange?.();
+
+      expect(gateway.eventLog).toBe(history);
+      expect(gateway.eventLogRevision).toBe(0);
+    },
+  );
+
+  it("retires an account change at unchanged settings without requiring presence", () => {
+    const { gateway, current } = store;
+    const observed = vi.fn<(events: readonly EventLogEntry[]) => void>();
+    gateway.subscribeEventLog(observed);
+    current().opts.onClose?.({ code: 1006, reason: "lost", willRetry: true });
+
+    current().opts.onHello?.(hello("account-b"));
+
+    expect(gateway.snapshot.selfUser).toBeNull();
+    expect(gateway.connectionRevision).toBe(0);
+    expect(gateway.eventLog).toEqual([]);
+    expect(gateway.eventLogRevision).toBe(1);
+    expect(observed).toHaveBeenLastCalledWith([]);
+
+    current().opts.onEvent?.(B_EVENT);
+    current().opts.onHello?.(hello("account-b"));
+    current().opts.onRecoveryScopeChange?.();
+    expect(gateway.eventLog.map((event) => event.payload)).toEqual([B_EVENT.payload]);
+    expect(gateway.eventLogRevision).toBe(1);
+  });
+
+  it("preserves authenticated history after a bootstrap handoff is consumed", () => {
+    const { gateway, current } = store;
+    gateway.connect({ bootstrapToken: "synthetic-bootstrap", bootstrapProfile: "owner" });
+    current().opts.onHello?.(hello("account-b"));
+    current().opts.onEvent?.(B_EVENT);
+    const history = gateway.eventLog;
+
+    gateway.connect();
+    current().opts.onHello?.(hello("account-b"));
+
+    expect(gateway.connection.bootstrapToken).toBe("");
+    expect(gateway.eventLog).toBe(history);
+    expect(gateway.eventLogRevision).toBe(1);
+  });
+
+  it.each(["replace", "stop", "record"] as const)(
+    "keeps retirement current when a log subscriber %ss synchronously",
+    (action) => {
+      const { gateway, clients, current } = store;
+      const observed: unknown[][] = [];
+      let armed = true;
+      gateway.subscribeEventLog((events) => {
+        if (!armed || events.length > 0) {
+          return;
+        }
+        armed = false;
+        if (action === "replace") {
+          gateway.connect({ gatewayUrl: C_URL });
+        } else if (action === "stop") {
+          gateway.stop();
+        } else {
+          current().opts.onEvent?.(B_EVENT);
+        }
+      });
+      gateway.subscribeEventLog((events) => observed.push(events.map((event) => event.payload)));
+
+      gateway.connect({ gatewayUrl: B_URL });
+
+      expect(observed).toEqual(action === "record" ? [[B_EVENT.payload]] : [[]]);
+      expect(gateway.eventLog.map((event) => event.payload)).toEqual(
+        action === "record" ? [B_EVENT.payload] : [],
+      );
+      expect(clients[1]?.started).toBe(action === "record" ? 1 : 0);
+      if (action === "replace") {
+        expect(gateway.connection.gatewayUrl).toBe(C_URL);
+        expect(current().started).toBe(1);
+      } else if (action === "stop") {
+        expect(gateway.snapshot.phase).toBe("stopped");
+      }
+    },
+  );
+
+  it.each(["replace", "stop"] as const)(
+    "publishes retirement when a connecting snapshot subscriber %ss the new client",
+    (action) => {
+      const { gateway, clients } = store;
+      const observed = vi.fn<(events: readonly EventLogEntry[]) => void>();
+      gateway.subscribeEventLog(observed);
+      let armed = true;
+      gateway.subscribe((snapshot) => {
+        if (!armed || snapshot.phase !== "connecting" || gateway.connection.gatewayUrl !== B_URL) {
+          return;
+        }
+        armed = false;
+        if (action === "replace") {
+          gateway.connect({ gatewayUrl: C_URL });
+        } else {
+          gateway.stop();
+        }
+      });
+
+      gateway.connect({ gatewayUrl: B_URL });
+
+      expect(observed).toHaveBeenLastCalledWith([]);
+      expect(gateway.eventLog).toEqual([]);
+      expect(clients[1]?.started).toBe(0);
+    },
+  );
+
+  it.each(["replace", "stop"] as const)(
+    "does not publish an account hello after its retirement subscriber %ss the client",
+    (action) => {
+      const { gateway, current } = store;
+      const retired = current();
+      const connectedScopes: Array<string | undefined> = [];
+      gateway.subscribe((snapshot) => {
+        if (snapshot.phase === "connected") {
+          connectedScopes.push(snapshot.hello?.auth?.recoveryScope);
+        }
+      });
+      let armed = true;
+      gateway.subscribeEventLog((events) => {
+        if (!armed || events.length > 0) {
+          return;
+        }
+        armed = false;
+        if (action === "replace") {
+          gateway.connect({ gatewayUrl: C_URL });
+        } else {
+          gateway.stop();
+        }
+      });
+
+      retired.opts.onHello?.(hello("account-b"));
+
+      expect(connectedScopes).toEqual([]);
+      expect(gateway.snapshot.phase).toBe(action === "replace" ? "connecting" : "stopped");
+      expect(gateway.eventLog).toEqual([]);
+    },
+  );
+});

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -38,6 +38,7 @@ import {
   createGatewayControlUiReloadOptions,
   isSameOriginGateway,
 } from "./gateway-control-ui-reload.ts";
+import { createGatewayEventLog, notifyGatewayObservers } from "./gateway-observers.ts";
 import {
   loadGatewaySessionSelection,
   loadSettings,
@@ -64,25 +65,6 @@ function readSuspensionPhase(payload: unknown): ApplicationGatewaySnapshot["susp
     phase === "prepared"
     ? phase
     : undefined;
-}
-
-function notifyGatewayObservers<T>(
-  listeners: ReadonlySet<(value: T) => void>,
-  value: T,
-  errorLabel: string,
-  isCurrent?: (value: T) => boolean,
-): void {
-  // Snapshot membership because callbacks may mutate subscriptions or replace their owner.
-  for (const listener of Array.from(listeners)) {
-    if (isCurrent && !isCurrent(value)) {
-      return;
-    }
-    try {
-      listener(value);
-    } catch (error) {
-      console.error(`[gateway] ${errorLabel} handler error:`, error);
-    }
-  }
 }
 
 function sameSelfUser(
@@ -155,7 +137,16 @@ export function createApplicationGateway(
   const listeners = new Set<(next: ApplicationGatewaySnapshot) => void>();
   const eventListeners = new Set<GatewayEventListener>();
   const eventLogListeners = new Set<(events: readonly EventLogEntry[]) => void>();
-  let eventLog: EventLogEntry[] = [];
+  const eventLog = createGatewayEventLog();
+  const publishEventLogRetirement = (events: readonly EventLogEntry[]) => {
+    // Retirement remains valid after a reentrant stop or same-account client replacement.
+    notifyGatewayObservers(
+      eventLogListeners,
+      events,
+      "event",
+      (current) => current === eventLog.entries,
+    );
+  };
   const clearOfflineIndicatorTimer = () => {
     if (offlineIndicatorTimer !== null) {
       globalThis.clearTimeout(offlineIndicatorTimer);
@@ -345,13 +336,10 @@ export function createApplicationGateway(
         }
       }
     }
-    eventLog = [{ ts: Date.now(), event: event.event, payload: event.payload }, ...eventLog].slice(
-      0,
-      250,
-    );
+    const entries = eventLog.record(event);
     const ownsEventLog = (current: readonly EventLogEntry[]) =>
-      current === eventLog && isCurrentClient(eventClient);
-    notifyGatewayObservers(eventLogListeners, eventLog, "event", ownsEventLog);
+      current === eventLog.entries && isCurrentClient(eventClient);
+    notifyGatewayObservers(eventLogListeners, entries, "event", ownsEventLog);
   };
 
   const connect = (overrides: ApplicationGatewayConnectOptions = {}) => {
@@ -388,6 +376,7 @@ export function createApplicationGateway(
       nextConnection.password !== connection.password ||
       nextConnection.bootstrapToken !== connection.bootstrapToken ||
       nextConnection.bootstrapProfile !== connection.bootstrapProfile;
+    const retiredEventLog = credentialsChanged ? eventLog.resetConnection() : null;
     if (credentialsChanged) {
       connectionRevision += 1;
       void clearStoredChatSnapshots();
@@ -466,6 +455,13 @@ export function createApplicationGateway(
         }
         // A successful hello retires bootstrap; the client has processed any issued device grant.
         connection = { ...connection, bootstrapToken: "", bootstrapProfile: undefined };
+        const retiredAuthLog = eventLog.bindRecoveryScope(hello.auth?.recoveryScope);
+        if (retiredAuthLog) {
+          publishEventLogRetirement(retiredAuthLog);
+          if (!isCurrentClient(nextClient)) {
+            return;
+          }
+        }
         const exactBuildIdentityAvailable = Boolean(hello.server?.buildId?.trim());
         const controlUiBuildFresh = !(
           isSameOriginGateway(nextConnection.gatewayUrl) &&
@@ -660,6 +656,9 @@ export function createApplicationGateway(
       lastErrorCode: null,
       lastErrorAuthReason: null,
     });
+    if (retiredEventLog) {
+      publishEventLogRetirement(retiredEventLog);
+    }
     if (isCurrentClient(nextClient)) {
       nextClient.start();
     }
@@ -676,7 +675,10 @@ export function createApplicationGateway(
       return connectionRevision;
     },
     get eventLog() {
-      return eventLog;
+      return eventLog.entries;
+    },
+    get eventLogRevision() {
+      return eventLog.revision;
     },
     connect,
     setSessionKey: (sessionKey) => {

--- a/ui/src/app/gateway.ts
+++ b/ui/src/app/gateway.ts
@@ -47,6 +47,8 @@ export type ApplicationGateway = {
   readonly connection: ApplicationGatewayConnection;
   readonly connectionRevision: number;
   readonly eventLog: readonly EventLogEntry[];
+  /** Advances when the connection or authentication context retires diagnostic history. */
+  readonly eventLogRevision: number;
   connect: (connection?: ApplicationGatewayConnectOptions) => void;
   setSessionKey: (sessionKey: string) => void;
   start: () => void;

--- a/ui/src/app/overlays-access.test-support.ts
+++ b/ui/src/app/overlays-access.test-support.ts
@@ -52,6 +52,7 @@ export function createGatewayHarness(
     connection: { gatewayUrl: "ws://gateway.test", password: "", token: "", bootstrapToken: "" },
     connectionRevision: 0,
     eventLog: [],
+    eventLogRevision: 0,
     connect,
     setSessionKey() {},
     start() {},

--- a/ui/src/components/command-palette.test.ts
+++ b/ui/src/components/command-palette.test.ts
@@ -54,6 +54,7 @@ function createGateway(
     connection: { gatewayUrl: "ws://localhost", token: "", bootstrapToken: "", password: "" },
     connectionRevision: 0,
     eventLog: [],
+    eventLogRevision: 0,
     connect: () => undefined,
     setSessionKey: () => undefined,
     start: () => undefined,

--- a/ui/src/lib/session-pull-requests.test.ts
+++ b/ui/src/lib/session-pull-requests.test.ts
@@ -55,6 +55,7 @@ function createGatewayHarness() {
     connection: { gatewayUrl: "ws://example.test", token: "", bootstrapToken: "", password: "" },
     connectionRevision: 0,
     eventLog: [],
+    eventLogRevision: 0,
     subscribe: subscribeSnapshots,
     subscribeEvents,
     subscribeEventLog: () => () => {},

--- a/ui/src/lib/session-viewer-presence.test.ts
+++ b/ui/src/lib/session-viewer-presence.test.ts
@@ -38,6 +38,7 @@ function createGatewayHarness() {
     connection: { gatewayUrl: "ws://example.test", token: "", bootstrapToken: "", password: "" },
     connectionRevision: 0,
     eventLog: [],
+    eventLogRevision: 0,
     subscribe: vi.fn((listener: (value: ApplicationGatewaySnapshot) => void) => {
       listeners.add(listener);
       return () => {

--- a/ui/src/pages/activity/activity-page.test.ts
+++ b/ui/src/pages/activity/activity-page.test.ts
@@ -3,8 +3,18 @@
 import { GatewayProtocolRequestError } from "@openclaw/gateway-client/browser";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AuditRunInspectResult } from "../../../../packages/gateway-protocol/src/schema/audit-run.js";
-import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
+import {
+  GatewayRequestError,
+  type GatewayBrowserClient,
+  type GatewayHelloOk,
+} from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import {
+  createGatewayEvent,
+  createGatewayStoreTestStore,
+} from "../../app/gateway-store.test-support.ts";
+import { loadSettings } from "../../app/settings.ts";
+import { setAvatarGatewayOrigin } from "../../lib/identity-avatar-context.ts";
 import type { ActivityRouteData, RunInspectorState } from "./run-inspector-model.ts";
 import type { ActivityEntry } from "./tool-activity.ts";
 import * as liveActivity from "./view.ts";
@@ -13,6 +23,8 @@ import "./activity-page.ts";
 type TestActivityPage = HTMLElement & {
   context: ApplicationContext;
   entries: ActivityEntry[];
+  expandedIds: Set<string>;
+  clearEntries: () => void;
   routeData: ActivityRouteData;
   render: () => unknown;
   runInspector: RunInspectorState;
@@ -43,7 +55,9 @@ function gateway(): ApplicationContext["gateway"] {
   return {
     snapshot,
     eventLog: [],
+    eventLogRevision: 0,
     subscribe: vi.fn(() => () => undefined),
+    subscribeEventLog: vi.fn(() => () => undefined),
     subscribeEvents: vi.fn(() => () => undefined),
   } as unknown as ApplicationContext["gateway"];
 }
@@ -65,8 +79,68 @@ function staleEntry(): ActivityEntry {
   };
 }
 
+const activeGateways = new Set<ApplicationContext["gateway"]>();
+const activePages = new Set<TestActivityPage>();
+
+function activityHello(recoveryScope = "activity-owner-a"): GatewayHelloOk {
+  return {
+    type: "hello-ok",
+    protocol: 1,
+    auth: { role: "operator", scopes: ["operator.read"], recoveryScope },
+  };
+}
+
+function activityGateway() {
+  const store = createGatewayStoreTestStore({
+    settings: {
+      ...loadSettings(),
+      gatewayUrl: "wss://activity.example.test",
+      token: "",
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+    },
+  });
+  activeGateways.add(store.gateway);
+  store.gateway.start();
+  store.current().opts.onHello?.(activityHello());
+  return store;
+}
+
+function bindActivity(source: ApplicationContext["gateway"]): TestActivityPage {
+  const page = document.createElement("openclaw-activity-page") as TestActivityPage;
+  page.context = { gateway: source } as unknown as ApplicationContext;
+  page.routeData = { mode: "live", selector: null };
+  activePages.add(page);
+  page.subscriptions.hostConnected();
+  return page;
+}
+
+function toolEvent(id: string) {
+  return createGatewayEvent("session.tool", {
+    stream: "tool",
+    runId: `run-${id}`,
+    sessionKey: "main",
+    data: {
+      toolCallId: id,
+      name: "read",
+      phase: "result",
+      result: { text: `${id} output` },
+    },
+  });
+}
+
 afterEach(() => {
+  for (const page of activePages) {
+    page.subscriptions.hostDisconnected();
+  }
+  for (const source of activeGateways) {
+    source.stop();
+  }
+  activePages.clear();
+  activeGateways.clear();
+  setAvatarGatewayOrigin(null);
   localStorage.clear();
+  sessionStorage.clear();
 });
 
 describe("ActivityPage gateway lifecycle", () => {
@@ -106,6 +180,102 @@ describe("ActivityPage gateway lifecycle", () => {
     expect(page.entries).toEqual([]);
 
     page.subscriptions.hostDisconnected();
+  });
+
+  it.each(["gateway", "account"] as const)(
+    "retires the mounted session's activity after a %s change",
+    (change) => {
+      const { gateway: source, current } = activityGateway();
+      const page = bindActivity(source);
+      current().opts.onEvent?.(toolEvent("old"));
+      expect(page.entries.map((entry) => entry.outputPreview)).toEqual(["old output"]);
+      page.expandedIds.add(page.entries[0]!.id);
+
+      if (change === "gateway") {
+        source.connect({ gatewayUrl: "wss://other-activity.example.test" });
+      } else {
+        current().opts.onClose?.({ code: 1006, reason: "reconnecting", willRetry: true });
+        current().opts.onHello?.(activityHello("activity-owner-b"));
+      }
+
+      expect(page.entries).toEqual([]);
+      expect(page.expandedIds.size).toBe(0);
+      current().opts.onEvent?.(toolEvent("new"));
+      expect(page.entries.map((entry) => entry.outputPreview)).toEqual(["new output"]);
+    },
+  );
+
+  it("keeps streamed previews and expansion across ordinary appends and reconnects", () => {
+    const { gateway: source, current } = activityGateway();
+    const page = bindActivity(source);
+    current().opts.onEvent?.(toolEvent("first"));
+    const firstId = page.entries[0]!.id;
+    page.expandedIds.add(firstId);
+
+    current().opts.onEvent?.(toolEvent("second"));
+    source.connect();
+    current().opts.onHello?.(activityHello());
+
+    expect(page.entries.map((entry) => entry.outputPreview)).toEqual([
+      "first output",
+      "second output",
+    ]);
+    expect([...page.expandedIds]).toEqual([firstId]);
+  });
+
+  it.each(["stop", "event"] as const)(
+    "retires activity when an earlier reset observer triggers a reentrant %s",
+    (action) => {
+      const { gateway: source, current } = activityGateway();
+      let retiring = false;
+      const unsubscribe = source.subscribeEventLog((events) => {
+        if (!retiring || events.length > 0) {
+          return;
+        }
+        retiring = false;
+        if (action === "stop") {
+          source.stop();
+        } else {
+          current().opts.onEvent?.(toolEvent("new"));
+        }
+      });
+      try {
+        const page = bindActivity(source);
+        current().opts.onEvent?.(toolEvent("old"));
+        retiring = true;
+
+        source.connect({ gatewayUrl: "wss://other-activity.example.test" });
+
+        expect(page.entries.map((entry) => entry.outputPreview)).toEqual(
+          action === "stop" ? [] : ["new output"],
+        );
+        if (action === "stop") {
+          expect(source.snapshot.phase).toBe("stopped");
+        }
+      } finally {
+        unsubscribe();
+      }
+    },
+  );
+
+  it("preserves manual Clear across navigation and unchanged reconnects", () => {
+    const { gateway: source, current } = activityGateway();
+    const firstPage = bindActivity(source);
+    current().opts.onEvent?.(toolEvent("cleared"));
+    firstPage.clearEntries();
+    firstPage.subscriptions.hostDisconnected();
+
+    const nextPage = bindActivity(source);
+    expect(nextPage.entries).toEqual([]);
+    source.connect();
+    current().opts.onHello?.(activityHello());
+    expect(nextPage.entries).toEqual([]);
+    current().opts.onEvent?.(toolEvent("new"));
+    expect(nextPage.entries.map((entry) => entry.outputPreview)).toEqual(["new output"]);
+    nextPage.subscriptions.hostDisconnected();
+
+    const revisitedPage = bindActivity(source);
+    expect(revisitedPage.entries.map((entry) => entry.outputPreview)).toEqual(["new output"]);
   });
 
   it("stores the safe-only inspection response directly", async () => {

--- a/ui/src/pages/activity/activity-page.ts
+++ b/ui/src/pages/activity/activity-page.ts
@@ -51,7 +51,8 @@ import {
 } from "./tool-activity.ts";
 import { renderActivity } from "./view.ts";
 
-let activityClearBoundary: EventLogEntry | undefined;
+// Clear survives navigation without retaining an evicted or retired payload.
+let activityClearBoundary: WeakRef<EventLogEntry> | undefined;
 
 function selectorKey(selector: RunInspectorSelector | null): string | null {
   return selector ? `${selector.kind}:${selector.id}` : null;
@@ -115,7 +116,18 @@ class ActivityPage extends OpenClawLightDomElement {
   private readonly subscriptions = new SubscriptionsController(this).effect(
     () => this.context?.gateway,
     (gateway) => {
+      let eventLogRevision = gateway.eventLogRevision;
       this.applyGatewaySnapshot(gateway, gateway.snapshot, true);
+      const stopEventLog = gateway.subscribeEventLog(() => {
+        const revision = gateway.eventLogRevision;
+        if (this.context.gateway !== gateway || revision === eventLogRevision) {
+          return;
+        }
+        eventLogRevision = revision;
+        activityClearBoundary = undefined;
+        // Log notification precedes event delivery; replay would apply the next event twice.
+        this.resetEntries();
+      });
       const stopEvents = gateway.subscribeEvents((event) => {
         this.applyGatewayEvent(gateway, event, Date.now());
       });
@@ -125,6 +137,7 @@ class ActivityPage extends OpenClawLightDomElement {
       return () => {
         stopGateway();
         stopEvents();
+        stopEventLog();
       };
     },
   );
@@ -483,7 +496,8 @@ class ActivityPage extends OpenClawLightDomElement {
   ) {
     let entries: ActivityEntry[] = [];
     const eventLog = gateway.eventLog;
-    const clearIndex = activityClearBoundary ? eventLog.indexOf(activityClearBoundary) : -1;
+    const clearBoundary = activityClearBoundary?.deref();
+    const clearIndex = clearBoundary ? eventLog.indexOf(clearBoundary) : -1;
     const visibleEvents = clearIndex < 0 ? eventLog : eventLog.slice(0, clearIndex);
     for (const event of visibleEvents.toReversed()) {
       entries = this.reduceGatewayEvent(entries, snapshot, event.event, event.payload, event.ts);
@@ -556,7 +570,12 @@ class ActivityPage extends OpenClawLightDomElement {
   }
 
   private clearEntries() {
-    activityClearBoundary = this.context.gateway.eventLog[0];
+    const boundary = this.context.gateway.eventLog[0];
+    activityClearBoundary = boundary ? new WeakRef(boundary) : undefined;
+    this.resetEntries();
+  }
+
+  private resetEntries() {
     this.entries = [];
     this.expandedIds = new Set();
     this.streamFollow.atBottom = true;

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -202,6 +202,7 @@ function setViewerPresenceContext(page: ChatPage) {
     connection: { gatewayUrl: "ws://example.test", token: "", bootstrapToken: "", password: "" },
     connectionRevision: 0,
     eventLog: [],
+    eventLogRevision: 0,
     connect: vi.fn(),
     setSessionKey: vi.fn(),
     start: vi.fn(),

--- a/ui/src/pages/model-setup/model-setup-first-run.test-support.ts
+++ b/ui/src/pages/model-setup/model-setup-first-run.test-support.ts
@@ -69,6 +69,7 @@ export function createFirstRunContext(refreshError?: string, beforeRefresh?: () 
     },
     connectionRevision: 0,
     eventLog: [],
+    eventLogRevision: 0,
     connect: () => undefined,
     setSessionKey: () => undefined,
     start: () => undefined,

--- a/ui/src/pages/model-setup/model-setup-reconnect.test.ts
+++ b/ui/src/pages/model-setup/model-setup-reconnect.test.ts
@@ -62,6 +62,7 @@ function createFixture() {
     },
     connectionRevision: 0,
     eventLog: [],
+    eventLogRevision: 0,
     connect: vi.fn(),
     setSessionKey: vi.fn(),
     start: vi.fn(),

--- a/ui/src/pages/plugins/plugins-page.test-support.ts
+++ b/ui/src/pages/plugins/plugins-page.test-support.ts
@@ -170,6 +170,7 @@ export function createGateway(client: GatewayBrowserClient, connected = true): G
     connection: { gatewayUrl: "ws://localhost", token: "", password: "", bootstrapToken: "" },
     connectionRevision: 0,
     eventLog: [],
+    eventLogRevision: 0,
     connect: () => undefined,
     setSessionKey: () => undefined,
     start: () => undefined,

--- a/ui/src/pages/skill-workshop/proposals.test.ts
+++ b/ui/src/pages/skill-workshop/proposals.test.ts
@@ -61,6 +61,7 @@ function createFixture(
       connection: { gatewayUrl: "", token: "", bootstrapToken: "", password: "" },
       connectionRevision: 0,
       eventLog: [],
+      eventLogRevision: 0,
       connect: vi.fn(),
       setSessionKey: vi.fn(),
       start: vi.fn(),


### PR DESCRIPTION
Fixes #137108

## What Problem This Solves

Fixes an issue where operators switching Gateway connections continued to see diagnostic event payloads from the previous Gateway in Debug and Live activity.

## Why This Change Was Made

Diagnostic history now retires when a different connection is selected or the accepted handshake changes authentication scope. Activity observes the same retirement while preserving incremental updates and expanded entries during unchanged reconnects.

## User Impact

Switching Gateways or authentication context clears preceding diagnostic data, including when the new connection fails. Ordinary reconnects retain useful troubleshooting history.

## Evidence

- New regression cases fail on the original code with retained messages and Activity previews, then pass with the repair.
- All 257 affected tests, the full changed-path gate, and the UI build passed on Blacksmith Testbox at `e47b00cb3496e7eccf6b586f5d534f7ac2bafee2`.
- The branch was rebased onto `270762e51d6559dfb4ede3f9fd5d8d1aaa342ac4` to follow the Control UI documentation split. Range-diff confirms the unchanged UI patch; all 15 UI source and test files are byte-identical, and the browser dependencies and authentication contracts are unchanged. Only the two documentation updates moved to their new canonical pages.
- [CI checks](https://github.com/openclaw/openclaw/pull/140426/checks) cover production/test types, UI E2E, builds, performance, lint, and docs for the current head.
- The browser scenarios use the real Control UI in Vite source mode with synthetic Gateway replies. Both versions use identical fixtures and a 1440 × 1000 viewport; all four scenarios completed without page errors.
- Independent media review confirmed the visible transitions and preserved expansion on unchanged reconnects. All five public attachments were fetched without authentication and matched the local capture bytes and SHA-256 hashes.

## Visual evidence

| View | Before | After |
| --- | --- | --- |
| Debug after Gateway switch | ![Gateway A message remains alongside B after connecting to Gateway B](https://github.com/user-attachments/assets/2b9ca94f-3210-4dd1-a58c-f0f3efc69c90) | ![Only Gateway B message remains after switching connections](https://github.com/user-attachments/assets/10936ec1-59a1-4f6b-88d4-f99e02fedbb3) |
| Live activity after account change | ![Account A tool preview remains after account B connects](https://github.com/user-attachments/assets/c595a618-aca7-4eb5-b9e2-22f392a0a40b) | ![Previous account tool preview is cleared when account B connects](https://github.com/user-attachments/assets/f8ff1fa3-dcbb-495c-93a5-d9d35c0ba31d) |

### Gateway switch and mounted Activity account-change recording

https://github.com/user-attachments/assets/0ecfd380-0582-4d60-897c-7f1d6040fe15

### Visual verification

- Baseline: 140d9e705ea30fc86a4865cf8e38eca31a74b9dd
- Exact head: `3a072714c5852e9c0d6c1121e8a4d7b74625dcd5`
- Scenario: Switch from Gateway A to B in Debug, then reconnect the same Gateway as a different authenticated account while Live activity stays mounted.
- Runtime/build: Vite source mode captured at e47b00cb3496e7eccf6b586f5d534f7ac2bafee2; reused for the patch-equivalent rebased head after range-diff and relevant runtime/dependency inspection; Node v24.19.0; Chromium 144.0.7559.0; synthetic Gateway fixtures and build labels
- Old Gateway messages after switching: 1 before; 0 after; new Gateway messages remain visible
- Old Activity previews after account change: 1 before; 0 after; the same Activity element remains mounted
- Unchanged reconnect: Preview and expansion preserved before and after
- New account tool event: One new preview after repair; no prior-account preview
- Browser errors: 0 in all before and after scenarios
- Screenshots inspected at original resolution; full recorded sequences reviewed.
- Raw source recordings retained.
- Removing the stale Debug row shortens the page and changes its scroll position.
- Independent review inspected all ten screenshots and full recorded sequences with no blocking findings.
- All five public assets returned HTTP 200 without authentication and matched the complete local bytes and SHA-256 hashes.
- The rebase changes only the canonical locations of the two documentation updates; all 15 changed UI source and test files are byte-identical to the captured head.
