### PR TITLE
refactor(channels): reuse normalized allowlist results

### DIFF
--- a/src/channels/message-access/effective-allow-from.ts
+++ b/src/channels/message-access/effective-allow-from.ts
@@ -1,4 +1,3 @@
-import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { mergeDmAllowFromSources, resolveGroupAllowFromSources } from "../allow-from.js";
 
 /**
@@ -18,19 +17,15 @@ export function resolveChannelIngressEffectiveAllowFromLists(params: {
   const allowFrom = Array.isArray(params.allowFrom) ? params.allowFrom : undefined;
   const groupAllowFrom = Array.isArray(params.groupAllowFrom) ? params.groupAllowFrom : undefined;
   const storeAllowFrom = Array.isArray(params.storeAllowFrom) ? params.storeAllowFrom : undefined;
-  const effectiveAllowFrom = normalizeStringEntries(
-    mergeDmAllowFromSources({
-      allowFrom,
-      storeAllowFrom,
-      dmPolicy: params.dmPolicy ?? undefined,
-    }),
-  );
-  const effectiveGroupAllowFrom = normalizeStringEntries(
-    resolveGroupAllowFromSources({
-      allowFrom,
-      groupAllowFrom,
-      fallbackToAllowFrom: params.groupAllowFromFallbackToAllowFrom ?? undefined,
-    }),
-  );
+  const effectiveAllowFrom = mergeDmAllowFromSources({
+    allowFrom,
+    storeAllowFrom,
+    dmPolicy: params.dmPolicy ?? undefined,
+  });
+  const effectiveGroupAllowFrom = resolveGroupAllowFromSources({
+    allowFrom,
+    groupAllowFrom,
+    fallbackToAllowFrom: params.groupAllowFromFallbackToAllowFrom ?? undefined,
+  });
   return { effectiveAllowFrom, effectiveGroupAllowFrom };
 }


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Channel message ingress normalizes effective DM and group allowlists a second time after their canonical source helpers already normalized them. The helper is used for the base, raw, and command-group ingress views. This is the small production follow-up to #140510 in the #135868 campaign's channel neighborhood.

## Why This Change Was Made

Return the two canonical helpers' results directly. Both helpers always return freshly allocated, normalized string arrays; the outer coercion/trim/filter pass adds no information. Raw-list selection, pairing-store policy, group fallback, and output isolation remain unchanged.

## User Impact

Production shrinks by 5 lines (+10/−15), removing two unnecessary normalization passes per helper call. Tests, tooling, docs, configuration, dependencies and public interfaces are unchanged.

## Evidence

| Deleted implementation | Preserved owner and coverage |
| --- | --- |
| Outer DM allowlist normalization | `src/channels/allow-from.ts:28` already normalizes the merged configured/pairing-store entries. `src/channels/allow-from.test.ts:11,20` retains coercion, trimming, empty-entry filtering and DM-policy-specific store handling. |
| Outer group allowlist normalization | `src/channels/allow-from.ts:43` selects the raw explicit/fallback list before normalizing it. `src/channels/allow-from.test.ts:45,54,63` retains group preference/fallback behavior; the message-access suite retains ingress decision and identity boundaries. |
| Redundant direct normalization import | Both producer helpers still own that dependency, so the import closure and exported API are unchanged. The private helper's three runtime callers remain unchanged (`src/channels/message-access/runtime.ts:597,604,611`). |

The source normalizer coerces to strings, trims, drops empty entries, and creates new arrays. Its output is idempotent under the removed second pass. Both producers return new arrays on every path, so removing the extra copies does not expose input arrays or alias DM and group outputs. No SDK or static-analysis owner reference requires the redundant calls. History retains the same producer normalization; no compatibility purpose was found for repeating it.

The full message-access directory plus the allow-from suite passed before and after: 81 cases in 7 files, 1.434 s → 1.399 s aggregate. A temporary differential compared 8,232 outcomes across nullable/missing/empty/numeric/whitespace lists, DM policies and group fallbacks; values matched and all output-array ownership checks passed. Independent pinned-candidate review is scoped-clean through P2. Full changed checks passed, including core/core-test types, lint, all three dead-export scans and selected guards. [Exact-head CI run 34067514660](https://github.com/openclaw/openclaw/actions/runs/34067514660) passed on `673f4ac36ac5139b1bb1cd736cd05b27b8ffd791`. ClawSweeper reviewed that head with no findings or before-merge/rank-up requests.
