### PR TITLE
refactor(config): remove inert defaults and duplicate Talk predicates

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -23,7 +23,6 @@ import {
   applyProviderConfigDefaultsForConfig,
   normalizeProviderConfigForConfigDefaults,
 } from "./provider-policy.js";
-import { normalizeTalkConfig } from "./talk.js";
 import type { ModelDefinitionConfig } from "./types.models.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
@@ -152,10 +151,6 @@ export function applySessionDefaults(
   }
 
   return next;
-}
-
-export function applyTalkConfigNormalization(config: OpenClawConfig): OpenClawConfig {
-  return normalizeTalkConfig(config);
 }
 
 /** Catalog metadata eligible to fill fields the operator did not author. */
@@ -479,25 +474,17 @@ export function applyAgentDefaults(cfg: OpenClawConfig): OpenClawConfig {
     return cfg;
   }
 
-  let mutated = false;
   const nextDefaults = defaults ? { ...defaults } : {};
   if (!hasMax) {
     nextDefaults.maxConcurrent = resolveAgentMaxConcurrent();
-    mutated = true;
   }
 
   const nextSubagents = defaults?.subagents ? { ...defaults.subagents } : {};
   if (!hasSubMax) {
     nextSubagents.maxConcurrent = DEFAULT_SUBAGENT_MAX_CONCURRENT;
-    mutated = true;
   }
   if (!hasSubArchive) {
     nextSubagents.archiveAfterMinutes = DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES;
-    mutated = true;
-  }
-
-  if (!mutated) {
-    return cfg;
   }
 
   return {
@@ -510,14 +497,6 @@ export function applyAgentDefaults(cfg: OpenClawConfig): OpenClawConfig {
       },
     },
   };
-}
-
-export function applyCronDefaults(cfg: OpenClawConfig): OpenClawConfig {
-  return cfg;
-}
-
-export function applyLoggingDefaults(cfg: OpenClawConfig): OpenClawConfig {
-  return cfg;
 }
 
 function hasAnthropicDefaultSignal(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {

--- a/src/config/materialize.ts
+++ b/src/config/materialize.ts
@@ -4,16 +4,14 @@ import {
   applyCompactionDefaults,
   applyContextPruningDefaults,
   applyAgentDefaults,
-  applyCronDefaults,
-  applyLoggingDefaults,
   applyMessageDefaults,
   applyModelDefaults,
   applySessionDefaults,
-  applyTalkConfigNormalization,
 } from "./defaults.js";
 import { inheritLegacyDefaultAgentId } from "./legacy.default-agent-owner.js";
 import { normalizeExecSafeBinProfilesInConfig } from "./normalize-exec-safe-bin.js";
 import { normalizeConfigPaths } from "./normalize-paths.js";
+import { normalizeTalkConfig } from "./talk.js";
 import type { OpenClawConfig, ResolvedSourceConfig, RuntimeConfig } from "./types.js";
 
 // Snapshot and load must materialize identically: prepared-runtime exact-config
@@ -38,17 +36,15 @@ export function materializeRuntimeConfig(
   } = {},
 ): RuntimeConfig {
   let next = applyMessageDefaults(config);
-  next = applyLoggingDefaults(next);
   next = applySessionDefaults(next);
   next = applyAgentDefaults(next);
-  next = applyCronDefaults(next);
   next = applyContextPruningDefaults(next, options);
   next = applyCompactionDefaults(next);
   next = applyModelDefaults(next, {
     manifestRegistry: options.manifestRegistry,
     loadManifestRegistry: options.loadManifestRegistry,
   });
-  next = applyTalkConfigNormalization(next);
+  next = normalizeTalkConfig(next);
   normalizeConfigPaths(next, options);
   normalizeExecSafeBinProfilesInConfig(next);
   return asRuntimeConfig(inheritLegacyDefaultAgentId(config, next));

--- a/src/config/talk.ts
+++ b/src/config/talk.ts
@@ -1,5 +1,6 @@
 // Normalizes talk-mode config for voice and channel interactions.
 import { findNormalizedProviderKey } from "@openclaw/model-catalog-core/provider-id";
+import { asFiniteNumberInRange } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeFastMode,
@@ -23,20 +24,6 @@ function normalizeTalkSecretInput(value: unknown): TalkProviderConfig["apiKey"] 
     return trimmed.length > 0 ? trimmed : undefined;
   }
   return coerceSecretRef(value) ?? undefined;
-}
-
-function normalizeSilenceTimeoutMs(value: unknown): number | undefined {
-  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
-    return undefined;
-  }
-  return value;
-}
-
-function normalizeVadThreshold(value: unknown): number | undefined {
-  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 1) {
-    return undefined;
-  }
-  return value;
 }
 
 function normalizePositiveInteger(value: unknown): number | undefined {
@@ -140,7 +127,7 @@ function normalizeTalkRealtimeConfig(value: unknown): TalkRealtimeConfig | undef
   ) {
     normalized.transport = source.transport;
   }
-  const vadThreshold = normalizeVadThreshold(source.vadThreshold);
+  const vadThreshold = asFiniteNumberInRange(source.vadThreshold, { min: 0, max: 1 });
   if (vadThreshold !== undefined) {
     normalized.vadThreshold = vadThreshold;
   }
@@ -233,7 +220,7 @@ export function normalizeTalkSection(value: TalkConfig | undefined): TalkConfig 
   if (typeof consultFastMode === "boolean") {
     normalized.consultFastMode = consultFastMode;
   }
-  const silenceTimeoutMs = normalizeSilenceTimeoutMs(source.silenceTimeoutMs);
+  const silenceTimeoutMs = normalizePositiveInteger(source.silenceTimeoutMs);
   if (silenceTimeoutMs !== undefined) {
     normalized.silenceTimeoutMs = silenceTimeoutMs;
   }


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Config materialization still carries no-op stages left after earlier product consolidations, an extra Talk forwarding function, and duplicate numeric predicates. This is the maintainer-requested cleanup lane of the #135868 split campaign; it extracts no feature content from that PR.

## Why This Change Was Made

Call the Talk owner directly at the existing pipeline position, remove the identity stages and unreachable agent-default bookkeeping, and reuse the existing integer and bounded-number readers. The Cron and logging passes became identities in #111382 and #111527; those changes already shipped in v2026.9.2. Repository-wide reference checks find only the materializer callers for the three removed exports, with no package or SDK export contract.

## User Impact

No intended behavior change. Defaults, authored concurrency values, archive time zero, Talk integer acceptance, inclusive VAD bounds, signed zero, non-coercion, and config-load/snapshot ordering remain the same. No settings, migrations, persistent data, or public SDK functions are removed.

## Evidence

- All 83 unchanged tests passed before and after across defaults, concurrency, Talk normalization/validation, best-effort load/snapshot, and canonical number coercion, using `node scripts/run-vitest.mjs`.
- A temporary comparison binds the complete old materializer to the complete old defaults and Talk owners, and compares actual new owners with real shared dependencies: 2,197 default combinations, 192 getter/throw cases, 160 Talk numeric cases, and 19 materializer configurations. Outputs, own keys, reference identity, signed zero, getter order, pipeline order, and 11 existing input-mutation outcomes match. Mutants that skip archive filling, tighten integer acceptance, or reject VAD zero are detected. This is bounded synchronous proof; it makes no live-provider claim.
- Complete `node scripts/check-changed.mjs` plan passed in 383.9 seconds on the rebased candidate, including core and core-test types, lint, zero dead exports and zero runtime import cycles. Clean Linux `pnpm build` passed on the rebased candidate in 197.29 seconds on Blacksmith Testbox (`tbx_01m1wg82gttx0sch288d6c9gpf`, [run 34066510112](https://github.com/openclaw/openclaw/actions/runs/34066510112)); 24 owner/dependency/build input hashes and tracked status were unchanged.
- Independent Codex local and committed-branch reviews: no actionable P0–P2 findings.

Production: +5/−43, net −38. Tests, tooling, docs, and baselines unchanged. Physical owner lines: defaults 593→572; materialize 55→51; Talk 338→325.

ClawSweeper reviewed the first published head and found no correctness or security findings and no before-merge requests. No rank-up changes were requested. The landing refresh rebases the same three-file patch onto newer main; the 24 recorded inputs remain unchanged. Full changed checks/build above ran before this final unrelated main refresh; focused tests and independent review are repeated and exact-head CI is required for the final head.

Final exact-head CI [34067363800](https://github.com/openclaw/openclaw/actions/runs/34067363800) passed on `debecdc0676b72221deb9f3d9f9946509781ad5a`: 107 successful jobs, 17 expected skips. The canonical watcher returned GREEN; a cancelled superseded ClawSweeper dispatch explained the raw rollup failure. No test retry or source repair was needed.
