### PR TITLE
fix(discord): reject numeric application ID pasted as bot token during setup

### DIFF
--- a/extensions/discord/src/setup-adapter.test.ts
+++ b/extensions/discord/src/setup-adapter.test.ts
@@ -1,0 +1,36 @@
+// Discord tests cover setup adapter token-shape validation (#140497 narrow slice).
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/setup";
+import { describe, expect, it } from "vitest";
+import { discordSetupContract } from "./setup-adapter.js";
+
+const validate = (input: Record<string, unknown>) =>
+  discordSetupContract.validateInput?.({
+    cfg: {},
+    accountId: DEFAULT_ACCOUNT_ID,
+    input,
+  } as never) ?? null;
+
+describe("discord setup adapter token shape", () => {
+  it("rejects a numeric application ID used as the bot token", () => {
+    const error = validate({ token: "1234567890123456789" });
+    expect(error).toMatch(/application ID/i);
+  });
+
+  it("accepts a dot-separated bot token shape", () => {
+    expect(validate({ token: "MTk4NjIyNDQ3NDUy.Xyz.Abc-def_123" })).toBeNull();
+  });
+
+  it("leaves non-string credential references to the contract type check", () => {
+    expect(validate({ token: { source: "exec", provider: "vault", id: "discord/work" } })).toBe(
+      "token must be a string.",
+    );
+  });
+
+  it("preserves the env-backed setup flow", () => {
+    expect(validate({ useEnv: true })).toBeNull();
+  });
+
+  it("keeps the missing-credential error for empty input", () => {
+    expect(validate({})).toBe("Discord requires token (or --use-env).");
+  });
+});

--- a/extensions/discord/src/setup-adapter.test.ts
+++ b/extensions/discord/src/setup-adapter.test.ts
@@ -1,23 +1,30 @@
-// Discord tests cover setup adapter token-shape validation (#140497 narrow slice).
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/setup";
 import { describe, expect, it } from "vitest";
 import { discordSetupContract } from "./setup-adapter.js";
 
-const validate = (input: Record<string, unknown>) =>
+const validate = (input: unknown) =>
   discordSetupContract.validateInput?.({
     cfg: {},
     accountId: DEFAULT_ACCOUNT_ID,
     input,
-  } as never) ?? null;
+  });
 
 describe("discord setup adapter token shape", () => {
-  it("rejects a numeric application ID used as the bot token", () => {
-    const error = validate({ token: "1234567890123456789" });
-    expect(error).toMatch(/application ID/i);
-  });
+  it.each(["1234567890123456789", " 1234567890123456789 ", "12345678901234"])(
+    "rejects numeric ID %j used as the bot token",
+    (token) => {
+      const error = validate({ token });
+      expect(error).toContain("application ID");
+      expect(error).toContain("Discord Developer Portal (Bot page)");
+    },
+  );
 
   it("accepts a dot-separated bot token shape", () => {
     expect(validate({ token: "MTk4NjIyNDQ3NDUy.Xyz.Abc-def_123" })).toBeNull();
+  });
+
+  it("does not enforce a token format for nonnumeric strings", () => {
+    expect(validate({ token: "opaque-token" })).toBeNull();
   });
 
   it("leaves non-string credential references to the contract type check", () => {

--- a/extensions/discord/src/setup-adapter.ts
+++ b/extensions/discord/src/setup-adapter.ts
@@ -7,22 +7,13 @@ import {
 
 const channel = "discord" as const;
 
-// A Discord application ID is a bare numeric snowflake. A bot token always
-// carries dot-separated segments, so a purely numeric token can never
-// authenticate: it means the application ID was pasted into the token field.
-const DISCORD_SNOWFLAKE_PATTERN = /^\d{15,25}$/;
-
-function isNumericApplicationId(value: unknown): boolean {
-  return typeof value === "string" && DISCORD_SNOWFLAKE_PATTERN.test(value.trim());
-}
-
 const discordSetupAdapter: ChannelSetupAdapter = createEnvPatchedAccountSetupAdapter({
   channelKey: channel,
   defaultAccountOnlyEnvError: "DISCORD_BOT_TOKEN can only be used for the default account.",
   missingCredentialError: "Discord requires token (or --use-env).",
   hasCredentials: (input) => Boolean(input.token),
   validateInput: ({ input }) =>
-    isNumericApplicationId(input.token)
+    input.token && /^\d+$/.test(input.token.trim())
       ? "Discord token looks like a numeric application ID, not a bot token. Paste the bot token from the Discord Developer Portal (Bot page), not the application ID (General Information page)."
       : null,
   buildPatch: (input) => (input.token ? { token: input.token } : {}),

--- a/extensions/discord/src/setup-adapter.ts
+++ b/extensions/discord/src/setup-adapter.ts
@@ -7,11 +7,24 @@ import {
 
 const channel = "discord" as const;
 
+// A Discord application ID is a bare numeric snowflake. A bot token always
+// carries dot-separated segments, so a purely numeric token can never
+// authenticate: it means the application ID was pasted into the token field.
+const DISCORD_SNOWFLAKE_PATTERN = /^\d{15,25}$/;
+
+function isNumericApplicationId(value: unknown): boolean {
+  return typeof value === "string" && DISCORD_SNOWFLAKE_PATTERN.test(value.trim());
+}
+
 const discordSetupAdapter: ChannelSetupAdapter = createEnvPatchedAccountSetupAdapter({
   channelKey: channel,
   defaultAccountOnlyEnvError: "DISCORD_BOT_TOKEN can only be used for the default account.",
   missingCredentialError: "Discord requires token (or --use-env).",
   hasCredentials: (input) => Boolean(input.token),
+  validateInput: ({ input }) =>
+    isNumericApplicationId(input.token)
+      ? "Discord token looks like a numeric application ID, not a bot token. Paste the bot token from the Discord Developer Portal (Bot page), not the application ID (General Information page)."
+      : null,
   buildPatch: (input) => (input.token ? { token: input.token } : {}),
 });
 


### PR DESCRIPTION
Related: #140497

## What Problem This Solves

Fixes an issue where users setting up Discord could paste a numeric application ID into the bot-token field and have it accepted and persisted. Setup now returns an actionable correction before applying account configuration. Reported by @DonnieFi.

## Why This Change Was Made

The existing plugin-owned validation hook in `extensions/discord/src/setup-adapter.ts` rejects trimmed, purely numeric input. The typed setup contract validates input before this hook, and `src/channels/plugins/account-config-mutation.ts` rejects invalid input before account application or persistence. Nonnumeric credentials, environment setup, stored configuration, and SecretRef semantics retain their existing handling.

A full token-format restriction was rejected because this repair only needs to catch an unmistakable numeric-ID mix-up. A blanket Gateway error for missing `startAccount` was also rejected: inbound startup is optional for valid send-only or login-only plugins, so absence alone does not establish a failed required startup. #140497 stays open for the separate configured-but-never-started diagnostics. The deferred-publication contract in #140550 is unchanged.

## User Impact

Users get an immediate error directing them to the Discord Developer Portal's **Bot** page for the bot token, rather than saving the application ID from General Information and debugging a nonworking channel.

Credit: @Bruce-Yii authored the fix and supplied isolated CLI proof; @obviyus simplified the validator and expanded its regression coverage. Both commits and their human attribution are preserved.

## Evidence

Final reviewed head: `6476c3e3468889675e2ae7d54bc5fd6c171a2940`.

Production delta: **+4 / -0, net +4**. Test delta: **+43 / -0, net +43**. The one-use predicate, its constant/comment block, and the unnecessary test cast were removed. This fits the expressly approved +15-production-line allowance; no behavior or tests were deleted to meet it.

- `node scripts/run-vitest.mjs extensions/discord/src/setup-adapter.test.ts extensions/discord/src/setup-account-state.test.ts extensions/discord/src/setup-surface.test.ts extensions/discord/setup-entry.test.ts`: **19 passed across 4 files**. Covers numeric IDs with whitespace and differing lengths, opaque and dotted credentials, invalid typed input, missing credentials, environment setup, unresolved SecretRef state, and existing guild settings.
- Fresh synthetic setup-contract probe: before, `validationError=null` and the numeric value reached the returned configuration; after, an actionable application-ID error is returned and the numeric token is not applied. The existing DM policy remains intact. No real credential or live Gateway was used.
- Exact-head [CI run](https://github.com/openclaw/openclaw/actions/runs/34073117142): **success**.
- [ClawSweeper's current-head review](https://github.com/openclaw/openclaw/pull/140531#issuecomment-5563289902): proof sufficient, no actionable findings or before-merge blockers.

### Contributor's production CLI proof

The contributor exercised real argv parsing into `channelsAddCommand` from source on Windows 11 / Node 24.16, with `HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH` pointing to an isolated temporary directory. The seed retained `dmPolicy: pairing` and `enabled: false`; no real token or live Discord request was used.

Before the fix, `openclaw channels add --channel discord --token 1234567890123456789` exited 0 and persisted the synthetic numeric ID. At the initial fix head `57612a4d0e82e32ded433b11986153cba242c1ea`, the same command exited 1 with the Bot-page correction and left the seeded config byte-identical. A synthetic nonnumeric correction exited 0 and preserved existing DM policy. The final validator preserves these outcomes and adds the numeric/opaque cases covered by the fresh tests above.

This is setup-boundary proof, not live Discord authentication or proof of the separate startup/status issue. No dependency, config option, schema, SDK contract, or changelog change is included.

Independent final-head Codex review against the PR merge base is **scoped-clean through P2**, with no actionable findings. `pnpm check:changed` and `git diff --check acbff80d68fce81afc695684b0a957661b9ee05a HEAD` both passed on the exact final head in an independent checkout. The initial nested-checkout attempt hit an ancestor dependency-resolution leak; the independent checkout resolved it without changing source or weakening checks. Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 140531` also passed its hosted-CI verification and preserved the same remote head.
