### PR TITLE
refactor(discord): remove retired auto-presence templates

### DIFF
--- a/extensions/discord/src/monitor/auto-presence.test.ts
+++ b/extensions/discord/src/monitor/auto-presence.test.ts
@@ -27,39 +27,63 @@ function createStore(params?: {
   };
 }
 
-function expectExhaustedDecision(params: { failureCounts: Record<string, number> }) {
-  const now = Date.now();
-  const updatePresence = vi.fn();
-  const controller = createDiscordAutoPresenceController({
-    accountId: "default",
-    discordConfig: {
-      autoPresence: {
-        enabled: true,
-        exhaustedText: "token exhausted",
-      },
-    },
-    gateway: { isConnected: true, updatePresence },
-    loadAuthStore: () =>
-      createStore({ cooldownUntil: now + 60_000, failureCounts: params.failureCounts }),
-    now: () => now,
-  });
-  controller.runNow();
-
-  expect(updatePresence).toHaveBeenCalledWith(
-    expect.objectContaining({
-      status: "dnd",
-      activities: [expect.objectContaining({ state: "token exhausted" })],
-    }),
-  );
-}
-
 describe("discord auto presence", () => {
-  it("maps exhausted runtime signal to dnd", () => {
-    expectExhaustedDecision({ failureCounts: { rate_limit: 2 } });
+  it.each(["rate_limit", "overloaded"])("maps %s cooldown to dnd", (reason) => {
+    const now = Date.now();
+    const updatePresence = vi.fn();
+    const controller = createDiscordAutoPresenceController({
+      accountId: "default",
+      discordConfig: {
+        autoPresence: {
+          enabled: true,
+        },
+      },
+      gateway: { isConnected: true, updatePresence },
+      loadAuthStore: () =>
+        createStore({ cooldownUntil: now + 60_000, failureCounts: { [reason]: 2 } }),
+      now: () => now,
+    });
+    controller.runNow();
+
+    expect(updatePresence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "dnd",
+        activities: [expect.objectContaining({ state: "token exhausted" })],
+      }),
+    );
   });
 
-  it("treats overloaded cooldown as exhausted", () => {
-    expectExhaustedDecision({ failureCounts: { overloaded: 2 } });
+  it("reports degraded availability when no auth profiles exist", () => {
+    const updatePresence = vi.fn();
+    const controller = createDiscordAutoPresenceController({
+      accountId: "default",
+      discordConfig: { autoPresence: { enabled: true } },
+      gateway: { isConnected: true, updatePresence },
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+    controller.runNow();
+    expect(updatePresence).toHaveBeenCalledWith({
+      since: null,
+      activities: [{ name: "Custom Status", type: 4, state: "runtime degraded" }],
+      status: "idle",
+      afk: false,
+    });
+  });
+
+  it("clears expired cooldowns without sending presence while disconnected", () => {
+    const now = Date.now();
+    const store = createStore({ cooldownUntil: now - 1, failureCounts: { rate_limit: 1 } });
+    const updatePresence = vi.fn();
+    const controller = createDiscordAutoPresenceController({
+      accountId: "default",
+      discordConfig: { autoPresence: { enabled: true } },
+      gateway: { isConnected: false, updatePresence },
+      loadAuthStore: () => store,
+      now: () => now,
+    });
+    controller.runNow();
+    expect(store.usageStats?.["openai:default"]?.cooldownUntil).toBeUndefined();
+    expect(updatePresence).not.toHaveBeenCalled();
   });
 
   it("recovers from exhausted to online once a profile becomes usable", () => {
@@ -69,11 +93,12 @@ describe("discord auto presence", () => {
     const controller = createDiscordAutoPresenceController({
       accountId: "default",
       discordConfig: {
+        activity: "working",
+        activityType: 0,
         autoPresence: {
           enabled: true,
           intervalMs: 5_000,
           minUpdateIntervalMs: 1_000,
-          exhaustedText: "token exhausted",
         },
       },
       gateway: {
@@ -103,7 +128,7 @@ describe("discord auto presence", () => {
       [
         {
           since: null,
-          activities: [],
+          activities: [{ name: "working", type: 0 }],
           status: "online",
           afk: false,
         },

--- a/extensions/discord/src/monitor/auto-presence.ts
+++ b/extensions/discord/src/monitor/auto-presence.ts
@@ -30,12 +30,6 @@ type ResolvedDiscordAutoPresenceConfig = {
   minUpdateIntervalMs: number;
 };
 
-type DiscordAutoPresenceDecision = {
-  state: DiscordAutoPresenceState;
-  unavailableReason?: AuthProfileFailureReason | null;
-  presence: UpdatePresenceData;
-};
-
 type PresenceGateway = {
   isConnected: boolean;
   updatePresence: (payload: UpdatePresenceData) => void;
@@ -77,17 +71,6 @@ function buildCustomStatusActivity(text: string): Activity {
   };
 }
 
-function renderTemplate(
-  template: string,
-  vars: Record<string, string | undefined>,
-): string | undefined {
-  const rendered = template
-    .replace(/\{([a-zA-Z0-9_]+)\}/g, (_full, key: string) => vars[key] ?? "")
-    .replace(/\s+/g, " ")
-    .trim();
-  return rendered.length > 0 ? rendered : undefined;
-}
-
 function isExhaustedUnavailableReason(reason: AuthProfileFailureReason | null): boolean {
   if (!reason) {
     return false;
@@ -101,20 +84,13 @@ function isExhaustedUnavailableReason(reason: AuthProfileFailureReason | null): 
   );
 }
 
-function formatUnavailableReason(reason: AuthProfileFailureReason | null): string {
-  if (!reason) {
-    return "unknown";
-  }
-  return reason.replace(/_/g, " ");
-}
-
-function resolveAuthAvailability(params: { store: AuthProfileStore; now: number }): {
-  state: DiscordAutoPresenceState;
-  unavailableReason?: AuthProfileFailureReason | null;
-} {
+function resolveAuthAvailability(params: {
+  store: AuthProfileStore;
+  now: number;
+}): DiscordAutoPresenceState {
   const profileIds = Object.keys(params.store.profiles);
   if (profileIds.length === 0) {
-    return { state: "degraded", unavailableReason: null };
+    return "degraded";
   }
 
   clearExpiredCooldowns(params.store, params.now);
@@ -123,7 +99,7 @@ function resolveAuthAvailability(params: { store: AuthProfileStore; now: number 
     (profileId) => !isProfileInCooldown(params.store, profileId, params.now),
   );
   if (hasUsableProfile) {
-    return { state: "healthy", unavailableReason: null };
+    return "healthy";
   }
 
   const unavailableReason = resolveProfilesUnavailableReason({
@@ -132,43 +108,20 @@ function resolveAuthAvailability(params: { store: AuthProfileStore; now: number 
     now: params.now,
   });
 
-  if (isExhaustedUnavailableReason(unavailableReason)) {
-    return {
-      state: "exhausted",
-      unavailableReason,
-    };
-  }
-
-  return {
-    state: "degraded",
-    unavailableReason,
-  };
+  return isExhaustedUnavailableReason(unavailableReason) ? "exhausted" : "degraded";
 }
 
 function resolvePresenceActivities(params: {
   state: DiscordAutoPresenceState;
-  cfg: ResolvedDiscordAutoPresenceConfig;
   basePresence: UpdatePresenceData | null;
-  unavailableReason?: AuthProfileFailureReason | null;
 }): Activity[] {
-  const reasonLabel = formatUnavailableReason(params.unavailableReason ?? null);
-
   if (params.state === "healthy") {
     return params.basePresence?.activities ?? [];
   }
 
-  if (params.state === "degraded") {
-    const template = "runtime degraded";
-    const text = renderTemplate(template, { reason: reasonLabel });
-    return text ? [buildCustomStatusActivity(text)] : [];
-  }
-
-  const defaultTemplate = isExhaustedUnavailableReason(params.unavailableReason ?? null)
-    ? "token exhausted"
-    : "model unavailable ({reason})";
-  const template = defaultTemplate;
-  const text = renderTemplate(template, { reason: reasonLabel });
-  return text ? [buildCustomStatusActivity(text)] : [];
+  return [
+    buildCustomStatusActivity(params.state === "degraded" ? "runtime degraded" : "token exhausted"),
+  ];
 }
 
 function resolvePresenceStatus(state: DiscordAutoPresenceState): UpdatePresenceData["status"] {
@@ -181,7 +134,7 @@ function resolvePresenceStatus(state: DiscordAutoPresenceState): UpdatePresenceD
   return "idle";
 }
 
-function resolveDiscordAutoPresenceDecision(params: {
+function resolveDiscordAutoPresenceUpdate(params: {
   discordConfig: Pick<
     DiscordAccountConfig,
     "autoPresence" | "activity" | "status" | "activityType" | "activityUrl"
@@ -189,7 +142,7 @@ function resolveDiscordAutoPresenceDecision(params: {
   authStore: AuthProfileStore;
   gatewayConnected: boolean;
   now?: number;
-}): DiscordAutoPresenceDecision | null {
+}): UpdatePresenceData | null {
   const autoPresence = resolveAutoPresenceConfig(params.discordConfig.autoPresence);
   if (!autoPresence.enabled) {
     return null;
@@ -202,27 +155,18 @@ function resolveDiscordAutoPresenceDecision(params: {
     store: params.authStore,
     now,
   });
-  const state = params.gatewayConnected ? availability.state : "degraded";
-  const unavailableReason = params.gatewayConnected
-    ? availability.unavailableReason
-    : (availability.unavailableReason ?? "unknown");
+  const state = params.gatewayConnected ? availability : "degraded";
 
   const activities = resolvePresenceActivities({
     state,
-    cfg: autoPresence,
     basePresence,
-    unavailableReason,
   });
 
   return {
-    state,
-    unavailableReason,
-    presence: {
-      since: null,
-      activities,
-      status: resolvePresenceStatus(state),
-      afk: false,
-    },
+    since: null,
+    activities,
+    status: resolvePresenceStatus(state),
+    afk: false,
   };
 }
 
@@ -257,8 +201,6 @@ export function createDiscordAutoPresenceController(params: {
   gateway: PresenceGateway;
   loadAuthStore?: () => AuthProfileStore;
   now?: () => number;
-  setIntervalFn?: typeof setInterval;
-  clearIntervalFn?: typeof clearInterval;
   log?: (message: string) => void;
 }): DiscordAutoPresenceController {
   const autoCfg = resolveAutoPresenceConfig(params.discordConfig.autoPresence);
@@ -274,17 +216,15 @@ export function createDiscordAutoPresenceController(params: {
 
   const loadAuthStore = params.loadAuthStore ?? (() => ensureAuthProfileStore());
   const now = params.now ?? (() => Date.now());
-  const setIntervalFn = params.setIntervalFn ?? setInterval;
-  const clearIntervalFn = params.clearIntervalFn ?? clearInterval;
 
   let timer: ReturnType<typeof setInterval> | undefined;
   let lastAppliedSignature: string | null = null;
   let lastAppliedAt = 0;
 
   const runEvaluation = (options?: { force?: boolean }) => {
-    let decision: DiscordAutoPresenceDecision | null;
+    let presence: UpdatePresenceData | null;
     try {
-      decision = resolveDiscordAutoPresenceDecision({
+      presence = resolveDiscordAutoPresenceUpdate({
         discordConfig: params.discordConfig,
         authStore: loadAuthStore(),
         gatewayConnected: params.gateway.isConnected,
@@ -299,13 +239,13 @@ export function createDiscordAutoPresenceController(params: {
       return;
     }
 
-    if (!decision || !params.gateway.isConnected) {
+    if (!presence || !params.gateway.isConnected) {
       return;
     }
 
     const forceApply = options?.force === true;
     const ts = now();
-    const signature = stablePresenceSignature(decision.presence);
+    const signature = stablePresenceSignature(presence);
     if (!forceApply && signature === lastAppliedSignature) {
       return;
     }
@@ -313,7 +253,7 @@ export function createDiscordAutoPresenceController(params: {
       return;
     }
 
-    params.gateway.updatePresence(decision.presence);
+    params.gateway.updatePresence(presence);
     lastAppliedSignature = signature;
     lastAppliedAt = ts;
   };
@@ -327,13 +267,13 @@ export function createDiscordAutoPresenceController(params: {
         return;
       }
       runEvaluation({ force: true });
-      timer = setIntervalFn(() => runEvaluation(), autoCfg.intervalMs);
+      timer = setInterval(() => runEvaluation(), autoCfg.intervalMs);
     },
     stop: () => {
       if (!timer) {
         return;
       }
-      clearIntervalFn(timer);
+      clearInterval(timer);
       timer = undefined;
     },
   };


### PR DESCRIPTION
## What Problem This Solves

Discord auto-presence still carried custom-text rendering and extra decision metadata after that configuration surface was retired. Every reachable generated status now uses a fixed string, but the old template and fallback paths obscured the state-to-presence mapping.

## Why This Change Was Made

Remove retired template/reason plumbing, unread private decision fields, the unreachable model-unavailable fallback, and unused interval-injection options. Return the existing Discord presence payload directly. Preserve configured healthy activities, availability classification, cooldown mutation, disconnected suppression, error handling, refresh, throttling, and signatures.

The retirement is explicit: `edecdbd05ef` (#111527) removed custom-text schema/runtime readers; Doctor already removes `healthyText`, `degradedText`, and `exhaustedText`. The remaining legacy type is Doctor-only input. `af3d796e199` (#107714) made the decision builder private, and its only caller reads the presence payload. Exhausted state is produced only after the exhausted-reason check, so the alternate template cannot be reached. No config/schema/migration changes are needed here. Follow-up deletion work for #135868.

## User Impact

No intended behavior change. Healthy presence stays online with configured activity, degraded presence stays idle with “runtime degraded”, and exhausted presence stays dnd with “token exhausted”. Production +24/−84 (net −60); tests +55/−30 (net +25).

## Evidence

- Seven focused boundary cases passed against original production code before the refactor. Afterward, all 65 tests across auto-presence, presence, provider startup, and provider suites passed.
- Existing exhaustion tests and their one-use helper are consolidated at `extensions/discord/src/monitor/auto-presence.test.ts:31` (rate-limit and overloaded rows); both original behaviors remain covered. Recovery remains at `:89`, now also checking configured healthy activity; refresh at `:139` and disabled mode at `:187` remain.
- Added cases at `:56` and `:73` protect degraded output with no profiles and cooldown cleanup while disconnected without a presence send. These cover ordering and payload risks exposed by this deletion.
- Independent Codex review: scoped-clean through P2. Full `node scripts/check-changed.mjs --base origin/main`: exit 0 on clean Blacksmith Testbox `tbx_01m1w9ztecj52rzx0gkbrrr4s9`, including lint and import cycles. [Run](https://github.com/openclaw/openclaw/actions/runs/34061202984). The one-shot lease completed and stopped; the backing Actions session can show cancellation during that cleanup. Local changed checks passed typechecking but lint was blocked because this nested worktree resolved `punycode` from its user-managed parent install; no parent files or guards were changed.
- Tests use an isolated state directory and a mocked Discord gateway boundary. No live Discord account was exercised; external API behavior is unchanged.
- Rebase updated main's Proxyline dependency from 0.3.7 to 0.3.11. Ran `pnpm install --frozen-lockfile --offline` once; all 65 focused tests passed again. The source patch is identical to the independently reviewed and clean-Testbox-checked patch.
- Exact-head CI watcher: GREEN. A cancelled older ClawSweeper dispatch was superseded by a successful same-head dispatch; the existing watcher reconciled it without reruns or guard changes.
- ClawSweeper reviewed exact head `852f30652bcaf749b25c227b7622d67b71d3f2bd`: no findings, security concerns, or requested rank-up changes. Maintainer source review agrees.
