### PR TITLE
fix(ui): stop catalog paging in hidden tabs

### DIFF
--- a/ui/src/components/app-sidebar-session-catalog-live.ts
+++ b/ui/src/components/app-sidebar-session-catalog-live.ts
@@ -457,6 +457,7 @@ export async function refreshSessionCatalogsLive(params: {
       agentId: params.agentId,
       pageDepths: params.pageDepths,
       isCurrent: revisionIsCurrent,
+      canRequestPage: () => revisionIsCurrent() && document.visibilityState !== "hidden",
     });
     if (!revisionIsCurrent()) {
       return;

--- a/ui/src/components/app-sidebar-session-catalog-state.ts
+++ b/ui/src/components/app-sidebar-session-catalog-state.ts
@@ -85,6 +85,7 @@ export async function refetchExpandedSessionCatalogPages(params: {
   agentId: string;
   pageDepths: ReadonlyMap<string, number>;
   isCurrent: () => boolean;
+  canRequestPage: () => boolean;
 }): Promise<SessionCatalog[]> {
   const previousCatalogs = new Map(params.previousCatalogs.map((catalog) => [catalog.id, catalog]));
   return Promise.all(
@@ -106,6 +107,10 @@ export async function refetchExpandedSessionCatalogPages(params: {
           let sessions = host.sessions;
           let nextCursor = host.nextCursor;
           for (let loadedPages = 0; loadedPages < pageDepth && nextCursor; loadedPages += 1) {
+            // Pausing automatic replay must retain the full visible window, not its partial prefix.
+            if (!params.canRequestPage()) {
+              return preserveExpandedCatalogHost(host, previous);
+            }
             let result: SessionsCatalogListResult;
             try {
               result = await params.client.request<SessionsCatalogListResult>(

--- a/ui/src/components/app-sidebar.catalog-hidden-pages.test.ts
+++ b/ui/src/components/app-sidebar.catalog-hidden-pages.test.ts
@@ -1,0 +1,216 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionsCatalogListResult } from "../../../packages/gateway-protocol/src/index.ts";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import type { ApplicationGatewaySnapshot } from "../app/context.ts";
+import {
+  catalogErrorPage,
+  catalogPage,
+  createGatewayHarness,
+  createSessions,
+  deferred,
+  mountSidebar,
+  type SidebarLifecycleState,
+} from "../test-helpers/app-sidebar.ts";
+import "../test-helpers/app-sidebar-suite.ts";
+import "./app-sidebar.ts";
+
+const page = (number: number, label = "Original", nextCursor = `page-${number + 1}`) =>
+  catalogPage([{ threadId: `thread-${number}`, name: `${label} ${number}` }], nextCursor);
+
+async function settle(sidebar: SidebarLifecycleState) {
+  await vi.advanceTimersByTimeAsync(0);
+  await sidebar.updateComplete;
+}
+
+async function loadMore(sidebar: SidebarLifecycleState) {
+  const button = sidebar.querySelector<HTMLButtonElement>(
+    '[data-session-catalog-load-more="codex"]',
+  );
+  expect(button).not.toBeNull();
+  expect(button?.disabled).toBe(false);
+  button?.click();
+  await settle(sidebar);
+}
+
+async function mountExpanded(request: ReturnType<typeof vi.fn>) {
+  const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+  gateway.publish({
+    hello: {
+      features: { methods: ["sessions.catalog.list"] },
+    } as ApplicationGatewaySnapshot["hello"],
+  });
+  const mounted = await mountSidebar(gateway.gateway, createSessions("main", ["agent:main:main"]));
+  mounted.sidebar.connected = true;
+  await mounted.sidebar.updateComplete;
+  await settle(mounted.sidebar);
+  await loadMore(mounted.sidebar);
+  await loadMore(mounted.sidebar);
+  expect(request).toHaveBeenCalledTimes(3);
+  expect(mounted.sidebar.textContent).toContain("Original 3");
+  return { ...mounted, gateway };
+}
+
+describe("AppSidebar expanded catalog refresh visibility", () => {
+  let visibility: DocumentVisibilityState;
+  let restoreVisibility: () => void;
+
+  const setVisibility = (next: DocumentVisibilityState) => {
+    visibility = next;
+    document.dispatchEvent(new Event("visibilitychange"));
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    visibility = "visible";
+    const spy = vi.spyOn(document, "visibilityState", "get").mockImplementation(() => visibility);
+    restoreVisibility = () => spy.mockRestore();
+  });
+
+  afterEach(() => {
+    restoreVisibility();
+    vi.useRealTimers();
+  });
+
+  it.each(["base", "expanded"] as const)(
+    "stops new automatic pages after hiding during the %s response and catches up once",
+    async (heldStage) => {
+      const pending = deferred<SessionsCatalogListResult>();
+      const request = vi
+        .fn()
+        .mockResolvedValueOnce(page(1))
+        .mockResolvedValueOnce(page(2))
+        .mockResolvedValueOnce(page(3));
+      if (heldStage === "base") {
+        request.mockReturnValueOnce(pending.promise);
+      } else {
+        request.mockResolvedValueOnce(page(1, "Refreshed"));
+        request.mockReturnValueOnce(pending.promise);
+      }
+      request.mockImplementation((_method, params: { cursors?: Record<string, string> }) => {
+        const cursor = params.cursors?.["gateway:local"];
+        return Promise.resolve(
+          page(cursor === "page-2" ? 2 : cursor === "page-3" ? 3 : 1, "Refreshed"),
+        );
+      });
+      const { sidebar } = await mountExpanded(request);
+      await vi.advanceTimersByTimeAsync(30_000);
+      const issuedBeforeHide = heldStage === "base" ? 4 : 5;
+      expect(request).toHaveBeenCalledTimes(issuedBeforeHide);
+
+      setVisibility("hidden");
+      pending.resolve(page(heldStage === "base" ? 1 : 2, "Refreshed"));
+      await settle(sidebar);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect.soft(request).toHaveBeenCalledTimes(issuedBeforeHide);
+      const host = sidebar.sessionData.sessionCatalogs[0]?.hosts[0];
+      expect(host?.sessions.map((row) => row.threadId)).toEqual([
+        "thread-1",
+        "thread-2",
+        "thread-3",
+      ]);
+      expect(host?.nextCursor).toBe("page-4");
+
+      const baseCallsBeforeShow = request.mock.calls.filter(([, params]) => !params.cursors).length;
+      const callsBeforeShow = request.mock.calls.length;
+      setVisibility("visible");
+      globalThis.dispatchEvent(new Event("focus"));
+      await vi.advanceTimersByTimeAsync(50);
+      await settle(sidebar);
+      expect(request.mock.calls.filter(([, params]) => !params.cursors)).toHaveLength(
+        baseCallsBeforeShow + 1,
+      );
+      expect(request).toHaveBeenCalledTimes(callsBeforeShow + 3);
+      expect(sidebar.textContent).toContain("Refreshed 1");
+      expect(sidebar.textContent).toContain("Refreshed 2");
+      expect(sidebar.textContent).toContain("Refreshed 3");
+    },
+  );
+
+  it("replays every loaded page while visible", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(page(1))
+      .mockResolvedValueOnce(page(2))
+      .mockResolvedValueOnce(page(3))
+      .mockResolvedValueOnce(page(1, "Refreshed"))
+      .mockResolvedValueOnce(page(2, "Refreshed"))
+      .mockResolvedValueOnce(page(3, "Refreshed"));
+    const { sidebar } = await mountExpanded(request);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await settle(sidebar);
+    expect(request).toHaveBeenCalledTimes(6);
+    expect(sidebar.textContent).toContain("Refreshed 3");
+    expect(sidebar.sessionData.sessionCatalogs[0]?.hosts[0]?.nextCursor).toBe("page-4");
+  });
+
+  it.each(["success", "error"] as const)(
+    "accepts an already-issued manual Load More %s while hidden",
+    async (outcome) => {
+      const pending = deferred<SessionsCatalogListResult>();
+      const request = vi
+        .fn()
+        .mockResolvedValueOnce(page(1))
+        .mockResolvedValueOnce(page(2))
+        .mockResolvedValueOnce(page(3))
+        .mockReturnValueOnce(pending.promise);
+      const { sidebar } = await mountExpanded(request);
+      await loadMore(sidebar);
+      expect(request).toHaveBeenCalledTimes(4);
+      setVisibility("hidden");
+      pending.resolve(
+        outcome === "success" ? page(4, "Manual", "") : catalogErrorPage("Page failed"),
+      );
+      await settle(sidebar);
+      expect(sidebar.sessionData.loadingMoreSessionCatalogIds.size).toBe(0);
+      expect(request).toHaveBeenCalledTimes(4);
+      expect(sidebar.textContent).toContain("Original 3");
+      const host = sidebar.sessionData.sessionCatalogs[0]?.hosts[0];
+      if (outcome === "success") {
+        expect(sidebar.textContent).toContain("Manual 4");
+        expect(host?.nextCursor).toBeUndefined();
+      } else {
+        expect(host?.error?.message).toBe("Page failed");
+        expect(host?.nextCursor).toBe("page-4");
+      }
+    },
+  );
+
+  it("does not fetch another page after the sidebar unmounts", async () => {
+    const pending = deferred<SessionsCatalogListResult>();
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(page(1))
+      .mockResolvedValueOnce(page(2))
+      .mockResolvedValueOnce(page(3))
+      .mockReturnValueOnce(pending.promise);
+    const { sidebar, provider } = await mountExpanded(request);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(request).toHaveBeenCalledTimes(4);
+    provider.remove();
+    pending.resolve(page(1, "Retired"));
+    await settle(sidebar);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(request).toHaveBeenCalledTimes(4);
+  });
+
+  it("accepts a complete exhausted first page while hidden", async () => {
+    const pending = deferred<SessionsCatalogListResult>();
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(page(1))
+      .mockResolvedValueOnce(page(2))
+      .mockResolvedValueOnce(page(3))
+      .mockReturnValueOnce(pending.promise);
+    const { sidebar } = await mountExpanded(request);
+    await vi.advanceTimersByTimeAsync(30_000);
+    setVisibility("hidden");
+    pending.resolve(page(1, "Only remaining", ""));
+    await settle(sidebar);
+    expect(request).toHaveBeenCalledTimes(4);
+    expect(sidebar.textContent).toContain("Only remaining 1");
+    expect(sidebar.textContent).not.toContain("Original 3");
+    expect(sidebar.sessionData.sessionCatalogs[0]?.hosts[0]?.nextCursor).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Control UI tab continued fetching previously expanded catalog pages after the operator switched away from it.

## Why This Change Was Made

The existing visibility handler paused future polls, but an in-flight poll could still start every remaining page of its automatic refresh. Automatic pagination now checks visibility and current request ownership before each additional page, preserving the full previously displayed rows and cursor when it pauses.

## User Impact

Hidden tabs stop starting automatic catalog page requests. Returning to the tab uses the existing coalesced refresh to update the expanded list. Already-issued manual Load More outcomes, complete responses, polling intervals, and reconnect behavior are preserved.

## Evidence

- The actual sidebar fixture earns two pages through Load More. Baseline hiding during the base response starts two unwanted page requests; hiding during an expanded-page response starts one. Both regressions pass after the fix.
- All 370 focused and sibling tests pass, including retained rows/cursors, visible catch-up, hidden manual success/error outcomes, exhausted responses, unmount, progressive updates, and reconnect ownership.
- The production-built Control UI passes all three browser cases on commit `3091fa6861d732336fc90d139fb466a250958f7f`, using the same scenario that produced two baseline failures and one passing manual control.
- Independent P0–P2 review and the complete changed gate pass, including core/UI typechecks, all unused-export scans, lint, and styles.

The browser proof uses a synthetic Gateway and controlled document visibility. An initial harness attempt stopped before the race because its paused clock withheld mock response delivery; correcting that clock advancement produced the baseline and candidate results above. No production latency claim is made from these request counts.

The matched screenshots show the expanded list after hiding: the baseline continued replaying pages, while the fix retains the previous window until the visible catch-up.

![Before: automatic paging continues after hiding](https://github.com/user-attachments/assets/ce18d0ca-d77a-45a1-8d49-c0b6837acefe)

![After: expanded rows are retained until the tab returns](https://github.com/user-attachments/assets/30da7d64-5fab-4bf1-a94e-e14a647f8881)