### PR TITLE
refactor(core): reuse grouped phone metadata

### DIFF
--- a/packages/normalization-core/src/phone-presentation.ts
+++ b/packages/normalization-core/src/phone-presentation.ts
@@ -1,19 +1,11 @@
-import {
-  getCountries,
-  getCountryCallingCode,
-  parsePhoneNumberFromString,
-} from "libphonenumber-js/min";
+import { parsePhoneNumberFromString } from "libphonenumber-js/min";
+import metadata from "libphonenumber-js/min/metadata";
 
-const sharedCountryCallingCodes = (() => {
-  const counts = new Map<string, number>();
-  for (const country of getCountries()) {
-    const callingCode = getCountryCallingCode(country);
-    counts.set(callingCode, (counts.get(callingCode) ?? 0) + 1);
-  }
-  return new Set(
-    [...counts.entries()].filter(([, count]) => count > 1).map(([callingCode]) => callingCode),
-  );
-})();
+const sharedCountryCallingCodes = new Set(
+  Object.entries(metadata.country_calling_codes)
+    .filter(([, countries]) => countries.length > 1)
+    .map(([callingCode]) => callingCode),
+);
 
 export function formatInternationalPhoneNumberForDisplay(
   raw: string,


### PR DESCRIPTION
## What Problem This Solves

Phone-number presentation used by the CLI and Control UI rebuilds calling-code groups from 245 per-country metadata lookups during module initialization, although the dependency already provides those groups.

## Why This Change Was Made

Read the documented, typed `libphonenumber-js/min/metadata` export directly and derive the shared-code set from its groups. This deletes the country-counting Map and wrapper calls, with eight fewer production lines and no test changes. The formatter, parser, country-label rules and raw CLI identifiers are unchanged.

The dependency remains 1.13.12. Its 245 countries, 206 calling-code groups and 12 shared codes produce the same set as the old calculation. Direct inspection of the normal emitted Node and browser code confirms that parsing and group lookup share one metadata binding within each artifact; this does not claim object identity across separate bundles.

## User Impact

No visible formatting changes. This is a smaller implementation and bundle cleanup, not a claim of a general startup or first-format speedup. The relevant browser JavaScript totals 350 fewer raw bytes.

## Evidence

- Original owner tests: 18 passed. Candidate owner, CLI, UI and real Chromium form coverage: 86 passed.
- All 27 normal changed checks passed in one run. Normal baseline UI build and one full candidate build passed. Twelve plain-Node assertions passed against the package and unified runtime exports. Independent code review found no actionable issues.
- Fixed source-level measurement: 48 fresh Node 26.8.1 processes, six display/CLI cases, both ABBA and BAAB orders, 432 retained exact returns. Each child has one timed import and first call, followed by eight untimed correctness controls. Independent audit decoded all return values and recomputed every reported statistic.
- Results are mixed: import group medians improve in 9/12 groups; first-call medians regress in 7/12. The largest import improvement is 16.15% in one order but a 0.21% regression in the reverse order. Shared-code imports improve 1.33%/4.77%; CLI shared-number first calls change by -5.78%/+19.27% (the latter is +0.261 ms). All six direct-phone first-call groups regress. Across all nine timing/resource metrics, 47/108 group means are adverse; complete opposing results are retained.
- There are only two observations per variant/case/order. Mean and median therefore coincide; these are descriptive observations, not confidence intervals, percentile measurements or traffic-weighted benefits. CPU/RSS results do not establish memory savings. Source import/formatter timings are separate from the built-output checks and are not whole Gateway, browser or CLI startup measurements.

Validation and measurements used frozen base `dfd5211a4b4697c1949415a37bd245734ba21955`. The phone owner remains unchanged on inspected current main. Later unrelated package/Vite exports, build entries and status credential handling are not credited to this change. A build admission refusal caused by insufficient disk space was retained; the subsequent ordinary full build passed after cache cleanup, with resource limits unchanged.

The maintainer tradeoff is explicit: retain the small, behavior-preserving simplification and reduced bundle size despite mixed sparse timings. No additional tuning or favorable rerun was used to obtain a speed claim. [Exact-head CI 34066797959](https://github.com/openclaw/openclaw/actions/runs/34066797959) and the required CI gate passed.
