### PR TITLE
feat(crabbox): report cloud bootstrap phase timings

### DIFF
--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -222,6 +222,8 @@ Each enrollment receives short-lived download authority scoped to that live prov
 
 Native dependencies are installed by npm for the cloud machine's operating system and CPU; the archive does not copy the build host's native `node_modules`. Registry access is still required, and this is not an offline dependency bundle. Bootstrap does not select a global OpenClaw installation merely because its version matches.
 
+Bootstrap emits `CRABBOX_PHASE:openclaw-bootstrap-*` markers into the Crabbox command stream for download, installation, verification, plugin activation, and node launch. Crabbox records these as command phase timings; cached runs emit only the work they perform.
+
 The Gateway reuses its prepared archive for subsequent enrollments with the same execution mode. Nodes keep successful installs under `~/.openclaw-worker/node-runtimes/<sha256>`, so a warm image can reuse the exact artifact. A different digest selects a different installation even when the version is unchanged. The runtime archive omits the worker deploy artifacts. After enrollment, OpenClaw `worker-turn` installs the content-addressed worker bundle from a matching archive retained in a prepared project image, or downloads it through the authenticated node channel when that archive is absent. Prepared archives still undergo validation; see [Warm images](/gateway/cloud-workers#warm-images). Codex `remote-exec` starts the managed exec-server directly. Existing placement checks, node-command allowlists, and invocation approval still govern execution.
 
 ### Build a complete custom node package

--- a/extensions/crabbox/src/crabbox-worker-node-enrollment.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-node-enrollment.test.ts
@@ -281,25 +281,19 @@ echo 123
   return { code, output: Buffer.concat(output).toString("utf8") };
 }
 
+async function expectSetupPhases(result: ReturnType<typeof enroll>) {
+  const completed = await result;
+  expect(completed.code).toBe(0);
+  const lines = completed.output.trim().split("\n");
+  // Crabbox consumes these stream markers; successful bootstrap emits no other data.
+  expect(lines.every((line) => /^CRABBOX_PHASE:[a-z.-]{1,80}$/.test(line))).toBe(true);
+  return lines.map((line) => line.slice("CRABBOX_PHASE:".length));
+}
+
 async function readLaunch(stateDir: string) {
   const target = path.join(stateDir, "launch.json");
-  // Child startup follows the test deadline, not waitFor's shorter polling deadline.
-  const watcher = fs.watch(stateDir, { persistent: false });
-  cleanups.push(() => watcher.close());
-  try {
-    await new Promise<void>((resolve, reject) => {
-      const inspect = () => {
-        if (fs.existsSync(target)) {
-          resolve();
-        }
-      };
-      watcher.on("change", inspect);
-      watcher.once("error", reject);
-      inspect();
-    });
-  } finally {
-    watcher.close();
-  }
+  // File watchers can miss a fast atomic rename before their subscription is ready.
+  await expect.poll(() => fs.existsSync(target), { timeout: 30_000 }).toBe(true);
   return JSON.parse(fs.readFileSync(target, "utf8")) as {
     build: string;
     cli: string;
@@ -333,10 +327,7 @@ describe.skipIf(process.platform === "win32")("source node bootstrap", () => {
       ...worker.nodeBootstrap,
       packageRelativePath: `worker-artifacts/${worker.nodeBootstrap.sha256}.tgz`,
     };
-    await expect(enroll(home, nodeBootstrap, undefined, true, workerBundle)).resolves.toEqual({
-      code: 0,
-      output: "",
-    });
+    await expectSetupPhases(enroll(home, nodeBootstrap, undefined, true, workerBundle));
     const archivePath = path.join(
       home,
       ".openclaw-worker",
@@ -369,10 +360,21 @@ describe.skipIf(process.platform === "win32")("source node bootstrap", () => {
       ...worker.nodeBootstrap,
       packageRelativePath: `worker-artifacts/${worker.nodeBootstrap.sha256}.tgz`,
     };
-    await expect(enroll(home, nodeBootstrap, undefined, true, workerBundle)).resolves.toEqual({
-      code: 0,
-      output: "",
-    });
+    expect(
+      await expectSetupPhases(enroll(home, nodeBootstrap, undefined, true, workerBundle)),
+    ).toEqual([
+      "openclaw-bootstrap-preparation",
+      "openclaw-bootstrap-download-connection",
+      "openclaw-bootstrap-download-http-response",
+      "openclaw-bootstrap-download-body",
+      "openclaw-bootstrap-download-connection",
+      "openclaw-bootstrap-download-http-response",
+      "openclaw-bootstrap-download-body",
+      "openclaw-bootstrap-installation",
+      "openclaw-bootstrap-runtime-verification",
+      "openclaw-bootstrap-worker-archive-publication",
+      "openclaw-bootstrap-complete",
+    ]);
     expect(fs.existsSync(path.join(home, ".openclaw"))).toBe(false);
     expect(fs.readdirSync(path.join(home, ".openclaw-worker", "node-runtimes"))).toEqual([
       nodeBootstrap.sha256,
@@ -408,12 +410,24 @@ describe.skipIf(process.platform === "win32")("source node bootstrap", () => {
     expect(fs.readFileSync(path.join(preparedPackage, workerBundle.packageRelativePath))).toEqual(
       workerBytes,
     );
-    await expect(enroll(home, nodeBootstrap, undefined, true, workerBundle)).resolves.toEqual({
-      code: 0,
-      output: "",
-    });
+    expect(
+      await expectSetupPhases(enroll(home, nodeBootstrap, undefined, true, workerBundle)),
+    ).toEqual([
+      "openclaw-bootstrap-preparation",
+      "openclaw-bootstrap-runtime-verification",
+      "openclaw-bootstrap-worker-archive-verification",
+      "openclaw-bootstrap-worker-archive-publication",
+      "openclaw-bootstrap-complete",
+    ]);
     expect(worker.authorizations).toEqual([`Bearer ${workerBundle.token}`]);
-    await expect(enroll(home, nodeBootstrap)).resolves.toEqual({ code: 0, output: "" });
+    expect(await expectSetupPhases(enroll(home, nodeBootstrap))).toEqual([
+      "openclaw-bootstrap-preparation",
+      "openclaw-bootstrap-runtime-verification",
+      "openclaw-bootstrap-activation",
+      "openclaw-bootstrap-plugin-activation",
+      "openclaw-bootstrap-node-launch",
+      "openclaw-bootstrap-complete",
+    ]);
     const launch = await readLaunch(stateDir);
     expect(launch).toMatchObject({
       build: "first",
@@ -437,7 +451,7 @@ describe.skipIf(process.platform === "win32")("source node bootstrap", () => {
     expect(authorizations).toEqual([`Bearer ${nodeBootstrap.token}`]);
     stop();
     fs.rmSync(path.join(stateDir, "launch.json"));
-    await expect(enroll(home, nodeBootstrap)).resolves.toEqual({ code: 0, output: "" });
+    await expectSetupPhases(enroll(home, nodeBootstrap));
     expect((await readLaunch(stateDir)).cli).toBe(launch.cli);
     expect(authorizations).toHaveLength(1);
   }, 30_000);
@@ -445,12 +459,12 @@ describe.skipIf(process.platform === "win32")("source node bootstrap", () => {
   it("selects new source bytes even when the public version has not changed", async () => {
     const { home, stateDir, stop } = testHome();
     const first = await serveArtifact(await packageFixture("first"));
-    await expect(enroll(home, first.nodeBootstrap)).resolves.toEqual({ code: 0, output: "" });
+    await expectSetupPhases(enroll(home, first.nodeBootstrap));
     const oldLaunch = await readLaunch(stateDir);
     stop();
     fs.rmSync(path.join(stateDir, "launch.json"));
     const second = await serveArtifact(await packageFixture("second"));
-    await expect(enroll(home, second.nodeBootstrap)).resolves.toEqual({ code: 0, output: "" });
+    await expectSetupPhases(enroll(home, second.nodeBootstrap));
     const launch = await readLaunch(stateDir);
     expect(launch.build).toBe("second");
     expect(launch.cli).not.toBe(oldLaunch.cli);
@@ -461,10 +475,10 @@ describe.skipIf(process.platform === "win32")("source node bootstrap", () => {
     async () => {
       const { home, stateDir } = testHome();
       const { nodeBootstrap, authorizations } = await serveArtifact(await packageFixture("first"));
-      await expect(enroll(home, nodeBootstrap)).resolves.toEqual({ code: 0, output: "" });
+      await expectSetupPhases(enroll(home, nodeBootstrap));
       await readLaunch(stateDir);
       const pid = fs.readFileSync(path.join(stateDir, "node.pid"), "utf8");
-      await expect(enroll(home, nodeBootstrap)).resolves.toEqual({ code: 0, output: "" });
+      await expectSetupPhases(enroll(home, nodeBootstrap));
       expect(fs.readFileSync(path.join(stateDir, "node.pid"), "utf8")).toBe(pid);
       expect(authorizations).toHaveLength(1);
       const rejected = await enroll(home, { ...nodeBootstrap, sha256: "b".repeat(64) });
@@ -527,7 +541,7 @@ describe.skipIf(process.platform === "win32")("source node bootstrap", () => {
       ),
     });
     expect(authorizations).toHaveLength(0);
-    await expect(enroll(home, nodeBootstrap)).resolves.toEqual({ code: 0, output: "" });
+    await expectSetupPhases(enroll(home, nodeBootstrap));
     expect((await readLaunch(stateDir)).build).toBe("tls");
     expect(authorizations).toEqual([`Bearer ${nodeBootstrap.token}`]);
   }, 30_000);
@@ -546,10 +560,7 @@ describe.runIf(hasBashMapfile)("Crabbox desktop node bootstrap", () => {
     async ({ enabled, runtimeDir }) => {
       const { home, stateDir } = testHome();
       const { nodeBootstrap } = await serveArtifact(await packageFixture("desktop"));
-      await expect(enroll(home, nodeBootstrap, { enabled, runtimeDir })).resolves.toEqual({
-        code: 0,
-        output: "",
-      });
+      await expectSetupPhases(enroll(home, nodeBootstrap, { enabled, runtimeDir }));
       const launch = await readLaunch(stateDir);
       expect(launch.enabledPlugins).toEqual(enabled ? ["demo", "cua-computer"] : ["demo"]);
       expect(launch.environment).toEqual(

--- a/extensions/crabbox/src/crabbox-worker-node-enrollment.ts
+++ b/extensions/crabbox/src/crabbox-worker-node-enrollment.ts
@@ -75,7 +75,13 @@ const setupCode = process.env.${CLOUD_SETUP_CODE_ENV};
 delete process.env.${CLOUD_BOOTSTRAP_TOKEN_ENV};
 delete process.env.${CLOUD_SETUP_CODE_ENV};
 process.umask(0o077);
-let phase = "preparation";
+let phase;
+const setPhase = (next) => {
+  if (phase === next) return;
+  phase = next;
+  console.error("CRABBOX_PHASE:openclaw-bootstrap-" + next.toLowerCase().replaceAll(" ", "-"));
+};
+setPhase("preparation");
 (async () => {
   let tokens;
   try { tokens = JSON.parse(credentials || "{}"); }
@@ -114,12 +120,13 @@ let phase = "preparation";
       if (!nodeInvocation || fs.realpathSync(path.join("/proc", pidText, "cwd")) !== runtimeDir || !env.includes("OPENCLAW_STATE_DIR=" + stateDir)) {
         throw new Error("Cloud worker node is running a different bootstrap artifact or invocation; release and reprovision the worker");
       }
+      setPhase("complete");
       return;
     }
     fs.unlinkSync(pidFile);
   }
   const verifyRuntime = (root) => {
-    phase = "runtime verification";
+    setPhase("runtime verification");
     if (!fs.lstatSync(root).isDirectory() || fs.realpathSync(root) !== root) throw new Error("Cloud worker bootstrap runtime path is unsafe");
     const packageRoot = path.join(root, "node_modules", "openclaw");
     const manifest = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"));
@@ -141,7 +148,7 @@ let phase = "preparation";
     if (bytes !== artifact.bytes || hash.digest("hex") !== artifact.sha256) throw new Error("Cloud worker bootstrap archive failed integrity verification");
   };
   const downloadArchive = async (artifact, token, archive) => {
-    phase = "download connection";
+    setPhase("download connection");
     if (!token) throw new Error("Cloud worker bootstrap download authority is unavailable");
     const url = new URL(artifact.url);
     if (!["http:", "https:"].includes(url.protocol) || url.username || url.password || url.search || url.hash || (artifact.tlsFingerprint && url.protocol !== "https:")) throw new Error("Cloud worker bootstrap artifact transport is invalid");
@@ -155,8 +162,8 @@ let phase = "preparation";
     });
     // Observe transport progress without changing when the pinned request may send credentials.
     request.once("socket", (socket) => {
-      socket.once("connect", () => { phase = url.protocol === "https:" ? "download TLS" : "download HTTP response"; });
-      socket.once("secureConnect", () => { if (!pin) phase = "download HTTP response"; });
+      socket.once("connect", () => { setPhase(url.protocol === "https:" ? "download TLS" : "download HTTP response"); });
+      socket.once("secureConnect", () => { if (!pin) setPhase("download HTTP response"); });
     });
     const pendingResponse = once(request, "response").then(([response]) => response);
     // Pinned private certificates authenticate the socket before any bearer bytes leave.
@@ -165,7 +172,7 @@ let phase = "preparation";
         const [socket] = await once(request, "socket");
         await once(socket, "secureConnect");
         if (normalizePin(socket.getPeerCertificate().fingerprint256 ?? "") !== pin) throw new Error("Cloud worker bootstrap TLS fingerprint mismatch");
-        phase = "download HTTP response";
+        setPhase("download HTTP response");
       }
       request.end();
     })().catch((error) => request.destroy(error));
@@ -173,7 +180,7 @@ let phase = "preparation";
     try {
       if (response.statusCode !== 200) throw new Error("Cloud worker bootstrap download failed with HTTP " + response.statusCode);
       if (response.headers["content-length"] !== undefined && Number(response.headers["content-length"]) !== artifact.bytes) throw new Error("Cloud worker bootstrap archive length does not match the Gateway");
-      phase = "download body";
+      setPhase("download body");
       const output = await fsp.open(archive, "wx", 0o600);
       try { await verifyArchive(response, artifact, output); }
       finally { await output.close(); }
@@ -186,6 +193,7 @@ let phase = "preparation";
     return path.join(root, "node_modules", "openclaw", ...parts);
   };
   const verifyWorkerArchive = async (root) => {
+    setPhase("worker archive verification");
     const archive = workerArchivePath(root);
     let handle;
     // A non-regular artifact (including a FIFO) must reject without blocking preparation.
@@ -202,6 +210,7 @@ let phase = "preparation";
   };
   const publishWorkerArchive = (root, downloaded) => {
     if (!workerBundle) return;
+    setPhase("worker archive publication");
     const archive = workerArchivePath(root);
     const directory = path.dirname(archive);
     fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
@@ -232,7 +241,7 @@ let phase = "preparation";
     }
     const installDir = existingRuntime ? runtimeDir : path.join(stage, "runtime");
     if (!existingRuntime) {
-      phase = "installation";
+      setPhase("installation");
       fs.mkdirSync(installDir, { mode: 0o700 });
       // npm 12 requires a project policy even when ignore-scripts is false.
       // Trust only the verified artifact; dependency script policy stays unchanged.
@@ -255,13 +264,17 @@ let phase = "preparation";
   } finally { fs.rmSync(stage, { recursive: true, force: true }); }
   }
   // A project snapshot contains only verified runtime bytes, never enrollment state.
-  if (!mode) return;
-  phase = "activation";
+  if (!mode) {
+    setPhase("complete");
+    return;
+  }
+  setPhase("activation");
   try {
     if (!fs.lstatSync(runtimeLink).isSymbolicLink()) throw new Error("Cloud worker runtime pointer is occupied");
     fs.unlinkSync(runtimeLink);
   } catch (error) { if (error.code !== "ENOENT") throw error; }
   fs.symlinkSync(runtimeDir, runtimeLink);
+  setPhase("plugin activation");
   for (const pluginId of new Set([...bootstrap.enabledPluginIds, ...${JSON.stringify(params.desktop ? ["cua-computer"] : [])}])) {
     const enabled = spawnSync(process.execPath, [cli, "plugins", "enable", pluginId], { env: nodeEnv, encoding: "utf8", timeout: 60000 });
     if (enabled.status !== 0) throw new Error("Cloud worker bootstrap could not enable plugin " + pluginId);
@@ -271,7 +284,7 @@ let phase = "preparation";
     fs.writeFileSync(setupFile, setupCode + "\\n", { mode: 0o600 });
   }
   const args = mode === "connect" ? ["connect", "--target-file", setupFile] : ["node", "run"];
-  phase = "node launch";
+  setPhase("node launch");
   const log = fs.openSync(path.join(stateDir, "node.log"), "a", 0o600);
   let child;
   try {
@@ -281,6 +294,7 @@ let phase = "preparation";
     catch (error) { process.kill(-child.pid, "SIGTERM"); throw error; }
     child.unref();
   } finally { fs.closeSync(log); }
+  setPhase("complete");
 })().catch((error) => { console.error("Cloud worker node bootstrap " + phase + " failed" + (error.code ? " (" + error.code + ")" : "") + ": " + error.message); process.exitCode = 1; });
 CRABBOX_NODE_ENROLLMENT_SCRIPT`;
   return {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators investigating slow cloud-session creation see one large bootstrap command duration and cannot distinguish download, installation, activation, and node launch.

Related: #140377 and the cloud-session startup follow-up.

## Why This Change Was Made

The node bootstrap script now emits fixed phase markers consumed by the existing released Crabbox CLI timing parser. The same phase setter retains the existing failure context; cached and preparation-only paths report the work they actually perform.

## User Impact

Cloud bootstrap diagnostics now identify which step consumes time. These markers measure latency; they do not themselves accelerate provisioning. Storage and schemas are unchanged.

## Evidence

- The original executable-script regression failed because no markers were emitted. The complete bootstrap test file now passes 17 tests, with one platform-specific skip. It covers cold, cached, runtime-only, enrollment, TLS, desktop, and failure paths. The test launcher also avoids a reproduced atomic-rename watcher race while retaining its existing 30-second bound.
- The released CLI phase parser was exercised against actual generated cold/cached/enrollment output delivered in three-byte fragments. The markers are static and contain no credentials; normal stdout is unchanged.
- Required changed-file checks, a full build, and independent P0–P2 review pass. Full build took 280.7s. Actual node-archive preparation verified the complete import graph, descriptor and hash, excluded worker deploy files, and closed its temporary provider afterward.
- A real AWS cold continuation passed on main `e1c1bc37c77f527c4c33b2dc3dd054f0886e1fdc` plus this exact three-file patch (SHA-256 `057ee98783ff97fc7e6ed087001efcc5399ca3d931072586ba85a3bd2e935bd7`). Its 45,166,456-byte runtime archive was verified as `9902ad0a9895e76795b7a99c957acaa971dc55054976d7a875eaba1d3050eef0`. Runtime installation occurred, all 11 expected markers were parsed, and no additional Gateway checkout appeared.
- The session restored four saved files, completed a real tool turn creating the fifth, advanced its accepted checkpoint from revision 7 to 8, and retained all five files after normal Stop. Provider cleanup was attested complete; the environment was destroyed, attachments cleared, and every owned process joined. Gateway shutdown exited naturally in 23.675s.

Observed cold-bootstrap phases totaled 43.353s: download body 19.151s, npm installation 19.259s, plugin activation 4.359s, and the remaining preparation/connection/verification/launch phases 0.584s. The enclosing CLI command took 102.103s and provider warmup 207.786s. Those are separate costs; the full command duration is not reported as npm time. Provider timings vary.

Further CLI admission overhead is being investigated separately. npm audit remains non-blocking at the maintainer's request.

Production +14 net lines for the shared phase-emission boundary; tests +11 and docs +2.


Data-model review: the automatic `unknown-data-model-change` classification is not applicable. This patch changes local phase tracking and stderr markers only; filesystem mutations, descriptor/enrollment payloads, stored fields, and schema are unchanged. Compatibility is exercised through the existing released CLI parser and the successful AWS run above; no migration is required.
