### PR TITLE
fix(macos): avoid Intel compatibility warnings in Apple silicon app bundles

### DIFF
--- a/docs/platforms/mac/dev-setup.md
+++ b/docs/platforms/mac/dev-setup.md
@@ -41,6 +41,12 @@ then replaces the previous app. `scripts/restart-mac.sh` uses
 the same path; `SKIP_TSC=1` no longer bypasses the runtime build. Existing
 content-checked build caches still avoid unnecessary declaration work.
 
+Each worker keeps native binaries that support its architecture and omits
+incompatible macOS, Linux, and Windows prebuilds. This prevents unused Intel-only
+dependencies from triggering macOS compatibility warnings in Apple silicon
+builds. Compatible universal binaries, JavaScript, WASM, and other resources
+remain intact.
+
 Universal builds require both arm64 and x86_64 runtimes to execute during
 validation. Building x86_64 on Apple Silicon requires Rosetta; a missing
 architecture or nonportable native dependency fails packaging. Node downloads

--- a/docs/platforms/mac/peekaboo.md
+++ b/docs/platforms/mac/peekaboo.md
@@ -82,11 +82,11 @@ Missing or unexpected architecture trees, escaping or cyclic worker symlinks, an
 libraries fail verification. Dependencies that violate this closure must be repaired in packaging, not excluded from
 validation. The portable installer needs neither a checkout nor a separate inventory helper.
 
-Elevation packaging constructs fresh workers from the complete installed package without changing that input.
+Both standard and elevation packaging construct fresh workers from the complete installed package without changing that input.
 It preserves JavaScript, WASM, other resources, modes, and contained relative symlinks, and omits only native images
 that cannot run on the selected Darwin architecture. Matching universal binaries remain intact. Windows-named source,
 scripts, and README files remain; directory names do not select files for omission. Unclassifiable native images and
-links that would escape, cycle, or become dangling stop packaging. Standard app packaging retains the full package.
+links that would escape, cycle, or become dangling stop packaging.
 Both paths use the same worker verification and publication flow; build metadata remains unchanged by materialization.
 
 The managed elevation workflow upgrades an already paired Mac. Its selected state and config must define an

--- a/scripts/stage-mac-node-worker.sh
+++ b/scripts/stage-mac-node-worker.sh
@@ -7,10 +7,8 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 DESTINATION="$1"
 shift
 [[ "$#" -gt 0 ]] || { echo "ERROR: No worker architectures requested" >&2; exit 1; }
-runtime_name=runtime
 case "${OPENCLAW_MAC_SIGNING_VARIANT:-standard}" in
-  standard) ;;
-  elevation-host) runtime_name=elevation ;;
+  standard|elevation-host) ;;
   *) echo "ERROR: Unknown Mac signing variant" >&2; exit 1 ;;
 esac
 # Scratch follows the caller's temp volume; only installed payloads need to
@@ -52,19 +50,19 @@ for arch in "$@"; do
         exit 1
       }
       install_openclaw
-      mv "$(node_dir)" "$2/runtime"
+      mv "$(node_dir)" "$2/installed"
     ' bash "$ROOT_DIR" "$STAGE/$arch" "$TARBALL" "$node_arch"
-  if [[ "$runtime_name" == elevation ]]; then
-    env -i HOME="$SCRATCH/$arch/home" PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
-      TMPDIR="$SCRATCH/$arch/tmp" /usr/bin/python3 -B "$ROOT_DIR/scripts/materialize-mac-node-worker.py" \
-      "$STAGE/$arch/runtime" "$STAGE/$arch/elevation" "$STAGE/$arch" "$arch"
-  fi
+  # Unused Intel prebuilds can trigger macOS compatibility warnings even when
+  # the app and its selected worker are native Apple silicon.
+  env -i HOME="$SCRATCH/$arch/home" PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+    TMPDIR="$SCRATCH/$arch/tmp" /usr/bin/python3 -B "$ROOT_DIR/scripts/materialize-mac-node-worker.py" \
+    "$STAGE/$arch/installed" "$STAGE/$arch/runtime" "$STAGE/$arch" "$arch"
   # Validate after moving out of its install prefix: absolute wrappers/symlinks
   # cannot accidentally make a non-relocatable payload pass the proof.
   env -i HOME="$SCRATCH/$arch/home" PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
     TMPDIR="$SCRATCH/$arch/tmp" \
-    "$STAGE/$arch/$runtime_name/bin/node" "$ROOT_DIR/scripts/verify-mac-node-worker.mjs" \
-    "$STAGE/$arch/$runtime_name" "$ROOT_DIR/dist/build-info.json"
+    "$STAGE/$arch/runtime/bin/node" "$ROOT_DIR/scripts/verify-mac-node-worker.mjs" \
+    "$STAGE/$arch/runtime" "$ROOT_DIR/dist/build-info.json"
 done
 
 mkdir -p "$DESTINATION"
@@ -73,5 +71,5 @@ for arch in "$@"; do
   [[ ! -e "$DESTINATION/$arch" && ! -L "$DESTINATION/$arch" ]] || { echo "ERROR: Worker destination exists: $DESTINATION/$arch" >&2; exit 1; }
 done
 for arch in "$@"; do
-  mv "$STAGE/$arch/$runtime_name" "$DESTINATION/$arch"
+  mv "$STAGE/$arch/runtime" "$DESTINATION/$arch"
 done

--- a/test/scripts/mac-node-worker-materialization.test-support.ts
+++ b/test/scripts/mac-node-worker-materialization.test-support.ts
@@ -210,6 +210,11 @@ if (process.argv[2].includes('/x86_64/') && fs.existsSync(${JSON.stringify(path.
   for (const arch of ["arm64", "x86_64"] as const) {
     const canonical = path.join(root, "canonical", arch);
     await write(path.join(canonical, "matching.node"), binaries[arch]);
+    await write(
+      path.join(canonical, "opposite.node"),
+      binaries[arch === "arm64" ? "x86_64" : "arm64"],
+    );
+    await write(path.join(canonical, "universal.node"), binaries.universal);
     await write(path.join(canonical, "foreign.node"), binaries.elf);
     await write(
       path.join(canonical, "nested/win32/build.mjs"),
@@ -289,7 +294,7 @@ function expectWorkerScratchCleaned(fixture: Awaited<ReturnType<typeof stagingFi
 }
 
 export function registerMacWorkerMaterializationTests() {
-  describe.skipIf(process.platform !== "darwin")("elevation worker materialization", () => {
+  describe.skipIf(process.platform !== "darwin")("Mac worker materialization", () => {
     const it = createMacScriptTest();
     it.for(["standard", "elevation-host"])(
       "keeps %s worker scratch in caller temp and publishes runtimes by same-volume moves",
@@ -334,9 +339,7 @@ export function registerMacWorkerMaterializationTests() {
             const arch = index === 0 ? "arm64" : "x86_64";
             const [node, runtime, expected] = call.split("|");
             expect(node).toBe(`${runtime}/bin/node`);
-            expect(runtime).toContain(
-              `/${arch}/${variant === "standard" ? "runtime" : "elevation"}`,
-            );
+            expect(runtime).toContain(`/${arch}/runtime`);
             expect(expected).toBe(path.join(fixture.root, "dist/build-info.json"));
             const scratch = path.resolve(runtime!, "../..");
             expect(path.dirname(scratch)).toBe(path.dirname(fixture.destination));
@@ -350,7 +353,7 @@ export function registerMacWorkerMaterializationTests() {
             ).toBe(verified!.productInode);
             expect(snapshot(path.join(fixture.destination, arch))).toEqual(
               snapshot(path.join(fixture.root, "canonical", arch)).filter(
-                (entry) => variant === "standard" || entry.path !== "foreign.node",
+                (entry) => !["foreign.node", "opposite.node"].includes(entry.path),
               ),
             );
           }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users launching a native Apple silicon OpenClaw app could see macOS's “Support Ending for Intel-based Apps” warning because unused Intel-only dependency prebuilds remained inside the app bundle.

## Why This Change Was Made

Apply the existing architecture-aware worker materializer to both standard and elevation app packaging. Each worker is derived from the complete installed package, verified in isolation, and published through the existing same-volume move flow. Incompatible macOS, Linux, and Windows binaries are omitted; compatible universal binaries, JavaScript, WASM, resources, and valid relative symlinks are preserved.

## User Impact

Apple silicon builds no longer carry unused Intel-only worker dependencies. Universal distribution builds continue to include their separate Intel worker. This change does not alter dependency versions, app signing policy, or Gateway state.

## Evidence

- Extended the existing staging fixture with opposite-architecture and universal Mach-O binaries. Before the fix, standard packaging failed because it retained the opposite-architecture and foreign-platform binaries; the elevation variant passed.
- `node scripts/run-vitest.mjs test/scripts/mac-node-worker.test.ts`: 117 tests passed.
- `node scripts/check-changed.mjs`: passed, including formatting, lint, test typechecking, and all 1,124 macOS/platform checks.
- Applied the unchanged materializer to a staged copy of an installed arm64 app: removed two Intel-only addons and six Linux/Windows prebuilds. All 21 remaining Mach-O binaries support arm64. Re-signed using the existing Developer ID identity; strict recursive signature verification passed.
- Both retained arm64 addons load with the bundled Node runtime. The canonical worker verifier passed native capability checks and both fresh-state and app-initialized-state readiness cases. The cleaned app was installed and relaunched successfully.
- Independent review found no actionable P0–P2 issues. The historical notification itself was not used as proof of removal; the binary inventory and runtime checks establish the repaired boundary.
