### PR TITLE
fix: keep MiniMax discovery on the selected credential

### DIFF
--- a/extensions/minimax/index.test.ts
+++ b/extensions/minimax/index.test.ts
@@ -92,10 +92,7 @@ describe("minimax provider hooks", () => {
           },
         },
       },
-      resolveProviderApiKey: () => ({
-        apiKey: "explicit-key",
-        discoveryApiKey: "explicit-key",
-      }),
+      resolveProviderApiKey: () => ({ apiKey: undefined }),
       resolveProviderAuth: () => ({
         apiKey: MINIMAX_OAUTH_MARKER,
         discoveryApiKey: "oauth-token",
@@ -111,14 +108,22 @@ describe("minimax provider hooks", () => {
     expect(headers.get("authorization")).toBeNull();
   });
 
-  it.each([
-    { name: "API-key profile without mode metadata", mode: undefined, bearer: false },
-    { name: "API-key profile", mode: "api_key", bearer: false },
-    { name: "token profile", mode: "token", bearer: true },
-    { name: "OAuth profile", mode: "oauth", bearer: true },
-  ] as const)(
-    "uses the selected $name ahead of another OAuth profile through the shared catalog wrapper",
-    async ({ mode, bearer }) => {
+  it.each(
+    (
+      [
+        { name: "API-key profile without mode metadata", mode: undefined, bearer: false },
+        { name: "token profile without mode metadata", mode: undefined, bearer: true },
+        { name: "API-key profile", mode: "api_key", bearer: false },
+        { name: "token profile", mode: "token", bearer: true },
+        { name: "OAuth profile", mode: "oauth", bearer: true },
+      ] as const
+    ).flatMap((entry) => [
+      { ...entry, available: true },
+      { ...entry, available: false },
+    ]),
+  )(
+    "keeps the selected $name coherent through the shared catalog wrapper (available: $available)",
+    async ({ mode, bearer, available }) => {
       const fetchMock = vi.fn(
         async (_input: RequestInfo | URL, _init?: RequestInit) =>
           new Response(JSON.stringify({ data: [{ id: "MiniMax-M3", object: "model" }] })),
@@ -130,7 +135,15 @@ describe("minimax provider hooks", () => {
         name: "MiniMax Provider",
       });
       const portalProvider = requireRegisteredProvider(providers, "minimax-portal");
-      const apiKey = mode === "oauth" ? MINIMAX_OAUTH_MARKER : "selected-profile-credential";
+      const legacyToken = mode === undefined && bearer;
+      const apiKey =
+        mode === "oauth"
+          ? MINIMAX_OAUTH_MARKER
+          : available
+            ? "selected-profile-credential"
+            : mode === "token"
+              ? "MINIMAX_OAUTH_TOKEN"
+              : "MINIMAX_API_KEY";
 
       const result = await runProviderCatalog({
         provider: portalProvider,
@@ -138,19 +151,32 @@ describe("minimax provider hooks", () => {
         env: {},
         resolveProviderApiKey: () => ({
           apiKey,
-          discoveryApiKey: "selected-profile-credential",
+          discoveryApiKey: available ? "selected-profile-credential" : undefined,
           profileId: "minimax-portal:selected",
           ...(mode ? { mode } : {}),
         }),
         resolveProviderAuth: () => ({
-          apiKey: MINIMAX_OAUTH_MARKER,
-          discoveryApiKey: "other-oauth-credential",
-          mode: "oauth",
-          profileId: "minimax-portal:other-oauth",
+          apiKey: legacyToken ? apiKey : MINIMAX_OAUTH_MARKER,
+          discoveryApiKey: legacyToken ? "selected-profile-credential" : "other-oauth-credential",
+          mode: legacyToken ? "token" : "oauth",
+          profileId: legacyToken ? "minimax-portal:selected" : "minimax-portal:other-oauth",
           source: "profile",
         }),
       });
 
+      const canDiscover = available || legacyToken;
+      expect(result?.outcomes).toEqual([
+        {
+          provider: "minimax-portal",
+          profileId: "minimax-portal:selected",
+          status: canDiscover ? "ready" : "unavailable",
+        },
+      ]);
+      if (!canDiscover) {
+        expect(result).toMatchObject({ providers: {} });
+        expect(fetchMock).not.toHaveBeenCalled();
+        return;
+      }
       const provider = result && "provider" in result ? result.provider : undefined;
       expect(provider?.apiKey).toBe(apiKey);
       const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
@@ -160,6 +186,62 @@ describe("minimax provider hooks", () => {
       );
     },
   );
+
+  it.each([
+    {
+      name: "different profiles",
+      selectedProfileId: "minimax-portal:selected",
+      resolvedProfileId: "minimax-portal:other",
+      mode: "token",
+    },
+    {
+      name: "unknown profiles",
+      selectedProfileId: undefined,
+      resolvedProfileId: undefined,
+      mode: undefined,
+    },
+    {
+      name: "different credential modes",
+      selectedProfileId: "minimax-portal:selected",
+      resolvedProfileId: "minimax-portal:selected",
+      mode: "api_key",
+    },
+  ] as const)("does not complete matching markers with $name", async (entry) => {
+    const { providers } = await registerProviderPlugin({
+      plugin: minimaxProviderPlugin,
+      id: "minimax",
+      name: "MiniMax Provider",
+    });
+    const result = await runProviderCatalog({
+      provider: requireRegisteredProvider(providers, "minimax-portal"),
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({
+        apiKey: "MINIMAX_OAUTH_TOKEN",
+        profileId: entry.selectedProfileId,
+        mode: entry.mode,
+      }),
+      resolveProviderAuth: () => ({
+        apiKey: "MINIMAX_OAUTH_TOKEN",
+        discoveryApiKey: "other-profile-token",
+        mode: "token",
+        source: "profile",
+        profileId: entry.resolvedProfileId,
+      }),
+    });
+
+    expect(result).toEqual({
+      providers: {},
+      outcomes: [
+        {
+          provider: "minimax-portal",
+          profileId: entry.selectedProfileId,
+          status: "unavailable",
+        },
+      ],
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
 
   it("uses Bearer discovery auth for MINIMAX_OAUTH_TOKEN", async () => {
     const fetchMock = vi.fn(
@@ -183,10 +265,11 @@ describe("minimax provider hooks", () => {
         mode: "api_key",
       }),
       resolveProviderAuth: () => ({
-        apiKey: "MINIMAX_OAUTH_TOKEN",
-        discoveryApiKey: "oauth-token",
-        mode: "api_key",
-        source: "env",
+        apiKey: MINIMAX_OAUTH_MARKER,
+        discoveryApiKey: "other-oauth-token",
+        mode: "oauth",
+        source: "profile",
+        profileId: "minimax-portal:other-oauth",
       }),
     } as never);
 

--- a/extensions/minimax/provider-registration.ts
+++ b/extensions/minimax/provider-registration.ts
@@ -6,12 +6,14 @@ import type {
   ProviderAuthContext,
   ProviderAuthResult,
   ProviderCatalogContext,
+  ProviderCatalogResult,
   ProviderResolveDynamicModelContext,
   ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/plugin-entry";
 import {
   MINIMAX_OAUTH_MARKER,
   buildOauthProviderAuthResult,
+  isNonSecretApiKeyMarker,
 } from "openclaw/plugin-sdk/provider-auth";
 import { buildOpenAICompatibleLiveProviderCatalog } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-entry";
@@ -150,16 +152,42 @@ async function resolveApiCatalog(ctx: ProviderCatalogContext) {
   });
 }
 
-async function resolvePortalCatalog(ctx: ProviderCatalogContext) {
+async function resolvePortalCatalog(ctx: ProviderCatalogContext): Promise<ProviderCatalogResult> {
   const explicitProvider = ctx.config.models?.providers?.[PORTAL_PROVIDER_ID];
   const apiKeyAuth = ctx.resolveProviderApiKey(PORTAL_PROVIDER_ID);
   const profileAuth = ctx.resolveProviderAuth(PORTAL_PROVIDER_ID, {
     oauthMarker: MINIMAX_OAUTH_MARKER,
   });
   const explicitApiKey = normalizeOptionalString(explicitProvider?.apiKey);
-  const apiKey = apiKeyAuth.apiKey ?? explicitApiKey ?? profileAuth.apiKey;
+  let auth: ReturnType<ProviderCatalogContext["resolveProviderApiKey" | "resolveProviderAuth"]> =
+    apiKeyAuth.apiKey !== undefined
+      ? apiKeyAuth
+      : explicitApiKey
+        ? { apiKey: explicitApiKey }
+        : profileAuth;
+  const { apiKey } = auth;
   if (!apiKey) {
     return null;
+  }
+  if (!normalizeOptionalString(auth.discoveryApiKey) && isNonSecretApiKeyMarker(apiKey)) {
+    // Legacy callbacks may omit material; only matching selection facts can complete it.
+    if (
+      auth.profileId &&
+      profileAuth.source === "profile" &&
+      auth.profileId === profileAuth.profileId &&
+      apiKey === profileAuth.apiKey &&
+      (auth.mode === undefined || auth.mode === profileAuth.mode)
+    ) {
+      auth = profileAuth;
+    }
+    if (!normalizeOptionalString(auth.discoveryApiKey)) {
+      return {
+        providers: {},
+        outcomes: [
+          { provider: PORTAL_PROVIDER_ID, profileId: auth.profileId, status: "unavailable" },
+        ],
+      };
+    }
   }
   const usesPortalBearerAuth =
     apiKeyAuth.apiKey === "MINIMAX_OAUTH_TOKEN" ||
@@ -174,18 +202,13 @@ async function resolvePortalCatalog(ctx: ProviderCatalogContext) {
     baseUrl: explicitBaseUrl || buildMinimaxPortalProvider(ctx.env).baseUrl,
     apiKey,
   });
-  const discoveryAuth = apiKeyAuth.discoveryApiKey
-    ? apiKeyAuth
-    : usesPortalBearerAuth
-      ? profileAuth
-      : apiKeyAuth;
   return await buildOpenAICompatibleLiveProviderCatalog({
     discoveryMode: "strict",
     providerId: PORTAL_PROVIDER_ID,
     providerConfig,
     apiKey,
-    discoveryApiKey: discoveryAuth.discoveryApiKey,
-    profileId: discoveryAuth.profileId,
+    discoveryApiKey: auth.discoveryApiKey,
+    profileId: auth.profileId,
     modelDiscovery: buildMinimaxModelDiscovery(usesPortalBearerAuth ? "oauth" : "api_key"),
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where MiniMax model discovery could use another stored OAuth profile when the selected token profile referred to a missing environment variable.

## Why This Change Was Made

MiniMax now keeps the selected credential's marker, request material, and profile identity together. Missing marker material reports unavailable before requesting models. Legacy callback omissions can still be completed when the profile, marker, and supplied mode identify the same selection.

## User Impact

A missing selected credential no longer silently discovers another account's models. API-key, direct environment, explicit configuration, token, and OAuth precedence and request schemes remain intact.

## Evidence

- Real temporary SQLite auth stores, normal secret activation, implicit-provider discovery, guarded loopback HTTP, and `openclaw models list --all --provider minimax-portal --json` reproduce the before/after behavior. On the base, missing token B sends OAuth A's bearer and publishes A's account-specific model. The fixed head reports B unavailable, sends no catalog request, and omits A's row while keeping the static model inventory.
- API-key, token, OAuth, direct environment, and explicit configuration controls use their own credentials and expected request schemes. Unavailable file/exec refs remain fail-closed; registered device-code methods still skip generic OAuth preparation. Matching legacy callback material remains supported.
- All 122 affected MiniMax, credential-provenance, and auth-order tests pass remotely. The same regression test on the base produces the seven expected failures, while its 25 other cases pass.
- The complete remote changed-path gate passes, including extension and test types, typed lint, formatting, boundary checks, ratchets, and import-cycle checks. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34058969997) is green.

The runtime probes use synthetic credentials and an isolated HTTP fixture. Provider credential acceptance is outside this change.
