### PR TITLE
docs: remove the empty release-sections nav group

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2305,15 +2305,6 @@
                   "releases/2026.9.1",
                   "releases/2026.8.2",
                   "releases/2026.8.1",
-                  {
-                    "group": "v2026.8.1 sections",
-                    "pages": [
-                      {
-                        "group": "Maintenance changes",
-                        "pages": []
-                      }
-                    ]
-                  },
                   "releases/2026.7.1",
                   "releases/2026.6.11"
                 ]


### PR DESCRIPTION
## What

Removes the now-empty `Release notes > v2026.8.1 sections` group and its empty `Maintenance changes` subgroup from `docs/docs.json`.

## Why

[#140353](https://github.com/openclaw/openclaw/pull/140353) removed the 23 child routes from that group to restore the release route-shape invariant. That left the group itself behind with no pages, which renders as a dead heading in the sidebar.

The child pages remain published and reachable from the `v2026.8.1` index page.

## Validation

```
vitest test/scripts/docs-sync-publish.test.ts   # "keeps generated locale navigation
                                                #  aligned with English routes" passes
node scripts/check-docs-mdx.mjs docs README.md  # passed, 775 files
node scripts/docs-link-audit.mjs                # 8291 links, 0 broken
```

Nav page count unchanged at 598.