### PR TITLE
improve(tests): batch ancestry fixture commits with fast-import

### DIFF
--- a/test/scripts/ci-git-owner.test.ts
+++ b/test/scripts/ci-git-owner.test.ts
@@ -75,22 +75,41 @@ function createAncestryFixture(options: {
   const root = mkdtempSync(join(tmpdir(), "openclaw-release-ancestry-"));
   const origin = join(root, "origin.git");
   fixtureGit(root, ["init", "--quiet", "--bare", origin]);
-  const tree = fixtureGit(root, [`--git-dir=${origin}`, "mktree"], "");
-  const sourceRoot = fixtureCommit(origin, tree, undefined, "source root");
-  const targetRoot = options.related
-    ? sourceRoot
-    : fixtureCommit(origin, tree, undefined, "target root");
+  const commits: string[] = [];
+  const sourceRef = "refs/heads/release-source";
+  const targetRef = "refs/heads/main";
+  const commit = (ref: string, parent: number | undefined, label: string) => {
+    const mark = commits.length + 1;
+    const message = `${label}\n`;
+    commits.push(`commit ${ref}
+mark :${mark}
+committer fixture <fixture@example.invalid> ${mark} +0000
+data ${Buffer.byteLength(message)}
+${message}${parent ? `from :${parent}\n` : ""}
+`);
+    return mark;
+  };
+  const sourceRoot = commit(sourceRef, undefined, "source root");
+  const targetRoot = options.related ? sourceRoot : commit(targetRef, undefined, "target root");
   let source = sourceRoot;
   for (let index = 0; index < options.sourceDistance; index++) {
-    source = fixtureCommit(origin, tree, source, `source ${String(index)}`);
+    source = commit(sourceRef, source, `source ${String(index)}`);
   }
   let target = targetRoot;
   for (let index = 0; index < options.targetDistance; index++) {
-    target = fixtureCommit(origin, tree, target, `target ${String(index)}`);
+    target = commit(targetRef, target, `target ${String(index)}`);
   }
-  fixtureGit(root, [`--git-dir=${origin}`, "update-ref", "refs/heads/release-source", source]);
-  fixtureGit(root, [`--git-dir=${origin}`, "update-ref", "refs/heads/main", target]);
-  return { origin, root, source, target };
+  fixtureGit(
+    origin,
+    ["fast-import", "--quiet"],
+    `${commits.join("")}reset ${sourceRef}\nfrom :${source}\n\nreset ${targetRef}\nfrom :${target}\n\n`,
+  );
+  return {
+    origin,
+    root,
+    source: fixtureGit(origin, ["rev-parse", sourceRef]),
+    target: fixtureGit(origin, ["rev-parse", targetRef]),
+  };
 }
 
 function createProvisionalMergeBaseFixture(): AncestryFixture & { base: string } {


### PR DESCRIPTION
## What Problem This Solves

Six release-ancestry tests create their histories by starting Git once per commit, adding 1,694 setup subprocesses before the real shallow-fetch checks run.

## Why This Change Was Made

Build each fresh repository with one Git fast-import stream, following the existing provisional-merge-base fixture. Preserve commit messages, empty trees, parent relationships, distinct/shared roots, branch endpoints, and every policy assertion. The moved-target test keeps its separate commit helper. This adds 19 net test lines; production code and real timeout/drain behavior are unchanged.

## User Impact

Faster fixture preparation while retaining real repository and shallow-history behavior. No overall test-suite improvement is claimed.

## Evidence

All six normalized graphs match before and after. A deliberately broken parent chain in an external diagnostic was rejected; repository source stayed unchanged. Setup uses 24 Git calls instead of 1,718 and measured 0.32s instead of 18.42s across those fixtures.

One sequential local full-file pair passed the same 123 cases, with 32 Linux-only cases skipped on macOS: Vitest 256.58s before and 217.31s after. These samples include ordinary scheduling and cache variation; the entire difference is not attributed to fixture construction. The six affected case durations totalled 28.96s and 7.51s, respectively. An additional 105 lifecycle sibling cases, the full changed-file gate, and independent review through P2 passed. [Exact-head Linux CI](https://github.com/openclaw/openclaw/actions/runs/34066645336/job/101576551317) passed all 155 cases, including the real timeout and drain checks.
