### PR TITLE
fix(matrix): run fixture loaders natively under Bun

### DIFF
--- a/extensions/matrix/doctor-contract-api.account-state.test.ts
+++ b/extensions/matrix/doctor-contract-api.account-state.test.ts
@@ -67,40 +67,56 @@ function runMatrixDoctorFix(params: { rootDir: string; stateDir: string }) {
   );
   fs.writeFileSync(
     loaderPath,
-    `import { registerHooks } from "node:module";
-registerHooks({
-  resolve(specifier, context, nextResolve) {
-    if (specifier.endsWith("/doctor-ui.js")) {
-      return {
-        shortCircuit: true,
-        url: "data:text/javascript," + encodeURIComponent([
-          "export async function detectUiProtocolFreshnessIssues() { return []; }",
-          "export function uiProtocolFreshnessIssueToHealthFinding() { return {}; }",
-          "export function uiProtocolFreshnessIssueToRepairEffects() { return []; }",
-          "export async function maybeRepairUiProtocolFreshness() {}",
-        ].join("\\n")),
-      };
-    }
-    if (specifier.endsWith("/doctor-health-contributions.js")) {
-      return {
-        shortCircuit: true,
-        url: "data:text/javascript," + encodeURIComponent(
-          "export async function runDoctorHealthContributions() {}",
-        ),
-      };
-    }
-    return nextResolve(specifier, context);
-  },
-});
+    String.raw`import { realpathSync } from "node:fs";
+const uiSource = [
+  'process.stderr.write("matrix-doctor-fixture:ui\\n");',
+  "export async function detectUiProtocolFreshnessIssues() { return []; }",
+  "export function uiProtocolFreshnessIssueToHealthFinding() { return {}; }",
+  "export function uiProtocolFreshnessIssueToRepairEffects() { return []; }",
+  "export async function maybeRepairUiProtocolFreshness() {}",
+].join("\n");
+const healthSource = [
+  'process.stderr.write("matrix-doctor-fixture:health\\n");',
+  "export async function runDoctorHealthContributions() {}",
+].join("\n");
+if (process.versions.bun) {
+  const { plugin } = await import("bun");
+  const sources = new Map([
+    [realpathSync("./src/commands/doctor-ui.ts"), uiSource],
+    [realpathSync("./src/flows/doctor-health-contributions.ts"), healthSource],
+  ]);
+  const escapedPaths = [...sources.keys()].map((path) => path.replace(/[.*+?^$(){}|[\]\\]/g, "\\$&"));
+  plugin({
+    name: "matrix-doctor-fixture",
+    setup(build) {
+      build.onLoad({ filter: new RegExp("^(?:" + escapedPaths.join("|") + ")$"), namespace: "file" }, ({ path }) => ({
+        contents: sources.get(realpathSync(path)),
+        loader: "js",
+      }));
+    },
+  });
+} else {
+  const { registerHooks } = await import("node:module");
+  registerHooks({
+    resolve(specifier, context, nextResolve) {
+      const source = specifier.endsWith("/doctor-ui.js")
+        ? uiSource
+        : specifier.endsWith("/doctor-health-contributions.js")
+          ? healthSource
+          : undefined;
+      return source === undefined
+        ? nextResolve(specifier, context)
+        : { shortCircuit: true, url: "data:text/javascript," + encodeURIComponent(source) };
+    },
+  });
+}
 `,
   );
   const entryPath = fileURLToPath(new URL("../../src/entry.ts", import.meta.url));
   return spawnSync(
     process.execPath,
     [
-      "--import",
-      "tsx",
-      "--import",
+      ...(process.versions.bun ? ["--preload"] : ["--import", "tsx", "--import"]),
       loaderPath,
       entryPath,
       "doctor",
@@ -207,6 +223,10 @@ describe("Matrix account state Doctor migration", () => {
     expect(doctor.error, doctorOutput).toBeUndefined();
     expect(doctor.signal, doctorOutput).toBeNull();
     expect(doctor.status, doctorOutput).toBe(0);
+    expect(doctor.stderr.match(/^matrix-doctor-fixture:(?:ui|health)$/gm)?.toSorted()).toEqual([
+      "matrix-doctor-fixture:health",
+      "matrix-doctor-fixture:ui",
+    ]);
     expect(doctorOutput).toContain(`Matrix account SQLite ${storageRootDir}`);
     expect(doctorOutput).not.toContain(`Matrix account SQLite ${archivedStorageRootDir}`);
     expect(doctorOutput).toContain(

--- a/extensions/matrix/src/matrix/config-update.import.test.ts
+++ b/extensions/matrix/src/matrix/config-update.import.test.ts
@@ -1,12 +1,32 @@
-import { runDirectImportSmoke } from "openclaw/plugin-sdk/test-fixtures";
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
+
+async function runSourceImportSmoke(code: string): Promise<string> {
+  const repoRoot = new URL("../../../../", import.meta.url);
+  const runtimeArgs = process.versions.bun
+    ? ["--tsconfig-override", fileURLToPath(new URL("tsconfig.json", repoRoot))]
+    : ["--import", "tsx"];
+  const { stdout } = await promisify(execFile)(process.execPath, [...runtimeArgs, "-e", code], {
+    cwd: fileURLToPath(repoRoot),
+    env: {
+      HOME: process.env.HOME,
+      NODE_OPTIONS: process.env.NODE_OPTIONS,
+      NODE_PATH: process.env.NODE_PATH,
+      PATH: process.env.PATH,
+      TERM: process.env.TERM,
+    },
+    timeout: 40_000,
+  });
+  return stdout;
+}
 
 describe("matrix config update import boundary", () => {
   it("updates secret inputs without loading secret setup or resolution", async () => {
-    const stdout = await runDirectImportSmoke(`
+    const stdout = await runSourceImportSmoke(String.raw`
 import { realpathSync } from "node:fs";
-import { registerHooks } from "node:module";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 const entryUrl = pathToFileURL(realpathSync("./extensions/matrix/src/matrix/config-update.ts")).href;
 const watchedUrls = new Map([
   [entryUrl, "entry"],
@@ -14,17 +34,36 @@ const watchedUrls = new Map([
   [pathToFileURL(realpathSync("./src/secrets/resolve.ts")).href, "resolver"],
 ]);
 const observed = { entry: false, setup: false, resolver: false };
-const hooks = registerHooks({
-  load(url, context, nextLoad) {
-    // Loader query parameters do not change which filesystem owner is loaded.
-    const canonicalUrl = new URL(url);
-    canonicalUrl.search = "";
-    canonicalUrl.hash = "";
-    const owner = watchedUrls.get(canonicalUrl.href);
-    if (owner) observed[owner] = true;
-    return nextLoad(url, context);
-  },
-});
+let deregister = () => {};
+if (process.versions.bun) {
+  const { plugin } = await import("bun");
+  const paths = [...watchedUrls.keys()].map((url) => fileURLToPath(url));
+  const escapedPaths = paths.map((path) => path.replace(/[.*+?^$(){}|[\]\\]/g, "\\$&"));
+  plugin({
+    name: "matrix-config-import-observer",
+    setup(build) {
+      build.onLoad({ filter: new RegExp("^(?:" + escapedPaths.join("|") + ")$"), namespace: "file" }, async ({ path }) => {
+        const owner = watchedUrls.get(pathToFileURL(realpathSync(path)).href);
+        if (owner) observed[owner] = true;
+        return { contents: new Uint8Array(await Bun.file(path).arrayBuffer()), loader: "ts" };
+      });
+    },
+  });
+} else {
+  const { registerHooks } = await import("node:module");
+  const hooks = registerHooks({
+    load(url, context, nextLoad) {
+      // Loader query parameters do not change which filesystem owner is loaded.
+      const canonicalUrl = new URL(url);
+      canonicalUrl.search = "";
+      canonicalUrl.hash = "";
+      const owner = watchedUrls.get(canonicalUrl.href);
+      if (owner) observed[owner] = true;
+      return nextLoad(url, context);
+    },
+  });
+  deregister = () => hooks.deregister();
+}
 try {
   const { updateMatrixAccountConfig } = await import(entryUrl);
   const ref = { source: "env", provider: "default", id: "MATRIX_IMPORT_TEST_TOKEN" };
@@ -39,7 +78,7 @@ try {
     explicitAccount: hasExplicitMatrixAccountConfig({ channels: { matrix: { accessToken: ref } } }, "default"),
   }));
 } finally {
-  hooks.deregister();
+  deregister();
 }
 `);
     const result = JSON.parse(stdout);


### PR DESCRIPTION
## What Problem This Solves

Fixes two Matrix fixtures using Node-only loader hooks when their child runs on Bun. Those fixtures failed before reaching the import-laziness and released-state migration assertions they are meant to protect.

## Why This Change Was Made

Keep Node's existing hook path and use native Bun instrumentation for the exact canonical fixture owners. The import observer supplies unchanged source bytes to Bun's native TypeScript compiler. Its local source-import launcher uses the existing root tsconfig so it observes the intended source dependency graph; the shared public-artifact smoke helper is unchanged.

The Doctor fixture preloads the same two intentional stubs and now verifies that each actually evaluated once. Migration, archive-byte integrity, cursor persistence, normalized output, and positive/negative import assertions remain intact. No production code, dependency, or shared resolver changes are included.

## User Impact

The fixtures can check the same Matrix contracts on Node and Bun. The Doctor case uses owned temporary HOME/config/state/log directories and a checksum-verified released synthetic SQLite fixture; no operator state, real providers, credentials, or services are used.

## Evidence

- Both exact cases passed on Node and failed on Bun before the repair, then passed on both runtimes afterward. Other cases were not selected locally.
- An external inert comparison verified unchanged native module values, relative imports, identity, and single evaluation. Source-graph inspection positively observed the SDK source owner without importing secret setup.
- Bun's separate tsconfig directory-mismatch stderr diagnostic is retained as a runtime limitation and is not claimed repaired. Existing expected output and exit checks remain unchanged.
- Fresh independent P0–P2 review passed with no actionable findings. The complete changed-file gate passed, including extension-test types, repository guards, dead-export checks, and scoped lint; all processes joined without a resource cap.

Only two test files change. Required hosted review and exact-head CI must pass before landing; this is not full Matrix, live-service, or all-platform coverage.
