### PR TITLE
refactor(node-host): share execution policy result fields

### DIFF
--- a/src/node-host/exec-policy.ts
+++ b/src/node-host/exec-policy.ts
@@ -95,75 +95,16 @@ export function evaluateSystemRunPolicy(params: {
   const analysisOk = shellWrapperBlocked ? false : params.analysisOk;
   const allowlistSatisfied = shellWrapperBlocked ? false : params.allowlistSatisfied;
   const approvedByAsk = params.approvalDecision !== null || params.approved === true;
-
-  if (params.security === "deny") {
-    return {
-      allowed: false,
-      eventReason: "security=deny",
-      errorMessage: "SYSTEM_RUN_DISABLED: security=deny",
+  const requiresAsk =
+    params.security !== "deny" &&
+    requiresExecApproval({
+      ask: params.ask,
+      security: params.security,
       analysisOk,
       allowlistSatisfied,
-      shellWrapperBlocked,
-      windowsShellWrapperBlocked,
-      requiresAsk: false,
-      approvalDecision: params.approvalDecision,
-      approvedByAsk,
-    };
-  }
-
-  const requiresAsk = requiresExecApproval({
-    ask: params.ask,
-    security: params.security,
-    analysisOk,
-    allowlistSatisfied,
-    durableApprovalSatisfied: params.durableApprovalSatisfied,
-  });
-  if (requiresAsk && !approvedByAsk) {
-    return {
-      allowed: false,
-      eventReason: "approval-required",
-      errorMessage: "SYSTEM_RUN_DENIED: approval required",
-      analysisOk,
-      allowlistSatisfied,
-      shellWrapperBlocked,
-      windowsShellWrapperBlocked,
-      requiresAsk,
-      approvalDecision: params.approvalDecision,
-      approvedByAsk,
-    };
-  }
-
-  if (params.security === "allowlist" && (!analysisOk || !allowlistSatisfied) && !approvedByAsk) {
-    if (params.durableApprovalSatisfied) {
-      return {
-        allowed: true,
-        analysisOk,
-        allowlistSatisfied,
-        shellWrapperBlocked,
-        windowsShellWrapperBlocked,
-        requiresAsk,
-        approvalDecision: params.approvalDecision,
-        approvedByAsk,
-      };
-    }
-    return {
-      allowed: false,
-      eventReason: "allowlist-miss",
-      errorMessage: formatSystemRunAllowlistMissMessage({
-        windowsShellWrapperBlocked,
-      }),
-      analysisOk,
-      allowlistSatisfied,
-      shellWrapperBlocked,
-      windowsShellWrapperBlocked,
-      requiresAsk,
-      approvalDecision: params.approvalDecision,
-      approvedByAsk,
-    };
-  }
-
-  return {
-    allowed: true,
+      durableApprovalSatisfied: params.durableApprovalSatisfied,
+    });
+  const context = {
     analysisOk,
     allowlistSatisfied,
     shellWrapperBlocked,
@@ -171,5 +112,44 @@ export function evaluateSystemRunPolicy(params: {
     requiresAsk,
     approvalDecision: params.approvalDecision,
     approvedByAsk,
+  };
+
+  if (params.security === "deny") {
+    return {
+      allowed: false,
+      eventReason: "security=deny",
+      errorMessage: "SYSTEM_RUN_DISABLED: security=deny",
+      ...context,
+    };
+  }
+
+  if (requiresAsk && !approvedByAsk) {
+    return {
+      allowed: false,
+      eventReason: "approval-required",
+      errorMessage: "SYSTEM_RUN_DENIED: approval required",
+      ...context,
+    };
+  }
+
+  if (
+    params.security === "allowlist" &&
+    (!analysisOk || !allowlistSatisfied) &&
+    !approvedByAsk &&
+    !params.durableApprovalSatisfied
+  ) {
+    return {
+      allowed: false,
+      eventReason: "allowlist-miss",
+      errorMessage: formatSystemRunAllowlistMissMessage({
+        windowsShellWrapperBlocked,
+      }),
+      ...context,
+    };
+  }
+
+  return {
+    allowed: true,
+    ...context,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Node-host execution policy repeats the same decision facts in four result branches and carries a separate success return for durable approval. Keeping those projections in sync adds maintenance work to the execution gate.

## Why This Change Was Made

Construct the common result fields once and use the existing success return for durable approval. Explicit deny still short-circuits approval evaluation; mandatory approval, Windows shell-wrapper handling, denial reasons, and result fields remain unchanged. `invoke-system-run.ts` is the only production consumer, at the initial decision and approved re-evaluation.

This removes duplicated implementation, not a compatibility contract. `git log -S durableApprovalSatisfied -- src/node-host/exec-policy.ts` confirms the durable-approval branch's history; its behavior remains covered and unchanged. Follow-up deletion work for #135868. Production +28/−48, net −20; tests/tooling/docs unchanged.

## User Impact

No intended behavior change. Node-host commands keep the same execution permissions and diagnostic results.

## Evidence

- Existing policy and system-run invocation suites: 96 tests passed.
- Local before/after comparison across 5,184 combinations of security, ask, approval decision, durable approval, and six boolean inputs: byte-identical result JSON.
- Existing coverage remains unchanged: `src/node-host/exec-policy.test.ts:52` (deny), `:68` (ask-always despite durable trust), `:96` (unapproved allowlist miss), `:113` (Windows guidance), and `src/node-host/invoke-system-run.test.ts:3101` (durable trust rerun).
- Independent Codex review: scoped-clean through P2. Full `node scripts/check-changed.mjs`: exit 0, including typechecks, lint, dead exports, import cycles, and repository guards.
- Windows policy cases use fixture inputs; no Windows node-host runtime was executed locally.
- ClawSweeper reviewed exact head `8875e438d6b7c795423da21e516936c16120d481`: no findings, security concerns, or requested rank-up changes. Maintainer source review agrees.
