### PR TITLE
fix: use the installed WebSocket transport for node streams

### DIFF
--- a/src/node-host/node-stream-transport.ts
+++ b/src/node-host/node-stream-transport.ts
@@ -1,6 +1,9 @@
+import { createRequire } from "node:module";
 import net from "node:net";
+import path from "node:path";
 import type { Duplex } from "node:stream";
-import { WebSocket, type ClientOptions, type RawData } from "ws";
+import { pathToFileURL } from "node:url";
+import type { ClientOptions, RawData, WebSocket } from "ws";
 import {
   buildCloudflareAccessHeaders,
   type CloudflareAccessCredentials,
@@ -8,6 +11,17 @@ import {
 import { applyGatewayWebSocketTlsPin } from "../../packages/gateway-client/src/websocket-transport.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
+const require = createRequire(import.meta.url);
+let webSocketConstructor: Promise<typeof WebSocket> | undefined;
+function loadWebSocketConstructor(): Promise<typeof WebSocket> {
+  // Pin validation needs ws's real ClientRequest/TLSSocket, not Bun's built-in adapter.
+  return (webSocketConstructor ??= import(
+    pathToFileURL(path.join(path.dirname(require.resolve("ws/package.json")), "wrapper.mjs")).href
+  ).then((module: typeof import("ws")) => module.default));
+}
+
+const WEBSOCKET_CONNECTING = 0;
+const WEBSOCKET_OPEN = 1;
 const MAX_PAYLOAD_BYTES = 1024 * 1024;
 const PAUSE_BUFFERED_BYTES = 4 * 1024 * 1024;
 const RESUME_CHECK_MS = 25;
@@ -146,7 +160,7 @@ function createNodeStreamSplice(params: {
     params.ws.on("message", onMessage);
     params.socket.on("drain", resumeWebSocket);
     params.socket.on("data", (chunk) => {
-      if (params.ws.readyState !== WebSocket.OPEN) {
+      if (params.ws.readyState !== WEBSOCKET_OPEN) {
         return;
       }
       params.ws.send(chunk, { binary: true }, (error) => error && finish("send-error", error));
@@ -168,7 +182,7 @@ function createNodeStreamSplice(params: {
     params.socket.once("close", () => {
       params.diagnostics.trigger ??= "target-close";
       stopInbound();
-      if (params.socket.readableEnded && params.ws.readyState === WebSocket.OPEN) {
+      if (params.socket.readableEnded && params.ws.readyState === WEBSOCKET_OPEN) {
         // Let the Gateway receive the last frames and close acknowledgement before
         // the control-channel invocation can retire its desktop/portal stream.
         params.ws.close();
@@ -182,7 +196,7 @@ function createNodeStreamSplice(params: {
   return {
     done,
     start() {
-      if (params.socket.destroyed || params.ws.readyState !== WebSocket.OPEN) {
+      if (params.socket.destroyed || params.ws.readyState !== WEBSOCKET_OPEN) {
         finish("splice-unavailable");
         return;
       }
@@ -230,7 +244,11 @@ export async function runNodeStreamTransport(params: {
     if (aborted) {
       return;
     }
-    ws = new WebSocket(
+    const NpmWebSocket = await Promise.race([loadWebSocketConstructor(), abort]);
+    if (aborted || !NpmWebSocket) {
+      return;
+    }
+    ws = new NpmWebSocket(
       attachWebSocketUrl(params),
       websocketOptions(params.gatewayTlsFingerprint, params.gatewayCloudflareAccess),
     );
@@ -279,7 +297,7 @@ export async function runNodeStreamTransport(params: {
   } finally {
     params.signal.removeEventListener("abort", onAbort);
     socket.destroy();
-    if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+    if (ws && (ws.readyState === WEBSOCKET_OPEN || ws.readyState === WEBSOCKET_CONNECTING)) {
       ws.close();
     }
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes node-host streams selecting Bun's built-in WebSocket adapter instead of the installed transport that provides the ClientRequest and TLSSocket interfaces used by the existing connection options.

## Why This Change Was Made

Lazily load the declared `ws` package through its installed ESM entry. Race that load against owner cancellation so an abort can settle and destroy the owned target without creating a socket afterward. Existing connection options, endpoint rules, payload and backpressure limits, and cleanup paths remain unchanged.

The normal node-host output ships with the root's declared ws dependency. Source-graph inspection and the actual build output confirm this transport is not included in the separately bundled standalone worker, so no worker transform or dependency change is added.

## User Impact

Node-host streams use the installed transport under the opt-in Bun runtime, and cancellation remains effective while that transport loads. Node remains the recommended runtime. This is not a claim of full Bun compatibility or validation of every transport-policy surface.

## Evidence

- Frozen pnpm 12.3.4 install with ws 8.21.3, Proxyline 0.3.11, and Undici 8.10.2.
- Node passed the 16 selected ordinary correct-pin/TLS cases in their original order.
- **Unresolved observation:** the initial Bun run passed 15/16, with one pre-cancellation echo missing. One authorized diagnostic rerun of the same original order passed 16/16; failure-only instrumentation did not fire, and the original test was restored exactly. No production change, assertion change, or deadline increase explains that difference. The initial result remains unexplained and is not claimed repaired.
- Four external fresh-process abort probes passed: pre-abort and immediate abort on Node and Bun. They verified settlement, target destruction, and no connection, upgrade, request, or target write. All processes joined without a resource cap.
- Complete changed-file gate and full build passed. Emitted worker artifacts lack the node-host transport and installed-ws lookup; the normal host artifact retains the intended package-relative lookup. Fresh independent P0–P2 review passed with no actionable findings and the intermittent result included in its context.

Local proof excluded wrong-pin, non-TLS, malformed, caller-auth, and bypass cases. No live external service was used. Required hosted review and exact-head CI must pass before landing. Only one production file changes; no test harness or dependency edits are committed.
