### PR TITLE
refactor(tests): reuse remaining CLI success fixtures

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1164,14 +1164,8 @@ describe("runCliAgent spawn path", () => {
       expect(input.argv).toContain("soft-cli-session");
       expect(input.argv?.join(" ")).toContain("/tmp/openclaw-soft-resume-system-prompt.md");
       return createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
+        ...createSuccessfulProcessExit(),
         stdout: "ok",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
       });
     });
     const context = buildPreparedCliRunContext({
@@ -1692,14 +1686,8 @@ describe("runCliAgent spawn path", () => {
     const logInfoSpy = vi.spyOn(cliBackendLog, "info").mockImplementation(() => undefined);
     supervisorSpawnMock.mockResolvedValueOnce(
       createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
+        ...createSuccessfulProcessExit(),
         stdout: "ok",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
       }),
     );
 
@@ -1752,14 +1740,10 @@ describe("runCliAgent spawn path", () => {
   it("returns process diagnostics with byte counts and bounded output hashes", async () => {
     supervisorSpawnMock.mockResolvedValueOnce(
       createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
+        ...createSuccessfulProcessExit(),
         durationMs: 75,
         stdout: "ok",
         stderr: "warn\n",
-        timedOut: false,
-        noOutputTimedOut: false,
       }),
     );
 
@@ -1839,14 +1823,8 @@ describe("runCliAgent spawn path", () => {
         "utf-8",
       );
       return createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
+        ...createSuccessfulProcessExit(),
         stdout: "ok",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
       });
     });
 

--- a/src/agents/cli-runner/execute.installation-target.test.ts
+++ b/src/agents/cli-runner/execute.installation-target.test.ts
@@ -8,6 +8,7 @@ import { buildPreparedCliRunContext } from "../cli-runner.test-helpers.js";
 import { executePreparedCliRun as executePreparedCliRunImpl } from "./execute.js";
 import {
   createManagedRun,
+  createSuccessfulProcessExit,
   supervisorSpawnMock,
   wrapPreparedCliRunWithTestAdmission,
 } from "./execute.test-support.js";
@@ -49,14 +50,9 @@ describe("CLI installation target", () => {
       }
       supervisorSpawnMock.mockResolvedValue(
         createManagedRun({
-          reason: "exit",
-          exitCode: 0,
-          exitSignal: null,
+          ...createSuccessfulProcessExit(),
           durationMs: 1,
           stdout: "done",
-          stderr: "",
-          timedOut: false,
-          noOutputTimedOut: false,
         }),
       );
       await withEnvAsync(

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -211,16 +211,7 @@ async function withDiagnosticsEnabled<T>(run: () => Promise<T>): Promise<T> {
 function holdSupervisorRun() {
   const entered = createDeferred();
   const release = createDeferred();
-  const exit = {
-    reason: "exit" as const,
-    exitCode: 0,
-    exitSignal: null,
-    durationMs: 50,
-    stdout: "",
-    stderr: "",
-    timedOut: false,
-    noOutputTimedOut: false,
-  };
+  const exit = createSuccessfulProcessExit();
   const managedRun = createManagedRun(exit);
   managedRun.wait.mockImplementation(async () => {
     entered.resolve();


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Six CLI tests repeat successful process-result fields already owned by their existing fixture helper, adding maintenance cost to the requested test cleanup.

## Why This Change Was Made

Reuse the unchanged success-result helper, retaining explicit output and duration overrides. The held-run fixture keeps its existing result identity and deferred wait/cancel behavior. This removes 35 net test lines without changing production code or assertions.

## User Impact

No product behavior changes. Success, diagnostics, installation-target, and held-run contracts remain covered. No runtime improvement is claimed.

## Evidence

- All 139 cases across the three affected files pass before and after with identical displayed case names.
- Field/value/order/absence and allocation checks pass, including the held wait returning the same exit object only after release.
- Failed-result fixtures and the prior cleanup remain unchanged.
- Full changed-file gate, deslop, and independent P2 review passed.
