### PR TITLE
fix: attribute slow session edits to internal waits

### DIFF
--- a/docs/gateway/diagnostics.md
+++ b/docs/gateway/diagnostics.md
@@ -119,6 +119,24 @@ The `cpuCoreRatio` in phase and liveness events is measured in core equivalents
 and can exceed `1`. See
 [CPU pressure and event-loop delay](/gateway/health#cpu-pressure-and-event-loop-delay).
 
+With diagnostics enabled, `sessions.patch` and `sessions.patchMany` calls lasting
+at least one second add an info-level `slow session patch` file-log record. Its
+`elapsedMs`, `phaseDurationsMs`, and `phaseCounts` distinguish lifecycle admission,
+snapshot reads, catalog preparation, projection, commit, runtime acknowledgements,
+effects, and response work. Records inherit the request's diagnostic trace when
+available and contain fixed phase names and numbers, not patch values or session
+keys. Repeated stage visits contribute to the counts and totals. Parallel and
+nested stages can overlap, so their totals are neither an exclusive breakdown
+of request time nor CPU measurements.
+
+SQLite session-write warnings also separate `queueWaitMs`, `writerExecutionMs`,
+and `completionDelayMs`. These measure time until the writer starts, work and
+awaits inside the writer lane, and time until its caller resumes after execution.
+Writer execution is not SQLite transaction-lock hold time; native transaction
+lock-wait and hold warnings remain separate. Writes rejected before entering the
+writer omit these three fields. This breakdown is in
+file logs, not the aggregate Gateway RPC Prometheus histograms.
+
 Stalled embedded-run diagnostics mark `terminalProgressStale=true`
 when the last bridge progress looked terminal (for example a raw response
 item or response-completion event) but the Gateway still considers the

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -2082,6 +2082,9 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   });
 
   it("passes explicit timeout overrides into agent attempts", async () => {
+    // Freeze preflight elapsed time to keep the forwarding assertions exact.
+    const now = Date.now();
+    vi.spyOn(Date, "now").mockReturnValue(now);
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
 

--- a/src/config/sessions/session-accessor.sqlite-scope.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.test.ts
@@ -1,0 +1,123 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { performance } from "node:perf_hooks";
+import { afterEach, expect, test, vi } from "vitest";
+import * as logging from "../../logging/logger.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { runExclusiveSqliteSessionWrite } from "./session-accessor.sqlite-scope.js";
+import { drainSessionStoreWriterQueuesForTest } from "./store-writer-state.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+test.each([false, true])(
+  "slow writer diagnostics separate waiting and execution without changing failure=%s",
+  async (fail) => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      let clock = 0;
+      const wallStart = Date.now();
+      vi.spyOn(performance, "now").mockImplementation(() => clock);
+      vi.spyOn(Date, "now").mockImplementation(() => wallStart + clock);
+      const owners = new AsyncLocalStorage<string>();
+      const records: Array<{ owner: string | undefined; args: unknown[] }> = [];
+      const getChildLogger = logging.getChildLogger;
+      vi.spyOn(logging, "getChildLogger").mockImplementation((...args) => {
+        const logger = getChildLogger(...args);
+        vi.spyOn(logger, "warn").mockImplementation((...values) => {
+          records.push({ owner: owners.getStore(), args: values });
+          return undefined;
+        });
+        return logger;
+      });
+      const scope = { agentId: "main", env: state.env };
+      const release = createDeferredCore();
+      const order: string[] = [];
+      const first = owners.run("first", () =>
+        runExclusiveSqliteSessionWrite(scope, async () => {
+          order.push("first:start");
+          await release.promise;
+          order.push("first:end");
+          return "first";
+        }),
+      );
+      expect(order).toEqual(["first:start"]);
+      clock = 100;
+      const failure = new Error("synthetic writer failure");
+      const second = owners.run("second", () =>
+        runExclusiveSqliteSessionWrite(scope, async () => {
+          order.push("second:start");
+          clock += 400;
+          if (fail) {
+            throw failure;
+          }
+          return "second";
+        }),
+      );
+      const settled = second.then(
+        (value) => ({ value }),
+        (error: unknown) => ({ error }),
+      );
+      const queuedSuccessor = owners.run("queued-successor", () =>
+        runExclusiveSqliteSessionWrite(scope, async () => {
+          order.push("queued-successor");
+          return "queued-successor";
+        }),
+      );
+      try {
+        expect(order).toEqual(["first:start"]);
+        clock = 1_600;
+        release.resolve();
+        expect(await first).toBe("first");
+        expect(await settled).toEqual(fail ? { error: failure } : { value: "second" });
+        expect(await queuedSuccessor).toBe("queued-successor");
+        expect(order).toEqual(["first:start", "first:end", "second:start", "queued-successor"]);
+        expect(records.find((entry) => entry.owner === "first")?.args[1]).toEqual(
+          expect.objectContaining({
+            elapsedMs: 2_000,
+            queueWaitMs: 0,
+            writerExecutionMs: 1_600,
+            completionDelayMs: 400,
+          }),
+        );
+        const record = records.find((entry) => entry.owner === "second");
+        expect(record?.args[1]).toEqual(
+          expect.objectContaining({
+            elapsedMs: 1_900,
+            queueWaitMs: 1_500,
+            writerExecutionMs: 400,
+            completionDelayMs: 0,
+          }),
+        );
+        if (fail) {
+          expect(record?.args[1]).toHaveProperty("error", failure);
+        }
+        await expect(runExclusiveSqliteSessionWrite(scope, async () => "successor")).resolves.toBe(
+          "successor",
+        );
+      } finally {
+        release.resolve();
+        await Promise.allSettled([first, second, queuedSuccessor]);
+        vi.restoreAllMocks();
+      }
+    });
+  },
+);
+
+test("a queued writer rejected by cleanup never runs after release", async () => {
+  await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+    const scope = { agentId: "main", env: state.env };
+    const release = createDeferredCore();
+    const first = runExclusiveSqliteSessionWrite(scope, async () => await release.promise);
+    const run = vi.fn(async () => "never");
+    const second = runExclusiveSqliteSessionWrite(scope, run);
+    const rejected = expect(second).rejects.toThrow("SQLite session store queue cleared for test");
+    const drained = drainSessionStoreWriterQueuesForTest();
+    try {
+      await rejected;
+      expect(run).not.toHaveBeenCalled();
+    } finally {
+      release.resolve();
+      await Promise.allSettled([first, second, drained]);
+    }
+    expect(run).not.toHaveBeenCalled();
+  });
+});

--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -1,6 +1,7 @@
 // Sanctioned low-level scope/Kysely entry point for doctor, migrations, and infrastructure.
 // Runtime feature code imports the session accessor barrel instead of this module.
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import { getChildLogger } from "../../logging/logger.js";
 import {
@@ -10,7 +11,7 @@ import {
   resolveAgentIdFromSessionKey,
   toAgentStoreSessionKey,
 } from "../../routing/session-key.js";
-import { runQueuedStoreWrite } from "../../shared/store-writer-queue.js";
+import { runQueuedStoreWrite, type StoreWriterTiming } from "../../shared/store-writer-queue.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
@@ -102,19 +103,31 @@ export async function runExclusiveSqliteSessionWrite<T>(
 ): Promise<T> {
   const databaseOptions = toDatabaseOptions(scope);
   const storePath = resolveOpenClawAgentSqlitePath(databaseOptions);
-  const startedAt = Date.now();
+  const startedAt = performance.now();
+  const timing: StoreWriterTiming = {};
+  const timingFields = (completedAt: number) => ({
+    elapsedMs: Math.round(completedAt - startedAt),
+    ...(timing.startedAt !== undefined && timing.finishedAt !== undefined
+      ? {
+          queueWaitMs: Math.round(timing.startedAt - startedAt),
+          writerExecutionMs: Math.round(timing.finishedAt - timing.startedAt),
+          completionDelayMs: Math.round(completedAt - timing.finishedAt),
+        }
+      : {}),
+  });
   try {
     const result = await runQueuedStoreWrite({
       queues: SQLITE_SESSION_WRITER_QUEUES,
       storePath,
       label: "runExclusiveSqliteSessionWrite",
       fn,
+      timing,
     });
-    const elapsedMs = Date.now() - startedAt;
-    if (elapsedMs >= SQLITE_SESSION_SLOW_WRITE_MS) {
+    const completedAt = performance.now();
+    if (completedAt - startedAt >= SQLITE_SESSION_SLOW_WRITE_MS) {
       getChildLogger({ subsystem: "session-sqlite" }).warn("slow SQLite session write", {
         agentId: scope.agentId,
-        elapsedMs,
+        ...timingFields(completedAt),
         storePath,
       });
     }
@@ -122,7 +135,7 @@ export async function runExclusiveSqliteSessionWrite<T>(
   } catch (error) {
     getChildLogger({ subsystem: "session-sqlite" }).warn("SQLite session write failed", {
       agentId: scope.agentId,
-      elapsedMs: Date.now() - startedAt,
+      ...timingFields(performance.now()),
       error,
       storePath,
     });

--- a/src/gateway/server-methods/sessions-mutations.catalog-queue.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.catalog-queue.test.ts
@@ -1,3 +1,4 @@
+import { performance } from "node:perf_hooks";
 import { afterEach, expect, test, vi } from "vitest";
 import {
   markPreparedModelRuntimeSnapshotsStale,
@@ -11,12 +12,23 @@ import {
   patchSessionEntryCore,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
+import {
+  areDiagnosticsEnabledForProcess,
+  setDiagnosticsEnabledForProcess,
+} from "../../infra/diagnostic-events.js";
+import {
+  createDiagnosticTraceContext,
+  getActiveDiagnosticTraceContext,
+  runWithDiagnosticTraceContext,
+} from "../../infra/diagnostic-trace-context.js";
+import * as sessionLifecycle from "../../sessions/session-lifecycle-admission.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { handleGatewayRequest } from "../server-methods.js";
 import { loadGatewayModelCatalog as loadActualGatewayModelCatalog } from "../server-model-catalog.js";
 import { sessionMutationHandlers } from "./sessions-mutations.js";
+import { sessionLog } from "./sessions-shared.js";
 import type { GatewayRequestContext } from "./types.js";
 
 afterEach(() => {
@@ -73,7 +85,21 @@ test("catalog reload releases the agent writer while preserving same-session ord
     const metadataResponse = vi.fn();
     const successorResponse = vi.fn();
     const patch = patchRequest(context);
-    const catalogPatch = patch({ key: catalogKey, contextWindow: "extended" }, catalogResponse);
+    const previousDiagnostics = areDiagnosticsEnabledForProcess();
+    setDiagnosticsEnabledForProcess(true);
+    let clock = performance.now();
+    const clockSpy = vi.spyOn(performance, "now").mockImplementation(() => clock);
+    const catalogTrace = createDiagnosticTraceContext();
+    const successorTrace = createDiagnosticTraceContext();
+    const records: Array<{ traceId: string | undefined; metadata: unknown }> = [];
+    const logSpy = vi.spyOn(sessionLog, "info").mockImplementation((message, metadata) => {
+      if (message === "slow session patch") {
+        records.push({ traceId: getActiveDiagnosticTraceContext()?.traceId, metadata });
+      }
+    });
+    const catalogPatch = runWithDiagnosticTraceContext(catalogTrace, () =>
+      patch({ key: catalogKey, contextWindow: "extended" }, catalogResponse),
+    );
     let metadataPatch: ReturnType<typeof patch> | undefined;
     let successorPatch: ReturnType<typeof patch> | undefined;
     let blockedMetadata: Error | undefined;
@@ -81,7 +107,9 @@ test("catalog reload releases the agent writer while preserving same-session ord
       await Promise.race([entered.promise, catalogPatch]);
       expect(loadGatewayModelCatalog).toHaveBeenCalledOnce();
       expect(catalogResponse).not.toHaveBeenCalled();
-      successorPatch = patch({ key: catalogKey, pinned: true }, successorResponse);
+      successorPatch = runWithDiagnosticTraceContext(successorTrace, () =>
+        patch({ key: catalogKey, pinned: true }, successorResponse),
+      );
       metadataPatch = patch({ key: metadataKey, pinned: true }, metadataResponse);
       await vi
         .waitFor(() =>
@@ -97,11 +125,15 @@ test("catalog reload releases the agent writer while preserving same-session ord
       ).toBeUndefined();
       expect(loadGatewayModelCatalog).toHaveBeenCalledOnce();
     } finally {
+      clock += 1_500;
       rejectPendingPreparedModelRuntimeReplacement(
         replacement,
         new Error("Synthetic catalog reload failed"),
       );
       await Promise.allSettled([catalogPatch, metadataPatch, successorPatch]);
+      clockSpy.mockRestore();
+      logSpy.mockRestore();
+      setDiagnosticsEnabledForProcess(previousDiagnostics);
     }
     expect(catalogResponse).toHaveBeenCalledWith(false, undefined, {
       code: "UNAVAILABLE",
@@ -118,6 +150,20 @@ test("catalog reload releases the agent writer while preserving same-session ord
     );
     expect(loadSessionEntry({ agentId: "main", sessionKey: metadataKey })?.pinnedAt).toEqual(
       expect.any(Number),
+    );
+    expect(records).toHaveLength(2);
+    expect(records.find((record) => record.traceId === catalogTrace.traceId)?.metadata).toEqual(
+      expect.objectContaining({
+        method: "sessions.patch",
+        phaseDurationsMs: expect.objectContaining({ catalog: 1_500 }),
+        phaseCounts: expect.objectContaining({ catalog: 1 }),
+      }),
+    );
+    expect(records.find((record) => record.traceId === successorTrace.traceId)?.metadata).toEqual(
+      expect.objectContaining({
+        method: "sessions.patch",
+        phaseDurationsMs: expect.objectContaining({ lifecycleAdmission: 1_500 }),
+      }),
     );
     if (blockedMetadata) {
       throw blockedMetadata;
@@ -280,6 +326,16 @@ test("patchMany prepares singleton agent groups without blocking another session
       },
     });
     const respond = vi.fn();
+    const previousDiagnostics = areDiagnosticsEnabledForProcess();
+    setDiagnosticsEnabledForProcess(true);
+    let clock = performance.now();
+    const clockSpy = vi.spyOn(performance, "now").mockImplementation(() => clock);
+    const timingRecords: unknown[] = [];
+    const logSpy = vi.spyOn(sessionLog, "info").mockImplementation((message, metadata) => {
+      if (message === "slow session patch") {
+        timingRecords.push(metadata);
+      }
+    });
     const batch = sessionMutationHandlers["sessions.patchMany"]!({
       params: { targets, patch: { contextWindow: "extended" } },
       respond,
@@ -296,6 +352,7 @@ test("patchMany prepares singleton agent groups without blocking another session
       );
       expect(respond).not.toHaveBeenCalled();
     } finally {
+      clock += 1_500;
       catalog.resolve([
         {
           provider: "anthropic",
@@ -305,6 +362,9 @@ test("patchMany prepares singleton agent groups without blocking another session
         },
       ]);
       await Promise.allSettled([batch, metadataPatch]);
+      clockSpy.mockRestore();
+      logSpy.mockRestore();
+      setDiagnosticsEnabledForProcess(previousDiagnostics);
     }
     expect(loadGatewayModelCatalog).toHaveBeenCalledTimes(2);
     expect(loadGatewayModelCatalog).toHaveBeenCalledWith({ agentId: "main" });
@@ -323,6 +383,14 @@ test("patchMany prepares singleton agent groups without blocking another session
     expect(loadSessionEntry({ agentId: "main", sessionKey: metadataKey })?.pinnedAt).toEqual(
       expect.any(Number),
     );
+    expect(timingRecords).toEqual([
+      expect.objectContaining({
+        method: "sessions.patchMany",
+        elapsedMs: 1_500,
+        phaseDurationsMs: expect.objectContaining({ catalog: 3_000 }),
+        phaseCounts: expect.objectContaining({ catalog: 2 }),
+      }),
+    ]);
   });
 });
 
@@ -464,6 +532,60 @@ test("dispatched authorization rejects an instance replaced during catalog prepa
     } finally {
       release.resolve();
       await Promise.allSettled([request, replacement]);
+    }
+  });
+});
+
+test("patch timing covers preparation and lifecycle finalization before cleanup", async () => {
+  await withOpenClawTestState({ scenario: "minimal" }, async () => {
+    const key = "agent:main:phase-boundaries";
+    await upsertSessionEntryCore(
+      { agentId: "main", sessionKey: key },
+      { sessionId: "phase-boundaries", updatedAt: 1 },
+    );
+    const previousDiagnostics = areDiagnosticsEnabledForProcess();
+    setDiagnosticsEnabledForProcess(true);
+    let clock = performance.now();
+    const clockSpy = vi.spyOn(performance, "now").mockImplementation(() => clock);
+    const log = vi.spyOn(sessionLog, "info").mockImplementation(() => {});
+    const runMutation = sessionLifecycle.runExclusiveSessionLifecycleMutation;
+    const lifecycle = vi
+      .spyOn(sessionLifecycle, "runExclusiveSessionLifecycleMutation")
+      .mockImplementation((params) =>
+        runMutation({
+          ...params,
+          prepare: async (owner) => {
+            await params.prepare?.(owner);
+            clock += 700;
+          },
+          finalize: async () => {
+            await params.finalize?.();
+            clock += 500;
+          },
+        }),
+      );
+    const response = vi.fn();
+    try {
+      await patchRequest(patchContext(async () => []))({ key, pinned: true }, response);
+      expect(response).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+      expect(log).toHaveBeenCalledWith(
+        "slow session patch",
+        expect.objectContaining({
+          elapsedMs: 1_200,
+          phaseDurationsMs: expect.objectContaining({
+            lifecycleAdmission: 700,
+            lifecycleFinalize: 500,
+            cleanup: 0,
+            snapshot: 0,
+            commit: 0,
+          }),
+        }),
+      );
+    } finally {
+      lifecycle.mockRestore();
+      log.mockRestore();
+      clockSpy.mockRestore();
+      setDiagnosticsEnabledForProcess(previousDiagnostics);
     }
   });
 });

--- a/src/gateway/server-methods/sessions-mutations.ts
+++ b/src/gateway/server-methods/sessions-mutations.ts
@@ -32,6 +32,7 @@ import { projectSessionPatchResult } from "../session-utils-model.js";
 import { gatewayClientSessionCreator } from "./gateway-client-identity.js";
 import { emitSessionsChanged } from "./session-change-event.js";
 import { resolveOperatorSessionCreation } from "./session-creation-provenance.js";
+import { startSessionPatchDiagnostics } from "./sessions-patch-diagnostics.js";
 import { executeSessionPatchMutations } from "./sessions-patch-engine.js";
 import { createCommitGuard } from "./sessions-patch-errors.js";
 import { sessionPatchTargetIdentity } from "./sessions-patch-expectations.js";
@@ -47,103 +48,120 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
     client,
     sessionMutationAuthorization,
   }) => {
-    if (
-      !assertValidParams(params, validateSessionsPatchManyParams, "sessions.patchMany", respond)
-    ) {
-      return;
+    const diagnostics = startSessionPatchDiagnostics("sessions.patchMany");
+    try {
+      if (
+        !assertValidParams(params, validateSessionsPatchManyParams, "sessions.patchMany", respond)
+      ) {
+        return;
+      }
+      const scopes = Array.isArray(client?.connect.scopes) ? client.connect.scopes : [];
+      if (
+        params.patch.permissionMode === "full" &&
+        client !== null &&
+        !scopes.includes(ADMIN_SCOPE)
+      ) {
+        respond(
+          false,
+          undefined,
+          missingScopeErrorShape({ missingScope: ADMIN_SCOPE, requiredScopes: [ADMIN_SCOPE] }),
+        );
+        return;
+      }
+      const targets = params.targets;
+      const executed = await executeSessionPatchMutations({
+        client,
+        context,
+        diagnostics,
+        patch: params.patch,
+        targets: targets.map((target) => ({
+          ...target,
+          commitGuard: createCommitGuard(target.key.trim(), () =>
+            sessionMutationAuthorization?.assertTargetCurrent({
+              sessionKey: target.key.trim(),
+              ...(target.agentId ? { agentId: target.agentId } : {}),
+            }),
+          ),
+        })),
+      });
+      if (!executed.ok) {
+        respond(false, undefined, executed.error);
+        return;
+      }
+      const outcomes: SessionsPatchManyResult["outcomes"] = [];
+      diagnostics?.scope("response");
+      for (const [index, outcome] of executed.outcomes.entries()) {
+        const target = targets[index]!;
+        const identity = {
+          key: target.key,
+          ...(target.agentId ? { agentId: target.agentId } : {}),
+        };
+        outcomes.push(
+          outcome.ok ? { ok: true, ...identity } : { ok: false, ...identity, error: outcome.error },
+        );
+      }
+      respond(true, { outcomes }, undefined);
+    } finally {
+      diagnostics?.finish();
     }
-    const scopes = Array.isArray(client?.connect.scopes) ? client.connect.scopes : [];
-    if (
-      params.patch.permissionMode === "full" &&
-      client !== null &&
-      !scopes.includes(ADMIN_SCOPE)
-    ) {
-      respond(
-        false,
-        undefined,
-        missingScopeErrorShape({ missingScope: ADMIN_SCOPE, requiredScopes: [ADMIN_SCOPE] }),
-      );
-      return;
-    }
-    const targets = params.targets;
-    const executed = await executeSessionPatchMutations({
-      client,
-      context,
-      patch: params.patch,
-      targets: targets.map((target) => ({
-        ...target,
-        commitGuard: createCommitGuard(target.key.trim(), () =>
-          sessionMutationAuthorization?.assertTargetCurrent({
-            sessionKey: target.key.trim(),
-            ...(target.agentId ? { agentId: target.agentId } : {}),
-          }),
-        ),
-      })),
-    });
-    if (!executed.ok) {
-      respond(false, undefined, executed.error);
-      return;
-    }
-    const outcomes: SessionsPatchManyResult["outcomes"] = [];
-    for (const [index, outcome] of executed.outcomes.entries()) {
-      const target = targets[index]!;
-      const identity = { key: target.key, ...(target.agentId ? { agentId: target.agentId } : {}) };
-      outcomes.push(
-        outcome.ok ? { ok: true, ...identity } : { ok: false, ...identity, error: outcome.error },
-      );
-    }
-    respond(true, { outcomes }, undefined);
   },
   "sessions.patch": async ({ params, respond, context, client, sessionMutationAuthorization }) => {
-    if (!assertValidParams(params, validateSessionsPatchParams, "sessions.patch", respond)) {
-      return;
-    }
-    const scopes = Array.isArray(client?.connect.scopes) ? client.connect.scopes : [];
-    if (params.permissionMode === "full" && client !== null && !scopes.includes(ADMIN_SCOPE)) {
+    const diagnostics = startSessionPatchDiagnostics("sessions.patch");
+    try {
+      if (!assertValidParams(params, validateSessionsPatchParams, "sessions.patch", respond)) {
+        return;
+      }
+      const scopes = Array.isArray(client?.connect.scopes) ? client.connect.scopes : [];
+      if (params.permissionMode === "full" && client !== null && !scopes.includes(ADMIN_SCOPE)) {
+        respond(
+          false,
+          undefined,
+          missingScopeErrorShape({ missingScope: ADMIN_SCOPE, requiredScopes: [ADMIN_SCOPE] }),
+        );
+        return;
+      }
+      const key = requireSessionKey(params.key, respond);
+      if (!key) {
+        return;
+      }
+      const patch = { ...params, key };
+      const target = sessionPatchTargetIdentity(patch);
+      const executed = await executeSessionPatchMutations({
+        client,
+        context,
+        diagnostics,
+        patch,
+        targets: [
+          {
+            ...target,
+            commitGuard: createCommitGuard(target.key, sessionMutationAuthorization?.assertCurrent),
+          },
+        ],
+      });
+      if (!executed.ok) {
+        respond(false, undefined, executed.error);
+        return;
+      }
+      const outcome = executed.outcomes[0]!;
+      if (!outcome.ok) {
+        respond(false, undefined, outcome.error);
+        return;
+      }
+      const prepared = executed.preparedByIndex[0]!;
+      diagnostics?.scope("response");
       respond(
-        false,
+        true,
+        projectSessionPatchResult({
+          ...prepared,
+          cfg: executed.cfg,
+          entry: outcome.entry,
+          modelCatalog: await executed.catalogs.available(prepared.targetAgentId),
+        }),
         undefined,
-        missingScopeErrorShape({ missingScope: ADMIN_SCOPE, requiredScopes: [ADMIN_SCOPE] }),
       );
-      return;
+    } finally {
+      diagnostics?.finish();
     }
-    const key = requireSessionKey(params.key, respond);
-    if (!key) {
-      return;
-    }
-    const patch = { ...params, key };
-    const target = sessionPatchTargetIdentity(patch);
-    const executed = await executeSessionPatchMutations({
-      client,
-      context,
-      patch,
-      targets: [
-        {
-          ...target,
-          commitGuard: createCommitGuard(target.key, sessionMutationAuthorization?.assertCurrent),
-        },
-      ],
-    });
-    if (!executed.ok) {
-      respond(false, undefined, executed.error);
-      return;
-    }
-    const outcome = executed.outcomes[0]!;
-    if (!outcome.ok) {
-      respond(false, undefined, outcome.error);
-      return;
-    }
-    const prepared = executed.preparedByIndex[0]!;
-    respond(
-      true,
-      projectSessionPatchResult({
-        ...prepared,
-        cfg: executed.cfg,
-        entry: outcome.entry,
-        modelCatalog: await executed.catalogs.available(prepared.targetAgentId),
-      }),
-      undefined,
-    );
   },
   "sessions.assignOwner": async ({ params, respond, context, client }) => {
     if (

--- a/src/gateway/server-methods/sessions-patch-catalog-preparation.ts
+++ b/src/gateway/server-methods/sessions-patch-catalog-preparation.ts
@@ -1,22 +1,27 @@
 import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import { prepareSessionsPatchEntry, projectSessionsPatchEntry } from "../sessions-patch.js";
+import type { SessionPatchDiagnostics } from "./sessions-patch-diagnostics.js";
 
 export type SessionPatchCatalogResult = Result<ModelCatalogEntry[], unknown>;
 
 export function createSessionPatchCatalogPreparation(
   loadCatalog: (agentId: string) => Promise<ModelCatalogEntry[]>,
+  diagnostics?: SessionPatchDiagnostics,
 ) {
   const preparations = new Map<string, Promise<SessionPatchCatalogResult>>();
   const prepare = (agentId: string) => {
     let promise = preparations.get(agentId);
     if (!promise) {
       promise = (async () => {
+        const timing = diagnostics?.scope("catalog");
         try {
           const catalog = await loadCatalog(agentId);
           return ok(Array.isArray(catalog) ? catalog : []);
         } catch (error) {
           return err(error);
+        } finally {
+          timing?.finish();
         }
       })();
       preparations.set(agentId, promise);

--- a/src/gateway/server-methods/sessions-patch-diagnostics.test.ts
+++ b/src/gateway/server-methods/sessions-patch-diagnostics.test.ts
@@ -1,0 +1,126 @@
+import { performance } from "node:perf_hooks";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import {
+  areDiagnosticsEnabledForProcess,
+  setDiagnosticsEnabledForProcess,
+} from "../../infra/diagnostic-events.js";
+import { startSessionPatchDiagnostics } from "./sessions-patch-diagnostics.js";
+import { sessionLog } from "./sessions-shared.js";
+
+let previousDiagnostics: boolean;
+beforeEach(() => {
+  previousDiagnostics = areDiagnosticsEnabledForProcess();
+});
+afterEach(() => {
+  setDiagnosticsEnabledForProcess(previousDiagnostics);
+  vi.restoreAllMocks();
+});
+
+test("disabled patch diagnostics do not start clocks or record work", () => {
+  setDiagnosticsEnabledForProcess(false);
+  const clock = vi.spyOn(performance, "now");
+  const log = vi.spyOn(sessionLog, "info");
+  expect(startSessionPatchDiagnostics("sessions.patch")).toBeUndefined();
+  expect(clock).not.toHaveBeenCalled();
+  expect(log).not.toHaveBeenCalled();
+});
+
+test("parallel and repeated phases retain separate elapsed contributions and bounded fields", () => {
+  setDiagnosticsEnabledForProcess(true);
+  let clock = 0;
+  vi.spyOn(performance, "now").mockImplementation(() => clock);
+  const log = vi.spyOn(sessionLog, "info").mockImplementation(() => {});
+  const diagnostics = expectDefined(
+    startSessionPatchDiagnostics("sessions.patchMany"),
+    "enabled bulk patch diagnostics",
+  );
+  const first = expectDefined(diagnostics.scope("catalog"), "active catalog phase");
+  const second = expectDefined(diagnostics.scope("catalog"), "active catalog phase");
+  clock = 600;
+  second.finish();
+  clock = 1_400;
+  first.finish();
+  const group = expectDefined(diagnostics.scope("snapshot"), "active snapshot phase");
+  clock = 1_500;
+  group.mark("projection");
+  clock = 1_600;
+  group.mark("snapshot");
+  clock = 1_800;
+  group.finish();
+  diagnostics.finish();
+  expect(log).toHaveBeenCalledExactlyOnceWith("slow session patch", {
+    method: "sessions.patchMany",
+    elapsedMs: 1_800,
+    phaseDurationsMs: { snapshot: 300, projection: 100, catalog: 2_000 },
+    phaseCounts: { snapshot: 2, projection: 1, catalog: 2 },
+  });
+});
+
+test("request settlement closes unfinished phases and retires retained markers", () => {
+  setDiagnosticsEnabledForProcess(true);
+  let clock = 0;
+  vi.spyOn(performance, "now").mockImplementation(() => clock);
+  const log = vi.spyOn(sessionLog, "info").mockImplementation(() => {});
+  const diagnostics = expectDefined(
+    startSessionPatchDiagnostics("sessions.patch"),
+    "enabled patch diagnostics",
+  );
+  const scope = expectDefined(diagnostics.scope("preflight"), "active preflight phase");
+  clock = 1_500;
+  diagnostics.finish();
+  clock = 3_000;
+  scope.mark("catalog");
+  scope.finish();
+  expect(diagnostics.scope("effects")).toBeUndefined();
+  diagnostics.finish();
+  expect(log).toHaveBeenCalledExactlyOnceWith("slow session patch", {
+    method: "sessions.patch",
+    elapsedMs: 1_500,
+    phaseDurationsMs: { preflight: 1_500 },
+    phaseCounts: { preflight: 1 },
+  });
+});
+
+test("a failed diagnostic sink cannot replace the operation error", () => {
+  setDiagnosticsEnabledForProcess(true);
+  let clock = 0;
+  vi.spyOn(performance, "now").mockImplementation(() => clock);
+  vi.spyOn(sessionLog, "info").mockImplementation(() => {
+    throw new Error("synthetic diagnostic sink failure");
+  });
+  const originalError = new Error("synthetic operation failure");
+  const operation = () => {
+    const diagnostics = expectDefined(
+      startSessionPatchDiagnostics("sessions.patch"),
+      "enabled patch diagnostics",
+    );
+    diagnostics.scope("preflight");
+    try {
+      clock = 1_500;
+      throw originalError;
+    } finally {
+      diagnostics.finish();
+    }
+  };
+  expect(operation).toThrow(originalError);
+});
+
+test("disabling diagnostics retires an in-flight observation without publishing it later", () => {
+  setDiagnosticsEnabledForProcess(true);
+  let clock = 0;
+  vi.spyOn(performance, "now").mockImplementation(() => clock);
+  const log = vi.spyOn(sessionLog, "info").mockImplementation(() => {});
+  const diagnostics = expectDefined(
+    startSessionPatchDiagnostics("sessions.patch"),
+    "enabled patch diagnostics",
+  );
+  const scope = expectDefined(diagnostics.scope("catalog"), "active catalog phase");
+  clock = 2_000;
+  setDiagnosticsEnabledForProcess(false);
+  diagnostics.finish();
+  setDiagnosticsEnabledForProcess(true);
+  scope.finish();
+  diagnostics.finish();
+  expect(log).not.toHaveBeenCalled();
+});

--- a/src/gateway/server-methods/sessions-patch-diagnostics.ts
+++ b/src/gateway/server-methods/sessions-patch-diagnostics.ts
@@ -1,0 +1,106 @@
+import { performance } from "node:perf_hooks";
+import { areDiagnosticsEnabledForProcess } from "../../infra/diagnostic-events.js";
+import { sessionLog } from "./sessions-shared.js";
+
+const SLOW_SESSION_PATCH_MS = 1_000;
+const PHASES = [
+  "preflight",
+  "archive",
+  "lifecycleAdmission",
+  "snapshot",
+  "projection",
+  "catalog",
+  "worktree",
+  "commit",
+  "worktreeCleanup",
+  "permissions",
+  "lifecycleFinalize",
+  "cleanup",
+  "effects",
+  "response",
+] as const;
+type SessionPatchPhase = (typeof PHASES)[number];
+type PhaseScope = { mark: (phase?: SessionPatchPhase) => void; finish: () => void };
+
+export type SessionPatchDiagnostics = NonNullable<ReturnType<typeof startSessionPatchDiagnostics>>;
+
+/** Fixed, request-owned elapsed totals. Parallel and nested phases can overlap. */
+export function startSessionPatchDiagnostics(method: "sessions.patch" | "sessions.patchMany") {
+  if (!areDiagnosticsEnabledForProcess()) {
+    return undefined;
+  }
+  const startedAt = performance.now();
+  const totals = new Map<SessionPatchPhase, { elapsedMs: number; count: number }>();
+  const scopes = new Set<PhaseScope>();
+  let finished = false;
+  return {
+    scope(initialPhase: SessionPatchPhase): PhaseScope | undefined {
+      if (finished) {
+        return undefined;
+      }
+      let phase: SessionPatchPhase | undefined = initialPhase;
+      let phaseStartedAt = performance.now();
+      let closed = false;
+      const scope: PhaseScope = {
+        mark(nextPhase) {
+          if (closed || finished) {
+            return;
+          }
+          const now = performance.now();
+          if (phase) {
+            const total = totals.get(phase) ?? { elapsedMs: 0, count: 0 };
+            total.elapsedMs += now - phaseStartedAt;
+            total.count++;
+            totals.set(phase, total);
+          }
+          phase = nextPhase;
+          phaseStartedAt = now;
+        },
+        finish() {
+          if (closed) {
+            return;
+          }
+          scope.mark();
+          closed = true;
+          scopes.delete(scope);
+        },
+      };
+      scopes.add(scope);
+      return scope;
+    },
+    finish() {
+      if (finished) {
+        return;
+      }
+      // Exceptions close unfinished scopes; no timer or process-global request state survives.
+      for (const scope of scopes) {
+        scope.finish();
+      }
+      finished = true;
+      if (!areDiagnosticsEnabledForProcess()) {
+        return;
+      }
+      const elapsedMs = performance.now() - startedAt;
+      if (elapsedMs < SLOW_SESSION_PATCH_MS) {
+        return;
+      }
+      const entries = PHASES.flatMap((phase) => {
+        const total = totals.get(phase);
+        return total ? [[phase, total] as const] : [];
+      });
+      try {
+        // The existing logger captures the caller's trace, never session keys or patch values.
+        sessionLog.info("slow session patch", {
+          method,
+          elapsedMs: Math.round(elapsedMs),
+          phaseDurationsMs: Object.fromEntries(
+            entries.map(([phase, total]) => [phase, Math.round(total.elapsedMs)]),
+          ),
+          phaseCounts: Object.fromEntries(entries.map(([phase, total]) => [phase, total.count])),
+        });
+      } catch {
+        // A diagnostic sink must not replace the mutation's result or original error.
+      }
+    },
+  };
+}

--- a/src/gateway/server-methods/sessions-patch-engine.ts
+++ b/src/gateway/server-methods/sessions-patch-engine.ts
@@ -42,6 +42,7 @@ import {
   createSessionPatchCatalogPreparation,
   type SessionPatchCatalogResult,
 } from "./sessions-patch-catalog-preparation.js";
+import type { SessionPatchDiagnostics } from "./sessions-patch-diagnostics.js";
 import { publishSessionPatchEffects } from "./sessions-patch-effects.js";
 import {
   invalidSessionPatchOutcome,
@@ -95,10 +96,12 @@ type MutationCoreResult =
 export async function executeSessionPatchMutations(params: {
   client: GatewayClient | null;
   context: GatewayRequestContext;
+  diagnostics?: SessionPatchDiagnostics;
   patch: Omit<SessionsPatchParams, keyof PatchTargetIdentity>;
   targets: readonly MutationTarget[];
 }): Promise<MutationCoreResult> {
   const { client } = params;
+  const timing = params.diagnostics?.scope("preflight");
   let personalModelSelection: UserModelAccountSelection | undefined;
   try {
     personalModelSelection = preparePersonalModelSelection(params, params.patch.model);
@@ -252,8 +255,9 @@ export async function executeSessionPatchMutations(params: {
     preparedByIndex[index] = preparedTarget;
   }
 
-  const catalogs = createSessionPatchCatalogPreparation((agentId) =>
-    params.context.loadGatewayModelCatalog({ agentId }),
+  const catalogs = createSessionPatchCatalogPreparation(
+    (agentId) => params.context.loadGatewayModelCatalog({ agentId }),
+    params.diagnostics,
   );
 
   if (prepared.length > 0) {
@@ -261,6 +265,7 @@ export async function executeSessionPatchMutations(params: {
       prepared.forEach((target) => releaseSessionPatchArchive(target.archivePreparation));
     try {
       // Cloud reclaim precedes every mutation mutex; an earlier Move may need one.
+      timing?.mark("archive");
       await Promise.all(
         prepared
           .filter((target) => target.fullPatch.archived === true)
@@ -288,6 +293,7 @@ export async function executeSessionPatchMutations(params: {
             }
           }),
       );
+      timing?.mark("lifecycleAdmission");
       await runExclusiveSessionLifecycleMutation({
         targets: prepared.map((target) => ({
           scope: target.storePath,
@@ -300,332 +306,366 @@ export async function executeSessionPatchMutations(params: {
         },
         finalize: releaseArchiveDrains,
         run: async () => {
-          const groups = new Map<string, PreparedPatchTarget[]>();
-          for (const target of prepared) {
-            if (target.fullPatch.archived === true && !target.archivePreparation) {
-              continue;
+          timing?.mark();
+          try {
+            const groups = new Map<string, PreparedPatchTarget[]>();
+            for (const target of prepared) {
+              if (target.fullPatch.archived === true && !target.archivePreparation) {
+                continue;
+              }
+              const groupKey = `${target.storePath}\0${target.targetAgentId}`;
+              const group = groups.get(groupKey) ?? [];
+              group.push(target);
+              groups.set(groupKey, group);
             }
-            const groupKey = `${target.storePath}\0${target.targetAgentId}`;
-            const group = groups.get(groupKey) ?? [];
-            group.push(target);
-            groups.set(groupKey, group);
-          }
-          await Promise.all(
-            [...groups.values()].map(async (group) => {
-              const first = group[0]!;
-              try {
-                // Keep every resolver candidate for queued alias revalidation. Label
-                // uniqueness needs only the requested label's owners, not the full store.
-                const selectedSessionKeys = group.flatMap((target) => [
-                  target.key,
-                  target.canonicalKey,
-                  ...target.initialStoreKeys,
-                ]);
-                const requestedLabel = parseSessionLabel(first.fullPatch.label);
-                const worktreeTransitions = new Map<number, WorktreeTransition>();
-                const commitGuards = new Set<() => ErrorShape | undefined>();
-                const projectGroup = async (
-                  entries: SqliteLifecycleTargetSnapshot,
-                  catalogPreparation?: SessionPatchCatalogResult,
-                ): Promise<GroupMutationOperation> => {
-                  const workingStore = Object.fromEntries(
-                    entries.flatMap(({ entry, sessionKey }) =>
-                      isInternalSessionEffectsKey(sessionKey) ? [] : [[sessionKey, entry] as const],
-                    ),
-                  );
-                  const labelOwners = new SessionLabelOwnerIndex(workingStore);
-                  const replacements: SessionEntryCanonicalReplacement[] = [];
-                  const projectedOutcomes: MutationOutcome[] = [];
-                  for (const target of group) {
-                    try {
-                      // Preflight facts can stale behind the writer queue; resolve this snapshot
-                      // again so a new legacy alias is rejected rather than promoted or deleted.
-                      const {
-                        entry: existingEntry,
-                        primaryKey,
-                        target: currentTarget,
-                      } = resolveCanonicalGatewaySessionStoreKey({
-                        cfg,
-                        key: target.key,
-                        store: workingStore,
-                        ...(target.requestedAgentId ? { agentId: target.requestedAgentId } : {}),
-                      });
-                      const creationError =
-                        !existingEntry &&
-                        authorizeGatewaySessionCreation({
-                          cfg,
-                          client,
-                          agentId: target.targetAgentId,
-                        });
-                      if (creationError) {
-                        projectedOutcomes.push({ ok: false, error: creationError });
-                        continue;
-                      }
-                      const candidateKeys = currentTarget.storeKeys;
-                      const ownershipError = resolvePluginSessionOwnershipError({
-                        action: "patch",
-                        entry: existingEntry,
-                        key: primaryKey,
-                        pluginOwnerId,
-                      });
-                      if (ownershipError) {
-                        projectedOutcomes.push({ ok: false, error: ownershipError });
-                        continue;
-                      }
-                      // Compare tool policy against the captured snapshot; the final
-                      // commit rejects a selection changed during preparation.
-                      const expectedSessionChanged =
-                        (target.fullPatch.expectedSessionId !== undefined &&
-                          existingEntry?.sessionId !== target.fullPatch.expectedSessionId) ||
-                        (target.fullPatch.expectedLifecycleRevision !== undefined &&
-                          existingEntry?.lifecycleRevision !==
-                            target.fullPatch.expectedLifecycleRevision) ||
-                        sessionPatchExpectations.sessionPatchExpectationsChanged(
-                          existingEntry,
-                          target.fullPatch,
-                        );
-                      const lifecycleEntryRemoved =
-                        target.initialEntry !== undefined && existingEntry === undefined;
-                      const archiveTargetChanged =
-                        target.fullPatch.archived === true &&
-                        (target.initialEntry === undefined
-                          ? existingEntry !== undefined
-                          : existingEntry !== undefined &&
-                            (existingEntry.sessionId !== target.initialEntry.sessionId ||
-                              existingEntry.lifecycleRevision !==
-                                target.initialEntry.lifecycleRevision));
-                      if (expectedSessionChanged || lifecycleEntryRemoved || archiveTargetChanged) {
-                        projectedOutcomes.push({
-                          ok: false,
-                          error: sessionChangedError(target.key),
-                        });
-                        continue;
-                      }
-                      if (target.fullPatch.archived === true) {
-                        const archiveError = validateSessionPatchArchiveProjection({
-                          cfg,
-                          existingEntry,
-                          fullPatch: target.fullPatch,
-                          key: target.key,
-                          ...(pluginOwnerId ? { pluginOwnerId } : {}),
-                          preparation: target.archivePreparation!,
+            await Promise.all(
+              [...groups.values()].map(async (group) => {
+                const first = group[0]!;
+                const groupTiming = params.diagnostics?.scope("snapshot");
+                try {
+                  // Keep every resolver candidate for queued alias revalidation. Label
+                  // uniqueness needs only the requested label's owners, not the full store.
+                  const selectedSessionKeys = group.flatMap((target) => [
+                    target.key,
+                    target.canonicalKey,
+                    ...target.initialStoreKeys,
+                  ]);
+                  const requestedLabel = parseSessionLabel(first.fullPatch.label);
+                  const worktreeTransitions = new Map<number, WorktreeTransition>();
+                  const commitGuards = new Set<() => ErrorShape | undefined>();
+                  const projectGroup = async (
+                    entries: SqliteLifecycleTargetSnapshot,
+                    catalogPreparation?: SessionPatchCatalogResult,
+                  ): Promise<GroupMutationOperation> => {
+                    const workingStore = Object.fromEntries(
+                      entries.flatMap(({ entry, sessionKey }) =>
+                        isInternalSessionEffectsKey(sessionKey)
+                          ? []
+                          : [[sessionKey, entry] as const],
+                      ),
+                    );
+                    const labelOwners = new SessionLabelOwnerIndex(workingStore);
+                    const replacements: SessionEntryCanonicalReplacement[] = [];
+                    const projectedOutcomes: MutationOutcome[] = [];
+                    for (const target of group) {
+                      try {
+                        // Preflight facts can stale behind the writer queue; resolve this snapshot
+                        // again so a new legacy alias is rejected rather than promoted or deleted.
+                        const {
+                          entry: existingEntry,
                           primaryKey,
+                          target: currentTarget,
+                        } = resolveCanonicalGatewaySessionStoreKey({
+                          cfg,
+                          key: target.key,
+                          store: workingStore,
+                          ...(target.requestedAgentId ? { agentId: target.requestedAgentId } : {}),
                         });
-                        if (archiveError) {
-                          projectedOutcomes.push({ ok: false, error: archiveError });
+                        const creationError =
+                          !existingEntry &&
+                          authorizeGatewaySessionCreation({
+                            cfg,
+                            client,
+                            agentId: target.targetAgentId,
+                          });
+                        if (creationError) {
+                          projectedOutcomes.push({ ok: false, error: creationError });
                           continue;
                         }
-                      }
-                      const unreadAck = resolveSessionUnreadAck(existingEntry, target.fullPatch);
-                      if (unreadAck.kind === "missing") {
-                        projectedOutcomes.push({
-                          ok: false,
-                          error: sessionChangedError(target.key),
+                        const candidateKeys = currentTarget.storeKeys;
+                        const ownershipError = resolvePluginSessionOwnershipError({
+                          action: "patch",
+                          entry: existingEntry,
+                          key: primaryKey,
+                          pluginOwnerId,
                         });
-                        continue;
-                      }
-                      if (unreadAck.kind === "stale") {
+                        if (ownershipError) {
+                          projectedOutcomes.push({ ok: false, error: ownershipError });
+                          continue;
+                        }
+                        // Compare tool policy against the captured snapshot; the final
+                        // commit rejects a selection changed during preparation.
+                        const expectedSessionChanged =
+                          (target.fullPatch.expectedSessionId !== undefined &&
+                            existingEntry?.sessionId !== target.fullPatch.expectedSessionId) ||
+                          (target.fullPatch.expectedLifecycleRevision !== undefined &&
+                            existingEntry?.lifecycleRevision !==
+                              target.fullPatch.expectedLifecycleRevision) ||
+                          sessionPatchExpectations.sessionPatchExpectationsChanged(
+                            existingEntry,
+                            target.fullPatch,
+                          );
+                        const lifecycleEntryRemoved =
+                          target.initialEntry !== undefined && existingEntry === undefined;
+                        const archiveTargetChanged =
+                          target.fullPatch.archived === true &&
+                          (target.initialEntry === undefined
+                            ? existingEntry !== undefined
+                            : existingEntry !== undefined &&
+                              (existingEntry.sessionId !== target.initialEntry.sessionId ||
+                                existingEntry.lifecycleRevision !==
+                                  target.initialEntry.lifecycleRevision));
+                        if (
+                          expectedSessionChanged ||
+                          lifecycleEntryRemoved ||
+                          archiveTargetChanged
+                        ) {
+                          projectedOutcomes.push({
+                            ok: false,
+                            error: sessionChangedError(target.key),
+                          });
+                          continue;
+                        }
+                        if (target.fullPatch.archived === true) {
+                          const archiveError = validateSessionPatchArchiveProjection({
+                            cfg,
+                            existingEntry,
+                            fullPatch: target.fullPatch,
+                            key: target.key,
+                            ...(pluginOwnerId ? { pluginOwnerId } : {}),
+                            preparation: target.archivePreparation!,
+                            primaryKey,
+                          });
+                          if (archiveError) {
+                            projectedOutcomes.push({ ok: false, error: archiveError });
+                            continue;
+                          }
+                        }
+                        const unreadAck = resolveSessionUnreadAck(existingEntry, target.fullPatch);
+                        if (unreadAck.kind === "missing") {
+                          projectedOutcomes.push({
+                            ok: false,
+                            error: sessionChangedError(target.key),
+                          });
+                          continue;
+                        }
+                        if (unreadAck.kind === "stale") {
+                          const authorizationFailure = params.targets[target.index]!.commitGuard();
+                          if (authorizationFailure) {
+                            projectedOutcomes.push({ ok: false, error: authorizationFailure });
+                            continue;
+                          }
+                          // A newer explicit marker owns the session until a later activation.
+                          projectedOutcomes.push({
+                            ok: true,
+                            applied: false,
+                            entry: unreadAck.entry,
+                          });
+                          continue;
+                        }
+                        const projection = await catalogs.project({
+                          agentId: target.targetAgentId,
+                          // Multi-target groups retain ordered effects and label claims.
+                          mode: group.length === 1 ? "prepare" : "ordered",
+                          catalog: catalogPreparation,
+                          projection: {
+                            cfg,
+                            creation,
+                            existingEntry,
+                            isLabelInUse: (label) => labelOwners.isLabelInUse(label, candidateKeys),
+                            storeKey: primaryKey,
+                            agentId: target.requestedAgentId,
+                            patch: target.fullPatch,
+                            archivedBy: archiveActor,
+                            personalModelSelection,
+                          },
+                        });
+                        if (projection.kind === "model-catalog") {
+                          // No replacements or runtime effects exist yet. Release this
+                          // writer snapshot; completed preparation must use fresh rows.
+                          return { result: projection };
+                        }
+                        const projected = projection.result;
+                        if (!projected.ok) {
+                          projectedOutcomes.push(projected);
+                          continue;
+                        }
+                        const placementPatchError = resolveSessionWorkerPlacementPatchError({
+                          agentId: target.targetAgentId,
+                          cfg,
+                          context: params.context,
+                          entry: projected.entry,
+                          key: target.key,
+                          patch: target.fullPatch,
+                          sessionKey: primaryKey,
+                          validateModelRuntime: true,
+                        });
+                        if (placementPatchError) {
+                          projectedOutcomes.push(invalidSessionPatchOutcome(placementPatchError));
+                          continue;
+                        }
                         const authorizationFailure = params.targets[target.index]!.commitGuard();
                         if (authorizationFailure) {
                           projectedOutcomes.push({ ok: false, error: authorizationFailure });
                           continue;
                         }
-                        // A newer explicit marker owns the session until a later activation.
-                        projectedOutcomes.push({
-                          ok: true,
-                          applied: false,
-                          entry: unreadAck.entry,
-                        });
-                        continue;
-                      }
-                      const projection = await catalogs.project({
-                        agentId: target.targetAgentId,
-                        // Multi-target groups retain ordered effects and label claims.
-                        mode: group.length === 1 ? "prepare" : "ordered",
-                        catalog: catalogPreparation,
-                        projection: {
-                          cfg,
-                          creation,
-                          existingEntry,
-                          isLabelInUse: (label) => labelOwners.isLabelInUse(label, candidateKeys),
-                          storeKey: primaryKey,
-                          agentId: target.requestedAgentId,
-                          patch: target.fullPatch,
-                          archivedBy: archiveActor,
-                          personalModelSelection,
-                        },
-                      });
-                      if (projection.kind === "model-catalog") {
-                        // No replacements or runtime effects exist yet. Release this
-                        // writer snapshot; completed preparation must use fresh rows.
-                        return { result: projection };
-                      }
-                      const projected = projection.result;
-                      if (!projected.ok) {
-                        projectedOutcomes.push(projected);
-                        continue;
-                      }
-                      const placementPatchError = resolveSessionWorkerPlacementPatchError({
-                        agentId: target.targetAgentId,
-                        cfg,
-                        context: params.context,
-                        entry: projected.entry,
-                        key: target.key,
-                        patch: target.fullPatch,
-                        sessionKey: primaryKey,
-                        validateModelRuntime: true,
-                      });
-                      if (placementPatchError) {
-                        projectedOutcomes.push(invalidSessionPatchOutcome(placementPatchError));
-                        continue;
-                      }
-                      const authorizationFailure = params.targets[target.index]!.commitGuard();
-                      if (authorizationFailure) {
-                        projectedOutcomes.push({ ok: false, error: authorizationFailure });
-                        continue;
-                      }
-                      if (
-                        existingEntry?.worktree &&
-                        typeof target.fullPatch.archived === "boolean"
-                      ) {
-                        const transition = await prepareSessionPatchWorktreeTransition({
-                          archived: target.fullPatch.archived,
-                          entry: existingEntry,
-                          context: params.context,
-                          scope: {
-                            agentId: target.targetAgentId,
-                            sessionKey: primaryKey,
-                            storePath: target.storePath,
-                          },
-                          authorize: params.targets[target.index]!.commitGuard,
-                          preparation: target.archivePreparation,
-                        });
-                        worktreeTransitions.set(target.index, transition);
-                      }
-                      if (permissionRuntime && existingEntry?.sessionId) {
-                        const permission = permissionRuntime.prepareSessionPatchPermissionChange({
-                          context: params.context,
-                          sessionId: existingEntry.sessionId,
-                          sessionKey: target.canonicalKey,
-                          agentId: target.targetAgentId,
-                          assertCurrent: params.targets[target.index]!.commitGuard,
-                        });
-                        if (!permission.ok) {
-                          projectedOutcomes.push(permission);
-                          continue;
+                        if (
+                          existingEntry?.worktree &&
+                          typeof target.fullPatch.archived === "boolean"
+                        ) {
+                          const worktreeTiming = params.diagnostics?.scope("worktree");
+                          let transition: WorktreeTransition;
+                          try {
+                            transition = await prepareSessionPatchWorktreeTransition({
+                              archived: target.fullPatch.archived,
+                              entry: existingEntry,
+                              context: params.context,
+                              scope: {
+                                agentId: target.targetAgentId,
+                                sessionKey: primaryKey,
+                                storePath: target.storePath,
+                              },
+                              authorize: params.targets[target.index]!.commitGuard,
+                              preparation: target.archivePreparation,
+                            });
+                          } finally {
+                            worktreeTiming?.finish();
+                          }
+                          worktreeTransitions.set(target.index, transition);
                         }
-                        target.permissionChange = permission.change;
+                        if (permissionRuntime && existingEntry?.sessionId) {
+                          const permission = permissionRuntime.prepareSessionPatchPermissionChange({
+                            context: params.context,
+                            sessionId: existingEntry.sessionId,
+                            sessionKey: target.canonicalKey,
+                            agentId: target.targetAgentId,
+                            assertCurrent: params.targets[target.index]!.commitGuard,
+                          });
+                          if (!permission.ok) {
+                            projectedOutcomes.push(permission);
+                            continue;
+                          }
+                          target.permissionChange = permission.change;
+                        }
+                        const previousSessionKeys = candidateKeys.filter(
+                          (sessionKey) => sessionKey !== primaryKey && workingStore[sessionKey],
+                        );
+                        commitGuards.add(params.targets[target.index]!.commitGuard);
+                        replacements.push({
+                          entry: projected.entry,
+                          previousSessionKeys,
+                          sessionKey: primaryKey,
+                        });
+                        const cloned = labelOwners.replaceEntry(
+                          candidateKeys,
+                          primaryKey,
+                          projected.entry,
+                        );
+                        projectedOutcomes.push({ ok: true, applied: true, entry: cloned });
+                      } catch (error) {
+                        projectedOutcomes.push({
+                          ok: false,
+                          error: unexpectedPatchError(target.key, error),
+                        });
                       }
-                      const previousSessionKeys = candidateKeys.filter(
-                        (sessionKey) => sessionKey !== primaryKey && workingStore[sessionKey],
-                      );
-                      commitGuards.add(params.targets[target.index]!.commitGuard);
-                      replacements.push({
-                        entry: projected.entry,
-                        previousSessionKeys,
-                        sessionKey: primaryKey,
-                      });
-                      const cloned = labelOwners.replaceEntry(
-                        candidateKeys,
-                        primaryKey,
-                        projected.entry,
-                      );
-                      projectedOutcomes.push({ ok: true, applied: true, entry: cloned });
-                    } catch (error) {
-                      projectedOutcomes.push({
-                        ok: false,
-                        error: unexpectedPatchError(target.key, error),
-                      });
                     }
-                  }
-                  return {
-                    replacements,
-                    result: { kind: "complete", outcomes: projectedOutcomes },
+                    return {
+                      replacements,
+                      result: { kind: "complete", outcomes: projectedOutcomes },
+                    };
                   };
-                };
-                const groupStore = {
-                  assertCommitAllowed: () => {
-                    // Fresh selections remain human-owned through the final commit;
-                    // existing session pins are intentionally not rebound to the caller.
-                    personalModelSelection?.assertCurrent();
-                    for (const guard of commitGuards) {
-                      const error = guard();
-                      if (error) {
-                        throw new SessionMutationAuthorizationChangedError(error);
+                  const groupStore = {
+                    assertCommitAllowed: () => {
+                      // Fresh selections remain human-owned through the final commit;
+                      // existing session pins are intentionally not rebound to the caller.
+                      personalModelSelection?.assertCurrent();
+                      for (const guard of commitGuards) {
+                        const error = guard();
+                        if (error) {
+                          throw new SessionMutationAuthorizationChangedError(error);
+                        }
                       }
-                    }
-                    for (const transition of worktreeTransitions.values()) {
-                      transition.assertCommitAllowed();
-                    }
-                  },
-                  agentId: first.targetAgentId,
-                  sessionKeys: selectedSessionKeys,
-                  ...(requestedLabel.ok ? { includeLabelOwners: requestedLabel.label } : {}),
-                  storePath: first.storePath,
-                  skipMaintenance: true,
-                };
-                const readGroup = () =>
-                  applySessionEntryCanonicalReplacements({
-                    ...groupStore,
-                    update: (entries) => ({ result: entries }),
-                  });
-                let snapshot = await readGroup();
-                // Preserve ordered label and runtime decisions without holding the
-                // agent writer across catalog, allocation, or filesystem preparation.
-                let operation = await projectGroup(snapshot);
-                if (operation.result.kind === "model-catalog") {
-                  const catalog = await catalogs.prepare(first.targetAgentId);
-                  snapshot = await readGroup();
-                  operation = await projectGroup(snapshot, catalog);
-                }
-                const { replacements, result } = operation;
-                if (result.kind !== "complete") {
-                  throw new Error("Session patch catalog preparation did not complete");
-                }
-                const groupOutcomes = replacements?.length
-                  ? await applySessionEntryCanonicalReplacements({
+                      for (const transition of worktreeTransitions.values()) {
+                        transition.assertCommitAllowed();
+                      }
+                    },
+                    agentId: first.targetAgentId,
+                    sessionKeys: selectedSessionKeys,
+                    ...(requestedLabel.ok ? { includeLabelOwners: requestedLabel.label } : {}),
+                    storePath: first.storePath,
+                    skipMaintenance: true,
+                  };
+                  const readGroup = () =>
+                    applySessionEntryCanonicalReplacements({
                       ...groupStore,
-                      update: (entries) => {
-                        // Async preparation owns detached rows, not permission to overwrite
-                        // a changed target, alias, or requested-label owner.
-                        assertLifecycleTargetSnapshotUnchanged(snapshot, entries, "session patch");
-                        return { replacements, result: result.outcomes };
-                      },
-                    })
-                  : result.outcomes;
-                for (const [groupIndex, target] of group.entries()) {
-                  const outcome = groupOutcomes[groupIndex]!;
-                  outcomes[target.index] = outcome;
-                  const afterCommit = worktreeTransitions.get(target.index)?.afterCommit;
-                  if (outcome.ok && outcome.applied && afterCommit) {
-                    outcome.cleanupError = await afterCommit(outcome.entry);
+                      update: (entries) => ({ result: entries }),
+                    });
+                  let snapshot = await readGroup();
+                  // Preserve ordered label and runtime decisions without holding the
+                  // agent writer across catalog, allocation, or filesystem preparation.
+                  groupTiming?.mark("projection");
+                  let operation = await projectGroup(snapshot);
+                  if (operation.result.kind === "model-catalog") {
+                    groupTiming?.mark();
+                    const catalog = await catalogs.prepare(first.targetAgentId);
+                    groupTiming?.mark("snapshot");
+                    snapshot = await readGroup();
+                    groupTiming?.mark("projection");
+                    operation = await projectGroup(snapshot, catalog);
                   }
+                  const { replacements, result } = operation;
+                  if (result.kind !== "complete") {
+                    throw new Error("Session patch catalog preparation did not complete");
+                  }
+                  groupTiming?.mark("commit");
+                  const groupOutcomes = replacements?.length
+                    ? await applySessionEntryCanonicalReplacements({
+                        ...groupStore,
+                        update: (entries) => {
+                          // Async preparation owns detached rows, not permission to overwrite
+                          // a changed target, alias, or requested-label owner.
+                          assertLifecycleTargetSnapshotUnchanged(
+                            snapshot,
+                            entries,
+                            "session patch",
+                          );
+                          return { replacements, result: result.outcomes };
+                        },
+                      })
+                    : result.outcomes;
+                  for (const [groupIndex, target] of group.entries()) {
+                    const outcome = groupOutcomes[groupIndex]!;
+                    outcomes[target.index] = outcome;
+                    const afterCommit = worktreeTransitions.get(target.index)?.afterCommit;
+                    if (outcome.ok && outcome.applied && afterCommit) {
+                      groupTiming?.mark("worktreeCleanup");
+                      outcome.cleanupError = await afterCommit(outcome.entry);
+                    }
+                  }
+                } catch (error) {
+                  for (const target of group) {
+                    outcomes[target.index] = {
+                      ok: false,
+                      error: unexpectedPatchError(target.key, error),
+                    };
+                  }
+                } finally {
+                  groupTiming?.finish();
                 }
-              } catch (error) {
-                for (const target of group) {
-                  outcomes[target.index] = {
-                    ok: false,
-                    error: unexpectedPatchError(target.key, error),
-                  };
-                }
+              }),
+            );
+            // Keep runtime acknowledgement in the mutation lane. A second browser
+            // must not persist a newer mode and then have this older update win.
+            timing?.mark("permissions");
+            for (const target of prepared) {
+              const outcome = outcomes[target.index];
+              if (!target.permissionChange || !outcome?.ok || !outcome.applied) {
+                continue;
               }
-            }),
-          );
-          // Keep runtime acknowledgement in the mutation lane. A second browser
-          // must not persist a newer mode and then have this older update win.
-          for (const target of prepared) {
-            const outcome = outcomes[target.index];
-            if (!target.permissionChange || !outcome?.ok || !outcome.applied) {
-              continue;
+              const error = await target.permissionChange.apply(
+                outcome.entry.permissionMode ?? null,
+              );
+              if (error) {
+                permissionErrors.set(target.index, error);
+              }
             }
-            const error = await target.permissionChange.apply(outcome.entry.permissionMode ?? null);
-            if (error) {
-              permissionErrors.set(target.index, error);
-            }
+          } finally {
+            timing?.mark("lifecycleFinalize");
           }
         },
       });
     } finally {
+      timing?.mark("cleanup");
       for (const target of prepared) {
         target.permissionChange?.finish();
       }
@@ -633,6 +673,7 @@ export async function executeSessionPatchMutations(params: {
     }
   }
 
+  timing?.mark("effects");
   await publishSessionPatchEffects({
     cfg,
     context: params.context,
@@ -644,6 +685,7 @@ export async function executeSessionPatchMutations(params: {
       return outcome?.ok && outcome.applied ? [{ target, entry: outcome.entry }] : [];
     }),
   });
+  timing?.finish();
 
   // Runtime application can fail after commit. Publish every saved field's
   // normal effects before returning the application error to the caller.

--- a/src/gateway/sessions-patch-catalog-queue.e2e.test.ts
+++ b/src/gateway/sessions-patch-catalog-queue.e2e.test.ts
@@ -1,10 +1,23 @@
+import fs from "node:fs/promises";
+import { setTimeout as delay } from "node:timers/promises";
+import { expectDefined } from "@openclaw/normalization-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { expect, test, vi } from "vitest";
 import {
   markPreparedModelRuntimeSnapshotsStale,
   rejectPendingPreparedModelRuntimeReplacement,
 } from "../agents/prepared-model-runtime.js";
 import { loadSessionEntry, upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
+import { runExclusiveSqliteSessionWrite } from "../config/sessions/session-accessor.sqlite-scope.js";
+import { SQLITE_SESSION_WRITER_QUEUES } from "../config/sessions/store-writer-state.js";
+import { onInternalDiagnosticEvent } from "../infra/diagnostic-events.js";
+import {
+  getActiveDiagnosticTraceContext,
+  type DiagnosticTraceContext,
+} from "../infra/diagnostic-trace-context.js";
+import { flushLogger, setLoggerOverride } from "../logging/logger.js";
 import { createDeferredCore } from "../shared/deferred.js";
+import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.js";
 import { captureEnv } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { ADMIN_SCOPE } from "./method-scopes.js";
@@ -26,8 +39,13 @@ test("an authenticated metadata patch completes while another session awaits cat
     configureManualGatewayBackgroundEnv(state.home);
     let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
     let client: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+    const logPath = state.path("gateway.log");
+    setLoggerOverride({ file: logPath, level: "info", consoleLevel: "silent" });
     try {
-      await state.writeConfig({ agents: { defaults: { workspace: state.workspaceDir } } });
+      await state.writeConfig({
+        agents: { defaults: { workspace: state.workspaceDir } },
+        diagnostics: { enabled: true },
+      });
       const port = await getGatewayE2ePortBlock();
       const token = "catalog-queue-synthetic-token";
       server = await startGatewayServer(port, {
@@ -56,9 +74,11 @@ test("an authenticated metadata patch completes while another session awaits cat
       await client.request("sessions.patch", { key: metadataKey, pinned: false });
       const entered = createDeferredCore();
       const originalLoader = modelCatalog.loadGatewayModelCatalog;
+      let catalogTrace: DiagnosticTraceContext | undefined;
       const loader = vi
         .spyOn(modelCatalog, "loadGatewayModelCatalog")
         .mockImplementation((params) => {
+          catalogTrace = getActiveDiagnosticTraceContext();
           entered.resolve();
           return originalLoader(params);
         });
@@ -81,6 +101,8 @@ test("an authenticated metadata patch completes while another session awaits cat
       try {
         await Promise.race([entered.promise, catalogPatch]);
         expect(loader).toHaveBeenCalledOnce();
+        // Exercise the real monotonic clock and file transport above the reporting threshold.
+        await delay(1_100);
         metadataPatch = client
           .request("sessions.patch", { key: metadataKey, pinned: true })
           .then((value) => {
@@ -121,14 +143,125 @@ test("an authenticated metadata patch completes while another session awaits cat
       if (blockedMetadata) {
         throw blockedMetadata;
       }
+
+      const releaseWriter = createDeferredCore();
+      const writerScope = { agentId: "main", env: state.env };
+      const blocker = runExclusiveSqliteSessionWrite(writerScope, async () => {
+        await releaseWriter.promise;
+      });
+      let writerTrace: DiagnosticTraceContext | undefined;
+      const stopObserving = onInternalDiagnosticEvent((event) => {
+        if (
+          event.type === "gateway.rpc" &&
+          event.phase === "received" &&
+          event.method === "sessions.patch"
+        ) {
+          writerTrace = event.trace;
+        }
+      });
+      const privateLabel = "synthetic private label absent from timing records";
+      const queuedPatch = client.request("sessions.patch", {
+        key: metadataKey,
+        label: privateLabel,
+      });
+      void queuedPatch.catch(() => {});
+      try {
+        const storePath = resolveOpenClawAgentSqlitePath(writerScope);
+        await vi.waitFor(() =>
+          expect(SQLITE_SESSION_WRITER_QUEUES.get(storePath)?.pending.length).toBeGreaterThan(0),
+        );
+        await delay(1_100);
+      } finally {
+        releaseWriter.resolve();
+        await Promise.allSettled([blocker, queuedPatch]);
+        stopObserving();
+      }
+      expect(await queuedPatch).toMatchObject({ entry: { label: privateLabel } });
+      await flushLogger();
+      const records = (await fs.readFile(logPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+      const findPatchTiming = (trace: DiagnosticTraceContext | undefined) => {
+        const expectedTrace = expectDefined(trace, "request trace");
+        const row = expectDefined(
+          records.find(
+            (record) =>
+              record.message === "slow session patch" &&
+              record.traceId === expectedTrace.traceId &&
+              record.spanId === expectedTrace.spanId,
+          ),
+          "correlated patch timing record",
+        );
+        return expectDefined(
+          Object.values(row).find(
+            (value): value is Record<string, unknown> =>
+              isRecord(value) && value.method === "sessions.patch",
+          ),
+          "patch timing metadata",
+        );
+      };
+      const catalogTiming = findPatchTiming(catalogTrace);
+      expect(catalogTiming).toMatchObject({ phaseCounts: { catalog: 1 } });
+      expect(isRecord(catalogTiming.phaseDurationsMs)).toBe(true);
+      if (isRecord(catalogTiming.phaseDurationsMs)) {
+        expect(catalogTiming.phaseDurationsMs.catalog).toBeGreaterThanOrEqual(1_000);
+      }
+      const writerTiming = findPatchTiming(writerTrace);
+      expect(writerTrace?.traceId).not.toBe(catalogTrace?.traceId);
+      const sqliteRow = expectDefined(
+        records.find(
+          (record) =>
+            typeof record.message === "string" &&
+            record.message.startsWith("slow SQLite session write") &&
+            record.traceId === writerTrace?.traceId &&
+            record.spanId === writerTrace?.spanId,
+        ),
+        "correlated SQLite timing record",
+      );
+      const sqliteTiming = expectDefined(
+        Object.values(sqliteRow).find(
+          (value): value is Record<string, unknown> =>
+            isRecord(value) && typeof value.queueWaitMs === "number",
+        ),
+        "SQLite timing metadata",
+      );
+      expect(sqliteTiming.queueWaitMs).toBeGreaterThanOrEqual(1_000);
+      expect(sqliteTiming.writerExecutionMs).toEqual(expect.any(Number));
+      expect(sqliteTiming.completionDelayMs).toEqual(expect.any(Number));
+      expect(JSON.stringify([catalogTiming, writerTiming])).not.toContain(privateLabel);
+      expect(JSON.stringify([catalogTiming, writerTiming])).not.toContain(metadataKey);
+      expect(JSON.stringify([catalogTiming, writerTiming])).not.toContain(catalogKey);
+      process.stdout.write(
+        "SESSION_PATCH_TIMING_TRACE_PROOF " +
+          JSON.stringify({
+            catalog: catalogTiming,
+            writer: writerTiming,
+            sqlite: {
+              queueWaitMs: sqliteTiming.queueWaitMs,
+              writerExecutionMs: sqliteTiming.writerExecutionMs,
+              completionDelayMs: sqliteTiming.completionDelayMs,
+            },
+            tracesCorrelated: true,
+          }) +
+          "\n",
+      );
     } finally {
       try {
         if (client) {
           await disconnectGatewayClient(client);
         }
       } finally {
-        await server?.close();
-        backgroundEnv.restore();
+        try {
+          await server?.close();
+        } finally {
+          try {
+            await flushLogger();
+          } finally {
+            setLoggerOverride({ level: "silent", consoleLevel: "silent" });
+            backgroundEnv.restore();
+          }
+        }
       }
     }
   });

--- a/src/shared/store-writer-queue.test.ts
+++ b/src/shared/store-writer-queue.test.ts
@@ -1,9 +1,60 @@
 // Verifies queue ownership and reentrancy across separately loaded runtime chunks.
 import { AsyncLocalStorage } from "node:async_hooks";
+import { performance } from "node:perf_hooks";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
-import { expect, it } from "vitest";
+import { expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
-import { runQueuedStoreWrite, type StoreWriterQueue } from "./store-writer-queue.js";
+import {
+  runQueuedStoreWrite,
+  type StoreWriterQueue,
+  type StoreWriterTiming,
+} from "./store-writer-queue.js";
+
+it("marks idle and reentrant execution without deferring either callback", async () => {
+  const queues = new Map<string, StoreWriterQueue>();
+  const outerTiming: StoreWriterTiming = {};
+  const innerTiming: StoreWriterTiming = {};
+  const order: string[] = [];
+  let clock = 0;
+  const clockSpy = vi.spyOn(performance, "now").mockImplementation(() => clock);
+  const pending = runQueuedStoreWrite({
+    queues,
+    storePath: "timed-store",
+    label: "outer",
+    timing: outerTiming,
+    fn: async () => {
+      order.push("outer");
+      clock = 5;
+      const inner = runQueuedStoreWrite({
+        queues,
+        storePath: "timed-store",
+        label: "inner",
+        reentrant: true,
+        timing: innerTiming,
+        fn: async () => {
+          order.push("inner");
+          clock = 10;
+          return "result";
+        },
+      });
+      expect(innerTiming.startedAt).toBe(5);
+      const result = await inner;
+      clock = 15;
+      return result;
+    },
+  });
+  try {
+    expect(order).toEqual(["outer", "inner"]);
+    expect(outerTiming.startedAt).toBe(0);
+    expect(await pending).toBe("result");
+    expect(innerTiming).toEqual({ startedAt: 5, finishedAt: 10 });
+    expect(outerTiming).toEqual({ startedAt: 0, finishedAt: 15 });
+    expect(queues.size).toBe(0);
+  } finally {
+    await pending.catch(() => {});
+    clockSpy.mockRestore();
+  }
+});
 
 it("retains each queued writer's caller context through async and reentrant work", async () => {
   const contexts = new AsyncLocalStorage<string>();

--- a/src/shared/store-writer-queue.ts
+++ b/src/shared/store-writer-queue.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { performance } from "node:perf_hooks";
 import { createDeferredCore } from "./deferred.js";
 import { resolveGlobalSingleton } from "./global-singleton.js";
 
@@ -22,6 +23,9 @@ export type StoreWriterQueue = {
 
 /** Store writer queues keyed by the canonical store path. */
 type StoreWriterQueues = Map<string, StoreWriterQueue>;
+
+/** Request-owned monotonic timestamps; queued work may be rejected without entering. */
+export type StoreWriterTiming = { startedAt?: number; finishedAt?: number };
 
 type ActiveStoreWriter = {
   active: boolean;
@@ -52,11 +56,18 @@ async function runActiveStoreWriter<T>(
   queues: StoreWriterQueues,
   storePath: string,
   fn: () => Promise<T>,
+  timing?: StoreWriterTiming,
 ): Promise<T> {
   const writer = { active: true, parent: activeStoreWriters.getStore(), queues, storePath };
+  if (timing) {
+    timing.startedAt = performance.now();
+  }
   try {
     return await activeStoreWriters.run(writer, fn);
   } finally {
+    if (timing) {
+      timing.finishedAt = performance.now();
+    }
     writer.active = false;
   }
 }
@@ -119,6 +130,7 @@ export async function runQueuedStoreWrite<T>(params: {
   label: string;
   fn: () => Promise<T>;
   reentrant?: boolean;
+  timing?: StoreWriterTiming;
 }): Promise<T> {
   if (!params.storePath || typeof params.storePath !== "string") {
     throw new Error(
@@ -130,7 +142,16 @@ export async function runQueuedStoreWrite<T>(params: {
   // Explicit reentrancy keeps one logical read/decide/write section on the
   // active lane; ordinary async children must queue behind the current writer.
   if (params.reentrant === true && isActiveStoreWriter(params.queues, params.storePath)) {
-    return await params.fn();
+    if (params.timing) {
+      params.timing.startedAt = performance.now();
+    }
+    try {
+      return await params.fn();
+    } finally {
+      if (params.timing) {
+        params.timing.finishedAt = performance.now();
+      }
+    }
   }
   // A queued writer retains its caller's authority, never the preceding writer's
   // async context. The active-writer scope still belongs to actual execution.
@@ -139,7 +160,13 @@ export async function runQueuedStoreWrite<T>(params: {
   return await new Promise<T>((resolve, reject) => {
     const task: StoreWriterTask = {
       fn: async () =>
-        await runInAsyncContext(runActiveStoreWriter, params.queues, params.storePath, params.fn),
+        await runInAsyncContext(
+          runActiveStoreWriter,
+          params.queues,
+          params.storePath,
+          params.fn,
+          params.timing,
+        ),
       resolve: (value) => resolve(value as T),
       reject,
     };


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators investigating slow session edits can see the overall request duration but cannot distinguish lifecycle admission, catalog work, snapshot/commit work, or finalization. The existing slow SQLite writer warning also combines queued time, execution, and delayed caller continuation.

## Why This Change Was Made

Record monotonic timestamps at the existing writer entry and settlement boundaries, and add their breakdown to the existing warning. With diagnostics enabled, slow `sessions.patch` and `sessions.patchMany` requests now emit one trace-correlated log record with fixed phase durations and counts.

The request owns its observations through completion and failure; retired or disabled scopes cannot publish later. Existing await order, mutation fencing, and return values are preserved. Parallel/nested phase totals can overlap and are elapsed time, not CPU or an exclusive partition. Writer execution includes awaits inside the writer lane and is separate from native SQLite transaction-lock hold time.

The +211 production lines supply the missing request observation lifecycle and optional queue timestamps; most raw diff churn is `try/finally` indentation. No configuration, schema, public RPC, or Prometheus metric changes. Documentation describes the existing enablement and the new fields.

## User Impact

Operators can identify internal waits without logging patch values or session keys. This repairs diagnostic coverage; the underlying causes of individual slow requests still require investigation.

## Evidence

- Original catalog/metadata ordering fixture failed because request timing records were absent; real queued-writer tests failed because wait/execution/completion fields were absent. Existing outcome/order controls remain covered.
- Focused Gateway, queue, and lifecycle coverage passes, including concurrent catalog loads, caller traces, queued failures, cleanup, reentrant synchronous entry, disabled diagnostics, and logging failure. A real lifecycle-owner regression fails with the former prepare-entry pause (`0ms` admission instead of `700ms`) and passes with the final run-entry boundary (`700ms` admission, `500ms` finalization).
- Full `node scripts/check-changed.mjs` passed. All four consuming test type graphs also passed after auditing every new assertion-helper call. Independent review is clean.
- Native Linux Node 24.19 full build and authenticated Gateway E2E passed. Raw source bytes/kinds/Git modes matched source revision `bbe9674b4ac1` before and after execution; its six diagnostic production files remain unchanged after the test-only CI correction below. Synthetic trace-correlated results: held catalog request `1157ms`, catalog phase `1152ms`; held writer request `1156ms`, snapshot phase `1152ms`, SQLite queue wait `1149ms`, execution `2ms`, completion delay `0ms`. Metadata excludes the fixture's session keys and private label.
- Overhead checks are bounded, not production latency attribution. One four-process comparison showed candidate medians `6.45/3.83ms` versus baseline `4.19/3.12ms` under uncontrolled host load. Within-process on/off rounds varied in both directions; final adjacent medians were `2.588854/2.588979ms`. Isolated final phase accounting measured `1.46–1.70µs` process CPU per metadata request, excluding SQLite and slow-record serialization.

Initial validation failures were retained and corrected: declaration checking rejected external dependency links, so a full private install replaced them; typechecking found missing assertion context messages, now audited across all 14 new calls; an unsupported native environment-forwarding option failed before the workload and was removed. No failing check was waived. The dedicated native lease is stopped.

CI follow-up: hosted checks exposed an existing timeout-forwarding fixture that expected `600000ms` after real preflight work had reduced the allowance to `599999ms`. The same assumption fails on the original baseline under controlled clock advancement. That one test now freezes `Date.now()` while retaining real timers and both exact assertions. The full model-switch and elapsed-budget/expiry suites passed 164 tests; the targeted changed-file type/lint gate and independent review passed. No production timeout behavior changed, and the updated head must still satisfy hosted CI before landing.
