### PR TITLE
fix(ui): align mobile chat messages with the composer

### DIFF
--- a/ui/src/e2e/chat-attributed-identity.e2e.test.ts
+++ b/ui/src/e2e/chat-attributed-identity.e2e.test.ts
@@ -3,7 +3,11 @@ import { expect, type Locator, type Page } from "playwright/test";
 import { beforeEach, it } from "vitest";
 // Control UI E2E tests cover attributed chat identity placement.
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
-import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import {
+  controlUiBundledSettingsStorageKey,
+  controlUiSessionUrl,
+  installMockGateway,
+} from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -68,6 +72,63 @@ function expectStableNamePosition(
 }
 
 suite.define(() => {
+  it.each(["none", "min-content", "max-content", "48rem", "82%", "min(768px, 82%)"])(
+    "keeps restored message width %s inside the mobile safe area",
+    async (messageWidth) => {
+      await suite.withPage({ viewport: { width: 932, height: 430 } }, async ({ page, context }) => {
+        const protocol = await context.newCDPSession(page);
+        await protocol.send("Emulation.setSafeAreaInsetsOverride", {
+          insets: { left: 44, right: 0, top: 0, bottom: 0 },
+        });
+        await installMockGateway(page, {
+          presenceUsers: [
+            {
+              self: true,
+              id: "profile-morgan",
+              identity: { type: "profile", id: "profile-morgan" },
+              name: "Morgan",
+            },
+          ],
+          historyMessages: [
+            { role: "assistant", content: "Keep the restored reading column clear of the notch." },
+          ],
+        });
+        await page.goto(`${suite.server.baseUrl}settings/appearance#settings-appearance-chat`);
+        const widthInput = page.locator("[data-settings-chat-message-width]");
+        await widthInput.fill(messageWidth);
+        await widthInput.press("Tab");
+        await expect
+          .poll(() =>
+            page.evaluate(
+              (key) => JSON.parse(localStorage.getItem(key) ?? "{}").chatMessageMaxWidth,
+              controlUiBundledSettingsStorageKey(suite.server.baseUrl),
+            ),
+          )
+          .toBe(messageWidth);
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:main"));
+        const transcript = page.locator(".chat-thread-inner");
+        await transcript
+          .getByText("Keep the restored reading column clear of the notch.")
+          .waitFor({ state: "attached" });
+        for (const direction of ["ltr", "rtl"]) {
+          await page.evaluate((dir) => {
+            document.documentElement.dir = dir;
+          }, direction);
+          await captureProof(page, `restored-width-${direction}.png`);
+          for (const frame of [transcript, page.locator(".agent-chat__composer-shell")]) {
+            const bounds = await frame.evaluate((element) => {
+              const rect = element.getBoundingClientRect();
+              return { left: rect.left, right: rect.right };
+            });
+            expect(bounds.left).toBeGreaterThanOrEqual(48);
+            expect(bounds.right).toBeLessThanOrEqual(924);
+            expect(bounds.left - 48).toBeCloseTo(924 - bounds.right, 0);
+          }
+        }
+      });
+    },
+  );
+
   it.each([
     { width: 320, height: 860, profiled: true, safeAreaLeft: 0 },
     { width: 328, height: 860, profiled: true, safeAreaLeft: 0 },

--- a/ui/src/e2e/chat-attributed-identity.e2e.test.ts
+++ b/ui/src/e2e/chat-attributed-identity.e2e.test.ts
@@ -68,6 +68,146 @@ function expectStableNamePosition(
 }
 
 suite.define(() => {
+  it.each([
+    { width: 390, height: 860, profiled: true, safeAreaLeft: 0 },
+    { width: 430, height: 860, profiled: true, safeAreaLeft: 0 },
+    { width: 932, height: 430, profiled: true, safeAreaLeft: 0 },
+    { width: 800, height: 430, profiled: true, safeAreaLeft: 44 },
+    { width: 390, height: 860, profiled: false, safeAreaLeft: 0 },
+    { width: 430, height: 860, profiled: false, safeAreaLeft: 0 },
+    { width: 932, height: 430, profiled: false, safeAreaLeft: 0 },
+    { width: 800, height: 430, profiled: false, safeAreaLeft: 44 },
+  ])(
+    "keeps attributed mobile content in one usable column at $width px (profile: $profiled)",
+    async ({ width, height, profiled, safeAreaLeft }) => {
+      await suite.withPage(
+        { viewport: { width, height }, hasTouch: true },
+        async ({ page, context }) => {
+          const protocol = await context.newCDPSession(page);
+          await protocol.send("Emulation.setSafeAreaInsetsOverride", {
+            insets: { left: safeAreaLeft, right: 0, top: 0, bottom: 0 },
+          });
+          const sessionKey = "agent:main:main";
+          const identity = { type: "profile" as const, id: "profile-morgan" };
+          const gateway = await installMockGateway(page, {
+            presenceUsers: profiled
+              ? [{ self: true, id: identity.id, identity, name: "Morgan" }]
+              : [],
+            historyMessages: [
+              {
+                role: "user",
+                content: "Keep the phone transcript readable.",
+                timestamp: Date.now() - 20_000,
+                __openclaw: {
+                  senderId: identity.id,
+                  senderIdentity: identity,
+                  senderName: "Morgan",
+                },
+              },
+              {
+                role: "assistant",
+                content:
+                  "The response uses the available transcript width.\n\n```ts\nconsole.log('readable code');\n```",
+                timestamp: Date.now() - 10_000,
+              },
+            ],
+          });
+          await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+          const transcript = page.locator(".chat-thread-inner");
+          await transcript.getByText("The response uses the available transcript width.").waitFor();
+          const expectColumn = async (content: Locator) => {
+            const frame = await transcript.boundingBox();
+            const bounds = await content.boundingBox();
+            expect(frame).not.toBeNull();
+            expect(bounds).not.toBeNull();
+            expect(bounds!.x).toBeCloseTo(frame!.x, 0);
+            expect(bounds!.width).toBeCloseTo(frame!.width, 0);
+          };
+          for (const direction of ["ltr", "rtl"]) {
+            await page.evaluate((dir) => {
+              document.documentElement.dir = dir;
+            }, direction);
+            await expectColumn(page.locator(".agent-chat__composer-shell"));
+            const frame = await transcript.boundingBox();
+            expect(frame!.x - Math.max(4, safeAreaLeft)).toBeCloseTo(
+              width - 4 - frame!.x - frame!.width,
+              0,
+            );
+            await expectColumn(page.locator(".chat-group.assistant > .chat-group-messages"));
+            await expect(page.locator(".chat-group .chat-avatar:visible")).toHaveCount(0);
+          }
+          await page
+            .locator(".agent-chat__composer-combobox textarea")
+            .fill("Read the example file.");
+          await page.getByRole("button", { name: "Send message" }).click();
+          const request = await gateway.waitForRequest("chat.send");
+          const params = request.params;
+          if (
+            !params ||
+            typeof params !== "object" ||
+            !("idempotencyKey" in params) ||
+            typeof params.idempotencyKey !== "string"
+          ) {
+            throw new Error("Expected the chat.send run ID");
+          }
+          const runId = params.idempotencyKey;
+          await page.locator(".chat-working-indicator").waitFor();
+          const working = page.locator(".chat-group--working > .chat-group-messages");
+          await expectColumn(working);
+          await expect(working).toHaveCSS("padding-inline-start", "0px");
+          await gateway.emitGatewayEvent("agent", {
+            runId,
+            sessionKey,
+            stream: "tool",
+            seq: 1,
+            ts: Date.now(),
+            data: {
+              name: "read",
+              phase: "start",
+              toolCallId: "mobile-read",
+              args: { path: "example.txt" },
+            },
+          });
+          const tool = page.locator('[data-message-id^="tool:assistant:mobile-read"]');
+          await tool.waitFor();
+          await expectColumn(page.locator(".chat-group.assistant > .chat-group-messages").last());
+          await gateway.emitChatFinal({ runId, text: "The example file is readable." });
+          await transcript.getByText("The example file is readable.").waitFor();
+          await gateway.emitGatewayEvent("session.message", {
+            sessionKey,
+            messageId: "mobile-peer-message",
+            messageSeq: 5,
+            message: {
+              role: "user",
+              content: "Riley joined this conversation.",
+              timestamp: Date.now(),
+              __openclaw: {
+                senderId: "profile-riley",
+                senderIdentity: { type: "profile", id: "profile-riley" },
+                senderName: "Riley",
+              },
+            },
+          });
+          const peer = page.locator(".chat-group--peer", {
+            hasText: "Riley joined this conversation.",
+          });
+          await expect(peer.locator(".chat-sender-name")).toHaveText("Riley");
+          await expect(peer.locator(".chat-group-footer")).toHaveCSS("opacity", "1");
+          if (height === 430) {
+            const thread = page.locator(".chat-thread");
+            await thread.focus();
+            await thread.press("Home");
+            await thread.press("End");
+            await expect
+              .poll(() => thread.evaluate((element) => element.scrollTop))
+              .toBeGreaterThan(0);
+            await expectColumn(page.locator(".agent-chat__composer-shell"));
+          }
+        },
+      );
+    },
+  );
+
   it("uses one avatar placement and keeps shared-thread authors readable", async () => {
     const artifactDir = proofArtifactDir;
     const context = await suite.browser.newContext({

--- a/ui/src/e2e/chat-attributed-identity.e2e.test.ts
+++ b/ui/src/e2e/chat-attributed-identity.e2e.test.ts
@@ -69,11 +69,15 @@ function expectStableNamePosition(
 
 suite.define(() => {
   it.each([
+    { width: 320, height: 860, profiled: true, safeAreaLeft: 0 },
+    { width: 328, height: 860, profiled: true, safeAreaLeft: 0 },
     { width: 390, height: 860, profiled: true, safeAreaLeft: 0 },
     { width: 430, height: 860, profiled: true, safeAreaLeft: 0 },
     { width: 932, height: 430, profiled: true, safeAreaLeft: 0 },
     { width: 800, height: 430, profiled: true, safeAreaLeft: 44 },
     { width: 390, height: 860, profiled: false, safeAreaLeft: 0 },
+    { width: 320, height: 860, profiled: false, safeAreaLeft: 0 },
+    { width: 328, height: 860, profiled: false, safeAreaLeft: 0 },
     { width: 430, height: 860, profiled: false, safeAreaLeft: 0 },
     { width: 932, height: 430, profiled: false, safeAreaLeft: 0 },
     { width: 800, height: 430, profiled: false, safeAreaLeft: 44 },

--- a/ui/src/e2e/native-plugin-ui.e2e.test.ts
+++ b/ui/src/e2e/native-plugin-ui.e2e.test.ts
@@ -602,9 +602,7 @@ suite.define(() => {
                 background: style.backgroundImage,
                 left: shellBounds.left + Number.parseFloat(style.left) - threadBounds.left,
                 right: threadBounds.right - (shellBounds.right - Number.parseFloat(style.right)),
-                scrollbar: Number.parseFloat(
-                  getComputedStyle(document.documentElement).getPropertyValue("--scrollbar-size"),
-                ),
+                scrollbar: (threadBounds.width - thread.clientWidth) / 2,
               };
             });
             const description = `${replacement || "Built-in"} at ${width}px`;

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1792,9 +1792,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         </body></html>`,
       );
       const avatar = page.locator(".chat-avatar");
-      for (const width of [430, 400, 390, 320, 401, 1366]) {
+      for (const width of [430, 400, 390, 320, 401, 768, 769, 1366]) {
         await page.setViewportSize({ width, height: 720 });
-        if (width <= 400) {
+        if (width <= 768) {
           await expectBrowser(avatar).toBeHidden();
         } else {
           await expectBrowser(avatar).toBeVisible();
@@ -2076,9 +2076,8 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             const composer = document
               .querySelector<HTMLElement>(".agent-chat__composer-shell")!
               .getBoundingClientRect();
-            const thread = document
-              .querySelector<HTMLElement>(".chat-thread")!
-              .getBoundingClientRect();
+            const threadElement = document.querySelector<HTMLElement>(".chat-thread")!;
+            const thread = threadElement.getBoundingClientRect();
             const fade = getComputedStyle(
               document.querySelector<HTMLElement>(".agent-chat__composer-shell")!,
               "::before",
@@ -2088,9 +2087,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
               conversation: rect(".chat-main__conversation"),
               fadeInsetLeft: composer.left + Number.parseFloat(fade.left) - thread.left,
               fadeInsetRight: thread.right - (composer.right - Number.parseFloat(fade.right)),
-              scrollbarSize: Number.parseFloat(
-                getComputedStyle(document.documentElement).getPropertyValue("--scrollbar-size"),
-              ),
+              scrollbarSize: (thread.width - threadElement.clientWidth) / 2,
               thread: rect(".chat-thread"),
             };
           });
@@ -3235,13 +3232,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       const page = await openFixture(width, height);
       try {
         const roles = await page.evaluate(() => {
-          const transcriptViewport = document.querySelector<HTMLElement>(".chat-thread")!;
-          const widthProbe = document.createElement("div");
-          widthProbe.style.width = "100%";
-          widthProbe.style.height = "0";
-          transcriptViewport.append(widthProbe);
-          const transcriptAvailableWidth = widthProbe.getBoundingClientRect().width;
-          widthProbe.remove();
           const rectFor = (selector: string) => {
             const node = document.querySelector(selector) as HTMLElement | null;
             if (!node) {
@@ -3260,7 +3250,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             assistantBubble: rectFor(".chat-group.assistant .chat-bubble:first-child"),
             transcript: rectFor(".chat-thread-inner"),
             transcriptViewport: rectFor(".chat-thread"),
-            transcriptAvailableWidth,
+            composer: rectFor(".agent-chat__composer-shell"),
             userLane: rectFor(".chat-group.user .chat-group-messages"),
             userBubble: rectFor(".chat-group.user .chat-bubble:first-child"),
           };
@@ -3284,7 +3274,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           ),
         ).toBeLessThanOrEqual(1);
         if (width <= 768) {
-          expect(roles.transcriptAvailableWidth - transcript.width).toBeCloseTo(32, 0);
+          const composer = expectControlRect(roles.composer, "composer");
+          expect(transcript.x).toBeCloseTo(composer.x, 0);
+          expect(transcript.width).toBeCloseTo(composer.width, 0);
         } else {
           expect(transcript.width).toBeCloseTo(768, 0);
         }

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -520,7 +520,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
           ? nothing
           : html`<div
               class="chat-group-footer ${
-                normalizedRole === "user" && avatarPlacement !== "footer"
+                normalizedRole === "user" && (isPeerGroup || avatarPlacement !== "footer")
                   ? "chat-group-footer--persistent-identity"
                   : ""
               }${sendFailure ? " chat-group-footer--send-failure" : ""}"

--- a/ui/src/styles/chat/composer.css
+++ b/ui/src/styles/chat/composer.css
@@ -3826,23 +3826,16 @@
     --chat-frame-inset-left: max(var(--chat-mobile-edge-inset, 4px), var(--safe-area-left, 0px));
     --chat-frame-inset-right: max(var(--chat-mobile-edge-inset, 4px), var(--safe-area-right, 0px));
     width: calc(100% - var(--chat-frame-inset-left) - var(--chat-frame-inset-right));
-    /* Center the capped frame inside the safe area, including asymmetric notches. */
-    margin-right: max(
-      var(--chat-frame-inset-right),
-      calc(
-        (100% - var(--chat-thread-max-width, 100%) - var(--chat-frame-inset-left) +
-            var(--chat-frame-inset-right)) /
-          2
-      )
-    );
-    margin-left: max(
-      var(--chat-frame-inset-left),
-      calc(
-        (100% - var(--chat-thread-max-width, 100%) + var(--chat-frame-inset-left) -
-            var(--chat-frame-inset-right)) /
-          2
-      )
-    );
+    margin-left: var(--chat-frame-inset-left);
+    margin-right: var(--chat-frame-inset-right);
+  }
+
+  .chat-thread-inner,
+  .chat .agent-chat__composer-shell {
+    position: relative;
+    /* Center within physical safe areas without doing arithmetic on max-width keywords. */
+    left: calc((var(--chat-frame-inset-left) - var(--chat-frame-inset-right)) / 2);
+    margin-inline: auto;
   }
 
   .agent-chat__composer-shell {

--- a/ui/src/styles/chat/composer.css
+++ b/ui/src/styles/chat/composer.css
@@ -3830,7 +3830,7 @@
     margin-right: max(
       var(--chat-frame-inset-right),
       calc(
-        (100% - var(--chat-thread-max-width, 48rem) - var(--chat-frame-inset-left) +
+        (100% - var(--chat-thread-max-width, 100%) - var(--chat-frame-inset-left) +
             var(--chat-frame-inset-right)) /
           2
       )
@@ -3838,7 +3838,7 @@
     margin-left: max(
       var(--chat-frame-inset-left),
       calc(
-        (100% - var(--chat-thread-max-width, 48rem) + var(--chat-frame-inset-left) -
+        (100% - var(--chat-thread-max-width, 100%) + var(--chat-frame-inset-left) -
             var(--chat-frame-inset-right)) /
           2
       )

--- a/ui/src/styles/chat/composer.css
+++ b/ui/src/styles/chat/composer.css
@@ -3816,15 +3816,37 @@
     min-width: 64px;
   }
 
+  .chat-thread {
+    scrollbar-gutter: auto;
+    scrollbar-width: none;
+  }
+
+  .chat-thread-inner,
   .agent-chat__composer-shell {
-    width: calc(
-      100% - max(var(--chat-mobile-edge-inset, 4px), var(--safe-area-left, 0px)) -
-        max(var(--chat-mobile-edge-inset, 4px), var(--safe-area-right, 0px))
+    --chat-frame-inset-left: max(var(--chat-mobile-edge-inset, 4px), var(--safe-area-left, 0px));
+    --chat-frame-inset-right: max(var(--chat-mobile-edge-inset, 4px), var(--safe-area-right, 0px));
+    width: calc(100% - var(--chat-frame-inset-left) - var(--chat-frame-inset-right));
+    /* Center the capped frame inside the safe area, including asymmetric notches. */
+    margin-right: max(
+      var(--chat-frame-inset-right),
+      calc(
+        (100% - var(--chat-thread-max-width, 48rem) - var(--chat-frame-inset-left) +
+            var(--chat-frame-inset-right)) /
+          2
+      )
     );
-    margin: var(--chat-composer-top-margin, 0px)
-      max(var(--chat-mobile-edge-inset, 4px), var(--safe-area-right, 0px))
-      calc(14px + var(--safe-area-bottom, 0px));
-    margin-left: max(var(--chat-mobile-edge-inset, 4px), var(--safe-area-left, 0px));
+    margin-left: max(
+      var(--chat-frame-inset-left),
+      calc(
+        (100% - var(--chat-thread-max-width, 48rem) + var(--chat-frame-inset-left) -
+            var(--chat-frame-inset-right)) /
+          2
+      )
+    );
+  }
+
+  .agent-chat__composer-shell {
+    margin-block: var(--chat-composer-top-margin, 0px) calc(14px + var(--safe-area-bottom, 0px));
     gap: 6px;
   }
 
@@ -3836,11 +3858,14 @@
 
 @media (display-mode: standalone) and (max-width: 768px),
   (display-mode: standalone) and (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
+  .chat-thread-inner,
   .agent-chat__composer-shell {
-    width: calc(100% - 2 * var(--chat-mobile-edge-inset, 4px));
-    margin-right: var(--chat-mobile-edge-inset, 4px);
+    --chat-frame-inset-left: var(--chat-mobile-edge-inset, 4px);
+    --chat-frame-inset-right: var(--chat-mobile-edge-inset, 4px);
+  }
+
+  .agent-chat__composer-shell {
     margin-bottom: 14px;
-    margin-left: var(--chat-mobile-edge-inset, 4px);
   }
 }
 

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -7,17 +7,19 @@
    message content and footer into separate rows so each row keeps the avatar
    gutter while only the message row controls avatar alignment. */
 .chat-group {
+  --chat-avatar-column: 36px;
+  --chat-avatar-gap: 10px;
+  --chat-avatar-gutter: calc(var(--chat-avatar-column) + var(--chat-avatar-gap));
   --chat-footer-row-offset: 26px;
   --chat-message-column-max: var(--chat-message-max-width, min(900px, 68%));
   --chat-run-block-gap: 12px;
   --chat-touch-row-margin: 14px;
   --chat-turn-gap: 50px;
   display: flex;
-  gap: 10px;
+  gap: var(--chat-avatar-gap);
   align-items: flex-start;
   padding-bottom: var(--chat-turn-gap);
-  margin-left: 4px;
-  margin-right: 16px;
+  margin-inline: 4px 16px;
 }
 
 /* User messages on right */
@@ -55,9 +57,9 @@
   --chat-group-avatar-column: 1;
   --chat-group-content-column: 2;
   display: grid;
-  grid-template-columns: 36px minmax(0, var(--chat-message-column-max));
+  grid-template-columns: var(--chat-avatar-column) minmax(0, var(--chat-message-column-max));
   grid-template-rows: auto auto;
-  gap: 2px 10px;
+  gap: 2px var(--chat-avatar-gap);
   justify-content: start;
   padding-bottom: calc(var(--chat-turn-gap) - var(--chat-footer-row-offset));
 }
@@ -65,14 +67,14 @@
 .chat-group.user.chat-group--with-footer {
   --chat-group-avatar-column: 2;
   --chat-group-content-column: 1;
-  grid-template-columns: minmax(0, var(--chat-message-column-max)) 36px;
+  grid-template-columns: minmax(0, var(--chat-message-column-max)) var(--chat-avatar-column);
   justify-content: end;
 }
 
 .chat-group.user.chat-group--with-footer:where(.chat-group--peer) {
   --chat-group-avatar-column: 1;
   --chat-group-content-column: 2;
-  grid-template-columns: 36px minmax(0, var(--chat-message-column-max));
+  grid-template-columns: var(--chat-avatar-column) minmax(0, var(--chat-message-column-max));
   justify-content: start;
 }
 
@@ -141,8 +143,7 @@
 .chat-group.tool {
   --chat-message-column-max: var(--chat-message-max-width, min(980px, 100%));
   display: block;
-  margin-inline-start: 4px;
-  padding-inline-start: 46px;
+  padding-inline-start: var(--chat-avatar-gutter);
 }
 
 .chat-group.tool.chat-group--with-footer {
@@ -719,7 +720,7 @@ img.chat-avatar.chat-avatar--logo {
 }
 
 .chat-group.workspace-conflict .chat-group-messages {
-  max-width: min(760px, calc(100% - 46px));
+  max-width: min(760px, calc(100% - var(--chat-avatar-gutter)));
 }
 
 .chat-group.workspace-conflict .chat-avatar {
@@ -758,7 +759,10 @@ img.chat-avatar.chat-avatar--logo {
    keep bubble cards. Border collapses to 0 so the streaming border pulse and hover
    outline become no-ops without extra rules. */
 .chat-group.assistant {
-  --chat-message-column-max: var(--chat-message-max-width, min(980px, calc(100% - 46px)));
+  --chat-message-column-max: var(
+    --chat-message-max-width,
+    min(980px, calc(100% - var(--chat-avatar-gutter)))
+  );
 }
 
 .chat-group.assistant .chat-bubble {
@@ -786,11 +790,7 @@ img.chat-avatar.chat-avatar--logo {
    the inset keeps the claw on the text column so the reply materializes
    exactly where it punched. Direct threads have no avatar indent to match. */
 .chat-group--working .chat-group-messages {
-  padding-left: 46px; /* .chat-avatar 36px + .chat-group gap 10px */
-}
-
-.chat-thread--direct .chat-group--working .chat-group-messages {
-  padding-left: 0;
+  padding-inline-start: var(--chat-avatar-gutter);
 }
 
 /* Direct (1:1) threads drop avatars entirely: one agent plus one user makes
@@ -801,23 +801,9 @@ img.chat-avatar.chat-avatar--logo {
 }
 
 .chat-thread--direct .chat-group {
+  --chat-avatar-column: 0px;
+  --chat-avatar-gap: 0px;
   margin-inline: 0;
-}
-
-.chat-thread--direct .chat-group.chat-group--with-footer {
-  --chat-group-avatar-column: 1;
-  --chat-group-content-column: 1;
-  grid-template-columns: minmax(0, var(--chat-message-column-max));
-}
-
-.chat-thread--direct .chat-group.assistant,
-.chat-thread--direct .chat-group.tool {
-  --chat-message-column-max: var(--chat-message-max-width, min(980px, 100%));
-}
-
-.chat-thread--direct .chat-group.tool {
-  margin-inline-start: 0;
-  padding-inline-start: 0;
 }
 
 .chat-duplicate-count {
@@ -1286,32 +1272,10 @@ img.chat-avatar.chat-avatar--logo {
 
 @media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
   .chat-group {
+    --chat-avatar-column: 0px;
+    --chat-avatar-gap: 0px;
     --chat-message-column-max: 82%;
-    margin-left: 0;
-    margin-right: 0;
-  }
-
-  .chat-group.tool,
-  .chat-group.assistant {
-    --chat-message-column-max: calc(100% - 46px);
-  }
-}
-
-@media (max-width: 400px) {
-  .chat-group {
-    --chat-message-column-max: 88%;
-  }
-
-  .chat-group.chat-group--with-footer,
-  .chat-group.user.chat-group--peer.chat-group--with-footer {
-    --chat-group-avatar-column: 1;
-    --chat-group-content-column: 1;
-    grid-template-columns: minmax(0, var(--chat-message-column-max));
-  }
-
-  .chat-group.tool,
-  .chat-group.assistant {
-    --chat-message-column-max: calc(100% - 46px);
+    margin-inline: 0;
   }
 
   .chat-avatar,
@@ -1319,9 +1283,14 @@ img.chat-avatar.chat-avatar--logo {
     display: none;
   }
 
-  /* Avatars are hidden at this width, so the working group's avatar-column
-     inset would strand the claw 46px from where the reply text lands. */
-  .chat-group--working .chat-group-messages {
-    padding-left: 0;
+  /* Peer names carry identity when narrow rows have no avatar column. */
+  .chat-group.user.chat-group--peer {
+    --chat-persistent-footer-opacity: 1;
+  }
+}
+
+@media (max-width: 400px) {
+  .chat-group {
+    --chat-message-column-max: 88%;
   }
 }

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -1278,8 +1278,7 @@ img.chat-avatar.chat-avatar--logo {
     margin-inline: 0;
   }
 
-  .chat-avatar,
-  .chat-avatar-slot {
+  .chat-group > :is(.chat-avatar, .chat-avatar-slot) {
     display: none;
   }
 

--- a/ui/src/styles/chat/message-layout.css
+++ b/ui/src/styles/chat/message-layout.css
@@ -760,7 +760,7 @@
 
 @media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
   .chat {
-    --chat-thread-gutter: 16px;
+    --chat-thread-gutter: var(--chat-mobile-edge-inset);
     --chat-thread-side-inset: 0px;
     --chat-mobile-edge-inset: 4px;
   }

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -28,7 +28,7 @@ openclaw-chat-pane {
 .chat-split-view__column {
   display: flex;
   flex-direction: column;
-  min-width: 320px;
+  min-width: min(320px, 100%);
   min-height: 0;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Mobile Control UI chat lost reading space to an empty avatar column, and a 320-pixel viewport could clip the right edge.

## Why This Change Was Made

Use shared responsive row spacing and a common transcript/composer frame. Preserve safe areas, landscape centering, desktop identities, shared attribution, and existing width settings.

## User Impact

Phone conversations gain a wider, aligned reading column. Sender names and scrolling remain available in shared conversations.

## Evidence

At 430 pixels, assistant content expanded from x76–400 to x8–422. At 320 pixels, both frames fit x8–312. Compiled browser checks covered progressive-web-app installation, reload, right-to-left layout, landscape safe areas, desktop, and new shared senders. Maintained layout/header tests and focused style checks passed; CI passed. This is web-browser proof, not native-app testing.

Closes #139994. Reported by @keith9681. AI-assisted repair.
