### PR TITLE
refactor(tests): share explicit model fallback configs

### DIFF
--- a/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test-support.ts
@@ -4,7 +4,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
-import { makeModelFallbackCfg } from "../test-helpers/model-fallback-config-fixture.js";
+import { createModelFallbackConfig } from "../test-helpers/model-fallback-config-fixture.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   createOverflowRunParams,
@@ -525,16 +525,7 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
         provider: "codex",
         model: "gpt-5.5",
         runId: "run-codex-turn-completion-idle-timeout-fallback",
-        config: makeModelFallbackCfg({
-          agents: {
-            defaults: {
-              model: {
-                primary: "openai/gpt-5.5",
-                fallbacks: ["anthropic/claude-opus-4-6"],
-              },
-            },
-          },
-        }),
+        config: createModelFallbackConfig("openai/gpt-5.5", ["anthropic/claude-opus-4-6"]),
       });
 
       expect(result.payloads?.[0]).toMatchObject({

--- a/src/agents/embedded-agent-runner/run.codex-server-error-fallback.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.codex-server-error-fallback.test-support.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
-import { makeModelFallbackCfg } from "../test-helpers/model-fallback-config-fixture.js";
+import { createModelFallbackConfig } from "../test-helpers/model-fallback-config-fixture.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   MockedFailoverError,
@@ -68,16 +68,7 @@ describe("runEmbeddedAgent Codex server_error fallback handoff", () => {
       ...createOverflowRunParams(state),
       runId: "run-codex-server-error-fallback",
       agentHarnessRuntimeOverride: "openclaw",
-      config: makeModelFallbackCfg({
-        agents: {
-          defaults: {
-            model: {
-              primary: "openai/gpt-5.4",
-              fallbacks: ["anthropic/claude-opus-4-6"],
-            },
-          },
-        },
-      }),
+      config: createModelFallbackConfig("openai/gpt-5.4", ["anthropic/claude-opus-4-6"]),
     });
 
     await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);

--- a/src/agents/embedded-agent-runner/run.cross-provider-fallback-error-context.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.cross-provider-fallback-error-context.test-support.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
-import { makeModelFallbackCfg } from "../test-helpers/model-fallback-config-fixture.js";
+import { createModelFallbackConfig } from "../test-helpers/model-fallback-config-fixture.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   MockedFailoverError,
@@ -79,16 +79,10 @@ function expectDeepseekAssistant(value: unknown) {
 }
 
 function makeCrossProviderFallbackConfig() {
-  return makeModelFallbackCfg({
-    agents: {
-      defaults: {
-        model: {
-          primary: "openai/gpt-5.4",
-          fallbacks: ["deepseek/deepseek-chat", "google/gemini-2.5-flash"],
-        },
-      },
-    },
-  });
+  return createModelFallbackConfig("openai/gpt-5.4", [
+    "deepseek/deepseek-chat",
+    "google/gemini-2.5-flash",
+  ]);
 }
 
 function useCrossProviderAuthFixture() {

--- a/src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test-support.ts
@@ -1,7 +1,7 @@
 // Full-entry coverage for handing replay-safe prompt timeouts to model fallback.
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
-import { makeModelFallbackCfg } from "../test-helpers/model-fallback-config-fixture.js";
+import { createModelFallbackConfig } from "../test-helpers/model-fallback-config-fixture.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   MockedFailoverError,
@@ -54,16 +54,7 @@ describe("runEmbeddedAgent prompt timeout fallback handoff", () => {
       provider: "openai",
       model: "gpt-5.4",
       runId: "run-prompt-timeout-fallback",
-      config: makeModelFallbackCfg({
-        agents: {
-          defaults: {
-            model: {
-              primary: "openai/gpt-5.4",
-              fallbacks: ["anthropic/claude-opus-4-6"],
-            },
-          },
-        },
-      }),
+      config: createModelFallbackConfig("openai/gpt-5.4", ["anthropic/claude-opus-4-6"]),
     });
 
     await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);
@@ -145,16 +136,7 @@ describe("runEmbeddedAgent prompt timeout fallback handoff", () => {
       provider: "openai",
       model: "gpt-5.4",
       runId: "run-post-tool-idle-finalization",
-      config: makeModelFallbackCfg({
-        agents: {
-          defaults: {
-            model: {
-              primary: "openai/gpt-5.4",
-              fallbacks: ["anthropic/claude-opus-4-6"],
-            },
-          },
-        },
-      }),
+      config: createModelFallbackConfig("openai/gpt-5.4", ["anthropic/claude-opus-4-6"]),
     });
 
     expect(result.payloads).toEqual([{ text: "The note was written once." }]);

--- a/src/agents/embedded-agent-runner/run/assistant-failure.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.test.ts
@@ -17,6 +17,7 @@ import {
   buildEmbeddedRunnerAssistant,
   makeEmbeddedRunnerAttempt,
 } from "../../test-helpers/embedded-agent-runner-e2e-fixtures.js";
+import { createModelFallbackConfig } from "../../test-helpers/model-fallback-config-fixture.js";
 import { handleEmbeddedAssistantFailure } from "./assistant-failure.js";
 import { resolveEmbeddedRunAttemptTerminalState } from "./terminal-outcome.js";
 
@@ -440,16 +441,9 @@ describe("handleEmbeddedAssistantFailure", () => {
   it("recovers a real loopback Mistral partial EOF through embedded model fallback", async () => {
     const { assistant, partialText } = await streamIncompleteMistralResponseOverLoopback();
     const classification = classifyAssistantFailoverReason(assistant);
-    const config = {
-      agents: {
-        defaults: {
-          model: {
-            primary: "mistral/mistral-large-latest",
-            fallbacks: ["google/mock-2"],
-          },
-        },
-      },
-    } satisfies OpenClawConfig;
+    const config = createModelFallbackConfig("mistral/mistral-large-latest", [
+      "google/mock-2",
+    ]) satisfies OpenClawConfig;
     const calls: string[] = [];
     let embeddedFailure: { reason: string; rawError?: string } | undefined;
     let embeddedTrace: AssistantFailureInput["traceAttempts"] = [];
@@ -764,16 +758,10 @@ describe("handleEmbeddedAssistantFailure", () => {
     const previous = process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS;
     process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS = "60000";
     try {
-      const config = {
-        agents: {
-          defaults: {
-            model: {
-              primary: "openai/mock-0",
-              fallbacks: ["anthropic/mock-1", "groq/mock-2"],
-            },
-          },
-        },
-      } satisfies OpenClawConfig;
+      const config = createModelFallbackConfig("openai/mock-0", [
+        "anthropic/mock-1",
+        "groq/mock-2",
+      ]) satisfies OpenClawConfig;
       const calls: string[] = [];
       const run = async (provider: string, model: string) => {
         calls.push(`${provider}/${model}`);

--- a/src/agents/embedded-agent-runner/usage-reporting.test-support.ts
+++ b/src/agents/embedded-agent-runner/usage-reporting.test-support.ts
@@ -3,6 +3,7 @@
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { createModelFallbackConfig } from "../test-helpers/model-fallback-config-fixture.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   mockedAcquireAgentRunPreparedModelRuntime,
@@ -60,16 +61,7 @@ describe("runEmbeddedAgent usage reporting", () => {
   });
 
   it("bootstraps runtime plugins with the resolved workspace before running", async () => {
-    const config = {
-      agents: {
-        defaults: {
-          model: {
-            primary: "anthropic/test-model",
-            fallbacks: ["openai/gpt-5.5"],
-          },
-        },
-      },
-    };
+    const config = createModelFallbackConfig("anthropic/test-model", ["openai/gpt-5.5"]);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Response 1"],
@@ -139,16 +131,7 @@ describe("runEmbeddedAgent usage reporting", () => {
   });
 
   it("preserves an explicitly pinned harness across fallback plugin planning", async () => {
-    const config = {
-      agents: {
-        defaults: {
-          model: {
-            primary: "codex/test-model",
-            fallbacks: ["openai/gpt-5.5"],
-          },
-        },
-      },
-    };
+    const config = createModelFallbackConfig("codex/test-model", ["openai/gpt-5.5"]);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({ assistantTexts: ["Response 1"] }),
     );

--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -9,7 +9,10 @@ import { createDiagnosticLogRecordCapture } from "../logging/test-helpers/diagno
 import type { AuthProfileStore } from "./auth-profiles.js";
 import type { FailoverReason } from "./failover/signal.js";
 import type { SessionSuspensionParams } from "./session-suspension.js";
-import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
+import {
+  makeModelFallbackCfg,
+  createModelFallbackConfig,
+} from "./test-helpers/model-fallback-config-fixture.js";
 
 function routingProvenance(
   requestedProvider: string,
@@ -239,16 +242,10 @@ async function expectProbeFailureFallsBack({
 }) {
   // Shared expectation for transient primary probe failures: probe the primary
   // once, then move to the first fallback with transient probing still allowed.
-  const cfg = makeCfg({
-    agents: {
-      defaults: {
-        model: {
-          primary: "openai/gpt-4.1-mini",
-          fallbacks: ["anthropic/claude-haiku-3-5", "google/gemini-2-flash"],
-        },
-      },
-    },
-  } as Partial<OpenClawConfig>);
+  const cfg = createModelFallbackConfig("openai/gpt-4.1-mini", [
+    "anthropic/claude-haiku-3-5",
+    "google/gemini-2-flash",
+  ]);
 
   mockedIsProfileInCooldown.mockReturnValue(true);
   mockedGetSoonestCooldownExpiry.mockReturnValue(1_700_000_000_000 + 30 * 1000);
@@ -518,16 +515,10 @@ describe("runWithModelFallback – probe logic", () => {
 
     probeThrottleInternals.lastProbeAttempt.clear();
 
-    const fallbackCfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-4.1-mini",
-            fallbacks: ["anthropic/claude-haiku-3-5", "google/gemini-2-flash"],
-          },
-        },
-      },
-    } as Partial<OpenClawConfig>);
+    const fallbackCfg = createModelFallbackConfig("openai/gpt-4.1-mini", [
+      "anthropic/claude-haiku-3-5",
+      "google/gemini-2-flash",
+    ]);
     mockedGetSoonestCooldownExpiry.mockReturnValue(NOW + 60 * 1000);
     const fallbackRun = vi
       .fn()
@@ -648,16 +639,10 @@ describe("runWithModelFallback – probe logic", () => {
   );
 
   it("keeps walking remaining fallbacks after an abort-wrapped RESOURCE_EXHAUSTED probe failure", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "google/gemini-3-flash-preview",
-            fallbacks: ["anthropic/claude-haiku-3-5", "deepseek/deepseek-chat"],
-          },
-        },
-      },
-    } as Partial<OpenClawConfig>);
+    const cfg = createModelFallbackConfig("google/gemini-3-flash-preview", [
+      "anthropic/claude-haiku-3-5",
+      "deepseek/deepseek-chat",
+    ]);
 
     mockedResolveAuthProfileOrder.mockImplementation(({ provider }: { provider: string }) => {
       if (provider === "google") {
@@ -874,16 +859,7 @@ describe("runWithModelFallback – probe logic", () => {
   });
 
   it("does not suspend the session when fallback candidates remain", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-4.1-mini",
-            fallbacks: ["anthropic/claude-haiku-3-5"],
-          },
-        },
-      },
-    } as Partial<OpenClawConfig>);
+    const cfg = createModelFallbackConfig("openai/gpt-4.1-mini", ["anthropic/claude-haiku-3-5"]);
 
     // Put only OpenAI into cooldown; Anthropic is available
     mockedIsProfileInCooldown.mockImplementation((_store: AuthProfileStore, profileId: string) =>
@@ -907,16 +883,7 @@ describe("runWithModelFallback – probe logic", () => {
   });
 
   it("defers embedded session suspension only while another candidate remains", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-4.1-mini",
-            fallbacks: ["anthropic/claude-haiku-3-5"],
-          },
-        },
-      },
-    } as Partial<OpenClawConfig>);
+    const cfg = createModelFallbackConfig("openai/gpt-4.1-mini", ["anthropic/claude-haiku-3-5"]);
     mockedIsProfileInCooldown.mockReturnValue(false);
     const run = vi
       .fn()
@@ -996,16 +963,7 @@ describe("runWithModelFallback – probe logic", () => {
   );
 
   it("keeps generic no-lane terminal suspension unbound", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-4.1-mini",
-            fallbacks: ["anthropic/claude-haiku-3-5"],
-          },
-        },
-      },
-    } as Partial<OpenClawConfig>);
+    const cfg = createModelFallbackConfig("openai/gpt-4.1-mini", ["anthropic/claude-haiku-3-5"]);
 
     // Both providers in cooldown
     mockedIsProfileInCooldown.mockReturnValue(true);
@@ -1048,16 +1006,7 @@ describe("runWithModelFallback – probe logic", () => {
   });
 
   it("records the final candidate when later candidates cannot run", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-4.1-mini",
-            fallbacks: ["anthropic/claude-haiku-3-5"],
-          },
-        },
-      },
-    } as Partial<OpenClawConfig>);
+    const cfg = createModelFallbackConfig("openai/gpt-4.1-mini", ["anthropic/claude-haiku-3-5"]);
     mockedIsProfileInCooldown.mockImplementation((_store: AuthProfileStore, profileId: string) =>
       profileId.startsWith("anthropic"),
     );
@@ -1090,16 +1039,7 @@ describe("runWithModelFallback – probe logic", () => {
   });
 
   it("restores deferred suspension when a later harness precheck fails", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-4.1-mini",
-            fallbacks: ["anthropic/claude-haiku-3-5"],
-          },
-        },
-      },
-    } as Partial<OpenClawConfig>);
+    const cfg = createModelFallbackConfig("openai/gpt-4.1-mini", ["anthropic/claude-haiku-3-5"]);
     mockedIsProfileInCooldown.mockReturnValue(false);
     const run = vi.fn().mockRejectedValueOnce(new Error("primary failed"));
 

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -47,7 +47,10 @@ import {
 } from "./run-termination.js";
 import { toSandboxProvisioningError } from "./sandbox/provisioning-error.js";
 import { resolveSessionSuspensionReason } from "./session-suspension.js";
-import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
+import {
+  makeModelFallbackCfg,
+  createModelFallbackConfig,
+} from "./test-helpers/model-fallback-config-fixture.js";
 
 const emptyManifestPlugins = [] as const;
 
@@ -848,16 +851,10 @@ describe("runWithModelFallback", () => {
     const previous = process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS;
     process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS = "60000";
     try {
-      const cfg = makeCfg({
-        agents: {
-          defaults: {
-            model: {
-              primary: "openai/gpt-5.4",
-              fallbacks: ["anthropic/claude-opus-4-7", "google/gemini-3.1-pro-preview"],
-            },
-          },
-        },
-      });
+      const cfg = createModelFallbackConfig("openai/gpt-5.4", [
+        "anthropic/claude-opus-4-7",
+        "google/gemini-3.1-pro-preview",
+      ]);
       const run = vi.fn(async (provider: string, model: string) => {
         if (provider === "openai") {
           throw new FailoverError("primary rate limited", {
@@ -1256,16 +1253,7 @@ describe("runWithModelFallback", () => {
   });
 
   it("carries the route origin for every fallback candidate", () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-4.1-mini",
-            fallbacks: ["anthropic/claude-haiku-3-5"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-4.1-mini", ["anthropic/claude-haiku-3-5"]);
 
     expect(
       testing.resolveFallbackCandidateRoutes({
@@ -1391,16 +1379,7 @@ describe("runWithModelFallback", () => {
   });
 
   it("does not treat Codex missing tool-result failures as model fallback candidates", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.4",
-            fallbacks: ["anthropic/claude-sonnet-4-6"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-5.4", ["anthropic/claude-sonnet-4-6"]);
     const missingToolResultError = new Error(
       "OpenClaw recorded a native Codex tool.call without a matching tool.result before the turn completed.",
     );
@@ -1418,16 +1397,7 @@ describe("runWithModelFallback", () => {
   });
 
   it("still falls back on unstructured provider text that merely mentions missing_tool_result", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.4",
-            fallbacks: ["anthropic/claude-sonnet-4-6"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-5.4", ["anthropic/claude-sonnet-4-6"]);
     const run = vi
       .fn()
       .mockRejectedValueOnce(new Error("provider diagnostic reason=missing_tool_result"))
@@ -1524,16 +1494,7 @@ describe("runWithModelFallback", () => {
   });
 
   it("fails closed when a strict plugin harness is missing", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.5",
-            fallbacks: ["anthropic/claude-sonnet-4-6"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-5.5", ["anthropic/claude-sonnet-4-6"]);
     const run = vi
       .fn()
       .mockRejectedValueOnce(new MissingAgentHarnessError("codex"))
@@ -1650,16 +1611,7 @@ describe("runWithModelFallback", () => {
   });
 
   it("uses session runtime overrides before auth cooldown skips", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.5",
-            fallbacks: ["anthropic/claude-sonnet-4-6"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-5.5", ["anthropic/claude-sonnet-4-6"]);
     const tempDir = await makeAuthTempDir();
     setAuthRuntimeStore(tempDir, {
       version: AUTH_STORE_VERSION,
@@ -1961,16 +1913,7 @@ describe("runWithModelFallback", () => {
   });
 
   it("does not run a second candidate after a canonical hard run timeout", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.4",
-            fallbacks: ["anthropic/claude-sonnet-4-6"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-5.4", ["anthropic/claude-sonnet-4-6"]);
     const timeoutError = new AgentRunTerminalOutcomeError(
       new Error("attempt aborted before prompt submission"),
       {
@@ -1994,16 +1937,10 @@ describe("runWithModelFallback", () => {
   });
 
   it("aborts the fallback chain when the transcript writer claim rebounds", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.4",
-            fallbacks: ["anthropic/claude-sonnet-4-6", "openai/gpt-4.1-mini"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-5.4", [
+      "anthropic/claude-sonnet-4-6",
+      "openai/gpt-4.1-mini",
+    ]);
     const reboundError = new Error("session writer claim changed before transcript persistence");
     reboundError.name = "SessionTranscriptWriterClaimReboundError";
     const run = vi.fn().mockRejectedValue(reboundError);
@@ -2020,16 +1957,10 @@ describe("runWithModelFallback", () => {
   });
 
   it("does not retry a superseded harness session generation on fallback models", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.4",
-            fallbacks: ["anthropic/claude-sonnet-4-6", "openai/gpt-4.1-mini"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-5.4", [
+      "anthropic/claude-sonnet-4-6",
+      "openai/gpt-4.1-mini",
+    ]);
     const supersededError = new AgentHarnessSessionSupersededError(
       "Codex session generation is no longer current: session-old",
     );
@@ -2047,16 +1978,10 @@ describe("runWithModelFallback", () => {
   });
 
   it("does not repeat model-independent harness preflight on fallback models", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.4",
-            fallbacks: ["anthropic/claude-sonnet-4-6", "openai/gpt-4.1-mini"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-5.4", [
+      "anthropic/claude-sonnet-4-6",
+      "openai/gpt-4.1-mini",
+    ]);
     const preflightError = new AgentHarnessPreflightError(
       "Computer Use live test failed after 2 attempts: thread/start timed out",
     );
@@ -2174,16 +2099,10 @@ describe("runWithModelFallback", () => {
   });
 
   it("does not spend model fallbacks on sandbox provisioning failures", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.4",
-            fallbacks: ["anthropic/claude-sonnet-4-6", "openai/gpt-4.1-mini"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-5.4", [
+      "anthropic/claude-sonnet-4-6",
+      "openai/gpt-4.1-mini",
+    ]);
     const provisioningError = toSandboxProvisioningError(
       new Error("Sandbox image not found: openclaw-sandbox:analyst. Build or pull it first."),
       "docker",
@@ -2208,16 +2127,10 @@ describe("runWithModelFallback", () => {
   });
 
   it("aborts fallback when a provider-looking wrapper carries writer claim rebound", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.4",
-            fallbacks: ["anthropic/claude-sonnet-4-6", "openai/gpt-4.1-mini"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-5.4", [
+      "anthropic/claude-sonnet-4-6",
+      "openai/gpt-4.1-mini",
+    ]);
     const writerClaimRebound = new Error(
       "session writer claim changed before transcript persistence",
     );
@@ -2239,16 +2152,7 @@ describe("runWithModelFallback", () => {
   });
 
   it("aborts the fallback chain on stale gateway lifecycle errors (#116418)", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "ollama/qwen3:0.6b",
-            fallbacks: ["minimax/MiniMax-M3"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("ollama/qwen3:0.6b", ["minimax/MiniMax-M3"]);
     const lifecycleError = createAgentRunStaleLifecycleError();
     const wrappedLifecycleError = new Error("request was aborted", { cause: lifecycleError });
     wrappedLifecycleError.name = "AbortError";
@@ -2397,16 +2301,7 @@ describe("runWithModelFallback", () => {
   });
 
   it("aborts the fallback chain on transcript continuation failures without candidate_failed attribution", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.4",
-            fallbacks: ["anthropic/claude-sonnet-4-6"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-5.4", ["anthropic/claude-sonnet-4-6"]);
     const continuationError = new TranscriptNotContinuableError("assistant");
     const run = vi.fn().mockRejectedValue(continuationError);
     const onFallbackStep = vi.fn();
@@ -2427,16 +2322,7 @@ describe("runWithModelFallback", () => {
   });
 
   it("still continues fallback on genuine timeout-shaped errors (#99943)", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.4",
-            fallbacks: ["anthropic/claude-sonnet-4-6"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-5.4", ["anthropic/claude-sonnet-4-6"]);
     const timeoutError = Object.assign(new Error("request timed out"), { name: "TimeoutError" });
     const run = vi.fn().mockRejectedValueOnce(timeoutError).mockResolvedValueOnce("ok");
 
@@ -2453,16 +2339,9 @@ describe("runWithModelFallback", () => {
   });
 
   it("continues to the next model after a Google invalid-key response (#114784)", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "google/gemini-3.1-pro-preview",
-            fallbacks: ["anthropic/claude-sonnet-4-6"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("google/gemini-3.1-pro-preview", [
+      "anthropic/claude-sonnet-4-6",
+    ]);
     const googleInvalidKey = new Error(
       "Google Generative AI API error (400): API key not valid. Please pass a valid API key. [code=INVALID_ARGUMENT]",
     );
@@ -2489,16 +2368,7 @@ describe("runWithModelFallback", () => {
   });
 
   it("keeps raw provider schema errors in fallback summaries", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.4",
-            fallbacks: ["openai/gpt-5.4-mini"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-5.4", ["openai/gpt-5.4-mini"]);
     const rawError =
       "400 The following tools cannot be used with reasoning.effort 'minimal': web_search.";
     const run = vi.fn().mockRejectedValue(
@@ -2532,16 +2402,9 @@ describe("runWithModelFallback", () => {
   });
 
   it("uses the candidate message instead of mismatched provider raw errors", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "anthropic/claude-opus-4-7",
-            fallbacks: ["google/gemini-3-pro-preview"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("anthropic/claude-opus-4-7", [
+      "google/gemini-3-pro-preview",
+    ]);
     const rawError = "You exceeded your current OpenAI quota.";
     const run = vi.fn().mockRejectedValue(
       new FailoverError("LLM request timed out.", {
@@ -2570,16 +2433,9 @@ describe("runWithModelFallback", () => {
   it.each([false, true])(
     "attributes the final failed candidate after fallback (watchdog=%s)",
     async (watchdog) => {
-      const cfg = makeCfg({
-        agents: {
-          defaults: {
-            model: {
-              primary: "anthropic/claude-opus-4-7",
-              fallbacks: ["google/gemini-3-pro-preview"],
-            },
-          },
-        },
-      });
+      const cfg = createModelFallbackConfig("anthropic/claude-opus-4-7", [
+        "google/gemini-3-pro-preview",
+      ]);
       const timeout = createCliTimeoutError(
         {},
         {
@@ -2617,16 +2473,7 @@ describe("runWithModelFallback", () => {
   );
 
   it("carries request attribution through exhausted fallback summaries", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.4",
-            fallbacks: ["anthropic/claude-opus-4-6"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-5.4", ["anthropic/claude-opus-4-6"]);
     const run = vi
       .fn()
       .mockRejectedValueOnce(Object.assign(new Error("rate limit exceeded"), { status: 429 }))
@@ -2654,16 +2501,7 @@ describe("runWithModelFallback", () => {
   });
 
   it("uses optional result classification to continue to configured fallbacks", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.4",
-            fallbacks: ["anthropic/claude-haiku-3-5"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-5.4", ["anthropic/claude-haiku-3-5"]);
     const run = vi
       .fn()
       .mockResolvedValueOnce({ payloads: [] })
@@ -2702,16 +2540,7 @@ describe("runWithModelFallback", () => {
   });
 
   it("continues fallback after embedded provider business-denial payloads", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "zai/glm-5.1",
-            fallbacks: ["openai/gpt-5.5"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("zai/glm-5.1", ["openai/gpt-5.5"]);
     const rawError =
       '{"success":false,"code":"CE-011","message":"当前ak因违规请求被禁止访问该模型"}';
     const run = vi
@@ -3024,16 +2853,10 @@ describe("runWithModelFallback", () => {
   });
 
   it("continues fallback past a stale switch to an earlier candidate (#58496 family)", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-4.1-mini",
-            fallbacks: ["anthropic/claude-haiku-3-5", "deepseek/deepseek-chat"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-4.1-mini", [
+      "anthropic/claude-haiku-3-5",
+      "deepseek/deepseek-chat",
+    ]);
     const switchError = new LiveSessionModelSwitchError({
       provider: "openai",
       model: "gpt-4.1-mini",
@@ -3112,16 +2935,7 @@ describe("runWithModelFallback", () => {
   });
 
   it("returns runtime-changing live switches to the retry owner before redirecting", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "anthropic/claude-haiku-3-5",
-            fallbacks: ["openai/gpt-5.6-luna"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("anthropic/claude-haiku-3-5", ["openai/gpt-5.6-luna"]);
     const switchError = new LiveSessionModelSwitchError({
       provider: "openai",
       model: "gpt-5.6-luna",
@@ -3285,16 +3099,9 @@ describe("runWithModelFallback", () => {
   });
 
   it("keeps configured fallbacks before configured primary for duplicate provider model ids", () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "deepseek/deepseek-v4-flash",
-            fallbacks: ["minimax-portal/MiniMax-M2.7"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("deepseek/deepseek-v4-flash", [
+      "minimax-portal/MiniMax-M2.7",
+    ]);
 
     expect(
       testing.resolveFallbackCandidates({
@@ -3310,16 +3117,10 @@ describe("runWithModelFallback", () => {
   });
 
   it("keeps configured fallback chain when current model is a configured fallback", () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-4.1-mini",
-            fallbacks: ["anthropic/claude-haiku-3-5", "openrouter/deepseek-chat"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-4.1-mini", [
+      "anthropic/claude-haiku-3-5",
+      "openrouter/deepseek-chat",
+    ]);
 
     expect(
       testing.resolveFallbackCandidates({
@@ -3362,16 +3163,7 @@ describe("runWithModelFallback", () => {
   });
 
   it("treats normalized default refs as primary and keeps configured fallback chain", () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-4.1-mini",
-            fallbacks: ["anthropic/claude-haiku-3-5"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-4.1-mini", ["anthropic/claude-haiku-3-5"]);
 
     expect(
       testing.resolveFallbackCandidates({
@@ -3558,16 +3350,7 @@ describe("runWithModelFallback", () => {
   });
 
   it("preserves auth mode metadata after fallback exhaustion", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.6-sol",
-            fallbacks: ["openai/gpt-5.6-terra"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-5.6-sol", ["openai/gpt-5.6-terra"]);
     const run = vi.fn().mockRejectedValue(
       new FailoverError("OpenAI OAuth unavailable", {
         reason: "auth_permanent",
@@ -4070,16 +3853,7 @@ describe("runWithModelFallback", () => {
   });
 
   it("keeps the configured-primary tail when inherited fallbacks stay unset", () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-4.1-mini",
-            fallbacks: ["anthropic/claude-haiku-3-5"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("openai/gpt-4.1-mini", ["anthropic/claude-haiku-3-5"]);
 
     // Reply/command preparation must project inherited fallbacks to `undefined`
     // so the candidate resolver owns the ladder and appends the configured
@@ -4107,16 +3881,7 @@ describe("runWithModelFallback", () => {
 
   it("refreshes cooldown expiry from persisted auth state before fallback summary", async () => {
     const expiry = Date.now() + 120_000;
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "anthropic/claude-opus-4-5",
-            fallbacks: ["openai/gpt-5.2"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("anthropic/claude-opus-4-5", ["openai/gpt-5.2"]);
     const store: AuthProfileStore = {
       version: AUTH_STORE_VERSION,
       profiles: {
@@ -4164,16 +3929,7 @@ describe("runWithModelFallback", () => {
     const now = Date.now();
     const unrelatedExpiry = now + 15_000;
     const relevantExpiry = now + 90_000;
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "anthropic/claude-opus-4-5",
-            fallbacks: ["openai/gpt-5.2"],
-          },
-        },
-      },
-    });
+    const cfg = createModelFallbackConfig("anthropic/claude-opus-4-5", ["openai/gpt-5.2"]);
     const store: AuthProfileStore = {
       version: AUTH_STORE_VERSION,
       profiles: {
@@ -4622,16 +4378,10 @@ describe("runWithModelFallback", () => {
       const cases = [
         {
           name: "same provider versioned session model",
-          cfg: makeCfg({
-            agents: {
-              defaults: {
-                model: {
-                  primary: "anthropic/claude-opus-4-6",
-                  fallbacks: ["anthropic/claude-sonnet-4-5", "google/gemini-2.5-flash"],
-                },
-              },
-            },
-          }),
+          cfg: createModelFallbackConfig("anthropic/claude-opus-4-6", [
+            "anthropic/claude-sonnet-4-5",
+            "google/gemini-2.5-flash",
+          ]),
           provider: "anthropic",
           model: "claude-sonnet-4-20250514",
           calls: [
@@ -4641,16 +4391,9 @@ describe("runWithModelFallback", () => {
         },
         {
           name: "same provider model version difference",
-          cfg: makeCfg({
-            agents: {
-              defaults: {
-                model: {
-                  primary: "anthropic/claude-opus-4-6",
-                  fallbacks: ["groq/llama-3.3-70b-versatile"],
-                },
-              },
-            },
-          }),
+          cfg: createModelFallbackConfig("anthropic/claude-opus-4-6", [
+            "groq/llama-3.3-70b-versatile",
+          ]),
           provider: "anthropic",
           model: "claude-opus-4-5",
           calls: [
@@ -4679,16 +4422,9 @@ describe("runWithModelFallback", () => {
         },
         {
           name: "exact primary uses fallbacks",
-          cfg: makeCfg({
-            agents: {
-              defaults: {
-                model: {
-                  primary: "anthropic/claude-opus-4-6",
-                  fallbacks: ["groq/llama-3.3-70b-versatile"],
-                },
-              },
-            },
-          }),
+          cfg: createModelFallbackConfig("anthropic/claude-opus-4-6", [
+            "groq/llama-3.3-70b-versatile",
+          ]),
           provider: "anthropic",
           model: "claude-opus-4-6",
           calls: [
@@ -4756,16 +4492,10 @@ describe("runWithModelFallback", () => {
 
     it("attempts same-provider fallbacks during transient cooldowns", async () => {
       const { dir } = await makeAuthStoreWithCooldown("anthropic", "timeout");
-      const cfg = makeCfg({
-        agents: {
-          defaults: {
-            model: {
-              primary: "anthropic/claude-opus-4-6",
-              fallbacks: ["anthropic/claude-sonnet-4-5", "groq/llama-3.3-70b-versatile"],
-            },
-          },
-        },
-      });
+      const cfg = createModelFallbackConfig("anthropic/claude-opus-4-6", [
+        "anthropic/claude-sonnet-4-5",
+        "groq/llama-3.3-70b-versatile",
+      ]);
 
       const run = vi.fn().mockResolvedValueOnce("sonnet success");
 
@@ -4823,16 +4553,10 @@ describe("runWithModelFallback", () => {
 
     it("skips same-provider models on persistent auth cooldowns", async () => {
       const { dir } = await makeAuthStoreWithCooldown("anthropic", "auth");
-      const cfg = makeCfg({
-        agents: {
-          defaults: {
-            model: {
-              primary: "anthropic/claude-opus-4-6",
-              fallbacks: ["anthropic/claude-sonnet-4-5", "groq/llama-3.3-70b-versatile"],
-            },
-          },
-        },
-      });
+      const cfg = createModelFallbackConfig("anthropic/claude-opus-4-6", [
+        "anthropic/claude-sonnet-4-5",
+        "groq/llama-3.3-70b-versatile",
+      ]);
 
       const run = vi.fn().mockResolvedValueOnce("groq success");
 
@@ -4870,16 +4594,10 @@ describe("runWithModelFallback", () => {
       };
       setAuthRuntimeStore(tmpDir, store);
 
-      const cfg = makeCfg({
-        agents: {
-          defaults: {
-            model: {
-              primary: "anthropic/claude-opus-4-6",
-              fallbacks: ["anthropic/claude-sonnet-4-5", "groq/llama-3.3-70b-versatile"],
-            },
-          },
-        },
-      });
+      const cfg = createModelFallbackConfig("anthropic/claude-opus-4-6", [
+        "anthropic/claude-sonnet-4-5",
+        "groq/llama-3.3-70b-versatile",
+      ]);
 
       const run = vi
         .fn()

--- a/src/agents/sticky-model-selection.test.ts
+++ b/src/agents/sticky-model-selection.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createModelFallbackConfig } from "./test-helpers/model-fallback-config-fixture.js";
 
 const mocks = vi.hoisted(() => ({
   cfg: {} as OpenClawConfig,
@@ -84,16 +85,9 @@ describe("persistStickyModelSelection", () => {
     {
       name: "shared default for an inheriting agent",
       agentId: "main",
-      cfg: {
-        agents: {
-          defaults: {
-            model: {
-              primary: "anthropic/claude-opus-4-6",
-              fallbacks: ["openai/gpt-5.6-luna"],
-            },
-          },
-        },
-      } satisfies OpenClawConfig,
+      cfg: createModelFallbackConfig("anthropic/claude-opus-4-6", [
+        "openai/gpt-5.6-luna",
+      ]) satisfies OpenClawConfig,
       target: "defaults" as const,
     },
     {

--- a/src/agents/test-helpers/model-fallback-config-fixture.ts
+++ b/src/agents/test-helpers/model-fallback-config-fixture.ts
@@ -18,3 +18,13 @@ export function makeModelFallbackCfg(overrides: Partial<OpenClawConfig> = {}): O
     ...overrides,
   } as OpenClawConfig;
 }
+
+export function createModelFallbackConfig(primary: string, fallbacks: string[]): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        model: { primary, fallbacks },
+      },
+    },
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Model fallback tests repeat the same nested configuration structure around explicit primary and fallback model references in 55 places.

## Why This Change Was Made

Add a constructor in the existing test fixture owner that requires both inputs, creates fresh wrapper objects, and preserves the supplied fallback array. Use it only at the 55 audited sites. The existing helper's defaults and shallow override behavior remain unchanged, as do case inputs, expected outcomes, and allocation timing. Net removal: 360 test lines and 49 test-support lines.

## User Impact

Less repeated test fixture code, with no production behavior change or runtime improvement claimed.

## Evidence

All 337 focused cases pass before and after, plus 161 model-selection and candidate-resolution siblings. The full changed-file gate, deslop, and independent review through P2 pass.

The preservation proof compares all 55 ordered object graphs, property descriptors, values, array references, and per-call freshness. It also matches 46,868 parsed tokens with allocation markers and confirms the old helper is byte-identical. A reversed-fallback diagnostic fails the independent order comparison. Intentional local-variable sharing, table-time allocation, and independent expected results remain intact.
