### PR TITLE
refactor(qa): reuse canonical process-counter parsers

### DIFF
--- a/extensions/qa-lab/src/process-tree-cpu.ts
+++ b/extensions/qa-lab/src/process-tree-cpu.ts
@@ -1,6 +1,11 @@
 // Qa Lab plugin module implements process tree cpu behavior.
 import { spawnSync } from "node:child_process";
-import { parseStrictFiniteNumber, parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
+import {
+  asNonNegativeFiniteNumber,
+  parseStrictFiniteNumber,
+  parseStrictNonNegativeInteger,
+  parseStrictPositiveInteger,
+} from "openclaw/plugin-sdk/number-runtime";
 import { isRecord as isPlainObject } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveQaWindowsPowerShellExePath } from "./windows-system-tools.js";
 
@@ -11,30 +16,6 @@ type ProcessTreeSnapshot = {
 };
 
 const PROCESS_TREE_SNAPSHOT_TIMEOUT_MS = 5_000;
-
-function parsePositiveInteger(value: unknown): number | null {
-  const parsed = parseStrictInteger(value);
-  if (parsed === undefined || parsed <= 0) {
-    return null;
-  }
-  return parsed;
-}
-
-function parseNonNegativeInteger(value: unknown): number | null {
-  const parsed = parseStrictInteger(value);
-  if (parsed === undefined || parsed < 0) {
-    return null;
-  }
-  return parsed;
-}
-
-function parseNonNegativeNumber(value: unknown): number | null {
-  const parsed = parseStrictFiniteNumber(value);
-  if (parsed === undefined || parsed < 0) {
-    return null;
-  }
-  return parsed;
-}
 
 function parsePsCpuTimeMs(raw: string): number | null {
   const match = raw.trim().match(/^(?:(\d+)-)?(\d+):(\d{2}(?:\.\d+)?)(?::(\d{2}(?:\.\d+)?))?$/u);
@@ -84,17 +65,17 @@ function parseWindowsProcessCpuTimeMs(params: {
   kernelModeTime: unknown;
   userModeTime: unknown;
 }): number | null {
-  const kernelModeTime = parseNonNegativeNumber(params.kernelModeTime);
-  const userModeTime = parseNonNegativeNumber(params.userModeTime);
-  if (kernelModeTime === null || userModeTime === null) {
+  const kernelModeTime = asNonNegativeFiniteNumber(parseStrictFiniteNumber(params.kernelModeTime));
+  const userModeTime = asNonNegativeFiniteNumber(parseStrictFiniteNumber(params.userModeTime));
+  if (kernelModeTime === undefined || userModeTime === undefined) {
     return null;
   }
   return Math.round((kernelModeTime + userModeTime) / 10_000);
 }
 
 function parseWindowsWorkingSetBytes(raw: unknown): number | null {
-  const parsed = parseNonNegativeNumber(raw);
-  return parsed === null ? null : Math.round(parsed);
+  const parsed = asNonNegativeFiniteNumber(parseStrictFiniteNumber(raw));
+  return parsed === undefined ? null : Math.round(parsed);
 }
 
 function parseWindowsProcessTreeSnapshot(raw: string): ProcessTreeSnapshot | null {
@@ -116,9 +97,9 @@ function parseWindowsProcessTreeSnapshot(raw: string): ProcessTreeSnapshot | nul
     if (!isPlainObject(entry)) {
       continue;
     }
-    const pid = parsePositiveInteger(entry.ProcessId);
-    const ppid = parseNonNegativeInteger(entry.ParentProcessId);
-    if (pid === null || ppid === null) {
+    const pid = parseStrictPositiveInteger(entry.ProcessId);
+    const ppid = parseStrictNonNegativeInteger(entry.ParentProcessId);
+    if (pid === undefined || ppid === undefined) {
       continue;
     }
 


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

QA Lab carries private process-counter parsers that duplicate helpers already provided by its existing Plugin SDK import. This is maintainer-requested cleanup for the #135868 split campaign and extracts no feature content from that PR.

## Why This Change Was Made

Use the canonical positive/nonnegative integer parsers for Windows process IDs and the canonical finite-number sign check for CPU/RSS counters. Only the private absence checks change from null to undefined; the public readers still return number or null.

Before this change, the complete owner matches stable v2026.9.2. The deleted helpers have only local callers, and the existing SDK barrel already exports their replacements. No compatibility, process-ownership, SDK, configuration, or storage contract is removed.

## User Impact

No intended behavior change. QA metrics retain strict decimal safe-integer process IDs, fractional and large finite counters, accepted exponent-form metrics, zero values, rounding, and descendant aggregation. Subprocess commands, trusted PowerShell selection, timeouts, and POSIX parsing remain unchanged.

## Evidence

- All 39 unchanged tests passed before and after with `node scripts/run-vitest.mjs`: Windows process snapshots, POSIX CPU/RSS parsing, and canonical number coercion.
- Independent Codex local and committed-branch reviews found no actionable P0–P2 issues.
- Temporary public-boundary comparison passed 2,526 CPU/RSS comparisons across 1,263 synthetic snapshot/root cases. Complete old and actual new owners use real SDK parsers and Windows path resolution; only child-local spawnSync is stubbed. Values, null results, propagated errors, and exact command/args/options match for Windows/Linux/macOS inputs. Mutants with permissive PID parsing and falsy-zero loss are detected. This is synthetic parser-boundary proof, not native OS integration.
- Full `node scripts/check-changed.mjs` plan passed in 329.66 seconds on clean Linux Blacksmith Testbox ([run 34067942680](https://github.com/openclaw/openclaw/actions/runs/34067942680), lease `tbx_01m1wj0d2r51fzz2rkta0gs3gp`, stopped). Extension and extension-test types, lint, Doctor contract checks, zero dead exports and zero runtime cycles passed. All nine recorded inputs remained unchanged through the main rebase; no lockfile change.

Production +14/−33, net −19; one private plugin file, 270→251 lines. Tests, tooling, docs, and baselines unchanged. No build, packaging, dynamic import, new SDK path, or published API change.

ClawSweeper completed its review of the same patch with no correctness or security findings and no before-merge/rank-up requests. Initial exact-head CI [34068374981](https://github.com/openclaw/openclaw/actions/runs/34068374981) passed (35 successful jobs, 16 expected skips). The final landing rebase only picked up unrelated agent-turn test fixtures; all nine proof inputs/lock stayed unchanged, all 39 tests passed again, and fresh branch review was clean. Final-head CI is required before merge.

Final exact-head CI [34068805999](https://github.com/openclaw/openclaw/actions/runs/34068805999) is green on `a320362cb8563a7cc875de376e69f94e2c480d3d`: 35 successful jobs, 16 expected skips; canonical watcher GREEN. No test retry or source repair was needed.
