### PR TITLE
fix(codex): carry selected models into prompt hooks

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-context.ts
+++ b/extensions/codex/src/app-server/run-attempt-context.ts
@@ -107,6 +107,12 @@ export async function prepareCodexAttemptContext(
     sessionKey: contextSessionKey,
     sessionId: params.sessionId,
     workspaceDir: params.workspaceDir,
+    // Native-owned models are confirmed after startup; hooks must not publish
+    // stale bindings or private transport overrides as the selected model.
+    ...(!usesSupervisionConnection &&
+    connection.mutable.startupBinding?.preserveNativeModel !== true
+      ? { modelProviderId: params.provider, modelId: params.modelId }
+      : {}),
     trigger: params.trigger,
     ...buildAgentHookContextChannelFields({
       sessionKey: contextSessionKey,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3405,7 +3405,12 @@ describe("runCodexAppServerAttempt", () => {
     const sessionManager = openRunSession(sessionFile);
     sessionManager.appendMessage(assistantMessage("previous turn", Date.now()));
     const harness = createStartedThreadHarness();
-    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
+    const params = createParams(sessionFile, workspaceDir, { provider: "openai" });
+    params.config = {
+      ...params.config,
+      agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
+    };
+    const run = runCodexAppServerAttempt(params);
     await harness.waitForMethod("turn/start");
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
@@ -3429,6 +3434,10 @@ describe("runCodexAppServerAttempt", () => {
     ]);
     expect(hookContext.runId).toBe("run-1");
     expect(hookContext.sessionId).toBe("session-1");
+    expect(hookContext).toMatchObject({
+      modelProviderId: params.provider,
+      modelId: params.modelId,
+    });
     const threadStart = harness.requests.find((request) => request.method === "thread/start");
     const threadStartParams = threadStart?.params as { developerInstructions?: string } | undefined;
     const wrappedPluginSystemContext = (text: string) =>
@@ -7346,12 +7355,16 @@ describe("runCodexAppServerAttempt", () => {
   it("retains the prepared execution model across native resume without exposing it in lifecycle events", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
     const runtimeModelId = "test-runtime-model";
+    const beforePromptBuild = vi.fn(() => undefined);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_prompt_build", handler: beforePromptBuild }]),
+    );
     const freshHarness = createStartedThreadHarness(
       async (method) =>
         method === "thread/start" ? { ...threadStartResult(), model: runtimeModelId } : undefined,
       { persistedThreads: [] },
     );
-    const params = createParams(sessionFile, workspaceDir);
+    const params = createParams(sessionFile, workspaceDir, { provider: "openai" });
     params.modelId = "gpt-5.6-sol";
     params.model = {
       ...params.model,
@@ -7366,6 +7379,10 @@ describe("runCodexAppServerAttempt", () => {
 
     const freshRun = runCodexAppServerAttempt(params, { runtimeModelId });
     await completeStartedRun(freshRun, freshHarness.waitForMethod, freshHarness.completeTurn);
+    expect(mockCall(beforePromptBuild, "before_prompt_build", -1)[1]).toMatchObject({
+      modelProviderId: params.provider,
+      modelId: params.modelId,
+    });
 
     for (const method of ["thread/start", "turn/start"]) {
       expect(freshHarness.requests.find((entry) => entry.method === method)).toMatchObject({
@@ -7391,6 +7408,10 @@ describe("runCodexAppServerAttempt", () => {
       { runtimeModelId },
     );
     await completeStartedRun(resumedRun, resumedHarness.waitForMethod, resumedHarness.completeTurn);
+    expect(mockCall(beforePromptBuild, "before_prompt_build", -1)[1]).toMatchObject({
+      modelProviderId: params.provider,
+      modelId: params.modelId,
+    });
 
     expectResumeRequest(resumedHarness.requests, {
       threadId: "thread-1",
@@ -7676,6 +7697,10 @@ describe("runCodexAppServerAttempt", () => {
   it("rejects a newly observed native model before inference with stale prepared host auth", async () => {
     const { sessionFile, workspaceDir, agentDir } = createRunPaths();
     const modelRef = { provider: "openai", model: "gpt-5.5" };
+    const beforePromptBuild = vi.fn(() => undefined);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_prompt_build", handler: beforePromptBuild }]),
+    );
     await writeExistingBinding(sessionFile, workspaceDir, {
       preserveNativeModel: true,
       authProfileId: "openai:host",
@@ -7719,6 +7744,10 @@ describe("runCodexAppServerAttempt", () => {
       }
       return error;
     });
+    expect(beforePromptBuild).toHaveBeenCalled();
+    const hookContext = mockCall(beforePromptBuild, "before_prompt_build")[1];
+    expect(hookContext).not.toHaveProperty("modelProviderId");
+    expect(hookContext).not.toHaveProperty("modelId");
     expect(harness.requests.some(({ method }) => method === "thread/resume")).toBe(true);
     expect(harness.requests.some(({ method }) => method === "turn/start")).toBe(false);
     expect(result instanceof Error || Boolean(readAttemptTerminal(result).promptError)).toBe(true);
@@ -7741,6 +7770,10 @@ describe("runCodexAppServerAttempt", () => {
     "preserves supervised native model and transport/home guards over $transport (answer: $hasAnswer)",
     async ({ transport, hasAnswer }) => {
       const { sessionFile, workspaceDir, agentDir } = createRunPaths();
+      const beforePromptBuild = vi.fn(() => undefined);
+      initializeGlobalHookRunner(
+        createMockPluginRegistry([{ hookName: "before_prompt_build", handler: beforePromptBuild }]),
+      );
       const codexHome = path.join(tempDir, "review-codex-home");
       vi.stubEnv("CODEX_HOME", codexHome);
       const rolloutPath = path.join(codexHome, "sessions", "thread-existing.jsonl");
@@ -7906,6 +7939,12 @@ describe("runCodexAppServerAttempt", () => {
         });
         const result = await run;
         expect(result.terminal).toEqual({ kind: "ok" });
+        expect(beforePromptBuild).toHaveBeenCalled();
+        for (let index = 0; index < beforePromptBuild.mock.calls.length; index += 1) {
+          const context = mockCall(beforePromptBuild, "before_prompt_build", index)[1];
+          expect(context).not.toHaveProperty("modelProviderId");
+          expect(context).not.toHaveProperty("modelId");
+        }
         expect(result.runtimeModelSelection).toEqual({
           provider: "openai",
           model: "gpt-5.6-luna",


### PR DESCRIPTION
Related: #130706

## What Problem This Solves

Codex prompt hooks on turns controlled by OpenClaw did not receive the selected provider/model. Plugins such as active-memory could therefore use the agent default instead of the model selected for the current turn.

## Why This Change Was Made

Supply the logical selected model through the existing hook context. Keep model fields absent when supervision or a preserved native binding owns selection: the hook runs before native startup confirms those facts. Private transport overrides remain separate.

## User Impact

Supporting plugins can inherit the selected model on host-controlled Codex turns. Native-owned sessions retain their existing unknown-model behavior before startup. No configuration, protocol or persistence surface changes.

## Evidence

- Managed cases failed before repair; a native-owner control caught an incomplete draft. Nine affected cases and 21 shared-hook tests pass, including fresh/resumed private transport and both native ownership modes.
- Independent P2 review: zero findings across two passes. The full changed-code gate and all 103 exact-head CI checks are terminal without failures.
- Live source execution with Codex 0.153.4 completed fresh and resumed authenticated turns on the same native thread. Both actual prompt callbacks and active-memory's real selector chose `openai/gpt-5.5` over configured `openai/gpt-5.4`, and both native turns returned the injected marker. Requested/effective/response model facts agreed; no successful tool calls or reroute occurred.
- Production +6/-0; tests +41/-2. The six lines carry two existing facts while preserving both native ownership exclusions.

The full live driver remains **failed** on two `one-shot client cleanup could not be confirmed` warnings. The ten cleanup/transport/launcher files are unchanged across base, PR and main. An independent auth-free initialize/close probe, with no model turn or hook, reproduced `{ exited: true, cleanup: "uncertain" }`; all five recorded process identities were gone afterward. The live-test inventory found no matching survivors; three unreadable environment records were separately identified as host control-plane processes. All fixture roots were removed and the isolated Testbox was stopped and independently verified completed. Raw failed receipts remain unchanged.

Follow-up: **native Codex one-shot cleanup confidence after official launcher shutdown**. Exact signal attribution remains unproven. This PR's changed hook behavior is live-verified; warning-free shutdown, a packaged Gateway build, full active-memory recall-subagent inference, and native-owned supervision live flows are not claimed.
