### PR TITLE
refactor(update): reuse sealed SQLite admission helpers

### DIFF
--- a/src/infra/update-managed-service-handoff-sealed.ts
+++ b/src/infra/update-managed-service-handoff-sealed.ts
@@ -1,3 +1,5 @@
 import "./sealed-runtime-bootstrap.js";
 
+export { assertOpenClawStateWriteAllowed } from "../state/openclaw-state-ownership.js";
+export { resolveImmutableSqliteFileUri } from "./node-sqlite.js";
 export { createManagedHandoffLeaseStore } from "./update-managed-service-handoff-lease.js";

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -111,7 +111,8 @@ function appendLog(line) {
   }
 }
 
-const { createManagedHandoffLeaseStore } = require("./runtime/${MANAGED_HANDOFF_RUNTIME_ENTRY}");
+const { assertOpenClawStateWriteAllowed, createManagedHandoffLeaseStore, resolveImmutableSqliteFileUri } =
+  require("./runtime/${MANAGED_HANDOFF_RUNTIME_ENTRY}");
 const leaseStore = createManagedHandoffLeaseStore({
   databasePath: params.updateLeaseDatabasePath,
   serviceManagerEnv: params.serviceManagerEnv,
@@ -176,16 +177,6 @@ function cleanupSensitiveFiles() {
 }
 
 
-// Keep this self-contained helper aligned with resolveImmutableSqliteFileUri;
-// the detached script cannot import the TypeScript runtime after replacement.
-function resolveImmutableStateDatabaseUri(databasePath) {
-  if (process.platform === "win32") {
-    const namespacedPath = path.toNamespacedPath(path.resolve(databasePath));
-    return "file:" + encodeURIComponent(namespacedPath) + "?mode=ro&immutable=1";
-  }
-  return pathToFileURL(path.resolve(databasePath)).href + "?mode=ro&immutable=1";
-}
-
 function assertStateDatabaseWriteAllowed(database) {
   if (
     !params.stateDatabasePath ||
@@ -198,7 +189,7 @@ function assertStateDatabaseWriteAllowed(database) {
   let db = database;
   if (!db) {
     const sqlite = require("node:sqlite");
-    db = new sqlite.DatabaseSync(resolveImmutableStateDatabaseUri(params.stateDatabasePath), {
+    db = new sqlite.DatabaseSync(resolveImmutableSqliteFileUri(params.stateDatabasePath), {
       readOnly: true,
     });
   }
@@ -206,40 +197,7 @@ function assertStateDatabaseWriteAllowed(database) {
     if (ownsDatabase) {
       db.exec("PRAGMA query_only = ON; PRAGMA trusted_schema = OFF;");
     }
-    const table = db
-      .prepare(
-        "SELECT 1 FROM main.sqlite_schema WHERE type = 'table' AND name = 'config_machine_state' LIMIT 1",
-      )
-      .get();
-    if (!table) return;
-    const row = db
-      .prepare(
-        "SELECT value_json FROM config_machine_state WHERE state_key = 'gateway.supervision' LIMIT 1",
-      )
-      .get();
-    if (!row) return;
-    const value = parseJsonColumn(row.value_json);
-    const keys =
-      value && typeof value === "object" && !Array.isArray(value) ? Object.keys(value).sort() : [];
-    if (
-      keys.join(",") !== "claimedAt,managerId,mode,version" ||
-      value.version !== 1 ||
-      value.mode !== "external" ||
-      typeof value.managerId !== "string" ||
-      !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(value.managerId) ||
-      !Number.isSafeInteger(value.claimedAt) ||
-      value.claimedAt < 0 ||
-      value.claimedAt > 8640000000000000
-    ) {
-      throw new Error("shared-state ownership metadata is malformed");
-    }
-    if ((process.env.OPENCLAW_SUPERVISOR_MODE || "").trim().toLowerCase() !== "external") {
-      throw new Error(
-        "shared state is externally supervised by " +
-          value.managerId +
-          "; use that external supervisor with OPENCLAW_SUPERVISOR_MODE=external",
-      );
-    }
+    assertOpenClawStateWriteAllowed({ database: db, databasePath: params.stateDatabasePath });
   } finally {
     if (ownsDatabase) {
       db.close();


### PR DESCRIPTION
## What Problem This Solves

The detached update helper duplicated the runtime's SQLite URI encoding and external-state ownership rules. Keeping those copies aligned made changes to shared-state write admission harder to maintain.

## Why This Change Was Made

The helper now uses the canonical URI and ownership helpers from its existing sealed runtime bundle. It still performs an immutable pre-open inspection and rechecks ownership after acquiring the write lock. The bundle is copied before package replacement, so the helper does not depend on the original installation remaining available.

Related: #135868. This is a production-deletion follow-up to the completed recovery split.

## User Impact

No intended behavior change. External ownership and malformed ownership metadata still refuse writes, and the existing external-supervisor marker retains its meaning. Refusals use the canonical runtime's diagnostic wording.

Production: **−40 lines** (+6/−46). Tests: **0 lines changed**. No new schema, store, dependency, configuration option, or test-only runtime seam.

## Evidence

- Focused handoff ownership, cross-process, lifecycle and SQLite suites: **219 passed, 2 existing skips**.
- Copied sealed bundle under a macOS filesystem sandbox denying the entire repository: **6 checks passed**. It verifies that repository reads actually fail, unclaimed state is readable, external and malformed ownership are refused, explicit external supervision is accepted, and Windows long-path URI encoding survives. Immutable checks preserve database bytes and modification time.
- Real-process suites separately protect ownership changes while waiting for the write lock and finalization after the updater replaces its module graph. The relocation probe is focused component proof, not a full installed updater run.
- The sealed output remains one `.mjs` file; size changes from 941,270 to 947,820 bytes (+6,550, about 0.7%).
- Fresh independent review: no actionable P0–P2 findings.
- Complete `node scripts/check-changed.mjs` plan passed, including core/core-test types, full-tree dead exports, lint, schema guard, and zero runtime import cycles.
- `pnpm build` passed; the final sealed artifact hash matches the copied artifact used in relocation proof.

Validated source head: `1e664044e5f66a8b82db78f99317c546d8957f65`. The pre-push rebase changed neither these source blobs nor the canonical ownership/SQLite/build contracts or lockfile.

Landed as [a880e83d1e1388eea0c87603d2d6cfe7aca64230](https://github.com/openclaw/openclaw/commit/a880e83d1e1388eea0c87603d2d6cfe7aca64230). Exact-head [CI](https://github.com/openclaw/openclaw/actions/runs/34067262436) passed, native review/preparation completed, and a fresh fetch plus Git ancestry verification confirmed the merge on main. As merged: **-40 production lines, zero test growth**.
