### PR TITLE
docs: correct three factual errors in gateway and secrets pages

### DIFF
--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -211,7 +211,7 @@ Notes:
 - Targets secret-bearing fields in `openclaw.json` plus the selected agent's auth profile store; canonical supported surface: [SecretRef Credential Surface](/reference/secretref-credential-surface).
 - Supports creating new auth profile mappings directly in the picker flow.
 - Runs preflight resolution before apply.
-- Generated plans default to scrub options enabled (`scrubEnv`, `scrubAuthProfilesForProviderTargets`, `scrubLegacyAuthJson`). Apply is one-way for scrubbed plaintext values.
+- Generated plans enable `scrubEnv` and `scrubAuthProfilesForProviderTargets`. `scrubLegacyAuthJson` stays disabled, because Doctor owns legacy `auth.json` migration. Apply is one-way for scrubbed plaintext values.
 - `--plan-out` refuses to create a plan whose UTF-8 serialized form exceeds 16 MiB (16,777,216 bytes), matching the `apply --from` input limit.
 - Without `--apply`, the CLI still prompts `Apply this plan now?` after preflight.
 - With `--apply` (and no `--yes`), the CLI prompts an extra irreversible-migration confirmation.

--- a/docs/gateway/cloudflare-access.md
+++ b/docs/gateway/cloudflare-access.md
@@ -142,7 +142,8 @@ openclaw tui
 
 Expect the TUI to reach `wss://gateway.example` and show `connected`. A first
 connection may report `device pairing required`; approve it in the Control UI under
-Settings → Devices, or run `openclaw devices approve --latest` on the Gateway host.
+Settings → Devices, or run `openclaw devices approve --latest` on the Gateway host
+to preview the request, then rerun the approval command it prints.
 
 Reaching the Gateway's own pairing prompt is itself the proof that Access was
 satisfied — an unauthenticated request never gets that far.

--- a/docs/gateway/multiple-gateways.md
+++ b/docs/gateway/multiple-gateways.md
@@ -17,7 +17,7 @@ The simplest rescue-bot setup:
 - Run the rescue bot on `--profile rescue`, with its own Telegram bot token.
 - Put the rescue bot on a different base port, e.g. `19789`.
 
-This keeps the rescue bot able to debug or apply config changes if the primary bot is down. Leave at least 20 ports between base ports so derived browser/CDP ports never collide.
+This keeps the rescue bot able to debug or apply config changes if the primary bot is down. Leave at least 120 ports between base ports so derived browser/CDP ports never collide. Each instance reaches base + 110: its browser control port is base + 2, and that port's CDP range runs to base + 110.
 
 ```bash
 # Rescue bot (separate Telegram bot, separate profile, port 19789)


### PR DESCRIPTION
Three verified factual errors found during the docs audit. Each is checked against the CLI reference or the source, not inferred.

## 1. `cloudflare-access`: the approval command does not approve

`docs/gateway/cloudflare-access.md` told the reader to approve a pending device pairing by running `openclaw devices approve --latest`.

`docs/cli/devices.md:42` says that flag does the opposite:

> Approve a pending pairing request by exact `requestId`. Omitting `requestId`, or passing `--latest`, only previews the newest pending request and exits (code 1); rerun with the exact request ID to approve.

A reader following the Cloudflare Access page gets exit code 1 and no approval. The page now says to preview with `--latest`, then rerun the approval command it prints.

## 2. `cli/secrets`: wrong default for `scrubLegacyAuthJson`

Two pages contradicted each other:

- `docs/cli/secrets.md:214` listed `scrubLegacyAuthJson` among scrub options that generated plans **enable**.
- `docs/gateway/secrets-plan-contract.md:131` says it is "a deprecated plan input and is always disabled".

Source settles it — the CLI page was wrong:

- `src/secrets/configure-plan.ts:266-270` builds the plan with `scrubEnv: true`, `scrubAuthProfilesForProviderTargets: true`, `scrubLegacyAuthJson: false`.
- `src/secrets/plan.ts:215` defaults it to `false`.

## 3. `multiple-gateways`: port spacing advice collides with its own arithmetic

Line 20 advised "at least 20 ports between base ports so derived browser/CDP ports never collide". The same page states the browser control port is `base + 2` (line 107) and CDP ports auto-allocate from `control port + 9` through `+ 108` (line 109), so one instance reaches `base + 110`.

Two gateways placed 20 ports apart overlap from `base + 31` onward. The advice is now 120 ports, with the arithmetic stated so the number is checkable.

## Validation

- `docs:check-mdx`: passed, 784 files.
- `docs-link-audit`: 8,326 internal links, 0 broken.
- STE hard violations on the three touched files unchanged at 30 (pre-existing baseline; a separate prose pass covers those).

Ledger ids `r5-0001`, `r5-0003`, `r5-0004`.