### PR TITLE
fix(gateway): reduce memory growth during session lookups

### DIFF
--- a/src/config/sessions/combined-store-gateway.test.ts
+++ b/src/config/sessions/combined-store-gateway.test.ts
@@ -364,3 +364,38 @@ it.skipIf(process.platform === "win32")(
     });
   },
 );
+
+it("omits retained prompt payloads unless a caller opts into the full projection", async () => {
+  await withOpenClawTestState({ label: "combined-store-projection" }, async () => {
+    const cfg: OpenClawConfig = {
+      agents: { entries: { main: { default: true } } },
+    };
+    replaceSessionEntrySync(
+      { agentId: "main", sessionKey: "agent:main:main" },
+      {
+        sessionId: "prompt-payload-session",
+        updatedAt: 7,
+        skillsSnapshot: { prompt: "skill prompt body", skills: [{ name: "example" }] },
+        systemPromptReport: {
+          source: "run",
+          generatedAt: 7,
+          systemPrompt: { chars: 17, projectContextChars: 0, nonProjectContextChars: 17 },
+          injectedWorkspaceFiles: [],
+          skills: { promptChars: 17, entries: [{ name: "example", blockChars: 17 }] },
+          tools: { listChars: 0, schemaChars: 0, entries: [] },
+        },
+      },
+    );
+
+    const defaultEntry = loadCombinedSessionStoreForGatewayCore(cfg).store["agent:main:main"];
+    expect.soft(defaultEntry?.sessionId).toBe("prompt-payload-session");
+    expect.soft(defaultEntry?.skillsSnapshot).toBeUndefined();
+    expect.soft(defaultEntry?.systemPromptReport).toBeUndefined();
+
+    const fullEntry = loadCombinedSessionStoreForGatewayCore(cfg, { projection: "full" }).store[
+      "agent:main:main"
+    ];
+    expect.soft(fullEntry?.skillsSnapshot?.prompt).toBe("skill prompt body");
+    expect(fullEntry?.systemPromptReport?.systemPrompt.chars).toBe(17);
+  });
+});

--- a/src/config/sessions/combined-store-gateway.test.ts
+++ b/src/config/sessions/combined-store-gateway.test.ts
@@ -491,3 +491,38 @@ it.skipIf(process.platform === "win32")(
     });
   },
 );
+
+it("omits retained prompt payloads unless a caller opts into the full projection", async () => {
+  await withOpenClawTestState({ label: "combined-store-projection" }, async () => {
+    const cfg: OpenClawConfig = {
+      agents: { entries: { main: { default: true } } },
+    };
+    replaceSessionEntrySync(
+      { agentId: "main", sessionKey: "agent:main:main" },
+      {
+        sessionId: "prompt-payload-session",
+        updatedAt: 7,
+        skillsSnapshot: { prompt: "skill prompt body", skills: [{ name: "example" }] },
+        systemPromptReport: {
+          source: "run",
+          generatedAt: 7,
+          systemPrompt: { chars: 17, projectContextChars: 0, nonProjectContextChars: 17 },
+          injectedWorkspaceFiles: [],
+          skills: { promptChars: 17, entries: [{ name: "example", blockChars: 17 }] },
+          tools: { listChars: 0, schemaChars: 0, entries: [] },
+        },
+      },
+    );
+
+    const defaultEntry = loadCombinedSessionStoreForGatewayCore(cfg).store["agent:main:main"];
+    expect.soft(defaultEntry?.sessionId).toBe("prompt-payload-session");
+    expect.soft(defaultEntry?.skillsSnapshot).toBeUndefined();
+    expect.soft(defaultEntry?.systemPromptReport).toBeUndefined();
+
+    const fullEntry = loadCombinedSessionStoreForGatewayCore(cfg, { projection: "full" }).store[
+      "agent:main:main"
+    ];
+    expect.soft(fullEntry?.skillsSnapshot?.prompt).toBe("skill prompt body");
+    expect(fullEntry?.systemPromptReport?.systemPrompt.chars).toBe(17);
+  });
+});

--- a/src/config/sessions/combined-store-gateway.ts
+++ b/src/config/sessions/combined-store-gateway.ts
@@ -468,7 +468,10 @@ export function loadCombinedSessionStoreForGatewayCore(
   store: Record<string, SessionEntry>;
   targetsBySessionKey: GatewayStoredSessionTargets;
 } {
-  const projection = opts.projection ?? "full";
+  // Store-wide reads default to metadata only. "full" retains skillsSnapshot and
+  // systemPromptReport for every row, so a caller that reads one field would still
+  // materialize every saved prompt; callers that need those blobs opt in explicitly.
+  const projection = opts.projection ?? "list";
   // Count admission and projection share this exact target set. Otherwise an optional
   // prewarm can approve one database and synchronously materialize another.
   const {

--- a/src/config/sessions/combined-store-gateway.ts
+++ b/src/config/sessions/combined-store-gateway.ts
@@ -548,7 +548,9 @@ export function loadCombinedSessionStoreForGatewayCore(
   store: Record<string, SessionEntry>;
   targetsBySessionKey: GatewayStoredSessionTargets;
 } {
-  const projection = opts.projection ?? "full";
+  // Store-wide metadata reads must not materialize saved prompts for every row.
+  // Consumers of retained prompt fields opt into the full projection.
+  const projection = opts.projection ?? "list";
   // Count admission and projection share this exact target set. Otherwise an optional
   // prewarm can approve one database and synchronously materialize another.
   const {

--- a/src/gateway/server-methods/usage-session-selection.ts
+++ b/src/gateway/server-methods/usage-session-selection.ts
@@ -203,10 +203,12 @@ export async function selectUsageSessions(params: {
   } = params;
   // Load session store for named sessions only on a result-cache miss.
   const sessionStoreOpts = effectiveAgentId ? { agentId: effectiveAgentId } : {};
-  const { store, targetsBySessionKey } = loadCombinedSessionStoreForGatewayCore(
-    config,
-    sessionStoreOpts,
-  );
+  // Usage rows report systemPromptReport as context weight, so this is the one
+  // store-wide reader that needs the retained prompt payload.
+  const { store, targetsBySessionKey } = loadCombinedSessionStoreForGatewayCore(config, {
+    ...sessionStoreOpts,
+    projection: "full",
+  });
   const scopedStore = Object.fromEntries(
     Object.entries(store).filter(
       ([key, entry]) =>

--- a/src/gateway/server-methods/usage-session-selection.ts
+++ b/src/gateway/server-methods/usage-session-selection.ts
@@ -203,10 +203,11 @@ export async function selectUsageSessions(params: {
   } = params;
   // Load session store for named sessions only on a result-cache miss.
   const sessionStoreOpts = effectiveAgentId ? { agentId: effectiveAgentId } : {};
-  const { store, targetsBySessionKey } = loadCombinedSessionStoreForGatewayCore(
-    config,
-    sessionStoreOpts,
-  );
+  // Usage exposes saved prompt reports as context weight, including its availability flag.
+  const { store, targetsBySessionKey } = loadCombinedSessionStoreForGatewayCore(config, {
+    ...sessionStoreOpts,
+    projection: "full",
+  });
   const scopedStore = Object.fromEntries(
     Object.entries(store).filter(
       ([key, entry]) =>

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -223,7 +223,7 @@ describe("sessions.usage", () => {
 
     expect(vi.mocked(loadCombinedSessionStoreForGatewayCore)).toHaveBeenCalledWith(
       TEST_RUNTIME_CONFIG,
-      { agentId: "main" },
+      { agentId: "main", projection: "full" },
     );
     expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(1);
     expect((mockArg(vi.mocked(discoverAllSessions), 0, 0) as { agentId?: string }).agentId).toBe(
@@ -241,7 +241,7 @@ describe("sessions.usage", () => {
 
     expect(vi.mocked(loadCombinedSessionStoreForGatewayCore)).toHaveBeenCalledWith(
       TEST_RUNTIME_CONFIG,
-      {},
+      { projection: "full" },
     );
     expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(2);
     expect(
@@ -280,7 +280,7 @@ describe("sessions.usage", () => {
 
     expect(vi.mocked(loadCombinedSessionStoreForGatewayCore)).toHaveBeenCalledWith(
       TEST_RUNTIME_CONFIG,
-      { agentId: "opus" },
+      { agentId: "opus", projection: "full" },
     );
     expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(1);
     expect((mockArg(vi.mocked(discoverAllSessions), 0, 0) as { agentId?: string }).agentId).toBe(
@@ -467,7 +467,7 @@ describe("sessions.usage", () => {
 
     expect(vi.mocked(loadCombinedSessionStoreForGatewayCore)).toHaveBeenCalledWith(
       TEST_RUNTIME_CONFIG,
-      { agentId: "codex" },
+      { agentId: "codex", projection: "full" },
     );
     expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(1);
     expect((mockArg(vi.mocked(discoverAllSessions), 0, 0) as { agentId?: string }).agentId).toBe(

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -225,7 +225,7 @@ describe("sessions.usage", () => {
 
     expect(vi.mocked(loadCombinedSessionStoreForGatewayCore)).toHaveBeenCalledWith(
       TEST_RUNTIME_CONFIG,
-      { agentId: "main" },
+      { agentId: "main", projection: "full" },
     );
     expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(1);
     expect((mockArg(vi.mocked(discoverAllSessions), 0, 0) as { agentId?: string }).agentId).toBe(
@@ -243,7 +243,7 @@ describe("sessions.usage", () => {
 
     expect(vi.mocked(loadCombinedSessionStoreForGatewayCore)).toHaveBeenCalledWith(
       TEST_RUNTIME_CONFIG,
-      {},
+      { projection: "full" },
     );
     expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(2);
     expect(
@@ -282,7 +282,7 @@ describe("sessions.usage", () => {
 
     expect(vi.mocked(loadCombinedSessionStoreForGatewayCore)).toHaveBeenCalledWith(
       TEST_RUNTIME_CONFIG,
-      { agentId: "opus" },
+      { agentId: "opus", projection: "full" },
     );
     expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(1);
     expect((mockArg(vi.mocked(discoverAllSessions), 0, 0) as { agentId?: string }).agentId).toBe(
@@ -469,7 +469,7 @@ describe("sessions.usage", () => {
 
     expect(vi.mocked(loadCombinedSessionStoreForGatewayCore)).toHaveBeenCalledWith(
       TEST_RUNTIME_CONFIG,
-      { agentId: "codex" },
+      { agentId: "codex", projection: "full" },
     );
     expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(1);
     expect((mockArg(vi.mocked(discoverAllSessions), 0, 0) as { agentId?: string }).agentId).toBe(

--- a/src/gateway/sessions-resolve-projection.test.ts
+++ b/src/gateway/sessions-resolve-projection.test.ts
@@ -1,6 +1,8 @@
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it, vi } from "vitest";
 import type { SessionsResolveParams } from "../../packages/gateway-protocol/src/index.js";
+import { setRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
+import { loadCombinedSessionStoreForGatewayCore } from "../config/sessions/combined-store-gateway.js";
 import { replaceSessionEntrySync } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -8,8 +10,13 @@ import {
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import {
+  resetResolvedSessionKeyForRunCacheForTest,
+  resolveSessionKeyForRun,
+} from "./server-session-key.js";
 import { roleClient, rolePolicyConfig } from "./session-sharing.test-utils.js";
 import { resolveSessionKeyFromResolveParams } from "./sessions-resolve.js";
+import { resolveWorkerSessionTarget } from "./worker-environments/session-target.js";
 
 const scope = { agentId: "main", sessionKey: "agent:main:target" };
 const entry = { sessionId: "target-id", updatedAt: 1, label: "original" };
@@ -147,4 +154,182 @@ describe("session resolution metadata", () => {
       });
     },
   );
+});
+
+// Marker lives only in sibling rows the lookups must never decode. A decode of
+// this text means a store-wide read carried saved prompts into JavaScript.
+const SIBLING_MARKER = "unrelated-lookup-prompt";
+const SIBLING_PROMPT = SIBLING_MARKER.repeat(1600);
+const TARGET_PROMPT = "target-lookup-prompt".repeat(1600);
+const SIBLING_ROWS = 24;
+
+function systemPromptReport(chars: number) {
+  return {
+    source: "run" as const,
+    generatedAt: 1,
+    systemPrompt: { chars, projectContextChars: 0, nonProjectContextChars: chars },
+    injectedWorkspaceFiles: [],
+    skills: { promptChars: chars, entries: [{ name: "seeded-skill", blockChars: chars }] },
+    tools: { listChars: 0, schemaChars: 0, entries: [] },
+  };
+}
+
+function seedStore() {
+  replaceSessionEntrySync(scope, {
+    sessionId: "target-id",
+    updatedAt: 2,
+    skillsSnapshot: { prompt: TARGET_PROMPT, skills: [{ name: "target-skill" }] },
+    systemPromptReport: systemPromptReport(TARGET_PROMPT.length),
+  });
+  for (let index = 0; index < SIBLING_ROWS; index++) {
+    replaceSessionEntrySync(
+      { ...scope, sessionKey: `agent:main:sibling-${index}` },
+      {
+        sessionId: `sibling-${index}`,
+        updatedAt: 1,
+        skillsSnapshot: { prompt: SIBLING_PROMPT, skills: [{ name: "sibling-skill" }] },
+        systemPromptReport: systemPromptReport(SIBLING_PROMPT.length),
+      },
+    );
+  }
+}
+
+/** Counts JSON.parse calls that decoded the sibling marker, plus their input bytes. */
+function measureSiblingDecodes<T>(run: () => T): { result: T; decodes: number; bytes: number } {
+  const parse = vi.spyOn(JSON, "parse");
+  try {
+    const result = run();
+    const matched = parse.mock.calls.filter(
+      ([json]) => typeof json === "string" && json.includes(SIBLING_MARKER),
+    );
+    return {
+      result,
+      decodes: matched.length,
+      bytes: matched.reduce((total, [json]) => total + (json as string).length, 0),
+    };
+  } finally {
+    parse.mockRestore();
+  }
+}
+
+describe("gateway session lookups", () => {
+  it("resolves a run id without decoding unrelated saved prompts", async () => {
+    await withOpenClawTestState({ label: "lookup-runid-projection" }, async () => {
+      setRuntimeConfigSnapshot(cfg);
+      seedStore();
+      resetResolvedSessionKeyForRunCacheForTest();
+
+      const observed = measureSiblingDecodes(() =>
+        resolveSessionKeyForRun("target-id", { agentId: "main" }),
+      );
+
+      // Caller-facing key drops the agent prefix; see resolveRunSessionKeyForCaller.
+      expect(observed.result).toBe("target");
+      expect(observed.decodes).toBe(0);
+      expect(observed.bytes).toBe(0);
+
+      resetResolvedSessionKeyForRunCacheForTest();
+      expect(resolveSessionKeyForRun("absent-run-id", { agentId: "main" })).toBeUndefined();
+    });
+  });
+
+  it("resolves a worker session target without decoding unrelated saved prompts", async () => {
+    await withOpenClawTestState({ label: "lookup-worker-projection" }, async () => {
+      setRuntimeConfigSnapshot(cfg);
+      seedStore();
+
+      const observed = measureSiblingDecodes(() => resolveWorkerSessionTarget(cfg, "target-id"));
+
+      // This lookup returns the raw canonical key, unlike the run-id lookup.
+      expect(observed.result?.sessionKey).toBe(scope.sessionKey);
+      expect(observed.result?.agentId).toBe("main");
+      expect(observed.result?.sessionId).toBe("target-id");
+
+      // The selected entry is re-read through its own still-full loader, so the
+      // narrowed store default must not strip the payload this caller returns.
+      expect(observed.result?.sessionEntry.skillsSnapshot?.prompt).toBe(TARGET_PROMPT);
+
+      // This caller reads the store twice: the identity scan fixed here, then
+      // resolveGatewaySessionStoreTargetWithStore, which passes no projection and
+      // still materializes every row. Only the first read stops decoding, so the
+      // remaining count is one pass, not zero; narrowing the second read is
+      // separate work because that loader owns the returned entry.
+      expect(observed.decodes).toBe(SIBLING_ROWS);
+
+      expect(resolveWorkerSessionTarget(cfg, "absent-session-id")).toBeUndefined();
+    });
+  });
+
+  it("decodes saved prompts only when a caller opts into the full projection", async () => {
+    await withOpenClawTestState({ label: "lookup-projection-arms" }, async () => {
+      setRuntimeConfigSnapshot(cfg);
+      seedStore();
+
+      // Pre-change behavior: the only production change to the loader is its
+      // `??` default, so an explicit "full" read is the pre-change caller.
+      const before = measureSiblingDecodes(() =>
+        loadCombinedSessionStoreForGatewayCore(cfg, { agentId: "main", projection: "full" }),
+      );
+      const after = measureSiblingDecodes(() =>
+        loadCombinedSessionStoreForGatewayCore(cfg, { agentId: "main" }),
+      );
+
+      // Same rows either way: this narrows fields, never the result set.
+      expect(Object.keys(before.result.store)).toHaveLength(SIBLING_ROWS + 1);
+      expect(Object.keys(after.result.store)).toHaveLength(SIBLING_ROWS + 1);
+
+      // usage reporting and the plugin transcript view stay pinned to "full" and
+      // must keep receiving the payload; the narrowed default must not reach them.
+      const beforeTarget = before.result.store[scope.sessionKey];
+      expect(beforeTarget?.systemPromptReport?.systemPrompt.chars).toBe(TARGET_PROMPT.length);
+      expect(beforeTarget?.skillsSnapshot?.prompt).toBe(TARGET_PROMPT);
+
+      const afterTarget = after.result.store[scope.sessionKey];
+      expect(afterTarget?.sessionId).toBe("target-id");
+      expect(afterTarget?.systemPromptReport).toBeUndefined();
+      expect(afterTarget?.skillsSnapshot).toBeUndefined();
+
+      expect(before.decodes).toBe(SIBLING_ROWS);
+      expect(before.bytes).toBeGreaterThan(SIBLING_ROWS * SIBLING_PROMPT.length);
+      expect(after.decodes).toBe(0);
+      expect(after.bytes).toBe(0);
+
+      console.log(
+        `[projection-proof] rows=${SIBLING_ROWS + 1} promptBytesPerRow=${SIBLING_PROMPT.length} ` +
+          `full: decodes=${before.decodes} decodedBytes=${before.bytes} | ` +
+          `list: decodes=${after.decodes} decodedBytes=${after.bytes}`,
+      );
+    });
+  });
+
+  it("keeps the freshest same-session-id row when prompts are not decoded", async () => {
+    await withOpenClawTestState({ label: "lookup-projection-freshness" }, async () => {
+      setRuntimeConfigSnapshot(cfg);
+      // Same sessionId on two keys: selection depends on updatedAt surviving the
+      // metadata projection, which is the field a bad projection would drop.
+      replaceSessionEntrySync(
+        { ...scope, sessionKey: "agent:main:stale" },
+        {
+          sessionId: "shared-id",
+          updatedAt: 1,
+          skillsSnapshot: { prompt: SIBLING_PROMPT, skills: [] },
+        },
+      );
+      replaceSessionEntrySync(
+        { ...scope, sessionKey: "agent:main:fresh" },
+        {
+          sessionId: "shared-id",
+          updatedAt: 99,
+          skillsSnapshot: { prompt: SIBLING_PROMPT, skills: [] },
+        },
+      );
+      resetResolvedSessionKeyForRunCacheForTest();
+
+      const observed = measureSiblingDecodes(() =>
+        resolveSessionKeyForRun("shared-id", { agentId: "main" }),
+      );
+      expect(observed.result).toBe("fresh");
+      expect(observed.decodes).toBe(0);
+    });
+  });
 });

--- a/src/gateway/sessions-resolve-projection.test.ts
+++ b/src/gateway/sessions-resolve-projection.test.ts
@@ -1,6 +1,8 @@
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it, vi } from "vitest";
 import type { SessionsResolveParams } from "../../packages/gateway-protocol/src/index.js";
+import { setRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
+import { loadCombinedSessionStoreForGatewayCore } from "../config/sessions/combined-store-gateway.js";
 import { replaceSessionEntrySync } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -8,8 +10,13 @@ import {
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import {
+  resetResolvedSessionKeyForRunCacheForTest,
+  resolveSessionKeyForRun,
+} from "./server-session-key.js";
 import { roleClient, rolePolicyConfig } from "./session-sharing.test-utils.js";
 import { resolveSessionKeyFromResolveParams } from "./sessions-resolve.js";
+import { resolveWorkerSessionTarget } from "./worker-environments/session-target.js";
 
 const scope = { agentId: "main", sessionKey: "agent:main:target" };
 const entry = { sessionId: "target-id", updatedAt: 1, label: "original" };
@@ -147,4 +154,181 @@ describe("session resolution metadata", () => {
       });
     },
   );
+});
+
+// Marker lives only in sibling rows the lookups must never decode. A decode of
+// this text means a store-wide read carried saved prompts into JavaScript.
+const SIBLING_MARKER = "unrelated-lookup-prompt";
+const SIBLING_PROMPT = SIBLING_MARKER.repeat(1600);
+const TARGET_PROMPT = "target-lookup-prompt".repeat(1600);
+const SIBLING_ROWS = 24;
+
+function systemPromptReport(chars: number) {
+  return {
+    source: "run" as const,
+    generatedAt: 1,
+    systemPrompt: { chars, projectContextChars: 0, nonProjectContextChars: chars },
+    injectedWorkspaceFiles: [],
+    skills: { promptChars: chars, entries: [{ name: "seeded-skill", blockChars: chars }] },
+    tools: { listChars: 0, schemaChars: 0, entries: [] },
+  };
+}
+
+function seedStore() {
+  replaceSessionEntrySync(scope, {
+    sessionId: "target-id",
+    updatedAt: 2,
+    skillsSnapshot: { prompt: TARGET_PROMPT, skills: [{ name: "target-skill" }] },
+    systemPromptReport: systemPromptReport(TARGET_PROMPT.length),
+  });
+  for (let index = 0; index < SIBLING_ROWS; index++) {
+    replaceSessionEntrySync(
+      { ...scope, sessionKey: `agent:main:sibling-${index}` },
+      {
+        sessionId: `sibling-${index}`,
+        updatedAt: 1,
+        skillsSnapshot: { prompt: SIBLING_PROMPT, skills: [{ name: "sibling-skill" }] },
+        systemPromptReport: systemPromptReport(SIBLING_PROMPT.length),
+      },
+    );
+  }
+}
+
+/** Counts JSON.parse calls that decoded the sibling marker, plus their input bytes. */
+function measureSiblingDecodes<T>(run: () => T): { result: T; decodes: number; bytes: number } {
+  const parse = vi.spyOn(JSON, "parse");
+  try {
+    const result = run();
+    const matched = parse.mock.calls.flatMap(([json]) =>
+      typeof json === "string" && json.includes(SIBLING_MARKER) ? [json] : [],
+    );
+    return {
+      result,
+      decodes: matched.length,
+      bytes: matched.reduce((total, json) => total + Buffer.byteLength(json), 0),
+    };
+  } finally {
+    parse.mockRestore();
+  }
+}
+
+describe("gateway session lookups", () => {
+  it("resolves a run id without decoding unrelated saved prompts", async () => {
+    await withOpenClawTestState({ label: "lookup-runid-projection" }, async () => {
+      setRuntimeConfigSnapshot(cfg);
+      seedStore();
+      resetResolvedSessionKeyForRunCacheForTest();
+
+      const observed = measureSiblingDecodes(() =>
+        resolveSessionKeyForRun("target-id", { agentId: "main" }),
+      );
+
+      // Caller-facing key drops the agent prefix; see resolveRunSessionKeyForCaller.
+      expect(observed.result).toBe("target");
+      expect(observed.decodes).toBe(0);
+      expect(observed.bytes).toBe(0);
+
+      resetResolvedSessionKeyForRunCacheForTest();
+      expect(resolveSessionKeyForRun("absent-run-id", { agentId: "main" })).toBeUndefined();
+    });
+  });
+
+  it("preserves the worker target payload while narrowing its identity scan", async () => {
+    await withOpenClawTestState({ label: "lookup-worker-projection" }, async () => {
+      setRuntimeConfigSnapshot(cfg);
+      seedStore();
+
+      const observed = measureSiblingDecodes(() => resolveWorkerSessionTarget(cfg, "target-id"));
+
+      // This lookup returns the raw canonical key, unlike the run-id lookup.
+      expect(observed.result?.sessionKey).toBe(scope.sessionKey);
+      expect(observed.result?.agentId).toBe("main");
+      expect(observed.result?.sessionId).toBe("target-id");
+
+      // The selected entry is re-read through its own still-full loader, so the
+      // narrowed store default must not strip the payload this caller returns.
+      expect(observed.result?.sessionEntry.skillsSnapshot?.prompt).toBe(TARGET_PROMPT);
+
+      // This caller reads the store twice: the identity scan fixed here, then
+      // resolveGatewaySessionStoreTargetWithStore, which passes no projection and
+      // still materializes every row. Only the first read stops decoding, so the
+      // remaining count is one pass, not zero; narrowing the second read is
+      // separate work because that loader owns the returned entry.
+      expect(observed.decodes).toBe(SIBLING_ROWS);
+
+      expect(resolveWorkerSessionTarget(cfg, "absent-session-id")).toBeUndefined();
+    });
+  });
+
+  it("decodes saved prompts only when a caller opts into the full projection", async () => {
+    await withOpenClawTestState({ label: "lookup-projection-arms" }, async () => {
+      setRuntimeConfigSnapshot(cfg);
+      seedStore();
+
+      // Explicit full loading is a payload control, not an executed baseline revision.
+      const before = measureSiblingDecodes(() =>
+        loadCombinedSessionStoreForGatewayCore(cfg, { agentId: "main", projection: "full" }),
+      );
+      const after = measureSiblingDecodes(() =>
+        loadCombinedSessionStoreForGatewayCore(cfg, { agentId: "main" }),
+      );
+
+      // Same rows either way: this narrows fields, never the result set.
+      expect(Object.keys(before.result.store)).toHaveLength(SIBLING_ROWS + 1);
+      expect(Object.keys(after.result.store)).toHaveLength(SIBLING_ROWS + 1);
+
+      // usage reporting and the plugin transcript view stay pinned to "full" and
+      // must keep receiving the payload; the narrowed default must not reach them.
+      const beforeTarget = before.result.store[scope.sessionKey];
+      expect(beforeTarget?.systemPromptReport?.systemPrompt.chars).toBe(TARGET_PROMPT.length);
+      expect(beforeTarget?.skillsSnapshot?.prompt).toBe(TARGET_PROMPT);
+
+      const afterTarget = after.result.store[scope.sessionKey];
+      expect(afterTarget?.sessionId).toBe("target-id");
+      expect(afterTarget?.systemPromptReport).toBeUndefined();
+      expect(afterTarget?.skillsSnapshot).toBeUndefined();
+
+      expect(before.decodes).toBe(SIBLING_ROWS);
+      expect(before.bytes).toBeGreaterThan(SIBLING_ROWS * SIBLING_PROMPT.length);
+      expect(after.decodes).toBe(0);
+      expect(after.bytes).toBe(0);
+
+      console.log(
+        `[projection-proof] rows=${SIBLING_ROWS + 1} promptBytesPerRow=${SIBLING_PROMPT.length} ` +
+          `full: decodes=${before.decodes} decodedBytes=${before.bytes} | ` +
+          `list: decodes=${after.decodes} decodedBytes=${after.bytes}`,
+      );
+    });
+  });
+
+  it("keeps the freshest same-session-id row when prompts are not decoded", async () => {
+    await withOpenClawTestState({ label: "lookup-projection-freshness" }, async () => {
+      setRuntimeConfigSnapshot(cfg);
+      // Same sessionId on two keys: selection depends on updatedAt surviving the
+      // metadata projection, which is the field a bad projection would drop.
+      replaceSessionEntrySync(
+        { ...scope, sessionKey: "agent:main:stale" },
+        {
+          sessionId: "shared-id",
+          updatedAt: 1,
+          skillsSnapshot: { prompt: SIBLING_PROMPT, skills: [] },
+        },
+      );
+      replaceSessionEntrySync(
+        { ...scope, sessionKey: "agent:main:fresh" },
+        {
+          sessionId: "shared-id",
+          updatedAt: 99,
+          skillsSnapshot: { prompt: SIBLING_PROMPT, skills: [] },
+        },
+      );
+      resetResolvedSessionKeyForRunCacheForTest();
+
+      const observed = measureSiblingDecodes(() =>
+        resolveSessionKeyForRun("shared-id", { agentId: "main" }),
+      );
+      expect(observed.result).toBe("fresh");
+      expect(observed.decodes).toBe(0);
+    });
+  });
 });

--- a/src/plugin-sdk/session-transcript-hit.projection.test.ts
+++ b/src/plugin-sdk/session-transcript-hit.projection.test.ts
@@ -1,0 +1,76 @@
+import { expect, it } from "vitest";
+import { loadSessionEntry, replaceSessionEntrySync } from "../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { loadCombinedSessionStoreForGateway } from "./session-transcript-hit.js";
+
+it.each([
+  {
+    name: "all agents",
+    options: {},
+    expectedKeys: ["agent:main:visible", "agent:research:visible", "agent:retired:visible"],
+  },
+  {
+    name: "one requested agent",
+    options: { agentId: "main" },
+    expectedKeys: ["agent:main:visible"],
+  },
+  {
+    name: "configured agents",
+    options: { configuredAgentsOnly: true },
+    expectedKeys: ["agent:main:visible", "agent:research:visible"],
+  },
+])("returns complete non-incognito entries for $name", async ({ options, expectedKeys }) => {
+  await withOpenClawTestState({ label: "plugin-transcript-projection" }, async () => {
+    const cfg: OpenClawConfig = {
+      agents: { entries: { main: { default: true }, research: {} } },
+    };
+    const skillsSnapshot = {
+      prompt: "Saved plugin skill instructions",
+      skills: [{ name: "plugin-fixture" }],
+    };
+    const systemPromptReport: NonNullable<SessionEntry["systemPromptReport"]> = {
+      source: "run",
+      generatedAt: 7,
+      systemPrompt: { chars: 83, projectContextChars: 31, nonProjectContextChars: 52 },
+      injectedWorkspaceFiles: [],
+      skills: { promptChars: 30, entries: [{ name: "plugin-fixture", blockChars: 30 }] },
+      tools: { listChars: 11, schemaChars: 19, entries: [] },
+    };
+    for (const agentId of ["main", "research", "retired"]) {
+      replaceSessionEntrySync(
+        { agentId, sessionKey: `agent:${agentId}:visible` },
+        {
+          sessionId: `${agentId}-visible`,
+          updatedAt: 7,
+          skillsSnapshot,
+          systemPromptReport,
+        },
+      );
+    }
+    const incognitoScope = {
+      agentId: "main",
+      sessionKey: "agent:main:dashboard:incognito-private",
+    };
+    replaceSessionEntrySync(incognitoScope, {
+      sessionId: "private-session",
+      updatedAt: 9,
+      incognito: true,
+      skillsSnapshot: { prompt: "Private plugin instructions", skills: [] },
+      systemPromptReport,
+    });
+    expect(loadSessionEntry(incognitoScope)).toMatchObject({
+      sessionId: "private-session",
+      incognito: true,
+    });
+
+    const { store } = loadCombinedSessionStoreForGateway(cfg, options);
+
+    expect(Object.keys(store).toSorted()).toEqual(expectedKeys);
+    for (const entry of Object.values(store)) {
+      expect.soft(entry.skillsSnapshot).toEqual(skillsSnapshot);
+      expect.soft(entry.systemPromptReport).toEqual(systemPromptReport);
+    }
+  });
+});

--- a/src/plugin-sdk/session-transcript-hit.ts
+++ b/src/plugin-sdk/session-transcript-hit.ts
@@ -26,7 +26,14 @@ export function loadCombinedSessionStoreForGateway(
   cfg: OpenClawConfig,
   opts: { agentId?: string; configuredAgentsOnly?: boolean } = {},
 ) {
-  const result = loadGatewaySessionStore(cfg, { ...opts, includeIncognito: false });
+  // Pinned to the retained payload: this SDK view has no projection option, so
+  // installed plugins already receive complete entries. Narrowing it here would
+  // silently drop fields from a published surface.
+  const result = loadGatewaySessionStore(cfg, {
+    ...opts,
+    includeIncognito: false,
+    projection: "full",
+  });
   return {
     storePath: result.storePath,
     // Plugin search hits can be re-persisted into durable transcripts, so the

--- a/src/plugin-sdk/session-transcript-hit.ts
+++ b/src/plugin-sdk/session-transcript-hit.ts
@@ -26,7 +26,12 @@ export function loadCombinedSessionStoreForGateway(
   cfg: OpenClawConfig,
   opts: { agentId?: string; configuredAgentsOnly?: boolean } = {},
 ) {
-  const result = loadGatewaySessionStore(cfg, { ...opts, includeIncognito: false });
+  // This published view has no projection option; installed plugins receive complete entries.
+  const result = loadGatewaySessionStore(cfg, {
+    ...opts,
+    includeIncognito: false,
+    projection: "full",
+  });
   return {
     storePath: result.storePath,
     // Plugin search hits can be re-persisted into durable transcripts, so the


### PR DESCRIPTION
## What Problem This Solves

Run lookups decoded saved prompts from every stored session, causing unnecessary memory growth.

## Why This Change Was Made

The combined Gateway reader now defaults to its existing metadata projection. Usage reports and the published plugin transcript helper explicitly retain full entries. The combined reader owns the projection default; existing storage writers and cache ownership are unchanged.

## User Impact

Large-store lookups use less memory without changing session selection or saved prompts.

## Evidence

A real isolated Gateway held 200 synthetic sessions across two agents. Three matched 48-request samples reduced prompt-bearing parses from 4,814 to 14 in the first sample and from 4,804 to four in each later sample. A shared background health refresh adds ten parses when it overlaps a sample. The largest resident-memory increase sampled after completed requests fell from 357–457 MB to 4.6–21.6 MB. These samples include the Gateway and client in one process and do not measure continuous memory peaks or exact heap allocation. Metadata scans and intentional full-entry reads remain.

`node scripts/run-vitest.mjs run src/gateway/sessions-resolve-projection.test.ts` passes after merging current main. Its registered `artifacts.list` regression fails on main because unrelated prompts are decoded.

## Compatibility

No schema, configuration, protocol, or public signature changes. Both original contributor commits remain. Separate full-store and startup/selected-entry reads are unchanged.

## Consumers

Usage context reports and plugin transcript entries retain both saved prompt fields.

## Invalidation

Existing cache invalidation, ownership, and incognito rules remain intact.

## Tests

Known, missing, freshest, ambiguous, agent-scoped and incognito controls; usage and plugin preservation; 98 focused owner and sibling tests passed.

Production growth is eight lines: combined reader +2, usage +1, plugin wrapper +5. Each retains the projection contract above. Growth accepted under the owner's standing acceptance (2026-09-15).
