### PR TITLE
refactor(mcp): reuse transport config normalization

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1861,7 +1861,7 @@ src/agents/mcp-connection-resolver.ts	2
 src/agents/mcp-http-fetch.ts	3
 src/agents/mcp-json-schema-validator.ts	6
 src/agents/mcp-oauth-store.ts	2
-src/agents/mcp-transport-config.ts	12
+src/agents/mcp-transport-config.ts	5
 src/agents/mcp-transport.ts	2
 src/agents/mcp-ui-resource.ts	4
 src/agents/media-generation-task-status-shared.ts	1

--- a/src/agents/mcp-http.ts
+++ b/src/agents/mcp-http.ts
@@ -4,10 +4,7 @@
  * MCP server setup uses this to validate SSE/streamable HTTP server records,
  * sanitize headers, and redact sensitive URLs in diagnostics.
  */
-import {
-  redactSensitiveUrl,
-  redactSensitiveUrlLikeString,
-} from "@openclaw/net-policy/redact-sensitive-url";
+import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { toMcpStringRecord } from "./mcp-config-shared.js";
 
@@ -75,9 +72,4 @@ export function resolveHttpMcpServerLaunchConfig(
       headers,
     },
   };
-}
-
-/** Describes an HTTP MCP server launch config without leaking URL credentials. */
-export function describeHttpMcpServerLaunchConfig(config: HttpMcpServerLaunchConfig): string {
-  return redactSensitiveUrl(config.url);
 }

--- a/src/agents/mcp-transport-config.ts
+++ b/src/agents/mcp-transport-config.ts
@@ -1,22 +1,20 @@
 /**
  * Resolves MCP transport command, environment, and timeout configuration.
  */
+import { redactSensitiveUrl } from "@openclaw/net-policy/redact-sensitive-url";
 import {
   asPositiveFiniteNumber,
   clampPositiveTimerTimeoutMs,
   resolvePositiveTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
+import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { resolveOpenClawMcpTransportAlias } from "../config/mcp-config-normalize.js";
 import { createDedupeCache } from "../infra/dedupe.js";
 import { logWarn } from "../logger.js";
 import { readTrimmedStringAlias } from "../utils/string-readers.js";
-import {
-  describeHttpMcpServerLaunchConfig,
-  resolveHttpMcpServerLaunchConfig,
-  type HttpMcpTransportType,
-} from "./mcp-http.js";
+import { resolveHttpMcpServerLaunchConfig, type HttpMcpTransportType } from "./mcp-http.js";
 import type { McpOAuthConfig } from "./mcp-oauth-provider.js";
 import {
   describeStdioMcpServerLaunchConfig,
@@ -82,22 +80,12 @@ function warnDroppedStdioEnvOnce(serverName: string, key: string): void {
   );
 }
 
-function getPositiveNumber(rawServer: unknown, keys: readonly string[]): number | undefined {
-  if (!rawServer || typeof rawServer !== "object") {
-    return undefined;
-  }
-  const record = rawServer as Record<string, unknown>;
-  for (const key of keys) {
-    const value = asPositiveFiniteNumber(record[key]);
-    if (value !== undefined) {
-      return value;
-    }
-  }
-  return undefined;
+function getPositiveNumber(rawServer: unknown, key: string): number | undefined {
+  return asPositiveFiniteNumber(asOptionalObjectRecord(rawServer)?.[key]);
 }
 
 function getConnectionTimeoutMs(rawServer: unknown): number {
-  const milliseconds = getPositiveNumber(rawServer, ["connectionTimeoutMs"]);
+  const milliseconds = getPositiveNumber(rawServer, "connectionTimeoutMs");
   if (milliseconds) {
     return clampPositiveTimerTimeoutMs(milliseconds) ?? DEFAULT_CONNECTION_TIMEOUT_MS;
   }
@@ -108,54 +96,21 @@ export function resolveMcpRequestTimeoutMs(
   rawServer: unknown,
   fallbackMs = DEFAULT_REQUEST_TIMEOUT_MS,
 ): number {
-  const milliseconds = getPositiveNumber(rawServer, ["requestTimeoutMs"]);
+  const milliseconds = getPositiveNumber(rawServer, "requestTimeoutMs");
   if (milliseconds) {
     return clampPositiveTimerTimeoutMs(milliseconds) ?? DEFAULT_REQUEST_TIMEOUT_MS;
   }
   return resolvePositiveTimerTimeoutMs(fallbackMs, DEFAULT_REQUEST_TIMEOUT_MS);
 }
 
-function getBooleanField(rawServer: unknown, keys: readonly string[]): boolean | undefined {
-  if (!rawServer || typeof rawServer !== "object") {
-    return undefined;
-  }
-  const record = rawServer as Record<string, unknown>;
-  for (const key of keys) {
-    const value = record[key];
-    if (typeof value === "boolean") {
-      return value;
-    }
-  }
-  return undefined;
+function getBooleanField(rawServer: unknown, key: string): boolean | undefined {
+  const value = asOptionalObjectRecord(rawServer)?.[key];
+  return typeof value === "boolean" ? value : undefined;
 }
 
 function getStringField(rawServer: unknown, keys: readonly string[]): string | undefined {
-  if (!rawServer || typeof rawServer !== "object") {
-    return undefined;
-  }
-  return readTrimmedStringAlias(rawServer as Record<string, unknown>, keys);
-}
-
-function getRequestedTransport(rawServer: unknown): string {
-  if (
-    !rawServer ||
-    typeof rawServer !== "object" ||
-    typeof (rawServer as { transport?: unknown }).transport !== "string"
-  ) {
-    return "";
-  }
-  return normalizeLowercaseStringOrEmpty((rawServer as { transport?: string }).transport);
-}
-
-function getRequestedTransportAlias(rawServer: unknown): HttpMcpTransportType | "" {
-  if (
-    !rawServer ||
-    typeof rawServer !== "object" ||
-    typeof (rawServer as { type?: unknown }).type !== "string"
-  ) {
-    return "";
-  }
-  return resolveOpenClawMcpTransportAlias((rawServer as { type?: string }).type) ?? "";
+  const record = asOptionalObjectRecord(rawServer);
+  return record ? readTrimmedStringAlias(record, keys) : undefined;
 }
 
 function resolveHttpTransportConfig(
@@ -202,8 +157,8 @@ function resolveHttpTransportConfig(
     !Array.isArray((rawServer as { oauth?: unknown }).oauth)
       ? { oauth: (rawServer as { oauth: ResolvedMcpOAuthConfig }).oauth }
       : {}),
-    ...(getBooleanField(rawServer, ["sslVerify"]) !== undefined
-      ? { sslVerify: getBooleanField(rawServer, ["sslVerify"]) }
+    ...(getBooleanField(rawServer, "sslVerify") !== undefined
+      ? { sslVerify: getBooleanField(rawServer, "sslVerify") }
       : {}),
     ...(getStringField(rawServer, ["clientCert"])
       ? { clientCert: getStringField(rawServer, ["clientCert"]) }
@@ -211,10 +166,10 @@ function resolveHttpTransportConfig(
     ...(getStringField(rawServer, ["clientKey"])
       ? { clientKey: getStringField(rawServer, ["clientKey"]) }
       : {}),
-    description: describeHttpMcpServerLaunchConfig(launch.config),
+    description: redactSensitiveUrl(launch.config.url),
     connectionTimeoutMs: getConnectionTimeoutMs(rawServer),
     requestTimeoutMs: resolveMcpRequestTimeoutMs(rawServer),
-    supportsParallelToolCalls: getBooleanField(rawServer, ["supportsParallelToolCalls"]) ?? false,
+    supportsParallelToolCalls: getBooleanField(rawServer, "supportsParallelToolCalls") ?? false,
   };
 }
 
@@ -225,8 +180,12 @@ export function resolveMcpTransportConfig(
   options?: { logWarnings?: boolean },
 ): ResolvedMcpTransportConfig | null {
   const logWarnings = options?.logWarnings !== false;
-  const requestedTransport = getRequestedTransport(rawServer);
-  const requestedTransportAlias = requestedTransport ? "" : getRequestedTransportAlias(rawServer);
+  const requestedTransport = normalizeLowercaseStringOrEmpty(
+    getStringField(rawServer, ["transport"]),
+  );
+  const requestedTransportAlias = requestedTransport
+    ? ""
+    : (resolveOpenClawMcpTransportAlias(getStringField(rawServer, ["type"])) ?? "");
   const effectiveTransport = requestedTransport || requestedTransportAlias;
   const stdioLaunch = resolveStdioMcpServerLaunchConfig(
     rawServer,
@@ -251,7 +210,7 @@ export function resolveMcpTransportConfig(
       description: describeStdioMcpServerLaunchConfig(stdioLaunch.config),
       connectionTimeoutMs: getConnectionTimeoutMs(rawServer),
       requestTimeoutMs: resolveMcpRequestTimeoutMs(rawServer),
-      supportsParallelToolCalls: getBooleanField(rawServer, ["supportsParallelToolCalls"]) ?? false,
+      supportsParallelToolCalls: getBooleanField(rawServer, "supportsParallelToolCalls") ?? false,
     };
   }
 
@@ -268,21 +227,14 @@ export function resolveMcpTransportConfig(
     return null;
   }
 
-  if (effectiveTransport === "streamable-http") {
-    const httpTransport = resolveHttpTransportConfig(
-      serverName,
-      rawServer,
-      "streamable-http",
-      logWarnings,
-    );
-    if (httpTransport) {
-      return httpTransport;
-    }
-  }
-
-  const sseTransport = resolveHttpTransportConfig(serverName, rawServer, "sse", logWarnings);
-  if (sseTransport) {
-    return sseTransport;
+  const httpTransport = resolveHttpTransportConfig(
+    serverName,
+    rawServer,
+    effectiveTransport === "streamable-http" ? "streamable-http" : "sse",
+    logWarnings,
+  );
+  if (httpTransport) {
+    return httpTransport;
   }
 
   const httpLaunch = resolveHttpMcpServerLaunchConfig(rawServer);


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

MCP server configuration repeats object/string checks and revalidates a rejected HTTP configuration under a different transport label. This is the maintainer-requested production deletion pass in the runtime owner neighborhood supporting concern C (stage 3) of the #135868 split.

## Why This Change Was Made

Reuse the canonical object and string readers, narrow private number/boolean readers to the single keys their callers actually supply, resolve the selected HTTP transport once, and call the existing URL redactor directly. This changes no transport selection, network fallback, cleanup evidence, or configuration contract.

## User Impact

Existing behavior is preserved: stdio precedence, canonical transport over type aliases, default SSE, timeout and boolean handling, OAuth/TLS fields, warnings and URL redaction. Production shrinks by 56 lines (+32/−88). Tests and docs are unchanged; tooling is +1/−1 for the required assertion-count ratchet shrink from 12 to 5. No dependencies or config options change.

## Evidence

| Deleted implementation | Evidence and preserved owner |
| --- | --- |
| Duplicate transport/type readers | `src/agents/mcp-transport-config.ts:111,183` now uses the existing string reader and normalization-core, preserving type, trimming, case and blank handling. `docs/plugins/bundles.md:157` retains the canonical transport/default/type-alias contract. |
| Multi-key loops and repeated object guards | `src/agents/mcp-transport-config.ts:83,106`: every private numeric/boolean reader call supplied one literal key; `asOptionalObjectRecord` preserves the old object guard, including arrays. Canonical primitive readers still decide value validity. |
| Repeated failed streamable-HTTP validation as SSE | `src/agents/mcp-transport-config.ts:230`: the HTTP validator's failure predicates depend only on record/URL/scheme, not transport type. Headers are processed only after validation, and successful resolution already returns immediately. This was duplicate config validation, not a network retry. |
| `describeHttpMcpServerLaunchConfig` forwarding export | `src/agents/mcp-transport-config.ts:169`: its sole caller now invokes the identical `redactSensitiveUrl(launch.config.url)`. Repository, SDK, package and docs searches found no other consumer or public export contract. |

`git log -S` for the private transport alias reader, explicit streamable branch, and description wrapper traces to `e357203be57`; no separate compatibility purpose was identified for these implementations. Their actual named contracts remain in the canonical readers and resolver.

Five focused owner/sibling suites passed before and after: 157 tests. A temporary differential probe compared 1,547 config records (canonical/alias precedence, blanks, unsupported values, URLs, stdio and metadata); all outputs are identical. No tests were changed. Full changed checks passed (core and core-test typechecks, lint, all three dead-export scans, cycles and selected guards). Before/after aggregate test durations: 68.20 s / 50.35 s. Exact-head CI [run 34059026701](https://github.com/openclaw/openclaw/actions/runs/34059026701) passed; independent Codex review is scoped-clean through P2.

ClawSweeper reviewed `fa31148cb6ee39d84a419d57b5ed79a86e287177` with no findings or before-merge/rank-up requests. Its source review independently confirmed transport-independent rejection, canonical coercion equivalence and the single description-helper consumer.
