### PR TITLE
fix(android): show full settings metrics and copy instance IDs

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -2885,7 +2885,7 @@ private fun CronJobFieldsPanel(rows: List<SettingsMetric>) {
           Modifier
             .fillMaxWidth()
             .heightIn(min = 46.dp)
-            .clickable(onClickLabel = nativeString("Copy \${row.title}", row.title)) { copyCronDetailValue(context, row.title, row.value) }
+            .clickable(onClickLabel = nativeString("Copy \${row.title}", row.title)) { copySettingsDetailValue(context, row.title, row.value) }
             .padding(vertical = 6.dp)
         } else {
           Modifier
@@ -2918,13 +2918,13 @@ private fun CronJobFieldsPanel(rows: List<SettingsMetric>) {
   }
 }
 
-private fun copyCronDetailValue(
+private fun copySettingsDetailValue(
   context: Context,
   title: String,
   value: String,
 ) {
   val clipboard = context.getSystemService(ClipboardManager::class.java) ?: return
-  clipboard.setPrimaryClip(ClipData.newPlainText("OpenClaw automation $title", value))
+  clipboard.setPrimaryClip(ClipData.newPlainText("OpenClaw $title", value))
   Toast.makeText(context, nativeString("\$title copied", title), Toast.LENGTH_SHORT).show()
 }
 
@@ -3347,33 +3347,33 @@ private fun SettingsToggleListRow(row: SettingsToggleRow) {
   }
 }
 
-/**
- * Reusable metric panel for settings screens with compact title/value rows.
- */
+/** These diagnostics have no detail view, so their rows must show complete values. */
 @Composable
 internal fun SettingsMetricPanel(rows: List<SettingsMetric>) {
-  ClawPanel(contentPadding = PaddingValues(horizontal = ClawTheme.spacing.xs, vertical = 4.dp)) {
-    ClawSeparatedColumn(items = rows) { row ->
-      Row(modifier = Modifier.fillMaxWidth().heightIn(min = 44.dp).padding(vertical = 6.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(ClawTheme.spacing.xxs)) {
-        Text(
-          text = row.title,
-          style = ClawTheme.type.body,
-          color = ClawTheme.colors.text,
-          modifier = Modifier.weight(0.9f),
-          maxLines = 1,
-          overflow = TextOverflow.Ellipsis,
-        )
-        Text(
-          text = row.value,
-          style = ClawTheme.type.caption,
-          color = ClawTheme.colors.textMuted,
-          modifier = Modifier.weight(1.1f),
-          maxLines = 1,
-          overflow = TextOverflow.Ellipsis,
-          textAlign = TextAlign.End,
-        )
+  val context = LocalContext.current
+  ClawListPanel(items = rows) { row ->
+    val rowModifier =
+      if (row.copyable) {
+        Modifier.clickable(onClickLabel = nativeString("Copy \${row.title}", row.title)) {
+          copySettingsDetailValue(context, row.title, row.value)
+        }
+      } else {
+        Modifier
       }
-    }
+    ClawListItem(
+      title = row.title,
+      subtitle = row.value,
+      metadata = nativeString("Tap to copy").takeIf { row.copyable },
+      modifier = rowModifier,
+      trailing =
+        if (row.copyable) {
+          {
+            Icon(imageVector = Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(14.dp), tint = ClawTheme.colors.text)
+          }
+        } else {
+          null
+        },
+    )
   }
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
@@ -15,6 +15,8 @@ import ai.openclaw.app.ui.design.ClawDesignTheme
 import ai.openclaw.app.ui.design.assertCompleteText
 import ai.openclaw.app.ui.design.contrastThemeCases
 import ai.openclaw.app.ui.design.renderedLabelContrast
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.graphics.Bitmap
 import androidx.compose.runtime.mutableStateOf
@@ -30,6 +32,7 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -38,6 +41,7 @@ import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.SavedStateHandle
@@ -127,6 +131,76 @@ class SettingsScreensContrastTest {
           }
         },
       ).around(composeRule)
+
+  @Test
+  @Config(qualifiers = "fr-rFR-w320dp-h800dp-mdpi")
+  fun gatewayInstanceIdCopiesTheWholeValueAtLargeFont() {
+    val application = RuntimeEnvironment.getApplication()
+    val clipboard = requireNotNull(application.getSystemService(ClipboardManager::class.java))
+    val previousClip = clipboard.primaryClip
+    try {
+      val model = offlineTypographyModel()
+      composeRule.setContent {
+        DeviceConfigurationOverride(DeviceConfigurationOverride.FontScale(2f)) {
+          ClawDesignTheme(dark = false) {
+            SettingsDetailScreen(model, SettingsRoute.Gateway, onBack = {})
+          }
+        }
+      }
+      val expected = model.instanceId.value
+      assertTrue(expected.isNotBlank())
+      val value = composeRule.onNodeWithText(expected, useUnmergedTree = true).performScrollTo()
+      value.assertIsDisplayed()
+      composeRule.runOnIdle { clipboard.setPrimaryClip(ClipData.newPlainText("Previous clipboard", "synthetic clipboard sentinel")) }
+      captureTypography("gateway-instance-id-before-copy")
+      value.performTouchInput { click() }
+      composeRule.runOnIdle {
+        assertEquals(
+          "The copyable Gateway instance ID must copy its full value",
+          expected,
+          clipboard.primaryClip
+            ?.getItemAt(0)
+            ?.text
+            ?.toString(),
+        )
+      }
+    } finally {
+      try {
+        if (previousClip == null) clipboard.clearPrimaryClip() else clipboard.setPrimaryClip(previousClip)
+      } finally {
+        NativeStringResources.setApplicationLocales(LocaleListCompat.getEmptyLocaleList())
+      }
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "fr-rFR-w320dp-h800dp-mdpi")
+  fun gatewayMetricsKeepVisibleLabelsAndFullValuesAtLargeFont() {
+    try {
+      val model = offlineTypographyModel()
+      composeRule.setContent {
+        DeviceConfigurationOverride(DeviceConfigurationOverride.FontScale(2f)) {
+          ClawDesignTheme(dark = false) {
+            SettingsDetailScreen(model, SettingsRoute.Gateway, onBack = {})
+          }
+        }
+      }
+      val failures = mutableListOf<String>()
+      for (text in listOf(nativeString("Connection"), nativeString("Instance ID"), model.instanceId.value)) {
+        // Exact semantic lookup alone must not certify the visible, possibly ellipsized value.
+        val node = composeRule.onNodeWithText(text, useUnmergedTree = true).performScrollTo()
+        captureTypography("gateway-metric-${if (text == model.instanceId.value) "instance-value" else text}")
+        try {
+          node.assertCompleteText(text)
+        } catch (error: AssertionError) {
+          failures += "$text: ${error.message}"
+        }
+      }
+      assertTrue("Gateway metric labels and values must remain readable:\n${failures.joinToString("\n")}", failures.isEmpty())
+    } finally {
+      NativeStringResources.setApplicationLocales(LocaleListCompat.getEmptyLocaleList())
+    }
+  }
 
   @Test
   @Config(qualifiers = "fr-rFR-w320dp-h800dp-mdpi")

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -247,6 +247,8 @@ After the first successful pairing, Android auto-reconnects on launch to the act
 
 Android retries temporary connection losses automatically. For a fresh attempt with the saved endpoint, open **Settings → Gateway** and tap **Reconnect**. **Disconnect** stops the connections and suppresses automatic reconnect for the current app session; it does not forget the pairing. Authentication or pairing errors can pause retries until you address the reported problem.
 
+Gateway summary rows wrap long labels and values. Tap **Instance ID** in **Settings → Gateway** to copy this phone's full identifier.
+
 Official setup codes connect Android as a node and grant full Gateway operator
 access by default over `wss://`. Plaintext non-loopback `ws://` setup
 automatically uses limited access for bearer-token safety. **Settings → Gateway**


### PR DESCRIPTION
Related: #140182

## What Problem This Solves

Fixes an issue where Android users could not read complete Settings metric labels and values at large font sizes, or copy their phone's Instance ID by tapping it. The ID row was marked copyable but had no click action.

## Why This Change Was Made

Settings metrics now use the existing wrapping list-row component instead of a separate single-line, ellipsized layout. Copyable rows expose a labelled action and copy the entire value through the shared Settings clipboard helper. This removes the duplicate row implementation without adding a component, configuration option, dependency or persistence change.

## User Impact

Gateway information remains readable on narrow screens with larger text. Tapping Instance ID copies the complete phone identifier. Existing cron detail copying is preserved.

## Evidence

Two regression tests fail on the parent and pass with this change: a Robolectric touch-input test leaves a sentinel clipboard unchanged before the fix, and rendered text-layout checks catch truncated labels and values. Both use French, 320dp width and 200% font size.

79 tests across eight Android suites, both Kotlin variants, ktlint and the configured changed-source Testbox gate passed. Independent source review and Codex review have no accepted actionable findings. Production +27/-27; tests +74/-0; documentation +2/-0.

### Installed before/update/after proof

The actual API36 Google Play emulator run passed all six cases: French/light setup, Gateway metrics and restoration on the parent; one install-r update; then the same three cases on this head. Both genuine APKs were built from exact source, independently checked and signed with the same fresh key. The update preserved the app UID and the scoped settings, locale, theme and display state.

The updated app copied the full synthetic Instance ID with one tap. One Android paste into focused Settings search produced the exact value; closing and reopening search proved it empty, then the test restored the original state. The harness never typed the expected ID or wrote it to the clipboard. Full PNG review confirms every ID character is visible at normal and 200% text sizes. Archived editor XML is deliberately redacted; the unredacted runtime predicate and full paste capture provide that evidence.

The native command and complete evidence export both exited 0. Independent audit checked 2,062 native commands, all six cases, the update, copy/paste and cleanup; all owned process groups and ports were closed. The linked [Testbox run](https://github.com/openclaw/openclaw/actions/runs/34063092208) is the hydration lease; its eventual stopped/cancelled status is not the external test command's verdict. Exact-head PR CI is still required before merge.

| Before, 320dp / 200% French text | After, same profile |
| --- | --- |
| ![Installed baseline: truncated metric labels and Instance ID](https://github.com/user-attachments/assets/aaf6048d-7e72-4275-bb4f-c79cbe5466ab) | ![Installed fix: complete metric labels and wrapped Instance ID](https://github.com/user-attachments/assets/aea8e865-7b8d-4a2f-b073-6028a1d3b92f) |

<details>
<summary>Normal-size comparison, upper large-text rows, and real clipboard paste</summary>

![Installed baseline at normal text size](https://github.com/user-attachments/assets/7f359d31-d1bd-4edb-95cc-e0c9159855db)
![Installed fix at normal text size](https://github.com/user-attachments/assets/e248040f-0347-4573-9c6e-1dc41ebb23e8)
![Upper metric rows retain complete labels at 200% text](https://github.com/user-attachments/assets/73286e56-04f9-46a6-962f-b2971363424c)
![One real paste produces the complete copied synthetic ID](https://github.com/user-attachments/assets/c9bbe011-c8ea-464a-8955-940999bc8d32)

</details>

Copy-action provenance: the Instance ID flag was introduced in [2c8306a](https://github.com/openclaw/openclaw/commit/2c8306a5bece58791d83c74c88f34f6630a82d99), whose metric panel did not consume it. That commit records Peter Steinberger as author and committer; the merge/push actor was not established. This does not claim the same origin for all truncation.

Separate app-audit follow-up: global search quick-action titles/descriptions still truncate at large text. Full accessibility labels and enabled click targets remain; no dispatch or TalkBack failure was demonstrated. That visual issue is outside this metric-row fix.
