### PR TITLE
refactor(trace): reuse the canonical usage counter type

### DIFF
--- a/src/auto-reply/reply/agent-runner-trace.ts
+++ b/src/auto-reply/reply/agent-runner-trace.ts
@@ -1,11 +1,16 @@
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { deriveContextPromptTokens } from "../../agents/usage.js";
+import { deriveContextPromptTokens, type NormalizedUsage } from "../../agents/usage.js";
 import { readLatestSessionUsageFromTranscriptAsync } from "../../gateway/session-transcript-readers.js";
 import { formatTokenCount } from "../../utils/token-format.js";
 import type { ReplyPayload } from "../types.js";
 import { INBOUND_CONTEXT_MARKER } from "./inbound-context-marker.js";
+
+type TraceUsageView = Pick<
+  NormalizedUsage,
+  "input" | "output" | "cacheRead" | "cacheWrite" | "total"
+>;
 
 function formatRawTraceBlock(title: string, value: string | undefined): string {
   const body = value?.trim() ? escapeTraceFence(value) : "<empty>";
@@ -16,17 +21,7 @@ function escapeTraceFence(value: string): string {
   return value.replace(/^~~~/gm, "\\~~~");
 }
 
-function hasTraceUsageFields(
-  usage:
-    | {
-        input?: number;
-        output?: number;
-        cacheRead?: number;
-        cacheWrite?: number;
-        total?: number;
-      }
-    | undefined,
-): boolean {
+function hasTraceUsageFields(usage: TraceUsageView | undefined): boolean {
   if (!usage) {
     return false;
   }
@@ -42,15 +37,7 @@ function formatTraceUsageLine(label: string, value: number | undefined): string 
 
 function formatUsageTraceBlock(
   title: string,
-  usage:
-    | {
-        input?: number;
-        output?: number;
-        cacheRead?: number;
-        cacheWrite?: number;
-        total?: number;
-      }
-    | undefined,
+  usage: TraceUsageView | undefined,
 ): string | undefined {
   if (!hasTraceUsageFields(usage)) {
     return undefined;
@@ -339,16 +326,7 @@ export async function accumulateSessionUsageFromTranscript(params: {
   sessionKey?: string;
   storePath?: string;
   sessionFile?: string;
-}): Promise<
-  | {
-      input?: number;
-      output?: number;
-      cacheRead?: number;
-      cacheWrite?: number;
-      total?: number;
-    }
-  | undefined
-> {
+}): Promise<TraceUsageView | undefined> {
   const sessionId = normalizeOptionalString(params.sessionId);
   if (!sessionId) {
     return undefined;
@@ -445,13 +423,7 @@ function formatRawTraceSummaryLine(params: {
   completion?: TraceCompletionView;
   contextLimit?: number;
   promptTokens?: number;
-  usage?: {
-    input?: number;
-    output?: number;
-    cacheRead?: number;
-    cacheWrite?: number;
-    total?: number;
-  };
+  usage?: TraceUsageView;
   toolSummary?: TraceToolSummaryView;
   contextManagement?: TraceContextManagementView;
   requestShaping?: {
@@ -506,27 +478,9 @@ function formatRawTraceSummaryLine(params: {
 export function buildInlineRawTracePayload(params: {
   rawUserText?: string;
   rawAssistantText?: string;
-  sessionUsage?: {
-    input?: number;
-    output?: number;
-    cacheRead?: number;
-    cacheWrite?: number;
-    total?: number;
-  };
-  usage?: {
-    input?: number;
-    output?: number;
-    cacheRead?: number;
-    cacheWrite?: number;
-    total?: number;
-  };
-  lastCallUsage?: {
-    input?: number;
-    output?: number;
-    cacheRead?: number;
-    cacheWrite?: number;
-    total?: number;
-  };
+  sessionUsage?: TraceUsageView;
+  usage?: TraceUsageView;
+  lastCallUsage?: TraceUsageView;
   provider?: string;
   model?: string;
   contextLimit?: number;


### PR DESCRIPTION
## What Problem This Solves

Raw trace reporting repeats the same five optional token counters in seven type declarations. Those copies can drift from the runtime accounting owner.

This is a cleanup contribution to the #135868 split campaign, independent of its feature stages.

## Why This Change Was Made

Use a private five-key Pick of the existing NormalizedUsage type for all seven declarations. The selected properties have exactly the same names, optionality and numeric types. The type import shares an existing module import, and no executable code changes.

The full accounting type also contains context, reasoning and cost fields; those do not become new declared trace fields. Original usage objects still pass through unchanged, preserving context accounting, formatting, authorization and supported transcript artifact reads. This removes duplicated declarations rather than retiring a shipped contract.

## User Impact

No user-visible behavior change. Raw trace output and its authorization rules remain unchanged.

## Evidence

- All 108 existing tests pass before and after in agent-runner-trace.test.ts and agent-runner.misc.runreplyagent.test.ts. These include raw output, session/last-turn totals, and withholding persisted raw traces from unauthorized senders.
- Actual-source comparison passes 107 contract assertions in each optional-property mode, including all seven usage surfaces and exported signatures; five intentional type mutations are rejected in each mode.
- Emitted JavaScript is byte-identical, including imports. A deliberate runtime projection is detected by that comparison. No build is needed for this erased private type change.
- The supplementary strict-optional run retains six existing implementation diagnostics on each side; complete diagnostics match after expanding only the new alias's displayed name. Contract assertions have zero errors. This is not a claim that the existing owner compiles under that extra option.
- Full changed-check plan passes: core/core-test types, formatting/lint, all three Knip export scans and architecture/storage guards. Runtime import cycles: zero.
- Independent Codex review is clean through P2. ClawSweeper also found no correctness/security findings or before-merge requests; no rank-up changes were requested.

Judged production: one file, 599 → 553 lines; +13/−59 = **−46**. Tests, tooling, docs and baselines are unchanged.
