### PR TITLE
fix(computer-use): fresh macOS proof rigs cannot list nodes

### DIFF
--- a/docs/nodes/computer-use.md
+++ b/docs/nodes/computer-use.md
@@ -85,6 +85,8 @@ Browser targets, pages, page elements, and dialogs are opaque capabilities. Reta
 
 The repository includes a development rig that preserves the real vertical path: agent-facing `computer` tool, Gateway `node.invoke`, paired node, and the selected node-local provider. It is deliberately isolated from the operator app and Gateway. The macOS path uses the signed app node; the Linux path uses the opt-in `cua-computer` plugin in a real X11 session.
 
+Both paths generate a fresh proof-only token in private config files: `gateway.auth.token` for the isolated Gateway and `gateway.remote.token` for the app or node. The Gateway launches with `--auth token --bind loopback`. The rig clears inherited Gateway credentials, URL/port overrides, and config/state/profile overrides so operator settings cannot replace the proof setup. Tokens never appear in emitted commands or `rig.json`; do not publish the generated configs or the whole scratch directory as proof.
+
 #### macOS
 
 Build a signed app from a clean, committed checkout, choose a fresh profile and non-default loopback port, and prepare the two config views:
@@ -97,7 +99,7 @@ scripts/dev/computer-use-macos-live-rig.sh prepare \
 
 Run the emitted `gateway` and `app` commands in separate terminals. The split config is intentional: the externally launched daemon reads a scratch config with `gateway.mode: "local"`, while the app profile reads `gateway.mode: "remote"`, direct transport, and the daemon's loopback URL. If the app reads local mode, its Port Guardian owns the route instead of joining the external daemon. The rig keeps its validated launch fields in non-executable `rig.json`; later commands reject unknown fields or paths that do not match the scratch/profile layout. It also seeds a dedicated `node` identity, completed onboarding, unpaused state, Computer Control, and the checkout path used to start the debug node worker. There is no separate node-mode toggle.
 
-In a third terminal, rerun the emitted `nodes` command until the paired entry is connected and advertises `computer.act` plus a `computerUse` descriptor. No operator-device approval step is involved: the loopback gateway silently pairs the rig's CLI identity on its first connect, and the proof runner is admitted as a local backend client without pairing at all. The rig keeps those two identities in separate state directories (`cli-state` and `agent-state`) because a paired operator device is pinned to the scopes of its first connect, and a CLI pairing would otherwise cap the proof client below `operator.write`.
+In a third terminal, rerun the emitted `nodes` command until the paired entry is connected and advertises `computer.act` plus a `computerUse` descriptor. No operator-device approval step is involved: the read-only CLI does not create an identity in fresh `cli-state`, and the proof token authenticates its loopback operator calls. The proof runner uses the same token as a local backend client in separate `agent-state`, retaining `operator.write`. Node device identity and pairing checks remain enabled; do not copy identities or disable device authentication to bootstrap the rig.
 
 If the node's command surface is still pending approval, take `.pending[0].requestId` from that `nodes` output and run `scripts/dev/computer-use-macos-live-rig.sh approve "$scratch" <request-id>`.
 
@@ -138,6 +140,8 @@ scripts/dev/computer-use-macos-live-rig.sh proof \
 ```
 
 The result and `window-before.png` / `window-after.png` stay under the scratch directory. A confirmed mutation must preserve the sentinel as the active X11 window and leave the pointer unchanged. An upstream `background_unavailable` or `background_occluded` result is valid refusal evidence only when it remains structured and no foreground retry is attempted. The rig rejects native Wayland even when `DISPLAY` is also present for XWayland; switch to X11 instead of claiming Wayland coverage.
+
+After either proof, stop only the Gateway, app/node, and fixture processes you launched for the rig. Retain only inspected proof results and synthetic captures, then remove the task-owned scratch directory. On macOS, also remove the fresh proof profile directory (`~/.openclaw-<profile>`) and its `ai.openclaw.mac.profile.<profile>` defaults domain. Never clean up the operator profile or Gateway.
 
 ### Windows and Linux (experimental, direct SDK)
 

--- a/scripts/dev/computer-use-macos-live-rig.sh
+++ b/scripts/dev/computer-use-macos-live-rig.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+umask 077
+
+# Proof config and credentials must win over the invoking operator's environment.
+unset OPENCLAW_GATEWAY_TOKEN OPENCLAW_GATEWAY_PASSWORD OPENCLAW_GATEWAY_URL OPENCLAW_GATEWAY_PORT
+unset OPENCLAW_CONFIG_PATH OPENCLAW_STATE_DIR OPENCLAW_PROFILE OPENCLAW_HOME OPENCLAW_AGENT_DIR
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
@@ -143,6 +148,45 @@ NODE
   esac
 }
 
+write_rig_configs() {
+  # Generate once inside Node: the token never enters shell arguments or output.
+  node - "$@" <<'NODE'
+const { randomBytes } = require("node:crypto");
+const fs = require("node:fs");
+const [platform, portRaw, gatewayPath, clientPath] = process.argv.slice(2);
+const port = Number(portRaw);
+const token = randomBytes(32).toString("hex");
+const nodes = { commands: { allow: ["computer.act"] } };
+const gateway = {
+  gateway: {
+    mode: "local",
+    port,
+    bind: "loopback",
+    auth: { mode: "token", token },
+    nodes,
+  },
+};
+const client = {
+  gateway: {
+    mode: "remote",
+    remote: { transport: "direct", url: `ws://127.0.0.1:${port}`, token },
+  },
+};
+if (platform === "linux") {
+  nodes.pairing = { autoApproveLocal: true, sshVerify: false };
+  client.browser = { enabled: false };
+  client.nodeHost = { browserProxy: { enabled: false } };
+  client.plugins = { entries: { "cua-computer": { enabled: true } } };
+} else {
+  client.gateway.port = port;
+  client.gateway.nodes = nodes;
+}
+for (const [file, config] of [[gatewayPath, gateway], [clientPath, client]]) {
+  fs.writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600, flag: "wx" });
+}
+NODE
+}
+
 prepare() {
   [[ $# -ge 4 && $# -le 5 ]] || { usage; exit 2; }
   local profile="$1"
@@ -189,30 +233,7 @@ prepare() {
   local staged_app_config="$scratch/app.json"
   local gateway_config="$scratch/gateway.json"
 
-  node - "$port" >"$gateway_config" <<'NODE'
-const port = Number(process.argv[2]);
-process.stdout.write(`${JSON.stringify({
-  gateway: {
-    mode: "local",
-    port,
-    auth: { mode: "none" },
-    nodes: { commands: { allow: ["computer.act"] } },
-  },
-}, null, 2)}\n`);
-NODE
-
-  node - "$port" >"$staged_app_config" <<'NODE'
-const port = Number(process.argv[2]);
-process.stdout.write(`${JSON.stringify({
-  gateway: {
-    mode: "remote",
-    port,
-    auth: { mode: "none" },
-    nodes: { commands: { allow: ["computer.act"] } },
-    remote: { transport: "direct", url: `ws://127.0.0.1:${port}` },
-  },
-}, null, 2)}\n`);
-NODE
+  write_rig_configs macos "$port" "$gateway_config" "$staged_app_config"
 
   mkdir -p "$app_state"
   cp "$staged_app_config" "$app_config"
@@ -266,38 +287,7 @@ prepare_linux() {
   mkdir -p "$scratch/agent-state" "$scratch/cli-state" "$scratch/gateway-state" "$scratch/node-state"
   local gateway_config="$scratch/gateway.json"
   local node_config="$scratch/node.json"
-  local gateway_token
-  gateway_token="$(node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("hex"))')"
-
-  node - "$port" "$gateway_token" >"$gateway_config" <<'NODE'
-const port = Number(process.argv[2]);
-const token = process.argv[3];
-process.stdout.write(`${JSON.stringify({
-  gateway: {
-    mode: "local",
-    port,
-    auth: { mode: "token", token },
-    nodes: {
-      commands: { allow: ["computer.act"] },
-      pairing: { autoApproveLocal: true, sshVerify: false },
-    },
-  },
-}, null, 2)}\n`);
-NODE
-
-  node - "$port" "$gateway_token" >"$node_config" <<'NODE'
-const port = Number(process.argv[2]);
-const token = process.argv[3];
-process.stdout.write(`${JSON.stringify({
-  gateway: {
-    mode: "remote",
-    remote: { transport: "direct", url: `ws://127.0.0.1:${port}`, token },
-  },
-  browser: { enabled: false },
-  nodeHost: { browserProxy: { enabled: false } },
-  plugins: { entries: { "cua-computer": { enabled: true } } },
-}, null, 2)}\n`);
-NODE
+  write_rig_configs linux "$port" "$gateway_config" "$node_config"
 
   node - "$repo_root" "$profile" "$port" "$gateway_config" "$scratch/gateway-state" \
     "$scratch/agent-state" "$node_config" "$scratch/node-state" "$DISPLAY" >"$scratch/rig.json" <<'NODE'
@@ -328,13 +318,11 @@ run_gateway() {
   [[ $# -eq 1 ]] || { usage; exit 2; }
   load_rig "$1"
   require_unoccupied_port "$OPENCLAW_CU_RIG_PORT"
-  local auth_mode="none"
-  [[ "$OPENCLAW_CU_RIG_PLATFORM" == "linux" ]] && auth_mode="token"
   exec env \
     OPENCLAW_CONFIG_PATH="$OPENCLAW_CU_RIG_GATEWAY_CONFIG" \
     OPENCLAW_STATE_DIR="$OPENCLAW_CU_RIG_GATEWAY_STATE" \
     node "$repo_root/scripts/run-node.mjs" --profile "$OPENCLAW_CU_RIG_PROFILE" \
-      gateway run --port "$OPENCLAW_CU_RIG_PORT" --auth "$auth_mode" --verbose
+      gateway run --port "$OPENCLAW_CU_RIG_PORT" --auth token --bind loopback --verbose
 }
 
 run_app() {
@@ -401,10 +389,9 @@ run_nodes() {
   [[ $# -eq 1 ]] || { usage; exit 2; }
   local scratch="$1"
   load_rig "$scratch"
-  # A paired operator device is pinned to the scopes of its first connect, and
-  # later widening needs an approval this rig cannot reach. The CLI therefore
-  # keeps its own identity here; the proof client stays in agent-state, where it
-  # is admitted unpaired as a local backend and keeps operator.write.
+  # Read-only CLI calls do not create device identities. The proof token admits
+  # loopback operator calls without pairing; node identity checks stay enabled.
+  # Keep CLI state separate from the proof runner's operator.write state.
   exec env \
     OPENCLAW_CONFIG_PATH="$OPENCLAW_CU_RIG_GATEWAY_CONFIG" \
     OPENCLAW_STATE_DIR="$scratch/cli-state" \

--- a/test/scripts/computer-use-live-rig.test.ts
+++ b/test/scripts/computer-use-live-rig.test.ts
@@ -1,5 +1,15 @@
 import { spawnSync } from "node:child_process";
-import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -42,8 +52,20 @@ function createRigRepository(): {
   copyFileSync(rigScriptSource, script);
   chmodSync(script, 0o755);
   writeFileSync(fixture, "# committed fixture\n");
-  writeFileSync(proof, "// committed proof\n");
-  writeExecutable(appExecutable, "#!/bin/sh\nexit 0\n");
+  const captureInvocation = `#!${process.execPath}
+console.log(JSON.stringify({
+  args: process.argv.slice(2),
+  config: process.env.OPENCLAW_CONFIG_PATH,
+  state: process.env.OPENCLAW_STATE_DIR,
+  profile: process.env.OPENCLAW_PROFILE,
+  ambient: ["OPENCLAW_GATEWAY_TOKEN", "OPENCLAW_GATEWAY_PASSWORD", "OPENCLAW_GATEWAY_URL", "OPENCLAW_GATEWAY_PORT"].filter(key => process.env[key] !== undefined),
+}));
+`;
+  writeFileSync(proof, captureInvocation);
+  writeFileSync(path.join(root, "scripts", "run-node.mjs"), captureInvocation);
+  writeExecutable(appExecutable, captureInvocation);
+  writeExecutable(path.join(fakeBin, "defaults"), '#!/bin/sh\n[ "$1" != read ]\n');
+  mkdirSync(path.join(root, "home"));
   writeExecutable(path.join(fakeBin, "codesign"), "#!/bin/sh\nexit 0\n");
   writeExecutable(path.join(fakeBin, "uname"), "#!/bin/sh\necho Linux\n");
   writeExecutable(path.join(fakeBin, "xdotool"), "#!/bin/sh\nexit 0\n");
@@ -83,12 +105,17 @@ function runRig(params: { root: string; script: string; fakeBin: string; args: s
     cwd: params.root,
     encoding: "utf8",
     env: {
-      ...process.env,
+      HOME: path.join(params.root, "home"),
+      OPENCLAW_HOME: path.join(params.root, "home"),
       DISPLAY: ":99",
-      WAYLAND_DISPLAY: "",
       XDG_SESSION_TYPE: "x11",
       PATH: `${params.fakeBin}:${process.env.PATH ?? ""}`,
+      OPENCLAW_GATEWAY_TOKEN: "synthetic-ambient-token",
+      OPENCLAW_GATEWAY_PASSWORD: "synthetic-ambient-password",
+      OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:18789",
+      OPENCLAW_GATEWAY_PORT: "18789",
     },
+    timeout: 15_000,
   });
 }
 
@@ -96,6 +123,108 @@ afterEach(() => {
   for (const root of fixtureRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+describe.each(["macos", "linux"] as const)("computer-use %s live rig auth", (platform) => {
+  async function prepareRig() {
+    const fixture = createRigRepository();
+    const scratch = path.join(fixture.root, "scratch");
+    const profile = "proof-test";
+    const port = String(await reservePort());
+    const args =
+      platform === "macos"
+        ? ["prepare", profile, port, fixture.app, scratch]
+        : ["prepare-linux", profile, port, scratch];
+    const result = runRig({ ...fixture, args });
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    return { ...fixture, scratch, profile, port, result };
+  }
+
+  it("generates matching private token configs for a fresh read-only CLI", async () => {
+    const rig = await prepareRig();
+    const gatewayPath = path.join(rig.scratch, "gateway.json");
+    const clientPath = path.join(rig.scratch, platform === "macos" ? "app.json" : "node.json");
+    const gateway = JSON.parse(readFileSync(gatewayPath, "utf8"));
+    const client = JSON.parse(readFileSync(clientPath, "utf8"));
+    expect(gateway.gateway.auth.mode).toBe("token");
+    // Boolean comparisons keep generated secrets out of assertion failures.
+    const token = gateway.gateway.auth.token;
+    expect(typeof token === "string" && /^[a-f0-9]{64}$/.test(token)).toBe(true);
+    expect(client.gateway.remote.token === token).toBe(true);
+    expect(`${rig.result.stdout}${rig.result.stderr}`.includes(token)).toBe(false);
+    expect(readFileSync(path.join(rig.scratch, "rig.json"), "utf8").includes(token)).toBe(false);
+    expect(gateway.gateway.mode).toBe("local");
+    expect(gateway.gateway.bind).toBe("loopback");
+    expect(gateway.gateway.nodes.commands.allow).toEqual(["computer.act"]);
+    expect(gateway.gateway.controlUi).toBeUndefined();
+    expect(client.gateway.mode).toBe("remote");
+    expect(client.gateway.remote.url).toBe(`ws://127.0.0.1:${rig.port}`);
+    expect(readdirSync(path.join(rig.scratch, "cli-state"))).toEqual([]);
+    const configPaths = [gatewayPath, clientPath];
+    if (platform === "macos") {
+      const appConfig = path.join(rig.root, "home", `.openclaw-${rig.profile}`, "openclaw.json");
+      expect(readFileSync(appConfig, "utf8") === readFileSync(clientPath, "utf8")).toBe(true);
+      expect(gateway.gateway.nodes.pairing).toBeUndefined();
+      configPaths.push(appConfig);
+    } else {
+      expect(gateway.gateway.nodes.pairing).toEqual({ autoApproveLocal: true, sshVerify: false });
+      expect(client.plugins.entries["cua-computer"].enabled).toBe(true);
+    }
+    for (const configPath of configPaths) {
+      expect(statSync(configPath).mode & 0o777).toBe(0o600);
+    }
+    const other = await prepareRig();
+    const otherToken = JSON.parse(readFileSync(path.join(other.scratch, "gateway.json"), "utf8"))
+      .gateway.auth.token;
+    expect(otherToken === token).toBe(false);
+  });
+
+  it("forces token/loopback launch and rejects ambient credential and target precedence", async () => {
+    const rig = await prepareRig();
+    const gatewayState =
+      platform === "macos"
+        ? path.join(rig.root, "home", `.openclaw-${rig.profile}`)
+        : path.join(rig.scratch, "gateway-state");
+    for (const [command, state, extra] of [
+      ["gateway", gatewayState, []],
+      ["nodes", path.join(rig.scratch, "cli-state"), []],
+      ["approve", path.join(rig.scratch, "agent-state"), ["synthetic-request"]],
+    ] as const) {
+      const result = runRig({ ...rig, args: [command, rig.scratch, ...extra] });
+      expect(result.stderr).toBe("");
+      expect(result.status).toBe(0);
+      const invocation = JSON.parse(result.stdout);
+      expect(invocation.ambient).toEqual([]);
+      expect(invocation.config).toBe(path.join(rig.scratch, "gateway.json"));
+      expect(invocation.state).toBe(state);
+      if (command === "gateway") {
+        expect(invocation.args).toEqual([
+          "--profile",
+          rig.profile,
+          "gateway",
+          "run",
+          "--port",
+          rig.port,
+          "--auth",
+          "token",
+          "--bind",
+          "loopback",
+          "--verbose",
+        ]);
+      }
+    }
+    const result = runRig({ ...rig, args: [platform === "macos" ? "app" : "node", rig.scratch] });
+    expect(result.status).toBe(0);
+    const invocation = JSON.parse(result.stdout);
+    expect(invocation.ambient).toEqual([]);
+    if (platform === "macos") {
+      expect(invocation.profile).toBe(rig.profile);
+    } else {
+      expect(invocation.config).toBe(path.join(rig.scratch, "node.json"));
+      expect(invocation.state).toBe(path.join(rig.scratch, "node-state"));
+    }
+  });
 });
 
 describe("computer-use live rig source integrity", () => {


### PR DESCRIPTION
Related: #138199. This is a separate proof-tooling repair and does not change that dependency PR.

## What Problem This Solves

Resolves a problem where maintainers preparing a fresh macOS computer-use proof rig could not list or approve nodes because the nodes CLI returned `device identity required`. The CLI intentionally uses read-only shared state and does not create an identity in a fresh `cli-state` directory, while the rig configured and forced unauthenticated Gateway mode.

## Why This Change Was Made

Use the existing authenticated loopback operator contract rather than weakening device authentication. Both macOS and Linux now generate one fresh proof-only token inside Node and write matching `gateway.auth.token` and `gateway.remote.token` configuration. The Gateway explicitly launches with `--auth token --bind loopback`.

Token-bearing configs are private from creation, generated tokens never enter shell arguments or emitted commands, and inherited Gateway credential/target and config/state/profile overrides cannot replace the isolated proof setup. Existing source-integrity, profile, port, signing, node identity, and pairing guards are preserved; Linux's existing pairing policy is unchanged. Documentation explains the read-only CLI contract and cleanup of task-owned proof state.

### Compatibility and review follow-up

The automated data-model compatibility checkbox is not applicable to this repair. No SQLite schema, persisted runtime-store contract, or `rig.json` format changes. The generated Gateway and client files use existing supported auth fields in disposable proof-only state; preparation requires a fresh profile and refuses an existing rig. Existing operator profiles, identities, and state are neither read nor migrated. Previously prepared proof scratch directories should be discarded using the documented task-owned cleanup and recreated, not upgraded in place. ClawSweeper's technical review found no introduced blocking defects or security findings.

## User Impact

Maintainers can prepare fresh macOS proof profiles without copying an operator identity or credentials, disabling device authentication, or touching the real Gateway. macOS and Linux share a coherent token setup. There is no change to production Gateway authentication or the computer-use providers.

## Evidence

- Executable shell regressions run the real copied rig in disposable repositories with isolated homes and stubbed platform/launch endpoints. The original script failed all four new cases; the repaired suite passes all six tests, including the two existing source-integrity guards.
- Coverage verifies matching per-rig random tokens, private config permissions, an empty fresh CLI state directory, absence of tokens in emitted output and `rig.json`, explicit token/loopback launch flags, isolated config/state routing, and ambient credential/target override rejection.
- Passed: `node scripts/run-vitest.mjs test/scripts/computer-use-live-rig.test.ts`.
- Passed required changed-file checks: `node scripts/check-changed.mjs -- scripts/dev/computer-use-macos-live-rig.sh test/scripts/computer-use-live-rig.test.ts docs/nodes/computer-use.md`.
- Passed shell syntax validation and `git diff --check`; independent review found no actionable P0–P2 findings.
- **Proof limitation:** the signed-app computer-use vertical was not rerun for this repair. The tests validate configuration and launch boundaries, not actual signed-app/TCC/provider behavior. No operator state or real Gateway was used.
