### PR TITLE
refactor(agents): use canonical Gateway node inventory

### DIFF
--- a/src/agents/bash-tools.exec-host-node-phases.test.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { GatewayClientRequestError } from "../../packages/gateway-client/src/request-error.js";
 import {
   formatNodeInvokeFailureFollowup,
   invokeNodeSystemRun,
@@ -124,23 +123,15 @@ describe("node execution target resolution", () => {
     callGatewayToolMock.mockReset();
   });
 
-  it("rejects legacy paired-node records without execution capabilities", async () => {
-    callGatewayToolMock
-      .mockRejectedValueOnce(
-        new GatewayClientRequestError({
-          code: "INVALID_REQUEST",
-          message: "unknown method: node.list",
-        }),
-      )
-      .mockResolvedValueOnce({ paired: [{ nodeId: "legacy-node", platform: "linux" }] });
+  it("rejects inventory records without execution capabilities", async () => {
+    callGatewayToolMock.mockResolvedValueOnce({
+      nodes: [{ nodeId: "node-1", platform: "linux" }],
+    });
 
     await expect(resolveNodeExecutionTarget(createDirectNodeRun().request)).rejects.toThrow(
       /supports system.run/,
     );
-    expect(callGatewayToolMock.mock.calls.map(([method]) => method)).toEqual([
-      "node.list",
-      "node.pair.list",
-    ]);
+    expect(callGatewayToolMock.mock.calls.map(([method]) => method)).toEqual(["node.list"]);
   });
 
   it("requires an explicit target when multiple connected nodes support system.run", async () => {

--- a/src/agents/tools/nodes-utils.test.ts
+++ b/src/agents/tools/nodes-utils.test.ts
@@ -1,5 +1,4 @@
-// Node utility tests cover node selection defaults and gateway fallback between
-// current and legacy node list methods.
+// Node selection defaults and Gateway inventory requests.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayProtocolRequestTimeoutError } from "../../../packages/gateway-client/src/protocol-request.js";
 import { GatewayClientRequestError } from "../../../packages/gateway-client/src/request-error.js";
@@ -143,49 +142,27 @@ describe("resolveNodeIdFromList defaults", () => {
 });
 
 describe("listNodes", () => {
-  it("falls back to node.pair.list only when node.list is unavailable", async () => {
-    // Old gateways only expose node.pair.list; newer authorization failures
-    // must still surface instead of being hidden by fallback.
-    gatewayMocks.callGatewayTool
-      .mockRejectedValueOnce(
-        new GatewayClientRequestError({
-          code: "INVALID_REQUEST",
-          message: "unknown method: node.list",
-        }),
-      )
-      .mockResolvedValueOnce({
-        pending: [],
-        paired: [{ nodeId: "pair-1", displayName: "Pair 1", platform: "ios", remoteIp: "1.2.3.4" }],
-      });
-
+  it("returns live node inventory and forwards cancellation", async () => {
+    const nodes = [node({ nodeId: "node-1", displayName: "Node 1", platform: "ios" })];
+    gatewayMocks.callGatewayTool.mockResolvedValueOnce({ nodes });
     const signal = new AbortController().signal;
-    await expect(listNodes({}, signal)).resolves.toEqual([
-      {
-        nodeId: "pair-1",
-        displayName: "Pair 1",
-        platform: "ios",
-        remoteIp: "1.2.3.4",
-      },
-    ]);
-    expect(gatewayMocks.callGatewayTool).toHaveBeenNthCalledWith(
-      1,
+    await expect(listNodes({}, signal)).resolves.toEqual(nodes);
+    expect(gatewayMocks.callGatewayTool).toHaveBeenCalledExactlyOnceWith(
       "node.list",
       {},
       {},
       { signal },
     );
-    expect(gatewayMocks.callGatewayTool).toHaveBeenNthCalledWith(
-      2,
-      "node.pair.list",
-      {},
-      {},
-      {
-        signal,
-      },
-    );
   });
 
   it.each([
+    {
+      label: "an unknown-method rejection",
+      error: new GatewayClientRequestError({
+        code: "INVALID_REQUEST",
+        message: "unknown method: node.list",
+      }),
+    },
     {
       label: "a local request timeout",
       error: new GatewayProtocolRequestTimeoutError({

--- a/src/agents/tools/nodes-utils.ts
+++ b/src/agents/tools/nodes-utils.ts
@@ -1,11 +1,6 @@
-/**
- * Nodes lookup helpers.
- *
- * Loads paired nodes from Gateway and resolves requested/default nodes with legacy pair-list fallback.
- */
+// Gateway node inventory and explicit/default target resolution.
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
-import { GatewayClientRequestError } from "../../../packages/gateway-client/src/request-error.js";
-import { parseNodeList, parsePairingList } from "../../shared/node-list-parse.js";
+import { parseNodeList } from "../../shared/node-list-parse.js";
 import type { NodeListNode } from "../../shared/node-list-types.js";
 import { resolveNodeFromNodeList, resolveNodeIdFromNodeList } from "../../shared/node-resolve.js";
 import { callGatewayTool, type GatewayCallOptions } from "./gateway.js";
@@ -19,33 +14,6 @@ type DefaultNodeSelectionOptions = {
   fallback?: DefaultNodeFallback;
   preferLocalMac?: boolean;
 };
-
-async function loadNodes(opts: GatewayCallOptions, signal?: AbortSignal): Promise<NodeListNode[]> {
-  try {
-    const res = await callGatewayTool("node.list", opts, {}, { signal });
-    return parseNodeList(res);
-  } catch (error) {
-    if (
-      !(error instanceof GatewayClientRequestError) ||
-      error.gatewayCode !== "INVALID_REQUEST" ||
-      error.retryable ||
-      error.message !== "unknown method: node.list" ||
-      (error.retryAfterMs !== undefined &&
-        (!Number.isInteger(error.retryAfterMs) || error.retryAfterMs < 0))
-    ) {
-      throw error;
-    }
-    // Older gateways only expose paired-node state; preserve node tools until node.list exists.
-    const res = await callGatewayTool("node.pair.list", opts, {}, { signal });
-    const { paired } = parsePairingList(res);
-    return paired.map((n) => ({
-      nodeId: n.nodeId,
-      displayName: n.displayName,
-      platform: n.platform,
-      remoteIp: n.remoteIp,
-    }));
-  }
-}
 
 function isLocalMacNode(node: NodeListNode): boolean {
   return (
@@ -120,12 +88,13 @@ function pickDefaultNode(nodes: NodeListNode[]): NodeListNode | null {
   });
 }
 
-/** Lists Gateway nodes, falling back to paired-node records for older Gateway versions. */
+/** Lists the Gateway node inventory. */
 export async function listNodes(
   opts: GatewayCallOptions,
   signal?: AbortSignal,
 ): Promise<NodeListNode[]> {
-  return loadNodes(opts, signal);
+  const res = await callGatewayTool("node.list", opts, {}, { signal });
+  return parseNodeList(res);
 }
 
 /** Resolves a node id from an already-loaded node list using shared node matching rules. */
@@ -157,7 +126,7 @@ export async function resolveAgentNode(
   query?: string,
   allowDefault = false,
 ): Promise<NodeListNode> {
-  const nodes = await loadNodes(opts);
+  const nodes = await listNodes(opts);
   return resolveNodeFromNodeList(nodes, query, {
     allowDefault,
     pickDefaultNode,


### PR DESCRIPTION
## What Problem This Solves

Agent node tools retain a second inventory path for Gateways without `node.list`, although every compatible stable Gateway already implements that method. This is a maintainer-requested production simplification follow-up to the #135868 split campaign.

## Why This Change Was Made

Use `node.list` as the single inventory owner and remove the `loadNodes` forwarding layer. The agent client uses the backend client mode and negotiates protocol 4 exclusively (`packages/gateway-protocol/src/version.ts`, `src/gateway/call.ts`). All 24 stable protocol-4 tags from v2026.5.12 through v2026.9.2 contain a real `node.list` handler; the earliest witness is [v2026.5.12 nodes.ts](https://github.com/openclaw/openclaw/blob/v2026.5.12/src/gateway/server-methods/nodes.ts#L839). The remote tag inventory was checked in full: all 110 calendar-version stable tags are present locally; the other 86 speak protocol 2 or 3 and are outside this client's negotiated contract.

Deletion evidence: the removed error classifier, `node.pair.list` request, and paired-record projection protected no admitted stable server. The public internal `listNodes` export still owns parsing and cancellation, and `resolveAgentNode` now calls it directly. Actual pairing operations continue to use their separate pairing API.

## User Impact

Supported Gateway inventory and target selection are unchanged. A server that violates the supported protocol's method set now surfaces its original error instead of returning partial pairing metadata.

## Evidence

- Focused owner suites before: 4 files, 107 cases, 6.85s; after: 4 files, 108 cases, 4.60s.
- Mobile UI and computer-tool consumers: 3 files, 107 cases, 8.08s.
- Node execution consumers: 4 files, 137 cases, 18.14s. Exact-head CI initially found a legacy fixture in `bash-tools.exec-host-node-phases.test.ts`; the capability rejection remains at line 126 as `rejects inventory records without execution capabilities`, now using `node.list`. Its no-dispatch assertion remains. Local reproduction confirmed the original test failure before this fixture repair.
- The removed test of the obsolete pairing fallback is replaced by `returns live node inventory and forwards cancellation` at `src/agents/tools/nodes-utils.test.ts:145`; all error-propagation cases remain in the table at line 159, extended with the formerly intercepted unknown-method error.
- Judged delta: production +6/−37 = **−31**; tests +18/−50 = **−32**; tooling/docs 0. No production growth or test cases removed.
- Independent autoreview: scoped-clean, no accepted/actionable findings.

- Full `node scripts/check-changed.mjs`: exit 0, including core and core-test type lanes, lint and all selected guards.
- Original-code proof: reverted the committed cut temporarily, retained the new test, and observed exactly the unknown-method case fail (20 passed, 1 failed). Restoring the production cut passes all 21 cases.
- No build required: internal inventory calls only; no packaging, published API or lazy boundary changed.

ClawSweeper reviewed the inventory change with no actionable findings or rank-up requests. The subsequent capability-test fixture repair passed fresh independent review and a second full changed-check run.
