### PR TITLE
test(gateway): retain saved source in reload fixtures

### DIFF
--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -510,9 +510,10 @@ describe("gateway e2e", () => {
         });
         await disconnectGatewayClient(newClient);
 
+        const sourceBeforeLoggingEdit = (await configIO.readConfigFileSnapshot()).sourceConfig;
         await writeConfigFile({
-          gateway: { auth: { mode: "token", token: fileToken } },
-          logging: { level: "debug" },
+          ...sourceBeforeLoggingEdit,
+          logging: { ...sourceBeforeLoggingEdit.logging, level: "debug" },
         });
         const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
           gateway?: { auth?: { token?: unknown } };
@@ -554,9 +555,10 @@ describe("gateway e2e", () => {
       const seededOrigins = getRuntimeConfig().gateway?.controlUi?.allowedOrigins;
       expect(seededOrigins?.length).toBeGreaterThan(0);
 
+      const sourceBeforeLoggingEdit = (await configIO.readConfigFileSnapshot()).sourceConfig;
       await writeConfigFile({
-        ...initialConfig,
-        logging: { level: "debug" },
+        ...sourceBeforeLoggingEdit,
+        logging: { ...sourceBeforeLoggingEdit.logging, level: "debug" },
       });
       await expect
         .poll(() => getRuntimeConfig().logging?.level, { timeout: 5_000, interval: 50 })
@@ -564,20 +566,22 @@ describe("gateway e2e", () => {
       expect(getRuntimeConfig().gateway?.controlUi?.allowedOrigins).toEqual(seededOrigins);
 
       expect(setConfigOverride("logging.level", "warn").ok).toBe(true);
+      const sourceBeforeOverrideWrite = (await configIO.readConfigFileSnapshot()).sourceConfig;
       await writeConfigFile({
-        ...initialConfig,
-        ui: { seamColor: "#123456" },
-        logging: { level: "debug" },
+        ...sourceBeforeOverrideWrite,
+        ui: { ...sourceBeforeOverrideWrite.ui, seamColor: "#123456" },
+        logging: { ...sourceBeforeOverrideWrite.logging, level: "debug" },
       });
       await expect
         .poll(() => getRuntimeConfig().logging?.level, { timeout: 5_000, interval: 50 })
         .toBe("warn");
 
       resetConfigOverrides();
+      const sourceBeforeOverrideReset = (await configIO.readConfigFileSnapshot()).sourceConfig;
       await writeConfigFile({
-        ...initialConfig,
-        ui: { seamColor: "#654321" },
-        logging: { level: "debug" },
+        ...sourceBeforeOverrideReset,
+        ui: { ...sourceBeforeOverrideReset.ui, seamColor: "#654321" },
+        logging: { ...sourceBeforeOverrideReset.logging, level: "debug" },
       });
       await expect
         .poll(() => getRuntimeConfig().logging?.level, { timeout: 5_000, interval: 50 })


### PR DESCRIPTION
Two remaining Gateway reload fixtures discarded saved config fields when constructing unrelated logging/UI updates. On current main, the config writer rejected both updates for removing roughly half the saved config, so the tests stopped before completing their SecretRef-auth and Control UI origin checks.

Read the current saved source before each update and retain existing logging/UI fields. The SecretRef test still rotates runtime credentials, authenticates the new client, and verifies that the original file token remains persisted. The origin test still checks seeded origins and logging overrides before and after reset. All existing assertions and timeouts remain unchanged.

Follow-up to #140433. Validation on pinned main `b9a80868`: both original cases reproduce `CONFIG_WRITE_REJECTED`; the repaired cases and four auth-reload siblings pass together, six real Gateway cases total, using this worktree's fresh canonical E2E build. Production LOC delta: 0; test LOC delta: +4.

The complete changed-file gate and independent P2 review pass.
