### PR TITLE
refactor(config): reuse environment substitution for write-back

### DIFF
--- a/src/config/env-preserve.ts
+++ b/src/config/env-preserve.ts
@@ -3,6 +3,7 @@ import { isDeepStrictEqual } from "node:util";
 import { expectDefined } from "@openclaw/normalization-core";
 import { isPlainObject } from "../infra/plain-object.js";
 import { isRecord } from "../utils.js";
+import { containsEnvVarReference, resolveConfigEnvVars } from "./env-substitution.js";
 
 /**
  * Preserves `${VAR}` environment variable references during config write-back.
@@ -63,17 +64,13 @@ function collectAuthoredEnvRefs(value: string): AuthoredEnvRef[] {
   return refs;
 }
 
-function hasUnescapedEnvVarRef(value: string): boolean {
-  return collectAuthoredEnvRefs(value).some((ref) => ref.kind === "unescaped");
-}
-
 function hasEscapedEnvVarRef(value: string): boolean {
   return collectAuthoredEnvRefs(value).some((ref) => ref.kind === "escaped");
 }
 
 function containsAuthoredUnescapedEnvTemplate(value: unknown): boolean {
   if (typeof value === "string") {
-    return hasUnescapedEnvVarRef(value);
+    return containsEnvVarReference(value);
   }
   if (Array.isArray(value)) {
     return value.some((item) => containsAuthoredUnescapedEnvTemplate(item));
@@ -134,7 +131,12 @@ function countResolvedActiveEnvRefsByPath(
   const countsByName = new Map<string, Map<string, number>>();
   const visit = (incomingItem: unknown, parsedItem: unknown, path: string[]) => {
     if (typeof incomingItem === "string" && typeof parsedItem === "string") {
-      if (!isDeepStrictEqual(incomingItem, tryResolveString(parsedItem, env))) {
+      if (
+        !isDeepStrictEqual(
+          incomingItem,
+          resolveConfigEnvVars(parsedItem, env, { onMissing: () => {} }),
+        )
+      ) {
         return;
       }
       for (const ref of collectAuthoredEnvRefs(parsedItem)) {
@@ -651,62 +653,9 @@ function matchAuthoredEscapedTemplateArrayItems(params: {
   return matches;
 }
 
-/**
- * Resolve `${VAR}` references in a single string using the given env.
- * Preserves missing references so matching remains aligned with config reads.
- *
- * Mirrors the substitution semantics of `substituteString` in env-substitution.ts:
- * - `${VAR}` → env value (returns null if missing)
- * - `$${VAR}` → literal `${VAR}` (escape sequence)
- */
-function tryResolveString(template: string, env: NodeJS.ProcessEnv): string {
-  const chunks: string[] = [];
-
-  for (let i = 0; i < template.length; i++) {
-    if (template[i] === "$") {
-      // Escaped: $${VAR} -> literal ${VAR}
-      if (template[i + 1] === "$" && template[i + 2] === "{") {
-        const start = i + 3;
-        const end = template.indexOf("}", start);
-        if (end !== -1) {
-          const name = template.slice(start, end);
-          if (ENV_VAR_NAME_PATTERN.test(name)) {
-            chunks.push(`\${${name}}`);
-            i = end;
-            continue;
-          }
-        }
-      }
-
-      // Substitution: ${VAR} -> env value
-      if (template[i + 1] === "{") {
-        const start = i + 2;
-        const end = template.indexOf("}", start);
-        if (end !== -1) {
-          const name = template.slice(start, end);
-          if (ENV_VAR_NAME_PATTERN.test(name)) {
-            const val = env[name];
-            if (val === undefined || val === "") {
-              chunks.push(`\${${name}}`);
-              i = end;
-              continue;
-            }
-            chunks.push(val);
-            i = end;
-            continue;
-          }
-        }
-      }
-    }
-    chunks.push(template.charAt(i));
-  }
-
-  return chunks.join("");
-}
-
 function resolveEnvVarRefsForComparison(value: unknown, env: NodeJS.ProcessEnv): unknown {
   if (typeof value === "string") {
-    return hasEnvVarRef(value) ? tryResolveString(value, env) : value;
+    return hasEnvVarRef(value) ? resolveConfigEnvVars(value, env, { onMissing: () => {} }) : value;
   }
   if (Array.isArray(value)) {
     return value.map((item) => resolveEnvVarRefsForComparison(item, env));
@@ -741,7 +690,7 @@ export function restoreEnvVarRefs(
   // String leaf: check if parsed was a ${VAR} template that resolves to incoming
   if (typeof incoming === "string" && typeof parsed === "string") {
     if (hasEnvVarRef(parsed)) {
-      const resolved = tryResolveString(parsed, env);
+      const resolved = resolveConfigEnvVars(parsed, env, { onMissing: () => {} });
       if (resolved === incoming) {
         // The incoming value matches what the env var resolves to — restore the reference
         return parsed;


### PR DESCRIPTION
## What Problem This Solves

Config write-back maintains a second environment-template scanner, duplicating the grammar and escape handling used when config is read. Keeping both implementations aligned creates avoidable maintenance work around preserved credential references.

This is an independent cleanup contribution to the #135868 split campaign.

## Why This Change Was Made

The three string-comparison sites now call the existing canonical resolver with its existing onMissing callback policy, which preserves unresolved placeholders. Active-reference detection also uses the canonical predicate. The duplicate private scanner and predicate are deleted.

The broader escaped-reference check, authored occurrence counts, array identity matching, and failure conditions remain intact. Both original owners match stable v2026.9.2; this preserves the shipped round-trip contract. The canonical resolver's default missing-variable failure policy is unchanged.

## User Impact

No user-visible behavior change. Authored references and escaped literals continue to survive config writes; intentional replacement values are retained, and ambiguous array edits still fail before writing.

## Evidence

- All 303 existing tests pass before and after across env-preserve, env-substitution, io.write-config and mutate. Coverage includes unresolved optional refs through included-file writes, escaped literals, and refusing ambiguous array removals without changing persisted bytes.
- Actual-source scanner comparison: 42,600 substitutions and 5,325 active-reference predicates match, including getter order/count, unchanged replacement values, and 4,764 thrown sentinel identities. Controls detect omitted missing-variable handling, active escapes and replacement rescanning.
- Full public restoreEnvVarRefs comparison: 7,706 cases match, including 1,957 mutation errors and output/reference-sharing behavior with frozen inputs. Controls detect missing-policy omission and escaped-reference confusion. This is bounded synthetic proof; the existing writer suites cover file persistence.
- Full changed-check plan passes: core/core-test typing, config documentation, formatting/lint, all three Knip export scans and architecture/storage guards. Runtime import cycles: zero.
- Independent Codex review is clean through P2. ClawSweeper also found no correctness/security findings or before-merge requests; no rank-up changes were requested.

Production: one file, 935 → 884 lines; +10/−61 = **−51**. Tests, tooling, docs and baselines are unchanged.
