### PR TITLE
fix(sdk): release buffered events when iterators close

### DIFF
--- a/packages/sdk/src/event-hub.retention.test-support.ts
+++ b/packages/sdk/src/event-hub.retention.test-support.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { setImmediate } from "node:timers/promises";
+import { EventHub } from "./event-hub.js";
+
+type Mode = "return" | "filter-error" | "reentrant-return" | "hub-close";
+type Payload = { kind: "backlog" | "trigger" };
+type Held = {
+  mode: Mode;
+  hub: EventHub<Payload>;
+  iterator: AsyncIterator<Payload>;
+  refs: Array<{ kind: Payload["kind"]; value: WeakRef<Payload> }>;
+};
+const held: Held[] = [];
+const report = {
+  phase: "setup",
+  gcPasses: 0,
+  controlRetained: null as boolean | null,
+  observations: [] as Array<{ mode: Mode; kind: Payload["kind"]; retained: boolean }>,
+  hubCloseDrained: false,
+  terminalBehavior: [] as Array<{ mode: Mode; outcome: "done" | "filter-error" }>,
+  cleanupErrors: [] as string[],
+  error: null as string | null,
+  verdict: "incomplete",
+};
+const reason = (error: unknown) =>
+  error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+
+function publishWeak(hub: EventHub<Payload>, kind: Payload["kind"]) {
+  // This activation owns the only temporary strong payload reference.
+  const payload: Payload = { kind };
+  const value = new WeakRef(payload);
+  hub.publish(payload);
+  return { kind, value };
+}
+
+async function prepare(mode: Mode) {
+  const hub = new EventHub<Payload>();
+  let returned: Promise<IteratorResult<Payload>> | undefined;
+  const stream = hub.stream((event) => {
+    if (event.kind === "trigger") {
+      if (mode === "filter-error") {
+        throw new Error("synthetic filter retirement");
+      }
+      if (mode === "reentrant-return") {
+        returned = iterator.return?.();
+      }
+    }
+    return true;
+  });
+  const iterator: AsyncIterator<Payload> = stream[Symbol.asyncIterator]();
+  const item: Held = { mode, hub, iterator, refs: [] };
+  held.push(item);
+  item.refs.push(publishWeak(hub, "backlog"));
+  if (mode === "return") {
+    await iterator.return?.();
+  } else if (mode === "hub-close") {
+    hub.close();
+  } else {
+    item.refs.push(publishWeak(hub, "trigger"));
+    if (mode === "reentrant-return") {
+      assert.ok(returned, "The filter must actually return the entered iterator");
+      await returned;
+    }
+  }
+}
+
+let failed = false;
+let failure: unknown;
+try {
+  const gc = globalThis.gc;
+  assert.ok(gc, "The retirement probe requires --expose-gc");
+  const control = new WeakRef({ uncached: true });
+  for (const mode of ["return", "filter-error", "reentrant-return", "hub-close"] as const) {
+    await prepare(mode);
+  }
+  report.phase = "collect";
+  // WeakRef construction keeps its target alive for the current job.
+  await setImmediate();
+  for (let pass = 0; pass < 8; pass++) {
+    gc();
+    await setImmediate();
+    report.gcPasses++;
+  }
+  report.phase = "observe";
+  report.controlRetained = control.deref() !== undefined;
+  report.observations = held.flatMap(({ mode, refs }) =>
+    refs.map(({ kind, value }) => ({ mode, kind, retained: value.deref() !== undefined })),
+  );
+  if (report.controlRetained) {
+    report.verdict = "gc-inconclusive";
+    throw new Error("Uncached control retained; no payload-retention conclusion");
+  }
+  report.phase = "verify-visible-contract";
+  for (const { mode, iterator, refs } of held) {
+    if (mode === "hub-close") {
+      const expected = refs[0]?.value.deref();
+      assert.ok(expected, "Hub close must retain its unread event for draining");
+      const next = await iterator.next();
+      assert.equal(next.done, false);
+      assert.equal(next.value, expected);
+      report.hubCloseDrained = true;
+    }
+    if (mode === "filter-error") {
+      await assert.rejects(iterator.next(), /synthetic filter retirement/);
+      report.terminalBehavior.push({ mode, outcome: "filter-error" });
+    } else {
+      assert.deepEqual(await iterator.next(), { done: true, value: undefined });
+      report.terminalBehavior.push({ mode, outcome: "done" });
+    }
+  }
+  report.phase = "verify-retirement";
+  report.verdict = "retention-failed";
+  const retainedRetired = report.observations.filter(
+    ({ mode, retained }) => mode !== "hub-close" && retained,
+  );
+  assert.deepEqual(
+    retainedRetired,
+    [],
+    "Retired iterators must release backlog and reentrant payloads",
+  );
+  report.verdict = "passed";
+} catch (error) {
+  failed = true;
+  failure = error;
+  report.error = reason(error);
+} finally {
+  for (const { hub, iterator } of held) {
+    try {
+      await iterator.return?.();
+    } catch (error) {
+      report.cleanupErrors.push(reason(error));
+      failed = true;
+      failure ??= error;
+    } finally {
+      hub.close();
+    }
+  }
+  if (report.cleanupErrors.length > 0) {
+    report.verdict = "cleanup-failed";
+  }
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+}
+if (failed) {
+  throw failure;
+}

--- a/packages/sdk/src/event-hub.test.ts
+++ b/packages/sdk/src/event-hub.test.ts
@@ -1,7 +1,101 @@
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { runNodeScript } from "../../../test/helpers/run-node-script.js";
 import { EventHub } from "./event-hub.js";
 
 describe("EventHub subscriber ownership", () => {
+  it("releases retired iterator payloads without discarding a closed hub's unread event", async ({
+    signal,
+  }) => {
+    const result = await runNodeScript(
+      [
+        "--expose-gc",
+        "--import",
+        "./scripts/tsx.mjs",
+        fileURLToPath(new URL("./event-hub.retention.test-support.ts", import.meta.url)),
+      ],
+      { ...process.env, NODE_OPTIONS: "", TSX_DISABLE_CACHE: "1" },
+      15_000,
+      {
+        cwd: fileURLToPath(new URL("../../../", import.meta.url)),
+        signal,
+        maxBuffer: 64 * 1024,
+        requireProcessTreeExit: process.platform !== "win32",
+      },
+    );
+    expect(result.error, result.stderr).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      verdict: "passed",
+      controlRetained: false,
+      hubCloseDrained: true,
+      cleanupErrors: [],
+    });
+  }, 30_000);
+
+  it("keeps buffered bursts ordered when publishing resumes during a partial drain", async () => {
+    const hub = new EventHub<number | undefined>();
+    const iterator = hub.stream()[Symbol.asyncIterator]();
+    const first = Array.from({ length: 4097 }, (_, index) => (index % 17 ? index : undefined));
+    const second = Array.from({ length: 2051 }, (_, index) => index + 4097);
+    for (const event of first) {
+      hub.publish(event);
+    }
+
+    const seen: Array<number | undefined> = [];
+    for (let index = 0; index < 2500; index++) {
+      const event = await iterator.next();
+      expect(event.done).toBe(false);
+      seen.push(event.value);
+    }
+    for (const event of second) {
+      hub.publish(event);
+    }
+    hub.close();
+    while (true) {
+      const event = await iterator.next();
+      if (event.done) {
+        break;
+      }
+      seen.push(event.value);
+    }
+
+    expect(seen).toEqual([...first, ...second]);
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+  });
+
+  it("drains undefined payloads before propagating an explicit undefined close error", async () => {
+    const hub = new EventHub<number | undefined>();
+    const iterator = hub.stream()[Symbol.asyncIterator]();
+    hub.publish(0);
+    hub.publish(undefined);
+    hub.close(undefined);
+
+    await expect(iterator.next()).resolves.toEqual({ done: false, value: 0 });
+    await expect(iterator.next()).resolves.toEqual({ done: false, value: undefined });
+    await expect(iterator.next()).rejects.toBeUndefined();
+  });
+
+  it("preserves nested publish order when a subscriber filter emits another event", async () => {
+    const hub = new EventHub<string>();
+    const filteredStream = hub.stream((event) => {
+      if (event === "outer") {
+        hub.publish("inner");
+      }
+      return true;
+    });
+    const filtered = filteredStream[Symbol.asyncIterator]();
+    const healthy = hub.stream()[Symbol.asyncIterator]();
+    hub.publish("outer");
+    hub.close();
+
+    for (const iterator of [filtered, healthy]) {
+      await expect(iterator.next()).resolves.toEqual({ done: false, value: "inner" });
+      await expect(iterator.next()).resolves.toEqual({ done: false, value: "outer" });
+      await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+    }
+  });
+
   it("isolates a failing filter from healthy event streams", async () => {
     const hub = new EventHub<string>();
     const failedStream = hub.stream(() => {

--- a/packages/sdk/src/event-hub.ts
+++ b/packages/sdk/src/event-hub.ts
@@ -66,7 +66,8 @@ export class EventHub<T> {
   stream(filter?: (event: T) => boolean, options: EventStreamOptions = {}): AsyncIterable<T> {
     return {
       [Symbol.asyncIterator]: (): AsyncIterator<T> => {
-        const queue: T[] = options.replay ? this.snapshot(filter) : [];
+        let queue: (T | undefined)[] = options.replay ? this.snapshot(filter) : [];
+        let queueHead = 0;
         let stopped = false;
         let streamError: unknown;
         let hasStreamError = false;
@@ -93,6 +94,8 @@ export class EventHub<T> {
             return;
           }
           stopped = true;
+          // Iterator retirement discards its backlog; hub close alone still permits draining.
+          queue.length = 0;
           this.listeners.delete(listener);
           finishPendingReads();
         };
@@ -106,7 +109,8 @@ export class EventHub<T> {
             cleanup();
             return;
           }
-          if (!matches) {
+          // A filter can synchronously return this iterator before publication resumes.
+          if (!matches || stopped) {
             return;
           }
           const pending = pendingReads.shift();
@@ -131,8 +135,16 @@ export class EventHub<T> {
               }
               return { done: true, value: undefined };
             }
-            if (queue.length > 0) {
-              return { done: false, value: queue.shift() as T };
+            if (queueHead < queue.length) {
+              const value = queue[queueHead] as T;
+              // Release consumed payloads immediately; lagging consumers compact only
+              // after a substantial prefix reaches half the buffer, amortizing dequeue.
+              queue[queueHead++] = undefined;
+              if (queueHead >= 1024 && queueHead * 2 >= queue.length) {
+                queue = queue.slice(queueHead);
+                queueHead = 0;
+              }
+              return { done: false, value };
             }
             if (!this.closed) {
               return await new Promise<IteratorResult<T>>((resolve, reject) => {


### PR DESCRIPTION
## What Problem This Solves

SDK event iterators retain unread payloads after the caller returns the iterator or its filter fails. A filter can also return its own iterator while publication is in progress, allowing the entered listener to enqueue another payload after retirement. Separately, draining a buffered burst repeatedly calls Array.shift.

## Why This Change Was Made

The iterator's cleanup owner now releases its queue. Publication rechecks the iterator's stopped state after calling a filter, preventing reentrant retirement from reacquiring buffered payloads. Ordinary hub closure still permits queued events to drain before done or a close error; it does not prematurely retire each iterator.

Buffered reads use a cursor, clear consumed slots immediately, and compact after a substantial consumed prefix reaches half the backing array. Replay, pending-read reservations, ordering, undefined payloads and public APIs remain unchanged. Production grows 12 lines to give the subscriber queue explicit consumption and retirement ownership; test/test-support growth is 239 lines. No configuration, dependency, storage schema or new queue abstraction.

## User Impact

Closed iterators release payload references, and several measured burst/replay workloads drain faster. Small/control cases can be slower; this is not a uniform latency or whole-process memory reduction claim.

## Evidence

The new actual-GC regression failed on the original main implementation for the intended retention assertion: returned/filter-failed backlogs and the event published after reentrant return stayed reachable while the uncached control collected. The repaired source releases those references while preserving ordinary hub-close draining by identity. The final regression passed. Separate consumed-reference probes preserve release of consumed events and ownership of the next unread event.

82 tests across six SDK suites passed, including real loopback WebSocket coverage. All 28 normal checks have qualified completion: 14 initial passes, five more after a test-support optional-access type fix, then the last nine after a formatter-sensitive expression became a named stream local. The final helper also passed its GC regression again. Both intermediate failures remain recorded; this is not one uninterrupted check run. Fresh independent Codex review found no actionable issues.

Fixed Node 26.8.1 comparison against `1594ebfcb945d852b1745753e16862c0d5b786dc`: Bgc/Cgc, then B0/C0/C1/B1; 2,112 complete lifecycle outcomes, 512 batch means, six consumed-GC cases. Independent audit decoded all outcomes and recomputed every statistic. JSON establishes value/sequence parity; object identity comes from the original executed strict assertions, not from JSON reconstruction.

R2 buffer medians improved 39.75%/27.81% for 1,000 events and 13.88%/26.23% for 10,000; four subscribers improved 25.49%/23.54%, replay drain 24.56%/20.69%. Adverse controls remain: one-event buffering +7.41%/+28.88%, explicit-undefined close +14.90%/+15.48%, reverse filter-error +8.80%, and reverse return-discard +4.72%. Overall, 9/32 medians, 14 means and 15 maximum batch means were adverse. The largest maximum-batch increases were +491.92% for a 20-event forward case and +224.79% for reverse filter-error. These are batch means, not individual latency percentiles.

Whole-child wall changed only −0.0546%/−1.3089%; reverse RSS and system CPU increased slightly. No Gateway/provider or overall SDK latency claim. The earlier dequeue-only candidate and its 1,000-event regressions remain separate evidence; R1/R2 timings are not pooled or treated as an isolated measurement of the retirement fix. All measured child processes closed and candidate source was restored.
