### PR TITLE
fix: identify workers behind slow session-write warnings

### DIFF
--- a/docs/gateway/diagnostics.md
+++ b/docs/gateway/diagnostics.md
@@ -137,6 +137,14 @@ lock-wait and hold warnings remain separate. Writes rejected before entering the
 writer omit these three fields. This breakdown is in
 file logs, not the aggregate Gateway RPC Prometheus histograms.
 
+These warnings include the writer's `pid`, Node `threadId`, and `isMainThread`.
+Reclamation callbacks also record their `reclamationKind` and, when a Worker was
+created, its captured `workerThreadId`. Within the same process lifetime, match
+the warning's `pid` and `workerThreadId` to an agent-database-open warning's
+`pid` and `threadId` to identify the awaited Worker. This establishes association,
+not CPU attribution or a breakdown of the Worker's lifetime. A missing Worker
+ID does not establish that work ran on the main thread.
+
 Stalled embedded-run diagnostics mark `terminalProgressStale=true`
 when the last bridge progress looked terminal (for example a raw response
 item or response-completion event) but the Gateway still considers the

--- a/src/config/sessions/session-accessor.sqlite-archive.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.ts
@@ -294,6 +294,7 @@ function resolveSourceWorkerExecArgv(): string[] {
 }
 
 function spawnSqliteTranscriptArchiveWorkerOperation<Result>(params: {
+  diagnostics?: { workerThreadId?: number };
   expectedMessageType: "done" | "published" | "reclaimed";
   onCommitRequest?: () => void;
   transferList?: ArrayBuffer[];
@@ -310,6 +311,10 @@ function spawnSqliteTranscriptArchiveWorkerOperation<Result>(params: {
       execArgv: sourceWorkerExecArgv,
       transferList: params.transferList,
     });
+    // Node clears threadId at exit. Keep only the spawned identity for the awaiting writer.
+    if (params.diagnostics) {
+      params.diagnostics.workerThreadId = worker.threadId;
+    }
   } catch (error) {
     return Promise.reject(toStringifiedError(error));
   }
@@ -358,6 +363,7 @@ const sqliteTranscriptArchiveWorkerQueue = new KeyedAsyncQueue();
 const SQLITE_TRANSCRIPT_ARCHIVE_WORKER_QUEUE_KEY = "lifecycle-archive";
 
 export function runSqliteTranscriptArchiveWorkerOperation<Result>(params: {
+  diagnostics?: { workerThreadId?: number };
   expectedMessageType: "done" | "published" | "reclaimed";
   onCommitRequest?: () => void;
   transferList?: ArrayBuffer[];

--- a/src/config/sessions/session-accessor.sqlite-contract.ts
+++ b/src/config/sessions/session-accessor.sqlite-contract.ts
@@ -16,6 +16,12 @@ import type { InternalSessionEntry as SessionEntry } from "./types.js";
 
 export type SessionEntryStatus = NonNullable<SessionEntry["status"]>;
 
+/** One writer callback owns this record; no Worker object or plan payload is retained. */
+export type SqliteSessionReclamationDiagnostics = {
+  kind?: "entry" | "lifecycle-artifacts" | "history-eviction" | "historical-generation";
+  workerThreadId?: number;
+};
+
 export type SessionTranscriptInstance = SessionEntrySummary & {
   agentId: string;
   /** Stable transcript identity, including rotated history for one logical session key. */

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -25,6 +25,7 @@ import type {
   ResetSessionEntryLifecycleResult,
   SessionLifecycleArtifactCleanupParams,
   SessionLifecycleArtifactCleanupResult,
+  SqliteSessionReclamationDiagnostics,
 } from "./session-accessor.sqlite-contract.js";
 import {
   hasPreparedNativeSessionDeletion,
@@ -58,7 +59,6 @@ import {
   runExclusiveSqliteSessionReclamation,
   runSqliteSessionReclamation,
   shouldDeleteSqliteSessionEntryLifecycle,
-  type SqliteSessionReclamationDiagnostics,
 } from "./session-accessor.sqlite-reclamation.js";
 import {
   cloneSessionEntry,

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -58,6 +58,7 @@ import {
   runExclusiveSqliteSessionReclamation,
   runSqliteSessionReclamation,
   shouldDeleteSqliteSessionEntryLifecycle,
+  type SqliteSessionReclamationDiagnostics,
 } from "./session-accessor.sqlite-reclamation.js";
 import {
   cloneSessionEntry,
@@ -156,26 +157,32 @@ export async function cleanupSessionLifecycleArtifactsCore(
     async (assertCurrent) =>
       await runExclusiveSqliteSessionReclamation(async () => {
         const materializedPlans = await materializeSessionStateDeletePlans(cleanupPlan.deletePlans);
-        return await runExclusiveSqliteSessionWrite(resolved, async () => {
-          assertCurrent();
-          const plan = createLifecycleArtifactReclamationPlan({
-            databaseOptions,
-            entries: cleanupPlan.entries,
-            materializedPlans,
-          });
-          const reclaimed = await runSqliteSessionReclamation({
-            assertCommitAllowed: assertCurrent,
-            forceInProcess: hasPreparedNativeSessionDeletion(),
-            plan,
-          });
-          if (reclaimed.kind !== plan.kind) {
-            throw new Error(
-              `SQLite session reclamation returned ${reclaimed.kind} for ${plan.kind}`,
-            );
-          }
-          emitCommittedSessionEntryRemovals(resolved.agentId, cleanupPlan.entries);
-          return reclaimed.value;
-        });
+        const diagnostics: SqliteSessionReclamationDiagnostics = {};
+        return await runExclusiveSqliteSessionWrite(
+          resolved,
+          async () => {
+            assertCurrent();
+            const plan = createLifecycleArtifactReclamationPlan({
+              databaseOptions,
+              entries: cleanupPlan.entries,
+              materializedPlans,
+            });
+            const reclaimed = await runSqliteSessionReclamation({
+              diagnostics,
+              assertCommitAllowed: assertCurrent,
+              forceInProcess: hasPreparedNativeSessionDeletion(),
+              plan,
+            });
+            if (reclaimed.kind !== plan.kind) {
+              throw new Error(
+                `SQLite session reclamation returned ${reclaimed.kind} for ${plan.kind}`,
+              );
+            }
+            emitCommittedSessionEntryRemovals(resolved.agentId, cleanupPlan.entries);
+            return reclaimed.value;
+          },
+          diagnostics,
+        );
       }),
     { additionalIdentities: cleanupPlan.deletePlans.map((plan) => plan.sessionId) },
   );
@@ -458,50 +465,56 @@ async function deleteSqliteSessionEntryLifecycleLocked(
         }
         const archivedGeneration = await runExclusiveSqliteSessionReclamation(async () => {
           const materializedGeneration = await materializeSessionStateDeletePlans([plan]);
-          return await runExclusiveSqliteSessionWrite(resolved, async () => {
-            params.commitGuard?.();
-            assertCurrent();
-            const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-            const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
-            if (
-              !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, targetSnapshot) ||
-              !shouldDeleteSqliteSessionEntryLifecycle(database, targetSnapshot[0]?.entry, params)
-            ) {
-              return DELETE_EXPECTED_ENTRY_MISMATCH;
-            }
-            const protectedSessionIds = collectAdmissionProtectedSessionIds({
-              database,
-              storePath: params.storePath,
-            });
-            if (protectedSessionIds.has(sessionId)) {
-              throw new Error(
-                `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
-              );
-            }
-            const reclamationPlan = createHistoricalGenerationReclamationPlan({
-              databaseOptions: toDatabaseOptions(resolved),
-              deleteParams: params,
-              materializedPlans: materializedGeneration,
-              preparedTargetSnapshot: prepared.targetSnapshot,
-              protectedSessionIds,
-              sessionId,
-            });
-            const reclaimed = await runSqliteSessionReclamation({
-              assertCommitAllowed: () => {
-                params.commitGuard?.();
-                assertCurrent();
-              },
-              forceInProcess: hasPreparedNativeSessionDeletion(),
-              onInProcessCommit: recordCommit,
-              plan: reclamationPlan,
-            });
-            if (reclaimed.kind !== reclamationPlan.kind) {
-              throw new Error(
-                `SQLite session reclamation returned ${reclaimed.kind} for ${reclamationPlan.kind}`,
-              );
-            }
-            return reclaimed.value;
-          });
+          const diagnostics: SqliteSessionReclamationDiagnostics = {};
+          return await runExclusiveSqliteSessionWrite(
+            resolved,
+            async () => {
+              params.commitGuard?.();
+              assertCurrent();
+              const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+              const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
+              if (
+                !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, targetSnapshot) ||
+                !shouldDeleteSqliteSessionEntryLifecycle(database, targetSnapshot[0]?.entry, params)
+              ) {
+                return DELETE_EXPECTED_ENTRY_MISMATCH;
+              }
+              const protectedSessionIds = collectAdmissionProtectedSessionIds({
+                database,
+                storePath: params.storePath,
+              });
+              if (protectedSessionIds.has(sessionId)) {
+                throw new Error(
+                  `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
+                );
+              }
+              const reclamationPlan = createHistoricalGenerationReclamationPlan({
+                databaseOptions: toDatabaseOptions(resolved),
+                deleteParams: params,
+                materializedPlans: materializedGeneration,
+                preparedTargetSnapshot: prepared.targetSnapshot,
+                protectedSessionIds,
+                sessionId,
+              });
+              const reclaimed = await runSqliteSessionReclamation({
+                diagnostics,
+                assertCommitAllowed: () => {
+                  params.commitGuard?.();
+                  assertCurrent();
+                },
+                forceInProcess: hasPreparedNativeSessionDeletion(),
+                onInProcessCommit: recordCommit,
+                plan: reclamationPlan,
+              });
+              if (reclaimed.kind !== reclamationPlan.kind) {
+                throw new Error(
+                  `SQLite session reclamation returned ${reclaimed.kind} for ${reclamationPlan.kind}`,
+                );
+              }
+              return reclaimed.value;
+            },
+            diagnostics,
+          );
         });
         if (archivedGeneration === DELETE_EXPECTED_ENTRY_MISMATCH) {
           return expectedEntryMismatchResult(historicalArchivedTranscripts);
@@ -527,31 +540,37 @@ async function deleteSqliteSessionEntryLifecycleLocked(
       // writer-lane sections so unrelated writes to this store can keep progressing.
       const result = await runExclusiveSqliteSessionReclamation(async () => {
         const materializedPlans = await materializeSessionStateDeletePlans(prepared.entryPlans);
-        return await runExclusiveSqliteSessionWrite(resolved, async () => {
-          params.commitGuard?.();
-          assertCurrent();
-          const reclamationPlan = createSessionEntryReclamationPlan({
-            databaseOptions: toDatabaseOptions(resolved),
-            deleteParams: params,
-            materializedPlans,
-            preparedTargetSnapshot: prepared.targetSnapshot,
-          });
-          const reclaimed = await runSqliteSessionReclamation({
-            assertCommitAllowed: () => {
-              params.commitGuard?.();
-              assertCurrent();
-            },
-            forceInProcess: hasPreparedNativeSessionDeletion(),
-            onInProcessCommit: recordCommit,
-            plan: reclamationPlan,
-          });
-          if (reclaimed.kind !== reclamationPlan.kind) {
-            throw new Error(
-              `SQLite session reclamation returned ${reclaimed.kind} for ${reclamationPlan.kind}`,
-            );
-          }
-          return reclaimed.value;
-        });
+        const diagnostics: SqliteSessionReclamationDiagnostics = {};
+        return await runExclusiveSqliteSessionWrite(
+          resolved,
+          async () => {
+            params.commitGuard?.();
+            assertCurrent();
+            const reclamationPlan = createSessionEntryReclamationPlan({
+              databaseOptions: toDatabaseOptions(resolved),
+              deleteParams: params,
+              materializedPlans,
+              preparedTargetSnapshot: prepared.targetSnapshot,
+            });
+            const reclaimed = await runSqliteSessionReclamation({
+              diagnostics,
+              assertCommitAllowed: () => {
+                params.commitGuard?.();
+                assertCurrent();
+              },
+              forceInProcess: hasPreparedNativeSessionDeletion(),
+              onInProcessCommit: recordCommit,
+              plan: reclamationPlan,
+            });
+            if (reclaimed.kind !== reclamationPlan.kind) {
+              throw new Error(
+                `SQLite session reclamation returned ${reclaimed.kind} for ${reclamationPlan.kind}`,
+              );
+            }
+            return reclaimed.value;
+          },
+          diagnostics,
+        );
       });
       if (result.deleted) {
         markCommitted();

--- a/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
@@ -1,19 +1,26 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { setImmediate as yieldToEventLoop, setTimeout as delay } from "node:timers/promises";
+import { isMainThread, threadId } from "node:worker_threads";
+import type { Worker } from "node:worker_threads";
 import { afterEach, expect, test, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { SqliteBoardStore } from "../../boards/sqlite-board-store.js";
+import { flushLogger, setLoggerOverride } from "../../logging/logger.js";
 import {
   closeOpenClawAgentDatabaseByPath,
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import { loadTranscriptEvents } from "./session-accessor.js";
+import { runSqliteTranscriptArchiveWorkerOperation } from "./session-accessor.sqlite-archive.js";
 import { loadSessionEntry, replaceSessionEntrySync } from "./session-accessor.sqlite-entry.js";
 import { ensureSessionEntrySync } from "./session-accessor.sqlite-initial-entry.js";
 import {
   createHistoryEvictionReclamationPlan,
   runSqliteSessionReclamation,
+  type SqliteSessionReclamationDiagnostics,
 } from "./session-accessor.sqlite-reclamation.js";
 import { runExclusiveSqliteSessionWrite } from "./session-accessor.sqlite-scope.js";
 import {
@@ -83,6 +90,10 @@ test.each([
   "two synchronous writers progress at reclamation ($operation, rejected: $rejected)",
   async ({ operation, rejected }) => {
     const { databaseOptions, plan, scopes } = createFixture();
+    const workers: Array<{ worker: Worker; id: number }> = [];
+    const observeWorker = (worker: Worker) => workers.push({ worker, id: worker.threadId });
+    process.on("worker", observeWorker);
+    const diagnostics: SqliteSessionReclamationDiagnostics = {};
     const board = new SqliteBoardStore({
       env: databaseOptions.env,
       resolveSession: ({ sessionKey }) => ({ ...databaseOptions, sessionKey }),
@@ -125,28 +136,40 @@ test.each([
         }
       });
     const reclamation = owner.run("reclamation-owner", () =>
-      runExclusiveSqliteSessionWrite(databaseOptions, () =>
-        runSqliteSessionReclamation({
-          forceInProcess: false,
-          plan,
-          assertCommitAllowed: () => {
-            commitChecks += 1;
-            expect(owner.getStore()).toBe("reclamation-owner");
-            if (rejected) {
-              throw new Error("reclamation owner retired");
-            }
-          },
-        }),
+      runExclusiveSqliteSessionWrite(
+        databaseOptions,
+        () =>
+          runSqliteSessionReclamation({
+            diagnostics,
+            forceInProcess: false,
+            plan,
+            assertCommitAllowed: () => {
+              commitChecks += 1;
+              expect(owner.getStore()).toBe("reclamation-owner");
+              if (rejected) {
+                throw new Error("reclamation owner retired");
+              }
+            },
+          }),
+        diagnostics,
       ),
     );
-    if (rejected) {
-      await expect(reclamation).rejects.toThrow("reclamation owner retired");
-    } else {
-      await expect(reclamation).resolves.toEqual({
-        kind: "history-eviction",
-        value: { archivedTranscripts: [], deleted: true },
-      });
+    try {
+      if (rejected) {
+        await expect(reclamation).rejects.toThrow("reclamation owner retired");
+      } else {
+        await expect(reclamation).resolves.toEqual({
+          kind: "history-eviction",
+          value: { archivedTranscripts: [], deleted: true },
+        });
+      }
+    } finally {
+      process.off("worker", observeWorker);
     }
+    expect(workers).toHaveLength(1);
+    expect(workers[0]?.id).toBeGreaterThan(0);
+    expect(diagnostics).toEqual({ kind: "history-eviction", workerThreadId: workers[0]?.id });
+    expect(workers[0]?.worker.threadId).toBe(-1);
     expect(commitChecks).toBe(1);
     expect(appendErrors).toEqual([]);
     expect(appends).toEqual(
@@ -222,4 +245,105 @@ test("one reclamation pass leaves a large freelist for bounded later maintenance
   await Promise.all([reclaimSqliteFreePages(databaseOptions), duringDrain]);
   const reopened = openOpenClawAgentDatabase(databaseOptions);
   expect(Number(reopened.db.prepare("PRAGMA freelist_count").get()?.freelist_count)).toBe(0);
+});
+
+test("queued and different-store reclamations retain only their own worker identity", async () => {
+  const first = createFixture();
+  const other = createFixture();
+  const diagnostics: SqliteSessionReclamationDiagnostics[] = [{}, {}, {}];
+  const operations = [first, first, other].map((fixture, index) => {
+    const record = diagnostics[index];
+    return runExclusiveSqliteSessionWrite(
+      fixture.databaseOptions,
+      () =>
+        runSqliteSessionReclamation({
+          forceInProcess: false,
+          plan: fixture.plan,
+          diagnostics: record,
+        }),
+      record,
+    );
+  });
+  try {
+    // The same-store successor has not entered its callback or claimed a worker.
+    expect(diagnostics[1]).toEqual({});
+    await Promise.all(operations);
+    expect(diagnostics.map((record) => record.kind)).toEqual([
+      "history-eviction",
+      "history-eviction",
+      "history-eviction",
+    ]);
+    const ids = diagnostics.map((record) => record.workerThreadId);
+    expect(ids.every((id) => typeof id === "number" && id > 0)).toBe(true);
+    expect(new Set(ids).size).toBe(3);
+  } finally {
+    await Promise.allSettled(operations);
+  }
+});
+
+test("in-process reclamation and rejected worker construction do not invent a worker identity", async () => {
+  const { plan } = createFixture();
+  const inProcess: SqliteSessionReclamationDiagnostics = {};
+  await runSqliteSessionReclamation({ forceInProcess: true, plan, diagnostics: inProcess });
+  expect(inProcess).toEqual({ kind: "history-eviction" });
+
+  const rejected: SqliteSessionReclamationDiagnostics = {};
+  await expect(
+    runSqliteTranscriptArchiveWorkerOperation({
+      diagnostics: rejected,
+      expectedMessageType: "reclaimed",
+      workerData: { notCloneable: () => undefined },
+    }),
+  ).rejects.toMatchObject({ name: "DataCloneError" });
+  expect(rejected).toEqual({});
+});
+
+test("file warnings link an awaited native worker without attributing it to the queued successor", async () => {
+  const { databaseOptions, plan } = createFixture();
+  const file = path.join(tempDirs.make("openclaw-writer-log-"), "writer.log");
+  const diagnostics: SqliteSessionReclamationDiagnostics = {};
+  const workers: Array<{ worker: Worker; id: number }> = [];
+  const observeWorker = (worker: Worker) => workers.push({ worker, id: worker.threadId });
+  setLoggerOverride({ level: "info", file });
+  process.on("worker", observeWorker);
+  const first = runExclusiveSqliteSessionWrite(
+    databaseOptions,
+    async () => {
+      // Exercise the real slow-warning threshold without a large database or a fake clock.
+      await delay(1_100);
+      return runSqliteSessionReclamation({ forceInProcess: false, plan, diagnostics });
+    },
+    diagnostics,
+  );
+  const second = runExclusiveSqliteSessionWrite(databaseOptions, async () => "successor");
+  try {
+    await expect(first).resolves.toMatchObject({ kind: "history-eviction" });
+    await expect(second).resolves.toBe("successor");
+    await flushLogger();
+    const records = (await fs.readFile(file, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+      .filter((record) => record["1"] === "slow SQLite session write")
+      .map((record) => record["2"]);
+    expect(workers).toHaveLength(1);
+    expect(workers[0]?.id).toBeGreaterThan(0);
+    expect(workers[0]?.worker.threadId).toBe(-1);
+    expect(records).toHaveLength(2);
+    expect(records[0]).toMatchObject({
+      pid: process.pid,
+      threadId,
+      isMainThread,
+      reclamationKind: "history-eviction",
+      workerThreadId: workers[0]?.id,
+    });
+    expect(records[1]).toMatchObject({ pid: process.pid, threadId, isMainThread });
+    expect(records[1]).not.toHaveProperty("workerThreadId");
+    expect(records[1]).not.toHaveProperty("reclamationKind");
+  } finally {
+    await Promise.allSettled([first, second]);
+    process.off("worker", observeWorker);
+    await flushLogger();
+    setLoggerOverride(null);
+  }
 });

--- a/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
@@ -15,12 +15,12 @@ import {
 } from "../../state/openclaw-agent-db.js";
 import { loadTranscriptEvents } from "./session-accessor.js";
 import { runSqliteTranscriptArchiveWorkerOperation } from "./session-accessor.sqlite-archive.js";
+import type { SqliteSessionReclamationDiagnostics } from "./session-accessor.sqlite-contract.js";
 import { loadSessionEntry, replaceSessionEntrySync } from "./session-accessor.sqlite-entry.js";
 import { ensureSessionEntrySync } from "./session-accessor.sqlite-initial-entry.js";
 import {
   createHistoryEvictionReclamationPlan,
   runSqliteSessionReclamation,
-  type SqliteSessionReclamationDiagnostics,
 } from "./session-accessor.sqlite-reclamation.js";
 import { runExclusiveSqliteSessionWrite } from "./session-accessor.sqlite-scope.js";
 import {

--- a/src/config/sessions/session-accessor.sqlite-reclamation.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.ts
@@ -117,6 +117,12 @@ export type SqliteSessionReclamationWorkerData = {
   type: "sqlite-transcript-archive-v2";
 };
 
+/** One writer callback owns this record; no Worker object or plan payload is retained. */
+export type SqliteSessionReclamationDiagnostics = {
+  kind?: SqliteSessionReclamationPlan["kind"];
+  workerThreadId?: number;
+};
+
 export type SqliteSessionReclamationWorkerResult = {
   cleanupIncomplete?: true;
   cleanupWarnings?: string[];
@@ -389,11 +395,15 @@ function prepareReclamationWorkerTransferList(plan: SqliteSessionReclamationPlan
 }
 
 export async function runSqliteSessionReclamation(params: {
+  diagnostics?: SqliteSessionReclamationDiagnostics;
   assertCommitAllowed?: () => void;
   forceInProcess: boolean;
   onInProcessCommit?: (database: OpenClawAgentDatabase) => void;
   plan: SqliteSessionReclamationPlan;
 }): Promise<SqliteSessionReclamationResult> {
+  if (params.diagnostics) {
+    params.diagnostics.kind = params.plan.kind;
+  }
   if (
     params.forceInProcess ||
     isIncognitoOpenClawAgentSqlitePath(params.plan.databaseOptions.path, {
@@ -413,6 +423,7 @@ export async function runSqliteSessionReclamation(params: {
   const recoveredCommitErrors: unknown[] = [];
   const runWorker = (authorize: () => unknown[]) =>
     runSqliteTranscriptArchiveWorkerOperation<SqliteSessionReclamationWorkerResult>({
+      diagnostics: params.diagnostics,
       expectedMessageType: "reclaimed",
       onCommitRequest: () => recoveredCommitErrors.push(...authorize()),
       transferList: prepareReclamationWorkerTransferList(params.plan),

--- a/src/config/sessions/session-accessor.sqlite-reclamation.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.ts
@@ -22,6 +22,7 @@ import type {
   DeleteSessionEntryLifecycleParams,
   DeleteSessionEntryLifecycleResult,
   SessionLifecycleArchivedTranscript,
+  SqliteSessionReclamationDiagnostics,
 } from "./session-accessor.sqlite-contract.js";
 import { runSqliteSessionDeletionTransaction } from "./session-accessor.sqlite-deletion.js";
 import {
@@ -115,12 +116,6 @@ export type SqliteSessionReclamationWorkerData = {
   operation: "reclaim";
   plan: SqliteSessionReclamationPlan;
   type: "sqlite-transcript-archive-v2";
-};
-
-/** One writer callback owns this record; no Worker object or plan payload is retained. */
-export type SqliteSessionReclamationDiagnostics = {
-  kind?: SqliteSessionReclamationPlan["kind"];
-  workerThreadId?: number;
 };
 
 export type SqliteSessionReclamationWorkerResult = {

--- a/src/config/sessions/session-accessor.sqlite-scope.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.test.ts
@@ -1,9 +1,11 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { performance } from "node:perf_hooks";
+import { isMainThread, threadId } from "node:worker_threads";
 import { afterEach, expect, test, vi } from "vitest";
 import * as logging from "../../logging/logger.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import type { SqliteSessionReclamationDiagnostics } from "./session-accessor.sqlite-reclamation.js";
 import { runExclusiveSqliteSessionWrite } from "./session-accessor.sqlite-scope.js";
 import { drainSessionStoreWriterQueuesForTest } from "./store-writer-state.js";
 
@@ -31,13 +33,23 @@ test.each([false, true])(
       const scope = { agentId: "main", env: state.env };
       const release = createDeferredCore();
       const order: string[] = [];
+      const diagnostics: SqliteSessionReclamationDiagnostics = {};
       const first = owners.run("first", () =>
-        runExclusiveSqliteSessionWrite(scope, async () => {
-          order.push("first:start");
-          await release.promise;
-          order.push("first:end");
-          return "first";
-        }),
+        runExclusiveSqliteSessionWrite(
+          scope,
+          async () => {
+            order.push("first:start");
+            await release.promise;
+            Object.assign(diagnostics, {
+              kind: "history-eviction",
+              workerThreadId: 7,
+              payload: "must not enter diagnostics",
+            });
+            order.push("first:end");
+            return "first";
+          },
+          diagnostics,
+        ),
       );
       expect(order).toEqual(["first:start"]);
       clock = 100;
@@ -72,21 +84,34 @@ test.each([false, true])(
         expect(order).toEqual(["first:start", "first:end", "second:start", "queued-successor"]);
         expect(records.find((entry) => entry.owner === "first")?.args[1]).toEqual(
           expect.objectContaining({
+            pid: process.pid,
+            threadId,
+            isMainThread,
+            reclamationKind: "history-eviction",
+            workerThreadId: 7,
             elapsedMs: 2_000,
             queueWaitMs: 0,
             writerExecutionMs: 1_600,
             completionDelayMs: 400,
           }),
         );
+        expect(records.find((entry) => entry.owner === "first")?.args[1]).not.toHaveProperty(
+          "payload",
+        );
         const record = records.find((entry) => entry.owner === "second");
         expect(record?.args[1]).toEqual(
           expect.objectContaining({
+            pid: process.pid,
+            threadId,
+            isMainThread,
             elapsedMs: 1_900,
             queueWaitMs: 1_500,
             writerExecutionMs: 400,
             completionDelayMs: 0,
           }),
         );
+        expect(record?.args[1]).not.toHaveProperty("reclamationKind");
+        expect(record?.args[1]).not.toHaveProperty("workerThreadId");
         if (fail) {
           expect(record?.args[1]).toHaveProperty("error", failure);
         }

--- a/src/config/sessions/session-accessor.sqlite-scope.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.test.ts
@@ -5,7 +5,7 @@ import { afterEach, expect, test, vi } from "vitest";
 import * as logging from "../../logging/logger.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
-import type { SqliteSessionReclamationDiagnostics } from "./session-accessor.sqlite-reclamation.js";
+import type { SqliteSessionReclamationDiagnostics } from "./session-accessor.sqlite-contract.js";
 import { runExclusiveSqliteSessionWrite } from "./session-accessor.sqlite-scope.js";
 import { drainSessionStoreWriterQueuesForTest } from "./store-writer-state.js";
 

--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -2,6 +2,7 @@
 // Runtime feature code imports the session accessor barrel instead of this module.
 import path from "node:path";
 import { performance } from "node:perf_hooks";
+import { isMainThread, threadId } from "node:worker_threads";
 import { getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import { getChildLogger } from "../../logging/logger.js";
 import {
@@ -26,6 +27,7 @@ import type {
   SessionTranscriptReadScope,
   SessionTranscriptWriteScope,
 } from "./session-accessor.sqlite-contract.js";
+import type { SqliteSessionReclamationDiagnostics } from "./session-accessor.sqlite-reclamation.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import { normalizeStoreSessionKey } from "./store-entry.js";
 import { SQLITE_SESSION_WRITER_QUEUES } from "./store-writer-state.js";
@@ -100,12 +102,20 @@ export function getSessionKysely(database: import("node:sqlite").DatabaseSync) {
 export async function runExclusiveSqliteSessionWrite<T>(
   scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">,
   fn: () => Promise<T>,
+  reclamation?: SqliteSessionReclamationDiagnostics,
 ): Promise<T> {
   const databaseOptions = toDatabaseOptions(scope);
   const storePath = resolveOpenClawAgentSqlitePath(databaseOptions);
   const startedAt = performance.now();
   const timing: StoreWriterTiming = {};
   const timingFields = (completedAt: number) => ({
+    pid: process.pid,
+    threadId,
+    isMainThread,
+    ...(reclamation?.kind ? { reclamationKind: reclamation.kind } : {}),
+    ...(reclamation?.workerThreadId !== undefined
+      ? { workerThreadId: reclamation.workerThreadId }
+      : {}),
     elapsedMs: Math.round(completedAt - startedAt),
     ...(timing.startedAt !== undefined && timing.finishedAt !== undefined
       ? {

--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -26,8 +26,8 @@ import type {
   SessionAccessScope,
   SessionTranscriptReadScope,
   SessionTranscriptWriteScope,
+  SqliteSessionReclamationDiagnostics,
 } from "./session-accessor.sqlite-contract.js";
-import type { SqliteSessionReclamationDiagnostics } from "./session-accessor.sqlite-reclamation.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import { normalizeStoreSessionKey } from "./store-entry.js";
 import { SQLITE_SESSION_WRITER_QUEUES } from "./store-writer-state.js";

--- a/src/config/sessions/session-history-eviction.ts
+++ b/src/config/sessions/session-history-eviction.ts
@@ -29,6 +29,7 @@ import {
   createHistoryEvictionReclamationPlan,
   runExclusiveSqliteSessionReclamation,
   runSqliteSessionReclamation,
+  type SqliteSessionReclamationDiagnostics,
 } from "./session-accessor.sqlite-reclamation.js";
 import { isRecentHistoricalSessionId } from "./session-accessor.sqlite-references.js";
 import {
@@ -530,34 +531,40 @@ async function enforceSessionHistoryMaintenanceSerialized(
         // fences admission while the store writer is released for archive I/O.
         const committedArchives = await runExclusiveSqliteSessionReclamation(async () => {
           const materialized = await materializeSessionStateDeletePlans([plan]);
-          return await runExclusiveSqliteSessionWrite(resolved, async () => {
-            const database = openOpenClawAgentDatabase(databaseOptions);
-            const reclamationPlan = createHistoryEvictionReclamationPlan({
-              databaseOptions,
-              diskBudget: { preserveRecentMs: params.maintenance.preserveRecentMs },
-              materializedPlans: materialized,
-              protectedSessionIds: collectCandidateAdditionalProtection({
-                database,
-                preserveRecentMs: params.maintenance.preserveRecentMs,
+          const diagnostics: SqliteSessionReclamationDiagnostics = {};
+          return await runExclusiveSqliteSessionWrite(
+            resolved,
+            async () => {
+              const database = openOpenClawAgentDatabase(databaseOptions);
+              const reclamationPlan = createHistoryEvictionReclamationPlan({
+                databaseOptions,
+                diskBudget: { preserveRecentMs: params.maintenance.preserveRecentMs },
+                materializedPlans: materialized,
+                protectedSessionIds: collectCandidateAdditionalProtection({
+                  database,
+                  preserveRecentMs: params.maintenance.preserveRecentMs,
+                  sessionId,
+                  storePath: params.storePath,
+                }),
                 sessionId,
-                storePath: params.storePath,
-              }),
-              sessionId,
-            });
-            const reclaimed = await runSqliteSessionReclamation({
-              forceInProcess: false,
-              plan: reclamationPlan,
-            });
-            if (reclaimed.kind !== reclamationPlan.kind) {
-              throw new Error(
-                `SQLite session reclamation returned ${reclaimed.kind} for ${reclamationPlan.kind}`,
-              );
-            }
-            if (!reclaimed.value.deleted) {
-              return null;
-            }
-            return reclaimed.value.archivedTranscripts;
-          });
+              });
+              const reclaimed = await runSqliteSessionReclamation({
+                diagnostics,
+                forceInProcess: false,
+                plan: reclamationPlan,
+              });
+              if (reclaimed.kind !== reclamationPlan.kind) {
+                throw new Error(
+                  `SQLite session reclamation returned ${reclaimed.kind} for ${reclamationPlan.kind}`,
+                );
+              }
+              if (!reclaimed.value.deleted) {
+                return null;
+              }
+              return reclaimed.value.archivedTranscripts;
+            },
+            diagnostics,
+          );
         });
         if (!committedArchives) {
           return null;

--- a/src/config/sessions/session-history-eviction.ts
+++ b/src/config/sessions/session-history-eviction.ts
@@ -18,6 +18,7 @@ import {
 } from "./disk-budget.js";
 import { publishSessionStateArchives } from "./session-accessor.sqlite-archive-store.js";
 import { materializeSessionStateDeletePlans } from "./session-accessor.sqlite-archive.js";
+import type { SqliteSessionReclamationDiagnostics } from "./session-accessor.sqlite-contract.js";
 import { emitArchivedTranscriptUpdates } from "./session-accessor.sqlite-events.js";
 import {
   collectSessionStateIdsForEntry,
@@ -29,7 +30,6 @@ import {
   createHistoryEvictionReclamationPlan,
   runExclusiveSqliteSessionReclamation,
   runSqliteSessionReclamation,
-  type SqliteSessionReclamationDiagnostics,
 } from "./session-accessor.sqlite-reclamation.js";
 import { isRecentHistoricalSessionId } from "./session-accessor.sqlite-references.js";
 import {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators investigating slow session cleanup could not tell which worker a slow SQLite writer callback had awaited. Nearby database-open warnings already identified their worker, but the writer warnings lacked the process and worker association needed to connect them reliably.

## Why This Change Was Made

Existing writer warnings now include the emitting PID and Node thread identity. Each reclamation callback owns a small diagnostic record containing its actual plan kind and the worker's numeric ID, captured at creation and preserved after exit. This uses the existing worker identity without adding trace IDs, timers, queues, configuration, or message fields. Queue ordering, commit authorization, database validation, and cleanup remain unchanged.

## User Impact

Operators can join a writer warning's PID and workerThreadId to a database-open warning's PID and threadId within the same process lifetime. This identifies an awaited worker; it does not turn elapsed time into CPU attribution or itself reduce latency. The documentation explains those limits.

## Evidence

- The original warning fails the PID/thread regression checks. Restoring only the original dispatcher also makes the real file-log test fail specifically on the missing worker ID.
- Actual workers cover successful and rejected reclamation, identity retention after exit, same-store queueing, different-store isolation, and absent identity for in-process work or constructor failure.
- A small real JSONL logging test crosses the existing warning threshold with a bounded delay and proves the queued successor does not inherit its predecessor's worker ID.
- Linux Crabbox: all 30 focused tests passed on Node 24.19.0, including the real file-log flow; the one-shot lease stopped successfully. That native run covered the initial diagnostic implementation. The subsequent type-only correction emits byte-identical JavaScript with the repository's esbuild version; its 15 focused tests also passed locally on Node 26.8.1.
- Independent P2 review: no accepted findings. Six alternating batches of 10,000 silent no-op writer calls had median process CPU times of 79.97 ms before, 80.32 ms after, and 79.67 ms with a record allocated per call. Wall timings were noisy under concurrent checks; this is not a claim about production latency or worker-lifetime cost.
- The initial implementation passed the full local changed-file gate. Additional CI then caught a static type-import cycle that the runtime-cycle check does not cover. Moving the diagnostic type to the existing SQLite contract removes that back-edge: the exact Madge check changed from one cycle to zero; refreshed core/test typechecks, targeted lint, focused tests, and P2 review all passed. Exact-head CI must pass before landing.

- A required rebase preserved main’s new disk-budget and recent-session protections at the same worker call. All 49 composed local tests passed, including recent, archived, pinned, and cross-owner retention rechecks. Fresh core/test types, targeted lint, Madge, formatting and P2 review also passed. Exact-head CI remains required before landing.

The production change is net +54 lines, including formatter expansion at existing multi-argument call sites. The added capability is explicit diagnostic ownership across six existing modules, including the existing type contract; no generic context framework was introduced.
