### PR TITLE
fix(ci): keep compact GitHub plans within the job cap

### DIFF
--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -2607,59 +2607,6 @@ export function packNodeTestGroups<Group>(
   return bins;
 }
 
-function packHostedToolingRunnerTails(jobs: CompactNodeTestShard[]) {
-  const runnerRanks = new Map([
-    [BUNDLED_NODE_TEST_RUNNER, 0],
-    [DEFAULT_NODE_TEST_RUNNER, 1],
-    [EXTRA_LARGE_NODE_TEST_RUNNER, 2],
-  ]);
-  const isToolingTail = (job: CompactNodeTestShard) =>
-    job.planConcurrency === 1 &&
-    !job.requiresDist &&
-    job.pretestBuildMode === undefined &&
-    job.groups.length > 0 &&
-    job.groups.every(
-      (group) =>
-        /^core-tooling-\d+-hosted-\d+$/u.test(group.shard_name) &&
-        group.configs.includes(TOOLING_CONFIG),
-    );
-  const tails = jobs
-    .filter(isToolingTail)
-    .toSorted((a, b) => (a.predictedSeconds ?? 0) - (b.predictedSeconds ?? 0));
-  for (const source of tails) {
-    const sourceIndex = jobs.indexOf(source);
-    const sourceRank = runnerRanks.get(source.runner);
-    if (sourceIndex === -1 || sourceRank === undefined) {
-      continue;
-    }
-    const target = tails.find((candidate) => {
-      const targetRank = runnerRanks.get(candidate.runner);
-      const groups = [...candidate.groups, ...source.groups];
-      const families = groups
-        .map(compactStripeFamily)
-        .filter((family): family is string => family !== undefined);
-      return (
-        candidate !== source &&
-        jobs.includes(candidate) &&
-        targetRank !== undefined &&
-        targetRank > sourceRank &&
-        groups.length <= COMPACT_NODE_TEST_JOB_GROUPS &&
-        new Set(families).size === families.length &&
-        (candidate.predictedSeconds ?? 0) + (source.predictedSeconds ?? 0) <=
-          COMPACT_EXCLUSIVE_JOB_SECONDS
-      );
-    });
-    if (!target) {
-      continue;
-    }
-    // Smaller tooling can use an already-required larger runner. Keep the
-    // high-memory owner first so the emitted runner and check identity stay stable.
-    target.groups.push(...source.groups);
-    target.predictedSeconds = (target.predictedSeconds ?? 0) + (source.predictedSeconds ?? 0);
-    jobs.splice(sourceIndex, 1);
-  }
-}
-
 function createCompactNodeTestShardBundles(
   options: NodeTestPlanOptions,
   compactMode: CompactNodeTestPlanMode,
@@ -2723,7 +2670,6 @@ function createCompactNodeTestShardBundles(
     }
   }
 
-  const compactJobs: CompactNodeTestShard[] = [];
   const estimateStripeSeconds = (group: NodeTestShardGroup) =>
     Math.max(
       synthesizedSplitSeconds.get(compactGroupTimingKey(group)) ?? 0,
@@ -2740,13 +2686,31 @@ function createCompactNodeTestShardBundles(
       )
     );
   };
-  for (const groups of groupsByRunner.values()) {
-    const usesBlacksmithCapacity =
-      isBlacksmithProfile ||
-      (options.runnerBackend === "hybrid" &&
-        [DEFAULT_NODE_TEST_RUNNER, BUNDLED_NODE_TEST_RUNNER, EXTRA_LARGE_NODE_TEST_RUNNER].includes(
-          groups[0].runner,
-        ));
+  const isHostedToolingGroup = (group: NodeTestShardGroup) =>
+    !group.requiresDist &&
+    group.pretestBuildMode === undefined &&
+    /^core-tooling-\d+-hosted-\d+$/u.test(group.shard_name) &&
+    group.configs.includes(TOOLING_CONFIG) &&
+    runnerRank(group) >= 0;
+  const runnerRank = (group: NodeTestShardGroup) =>
+    [BUNDLED_NODE_TEST_RUNNER, DEFAULT_NODE_TEST_RUNNER, EXTRA_LARGE_NODE_TEST_RUNNER].indexOf(
+      group.runner,
+    );
+  const hasDistinctStripeFamilies = (groups: NodeTestShardGroup[]) => {
+    const families = groups
+      .map(compactStripeFamily)
+      .filter((family): family is string => family !== undefined);
+    return new Set(families).size === families.length;
+  };
+  const packsHostedTooling = compactMode === "pull-request" && options.runnerBackend === "github";
+  const usesBlacksmithCapacity = (runner: string) =>
+    isBlacksmithProfile ||
+    (options.runnerBackend === "hybrid" &&
+      [DEFAULT_NODE_TEST_RUNNER, BUNDLED_NODE_TEST_RUNNER, EXTRA_LARGE_NODE_TEST_RUNNER].includes(
+        runner,
+      ));
+  let packedBins = [...groupsByRunner.values()].flatMap((groups) => {
+    const usesBlacksmithRunner = usesBlacksmithCapacity(groups[0].runner);
     // Admit the final groups with their shared prerequisite. Rebalancing after
     // this check can break build sharing and exceed a bin's admitted cap.
     const sortedGroups = groups
@@ -2761,7 +2725,7 @@ function createCompactNodeTestShardBundles(
       // Keep ordinary work off serial runtime hosts. Hybrid exclusive/dist bins
       // retain their existing prerequisite sharing and admission policy.
       if (
-        (isBlacksmithProfile || (usesBlacksmithCapacity && !exclusive && !group.requiresDist)) &&
+        (isBlacksmithProfile || (usesBlacksmithRunner && !exclusive && !group.requiresDist)) &&
         Boolean(candidate[0].pretestBuildMode) !== Boolean(group.pretestBuildMode)
       ) {
         return false;
@@ -2786,23 +2750,13 @@ function createCompactNodeTestShardBundles(
             ? COMPACT_EXPANDED_NODE_TEST_JOB_SECONDS
             : resolveCiNodeTestRunnerClass(group.runner).secondsCap;
       const parallel =
-        usesBlacksmithCapacity &&
+        usesBlacksmithRunner &&
         combined.every(isParallelCompactGroup) &&
         combined.every((entry) => estimateBinSeconds([entry]) <= serialSecondsCap);
       const secondsCap = parallel ? COMPACT_PARALLEL_NODE_TEST_JOB_SECONDS : serialSecondsCap;
-      // A later unrelated member can revoke an earlier complete-CLI exemption.
-      // Recheck every sibling collision against the final bin's eligibility.
-      const preservesStripeFamilies = combined.every((entry, index) => {
-        const family = compactStripeFamily(entry);
-        return (
-          family === undefined ||
-          sharesSerialCliBudget ||
-          combined.slice(0, index).every((previous) => compactStripeFamily(previous) !== family)
-        );
-      });
       return (
         isExclusiveCompactGroup(candidate[0]) === exclusive &&
-        preservesStripeFamilies &&
+        (sharesSerialCliBudget || hasDistinctStripeFamilies(combined)) &&
         (parallel || candidate.length < COMPACT_NODE_TEST_JOB_GROUPS) &&
         estimateBinSeconds(combined) <= secondsCap
       );
@@ -2810,47 +2764,91 @@ function createCompactNodeTestShardBundles(
     bins.sort(
       (a, b) => Number(isExclusiveCompactGroup(a[0])) - Number(isExclusiveCompactGroup(b[0])),
     );
-
-    for (const [index, bin] of bins.entries()) {
-      const [firstGroup] = bin;
-      const { name: runnerClass } = resolveCiNodeTestRunnerClass(firstGroup.runner);
-      const distSuffix = firstGroup.requiresDist ? "-dist" : "";
-      const checkName = `checks-node-compact-${runnerClass}${distSuffix}-${index + 1}`;
-      const runner = firstGroup.runner;
-      const pretestBuildMode = mergeVitestPretestBuildModes(
-        bin.map((group) => group.pretestBuildMode),
+    return bins;
+  });
+  if (packsHostedTooling) {
+    const anchors = packedBins
+      .map((bin) => bin.filter((group) => !isHostedToolingGroup(group)))
+      .filter((bin): bin is [NodeTestShardGroup, ...NodeTestShardGroup[]] => bin.length > 0);
+    const hostedGroups = packedBins
+      .flatMap((bin) => bin.filter(isHostedToolingGroup))
+      .toSorted(
+        (a, b) =>
+          runnerRank(b) - runnerRank(a) ||
+          estimateBinSeconds([b]) - estimateBinSeconds([a]) ||
+          a.shard_name.localeCompare(b.shard_name),
       );
-      // The runner admits overlap only after measuring capacity; exclusive and
-      // runtime-building jobs stay serial regardless of the requested class.
-      const planConcurrency =
-        usesBlacksmithCapacity && bin.length > 1 && bin.every(isParallelCompactGroup) ? 2 : 1;
-      // Tooling's nested compilers need host capacity while keeping serial isolation.
-      // Promote only the emitted runner so packing, names and timing keys stay stable.
-      const capacityRunner =
-        planConcurrency === 2 ||
-        (isBlacksmithProfile && bin.some((group) => group.configs.includes(TOOLING_CONFIG)))
-          ? EXTRA_LARGE_NODE_TEST_RUNNER
-          : runner;
-      compactJobs.push({
-        checkName,
-        groups: bin,
-        ...(pretestBuildMode ? { pretestBuildMode } : {}),
-        requiresDist: firstGroup.requiresDist,
-        runner: capacityRunner,
-        shardName: `compact-${runnerClass}${distSuffix}-${index + 1}`,
-        // Whole-config groups run entire suites; keep their generous timeout.
-        ...(bin.some((group) => !group.includePatterns)
-          ? { timeoutMinutes: COMPACT_WHOLE_NODE_TEST_TIMEOUT_MINUTES }
-          : {}),
-        planConcurrency,
-        predictedSeconds: estimateBinSeconds(bin),
-      });
-    }
+    const strongestGroupCount =
+      hostedGroups.findLastIndex((group) => group.runner === hostedGroups[0]!.runner) + 1;
+    const units = [
+      ...hostedGroups.slice(0, strongestGroupCount).map((group) => [group]),
+      ...anchors,
+      ...hostedGroups.slice(strongestGroupCount).map((group) => [group]),
+    ] as Array<[NodeTestShardGroup, ...NodeTestShardGroup[]]>;
+    packedBins = packNodeTestGroups(units, (candidate, unit) => {
+      if (!isHostedToolingGroup(unit[0])) {
+        return false;
+      }
+      const candidateGroups = candidate.flat();
+      const owner = candidate[0][0];
+      const group = unit[0];
+      const combined = [...candidateGroups, group];
+      return (
+        ((owner.runner === group.runner && owner.requiresDist === group.requiresDist) ||
+          (combined.every(isHostedToolingGroup) && runnerRank(owner) > runnerRank(group))) &&
+        isExclusiveCompactGroup(owner) === isExclusiveCompactGroup(group) &&
+        candidateGroups.length < COMPACT_NODE_TEST_JOB_GROUPS &&
+        hasDistinctStripeFamilies(combined) &&
+        estimateBinSeconds(combined) <= COMPACT_EXCLUSIVE_JOB_SECONDS
+      );
+    }).map((bin) => bin.flat() as [NodeTestShardGroup, ...NodeTestShardGroup[]]);
   }
 
-  if (compactMode === "pull-request" && options.runnerBackend === "github") {
-    packHostedToolingRunnerTails(compactJobs);
+  const compactJobs: CompactNodeTestShard[] = [];
+  const nextJobIndexByClass = new Map<string, number>();
+  for (const bin of packedBins) {
+    const [firstGroup] = bin;
+    const { name: runnerClass } = resolveCiNodeTestRunnerClass(firstGroup.runner);
+    const distSuffix = firstGroup.requiresDist ? "-dist" : "";
+    const jobClass = `${runnerClass}${distSuffix}`;
+    const jobIndex = (nextJobIndexByClass.get(jobClass) ?? 0) + 1;
+    nextJobIndexByClass.set(jobClass, jobIndex);
+    const checkName = `checks-node-compact-${jobClass}-${jobIndex}`;
+    const runner = firstGroup.runner;
+    const pretestBuildMode = mergeVitestPretestBuildModes(
+      bin.map((group) => group.pretestBuildMode),
+    );
+    // The runner admits overlap only after measuring capacity; exclusive and
+    // runtime-building jobs stay serial regardless of the requested class.
+    const planConcurrency =
+      usesBlacksmithCapacity(firstGroup.runner) &&
+      bin.length > 1 &&
+      bin.every(isParallelCompactGroup)
+        ? 2
+        : 1;
+    // Tooling's nested compilers need host capacity while keeping serial isolation.
+    // Promote only the emitted runner so packing, names and timing keys stay stable.
+    const capacityRunner =
+      planConcurrency === 2 ||
+      (isBlacksmithProfile && bin.some((group) => group.configs.includes(TOOLING_CONFIG)))
+        ? EXTRA_LARGE_NODE_TEST_RUNNER
+        : runner;
+    compactJobs.push({
+      checkName,
+      groups: bin,
+      ...(pretestBuildMode ? { pretestBuildMode } : {}),
+      requiresDist: firstGroup.requiresDist,
+      runner: capacityRunner,
+      shardName: `compact-${jobClass}-${jobIndex}`,
+      // Whole-config groups run entire suites; keep their generous timeout.
+      ...(bin.some((group) => !group.includePatterns)
+        ? { timeoutMinutes: COMPACT_WHOLE_NODE_TEST_TIMEOUT_MINUTES }
+        : {}),
+      planConcurrency,
+      predictedSeconds: estimateBinSeconds(bin),
+    });
   }
+
   if (compactJobs.length > COMPACT_NODE_TEST_JOB_CAP) {
     throw new Error(
       `compact ${options.runnerBackend ?? "blacksmith"} node test plan exceeds ${COMPACT_NODE_TEST_JOB_CAP} jobs (${compactJobs.length} planned)`,

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -369,7 +369,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
                     (job.pretestBuildMode === buildMode &&
                       job.groups[0]!.includePatterns?.length === runtimeConsumers.length &&
                       job.groups[0]!.includePatterns?.every((file) =>
-                        runtimeConsumers.some((consumer) => consumer === file),
+                        runtimeConsumers.some((runtimeConsumer) => runtimeConsumer === file),
                       ))),
               ),
           ).toBe(true);
@@ -2092,6 +2092,114 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       ],
       requiresDist: false,
     });
+  });
+
+  it("keeps hosted tooling within the GitHub job cap when its inventory grows", async () => {
+    const options = {
+      compactMode: "pull-request" as const,
+      runnerBackend: "github",
+    };
+    const syntheticToolingFile = "test/scripts/resolve-fs-safe-native-contract.test.ts";
+    const isHostedToolingGroup = (group: { shard_name: string }) =>
+      /^core-tooling-\d+-hosted-\d+$/u.test(group.shard_name);
+    const isNumberedToolingGroup = (group: { shard_name: string }) =>
+      /^core-tooling-\d+(?:-hosted-\d+)?$/u.test(group.shard_name);
+    const runnerRanks = new Map([
+      [BUNDLED_NODE_TEST_RUNNER, 0],
+      [DEFAULT_NODE_TEST_RUNNER, 1],
+      [EXTRA_LARGE_NODE_TEST_RUNNER, 2],
+    ]);
+    const nonToolingPlacement = (plan: CompactNodeTestShard[]) =>
+      plan
+        .flatMap((job) => {
+          const groups = job.groups
+            .filter((group) => !isHostedToolingGroup(group))
+            .map((group) => group.shard_name)
+            .toSorted();
+          return groups.length === 0
+            ? []
+            : [
+                {
+                  groups,
+                  planConcurrency: job.planConcurrency,
+                  pretestBuildMode: job.pretestBuildMode,
+                  requiresDist: job.requiresDist,
+                  runner: job.runner,
+                },
+              ];
+        })
+        .toSorted((a, b) => a.groups.join("\0").localeCompare(b.groups.join("\0")));
+    const baseline = createNodeTestShardBundles(options);
+    const baselineToolingFiles = baseline
+      .flatMap((job) => job.groups)
+      .filter(isNumberedToolingGroup)
+      .flatMap((group) => group.includePatterns ?? []);
+    vi.resetModules();
+    vi.doMock("../../scripts/lib/list-test-files.mts", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("../../scripts/lib/list-test-files.mts")>();
+      return {
+        ...actual,
+        listTrackedTestFiles(rootDir: string, suffix?: string) {
+          const files = actual.listTrackedTestFiles(rootDir, suffix);
+          return rootDir === "test" ? [...files, syntheticToolingFile].toSorted() : files;
+        },
+      };
+    });
+    try {
+      const { createNodeTestShardBundles: createPlanWithGrownInventory } =
+        await import("../../scripts/lib/ci-node-test-plan.mts");
+      const grown = createPlanWithGrownInventory(options);
+      const toolingGroups = grown.flatMap((job) => job.groups).filter(isNumberedToolingGroup);
+      const toolingFiles = toolingGroups.flatMap((group) => group.includePatterns ?? []);
+      const crossRunnerHostedJobs: CompactNodeTestShard[] = [];
+
+      expect(grown.length).toBeLessThanOrEqual(80);
+      expect(new Set(toolingFiles).size).toBe(toolingFiles.length);
+      expect(toolingFiles.toSorted()).toEqual(
+        [...baselineToolingFiles, syntheticToolingFile].toSorted(),
+      );
+      expect(nonToolingPlacement(grown)).toEqual(nonToolingPlacement(baseline));
+
+      for (const job of grown) {
+        const hostedToolingGroups = job.groups.filter(isHostedToolingGroup);
+        if (hostedToolingGroups.length === 0) {
+          continue;
+        }
+        const families = hostedToolingGroups.map((group) =>
+          group.shard_name.replace(/-hosted-\d+$/u, ""),
+        );
+        expect(new Set(families).size).toBe(families.length);
+        expect(job.requiresDist).toBe(false);
+        expect(job.planConcurrency).toBe(1);
+        expect(job.groups.length).toBeLessThanOrEqual(10);
+        if (job.groups.length > 1) {
+          expect(job.predictedSeconds).toBeLessThanOrEqual(150);
+        }
+        expect(job.runner).toBe(job.groups[0]?.runner);
+        expect(
+          hostedToolingGroups.every(
+            (group) => (runnerRanks.get(job.runner) ?? -1) >= (runnerRanks.get(group.runner) ?? 0),
+          ),
+        ).toBe(true);
+        if (hostedToolingGroups.some((group) => group.runner !== job.runner)) {
+          crossRunnerHostedJobs.push(job);
+          expect(job.groups.every(isHostedToolingGroup)).toBe(true);
+          expect(job.pretestBuildMode).toBeUndefined();
+          expect(job.groups.every((group) => group.pretestBuildMode === undefined)).toBe(true);
+        }
+      }
+      expect(crossRunnerHostedJobs).toHaveLength(1);
+      expect(crossRunnerHostedJobs[0]?.runner).toBe(DEFAULT_NODE_TEST_RUNNER);
+      expect(crossRunnerHostedJobs[0]?.groups.map((group) => group.shard_name)).toEqual([
+        "core-tooling-15-hosted-3",
+        "core-tooling-6-hosted-2",
+        "core-tooling-2-hosted-2",
+        "core-tooling-3-hosted-2",
+      ]);
+    } finally {
+      vi.doUnmock("../../scripts/lib/list-test-files.mts");
+      vi.resetModules();
+    }
   });
 
   it("assigns Blacksmith runners to every core node shard", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where GitHub pull-request CI planning could exceed the 80-job cap when the tracked tooling-test inventory grew.

## Why This Change Was Made

Hosted, no-build, non-dist tooling groups now participate in the canonical packing pass across ranked GitHub runner classes. The strongest runner group remains first and owns the emitted job, while existing family, group-count, and 150-second admission limits continue to apply. Blacksmith, hybrid, push, release, file-partition, timing-key, pretest, and isolated-tooling behavior remain unchanged.

## User Impact

Pull requests can add tooling tests without making the GitHub CI planner fail solely because it generated an 81st job.

## Evidence

- Pre-fix production at `e07af7166c1677fa8072f1ad19ab5a7a508ac76e` fails the inventory-growth regression with `compact github node test plan exceeds 80 jobs (81 planned)`.
- Repaired head `10439be7d8a2aaddebfdaf559e26947112ef12da` produces 80 release-inclusive GitHub PR jobs.
- `node scripts/run-vitest.mjs test/scripts/ci-node-test-plan.test.ts --maxWorkers=1`: 51/51 passed.
- Focused regression verifies exact-once tooling coverage, unchanged non-tooling placement, deterministic mixed-runner group order, first-group runner ownership, no demotion, distinct families, and existing 10-group/150-second limits.
- `oxfmt`, `oxlint`, and `git diff --check` pass.
