### PR TITLE
refactor: consolidate LINE markdown parser coverage

### DIFF
--- a/extensions/line/src/markdown-to-line.test.ts
+++ b/extensions/line/src/markdown-to-line.test.ts
@@ -14,48 +14,6 @@ function requireEntry<T>(entries: readonly T[], index: number, context: string):
 }
 
 describe("stripMarkdown", () => {
-  it("strips inline markdown marker variants", () => {
-    const cases = [
-      ["strips bold **", "This is **bold** text", "This is bold text"],
-      ["strips bold __", "This is __bold__ text", "This is bold text"],
-      ["strips italic *", "This is *italic* text", "This is italic text"],
-      ["strips italic _", "This is _italic_ text", "This is italic text"],
-      ["strips strikethrough", "This is ~~deleted~~ text", "This is deleted text"],
-      ["strips setext heading underline", "Above\n---\nBelow", "Above\nBelow"],
-      ["removes hr ***", "Above\n***\nBelow", "Above\n\nBelow"],
-      ["strips inline code markers", "Use `const` keyword", "Use const keyword"],
-    ] as const;
-    for (const [name, input, expected] of cases) {
-      expect(stripMarkdown(input), name).toBe(expected);
-    }
-  });
-
-  it("preserves underscores inside words", () => {
-    expect(stripMarkdown("here_is_a_message")).toBe("here_is_a_message");
-    expect(stripMarkdown("snake_case_var")).toBe("snake_case_var");
-    expect(stripMarkdown("use foo_bar_baz in code")).toBe("use foo_bar_baz in code");
-  });
-
-  it("still strips proper italic _text_", () => {
-    expect(stripMarkdown("This is _italic_ text")).toBe("This is italic text");
-    expect(stripMarkdown("_italic_ at start")).toBe("italic at start");
-    expect(stripMarkdown("end _italic_")).toBe("end italic");
-  });
-
-  it("strips italic between underscored words", () => {
-    expect(stripMarkdown("foo_bar _italic_ baz_qux")).toBe("foo_bar italic baz_qux");
-  });
-
-  it("preserves underscores inside non-Latin words", () => {
-    expect(stripMarkdown("привет_мир_тест")).toBe("привет_мир_тест");
-    expect(stripMarkdown("東京_駅_前")).toBe("東京_駅_前");
-    expect(stripMarkdown("var_123_end")).toBe("var_123_end");
-  });
-
-  it("strips standalone italic between non-Latin words", () => {
-    expect(stripMarkdown("こんにちは _italic_ テスト")).toBe("こんにちは italic テスト");
-  });
-
   it("handles complex markdown", () => {
     const input = `# Title
 
@@ -65,16 +23,13 @@ This is **bold** and *italic* text.
 
 Some ~~deleted~~ content.`;
 
-    const result = stripMarkdown(input);
+    expect(stripMarkdown(input)).toBe(`Title
 
-    expect(result).toContain("Title");
-    expect(result).toContain("This is bold and italic text.");
-    expect(result).toContain("A quote");
-    expect(result).toContain("Some deleted content.");
-    expect(result).not.toContain("#");
-    expect(result).not.toContain("**");
-    expect(result).not.toContain("~~");
-    expect(result).not.toContain(">");
+This is bold and italic text.
+
+A quote
+
+Some deleted content.`);
   });
 });
 

--- a/src/tts/prepare-text.test.ts
+++ b/src/tts/prepare-text.test.ts
@@ -36,24 +36,38 @@ const PLAIN_PROFILE = {
  * (e.g. "hashtag hashtag hashtag" for ### headers).
  */
 describe("TTS text preparation – stripMarkdown", () => {
-  it("strips markdown headers before TTS", () => {
+  it("strips markdown headings and horizontal rules before TTS", () => {
     expect(stripMarkdown("### System Design Basics")).toBe("System Design Basics");
     expect(stripMarkdown("## Heading\nSome text")).toBe("Heading\nSome text");
+    expect(stripMarkdown("Above\n---\nBelow")).toBe("Above\nBelow");
+    expect(stripMarkdown("Above\n***\nBelow")).toBe("Above\n\nBelow");
   });
 
   it("strips bold and italic markers before TTS", () => {
     expect(stripMarkdown("This is **important** and *useful*")).toBe(
       "This is important and useful",
     );
+    expect(stripMarkdown("This is __bold__ text")).toBe("This is bold text");
   });
 
   it("preserves underscores inside words while still stripping italic markers", () => {
-    expect(stripMarkdown("here_is_a_message")).toBe("here_is_a_message");
-    expect(stripMarkdown("привет_мир_тест")).toBe("привет_мир_тест");
-    expect(stripMarkdown("東京_駅_前")).toBe("東京_駅_前");
-    expect(stripMarkdown("use foo_bar_baz and _italic_ text")).toBe(
-      "use foo_bar_baz and italic text",
-    );
+    const cases = [
+      ["here_is_a_message", "here_is_a_message"],
+      ["snake_case_var", "snake_case_var"],
+      ["use foo_bar_baz in code", "use foo_bar_baz in code"],
+      ["This is _italic_ text", "This is italic text"],
+      ["_italic_ at start", "italic at start"],
+      ["end _italic_", "end italic"],
+      ["foo_bar _italic_ baz_qux", "foo_bar italic baz_qux"],
+      ["привет_мир_тест", "привет_мир_тест"],
+      ["東京_駅_前", "東京_駅_前"],
+      ["var_123_end", "var_123_end"],
+      ["こんにちは _italic_ テスト", "こんにちは italic テスト"],
+      ["use foo_bar_baz and _italic_ text", "use foo_bar_baz and italic text"],
+    ] as const;
+    for (const [input, expected] of cases) {
+      expect(stripMarkdown(input), input).toBe(expected);
+    }
   });
 
   it("strips inline code markers before TTS", () => {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

LINE's Markdown tests replay generic parsing cases through a direct re-export of the shared Markdown stripper. That duplicates maintenance without testing additional LINE behavior.

## Why This Change Was Made

Keep one mixed-Markdown case at the LINE export and strengthen it to check the exact output. Remove six local replay cases, carrying uncovered underscore, Unicode, numeric-boundary, and horizontal-rule inputs into existing shared-function tests. All LINE Flex, ordering, size-limit, and role-header cases remain unchanged.

## User Impact

No production changes. This maintainer-requested cleanup removes 31 net test lines while preserving the historical parsing regressions at their shared owner. It does not claim faster test execution.

## Evidence

- Original suites: 64 cases passed. Revised LINE and shared preparation/speech suites: 58 cases passed, reflecting six removed replay cases.
- Exact input/output inventory preserves the historical boundary cases and all original shared assertions; simple marker examples are covered by retained mixed-Markdown and inline-code cases.
- A controlled intraword-underscore regression fails the shared test; an incorrectly exported Markdown passthrough fails the LINE case. Original source bytes were restored and all 58 cases passed again.
- Formatting, deslop, and fresh P2 review passed. Full changed-file gate passed.
