### PR TITLE
fix(tooling): omit Trae machine squash credit

### DIFF
--- a/scripts/pr-lib/merge-body.mjs
+++ b/scripts/pr-lib/merge-body.mjs
@@ -58,7 +58,7 @@ function trailers(body) {
 function isMachineCredit(line) {
   // Match published machine addresses, never names or provider domains that
   // can also identify human contributors.
-  return /^Co-authored-by:\s*[^<>]+<(?:noreply@anthropic\.com|cursoragent@cursor\.com|amp@ampcode\.com|codex@openai\.com)>$/i.test(
+  return /^Co-authored-by:\s*[^<>]+<(?:noreply@anthropic\.com|cursoragent@cursor\.com|amp@ampcode\.com|codex@openai\.com|solo-agent@trae\.ai)>$/i.test(
     line,
   );
 }

--- a/test/scripts/pr-merge.test.ts
+++ b/test/scripts/pr-merge.test.ts
@@ -348,6 +348,9 @@ describePosix("native squash attribution", () => {
     "Co-authored-by: Codex <codex@openai.com>",
     "co-authored-by: Codex <CODEX@OPENAI.COM>",
     "Co-Authored-By: Codex\n <codex@openai.com>",
+    "Co-authored-by: Trae Solo <solo-agent@trae.ai>",
+    "co-authored-by: Trae Solo <SOLO-AGENT@TRAE.AI>",
+    "Co-Authored-By: Trae Solo\n <solo-agent@trae.ai>",
   ])("omits imported machine credit while preserving human credit: %j", (machineCredit) => {
     const humanCredit = [
       "Co-authored-by: Claude <claude@example.com>",
@@ -362,6 +365,9 @@ describePosix("native squash attribution", () => {
       "Co-authored-by: Codex <codex@example.com>",
       "Co-authored-by: Human <person@openai.com>",
       "Co-authored-by: Other <codex@openai.com.example.org>",
+      "Co-authored-by: Trae Solo <solo-agent@example.com>",
+      "Co-authored-by: Human <person@trae.ai>",
+      "Co-authored-by: Other <solo-agent@trae.ai.example.org>",
     ].join("\n");
     const server = "Co-authored-by: Server <server@example.com>";
     const result = prepareBody({
@@ -384,6 +390,7 @@ describePosix("native squash attribution", () => {
     "Reviewed correction.\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\n",
     "Reviewed correction.\n\nCo-authored-by: Amp <amp@ampcode.com>\n",
     "Reviewed correction.\n\nCo-authored-by: Codex <codex@openai.com>\n",
+    "Reviewed correction.\n\nCo-authored-by: Trae Solo <solo-agent@trae.ai>\n",
   ])(
     "requires a reviewed body when the chosen message contains machine credit: %j",
     (overrideBody) => {
@@ -404,6 +411,7 @@ describePosix("native squash attribution", () => {
     "Cursor <cursoragent@cursor.com>",
     "Amp <amp@ampcode.com>",
     "Codex <codex@openai.com>",
+    "Trae Solo <solo-agent@trae.ai>",
   ])("rejects machine credit present only in the default server preview: %s", (identity) => {
     const result = prepareBody({
       sourceMessages: ["Repair"],


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/136231

## What Problem This Solves

Native squash composition can restore `trae-solo-agent <solo-agent@trae.ai>`
from contributor source trailers into a reviewed merge message. This blocks
landing while preserving human credit without agent attribution.

## Why This Change Was Made

Classify only the exact published Trae machine address in the existing squash
credit filter. Human names, other `trae.ai` addresses, and lookalike domains
remain credited.

## User Impact

Maintainers can land affected contributor PRs through the native workflow while
preserving legitimate human credit. Runtime behavior is unchanged.

## Evidence

- Five focused regression cases fail before the classifier update.
- All 63 native attribution tests pass afterward.
- The captured #136231 composition retains Vincent Koc and excludes Trae Solo
  and Claude machine attribution.
- Tooling: +1/-1. Tests: +8/-0.
