### PR TITLE
fix(matrix): isolate CLI tests across runtimes

### DIFF
--- a/extensions/matrix/src/cli.test.ts
+++ b/extensions/matrix/src/cli.test.ts
@@ -265,9 +265,12 @@ function mockMatrixVerificationSummary(overrides: Record<string, unknown> = {}) 
 }
 
 describe("matrix CLI verification commands", () => {
+  let previousExitCode: typeof process.exitCode;
+
   beforeEach(() => {
     vi.clearAllMocks();
-    process.exitCode = undefined;
+    previousExitCode = process.exitCode;
+    process.exitCode = 0;
     vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => consoleLogMock(...args));
     vi.spyOn(console, "error").mockImplementation((...args: unknown[]) =>
       consoleErrorMock(...args),
@@ -329,7 +332,7 @@ describe("matrix CLI verification commands", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-    process.exitCode = undefined;
+    process.exitCode = previousExitCode ?? 0;
   });
 
   it("sets non-zero exit code for device verification failures in JSON mode", async () => {
@@ -899,7 +902,7 @@ describe("matrix CLI verification commands", () => {
         expect(output).toContain(`Recovery key stored: ${recoveryKey === null ? "no" : "yes"}`);
         expect(output).not.toContain("test-recovery-key");
         expect(stdoutWriteMock).not.toHaveBeenCalled();
-        expect(process.exitCode).toBeUndefined();
+        expect(process.exitCode).toBe(0);
       },
     );
 
@@ -920,7 +923,7 @@ describe("matrix CLI verification commands", () => {
       });
       expect(JSON.parse(String(stdoutWriteArg()))).toEqual(status);
       expect(consoleLogMock).not.toHaveBeenCalled();
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(0);
     });
   });
 
@@ -1345,7 +1348,7 @@ describe("matrix CLI verification commands", () => {
           status: matrixVerificationStatus(),
         });
       }
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(0);
     },
   );
 
@@ -1462,7 +1465,7 @@ describe("matrix CLI verification commands", () => {
     });
     await runMatrixCli(["matrix", "encryption", "setup", "--json"]);
 
-    expect(process.exitCode).toBeUndefined();
+    expect(process.exitCode).toBe(0);
     const write = mockCallArg(matrixRuntimeReplaceConfigFileMock) as { nextConfig: CoreConfig };
     expect(write.nextConfig.channels?.matrix?.accessToken).toEqual(
       source.channels?.matrix?.accessToken,
@@ -1503,7 +1506,7 @@ describe("matrix CLI verification commands", () => {
     );
 
     expect(matrixRuntimeReplaceConfigFileMock).toHaveBeenCalledOnce();
-    expect(process.exitCode).toBeUndefined();
+    expect(process.exitCode).toBe(0);
     const result = JSON.parse(String(stdoutWriteArg()));
     expect(result.encryptionEnabled).toBe(true);
     expectRecordFields(result.verificationBootstrap, {
@@ -1579,7 +1582,7 @@ describe("matrix CLI verification commands", () => {
     await runMatrixCli(matrixAccountPasswordArgs());
 
     expect(matrixRuntimeReplaceConfigFileMock).toHaveBeenCalled();
-    expect(process.exitCode).toBeUndefined();
+    expect(process.exitCode).toBe(0);
     expect(console.log).toHaveBeenCalledWith("Saved matrix account: ops");
     expect(console.error).toHaveBeenCalledWith(
       "Matrix device health warning: homeserver unavailable",
@@ -1591,7 +1594,7 @@ describe("matrix CLI verification commands", () => {
     await runMatrixCli(matrixAccountPasswordArgs("ops", "--json"));
 
     expect(matrixRuntimeReplaceConfigFileMock).toHaveBeenCalled();
-    expect(process.exitCode).toBeUndefined();
+    expect(process.exitCode).toBe(0);
     const jsonOutput = stdoutWriteArg();
     expect(typeof jsonOutput).toBe("string");
     const payload = JSON.parse(String(jsonOutput)) as Record<string, unknown>;
@@ -1689,6 +1692,7 @@ describe("matrix CLI verification commands", () => {
       "mxc://example/avatar",
     ]);
 
+    expect(process.exitCode ?? 0).toBe(0);
     expectRecordFields(mockCallArg(updateMatrixOwnProfileMock), {
       accountId: "alerts",
       displayName: "Alerts Bot",


### PR DESCRIPTION
## What Problem This Solves

Fixes Matrix CLI tests retaining a previous command's failure status under Bun. Assigning `undefined` to `process.exitCode` does not reliably clear a prior nonzero value there, so a later successful mocked command can inherit the failure.

## Why This Change Was Made

Make each fixture establish an explicit zero status, then restore the surrounding status with a zero fallback. Existing failure assertions remain at 1; existing success assertions match the fixture-owned zero. A normalized exit-status assertion in the existing profile-command case catches the original leak without adding a new test.

## User Impact

The Matrix CLI test fixture is isolated across runtimes. Production CLI behavior, verification, configuration, and credentials are unchanged.

## Evidence

- The exact existing mocked failure→profile-success pair ran in its original order. Before the repair, Node passed both cases and Bun failed the success assertion with the earlier status 1. Afterward Node and Bun both passed both cases; all other cases remained unselected locally.
- No real verification, credentials, service, or network operation was performed in local proof.
- The complete changed-file gate passed, including extension-test type checks, repository guards, dead-export checks, and scoped lint; all processes joined without a resource cap.
- Fresh independent P0–P2 review passed with no actionable findings.

Only one test file changes. Required hosted review and exact-head CI must pass before landing.
