### PR TITLE
fix(agents): xAI OAuth auto model cannot be materialized

### DIFF
--- a/src/agents/runtime-plan/materialize-model.test.ts
+++ b/src/agents/runtime-plan/materialize-model.test.ts
@@ -410,3 +410,52 @@ describe("materializePreparedRuntimeModel", () => {
     ).rejects.toThrow(/prepared subscription route/u);
   });
 });
+
+describe("provider-resolved model aliases", () => {
+  it("accepts a catalog alias the owning provider resolved to its canonical model", async () => {
+    // xAI's OAuth catalog generates an `auto` entry carrying its canonical target, and the
+    // provider resolves it during normalization. Before this was tolerated, materialization
+    // compared the resolved id against the requested alias and refused its own resolution.
+    const aliasPlan: AgentRuntimeAuthPlan = {
+      providerForAuth: "xai",
+      authProfileProviderForAuth: "xai",
+      forwardedAuthProfileId: "xai:oauth",
+      selectedAuthMode: "token",
+    };
+    const canonical = {
+      provider: "xai",
+      id: "grok-4.6",
+      params: { canonicalModelId: "grok-4.6" },
+    };
+
+    const materialized = await materializePreparedRuntimeModel({
+      plan: aliasPlan,
+      provider: "xai",
+      modelId: "auto",
+      forceResolve: true,
+      resolveModel: async () => ({ model: canonical as never }),
+    });
+
+    expect(materialized?.id).toBe("grok-4.6");
+  });
+
+  it("still refuses a resolved model the provider did not derive from the request", async () => {
+    const aliasPlan: AgentRuntimeAuthPlan = {
+      providerForAuth: "xai",
+      authProfileProviderForAuth: "xai",
+      forwardedAuthProfileId: "xai:oauth",
+      selectedAuthMode: "token",
+    };
+    const unrelated = { provider: "xai", id: "grok-4.6", params: {} };
+
+    await expect(
+      materializePreparedRuntimeModel({
+        plan: aliasPlan,
+        provider: "xai",
+        modelId: "grok-4.5",
+        forceResolve: true,
+        resolveModel: async () => ({ model: unrelated as never }),
+      }),
+    ).rejects.toThrow(/Unable to rematerialize/);
+  });
+});

--- a/src/agents/runtime-plan/materialize-model.ts
+++ b/src/agents/runtime-plan/materialize-model.ts
@@ -1,6 +1,7 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { normalizeProviderResolvedModelWithPlugin } from "../../plugins/provider-runtime.js";
 import { FailoverError } from "../failover/error.js";
 import { resolveBuiltInModelSuppressionFromManifest } from "../model-suppression.js";
 import {
@@ -135,11 +136,33 @@ export async function materializePreparedRuntimeModel<Model extends RuntimeRoute
         })
       : resolveProviderModelMaterializationAuthMode(params.plan.selectedAuthMode),
   });
+  // A provider may legitimately resolve a catalog alias to its canonical model, so the
+  // requested id and the resolved id differ for a correct resolution. Ask the owning
+  // provider whether it produced this id from the requested one rather than encoding
+  // any provider's alias table here. A genuine mismatch still fails: normalizing a
+  // different requested id does not yield the resolved id.
+  const resolvedFromRequestedAlias =
+    resolved.model &&
+    canonicalizeProviderModelId(params.provider, resolved.model.id ?? "") !==
+      canonicalizeProviderModelId(params.provider, params.modelId)
+      ? normalizeProviderResolvedModelWithPlugin({
+          provider: params.provider,
+          modelId: params.modelId,
+          ...(params.config ? { config: params.config } : {}),
+          ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+          context: {
+            provider: params.provider,
+            modelId: params.modelId,
+            model: { ...resolved.model, id: params.modelId } as never,
+          },
+        })?.id === resolved.model.id
+      : false;
   if (
     !resolved.model ||
     normalizeProviderId(resolved.model.provider ?? "") !== normalizeProviderId(params.provider) ||
-    canonicalizeProviderModelId(params.provider, resolved.model.id ?? "") !==
-      canonicalizeProviderModelId(params.provider, params.modelId) ||
+    (!resolvedFromRequestedAlias &&
+      canonicalizeProviderModelId(params.provider, resolved.model.id ?? "") !==
+        canonicalizeProviderModelId(params.provider, params.modelId)) ||
     (route &&
       !modelMatchesPreparedTarget({
         model: resolved.model,


### PR DESCRIPTION
## What Problem This Solves

Fixes #140466.

Selecting the xAI OAuth `auto` model fails prepared-auth materialization:

```
Unable to rematerialize xai/auto for its resolved auth profile.
```

The alias is generated by the provider and resolved by the provider. `withXaiOAuthAutoModel` emits the `auto` catalog entry carrying `params.canonicalModelId`, and `normalizeXaiResolvedModel` resolves it:

`extensions/xai/model-id.ts:16-27`

```ts
const canonicalModelId = params?.canonicalModelId;
return typeof canonicalModelId === "string" && canonicalModelId.trim()
  ? canonicalModelId.trim()
  : id;
```

So resolution correctly returns `grok-4.6` while the requested id is still `auto`. Materialization then compared those two ids directly and rejected the result:

`src/agents/runtime-plan/materialize-model.ts`

```ts
canonicalizeProviderModelId(params.provider, resolved.model.id ?? "") !==
  canonicalizeProviderModelId(params.provider, params.modelId) ||
```

`canonicalizeProviderModelId` cannot reconcile them. It resolves through the provider's `normalizeModelCatalogId` surface, xAI does not implement that hook, and it could not help here anyway: the canonical target comes from the runtime catalog row rather than a static alias table, so `auto` canonicalizes to `auto` and `grok-4.6` to `grok-4.6`.

## Why This Change Was Made

The check is right to exist; it just had no way to tell a provider's own alias resolution from a wrong model. So it now asks the owning provider, through the `normalizeResolvedModel` hook the provider already implements, whether the resolved id came from the requested one.

The alternatives both looked worse. Teaching core that xAI's `auto` means `grok-4.6` puts provider policy in core, which the architecture rules exclude. Having xAI stop rewriting the id would break the alias resolution that makes the catalog entry usable in the first place.

Callers legitimately pass the alias. `credential-scoped-model.ts` and `simple-completion-runtime.ts` hand over the selected model id, and neither can pre-resolve it, because the canonical target only exists on the catalog row that resolution returns.

The guard is not loosened. The alias path is consulted only when the ids already differ, and it accepts only when the provider maps the requested id onto exactly the resolved id.

## User Impact

An xAI OAuth user who selects the `auto` model can use it. Before this, that catalog entry was unusable, and the reporter's comparison showed selecting the canonical target directly worked while the alias did not.

## Evidence

Production change is +25/-2 in one file.

The regression test fails on unfixed code with the reported error. Reverting only `materialize-model.ts`:

```
× accepts a catalog alias the owning provider resolved to its canonical model
  → Unable to rematerialize xai/auto for its resolved auth profile.
  Tests  1 failed | 13 passed (14)
```

The second test, which asserts a resolved model the provider did not derive is still refused, passes both before and after, so it demonstrates the guard was not weakened rather than merely following the change.

```
node scripts/run-vitest.mjs src/agents/runtime-plan       11 files, 146 passed
node scripts/run-vitest.mjs extensions/xai                33 files, 562 passed
node scripts/run-tsgo.mjs -p tsconfig.core.json                          clean
node scripts/run-oxlint.mjs <both touched files>                         clean
./node_modules/.bin/oxfmt --check <both touched files>                   clean
```

Proof ceiling, stated plainly: I have no xAI OAuth credentials, so I did not drive a live xAI session. The evidence is at the materialization boundary the issue names, using the real provider hook rather than a stub, which I verified fires and returns `grok-4.6` for the `auto` row before writing the test. That is the same credential-free boundary level as the reproduction in the issue.

AI-assisted: yes. I traced the source path by hand and ran every command above myself.
