### PR TITLE
fix(models): cap configured output at the final context window

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -16,7 +16,7 @@ Reference for **LLM/model providers** (not chat channels like WhatsApp/Telegram)
     - Model refs use `provider/model` (example: `opencode/claude-opus-4-6`).
     - `agents.defaults.models` stores aliases and per-model settings; `agents.defaults.modelPolicy.allow` is the optional explicit override allowlist.
     - CLI helpers: `openclaw onboard`, `openclaw models list`, `openclaw models set <provider/model>`.
-    - `models.providers.*.maxTokens` sets the provider-level output-token default. On each `models.providers.*.models[]` entry, `contextWindow` declares the native window, `contextTokens` caps active input, and `maxTokens` overrides output capacity for that model.
+    - `models.providers.*.maxTokens` sets the provider-level output-token default. On each `models.providers.*.models[]` entry, `contextWindow` declares the native window, `contextTokens` caps active input, and `maxTokens` overrides output capacity for that model. Configured output limits are clamped to the final native context window when known: the per-model `contextWindow`, otherwise the discovered window.
     - Fallback rules, cooldown probes, and session-override persistence: [Model failover](/concepts/model-failover).
 
   </Accordion>
@@ -695,7 +695,7 @@ Example (OpenAI-compatible):
     - `reasoning: false`
     - `input: ["text"]`
     - `cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }`
-    - `maxTokens: 8192`
+    - `maxTokens`: no fixed default. For OpenAI-compatible Completions, an unknown output limit omits both `max_tokens` and `max_completion_tokens`, letting the provider apply its default.
 
     An omitted `contextWindow` remains unset so authored native-window metadata is unambiguous. When neither discovery nor per-model context metadata is available, context-budget callers use the standard `200000`-token fallback.
 

--- a/src/agents/embedded-agent-runner/model.configured-overrides.ts
+++ b/src/agents/embedded-agent-runner/model.configured-overrides.ts
@@ -547,12 +547,12 @@ export function applyConfiguredProviderOverrides(params: {
     workspaceDir: params.workspaceDir,
     runtimeHooks: params.runtimeHooks,
   });
-  const resolvedContextWindow = metadataOverrideModel?.contextWindow;
+  const contextWindow = metadataOverrideModel?.contextWindow ?? discoveredModel.contextWindow;
   const configuredMaxTokens = metadataOverrideModel?.maxTokens ?? providerConfig.maxTokens;
   const resolvedMaxTokens = configuredMaxTokens ?? discoveredModel.maxTokens;
   const normalizedResolvedMaxTokens = clampModelMaxTokensToContextWindow(
     resolvedMaxTokens,
-    resolvedContextWindow,
+    contextWindow,
   );
   const catalogCompat = mergeModelCompat(
     configuredStaticCatalogModel?.compat,
@@ -620,7 +620,7 @@ export function applyConfiguredProviderOverrides(params: {
             configuredModel: metadataOverrideModel,
             catalogCost: discoveredModel.cost,
           }),
-          contextWindow: resolvedContextWindow ?? discoveredModel.contextWindow,
+          contextWindow,
           contextTokens: metadataOverrideModel?.contextTokens ?? discoveredModel.contextTokens,
           ...(normalizedResolvedMaxTokens !== undefined
             ? {

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2020,27 +2020,33 @@ describe("resolveModel", () => {
     });
   });
 
-  it("marks a provider-level maxTokens override as configured", async () => {
-    mockDiscoveredGroqModel();
-    const cfg = makeProviderConfig("groq", {
-      baseUrl: "https://api.groq.com/openai/v1",
-      api: "openai-completions",
-      maxTokens: 2_048,
-    });
+  it.each([
+    { maxTokens: 2_048, expectedMaxTokens: 2_048 },
+    { maxTokens: 262_144, expectedMaxTokens: 131_072 },
+  ])(
+    "bounds provider maxTokens overrides by the discovered context window ($maxTokens)",
+    async ({ maxTokens, expectedMaxTokens }) => {
+      mockDiscoveredGroqModel();
+      const cfg = makeProviderConfig("groq", {
+        baseUrl: "https://api.groq.com/openai/v1",
+        api: "openai-completions",
+        maxTokens,
+      });
 
-    const result = await resolveModelForTest(
-      "groq",
-      "llama-3.3-70b-versatile",
-      state.agentDir(),
-      cfg,
-    );
-    const model = expectResolvedModel(result);
+      const result = await resolveModelForTest(
+        "groq",
+        "llama-3.3-70b-versatile",
+        state.agentDir(),
+        cfg,
+      );
 
-    expectRecordFields(model, {
-      maxTokens: 2_048,
-      maxTokensSource: "configured",
-    });
-  });
+      expectRecordFields(expectResolvedModel(result), {
+        contextWindow: 131_072,
+        maxTokens: expectedMaxTokens,
+        maxTokensSource: "configured",
+      });
+    },
+  );
 
   it("marks a configured-model top-level maxTokens override as configured", async () => {
     mockDiscoveredGroqModel();


### PR DESCRIPTION
Related: #130706

## What Problem This Solves

Fixes an issue where a provider-level output-token override could exceed a model's discovered context window. For example, a model retaining a 4,096-token window could be sent `max_tokens: 8192` when no per-model window was authored.

## Why This Change Was Made

Resolve the final context window before clamping and use that same value in the returned model. Authored model windows keep precedence; discovered windows now also constrain the output limit. The change removes the later duplicate fallback expression.

## User Impact

Configured output limits respect the model's final native window. Documentation also reflects observed OpenAI-compatible behavior: unknown output limits remain absent from requests instead of receiving a fixed 8,192-token default.

## Evidence

- The oversize regression failed before the repair; 200 focused model and fallback tests passed afterward.
- Actual model resolution and HTTP transport against an isolated synthetic endpoint: `8192` was rejected with HTTP 400; the repaired `4096` request completed with HTTP 200. A smaller output-limit control passed in both versions.
- Actual embedded OpenAI-compatible stream controls verified omission of unknown output limits and transmission of an explicitly configured limit.
- After a clean rebase onto `9a9b9232`, all changed files and the patch remained byte-identical; five focused cases and all seven HTTP controls passed again.
- Independent P2 review: scoped-clean, zero findings. Full changed-code gate passed, including types, lint, docs and architecture checks.
- Production: +3/-3, **net zero**. Tests: net +6. Two documentation lines corrected.

This is a focused repair of an existing bug discovered during #130706 extraction. The HTTP proofs use synthetic local services and declared model limits, not authenticated upstream inference.
