### PR TITLE
fix(doctor): exclude sidecar ctime/mtime from cleanup verifier (#140467)

### DIFF
--- a/src/commands/doctor-session-sqlite-verification.test.ts
+++ b/src/commands/doctor-session-sqlite-verification.test.ts
@@ -1,0 +1,133 @@
+// Regression tests for the recovery destination verifier. Sidecar files (WAL/SHM/journal)
+// can have ctime/mtime/size churn from read-only queries; only their identity (dev/ino)
+// is fenced. The main database file is fully fenced so substantive writes are still
+// detected after a WAL checkpoint. (#140467)
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
+import type { SessionSqliteMigrationTargetManifest } from "./doctor-session-sqlite-migration-run.js";
+import { createRecoveryDestinationVerifier } from "./doctor-session-sqlite-verification.js";
+
+const autoCleanupTempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function makeMinimalTargetManifest(
+  sqlitePath: string,
+  agentId: string,
+): SessionSqliteMigrationTargetManifest {
+  return {
+    agentId,
+    sqlitePath,
+    storePath: path.dirname(sqlitePath),
+    completedMoves: [],
+    issues: [],
+    plannedMoves: [],
+    validationBeforeArchive: "not_run",
+  };
+}
+
+describe("createRecoveryDestinationVerifier", () => {
+  let stateDir: string;
+  let agentId: string;
+  let sqlitePath: string;
+
+  beforeEach(() => {
+    stateDir = autoCleanupTempDirs.make("verification-");
+    agentId = "test-agent";
+    sqlitePath = resolveOpenClawAgentSqlitePath({
+      agentId,
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    fs.mkdirSync(path.dirname(sqlitePath), { recursive: true });
+    const db = openOpenClawAgentDatabase({
+      agentId,
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    // Force WAL/SHM files to exist by writing a row then checkpointing.
+    db.db.exec(
+      `CREATE TABLE IF NOT EXISTS probe (id INTEGER PRIMARY KEY);
+       INSERT INTO probe (id) VALUES (1);`,
+    );
+    db.db.exec("PRAGMA wal_checkpoint(TRUNCATE);");
+    // Reopen to recreate WAL/SHM, then leave them in place after close.
+    db.db.exec("INSERT INTO probe (id) VALUES (2);");
+    closeOpenClawAgentDatabasesForTest();
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+  });
+
+  it("does not throw when a sidecar file's ctime/mtime changes from a read-only query", () => {
+    const verify = createRecoveryDestinationVerifier(stateDir);
+    const target = makeMinimalTargetManifest(sqlitePath, agentId);
+
+    // Establish baseline.
+    verify([{ target }]);
+
+    // Simulate a read-only query touching WAL/SHM state by advancing their
+    // mtime/ctime well past the baseline.
+    const sidecarPaths = resolveSqliteDatabaseFilePaths(sqlitePath).slice(1);
+    const future = new Date((Date.now() / 1000) * 1000 + 60_000);
+    for (const sidecar of sidecarPaths) {
+      if (fs.existsSync(sidecar)) {
+        fs.utimesSync(sidecar, future, future);
+      }
+    }
+
+    // Should NOT throw — sidecar dev/ino are unchanged, only ctime/mtime churned.
+    expect(() => verify([{ target }])).not.toThrow();
+  });
+
+  it("throws when the main database file's mtime changes (substantive write)", () => {
+    const verify = createRecoveryDestinationVerifier(stateDir);
+    const target = makeMinimalTargetManifest(sqlitePath, agentId);
+
+    // Establish baseline.
+    verify([{ target }]);
+
+    // Simulate a substantive write to the main database file.
+    const future = new Date((Date.now() / 1000) * 1000 + 60_000);
+    fs.utimesSync(sqlitePath, future, future);
+
+    // SHOULD throw — main DB (index 0) is fully fenced.
+    expect(() => verify([{ target }])).toThrow(
+      "Recovery destination database changed; preview cleanup again.",
+    );
+  });
+
+  it("throws when a sidecar file is replaced with a different inode (identity change)", () => {
+    const verify = createRecoveryDestinationVerifier(stateDir);
+    const target = makeMinimalTargetManifest(sqlitePath, agentId);
+
+    // Establish baseline.
+    verify([{ target }]);
+
+    // Replace a sidecar file with a new file (different inode).
+    const walPath = `${sqlitePath}-wal`;
+    if (fs.existsSync(walPath)) {
+      fs.unlinkSync(walPath);
+    }
+    fs.writeFileSync(walPath, Buffer.alloc(32));
+
+    // SHOULD throw — sidecar dev/ino changed (identity change is always fenced).
+    expect(() => verify([{ target }])).toThrow(
+      "Recovery destination database changed; preview cleanup again.",
+    );
+  });
+
+  it("establishes baseline and passes on a clean re-check", () => {
+    const verify = createRecoveryDestinationVerifier(stateDir);
+    const target = makeMinimalTargetManifest(sqlitePath, agentId);
+
+    verify([{ target }]);
+    // A clean re-check with no changes should not throw.
+    expect(() => verify([{ target }])).not.toThrow();
+  });
+});

--- a/src/commands/doctor-session-sqlite-verification.test.ts
+++ b/src/commands/doctor-session-sqlite-verification.test.ts
@@ -102,24 +102,31 @@ describe("createRecoveryDestinationVerifier", () => {
     );
   });
 
-  it("throws when a sidecar file is replaced with a different inode (identity change)", () => {
+  it("throws when a sidecar file is deleted after baseline (identity loss)", () => {
     const verify = createRecoveryDestinationVerifier(stateDir);
     const target = makeMinimalTargetManifest(sqlitePath, agentId);
 
     // Establish baseline.
     verify([{ target }]);
 
-    // Replace a sidecar file with a new file (different inode).
+    // Delete a sidecar file that existed in the baseline. The verifier should
+    // detect the identity change (dev/ino now undefined vs. recorded BigInt).
     const walPath = `${sqlitePath}-wal`;
     if (fs.existsSync(walPath)) {
       fs.unlinkSync(walPath);
+      // SHOULD throw — sidecar identity (dev/ino) changed from recorded to undefined.
+      expect(() => verify([{ target }])).toThrow(
+        "Recovery destination database changed; preview cleanup again.",
+      );
+    } else {
+      // If no WAL sidecar exists, create one and verify deletion is detected.
+      fs.writeFileSync(walPath, Buffer.alloc(32));
+      verify([{ target }]); // Re-establish baseline with the WAL present.
+      fs.unlinkSync(walPath);
+      expect(() => verify([{ target }])).toThrow(
+        "Recovery destination database changed; preview cleanup again.",
+      );
     }
-    fs.writeFileSync(walPath, Buffer.alloc(32));
-
-    // SHOULD throw — sidecar dev/ino changed (identity change is always fenced).
-    expect(() => verify([{ target }])).toThrow(
-      "Recovery destination database changed; preview cleanup again.",
-    );
   });
 
   it("establishes baseline and passes on a clean re-check", () => {

--- a/src/commands/doctor-session-sqlite-verification.test.ts
+++ b/src/commands/doctor-session-sqlite-verification.test.ts
@@ -71,9 +71,11 @@ describe("createRecoveryDestinationVerifier", () => {
     // Establish baseline.
     verify([{ target }]);
 
-    // Simulate a read-only query touching WAL/SHM state by advancing their
-    // mtime/ctime well past the baseline.
-    const sidecarPaths = resolveSqliteDatabaseFilePaths(sqlitePath).slice(1);
+    // Simulate a read-only query touching SHM/journal state by advancing their
+    // mtime/ctime well past the baseline.  Only SHM/journal sidecars (index >= 2) are
+    // exempt from ctime/mtime fencing; the WAL file is still fully fenced because
+    // read-only transactions do not write to the WAL. (#140467)
+    const sidecarPaths = resolveSqliteDatabaseFilePaths(sqlitePath).slice(2);
     const future = new Date((Date.now() / 1000) * 1000 + 60_000);
     for (const sidecar of sidecarPaths) {
       if (fs.existsSync(sidecar)) {
@@ -81,7 +83,7 @@ describe("createRecoveryDestinationVerifier", () => {
       }
     }
 
-    // Should NOT throw — sidecar dev/ino are unchanged, only ctime/mtime churned.
+    // Should NOT throw — SHM/journal dev/ino/size are unchanged, only ctime/mtime churned.
     expect(() => verify([{ target }])).not.toThrow();
   });
 
@@ -137,7 +139,31 @@ describe("createRecoveryDestinationVerifier", () => {
     const initial = fs.existsSync(walPath) ? fs.readFileSync(walPath) : Buffer.alloc(0);
     fs.writeFileSync(walPath, Buffer.alloc(initial.length + 4096));
 
-    // SHOULD throw — sidecar size changed (substantive write is still fenced).
+    // SHOULD throw — WAL size changed (substantive write is still fenced).
+    expect(() => verify([{ target }])).toThrow(
+      "Recovery destination database changed; preview cleanup again.",
+    );
+  });
+
+  it("throws when the WAL file's content changes at the same size (same-size WAL commit)", () => {
+    const verify = createRecoveryDestinationVerifier(stateDir);
+    const target = makeMinimalTargetManifest(sqlitePath, agentId);
+
+    // Ensure a WAL sidecar exists with a known payload before baseline.
+    const walPath = `${sqlitePath}-wal`;
+    const payload = Buffer.alloc(256, 0xab);
+    fs.writeFileSync(walPath, payload);
+
+    // Establish baseline.
+    verify([{ target }]);
+
+    // Overwrite the WAL content WITHOUT changing its size (simulates a same-size WAL
+    // commit where SQLite recycles the existing WAL space). (#140467)
+    const sameSize = Buffer.alloc(256, 0xcd);
+    fs.writeFileSync(walPath, sameSize);
+
+    // SHOULD throw — the WAL file (index 1) is fully fenced, so the ctime/mtime change
+    // from the in-place content rewrite is detected even though size is unchanged.
     expect(() => verify([{ target }])).toThrow(
       "Recovery destination database changed; preview cleanup again.",
     );

--- a/src/commands/doctor-session-sqlite-verification.test.ts
+++ b/src/commands/doctor-session-sqlite-verification.test.ts
@@ -75,7 +75,7 @@ describe("createRecoveryDestinationVerifier", () => {
     // mtime/ctime well past the baseline.  Only the SHM file (index 2) is exempt from
     // ctime/mtime fencing — read-only queries update SHM read marks. The WAL (index 1)
     // and rollback journal (index 3) are still fully fenced. (#140467)
-    const shmPath = resolveSqliteDatabaseFilePaths(sqlitePath)[2];
+    const shmPath = resolveSqliteDatabaseFilePaths(sqlitePath)[2]!;
     const future = new Date((Date.now() / 1000) * 1000 + 60_000);
     if (fs.existsSync(shmPath)) {
       fs.utimesSync(shmPath, future, future);
@@ -159,6 +159,12 @@ describe("createRecoveryDestinationVerifier", () => {
     // commit where SQLite recycles the existing WAL space). (#140467)
     const sameSize = Buffer.alloc(256, 0xcd);
     fs.writeFileSync(walPath, sameSize);
+
+    // Explicitly advance the mtime past the baseline so the test is deterministic across
+    // platforms — on some Linux filesystems a same-size rewrite may land within the same
+    // nanosecond tick as the baseline. A real same-size WAL commit changes the WAL mtime.
+    const walFuture = new Date((Date.now() / 1000) * 1000 + 60_000);
+    fs.utimesSync(walPath, walFuture, walFuture);
 
     // SHOULD throw — the WAL file (index 1) is fully fenced, so the ctime/mtime change
     // from the in-place content rewrite is detected even though size is unchanged.

--- a/src/commands/doctor-session-sqlite-verification.test.ts
+++ b/src/commands/doctor-session-sqlite-verification.test.ts
@@ -71,19 +71,17 @@ describe("createRecoveryDestinationVerifier", () => {
     // Establish baseline.
     verify([{ target }]);
 
-    // Simulate a read-only query touching SHM/journal state by advancing their
-    // mtime/ctime well past the baseline.  Only SHM/journal sidecars (index >= 2) are
-    // exempt from ctime/mtime fencing; the WAL file is still fully fenced because
-    // read-only transactions do not write to the WAL. (#140467)
-    const sidecarPaths = resolveSqliteDatabaseFilePaths(sqlitePath).slice(2);
+    // Simulate a read-only query touching SHM state by advancing the SHM file's
+    // mtime/ctime well past the baseline.  Only the SHM file (index 2) is exempt from
+    // ctime/mtime fencing — read-only queries update SHM read marks. The WAL (index 1)
+    // and rollback journal (index 3) are still fully fenced. (#140467)
+    const shmPath = resolveSqliteDatabaseFilePaths(sqlitePath)[2];
     const future = new Date((Date.now() / 1000) * 1000 + 60_000);
-    for (const sidecar of sidecarPaths) {
-      if (fs.existsSync(sidecar)) {
-        fs.utimesSync(sidecar, future, future);
-      }
+    if (fs.existsSync(shmPath)) {
+      fs.utimesSync(shmPath, future, future);
     }
 
-    // Should NOT throw — SHM/journal dev/ino/size are unchanged, only ctime/mtime churned.
+    // Should NOT throw — SHM dev/ino/size are unchanged, only ctime/mtime churned.
     expect(() => verify([{ target }])).not.toThrow();
   });
 

--- a/src/commands/doctor-session-sqlite-verification.test.ts
+++ b/src/commands/doctor-session-sqlite-verification.test.ts
@@ -106,27 +106,21 @@ describe("createRecoveryDestinationVerifier", () => {
     const verify = createRecoveryDestinationVerifier(stateDir);
     const target = makeMinimalTargetManifest(sqlitePath, agentId);
 
-    // Establish baseline.
+    // Ensure a WAL sidecar exists before baseline so the fallback path is deterministic.
+    const walPath = `${sqlitePath}-wal`;
+    if (!fs.existsSync(walPath)) {
+      fs.writeFileSync(walPath, Buffer.alloc(32));
+    }
+
+    // Establish baseline with the WAL present.
     verify([{ target }]);
 
-    // Delete a sidecar file that existed in the baseline. The verifier should
-    // detect the identity change (dev/ino now undefined vs. recorded BigInt).
-    const walPath = `${sqlitePath}-wal`;
-    if (fs.existsSync(walPath)) {
-      fs.unlinkSync(walPath);
-      // SHOULD throw — sidecar identity (dev/ino) changed from recorded to undefined.
-      expect(() => verify([{ target }])).toThrow(
-        "Recovery destination database changed; preview cleanup again.",
-      );
-    } else {
-      // If no WAL sidecar exists, create one and verify deletion is detected.
-      fs.writeFileSync(walPath, Buffer.alloc(32));
-      verify([{ target }]); // Re-establish baseline with the WAL present.
-      fs.unlinkSync(walPath);
-      expect(() => verify([{ target }])).toThrow(
-        "Recovery destination database changed; preview cleanup again.",
-      );
-    }
+    // Delete the sidecar that existed in the baseline. The verifier should detect the
+    // identity change (dev/ino now undefined vs. recorded BigInt). (#140467)
+    fs.unlinkSync(walPath);
+    expect(() => verify([{ target }])).toThrow(
+      "Recovery destination database changed; preview cleanup again.",
+    );
   });
 
   it("throws when a sidecar file's size changes (substantive WAL commit)", () => {

--- a/src/commands/doctor-session-sqlite-verification.test.ts
+++ b/src/commands/doctor-session-sqlite-verification.test.ts
@@ -129,6 +129,26 @@ describe("createRecoveryDestinationVerifier", () => {
     }
   });
 
+  it("throws when a sidecar file's size changes (substantive WAL commit)", () => {
+    const verify = createRecoveryDestinationVerifier(stateDir);
+    const target = makeMinimalTargetManifest(sqlitePath, agentId);
+
+    // Establish baseline.
+    verify([{ target }]);
+
+    // Grow the WAL sidecar file (simulates a substantive WAL commit that appends frames).
+    // The verifier should detect the size change on the sidecar even though ctime/mtime are
+    // excluded, because substantive writes must still be caught. (#140467)
+    const walPath = `${sqlitePath}-wal`;
+    const initial = fs.existsSync(walPath) ? fs.readFileSync(walPath) : Buffer.alloc(0);
+    fs.writeFileSync(walPath, Buffer.alloc(initial.length + 4096));
+
+    // SHOULD throw — sidecar size changed (substantive write is still fenced).
+    expect(() => verify([{ target }])).toThrow(
+      "Recovery destination database changed; preview cleanup again.",
+    );
+  });
+
   it("establishes baseline and passes on a clean re-check", () => {
     const verify = createRecoveryDestinationVerifier(stateDir);
     const target = makeMinimalTargetManifest(sqlitePath, agentId);

--- a/src/commands/doctor-session-sqlite-verification.ts
+++ b/src/commands/doctor-session-sqlite-verification.ts
@@ -46,12 +46,11 @@ export function createRecoveryDestinationVerifier(stateDir: string) {
       }
       // Even a read-only SQLite connection can create or update WAL/SHM files. Establish the
       // baseline after owner inspection closes it; later checks only stat, never reopen or hash
-      // the DB.  Sidecar files (WAL/SHM/journal) can have ctime/mtime churn from read-only
-      // queries (e.g. `openclaw sessions --all-agents --json`), so their ctime/mtime are excluded
-      // from the fence.  Identity (dev/ino) and size are still checked for sidecars so that a
-      // substantive WAL commit (which grows the WAL) and file replacement are detected.  The main
-      // database file (index 0) is fully fenced so in-place writes are detected after a checkpoint.
-      // (#140467)
+      // the DB.  Read-only queries update the SHM file (read marks) and may create WAL/SHM/journal
+      // sidecars, so their ctime/mtime are excluded from the fence to avoid false positives.
+      // The WAL file (index 1) is still fully fenced because read-only transactions do not write
+      // to the WAL — a substantive same-size or growing WAL commit is detected via ctime/mtime/
+      // size, and the main database file (index 0) is fully fenced for in-place writes. (#140467)
       const files = paths.map((file) =>
         fs.lstatSync(file, { bigint: true, throwIfNoEntry: false }),
       );
@@ -61,7 +60,7 @@ export function createRecoveryDestinationVerifier(stateDir: string) {
         (expected &&
           (expected.agentId !== target.agentId ||
             files.some((file, index) =>
-              (index === 0
+              (index <= 1
                 ? (["dev", "ino", "ctimeNs", "mtimeNs", "size"] as const)
                 : (["dev", "ino", "size"] as const)
               ).some((key) => file?.[key] !== expected.files[index]?.[key]),

--- a/src/commands/doctor-session-sqlite-verification.ts
+++ b/src/commands/doctor-session-sqlite-verification.ts
@@ -46,11 +46,12 @@ export function createRecoveryDestinationVerifier(stateDir: string) {
       }
       // Even a read-only SQLite connection can create or update WAL/SHM files. Establish the
       // baseline after owner inspection closes it; later checks only stat, never reopen or hash
-      // the DB.  Read-only queries update the SHM file (read marks) and may create WAL/SHM/journal
-      // sidecars, so their ctime/mtime are excluded from the fence to avoid false positives.
-      // The WAL file (index 1) is still fully fenced because read-only transactions do not write
-      // to the WAL — a substantive same-size or growing WAL commit is detected via ctime/mtime/
-      // size, and the main database file (index 0) is fully fenced for in-place writes. (#140467)
+      // the DB.  Read-only queries update the SHM file (read marks) — the only sidecar whose
+      // ctime/mtime is excluded from the fence. The WAL file (index 1) is fully fenced because
+      // read-only transactions do not write to the WAL, so a substantive same-size or growing
+      // WAL commit is detected via ctime/mtime/size. The rollback journal (index 3) is fully
+      // fenced because it carries database pages and recovery metadata, not reader marks.
+      // The main database file (index 0) is fully fenced for in-place writes. (#140467)
       const files = paths.map((file) =>
         fs.lstatSync(file, { bigint: true, throwIfNoEntry: false }),
       );
@@ -60,9 +61,9 @@ export function createRecoveryDestinationVerifier(stateDir: string) {
         (expected &&
           (expected.agentId !== target.agentId ||
             files.some((file, index) =>
-              (index <= 1
-                ? (["dev", "ino", "ctimeNs", "mtimeNs", "size"] as const)
-                : (["dev", "ino", "size"] as const)
+              (index === 2
+                ? (["dev", "ino", "size"] as const)
+                : (["dev", "ino", "ctimeNs", "mtimeNs", "size"] as const)
               ).some((key) => file?.[key] !== expected.files[index]?.[key]),
             )))
       ) {

--- a/src/commands/doctor-session-sqlite-verification.ts
+++ b/src/commands/doctor-session-sqlite-verification.ts
@@ -46,10 +46,12 @@ export function createRecoveryDestinationVerifier(stateDir: string) {
       }
       // Even a read-only SQLite connection can create or update WAL/SHM files. Establish the
       // baseline after owner inspection closes it; later checks only stat, never reopen or hash
-      // the DB.  Sidecar files (WAL/SHM/journal) can have ctime/mtime/size churn from read-only
-      // queries (e.g. `openclaw sessions --all-agents --json`), so only their identity (dev/ino)
-      // is fenced.  The main database file (index 0) is fully fenced so substantive writes are
-      // still detected after a WAL checkpoint. (#140467)
+      // the DB.  Sidecar files (WAL/SHM/journal) can have ctime/mtime churn from read-only
+      // queries (e.g. `openclaw sessions --all-agents --json`), so their ctime/mtime are excluded
+      // from the fence.  Identity (dev/ino) and size are still checked for sidecars so that a
+      // substantive WAL commit (which grows the WAL) and file replacement are detected.  The main
+      // database file (index 0) is fully fenced so in-place writes are detected after a checkpoint.
+      // (#140467)
       const files = paths.map((file) =>
         fs.lstatSync(file, { bigint: true, throwIfNoEntry: false }),
       );
@@ -61,7 +63,7 @@ export function createRecoveryDestinationVerifier(stateDir: string) {
             files.some((file, index) =>
               (index === 0
                 ? (["dev", "ino", "ctimeNs", "mtimeNs", "size"] as const)
-                : (["dev", "ino"] as const)
+                : (["dev", "ino", "size"] as const)
               ).some((key) => file?.[key] !== expected.files[index]?.[key]),
             )))
       ) {

--- a/src/commands/doctor-session-sqlite-verification.ts
+++ b/src/commands/doctor-session-sqlite-verification.ts
@@ -44,8 +44,12 @@ export function createRecoveryDestinationVerifier(stateDir: string) {
           throw new Error("destination database ownership cannot be verified");
         }
       }
-      // Even a read-only SQLite connection can create WAL/SHM files. Establish the baseline
-      // after owner inspection closes it; later checks only stat, never reopen or hash the DB.
+      // Even a read-only SQLite connection can create or update WAL/SHM files. Establish the
+      // baseline after owner inspection closes it; later checks only stat, never reopen or hash
+      // the DB.  Sidecar files (WAL/SHM/journal) can have ctime/mtime/size churn from read-only
+      // queries (e.g. `openclaw sessions --all-agents --json`), so only their identity (dev/ino)
+      // is fenced.  The main database file (index 0) is fully fenced so substantive writes are
+      // still detected after a WAL checkpoint. (#140467)
       const files = paths.map((file) =>
         fs.lstatSync(file, { bigint: true, throwIfNoEntry: false }),
       );
@@ -55,9 +59,10 @@ export function createRecoveryDestinationVerifier(stateDir: string) {
         (expected &&
           (expected.agentId !== target.agentId ||
             files.some((file, index) =>
-              (["dev", "ino", "ctimeNs", "mtimeNs", "size"] as const).some(
-                (key) => file?.[key] !== expected.files[index]?.[key],
-              ),
+              (index === 0
+                ? (["dev", "ino", "ctimeNs", "mtimeNs", "size"] as const)
+                : (["dev", "ino"] as const)
+              ).some((key) => file?.[key] !== expected.files[index]?.[key]),
             )))
       ) {
         throw new Error("Recovery destination database changed; preview cleanup again.");


### PR DESCRIPTION
## What Problem This Solves

`openclaw update cleanup` (migration recovery retirement) aborts with **"Recovery destination database changed; preview cleanup again."** whenever a separate read-only process (e.g. `openclaw sessions --all-agents --json`) has touched the destination SQLite database since the preview was captured. Read-only SQLite connections in WAL mode update the SHM file's read marks (mtime/ctime churn) — the cleanup verifier fences ALL stat fields for ALL files including sidecars, so this harmless SHM churn trips a false positive and blocks retirement of stale recovery originals. Closes #140467.

## Root Cause

`createRecoveryDestinationVerifier` in `src/commands/doctor-session-sqlite-verification.ts` fences `["dev", "ino", "ctimeNs", "mtimeNs", "size"]` for **all** files. A read-only query (separate process) opens the DB in WAL mode and writes read marks to the **SHM** file → SHM `mtimeNs`/`ctimeNs` change → false positive.

## Fix — narrowest possible exception (SHM only)

Only the **SHM file (index 2)** gets the ctime/mtime exception. Everything else is fully fenced:

| File | Index | Fenced fields | Rationale |
|------|-------|--------------|-----------|
| Main DB | 0 | dev/ino/ctime/mtime/size | Unchanged — in-place writes after checkpoint detected |
| WAL (`-wal`) | 1 | dev/ino/ctime/mtime/size | **Fully fenced** — read-only transactions don't write to WAL ([SQLite WAL spec](https://www.sqlite.org/wal.html)); same-size and growing WAL commits detected via ctime/mtime/size |
| SHM (`-shm`) | 2 | dev/ino/size | **Exception** — read-only queries update SHM read marks (the false-positive source); size changes still detected |
| Journal (`-journal`) | 3 | dev/ino/ctime/mtime/size | **Fully fenced** — rollback journal carries database pages and recovery metadata, not reader marks; same-size journal rewrites detected |

This addresses both ClawSweeper findings:
- **P1 (same-size WAL commits)**: WAL is fully fenced → same-size WAL commit detected via ctime/mtime ✓
- **P2 (rollback journal exception)**: Only SHM (index 2) is exempt; journal is fully fenced ✓

## Evidence

### Test results (commit `9e3a23fca`)

**6 new regression tests** in `src/commands/doctor-session-sqlite-verification.test.ts`:
```
 ✓ does not throw when a sidecar file's ctime/mtime changes from a read-only query
   (advances SHM mtime only → no throw)
 ✓ throws when the main database file's mtime changes (substantive write)
 ✓ throws when a sidecar file is deleted after baseline (identity loss: dev/ino → undefined)
 ✓ throws when a sidecar file's size changes (substantive WAL commit: growing WAL)
 ✓ throws when the WAL file's content changes at the same size (same-size WAL commit)
   (overwrite WAL content at same size → throw via WAL ctime/mtime)
 ✓ establishes baseline and passes on a clean re-check
 Tests  6 passed (6)
```

**9 existing cleanup flow tests** in `src/commands/doctor-session-sqlite.test.ts` (full `retireSessionSqliteRecovery` flow, 3 phases × 3 change types):
```
 ✓ retains originals after destination WAL commit during confirmation/publication/unlink-intent
 ✓ retains originals after destination in-place edit during confirmation/publication/unlink-intent
 ✓ retains originals after destination truncation during confirmation/publication/unlink-intent
 Tests  9 passed | 222 skipped (231)
```

These existing tests exercise the **real cleanup flow** (`retireSessionSqliteRecovery` → `assertDestinations` → `createRecoveryDestinationVerifier`) and confirm substantive WAL commits, in-place edits, and truncation all retain recovery originals. The fix preserves this detection.

### Why the SHM exception is the narrowest correct fix

Per [SQLite WAL documentation](https://www.sqlite.org/wal.html):
1. **Read-only transactions** acquire a read lock on the WAL but **do not write to the WAL file** — they only update SHM read marks. So the WAL file's ctime/mtime are only changed by substantive commits.
2. **SHM file** stores reader metadata (read marks) — read-only queries update it → this is the false-positive source from issue #140467.
3. **Rollback journal** carries database pages and recovery metadata, not reader marks — same-size journal rewrites are substantive and must be detected.
4. **Main DB** in-place writes after checkpoint change ctime/mtime/size — must be detected.

The fix exempts ONLY the SHM file's ctime/mtime. All other files (main DB, WAL, journal) retain full 5-field fencing. This is the minimal change that fixes the false positive without weakening durable-change detection.
