### PR TITLE
fix(xai): keep OAuth proxy transport and catalog on setup (#140482)

### DIFF
--- a/extensions/xai/model-definitions.ts
+++ b/extensions/xai/model-definitions.ts
@@ -288,6 +288,18 @@ export function buildXaiCatalogModels(): ModelDefinitionConfig[] {
   );
 }
 
+// Grok subscription (OAuth) serves the frontier models through the OAuth proxy
+// (cli-chat-proxy.grok.com). Only those are valid OAuth catalog rows: the API
+// catalog ids (grok-build-0.1, grok-4.3, grok-4.20-*) are not reachable over
+// the subscription transport and must never be written into an OAuth setup.
+const XAI_OAUTH_SELECTABLE_MODEL_IDS = new Set<string>(["grok-4.6", "grok-4.5"]);
+
+export function buildXaiOAuthCatalogModels(): ModelDefinitionConfig[] {
+  return XAI_MODEL_CATALOG.filter((entry) => XAI_OAUTH_SELECTABLE_MODEL_IDS.has(entry.id)).map(
+    (entry) => toModelDefinition(entry),
+  );
+}
+
 export function resolveXaiCatalogEntry(modelId: string) {
   const trimmed = modelId.trim();
   const lower = normalizeXaiCatalogModelId(modelId);

--- a/extensions/xai/onboard.test.ts
+++ b/extensions/xai/onboard.test.ts
@@ -119,6 +119,33 @@ describe("xai onboard", () => {
     expect(cfg.agents?.defaults?.models?.["xai/auto"]?.alias).toBe("Grok");
   });
 
+  it("keeps the OAuth proxy baseUrl and OAuth catalog for OAuth setup", () => {
+    // Regression for #140482: a successful Grok OAuth login must keep the
+    // subscription proxy transport (cli-chat-proxy.grok.com), not overwrite it
+    // with the API-key endpoint and API-only catalog models.
+    const cfg = applyXaiOAuthConfig({});
+
+    expect(cfg.models?.providers?.xai?.baseUrl).toBe("https://cli-chat-proxy.grok.com/v1");
+    expect(cfg.models?.providers?.xai?.api).toBe("openai-responses");
+    expect(cfg.models?.providers?.xai?.models.map((m) => m.id)).toEqual([
+      "grok-4.6",
+      "grok-4.5",
+    ]);
+  });
+
+  it("preserves existing subscription catalog models on OAuth re-login", () => {
+    // Repeated login must not keep appending API-catalog models: existing
+    // OAuth rows stay first, and no API-only ids are merged in.
+    const base = applyXaiOAuthConfig({});
+    const rerun = applyXaiOAuthConfig(base);
+
+    expect(rerun.models?.providers?.xai?.baseUrl).toBe("https://cli-chat-proxy.grok.com/v1");
+    expect(rerun.models?.providers?.xai?.models.map((m) => m.id)).toEqual([
+      "grok-4.6",
+      "grok-4.5",
+    ]);
+  });
+
   it("preserves existing model fallbacks", () => {
     const cfg = applyXaiConfig(createConfigWithFallbacks());
     expect(resolveAgentModelFallbackValues(cfg.agents?.defaults?.model)).toEqual([

--- a/extensions/xai/onboard.ts
+++ b/extensions/xai/onboard.ts
@@ -5,10 +5,13 @@ import {
 } from "openclaw/plugin-sdk/provider-onboard";
 import {
   buildXaiCatalogModels,
+  buildXaiOAuthCatalogModels,
   isLegacyXaiBuiltinModel,
   XAI_BASE_URL,
   XAI_DEFAULT_MODEL_ID,
 } from "./model-definitions.js";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { XAI_GROK_OAUTH_BASE_URL } from "./provider-catalog.js";
 import { XAI_OAUTH_AUTO_MODEL_ID } from "./model-id.js";
 
 export const XAI_DEFAULT_MODEL_REF = `xai/${XAI_DEFAULT_MODEL_ID}`;
@@ -16,21 +19,36 @@ export const XAI_DEFAULT_MODEL_REF = `xai/${XAI_DEFAULT_MODEL_ID}`;
 // remote default setting. API-key setup stays on the pinned default above.
 export const XAI_OAUTH_DEFAULT_MODEL_REF = `xai/${XAI_OAUTH_AUTO_MODEL_ID}`;
 
-function createXaiPresetAppliers(primaryModelRef: string) {
+function createXaiPresetAppliers(
+  primaryModelRef: string,
+  baseUrl: string,
+  catalogModels: ModelDefinitionConfig[],
+) {
   return createModelCatalogPresetAppliers<["openai-completions" | "openai-responses"]>({
     primaryModelRef,
     resolveParams: (_cfg: OpenClawConfig, api) => ({
       providerId: "xai",
       api,
-      baseUrl: XAI_BASE_URL,
-      catalogModels: buildXaiCatalogModels(),
+      baseUrl,
+      catalogModels,
       aliases: [{ modelRef: primaryModelRef, alias: "Grok" }],
     }),
   });
 }
 
-const xaiPresetAppliers = createXaiPresetAppliers(XAI_DEFAULT_MODEL_REF);
-const xaiOAuthPresetAppliers = createXaiPresetAppliers(XAI_OAUTH_DEFAULT_MODEL_REF);
+const xaiPresetAppliers = createXaiPresetAppliers(
+  XAI_DEFAULT_MODEL_REF,
+  XAI_BASE_URL,
+  buildXaiCatalogModels(),
+);
+// The OAuth preset keeps the subscription proxy transport and the OAuth-only
+// catalog (grok-4.6 / grok-4.5). Using the API baseUrl or the API catalog here
+// overwrites a working Grok subscription login with unusable API rows (#140482).
+const xaiOAuthPresetAppliers = createXaiPresetAppliers(
+  XAI_OAUTH_DEFAULT_MODEL_REF,
+  XAI_GROK_OAUTH_BASE_URL,
+  buildXaiOAuthCatalogModels(),
+);
 
 function pruneRetiredXaiBuiltinModels(cfg: OpenClawConfig): OpenClawConfig {
   const provider = cfg.models?.providers?.xai;


### PR DESCRIPTION
Closes #140482

## What Problem This Solves

Fixes an issue where a Grok (xAI) subscription user who already had a working OAuth login would have their provider metadata silently overwritten by the API-key endpoint the next time they ran `openclaw models auth login --provider xai --method oauth`: `models.providers.xai.baseUrl` became `https://api.x.ai/v1`, API-catalog models (`grok-build-0.1`, `grok-4.3`, `grok-4.20-0309-*`) were appended without the subscription proxy base URL, and `xai/auto` became unusable until the user manually restored the OAuth catalog.

## Why This Change Was Made

The OAuth setup preset was built by the same helper as the API-key preset, which hardcodes the public API base URL and the full API model catalog. A successful OAuth login then applied that preset, replacing the subscription proxy transport (`cli-chat-proxy.grok.com`) and merging in API-only rows that are not reachable over the Grok subscription.

The fix separates the two presets: the OAuth preset now keeps the subscription proxy base URL (`XAI_GROK_OAUTH_BASE_URL`) and constrains its catalog to the frontier models served over the subscription transport (`grok-4.6`, `grok-4.5`), via a shared `buildXaiOAuthCatalogModels()`. Both presets still preserve existing user model entries first (the SDK merge behavior is unchanged), so re-running login no longer appends API rows. The auto alias to `xai/auto` is intentionally left untouched here — that is tracked separately in #140466.

## User Impact

A Grok subscription user can re-run `openclaw models auth login --provider xai --method oauth` without losing their working subscription transport or gaining unusable API-key models; `xai/auto` and `xai/grok-4.6` keep resolving through `cli-chat-proxy.grok.com`. API-key setup is unchanged.

## Evidence

Regression tests added in `extensions/xai/onboard.test.ts`:

- `keeps the OAuth proxy baseUrl and OAuth catalog for OAuth setup` — asserts the OAuth preset writes `https://cli-chat-proxy.grok.com/v1` and only `grok-4.6` / `grok-4.5` (fails on main with `expected 'https://cli-chat-proxy.grok.com/v1' to be 'https://api.x.ai/v1'`).
- `preserves existing subscription catalog models on OAuth re-login` — asserts re-running the OAuth preset is idempotent over the catalog and does not append API rows.

Verified: `pnpm install` clean, `extensions/xai/onboard.test.ts` 8/8 passing under `test/vitest/vitest.extension-providers.config.ts`, `pnpm lint` (oxlint) passing on all three changed files, `tsc --noEmit -p extensions/xai/tsconfig.json` exit 0. No lockfile or unrelated changes.