### PR TITLE
refactor(tests): remove unused parent context cache reset

### DIFF
--- a/src/agents/context-runtime-state.test.ts
+++ b/src/agents/context-runtime-state.test.ts
@@ -1,10 +1,5 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { execNodeEvalSync } from "../test-utils/node-process.js";
-import { resetContextWindowCacheForTest } from "./context-runtime-state.js";
-
-afterEach(() => {
-  resetContextWindowCacheForTest();
-});
 
 describe("context runtime state", () => {
   it("invalidates a released load marker when the process-global cache is introduced", () => {


### PR DESCRIPTION
## What Problem This Solves

Context-runtime tests exercise their cache behavior in child processes, but still import and reset an unused copy of the cache in the parent test process.

## Why This Change Was Made

Remove the parent-only import and cleanup hook. All child fixtures, cases, and assertions stay unchanged; the reset export and its other callers remain. This removes five net test lines.

## User Impact

Less unused test setup, with no production behavior change or claimed runtime improvement.

## Evidence

All three focused cases pass before and after. The full changed-file gate, deslop, and independent review through P2 pass. Exact diff verification confirms only the unused import and hook were removed. Local timing samples are not used as performance evidence.
