### PR TITLE
refactor(setup): reuse lazy promise loaders

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -23,7 +23,7 @@ import type { OpenClawConfig } from "../config/types.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime, writeRuntimeJson } from "../runtime.js";
-import { createLazyImportLoader } from "../shared/lazy-promise.js";
+import { createLazyPromise } from "../shared/lazy-promise.js";
 import { shortenHomePath } from "../utils.js";
 
 type ConfigIO = {
@@ -55,33 +55,13 @@ type SetupCommandDeps = {
   replaceConfigFile?: ReplaceConfigFile;
 };
 
-type AgentWorkspaceModule = typeof import("../agents/workspace.js");
 type ConfigIOModule = typeof import("../config/config.js");
-type ConfigLoggingModule = typeof import("../config/logging.js");
-
-const agentWorkspaceModuleLoader = createLazyImportLoader<AgentWorkspaceModule>(
-  () => import("../agents/workspace.js"),
-);
-const configIOModuleLoader = createLazyImportLoader<ConfigIOModule>(
-  () => import("../config/config.js"),
-);
-const configLoggingModuleLoader = createLazyImportLoader<ConfigLoggingModule>(
-  () => import("../config/logging.js"),
-);
 
 // Keep setup's cold path small; config/workspace modules are loaded only when
 // their default dependency is actually needed.
-function loadAgentWorkspaceModule(): Promise<AgentWorkspaceModule> {
-  return agentWorkspaceModuleLoader.load();
-}
-
-function loadConfigIOModule(): Promise<ConfigIOModule> {
-  return configIOModuleLoader.load();
-}
-
-function loadConfigLoggingModule(): Promise<ConfigLoggingModule> {
-  return configLoggingModuleLoader.load();
-}
+const loadAgentWorkspaceModule = createLazyPromise(() => import("../agents/workspace.js"));
+const loadConfigIOModule = createLazyPromise(() => import("../config/config.js"));
+const loadConfigLoggingModule = createLazyPromise(() => import("../config/logging.js"));
 
 async function createDefaultConfigIO(): Promise<ConfigIO> {
   const { createConfigIO } = await loadConfigIOModule();


### PR DESCRIPTION
Related: #130706.

## What Problem This Solves

The baseline setup command maintained three private loader adapters around the existing lazy-promise owner. This is the maintainer-requested cleanup accompanying the config/setup repairs extracted from #130706.

## Why This Change Was Made

Use `createLazyPromise` directly for the workspace, config, and logging imports. It delegates to the same cache owner as the old adapters, preserving deferred imports, shared promises and retry after rejection. Removes 20 production lines with no test additions.

## User Impact

No intended behavior change. `openclaw setup --baseline` continues to create or update the selected workspace and preserve established config, include files, and environment references. Modules still load only when their default dependencies are used.

## Evidence

On a4421d907e2b99619909d1a655308376655725a0:

- 35 existing tests passed, including setup lazy-import behavior and the shared lazy-promise owner. Four real-file source controls produced identical before/after results.
- Full changed gate and independent P2 review passed with no findings.
- Normal `pnpm build` passed all 16 phases, including declarations, CLI bootstrap imports, plugin SDK exports, and postbuild.
- Ten real compiled `dist/index.js setup` invocations passed in isolated state: public help; fresh creation; unchanged reruns; JSON and human workspace updates; established include/environment-reference preservation; invalid-config refusal with unchanged bytes.
- Complete source and runtime inventories stayed unchanged during compiled proof; natural build stamps match the commit. All owned processes exited and temporary state was removed.

The compiled CLI controls exercise the documented `--baseline` path. They do not call a model provider, run a Gateway, or alter an existing operator installation.
