### PR TITLE
fix(ui): reconcile superseded config refreshes after mutations

### DIFF
--- a/ui/src/lib/config/config-external-refresh.test.ts
+++ b/ui/src/lib/config/config-external-refresh.test.ts
@@ -1,0 +1,236 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ConfigSnapshot } from "../../api/types.ts";
+import { loadConfig } from "./config-gateway-operations.ts";
+import { nextRequestVersion } from "./config-state-model.ts";
+import { createConfigCapabilityHarness, deferred } from "./config-test-harness.ts";
+
+function snapshot(count: number): ConfigSnapshot {
+  return {
+    config: { count },
+    raw: JSON.stringify({ count }),
+    hash: `hash-${count}`,
+    valid: true,
+    issues: [],
+  };
+}
+
+describe("external mutation config refresh", () => {
+  it.each([
+    { order: "mutation read first", failure: false },
+    { order: "successor read first", failure: false },
+    { order: "mutation read first", failure: true },
+    { order: "successor read first", failure: true },
+  ])(
+    "uses the actual successor result with $order (failure: $failure)",
+    async ({ order, failure }) => {
+      const mutationRead = deferred<ConfigSnapshot>();
+      const successorRead = deferred<ConfigSnapshot>();
+      const mutationReadStarted = deferred<void>();
+      let reads = 0;
+      const request = vi.fn((method: string) => {
+        if (method !== "config.get") {
+          return Promise.resolve({ ok: true });
+        }
+        reads += 1;
+        if (reads === 1) {
+          return Promise.resolve(snapshot(1));
+        }
+        if (reads === 2) {
+          mutationReadStarted.resolve();
+          return mutationRead.promise;
+        }
+        if (reads === 3) {
+          return successorRead.promise;
+        }
+        throw new Error(`Unexpected configuration read ${reads}`);
+      });
+      const { runtimeConfig } = createConfigCapabilityHarness(
+        request as GatewayBrowserClient["request"],
+      );
+      try {
+        await runtimeConfig.ensureLoaded();
+        const mutation = runtimeConfig.runExternalMutation((client) =>
+          client.request("plugins.setEnabled", { pluginId: "test-plugin", enabled: true }),
+        );
+        await mutationReadStarted.promise;
+        runtimeConfig.setRaw('{"count":9}');
+        // The generation-triggered page refresh starts after the RPC and its own fresh read.
+        const refresh = runtimeConfig.refresh();
+        expect(reads).toBe(3);
+        const finishSuccessor = () =>
+          failure
+            ? successorRead.reject(new Error("current refresh unavailable"))
+            : successorRead.resolve(snapshot(3));
+        if (order === "mutation read first") {
+          mutationRead.resolve(snapshot(2));
+          await mutationRead.promise;
+          finishSuccessor();
+        } else {
+          finishSuccessor();
+          await refresh;
+          mutationRead.resolve(snapshot(2));
+        }
+        await refresh;
+        await expect(mutation).resolves.toEqual({
+          ok: true,
+          value: { ok: true },
+          refresh: failure ? { ok: false, error: "current refresh unavailable" } : { ok: true },
+        });
+        expect(runtimeConfig.state.configSnapshot?.hash).toBe(failure ? "hash-1" : "hash-3");
+        expect(runtimeConfig.state.lastError).toBe(failure ? "current refresh unavailable" : null);
+        expect(runtimeConfig.state.configRaw).toBe('{"count":9}');
+        expect(runtimeConfig.state.configDraftBaseHash).toBe("hash-1");
+        expect(runtimeConfig.state.configFormDirty).toBe(true);
+      } finally {
+        runtimeConfig.dispose();
+      }
+    },
+  );
+  it.each(["write acknowledgement", "disconnect", "same-client reconnect", "dispose"] as const)(
+    "ends a pending mutation refresh on %s without waiting for its transport reply",
+    async (retirement) => {
+      const pendingRead = deferred<ConfigSnapshot>();
+      const readStarted = deferred<void>();
+      let reads = 0;
+      const request = vi.fn((method: string) => {
+        if (method !== "config.get") {
+          return Promise.resolve({ ok: true });
+        }
+        if (++reads === 1) {
+          return Promise.resolve(snapshot(1));
+        }
+        if (reads === 3) {
+          return Promise.resolve(snapshot(3));
+        }
+        readStarted.resolve();
+        return pendingRead.promise;
+      });
+      const { runtimeConfig, publish } = createConfigCapabilityHarness(
+        request as GatewayBrowserClient["request"],
+      );
+      try {
+        await runtimeConfig.ensureLoaded();
+        const mutation = runtimeConfig.runExternalMutation((client) =>
+          client.request("plugins.setEnabled", { pluginId: "test-plugin", enabled: true }),
+        );
+        await readStarted.promise;
+        if (retirement === "write acknowledgement") {
+          // Config write acknowledgements invalidate older reads without issuing a replacement.
+          nextRequestVersion(runtimeConfig.state, "config");
+        } else if (retirement === "disconnect" || retirement === "same-client reconnect") {
+          publish(false);
+          if (retirement === "same-client reconnect") {
+            publish(true);
+          }
+        } else {
+          runtimeConfig.dispose();
+        }
+        await expect(mutation).resolves.toEqual({
+          ok: true,
+          value: { ok: true },
+          refresh: {
+            ok: false,
+            error:
+              retirement === "write acknowledgement"
+                ? "The configuration refresh was superseded by a configuration write."
+                : "Connection changed before the configuration update was refreshed.",
+          },
+        });
+        expect(reads).toBe(retirement === "same-client reconnect" ? 3 : 2);
+        pendingRead.resolve(snapshot(99));
+        await pendingRead.promise;
+        expect(runtimeConfig.state.configSnapshot?.hash).toBe(
+          retirement === "same-client reconnect" ? "hash-3" : "hash-1",
+        );
+      } finally {
+        pendingRead.resolve(snapshot(99));
+        runtimeConfig.dispose();
+      }
+    },
+  );
+
+  it("does not borrow a successor's apply outcome for reconnect draft recovery", async () => {
+    const stale = deferred<ConfigSnapshot>();
+    const request = vi.fn((method: string) => {
+      if (method !== "config.get") {
+        throw new Error(`Unexpected request ${method}`);
+      }
+      return request.mock.calls.length === 1 ? stale.promise : Promise.resolve(snapshot(2));
+    });
+    const { runtimeConfig } = createConfigCapabilityHarness(
+      request as GatewayBrowserClient["request"],
+    );
+    const captureDraft = vi.fn();
+    try {
+      const original = loadConfig(runtimeConfig.state, { beforeApplySnapshot: captureDraft });
+      await expect(loadConfig(runtimeConfig.state)).resolves.toBe(true);
+      stale.resolve(snapshot(1));
+      await expect(original).resolves.toBe(false);
+      expect(captureDraft).not.toHaveBeenCalled();
+      expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
+    } finally {
+      runtimeConfig.dispose();
+    }
+  });
+
+  it("rechecks connection ownership after the pre-adoption recovery callback", async () => {
+    const request = vi.fn(async () => snapshot(1));
+    const { runtimeConfig, publish } = createConfigCapabilityHarness(
+      request as GatewayBrowserClient["request"],
+    );
+    try {
+      await expect(
+        loadConfig(runtimeConfig.state, { beforeApplySnapshot: () => publish(false) }),
+      ).resolves.toBe(false);
+      expect(runtimeConfig.state.configSnapshot).toBeNull();
+    } finally {
+      runtimeConfig.dispose();
+    }
+  });
+  it("records a successor started synchronously by a loading-state subscriber", async () => {
+    const staleRead = deferred<ConfigSnapshot>();
+    let reads = 0;
+    const request = vi.fn((method: string) => {
+      if (method !== "config.get") {
+        return Promise.resolve({ ok: true });
+      }
+      reads += 1;
+      return reads === 2 ? staleRead.promise : Promise.resolve(snapshot(reads));
+    });
+    const { runtimeConfig } = createConfigCapabilityHarness(
+      request as GatewayBrowserClient["request"],
+    );
+    let successor: Promise<void> | undefined;
+    let observe = false;
+    const stop = runtimeConfig.subscribe((state) => {
+      if (observe && state.configLoading) {
+        observe = false;
+        successor = runtimeConfig.refresh();
+      }
+    });
+    try {
+      await runtimeConfig.ensureLoaded();
+      observe = true;
+      const mutation = runtimeConfig.runExternalMutation((client) =>
+        client.request("plugins.setEnabled", { pluginId: "test-plugin", enabled: true }),
+      );
+      await expect(mutation).resolves.toEqual({
+        ok: true,
+        value: { ok: true },
+        refresh: { ok: true },
+      });
+      await successor;
+      expect(reads).toBe(3);
+      expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-3");
+      staleRead.resolve(snapshot(2));
+      await staleRead.promise;
+      expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-3");
+    } finally {
+      staleRead.resolve(snapshot(2));
+      stop();
+      runtimeConfig.dispose();
+    }
+  });
+});

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -1,4 +1,5 @@
 import { ErrorCodes } from "@openclaw/gateway-client/browser";
+import { err as failure, ok, type Result } from "@openclaw/normalization-core/result";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ConfigSchemaResponse, ConfigSnapshot } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
@@ -14,11 +15,14 @@ import {
   serializeFormForSubmit,
 } from "./config-draft-model.ts";
 import {
+  beginConfigRead,
+  currentConfigRead,
   currentConfigConnectionEpoch,
   isCurrentConfigConnection,
   isCurrentRequest,
   nextRequestVersion,
   resolveEditableSnapshotConfig,
+  type ConfigRead,
   type ConfigGatewayClient,
   type LoadConfigOptions,
   type RuntimeConfigState,
@@ -157,7 +161,7 @@ export async function executeConfigExternalMutation<T>(
   connectionEpoch: number,
   task: (client: GatewayBrowserClient) => Promise<T>,
   options: RuntimeConfigExternalMutationOptions<T>,
-  refresh: () => Promise<boolean>,
+  refresh: () => Promise<Result<void, string>>,
 ): Promise<RuntimeConfigExternalMutationResult<T>> {
   if (!isCurrentConfigConnection(state, client, connectionEpoch)) {
     return {
@@ -210,11 +214,8 @@ export async function executeConfigExternalMutation<T>(
     if (!isCurrentConfigConnection(state, client, connectionEpoch)) {
       return refreshFailure("Connection changed before the configuration update was refreshed.");
     }
-    if (!refreshed) {
-      return refreshFailure(
-        state.lastError ??
-          "The configuration update completed, but its authoritative refresh failed.",
-      );
+    if (!refreshed.ok) {
+      return refreshFailure(refreshed.error);
     }
     return { ok: true, value, refresh: { ok: true } };
   } catch (error) {
@@ -222,17 +223,68 @@ export async function executeConfigExternalMutation<T>(
   }
 }
 
-export async function loadConfig(
+type ConfigLoadOptions = LoadConfigOptions & {
+  background?: boolean;
+  beforeApplySnapshot?: () => void;
+};
+
+function startConfigLoad(
   state: RuntimeConfigState,
-  options: LoadConfigOptions & { background?: boolean; beforeApplySnapshot?: () => void } = {},
+  options: ConfigLoadOptions = {},
   isCurrentLoad: () => boolean = () => true,
-): Promise<boolean> {
+): ConfigRead | null {
   const client = state.client;
   if (!client || !state.connected) {
-    return false;
+    return null;
   }
-  const connectionEpoch = currentConfigConnectionEpoch(state);
-  const version = nextRequestVersion(state, "config");
+  const read = beginConfigRead(state, client);
+  void readConfig(state, read, options, isCurrentLoad).then(read.completion.resolve);
+  return read;
+}
+
+export function loadConfig(
+  state: RuntimeConfigState,
+  options: ConfigLoadOptions = {},
+  isCurrentLoad: () => boolean = () => true,
+): Promise<boolean> {
+  const read = startConfigLoad(state, options, isCurrentLoad);
+  return read ? read.completion.promise.then((result) => result.ok) : Promise.resolve(false);
+}
+
+export async function refreshConfigAfterMutation(
+  state: RuntimeConfigState,
+): Promise<Result<void, string>> {
+  // A generation event can precede the RPC's final commit. Always issue a fresh
+  // read here; only actual later reads can satisfy this mutation's refresh.
+  let read = startConfigLoad(state);
+  if (!read) {
+    return failure("Configuration is unavailable; reconnect and try again.");
+  }
+  const { client, connectionEpoch } = read;
+  while (true) {
+    const result = await Promise.race([read.completion.promise, read.invalidated.promise]);
+    if (!isCurrentConfigConnection(state, client, connectionEpoch)) {
+      return failure("Connection changed before the configuration update was refreshed.");
+    }
+    const latest = currentConfigRead(state);
+    if (!latest || !isCurrentRequest(state, "config", latest.version, client, connectionEpoch)) {
+      return failure("The configuration refresh was superseded by a configuration write.");
+    }
+    if (latest === read) {
+      return result;
+    }
+    read = latest;
+  }
+}
+
+async function readConfig(
+  state: RuntimeConfigState,
+  { client, connectionEpoch, version }: ConfigRead,
+  options: ConfigLoadOptions,
+  isCurrentLoad: () => boolean,
+): Promise<Result<void, string>> {
+  const isCurrent = () =>
+    isCurrentLoad() && isCurrentRequest(state, "config", version, client, connectionEpoch);
   if (!options.background) {
     state.configLoading = true;
   }
@@ -242,11 +294,14 @@ export async function loadConfig(
   }
   try {
     const res = await client.request<ConfigSnapshot>("config.get", {});
-    if (!isCurrentRequest(state, "config", version, client, connectionEpoch) || !isCurrentLoad()) {
-      return false;
+    if (!isCurrent()) {
+      return failure("The configuration refresh was superseded.");
     }
     // Recovery captures the latest intent before a clean draft is replaced.
     options.beforeApplySnapshot?.();
+    if (!isCurrent()) {
+      return failure("The configuration refresh was superseded.");
+    }
     applyConfigSnapshot(state, res, options);
     // An explicit reload reconciles a clean patch failure. Background applied-revision
     // polling must leave the rejected intent and its explanation visible.
@@ -256,12 +311,13 @@ export async function loadConfig(
       }
       state.lastError = null;
     }
-    return true;
-  } catch (err) {
-    if (isCurrentRequest(state, "config", version, client, connectionEpoch)) {
-      state.lastError = formatUiError(err);
+    return ok(undefined);
+  } catch (error) {
+    const message = formatUiError(error);
+    if (isCurrent()) {
+      state.lastError = message;
     }
-    return false;
+    return failure(message);
   } finally {
     if (
       !options.background &&

--- a/ui/src/lib/config/config-state-model.ts
+++ b/ui/src/lib/config/config-state-model.ts
@@ -2,6 +2,8 @@ import {
   asNullableRecord as asConfigRecord,
   isRecord,
 } from "@openclaw/normalization-core/record-coerce";
+import type { Result } from "@openclaw/normalization-core/result";
+import { createDeferredCore, type Deferred } from "../../../../src/shared/deferred.js";
 import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
 import type { ConfigSnapshot, ConfigUiHints } from "../../api/types.ts";
 import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
@@ -46,6 +48,40 @@ const requestVersionsByState = new WeakMap<
   { config: number; schema: number }
 >();
 const connectionEpochsByState = new WeakMap<object, number>();
+export type ConfigRead = {
+  version: number;
+  client: GatewayBrowserClient;
+  connectionEpoch: number;
+  completion: Deferred<Result<void, string>>;
+  invalidated: Deferred<Result<void, string>>;
+};
+const configReadsByState = new WeakMap<object, ConfigRead>();
+
+function invalidateConfigRead(state: object): void {
+  const read = configReadsByState.get(state);
+  configReadsByState.delete(state);
+  read?.invalidated.resolve({ ok: false, error: "The configuration refresh was superseded." });
+}
+
+export function currentConfigRead(state: RuntimeConfigState): ConfigRead | undefined {
+  return configReadsByState.get(state);
+}
+
+export function beginConfigRead(
+  state: RuntimeConfigState,
+  client: GatewayBrowserClient,
+): ConfigRead {
+  const read: ConfigRead = {
+    version: nextRequestVersion(state, "config"),
+    client,
+    connectionEpoch: currentConfigConnectionEpoch(state),
+    completion: createDeferredCore(),
+    invalidated: createDeferredCore(),
+  };
+  // Register before request dispatch can synchronously start a successor read.
+  configReadsByState.set(state, read);
+  return read;
+}
 
 type RuntimeConfigGatewaySnapshot = {
   client: GatewayBrowserClient | null;
@@ -108,6 +144,9 @@ export function createInitialConfigState(
 }
 
 export function nextRequestVersion(state: RuntimeConfigState, key: "config" | "schema"): number {
+  if (key === "config") {
+    invalidateConfigRead(state);
+  }
   const current = requestVersionsByState.get(state) ?? { config: 0, schema: 0 };
   const next = { ...current, [key]: current[key] + 1 };
   requestVersionsByState.set(state, next);
@@ -115,6 +154,7 @@ export function nextRequestVersion(state: RuntimeConfigState, key: "config" | "s
 }
 
 export function clearConfigRequestVersions(state: RuntimeConfigState): void {
+  invalidateConfigRead(state);
   requestVersionsByState.delete(state);
 }
 
@@ -123,6 +163,7 @@ export function currentConfigConnectionEpoch(state: object): number {
 }
 
 export function invalidateConfigConnection(state: object): void {
+  invalidateConfigRead(state);
   connectionEpochsByState.set(state, currentConfigConnectionEpoch(state) + 1);
 }
 

--- a/ui/src/lib/config/config-write-coordinator.ts
+++ b/ui/src/lib/config/config-write-coordinator.ts
@@ -14,6 +14,7 @@ import {
   executeConfigExternalMutation,
   loadConfig,
   refreshDraft,
+  refreshConfigAfterMutation,
   submitConfigDraft,
   type ConfigSubmission,
   type ConfigSubmissionObserver,
@@ -723,8 +724,7 @@ export function createConfigWriteCoordinator({
               task,
               options,
               async () => {
-                // Do not join a config.get that started before the external RPC.
-                const refresh = run(() => loadConfig(state));
+                const refresh = run(() => refreshConfigAfterMutation(state));
                 void trackLoad("config", refresh);
                 return await refresh;
               },


### PR DESCRIPTION
A successful plugin or other external config mutation could show a configuration-refresh warning even when a later refresh had already loaded the new state. The original read reported that it was superseded, and the mutation treated that as a failed refresh.

Record completion at the config-read owner and follow actual later reads within the same connection. Every mutation still starts a fresh read after its RPC. A later failure remains a failure; writes, disconnects, and disposal release pending refresh waits. Ordinary loads keep their own result and recovery callback, and unsaved drafts retain their bytes and base hash.

Validation: both successful response-order regressions fail on main; 184 config tests pass with the fix. An independent browser check passed nine synthetic contracts, including the actual plugin Enable → config.get flow and browser capability checks for ordering, failures, drafts, reconnects, and callback ownership. No real Gateway or plugin backend is claimed. Independent Codex review and the full changed-file gate passed, including UI/test types and i18n. Paired, inspected screenshots show the false warning on main and successful completion with the fix under identical mocked Gateway traffic.

Production +97 lines records the actual read's completion and invalidation using the existing request versions and connection epochs. No new config, schema, dependency, or public API is introduced. This is independent of the larger plugin lifecycle work in #135599.


Before and after under identical mocked Gateway traffic:

![Before: false refresh warning](https://github.com/user-attachments/assets/352386a9-d4e8-49fb-8955-6f9a801978ef)

![After: completed refresh](https://github.com/user-attachments/assets/f64d861d-bf36-461a-a98f-bde77229406c)
