### PR TITLE
refactor(tui): prepare session picker rows once per overlay

### DIFF
--- a/src/tui/components/filterable-select-list.test.ts
+++ b/src/tui/components/filterable-select-list.test.ts
@@ -193,7 +193,26 @@ describe("FilterableSelectList", () => {
     }
     expect(rendered).not.toContain("fv-end\r\nمرحبا\tשלום");
 
+    // Text removed from display remains part of the original search fields.
+    list.handleInput("\x1b");
+    typeInput(list, "filter-title");
+    expect(list.getSelectedItem()).toMatchObject({ searchText: "raw-filter-target" });
     list.handleInput("\r");
     expect(selectedValue).toBe(rawValue);
+  });
+
+  it("reads changed row fields when the picker is reopened", () => {
+    const item = { value: "session", label: "Before", searchText: "old-name" };
+    const first = new FilterableSelectList([item], 5, mockTheme);
+    typeInput(first, "old-name");
+    expect(first.getSelectedItem()?.value).toBe("session");
+
+    item.label = "After";
+    item.searchText = "new-name";
+    const reopened = new FilterableSelectList([item], 5, mockTheme);
+    typeInput(reopened, "new-name");
+
+    expect(reopened.getSelectedItem()).toMatchObject(item);
+    expect(reopened.render(80).join("\n")).toContain("After");
   });
 });

--- a/src/tui/components/filterable-select-list.ts
+++ b/src/tui/components/filterable-select-list.ts
@@ -30,7 +30,7 @@ interface FilterableSelectListTheme extends SelectListTheme {
 export class FilterableSelectList implements Component, Focusable {
   private input: Input;
   private selectList: SelectList;
-  private allItems: FilterableSelectItem[];
+  private allItems: Array<{ item: FilterableSelectItem; searchText: string }>;
   private maxVisible: number;
   private theme: FilterableSelectListTheme;
 
@@ -38,7 +38,18 @@ export class FilterableSelectList implements Component, Focusable {
   onCancel?: () => void;
 
   constructor(items: FilterableSelectItem[], maxVisible: number, theme: FilterableSelectListTheme) {
-    this.allItems = items;
+    // Each overlay owns fixed rows; search keeps raw fields while display copies stay sanitized.
+    this.allItems = items.map((item) => ({
+      searchText: [item.label, item.description, item.searchText].filter(Boolean).join(" "),
+      item: {
+        ...item,
+        label:
+          sanitizeRenderableLine(item.label || item.value) ||
+          sanitizeRenderableLine(item.value) ||
+          "(unnamed)",
+        description: sanitizeRenderableLine(item.description ?? ""),
+      },
+    }));
     this.maxVisible = maxVisible;
     this.theme = theme;
     this.input = new Input();
@@ -62,27 +73,13 @@ export class FilterableSelectList implements Component, Focusable {
   }
 
   private applyFilter(): void {
-    const filterText = this.input.getValue();
-    if (!filterText.trim()) {
-      this.selectList = this.createSelectList(this.allItems);
-      return;
-    }
-    const filtered = fuzzyFilter(this.allItems, filterText, (item) =>
-      [item.label, item.description, item.searchText].filter(Boolean).join(" "),
-    );
+    const filtered = fuzzyFilter(this.allItems, this.input.getValue(), (entry) => entry.searchText);
     this.selectList = this.createSelectList(filtered);
   }
 
-  private createSelectList(items: FilterableSelectItem[]): SelectList {
+  private createSelectList(items: typeof this.allItems): SelectList {
     return new SelectList(
-      items.map((item) => ({
-        ...item,
-        label:
-          sanitizeRenderableLine(item.label || item.value) ||
-          sanitizeRenderableLine(item.value) ||
-          "(unnamed)",
-        description: sanitizeRenderableLine(item.description ?? ""),
-      })),
+      items.map((entry) => entry.item),
       this.maxVisible,
       this.theme,
     );


### PR DESCRIPTION
## What Problem This Solves

Typing in the recent-session picker repeatedly rebuilds searchable strings and sanitizes display rows that stay fixed for the life of the overlay.

## Why This Change Was Made

Prepare each row's raw search text and sanitized display copy when the overlay opens, then reuse those facts during filtering. Reopening builds a fresh snapshot. Native fuzzy matching, ordering, keyboard behavior, selected values and extra properties remain unchanged. The production caller consumes the selected value without mutating rows.

Production −3 lines; tests +19. No new cache beyond the existing overlay lifetime, public API, configuration, or dependency. No intended visual change.

## User Impact

Most measured filtering, editing and reopening interactions do less work. Opening pays a small preparation cost. This is not a uniform speedup or a claim about complete Gateway/model latency.

## Evidence

298 focused tests and independent Codex review passed on the unchanged source. Normal-check coverage is qualified: the first 20 checks passed, then type-aware lint exceeded an 8 GiB process-tree cap. The identical lint command passed at the campaign's 16 GiB normal-lint allowance; the eight remaining checks passed at their original 8 GiB cap. The initial failure and all receipts remain preserved; no source, target, suppression or check selection changed.

Two existing real-PTY picker scenarios passed on both baseline and candidate: authenticated terminal-frame selection and focus/selection in a compact terminal beside a side result. These use the real TUI with a fake backend, not Gateway/provider transport. The 67 tests outside the selected cases were skipped in each PTY run. Their one-off test durations are not performance measurements.

Fixed Node 26.8.1 / pi-tui 0.84.4 B0/C0/C1/B1 cohort at baseline `45213bbddbe8ec95326981367c10ba7eb4c68240`: 16 scenarios, 2,304 complete lifetimes, 22,608 frame/state observations, and 19,440 input/observation timings. Every recorded body, callback and frame matches across sources. Independent state/item/callback invariants and all 496 scalar timing reductions passed. Frames establish parity, not an independent pixel oracle; reference identity was asserted in process and cannot be recovered from JSON.

For fifty items, first-filter whole lifetime improved 15.34%/17.01%; first input plus rendering improved 35.60%/35.76%; edit/delete/clear/replace improved 21.61%/13.19%; fresh reopen improved 20.49%/21.52%. Fifty-item construction regressed 9.80%/12.42% (+21/+24 µs), and whole-open regressed 4.29%/2.13%. Resize also regressed slightly.

**Equal-score is a material adverse exception:** forward whole lifetime was +98.47% (3.281→6.512 ms), versus −36.07% in reverse. Forward constructor median was +125.86%, and maximum 0.209→13.030 ms. No GC/host-load cause is asserted, no favorable rerun was selected, and every adverse observation remains included. Across 124 comparisons, 43 medians, 44 means, 58 maxima and 41 batch medians were adverse.

Whole-child wall improved 10.65%/16.14%, but reverse kernel peak RSS increased 0.74% and system CPU 1.26%. No general memory claim. All measurement/PTY processes closed, candidate source was restored, and selected pins remained unchanged.


Maintainer resolution of the review’s two merge risks:

1. Accept the disclosed construction cost and workload-dependent results for this scoped cleanup. Preparation stays owned by each overlay, reopening stays fresh, and performance claims remain limited to measured interactions. The equal-score forward regression remains explicitly reported; no uniform latency claim is made.
2. Direct dependency inspection is complete. I read the full installed pi-tui 0.84.4 `dist/fuzzy.js` and `dist/components/select-list.js`. `fuzzyFilter` returns the supplied items immediately for an empty/whitespace query (lines 77–80), and also returns them when slash/whitespace tokenization produces no tokens (lines 81–87). Nonempty matching returns original records in score order (line 108). SelectList reads the supplied rows and returns the selected row without mutating it. The inspected SHA-256 values are `4e8de99d7a73e192b1215d5e37c1cbd687be1c8917edfd0ceb7636f44352cbc8` and `ea14ebd2f64ed045563360b598eeccc816f7f9f252df6b7bc492309cfe49c545`, respectively. The fixed component and PTY comparisons use this same installed dependency on both sides.
