### PR TITLE
refactor(tui): remove test-only shutdown timer hooks

### DIFF
--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -1016,7 +1016,6 @@ describe("TUI shutdown safety", () => {
           finishTuiStop = resolve;
         }),
     );
-    const clearTimeoutFn = vi.fn();
     const requestFinish = vi.fn(() => calls.push("finish"));
     const onError = vi.fn((error: unknown) => {
       calls.push("error");
@@ -1032,19 +1031,18 @@ describe("TUI shutdown safety", () => {
       requestFinish,
       onError,
       keepHardExitArmed: false,
-      clearTimeoutFn,
     });
 
     await vi.advanceTimersByTimeAsync(0);
     expect(calls).toEqual(["client", "tui"]);
-    expect(clearTimeoutFn).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(1);
     expect(requestFinish).not.toHaveBeenCalled();
 
     finishTuiStop?.();
     await vi.advanceTimersByTimeAsync(0);
     expect(calls).toEqual(["client", "tui", "error", "finish"]);
     expect(stopTui).toHaveBeenCalledOnce();
-    expect(clearTimeoutFn).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
     expect(onError).toHaveBeenCalledOnce();
     expect(requestFinish).toHaveBeenCalledOnce();
   });
@@ -1093,34 +1091,29 @@ describe("TUI shutdown safety", () => {
   });
 
   it("does not keep a clean standalone TUI alive for the watchdog deadline", () => {
-    const unref = vi.fn();
-    const setTimeoutFn = vi.fn((_callback: () => void, delayMs: number) => {
-      expect(delayMs).toBe(2000);
-      return { unref };
-    });
-    const exit = vi.fn();
-    const writeStderr = vi.fn();
-
-    scheduleProcessExitAfterTuiReturn({ setTimeoutFn, exit, writeStderr });
-
-    expect(setTimeoutFn).toHaveBeenCalledOnce();
-    expect(unref).toHaveBeenCalledOnce();
-    expect(writeStderr).not.toHaveBeenCalled();
-    expect(exit).not.toHaveBeenCalled();
+    const timer = scheduleProcessExitAfterTuiReturn();
+    try {
+      expect(timer.hasRef()).toBe(false);
+    } finally {
+      clearTimeout(timer);
+    }
   });
 
-  it("forces standalone TUI exit on deadline while another handle lingers", async () => {
+  it("forces standalone TUI exit on deadline while another handle lingers", () => {
     vi.useFakeTimers();
     const lingeringHandle = setInterval(() => {}, 60_000);
-    const exit = vi.fn();
-    const writeStderr = vi.fn();
+    const exited = new Error("process exited");
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw exited;
+    });
+    const writeStderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
 
-    const timer = scheduleProcessExitAfterTuiReturn({ exit, writeStderr });
+    const timer = scheduleProcessExitAfterTuiReturn();
 
-    expect((timer as NodeJS.Timeout).hasRef()).toBe(false);
-    await vi.advanceTimersByTimeAsync(1999);
+    expect(timer.hasRef()).toBe(false);
+    vi.advanceTimersByTime(1999);
     expect(exit).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(1);
+    expect(() => vi.advanceTimersByTime(1)).toThrow(exited);
     expect(writeStderr).toHaveBeenCalledWith("openclaw tui forcing process exit after return\n");
     expect(exit).toHaveBeenCalledWith(0);
     clearInterval(lingeringHandle);

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -508,12 +508,6 @@ const TUI_SHUTDOWN_DRAIN_IDLE_MS = 100;
 const TUI_SHUTDOWN_HARD_EXIT_MS = 2000;
 const TUI_PROCESS_EXIT_AFTER_RETURN_MS = 2000;
 
-type TuiProcessExitTimer = {
-  unref?: () => void;
-};
-
-type TuiProcessExitTimeout = (callback: () => void, delayMs: number) => TuiProcessExitTimer;
-
 type TuiShutdownTask = () => void | Promise<void>;
 
 export function beginTuiShutdown(params: {
@@ -526,14 +520,9 @@ export function beginTuiShutdown(params: {
   hardExitMs: number;
   keepHardExitArmed?: boolean;
   onError: (error: unknown) => void;
-  clearTimeoutFn?: (timer: TuiProcessExitTimer) => void;
-  setTimeoutFn?: TuiProcessExitTimeout;
-}): TuiProcessExitTimer {
-  const hardExit = params.setTimeoutFn
-    ? { kind: "custom" as const, timer: params.setTimeoutFn(params.forceExit, params.hardExitMs) }
-    : { kind: "native" as const, timer: setTimeout(params.forceExit, params.hardExitMs) };
-  const hardExitTimer = hardExit.timer;
-  hardExitTimer.unref?.();
+}): ReturnType<typeof setTimeout> {
+  const hardExitTimer = setTimeout(params.forceExit, params.hardExitMs);
+  hardExitTimer.unref();
   // Stop referenced animations before transport teardown can stall or redraw.
   params.disposeStatus();
   void Promise.resolve()
@@ -562,11 +551,7 @@ export function beginTuiShutdown(params: {
     })
     .finally(() => {
       if (params.keepHardExitArmed !== true) {
-        if (params.clearTimeoutFn) {
-          params.clearTimeoutFn(hardExitTimer);
-        } else if (hardExit.kind === "native") {
-          clearTimeout(hardExit.timer);
-        }
+        clearTimeout(hardExitTimer);
       }
       params.disposeStatus();
     })
@@ -632,41 +617,19 @@ export function resolveTuiShutdownHardExitMs(params: { localMode?: boolean } = {
   return TUI_SHUTDOWN_HARD_EXIT_MS + (params.localMode ? resolveLocalRunShutdownGraceMs() : 0);
 }
 
-type ScheduleProcessExitAfterTuiReturnParams = {
-  delayMs?: number;
-  setTimeoutFn?: TuiProcessExitTimeout;
-  exit?: (code?: number) => never | void;
-  writeStderr?: (text: string) => void;
-};
-
 export function scheduleProcessExitAfterTuiReturn(
-  params?: ScheduleProcessExitAfterTuiReturnParams & { setTimeoutFn?: undefined },
-): ReturnType<typeof setTimeout>;
-export function scheduleProcessExitAfterTuiReturn(
-  params: ScheduleProcessExitAfterTuiReturnParams & { setTimeoutFn: TuiProcessExitTimeout },
-): TuiProcessExitTimer;
-export function scheduleProcessExitAfterTuiReturn(
-  params: ScheduleProcessExitAfterTuiReturnParams = {},
-): TuiProcessExitTimer {
+  params: { delayMs?: number } = {},
+): ReturnType<typeof setTimeout> {
   const delayMs = Math.max(0, Math.floor(params.delayMs ?? TUI_PROCESS_EXIT_AFTER_RETURN_MS));
-  const exit = params.exit ?? ((code?: number) => process.exit(code));
-  const writeStderr =
-    params.writeStderr ??
-    ((text: string) => {
-      process.stderr.write(text);
-    });
-  const onTimeout = () => {
+  const timer = setTimeout(() => {
     try {
-      writeStderr("openclaw tui forcing process exit after return\n");
+      process.stderr.write("openclaw tui forcing process exit after return\n");
     } catch {
       // Best effort only; forced exit must not depend on stderr.
     }
-    exit(0);
-  };
-  const timer = params.setTimeoutFn
-    ? params.setTimeoutFn(onTimeout, delayMs)
-    : setTimeout(onTimeout, delayMs);
-  timer.unref?.();
+    process.exit(0);
+  }, delayMs);
+  timer.unref();
   return timer;
 }
 


### PR DESCRIPTION
## What Problem This Solves

TUI shutdown maintained custom timer and process-sink variants used only by its tests. That duplicated the native Node path that standalone TUI and setup actually execute.

## Why This Change Was Made

Use native timers, stderr, and process exit in the shutdown owner; exercise timer state and process sinks through Vitest instead of injecting alternative implementations. Repository-wide callers use none of the removed hooks. Setup's `delayMs` override remains, preserving its longer local cleanup budget. The TUI helpers have no declared package or plugin SDK subpath contract.

History: `dc8f90197e6` introduced the drained-teardown exit path; `f4871eb86b4` added custom/native timer branching for test typing; `78796d8e230` established the setup cleanup budget that this change retains. Follow-up deletion work for #135868.

## User Impact

No intended behavior change. Shutdown ordering, terminal restoration after transport failure, error reporting, watchdog deadlines, unref behavior, and cancellation remain unchanged. Net production −37 lines; tests −7 lines.

## Evidence

- Baseline: 88 TUI tests passed. After: 88 TUI and 75 setup-finalization tests passed.
- Fake-backend PTY lane: 99 tests across 8 files passed. This runs the real TUI loop with a fake backend; it does not establish live Gateway/provider or embedded-persistence behavior.
- Full `node scripts/check-changed.mjs`: exit 0, including typechecking, lint, guards, dead exports, and import cycles. Independent Codex review: scoped-clean through P2.
- No test cases were removed. Coverage mappings for removed injected-hook assertions: `src/tui/tui.test.ts:1007` retains terminal cleanup after transport rejection and now verifies the native timer is removed; `:1093` checks the real watchdog's unreferenced state; `:1102` retains deadline/diagnostic/exit proof through fake timers and process spies. The embedded shutdown cancellation case at `:1080` remains.
- ClawSweeper reviewed exact head `ef7823423d84d62bfcfa8322162ae768a4c28f49`: no findings, security concerns, or rank-up changes requested. Maintainer source review agrees.
