### PR TITLE
fix(update): report same-version channel switches as successful

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -423,11 +423,12 @@ aligned:
 
 ### Validation and activation
 
-If the resolved package version equals the installed version, or the Git target
-SHA equals `HEAD`, the run finishes `skipped` with reason `already-current`.
-It does not stop, replace, or restart the Gateway. Read-only plugin convergence
-checks can still report repair needs; use `openclaw update repair` to apply them.
-An explicit `--channel` selection still persists the channel for future updates.
+If the resolved package version equals the installed version without changing
+the selected channel, or the Git target SHA equals `HEAD`, the run finishes
+`skipped` with reason `already-current`. A same-version explicit `--channel`
+change persists the new channel and finishes successfully. Neither path stops,
+replaces, or restarts the Gateway. Read-only plugin convergence checks can still
+report repair needs; use `openclaw update repair` to apply them.
 
 For targets that support candidate validation, the old Gateway keeps serving through `staging` and
 `validating`. The updater uses the candidate entrypoint for Doctor lint

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -6069,6 +6069,75 @@ describe("update-cli", () => {
     },
   );
 
+  it("reports a same-version channel switch as successful without updating the package", async () => {
+    const root = await mockPackageInstallAtCaseDir();
+    const stateDir = tempDirs.make("openclaw-update-channel-switch-");
+    readPackageVersion.mockResolvedValue("2026.4.22");
+    primeNpmChannelTag("beta", "2026.4.22");
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue(
+      configSnapshot({ update: { channel: "stable" } }),
+    );
+    await writeJsonFixture(path.join(stateDir, "openclaw.json"), {
+      update: { channel: "stable" },
+    });
+    mockRunningManagedGateway(["node", path.join(root, "dist", "index.js"), "gateway", "run"]);
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      await updateCommand({ channel: "beta", yes: true, restart: true, json: true });
+    });
+
+    expect(lastReplaceConfigCall()?.nextConfig?.update?.channel).toBe("beta");
+    expectNoSideEffects(
+      serviceStop,
+      serviceRestart,
+      runDaemonRestart,
+      candidateValidation,
+      syncPluginsForUpdateChannel,
+      updateNpmInstalledPlugins,
+    );
+    expect(packageInstallCommandCall()?.[0]).toBeUndefined();
+    expect(doctorCommandCall()).toBeUndefined();
+    expect(lastWriteJsonCall()).toMatchObject({ status: "ok" });
+    expect(lastWriteJsonCall()).not.toHaveProperty("reason");
+    const result = lastWriteJsonCall() as UpdateRunResult;
+    expect(
+      getUpdateRun(requireValue(result.runId, "channel switch run id"), {
+        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      }),
+    ).toMatchObject({ status: "succeeded", downtimeMs: 0 });
+  });
+
+  it("keeps an explicit same-version channel no-op skipped without rewriting config", async () => {
+    const root = await mockPackageInstallAtCaseDir();
+    const stateDir = tempDirs.make("openclaw-update-channel-noop-");
+    readPackageVersion.mockResolvedValue("2026.4.22");
+    primeNpmChannelTag("beta", "2026.4.22");
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue(
+      configSnapshot({ update: { channel: "beta" } }),
+    );
+    await writeJsonFixture(path.join(stateDir, "openclaw.json"), {
+      update: { channel: "beta" },
+    });
+    mockRunningManagedGateway(["node", path.join(root, "dist", "index.js"), "gateway", "run"]);
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      await updateCommand({ channel: "beta", yes: true, restart: true, json: true });
+    });
+
+    expect(replaceConfigFile).not.toHaveBeenCalled();
+    expectNoSideEffects(
+      serviceStop,
+      serviceRestart,
+      runDaemonRestart,
+      candidateValidation,
+      syncPluginsForUpdateChannel,
+      updateNpmInstalledPlugins,
+    );
+    expect(packageInstallCommandCall()?.[0]).toBeUndefined();
+    expect(doctorCommandCall()).toBeUndefined();
+    expect(lastWriteJsonCall()).toMatchObject({ status: "skipped", reason: "already-current" });
+  });
+
   it("runs the package update when latest target lookup is unresolved", async () => {
     setTty(false);
     await mockPackageInstallAtCaseDir();

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -514,13 +514,14 @@ async function updateCommandInternal(
 
   if (packageAlreadyCurrent) {
     const { finishAlreadyCurrentUpdate } = await import("./update-execution.runtime.js");
+    const channelChanged = requestedChannel !== null && requestedChannel !== storedChannel;
     await finishAlreadyCurrentUpdate({
       opts,
       result: {
-        status: "skipped",
+        status: channelChanged ? "ok" : "skipped",
         mode: packageInstallTarget?.manager ?? "unknown",
         root,
-        reason: "already-current",
+        ...(channelChanged ? {} : { reason: "already-current" }),
         before: { version: currentVersion },
         after: { version: currentVersion },
         steps: [],


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/138839

## What Problem This Solves

Fixes an issue where users switching update channels would receive a `skipped` / `already-current` result even though OpenClaw successfully persisted the new channel when both channels resolved to the installed package version.

## Why This Change Was Made

A package-current run now distinguishes a real channel change from a command no-op. After the existing finalizer successfully persists a different requested channel, the command reports `ok` with no skip reason; an unchanged channel remains `skipped` with `already-current`. Package installation, candidate validation, Doctor/plugin mutation, and Gateway stop/restart remain bypassed.

## User Impact

Operators can switch from `stable` to `beta` at the same package version and receive a truthful success result without unnecessary package or service churn.

## Evidence

- Refreshed exact head: `04d7dc1b5bc542a6eb42b2a8b561181a96ef7bb6`.
- Pre-fix regression: the focused stable-to-beta case failed because JSON returned `skipped` instead of `ok`.
- Focused same-version channel cases after refresh: 2 passed.
- Full `src/cli/update-cli.test.ts`: 409 passed.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/34067116187 passed after one failed-job rerun; the original failure was an unrelated `test/scripts/run-vitest-profile.test.ts` help-mode timeout after 479 tests passed.
- Hosted Package Acceptance: https://github.com/openclaw/openclaw/actions/runs/34067187194 passed the exact-head same-version stable-to-beta scenario, then failed later in the unrelated package-to-git dirty-worktree scenario.
- Direct-AWS Crabbox fallback: `run_b2e02ecaa0c7` passed the exact-head scoped Docker scenario with JSON `status: ok`, no reason, persisted `beta`, a succeeded ledger, unchanged package version, and zero downtime.
- `pnpm docs:check-mdx`: passed across 793 files.
- Targeted oxlint, formatting, and `git diff --check`: passed.
- Autoreview (Codex `gpt-5.6-sol`, high, P0-P2): scoped clean. It was not repeated after the mechanical rebase because the patch ID was unchanged.
- Local `check:changed` passed through the core graph boundary, then stopped at core typecheck because the linked worktree's `node_modules/.bin/tsgo` resolves outside the checkout. Exact-head CI passed the full gate.
- Codex contract check at `5f49aba876922d6f2f55caa153bbb0ed1b46feba`: `codex-rs/cli/src/main.rs:786-898` and `:1579-1586` show Codex update is its own installation-method command path with no OpenClaw channel persistence or outcome coupling.
