### PR TITLE
fix(update): preserve Git runtime staging across source fences

### DIFF
--- a/src/infra/update-runner-git-admission.test.ts
+++ b/src/infra/update-runner-git-admission.test.ts
@@ -36,7 +36,7 @@ function fixture(relativeRemote = false) {
   git(source, "init", "-b", "main");
   git(source, "config", "user.name", "Update fixture");
   git(source, "config", "user.email", "fixture@example.invalid");
-  fs.writeFileSync(path.join(source, ".gitignore"), "node_modules/\ndist/\n.artifacts/\n*.tmp\n");
+  fs.writeFileSync(path.join(source, ".gitignore"), "node_modules/\ndist/\n.artifacts/\n");
   fs.writeFileSync(path.join(source, "openclaw.mjs"), "export {};\n");
   const commit = (version: string, agentSchema: number) => {
     fs.writeFileSync(

--- a/src/infra/update-runner-git-candidate.test.ts
+++ b/src/infra/update-runner-git-candidate.test.ts
@@ -155,7 +155,7 @@ describe("Git candidate activation", () => {
     );
     await fs.writeFile(
       path.join(remote, ".gitignore"),
-      "node_modules/\ndist/\n.artifacts\n.pnpm\ncache/\n*.tmp\n",
+      "node_modules/\ndist/\n.artifacts\n.pnpm\ncache/\n",
     );
     await git(remote, "add", ".");
     await git(remote, "commit", "-m", "base");
@@ -233,6 +233,15 @@ describe("Git candidate activation", () => {
     });
   }
 
+  async function expectNoRuntimeStagingPaths() {
+    const entries = await fs.readdir(root, { recursive: true });
+    expect(
+      entries.filter((entry) =>
+        /\.openclaw-update-[0-9a-f]{8}-[0-9a-f-]{27}\.tmp(?:\/|$)/u.test(entry),
+      ),
+    ).toEqual([]);
+  }
+
   it.each(["dev", "stable", "beta"] as const)(
     "does not stop or build an already-current %s checkout",
     async (channel) => {
@@ -255,24 +264,70 @@ describe("Git candidate activation", () => {
     });
     expect(result.status, JSON.stringify(result)).toBe("ok");
     expect(events).toEqual(["build", "prepare exposure", "validate", "stop"]);
+    await expectRuntime(root, beforeSha);
+    await expectNoRuntimeStagingPaths();
   });
 
-  it.each([false, true])(
-    "preserves source changes made during validation without stopping the service (database inspection: %s)",
-    async (inspection) => {
+  it("does not exempt stale staging paths during initial admission", async () => {
+    const stale = path.join(root, "dist.openclaw-update-00000000-0000-0000-0000-000000000000.tmp");
+    await fs.mkdir(stale);
+    await fs.writeFile(path.join(stale, "candidate"), "operator-owned");
+    const result = await update();
+    expect(result).toMatchObject({ status: "skipped", reason: "dirty" });
+    expect(events).toEqual([]);
+    expect(await fs.readFile(path.join(stale, "candidate"), "utf8")).toBe("operator-owned");
+  });
+
+  it.each([
+    { mutation: "untracked", inspection: false },
+    { mutation: "untracked", inspection: true },
+    { mutation: "tracked", inspection: false },
+    { mutation: "head", inspection: false },
+    { mutation: "branch", inspection: false },
+  ] as const)(
+    "preserves $mutation source changes made during validation without stopping the service (database inspection: $inspection)",
+    async ({ mutation, inspection }) => {
       await advanceRemote();
       const result = await update({
         ...(inspection ? { inspectGitTarget: async () => undefined } : {}),
         validateCandidate: async () => {
-          await fs.writeFile(path.join(root, "operator-change.txt"), "keep this change");
+          if (mutation === "untracked") {
+            await fs.mkdir(path.join(root, "dist.openclaw-update-operator.tmp"));
+            await fs.writeFile(
+              path.join(root, "dist.openclaw-update-operator.tmp", "keep.txt"),
+              "keep this change",
+            );
+          } else if (mutation === "tracked") {
+            await fs.appendFile(path.join(root, "package.json"), "\n");
+          } else if (mutation === "head") {
+            await fs.writeFile(path.join(root, "operator-change.txt"), "committed change");
+            await git(root, "add", "operator-change.txt");
+            await git(root, "commit", "-m", "operator change");
+          } else {
+            await git(root, "checkout", "-b", "operator-branch");
+          }
         },
       });
       expect(result).toMatchObject({ status: "skipped", reason: "dirty" });
       expect(stopped).toBe(false);
-      expect(await fs.readFile(path.join(root, "operator-change.txt"), "utf8")).toBe(
-        "keep this change",
-      );
-      expect(await git(root, "rev-parse", "HEAD")).toBe(beforeSha);
+      if (mutation === "untracked") {
+        expect(
+          await fs.readFile(
+            path.join(root, "dist.openclaw-update-operator.tmp", "keep.txt"),
+            "utf8",
+          ),
+        ).toBe("keep this change");
+      } else if (mutation === "tracked") {
+        expect(await fs.readFile(path.join(root, "package.json"), "utf8")).toMatch(/\n$/u);
+      } else if (mutation === "head") {
+        expect(await git(root, "rev-parse", "HEAD")).not.toBe(beforeSha);
+      } else {
+        expect(await git(root, "branch", "--show-current")).toBe("operator-branch");
+      }
+      if (mutation !== "head") {
+        expect(await git(root, "rev-parse", "HEAD")).toBe(beforeSha);
+      }
+      await expectNoRuntimeStagingPaths();
     },
   );
 

--- a/src/infra/update-runner-git-commands.ts
+++ b/src/infra/update-runner-git-commands.ts
@@ -42,8 +42,20 @@ export function resolveBuildEnv(
   };
 }
 
-export function gitCleanCheckArgs(gitRoot: string): string[] {
-  return ["git", "-C", gitRoot, "status", "--porcelain", "--", ":!dist/control-ui/"];
+export function gitCleanCheckArgs(
+  gitRoot: string,
+  sourceTreeStagingPaths: readonly string[] = [],
+): string[] {
+  return [
+    "git",
+    "-C",
+    gitRoot,
+    "status",
+    "--porcelain",
+    "--",
+    ":!dist/control-ui/",
+    ...sourceTreeStagingPaths.map((relative) => `:(top,exclude,literal)${relative}`),
+  ];
 }
 
 async function hasExplicitPnpmPreferOfflineConfig(params: {

--- a/src/infra/update-runner-git-runtime.ts
+++ b/src/infra/update-runner-git-runtime.ts
@@ -177,6 +177,17 @@ export async function prepareGitRuntimePromotion(
     throw error;
   }
   return {
+    // Source fences may hide only transaction-owned staging. The same exact
+    // paths preserve pending originals while rollback cleans unrelated files.
+    sourceTreeStagingPaths: staged.flatMap(({ temporary }) => {
+      const relative = path.relative(relocation.destinationRoot, temporary);
+      return relative &&
+        relative !== ".." &&
+        !relative.startsWith(`..${path.sep}`) &&
+        !path.isAbsolute(relative)
+        ? [relative.split(path.sep).join("/")]
+        : [];
+    }),
     async activate() {
       for (const entry of staged) {
         try {

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -197,6 +197,10 @@ export async function updateGitCheckout(params: {
         "-fd",
         "-e",
         "dist/control-ui/",
+        ...(runtimePromotion?.sourceTreeStagingPaths.flatMap((relative) => [
+          "-e",
+          `/${relative}/`,
+        ]) ?? []),
       ])) && restored;
     if (branch && branch !== "HEAD") {
       const checkedOut = await appendRecoveryStep("git rollback checkout", [
@@ -300,7 +304,10 @@ export async function updateGitCheckout(params: {
       cwd: gitRoot,
       timeoutMs,
     });
-    const currentStatus = await runCommand(gitCleanCheckArgs(gitRoot), { cwd: gitRoot, timeoutMs });
+    const currentStatus = await runCommand(
+      gitCleanCheckArgs(gitRoot, runtimePromotion?.sourceTreeStagingPaths),
+      { cwd: gitRoot, timeoutMs },
+    );
     if (currentHead.code !== 0 || currentStatus.code !== 0) {
       return { status: "error" as const, reason: "clean-check-failed" as const };
     }


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/138839
Related: https://github.com/openclaw/openclaw/pull/140493
Related: https://github.com/openclaw/openclaw/pull/137893

## What Problem This Solves

Fixes an issue where package-to-Git updates could reject a validated candidate as a dirty checkout because runtime promotion created its own staging directories before the final source-integrity check.

## Why This Change Was Made

Runtime promotion now reports the exact repository-relative paths it owns. Post-preflight Git status checks exclude only those literal paths, and rollback preserves the same exact staging directories while cleaning unrelated files. Initial admission and every unrelated source, HEAD, and branch change remain fail-closed.

The candidate and admission fixtures no longer hide the defect with a broad `*.tmp` ignore.

## User Impact

Operators can switch a package installation to Git without the updater mistaking its own prepared runtime for operator dirt. Real checkout changes still stop the update before service mutation.

## Evidence

- Exact head: `33f1747386a2079607c71648590c5861e678a45a`, refreshed onto main with prerequisite `8bc090cc66df0eab4b6ef36de56ece8d93e49685` and fixture `b044ff9342b4dd1360ab00a290ad265b53a2e8b9` in its ancestry.
- Pre-fix reproduction: package-to-Git returned `skipped/dirty` after removing the fixture `*.tmp` ignore.
- `src/infra/update-runner-git-candidate.test.ts` + `src/infra/update-runner-git-admission.test.ts`: 62/62 passed.
- `src/infra/update-runner.test.ts` + `src/infra/update-post-core-finalize.test.ts`: 142/142 passed.
- Regression coverage includes no-ignore package-to-Git success, nested runtime activation, stale staging-shaped admission failure, unrelated tracked/untracked changes, HEAD/branch movement, rollback restoration, and staging cleanup.
- Changed checks passed through formatting, policy, boundary, and graph gates; local `tsgo` stopped only because linked-worktree declaration inputs resolve through the shared owner checkout.
- Fresh exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/34076434182
- Independent autoreview confirmed the exact literal pathspec and dirty-detection design. Its two P2 concerns were rejected from source/test evidence: staging temporaries are directories created by `fs.mkdir`, and the existing activation-failure matrix exercises rollback with staged runtime backups present.
- Codex `5f49aba876922d6f2f55caa153bbb0ed1b46feba` has no coupling after inspecting `codex-rs/core/src/tools/registry.rs:235-280`, `codex-rs/core/src/session/mcp.rs:320-374`, and `codex-rs/core/src/tools/context.rs:410-470`.

## Full-Lane Proof

- Fresh exact-head hosted `update-channel-switch` passed: https://github.com/openclaw/openclaw/actions/runs/34076443845 (targeted job https://github.com/openclaw/openclaw/actions/runs/34076443845/job/101605292110).
- The hosted artifact records all three legs: package stable to package beta, package to Git dev, and Git to package stable.
- Fresh exact-head Crabbox/Testbox passed: provider `blacksmith-testbox`, lease `tbx_01m1wv70qmpd4w1cxh3hzq9dtt`, hydration run https://github.com/openclaw/openclaw/actions/runs/34076487366. The wrapper verified source `33f1747386a2079607c71648590c5861e678a45a`, completed the full lane with exit code 0, and then stopped the one-shot Testbox; the delegated hydration workflow is therefore cancelled during provider-owned cleanup.
- Prior stacked runs are supporting evidence only: hosted https://github.com/openclaw/openclaw/actions/runs/34071751690 and Crabbox hydration https://github.com/openclaw/openclaw/actions/runs/34071770531 reached the final Git-to-package leg before prerequisite #140598 landed.
