### PR TITLE
refactor(tests): remove unused Docker heartbeat fixtures

### DIFF
--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -1033,25 +1033,7 @@ grep -q '^build -t demo-image .$' "$TMPDIR/docker-seen"
 
   it("prints heartbeat progress for long successful centralized Docker builds", () => {
     const workDir = tempDirs.make("openclaw-docker-build-heartbeat-");
-    writeExecutables(join(workDir, "bin"), {
-      timeout: `#!/bin/bash
-set -euo pipefail
-if [[ "$1" = "--kill-after=1s" ]]; then
-  exit 0
-fi
-shift 2
-"$@"
-`,
-      docker: `#!/bin/sh
-printf "captured docker build log\\n"
-/bin/sleep 0.05
-`,
-    });
-
     const script = repoShell(workDir)`
-export PATH="$TMPDIR/bin:$PATH"
-export OPENCLAW_DOCKER_BUILD_HEARTBEAT_SECONDS=1
-
 source "$ROOT_DIR/scripts/lib/docker-build.sh"
 
 printf "captured docker build log\\n" >"$TMPDIR/build.log"


### PR DESCRIPTION
## What Problem This Solves

The Docker heartbeat formatting test still creates unused Docker and timeout executables and environment settings left over from its earlier build-based setup.

## Why This Change Was Made

Remove the 18 unused setup lines. The test now calls the heartbeat helper directly; every existing case and assertion remains unchanged. No production code changes.

## User Impact

Less dead test setup to maintain. No runtime or sleep reduction is claimed: the removed stub's sleep was never invoked.

## Evidence

Four focused cases pass: heartbeat progress, timeout forwarding, real interruption, and quick-build completion. The full changed-file gate and independent review through P2 pass. An initial dependency-ownership guard rejected a shared installation symlink; an isolated frozen-lockfile install resolved that environment issue, with no dependency changes or guard bypass.
