### PR TITLE
fix(plugins): reduce bundled catalog lookup overhead

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3394,7 +3394,6 @@ src/plugins/memory-runtime.ts	1
 src/plugins/module-export.ts	2
 src/plugins/native-module-require.ts	3
 src/plugins/official-external-plugin-catalog-snapshot-store.ts	4
-src/plugins/official-external-plugin-targets.ts	1
 src/plugins/official-external-provider-endpoints.ts	1
 src/plugins/openai-compatible-embedding-provider.ts	2
 src/plugins/plugin-cache-primitives.ts	1

--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -747,7 +747,6 @@ src/plugins/manifest-registry.ts
 src/plugins/marketplace.test.ts
 src/plugins/marketplace.ts
 src/plugins/official-external-plugin-catalog.test.ts
-src/plugins/official-external-plugin-catalog.ts
 src/plugins/plugin-registry-snapshot.test.ts
 src/plugins/provider-runtime.test.ts
 src/plugins/provider-runtime.ts

--- a/src/claws/package-remove.ts
+++ b/src/claws/package-remove.ts
@@ -1,6 +1,6 @@
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
 import { runPluginUninstallCommand } from "../cli/plugins-uninstall-command.js";
-import { normalizeClawHubSha256Integrity } from "../infra/clawhub-artifacts.js";
+import { normalizeClawHubSha256Integrity } from "../infra/clawhub-integrity.js";
 import { resolveInstalledClawHubPlugin } from "../plugins/plugin-install-preflight.js";
 import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
 import {

--- a/src/claws/package-resume.ts
+++ b/src/claws/package-resume.ts
@@ -1,5 +1,5 @@
 import { stableStringify } from "@openclaw/normalization-core";
-import { normalizeClawHubSha256Integrity } from "../infra/clawhub-artifacts.js";
+import { normalizeClawHubSha256Integrity } from "../infra/clawhub-integrity.js";
 import {
   openExistingOpenClawStateDatabaseReadOnly,
   type OpenClawStateDatabaseOptions,

--- a/src/claws/packages.ts
+++ b/src/claws/packages.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { coerceErrorMessage, stableStringify } from "@openclaw/normalization-core";
 import { runPluginInstallCommand } from "../cli/plugins-install-command.js";
 import { runPluginUninstallCommand } from "../cli/plugins-uninstall-command.js";
-import { normalizeClawHubSha256Integrity } from "../infra/clawhub-artifacts.js";
+import { normalizeClawHubSha256Integrity } from "../infra/clawhub-integrity.js";
 import { installPluginFromClawHub } from "../plugins/clawhub.js";
 import { PLUGIN_ARTIFACT_ADAPTER_IDENTITY } from "../plugins/install-artifact-inspection.js";
 import {

--- a/src/infra/clawhub-artifacts.test.ts
+++ b/src/infra/clawhub-artifacts.test.ts
@@ -10,9 +10,8 @@ import {
   downloadClawHubPackageArchive,
   downloadClawHubSkillArchive,
   downloadClawHubSkillArchiveUrl,
-  normalizeClawHubSha256Integrity,
-  normalizeClawHubSha256Hex,
 } from "./clawhub-artifacts.js";
+import { normalizeClawHubSha256Integrity, normalizeClawHubSha256Hex } from "./clawhub-integrity.js";
 import * as privateTempWorkspace from "./private-temp-workspace.js";
 
 const tempDirs = createTrackedTempDirs();

--- a/src/infra/clawhub-artifacts.ts
+++ b/src/infra/clawhub-artifacts.ts
@@ -2,10 +2,7 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   createClawHubError,
   readClawHubBytes,
@@ -13,6 +10,7 @@ import {
   resolveClawHubBaseUrl,
   type ClawHubFetch,
 } from "./clawhub-client.js";
+import { normalizeClawHubSha256Hex } from "./clawhub-integrity.js";
 import { sha256Base64, sha256Hex } from "./crypto-digest.js";
 import { createTempDownloadTarget } from "./temp-download.js";
 
@@ -90,43 +88,6 @@ async function stageClawHubArchive(params: {
     await target.cleanup().catch(() => undefined);
     throw error;
   }
-}
-
-/** Normalizes ClawHub SHA-256 metadata into Subresource Integrity format. */
-export function normalizeClawHubSha256Integrity(value: string): string | null {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-  const prefixedBase64 = /^sha256-([A-Za-z0-9+/]+={0,1})$/.exec(trimmed);
-  if (prefixedBase64?.[1]) {
-    try {
-      const decoded = Buffer.from(prefixedBase64[1], "base64");
-      if (decoded.length === 32) {
-        return `sha256-${decoded.toString("base64")}`;
-      }
-    } catch {
-      return null;
-    }
-    return null;
-  }
-  const prefixedHex = /^sha256:([A-Fa-f0-9]{64})$/.exec(trimmed);
-  if (prefixedHex?.[1]) {
-    return `sha256-${Buffer.from(prefixedHex[1], "hex").toString("base64")}`;
-  }
-  if (/^[A-Fa-f0-9]{64}$/.test(trimmed)) {
-    return `sha256-${Buffer.from(trimmed, "hex").toString("base64")}`;
-  }
-  return null;
-}
-
-/** Normalizes ClawHub SHA-256 metadata into lowercase hex form. */
-export function normalizeClawHubSha256Hex(value: string): string | null {
-  const trimmed = value.trim();
-  if (!/^[A-Fa-f0-9]{64}$/.test(trimmed)) {
-    return null;
-  }
-  return normalizeLowercaseStringOrEmpty(trimmed);
 }
 
 export async function downloadClawHubPackageArchive(params: {

--- a/src/infra/clawhub-integrity.ts
+++ b/src/infra/clawhub-integrity.ts
@@ -1,0 +1,38 @@
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+
+/** Normalizes ClawHub SHA-256 metadata into Subresource Integrity format. */
+export function normalizeClawHubSha256Integrity(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const prefixedBase64 = /^sha256-([A-Za-z0-9+/]+={0,1})$/.exec(trimmed);
+  if (prefixedBase64?.[1]) {
+    try {
+      const decoded = Buffer.from(prefixedBase64[1], "base64");
+      if (decoded.length === 32) {
+        return `sha256-${decoded.toString("base64")}`;
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  }
+  const prefixedHex = /^sha256:([A-Fa-f0-9]{64})$/.exec(trimmed);
+  if (prefixedHex?.[1]) {
+    return `sha256-${Buffer.from(prefixedHex[1], "hex").toString("base64")}`;
+  }
+  if (/^[A-Fa-f0-9]{64}$/.test(trimmed)) {
+    return `sha256-${Buffer.from(trimmed, "hex").toString("base64")}`;
+  }
+  return null;
+}
+
+/** Normalizes ClawHub SHA-256 metadata into lowercase hex form. */
+export function normalizeClawHubSha256Hex(value: string): string | null {
+  const trimmed = value.trim();
+  if (!/^[A-Fa-f0-9]{64}$/.test(trimmed)) {
+    return null;
+  }
+  return normalizeLowercaseStringOrEmpty(trimmed);
+}

--- a/src/plugins/clawhub.ts
+++ b/src/plugins/clawhub.ts
@@ -18,17 +18,17 @@ import {
   DEFAULT_MAX_ENTRY_BYTES,
   loadZipArchiveWithPreflight,
 } from "../infra/archive.js";
-import {
-  downloadClawHubPackageArchive,
-  normalizeClawHubSha256Integrity,
-  normalizeClawHubSha256Hex,
-} from "../infra/clawhub-artifacts.js";
+import { downloadClawHubPackageArchive } from "../infra/clawhub-artifacts.js";
 import {
   ClawHubRequestError,
   isDefaultClawHubBaseUrl,
   resolveClawHubBaseUrl,
 } from "../infra/clawhub-client.js";
 import { checkClawHubPackageTrust } from "../infra/clawhub-install-trust.js";
+import {
+  normalizeClawHubSha256Integrity,
+  normalizeClawHubSha256Hex,
+} from "../infra/clawhub-integrity.js";
 import {
   fetchClawHubPackageArtifact,
   fetchClawHubPackageDetail,

--- a/src/plugins/official-external-plugin-bundled-catalogs.test.ts
+++ b/src/plugins/official-external-plugin-bundled-catalogs.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getOfficialExternalPluginCatalogEntry,
+  getOfficialExternalPluginCatalogEntryForPackage,
+  isOfficialExternalPluginId,
+  listOfficialExternalChannelCatalogEntries,
+  listOfficialExternalPluginCatalogEntries,
+  listOfficialExternalProviderCatalogEntries,
+  resolveOfficialExternalProviderContractPluginIds,
+  resolveOfficialExternalProviderPluginIds,
+} from "./official-external-plugin-catalog.js";
+import type { OfficialExternalPluginCatalogEntry } from "./official-external-plugin-catalog.types.js";
+import {
+  hasOfficialExternalChannelTarget,
+  hasOfficialExternalContractTarget,
+  hasOfficialExternalProviderTarget,
+  hasOfficialExternalWebContractEnvTarget,
+  hasOfficialExternalWebSearchTarget,
+} from "./official-external-plugin-targets.js";
+
+const fixtures = vi.hoisted(() => {
+  // Plugin-lane setup can import the real catalog before this file's JSON mocks.
+  vi.resetModules();
+  const winner = {
+    name: " @fixture/Shared ",
+    kind: " plugin ",
+    openclaw: {
+      plugin: { id: " Shared " },
+      channel: { id: "Channel" },
+      providers: [{ id: " Model ", aliases: [" Alias "] }],
+      contracts: { embeddingProviders: [" Capability "] },
+    },
+  };
+  function targetEntry(id: string, prefix: string): OfficialExternalPluginCatalogEntry {
+    return {
+      name: `@fixture/${prefix}`,
+      kind: "plugin",
+      openclaw: {
+        plugin: { id },
+        channel: {
+          id: `${prefix}-channel`,
+          label: prefix,
+          configuredState: { env: { allOf: [`${prefix}_CHANNEL_KEY`] } },
+        },
+        providers: [{ id: `${prefix}-model`, envVars: [`${prefix}_MODEL_KEY`] }],
+        contracts: {
+          embeddingProviders: [`${prefix}-embedding`],
+          webFetchProviders: [`${prefix}-web`],
+        },
+        webSearchProviders: [{ id: `${prefix}-web`, envVars: [`${prefix}_WEB_KEY`] }],
+      },
+    };
+  }
+  const rejected = {
+    ...targetEntry("SourceFiltered", "rejected"),
+    install: { candidates: [{ sourceRef: "unconfigured-source", package: "@fixture/rejected" }] },
+  };
+  const accepted = {
+    name: "@fixture/accepted",
+    openclaw: { plugin: { id: "SourceFiltered" } },
+    install: { candidates: [{ sourceRef: "public-npm", package: "@fixture/accepted" }] },
+  };
+  const shadow = targetEntry("Shared", "shadow");
+  const pluginShadow = { name: "@fixture/plugin-shadow", openclaw: { plugin: { id: "Shared" } } };
+  const otherKind = {
+    name: "@fixture/other-kind",
+    kind: "channel",
+    openclaw: { plugin: { id: "Shared" } },
+  };
+  const lowercase = { name: "@fixture/shared", openclaw: { plugin: { id: "shared" } } };
+  const fallback = { id: "FallbackOnly", name: "@fixture/fallback" };
+  const mutable: OfficialExternalPluginCatalogEntry = {
+    name: "@fixture/mutable",
+    openclaw: { plugin: { id: "Mutable" }, providers: [{ id: "OriginalProvider" }] },
+  };
+  return {
+    winner,
+    rejected,
+    accepted,
+    shadow,
+    otherKind,
+    lowercase,
+    fallback,
+    mutable,
+    channelCatalog: { entries: [rejected, winner, otherKind] },
+    providerCatalog: { entries: [shadow, accepted, lowercase] },
+    pluginCatalog: { entries: [pluginShadow, fallback, mutable] },
+  };
+});
+
+vi.mock("../../scripts/lib/official-external-channel-catalog.json", () => ({
+  default: fixtures.channelCatalog,
+}));
+vi.mock("../../scripts/lib/official-external-provider-catalog.json", () => ({
+  default: fixtures.providerCatalog,
+}));
+vi.mock("../../scripts/lib/official-external-plugin-catalog.json", () => ({
+  default: fixtures.pluginCatalog,
+}));
+
+describe("bundled official external catalog behavior", () => {
+  it("keeps the first matching kind and exact identity across catalog sources", () => {
+    expect(listOfficialExternalPluginCatalogEntries()).toEqual([
+      fixtures.winner,
+      fixtures.otherKind,
+      fixtures.accepted,
+      fixtures.lowercase,
+      fixtures.fallback,
+      fixtures.mutable,
+    ]);
+    expect(getOfficialExternalPluginCatalogEntry("Shared")).toBe(fixtures.winner);
+    expect(
+      getOfficialExternalPluginCatalogEntryForPackage("@fixture/plugin-shadow"),
+    ).toBeUndefined();
+  });
+
+  it("rejects unconfigured source references before selecting a duplicate or lookup match", () => {
+    expect(getOfficialExternalPluginCatalogEntry("SourceFiltered")).toBe(fixtures.accepted);
+    expect(getOfficialExternalPluginCatalogEntry("rejected-model")).toBeUndefined();
+    expect(getOfficialExternalPluginCatalogEntryForPackage("@fixture/rejected")).toBeUndefined();
+    expect(
+      resolveOfficialExternalProviderPluginIds({ providerIds: new Set(["rejected-model"]) }),
+    ).toEqual([]);
+  });
+
+  it("keeps exact lookup identities separate from lowercase canonical and provider queries", () => {
+    expect(getOfficialExternalPluginCatalogEntry(" Shared ")).toBe(fixtures.winner);
+    expect(getOfficialExternalPluginCatalogEntry("shared")).toBe(fixtures.lowercase);
+    expect(getOfficialExternalPluginCatalogEntry("SHARED")).toBeUndefined();
+    expect(getOfficialExternalPluginCatalogEntry(" Alias ")).toBe(fixtures.winner);
+    expect(getOfficialExternalPluginCatalogEntry("alias")).toBeUndefined();
+    expect(getOfficialExternalPluginCatalogEntryForPackage(" @fixture/Shared ")).toBe(
+      fixtures.winner,
+    );
+    expect(getOfficialExternalPluginCatalogEntryForPackage("@fixture/SHARED")).toBeUndefined();
+    expect(isOfficialExternalPluginId(" SHARED ")).toBe(true);
+    expect(isOfficialExternalPluginId("Alias")).toBe(false);
+    expect(isOfficialExternalPluginId("fallbackonly")).toBe(true);
+    expect(getOfficialExternalPluginCatalogEntry("FallbackOnly")).toBeUndefined();
+    expect(resolveOfficialExternalProviderPluginIds({ providerIds: new Set([" ALIAS "]) })).toEqual(
+      ["Shared"],
+    );
+    expect(
+      resolveOfficialExternalProviderContractPluginIds({
+        contract: "embeddingProviders",
+        providerIds: new Set([" capability "]),
+      }),
+    ).toEqual(["Shared"]);
+  });
+
+  it.each([
+    ["plugin", listOfficialExternalPluginCatalogEntries],
+    ["channel", listOfficialExternalChannelCatalogEntries],
+    ["provider", listOfficialExternalProviderCatalogEntries],
+  ] as const)("returns independent %s arrays with shared row identities", (_kind, list) => {
+    const first = list();
+    const second = list();
+    expect(first).not.toBe(second);
+    expect(first[0]).toBe(fixtures.winner);
+    expect(second[0]).toBe(fixtures.winner);
+    first.length = 0;
+    expect(list()[0]).toBe(fixtures.winner);
+  });
+
+  it("observes mutations to returned rows in later lookups and projections", () => {
+    const entry = getOfficialExternalPluginCatalogEntry("Mutable")!;
+    const originalName = entry.name;
+    const originalManifest = entry.openclaw;
+    try {
+      entry.name = "@fixture/renamed";
+      entry.openclaw = {
+        plugin: { id: "Renamed" },
+        channel: { id: "RenamedChannel", label: "Renamed" },
+      };
+
+      expect(getOfficialExternalPluginCatalogEntry("Mutable")).toBeUndefined();
+      expect(getOfficialExternalPluginCatalogEntry("OriginalProvider")).toBeUndefined();
+      expect(getOfficialExternalPluginCatalogEntry("Renamed")).toBe(entry);
+      expect(getOfficialExternalPluginCatalogEntryForPackage("@fixture/mutable")).toBeUndefined();
+      expect(getOfficialExternalPluginCatalogEntryForPackage("@fixture/renamed")).toBe(entry);
+      expect(isOfficialExternalPluginId("mutable")).toBe(false);
+      expect(isOfficialExternalPluginId("renamed")).toBe(true);
+      expect(listOfficialExternalChannelCatalogEntries()).toContain(entry);
+      expect(listOfficialExternalProviderCatalogEntries()).not.toContain(entry);
+      expect(
+        hasOfficialExternalChannelTarget({ config: { channels: { renamedchannel: {} } }, env: {} }),
+      ).toBe(true);
+      expect(
+        hasOfficialExternalProviderTarget({ providerIds: ["OriginalProvider"], env: {} }),
+      ).toBe(false);
+    } finally {
+      entry.name = originalName;
+      entry.openclaw = originalManifest;
+    }
+  });
+
+  it.each(["shadow", "rejected"])(
+    "keeps conservative repair targets from the %s row excluded by normal catalog selection",
+    (prefix) => {
+      expect(getOfficialExternalPluginCatalogEntry(`${prefix}-model`)).toBeUndefined();
+      expect(
+        hasOfficialExternalProviderTarget({
+          providerIds: [` ${prefix.toUpperCase()}-MODEL `],
+          env: {},
+        }),
+      ).toBe(true);
+      expect(
+        hasOfficialExternalProviderTarget({
+          providerIds: [],
+          env: { [`${prefix}_MODEL_KEY`]: "key" },
+        }),
+      ).toBe(true);
+      expect(
+        hasOfficialExternalContractTarget({
+          contract: "embeddingProviders",
+          providerIds: [`${prefix}-embedding`],
+        }),
+      ).toBe(true);
+      expect(
+        hasOfficialExternalChannelTarget({ config: {}, env: { [`${prefix}_CHANNEL_KEY`]: "key" } }),
+      ).toBe(true);
+      expect(
+        hasOfficialExternalWebContractEnvTarget({
+          contract: "webFetchProviders",
+          env: { [`${prefix}_WEB_KEY`]: "key" },
+        }),
+      ).toBe(true);
+      expect(hasOfficialExternalWebSearchTarget({ providerId: `${prefix}-web`, env: {} })).toBe(
+        true,
+      );
+    },
+  );
+});

--- a/src/plugins/official-external-plugin-bundled-catalogs.ts
+++ b/src/plugins/official-external-plugin-bundled-catalogs.ts
@@ -1,16 +1,11 @@
-// Generated bundled catalogs shared by full catalog loading and startup projections.
+// One generated source inventory shared by catalog queries and conservative repair checks.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import channelCatalog from "../../scripts/lib/official-external-channel-catalog.json" with { type: "json" };
 import pluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import providerCatalog from "../../scripts/lib/official-external-provider-catalog.json" with { type: "json" };
+import type { OfficialExternalPluginCatalogEntry } from "./official-external-plugin-catalog.types.js";
 
-export const BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOGS = [
-  channelCatalog,
-  providerCatalog,
-  pluginCatalog,
-] as const;
-
-export const BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_ENTRIES: readonly unknown[] = [
-  ...channelCatalog.entries,
-  ...providerCatalog.entries,
-  ...pluginCatalog.entries,
-];
+export const BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_ENTRIES: readonly OfficialExternalPluginCatalogEntry[] =
+  [channelCatalog, providerCatalog, pluginCatalog].flatMap((source: { entries: unknown[] }) =>
+    source.entries.filter((entry): entry is OfficialExternalPluginCatalogEntry => isRecord(entry)),
+  );

--- a/src/plugins/official-external-plugin-catalog-hosted.ts
+++ b/src/plugins/official-external-plugin-catalog-hosted.ts
@@ -1,0 +1,729 @@
+// Loads hosted official catalogs while preserving feed authority and snapshot freshness.
+import { createHash } from "node:crypto";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { MANIFEST_KEY } from "../compat/legacy-names.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { cancelUnreadResponseBody, readResponseWithLimit } from "../infra/http-body.js";
+import {
+  HostedCatalogSignedFeedMonotonicityError,
+  isOfficialExternalPluginCatalogFeed,
+  parseOfficialExternalPluginCatalogTimestamp,
+  parseOfficialExternalPluginCatalogEntries,
+  filterOfficialExternalPluginCatalogEntriesBySourceRefs,
+  dedupeOfficialExternalPluginCatalogEntries,
+  resolveHostedCatalogFeedSource,
+  shouldRequireManifestInstallSourceRef,
+} from "./official-external-plugin-catalog-source.js";
+import { listOfficialExternalPluginCatalogEntries } from "./official-external-plugin-catalog.js";
+import type {
+  OfficialExternalPluginCatalogEntry,
+  OfficialExternalPluginCatalogFeedVerification,
+  OfficialExternalPluginCatalogProfileConfig,
+  OfficialExternalPluginCatalogFeed,
+  HostedOfficialExternalPluginCatalogSnapshot,
+  HostedOfficialExternalPluginCatalogSnapshotStore,
+  HostedOfficialExternalPluginCatalogTrustState,
+  HostedOfficialExternalPluginCatalogLoadResult,
+} from "./official-external-plugin-catalog.types.js";
+
+const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS = 5000;
+
+const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES = 1024 * 1024;
+
+const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS = 5000;
+
+const DSSE_ENVELOPE_MEDIA_TYPE = "application/vnd.dsse+json";
+
+class HostedCatalogFeedTimestampError extends Error {
+  constructor(
+    message: string,
+    readonly sequence: number,
+  ) {
+    super(message);
+  }
+}
+
+class HostedCatalogSnapshotWriteError extends Error {
+  readonly originalError: unknown;
+
+  constructor(originalError: unknown) {
+    super("hosted catalog snapshot write failed");
+    this.name = "HostedCatalogSnapshotWriteError";
+    this.originalError = originalError;
+  }
+}
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+function normalizeHostedCatalogHeader(value: string | null): string | undefined {
+  const normalized = normalizeOptionalString(value);
+  return normalized || undefined;
+}
+
+function sha256Hex(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function parseHostedCatalogContentLength(raw: string | null, maxBytes: number): void {
+  const normalized = normalizeOptionalString(raw);
+  if (!normalized) {
+    return;
+  }
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error("hosted catalog feed has invalid content-length");
+  }
+  const size = Number(normalized);
+  if (!Number.isSafeInteger(size) || size > maxBytes) {
+    throw new Error(`hosted catalog feed exceeds ${maxBytes} bytes`);
+  }
+}
+
+async function readHostedCatalogResponseText(params: {
+  response: Response;
+  maxBytes: number;
+  chunkTimeoutMs: number;
+}): Promise<string> {
+  parseHostedCatalogContentLength(params.response.headers.get("content-length"), params.maxBytes);
+  const streamless = !params.response.body || typeof params.response.body.getReader !== "function";
+  // Hosted remote feeds are untrusted input, so fail closed when Fetch cannot
+  // provide a streaming body instead of trusting Content-Length before read.
+  if (streamless) {
+    throw new Error("hosted catalog feed streaming response body unavailable");
+  }
+  const buffer = await readResponseWithLimit(params.response, params.maxBytes, {
+    chunkTimeoutMs: params.chunkTimeoutMs,
+    onOverflow: ({ maxBytes }) => new Error(`hosted catalog feed exceeds ${maxBytes} bytes`),
+    onIdleTimeout: ({ chunkTimeoutMs }) =>
+      new Error(`hosted catalog feed read timed out after ${chunkTimeoutMs}ms`),
+  });
+  return new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+}
+
+function bundledFallbackResult(
+  error: unknown,
+  metadata?: HostedOfficialExternalPluginCatalogLoadResult["metadata"],
+): HostedOfficialExternalPluginCatalogLoadResult {
+  return {
+    source: "bundled-fallback",
+    entries: listOfficialExternalPluginCatalogEntries(),
+    error: formatErrorMessage(error),
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+function emptyBundledFallbackResult(error: unknown): HostedOfficialExternalPluginCatalogLoadResult {
+  return {
+    source: "bundled-fallback",
+    entries: [],
+    error: formatErrorMessage(error),
+  };
+}
+
+async function parseHostedCatalogFeedBody(params: {
+  body: string;
+  expectedFeedId?: string;
+  verification?: OfficialExternalPluginCatalogFeedVerification;
+  verifiedAt: string;
+  allowLegacyBetaEnvelope?: boolean;
+  now: Date;
+  allowExpired?: boolean;
+  allowMissingExpiry?: boolean;
+}): Promise<{
+  feed: OfficialExternalPluginCatalogFeed;
+  trust?: HostedOfficialExternalPluginCatalogTrustState;
+  expired?: boolean;
+}> {
+  const raw = JSON.parse(params.body) as unknown;
+  if (params.verification?.mode === "signed") {
+    const { verifyOfficialExternalPluginCatalogSignedEnvelope } =
+      await import("./official-external-plugin-catalog-envelope.js");
+    const threshold = params.verification.threshold ?? 1;
+    const verification = verifyOfficialExternalPluginCatalogSignedEnvelope(raw, {
+      trustedKeys: params.verification.keys,
+      threshold,
+      ...(params.allowLegacyBetaEnvelope ? { allowLegacyBetaEnvelope: true } : {}),
+    });
+    if (!verification.ok) {
+      const invalidTimestampSequence =
+        verification.error === "invalid-payload" && "authenticatedPayload" in verification
+          ? readOfficialExternalPluginCatalogInvalidTimestampSequence(
+              verification.authenticatedPayload,
+            )
+          : undefined;
+      if (invalidTimestampSequence !== undefined) {
+        throw new HostedCatalogFeedTimestampError(verification.message, invalidTimestampSequence);
+      }
+      throw new Error(verification.message);
+    }
+    if (params.expectedFeedId && verification.feed.id !== params.expectedFeedId) {
+      throw new Error(
+        `hosted catalog feed id "${verification.feed.id}" did not match expected "${params.expectedFeedId}"`,
+      );
+    }
+    const generatedAtMs = parseOfficialExternalPluginCatalogTimestamp(
+      verification.feed.generatedAt,
+    );
+    const expiresAt = normalizeOptionalString(verification.feed.expiresAt);
+    if (generatedAtMs === undefined) {
+      throw new Error("hosted catalog signed feed requires a valid generatedAt value");
+    }
+    let expired: boolean;
+    if (!expiresAt) {
+      if (params.allowMissingExpiry !== true) {
+        throw new Error("hosted catalog signed feed requires a valid expiresAt value");
+      }
+      expired = true;
+    } else {
+      const expiresAtMs = parseOfficialExternalPluginCatalogTimestamp(expiresAt);
+      if (expiresAtMs === undefined) {
+        throw new Error("hosted catalog signed feed requires a valid expiresAt value");
+      }
+      if (expiresAtMs <= generatedAtMs) {
+        throw new Error("hosted catalog signed feed expiresAt must be later than generatedAt");
+      }
+      expired = expiresAtMs <= params.now.getTime();
+    }
+    if (expired && params.allowExpired !== true) {
+      throw new Error(
+        expiresAt
+          ? `hosted catalog signed feed expired at ${expiresAt}`
+          : "hosted catalog signed feed has no expiresAt",
+      );
+    }
+    return {
+      feed: enforceHostedCatalogFeedInstallAuthority(verification.feed),
+      trust: {
+        mode: "signed",
+        signedBy: verification.signedBy,
+        signatureCount: verification.signatureCount ?? 1,
+        threshold,
+        verifiedAt: params.verifiedAt,
+      },
+      ...(expired ? { expired: true } : {}),
+    };
+  }
+  if (!isOfficialExternalPluginCatalogFeed(raw)) {
+    throw new Error("hosted catalog feed did not match a supported schema version");
+  }
+  if (params.expectedFeedId && raw.id !== params.expectedFeedId) {
+    throw new Error(
+      `hosted catalog feed id "${raw.id}" did not match expected "${params.expectedFeedId}"`,
+    );
+  }
+  return { feed: enforceHostedCatalogFeedInstallAuthority(raw) };
+}
+
+function enforceHostedCatalogFeedInstallAuthority(
+  feed: OfficialExternalPluginCatalogFeed,
+): OfficialExternalPluginCatalogFeed {
+  if (feed.schemaVersion < 2) {
+    return feed;
+  }
+  return {
+    ...feed,
+    entries: feed.entries.map((entry) => {
+      const state = normalizeOptionalString(entry.state);
+      const publisherTrust = normalizeOptionalString(entry.publisher?.trust);
+      return state === "available" && publisherTrust === "official"
+        ? entry
+        : removeOfficialExternalPluginCatalogInstallAuthority(entry);
+    }),
+  };
+}
+
+function readOfficialExternalPluginCatalogInvalidTimestampSequence(
+  raw: unknown,
+): number | undefined {
+  if (!isRecord(raw)) {
+    return undefined;
+  }
+  if (
+    typeof raw.generatedAt === "string" &&
+    parseOfficialExternalPluginCatalogTimestamp(raw.generatedAt) !== undefined
+  ) {
+    return undefined;
+  }
+  const normalized = {
+    ...raw,
+    generatedAt: "1970-01-01T00:00:00.000Z",
+  };
+  return isOfficialExternalPluginCatalogFeed(normalized) ? normalized.sequence : undefined;
+}
+
+async function loadHostedCatalogSnapshotResult(params: {
+  snapshot: HostedOfficialExternalPluginCatalogSnapshot;
+  error: unknown;
+  expectedSha256?: string;
+  ifNoneMatch?: string;
+  ifModifiedSince?: string;
+  catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
+  requireManifestInstallSourceRef?: boolean;
+  expectedFeedId?: string;
+  verification?: OfficialExternalPluginCatalogFeedVerification;
+  now: Date;
+}): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
+  assertSnapshotMatchesRequestValidators({
+    snapshot: params.snapshot,
+    ifNoneMatch: params.ifNoneMatch,
+    ifModifiedSince: params.ifModifiedSince,
+  });
+  const checksum = sha256Hex(params.snapshot.body);
+  if (checksum !== params.snapshot.metadata.checksum) {
+    throw new Error("hosted catalog snapshot checksum mismatch");
+  }
+  if (params.expectedSha256 && params.expectedSha256 !== checksum) {
+    throw new Error("hosted catalog snapshot checksum did not match expected checksum");
+  }
+  const parsed = await parseHostedCatalogFeedBody({
+    body: params.snapshot.body,
+    expectedFeedId: params.expectedFeedId,
+    verification: params.verification,
+    verifiedAt: params.snapshot.trust?.verifiedAt ?? params.snapshot.savedAt,
+    allowLegacyBetaEnvelope: true,
+    now: params.now,
+    allowExpired: true,
+    allowMissingExpiry: true,
+  });
+  const entries = dedupeOfficialExternalPluginCatalogEntries(
+    filterOfficialExternalPluginCatalogEntriesBySourceRefs(
+      parseOfficialExternalPluginCatalogEntries(parsed.feed),
+      {
+        catalogConfig: params.catalogConfig,
+        requireManifestInstallSourceRef: params.requireManifestInstallSourceRef,
+      },
+    ),
+  );
+  const visibleEntries = parsed.expired
+    ? entries.map((entry) => removeOfficialExternalPluginCatalogInstallAuthority(entry))
+    : entries;
+  return {
+    source: "hosted-snapshot",
+    entries: visibleEntries,
+    feed: parsed.expired ? { ...parsed.feed, entries: visibleEntries } : parsed.feed,
+    metadata: params.snapshot.metadata,
+    snapshot: params.snapshot,
+    ...(parsed.trust ? { trust: parsed.trust } : {}),
+    error: parsed.expired
+      ? `${formatErrorMessage(params.error)}; ${parsed.feed.expiresAt ? `hosted catalog signed feed expired at ${parsed.feed.expiresAt}` : "hosted catalog signed feed has no expiresAt"}`
+      : formatErrorMessage(params.error),
+  };
+}
+
+function removeOfficialExternalPluginCatalogInstallAuthority(
+  entry: OfficialExternalPluginCatalogEntry,
+): OfficialExternalPluginCatalogEntry {
+  const { install: _feedInstall, [MANIFEST_KEY]: manifest, ...metadata } = entry;
+  if (!manifest) {
+    return { ...metadata, state: "unavailable" };
+  }
+  const { install: _manifestInstall, ...manifestMetadata } = manifest;
+  return {
+    ...metadata,
+    state: "unavailable",
+    [MANIFEST_KEY]: manifestMetadata,
+  };
+}
+
+function isHostedCatalogSignedFeedRollback(params: {
+  candidate: OfficialExternalPluginCatalogFeed;
+  current: Pick<OfficialExternalPluginCatalogFeed, "sequence"> & { generatedAt?: string };
+}): boolean {
+  if (params.candidate.sequence < params.current.sequence) {
+    return true;
+  }
+  if (params.candidate.sequence > params.current.sequence) {
+    return false;
+  }
+  if (params.current.generatedAt === undefined) {
+    return false;
+  }
+  return Date.parse(params.candidate.generatedAt) < Date.parse(params.current.generatedAt);
+}
+
+function assertSnapshotMatchesRequestValidators(params: {
+  snapshot: HostedOfficialExternalPluginCatalogSnapshot;
+  ifNoneMatch?: string;
+  ifModifiedSince?: string;
+}): void {
+  if (params.ifNoneMatch && params.snapshot.metadata.etag !== params.ifNoneMatch) {
+    throw new Error("hosted catalog snapshot ETag did not match request validator");
+  }
+  if (
+    !params.ifNoneMatch &&
+    params.ifModifiedSince &&
+    params.snapshot.metadata.lastModified !== params.ifModifiedSince
+  ) {
+    throw new Error("hosted catalog snapshot Last-Modified did not match request validator");
+  }
+}
+
+async function snapshotOrBundledFallbackResult(params: {
+  error: unknown;
+  snapshotStore?: HostedOfficialExternalPluginCatalogSnapshotStore;
+  url: string;
+  metadata?: HostedOfficialExternalPluginCatalogLoadResult["metadata"];
+  expectedSha256?: string;
+  ifNoneMatch?: string;
+  ifModifiedSince?: string;
+  catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
+  requireManifestInstallSourceRef?: boolean;
+  expectedFeedId?: string;
+  verification?: OfficialExternalPluginCatalogFeedVerification;
+  now: Date;
+}): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
+  if (params.snapshotStore) {
+    try {
+      const snapshot = await params.snapshotStore.read(params.url);
+      if (snapshot) {
+        return await loadHostedCatalogSnapshotResult({
+          snapshot,
+          error: params.error,
+          expectedSha256: params.expectedSha256,
+          ifNoneMatch: params.ifNoneMatch,
+          ifModifiedSince: params.ifModifiedSince,
+          catalogConfig: params.catalogConfig,
+          requireManifestInstallSourceRef: params.requireManifestInstallSourceRef,
+          expectedFeedId: params.expectedFeedId,
+          verification: params.verification,
+          now: params.now,
+        });
+      }
+    } catch (snapshotErr) {
+      if (params.verification?.mode === "signed") {
+        return emptyBundledFallbackResult(
+          `${formatErrorMessage(params.error)}; snapshot fallback failed: ${formatErrorMessage(snapshotErr)}`,
+        );
+      }
+      return bundledFallbackResult(
+        `${formatErrorMessage(params.error)}; snapshot fallback failed: ${formatErrorMessage(snapshotErr)}`,
+        params.metadata,
+      );
+    }
+  }
+  if (params.verification?.mode === "signed") {
+    return emptyBundledFallbackResult(params.error);
+  }
+  return bundledFallbackResult(params.error, params.metadata);
+}
+
+async function resolveHostedCatalogSnapshotStore(params: {
+  snapshotStore?: HostedOfficialExternalPluginCatalogSnapshotStore | null;
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+  stateDatabasePath?: string;
+}): Promise<HostedOfficialExternalPluginCatalogSnapshotStore | undefined> {
+  if (params.snapshotStore !== undefined) {
+    return params.snapshotStore ?? undefined;
+  }
+  const { createSqliteHostedOfficialExternalPluginCatalogSnapshotStore } =
+    await import("./official-external-plugin-catalog-snapshot-store.js");
+  return createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({
+    ...(params.env ? { env: params.env } : {}),
+    ...(params.stateDir ? { stateDir: params.stateDir } : {}),
+    ...(params.stateDatabasePath ? { stateDatabasePath: params.stateDatabasePath } : {}),
+  });
+}
+
+export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
+  feedUrl?: string;
+  feedProfile?: string;
+  catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+  maxBytes?: number;
+  chunkTimeoutMs?: number;
+  ifNoneMatch?: string;
+  ifModifiedSince?: string;
+  expectedSha256?: string;
+  offline?: boolean;
+  requireSnapshotWrite?: boolean;
+  snapshotStore?: HostedOfficialExternalPluginCatalogSnapshotStore | null;
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+  stateDatabasePath?: string;
+  now?: () => Date;
+}): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
+  let source: {
+    url: URL;
+    hostnameAllowlist: string[];
+    expectedFeedId?: string;
+    verification?: OfficialExternalPluginCatalogFeedVerification;
+  };
+  try {
+    source = resolveHostedCatalogFeedSource({
+      feedUrl: params?.feedUrl,
+      feedProfile: params?.feedProfile,
+      catalogConfig: params?.catalogConfig,
+    });
+  } catch (err) {
+    return bundledFallbackResult(err);
+  }
+  const { url } = source;
+  const snapshotStore = await resolveHostedCatalogSnapshotStore({
+    snapshotStore: params?.snapshotStore,
+    env: params?.env,
+    stateDir: params?.stateDir,
+    stateDatabasePath: params?.stateDatabasePath,
+  });
+  const expectedSha256 = normalizeOptionalString(params?.expectedSha256);
+  const currentTime = () => params?.now?.() ?? new Date();
+  const requireManifestInstallSourceRef = shouldRequireManifestInstallSourceRef({
+    feedUrl: params?.feedUrl,
+    feedProfile: params?.feedProfile,
+    catalogConfig: params?.catalogConfig,
+  });
+  if (params?.offline === true) {
+    return await snapshotOrBundledFallbackResult({
+      error: "hosted catalog feed offline mode",
+      snapshotStore,
+      url: url.href,
+      expectedSha256,
+      catalogConfig: params?.catalogConfig,
+      requireManifestInstallSourceRef,
+      expectedFeedId: source.expectedFeedId,
+      verification: source.verification,
+      now: currentTime(),
+    });
+  }
+  const headers = new Headers();
+  const ifNoneMatch = normalizeOptionalString(params?.ifNoneMatch);
+  const signedOperation = source.verification?.mode === "signed";
+  const ifModifiedSince = signedOperation
+    ? undefined
+    : normalizeOptionalString(params?.ifModifiedSince);
+  if (ifNoneMatch) {
+    headers.set("if-none-match", ifNoneMatch);
+  }
+  if (ifModifiedSince) {
+    headers.set("if-modified-since", ifModifiedSince);
+  }
+  if (signedOperation) {
+    headers.set("accept", DSSE_ENVELOPE_MEDIA_TYPE);
+  }
+  const metadataBase = (response: Response) => {
+    const etag = normalizeHostedCatalogHeader(response.headers.get("etag"));
+    const lastModified = normalizeHostedCatalogHeader(response.headers.get("last-modified"));
+    return {
+      url: url.href,
+      status: response.status,
+      ...(etag ? { etag } : {}),
+      ...(lastModified ? { lastModified } : {}),
+    };
+  };
+  let response: Response | undefined;
+  let release: (() => Promise<void>) | undefined;
+  try {
+    const { fetchWithSsrFGuard } = await import("../infra/net/fetch-guard.js");
+    const guarded = await fetchWithSsrFGuard({
+      url: url.href,
+      fetchImpl: params?.fetchImpl,
+      init: { method: "GET", headers },
+      requireHttps: true,
+      maxRedirects: 2,
+      timeoutMs: params?.timeoutMs ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS,
+      policy: { hostnameAllowlist: source.hostnameAllowlist },
+      auditContext: "official-external-plugin-catalog-feed",
+    });
+    response = guarded.response;
+    release = guarded.release;
+    const base = metadataBase(response);
+    if (response.status === 304) {
+      return await snapshotOrBundledFallbackResult({
+        error: "hosted catalog feed returned HTTP 304",
+        snapshotStore,
+        url: url.href,
+        metadata: base,
+        expectedSha256,
+        ifNoneMatch,
+        ifModifiedSince,
+        catalogConfig: params?.catalogConfig,
+        requireManifestInstallSourceRef,
+        expectedFeedId: source.expectedFeedId,
+        verification: source.verification,
+        now: currentTime(),
+      });
+    }
+    if (!response.ok) {
+      return await snapshotOrBundledFallbackResult({
+        error: `hosted catalog feed returned HTTP ${response.status}`,
+        snapshotStore,
+        url: url.href,
+        metadata: base,
+        expectedSha256,
+        ifNoneMatch,
+        ifModifiedSince,
+        catalogConfig: params?.catalogConfig,
+        requireManifestInstallSourceRef,
+        expectedFeedId: source.expectedFeedId,
+        verification: source.verification,
+        now: currentTime(),
+      });
+    }
+    if (
+      signedOperation &&
+      response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase() !==
+        DSSE_ENVELOPE_MEDIA_TYPE
+    ) {
+      return await snapshotOrBundledFallbackResult({
+        error: `signed hosted catalog feed must use ${DSSE_ENVELOPE_MEDIA_TYPE}`,
+        snapshotStore,
+        url: url.href,
+        metadata: base,
+        expectedSha256,
+        ifNoneMatch,
+        catalogConfig: params?.catalogConfig,
+        requireManifestInstallSourceRef,
+        expectedFeedId: source.expectedFeedId,
+        verification: source.verification,
+        now: currentTime(),
+      });
+    }
+    const body = await readHostedCatalogResponseText({
+      response,
+      maxBytes: params?.maxBytes ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES,
+      chunkTimeoutMs:
+        params?.chunkTimeoutMs ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS,
+    });
+    const checksum = sha256Hex(body);
+    const metadata = { ...base, checksum };
+    if (expectedSha256 && expectedSha256 !== checksum) {
+      return await snapshotOrBundledFallbackResult({
+        error: `hosted catalog feed checksum mismatch: expected ${expectedSha256}`,
+        snapshotStore,
+        url: url.href,
+        metadata,
+        expectedSha256,
+        ifNoneMatch,
+        ifModifiedSince,
+        catalogConfig: params?.catalogConfig,
+        requireManifestInstallSourceRef,
+        expectedFeedId: source.expectedFeedId,
+        verification: source.verification,
+        now: currentTime(),
+      });
+    }
+    const now = currentTime();
+    const verifiedAt = now.toISOString();
+    const parsed = await parseHostedCatalogFeedBody({
+      body,
+      expectedFeedId: source.expectedFeedId,
+      verification: source.verification,
+      verifiedAt,
+      now,
+    }).catch(async (err: unknown) => {
+      return await snapshotOrBundledFallbackResult({
+        error: err,
+        snapshotStore,
+        url: url.href,
+        metadata,
+        expectedSha256,
+        ifNoneMatch,
+        ifModifiedSince,
+        catalogConfig: params?.catalogConfig,
+        requireManifestInstallSourceRef,
+        expectedFeedId: source.expectedFeedId,
+        verification: source.verification,
+        now,
+      });
+    });
+    if ("source" in parsed) {
+      return parsed;
+    }
+    if (snapshotStore && parsed.trust?.mode === "signed") {
+      const currentSnapshot = await snapshotStore.read(url.href);
+      if (currentSnapshot?.trust?.mode === "signed") {
+        const current =
+          currentSnapshot.monotonic?.mode === "signed-feed"
+            ? currentSnapshot.monotonic
+            : (
+                await parseHostedCatalogFeedBody({
+                  body: currentSnapshot.body,
+                  expectedFeedId: source.expectedFeedId,
+                  verification: source.verification,
+                  verifiedAt: currentSnapshot.trust.verifiedAt,
+                  allowLegacyBetaEnvelope: true,
+                  now,
+                  allowExpired: true,
+                  allowMissingExpiry: true,
+                }).catch((err: unknown) => {
+                  // Only an authenticated invalid-timestamp payload is repairable. Signature
+                  // and trust failures must remain fail-closed so rollback checks cannot be bypassed.
+                  if (err instanceof HostedCatalogFeedTimestampError) {
+                    return { feed: { sequence: err.sequence } };
+                  }
+                  throw err;
+                })
+              ).feed;
+        if (
+          isHostedCatalogSignedFeedRollback({
+            candidate: parsed.feed,
+            current,
+          })
+        ) {
+          throw new HostedCatalogSignedFeedMonotonicityError(
+            "hosted catalog signed feed sequence is older than current snapshot",
+          );
+        }
+      }
+    }
+    const entries = filterOfficialExternalPluginCatalogEntriesBySourceRefs(
+      parseOfficialExternalPluginCatalogEntries(parsed.feed),
+      {
+        catalogConfig: params?.catalogConfig,
+        requireManifestInstallSourceRef,
+      },
+    );
+    await snapshotStore
+      ?.write({
+        body,
+        metadata,
+        savedAt: verifiedAt,
+        ...(parsed.trust ? { trust: parsed.trust } : {}),
+        ...(parsed.trust?.mode === "signed"
+          ? {
+              monotonic: {
+                mode: "signed-feed",
+                sequence: parsed.feed.sequence,
+                generatedAt: parsed.feed.generatedAt,
+              },
+            }
+          : {}),
+      })
+      .catch((err: unknown) => {
+        if (err instanceof HostedCatalogSignedFeedMonotonicityError) {
+          throw err;
+        }
+        if (params?.requireSnapshotWrite) {
+          throw new HostedCatalogSnapshotWriteError(err);
+        }
+      });
+    return {
+      source: "hosted",
+      entries: dedupeOfficialExternalPluginCatalogEntries(entries),
+      feed: parsed.feed,
+      metadata,
+      ...(parsed.trust ? { trust: parsed.trust } : {}),
+    };
+  } catch (err) {
+    if (err instanceof HostedCatalogSnapshotWriteError) {
+      throw err.originalError;
+    }
+    return await snapshotOrBundledFallbackResult({
+      error: err,
+      snapshotStore,
+      url: url.href,
+      expectedSha256,
+      ifNoneMatch,
+      ifModifiedSince,
+      catalogConfig: params?.catalogConfig,
+      requireManifestInstallSourceRef,
+      expectedFeedId: source.expectedFeedId,
+      verification: source.verification,
+      now: currentTime(),
+    });
+  } finally {
+    await cancelUnreadResponseBody(response);
+    await release?.().catch(() => undefined);
+  }
+}

--- a/src/plugins/official-external-plugin-catalog-source.ts
+++ b/src/plugins/official-external-plugin-catalog-source.ts
@@ -1,0 +1,413 @@
+// Pure catalog identities, source profiles, and feed validation shared by static and hosted readers.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { MANIFEST_KEY } from "../compat/legacy-names.js";
+import type {
+  OfficialExternalPluginCatalogEntry,
+  OfficialExternalPluginCatalogManifest,
+  OfficialExternalPluginCatalogInstallCandidate,
+  OfficialExternalPluginCatalogFeed,
+  OfficialExternalPluginCatalogFeedSigningKey,
+  OfficialExternalPluginCatalogFeedVerification,
+  OfficialExternalPluginCatalogProfileConfig,
+} from "./official-external-plugin-catalog.types.js";
+
+export class HostedCatalogSignedFeedMonotonicityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "HostedCatalogSignedFeedMonotonicityError";
+  }
+}
+
+const SUPPORTED_OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSIONS = new Set([1, 2]);
+
+const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL = "https://clawhub.ai/v1/feeds/plugins";
+
+const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE = "clawhub-public";
+
+const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_ID = "clawhub-official";
+
+const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_SOURCE_REF = "public-clawhub";
+
+const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_NPM_SOURCE_REF = "public-npm";
+
+const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEYS: readonly OfficialExternalPluginCatalogFeedSigningKey[] =
+  [];
+
+export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG: OfficialExternalPluginCatalogProfileConfig =
+  {
+    feeds: {
+      [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE]: {
+        url: DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL,
+        feedId: DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_ID,
+      },
+    },
+    sources: {
+      [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_SOURCE_REF]: {
+        type: "clawhub",
+        baseUrl: "https://clawhub.ai",
+      },
+      [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_NPM_SOURCE_REF]: {
+        type: "npm",
+        registry: "https://registry.npmjs.org/",
+      },
+    },
+  };
+
+const ISO_CALENDAR_DATE_PREFIX_RE = /^(\d{4})-(\d{2})-(\d{2})/u;
+
+export function parseOfficialExternalPluginCatalogTimestamp(value: string): number | undefined {
+  const timestamp = value.trim();
+  const parsed = Date.parse(timestamp);
+  if (!Number.isFinite(parsed)) {
+    return undefined;
+  }
+  const calendarDate = ISO_CALENDAR_DATE_PREFIX_RE.exec(timestamp);
+  if (!calendarDate) {
+    return parsed;
+  }
+  const year = Number(calendarDate[1]);
+  const month = Number(calendarDate[2]);
+  const day = Number(calendarDate[3]);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+  // Shipped releases accepted every Date.parse-compatible serialization. Keep those
+  // formats, but reject ISO-shaped impossible dates that Date.parse normalizes.
+  return month >= 1 && month <= 12 && day >= 1 && day <= daysInMonth[month - 1]!
+    ? parsed
+    : undefined;
+}
+
+export function isOfficialExternalPluginCatalogSequence(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+export function isOfficialExternalPluginCatalogFeed(
+  raw: unknown,
+): raw is OfficialExternalPluginCatalogFeed {
+  if (!isRecord(raw)) {
+    return false;
+  }
+  const sequence = raw.sequence;
+  const generatedAt = raw.generatedAt;
+  const generatedAtMs =
+    typeof generatedAt === "string"
+      ? parseOfficialExternalPluginCatalogTimestamp(generatedAt)
+      : undefined;
+  const entries = raw.entries;
+  return (
+    typeof raw.schemaVersion === "number" &&
+    SUPPORTED_OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSIONS.has(raw.schemaVersion) &&
+    typeof raw.id === "string" &&
+    raw.id.trim().length > 0 &&
+    typeof generatedAt === "string" &&
+    generatedAt.trim().length > 0 &&
+    generatedAtMs !== undefined &&
+    isOfficialExternalPluginCatalogSequence(sequence) &&
+    Array.isArray(entries)
+  );
+}
+
+export function parseOfficialExternalPluginCatalogEntries(
+  raw: unknown,
+): OfficialExternalPluginCatalogEntry[] {
+  if (Array.isArray(raw)) {
+    return raw.filter((entry): entry is OfficialExternalPluginCatalogEntry => isRecord(entry));
+  }
+  if (isOfficialExternalPluginCatalogFeed(raw)) {
+    return raw.entries.filter((entry): entry is OfficialExternalPluginCatalogEntry =>
+      isRecord(entry),
+    );
+  }
+  if (!isRecord(raw)) {
+    return [];
+  }
+  if ("schemaVersion" in raw) {
+    return [];
+  }
+  const list = raw.entries ?? raw.packages ?? raw.plugins;
+  if (!Array.isArray(list)) {
+    return [];
+  }
+  return list.filter((entry): entry is OfficialExternalPluginCatalogEntry => isRecord(entry));
+}
+
+export function resolveOfficialExternalPluginCatalogProfileConfig(
+  config?: OfficialExternalPluginCatalogProfileConfig,
+): Required<OfficialExternalPluginCatalogProfileConfig> {
+  const configuredDefaultFeed =
+    config?.feeds?.[DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE];
+  const bundledVerification =
+    DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEYS.length > 0
+      ? {
+          mode: "signed" as const,
+          keys: DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEYS,
+        }
+      : undefined;
+  const defaultFeed = DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG.feeds?.[
+    DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE
+  ] ?? {
+    url: DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL,
+    feedId: DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_ID,
+  };
+  return {
+    feeds: {
+      ...config?.feeds,
+      [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE]: {
+        ...defaultFeed,
+        ...(bundledVerification ? { verification: bundledVerification } : {}),
+        ...configuredDefaultFeed,
+      },
+    },
+    sources: {
+      ...DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG.sources,
+      ...config?.sources,
+    },
+  };
+}
+
+export function getFeedEntryInstallCandidateRecords(
+  entry: OfficialExternalPluginCatalogEntry,
+): OfficialExternalPluginCatalogInstallCandidate[] {
+  const install = isRecord(entry.install) ? entry.install : undefined;
+  const candidates = install?.candidates;
+  if (!Array.isArray(candidates)) {
+    return [];
+  }
+  return candidates.filter(
+    (candidate): candidate is OfficialExternalPluginCatalogInstallCandidate => isRecord(candidate),
+  );
+}
+
+function getManifestInstallSourceRefCandidate(
+  entry: OfficialExternalPluginCatalogEntry,
+): OfficialExternalPluginCatalogInstallCandidate | undefined {
+  const install = getOfficialExternalPluginCatalogManifest(entry)?.install;
+  if (!install) {
+    return undefined;
+  }
+  const hasInstallSpec = Boolean(
+    normalizeOptionalString(install.clawhubSpec) ||
+    normalizeOptionalString(install.npmSpec) ||
+    normalizeOptionalString(install.localPath),
+  );
+  if (!hasInstallSpec) {
+    return undefined;
+  }
+  return {
+    sourceRef: normalizeOptionalString(install.sourceRef),
+    package:
+      normalizeOptionalString(install.npmSpec) ?? normalizeOptionalString(install.clawhubSpec),
+  };
+}
+
+export function hasKnownCatalogSourceRef(
+  candidate: OfficialExternalPluginCatalogInstallCandidate,
+  sourceRefs: ReadonlySet<string>,
+): boolean {
+  const sourceRef = normalizeOptionalString(candidate.sourceRef);
+  return Boolean(sourceRef && sourceRefs.has(sourceRef));
+}
+
+export function filterOfficialExternalPluginCatalogEntriesBySourceRefs(
+  entries: OfficialExternalPluginCatalogEntry[],
+  params?: {
+    catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
+    requireManifestInstallSourceRef?: boolean;
+  },
+): OfficialExternalPluginCatalogEntry[] {
+  let configuredSourceRefs: Set<string> | undefined;
+  return entries.filter((entry) => {
+    // One synchronous batch owns these configured facts; empty batches stay lazy.
+    configuredSourceRefs ??= new Set(
+      Object.keys(resolveOfficialExternalPluginCatalogProfileConfig(params?.catalogConfig).sources),
+    );
+    let candidates = getFeedEntryInstallCandidateRecords(entry);
+    if (params?.requireManifestInstallSourceRef) {
+      const manifestCandidate = getManifestInstallSourceRefCandidate(entry);
+      if (manifestCandidate) {
+        candidates = [...candidates, manifestCandidate];
+      } else if (candidates.length === 0) {
+        candidates = [{}];
+      }
+    }
+    let valid = true;
+    for (const candidate of candidates) {
+      if (!hasKnownCatalogSourceRef(candidate, configuredSourceRefs)) {
+        valid = false;
+      }
+    }
+    return valid;
+  });
+}
+
+// Generated source structure is stable; rows remain shared and must be read on each query.
+
+export function dedupeOfficialExternalPluginCatalogEntries(
+  entries: OfficialExternalPluginCatalogEntry[],
+): OfficialExternalPluginCatalogEntry[] {
+  const resolved = new Map<string, OfficialExternalPluginCatalogEntry>();
+  for (const entry of entries) {
+    const key = resolveOfficialExternalPluginCatalogEntryKey(entry);
+    if (key && !resolved.has(key)) {
+      resolved.set(key, entry);
+    }
+  }
+  return [...resolved.values()];
+}
+
+export function resolveOfficialExternalPluginCatalogEntryKey(
+  entry: OfficialExternalPluginCatalogEntry,
+): string | undefined {
+  const pluginId = resolveOfficialExternalPluginId(entry);
+  if (pluginId) {
+    return `${normalizeOptionalString(entry.kind) ?? "plugin"}:${pluginId}`;
+  }
+  const name = normalizeOptionalString(entry.name);
+  if (name) {
+    return name;
+  }
+  const id = normalizeOptionalString(entry.id);
+  if (id) {
+    return `${normalizeOptionalString(entry.kind) ?? normalizeOptionalString(entry.type) ?? "plugin"}:${id}`;
+  }
+  return undefined;
+}
+
+export function getOfficialExternalPluginCatalogManifest(
+  entry: OfficialExternalPluginCatalogEntry,
+): OfficialExternalPluginCatalogManifest | undefined {
+  const manifest = entry[MANIFEST_KEY];
+  return isRecord(manifest) ? manifest : undefined;
+}
+
+export function resolveOfficialExternalPluginId(
+  entry: OfficialExternalPluginCatalogEntry,
+): string | undefined {
+  const manifest = getOfficialExternalPluginCatalogManifest(entry);
+  return (
+    normalizeOptionalString(manifest?.plugin?.id) ??
+    normalizeOptionalString(manifest?.channel?.id) ??
+    normalizeOptionalString(manifest?.providers?.[0]?.id) ??
+    normalizeOptionalString(entry.id)
+  );
+}
+
+const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST = ["clawhub.ai"];
+
+function resolveHostedCatalogFeedUrl(raw: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw.trim());
+  } catch {
+    throw new Error("hosted catalog feed URL is invalid");
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error("hosted catalog feed URL must use HTTPS");
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error("hosted catalog feed URL must not include credentials");
+  }
+  if (parsed.search || parsed.hash) {
+    throw new Error("hosted catalog feed URL must not include query strings or fragments");
+  }
+  return parsed;
+}
+
+export function resolveHostedCatalogFeedSource(params: {
+  feedUrl?: string;
+  feedProfile?: string;
+  catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
+}): {
+  url: URL;
+  hostnameAllowlist: string[];
+  expectedFeedId?: string;
+  verification?: OfficialExternalPluginCatalogFeedVerification;
+} {
+  const explicitFeedUrl = normalizeOptionalString(params.feedUrl);
+  const explicitProfileName = normalizeOptionalString(params.feedProfile);
+  if (explicitFeedUrl) {
+    const url = resolveHostedCatalogFeedUrl(explicitFeedUrl);
+    if (!OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST.includes(url.hostname)) {
+      throw new Error("hosted catalog feed URL hostname is not allowed");
+    }
+    const defaultProfile =
+      explicitProfileName === undefined
+        ? resolveOfficialExternalPluginCatalogProfileConfig(params.catalogConfig).feeds[
+            DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE
+          ]
+        : undefined;
+    const profileName =
+      explicitProfileName ??
+      (defaultProfile && resolveHostedCatalogFeedUrl(defaultProfile.url).href === url.href
+        ? DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE
+        : undefined);
+    const profileConfig =
+      profileName === undefined
+        ? undefined
+        : resolveOfficialExternalPluginCatalogProfileConfig(params.catalogConfig);
+    const profile = profileName === undefined ? undefined : profileConfig?.feeds[profileName];
+    if (profileName !== undefined && !profile) {
+      throw new Error(`hosted catalog feed profile "${profileName}" is not configured`);
+    }
+    return {
+      url,
+      hostnameAllowlist: OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST,
+      ...(profile?.feedId ? { expectedFeedId: profile.feedId } : {}),
+      ...(profile?.verification ? { verification: profile.verification } : {}),
+    };
+  }
+  const profileName = explicitProfileName ?? DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE;
+  const profileConfig = resolveOfficialExternalPluginCatalogProfileConfig(params.catalogConfig);
+  const profile = profileConfig.feeds[profileName];
+  if (!profile) {
+    throw new Error(`hosted catalog feed profile "${profileName}" is not configured`);
+  }
+  const url = resolveHostedCatalogFeedUrl(profile.url);
+  return {
+    url,
+    hostnameAllowlist: uniqueStrings([
+      ...OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST,
+      url.hostname,
+    ]),
+    ...(profile.feedId ? { expectedFeedId: profile.feedId } : {}),
+    verification: profile.verification,
+  };
+}
+
+export function shouldRequireManifestInstallSourceRef(params: {
+  feedUrl?: string;
+  feedProfile?: string;
+  catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
+}): boolean {
+  const feedUrl = normalizeOptionalString(params.feedUrl);
+  if (feedUrl) {
+    try {
+      return (
+        resolveHostedCatalogFeedUrl(feedUrl).href !==
+        resolveHostedCatalogFeedUrl(DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL).href
+      );
+    } catch {
+      return true;
+    }
+  }
+  const profileName =
+    normalizeOptionalString(params.feedProfile) ??
+    DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE;
+  if (profileName !== DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE) {
+    return true;
+  }
+  const profileConfig = resolveOfficialExternalPluginCatalogProfileConfig(params.catalogConfig);
+  const profileUrl = normalizeOptionalString(profileConfig.feeds[profileName]?.url);
+  try {
+    return (
+      resolveHostedCatalogFeedUrl(profileUrl ?? DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL)
+        .href !==
+      resolveHostedCatalogFeedUrl(DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL).href
+    );
+  } catch {
+    return true;
+  }
+}

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -329,8 +329,15 @@ describe("official external plugin catalog", () => {
       "utf8",
     );
 
-    expect(source).not.toMatch(/from ["']\.\.\/infra\/net\/fetch-guard\.js["']/);
-    expect(source).toContain('await import("../infra/net/fetch-guard.js")');
+    const hostedSource = readFileSync(
+      new URL("./official-external-plugin-catalog-hosted.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).not.toMatch(/from ["'].*(?:catalog-hosted|fetch-guard)\.js["']/);
+    expect(source).toContain('await import("./official-external-plugin-catalog-hosted.js")');
+    expect(hostedSource).not.toMatch(/from ["']\.\.\/infra\/net\/fetch-guard\.js["']/);
+    expect(hostedSource).toContain('await import("../infra/net/fetch-guard.js")');
   });
 
   it.each([

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -1,27 +1,25 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 /** Reads official external plugin/channel/provider catalogs into manifest-like metadata. */
-import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { MANIFEST_KEY } from "../compat/legacy-names.js";
-import { normalizeClawHubSha256Integrity } from "../infra/clawhub-artifacts.js";
-import { formatErrorMessage } from "../infra/errors.js";
-import { cancelUnreadResponseBody, readResponseWithLimit } from "../infra/http-body.js";
-import { isRecord } from "../utils.js";
+import { normalizeClawHubSha256Integrity } from "../infra/clawhub-integrity.js";
 import { resolvePluginInstallSources, type PluginInstallSource } from "./install-channel-specs.js";
-import { BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOGS } from "./official-external-plugin-bundled-catalogs.js";
+import { BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_ENTRIES } from "./official-external-plugin-bundled-catalogs.js";
+import {
+  DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG,
+  getFeedEntryInstallCandidateRecords,
+  getOfficialExternalPluginCatalogManifest,
+  hasKnownCatalogSourceRef,
+  resolveOfficialExternalPluginCatalogEntryKey,
+  resolveOfficialExternalPluginCatalogProfileConfig,
+  resolveOfficialExternalPluginId,
+} from "./official-external-plugin-catalog-source.js";
 import type {
   OfficialExternalChannelSecretContract,
-  OfficialExternalPluginCatalogManifest,
   OfficialExternalPluginCatalogEntry,
   OfficialExternalPluginCatalogInstallCandidate,
   OfficialExternalPluginCatalogSourceProfile,
-  OfficialExternalPluginCatalogFeedVerification,
-  OfficialExternalPluginCatalogFeedSigningKey,
   OfficialExternalPluginCatalogProfileConfig,
-  OfficialExternalPluginCatalogFeed,
-  HostedOfficialExternalPluginCatalogSnapshot,
-  HostedOfficialExternalPluginCatalogSnapshotStore,
-  HostedOfficialExternalPluginCatalogTrustState,
   HostedOfficialExternalPluginCatalogLoadResult,
 } from "./official-external-plugin-catalog.types.js";
 import type { PluginPackageInstall } from "./package-manifest.types.js";
@@ -40,277 +38,20 @@ export type {
   HostedOfficialExternalPluginCatalogLoadResult,
 } from "./official-external-plugin-catalog.types.js";
 
-class HostedCatalogSnapshotWriteError extends Error {
-  readonly originalError: unknown;
-
-  constructor(originalError: unknown) {
-    super("hosted catalog snapshot write failed");
-    this.name = "HostedCatalogSnapshotWriteError";
-    this.originalError = originalError;
-  }
-}
-
-export class HostedCatalogSignedFeedMonotonicityError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "HostedCatalogSignedFeedMonotonicityError";
-  }
-}
-
-type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+export {
+  HostedCatalogSignedFeedMonotonicityError,
+  isOfficialExternalPluginCatalogFeed,
+  isOfficialExternalPluginCatalogSequence,
+  parseOfficialExternalPluginCatalogTimestamp,
+  getOfficialExternalPluginCatalogManifest,
+  resolveOfficialExternalPluginId,
+} from "./official-external-plugin-catalog-source.js";
 
 type OfficialExternalProviderContract =
   | "embeddingProviders"
   | "mediaUnderstandingProviders"
   | "speechProviders"
   | "webFetchProviders";
-
-const SUPPORTED_OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSIONS = new Set([1, 2]);
-const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL = "https://clawhub.ai/v1/feeds/plugins";
-const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE = "clawhub-public";
-const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_ID = "clawhub-official";
-const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_SOURCE_REF = "public-clawhub";
-const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_NPM_SOURCE_REF = "public-npm";
-const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEYS: readonly OfficialExternalPluginCatalogFeedSigningKey[] =
-  [];
-const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG: OfficialExternalPluginCatalogProfileConfig =
-  {
-    feeds: {
-      [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE]: {
-        url: DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL,
-        feedId: DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_ID,
-      },
-    },
-    sources: {
-      [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_SOURCE_REF]: {
-        type: "clawhub",
-        baseUrl: "https://clawhub.ai",
-      },
-      [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_NPM_SOURCE_REF]: {
-        type: "npm",
-        registry: "https://registry.npmjs.org/",
-      },
-    },
-  };
-const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS = 5000;
-const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES = 1024 * 1024;
-const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS = 5000;
-const DSSE_ENVELOPE_MEDIA_TYPE = "application/vnd.dsse+json";
-const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST = ["clawhub.ai"];
-const ISO_CALENDAR_DATE_PREFIX_RE = /^(\d{4})-(\d{2})-(\d{2})/u;
-
-export function parseOfficialExternalPluginCatalogTimestamp(value: string): number | undefined {
-  const timestamp = value.trim();
-  const parsed = Date.parse(timestamp);
-  if (!Number.isFinite(parsed)) {
-    return undefined;
-  }
-  const calendarDate = ISO_CALENDAR_DATE_PREFIX_RE.exec(timestamp);
-  if (!calendarDate) {
-    return parsed;
-  }
-  const year = Number(calendarDate[1]);
-  const month = Number(calendarDate[2]);
-  const day = Number(calendarDate[3]);
-  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
-  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-
-  // Shipped releases accepted every Date.parse-compatible serialization. Keep those
-  // formats, but reject ISO-shaped impossible dates that Date.parse normalizes.
-  return month >= 1 && month <= 12 && day >= 1 && day <= daysInMonth[month - 1]!
-    ? parsed
-    : undefined;
-}
-
-export function isOfficialExternalPluginCatalogSequence(value: unknown): value is number {
-  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
-}
-
-export function isOfficialExternalPluginCatalogFeed(
-  raw: unknown,
-): raw is OfficialExternalPluginCatalogFeed {
-  if (!isRecord(raw)) {
-    return false;
-  }
-  const sequence = raw.sequence;
-  const generatedAt = raw.generatedAt;
-  const generatedAtMs =
-    typeof generatedAt === "string"
-      ? parseOfficialExternalPluginCatalogTimestamp(generatedAt)
-      : undefined;
-  const entries = raw.entries;
-  return (
-    typeof raw.schemaVersion === "number" &&
-    SUPPORTED_OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSIONS.has(raw.schemaVersion) &&
-    typeof raw.id === "string" &&
-    raw.id.trim().length > 0 &&
-    typeof generatedAt === "string" &&
-    generatedAt.trim().length > 0 &&
-    generatedAtMs !== undefined &&
-    isOfficialExternalPluginCatalogSequence(sequence) &&
-    Array.isArray(entries)
-  );
-}
-
-function parseOfficialExternalPluginCatalogEntries(
-  raw: unknown,
-): OfficialExternalPluginCatalogEntry[] {
-  if (Array.isArray(raw)) {
-    return raw.filter((entry): entry is OfficialExternalPluginCatalogEntry => isRecord(entry));
-  }
-  if (isOfficialExternalPluginCatalogFeed(raw)) {
-    return raw.entries.filter((entry): entry is OfficialExternalPluginCatalogEntry =>
-      isRecord(entry),
-    );
-  }
-  if (!isRecord(raw)) {
-    return [];
-  }
-  if ("schemaVersion" in raw) {
-    return [];
-  }
-  const list = raw.entries ?? raw.packages ?? raw.plugins;
-  if (!Array.isArray(list)) {
-    return [];
-  }
-  return list.filter((entry): entry is OfficialExternalPluginCatalogEntry => isRecord(entry));
-}
-
-function normalizeHostedCatalogHeader(value: string | null): string | undefined {
-  const normalized = normalizeOptionalString(value);
-  return normalized || undefined;
-}
-
-function sha256Hex(value: string): string {
-  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
-}
-
-function resolveHostedCatalogFeedUrl(raw: string): URL {
-  let parsed: URL;
-  try {
-    parsed = new URL(raw.trim());
-  } catch {
-    throw new Error("hosted catalog feed URL is invalid");
-  }
-  if (parsed.protocol !== "https:") {
-    throw new Error("hosted catalog feed URL must use HTTPS");
-  }
-  if (parsed.username || parsed.password) {
-    throw new Error("hosted catalog feed URL must not include credentials");
-  }
-  if (parsed.search || parsed.hash) {
-    throw new Error("hosted catalog feed URL must not include query strings or fragments");
-  }
-  return parsed;
-}
-
-function resolveOfficialExternalPluginCatalogProfileConfig(
-  config?: OfficialExternalPluginCatalogProfileConfig,
-): Required<OfficialExternalPluginCatalogProfileConfig> {
-  const configuredDefaultFeed =
-    config?.feeds?.[DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE];
-  const bundledVerification =
-    DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEYS.length > 0
-      ? {
-          mode: "signed" as const,
-          keys: DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEYS,
-        }
-      : undefined;
-  const defaultFeed = DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG.feeds?.[
-    DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE
-  ] ?? {
-    url: DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL,
-    feedId: DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_ID,
-  };
-  return {
-    feeds: {
-      ...config?.feeds,
-      [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE]: {
-        ...defaultFeed,
-        ...(bundledVerification ? { verification: bundledVerification } : {}),
-        ...configuredDefaultFeed,
-      },
-    },
-    sources: {
-      ...DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG.sources,
-      ...config?.sources,
-    },
-  };
-}
-
-function resolveHostedCatalogFeedSource(params: {
-  feedUrl?: string;
-  feedProfile?: string;
-  catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
-}): {
-  url: URL;
-  hostnameAllowlist: string[];
-  expectedFeedId?: string;
-  verification?: OfficialExternalPluginCatalogFeedVerification;
-} {
-  const explicitFeedUrl = normalizeOptionalString(params.feedUrl);
-  const explicitProfileName = normalizeOptionalString(params.feedProfile);
-  if (explicitFeedUrl) {
-    const url = resolveHostedCatalogFeedUrl(explicitFeedUrl);
-    if (!OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST.includes(url.hostname)) {
-      throw new Error("hosted catalog feed URL hostname is not allowed");
-    }
-    const defaultProfile =
-      explicitProfileName === undefined
-        ? resolveOfficialExternalPluginCatalogProfileConfig(params.catalogConfig).feeds[
-            DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE
-          ]
-        : undefined;
-    const profileName =
-      explicitProfileName ??
-      (defaultProfile && resolveHostedCatalogFeedUrl(defaultProfile.url).href === url.href
-        ? DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE
-        : undefined);
-    const profileConfig =
-      profileName === undefined
-        ? undefined
-        : resolveOfficialExternalPluginCatalogProfileConfig(params.catalogConfig);
-    const profile = profileName === undefined ? undefined : profileConfig?.feeds[profileName];
-    if (profileName !== undefined && !profile) {
-      throw new Error(`hosted catalog feed profile "${profileName}" is not configured`);
-    }
-    return {
-      url,
-      hostnameAllowlist: OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST,
-      ...(profile?.feedId ? { expectedFeedId: profile.feedId } : {}),
-      ...(profile?.verification ? { verification: profile.verification } : {}),
-    };
-  }
-  const profileName = explicitProfileName ?? DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE;
-  const profileConfig = resolveOfficialExternalPluginCatalogProfileConfig(params.catalogConfig);
-  const profile = profileConfig.feeds[profileName];
-  if (!profile) {
-    throw new Error(`hosted catalog feed profile "${profileName}" is not configured`);
-  }
-  const url = resolveHostedCatalogFeedUrl(profile.url);
-  return {
-    url,
-    hostnameAllowlist: uniqueStrings([
-      ...OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST,
-      url.hostname,
-    ]),
-    ...(profile.feedId ? { expectedFeedId: profile.feedId } : {}),
-    verification: profile.verification,
-  };
-}
-
-function getFeedEntryInstallCandidateRecords(
-  entry: OfficialExternalPluginCatalogEntry,
-): OfficialExternalPluginCatalogInstallCandidate[] {
-  const install = isRecord(entry.install) ? entry.install : undefined;
-  const candidates = install?.candidates;
-  if (!Array.isArray(candidates)) {
-    return [];
-  }
-  return candidates.filter(
-    (candidate): candidate is OfficialExternalPluginCatalogInstallCandidate => isRecord(candidate),
-  );
-}
 
 function getFeedEntryInstallCandidates(
   entry: OfficialExternalPluginCatalogEntry,
@@ -326,804 +67,43 @@ function getFeedEntryInstallCandidates(
   return getFeedEntryInstallCandidateRecords(entry);
 }
 
-function shouldRequireManifestInstallSourceRef(params: {
-  feedUrl?: string;
-  feedProfile?: string;
-  catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
-}): boolean {
-  const feedUrl = normalizeOptionalString(params.feedUrl);
-  if (feedUrl) {
-    try {
-      return (
-        resolveHostedCatalogFeedUrl(feedUrl).href !==
-        resolveHostedCatalogFeedUrl(DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL).href
-      );
-    } catch {
-      return true;
+const BUNDLED_CATALOG_SOURCE_REFS = new Set(
+  Object.keys(DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG.sources ?? {}),
+);
+
+function* bundledOfficialExternalPluginCatalogEntries(): Generator<OfficialExternalPluginCatalogEntry> {
+  const seen = new Set<string>();
+  for (const entry of BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_ENTRIES) {
+    const install = isRecord(entry.install) ? entry.install : undefined;
+    const candidates = install?.candidates;
+    if (
+      Array.isArray(candidates) &&
+      candidates.some((candidate) => {
+        if (!isRecord(candidate)) {
+          return false;
+        }
+        return !hasKnownCatalogSourceRef(candidate, BUNDLED_CATALOG_SOURCE_REFS);
+      })
+    ) {
+      continue;
     }
-  }
-  const profileName =
-    normalizeOptionalString(params.feedProfile) ??
-    DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE;
-  if (profileName !== DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE) {
-    return true;
-  }
-  const profileConfig = resolveOfficialExternalPluginCatalogProfileConfig(params.catalogConfig);
-  const profileUrl = normalizeOptionalString(profileConfig.feeds[profileName]?.url);
-  try {
-    return (
-      resolveHostedCatalogFeedUrl(profileUrl ?? DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL)
-        .href !==
-      resolveHostedCatalogFeedUrl(DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL).href
-    );
-  } catch {
-    return true;
-  }
-}
-
-function getManifestInstallSourceRefCandidate(
-  entry: OfficialExternalPluginCatalogEntry,
-): OfficialExternalPluginCatalogInstallCandidate | undefined {
-  const install = getOfficialExternalPluginCatalogManifest(entry)?.install;
-  if (!install) {
-    return undefined;
-  }
-  const hasInstallSpec = Boolean(
-    normalizeOptionalString(install.clawhubSpec) ||
-    normalizeOptionalString(install.npmSpec) ||
-    normalizeOptionalString(install.localPath),
-  );
-  if (!hasInstallSpec) {
-    return undefined;
-  }
-  return {
-    sourceRef: normalizeOptionalString(install.sourceRef),
-    package:
-      normalizeOptionalString(install.npmSpec) ?? normalizeOptionalString(install.clawhubSpec),
-  };
-}
-
-function filterOfficialExternalPluginCatalogEntriesBySourceRefs(
-  entries: OfficialExternalPluginCatalogEntry[],
-  params?: {
-    catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
-    requireManifestInstallSourceRef?: boolean;
-  },
-): OfficialExternalPluginCatalogEntry[] {
-  let configuredSourceRefs: Set<string> | undefined;
-  return entries.filter((entry) => {
-    // One synchronous batch owns these configured facts; empty batches stay lazy.
-    configuredSourceRefs ??= new Set(
-      Object.keys(resolveOfficialExternalPluginCatalogProfileConfig(params?.catalogConfig).sources),
-    );
-    let candidates = getFeedEntryInstallCandidateRecords(entry);
-    if (params?.requireManifestInstallSourceRef) {
-      const manifestCandidate = getManifestInstallSourceRefCandidate(entry);
-      if (manifestCandidate) {
-        candidates = [...candidates, manifestCandidate];
-      } else if (candidates.length === 0) {
-        candidates = [{}];
-      }
-    }
-    let valid = true;
-    for (const candidate of candidates) {
-      const sourceRef = normalizeOptionalString(candidate.sourceRef);
-      if (!sourceRef || !configuredSourceRefs.has(sourceRef)) {
-        valid = false;
-      }
-    }
-    return valid;
-  });
-}
-
-function parseHostedCatalogContentLength(raw: string | null, maxBytes: number): void {
-  const normalized = normalizeOptionalString(raw);
-  if (!normalized) {
-    return;
-  }
-  if (!/^\d+$/.test(normalized)) {
-    throw new Error("hosted catalog feed has invalid content-length");
-  }
-  const size = Number(normalized);
-  if (!Number.isSafeInteger(size) || size > maxBytes) {
-    throw new Error(`hosted catalog feed exceeds ${maxBytes} bytes`);
-  }
-}
-
-async function readHostedCatalogResponseText(params: {
-  response: Response;
-  maxBytes: number;
-  chunkTimeoutMs: number;
-}): Promise<string> {
-  parseHostedCatalogContentLength(params.response.headers.get("content-length"), params.maxBytes);
-  const streamless = !params.response.body || typeof params.response.body.getReader !== "function";
-  // Hosted remote feeds are untrusted input, so fail closed when Fetch cannot
-  // provide a streaming body instead of trusting Content-Length before read.
-  if (streamless) {
-    throw new Error("hosted catalog feed streaming response body unavailable");
-  }
-  const buffer = await readResponseWithLimit(params.response, params.maxBytes, {
-    chunkTimeoutMs: params.chunkTimeoutMs,
-    onOverflow: ({ maxBytes }) => new Error(`hosted catalog feed exceeds ${maxBytes} bytes`),
-    onIdleTimeout: ({ chunkTimeoutMs }) =>
-      new Error(`hosted catalog feed read timed out after ${chunkTimeoutMs}ms`),
-  });
-  return new TextDecoder("utf-8", { fatal: true }).decode(buffer);
-}
-
-function bundledOfficialExternalPluginCatalogEntries(): OfficialExternalPluginCatalogEntry[] {
-  return BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOGS.flatMap((source) =>
-    filterOfficialExternalPluginCatalogEntriesBySourceRefs(
-      parseOfficialExternalPluginCatalogEntries(source),
-    ),
-  );
-}
-
-function dedupeOfficialExternalPluginCatalogEntries(
-  entries: OfficialExternalPluginCatalogEntry[],
-): OfficialExternalPluginCatalogEntry[] {
-  const resolved = new Map<string, OfficialExternalPluginCatalogEntry>();
-  for (const entry of entries) {
     const key = resolveOfficialExternalPluginCatalogEntryKey(entry);
-    if (key && !resolved.has(key)) {
-      resolved.set(key, entry);
+    if (key && !seen.has(key)) {
+      seen.add(key);
+      yield entry;
     }
   }
-  return [...resolved.values()];
 }
 
-function resolveOfficialExternalPluginCatalogEntryKey(
-  entry: OfficialExternalPluginCatalogEntry,
-): string | undefined {
-  const pluginId = resolveOfficialExternalPluginId(entry);
-  if (pluginId) {
-    return `${normalizeOptionalString(entry.kind) ?? "plugin"}:${pluginId}`;
-  }
-  const name = normalizeOptionalString(entry.name);
-  if (name) {
-    return name;
-  }
-  const id = normalizeOptionalString(entry.id);
-  if (id) {
-    return `${normalizeOptionalString(entry.kind) ?? normalizeOptionalString(entry.type) ?? "plugin"}:${id}`;
+function findBundledOfficialExternalPluginCatalogEntry(
+  matches: (entry: OfficialExternalPluginCatalogEntry) => boolean,
+): OfficialExternalPluginCatalogEntry | undefined {
+  for (const entry of bundledOfficialExternalPluginCatalogEntries()) {
+    if (matches(entry)) {
+      return entry;
+    }
   }
   return undefined;
-}
-
-function bundledFallbackResult(
-  error: unknown,
-  metadata?: HostedOfficialExternalPluginCatalogLoadResult["metadata"],
-): HostedOfficialExternalPluginCatalogLoadResult {
-  return {
-    source: "bundled-fallback",
-    entries: listOfficialExternalPluginCatalogEntries(),
-    error: formatErrorMessage(error),
-    ...(metadata ? { metadata } : {}),
-  };
-}
-
-function emptyBundledFallbackResult(error: unknown): HostedOfficialExternalPluginCatalogLoadResult {
-  return {
-    source: "bundled-fallback",
-    entries: [],
-    error: formatErrorMessage(error),
-  };
-}
-
-async function parseHostedCatalogFeedBody(params: {
-  body: string;
-  expectedFeedId?: string;
-  verification?: OfficialExternalPluginCatalogFeedVerification;
-  verifiedAt: string;
-  allowLegacyBetaEnvelope?: boolean;
-  now: Date;
-  allowExpired?: boolean;
-  allowMissingExpiry?: boolean;
-}): Promise<{
-  feed: OfficialExternalPluginCatalogFeed;
-  trust?: HostedOfficialExternalPluginCatalogTrustState;
-  expired?: boolean;
-}> {
-  const raw = JSON.parse(params.body) as unknown;
-  if (params.verification?.mode === "signed") {
-    const { verifyOfficialExternalPluginCatalogSignedEnvelope } =
-      await import("./official-external-plugin-catalog-envelope.js");
-    const threshold = params.verification.threshold ?? 1;
-    const verification = verifyOfficialExternalPluginCatalogSignedEnvelope(raw, {
-      trustedKeys: params.verification.keys,
-      threshold,
-      ...(params.allowLegacyBetaEnvelope ? { allowLegacyBetaEnvelope: true } : {}),
-    });
-    if (!verification.ok) {
-      const invalidTimestampSequence =
-        verification.error === "invalid-payload" && "authenticatedPayload" in verification
-          ? readOfficialExternalPluginCatalogInvalidTimestampSequence(
-              verification.authenticatedPayload,
-            )
-          : undefined;
-      if (invalidTimestampSequence !== undefined) {
-        throw new HostedCatalogFeedTimestampError(verification.message, invalidTimestampSequence);
-      }
-      throw new Error(verification.message);
-    }
-    if (params.expectedFeedId && verification.feed.id !== params.expectedFeedId) {
-      throw new Error(
-        `hosted catalog feed id "${verification.feed.id}" did not match expected "${params.expectedFeedId}"`,
-      );
-    }
-    const generatedAtMs = parseOfficialExternalPluginCatalogTimestamp(
-      verification.feed.generatedAt,
-    );
-    const expiresAt = normalizeOptionalString(verification.feed.expiresAt);
-    if (generatedAtMs === undefined) {
-      throw new Error("hosted catalog signed feed requires a valid generatedAt value");
-    }
-    let expired: boolean;
-    if (!expiresAt) {
-      if (params.allowMissingExpiry !== true) {
-        throw new Error("hosted catalog signed feed requires a valid expiresAt value");
-      }
-      expired = true;
-    } else {
-      const expiresAtMs = parseOfficialExternalPluginCatalogTimestamp(expiresAt);
-      if (expiresAtMs === undefined) {
-        throw new Error("hosted catalog signed feed requires a valid expiresAt value");
-      }
-      if (expiresAtMs <= generatedAtMs) {
-        throw new Error("hosted catalog signed feed expiresAt must be later than generatedAt");
-      }
-      expired = expiresAtMs <= params.now.getTime();
-    }
-    if (expired && params.allowExpired !== true) {
-      throw new Error(
-        expiresAt
-          ? `hosted catalog signed feed expired at ${expiresAt}`
-          : "hosted catalog signed feed has no expiresAt",
-      );
-    }
-    return {
-      feed: enforceHostedCatalogFeedInstallAuthority(verification.feed),
-      trust: {
-        mode: "signed",
-        signedBy: verification.signedBy,
-        signatureCount: verification.signatureCount ?? 1,
-        threshold,
-        verifiedAt: params.verifiedAt,
-      },
-      ...(expired ? { expired: true } : {}),
-    };
-  }
-  if (!isOfficialExternalPluginCatalogFeed(raw)) {
-    throw new Error("hosted catalog feed did not match a supported schema version");
-  }
-  if (params.expectedFeedId && raw.id !== params.expectedFeedId) {
-    throw new Error(
-      `hosted catalog feed id "${raw.id}" did not match expected "${params.expectedFeedId}"`,
-    );
-  }
-  return { feed: enforceHostedCatalogFeedInstallAuthority(raw) };
-}
-
-function enforceHostedCatalogFeedInstallAuthority(
-  feed: OfficialExternalPluginCatalogFeed,
-): OfficialExternalPluginCatalogFeed {
-  if (feed.schemaVersion < 2) {
-    return feed;
-  }
-  return {
-    ...feed,
-    entries: feed.entries.map((entry) => {
-      const state = normalizeOptionalString(entry.state);
-      const publisherTrust = normalizeOptionalString(entry.publisher?.trust);
-      return state === "available" && publisherTrust === "official"
-        ? entry
-        : removeOfficialExternalPluginCatalogInstallAuthority(entry);
-    }),
-  };
-}
-
-class HostedCatalogFeedTimestampError extends Error {
-  constructor(
-    message: string,
-    readonly sequence: number,
-  ) {
-    super(message);
-  }
-}
-
-function readOfficialExternalPluginCatalogInvalidTimestampSequence(
-  raw: unknown,
-): number | undefined {
-  if (!isRecord(raw)) {
-    return undefined;
-  }
-  if (
-    typeof raw.generatedAt === "string" &&
-    parseOfficialExternalPluginCatalogTimestamp(raw.generatedAt) !== undefined
-  ) {
-    return undefined;
-  }
-  const normalized = {
-    ...raw,
-    generatedAt: "1970-01-01T00:00:00.000Z",
-  };
-  return isOfficialExternalPluginCatalogFeed(normalized) ? normalized.sequence : undefined;
-}
-
-async function loadHostedCatalogSnapshotResult(params: {
-  snapshot: HostedOfficialExternalPluginCatalogSnapshot;
-  error: unknown;
-  expectedSha256?: string;
-  ifNoneMatch?: string;
-  ifModifiedSince?: string;
-  catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
-  requireManifestInstallSourceRef?: boolean;
-  expectedFeedId?: string;
-  verification?: OfficialExternalPluginCatalogFeedVerification;
-  now: Date;
-}): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
-  assertSnapshotMatchesRequestValidators({
-    snapshot: params.snapshot,
-    ifNoneMatch: params.ifNoneMatch,
-    ifModifiedSince: params.ifModifiedSince,
-  });
-  const checksum = sha256Hex(params.snapshot.body);
-  if (checksum !== params.snapshot.metadata.checksum) {
-    throw new Error("hosted catalog snapshot checksum mismatch");
-  }
-  if (params.expectedSha256 && params.expectedSha256 !== checksum) {
-    throw new Error("hosted catalog snapshot checksum did not match expected checksum");
-  }
-  const parsed = await parseHostedCatalogFeedBody({
-    body: params.snapshot.body,
-    expectedFeedId: params.expectedFeedId,
-    verification: params.verification,
-    verifiedAt: params.snapshot.trust?.verifiedAt ?? params.snapshot.savedAt,
-    allowLegacyBetaEnvelope: true,
-    now: params.now,
-    allowExpired: true,
-    allowMissingExpiry: true,
-  });
-  const entries = dedupeOfficialExternalPluginCatalogEntries(
-    filterOfficialExternalPluginCatalogEntriesBySourceRefs(
-      parseOfficialExternalPluginCatalogEntries(parsed.feed),
-      {
-        catalogConfig: params.catalogConfig,
-        requireManifestInstallSourceRef: params.requireManifestInstallSourceRef,
-      },
-    ),
-  );
-  const visibleEntries = parsed.expired
-    ? entries.map((entry) => removeOfficialExternalPluginCatalogInstallAuthority(entry))
-    : entries;
-  return {
-    source: "hosted-snapshot",
-    entries: visibleEntries,
-    feed: parsed.expired ? { ...parsed.feed, entries: visibleEntries } : parsed.feed,
-    metadata: params.snapshot.metadata,
-    snapshot: params.snapshot,
-    ...(parsed.trust ? { trust: parsed.trust } : {}),
-    error: parsed.expired
-      ? `${formatErrorMessage(params.error)}; ${parsed.feed.expiresAt ? `hosted catalog signed feed expired at ${parsed.feed.expiresAt}` : "hosted catalog signed feed has no expiresAt"}`
-      : formatErrorMessage(params.error),
-  };
-}
-
-function removeOfficialExternalPluginCatalogInstallAuthority(
-  entry: OfficialExternalPluginCatalogEntry,
-): OfficialExternalPluginCatalogEntry {
-  const { install: _feedInstall, [MANIFEST_KEY]: manifest, ...metadata } = entry;
-  if (!manifest) {
-    return { ...metadata, state: "unavailable" };
-  }
-  const { install: _manifestInstall, ...manifestMetadata } = manifest;
-  return {
-    ...metadata,
-    state: "unavailable",
-    [MANIFEST_KEY]: manifestMetadata,
-  };
-}
-
-function isHostedCatalogSignedFeedRollback(params: {
-  candidate: OfficialExternalPluginCatalogFeed;
-  current: Pick<OfficialExternalPluginCatalogFeed, "sequence"> & { generatedAt?: string };
-}): boolean {
-  if (params.candidate.sequence < params.current.sequence) {
-    return true;
-  }
-  if (params.candidate.sequence > params.current.sequence) {
-    return false;
-  }
-  if (params.current.generatedAt === undefined) {
-    return false;
-  }
-  return Date.parse(params.candidate.generatedAt) < Date.parse(params.current.generatedAt);
-}
-
-function assertSnapshotMatchesRequestValidators(params: {
-  snapshot: HostedOfficialExternalPluginCatalogSnapshot;
-  ifNoneMatch?: string;
-  ifModifiedSince?: string;
-}): void {
-  if (params.ifNoneMatch && params.snapshot.metadata.etag !== params.ifNoneMatch) {
-    throw new Error("hosted catalog snapshot ETag did not match request validator");
-  }
-  if (
-    !params.ifNoneMatch &&
-    params.ifModifiedSince &&
-    params.snapshot.metadata.lastModified !== params.ifModifiedSince
-  ) {
-    throw new Error("hosted catalog snapshot Last-Modified did not match request validator");
-  }
-}
-
-async function snapshotOrBundledFallbackResult(params: {
-  error: unknown;
-  snapshotStore?: HostedOfficialExternalPluginCatalogSnapshotStore;
-  url: string;
-  metadata?: HostedOfficialExternalPluginCatalogLoadResult["metadata"];
-  expectedSha256?: string;
-  ifNoneMatch?: string;
-  ifModifiedSince?: string;
-  catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
-  requireManifestInstallSourceRef?: boolean;
-  expectedFeedId?: string;
-  verification?: OfficialExternalPluginCatalogFeedVerification;
-  now: Date;
-}): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
-  if (params.snapshotStore) {
-    try {
-      const snapshot = await params.snapshotStore.read(params.url);
-      if (snapshot) {
-        return await loadHostedCatalogSnapshotResult({
-          snapshot,
-          error: params.error,
-          expectedSha256: params.expectedSha256,
-          ifNoneMatch: params.ifNoneMatch,
-          ifModifiedSince: params.ifModifiedSince,
-          catalogConfig: params.catalogConfig,
-          requireManifestInstallSourceRef: params.requireManifestInstallSourceRef,
-          expectedFeedId: params.expectedFeedId,
-          verification: params.verification,
-          now: params.now,
-        });
-      }
-    } catch (snapshotErr) {
-      if (params.verification?.mode === "signed") {
-        return emptyBundledFallbackResult(
-          `${formatErrorMessage(params.error)}; snapshot fallback failed: ${formatErrorMessage(snapshotErr)}`,
-        );
-      }
-      return bundledFallbackResult(
-        `${formatErrorMessage(params.error)}; snapshot fallback failed: ${formatErrorMessage(snapshotErr)}`,
-        params.metadata,
-      );
-    }
-  }
-  if (params.verification?.mode === "signed") {
-    return emptyBundledFallbackResult(params.error);
-  }
-  return bundledFallbackResult(params.error, params.metadata);
-}
-async function resolveHostedCatalogSnapshotStore(params: {
-  snapshotStore?: HostedOfficialExternalPluginCatalogSnapshotStore | null;
-  env?: NodeJS.ProcessEnv;
-  stateDir?: string;
-  stateDatabasePath?: string;
-}): Promise<HostedOfficialExternalPluginCatalogSnapshotStore | undefined> {
-  if (params.snapshotStore !== undefined) {
-    return params.snapshotStore ?? undefined;
-  }
-  const { createSqliteHostedOfficialExternalPluginCatalogSnapshotStore } =
-    await import("./official-external-plugin-catalog-snapshot-store.js");
-  return createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({
-    ...(params.env ? { env: params.env } : {}),
-    ...(params.stateDir ? { stateDir: params.stateDir } : {}),
-    ...(params.stateDatabasePath ? { stateDatabasePath: params.stateDatabasePath } : {}),
-  });
-}
-
-async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
-  feedUrl?: string;
-  feedProfile?: string;
-  catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
-  fetchImpl?: FetchLike;
-  timeoutMs?: number;
-  maxBytes?: number;
-  chunkTimeoutMs?: number;
-  ifNoneMatch?: string;
-  ifModifiedSince?: string;
-  expectedSha256?: string;
-  offline?: boolean;
-  requireSnapshotWrite?: boolean;
-  snapshotStore?: HostedOfficialExternalPluginCatalogSnapshotStore | null;
-  env?: NodeJS.ProcessEnv;
-  stateDir?: string;
-  stateDatabasePath?: string;
-  now?: () => Date;
-}): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
-  let source: {
-    url: URL;
-    hostnameAllowlist: string[];
-    expectedFeedId?: string;
-    verification?: OfficialExternalPluginCatalogFeedVerification;
-  };
-  try {
-    source = resolveHostedCatalogFeedSource({
-      feedUrl: params?.feedUrl,
-      feedProfile: params?.feedProfile,
-      catalogConfig: params?.catalogConfig,
-    });
-  } catch (err) {
-    return bundledFallbackResult(err);
-  }
-  const { url } = source;
-  const snapshotStore = await resolveHostedCatalogSnapshotStore({
-    snapshotStore: params?.snapshotStore,
-    env: params?.env,
-    stateDir: params?.stateDir,
-    stateDatabasePath: params?.stateDatabasePath,
-  });
-  const expectedSha256 = normalizeOptionalString(params?.expectedSha256);
-  const currentTime = () => params?.now?.() ?? new Date();
-  const requireManifestInstallSourceRef = shouldRequireManifestInstallSourceRef({
-    feedUrl: params?.feedUrl,
-    feedProfile: params?.feedProfile,
-    catalogConfig: params?.catalogConfig,
-  });
-  if (params?.offline === true) {
-    return await snapshotOrBundledFallbackResult({
-      error: "hosted catalog feed offline mode",
-      snapshotStore,
-      url: url.href,
-      expectedSha256,
-      catalogConfig: params?.catalogConfig,
-      requireManifestInstallSourceRef,
-      expectedFeedId: source.expectedFeedId,
-      verification: source.verification,
-      now: currentTime(),
-    });
-  }
-  const headers = new Headers();
-  const ifNoneMatch = normalizeOptionalString(params?.ifNoneMatch);
-  const signedOperation = source.verification?.mode === "signed";
-  const ifModifiedSince = signedOperation
-    ? undefined
-    : normalizeOptionalString(params?.ifModifiedSince);
-  if (ifNoneMatch) {
-    headers.set("if-none-match", ifNoneMatch);
-  }
-  if (ifModifiedSince) {
-    headers.set("if-modified-since", ifModifiedSince);
-  }
-  if (signedOperation) {
-    headers.set("accept", DSSE_ENVELOPE_MEDIA_TYPE);
-  }
-  const metadataBase = (response: Response) => {
-    const etag = normalizeHostedCatalogHeader(response.headers.get("etag"));
-    const lastModified = normalizeHostedCatalogHeader(response.headers.get("last-modified"));
-    return {
-      url: url.href,
-      status: response.status,
-      ...(etag ? { etag } : {}),
-      ...(lastModified ? { lastModified } : {}),
-    };
-  };
-  let response: Response | undefined;
-  let release: (() => Promise<void>) | undefined;
-  try {
-    const { fetchWithSsrFGuard } = await import("../infra/net/fetch-guard.js");
-    const guarded = await fetchWithSsrFGuard({
-      url: url.href,
-      fetchImpl: params?.fetchImpl,
-      init: { method: "GET", headers },
-      requireHttps: true,
-      maxRedirects: 2,
-      timeoutMs: params?.timeoutMs ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS,
-      policy: { hostnameAllowlist: source.hostnameAllowlist },
-      auditContext: "official-external-plugin-catalog-feed",
-    });
-    response = guarded.response;
-    release = guarded.release;
-    const base = metadataBase(response);
-    if (response.status === 304) {
-      return await snapshotOrBundledFallbackResult({
-        error: "hosted catalog feed returned HTTP 304",
-        snapshotStore,
-        url: url.href,
-        metadata: base,
-        expectedSha256,
-        ifNoneMatch,
-        ifModifiedSince,
-        catalogConfig: params?.catalogConfig,
-        requireManifestInstallSourceRef,
-        expectedFeedId: source.expectedFeedId,
-        verification: source.verification,
-        now: currentTime(),
-      });
-    }
-    if (!response.ok) {
-      return await snapshotOrBundledFallbackResult({
-        error: `hosted catalog feed returned HTTP ${response.status}`,
-        snapshotStore,
-        url: url.href,
-        metadata: base,
-        expectedSha256,
-        ifNoneMatch,
-        ifModifiedSince,
-        catalogConfig: params?.catalogConfig,
-        requireManifestInstallSourceRef,
-        expectedFeedId: source.expectedFeedId,
-        verification: source.verification,
-        now: currentTime(),
-      });
-    }
-    if (
-      signedOperation &&
-      response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase() !==
-        DSSE_ENVELOPE_MEDIA_TYPE
-    ) {
-      return await snapshotOrBundledFallbackResult({
-        error: `signed hosted catalog feed must use ${DSSE_ENVELOPE_MEDIA_TYPE}`,
-        snapshotStore,
-        url: url.href,
-        metadata: base,
-        expectedSha256,
-        ifNoneMatch,
-        catalogConfig: params?.catalogConfig,
-        requireManifestInstallSourceRef,
-        expectedFeedId: source.expectedFeedId,
-        verification: source.verification,
-        now: currentTime(),
-      });
-    }
-    const body = await readHostedCatalogResponseText({
-      response,
-      maxBytes: params?.maxBytes ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES,
-      chunkTimeoutMs:
-        params?.chunkTimeoutMs ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS,
-    });
-    const checksum = sha256Hex(body);
-    const metadata = { ...base, checksum };
-    if (expectedSha256 && expectedSha256 !== checksum) {
-      return await snapshotOrBundledFallbackResult({
-        error: `hosted catalog feed checksum mismatch: expected ${expectedSha256}`,
-        snapshotStore,
-        url: url.href,
-        metadata,
-        expectedSha256,
-        ifNoneMatch,
-        ifModifiedSince,
-        catalogConfig: params?.catalogConfig,
-        requireManifestInstallSourceRef,
-        expectedFeedId: source.expectedFeedId,
-        verification: source.verification,
-        now: currentTime(),
-      });
-    }
-    const now = currentTime();
-    const verifiedAt = now.toISOString();
-    const parsed = await parseHostedCatalogFeedBody({
-      body,
-      expectedFeedId: source.expectedFeedId,
-      verification: source.verification,
-      verifiedAt,
-      now,
-    }).catch(async (err: unknown) => {
-      return await snapshotOrBundledFallbackResult({
-        error: err,
-        snapshotStore,
-        url: url.href,
-        metadata,
-        expectedSha256,
-        ifNoneMatch,
-        ifModifiedSince,
-        catalogConfig: params?.catalogConfig,
-        requireManifestInstallSourceRef,
-        expectedFeedId: source.expectedFeedId,
-        verification: source.verification,
-        now,
-      });
-    });
-    if ("source" in parsed) {
-      return parsed;
-    }
-    if (snapshotStore && parsed.trust?.mode === "signed") {
-      const currentSnapshot = await snapshotStore.read(url.href);
-      if (currentSnapshot?.trust?.mode === "signed") {
-        const current =
-          currentSnapshot.monotonic?.mode === "signed-feed"
-            ? currentSnapshot.monotonic
-            : (
-                await parseHostedCatalogFeedBody({
-                  body: currentSnapshot.body,
-                  expectedFeedId: source.expectedFeedId,
-                  verification: source.verification,
-                  verifiedAt: currentSnapshot.trust.verifiedAt,
-                  allowLegacyBetaEnvelope: true,
-                  now,
-                  allowExpired: true,
-                  allowMissingExpiry: true,
-                }).catch((err: unknown) => {
-                  // Only an authenticated invalid-timestamp payload is repairable. Signature
-                  // and trust failures must remain fail-closed so rollback checks cannot be bypassed.
-                  if (err instanceof HostedCatalogFeedTimestampError) {
-                    return { feed: { sequence: err.sequence } };
-                  }
-                  throw err;
-                })
-              ).feed;
-        if (
-          isHostedCatalogSignedFeedRollback({
-            candidate: parsed.feed,
-            current,
-          })
-        ) {
-          throw new HostedCatalogSignedFeedMonotonicityError(
-            "hosted catalog signed feed sequence is older than current snapshot",
-          );
-        }
-      }
-    }
-    const entries = filterOfficialExternalPluginCatalogEntriesBySourceRefs(
-      parseOfficialExternalPluginCatalogEntries(parsed.feed),
-      {
-        catalogConfig: params?.catalogConfig,
-        requireManifestInstallSourceRef,
-      },
-    );
-    await snapshotStore
-      ?.write({
-        body,
-        metadata,
-        savedAt: verifiedAt,
-        ...(parsed.trust ? { trust: parsed.trust } : {}),
-        ...(parsed.trust?.mode === "signed"
-          ? {
-              monotonic: {
-                mode: "signed-feed",
-                sequence: parsed.feed.sequence,
-                generatedAt: parsed.feed.generatedAt,
-              },
-            }
-          : {}),
-      })
-      .catch((err: unknown) => {
-        if (err instanceof HostedCatalogSignedFeedMonotonicityError) {
-          throw err;
-        }
-        if (params?.requireSnapshotWrite) {
-          throw new HostedCatalogSnapshotWriteError(err);
-        }
-      });
-    return {
-      source: "hosted",
-      entries: dedupeOfficialExternalPluginCatalogEntries(entries),
-      feed: parsed.feed,
-      metadata,
-      ...(parsed.trust ? { trust: parsed.trust } : {}),
-    };
-  } catch (err) {
-    if (err instanceof HostedCatalogSnapshotWriteError) {
-      throw err.originalError;
-    }
-    return await snapshotOrBundledFallbackResult({
-      error: err,
-      snapshotStore,
-      url: url.href,
-      expectedSha256,
-      ifNoneMatch,
-      ifModifiedSince,
-      catalogConfig: params?.catalogConfig,
-      requireManifestInstallSourceRef,
-      expectedFeedId: source.expectedFeedId,
-      verification: source.verification,
-      now: currentTime(),
-    });
-  } finally {
-    await cancelUnreadResponseBody(response);
-    await release?.().catch(() => undefined);
-  }
 }
 
 function formatFeedInstallCandidateSpec(
@@ -1230,25 +210,6 @@ function normalizeNpmExpectedIntegrity(value: unknown): string | undefined {
 }
 
 /** Returns manifest metadata from an official external catalog entry when present. */
-export function getOfficialExternalPluginCatalogManifest(
-  entry: OfficialExternalPluginCatalogEntry,
-): OfficialExternalPluginCatalogManifest | undefined {
-  const manifest = entry[MANIFEST_KEY];
-  return isRecord(manifest) ? manifest : undefined;
-}
-
-export function resolveOfficialExternalPluginId(
-  entry: OfficialExternalPluginCatalogEntry,
-): string | undefined {
-  const manifest = getOfficialExternalPluginCatalogManifest(entry);
-  return (
-    normalizeOptionalString(manifest?.plugin?.id) ??
-    normalizeOptionalString(manifest?.channel?.id) ??
-    normalizeOptionalString(manifest?.providers?.[0]?.id) ??
-    normalizeOptionalString(entry.id)
-  );
-}
-
 /** Returns legacy plugin ids used only for trusted update migrations. */
 export function resolveOfficialExternalPluginLegacyIds(
   entry: OfficialExternalPluginCatalogEntry,
@@ -1363,13 +324,17 @@ export function resolveOfficialExternalPluginInstall(
 }
 
 export async function loadConfiguredHostedOfficialExternalPluginCatalogEntries(
-  params?: Parameters<typeof loadHostedOfficialExternalPluginCatalogEntries>[0],
+  params?: Parameters<
+    typeof import("./official-external-plugin-catalog-hosted.js").loadHostedOfficialExternalPluginCatalogEntries
+  >[0],
 ): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
+  const { loadHostedOfficialExternalPluginCatalogEntries } =
+    await import("./official-external-plugin-catalog-hosted.js");
   return await loadHostedOfficialExternalPluginCatalogEntries(params);
 }
 
 export function listOfficialExternalPluginCatalogEntries(): OfficialExternalPluginCatalogEntry[] {
-  return dedupeOfficialExternalPluginCatalogEntries(bundledOfficialExternalPluginCatalogEntries());
+  return [...bundledOfficialExternalPluginCatalogEntries()];
 }
 
 /** Returns whether an id is the canonical id of an official external plugin. */
@@ -1378,8 +343,10 @@ export function isOfficialExternalPluginId(pluginId: string): boolean {
   if (!normalized) {
     return false;
   }
-  return listOfficialExternalPluginCatalogEntries().some(
-    (entry) => resolveOfficialExternalPluginId(entry)?.toLowerCase() === normalized,
+  return (
+    findBundledOfficialExternalPluginCatalogEntry(
+      (entry) => resolveOfficialExternalPluginId(entry)?.toLowerCase() === normalized,
+    ) !== undefined
   );
 }
 
@@ -1397,7 +364,7 @@ export function resolveOfficialExternalProviderContractPluginIds(params: {
     return [];
   }
   const pluginIds = new Set<string>();
-  for (const entry of listOfficialExternalPluginCatalogEntries()) {
+  for (const entry of bundledOfficialExternalPluginCatalogEntries()) {
     const pluginId = resolveOfficialExternalPluginId(entry);
     const providerIds =
       getOfficialExternalPluginCatalogManifest(entry)?.contracts?.[params.contract];
@@ -1420,7 +387,7 @@ export function resolveOfficialExternalWebProviderContractPluginIdsForEnv(params
   env: NodeJS.ProcessEnv;
 }): string[] {
   const pluginIds = new Set<string>();
-  for (const entry of listOfficialExternalPluginCatalogEntries()) {
+  for (const entry of bundledOfficialExternalPluginCatalogEntries()) {
     const pluginId = resolveOfficialExternalPluginId(entry);
     const manifest = getOfficialExternalPluginCatalogManifest(entry);
     const contractProviderIds = new Set(
@@ -1599,7 +566,7 @@ export function getOfficialExternalPluginCatalogEntry(
   if (!normalized) {
     return undefined;
   }
-  return listOfficialExternalPluginCatalogEntries().find((entry) =>
+  return findBundledOfficialExternalPluginCatalogEntry((entry) =>
     resolveOfficialExternalPluginLookupIds(entry).includes(normalized),
   );
 }
@@ -1611,7 +578,7 @@ export function getOfficialExternalPluginCatalogEntryForPackage(
   if (!normalized) {
     return undefined;
   }
-  return listOfficialExternalPluginCatalogEntries().find(
+  return findBundledOfficialExternalPluginCatalogEntry(
     (entry) => normalizeOptionalString(entry.name) === normalized,
   );
 }
@@ -1628,4 +595,3 @@ export function isExternallyDistributedPlugin(plugin: {
     (entry !== undefined && resolveOfficialExternalPluginId(entry) === plugin.pluginId)
   );
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/plugins/official-external-plugin-targets.ts
+++ b/src/plugins/official-external-plugin-targets.ts
@@ -3,39 +3,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_ENTRIES } from "./official-external-plugin-bundled-catalogs.js";
-
-type StaticProvider = {
-  id?: string;
-  aliases?: readonly string[];
-  envVars?: readonly string[];
-};
-
-type StaticWebProvider = {
-  id?: string;
-  envVars?: readonly string[];
-};
-
-type StaticConfiguredState = {
-  env?: {
-    allOf?: readonly string[];
-    anyOf?: readonly string[];
-  };
-};
-
-type StaticManifest = {
-  channel?: {
-    id?: string;
-    envVars?: readonly string[];
-    configuredState?: StaticConfiguredState;
-  };
-  contracts?: Record<string, readonly string[]>;
-  providers?: readonly StaticProvider[];
-  webSearchProviders?: readonly StaticWebProvider[];
-};
-
-type StaticEntry = { openclaw?: StaticManifest };
-
-const STATIC_ENTRIES = BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_ENTRIES as readonly StaticEntry[];
+import type { OfficialExternalPluginCatalogManifest } from "./official-external-plugin-catalog.types.js";
 
 function normalizeIds(values: Iterable<string>): Set<string> {
   return new Set(
@@ -51,7 +19,7 @@ function envHasAny(env: NodeJS.ProcessEnv, names: readonly string[] | undefined)
 
 function envHasChannelCandidate(
   env: NodeJS.ProcessEnv,
-  channel: StaticManifest["channel"],
+  channel: OfficialExternalPluginCatalogManifest["channel"],
 ): boolean {
   const allOf = channel?.configuredState?.env?.allOf ?? [];
   const anyOf = channel?.configuredState?.env?.anyOf ?? [];
@@ -63,7 +31,7 @@ export function hasOfficialExternalProviderTarget(params: {
   env: NodeJS.ProcessEnv;
 }): boolean {
   const providerIds = normalizeIds(params.providerIds);
-  return STATIC_ENTRIES.some((entry) =>
+  return BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_ENTRIES.some((entry) =>
     entry.openclaw?.providers?.some(
       (provider) =>
         envHasAny(params.env, provider.envVars) ||
@@ -76,14 +44,14 @@ export function hasOfficialExternalProviderTarget(params: {
 }
 
 export function hasOfficialExternalContractTarget(params: {
-  contract: string;
+  contract: keyof NonNullable<OfficialExternalPluginCatalogManifest["contracts"]>;
   providerIds: Iterable<string>;
 }): boolean {
   const providerIds = normalizeIds(params.providerIds);
   if (providerIds.size === 0) {
     return false;
   }
-  return STATIC_ENTRIES.some((entry) =>
+  return BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_ENTRIES.some((entry) =>
     entry.openclaw?.contracts?.[params.contract]?.some((providerId) => {
       const normalized = normalizeOptionalLowercaseString(providerId);
       return normalized ? providerIds.has(normalized) : false;
@@ -92,10 +60,10 @@ export function hasOfficialExternalContractTarget(params: {
 }
 
 export function hasOfficialExternalWebContractEnvTarget(params: {
-  contract: string;
+  contract: keyof NonNullable<OfficialExternalPluginCatalogManifest["contracts"]>;
   env: NodeJS.ProcessEnv;
 }): boolean {
-  return STATIC_ENTRIES.some((entry) => {
+  return BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_ENTRIES.some((entry) => {
     const manifest = entry.openclaw;
     const contractIds = normalizeIds(manifest?.contracts?.[params.contract] ?? []);
     return manifest?.webSearchProviders?.some((provider) => {
@@ -112,7 +80,7 @@ export function hasOfficialExternalChannelTarget(params: {
   env: NodeJS.ProcessEnv;
 }): boolean {
   const channels = isRecord(params.config.channels) ? params.config.channels : undefined;
-  return STATIC_ENTRIES.some((entry) => {
+  return BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_ENTRIES.some((entry) => {
     const channel = entry.openclaw?.channel;
     const channelId = normalizeOptionalLowercaseString(channel?.id);
     if (!channelId) {
@@ -131,7 +99,7 @@ export function hasOfficialExternalWebSearchTarget(params: {
   env: NodeJS.ProcessEnv;
 }): boolean {
   const configuredId = normalizeOptionalLowercaseString(params.providerId);
-  return STATIC_ENTRIES.some((entry) =>
+  return BUNDLED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_ENTRIES.some((entry) =>
     entry.openclaw?.webSearchProviders?.some((provider) => {
       const providerId = normalizeOptionalLowercaseString(provider.id);
       return (

--- a/src/skills/lifecycle/clawhub-install-core.ts
+++ b/src/skills/lifecycle/clawhub-install-core.ts
@@ -5,7 +5,6 @@ import {
   downloadClawHubGitHubSkillArchive,
   downloadClawHubSkillArchive,
   downloadClawHubSkillArchiveUrl,
-  normalizeClawHubSha256Integrity,
   type ClawHubDownloadResult,
 } from "../../infra/clawhub-artifacts.js";
 import { isDefaultClawHubBaseUrl, resolveClawHubBaseUrl } from "../../infra/clawhub-client.js";
@@ -13,6 +12,7 @@ import {
   checkClawHubPackageTrust,
   type ClawHubTrustErrorCode,
 } from "../../infra/clawhub-install-trust.js";
+import { normalizeClawHubSha256Integrity } from "../../infra/clawhub-integrity.js";
 import {
   CLAWHUB_SKILLS_SH_TRUST_LABEL,
   CLAWHUB_SKILLS_SH_TRUST_STATE,

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -2,11 +2,9 @@
 import fs from "node:fs/promises";
 import { err as resultError, ok, type Result } from "@openclaw/normalization-core/result";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import {
-  downloadClawHubSkillArchive,
-  normalizeClawHubSha256Integrity,
-} from "../../infra/clawhub-artifacts.js";
+import { downloadClawHubSkillArchive } from "../../infra/clawhub-artifacts.js";
 import type { ClawHubTrustErrorCode } from "../../infra/clawhub-install-trust.js";
+import { normalizeClawHubSha256Integrity } from "../../infra/clawhub-integrity.js";
 import {
   CLAWHUB_SKILLS_SH_REF_PREFIX,
   fetchClawHubSkillVerification,


### PR DESCRIPTION
Closes #140595

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Resolves avoidable work during bundled plugin package and manifest lookups: each direct query rebuilds complete catalog collections, and the static lookup import loads hosted fetching and artifact-download implementations.

## Why This Change Was Made

Share one typed raw bundled source, validate and deduplicate live rows as queries iterate, and stop direct lookups at the matching row. Move hosted fetching behind the existing async public entrypoint and move pure ClawHub integrity helpers into a leaf module used by their real consumers. Remove the duplicate raw-target type mirror and its assertion.

Shared rows remain mutable and list APIs return fresh outer arrays. Conservative repair targets still inspect raw shadowed and source-rejected rows with current environment/configuration. Hosted validation, signed-feed monotonicity, snapshot/fallback behavior, freshness and helper/error identity retain their existing contracts.

## User Impact

Static catalog users load a smaller module graph and do less repeated lookup work. In the paired built probe, the median 95,000-lookup run improved from 1001.76 ms to 531.07 ms; one sweep of 95 rows saves about 0.47 ms. Cold import loaded 58 module URLs instead of 255.

This is an import and representation repair, not a net source-deletion claim: production is +68 lines, tests are +239, and two obsolete ratchet entries were mechanically removed. Related #138312 and active #135997 address distinct work; preserve the latter's type re-export removal during integration.

## Evidence

- 138 focused tests passed across official catalogs, tiny mutable/source-filter fixtures, conservative targets, signed envelopes and ClawHub artifact/integrity behavior.
- Complete check:changed and full build passed. Independent isolated P2 autoreview found no actionable findings; all 18 final source hashes and the unchanged lockfile match the reviewed manifest.
- The same final probe ran on both source and built outputs after normal frozen installs, with both heavy slots reserved to exclude overlapping admitted jobs. Both sides ran five samples of 95,000 real package/manifest lookups over 95 rows, with matching checksum 475,000.
- Built module URLs fell from 255 to 58. One paired cold-import sample measured 86.16 ms to 11.54 ms and immediate RSS of 72.06 MiB to 50.20 MiB. Download, client, temporary-download and hosted-loader implementations were absent from the repaired static import graph.

The cold import and RSS values are single isolated observations, not full-Gateway gains. Source bytes are not heap bytes. Minor-GC events increased from 1425 to 1954; no reduction in collection count or exact allocated-byte total is claimed.
