### PR TITLE
refactor(routing): reuse prepared event session targets

### DIFF
--- a/src/infra/event-session-routing.test.ts
+++ b/src/infra/event-session-routing.test.ts
@@ -9,6 +9,96 @@ import {
 } from "./event-session-routing.js";
 
 describe("event session routing", () => {
+  it.each([
+    ["account DM", 0],
+    ["nested account DM", 1],
+    ["account", 2],
+    ["nested account", 3],
+    ["channel DM", 4],
+    ["channel", 5],
+  ] as const)(
+    "uses the first configured %s allowlist, including an empty list",
+    (_source, first) => {
+      for (const selected of [["123"], []]) {
+        const lists = Array.from({ length: 6 }, (_, index) =>
+          index < first ? undefined : index === first ? selected : [`other-${index}`],
+        );
+        const cfg: OpenClawConfig = {
+          agents: { entries: { main: {} } },
+          channels: {
+            example: {
+              dm: { allowFrom: lists[4] },
+              allowFrom: lists[5],
+              accounts: {
+                work: {
+                  dm: { allowFrom: lists[0] },
+                  allowFrom: lists[2],
+                  config: { dm: { allowFrom: lists[1] }, allowFrom: lists[3] },
+                },
+              },
+            },
+          },
+        };
+        const sessionKey = "agent:main:example:work:direct:123:thread:456";
+        const policy = resolveEventSessionRoutingPolicy({ cfg, sessionKey });
+        expect(policy.allowFrom).toEqual(selected);
+        expect(resolveEventSessionKeyForPolicy(sessionKey, policy)).toBe(
+          selected.length === 0 ? sessionKey : "agent:main:main",
+        );
+      }
+    },
+  );
+
+  it.each([
+    { channel: undefined, accountId: undefined, expected: "original" },
+    { channel: " Other ", accountId: " ALT ", expected: "override" },
+    { channel: "", accountId: " ", expected: "original" },
+    { channel: "other", accountId: "", expected: "other-work" },
+  ])("resolves channel/account overrides $channel/$accountId", ({ expected, ...overrides }) => {
+    const cfg: OpenClawConfig = {
+      agents: { entries: { main: {} } },
+      channels: {
+        example: { accounts: { work: { allowFrom: ["original"] } } },
+        other: {
+          accounts: {
+            work: { allowFrom: ["other-work"] },
+            alt: { allowFrom: ["override"] },
+          },
+        },
+      },
+    };
+    const params = {
+      cfg,
+      sessionKey: "agent:main:example:work:direct:123",
+      ...overrides,
+    };
+    expect(resolveEventSessionRoutingPolicy(params).allowFrom).toEqual([expected]);
+    expect(resolveEventSessionRoutingPolicy({ ...params, allowFrom: [] }).allowFrom).toEqual([]);
+  });
+
+  it.each([
+    ["agent:ops_1:example:direct:123", "agent:ops_1:main"],
+    ["  AGENT:OPS_1:EXAMPLE:DIRECT:123:THREAD:t  ", "agent:ops_1:main"],
+    ["agent:ops_1:example:direct:123:thread:", "agent:ops_1:main"],
+    ["agent:ops_1:example:direct:123:thread:first:thread:last", null],
+    ["agent::example:direct:123:thread:t", null],
+    ["agent:ops_1::example:direct:123:thread:t", null],
+    ["prefix:agent:ops_1:example:direct:123:thread:t", null],
+    ["agent:ops_1:agent:other:example:direct:123:thread:t", null],
+    ["agent:ops_1:example:direct::thread:t", null],
+    ["agent:ops_1:example:group:123:thread:t", null],
+  ] as const)("preserves direct event owner and thread parsing for %s", (sessionKey, expected) => {
+    expect(
+      resolveMainScopedEventSessionKey({
+        cfg: {
+          agents: { entries: { ops_1: {} } },
+          channels: { example: { allowFrom: ["123"] } },
+        },
+        sessionKey,
+      }),
+    ).toBe(expected);
+  });
+
   it("routes single-owner dmScope=main direct event keys to the agent main session", () => {
     const cfg: OpenClawConfig = {
       agents: { entries: { main: { default: true } } },

--- a/src/infra/event-session-routing.ts
+++ b/src/infra/event-session-routing.ts
@@ -56,12 +56,6 @@ function readAccountConfig(value: unknown): UnknownRecord | undefined {
   return isRecord(value) && isRecord(value.config) ? value.config : undefined;
 }
 
-function firstConfiguredAllowFrom(
-  ...candidates: Array<Array<string | number> | undefined>
-): Array<string | number> | undefined {
-  return candidates.find((candidate) => candidate !== undefined);
-}
-
 function normalizeEntry(value: string): string | undefined {
   return normalizeLowercaseStringOrEmpty(value) || undefined;
 }
@@ -96,7 +90,7 @@ function parseDirectAgentSessionTarget(
 /** Resolve the configured DM allowlist that applies to an event session. */
 function resolveEventSessionAllowFrom(params: {
   cfg?: OpenClawConfig;
-  sessionKey?: string | null;
+  target: DirectSessionTarget | null;
   channel?: string | null;
   accountId?: string | null;
 }): Array<string | number> | undefined {
@@ -104,8 +98,7 @@ function resolveEventSessionAllowFrom(params: {
   if (!cfg?.channels) {
     return undefined;
   }
-  const target = parseDirectAgentSessionTarget(params.sessionKey);
-  const channelKey = normalizeLowercaseStringOrEmpty(params.channel ?? target?.channel);
+  const channelKey = normalizeLowercaseStringOrEmpty(params.channel ?? params.target?.channel);
   if (!channelKey) {
     return undefined;
   }
@@ -113,17 +106,17 @@ function resolveEventSessionAllowFrom(params: {
   if (!isRecord(channelConfig)) {
     return undefined;
   }
-  const accountId = normalizeLowercaseStringOrEmpty(params.accountId ?? target?.accountId);
+  const accountId = normalizeLowercaseStringOrEmpty(params.accountId ?? params.target?.accountId);
   const accountConfig =
     accountId && isRecord(channelConfig.accounts) ? channelConfig.accounts[accountId] : undefined;
   const accountNestedConfig = readAccountConfig(accountConfig);
-  return firstConfiguredAllowFrom(
-    readDmAllowFrom(accountConfig),
-    readDmAllowFrom(accountNestedConfig),
-    readAllowFrom(accountConfig),
-    readAllowFrom(accountNestedConfig),
-    readDmAllowFrom(channelConfig),
-    readAllowFrom(channelConfig),
+  return (
+    readDmAllowFrom(accountConfig) ??
+    readDmAllowFrom(accountNestedConfig) ??
+    readAllowFrom(accountConfig) ??
+    readAllowFrom(accountNestedConfig) ??
+    readDmAllowFrom(channelConfig) ??
+    readAllowFrom(channelConfig)
   );
 }
 
@@ -174,7 +167,7 @@ export function resolveEventSessionRoutingPolicy(params: {
     params.allowFrom ??
     resolveEventSessionAllowFrom({
       cfg: params.cfg,
-      sessionKey: params.sessionKey,
+      target,
       channel,
       accountId,
     });
@@ -206,9 +199,8 @@ export function resolveMainScopedEventSessionKey(params: {
   if (!sessionKey || params.policy?.preserveSessionKey === true) {
     return null;
   }
-  const parsed = parseAgentSessionKey(sessionKey);
   const target = parseDirectAgentSessionTarget(sessionKey);
-  if (!parsed || !target) {
+  if (!target) {
     return null;
   }
   const resolvedAgentId = normalizeAgentId(params.agentId ?? target.agentId);


### PR DESCRIPTION
## What Problem This Solves

Event-triggered work repeatedly parses the same direct-session key while preparing routing policy. Allowlist selection also evaluates all six configuration locations even when the first one is already authoritative.

## Why This Change Was Made

Carry the parsed direct target into the private allowlist resolver, short-circuit the existing allowlist readers with nullish coalescing, and remove an outer parse already implied by successful direct-target parsing. This deletes duplicate work without introducing a cache or a second routing path.

The six-location precedence, authoritative empty arrays, named and blank overrides, agent ownership, thread handling, route-binding preservation, cron mapping, and wildcard/multiple-owner behavior stay unchanged. Production −8 lines; tests +90. No config, API, protocol, schema, or authorization change.

## User Impact

Less local work when preparing event routing. There is no intended routing or delivery change, and this does not claim faster complete Gateway turns or cron execution.

## Evidence

122 focused tests passed. All 29 normal checks are covered by qualified recovery: the original gate passed 18 checks before a disk safety stop; recovery completed the remaining checks. A test-only unused callback name and its formatting were corrected after lint/format failures. The successful stages were not replayed. Fresh independent Codex review is clean. Every failure and process-closure receipt remains recorded; this is not described as one uninterrupted gate pass.

Fixed B0/C0/C1/B1 measurement on Node 26.8.1 at baseline `81050949f524ee1e486db5ef973366196dcdeb0a`: 32 fixtures expand to 128 repeated/rotating policy/composed rows, 545,024 checked calls, 4,352 retained first outputs and 4,096 batch means. Independent audit decoded every V8 output (including undefined properties), reconstructed fixture expectations, and recomputed all 768 statistics. Warmup/timed outputs were checked in process; only first outputs were retained. Saved input JSON omits undefined fields; original input V8 bytes were not archived.

Configured-precedence policy medians improved 23.25–43.54%; override composition improved 15.45–27.10%; binding-preserved composition improved 29.62–38.62%. The fuller first-precedence repeated/composed row was near-flat: −2.78% forward / +2.40% reverse. All 9/256 adverse medians, 12 means and 40 maximum batch means remain included. Largest median adverse: +8.09% (+105 ns) on an explicit-allowlist control; largest maximum-batch adverse: +119.14% (+1.66 µs) on a missing-channel control. These maxima are not individual latency percentiles.

Native whole-child wall improved 16.04%/11.13%, but reverse system CPU increased 11.76% and forward peak RSS increased slightly. No uniform memory or end-to-end claim. All phase/reducer processes closed, source was restored, and selected pins remained stable. This exercises the actual exported policy/key/wake composition; it does not dispatch a heartbeat, contact a channel, or use provider credentials. Real-Gateway campaign measurements remain separate.
