### PR TITLE
refactor(plugin-sdk): reuse canonical model normalizers

### DIFF
--- a/src/plugin-sdk/provider-model-shared.ts
+++ b/src/plugin-sdk/provider-model-shared.ts
@@ -1,9 +1,4 @@
 // Provider model helpers normalize model catalog entries shared by provider plugins.
-import { normalizeProviderId as normalizeProviderIdCore } from "@openclaw/model-catalog-core/provider-id";
-import {
-  normalizeAntigravityPreviewModelId as normalizeAntigravityPreviewModelIdCore,
-  normalizeGooglePreviewModelId as normalizeGooglePreviewModelIdCore,
-} from "@openclaw/model-catalog-core/provider-model-id-normalize";
 import { normalizeOptionalLowercaseString } from "../../packages/normalization-core/src/string-coerce.js";
 import {
   buildAnthropicReplayPolicyForModel,
@@ -24,6 +19,12 @@ import type {
   ProviderRuntimeModel,
   ProviderSanitizeReplayHistoryContext,
 } from "./plugin-entry.js";
+
+export { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+export {
+  normalizeAntigravityPreviewModelId,
+  normalizeGooglePreviewModelId,
+} from "@openclaw/model-catalog-core/provider-model-id-normalize";
 
 type SelfHostedOpenAICompatibleProviderOverrides = Partial<
   Omit<ProviderPlugin, "id" | "label" | "docsPath" | "envVars" | "auth" | "catalog" | "wizard">
@@ -206,16 +207,6 @@ export {
   buildStrictAnthropicReplayPolicy,
 };
 
-/**
- * Normalizes provider ids for config, catalog, and plugin-registry matching.
- */
-export function normalizeProviderId(
-  /** Provider id from config, catalog, or plugin metadata. */
-  provider: string,
-): string {
-  return normalizeProviderIdCore(provider);
-}
-
 /** Compare canonical flat rates without assuming display-only models include cost metadata. */
 export function modelCostsEqual(
   current: ProviderRuntimeModel["cost"] | undefined,
@@ -313,26 +304,6 @@ export function isProxyReasoningUnsupportedModelHint(
   modelId: string,
 ): boolean {
   return getModelProviderHint(modelId) === "x-ai";
-}
-
-/**
- * Normalizes Antigravity preview model ids to the canonical provider catalog form.
- */
-export function normalizeAntigravityPreviewModelId(
-  /** Antigravity preview model id from config or catalog data. */
-  id: string,
-): string {
-  return normalizeAntigravityPreviewModelIdCore(id);
-}
-
-/**
- * Normalizes Google preview model ids to the canonical provider catalog form.
- */
-export function normalizeGooglePreviewModelId(
-  /** Google preview model id from config or catalog data. */
-  id: string,
-): string {
-  return normalizeGooglePreviewModelIdCore(id);
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

The provider-model SDK maintains three forwarding functions whose bodies only call the canonical normalizers already imported from model-catalog-core. The duplicate definitions add maintenance surface without owning different behavior.

## Why This Change Was Made

Re-export those same normalizers directly from their existing module paths. `normalizeProviderId`, `normalizeAntigravityPreviewModelId`, and `normalizeGooglePreviewModelId` retain their names and `(string) => string` signatures. No public SDK export is removed, and no dependency is added.

Stable-contract check: `v2026.9.2` publishes `openclaw/plugin-sdk/provider-model-shared` with all three exports; its SDK and canonical normalizer sources match the pre-change sources. `git log -S` traces the forwarding bodies to `e357203be57`. This changes implementation ownership while preserving the shipped contract. Follow-up deletion work for #135868. Production +6/−35, net −29; tests/tooling/docs unchanged.

## User Impact

No intended behavior change for bundled or external plugins. Provider and preview model IDs normalize exactly as before.

## Evidence

- 98 tests passed across the SDK owner, canonical model normalizers, Fireworks, and LM Studio consumers.
- Independent Codex review: scoped-clean through P2.
- Final-snapshot `pnpm build`, full `node scripts/check-changed.mjs --base origin/main`, and all 98 focused tests passed sequentially on clean Blacksmith Testbox `tbx_01m1wcs5bs6t2xwq1sryb5prpe`: exit 0, lease stopped completed. [Run](https://github.com/openclaw/openclaw/actions/runs/34063598430). Local checks caught and resolved import-first placement, then whole-extension lint hit the known nested-parent `punycode` boundary. No parent install or guard changes; the clean run passed whole-extension lint. A backing Actions cancellation during one-shot lease cleanup does not change the successful command result.
- No tests or public exports removed; existing owner and consumer coverage remains.
- ClawSweeper reviewed exact head `bbb0d2876f243c8b2a8ee91cb97992bfa2946f55`: no findings, security concerns, or requested rank-up changes. Maintainer source review agrees.
