### PR TITLE
fix(ui): restore file editor focus after preview

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -63,6 +63,8 @@ Keep each agent's workspace path explicit when retaining older directories. Befo
 
 ## Workspace file map
 
+Use **Settings → Agents → Files** in the Control UI to edit these files. **Preview** shows the current draft; **Edit** returns to the editor so you can continue typing, while **Close** returns to **Preview**.
+
 Standard files OpenClaw expects inside the workspace:
 
 <AccordionGroup>

--- a/ui/src/pages/agents/agent-file-preview.browser.test.ts
+++ b/ui/src/pages/agents/agent-file-preview.browser.test.ts
@@ -1,0 +1,117 @@
+import { nothing, render } from "lit";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import "../../styles.css";
+import "../../styles/settings.css";
+import "../../styles/agents.css";
+import "../../styles/sidebar-markdown.css";
+import { getRenderedModalDialog } from "../../test-helpers/modal-dialog.ts";
+import { renderAgentFiles } from "./panels-status-files.ts";
+
+const browserMode = "__vitest_browser__" in globalThis;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  container.className = "settings-page";
+  document.body.append(container);
+});
+
+afterEach(() => {
+  render(nothing, container);
+  container.remove();
+});
+
+function afterOwnHide(dialog: HTMLElement): Promise<void> {
+  return new Promise((resolve) => {
+    const hidden = (event: Event) => {
+      if (event.target !== dialog) {
+        return;
+      }
+      dialog.removeEventListener("wa-after-hide", hidden);
+      // The real dialog and adapter queue return focus before this observer's task.
+      setTimeout(resolve, 0);
+    };
+    dialog.addEventListener("wa-after-hide", hidden);
+  });
+}
+
+function requireButton(selector: string): HTMLButtonElement {
+  const button = container.querySelector<HTMLButtonElement>(selector);
+  if (!button) {
+    throw new Error(`Missing file-preview button: ${selector}`);
+  }
+  return button;
+}
+
+describe.runIf(browserMode)("agent file preview focus", () => {
+  it.each(["edit", "close"] as const)(
+    "returns focus to the intended owner after %s and retained reopen",
+    async (action) => {
+      const { userEvent } = await import("vitest/browser");
+      const changes: string[] = [];
+      let expectedDraft = "Unsaved file preview draft";
+      render(
+        renderAgentFiles({
+          agentId: "main",
+          agentFilesList: {
+            agentId: "main",
+            workspace: "/synthetic/workspace",
+            files: [{ name: "AGENTS.md", path: "/synthetic/workspace/AGENTS.md", missing: false }],
+          },
+          agentFilesLoading: false,
+          agentFilesError: null,
+          agentFileActive: "AGENTS.md",
+          agentFileContents: { "AGENTS.md": "Saved instructions" },
+          agentFileDrafts: { "AGENTS.md": expectedDraft },
+          agentFileSaving: false,
+          canWrite: true,
+          onLoadFiles: () => undefined,
+          onSelectFile: () => undefined,
+          onFileDraftChange: (_name, content) => changes.push(content),
+          onFileReset: () => undefined,
+          onFileSave: () => undefined,
+        }),
+        container,
+      );
+      const textarea = container.querySelector<HTMLTextAreaElement>(".agent-file-textarea");
+      if (!textarea) {
+        throw new Error("Missing agent file editor");
+      }
+      const preview = requireButton(".agent-file-actions button");
+      const { modal, webAwesomeDialog, dialog } = await getRenderedModalDialog(container);
+      expect(dialog.open).toBe(false);
+      expect(textarea.value).toBe(expectedDraft);
+
+      for (let opening = 0; opening < 2; opening += 1) {
+        textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+        preview.focus();
+        await userEvent.keyboard("{Enter}");
+        await getRenderedModalDialog(container);
+        await expect.poll(() => dialog.open).toBe(true);
+        await Promise.all(dialog.getAnimations().map((animation) => animation.finished));
+        const closed = afterOwnHide(webAwesomeDialog);
+        await userEvent.click(
+          requireButton(
+            action === "edit" ? '[aria-label="Edit file"]' : '[aria-label="Close preview"]',
+          ),
+        );
+        await closed;
+        expect(dialog.open).toBe(false);
+        expect(modal.isConnected).toBe(true);
+
+        if (action === "edit") {
+          // Keyboard input must follow the returned focus; filling the locator would hide the bug.
+          await userEvent.keyboard("-continued");
+          expectedDraft += "-continued";
+          expect(textarea.value).toBe(expectedDraft);
+          expect(changes.at(-1)).toBe(expectedDraft);
+          expect(document.activeElement).toBe(textarea);
+        } else {
+          expect(document.activeElement).toBe(preview);
+          expect(textarea.value).toBe(expectedDraft);
+          expect(changes).toEqual([]);
+        }
+      }
+    },
+  );
+});

--- a/ui/src/pages/agents/panels-status-files.ts
+++ b/ui/src/pages/agents/panels-status-files.ts
@@ -632,15 +632,14 @@ export function renderAgentFiles(params: {
                                         const modal = (e.currentTarget as HTMLElement).closest(
                                           "openclaw-modal-dialog",
                                         ) as OpenClawModalDialog | null;
+                                        const textarea = modal
+                                          ?.closest(".settings-group")
+                                          ?.querySelector<HTMLElement>(".agent-file-textarea");
+                                        modal?.setReturnFocusTarget(textarea ?? null);
                                         modal?.hide();
                                         if (modal) {
                                           resetAgentFilePreview(modal);
                                         }
-                                        const textarea =
-                                          document.querySelector<HTMLElement>(
-                                            ".agent-file-textarea",
-                                          );
-                                        textarea?.focus();
                                       }}
                                     >
                                       <span aria-hidden="true">${icons.edit}</span>


### PR DESCRIPTION
Closes #140492

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users choose **Edit** in an agent file preview, then type, but the draft does not change because focus returns to **Preview** after the dialog closes.

## Why This Change Was Made

Edit now identifies the editor in the preview's own settings group and registers it with the modal's existing return-focus mechanism before hiding. The modal adapter restores focus after the native close lifecycle finishes. This removes the eager document-wide lookup and focus call, and the workspace documentation explains the Edit and Close destinations.

## User Impact

Users can choose **Edit** and continue typing in the current draft. **Close** continues to return focus to **Preview**. The native regression also checks reopening the same modal.

## Evidence

- Native Chromium baseline: one intended Edit failure and one passing Close control. Typing `-continued` after Edit left the original draft unchanged; the inspected synthetic screenshot shows focus on Preview.
- Identical regression after the repair: **2 passed, 0 failed, 0 skipped**, including actual keyboard input, the draft-change callback, focus, and retained-modal reopening.
- Existing modal coverage: **15 jsdom tests and 9 native Chromium tests passed**. The initial combined invocation exited 1 because the JSON reporter rejected the browser configuration before its tests ran. That failure is retained; only the unexecuted native suite was then run separately.
- Targeted two-thread formatting passed for the production and regression files.
- Scoped managed review reported no accepted/actionable P0–P2 findings.

Production: **+4/−5, net −1**. Regression coverage: **+117 test lines**. Documentation: **+2 lines**.

The complete three-path changed gate passed in **502.456 seconds**, including typechecks, i18n verification, export scans, lint and style checks. Source, index, untracked-test bytes and dependency inputs remained unchanged. The final signed candidate `6aba348f6af03ec14033dbb1f47cf2a85d539e3c` passed an uncached **83.252-second** build with complete source/dependency/artifact seals.

Built-application before/after proof passed in Chromium using the real Control UI assets and their compiled HTTP serving handler, with synthetic Gateway data. Each run opens the preview twice, chooses Edit and types `-continued`, then checks ordinary Close. The baseline leaves focus on Preview and misses both suffixes; the candidate focuses the editor and retains both. Both runs recorded **13 mocked Gateway requests and 63 served assets**, zero file-save requests, zero page/console errors, complete build/source checks, and verified process/listener cleanup.

All five screenshots and the video from each run were inspected. Public copies crop only the unrelated bottom footer. Baseline build: `e0f848cf4a82664261de1e82ff5565c19ffb599c`; all 44 relevant source inputs match the candidate base, with only the reviewed caller override on the fixed build. This is built UI with a mocked Gateway, not a real model or external service run.

Two earlier recording setup failures are retained: the initial static server omitted the Gateway's asset-path preparation, then the loader inherited an unrelated working directory. The final driver uses the sealed compiled serving owner and anchors its working directory to the verified checkout. No product change, timeout increase, or weakened UI assertion resolved these setup failures.

Exact-head [CI 34064534118](https://github.com/openclaw/openclaw/actions/runs/34064534118) completed successfully: 89 jobs succeeded and 12 were skipped. Native landing verification remains.

Before and after (after the second Edit):


![Before: Edit leaves focus on Preview and typing misses the editor](https://github.com/user-attachments/assets/e8d7a2a2-eebc-4a16-8e36-5c2efddce4db)

![After: Edit returns focus to the editor and both typed suffixes are retained](https://github.com/user-attachments/assets/62c12226-76d4-43f8-8599-c16f8a8d16a2)

https://github.com/user-attachments/assets/58aca4ba-6a26-4d0e-83a8-513f1b21b550

https://github.com/user-attachments/assets/9334c494-8f47-4a63-bb1a-65fb6b5bd429
