### PR TITLE
refactor(channels): simplify config write target checks

### DIFF
--- a/src/channels/plugins/config-write-policy-shared.ts
+++ b/src/channels/plugins/config-write-policy-shared.ts
@@ -50,18 +50,6 @@ export type ConfigWriteAuthorizationResultLike<TChannelId extends string = strin
       };
     };
 
-function listConfigWriteTargetScopes<TChannelId extends string>(
-  target?: ConfigWriteTargetLike<TChannelId>,
-): ConfigWriteScopeLike<TChannelId>[] {
-  if (!target || target.kind === "global") {
-    return [];
-  }
-  if (target.kind === "ambiguous") {
-    return target.scopes;
-  }
-  return [target.scope];
-}
-
 function resolveChannelConfig(
   cfg: ConfigWritePolicyConfig,
   channelId?: string | null,
@@ -129,28 +117,21 @@ export function authorizeConfigWriteShared<TChannelId extends string>(params: {
       blockedScope: { kind: "origin", scope: params.origin },
     };
   }
-  const seen = new Set<string>();
-  for (const target of listConfigWriteTargetScopes(params.target)) {
-    if (!target.channelId) {
-      continue;
-    }
-    const key = `${target.channelId}:${normalizeAccountId(target.accountId)}`;
-    if (seen.has(key)) {
-      continue;
-    }
-    // Deduplicate account scopes so a broad path does not report the same block twice.
-    seen.add(key);
+  const target = params.target;
+  if (target && target.kind !== "global") {
+    const scope: ConfigWriteScopeLike<TChannelId> = target.scope;
     if (
+      scope.channelId &&
       !resolveChannelConfigWritesShared({
         cfg: params.cfg,
-        channelId: target.channelId,
-        accountId: target.accountId,
+        channelId: scope.channelId,
+        accountId: scope.accountId,
       })
     ) {
       return {
         allowed: false,
         reason: "target-disabled",
-        blockedScope: { kind: "target", scope: target },
+        blockedScope: { kind: "target", scope },
       };
     }
   }


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Channel config-write authorization maintains a list, loop and deduplication set for multiple target scopes after it has already rejected ambiguous targets. This is a maintainer-requested production deletion follow-up supporting the #135868 campaign in the channel/config neighborhood (brief concern F).

## Why This Change Was Made

Check the single remaining channel/account scope directly. Preserve the existing order: internal bypass, ambiguous-target rejection, origin policy, target policy, then allow. Account normalization remains in the canonical policy resolver, and denial results retain the original scope object.

## User Impact

No change for supported config-write requests or SDK signatures. Production shrinks by 19 lines (+7/−26) in one file. Tests, tooling, docs, configuration and dependencies are unchanged.

## Evidence

| Deleted implementation | Preserved contract and coverage |
| --- | --- |
| `listConfigWriteTargetScopes` and its ambiguous-target branch | `authorizeConfigWriteShared` rejects ambiguity before target evaluation. Only absent/global or a single channel/account scope can remain. `src/channels/plugins/contracts/test-helpers/config-write-contract-suites.ts:95,147` retains origin/target/account/bypass/global and ambiguous-path coverage through the existing contract suites. |
| Target loop, `seen` set and duplicate-key normalization | A fresh set with at most one entry cannot deduplicate anything. Account normalization and case-insensitive lookup remain in `resolveChannelConfigWritesShared`; `src/plugin-sdk/channel-config-helpers.test.ts:235` retains the case-insensitive account-denial boundary. |
| Multi-target control-flow scaffolding | `src/auto-reply/reply/commands-allowlist.test.ts:513,673,692` retains denied config/store writes and the no-write enablement hint. Public target/result types and error/blocked-scope behavior are retained. |

The public contract remains default-enabled `configWrites !== false` (`docs/channels/telegram.md:827`), with `/allowlist` honoring channel configWrites (`docs/tools/slash-commands.md:596`). No SDK export or compatibility surface is removed. Repository/static-analysis searches found no other caller or named owner for the deleted private helper. Its history contains the same early ambiguity rejection; no multi-target continuation contract was identified.

A temporary differential probe compared 1,155 authorization outcomes across supported scope variants, bypasses, ambiguity, account policies/casing, and missing-scope errors. Outputs and blocked-scope reference identity matched exactly. Five existing focused suites passed before/after with all 61 cases retained, 7.482 s → 7.092 s aggregate. Independent pinned-candidate review is scoped-clean through P2. The configured Blacksmith Testbox `tbx_01m1we5y9j2fcj3ft270h3byfk` passed `pnpm build` and the full selected changed-check plan, including core and extension type/test lanes and lint. Source SHA256 matched the local candidate; the command returned exit 0 in 22m36.5s and the lease stopped ([run 34064790112](https://github.com/openclaw/openclaw/actions/runs/34064790112)). The wrapper exit/timing record is the delegated proof; cleanup may cancel the backing Actions run. [Final-head CI run 34066277419](https://github.com/openclaw/openclaw/actions/runs/34066277419) completed successfully.

Rebased onto the landed recovery stage (#135868). The owner/callee slice and lockfile are unchanged; all 61 focused cases pass again and the fresh committed-branch review is scoped-clean through P2. Final head: `b08afd8782dc07f719812d600c7267cb98ec5815`; exact-head CI passed. ClawSweeper reviewed this head with no findings or before-merge/rank-up requests.
