### PR TITLE
fix(gateway): avoid false 304 responses for quoted ETags

### DIFF
--- a/docs/nodes/media-playback.md
+++ b/docs/nodes/media-playback.md
@@ -89,6 +89,8 @@ The ticketed byte routes support:
 - `ETag` and `If-Range` for safe resume of immutable managed originals
 - `HEAD` requests with the same content metadata and no response body
 
+For immutable originals, `If-None-Match` compares complete quoted tags using weak comparison. Commas and asterisks inside a quoted tag are literal; only a standalone `*` is a wildcard. A nonmatching tag leaves the normal full or ranged response intact.
+
 Local assistant files can change, and playback renditions can become available
 after a conversion retry. These responses revalidate without reusable validators:
 cached ETags or modification dates cannot suppress fresh bytes, and `If-Range`

--- a/src/gateway/control-ui-conditional.http.test.ts
+++ b/src/gateway/control-ui-conditional.http.test.ts
@@ -79,6 +79,11 @@ const conditionalCases: {
   },
   { name: "stale If-None-Match alone", headers: { "If-None-Match": '"stale"' }, status: 200 },
   {
+    name: "quoted comma/star is not a wildcard and supersedes the date",
+    headers: { "If-None-Match": '"client,*,tag"', "If-Modified-Since": lastModified },
+    status: 200,
+  },
+  {
     name: "stale If-None-Match overrides equal If-Modified-Since",
     headers: { "If-None-Match": '"stale"', "If-Modified-Since": lastModified },
     status: 200,

--- a/src/gateway/http-byte-range.test.ts
+++ b/src/gateway/http-byte-range.test.ts
@@ -445,6 +445,21 @@ describe("resolveByteResponse", () => {
   });
 
   it.each([
+    { etag: '"opaque,tag"', header: 'W/"opaque,tag"' },
+    { etag: 'W/"opaque,tag"', header: '"opaque,tag"' },
+    { etag: 'W/"opaque,tag"', header: 'W/"opaque,tag"' },
+  ])("weakly compares complete $header against $etag", ({ etag, header }) => {
+    expect(
+      resolveByteResponse({
+        ...IMMUTABLE_FILE,
+        validators: { ...IMMUTABLE_FILE.validators, etag },
+        method: "GET",
+        request: createByteRequest({ "if-none-match": header }),
+      }),
+    ).toMatchObject({ kind: "not-modified", statusCode: 304 });
+  });
+
+  it.each([
     { label: "exact", header: (etag: string) => etag },
     { label: "weak", header: (etag: string) => `W/${etag}` },
     { label: "wildcard", header: () => "*" },

--- a/src/gateway/http-conditional.ts
+++ b/src/gateway/http-conditional.ts
@@ -1,6 +1,7 @@
 // HTTP validators share strict date admission and weak entity-tag comparison.
 import type { IncomingMessage } from "node:http";
 import { parseHttpDateInstant } from "@openclaw/ai/internal/retry-after";
+import { splitHttpHeaderValue } from "./http-header-value.js";
 
 export function matchesHttpIfModifiedSince(
   request: Pick<IncomingMessage, "headersDistinct"> | undefined,
@@ -28,8 +29,12 @@ export function matchesHttpIfNoneMatch(
   if (!value) {
     return false;
   }
-  return value.split(",").some((candidate) => {
-    const tag = candidate.trim();
-    return tag === "*" || tag === etag || (tag.startsWith("W/") && tag.slice(2) === etag);
-  });
+  const expected = etag?.replace(/^W\//u, "");
+  return (
+    value.trim() === "*" ||
+    (splitHttpHeaderValue(value, ",", "opaque-tag")?.some(
+      (candidate) => candidate.trim().replace(/^W\//u, "") === expected,
+    ) ??
+      false)
+  );
 }

--- a/src/gateway/http-header-value.ts
+++ b/src/gateway/http-header-value.ts
@@ -1,0 +1,31 @@
+/** Split only outside quotes; entity-tags keep backslashes literal instead of escaping quotes. */
+export function splitHttpHeaderValue(
+  value: string,
+  delimiter: string,
+  quoteMode: "quoted-string" | "opaque-tag",
+): string[] | null {
+  const parts: string[] = [];
+  let start = 0;
+  let quoted = false;
+  let escaped = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (escaped) {
+      escaped = false;
+    } else if (quoted && quoteMode === "quoted-string" && character === "\\") {
+      escaped = true;
+    } else if (character === '"') {
+      quoted = !quoted;
+    } else if (!quoted && character === delimiter) {
+      parts.push(value.slice(start, index));
+      start = index + 1;
+    }
+  }
+
+  if (quoted || escaped) {
+    return null;
+  }
+  parts.push(value.slice(start));
+  return parts;
+}

--- a/src/gateway/http-media-range.ts
+++ b/src/gateway/http-media-range.ts
@@ -1,4 +1,5 @@
 // Pure helpers for HTTP Accept media-range parsing.
+import { splitHttpHeaderValue } from "./http-header-value.js";
 
 const HTTP_TOKEN_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/u;
 const HTTP_QVALUE_PATTERN = /^(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?)$/u;
@@ -6,45 +7,6 @@ const HTTP_OPTIONAL_WHITESPACE_PATTERN = /^[\t ]+|[\t ]+$/gu;
 
 function trimHttpOptionalWhitespace(value: string): string {
   return value.replace(HTTP_OPTIONAL_WHITESPACE_PATTERN, "");
-}
-
-function splitOutsideQuotedStrings(value: string, delimiter: string): string[] | null {
-  const parts: string[] = [];
-  let start = 0;
-  let quoted = false;
-  let escaped = false;
-
-  for (let index = 0; index < value.length; index += 1) {
-    const character = value[index];
-    if (quoted) {
-      if (escaped) {
-        escaped = false;
-        continue;
-      }
-      if (character === "\\") {
-        escaped = true;
-        continue;
-      }
-      if (character === '"') {
-        quoted = false;
-      }
-      continue;
-    }
-    if (character === '"') {
-      quoted = true;
-      continue;
-    }
-    if (character === delimiter) {
-      parts.push(value.slice(start, index));
-      start = index + 1;
-    }
-  }
-
-  if (quoted || escaped) {
-    return null;
-  }
-  parts.push(value.slice(start));
-  return parts;
 }
 
 function parseParameterValue(value: string): string | null {
@@ -87,7 +49,7 @@ type ParsedMediaType = {
 };
 
 function parseMediaType(value: string, allowQuality: boolean): ParsedMediaType | null {
-  const segments = splitOutsideQuotedStrings(value, ";");
+  const segments = splitHttpHeaderValue(value, ";", "quoted-string");
   if (!segments) {
     return null;
   }
@@ -180,7 +142,7 @@ export function acceptsMediaType(
     return false;
   }
 
-  const ranges = splitOutsideQuotedStrings(accept, ",");
+  const ranges = splitHttpHeaderValue(accept, ",", "quoted-string");
   if (!ranges) {
     return false;
   }

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -637,36 +637,139 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
     }
   });
 
-  it.each(["GET", "HEAD"])(
-    "revalidates managed media ETags before ranges for %s",
-    async (method) => {
-      const { attachmentId, sessionKey } = await createFixture(stateDir);
+  it.each<{
+    name: string;
+    method?: string;
+    range?: string;
+    ifRange?: string;
+    validator: string | string[] | ((etag: string) => string);
+    expectedStatus: number;
+  }>([
+    {
+      name: "quoted comma/star GET",
+      validator: '"client,*,tag"',
+      expectedStatus: 200,
+    },
+    {
+      name: "quoted comma/star HEAD",
+      method: "HEAD",
+      validator: '"client,*,tag"',
+      expectedStatus: 200,
+    },
+    {
+      name: "quoted comma/star range",
+      range: "bytes=2-5",
+      validator: '"client,*,tag"',
+      expectedStatus: 206,
+    },
+    {
+      name: "weak quoted comma/star range",
+      range: "bytes=2-5",
+      validator: 'W/"client,*,tag"',
+      expectedStatus: 206,
+    },
+    {
+      name: "multiple nonmatching fields",
+      validator: ['"client,*,tag"', '"other"'],
+      expectedStatus: 200,
+    },
+    {
+      name: "quoted literal asterisk",
+      validator: '"*"',
+      expectedStatus: 200,
+    },
+    {
+      name: "ordinary stale range",
+      range: "bytes=2-5",
+      validator: '"stale"',
+      expectedStatus: 206,
+    },
+    {
+      name: "strong match",
+      validator: (etag: string) => etag,
+      expectedStatus: 304,
+    },
+    {
+      name: "weak HEAD match before If-Range",
+      method: "HEAD",
+      range: "bytes=2-5",
+      ifRange: '"stale"',
+      validator: (etag: string) => `W/${etag}`,
+      expectedStatus: 304,
+    },
+    {
+      name: "matching list before If-Range",
+      range: "bytes=2-5",
+      ifRange: '"stale"',
+      validator: (etag: string) => `"other", W/${etag}`,
+      expectedStatus: 304,
+    },
+    {
+      name: "standalone wildcard",
+      validator: "*",
+      expectedStatus: 304,
+    },
+    {
+      name: "literal backslash before a matching tag",
+      validator: (etag: string) => String.raw`"trailing\", ` + etag,
+      expectedStatus: 304,
+    },
+  ])(
+    "honors $name for managed media",
+    async ({ method = "GET", range, ifRange, validator, expectedStatus }) => {
+      const body = Buffer.from("0123456789");
+      const { attachmentId, sessionKey } = await createFixture(stateDir, {
+        filename: "report.txt",
+        contentType: "text/plain",
+        body,
+      });
       const pathName = `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`;
-      const initial = await requestManagedImage({
+      const request = {
         stateDir,
         pathName,
         authResponse: { authMethod: "token" },
-      });
-      const etag = initial.result.headers.etag;
+        transcriptMessages: [
+          {
+            role: "assistant",
+            content: [{ type: "attachment", attachment: { url: pathName } }],
+            __openclaw: { id: "msg-1" },
+          },
+        ],
+      };
+      const initial = await requestManagedImage(request);
+      const etag = String(initial.result.headers.etag);
       expect(etag).toMatch(/^"[A-Za-z0-9_-]+"$/);
 
+      const ifNoneMatch = typeof validator === "function" ? validator(etag) : validator;
       const { result } = await requestManagedImage({
-        stateDir,
-        pathName,
+        ...request,
         method,
-        authResponse: { authMethod: "token" },
-        headers: {
-          "if-none-match": `W/${String(etag)}`,
-          range: "bytes=0-3",
-          "if-range": '"stale"',
-        },
+        headers: [
+          "Host",
+          "127.0.0.1",
+          ...[ifNoneMatch].flat().flatMap((value) => ["if-none-match", value]),
+          ...(range ? ["range", range] : []),
+          ...(ifRange ? ["if-range", ifRange] : []),
+        ],
       });
 
-      expect(result.statusCode).toBe(304);
+      expect(result.statusCode).toBe(expectedStatus);
       expect(result.headers.etag).toBe(etag);
-      expect(result.headers["content-length"]).toBeUndefined();
-      expect(result.headers["content-range"]).toBeUndefined();
-      expect(result.body).toHaveLength(0);
+      expect(result.headers["content-type"]).toBe("text/plain");
+      expect(result.headers["content-disposition"]).toContain('filename="report.txt"');
+      expect(result.headers["content-length"]).toBe(
+        expectedStatus === 304 ? undefined : expectedStatus === 206 ? "4" : "10",
+      );
+      expect(result.headers["content-range"]).toBe(
+        expectedStatus === 206 ? "bytes 2-5/10" : undefined,
+      );
+      expect(result.body.toString("utf8")).toBe(
+        method === "HEAD" || expectedStatus === 304
+          ? ""
+          : expectedStatus === 206
+            ? "2345"
+            : "0123456789",
+      );
     },
   );
 

--- a/src/gateway/workspace-icon-http.test.ts
+++ b/src/gateway/workspace-icon-http.test.ts
@@ -245,22 +245,63 @@ describe("handleWorkspaceIconHttpRequest", () => {
     },
   );
 
-  it("revalidates an unchanged icon without resending its bytes", async () => {
-    const root = await makeWorkspace({ "favicon.png": PNG_BYTES });
-    mocks.resolveLocalSessionWorkspaceRoot.mockReturnValue(root);
-    await prepareSessionWorkspaceIcon({ sessionKey: "agent:main:one" });
+  it.each([
+    {
+      name: "exact current tag",
+      method: "GET",
+      validator: (etag: string) => etag,
+      expectedStatus: 304,
+    },
+    {
+      name: "quoted comma/star GET",
+      method: "GET",
+      validator: '"client,*,tag"',
+      expectedStatus: 200,
+    },
+    {
+      name: "weak quoted comma/star HEAD",
+      method: "HEAD",
+      validator: 'W/"client,*,tag"',
+      expectedStatus: 200,
+    },
+    {
+      name: "literal backslash before weak match",
+      method: "HEAD",
+      validator: (etag: string) => String.raw`"trailing\", W/` + etag,
+      expectedStatus: 304,
+    },
+  ])(
+    "honors $name for workspace image responses",
+    async ({ method, validator, expectedStatus }) => {
+      const root = await makeWorkspace({ "favicon.png": PNG_BYTES });
+      mocks.resolveLocalSessionWorkspaceRoot.mockReturnValue(root);
+      await prepareSessionWorkspaceIcon({ sessionKey: "agent:main:one" });
 
-    const first = await fetch(iconRoute("agent:main:one"));
-    const etag = first.headers.get("etag");
-    expect(etag).toBeTruthy();
-    await first.arrayBuffer();
+      const first = await fetch(iconRoute("agent:main:one"));
+      const etag = first.headers.get("etag") ?? "";
+      expect(etag).toMatch(/^"[A-Za-z0-9_-]+"$/);
+      await first.arrayBuffer();
 
-    const revalidated = await fetch(iconRoute("agent:main:one"), {
-      headers: { "If-None-Match": etag ?? "" },
-    });
-    expect(revalidated.status).toBe(304);
-    expect((await revalidated.arrayBuffer()).byteLength).toBe(0);
-  });
+      const response = await fetch(iconRoute("agent:main:one"), {
+        method,
+        headers: { "If-None-Match": typeof validator === "function" ? validator(etag) : validator },
+      });
+      expect(response.status).toBe(expectedStatus);
+      expect(response.headers.get("etag")).toBe(etag);
+      expect(response.headers.get("content-disposition")).toBe(
+        'attachment; filename="workspace-icon"',
+      );
+      expect(response.headers.get("content-length")).toBe(
+        expectedStatus === 304 ? null : String(PNG_BYTES.byteLength),
+      );
+      if (expectedStatus === 200) {
+        expect(response.headers.get("content-type")).toBe("image/png");
+      }
+      expect(Buffer.from(await response.arrayBuffer())).toEqual(
+        expectedStatus === 304 || method === "HEAD" ? Buffer.alloc(0) : PNG_BYTES,
+      );
+    },
+  );
 
   it("omits the body but keeps the representation headers on HEAD", async () => {
     const root = await makeWorkspace({ "favicon.png": PNG_BYTES });


### PR DESCRIPTION
Closes #140528

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes empty `304 Not Modified` responses when a client sends a nonmatching quoted ETag such as `"client,*,tag"`. Its literal asterisk was incorrectly treated as a wildcard, suppressing managed-media bytes and producing incorrect workspace-image revalidation results.

## Why This Change Was Made

The shared matcher now compares complete quoted tags, removes the weak prefix from both operands, and recognizes only a standalone wildcard. It reuses the existing delimiter scanner with explicit quote rules: ETags keep backslashes literal, while Accept retains quoted-string escaping. The old private scanner is removed.

## User Impact

Nonmatching tags receive the normal full or ranged response. Matching tags, weak matches, wildcard requests and conditional-request precedence retain their intended behavior. The shared owner covers managed media and image callers; the media playback documentation explains the contract.

## Evidence

- Original 25-case regression corpus: ten intended failures and 15 passing controls. Fixed corpus: 25/25.
- 631 distinct tests across six Gateway/HTTP suites passed, including Accept/REST/SSE siblings. The managed-media file was rerun after the final fixture cleanup: 129/129. Other tested source files are unchanged.
- Complete eight-path changed gate passed; two independent review passes found no actionable P0–P2 issues. Final commit: `f369f6de53d7d3e47eb10558a0a000e194742da6`.
- Fresh uncached build passed. Real isolated Gateway before/after proof used public session/chat/artifact creation, workspace-icon preparation and exact HTTP sockets, with one local scripted Responses request per build.

| Gateway proof | Baseline | Fixed |
| --- | --- | --- |
| Matrix requests | 21 | 21 |
| Incorrect 304 responses | 7 | 0 |
| Expected control behavior | 14/14 | 14/14 |
| Full/partial/not-modified responses | 4 / 1 / 16 | 9 / 3 / 9 |

Both runs verified exact bytes, ranges, metadata, complete source/dependency/artifact inventories and unforced process/listener cleanup. Three comma-bearing **current** ETag cases remain source tests because these public routes emit hash-based validators. This proof exercises the actual Gateway with a local model fixture; it makes no external-provider claim.

Validation first exposed test-fixture typing, an omitted Host in raw headers, and unnecessary table mapping rejected by lint. Those fixtures were corrected before the passing final runs. An earlier proof log needed a redaction-quoting correction; the original evidence is retained and both complete Gateway runs were repeated successfully.

Production **+43/−45, net −2**; tests **+197/−33, net +164**; docs **+2**. The final patch composes byte-for-byte onto inspected main `422b8c0ec78686d805c8ed4be37caa84591307dc`. Original introduction is unknown in the available history.
