### PR TITLE
fix(release): accept reviewed Codex cleanup fixture spawns

### DIFF
--- a/scripts/lib/plugin-npm-security-scan.mts
+++ b/scripts/lib/plugin-npm-security-scan.mts
@@ -143,6 +143,7 @@ const CURRENT_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS = new Map<string, number>(
   ["@openclaw/codex:dangerous-exec:dist/session-catalog-<hash>.js", 1],
   ["@openclaw/codex:dangerous-exec:dist/transport-stdio-<hash>.js", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/attempt-startup-retry.test.ts", 6],
+  ["@openclaw/codex:dangerous-exec:src/app-server/run-attempt-one-shot-cleanup.test.ts", 3],
   ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server.http.test.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-orphan.test-helper.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-orphan.test.ts", 3],

--- a/test/scripts/plugin-npm-security-scan.test.ts
+++ b/test/scripts/plugin-npm-security-scan.test.ts
@@ -309,6 +309,57 @@ describe("scripts/lib/plugin-npm-security-scan.mts", () => {
     },
   );
 
+  it.each([3, 4])(
+    "reviews exactly three current Codex cleanup fixture spawns, preserving frozen policy: %s",
+    async (count) => {
+      const packageName = "@openclaw/codex";
+      const fixtureKey = `${packageName}:dangerous-exec:src/app-server/run-attempt-one-shot-cleanup.test.ts`;
+      const fixture = [
+        'import { spawn } from "node:child_process";',
+        ...Array.from({ length: count }, () => 'spawn(process.execPath, ["fixture.mjs"]);'),
+      ].join("\n");
+      const artifact = writePluginArtifact({
+        extensionId: "codex",
+        files: { "src/app-server/run-attempt-one-shot-cleanup.test.ts": fixture },
+        packageName,
+      });
+      const current = await scanPublishablePluginPackages([artifact.artifact]);
+      expect(current.scanErrors).toEqual([]);
+      expect(current.packageResults[0]?.unexpectedCriticalFindings).toEqual([]);
+      expect(current.packageResults[0]?.reviewedCriticalFindings).toEqual(
+        Array.from({ length: count }, () => fixtureKey),
+      );
+      const currentReport = buildPluginNpmSecurityScanReport({
+        candidateSha: CANDIDATE_SHA,
+        packageResults: [
+          {
+            ...current.packageResults[0]!,
+            reviewedCriticalFindings: [
+              ...current.packageResults[0]!.reviewedCriticalFindings,
+              `${packageName}:dangerous-exec:src/app-server/transport-stdio.ts`,
+              `${packageName}:dangerous-exec:src/doctor.ts`,
+              ...currentLayoutFindings(),
+            ],
+          },
+        ],
+        toolingSha: TOOLING_SHA,
+      });
+      const packageErrors = currentReport.errors.filter((error) =>
+        error.startsWith(`${packageName}:`),
+      );
+      expect(packageErrors).toEqual(
+        count === 3 ? [] : [expect.stringContaining("reviewed critical inventory mismatch")],
+      );
+
+      const frozen = await scanPublishablePluginPackages(
+        [artifact.artifact],
+        "extended-stable/2026.6.33",
+      );
+      expect(frozen.scanErrors).toEqual([]);
+      expect(frozen.packageResults[0]?.unexpectedCriticalFindings).toHaveLength(count);
+    },
+  );
+
   it("scans checked-in malicious code without running candidate hooks or helpers", async () => {
     const candidateRoot = tempDirs.make("openclaw-plugin-security-inert-pack-");
     const artifactRoot = tempDirs.make("openclaw-plugin-security-inert-artifacts-");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where current-main full release validation rejects the Codex npm artifact after the one-shot cleanup regression fixture added three reviewed process spawns.

## Why This Change Was Made

The npm security scanner deliberately inspects supplemental inert packed source, including tests. The new calls live only in `src/app-server/run-attempt-one-shot-cleanup.test.ts`, are not imported by plugin runtime code, and are packed because the Codex package includes source tests. Add that exact path and exact count to the current optional packed-source inventory; the frozen extended-stable inventory remains unchanged.

Direct upstream Codex inspection at `578c1b2230288104041e880a86d0f7f3a5ca6e47` confirms that the distinct `process/spawn` API is experimental, connection-scoped, and intentionally unsandboxed (`codex-rs/app-server-protocol/src/protocol/v2/process.rs:20`, `codex-rs/app-server/src/request_processors/process_exec_processor.rs:68`, `codex-rs/app-server/src/message_processor.rs:1443`). This repair does not change that protocol or any runtime execution path.

## User Impact

No product/runtime behavior changes. Current-main release validation can accept the known inert fixture findings while continuing to fail closed on extra calls or any unreviewed path.

## Evidence

- Red: the focused scanner regression reported all three fixture calls as unexpected before the policy entry.
- Green: `pnpm exec vitest run --config vitest.config.ts test/scripts/plugin-npm-security-scan.test.ts` — 18 tests passed.
- Exact-count proof: three calls pass; a fourth produces `reviewed critical inventory mismatch`.
- Frozen-policy proof: `extended-stable/2026.6.33` still reports all fixture calls as unexpected.
- Artifact proof: `npm pack --dry-run --json --ignore-scripts` includes `src/app-server/run-attempt-one-shot-cleanup.test.ts`.
- Changed gates: `node scripts/check-changed.mjs -- scripts/lib/plugin-npm-security-scan.mts test/scripts/plugin-npm-security-scan.test.ts` passed.
- Independent autoreview: scoped clean, patch correct, confidence 0.96.

Tooling policy: +1 line. Tests: +51 lines. Product/runtime: 0 lines.
