### PR TITLE
refactor(daemon): simplify LaunchAgent policy branches

### DIFF
--- a/src/daemon/launchd-runtime.ts
+++ b/src/daemon/launchd-runtime.ts
@@ -75,22 +75,11 @@ export async function resolveLaunchAgentGatewayContext(env: GatewayServiceEnv): 
     return { port: null, probeHosts: [] };
   }
   const command = await readLaunchAgentProgramArguments(env).catch(() => null);
-  const fromArgs = parseTcpPortFromArgs(command?.programArguments);
-  if (fromArgs !== null) {
-    return {
-      port: fromArgs,
-      probeHosts: await resolveGatewayServiceProbeHosts({ env, command }),
-    };
-  }
-  const fromServiceEnv = parseTcpPort(command?.environment?.OPENCLAW_GATEWAY_PORT ?? "");
-  if (fromServiceEnv !== null) {
-    return {
-      port: fromServiceEnv,
-      probeHosts: await resolveGatewayServiceProbeHosts({ env, command }),
-    };
-  }
   return {
-    port: parseTcpPort(env.OPENCLAW_GATEWAY_PORT ?? ""),
+    port:
+      parseTcpPortFromArgs(command?.programArguments) ??
+      parseTcpPort(command?.environment?.OPENCLAW_GATEWAY_PORT ?? "") ??
+      parseTcpPort(env.OPENCLAW_GATEWAY_PORT ?? ""),
     probeHosts: await resolveGatewayServiceProbeHosts({ env, command }),
   };
 }
@@ -100,14 +89,6 @@ export function resolveLaunchAgentGuiDomain(): string {
     return "gui/501";
   }
   return `gui/${process.getuid()}`;
-}
-
-function throwBootstrapGuiSessionError(params: {
-  detail: string;
-  domain: string;
-  actionHint: string;
-}) {
-  throw new Error(formatLaunchAgentGuiSessionError(params));
 }
 
 export function formatLaunchAgentGuiSessionError(params: {
@@ -154,11 +135,13 @@ export async function bootstrapLaunchAgentOrThrow(params: {
     }
     const detail = (boot.stderr || boot.stdout).trim();
     if (isUnsupportedGuiDomain(detail)) {
-      throwBootstrapGuiSessionError({
-        detail,
-        domain: params.domain,
-        actionHint: params.actionHint,
-      });
+      throw new Error(
+        formatLaunchAgentGuiSessionError({
+          detail,
+          domain: params.domain,
+          actionHint: params.actionHint,
+        }),
+      );
     }
     if (boot.termination === "exit" && isLaunchctlOperationAlreadyInProgress(detail)) {
       const state = await probeLaunchAgentState(params.serviceTarget);

--- a/src/daemon/service-env-render-policy.ts
+++ b/src/daemon/service-env-render-policy.ts
@@ -7,16 +7,6 @@ import {
 } from "./service-managed-env.js";
 import type { GatewayServiceEnvironmentValueSource } from "./service-types.js";
 
-function isLaunchAgentServiceEnvironment(params: {
-  platform: NodeJS.Platform;
-  serviceEnvironment: Record<string, string | undefined>;
-}): boolean {
-  return (
-    params.platform === "darwin" &&
-    Boolean(params.serviceEnvironment.OPENCLAW_LAUNCHD_LABEL?.trim())
-  );
-}
-
 function addManagedServiceEnvEntries(params: {
   plan: MutableServiceEnvPlan;
   entries: Record<string, string | undefined>;
@@ -45,7 +35,9 @@ export function applyManagedServiceEnvRenderPolicy(params: {
   stateDirDotEnvEnvironment: Record<string, string | undefined>;
   configSecretRefEnvironment: Record<string, string | undefined>;
 }): void {
-  const launchAgent = isLaunchAgentServiceEnvironment(params);
+  const launchAgent =
+    params.platform === "darwin" &&
+    Boolean(params.serviceEnvironment.OPENCLAW_LAUNCHD_LABEL?.trim());
   writeManagedServiceEnvKeysToEnvironment(params.plan.environment, params.managedServiceEnvKeys);
   if (params.plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS) {
     params.plan.environmentValueSources.OPENCLAW_SERVICE_MANAGED_ENV_KEYS = "inline";


### PR DESCRIPTION
## What Problem This Solves

LaunchAgent handling repeated the same gateway probe result across port-selection branches and kept two private wrappers with one caller each. This removes that duplication while retaining the existing policy owners.

## Why This Change Was Made

Port resolution now has one return path with the same precedence: command arguments, stored service environment, then caller environment. The single-use environment predicate and GUI-error throwing wrapper are inlined; the canonical error formatter remains.

Related: #135868. This is a separate production-deletion follow-up in the native-service neighborhood.

## User Impact

No intended behavior change. Invalid ports still fall through, non-Gateway services still avoid probing, LaunchAgent environment/SecretRef precedence is unchanged, and unsupported GUI sessions retain the same actionable error message.

Production: **−25 lines** (+14/−39). Tests: **0 lines changed**. No config, dependency, public API, or native-supervisor policy change.

## Evidence

- Existing LaunchAgent, daemon install-plan and TCP port suites: **263 tests passed across three files**. These use isolated mocked native boundaries and do not operate the user's LaunchAgent.
- Complete `node scripts/check-changed.mjs` plan passed, including core/core-test types, all dead-export scans, lint and zero runtime import cycles.
- Formatting and `git diff --check` passed.
- Fresh independent review: no actionable P0–P2 findings.
- No build or lazy-loading boundary changed; no additional packaging proof was required.

Validated source head: `910ff43091e1d6845e4c02978c8291f9552350c3`. The pre-push rebase changed no touched file, parser/environment owner, or lockfile.

Landed as [fef4b9675363387544c3cd68de974b20d1778dbf](https://github.com/openclaw/openclaw/commit/fef4b9675363387544c3cd68de974b20d1778dbf). Exact-head [CI](https://github.com/openclaw/openclaw/actions/runs/34067724959) passed, native review/preparation completed, and a fresh fetch plus Git ancestry verification confirmed the merge on main. As merged: **-25 production lines, zero test growth**.
