### PR TITLE
refactor(prometheus): consolidate ordered metric recording

### DIFF
--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -94,11 +94,8 @@ function createPrometheusMetricStore() {
   const histograms = new Map<string, HistogramSample>();
   let droppedSeries = 0;
 
-  const canCreateSeries = <T>(map: Map<string, T>, key: string, metricName: string): boolean => {
+  const canCreateSeries = <T>(map: Map<string, T>, key: string): boolean => {
     if (map.has(key)) {
-      return true;
-    }
-    if (metricName === DROPPED_SERIES_COUNTER_NAME) {
       return true;
     }
     if (counters.size + gauges.size + histograms.size < MAX_PROMETHEUS_SERIES) {
@@ -113,7 +110,7 @@ function createPrometheusMetricStore() {
       return;
     }
     const key = metricKey(name, labels);
-    if (!canCreateSeries(counters, key, name)) {
+    if (!canCreateSeries(counters, key)) {
       return;
     }
     const existing = counters.get(key);
@@ -129,7 +126,7 @@ function createPrometheusMetricStore() {
       return;
     }
     const key = metricKey(name, labels);
-    if (!canCreateSeries(gauges, key, name)) {
+    if (!canCreateSeries(gauges, key)) {
       return;
     }
     gauges.set(key, { help, labels, value });
@@ -146,7 +143,7 @@ function createPrometheusMetricStore() {
       return;
     }
     const key = metricKey(name, labels);
-    if (!canCreateSeries(histograms, key, name)) {
+    if (!canCreateSeries(histograms, key)) {
       return;
     }
     let sample = histograms.get(key);
@@ -682,23 +679,25 @@ function recordDiagnosticEvent(
         harnessLabels(evt),
       );
       return;
-    case "message.processed":
-      store.counter("openclaw_message_processed_total", "Inbound messages processed by outcome.", {
+    case "message.processed": {
+      const labels = {
         channel: normalizeDiagnosticValue(evt.channel),
         outcome: evt.outcome,
         reason: normalizeDiagnosticValue(evt.reason, "none"),
-      });
+      };
+      store.counter(
+        "openclaw_message_processed_total",
+        "Inbound messages processed by outcome.",
+        labels,
+      );
       store.histogram(
         "openclaw_message_processed_duration_seconds",
         "Inbound message processing duration in seconds.",
-        {
-          channel: normalizeDiagnosticValue(evt.channel),
-          outcome: evt.outcome,
-          reason: normalizeDiagnosticValue(evt.reason, "none"),
-        },
+        labels,
         seconds(evt.durationMs),
       );
       return;
+    }
     case "webhook.received":
       store.counter(
         "openclaw_webhook_received_total",
@@ -747,59 +746,50 @@ function recordDiagnosticEvent(
         },
       );
       return;
-    case "message.dispatch.completed":
+    case "message.dispatch.completed": {
+      const labels = {
+        channel: normalizeDiagnosticValue(evt.channel),
+        outcome: evt.outcome,
+        reason: normalizeDiagnosticValue(evt.reason, "none"),
+        source: normalizeDiagnosticValue(evt.source),
+      };
       store.counter(
         "openclaw_message_dispatch_completed_total",
         "Inbound message dispatch attempts completed by outcome.",
-        {
-          channel: normalizeDiagnosticValue(evt.channel),
-          outcome: evt.outcome,
-          reason: normalizeDiagnosticValue(evt.reason, "none"),
-          source: normalizeDiagnosticValue(evt.source),
-        },
+        labels,
       );
       store.histogram(
         "openclaw_message_dispatch_duration_seconds",
         "Inbound message dispatch duration in seconds.",
-        {
-          channel: normalizeDiagnosticValue(evt.channel),
-          outcome: evt.outcome,
-          reason: normalizeDiagnosticValue(evt.reason, "none"),
-          source: normalizeDiagnosticValue(evt.source),
-        },
+        labels,
         seconds(evt.durationMs),
       );
       return;
+    }
     case "message.delivery.completed":
-    case "message.delivery.error":
+    case "message.delivery.error": {
+      const labels = {
+        channel: normalizeDiagnosticValue(evt.channel),
+        delivery_kind: normalizeDiagnosticValue(evt.deliveryKind, "other"),
+        error_category:
+          evt.type === "message.delivery.error"
+            ? normalizeDiagnosticValue(evt.errorCategory, "other")
+            : "none",
+        outcome: evt.type === "message.delivery.error" ? "error" : "completed",
+      };
       store.counter(
         "openclaw_message_delivery_total",
         "Outbound message delivery attempts by outcome.",
-        {
-          channel: normalizeDiagnosticValue(evt.channel),
-          delivery_kind: normalizeDiagnosticValue(evt.deliveryKind, "other"),
-          error_category:
-            evt.type === "message.delivery.error"
-              ? normalizeDiagnosticValue(evt.errorCategory, "other")
-              : "none",
-          outcome: evt.type === "message.delivery.error" ? "error" : "completed",
-        },
+        labels,
       );
       store.histogram(
         "openclaw_message_delivery_duration_seconds",
         "Outbound message delivery duration in seconds.",
-        {
-          channel: normalizeDiagnosticValue(evt.channel),
-          delivery_kind: normalizeDiagnosticValue(evt.deliveryKind, "other"),
-          error_category:
-            evt.type === "message.delivery.error"
-              ? normalizeDiagnosticValue(evt.errorCategory, "other")
-              : "none",
-          outcome: evt.type === "message.delivery.error" ? "error" : "completed",
-        },
+        labels,
         seconds(evt.durationMs),
       );
       return;
+    }
     case "talk.event":
       store.counter("openclaw_talk_event_total", "Talk events emitted by type.", talkLabels(evt));
       store.histogram(
@@ -886,24 +876,18 @@ function recordDiagnosticEvent(
       });
       return;
     case "diagnostic.memory.sample":
-      store.gauge(
-        "openclaw_memory_bytes",
-        "Latest process memory usage by memory kind.",
-        { kind: "rss" },
-        evt.memory.rssBytes,
-      );
-      store.gauge(
-        "openclaw_memory_bytes",
-        "Latest process memory usage by memory kind.",
-        { kind: "heap_total" },
-        evt.memory.heapTotalBytes,
-      );
-      store.gauge(
-        "openclaw_memory_bytes",
-        "Latest process memory usage by memory kind.",
-        { kind: "heap_used" },
-        evt.memory.heapUsedBytes,
-      );
+      for (const [kind, field] of [
+        ["rss", "rssBytes"],
+        ["heap_total", "heapTotalBytes"],
+        ["heap_used", "heapUsedBytes"],
+      ] as const) {
+        store.gauge(
+          "openclaw_memory_bytes",
+          "Latest process memory usage by memory kind.",
+          { kind },
+          evt.memory[field],
+        );
+      }
       store.histogram(
         "openclaw_memory_rss_bytes",
         "RSS memory sample distribution in bytes.",
@@ -928,24 +912,14 @@ function recordDiagnosticEvent(
         "Diagnostic liveness warning events.",
         livenessLabels(evt),
       );
-      store.gauge(
-        "openclaw_liveness_sessions",
-        "Latest session counts reported with diagnostic liveness warnings.",
-        { state: "active" },
-        numericValue(evt.active),
-      );
-      store.gauge(
-        "openclaw_liveness_sessions",
-        "Latest session counts reported with diagnostic liveness warnings.",
-        { state: "waiting" },
-        numericValue(evt.waiting),
-      );
-      store.gauge(
-        "openclaw_liveness_sessions",
-        "Latest session counts reported with diagnostic liveness warnings.",
-        { state: "queued" },
-        numericValue(evt.queued),
-      );
+      for (const state of ["active", "waiting", "queued"] as const) {
+        store.gauge(
+          "openclaw_liveness_sessions",
+          "Latest session counts reported with diagnostic liveness warnings.",
+          { state },
+          numericValue(evt[state]),
+        );
+      }
       store.histogram(
         "openclaw_liveness_event_loop_delay_p99_seconds",
         "P99 event-loop delay reported by diagnostic liveness warnings in seconds.",
@@ -974,34 +948,20 @@ function recordDiagnosticEvent(
       );
       return;
     case "diagnostic.async_queue.dropped":
-      store.counter(
-        "openclaw_diagnostic_async_queue_dropped_total",
-        "Async diagnostic queue drops by dropped event class.",
-        { drop_class: "total" },
-        numericValue(evt.droppedEvents),
-      );
-      if (evt.droppedTrustedEvents !== undefined) {
+      for (const [dropClass, field] of [
+        ["total", "droppedEvents"],
+        ["trusted", "droppedTrustedEvents"],
+        ["untrusted", "droppedUntrustedEvents"],
+        ["priority", "droppedPriorityEvents"],
+      ] as const) {
+        if (field !== "droppedEvents" && evt[field] === undefined) {
+          continue;
+        }
         store.counter(
           "openclaw_diagnostic_async_queue_dropped_total",
           "Async diagnostic queue drops by dropped event class.",
-          { drop_class: "trusted" },
-          numericValue(evt.droppedTrustedEvents),
-        );
-      }
-      if (evt.droppedUntrustedEvents !== undefined) {
-        store.counter(
-          "openclaw_diagnostic_async_queue_dropped_total",
-          "Async diagnostic queue drops by dropped event class.",
-          { drop_class: "untrusted" },
-          numericValue(evt.droppedUntrustedEvents),
-        );
-      }
-      if (evt.droppedPriorityEvents !== undefined) {
-        store.counter(
-          "openclaw_diagnostic_async_queue_dropped_total",
-          "Async diagnostic queue drops by dropped event class.",
-          { drop_class: "priority" },
-          numericValue(evt.droppedPriorityEvents),
+          { drop_class: dropClass },
+          numericValue(evt[field]),
         );
       }
       store.gauge(


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

The Prometheus exporter repeats fixed-label metric recordings and identical message-label construction, and its private series-cap check has an unreachable exception. This is maintainer-requested cleanup for the #135868 split campaign; it extracts no recovery feature content.

## Why This Change Was Made

Record the memory, liveness-session, and diagnostic-drop families through explicit ordered field lists, and prepare each message label set once for its counter/histogram pair. Trusted diagnostic listeners receive structured-cloned, deeply frozen events in both current main and v2026.9.2 (`src/infra/diagnostic-events.ts`); the private store never mutates or exposes the labels. Label sharing follows that host event contract; custom mutable test contexts are outside it.

Remove the dropped-series-name exception from admission: the synthetic `openclaw_prometheus_series_dropped_total` sample is appended directly by snapshot rendering, and no private counter/gauge/histogram caller supplies that name. Existing samples still update at the cap and refused new samples still increment the drop count.

## User Impact

No intended metric or endpoint change. Names, help text, labels, buckets, recording order, the 2,048-sample cap, overflow accounting, trust filtering, lifecycle, and HTTP behavior remain the same. Optional drop counters retain their original omission checks and numeric behavior.

## Evidence

- All 31 unchanged tests passed before and after: service metrics, HTTP scrapes, event-loop/GC windows, and runtime identity, including saturation and existing-series updates.
- Independent Codex local and committed-branch reviews found no actionable P0–P2 issues.
- A temporary full-owner comparison passed 876 paired scenarios, including 50 cap-boundary cases, with byte-identical public scrape bodies and matching headers/lifecycle reports. It preserves admission order, existing-series updates, omitted versus present invalid drop fields, bounded labels, and trust filtering. Mutants that reorder fields, omit the optional guard, or corrupt drop accounting are detected.
- The real host diagnostic subscription/emitter delivered distinct deeply frozen event clones to both exporters; producer mutation, untrusted rejection, internal-event acceptance, and unsubscribe were checked. This exercises the dispatcher, not a full Gateway or plugin lease lifecycle.
- Full clean Linux `node scripts/check-changed.mjs` plan passed in 338.37 seconds, including both extension type lanes, lint, six Doctor contract checks, zero dead exports and zero runtime import cycles. All 18 recorded inputs and tracked status stayed unchanged. Full `pnpm build` passed in 189.66 seconds, including 152 public SDK subpaths and 53 native control-plane modules. Both commands ran on Blacksmith Testbox lease `tbx_01m1wkte8emyk935ps34ya3fjb` ([run 34069527652](https://github.com/openclaw/openclaw/actions/runs/34069527652)).

Production +68/−108, net −40; one runtime file, 1166→1126 lines. Tests, tooling, docs, and baselines unchanged. The existing max-lines exception remains because the owner is still oversized.

ClawSweeper completed review of this patch with no correctness/security findings or before-merge/rank-up requests. Initial exact-head CI [34070441883](https://github.com/openclaw/openclaw/actions/runs/34070441883) was green. The landing rebase preserves every recorded proof input and lockfile; all 31 focused tests and a fresh branch review passed again. Final-head CI is required before merge.

Final exact-head CI [34070938084](https://github.com/openclaw/openclaw/actions/runs/34070938084) passed on `1112cd1af6e16fb0fb14e862f1883f385a73c18c`: 31 successful jobs, 17 expected skips. The first watcher stopped on a Labeler cancellation caused by a body-only edit cancelling its in-flight run while the replacement skipped. Its setup log was inspected, one targeted Labeler rerun passed, and the restarted canonical watcher returned GREEN. No product test or source repair was needed.
