### PR TITLE
fix(setup): match prepared credentials to the model provider

### DIFF
--- a/src/system-agent/setup-inference-persist.test.ts
+++ b/src/system-agent/setup-inference-persist.test.ts
@@ -123,6 +123,9 @@ function createFreshProviderPlan() {
     routeAgentId: "main",
     agentDir: path.join(root, "state", "agents", "main", "agent"),
   });
+  if ("error" in plan) {
+    throw new Error(plan.error);
+  }
   if (!plan.manualAuth) {
     throw new Error("Prepared provider plan omitted manual auth");
   }
@@ -302,6 +305,9 @@ describe("provider installation changes runtime defaults without editing source"
           routeAgentId: "main",
           agentDir: path.join(stateDir, "agents", "main", "agent"),
         });
+        if ("error" in plan) {
+          throw new Error(plan.error);
+        }
         const manualAuth = plan.manualAuth;
         if (!manualAuth) {
           throw new Error("Prepared provider plan omitted manual auth");

--- a/src/system-agent/setup-inference-plan-helpers.ts
+++ b/src/system-agent/setup-inference-plan-helpers.ts
@@ -452,14 +452,13 @@ export function buildPreparedProviderTestPlan(params: {
   sourceCfg: OpenClawConfig;
   preparedConfig: OpenClawConfig;
   profiles: ProviderAuthResult["profiles"];
-  selectedProfileId?: string;
   providerPlugin?: ProviderPlugin;
   modelRef: string;
   pluginId?: string;
   routeAgentId: string;
   agentDir: string;
   pendingPluginInstalls?: Record<string, PluginInstallRecord>;
-}): SetupInferenceTestPlan {
+}): SetupInferenceTestPlan | { error: string } {
   const ref = parseRef(params.modelRef);
   // Auth starters are raw provider input; guided discovery already chose its canonical model.
   ref.model =
@@ -470,6 +469,16 @@ export function buildPreparedProviderTestPlan(params: {
       }),
     ) ?? ref.model;
   const modelRef = `${ref.provider}/${ref.model}`;
+  // Auth can return several providers; only the selected model's credential enters its plan.
+  const providerId = normalizeProviderId(ref.provider);
+  const matchingProfile = params.profiles.find(
+    (profile) => normalizeProviderId(profile.credential.provider) === providerId,
+  );
+  if (params.profiles.length > 0 && !matchingProfile) {
+    return {
+      error: `${params.providerPlugin?.label ?? ref.provider} did not return credentials for "${modelRef}".`,
+    };
+  }
   const projection = {
     baseConfig: params.cfg,
     preparedConfig: params.preparedConfig,
@@ -479,11 +488,11 @@ export function buildPreparedProviderTestPlan(params: {
     pluginId: params.pluginId,
     agentId: params.routeAgentId,
   };
-  const prepared = params.selectedProfileId
+  const prepared = matchingProfile
     ? prepareManualAuthForActivation({
         ...projection,
         profiles: params.profiles,
-        selectedProfileId: params.selectedProfileId,
+        selectedProfileId: matchingProfile.profileId,
       })
     : {
         config: projectManualInferenceConfig(projection),

--- a/src/system-agent/setup-inference-plan.provider-auth.test.ts
+++ b/src/system-agent/setup-inference-plan.provider-auth.test.ts
@@ -78,6 +78,66 @@ describe("catalog-only provider preparation", () => {
     expect(persistAuthProfiles).not.toHaveBeenCalled();
   });
 
+  it.each(["matching-last", "missing-match"] as const)(
+    "selects the model provider's credential from %s auth profiles",
+    async (profileCase) => {
+      const matchingCredential = {
+        type: "api_key" as const,
+        provider: "FIXTURE",
+        key: "synthetic-selected-key",
+      };
+      vi.mocked(prepareAuthChoiceLoadedPluginProvider).mockResolvedValue({
+        config,
+        agentModelOverride: "fixture/starter-alias",
+        provider: {
+          id: "fixture",
+          label: "Fixture",
+          auth: [],
+          normalizeModelId: () => "test-model",
+        },
+        authProfiles: [
+          {
+            profileId: "other:default",
+            credential: {
+              type: "api_key",
+              provider: "other",
+              key: "synthetic-unrelated-key",
+            },
+          },
+          ...(profileCase === "matching-last"
+            ? [{ profileId: "fixture:default", credential: matchingCredential }]
+            : []),
+        ],
+        persistAuthProfiles,
+      });
+      const plan = await buildTestPlan({
+        kind: "provider-auth",
+        authChoice: "fixture-api-key",
+        cfg: config,
+        sourceCfg: config,
+        workspaceDir: "/tmp/isolated-provider-probe",
+        pluginWorkspaceDir: "/tmp/selected-workspace",
+        agentDir: "/tmp/isolated-provider-probe/agent",
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() as never },
+        prompter: createWizardPrompter(),
+        deps: { resolveManifestProviderAuthChoice: () => undefined },
+      });
+      expect(persistAuthProfiles).not.toHaveBeenCalled();
+      if (profileCase === "missing-match") {
+        expect(plan).toEqual({ error: expect.stringContaining("did not return credentials") });
+        return;
+      }
+      expect(plan).toMatchObject({
+        modelRef: "fixture/test-model",
+        manualAuth: { profiles: [{ credential: matchingCredential }] },
+      });
+      if ("error" in plan) {
+        throw new Error(plan.error);
+      }
+      expect(plan.authProfileId).toBe(plan.manualAuth?.profiles[0]?.profileId);
+    },
+  );
+
   it.each(["openclaw", "fixture-cli"])(
     "normalizes the starter while retaining trusted installation and the selected %s runtime",
     async (runtimeId) => {

--- a/src/system-agent/setup-inference-plan.ts
+++ b/src/system-agent/setup-inference-plan.ts
@@ -187,21 +187,11 @@ export async function buildTestPlan(params: {
         config: enableResult.config,
         result,
       });
-      const matchingProfile = result.profiles.find(
-        (profile) =>
-          normalizeProviderId(profile.credential.provider) === normalizeProviderId(ref.provider),
-      );
-      if (result.profiles.length > 0 && !matchingProfile) {
-        return {
-          error: `${choice.choiceLabel} did not return credentials for its detected model.`,
-        };
-      }
       return buildPreparedProviderTestPlan({
         cfg,
         sourceCfg: params.sourceCfg,
         preparedConfig,
         profiles: result.profiles,
-        selectedProfileId: matchingProfile?.profileId,
         modelRef,
         pluginId: choice.pluginId,
         agentDir: params.agentDir,
@@ -491,7 +481,6 @@ export async function buildTestPlan(params: {
           sourceCfg: params.sourceCfg,
           preparedConfig: prepared.config,
           profiles: prepared.authProfiles,
-          selectedProfileId: prepared.authProfiles[0]?.profileId,
           providerPlugin: prepared.provider,
           modelRef,
           pluginId: managedWizardChoice.pluginId,
@@ -660,21 +649,11 @@ export async function buildTestPlan(params: {
           error: `${resolved.provider.label} returned an invalid starter model.`,
         };
       }
-      const matchingProfile = result.profiles.find(
-        (profile) =>
-          normalizeProviderId(profile.credential.provider) === normalizeProviderId(ref.provider),
-      );
-      if (result.profiles.length > 0 && !matchingProfile) {
-        return {
-          error: `${resolved.provider.label} did not return credentials for its starter model.`,
-        };
-      }
       return buildPreparedProviderTestPlan({
         cfg,
         sourceCfg: params.sourceCfg,
         preparedConfig,
         profiles: result.profiles,
-        selectedProfileId: matchingProfile?.profileId,
         modelRef,
         pluginId: resolved.provider.pluginId,
         ...(interactive && choice.appGuidedDiscovery === true


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users preparing a model could have their setup probe select another provider's credential when sign-in returned multiple profiles and the matching profile was not first. A result with no matching credential could also produce a runnable setup plan.

## Why This Change Was Made

The managed wizard selected the first profile, while other setup paths matched the model provider. The shared plan builder now owns that selection after model normalization and rejects nonempty profile lists without a match, removing the duplicated caller checks.

## User Impact

Setup selects the credential belonging to the prepared model. Empty-profile setup, guided model normalization, explicit CLI credential selection, and staged persistence retain their existing behavior.

## Evidence

- Reproduced both failures on pinned main `b9a80868391915779369f75fbb1db63b66de9fb1`; four existing controls passed.
- **179 tests passed** across setup inference, provider-auth planning, and persistence.
- Full normal `check:changed` passed, including core/test types, lint, boundary checks, and dead-code scans.
- Canonical independent **P2 review: scoped-clean**.
- Standalone source-bound proof, outside Vitest: a real config-loaded CJS provider's auth method ran through `buildTestPlan`. Matching-last selected the correct credential, missing-match was rejected, and empty profiles remained valid. Each case invoked actual auth and model normalization, left config unchanged, and returned a data-only outcome. This used synthetic local credentials, with no external authentication.
- **Production: −12 LOC. Tests: +66 LOC.**
