### PR TITLE
improve: avoid repeated validation when loading cron jobs

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -200,12 +200,9 @@ export async function ensureLoaded(
     const hydratedRaw = normalized ?? raw;
     let invalidReason = rawInvalidReason ?? getInvalidPersistedCronJobReason(hydratedRaw);
     const hydratedSchedule = isRecord(hydratedRaw.schedule) ? hydratedRaw.schedule : {};
-    if (
-      !invalidReason &&
-      isValidatedCronJob(hydratedRaw) &&
-      hydratedRaw.enabled &&
-      hydratedSchedule.kind === "every"
-    ) {
+    // The satisfiability probe below does not mutate this row, so its typed validation stays valid.
+    const hydratedIsValid = !invalidReason && isValidatedCronJob(hydratedRaw);
+    if (hydratedIsValid && hydratedRaw.enabled && hydratedSchedule.kind === "every") {
       try {
         assertTimeScheduleSatisfiable(
           { ...hydratedRaw, state: {} },
@@ -240,7 +237,7 @@ export async function ensureLoaded(
       continue;
     }
     // Validated above, so the raw record is now a trusted CronJob.
-    if (!isValidatedCronJob(hydratedRaw)) {
+    if (!hydratedIsValid) {
       continue;
     }
     const hydrated = hydratedRaw;


### PR DESCRIPTION
## What Problem This Solves

Reloading a large cron store repeats the same structural validation of each hydrated job even though the job has not changed between checks. Reads and scheduler-disabled mutations can pay this cost while loading the current schedule.

## Why This Change Was Made

Reuse the existing typed validation result within the current hydration iteration. The intervening schedule-satisfiability probe reads a copy; unsatisfiable jobs still take the existing quarantine path before admission. The earlier raw and hydrated validation, row ordering, and persistence ownership stay intact.

This removes three production lines and introduces no cache, configuration, schema, dependency, or API change.

## User Impact

Cron hydration performs one fewer repeated structural check per accepted row. This is a bounded reduction in repeated work, not a claim that large cron requests or event-loop stalls are eliminated.

## Evidence

Synthetic Linux Node 26.7 source-runtime capture: 13,130 jobs produced 26,260 calls to the private typed-validation wrapper before the change and 13,130 afterward, with identical input/output digests and unchanged persisted data. These counts cover that wrapper only; earlier structural checks remain. Timing completed before precise coverage instrumentation. Seven sequential samples per independent process had overlapping elapsed ranges, so this does not establish a substantial latency improvement.

All 26 focused tests passed through the canonical cron configuration, including hydration, quarantine recovery bytes, unsatisfiable and disabled schedules, and durable-state ordering. The first attempt selected the general unit configuration, which excludes cron tests; its zero-test failure is retained. Independent source review and isolated P2 review found no actionable issue.

The complete changed-source gate passed all 28 selected blocking checks, including production types, all 16 core-test type graphs, lint, and dead exports. Required CI and CodeQL also passed for this head.

The matched compiled Gateway pair passed the unchanged 65-agent, 13,130-job scenario: four exact 200-job replies within the original 20-second deadline, followed by natural shutdown without forced cleanup. Baseline response times were 2699/3465/2467/2274 ms; candidate times were 2699/3399/2348/2286 ms. These single observations show mixed small differences, not a substantial speedup. Both runs reported event-loop degradation before and after.

A final correctness run against the exact CI merge commit `49fd1f3d3d31` also passed after incorporating the startup-discovery and dependency changes that landed on main: all four expected pages returned within 20 seconds and shutdown completed naturally in 29.3 seconds. Source, build, runtime, unchanged artifact seals, and cleanup were verified. Event-loop degradation remained visible. This is separate from the matched performance observations.
