### PR TITLE
refactor(agent-core): repair Unicode tails in one pass

### DIFF
--- a/packages/agent-core/src/harness/utils/truncate.test.ts
+++ b/packages/agent-core/src/harness/utils/truncate.test.ts
@@ -27,6 +27,50 @@ describe("truncate utilities", () => {
   });
 
   it.each([
+    { tail: "\uD800", maxBytes: 3, expected: "\uFFFD" },
+    { tail: "\uDC00", maxBytes: 3, expected: "\uFFFD" },
+    { tail: "\uD800\uD800", maxBytes: 6, expected: "\uFFFD\uFFFD" },
+    { tail: "\uD800a\uDC00", maxBytes: 7, expected: "\uFFFDa\uFFFD" },
+    { tail: "\uD800\uD800\uDC00", maxBytes: 7, expected: "\uFFFD\uD800\uDC00" },
+    { tail: "\uDC00\uD800\uDC00", maxBytes: 7, expected: "\uFFFD\uD800\uDC00" },
+    { tail: "🙂\uD800", maxBytes: 7, expected: "🙂\uFFFD" },
+    { tail: "\uD800", maxBytes: 2, expected: "" },
+    { tail: "\uD800🙂", maxBytes: 4, expected: "🙂" },
+    { tail: "🙂\uDC00", maxBytes: 3, expected: "\uFFFD" },
+    { tail: "\uDC00\uD800\uDC00", maxBytes: 4, expected: "\uD800\uDC00" },
+  ])(
+    "repairs only retained lone surrogates within $maxBytes bytes: $tail",
+    ({ tail, maxBytes, expected }) => {
+      const content = `discarded-${tail}`;
+      expect(truncateTail(content, { maxBytes })).toEqual({
+        content: expected,
+        truncated: true,
+        truncatedBy: "bytes",
+        totalLines: 1,
+        totalBytes: Buffer.byteLength(content),
+        outputLines: 1,
+        outputBytes: Buffer.byteLength(expected),
+        lastLinePartial: true,
+        firstLineExceedsLimit: false,
+        maxLines: 2000,
+        maxBytes,
+      });
+    },
+  );
+
+  it("preserves malformed strings when they fit without truncation", () => {
+    const content = "\uD800🙂\uDC00";
+    expect(truncateTail(content, { maxBytes: 10 })).toMatchObject({
+      content,
+      truncated: false,
+      truncatedBy: null,
+      totalBytes: 10,
+      outputBytes: 10,
+      lastLinePartial: false,
+    });
+  });
+
+  it.each([
     {
       name: "CRLF",
       content: "a\r\n\r\nb\r\n",

--- a/packages/agent-core/src/harness/utils/truncate.ts
+++ b/packages/agent-core/src/harness/utils/truncate.ts
@@ -91,29 +91,6 @@ function utf8ByteLength(content: string): number {
   return bytes;
 }
 
-function replaceUnpairedSurrogates(content: string): string {
-  let output = "";
-  for (let i = 0; i < content.length; i++) {
-    const code = content.charCodeAt(i);
-    if (code >= 0xd800 && code <= 0xdbff) {
-      if (i + 1 < content.length) {
-        const next = content.charCodeAt(i + 1);
-        if (next >= 0xdc00 && next <= 0xdfff) {
-          output += content.charAt(i) + content.charAt(i + 1);
-          i++;
-          continue;
-        }
-      }
-      output += "�";
-    } else if (code >= 0xdc00 && code <= 0xdfff) {
-      output += "�";
-    } else {
-      output += content.charAt(i);
-    }
-  }
-  return output;
-}
-
 /**
  * Format byte counts for compact tool-output diagnostics.
  */
@@ -320,7 +297,8 @@ function truncateStringToBytesFromEnd(str: string, maxBytes: number): string {
 
   let outputBytes = 0;
   let start = str.length;
-  let needsReplacement = false;
+  let unchangedEnd = str.length;
+  let repairedTail = "";
   for (let i = str.length; i > 0;) {
     let characterStart = i - 1;
     const code = str.charCodeAt(characterStart);
@@ -346,12 +324,15 @@ function truncateStringToBytesFromEnd(str: string, maxBytes: number): string {
     }
     outputBytes += characterBytes;
     start = characterStart;
-    needsReplacement ||= unpairedSurrogate;
+    if (unpairedSurrogate) {
+      // Selection already identified the lone surrogate; retain the valid span to its right.
+      repairedTail = "\uFFFD" + str.slice(i, unchangedEnd) + repairedTail;
+      unchangedEnd = characterStart;
+    }
     i = characterStart;
   }
 
-  const output = str.slice(start);
-  return needsReplacement ? replaceUnpairedSurrogates(output) : output;
+  return str.slice(start, unchangedEnd) + repairedTail;
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Truncating a long tool-output line can scan its selected suffix twice when the suffix contains lone UTF-16 surrogates. The second scan repeats character classification already required to enforce the byte limit.

## Why This Change Was Made

The byte selector now assembles repaired spans as it selects characters. It preserves complete surrogate pairs, inserts U+FFFD only for selected lone surrogates, and keeps valid spans in their original order. This deletes the separate repair helper: production −19 lines; tests +44. No public API, limit, configuration, storage, or prompt changes.

## User Impact

Output and metadata remain identical. This is a smaller implementation with a measured local performance tradeoff, not a claim of faster Gateway turns. Sparse malformed tails benefit from avoiding the second scan; dense malformed tails can cost several additional microseconds.

## Evidence

- 36 focused tests, 28 normal changed-surface checks, and independent Codex review passed. Added coverage includes adjacent/separated lone surrogates, complete pairs, byte boundaries, and unchanged malformed strings that fit. Source and tests are unchanged since validation.
- Fixed B0/C0/C1/B1 comparison on Node 26.8.1, frozen baseline `ff5053f8b64341fccc4d2ace12cf9ececb49e1e6`: 235 rows, 1,551,940 checked invocations, 940 retained first-result bodies, and 7,520 retained batch durations. Independent audit verified every first body and all timing reductions. Repeated successful bodies were checked in process, not individually archived.
- Selected malformed-repair medians improved in 148/186 comparisons. At a 4 KiB / 2,000-line limit, mixed malformed/valid tails improved 4.93%/6.57%; high-high-low patterns improved 14.87%/9.54%; sparse boundary repair improved 60.92%/58.73%. Dense lone-high/low patterns regressed about 16–21%, roughly 3–4 µs. Worst dense-repair median adverse: +4.607 µs. All rows remain included: 178/470 medians, 182 means, and 207 maxima were adverse. Valid multiline-ASCII controls had one-order outliers of +26.769 µs and +17.377 µs, with near-flat reverse observations; these are not discarded or attributed away.
- Separate actual-result GC probe: 32 fresh children, 256 complete results from distinct 2 MiB inputs, 64-byte/4 KiB tails. Measurements precede probe access to returned content. Repaired tails show no large new retained backing signal in this build; candidate held-heap differences range −4,496 to +1,928 bytes for eight results. This is not a portable no-leak or heap-reduction claim. All children/reducer closed, source restored, and independent output/counter/pin audit passed.

The heap controls found a pre-existing follow-up: **release backing storage for valid single-line tails**. Both baseline and candidate retain about 16 MiB externally while eight tiny valid tails remain held; that signal disappears after result release. It is separate from this repair. RSS capacity and sampled process peaks are not treated as reachable storage.

Earlier regex and disk-admission failures remain recorded separately; neither was relabeled as passing. The actual public truncation flow and accumulator controls were exercised locally. No credentialed Gateway turn was attributed to this change: ordinary decoded process output does not exercise lone-surrogate repair, and the campaign's real-Gateway measurements are separate.
