### PR TITLE
fix: avoid retaining discarded tool output

### DIFF
--- a/packages/agent-core/src/harness/utils/truncate.retention.test-support.ts
+++ b/packages/agent-core/src/harness/utils/truncate.retention.test-support.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { setImmediate } from "node:timers/promises";
+import { truncateHead, truncateLine, truncateTail } from "./truncate.js";
+
+const [mode, rawLimit] = process.argv.slice(2);
+const limit = Number(rawLimit);
+assert.ok(mode === "head" || mode === "tail" || mode === "partial-tail" || mode === "line");
+assert.ok(limit === 64 || limit === 4096);
+const gc = globalThis.gc;
+assert.ok(gc, "The retention child requires --expose-gc");
+const inputUnits = 2 * 1024 * 1024;
+
+function makeResults() {
+  const results = [];
+  for (let index = 0; index < 8; index++) {
+    const bytes = Buffer.alloc(inputUnits * 2);
+    bytes.fill(Buffer.from([65 + index, 0]));
+    if (mode === "head") {
+      bytes.writeUInt16LE(10, limit * 2);
+    } else if (mode === "tail") {
+      bytes.writeUInt16LE(10, (inputUnits - limit - 1) * 2);
+    }
+    const input = bytes.toString("utf16le");
+    results.push(
+      mode === "line"
+        ? truncateLine(input, limit)
+        : (mode === "head" ? truncateHead : truncateTail)(input, { maxBytes: limit }),
+    );
+  }
+  return results;
+}
+
+const collect = async () => {
+  for (let pass = 0; pass < 3; pass++) {
+    await setImmediate();
+    gc();
+  }
+  return process.memoryUsage();
+};
+
+const before = await collect();
+const results = makeResults();
+const held = await collect();
+// Reading or serializing a returned string can flatten it and hide source retention.
+for (const [index, result] of results.entries()) {
+  const content = String.fromCharCode(65 + index).repeat(limit);
+  assert.deepEqual(
+    result,
+    mode === "line"
+      ? { text: `${content}... [truncated]`, wasTruncated: true }
+      : {
+          content,
+          truncated: true,
+          truncatedBy: "bytes",
+          totalLines: mode === "partial-tail" ? 1 : 2,
+          totalBytes: inputUnits,
+          outputLines: 1,
+          outputBytes: limit,
+          lastLinePartial: mode === "partial-tail",
+          firstLineExceedsLimit: false,
+          maxLines: 2000,
+          maxBytes: limit,
+        },
+  );
+}
+process.stdout.write(
+  JSON.stringify({
+    heapUsedIncrease: held.heapUsed - before.heapUsed,
+    externalIncrease: held.external - before.external,
+    results,
+  }),
+);

--- a/packages/agent-core/src/harness/utils/truncate.retention.test.ts
+++ b/packages/agent-core/src/harness/utils/truncate.retention.test.ts
@@ -1,0 +1,39 @@
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+import { runNodeScript } from "../../../../../test/helpers/run-node-script.js";
+
+it.for(
+  ["head", "tail", "partial-tail", "line"].flatMap((mode) =>
+    [64, 4096].map((limit) => ({ mode, limit })),
+  ),
+)(
+  "owns $mode output with a $limit limit",
+  { timeout: 30_000 },
+  async ({ mode, limit }, { signal }) => {
+    const result = await runNodeScript(
+      [
+        "--expose-gc",
+        "--import",
+        "tsx",
+        fileURLToPath(new URL("./truncate.retention.test-support.ts", import.meta.url)),
+        mode,
+        String(limit),
+      ],
+      { ...process.env, NODE_OPTIONS: "", TSX_DISABLE_CACHE: "1" },
+      15_000,
+      {
+        cwd: fileURLToPath(new URL("../../../../../", import.meta.url)),
+        signal,
+        maxBuffer: 64 * 1024,
+        requireProcessTreeExit: process.platform !== "win32",
+      },
+    );
+    expect(result.error, result.stderr).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    const observed = JSON.parse(result.stdout);
+    expect(observed.results).toHaveLength(8);
+    // Eight small outputs may allocate, but must not retain eight 2MiB sources.
+    expect(observed.heapUsedIncrease).toBeLessThan(1024 * 1024);
+    expect(observed.externalIncrease).toBeLessThan(1024 * 1024);
+  },
+);

--- a/packages/agent-core/src/harness/utils/truncate.test.ts
+++ b/packages/agent-core/src/harness/utils/truncate.test.ts
@@ -26,6 +26,15 @@ describe("truncate utilities", () => {
     expect(result.outputBytes).toBe(4);
   });
 
+  it("preserves a leading BOM and NUL in a partial tail line", () => {
+    expect(truncateTail("discarded-\uFEFFA\0B", { maxBytes: 6 })).toMatchObject({
+      content: "\uFEFFA\0B",
+      outputBytes: 6,
+      outputLines: 1,
+      lastLinePartial: true,
+    });
+  });
+
   it.each([
     { tail: "\uD800", maxBytes: 3, expected: "\uFFFD" },
     { tail: "\uDC00", maxBytes: 3, expected: "\uFFFD" },
@@ -102,6 +111,26 @@ describe("truncate utilities", () => {
       truncatedBy: "bytes",
     },
     {
+      name: "lone UTF-16 units",
+      content: "\uD800x\uDC00\ndiscarded\n\uD800x\uDC00",
+      maxLines: 2,
+      maxBytes: 7,
+      head: "\uD800x\uDC00",
+      tail: "\uD800x\uDC00",
+      outputLines: 1,
+      truncatedBy: "bytes",
+    },
+    {
+      name: "BOM and NUL",
+      content: "\uFEFFA\0B\ndiscarded\n\uFEFFA\0B",
+      maxLines: 2,
+      maxBytes: 6,
+      head: "\uFEFFA\0B",
+      tail: "\uFEFFA\0B",
+      outputLines: 1,
+      truncatedBy: "bytes",
+    },
+    {
       name: "line limit first",
       content: "a\nb\nc",
       maxLines: 1,
@@ -152,6 +181,13 @@ describe("truncate utilities", () => {
       const result = truncateLine("this is a very long line", 10);
       expect(result.wasTruncated).toBe(true);
       expect(result.text).toBe("this is a ... [truncated]");
+    });
+
+    it.each(["\uD800x\uDC00", "\uFEFFA\0B"])("preserves retained code units in %j", (prefix) => {
+      expect(truncateLine(`${prefix}discarded`, prefix.length)).toEqual({
+        text: `${prefix}... [truncated]`,
+        wasTruncated: true,
+      });
     });
 
     it("keeps 500 characters and truncates longer lines by default", () => {

--- a/packages/agent-core/src/harness/utils/truncate.ts
+++ b/packages/agent-core/src/harness/utils/truncate.ts
@@ -46,9 +46,15 @@ interface ResolvedTruncationInput {
 
 interface RuntimeBuffer {
   byteLength(content: string, encoding: "utf8"): number;
+  from(content: string, encoding: "utf16le"): { toString(encoding: "utf16le"): string };
 }
 
 const runtimeBuffer = (globalThis as { Buffer?: RuntimeBuffer }).Buffer;
+
+function copyString(content: string): string {
+  // Copy selected code units without normalizing lone surrogates or retaining the source backing.
+  return runtimeBuffer ? runtimeBuffer.from(content, "utf16le").toString("utf16le") : content;
+}
 
 function findFirstNonAscii(content: string): number {
   for (let index = 0; index < content.length; index++) {
@@ -132,7 +138,9 @@ function buildTruncationResult(
   },
 ): TruncationResult {
   return {
-    content: params.content,
+    // One-element joins can retain a source slice; multiline joins build their own text.
+    content:
+      params.truncated && params.outputLines === 1 ? copyString(params.content) : params.content,
     truncated: params.truncated,
     truncatedBy: params.truncatedBy,
     totalLines: input.totalLines,
@@ -360,5 +368,5 @@ export function truncateLine(
       }
     }
   }
-  return { text: `${line.slice(0, cut)}... [truncated]`, wasTruncated: true };
+  return { text: `${copyString(line.slice(0, cut))}... [truncated]`, wasTruncated: true };
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Resolves a problem where retaining short tool-output previews, command tails or grep lines could also keep megabytes of discarded input alive.

## Why This Change Was Made

Copy selected single-line head/tail results and truncated line prefixes at their existing producers using lossless UTF-16 copying. This preserves byte/line budgets, metadata, BOMs, NULs and paired or lone surrogate units. It adds work proportional to selected text so discarded input can be released when no other caller retains it.

## User Impact

Sessions can retain small truncated results without keeping the original large input through those results on the tested Node paths. Tool text and truncation notices are unchanged.

## Evidence

- Eight fresh Node 26.8.1 retention cases cover head, complete/partial tail and line prefixes at small and larger limits. Baseline external memory increased 16,777,256 bytes per eight tiny results; the candidate passes separate external and heapUsed growth bounds below 1MiB. Measurement precedes reading or serializing returned content.
- 49 qualified tests: 41 unchanged owner/facade/accumulator cases plus 8 final retention cases. 28 distinct normal checks: 16 unchanged earlier passes plus 12 final checks, including both typechecks and lint. These are qualified totals, not a monolithic rerun.
- 20 complete Unicode/BOM/NUL value cases passed across normal Buffer and Buffer-absent Node modes. Buffer absence is value-only proof; Bun remains unrun and source-qualified.
- Independent P2 review is scoped clean with no findings. Earlier fixture context, timeout-type and GC type/lint failures were fixed and preserved; final applicable checks pass.
- Fixed 14-scenario B0/C0/C1/B1 comparison: 56 fresh Node processes, 448 complete returned objects and per-call CPU observations, all outputs matched. In ten source-retention cases, held external growth fell from 16,777,256–16,777,272 bytes to 56 bytes per eight retained results; four already-repaired tail controls remained at 56 bytes. Heap growth stayed separate from external memory; this is not an RSS-release claim.
- Copying costs CPU: 8 of 14 scenario means were adverse. The line-prefix cases added 90–129 microseconds per eight calls (about 11–16 microseconds per call). The largest tail-row increase was 50.9%; other rows varied in both directions. These two block pairs are descriptive, not a statistically established throughput improvement. All adverse observations are retained, and no Gateway speedup is claimed.
- Production: +8 lines for bounded, lossless string ownership; tests/support: +147 lines. Existing multiline and fitting-result paths stay unchanged.

Exact-head [CI and required gate](https://github.com/openclaw/openclaw/actions/runs/34072455805) passed.
