### PR TITLE
refactor(test): use executable deadcode coverage

### DIFF
--- a/test/scripts/check-deadcode-exports.test.ts
+++ b/test/scripts/check-deadcode-exports.test.ts
@@ -44,20 +44,6 @@ function listQaScenarioExecutionPaths(dir = "qa/scenarios"): string[] {
 }
 
 describe("check-deadcode-exports", () => {
-  it("requests every unused-export issue class from Knip", () => {
-    const script = fs.readFileSync(
-      new URL("../../scripts/check-deadcode-exports.mts", import.meta.url),
-      "utf8",
-    );
-    expect(script).toContain('"exports,nsExports,types,nsTypes,enumMembers,namespaceMembers"');
-    expect(script).toContain('"config/knip.config.ts", "--production"');
-    expect(script).toContain('"config/knip.all-exports.config.ts"');
-    expect(script).toContain('"config/knip.scripts-exports.config.ts"');
-    expect(script).toContain(
-      'args: ["--config", "config/knip.scripts-exports.config.ts", "--include-entry-exports"]',
-    );
-  });
-
   it("excludes test support only from the production scan", () => {
     expect(knipConfig.ignore).toContain("dist/**");
     expect(knipConfig.ignore).toContain("**/test-helpers/**");

--- a/test/scripts/check-deadcode-unused-files.test.ts
+++ b/test/scripts/check-deadcode-unused-files.test.ts
@@ -5,7 +5,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   checkKnipUnusedFileScanResult,
   checkUnusedFiles,
@@ -58,33 +58,43 @@ async function withFakeProcessSignals(
   child: FakeKnipProcess,
   run: (kills: ProcessKillSignal[]) => Promise<void>,
 ): Promise<void> {
-  const originalKill = process.kill;
+  const originalKill = process.kill.bind(process);
   const kills: ProcessKillSignal[] = [];
   const restoredSignals: ProcessKillSignal[] = [];
   const observer: typeof process.kill = (pid, signal) => {
-    if (Math.abs(pid) !== child.pid) return originalKill(pid, signal);
+    if (Math.abs(pid) !== child.pid) {
+      return originalKill(pid, signal);
+    }
     restoredSignals.push(signal);
-    if (signal === 0) throw Object.assign(new Error("gone"), { code: "ESRCH" });
+    if (signal === 0) {
+      throw Object.assign(new Error("gone"), { code: "ESRCH" });
+    }
     return true;
   };
-  process.kill = (pid, signal) => {
-    if (Math.abs(pid) !== child.pid) return observer(pid, signal);
-    if (signal === 0) throw Object.assign(new Error("gone"), { code: "ESRCH" });
+  const killSpy = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+    if (Math.abs(pid) !== child.pid) {
+      return observer(pid, signal);
+    }
+    if (signal === 0) {
+      throw Object.assign(new Error("gone"), { code: "ESRCH" });
+    }
     kills.push(signal);
     finishFakeProcess(child, null, (signal as NodeJS.Signals | undefined) ?? "SIGTERM");
     return true;
-  };
+  });
   try {
     await run(kills);
   } finally {
     // Restore the inner mock to a safe observer until any grace callback has run.
     // Keep this guard even on assertion failure: fake PIDs must never reach the OS.
-    process.kill = observer;
+    killSpy.mockImplementation(observer);
     try {
-      await new Promise((resolve) => setTimeout(resolve, FAKE_KNIP_KILL_GRACE_MS));
+      await new Promise((resolve) => {
+        setTimeout(resolve, FAKE_KNIP_KILL_GRACE_MS);
+      });
       expect(restoredSignals, "signaling survived process.kill mock restoration").toEqual([]);
     } finally {
-      process.kill = originalKill;
+      killSpy.mockRestore();
     }
   }
 }
@@ -109,8 +119,6 @@ describe("check-deadcode-unused-files", () => {
     expect(existsSync(path.resolve("scripts/deadcode-unused-files.allowlist.mjs"))).toBe(false);
     const script = readFileSync(path.resolve("scripts/check-deadcode-unused-files.mts"), "utf8");
     expect(script).not.toContain("allowlist");
-    expect(script).toContain('"config/knip.all-exports.config.ts"');
-    expect(script).toContain("result.status !== 0");
   });
 
   it("parses the compact Knip unused-file section", () => {


### PR DESCRIPTION
## What Problem This Solves

Deadcode tests still check the spelling of scanner flags, config paths, and a status predicate even though the existing reporting suite observes those contracts through the real CLI and child processes. Equivalent implementation changes can therefore break redundant source-string assertions.

## Why This Change Was Made

Remove seven source-spelling assertions across two test files. The reporting suite retains exact child arguments for production, full-tree, and script scans, including all export issue classes and entry-export flags. The unused-file suite still rejects a nonzero scanner exit with empty output.

The executable reporting coverage was introduced in #132412. Its configuration, no-allowlist, zero-findings policy, parsing, timeout, signal, and descendant-cleanup checks remain intact. The retained fake-PID fixture also uses Vitest to restore the exact original process method, resolving existing method-binding and cleanup-style lint errors without changing its grace window or signal behavior.

## User Impact

No production change. Developers retain behavioral guard coverage while avoiding duplicate constraints on source formatting and expression spelling.

## Evidence

- Baseline 50/50; candidate 49/49 across the exports, unused-files, and reporting suites. Only the redundant source-assertion case was deleted; every retained case title matches.
- Removing an export issue class deliberately fails all three retained export-reporting scenarios. Ignoring nonzero status deliberately fails the retained empty-output rejection case. Both temporary controls were fully reverted before candidate proof.
- The reporting suite executes both real CLI owners with synthetic scanner output. All seven scenarios, production files, and test-support helpers are unchanged.
- Two test files: +21/-27 lines, seven assertions removed, no new cases or production changes. Six lint errors reproduced on unchanged main; the fixture correction passed all 49 cases. Final independent review is clean through P2, and all 15 normal changed checks passed.
