### PR TITLE
docs(mantis): clarify inline proof commands and activation

### DIFF
--- a/docs/concepts/mantis.md
+++ b/docs/concepts/mantis.md
@@ -312,14 +312,46 @@ validates that the resolved SHA is either an
 ancestor of `origin/main`, a release tag (`v*`), or the head of an open PR
 before running with secret-bearing credentials.
 
-The scenario workflows remain available through manual Actions dispatch.
+The legacy scenario workflows above remain available through manual Actions dispatch.
 
 Do not rely on the former `@clawsweeper mantis ...` example as a dedicated
 dispatch command. ClawSweeper's current command parser routes an unrecognized
-mention to general assistance, not a typed Mantis dispatch. Use the manual
-Actions entrypoints above; a future command integration must reuse the command
-authorization and dispatch owners rather than infer execution authority from
-review prose.
+mention to general assistance, not a typed Mantis dispatch.
+
+The separate request-bound integration in
+[ClawSweeper #1425](https://github.com/openclaw/clawsweeper/pull/1425) and
+[OpenClaw #138953](https://github.com/openclaw/openclaw/pull/138953) lets the
+reviewer select relevant proof before completing its original review. It does
+not restore automatic post-review recording or require every check on every PR.
+Hosted execution requires the trusted producer workflows on `main` and the
+matching ClawSweeper Worker/runtime deployment; merging documentation does not
+activate it. The existing Convex credential service is still required, but its
+APIs are reused without a Convex schema change or deployment.
+
+Once that integration is deployed, a human maintainer can request a review with
+proof available, without supplying a SHA:
+
+```text
+@clawsweeper proof
+@clawsweeper proof web-ui-chat-proof
+@clawsweeper proof telegram-bot-e2e-proof
+@clawsweeper proof web-ui-chat-proof,telegram-bot-e2e-proof
+```
+
+The bare command lets the reviewer select useful checks; explicit selections
+request each named check. The review resolves the current PR head. Control UI
+supports the fixed chat smoke against a mocked Gateway; Telegram supports a
+bounded, data-only Test Server plan. The legacy Crabline recipe is not a third
+inline tool. Missing, late, or incomplete observations remain inconclusive.
+The reviewer assesses results in the same review; successful execution alone
+does not clear proof, other readiness blockers, or merge requirements.
+
+Selected checks share a 20-minute proof ceiling, further bounded by the original
+review's remaining time minus its final-decision reserve. With the default
+20-minute review timeout and 90-second reserve, that is at most 18m30s if invoked
+immediately, less after analysis. This is a ceiling, not a fixed wait or a fresh
+budget per check. A consumer timeout does not itself cancel a dispatched producer;
+producer cleanup and credential/lease limits remain separate.
 
 ### Telegram proof is a separate QA entrypoint
 
@@ -428,6 +460,4 @@ thread/reply relations, restart resume); neither is implemented yet.
 - Which Discord bot should be the driver vs. the SUT when the existing Mantis
   bot is reused?
 - How long should GitHub retain Mantis artifacts for PRs?
-- When should ClawSweeper automatically recommend a Mantis scenario instead of
-  waiting for a maintainer command?
 - Should screenshots be redacted or cropped before upload for public PRs?


### PR DESCRIPTION
## What Problem This Solves

The Mantis page still calls command integration future work and lists automatic selection as an open question. That conflicts with the paired request-bound implementation in [ClawSweeper #1425](https://github.com/openclaw/clawsweeper/pull/1425) and [OpenClaw #138953](https://github.com/openclaw/openclaw/pull/138953).

Related: merged [#138210](https://github.com/openclaw/openclaw/pull/138210). This follows @brokemac79's request and @obviyus's feedback to make useful proof available inside the original review.

## Why This Change Was Made

Correct the operator-facing instructions without adding more changes to the producer PR. The producer already adds a detailed later section about isolation and observations; this separate, non-overlapping patch supplies command, activation and timing guidance.

## User Impact

- Distinguishes legacy manual Actions entrypoints from selective inline proof; keeps the warning that `@clawsweeper mantis` is not a typed dispatch command.
- Shows the bare `@clawsweeper proof` override and either/both supported scenario selections, with automatic current-head resolution.
- Explains the shared 20-minute ceiling and smaller remaining-review bound, rather than promising a fresh 20 minutes per check.
- Makes coordinated producer/Worker deployment explicit, retains the existing Convex service without requiring its deployment, and does not claim the feature is already active.
- Removes the obsolete automatic-selection open question. No automatic post-review recording is restored.

## Evidence

Scope is one English Markdown page only. No runtime, tests, workflow, database/schema, navigation, generated/localized docs or `CHANGELOG.md` changes.

**Documentation proof:** compared live merged/current-main page blob `38b736cccb9cdb41d6cc79927888d87b802ef5ad` with consumer `d405f24703ad7a7fc1539d06304faefdd98ebe8d` command parser/prompt/budget and the then-current producer `72ace9d87d5002fed4828b811ecb4f01ca6284b1`, plus both live PR bodies. The final reviewed and published producer revision is now `f838be8f1e04fbca321aa60479f17490c9231aa1`. An independent combined-patch audit found no contradictory claims or overlapping edits with the producer's later detailed section.

Executed on Node 24.19.0 using the dependency-ready checkout's repository tooling against the exact edited page:

```text
node scripts/check-docs-mdx.mjs <docs-worktree>/docs/concepts/mantis.md
  Docs MDX check passed (1 files).
pnpm exec oxfmt --check <docs-worktree>/docs/concepts/mantis.md
  All matched files use the correct format.
git diff --check
  passed in the docs worktree.
```

No new headings, internal links, config fences or navigation routes are introduced. Both external PR links were inspected live. English remains the source of truth; translations are generated in the separate docs publish repository.

Codex reviews are **scoped-clean through P2, zero actionable findings**: dirty review confidence 0.97; committed-branch review confidence 0.98 at `7f5e0d0b84e6ce5442b43b848acc67b0aff1351a`, base `1fde67b08a4e8426474a46acd9ea968e300f8872`. Commands: `python .agents/skills/autoreview/scripts/autoreview --mode local --max-priority P2 --prompt <paired source context>` before commit, then `--mode branch --base 1fde67b08a4e8426474a46acd9ea968e300f8872 --max-priority P2` after commit. Full scanning and final source verification stayed enabled. Source/mirror trees and complete binary branch diff matched; no findings required edits. `git merge-tree --write-tree <docs-head> 72ace9d87d5002fed4828b811ecb4f01ca6284b1` also passed, proving the docs changes combined without conflict with that historical producer head. This historical merge-tree check is not a claim of fresh merge compatibility with the final producer revision.

## Risks and Rollout

### Pinned consumer source verification

The first ClawSweeper review could not retrieve the companion repository's blobs. To make the cross-repository evidence inspectable here, the following excerpts were checked against the GitHub Contents API at exact consumer revision `d405f24703ad7a7fc1539d06304faefdd98ebe8d`; every returned blob SHA matched the local Git object, not a stale web-search result.

[Command parser](https://github.com/openclaw/clawsweeper/blob/d405f24703ad7a7fc1539d06304faefdd98ebe8d/src/repair/proof-command.ts) (blob `50a85f20dc72172815594384d4a2a4686250e01e`):

```ts
export const PROOF_COMMAND_USAGE =
  "@clawsweeper proof [scenario-id[,scenario-id...]] [40-character-head-sha]";
```

Its supported list is `["web-ui-chat-proof", "telegram-bot-e2e-proof"]`; `selection === "auto"` returns both as available options. Admission sets `const scenarioId = match[1] ?? "auto"` and `const headSha = match[2] ?? input.currentHeadSha`, rejecting a supplied SHA that differs from the current PR head. The review prompt says to select useful supported checks in auto mode; explicit mode says to attempt each requested supported check and explain unavailable/inconclusive selections. Both use observations in that review's final decision and explicitly forbid enqueueing another review.

[Shared ceiling](https://github.com/openclaw/clawsweeper/blob/d405f24703ad7a7fc1539d06304faefdd98ebe8d/src/review-proof-limits.ts#L2) (blob `161fd310c29f66220c8d4c40078fde0855736df3`):

```ts
export const REVIEW_PROOF_LIFETIME_MS = 20 * 60_000;
```

[Original review bound](https://github.com/openclaw/clawsweeper/blob/d405f24703ad7a7fc1539d06304faefdd98ebe8d/src/codex-app-server-worker.ts#L298) (blob `733f4a2f899aa5754d2c293baa0a62b3cf157b13`):

```ts
const remainingProofMs = Math.max(
  0,
  Math.floor(reviewDeadline - Date.now() - Math.min(90_000, options.timeoutMs / 10)),
);
```

The worker defines `reviewDeadline = Date.now() + options.timeoutMs` once and uses `AbortSignal.timeout(remainingProofMs)` for proof. [Default review timeout](https://github.com/openclaw/clawsweeper/blob/d405f24703ad7a7fc1539d06304faefdd98ebe8d/src/clawsweeper-policy.ts#L84) (blob `84278c4602d9fdaabfca98a9b162f11337264aa0`) is `DEFAULT_REVIEW_CODEX_TIMEOUT_MS = 1_200_000`. Thus immediate proof has at most `1_200_000 - 90_000 = 1_110_000` ms, or **18m30s**, less elapsed analysis. These exact-source checks resolve the review's source-access question; they do not claim deployment.

### Complete-source follow-up

A supplemental read-only audit read the complete exact-consumer `proof-command.ts`, `codex-app-server-worker.ts`, and `review-proof-client.ts`, plus the relevant router, execution and timeout wiring, at `d405f24703ad7a7fc1539d06304faefdd98ebe8d`. This closes the remaining local source-inspection gap identified by review `5562250553`; it does not claim that the reviewing service itself has regained source access or that its needs-human status has been cleared.

The audit confirmed all four documented command forms, automatic current-head capture, explicit scenario restriction, tool results returned to the active original review turn, the shared ceiling and final-decision reserve, and consumer cancellation limited to its HTTP wait. It also compared the producer documentation and existing credential-lease integration in staged tree `3608c96829a8fc3a936bbc21f282f7f5c964237b`; no contradictory or overlapping documentation changes were found. The final reviewed and published producer commit `f838be8f1e04fbca321aa60479f17490c9231aa1` resolves to tree `6acbc2a81d5662db4dd4e3e14ae3a48cd164302d`. Its only difference from the audited tree is a three-line Web UI observer check marking a non-success send response as a protocol error; documentation and credential integration are unchanged. Fresh `git merge-tree --write-tree 7f5e0d0b84e6ce5442b43b848acc67b0aff1351a f838be8f1e04fbca321aa60479f17490c9231aa1` passed, producing tree `79dc065da865c794f8766838a3dc9737f756f29f` without changing either branch.

The existing Convex credential service remains necessary, but its APIs are reused without a Convex schema/API deployment or new broker credential. Coordinated producer workflow and consumer Worker/runtime deployment, followed by hosted verification, remain separate requirements. No rollout was executed by this documentation audit. It supplies source/prose verification, not live Telegram proof, hosted latency measurements, new runtime proof, or merge authorization.

This validates prose/source accuracy and MDX/formatting, not hosted activation, live Telegram or end-to-end latency. It must remain clear that the paired workflows/runtime need deployment. The existing producer PR retains the detailed execution boundaries; neither docs PR is a deployment or merge authorization.

Release-note context: clarify how selective inline proof is requested, bounded and activated.
