### PR TITLE
fix(tests): isolate safe-bin fixtures from host executable layouts

### DIFF
--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -128,6 +128,7 @@ describe("exec approvals node host allowlist check", () => {
       kind: "executable" as const,
       rawExecutable: "head",
       resolvedPath: "/usr/bin/head",
+      resolvedRealPath: "/usr/bin/head",
       executableName: "head",
     };
     // Not in allowlist

--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -73,6 +73,7 @@ describe("exec approvals allowlist evaluation", () => {
             execution: makeMockExecutableResolution({
               rawExecutable: "head",
               resolvedPath: "/usr/bin/head",
+              resolvedRealPath: "/usr/bin/head",
               executableName: "head",
             }),
           }),
@@ -244,6 +245,7 @@ describe("exec approvals allowlist evaluation", () => {
         execution: makeMockExecutableResolution({
           rawExecutable: "head",
           resolvedPath: "/usr/bin/head",
+          resolvedRealPath: "/usr/bin/head",
           executableName: "head",
         }),
       }),

--- a/src/infra/exec-authorization-render.test.ts
+++ b/src/infra/exec-authorization-render.test.ts
@@ -94,9 +94,10 @@ describe("exec authorization renderer", () => {
   });
 
   it("renders dispatch-wrapper safe-bin commands without quote-all argv rendering", async () => {
+    const binDir = makeExecApprovalsTempDir();
     const plan = await planShellAuthorization({
       command: "env rg -n needle",
-      env: POSIX_ENV,
+      env: makePathEnv(binDir),
     });
 
     const command = renderOk(


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Resolves a problem where safe-bin and command-rendering tests fail on hosts with different executable layouts. A host that links `/usr/bin/head` to a coreutils installation outside `/usr/bin`, or has `rg` installed in its standard PATH, changes the outcome of four fixtures that intended to supply fixed executable identities.

## Why This Change Was Made

Three mocked executable resolutions now explicitly supply their intended canonical path. The unresolved-command renderer case uses an owned empty PATH directory. Production trust policy, canonical-path enforcement, and command rendering remain unchanged; real-filesystem positive and negative trust cases and resolved-path renderer cases remain intact.

## User Impact

No user-visible runtime change. Developers get deterministic fixtures across these host layouts without weakening security assertions. This correctness repair adds four test lines and offsets the test-cleanup campaign's net removals by four; it carries no runtime improvement claim.

## Evidence

Both comparison arms reproduced the same four failures before this repair. Focused validation passed all 166 cases across the three affected files and safe-bin trust, runtime-policy, and quoting siblings. The required changed gate, formatting, diff checks, and fresh independent P2 review passed. Every existing assertion and case name is unchanged, verified by exact baseline-source reconstruction.
