### PR TITLE
refactor(plugin-sdk): simplify approval forwarding mode resolution

### DIFF
--- a/src/plugin-sdk/approval-native-helpers.ts
+++ b/src/plugin-sdk/approval-native-helpers.ts
@@ -416,12 +416,6 @@ function resolveApprovalForwardingConfig(params: {
     : params.cfg.approvals?.exec;
 }
 
-function normalizeApprovalForwardingMode(
-  mode: ExecApprovalForwardingConfig["mode"] | undefined,
-): ExecApprovalForwardingMode {
-  return mode ?? "session";
-}
-
 function approvalModeIncludesSession(mode: ExecApprovalForwardingMode): boolean {
   return mode === "session" || mode === "both";
 }
@@ -542,8 +536,7 @@ function isExplicitTargetApprovalEligibleViaForwarding(
 export function createChannelApprovalForwardingEvaluator(
   params: ChannelApprovalForwardingEvaluatorParams,
 ) {
-  const resolveForwardingMode = (config: ExecApprovalForwardingConfig) =>
-    normalizeApprovalForwardingMode(config.mode);
+  const resolveForwardingMode = (config: ExecApprovalForwardingConfig) => config.mode ?? "session";
 
   const isPotentialRoute = (input: ChannelApprovalPotentialRouteParams): boolean => {
     return canApprovalPotentiallyRoute({
@@ -604,22 +597,14 @@ export function createChannelApprovalForwardingEvaluator(
   };
 }
 
-function normalizeApprovalForwardingModeWithDefault(params: {
-  config: ExecApprovalForwardingConfig;
-  defaultForwardingMode: ExecApprovalForwardingMode;
-}): ExecApprovalForwardingMode {
-  return params.config.mode ?? params.defaultForwardingMode;
-}
-
 /** Create the standard route gates for native channel approval forwarding. */
 export function createNativeApprovalChannelRouteGates<TTarget extends NativeApprovalTarget>(
   params: NativeApprovalChannelRouteGateParams<TTarget>,
 ): NativeApprovalChannelRouteGates {
-  const resolveForwardingMode = (config: ExecApprovalForwardingConfig) =>
-    normalizeApprovalForwardingModeWithDefault({
-      config,
-      defaultForwardingMode: params.defaultForwardingMode,
-    });
+  const resolveForwardingMode = (config: ExecApprovalForwardingConfig) => {
+    const defaultForwardingMode = params.defaultForwardingMode;
+    return config.mode ?? defaultForwardingMode;
+  };
 
   const targetsMatch =
     params.targetsMatch ??


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Native approval routing keeps two private one-use mode relays around its existing public factories. This is the maintainer-requested cleanup follow-up to #140415 in the #135868 split campaign; it extracts no recovery feature content.

## Why This Change Was Made

Resolve the same mode in each factory's existing local closure. The generic evaluator retains its session default. The native resolver still reads the caller's current default once before reading config.mode on every admitted invocation, preserving accessor order, errors, and changes between calls.

The removed functions have only their local callers and no public export. Public factory types, approval families, admission, filters, account binding, target matching, and fallback suppression remain unchanged.

## User Impact

No intended behavior change. Session, explicit-target, and combined forwarding keep the same defaults and routing decisions. This adds no SDK capability, setting, or authority path.

## Evidence

- All 86 unchanged tests passed before and after across both SDK owners and Slack, Google Chat, and Microsoft Teams approval consumers.
- A temporary comparison uses the complete old and actual new owners with real shared helpers: 1,484 paired factory scenarios and 8,022 public calls per version match results, callback/getter order, controlled mutations, and 29 propagated sentinel errors. Mutants that lazily read the default or capture it at factory construction are detected by independent result/order anchors. No approval was sent or command executed.
- Independent Codex local and committed-branch reviews found no actionable P0–P2 issues. The full clean Linux `node scripts/check-changed.mjs` plan passed in 1,065.87 seconds, including all four type lanes, SDK export/surface checks, full extension lint, zero dead exports, and zero runtime cycles. All 20 recorded inputs and tracked status remained unchanged. Full `pnpm build` passed in 193.76 seconds. Both commands ran on Blacksmith Testbox ([run 34072265380](https://github.com/openclaw/openclaw/actions/runs/34072265380), stopped lease `tbx_01m1wprtw3kna6pzka15dffpr2`).

Production +5/−20, net −15; one runtime file, 975→960 lines. Tests, tooling, docs, and baselines unchanged. The existing max-lines entry remains because the owner is still oversized.

Final landing refresh rebased onto `44f047f9b60`. All 20 recorded test/build inputs and all 10 paired-proof dependency hashes remained unchanged, including the lockfile. All 86 focused tests passed again in 374.53 seconds, and fresh branch Codex autoreview remained scoped-clean through P2. The full Linux check/build evidence above remains bound to unchanged inputs; final exact-head CI is required before native landing.

ClawSweeper [reviewed the patch](https://github.com/openclaw/openclaw/pull/140596#issuecomment-5563892051) with no actionable correctness finding and no requested pre-merge or rank-up work. No review finding was skipped.
