### PR TITLE
refactor(tests): reuse deferred gates in post-attach tests

### DIFF
--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -714,10 +714,7 @@ describe("startGatewayPostAttachRuntime", () => {
   });
 
   it("gates main-session recovery behind post-ready work", async () => {
-    let releasePostReadyWork!: () => void;
-    const postReadyWork = new Promise<void>((resolve) => {
-      releasePostReadyWork = resolve;
-    });
+    const { promise: postReadyWork, resolve: releasePostReadyWork } = createDeferred();
     let waitForStart: (() => Promise<void>) | undefined;
     hoisted.scheduleRestartAbortedMainSessionRecovery.mockImplementationOnce(
       (params: { waitForStart?: () => Promise<void> }) => {
@@ -897,10 +894,7 @@ describe("startGatewayPostAttachRuntime", () => {
 
   it("keeps delayed restart sentinel recovery admitted until wake work completes", async () => {
     vi.useFakeTimers();
-    let finishWake: (() => void) | undefined;
-    const wake = new Promise<void>((resolve) => {
-      finishWake = resolve;
-    });
+    const { promise: wake, resolve: finishWake } = createDeferred();
     hoisted.scheduleRestartSentinelWake.mockReturnValueOnce(wake);
 
     const sidecar = testing.scheduleRestartSentinelWakeAfterReady({
@@ -1572,10 +1566,7 @@ describe("startGatewayPostAttachRuntime", () => {
   ])(
     "starts and can cancel Control UI assets for $name roots while plugins are pending",
     async ({ state }) => {
-      let finishPluginStartup: (() => void) | undefined;
-      const pluginStartup = new Promise<void>((resolve) => {
-        finishPluginStartup = resolve;
-      });
+      const { promise: pluginStartup, resolve: finishPluginStartup } = createDeferred();
       const buildController = new AbortController();
       const buildSignal = buildController.signal;
       const startControlUiBuild = vi.fn(
@@ -1771,10 +1762,7 @@ describe("startGatewayPostAttachRuntime", () => {
       typedHooks: [],
     } as never;
     let startupClaimCurrent = true;
-    let releasePluginLoad: (() => void) | undefined;
-    const pluginLoadReady = new Promise<void>((resolve) => {
-      releasePluginLoad = resolve;
-    });
+    const { promise: pluginLoadReady, resolve: releasePluginLoad } = createDeferred();
     const pluginRuntimeClaim = {
       isCurrent: () => startupClaimCurrent,
       waitForUnblocked: async () => true,
@@ -2321,10 +2309,7 @@ describe("startGatewayPostAttachRuntime", () => {
 
   it("releases startup account starts before awaiting channel handoff", async () => {
     const events: string[] = [];
-    let releaseAccountStarts!: () => void;
-    const accountStartsReady = new Promise<void>((resolve) => {
-      releaseAccountStarts = resolve;
-    });
+    const { promise: accountStartsReady, resolve: releaseAccountStarts } = createDeferred();
     const startChannels = vi.fn(async () => {
       events.push("channels-start");
       await accountStartsReady;
@@ -2823,10 +2808,7 @@ describe("startGatewayPostAttachRuntime", () => {
     const registry = createEmptyPluginRegistry();
     const broadcastPluginEvent = vi.fn();
     let context: OpenClawPluginServiceContext | undefined;
-    let releaseCleanup: (() => void) | undefined;
-    const cleanupReleased = new Promise<void>((resolve) => {
-      releaseCleanup = resolve;
-    });
+    const { promise: cleanupReleased, resolve: releaseCleanup } = createDeferred();
     registry.services.push({
       pluginId: "deferred-deadline",
       source: "test",
@@ -4018,14 +4000,8 @@ describe("startGatewayPostAttachRuntime", () => {
   });
 
   it("warms the CA cache before worker placement and sidecar startup", async () => {
-    let finishWarmup: (() => void) | undefined;
-    const warmupReady = new Promise<void>((resolve) => {
-      finishWarmup = resolve;
-    });
-    let finishReconcile: (() => void) | undefined;
-    const reconcileReady = new Promise<void>((resolve) => {
-      finishReconcile = resolve;
-    });
+    const { promise: warmupReady, resolve: finishWarmup } = createDeferred();
+    const { promise: reconcileReady, resolve: finishReconcile } = createDeferred();
     const startupOrder: string[] = [];
     const warmSystemCa = vi.fn(async () => {
       startupOrder.push("ca-warmup");
@@ -4140,14 +4116,8 @@ describe("startGatewayPostAttachRuntime", () => {
 
   it("stops worker placement once when close begins while it starts", async () => {
     let closeStarted = false;
-    let releaseWorkerStart: (() => void) | undefined;
-    const workerStartBlocked = new Promise<void>((resolve) => {
-      releaseWorkerStart = resolve;
-    });
-    let markWorkerStart: (() => void) | undefined;
-    const workerStartReached = new Promise<void>((resolve) => {
-      markWorkerStart = resolve;
-    });
+    const { promise: workerStartBlocked, resolve: releaseWorkerStart } = createDeferred();
+    const { promise: workerStartReached, resolve: markWorkerStart } = createDeferred();
     const workerSidecar = { stop: vi.fn(async () => {}) };
     const startGatewaySidecarsValue = vi.fn();
     const runtimePromise = startGatewayPostAttachRuntime(
@@ -4269,14 +4239,8 @@ describe("startGatewayPostAttachRuntime", () => {
 
   it("does not activate restored recovery when close begins during activation loading", async () => {
     let closeStarted = false;
-    let releaseRecoveryLoad: (() => void) | undefined;
-    const recoveryLoadReady = new Promise<void>((resolve) => {
-      releaseRecoveryLoad = resolve;
-    });
-    let markRecoveryLoadStarted: (() => void) | undefined;
-    const recoveryLoadStarted = new Promise<void>((resolve) => {
-      markRecoveryLoadStarted = resolve;
-    });
+    const { promise: recoveryLoadReady, resolve: releaseRecoveryLoad } = createDeferred();
+    const { promise: recoveryLoadStarted, resolve: markRecoveryLoadStarted } = createDeferred();
     const pluginServices: PluginServicesHandle = {
       reload: vi.fn(async () => {}),
       stop: vi.fn(async () => {}),
@@ -4342,10 +4306,7 @@ describe("startGatewayPostAttachRuntime", () => {
       typedHooks: [],
     } as never;
     const loaded = { pluginRegistry, gatewayMethods: ["core.ping"] };
-    let releasePluginLoad: (() => void) | undefined;
-    const pluginLoadReady = new Promise<void>((resolve) => {
-      releasePluginLoad = resolve;
-    });
+    const { promise: pluginLoadReady, resolve: releasePluginLoad } = createDeferred();
     const loadStartupPlugins = vi.fn(async () => {
       await pluginLoadReady;
       return loaded;
@@ -4444,10 +4405,7 @@ describe("startGatewayPostAttachRuntime", () => {
     vi.useFakeTimers();
     hoisted.hasInternalHookListeners.mockReturnValue(true);
     const trace = createStartupTraceRecorder();
-    let releasePostReadyWork!: () => void;
-    const postReadyWork = new Promise<void>((resolve) => {
-      releasePostReadyWork = resolve;
-    });
+    const { promise: postReadyWork, resolve: releasePostReadyWork } = createDeferred();
 
     const result = await startGatewaySidecars({
       cfg: {} as never,


### PR DESCRIPTION
## What Problem This Solves

Post-attach startup tests repeat promise/resolver setup for local synchronization gates.

## Why This Change Was Made

Use the existing deferred helper for 14 audited gates, preserving their names and allocation points. Seven callback/generation gates remain untouched. Every case, assertion, and gate use stays unchanged; this removes 42 net test lines without production changes.

## User Impact

Less repeated fixture code while retaining startup and lifecycle coverage. No runtime improvement is claimed.

## Evidence

All 117 file cases pass before and after, plus eight sibling cases. The full changed-file gate, deslop, and independent review through P2 pass. Preservation comparison matches 33,275 normalized tokens, including all 14 allocation markers.
