### PR TITLE
fix: avoid repeated xAI OAuth refresh during discovery

### DIFF
--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -206,6 +206,9 @@ export default defineSingleProviderPluginEntry({
       order: "simple",
       run: async (ctx) => {
         const auth = ctx.resolveProviderAuth(PROVIDER_ID);
+        if (auth.preparationFailed) {
+          return null;
+        }
         const { resolveApiKeyForProvider } =
           await import("openclaw/plugin-sdk/provider-auth-runtime");
         const runtimeAuth = await resolveApiKeyForProvider({
@@ -214,6 +217,8 @@ export default defineSingleProviderPluginEntry({
           ...(ctx.agentDir ? { agentDir: ctx.agentDir } : {}),
           ...(ctx.workspaceDir ? { workspaceDir: ctx.workspaceDir } : {}),
           ...(auth.profileId ? { profileId: auth.profileId, lockedProfile: true } : {}),
+          // Prepared direct auth must not reopen failed profile candidates.
+          ...(!auth.profileId && auth.mode !== "none" ? { allowAuthProfileFallback: false } : {}),
         }).catch(() => undefined);
         const selectedAuth =
           runtimeAuth?.mode === "oauth" && runtimeAuth.apiKey

--- a/test/openai-model-discovery-auth-order.test.ts
+++ b/test/openai-model-discovery-auth-order.test.ts
@@ -3,6 +3,7 @@ import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-cata
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import chutesPlugin from "../extensions/chutes/index.js";
 import { buildOpenAIProvider } from "../extensions/openai/api.js";
+import xaiPlugin from "../extensions/xai/index.js";
 import {
   createExpiredOauthStore,
   readAuthProfileStoreForTest,
@@ -49,6 +50,7 @@ describe("Provider model discovery auth preparation", () => {
   afterEach(async () => {
     clearLiveCatalogCacheForTests();
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     discovery.providers = [];
     await state?.cleanup();
   });
@@ -60,6 +62,7 @@ describe("Provider model discovery auth preparation", () => {
       providerId?: string;
       outcomes?: ProviderCatalogOutcome[];
       timeoutMs?: number;
+      env?: NodeJS.ProcessEnv;
     } = {},
   ) {
     return planOpenClawModelsJson({
@@ -68,7 +71,7 @@ describe("Provider model discovery auth preparation", () => {
         discoveryAuthConfig: config,
         sourceConfigForSecrets: config,
         agentDir,
-        env: {},
+        env: options.env ?? {},
         envFingerprint: {},
         providerDiscoveryProviderIds: [options.providerId ?? "openai"],
         providerDiscoveryTimeoutMs: options.timeoutMs,
@@ -163,85 +166,128 @@ describe("Provider model discovery auth preparation", () => {
     expect(plan.action === "write" ? plan.contents : "").not.toContain(keyA);
   });
 
-  it("continues from failed OAuth to the next configured API-key profile", async () => {
-    const profileA = "openai:oauth-a";
-    const profileB = "openai:api-key-b";
-    const keyB = "selected-profile-b";
-    const config: OpenClawConfig = {
-      auth: {
-        order: {
-          openai: [profileA, profileB],
+  it.each([
+    { providerId: "openai", source: "profile", modelId: "gpt-5.5" },
+    { providerId: "xai", source: "profile", modelId: "grok-4.3" },
+    { providerId: "xai", source: "config", modelId: "grok-4.3" },
+    { providerId: "xai", source: "env", modelId: "grok-4.3" },
+  ])(
+    "continues from failed $providerId OAuth to $source API-key auth without repeating refresh",
+    async ({ providerId, source, modelId }) => {
+      if (providerId === "xai") {
+        xaiPlugin.register(
+          createTestPluginApi({
+            registerProvider: (provider) => {
+              discovery.providers = [provider];
+            },
+          }),
+        );
+      }
+      const profileA = `${providerId}:oauth-a`;
+      const profileB = `${providerId}:api-key-b`;
+      const keyB = "selected-profile-b";
+      const config: OpenClawConfig = {
+        auth: {
+          order: {
+            [providerId]: [profileA, profileB],
+          },
         },
-      },
-    };
-    const store = createExpiredOauthStore({
-      profileId: profileA,
-      provider: "openai",
-      access: "rejected-oauth-a",
-      refresh: "refresh-a",
-    });
-    store.profiles[profileB] = {
-      type: "api_key",
-      provider: "openai",
-      key: keyB,
-    };
-    await state.writeAuthProfiles(store);
-    const events: string[] = [];
-    // Diagnostic copy is independent of refresh selection and loads the full plugin runtime.
-    vi.spyOn(providerRuntime, "buildProviderAuthDoctorHintWithPlugin").mockResolvedValue(undefined);
-    const refresh = vi
-      .spyOn(providerRuntime, "resolveProviderOAuthCredentialWithPlugin")
-      .mockImplementation(async ({ credential }) => {
-        events.push(`refresh:${credential.access}`);
-        throw new Error("synthetic OAuth refresh failure");
+      };
+      const store = createExpiredOauthStore({
+        profileId: profileA,
+        provider: providerId,
+        access: "rejected-oauth-a",
+        refresh: "refresh-a",
       });
-    const { resolveApiKeyForProvider } = providerAuthRuntime;
-    const runtimeAuth = vi
-      .spyOn(providerAuthRuntime, "resolveApiKeyForProvider")
-      .mockImplementation(async (params) => {
-        events.push(`resolve:${params.profileId}`);
-        return resolveApiKeyForProvider(params);
+      if (source === "profile") {
+        store.profiles[profileB] = { type: "api_key", provider: providerId, key: keyB };
+      } else if (source === "config") {
+        config.models = {
+          providers: {
+            [providerId]: {
+              baseUrl: "https://api.x.ai/v1",
+              api: "openai-responses",
+              apiKey: keyB,
+              models: [],
+            },
+          },
+        };
+      } else {
+        vi.stubEnv("XAI_API_KEY", keyB);
+      }
+      await state.writeAuthProfiles(store);
+      const events: string[] = [];
+      // Diagnostic copy is independent of refresh selection and loads the full plugin runtime.
+      vi.spyOn(providerRuntime, "buildProviderAuthDoctorHintWithPlugin").mockResolvedValue(
+        undefined,
+      );
+      const refresh = vi
+        .spyOn(providerRuntime, "resolveProviderOAuthCredentialWithPlugin")
+        .mockImplementation(async ({ credential }) => {
+          events.push(`refresh:${credential.access}`);
+          throw new Error("synthetic OAuth refresh failure");
+        });
+      const { resolveApiKeyForProvider } = providerAuthRuntime;
+      const runtimeAuth = vi
+        .spyOn(providerAuthRuntime, "resolveApiKeyForProvider")
+        .mockImplementation(async (params) => {
+          events.push(`resolve:${params.profileId}`);
+          return resolveApiKeyForProvider(params);
+        });
+      const requests: string[] = [];
+      const outcomes: ProviderCatalogOutcome[] = [];
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+        events.push("catalog");
+        requests.push(new Headers(init?.headers).get("authorization") ?? "");
+        return Response.json({ data: [{ id: modelId, object: "model" }] });
       });
-    const requests: string[] = [];
-    const outcomes: ProviderCatalogOutcome[] = [];
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
-      events.push("catalog");
-      requests.push(new Headers(init?.headers).get("authorization") ?? "");
-      return Response.json({ data: [{ id: "gpt-5.5", object: "model" }] });
-    });
 
-    const plan = await planCatalog(config, store, { outcomes });
+      const plan = await planCatalog(config, store, {
+        providerId,
+        outcomes,
+        ...(source === "env" ? { env: { XAI_API_KEY: keyB } } : {}),
+      });
 
-    expect(refresh).toHaveBeenCalledOnce();
-    expect(refresh).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider: "openai",
-        refresh: true,
-        credential: expect.objectContaining({
-          type: "oauth",
-          provider: "openai",
-          access: "rejected-oauth-a",
-          refresh: "refresh-a",
+      expect(refresh).toHaveBeenCalledOnce();
+      expect(refresh).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: providerId,
+          refresh: true,
+          credential: expect.objectContaining({
+            type: "oauth",
+            provider: providerId,
+            access: "rejected-oauth-a",
+            refresh: "refresh-a",
+          }),
         }),
-      }),
-    );
-    expect(events).toEqual(["refresh:rejected-oauth-a", `resolve:${profileB}`, "catalog"]);
-    expect({
-      runtimeProfiles: runtimeAuth.mock.calls.map(([params]) => ({
-        profileId: params.profileId,
-        lockedProfile: params.lockedProfile,
-      })),
-      requests,
-      outcomes,
-      action: plan.action,
-    }).toEqual({
-      runtimeProfiles: [{ profileId: profileB, lockedProfile: true }],
-      requests: [`Bearer ${keyB}`],
-      outcomes: [{ provider: "openai", profileId: profileB, status: "ready" }],
-      action: "write",
-    });
-    expect(plan.action === "write" ? plan.contents : "").not.toContain("rejected-oauth-a");
-  });
+      );
+      const resolvedProfile = source === "profile" ? profileB : undefined;
+      expect(events).toEqual(["refresh:rejected-oauth-a", `resolve:${resolvedProfile}`, "catalog"]);
+      expect({
+        runtimeProfiles: runtimeAuth.mock.calls.map(([params]) => ({
+          profileId: params.profileId,
+          lockedProfile: params.lockedProfile,
+        })),
+        requests,
+        outcomes,
+        action: plan.action,
+      }).toEqual({
+        runtimeProfiles: [
+          { profileId: resolvedProfile, lockedProfile: resolvedProfile ? true : undefined },
+        ],
+        requests: [`Bearer ${keyB}`],
+        outcomes: [
+          {
+            provider: providerId,
+            ...(resolvedProfile ? { profileId: resolvedProfile } : {}),
+            status: "ready",
+          },
+        ],
+        action: "write",
+      });
+      expect(plan.action === "write" ? plan.contents : "").not.toContain("rejected-oauth-a");
+    },
+  );
 
   it.each(["oauth", "token"] as const)(
     "uses subscription discovery for configured literal %s credentials without a profile",
@@ -356,14 +402,16 @@ describe("Provider model discovery auth preparation", () => {
   });
 
   it.each([
-    { providerId: "chutes", profileCount: 1 },
-    { providerId: "chutes", profileCount: 2 },
-    { providerId: "openai", profileCount: 1 },
+    { providerId: "chutes", profileCount: 1, plugin: chutesPlugin },
+    { providerId: "chutes", profileCount: 2, plugin: chutesPlugin },
+    { providerId: "openai", profileCount: 1, plugin: null },
+    { providerId: "xai", profileCount: 1, plugin: xaiPlugin },
+    { providerId: "xai", profileCount: 2, plugin: xaiPlugin },
   ])(
     "retains the $providerId catalog when all $profileCount OAuth profiles fail preparation",
-    async ({ providerId, profileCount }) => {
-      if (providerId === "chutes") {
-        chutesPlugin.register(
+    async ({ providerId, profileCount, plugin }) => {
+      if (plugin) {
+        plugin.register(
           createTestPluginApi({
             registerProvider: (provider) => {
               discovery.providers = [provider];


### PR DESCRIPTION
Related: #137120

## What Problem This Solves

Fixes an issue where refreshing xAI models could resend an OAuth refresh request after credential preparation had already failed. This also happened when a usable configured API key was available as the fallback. Repeating an ambiguous failed refresh is unsafe for rotating tokens.

## Why This Change Was Made

The xAI catalog now honors exhausted preparation and keeps a prepared environment or configuration fallback from reopening implicit profile selection. It uses the existing runtime auth option for direct fallback attempts; selected stored profiles and genuinely absent catalog auth retain their existing resolution paths.

## User Impact

Model discovery does not repeat failed OAuth preparation. Valid stored, configured, and environment API-key fallbacks still work, and failed discovery retains its existing profile-scoped outcomes and compatible-inventory behavior. No new settings, dependencies, schema changes, or session-pin policy are introduced.

## Evidence

- On unchanged base `e1c1bc37c77f527c4c33b2dc3dd054f0886e1fdc`, the real planner and registered xAI plugin made two refresh attempts for one exhausted profile and four for two. The configured-key fallback also refreshed the failed profile twice. Stored-key fallback controls passed.
- Six focused planner cases pass on the candidate: one/two-profile exhaustion, xAI stored/configured/environment key fallback, and the existing OpenAI stored-key control. All 48 xAI provider tests pass, including genuine absent-auth runtime discovery, OAuth catalog behavior, and API-key fallback.
- Changed-path formatting, typed lint, conflict/assertion/line ratchets, and independent review through P2 pass.
- All seven affected test files and the complete remote changed-path gate pass, including the owning production/test type graphs, lint, boundary checks, and ratchets. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34058774386) is green.
- Real built Gateway `models.list` calls against temporary SQLite auth stores reproduce two failed refresh requests per profile before the fix and one after it. Matched before/after cases cover an ambiguous transport disconnect, two profiles returning HTTP 503, and a usable configured API-key fallback. The fallback still makes one correctly authenticated model request and reports ready.
- Prepared-only reads make no additional provider requests, and persisted credential data remains unchanged in every case. Each Gateway, fixture server, and temporary state directory was cleaned up.

The runtime probes use synthetic credentials and controlled loopback HTTPS through a managed proxy. They establish request count, credential selection, and runtime behavior, not vendor credential acceptance. No provider API contract changes.
