### PR TITLE
fix(code-mode): release consumed resume payloads

### DIFF
--- a/src/agents/code-mode-worker-lifecycle.test.ts
+++ b/src/agents/code-mode-worker-lifecycle.test.ts
@@ -178,7 +178,7 @@ describe("Code Mode worker lifecycle", () => {
     expect(result).toMatchObject({ status: "failed", error: "Error: prelude failure" });
   });
 
-  it("transfers snapshot heaps across resumes without storage codec copies", async () => {
+  it("transfers snapshot heaps and releases consumed copies across resumes", async () => {
     const tempDirs = useAutoCleanupTempDirTracker(onTestFinished);
     const dir = tempDirs.make("code-mode-snapshot-transfer-");
     const workerPath = path.join(dir, "snapshot-worker.ts");
@@ -189,8 +189,46 @@ describe("Code Mode worker lifecycle", () => {
     await writeFile(
       workerPath,
       `
+      import assert from "node:assert/strict";
+      import { setImmediate } from "node:timers/promises";
+      import { setFlagsFromString } from "node:v8";
+      import { runInNewContext } from "node:vm";
       import { parentPort } from "node:worker_threads";
       const { QuickJS } = await import(${JSON.stringify(quickJsUrl.href)});
+      setFlagsFromString("--expose-gc");
+      const gc = runInNewContext("gc");
+      let consumed;
+      let settlements = [];
+      parentPort.on("message", ({ input }) => {
+        if (input.kind === "resume") {
+          settlements = input.settledRequests.map(({ value }) => new WeakRef(value));
+        }
+      });
+      const restore = QuickJS.restore;
+      QuickJS.restore = async (snapshot, options) => {
+        consumed = {
+          memory: new WeakRef(snapshot.memory.buffer),
+          bytes: snapshot.memory.buffer.byteLength,
+          control: new WeakRef(new ArrayBuffer(1)),
+        };
+        const vm = await restore(snapshot, options);
+        // End the WeakRef creation job before production resumes and releases its input.
+        await setImmediate();
+        return vm;
+      };
+      const executePendingJobs = QuickJS.prototype.executePendingJobs;
+      QuickJS.prototype.executePendingJobs = function (...args) {
+        if (consumed) {
+          gc();
+          assert.equal(consumed.control.deref(), undefined, "unowned buffer must collect");
+          assert.equal(consumed.memory.deref()?.byteLength ?? 0, 0,
+            "resumed VM retained its consumed " + consumed.bytes + " byte snapshot");
+          assert.ok(settlements.every((reference) => reference.deref() === undefined),
+            "resumed VM retained delivered settlement values");
+          consumed = undefined;
+        }
+        return executePendingJobs.apply(this, args);
+      };
       const serialize = QuickJS.serializeSnapshot;
       QuickJS.serializeSnapshot = (snapshot) => {
         if (snapshot.memory.byteLength > 0) throw new Error("snapshot heap serialization copies memory");
@@ -215,16 +253,22 @@ describe("Code Mode worker lifecycle", () => {
         kind: "exec",
         source: `const bytes = new Uint8Array(1024 * 1024);
           bytes[0] = 7;
+          const sibling = new Promise(resolve => setTimeout(() => {
+            bytes[bytes.length - 1] += 2;
+            resolve("sibling");
+          }, 1));
           await yield_control();
-          bytes[bytes.length - 1] = bytes[0] + 2;
+          bytes[bytes.length - 1] = bytes[0];
           await yield_control();
-          return [bytes.length, bytes[0], bytes[bytes.length - 1]];`,
+          const siblingValue = await sibling;
+          return [bytes.length, bytes[0], bytes[bytes.length - 1], siblingValue];`,
         config,
         catalog: [],
       },
       10_000,
       workerUrl,
     );
+    let siblingId: string | undefined;
     for (let leg = 0; leg < 2; leg++) {
       expect(result, result.status === "failed" ? result.error : undefined).toMatchObject({
         status: "waiting",
@@ -233,12 +277,23 @@ describe("Code Mode worker lifecycle", () => {
         throw new Error("expected a suspended guest");
       }
       const memory = result.snapshot.memory.buffer;
+      const siblingRequests = result.pendingRequests.filter(({ method }) => method === "sleep");
+      expect(siblingRequests).toHaveLength(1);
+      if (leg === 0) {
+        siblingId = siblingRequests[0]?.id;
+      } else {
+        expect(siblingRequests[0]?.id).toBe(siblingId);
+      }
+      const pendingRequests = leg === 0 ? siblingRequests : [];
       result = await runCodeModeWorker(
         {
           kind: "resume",
           snapshot: result.snapshot,
           config,
-          settledRequests: result.pendingRequests.map(({ id }) => ({ id, ok: true, value: null })),
+          pendingRequests,
+          settledRequests: result.pendingRequests
+            .filter((request) => !pendingRequests.includes(request))
+            .map(({ id }) => ({ id, ok: true, value: { leg } })),
         },
         10_000,
         workerUrl,
@@ -247,7 +302,7 @@ describe("Code Mode worker lifecycle", () => {
     }
     expect(result).toMatchObject({
       status: "completed",
-      value: { kind: "complete", json: "[1048576,7,9]" },
+      value: { kind: "complete", json: '[1048576,7,9,"sibling"]' },
     });
   });
 

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -294,8 +294,9 @@ function createHostCancelRequestHandler(params: {
 
 async function createVm(input: CodeModeWorkerPayload, bridge: BridgeState): Promise<VmRun> {
   const startedAt = performance.now();
+  const timeoutMs = input.config.timeoutMs;
   let timedOut = false;
-  const deadlineReached = () => performance.now() - startedAt >= input.config.timeoutMs;
+  const deadlineReached = () => performance.now() - startedAt >= timeoutMs;
   const options = {
     wasm: input.wasmModule,
     memoryLimit: input.config.memoryLimitBytes,
@@ -311,6 +312,10 @@ async function createVm(input: CodeModeWorkerPayload, bridge: BridgeState): Prom
       ? await QuickJS.restore(input.snapshot, options)
       : await QuickJS.create(options);
   try {
+    if (input.kind === "resume") {
+      // Restore owns an independent WASM heap; all incoming aliases share this snapshot.
+      input.snapshot.memory = new Uint8Array();
+    }
     const callbacks = [
       ["__openclawHostRequest", createHostRequestHandler({ vm, bridge, config: input.config })],
       ["__openclawHostCancelRequest", createHostCancelRequestHandler({ vm, bridge })],
@@ -595,6 +600,8 @@ async function run(input: CodeModeWorkerPayload): Promise<CodeModeWorkerResult> 
           }
         }
       });
+      // Guest promises now own the replayed JSON values; release every input-frame alias.
+      input.settledRequests.length = 0;
     },
   });
 }


### PR DESCRIPTION
Closes #140564

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Resolves a problem where resumed Code Mode programs retain the consumed incoming snapshot and delivered host-result values alongside the restored guest heap, increasing memory use during the resumed execution.

## Why This Change Was Made

Clear the shared input snapshot's memory after successful QuickJS restore, capture the timeout scalar for the deadline callback, and drain the shared settlement array after successful replay. QuickJS 3.6.0 copies snapshot bytes into its independent WASM heap; the guest owns the parsed replay values. Pending siblings retain their existing owner.

## User Impact

Resumed Code Mode execution can reclaim consumed input payloads while the guest keeps running. The real-worker probe released one 5,636,096-byte backing allocation on each measured resume, with identical guest results and sibling behavior. Parent frontier retention is unchanged.

## Evidence

- The pinned dependency was personally inspected after a normal frozen-lockfile install: `quickjs-wasi@3.6.0/dist/index.js`, SHA-256 `91fcfc11e7f7372f3aee8d4373c0d4f969baac5cd12648663971550054217ae8`. `QuickJS.restore` (lines 316–352) creates a fresh VM and copies into its exported WASM memory with `dst.set(snapshot.memory)`; `snapshot` (lines 1769–1772) creates an independent slice. This resolves the automated reviewer's stated inability to inspect the exact pinned package.
- The real-worker retention regression failed on the original worker for the intended retained-backing-buffer reason and passed after the repair. It uses an event-loop turn and an independently collectible control buffer before checking collection.
- 139 focused tests passed across nine files, covering worker lifecycle, waits, cancellation, limits, rejections, guest execution and TypeScript. The extended two-resume test preserves guest bytes, the existing transfer/codec protections, and pending sibling identity and settlement.
- The complete changed-file check and full build passed. Independent isolated P2 autoreview found no actionable findings; the final file hashes match the reviewed candidate.
- A separate real-worker probe with a 4 MiB guest array observed consumed snapshot retention fall from 5,636,096 bytes to zero on each of two serial resumed legs, and delivered settlement retention fall from 1/2 values to zero. Guest output remained `[4194304,7,9,"sibling"]`.

The resumed legs run serially, so their saved sizes are not summed into a peak-memory figure. GC instrumentation and allocator timing make the single-run RSS and duration observations unsuitable as general Gateway memory or latency claims. Related #137168 addressed dispatch/pool ownership; this repair owns successful worker restore and replay.
