### PR TITLE
refactor(perplexity): remove redundant private-helper tests

### DIFF
--- a/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
@@ -458,8 +458,3 @@ export async function executePerplexitySearch(
   writeCachedSearchPayload(cacheKey, payload, cacheTtlMs);
   return payload;
 }
-
-export const testing = {
-  resolvePerplexityRequestModel,
-  resolvePerplexityApiKey,
-} as const;

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -1,5 +1,5 @@
 // Perplexity tests cover perplexity web search provider plugin behavior.
-import { withEnv, withEnvAsync } from "openclaw/plugin-sdk/test-env";
+import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const withTrustedWebSearchEndpointMock = vi.hoisted(() => vi.fn());
@@ -13,7 +13,6 @@ vi.mock("openclaw/plugin-sdk/provider-web-search", async (importOriginal) => {
 });
 
 import { createPerplexityWebSearchProvider } from "./perplexity-web-search-provider.js";
-import { testing } from "./perplexity-web-search-provider.runtime.js";
 
 const openRouterApiKeyEnv = ["OPENROUTER_API", "KEY"].join("_");
 const perplexityApiKeyEnv = ["PERPLEXITY_API", "KEY"].join("_");
@@ -415,27 +414,6 @@ describe("perplexity web search provider", () => {
 
     await expect(result).rejects.toThrow("Perplexity request canceled in flight");
     expect(withTrustedWebSearchEndpointMock.mock.calls[0]?.[0]?.signal).toBe(controller.signal);
-  });
-
-  it("strips the provider prefix only for direct chat request models", () => {
-    expect(
-      testing.resolvePerplexityRequestModel("https://api.perplexity.ai", "perplexity/sonar-pro"),
-    ).toBe("sonar-pro");
-    expect(
-      testing.resolvePerplexityRequestModel("https://openrouter.ai/api/v1", "perplexity/sonar-pro"),
-    ).toBe("perplexity/sonar-pro");
-  });
-
-  it.each([
-    { env: perplexityApiKeyEnv, key: directPerplexityApiKey, source: "perplexity_env" },
-    { env: openRouterApiKeyEnv, key: openRouterPerplexityApiKey, source: "openrouter_env" },
-  ])("retains the $source credential origin", ({ env, key, source }) => {
-    withEnv(
-      { [perplexityApiKeyEnv]: undefined, [openRouterApiKeyEnv]: undefined, [env]: key },
-      () => {
-        expect(testing.resolvePerplexityApiKey()).toEqual({ apiKey: key, source });
-      },
-    );
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Perplexity retains a production export solely for three private-helper test cases. The provider's existing 12-row execution table already verifies the endpoint, Authorization header, and request model behind those assertions.

## Why This Change Was Made

Remove the private testing export, its three redundant cases, and unused test imports. Keep the runtime functions and the complete execution table unchanged. The table independently resolves runtime credentials; metadata setup only determines the tool schema.

This finishes test-scaffolding cleanup left after the runtime configuration consolidation in #135159.

## User Impact

No runtime or public API behavior change. Direct Perplexity and OpenRouter routing, model-prefix handling, credential precedence, cache behavior, cancellation, and error coverage remain protected.

## Evidence

- Baseline 51/51; candidate 48/48. Exactly the three private-helper cases were removed; every retained case title matches.
- All 12 routing rows still inspect actual requests. Deliberately breaking prefix stripping fails the two direct-model rows; discarding environment origin fails the two opposite-prefix environment rows. Both controls used synthetic fixtures and the existing mocked transport, and were fully reverted before the candidate run.
- Production: five lines removed (private export plus blank line). Tests: +1/-23. Executable runtime function bytes are unchanged.
- Final independent review through P2 is clean. All 25 normal changed checks passed through the wrapper's local fallback after no ready remote provider; no authenticated vendor call is claimed for this behavior-neutral cleanup.
