### PR TITLE
fix(memory): preserve indentation in cited search snippets

### DIFF
--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -616,6 +616,8 @@ full-text matching, including in queries that also contain short terms.
 
 `memory.citations` controls citation visibility for built-in memory results:
 
+Cited snippets preserve leading indentation; trailing whitespace is removed before the source footer.
+
 | Value            | Behavior                                               |
 | ---------------- | ------------------------------------------------------ |
 | `auto` (default) | Include `Source: <path#line>` when useful              |

--- a/extensions/memory-core/src/tools.citations.ts
+++ b/extensions/memory-core/src/tools.citations.ts
@@ -24,7 +24,7 @@ export function decorateCitations(
   }
   return results.map((entry) => {
     const citation = formatCitation(entry);
-    const snippet = `${entry.snippet.trim()}\n\nSource: ${citation}`;
+    const snippet = `${entry.snippet.trimEnd()}\n\nSource: ${citation}`;
     return { ...entry, citation, snippet };
   });
 }

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 // Memory Core integration tests exercise the real SQLite search manager through tools.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
@@ -27,6 +29,107 @@ describe("memory_search real manager", () => {
 
   beforeEach(() => {
     testing.resetMemorySearchToolCooldowns();
+  });
+
+  it.each([
+    {
+      label: "space-indented citations on",
+      mode: "on",
+      sessionKey: "agent:main:main",
+      query: "CitationIndentSpaces",
+      text: "    CitationIndentSpaces()\n    preserveIndentation()",
+      expected:
+        "    CitationIndentSpaces()\n    preserveIndentation()\n\nSource: memory/citation-indent.md#L1-L2",
+    },
+    {
+      label: "tab-indented direct auto citations",
+      mode: "auto",
+      sessionKey: "agent:main:telegram:direct:fixture",
+      query: "CitationIndentTabs",
+      text: "\tCitationIndentTabs()\n\tpreserveIndentation()",
+      expected:
+        "\tCitationIndentTabs()\n\tpreserveIndentation()\n\nSource: memory/citation-indent.md#L1-L2",
+    },
+    {
+      label: "space-indented citations off",
+      mode: "off",
+      sessionKey: "agent:main:main",
+      query: "CitationIndentOff",
+      text: "    CitationIndentOff()\n    preserveIndentation()",
+      expected: "    CitationIndentOff()\n    preserveIndentation()",
+    },
+    {
+      label: "tab-indented group auto citations",
+      mode: "auto",
+      sessionKey: "agent:main:telegram:group:fixture",
+      query: "CitationIndentGroup",
+      text: "\tCitationIndentGroup()\n\tpreserveIndentation()",
+      expected: "\tCitationIndentGroup()\n\tpreserveIndentation()",
+    },
+    {
+      label: "ordinary citation suffix whitespace",
+      mode: "on",
+      sessionKey: "agent:main:main",
+      query: "CitationPlainControl",
+      text: "CitationPlainControl()\nfinish()\n \t",
+      expected: "CitationPlainControl()\nfinish()\n\nSource: memory/citation-indent.md#L1-L3",
+    },
+  ] as const)("preserves indexed snippet layout for $label", async (testCase) => {
+    const filePath = path.join(fixture.paths.memory, "citation-indent.md");
+    await fs.writeFile(filePath, testCase.text);
+    const baseConfig = fixture.createConfig({
+      provider: "none",
+      sources: ["memory"],
+      vectorEnabled: false,
+      minScore: 0,
+    });
+    const cfg = {
+      ...baseConfig,
+      memory: { ...baseConfig.memory, citations: testCase.mode },
+      plugins: {
+        ...baseConfig.plugins,
+        entries: { "memory-core": { config: { dreaming: { enabled: false } } } },
+      },
+    } satisfies OpenClawConfig;
+    const manager = await fixture.getFreshManager(cfg, "cli");
+    await manager.sync({ reason: "cli", force: true });
+    const raw = await manager.search(testCase.query, { sources: ["memory"] });
+    expect(raw).toHaveLength(1);
+    expect(raw[0]).toMatchObject({
+      path: "memory/citation-indent.md",
+      snippet: testCase.text,
+    });
+    await manager.close();
+
+    const tool = createMemorySearchTool({
+      config: cfg,
+      agentId: "main",
+      agentSessionKey: testCase.sessionKey,
+      oneShotCliRun: true,
+    });
+    if (!tool) {
+      throw new Error("memory_search tool missing");
+    }
+    const result = await tool.execute("citation-indentation", {
+      query: testCase.query,
+      corpus: "memory",
+    });
+    const expected = {
+      results: [{ path: "memory/citation-indent.md", snippet: testCase.expected }],
+    };
+    expect
+      .soft(result.details, "tool result details preserve snippet layout")
+      .toMatchObject(expected);
+    const content = result.content[0];
+    if (!content || content.type !== "text") {
+      throw new Error("memory_search returned no model-visible JSON");
+    }
+    expect
+      .soft(JSON.parse(content.text), "model-visible JSON preserves snippet layout")
+      .toMatchObject(expected);
+    expect(await fs.readFile(filePath, "utf8")).toBe(testCase.text);
+    expect(fixture.provider.embedBatchCalls).toBe(0);
+    expect(fixture.provider.embedQueryCalls).toBe(0);
   });
 
   it("reports current invalid config after replacing the config of a retained tool", async () => {


### PR DESCRIPTION
Closes #140470

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users requesting cited memory-search results receive a snippet with its first line's indentation removed. For example, a retrieved two-line excerpt beginning with four spaces loses those spaces on its first line when the source footer is added.

## Why This Change Was Made

The citation decorator used `trim()` on the retrieved snippet. Switching to `trimEnd()` preserves meaningful leading whitespace while retaining the existing trailing-padding cleanup and citation behavior. The repair stays at the result-formatting boundary after retrieval, and the citation documentation now states how leading indentation and trailing whitespace are handled.

## User Impact

Cited built-in memory-search excerpts preserve their leading spaces and tabs in both tool details and model-visible JSON. The source footer and its line range remain available as before.

## Evidence

- Real SQLite manager-to-tool regression: two intended failures and three passing controls before the fix; the identical five cases pass afterward. The cases cover spaces with citations on, tabs with direct-auto citations, citations off, group-auto citations, and trailing-padding cleanup.
- The raw manager snippet is qualified before tool invocation. Each case checks both public output forms, unchanged source-file bytes, and zero embedding batch/query calls.
- Complete citation/tool and real-manager test files: **37 passed, 0 failed, 0 skipped** on Node 24.20.0.
- Targeted formatting passed for the implementation and regression test.
- Scoped managed review reported no accepted/actionable P0–P2 findings.

Production: **+1/−1, net zero**. Regression coverage: **+103 test lines**. Documentation: **+2 lines**.

- The complete three-path changed gate passed in **333.510 seconds**, including formatting, both plugin typechecks, required doctor-contract tests, and scoped lint. Source, index and lock inputs remained unchanged.
- The final signed candidate `27c0206d7aebb796af8c4b2c6ce58ae4d39ef0df` passed an uncached **100.427-second** build. Complete source, dependency and generated-artifact inventories were sealed and independently verified before and after runtime proof.
- Built-product before/after proof used the normal CLI to index three literal Markdown files, then four authenticated `POST /tools/invoke` calls across fresh citations-on/off Gateways per build. The baseline reproduced both first-line indentation losses while both controls passed; the fixed build preserved both excerpts and both controls. Raw CLI snippets were verified before and after, model-visible JSON equaled details, and all owned processes/listeners and successful private fixtures were cleaned up.

| Case | Baseline | Fixed |
| --- | --- | --- |
| Spaces, citations on | First-line indentation removed | Preserved |
| Tabs, citations on | First-line indentation removed | Preserved |
| Plain trailing padding, citations on | Existing cleanup preserved | Preserved |
| Spaces, citations off | Indentation preserved | Preserved |

The built baseline was `e0f848cf4a82664261de1e82ff5565c19ffb599c`; all 34 inspected owners matched the candidate's base `1fde67b08a4e8426474a46acd9ea968e300f8872`. Current-main composition was also checked at `6bfa52059c29596c0aca9d5913b3451f565f61e9`.

The first HTTP proof attempt stopped on an incorrect expected diagnostic-mode field after a successful response. The normal builtin owner leaves that field absent; the corrected script requires that exact shape. The original failure is retained. No product change, timeout increase, or output substitution was used to resolve it.

This proves builtin keyword indexing and the actual Gateway/tool serialization path. It does not claim external embedding-provider, model-turn, QMD, or native UI coverage. Exact-head [CI 34062448756](https://github.com/openclaw/openclaw/actions/runs/34062448756) completed successfully: 78 jobs succeeded and 16 were skipped. Native landing verification remains.

