### PR TITLE
fix(models): keep status plugin metadata isolated

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2499,7 +2499,6 @@ src/commands/models/list.persisted-catalog.ts	2
 src/commands/models/list.probe.ts	2
 src/commands/models/list.registry.ts	3
 src/commands/models/list.rows.ts	3
-src/commands/models/list.status-command.ts	1
 src/commands/models/shared.ts	3
 src/commands/onboard-agent.ts	1
 src/commands/onboard-config.ts	3

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -72,12 +72,8 @@ import { parseModelPolicyWildcardRef } from "../../config/model-policy-ref.js";
 import { resolveMergedModelProviderConfig } from "../../config/model-provider-config.js";
 import { getShellEnvAppliedKeys, shouldEnableShellEnvFallback } from "../../infra/shell-env.js";
 import type { ProviderModelRouteCandidate } from "../../plugin-sdk/provider-model-types.js";
-import {
-  getCurrentPluginMetadataSnapshot,
-  installTemporaryCurrentPluginMetadataSnapshot,
-} from "../../plugins/current-plugin-metadata-snapshot.js";
+import { withPluginMetadataSnapshotScope } from "../../plugins/current-plugin-metadata-snapshot.js";
 import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
-import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import type { ProviderSyntheticAuthResult } from "../../plugins/provider-external-auth.types.js";
 import { prepareProviderSyntheticAuthWithPlugin } from "../../plugins/provider-runtime.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../../plugins/synthetic-auth.runtime.js";
@@ -222,43 +218,6 @@ function parseOptionalPositiveIntegerOption(raw: unknown, label: string, fallbac
   return parsed;
 }
 
-function isCompletePluginMetadataSnapshot(value: unknown): value is PluginMetadataSnapshot {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const snapshot = value as Partial<PluginMetadataSnapshot>;
-  return (
-    typeof snapshot.policyHash === "string" &&
-    snapshot.index !== undefined &&
-    snapshot.manifestRegistry !== undefined
-  );
-}
-
-function installCommandPluginMetadataSnapshot(params: {
-  snapshot: PluginMetadataSnapshot;
-  config: Awaited<ReturnType<typeof loadModelsConfig>>;
-  workspaceDir?: string;
-  env: NodeJS.ProcessEnv;
-}): () => void {
-  if (!isCompletePluginMetadataSnapshot(params.snapshot)) {
-    return () => {};
-  }
-  const current = getCurrentPluginMetadataSnapshot({
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-  });
-  if (current) {
-    return () => {};
-  }
-  const lease = installTemporaryCurrentPluginMetadataSnapshot(params.snapshot, {
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-  });
-  return lease.release;
-}
-
 function syntheticAuthCredential(
   provider: string,
   auth: StatusSyntheticAuth,
@@ -388,1347 +347,1346 @@ export async function modelsStatusCommand(
     codexRuntimeAvailabilityByProvider.set(provider, pending);
     return pending;
   };
-  const cleanupPluginMetadataSnapshot = installCommandPluginMetadataSnapshot({
-    snapshot: metadataSnapshot,
-    config: cfg,
-    workspaceDir,
-    env: process.env,
-  });
-  try {
-    // agentId, not a synthetic config carrying the agent's primary into global
-    // defaults: the canonical resolvers merge per-agent model rows themselves, so
-    // the synthetic route resolved a bare per-agent alias against global defaults
-    // and reported a different provider than runtime selects.
-    const resolved = resolveConfiguredModelRef({
-      cfg,
-      agentId,
-      defaultProvider: DEFAULT_PROVIDER,
-      defaultModel: DEFAULT_MODEL,
-      ...DISPLAY_MODEL_PARSE_OPTIONS,
-    });
-
-    const rawDefaultsModel = resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model) ?? "";
-    const rawModel = agentModelPrimary ?? rawDefaultsModel;
-    const resolvedLabel = modelKey(resolved.provider, resolved.model);
-    const defaultLabel = rawModel || resolvedLabel;
-    const defaultsFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.model);
-    const fallbacks = agentFallbacksOverride ?? defaultsFallbacks;
-    const imageModel = resolveAgentModelPrimaryValue(cfg.agents?.defaults?.imageModel) ?? "";
-    const imageFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.imageModel);
-    // Narration/titles ride the utility model on a plain API auth path that can
-    // differ from the primary's (e.g. OAuth primary, api_key utility); show the
-    // resolved ref so a broken utility credential is inspectable here.
-    const utilitySetting = readUtilityModelSetting(cfg, workspaceAgentId);
-    const utilityModelRef = resolveUtilityModelRefForAgent({ cfg, agentId: workspaceAgentId });
-    // resolveUtilityModelRefForAgent never falls back to the primary model: an
-    // unset setting yields the provider-declared default or undefined, so a
-    // non-null auto result really is a provider default (unlike the runtime's
-    // simple-completion selection, which does fall back to the primary).
-    const utilityModelSource =
-      utilitySetting.kind === "explicit"
-        ? "config"
-        : utilitySetting.kind === "disabled"
-          ? "disabled"
-          : utilityModelRef
-            ? "provider-default"
-            : "none";
-    const configuredAllowRefs = [
-      ...resolveConfiguredModelPolicyAllow({ cfg, agentId: workspaceAgentId }).refs,
-    ];
-
-    const modelsPath = path.join(agentDir, "models.json");
-    const aliasIndex = buildModelAliasIndex({
-      cfg,
-      agentId,
-      defaultProvider: DEFAULT_PROVIDER,
-      ...DISPLAY_MODEL_PARSE_OPTIONS,
-    });
-    // The index is the same effective alias set the resolvers use, so per-agent
-    // rows that replace or empty-disable a default alias are reflected here
-    // instead of being read straight off `agents.defaults.models`.
-    const aliases = Object.fromEntries(
-      [...aliasIndex.byAlias.values()].map((match) => [
-        match.alias,
-        modelKey(match.ref.provider, match.ref.model),
-      ]),
-    );
-    const resolveStatusModelRef = (raw: string | undefined) => {
-      const modelRef = raw?.trim();
-      if (!modelRef) {
-        return undefined;
-      }
-      return resolveModelRefFromString({
+  return withPluginMetadataSnapshotScope(
+    metadataSnapshot,
+    async () => {
+      // agentId, not a synthetic config carrying the agent's primary into global
+      // defaults: the canonical resolvers merge per-agent model rows themselves, so
+      // the synthetic route resolved a bare per-agent alias against global defaults
+      // and reported a different provider than runtime selects.
+      const resolved = resolveConfiguredModelRef({
         cfg,
         agentId,
-        raw: modelRef,
         defaultProvider: DEFAULT_PROVIDER,
-        aliasIndex,
+        defaultModel: DEFAULT_MODEL,
         ...DISPLAY_MODEL_PARSE_OPTIONS,
-      })?.ref;
-    };
-    const textUsesOpenAI = [defaultLabel, ...fallbacks].some(
-      (raw) =>
-        normalizeProviderId(resolveStatusModelRef(raw)?.provider ?? "") === OPENAI_PROVIDER_ID,
-    );
-    // Match execution's read-only, provider-scoped Codex CLI overlay. This lets
-    // status select the same OpenAI subscription profile without scanning
-    // unrelated external CLIs or prompting the keychain.
-    const store = textUsesOpenAI
-      ? ensureAuthProfileStore(agentDir, {
-          allowKeychainPrompt: false,
-          config: cfg,
-          externalCliProviderIds: [OPENAI_PROVIDER_ID],
-          readOnly: true,
-        })
-      : ensureAuthProfileStoreWithoutExternalProfiles(agentDir);
-    const providersFromStore = new Set(
-      Object.values(store.profiles)
-        .map((profile) => normalizeProviderId(profile.provider))
-        .filter((p): p is string => Boolean(p)),
-    );
-    const providersFromConfig = new Set(
-      Object.keys(cfg.models?.providers ?? {})
-        .map((p) => (typeof p === "string" ? normalizeProviderId(p) : ""))
-        .filter(Boolean),
-    );
-    const providersFromModels = new Set<string>();
-    const providerUseRefs: StatusProviderUseRef[] = [];
-    const addProviderUse = (
-      raw: string | undefined,
-      allowCodexRuntimeFallback: boolean,
-      routeScope: StatusProviderUseRef["routeScope"],
-    ) => {
-      const ref = resolveStatusModelRef(raw);
-      if (ref?.provider) {
-        const provider = normalizeProviderId(ref.provider);
-        providerUseRefs.push({
-          provider,
-          model: ref.model,
-          allowCodexRuntimeFallback,
-          routeScope,
-        });
-      }
-    };
-    for (const raw of [
-      defaultLabel,
-      ...fallbacks,
-      imageModel,
-      ...imageFallbacks,
-      utilityModelRef ?? "",
-      ...configuredAllowRefs,
-    ]) {
-      const ref = resolveStatusModelRef(raw);
-      if (ref?.provider) {
-        providersFromModels.add(normalizeProviderId(ref.provider));
-      }
-    }
-    for (const raw of [defaultLabel, ...fallbacks]) {
-      addProviderUse(raw, true, "text");
-    }
-    for (const raw of [imageModel, ...imageFallbacks]) {
-      addProviderUse(raw, false, "image");
-    }
-    // Utility completions (narration/titles) are a text-route auth consumer in
-    // their own right: an OAuth-healthy primary does not prove the utility's
-    // plain API path, so the ref gets full route analysis without inheriting
-    // the primary's codex-runtime fallback.
-    addProviderUse(utilityModelRef, false, "text");
-    // Display the canonical provider/model: utilityModel accepts aliases, and
-    // route issues/probes always report the resolved ref.
-    const resolvedUtilityRef = utilityModelRef ? resolveStatusModelRef(utilityModelRef) : undefined;
-    const utilityModelDisplayRef = resolvedUtilityRef
-      ? modelKey(normalizeProviderId(resolvedUtilityRef.provider), resolvedUtilityRef.model)
-      : (utilityModelRef ?? null);
+      });
 
-    const providersFromEnv = new Set<string>();
-    // Use the shared provider-env registry so `models status` stays aligned with
-    // env-backed providers beyond the text-model defaults (for example image-gen).
-    const envLookupParams = {
-      config: cfg,
-      workspaceDir,
-      env: process.env,
-      metadataSnapshot,
-    };
-    const { aliasMap, envCandidateMap, authEvidenceMap } =
-      resolveProviderEnvAuthLookupMaps(envLookupParams);
-    for (const provider of listProviderEnvAuthLookupKeys({ envCandidateMap, authEvidenceMap })) {
-      if (
-        resolveEnvApiKey(provider, process.env, {
-          config: cfg,
-          workspaceDir,
-          aliasMap,
-          candidateMap: envCandidateMap,
-          authEvidenceMap,
-          skipSetupProviderFallback: true,
-        })
-      ) {
-        providersFromEnv.add(provider);
-      }
-    }
-    const syntheticAuthProviderRefs = new Set(
-      resolveRuntimeSyntheticAuthProviderRefs({
-        index: metadataSnapshot.index,
-        registryDiagnostics: metadataSnapshot.registryDiagnostics,
-      }).map((provider) => normalizeProviderId(provider)),
-    );
-    const createStatusAuthResolver = (
-      authStore: Parameters<typeof createModelAuthAvailabilityResolver>[0]["authStore"],
-    ) =>
-      createModelAuthAvailabilityResolver({
+      const rawDefaultsModel = resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model) ?? "";
+      const rawModel = agentModelPrimary ?? rawDefaultsModel;
+      const resolvedLabel = modelKey(resolved.provider, resolved.model);
+      const defaultLabel = rawModel || resolvedLabel;
+      const defaultsFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.model);
+      const fallbacks = agentFallbacksOverride ?? defaultsFallbacks;
+      const imageModel = resolveAgentModelPrimaryValue(cfg.agents?.defaults?.imageModel) ?? "";
+      const imageFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.imageModel);
+      // Narration/titles ride the utility model on a plain API auth path that can
+      // differ from the primary's (e.g. OAuth primary, api_key utility); show the
+      // resolved ref so a broken utility credential is inspectable here.
+      const utilitySetting = readUtilityModelSetting(cfg, workspaceAgentId);
+      const utilityModelRef = resolveUtilityModelRefForAgent({ cfg, agentId: workspaceAgentId });
+      // resolveUtilityModelRefForAgent never falls back to the primary model: an
+      // unset setting yields the provider-declared default or undefined, so a
+      // non-null auto result really is a provider default (unlike the runtime's
+      // simple-completion selection, which does fall back to the primary).
+      const utilityModelSource =
+        utilitySetting.kind === "explicit"
+          ? "config"
+          : utilitySetting.kind === "disabled"
+            ? "disabled"
+            : utilityModelRef
+              ? "provider-default"
+              : "none";
+      const configuredAllowRefs = [
+        ...resolveConfiguredModelPolicyAllow({ cfg, agentId: workspaceAgentId }).refs,
+      ];
+
+      const modelsPath = path.join(agentDir, "models.json");
+      const aliasIndex = buildModelAliasIndex({
         cfg,
-        authStore,
-        agentDir,
+        agentId,
+        defaultProvider: DEFAULT_PROVIDER,
+        ...DISPLAY_MODEL_PARSE_OPTIONS,
+      });
+      // The index is the same effective alias set the resolvers use, so per-agent
+      // rows that replace or empty-disable a default alias are reflected here
+      // instead of being read straight off `agents.defaults.models`.
+      const aliases = Object.fromEntries(
+        [...aliasIndex.byAlias.values()].map((match) => [
+          match.alias,
+          modelKey(match.ref.provider, match.ref.model),
+        ]),
+      );
+      const resolveStatusModelRef = (raw: string | undefined) => {
+        const modelRef = raw?.trim();
+        if (!modelRef) {
+          return undefined;
+        }
+        return resolveModelRefFromString({
+          cfg,
+          agentId,
+          raw: modelRef,
+          defaultProvider: DEFAULT_PROVIDER,
+          aliasIndex,
+          ...DISPLAY_MODEL_PARSE_OPTIONS,
+        })?.ref;
+      };
+      const textUsesOpenAI = [defaultLabel, ...fallbacks].some(
+        (raw) =>
+          normalizeProviderId(resolveStatusModelRef(raw)?.provider ?? "") === OPENAI_PROVIDER_ID,
+      );
+      // Match execution's read-only, provider-scoped Codex CLI overlay. This lets
+      // status select the same OpenAI subscription profile without scanning
+      // unrelated external CLIs or prompting the keychain.
+      const store = textUsesOpenAI
+        ? ensureAuthProfileStore(agentDir, {
+            allowKeychainPrompt: false,
+            config: cfg,
+            externalCliProviderIds: [OPENAI_PROVIDER_ID],
+            readOnly: true,
+          })
+        : ensureAuthProfileStoreWithoutExternalProfiles(agentDir);
+      const providersFromStore = new Set(
+        Object.values(store.profiles)
+          .map((profile) => normalizeProviderId(profile.provider))
+          .filter((p): p is string => Boolean(p)),
+      );
+      const providersFromConfig = new Set(
+        Object.keys(cfg.models?.providers ?? {})
+          .map((p) => (typeof p === "string" ? normalizeProviderId(p) : ""))
+          .filter(Boolean),
+      );
+      const providersFromModels = new Set<string>();
+      const providerUseRefs: StatusProviderUseRef[] = [];
+      const addProviderUse = (
+        raw: string | undefined,
+        allowCodexRuntimeFallback: boolean,
+        routeScope: StatusProviderUseRef["routeScope"],
+      ) => {
+        const ref = resolveStatusModelRef(raw);
+        if (ref?.provider) {
+          const provider = normalizeProviderId(ref.provider);
+          providerUseRefs.push({
+            provider,
+            model: ref.model,
+            allowCodexRuntimeFallback,
+            routeScope,
+          });
+        }
+      };
+      for (const raw of [
+        defaultLabel,
+        ...fallbacks,
+        imageModel,
+        ...imageFallbacks,
+        utilityModelRef ?? "",
+        ...configuredAllowRefs,
+      ]) {
+        const ref = resolveStatusModelRef(raw);
+        if (ref?.provider) {
+          providersFromModels.add(normalizeProviderId(ref.provider));
+        }
+      }
+      for (const raw of [defaultLabel, ...fallbacks]) {
+        addProviderUse(raw, true, "text");
+      }
+      for (const raw of [imageModel, ...imageFallbacks]) {
+        addProviderUse(raw, false, "image");
+      }
+      // Utility completions (narration/titles) are a text-route auth consumer in
+      // their own right: an OAuth-healthy primary does not prove the utility's
+      // plain API path, so the ref gets full route analysis without inheriting
+      // the primary's codex-runtime fallback.
+      addProviderUse(utilityModelRef, false, "text");
+      // Display the canonical provider/model: utilityModel accepts aliases, and
+      // route issues/probes always report the resolved ref.
+      const resolvedUtilityRef = utilityModelRef
+        ? resolveStatusModelRef(utilityModelRef)
+        : undefined;
+      const utilityModelDisplayRef = resolvedUtilityRef
+        ? modelKey(normalizeProviderId(resolvedUtilityRef.provider), resolvedUtilityRef.model)
+        : (utilityModelRef ?? null);
+
+      const providersFromEnv = new Set<string>();
+      // Use the shared provider-env registry so `models status` stays aligned with
+      // env-backed providers beyond the text-model defaults (for example image-gen).
+      const envLookupParams = {
+        config: cfg,
         workspaceDir,
         env: process.env,
-        // A generic Codex runtime marker proves only that the harness can be
-        // contacted. It is not an OpenAI model credential.
-        syntheticAuthProviderRefs: [...syntheticAuthProviderRefs].filter(
-          (provider) => provider !== "codex",
-        ),
         metadataSnapshot,
-      });
-    let authResolver = createStatusAuthResolver(store);
-    // Status already owns the complete provider/auth use set. Carry it into the
-    // catalog owner so a read-only status does not discover every provider plugin.
-    const probedProvider = normalizeOptionalString(opts.probeProvider);
-    const providerDiscoveryProviderIds = [
-      ...new Set([
-        ...authResolver.providerDiscoveryProviderIds,
-        ...providersFromConfig,
-        ...providersFromModels,
-        ...(probedProvider ? [normalizeProviderId(probedProvider)] : []),
-      ]),
-    ].toSorted((left, right) => left.localeCompare(right));
-    const catalog = await loadPreparedModelCatalogSnapshot({
-      config: cfg,
-      agentId: workspaceAgentId,
-      providerDiscoveryProviderIds,
-      readOnly: true,
-    });
-    const visibilityPolicy = createModelVisibilityPolicy({
-      cfg,
-      catalog: catalog.entries,
-      defaultProvider: resolved.provider,
-      defaultModel: resolved.model,
-      agentId: workspaceAgentId,
-      ...DISPLAY_MODEL_PARSE_OPTIONS,
-    });
-    const allowed = visibilityPolicy.allowAny
-      ? []
-      : [
-          ...new Set([
-            ...visibilityPolicy.allowedCatalog.map((entry) => modelKey(entry.provider, entry.id)),
-            ...configuredAllowRefs.flatMap((raw) => {
-              const wildcard = parseModelPolicyWildcardRef(raw);
-              if (!wildcard) {
-                return [];
-              }
-              const prefix = wildcard.key.slice(0, -1);
-              const hasCatalogMatch = catalog.entries.some((entry) =>
-                modelKey(entry.provider, entry.id).startsWith(prefix),
-              );
-              return hasCatalogMatch ? [] : [wildcard.key];
-            }),
-          ]),
-        ].toSorted();
-    const routeSourcesByModel = new Map<
-      string,
-      Array<{ api?: (typeof catalog.routeVariants)[number]["api"]; baseUrl?: string }>
-    >();
-    const resolveStatusRouteIdentityKey = (entry: { provider: string; id: string }) => {
-      const provider = normalizeProviderId(entry.provider);
-      // Physical catalog rows may repeat their provider in the model id.
-      // Collapse only that prefix; the remaining model id stays case-sensitive.
-      return resolveModelCatalogIdentityKey({
-        provider,
-        id: stripSelfProviderModelPrefix(provider, modelKey(provider, entry.id)),
-      });
-    };
-    for (const entry of catalog.routeVariants) {
-      if (entry.api === undefined && entry.baseUrl === undefined) {
-        continue;
+      };
+      const { aliasMap, envCandidateMap, authEvidenceMap } =
+        resolveProviderEnvAuthLookupMaps(envLookupParams);
+      for (const provider of listProviderEnvAuthLookupKeys({ envCandidateMap, authEvidenceMap })) {
+        if (
+          resolveEnvApiKey(provider, process.env, {
+            config: cfg,
+            workspaceDir,
+            aliasMap,
+            candidateMap: envCandidateMap,
+            authEvidenceMap,
+            skipSetupProviderFallback: true,
+          })
+        ) {
+          providersFromEnv.add(provider);
+        }
       }
-      const key = resolveStatusRouteIdentityKey(entry);
-      const sources = routeSourcesByModel.get(key) ?? [];
-      sources.push({ api: entry.api, baseUrl: entry.baseUrl });
-      routeSourcesByModel.set(key, sources);
-    }
-    const resolveProviderUses = async (
-      resolver: ModelAuthAvailabilityResolver,
-    ): Promise<StatusProviderUse[]> =>
-      await Promise.all(
-        providerUseRefs.map(async (usage) => {
-          const observedRoutes = routeSourcesByModel.get(
-            resolveStatusRouteIdentityKey({ provider: usage.provider, id: usage.model }),
-          );
-          const ref = {
-            modelId: usage.model,
-            ...(observedRoutes ? { observedRoutes } : {}),
-          };
-          // Image tools own their provider auth behavior. The text-route artifact
-          // must not reinterpret image auth as an OpenAI text transport.
-          const rawEvaluation: ModelAuthAvailabilityEvaluation =
-            usage.routeScope === "text"
-              ? resolver.evaluateModelAuth(usage.provider, ref)
-              : {
-                  availability: resolver.resolveProviderAuthAvailability(usage.provider, ref),
-                  routeResolution: null,
-                };
-          const providerRouteIncompatible = rawEvaluation.routeResolution?.kind === "incompatible";
-          const requestedCodexRuntimeAuth =
-            !providerRouteIncompatible &&
-            usage.allowCodexRuntimeFallback &&
-            resolveAgentHarnessPolicy({
-              provider: usage.provider,
-              modelId: usage.model,
-              ...(rawEvaluation.selectedRoute
-                ? {
-                    modelApi: rawEvaluation.selectedRoute.api,
-                    modelBaseUrl: rawEvaluation.selectedRoute.baseUrl,
-                  }
-                : {}),
-              config: cfg,
-              agentId: workspaceAgentId,
-            }).runtime === "codex";
-          const runtimeIncompatibility =
-            requestedCodexRuntimeAuth &&
-            usage.provider !== OPENAI_PROVIDER_ID &&
-            usage.provider !== "codex"
-              ? {
-                  code: "unsupported-codex-runtime-provider",
-                  message: `The Codex runtime does not support provider ${usage.provider}.`,
-                }
-              : undefined;
-          const usesCodexRuntimeAuth =
-            requestedCodexRuntimeAuth && runtimeIncompatibility === undefined;
-          const runtimeAvailability = usesCodexRuntimeAuth
-            ? await resolveCodexRuntimeAvailability(usage.provider)
-            : undefined;
-          return {
-            provider: usage.provider,
-            model: usage.model,
-            allowCodexRuntimeFallback: usage.allowCodexRuntimeFallback,
-            evaluation: rawEvaluation,
-            usesCodexRuntimeAuth,
-            runtimeAvailability,
-            runtimeIncompatibility,
-          };
-        }),
+      const syntheticAuthProviderRefs = new Set(
+        resolveRuntimeSyntheticAuthProviderRefs({
+          index: metadataSnapshot.index,
+          registryDiagnostics: metadataSnapshot.registryDiagnostics,
+        }).map((provider) => normalizeProviderId(provider)),
       );
-    let providerUses = await resolveProviderUses(authResolver);
-    const syntheticAuthByProvider = new Map<string, StatusSyntheticAuth>();
-    const runtimeSyntheticAuthByProvider = new Map<string, StatusSyntheticAuth>();
-    const cliRuntimeAuthUsages = providerUses
-      // Codex harness auth is already modeled by the selected OpenAI route.
-      // CLI-runtime aliases are only for distinct backends such as Gemini CLI.
-      .filter((usage) => usage.allowCodexRuntimeFallback && !usage.usesCodexRuntimeAuth)
-      .map((usage) => {
-        const runtimeProvider = resolveCliRuntimeExecutionProvider({
-          provider: usage.provider,
-          modelId: usage.model,
+      const createStatusAuthResolver = (
+        authStore: Parameters<typeof createModelAuthAvailabilityResolver>[0]["authStore"],
+      ) =>
+        createModelAuthAvailabilityResolver({
           cfg,
-          agentId: workspaceAgentId,
+          authStore,
+          agentDir,
+          workspaceDir,
+          env: process.env,
+          // A generic Codex runtime marker proves only that the harness can be
+          // contacted. It is not an OpenAI model credential.
+          syntheticAuthProviderRefs: [...syntheticAuthProviderRefs].filter(
+            (provider) => provider !== "codex",
+          ),
+          metadataSnapshot,
         });
-        const normalizedRuntime = runtimeProvider
-          ? normalizeProviderId(runtimeProvider)
-          : undefined;
-        return normalizedRuntime && normalizedRuntime !== usage.provider
-          ? {
+      let authResolver = createStatusAuthResolver(store);
+      // Status already owns the complete provider/auth use set. Carry it into the
+      // catalog owner so a read-only status does not discover every provider plugin.
+      const probedProvider = normalizeOptionalString(opts.probeProvider);
+      const providerDiscoveryProviderIds = [
+        ...new Set([
+          ...authResolver.providerDiscoveryProviderIds,
+          ...providersFromConfig,
+          ...providersFromModels,
+          ...(probedProvider ? [normalizeProviderId(probedProvider)] : []),
+        ]),
+      ].toSorted((left, right) => left.localeCompare(right));
+      const catalog = await loadPreparedModelCatalogSnapshot({
+        config: cfg,
+        agentId: workspaceAgentId,
+        providerDiscoveryProviderIds,
+        readOnly: true,
+      });
+      const visibilityPolicy = createModelVisibilityPolicy({
+        cfg,
+        catalog: catalog.entries,
+        defaultProvider: resolved.provider,
+        defaultModel: resolved.model,
+        agentId: workspaceAgentId,
+        ...DISPLAY_MODEL_PARSE_OPTIONS,
+      });
+      const allowed = visibilityPolicy.allowAny
+        ? []
+        : [
+            ...new Set([
+              ...visibilityPolicy.allowedCatalog.map((entry) => modelKey(entry.provider, entry.id)),
+              ...configuredAllowRefs.flatMap((raw) => {
+                const wildcard = parseModelPolicyWildcardRef(raw);
+                if (!wildcard) {
+                  return [];
+                }
+                const prefix = wildcard.key.slice(0, -1);
+                const hasCatalogMatch = catalog.entries.some((entry) =>
+                  modelKey(entry.provider, entry.id).startsWith(prefix),
+                );
+                return hasCatalogMatch ? [] : [wildcard.key];
+              }),
+            ]),
+          ].toSorted();
+      const routeSourcesByModel = new Map<
+        string,
+        Array<{ api?: (typeof catalog.routeVariants)[number]["api"]; baseUrl?: string }>
+      >();
+      const resolveStatusRouteIdentityKey = (entry: { provider: string; id: string }) => {
+        const provider = normalizeProviderId(entry.provider);
+        // Physical catalog rows may repeat their provider in the model id.
+        // Collapse only that prefix; the remaining model id stays case-sensitive.
+        return resolveModelCatalogIdentityKey({
+          provider,
+          id: stripSelfProviderModelPrefix(provider, modelKey(provider, entry.id)),
+        });
+      };
+      for (const entry of catalog.routeVariants) {
+        if (entry.api === undefined && entry.baseUrl === undefined) {
+          continue;
+        }
+        const key = resolveStatusRouteIdentityKey(entry);
+        const sources = routeSourcesByModel.get(key) ?? [];
+        sources.push({ api: entry.api, baseUrl: entry.baseUrl });
+        routeSourcesByModel.set(key, sources);
+      }
+      const resolveProviderUses = async (
+        resolver: ModelAuthAvailabilityResolver,
+      ): Promise<StatusProviderUse[]> =>
+        await Promise.all(
+          providerUseRefs.map(async (usage) => {
+            const observedRoutes = routeSourcesByModel.get(
+              resolveStatusRouteIdentityKey({ provider: usage.provider, id: usage.model }),
+            );
+            const ref = {
+              modelId: usage.model,
+              ...(observedRoutes ? { observedRoutes } : {}),
+            };
+            // Image tools own their provider auth behavior. The text-route artifact
+            // must not reinterpret image auth as an OpenAI text transport.
+            const rawEvaluation: ModelAuthAvailabilityEvaluation =
+              usage.routeScope === "text"
+                ? resolver.evaluateModelAuth(usage.provider, ref)
+                : {
+                    availability: resolver.resolveProviderAuthAvailability(usage.provider, ref),
+                    routeResolution: null,
+                  };
+            const providerRouteIncompatible =
+              rawEvaluation.routeResolution?.kind === "incompatible";
+            const requestedCodexRuntimeAuth =
+              !providerRouteIncompatible &&
+              usage.allowCodexRuntimeFallback &&
+              resolveAgentHarnessPolicy({
+                provider: usage.provider,
+                modelId: usage.model,
+                ...(rawEvaluation.selectedRoute
+                  ? {
+                      modelApi: rawEvaluation.selectedRoute.api,
+                      modelBaseUrl: rawEvaluation.selectedRoute.baseUrl,
+                    }
+                  : {}),
+                config: cfg,
+                agentId: workspaceAgentId,
+              }).runtime === "codex";
+            const runtimeIncompatibility =
+              requestedCodexRuntimeAuth &&
+              usage.provider !== OPENAI_PROVIDER_ID &&
+              usage.provider !== "codex"
+                ? {
+                    code: "unsupported-codex-runtime-provider",
+                    message: `The Codex runtime does not support provider ${usage.provider}.`,
+                  }
+                : undefined;
+            const usesCodexRuntimeAuth =
+              requestedCodexRuntimeAuth && runtimeIncompatibility === undefined;
+            const runtimeAvailability = usesCodexRuntimeAuth
+              ? await resolveCodexRuntimeAvailability(usage.provider)
+              : undefined;
+            return {
               provider: usage.provider,
               model: usage.model,
               allowCodexRuntimeFallback: usage.allowCodexRuntimeFallback,
-              runtime: normalizedRuntime,
-            }
-          : undefined;
-      })
-      .filter((usage): usage is NonNullable<typeof usage> => Boolean(usage));
-
-    const providers = Array.from(
-      new Set([
-        ...providersFromStore,
-        ...providersFromConfig,
-        ...providersFromModels,
-        ...providersFromEnv,
-        ...cliRuntimeAuthUsages.map((usage) => usage.runtime),
-      ]),
-    )
-      .map((p) => normalizeOptionalString(p) ?? "")
-      .filter(Boolean)
-      .toSorted((a, b) => a.localeCompare(b));
-    const syntheticProvidersToProbe = new Set(
-      providers.map((provider) => normalizeProviderId(provider)),
-    );
-    const codexProvider = normalizeProviderId(OPENAI_PROVIDER_ID);
-    const codexProviderAlias = aliasMap[codexProvider] ?? codexProvider;
-    let codexRuntimeAuthUsages = providerUses.filter((usage) => usage.usesCodexRuntimeAuth);
-    if (codexRuntimeAuthUsages.length > 0) {
-      syntheticProvidersToProbe.add(codexProvider);
-      syntheticProvidersToProbe.add(codexProviderAlias);
-      syntheticProvidersToProbe.add("codex");
-    }
-    for (const provider of syntheticProvidersToProbe) {
-      const normalized = normalizeProviderId(provider);
-      if (!syntheticAuthProviderRefs.has(normalized)) {
-        continue;
-      }
-      const resolvedLocal = await prepareProviderSyntheticAuthWithPlugin({
-        provider: normalized,
-        config: cfg,
-        workspaceDir,
-        context: {
-          config: cfg,
-          provider: normalized,
-          providerConfig: resolveMergedModelProviderConfig(cfg, normalized),
-        },
-      });
-      if (!resolvedLocal) {
-        continue;
-      }
-      const syntheticAuth: StatusSyntheticAuth = {
-        value: "plugin-owned",
-        source: resolvedLocal.source,
-        credential: resolvedLocal.apiKey,
-        mode: resolvedLocal.mode,
-        expiresAt: resolvedLocal.expiresAt,
-      };
-      syntheticAuthByProvider.set(normalized, syntheticAuth);
-      // The generic Codex token authenticates the local harness, not an
-      // OpenAI model route. Only provider-owned synthetic credentials may
-      // become concrete evaluator profiles.
-      if (normalized !== "codex") {
-        runtimeSyntheticAuthByProvider.set(normalized, syntheticAuth);
-      }
-      if (normalized !== "codex" && normalized === codexProviderAlias) {
-        syntheticAuthByProvider.set(codexProvider, syntheticAuth);
-      }
-    }
-    const runtimeCredentialsByProvider = new Map(
-      Array.from(runtimeSyntheticAuthByProvider.entries())
-        .map(([provider, auth]) => [provider, syntheticAuthCredential(provider, auth)] as const)
-        .filter((entry): entry is readonly [string, AuthProfileCredential] => Boolean(entry[1])),
-    );
-    if (runtimeCredentialsByProvider.size > 0) {
-      const syntheticProfiles = Object.fromEntries(
-        Array.from(runtimeCredentialsByProvider.entries()).map(([provider, credential]) => [
-          `${provider}:runtime-synthetic`,
-          credential,
-        ]),
-      );
-      authResolver = createStatusAuthResolver({
-        ...store,
-        profiles: { ...store.profiles, ...syntheticProfiles },
-      });
-      providerUses = await resolveProviderUses(authResolver);
-      codexRuntimeAuthUsages = providerUses.filter((usage) => usage.usesCodexRuntimeAuth);
-    }
-
-    const applied = getShellEnvAppliedKeys();
-    const shellFallbackEnabled =
-      shouldEnableShellEnvFallback(process.env) || cfg.env?.shellEnv?.enabled === true;
-    const providerAuth = Array.from(
-      new Set([
-        ...providers,
-        ...(codexRuntimeAuthUsages.length > 0 && syntheticAuthByProvider.has(codexProvider)
-          ? [codexProvider]
-          : []),
-      ]),
-    )
-      .toSorted((a, b) => a.localeCompare(b))
-      .map((provider) =>
-        resolveProviderAuthOverview({
-          provider,
-          cfg,
-          store,
-          modelsPath,
-          agentDir,
-          workspaceDir,
-          syntheticAuth: syntheticAuthByProvider.get(provider),
-          aliasMap,
-          envCandidateMap,
-          authEvidenceMap,
-        }),
-      )
-      .filter((entry) => {
-        const hasAny =
-          entry.profiles.count > 0 ||
-          Boolean(entry.env) ||
-          Boolean(entry.modelsJson) ||
-          Boolean(entry.syntheticAuth);
-        return hasAny;
-      });
-    const providerAuthMap = new Map(providerAuth.map((entry) => [entry.provider, entry]));
-    const missingProviderAuthEffective: ProviderAuthOverview["effective"] = {
-      kind: "missing",
-      detail: "missing",
-    };
-    const runtimeAuthStore = getRuntimeAuthProfileStoreSnapshot(agentDir);
-    const healthStore = runtimeAuthStore
-      ? {
-          ...store,
-          profiles: { ...store.profiles, ...runtimeAuthStore.profiles },
-        }
-      : store;
-    const authHealth = buildAuthHealthSummary({
-      store: healthStore,
-      cfg,
-      warnAfterMs: DEFAULT_OAUTH_WARN_MS,
-      runtimeCredentialsByProvider,
-      allowKeychainPrompt: false,
-    });
-    const authProfileHealthById = new Map(
-      authHealth.profiles.map((profile) => [profile.profileId, profile]),
-    );
-    const resolveProviderAuthHealthId = (provider: string): string =>
-      resolveProviderIdForAuth(provider, envLookupParams);
-    const resolveRuntimeAuthRouteEffective = (
-      provider: string,
-      evaluation?: ModelAuthAvailabilityEvaluation,
-    ): ProviderAuthOverview["effective"] => {
-      if (!evaluation) {
-        return providerAuthMap.get(provider)?.effective ?? missingProviderAuthEffective;
-      }
-      if (evaluation?.availability === false) {
-        return missingProviderAuthEffective;
-      }
-      const candidates = Array.from(
-        new Set([normalizeProviderId(provider), resolveProviderAuthHealthId(provider)]),
-      );
-      const profileId = evaluation.selectedProfileId;
-      if (profileId) {
-        const credentialProvider = store.profiles[profileId]?.provider ?? provider;
-        const source = providerAuthMap.get(
-          resolveProviderAuthHealthId(credentialProvider),
-        )?.effective;
-        return source && source.kind !== "missing"
-          ? source
-          : { kind: "profiles", detail: profileId };
-      }
-      for (const candidate of candidates) {
-        const auth = providerAuthMap.get(candidate);
-        if (evaluation.evidence === "environment" && auth?.env) {
-          return { kind: "env", detail: auth.env.value };
-        }
-        if (
-          (evaluation.evidence === "provider-config" || evaluation.evidence === "runtime") &&
-          auth?.modelsJson
-        ) {
-          return { kind: "models.json", detail: auth.modelsJson.value };
-        }
-        if (evaluation.evidence === "synthetic" && syntheticAuthByProvider.has(candidate)) {
-          return {
-            kind: "synthetic",
-            detail: syntheticAuthByProvider.get(candidate)?.source ?? "plugin-owned",
-          };
-        }
-      }
-      const direct = providerAuthMap.get(provider)?.effective;
-      return direct ?? missingProviderAuthEffective;
-    };
-    const resolveCliRuntimeAuthProvider = (usage: (typeof providerUses)[number]) =>
-      cliRuntimeAuthUsages.find(
-        (candidate) =>
-          candidate.provider === usage.provider &&
-          candidate.model === usage.model &&
-          candidate.allowCodexRuntimeFallback === usage.allowCodexRuntimeFallback,
-      )?.runtime;
-    const hasUsableAuthForProviderInUse = (usage: (typeof providerUses)[number]): boolean => {
-      const cliRuntimeAuthProvider = resolveCliRuntimeAuthProvider(usage);
-      if (cliRuntimeAuthProvider) {
-        return authResolver.resolveProviderAuthAvailability(cliRuntimeAuthProvider) !== false;
-      }
-      if (resolveStatusProviderUseIncompatibility(usage)) {
-        // Route contract failures are reported separately from missing auth.
-        return true;
-      }
-      // Unknown evidence is reported as indeterminate, not missing auth.
-      return usage.evaluation.availability !== false;
-    };
-    const codexRuntimeUsagesByProvider = new Map<string, StatusProviderUse[]>();
-    for (const usage of codexRuntimeAuthUsages) {
-      const usages = codexRuntimeUsagesByProvider.get(usage.provider) ?? [];
-      usages.push(usage);
-      codexRuntimeUsagesByProvider.set(usage.provider, usages);
-    }
-    const runtimeAuthRouteEntries: Array<readonly [string, StatusRuntimeAuthRoute]> = [
-      ...Array.from(codexRuntimeUsagesByProvider.entries()).map(([provider, usages]) => {
-        const representative =
-          usages.find((usage) => usage.evaluation.availability === true) ?? usages[0];
-        const effective = resolveRuntimeAuthRouteEffective(
-          codexProvider,
-          representative?.evaluation,
+              evaluation: rawEvaluation,
+              usesCodexRuntimeAuth,
+              runtimeAvailability,
+              runtimeIncompatibility,
+            };
+          }),
         );
-        const availabilities = usages.map((usage) => usage.evaluation.availability);
-        const authStatus = availabilities.every((availability) => availability === true)
-          ? "usable"
-          : availabilities.some((availability) => availability === false)
-            ? "missing"
-            : "indeterminate";
-        const runtimeAvailability = representative?.runtimeAvailability;
-        const route: StatusRuntimeAuthRoute =
-          runtimeAvailability?.status === "unavailable"
-            ? {
-                provider,
-                runtime: "codex",
-                authProvider: codexProvider,
-                status: "unavailable",
-                effective,
-                authStatus,
-                runtimeStatus: runtimeAvailability.status,
-                runtimeReason: runtimeAvailability.reason,
-                runtimeDetail: runtimeAvailability.detail,
-                runtimePluginIds: runtimeAvailability.ownerPluginIds,
-              }
-            : {
-                provider,
-                runtime: "codex",
-                authProvider: codexProvider,
-                status: authStatus,
-                effective,
-              };
-        return [`${provider}:codex:${codexProvider}`, route] as const;
-      }),
-      ...cliRuntimeAuthUsages.map((usage) => {
-        const evaluation = authResolver.evaluateModelAuth(usage.runtime);
-        const effective = resolveRuntimeAuthRouteEffective(usage.runtime, evaluation);
-        return [
-          `${usage.provider}:${usage.runtime}:${usage.runtime}`,
-          {
+      let providerUses = await resolveProviderUses(authResolver);
+      const syntheticAuthByProvider = new Map<string, StatusSyntheticAuth>();
+      const runtimeSyntheticAuthByProvider = new Map<string, StatusSyntheticAuth>();
+      const cliRuntimeAuthUsages = providerUses
+        // Codex harness auth is already modeled by the selected OpenAI route.
+        // CLI-runtime aliases are only for distinct backends such as Gemini CLI.
+        .filter((usage) => usage.allowCodexRuntimeFallback && !usage.usesCodexRuntimeAuth)
+        .map((usage) => {
+          const runtimeProvider = resolveCliRuntimeExecutionProvider({
             provider: usage.provider,
-            runtime: usage.runtime,
-            authProvider: usage.runtime,
-            status:
-              evaluation.availability === true
-                ? "usable"
-                : evaluation.availability === false
-                  ? "missing"
-                  : "indeterminate",
-            effective,
-          },
-        ] as const;
-      }),
-    ];
-    const runtimeAuthRoutes = Array.from(
-      new Map<string, StatusRuntimeAuthRoute>(runtimeAuthRouteEntries).values(),
-    ).toSorted((a, b) => a.provider.localeCompare(b.provider));
-    const modelRouteIssues = providerUses.flatMap<StatusModelRouteIssue>((usage) => {
-      const cliRuntimeAuthProvider = resolveCliRuntimeAuthProvider(usage);
-      const evaluation = cliRuntimeAuthProvider
-        ? authResolver.evaluateModelAuth(cliRuntimeAuthProvider)
-        : usage.evaluation;
-      const incompatibility = resolveStatusProviderUseIncompatibility(usage);
-      if (incompatibility) {
-        return [
-          {
-            kind: "incompatible" as const,
-            provider: usage.provider,
-            model: usage.model,
-            code: incompatibility.code,
-            message: incompatibility.message,
-          },
-        ];
-      }
-      if (evaluation.availability === undefined) {
-        return [
-          {
-            kind: "indeterminate" as const,
-            provider: usage.provider,
-            model: usage.model,
-            ...(evaluation.evidence ? { evidence: evaluation.evidence } : {}),
-            message: `Auth readiness could not be confirmed for ${usage.provider}/${usage.model}.`,
-          },
-        ];
-      }
-      if (!usage.evaluation.selectedRoute || evaluation.availability) {
-        return [];
-      }
-      const authRequirement = usage.evaluation.selectedRoute.authRequirement;
-      return [
-        {
-          kind: "missing-auth" as const,
-          provider: usage.provider,
-          model: usage.model,
-          authRequirement,
-          message: `No usable ${authRequirement} authentication is available for ${usage.provider}/${usage.model}.`,
-        },
-      ];
-    });
-    // Utility (or duplicate fallback) refs can repeat a configured model;
-    // identical diagnostics collapse while genuinely different evaluations
-    // for the same model (e.g. codex-fallback vs plain route) stay separate.
-    const seenRouteIssues = new Set<string>();
-    const dedupedModelRouteIssues = modelRouteIssues.filter((issue) => {
-      const key = JSON.stringify(issue);
-      if (seenRouteIssues.has(key)) {
-        return false;
-      }
-      seenRouteIssues.add(key);
-      return true;
-    });
-    const missingProvidersInUse = Array.from(
-      new Set(
-        providerUses
-          .filter((usage) => !hasUsableAuthForProviderInUse(usage))
-          .map((usage) => resolveCliRuntimeAuthProvider(usage) ?? usage.provider),
-      ),
-    )
-      .filter(
-        (provider) =>
-          !isCliProvider(provider, cfg) ||
-          cliRuntimeAuthUsages.some((usage) => usage.runtime === provider),
-      )
-      .toSorted((a, b) => a.localeCompare(b));
-
-    const probeProfileIds = (() => {
-      if (!opts.probeProfile) {
-        return [];
-      }
-      const raw = Array.isArray(opts.probeProfile) ? opts.probeProfile : [opts.probeProfile];
-      return raw
-        .flatMap((value) => (value ?? "").split(","))
-        .map((value) => value.trim())
-        .filter(Boolean);
-    })();
-    const probeTimeoutMs = parseOptionalPositiveFiniteOption(
-      opts.probeTimeout,
-      "--probe-timeout",
-      8000,
-    );
-    const probeConcurrency = parseOptionalPositiveIntegerOption(
-      opts.probeConcurrency,
-      "--probe-concurrency",
-      2,
-    );
-    const probeMaxTokens = parseOptionalPositiveIntegerOption(
-      opts.probeMaxTokens,
-      "--probe-max-tokens",
-      8,
-    );
-
-    const rawCandidates = [
-      rawModel || resolvedLabel,
-      ...fallbacks,
-      imageModel,
-      ...imageFallbacks,
-      // Probe the configured utility model itself; an arbitrary catalog model
-      // from the same provider can sit on a different auth route.
-      utilityModelRef ?? "",
-      ...configuredAllowRefs,
-    ].filter(Boolean);
-    const resolvedCandidates = rawCandidates
-      .map(
-        (raw) =>
-          resolveModelRefFromString({
-            cfg,
-            agentId,
-            raw: raw ?? "",
-            defaultProvider: DEFAULT_PROVIDER,
-            aliasIndex,
-            ...DISPLAY_MODEL_PARSE_OPTIONS,
-          })?.ref,
-      )
-      .filter((ref): ref is { provider: string; model: string } => Boolean(ref));
-    const modelCandidates = resolvedCandidates.map((ref) => `${ref.provider}/${ref.model}`);
-
-    let probeSummary: AuthProbeSummary | undefined;
-    if (opts.probe) {
-      const [{ withProgressTotals }, { runAuthProbes }] = await Promise.all([
-        progressRuntimeLoader.load(),
-        listProbeRuntimeLoader.load(),
-      ]);
-      probeSummary = await withProgressTotals(
-        { label: "Probing auth profiles…", total: 1 },
-        async (update) => {
-          return await runAuthProbes({
+            modelId: usage.model,
             cfg,
             agentId: workspaceAgentId,
-            agentDir,
-            workspaceDir,
-            providers,
-            modelCandidates,
-            options: {
-              provider: opts.probeProvider,
-              profileIds: probeProfileIds,
-              timeoutMs: probeTimeoutMs,
-              concurrency: probeConcurrency,
-              maxTokens: probeMaxTokens,
-            },
-            // Direct CLI probes create hidden sessions in the canonical agent DB.
-            // Gateway RPC probes omit this because the Gateway already owns the lock.
-            stateOwnership: { mode: "exclusive" },
-            onProgress: update,
           });
-        },
-      );
-    }
+          const normalizedRuntime = runtimeProvider
+            ? normalizeProviderId(runtimeProvider)
+            : undefined;
+          return normalizedRuntime && normalizedRuntime !== usage.provider
+            ? {
+                provider: usage.provider,
+                model: usage.model,
+                allowCodexRuntimeFallback: usage.allowCodexRuntimeFallback,
+                runtime: normalizedRuntime,
+              }
+            : undefined;
+        })
+        .filter((usage): usage is NonNullable<typeof usage> => Boolean(usage));
 
-    const providersWithOauth = providerAuth
-      .filter(
-        (entry) =>
-          entry.profiles.oauth > 0 ||
-          entry.profiles.token > 0 ||
-          entry.env?.value === "OAuth (env)",
+      const providers = Array.from(
+        new Set([
+          ...providersFromStore,
+          ...providersFromConfig,
+          ...providersFromModels,
+          ...providersFromEnv,
+          ...cliRuntimeAuthUsages.map((usage) => usage.runtime),
+        ]),
       )
-      .map((entry) => {
-        const count =
-          entry.profiles.oauth +
-          entry.profiles.token +
-          (entry.env?.value === "OAuth (env)" ? 1 : 0);
-        return `${entry.provider} (${count})`;
-      });
-
-    const oauthProfiles = authHealth.profiles.filter(
-      (profile) => profile.type === "oauth" || profile.type === "token",
-    );
-
-    const unusableProfiles = (() => {
-      const now = Date.now();
-      const out: Array<{
-        profileId: string;
-        provider?: string;
-        kind: "cooldown" | "disabled";
-        reason?: string;
-        classification?: string;
-        recoveryHint: string;
-        until: number;
-        remainingMs: number;
-      }> = [];
-      for (const profileId of Object.keys(store.usageStats ?? {})) {
-        const unusableUntil = resolveProfileUnusableUntilForDisplay(store, profileId);
-        if (!unusableUntil || now >= unusableUntil) {
+        .map((p) => normalizeOptionalString(p) ?? "")
+        .filter(Boolean)
+        .toSorted((a, b) => a.localeCompare(b));
+      const syntheticProvidersToProbe = new Set(
+        providers.map((provider) => normalizeProviderId(provider)),
+      );
+      const codexProvider = normalizeProviderId(OPENAI_PROVIDER_ID);
+      const codexProviderAlias = aliasMap[codexProvider] ?? codexProvider;
+      let codexRuntimeAuthUsages = providerUses.filter((usage) => usage.usesCodexRuntimeAuth);
+      if (codexRuntimeAuthUsages.length > 0) {
+        syntheticProvidersToProbe.add(codexProvider);
+        syntheticProvidersToProbe.add(codexProviderAlias);
+        syntheticProvidersToProbe.add("codex");
+      }
+      for (const provider of syntheticProvidersToProbe) {
+        const normalized = normalizeProviderId(provider);
+        if (!syntheticAuthProviderRefs.has(normalized)) {
           continue;
         }
-        const stats = store.usageStats?.[profileId];
-        const kind =
-          typeof stats?.disabledUntil === "number" && now < stats.disabledUntil
-            ? "disabled"
-            : "cooldown";
-        const reason = kind === "disabled" ? stats?.disabledReason : stats?.cooldownReason;
-        const classification = kind === "cooldown" ? stats?.cooldownClassification : undefined;
-        const provider = store.profiles[profileId]?.provider;
-        out.push({
-          profileId,
-          provider,
-          kind,
-          reason,
-          ...(classification ? { classification } : {}),
-          recoveryHint: buildAuthProfileUnusableHint({
-            kind,
-            reason,
-            provider: provider ?? profileId,
-            profileId,
-          }),
-          until: unusableUntil,
-          remainingMs: unusableUntil - now,
+        const resolvedLocal = await prepareProviderSyntheticAuthWithPlugin({
+          provider: normalized,
+          config: cfg,
+          workspaceDir,
+          context: {
+            config: cfg,
+            provider: normalized,
+            providerConfig: resolveMergedModelProviderConfig(cfg, normalized),
+          },
         });
-      }
-      return out.toSorted((a, b) => a.remainingMs - b.remainingMs);
-    })();
-
-    const checkStatus = (() => {
-      type RequirementHealth = "ok" | "expiring" | "missing" | "indeterminate";
-      const resolveRouteAuthHealth = (usage: StatusProviderUse): RequirementHealth => {
-        if (resolveStatusProviderUseIncompatibility(usage)) {
-          return "missing";
+        if (!resolvedLocal) {
+          continue;
         }
+        const syntheticAuth: StatusSyntheticAuth = {
+          value: "plugin-owned",
+          source: resolvedLocal.source,
+          credential: resolvedLocal.apiKey,
+          mode: resolvedLocal.mode,
+          expiresAt: resolvedLocal.expiresAt,
+        };
+        syntheticAuthByProvider.set(normalized, syntheticAuth);
+        // The generic Codex token authenticates the local harness, not an
+        // OpenAI model route. Only provider-owned synthetic credentials may
+        // become concrete evaluator profiles.
+        if (normalized !== "codex") {
+          runtimeSyntheticAuthByProvider.set(normalized, syntheticAuth);
+        }
+        if (normalized !== "codex" && normalized === codexProviderAlias) {
+          syntheticAuthByProvider.set(codexProvider, syntheticAuth);
+        }
+      }
+      const runtimeCredentialsByProvider = new Map(
+        Array.from(runtimeSyntheticAuthByProvider.entries())
+          .map(([provider, auth]) => [provider, syntheticAuthCredential(provider, auth)] as const)
+          .filter((entry): entry is readonly [string, AuthProfileCredential] => Boolean(entry[1])),
+      );
+      if (runtimeCredentialsByProvider.size > 0) {
+        const syntheticProfiles = Object.fromEntries(
+          Array.from(runtimeCredentialsByProvider.entries()).map(([provider, credential]) => [
+            `${provider}:runtime-synthetic`,
+            credential,
+          ]),
+        );
+        authResolver = createStatusAuthResolver({
+          ...store,
+          profiles: { ...store.profiles, ...syntheticProfiles },
+        });
+        providerUses = await resolveProviderUses(authResolver);
+        codexRuntimeAuthUsages = providerUses.filter((usage) => usage.usesCodexRuntimeAuth);
+      }
+
+      const applied = getShellEnvAppliedKeys();
+      const shellFallbackEnabled =
+        shouldEnableShellEnvFallback(process.env) || cfg.env?.shellEnv?.enabled === true;
+      const providerAuth = Array.from(
+        new Set([
+          ...providers,
+          ...(codexRuntimeAuthUsages.length > 0 && syntheticAuthByProvider.has(codexProvider)
+            ? [codexProvider]
+            : []),
+        ]),
+      )
+        .toSorted((a, b) => a.localeCompare(b))
+        .map((provider) =>
+          resolveProviderAuthOverview({
+            provider,
+            cfg,
+            store,
+            modelsPath,
+            agentDir,
+            workspaceDir,
+            syntheticAuth: syntheticAuthByProvider.get(provider),
+            aliasMap,
+            envCandidateMap,
+            authEvidenceMap,
+          }),
+        )
+        .filter((entry) => {
+          const hasAny =
+            entry.profiles.count > 0 ||
+            Boolean(entry.env) ||
+            Boolean(entry.modelsJson) ||
+            Boolean(entry.syntheticAuth);
+          return hasAny;
+        });
+      const providerAuthMap = new Map(providerAuth.map((entry) => [entry.provider, entry]));
+      const missingProviderAuthEffective: ProviderAuthOverview["effective"] = {
+        kind: "missing",
+        detail: "missing",
+      };
+      const runtimeAuthStore = getRuntimeAuthProfileStoreSnapshot(agentDir);
+      const healthStore = runtimeAuthStore
+        ? {
+            ...store,
+            profiles: { ...store.profiles, ...runtimeAuthStore.profiles },
+          }
+        : store;
+      const authHealth = buildAuthHealthSummary({
+        store: healthStore,
+        cfg,
+        warnAfterMs: DEFAULT_OAUTH_WARN_MS,
+        runtimeCredentialsByProvider,
+        allowKeychainPrompt: false,
+      });
+      const authProfileHealthById = new Map(
+        authHealth.profiles.map((profile) => [profile.profileId, profile]),
+      );
+      const resolveProviderAuthHealthId = (provider: string): string =>
+        resolveProviderIdForAuth(provider, envLookupParams);
+      const resolveRuntimeAuthRouteEffective = (
+        provider: string,
+        evaluation?: ModelAuthAvailabilityEvaluation,
+      ): ProviderAuthOverview["effective"] => {
+        if (!evaluation) {
+          return providerAuthMap.get(provider)?.effective ?? missingProviderAuthEffective;
+        }
+        if (evaluation?.availability === false) {
+          return missingProviderAuthEffective;
+        }
+        const candidates = Array.from(
+          new Set([normalizeProviderId(provider), resolveProviderAuthHealthId(provider)]),
+        );
+        const profileId = evaluation.selectedProfileId;
+        if (profileId) {
+          const credentialProvider = store.profiles[profileId]?.provider ?? provider;
+          const source = providerAuthMap.get(
+            resolveProviderAuthHealthId(credentialProvider),
+          )?.effective;
+          return source && source.kind !== "missing"
+            ? source
+            : { kind: "profiles", detail: profileId };
+        }
+        for (const candidate of candidates) {
+          const auth = providerAuthMap.get(candidate);
+          if (evaluation.evidence === "environment" && auth?.env) {
+            return { kind: "env", detail: auth.env.value };
+          }
+          if (
+            (evaluation.evidence === "provider-config" || evaluation.evidence === "runtime") &&
+            auth?.modelsJson
+          ) {
+            return { kind: "models.json", detail: auth.modelsJson.value };
+          }
+          if (evaluation.evidence === "synthetic" && syntheticAuthByProvider.has(candidate)) {
+            return {
+              kind: "synthetic",
+              detail: syntheticAuthByProvider.get(candidate)?.source ?? "plugin-owned",
+            };
+          }
+        }
+        const direct = providerAuthMap.get(provider)?.effective;
+        return direct ?? missingProviderAuthEffective;
+      };
+      const resolveCliRuntimeAuthProvider = (usage: (typeof providerUses)[number]) =>
+        cliRuntimeAuthUsages.find(
+          (candidate) =>
+            candidate.provider === usage.provider &&
+            candidate.model === usage.model &&
+            candidate.allowCodexRuntimeFallback === usage.allowCodexRuntimeFallback,
+        )?.runtime;
+      const hasUsableAuthForProviderInUse = (usage: (typeof providerUses)[number]): boolean => {
+        const cliRuntimeAuthProvider = resolveCliRuntimeAuthProvider(usage);
+        if (cliRuntimeAuthProvider) {
+          return authResolver.resolveProviderAuthAvailability(cliRuntimeAuthProvider) !== false;
+        }
+        if (resolveStatusProviderUseIncompatibility(usage)) {
+          // Route contract failures are reported separately from missing auth.
+          return true;
+        }
+        // Unknown evidence is reported as indeterminate, not missing auth.
+        return usage.evaluation.availability !== false;
+      };
+      const codexRuntimeUsagesByProvider = new Map<string, StatusProviderUse[]>();
+      for (const usage of codexRuntimeAuthUsages) {
+        const usages = codexRuntimeUsagesByProvider.get(usage.provider) ?? [];
+        usages.push(usage);
+        codexRuntimeUsagesByProvider.set(usage.provider, usages);
+      }
+      const runtimeAuthRouteEntries: Array<readonly [string, StatusRuntimeAuthRoute]> = [
+        ...Array.from(codexRuntimeUsagesByProvider.entries()).map(([provider, usages]) => {
+          const representative =
+            usages.find((usage) => usage.evaluation.availability === true) ?? usages[0];
+          const effective = resolveRuntimeAuthRouteEffective(
+            codexProvider,
+            representative?.evaluation,
+          );
+          const availabilities = usages.map((usage) => usage.evaluation.availability);
+          const authStatus = availabilities.every((availability) => availability === true)
+            ? "usable"
+            : availabilities.some((availability) => availability === false)
+              ? "missing"
+              : "indeterminate";
+          const runtimeAvailability = representative?.runtimeAvailability;
+          const route: StatusRuntimeAuthRoute =
+            runtimeAvailability?.status === "unavailable"
+              ? {
+                  provider,
+                  runtime: "codex",
+                  authProvider: codexProvider,
+                  status: "unavailable",
+                  effective,
+                  authStatus,
+                  runtimeStatus: runtimeAvailability.status,
+                  runtimeReason: runtimeAvailability.reason,
+                  runtimeDetail: runtimeAvailability.detail,
+                  runtimePluginIds: runtimeAvailability.ownerPluginIds,
+                }
+              : {
+                  provider,
+                  runtime: "codex",
+                  authProvider: codexProvider,
+                  status: authStatus,
+                  effective,
+                };
+          return [`${provider}:codex:${codexProvider}`, route] as const;
+        }),
+        ...cliRuntimeAuthUsages.map((usage) => {
+          const evaluation = authResolver.evaluateModelAuth(usage.runtime);
+          const effective = resolveRuntimeAuthRouteEffective(usage.runtime, evaluation);
+          return [
+            `${usage.provider}:${usage.runtime}:${usage.runtime}`,
+            {
+              provider: usage.provider,
+              runtime: usage.runtime,
+              authProvider: usage.runtime,
+              status:
+                evaluation.availability === true
+                  ? "usable"
+                  : evaluation.availability === false
+                    ? "missing"
+                    : "indeterminate",
+              effective,
+            },
+          ] as const;
+        }),
+      ];
+      const runtimeAuthRoutes = Array.from(
+        new Map<string, StatusRuntimeAuthRoute>(runtimeAuthRouteEntries).values(),
+      ).toSorted((a, b) => a.provider.localeCompare(b.provider));
+      const modelRouteIssues = providerUses.flatMap<StatusModelRouteIssue>((usage) => {
         const cliRuntimeAuthProvider = resolveCliRuntimeAuthProvider(usage);
         const evaluation = cliRuntimeAuthProvider
           ? authResolver.evaluateModelAuth(cliRuntimeAuthProvider)
           : usage.evaluation;
+        const incompatibility = resolveStatusProviderUseIncompatibility(usage);
+        if (incompatibility) {
+          return [
+            {
+              kind: "incompatible" as const,
+              provider: usage.provider,
+              model: usage.model,
+              code: incompatibility.code,
+              message: incompatibility.message,
+            },
+          ];
+        }
         if (evaluation.availability === undefined) {
-          return "indeterminate";
+          return [
+            {
+              kind: "indeterminate" as const,
+              provider: usage.provider,
+              model: usage.model,
+              ...(evaluation.evidence ? { evidence: evaluation.evidence } : {}),
+              message: `Auth readiness could not be confirmed for ${usage.provider}/${usage.model}.`,
+            },
+          ];
         }
-        if (!evaluation.availability) {
-          return "missing";
+        if (!usage.evaluation.selectedRoute || evaluation.availability) {
+          return [];
         }
-        const profileId = evaluation.selectedProfileId;
-        if (!profileId) {
-          return "ok";
-        }
-        const health = authProfileHealthById.get(profileId);
-        if (health?.status === "expiring") {
-          return "expiring";
-        }
-        if (health?.status === "expired" || health?.status === "missing") {
-          return "missing";
-        }
-        return "ok";
-      };
-      const routeAuthHealth = new Set(providerUses.map(resolveRouteAuthHealth));
-      const hasExpiredOrMissing =
-        dedupedModelRouteIssues.some(
-          (issue) => issue.kind === "incompatible" || issue.kind === "indeterminate",
-        ) ||
-        routeAuthHealth.has("missing") ||
-        routeAuthHealth.has("indeterminate") ||
-        runtimeAuthRoutes.some((route) => route.status === "unavailable") ||
-        missingProvidersInUse.length > 0;
-      const hasExpiring = routeAuthHealth.has("expiring");
-      if (hasExpiredOrMissing) {
-        return 1;
-      }
-      if (hasExpiring) {
-        return 2;
-      }
-      return 0;
-    })();
-
-    if (opts.json) {
-      writeRuntimeJson(runtime, {
-        configPath,
-        ...(agentId ? { agentId } : {}),
-        agentDir,
-        defaultModel: defaultLabel,
-        resolvedDefault: resolvedLabel,
-        fallbacks,
-        imageModel: imageModel || null,
-        imageFallbacks,
-        utilityModel: { ref: utilityModelDisplayRef, source: utilityModelSource },
-        ...(agentId
-          ? {
-              modelConfig: {
-                defaultSource: agentModelPrimary ? "agent" : "defaults",
-                fallbacksSource: agentFallbacksOverride !== undefined ? "agent" : "defaults",
-              },
-            }
-          : {}),
-        aliases,
-        allowed,
-        auth: {
-          storePath: resolveAuthStorePathForDisplay(agentDir),
-          shellEnvFallback: {
-            enabled: shellFallbackEnabled,
-            appliedKeys: applied,
+        const authRequirement = usage.evaluation.selectedRoute.authRequirement;
+        return [
+          {
+            kind: "missing-auth" as const,
+            provider: usage.provider,
+            model: usage.model,
+            authRequirement,
+            message: `No usable ${authRequirement} authentication is available for ${usage.provider}/${usage.model}.`,
           },
-          providersWithOAuth: providersWithOauth,
-          missingProvidersInUse,
-          modelRouteIssues: dedupedModelRouteIssues,
-          runtimeAuthRoutes,
-          providers: providerAuth,
-          unusableProfiles,
-          oauth: {
-            warnAfterMs: authHealth.warnAfterMs,
-            profiles: authHealth.profiles,
-            providers: authHealth.providers,
-          },
-          probes: probeSummary,
-        },
+        ];
       });
-      finishModelsStatusOutput(runtime, opts.check, checkStatus);
-      return;
-    }
-
-    if (opts.plain) {
-      writeRuntimeStdout(runtime, resolvedLabel);
-      finishModelsStatusOutput(runtime, opts.check, checkStatus);
-      return;
-    }
-
-    const rich = isRich(opts);
-    type ModelConfigSource = "agent" | "defaults";
-    const label = (value: string) => colorize(rich, theme.accent, value.padEnd(14));
-    const labelWithSource = (value: string, source?: ModelConfigSource) =>
-      label(source ? `${value} (${source})` : value);
-    const displayDefault =
-      rawModel && rawModel !== resolvedLabel
-        ? `${resolvedLabel} (from ${rawModel})`
-        : resolvedLabel;
-
-    runtime.log(
-      `${label("Config")}${colorize(rich, theme.muted, ":")} ${colorize(rich, theme.info, shortenHomePath(configPath))}`,
-    );
-    runtime.log(
-      `${label("Agent dir")}${colorize(rich, theme.muted, ":")} ${colorize(
-        rich,
-        theme.info,
-        shortenHomePath(agentDir),
-      )}`,
-    );
-    runtime.log(
-      `${labelWithSource("Default", agentId ? (agentModelPrimary ? "agent" : "defaults") : undefined)}${colorize(
-        rich,
-        theme.muted,
-        ":",
-      )} ${colorize(rich, theme.success, displayDefault)}`,
-    );
-    runtime.log(
-      `${labelWithSource(
-        `Fallbacks (${fallbacks.length || 0})`,
-        agentId ? (agentFallbacksOverride !== undefined ? "agent" : "defaults") : undefined,
-      )}${colorize(rich, theme.muted, ":")} ${colorize(
-        rich,
-        fallbacks.length ? theme.warn : theme.muted,
-        fallbacks.length ? fallbacks.join(", ") : "-",
-      )}`,
-    );
-    runtime.log(
-      `${label("Utility model")}${colorize(rich, theme.muted, ":")} ${colorize(
-        rich,
-        utilityModelDisplayRef ? theme.success : theme.muted,
-        utilityModelDisplayRef
-          ? `${utilityModelDisplayRef}${utilityModelSource === "provider-default" ? " (provider default)" : ""}`
-          : utilityModelSource === "disabled"
-            ? "off"
-            : "-",
-      )}`,
-    );
-    runtime.log(
-      `${labelWithSource("Image model", agentId ? "defaults" : undefined)}${colorize(
-        rich,
-        theme.muted,
-        ":",
-      )} ${colorize(rich, imageModel ? theme.accentBright : theme.muted, imageModel || "-")}`,
-    );
-    runtime.log(
-      `${labelWithSource(
-        `Image fallbacks (${imageFallbacks.length || 0})`,
-        agentId ? "defaults" : undefined,
-      )}${colorize(rich, theme.muted, ":")} ${colorize(
-        rich,
-        imageFallbacks.length ? theme.accentBright : theme.muted,
-        imageFallbacks.length ? imageFallbacks.join(", ") : "-",
-      )}`,
-    );
-    runtime.log(
-      `${label(`Aliases (${Object.keys(aliases).length || 0})`)}${colorize(rich, theme.muted, ":")} ${colorize(
-        rich,
-        Object.keys(aliases).length ? theme.accent : theme.muted,
-        Object.keys(aliases).length
-          ? Object.entries(aliases)
-              .map(([alias, target]) =>
-                rich
-                  ? `${theme.accentDim(alias)} ${theme.muted("->")} ${theme.info(target)}`
-                  : `${alias} -> ${target}`,
-              )
-              .join(", ")
-          : "-",
-      )}`,
-    );
-    runtime.log(
-      `${label(`Allowed models (${allowed.length || 0})`)}${colorize(rich, theme.muted, ":")} ${colorize(
-        rich,
-        allowed.length ? theme.info : theme.muted,
-        allowed.length ? allowed.join(", ") : "all",
-      )}`,
-    );
-
-    runtime.log("");
-    runtime.log(colorize(rich, theme.heading, "Auth overview"));
-    runtime.log(
-      `${label("Auth store")}${colorize(rich, theme.muted, ":")} ${colorize(
-        rich,
-        theme.info,
-        shortenHomePath(resolveAuthStorePathForDisplay(agentDir)),
-      )}`,
-    );
-    runtime.log(
-      `${label("Shell env")}${colorize(rich, theme.muted, ":")} ${colorize(
-        rich,
-        shellFallbackEnabled ? theme.success : theme.muted,
-        shellFallbackEnabled ? "on" : "off",
-      )}${applied.length ? colorize(rich, theme.muted, ` (applied: ${applied.join(", ")})`) : ""}`,
-    );
-    runtime.log(
-      `${label(`Providers w/ OAuth/tokens (${providersWithOauth.length || 0})`)}${colorize(
-        rich,
-        theme.muted,
-        ":",
-      )} ${colorize(
-        rich,
-        providersWithOauth.length ? theme.info : theme.muted,
-        providersWithOauth.length ? providersWithOauth.join(", ") : "-",
-      )}`,
-    );
-
-    const formatKey = (key: string) => colorize(rich, theme.warn, key);
-    const formatKeyValue = (key: string, value: string) =>
-      `${formatKey(key)}=${colorize(rich, theme.info, value)}`;
-    const formatSeparator = () => colorize(rich, theme.muted, " | ");
-
-    for (const entry of providerAuth) {
-      const separator = formatSeparator();
-      const bits: string[] = [];
-      bits.push(
-        formatKeyValue(
-          "effective",
-          `${colorize(rich, theme.accentBright, entry.effective.kind)}:${colorize(
-            rich,
-            theme.muted,
-            entry.effective.detail,
-          )}`,
-        ),
-      );
-      if (entry.profiles.count > 0) {
-        bits.push(formatKeyValue("profiles", formatProviderAuthProfileCounts(entry.profiles)));
-        if (entry.profiles.labels.length > 0) {
-          bits.push(colorize(rich, theme.info, entry.profiles.labels.join(", ")));
+      // Utility (or duplicate fallback) refs can repeat a configured model;
+      // identical diagnostics collapse while genuinely different evaluations
+      // for the same model (e.g. codex-fallback vs plain route) stay separate.
+      const seenRouteIssues = new Set<string>();
+      const dedupedModelRouteIssues = modelRouteIssues.filter((issue) => {
+        const key = JSON.stringify(issue);
+        if (seenRouteIssues.has(key)) {
+          return false;
         }
-      }
-      if (entry.env) {
-        bits.push(
-          formatKeyValue(
-            "env",
-            `${entry.env.value}${separator}${formatKeyValue("source", entry.env.source)}`,
-          ),
-        );
-      }
-      if (entry.modelsJson) {
-        bits.push(
-          formatKeyValue(
-            "models.json",
-            `${entry.modelsJson.value}${separator}${formatKeyValue("source", entry.modelsJson.source)}`,
-          ),
-        );
-      }
-      if (entry.syntheticAuth) {
-        bits.push(
-          formatKeyValue(
-            "synthetic",
-            `${entry.syntheticAuth.value}${separator}${formatKeyValue("source", entry.syntheticAuth.source)}`,
-          ),
-        );
-      }
-      runtime.log(`- ${theme.heading(entry.provider)} ${bits.join(separator)}`);
-    }
+        seenRouteIssues.add(key);
+        return true;
+      });
+      const missingProvidersInUse = Array.from(
+        new Set(
+          providerUses
+            .filter((usage) => !hasUsableAuthForProviderInUse(usage))
+            .map((usage) => resolveCliRuntimeAuthProvider(usage) ?? usage.provider),
+        ),
+      )
+        .filter(
+          (provider) =>
+            !isCliProvider(provider, cfg) ||
+            cliRuntimeAuthUsages.some((usage) => usage.runtime === provider),
+        )
+        .toSorted((a, b) => a.localeCompare(b));
 
-    if (runtimeAuthRoutes.length > 0) {
+      const probeProfileIds = (() => {
+        if (!opts.probeProfile) {
+          return [];
+        }
+        const raw = Array.isArray(opts.probeProfile) ? opts.probeProfile : [opts.probeProfile];
+        return raw
+          .flatMap((value) => (value ?? "").split(","))
+          .map((value) => value.trim())
+          .filter(Boolean);
+      })();
+      const probeTimeoutMs = parseOptionalPositiveFiniteOption(
+        opts.probeTimeout,
+        "--probe-timeout",
+        8000,
+      );
+      const probeConcurrency = parseOptionalPositiveIntegerOption(
+        opts.probeConcurrency,
+        "--probe-concurrency",
+        2,
+      );
+      const probeMaxTokens = parseOptionalPositiveIntegerOption(
+        opts.probeMaxTokens,
+        "--probe-max-tokens",
+        8,
+      );
+
+      const rawCandidates = [
+        rawModel || resolvedLabel,
+        ...fallbacks,
+        imageModel,
+        ...imageFallbacks,
+        // Probe the configured utility model itself; an arbitrary catalog model
+        // from the same provider can sit on a different auth route.
+        utilityModelRef ?? "",
+        ...configuredAllowRefs,
+      ].filter(Boolean);
+      const resolvedCandidates = rawCandidates
+        .map(
+          (raw) =>
+            resolveModelRefFromString({
+              cfg,
+              agentId,
+              raw: raw ?? "",
+              defaultProvider: DEFAULT_PROVIDER,
+              aliasIndex,
+              ...DISPLAY_MODEL_PARSE_OPTIONS,
+            })?.ref,
+        )
+        .filter((ref): ref is { provider: string; model: string } => Boolean(ref));
+      const modelCandidates = resolvedCandidates.map((ref) => `${ref.provider}/${ref.model}`);
+
+      let probeSummary: AuthProbeSummary | undefined;
+      if (opts.probe) {
+        const [{ withProgressTotals }, { runAuthProbes }] = await Promise.all([
+          progressRuntimeLoader.load(),
+          listProbeRuntimeLoader.load(),
+        ]);
+        probeSummary = await withProgressTotals(
+          { label: "Probing auth profiles…", total: 1 },
+          async (update) => {
+            return await runAuthProbes({
+              cfg,
+              agentId: workspaceAgentId,
+              agentDir,
+              workspaceDir,
+              providers,
+              modelCandidates,
+              options: {
+                provider: opts.probeProvider,
+                profileIds: probeProfileIds,
+                timeoutMs: probeTimeoutMs,
+                concurrency: probeConcurrency,
+                maxTokens: probeMaxTokens,
+              },
+              // Direct CLI probes create hidden sessions in the canonical agent DB.
+              // Gateway RPC probes omit this because the Gateway already owns the lock.
+              stateOwnership: { mode: "exclusive" },
+              onProgress: update,
+            });
+          },
+        );
+      }
+
+      const providersWithOauth = providerAuth
+        .filter(
+          (entry) =>
+            entry.profiles.oauth > 0 ||
+            entry.profiles.token > 0 ||
+            entry.env?.value === "OAuth (env)",
+        )
+        .map((entry) => {
+          const count =
+            entry.profiles.oauth +
+            entry.profiles.token +
+            (entry.env?.value === "OAuth (env)" ? 1 : 0);
+          return `${entry.provider} (${count})`;
+        });
+
+      const oauthProfiles = authHealth.profiles.filter(
+        (profile) => profile.type === "oauth" || profile.type === "token",
+      );
+
+      const unusableProfiles = (() => {
+        const now = Date.now();
+        const out: Array<{
+          profileId: string;
+          provider?: string;
+          kind: "cooldown" | "disabled";
+          reason?: string;
+          classification?: string;
+          recoveryHint: string;
+          until: number;
+          remainingMs: number;
+        }> = [];
+        for (const profileId of Object.keys(store.usageStats ?? {})) {
+          const unusableUntil = resolveProfileUnusableUntilForDisplay(store, profileId);
+          if (!unusableUntil || now >= unusableUntil) {
+            continue;
+          }
+          const stats = store.usageStats?.[profileId];
+          const kind =
+            typeof stats?.disabledUntil === "number" && now < stats.disabledUntil
+              ? "disabled"
+              : "cooldown";
+          const reason = kind === "disabled" ? stats?.disabledReason : stats?.cooldownReason;
+          const classification = kind === "cooldown" ? stats?.cooldownClassification : undefined;
+          const provider = store.profiles[profileId]?.provider;
+          out.push({
+            profileId,
+            provider,
+            kind,
+            reason,
+            ...(classification ? { classification } : {}),
+            recoveryHint: buildAuthProfileUnusableHint({
+              kind,
+              reason,
+              provider: provider ?? profileId,
+              profileId,
+            }),
+            until: unusableUntil,
+            remainingMs: unusableUntil - now,
+          });
+        }
+        return out.toSorted((a, b) => a.remainingMs - b.remainingMs);
+      })();
+
+      const checkStatus = (() => {
+        type RequirementHealth = "ok" | "expiring" | "missing" | "indeterminate";
+        const resolveRouteAuthHealth = (usage: StatusProviderUse): RequirementHealth => {
+          if (resolveStatusProviderUseIncompatibility(usage)) {
+            return "missing";
+          }
+          const cliRuntimeAuthProvider = resolveCliRuntimeAuthProvider(usage);
+          const evaluation = cliRuntimeAuthProvider
+            ? authResolver.evaluateModelAuth(cliRuntimeAuthProvider)
+            : usage.evaluation;
+          if (evaluation.availability === undefined) {
+            return "indeterminate";
+          }
+          if (!evaluation.availability) {
+            return "missing";
+          }
+          const profileId = evaluation.selectedProfileId;
+          if (!profileId) {
+            return "ok";
+          }
+          const health = authProfileHealthById.get(profileId);
+          if (health?.status === "expiring") {
+            return "expiring";
+          }
+          if (health?.status === "expired" || health?.status === "missing") {
+            return "missing";
+          }
+          return "ok";
+        };
+        const routeAuthHealth = new Set(providerUses.map(resolveRouteAuthHealth));
+        const hasExpiredOrMissing =
+          dedupedModelRouteIssues.some(
+            (issue) => issue.kind === "incompatible" || issue.kind === "indeterminate",
+          ) ||
+          routeAuthHealth.has("missing") ||
+          routeAuthHealth.has("indeterminate") ||
+          runtimeAuthRoutes.some((route) => route.status === "unavailable") ||
+          missingProvidersInUse.length > 0;
+        const hasExpiring = routeAuthHealth.has("expiring");
+        if (hasExpiredOrMissing) {
+          return 1;
+        }
+        if (hasExpiring) {
+          return 2;
+        }
+        return 0;
+      })();
+
+      if (opts.json) {
+        writeRuntimeJson(runtime, {
+          configPath,
+          ...(agentId ? { agentId } : {}),
+          agentDir,
+          defaultModel: defaultLabel,
+          resolvedDefault: resolvedLabel,
+          fallbacks,
+          imageModel: imageModel || null,
+          imageFallbacks,
+          utilityModel: { ref: utilityModelDisplayRef, source: utilityModelSource },
+          ...(agentId
+            ? {
+                modelConfig: {
+                  defaultSource: agentModelPrimary ? "agent" : "defaults",
+                  fallbacksSource: agentFallbacksOverride !== undefined ? "agent" : "defaults",
+                },
+              }
+            : {}),
+          aliases,
+          allowed,
+          auth: {
+            storePath: resolveAuthStorePathForDisplay(agentDir),
+            shellEnvFallback: {
+              enabled: shellFallbackEnabled,
+              appliedKeys: applied,
+            },
+            providersWithOAuth: providersWithOauth,
+            missingProvidersInUse,
+            modelRouteIssues: dedupedModelRouteIssues,
+            runtimeAuthRoutes,
+            providers: providerAuth,
+            unusableProfiles,
+            oauth: {
+              warnAfterMs: authHealth.warnAfterMs,
+              profiles: authHealth.profiles,
+              providers: authHealth.providers,
+            },
+            probes: probeSummary,
+          },
+        });
+        finishModelsStatusOutput(runtime, opts.check, checkStatus);
+        return;
+      }
+
+      if (opts.plain) {
+        writeRuntimeStdout(runtime, resolvedLabel);
+        finishModelsStatusOutput(runtime, opts.check, checkStatus);
+        return;
+      }
+
+      const rich = isRich(opts);
+      type ModelConfigSource = "agent" | "defaults";
+      const label = (value: string) => colorize(rich, theme.accent, value.padEnd(14));
+      const labelWithSource = (value: string, source?: ModelConfigSource) =>
+        label(source ? `${value} (${source})` : value);
+      const displayDefault =
+        rawModel && rawModel !== resolvedLabel
+          ? `${resolvedLabel} (from ${rawModel})`
+          : resolvedLabel;
+
+      runtime.log(
+        `${label("Config")}${colorize(rich, theme.muted, ":")} ${colorize(rich, theme.info, shortenHomePath(configPath))}`,
+      );
+      runtime.log(
+        `${label("Agent dir")}${colorize(rich, theme.muted, ":")} ${colorize(
+          rich,
+          theme.info,
+          shortenHomePath(agentDir),
+        )}`,
+      );
+      runtime.log(
+        `${labelWithSource("Default", agentId ? (agentModelPrimary ? "agent" : "defaults") : undefined)}${colorize(
+          rich,
+          theme.muted,
+          ":",
+        )} ${colorize(rich, theme.success, displayDefault)}`,
+      );
+      runtime.log(
+        `${labelWithSource(
+          `Fallbacks (${fallbacks.length || 0})`,
+          agentId ? (agentFallbacksOverride !== undefined ? "agent" : "defaults") : undefined,
+        )}${colorize(rich, theme.muted, ":")} ${colorize(
+          rich,
+          fallbacks.length ? theme.warn : theme.muted,
+          fallbacks.length ? fallbacks.join(", ") : "-",
+        )}`,
+      );
+      runtime.log(
+        `${label("Utility model")}${colorize(rich, theme.muted, ":")} ${colorize(
+          rich,
+          utilityModelDisplayRef ? theme.success : theme.muted,
+          utilityModelDisplayRef
+            ? `${utilityModelDisplayRef}${utilityModelSource === "provider-default" ? " (provider default)" : ""}`
+            : utilityModelSource === "disabled"
+              ? "off"
+              : "-",
+        )}`,
+      );
+      runtime.log(
+        `${labelWithSource("Image model", agentId ? "defaults" : undefined)}${colorize(
+          rich,
+          theme.muted,
+          ":",
+        )} ${colorize(rich, imageModel ? theme.accentBright : theme.muted, imageModel || "-")}`,
+      );
+      runtime.log(
+        `${labelWithSource(
+          `Image fallbacks (${imageFallbacks.length || 0})`,
+          agentId ? "defaults" : undefined,
+        )}${colorize(rich, theme.muted, ":")} ${colorize(
+          rich,
+          imageFallbacks.length ? theme.accentBright : theme.muted,
+          imageFallbacks.length ? imageFallbacks.join(", ") : "-",
+        )}`,
+      );
+      runtime.log(
+        `${label(`Aliases (${Object.keys(aliases).length || 0})`)}${colorize(rich, theme.muted, ":")} ${colorize(
+          rich,
+          Object.keys(aliases).length ? theme.accent : theme.muted,
+          Object.keys(aliases).length
+            ? Object.entries(aliases)
+                .map(([alias, target]) =>
+                  rich
+                    ? `${theme.accentDim(alias)} ${theme.muted("->")} ${theme.info(target)}`
+                    : `${alias} -> ${target}`,
+                )
+                .join(", ")
+            : "-",
+        )}`,
+      );
+      runtime.log(
+        `${label(`Allowed models (${allowed.length || 0})`)}${colorize(rich, theme.muted, ":")} ${colorize(
+          rich,
+          allowed.length ? theme.info : theme.muted,
+          allowed.length ? allowed.join(", ") : "all",
+        )}`,
+      );
+
       runtime.log("");
-      runtime.log(colorize(rich, theme.heading, "Runtime auth"));
-      for (const route of runtimeAuthRoutes) {
-        const runtimeAvailability =
-          route.status === "unavailable"
-            ? `${formatSeparator()}${formatKeyValue(
-                "auth",
-                route.authStatus,
-              )}${formatSeparator()}${formatKeyValue("runtime", route.runtimeStatus)}${
-                route.runtimeDetail
-                  ? `${formatSeparator()}${colorize(rich, theme.muted, route.runtimeDetail)}`
-                  : ""
-              }`
-            : "";
-        runtime.log(
-          `- ${theme.heading(route.provider)} via ${colorize(
-            rich,
-            theme.accentBright,
-            route.runtime,
-          )} uses ${theme.heading(route.authProvider)} ${formatKeyValue(
+      runtime.log(colorize(rich, theme.heading, "Auth overview"));
+      runtime.log(
+        `${label("Auth store")}${colorize(rich, theme.muted, ":")} ${colorize(
+          rich,
+          theme.info,
+          shortenHomePath(resolveAuthStorePathForDisplay(agentDir)),
+        )}`,
+      );
+      runtime.log(
+        `${label("Shell env")}${colorize(rich, theme.muted, ":")} ${colorize(
+          rich,
+          shellFallbackEnabled ? theme.success : theme.muted,
+          shellFallbackEnabled ? "on" : "off",
+        )}${applied.length ? colorize(rich, theme.muted, ` (applied: ${applied.join(", ")})`) : ""}`,
+      );
+      runtime.log(
+        `${label(`Providers w/ OAuth/tokens (${providersWithOauth.length || 0})`)}${colorize(
+          rich,
+          theme.muted,
+          ":",
+        )} ${colorize(
+          rich,
+          providersWithOauth.length ? theme.info : theme.muted,
+          providersWithOauth.length ? providersWithOauth.join(", ") : "-",
+        )}`,
+      );
+
+      const formatKey = (key: string) => colorize(rich, theme.warn, key);
+      const formatKeyValue = (key: string, value: string) =>
+        `${formatKey(key)}=${colorize(rich, theme.info, value)}`;
+      const formatSeparator = () => colorize(rich, theme.muted, " | ");
+
+      for (const entry of providerAuth) {
+        const separator = formatSeparator();
+        const bits: string[] = [];
+        bits.push(
+          formatKeyValue(
             "effective",
-            `${colorize(rich, theme.accentBright, route.effective.kind)}:${colorize(
+            `${colorize(rich, theme.accentBright, entry.effective.kind)}:${colorize(
               rich,
               theme.muted,
-              route.effective.detail,
+              entry.effective.detail,
             )}`,
-          )}${formatSeparator()}${formatKeyValue("status", route.status)}${runtimeAvailability}`,
+          ),
         );
-      }
-    }
-
-    if (dedupedModelRouteIssues.length > 0) {
-      runtime.log("");
-      runtime.log(colorize(rich, theme.heading, "Model route issues"));
-      for (const issue of dedupedModelRouteIssues) {
-        const modelRef = `${issue.provider}/${issue.model}`;
-        if (issue.kind === "incompatible") {
-          runtime.log(`- ${theme.heading(modelRef)} [${issue.code}] ${issue.message}`);
-          continue;
-        }
-        if (issue.kind === "indeterminate") {
-          runtime.log(`- ${theme.heading(modelRef)} [indeterminate] ${issue.message}`);
-          continue;
-        }
-        runtime.log(
-          `- ${theme.heading(modelRef)} requires ${issue.authRequirement} auth: ${issue.message}`,
-        );
-      }
-    }
-
-    if (missingProvidersInUse.length > 0) {
-      const { buildProviderAuthRecoveryHint } =
-        await import("../../agents/provider-auth-recovery-hint.js");
-      runtime.log("");
-      runtime.log(colorize(rich, theme.heading, "Missing auth"));
-      for (const provider of missingProvidersInUse) {
-        const requiresSubscription = dedupedModelRouteIssues.some(
-          (issue) =>
-            issue.kind === "missing-auth" &&
-            issue.provider === provider &&
-            issue.authRequirement === "subscription",
-        );
-        const hint = buildProviderAuthRecoveryHint({
-          provider,
-          config: cfg,
-          includeEnvVar: !requiresSubscription,
-        });
-        runtime.log(`- ${theme.heading(provider)} ${hint}`);
-      }
-    }
-
-    if (unusableProfiles.length > 0) {
-      runtime.log("");
-      runtime.log(colorize(rich, theme.heading, "Unavailable auth profiles"));
-      for (const profile of unusableProfiles) {
-        const diagnostic = profile.classification ?? profile.reason;
-        const reason = diagnostic ? `:${diagnostic}` : "";
-        const provider = profile.provider ? ` (${profile.provider})` : "";
-        runtime.log(
-          `- ${theme.heading(profile.profileId)}${provider} ${profile.kind}${reason} (${formatRemainingShort(profile.remainingMs)}) — ${profile.recoveryHint}`,
-        );
-      }
-    }
-
-    runtime.log("");
-    runtime.log(colorize(rich, theme.heading, "OAuth/token status"));
-    if (oauthProfiles.length === 0) {
-      runtime.log(colorize(rich, theme.muted, "- none"));
-    } else {
-      const { formatUsageWindowSummary, loadProviderUsageSummary, resolveUsageProviderId } =
-        await providerUsageRuntimeLoader.load();
-      const usageByProvider = new Map<string, string>();
-      const usageProviders = Array.from(
-        new Set(
-          oauthProfiles
-            .map((profile) =>
-              resolveUsageProviderId(profile.provider, { credentialType: profile.type }),
-            )
-            .filter((provider): provider is NonNullable<typeof provider> => Boolean(provider)),
-        ),
-      );
-      if (usageProviders.length > 0) {
-        try {
-          const usageSummary = await loadProviderUsageSummary({
-            providers: usageProviders,
-            agentDir,
-            timeoutMs: 3500,
-          });
-          for (const snapshot of usageSummary.providers) {
-            const formatted = formatUsageWindowSummary(snapshot, {
-              now: Date.now(),
-              maxWindows: 2,
-              includeResets: true,
-            });
-            if (formatted) {
-              usageByProvider.set(snapshot.provider, formatted);
-            }
+        if (entry.profiles.count > 0) {
+          bits.push(formatKeyValue("profiles", formatProviderAuthProfileCounts(entry.profiles)));
+          if (entry.profiles.labels.length > 0) {
+            bits.push(colorize(rich, theme.info, entry.profiles.labels.join(", ")));
           }
-        } catch {
-          // ignore usage failures
+        }
+        if (entry.env) {
+          bits.push(
+            formatKeyValue(
+              "env",
+              `${entry.env.value}${separator}${formatKeyValue("source", entry.env.source)}`,
+            ),
+          );
+        }
+        if (entry.modelsJson) {
+          bits.push(
+            formatKeyValue(
+              "models.json",
+              `${entry.modelsJson.value}${separator}${formatKeyValue("source", entry.modelsJson.source)}`,
+            ),
+          );
+        }
+        if (entry.syntheticAuth) {
+          bits.push(
+            formatKeyValue(
+              "synthetic",
+              `${entry.syntheticAuth.value}${separator}${formatKeyValue("source", entry.syntheticAuth.source)}`,
+            ),
+          );
+        }
+        runtime.log(`- ${theme.heading(entry.provider)} ${bits.join(separator)}`);
+      }
+
+      if (runtimeAuthRoutes.length > 0) {
+        runtime.log("");
+        runtime.log(colorize(rich, theme.heading, "Runtime auth"));
+        for (const route of runtimeAuthRoutes) {
+          const runtimeAvailability =
+            route.status === "unavailable"
+              ? `${formatSeparator()}${formatKeyValue(
+                  "auth",
+                  route.authStatus,
+                )}${formatSeparator()}${formatKeyValue("runtime", route.runtimeStatus)}${
+                  route.runtimeDetail
+                    ? `${formatSeparator()}${colorize(rich, theme.muted, route.runtimeDetail)}`
+                    : ""
+                }`
+              : "";
+          runtime.log(
+            `- ${theme.heading(route.provider)} via ${colorize(
+              rich,
+              theme.accentBright,
+              route.runtime,
+            )} uses ${theme.heading(route.authProvider)} ${formatKeyValue(
+              "effective",
+              `${colorize(rich, theme.accentBright, route.effective.kind)}:${colorize(
+                rich,
+                theme.muted,
+                route.effective.detail,
+              )}`,
+            )}${formatSeparator()}${formatKeyValue("status", route.status)}${runtimeAvailability}`,
+          );
         }
       }
 
-      const formatStatus = (status: string) => {
-        if (status === "ok") {
-          return colorize(rich, theme.success, "ok");
-        }
-        if (status === "static") {
-          return colorize(rich, theme.muted, "static");
-        }
-        if (status === "expiring") {
-          return colorize(rich, theme.warn, "expiring");
-        }
-        if (status === "missing") {
-          return colorize(rich, theme.warn, "unknown");
-        }
-        return colorize(rich, theme.error, "expired");
-      };
-
-      const profilesByProvider = new Map<string, typeof oauthProfiles>();
-      for (const profile of oauthProfiles) {
-        const current = profilesByProvider.get(profile.provider);
-        if (current) {
-          current.push(profile);
-        } else {
-          profilesByProvider.set(profile.provider, [profile]);
+      if (dedupedModelRouteIssues.length > 0) {
+        runtime.log("");
+        runtime.log(colorize(rich, theme.heading, "Model route issues"));
+        for (const issue of dedupedModelRouteIssues) {
+          const modelRef = `${issue.provider}/${issue.model}`;
+          if (issue.kind === "incompatible") {
+            runtime.log(`- ${theme.heading(modelRef)} [${issue.code}] ${issue.message}`);
+            continue;
+          }
+          if (issue.kind === "indeterminate") {
+            runtime.log(`- ${theme.heading(modelRef)} [indeterminate] ${issue.message}`);
+            continue;
+          }
+          runtime.log(
+            `- ${theme.heading(modelRef)} requires ${issue.authRequirement} auth: ${issue.message}`,
+          );
         }
       }
 
-      for (const [provider, profiles] of profilesByProvider) {
-        const usageProfile = profiles.find(
-          (profile) => profile.type === "oauth" || profile.type === "token",
-        );
-        const usageKey = resolveUsageProviderId(provider, {
-          credentialType: usageProfile?.type,
-        });
-        const usage = usageKey ? usageByProvider.get(usageKey) : undefined;
-        const usageSuffix = usage ? colorize(rich, theme.muted, ` usage: ${usage}`) : "";
-        runtime.log(`- ${colorize(rich, theme.heading, provider)}${usageSuffix}`);
-        for (const profile of profiles) {
-          const labelText = profile.label || profile.profileId;
-          const labelLocal = colorize(rich, theme.accent, labelText);
-          const status = formatStatus(profile.status);
-          const expiry =
-            profile.status === "static"
-              ? ""
-              : profile.expiresAt
-                ? ` expires in ${formatRemainingShort(profile.remainingMs)}`
-                : " expires unknown";
-          runtime.log(`  - ${labelLocal} ${status}${expiry}`);
+      if (missingProvidersInUse.length > 0) {
+        const { buildProviderAuthRecoveryHint } =
+          await import("../../agents/provider-auth-recovery-hint.js");
+        runtime.log("");
+        runtime.log(colorize(rich, theme.heading, "Missing auth"));
+        for (const provider of missingProvidersInUse) {
+          const requiresSubscription = dedupedModelRouteIssues.some(
+            (issue) =>
+              issue.kind === "missing-auth" &&
+              issue.provider === provider &&
+              issue.authRequirement === "subscription",
+          );
+          const hint = buildProviderAuthRecoveryHint({
+            provider,
+            config: cfg,
+            includeEnvVar: !requiresSubscription,
+          });
+          runtime.log(`- ${theme.heading(provider)} ${hint}`);
         }
       }
-    }
 
-    if (probeSummary) {
-      const [
-        { getTerminalTableWidth, renderTable },
-        { describeProbeSummary, formatProbeLatency, sortProbeResults },
-      ] = await Promise.all([terminalTableRuntimeLoader.load(), listProbeRuntimeLoader.load()]);
+      if (unusableProfiles.length > 0) {
+        runtime.log("");
+        runtime.log(colorize(rich, theme.heading, "Unavailable auth profiles"));
+        for (const profile of unusableProfiles) {
+          const diagnostic = profile.classification ?? profile.reason;
+          const reason = diagnostic ? `:${diagnostic}` : "";
+          const provider = profile.provider ? ` (${profile.provider})` : "";
+          runtime.log(
+            `- ${theme.heading(profile.profileId)}${provider} ${profile.kind}${reason} (${formatRemainingShort(profile.remainingMs)}) — ${profile.recoveryHint}`,
+          );
+        }
+      }
+
       runtime.log("");
-      runtime.log(colorize(rich, theme.heading, "Auth probes"));
-      if (probeSummary.results.length === 0) {
+      runtime.log(colorize(rich, theme.heading, "OAuth/token status"));
+      if (oauthProfiles.length === 0) {
         runtime.log(colorize(rich, theme.muted, "- none"));
       } else {
-        const tableWidth = getTerminalTableWidth();
-        const sorted = sortProbeResults(probeSummary.results);
-        const statusColor = (status: string) => {
-          if (status === "ok") {
-            return theme.success;
-          }
-          if (status === "rate_limit") {
-            return theme.warn;
-          }
-          if (status === "timeout" || status === "billing") {
-            return theme.warn;
-          }
-          if (status === "auth" || status === "format") {
-            return theme.error;
-          }
-          if (status === "no_model") {
-            return theme.muted;
-          }
-          return theme.muted;
-        };
-        const rows = sorted.map((result) => {
-          const status = colorize(rich, statusColor(result.status), result.status);
-          const latency = formatProbeLatency(result.latencyMs);
-          const modelLabel = result.model ?? `${result.provider}/-`;
-          const modeLabel = result.mode
-            ? ` ${colorize(rich, theme.muted, `(${result.mode})`)}`
-            : "";
-          const profile = `${colorize(rich, theme.accent, result.label)}${modeLabel}`;
-          const detail = result.error?.trim();
-          const detailLabel = detail ? `\n${colorize(rich, theme.muted, `↳ ${detail}`)}` : "";
-          const statusLabel = `${status}${colorize(rich, theme.muted, ` · ${latency}`)}${detailLabel}`;
-          return {
-            Model: colorize(rich, theme.heading, modelLabel),
-            Profile: profile,
-            Status: statusLabel,
-          };
-        });
-        runtime.log(
-          renderTable({
-            width: tableWidth,
-            columns: [
-              { key: "Model", header: "Model", minWidth: 18 },
-              { key: "Profile", header: "Profile", minWidth: 24 },
-              { key: "Status", header: "Status", minWidth: 12 },
-            ],
-            rows,
-          }).trimEnd(),
+        const { formatUsageWindowSummary, loadProviderUsageSummary, resolveUsageProviderId } =
+          await providerUsageRuntimeLoader.load();
+        const usageByProvider = new Map<string, string>();
+        const usageProviders = Array.from(
+          new Set(
+            oauthProfiles
+              .map((profile) =>
+                resolveUsageProviderId(profile.provider, { credentialType: profile.type }),
+              )
+              .filter((provider): provider is NonNullable<typeof provider> => Boolean(provider)),
+          ),
         );
-        runtime.log(colorize(rich, theme.muted, describeProbeSummary(probeSummary)));
+        if (usageProviders.length > 0) {
+          try {
+            const usageSummary = await loadProviderUsageSummary({
+              providers: usageProviders,
+              agentDir,
+              timeoutMs: 3500,
+            });
+            for (const snapshot of usageSummary.providers) {
+              const formatted = formatUsageWindowSummary(snapshot, {
+                now: Date.now(),
+                maxWindows: 2,
+                includeResets: true,
+              });
+              if (formatted) {
+                usageByProvider.set(snapshot.provider, formatted);
+              }
+            }
+          } catch {
+            // ignore usage failures
+          }
+        }
+
+        const formatStatus = (status: string) => {
+          if (status === "ok") {
+            return colorize(rich, theme.success, "ok");
+          }
+          if (status === "static") {
+            return colorize(rich, theme.muted, "static");
+          }
+          if (status === "expiring") {
+            return colorize(rich, theme.warn, "expiring");
+          }
+          if (status === "missing") {
+            return colorize(rich, theme.warn, "unknown");
+          }
+          return colorize(rich, theme.error, "expired");
+        };
+
+        const profilesByProvider = new Map<string, typeof oauthProfiles>();
+        for (const profile of oauthProfiles) {
+          const current = profilesByProvider.get(profile.provider);
+          if (current) {
+            current.push(profile);
+          } else {
+            profilesByProvider.set(profile.provider, [profile]);
+          }
+        }
+
+        for (const [provider, profiles] of profilesByProvider) {
+          const usageProfile = profiles.find(
+            (profile) => profile.type === "oauth" || profile.type === "token",
+          );
+          const usageKey = resolveUsageProviderId(provider, {
+            credentialType: usageProfile?.type,
+          });
+          const usage = usageKey ? usageByProvider.get(usageKey) : undefined;
+          const usageSuffix = usage ? colorize(rich, theme.muted, ` usage: ${usage}`) : "";
+          runtime.log(`- ${colorize(rich, theme.heading, provider)}${usageSuffix}`);
+          for (const profile of profiles) {
+            const labelText = profile.label || profile.profileId;
+            const labelLocal = colorize(rich, theme.accent, labelText);
+            const status = formatStatus(profile.status);
+            const expiry =
+              profile.status === "static"
+                ? ""
+                : profile.expiresAt
+                  ? ` expires in ${formatRemainingShort(profile.remainingMs)}`
+                  : " expires unknown";
+            runtime.log(`  - ${labelLocal} ${status}${expiry}`);
+          }
+        }
       }
-    }
-    finishModelsStatusOutput(runtime, opts.check, checkStatus);
-  } finally {
-    cleanupPluginMetadataSnapshot();
-  }
+
+      if (probeSummary) {
+        const [
+          { getTerminalTableWidth, renderTable },
+          { describeProbeSummary, formatProbeLatency, sortProbeResults },
+        ] = await Promise.all([terminalTableRuntimeLoader.load(), listProbeRuntimeLoader.load()]);
+        runtime.log("");
+        runtime.log(colorize(rich, theme.heading, "Auth probes"));
+        if (probeSummary.results.length === 0) {
+          runtime.log(colorize(rich, theme.muted, "- none"));
+        } else {
+          const tableWidth = getTerminalTableWidth();
+          const sorted = sortProbeResults(probeSummary.results);
+          const statusColor = (status: string) => {
+            if (status === "ok") {
+              return theme.success;
+            }
+            if (status === "rate_limit") {
+              return theme.warn;
+            }
+            if (status === "timeout" || status === "billing") {
+              return theme.warn;
+            }
+            if (status === "auth" || status === "format") {
+              return theme.error;
+            }
+            if (status === "no_model") {
+              return theme.muted;
+            }
+            return theme.muted;
+          };
+          const rows = sorted.map((result) => {
+            const status = colorize(rich, statusColor(result.status), result.status);
+            const latency = formatProbeLatency(result.latencyMs);
+            const modelLabel = result.model ?? `${result.provider}/-`;
+            const modeLabel = result.mode
+              ? ` ${colorize(rich, theme.muted, `(${result.mode})`)}`
+              : "";
+            const profile = `${colorize(rich, theme.accent, result.label)}${modeLabel}`;
+            const detail = result.error?.trim();
+            const detailLabel = detail ? `\n${colorize(rich, theme.muted, `↳ ${detail}`)}` : "";
+            const statusLabel = `${status}${colorize(rich, theme.muted, ` · ${latency}`)}${detailLabel}`;
+            return {
+              Model: colorize(rich, theme.heading, modelLabel),
+              Profile: profile,
+              Status: statusLabel,
+            };
+          });
+          runtime.log(
+            renderTable({
+              width: tableWidth,
+              columns: [
+                { key: "Model", header: "Model", minWidth: 18 },
+                { key: "Profile", header: "Profile", minWidth: 24 },
+                { key: "Status", header: "Status", minWidth: 12 },
+              ],
+              rows,
+            }).trimEnd(),
+          );
+          runtime.log(colorize(rich, theme.muted, describeProbeSummary(probeSummary)));
+        }
+      }
+      finishModelsStatusOutput(runtime, opts.check, checkStatus);
+    },
+    { config: cfg, workspaceDir, env: process.env },
+  );
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -676,7 +676,7 @@ describe("modelsStatusCommand auth overview", () => {
     }
   });
 
-  it("does not restore over plugin metadata published while status is running", async () => {
+  it("keeps status metadata scoped while another operation publishes metadata", async () => {
     const originalLoadModelCatalog = mocks.loadModelCatalog.getMockImplementation();
     const config = mocks.loadConfig();
     const workspaceDir = "/tmp/openclaw-agent/workspace";
@@ -699,6 +699,9 @@ describe("modelsStatusCommand auth overview", () => {
     try {
       await catalogStarted.promise;
       expect(replacement).toBeDefined();
+      expect(
+        getCurrentPluginMetadataSnapshot({ config, workspaceDir, env: process.env }),
+      ).toBeUndefined();
       clearPluginMetadataLifecycleCaches();
       setCurrentPluginMetadataSnapshot(replacement!, {
         config,

--- a/src/commands/onboard-interactive.test.ts
+++ b/src/commands/onboard-interactive.test.ts
@@ -17,13 +17,16 @@ import type { BoundVerifySetupInferenceResult } from "../system-agent/setup-infe
 import {
   createSystemAgentVerifiedInferenceTestFixture,
   installSystemAgentClaudeCliBackendTestFixture,
-  installSystemAgentPluginMetadataTestSnapshot,
+  createSystemAgentPluginMetadataTestSnapshot,
 } from "../system-agent/system-agent.test-helpers.js";
 import { resolveSystemAgentVerifiedInferenceRoute } from "../system-agent/verified-inference.js";
 import { createTempHomeEnv } from "../test-utils/temp-home.js";
 import { WizardCancelledError } from "../wizard/prompts.js";
-import { runConversationalOnboarding, runInteractiveSetup } from "./onboard-interactive.js";
-import { runSystemAgentWithInference } from "./system-agent-with-inference.js";
+import {
+  runConversationalOnboarding as runConversationalOnboardingImpl,
+  runInteractiveSetup,
+} from "./onboard-interactive.js";
+import { runSystemAgentWithInference as runSystemAgentWithInferenceImpl } from "./system-agent-with-inference.js";
 
 const mocks = vi.hoisted(() => ({
   createClackPrompter: vi.fn(() => ({ id: "prompter" })),
@@ -63,8 +66,12 @@ vi.mock("../../packages/terminal-core/src/restore.js", () => ({
 
 describe("runConversationalOnboarding", () => {
   let home: Awaited<ReturnType<typeof createTempHomeEnv>>;
-  let metadata: ReturnType<typeof installSystemAgentPluginMetadataTestSnapshot> | undefined;
+  let metadata: ReturnType<typeof createSystemAgentPluginMetadataTestSnapshot> | undefined;
   let restoreCliBackend: (() => void) | undefined;
+  const runConversationalOnboarding: typeof runConversationalOnboardingImpl = (...args) =>
+    metadata!.run(() => runConversationalOnboardingImpl(...args));
+  const runSystemAgentWithInference: typeof runSystemAgentWithInferenceImpl = (...args) =>
+    metadata!.run(() => runSystemAgentWithInferenceImpl(...args));
   let previousRegistry: ReturnType<typeof captureActivePluginRegistrySnapshot>;
   let rootRegistry: ReturnType<typeof createEmptyPluginRegistry>;
   let terminal: PassThrough & { isTTY: boolean };
@@ -80,7 +87,7 @@ describe("runConversationalOnboarding", () => {
 
   afterEach(async () => {
     terminal.destroy();
-    metadata?.restore();
+
     metadata = undefined;
     restoreCliBackend?.();
     restoreCliBackend = undefined;
@@ -106,11 +113,11 @@ describe("runConversationalOnboarding", () => {
       },
       plugins: { entries: { codex: { enabled: true }, "fixture-runtime": { enabled: true } } },
     };
-    metadata = installSystemAgentPluginMetadataTestSnapshot(config);
+    metadata = createSystemAgentPluginMetadataTestSnapshot(config);
     if (runner === "cli") {
       restoreCliBackend = installSystemAgentClaudeCliBackendTestFixture();
     }
-    const fixture = await createSystemAgentVerifiedInferenceTestFixture(config);
+    const fixture = await metadata.run(() => createSystemAgentVerifiedInferenceTestFixture(config));
     // Keep the handoff's actual registry lookup and artifact validation; the binding
     // factory's validator override is only for constructing synthetic probe evidence.
     const { validateAgentHarnessRuntimeArtifact: _fixtureValidator, ...ownerDeps } = fixture.deps;

--- a/src/gateway/server-methods/system-agent-approval.test.ts
+++ b/src/gateway/server-methods/system-agent-approval.test.ts
@@ -3,7 +3,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { createOperationalRunInstanceRef } from "../../agents/admitted-run-context.js";
@@ -27,7 +27,7 @@ import { closeOpenClawStateDatabaseByPath } from "../../state/openclaw-state-db.
 import { SystemAgentChatEngine } from "../../system-agent/chat-engine.js";
 import {
   createSystemAgentVerifiedInferenceTestFixture,
-  installSystemAgentPluginMetadataTestSnapshot,
+  createSystemAgentPluginMetadataTestSnapshot,
   readLastSystemAgentAuditEntry,
   type SystemAgentPluginMetadataTestSnapshot,
 } from "../../system-agent/system-agent.test-helpers.js";
@@ -66,11 +66,7 @@ describe("Full Access delegated chat", () => {
   let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
 
   beforeAll(() => {
-    pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot(verifiedConfig);
-  });
-
-  afterAll(() => {
-    pluginMetadataSnapshot?.restore();
+    pluginMetadataSnapshot = createSystemAgentPluginMetadataTestSnapshot(verifiedConfig);
   });
 
   afterEach(async () => {
@@ -83,7 +79,7 @@ describe("Full Access delegated chat", () => {
     resetPluginStateStoreForTests();
     resetCommandQueueStateForTest();
     vi.unstubAllEnvs();
-    pluginMetadataSnapshot?.rebindForCurrentEnv();
+
     systemAgentTempDirs.cleanup();
   });
 
@@ -95,8 +91,10 @@ describe("Full Access delegated chat", () => {
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(stateDir, "openclaw.json"));
     fs.writeFileSync(path.join(stateDir, "openclaw.json"), JSON.stringify(verifiedConfig));
-    pluginMetadataSnapshot?.rebindForCurrentEnv();
-    const fixture = await createSystemAgentVerifiedInferenceTestFixture(verifiedConfig);
+
+    const fixture = await pluginMetadataSnapshot!.run(() =>
+      createSystemAgentVerifiedInferenceTestFixture(verifiedConfig),
+    );
     setupInferenceMocks.resolvePersistentApplyInference.mockResolvedValue(
       fixture.binding.execution,
     );
@@ -196,15 +194,17 @@ describe("Full Access delegated chat", () => {
     const callChat = async (params: Record<string, unknown>) => {
       const respond = vi.fn<(ok: boolean, payload?: unknown, error?: unknown) => void>();
       const handler = expectDefined(systemAgentHandlers["openclaw.chat"], "chat handler");
-      await handler({
-        params,
-        respond,
-        context,
-        client: {
-          connId: "conn-test",
-          connect: { device: { id: "device-test" } },
-        } as GatewayClient,
-      } as never);
+      await pluginMetadataSnapshot!.run(() =>
+        handler({
+          params,
+          respond,
+          context,
+          client: {
+            connId: "conn-test",
+            connect: { device: { id: "device-test" } },
+          } as GatewayClient,
+        } as never),
+      );
       const [ok, payload, error] = expectDefined(respond.mock.calls[0], "chat response");
       return { ok, payload, error };
     };

--- a/src/gateway/server-methods/system-agent.test-support.ts
+++ b/src/gateway/server-methods/system-agent.test-support.ts
@@ -14,7 +14,7 @@ import { CommandLane } from "../../process/lanes.js";
 import { SystemAgentChatEngine } from "../../system-agent/chat-engine.js";
 import {
   createSystemAgentVerifiedInferenceTestFixture,
-  installSystemAgentPluginMetadataTestSnapshot,
+  createSystemAgentPluginMetadataTestSnapshot,
   type SystemAgentPluginMetadataTestSnapshot,
 } from "../../system-agent/system-agent.test-helpers.js";
 import type {
@@ -56,8 +56,17 @@ export function makeContext(sessions: Map<string, SystemAgentChatSession>): Gate
   return { systemAgentSessions: sessions } as unknown as GatewayRequestContext;
 }
 
+let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
+
 export function systemAgentHandler(method: keyof typeof systemAgentHandlers) {
-  return expectDefined(systemAgentHandlers[method], `systemAgentHandlers["${method}"] invariant`);
+  const handler = expectDefined(
+    systemAgentHandlers[method],
+    `systemAgentHandlers["${method}"] invariant`,
+  );
+  return (...args: Parameters<typeof handler>) =>
+    expectDefined(pluginMetadataSnapshot, "metadata fixture was not initialized").run(() =>
+      handler(...args),
+    );
 }
 
 export function systemAgentLane() {
@@ -76,7 +85,7 @@ export const verifiedConfig: OpenClawConfig = {
 export function useSystemAgentGatewayTestFixture() {
   let verifiedInference: SystemAgentVerifiedInferenceBinding | undefined;
   let verifiedInferenceDeps: SystemAgentVerifiedInferenceDeps | undefined;
-  let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
+
   const systemAgentTempDirs = useAutoCleanupTempDirTracker(afterEach);
   let previousAppliedHash: string | null = null;
 
@@ -122,14 +131,15 @@ export function useSystemAgentGatewayTestFixture() {
   }
 
   beforeAll(async () => {
-    pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot(verifiedConfig);
-    const fixture = await createSystemAgentVerifiedInferenceTestFixture(verifiedConfig);
+    pluginMetadataSnapshot = createSystemAgentPluginMetadataTestSnapshot(verifiedConfig);
+    const fixture = await pluginMetadataSnapshot.run(() =>
+      createSystemAgentVerifiedInferenceTestFixture(verifiedConfig),
+    );
     verifiedInference = fixture.binding;
     verifiedInferenceDeps = fixture.deps;
   });
 
   afterAll(() => {
-    pluginMetadataSnapshot?.restore();
     verifiedInference = undefined;
     verifiedInferenceDeps = undefined;
   });
@@ -178,7 +188,6 @@ export function useSystemAgentGatewayTestFixture() {
     resetPluginStateStoreForTests();
     resetCommandQueueStateForTest();
     vi.unstubAllEnvs();
-    pluginMetadataSnapshot?.rebindForCurrentEnv();
   });
 
   return {

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -44,7 +44,7 @@ import { onDiagnosticEvent, type DiagnosticPayloadLargeEvent } from "../infra/di
 import { flushDiagnosticsTimeline } from "../infra/diagnostics-timeline.js";
 import { ExecApprovalsMigrationRequiredError } from "../infra/exec-approvals-migration-gate.js";
 import { getMediaDir } from "../media/store.js";
-import { installTemporaryCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import { rebasePluginMetadataSnapshotManifestRegistry } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
@@ -2043,7 +2043,6 @@ describe("gateway server chat", () => {
         },
       },
       async (state) => {
-        let releasePluginMetadata: () => boolean = () => false;
         const previousAgentConfig = testState.agentConfig;
         const previousAgentsConfig = testState.agentsConfig;
         openDirectChatSession();
@@ -2068,431 +2067,440 @@ describe("gateway server chat", () => {
           await state.writeConfig(config);
           const pluginMetadataSnapshot = createGatewayPluginMetadataSnapshot(config);
           assertPluginMetadataSnapshotConsistency(pluginMetadataSnapshot);
-          releasePluginMetadata = installTemporaryCurrentPluginMetadataSnapshot(
+          await withPluginMetadataSnapshotScope(
             pluginMetadataSnapshot,
-            {
-              config,
-              compatibleConfigs: [config],
-              env: process.env,
-            },
-          ).release;
-          const persistedConfig = getRuntimeConfig();
-          expect(persistedConfig.auth?.order?.openai).toEqual([
-            "openai:api",
-            "openai:chatgpt",
-            "openai:expired",
-          ]);
-          testState.agentsConfig = persistedConfig.agents;
-          testState.agentConfig = persistedConfig.agents?.defaults;
-          await writeSessionStore({
-            entries: {
-              "agent:work:main": {
+            async () => {
+              const persistedConfig = getRuntimeConfig();
+              expect(persistedConfig.auth?.order?.openai).toEqual([
+                "openai:api",
+                "openai:chatgpt",
+                "openai:expired",
+              ]);
+              testState.agentsConfig = persistedConfig.agents;
+              testState.agentConfig = persistedConfig.agents?.defaults;
+              await writeSessionStore({
+                entries: {
+                  "agent:work:main": {
+                    sessionId: "sess-work",
+                    modelProvider: "openai",
+                    model: "gpt-5.5",
+                    authProfileOverride: "openai:chatgpt",
+                    authProfileOverrideSource: "user",
+                    updatedAt: Date.now(),
+                  },
+                  "agent:work:auto": {
+                    sessionId: "sess-work-auto",
+                    modelProvider: "openai",
+                    model: "gpt-5.5",
+                    authProfileOverride: "openai:expired",
+                    authProfileOverrideSource: "auto",
+                    updatedAt: Date.now(),
+                  },
+                  "agent:work:auto-preferred": {
+                    sessionId: "sess-work-auto-preferred",
+                    modelProvider: "openai",
+                    model: "gpt-5.5",
+                    authProfileOverride: "openai:chatgpt",
+                    authProfileOverrideSource: "auto",
+                    updatedAt: Date.now(),
+                  },
+                  "agent:work:legacy-auto": {
+                    sessionId: "sess-work-legacy-auto",
+                    modelProvider: "openai",
+                    model: "gpt-5.5",
+                    authProfileOverride: "openai:expired",
+                    authProfileOverrideCompactionCount: 0,
+                    updatedAt: Date.now(),
+                  },
+                },
+              });
+              const { loadGatewaySessionEntryReadOnly } = await import("./session-utils.js");
+              const loaded = loadGatewaySessionEntryReadOnly("agent:work:main");
+              expect(loaded.cfg.agents?.defaults?.model).toEqual(config.agents.defaults.model);
+              expect(loaded.cfg.agents?.entries).toEqual(config.agents.entries);
+              expect(loaded.canonicalKey).toBe("agent:work:main");
+              expect(loaded.entry).toMatchObject({
                 sessionId: "sess-work",
                 modelProvider: "openai",
                 model: "gpt-5.5",
                 authProfileOverride: "openai:chatgpt",
-                authProfileOverrideSource: "user",
-                updatedAt: Date.now(),
-              },
-              "agent:work:auto": {
-                sessionId: "sess-work-auto",
-                modelProvider: "openai",
-                model: "gpt-5.5",
-                authProfileOverride: "openai:expired",
-                authProfileOverrideSource: "auto",
-                updatedAt: Date.now(),
-              },
-              "agent:work:auto-preferred": {
-                sessionId: "sess-work-auto-preferred",
-                modelProvider: "openai",
-                model: "gpt-5.5",
-                authProfileOverride: "openai:chatgpt",
-                authProfileOverrideSource: "auto",
-                updatedAt: Date.now(),
-              },
-              "agent:work:legacy-auto": {
-                sessionId: "sess-work-legacy-auto",
-                modelProvider: "openai",
-                model: "gpt-5.5",
-                authProfileOverride: "openai:expired",
-                authProfileOverrideCompactionCount: 0,
-                updatedAt: Date.now(),
-              },
-            },
-          });
-          const { loadGatewaySessionEntryReadOnly } = await import("./session-utils.js");
-          const loaded = loadGatewaySessionEntryReadOnly("agent:work:main");
-          expect(loaded.cfg.agents?.defaults?.model).toEqual(config.agents.defaults.model);
-          expect(loaded.cfg.agents?.entries).toEqual(config.agents.entries);
-          expect(loaded.canonicalKey).toBe("agent:work:main");
-          expect(loaded.entry).toMatchObject({
-            sessionId: "sess-work",
-            modelProvider: "openai",
-            model: "gpt-5.5",
-            authProfileOverride: "openai:chatgpt",
-          });
-          await state.writeAuthProfiles({
-            version: 1,
-            profiles: {
-              "openai:chatgpt": {
-                type: "oauth",
+              });
+              await state.writeAuthProfiles({
+                version: 1,
+                profiles: {
+                  "openai:chatgpt": {
+                    type: "oauth",
+                    provider: "openai",
+                    access: "chatgpt-access",
+                    refresh: "chatgpt-refresh",
+                    expires: Date.now() + 30 * 60_000,
+                  },
+                },
+              });
+              await state.writeAuthProfiles(
+                {
+                  version: 1,
+                  profiles: {
+                    "openai:api": {
+                      type: "api_key",
+                      provider: "openai",
+                      key: "platform-api-key",
+                    },
+                    "openai:chatgpt": {
+                      type: "oauth",
+                      provider: "openai",
+                      access: "work-chatgpt-access",
+                      refresh: "work-chatgpt-refresh",
+                      expires: Date.now() + 30 * 60_000,
+                    },
+                    "openai:expired": {
+                      type: "oauth",
+                      provider: "openai",
+                      access: "expired-work-chatgpt-access",
+                      expires: Date.now() - 60_000,
+                    },
+                  },
+                },
+                "work",
+              );
+              const platformRoute = {
+                id: "gpt-5.5",
+                name: "GPT-5.5",
                 provider: "openai",
-                access: "chatgpt-access",
-                refresh: "chatgpt-refresh",
-                expires: Date.now() + 30 * 60_000,
-              },
-            },
-          });
-          await state.writeAuthProfiles(
-            {
-              version: 1,
-              profiles: {
-                "openai:api": {
-                  type: "api_key",
-                  provider: "openai",
-                  key: "platform-api-key",
-                },
-                "openai:chatgpt": {
-                  type: "oauth",
-                  provider: "openai",
-                  access: "work-chatgpt-access",
-                  refresh: "work-chatgpt-refresh",
-                  expires: Date.now() + 30 * 60_000,
-                },
-                "openai:expired": {
-                  type: "oauth",
-                  provider: "openai",
-                  access: "expired-work-chatgpt-access",
-                  expires: Date.now() - 60_000,
-                },
-              },
-            },
-            "work",
-          );
-          const platformRoute = {
-            id: "gpt-5.5",
-            name: "GPT-5.5",
-            provider: "openai",
-            api: "openai-responses" as const,
-            baseUrl: "https://api.openai.com/v1",
-            contextWindow: 1_000_000,
-            reasoning: true,
-            compat: { supportedReasoningEfforts: ["none", "low", "medium", "high", "xhigh"] },
-          };
-          const subscriptionRoute = {
-            ...platformRoute,
-            api: "openai-chatgpt-responses" as const,
-            baseUrl: "https://chatgpt.com/backend-api/codex",
-            contextWindow: 400_000,
-            reasoning: false,
-            compat: { supportedReasoningEfforts: ["low"] },
-            params: { apiKey: "private-route-token" },
-          };
-          const catalogSnapshot = {
-            entries: [subscriptionRoute],
-            routeVariants: [subscriptionRoute, platformRoute],
-          };
-          const { loadAuthProfileStoreForRuntime } = await import("../agents/auth-profiles.js");
-          const { resolveAgentDir } = await import("../agents/agent-scope.js");
-          const preparedAuthStoreByAgentId = new Map([
-            [
-              "main",
-              loadAuthProfileStoreForRuntime(resolveAgentDir(persistedConfig, "main"), {
-                readOnly: true,
-              }),
-            ],
-            [
-              "work",
-              loadAuthProfileStoreForRuntime(resolveAgentDir(persistedConfig, "work"), {
-                inheritedAuthDir: resolveAgentDir(persistedConfig, "main"),
-                readOnly: true,
-              }),
-            ],
-          ]);
-          const requirePreparedAuthStore = (agentId: string) => {
-            const authStore = preparedAuthStoreByAgentId.get(agentId);
-            if (!authStore) {
-              throw new Error(`expected prepared auth store for agent "${agentId}"`);
-            }
-            return authStore;
-          };
-          const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
-          const { buildModelsListResult, createGatewayAgentModelCatalogProjector } =
-            await import("./server-methods/models-list-result.js");
-          const projectionByKey = new Map<
-            string,
-            Promise<{
-              modelCatalog: ModelCatalogEntry[];
-              metadata: { models: unknown[]; swarmEnabled: boolean };
-            }>
-          >();
-          const projectAgent = (
-            context: GatewayRequestContext,
-            agentId: string,
-            sessionEntry?: Parameters<GatewayRequestContext["readChatMetadata"]>[0]["sessionEntry"],
-          ) => {
-            const profileId = sessionEntry?.authProfileOverride?.trim();
-            const profileSource = sessionEntry?.authProfileOverrideSource;
-            const legacyUserProfile =
-              profileSource === undefined &&
-              sessionEntry?.authProfileOverrideCompactionCount === undefined;
-            const key = [
-              agentId,
-              profileId ?? "",
-              profileId && (profileSource === "user" || legacyUserProfile) ? profileId : "",
-            ].join("\0");
-            const existing = projectionByKey.get(key);
-            if (existing) {
-              return existing;
-            }
-            const projector = createGatewayAgentModelCatalogProjector({
-              cfg: persistedConfig,
-              agentId,
-              snapshot: catalogSnapshot,
-              metadataSnapshot: pluginMetadataSnapshot,
-              preparedAuthStore: requirePreparedAuthStore(agentId),
-              ...(profileId ? { preferredProfileId: profileId } : {}),
-              ...(profileId && (profileSource === "user" || legacyUserProfile)
-                ? { pinnedProfileId: profileId }
-                : {}),
-            });
-            const projection = Promise.all([
-              projector.projectCatalog(),
-              buildModelsListResult({
-                context,
-                agentId,
-                params: { view: "configured" },
-                preloadedCatalog: {
-                  agentId,
-                  config: persistedConfig,
-                  snapshot: catalogSnapshot,
-                },
-                preloadedOnly: true,
-                catalogProjector: projector,
-              }),
-            ]).then(([modelCatalog, metadata]) => ({
-              modelCatalog,
-              metadata: { ...metadata, swarmEnabled: false },
-            }));
-            projectionByKey.set(key, projection);
-            return projection;
-          };
-          const context = createDirectChatContext({
-            loadGatewayModelCatalogSnapshot: vi
-              .fn<GatewayRequestContext["loadGatewayModelCatalogSnapshot"]>()
-              .mockResolvedValue({
-                agentId: "work",
-                agentDir: "/tmp/chat-work-agent",
-                catalogComplete: false,
-                workspaceDir: "/tmp/chat-work-workspace",
-                config: persistedConfig,
-                ...catalogSnapshot,
-              }),
-            getRuntimeConfig: () => persistedConfig,
-            readChatStartupProjection: vi.fn(async ({ agentId, sessionEntry }) => {
-              const [neutralProjection, sessionProjection] = await Promise.all([
-                projectAgent(context, agentId),
-                projectAgent(context, agentId, sessionEntry),
-              ]);
-              preparedThinkingPolicy.fallback = sessionProjection.modelCatalog.some(
-                (entry) => entry.reasoning === true,
-              )
-                ? "base"
-                : "off";
-              return {
-                metadata: sessionProjection.metadata,
-                sessionModelCatalog: sessionProjection.modelCatalog,
-                defaultModelCatalog: neutralProjection.modelCatalog,
+                api: "openai-responses" as const,
+                baseUrl: "https://api.openai.com/v1",
+                contextWindow: 1_000_000,
+                reasoning: true,
+                compat: { supportedReasoningEfforts: ["none", "low", "medium", "high", "xhigh"] },
               };
-            }),
-          });
-          const expiredPreferenceEvaluation = await createGatewayAgentModelCatalogProjector({
-            cfg: persistedConfig,
-            agentId: "work",
-            snapshot: catalogSnapshot,
-            metadataSnapshot: pluginMetadataSnapshot,
-            preparedAuthStore: requirePreparedAuthStore("work"),
-            preferredProfileId: "openai:expired",
-          }).evaluateEntry(subscriptionRoute, catalogSnapshot.routeVariants);
-          expect(expiredPreferenceEvaluation).toMatchObject({
-            availability: true,
-            selectedProfileId: "openai:api",
-            selectedRoute: { authRequirement: "api-key" },
-          });
-          // Main only has subscription auth; work's neutral default selects API auth.
-          // Keep the Off-only default control separate from work's locked session profile.
-          await callDirectChat("chat.startup", {
-            id: "startup-main-neutral-route",
-            params: { sessionKey: "agent:main:main" },
-            respond: captureChatResponse(responses),
-            context,
-          });
-          expect(responses).toHaveLength(1);
-          expect(responses[0]?.ok, JSON.stringify(responses[0]?.error)).toBe(true);
-          const mainPayload = responses[0]?.payload as {
-            defaults?: GatewaySessionsDefaults;
-            sessionInfo?: { thinkingLevels?: Array<{ id: string }> };
-          };
-          expect(mainPayload.defaults).toMatchObject({ modelProvider: "openai", model: "gpt-5.5" });
-          expect(mainPayload.defaults?.thinkingLevels?.map((level) => level.id)).toEqual(["off"]);
-          expect(mainPayload.sessionInfo?.thinkingLevels?.map((level) => level.id)).toEqual([
-            "off",
-          ]);
-          responses.length = 0;
-          await callDirectChat("chat.startup", {
-            id: "startup-dual-route-catalog",
-            params: { sessionKey: "agent:work:main" },
-            respond: captureChatResponse(responses),
-            context,
-          });
-
-          expect(context.loadGatewayModelCatalogSnapshot).not.toHaveBeenCalled();
-          expect(responses).toHaveLength(1);
-          expect(responses[0]?.ok).toBe(true);
-          const payload = responses[0]?.payload as
-            | {
-                metadata?: { models?: unknown[] };
-                sessionInfo?: { thinkingLevels?: Array<{ id?: string }> };
-                defaults?: { thinkingLevels?: Array<{ id?: string }> };
-              }
-            | undefined;
-          expect(payload?.metadata?.models).toEqual([
-            expect.objectContaining({
-              id: "gpt-5.5",
-              name: "GPT-5.5",
-              provider: "openai",
-              agentRuntime: {
-                id: "codex",
-                cloudPlacementSupported: false,
-                devicePlacementSupported: false,
-                source: "implicit",
-              },
-              contextWindow: 400_000,
-              reasoning: false,
-              available: true,
-            }),
-          ]);
-          expect(payload?.sessionInfo?.thinkingLevels?.map((level) => level.id)).toEqual(["off"]);
-          expect(payload?.defaults?.thinkingLevels?.map((level) => level.id)).toEqual([
-            "off",
-            "minimal",
-            "low",
-            "medium",
-            "high",
-            "xhigh",
-          ]);
-          const serialized = JSON.stringify(responses[0]?.payload);
-          expect(serialized).not.toContain("private-route-token");
-          expect(serialized).not.toContain("platform-api-key");
-          expect(serialized).not.toContain("chatgpt-access");
-          expect(serialized).not.toContain("supportedReasoningEfforts");
-          expect(serialized).not.toContain(platformRoute.baseUrl);
-          expect(serialized).not.toContain(subscriptionRoute.baseUrl);
-
-          for (const [index, [sessionKey, sessionId, expectedRoute]] of [
-            ["agent:work:auto-preferred", "sess-work-auto-preferred", "subscription"],
-            ["agent:work:auto", "sess-work-auto", "platform"],
-            ["agent:work:legacy-auto", "sess-work-legacy-auto", "platform"],
-          ].entries()) {
-            await writeMainSessionTranscript(
-              [
-                createTextTranscriptEvent("user", "route reasoning", {
-                  id: "route-message",
-                  parentId: null,
-                }),
-              ],
-              sessionId,
-              { agentId: "work", sessionKey },
-            );
-            responses.length = 0;
-            await callDirectChat("chat.startup", {
-              id: `startup-preferred-route-${index}`,
-              params: { sessionKey },
-              respond: ((ok, responsePayload, error) => {
-                responses.push({ ok, payload: responsePayload, error });
-              }) as RespondFn,
-              context,
-            });
-
-            expect(responses).toHaveLength(1);
-            expect(responses[0]?.ok).toBe(true);
-            const preferredPayload = responses[0]?.payload as
-              | {
-                  metadata?: { models?: Array<{ contextWindow?: number }> };
-                  defaults?: GatewaySessionsDefaults;
-                  sessionInfo?: {
-                    agentRuntime?: unknown;
-                    thinkingLevel?: string;
-                    thinkingDefault?: string;
-                    thinkingLevels?: Array<{ id?: string }>;
-                    thinkingOptions?: string[];
-                  };
+              const subscriptionRoute = {
+                ...platformRoute,
+                api: "openai-chatgpt-responses" as const,
+                baseUrl: "https://chatgpt.com/backend-api/codex",
+                contextWindow: 400_000,
+                reasoning: false,
+                compat: { supportedReasoningEfforts: ["low"] },
+                params: { apiKey: "private-route-token" },
+              };
+              const catalogSnapshot = {
+                entries: [subscriptionRoute],
+                routeVariants: [subscriptionRoute, platformRoute],
+              };
+              const { loadAuthProfileStoreForRuntime } = await import("../agents/auth-profiles.js");
+              const { resolveAgentDir } = await import("../agents/agent-scope.js");
+              const preparedAuthStoreByAgentId = new Map([
+                [
+                  "main",
+                  loadAuthProfileStoreForRuntime(resolveAgentDir(persistedConfig, "main"), {
+                    readOnly: true,
+                  }),
+                ],
+                [
+                  "work",
+                  loadAuthProfileStoreForRuntime(resolveAgentDir(persistedConfig, "work"), {
+                    inheritedAuthDir: resolveAgentDir(persistedConfig, "main"),
+                    readOnly: true,
+                  }),
+                ],
+              ]);
+              const requirePreparedAuthStore = (agentId: string) => {
+                const authStore = preparedAuthStoreByAgentId.get(agentId);
+                if (!authStore) {
+                  throw new Error(`expected prepared auth store for agent "${agentId}"`);
                 }
-              | undefined;
-            expect(preferredPayload?.metadata?.models?.[0]?.contextWindow, sessionKey).toBe(
-              expectedRoute === "subscription" ? 400_000 : 1_000_000,
-            );
-            const thinkingLevels = preferredPayload?.sessionInfo?.thinkingLevels?.map(
-              (level) => level.id,
-            );
-            if (expectedRoute === "subscription") {
-              expect(thinkingLevels, sessionKey).toEqual(["off"]);
-            } else {
-              expect(thinkingLevels, sessionKey).toContain("high");
-            }
-            expect(preferredPayload?.sessionInfo?.thinkingLevel ?? null).toBeNull();
-            let cursor: string | undefined;
-            for (const mode of ["page", "delta"] as const) {
-              responses.length = 0;
-              await callDirectChat("chat.history", {
-                id: `history-preferred-route-${index}-${mode}`,
-                params: { sessionKey, ...(mode === "delta" ? { cursor } : {}) },
+                return authStore;
+              };
+              const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
+              const { buildModelsListResult, createGatewayAgentModelCatalogProjector } =
+                await import("./server-methods/models-list-result.js");
+              const projectionByKey = new Map<
+                string,
+                Promise<{
+                  modelCatalog: ModelCatalogEntry[];
+                  metadata: { models: unknown[]; swarmEnabled: boolean };
+                }>
+              >();
+              const projectAgent = (
+                context: GatewayRequestContext,
+                agentId: string,
+                sessionEntry?: Parameters<
+                  GatewayRequestContext["readChatMetadata"]
+                >[0]["sessionEntry"],
+              ) => {
+                const profileId = sessionEntry?.authProfileOverride?.trim();
+                const profileSource = sessionEntry?.authProfileOverrideSource;
+                const legacyUserProfile =
+                  profileSource === undefined &&
+                  sessionEntry?.authProfileOverrideCompactionCount === undefined;
+                const key = [
+                  agentId,
+                  profileId ?? "",
+                  profileId && (profileSource === "user" || legacyUserProfile) ? profileId : "",
+                ].join("\0");
+                const existing = projectionByKey.get(key);
+                if (existing) {
+                  return existing;
+                }
+                const projector = createGatewayAgentModelCatalogProjector({
+                  cfg: persistedConfig,
+                  agentId,
+                  snapshot: catalogSnapshot,
+                  metadataSnapshot: pluginMetadataSnapshot,
+                  preparedAuthStore: requirePreparedAuthStore(agentId),
+                  ...(profileId ? { preferredProfileId: profileId } : {}),
+                  ...(profileId && (profileSource === "user" || legacyUserProfile)
+                    ? { pinnedProfileId: profileId }
+                    : {}),
+                });
+                const projection = Promise.all([
+                  projector.projectCatalog(),
+                  buildModelsListResult({
+                    context,
+                    agentId,
+                    params: { view: "configured" },
+                    preloadedCatalog: {
+                      agentId,
+                      config: persistedConfig,
+                      snapshot: catalogSnapshot,
+                    },
+                    preloadedOnly: true,
+                    catalogProjector: projector,
+                  }),
+                ]).then(([modelCatalog, metadata]) => ({
+                  modelCatalog,
+                  metadata: { ...metadata, swarmEnabled: false },
+                }));
+                projectionByKey.set(key, projection);
+                return projection;
+              };
+              const context = createDirectChatContext({
+                loadGatewayModelCatalogSnapshot: vi
+                  .fn<GatewayRequestContext["loadGatewayModelCatalogSnapshot"]>()
+                  .mockResolvedValue({
+                    agentId: "work",
+                    agentDir: "/tmp/chat-work-agent",
+                    catalogComplete: false,
+                    workspaceDir: "/tmp/chat-work-workspace",
+                    config: persistedConfig,
+                    ...catalogSnapshot,
+                  }),
+                getRuntimeConfig: () => persistedConfig,
+                readChatStartupProjection: vi.fn(async ({ agentId, sessionEntry }) => {
+                  const [neutralProjection, sessionProjection] = await Promise.all([
+                    projectAgent(context, agentId),
+                    projectAgent(context, agentId, sessionEntry),
+                  ]);
+                  preparedThinkingPolicy.fallback = sessionProjection.modelCatalog.some(
+                    (entry) => entry.reasoning === true,
+                  )
+                    ? "base"
+                    : "off";
+                  return {
+                    metadata: sessionProjection.metadata,
+                    sessionModelCatalog: sessionProjection.modelCatalog,
+                    defaultModelCatalog: neutralProjection.modelCatalog,
+                  };
+                }),
+              });
+              const expiredPreferenceEvaluation = await createGatewayAgentModelCatalogProjector({
+                cfg: persistedConfig,
+                agentId: "work",
+                snapshot: catalogSnapshot,
+                metadataSnapshot: pluginMetadataSnapshot,
+                preparedAuthStore: requirePreparedAuthStore("work"),
+                preferredProfileId: "openai:expired",
+              }).evaluateEntry(subscriptionRoute, catalogSnapshot.routeVariants);
+              expect(expiredPreferenceEvaluation).toMatchObject({
+                availability: true,
+                selectedProfileId: "openai:api",
+                selectedRoute: { authRequirement: "api-key" },
+              });
+              // Main only has subscription auth; work's neutral default selects API auth.
+              // Keep the Off-only default control separate from work's locked session profile.
+              await callDirectChat("chat.startup", {
+                id: "startup-main-neutral-route",
+                params: { sessionKey: "agent:main:main" },
                 respond: captureChatResponse(responses),
                 context,
               });
               expect(responses).toHaveLength(1);
               expect(responses[0]?.ok, JSON.stringify(responses[0]?.error)).toBe(true);
-              const history = responses[0]?.payload as {
-                kind?: string;
-                deltaCursor?: string;
-                thinkingLevel?: string;
+              const mainPayload = responses[0]?.payload as {
                 defaults?: GatewaySessionsDefaults;
-                sessionInfo?: NonNullable<typeof preferredPayload>["sessionInfo"];
+                sessionInfo?: { thinkingLevels?: Array<{ id: string }> };
               };
-              const label = `${sessionKey} ${mode}`;
-              if (mode === "delta") {
-                expect(history.kind, label).toBe("delta");
-              } else {
-                expect(history.deltaCursor, label).toEqual(expect.any(String));
-                cursor = history.deltaCursor;
-                expect(history.defaults, `${label} neutral defaults`).toEqual(
-                  preferredPayload?.defaults,
+              expect(mainPayload.defaults).toMatchObject({
+                modelProvider: "openai",
+                model: "gpt-5.5",
+              });
+              expect(mainPayload.defaults?.thinkingLevels?.map((level) => level.id)).toEqual([
+                "off",
+              ]);
+              expect(mainPayload.sessionInfo?.thinkingLevels?.map((level) => level.id)).toEqual([
+                "off",
+              ]);
+              responses.length = 0;
+              await callDirectChat("chat.startup", {
+                id: "startup-dual-route-catalog",
+                params: { sessionKey: "agent:work:main" },
+                respond: captureChatResponse(responses),
+                context,
+              });
+
+              expect(context.loadGatewayModelCatalogSnapshot).not.toHaveBeenCalled();
+              expect(responses).toHaveLength(1);
+              expect(responses[0]?.ok).toBe(true);
+              const payload = responses[0]?.payload as
+                | {
+                    metadata?: { models?: unknown[] };
+                    sessionInfo?: { thinkingLevels?: Array<{ id?: string }> };
+                    defaults?: { thinkingLevels?: Array<{ id?: string }> };
+                  }
+                | undefined;
+              expect(payload?.metadata?.models).toEqual([
+                expect.objectContaining({
+                  id: "gpt-5.5",
+                  name: "GPT-5.5",
+                  provider: "openai",
+                  agentRuntime: {
+                    id: "codex",
+                    cloudPlacementSupported: false,
+                    devicePlacementSupported: false,
+                    source: "implicit",
+                  },
+                  contextWindow: 400_000,
+                  reasoning: false,
+                  available: true,
+                }),
+              ]);
+              expect(payload?.sessionInfo?.thinkingLevels?.map((level) => level.id)).toEqual([
+                "off",
+              ]);
+              expect(payload?.defaults?.thinkingLevels?.map((level) => level.id)).toEqual([
+                "off",
+                "minimal",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+              ]);
+              const serialized = JSON.stringify(responses[0]?.payload);
+              expect(serialized).not.toContain("private-route-token");
+              expect(serialized).not.toContain("platform-api-key");
+              expect(serialized).not.toContain("chatgpt-access");
+              expect(serialized).not.toContain("supportedReasoningEfforts");
+              expect(serialized).not.toContain(platformRoute.baseUrl);
+              expect(serialized).not.toContain(subscriptionRoute.baseUrl);
+
+              for (const [index, [sessionKey, sessionId, expectedRoute]] of [
+                ["agent:work:auto-preferred", "sess-work-auto-preferred", "subscription"],
+                ["agent:work:auto", "sess-work-auto", "platform"],
+                ["agent:work:legacy-auto", "sess-work-legacy-auto", "platform"],
+              ].entries()) {
+                await writeMainSessionTranscript(
+                  [
+                    createTextTranscriptEvent("user", "route reasoning", {
+                      id: "route-message",
+                      parentId: null,
+                    }),
+                  ],
+                  sessionId,
+                  { agentId: "work", sessionKey },
                 );
-                expect
-                  .soft(history.thinkingLevel, `${label} effective thinking`)
-                  .toBe(preferredPayload?.sessionInfo?.thinkingDefault);
+                responses.length = 0;
+                await callDirectChat("chat.startup", {
+                  id: `startup-preferred-route-${index}`,
+                  params: { sessionKey },
+                  respond: ((ok, responsePayload, error) => {
+                    responses.push({ ok, payload: responsePayload, error });
+                  }) as RespondFn,
+                  context,
+                });
+
+                expect(responses).toHaveLength(1);
+                expect(responses[0]?.ok).toBe(true);
+                const preferredPayload = responses[0]?.payload as
+                  | {
+                      metadata?: { models?: Array<{ contextWindow?: number }> };
+                      defaults?: GatewaySessionsDefaults;
+                      sessionInfo?: {
+                        agentRuntime?: unknown;
+                        thinkingLevel?: string;
+                        thinkingDefault?: string;
+                        thinkingLevels?: Array<{ id?: string }>;
+                        thinkingOptions?: string[];
+                      };
+                    }
+                  | undefined;
+                expect(preferredPayload?.metadata?.models?.[0]?.contextWindow, sessionKey).toBe(
+                  expectedRoute === "subscription" ? 400_000 : 1_000_000,
+                );
+                const thinkingLevels = preferredPayload?.sessionInfo?.thinkingLevels?.map(
+                  (level) => level.id,
+                );
+                if (expectedRoute === "subscription") {
+                  expect(thinkingLevels, sessionKey).toEqual(["off"]);
+                } else {
+                  expect(thinkingLevels, sessionKey).toContain("high");
+                }
+                expect(preferredPayload?.sessionInfo?.thinkingLevel ?? null).toBeNull();
+                let cursor: string | undefined;
+                for (const mode of ["page", "delta"] as const) {
+                  responses.length = 0;
+                  await callDirectChat("chat.history", {
+                    id: `history-preferred-route-${index}-${mode}`,
+                    params: { sessionKey, ...(mode === "delta" ? { cursor } : {}) },
+                    respond: captureChatResponse(responses),
+                    context,
+                  });
+                  expect(responses).toHaveLength(1);
+                  expect(responses[0]?.ok, JSON.stringify(responses[0]?.error)).toBe(true);
+                  const history = responses[0]?.payload as {
+                    kind?: string;
+                    deltaCursor?: string;
+                    thinkingLevel?: string;
+                    defaults?: GatewaySessionsDefaults;
+                    sessionInfo?: NonNullable<typeof preferredPayload>["sessionInfo"];
+                  };
+                  const label = `${sessionKey} ${mode}`;
+                  if (mode === "delta") {
+                    expect(history.kind, label).toBe("delta");
+                  } else {
+                    expect(history.deltaCursor, label).toEqual(expect.any(String));
+                    cursor = history.deltaCursor;
+                    expect(history.defaults, `${label} neutral defaults`).toEqual(
+                      preferredPayload?.defaults,
+                    );
+                    expect
+                      .soft(history.thinkingLevel, `${label} effective thinking`)
+                      .toBe(preferredPayload?.sessionInfo?.thinkingDefault);
+                  }
+                  expect(
+                    history.sessionInfo?.thinkingLevel ?? null,
+                    `${label} override`,
+                  ).toBeNull();
+                  expect(history.sessionInfo?.agentRuntime, `${label} runtime`).toEqual(
+                    preferredPayload?.sessionInfo?.agentRuntime,
+                  );
+                  expect
+                    .soft(history.sessionInfo?.thinkingDefault, `${label} default`)
+                    .toBe(preferredPayload?.sessionInfo?.thinkingDefault);
+                  expect
+                    .soft(history.sessionInfo?.thinkingLevels, `${label} supported levels`)
+                    .toEqual(preferredPayload?.sessionInfo?.thinkingLevels);
+                  expect
+                    .soft(history.sessionInfo?.thinkingOptions, `${label} supported options`)
+                    .toEqual(preferredPayload?.sessionInfo?.thinkingOptions);
+                }
               }
-              expect(history.sessionInfo?.thinkingLevel ?? null, `${label} override`).toBeNull();
-              expect(history.sessionInfo?.agentRuntime, `${label} runtime`).toEqual(
-                preferredPayload?.sessionInfo?.agentRuntime,
-              );
-              expect
-                .soft(history.sessionInfo?.thinkingDefault, `${label} default`)
-                .toBe(preferredPayload?.sessionInfo?.thinkingDefault);
-              expect
-                .soft(history.sessionInfo?.thinkingLevels, `${label} supported levels`)
-                .toEqual(preferredPayload?.sessionInfo?.thinkingLevels);
-              expect
-                .soft(history.sessionInfo?.thinkingOptions, `${label} supported options`)
-                .toEqual(preferredPayload?.sessionInfo?.thinkingOptions);
-            }
-          }
+            },
+            { config, compatibleConfigs: [config], env: process.env },
+          );
         } finally {
           preparedThinkingPolicy.fallback = "off";
           testState.agentConfig = previousAgentConfig;
           testState.agentsConfig = previousAgentsConfig;
           testState.sessionStorePath = undefined;
-          releasePluginMetadata();
         }
       },
     );

--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -10,9 +10,7 @@ import { describe, expect, it, vi } from "vitest";
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import {
   getCurrentPluginMetadataSnapshot,
-  installTemporaryCurrentPluginMetadataSnapshot,
   isCurrentPluginMetadataSnapshotRuntimeGeneration,
-  setGatewayPluginMetadataSnapshot,
   withPluginMetadataSnapshotScope,
 } from "./current-plugin-metadata-snapshot.js";
 import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
@@ -549,13 +547,6 @@ describe("current plugin metadata snapshot", () => {
         }),
       ).toBeUndefined();
       expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("raw");
-
-      const lease = installTemporaryCurrentPluginMetadataSnapshot(
-        createSnapshot({ normalizationAlias: "temporary" }),
-      );
-      expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("temporary");
-      expect(lease.release()).toBe(true);
-      expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("raw");
     } finally {
       clearCurrentPluginMetadataSnapshot();
     }
@@ -838,115 +829,7 @@ describe("current plugin metadata snapshot", () => {
     expect(getCurrentPluginMetadataSnapshot()).toBe(derived);
   });
 
-  it("restores the previous current snapshot after a temporary lease", () => {
-    const firstConfig = { plugins: { allow: ["first"] } };
-    const secondConfig = {
-      plugins: { allow: ["second"], load: { paths: ["/plugins/temporary"] } },
-    };
-    const first = createSnapshot({ config: firstConfig });
-    const second = createSnapshot({ config: secondConfig });
-    setCurrentPluginMetadataSnapshot(first, { config: firstConfig });
-
-    const lease = installTemporaryCurrentPluginMetadataSnapshot(second, {
-      config: secondConfig,
-    });
-    expect(getCurrentPluginMetadataSnapshot({ config: secondConfig })).toBe(second);
-    expect(
-      getCurrentPluginMetadataSnapshot({ requireDefaultDiscoveryContext: true }),
-    ).toBeUndefined();
-    expect(lease.release()).toBe(true);
-
-    expect(getCurrentPluginMetadataSnapshot({ config: firstConfig })).toBe(first);
-    expect(getCurrentPluginMetadataSnapshot({ requireDefaultDiscoveryContext: true })).toBe(first);
-    expect(getCurrentPluginMetadataSnapshot({ config: secondConfig })).toBeUndefined();
-  });
-
-  it("restores exact config identity and environment across a temporary metadata snapshot", () => {
-    const config = { plugins: { load: { paths: ["~/plugins"] } } };
-    const snapshot = createSnapshot({ config });
-    const originalEnv = {
-      HOME: "/home/original-snapshot",
-      OPENCLAW_HOME: undefined,
-    } as NodeJS.ProcessEnv;
-    const changedEnv = {
-      HOME: "/home/changed-snapshot",
-      OPENCLAW_HOME: undefined,
-    } as NodeJS.ProcessEnv;
-    setCurrentPluginMetadataSnapshot(snapshot, { config, env: originalEnv });
-
-    const lease = installTemporaryCurrentPluginMetadataSnapshot(createSnapshot());
-    expect(lease.release()).toBe(true);
-
-    expect(getCurrentPluginMetadataSnapshot({ config, env: originalEnv })).toBe(snapshot);
-    expect(getCurrentPluginMetadataSnapshot({ config, env: changedEnv })).toBeUndefined();
-  });
-
-  it("restores exact config identity after in-place changes", () => {
-    const config = { plugins: { allow: ["first"] } };
-    const snapshot = createSnapshot({ config });
-    setCurrentPluginMetadataSnapshot(snapshot, { config });
-
-    const lease = installTemporaryCurrentPluginMetadataSnapshot(createSnapshot());
-    expect(lease.release()).toBe(true);
-    config.plugins.allow = ["changed"];
-
-    expect(getCurrentPluginMetadataSnapshot({ config })).toBe(snapshot);
-  });
-
-  it("restores a temporary lease while its publication is current", () => {
-    const firstConfig = { plugins: { allow: ["first"] } };
-    const temporaryConfig = { plugins: { allow: ["temporary"] } };
-    const first = createSnapshot({ config: firstConfig });
-    const temporary = createSnapshot({ config: temporaryConfig });
-    setCurrentPluginMetadataSnapshot(first, { config: firstConfig });
-
-    const lease = installTemporaryCurrentPluginMetadataSnapshot(temporary, {
-      config: temporaryConfig,
-    });
-
-    expect(lease.release()).toBe(true);
-    expect(getCurrentPluginMetadataSnapshot({ config: firstConfig })).toBe(first);
-    expect(lease.release()).toBe(false);
-  });
-
-  it("does not release a temporary lease over a newer publication or lifecycle clear", () => {
-    const original = createSnapshot({ normalizationAlias: "original" });
-    const temporary = createSnapshot({ normalizationAlias: "temporary" });
-    const newer = createSnapshot({ normalizationAlias: "newer" });
-    setCurrentPluginMetadataSnapshot(original);
-
-    const clearedLease = installTemporaryCurrentPluginMetadataSnapshot(temporary);
-    clearCurrentPluginMetadataSnapshot();
-    expect(clearedLease.release()).toBe(false);
-    expect(getCurrentPluginMetadataSnapshot()).toBeUndefined();
-    expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("raw");
-
-    const replacedLease = installTemporaryCurrentPluginMetadataSnapshot(temporary);
-    setGatewayPluginMetadataSnapshot(newer);
-    expect(replacedLease.release()).toBe(false);
-    expect(getCurrentPluginMetadataSnapshot()).toBe(newer);
-    expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("newer");
-  });
-
-  it("unwinds nested temporary leases when they release out of order", () => {
-    const original = createSnapshot({ normalizationAlias: "original" });
-    const outerSnapshot = createSnapshot({ normalizationAlias: "outer" });
-    const innerSnapshot = createSnapshot({ normalizationAlias: "inner" });
-    setCurrentPluginMetadataSnapshot(original);
-
-    const outer = installTemporaryCurrentPluginMetadataSnapshot(outerSnapshot);
-    const inner = installTemporaryCurrentPluginMetadataSnapshot(innerSnapshot);
-
-    expect(outer.release()).toBe(false);
-    expect(getCurrentPluginMetadataSnapshot()).toBe(innerSnapshot);
-    expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("inner");
-    expect(inner.release()).toBe(true);
-    expect(getCurrentPluginMetadataSnapshot()).toBe(original);
-    expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("original");
-    expect(inner.release()).toBe(false);
-  });
-
-  it("publishes and restores prepared model policies without enumerating declarations", () => {
+  it("publishes prepared model policies without enumerating declarations", () => {
     const enumerate = vi.fn((target: object) => Reflect.ownKeys(target));
     const prepare = (alias: string) =>
       restorePluginMetadataSnapshot(
@@ -965,7 +848,7 @@ describe("current plugin metadata snapshot", () => {
         }),
       );
     const original = prepare("original");
-    const temporary = prepare("temporary");
+    const replacement = prepare("replacement");
     const empty = restorePluginMetadataSnapshot(createPluginMetadataSnapshotFixture());
     const env = {
       HOME: "/home/original-snapshot",
@@ -977,16 +860,11 @@ describe("current plugin metadata snapshot", () => {
       setCurrentPluginMetadataSnapshot(original, { env });
       expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("original");
 
-      const lease = installTemporaryCurrentPluginMetadataSnapshot(temporary);
-      expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("temporary");
+      setCurrentPluginMetadataSnapshot(replacement);
+      expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("replacement");
 
-      const emptyLease = installTemporaryCurrentPluginMetadataSnapshot(empty);
+      setCurrentPluginMetadataSnapshot(empty);
       expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("raw");
-      expect(emptyLease.release()).toBe(true);
-      expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("temporary");
-
-      expect(lease.release()).toBe(true);
-      expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("original");
       clearCurrentPluginMetadataSnapshot();
       expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("raw");
       expect(enumerate).not.toHaveBeenCalled();

--- a/src/plugins/current-plugin-metadata-snapshot.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.ts
@@ -7,7 +7,6 @@ import {
   getGatewayPluginMetadataSnapshot,
   getCurrentPluginMetadataSnapshotState,
   setCurrentPluginMetadataSnapshotState,
-  type CurrentPluginMetadataSnapshotRevision,
 } from "./current-plugin-metadata-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import {
@@ -29,12 +28,6 @@ import type {
 } from "./plugin-metadata-snapshot.types.js";
 import { normalizePluginIdScope, serializePluginIdScope } from "./plugin-scope.js";
 
-type CurrentPluginMetadataSnapshotState = ReturnType<
-  typeof getCurrentPluginMetadataSnapshotState
-> & {
-  configIdentities: WeakSet<OpenClawConfig>;
-};
-
 type CurrentPluginMetadataSnapshotOptions = {
   config?: OpenClawConfig;
   compatibleConfigs?: readonly OpenClawConfig[];
@@ -42,17 +35,6 @@ type CurrentPluginMetadataSnapshotOptions = {
   /** Only immutable runtime generations may trust identity across policy drift. */
   trustConfigIdentity?: boolean;
   workspaceDir?: string;
-};
-
-type TemporaryPluginMetadataSnapshotLeaseState = {
-  parent: TemporaryPluginMetadataSnapshotLeaseState | undefined;
-  previousState: CurrentPluginMetadataSnapshotState;
-  revision: CurrentPluginMetadataSnapshotRevision;
-  released: boolean;
-};
-
-type TemporaryPluginMetadataSnapshotLease = {
-  release: () => boolean;
 };
 
 type CurrentPluginMetadataSnapshotParams = {
@@ -89,10 +71,6 @@ export type PluginMetadataSnapshotScopeRunner = <T>(
   run: () => T,
 ) => T;
 
-let activeTemporaryPluginMetadataSnapshotLease:
-  | TemporaryPluginMetadataSnapshotLeaseState
-  | undefined;
-
 const SCOPED_PLUGIN_METADATA_SNAPSHOT_KEY = Symbol.for("openclaw.scopedPluginMetadataSnapshot");
 const scopedPluginMetadataSnapshot = resolveGlobalSingleton<
   AsyncLocalStorage<ScopedPluginMetadataSnapshot>
@@ -112,7 +90,7 @@ function publishCurrentPluginMetadataSnapshot(
   snapshot: PluginMetadataSnapshot,
   options: CurrentPluginMetadataSnapshotOptions,
   owner: "gateway" | "operation" = "operation",
-): CurrentPluginMetadataSnapshotRevision {
+): void {
   if (getCurrentPluginMetadataSnapshotState().owner === "gateway") {
     throw new Error("Gateway plugin metadata can only be replaced after shutdown");
   }
@@ -136,7 +114,7 @@ function publishCurrentPluginMetadataSnapshot(
     configFingerprint === defaultDiscoveryConfigFingerprint ||
     snapshot.configFingerprint === defaultDiscoveryConfigFingerprint ||
     Boolean(compatibleConfigFingerprints?.includes(defaultDiscoveryConfigFingerprint));
-  const revision = setCurrentPluginMetadataSnapshotState(
+  setCurrentPluginMetadataSnapshotState(
     snapshot,
     configFingerprint,
     compatiblePolicyHashes,
@@ -160,7 +138,6 @@ function publishCurrentPluginMetadataSnapshot(
   for (const config of options.compatibleConfigs ?? []) {
     currentPluginMetadataConfigIdentityCache.add(config);
   }
-  return revision;
 }
 
 /** Publishes package facts once; config reload only replaces their runtime bindings. */
@@ -178,7 +155,6 @@ export function setGatewayPluginMetadataSnapshot(
     throw new Error("Gateway plugin metadata can only be replaced after shutdown");
   }
   adoptProcessPluginCache(getPluginMetadataSnapshotCache(snapshot));
-  activeTemporaryPluginMetadataSnapshotLease = undefined;
   publishCurrentPluginMetadataSnapshot(snapshot, options, "gateway");
 }
 
@@ -193,7 +169,6 @@ export function adoptCurrentPluginMetadataSnapshotIfAbsent(
   ) {
     return;
   }
-  activeTemporaryPluginMetadataSnapshotLease = undefined;
   publishCurrentPluginMetadataSnapshot(snapshot, options);
 }
 
@@ -204,88 +179,6 @@ function isScopedSnapshotInCurrentCache(scoped: ScopedPluginMetadataSnapshot): b
     !scoped.snapshot ||
     getPluginMetadataSnapshotCache(scoped.snapshot) === cache
   );
-}
-
-function captureCurrentPluginMetadataSnapshotState(): CurrentPluginMetadataSnapshotState {
-  return {
-    ...getCurrentPluginMetadataSnapshotState(),
-    configIdentities: currentPluginMetadataConfigIdentityCache.capture(),
-  };
-}
-
-function restoreCapturedCurrentPluginMetadataSnapshotState(
-  state: CurrentPluginMetadataSnapshotState,
-): CurrentPluginMetadataSnapshotRevision {
-  currentPluginMetadataConfigIdentityCache.restore(state.configIdentities);
-  return setCurrentPluginMetadataSnapshotState(
-    state.snapshot,
-    state.configFingerprint,
-    state.compatiblePolicyHashes,
-    state.compatibleConfigFingerprints,
-    state.modelIdNormalizationPolicies,
-    state.owner,
-    state.envFingerprint,
-    state.defaultDiscoveryCompatible,
-  );
-}
-
-function resolveTemporaryPluginMetadataSnapshotLeaseParent():
-  | TemporaryPluginMetadataSnapshotLeaseState
-  | undefined {
-  const active = activeTemporaryPluginMetadataSnapshotLease;
-  if (active && getCurrentPluginMetadataSnapshotState().revision !== active.revision) {
-    activeTemporaryPluginMetadataSnapshotLease = undefined;
-    return undefined;
-  }
-  return active;
-}
-
-function releaseTemporaryPluginMetadataSnapshotLease(
-  lease: TemporaryPluginMetadataSnapshotLeaseState,
-): boolean {
-  if (lease.released) {
-    return false;
-  }
-  lease.released = true;
-  if (activeTemporaryPluginMetadataSnapshotLease !== lease) {
-    return false;
-  }
-
-  let restored = false;
-  while (activeTemporaryPluginMetadataSnapshotLease?.released) {
-    const current: TemporaryPluginMetadataSnapshotLeaseState =
-      activeTemporaryPluginMetadataSnapshotLease;
-    if (getCurrentPluginMetadataSnapshotState().revision !== current.revision) {
-      activeTemporaryPluginMetadataSnapshotLease = undefined;
-      return restored;
-    }
-    const restoredRevision = restoreCapturedCurrentPluginMetadataSnapshotState(
-      current.previousState,
-    );
-    activeTemporaryPluginMetadataSnapshotLease = current.parent;
-    if (activeTemporaryPluginMetadataSnapshotLease) {
-      activeTemporaryPluginMetadataSnapshotLease.revision = restoredRevision;
-    }
-    restored = true;
-  }
-  return restored;
-}
-
-/** Temporarily publishes metadata without restoring over lifecycle-owned replacements. */
-export function installTemporaryCurrentPluginMetadataSnapshot(
-  snapshot: PluginMetadataSnapshot,
-  options: CurrentPluginMetadataSnapshotOptions = {},
-): TemporaryPluginMetadataSnapshotLease {
-  const lease: TemporaryPluginMetadataSnapshotLeaseState = {
-    parent: resolveTemporaryPluginMetadataSnapshotLeaseParent(),
-    previousState: captureCurrentPluginMetadataSnapshotState(),
-    revision: publishCurrentPluginMetadataSnapshot(snapshot, options),
-    released: false,
-  };
-  activeTemporaryPluginMetadataSnapshotLease = lease;
-  return {
-    release: () => releaseTemporaryPluginMetadataSnapshotLease(lease),
-  };
 }
 
 /** Carries one owner-prepared metadata generation through nested async plugin lookups. */

--- a/src/plugins/current-plugin-metadata-state.ts
+++ b/src/plugins/current-plugin-metadata-state.ts
@@ -4,24 +4,16 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getPluginCache, getProcessPluginCache } from "./plugin-cache.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 
-export type CurrentPluginMetadataSnapshotRevision = symbol;
-
 /** Owns config identity reuse for the current immutable metadata snapshot. */
 export const currentPluginMetadataConfigIdentityCache = {
   add(config: OpenClawConfig): void {
     getProcessPluginCache().metadata.current.configIdentities.add(config);
-  },
-  capture(): WeakSet<OpenClawConfig> {
-    return getProcessPluginCache().metadata.current.configIdentities;
   },
   clear(): void {
     getProcessPluginCache().metadata.current.configIdentities = new WeakSet();
   },
   has(config: OpenClawConfig): boolean {
     return getProcessPluginCache().metadata.current.configIdentities.has(config);
-  },
-  restore(identities: WeakSet<OpenClawConfig>): void {
-    getProcessPluginCache().metadata.current.configIdentities = identities;
   },
 };
 
@@ -35,7 +27,7 @@ export function setCurrentPluginMetadataSnapshotState(
   owner: "gateway" | "operation" = "operation",
   envFingerprint?: string,
   defaultDiscoveryCompatible = false,
-): CurrentPluginMetadataSnapshotRevision {
+): void {
   const state = getProcessPluginCache().metadata.current;
   state.snapshot = snapshot;
   state.owner = owner;
@@ -44,10 +36,10 @@ export function setCurrentPluginMetadataSnapshotState(
   state.defaultDiscoveryCompatible = Boolean(snapshot && defaultDiscoveryCompatible);
   state.compatiblePolicyHashes = snapshot ? compatiblePolicyHashes : undefined;
   state.compatibleConfigFingerprints = snapshot ? compatibleConfigFingerprints : undefined;
-  state.modelIdNormalizationPolicies = snapshot ? modelIdNormalizationPolicies : undefined;
-  setCurrentManifestModelIdNormalizationPolicies(state.modelIdNormalizationPolicies);
+  setCurrentManifestModelIdNormalizationPolicies(
+    snapshot ? modelIdNormalizationPolicies : undefined,
+  );
   state.revision = Symbol("plugin-metadata-snapshot");
-  return state.revision;
 }
 
 /** Clears the snapshot, its identity cache, and process-wide model normalization. */
@@ -92,7 +84,6 @@ export function getCurrentPluginMetadataSnapshotState() {
     defaultDiscoveryCompatible: state.defaultDiscoveryCompatible,
     compatiblePolicyHashes: state.compatiblePolicyHashes,
     compatibleConfigFingerprints: state.compatibleConfigFingerprints,
-    modelIdNormalizationPolicies: state.modelIdNormalizationPolicies,
     revision: state.revision,
   };
 }

--- a/src/plugins/plugin-cache-metadata.ts
+++ b/src/plugins/plugin-cache-metadata.ts
@@ -16,9 +16,6 @@ type CurrentPluginMetadataCacheState = {
   defaultDiscoveryCompatible: boolean;
   compatiblePolicyHashes: readonly string[] | undefined;
   compatibleConfigFingerprints: readonly string[] | undefined;
-  modelIdNormalizationPolicies:
-    | PluginMetadataSnapshot["owners"]["modelIdNormalizationPolicies"]
-    | undefined;
   revision: symbol;
   configIdentities: WeakSet<OpenClawConfig>;
 };
@@ -59,7 +56,6 @@ export function createPluginCacheMetadata(): PluginCacheMetadata {
         defaultDiscoveryCompatible: false,
         compatiblePolicyHashes: undefined,
         compatibleConfigFingerprints: undefined,
-        modelIdNormalizationPolicies: undefined,
         revision: Symbol("plugin-metadata-snapshot"),
         configIdentities: new WeakSet(),
       },

--- a/src/system-agent/agent-turn.terminal.test.ts
+++ b/src/system-agent/agent-turn.terminal.test.ts
@@ -1,27 +1,34 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { createSystemAgentSession } from "./agent-turn.js";
-import { runSystemAgentTurnWithDeps } from "./agent-turn.test-support.js";
+import { runSystemAgentTurnWithDeps as runSystemAgentTurnWithDepsImpl } from "./agent-turn.test-support.js";
 import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
 import {
-  createSystemAgentVerifiedInferenceTestFixture,
-  installSystemAgentPluginMetadataTestSnapshot,
+  createSystemAgentVerifiedInferenceTestFixture as createSystemAgentVerifiedInferenceTestFixtureImpl,
+  createSystemAgentPluginMetadataTestSnapshot,
   type SystemAgentPluginMetadataTestSnapshot,
 } from "./system-agent.test-helpers.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
 
-beforeAll(() => {
-  pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot();
-});
+const runSystemAgentTurnWithDeps: typeof runSystemAgentTurnWithDepsImpl = (...args) =>
+  pluginMetadataSnapshot!.run(() => runSystemAgentTurnWithDepsImpl(...args));
 
-afterAll(() => pluginMetadataSnapshot?.restore());
+const createSystemAgentVerifiedInferenceTestFixture: typeof createSystemAgentVerifiedInferenceTestFixtureImpl =
+  (...args) =>
+    pluginMetadataSnapshot!.run(
+      () => createSystemAgentVerifiedInferenceTestFixtureImpl(...args),
+      args[0],
+    );
+
+beforeAll(() => {
+  pluginMetadataSnapshot = createSystemAgentPluginMetadataTestSnapshot();
+});
 
 afterEach(() => {
   vi.unstubAllEnvs();
-  pluginMetadataSnapshot?.rebindForCurrentEnv();
 });
 
 describe("system-agent terminal failure cleanup", () => {
@@ -103,7 +110,7 @@ describe("system-agent terminal failure cleanup", () => {
     },
   ])("clears partial session state after $name", async ({ runEmbeddedAgent }) => {
     vi.stubEnv("OPENCLAW_STATE_DIR", tempDirs.make("openclaw-turn-failure-"));
-    pluginMetadataSnapshot?.rebindForCurrentEnv();
+
     const config: OpenClawConfig = {
       agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
     };

--- a/src/system-agent/agent-turn.test.ts
+++ b/src/system-agent/agent-turn.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { listAgentEntries } from "../agents/agent-scope-config.js";
 import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
 import { fingerprintResolvedProviderAuth } from "../agents/execution-auth-binding.js";
@@ -12,16 +12,19 @@ import {
   createSystemAgentSession,
   type SystemAgentSession,
 } from "./agent-turn.js";
-import { runSystemAgentTurnWithDeps, type SystemAgentTurnDeps } from "./agent-turn.test-support.js";
-import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
-import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
 import {
-  createSystemAgentVerifiedInferenceTestFixture,
+  runSystemAgentTurnWithDeps as runSystemAgentTurnWithDepsImpl,
+  type SystemAgentTurnDeps,
+} from "./agent-turn.test-support.js";
+import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
+import { resolveSystemAgentConfiguredRouteFromConfig as resolveSystemAgentConfiguredRouteFromConfigImpl } from "./inference-route.js";
+import {
+  createSystemAgentVerifiedInferenceTestFixture as createSystemAgentVerifiedInferenceTestFixtureImpl,
   installSystemAgentClaudeCliBackendTestFixture,
-  installSystemAgentPluginMetadataTestSnapshot,
+  createSystemAgentPluginMetadataTestSnapshot,
   type SystemAgentPluginMetadataTestSnapshot,
 } from "./system-agent.test-helpers.js";
-import { createSystemAgentVerifiedInferenceBinding } from "./verified-inference.js";
+import { createSystemAgentVerifiedInferenceBinding as createSystemAgentVerifiedInferenceBindingImpl } from "./verified-inference.js";
 
 vi.mock("../plugins/providers.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../plugins/providers.js")>()),
@@ -67,11 +70,32 @@ const tempDirs: string[] = [];
 let restoreCliBackendFixture: (() => void) | undefined;
 let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
 
+const runSystemAgentTurnWithDeps: typeof runSystemAgentTurnWithDepsImpl = (...args) =>
+  pluginMetadataSnapshot!.run(() => runSystemAgentTurnWithDepsImpl(...args));
+
+const createSystemAgentVerifiedInferenceTestFixture: typeof createSystemAgentVerifiedInferenceTestFixtureImpl =
+  (...args) =>
+    pluginMetadataSnapshot!.run(
+      () => createSystemAgentVerifiedInferenceTestFixtureImpl(...args),
+      args[0],
+    );
+
+const resolveSystemAgentConfiguredRouteFromConfig: typeof resolveSystemAgentConfiguredRouteFromConfigImpl =
+  (...args) =>
+    pluginMetadataSnapshot!.run(
+      () => resolveSystemAgentConfiguredRouteFromConfigImpl(...args),
+      args[0],
+    );
+
+const createSystemAgentVerifiedInferenceBinding: typeof createSystemAgentVerifiedInferenceBindingImpl =
+  (...args) =>
+    pluginMetadataSnapshot!.run(() => createSystemAgentVerifiedInferenceBindingImpl(...args));
+
 function useTempStateDir(): string {
   const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-turn-"));
   tempDirs.push(stateDir);
   vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
-  pluginMetadataSnapshot?.rebindForCurrentEnv();
+
   return stateDir;
 }
 
@@ -104,11 +128,7 @@ async function createVerifiedSession(config: OpenClawConfig) {
 }
 
 beforeAll(() => {
-  pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot();
-});
-
-afterAll(() => {
-  pluginMetadataSnapshot?.restore();
+  pluginMetadataSnapshot = createSystemAgentPluginMetadataTestSnapshot();
 });
 
 beforeEach(() => {
@@ -119,7 +139,7 @@ afterEach(() => {
   restoreCliBackendFixture?.();
   restoreCliBackendFixture = undefined;
   vi.unstubAllEnvs();
-  pluginMetadataSnapshot?.rebindForCurrentEnv();
+
   vi.clearAllMocks();
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });

--- a/src/system-agent/approval-intent.test.ts
+++ b/src/system-agent/approval-intent.test.ts
@@ -2,14 +2,14 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
-  classifySystemAgentApprovalIntent,
+  classifySystemAgentApprovalIntent as classifySystemAgentApprovalIntentImpl,
   type SystemAgentApprovalIntentDeps,
 } from "./approval-intent.js";
 import { classifySystemAgentApprovalText } from "./operator-approval.js";
 import {
   createSystemAgentVerifiedInferenceTestFixture,
   installSystemAgentClaudeCliBackendTestFixture,
-  installSystemAgentPluginMetadataTestSnapshot,
+  createSystemAgentPluginMetadataTestSnapshot,
   type SystemAgentPluginMetadataTestSnapshot,
 } from "./system-agent.test-helpers.js";
 import type { SystemAgentVerifiedInferenceBinding } from "./verified-inference.js";
@@ -39,33 +39,35 @@ function verifiedInferenceConfig(model: string): OpenClawConfig {
 
 async function createVerifiedInference(
   model = "openai/gpt-5.5@openai:p2",
+  metadata = cliPluginMetadataSnapshot!,
 ): Promise<SystemAgentVerifiedInferenceBinding> {
-  return (await createSystemAgentVerifiedInferenceTestFixture(verifiedInferenceConfig(model)))
-    .binding;
+  return metadata.run(
+    async () =>
+      (await createSystemAgentVerifiedInferenceTestFixture(verifiedInferenceConfig(model))).binding,
+    verifiedInferenceConfig(model),
+  );
 }
 
 let sharedVerifiedInference: SystemAgentVerifiedInferenceBinding | undefined;
 let restoreCliBackendFixture: (() => void) | undefined;
 let cliPluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
 
+const classifySystemAgentApprovalIntent: typeof classifySystemAgentApprovalIntentImpl = (...args) =>
+  cliPluginMetadataSnapshot!.run(() => classifySystemAgentApprovalIntentImpl(...args));
+
 beforeAll(async () => {
   restoreCliBackendFixture = installSystemAgentClaudeCliBackendTestFixture();
-  const defaultSnapshot = installSystemAgentPluginMetadataTestSnapshot(
+  const defaultSnapshot = createSystemAgentPluginMetadataTestSnapshot(
     verifiedInferenceConfig(DEFAULT_MODEL),
   );
-  try {
-    sharedVerifiedInference = await createVerifiedInference(DEFAULT_MODEL);
-  } finally {
-    defaultSnapshot.restore();
-  }
-  cliPluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot(
+  sharedVerifiedInference = await createVerifiedInference(DEFAULT_MODEL, defaultSnapshot);
+  cliPluginMetadataSnapshot = createSystemAgentPluginMetadataTestSnapshot(
     verifiedInferenceConfig(CLI_MODEL),
   );
 });
 
 afterAll(() => {
   restoreCliBackendFixture?.();
-  cliPluginMetadataSnapshot?.restore();
 });
 
 function requireSharedVerifiedInference(): SystemAgentVerifiedInferenceBinding {

--- a/src/system-agent/chat-engine.test-support.ts
+++ b/src/system-agent/chat-engine.test-support.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, beforeAll, expect, vi } from "vitest";
+import { afterEach, beforeAll, expect, vi } from "vitest";
 import {
   fingerprintAuthProfileCredential,
   fingerprintOpaqueRuntimeOwner,
@@ -10,22 +10,23 @@ import {
 } from "../agents/execution-auth-binding.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import type { runSetupMemoryImportStep } from "../wizard/setup.memory-import.js";
+import { runSystemAgentTurnWithDeps as runSystemAgentTurnWithDepsImpl } from "./agent-turn.test-support.js";
 import {
   SystemAgentChatEngine as RuntimeSystemAgentChatEngine,
   type SystemAgentChatEngineOptions,
 } from "./chat-engine.js";
 import type { ChatWizardHostDependencies } from "./chat-wizard-host.js";
 import {
-  resolveSystemAgentConfiguredRouteFromConfig,
+  resolveSystemAgentConfiguredRouteFromConfig as resolveSystemAgentConfiguredRouteFromConfigImpl,
   type SystemAgentConfiguredRoute,
 } from "./inference-route.js";
 import {
-  createSystemAgentVerifiedInferenceTestFixture,
-  installSystemAgentPluginMetadataTestSnapshot,
+  createSystemAgentVerifiedInferenceTestFixture as createSystemAgentVerifiedInferenceTestFixtureImpl,
+  createSystemAgentPluginMetadataTestSnapshot,
   type SystemAgentPluginMetadataTestSnapshot,
 } from "./system-agent.test-helpers.js";
 import {
-  createSystemAgentVerifiedInferenceBinding,
+  createSystemAgentVerifiedInferenceBinding as createSystemAgentVerifiedInferenceBindingImpl,
   type SystemAgentVerifiedInferenceBinding,
   type SystemAgentVerifiedInferenceDeps,
 } from "./verified-inference.js";
@@ -129,11 +130,33 @@ export let sharedVerifiedInference: SystemAgentVerifiedInferenceBinding | undefi
 let sharedVerifiedInferenceDeps: SystemAgentVerifiedInferenceDeps | undefined;
 let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
 
+const resolveSystemAgentConfiguredRouteFromConfig: typeof resolveSystemAgentConfiguredRouteFromConfigImpl =
+  (...args) =>
+    pluginMetadataSnapshot!.run(
+      () => resolveSystemAgentConfiguredRouteFromConfigImpl(...args),
+      args[0],
+    );
+
+const createSystemAgentVerifiedInferenceTestFixture: typeof createSystemAgentVerifiedInferenceTestFixtureImpl =
+  (...args) =>
+    pluginMetadataSnapshot!.run(
+      () => createSystemAgentVerifiedInferenceTestFixtureImpl(...args),
+      args[0],
+    );
+
+const createSystemAgentVerifiedInferenceBinding: typeof createSystemAgentVerifiedInferenceBindingImpl =
+  (...args) =>
+    pluginMetadataSnapshot!.run(() => createSystemAgentVerifiedInferenceBindingImpl(...args));
+
+export const runSystemAgentTurnWithDeps: typeof runSystemAgentTurnWithDepsImpl = (...args) =>
+  pluginMetadataSnapshot!.run(() => runSystemAgentTurnWithDepsImpl(...args));
+
+export { createSystemAgentVerifiedInferenceTestFixture };
+
 export function useTempStateDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-engine-"));
   tempDirs.push(dir);
   vi.stubEnv("OPENCLAW_STATE_DIR", dir);
-  pluginMetadataSnapshot?.rebindForCurrentEnv();
   return dir;
 }
 
@@ -279,6 +302,40 @@ type TestSystemAgentChatEngineOptions = Omit<SystemAgentChatEngineOptions, "veri
 
 /** Every ordinary engine test starts from a real, live-gate-shaped authority grant. */
 export class SystemAgentChatEngine extends RuntimeSystemAgentChatEngine {
+  override answerWizard(...args: Parameters<RuntimeSystemAgentChatEngine["answerWizard"]>) {
+    return pluginMetadataSnapshot!.run(() => super.answerWizard(...args));
+  }
+
+  override cancelWizard(...args: Parameters<RuntimeSystemAgentChatEngine["cancelWizard"]>) {
+    return pluginMetadataSnapshot!.run(() => super.cancelWizard(...args));
+  }
+
+  override resolveOperatorApproval(
+    ...args: Parameters<RuntimeSystemAgentChatEngine["resolveOperatorApproval"]>
+  ) {
+    return pluginMetadataSnapshot!.run(() => super.resolveOperatorApproval(...args));
+  }
+
+  override loadOverview(...args: Parameters<RuntimeSystemAgentChatEngine["loadOverview"]>) {
+    return pluginMetadataSnapshot!.run(() => super.loadOverview(...args));
+  }
+
+  override planGreeting(...args: Parameters<RuntimeSystemAgentChatEngine["planGreeting"]>) {
+    return pluginMetadataSnapshot!.run(() => super.planGreeting(...args));
+  }
+
+  override seedHistory(...args: Parameters<RuntimeSystemAgentChatEngine["seedHistory"]>) {
+    return pluginMetadataSnapshot!.run(() => super.seedHistory(...args));
+  }
+
+  override propose(...args: Parameters<RuntimeSystemAgentChatEngine["propose"]>) {
+    return pluginMetadataSnapshot!.run(() => super.propose(...args));
+  }
+
+  override handle(...args: Parameters<RuntimeSystemAgentChatEngine["handle"]>) {
+    return pluginMetadataSnapshot!.run(() => super.handle(...args));
+  }
+
   constructor(opts: TestSystemAgentChatEngineOptions = {}) {
     const {
       runChannelSetupWizard,
@@ -337,7 +394,7 @@ export async function advanceGatewayWizardToToken(engine: SystemAgentChatEngine)
 }
 
 beforeAll(async () => {
-  pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot(
+  pluginMetadataSnapshot = createSystemAgentPluginMetadataTestSnapshot(
     sharedVerifiedInferenceConfig,
   );
   const fixture = await createSystemAgentVerifiedInferenceTestFixture(
@@ -351,13 +408,8 @@ beforeAll(async () => {
   );
 });
 
-afterAll(() => {
-  pluginMetadataSnapshot?.restore();
-});
-
 afterEach(() => {
   vi.unstubAllEnvs();
-  pluginMetadataSnapshot?.rebindForCurrentEnv();
   vi.clearAllMocks();
   mocks.readConfigFileSnapshot.mockResolvedValue(
     configSnapshot(structuredClone(sharedVerifiedInferenceConfig)) as never,
@@ -404,7 +456,6 @@ export { expectDefined } from "@openclaw/normalization-core";
 export { hashSystemAgentOperation } from "./operator-approval.js";
 export type { OpenClawConfig } from "../config/types.openclaw.js";
 export type { WizardPrompter } from "../wizard/prompts.js";
-export { runSystemAgentTurnWithDeps } from "./agent-turn.test-support.js";
 export { classifySystemAgentApprovalText } from "./operator-approval.js";
 export { SystemAgentWizardAnswerError } from "./chat-engine.js";
 export type { SystemAgentChatEngineOptions } from "./chat-engine.js";

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { SystemAgentSession } from "./agent-turn.js";
 import type { SystemAgentTurnDeps } from "./agent-turn.test-support.js";
 import {
+  createSystemAgentVerifiedInferenceTestFixture,
   fakeOverviewLoader,
   useTempStateDir,
   configSnapshot,
@@ -15,7 +16,6 @@ import {
   type SystemAgentChatEngineOptions,
 } from "./chat-engine.test-support.js";
 import { loadSystemAgentOverview } from "./overview.js";
-import { createSystemAgentVerifiedInferenceTestFixture } from "./system-agent.test-helpers.js";
 
 describe("SystemAgentChatEngine facade", () => {
   it("ends a partial timed-out agent turn without starting a second planner inference", async () => {

--- a/src/system-agent/config-redaction.test.ts
+++ b/src/system-agent/config-redaction.test.ts
@@ -4,29 +4,40 @@ import {
   setRuntimeConfigSnapshot,
 } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { installTemporaryCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
 import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import {
-  isSystemAgentSensitiveConfigPathEmbedding,
-  isSystemAgentSensitiveConfigValue,
-  redactSystemAgentConfigPath,
-  redactSystemAgentConfig,
+  isSystemAgentSensitiveConfigPathEmbedding as isSystemAgentSensitiveConfigPathEmbeddingImpl,
+  isSystemAgentSensitiveConfigValue as isSystemAgentSensitiveConfigValueImpl,
+  redactSystemAgentConfigPath as redactSystemAgentConfigPathImpl,
+  redactSystemAgentConfig as redactSystemAgentConfigImpl,
 } from "./config-redaction.js";
 import {
-  installSystemAgentPluginMetadataTestSnapshot,
+  createSystemAgentPluginMetadataTestSnapshot,
   type SystemAgentPluginMetadataTestSnapshot,
 } from "./system-agent.test-helpers.js";
 
 let pluginMetadata: SystemAgentPluginMetadataTestSnapshot | undefined;
 
+const isSystemAgentSensitiveConfigPathEmbedding: typeof isSystemAgentSensitiveConfigPathEmbeddingImpl =
+  (...args) => pluginMetadata!.run(() => isSystemAgentSensitiveConfigPathEmbeddingImpl(...args));
+
+const isSystemAgentSensitiveConfigValue: typeof isSystemAgentSensitiveConfigValueImpl = (...args) =>
+  pluginMetadata!.run(() => isSystemAgentSensitiveConfigValueImpl(...args));
+
+const redactSystemAgentConfigPath: typeof redactSystemAgentConfigPathImpl = (...args) =>
+  pluginMetadata!.run(() => redactSystemAgentConfigPathImpl(...args));
+
+const redactSystemAgentConfig: typeof redactSystemAgentConfigImpl = (...args) =>
+  pluginMetadata!.run(() => redactSystemAgentConfigImpl(...args));
+
 beforeEach(() => {
   const config = {};
   setRuntimeConfigSnapshot(config, config);
-  pluginMetadata = installSystemAgentPluginMetadataTestSnapshot(config);
+  pluginMetadata = createSystemAgentPluginMetadataTestSnapshot(config);
 });
 
 afterEach(() => {
-  pluginMetadata?.restore();
   pluginMetadata = undefined;
   clearRuntimeConfigSnapshot();
 });
@@ -165,7 +176,6 @@ describe("redactSystemAgentConfig", () => {
   it.each(["plus", "core"])(
     "redacts retained owner credentials with %s selected first",
     (first) => {
-      pluginMetadata?.restore();
       const snapshot = createPluginMetadataSnapshotFixture({
         plugins: ["core", "plus"].map((id) => ({
           id,
@@ -191,30 +201,28 @@ describe("redactSystemAgentConfig", () => {
         plugins: { entries: { plus: { enabled: false }, core: { enabled: true } } },
         channels: { proofchat: { plus: "synthetic-plus", core: "synthetic-core" } },
       };
-      const lease = installTemporaryCurrentPluginMetadataSnapshot(snapshot, {
-        config: preferred,
-        compatibleConfigs: [preferred, fallback],
-      });
-      try {
-        const configs =
-          first === "plus" ? ([preferred, fallback] as const) : ([fallback, preferred] as const);
-        for (const config of [...configs, configs[0]]) {
-          setRuntimeConfigSnapshot(config, config);
-          expect(redactSystemAgentConfig(config, { config })).toMatchObject({
-            channels: { proofchat: { plus: "<redacted>", core: "<redacted>" } },
-          });
-          for (const owner of ["core", "plus"]) {
-            expect(
-              isSystemAgentSensitiveConfigValue(`channels.proofchat.${owner}`, "synthetic"),
-            ).toBe(true);
-            expect(redactSystemAgentConfigPath(`channels.proofchat.${owner}.synthetic`)).toBe(
-              "<redacted path>",
-            );
+      withPluginMetadataSnapshotScope(
+        snapshot,
+        () => {
+          const configs =
+            first === "plus" ? ([preferred, fallback] as const) : ([fallback, preferred] as const);
+          for (const config of [...configs, configs[0]]) {
+            setRuntimeConfigSnapshot(config, config);
+            expect(redactSystemAgentConfigImpl(config, { config })).toMatchObject({
+              channels: { proofchat: { plus: "<redacted>", core: "<redacted>" } },
+            });
+            for (const owner of ["core", "plus"]) {
+              expect(
+                isSystemAgentSensitiveConfigValueImpl(`channels.proofchat.${owner}`, "synthetic"),
+              ).toBe(true);
+              expect(redactSystemAgentConfigPathImpl(`channels.proofchat.${owner}.synthetic`)).toBe(
+                "<redacted path>",
+              );
+            }
           }
-        }
-      } finally {
-        lease.release();
-      }
+        },
+        { config: preferred, compatibleConfigs: [preferred, fallback] },
+      );
     },
   );
 

--- a/src/system-agent/operations-parse.test.ts
+++ b/src/system-agent/operations-parse.test.ts
@@ -4,22 +4,27 @@ import {
   clearRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
 } from "../config/runtime-snapshot.js";
-import { isPersistentSystemAgentOperation, parseSystemAgentOperation } from "./operations.js";
 import {
-  installSystemAgentPluginMetadataTestSnapshot,
+  isPersistentSystemAgentOperation,
+  parseSystemAgentOperation as parseSystemAgentOperationImpl,
+} from "./operations.js";
+import {
+  createSystemAgentPluginMetadataTestSnapshot,
   type SystemAgentPluginMetadataTestSnapshot,
 } from "./system-agent.test-helpers.js";
 
 let pluginMetadata: SystemAgentPluginMetadataTestSnapshot | undefined;
 
+const parseSystemAgentOperation: typeof parseSystemAgentOperationImpl = (...args) =>
+  pluginMetadata!.run(() => parseSystemAgentOperationImpl(...args));
+
 beforeAll(() => {
   const config = {};
   setRuntimeConfigSnapshot(config, config);
-  pluginMetadata = installSystemAgentPluginMetadataTestSnapshot(config);
+  pluginMetadata = createSystemAgentPluginMetadataTestSnapshot(config);
 });
 
 afterAll(() => {
-  pluginMetadata?.restore();
   clearRuntimeConfigSnapshot();
 });
 

--- a/src/system-agent/operations.setup-transaction.test.ts
+++ b/src/system-agent/operations.setup-transaction.test.ts
@@ -5,11 +5,14 @@ import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-stor
 import type { LocalOnboardingState } from "../state/local-onboarding-state.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
-import { executeSystemAgentOperation, type SystemAgentCommandDeps } from "./operations.js";
+import {
+  executeSystemAgentOperation as executeSystemAgentOperationImpl,
+  type SystemAgentCommandDeps,
+} from "./operations.js";
 import type { SystemAgentSetupApplyResult } from "./setup-apply.js";
 import { createSystemAgentTestRuntime } from "./system-agent.runtime.test-support.js";
 import {
-  installSystemAgentPluginMetadataTestSnapshot,
+  createSystemAgentPluginMetadataTestSnapshot,
   type SystemAgentPluginMetadataTestSnapshot,
 } from "./system-agent.test-helpers.js";
 
@@ -177,8 +180,11 @@ function createRecoverySetupDeps(
 const opTempDirs = useAutoCleanupTempDirTracker(afterEach);
 let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
 
+const executeSystemAgentOperation: typeof executeSystemAgentOperationImpl = (...args) =>
+  pluginMetadataSnapshot!.run(() => executeSystemAgentOperationImpl(...args));
+
 beforeAll(() => {
-  pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot();
+  pluginMetadataSnapshot = createSystemAgentPluginMetadataTestSnapshot();
   mockConfig.setPluginMetadataBinder((config) => {
     pluginMetadataSnapshot?.bindForConfig(config);
   });
@@ -187,7 +193,6 @@ beforeAll(() => {
 
 afterAll(() => {
   mockConfig.setPluginMetadataBinder(() => {});
-  pluginMetadataSnapshot?.restore();
 });
 
 describe("system-agent setup transaction", () => {

--- a/src/system-agent/operations.setup.test.ts
+++ b/src/system-agent/operations.setup.test.ts
@@ -8,13 +8,16 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-store.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
-import { executeSystemAgentOperation, type SystemAgentCommandDeps } from "./operations.js";
+import {
+  executeSystemAgentOperation as executeSystemAgentOperationImpl,
+  type SystemAgentCommandDeps,
+} from "./operations.js";
 import { createSystemAgentTestRuntime } from "./system-agent.runtime.test-support.js";
 import {
   expectSystemAgentAuditRecord as expectAuditRecord,
   expectTestRecordFields as expectRecordFields,
   installSystemAgentClaudeCliBackendTestFixture,
-  installSystemAgentPluginMetadataTestSnapshot,
+  createSystemAgentPluginMetadataTestSnapshot,
   readLastSystemAgentAuditEntry as readLastAuditEntry,
   requireTestRecord as requireRecord,
   type SystemAgentPluginMetadataTestSnapshot,
@@ -162,9 +165,12 @@ const opTempDirs = useAutoCleanupTempDirTracker(afterEach);
 let restoreCliBackendFixture: (() => void) | undefined;
 let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
 
+const executeSystemAgentOperation: typeof executeSystemAgentOperationImpl = (...args) =>
+  pluginMetadataSnapshot!.run(() => executeSystemAgentOperationImpl(...args));
+
 beforeAll(() => {
   restoreCliBackendFixture = installSystemAgentClaudeCliBackendTestFixture();
-  pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot();
+  pluginMetadataSnapshot = createSystemAgentPluginMetadataTestSnapshot();
   mockConfig.setPluginMetadataBinder((config) => {
     pluginMetadataSnapshot?.bindForConfig(config as OpenClawConfig);
   });
@@ -173,7 +179,7 @@ beforeAll(() => {
 
 afterAll(() => {
   mockConfig.setPluginMetadataBinder(() => {});
-  pluginMetadataSnapshot?.restore();
+
   restoreCliBackendFixture?.();
 });
 

--- a/src/system-agent/operations.test.ts
+++ b/src/system-agent/operations.test.ts
@@ -20,7 +20,7 @@ import {
   isPersistentSystemAgentOperation,
 } from "./operations.js";
 import { createSystemAgentTestRuntime } from "./system-agent.runtime.test-support.js";
-import { installSystemAgentPluginMetadataTestSnapshot } from "./system-agent.test-helpers.js";
+import { createSystemAgentPluginMetadataTestSnapshot } from "./system-agent.test-helpers.js";
 
 type TestConfig = Record<string, unknown>;
 
@@ -364,17 +364,15 @@ describe("system agent operations", () => {
       },
     };
     mockConfig.setConfig(config);
-    const pluginMetadata = installSystemAgentPluginMetadataTestSnapshot(config);
+    const pluginMetadata = createSystemAgentPluginMetadataTestSnapshot(config);
     const { runtime, lines } = createSystemAgentTestRuntime();
 
-    try {
+    await pluginMetadata.run(async () => {
       await executeSystemAgentOperation(
         { kind: "config-get", path: "plugins.entries.codex.config.appServer" },
         runtime,
       );
-    } finally {
-      pluginMetadata.restore();
-    }
+    });
 
     expect(lines.join("\n")).toContain('"headers": "<redacted>"');
     expect(lines.join("\n")).not.toContain(authorization);
@@ -396,35 +394,36 @@ describe("system agent operations", () => {
     };
     mockConfig.setConfig(config);
     setRuntimeConfigSnapshot(config, config);
-    const pluginMetadata = installSystemAgentPluginMetadataTestSnapshot(config);
+    const pluginMetadata = createSystemAgentPluginMetadataTestSnapshot(config);
     const { runtime, lines } = createSystemAgentTestRuntime();
 
     try {
-      await executeSystemAgentOperation(
-        { kind: "config-get", path: "channels.synology-chat" },
-        runtime,
-      );
+      await pluginMetadata.run(async () => {
+        await executeSystemAgentOperation(
+          { kind: "config-get", path: "channels.synology-chat" },
+          runtime,
+        );
 
-      expect(lines.join("\n")).toContain('"webhookUrl": "<redacted>"');
-      expect(lines.join("\n")).toContain('"incomingUrl": "<redacted>"');
-      expect(lines.join("\n")).not.toContain("callback-secret");
-      expect(lines.join("\n")).not.toContain("incoming-secret");
-      expect(
-        describeSystemAgentPersistentOperation({
-          kind: "config-set",
-          path: "channels.synology-chat.accounts.work.webhookUrl",
-          value: callbackUrl,
-        }),
-      ).toBe("set config channels.synology-chat.accounts.work.webhookUrl to <redacted>");
-      expect(
-        describeSystemAgentPersistentOperation({
-          kind: "config-set",
-          path: "channels.synology-chat",
-          value: `{ webhookUrl: "${callbackUrl}" }`,
-        }),
-      ).toBe("set config channels.synology-chat to <redacted>");
+        expect(lines.join("\n")).toContain('"webhookUrl": "<redacted>"');
+        expect(lines.join("\n")).toContain('"incomingUrl": "<redacted>"');
+        expect(lines.join("\n")).not.toContain("callback-secret");
+        expect(lines.join("\n")).not.toContain("incoming-secret");
+        expect(
+          describeSystemAgentPersistentOperation({
+            kind: "config-set",
+            path: "channels.synology-chat.accounts.work.webhookUrl",
+            value: callbackUrl,
+          }),
+        ).toBe("set config channels.synology-chat.accounts.work.webhookUrl to <redacted>");
+        expect(
+          describeSystemAgentPersistentOperation({
+            kind: "config-set",
+            path: "channels.synology-chat",
+            value: `{ webhookUrl: "${callbackUrl}" }`,
+          }),
+        ).toBe("set config channels.synology-chat to <redacted>");
+      });
     } finally {
-      pluginMetadata.restore();
       clearRuntimeConfigSnapshot();
     }
   });

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -59,28 +59,28 @@ import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { WizardCancelledError, WizardNavigationError } from "../wizard/prompts.js";
 import { cleanupSystemAgentSession, createSystemAgentSession } from "./agent-turn.js";
-import { runSystemAgentTurnWithDeps } from "./agent-turn.test-support.js";
-import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
+import { runSystemAgentTurnWithDeps as runSystemAgentTurnWithDepsImpl } from "./agent-turn.test-support.js";
+import { resolveSystemAgentConfiguredRouteFromConfig as resolveSystemAgentConfiguredRouteFromConfigImpl } from "./inference-route.js";
 import { setupInferenceLog, type ActivateSetupInferenceDeps } from "./setup-inference-core.js";
 import { resolveSetupInferenceProbeStreamParams } from "./setup-inference-probe.js";
-import { runSetupInferenceTest } from "./setup-inference-test.js";
+import { runSetupInferenceTest as runSetupInferenceTestImpl } from "./setup-inference-test.js";
 import {
   SetupInferenceActivationIndeterminateError,
   activateSetupInference as activateSetupInferenceImpl,
   type BoundVerifySetupInferenceResult,
-  detectSetupInference,
-  listManualSetupInferenceOptions,
+  detectSetupInference as detectSetupInferenceImpl,
+  listManualSetupInferenceOptions as listManualSetupInferenceOptionsImpl,
   listSetupInferenceAuthOptions,
   listSetupInferenceManualProviders,
   listSetupInferencePrepareOptions,
-  resolvePersistentApplyInference,
+  resolvePersistentApplyInference as resolvePersistentApplyInferenceImpl,
   type VerifySetupInferenceResult,
   verifySetupInference as verifySetupInferenceImpl,
   verifySetupInferenceConfig as verifySetupInferenceConfigImpl,
 } from "./setup-inference.js";
-import { applySystemAgentModelSelection } from "./setup-model-selection.js";
+import { applySystemAgentModelSelection as applySystemAgentModelSelectionImpl } from "./setup-model-selection.js";
 import {
-  installSystemAgentPluginMetadataTestSnapshot,
+  createSystemAgentPluginMetadataTestSnapshot,
   type SystemAgentPluginMetadataTestSnapshot,
 } from "./system-agent.test-helpers.js";
 import {
@@ -162,10 +162,36 @@ const suiteTempRootTracker = createSuiteTempRootTracker({
   prefix: "setup-inference-test-",
 });
 let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
+
+const runSystemAgentTurnWithDeps: typeof runSystemAgentTurnWithDepsImpl = (...args) =>
+  pluginMetadataSnapshot!.run(() => runSystemAgentTurnWithDepsImpl(...args));
+
+const resolveSystemAgentConfiguredRouteFromConfig: typeof resolveSystemAgentConfiguredRouteFromConfigImpl =
+  (...args) =>
+    pluginMetadataSnapshot!.run(
+      () => resolveSystemAgentConfiguredRouteFromConfigImpl(...args),
+      args[0],
+    );
+
+const resolvePersistentApplyInference: typeof resolvePersistentApplyInferenceImpl = (...args) =>
+  pluginMetadataSnapshot!.run(() => resolvePersistentApplyInferenceImpl(...args));
+
+const detectSetupInference: typeof detectSetupInferenceImpl = (...args) =>
+  pluginMetadataSnapshot!.run(() => detectSetupInferenceImpl(...args));
+
+const listManualSetupInferenceOptions: typeof listManualSetupInferenceOptionsImpl = (...args) =>
+  pluginMetadataSnapshot!.run(() => listManualSetupInferenceOptionsImpl(...args));
+
+const runSetupInferenceTest: typeof runSetupInferenceTestImpl = (...args) =>
+  pluginMetadataSnapshot!.run(() => runSetupInferenceTestImpl(...args));
+
+const applySystemAgentModelSelection: typeof applySystemAgentModelSelectionImpl = (...args) =>
+  pluginMetadataSnapshot!.run(() => applySystemAgentModelSelectionImpl(...args));
+
 let inMemoryAuthProfileStores = new Map<string, AuthProfileStore>();
 
 beforeAll(async () => {
-  pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot(
+  pluginMetadataSnapshot = createSystemAgentPluginMetadataTestSnapshot(
     materializedMainRuntimeConfig,
   );
   cliBackendsTesting.setDepsForTest({
@@ -203,13 +229,12 @@ afterAll(async () => {
     }
   } finally {
     cliBackendsTesting.resetDepsForTest();
-    pluginMetadataSnapshot?.restore();
   }
 });
 
 beforeEach(() => {
   inMemoryAuthProfileStores = new Map();
-  pluginMetadataSnapshot?.rebindForCurrentEnv();
+  pluginMetadataSnapshot?.bindForConfig(materializedMainRuntimeConfig);
 });
 
 async function createMainAgentFixture() {
@@ -415,14 +440,16 @@ async function activateSetupInference(
       } as never);
     }) as typeof deps.transformConfigWithPendingPluginInstalls;
   }
-  return activateSetupInferenceImpl({
-    runtime,
-    surface: "gateway",
-    ...activationParams,
-    // Most activation tests isolate commit mechanics from the verified-owner
-    // implementation. Owner-CAS regressions opt back into the real helper.
-    deps,
-  });
+  return pluginMetadataSnapshot!.run(() =>
+    activateSetupInferenceImpl({
+      runtime,
+      surface: "gateway",
+      ...activationParams,
+      // Most activation tests isolate commit mechanics from the verified-owner
+      // implementation. Owner-CAS regressions opt back into the real helper.
+      deps,
+    }),
+  );
 }
 
 type TestVerifySetupInferenceParams = Omit<
@@ -443,11 +470,13 @@ function verifySetupInference(
   params: TestVerifySetupInferenceParams & { bindSession?: boolean },
 ): Promise<VerifySetupInferenceResult | BoundVerifySetupInferenceResult> {
   const { useRealAuthProfileStore = false, ...verifyParams } = params;
-  return verifySetupInferenceImpl({
-    runtime,
-    ...verifyParams,
-    deps: withSuiteFixtures(verifyParams.deps, useRealAuthProfileStore),
-  } as never);
+  return pluginMetadataSnapshot!.run(() =>
+    verifySetupInferenceImpl({
+      runtime,
+      ...verifyParams,
+      deps: withSuiteFixtures(verifyParams.deps, useRealAuthProfileStore),
+    } as never),
+  );
 }
 
 async function verifySetupInferenceConfig(
@@ -458,11 +487,13 @@ async function verifySetupInferenceConfig(
 ): ReturnType<typeof verifySetupInferenceConfigImpl> {
   const { useRealAuthProfileStore = false, ...verifyParams } = params;
   pluginMetadataSnapshot?.bind({ config: verifyParams.config, env: process.env });
-  return verifySetupInferenceConfigImpl({
-    runtime,
-    ...verifyParams,
-    deps: withSuiteFixtures(verifyParams.deps, useRealAuthProfileStore),
-  });
+  return pluginMetadataSnapshot!.run(() =>
+    verifySetupInferenceConfigImpl({
+      runtime,
+      ...verifyParams,
+      deps: withSuiteFixtures(verifyParams.deps, useRealAuthProfileStore),
+    }),
+  );
 }
 
 type SuccessfulRunParams = {
@@ -5167,7 +5198,6 @@ describe("activateSetupInference", () => {
       );
     } finally {
       clearCurrentPluginMetadataSnapshot();
-      pluginMetadataSnapshot?.rebindForCurrentEnv();
     }
     expect(getPluginRuntimeGatewayRequestScope()).toBeUndefined();
     expect(ownerArtifactRegistry).toBe(stagedRegistry);

--- a/src/system-agent/setup-lifetime.test.ts
+++ b/src/system-agent/setup-lifetime.test.ts
@@ -17,7 +17,7 @@ import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { executeSystemAgentOperation } from "./operations-execute.js";
 import type { SystemAgentOverview } from "./overview.js";
 import { createSystemAgentTestRuntime } from "./system-agent.runtime.test-support.js";
-import { installSystemAgentPluginMetadataTestSnapshot } from "./system-agent.test-helpers.js";
+import { createSystemAgentPluginMetadataTestSnapshot } from "./system-agent.test-helpers.js";
 
 const preparation = vi.hoisted(() => ({
   gateway: undefined as (() => Promise<void>) | undefined,
@@ -77,7 +77,7 @@ it.each([
   const entered = createDeferred();
   const resume = createDeferred();
   let paused = false;
-  let metadata: ReturnType<typeof installSystemAgentPluginMetadataTestSnapshot> | undefined;
+  let metadata: ReturnType<typeof createSystemAgentPluginMetadataTestSnapshot> | undefined;
   let completion: Promise<unknown> | undefined;
   const { runtime, lines } = createSystemAgentTestRuntime();
   const workspace = state.workspaceDir;
@@ -110,9 +110,7 @@ it.each([
   };
   try {
     await state.writeConfig(config);
-    metadata = installSystemAgentPluginMetadataTestSnapshot(
-      (await readConfigFileSnapshot()).config,
-    );
+    metadata = createSystemAgentPluginMetadataTestSnapshot((await readConfigFileSnapshot()).config);
     const beforeRaw = await fs.readFile(state.configPath, "utf8");
     if (phase === "config") {
       preparation.gateway = pause;
@@ -146,18 +144,22 @@ it.each([
         entered.resolve();
       };
     }
-    completion = executeSystemAgentOperation({ kind: "setup", workspace }, runtime, {
-      approved: true,
-      ...(loss === "direct" ? {} : { beforePersistentApply }),
-      deps: {
-        setupSurface: "gateway",
-        loadOverview: async () => ({ defaultModel: model }) as SystemAgentOverview,
-        verifyInferenceConfig: async () => ({ ok: true, modelRef: model, latencyMs: 1 }),
-      },
-    }).then(
-      (result) => ({ result }),
-      (error: unknown) => ({ error }),
-    );
+    completion = metadata
+      .run(() =>
+        executeSystemAgentOperation({ kind: "setup", workspace }, runtime, {
+          approved: true,
+          ...(loss === "direct" ? {} : { beforePersistentApply }),
+          deps: {
+            setupSurface: "gateway",
+            loadOverview: async () => ({ defaultModel: model }) as SystemAgentOverview,
+            verifyInferenceConfig: async () => ({ ok: true, modelRef: model, latencyMs: 1 }),
+          },
+        }),
+      )
+      .then(
+        (result) => ({ result }),
+        (error: unknown) => ({ error }),
+      );
     await withTestTimeout(
       Promise.race([
         entered.promise,
@@ -228,7 +230,6 @@ it.each([
     await completion;
     admission.close();
     replacement?.close();
-    metadata?.restore();
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
     await state.cleanup();

--- a/src/system-agent/system-agent.test-helpers.ts
+++ b/src/system-agent/system-agent.test-helpers.ts
@@ -12,10 +12,17 @@ import {
 import { resolveCliRuntimeExecutionProvider } from "../agents/model-runtime-aliases.js";
 import { resolveSimpleCompletionSelectionForAgent } from "../agents/simple-completion-runtime.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { installTemporaryCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
+import {
+  bindPluginMetadataSnapshotCache,
+  getPluginMetadataSnapshotCache,
+} from "../plugins/plugin-cache.js";
 import { resolvePluginControlPlaneFingerprint } from "../plugins/plugin-control-plane-context.js";
-import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import {
+  loadPluginMetadataSnapshot,
+  type resolvePluginMetadataSnapshot,
+} from "../plugins/plugin-metadata-snapshot.js";
 import { listSystemAgentAuditEntriesForTests } from "./audit.test-support.js";
 import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
 import {
@@ -38,9 +45,7 @@ export type SystemAgentPluginMetadataTestSnapshot = {
     config: OpenClawConfig,
     workspaceDir?: string,
   ) => ReturnType<typeof resolvePluginMetadataSnapshot>;
-  /** Rebind after a test redirects to another empty state root with the same plugin inventory. */
-  rebindForCurrentEnv: () => void;
-  restore: () => void;
+  run: <T>(run: () => T, config?: OpenClawConfig) => T;
 };
 
 /** Install the contract-level selectable CLI backend used by core system-agent tests. */
@@ -72,14 +77,16 @@ export function installSystemAgentClaudeCliBackendTestFixture(): () => void {
   return () => cliBackendsTesting.resetDepsForTest();
 }
 
-/** Install the process-stable plugin metadata snapshot that the real Gateway owns. */
-export function installSystemAgentPluginMetadataTestSnapshot(
+/** Prepare one inventory; each test operation owns its scoped config and environment. */
+export function createSystemAgentPluginMetadataTestSnapshot(
   config: OpenClawConfig = {},
 ): SystemAgentPluginMetadataTestSnapshot {
-  const prepared = resolvePluginMetadataSnapshot({ config, env: process.env });
-  let releaseCurrentSnapshot: () => boolean = () => false;
-  const bind = (params: Parameters<typeof resolvePluginMetadataSnapshot>[0]) => {
-    releaseCurrentSnapshot();
+  const prepared = loadPluginMetadataSnapshot({ config, env: process.env, allowCurrent: false });
+  let boundParams: Parameters<typeof resolvePluginMetadataSnapshot>[0] = {
+    config,
+    env: process.env,
+  };
+  const prepareSnapshot = (params: Parameters<typeof resolvePluginMetadataSnapshot>[0]) => {
     const policyHash = resolveInstalledPluginIndexPolicyHash(params.config);
     const index =
       prepared.index.policyHash === policyHash ? prepared.index : { ...prepared.index, policyHash };
@@ -96,24 +103,20 @@ export function installSystemAgentPluginMetadataTestSnapshot(
       }),
       ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
     };
-    releaseCurrentSnapshot = installTemporaryCurrentPluginMetadataSnapshot(snapshot, {
-      config: params.config,
-      env: params.env,
-      workspaceDir: params.workspaceDir,
-    }).release;
+    bindPluginMetadataSnapshotCache(snapshot, getPluginMetadataSnapshotCache(prepared));
     return snapshot;
   };
-  const rebindForCurrentEnv = () => {
-    bind({ config, env: process.env });
+  const bind = (params: Parameters<typeof resolvePluginMetadataSnapshot>[0]) => {
+    boundParams = params;
+    return prepareSnapshot(params);
   };
-  rebindForCurrentEnv();
   return {
     bind,
     bindForConfig: (nextConfig, workspaceDir) =>
       bind({ config: nextConfig, env: process.env, workspaceDir }),
-    rebindForCurrentEnv,
-    restore: () => {
-      releaseCurrentSnapshot();
+    run: (run, nextConfig) => {
+      const params = { ...boundParams, config: nextConfig ?? boundParams.config, env: process.env };
+      return withPluginMetadataSnapshotScope(prepareSnapshot(params), run, params);
     },
   };
 }

--- a/src/system-agent/verified-inference.test-support.ts
+++ b/src/system-agent/verified-inference.test-support.ts
@@ -1,4 +1,5 @@
 import { vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginOrigin } from "../plugins/types.js";
 
 type TestPluginRecord = {
@@ -56,3 +57,29 @@ export const codexRuntimeArtifactAuth = {
   runtimeArtifactFingerprint: "codex-runtime-v1",
   runtimeArtifactId: "codex-app-server",
 } as const;
+
+export function config(model = "openai/gpt-5.5@openai:verified"): OpenClawConfig {
+  return {
+    agents: { defaults: { model } },
+    auth: {
+      profiles: {
+        "openai:verified": { provider: "openai", mode: "api_key" },
+      },
+    },
+  };
+}
+
+export function profileAuth(profileId: string, apiKey: string) {
+  return { apiKey, profileId, source: `profile:${profileId}`, mode: "api-key" as const };
+}
+
+export function profileStore(profileId: string, credential: object) {
+  return vi.fn(() => ({ version: 1, profiles: { [profileId]: credential } })) as never;
+}
+
+export function requireFingerprint(value: string | undefined): string {
+  if (!value) {
+    throw new Error("missing test auth fingerprint");
+  }
+  return value;
+}

--- a/src/system-agent/verified-inference.test.ts
+++ b/src/system-agent/verified-inference.test.ts
@@ -10,19 +10,23 @@ import {
   fingerprintResolvedProviderAuth,
 } from "../agents/execution-auth-binding.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
-import { resolvePersistentApplyInference } from "./setup-inference.js";
+import { resolveSystemAgentConfiguredRouteFromConfig as resolveSystemAgentConfiguredRouteFromConfigImpl } from "./inference-route.js";
+import { resolvePersistentApplyInference as resolvePersistentApplyInferenceImpl } from "./setup-inference.js";
 import {
   installSystemAgentClaudeCliBackendTestFixture,
-  installSystemAgentPluginMetadataTestSnapshot,
+  createSystemAgentPluginMetadataTestSnapshot,
   type SystemAgentPluginMetadataTestSnapshot,
 } from "./system-agent.test-helpers.js";
 import {
-  createSystemAgentVerifiedInferenceBinding,
-  resolveSystemAgentVerifiedInferenceRoute,
+  createSystemAgentVerifiedInferenceBinding as createSystemAgentVerifiedInferenceBindingImpl,
+  resolveSystemAgentVerifiedInferenceRoute as resolveSystemAgentVerifiedInferenceRouteImpl,
   type SystemAgentVerifiedInferenceDeps,
 } from "./verified-inference.js";
 import {
+  config,
+  profileAuth,
+  profileStore,
+  requireFingerprint,
   cliRuntimeArtifactAuth,
   cliRuntimeArtifactDeps,
   codexRuntimeArtifactAuth,
@@ -88,20 +92,36 @@ const profile = {
 
 const runtime = { log: () => {}, error: () => {}, exit: () => {} } as never;
 let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
+
+const resolveSystemAgentConfiguredRouteFromConfig: typeof resolveSystemAgentConfiguredRouteFromConfigImpl =
+  (...args) =>
+    pluginMetadataSnapshot!.run(
+      () => resolveSystemAgentConfiguredRouteFromConfigImpl(...args),
+      args[0],
+    );
+
+const resolvePersistentApplyInference: typeof resolvePersistentApplyInferenceImpl = (...args) =>
+  pluginMetadataSnapshot!.run(() => resolvePersistentApplyInferenceImpl(...args));
+
+const createSystemAgentVerifiedInferenceBinding: typeof createSystemAgentVerifiedInferenceBindingImpl =
+  (...args) =>
+    pluginMetadataSnapshot!.run(() => createSystemAgentVerifiedInferenceBindingImpl(...args));
+
+const resolveSystemAgentVerifiedInferenceRoute: typeof resolveSystemAgentVerifiedInferenceRouteImpl =
+  (...args) =>
+    pluginMetadataSnapshot!.run(() => resolveSystemAgentVerifiedInferenceRouteImpl(...args));
 let restoreCliBackendFixture: (() => void) | undefined;
 
 beforeAll(() => {
-  pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot(config());
+  pluginMetadataSnapshot = createSystemAgentPluginMetadataTestSnapshot(config());
   restoreCliBackendFixture = installSystemAgentClaudeCliBackendTestFixture();
 });
 
 afterAll(() => {
   restoreCliBackendFixture?.();
-  pluginMetadataSnapshot?.restore();
 });
 
 beforeEach(() => {
-  pluginMetadataSnapshot?.rebindForCurrentEnv();
   pluginRegistryState.providerOwnerIds = ["provider-owner"];
   pluginRegistryState.records = [pluginRecord("provider-owner"), pluginRecord("codex")];
   harnessRuntimeArtifactState.id = "codex-app-server";
@@ -132,32 +152,6 @@ function authDeps(apiKey = "verified-key") {
       },
     ),
   };
-}
-
-function config(model = "openai/gpt-5.5@openai:verified"): OpenClawConfig {
-  return {
-    agents: { defaults: { model } },
-    auth: {
-      profiles: {
-        "openai:verified": { provider: "openai", mode: "api_key" },
-      },
-    },
-  };
-}
-
-function profileAuth(profileId: string, apiKey: string) {
-  return { apiKey, profileId, source: `profile:${profileId}`, mode: "api-key" as const };
-}
-
-function profileStore(profileId: string, credential: object) {
-  return vi.fn(() => ({ version: 1, profiles: { [profileId]: credential } })) as never;
-}
-
-function requireFingerprint(value: string | undefined): string {
-  if (!value) {
-    throw new Error("missing test auth fingerprint");
-  }
-  return value;
 }
 
 async function bindingFor(

--- a/src/transcripts/status.metadata.test.ts
+++ b/src/transcripts/status.metadata.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import { createPluginMetadataSnapshot } from "../config/plugin-auto-enable.test-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { installTemporaryCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
 import * as discovery from "../plugins/discovery.js";
 import * as loader from "../plugins/loader.js";
 import { loadPluginManifestRegistryForInstalledIndex } from "../plugins/manifest-registry-installed.js";
@@ -83,7 +83,6 @@ describe("transcript setup metadata boundary", () => {
       const previous = captureActivePluginRegistrySnapshot();
       const active = createEmptyPluginRegistry();
       setActivePluginRegistry(active);
-      const lease = installTemporaryCurrentPluginMetadataSnapshot(metadata, { config: cfg });
       const store = new TranscriptsStore(state.statePath("transcripts"));
       const readStatus = async () => {
         const discover = vi.spyOn(discovery, "discoverOpenClawPlugins").mockImplementation(() => {
@@ -94,7 +93,11 @@ describe("transcript setup metadata boundary", () => {
         });
         const read = vi.spyOn(fs, "readFileSync");
         try {
-          const result = await readTranscriptLibraryStatus(store, cfg);
+          const result = await withPluginMetadataSnapshotScope(
+            metadata,
+            () => readTranscriptLibraryStatus(store, cfg),
+            { config: cfg },
+          );
           expect(discover).not.toHaveBeenCalled();
           expect(resolve).not.toHaveBeenCalled();
           expect(
@@ -138,7 +141,6 @@ describe("transcript setup metadata boundary", () => {
           });
         }
       } finally {
-        lease.release();
         restoreActivePluginRegistrySnapshot(previous);
       }
     });

--- a/src/transcripts/status.test.ts
+++ b/src/transcripts/status.test.ts
@@ -6,10 +6,7 @@ import {
   makeRegistry,
 } from "../config/plugin-auto-enable.test-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  installTemporaryCurrentPluginMetadataSnapshot,
-  withPluginMetadataSnapshotScope,
-} from "../plugins/current-plugin-metadata-snapshot.js";
+import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
   captureActivePluginRegistrySnapshot,
@@ -189,11 +186,14 @@ describe("transcript library capture health", () => {
         },
       });
       setActivePluginRegistry(registry);
-      const lease = installTemporaryCurrentPluginMetadataSnapshot(metadata, { config: cfg });
       try {
         const store = new TranscriptsStore(path.join(state.stateDir, "transcripts"));
         const importedBefore = listImportedRuntimePluginIds();
-        const result = await readTranscriptLibraryStatus(store, cfg);
+        const result = await withPluginMetadataSnapshotScope(
+          metadata,
+          () => readTranscriptLibraryStatus(store, cfg),
+          { config: cfg },
+        );
         expect(result.providers).toEqual(
           expect.arrayContaining([
             expect.objectContaining({ providerId: "declared-source", availability: "enabled" }),
@@ -226,7 +226,6 @@ describe("transcript library capture health", () => {
         expect(status).not.toHaveBeenCalled();
         expect(listImportedRuntimePluginIds()).toEqual(importedBefore);
       } finally {
-        lease.release();
         restoreActivePluginRegistrySnapshot(previous);
       }
     });
@@ -252,28 +251,23 @@ describe("transcript library capture health", () => {
       });
       const scoped = { ...metadata, pluginIds: ["limited-scope"] };
       // An agent-scoped metadata generation cannot establish Gateway-wide absence.
-      const lease = installTemporaryCurrentPluginMetadataSnapshot(scoped, { config: cfg });
-      try {
-        const result = await withPluginMetadataSnapshotScope(
-          scoped,
-          () => readTranscriptLibraryStatus(store, cfg),
-          { config: cfg, trustConfigIdentity: immutable },
-        );
-        expect(result.configuredSources).toHaveLength(100);
-        expect(result.providers).toHaveLength(100);
-        expect(result.omitted).toMatchObject({
-          configuredSources: 2,
-          providers: expect.any(Number),
-        });
-        expect(
-          result.providers
-            .filter((provider) => provider.providerId.startsWith("missing-"))
-            .every((provider) => provider.availability === "unknown"),
-        ).toBe(true);
-        expect(result.latestTranscript).toBeNull();
-      } finally {
-        lease.release();
-      }
+      const result = await withPluginMetadataSnapshotScope(
+        scoped,
+        () => readTranscriptLibraryStatus(store, cfg),
+        { config: cfg, trustConfigIdentity: immutable },
+      );
+      expect(result.configuredSources).toHaveLength(100);
+      expect(result.providers).toHaveLength(100);
+      expect(result.omitted).toMatchObject({
+        configuredSources: 2,
+        providers: expect.any(Number),
+      });
+      expect(
+        result.providers
+          .filter((provider) => provider.providerId.startsWith("missing-"))
+          .every((provider) => provider.availability === "unknown"),
+      ).toBe(true);
+      expect(result.latestTranscript).toBeNull();
     },
   );
 });

--- a/test/e2e/qa-lab/media/music-generation-controls.e2e.test.ts
+++ b/test/e2e/qa-lab/media/music-generation-controls.e2e.test.ts
@@ -10,7 +10,7 @@ import type {
   MusicGenerationRequest,
 } from "../../../../src/music-generation/types.js";
 import { prepareMediaCapabilityProviders } from "../../../../src/plugins/capability-provider-runtime.js";
-import { installTemporaryCurrentPluginMetadataSnapshot } from "../../../../src/plugins/current-plugin-metadata-snapshot.js";
+import { withPluginMetadataSnapshotScope } from "../../../../src/plugins/current-plugin-metadata-snapshot.js";
 import { resolvePluginRegistryLoadCacheKey } from "../../../../src/plugins/loader.js";
 import type { PluginManifestRecord } from "../../../../src/plugins/manifest-registry.js";
 import { createEmptyPluginRegistry } from "../../../../src/plugins/registry.js";
@@ -183,46 +183,45 @@ describe("music generation controls QA product proof", () => {
   it("lists capabilities, falls back in config order, normalizes controls, and persists audio", async () => {
     const fixture = createMusicFixture();
     const activeRegistry = captureActivePluginRegistrySnapshot();
-    const metadataLease = installTemporaryCurrentPluginMetadataSnapshot(
+    await withPluginMetadataSnapshotScope(
       fixture.pluginMetadataSnapshot,
-      {
-        config: fixture.config,
-      },
-    );
-    try {
-      const pluginIds = [PLUGIN_ID];
-      const cacheKey = resolvePluginRegistryLoadCacheKey({
-        config: fixture.config,
-        onlyPluginIds: pluginIds,
-        activate: false,
-      });
-      setActivePluginRegistry(fixture.registry, cacheKey);
-      const listed = (await fixture.tool.execute("music-list", {
-        action: "list",
-      })) as ToolResult;
-      const listedProviders = detailsOf(listed).providers as Array<Record<string, unknown>>;
-      const primaryListing = listedProviders.find((entry) => entry.id === fixture.primary.id);
-      const fallbackListing = listedProviders.find((entry) => entry.id === fixture.fallback.id);
+      async () => {
+        try {
+          const pluginIds = [PLUGIN_ID];
+          const cacheKey = resolvePluginRegistryLoadCacheKey({
+            config: fixture.config,
+            onlyPluginIds: pluginIds,
+            activate: false,
+          });
+          setActivePluginRegistry(fixture.registry, cacheKey);
+          const listed = (await fixture.tool.execute("music-list", {
+            action: "list",
+          })) as ToolResult;
+          const listedProviders = detailsOf(listed).providers as Array<Record<string, unknown>>;
+          const primaryListing = listedProviders.find((entry) => entry.id === fixture.primary.id);
+          const fallbackListing = listedProviders.find((entry) => entry.id === fixture.fallback.id);
 
-      expect(primaryListing).toMatchObject({
-        configured: true,
-        defaultModel: "song-v1",
-        models: ["song-v1"],
-        modes: ["generate"],
-      });
-      expect(fallbackListing).toMatchObject({
-        configured: true,
-        defaultModel: "beat-v2",
-        models: ["beat-v2"],
-        modes: ["generate"],
-      });
-      expect(textOf(listed)).toContain(
-        "capabilities: modes=generate, maxDurationSeconds=60, lyrics, instrumental, duration, format, supportedFormats=mp3/wav",
-      );
-    } finally {
-      metadataLease.release();
-      restoreActivePluginRegistrySnapshot(activeRegistry);
-    }
+          expect(primaryListing).toMatchObject({
+            configured: true,
+            defaultModel: "song-v1",
+            models: ["song-v1"],
+            modes: ["generate"],
+          });
+          expect(fallbackListing).toMatchObject({
+            configured: true,
+            defaultModel: "beat-v2",
+            models: ["beat-v2"],
+            modes: ["generate"],
+          });
+          expect(textOf(listed)).toContain(
+            "capabilities: modes=generate, maxDurationSeconds=60, lyrics, instrumental, duration, format, supportedFormats=mp3/wav",
+          );
+        } finally {
+          restoreActivePluginRegistrySnapshot(activeRegistry);
+        }
+      },
+      { config: fixture.config },
+    );
 
     const stateDir = tempDirs.make("openclaw-qa-music-controls-");
     await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where running `models status` could cause concurrent operations to read plugin metadata from that command's workspace while it waited for model information.

## Why This Change Was Made

Run the status operation inside the existing asynchronous metadata scope. Remove the temporary process-global lease stack, its capture/restore helpers, and the policy state stored only for lease restoration. Gateway startup publication restrictions and CLI metadata revision checks remain intact.

Migrate fixture consumers to operation scopes while retaining their behavioral assertions. Production code shrinks by 162 lines; tests and support grow by 58 lines, with one obsolete assertion-baseline entry removed.

## User Impact

Concurrent operations keep their own plugin metadata. The status command's model selection, output and CLI options are preserved. This is an independent cleanup of the existing metadata API, with no new configuration or persistence changes.

## Evidence

- Causal regression: while status waits for its catalog, an unrelated reader incorrectly sees the command's workspace snapshot on the old implementation. The identical test passes with scoped metadata and still protects newer publications.
- Rebased head: all 40 models-status tests pass, including the upstream case-distinct route cases and the held-snapshot isolation regression. Metadata publication, model-normalization and CLI-lifetime checks add 87 passing tests (127 total).
- Earlier broad validation on the original base passed 688 affected tests across 22 files, including system-agent, Gateway, onboarding, transcript metadata and music-generation QA coverage. This remains supporting pre-rebase evidence.
- Isolated real `pnpm openclaw models status --json`: a synthetic plugin's alias resolves correctly, its default utility model is reported, and its runtime entry is never imported.
- Independent P2 autoreview: no actionable findings. Normal changed-code gate passes on the rebased head, including all selected typechecks, lint, formatting and guards.

No live provider credentials or operator Gateway were used.
