### PR TITLE
refactor(sandbox): share configured tool-list selection

### DIFF
--- a/src/agents/sandbox/tool-policy.ts
+++ b/src/agents/sandbox/tool-policy.ts
@@ -22,86 +22,33 @@ type SandboxToolPolicyConfig = {
   deny?: string[];
 };
 
-function buildSource(params: {
-  scope: "agent" | "global" | "default";
-  key: string;
-}): SandboxToolPolicySource {
-  return {
-    source: params.scope,
-    key: params.key,
-  } satisfies SandboxToolPolicySource;
-}
-
-function pickConfiguredList(params: { agent?: string[]; global?: string[] }): {
+function pickConfiguredList(
+  field: keyof SandboxToolPolicyConfig,
+  agent?: SandboxToolPolicyConfig,
+  global?: SandboxToolPolicyConfig,
+): {
   values?: string[];
   source: SandboxToolPolicySource;
 } {
-  if (Array.isArray(params.agent)) {
+  const agentValues = agent?.[field];
+  const globalValues = global?.[field];
+  const key = `tools.sandbox.tools.${field}`;
+  if (Array.isArray(agentValues)) {
     return {
-      values: params.agent,
-      source: buildSource({
-        scope: "agent",
-        key: "agents.entries.*.tools.sandbox.tools.allow",
-      }),
+      values: agentValues,
+      source: { source: "agent", key: `agents.entries.*.${key}` },
     };
   }
-  if (Array.isArray(params.global)) {
+  if (Array.isArray(globalValues)) {
     return {
-      values: params.global,
-      source: buildSource({ scope: "global", key: "tools.sandbox.tools.allow" }),
+      values: globalValues,
+      source: { source: "global", key },
     };
   }
   return {
     values: undefined,
-    source: buildSource({ scope: "default", key: "tools.sandbox.tools.allow" }),
+    source: { source: "default", key },
   };
-}
-
-function pickConfiguredDeny(params: { agent?: string[]; global?: string[] }): {
-  values?: string[];
-  source: SandboxToolPolicySource;
-} {
-  if (Array.isArray(params.agent)) {
-    return {
-      values: params.agent,
-      source: buildSource({
-        scope: "agent",
-        key: "agents.entries.*.tools.sandbox.tools.deny",
-      }),
-    };
-  }
-  if (Array.isArray(params.global)) {
-    return {
-      values: params.global,
-      source: buildSource({ scope: "global", key: "tools.sandbox.tools.deny" }),
-    };
-  }
-  return {
-    values: undefined,
-    source: buildSource({ scope: "default", key: "tools.sandbox.tools.deny" }),
-  };
-}
-
-function pickConfiguredAlsoAllow(params: { agent?: string[]; global?: string[] }): {
-  values?: string[];
-  source?: SandboxToolPolicySource;
-} {
-  if (Array.isArray(params.agent)) {
-    return {
-      values: params.agent,
-      source: buildSource({
-        scope: "agent",
-        key: "agents.entries.*.tools.sandbox.tools.alsoAllow",
-      }),
-    };
-  }
-  if (Array.isArray(params.global)) {
-    return {
-      values: params.global,
-      source: buildSource({ scope: "global", key: "tools.sandbox.tools.alsoAllow" }),
-    };
-  }
-  return { values: undefined, source: undefined };
 }
 
 function mergeAllowlist(
@@ -245,18 +192,9 @@ export function resolveSandboxToolPolicyForAgent(
   const agentPolicy = agentConfig?.tools?.sandbox?.tools as SandboxToolPolicyConfig | undefined;
   const globalPolicy = cfg?.tools?.sandbox?.tools as SandboxToolPolicyConfig | undefined;
 
-  const allowConfig = pickConfiguredList({
-    agent: agentPolicy?.allow,
-    global: globalPolicy?.allow,
-  });
-  const alsoAllowConfig = pickConfiguredAlsoAllow({
-    agent: agentPolicy?.alsoAllow,
-    global: globalPolicy?.alsoAllow,
-  });
-  const denyConfig = pickConfiguredDeny({
-    agent: agentPolicy?.deny,
-    global: globalPolicy?.deny,
-  });
+  const allowConfig = pickConfiguredList("allow", agentPolicy, globalPolicy);
+  const alsoAllowConfig = pickConfiguredList("alsoAllow", agentPolicy, globalPolicy);
+  const denyConfig = pickConfiguredList("deny", agentPolicy, globalPolicy);
 
   const explicitAllowPatterns = resolveExplicitSandboxReAllowPatterns({
     allow: allowConfig.values,


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Sandbox tool configuration repeats the same agent/global/default list-selection policy for `allow`, `deny`, and `alsoAllow`. This is the maintainer-requested production deletion pass supporting concern C of the #135868 split.

## Why This Change Was Made

Use one private selector keyed by the existing policy field and construct its source metadata directly. Selection, empty-array overrides, final provenance, allow/deny merging, contained-tool defaults, and shipped deny behavior remain unchanged.

## User Impact

No user-visible behavior change. Production shrinks by 62 lines (+18/−80) in one file. Tests, tooling, docs, configuration, dependencies and public types are unchanged.

## Evidence

| Deleted implementation | Preserved contract and coverage |
| --- | --- |
| Separate `pickConfiguredDeny` and `pickConfiguredAlsoAllow` flows | `src/agents/sandbox/tool-policy.ts:25` now shares the same `Array.isArray` agent > global > default selection. Explicit empty arrays still override populated lower-priority lists. `src/agents/sandbox-explain.test.ts:23` covers precedence and final sources; `src/agents/sandbox/tool-policy.test.ts:52,126,176,459` covers additive allows, empty allow, resolver/runtime alignment and deny precedence. |
| `buildSource` copier | The selector emits the identical `source` and config-key fields directly. The helper was private and only renamed `scope` to `source`; source labels remain covered by explanation tests. |
| Repeated per-field call setup | The public resolver selects each of the three existing fields through the same private owner. Property reads retain agent-before-global order. Missing `alsoAllow` now has an internal default source record, but unchanged `pickAllowSource` selects `alsoAllow` only for agent/global sources; the default record never changes returned provenance. |

`docs/gateway/sandbox-vs-tool-policy-vs-elevated.md:69` and `docs/tools/multi-agent-sandbox-tools.md:219` retain the sandbox policy contract. The public result still contains the same allow/deny lists and source metadata. Static searches found no SDK, script or CodeQL owner reference to the removed private helpers. `git log -S` reaches their earlier owner/facade history (`501190d2e83` / `6af2ded0116`); the shallow default history boundary at `e357203be57` is not claimed as their introduction. Existing contained-tool and legacy-image deny decisions remain untouched.

Three unchanged focused suites passed before and after: 64 cases. A temporary differential probe compared 4,114 complete policy results across agent/global missing, empty, populated and invalid lists plus contained-tool options; all outputs matched exactly. Independent pinned-candidate review is scoped-clean through P2. Full changed checks passed, including core/core-test types, lint, all three dead-export scans and selected guards. Aggregate focused-suite duration was 16.67 s before and 16.35 s after. [Exact-head CI run 34062556542](https://github.com/openclaw/openclaw/actions/runs/34062556542) passed on `26ed51d123819cb3ea0fe30aefd46b64e1214ad1`. ClawSweeper reviewed that head with no findings or before-merge/rank-up requests.
