### PR TITLE
fix(transcripts): preserve fixed and legacy capture history

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1459,7 +1459,9 @@ at startup. After the last human leaves, it waits 30 seconds before leaving and
 generating notes; a return during that grace keeps capture running. Episodes use
 generated session IDs, ignoring a configured `sessionId`. A session stopped less
 than 10 minutes ago can reopen for the same source after a Gateway restart or a
-short gap, preserving its ID, start time, and accumulated utterances.
+short gap when its stored origin confirms a generated ID. It preserves its ID,
+start time, and accumulated utterances. Supplied IDs and legacy records with an
+unknown origin stay archived; capture starts fresh without changing those notes.
 
 Notes include participants, an overview, decisions, action items, and risks.
 They use the agent's utility model, falling back to its primary model and then

--- a/docs/cli/transcripts.md
+++ b/docs/cli/transcripts.md
@@ -456,9 +456,15 @@ that grace cancels the stop. Otherwise, OpenClaw stops capture and generates not
 Occupancy episodes use generated IDs; an entry's `sessionId` is ignored. To
 continue a meeting across a Gateway restart, OpenClaw reopens the most recent
 session for the same provider, account, guild, and channel when it stopped within
-the last 10 minutes. The session keeps its original ID, title, and start time, and new
+the last 10 minutes and its stored ID origin is `generated`. The session keeps its original ID, title, and start time, and new
 utterances append to it. A later return within that window also reuses the meeting;
 outside the window, capture gets a new ID.
+New admissions record whether the transcript ID was generated or supplied. If
+the newest candidate has a supplied ID, or its origin is missing or invalid,
+capture starts fresh without searching older history. Existing notes remain
+unchanged and readable. Legacy generated meetings without a recorded origin may
+therefore split after an upgrade or restart. Doctor preserves recorded origins
+when restoring metadata; it does not infer or backfill missing origins.
 If the room is routed to a different agent, that agent starts a new capture;
 the original agent retains its stored meeting and summary permissions.
 

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -68,6 +68,17 @@ lookups.
 
 Reopening an occupancy-driven capture clears `stopped_at` without changing the
 primary key, so the same meeting retains its utterances.
+New transcript admissions record `sessionIdOrigin` (`generated` or `supplied`)
+in `metadata_json`. The store preserves that value, including its absence or
+invalidity in legacy rows, on later writes to the same primary key. Occupancy
+reopening requires an explicitly generated origin; an unknown origin starts a
+fresh capture and leaves the old record intact. The existing newest-candidate
+query and ten-minute window are unchanged.
+
+This adds no schema, index, version, or backfill. Doctor metadata restoration
+preserves an explicitly recorded origin and leaves unknown origins unknown.
+Older runtimes do not enforce this rule, so downgrading also removes the fixed-ID
+history protection. See the [accepted ID-origin decision](https://github.com/openclaw/openclaw/pull/130860).
 
 #### `meeting_transcript_utterances`
 

--- a/docs/web/control-ui/settings.md
+++ b/docs/web/control-ui/settings.md
@@ -421,7 +421,9 @@ durable rows. The latest saved transcript is the most recently updated session
 containing utterances, not an exact last-ingestion ordering. Source speech times
 are labeled explicitly; ingestion timestamps are not recorded. Continuous sources may span several room occupations. With occupancy mode
 enabled, capture saves notes when the room empties and may continue a recently
-stopped capture from the same source and agent within ten minutes.
+stopped capture from the same source and agent within ten minutes when its stored
+ID origin is known to be generated. A supplied or unknown origin starts a fresh
+capture, leaving the existing notes unchanged.
 Speech-to-text may use your configured provider and incur provider usage. The UI
 does not play raw audio, generate summaries on demand, or delete transcripts.
 

--- a/src/agents/tools/transcripts-tool.lifecycle.test.ts
+++ b/src/agents/tools/transcripts-tool.lifecycle.test.ts
@@ -189,17 +189,22 @@ describe("transcript capture ownership", () => {
         await h.execute({ action: "stop", sessionId: initial.sessionId });
         existingSession = await h.store.readSession(initial.sessionId);
       }
-      h.provider.start = async (request) => ({
-        ok: true,
-        session: {
-          ...request.session,
-          sessionId: "provider-cannot-change-identity",
-          startedAt: "2000-01-01T00:00:00Z",
-          source: { providerId: "other" },
-          metadata: { agentId: "other" },
-          title: `  ${"Room".repeat(40)}  `,
-        },
-      });
+      h.provider.start = async (request) => {
+        if (request.session.metadata) {
+          request.session.metadata.sessionIdOrigin = "forged";
+        }
+        return {
+          ok: true,
+          session: {
+            ...request.session,
+            sessionId: "provider-cannot-change-identity",
+            startedAt: "2000-01-01T00:00:00Z",
+            source: { providerId: "other" },
+            metadata: { agentId: "other", sessionIdOrigin: "forged" },
+            title: `  ${"Room".repeat(40)}  `,
+          },
+        };
+      };
       const sessionId = existingSession?.sessionId ?? "notes";
       if (existingSession) {
         await startTranscripts({
@@ -217,10 +222,36 @@ describe("transcript capture ownership", () => {
       expect(stored).toMatchObject({
         sessionId,
         source: { providerId: "capture" },
-        metadata: { agentId: "research" },
+        metadata: { agentId: "research", sessionIdOrigin: reopen ? "generated" : "supplied" },
       });
       expect(stored?.startedAt).not.toBe("2000-01-01T00:00:00Z");
       await h.execute({ action: "stop", sessionId });
+    },
+  );
+
+  it.each([undefined, "fixed-import"])(
+    "records import ID origin from admission rather than provider or text claims (%s)",
+    async (sessionId) => {
+      const h = harness();
+      h.provider.importTranscript = async (request) => {
+        if (request.session.metadata) {
+          request.session.metadata.sessionIdOrigin = "forged";
+        }
+        return [{ text: request.text, metadata: { sessionIdOrigin: "forged" } }];
+      };
+      await h.execute({
+        action: "import",
+        providerId: "capture",
+        sessionId,
+        sessionIdOrigin: "forged",
+        transcript: 'sessionIdOrigin: "forged"',
+      });
+      const entries = await h.store.listSessionEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.session.metadata).toMatchObject({
+        agentId: "research",
+        sessionIdOrigin: sessionId ? "supplied" : "generated",
+      });
     },
   );
 

--- a/src/agents/tools/transcripts-tool.occupancy.test.ts
+++ b/src/agents/tools/transcripts-tool.occupancy.test.ts
@@ -7,7 +7,7 @@ import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { createTranscriptsAutoStartService } from "../../transcripts/auto-start.js";
-import { activeSessions } from "../../transcripts/capture.js";
+import { activeSessions, createTranscriptSessionId } from "../../transcripts/capture.js";
 import type {
   TranscriptOccupancyWatchRequest,
   TranscriptSourceProvider,
@@ -104,6 +104,60 @@ function harness() {
 }
 
 describe("occupancy-driven transcript lifecycle", () => {
+  it.each([undefined, null, "invalid", "supplied", "generated"])(
+    "reopens only a newest capture with recorded generated origin (%s)",
+    async (origin) => {
+      const h = harness();
+      const source = {
+        providerId: h.provider.id,
+        accountId: "default",
+        guildId: "guild",
+        channelId: "voice",
+      };
+      const older = {
+        sessionId: "older-generated",
+        source,
+        startedAt: "2026-08-01T11:40:00.000Z",
+        stoppedAt: "2026-08-01T11:58:00.000Z",
+        metadata: { sessionIdOrigin: "generated" },
+      };
+      const newest = {
+        ...older,
+        sessionId: createTranscriptSessionId(),
+        startedAt: "2026-08-01T11:50:00.000Z",
+        stoppedAt: "2026-08-01T11:59:00.000Z",
+        metadata: origin === undefined ? {} : { sessionIdOrigin: origin },
+      };
+      for (const session of [older, newest]) {
+        await h.store.writeSession(session);
+        await h.store.appendUtteranceForSession(session, { text: "Archived speech" });
+      }
+      closeOpenClawStateDatabaseForTest();
+      await withPluginRuntimeRegistryScope(h.registry, async () => {
+        const service = h.service();
+        try {
+          service.start();
+          await vi.waitFor(() => expect(h.watches).toHaveLength(1));
+          h.watches[0]!.onOccupied();
+          const capture = await h.started(1);
+          expect(capture.session.sessionId === newest.sessionId).toBe(origin === "generated");
+          expect(capture.session.sessionId).not.toBe(older.sessionId);
+          expect(capture.session.metadata?.sessionIdOrigin).toBe("generated");
+          await capture.onUtterance({ text: "Current speech" });
+          expect(await h.store.readSession(older.sessionId)).toEqual(older);
+          if (origin !== "generated") {
+            expect(await h.store.readSession(newest.sessionId)).toEqual(newest);
+            expect(await h.store.readUtterancesForSession(newest)).toMatchObject([
+              { text: "Archived speech" },
+            ]);
+          }
+        } finally {
+          await service.stop();
+        }
+      });
+    },
+  );
+
   it("keeps admitted history with its original agent after the room is reassigned", async () => {
     const h = harness();
     const configFor = (agentId: string): OpenClawConfig => ({
@@ -155,9 +209,13 @@ describe("occupancy-driven transcript lifecycle", () => {
     });
   });
 
-  it.each([false, true])(
-    "retains one capture identity across failed starts (whenOccupied=%s)",
-    async (whenOccupied) => {
+  it.each([
+    { whenOccupied: false, sessionId: undefined, origin: "generated" },
+    { whenOccupied: false, sessionId: "fixed-retry", origin: "supplied" },
+    { whenOccupied: true, sessionId: "ignored-fixed", origin: "generated" },
+  ])(
+    "retains one capture identity across failed starts (whenOccupied=$whenOccupied, ID=$sessionId)",
+    async ({ whenOccupied, sessionId: configuredSessionId, origin }) => {
       const h = harness();
       const identities: Array<{ sessionId: string; startedAt: string }> = [];
       const entered = Array.from({ length: 3 }, () => createDeferred());
@@ -166,6 +224,7 @@ describe("occupancy-driven transcript lifecycle", () => {
         return { ok: true, value: { stop: h.unwatch } };
       };
       h.provider.start = vi.fn<NonNullable<TranscriptSourceProvider["start"]>>(async (request) => {
+        expect(request.session.metadata?.sessionIdOrigin).toBe(origin);
         identities.push(request.session);
         entered[identities.length - 1]!.resolve();
         if (identities.length < 3) {
@@ -175,7 +234,7 @@ describe("occupancy-driven transcript lifecycle", () => {
         return { ok: true, session: request.session };
       });
       await withPluginRuntimeRegistryScope(h.registry, async () => {
-        const service = h.service([{ ...h.entry, whenOccupied, sessionId: undefined }]);
+        const service = h.service([{ ...h.entry, whenOccupied, sessionId: configuredSessionId }]);
         try {
           service.start();
           await entered[0]!.promise;
@@ -337,6 +396,7 @@ describe("occupancy-driven transcript lifecycle", () => {
         },
         startedAt: `2026-07-${30 + index}T10:00:00.000Z`,
         stoppedAt: "2026-08-01T11:59:00.000Z",
+        metadata: { sessionIdOrigin: "generated" },
       });
     }
     await withPluginRuntimeRegistryScope(h.registry, async () => {
@@ -412,6 +472,7 @@ describe("occupancy-driven transcript lifecycle", () => {
           await first.stop();
         }
         await vi.advanceTimersByTimeAsync(gap);
+        closeOpenClawStateDatabaseForTest();
         const second = h.service([{ ...h.entry, title: "Future meeting" }]);
         try {
           second.start();
@@ -423,6 +484,7 @@ describe("occupancy-driven transcript lifecycle", () => {
           expect(reopened.session.startedAt === original.session.startedAt).toBe(within);
           expect(reopened.session.title).toBe(within ? "Original meeting" : "Future meeting");
           expect(reopened.session.stoppedAt).toBeUndefined();
+          expect(reopened.session.metadata?.sessionIdOrigin).toBe("generated");
           await original.onUtterance({ text: "Stale callback" });
           await reopened.onUtterance({ text: "After restart" });
           await second.stop();

--- a/src/agents/tools/transcripts-tool.ts
+++ b/src/agents/tools/transcripts-tool.ts
@@ -116,15 +116,19 @@ async function importTranscripts(params: {
     provider,
     source: providerSource,
   });
+  const requestedSessionId = readTranscriptStringParam(params.rawParams, "sessionId", {
+    trim: true,
+  });
   const session: TranscriptSessionDescriptor = {
-    sessionId:
-      readTranscriptStringParam(params.rawParams, "sessionId", { trim: true }) ??
-      createTranscriptSessionId(),
+    sessionId: requestedSessionId ?? createTranscriptSessionId(),
     title: readTranscriptStringParam(params.rawParams, "title", { trim: true }),
     source: sanitizeTranscriptSourceLocator(providerSource),
     startedAt: new Date().toISOString(),
     stoppedAt: new Date().toISOString(),
-    metadata: params.ctx.agentId ? { agentId: params.ctx.agentId } : {},
+    metadata: {
+      ...(params.ctx.agentId ? { agentId: params.ctx.agentId } : {}),
+      sessionIdOrigin: requestedSessionId ? "supplied" : "generated",
+    },
   };
   const transcript = readTranscriptStringParam(params.rawParams, "transcript", {
     required: true,
@@ -133,7 +137,7 @@ async function importTranscripts(params: {
   await params.store.writeSession(session);
   const utterances = await provider.importTranscript({
     cfg: params.ctx.config,
-    session: { ...session, source: providerSource },
+    session: { ...session, source: providerSource, metadata: { ...session.metadata } },
     text: transcript,
     speakerLabel: readTranscriptStringParam(params.rawParams, "speakerLabel", { trim: true }),
   });

--- a/src/meeting-bot/transcripts-bridge.runtime.ts
+++ b/src/meeting-bot/transcripts-bridge.runtime.ts
@@ -61,6 +61,8 @@ function descriptorForSession(
     startedAt: session.createdAt,
     metadata: {
       agentId: session.agentId,
+      // The meeting owner supplies this transcript ID.
+      sessionIdOrigin: "supplied",
       meetingSessionId: session.id,
       mode: session.mode,
       participantIdentity: session.participantIdentity,

--- a/src/meeting-bot/transcripts-bridge.test.ts
+++ b/src/meeting-bot/transcripts-bridge.test.ts
@@ -494,6 +494,7 @@ describe("MeetingDurableTranscriptBridge", () => {
     await expect(store.readSession(current.id)).resolves.toMatchObject({
       metadata: {
         finalCaptureError: "",
+        sessionIdOrigin: "supplied",
         finalCaptureFailedAt: expect.any(String),
       },
       stoppedAt: expect.any(String),

--- a/src/transcripts/auto-start.ts
+++ b/src/transcripts/auto-start.ts
@@ -170,7 +170,12 @@ export function createTranscriptsAutoStartService(
     index: number,
     params: Pick<
       Parameters<typeof startTranscripts>[0],
-      "store" | "rawParams" | "abortSignal" | "existingSession" | "onCaptureEnded"
+      | "store"
+      | "rawParams"
+      | "abortSignal"
+      | "existingSession"
+      | "onCaptureEnded"
+      | "sessionIdOrigin"
     >,
   ) => {
     diagnostics?.record(index, capture.lifecycleToken, "starting");
@@ -243,6 +248,7 @@ export function createTranscriptsAutoStartService(
         }
         await startCapture(capture, index, {
           store,
+          sessionIdOrigin: entry.sessionId ? "supplied" : "generated",
           abortSignal: controller.signal,
           rawParams: { ...entry, title: futureTitle(entry, index) },
         });
@@ -340,6 +346,7 @@ export function createTranscriptsAutoStartService(
             );
           const candidate =
             recent &&
+            recent.metadata?.sessionIdOrigin === "generated" &&
             (!(source.agentId ?? ctx.agentId) ||
               (recent.metadata?.agentId ?? "main") === (source.agentId ?? ctx.agentId)) &&
             !activeSessions.has(recent.sessionId) &&
@@ -355,6 +362,7 @@ export function createTranscriptsAutoStartService(
           capture = owned;
           const result = await startCapture(owned, index, {
             store,
+            sessionIdOrigin: "generated",
             abortSignal: controller.signal,
             existingSession: candidate,
             rawParams: {

--- a/src/transcripts/capture.ts
+++ b/src/transcripts/capture.ts
@@ -495,6 +495,8 @@ export async function startTranscripts(params: {
   configuredLifecycle?: true;
   lifecycleToken?: symbol;
   existingSession?: TranscriptSessionDescriptor;
+  /** Configured capture retains the original choice before supplying its selected ID. */
+  sessionIdOrigin?: "generated" | "supplied";
   onCaptureEnded?: () => void;
 }) {
   if (params.abortSignal?.aborted) {
@@ -545,11 +547,12 @@ export async function startTranscripts(params: {
       source: providerSource,
     });
   }
+  const requestedSessionId = readTranscriptStringParam(params.rawParams, "sessionId", {
+    trim: true,
+  });
   const session: TranscriptSessionDescriptor = {
     sessionId:
-      params.existingSession?.sessionId ??
-      readTranscriptStringParam(params.rawParams, "sessionId", { trim: true }) ??
-      createTranscriptSessionId(),
+      params.existingSession?.sessionId ?? requestedSessionId ?? createTranscriptSessionId(),
     title: params.existingSession
       ? params.existingSession.title
       : readTranscriptStringParam(params.rawParams, "title", { trim: true }),
@@ -557,9 +560,11 @@ export async function startTranscripts(params: {
     startedAt: params.existingSession?.startedAt ?? new Date().toISOString(),
     metadata: params.existingSession
       ? params.existingSession.metadata
-      : agentId
-        ? { agentId }
-        : undefined,
+      : {
+          ...(agentId ? { agentId } : {}),
+          sessionIdOrigin:
+            params.sessionIdOrigin ?? (requestedSessionId ? "supplied" : "generated"),
+        },
   };
   if (activeSessions.has(session.sessionId) || startingSessionIds.has(session.sessionId)) {
     throw new TranscriptStartError(

--- a/src/transcripts/store.test.ts
+++ b/src/transcripts/store.test.ts
@@ -36,6 +36,60 @@ function session(
 }
 
 describe("TranscriptsStore", () => {
+  it.each([undefined, null, "invalid", "generated", "supplied"])(
+    "retains the admitted ID origin %s across updates, reopen, and Doctor restoration",
+    async (origin) => {
+      const { store } = createStore();
+      const target = {
+        ...session(),
+        metadata: {
+          agentId: "original",
+          ...(origin === undefined ? {} : { sessionIdOrigin: origin }),
+        },
+      };
+      await store.writeSession(target);
+      await store.appendUtteranceForSession(target, { text: "Saved history" });
+      closeOpenClawStateDatabaseForTest();
+      for (const metadata of [undefined, { sessionIdOrigin: "generated", agentId: "updated" }]) {
+        await store.writeSession({ ...target, metadata, stoppedAt: "2026-07-01T10:01:00.000Z" });
+        const stored = await store.readSession(target.sessionId);
+        expect(stored?.metadata?.sessionIdOrigin).toEqual(origin);
+        expect(Object.hasOwn(stored?.metadata ?? {}, "sessionIdOrigin")).toBe(origin !== undefined);
+        expect(stored?.metadata?.agentId).toBe(metadata?.agentId);
+        expect(await store.readUtterancesForSession(target)).toMatchObject([
+          { text: "Saved history" },
+        ]);
+      }
+      const canonical = await store.readSession(target.sessionId);
+      const exported = await store.materializeSessionArtifacts(target, "all");
+      const restoredState = tempDirs.make("transcript-origin-restore-");
+      fs.mkdirSync(path.join(restoredState, "transcripts", "2026-07-01"), { recursive: true });
+      fs.cpSync(
+        exported.sessionDir,
+        path.join(restoredState, "transcripts", "2026-07-01", target.sessionId),
+        { recursive: true },
+      );
+      closeOpenClawStateDatabaseForTest();
+      const { detectLegacyMeetingTranscripts, migrateLegacyMeetingTranscripts } =
+        await import("../infra/state-migrations.meeting-transcripts.js");
+      const env = { ...process.env, OPENCLAW_STATE_DIR: restoredState };
+      const migrated = await migrateLegacyMeetingTranscripts({
+        detected: detectLegacyMeetingTranscripts({
+          stateDir: restoredState,
+          doctorOnlyStateMigrations: true,
+        }),
+        stateDir: restoredState,
+        env,
+      });
+      expect(migrated.warnings).toEqual([]);
+      const restored = new TranscriptsStore(path.join(restoredState, "transcripts"), { env });
+      expect(await restored.readSession(target.sessionId)).toEqual(canonical);
+      expect(await restored.readUtterancesForSession(target)).toMatchObject([
+        { text: "Saved history" },
+      ]);
+    },
+  );
+
   it("encodes portable slugs for Windows-reserved and trailing-dot IDs", () => {
     expect(safeTranscriptPathSegment("CON")).toBe("%43%4F%4E");
     expect(safeTranscriptPathSegment("foo.")).toBe("%66%6F%6F%2E");

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -382,6 +382,21 @@ export class TranscriptsStore {
     };
     const now = Date.now();
     this.transaction("meeting-transcripts.session.write", ({ db: database }) => {
+      const previous = executeSqliteQueryTakeFirstSync(
+        database,
+        meetingTranscriptSessionQuery(database, session).selectAll(),
+      );
+      if (previous) {
+        // ID origin belongs to admission, including the absence of that fact in legacy rows.
+        const admittedMetadata = sessionFromRow(previous).metadata;
+        let metadata = session.metadata ? { ...session.metadata } : undefined;
+        if (admittedMetadata && Object.hasOwn(admittedMetadata, "sessionIdOrigin")) {
+          metadata = { ...metadata, sessionIdOrigin: admittedMetadata.sessionIdOrigin };
+        } else if (metadata) {
+          delete metadata.sessionIdOrigin;
+        }
+        sessionValues.metadata_json = metadata ? JSON.stringify(metadata) : null;
+      }
       executeSqliteQuerySync(
         database,
         meetingTranscriptDb(database)


### PR DESCRIPTION
Related: #130860

## What Problem This Solves

Fixes an issue where switching from a supplied transcript ID to occupancy-driven capture could reopen and append to that archived capture. Legacy records do not identify whether their IDs were supplied or generated, so ID spelling and current configuration cannot safely establish reopening eligibility.

## Why This Change Was Made

Native capture and import admission record `sessionIdOrigin` in existing session metadata. Configured capture carries the original ID choice before supplying its selected ID; the meeting bridge records that its transcript ID was supplied by the meeting owner. The store preserves the original value, including missing or invalid legacy values, on later writes to the same identity. Provider results, mutated provider request metadata, and utterance text cannot establish that fact.

Occupancy uses the existing source/window query and newest-row selection. Only an explicitly generated candidate can reopen after the existing ownership checks; a newer ineligible row does not cause a search for an older generated meeting. The [persistence decision is approved in #130860](https://github.com/openclaw/openclaw/pull/130860).

## User Impact

New generated captures still continue within the existing ten-minute window. Supplied IDs and legacy captures with unknown or invalid origin start fresh, leaving prior notes and identities unchanged. Some genuinely generated legacy meetings therefore split after upgrade or restart, as approved. Doctor restoration preserves recorded origins without inferring or backfilling them.

No schema, index, configuration option, protocol/package version, or retention policy changes. Session writes add a bounded primary-key read inside the existing transaction to preserve admission metadata. Older runtimes do not enforce this policy; downgrading also removes the fixed-history protection.

## Evidence

- Five store regressions and four ineligible-reopen regressions failed on the original source for the expected reasons.
- All 103 focused store, occupancy, capture/import lifecycle, and meeting-bridge cases pass, including database reopen, failed-start retries, forged provider metadata, and Doctor export/restoration.
- Core types, the full changed-code gate, and fresh independent P0–P2 review passed.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34072296360) passed on `f69ef976d1b40eabeec85f91e1a35133d89a7734`.

The [isolated live proof](https://github.com/openclaw/openclaw/actions/runs/34072269369) passed across three genuinely separate Gateway processes sharing fresh SQLite state. All capture admission and stopping used configured Gateway startup and `Gateway.close()`, with actual `transcripts.status/get/list` WebSocket readback. Generated history reopened in place; supplied/generated-looking and legacy absent/invalid histories started fresh; a newer supplied row prevented falling back to older generated history. The final ten rows, prior notes, raw IDs, selectors and archive responses matched the expected results. All 59 frozen source hashes were verified, and the owned Testbox is stopped.

The provider's occupancy and text are synthetic. No external channel, model call, operator Gateway, or agent-turn authority is exercised. An earlier harness attempted the unavailable HTTP transcript-tool surface and failed before policy validation; its evidence is retained. The final proof uses the supported Gateway lifecycle and archive RPCs without changing product authorization.
