### PR TITLE
fix(portals): reach IPv6 loopback with IPv4-only localhost records

### DIFF
--- a/docs/gateway/portals.md
+++ b/docs/gateway/portals.md
@@ -61,7 +61,7 @@ The Gateway never executes these commands automatically. The agent reads the fil
 
 The application must honor `PORT`. Use `PUBLIC_URL` when it needs to generate absolute URLs.
 
-The server can listen on IPv4 or IPv6 loopback (`127.0.0.1` or `::1`), both on the Gateway host and on a worker. Worker streams also preserve the node's configured Gateway context path when connecting through a reverse proxy.
+The server can listen on IPv4 or IPv6 loopback (`127.0.0.1` or `::1`), both on the Gateway host and on a worker, even when the machine's `localhost` records list only one address family. Worker streams also preserve the node's configured Gateway context path when connecting through a reverse proxy.
 
 The proxy rewrites `Host` to the local target, so typical development servers such as Vite and Next.js need no additional configuration. WebSockets and hot module replacement are proxied through the same portal.
 

--- a/src/gateway/portals/portal-http-proxy.test.ts
+++ b/src/gateway/portals/portal-http-proxy.test.ts
@@ -10,6 +10,7 @@ import net, { type AddressInfo } from "node:net";
 import { duplexPair, type Duplex } from "node:stream";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { type RawData, WebSocket, WebSocketServer } from "ws";
+import { mockIpv4OnlyLocalhostLookup } from "../../../test/helpers/loopback-dns.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { getFreePort } from "../../test-utils/ports.js";
 import type { PortalTarget } from "./portal-http-proxy.js";
@@ -812,6 +813,7 @@ describe("portal HTTP proxy", () => {
   );
 
   it("reaches IPv6-only targets through the localhost dual-stack dial", async () => {
+    mockIpv4OnlyLocalhostLookup();
     // Node >=17 dev servers (Vite, Next.js) often bind ::1 only on "localhost".
     // Probe IPv4 so localhost cannot reach the shared IPv4 fixture on the same port.
     const v6Port = await getFreePort();

--- a/src/gateway/portals/portal-http-proxy.ts
+++ b/src/gateway/portals/portal-http-proxy.ts
@@ -8,6 +8,7 @@ import type {
 import { request as requestHttp } from "node:http";
 import net from "node:net";
 import type { Duplex } from "node:stream";
+import { createLoopbackConnectOptions } from "../../infra/loopback-connect.js";
 
 const PORTAL_AUTH_NAME = "openclaw_portal";
 // Browser cookie jars are hostname-scoped, so the stable listener port in the
@@ -220,9 +221,7 @@ async function connectPortalTarget(target: PortalTarget): Promise<Duplex> {
   if (target.kind === "worker") {
     return await target.connect();
   }
-  // Dial "localhost", not a fixed loopback literal: Node >=17 dev servers (Vite,
-  // Next.js) often bind ::1 only, and family autoselection reaches either stack.
-  return net.connect({ host: "localhost", autoSelectFamily: true, port: target.port });
+  return net.connect(createLoopbackConnectOptions(target.port));
 }
 
 function connectionHeaderTokens(headers: IncomingHttpHeaders): Set<string> {

--- a/src/infra/loopback-connect.test.ts
+++ b/src/infra/loopback-connect.test.ts
@@ -1,0 +1,31 @@
+import { once } from "node:events";
+import net from "node:net";
+import { expect, it } from "vitest";
+import { createLoopbackConnectOptions } from "./loopback-connect.js";
+
+it.each([
+  { family: 4, host: "127.0.0.1" },
+  { family: 6, host: "::1" },
+])("connects with an explicitly selected IPv$family lookup", async ({ family, host }) => {
+  const server = net.createServer((socket) => socket.end("loopback"));
+  let socket: net.Socket | undefined;
+  try {
+    server.listen(0, host);
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected a TCP listener");
+    }
+    socket = net.connect({ ...createLoopbackConnectOptions(address.port), family });
+    let response = "";
+    for await (const chunk of socket) {
+      response += chunk.toString();
+    }
+    expect(response).toBe("loopback");
+  } finally {
+    socket?.destroy();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  }
+});

--- a/src/infra/loopback-connect.ts
+++ b/src/infra/loopback-connect.ts
@@ -1,0 +1,24 @@
+import type { TcpNetConnectOpts } from "node:net";
+
+export function createLoopbackConnectOptions(port: number): TcpNetConnectOpts {
+  return {
+    host: "localhost",
+    port,
+    autoSelectFamily: true,
+    lookup(_hostname, options, callback) {
+      // Localhost records can omit a family even when its loopback listener works.
+      queueMicrotask(() => {
+        if (options.all) {
+          callback(null, [
+            { address: "127.0.0.1", family: 4 },
+            { address: "::1", family: 6 },
+          ]);
+        } else if (options.family === 6) {
+          callback(null, "::1", 6);
+        } else {
+          callback(null, "127.0.0.1", 4);
+        }
+      });
+    },
+  };
+}

--- a/src/node-host/node-stream-transport.ts
+++ b/src/node-host/node-stream-transport.ts
@@ -9,6 +9,7 @@ import {
   type CloudflareAccessCredentials,
 } from "../../packages/gateway-client/src/cloudflare-access.js";
 import { applyGatewayWebSocketTlsPin } from "../../packages/gateway-client/src/websocket-transport.js";
+import { createLoopbackConnectOptions } from "../infra/loopback-connect.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 const require = createRequire(import.meta.url);
@@ -269,7 +270,7 @@ export async function runNodeStreamTransport(params: {
     }
     if ("port" in params.target && socket instanceof net.Socket) {
       // Portals attach first so a refused target closes the claimed ticket.
-      socket.connect({ port: params.target.port, host: "localhost", autoSelectFamily: true });
+      socket.connect(createLoopbackConnectOptions(params.target.port));
       await Promise.race([waitForSocketConnect(socket), abort]);
     }
     if (aborted) {

--- a/src/node-host/portal-stream-command.test.ts
+++ b/src/node-host/portal-stream-command.test.ts
@@ -2,6 +2,7 @@ import http from "node:http";
 import net from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
+import { mockIpv4OnlyLocalhostLookup } from "../../test/helpers/loopback-dns.js";
 import { invokeNodeWorkerPortalStream } from "./portal-stream-command.js";
 
 const TICKET = "a".repeat(48);
@@ -81,6 +82,9 @@ describe("node worker portal stream command", () => {
   ])(
     "attaches %s loopback through Gateway context %j and closes on cancellation",
     async (host, contextPath) => {
+      if (host === "::1") {
+        mockIpv4OnlyLocalhostLookup();
+      }
       const peers = new Set<net.Socket>();
       const local = net.createServer((socket) => {
         peers.add(socket);

--- a/test/helpers/loopback-dns.ts
+++ b/test/helpers/loopback-dns.ts
@@ -1,0 +1,21 @@
+import dns from "node:dns";
+import type { LookupFunction } from "node:net";
+import { onTestFinished, vi } from "vitest";
+
+export function mockIpv4OnlyLocalhostLookup(): void {
+  const resolver: { lookup: LookupFunction } = dns;
+  const originalLookup = resolver.lookup;
+  const lookup = vi.spyOn(resolver, "lookup").mockImplementation((hostname, options, callback) => {
+    if (hostname !== "localhost" || typeof options !== "object" || !options || options.family) {
+      return originalLookup(hostname, options, callback);
+    }
+    queueMicrotask(() => {
+      if (options.all) {
+        callback(null, [{ address: "127.0.0.1", family: 4 }]);
+      } else {
+        callback(null, "127.0.0.1", 4);
+      }
+    });
+  });
+  onTestFinished(() => lookup.mockRestore());
+}


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Fixes an issue where users opening a portal backed by an IPv6-only local server would fail to connect when the host's `localhost` records listed only IPv4. This affects both Gateway-hosted targets and worker portal streams, despite their documented support for either loopback family.

## Why This Change Was Made

Gateway and worker connections now share explicit IPv4 and IPv6 loopback lookup options while retaining Node's automatic family selection. The lookup supplies only `127.0.0.1` and `::1`; connection ordering relative to portal attachment, cancellation, and socket cleanup stays with the existing owners. The portal documentation now makes the host-DNS independence explicit.

## User Impact

Portals can reach IPv4-only or IPv6-only local applications even when system localhost records omit the application's address family. No configuration change is required.

## Evidence

Controlled IPv4-only localhost resolution made both existing integration suites fail before the production fix. With the fix, all 83 cases across five focused files passed, including real Gateway and worker socket flows. The final helper test adjustment passed both explicit-family cases. Fresh independent P2 review is scoped-clean with no actionable findings.

The final full changed gate, formatting, diff checks, and deslop passed. An earlier gate caught a Promise executor lint issue; the corrected helper passed both cases and the complete gate. This correctness repair adds 58 test/support lines and 24 production lines, recorded as campaign offsets. No local build, aggregate coverage, or runtime improvement claim is made.
