### PR TITLE
fix(media): release completed document source buffers

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -4,6 +4,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
@@ -2186,25 +2187,81 @@ describe("applyMediaUnderstanding", () => {
     expectPolicyRejectedFileApplied({ ctx, result, mime: "application/pdf" });
   });
 
-  it("keeps cached attachment bytes intact when a PDF extractor mutates its input", async () => {
-    const original = Buffer.from("%PDF-1.7\nfixture");
-    const mediaPath = await createTempMediaFile({ fileName: "mutable.pdf", content: original });
-    const { MediaAttachmentCache } = await import("./attachments.cache.js");
-    const pdf = await import("../media/pdf-extract.js");
-    const getBuffer = vi.spyOn(MediaAttachmentCache.prototype, "getBuffer");
-    const extract = vi.spyOn(pdf, "extractPdfContent").mockImplementation(async ({ buffer }) => {
-      buffer.fill(0);
-      return { text: "extracted PDF", images: [] };
-    });
-    try {
-      const { ctx } = await applyWithDisabledMedia({ body: "<media:file>", mediaPath });
-      expect(ctx.Body).toContain("extracted PDF");
-      expect((await getBuffer.mock.results[0]?.value)?.buffer).toEqual(original);
-    } finally {
-      extract.mockRestore();
-      getBuffer.mockRestore();
-    }
-  });
+  it.each(["completed", "timed-out"] as const)(
+    "preserves earlier provider bytes when a %s PDF extractor mutates its input",
+    async (outcome) => {
+      const original = Buffer.alloc(2048, 0x20);
+      original.write("%PDF-1.7\nfixture");
+      const ctx = await createAudioCtx({
+        fileName: "mutable.txt",
+        mediaType: "audio/ogg",
+        content: original,
+      });
+      const followingFile = await createTempMediaFile({
+        fileName: "following.txt",
+        content: "Following document survives",
+      });
+      ctx.media?.push({ path: followingFile, contentType: "text/plain" });
+      let borrowed: Buffer | undefined;
+      const transcribeAudio = vi.fn<NonNullable<MediaUnderstandingProvider["transcribeAudio"]>>(
+        async (request) => {
+          borrowed = request.buffer;
+          throw new Error("Not an audio document");
+        },
+      );
+      const started = createDeferred();
+      const finish = createDeferred();
+      const finished = createDeferred();
+      let extractionInput: Buffer | undefined;
+      const pdf = await import("../media/pdf-extract.js");
+      const extract = vi.spyOn(pdf, "extractPdfContent").mockImplementation(async ({ buffer }) => {
+        extractionInput = buffer;
+        started.resolve();
+        if (outcome === "timed-out") {
+          await finish.promise;
+        }
+        buffer.fill(0);
+        finished.resolve();
+        return { text: "extracted PDF", images: [] };
+      });
+      vi.useFakeTimers();
+      try {
+        const application = applyMediaUnderstanding({
+          ctx,
+          cfg: {
+            ...createGroqAudioConfig(),
+            gateway: { http: { endpoints: { responses: { files: { timeoutMs: 10 } } } } },
+          },
+          providers: { groq: { id: "groq", transcribeAudio } },
+        });
+        await started.promise;
+        if (outcome === "timed-out") {
+          await vi.advanceTimersByTimeAsync(10);
+        }
+        const result = await application;
+        expect(result.appliedFile).toBe(true);
+        expect(transcribeAudio).toHaveBeenCalledOnce();
+        expect(ctx.Body).toContain("Following document survives");
+        if (outcome === "timed-out") {
+          expect(ctx.Body).toContain("[Attachment could not be read]");
+          expect(extractionInput).toEqual(original);
+          finish.resolve();
+          await finished.promise;
+          expect(ctx.Body).not.toContain("extracted PDF");
+        } else {
+          expect(ctx.Body).toContain("extracted PDF");
+        }
+        expect(borrowed).toEqual(original);
+      } finally {
+        finish.resolve();
+        if (extractionInput) {
+          await finished.promise;
+        }
+        extract.mockRestore();
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("respects configured allowedMimes for text-like attachments", async () => {
     const tsvText = "a\tb\tc\n1\t2\t3";

--- a/src/media-understanding/attachments.cache.ts
+++ b/src/media-understanding/attachments.cache.ts
@@ -450,6 +450,14 @@ export class MediaAttachmentCache {
     await Promise.all(cleanups);
   }
 
+  /** Drops this cache's bytes after terminal file processing; earlier borrowers keep ownership. */
+  releaseBuffer(attachmentIndex: number): void {
+    const entry = this.entries.get(attachmentIndex);
+    if (entry) {
+      entry.bufferResult = undefined;
+    }
+  }
+
   private async ensureEntry(attachmentIndex: number): Promise<AttachmentCacheEntry> {
     const existing = this.entries.get(attachmentIndex);
     if (existing) {

--- a/src/media-understanding/file-context.ts
+++ b/src/media-understanding/file-context.ts
@@ -241,7 +241,7 @@ export async function extractFileContext(params: {
       limits,
       skipAttachmentIndexes,
       assertCurrent: params.assertCurrent,
-    });
+    }).finally(() => cache.releaseBuffer(attachment.index));
     params.assertCurrent?.();
     if (outcome.kind === "extracted" || outcome.kind === "rendered-to-images") {
       images.push(


### PR DESCRIPTION
Closes #140560

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Resolves a problem where turns containing several large document attachments retain every original source buffer until file extraction finishes, adding memory pressure while later documents are processed.

## Why This Change Was Made

Release the cache-owned source reference after each terminal document classification settles, including rejected, failed, and timed-out attempts. Earlier providers keep their borrowed bytes, and PDF extractors retain their existing separate mutable copy. Temporary-file cleanup remains owned by the attachment cache.

## User Impact

Multi-document turns can reclaim completed source buffers during extraction. A real eight-document plain-text probe retained 20 MiB instead of 160 MiB at the eighth document, making 140 MiB of earlier originals collectible while preserving the extracted result.

## Evidence

- Hosted CI passed on the published head after one targeted rerun of an unchanged Windows startup environment fixture that initially failed with `EBUSY` during temporary-directory cleanup. The media source and assertions were unchanged.
- 129 focused tests passed across media application, attachment caching, guards, media-store references, and extraction limits.
- The complete changed-file check passed, including core and core-test typechecking, lint, formatting, and selected repository guards. Independent isolated P2 autoreview found no actionable findings.
- The ownership probe used eight distinct local 20 MiB text files through real reads, MIME classification, and extraction. All eight rendered blocks matched after normalizing only randomized external-content fence IDs.
- Completed and timed-out mutating PDF extraction preserve an earlier provider's borrowed original, continue to the following text document, and do not publish late extraction text. Existing cleanup, rejection, and self-serve metadata coverage passed.

The source-retention measurement uses forced garbage collection. Single-run RSS and timing observations are not presented as general performance claims; PDF decoder memory and legitimate outstanding provider borrows are outside the measured reduction.
