### PR TITLE
fix(usage): release completed request payloads

### DIFF
--- a/ui/src/pages/usage/detail-controller.ts
+++ b/ui/src/pages/usage/detail-controller.ts
@@ -1,4 +1,3 @@
-import { initialState, Task, TaskStatus } from "@lit/task";
 import type { ReactiveControllerHost } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import {
@@ -14,6 +13,7 @@ import {
 } from "../../lib/sessions/usage.ts";
 import type { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { failUsageDetailRefresh } from "./detail-refresh.ts";
+import { createUsageRequest } from "./request.ts";
 import type { SessionLogEntry, UsageSessionEntry } from "./types.ts";
 
 function createUsageDetailRequest<T>(
@@ -24,13 +24,11 @@ function createUsageDetailRequest<T>(
 ) {
   let value: { sessionKey: string; data: T } | null = null;
   let status = createPanelRefreshStatus();
-  const task = new Task(host, {
-    autoRun: false,
-    args: (): readonly [GatewayBrowserClient | null, string] => [null, ""],
-    task: async ([client, sessionKey], { signal }) =>
-      client && sessionKey
-        ? { sessionKey, data: await request(client, sessionKey, signal) }
-        : initialState,
+  const task = createUsageRequest(host, {
+    task: async ([client, sessionKey]: readonly [GatewayBrowserClient, string], { signal }) => ({
+      sessionKey,
+      data: await request(client, sessionKey, signal),
+    }),
     onComplete: (result) => {
       value = result;
       status = completePanelRefresh();
@@ -44,10 +42,6 @@ function createUsageDetailRequest<T>(
     },
   });
 
-  const cancel = () => {
-    // A null-client run fences late completions while retaining the last displayed detail.
-    void task.run([null, ""]);
-  };
   return {
     get data() {
       return value?.data ?? null;
@@ -56,30 +50,30 @@ function createUsageDetailRequest<T>(
       return status;
     },
     get loading() {
-      return task.status === TaskStatus.PENDING;
+      return task.pending;
     },
     load(sessionKey: string): Promise<void> {
       const client = gateway.client;
       if (!client || !gateway.connected) {
         return Promise.resolve();
       }
-      const enabled = canLoad?.(sessionKey) !== false;
+      const enabled = Boolean(sessionKey) && canLoad?.(sessionKey) !== false;
       if (value?.sessionKey !== sessionKey || !enabled) {
         value = null;
         status = createPanelRefreshStatus();
       }
       if (!enabled) {
-        cancel();
+        task.cancel();
         return Promise.resolve();
       }
       status = beginPanelRefresh(status);
       return task.run([client, sessionKey]);
     },
-    cancel,
+    cancel: task.cancel,
     clear() {
       value = null;
       status = createPanelRefreshStatus();
-      cancel();
+      task.cancel();
     },
   };
 }

--- a/ui/src/pages/usage/export.ts
+++ b/ui/src/pages/usage/export.ts
@@ -1,4 +1,3 @@
-import { initialState, Task } from "@lit/task";
 import type { ReactiveControllerHost } from "lit";
 import { t } from "../../i18n/index.ts";
 import { downloadTextFile } from "../../lib/download.ts";
@@ -6,24 +5,20 @@ import { requestSessionUsage, type SessionUsageQuery } from "../../lib/sessions/
 import { showToast } from "../../lib/toast.ts";
 import type { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { currentLocalDate, toUsageErrorMessage } from "./helpers.ts";
+import { createUsageRequest } from "./request.ts";
 import type { UsageJsonExport, UsageSessionEntry } from "./types.ts";
 
 function sessionIdentity({ agentId, key }: UsageSessionEntry): string {
   return JSON.stringify([agentId, key]);
 }
 
-export function createUsageJsonExportTask(
+export function createUsageJsonExportRequest(
   host: ReactiveControllerHost,
   gateway: GatewayPageController,
   query: () => SessionUsageQuery,
 ) {
-  return new Task(host, {
-    autoRun: false,
-    args: (): readonly [UsageJsonExport | null] => [null],
-    task: async ([data], { signal }) => {
-      if (!data) {
-        return initialState;
-      }
+  return createUsageRequest(host, {
+    task: async (data: UsageJsonExport, { signal }) => {
       const connection = gateway.capture();
       if (!connection) {
         throw new Error(t("common.offline"));

--- a/ui/src/pages/usage/request.ts
+++ b/ui/src/pages/usage/request.ts
@@ -1,0 +1,53 @@
+import type { ReactiveControllerHost } from "lit";
+
+/** Requests publish into their display owner; completed payloads are never cached here. */
+export function createUsageRequest<Args, Value>(
+  host: Pick<ReactiveControllerHost, "requestUpdate">,
+  options: {
+    task: (args: Args, options: { signal: AbortSignal }) => Promise<Value>;
+    onComplete: (value: Value) => void;
+    onError: (error: unknown) => void;
+  },
+) {
+  let active: AbortController | null = null;
+  const settle = (request: AbortController, notify: () => void) => {
+    if (active !== request) {
+      return;
+    }
+    // Completion may immediately start a successor through the refresh policy.
+    active = null;
+    try {
+      notify();
+    } catch {
+      // Completion notifications retain the former Task's error isolation.
+    } finally {
+      host.requestUpdate();
+    }
+  };
+  return {
+    get pending() {
+      return active !== null;
+    },
+    cancel: () => {
+      const previous = active;
+      active = null;
+      previous?.abort();
+      host.requestUpdate();
+    },
+    async run(args: Args): Promise<void> {
+      const previous = active;
+      const request = new AbortController();
+      active = request;
+      previous?.abort();
+      host.requestUpdate();
+      let value: Value;
+      try {
+        value = await options.task(args, { signal: request.signal });
+      } catch (error) {
+        settle(request, () => options.onError(error));
+        return;
+      }
+      settle(request, () => options.onComplete(value));
+    },
+  };
+}

--- a/ui/src/pages/usage/types.ts
+++ b/ui/src/pages/usage/types.ts
@@ -11,17 +11,12 @@ import type {
   SessionsUsageTotals,
   SessionUsageTimePoint,
 } from "./data-types.ts";
-import type { ProviderUsageSnapshot, UsageSnapshotResult } from "./request-usage-snapshot.ts";
+import type { ProviderUsageSnapshot } from "./request-usage-snapshot.ts";
 
 export type UsageSessionEntry = SessionsUsageEntry;
 export type UsageTotals = SessionsUsageTotals;
 export type CostDailyEntry = CostUsageDailyEntry;
 export type UsageAggregates = SessionsUsageResult["aggregates"];
-
-export type UsageTaskValue = {
-  epoch: object;
-  snapshot: UsageSnapshotResult;
-};
 
 export type UsageContextDetail = {
   weight: UsageSessionEntry["contextWeight"];

--- a/ui/src/pages/usage/usage-page-details.test.ts
+++ b/ui/src/pages/usage/usage-page-details.test.ts
@@ -1,15 +1,18 @@
 /* @vitest-environment jsdom */
 
+import { queryObjects } from "node:v8";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionUsageTimeSeries } from "../../../../src/shared/session-usage-timeseries-types.js";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionsUsageResult } from "../../api/types.ts";
 import * as downloads from "../../lib/download.ts";
 import * as toast from "../../lib/toast.ts";
+import { collectGarbageForTest } from "../../test-helpers/garbage-collection.ts";
 import type { UsageSessionEntry } from "./types.ts";
 import {
   cacheSnapshot,
   cleanupUsagePageTest,
+  contextWithClient,
   createPage,
   deferred,
   focusDocument,
@@ -32,6 +35,124 @@ function contextWeight(name: string): NonNullable<UsageSessionEntry["contextWeig
 }
 
 describe("UsagePage detail requests", () => {
+  it("releases hydrated export reports after download while the page stays mounted", async () => {
+    class ExportReport {
+      name = "exported-context";
+      blockChars = 10;
+    }
+    let report: WeakRef<ExportReport> | undefined;
+    const snapshot = cacheSnapshot("sessions", "fresh");
+    const session = {
+      key: "agent:main:export-lifetime",
+      label: "Export lifetime",
+      agentId: "main",
+      hasContextWeight: true,
+      usage: snapshot.result.totals,
+    };
+    const request = async (method: string, params?: Record<string, unknown>) => {
+      if (method === "sessions.usage") {
+        const weight = params?.includeContextWeight
+          ? {
+              ...contextWeight("exported-context"),
+              skills: { promptChars: 10, entries: [new ExportReport()] },
+            }
+          : undefined;
+        if (weight) {
+          report = new WeakRef(weight.skills.entries[0]!);
+        }
+        return {
+          ...snapshot.result,
+          sessions: [{ ...session, ...(weight ? { contextWeight: weight } : {}) }],
+        };
+      }
+      return method === "usage.cost" ? snapshot.costSummary : { providers: [] };
+    };
+    const download = vi.spyOn(downloads, "downloadTextFile").mockImplementation(() => {});
+    const page = await createPage({ request } as unknown as GatewayBrowserClient, true);
+    await preloadUsage(page);
+    page
+      .querySelector(".usage-export-menu")!
+      .dispatchEvent(new CustomEvent("wa-select", { detail: { item: { value: "json" } } }));
+    await vi.waitFor(() => expect(download).toHaveBeenCalledOnce());
+    expect(download.mock.calls[0]![1]).toContain("exported-context");
+    const collectionControl = new WeakRef({ unowned: true });
+    await collectGarbageForTest(() => {
+      queryObjects(ExportReport);
+    });
+    expect(collectionControl.deref()).toBeUndefined();
+    expect(report).toBeDefined();
+    expect(report!.deref()).toBeUndefined();
+    expect(page.isConnected).toBe(true);
+  });
+
+  it("keeps cancelled details displayed and releases them on explicit clear", async () => {
+    class DetailPayload {
+      timestamp = 1;
+      totalTokens = 10;
+      role = "user";
+      content = "Selected session";
+    }
+    const payloads: WeakRef<DetailPayload>[] = [];
+    const request = async (method: string) => {
+      const payload = new DetailPayload();
+      payloads.push(new WeakRef(payload));
+      return method === "sessions.usage.logs" ? { logs: [payload] } : { points: [payload] };
+    };
+    const page = await createPage({ request } as unknown as GatewayBrowserClient);
+    await page.details.timeSeries.load("agent:main:detail-lifetime");
+    await page.details.sessionLogs.load("agent:main:detail-lifetime");
+    page.details.cancel();
+    const collectionControl = new WeakRef({ unowned: true });
+    await collectGarbageForTest(() => {
+      queryObjects(DetailPayload);
+    });
+    expect(collectionControl.deref()).toBeUndefined();
+    expect(payloads).toHaveLength(2);
+    expect(payloads.every((payload) => payload.deref() !== undefined)).toBe(true);
+    expect(page.details.timeSeries.data).not.toBeNull();
+    expect(page.details.sessionLogs.data).not.toBeNull();
+
+    page.details.clear();
+    await collectGarbageForTest(() => {
+      queryObjects(DetailPayload);
+    });
+    expect(payloads.every((payload) => payload.deref() === undefined)).toBe(true);
+    expect(page.details.timeSeries.data).toBeNull();
+    expect(page.details.sessionLogs.data).toBeNull();
+    expect(page.isConnected).toBe(true);
+  });
+
+  it("releases a loaded overview when its Gateway identity is replaced", async () => {
+    class OverviewPayload {
+      key = "agent:main:overview-lifetime";
+      usage = null;
+    }
+    let payload: WeakRef<OverviewPayload> | undefined;
+    const snapshot = cacheSnapshot("sessions", "fresh");
+    const request = async (method: string) => {
+      if (method === "sessions.usage") {
+        const report = new OverviewPayload();
+        payload = new WeakRef(report);
+        return { ...snapshot.result, sessions: [report] };
+      }
+      return method === "usage.cost" ? snapshot.costSummary : { providers: [] };
+    };
+    const page = await createPage({ request } as unknown as GatewayBrowserClient);
+    await page.loadUsage();
+    expect(payload).toBeDefined();
+    page.context = contextWithClient({
+      request: async () => ({}),
+    } as unknown as GatewayBrowserClient);
+    page.requestUpdate();
+    await page.updateComplete;
+    const collectionControl = new WeakRef({ unowned: true });
+    await collectGarbageForTest(() => {
+      queryObjects(OverviewPayload);
+    });
+    expect(collectionControl.deref()).toBeUndefined();
+    expect(payload!.deref()).toBeUndefined();
+    expect(page.isConnected).toBe(true);
+  });
   it("loads context only for the selected session and fences superseded replies through retry", async () => {
     const snapshot = cacheSnapshot("sessions", "fresh");
     const keys = ["agent:main:first", "agent:main:second", "global"];
@@ -383,27 +504,35 @@ describe("UsagePage detail requests", () => {
     expect(page.providerUsageStalled).toBe(false);
   });
 
-  it("commits only the latest time-series selection", async () => {
-    const first = deferred<SessionUsageTimeSeries>();
-    const second = deferred<SessionUsageTimeSeries>();
-    const request = vi.fn((_method: string, params: { key: string }) =>
-      params.key === "agent:main:a" ? first.promise : second.promise,
-    );
-    const page = await createPage({ request } as unknown as GatewayBrowserClient);
+  it.each(["resolve", "reject"])(
+    "commits only the latest time-series selection (%s)",
+    async (completion) => {
+      const first = deferred<SessionUsageTimeSeries>();
+      const second = deferred<SessionUsageTimeSeries>();
+      const request = vi.fn((_method: string, params: { key: string }) =>
+        params.key === "agent:main:a" ? first.promise : second.promise,
+      );
+      const page = await createPage({ request } as unknown as GatewayBrowserClient);
 
-    page.usageSelectedSessions = ["agent:main:a"];
-    const firstLoad = page.details.timeSeries.load("agent:main:a");
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
-    page.usageSelectedSessions = ["agent:main:b"];
-    const secondLoad = page.details.timeSeries.load("agent:main:b");
-    const latest = { points: [{ timestamp: 2 }] } as SessionUsageTimeSeries;
-    second.resolve(latest);
-    await secondLoad;
-    first.resolve({ points: [{ timestamp: 1 }] } as SessionUsageTimeSeries);
-    await firstLoad;
+      page.usageSelectedSessions = ["agent:main:a"];
+      const firstLoad = page.details.timeSeries.load("agent:main:a");
+      await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+      page.usageSelectedSessions = ["agent:main:b"];
+      const secondLoad = page.details.timeSeries.load("agent:main:b");
+      const latest = { points: [{ timestamp: 2 }] } as SessionUsageTimeSeries;
+      second.resolve(latest);
+      await secondLoad;
+      if (completion === "resolve") {
+        first.resolve({ points: [{ timestamp: 1 }] } as SessionUsageTimeSeries);
+      } else {
+        first.reject(new Error("superseded timeline failed"));
+      }
+      await firstLoad;
 
-    expect(page.details.timeSeries.data).toBe(latest);
-  });
+      expect(page.details.timeSeries.data).toBe(latest);
+      expect(page.details.timeSeries.status.error).toBeNull();
+    },
+  );
 
   it("retains stale time-series data until a retry succeeds", async () => {
     const retry = deferred<SessionUsageTimeSeries>();

--- a/ui/src/pages/usage/usage-page.test-support.ts
+++ b/ui/src/pages/usage/usage-page.test-support.ts
@@ -19,6 +19,7 @@ export type TestUsagePage = HTMLElement & {
   providerUsageSummary: { updatedAt: number; providers: unknown[] } | null;
   providerUsageUnavailable: boolean;
   loadUsage: () => Promise<void>;
+  requestUpdate: () => void;
   render: () => unknown;
   readonly updateComplete: Promise<boolean>;
 };

--- a/ui/src/pages/usage/usage-page.ts
+++ b/ui/src/pages/usage/usage-page.ts
@@ -1,5 +1,4 @@
 import { consume } from "@lit/context";
-import { initialState, Task, TaskStatus } from "@lit/task";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
@@ -21,7 +20,7 @@ import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { isUsageCacheIncomplete } from "./cache-status.ts";
 import type { ProviderUsageSummary } from "./data-types.ts";
 import { UsageDetailsController } from "./detail-controller.ts";
-import { createUsageJsonExportTask } from "./export.ts";
+import { createUsageJsonExportRequest } from "./export.ts";
 import {
   currentLocalDate,
   selectUsageSessionKeys,
@@ -35,12 +34,12 @@ import {
   type ProviderUsageSnapshot,
   requestUsageSnapshot,
 } from "./request-usage-snapshot.ts";
+import { createUsageRequest } from "./request.ts";
 import {
   DEFAULT_VISIBLE_COLUMNS,
   type SessionLogRole,
   type UsageProps,
   type UsageRouteData,
-  type UsageTaskValue,
 } from "./types.ts";
 import { renderUsage } from "./view.ts";
 
@@ -92,9 +91,6 @@ class UsagePage extends OpenClawLightDomElement {
 
   private dateDebounceTimer: number | null = null;
   private queryDebounceTimer: number | null = null;
-  // Invalidation runs the Task with a null client to supersede stale completions.
-  // Track real gateway work separately so that no-op runs cannot block reconnect retries.
-  private usageTaskActiveClient: GatewayBrowserClient | null = null;
   // The client survives transport reconnects, so retry budgets need a separate epoch.
   private connectionEpoch: object = {};
   private routeDataInitialized = false;
@@ -115,10 +111,9 @@ class UsagePage extends OpenClawLightDomElement {
         return;
       }
       this.refreshPolicy.interrupt();
-      this.usageTaskActiveClient = null;
-      void this.usageTask.run(this.usageTaskArgs(null));
+      this.usageRequest.cancel();
       this.details.cancel();
-      void this.usageExportTask.run([null]);
+      this.usageExportRequest.cancel();
     },
     onSnapshot: (change) => this.handleGatewaySnapshot(change),
     onPageActivation: () => this.refreshPolicy.request("focus"),
@@ -133,41 +128,26 @@ class UsagePage extends OpenClawLightDomElement {
     this.requestUpdate();
   });
 
-  private usageTaskArgs(client = this.gateway.connected ? this.gateway.client : null) {
-    return [
-      client,
-      this.usageLoadStartDate,
-      this.usageLoadEndDate,
-      this.usageScope,
-      this.usageTimeZone,
-      normalizeLowercaseStringOrEmpty(this.usageAgentId ?? "") || null,
-    ] as const;
-  }
-
-  private readonly usageTask = new Task(this, {
-    autoRun: false,
-    args: () => this.usageTaskArgs(),
-    task: async ([client, startDate, endDate, scope, timeZone, normalizedAgentId], { signal }) => {
-      if (!client) {
-        return initialState;
-      }
-      if (this.routeDataEnabled) {
-        return initialState;
-      }
+  private readonly usageRequest = createUsageRequest(this, {
+    task: async (client: GatewayBrowserClient, { signal }) => {
       this.refreshPolicy.beginLoad();
       const epoch = this.connectionEpoch;
-      const agentId = normalizedAgentId || undefined;
       return {
         epoch,
         snapshot: await requestUsageSnapshot(
           client,
-          { startDate, endDate, agentId, scope, timeZone },
+          {
+            startDate: this.usageLoadStartDate,
+            endDate: this.usageLoadEndDate,
+            scope: this.usageScope,
+            timeZone: this.usageTimeZone,
+            agentId: normalizeLowercaseStringOrEmpty(this.usageAgentId ?? "") || undefined,
+          },
           signal,
         ),
-      } satisfies UsageTaskValue;
+      };
     },
     onComplete: (value) => {
-      this.usageTaskActiveClient = null;
       const snapshot = value.snapshot;
       if (snapshot.ok) {
         this.usageResult = snapshot.value.result;
@@ -189,14 +169,13 @@ class UsagePage extends OpenClawLightDomElement {
       this.refreshPolicy.flushPending();
     },
     onError: (error) => {
-      this.usageTaskActiveClient = null;
       this.applyUsageError(error);
       this.applyUsageLoadState({ state: "pending" }, this.connectionEpoch, null);
       this.refreshPolicy.flushPending();
     },
   });
 
-  private readonly usageExportTask = createUsageJsonExportTask(this, this.gateway, () => ({
+  private readonly usageExportRequest = createUsageJsonExportRequest(this, this.gateway, () => ({
     startDate: this.usageLoadStartDate,
     endDate: this.usageLoadEndDate,
     scope: this.usageScope,
@@ -238,10 +217,9 @@ class UsagePage extends OpenClawLightDomElement {
     this.clearDateDebounce();
     this.clearQueryDebounce();
     this.refreshPolicy.dispose();
-    this.usageTaskActiveClient = null;
-    void this.usageTask.run(this.usageTaskArgs(null));
+    this.usageRequest.cancel();
     this.details.cancel();
-    void this.usageExportTask.run([null]);
+    this.usageExportRequest.cancel();
     super.disconnectedCallback();
   }
 
@@ -295,8 +273,7 @@ class UsagePage extends OpenClawLightDomElement {
 
   private resetForClientChange() {
     this.clearDateDebounce();
-    this.usageTaskActiveClient = null;
-    void this.usageTask.run(this.usageTaskArgs(null));
+    this.usageRequest.cancel();
     if (this.routeDataInitialized) {
       this.routeDataEnabled = false;
     }
@@ -359,7 +336,7 @@ class UsagePage extends OpenClawLightDomElement {
   }
 
   private get usageLoading(): boolean {
-    return !this.routeDataInitialized || this.usageTaskActiveClient !== null;
+    return !this.routeDataInitialized || this.usageRequest.pending;
   }
 
   private loadUsage(): Promise<void> {
@@ -368,14 +345,13 @@ class UsagePage extends OpenClawLightDomElement {
       this.refreshPolicy.markLoadDeferred();
       return Promise.resolve();
     }
-    // Filter changes must supersede active work; Task.run fences the old result
+    // Filter changes must supersede active work; the request fences the old result
     // so it cannot publish under the newly rendered query controls.
     this.routeDataEnabled = false;
     this.usageLoadStartDate = this.usageStartDate;
     this.usageLoadEndDate = this.usageEndDate;
     this.usageError = null;
-    this.usageTaskActiveClient = client;
-    return this.usageTask.run();
+    return this.usageRequest.run(client);
   }
 
   private clearSelections() {
@@ -391,7 +367,7 @@ class UsagePage extends OpenClawLightDomElement {
   }
 
   private clearSelectionsAndDetails() {
-    void this.usageExportTask.run([null]);
+    this.usageExportRequest.cancel();
     this.clearSelections();
     this.clearDetails();
   }
@@ -465,7 +441,7 @@ class UsagePage extends OpenClawLightDomElement {
     const props: UsageProps = {
       data: {
         loading: this.usageLoading,
-        exporting: this.usageExportTask.status === TaskStatus.PENDING,
+        exporting: this.usageExportRequest.pending,
         error: this.usageError,
         sessions: this.usageResult?.sessions ?? [],
         agents:
@@ -603,7 +579,7 @@ class UsagePage extends OpenClawLightDomElement {
         },
         display: {
           onExportJson: (data) => {
-            void this.usageExportTask.run([data]);
+            void this.usageExportRequest.run(data);
           },
           onChartModeChange: (mode) => (this.usageChartMode = mode),
           onDailyChartModeChange: (mode) => (this.usageDailyChartMode = mode),


### PR DESCRIPTION
Closes #140584

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Resolves a problem where the mounted Usage page retains completed JSON export context reports and discarded overview/detail responses after their visible owner has finished with them.

## Why This Change Was Made

Use one small invocation owner for Usage overview, detail and export requests. It retains the active AbortController, publishes completed data to the existing display owner, retires pending state before completion notifications, and fences superseded successes and errors. This removes the finished request's hidden argument/result retention and the overview's duplicate active-client marker.

## User Impact

Completed export reports and explicitly cleared details can be reclaimed while the Usage page remains open. Cancelling a detail refresh preserves the displayed data; later stale results cannot replace the current selection. JSON export still uses the clicked snapshot and validates Gateway identity before downloading.

This is bounded latest-result retention. No byte-size, general RSS, or accumulating-leak claim is made. The integration preserves #140573's concrete-session export identity check.

## Evidence

- A private combined-main proof preserved #140573 and passed all 14 complete detail-file tests, including its session-instance matrix and the lifetime cases. Candidate added/removed lines remain identical to the approved patch.
- All three lifetime regressions failed against original production at the retained WeakRefs while independent collection controls collected. All 31 focused Usage page/detail tests pass on the repair, including stale success/rejection, retries, permission failures, cancellation and identity changes.
- The complete changed-file check passed, including typechecks, lint, styles, catalogs and repository guards. Independent isolated P2 autoreview found no actionable findings; final source hashes match the reviewed candidate.
- A real Chromium mock-Gateway scenario verified the actual downloaded JSON after a filter change from Alpha to Beta during hydration and verified that cancelled late hydration causes no second download. No page errors occurred.
- Actual parsed browser RPC objects for the exported context report and cleared timeline, logs and context detail became collectible after retirement while the page remained mounted. Displayed details remained alive before Clear. The overview identity replacement is also covered at the actual page/controller boundary.
- The approved synthetic before/after overview captures below are byte-identical and demonstrate visible UI parity. Object collection is established by the separate real-page observations, not by screenshots.

Before and after: the Usage overview retains the same controls, metrics and layout.

![Before: synthetic Usage overview; visible UI parity only](https://github.com/user-attachments/assets/32b5c2ea-91c2-4bc4-b548-3021ce7dcfbe)

![After: synthetic Usage overview; visible UI parity only](https://github.com/user-attachments/assets/53d5c899-5721-4c4c-972d-d219f7200d95)