### PR TITLE
fix(plugins): isolate unreadable tool factory errors

### DIFF
--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -3698,6 +3698,14 @@ describe("resolvePluginTools optional tools", () => {
   it.each([
     ["unlogged invalid-config", createInvalidConfigError("/tmp/openclaw.json", "invalid property")],
     ["ordinary factory", new Error("factory unavailable")],
+    [
+      "unreadable-message factory",
+      Object.defineProperty(new Error("unreadable message"), "message", {
+        get() {
+          throw new Error("message getter failed");
+        },
+      }),
+    ],
   ])("still logs %s errors from plugin factories (#137694)", (_kind, error) => {
     setRegistry([
       createNamedToolEntry("memory-wiki", "memory_wiki_tool", {
@@ -3705,6 +3713,7 @@ describe("resolvePluginTools optional tools", () => {
           throw error;
         },
       }),
+      createNamedToolEntry("healthy-plugin", "healthy_tool"),
     ]);
     const errorSpy = vi.fn();
     loggingState.rawConsole = { log: vi.fn(), info: vi.fn(), warn: vi.fn(), error: errorSpy };
@@ -3712,7 +3721,7 @@ describe("resolvePluginTools optional tools", () => {
 
     expectResolvedToolNames(
       resolvePluginTools(createResolveToolsParams({ toolAllowlist: ["*"] })),
-      [],
+      ["healthy_tool"],
     );
     expect(errorSpy).toHaveBeenCalledOnce();
     expect(errorSpy).toHaveBeenCalledWith(

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -6,6 +6,7 @@ import { normalizeToolPolicyName } from "../agents/tool-policy.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { normalizeConversationReadInvocationOrigin } from "../channels/plugins/conversation-read-origin.js";
 import { isInvalidConfigError } from "../config/io.invalid-config.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   getLoadedRuntimePluginRegistry,
@@ -368,7 +369,7 @@ function resolvePluginToolFactoryEntry(params: {
     // sets diagnosticEmitted). Directly-created or wrapped tagged errors have
     // no prior log, so they still need the resolver diagnostic here.
     if (!(isInvalidConfigError(err) && err.diagnosticEmitted)) {
-      params.logError(`plugin tool failed (${params.entry.pluginId}): ${String(err)}`);
+      params.logError(`plugin tool failed (${params.entry.pluginId}): ${formatErrorMessage(err)}`);
     }
   }
 


### PR DESCRIPTION
A plugin tool factory can throw an Error whose `message` getter also throws. The resolver caught the factory failure, but its diagnostic used `String(err)`, which threw again and aborted assembly of healthy sibling tools.

Use the shared redacted error formatter at that catch boundary so the failed factory produces one diagnostic and resolution continues. Keep the existing suppression for invalid-config diagnostics already emitted by their owner. Extend the existing error table to cover the unreadable message and retain a healthy sibling in all three cases.

Validation on pinned main `30ea82ac`: the new case fails before the fix while both controls pass; 189 focused tests across optional tools, host-hook contracts, and registry lifecycle pass after it. A separate process with two generated plugins through the real loader reproduces the baseline assembly failure, then returns and successfully executes the healthy tool after the fix. That process receives an explicit minimal environment, no credentials, and isolated state; both runs exited naturally and their state directories were cleaned up.

Production LOC delta: +1 for importing the existing formatter; test LOC delta: +9. No new helper, dependency, configuration, or schema.

The complete changed-file gate, including typechecks and zero runtime import cycles, and independent P2 review pass.
