### PR TITLE
fix(anthropic): preserve resumed CLI caches across Git changes

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -143,6 +143,13 @@ claude update
 
 The bundled `claude-cli` backend prefers Claude Code's native skill resolver. When the current skills snapshot has at least one selected skill with a materialized path, OpenClaw passes a temporary Claude Code plugin via `--plugin-dir` and omits the duplicate OpenClaw skills catalog from the appended system prompt. Without a materialized plugin skill, OpenClaw keeps the prompt catalog as a fallback. Skill env/API key overrides still apply to the child process environment for the run.
 
+OpenClaw disables Claude Code's built-in Git workflow instructions and startup
+Git-status snapshot with `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1`. Claude Code
+rebuilds that snapshot when a process resumes, so workspace edits or commits
+would otherwise invalidate cached conversation history. Git tools and workspace
+instructions remain available. This does not prevent cache misses after prompt
+changes, compaction, model or thinking changes, or cache expiry.
+
 OpenClaw always launches Claude Code with its default permission mode.
 OpenClaw's permission responses and `PreToolUse` hook keep native tools under
 host control, including when user or enterprise settings would otherwise

--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -272,23 +272,25 @@ export function buildAnthropicCliBackend(
               }
             : undefined;
         const env = {
+          // Claude rebuilds the startup Git snapshot on process resume, rewriting
+          // the conversation prefix after workspace edits or commits. OpenClaw
+          // supplies workspace instructions; Git state can be read with tools.
+          CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS: "1",
           ...resolveClaudeCliAutoCompactEnv(context.contextTokenBudget),
           ...(context.contextWindow === "200k" ? { CLAUDE_CODE_DISABLE_1M_CONTEXT: "1" } : {}),
           ...resolveClaudeCliThinkingEnv(context.thinkingLevel, context.modelId),
           ...authInput?.env,
         };
-        return Object.keys(env).length > 0 || isolatedCompletion || cliExecution
-          ? {
-              env,
-              // The paired side-question argv projection disables settings, memory,
-              // hooks, session persistence, and tools before process launch.
-              ...(isolatedCompletion ? { isolatedCompletionEnforced: true as const } : {}),
-              ...(authInput?.clearEnv ? { clearEnv: authInput.clearEnv } : {}),
-              ...(authInput?.secretInput ? { secretInput: authInput.secretInput } : {}),
-              ...(authInput?.cleanup ? { cleanup: authInput.cleanup } : {}),
-              ...cliExecution,
-            }
-          : undefined;
+        return {
+          env,
+          // The paired side-question argv projection disables settings, memory,
+          // hooks, session persistence, and tools before process launch.
+          ...(isolatedCompletion ? { isolatedCompletionEnforced: true as const } : {}),
+          ...(authInput?.clearEnv ? { clearEnv: authInput.clearEnv } : {}),
+          ...(authInput?.secretInput ? { secretInput: authInput.secretInput } : {}),
+          ...(authInput?.cleanup ? { cleanup: authInput.cleanup } : {}),
+          ...cliExecution,
+        };
       };
       const supportProbe = options.ensureDynamicSystemPromptSectionsSupport?.();
       return supportProbe ? supportProbe.then(prepare) : prepare();

--- a/extensions/anthropic/cli-context-window.test.ts
+++ b/extensions/anthropic/cli-context-window.test.ts
@@ -25,6 +25,7 @@ describe("Claude CLI context-window selection", () => {
         env: {
           CLAUDE_CODE_AUTO_COMPACT_WINDOW: "200000",
           CLAUDE_CODE_DISABLE_1M_CONTEXT: "1",
+          CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS: "1",
         },
       });
       expect(resolveModelId?.({ modelId, contextWindow: "1m" })).toBe(`${modelId}[1m]`);
@@ -36,7 +37,12 @@ describe("Claude CLI context-window selection", () => {
           contextWindow: "1m",
           contextTokenBudget: 1_000_000,
         }),
-      ).toEqual({ env: { CLAUDE_CODE_AUTO_COMPACT_WINDOW: "1000000" } });
+      ).toEqual({
+        env: {
+          CLAUDE_CODE_AUTO_COMPACT_WINDOW: "1000000",
+          CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS: "1",
+        },
+      });
       expect(backend.config.clearEnv).toContain("CLAUDE_CODE_DISABLE_1M_CONTEXT");
       expect(resolveModelId?.({ modelId: "claude-opus-4-8" })).toBe("claude-opus-4-8");
     },

--- a/extensions/anthropic/cli-shared.execution-env.test.ts
+++ b/extensions/anthropic/cli-shared.execution-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveClaudeCliThinkingEnv } from "./cli-shared.js";
+import { resolveClaudeCliAutoCompactEnv, resolveClaudeCliThinkingEnv } from "./cli-shared.js";
 
 describe("Claude CLI execution environment", () => {
   it.each([
@@ -16,4 +16,16 @@ describe("Claude CLI execution environment", () => {
       expect(resolveClaudeCliThinkingEnv(level, "claude-fable-5")).toBeUndefined();
     },
   );
+});
+
+describe("resolveClaudeCliAutoCompactEnv", () => {
+  it("maps the effective OpenClaw context budget into Claude Code compaction", () => {
+    expect(resolveClaudeCliAutoCompactEnv(100_000.9)).toEqual({
+      CLAUDE_CODE_AUTO_COMPACT_WINDOW: "100000",
+    });
+  });
+
+  it.each([undefined, 0, 0.5, Number.NaN])("rejects an invalid context budget: %s", (budget) => {
+    expect(resolveClaudeCliAutoCompactEnv(budget)).toBeUndefined();
+  });
 });

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -5,7 +5,6 @@ import { buildAnthropicCliBackend } from "./cli-backend.js";
 import {
   CLAUDE_CLI_CLEAR_ENV,
   normalizeClaudeBackendConfig,
-  resolveClaudeCliAutoCompactEnv,
   resolveClaudeCliExecutionArgs,
   supportsClaudeDynamicSystemPromptSections,
 } from "./cli-shared.js";
@@ -70,7 +69,10 @@ describe("Claude CLI adapter equivalence", () => {
       isolatedCompletionSystemPrompt: string;
     }) as { env?: Record<string, string>; isolatedCompletionEnforced?: true };
 
-    expect(prepared).toEqual({ env: {}, isolatedCompletionEnforced: true });
+    expect(prepared).toEqual({
+      env: { CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS: "1" },
+      isolatedCompletionEnforced: true,
+    });
   });
 
   it("builds Claude Code's native manual compaction command", () => {
@@ -107,18 +109,6 @@ describe("Claude CLI adapter equivalence", () => {
       ok: false,
       reason: "Claude CLI did not confirm that native compaction ran.",
     });
-  });
-});
-
-describe("resolveClaudeCliAutoCompactEnv", () => {
-  it("maps the effective OpenClaw context budget into Claude Code compaction", () => {
-    expect(resolveClaudeCliAutoCompactEnv(100_000.9)).toEqual({
-      CLAUDE_CODE_AUTO_COMPACT_WINDOW: "100000",
-    });
-  });
-
-  it.each([undefined, 0, 0.5, Number.NaN])("rejects an invalid context budget: %s", (budget) => {
-    expect(resolveClaudeCliAutoCompactEnv(budget)).toBeUndefined();
   });
 });
 
@@ -918,7 +908,10 @@ describe("normalizeClaudeBackendConfig", () => {
         contextTokenBudget: 100_000,
       }),
     ).toEqual({
-      env: { CLAUDE_CODE_AUTO_COMPACT_WINDOW: "100000" },
+      env: {
+        CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS: "1",
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "100000",
+      },
     });
   });
 
@@ -948,6 +941,7 @@ describe("normalizeClaudeBackendConfig", () => {
     }) as ClaudePreparedExecutionWithSecret;
 
     expect(prepared.env).toEqual({
+      CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS: "1",
       CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR: "3",
     });
     expect(prepared.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
@@ -1058,6 +1052,7 @@ describe("normalizeClaudeBackendConfig", () => {
     }) as ClaudePreparedExecutionWithSecret;
 
     expect(prepared.env).toEqual({
+      CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS: "1",
       CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR: "3",
     });
     expect(prepared.env).not.toHaveProperty("ANTHROPIC_API_KEY");

--- a/src/node-host/invoke-agent-cli-claude.test.ts
+++ b/src/node-host/invoke-agent-cli-claude.test.ts
@@ -299,6 +299,7 @@ process.stdout.write(JSON.stringify({
   descriptor: descriptor ?? null,
   rawPresent: Object.hasOwn(process.env, "CLAUDE_CODE_OAUTH_TOKEN") || Object.hasOwn(process.env, "ANTHROPIC_API_KEY"),
   scrubPresent: Object.hasOwn(process.env, "CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"),
+  gitInstructionsDisabled: process.env.CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS,
 }) + "\\n");`);
       const calls: Array<{ method: string; params: unknown }> = [];
       const handleSystemRun = vi.fn(
@@ -356,6 +357,7 @@ process.stdout.write(JSON.stringify({
       });
       expect(progress).toContain('"rawPresent":false');
       expect(progress).toContain('"scrubPresent":false');
+      expect(progress).toContain('"gitInstructionsDisabled":"1"');
       expect(calls).toContainEqual({
         method: "node.invoke.result",
         params: expect.objectContaining({
@@ -520,6 +522,7 @@ process.stdout.write(JSON.stringify({
   descriptor: process.env[${JSON.stringify(descriptorEnv)}],
   rawPresent: Object.hasOwn(process.env, ${JSON.stringify(rawEnv)}),
   scrubPresent: Object.hasOwn(process.env, "CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"),
+  gitInstructionsDisabled: process.env.CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS,
 }) + "\\n");`);
       const request = { argv: ["-p"], idleTimeoutMs: 1_000, timeoutMs: 5_000 };
       const calls: Array<{ method: string; params: unknown }> = [];
@@ -543,6 +546,7 @@ process.stdout.write(JSON.stringify({
       expect(progress).toContain('"descriptor":"3"');
       expect(progress).toContain('"rawPresent":false');
       expect(progress).toContain('"scrubPresent":false');
+      expect(progress).toContain('"gitInstructionsDisabled":"1"');
       expect(result).toMatchObject({ exitCode: 0, success: true });
     },
   );

--- a/src/node-host/invoke-agent-cli-claude.ts
+++ b/src/node-host/invoke-agent-cli-claude.ts
@@ -151,7 +151,8 @@ export async function runClaudeCliNodeCommand(params: {
         mode: "child",
         argv,
         cwd: params.cwd,
-        env: params.env,
+        // Apply the cache-stable Git policy locally without extending the node wire contract.
+        env: { ...(params.env ?? process.env), CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS: "1" },
         exactEnv: true,
         input:
           skillSession?.rewriteReferences(params.request.stdin ?? "") ?? params.request.stdin ?? "",


### PR DESCRIPTION
## Summary

### High Level TLDR

Fixes avoidable prompt-cache misses when an OpenClaw-managed Claude CLI session resumes after files or commits change in its Git workspace. Disable Claude Code's startup Git snapshot for these runs, including native execution on paired nodes.

## What Problem This Solves

Users returning to an active conversation can pay to cache the same history again even within the cache TTL. Long conversations amplify that cost. A normal repository edit or background commit is sufficient to trigger it when the native process resumes.

## Why This Change Was Made

### Root Cause

Claude Code 2.1.263 rebuilds its Git-status context at process startup, including on `--resume`. Captured native requests show the changed snapshot inserted near the beginning of the first user message. OpenClaw's `excludeDynamicSections` initialization option keeps the static system prefix reusable, but does not freeze this conversation context.

An isolated reproduction kept the system prompt and tool definitions identical, changed only synthetic workspace files between process resumes, and observed the first historical user message change. This reproduces independently of OpenClaw transcript storage or overlays. Full OpenClaw local runs reproduced the resulting partial cache hits with real Haiku requests.

The Anthropic backend now prepares `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS=1`. The node-local Claude process launcher applies the same policy without adding fields or environment keys to the node wire contract. The setting's documented scope includes both the Git snapshot and Claude Code's bundled commit/PR instructions: [Claude Code environment variables](https://code.claude.com/docs/en/env-vars).

## User Impact

Repository activity no longer forces this conversation-prefix rewrite on resumed Claude CLI runs. Git tools, workspace instructions, credentials, and tool approvals remain available. The first request after adopting the changed prompt policy can rebuild the cache once. Expiry, compaction, prompt edits, and model/thinking changes can still invalidate cache entries.

## Verification

### Real behavior proof

Linux, Claude Code 2.1.263, `claude-cli/claude-haiku-4-5`, thinking off, no fallback. Each run used a disposable HOME, OpenClaw state/config, and synthetic Git workspace. A bounded localhost proxy forwarded only Haiku inference requests and recorded request bodies plus native usage; credentials were kept out of captures.

For both baseline and the proposed environment policy: send one synthetic reference message, then resume twice in separate OpenClaw processes with `agent --local --agent main --session-id <same-id> --model claude-cli/claude-haiku-4-5 --thinking off --message 'Reply exactly OK.' --timeout 45 --json`. Create another untracked synthetic file before each resume. Repeat with a fresh session and the environment policy enabled.

| Resume | Cache read | Cache write | Input reuse |
| --- | ---: | ---: | ---: |
| Baseline 1 | 34,898 | 11,721 | 74.85% |
| Baseline 2 | 34,898 | 11,785 | 74.75% |
| Policy enabled 1 | 44,845 | 56 | 99.87% |
| Policy enabled 2 | 44,901 | 56 | 99.87% |

Each request also had three uncached input tokens. Within each session, system and tools were unchanged. Baseline resumes rewrote historical context; policy-enabled resumes preserved all prior message content, excluding moving cache markers.

The two resumed calls took 5.94/3.68 seconds before and 3.42/3.39 seconds with the policy. This small sample demonstrates cache-write savings, not a statistically established latency improvement.

After `pnpm build`, the same fixture ran through the candidate's `./openclaw.mjs` without manually setting the Git environment policy. The two resumes read/wrote **44,862/56** and **44,918/56** (both **99.87%**). Request comparison verified unchanged system/tools and all prior message content. The bounded probe finished with:

```text
RESUME_REUSE 99.869
RESUME_REUSE 99.869
BUILT_CANDIDATE_CACHE_PROOF_PASS
```

A further MCP-enabled probe used the same built candidate with 39 OpenClaw MCP tools and native tool search enabled. Three separate process launches with intervening synthetic Git changes preserved the entire prior request prefix. Real Haiku resumes read/wrote **55,676/56** and **55,732/56**, each with three uncached input tokens (**99.89%** reuse). The probe ended with `BUILT_CANDIDATE_MCP_CACHE_PROOF_PASS`. A matching mock-provider run also verified unchanged semantic request parameters.

### Automated checks

- GitHub CI on `480d50f93ce`: all 135 executed checks passed (43 skipped).
- Focused provider, CLI spawn, and node invocation tests: 152 passed. After correcting the context-window expectations found by CI, all 465 Anthropic provider tests and the changed-file gate passed.
- Regression assertions failed before the repair: the provider omitted the environment setting and node child processes lacked it. The final checks also exercise credential descriptor preservation and existing node request decoding.
- `pnpm build`: passed. Core and extension production/test typechecks passed. The aggregate changed checker stopped at the test-file line limit; related environment tests were moved into their existing file, and affected checks plus the remaining guards were rerun separately.

### What was not tested

No production Gateway or Telegram session was changed or restarted. No Opus inference was used. Live provider proof covered both the proposed policy through the installed route and the built candidate; the production deployment does not contain this patch. Paired-node subprocess behavior is covered locally; a remote node fleet and other operating systems were not exercised. No separate independent reviewer was invoked locally.
