### PR TITLE
fix(android): keep search readable at large text sizes

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt
@@ -11,6 +11,7 @@ import ai.openclaw.app.i18n.resolveNativeText
 import ai.openclaw.app.i18n.resolveNativeTextResource
 import ai.openclaw.app.i18n.verbatimText
 import ai.openclaw.app.ui.design.ClawEmptyState
+import ai.openclaw.app.ui.design.ClawListItem
 import ai.openclaw.app.ui.design.ClawPanel
 import ai.openclaw.app.ui.design.ClawPlainIconButton
 import ai.openclaw.app.ui.design.ClawScaffold
@@ -54,7 +55,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.style.TextAlign
@@ -296,26 +296,18 @@ private fun CommandActionRow(
 ) {
   val title = row.title.resolveNativeTextResource()
   val subtitle = row.subtitle.resolveNativeTextResource()
-  Surface(color = Color.Transparent, contentColor = ClawTheme.colors.text) {
-    Row(
-      modifier =
-        Modifier
-          .fillMaxWidth()
-          .heightIn(min = 52.dp)
-          .clip(RoundedCornerShape(ClawTheme.radii.row))
-          .clickable(onClickLabel = commandActionAccessibilityDescription(row.action, title), onClick = { onOpen(row.action) })
-          .padding(horizontal = 2.dp, vertical = 6.dp),
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.spacedBy(9.dp),
-    ) {
-      CommandRowIcon(icon = row.icon)
-      Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
-        Text(text = title, style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis)
-        Text(text = subtitle, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
-      }
-      CommandRowChevron(contentDescription = null)
-    }
-  }
+  ClawListItem(
+    title = title,
+    subtitle = subtitle,
+    modifier =
+      Modifier
+        .heightIn(min = 52.dp)
+        .clip(RoundedCornerShape(ClawTheme.radii.row))
+        .clickable(onClickLabel = commandActionAccessibilityDescription(row.action, title), onClick = { onOpen(row.action) })
+        .padding(horizontal = 2.dp),
+    leading = { CommandRowIcon(icon = row.icon) },
+    trailing = { CommandRowChevron(contentDescription = null) },
+  )
 }
 
 @Composable

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt
@@ -10,6 +10,7 @@ import ai.openclaw.app.i18n.nativeText
 import ai.openclaw.app.i18n.resolveNativeText
 import ai.openclaw.app.i18n.resolveNativeTextResource
 import ai.openclaw.app.i18n.verbatimText
+import ai.openclaw.app.ui.design.ClawAvatarMark
 import ai.openclaw.app.ui.design.ClawEmptyState
 import ai.openclaw.app.ui.design.ClawListItem
 import ai.openclaw.app.ui.design.ClawPanel
@@ -115,7 +116,7 @@ internal fun CommandPalette(
               modifier = Modifier.size(ClawTheme.spacing.touchTarget),
               contentAlignment = Alignment.Center,
             ) {
-              CommandAvatar(text = "OC")
+              ClawAvatarMark(text = "OC")
             }
           }
         }
@@ -373,21 +374,6 @@ private fun CommandRowChevron(contentDescription: String?) {
       modifier = Modifier.size(17.dp),
       tint = ClawTheme.colors.textMuted,
     )
-  }
-}
-
-@Composable
-private fun CommandAvatar(text: String) {
-  Surface(
-    modifier = Modifier.size(34.dp),
-    shape = CircleShape,
-    color = ClawTheme.colors.surfaceRaised,
-    contentColor = ClawTheme.colors.text,
-    border = BorderStroke(1.dp, ClawTheme.colors.border),
-  ) {
-    Box(contentAlignment = Alignment.Center) {
-      Text(text = localizedUppercase(text.take(2), currentAppLanguage().languageTag), style = ClawTheme.type.label)
-    }
   }
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawNavigation.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawNavigation.kt
@@ -1,5 +1,7 @@
 package ai.openclaw.app.ui.design
 
+import ai.openclaw.app.currentAppLanguage
+import ai.openclaw.app.ui.localizedUppercase
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -16,6 +18,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -28,6 +31,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
 
 /**
  * Stable bottom-navigation destination descriptor.
@@ -169,8 +174,15 @@ internal fun ClawAvatarMark(
     contentColor = ClawTheme.colors.text,
     border = BorderStroke(1.dp, ClawTheme.colors.border),
   ) {
-    Box(contentAlignment = Alignment.Center) {
-      Text(text = text.take(2).uppercase(), style = ClawTheme.type.label)
+    Box(modifier = Modifier.padding(4.dp), contentAlignment = Alignment.Center) {
+      val label = ClawTheme.type.label
+      // A fixed sp line height would still clip when autosizing shrinks the initials.
+      Text(
+        text = localizedUppercase(text.take(2), currentAppLanguage().languageTag),
+        style = label.copy(lineHeight = (label.lineHeight.value / label.fontSize.value).em),
+        maxLines = 1,
+        autoSize = TextAutoSize.StepBased(minFontSize = 1.sp, maxFontSize = label.fontSize),
+      )
     }
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/CommandPaletteLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/CommandPaletteLogicTest.kt
@@ -219,6 +219,11 @@ class CommandPaletteLogicTest {
       for (scale in listOf(1f, 2f)) {
         composeRule.runOnIdle { fontScale.value = scale }
         composeRule.onNodeWithContentDescription(nativeString("Search settings")).performClick()
+        try {
+          composeRule.onNode(hasText("OC") and hasAnyAncestor(searchResults), useUnmergedTree = true).assertCompleteText("OC")
+        } catch (error: AssertionError) {
+          failures += "$scale: avatar OC: ${error.message}"
+        }
         for ((index, label) in labels.withIndex()) {
           val node = composeRule.onNode(hasText(label) and hasAnyAncestor(searchResults), useUnmergedTree = true)
           node.performScrollTo().assertIsDisplayed()

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/CommandPaletteLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/CommandPaletteLogicTest.kt
@@ -8,7 +8,9 @@ import ai.openclaw.app.closeNodeRuntimeTestFixture
 import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.i18n.resolveNativeText
 import ai.openclaw.app.i18n.verbatimText
+import ai.openclaw.app.ui.design.assertCompleteText
 import android.content.Context
+import android.graphics.Bitmap
 import androidx.activity.OnBackPressedDispatcher
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.layout.width
@@ -16,12 +18,14 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.DeviceConfigurationOverride
 import androidx.compose.ui.test.FontScale
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasClickAction
@@ -32,6 +36,7 @@ import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToNode
@@ -53,6 +58,7 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 import org.robolectric.util.ReflectionHelpers
+import java.io.File
 import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
@@ -184,6 +190,65 @@ class CommandPaletteLogicTest {
       composeRule.onNodeWithText(nativeString("Licenses")).performClick()
       composeRule.onNodeWithText(nativeString("OpenClaw appreciates its partners in the open-source community.")).assertIsDisplayed()
       assertRuntimeUnchanged()
+    }
+  }
+
+  @Test
+  @GraphicsMode(GraphicsMode.Mode.NATIVE)
+  @Config(qualifiers = "fr-w320dp-h800dp-420dpi")
+  fun quickActionTitlesAndDescriptionsRemainReadableAtLargeFont() {
+    val fontScale = mutableStateOf(1f)
+    val labels =
+      listOf(
+        "Open Chat",
+        "Start or continue a conversation",
+        "Start Voice",
+        "Talk or dictate with OpenClaw",
+        "Browse Threads",
+        "Find previous conversations",
+        "Providers & Models",
+        "Connect Gateway to view providers",
+        "Settings",
+        "Gateway, voice, notifications, privacy",
+      ).map { nativeString(it) }
+    val evidence = File("build/outputs/search-action-readability", UUID.randomUUID().toString())
+    assertTrue(evidence.mkdirs())
+    withShell(HomeDestination.Settings, Modifier.width(320.dp), { fontScale.value }) { _, assertRuntimeUnchanged ->
+      val searchResults = hasScrollAction() and hasAnyDescendant(hasSetTextAction())
+      val failures = mutableListOf<String>()
+      for (scale in listOf(1f, 2f)) {
+        composeRule.runOnIdle { fontScale.value = scale }
+        composeRule.onNodeWithContentDescription(nativeString("Search settings")).performClick()
+        for ((index, label) in labels.withIndex()) {
+          val node = composeRule.onNode(hasText(label) and hasAnyAncestor(searchResults), useUnmergedTree = true)
+          node.performScrollTo().assertIsDisplayed()
+          File(evidence, "$scale-$index.png").outputStream().use {
+            assertTrue(
+              composeRule
+                .onRoot()
+                .captureToImage()
+                .asAndroidBitmap()
+                .compress(Bitmap.CompressFormat.PNG, 100, it),
+            )
+          }
+          try {
+            node.assertCompleteText(label)
+          } catch (error: AssertionError) {
+            failures += "$scale: $label: ${error.message}"
+          }
+          if (index % 2 == 0) {
+            val action = composeRule.onNode(hasText(label) and hasClickAction() and hasAnyAncestor(searchResults)).fetchSemanticsNode()
+            val clickLabel = if (index < 6) label else nativeString("Open \${row.title}", label)
+            assertEquals(clickLabel, action.config[SemanticsActions.OnClick].label)
+          }
+          assertRuntimeUnchanged()
+        }
+        composeRule.onNode(hasText(nativeString("Settings")) and hasClickAction() and hasAnyAncestor(searchResults)).performClick()
+        composeRule.onNode(hasSetTextAction()).assertDoesNotExist()
+        composeRule.onNodeWithTag("sidebar-open-settings").assertIsDisplayed()
+        assertRuntimeUnchanged()
+      }
+      assertTrue("Quick actions must expose their complete title and description:\n${failures.joinToString("\n")}", failures.isEmpty())
     }
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/design/ClawComponentsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/design/ClawComponentsTest.kt
@@ -88,6 +88,52 @@ class ClawComponentsTest {
   val composeRule = createComposeRule()
 
   @Test
+  fun avatarMarksKeepBothGlyphsInsideTheirCircleAtLargeFont() {
+    val fontScale = mutableStateOf(1f)
+    val marks = listOf("OC", "WW")
+    val evidence = File("build/outputs/avatar-monogram", UUID.randomUUID().toString())
+    assertTrue(evidence.mkdirs())
+    composeRule.setContent {
+      DeviceConfigurationOverride(DeviceConfigurationOverride.FontScale(fontScale.value)) {
+        ClawDesignTheme {
+          Column(modifier = Modifier.verticalScroll(rememberScrollState()), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            marks.forEach { ClawAvatarMark(text = it.lowercase(), modifier = Modifier.testTag("avatar-$it")) }
+          }
+        }
+      }
+    }
+    val failures = mutableListOf<String>()
+    for (scale in listOf(1f, 2f)) {
+      composeRule.runOnIdle { fontScale.value = scale }
+      for (mark in marks) {
+        val container = composeRule.onNodeWithTag("avatar-$mark")
+        val text = composeRule.onNodeWithText(mark, useUnmergedTree = true)
+        val layouts = mutableListOf<TextLayoutResult>()
+        text.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { assertTrue(it(layouts)) }
+        val layout = layouts.single()
+        val node = text.fetchSemanticsNode()
+        val circle = container.fetchSemanticsNode().boundsInRoot
+        val glyphs = mark.indices.map { layout.getBoundingBox(it).translate(node.positionInRoot) }
+        println("AVATAR_MONOGRAM scale=$scale text=$mark lines=${layout.lineCount} layout=${layout.size} paragraph=${layout.multiParagraph.height} circle=$circle glyphs=$glyphs")
+        File(evidence, "$scale-$mark.png").outputStream().use {
+          assertTrue(container.captureToImage().asAndroidBitmap().compress(Bitmap.CompressFormat.PNG, 100, it))
+        }
+        try {
+          text.assertCompleteText(mark)
+          assertEquals("Initials must remain one line", 1, layout.lineCount)
+          for (glyph in glyphs) {
+            assertTrue("Each initial needs positive glyph geometry", glyph.width > 0 && glyph.height > 0)
+            assertTrue("Both initials must fit inside the avatar bounds", glyph.left >= circle.left && glyph.top >= circle.top && glyph.right <= circle.right && glyph.bottom <= circle.bottom)
+          }
+        } catch (error: AssertionError) {
+          failures += "$scale: $mark: ${error.message}"
+        }
+      }
+    }
+    assertTrue("Avatar marks must retain their complete initials:\n${failures.joinToString("\n")}", failures.isEmpty())
+  }
+
+  @Test
   fun detailRowKeepsInstallOnlyTrustWarningVisible() {
     val results =
       parseClawHubSearchResults(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening Search would see truncated quick-action names and descriptions, especially with large text and longer translations. In French at 320dp/font scale 2, nine of ten labels lose text. The header's two-letter mark also clips its second letter.

## Why This Change Was Made

Replace duplicate action and monogram renderers with the existing shared components. Action text wraps at the chosen font size. The bounded decorative mark fits its text using Compose autosizing with proportional line height, without changing global font scaling. The original labelled click remains the sole action owner; typed destinations, filtering, availability and recent-thread previews are unchanged.

Combined production: +29/−39 (**10 fewer lines**). Tests: +116, four files total. No dependency, configuration, protocol or persistence change.

## User Impact

All five action names and descriptions remain readable, and both initials remain visible. Taller rows scroll normally. Navigation and accessibility action labels are preserved; the monogram cleanup leaves normal-size renders byte-for-byte unchanged from the action-row fix.

## Evidence

- Rendered red/green regressions cover ten action labels and both initials at French 320dp/font scales 1 and 2, complete glyph/line geometry, localized click labels and Settings dismissal.
- 79 owner/sibling tests pass, both Play and ThirdParty Kotlin variants compile, Android lint and ktlint pass, and all 14 changed checks pass. Independent review of the complete combined branch found no actionable P0–P2 findings.
- **Installed verification complete on `8991f70814c5efc5c97d6001d4276fea28ac24ba`.** The fresh Android 36 Testbox comparison installed baseline `422b8c0`, then performed one in-place update to the combined fix with the same package, signer and UID. All six configure/Search/restore cases completed: French 320dp at font scales 1 and 2, typed query and empty-query reopen, all five destination callbacks, final Settings navigation, and restoration of language, effective theme, display and text scale.
- With the keyboard still shown, one gesture per candidate font profile moved the editor, action title and description together by 51px and 65px. The query stayed empty and focused. No forced hide, retype or gesture replay was used. Complete original evidence (11,821 files) was downloaded and independently checked; full screenshots confirm readable action text and both initials. Owned processes and ports were checked closed, and the Testbox was stopped.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34078134897) is green. The [Testbox runtime](https://github.com/openclaw/openclaw/actions/runs/34091439759) used a synthetic fixture; this is installed UI/navigation evidence, not live-provider or complete chat-state preservation proof. The latest ClawSweeper before-merge and Rank-up requests are covered by this completed run.

Earlier incomplete runs remain failures: one reached its deadline; another stopped at the test observer's incorrect interpretation of Android window coordinates. The fresh run used the reviewed single-acquisition/current-window observer and completed without skipping required scenarios or extending its input deadline.

<details>
<summary>Before and after: French, large text (Compose/Robolectric, not installed APK proof)</summary>

Before:

![Before: quick actions lose their names and descriptions](https://github.com/user-attachments/assets/4614918e-a662-42a8-a481-bc6216c04e3e)

After, upper actions and complete initials:

![After: complete initials and wrapping upper actions](https://github.com/user-attachments/assets/945f4be9-ab6f-4833-bff8-71212c96777a)

After, lower actions (unchanged by the monogram fix):

![After: Providers and Settings descriptions wrap completely](https://github.com/user-attachments/assets/c3b489fe-2206-4ba2-87bc-2ad84e7f95e6)

</details>

<details>
<summary>After: normal text size, unchanged by monogram fitting</summary>

![After: all five actions at normal text size](https://github.com/user-attachments/assets/b301beff-8a2d-4852-ba4c-b223e60422da)

</details>

<details>
<summary>Installed APKs: French, 320dp, large text</summary>

Baseline: truncated action text and a clipped second initial.

![Before: large-text Search truncates quick actions and the second initial](https://github.com/user-attachments/assets/5ec208d3-7b43-4a18-a7a4-1b6e6748be97)

Combined fix: complete initials and wrapping upper actions, with the keyboard shown.

![After: complete initials and wrapping quick actions with the keyboard shown](https://github.com/user-attachments/assets/da50f522-fab3-43c9-a206-e196c591589a)

After one keyboard-visible scroll: the empty query stays focused and content moves upward.

![After one scroll: focused empty query and keyboard remain visible](https://github.com/user-attachments/assets/bee50964-fe5f-420c-9edc-c4907efe7945)

Lower actions after scrolling: complete Threads, Providers and Settings labels. Recent-thread previews retain their existing truncation behavior.

![After: complete lower quick-action names and descriptions](https://github.com/user-attachments/assets/e88311a8-5189-490b-8127-baeb5245e6aa)

</details>
