### PR TITLE
fix(ui): prevent usage exports from mixing session instances

### DIFF
--- a/docs/web/control-ui/feature-reference.md
+++ b/docs/web/control-ui/feature-reference.md
@@ -88,6 +88,7 @@ Control UI capabilities grouped by area, each with the Gateway RPC methods behin
     - A provider usage failure does not block the session/cost dashboard; unavailable provider cards show their own error state.
     - Incomplete session/cost totals stay readable while the visible, focused page checks for updates. Automatic checks are bounded; if they pause, select **Refresh** to check again.
     - The overview loads session summaries first. Full system-prompt breakdowns load when you select a session; the `has:context` filter still works before opening details.
+    - JSON exports keep the displayed usage snapshot and load prompt details for the same session instance. If that session has been replaced, refresh Usage and export again.
 
   </Accordion>
   <Accordion title="Debug, logs, update">

--- a/ui/src/pages/usage/export.ts
+++ b/ui/src/pages/usage/export.ts
@@ -8,8 +8,9 @@ import type { GatewayPageController } from "../../lit/gateway-page-controller.ts
 import { currentLocalDate, toUsageErrorMessage } from "./helpers.ts";
 import type { UsageJsonExport, UsageSessionEntry } from "./types.ts";
 
-function sessionIdentity({ agentId, key }: UsageSessionEntry): string {
-  return JSON.stringify([agentId, key]);
+// Logical keys can be reused after deletion; context belongs to a concrete session.
+function sessionIdentity({ agentId, key, sessionId }: UsageSessionEntry): string {
+  return JSON.stringify([agentId, key, sessionId]);
 }
 
 export function createUsageJsonExportTask(

--- a/ui/src/pages/usage/usage-page-details.test.ts
+++ b/ui/src/pages/usage/usage-page-details.test.ts
@@ -203,6 +203,7 @@ describe("UsagePage detail requests", () => {
       ...snapshot.result,
       sessions: ["First", "Second"].map((label, index) => ({
         key: "global",
+        sessionId: "shared-instance",
         label,
         agentId: index === 0 ? "main" : "opus",
         hasContextWeight: true,
@@ -247,14 +248,17 @@ describe("UsagePage detail requests", () => {
       sessions: result.sessions.map((session) => ({
         ...session,
         usage: { ...session.usage, totalTokens: 9999 },
-        contextWeight: contextWeight(session.label),
+        contextWeight: { ...contextWeight(session.label), sessionId: session.sessionId },
       })),
     };
     pending.resolve(full);
     await vi.waitFor(() => expect(download).toHaveBeenCalledOnce());
     const payload = JSON.parse(download.mock.calls[0]![1]) as { sessions: UsageSessionEntry[] };
     expect(payload.sessions).toEqual([
-      { ...result.sessions[0], contextWeight: contextWeight("First") },
+      {
+        ...result.sessions[0],
+        contextWeight: { ...contextWeight("First"), sessionId: "shared-instance" },
+      },
     ]);
     expect(page.querySelector('.usage-export-menu button[aria-busy="true"]')).toBeNull();
 
@@ -280,6 +284,60 @@ describe("UsagePage detail requests", () => {
       }),
     );
     expect(download).toHaveBeenCalledOnce();
+
+    for (const [scenario, sessionId, otherSessionId, expectedDownloads] of [
+      ["matching instance", "shared-instance", "shared-instance", 1],
+      ["replacement instance", "replacement-instance", "shared-instance", 0],
+      ["unrelated agent replacement", "shared-instance", "other-instance", 1],
+    ] as const) {
+      download.mockClear();
+      notice.mockClear();
+      pending = deferred<SessionsUsageResult>();
+      exportJson();
+      await page.updateComplete;
+      expect(page.querySelector('.usage-export-menu button[aria-busy="true"]')).not.toBeNull();
+      pending.resolve({
+        ...full,
+        sessions: [
+          {
+            ...full.sessions[0]!,
+            sessionId,
+            contextWeight: { ...contextWeight("Current first"), sessionId },
+          },
+          {
+            ...full.sessions[1]!,
+            sessionId: otherSessionId,
+            contextWeight: { ...contextWeight("Other agent"), sessionId: otherSessionId },
+          },
+        ],
+      });
+      await vi.waitFor(() =>
+        expect(page.querySelector('.usage-export-menu button[aria-busy="true"]')).toBeNull(),
+      );
+      expect(download, scenario).toHaveBeenCalledTimes(expectedDownloads);
+      if (expectedDownloads === 0) {
+        expect(notice).toHaveBeenCalledWith({
+          message: expect.stringContaining("Refresh usage and try again"),
+        });
+      } else {
+        expect(notice).not.toHaveBeenCalled();
+        const exportedPayload = JSON.parse(download.mock.calls[0]![1]) as {
+          sessions: UsageSessionEntry[];
+        };
+        expect(exportedPayload.sessions).toMatchObject([
+          {
+            key: "global",
+            agentId: "main",
+            sessionId: "shared-instance",
+            usage: { totalTokens: 100 },
+            contextWeight: {
+              sessionId: "shared-instance",
+              skills: { entries: [{ name: "Current first" }] },
+            },
+          },
+        ]);
+      }
+    }
   });
 
   it("marks provider usage stalled once the retry budget is spent", async () => {


### PR DESCRIPTION
Closes #140567

## What Problem This Solves

Fixes Usage JSON exports that attach a replacement session's prompt context to an older displayed usage row after the logical session key is reused. This affects both Current instance and the default Historical lineage view.

## Why This Change Was Made

The existing shared export key now includes the concrete session ID alongside agent and logical key. Map construction, required-context validation and context lookup all use that one identity. The existing refresh error handles replacement; the original lazy-loading behavior and same-instance updates are preserved.

## User Impact

An export keeps the displayed usage snapshot and loads details belonging to that same instance. If it has been replaced, the UI asks the operator to refresh instead of downloading mixed data. Refreshing then exports the replacement correctly. The Usage reference documents this recovery.

## Evidence

- The rendered-page regression failed before the repair: the replacement case downloaded a file when it should not. Nine other tests passed. The identical fixed file passes all ten tests; 41 related Usage/refresh/query tests also pass.
- The complete three-path changed gate passed, including core/UI typechecks, i18n, lint and repository guards. Independent P0–P2 review was clean. Signed head: `c864dc2389cdc40578c34fd9c4774d121a4612c0`; fresh uncached build passed.
- Six runs of the real compiled UI used public mock Gateway snapshots, normal menu clicks and actual browser downloads. Both views reproduced A/100 tokens plus B context before the fix. Both reject that export afterward and show the existing refresh message. Refresh-B recovery and fresh-context/same-ID controls pass on both builds.

| Browser result | Before | After |
| --- | --- | --- |
| Replacement exports mixing A's row with B's report | 2 | 0 |
| Replacement exports visibly requesting refresh | 0 | 2 |
| Valid refresh/same-instance downloads | 3 | 3 |

All eight downloaded files, 20 screenshots and six videos were inspected. Complete source, dependency and generated-artifact checks passed before and after every run; browser, context, server and listeners closed normally. This is a real UI snapshot scenario with a mocked Gateway, not a live deletion/recreation or provider test.

Production **+3/−2**: two executable lines replaced and one ownership comment added. Tests **+60/−2**; docs **+1**. The affected owners are unchanged on inspected main `6df7c32f477a458950f01a541119944b5bd85557`.

Provenance: the parent-relative diff of #132064 (`d9f3d88409358603ab4c0ad1afd7eab846c6a0d8`) introduced the weaker join. Stable `v2026.9.2` retains it; that is source evidence only.

### Inspected synthetic browser evidence

Before: the export completes without a refresh warning; the actual downloaded JSON contains row A with context B. After: the existing refresh message prevents that mixed download. The short recordings also include successful refresh-B recovery.

![Before: export completes with no refresh message; downloaded fields are shown in the report](https://github.com/user-attachments/assets/f7f35174-5038-4d8c-9621-b40bcbaf4b44)

![After: the UI asks to refresh when the session instance changed](https://github.com/user-attachments/assets/410c7067-d8c2-4531-a0d8-dd7334dd1b7b)

https://github.com/user-attachments/assets/d9da2f74-e74b-444f-b017-32e4ac40b12d

https://github.com/user-attachments/assets/020e4a2f-b88b-43bb-8bde-82725903fa70
