### PR TITLE
refactor(tools): remove unreachable allowlist diagnostic state

### DIFF
--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -184,15 +184,9 @@ export function applyToolPolicyPipeline<TTool extends { name: string }>(params: 
           (entry) => !isKnownCoreToolId(entry) && !unavailableCoreWarningAllowlist.has(entry),
         );
         const warningEntries = [...warnableGatedCoreEntries, ...otherEntries];
-        if (
-          shouldWarnAboutUnknownAllowlist({
-            hasGatedCoreEntries: warnableGatedCoreEntries.length > 0,
-            hasOtherEntries: otherEntries.length > 0,
-          })
-        ) {
+        if (warningEntries.length > 0) {
           const entries = warningEntries.join(", ");
           const suffix = describeUnknownAllowlistSuffix({
-            pluginOnlyAllowlist: resolved.pluginOnlyAllowlist,
             hasGatedCoreEntries: warnableGatedCoreEntries.length > 0,
             hasOtherEntries: otherEntries.length > 0,
             unavailableCoreToolReason: step.unavailableCoreToolReason,
@@ -227,22 +221,11 @@ export function applyToolPolicyPipeline<TTool extends { name: string }>(params: 
   return filtered;
 }
 
-function shouldWarnAboutUnknownAllowlist(params: {
-  hasGatedCoreEntries: boolean;
-  hasOtherEntries: boolean;
-}): boolean {
-  return params.hasGatedCoreEntries || params.hasOtherEntries;
-}
-
 function describeUnknownAllowlistSuffix(params: {
-  pluginOnlyAllowlist: boolean;
   hasGatedCoreEntries: boolean;
   hasOtherEntries: boolean;
   unavailableCoreToolReason?: string;
 }): string {
-  const preface = params.pluginOnlyAllowlist
-    ? "Allowlist contains only plugin entries; core tools will not be available."
-    : "";
   const unavailableCoreToolReason = params.unavailableCoreToolReason?.trim();
   const unavailableCoreDetail = unavailableCoreToolReason
     ? `These entries are shipped core tools but unavailable here: ${unavailableCoreToolReason}.`
@@ -250,11 +233,9 @@ function describeUnknownAllowlistSuffix(params: {
   const mixedUnavailableCoreDetail = unavailableCoreToolReason
     ? `Some entries are shipped core tools but unavailable here: ${unavailableCoreToolReason}; other entries won't match any tool unless the plugin is enabled.`
     : "Some entries are shipped core tools but unavailable in the current runtime/provider/model/config; other entries won't match any tool unless the plugin is enabled.";
-  const detail =
-    params.hasGatedCoreEntries && params.hasOtherEntries
-      ? mixedUnavailableCoreDetail
-      : params.hasGatedCoreEntries
-        ? unavailableCoreDetail
-        : "These entries won't match any tool unless the plugin is enabled.";
-  return preface ? `${preface} ${detail}` : detail;
+  return params.hasGatedCoreEntries && params.hasOtherEntries
+    ? mixedUnavailableCoreDetail
+    : params.hasGatedCoreEntries
+      ? unavailableCoreDetail
+      : "These entries won't match any tool unless the plugin is enabled.";
 }

--- a/src/agents/tool-policy.plugin-only-allowlist.test.ts
+++ b/src/agents/tool-policy.plugin-only-allowlist.test.ts
@@ -20,7 +20,6 @@ describe("analyzeAllowlistByToolType", () => {
     const input = { allow: ["lobster"] };
     const policy = analyzeAllowlistByToolType(input, pluginGroups, coreTools);
     expect(input).toEqual({ allow: ["lobster"] });
-    expect(policy.pluginOnlyAllowlist).toBe(true);
     expect(policy.unknownAllowlist).toStrictEqual([]);
   });
 
@@ -28,7 +27,6 @@ describe("analyzeAllowlistByToolType", () => {
     const input = { allow: ["group:plugins"] };
     const policy = analyzeAllowlistByToolType(input, pluginGroups, coreTools);
     expect(input).toEqual({ allow: ["group:plugins"] });
-    expect(policy.pluginOnlyAllowlist).toBe(true);
     expect(policy.unknownAllowlist).toStrictEqual([]);
   });
 
@@ -51,7 +49,6 @@ describe("analyzeAllowlistByToolType", () => {
     const input = { allow: ["lobster"] };
     const policy = analyzeAllowlistByToolType(input, emptyPlugins, coreTools);
     expect(input).toEqual({ allow: ["lobster"] });
-    expect(policy.pluginOnlyAllowlist).toBe(false);
     expect(policy.unknownAllowlist).toEqual(["lobster"]);
   });
 
@@ -63,9 +60,8 @@ describe("analyzeAllowlistByToolType", () => {
     expect(policy.unknownAllowlist).toEqual(["lobster"]);
   });
 
-  it("does not mark unavailable core entries as plugin-only", () => {
+  it("reports unavailable core entries as unknown", () => {
     const policy = analyzeAllowlistByToolType({ allow: ["apply_patch"] }, pluginGroups, coreTools);
-    expect(policy.pluginOnlyAllowlist).toBe(false);
     expect(policy.unknownAllowlist).toEqual(["apply_patch"]);
   });
 
@@ -76,7 +72,6 @@ describe("analyzeAllowlistByToolType", () => {
       pluginToolNames: ["llm-task"],
     });
     expect(input).toEqual({ allow: ["llm-task"] });
-    expect(policy.pluginOnlyAllowlist).toBe(true);
     expect(policy.unknownAllowlist).toStrictEqual([]);
   });
 
@@ -88,7 +83,6 @@ describe("analyzeAllowlistByToolType", () => {
       coreTools,
       { mcpServerNames: ["paperless", "Home Assistant"] },
     );
-    expect(policy.pluginOnlyAllowlist).toBe(true);
     expect(policy.unknownAllowlist).toStrictEqual([]);
   });
 
@@ -100,7 +94,6 @@ describe("analyzeAllowlistByToolType", () => {
       coreTools,
       { mcpServerNames: ["paperless"] },
     );
-    expect(policy.pluginOnlyAllowlist).toBe(false);
     expect(policy.unknownAllowlist).toStrictEqual(["papreless__*"]);
   });
 

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -40,7 +40,6 @@ export type PluginToolGroups = {
 /** Analysis of an allowlist after matching core and plugin tool ids. */
 type AllowlistResolution = {
   unknownAllowlist: string[];
-  pluginOnlyAllowlist: boolean;
 };
 
 export type DeclaredToolAllowlistContext = {
@@ -273,7 +272,7 @@ function isDeclaredMcpAllowlistEntry(entry: string, prefixes: Set<string>): bool
   return false;
 }
 
-/** Classifies allowlists as core, plugin-only, or unknown for diagnostics. */
+/** Finds allowlist entries that match neither core nor declared plugin tools. */
 export function analyzeAllowlistByToolType(
   policy: ToolPolicyLike | undefined,
   groups: PluginToolGroups,
@@ -281,11 +280,11 @@ export function analyzeAllowlistByToolType(
   declaredTools?: DeclaredToolAllowlistContext,
 ): AllowlistResolution {
   if (!policy?.allow || policy.allow.length === 0) {
-    return { unknownAllowlist: [], pluginOnlyAllowlist: false };
+    return { unknownAllowlist: [] };
   }
   const normalized = normalizeToolList(expandShippedCoreToolPolicyNames(policy.allow));
   if (normalized.length === 0) {
-    return { unknownAllowlist: [], pluginOnlyAllowlist: false };
+    return { unknownAllowlist: [] };
   }
   const pluginIds = new Set(groups.byPlugin.keys());
   for (const value of declaredTools?.pluginIds ?? []) {
@@ -303,10 +302,8 @@ export function analyzeAllowlistByToolType(
   }
   const mcpToolPrefixes = buildDeclaredMcpToolPrefixes(declaredTools?.mcpServerNames);
   const unknownAllowlist: string[] = [];
-  let hasOnlyPluginEntries = true;
   for (const entry of normalized) {
     if (entry === "*") {
-      hasOnlyPluginEntries = false;
       continue;
     }
     const isPluginEntry =
@@ -316,17 +313,12 @@ export function analyzeAllowlistByToolType(
       isDeclaredMcpAllowlistEntry(entry, mcpToolPrefixes);
     const expanded = expandToolGroups([entry]);
     const isCoreEntry = expanded.some((tool) => coreTools.has(tool));
-    if (!isPluginEntry) {
-      hasOnlyPluginEntries = false;
-    }
     if (!isCoreEntry && !isPluginEntry) {
       unknownAllowlist.push(entry);
     }
   }
-  const pluginOnlyAllowlist = hasOnlyPluginEntries;
   return {
     unknownAllowlist: uniqueStrings(unknownAllowlist),
-    pluginOnlyAllowlist,
   };
 }
 


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Tool-policy diagnostics compute a plugin-only flag that cannot affect a reachable warning. This is a maintainer-requested production deletion follow-up supporting concern C (stage 3) of the #135868 split.

## Why This Change Was Made

Remove the unused classification bit and its unreachable warning preface. Check the assembled warning list directly instead of routing two nonempty flags through a private boolean-OR helper. Restrictive plugin-only allowlists, unknown-entry diagnostics, warning order/cache, filtering, and audit behavior remain unchanged.

## User Impact

No user-visible behavior change. Production shrinks by 27 lines (+9/−36); tests shrink by 7 lines (+1/−8), with every test case retained. Tooling, docs, configuration, dependencies and public SDK surfaces are unchanged.

## Evidence

An entry reaches `unknownAllowlist` only when both `isCoreEntry` and `isPluginEntry` are false. Every false `isPluginEntry` previously cleared `hasOnlyPluginEntries`. Therefore the sole warning consumer, guarded by a nonempty unknown list, could never observe `pluginOnlyAllowlist: true`. Removing that state preserves all emitted warning text.

| Deleted implementation/assertions | Remaining behavior proof |
| --- | --- |
| `pluginOnlyAllowlist` bit and `hasOnlyPluginEntries` bookkeeping | `src/agents/tool-policy.plugin-only-allowlist.test.ts:19,26,47,63,68,78,89` retains known/unknown-entry and input-immutability checks for every affected case. Only seven internal-bit assertions were removed. |
| Unreachable plugin-only warning preface | `src/agents/tool-policy-pipeline.test.ts:69` retains the regression that plugin-only allowlists remain restrictive; `:171` asserts exact reachable unknown-entry warning text. Existing mixed/gated/declared-MCP and suppression cases remain unchanged. |
| `shouldWarnAboutUnknownAllowlist` boolean-OR wrapper | `warningEntries` is exactly the concatenation of the two arrays whose nonempty flags formed the OR. Existing pipeline warning-suppression and exact-message tests retain this boundary. |

The earlier restrictive-allowlist repair (#58476, `193fdd6e3b0`) remains intact. The removed flag fed no policy selection or expansion. Repository-wide symbol/module searches found no SDK or other production consumer of it. Per-layer declaration reads, frozen allowlists, warning deduplication/eviction and `auditToolPolicyFilter` are untouched; no identity/receipt collection or authority semantics change.

Three focused suites passed before and after with all 89 cases retained: 6.916 s → 8.166 s aggregate. Independent pinned-candidate review is scoped-clean through P2. Full changed checks passed, including core/core-test types, lint, all three dead-export scans and selected guards. [Exact-head CI run 34063811581](https://github.com/openclaw/openclaw/actions/runs/34063811581) passed on `95470d414940b10e17f77acb2ccdbaa748ed3ffd`. ClawSweeper reviewed that head with no findings or before-merge/rank-up requests. No tests were added, replaced with mocks, or weakened by timeout changes.
