### PR TITLE
fix(parallels): detect host networking before VMs start

### DIFF
--- a/scripts/e2e/parallels/host-server.ts
+++ b/scripts/e2e/parallels/host-server.ts
@@ -3,29 +3,77 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { rm } from "node:fs/promises";
 import { createServer } from "node:http";
-import { createConnection } from "node:net";
+import { createConnection, isIPv4 } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Readable } from "node:stream";
 import { sleep as delay } from "../../lib/sleep.mjs";
-import { die, run, say, sh, warn } from "./host-command.ts";
+import { die, run, say, warn } from "./host-command.ts";
 import type { HostServer, NpmRegistryPackage, NpmRegistryServer } from "./types.ts";
 
 const HOST_SERVER_STDERR_LIMIT_BYTES = 64 * 1024;
 const HOST_SERVER_STDERR_DRAIN_MS = 5_000;
 type HostServerChild = ChildProcess & { stderr: Readable };
 
+function parseSharedAdapterIpv4(output: string): string {
+  let inParallelsAdapter = false;
+  for (const line of output.split(/\r?\n/)) {
+    const section = line.match(/^\s*([^:]+):\s*$/);
+    if (section) {
+      inParallelsAdapter = section[1]?.trim() === "Parallels adapter";
+      continue;
+    }
+    if (!inParallelsAdapter) {
+      continue;
+    }
+    const address = line.match(/^\s*IPv4 address:\s*(\S+)\s*$/)?.[1];
+    if (address) {
+      return isIPv4(address) ? address : "";
+    }
+  }
+  return "";
+}
+
+function resolveConfiguredSharedHostIp(): string {
+  try {
+    const result = run("prlsrvctl", ["net", "info", "Shared"], {
+      check: false,
+      env: { ...process.env, LC_ALL: "C" },
+      quiet: true,
+    });
+    return result.status === 0 ? parseSharedAdapterIpv4(result.stdout) : "";
+  } catch {
+    return "";
+  }
+}
+
+function resolveInterfaceHostIp(): string {
+  try {
+    const result = run("ifconfig", [], { check: false, quiet: true });
+    if (result.status !== 0) {
+      return "";
+    }
+    for (const line of result.stdout.split(/\r?\n/)) {
+      const address = line.match(/(?:^|\s)inet\s+(10\.211\.\d+\.\d+)(?:\s|$)/)?.[1];
+      if (address && isIPv4(address)) {
+        return address;
+      }
+    }
+  } catch {
+    // The configured network lookup above remains authoritative when interfaces are absent.
+  }
+  return "";
+}
+
 export function resolveHostIp(explicit = ""): string {
   if (explicit) {
     return explicit;
   }
-  const output = sh("ifconfig | awk '/inet 10\\.211\\./ { print $2; exit }'", {
-    quiet: true,
-  }).stdout.trim();
-  if (!output) {
+  const hostIp = resolveConfiguredSharedHostIp() || resolveInterfaceHostIp();
+  if (!hostIp) {
     die("failed to detect Parallels host IP; pass --host-ip");
   }
-  return output;
+  return hostIp;
 }
 
 function allocateHostPort(): number {

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -29,6 +29,7 @@ import {
   parseMacosDsclUserHomeLine,
   readGitCommitEnv,
   readPositiveIntEnv,
+  resolveHostIp,
   resolveLatestVersion,
   resolveParallelsModelTimeoutSeconds,
   resolveProviderAuth as resolveProviderAuthDirect,
@@ -165,6 +166,47 @@ function writeNodeFakePrlctl(tempDir: string, body: string): void {
     tempDir,
     `#!/usr/bin/env node\n${program}\n`,
     `import { basename } from "node:path"; if ([process.argv0, process.execPath].some((value) => basename(value).toLowerCase() === "prlctl.exe")) { ${program} }`,
+  );
+}
+
+function writeFakeHostIpCommand(tempDir: string, name: string, body: string): void {
+  const commandPath = join(tempDir, name);
+  writeFileSync(commandPath, `#!/bin/sh\n${body}\n`);
+  chmodSync(commandPath, 0o755);
+}
+
+function withFakeHostIpCommands<T>(
+  input: {
+    ifconfigOutput?: string;
+    ifconfigStatus?: number;
+    prlsrvctlOutput?: string;
+    prlsrvctlStatus?: number;
+  },
+  runTest: (callsPath: string) => T,
+): T {
+  const tempDir = makeTempDir(tempDirs, "openclaw-parallels-host-ip-");
+  const callsPath = join(tempDir, "calls.log");
+  writeFakeHostIpCommand(
+    tempDir,
+    "prlsrvctl",
+    'printf "prlsrvctl:%s:%s\\n" "$LC_ALL" "$*" >>"$OPENCLAW_HOST_IP_CALLS"\nprintf "%b" "$OPENCLAW_PRLSRVCTL_OUTPUT"\nexit "$OPENCLAW_PRLSRVCTL_STATUS"',
+  );
+  writeFakeHostIpCommand(
+    tempDir,
+    "ifconfig",
+    'printf "ifconfig:%s\\n" "$*" >>"$OPENCLAW_HOST_IP_CALLS"\nprintf "%b" "$OPENCLAW_IFCONFIG_OUTPUT"\nexit "$OPENCLAW_IFCONFIG_STATUS"',
+  );
+  return withEnv(
+    {
+      LC_ALL: "fixture-locale",
+      OPENCLAW_HOST_IP_CALLS: callsPath,
+      OPENCLAW_IFCONFIG_OUTPUT: input.ifconfigOutput ?? "",
+      OPENCLAW_IFCONFIG_STATUS: String(input.ifconfigStatus ?? 0),
+      OPENCLAW_PRLSRVCTL_OUTPUT: input.prlsrvctlOutput ?? "",
+      OPENCLAW_PRLSRVCTL_STATUS: String(input.prlsrvctlStatus ?? 0),
+      PATH: `${tempDir}${delimiter}${process.env.PATH ?? ""}`,
+    },
+    () => runTest(callsPath),
   );
 }
 
@@ -903,6 +945,74 @@ ensure_vm_running`,
       12,
     );
     expect(retained).toBe(`${"a".repeat(2)}${"b".repeat(10)}`);
+  });
+
+  describe.skipIf(process.platform === "win32")("Parallels host IP detection", () => {
+    it("keeps an explicit host IP above both detectors", () => {
+      withFakeHostIpCommands({}, (callsPath) => {
+        expect(resolveHostIp("192.0.2.10")).toBe("192.0.2.10");
+        expect(existsSync(callsPath)).toBe(false);
+      });
+    });
+
+    it("reads the configured Shared adapter before any live interface exists", () => {
+      const output = `Network ID: Shared
+Type: shared
+Parallels adapter:
+\tIPv4 address: 10.211.55.2
+\tIPv4 subnet mask: 255.255.255.0
+DHCPv4 server:
+\tServer address: 10.211.55.1
+`;
+      withFakeHostIpCommands({ ifconfigStatus: 1, prlsrvctlOutput: output }, (callsPath) => {
+        expect(resolveHostIp()).toBe("10.211.55.2");
+        expect(readFileSync(callsPath, "utf8")).toBe("prlsrvctl:C:net info Shared\n");
+      });
+    });
+
+    it("accepts CRLF and harmless whitespace in Shared network output", () => {
+      const output =
+        "Network ID: Shared\r\n  Parallels adapter:  \r\n    IPv4 address:   10.211.55.3  \r\nDHCPv4 server:\r\n";
+      withFakeHostIpCommands({ prlsrvctlOutput: output }, () => {
+        expect(resolveHostIp()).toBe("10.211.55.3");
+      });
+    });
+
+    it.each(["", "    IPv4 address: not-an-ip\n"])(
+      "falls back to ifconfig when the adapter address is missing or malformed",
+      (adapterLine) => {
+        const output = `Network ID: Shared
+Parallels adapter:
+${adapterLine}DHCPv4 server:
+    Server address: 10.211.55.1
+`;
+        withFakeHostIpCommands(
+          {
+            ifconfigOutput: "vnic0: flags=8843<UP>\n\tinet 10.211.55.9 netmask 0xffffff00\n",
+            prlsrvctlOutput: output,
+          },
+          (callsPath) => {
+            expect(resolveHostIp()).toBe("10.211.55.9");
+            expect(readFileSync(callsPath, "utf8")).toBe(
+              "prlsrvctl:C:net info Shared\nifconfig:\n",
+            );
+          },
+        );
+      },
+    );
+
+    it("preserves ifconfig fallback when Shared network lookup fails", () => {
+      withFakeHostIpCommands(
+        {
+          ifconfigOutput: "bridge100: flags=8863<UP>\n\tinet 10.211.55.7 netmask 0xffffff00\n",
+          prlsrvctlStatus: 1,
+        },
+        (callsPath) => {
+          expect(resolveHostIp()).toBe("10.211.55.7");
+          expect(readFileSync(callsPath, "utf8")).toBe("prlsrvctl:C:net info Shared\nifconfig:\n");
+        },
+      );
+    });
   });
 
   it("accepts npm 10/11 array and npm 12 workspace result shapes", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Parallels release-validation smoke tests would stop before starting any VM when the Shared network adapter existed in Parallels configuration but no live `vnic` interface was present yet.

## Why This Change Was Made

The host resolver now reads the configured Shared network adapter from `prlsrvctl` first, validates its IPv4 address, and retains the existing live-interface lookup as a fallback. Explicit `--host-ip` input remains highest priority.

## User Impact

Operators can start the Parallels smoke matrix from a stopped-VM state without manually discovering and passing the host IP.

## Evidence

- `node --import ./scripts/tsx.mjs scripts/test-projects.mts test/scripts/parallels-smoke-model.test.ts`
- 111 tests passed on exact head `ce8f5fff4b0e`
- Coverage includes configured-adapter discovery, malformed output, CRLF/whitespace, explicit override, failed `prlsrvctl`, and legacy `ifconfig` fallback.
- Trusted-host exact-head proof used the production resolver and matched the configured Shared adapter.
- The Ubuntu proof VM began stopped, downloaded and matched a host-served marker, and returned to stopped state.
- The host server and temporary proof input were cleaned after the run.
- No release, publish, tag, registry, or full FRV workflow was invoked.
