### PR TITLE
refactor(ui): share people card dismissal handling

### DIFF
--- a/ui/src/components/sidebar-people.runtime.ts
+++ b/ui/src/components/sidebar-people.runtime.ts
@@ -153,8 +153,8 @@ export class SidebarPeopleRuntime {
     };
     this.portal.markTrigger(trigger);
     this.observer.observe(this.host, { childList: true, subtree: true });
-    document.addEventListener("pointerdown", this.outsidePointer, true);
-    document.addEventListener("focusin", this.outsideFocus, true);
+    document.addEventListener("pointerdown", this.outsideInteraction, true);
+    document.addEventListener("focusin", this.outsideInteraction, true);
     document.addEventListener("keydown", this.outsideKey, true);
     this.portal.scheduleOpen(delay, () => {
       if (this.portal.held) {
@@ -356,17 +356,7 @@ export class SidebarPeopleRuntime {
     this.portal.focusInside = document.activeElement === this.active?.trigger;
   }
 
-  private readonly outsidePointer = (event: Event) => {
-    if (
-      event.target instanceof Node &&
-      !this.active?.row.contains(event.target) &&
-      !this.portal.card?.contains(event.target)
-    ) {
-      this.close();
-    }
-  };
-
-  private readonly outsideFocus = (event: Event) => {
+  private readonly outsideInteraction = (event: Event) => {
     if (
       event.target instanceof Node &&
       !this.active?.row.contains(event.target) &&
@@ -393,8 +383,8 @@ export class SidebarPeopleRuntime {
       this.lastOpenAt = performance.now();
     }
     this.observer.disconnect();
-    document.removeEventListener("pointerdown", this.outsidePointer, true);
-    document.removeEventListener("focusin", this.outsideFocus, true);
+    document.removeEventListener("pointerdown", this.outsideInteraction, true);
+    document.removeEventListener("focusin", this.outsideInteraction, true);
     document.removeEventListener("keydown", this.outsideKey, true);
     this.portal.reset();
     this.active?.trigger.setAttribute("aria-haspopup", "dialog");


### PR DESCRIPTION
## What Problem This Solves

The sidebar people card maintains separate outside-pointer and outside-focus callbacks with identical bodies. Every change to the dismissal rule therefore needs to keep two copies aligned.

## Why This Change Was Made

Use one instance-owned arrow callback for both DOM event types, with matching capture-phase registration and removal. The outside-target predicate, lexical receiver, close/reset ordering, and separate keyboard handling remain unchanged. No public API, styles, imports, or tests change. History `3aaf13ca842` (#130664) introduced both handlers together; their bodies and capture flags are identical. Follow-up deletion work for #135868. Production +5/−15, net −10; tests/tooling/docs unchanged.

## User Impact

No intended behavior change. People cards keep the same pointer, focus, keyboard, and cleanup behavior.

## Evidence

- All five existing people-card browser scenarios passed before and after the change using the real Control UI and a mocked Gateway, with desktop/touch and namespace-collision coverage.
- Before/after screenshots were captured by that existing suite and inspected: synthetic Alice/Owner data only; no credentials or private data. They show visual parity.
- Independent Codex review: scoped-clean through P2.
- Full `node scripts/check-changed.mjs`: exit 0, including UI/core typechecking, i18n, lint and guards. `pnpm ui:build`: exit 0.
- No tests removed or added. The existing people-activity-card.e2e.test.ts suite remains the behavior boundary.

![Before: synthetic people card](https://github.com/user-attachments/assets/a3c4d67f-a72b-4515-ac8c-bacc8c18d76e)

![After: synthetic people card](https://github.com/user-attachments/assets/04bbd02d-971c-4201-b601-e1362b9aa5c3)

ClawSweeper reviewed exact head `b85ca8bec4d44028bc56515ff384b74b973ce256`: no findings, security concerns, or requested rank-up changes. Maintainer source review agrees. Exact-head CI is green.
