### PR TITLE
fix(state): distinguish maintenance heartbeat startup failures

### DIFF
--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -614,6 +614,8 @@ Agent database maintenance fences other writers with a 60-second lease in the sh
 
 Maintenance schema admission runs its initial full-file integrity check in a read-only Worker when that check is outside a write transaction. The connection and maintenance lease remain held until the Worker exits. Schema changes, index repairs, and compaction retain their synchronous phases.
 
+Startup errors containing `state lease heartbeat did not become ready` include `phase=startup`, the settlement trigger (`timeout` or `message`), and the status observed before the parent marks failure. `status=starting` distinguishes readiness still pending from `status=lost`, where loss was already recorded. `elapsedMs` measures monotonic time since heartbeat startup began; `timeoutMs` is the startup wait budget, capped at five seconds or the remaining initial lease lifetime. These fields do not establish why startup stalled or ownership was lost.
+
 The heartbeat proves ownership, not migration progress. A live but stuck maintenance process can keep its lease; stop that process before retrying Doctor.
 
 ## Troubleshooting

--- a/src/state/openclaw-state-lease-heartbeat.startup.test.ts
+++ b/src/state/openclaw-state-lease-heartbeat.startup.test.ts
@@ -1,0 +1,90 @@
+import type { EventEmitter } from "node:events";
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  leaseHeartbeatState as state,
+  type LeaseHeartbeatWorkerData,
+} from "./openclaw-state-lease-heartbeat-shared.js";
+import { startOpenClawStateLeaseHeartbeat } from "./openclaw-state-lease-heartbeat.js";
+
+const { workers } = vi.hoisted(() => ({
+  workers: [] as (EventEmitter & { shared: BigInt64Array })[],
+}));
+
+vi.mock("node:worker_threads", async () => {
+  const { EventEmitter } = await import("node:events");
+  return {
+    Worker: class extends EventEmitter {
+      shared: BigInt64Array;
+      stdout = { resume() {} };
+      stderr = { resume() {} };
+
+      constructor(_url: URL, options: { workerData: LeaseHeartbeatWorkerData }) {
+        super();
+        this.shared = new BigInt64Array(options.workerData.shared);
+        workers.push(this);
+      }
+
+      async terminate() {
+        return 0;
+      }
+    },
+  };
+});
+
+beforeEach(() => {
+  workers.length = 0;
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date", "performance"] });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("state lease heartbeat startup diagnostics", () => {
+  it.each([
+    { status: "starting", trigger: "timeout", remainingMs: 60_000, elapsedMs: 5_000 },
+    { status: "lost", trigger: "timeout", remainingMs: 60_000, elapsedMs: 5_000 },
+    { status: "lost", trigger: "message", remainingMs: 60_000, elapsedMs: 25 },
+    { status: "starting", trigger: "timeout", remainingMs: 750, elapsedMs: 750 },
+  ] as const)(
+    "reports $status at $trigger after $elapsedMs ms (remaining lease $remainingMs ms)",
+    async ({ status, trigger, remainingMs, elapsedMs }) => {
+      const onLost = vi.fn();
+      const heartbeat = startOpenClawStateLeaseHeartbeat({
+        path: "/synthetic-private-state/lease.sqlite",
+        identity: {
+          scope: "synthetic-private-scope",
+          key: "synthetic-private-key",
+          owner: "synthetic-owner-token",
+        },
+        leaseMs: 60_000,
+        heartbeatMs: 20_000,
+        expiresAt: Date.now() + remainingMs,
+        onLost,
+      });
+      const outcome = heartbeat.ready.catch((error: unknown) => error);
+      const worker = workers[0];
+      try {
+        assert(worker, "Expected the heartbeat worker to be constructed");
+        Atomics.store(worker.shared, state.status, state[status]);
+        await vi.advanceTimersByTimeAsync(elapsedMs - 1);
+        expect(onLost).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        if (trigger === "message") {
+          worker.emit("message", null);
+        }
+        const error = await outcome;
+        expect(error).toEqual(
+          new Error(
+            `state lease heartbeat did not become ready (phase=startup, trigger=${trigger}, status=${status}, elapsedMs=${elapsedMs}, timeoutMs=${Math.min(5_000, remainingMs)})`,
+          ),
+        );
+        expect(onLost).toHaveBeenCalledExactlyOnceWith(error);
+        expect(Atomics.load(worker.shared, state.status)).toBe(state.lost);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        await heartbeat.stop();
+      }
+    },
+  );
+});

--- a/src/state/openclaw-state-lease-heartbeat.ts
+++ b/src/state/openclaw-state-lease-heartbeat.ts
@@ -16,6 +16,7 @@ export function startOpenClawStateLeaseHeartbeat(
     onLost: (error: Error) => void;
   },
 ) {
+  const startedAt = performance.now();
   const shared = new BigInt64Array(new SharedArrayBuffer(3 * BigInt64Array.BYTES_PER_ELEMENT));
   const url = resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.stateLeaseHeartbeat);
   const worker = new Worker(url, {
@@ -50,23 +51,41 @@ export function startOpenClawStateLeaseHeartbeat(
     ready.reject(error);
     params.onLost(error);
   };
-  const settleStartup = () => {
+  const settleStartup = (trigger: "timeout" | "message") => {
     clearTimeout(startTimer);
     // Readiness precedes notification delivery. A delayed parent must not
     // overwrite ready; callback entry still requires a fresh acknowledgement.
-    if (Atomics.compareExchange(shared, state.status, state.starting, state.lost) === state.ready) {
+    const observedStatus = Atomics.compareExchange(
+      shared,
+      state.status,
+      state.starting,
+      state.lost,
+    );
+    if (observedStatus === state.ready) {
       ready.resolve();
     } else {
-      fail(new Error("state lease heartbeat did not become ready"));
+      // Report the status before our transition, not the lost state it writes.
+      const status =
+        observedStatus === state.starting
+          ? "starting"
+          : observedStatus === state.lost
+            ? "lost"
+            : "closed";
+      fail(
+        new Error(
+          `state lease heartbeat did not become ready (phase=startup, trigger=${trigger}, status=${status}, elapsedMs=${Math.round(performance.now() - startedAt)}, timeoutMs=${startupTimeoutMs})`,
+        ),
+      );
     }
   };
-  const startTimer = setTimeout(
-    settleStartup,
-    Math.max(1, Math.min(WORKER_START_TIMEOUT_MS, params.expiresAt - Date.now())),
+  const startupTimeoutMs = Math.max(
+    1,
+    Math.min(WORKER_START_TIMEOUT_MS, params.expiresAt - Date.now()),
   );
+  const startTimer = setTimeout(() => settleStartup("timeout"), startupTimeoutMs);
   worker.once("error", fail);
   worker.once("exit", () => fail(new Error("state lease heartbeat exited")));
-  worker.once("message", settleStartup);
+  worker.once("message", () => settleStartup("message"));
   let stopping: Promise<number> | undefined;
   const close = () => {
     Atomics.store(shared, state.status, state.closed);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Doctor could defer maintenance and skip migration discovery with only `state lease heartbeat did not become ready`, leaving operators unable to distinguish a heartbeat still starting at its deadline from one whose loss was already recorded.

A Matrix Doctor regression encountered this message; unchanged focused and full Matrix reruns subsequently passed. That evidence established the diagnostic gap, not the cause of the intermittent startup failure.

## Why This Change Was Made

Retain the status returned by the existing atomic startup transition and append bounded `phase`, settlement `trigger`, `status`, monotonic `elapsedMs`, and actual startup `timeoutMs` fields to the producer's error. The worker, shared-state protocol, and lease owner remain unchanged; diagnostics contain no paths, identity values, or owner tokens.

The published-readiness repair in [e3ce08cd5ec](https://github.com/openclaw/openclaw/commit/e3ce08cd5ec11fa53e6d578770112ea26fcb0d80) is already present and is preserved, not reimplemented. This change retains the five-second startup cap, one-second response deadline, 60-second maintenance lease, and all readiness, ownership, loss, and cleanup checks. No config, schema, persistence, or instrumentation framework is added.

## User Impact

Doctor startup failures now identify whether readiness was still pending or loss had already been recorded, the event that settled startup, and the elapsed time versus the startup wait budget. The database reference explains these fields and their limitations. This is diagnostic-only: it does not change lease behavior, identify host load as a cause, or claim to repair the intermittent startup failure itself.

## Evidence

- All four new startup regression cases failed against the unchanged producer specifically because it emitted the bare error without the diagnostic fields. They cover pending startup versus recorded loss, timeout versus message settlement, and an expiry-limited startup budget.
- 30 tests passed across seven files: startup diagnostics, real-worker heartbeat safety, state-lease lifecycle, agent database lease ownership, and the three focused Matrix Doctor account-state/archive-scan/import suites. Existing published-readiness-withheld coverage passed unchanged.
- The complete changed-file checks passed, including production/test typechecks, formatting, lint, ownership-related guards, dead exports, and import cycles. An initial test-fixture type-narrowing error was corrected before the successful run; the final four-case startup rerun passed.
- Independent autoreview of the final diff found no actionable P0–P2 findings.

Focused behavioral proof:

```bash
node scripts/run-vitest.mjs src/state/openclaw-state-lease-heartbeat.startup.test.ts src/state/openclaw-state-lease-heartbeat.test.ts src/state/openclaw-state-lease.test.ts src/state/openclaw-agent-db.lease-owner.test.ts extensions/matrix/doctor-contract-api.account-state.test.ts extensions/matrix/doctor-contract-api.archive-scan.test.ts extensions/matrix/doctor-contract-api.import.test.ts
```

Changed checks:

```bash
node scripts/check-changed.mjs -- src/state/openclaw-state-lease-heartbeat.ts src/state/openclaw-state-lease-heartbeat.startup.test.ts docs/reference/database-schemas.md
```

The retained dependency-refresh candidate and live Gateways were not modified. Fresh proof here uses isolated test fixtures, not a live Gateway, and does not claim to recreate historical worker scheduling.
