### PR TITLE
perf: reduce duplicate session reads during worker cleanup

### DIFF
--- a/src/config/sessions/session-accessor.readonly.test.ts
+++ b/src/config/sessions/session-accessor.readonly.test.ts
@@ -1,11 +1,13 @@
 import fs from "node:fs";
+import { DatabaseSync, type StatementSync } from "node:sqlite";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   cleanupTempDirs,
   makeTempDir,
   useAutoCleanupTempDirTracker,
 } from "../../../test/helpers/temp-dir.js";
+import { clearNodeSqliteKyselyCacheForDatabase } from "../../infra/kysely-sync.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   getOpenClawAgentDatabaseIfOpen,
@@ -30,6 +32,7 @@ import {
   readSessionTranscriptWatermarkBatch,
   readSessionIdentityEvidenceBatch,
   readSessionStoreSummaryReadOnly,
+  recordSessionParticipant,
   replaceSessionEntrySync,
   resolveTranscriptSessionKeyBySessionId,
   upsertSessionEntryCore,
@@ -452,48 +455,178 @@ describe("session accessor readonly listing", () => {
     ]);
   });
 
-  it("rejects stale valid projections for unreadable session identity evidence", async () => {
-    const stateDir = autoTempDirs.make("openclaw-session-readonly-stale-valid-evidence-");
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    const agentId = "worker-1";
-    const sessionId = "session-1";
-    const sessionKey = "agent:worker-1:main";
-    await upsertSessionEntryCore({ agentId, env, sessionKey }, { sessionId, updatedAt: 1 });
-    const readableSessionId = "session-2";
-    const readableSessionKey = "agent:worker-1:readable";
-    await upsertSessionEntryCore(
-      { agentId, env, sessionKey: readableSessionKey },
-      { sessionId: readableSessionId, updatedAt: 1 },
-    );
-    const database = openOpenClawAgentDatabase({ agentId, env });
-    database.db
-      .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
-      .run(JSON.stringify({ sessionId: "mismatched-session", updatedAt: 1 }), sessionKey);
-    database.db
-      .prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?")
-      .run(sessionKey);
+  it.each(["identity", "timestamp", "json", "participant"])(
+    "rejects stale valid %s evidence without relying on a fallback read",
+    async (corruption) => {
+      const stateDir = autoTempDirs.make("openclaw-session-readonly-stale-valid-evidence-");
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const agentId = "worker-1";
+      const sessionId = "session-1";
+      const sessionKey = "agent:worker-1:main";
+      await upsertSessionEntryCore({ agentId, env, sessionKey }, { sessionId, updatedAt: 1 });
+      const readableSessionId = "session-2";
+      const readableSessionKey = "agent:worker-1:readable";
+      await upsertSessionEntryCore(
+        { agentId, env, sessionKey: readableSessionKey },
+        { sessionId: readableSessionId, updatedAt: 1 },
+      );
+      const database = openOpenClawAgentDatabase({ agentId, env });
+      if (corruption === "participant") {
+        recordSessionParticipant(
+          { agentId, env, sessionKey },
+          { identity: { type: "agent", id: "peer" }, promptedAt: 1 },
+        );
+        database.db
+          .prepare("UPDATE session_participants SET identity_namespace = ? WHERE session_key = ?")
+          .run("{}", sessionKey);
+      } else {
+        const entryJson =
+          corruption === "json"
+            ? "{"
+            : JSON.stringify({
+                sessionId: corruption === "identity" ? "mismatched-session" : sessionId,
+                updatedAt: corruption === "timestamp" ? 2 : 1,
+              });
+        database.db
+          .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
+          .run(entryJson, sessionKey);
+      }
+      database.db
+        .prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?")
+        .run(sessionKey);
+
+      expect(
+        readSessionIdentityEvidenceBatch([
+          { agentId, env, sessionId, sessionKey, storePath: database.path },
+        ]),
+      ).toEqual([{ status: "unknown", reason: "row-invalid" }]);
+
+      expect(
+        readSessionIdentityEvidenceBatch([
+          { agentId, sessionId, sessionKey, storePath: database.path },
+          {
+            agentId,
+            sessionId,
+            sessionKey: "agent:worker-1:old-key",
+            storePath: database.path,
+          },
+          {
+            agentId,
+            sessionId: readableSessionId,
+            sessionKey: readableSessionKey,
+            storePath: database.path,
+          },
+        ]),
+      ).toEqual([
+        { status: "unknown", reason: "row-invalid" },
+        { status: "unknown", reason: "row-invalid" },
+        { status: "current", sessionKey: readableSessionKey },
+      ]);
+    },
+  );
+
+  it("keeps retained identity ambiguity even when the exact key is present", async () => {
+    const env = { OPENCLAW_STATE_DIR: autoTempDirs.make("openclaw-session-retained-evidence-") };
+    const scope = { agentId: "worker-1", env };
+    const sessionId = "retained-generation";
+    const sessionKey = "agent:worker-1:retained";
+    runOpenClawAgentWriteTransaction((database) => {
+      ensureTranscriptSessionRoot(database, { ...scope, sessionKey, sessionId }, 1);
+    }, scope);
+    const storePath = resolveOpenClawAgentSqlitePath(scope);
+    const probe = { ...scope, sessionId, sessionKey, storePath };
+    expect(readSessionIdentityEvidenceBatch([probe])).toEqual([{ status: "absent" }]);
+
+    const currentKey = "agent:worker-1:current";
+    await upsertSessionEntryCore({ ...scope, sessionKey: currentKey }, { sessionId, updatedAt: 1 });
 
     expect(
       readSessionIdentityEvidenceBatch([
-        { agentId, sessionId, sessionKey, storePath: database.path },
-        {
-          agentId,
-          sessionId,
-          sessionKey: "agent:worker-1:old-key",
-          storePath: database.path,
-        },
-        {
-          agentId,
-          sessionId: readableSessionId,
-          sessionKey: readableSessionKey,
-          storePath: database.path,
-        },
+        probe,
+        { ...probe, sessionKey: currentKey },
+        { ...scope, sessionId, storePath },
       ]),
     ).toEqual([
-      { status: "unknown", reason: "row-invalid" },
-      { status: "unknown", reason: "row-invalid" },
-      { status: "current", sessionKey: readableSessionKey },
+      { status: "unknown", reason: "ambiguous" },
+      { status: "current", sessionKey: currentKey },
+      { status: "unknown", reason: "ambiguous" },
     ]);
+  });
+
+  it("validates a later required fallback row after another connection commits", async () => {
+    const stateDir = autoTempDirs.make("openclaw-session-evidence-external-commit-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const agentId = "worker-1";
+    const sessionKey = "agent:worker-1:main";
+    const sessionId = "shared-generation";
+    await upsertSessionEntryCore({ agentId, env, sessionKey }, { sessionId, updatedAt: 1 });
+    const database = openOpenClawAgentDatabase({ agentId, env });
+    const probe = { agentId, env, sessionId, storePath: database.path };
+    const probes = [{ ...probe, sessionKey }, probe];
+    expect(readSessionIdentityEvidenceBatch(probes)).toEqual([
+      { status: "current", sessionKey },
+      { status: "current", sessionKey },
+    ]);
+
+    const external = new DatabaseSync(database.path);
+    const events: string[] = [];
+    clearNodeSqliteKyselyCacheForDatabase(database.db);
+    const originalPrepare = database.db.prepare.bind(database.db);
+    const prepareSpy = vi.spyOn(database.db, "prepare").mockImplementation((sqlText) => {
+      const statement = originalPrepare(sqlText);
+      const normalized = sqlText.toLowerCase().replaceAll(/\s+/g, " ");
+      if (!normalized.includes('from "session_nodes"')) {
+        return statement;
+      }
+      const exact = normalized.includes('where "session_key" in');
+      const fallback = normalized.includes('where "current_session_id" in');
+      if (!exact && !fallback) {
+        return statement;
+      }
+      const originalIterate = statement.iterate.bind(statement) as (
+        ...args: unknown[]
+      ) => ReturnType<StatementSync["iterate"]>;
+      statement.iterate = ((...args: unknown[]) => {
+        const rows = originalIterate(...args);
+        return (function* () {
+          yield* rows;
+          events.push(exact ? "exact-read" : "fallback-read");
+          if (exact) {
+            // Commit after SQLite finishes the exact read. The identity-only probe
+            // still requires a fallback, whose later row must replace that snapshot.
+            external.exec("BEGIN IMMEDIATE");
+            try {
+              external
+                .prepare(
+                  "UPDATE session_nodes SET entry_json = ?, updated_at = ? WHERE session_key = ?",
+                )
+                .run(JSON.stringify({ sessionId, updatedAt: 2 }), 3, sessionKey);
+              external
+                .prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?")
+                .run(sessionKey);
+              external.exec("COMMIT");
+              events.push("external-commit");
+            } catch (error) {
+              external.exec("ROLLBACK");
+              throw error;
+            }
+          }
+        })();
+      }) as StatementSync["iterate"];
+      return statement;
+    });
+    try {
+      const observed = readSessionIdentityEvidenceBatch(probes);
+      expect(events).toEqual(["exact-read", "external-commit", "fallback-read"]);
+      expect(observed).toEqual([
+        { status: "unknown", reason: "row-invalid" },
+        { status: "unknown", reason: "row-invalid" },
+      ]);
+    } finally {
+      clearNodeSqliteKyselyCacheForDatabase(database.db);
+      prepareSpy.mockRestore();
+      external.close();
+    }
   });
 
   it("uses the current-session-id index for fallback identity probes", async () => {

--- a/src/config/sessions/session-accessor.sqlite-entry-availability.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-availability.ts
@@ -146,7 +146,15 @@ function readSessionIdentityEvidenceRows(
     [...new Set(items.flatMap((item) => (item.sessionKey ? [item.sessionKey] : [])))],
     "session_key",
   );
-  readChunks([...new Set(items.map((item) => item.sessionId))], "current_session_id");
+  // Matching headers only avoid redundant reads; the full validator below still owns
+  // validity. Other probes may require the same identity and replace this snapshot.
+  const fallbackIds = items.flatMap((item) => {
+    const exactRow = item.sessionKey ? rowsByKey.get(item.sessionKey) : undefined;
+    return exactRow?.entry_valid === 1 && exactRow.current_session_id === item.sessionId
+      ? []
+      : [item.sessionId];
+  });
+  readChunks([...new Set(fallbackIds)], "current_session_id");
 
   const rowsBySessionId = new Map<string, SessionIdentityEvidenceRow[]>();
   const readableKeys = new Set<string>();

--- a/src/gateway/server-worker-placement-session-evidence.test.ts
+++ b/src/gateway/server-worker-placement-session-evidence.test.ts
@@ -16,6 +16,7 @@ vi.mock("../logging/subsystem.js", async () => {
     },
   };
 });
+import { trackSqliteStatementExecutions } from "../../test/helpers/sqlite-statement-execution-counter.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
 import * as sessionAccessor from "../config/sessions/session-accessor.js";
@@ -26,9 +27,15 @@ import {
   openOpenClawAgentDatabase,
   resolveIncognitoOpenClawAgentSqlitePath,
 } from "../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { createWorkerPlacementSessionEvidenceResolver } from "./server-worker-placement-session-evidence.js";
 import type { WorkerSessionPlacementRecord } from "./worker-environments/placement-record.js";
+import { createPlacementSessionRetirement } from "./worker-environments/placement-session-retirement.js";
+import { createWorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const resolveTargetsReadOnlySpy = vi.spyOn(
@@ -39,6 +46,7 @@ const readIdentityEvidenceBatchSpy = vi.spyOn(sessionAccessor, "readSessionIdent
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
   resetConfigRuntimeState();
   resolveTargetsReadOnlySpy.mockClear();
   readIdentityEvidenceBatchSpy.mockClear();
@@ -80,6 +88,114 @@ async function resolvePlacementEvidence(placement: WorkerSessionPlacementRecord)
 }
 
 describe("worker placement session evidence", () => {
+  it.each([
+    { count: 12, prompt: "saved prompt ".repeat(16_384) },
+    { count: 401, prompt: "" },
+  ])(
+    "does not duplicate exact-current payloads for $count placements",
+    async ({ count, prompt }) => {
+      const stateDir = tempDirs.make("openclaw-placement-exact-first-");
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        const placements = Array.from({ length: count }, (_, index) =>
+          localPlacement(`exact-current-${index}`, `agent:main:exact-current-${index}`),
+        );
+        for (const placement of placements) {
+          await sessionAccessor.upsertSessionEntryCore(
+            { agentId: placement.agentId, sessionKey: placement.sessionKey },
+            {
+              sessionId: placement.sessionId,
+              updatedAt: 1,
+              skillsSnapshot: { prompt, skills: [] },
+            },
+          );
+        }
+        const warm = await createWorkerPlacementSessionEvidenceResolver(placements);
+        await expect(Promise.all(placements.map(warm))).resolves.toEqual(
+          placements.map(() => "current"),
+        );
+        const database = openOpenClawAgentDatabase({ agentId: "main" });
+        const statements = trackSqliteStatementExecutions(database.db, ["fallback"], (sql) => {
+          const normalized = sql.toLowerCase().replaceAll(/\s+/g, " ");
+          return normalized.includes('from "session_nodes"') &&
+            normalized.includes('where "current_session_id" in')
+            ? "fallback"
+            : null;
+        });
+        try {
+          const resolve = await createWorkerPlacementSessionEvidenceResolver(placements);
+          await expect(Promise.all(placements.map(resolve))).resolves.toEqual(
+            placements.map(() => "current"),
+          );
+          expect(
+            statements.textBytes.fallback,
+            JSON.stringify({
+              queries: statements.counts.fallback,
+              rows: statements.rowCounts.fallback,
+              bytes: statements.textBytes.fallback,
+            }),
+          ).toBeLessThan(16_384);
+        } finally {
+          statements.restore();
+        }
+      });
+    },
+  );
+
+  it("retires absent ownerless placements while retaining valid, unreadable, and claimed sessions", async () => {
+    const stateDir = tempDirs.make("openclaw-placement-evidence-retirement-");
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      const placements = createWorkerSessionPlacementStore({
+        database: openOpenClawStateDatabase(),
+        now: () => 1_000,
+      });
+      const identities = ["current", "unreadable", "absent", "claimed"].map((kind) => ({
+        agentId: "main",
+        sessionId: `session-${kind}`,
+        sessionKey: `agent:main:${kind}`,
+      }));
+      const claim = placements.claimTurn({
+        ...identities[3]!,
+        owner: { kind: "local" },
+        claimId: "live-claim",
+        runId: "live-run",
+      });
+      const requested = identities.map((identity) => placements.startDispatch(identity));
+      for (const identity of identities.slice(0, 2)) {
+        await sessionAccessor.upsertSessionEntryCore(identity, {
+          sessionId: identity.sessionId,
+          updatedAt: 1,
+        });
+      }
+      const database = openOpenClawAgentDatabase({ agentId: "main" });
+      database.db
+        .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
+        .run("{", identities[1]!.sessionKey);
+      database.db
+        .prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?")
+        .run(identities[1]!.sessionKey);
+      const forceDestroyEnvironment = vi.fn();
+      const retirement = createPlacementSessionRetirement({
+        placements,
+        environments: { get: () => undefined },
+        forceDestroyEnvironment,
+        createSessionEvidenceResolver: createWorkerPlacementSessionEvidenceResolver,
+        warn: vi.fn(),
+      });
+
+      await retirement.reconcile();
+
+      expect(placements.get(identities[0]!.sessionId)).toEqual(requested[0]);
+      expect(placements.get(identities[1]!.sessionId)).toEqual(requested[1]);
+      expect(placements.get(identities[2]!.sessionId)).toBeUndefined();
+      expect(placements.get(identities[3]!.sessionId)).toMatchObject({
+        state: "requested",
+        generation: requested[3]!.generation,
+        turnClaim: { owner: "local", claimId: claim.claimId, runId: claim.runId },
+      });
+      expect(forceDestroyEnvironment).not.toHaveBeenCalled();
+    });
+  });
+
   it("keeps ordinary discovery failures independent from incognito evidence", async () => {
     const stateDir = tempDirs.make("openclaw-placement-session-read-failed-");
     await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where periodic worker cleanup spends unnecessary time synchronously reading large saved session snapshots, delaying other Gateway work even when every placement already matches its exact session key.

## Why This Change Was Made

Use the exact row headers to select only the session IDs that still need fallback lookup. The existing full JSON, canonical-key, participant, and result validation remains authoritative; a matching header is only a query-planning hint. Identity-only probes, moved keys, retained-row ambiguity, unavailable stores, and placement claim checks keep their existing behavior.

No schema, stored representation, cache, configuration, or public API changes. Reads remain nontransactional across other connections: this removes an incidental second observation and does not promise an atomic or fresher snapshot. A required fallback still replaces the earlier exact row before full validation.

## User Impact

Worker cleanup performs less synchronous read work for current placements while retaining the existing session-validation and retirement checks.

## Evidence

Blacksmith Testbox, Node 24.19.0 / pnpm 12.3.4, isolated synthetic state:

- Original real-resolver regression: 12 exact-current placements unnecessarily transferred another 2,558,322 bytes; 401 tiny placements transferred another 82,677 bytes. Both fail the payload budget on original code and pass with this change.
- 74 tests pass across the reader, participant, real resolver/retirement, Doctor, canonical-key, and startup cleanup/maintenance suites. Seven new preservation controls also pass against original code, including a real second-connection commit before required fallback and actual placement-store retention/retirement with a live turn claim.
- Full `check:changed` passes, including core and test type checks, lint, dependency and storage guards, and full dead-export scans. Isolated P2 review is clean.
- Paired timings use 36 samples per reader and rotate all six execution orders. Two independently loaded copies of the original reader provide a same-code control; every result is compared for equality.

| Synthetic batch | Original median | Identical-original control | Candidate median |
| --- | ---: | ---: | ---: |
| 32 tiny current rows | 0.632 ms | 0.621 ms | 0.585 ms |
| 16 current rows with 1 MiB saved prompts | 13.459 ms | 13.571 ms | 9.885 ms |
| 16 rows with nested reports and 64 KiB prompts | 1.405 ms | 1.411 ms | 1.295 ms |
| 32 rows, half requiring moved-key fallback | 1.412 ms | 1.402 ms | 1.298 ms |
| 401 tiny current rows | 7.042 ms | 7.002 ms | 6.551 ms |
| 16 rows with fresh database handles | 2.402 ms | 2.387 ms | 2.253 ms |

The large-prompt batch is about 27% faster, with median next-turn delay falling from 13.494/13.622 ms to 9.926 ms. These are bounded reader measurements, not an overall Gateway speedup or an attribution of production stalls. Full row parsing still runs. Process CPU for the tiny first case was noisy; no uniform CPU-reduction claim is made.
