### PR TITLE
refactor(ai): share Responses function-tool assembly

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1486,7 +1486,7 @@ packages/ai/src/transports/openai-responses-compact-request.ts	2
 packages/ai/src/transports/openai-responses-continuation.ts	2
 packages/ai/src/transports/openai-responses-contracts.ts	1
 packages/ai/src/transports/openai-responses-debug.ts	12
-packages/ai/src/transports/openai-responses-params-internal.ts	11
+packages/ai/src/transports/openai-responses-params-internal.ts	10
 packages/ai/src/transports/openai-responses-payload-policy.ts	3
 packages/ai/src/transports/openai-responses-prompt-observer-internal.ts	2
 packages/ai/src/transports/openai-responses-replay-internal.ts	11

--- a/packages/ai/src/providers/openai-responses-tools.integration.test.ts
+++ b/packages/ai/src/providers/openai-responses-tools.integration.test.ts
@@ -1,0 +1,108 @@
+import { expect, it } from "vitest";
+import { configureAiTransportHost } from "../host.js";
+import { createLlmRuntime } from "../stream.js";
+import { createOpenAIResponsesTransportStreamFn } from "../transports/openai-responses-client.js";
+import {
+  createResponsesLoopbackServer,
+  responsesLoopbackModel,
+} from "../transports/openai-responses-loopback.test-support.js";
+import type { Context, Tool } from "../types.js";
+import { registerBuiltInApiProviders } from "./register-builtins.js";
+
+it.each(
+  (["provider", "transport"] as const).flatMap((entrypoint) =>
+    [true, false, undefined].map((strict) => ({ entrypoint, strict })),
+  ),
+)("serializes $entrypoint Responses tools with strict=$strict", async ({ entrypoint, strict }) => {
+  const server = await createResponsesLoopbackServer(() => [
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_tools",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            id: "msg_tools",
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "output_text", text: "done", annotations: [] }],
+          },
+        ],
+        usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+      },
+    },
+  ]);
+  configureAiTransportHost({ resolveOpenAIStrictToolSetting: () => strict });
+  const parameters = Object.freeze({
+    type: "object",
+    properties: Object.freeze({}),
+    required: Object.freeze([]),
+    additionalProperties: false,
+  });
+  let descriptionReads = 0;
+  const tools: Tool[] = [
+    { name: "zeta", description: "Last", parameters },
+    {
+      name: "alpha",
+      get description(): string {
+        descriptionReads += 1;
+        throw new Error("Optional description is unavailable");
+      },
+      parameters,
+    },
+  ];
+  const context: Context = {
+    messages: [{ role: "user", content: "hello", timestamp: 1 }],
+    tools,
+  };
+  const expectedTools = [
+    { type: "function", name: "alpha", parameters, ...(strict !== undefined ? { strict } : {}) },
+    {
+      type: "function",
+      name: "zeta",
+      description: "Last",
+      parameters,
+      ...(strict !== undefined ? { strict } : {}),
+    },
+  ];
+  const lifecycle: string[] = [];
+  const options = {
+    apiKey: "synthetic-key",
+    cacheRetention: "none" as const,
+    transport: "sse" as const,
+    onPayload: () => {
+      lifecycle.push("payload");
+    },
+    onResponse: () => {
+      lifecycle.push("response");
+    },
+  };
+  try {
+    const runtime = createLlmRuntime();
+    registerBuiltInApiProviders(runtime.registry);
+    const stream =
+      entrypoint === "provider"
+        ? runtime.stream(responsesLoopbackModel, context, options)
+        : await createOpenAIResponsesTransportStreamFn()(responsesLoopbackModel, context, options);
+    for await (const event of stream) {
+      if (event.type === "start" || event.type === "done" || event.type === "error") {
+        lifecycle.push(event.type);
+      }
+    }
+    const result = await stream.result();
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toEqual([expect.objectContaining({ type: "text", text: "done" })]);
+    expect(result.usage).toMatchObject({ input: 5, output: 3, totalTokens: 8 });
+    expect(lifecycle).toEqual(["payload", "response", "start", "done"]);
+    expect(server.requests).toHaveLength(1);
+    expect(server.requests[0]?.tools).toEqual(expectedTools);
+    expect(server.rawRequests[0]).toContain(`"tools":${JSON.stringify(expectedTools)}`);
+    expect(descriptionReads).toBe(1);
+    expect(tools.map((tool) => tool.name)).toEqual(["zeta", "alpha"]);
+    expect(tools.every((tool) => tool.parameters === parameters)).toBe(true);
+  } finally {
+    configureAiTransportHost({});
+    await server.close();
+  }
+});

--- a/packages/ai/src/providers/openai-responses-tools.ts
+++ b/packages/ai/src/providers/openai-responses-tools.ts
@@ -1,6 +1,6 @@
 // OpenAI Responses tool helpers convert runtime tools to Responses API schemas.
 import { createHash } from "node:crypto";
-import type { Tool as OpenAITool } from "openai/resources/responses/responses.js";
+import type { FunctionTool } from "openai/resources/responses/responses.js";
 import { getAiTransportHost } from "../host.js";
 import type { Model, Tool } from "../types.js";
 import { sortPromptCacheToolsByName } from "../utils/prompt-cache-stability.js";
@@ -29,7 +29,7 @@ type ResponsesFunctionTool = {
 
 type ConvertedResponsesTools = {
   projection: OpenAIToolProjection;
-  tools: OpenAITool[];
+  tools: FunctionTool[];
 };
 
 // Converts OpenClaw tool schemas to OpenAI Responses tools, including strict-mode compatibility.
@@ -69,7 +69,8 @@ export function convertResponsesToolPayload(
     if (strict !== undefined) {
       result.strict = strict;
     }
-    return result as OpenAITool;
+    // Compatible endpoints can require strict to be absent; the SDK declares it required.
+    return result as FunctionTool;
   });
   return { projection, tools: convertedTools };
 }

--- a/packages/ai/src/providers/openai-responses-tools.ts
+++ b/packages/ai/src/providers/openai-responses-tools.ts
@@ -41,10 +41,19 @@ const loggedStrictToolDowngradeDiagnosticKeys = new Set<string>();
 export function convertResponsesToolPayload(
   tools: Tool[],
   options?: ConvertResponsesToolsOptions,
+  resolveStrict?: (
+    projection: OpenAIToolProjection,
+    setting: boolean | null | undefined,
+  ) => boolean | undefined,
 ): ConvertedResponsesTools {
   const projection = projectOpenAITools(tools);
-  const strictSetting = resolveResponsesStrictToolSetting(options);
-  const strict = resolveResponsesStrictToolFlag(projection, strictSetting, options?.model);
+  const strict = resolveStrict
+    ? resolveStrict(projection, options?.strict)
+    : resolveResponsesStrictToolFlag(
+        projection,
+        resolveResponsesStrictToolSetting(options),
+        options?.model,
+      );
   // Sort tools before request construction so prompt-cache bytes stay deterministic.
   const convertedTools = sortPromptCacheToolsByName(projection.tools).map((tool) => {
     const result: ResponsesFunctionTool = {

--- a/packages/ai/src/transports/openai-responses-loopback.test-support.ts
+++ b/packages/ai/src/transports/openai-responses-loopback.test-support.ts
@@ -20,9 +20,11 @@ export const responsesLoopbackModel = {
 
 export async function createResponsesLoopbackServer(events: (turn: number) => unknown[]) {
   const requests: Array<Record<string, unknown>> = [];
+  const rawRequests: string[] = [];
   const authorization: Array<string | undefined> = [];
   let connections = 0;
   const eventsForRequest = (body: string) => {
+    rawRequests.push(body);
     requests.push(JSON.parse(body) as Record<string, unknown>);
     return events(requests.length);
   };
@@ -79,6 +81,7 @@ export async function createResponsesLoopbackServer(events: (turn: number) => un
     });
   return {
     requests,
+    rawRequests,
     authorization,
     get connections() {
       return connections;

--- a/packages/ai/src/transports/openai-responses-params-internal.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.ts
@@ -1,7 +1,6 @@
 import type { Context, Model } from "@openclaw/llm-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type {
-  FunctionTool,
   ResponseFormatTextConfig,
   ResponseInput,
 } from "openai/resources/responses/responses.js";
@@ -13,12 +12,8 @@ import {
   supportsOpenAITemperature,
   type OpenAIApiReasoningEffort,
 } from "../providers/openai-reasoning-effort.js";
-import {
-  projectOpenAITools,
-  reconcileOpenAIResponsesToolChoice,
-  type OpenAIToolProjection,
-} from "../providers/openai-tool-projection.js";
-import { normalizeOpenAIStrictToolParameters } from "../providers/openai-tool-schema.js";
+import { convertResponsesToolPayload } from "../providers/openai-responses-tools.js";
+import { reconcileOpenAIResponsesToolChoice } from "../providers/openai-tool-projection.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
 import { resolveOpenAIStrictToolSetting } from "./host-policy.js";
 import type { OpenAIResponsesReplayMode } from "./openai-responses-compaction-replay.js";
@@ -41,11 +36,7 @@ import {
   resolveOpenAIStrictToolFlagWithDiagnostics,
   usesNativeOpenAICodexResponsesBackend,
 } from "./openai-transport-params.js";
-import {
-  resolvePromptCacheKey,
-  sortTransportToolsByName,
-  type OpenAIModeModel,
-} from "./openai-transport-shared.js";
+import { resolvePromptCacheKey, type OpenAIModeModel } from "./openai-transport-shared.js";
 import { sanitizeTransportPayloadText } from "./transport-stream-shared.js";
 
 const OPENAI_RESPONSES_TOOL_CALL_PROVIDERS = new Set([
@@ -54,37 +45,6 @@ const OPENAI_RESPONSES_TOOL_CALL_PROVIDERS = new Set([
   "azure-openai-responses",
   "github-copilot",
 ]);
-
-function convertResponsesTools(
-  tools: NonNullable<Context["tools"]>,
-  model: OpenAIModeModel,
-  options?: { strict?: boolean | null },
-): { projection: OpenAIToolProjection; tools: FunctionTool[] } {
-  const projection = projectOpenAITools(tools);
-  const strict = resolveOpenAIStrictToolFlagWithDiagnostics(projection, options?.strict, {
-    transport: "responses",
-    model,
-  });
-  return {
-    projection,
-    tools: sortTransportToolsByName(projection.tools).map((tool): FunctionTool => {
-      const result = {
-        type: "function" as const,
-        name: tool.name,
-        description: tool.description,
-        parameters: normalizeOpenAIStrictToolParameters(
-          tool.parameters,
-          strict === true,
-          model.compat,
-        ),
-      } as FunctionTool;
-      if (strict !== undefined) {
-        result.strict = strict;
-      }
-      return result;
-    }),
-  };
-}
 
 function resolveOpenAIReasoningEffort(
   options: OpenAIResponsesOptions | undefined,
@@ -339,11 +299,20 @@ export function buildOpenAIResponsesParams(
     params.service_tier = options.serviceTier;
   }
   if (context.tools) {
-    const converted = convertResponsesTools(context.tools, model as OpenAIModeModel, {
-      strict: resolveOpenAIStrictToolSetting(model as OpenAIModeModel, {
-        transport: "stream",
-      }),
-    });
+    const converted = convertResponsesToolPayload(
+      context.tools,
+      {
+        model,
+        strict: resolveOpenAIStrictToolSetting(model as OpenAIModeModel, {
+          transport: "stream",
+        }),
+      },
+      (projection, setting) =>
+        resolveOpenAIStrictToolFlagWithDiagnostics(projection, setting, {
+          transport: "responses",
+          model: model as OpenAIModeModel,
+        }),
+    );
     if (
       converted.tools.length > 0 ||
       (converted.projection.inputToolCount === 0 && converted.projection.diagnostics.length === 0)


### PR DESCRIPTION
Closes #140590

## What Problem This Solves

The built-in and managed OpenAI Responses adapters independently assemble the same function-tool payload, creating two places where schema conversion and prompt-cache bytes can drift.

## Why This Change Was Made

Use the existing Responses converter for both entrypoints and remove the managed adapter's private converter. A private strict-policy callback keeps transport diagnostics and evaluation order with their current owner. Tool-choice, empty-tool handling, cache policy, reasoning, and stream lifecycle are unchanged.

## User Impact

No intentional behavior change. Responses function tools now have one serialization owner, with strictly less production code. Chat Completions and Anthropic policies are unchanged.

## Evidence

- 137 existing baseline tests and 6 new real-SDK loopback cases passed before the production refactor.
- 208 provider, Azure, ChatGPT tool, continuation, and response-hook tests passed after consolidation.
- The loopback cases assert serialized tool bytes and strict=true/false/omitted, deterministic order, one read of an unreadable optional description, input preservation, hook order, and successful terminal output. Existing continuation cases exercise real SSE and cached WebSockets.
- Production delta: 32 added, 53 deleted, net -21. Test/support: +111/-0; assertion baseline: +1/-1. Test/support additions are counted separately.
- Independent P2 review completed. The final review confirmed the corrected working tree; its index-only type finding was resolved by staging that exact correction. The 208-test cohort passed again after the positional callback cleanup.
- Initial CI exposed the converter's overly broad tool return type and the required assertion-baseline shrink. The converter now returns only FunctionTool[]; local core typechecking and the assertion ratchet pass.
- [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34074431657) for `9982b24a7156bdc9ec32e6861ddcb19848e33ca2`, including build artifacts and the previously failing type/lint/boundary/ratchet checks. Supplementary local build/test-type and Testbox changed-code runs were stopped as redundant after the full exact-head hosted proof and landing completed; they are not counted as passing local gates. The final supplementary Testbox run passed baseline/format/package guards and core production types before it was stopped during core test-type preparation.

No billable vendor requests or production sessions were used.
