### PR TITLE
fix(update): complete same-version Git-to-package switches

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -430,11 +430,12 @@ aligned:
 ### Validation and activation
 
 If the resolved package version equals the installed version without changing
-the selected channel, or the Git target SHA equals `HEAD`, the run finishes
-`skipped` with reason `already-current`. A same-version explicit `--channel`
-change persists the new channel and finishes successfully. Neither path stops,
-replaces, or restarts the Gateway. Read-only plugin convergence checks can still
-report repair needs; use `openclaw update repair` to apply them.
+the selected channel or installation method, or the Git target SHA equals
+`HEAD`, the run finishes `skipped` with reason `already-current`. A same-version
+explicit `--channel` or installation-method change finishes successfully.
+Neither path stops or restarts the Gateway unless the installation method
+changes. Read-only plugin convergence checks can still report repair needs; use
+`openclaw update repair` to apply them.
 
 For targets that support candidate validation, the old Gateway keeps serving through `staging` and
 `validating`. The updater uses the candidate entrypoint for Doctor lint

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -6138,6 +6138,56 @@ describe("update-cli", () => {
     expect(lastWriteJsonCall()).toMatchObject({ status: "skipped", reason: "already-current" });
   });
 
+  it("completes an equal-version Git-to-package switch", async () => {
+    const { nodeModules, pkgRoot } = await setupInstalledPackageRoot(
+      createCaseDir("openclaw-git-to-package-same-version"),
+      "2026.4.22",
+    );
+    await fs.writeFile(path.join(pkgRoot, "dist", "index.js"), "git runtime\n");
+    await writePackageDistInventory(pkgRoot);
+    mockNpmGlobalCommands(nodeModules, async (argv) => {
+      if (argv[0] !== "npm" || argv[1] !== "i") {
+        return;
+      }
+      await writeNpmPackageInstall(argv, pkgRoot, "2026.4.22");
+      const stagePrefix = requireValue(argv[argv.indexOf("--prefix") + 1], "staged prefix");
+      const stageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+      await fs.writeFile(path.join(stageRoot, "dist", "index.js"), "package runtime\n");
+      await writePackageDistInventory(stageRoot);
+    });
+    mockCurrentProcessFreshDoctor({ packageRoot: pkgRoot });
+    vi.mocked(resolveUpdateInstallKind).mockResolvedValue("git");
+    vi.mocked(resolveUpdateInstallIdentity).mockResolvedValue({
+      installKind: "git",
+      git: { tag: "v2026.4.22", branch: "main" },
+    });
+    readPackageVersion.mockImplementation(async (root: string) => {
+      const manifest = JSON.parse(await fs.readFile(path.join(root, "package.json"), "utf8")) as {
+        version: string;
+      };
+      return manifest.version;
+    });
+    primeNpmChannelTag("latest", "2026.4.22");
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue(
+      configSnapshot({ update: { channel: "dev" } }),
+    );
+
+    await updateCommand({ channel: "stable", yes: true, restart: false, json: true });
+
+    expectPackageInstallSpec("openclaw@2026.4.22");
+    expect(candidateValidation).toHaveBeenCalled();
+    await expect(fs.readFile(path.join(pkgRoot, "dist", "index.js"), "utf8")).resolves.toBe(
+      "package runtime\n",
+    );
+    expect(lastReplaceConfigCall()?.nextConfig?.update?.channel).toBe("stable");
+    expect(lastWriteJsonCall()).toMatchObject({
+      status: "ok",
+      mode: "npm",
+      root: pkgRoot,
+    });
+    expect((lastWriteJsonCall() as UpdateRunResult).reason).toBeUndefined();
+  });
+
   it("runs the package update when latest target lookup is unresolved", async () => {
     setTty(false);
     await mockPackageInstallAtCaseDir();

--- a/src/cli/update-cli/update-command-package.ts
+++ b/src/cli/update-cli/update-command-package.ts
@@ -253,6 +253,7 @@ export async function runPackageInstallUpdate(
     installSpec,
     packageName,
     packageRoot: pkgRoot,
+    requirePackageReplacement: params.installKind === "git",
     runCommand: runCommandWithTimeout,
     timeoutMs: params.timeoutMs,
     ...(installEnv === undefined ? {} : { env: installEnv }),

--- a/src/infra/package-update-steps.recovery.test.ts
+++ b/src/infra/package-update-steps.recovery.test.ts
@@ -277,6 +277,75 @@ describe("package update recovery safety", () => {
     },
   );
 
+  it("replaces equal-version package bytes and rolls them back after verification fails", async () => {
+    await withTestDir({ prefix: "openclaw-package-equal-version-replacement-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      const launcher = path.join(prefix, "bin", "openclaw");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(path.join(packageRoot, "dist", "index.js"), "old runtime\n");
+      await fs.mkdir(path.dirname(launcher), { recursive: true });
+      await fs.writeFile(launcher, "old launcher\n");
+
+      const result = await runGlobalPackageUpdateSteps({
+        installTarget: createNpmTarget(globalRoot),
+        installSpec: "openclaw@1.0.0",
+        packageName: "openclaw",
+        packageRoot,
+        requirePackageReplacement: true,
+        runCommand: createRootRunner(globalRoot),
+        runStep: async ({ name, argv }) => {
+          const stagePrefix = argv[argv.indexOf("--prefix") + 1];
+          if (!stagePrefix) {
+            throw new Error("missing stage prefix");
+          }
+          const stageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+          await writePackageRoot(stageRoot, "1.0.0");
+          await fs.writeFile(path.join(stageRoot, "dist", "index.js"), "new runtime\n");
+          await fs.mkdir(path.join(stagePrefix, "bin"), { recursive: true });
+          await fs.writeFile(path.join(stagePrefix, "bin", "openclaw"), "new launcher\n");
+          return { name, command: argv.join(" "), cwd: stagePrefix, durationMs: 0, exitCode: 0 };
+        },
+        validateCandidate: async (candidateRoot) => {
+          await expect(
+            fs.readFile(path.join(candidateRoot, "dist", "index.js"), "utf8"),
+          ).resolves.toBe("new runtime\n");
+          await expect(
+            fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8"),
+          ).resolves.toBe("old runtime\n");
+          return [];
+        },
+        beforeActivate: async () => {},
+        postVerifyStep: async (candidateRoot) => {
+          await expect(
+            fs.readFile(path.join(candidateRoot, "dist", "index.js"), "utf8"),
+          ).resolves.toBe("new runtime\n");
+          return {
+            name: "doctor",
+            command: "doctor --fix",
+            cwd: candidateRoot,
+            durationMs: 0,
+            exitCode: 1,
+          };
+        },
+        timeoutMs: 1000,
+      });
+
+      expect(result.reason).toBeUndefined();
+      expect(result.failedStep?.name).toBe("doctor");
+      expect(result.recovery).toEqual({
+        serviceRestartSafe: false,
+        reason: "runtime-verification-failed",
+        packageRollbackVerified: true,
+      });
+      await expect(fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8")).resolves.toBe(
+        "old runtime\n",
+      );
+      await expect(fs.readFile(launcher, "utf8")).resolves.toBe("old launcher\n");
+    });
+  });
+
   it("recovers the verified original when staging preparation fails before hooks run", async () => {
     await withTestDir({ prefix: "openclaw-package-stage-recovery-" }, async (base) => {
       const globalRoot = path.join(base, "lib", "node_modules");

--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -659,6 +659,7 @@ export async function runGlobalPackageUpdateSteps(params: {
   installSpec: string;
   packageName: string;
   packageRoot?: string | null;
+  requirePackageReplacement?: boolean;
   runCommand: CommandRunner;
   runStep: PackageUpdateStepRunner;
   timeoutMs: number;
@@ -1064,6 +1065,7 @@ export async function runGlobalPackageUpdateSteps(params: {
         stagedInstall &&
         !params.expectedGitCheckout &&
         requireStaging &&
+        !params.requirePackageReplacement &&
         candidateVersion &&
         candidateVersion === (await readPackageVersionIfPresent(originalPackageRoot))
       ) {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/138839
Related: https://github.com/openclaw/openclaw/pull/140493
Related: https://github.com/openclaw/openclaw/pull/140553
Related: https://github.com/openclaw/openclaw/pull/137893

## What Problem This Solves

Fixes an issue where users switching a Git installation to the stable package channel at the same OpenClaw version would receive an already-current result while the Git installation remained active.

## Why This Change Was Made

The package update owner now receives one explicit caller-owned fact when the current installation is Git. That fact disables only the staged equal-version shortcut, preserving candidate validation, transactional replacement, and rollback without changing generic install-kind inference or update execution behavior.

## User Impact

A same-version Git-to-package switch now installs and reports the package target, persists the stable channel only after success, and retains the existing rollback guarantees if verification fails.

## Evidence

- Before the fix, the recovery regression returned `already-current` and the CLI regression never reached candidate validation.
- `src/infra/package-update-steps.recovery.test.ts`: 36 passed.
- `src/cli/update-cli.test.ts`: 410 passed.
- Fresh P1 autoreview: scoped clean.
- `git diff --check`: passed.
- Exact-head PR CI at `8daff1941a1a73ac6e71ef7d090bf9e9a49a4208`: passed, including the authoritative typecheck and changed-test shards: https://github.com/openclaw/openclaw/actions/runs/34074212986
- Exact-head hosted `update-channel-switch` at `8daff1941a1a73ac6e71ef7d090bf9e9a49a4208`: reached the package-to-Git leg, then failed on the separate false-dirty staging defect owned by #140553: https://github.com/openclaw/openclaw/actions/runs/34074211750
- The two independently scoped fixes create a validation dependency: #140553 reaches Git-to-package but needs this PR to complete it; this PR reaches package-to-Git but needs #140553 to complete it. Neither production diff was expanded.
- Exact stacked integration SHA `034c3b36a5bcba6aa561b57499d5ccf282539577` contains the unchanged heads of #140553 and this PR solely for full-cycle proof.
- Fresh Blacksmith Testbox lease `tbx_01m1wsfy626jnpzdj8rp8ry1gq` (`tidal-crayfish`) ran `pnpm test:docker:update-channel-switch` at that exact stacked SHA. Stable-to-beta, package-to-Git, and same-version Git-to-package all passed; exit 0 in 5m53s.
- Exact stacked hosted `update-channel-switch`: passed all three switch legs in 4m47s at `034c3b36a5bcba6aa561b57499d5ccf282539577`: https://github.com/openclaw/openclaw/actions/runs/34074745432
