### PR TITLE
refactor(gateway): share placement move matching

### DIFF
--- a/src/gateway/worker-environments/placement-move-intent.ts
+++ b/src/gateway/worker-environments/placement-move-intent.ts
@@ -280,27 +280,25 @@ function requireExactMove(
   return fromRow(row);
 }
 
-function deleteExactMove(db: DatabaseSync, intent: WorkerPlacementMoveIntent): void {
+function exactMoveValues(intent: WorkerPlacementMoveIntent) {
   const values = targetValues(intent.target);
-  let statement = moveQuery(db)
+  return {
+    operation_id: intent.operationId,
+    session_id: intent.sessionId,
+    source_generation: intent.source.generation,
+    source_environment_id: intent.source.environmentId,
+    source_owner_epoch: intent.source.ownerEpoch,
+    target_kind: values.target_kind,
+    abandon_source: abandonSourceValue(intent.abandonSource),
+    target_id: values.target_id,
+    target_machine_class: values.target_machine_class,
+  };
+}
+
+function deleteExactMove(db: DatabaseSync, intent: WorkerPlacementMoveIntent): void {
+  const statement = moveQuery(db)
     .deleteFrom("worker_session_placement_moves")
-    .where("operation_id", "=", intent.operationId)
-    .where("session_id", "=", intent.sessionId)
-    .where("source_generation", "=", intent.source.generation)
-    .where("source_environment_id", "=", intent.source.environmentId)
-    .where("source_owner_epoch", "=", intent.source.ownerEpoch)
-    .where("target_kind", "=", values.target_kind);
-  statement = intent.abandonSource
-    ? statement.where("abandon_source", "=", 1)
-    : statement.where("abandon_source", "is", null);
-  statement =
-    values.target_id === null
-      ? statement.where("target_id", "is", null)
-      : statement.where("target_id", "=", values.target_id);
-  statement =
-    values.target_machine_class === null
-      ? statement.where("target_machine_class", "is", null)
-      : statement.where("target_machine_class", "=", values.target_machine_class);
+    .where((eb) => eb.and(exactMoveValues(intent)));
   const result = executeSqliteQuerySync(db, statement);
   if (result.numAffectedRows !== 1n) {
     throw new Error(`Session ${intent.sessionId} placement move changed before completion`);
@@ -481,27 +479,10 @@ export function createPlacementMoveOps(runtime: PlacementStoreRuntime) {
           return false;
         }
         const intent = fromRow(row);
-        const values = targetValues(intent.target);
-        let statement = moveQuery(db)
+        const statement = moveQuery(db)
           .updateTable("worker_session_placement_moves")
           .set({ last_error: boundedWorkerError(input.error), updated_at_ms: now() })
-          .where("operation_id", "=", intent.operationId)
-          .where("session_id", "=", intent.sessionId)
-          .where("source_generation", "=", intent.source.generation)
-          .where("source_environment_id", "=", intent.source.environmentId)
-          .where("source_owner_epoch", "=", intent.source.ownerEpoch)
-          .where("target_kind", "=", values.target_kind);
-        statement = intent.abandonSource
-          ? statement.where("abandon_source", "=", 1)
-          : statement.where("abandon_source", "is", null);
-        statement =
-          values.target_id === null
-            ? statement.where("target_id", "is", null)
-            : statement.where("target_id", "=", values.target_id);
-        statement =
-          values.target_machine_class === null
-            ? statement.where("target_machine_class", "is", null)
-            : statement.where("target_machine_class", "=", values.target_machine_class);
+          .where((eb) => eb.and(exactMoveValues(intent)));
         return executeSqliteQuerySync(db, statement).numAffectedRows === 1n;
       });
     },


### PR DESCRIPTION
## What Problem This Solves

Placement-move error recording and deletion duplicate the same complete move-identity predicate, including three nullable-field branches. This is a maintainer-requested production simplification in the #135868 split campaign.

## Why This Change Was Made

Share the nine-field match and let the existing Kysely object predicate choose equality or `IS NULL`. The same operation ID, session ID, source generation, environment, owner epoch, target kind/ID/machine class, and abandonment value remain required by both mutations.

Deletion evidence: Kysely's existing filter-object parser uses `IS` for null and equality for strings/numbers. `fromRow`, `targetValues`, and `abandonSourceValue` produce all nine defined values, so no criterion is omitted. The `1`/`NULL` abandonment encoding, synchronous transaction owner, state checks and affected-row checks are unchanged.

## User Impact

No behavior change. Stale placement moves still fail their exact identity checks, and error recording and completion retain the same persistence behavior.

## Evidence

- Real SQLite owner suites before: 3 files, 31 cases, 35.54s; after: 3 files, 31 cases, 19.99s. Move, abandonment and schema-compatibility cases are unchanged.
- A compiler comparison covered 16 target/flag/update/delete encodings: predicate SQL matches apart from one grouping parenthesis, with identical bound parameters. The changed map preserves that field order.
- Production +19/−38 = **−19**. Tests/tooling/docs zero; no tests removed.
- No schema, protocol, migration, retention or transaction change.

- Full `node scripts/check-changed.mjs`: exit 0, including both typecheck lanes, lint and all selected guards.
- Independent autoreview: scoped-clean, no accepted/actionable findings.
- No build required: internal query construction only; no packaging, lazy-loading or public API changes.
