### PR TITLE
refactor(codex): remove redundant app-server forwarding

### DIFF
--- a/extensions/codex/src/app-server/app-server-policy.ts
+++ b/extensions/codex/src/app-server/app-server-policy.ts
@@ -12,11 +12,10 @@ export function resolveCodexAppServerForModelProvider(params: {
   agentDir?: string;
   codexConfigToml?: string | null;
 }): CodexAppServerRuntimeOptions {
-  const explicitProvider = normalizeModelBackedReviewerProvider(params.provider);
   if (
     !isCodexModelBackedApprovalsReviewer(params.appServer.approvalsReviewer) ||
     canUseCodexModelBackedApprovalsReviewerForModel({
-      modelProvider: explicitProvider,
+      modelProvider: params.provider,
       model: params.model,
       config: params.config,
       // Reviewer trust follows the spawned process, not the gateway's ambient home or endpoint.
@@ -37,9 +36,4 @@ export function resolveCodexAppServerForModelProvider(params: {
 
 function isCodexModelBackedApprovalsReviewer(value: string): boolean {
   return value === "auto_review" || value === "guardian_subagent";
-}
-
-function normalizeModelBackedReviewerProvider(provider: string | undefined): string | undefined {
-  const normalized = provider?.trim().toLowerCase();
-  return normalized || undefined;
 }

--- a/extensions/codex/src/app-server/native-subagent-notification.ts
+++ b/extensions/codex/src/app-server/native-subagent-notification.ts
@@ -40,13 +40,13 @@ function extractCodexNativeSubagentCompletions(
   if (!item) {
     return [];
   }
-  const text = readTrustedInterAgentCommunicationContent(item);
-  if (!text) {
+  const communication = readTrustedInterAgentCommunication(item);
+  const text = communication?.content;
+  if (typeof text !== "string" || !text) {
     return [];
   }
-  const author = readTrustedInterAgentCommunicationAuthor(item);
   return extractCodexNativeSubagentCompletionsFromText(text).filter(
-    (completion) => completion.agentPath === author,
+    (completion) => completion.agentPath === communication?.author,
   );
 }
 
@@ -227,16 +227,6 @@ function completedWithoutFinalAssistantMessage(): {
     text: "Codex native subagent completed without a final assistant message.",
     kind: "no_final_assistant_message",
   };
-}
-
-function readTrustedInterAgentCommunicationContent(item: JsonObject): string | undefined {
-  const communication = readTrustedInterAgentCommunication(item);
-  return typeof communication?.content === "string" ? communication.content : undefined;
-}
-
-function readTrustedInterAgentCommunicationAuthor(item: JsonObject): string | undefined {
-  const communication = readTrustedInterAgentCommunication(item);
-  return typeof communication?.author === "string" ? communication.author : undefined;
 }
 
 function readTrustedInterAgentCommunication(item: JsonObject): JsonObject | undefined {

--- a/extensions/codex/src/app-server/thread-fingerprints.ts
+++ b/extensions/codex/src/app-server/thread-fingerprints.ts
@@ -10,7 +10,7 @@ import { hashCodexAppServerBindingFingerprint } from "./session-binding.js";
 import { resolveCodexGpt56MultiAgentVersion } from "./thread-binding-policy.js";
 
 export function codexDynamicToolsFingerprint(dynamicTools: readonly JsonValue[]): string {
-  return fingerprintDynamicTools(dynamicTools);
+  return hashCodexAppServerBindingFingerprint(legacyFingerprintDynamicTools(dynamicTools));
 }
 
 export function codexLegacyDynamicToolsFingerprint(dynamicTools: CodexDynamicToolSpec[]): string {
@@ -25,14 +25,10 @@ export function areCodexDynamicToolFingerprintsCompatible(params: {
   return areDynamicToolFingerprintsCompatible(params.previous, params.next, params.nextLegacy);
 }
 
-function fingerprintDynamicTools(dynamicTools: readonly JsonValue[]): string {
-  return hashCodexAppServerBindingFingerprint(legacyFingerprintDynamicTools(dynamicTools));
-}
-
 function legacyFingerprintDynamicTools(dynamicTools: readonly JsonValue[]): string {
-  return JSON.stringify(
-    dynamicTools.map(fingerprintDynamicToolSpec).toSorted(compareJsonFingerprint),
-  );
+  // Codex persists the complete model-visible schema at thread/start; resume
+  // cannot refresh changed tool or nested input descriptions.
+  return JSON.stringify(dynamicTools.map(stabilizeJsonValue).toSorted(compareJsonFingerprint));
 }
 
 export function legacyFingerprintUserMcpServersConfigPatch(
@@ -128,12 +124,6 @@ export function fingerprintEnvironmentSelection(
   environments: CodexTurnEnvironmentParams[] | undefined,
 ): string | undefined {
   return environments ? JSON.stringify(environments.map(stabilizeJsonValue)) : undefined;
-}
-
-function fingerprintDynamicToolSpec(tool: JsonValue): JsonValue {
-  // Codex persists the complete model-visible schema at thread/start; resume
-  // cannot refresh changed tool or nested input descriptions.
-  return stabilizeJsonValue(tool);
 }
 
 function stabilizeJsonValue(value: JsonValue): JsonValue {

--- a/extensions/codex/src/app-server/transport-websocket.ts
+++ b/extensions/codex/src/app-server/transport-websocket.ts
@@ -44,7 +44,7 @@ export function createWebSocketTransport(
   const socket = unixSocketPath
     ? new WebSocket("ws://localhost/", {
         ...websocketOptions,
-        createConnection: () => net.createConnection(unixSocketPath),
+        createConnection: () => connectCodexAppServerUnixSocket(unixSocketPath),
       })
     : new WebSocket(options.url, websocketOptions);
   const pendingFrames: string[] = [];
@@ -206,6 +206,11 @@ export function createWebSocketTransport(
     },
     once: (event, listener) => events.once(event, listener),
   };
+}
+
+/** Opens the owner-scoped Codex control socket used by the WebSocket upgrade. */
+function connectCodexAppServerUnixSocket(socketPath: string): net.Socket {
+  return net.createConnection(socketPath);
 }
 
 /** Resolves the canonical or explicitly configured Codex control socket. */

--- a/extensions/codex/src/app-server/transport-websocket.ts
+++ b/extensions/codex/src/app-server/transport-websocket.ts
@@ -44,7 +44,7 @@ export function createWebSocketTransport(
   const socket = unixSocketPath
     ? new WebSocket("ws://localhost/", {
         ...websocketOptions,
-        createConnection: () => connectCodexAppServerUnixSocket(unixSocketPath),
+        createConnection: () => net.createConnection(unixSocketPath),
       })
     : new WebSocket(options.url, websocketOptions);
   const pendingFrames: string[] = [];
@@ -206,11 +206,6 @@ export function createWebSocketTransport(
     },
     once: (event, listener) => events.once(event, listener),
   };
-}
-
-/** Opens the owner-scoped Codex control socket used by the WebSocket upgrade. */
-function connectCodexAppServerUnixSocket(socketPath: string): net.Socket {
-  return net.createConnection(socketPath);
 }
 
 /** Resolves the canonical or explicitly configured Codex control socket. */


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Codex app-server preparation contains private forwarding helpers and parses the same trusted communication twice. This is the maintainer-requested production deletion follow-up for concern C (stage 3) of the #135868 split.

## Why This Change Was Made

Read the validated communication once, let the existing reviewer predicate normalize its provider, and call the canonical fingerprint operations directly. All public entrypoints, completion formats, validation, reviewer trust rules, fingerprint compatibility and cleanup ownership remain unchanged.

## User Impact

No user-visible behavior change. Production shrinks by 26 lines (+9/−35); tests, tooling and docs are unchanged. No dependencies, configuration options or protocol changes.

## Evidence

| Deleted implementation | Remaining owner and coverage |
| --- | --- |
| Two single-use notification field helpers and duplicate parsing | `native-subagent-notification.ts:43` parses once; the unchanged reader validates the assistant/commentary envelope, author/recipient/content types and `trigger_turn: false`. The nonempty-content guard and author/path match remain. `native-subagent-notification.test.ts:153,196,209` covers extraction, mismatched authors and invalid envelopes; `:39,62` retains both receipt formats. |
| Repeated provider normalization | `app-server-policy.ts:18` passes the provider to `config-reviewer-policy.ts:74`, which already trims and lowercases it. Its trust callees do not consume raw `modelProvider`. `app-server-policy.test.ts:157,184,223,296,331` and `config.test.ts` retain provider, endpoint and effective-home trust behavior. |
| Private fingerprint forwarding helpers | `thread-fingerprints.ts:13,28` directly composes the same stabilization, sorting, serialization and hash. The complete-schema contract comment is retained. `thread-fingerprints.test.ts:27,39,49,65` retains model-visible descriptions, literal property names and ordering stability. All raw/hashed compatibility readers remain. |

Paths in the table are under `extensions/codex/src/app-server/`. Symbol searches show only the removed private definitions and the migrated callers. `git log -S` reaches `e357203be57` for notification/provider helpers and `b4b6afadd3c` for fingerprint forwarding; no separate public contract was identified for these private layers. This does not claim removal of a legacy protocol contract.

Direct dependency inspection used sibling Codex tag `rust-v0.153.4`, commit `3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`: `protocol.rs:804–840`, `core/src/agent/control.rs:612–663`, and `app-server-protocol/src/protocol/v2/item.rs:250–260`. Both completion producers and optional message phase remain current contracts and are retained. Prior compression PRs #139937 and #139953 were read; this change leaves their distinct cleanup evidence untouched.

Five existing suites passed before and after: 242 cases, 29.68 s → 18.07 s. Final committed-branch independent review is scoped-clean through P2. No tests were changed or replaced with mocks.

The full selected changed-check plan passed on Blacksmith Testbox `tbx_01m1w9h8fy0tz1qcmh7angtxfw` ([run 34060799199](https://github.com/openclaw/openclaw/actions/runs/34060799199)): all three source hashes matched, command duration 7m25s, exit 0, and lease stopped. Local lint preparation had refused ancestor `node_modules/punycode` in the nested checkout; no dependency or guard change was made to bypass that boundary. The wrapper exit/timing record is the delegated proof; successful cleanup may cancel the backing Actions run.

CI identified an additional ownership contract: `.github/codeql/openclaw-boundary/queries/raw-socket-callsite-classification.ql:81` classifies the existing `connectCodexAppServerUnixSocket` owner. The proposed five-line socket-wrapper deletion was withdrawn; `transport-websocket.ts` is byte-identical to the base. The classification rule and all baselines are unchanged.

Final head `a87d35adeea2f1e28d0198043bdb4691b1ea7310` passed [exact-head CI run 34060782009](https://github.com/openclaw/openclaw/actions/runs/34060782009), with the watcher reporting GREEN. ClawSweeper reviewed that head with no findings or before-merge/rank-up requests, including direct pinned Codex source inspection. Native review/prepare/merge landed it as `bd6f54b8aba690eaa8f42b7c9d74b06641d679b2`; GitHub state and main ancestry were verified.

Main's concurrent Proxyline dependency update was reported by the merge wrapper. After refreshing the local lockfile install once, post-merge checks covered all 399 retained MCP/Codex focused cases: three MCP deadline cases initially failed in the combined run and passed on one isolated rerun without changing assertions/timeouts; the remaining suites passed. The checkout is clean.
