### PR TITLE
docs(macos): publish native app support requirements

### DIFF
--- a/docs/platforms/mac/dev-setup.md
+++ b/docs/platforms/mac/dev-setup.md
@@ -9,6 +9,9 @@ title: "macOS dev setup"
 
 Build and run the OpenClaw macOS application from source.
 
+The packaged app requires macOS 15.0 or later. The build host must also meet
+the Xcode requirements below.
+
 ## Prerequisites
 
 - **Xcode 26.4+** (Swift 6.3 toolchain), on the latest macOS available in

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -20,6 +20,20 @@ bounded image model and renderer.
 
 Only need the CLI and Gateway? Start with [Getting started](/start/getting-started).
 
+## Requirements
+
+**OpenClaw.app requires macOS 15.0 (Sequoia) or later.** This also applies to
+its native `openclaw-mac` helper. [Voice Wake and push-to-talk](/platforms/mac/voicewake#requirements)
+require macOS 26 or later.
+
+The Node-based CLI and Gateway need a [supported Node version](/install/node)
+on an operating system supported by that runtime. Official Node 24 and Node 26
+macOS binaries require macOS 13.5 or later. Running the CLI on an older Mac
+does not make the native app compatible with that macOS version.
+
+Building from source also requires the toolchain listed in
+[macOS developer setup](/platforms/mac/dev-setup#prerequisites).
+
 ## Download
 
 Get macOS app builds from [OpenClaw GitHub releases](https://github.com/openclaw/openclaw/releases).


### PR DESCRIPTION
## What Problem This Solves

Users could not readily tell whether the native macOS app supports their Mac or distinguish its requirements from the Node-based CLI/Gateway. Related: #139109; its launchctl parser repair is separate from this documentation change.

## Why This Change Was Made

Publishes the existing macOS 15.0 (Sequoia) minimum for OpenClaw.app and its native helper, links the macOS 26 requirement for Voice Wake/push-to-talk, and separates installed-app compatibility from Xcode build-host prerequisites. CLI/Gateway requirements remain tied to the supported Node runtime; official Node 24/26 macOS binaries target 13.5.

Peter approved lifting the draft hold and landing this documentation on September 7, 2026. No deployment target, dependency, runtime acceptance, or feature gate changed.

## User Impact

Users can check native app compatibility before downloading and follow the appropriate CLI, voice, or source-build requirements.

## Evidence

- Exact reviewed head: `23c8a0de7a642e442814729257a76508b1cdb72a`.
- [Required docs CI passed](https://github.com/openclaw/openclaw/actions/runs/34100830583). Native `scripts/pr` review validation, `OPENCLAW_TESTBOX=1` preparation, and merge verification passed without rebasing.
- Personally checked `apps/macos/Package.swift`, `Info.plist`, `Constants.swift`, voice callers, and linked requirements headings; independent review found no actionable correctness issue. `git diff --check` passed.
- Documentation only: +17/-0; production and test code unchanged. No older-macOS native qualification or backport build is claimed.
- Landed as [5b2b7173023dd5cb841364b2048f08d62e9101c5](https://github.com/openclaw/openclaw/commit/5b2b7173023dd5cb841364b2048f08d62e9101c5).
