### PR TITLE
refactor: streamline skills JSON output

### DIFF
--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -76,19 +76,8 @@ function sanitizeJsonString(value: string): string {
     .replace(JSON_CONTROL_CHAR_REGEX, "");
 }
 
-function sanitizeJsonValue(value: unknown): unknown {
-  if (typeof value === "string") {
-    return sanitizeJsonString(value);
-  }
-  if (Array.isArray(value)) {
-    return value.map((item) => sanitizeJsonValue(item));
-  }
-  if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, entryValue]) => [key, sanitizeJsonValue(entryValue)]),
-    );
-  }
-  return value;
+function sanitizeJsonValue(_key: string, value: unknown): unknown {
+  return typeof value === "string" ? sanitizeJsonString(value) : value;
 }
 function formatSkillName(skill: SkillStatusEntry): string {
   const emoji = normalizeSkillEmoji(skill.emoji);
@@ -117,7 +106,7 @@ export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOpti
   const skills = opts.eligible ? report.skills.filter(isReadyForAgent) : report.skills;
 
   if (opts.json) {
-    const jsonReport = sanitizeJsonValue({
+    const jsonReport = {
       workspaceDir: report.workspaceDir,
       managedSkillsDir: report.managedSkillsDir,
       skills: skills.map((s) => ({
@@ -137,8 +126,8 @@ export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOpti
         homepage: s.homepage,
         missing: s.missing,
       })),
-    });
-    return JSON.stringify(jsonReport, null, 2);
+    };
+    return JSON.stringify(jsonReport, sanitizeJsonValue, 2);
   }
 
   if (skills.length === 0) {
@@ -190,20 +179,20 @@ export function formatSkillInfo(
   opts: SkillInfoOptions,
 ): string {
   const requestedName = skillName.trim();
-  const safeRequestedName = sanitizeJsonString(sanitizeForLog(requestedName));
   const skill = resolveSkillStatusEntry(report.skills, requestedName);
 
   if (!skill) {
     if (opts.json) {
       return JSON.stringify(
-        sanitizeJsonValue({
+        {
           ...formatCliJsonFailure(`Skill "${requestedName}" not found.`),
           skill: requestedName,
-        }),
-        null,
+        },
+        sanitizeJsonValue,
         2,
       );
     }
+    const safeRequestedName = sanitizeJsonString(sanitizeForLog(requestedName));
     return appendClawHubHint(
       `Skill "${safeRequestedName}" not found. Run \`${formatCliCommand("openclaw skills list")}\` to see available skills.`,
       opts.json,
@@ -211,7 +200,7 @@ export function formatSkillInfo(
   }
 
   if (opts.json) {
-    return JSON.stringify(sanitizeJsonValue(skill), null, 2);
+    return JSON.stringify(skill, sanitizeJsonValue, 2);
   }
 
   const lines: string[] = [];
@@ -321,7 +310,7 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
 
   if (opts.json) {
     return JSON.stringify(
-      sanitizeJsonValue({
+      {
         agentId,
         agentSkillFilter: report.agentSkillFilter,
         workspaceDir: report.workspaceDir,
@@ -352,8 +341,8 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
           missing: s.missing,
           install: s.install,
         })),
-      }),
-      null,
+      },
+      sanitizeJsonValue,
       2,
     );
   }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Large `openclaw skills list --json` inventories spend avoidable time formatting their reports. This reduces that work while preserving the machine-readable output contract and terminal-control sanitization.

## Why This Change Was Made

Apply the existing string sanitizer during JSON serialization instead of recursively copying the report first. Also prepare the human lookup-error name only when returning that error. The cleanup removes 11 production lines without adding dependencies, configuration, or API fields.

The contract is the plain status reports produced by Gateway/local discovery, not arbitrary class instances or custom `toJSON` methods.

## User Impact

The fixed cohort's clean 1,000-skill list JSON medians improved **14.74% / 14.79%**, saving about **0.404 / 0.428 ms** per formatting call. Control-bearing 1,000-skill lists improved **13.04% / 12.63%**. All returned output bytes were preserved.

The benefit is localized, not uniform: clean 1,000-skill info JSON regressed **55.22% / 69.55%** (**16.16 / 21.77 µs**), some check rows regressed roughly 1–8%, and human-output controls were mixed and frequently adverse. Kernel and sampled tree peak RSS increased about **0.8–1.1%**. No overall CLI-startup, Gateway, or memory improvement is claimed.

## Evidence

- **37 tests** across the two existing skills CLI test files passed on the final source; native wall time was 9.13 seconds. **All 28 normal checks** passed on that source in 304.76 seconds, without retry or source changes during validation.
- Fresh canonical **P2 review passed**, scoped-clean with no actionable findings (39.53 seconds). Installation/readiness and the unchanged path-only plan are explicitly retained from the preceding source revision.
- Fixed **53-row B0/C0/C1/B1** measurements preserve **4,028 complete reconstructable returns**: **3,116 independent JSON-value and pretty-byte checks**, plus **912 human-text byte comparisons**. Every call also checked unchanged input/options. An independent data audit reconstructed every return and reproduced all statistics.
- **39/106 medians, 39/106 means, and 45/106 maxima are adverse**. JSON rows contribute 21/82 adverse medians; unchanged human-text controls contribute 18/24. All rows are included below. Whole-child wall improved 8.89% / 0.80%, but those clocks include loading, fixture/oracle work, and capture I/O.

First observations and warmups were **untimed correctness checks**. Each reported sample is the mean of two separately clocked formatter calls; maxima are maximum batch means, not latency percentiles. Discovery and provider/Gateway execution are outside the measured formatter intervals.

The first capture attempt hit the unchanged 64 MiB journal cap after 948 verified returns and produced no performance verdict. R2 retained full strings in a lossless dictionary with one exact reference per return, including new differing outputs before assertions, then ran a **fresh complete cohort**. No cap or call count was increased/reduced, no partial R1 timing was pooled, and all failed-attempt evidence remains preserved. Capture changes happened outside the clock but can affect process state, so these are descriptive workload results rather than a universal speedup.

<details>
<summary>All 53 rows: forward and reverse median / mean / maximum changes</summary>

Percent change is candidate relative to baseline; negative is faster. Forward is B0→C0 and reverse is B1→C1. “controls” fixtures contain ANSI/C0/C1-bearing strings.

| Row | Forward median / mean / max % | Reverse median / mean / max % |
| --- | ---: | ---: |
| clean-0-list-json | +7.39 / -10.15 / -37.53 | -19.65 / -24.09 / -38.67 |
| clean-0-list-eligible-json | -2.56 / -0.78 / +48.57 | +0.00 / -8.69 / +13.93 |
| clean-0-check-json | -31.45 / -18.01 / +59.59 | -35.64 / -92.25 / -98.50 |
| clean-0-info-json | -2.77 / +13.63 / +87.96 | -7.01 / -4.62 / -8.41 |
| clean-1-list-json | -15.40 / -17.00 / -14.29 | -18.65 / -21.94 / -16.34 |
| clean-1-list-eligible-json | -19.19 / -29.61 / -47.28 | -26.92 / -26.13 / -34.53 |
| clean-1-check-json | -10.87 / -18.00 / -26.79 | -19.95 / -16.65 / -14.91 |
| clean-1-info-json | -15.03 / -8.80 / +26.62 | -24.56 / -18.70 / +6.87 |
| clean-20-list-json | -17.62 / -19.49 / -19.94 | -19.47 / -24.01 / -37.44 |
| clean-20-list-eligible-json | -10.90 / -20.77 / -31.01 | -20.21 / -21.54 / -21.76 |
| clean-20-check-json | +2.81 / -2.50 / -12.47 | -2.79 / -6.39 / -19.29 |
| clean-20-info-json | -23.97 / -27.53 / -48.07 | -22.29 / -20.45 / -19.91 |
| clean-200-list-json | -15.21 / -25.32 / -58.10 | -13.98 / -27.30 / -62.83 |
| clean-200-list-eligible-json | -10.71 / -25.46 / -62.08 | -17.77 / -17.23 / -20.74 |
| clean-200-check-json | +8.44 / +5.62 / +3.27 | +2.40 / +21.55 / +136.52 |
| clean-200-info-json | -13.56 / +2.52 / -8.51 | +32.88 / +24.63 / -12.64 |
| clean-1000-list-json | -14.74 / -15.49 / -23.29 | -14.79 / -15.80 / -23.95 |
| clean-1000-list-eligible-json | -10.09 / -11.96 / -20.69 | -15.04 / -13.98 / -20.25 |
| clean-1000-check-json | +7.63 / +6.57 / +5.39 | +1.22 / -0.94 / +3.34 |
| clean-1000-info-json | +55.22 / +29.70 / +12.22 | +69.55 / +70.93 / +38.10 |
| controls-0-list-json | +1.19 / +4.34 / +8.20 | -4.52 / -10.49 / -38.32 |
| controls-0-list-eligible-json | +3.42 / +1.96 / -1.00 | +6.85 / +27.78 / +110.79 |
| controls-0-check-json | +0.22 / +17.67 / +50.00 | -9.24 / -10.77 / +4.35 |
| controls-0-info-json | -3.97 / +1.01 / +17.29 | -13.73 / -9.40 / -17.92 |
| controls-1-list-json | +0.57 / +26.68 / +195.09 | +0.15 / -2.73 / -18.40 |
| controls-1-list-eligible-json | -1.42 / +3.04 / +31.50 | -4.43 / -2.77 / +8.58 |
| controls-1-check-json | -7.42 / +19.32 / +179.87 | -2.10 / -2.41 / -2.54 |
| controls-1-info-json | -7.52 / -5.33 / +12.88 | -8.34 / -8.14 / -9.39 |
| controls-20-list-json | -5.43 / -8.41 / -18.10 | -6.76 / -9.93 / -17.77 |
| controls-20-list-eligible-json | -5.80 / -27.91 / -60.67 | -0.80 / -27.13 / -69.93 |
| controls-20-check-json | +7.34 / +11.73 / +12.10 | +2.64 / +5.35 / +16.31 |
| controls-20-info-json | +15.75 / +22.68 / +43.54 | -2.60 / -2.87 / -5.27 |
| controls-200-list-json | -2.67 / -7.62 / -25.52 | -10.27 / -12.17 / -26.21 |
| controls-200-list-eligible-json | -13.70 / -15.27 / -26.65 | -11.18 / -14.05 / -34.03 |
| controls-200-check-json | +8.28 / +4.17 / -3.99 | +4.41 / +2.19 / +0.33 |
| controls-200-info-json | -23.53 / -8.43 / +44.62 | -10.77 / -12.08 / +1.94 |
| controls-1000-list-json | -13.04 / -12.61 / -10.81 | -12.63 / -13.47 / -15.53 |
| controls-1000-list-eligible-json | -6.09 / -7.65 / -14.55 | -13.67 / -13.08 / -14.95 |
| controls-1000-check-json | -1.24 / -0.63 / -1.53 | -0.62 / -2.12 / -9.24 |
| controls-1000-info-json | +44.83 / +9.42 / +4.37 | -34.09 / -22.42 / -25.94 |
| clean-1-list-text | +6.81 / +1.83 / -2.80 | -9.45 / -5.67 / +1.72 |
| clean-1-check-text | +6.70 / +3.92 / +7.04 | +1.15 / -0.45 / -6.50 |
| clean-1-info-text | -3.03 / -21.34 / -60.34 | -2.58 / -4.38 / -11.25 |
| clean-200-list-text | +3.61 / +2.82 / +5.82 | +8.00 / +15.54 / +55.98 |
| clean-200-check-text | +15.54 / +12.47 / +24.64 | +23.61 / +32.01 / +91.38 |
| clean-200-info-text | +9.38 / +46.40 / +76.41 | +29.92 / +135.40 / +212.83 |
| controls-1-list-text | +11.74 / +83.24 / +521.44 | +7.53 / +159.88 / +819.90 |
| controls-1-check-text | -2.21 / -0.25 / +3.21 | +22.13 / +163.43 / +761.18 |
| controls-1-info-text | -5.31 / -7.74 / -18.93 | +41.67 / +37.74 / +56.77 |
| controls-200-list-text | +0.94 / +1.12 / +3.42 | +0.24 / +0.99 / +3.19 |
| controls-200-check-text | +6.12 / +1.92 / -2.30 | -1.91 / +1.01 / -0.35 |
| controls-200-info-text | +12.66 / -6.87 / -33.89 | +0.62 / +24.02 / +104.19 |
| missing-controls-info-json | -13.20 / -37.81 / -63.13 | -10.10 / -10.93 / -11.28 |

</details>

Exact-head [CI and required gate](https://github.com/openclaw/openclaw/actions/runs/34073518124) passed.
