### PR TITLE
refactor(gateway): reuse pending node acknowledgment policy

### DIFF
--- a/src/gateway/server-methods/nodes.pending.ts
+++ b/src/gateway/server-methods/nodes.pending.ts
@@ -68,30 +68,7 @@ function resolveAllowedPendingNodeActions(params: {
   return allowed;
 }
 
-function ackPendingNodeActions(
-  nodeId: string,
-  ids: string[],
-  pairingGeneration: string,
-): PendingNodeAction[] {
-  if (ids.length === 0) {
-    return listPendingNodeActions({
-      nodeId,
-      pairingGeneration,
-      ttlMs: nodeInvokePolicy.pendingActionTtlMs,
-    });
-  }
-  return acknowledgePendingNodeActions({
-    nodeId,
-    pairingGeneration,
-    ids,
-    ttlMs: nodeInvokePolicy.pendingActionTtlMs,
-  });
-}
-
 export function toPendingParamsJSON(params: unknown): string | undefined {
-  if (params === undefined) {
-    return undefined;
-  }
   try {
     return JSON.stringify(params);
   } catch {
@@ -169,7 +146,12 @@ export const nodePendingActionHandlers: GatewayRequestHandlers = {
         return;
       }
       const ackIds = normalizeUniqueTrimmedStringList(params.ids);
-      const remaining = ackPendingNodeActions(trimmedNodeId, ackIds, generation.key);
+      const remaining = acknowledgePendingNodeActions({
+        nodeId: trimmedNodeId,
+        pairingGeneration: generation.key,
+        ids: ackIds,
+        ttlMs: nodeInvokePolicy.pendingActionTtlMs,
+      });
       if (!(await isNodePairingGenerationCurrent(generation))) {
         respondPairingChanged(respond);
         return;


### PR DESCRIPTION
## What Problem This Solves

Pending-node acknowledgment duplicates a no-op policy already owned by node runtime state. This is the required follow-up to #140532 and part of the maintainer-requested #135868 production deletion campaign.

## Why This Change Was Made

Call `acknowledgePendingNodeActions` directly. That owner already prunes by the same TTL and pairing generation, then returns the pruned list when the normalized IDs are empty. The removed private wrapper selected the equivalent `listPendingNodeActions` path for that case and merely forwarded all other cases.

The pending-parameter serializer also uses `JSON.stringify`'s existing `undefined` result directly. Its catch for values that cannot be serialized remains.

## User Impact

No behavior change. Pending action acknowledgment, response shape, TTL pruning, serialization and pairing-generation fencing remain unchanged.

## Evidence

- Owner suites before: 2 files, 107 cases, 15.61s; after: 2 files, 107 cases, 12.44s. `nodes.invoke-wake.test.ts` retains queued-action acknowledgment and retired-pairing rejection; `nodes.validation.test.ts` retains request validation.
- Deletion evidence: `src/gateway/node-runtime-state.ts:124` already owns the empty-ID return after pruning. Both handler generation checks and connection checks remain in place. `JSON.stringify(undefined)` returns `undefined` without throwing.
- Production +6/−24 = **−18**. Tests, tooling and docs: zero. No test body or case removed.

- Full `node scripts/check-changed.mjs`: exit 0, including both typecheck lanes, lint and every selected guard.
- Independent autoreview: scoped-clean, no accepted/actionable findings.
- No build required: internal handler simplification without packaging, lazy-loading or published surface changes.
