### PR TITLE
test(gateway): preserve saved config in auth reload fixture

### DIFF
--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { WizardStartResult } from "../../packages/gateway-protocol/src/index.js";
+import { collectChangedPaths } from "../config/config-change-paths.js";
 import {
   clearConfigCache,
   clearRuntimeConfigSnapshot,
@@ -271,10 +272,14 @@ describe("gateway e2e", () => {
           callerAuthOverride.rateLimit!.maxAttempts = 99;
           callerTailscaleOverride.preserveFunnel = false;
         }
+        const sourceBeforeLoggingEdit = (await configIO.readConfigFileSnapshot()).sourceConfig;
         const nextLoggingSource = {
-          ...initialConfig,
-          logging: { level: "debug" },
+          ...sourceBeforeLoggingEdit,
+          logging: { ...sourceBeforeLoggingEdit.logging, level: "debug" },
         } satisfies OpenClawConfig;
+        const loggingChanges = new Set<string>();
+        collectChangedPaths(sourceBeforeLoggingEdit, nextLoggingSource, "", loggingChanges);
+        expect([...loggingChanges]).toEqual(["logging.level"]);
         await writeConfigFile(nextLoggingSource);
         await expect
           .poll(() => getRuntimeConfig().logging?.level, { timeout: 5_000, interval: 50 })


### PR DESCRIPTION
The Gateway auth reload tests rebuilt a logging-only update from their initial config object. The first config write and Gateway startup had already added native-session-catalog privacy preferences, metadata, and agent workspace state, so that later write unintentionally removed those fields instead of testing a safe logging reload.

Read the current saved source immediately before the update, preserve existing logging fields, and assert that the only changed path is `logging.level`. All four generated, explicit-override, SecretRef-override, and runtime-override cases retain their source, runtime-auth, policy, and WebSocket reconnection assertions.

Validation on main `62fca0de`: a fresh canonical E2E build, four real Gateway/WebSocket cases failing before the fixture repair with unexpected `plugins`, `meta`, and `agents` changes, then all four passing after the repair. No production code changes; net test LOC +5.

The complete changed-file gate and fresh independent P2 review pass.

Extracted while splitting #135599. Follow-up: audit the other saved-config replacements in the Control UI origin-reload and SecretRef rotation fixtures; their similar pattern is recorded without claiming an independently established failure.
