### PR TITLE
refactor(tests): retain transport-driven auth dismissal coverage

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -1577,27 +1577,6 @@ extension OnboardingAISetupModel {
     }
 
     #if DEBUG
-    func _test_setProviderAuth(option: AuthOption, sessionID: String) {
-        self.activeAuthOption = option
-        self.providerWizardKind = .auth
-        self.authSessionID = sessionID
-        self.authBusy = true
-    }
-
-    func _test_applyAuthWizardResult(
-        done: Bool,
-        status: String?,
-        error: String?,
-        preparedModelRef: String? = nil)
-    {
-        self.applyAuthWizardResult(
-            done: done,
-            step: nil,
-            status: status,
-            error: error,
-            preparedModelRef: preparedModelRef)
-    }
-
     var _test_authSessionID: String? {
         self.authSessionID
     }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -2183,37 +2183,6 @@ struct OnboardingAISetupTests {
         #expect(OnboardingProviderAuthLink.safeURL("Read https://docs.openclaw.ai/start/faq") == nil)
     }
 
-    @Test func `terminal provider failure remains copyable and can dismiss`() {
-        let model = OnboardingAISetupModel()
-        let option = OnboardingAISetupModel.AuthOption(
-            id: "openai:oauth",
-            brandId: nil,
-            label: "OpenAI",
-            hint: nil,
-            groupLabel: "OpenAI",
-            icon: nil,
-            website: nil,
-            kind: "oauth",
-            featured: true
-        )
-        model._test_setProviderAuth(option: option, sessionID: "finished-session")
-
-        model._test_applyAuthWizardResult(
-            done: true,
-            status: "error",
-            error: "The authorization request was denied."
-        )
-
-        #expect(model.activeAuthOption?.id == option.id)
-        #expect(model.authError?.copyText == "The authorization request was denied.")
-        #expect(model._test_authSessionID == nil)
-        #expect(!model.authBusy)
-
-        model.cancelProviderAuth()
-        #expect(model.activeAuthOption == nil)
-        #expect(model.authError == nil)
-    }
-
     @Test func `provider auth callback reacquires its route after a pre-dispatch disconnect`() async throws {
         let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingProviderAuthReconnectTests"))
         let detections = AISetupSocketGeneration()
@@ -2564,6 +2533,7 @@ struct OnboardingAISetupTests {
                 #expect(sheet.actions["Cancel"] == true)
                 model.cancelProviderAuth()
                 #expect(model.activeAuthOption == nil)
+                #expect(model.authError == nil)
             } else {
                 await waitForAISetupState { model.connected }
                 #expect(model.connected)


### PR DESCRIPTION
## What Problem This Solves

A native onboarding test directly installs private auth state to check error dismissal, duplicating stronger transport-driven coverage and retaining two DEBUG-only methods solely for that shortcut.

## Why This Change Was Made

Remove the redundant direct-state test and its two test-only methods. Add the explicit cleared-error assertion to the existing transport-driven terminal-failure dismissal cases, which already verify the copyable error, inactive session, idle state, and sheet actions.

## User Impact

No release behavior or visual change. Net removal: 30 test lines and 21 DEBUG-only source lines, counted separately. Real request and cancellation ordering coverage remains intact.

## Evidence

The retained transport-driven cases cover terminal errors and dismissal through the existing session fixtures. Local structural checks passed; Swift formatting/lint comparison found no new diagnostics relative to the baseline. Independent review through P2 passed. [Exact-head macOS CI](https://github.com/openclaw/openclaw/actions/runs/34058475625) passed, including the Swift release build and native test job. No AppKit tests or app were executed on the operator desktop.
