### PR TITLE
fix(ci): keep FRV on the selected GitHub transport

### DIFF
--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -19,9 +19,10 @@ import {
   validateReleaseStateArtifact,
 } from "./full-release-validation-policy.mjs";
 import { requireOptionArgument } from "./lib/arg-utils.mts";
-import { execGhRead } from "./lib/plain-gh.mjs";
+import { execPlainGh } from "./lib/plain-gh.mjs";
 import { parseReleaseContextRef, resolveReleaseContextIdentity } from "./lib/release-context.mjs";
 
+const REPOSITORY = "openclaw/openclaw";
 const WORKFLOW = "full-release-validation.yml";
 const TRUSTED_WORKFLOW_PATH = `.github/workflows/${WORKFLOW}`;
 const RELEASE_ISOLATION_TOOLING_CONTRACT = "2";
@@ -36,6 +37,7 @@ export const FULL_RELEASE_GITHUB_POLL_INTERVAL_MS = 2 * 60_000;
 const FULL_RELEASE_PROGRESS_INTERVAL_MS = 15 * 60_000;
 const FULL_RELEASE_RUN_DISCOVERY_DELAYS_MS = [30_000, 60_000, 120_000];
 const RELEASE_DECISION_FILE = "full-release-decision.json";
+const GH_NO_CACHE_HEADER = "Cache-Control: max-age=0";
 const GH_READ_OPTIONS = {
   encoding: "utf8",
   killSignal: "SIGKILL",
@@ -156,6 +158,137 @@ function runStatus(command: string, args: string[], options: CommandOptions = {}
     stdio: options.stdio ?? ["ignore", "pipe", "inherit"],
     timeout: options.timeoutMs ?? GH_READ_TIMEOUT_MS,
   });
+}
+
+function runGh(args: string[], options: CommandOptions = {}) {
+  if (options.dryRun) {
+    console.log(["+", "gh", ...args].join(" "));
+    return "";
+  }
+  const output = execPlainGh(args, {
+    encoding: "utf8",
+    stdio: options.stdio ?? ["ignore", "pipe", "inherit"],
+    ...(options.timeoutMs === undefined ? {} : { timeout: options.timeoutMs }),
+  });
+  return typeof output === "string" ? output.trim() : "";
+}
+
+function runGhStatus(args: string[], options: CommandOptions = {}): CommandStatus {
+  try {
+    return {
+      signal: null,
+      status: 0,
+      stderr: "",
+      stdout: execPlainGh(args, {
+        encoding: "utf8",
+        killSignal: "SIGKILL",
+        stdio: options.stdio ?? ["ignore", "pipe", "inherit"],
+        timeout: options.timeoutMs ?? GH_READ_TIMEOUT_MS,
+      }),
+    };
+  } catch (error) {
+    const failure = error instanceof Error ? error : new Error(String(error));
+    const details = failure as Error & {
+      signal?: unknown;
+      status?: number | null;
+      stderr?: unknown;
+      stdout?: unknown;
+    };
+    return {
+      error: failure,
+      signal: details.signal,
+      status: details.status ?? 1,
+      stderr: details.stderr ?? "",
+      stdout: details.stdout ?? "",
+    };
+  }
+}
+
+function readGhApi(
+  endpoint: string,
+  fields: string[] = [],
+  options: ExecFileSyncOptionsWithStringEncoding = GH_READ_OPTIONS,
+) {
+  return execPlainGh(
+    ["api", "--method", "GET", endpoint, ...fields, "-H", GH_NO_CACHE_HEADER],
+    options,
+  );
+}
+
+function commandFailureMessage(error: unknown): string {
+  if (error === undefined || error === null) {
+    return "";
+  }
+  if (!(error instanceof Error)) {
+    return displayValue(error);
+  }
+  const details = error as Error & {
+    cause?: unknown;
+    stderr?: unknown;
+    stdout?: unknown;
+  };
+  const outputText = (value: unknown) => {
+    if (typeof value === "string") {
+      return value.trim();
+    }
+    return Buffer.isBuffer(value) ? value.toString("utf8").trim() : "";
+  };
+  return [
+    outputText(details.stderr),
+    outputText(details.stdout),
+    error.message,
+    details.cause === error ? "" : commandFailureMessage(details.cause),
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function createTemporaryRef(ref: string, sha: string, dryRun: boolean) {
+  try {
+    runGh(
+      [
+        "api",
+        "--method",
+        "POST",
+        `repos/${REPOSITORY}/git/refs`,
+        "-f",
+        `ref=${ref}`,
+        "-f",
+        `sha=${sha}`,
+      ],
+      { dryRun, stdio: ["ignore", "pipe", "pipe"] },
+    );
+  } catch (error) {
+    const message = commandFailureMessage(error);
+    if (!message.includes("Object does not exist")) {
+      throw new Error(message, { cause: error });
+    }
+    // The refs API cannot transfer a commit that exists only in the local
+    // object database. Preserve the shipped local-candidate contract.
+    run("git", ["push", "origin", `${sha}:${ref}`], {
+      dryRun,
+      stdio: "inherit",
+    });
+  }
+}
+
+function deleteTemporaryRefs(refs: string[], dryRun: boolean) {
+  const failures: string[] = [];
+  for (const ref of refs) {
+    try {
+      runGh(
+        ["api", "--method", "DELETE", `repos/${REPOSITORY}/git/refs/${ref.slice("refs/".length)}`],
+        {
+          dryRun,
+        },
+      );
+    } catch (error) {
+      failures.push(`${ref}: ${commandFailureMessage(error)}`);
+    }
+  }
+  if (failures.length > 0) {
+    throw new Error(`Failed to delete temporary refs: ${failures.join("; ")}`);
+  }
 }
 
 export function parseArgs(argv: string[]) {
@@ -489,29 +622,20 @@ function collectRunId(dispatchOutput: string) {
 }
 
 function findLatestRunId(branch: string, sha: string) {
-  const json = execGhRead(
-    [
-      "run",
-      "list",
-      "--workflow",
-      WORKFLOW,
-      "--branch",
-      branch,
-      "--event",
-      "workflow_dispatch",
-      "--limit",
-      "20",
-      "--json",
-      "databaseId,headSha,createdAt",
-    ],
-    GH_READ_OPTIONS,
+  const response: unknown = JSON.parse(
+    readGhApi(
+      `repos/${REPOSITORY}/actions/workflows/${WORKFLOW}/runs`,
+      ["-f", `branch=${branch}`, "-f", "event=workflow_dispatch", "-f", "per_page=20"],
+      GH_READ_OPTIONS,
+    ),
   );
-  const runs: unknown = JSON.parse(json);
-  if (!Array.isArray(runs)) {
-    throw new Error("Full Release Validation run list response was not an array");
+  if (!isJsonRecord(response) || !Array.isArray(response.workflow_runs)) {
+    throw new Error("Full Release Validation run list response was invalid");
   }
-  const match = runs.find((runItem: unknown) => isJsonRecord(runItem) && runItem.headSha === sha);
-  const databaseId = isJsonRecord(match) ? match.databaseId : undefined;
+  const match = response.workflow_runs.find(
+    (runItem: unknown) => isJsonRecord(runItem) && runItem.head_sha === sha,
+  );
+  const databaseId = isJsonRecord(match) ? match.id : undefined;
   return typeof databaseId === "string" || typeof databaseId === "number" ? String(databaseId) : "";
 }
 
@@ -520,7 +644,7 @@ function readWorkflowRun(parentRunId: string, workflowSha: string) {
     throw new Error("parent run ID must be a positive decimal");
   }
   const workflowRun: unknown = JSON.parse(
-    execGhRead(["api", `repos/openclaw/openclaw/actions/runs/${parentRunId}`], GH_READ_OPTIONS),
+    readGhApi(`repos/${REPOSITORY}/actions/runs/${parentRunId}`, [], GH_READ_OPTIONS),
   );
   if (!isJsonRecord(workflowRun)) {
     throw new Error(`Full Release Validation run ${parentRunId} returned an invalid response`);
@@ -535,8 +659,9 @@ function readWorkflowRun(parentRunId: string, workflowSha: string) {
 
 function readActiveParentJobs(parentRunId: string) {
   const response: unknown = JSON.parse(
-    execGhRead(
-      ["api", `repos/openclaw/openclaw/actions/runs/${parentRunId}/jobs?per_page=100`],
+    readGhApi(
+      `repos/${REPOSITORY}/actions/runs/${parentRunId}/jobs`,
+      ["-f", "per_page=100"],
       GH_READ_OPTIONS,
     ),
   );
@@ -584,11 +709,11 @@ export function tryReadReleaseDecision(
   parentRunId: string,
   parentRunAttempt: number,
   workflowSha: string,
-  runStatusImpl: (
-    command: string,
-    args: string[],
-    options?: CommandOptions,
-  ) => CommandStatus = runStatus,
+  runStatusImpl: (command: string, args: string[], options?: CommandOptions) => CommandStatus = (
+    _command,
+    args,
+    options,
+  ) => runGhStatus(args, options),
 ) {
   const artifactName = `full-release-decision-${parentRunId}-${parentRunAttempt}`;
   const downloadDir = mkdtempSync(join(tmpdir(), "openclaw-release-decision-"));
@@ -600,7 +725,7 @@ export function tryReadReleaseDecision(
         "download",
         parentRunId,
         "--repo",
-        "openclaw/openclaw",
+        REPOSITORY,
         "--name",
         artifactName,
         "--dir",
@@ -663,11 +788,9 @@ function releaseDecisionAvailable(parentRunId: string, parentRunAttempt: number)
   const artifactName = `full-release-decision-${parentRunId}-${parentRunAttempt}`;
   try {
     const response: unknown = JSON.parse(
-      execGhRead(
-        [
-          "api",
-          `repos/openclaw/openclaw/actions/runs/${parentRunId}/artifacts?per_page=100&name=${artifactName}`,
-        ],
+      readGhApi(
+        `repos/${REPOSITORY}/actions/runs/${parentRunId}/artifacts`,
+        ["-f", "per_page=100", "-f", `name=${artifactName}`],
         { ...GH_READ_OPTIONS, stdio: ["ignore", "pipe", "pipe"] },
       ),
     );
@@ -984,22 +1107,25 @@ function main() {
   let parentRunId: string | undefined;
   let parentConclusion = "";
   let evidenceVerified = false;
+  let targetRefCreated = false;
+  let workflowRefCreated = false;
+  let dispatchAttempted = false;
+  let operationError: Error | undefined;
   try {
-    run("git", ["push", "origin", `${targetSha}:${remoteTargetBranchRef}`], {
-      dryRun: args.dryRun,
-      stdio: "inherit",
-    });
-    run("git", ["push", "origin", `${workflowSha}:${remoteBranchRef}`], {
-      dryRun: args.dryRun,
-      stdio: "inherit",
-    });
+    createTemporaryRef(remoteTargetBranchRef, targetSha, args.dryRun);
+    targetRefCreated = true;
+    createTemporaryRef(remoteBranchRef, workflowSha, args.dryRun);
+    workflowRefCreated = true;
 
     const dispatchArgs = ["workflow", "run", WORKFLOW, "--ref", branch];
     for (const [key, value] of Object.entries(dispatchInputs)) {
       dispatchArgs.push("-f", `${key}=${value}`);
     }
 
-    const dispatchOutput = run("gh", dispatchArgs, { dryRun: args.dryRun });
+    // Once dispatch starts, the refs may be needed for GitHub reruns even when
+    // the client loses the response. Cleanup resumes only after verified success.
+    dispatchAttempted = true;
+    const dispatchOutput = runGh(dispatchArgs, { dryRun: args.dryRun });
     if (dispatchOutput) {
       console.log(dispatchOutput);
     }
@@ -1021,47 +1147,67 @@ function main() {
       }
     }
     if (!parentRunId) {
-      if (args.dryRun) {
-        return;
+      if (!args.dryRun) {
+        throw new Error("Could not determine Full Release Validation run id.");
       }
-      throw new Error("Could not determine Full Release Validation run id.");
-    }
-
-    console.log(`Parent run: https://github.com/openclaw/openclaw/actions/runs/${parentRunId}`);
-    const completedRun = waitForWorkflowRun(parentRunId, workflowSha);
-    parentConclusion = stringValue(completedRun.conclusion);
-    if (parentConclusion !== "success") {
-      throw new Error(
-        `Full Release Validation concluded ${parentConclusion.toLowerCase() || "without a conclusion"}: https://github.com/openclaw/openclaw/actions/runs/${parentRunId}`,
-      );
-    }
-    verifyReleaseEvidence(parentRunId, workflowSha, args.trustedWorkflowRef);
-    evidenceVerified = true;
-  } finally {
-    if (
-      shouldDeleteTemporaryWorkflowRef({
-        keepBranch: args.keepBranch,
-        dryRun: args.dryRun,
-        parentConclusion,
-        evidenceVerified,
-      })
-    ) {
-      run("git", ["push", "origin", `:${remoteBranchRef}`, `:${remoteTargetBranchRef}`], {
-        dryRun: args.dryRun,
-        stdio: "inherit",
-      });
     } else {
-      const keptRefs = `${remoteBranchRef} and ${remoteTargetBranchRef}`;
-      console.warn(
-        args.keepBranch
-          ? `Kept ${keptRefs}`
-          : `Kept ${keptRefs}: ${
-              parentConclusion === "success"
-                ? "release evidence was not verified"
-                : `parent concluded ${parentConclusion || "without a conclusion"}`
-            }. Keep it through GitHub reruns or evidence diagnosis; delete it after verified success.`,
-      );
+      console.log(`Parent run: https://github.com/openclaw/openclaw/actions/runs/${parentRunId}`);
+      const completedRun = waitForWorkflowRun(parentRunId, workflowSha);
+      parentConclusion = stringValue(completedRun.conclusion);
+      if (parentConclusion !== "success") {
+        throw new Error(
+          `Full Release Validation concluded ${parentConclusion.toLowerCase() || "without a conclusion"}: https://github.com/openclaw/openclaw/actions/runs/${parentRunId}`,
+        );
+      }
+      verifyReleaseEvidence(parentRunId, workflowSha, args.trustedWorkflowRef);
+      evidenceVerified = true;
     }
+  } catch (error) {
+    operationError = error instanceof Error ? error : new Error(String(error));
+  }
+
+  const createdRefs = [
+    ...(workflowRefCreated ? [remoteBranchRef] : []),
+    ...(targetRefCreated ? [remoteTargetBranchRef] : []),
+  ];
+  const cleanupBeforeDispatch = !dispatchAttempted && createdRefs.length > 0;
+  const cleanupAfterSuccess = shouldDeleteTemporaryWorkflowRef({
+    keepBranch: args.keepBranch,
+    dryRun: args.dryRun,
+    parentConclusion,
+    evidenceVerified,
+  });
+  let cleanupError: Error | undefined;
+  if (cleanupBeforeDispatch || cleanupAfterSuccess) {
+    try {
+      deleteTemporaryRefs(createdRefs, args.dryRun);
+    } catch (error) {
+      cleanupError = error instanceof Error ? error : new Error(String(error));
+    }
+  } else if (createdRefs.length > 0) {
+    const keptRefs = createdRefs.join(" and ");
+    console.warn(
+      args.keepBranch
+        ? `Kept ${keptRefs}`
+        : `Kept ${keptRefs}: ${
+            parentConclusion === "success"
+              ? "release evidence was not verified"
+              : `parent concluded ${parentConclusion || "without a conclusion"}`
+          }. Keep it through GitHub reruns or evidence diagnosis; delete it after verified success.`,
+    );
+  }
+
+  if (operationError && cleanupError) {
+    throw new Error(
+      `${commandFailureMessage(operationError)}; temporary ref cleanup also failed: ${commandFailureMessage(cleanupError)}`,
+      { cause: new AggregateError([operationError, cleanupError]) },
+    );
+  }
+  if (operationError) {
+    throw operationError;
+  }
+  if (cleanupError) {
+    throw cleanupError;
   }
 }
 

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -56,6 +56,9 @@ function runGit(cwd: string, args: string[]): string {
 
 function createDispatchFixture(
   options: {
+    createRefFailure?: "target" | "workflow";
+    deleteRefFailures?: Array<"target" | "workflow">;
+    dispatchFailure?: boolean;
     dispatchReturnsRunUrl?: boolean;
     parentRunStates?: Array<{
       conclusion: string | null;
@@ -68,6 +71,8 @@ function createDispatchFixture(
       decisionAttempt?: number;
     }>;
     runDiscoveryMisses?: number;
+    targetAlreadyRemote?: boolean;
+    includeTargetRef?: boolean;
     workflowSource?: string;
   } = {},
 ) {
@@ -77,6 +82,7 @@ function createDispatchFixture(
   const binDir = join(root, "bin");
   const gitCallsPath = join(root, "git-calls.jsonl");
   const ghCallsPath = join(root, "gh-calls.jsonl");
+  const pathGhCallsPath = join(root, "path-gh-calls.jsonl");
   const parentRunIndexPath = join(root, "parent-run-index.txt");
   const runDiscoveryIndexPath = join(root, "run-discovery-index.txt");
   const preloadPath = join(root, "immediate-poll.mjs");
@@ -86,6 +92,7 @@ function createDispatchFixture(
   mkdirSync(binDir);
   writeFileSync(gitCallsPath, "");
   writeFileSync(ghCallsPath, "");
+  writeFileSync(pathGhCallsPath, "");
   writeFileSync(parentRunIndexPath, "0");
   writeFileSync(runDiscoveryIndexPath, "0");
   writeFileSync(waitCallsPath, "");
@@ -161,7 +168,9 @@ console.log(JSON.stringify({ valid: true, current: { runId: "123" }, root: { run
   runGit(checkout, ["add", "target.txt"]);
   runGit(checkout, ["commit", "-m", "test: release target"]);
   const targetSha = runGit(checkout, ["rev-parse", "HEAD"]);
-  runGit(checkout, ["push", "-u", "origin", releaseRef]);
+  if (options.targetAlreadyRemote !== false) {
+    runGit(checkout, ["push", "-u", "origin", releaseRef]);
+  }
   runGit(checkout, ["checkout", "main"]);
 
   const gitPath = join(binDir, "git");
@@ -186,12 +195,80 @@ process.exit(result.status ?? 1);
     ghPath,
     `#!${process.execPath}
 const fs = require("node:fs");
+fs.appendFileSync(process.env.MOCK_PATH_GH_CALLS, JSON.stringify(process.argv.slice(2)) + "\\n");
+console.error("PATH gh must not be used");
+process.exit(89);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+
+  const selectedGhPath = join(binDir, "selected-gh");
+  writeFileSync(
+    selectedGhPath,
+    `#!${process.execPath}
+const fs = require("node:fs");
+const { spawnSync } = require("node:child_process");
 const args = process.argv.slice(2);
 fs.appendFileSync(process.env.MOCK_GH_CALLS, JSON.stringify(args) + "\\n");
 const parentRunStates = ${JSON.stringify(options.parentRunStates ?? [{ conclusion: "success", status: "completed" }])};
 const parentRunIndexPath = ${JSON.stringify(parentRunIndexPath)};
 const runDiscoveryIndexPath = ${JSON.stringify(runDiscoveryIndexPath)};
-if (args[0] === "workflow" && args[1] === "run") {
+const endpoint = args.find((arg) => arg.startsWith("repos/openclaw/openclaw/")) || "";
+const methodIndex = args.indexOf("--method");
+const method = methodIndex >= 0 ? args[methodIndex + 1] : "GET";
+const fields = new Map();
+for (let index = 0; index < args.length; index += 1) {
+  if (args[index] !== "-f") continue;
+  const assignment = args[index + 1] || "";
+  const separator = assignment.indexOf("=");
+  fields.set(assignment.slice(0, separator), assignment.slice(separator + 1));
+  index += 1;
+}
+const hasNoCache = args.some(
+  (arg, index) => ["-H", "--header"].includes(arg) && args[index + 1] === "Cache-Control: max-age=0",
+);
+if (args[0] === "api" && method === "GET" && !hasNoCache) {
+  console.error("authoritative reads require Cache-Control: max-age=0");
+  process.exit(18);
+}
+if (args[0] === "api" && method === "POST" && endpoint.endsWith("/git/refs")) {
+  const ref = fields.get("ref") || "";
+  const sha = fields.get("sha") || "";
+  const kind = ref.includes("/validation/") ? "target" : "workflow";
+  if (kind === ${JSON.stringify(options.createRefFailure ?? "")}) {
+    console.error("configured " + kind + " ref creation failure");
+    process.exit(19);
+  }
+  const object = spawnSync(
+    "git",
+    ["--git-dir", process.env.MOCK_ORIGIN, "cat-file", "-e", sha + "^{object}"],
+    {
+      env: { ...process.env, PATH: process.env.MOCK_REAL_PATH },
+      stdio: "ignore",
+    },
+  );
+  if (object.status !== 0) {
+    console.error("gh: Object does not exist (HTTP 422)");
+    process.exit(19);
+  }
+  const result = spawnSync("git", ["--git-dir", process.env.MOCK_ORIGIN, "update-ref", ref, sha], {
+    env: { ...process.env, PATH: process.env.MOCK_REAL_PATH },
+    stdio: "inherit",
+  });
+  process.exit(result.status ?? 1);
+} else if (args[0] === "api" && method === "DELETE" && endpoint.includes("/git/refs/")) {
+  const ref = "refs/" + endpoint.slice(endpoint.indexOf("/git/refs/") + "/git/refs/".length);
+  const kind = ref.includes("/validation/") ? "target" : "workflow";
+  if (${JSON.stringify(options.deleteRefFailures ?? [])}.includes(kind)) {
+    console.error("configured " + kind + " ref deletion failure");
+    process.exit(20);
+  }
+  const result = spawnSync("git", ["--git-dir", process.env.MOCK_ORIGIN, "update-ref", "-d", ref], {
+    env: { ...process.env, PATH: process.env.MOCK_REAL_PATH },
+    stdio: "inherit",
+  });
+  process.exit(result.status ?? 1);
+} else if (args[0] === "workflow" && args[1] === "run") {
   const declaredInputs = new Set(JSON.parse(process.env.MOCK_WORKFLOW_INPUTS));
   for (let index = 0; index < args.length; index += 1) {
     if (args[index] !== "-f") continue;
@@ -203,21 +280,25 @@ if (args[0] === "workflow" && args[1] === "run") {
     }
     index += 1;
   }
+  if (${JSON.stringify(options.dispatchFailure ?? false)}) {
+    console.error("configured workflow dispatch failure");
+    process.exit(21);
+  }
   if (${JSON.stringify(options.dispatchReturnsRunUrl ?? true)}) {
     console.log("https://github.com/openclaw/openclaw/actions/runs/123");
   }
-} else if (args[0] === "run" && args[1] === "list") {
+} else if (args[0] === "api" && endpoint.endsWith("/actions/workflows/full-release-validation.yml/runs")) {
   const index = Number(fs.readFileSync(runDiscoveryIndexPath, "utf8"));
   fs.writeFileSync(runDiscoveryIndexPath, String(index + 1));
-  console.log(JSON.stringify(index < ${JSON.stringify(options.runDiscoveryMisses ?? 0)}
+  console.log(JSON.stringify({ workflow_runs: index < ${JSON.stringify(options.runDiscoveryMisses ?? 0)}
     ? []
-    : [{ databaseId: 123, headSha: process.env.MOCK_WORKFLOW_SHA, createdAt: "2026-08-28T00:00:00Z" }]));
-} else if (args[0] === "api" && args.at(-1).endsWith("/actions/runs/123")) {
+    : [{ id: 123, head_sha: process.env.MOCK_WORKFLOW_SHA, created_at: "2026-08-28T00:00:00Z" }] }));
+} else if (args[0] === "api" && endpoint.endsWith("/actions/runs/123")) {
   const index = Number(fs.readFileSync(parentRunIndexPath, "utf8"));
   const state = parentRunStates[Math.min(index, parentRunStates.length - 1)];
   fs.writeFileSync(parentRunIndexPath, String(index + 1));
   console.log(JSON.stringify({ ...state, head_sha: process.env.MOCK_WORKFLOW_SHA, run_attempt: state.attempt ?? 1 }));
-} else if (args[0] === "api" && args.at(-1).includes("/artifacts?")) {
+} else if (args[0] === "api" && endpoint.endsWith("/artifacts")) {
   const index = Number(fs.readFileSync(parentRunIndexPath, "utf8")) - 1;
   const state = parentRunStates[index];
   if (state.metadataError) {
@@ -227,7 +308,7 @@ if (args[0] === "workflow" && args[1] === "run") {
   console.log(JSON.stringify({ artifacts: state.artifacts ?? (state.artifactReady ? [{
     name: "full-release-decision-123-" + (state.attempt ?? 1), expired: false,
   }] : []) }));
-} else if (args[0] === "api" && args.at(-1).includes("/jobs?")) {
+} else if (args[0] === "api" && endpoint.endsWith("/jobs")) {
   console.log(JSON.stringify({ jobs: [{ name: "Diagnostic Drain", status: "in_progress" }] }));
 } else if (args[0] === "run" && args[1] === "download") {
   const index = Number(fs.readFileSync(parentRunIndexPath, "utf8")) - 1;
@@ -254,7 +335,7 @@ if (args[0] === "workflow" && args[1] === "run") {
 }
 `,
   );
-  chmodSync(ghPath, 0o755);
+  chmodSync(selectedGhPath, 0o755);
 
   const run = (extraArgs: string[] = []) => {
     const trustedRefIndex = extraArgs.indexOf("--trusted-workflow-ref");
@@ -264,7 +345,13 @@ if (args[0] === "workflow" && args[1] === "run") {
       trustedWorkflowRef === "main" ? "refs/heads/main" : `refs/tags/${trustedWorkflowRef}`;
     return spawnSync(
       process.execPath,
-      [SCRIPT_PATH, "--sha", targetSha, "--target-ref", releaseRef, ...extraArgs],
+      [
+        SCRIPT_PATH,
+        "--sha",
+        targetSha,
+        ...(options.includeTargetRef === false ? [] : ["--target-ref", releaseRef]),
+        ...extraArgs,
+      ],
       {
         cwd: checkout,
         encoding: "utf8",
@@ -275,12 +362,16 @@ if (args[0] === "workflow" && args[1] === "run") {
             .join(" "),
           MOCK_GH_CALLS: ghCallsPath,
           MOCK_GIT_CALLS: gitCallsPath,
+          MOCK_ORIGIN: origin,
+          MOCK_PATH_GH_CALLS: pathGhCallsPath,
           MOCK_REAL_PATH: process.env.PATH,
           MOCK_TRUSTED_WORKFLOW_FULL_REF: trustedWorkflowFullRef,
           MOCK_TRUSTED_WORKFLOW_REF: trustedWorkflowRef,
           MOCK_WAIT_CALLS: waitCallsPath,
           MOCK_WORKFLOW_INPUTS: JSON.stringify(declaredWorkflowInputs),
           MOCK_WORKFLOW_SHA: workflowSha,
+          GH_TOKEN: "fixture-token",
+          OPENCLAW_GH_BIN: selectedGhPath,
           PATH: `${binDir}:${process.env.PATH}`,
         },
       },
@@ -302,14 +393,34 @@ if (args[0] === "workflow" && args[1] === "run") {
     gitCallsPath,
     origin,
     oldWorkflowSha,
+    pathGhCallsPath,
     readCalls,
     readWaits,
     releaseRef,
     run,
+    selectedGhPath,
     targetSha,
     trustedWorkflowTag,
     workflowSha,
   };
+}
+
+function ghApiEndpoint(args: string[]): string {
+  return args.find((arg) => arg.startsWith("repos/openclaw/openclaw/")) ?? "";
+}
+
+function ghApiMethod(args: string[]): string {
+  const index = args.indexOf("--method");
+  return index >= 0 ? (args[index + 1] ?? "") : "GET";
+}
+
+function ghField(args: string[], name: string): string {
+  const prefix = `${name}=`;
+  return (
+    args
+      .find((arg, index) => args[index - 1] === "-f" && arg.startsWith(prefix))
+      ?.slice(prefix.length) ?? ""
+  );
 }
 
 describe("full-release-validation-at-sha", () => {
@@ -728,9 +839,13 @@ describe("full-release-validation-at-sha", () => {
       expect(result.status, result.stderr).toBe(0);
       expect(fixture.readWaits()).toEqual([30_000, 120_000]);
       const calls = fixture.readCalls(fixture.ghCallsPath);
-      expect(calls.filter((args) => args[0] === "run" && args[1] === "list")).toHaveLength(2);
       expect(
-        calls.filter((args) => args[0] === "api" && args[1]?.endsWith("/actions/runs/123")),
+        calls.filter((args) =>
+          ghApiEndpoint(args).endsWith("/actions/workflows/full-release-validation.yml/runs"),
+        ),
+      ).toHaveLength(2);
+      expect(
+        calls.filter((args) => ghApiEndpoint(args).endsWith("/actions/runs/123")),
       ).toHaveLength(2);
     } finally {
       fixture.cleanup();
@@ -748,7 +863,11 @@ describe("full-release-validation-at-sha", () => {
       expect(result.stderr).toContain("Could not determine Full Release Validation run id.");
       expect(fixture.readWaits()).toEqual([30_000, 60_000, 120_000]);
       const calls = fixture.readCalls(fixture.ghCallsPath);
-      expect(calls.filter((args) => args[0] === "run" && args[1] === "list")).toHaveLength(4);
+      expect(
+        calls.filter((args) =>
+          ghApiEndpoint(args).endsWith("/actions/workflows/full-release-validation.yml/runs"),
+        ),
+      ).toHaveLength(4);
     } finally {
       fixture.cleanup();
     }
@@ -856,8 +975,8 @@ describe("full-release-validation-at-sha", () => {
   it("bounds GitHub reads without applying a timeout to workflow dispatch", () => {
     const source = readFileSync("scripts/full-release-validation-at-sha.mts", "utf8");
     expect(source).toContain("timeout: GH_READ_TIMEOUT_MS");
-    expect(source.match(/GH_READ_OPTIONS/gu)).toHaveLength(5);
-    expect(source).toContain('const dispatchOutput = run("gh", dispatchArgs');
+    expect(source).toContain("const dispatchOutput = runGh(dispatchArgs");
+    expect(source).not.toContain('run("gh"');
   });
 
   it("rejects incomplete trusted release harnesses before dispatch", () => {
@@ -983,26 +1102,53 @@ describe("full-release-validation-at-sha", () => {
         expect(result.status, result.stderr).toBe(0);
         const gitCalls = fixture.readCalls(fixture.gitCallsPath);
         const ghCalls = fixture.readCalls(fixture.ghCallsPath);
-        const targetPush = gitCalls.find(
-          (args) => args[0] === "push" && args[2]?.includes(":refs/heads/validation/target-"),
+        const createCalls = ghCalls.filter(
+          (args) =>
+            args[0] === "api" &&
+            ghApiMethod(args) === "POST" &&
+            ghApiEndpoint(args).endsWith("/git/refs"),
         );
-        expect(targetPush?.[2]).toMatch(
+        const targetCreate = createCalls.find((args) =>
+          ghField(args, "ref").startsWith("refs/heads/validation/target-"),
+        );
+        expect(ghField(targetCreate ?? [], "ref")).toMatch(
           new RegExp(
-            `^${fixture.targetSha}:refs/heads/validation/target-${fixture.targetSha.slice(0, 12)}-[0-9]+$`,
+            `^refs/heads/validation/target-${fixture.targetSha.slice(0, 12)}-[0-9]+$`,
             "u",
           ),
         );
-        const targetBranch = targetPush?.[2]?.split(":refs/heads/")[1];
-        const workflowPush = gitCalls.find(
-          (args) => args[0] === "push" && args[2]?.includes(":refs/heads/release-ci/"),
+        expect(ghField(targetCreate ?? [], "sha")).toBe(fixture.targetSha);
+        const targetBranch = ghField(targetCreate ?? [], "ref").slice("refs/heads/".length);
+        const workflowCreate = createCalls.find((args) =>
+          ghField(args, "ref").startsWith("refs/heads/release-ci/"),
         );
-        const workflowBranch = workflowPush?.[2]?.split(":refs/heads/")[1];
-        expect(workflowPush?.[2]).toMatch(
-          new RegExp(
-            `^${fixture.workflowSha}:refs/heads/release-ci/${fixture.workflowSha.slice(0, 12)}-[0-9]+$`,
-            "u",
-          ),
+        const workflowBranch = ghField(workflowCreate ?? [], "ref").slice("refs/heads/".length);
+        expect(ghField(workflowCreate ?? [], "ref")).toMatch(
+          new RegExp(`^refs/heads/release-ci/${fixture.workflowSha.slice(0, 12)}-[0-9]+$`, "u"),
         );
+        expect(ghField(workflowCreate ?? [], "sha")).toBe(fixture.workflowSha);
+        expect(createCalls).toEqual([
+          [
+            "api",
+            "--method",
+            "POST",
+            "repos/openclaw/openclaw/git/refs",
+            "-f",
+            `ref=refs/heads/${targetBranch}`,
+            "-f",
+            `sha=${fixture.targetSha}`,
+          ],
+          [
+            "api",
+            "--method",
+            "POST",
+            "repos/openclaw/openclaw/git/refs",
+            "-f",
+            `ref=refs/heads/${workflowBranch}`,
+            "-f",
+            `sha=${fixture.workflowSha}`,
+          ],
+        ]);
         const dispatch = ghCalls.find((args) => args[0] === "workflow" && args[1] === "run");
         expect(dispatch?.slice(0, 5)).toEqual([
           "workflow",
@@ -1036,9 +1182,18 @@ describe("full-release-validation-at-sha", () => {
           fullRef: "refs/heads/main",
           sha: fixture.workflowSha,
         });
-        expect(ghCalls).toContainEqual(["api", "repos/openclaw/openclaw/actions/runs/123"]);
+        expect(ghCalls.some((args) => ghApiEndpoint(args).endsWith("/actions/runs/123"))).toBe(
+          true,
+        );
         expect(ghCalls.some((args) => args[0] === "graphql")).toBe(false);
         expect(ghCalls.some((args) => args[0] === "run" && args[1] === "watch")).toBe(false);
+        for (const read of ghCalls.filter(
+          (args) => args[0] === "api" && ghApiMethod(args) === "GET",
+        )) {
+          expect(read).toContain("Cache-Control: max-age=0");
+        }
+        expect(readFileSync(fixture.pathGhCallsPath, "utf8")).toBe("");
+        expect(gitCalls.filter((args) => args[0] === "push")).toEqual([]);
         expect(result.stdout).toContain(`Validation SHA: ${fixture.targetSha}`);
         expect(result.stdout).toContain(`Tooling SHA: ${fixture.workflowSha}`);
         expect(result.stdout).toContain(
@@ -1050,11 +1205,11 @@ describe("full-release-validation-at-sha", () => {
         expect(result.stdout.indexOf("Parent run:")).toBeLessThan(
           result.stdout.indexOf("Parent run status:"),
         );
-        expect(gitCalls).toContainEqual([
-          "push",
-          "origin",
-          `:refs/heads/${workflowBranch}`,
-          `:refs/heads/${targetBranch}`,
+        expect(
+          ghCalls.filter((args) => args[0] === "api" && ghApiMethod(args) === "DELETE"),
+        ).toEqual([
+          ["api", "--method", "DELETE", `repos/openclaw/openclaw/git/refs/heads/${workflowBranch}`],
+          ["api", "--method", "DELETE", `repos/openclaw/openclaw/git/refs/heads/${targetBranch}`],
         ]);
         expect(runGit(fixture.origin, ["for-each-ref", "--format=%(refname)", "refs/heads"])).toBe(
           [
@@ -1068,6 +1223,130 @@ describe("full-release-validation-at-sha", () => {
       }
     },
   );
+
+  it.each([
+    { failure: "target" as const, created: 0, deleted: 0 },
+    { failure: "workflow" as const, created: 1, deleted: 1 },
+  ])(
+    "cleans only refs created before a $failure ref creation failure",
+    ({ failure, created, deleted }) => {
+      const fixture = createDispatchFixture({ createRefFailure: failure });
+      try {
+        const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain(`configured ${failure} ref creation failure`);
+        const calls = fixture.readCalls(fixture.ghCallsPath);
+        const createCalls = calls.filter(
+          (args) => args[0] === "api" && ghApiMethod(args) === "POST",
+        );
+        const deleteCalls = calls.filter(
+          (args) => args[0] === "api" && ghApiMethod(args) === "DELETE",
+        );
+        expect(createCalls).toHaveLength(created + 1);
+        expect(deleteCalls).toHaveLength(deleted);
+        if (failure === "workflow") {
+          const targetRef = ghField(createCalls[0] ?? [], "ref");
+          expect(deleteCalls).toEqual([
+            [
+              "api",
+              "--method",
+              "DELETE",
+              `repos/openclaw/openclaw/git/refs/${targetRef.slice("refs/".length)}`,
+            ],
+          ]);
+        }
+        expect(calls.some((args) => args[0] === "workflow" && args[1] === "run")).toBe(false);
+        expect(
+          fixture.readCalls(fixture.gitCallsPath).filter((args) => args[0] === "push"),
+        ).toEqual([]);
+        expect(
+          runGit(fixture.origin, [
+            "for-each-ref",
+            "--format=%(refname)",
+            "refs/heads/release-ci",
+            "refs/heads/validation",
+          ]),
+        ).toBe("");
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it("uploads a local-only candidate before creating its temporary ref", () => {
+    const fixture = createDispatchFixture({
+      includeTargetRef: false,
+      targetAlreadyRemote: false,
+    });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stderr).toBe(0);
+      const ghCalls = fixture.readCalls(fixture.ghCallsPath);
+      const targetCreate = ghCalls.find(
+        (args) =>
+          args[0] === "api" &&
+          ghApiMethod(args) === "POST" &&
+          ghField(args, "ref").startsWith("refs/heads/validation/target-"),
+      );
+      expect(targetCreate).toBeDefined();
+      const targetRef = ghField(targetCreate ?? [], "ref");
+      const pushes = fixture.readCalls(fixture.gitCallsPath).filter((args) => args[0] === "push");
+      expect(pushes).toEqual([["push", "origin", `${fixture.targetSha}:${targetRef}`]]);
+      expect(runGit(fixture.origin, ["cat-file", "-e", `${fixture.targetSha}^{commit}`])).toBe("");
+      expect(
+        runGit(fixture.origin, [
+          "for-each-ref",
+          "--format=%(refname)",
+          "refs/heads/release-ci",
+          "refs/heads/validation",
+        ]),
+      ).toBe("");
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("retains both refs after workflow dispatch is attempted", () => {
+    const fixture = createDispatchFixture({ dispatchFailure: true });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("configured workflow dispatch failure");
+      const calls = fixture.readCalls(fixture.ghCallsPath);
+      expect(calls.filter((args) => args[0] === "api" && ghApiMethod(args) === "DELETE")).toEqual(
+        [],
+      );
+      expect(
+        runGit(fixture.origin, [
+          "for-each-ref",
+          "--format=%(refname)",
+          "refs/heads/release-ci",
+          "refs/heads/validation",
+        ]).split("\n"),
+      ).toHaveLength(2);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("attempts both ref deletions and reports every cleanup failure", () => {
+    const fixture = createDispatchFixture({ deleteRefFailures: ["workflow", "target"] });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Failed to delete temporary refs");
+      expect(result.stderr).toContain("configured workflow ref deletion failure");
+      expect(result.stderr).toContain("configured target ref deletion failure");
+      const deleteCalls = fixture
+        .readCalls(fixture.ghCallsPath)
+        .filter((args) => args[0] === "api" && ghApiMethod(args) === "DELETE");
+      expect(deleteCalls).toHaveLength(2);
+      expect(ghApiEndpoint(deleteCalls[0] ?? [])).toContain("/git/refs/heads/release-ci/");
+      expect(ghApiEndpoint(deleteCalls[1] ?? [])).toContain("/git/refs/heads/validation/target-");
+    } finally {
+      fixture.cleanup();
+    }
+  });
 
   it("retries an absent decision artifact through a parent status regression", () => {
     const fixture = createDispatchFixture({
@@ -1084,7 +1363,7 @@ describe("full-release-validation-at-sha", () => {
       const calls = fixture.readCalls(fixture.ghCallsPath);
       const parentPolls = calls
         .map((args, index) => ({ args, index }))
-        .filter(({ args }) => args[0] === "api" && args[1]?.endsWith("/actions/runs/123"));
+        .filter(({ args }) => ghApiEndpoint(args).endsWith("/actions/runs/123"));
       const artifactDownloads = calls
         .map((args, index) => ({ args, index }))
         .filter(({ args }) => args[0] === "run" && args[1] === "download");
@@ -1116,7 +1395,7 @@ describe("full-release-validation-at-sha", () => {
       expect(result.status, result.stderr).toBe(0);
       const calls = fixture.readCalls(fixture.ghCallsPath);
       expect(
-        calls.filter((args) => args[0] === "api" && args[1]?.endsWith("/actions/runs/123")),
+        calls.filter((args) => ghApiEndpoint(args).endsWith("/actions/runs/123")),
       ).toHaveLength(5);
       expect(calls.filter((args) => args[0] === "run" && args[1] === "download")).toHaveLength(2);
     } finally {
@@ -1202,12 +1481,8 @@ describe("full-release-validation-at-sha", () => {
       expect(result.status, result.stderr).toBe(0);
       const calls = fixture.readCalls(fixture.ghCallsPath);
       expect(calls.filter((args) => args[0] === "run" && args[1] === "download")).toHaveLength(1);
-      expect(calls.filter((args) => args[0] === "api" && args[1]?.includes("/jobs?"))).toHaveLength(
-        1,
-      );
-      expect(
-        calls.filter((args) => args[0] === "api" && args[1]?.includes("/artifacts?")),
-      ).toHaveLength(10);
+      expect(calls.filter((args) => ghApiEndpoint(args).endsWith("/jobs"))).toHaveLength(1);
+      expect(calls.filter((args) => ghApiEndpoint(args).endsWith("/artifacts"))).toHaveLength(10);
       expect(fixture.readWaits()).toEqual(Array(10).fill(120_000));
     } finally {
       fixture.cleanup();
@@ -1451,10 +1726,11 @@ describe("full-release-validation-at-sha", () => {
       const result = fixture.run(["--workflow-sha", fixture.workflowSha, "--keep-branch"]);
       expect(result.status, result.stderr).toBe(0);
       const gitCalls = fixture.readCalls(fixture.gitCallsPath);
+      expect(gitCalls.filter((args) => args[0] === "push")).toEqual([]);
       expect(
-        gitCalls.some(
-          (args) => args[0] === "push" && args.slice(2).some((value) => value.startsWith(":")),
-        ),
+        fixture
+          .readCalls(fixture.ghCallsPath)
+          .some((args) => args[0] === "api" && ghApiMethod(args) === "DELETE"),
       ).toBe(false);
       const remoteRefs = runGit(fixture.origin, [
         "for-each-ref",
@@ -1496,8 +1772,12 @@ describe("full-release-validation-at-sha", () => {
             ...process.env,
             MOCK_GH_CALLS: fixture.ghCallsPath,
             MOCK_GIT_CALLS: fixture.gitCallsPath,
+            MOCK_ORIGIN: fixture.origin,
+            MOCK_PATH_GH_CALLS: fixture.pathGhCallsPath,
             MOCK_REAL_PATH: process.env.PATH,
             MOCK_WORKFLOW_SHA: fixture.workflowSha,
+            GH_TOKEN: "fixture-token",
+            OPENCLAW_GH_BIN: fixture.selectedGhPath,
             PATH: `${join(fixture.checkout, "..", "bin")}:${process.env.PATH}`,
           },
         },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation could fail before workflow dispatch when the selected authenticated GitHub transport differed from the machine's native `git` or `gh` credentials.

## Why This Change Was Made

The exact-SHA helper now routes temporary ref lifecycle, workflow dispatch, authoritative reads, and evidence downloads through the existing selected GitHub CLI boundary. It cleans partial pre-dispatch ref creation, retains refs after dispatch uncertainty, and attempts both deletions after verified success.

When GitHub reports that a candidate object exists only in the local repository, the helper preserves the shipped `git push <sha>:<ref>` object-transfer path rather than silently dropping local-only candidate support.

## User Impact

Release-validation operators can use the authenticated `OPENCLAW_GH_BIN` transport consistently for remote commits while retaining validation of newly committed local candidates.

## Evidence

- `node --import ./scripts/tsx.mjs scripts/test-projects.mts test/scripts/full-release-validation-at-sha.test.ts`
- 59 tests passed on exact head `f90a2dd81a2`
- `node --import tsx scripts/run-oxlint-shards.mts --only=scripts --threads=1`
- `pnpm exec oxfmt --check scripts/full-release-validation-at-sha.mts test/scripts/full-release-validation-at-sha.test.ts`
- Regression coverage proves a candidate absent from the remote object database is transferred before its temporary ref is created.
- Live non-release transport smoke created, read with `Cache-Control: max-age=0`, and deleted a temporary `validation/transport-smoke-*` ref.
- Post-fix autoreview: scoped clean.
- No workflow was dispatched and no release surface was invoked.
