### PR TITLE
improve: retain current worker builds between sessions

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -494,20 +494,20 @@ do not start a second CLI node for the same Mac. Its native camera, screen, and
 desktop capabilities remain on that identity. If the shared runtime cannot
 start, native capabilities remain available, but session hosting is unavailable.
 
-When a paired session host reconnects after a Gateway update, the Gateway prepares
-its current sealed worker artifact on that host. The node verifies the exact
-content hash, publishes the artifact atomically, and prewarms it when supported.
+When a session first needs the current worker build, the Gateway sends its sealed
+worker artifact to the paired host. The node verifies the exact content hash,
+publishes the artifact atomically, and prewarms it when supported by the execution mode.
 The artifact contains its complete JavaScript dependency closure; the node does
-not install packages or execute lifecycle scripts. A session started during
-preparation waits for that same operation. Cancelling the session does not cancel
-host preparation; disconnecting or revoking the host does.
+not install packages or execute lifecycle scripts. Installation belongs to the
+session request and receives its cancellation signal. Reconnect maintenance does
+not install or prewarm a worker build.
 
-Nodes retain one current prepared artifact per Gateway namespace, even with no
-sessions. Older builds remain only while a live or recoverable placement needs
-them; normal maintenance removes unreferenced builds. Each new dispatch still
-validates the installed artifact. Preparation failures are reported in Gateway
-logs; retry Start or reconnect the host. Cloud-enrolled nodes keep their own
-execution-mode-specific preparation lifecycle.
+Once installed, persistent nodes retain one current worker artifact per Gateway
+namespace, even with no sessions. Older builds remain only while a live or
+recoverable placement needs them; normal maintenance removes unreferenced builds.
+Each new dispatch still validates the installed artifact and reuses it when valid,
+avoiding another download. Cloud-enrolled nodes keep their own execution-mode-specific
+installation and retention lifecycle.
 
 You can also enroll and enable a service host in one step with
 `openclaw connect --service --session-host`. In Control UI New Session, a
@@ -520,8 +520,8 @@ the device filesystem.
 
 The Devices page shows the validated Gateway-owned worker version in the node's
 metadata. If the current artifact is missing or fails validation, Devices shows
-a **worker missing** warning; reconnect preparation or an explicit new session
-installs the current bundle. This status is observational and reconnect-scoped: launch still
+a **worker missing** warning; an explicit new session installs the current bundle.
+This status is observational and reconnect-scoped: launch still
 requires the exact durable receipt and current node authority.
 
 Node hosts must support the current private worker-supervisor dialect before

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -494,13 +494,20 @@ do not start a second CLI node for the same Mac. Its native camera, screen, and
 desktop capabilities remain on that identity. If the shared runtime cannot
 start, native capabilities remain available, but session hosting is unavailable.
 
-On the first session dispatch
-for a Gateway build, the node downloads one sealed worker artifact from that
-paired Gateway, verifies its exact content hash, and publishes it atomically
-under the Gateway-namespaced node-host bundle root. The artifact already
-contains its complete JavaScript dependency closure; the node does not install
-packages or execute lifecycle scripts. Later turns reuse the immutable artifact
-while its receipt still matches the Gateway's current build.
+When a paired session host reconnects after a Gateway update, the Gateway prepares
+its current sealed worker artifact on that host. The node verifies the exact
+content hash, publishes the artifact atomically, and prewarms it when supported.
+The artifact contains its complete JavaScript dependency closure; the node does
+not install packages or execute lifecycle scripts. A session started during
+preparation waits for that same operation. Cancelling the session does not cancel
+host preparation; disconnecting or revoking the host does.
+
+Nodes retain one current prepared artifact per Gateway namespace, even with no
+sessions. Older builds remain only while a live or recoverable placement needs
+them; normal maintenance removes unreferenced builds. Each new dispatch still
+validates the installed artifact. Preparation failures are reported in Gateway
+logs; retry Start or reconnect the host. Cloud-enrolled nodes keep their own
+execution-mode-specific preparation lifecycle.
 
 You can also enroll and enable a service host in one step with
 `openclaw connect --service --session-host`. In Control UI New Session, a
@@ -512,9 +519,9 @@ device placement becomes active. New Session does not bind `execNode` or browse
 the device filesystem.
 
 The Devices page shows the validated Gateway-owned worker version in the node's
-metadata. If the retained artifact is missing or fails validation, Devices shows
-a **worker missing** warning; start a new session on that device to reinstall the
-current bundle. This status is observational and reconnect-scoped: launch still
+metadata. If the current artifact is missing or fails validation, Devices shows
+a **worker missing** warning; reconnect preparation or an explicit new session
+installs the current bundle. This status is observational and reconnect-scoped: launch still
 requires the exact durable receipt and current node authority.
 
 Node hosts must support the current private worker-supervisor dialect before

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -135,7 +135,7 @@ export async function prepareGatewayLifecycle(params: {
       if (change.availabilityChanged) {
         workerPlacementRuntime?.runnerAvailability.markChanged();
       }
-      if (change.inventoryChanged) {
+      if (change.inventoryChanged || change.availabilityChanged) {
         void workerPlacementRuntime?.scheduleNodeWorkspaceRetention(nodeId);
       }
     },

--- a/src/gateway/server-runtime-state-prepare.ts
+++ b/src/gateway/server-runtime-state-prepare.ts
@@ -138,7 +138,7 @@ export async function prepareGatewayKernelState(params: {
     workerEnvironmentService,
     workerLiveEvents,
     nodeWorkerGatewayNamespace,
-    nodeWorkerBundlePreparation,
+    nodeWorkerBundleRetention,
     bindDeviceNodeControl,
     bindWorkerNodeDesktopControl,
     bindNodeWorkspaceBindingResolver,
@@ -175,7 +175,7 @@ export async function prepareGatewayKernelState(params: {
             placements: workerEnvironmentStartup.placementStore,
             environments: workerEnvironmentService,
             gatewayNamespace: nodeWorkerGatewayNamespace,
-            nodeWorkerBundlePreparation,
+            nodeWorkerBundleRetention,
             getSessionChangeContext: () => pluginGatewayContext.current,
             persistAbandonedPartial: async ({ sessionId, sessionKey, agentId, runId }) => {
               // Placement runtime starts before chat state exists; moves invoke this only after startup.

--- a/src/gateway/server-runtime-state-prepare.ts
+++ b/src/gateway/server-runtime-state-prepare.ts
@@ -138,6 +138,7 @@ export async function prepareGatewayKernelState(params: {
     workerEnvironmentService,
     workerLiveEvents,
     nodeWorkerGatewayNamespace,
+    nodeWorkerBundlePreparation,
     bindDeviceNodeControl,
     bindWorkerNodeDesktopControl,
     bindNodeWorkspaceBindingResolver,
@@ -174,6 +175,7 @@ export async function prepareGatewayKernelState(params: {
             placements: workerEnvironmentStartup.placementStore,
             environments: workerEnvironmentService,
             gatewayNamespace: nodeWorkerGatewayNamespace,
+            nodeWorkerBundlePreparation,
             getSessionChangeContext: () => pluginGatewayContext.current,
             persistAbandonedPartial: async ({ sessionId, sessionKey, agentId, runId }) => {
               // Placement runtime starts before chat state exists; moves invoke this only after startup.

--- a/src/gateway/server-worker-environment-startup.ts
+++ b/src/gateway/server-worker-environment-startup.ts
@@ -27,10 +27,10 @@ import {
 import type { WorkerLiveEventReceiver } from "./worker-environments/live-events.js";
 import type { createNodeBootstrapArtifactProvider } from "./worker-environments/node-bootstrap-artifact.js";
 import { createWorkerNodeEnrollmentManager } from "./worker-environments/node-enrollment.js";
-import type { NodeWorkerBundlePreparation } from "./worker-environments/node-worker-bundle-installer.js";
 import type { NodeWorkerBundleTransferHttpCallback } from "./worker-environments/node-worker-bundle-transfer-http.js";
 import { nodeWorkerGatewayNamespace as resolveNodeWorkerGatewayNamespace } from "./worker-environments/node-worker-gateway-namespace.js";
 import type { NodeWorkerWorkspaceBindingResolver } from "./worker-environments/node-worker-tunnel.js";
+import type { NodeWorkerBundleRetention } from "./worker-environments/node-workspace-retain-coordinator.js";
 import type { NodeWorkspaceTransferHttpCallback } from "./worker-environments/node-workspace-transfer-http-contract.js";
 import type { WorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
 import type { WorkerPlacementDispatchContract } from "./worker-environments/service-contract.js";
@@ -64,7 +64,7 @@ export type GatewayWorkerEnvironmentRuntime = {
   workerLiveEvents?: WorkerLiveEventReceiver;
   workerTunnelManager?: WorkerTunnelManager;
   nodeWorkerGatewayNamespace?: string;
-  nodeWorkerBundlePreparation?: NodeWorkerBundlePreparation;
+  nodeWorkerBundleRetention?: NodeWorkerBundleRetention;
   bindWorkerSessionDispatch?: (dispatch: WorkerPlacementDispatchContract["dispatch"]) => void;
   bindDeviceNodeControl?: (transport: NodeWorkerSupervisorTransport) => void;
   bindWorkerNodeDesktopControl?: (transport: NodeWorkerSupervisorTransport) => void;
@@ -299,20 +299,16 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
     gatewayNamespace: nodeWorkerGatewayNamespace,
     getTransport: () => deviceRuntime.getNodeTransport(),
     transfer: nodeWorkerBundleTransfer,
-    isEnvironmentOwnedNode,
-    warn: (message) => workerEnvironmentLog.warn(message),
   });
-  const nodeWorkerBundlePreparation: NodeWorkerBundlePreparation = {
+  const nodeWorkerBundleRetention: NodeWorkerBundleRetention = {
     isEnvironmentOwnedNode,
-    currentArtifact: async () => {
+    currentBuild: async () => {
       const artifact = await prepareInstallation("bundle");
       if (artifact.install !== "bundle") {
-        throw new Error("Node worker preparation requires a bundle artifact");
+        throw new Error("Node worker retention requires a bundle artifact");
       }
       return artifact;
     },
-    prepare: nodeWorkerBundleInstaller.prepare,
-    invalidate: nodeWorkerBundleInstaller.invalidate,
   };
   const nodeEnrollment = createWorkerNodeEnrollmentManager({
     store: params.startup.store,
@@ -401,20 +397,16 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
         ? deviceRuntime.provider
         : resolveWorkerProvider(params.getPluginRegistry(), providerId),
     prepareInstallation,
-    ensureNodeWorkerBundle: nodeWorkerBundleInstaller.ensure,
+    ensureNodeWorkerBundle: nodeWorkerBundleInstaller,
     prepareNodeBootstrap: nodeEnrollment.prepare,
     prepareNodeEnrollment: nodeEnrollment.begin,
     prepareNodeRuntime: nodeEnrollment.prepareRuntime,
     closeNodeRuntime: nodeEnrollment.closeRuntime,
     closeNodeEnrollment: nodeEnrollment.close,
     retireNodeEnrollment: nodeEnrollment.retire,
-    stopNodeEnrollmentWaits: () => {
-      nodeEnrollment.stop();
-      nodeWorkerBundleInstaller.stop();
-    },
+    stopNodeEnrollmentWaits: nodeEnrollment.stop,
     closeNodeBootstrapArtifacts: async () => {
       await Promise.all([
-        nodeWorkerBundleInstaller.close(),
         ...[...bootstrapProducers.values()].map(({ producer }) => producer.close()),
         ...retiringBootstrapProducers,
       ]);
@@ -539,13 +531,12 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
     workerLiveEvents,
     workerTunnelManager,
     nodeWorkerGatewayNamespace,
-    nodeWorkerBundlePreparation,
+    nodeWorkerBundleRetention,
     bindWorkerSessionDispatch: (dispatch) => {
       dispatchChild = dispatch;
     },
     bindDeviceNodeControl: (transport) => {
       deviceRuntime.bindNodeTransport(transport);
-      nodeWorkerBundleInstaller.invalidate();
       if (workerNodeDesktopStreamBroker) {
         workerNodePortalCarrier.bindRuntime({
           transport,

--- a/src/gateway/server-worker-environment-startup.ts
+++ b/src/gateway/server-worker-environment-startup.ts
@@ -27,6 +27,7 @@ import {
 import type { WorkerLiveEventReceiver } from "./worker-environments/live-events.js";
 import type { createNodeBootstrapArtifactProvider } from "./worker-environments/node-bootstrap-artifact.js";
 import { createWorkerNodeEnrollmentManager } from "./worker-environments/node-enrollment.js";
+import type { NodeWorkerBundlePreparation } from "./worker-environments/node-worker-bundle-installer.js";
 import type { NodeWorkerBundleTransferHttpCallback } from "./worker-environments/node-worker-bundle-transfer-http.js";
 import { nodeWorkerGatewayNamespace as resolveNodeWorkerGatewayNamespace } from "./worker-environments/node-worker-gateway-namespace.js";
 import type { NodeWorkerWorkspaceBindingResolver } from "./worker-environments/node-worker-tunnel.js";
@@ -63,6 +64,7 @@ export type GatewayWorkerEnvironmentRuntime = {
   workerLiveEvents?: WorkerLiveEventReceiver;
   workerTunnelManager?: WorkerTunnelManager;
   nodeWorkerGatewayNamespace?: string;
+  nodeWorkerBundlePreparation?: NodeWorkerBundlePreparation;
   bindWorkerSessionDispatch?: (dispatch: WorkerPlacementDispatchContract["dispatch"]) => void;
   bindDeviceNodeControl?: (transport: NodeWorkerSupervisorTransport) => void;
   bindWorkerNodeDesktopControl?: (transport: NodeWorkerSupervisorTransport) => void;
@@ -291,11 +293,27 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
     validateWorkerTurn: (binding) => placementGate.validateWorkerTurn(binding),
     workspaceTransfer: nodeWorkspaceTransfer,
   });
-  const ensureNodeWorkerBundle = createGatewayNodeWorkerBundleInstaller({
+  const isEnvironmentOwnedNode = (nodeId: string) =>
+    params.startup.store.hasNodeEnrollmentOwner(nodeId);
+  const nodeWorkerBundleInstaller = createGatewayNodeWorkerBundleInstaller({
     gatewayNamespace: nodeWorkerGatewayNamespace,
     getTransport: () => deviceRuntime.getNodeTransport(),
     transfer: nodeWorkerBundleTransfer,
+    isEnvironmentOwnedNode,
+    warn: (message) => workerEnvironmentLog.warn(message),
   });
+  const nodeWorkerBundlePreparation: NodeWorkerBundlePreparation = {
+    isEnvironmentOwnedNode,
+    currentArtifact: async () => {
+      const artifact = await prepareInstallation("bundle");
+      if (artifact.install !== "bundle") {
+        throw new Error("Node worker preparation requires a bundle artifact");
+      }
+      return artifact;
+    },
+    prepare: nodeWorkerBundleInstaller.prepare,
+    invalidate: nodeWorkerBundleInstaller.invalidate,
+  };
   const nodeEnrollment = createWorkerNodeEnrollmentManager({
     store: params.startup.store,
     getConfig: getRuntimeConfig,
@@ -383,16 +401,20 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
         ? deviceRuntime.provider
         : resolveWorkerProvider(params.getPluginRegistry(), providerId),
     prepareInstallation,
-    ensureNodeWorkerBundle,
+    ensureNodeWorkerBundle: nodeWorkerBundleInstaller.ensure,
     prepareNodeBootstrap: nodeEnrollment.prepare,
     prepareNodeEnrollment: nodeEnrollment.begin,
     prepareNodeRuntime: nodeEnrollment.prepareRuntime,
     closeNodeRuntime: nodeEnrollment.closeRuntime,
     closeNodeEnrollment: nodeEnrollment.close,
     retireNodeEnrollment: nodeEnrollment.retire,
-    stopNodeEnrollmentWaits: nodeEnrollment.stop,
+    stopNodeEnrollmentWaits: () => {
+      nodeEnrollment.stop();
+      nodeWorkerBundleInstaller.stop();
+    },
     closeNodeBootstrapArtifacts: async () => {
       await Promise.all([
+        nodeWorkerBundleInstaller.close(),
         ...[...bootstrapProducers.values()].map(({ producer }) => producer.close()),
         ...retiringBootstrapProducers,
       ]);
@@ -517,11 +539,13 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
     workerLiveEvents,
     workerTunnelManager,
     nodeWorkerGatewayNamespace,
+    nodeWorkerBundlePreparation,
     bindWorkerSessionDispatch: (dispatch) => {
       dispatchChild = dispatch;
     },
     bindDeviceNodeControl: (transport) => {
       deviceRuntime.bindNodeTransport(transport);
+      nodeWorkerBundleInstaller.invalidate();
       if (workerNodeDesktopStreamBroker) {
         workerNodePortalCarrier.bindRuntime({
           transport,

--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -37,6 +37,7 @@ import {
 } from "./server-worker-placement-session-target.js";
 import { recoverGatewayWorkerPlacementWorkspaces } from "./server-worker-placement-workspace-recovery.js";
 import { materializeSessionRepositoryWorkspaceOnGateway } from "./session-repository-materialization.js";
+import type { NodeWorkerBundlePreparation } from "./worker-environments/node-worker-bundle-installer.js";
 import { createNodeWorkspaceRetainCoordinator } from "./worker-environments/node-workspace-retain-coordinator.js";
 import { createWorkerPlacementDiskSpaceMonitor } from "./worker-environments/placement-disk-space.js";
 import { coordinateWorkerPlacementDispatch } from "./worker-environments/placement-dispatch-coordinator.js";
@@ -69,6 +70,7 @@ export type GatewayWorkerPlacementRuntimeParams = {
   placements: WorkerSessionPlacementStore;
   environments: WorkerEnvironmentService;
   gatewayNamespace: string;
+  nodeWorkerBundlePreparation?: NodeWorkerBundlePreparation;
   persistAbandonedPartial?: (request: {
     sessionId: string;
     sessionKey: string;
@@ -119,6 +121,7 @@ export function createGatewayWorkerPlacementRuntime(
     loadWorkerPlacementSessionRuntimeModule,
   );
   const nodeWorkspaceRetention = createNodeWorkspaceRetainCoordinator({
+    preparation: params.nodeWorkerBundlePreparation,
     gatewayNamespace: params.gatewayNamespace,
     placements: params.placements,
     environments: params.environments,
@@ -594,7 +597,7 @@ export function createGatewayWorkerPlacementRuntime(
         }
         if (!stopped) {
           stopped = true;
-          // Cancel only enrollment: admitted recovery may still finish attaching before service stop.
+          // Close enrollment and idle preparation; admitted recovery keeps its own bootstrap owner.
           params.environments.stopNodeEnrollmentWaits?.();
           clearInterval(placementReconcileInterval);
           placementReconcileInterval = undefined;
@@ -633,35 +636,30 @@ export function createGatewayWorkerPlacementRuntime(
     try {
       // Track startup reconciliation in the placement slot so a concurrent
       // close prelude drains it before uninstalling guards and stopping environments.
-      const startupRecovery = recoverGatewayWorkerPlacementWorkspaces({
-        placements: params.placements,
-        resolveWorkspace,
-      });
-      placementReconcile.current = startupRecovery;
-      try {
-        await startupRecovery;
-      } finally {
-        if (placementReconcile.current === startupRecovery) {
-          placementReconcile.current = undefined;
+      for (const reconcile of [
+        () =>
+          recoverGatewayWorkerPlacementWorkspaces({
+            placements: params.placements,
+            resolveWorkspace,
+          }),
+        () =>
+          publishPlacementChanges(async () => {
+            await rawDispatchService.reconcile("startup");
+            await reconcilePublications();
+          }),
+      ]) {
+        const current = reconcile();
+        placementReconcile.current = current;
+        try {
+          await current;
+        } finally {
+          if (placementReconcile.current === current) {
+            placementReconcile.current = undefined;
+          }
         }
-      }
-      if (hooks.isClosePreludeStarted()) {
-        return await stopBeforeReady();
-      }
-      const startupReconcile = publishPlacementChanges(async () => {
-        await rawDispatchService.reconcile("startup");
-        await reconcilePublications();
-      });
-      placementReconcile.current = startupReconcile;
-      try {
-        await startupReconcile;
-      } finally {
-        if (placementReconcile.current === startupReconcile) {
-          placementReconcile.current = undefined;
+        if (hooks.isClosePreludeStarted()) {
+          return await stopBeforeReady();
         }
-      }
-      if (hooks.isClosePreludeStarted()) {
-        return await stopBeforeReady();
       }
       void nodeWorkspaceRetention.start();
       if (hooks.isClosePreludeStarted()) {

--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -37,8 +37,10 @@ import {
 } from "./server-worker-placement-session-target.js";
 import { recoverGatewayWorkerPlacementWorkspaces } from "./server-worker-placement-workspace-recovery.js";
 import { materializeSessionRepositoryWorkspaceOnGateway } from "./session-repository-materialization.js";
-import type { NodeWorkerBundlePreparation } from "./worker-environments/node-worker-bundle-installer.js";
-import { createNodeWorkspaceRetainCoordinator } from "./worker-environments/node-workspace-retain-coordinator.js";
+import {
+  createNodeWorkspaceRetainCoordinator,
+  type NodeWorkerBundleRetention,
+} from "./worker-environments/node-workspace-retain-coordinator.js";
 import { createWorkerPlacementDiskSpaceMonitor } from "./worker-environments/placement-disk-space.js";
 import { coordinateWorkerPlacementDispatch } from "./worker-environments/placement-dispatch-coordinator.js";
 import type { WorkerDevicePlacementRequirementResolver } from "./worker-environments/placement-dispatch-startup.js";
@@ -70,7 +72,7 @@ export type GatewayWorkerPlacementRuntimeParams = {
   placements: WorkerSessionPlacementStore;
   environments: WorkerEnvironmentService;
   gatewayNamespace: string;
-  nodeWorkerBundlePreparation?: NodeWorkerBundlePreparation;
+  nodeWorkerBundleRetention?: NodeWorkerBundleRetention;
   persistAbandonedPartial?: (request: {
     sessionId: string;
     sessionKey: string;
@@ -121,7 +123,7 @@ export function createGatewayWorkerPlacementRuntime(
     loadWorkerPlacementSessionRuntimeModule,
   );
   const nodeWorkspaceRetention = createNodeWorkspaceRetainCoordinator({
-    preparation: params.nodeWorkerBundlePreparation,
+    bundleRetention: params.nodeWorkerBundleRetention,
     gatewayNamespace: params.gatewayNamespace,
     placements: params.placements,
     environments: params.environments,
@@ -597,7 +599,7 @@ export function createGatewayWorkerPlacementRuntime(
         }
         if (!stopped) {
           stopped = true;
-          // Close enrollment and idle preparation; admitted recovery keeps its own bootstrap owner.
+          // Cancel enrollment; admitted recovery keeps its own bootstrap owner.
           params.environments.stopNodeEnrollmentWaits?.();
           clearInterval(placementReconcileInterval);
           placementReconcileInterval = undefined;

--- a/src/gateway/worker-environments/node-worker-bundle-installer.test.ts
+++ b/src/gateway/worker-environments/node-worker-bundle-installer.test.ts
@@ -31,6 +31,12 @@ const artifact = {
   tarballPath: "/gateway/bundle.tgz",
 };
 
+const receipt = {
+  bundleHash: artifact.bundleHash,
+  openclawVersion: artifact.openclawVersion,
+  protocolFeatures: artifact.protocolFeatures,
+};
+
 function nodeProof(nodeId: string, bundlePrewarm?: 1): NodeWorkerSupervisorNodeProof {
   return {
     ...node,
@@ -55,7 +61,7 @@ describe("Gateway node worker bundle installer", () => {
       payload: artifact,
     }));
     const listCurrentNodes = vi.fn(() => discovered.promise);
-    const ensure = createGatewayNodeWorkerBundleInstaller({
+    const { ensure } = createGatewayNodeWorkerBundleInstaller({
       gatewayNamespace: "gateway-test",
       getTransport: () => ({
         hasCurrentRunner: () => false,
@@ -110,7 +116,7 @@ describe("Gateway node worker bundle installer", () => {
       isCurrent: (candidate) => candidate === node,
       invoke,
     };
-    const ensure = createGatewayNodeWorkerBundleInstaller({
+    const { ensure } = createGatewayNodeWorkerBundleInstaller({
       gatewayNamespace: "gateway-test",
       getTransport: () => transport,
       transfer,
@@ -152,7 +158,7 @@ describe("Gateway node worker bundle installer", () => {
         }),
       }),
     };
-    const ensure = createGatewayNodeWorkerBundleInstaller({
+    const { ensure } = createGatewayNodeWorkerBundleInstaller({
       gatewayNamespace: "gateway-test",
       getTransport: () => transport,
       transfer,
@@ -179,7 +185,7 @@ describe("Gateway node worker bundle installer", () => {
       isCurrent: () => true,
       invoke,
     };
-    const ensure = createGatewayNodeWorkerBundleInstaller({
+    const { ensure } = createGatewayNodeWorkerBundleInstaller({
       gatewayNamespace: "gateway-test",
       getTransport: () => transport,
       transfer,
@@ -198,5 +204,165 @@ describe("Gateway node worker bundle installer", () => {
 
     expect(invoke.mock.calls[0]?.[0].params).toMatchObject({ bundlePrewarm: 1 });
     expect(invoke.mock.calls[1]?.[0].params).not.toHaveProperty("bundlePrewarm");
+  });
+
+  it("shares a pending host preparation without giving a cancelled Start its custody", async () => {
+    const installed = createDeferredCore<{ ok: boolean; payloadJSON: string }>();
+    const transfer = createNodeWorkerBundleTransferService();
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(() => installed.promise);
+    const transport: NodeWorkerSupervisorTransport = {
+      hasCurrentRunner: () => true,
+      listCurrentNodes: async () => [node],
+      isCurrent: () => true,
+      invoke,
+    };
+    const installer = createGatewayNodeWorkerBundleInstaller({
+      gatewayNamespace: "gateway-test",
+      getTransport: () => transport,
+      transfer,
+    });
+    const prepared = installer.prepare({ node, artifact });
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+    const controller = new AbortController();
+    const cancelled = installer.ensure({
+      deviceId: node.nodeId,
+      artifact,
+      prewarm: true,
+      signal: controller.signal,
+    });
+    const remaining = installer.ensure({ deviceId: node.nodeId, artifact, prewarm: true });
+    const cancelledResult = expect(cancelled).rejects.toMatchObject({ name: "AbortError" });
+    controller.abort();
+    await cancelledResult;
+    expect(invoke.mock.calls[0]?.[0].signal?.aborted).toBe(false);
+    installed.resolve({ ok: true, payloadJSON: JSON.stringify(receipt) });
+    await Promise.all([prepared, remaining]);
+    expect(invoke).toHaveBeenCalledOnce();
+    await installer.ensure({ deviceId: node.nodeId, artifact, prewarm: true });
+    expect(invoke).toHaveBeenCalledTimes(2);
+    await installer.close();
+    transfer.closeAll();
+  });
+
+  it("fences a replaced connection without delaying its successor", async () => {
+    const held = createDeferredCore<{ ok: boolean; payloadJSON: string }>();
+    const replacement = { ...node, connId: "replacement", pairingGeneration: "replacement" };
+    let current = node;
+    const transfer = createNodeWorkerBundleTransferService();
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) =>
+      request.node === node
+        ? await held.promise
+        : { ok: true, payloadJSON: JSON.stringify(receipt) },
+    );
+    const transport: NodeWorkerSupervisorTransport = {
+      hasCurrentRunner: () => true,
+      listCurrentNodes: async () => [current],
+      isCurrent: (proof) => proof === current,
+      invoke,
+    };
+    const installer = createGatewayNodeWorkerBundleInstaller({
+      gatewayNamespace: "gateway-test",
+      getTransport: () => transport,
+      transfer,
+    });
+    const old = installer.prepare({ node, artifact });
+    const rejected = old.catch((error: unknown) => error);
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+    current = replacement;
+    installer.invalidate(node.nodeId);
+    expect(invoke.mock.calls[0]?.[0].signal?.aborted).toBe(true);
+    await installer.prepare({ node: replacement, artifact });
+    expect(invoke).toHaveBeenCalledTimes(2);
+    held.resolve({ ok: true, payloadJSON: JSON.stringify(receipt) });
+    expect(await rejected).toMatchObject({
+      message: "Device worker preparation connection is no longer current",
+    });
+    await installer.close();
+    transfer.closeAll();
+  });
+
+  it("does not retry a failed background generation until an explicit Start", async () => {
+    const transfer = createNodeWorkerBundleTransferService();
+    const invoke = vi
+      .fn<NodeWorkerSupervisorTransport["invoke"]>()
+      .mockResolvedValueOnce({ ok: false, error: { message: "transfer unavailable" } })
+      .mockResolvedValue({ ok: true, payloadJSON: JSON.stringify(receipt) });
+    const transport: NodeWorkerSupervisorTransport = {
+      hasCurrentRunner: () => true,
+      listCurrentNodes: async () => [node],
+      isCurrent: () => true,
+      invoke,
+    };
+    const warn = vi.fn();
+    const installer = createGatewayNodeWorkerBundleInstaller({
+      warn,
+      gatewayNamespace: "gateway-test",
+      getTransport: () => transport,
+      transfer,
+    });
+    await expect(installer.prepare({ node, artifact })).rejects.toThrow("transfer unavailable");
+    await expect(installer.prepare({ node, artifact })).rejects.toThrow("transfer unavailable");
+    expect(invoke).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledOnce();
+    await installer.ensure({ deviceId: node.nodeId, artifact, prewarm: true });
+    expect(invoke).toHaveBeenCalledTimes(2);
+    await installer.close();
+    transfer.closeAll();
+  });
+
+  it("leaves cloud enrollment cancellation with its environment owner", async () => {
+    const controller = new AbortController();
+    const transfer = createNodeWorkerBundleTransferService();
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
+      expect(request.signal).toBe(controller.signal);
+      controller.abort();
+      return { ok: true, payloadJSON: JSON.stringify(receipt) };
+    });
+    const transport: NodeWorkerSupervisorTransport = {
+      hasCurrentRunner: () => true,
+      listCurrentNodes: async () => [node],
+      isCurrent: () => true,
+      invoke,
+    };
+    const installer = createGatewayNodeWorkerBundleInstaller({
+      gatewayNamespace: "gateway-test",
+      getTransport: () => transport,
+      transfer,
+      isEnvironmentOwnedNode: () => true,
+    });
+    await expect(
+      installer.ensure({
+        deviceId: node.nodeId,
+        artifact,
+        prewarm: true,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("no longer current");
+    await installer.close();
+    transfer.closeAll();
+  });
+
+  it("rejects a shared preparation when enrollment claims the node without an inventory event", async () => {
+    let environmentOwned = false;
+    const transfer = createNodeWorkerBundleTransferService();
+    const transport: NodeWorkerSupervisorTransport = {
+      hasCurrentRunner: () => true,
+      listCurrentNodes: async () => [node],
+      isCurrent: () => true,
+      invoke: async (request) => {
+        environmentOwned = true;
+        expect(request.isDispatchAuthorized()).toBe(false);
+        return { ok: true, payloadJSON: JSON.stringify(receipt) };
+      },
+    };
+    const installer = createGatewayNodeWorkerBundleInstaller({
+      gatewayNamespace: "gateway-test",
+      getTransport: () => transport,
+      transfer,
+      isEnvironmentOwnedNode: () => environmentOwned,
+    });
+    await expect(installer.prepare({ node, artifact })).rejects.toThrow("no longer current");
+    await installer.close();
+    transfer.closeAll();
   });
 });

--- a/src/gateway/worker-environments/node-worker-bundle-installer.test.ts
+++ b/src/gateway/worker-environments/node-worker-bundle-installer.test.ts
@@ -61,7 +61,7 @@ describe("Gateway node worker bundle installer", () => {
       payload: artifact,
     }));
     const listCurrentNodes = vi.fn(() => discovered.promise);
-    const { ensure } = createGatewayNodeWorkerBundleInstaller({
+    const ensure = createGatewayNodeWorkerBundleInstaller({
       gatewayNamespace: "gateway-test",
       getTransport: () => ({
         hasCurrentRunner: () => false,
@@ -116,7 +116,7 @@ describe("Gateway node worker bundle installer", () => {
       isCurrent: (candidate) => candidate === node,
       invoke,
     };
-    const { ensure } = createGatewayNodeWorkerBundleInstaller({
+    const ensure = createGatewayNodeWorkerBundleInstaller({
       gatewayNamespace: "gateway-test",
       getTransport: () => transport,
       transfer,
@@ -158,7 +158,7 @@ describe("Gateway node worker bundle installer", () => {
         }),
       }),
     };
-    const { ensure } = createGatewayNodeWorkerBundleInstaller({
+    const ensure = createGatewayNodeWorkerBundleInstaller({
       gatewayNamespace: "gateway-test",
       getTransport: () => transport,
       transfer,
@@ -185,7 +185,7 @@ describe("Gateway node worker bundle installer", () => {
       isCurrent: () => true,
       invoke,
     };
-    const { ensure } = createGatewayNodeWorkerBundleInstaller({
+    const ensure = createGatewayNodeWorkerBundleInstaller({
       gatewayNamespace: "gateway-test",
       getTransport: () => transport,
       transfer,
@@ -206,163 +206,36 @@ describe("Gateway node worker bundle installer", () => {
     expect(invoke.mock.calls[1]?.[0].params).not.toHaveProperty("bundlePrewarm");
   });
 
-  it("shares a pending host preparation without giving a cancelled Start its custody", async () => {
-    const installed = createDeferredCore<{ ok: boolean; payloadJSON: string }>();
-    const transfer = createNodeWorkerBundleTransferService();
-    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(() => installed.promise);
-    const transport: NodeWorkerSupervisorTransport = {
-      hasCurrentRunner: () => true,
-      listCurrentNodes: async () => [node],
-      isCurrent: () => true,
-      invoke,
-    };
-    const installer = createGatewayNodeWorkerBundleInstaller({
-      gatewayNamespace: "gateway-test",
-      getTransport: () => transport,
-      transfer,
-    });
-    const prepared = installer.prepare({ node, artifact });
-    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
-    const controller = new AbortController();
-    const cancelled = installer.ensure({
-      deviceId: node.nodeId,
-      artifact,
-      prewarm: true,
-      signal: controller.signal,
-    });
-    const remaining = installer.ensure({ deviceId: node.nodeId, artifact, prewarm: true });
-    const cancelledResult = expect(cancelled).rejects.toMatchObject({ name: "AbortError" });
-    controller.abort();
-    await cancelledResult;
-    expect(invoke.mock.calls[0]?.[0].signal?.aborted).toBe(false);
-    installed.resolve({ ok: true, payloadJSON: JSON.stringify(receipt) });
-    await Promise.all([prepared, remaining]);
-    expect(invoke).toHaveBeenCalledOnce();
-    await installer.ensure({ deviceId: node.nodeId, artifact, prewarm: true });
-    expect(invoke).toHaveBeenCalledTimes(2);
-    await installer.close();
-    transfer.closeAll();
-  });
-
-  it("fences a replaced connection without delaying its successor", async () => {
-    const held = createDeferredCore<{ ok: boolean; payloadJSON: string }>();
-    const replacement = { ...node, connId: "replacement", pairingGeneration: "replacement" };
-    let current = node;
-    const transfer = createNodeWorkerBundleTransferService();
-    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) =>
-      request.node === node
-        ? await held.promise
-        : { ok: true, payloadJSON: JSON.stringify(receipt) },
-    );
-    const transport: NodeWorkerSupervisorTransport = {
-      hasCurrentRunner: () => true,
-      listCurrentNodes: async () => [current],
-      isCurrent: (proof) => proof === current,
-      invoke,
-    };
-    const installer = createGatewayNodeWorkerBundleInstaller({
-      gatewayNamespace: "gateway-test",
-      getTransport: () => transport,
-      transfer,
-    });
-    const old = installer.prepare({ node, artifact });
-    const rejected = old.catch((error: unknown) => error);
-    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
-    current = replacement;
-    installer.invalidate(node.nodeId);
-    expect(invoke.mock.calls[0]?.[0].signal?.aborted).toBe(true);
-    await installer.prepare({ node: replacement, artifact });
-    expect(invoke).toHaveBeenCalledTimes(2);
-    held.resolve({ ok: true, payloadJSON: JSON.stringify(receipt) });
-    expect(await rejected).toMatchObject({
-      message: "Device worker preparation connection is no longer current",
-    });
-    await installer.close();
-    transfer.closeAll();
-  });
-
-  it("does not retry a failed background generation until an explicit Start", async () => {
-    const transfer = createNodeWorkerBundleTransferService();
-    const invoke = vi
-      .fn<NodeWorkerSupervisorTransport["invoke"]>()
-      .mockResolvedValueOnce({ ok: false, error: { message: "transfer unavailable" } })
-      .mockResolvedValue({ ok: true, payloadJSON: JSON.stringify(receipt) });
-    const transport: NodeWorkerSupervisorTransport = {
-      hasCurrentRunner: () => true,
-      listCurrentNodes: async () => [node],
-      isCurrent: () => true,
-      invoke,
-    };
-    const warn = vi.fn();
-    const installer = createGatewayNodeWorkerBundleInstaller({
-      warn,
-      gatewayNamespace: "gateway-test",
-      getTransport: () => transport,
-      transfer,
-    });
-    await expect(installer.prepare({ node, artifact })).rejects.toThrow("transfer unavailable");
-    await expect(installer.prepare({ node, artifact })).rejects.toThrow("transfer unavailable");
-    expect(invoke).toHaveBeenCalledOnce();
-    expect(warn).toHaveBeenCalledOnce();
-    await installer.ensure({ deviceId: node.nodeId, artifact, prewarm: true });
-    expect(invoke).toHaveBeenCalledTimes(2);
-    await installer.close();
-    transfer.closeAll();
-  });
-
-  it("leaves cloud enrollment cancellation with its environment owner", async () => {
-    const controller = new AbortController();
-    const transfer = createNodeWorkerBundleTransferService();
-    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
-      expect(request.signal).toBe(controller.signal);
-      controller.abort();
-      return { ok: true, payloadJSON: JSON.stringify(receipt) };
-    });
-    const transport: NodeWorkerSupervisorTransport = {
-      hasCurrentRunner: () => true,
-      listCurrentNodes: async () => [node],
-      isCurrent: () => true,
-      invoke,
-    };
-    const installer = createGatewayNodeWorkerBundleInstaller({
-      gatewayNamespace: "gateway-test",
-      getTransport: () => transport,
-      transfer,
-      isEnvironmentOwnedNode: () => true,
-    });
-    await expect(
-      installer.ensure({
-        deviceId: node.nodeId,
-        artifact,
-        prewarm: true,
-        signal: controller.signal,
-      }),
-    ).rejects.toThrow("no longer current");
-    await installer.close();
-    transfer.closeAll();
-  });
-
-  it("rejects a shared preparation when enrollment claims the node without an inventory event", async () => {
-    let environmentOwned = false;
-    const transfer = createNodeWorkerBundleTransferService();
-    const transport: NodeWorkerSupervisorTransport = {
-      hasCurrentRunner: () => true,
-      listCurrentNodes: async () => [node],
-      isCurrent: () => true,
-      invoke: async (request) => {
-        environmentOwned = true;
-        expect(request.isDispatchAuthorized()).toBe(false);
+  it.each([true, false])(
+    "keeps explicit cancellation with its request when prewarm is %s",
+    async (prewarm) => {
+      const controller = new AbortController();
+      const transfer = createNodeWorkerBundleTransferService();
+      const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
+        expect(request.signal).toBe(controller.signal);
+        controller.abort();
         return { ok: true, payloadJSON: JSON.stringify(receipt) };
-      },
-    };
-    const installer = createGatewayNodeWorkerBundleInstaller({
-      gatewayNamespace: "gateway-test",
-      getTransport: () => transport,
-      transfer,
-      isEnvironmentOwnedNode: () => environmentOwned,
-    });
-    await expect(installer.prepare({ node, artifact })).rejects.toThrow("no longer current");
-    await installer.close();
-    transfer.closeAll();
-  });
+      });
+      const transport: NodeWorkerSupervisorTransport = {
+        hasCurrentRunner: () => true,
+        listCurrentNodes: async () => [node],
+        isCurrent: () => true,
+        invoke,
+      };
+      const ensure = createGatewayNodeWorkerBundleInstaller({
+        gatewayNamespace: "gateway-test",
+        getTransport: () => transport,
+        transfer,
+      });
+      await expect(
+        ensure({
+          deviceId: node.nodeId,
+          artifact,
+          prewarm,
+          signal: controller.signal,
+        }),
+      ).rejects.toThrow("no longer current");
+      transfer.closeAll();
+    },
+  );
 });

--- a/src/gateway/worker-environments/node-worker-bundle-installer.ts
+++ b/src/gateway/worker-environments/node-worker-bundle-installer.ts
@@ -2,48 +2,40 @@ import { WORKER_BUNDLE_PREWARM_VERSION } from "../../../packages/gateway-protoco
 import { racePromiseWithAbortSignal } from "../../infra/abort-signal.js";
 import { NODE_WORKER_BUNDLE_INSTALL_COMMAND } from "../../infra/node-commands.js";
 import { parseNodeWorkerBundleInstallResult } from "../../worker/node-bundle-install-protocol.js";
-import { sameWorkerBuild } from "../../worker/worker-build-identity.js";
-import type {
-  NodeWorkerSupervisorNodeProof,
-  NodeWorkerSupervisorTransport,
-} from "../node-registry-private.js";
+import type { NodeWorkerSupervisorTransport } from "../node-registry-private.js";
 import { verifyWorkerAdmissionHandshake } from "./admission.js";
 import { workerBootstrapOperationTimeoutMs } from "./bootstrap.js";
 import type { WorkerInstallationArtifact } from "./bundle.js";
 import type { NodeWorkerBundleTransferService } from "./node-worker-bundle-transfer-service.js";
 
-type WorkerBundleArtifact = Extract<WorkerInstallationArtifact, { install: "bundle" }>;
-type InstallRequest = {
-  node: NodeWorkerSupervisorNodeProof;
-  artifact: WorkerBundleArtifact;
-  prewarm: boolean;
-  signal?: AbortSignal;
-  isAuthorized?: () => boolean;
-};
-
-export type NodeWorkerBundlePreparation = {
-  currentArtifact: () => Promise<WorkerBundleArtifact>;
-  isEnvironmentOwnedNode: (nodeId: string) => boolean;
-  prepare: (params: Omit<InstallRequest, "prewarm" | "isAuthorized">) => Promise<void>;
-  invalidate: (nodeId?: string) => void;
-};
-
 export function createGatewayNodeWorkerBundleInstaller(options: {
   gatewayNamespace: string;
   getTransport: () => NodeWorkerSupervisorTransport | undefined;
   transfer: NodeWorkerBundleTransferService;
-  isEnvironmentOwnedNode?: (nodeId: string) => boolean;
-  warn?: (message: string) => void;
 }) {
-  const install = async (params: InstallRequest, transport: NodeWorkerSupervisorTransport) => {
-    const { node, artifact } = params;
+  return async (params: {
+    deviceId: string;
+    artifact: Extract<WorkerInstallationArtifact, { install: "bundle" }>;
+    prewarm: boolean;
+    signal?: AbortSignal;
+  }) => {
+    params.signal?.throwIfAborted();
+    const transport = options.getTransport();
+    if (!transport) {
+      throw new Error("Device worker node transport is unavailable");
+    }
+    const node = (
+      await racePromiseWithAbortSignal(transport.listCurrentNodes(), params.signal)
+    ).find((candidate) => candidate.nodeId === params.deviceId);
+    params.signal?.throwIfAborted();
+    if (!node) {
+      throw new Error("Device worker node is not connected with the installer dialect");
+    }
+    const { artifact } = params;
     const isAuthorized = () =>
-      !params.signal?.aborted &&
-      params.isAuthorized?.() !== false &&
-      options.getTransport() === transport &&
-      transport.isCurrent(node);
+      !params.signal?.aborted && options.getTransport() === transport && transport.isCurrent(node);
     if (!isAuthorized()) {
-      throw new Error("Device worker preparation connection is no longer current");
+      throw new Error("Device worker installation connection is no longer current");
     }
     const bundlePrewarm =
       params.prewarm && (node.workerHost.bundlePrewarm ?? 0) >= WORKER_BUNDLE_PREWARM_VERSION
@@ -68,7 +60,7 @@ export function createGatewayNodeWorkerBundleInstaller(options: {
         ...(params.signal ? { signal: params.signal } : {}),
       });
       if (!isAuthorized()) {
-        throw new Error("Device worker preparation connection is no longer current");
+        throw new Error("Device worker installation connection is no longer current");
       }
       if (!result.ok) {
         throw new Error(
@@ -93,144 +85,5 @@ export function createGatewayNodeWorkerBundleInstaller(options: {
     } finally {
       options.transfer.revoke(prepared.token);
     }
-  };
-  type Preparation = {
-    node: NodeWorkerSupervisorNodeProof;
-    transport: NodeWorkerSupervisorTransport;
-    artifact: WorkerBundleArtifact;
-    controller: AbortController;
-    pending: boolean;
-    result: ReturnType<typeof install>;
-  };
-  const preparations = new Map<string, Preparation>();
-  const operations = new Set<ReturnType<typeof install>>();
-  let stopped = false;
-  const invalidate = (nodeId?: string) => {
-    for (const [id, entry] of preparations) {
-      if (nodeId && id !== nodeId) {
-        continue;
-      }
-      if (
-        stopped ||
-        options.getTransport() !== entry.transport ||
-        !entry.transport.isCurrent(entry.node) ||
-        options.isEnvironmentOwnedNode?.(id)
-      ) {
-        preparations.delete(id);
-        entry.controller.abort(new Error("Device worker preparation owner closed"));
-      }
-    }
-  };
-  const prepare = (
-    params: Omit<InstallRequest, "prewarm" | "isAuthorized">,
-    validateAgain: boolean,
-  ): ReturnType<typeof install> => {
-    params.signal?.throwIfAborted();
-    invalidate(params.node.nodeId);
-    const transport = options.getTransport();
-    if (
-      !transport ||
-      stopped ||
-      !transport.isCurrent(params.node) ||
-      options.isEnvironmentOwnedNode?.(params.node.nodeId)
-    ) {
-      throw new Error("Device worker preparation connection is no longer current");
-    }
-    const previous = preparations.get(params.node.nodeId);
-    if (
-      previous &&
-      previous.node.connId === params.node.connId &&
-      previous.node.pairingGeneration === params.node.pairingGeneration &&
-      previous.node.pairingIdentity === params.node.pairingIdentity &&
-      sameWorkerBuild(previous.artifact, params.artifact) &&
-      previous.artifact.tarballSha256 === params.artifact.tarballSha256 &&
-      (!validateAgain || previous.pending)
-    ) {
-      return racePromiseWithAbortSignal(previous.result, params.signal);
-    }
-    previous?.controller.abort(new Error("Device worker preparation build replaced"));
-    const controller = new AbortController();
-    // Hosting consent owns preparation. A cancelled Start releases its wait, while
-    // disconnect, pairing replacement and Gateway shutdown close the actual install.
-    const result = Promise.resolve().then(() =>
-      install(
-        {
-          ...params,
-          prewarm: true,
-          signal: controller.signal,
-          isAuthorized: () => !stopped && !options.isEnvironmentOwnedNode?.(params.node.nodeId),
-        },
-        transport,
-      ),
-    );
-    const entry: Preparation = {
-      node: params.node,
-      transport,
-      artifact: params.artifact,
-      controller,
-      pending: true,
-      result,
-    };
-    preparations.set(params.node.nodeId, entry);
-    operations.add(result);
-    const settled = () => {
-      entry.pending = false;
-      operations.delete(result);
-    };
-    void result.then(settled, (error: unknown) => {
-      settled();
-      if (
-        !controller.signal.aborted &&
-        transport.isCurrent(params.node) &&
-        !options.isEnvironmentOwnedNode?.(params.node.nodeId)
-      ) {
-        options.warn?.(
-          `Node worker preparation failed (${params.node.nodeId}); retry Start or reconnect the host: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-    });
-    return racePromiseWithAbortSignal(result, params.signal);
-  };
-  const stop = () => {
-    stopped = true;
-    invalidate();
-  };
-  return {
-    invalidate,
-    stop,
-    async close() {
-      stop();
-      await Promise.allSettled(operations);
-    },
-    prepare: async (params: Omit<InstallRequest, "prewarm" | "isAuthorized">) => {
-      await prepare(params, false);
-    },
-    ensure: async (params: {
-      deviceId: string;
-      artifact: WorkerBundleArtifact;
-      prewarm: boolean;
-      signal?: AbortSignal;
-    }) => {
-      params.signal?.throwIfAborted();
-      const transport = options.getTransport();
-      if (!transport) {
-        throw new Error("Device worker node transport is unavailable");
-      }
-      const node = (
-        await racePromiseWithAbortSignal(transport.listCurrentNodes(), params.signal)
-      ).find((candidate) => candidate.nodeId === params.deviceId);
-      params.signal?.throwIfAborted();
-      if (!node) {
-        throw new Error("Device worker node is not connected with the installer dialect");
-      }
-      // Ephemeral cloud enrollment retains its own cancellation owner; remote-exec
-      // does not pay OpenClaw prewarming. Only persistent worker hosts share preparation.
-      if (options.isEnvironmentOwnedNode?.(node.nodeId) || !params.prewarm) {
-        return await install({ ...params, node }, transport);
-      }
-      // A settled preparation is not a replacement for native integrity validation
-      // on an explicit new dispatch. Only concurrent in-flight validation is shared.
-      return await prepare({ ...params, node }, true);
-    },
   };
 }

--- a/src/gateway/worker-environments/node-worker-bundle-installer.ts
+++ b/src/gateway/worker-environments/node-worker-bundle-installer.ts
@@ -2,39 +2,49 @@ import { WORKER_BUNDLE_PREWARM_VERSION } from "../../../packages/gateway-protoco
 import { racePromiseWithAbortSignal } from "../../infra/abort-signal.js";
 import { NODE_WORKER_BUNDLE_INSTALL_COMMAND } from "../../infra/node-commands.js";
 import { parseNodeWorkerBundleInstallResult } from "../../worker/node-bundle-install-protocol.js";
-import type { NodeWorkerSupervisorTransport } from "../node-registry-private.js";
+import { sameWorkerBuild } from "../../worker/worker-build-identity.js";
+import type {
+  NodeWorkerSupervisorNodeProof,
+  NodeWorkerSupervisorTransport,
+} from "../node-registry-private.js";
 import { verifyWorkerAdmissionHandshake } from "./admission.js";
 import { workerBootstrapOperationTimeoutMs } from "./bootstrap.js";
 import type { WorkerInstallationArtifact } from "./bundle.js";
 import type { NodeWorkerBundleTransferService } from "./node-worker-bundle-transfer-service.js";
 
 type WorkerBundleArtifact = Extract<WorkerInstallationArtifact, { install: "bundle" }>;
+type InstallRequest = {
+  node: NodeWorkerSupervisorNodeProof;
+  artifact: WorkerBundleArtifact;
+  prewarm: boolean;
+  signal?: AbortSignal;
+  isAuthorized?: () => boolean;
+};
+
+export type NodeWorkerBundlePreparation = {
+  currentArtifact: () => Promise<WorkerBundleArtifact>;
+  isEnvironmentOwnedNode: (nodeId: string) => boolean;
+  prepare: (params: Omit<InstallRequest, "prewarm" | "isAuthorized">) => Promise<void>;
+  invalidate: (nodeId?: string) => void;
+};
 
 export function createGatewayNodeWorkerBundleInstaller(options: {
   gatewayNamespace: string;
   getTransport: () => NodeWorkerSupervisorTransport | undefined;
   transfer: NodeWorkerBundleTransferService;
+  isEnvironmentOwnedNode?: (nodeId: string) => boolean;
+  warn?: (message: string) => void;
 }) {
-  return async (params: {
-    deviceId: string;
-    artifact: WorkerBundleArtifact;
-    prewarm: boolean;
-    signal?: AbortSignal;
-  }) => {
-    params.signal?.throwIfAborted();
-    const transport = options.getTransport();
-    if (!transport) {
-      throw new Error("Device worker node transport is unavailable");
+  const install = async (params: InstallRequest, transport: NodeWorkerSupervisorTransport) => {
+    const { node, artifact } = params;
+    const isAuthorized = () =>
+      !params.signal?.aborted &&
+      params.isAuthorized?.() !== false &&
+      options.getTransport() === transport &&
+      transport.isCurrent(node);
+    if (!isAuthorized()) {
+      throw new Error("Device worker preparation connection is no longer current");
     }
-    const node = (
-      await racePromiseWithAbortSignal(transport.listCurrentNodes(), params.signal)
-    ).find((candidate) => candidate.nodeId === params.deviceId);
-    params.signal?.throwIfAborted();
-    if (!node) {
-      throw new Error("Device worker node is not connected with the installer dialect");
-    }
-    const { artifact } = params;
-    const isAuthorized = () => !params.signal?.aborted && transport.isCurrent(node);
     const bundlePrewarm =
       params.prewarm && (node.workerHost.bundlePrewarm ?? 0) >= WORKER_BUNDLE_PREWARM_VERSION
         ? WORKER_BUNDLE_PREWARM_VERSION
@@ -57,6 +67,9 @@ export function createGatewayNodeWorkerBundleInstaller(options: {
         isDispatchAuthorized: isAuthorized,
         ...(params.signal ? { signal: params.signal } : {}),
       });
+      if (!isAuthorized()) {
+        throw new Error("Device worker preparation connection is no longer current");
+      }
       if (!result.ok) {
         throw new Error(
           result.error?.message
@@ -80,5 +93,144 @@ export function createGatewayNodeWorkerBundleInstaller(options: {
     } finally {
       options.transfer.revoke(prepared.token);
     }
+  };
+  type Preparation = {
+    node: NodeWorkerSupervisorNodeProof;
+    transport: NodeWorkerSupervisorTransport;
+    artifact: WorkerBundleArtifact;
+    controller: AbortController;
+    pending: boolean;
+    result: ReturnType<typeof install>;
+  };
+  const preparations = new Map<string, Preparation>();
+  const operations = new Set<ReturnType<typeof install>>();
+  let stopped = false;
+  const invalidate = (nodeId?: string) => {
+    for (const [id, entry] of preparations) {
+      if (nodeId && id !== nodeId) {
+        continue;
+      }
+      if (
+        stopped ||
+        options.getTransport() !== entry.transport ||
+        !entry.transport.isCurrent(entry.node) ||
+        options.isEnvironmentOwnedNode?.(id)
+      ) {
+        preparations.delete(id);
+        entry.controller.abort(new Error("Device worker preparation owner closed"));
+      }
+    }
+  };
+  const prepare = (
+    params: Omit<InstallRequest, "prewarm" | "isAuthorized">,
+    validateAgain: boolean,
+  ): ReturnType<typeof install> => {
+    params.signal?.throwIfAborted();
+    invalidate(params.node.nodeId);
+    const transport = options.getTransport();
+    if (
+      !transport ||
+      stopped ||
+      !transport.isCurrent(params.node) ||
+      options.isEnvironmentOwnedNode?.(params.node.nodeId)
+    ) {
+      throw new Error("Device worker preparation connection is no longer current");
+    }
+    const previous = preparations.get(params.node.nodeId);
+    if (
+      previous &&
+      previous.node.connId === params.node.connId &&
+      previous.node.pairingGeneration === params.node.pairingGeneration &&
+      previous.node.pairingIdentity === params.node.pairingIdentity &&
+      sameWorkerBuild(previous.artifact, params.artifact) &&
+      previous.artifact.tarballSha256 === params.artifact.tarballSha256 &&
+      (!validateAgain || previous.pending)
+    ) {
+      return racePromiseWithAbortSignal(previous.result, params.signal);
+    }
+    previous?.controller.abort(new Error("Device worker preparation build replaced"));
+    const controller = new AbortController();
+    // Hosting consent owns preparation. A cancelled Start releases its wait, while
+    // disconnect, pairing replacement and Gateway shutdown close the actual install.
+    const result = Promise.resolve().then(() =>
+      install(
+        {
+          ...params,
+          prewarm: true,
+          signal: controller.signal,
+          isAuthorized: () => !stopped && !options.isEnvironmentOwnedNode?.(params.node.nodeId),
+        },
+        transport,
+      ),
+    );
+    const entry: Preparation = {
+      node: params.node,
+      transport,
+      artifact: params.artifact,
+      controller,
+      pending: true,
+      result,
+    };
+    preparations.set(params.node.nodeId, entry);
+    operations.add(result);
+    const settled = () => {
+      entry.pending = false;
+      operations.delete(result);
+    };
+    void result.then(settled, (error: unknown) => {
+      settled();
+      if (
+        !controller.signal.aborted &&
+        transport.isCurrent(params.node) &&
+        !options.isEnvironmentOwnedNode?.(params.node.nodeId)
+      ) {
+        options.warn?.(
+          `Node worker preparation failed (${params.node.nodeId}); retry Start or reconnect the host: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    });
+    return racePromiseWithAbortSignal(result, params.signal);
+  };
+  const stop = () => {
+    stopped = true;
+    invalidate();
+  };
+  return {
+    invalidate,
+    stop,
+    async close() {
+      stop();
+      await Promise.allSettled(operations);
+    },
+    prepare: async (params: Omit<InstallRequest, "prewarm" | "isAuthorized">) => {
+      await prepare(params, false);
+    },
+    ensure: async (params: {
+      deviceId: string;
+      artifact: WorkerBundleArtifact;
+      prewarm: boolean;
+      signal?: AbortSignal;
+    }) => {
+      params.signal?.throwIfAborted();
+      const transport = options.getTransport();
+      if (!transport) {
+        throw new Error("Device worker node transport is unavailable");
+      }
+      const node = (
+        await racePromiseWithAbortSignal(transport.listCurrentNodes(), params.signal)
+      ).find((candidate) => candidate.nodeId === params.deviceId);
+      params.signal?.throwIfAborted();
+      if (!node) {
+        throw new Error("Device worker node is not connected with the installer dialect");
+      }
+      // Ephemeral cloud enrollment retains its own cancellation owner; remote-exec
+      // does not pay OpenClaw prewarming. Only persistent worker hosts share preparation.
+      if (options.isEnvironmentOwnedNode?.(node.nodeId) || !params.prewarm) {
+        return await install({ ...params, node }, transport);
+      }
+      // A settled preparation is not a replacement for native integrity validation
+      // on an explicit new dispatch. Only concurrent in-flight validation is shared.
+      return await prepare({ ...params, node }, true);
+    },
   };
 }

--- a/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
+++ b/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
@@ -105,7 +105,7 @@ function createHarness(
     }>;
     node?: NodeWorkerSupervisorNodeProof;
     currentBundleStatus?: NodeWorkerBundleStatusObservation;
-    preparation?: Parameters<typeof createNodeWorkspaceRetainCoordinator>[0]["preparation"];
+    bundleRetention?: Parameters<typeof createNodeWorkspaceRetainCoordinator>[0]["bundleRetention"];
     additionalManifestRefs?: Parameters<
       typeof createNodeWorkspaceRetainCoordinator
     >[0]["additionalManifestRefs"];
@@ -153,7 +153,7 @@ function createHarness(
       list: () => (params.placements ?? [placement()]) as never,
       listPendingWorkspaceResults: () => params.pendingResults ?? [],
     } as Pick<WorkerSessionPlacementStore, "list" | "listPendingWorkspaceResults">,
-    preparation: params.preparation,
+    bundleRetention: params.bundleRetention,
     additionalManifestRefs: params.additionalManifestRefs,
     warn,
   });
@@ -690,24 +690,18 @@ describe("node workspace retain coordinator", () => {
     }
   });
 
-  it("retains the prepared current build without keeping unreferenced older builds", async () => {
+  it("retains the current build without installing it or keeping unreferenced older builds", async () => {
     const artifact = {
-      install: "bundle" as const,
       bundleHash: "c".repeat(64),
       openclawVersion: "2026.8.10",
       protocolFeatures: [],
-      tarballBytes: 1,
-      tarballSha256: "d".repeat(64),
-      tarballPath: "/current.tgz",
     };
     const input = {
       environments: [environment()],
       placements: [placement()],
-      preparation: {
-        currentArtifact: async () => artifact,
+      bundleRetention: {
+        currentBuild: async () => artifact,
         isEnvironmentOwnedNode: () => false,
-        prepare: vi.fn(async () => {}),
-        invalidate: vi.fn(),
       },
       results: [
         { applied: true, deleted: 0, hasMore: false, bundleGeneration: 1 },
@@ -731,15 +725,18 @@ describe("node workspace retain coordinator", () => {
       bundleHashes: [artifact.bundleHash],
       retain: [],
     });
+    expect(invoke.mock.calls.map(([request]) => request.command)).toEqual([
+      NODE_WORKER_WORKSPACE_RETAIN_COMMAND,
+      NODE_WORKER_WORKSPACE_RETAIN_COMMAND,
+      NODE_WORKER_WORKSPACE_RETAIN_COMMAND,
+    ]);
     await coordinator.stop();
   });
 
-  it("does not prepare a node owned by cloud enrollment", async () => {
-    const preparation = {
-      currentArtifact: vi.fn(),
+  it("does not add the current-build retention pin to cloud-enrolled nodes", async () => {
+    const bundleRetention = {
+      currentBuild: vi.fn(),
       isEnvironmentOwnedNode: () => true,
-      prepare: vi.fn(),
-      invalidate: vi.fn(),
     };
     const { coordinator } = createHarness({
       environments: [
@@ -748,27 +745,26 @@ describe("node workspace retain coordinator", () => {
           profileSnapshot: { executionMode: "remote-exec" },
         }),
       ],
-      preparation,
+      bundleRetention,
     });
     await coordinator.start();
-    expect(preparation.currentArtifact).not.toHaveBeenCalled();
-    expect(preparation.prepare).not.toHaveBeenCalled();
+    expect(bundleRetention.currentBuild).not.toHaveBeenCalled();
     await coordinator.stop();
   });
 
-  it("prepares a newly connected node while another node's installation is held", async () => {
+  it("maintains a newly connected node while another node's retention is held", async () => {
     const held = createDeferredCore();
     const second = { ...node, nodeId: "node-2", connId: "connection-2" };
     let nodes: NodeWorkerSupervisorNodeProof[] = [node];
-    const prepare = vi.fn(async ({ node: current }: { node: NodeWorkerSupervisorNodeProof }) => {
-      if (current.nodeId === node.nodeId) {
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) => {
+      if (request.node.nodeId === node.nodeId) {
         await held.promise;
       }
+      return {
+        ok: true,
+        payloadJSON: JSON.stringify({ applied: true, deleted: 0, hasMore: false }),
+      };
     });
-    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async () => ({
-      ok: true,
-      payloadJSON: JSON.stringify({ applied: true, deleted: 0, hasMore: false }),
-    }));
     const transport: NodeWorkerSupervisorTransport = {
       listCurrentNodes: async () => nodes,
       hasCurrentRunner: () => true,
@@ -779,63 +775,44 @@ describe("node workspace retain coordinator", () => {
       gatewayNamespace: "gateway-test",
       environments: { list: () => [] },
       placements: { list: () => [], listPendingWorkspaceResults: () => [] },
-      preparation: {
-        isEnvironmentOwnedNode: () => false,
-        currentArtifact: async () => ({
-          install: "bundle",
-          bundleHash: "c".repeat(64),
-          openclawVersion: "2026.8.10",
-          protocolFeatures: [],
-          tarballBytes: 1,
-          tarballSha256: "d".repeat(64),
-          tarballPath: "/current.tgz",
-        }),
-        prepare,
-        invalidate: () => {},
-      },
       warn: vi.fn(),
     });
     coordinator.bindTransport(transport);
     const first = coordinator.start();
-    await vi.waitFor(() => expect(prepare).toHaveBeenCalledOnce());
-    nodes = [node, second];
-    await coordinator.schedule(second.nodeId);
-    expect(invoke).toHaveBeenCalledWith(expect.objectContaining({ node: second }));
-    expect(invoke).not.toHaveBeenCalledWith(expect.objectContaining({ node }));
-    held.resolve();
-    await first;
-    await coordinator.stop();
+    try {
+      await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+      nodes = [node, second];
+      await coordinator.schedule(second.nodeId);
+      expect(invoke).toHaveBeenCalledWith(expect.objectContaining({ node: second }));
+    } finally {
+      held.resolve();
+      await first;
+      await coordinator.stop();
+    }
   });
 
-  it("rechecks environment ownership after artifact preparation before installing or retaining it", async () => {
+  it("rechecks environment ownership after resolving the current build before retaining it", async () => {
     const artifact = {
-      install: "bundle" as const,
       bundleHash: "c".repeat(64),
       openclawVersion: "2026.8.10",
       protocolFeatures: [],
-      tarballBytes: 1,
-      tarballSha256: "d".repeat(64),
-      tarballPath: "/current.tgz",
     };
     const held = createDeferredCore<typeof artifact>();
     let environmentOwned = false;
-    const preparation = {
+    const bundleRetention = {
       isEnvironmentOwnedNode: () => environmentOwned,
-      currentArtifact: vi.fn(() => held.promise),
-      prepare: vi.fn(),
-      invalidate: vi.fn(),
+      currentBuild: vi.fn(() => held.promise),
     };
     const { coordinator, invoke } = createHarness({
       environments: [],
       placements: [],
-      preparation,
+      bundleRetention,
     });
     const startup = coordinator.start();
-    await vi.waitFor(() => expect(preparation.currentArtifact).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(bundleRetention.currentBuild).toHaveBeenCalledOnce());
     environmentOwned = true;
     held.resolve(artifact);
     await startup;
-    expect(preparation.prepare).not.toHaveBeenCalled();
     expect(invoke.mock.calls[0]?.[0].params).toMatchObject({ bundleHashes: [] });
     expect(invoke.mock.calls[0]?.[0].params).not.toHaveProperty("bundleStatusHash");
     await coordinator.stop();

--- a/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
+++ b/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { NODE_WORKER_WORKSPACE_RETAIN_COMMAND } from "../../infra/node-commands.js";
 import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../../infra/node-runner-inventory.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import {
   NODE_WORKER_BUNDLE_RETAIN_MAX_HASHES,
   NODE_WORKER_RETAIN_REQUEST_MAX_BYTES,
@@ -104,6 +105,7 @@ function createHarness(
     }>;
     node?: NodeWorkerSupervisorNodeProof;
     currentBundleStatus?: NodeWorkerBundleStatusObservation;
+    preparation?: Parameters<typeof createNodeWorkspaceRetainCoordinator>[0]["preparation"];
     additionalManifestRefs?: Parameters<
       typeof createNodeWorkspaceRetainCoordinator
     >[0]["additionalManifestRefs"];
@@ -151,6 +153,7 @@ function createHarness(
       list: () => (params.placements ?? [placement()]) as never,
       listPendingWorkspaceResults: () => params.pendingResults ?? [],
     } as Pick<WorkerSessionPlacementStore, "list" | "listPendingWorkspaceResults">,
+    preparation: params.preparation,
     additionalManifestRefs: params.additionalManifestRefs,
     warn,
   });
@@ -685,5 +688,156 @@ describe("node workspace retain coordinator", () => {
     } finally {
       await coordinator.stop();
     }
+  });
+
+  it("retains the prepared current build without keeping unreferenced older builds", async () => {
+    const artifact = {
+      install: "bundle" as const,
+      bundleHash: "c".repeat(64),
+      openclawVersion: "2026.8.10",
+      protocolFeatures: [],
+      tarballBytes: 1,
+      tarballSha256: "d".repeat(64),
+      tarballPath: "/current.tgz",
+    };
+    const input = {
+      environments: [environment()],
+      placements: [placement()],
+      preparation: {
+        currentArtifact: async () => artifact,
+        isEnvironmentOwnedNode: () => false,
+        prepare: vi.fn(async () => {}),
+        invalidate: vi.fn(),
+      },
+      results: [
+        { applied: true, deleted: 0, hasMore: false, bundleGeneration: 1 },
+        { applied: true, deleted: 0, hasMore: false, bundleGeneration: 1 },
+        { applied: true, deleted: 1, hasMore: false, bundleGeneration: 1 },
+      ],
+    };
+    const { coordinator, invoke } = createHarness(input);
+    await coordinator.start();
+    await coordinator.schedule();
+    expect(invoke.mock.calls[1]?.[0].params).toMatchObject({
+      acknowledgedBundleGeneration: 1,
+      bundleHashes: ["b".repeat(64), artifact.bundleHash],
+      bundleStatusHash: artifact.bundleHash,
+    });
+    input.environments = [];
+    input.placements = [];
+    await coordinator.schedule();
+    expect(invoke.mock.calls[2]?.[0].params).toMatchObject({
+      acknowledgedBundleGeneration: 1,
+      bundleHashes: [artifact.bundleHash],
+      retain: [],
+    });
+    await coordinator.stop();
+  });
+
+  it("does not prepare a node owned by cloud enrollment", async () => {
+    const preparation = {
+      currentArtifact: vi.fn(),
+      isEnvironmentOwnedNode: () => true,
+      prepare: vi.fn(),
+      invalidate: vi.fn(),
+    };
+    const { coordinator } = createHarness({
+      environments: [
+        environment({
+          nodeSetupId: "cloud-setup",
+          profileSnapshot: { executionMode: "remote-exec" },
+        }),
+      ],
+      preparation,
+    });
+    await coordinator.start();
+    expect(preparation.currentArtifact).not.toHaveBeenCalled();
+    expect(preparation.prepare).not.toHaveBeenCalled();
+    await coordinator.stop();
+  });
+
+  it("prepares a newly connected node while another node's installation is held", async () => {
+    const held = createDeferredCore();
+    const second = { ...node, nodeId: "node-2", connId: "connection-2" };
+    let nodes: NodeWorkerSupervisorNodeProof[] = [node];
+    const prepare = vi.fn(async ({ node: current }: { node: NodeWorkerSupervisorNodeProof }) => {
+      if (current.nodeId === node.nodeId) {
+        await held.promise;
+      }
+    });
+    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async () => ({
+      ok: true,
+      payloadJSON: JSON.stringify({ applied: true, deleted: 0, hasMore: false }),
+    }));
+    const transport: NodeWorkerSupervisorTransport = {
+      listCurrentNodes: async () => nodes,
+      hasCurrentRunner: () => true,
+      isCurrent: () => true,
+      invoke,
+    };
+    const coordinator = createNodeWorkspaceRetainCoordinator({
+      gatewayNamespace: "gateway-test",
+      environments: { list: () => [] },
+      placements: { list: () => [], listPendingWorkspaceResults: () => [] },
+      preparation: {
+        isEnvironmentOwnedNode: () => false,
+        currentArtifact: async () => ({
+          install: "bundle",
+          bundleHash: "c".repeat(64),
+          openclawVersion: "2026.8.10",
+          protocolFeatures: [],
+          tarballBytes: 1,
+          tarballSha256: "d".repeat(64),
+          tarballPath: "/current.tgz",
+        }),
+        prepare,
+        invalidate: () => {},
+      },
+      warn: vi.fn(),
+    });
+    coordinator.bindTransport(transport);
+    const first = coordinator.start();
+    await vi.waitFor(() => expect(prepare).toHaveBeenCalledOnce());
+    nodes = [node, second];
+    await coordinator.schedule(second.nodeId);
+    expect(invoke).toHaveBeenCalledWith(expect.objectContaining({ node: second }));
+    expect(invoke).not.toHaveBeenCalledWith(expect.objectContaining({ node }));
+    held.resolve();
+    await first;
+    await coordinator.stop();
+  });
+
+  it("rechecks environment ownership after artifact preparation before installing or retaining it", async () => {
+    const artifact = {
+      install: "bundle" as const,
+      bundleHash: "c".repeat(64),
+      openclawVersion: "2026.8.10",
+      protocolFeatures: [],
+      tarballBytes: 1,
+      tarballSha256: "d".repeat(64),
+      tarballPath: "/current.tgz",
+    };
+    const held = createDeferredCore<typeof artifact>();
+    let environmentOwned = false;
+    const preparation = {
+      isEnvironmentOwnedNode: () => environmentOwned,
+      currentArtifact: vi.fn(() => held.promise),
+      prepare: vi.fn(),
+      invalidate: vi.fn(),
+    };
+    const { coordinator, invoke } = createHarness({
+      environments: [],
+      placements: [],
+      preparation,
+    });
+    const startup = coordinator.start();
+    await vi.waitFor(() => expect(preparation.currentArtifact).toHaveBeenCalledOnce());
+    environmentOwned = true;
+    held.resolve(artifact);
+    await startup;
+    expect(preparation.prepare).not.toHaveBeenCalled();
+    expect(invoke.mock.calls[0]?.[0].params).toMatchObject({ bundleHashes: [] });
+    expect(invoke.mock.calls[0]?.[0].params).not.toHaveProperty("bundleStatusHash");
+    await coordinator.stop();
   });
 });

--- a/src/gateway/worker-environments/node-workspace-retain-coordinator.ts
+++ b/src/gateway/worker-environments/node-workspace-retain-coordinator.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import type { WorkerAdmissionHandshake } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { NODE_WORKER_WORKSPACE_RETAIN_COMMAND } from "../../infra/node-commands.js";
 import {
   NODE_WORKER_BUNDLE_RETENTION_VERSION,
@@ -15,7 +16,6 @@ import type {
   NodeWorkerSupervisorNodeProof,
   NodeWorkerSupervisorTransport,
 } from "../node-registry-private.js";
-import type { NodeWorkerBundlePreparation } from "./node-worker-bundle-installer.js";
 import type {
   WorkerSessionPlacementRecord,
   WorkerSessionPlacementStore,
@@ -26,11 +26,18 @@ import { listRetainedWorkerBundleHashes } from "./worker-bundle-retention.js";
 const RETAIN_COMMAND_TIMEOUT_MS = 10 * 60_000;
 const TERMINAL_ENVIRONMENT_STATES = new Set(["destroyed", "failed", "orphaned"]);
 
+export type NodeWorkerBundleRetention = {
+  currentBuild: () => Promise<
+    Readonly<Pick<WorkerAdmissionHandshake, "bundleHash" | "openclawVersion">>
+  >;
+  isEnvironmentOwnedNode: (nodeId: string) => boolean;
+};
+
 type NodeWorkspaceRetainCoordinatorOptions = {
   gatewayNamespace: string;
   placements: Pick<WorkerSessionPlacementStore, "list" | "listPendingWorkspaceResults">;
   environments: Pick<WorkerEnvironmentService, "list">;
-  preparation?: NodeWorkerBundlePreparation;
+  bundleRetention?: NodeWorkerBundleRetention;
   additionalManifestRefs?: (placement: WorkerSessionPlacementRecord) => readonly string[];
   warn: (message: string) => void;
 };
@@ -155,35 +162,20 @@ export function createNodeWorkspaceRetainCoordinator(
     node: NodeWorkerSupervisorNodeProof,
   ): Promise<void> => {
     // Environment-owned cloud nodes prepare under their enrollment/mode owner.
-    // Persistent, consented session hosts retain one current build even before a first session.
-    const preparation = options.preparation;
-    let currentArtifact =
-      preparation && !preparation.isEnvironmentOwnedNode(node.nodeId)
-        ? await preparation.currentArtifact()
+    // Persistent hosts keep the current build when installed; maintenance never installs it.
+    const bundleRetention = options.bundleRetention;
+    let currentBuild =
+      bundleRetention && !bundleRetention.isEnvironmentOwnedNode(node.nodeId)
+        ? await bundleRetention.currentBuild()
         : undefined;
-    if (preparation?.isEnvironmentOwnedNode(node.nodeId)) {
-      currentArtifact = undefined;
-    }
-    if (currentArtifact) {
-      try {
-        await preparation!.prepare({
-          node,
-          artifact: currentArtifact,
-          signal: abortController.signal,
-        });
-      } catch {
-        // The preparation attempt reports failure once. Retention/status still
-        // inspect the current build without retrying that failed generation.
-      }
-    }
-    if (preparation?.isEnvironmentOwnedNode(node.nodeId)) {
-      currentArtifact = undefined;
+    if (bundleRetention?.isEnvironmentOwnedNode(node.nodeId)) {
+      currentBuild = undefined;
     }
     const isCurrent = () =>
       !stopped &&
       transport === currentTransport &&
       currentTransport.isCurrent(node) &&
-      (!currentArtifact || !preparation!.isEnvironmentOwnedNode(node.nodeId));
+      (!currentBuild || !bundleRetention!.isEnvironmentOwnedNode(node.nodeId));
 
     if (!isCurrent()) {
       return;
@@ -191,7 +183,7 @@ export function createNodeWorkspaceRetainCoordinator(
     const retainedBundleHashes = [
       ...new Set([
         ...snapshotBundleHashesForNode(options, node.nodeId),
-        ...(currentArtifact ? [currentArtifact.bundleHash] : []),
+        ...(currentBuild ? [currentBuild.bundleHash] : []),
       ]),
     ].toSorted();
     const bundleRetentionSupported =
@@ -218,7 +210,7 @@ export function createNodeWorkspaceRetainCoordinator(
       Buffer.byteLength(JSON.stringify(retentionInput), "utf8") <=
         NODE_WORKER_RETAIN_REQUEST_MAX_BYTES;
     const bundleStatusTarget = bundleStatusSupported
-      ? (currentArtifact ?? bundleStatusTargetForNode(options, node.nodeId))
+      ? (currentBuild ?? bundleStatusTargetForNode(options, node.nodeId))
       : undefined;
     const statusInput =
       bundleStatusTarget && retainedBundleHashes.includes(bundleStatusTarget.bundleHash)
@@ -284,7 +276,7 @@ export function createNodeWorkspaceRetainCoordinator(
         const bundleStatus = retained.bundleStatus;
         const requestedBundleHash = input.bundleStatusHash;
         const currentStatusTarget = requestedBundleHash
-          ? (currentArtifact ?? bundleStatusTargetForNode(options, node.nodeId))
+          ? (currentBuild ?? bundleStatusTargetForNode(options, node.nodeId))
           : undefined;
         const statusTargetMatches =
           currentStatusTarget != null &&
@@ -311,7 +303,6 @@ export function createNodeWorkspaceRetainCoordinator(
   };
 
   const schedule = (nodeId?: string): Promise<void> => {
-    options.preparation?.invalidate(nodeId);
     if (stopped) {
       return Promise.resolve();
     }
@@ -350,7 +341,7 @@ export function createNodeWorkspaceRetainCoordinator(
             }
           } else {
             // The all-node join reports completion; each reconnect has its own
-            // coalesced operation and never queues behind another node's download.
+            // coalesced operation and never queues behind another node's maintenance.
             await Promise.all(nodes.map((node) => schedule(node.nodeId)));
           }
         } catch (error) {

--- a/src/gateway/worker-environments/node-workspace-retain-coordinator.ts
+++ b/src/gateway/worker-environments/node-workspace-retain-coordinator.ts
@@ -15,6 +15,7 @@ import type {
   NodeWorkerSupervisorNodeProof,
   NodeWorkerSupervisorTransport,
 } from "../node-registry-private.js";
+import type { NodeWorkerBundlePreparation } from "./node-worker-bundle-installer.js";
 import type {
   WorkerSessionPlacementRecord,
   WorkerSessionPlacementStore,
@@ -29,6 +30,7 @@ type NodeWorkspaceRetainCoordinatorOptions = {
   gatewayNamespace: string;
   placements: Pick<WorkerSessionPlacementStore, "list" | "listPendingWorkspaceResults">;
   environments: Pick<WorkerEnvironmentService, "list">;
+  preparation?: NodeWorkerBundlePreparation;
   additionalManifestRefs?: (placement: WorkerSessionPlacementRecord) => readonly string[];
   warn: (message: string) => void;
 };
@@ -144,7 +146,7 @@ export function createNodeWorkspaceRetainCoordinator(
   let transport: NodeWorkerSupervisorTransport | undefined;
   let sequence = 0;
   let pendingAll = false;
-  let operation: Promise<void> | undefined;
+  const operations = new Map<string | undefined, Promise<void>>();
   let started = false;
   let stopped = false;
 
@@ -152,7 +154,46 @@ export function createNodeWorkspaceRetainCoordinator(
     currentTransport: NodeWorkerSupervisorTransport,
     node: NodeWorkerSupervisorNodeProof,
   ): Promise<void> => {
-    const retainedBundleHashes = snapshotBundleHashesForNode(options, node.nodeId);
+    // Environment-owned cloud nodes prepare under their enrollment/mode owner.
+    // Persistent, consented session hosts retain one current build even before a first session.
+    const preparation = options.preparation;
+    let currentArtifact =
+      preparation && !preparation.isEnvironmentOwnedNode(node.nodeId)
+        ? await preparation.currentArtifact()
+        : undefined;
+    if (preparation?.isEnvironmentOwnedNode(node.nodeId)) {
+      currentArtifact = undefined;
+    }
+    if (currentArtifact) {
+      try {
+        await preparation!.prepare({
+          node,
+          artifact: currentArtifact,
+          signal: abortController.signal,
+        });
+      } catch {
+        // The preparation attempt reports failure once. Retention/status still
+        // inspect the current build without retrying that failed generation.
+      }
+    }
+    if (preparation?.isEnvironmentOwnedNode(node.nodeId)) {
+      currentArtifact = undefined;
+    }
+    const isCurrent = () =>
+      !stopped &&
+      transport === currentTransport &&
+      currentTransport.isCurrent(node) &&
+      (!currentArtifact || !preparation!.isEnvironmentOwnedNode(node.nodeId));
+
+    if (!isCurrent()) {
+      return;
+    }
+    const retainedBundleHashes = [
+      ...new Set([
+        ...snapshotBundleHashesForNode(options, node.nodeId),
+        ...(currentArtifact ? [currentArtifact.bundleHash] : []),
+      ]),
+    ].toSorted();
     const bundleRetentionSupported =
       node.workerHost.bundleRetention === NODE_WORKER_BUNDLE_RETENTION_VERSION;
     const bundleStatusSupported =
@@ -177,7 +218,7 @@ export function createNodeWorkspaceRetainCoordinator(
       Buffer.byteLength(JSON.stringify(retentionInput), "utf8") <=
         NODE_WORKER_RETAIN_REQUEST_MAX_BYTES;
     const bundleStatusTarget = bundleStatusSupported
-      ? bundleStatusTargetForNode(options, node.nodeId)
+      ? (currentArtifact ?? bundleStatusTargetForNode(options, node.nodeId))
       : undefined;
     const statusInput =
       bundleStatusTarget && retainedBundleHashes.includes(bundleStatusTarget.bundleHash)
@@ -212,8 +253,11 @@ export function createNodeWorkspaceRetainCoordinator(
         params: input,
         timeoutMs: RETAIN_COMMAND_TIMEOUT_MS,
         signal: abortController.signal,
-        isDispatchAuthorized: () => !stopped && transport === currentTransport,
+        isDispatchAuthorized: isCurrent,
       });
+      if (!isCurrent()) {
+        return;
+      }
       if (!result.ok) {
         throw new Error(
           result.error?.message ??
@@ -240,7 +284,7 @@ export function createNodeWorkspaceRetainCoordinator(
         const bundleStatus = retained.bundleStatus;
         const requestedBundleHash = input.bundleStatusHash;
         const currentStatusTarget = requestedBundleHash
-          ? bundleStatusTargetForNode(options, node.nodeId)
+          ? (currentArtifact ?? bundleStatusTargetForNode(options, node.nodeId))
           : undefined;
         const statusTargetMatches =
           currentStatusTarget != null &&
@@ -266,46 +310,8 @@ export function createNodeWorkspaceRetainCoordinator(
     }
   };
 
-  const drain = async (): Promise<void> => {
-    while (pendingAll || pendingNodes.size > 0) {
-      if (stopped) {
-        return;
-      }
-      const reconcileAll = pendingAll;
-      const requestedNodes = new Set(pendingNodes);
-      pendingAll = false;
-      pendingNodes.clear();
-      const currentTransport = transport;
-      if (!currentTransport) {
-        continue;
-      }
-      let currentNodes: readonly NodeWorkerSupervisorNodeProof[];
-      try {
-        currentNodes = await currentTransport.listCurrentNodes();
-      } catch (error) {
-        options.warn(
-          `Node workspace retain inventory failed: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        continue;
-      }
-      const targets = reconcileAll
-        ? currentNodes
-        : currentNodes.filter((node) => requestedNodes.has(node.nodeId));
-      await Promise.all(
-        targets.map(async (node) => {
-          try {
-            await publishSnapshot(currentTransport, node);
-          } catch (error) {
-            options.warn(
-              `Node workspace retain publication failed (${node.nodeId}): ${error instanceof Error ? error.message : String(error)}`,
-            );
-          }
-        }),
-      );
-    }
-  };
-
   const schedule = (nodeId?: string): Promise<void> => {
+    options.preparation?.invalidate(nodeId);
     if (stopped) {
       return Promise.resolve();
     }
@@ -314,28 +320,54 @@ export function createNodeWorkspaceRetainCoordinator(
     } else {
       pendingAll = true;
     }
-    if (!started) {
+    if (!started || !transport) {
       return Promise.resolve();
     }
-    if (operation) {
-      return operation;
+    const previous = operations.get(nodeId);
+    if (previous) {
+      return previous;
     }
-    const current = drain().catch((error: unknown) => {
-      options.warn(
-        `Node workspace retain reconciliation failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    });
-    const tracked = current.finally(() => {
-      if (operation !== tracked) {
-        return;
+    const run = async () => {
+      do {
+        if (nodeId) {
+          pendingNodes.delete(nodeId);
+        } else {
+          pendingAll = false;
+        }
+        const currentTransport = transport;
+        if (!currentTransport || stopped) {
+          return;
+        }
+        try {
+          const nodes = await currentTransport.listCurrentNodes();
+          if (stopped || transport !== currentTransport) {
+            continue;
+          }
+          if (nodeId) {
+            const node = nodes.find((candidate) => candidate.nodeId === nodeId);
+            if (node && currentTransport.isCurrent(node)) {
+              await publishSnapshot(currentTransport, node);
+            }
+          } else {
+            // The all-node join reports completion; each reconnect has its own
+            // coalesced operation and never queues behind another node's download.
+            await Promise.all(nodes.map((node) => schedule(node.nodeId)));
+          }
+        } catch (error) {
+          options.warn(
+            `Node workspace retain publication failed (${nodeId ?? "inventory"}): ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      } while (nodeId ? pendingNodes.has(nodeId) : pendingAll);
+    };
+    const operation = run().finally(() => {
+      operations.delete(nodeId);
+      if (!stopped && (nodeId ? pendingNodes.has(nodeId) : pendingAll)) {
+        void schedule(nodeId);
       }
-      operation = undefined;
-      if (!stopped && (pendingAll || pendingNodes.size > 0)) {
-        void schedule();
-      }
     });
-    operation = tracked;
-    return tracked;
+    operations.set(nodeId, operation);
+    return operation;
   };
 
   return {
@@ -347,7 +379,12 @@ export function createNodeWorkspaceRetainCoordinator(
     },
     start(): Promise<void> {
       started = true;
-      return schedule();
+      const targets = pendingAll ? [undefined] : [...pendingNodes];
+      pendingAll = false;
+      pendingNodes.clear();
+      return Promise.all((targets.length ? targets : [undefined]).map(schedule)).then(
+        () => undefined,
+      );
     },
     schedule,
     async stop(): Promise<void> {
@@ -356,7 +393,7 @@ export function createNodeWorkspaceRetainCoordinator(
       abortController.abort(new Error("node workspace retention stopped"));
       pendingAll = false;
       pendingNodes.clear();
-      await operation;
+      await Promise.all(operations.values());
     },
   };
 }

--- a/src/gateway/worker-environments/provider-provisioning-node.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning-node.test.ts
@@ -45,6 +45,17 @@ describe("node worker provider provisioning", () => {
         ok: true,
         payload: support.BOOTSTRAP_RECEIPT,
       }));
+      const transport: NodeWorkerSupervisorTransport = {
+        hasCurrentRunner: () => true,
+        listCurrentNodes: async () => [node],
+        isCurrent: (candidate) => candidate === node,
+        invoke,
+      };
+      const installer = createGatewayNodeWorkerBundleInstaller({
+        gatewayNamespace: "gateway-test",
+        getTransport: () => transport,
+        transfer,
+      });
       const workerService = support.createService(
         support.createProvider({
           supportedExecutionModes: ["worker-turn", "remote-exec"],
@@ -55,16 +66,7 @@ describe("node worker provider provisioning", () => {
           }),
         }),
         {
-          ensureNodeWorkerBundle: createGatewayNodeWorkerBundleInstaller({
-            gatewayNamespace: "gateway-test",
-            getTransport: () => ({
-              hasCurrentRunner: () => true,
-              listCurrentNodes: async () => [node],
-              isCurrent: (candidate) => candidate === node,
-              invoke,
-            }),
-            transfer,
-          }),
+          ensureNodeWorkerBundle: installer.ensure,
         },
       );
       try {
@@ -90,6 +92,7 @@ describe("node worker provider provisioning", () => {
           expect(input).toHaveProperty("bundlePrewarm", 1);
         }
       } finally {
+        await installer.close();
         transfer.closeAll();
       }
     },

--- a/src/gateway/worker-environments/provider-provisioning-node.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning-node.test.ts
@@ -51,7 +51,7 @@ describe("node worker provider provisioning", () => {
         isCurrent: (candidate) => candidate === node,
         invoke,
       };
-      const installer = createGatewayNodeWorkerBundleInstaller({
+      const ensureNodeWorkerBundle = createGatewayNodeWorkerBundleInstaller({
         gatewayNamespace: "gateway-test",
         getTransport: () => transport,
         transfer,
@@ -66,7 +66,7 @@ describe("node worker provider provisioning", () => {
           }),
         }),
         {
-          ensureNodeWorkerBundle: installer.ensure,
+          ensureNodeWorkerBundle,
         },
       );
       try {
@@ -92,7 +92,6 @@ describe("node worker provider provisioning", () => {
           expect(input).toHaveProperty("bundlePrewarm", 1);
         }
       } finally {
-        await installer.close();
         transfer.closeAll();
       }
     },

--- a/src/gateway/worker-environments/store-node-enrollment.test.ts
+++ b/src/gateway/worker-environments/store-node-enrollment.test.ts
@@ -78,6 +78,8 @@ describe("worker environment node enrollment store", () => {
     expect(pending.nodeDeviceId).toBeNull();
     expect(store.ensureNodeEnrollment("worker-enrollment").nodeSetupId).toBe(setupId);
     expect(store.hasPendingNodeEnrollmentSetup(setupId, "cloud-device-1")).toBe(true);
+    expect(store.hasNodeEnrollmentOwner("cloud-device-1")).toBe(false);
+    const inventoryVersion = store.inventoryVersion();
 
     const issued = await ensureDevicePairSetupBootstrapToken({
       baseDir: root,
@@ -108,6 +110,9 @@ describe("worker environment node enrollment store", () => {
     });
     expect(store.hasPendingNodeEnrollmentSetup(setupId, "cloud-device-1")).toBe(true);
     expect(store.hasPendingNodeEnrollmentSetup(setupId, "different-cloud-device")).toBe(false);
+    expect(store.inventoryVersion()).toBe(inventoryVersion);
+    expect(store.hasNodeEnrollmentOwner("cloud-device-1")).toBe(true);
+    expect(store.hasNodeEnrollmentOwner("different-cloud-device")).toBe(false);
   });
 
   it("rejects a destroy-requested provisioning setup", async () => {
@@ -158,6 +163,7 @@ describe("worker environment node enrollment store", () => {
       const setupId = seedEnrollmentState(state, "cloud-device-bound");
 
       expect(store.hasPendingNodeEnrollmentSetup(setupId, "cloud-device-bound")).toBe(true);
+      expect(store.hasNodeEnrollmentOwner("cloud-device-bound")).toBe(true);
       expect(store.hasPendingNodeEnrollmentSetup(setupId, "different-cloud-device")).toBe(false);
       expect(store.hasPendingNodeEnrollmentSetup("missing-setup", "cloud-device-bound")).toBe(
         false,
@@ -182,6 +188,9 @@ describe("worker environment node enrollment store", () => {
       const setupId = seedEnrollmentState(state, "cloud-device-bound");
 
       expect(store.hasPendingNodeEnrollmentSetup(setupId, "cloud-device-bound")).toBe(false);
+      expect(store.hasNodeEnrollmentOwner("cloud-device-bound")).toBe(
+        state === "requested" || state === "draining" || state === "destroying",
+      );
     },
   );
 
@@ -223,6 +232,7 @@ describe("worker environment node enrollment store", () => {
       sharedHost: true,
       ownerEpoch: 1,
     });
+    expect(store.hasNodeEnrollmentOwner("device-1")).toBe(false);
     expect(
       database.db
         .prepare(

--- a/src/gateway/worker-environments/store.ts
+++ b/src/gateway/worker-environments/store.ts
@@ -926,6 +926,23 @@ export function createWorkerEnvironmentStore(
     },
     get: (environmentId: string) => find(read(), required(environmentId, "id")),
     inventoryVersion: () => inventoryVersion,
+    hasNodeEnrollmentOwner(nodeId: string): boolean {
+      const db = read();
+      // Pairing can bind the node without changing inventoryVersion. Cleanup states
+      // still own enrollment until the environment reaches its terminal state.
+      return (
+        executeSqliteQueryTakeFirstSync(
+          db,
+          query(db)
+            .selectFrom("worker_environments")
+            .select("environment_id")
+            .where("node_device_id", "=", nodeId)
+            .where("node_setup_id", "is not", null)
+            .where("state", "not in", TERMINAL_STATES)
+            .limit(1),
+        ) !== undefined
+      );
+    },
     hasPendingNodeEnrollmentSetup(setupIdInput: string, deviceIdInput: string): boolean {
       const setupId = setupIdInput.trim();
       const deviceId = deviceIdInput.trim();


### PR DESCRIPTION
Related: #140425

## What Problem This Solves

Fixes an issue where closing the last session on a persistent node can discard the current worker build, forcing the next session to download it again. Slow maintenance on one node can also delay another node.

## Why This Change Was Made

Keep one installed current worker artifact per Gateway namespace alongside existing live/recovery references, using the existing bounded retention protocol. Coalesce maintenance independently per node. Read current enrollment ownership from the canonical store instead of caching it by inventory version, which pairing does not update.

This revision removes the earlier automatic remote installation and shared preparation lifetime. Installation remains owned by an explicit session request and its cancellation signal; maintenance only retains installed software. Existing native integrity validation and cloud execution-mode ownership remain unchanged.

## User Impact

Later sessions reuse the current installed build after earlier sessions close. Unreferenced older builds remain eligible for normal cleanup. First use after a Gateway build change still installs the new artifact: this is a partial improvement toward #140425, not prewarming or a ten-second cold-start guarantee.

No schema, index, configuration, dependency, permission, or protocol changes. Node documentation describes the retention and installation boundaries. Release-note context is recorded here; CHANGELOG.md is release-owned.

## Evidence

- 137 focused tests across ten files pass, covering acknowledged retention after all sessions disappear, fresh enrollment reads, independent node progress, explicit installation cancellation, provider modes, and startup/shutdown.
- The original current-build retention regression fails against the previous coordinator. The revised maintenance tests also verify that maintenance sends retention commands only.
- Full canonical changed gate passed for all twelve paths: production/test typechecks, formatting, lint, dead-export scans, and architecture guards. A fresh full `pnpm build` also passed on the exact PR head with Node 24.20.0 and pnpm 12.3.4; that build is running in the dev Gateway.
- Independent review of the complete replacement is clean through P2. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34075368147) passed 108 jobs with 16 scope skips on `9f05f2ba0dcadf7276a588653d3ce96f0fe6ac5a`.
- Live test on a retained Intel Mac: first dispatch activated in 31.97 seconds; a second session after cleanup activated in 7.79 seconds. Both real agent tool calls returned `Darwin` successfully. After the first close, live/recovery and nonterminal-environment pins were zero; normal cleanup removed its workspace while the bundle receipt, bytes, inodes, and modification times stayed identical through the second activation. Both synthetic sessions were archived. This is two-sample warm reuse evidence, not a cold-cloud SLO or a measured network-download count.

The earlier background-installation finding was addressed by removing that design. Earlier CI and investigation results are historical evidence, not validation of the removed cancellation contract. There are no UI appearance changes.
