### PR TITLE
docs: drop /en/ prefix from 12 redirect destinations

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -54,51 +54,51 @@
   "redirects": [
     {
       "source": "/cli/commitments",
-      "destination": "/en/automation#retired-inferred-commitments"
+      "destination": "/automation#retired-inferred-commitments"
     },
     {
       "source": "/concepts/commitments",
-      "destination": "/en/automation#retired-inferred-commitments"
+      "destination": "/automation#retired-inferred-commitments"
     },
     {
       "source": "/concepts/channel-docking",
-      "destination": "/en/concepts/session#retired-channel-docking"
+      "destination": "/concepts/session#retired-channel-docking"
     },
     {
       "source": "/install/clawdock",
-      "destination": "/en/install/docker#clawdock-migration"
+      "destination": "/install/docker#clawdock-migration"
     },
     {
       "source": "/plan/swarms",
-      "destination": "/en/tools/swarm"
+      "destination": "/tools/swarm"
     },
     {
       "source": "/plugins/reference/linux-canvas",
-      "destination": "/en/platforms/linux#retired-linux-canvas"
+      "destination": "/platforms/linux#retired-linux-canvas"
     },
     {
       "source": "/plugins/reference/open-prose",
-      "destination": "/en/prose"
+      "destination": "/prose"
     },
     {
       "source": "/plugins/reference/workspaces",
-      "destination": "/en/web/dashboards#retired-workspaces"
+      "destination": "/web/dashboards#retired-workspaces"
     },
     {
       "source": "/providers/qwen-oauth",
-      "destination": "/en/providers/qwen#retired-qwen-portal-authentication"
+      "destination": "/providers/qwen#retired-qwen-portal-authentication"
     },
     {
       "source": "/refactor/canvas",
-      "destination": "/en/platforms/mac/canvas"
+      "destination": "/platforms/mac/canvas"
     },
     {
       "source": "/reference/templates/TOOLS.dev",
-      "destination": "/en/reference/templates/AGENTS.dev#tools"
+      "destination": "/reference/templates/AGENTS.dev#tools"
     },
     {
       "source": "/web/workspaces",
-      "destination": "/en/web/dashboards#retired-workspaces"
+      "destination": "/web/dashboards#retired-workspaces"
     },
     {
       "source": "/concepts/message-lifecycle-refactor",


### PR DESCRIPTION
## What

Twelve entries in `docs/docs.json` redirect to `/en/`-prefixed destinations. The other 283 use root-relative paths. This drops the prefix from those twelve.

## Why

English pages are served at the site root, so the `/en/` destinations 404 in production:

```
$ curl -s -o /dev/null -w '%{http_code}\n' https://docs.openclaw.ai/en/tools/swarm
404
$ curl -s -o /dev/null -w '%{http_code}\n' https://docs.openclaw.ai/tools/swarm
200
```

A reader who opens a redirect source such as `/plan/swarms` gets the "Redirecting" interstitial and then lands on a 404.

The `/en/` prefix belongs to the generated locale trees only. `scripts/docs-sync-publish.mjs` adds a locale prefix per locale at publish time (`prefixLocalePage`), and `docs/AGENTS.md` requires internal links to stay root-relative.

## Affected sources

`/cli/commitments`, `/concepts/commitments`, `/concepts/channel-docking`, `/install/clawdock`, `/plan/swarms`, `/plugins/reference/linux-canvas`, `/plugins/reference/open-prose`, `/plugins/reference/workspaces`, `/providers/qwen-oauth`, `/refactor/canvas`, `/reference/templates/TOOLS.dev`, `/web/workspaces`

## Validation

- All 12 rewritten destinations and their anchors resolve on disk (script-checked).
- `docs:check-mdx`: passed, 784 files.
- `docs-link-audit`: 8,326 internal links, 0 broken.

Found during the docs audit. Supersedes #140211, which was closed when a merge race deleted its branch.