### PR TITLE
fix(ci): isolate compact planner inventory growth fixture

### DIFF
--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -2099,7 +2099,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       compactMode: "pull-request" as const,
       runnerBackend: "github",
     };
-    const syntheticToolingFile = "test/scripts/resolve-fs-safe-native-contract.test.ts";
+    const inventoryGrowthFile = "test/scripts/resolve-fs-safe-native-contract.test.ts";
     const isHostedToolingGroup = (group: { shard_name: string }) =>
       /^core-tooling-\d+-hosted-\d+$/u.test(group.shard_name);
     const isNumberedToolingGroup = (group: { shard_name: string }) =>
@@ -2129,77 +2129,85 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
               ];
         })
         .toSorted((a, b) => a.groups.join("\0").localeCompare(b.groups.join("\0")));
-    const baseline = createNodeTestShardBundles(options);
+    const createPlanWithInventory = async (includeGrowthFile: boolean) => {
+      vi.resetModules();
+      vi.doMock("../../scripts/lib/list-test-files.mts", async (importOriginal) => {
+        const actual =
+          await importOriginal<typeof import("../../scripts/lib/list-test-files.mts")>();
+        return {
+          ...actual,
+          listTrackedTestFiles(rootDir: string, suffix?: string) {
+            const files = actual
+              .listTrackedTestFiles(rootDir, suffix)
+              .filter((file) => file !== inventoryGrowthFile);
+            return rootDir === "test" && includeGrowthFile
+              ? [...files, inventoryGrowthFile].toSorted()
+              : files;
+          },
+        };
+      });
+      try {
+        const { createNodeTestShardBundles: createPlan } =
+          await import("../../scripts/lib/ci-node-test-plan.mts");
+        return createPlan(options);
+      } finally {
+        vi.doUnmock("../../scripts/lib/list-test-files.mts");
+        vi.resetModules();
+      }
+    };
+    const baseline = await createPlanWithInventory(false);
     const baselineToolingFiles = baseline
       .flatMap((job) => job.groups)
       .filter(isNumberedToolingGroup)
       .flatMap((group) => group.includePatterns ?? []);
-    vi.resetModules();
-    vi.doMock("../../scripts/lib/list-test-files.mts", async (importOriginal) => {
-      const actual = await importOriginal<typeof import("../../scripts/lib/list-test-files.mts")>();
-      return {
-        ...actual,
-        listTrackedTestFiles(rootDir: string, suffix?: string) {
-          const files = actual.listTrackedTestFiles(rootDir, suffix);
-          return rootDir === "test" ? [...files, syntheticToolingFile].toSorted() : files;
-        },
-      };
-    });
-    try {
-      const { createNodeTestShardBundles: createPlanWithGrownInventory } =
-        await import("../../scripts/lib/ci-node-test-plan.mts");
-      const grown = createPlanWithGrownInventory(options);
-      const toolingGroups = grown.flatMap((job) => job.groups).filter(isNumberedToolingGroup);
-      const toolingFiles = toolingGroups.flatMap((group) => group.includePatterns ?? []);
-      const crossRunnerHostedJobs: CompactNodeTestShard[] = [];
+    const grown = await createPlanWithInventory(true);
+    const toolingGroups = grown.flatMap((job) => job.groups).filter(isNumberedToolingGroup);
+    const toolingFiles = toolingGroups.flatMap((group) => group.includePatterns ?? []);
+    const crossRunnerHostedJobs: CompactNodeTestShard[] = [];
 
-      expect(grown.length).toBeLessThanOrEqual(80);
-      expect(new Set(toolingFiles).size).toBe(toolingFiles.length);
-      expect(toolingFiles.toSorted()).toEqual(
-        [...baselineToolingFiles, syntheticToolingFile].toSorted(),
-      );
-      expect(nonToolingPlacement(grown)).toEqual(nonToolingPlacement(baseline));
+    expect(grown.length).toBeLessThanOrEqual(80);
+    expect(new Set(toolingFiles).size).toBe(toolingFiles.length);
+    expect(toolingFiles.toSorted()).toEqual(
+      [...baselineToolingFiles, inventoryGrowthFile].toSorted(),
+    );
+    expect(nonToolingPlacement(grown)).toEqual(nonToolingPlacement(baseline));
 
-      for (const job of grown) {
-        const hostedToolingGroups = job.groups.filter(isHostedToolingGroup);
-        if (hostedToolingGroups.length === 0) {
-          continue;
-        }
-        const families = hostedToolingGroups.map((group) =>
-          group.shard_name.replace(/-hosted-\d+$/u, ""),
-        );
-        expect(new Set(families).size).toBe(families.length);
-        expect(job.requiresDist).toBe(false);
-        expect(job.planConcurrency).toBe(1);
-        expect(job.groups.length).toBeLessThanOrEqual(10);
-        if (job.groups.length > 1) {
-          expect(job.predictedSeconds).toBeLessThanOrEqual(150);
-        }
-        expect(job.runner).toBe(job.groups[0]?.runner);
-        expect(
-          hostedToolingGroups.every(
-            (group) => (runnerRanks.get(job.runner) ?? -1) >= (runnerRanks.get(group.runner) ?? 0),
-          ),
-        ).toBe(true);
-        if (hostedToolingGroups.some((group) => group.runner !== job.runner)) {
-          crossRunnerHostedJobs.push(job);
-          expect(job.groups.every(isHostedToolingGroup)).toBe(true);
-          expect(job.pretestBuildMode).toBeUndefined();
-          expect(job.groups.every((group) => group.pretestBuildMode === undefined)).toBe(true);
-        }
+    for (const job of grown) {
+      const hostedToolingGroups = job.groups.filter(isHostedToolingGroup);
+      if (hostedToolingGroups.length === 0) {
+        continue;
       }
-      expect(crossRunnerHostedJobs).toHaveLength(1);
-      expect(crossRunnerHostedJobs[0]?.runner).toBe(DEFAULT_NODE_TEST_RUNNER);
-      expect(crossRunnerHostedJobs[0]?.groups.map((group) => group.shard_name)).toEqual([
-        "core-tooling-15-hosted-3",
-        "core-tooling-6-hosted-2",
-        "core-tooling-2-hosted-2",
-        "core-tooling-3-hosted-2",
-      ]);
-    } finally {
-      vi.doUnmock("../../scripts/lib/list-test-files.mts");
-      vi.resetModules();
+      const families = hostedToolingGroups.map((group) =>
+        group.shard_name.replace(/-hosted-\d+$/u, ""),
+      );
+      expect(new Set(families).size).toBe(families.length);
+      expect(job.requiresDist).toBe(false);
+      expect(job.planConcurrency).toBe(1);
+      expect(job.groups.length).toBeLessThanOrEqual(10);
+      if (job.groups.length > 1) {
+        expect(job.predictedSeconds).toBeLessThanOrEqual(150);
+      }
+      expect(job.runner).toBe(job.groups[0]?.runner);
+      expect(
+        hostedToolingGroups.every(
+          (group) => (runnerRanks.get(job.runner) ?? -1) >= (runnerRanks.get(group.runner) ?? 0),
+        ),
+      ).toBe(true);
+      if (hostedToolingGroups.some((group) => group.runner !== job.runner)) {
+        crossRunnerHostedJobs.push(job);
+        expect(job.groups.every(isHostedToolingGroup)).toBe(true);
+        expect(job.pretestBuildMode).toBeUndefined();
+        expect(job.groups.every((group) => group.pretestBuildMode === undefined)).toBe(true);
+      }
     }
+    expect(crossRunnerHostedJobs).toHaveLength(1);
+    expect(crossRunnerHostedJobs[0]?.runner).toBe(DEFAULT_NODE_TEST_RUNNER);
+    expect(crossRunnerHostedJobs[0]?.groups.map((group) => group.shard_name)).toEqual([
+      "core-tooling-15-hosted-3",
+      "core-tooling-6-hosted-2",
+      "core-tooling-2-hosted-2",
+      "core-tooling-3-hosted-2",
+    ]);
   });
 
   it("assigns Blacksmith runners to every core node shard", () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/140512
Related: https://github.com/openclaw/openclaw/pull/137893

## What Problem This Solves

Fixes an issue where the compact planner inventory-growth regression duplicated its fixture filename when another PR added that file for real, causing a false `81 planned` failure even though the real merged inventory remained within the 80-job cap.

## Why This Change Was Made

The test now constructs its baseline and one-file growth inventories explicitly. Each inventory uses a separate dynamic import because the planner initializes `SPLIT_NODE_SHARDS` at module load: the baseline removes the growth path, and the growth case adds exactly one copy.

All existing planner policy assertions remain unchanged, including the 80-job and 150-second limits, exact-once coverage, family separation, runner rank, build/dist policy, non-tooling placement, and deterministic mixed-runner ordering.

This test-only PR is policy-compliant: `main` is green for this case, while #137893 turns the fixture's formerly synthetic filename into a real tracked path and exposes the duplicate-fixture bug.

## User Impact

Maintainers can validate legitimate tooling inventory growth without a false compact-plan cap failure. Production behavior and the planner algorithm are unchanged.

## Evidence

- Pre-fix controlled reproduction with the #137893 path present: focused test failed with `compact github node test plan exceeds 80 jobs (81 planned)`.
- Focused regression after the fix: 1 passed.
- Full planner suite: 51 passed.
- `oxfmt`, targeted `oxlint`, and `git diff --check`: passed.
- `check:changed`: all reachable guards passed; local test-root `tsgo` stopped only because linked-worktree declaration inputs resolve through the shared install outside the checkout. Exact-head CI covers that lane.
- Fresh autoreview through P2: scoped clean.
- LOC: production 0; tests +73/-65.
- Codex hard gate: sibling Codex `5f49aba876922d6f2f55caa153bbb0ed1b46feba` was inspected at `codex-rs/core/src/tools/registry.rs`, `codex-rs/core/src/session/mcp.rs`, and `codex-rs/core/src/tools/context.rs`; no planner or runtime coupling exists.
