### PR TITLE
refactor(plugin-sdk): consolidate provider preset construction

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3289,7 +3289,7 @@ src/plugin-sdk/provider-auth.ts	1
 src/plugin-sdk/provider-catalog-shared.ts	1
 src/plugin-sdk/provider-enable-config.ts	2
 src/plugin-sdk/provider-entry.ts	3
-src/plugin-sdk/provider-onboard.ts	6
+src/plugin-sdk/provider-onboard.ts	5
 src/plugin-sdk/provider-stream-shared.ts	14
 src/plugin-sdk/provider-stream.ts	1
 src/plugin-sdk/provider-tools.ts	10

--- a/src/plugin-sdk/provider-onboard.ts
+++ b/src/plugin-sdk/provider-onboard.ts
@@ -171,27 +171,6 @@ function resolveProviderModelMergeState(
   };
 }
 
-function buildProviderConfig(params: {
-  existingProvider: ModelProviderConfig | undefined;
-  api: ModelApi;
-  baseUrl: string;
-  mergedModels: ModelDefinitionConfig[];
-  fallbackModels: ModelDefinitionConfig[];
-}): ModelProviderConfig {
-  const { apiKey: existingApiKey, ...existingProviderRest } = (params.existingProvider ?? {}) as {
-    apiKey?: string;
-  };
-  const normalizedApiKey = typeof existingApiKey === "string" ? existingApiKey.trim() : undefined;
-
-  return {
-    ...existingProviderRest,
-    baseUrl: params.baseUrl,
-    api: params.api,
-    ...(normalizedApiKey ? { apiKey: normalizedApiKey } : {}),
-    models: params.mergedModels.length > 0 ? params.mergedModels : params.fallbackModels,
-  };
-}
-
 function applyProviderConfigWithMergedModels(
   cfg: OpenClawConfig,
   params: {
@@ -201,18 +180,19 @@ function applyProviderConfigWithMergedModels(
     api: ModelApi;
     baseUrl: string;
     mergedModels: ModelDefinitionConfig[];
-    fallbackModels: ModelDefinitionConfig[];
   },
 ): OpenClawConfig {
   const mergedModels = normalizeProviderModelsForConfig(params.providerId, params.mergedModels);
-  const fallbackModels = normalizeProviderModelsForConfig(params.providerId, params.fallbackModels);
-  params.providerState.providers[params.providerId] = buildProviderConfig({
-    existingProvider: params.providerState.existingProvider,
-    api: params.api,
+  const { apiKey: existingApiKey, ...existingProviderRest } =
+    params.providerState.existingProvider ?? {};
+  const normalizedApiKey = typeof existingApiKey === "string" ? existingApiKey.trim() : undefined;
+  params.providerState.providers[params.providerId] = {
+    ...existingProviderRest,
     baseUrl: params.baseUrl,
-    mergedModels,
-    fallbackModels,
-  });
+    api: params.api,
+    ...(normalizedApiKey ? { apiKey: normalizedApiKey } : {}),
+    models: mergedModels,
+  };
   return applyOnboardAuthAgentModelsAndProviders(cfg, {
     agentModels: params.agentModels,
     providers: params.providerState.providers,
@@ -487,7 +467,6 @@ export function applyProviderConfigWithDefaultModels(
     api: params.api,
     baseUrl: params.baseUrl,
     mergedModels,
-    fallbackModels: defaultModels,
   });
 }
 
@@ -526,19 +505,15 @@ export function applyProviderConfigWithDefaultModelPreset(
     primaryModelRef?: string;
   },
 ): OpenClawConfig {
-  const next = applyProviderConfigWithDefaultModel(cfg, {
-    agentModels: withAgentModelAliases(cfg.agents?.defaults?.models, params.aliases ?? []),
+  return applyProviderConfigWithDefaultModelsPreset(cfg, {
     providerId: params.providerId,
     api: params.api,
     baseUrl: params.baseUrl,
-    defaultModel: params.defaultModel,
+    defaultModels: [params.defaultModel],
     defaultModelId: params.defaultModelId,
+    aliases: params.aliases,
+    primaryModelRef: params.primaryModelRef,
   });
-  return params.primaryModelRef
-    ? hasAgentDefaultModelPrimary(cfg)
-      ? next
-      : applyAgentDefaultModelPrimary(next, params.primaryModelRef)
-    : next;
 }
 
 /** Build setup appliers for presets that resolve to one default provider model. */
@@ -634,7 +609,6 @@ export function applyProviderConfigWithModelCatalog(
     api: params.api,
     baseUrl: params.baseUrl,
     mergedModels,
-    fallbackModels: catalogModels,
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Provider onboarding repeats the same preset policy and passes merged model data through a one-use constructor and redundant fallback list. Those parallel paths add maintenance work without owning different supported behavior.

## Why This Change Was Made

Keep every stable SDK entrypoint and signature. The single-model preset delegates explicit fields to the existing multi-model preset. The private merged-model owner now constructs its provider block directly, preserving normalization before API-key trimming/omission and the existing provider merge.

Both private callers already produce an empty merged list only when their default/catalog list is empty; normalization never empties a nonempty valid list. The fallback list therefore cannot change the selected models. `buildProviderConfig` had one private caller. These bodies and public signatures were checked against stable `v2026.9.2`; no public export is removed. Alias-only onboarding and the required catalog normalization remain unchanged. Follow-up deletion work for #135868. Production +13/−39, net −26; tests/docs unchanged; the assertion-safety count is tightened from 6 to 5 after removing the obsolete cast (tooling net 0).

## User Impact

No intended behavior change. Existing models, aliases, provider settings, API-key handling, and an already-selected primary model retain their current precedence.

## Evidence

- 936 unique before/after SDK scenarios produced byte-identical results, including reference flags; every call preserved its input configuration.
- 31 tests passed across the SDK owner, onboarding config merges, LiteLLM, and Mistral.
- Existing tests cover missing-model append, provider settings/auth clearing, canonical keys, retired model normalization, catalog deduplication, aliases, and existing-primary preservation. No tests removed or added.
- Independent Codex review: scoped-clean through P2.
- Clean `pnpm build` passed on Testbox `tbx_01m1wf8zj45tkxg6eyp2wtw6z5` ([build run](https://github.com/openclaw/openclaw/actions/runs/34065675533)). The initial gate required the exact assertion-count reduction after the obsolete cast was removed. After that tooling-only correction, full `node scripts/check-changed.mjs --base origin/main` and all 31 focused tests passed on `tbx_01m1wfv3es3m7wggwctwcrzf7z` ([gate run](https://github.com/openclaw/openclaw/actions/runs/34066170218)), exit 0. Both leases stopped. Clean proof avoids the established ancestor-install punycode boundary; no parent install or guard was weakened.
- ClawSweeper reviewed exact head `4e9b1e839138d7d9e89e2c82aad35ff619897859`: no findings, security concerns, or requested rank-up changes. Maintainer source review agrees.
