### PR TITLE
fix(plugins): inherit active config for embedded agent runs

### DIFF
--- a/src/plugins/runtime/runtime-embedded-agent.runtime.test.ts
+++ b/src/plugins/runtime/runtime-embedded-agent.runtime.test.ts
@@ -71,34 +71,42 @@ describe("plugin embedded-agent runtime admission", () => {
     mocks.runEmbeddedAgentCore.mockResolvedValue({ payloads: [] });
   });
 
-  it("binds plugin facts and closes the exact prepared admission after success", async () => {
-    await expect(
-      withPluginRuntimePluginIdScope("memory-plugin", () => runPluginEmbeddedAgent(params)),
-    ).resolves.toEqual({ payloads: [] });
+  it.each(["explicit", "runtime"] as const)(
+    "shares %s config between admission and execution and closes admission",
+    async (configSource) => {
+      const runParams = configSource === "explicit" ? params : { ...params, config: undefined };
+      if (configSource === "runtime") {
+        mocks.getRuntimeConfig.mockReturnValueOnce(config);
+      }
+      await expect(
+        withPluginRuntimePluginIdScope("memory-plugin", () => runPluginEmbeddedAgent(runParams)),
+      ).resolves.toEqual({ payloads: [] });
 
-    expect(mocks.prepareAgentRunAdmission).toHaveBeenCalledWith({
-      cfg: config,
-      operationalRunInstance: { instanceId: "instance:run-plugin", runId: "run-plugin" },
-      facts: {
-        runId: "run-plugin",
-        agentId: "researcher",
-        ingress: {
-          kind: "plugin",
-          boundary: "plugin-runtime",
-          rawSourceRef: "memory-plugin",
-          state: "present",
+      expect(mocks.prepareAgentRunAdmission).toHaveBeenCalledWith({
+        cfg: config,
+        operationalRunInstance: { instanceId: "instance:run-plugin", runId: "run-plugin" },
+        facts: {
+          runId: "run-plugin",
+          agentId: "researcher",
+          ingress: {
+            kind: "plugin",
+            boundary: "plugin-runtime",
+            rawSourceRef: "memory-plugin",
+            state: "present",
+          },
         },
-      },
-      onAdmitted: expect.any(Function),
-    });
-    expect(mocks.runEmbeddedAgentCore).toHaveBeenCalledWith(
-      expect.objectContaining({
-        ...params,
-        preparedRunAdmission: expect.objectContaining({ close: mocks.close }),
-      }),
-    );
-    expect(mocks.close).toHaveBeenCalledOnce();
-  });
+        onAdmitted: expect.any(Function),
+      });
+      expect(mocks.runEmbeddedAgentCore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...params,
+          preparedRunAdmission: expect.objectContaining({ close: mocks.close }),
+        }),
+      );
+      expect(mocks.getRuntimeConfig).toHaveBeenCalledTimes(configSource === "runtime" ? 1 : 0);
+      expect(mocks.close).toHaveBeenCalledOnce();
+    },
+  );
 
   it("closes the prepared admission when core execution throws", async () => {
     mocks.runEmbeddedAgentCore.mockRejectedValueOnce(new Error("core failed"));

--- a/src/plugins/runtime/runtime-embedded-agent.runtime.ts
+++ b/src/plugins/runtime/runtime-embedded-agent.runtime.ts
@@ -33,8 +33,9 @@ export const runPluginEmbeddedAgent: PluginRuntime["agent"]["runEmbeddedAgent"] 
   params.abortSignal?.throwIfAborted();
   const decisionOccurrenceId = randomUUID();
   let admittedRunContext: AdmittedRunContext | undefined;
+  const config = params.config ?? getRuntimeConfig();
   const preparedRunAdmission = prepareAgentRunAdmission({
-    cfg: params.config ?? getRuntimeConfig(),
+    cfg: config,
     operationalRunInstance: createOperationalRunInstanceRef(params.runId),
     facts: {
       runId: params.runId,
@@ -77,7 +78,7 @@ export const runPluginEmbeddedAgent: PluginRuntime["agent"]["runEmbeddedAgent"] 
   params.abortSignal?.addEventListener("abort", close, { once: true });
   try {
     params.abortSignal?.throwIfAborted();
-    const result = await runEmbeddedAgentCore({ ...params, preparedRunAdmission });
+    const result = await runEmbeddedAgentCore({ ...params, config, preparedRunAdmission });
     if (admittedRunContext && getAdmittedRunDelegatedAuthority(admittedRunContext)) {
       recordRuntimeActionDecision({
         token: admittedRunContext.executionIdentityToken,


### PR DESCRIPTION
Related: #130706

## What Problem This Solves

Fixes an issue where plugins starting an embedded agent without an explicit config could fail with a missing-agent-roster error despite a configured Gateway. Admission read the active config, but execution did not receive it.

## Why This Change Was Made

Capture the effective config once and pass that same value to admission and execution. The existing registry boundary already captures route inputs before awaited ownership work; explicit config and run cleanup retain their current behavior.

## User Impact

Plugin agent runs inherit the active agents and model aliases when config is omitted. This fixes an existing bug discovered while splitting #130706 into focused repairs.

## Evidence

- Regression failed before the repair; 49 focused runtime, adapter and registry tests passed afterward.
- Real scoped plugin API plus a synthetic HTTP provider: omitted config failed before; omitted and explicit config now resolve `fast` to `fixture-model` and complete successfully. Caller-input mutation controls also passed.
- After a clean rebase onto `9a9b9232`, all changed files and the patch remained byte-identical; 18 adapter tests and the real scoped API/input-mutation HTTP controls passed again.
- Independent P2 review: scoped-clean, zero findings. Full changed-code gate passed, including types, lint and architecture checks.
- Production: +3/-2, net **+1**. Tests: net +8. The added binding keeps both existing owners on one config snapshot.

HTTP proof used isolated local state and a synthetic provider; no authenticated upstream inference is claimed.
