### PR TITLE
refactor(plugin-sdk): simplify facade contracts and private relays

### DIFF
--- a/src/plugin-sdk/facade-activation-check.runtime.ts
+++ b/src/plugin-sdk/facade-activation-check.runtime.ts
@@ -24,48 +24,41 @@ import { ALWAYS_ALLOWED_RUNTIME_DIR_NAMES } from "./facade-activation-contract.j
 import {
   resolveBundledMetadataManifestRecord,
   resolveRegistryPluginModuleLocationFromRecords,
+  type FacadeModuleLocationLike,
   type FacadePluginManifestLike,
 } from "./facade-resolution-shared.js";
 
 const ALWAYS_ALLOWED_RUNTIME_DIR_NAME_SET = new Set<string>(ALWAYS_ALLOWED_RUNTIME_DIR_NAMES);
 const EMPTY_FACADE_BOUNDARY_CONFIG: OpenClawConfig = {};
 
-type FacadeModuleLocation = {
-  modulePath: string;
-  boundaryRoot: string;
-};
+type FacadeActivationCheckParams = Parameters<typeof resolveBundledMetadataManifestRecord>[0];
 
-function readFacadeBoundaryConfigSafely(): {
-  rawConfig: OpenClawConfig;
-} {
+function readFacadeBoundaryConfigSafely(): OpenClawConfig {
   try {
     const sourceSnapshot = getRuntimeConfigSourceSnapshot();
     if (sourceSnapshot) {
-      return { rawConfig: sourceSnapshot };
+      return sourceSnapshot;
     }
     const runtimeSnapshot = getRuntimeConfigSnapshot();
     if (runtimeSnapshot) {
-      return { rawConfig: runtimeSnapshot };
+      return runtimeSnapshot;
     }
     const configPath = resolveConfigPath();
     if (!fs.existsSync(configPath)) {
-      return { rawConfig: EMPTY_FACADE_BOUNDARY_CONFIG };
+      return EMPTY_FACADE_BOUNDARY_CONFIG;
     }
     const raw = fs.readFileSync(configPath, "utf8");
     const parsed = parseJsonWithJson5Fallback(raw);
-    const rawConfig =
-      parsed && typeof parsed === "object"
-        ? (parsed as OpenClawConfig)
-        : EMPTY_FACADE_BOUNDARY_CONFIG;
-    return { rawConfig };
+    return parsed && typeof parsed === "object"
+      ? (parsed as OpenClawConfig)
+      : EMPTY_FACADE_BOUNDARY_CONFIG;
   } catch {
-    return { rawConfig: EMPTY_FACADE_BOUNDARY_CONFIG };
+    return EMPTY_FACADE_BOUNDARY_CONFIG;
   }
 }
 
 function getFacadeBoundaryResolvedConfig() {
-  const readResult = readFacadeBoundaryConfigSafely();
-  const { rawConfig } = readResult;
+  const rawConfig = readFacadeBoundaryConfigSafely();
   const autoEnabled = configMayNeedPluginAutoEnable(rawConfig, process.env)
     ? applyPluginAutoEnable({
         config: rawConfig,
@@ -102,7 +95,7 @@ export function resolveRegistryPluginModuleLocation(params: {
   dirName: string;
   artifactBasename: string;
   env?: NodeJS.ProcessEnv;
-}): FacadeModuleLocation | null {
+}): FacadeModuleLocationLike | null {
   const registry = getFacadeManifestRegistry(params.env ? { env: params.env } : {});
   return resolveRegistryPluginModuleLocationFromRecords({
     registry,
@@ -111,13 +104,9 @@ export function resolveRegistryPluginModuleLocation(params: {
   });
 }
 
-function resolveBundledPluginManifestRecord(params: {
-  dirName: string;
-  artifactBasename: string;
-  location: FacadeModuleLocation | null;
-  sourceExtensionsRoot: string;
-  env?: NodeJS.ProcessEnv;
-}): FacadePluginManifestLike | null {
+function resolveBundledPluginManifestRecord(
+  params: FacadeActivationCheckParams,
+): FacadePluginManifestLike | null {
   const metadataRecord = resolveBundledMetadataManifestRecord(params);
   if (metadataRecord) {
     return metadataRecord;
@@ -143,24 +132,16 @@ function resolveBundledPluginManifestRecord(params: {
 }
 
 /** Resolves the stable plugin id used for telemetry and error reporting. */
-export function resolveTrackedFacadePluginId(params: {
-  dirName: string;
-  artifactBasename: string;
-  location: FacadeModuleLocation | null;
-  sourceExtensionsRoot: string;
-  env?: NodeJS.ProcessEnv;
-}): string {
+export function resolveTrackedFacadePluginId(params: FacadeActivationCheckParams): string {
   return resolveBundledPluginManifestRecord(params)?.id ?? params.dirName;
 }
 
 /** Evaluates whether a bundled plugin's api/runtime-api facade is currently enabled. */
-export function resolveBundledPluginPublicSurfaceAccess(params: {
-  dirName: string;
-  artifactBasename: string;
-  location: FacadeModuleLocation | null;
-  sourceExtensionsRoot: string;
-  env?: NodeJS.ProcessEnv;
-}): { allowed: boolean; pluginId?: string; reason?: string } {
+export function resolveBundledPluginPublicSurfaceAccess(params: FacadeActivationCheckParams): {
+  allowed: boolean;
+  pluginId?: string;
+  reason?: string;
+} {
   if (
     params.artifactBasename === "runtime-api.js" &&
     ALWAYS_ALLOWED_RUNTIME_DIR_NAME_SET.has(params.dirName)
@@ -235,13 +216,9 @@ export function throwForBundledPluginPublicSurfaceAccess(params: {
 }
 
 /** Resolves bundled facade access and throws unless the facade is allowed to load. */
-export function resolveActivatedBundledPluginPublicSurfaceAccessOrThrow(params: {
-  dirName: string;
-  artifactBasename: string;
-  location: FacadeModuleLocation | null;
-  sourceExtensionsRoot: string;
-  env?: NodeJS.ProcessEnv;
-}) {
+export function resolveActivatedBundledPluginPublicSurfaceAccessOrThrow(
+  params: FacadeActivationCheckParams,
+) {
   const access = resolveBundledPluginPublicSurfaceAccess(params);
   if (!access.allowed) {
     throwForBundledPluginPublicSurfaceAccess({

--- a/src/plugin-sdk/facade-runtime.ts
+++ b/src/plugin-sdk/facade-runtime.ts
@@ -30,11 +30,7 @@ const OPENCLAW_PACKAGE_ROOT =
   }) ?? fileURLToPath(new URL("../..", import.meta.url));
 const CURRENT_MODULE_PATH = fileURLToPath(import.meta.url);
 const OPENCLAW_SOURCE_EXTENSIONS_ROOT = path.resolve(OPENCLAW_PACKAGE_ROOT, "extensions");
-function createFacadeResolutionKey(params: {
-  dirName: string;
-  artifactBasename: string;
-  env?: NodeJS.ProcessEnv;
-}): string {
+function createFacadeResolutionKey(params: BundledPluginPublicSurfaceParams): string {
   const bundledPluginsDir = resolveBundledPluginsDir(params.env ?? process.env);
   return createFacadeResolutionKeyShared({
     ...params,
@@ -43,19 +39,9 @@ function createFacadeResolutionKey(params: {
   });
 }
 
-function resolveRegistryPluginModuleLocation(params: {
-  dirName: string;
-  artifactBasename: string;
-  env?: NodeJS.ProcessEnv;
-}): { modulePath: string; boundaryRoot: string } | null {
-  return loadFacadeActivationCheckRuntime().resolveRegistryPluginModuleLocation(params);
-}
-
-function resolveFacadeModuleLocationUncached(params: {
-  dirName: string;
-  artifactBasename: string;
-  env?: NodeJS.ProcessEnv;
-}): { modulePath: string; boundaryRoot: string } | null {
+function resolveFacadeModuleLocationUncached(
+  params: BundledPluginPublicSurfaceParams,
+): { modulePath: string; boundaryRoot: string } | null {
   const env = params.env ?? process.env;
   if (!areBundledPluginsDisabled(env)) {
     const bundledPluginsDir = resolveBundledPluginsDir(env);
@@ -69,14 +55,12 @@ function resolveFacadeModuleLocationUncached(params: {
       return bundledLocation;
     }
   }
-  return resolveRegistryPluginModuleLocation(params);
+  return loadFacadeActivationCheckRuntime().resolveRegistryPluginModuleLocation(params);
 }
 
-function resolveFacadeModuleLocation(params: {
-  dirName: string;
-  artifactBasename: string;
-  env?: NodeJS.ProcessEnv;
-}): { modulePath: string; boundaryRoot: string } | null {
+function resolveFacadeModuleLocation(
+  params: BundledPluginPublicSurfaceParams,
+): { modulePath: string; boundaryRoot: string } | null {
   // Custom environments may select different installed-plugin profiles, so
   // their facade locations must not enter the process-wide gateway cache.
   if (params.env !== undefined && params.env !== process.env) {
@@ -220,11 +204,9 @@ export function loadBundledPluginPublicSurfaceModuleSync<T extends object>(
 
 /** Load an activated plugin public surface or throw when activation policy blocks access. */
 // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Dynamic facade loaders use caller-supplied module surface types.
-export function loadActivatedBundledPluginPublicSurfaceModuleSync<T extends object>(params: {
-  dirName: string;
-  artifactBasename: string;
-  env?: NodeJS.ProcessEnv;
-}): T {
+export function loadActivatedBundledPluginPublicSurfaceModuleSync<T extends object>(
+  params: BundledPluginPublicSurfaceParams,
+): T {
   loadFacadeActivationCheckRuntime().resolveActivatedBundledPluginPublicSurfaceAccessOrThrow(
     buildFacadeActivationCheckParams(params),
   );
@@ -246,11 +228,9 @@ export async function loadActivatedBundledPluginPublicSurfaceModule<T extends ob
 
 /** Load an activated plugin public surface, returning null when activation policy blocks access. */
 // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Dynamic facade loaders use caller-supplied module surface types.
-export function tryLoadActivatedBundledPluginPublicSurfaceModuleSync<T extends object>(params: {
-  dirName: string;
-  artifactBasename: string;
-  env?: NodeJS.ProcessEnv;
-}): T | null {
+export function tryLoadActivatedBundledPluginPublicSurfaceModuleSync<T extends object>(
+  params: BundledPluginPublicSurfaceParams,
+): T | null {
   const access = loadFacadeActivationCheckRuntime().resolveBundledPluginPublicSurfaceAccess(
     buildFacadeActivationCheckParams(params),
   );
@@ -261,11 +241,9 @@ export function tryLoadActivatedBundledPluginPublicSurfaceModuleSync<T extends o
 }
 
 /** Async variant of tryLoadActivatedBundledPluginPublicSurfaceModuleSync for async call sites. */
-export async function tryLoadActivatedBundledPluginPublicSurfaceModule<T extends object>(params: {
-  dirName: string;
-  artifactBasename: string;
-  env?: NodeJS.ProcessEnv;
-}): Promise<T | null> {
+export async function tryLoadActivatedBundledPluginPublicSurfaceModule<T extends object>(
+  params: BundledPluginPublicSurfaceParams,
+): Promise<T | null> {
   const runtime = await loadFacadeActivationCheckRuntimeAsync();
   const access = runtime.resolveBundledPluginPublicSurfaceAccess(
     buildFacadeActivationCheckParams(params),


### PR DESCRIPTION
## What Problem This Solves

The shared plugin facade path repeats its input contracts and passes values through two private wrappers. These copies add maintenance work around resolution and activation without owning separate policy.

This is an independent cleanup contribution to the #135868 split campaign.

## Why This Change Was Made

Ten repeated parameter shapes reuse existing resolver contracts, and the duplicate location shape uses its canonical type. A private registry relay is inlined at its sole fallback call. The private config reader returns the same config directly to its sole caller, which previously unwrapped a fresh envelope immediately.

The change preserves method receivers, configuration identity, source/runtime snapshot order, empty fallback identity, exception scope, custom-environment cache bypass, activation checks, and the existing synchronous/source/asynchronous loading paths. Both original owners match stable v2026.9.2.

## User Impact

No user-visible behavior change. Plugin facades retain their existing activation, loading, caching, and error contracts.

## Evidence

- All 84 existing tests pass before and after across ten direct and representative consumer suites, including cold activation, disabled-plugin rejection, artifact failure, cached export identity, source-snapshot preference, and linked QA-runner loading.
- Actual-source type comparison passes 180 assertions per optional-property mode, including public/generic signatures, ten input shapes, nullable location, and optional/readonly keys. Required-environment and non-null-location mutations are rejected in both modes.
- A structural emitted-code comparison permits only the two reviewed private wrapper eliminations. It verifies diff scope; runtime evidence comes from the boundary and consumer tests.
- The extra strict-optional mode retains three existing owner diagnostics per side, with identical messages, codes and spans. Contract assertions are clean; no whole-repository strict-mode compilation claim.
- Full changed-check plan passes on isolated Linux Blacksmith Testbox: core/core-test and extension/extension-test types, SDK surface guards, all three Knip export scans, lint and architecture guards.
- Full pnpm build passes, including all 152 public SDK subpaths and Control UI performance gates. The build leaves tracked files unchanged; 22 source/input hashes match before and after both commands.
- Independent Codex review is clean through P2. ClawSweeper found no correctness/security defect.

ClawSweeper checklist disposition: the requested data-model migration proof is not applicable to this diff. The removed `{ rawConfig }` object is a private, process-local return envelope; its only caller immediately extracts the property before any other use. It is never persisted or serialized. The same source/runtime snapshot getters, config path, `existsSync`/`readFileSync`, JSON5 parser, parsed config object, and empty fallback are retained. No schema, serializer, stored field, version, or migration changes. The stable v2026.9.2 comparison, exact projected reader/caller type checks, narrowly constrained emitted-code comparison, and before/after activation/snapshot tests support that compatibility conclusion. No migration or baseline change was added for this checklist. The final-head ClawSweeper technical review independently confirmed that the previous migration concern is resolved and there is no introduced storage/serialization boundary; its generic checklist remains displayed.

Production: two files, 543 → 498 lines; +41/−86 = **−45**. Tests, tooling, docs and baselines are unchanged.
