### PR TITLE
fix(gateway): preserve child turns during systemd drain

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -600,8 +600,10 @@ restore fail closed so restore cannot silently replace or hide recoverable data.
 After verifying the migration and current history, use
 `openclaw update cleanup --dry-run` to inspect retained recovery data without
 stopping the Gateway. Apply with `openclaw update cleanup` or
-`openclaw update cleanup --yes --json` only after stopping the Gateway and other
-SQLite maintenance for the same profile/state directory. This permanently
+`openclaw update cleanup --yes --json` only after stopping the Gateway, other
+SQLite maintenance, and database readers for the same profile/state directory.
+Keep session-listing watchers stopped until cleanup exits: even read-only
+connections can change WAL/SHM sidecars and invalidate verification. This permanently
 retires eligible rollback originals; it does not remove current SQLite history
 or operator backups. Manifests remain while retained or pending artifacts need
 them, so interrupted cleanup can be resumed. Restore distinguishes intentional

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -338,8 +338,14 @@ listed separately as requiring verification. Protected and blocked artifacts
 include reason codes.
 
 Before applying, stop the Gateway for that same profile/state directory and wait
-for other SQLite maintenance commands to finish. Cleanup requires exclusive
-offline state ownership and never stops or restarts a service itself.
+for other SQLite maintenance commands to finish. Stop database readers too,
+including watchers that repeatedly run `openclaw sessions --all-agents --json`,
+and keep them stopped until cleanup exits. Read-only SQLite connections can
+create or change WAL/SHM sidecars, invalidating cleanup's destination check even
+when session content is unchanged. If cleanup reports `Recovery destination
+database changed; preview cleanup again.`, stop those readers, preview again,
+and retry. Cleanup requires exclusive offline state ownership and never stops
+or restarts a service itself.
 
 <Warning>
 Cleanup permanently removes the selected rollback originals, including branches

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -261,7 +261,7 @@ TimeoutStopSec=330
 TimeoutStartSec=30
 SuccessExitStatus=0 143
 OOMPolicy=continue
-KillMode=control-group
+KillMode=mixed
 
 [Install]
 WantedBy=default.target

--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -105,6 +105,16 @@ gateway stops accepting new work, then waits for active agent turns and
 background tasks to finish, up to a drain budget (5 minutes by default). Most
 restarts therefore interrupt nothing at all.
 
+On Linux, the systemd unit must use `KillMode=mixed` so the initial stop signal
+reaches only the Gateway. Systemd still kills remaining child processes when the
+Gateway exits or its stop deadline expires. Older `KillMode=control-group` units
+signal child runtimes immediately, which can interrupt a turn before drain finishes.
+After upgrading, run `openclaw gateway install --force` for the same profile to
+rewrite and restart the managed unit. Ordinary updates leave existing Linux
+service definitions unchanged. Doctor reports incompatible effective settings;
+operator-owned drop-ins must be inspected and updated separately because reinstalling
+the base unit preserves them. See [Linux services](/platforms/linux).
+
 Replies to pending node commands remain accepted during the drain, including
 worker cleanup started by shutdown. Each reply must still match its live
 invocation, node connection, pairing generation, and owning lifecycle. This

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -153,7 +153,9 @@ openclaw update cleanup --dry-run
 Use the same profile and state/config overrides as the update, and check the
 state directory printed in the report. The metadata-only preview can run while
 the Gateway is active. To apply, stop that Gateway yourself, wait for other
-SQLite maintenance to finish, then run `openclaw update cleanup`. Cleanup never
+SQLite maintenance to finish, and stop database readers such as session-listing
+watchers. Keep them stopped until `openclaw update cleanup` exits; read-only
+connections can change WAL/SHM sidecars and invalidate verification. Cleanup never
 stops or restarts the Gateway. Confirmation defaults to **No**; automation must
 explicitly pass `--yes`, including when using `--json`.
 

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -333,7 +333,7 @@ TimeoutStopSec=330
 TimeoutStartSec=30
 SuccessExitStatus=0 143
 OOMPolicy=continue
-KillMode=control-group
+KillMode=mixed
 
 [Install]
 WantedBy=default.target

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -604,6 +604,20 @@ describe("auditGatewayServiceConfig", () => {
 
   it.each([
     {
+      name: "detects a control-group drop-in over a mixed base unit",
+      unit: ["KillMode=mixed"],
+      manager: ["KillMode=control-group"],
+      code: SERVICE_AUDIT_CODES.systemdKillModeControlGroup,
+      expected: true,
+    },
+    {
+      name: "accepts effective mixed mode over an older base unit",
+      unit: ["KillMode=control-group"],
+      manager: ["KillMode=mixed"],
+      code: SERVICE_AUDIT_CODES.systemdKillModeControlGroup,
+      expected: false,
+    },
+    {
       name: "uses manager KillMode instead of the base unit",
       unit: [
         "After=network-online.target",
@@ -699,7 +713,7 @@ describe("auditGatewayServiceConfig", () => {
     }
   });
 
-  it.each(["process", "none"])(
+  it.each(["process", "none", "control-group", ""])(
     `warns when KillMode is %s in explicit unit file`,
     async (killMode) => {
       const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-killmode-"));
@@ -720,7 +734,11 @@ describe("auditGatewayServiceConfig", () => {
               environment: { PATH: "/usr/bin:/bin" },
             },
           });
-          expect(hasIssue(audit, SERVICE_AUDIT_CODES.systemdKillModeProcessOrNone)).toBe(true);
+          const code =
+            killMode === "process" || killMode === "none"
+              ? SERVICE_AUDIT_CODES.systemdKillModeProcessOrNone
+              : SERVICE_AUDIT_CODES.systemdKillModeControlGroup;
+          expect(hasIssue(audit, code)).toBe(true);
           expect(execSystemctlUser).toHaveBeenCalledWith({ HOME: home }, expect.any(Array), 10_000);
         }
       } finally {
@@ -738,7 +756,7 @@ describe("auditGatewayServiceConfig", () => {
           `After=basic.target ${continuation}network-online.target`,
           `Wants=basic.target ${continuation}network-online.target`,
           `RestartSec=${continuation}5s`,
-          `KillMode=${continuation}control-group`,
+          `KillMode=${continuation}mixed`,
         ]);
         const audit = await auditGatewayServiceConfig({
           env: { HOME: home },

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -75,6 +75,7 @@ export const SERVICE_AUDIT_CODES = {
   systemdRestartSec: "systemd-restart-sec",
   systemdWantsNetworkOnline: "systemd-wants-network-online",
   systemdKillModeProcessOrNone: "systemd-kill-mode-process-or-none",
+  systemdKillModeControlGroup: "systemd-kill-mode-control-group",
   systemdUnitBackupUnsafe: "systemd-unit-backup-unsafe",
 } as const;
 
@@ -141,16 +142,11 @@ function parseSystemdUnit(content: string): {
     if (!value) {
       continue;
     }
-    if (key === "After") {
+    if (key === "After" || key === "Wants") {
+      const dependencies = key === "After" ? after : wants;
       for (const entry of value.split(/\s+/)) {
         if (entry) {
-          after.add(entry);
-        }
-      }
-    } else if (key === "Wants") {
-      for (const entry of value.split(/\s+/)) {
-        if (entry) {
-          wants.add(entry);
+          dependencies.add(entry);
         }
       }
     } else if (key === "RestartSec") {
@@ -245,12 +241,15 @@ async function auditSystemdUnit(
       level: "recommended",
     });
   }
-  const killMode = normalizeLowercaseStringOrEmpty(parsed.killMode);
-  if (killMode === "process" || killMode === "none") {
+  const killMode = normalizeLowercaseStringOrEmpty(parsed.killMode) || "control-group";
+  if (killMode !== "mixed") {
     issues.push({
-      code: SERVICE_AUDIT_CODES.systemdKillModeProcessOrNone,
+      code:
+        killMode === "process" || killMode === "none"
+          ? SERVICE_AUDIT_CODES.systemdKillModeProcessOrNone
+          : SERVICE_AUDIT_CODES.systemdKillModeControlGroup,
       message:
-        "KillMode is process/none; service child processes can survive gateway stops and restarts.",
+        "KillMode=mixed is required to drain active turns before final service child cleanup; inspect unit and drop-in overrides.",
       detail: `${unitPath}: ${killMode}`,
       level: "recommended",
     });

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -107,13 +107,13 @@ describe("buildSystemdUnit", () => {
     expect(execStart).toBe('ExecStart=/usr/bin/openclaw gateway --name "My Bot"');
   });
 
-  it("renders control-group kill mode for child-process cleanup", () => {
+  it("drains through the main process while retaining final child-process cleanup", () => {
     const unit = buildSystemdUnit({
       description: "OpenClaw Gateway",
       programArguments: ["/usr/bin/openclaw", "gateway", "run"],
       environment: {},
     });
-    expect(unit).toContain("KillMode=control-group");
+    expect(unit).toContain("KillMode=mixed");
     expect(unit).toContain("TimeoutStopSec=330");
     expect(unit).toContain("TimeoutStartSec=30");
     expect(unit).toContain("SuccessExitStatus=0 143");

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -82,9 +82,7 @@ export function buildSystemdUnit({
     "Restart=always",
     "RestartSec=5",
     "RestartPreventExitStatus=78",
-    // Must cover the gateway's SIGTERM drain budget (five minutes) plus its
-    // teardown reserve. Otherwise systemd kills the embedded model/tool
-    // process before the gateway can finish the cooperative drain.
+    // Cover the gateway's five-minute SIGTERM drain plus its teardown reserve.
     "TimeoutStopSec=330",
     "TimeoutStartSec=30",
     "SuccessExitStatus=0 143",
@@ -92,9 +90,9 @@ export function buildSystemdUnit({
     // gateway. Keep the service running when that happens; the child surface is
     // already responsible for reporting the failed command/session.
     "OOMPolicy=continue",
-    // Keep service children in the same lifecycle so restarts do not leave
-    // orphan ACP/runtime workers behind.
-    "KillMode=control-group",
+    // Signal only the gateway during drain; systemd still kills remaining
+    // children when the gateway exits or TimeoutStopSec expires.
+    "KillMode=mixed",
     workingDirLine,
     ...environmentFileLines,
     ...envLines,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Linux managed Gateway restart interrupted an active child runtime before its advertised drain window finished (#140479, reported by @DonnieFi). Also documents the missing offline-reader prerequisite for recovery cleanup (#140467, reported by @agentzerodao); that reporter confirms main-session recovery succeeded after upgrading to 2026.9.2.

Related: #140479, #140467.

## Why This Change Was Made

The generated systemd unit gave the Gateway 330 seconds to stop, but `KillMode=control-group` immediately sent SIGTERM to its children as well. `src/daemon/systemd-unit.ts` now uses `mixed`: the Gateway owns cooperative drain, and systemd retains final cgroup cleanup after parent exit or timeout. `src/daemon/service-audit.ts` checks the effective manager setting, including drop-ins, and flags older or omitted modes. Existing process/none diagnostic codes remain intact; duplicate dependency parsing is consolidated.

Increasing the timeout cannot postpone that initial child signal. Process/none would abandon final descendant cleanup. Adding a separate Gateway-first stop protocol would duplicate lifecycle orchestration. The repair uses the supervisor's existing main-process-first contract instead.

Cleanup documentation explicitly requires session watchers and other database readers to stay stopped until cleanup exits, explains WAL/SHM changes, and gives the retry action. Unlike #140505, this does not relax destination verification or change persistence semantics. The issue's accepted documentation alternative preserves the existing deletion safeguards.

## User Impact

New or explicitly reinstalled Linux units let child turns complete during Gateway drain. Existing installations need `openclaw gateway install --force` for their selected profile; ordinary update-mode Doctor preserves existing Linux service definitions. Operator-owned drop-ins remain separately editable and are checked through their effective setting. Cleanup users can identify and stop readers that invalidate offline verification.

## Evidence

Reviewed head: `b1d9cde423b9dd70292fdb189f257624b6c7e740`.

- Pre-fix regressions: generated-unit test rejected control-group; audit tests failed to flag an effective control-group drop-in, explicit control-group, and omitted KillMode. They pass after repair.
- Focused daemon, Gateway run-loop, and real-process SIGTERM suite: **396 passed**. Final audit-only rerun: **62 passed**.
- Main-session recovery state/store/marking and selected startup/repeated-restart harnesses: **70 passed**. The original 9.1 operator abort interleaving was not reproduced or attributed to one historical commit; no recovery/admission guard was changed.
- Existing cleanup destination mutation and successful retirement tests: **10 passed**. In-place edits, truncation, and WAL commits retain originals across confirmation/publication/unlink phases.
- `pnpm check:changed` passed all gates, including core/core-test typechecks, three dead-export scans, lint and repository guards; `git diff --check` passed.
- Independent Codex review: no actionable P0–P2 findings on the final diff. An initial check caught string widening in a test table; using the exported audit constants corrected that type error.
- [Native systemd 255 Testbox proof](https://github.com/openclaw/openclaw/actions/runs/34071913812): **6/6 passed** with detached synthetic stdio children. Control-group interrupts active work; mixed permits completion during stop and actual restart, with a fresh successor MainPID. Timeout, parent crash, and ordinary stop still remove descendants. Zero test units/processes remain; lease `tbx_01m1wpdp5yxrtq5zqf7gjp1sja` stopped, wrapper exit 0. The synthetic timeout was shortened to two seconds; production remains 330 seconds. External Testbox cleanup may mark its backing Actions run cancelled; the wrapper records successful proof independently.

The sibling Codex source was personally inspected at dependency revision `64b482500d00b331189beefd173a5e08b4060ff2`: `codex-rs/app-server/src/lib.rs:742-744` disables graceful signal restart for stdio; `:1040-1063` exits on stdio closure; `:1203-1212` shuts down threads. `codex-rs/app-server-transport/src/transport/stdio.rs:44-78` translates stdin EOF to connection closure. Native systemd proof uses synthetic piped child work, not an authenticated provider or a reproduction of the reporter's exact clean-exit code.

Production: **+15/-18 (net -3)**. Tests: **+23/-5 (net +18)**. Docs: **+27/-7 (net +20)**. No new configuration, schema, persistence semantics, protocol, dependency, public SDK boundary, or changelog changes.

```sh
node scripts/run-vitest.mjs src/daemon/systemd-unit.test.ts src/daemon/service-audit.test.ts src/daemon/systemd.test.ts src/cli/gateway-cli/run-loop.test.ts src/cli/gateway-cli/run-loop.direct-stop-active-work.process.test.ts
node scripts/run-vitest.mjs src/daemon/service-audit.test.ts
node scripts/run-vitest.mjs src/agents/main-session-recovery/main-session-recovery-state.test.ts src/agents/main-session-recovery/main-session-recovery-store.test.ts src/agents/main-session-recovery/main-session-restart-recovery-marking.test.ts
node scripts/run-vitest.mjs src/agents/main-session-recovery/main-session-restart-recovery.test.ts -t 'marks startup-orphaned running main sessions before recovery|aborts an exact recovery accepted after the execution-start deadline|keeps restart safety across a second restart of the recovery turn|resumes an abort artifact persisted with the gateway restart reason'
node scripts/run-vitest.mjs src/agents/main-session-recovery/main-session-restart-recovery.test.ts -t 'restores an accepted recovery that fails before execution starts' --reporter=dot
node scripts/run-vitest.mjs src/commands/doctor-session-sqlite.test.ts -t 'retains originals after destination|retires.*original'
pnpm check:changed
git diff --check
```

CI: [exact-head run 34072463845](https://github.com/openclaw/openclaw/actions/runs/34072463845) completed successfully on `b1d9cde423b9dd70292fdb189f257624b6c7e740`, with no failed jobs. No contributor PR code was used; thanks to both issue reporters for the operational evidence.


### Review follow-through

ClawSweeper found no actionable source or security defect. Its remaining risk concerns independent access to the native evidence and the exact reported clean-exit signature. The mitigation is the implemented ownership boundary: Gateway drain, systemd final cleanup, effective-mode diagnostics, and explicit reinstall/drop-in guidance. The exact native Codex exit signature remains an explicit proof gap; an authenticated-provider replay is deferred because this patch changes the supervisor signal target and neither the provider nor stdio implementation. Detached-process kernel proof plus the existing Gateway process/recovery harnesses establishes the repaired boundary.

For direct inspection, the public dependency revision is available at [Codex stdio signal handling](https://github.com/openai/codex/blob/64b482500d00b331189beefd173a5e08b4060ff2/codex-rs/app-server/src/lib.rs#L742) and [stdin closure](https://github.com/openai/codex/blob/64b482500d00b331189beefd173a5e08b4060ff2/codex-rs/app-server-transport/src/transport/stdio.rs#L44). Availability was verified through the upstream commit API.

Sanitized observations from the completed native systemd 255 run:

| Policy and action | Observed result |
| --- | --- |
| control-group stop during work | Detached child received SIGTERM before completion; return 143; parent saw closed pipe. |
| mixed stop during work | Parent received SIGTERM; child completed afterward with return 0 and no child SIGTERM. |
| mixed actual restart | Original child completed and parent exited before a new MainPID started. |
| mixed stop timeout | Uncooperative parent and child both removed after the shortened two-second fixture deadline (2.212 s). |
| mixed parent crash | Parent and lingering detached child both removed (0.007 s). |
| mixed ordinary stop | Parent exited and lingering detached child was removed (0.022 s). |

The fixture asserted distinct parent/child session IDs and process groups. Final cleanup reported zero owned transient units and zero running observed process IDs, including the restart successor. The Testbox wrapper reported `exitCode=0`, `runStatus=succeeded`, then stopped its lease. Its later external-portal synchronization warning did not change the proof result. These observations are synthetic process evidence; no claim about the reporter's exact exit code is added.
