### PR TITLE
fix: distinguish sync and async admission in slow database warnings

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -306,8 +306,11 @@ The structured warning also includes `pid`, Node's `threadId`, and `isMainThread
 for the opener emitting it. Inspect each `openclaw logs --json` event's original
 `raw` record; ordinary console text omits structured metadata.
 An opener on the main thread may have awaited an integrity Worker, so these
-fields do not identify the thread performing every phase. Correlate the process
-ID with the log timestamp and current process; PIDs can be reused after exit.
+fields do not identify the thread performing every phase. `admissionMode` records
+the actual `sync` or `async` open driver. Async admission offloads its initial
+integrity check; resumed validation and repair can still run on the opener.
+Correlate the process ID with the log timestamp and current process; PIDs can be
+reused after exit.
 
 ### Slow reply preparation
 

--- a/src/state/openclaw-agent-db-lifecycle.ts
+++ b/src/state/openclaw-agent-db-lifecycle.ts
@@ -70,7 +70,11 @@ const cache = resolveGlobalSingleton<AgentDatabaseLifecycle>(
 );
 
 /** Each physical-open generator owns these checkpoints across any integrity await. */
-export function startAgentDatabaseOpenTiming(agentId: string, pathname: string) {
+export function startAgentDatabaseOpenTiming(
+  agentId: string,
+  pathname: string,
+  admissionMode: "sync" | "async",
+) {
   const startedAt = performance.now();
   let elapsedMs = 0;
   const phaseDurationsMs = { open: 0, validation: 0, configuration: 0, schema: 0, registration: 0 };
@@ -87,6 +91,7 @@ export function startAgentDatabaseOpenTiming(agentId: string, pathname: string) 
         pid: process.pid,
         threadId,
         isMainThread,
+        admissionMode,
         phaseDurationsMs,
         thresholdMs: OPENCLAW_AGENT_DB_SLOW_OPEN_MS,
       });

--- a/src/state/openclaw-agent-db.open-timing.test.ts
+++ b/src/state/openclaw-agent-db.open-timing.test.ts
@@ -111,6 +111,7 @@ describe("agent database open timings", () => {
       pid: process.pid,
       threadId,
       isMainThread,
+      admissionMode: "sync",
       thresholdMs: 1_000,
       phaseDurationsMs: {
         open: 60,
@@ -145,6 +146,7 @@ describe("agent database open timings", () => {
       pid: process.pid,
       threadId,
       isMainThread,
+      admissionMode: "sync",
       thresholdMs: 1_000,
       phaseDurationsMs: {
         open: 60,
@@ -205,6 +207,7 @@ describe("agent database open timings", () => {
         pid: process.pid,
         threadId,
         isMainThread,
+        admissionMode: "async",
         thresholdMs: 1_000,
         phaseDurationsMs: {
           open: 60,

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -420,7 +420,7 @@ function* openOpenClawAgentDatabaseSteps(
         env: leaseEnvironment,
       });
   }
-  const finishPhase = startAgentDatabaseOpenTiming(agentId, pathname);
+  const finishPhase = startAgentDatabaseOpenTiming(agentId, pathname, pending ? "async" : "sync");
   let openedDb: DatabaseSync | undefined;
   let openedDatabase: OpenClawAgentDatabase | undefined;
   let openedWalMaintenance: SqliteWalMaintenance | undefined;


### PR DESCRIPTION
Related: #139835

## What Problem This Solves

Fixes an issue where operators cannot tell whether a slow agent database open used synchronous or asynchronous admission. The warning identifies the emitting thread, but its validation duration can include time awaiting an integrity Worker.

## Why This Change Was Made

Capture `admissionMode: "sync" | "async"` at the canonical physical-open driver and include it in the existing warning. Keep the threshold, phase durations, quiet cache hits and single warning for coalesced callers unchanged. No configuration, schema, validation, cache or lease-policy change.

## User Impact

Operators can distinguish the admission driver before investigating a slow open. The field does not claim that all validation runs on one thread or that elapsed time is CPU time; asynchronous admission can still resume validation and repair on its opener. The logging documentation explains that limit.

## Evidence

- Node 26.7 baseline with the new expectations: exactly three missing-field failures for initial sync open, validated sync reopen and actual coalesced async Worker admission. The below-threshold quiet-open control passed. Original failures and native process cleanup were retained.
- Independent Codex review found no actionable P0–P2 findings. Formatting and changed-lane planning passed.
- Committed `d60400a9a994` passed 133 focused timing/agent-database tests with six existing filesystem-platform skips, plus the full changed-file gate on Linux/Node 26.7. The three formerly failing diagnostic expectations now pass; original native/test outputs and source identity are retained.
- [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34064775317).
