### PR TITLE
refactor(memory): reuse current index identity resolution during sync

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -363,6 +363,8 @@ export abstract class MemoryManagerSyncBase extends MemoryManagerDatabaseContext
   protected resolveCurrentIndexIdentityState(params?: {
     meta?: MemoryIndexMeta | null;
     provider?: { id: string; model: string } | null;
+    providerKey?: string;
+    providerIdentities?: MemoryIndexProviderIdentity[];
     providerKeyKnown?: boolean;
     vectorReady?: boolean;
     hasIndexedChunks?: boolean;
@@ -410,20 +412,27 @@ export abstract class MemoryManagerSyncBase extends MemoryManagerDatabaseContext
         })
       : [];
     const providerIdentities =
-      initializedProviderIdentities.length > 0
+      params?.providerIdentities ??
+      (initializedProviderIdentities.length > 0
         ? initializedProviderIdentities
-        : configuredProviderIdentities;
+        : configuredProviderIdentities);
     const configuredProviderKeyKnown = configuredProviderIdentities.length > 0;
+    const providerKeyKnown = params?.providerIdentities
+      ? (params.providerKeyKnown ?? true)
+      : configuredProviderKeyKnown || params?.providerKeyKnown;
     return resolveMemoryIndexIdentityState({
       meta: params && "meta" in params ? params.meta! : this.readMeta(),
       provider,
-      providerKey: configuredProviderKeyKnown
-        ? providerIdentities[0]?.providerKey
-        : params?.providerKeyKnown === false
-          ? undefined
-          : (this.providerKey ?? undefined),
+      providerKey:
+        params && "providerKey" in params
+          ? params.providerKey
+          : configuredProviderKeyKnown
+            ? providerIdentities[0]?.providerKey
+            : providerKeyKnown === false
+              ? undefined
+              : (this.providerKey ?? undefined),
       providerAliases: providerIdentities.slice(1),
-      providerKeyKnown: configuredProviderKeyKnown ? true : params?.providerKeyKnown,
+      providerKeyKnown,
       configuredSources: resolveConfiguredSourcesForMeta(this.sources),
       configuredScopeHash: resolveConfiguredScopeHash({
         workspaceDir: this.workspaceDir,

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -40,7 +40,6 @@ import {
   MEMORY_INDEX_PROVENANCE_VERSION,
   resolveConfiguredScopeHash,
   resolveConfiguredSourcesForMeta,
-  resolveMemoryIndexIdentityState,
   type MemoryIndexMeta,
   type MemoryIndexProviderIdentity,
 } from "./manager-reindex-state.js";
@@ -200,27 +199,15 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
       const syncProviderIdentities =
         this.syncProviderGeneration?.identities ?? this.resolveProviderIndexIdentities();
       const hasIndexedChunks = this.hasIndexedChunks();
-      const indexIdentity = resolveMemoryIndexIdentityState({
+      const indexIdentity = this.resolveCurrentIndexIdentityState({
         meta,
         // Also detects provider→FTS-only transitions so orphaned old-model FTS rows are cleaned up.
         provider: syncProvider ? { id: syncProvider.id, model: syncProvider.model } : null,
         providerKey: syncProviderKey ?? undefined,
-        providerAliases: syncProviderIdentities.slice(1),
-        configuredSources: resolveConfiguredSourcesForMeta(this.sources),
-        configuredScopeHash: resolveConfiguredScopeHash({
-          workspaceDir: this.workspaceDir,
-          extraPaths: this.settings.extraPaths,
-          multimodal: {
-            enabled: this.settings.multimodal.enabled,
-            modalities: this.settings.multimodal.modalities,
-            maxFileBytes: this.settings.multimodal.maxFileBytes,
-          },
-        }),
-        chunkTokens: this.settings.chunking.tokens,
-        chunkOverlap: this.settings.chunking.overlap,
+        providerIdentities: syncProviderIdentities,
+        providerKeyKnown: true,
         vectorReady,
         hasIndexedChunks,
-        ftsTokenizer: this.settings.store.fts.tokenizer,
       });
       const needsInitialIndex = indexIdentity.status !== "valid" && !hasIndexedChunks;
       // Missing metadata cannot prove whether existing chunks were semantic.


### PR DESCRIPTION
## Summary

- route sync-time index identity checks through the existing current-identity resolver
- allow sync provider generations to supply their resolved key and identities explicitly
- remove the duplicate source, scope, chunking, and tokenizer identity assembly from the sync path

## Testing

- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-sync-control.test.ts extensions/memory-core/src/memory/manager-targeted-sync.test.ts extensions/memory-core/src/memory/manager-reindex-state.test.ts` (33 tests)
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental`
- `node scripts/run-oxlint.mjs extensions/memory-core/src/memory/manager-sync-base.ts extensions/memory-core/src/memory/manager-sync-ops.ts`
- `oxfmt --check` on both changed files
- `git diff --check origin/main...HEAD`