### PR TITLE
refactor(plugins): reuse immutable installed-index preparation

### DIFF
--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -129,6 +129,12 @@ hashing. Activation and runtime service generations can change while their
 package metadata stays fixed. Account health and authentication state are not
 part of the immutable package inventory.
 
+The same cache generation prepares installed-index scope lookups, compiled model
+matching patterns, parsed install-record projections, and manifest fingerprints
+once per immutable index. Mutable management indexes remain uncached. Lookup
+methods and install-record results remain caller-owned; enablement and trust are
+evaluated from the current operation's policy rather than stored in these facts.
+
 Provider auth aliases are normalized and indexed with the snapshot. Lookups
 select among those prepared candidates using the current workspace trust config;
 they do not cache trust decisions or credentials. Callers supplying a partial

--- a/src/plugins/gateway-startup-plugin-config.ts
+++ b/src/plugins/gateway-startup-plugin-config.ts
@@ -37,8 +37,11 @@ import {
   collectConfiguredWebSearchProviderIds,
 } from "./gateway-startup-plugin-providers.js";
 import { collectConfiguredSpeechProviderIds } from "./gateway-startup-speech-providers.js";
-import type { InstalledPluginIndexScopeLookup } from "./installed-plugin-index-scope-lookup.js";
-import type { InstalledPluginIndex, InstalledPluginIndexRecord } from "./installed-plugin-index.js";
+import type {
+  InstalledPluginIndex,
+  InstalledPluginIndexRecord,
+  InstalledPluginIndexScopeLookup,
+} from "./installed-plugin-index-types.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
 import { normalizePluginsConfigWithRegistry } from "./plugin-registry-contributions.js";
 

--- a/src/plugins/installed-plugin-index-facts.test.ts
+++ b/src/plugins/installed-plugin-index-facts.test.ts
@@ -61,6 +61,8 @@ describe("prepared installed-index readers", () => {
         expect(ownerIds(lookup, " SHARED ")).toEqual(["alpha", "beta"]);
         expect(lookup.canResolveDirectProviderIds(["shared"], new Set())).toBe(false);
         expect(lookup.canResolveDirectProviderIds(["alpha"], new Set())).toBe(true);
+        expect(lookup.hasInstalledPluginIds([" ALPHA ", "beta"])).toBe(true);
+        expect(lookup.hasInstalledPluginIds(["shared"])).toBe(false);
         expect(lookup.hasShorthandModelOwners(["fixture-model"])).toBe(true);
         expect(lookup.hasShorthandModelOwners(["fixture/anything"])).toBe(true);
         expect(lookup.hasAgentHarnessOwners(["fixture-runtime"])).toBe(true);

--- a/src/plugins/installed-plugin-index-facts.test.ts
+++ b/src/plugins/installed-plugin-index-facts.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as installRecordMap from "../config/plugin-install-record-map.js";
+import * as safeRegex from "../security/safe-regex.js";
+import { extractPluginInstallRecordsFromInstalledPluginIndex } from "./installed-plugin-index-install-records.js";
+import { createInstalledPluginIndexScopeLookup } from "./installed-plugin-index-scope-lookup.js";
+import { isInstalledPluginEnabled } from "./installed-plugin-index.js";
+import { createPluginCache, withPluginCache } from "./plugin-cache.js";
+import { finalizePluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "./plugin-metadata.test-support.js";
+
+function createSnapshot(provider = "shared") {
+  const snapshot = createPluginMetadataSnapshotFixture({
+    plugins: [
+      { id: "alpha", origin: "global" },
+      { id: "beta", origin: "global" },
+    ],
+  });
+  snapshot.index.installRecords = {
+    alpha: { source: "npm", spec: " alpha@1 ", clawhubTrustReasons: [" reviewed "] },
+  };
+  for (const plugin of snapshot.index.plugins) {
+    plugin.startup.agentHarnesses = ["fixture-runtime"];
+    plugin.contributions = {
+      channels: ["fixture-channel"],
+      channelConfigs: [],
+      providers: [provider, provider],
+      modelCatalogProviders: [],
+      modelSupportPrefixes: ["fixture/"],
+      modelSupportPatterns: ["^fixture-model$"],
+      autoEnableProviderIds: [],
+      commandAliases: [],
+      contracts: { speechProviders: [provider] },
+    };
+  }
+  return snapshot;
+}
+
+function ownerIds(lookup: ReturnType<typeof createInstalledPluginIndexScopeLookup>, id: string) {
+  const ids = new Set<string>();
+  lookup.addProviderContributionOwners(ids, [id]);
+  return [...ids];
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("prepared installed-index readers", () => {
+  it("prepares immutable ownership and install records once while preserving policy and caller copies", () => {
+    withPluginCache(createPluginCache(), () => {
+      const snapshot = finalizePluginMetadataSnapshot(createSnapshot());
+      const compile = vi.spyOn(safeRegex, "compileSafeRegex");
+      const parse = vi.spyOn(installRecordMap, "parsePluginInstallRecordMap");
+      const first = createInstalledPluginIndexScopeLookup(snapshot.index);
+      const records = extractPluginInstallRecordsFromInstalledPluginIndex(snapshot.index);
+      assert(records.alpha);
+      records.alpha.spec = "caller-owned";
+      records.alpha.clawhubTrustReasons?.push("caller-owned");
+      first.addProviderContributionOwners = () => {};
+      for (let call = 0; call < 5; call++) {
+        const lookup = createInstalledPluginIndexScopeLookup(snapshot.index);
+        expect(ownerIds(lookup, " SHARED ")).toEqual(["alpha", "beta"]);
+        expect(lookup.canResolveDirectProviderIds(["shared"], new Set())).toBe(false);
+        expect(lookup.canResolveDirectProviderIds(["alpha"], new Set())).toBe(true);
+        expect(lookup.hasShorthandModelOwners(["fixture-model"])).toBe(true);
+        expect(lookup.hasShorthandModelOwners(["fixture/anything"])).toBe(true);
+        expect(lookup.hasAgentHarnessOwners(["fixture-runtime"])).toBe(true);
+        expect(lookup.hasChannelContributionOwners(["fixture-channel"])).toBe(true);
+        expect(lookup.hasDirectChannelOwners(["fixture-channel"])).toBe(false);
+        expect(extractPluginInstallRecordsFromInstalledPluginIndex(snapshot.index)).toEqual({
+          alpha: { source: "npm", spec: "alpha@1", clawhubTrustReasons: ["reviewed"] },
+        });
+      }
+      expect.soft(compile).toHaveBeenCalledTimes(2);
+      expect.soft(parse).toHaveBeenCalledTimes(1);
+      expect(
+        isInstalledPluginEnabled(snapshot.index, "alpha", { plugins: { allow: ["alpha"] } }),
+      ).toBe(true);
+      expect(
+        isInstalledPluginEnabled(snapshot.index, "alpha", { plugins: { deny: ["alpha"] } }),
+      ).toBe(false);
+      expect(isInstalledPluginEnabled(snapshot.index, "missing")).toBe(false);
+    });
+  });
+
+  it("returns independent accepted surfaces from the immutable ledger", () => {
+    const snapshot = createSnapshot();
+    assert(snapshot.index.installRecords.alpha);
+    snapshot.index.installRecords.alpha.acceptedSurface = {
+      channels: ["fixture-channel"],
+      providers: [],
+      tools: [],
+      contracts: [],
+      hooks: [],
+      mcpServers: [],
+      cliCommands: [],
+      cliBackends: [],
+      skills: [],
+      dangerousConfigFlags: [],
+    };
+    finalizePluginMetadataSnapshot(snapshot);
+    withPluginCache(createPluginCache(), () => {
+      const first = extractPluginInstallRecordsFromInstalledPluginIndex(snapshot.index);
+      assert(first.alpha?.acceptedSurface);
+      first.alpha.acceptedSurface!.channels.push("caller-owned");
+      delete first.alpha;
+      const next = extractPluginInstallRecordsFromInstalledPluginIndex(snapshot.index);
+      expect(next.alpha?.acceptedSurface?.channels).toEqual(["fixture-channel"]);
+      expect(Object.getPrototypeOf(next)).toBeNull();
+    });
+  });
+
+  it.each([false, true])("rereads mutable nested inputs (frozen shell: %s)", (freezeShell) => {
+    withPluginCache(createPluginCache(), () => {
+      const snapshot = createSnapshot();
+      if (freezeShell) {
+        Object.freeze(snapshot.index);
+      }
+      expect(ownerIds(createInstalledPluginIndexScopeLookup(snapshot.index), "shared")).toEqual([
+        "alpha",
+        "beta",
+      ]);
+      expect(extractPluginInstallRecordsFromInstalledPluginIndex(snapshot.index).alpha?.spec).toBe(
+        "alpha@1",
+      );
+      for (const plugin of snapshot.index.plugins) {
+        plugin.contributions!.providers = ["replacement"];
+        plugin.contributions!.contracts = {};
+      }
+      assert(snapshot.index.installRecords.alpha);
+      snapshot.index.installRecords.alpha.spec = "alpha@2";
+      expect(ownerIds(createInstalledPluginIndexScopeLookup(snapshot.index), "shared")).toEqual([]);
+      expect(
+        ownerIds(createInstalledPluginIndexScopeLookup(snapshot.index), "replacement"),
+      ).toEqual(["alpha", "beta"]);
+      expect(extractPluginInstallRecordsFromInstalledPluginIndex(snapshot.index).alpha?.spec).toBe(
+        "alpha@2",
+      );
+    });
+  });
+
+  it("keeps operation caches independent and retained lookup callbacks on their original inventory", () => {
+    const snapshot = finalizePluginMetadataSnapshot(createSnapshot());
+    const cache = createPluginCache();
+    const read = () => {
+      extractPluginInstallRecordsFromInstalledPluginIndex(snapshot.index);
+      return createInstalledPluginIndexScopeLookup(snapshot.index);
+    };
+    const parse = vi.spyOn(installRecordMap, "parsePluginInstallRecordMap");
+    const retained = withPluginCache(cache, read);
+    withPluginCache(createPluginCache(), read);
+    withPluginCache(cache, read);
+    expect(parse).toHaveBeenCalledTimes(2);
+    const replacement = finalizePluginMetadataSnapshot(createSnapshot("replacement"));
+    const current = withPluginCache(cache, () =>
+      createInstalledPluginIndexScopeLookup(replacement.index),
+    );
+    expect(ownerIds(current, "shared")).toEqual([]);
+    expect(ownerIds(current, "replacement")).toEqual(["alpha", "beta"]);
+    expect(ownerIds(retained, "shared")).toEqual(["alpha", "beta"]);
+    expect(ownerIds(retained, "replacement")).toEqual([]);
+  });
+});

--- a/src/plugins/installed-plugin-index-facts.ts
+++ b/src/plugins/installed-plugin-index-facts.ts
@@ -1,0 +1,48 @@
+import { isProxy } from "node:util/types";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
+import type { InstalledPluginIndexScopeLookup } from "./installed-plugin-index-scope-lookup.js";
+import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
+import { getPluginCache } from "./plugin-cache.js";
+
+export type InstalledPluginIndexFacts = {
+  fingerprint?: string;
+  scopeLookup?: InstalledPluginIndexScopeLookup;
+  installRecords?: Record<string, PluginInstallRecord>;
+};
+
+function isDeepFrozenJsonLike(value: unknown, seen = new WeakSet<object>()): boolean {
+  if (!value || typeof value !== "object") {
+    return typeof value !== "function";
+  }
+  if (seen.has(value)) {
+    return true;
+  }
+  if (isProxy(value) || !Object.isFrozen(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== null && prototype !== Object.prototype && prototype !== Array.prototype) {
+    return false;
+  }
+  seen.add(value);
+  return Object.values(Object.getOwnPropertyDescriptors(value)).every(
+    (entry) => "value" in entry && isDeepFrozenJsonLike(entry.value, seen),
+  );
+}
+
+/** Package facts share the existing generation; mutable management inputs stay uncached. */
+export function getInstalledPluginIndexFacts(
+  index: InstalledPluginIndex,
+): InstalledPluginIndexFacts | undefined {
+  const entries = getPluginCache().metadata.indexFacts;
+  const existing = entries.get(index);
+  if (existing) {
+    return existing;
+  }
+  if (!isDeepFrozenJsonLike(index)) {
+    return undefined;
+  }
+  const facts: InstalledPluginIndexFacts = {};
+  entries.set(index, facts);
+  return facts;
+}

--- a/src/plugins/installed-plugin-index-facts.ts
+++ b/src/plugins/installed-plugin-index-facts.ts
@@ -1,14 +1,9 @@
 import { isProxy } from "node:util/types";
-import type { PluginInstallRecord } from "../config/types.plugins.js";
-import type { InstalledPluginIndexScopeLookup } from "./installed-plugin-index-scope-lookup.js";
-import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
+import type {
+  InstalledPluginIndex,
+  InstalledPluginIndexFacts,
+} from "./installed-plugin-index-types.js";
 import { getPluginCache } from "./plugin-cache.js";
-
-export type InstalledPluginIndexFacts = {
-  fingerprint?: string;
-  scopeLookup?: InstalledPluginIndexScopeLookup;
-  installRecords?: Record<string, PluginInstallRecord>;
-};
 
 function isDeepFrozenJsonLike(value: unknown, seen = new WeakSet<object>()): boolean {
   if (!value || typeof value !== "object") {

--- a/src/plugins/installed-plugin-index-install-records.ts
+++ b/src/plugins/installed-plugin-index-install-records.ts
@@ -5,6 +5,7 @@ import {
   setPluginInstallRecordMapEntry,
 } from "../config/plugin-install-record-map.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { getInstalledPluginIndexFacts } from "./installed-plugin-index-facts.js";
 import type {
   InstalledPluginIndex,
   InstalledPluginInstallRecordInfo,
@@ -35,8 +36,30 @@ function restoreInstallRecordMap(
 export function extractPluginInstallRecordsFromInstalledPluginIndex(
   index: InstalledPluginIndex | null | undefined,
 ): Record<string, PluginInstallRecord> {
+  const facts = index ? getInstalledPluginIndexFacts(index) : undefined;
+  if (!facts) {
+    return restoreInstallRecordMap(indexInstallRecords(index));
+  }
+  const parsed = (facts.installRecords ??= restoreInstallRecordMap(indexInstallRecords(index)));
+  const records = createPluginInstallRecordMap<PluginInstallRecord>();
+  for (const [pluginId, record] of Object.entries(parsed)) {
+    // Match schema parsing's copies of known structured fields; passthrough fields stay intact.
+    setPluginInstallRecordMapEntry(records, pluginId, {
+      ...record,
+      ...(record.clawhubTrustReasons
+        ? { clawhubTrustReasons: [...record.clawhubTrustReasons] }
+        : {}),
+      ...(record.acceptedSurface
+        ? { acceptedSurface: structuredClone(record.acceptedSurface) }
+        : {}),
+    });
+  }
+  return records;
+}
+
+function indexInstallRecords(index: InstalledPluginIndex | null | undefined) {
   if (index && Object.hasOwn(index, "installRecords")) {
-    return restoreInstallRecordMap(index.installRecords);
+    return index.installRecords;
   }
   const records = createPluginInstallRecordMap<PluginInstallRecord>();
   for (const plugin of index?.plugins ?? []) {
@@ -44,5 +67,5 @@ export function extractPluginInstallRecordsFromInstalledPluginIndex(
       setPluginInstallRecordMapEntry(records, plugin.pluginId, plugin.installRecord);
     }
   }
-  return restoreInstallRecordMap(records);
+  return records;
 }

--- a/src/plugins/installed-plugin-index-scope-lookup.ts
+++ b/src/plugins/installed-plugin-index-scope-lookup.ts
@@ -3,7 +3,8 @@ import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/s
 import { compileSafeRegex } from "../security/safe-regex.js";
 import { normalizePluginId } from "./config-state.js";
 import { CONFIG_PATH_ACTIVATION_COMPAT_CODE } from "./installed-plugin-index-config-path-scope.js";
-import type { InstalledPluginIndex, InstalledPluginIndexRecord } from "./installed-plugin-index.js";
+import { getInstalledPluginIndexFacts } from "./installed-plugin-index-facts.js";
+import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 
 const PROVIDER_CONTRIBUTION_CONTRACTS = [
   "externalAuthProviders",
@@ -21,8 +22,6 @@ const PROVIDER_CONTRIBUTION_CONTRACTS = [
   "workerProviders",
   "usageProviders",
 ] as const;
-
-type OwnerMap = ReadonlyMap<string, readonly string[]>;
 
 type ModelSupportOwner = {
   pluginId: string;
@@ -51,73 +50,34 @@ export type InstalledPluginIndexScopeLookup = {
   normalizePluginId: (pluginId: string) => string;
 };
 
-function appendOwner(
-  owners: Map<string, string[]>,
-  rawKey: string | undefined,
-  pluginId: string,
-): void {
-  const key = normalizeOptionalLowercaseString(rawKey);
-  if (!key) {
-    return;
-  }
-  const existing = owners.get(key);
-  if (existing) {
-    existing.push(pluginId);
-    return;
-  }
-  owners.set(key, [pluginId]);
+/** A private ownership index shares normalization and duplicate handling across scope kinds. */
+function createOwnerLookup() {
+  const owners = new Map<string, Set<string>>();
+  const resolve = (id: string) => owners.get(normalizeOptionalLowercaseString(id) ?? "");
+  return {
+    index(pluginId: string, ids: readonly (string | undefined)[]) {
+      for (const id of ids) {
+        const key = normalizeOptionalLowercaseString(id);
+        if (key) {
+          const pluginIds = owners.get(key) ?? new Set<string>();
+          pluginIds.add(pluginId);
+          owners.set(key, pluginIds);
+        }
+      }
+    },
+    add(target: Set<string>, ids: readonly string[]) {
+      for (const id of ids) {
+        for (const pluginId of resolve(id) ?? []) {
+          target.add(pluginId);
+        }
+      }
+    },
+    has: (ids: readonly string[]) => ids.every((id) => resolve(id) !== undefined),
+  };
 }
 
-function freezeOwnerMap(owners: Map<string, string[]>): OwnerMap {
-  return new Map(
-    [...owners.entries()].map(([key, pluginIds]) => [key, Object.freeze([...new Set(pluginIds)])]),
-  );
-}
-
-function addOwners(target: Set<string>, owners: OwnerMap, ids: readonly string[]): void {
-  for (const id of ids) {
-    const normalized = normalizeOptionalLowercaseString(id);
-    if (!normalized) {
-      continue;
-    }
-    for (const pluginId of owners.get(normalized) ?? []) {
-      target.add(pluginId);
-    }
-  }
-}
-
-function hasOwners(owners: OwnerMap, ids: readonly string[]): boolean {
-  return ids.every((id) => {
-    const normalized = normalizeOptionalLowercaseString(id);
-    return Boolean(normalized && owners.has(normalized));
-  });
-}
-
-function listContributionValues(
-  plugin: InstalledPluginIndexRecord,
-  key: keyof NonNullable<InstalledPluginIndexRecord["contributions"]>,
-): readonly string[] {
-  const value = plugin.contributions?.[key];
+function listValues(value: unknown): readonly string[] {
   return Array.isArray(value) ? value : [];
-}
-
-function listContractContributionValues(
-  plugin: InstalledPluginIndexRecord,
-  key: string,
-): readonly string[] {
-  const value = plugin.contributions?.contracts?.[key];
-  return Array.isArray(value) ? value : [];
-}
-
-function compileModelSupportPatterns(patterns: readonly string[]): readonly RegExp[] {
-  const compiled: RegExp[] = [];
-  for (const pattern of patterns) {
-    const regex = compileSafeRegex(pattern, "u");
-    if (regex) {
-      compiled.push(regex);
-    }
-  }
-  return compiled;
 }
 
 function modelSupportOwnerMatches(owner: ModelSupportOwner, modelId: string): boolean {
@@ -131,100 +91,66 @@ function modelSupportOwnerMatches(owner: ModelSupportOwner, modelId: string): bo
   return owner.patterns.some((pattern) => pattern.test(trimmed));
 }
 
-function buildLookupMaps(index: InstalledPluginIndex): {
-  agentHarnessOwners: OwnerMap;
-  channelContributionOwners: OwnerMap;
-  directChannelOwners: OwnerMap;
-  directProviderOwners: OwnerMap;
-  installedPluginIds: ReadonlySet<string>;
-  modelSupportOwners: readonly ModelSupportOwner[];
-  pluginIdsByLowercase: ReadonlyMap<string, string>;
-  providerContributionOwners: OwnerMap;
-} {
-  const agentHarnessOwners = new Map<string, string[]>();
-  const channelContributionOwners = new Map<string, string[]>();
-  const directChannelOwners = new Map<string, string[]>();
-  const directProviderOwners = new Map<string, string[]>();
+export function createInstalledPluginIndexScopeLookup(
+  index: InstalledPluginIndex,
+): InstalledPluginIndexScopeLookup {
+  const facts = getInstalledPluginIndexFacts(index);
+  if (facts?.scopeLookup) {
+    return { ...facts.scopeLookup };
+  }
+  const agentHarnessOwners = createOwnerLookup();
+  const channelContributionOwners = createOwnerLookup();
+  const directChannelOwners = createOwnerLookup();
+  const directProviderOwners = createOwnerLookup();
+  const providerContributionOwners = createOwnerLookup();
   const pluginIdsByLowercase = new Map<string, string>();
-  const providerContributionOwners = new Map<string, string[]>();
   const modelSupportOwners: ModelSupportOwner[] = [];
-
   for (const plugin of index.plugins) {
     const normalizedPluginId = normalizeOptionalLowercaseString(plugin.pluginId);
     if (normalizedPluginId) {
       pluginIdsByLowercase.set(normalizedPluginId, plugin.pluginId);
-      appendOwner(directChannelOwners, plugin.pluginId, plugin.pluginId);
-      appendOwner(directProviderOwners, plugin.pluginId, plugin.pluginId);
-      appendOwner(channelContributionOwners, plugin.pluginId, plugin.pluginId);
-      appendOwner(providerContributionOwners, plugin.pluginId, plugin.pluginId);
+      directProviderOwners.index(plugin.pluginId, [plugin.pluginId]);
     }
-    for (const runtimeId of plugin.startup.agentHarnesses) {
-      appendOwner(agentHarnessOwners, runtimeId, plugin.pluginId);
-    }
-
-    appendOwner(directChannelOwners, plugin.packageChannel?.id, plugin.pluginId);
-    appendOwner(channelContributionOwners, plugin.packageChannel?.id, plugin.pluginId);
-    for (const channelId of listContributionValues(plugin, "channels")) {
-      appendOwner(channelContributionOwners, channelId, plugin.pluginId);
-    }
-    for (const channelId of listContributionValues(plugin, "channelConfigs")) {
-      appendOwner(channelContributionOwners, channelId, plugin.pluginId);
-    }
-
-    for (const providerId of listContributionValues(plugin, "providers")) {
-      appendOwner(providerContributionOwners, providerId, plugin.pluginId);
-    }
-    for (const providerId of listContributionValues(plugin, "modelCatalogProviders")) {
-      appendOwner(providerContributionOwners, providerId, plugin.pluginId);
-    }
-    for (const providerId of listContributionValues(plugin, "autoEnableProviderIds")) {
-      appendOwner(providerContributionOwners, providerId, plugin.pluginId);
-    }
-    for (const contract of PROVIDER_CONTRIBUTION_CONTRACTS) {
-      for (const providerId of listContractContributionValues(plugin, contract)) {
-        appendOwner(providerContributionOwners, providerId, plugin.pluginId);
-      }
-    }
-
+    directChannelOwners.index(plugin.pluginId, [plugin.pluginId, plugin.packageChannel?.id]);
+    agentHarnessOwners.index(plugin.pluginId, plugin.startup.agentHarnesses);
+    channelContributionOwners.index(plugin.pluginId, [
+      plugin.pluginId,
+      plugin.packageChannel?.id,
+      ...listValues(plugin.contributions?.channels),
+      ...listValues(plugin.contributions?.channelConfigs),
+    ]);
+    providerContributionOwners.index(plugin.pluginId, [
+      plugin.pluginId,
+      ...listValues(plugin.contributions?.providers),
+      ...listValues(plugin.contributions?.modelCatalogProviders),
+      ...listValues(plugin.contributions?.autoEnableProviderIds),
+      ...PROVIDER_CONTRIBUTION_CONTRACTS.flatMap((contract) =>
+        listValues(plugin.contributions?.contracts?.[contract]),
+      ),
+    ]);
     modelSupportOwners.push({
       pluginId: plugin.pluginId,
-      prefixes: listContributionValues(plugin, "modelSupportPrefixes"),
-      patterns: compileModelSupportPatterns(listContributionValues(plugin, "modelSupportPatterns")),
+      prefixes: listValues(plugin.contributions?.modelSupportPrefixes),
+      patterns: listValues(plugin.contributions?.modelSupportPatterns).flatMap((pattern) => {
+        const regex = compileSafeRegex(pattern, "u");
+        return regex ? [regex] : [];
+      }),
     });
   }
-
-  return {
-    agentHarnessOwners: freezeOwnerMap(agentHarnessOwners),
-    channelContributionOwners: freezeOwnerMap(channelContributionOwners),
-    directChannelOwners: freezeOwnerMap(directChannelOwners),
-    directProviderOwners: freezeOwnerMap(directProviderOwners),
-    installedPluginIds: new Set(pluginIdsByLowercase.keys()),
-    modelSupportOwners,
-    pluginIdsByLowercase,
-    providerContributionOwners: freezeOwnerMap(providerContributionOwners),
-  };
-}
-
-export function createInstalledPluginIndexScopeLookup(
-  index: InstalledPluginIndex,
-): InstalledPluginIndexScopeLookup {
-  const maps = buildLookupMaps(index);
   const normalizeInstalledPluginId = (pluginId: string): string => {
     const normalized = normalizePluginId(pluginId);
     const lowercase = normalizeOptionalLowercaseString(normalized);
-    return lowercase ? (maps.pluginIdsByLowercase.get(lowercase) ?? normalized) : normalized;
+    return lowercase ? (pluginIdsByLowercase.get(lowercase) ?? normalized) : normalized;
   };
-  return {
-    addAgentHarnessOwners: (target, ids) => addOwners(target, maps.agentHarnessOwners, ids),
-    addChannelContributionOwners: (target, ids) =>
-      addOwners(target, maps.channelContributionOwners, ids),
-    addDirectChannelOwners: (target, ids) => addOwners(target, maps.directChannelOwners, ids),
-    addDirectProviderOwners: (target, ids) => addOwners(target, maps.directProviderOwners, ids),
-    addProviderContributionOwners: (target, ids) =>
-      addOwners(target, maps.providerContributionOwners, ids),
+  const lookup: InstalledPluginIndexScopeLookup = {
+    addAgentHarnessOwners: agentHarnessOwners.add,
+    addChannelContributionOwners: channelContributionOwners.add,
+    addDirectChannelOwners: directChannelOwners.add,
+    addDirectProviderOwners: directProviderOwners.add,
+    addProviderContributionOwners: providerContributionOwners.add,
     addShorthandModelOwners: (target, modelIds) => {
       for (const modelId of modelIds) {
-        for (const owner of maps.modelSupportOwners) {
+        for (const owner of modelSupportOwners) {
           if (modelSupportOwnerMatches(owner, modelId)) {
             target.add(owner.pluginId);
           }
@@ -240,30 +166,34 @@ export function createInstalledPluginIndexScopeLookup(
       return providerIds.every((providerId) => {
         const normalized = normalizeOptionalLowercaseString(providerId);
         return Boolean(
-          normalized &&
-          (maps.directProviderOwners.has(normalized) || normalizedScope.has(normalized)),
+          normalized && (directProviderOwners.has([normalized]) || normalizedScope.has(normalized)),
         );
       });
     },
-    hasChannelContributionOwners: (ids) => hasOwners(maps.channelContributionOwners, ids),
-    hasAgentHarnessOwners: (ids) => hasOwners(maps.agentHarnessOwners, ids),
+    hasChannelContributionOwners: channelContributionOwners.has,
+    hasAgentHarnessOwners: agentHarnessOwners.has,
     hasCompleteConfigPathActivationMetadata: () =>
       index.plugins.every(
         (plugin) =>
           !plugin.compat.includes(CONFIG_PATH_ACTIVATION_COMPAT_CODE) ||
           plugin.startup.configPaths !== undefined,
       ),
-    hasDirectChannelOwners: (ids) => hasOwners(maps.directChannelOwners, ids),
+    hasDirectChannelOwners: directChannelOwners.has,
     hasInstalledPluginIds: (ids) =>
       [...ids].every((pluginId) => {
         const normalized = normalizeOptionalLowercaseString(pluginId);
-        return Boolean(normalized && maps.installedPluginIds.has(normalized));
+        return Boolean(normalized && pluginIdsByLowercase.has(normalized));
       }),
-    hasProviderContributionOwners: (ids) => hasOwners(maps.providerContributionOwners, ids),
+    hasProviderContributionOwners: providerContributionOwners.has,
     hasShorthandModelOwners: (modelIds) =>
       modelIds.every((modelId) =>
-        maps.modelSupportOwners.some((owner) => modelSupportOwnerMatches(owner, modelId)),
+        modelSupportOwners.some((owner) => modelSupportOwnerMatches(owner, modelId)),
       ),
     normalizePluginId: normalizeInstalledPluginId,
   };
+  if (facts) {
+    // Callers own their method object; immutable maps remain private to these closures.
+    facts.scopeLookup = { ...lookup };
+  }
+  return lookup;
 }

--- a/src/plugins/installed-plugin-index-scope-lookup.ts
+++ b/src/plugins/installed-plugin-index-scope-lookup.ts
@@ -4,7 +4,10 @@ import { compileSafeRegex } from "../security/safe-regex.js";
 import { normalizePluginId } from "./config-state.js";
 import { CONFIG_PATH_ACTIVATION_COMPAT_CODE } from "./installed-plugin-index-config-path-scope.js";
 import { getInstalledPluginIndexFacts } from "./installed-plugin-index-facts.js";
-import type { InstalledPluginIndex } from "./installed-plugin-index.js";
+import type {
+  InstalledPluginIndex,
+  InstalledPluginIndexScopeLookup,
+} from "./installed-plugin-index-types.js";
 
 const PROVIDER_CONTRIBUTION_CONTRACTS = [
   "externalAuthProviders",
@@ -29,27 +32,6 @@ type ModelSupportOwner = {
   patterns: readonly RegExp[];
 };
 
-export type InstalledPluginIndexScopeLookup = {
-  addAgentHarnessOwners: (target: Set<string>, ids: readonly string[]) => void;
-  addChannelContributionOwners: (target: Set<string>, ids: readonly string[]) => void;
-  addDirectChannelOwners: (target: Set<string>, ids: readonly string[]) => void;
-  addDirectProviderOwners: (target: Set<string>, ids: readonly string[]) => void;
-  addProviderContributionOwners: (target: Set<string>, ids: readonly string[]) => void;
-  addShorthandModelOwners: (target: Set<string>, modelIds: readonly string[]) => void;
-  canResolveDirectProviderIds: (
-    providerIds: readonly string[],
-    scopePluginIds: ReadonlySet<string>,
-  ) => boolean;
-  hasChannelContributionOwners: (ids: readonly string[]) => boolean;
-  hasAgentHarnessOwners: (ids: readonly string[]) => boolean;
-  hasCompleteConfigPathActivationMetadata: () => boolean;
-  hasDirectChannelOwners: (ids: readonly string[]) => boolean;
-  hasInstalledPluginIds: (ids: Iterable<string>) => boolean;
-  hasProviderContributionOwners: (ids: readonly string[]) => boolean;
-  hasShorthandModelOwners: (modelIds: readonly string[]) => boolean;
-  normalizePluginId: (pluginId: string) => string;
-};
-
 /** A private ownership index shares normalization and duplicate handling across scope kinds. */
 function createOwnerLookup() {
   const owners = new Map<string, Set<string>>();
@@ -65,7 +47,7 @@ function createOwnerLookup() {
         }
       }
     },
-    add(target: Set<string>, ids: readonly string[]) {
+    add: (target: Set<string>, ids: readonly string[]) => {
       for (const id of ids) {
         for (const pluginId of resolve(id) ?? []) {
           target.add(pluginId);
@@ -76,7 +58,7 @@ function createOwnerLookup() {
   };
 }
 
-function listValues(value: unknown): readonly string[] {
+function listValues(value: readonly string[] | undefined): readonly string[] {
   return Array.isArray(value) ? value : [];
 }
 
@@ -101,7 +83,7 @@ export function createInstalledPluginIndexScopeLookup(
   const agentHarnessOwners = createOwnerLookup();
   const channelContributionOwners = createOwnerLookup();
   const directChannelOwners = createOwnerLookup();
-  const directProviderOwners = createOwnerLookup();
+  const installedPluginOwners = createOwnerLookup();
   const providerContributionOwners = createOwnerLookup();
   const pluginIdsByLowercase = new Map<string, string>();
   const modelSupportOwners: ModelSupportOwner[] = [];
@@ -109,7 +91,7 @@ export function createInstalledPluginIndexScopeLookup(
     const normalizedPluginId = normalizeOptionalLowercaseString(plugin.pluginId);
     if (normalizedPluginId) {
       pluginIdsByLowercase.set(normalizedPluginId, plugin.pluginId);
-      directProviderOwners.index(plugin.pluginId, [plugin.pluginId]);
+      installedPluginOwners.index(plugin.pluginId, [plugin.pluginId]);
     }
     directChannelOwners.index(plugin.pluginId, [plugin.pluginId, plugin.packageChannel?.id]);
     agentHarnessOwners.index(plugin.pluginId, plugin.startup.agentHarnesses);
@@ -146,7 +128,7 @@ export function createInstalledPluginIndexScopeLookup(
     addAgentHarnessOwners: agentHarnessOwners.add,
     addChannelContributionOwners: channelContributionOwners.add,
     addDirectChannelOwners: directChannelOwners.add,
-    addDirectProviderOwners: directProviderOwners.add,
+    addDirectProviderOwners: installedPluginOwners.add,
     addProviderContributionOwners: providerContributionOwners.add,
     addShorthandModelOwners: (target, modelIds) => {
       for (const modelId of modelIds) {
@@ -166,7 +148,8 @@ export function createInstalledPluginIndexScopeLookup(
       return providerIds.every((providerId) => {
         const normalized = normalizeOptionalLowercaseString(providerId);
         return Boolean(
-          normalized && (directProviderOwners.has([normalized]) || normalizedScope.has(normalized)),
+          normalized &&
+          (installedPluginOwners.has([normalized]) || normalizedScope.has(normalized)),
         );
       });
     },
@@ -179,11 +162,7 @@ export function createInstalledPluginIndexScopeLookup(
           plugin.startup.configPaths !== undefined,
       ),
     hasDirectChannelOwners: directChannelOwners.has,
-    hasInstalledPluginIds: (ids) =>
-      [...ids].every((pluginId) => {
-        const normalized = normalizeOptionalLowercaseString(pluginId);
-        return Boolean(normalized && pluginIdsByLowercase.has(normalized));
-      }),
+    hasInstalledPluginIds: (ids) => installedPluginOwners.has([...ids]),
     hasProviderContributionOwners: providerContributionOwners.has,
     hasShorthandModelOwners: (modelIds) =>
       modelIds.every((modelId) =>

--- a/src/plugins/installed-plugin-index-types.ts
+++ b/src/plugins/installed-plugin-index-types.ts
@@ -160,6 +160,34 @@ export type InstalledPluginIndex = {
   diagnostics: readonly PluginDiagnostic[];
 };
 
+export type InstalledPluginIndexScopeLookup = {
+  addAgentHarnessOwners: (target: Set<string>, ids: readonly string[]) => void;
+  addChannelContributionOwners: (target: Set<string>, ids: readonly string[]) => void;
+  addDirectChannelOwners: (target: Set<string>, ids: readonly string[]) => void;
+  addDirectProviderOwners: (target: Set<string>, ids: readonly string[]) => void;
+  addProviderContributionOwners: (target: Set<string>, ids: readonly string[]) => void;
+  addShorthandModelOwners: (target: Set<string>, modelIds: readonly string[]) => void;
+  canResolveDirectProviderIds: (
+    providerIds: readonly string[],
+    scopePluginIds: ReadonlySet<string>,
+  ) => boolean;
+  hasChannelContributionOwners: (ids: readonly string[]) => boolean;
+  hasAgentHarnessOwners: (ids: readonly string[]) => boolean;
+  hasCompleteConfigPathActivationMetadata: () => boolean;
+  hasDirectChannelOwners: (ids: readonly string[]) => boolean;
+  hasInstalledPluginIds: (ids: Iterable<string>) => boolean;
+  hasProviderContributionOwners: (ids: readonly string[]) => boolean;
+  hasShorthandModelOwners: (modelIds: readonly string[]) => boolean;
+  normalizePluginId: (pluginId: string) => string;
+};
+
+/** In-memory projections owned by one immutable installed-index cache generation. */
+export type InstalledPluginIndexFacts = {
+  fingerprint?: string;
+  scopeLookup?: InstalledPluginIndexScopeLookup;
+  installRecords?: Record<string, PluginInstallRecord>;
+};
+
 export type LoadInstalledPluginIndexParams = {
   config?: OpenClawConfig;
   workspaceDir?: string;

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -16,6 +16,7 @@ import { listBundledSourceOverlayDirs } from "./bundled-source-overlays.js";
 import { recordPluginCandidateInstallOwner } from "./candidate-install-owner.js";
 import { discoverConfiguredPluginLoadPaths, type PluginCandidate } from "./discovery.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
+import { getInstalledPluginIndexFacts } from "./installed-plugin-index-facts.js";
 import { hashStableJson } from "./installed-plugin-index-hash.js";
 import {
   isInstalledPluginIndexInstallOwnerAmbiguous,
@@ -43,7 +44,6 @@ import {
   pluginCacheRealpathSync,
   readPluginCacheFile,
 } from "./plugin-cache-files.js";
-import { getPluginCache } from "./plugin-cache.js";
 import { tracePluginLifecyclePhase } from "./plugin-lifecycle-trace.js";
 import {
   normalizePluginDependencySpecs,
@@ -56,25 +56,11 @@ type InstalledPackageMetadata = {
   packageOptionalDependencies?: PluginDependencySpecMap;
 };
 
-function isDeepFrozenJsonLike(value: unknown, seen = new WeakSet<object>()): boolean {
-  if (!value || typeof value !== "object") {
-    return true;
-  }
-  const object = value;
-  if (seen.has(object)) {
-    return true;
-  }
-  if (!Object.isFrozen(object)) {
-    return false;
-  }
-  seen.add(object);
-  return Object.values(value).every((entry) => isDeepFrozenJsonLike(entry, seen));
-}
-
 export function resolveInstalledManifestRegistryIndexFingerprint(
   index: InstalledPluginIndex,
 ): string {
-  const cached = getPluginCache().metadata.indexFingerprints.get(index);
+  const facts = getInstalledPluginIndexFacts(index);
+  const cached = facts?.fingerprint;
   if (cached) {
     return cached;
   }
@@ -98,8 +84,8 @@ export function resolveInstalledManifestRegistryIndexFingerprint(
       }),
     ),
   });
-  if (isDeepFrozenJsonLike(index)) {
-    getPluginCache().metadata.indexFingerprints.set(index, fingerprint);
+  if (facts) {
+    facts.fingerprint = fingerprint;
   }
   return fingerprint;
 }

--- a/src/plugins/plugin-cache-metadata.ts
+++ b/src/plugins/plugin-cache-metadata.ts
@@ -3,8 +3,10 @@ import type { BundledChannelCatalogEntry } from "../channels/bundled-channel-cat
 import type { ManifestChannelPlugin } from "../channels/plugins/manifest-channel-plugin.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginDiscoveryResult } from "./discovery.types.js";
-import type { InstalledPluginIndexFacts } from "./installed-plugin-index-facts.js";
-import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
+import type {
+  InstalledPluginIndex,
+  InstalledPluginIndexFacts,
+} from "./installed-plugin-index-types.js";
 import type { ManifestModelSuppressionResolver } from "./manifest-model-suppression.types.js";
 import type { PluginManifestRecord } from "./manifest-registry.types.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";

--- a/src/plugins/plugin-cache-metadata.ts
+++ b/src/plugins/plugin-cache-metadata.ts
@@ -3,6 +3,7 @@ import type { BundledChannelCatalogEntry } from "../channels/bundled-channel-cat
 import type { ManifestChannelPlugin } from "../channels/plugins/manifest-channel-plugin.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginDiscoveryResult } from "./discovery.types.js";
+import type { InstalledPluginIndexFacts } from "./installed-plugin-index-facts.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
 import type { ManifestModelSuppressionResolver } from "./manifest-model-suppression.types.js";
 import type { PluginManifestRecord } from "./manifest-registry.types.js";
@@ -31,7 +32,7 @@ export type PluginCacheMetadata = {
     projections: WeakMap<PluginMetadataSnapshot, Map<string, PluginMetadataSnapshot>>;
     projectionSources: WeakMap<PluginMetadataSnapshot, PluginMetadataSnapshot>;
     completions: WeakMap<PluginMetadataSnapshot, PluginMetadataSnapshot>;
-    indexFingerprints: WeakMap<InstalledPluginIndex, string>;
+    indexFacts: WeakMap<InstalledPluginIndex, InstalledPluginIndexFacts>;
     channelAdapters: WeakMap<PluginManifestRecord, Map<string, ManifestChannelPlugin | undefined>>;
     bundledChannelCatalogs: Map<string, BundledChannelCatalogEntry[]>;
     staticCatalogStates: WeakMap<object, WeakMap<OpenClawConfig, BundledStaticCatalogState>>;
@@ -64,7 +65,7 @@ export function createPluginCacheMetadata(): PluginCacheMetadata {
       projections: new WeakMap(),
       projectionSources: new WeakMap(),
       completions: new WeakMap(),
-      indexFingerprints: new WeakMap(),
+      indexFacts: new WeakMap(),
       channelAdapters: new WeakMap(),
       bundledChannelCatalogs: new Map(),
       staticCatalogStates: new WeakMap(),


### PR DESCRIPTION
## What Problem This Solves

Plugin startup and scoped runtime lookups rebuild ownership maps, revisit model matching patterns, and parse the same install ledger even after the installed index belongs to an immutable metadata generation.

## Why This Change Was Made

Extend the existing generation-owned installed-index fingerprint cache to retain lookup and parsed install-record facts. Consolidate private ownership-map construction while preserving distinct direct-owner, contribution-owner, and exact installed-ID contracts. Types live in the existing installed-index type owner, keeping the import graph acyclic.

Mutable management indexes remain uncached. Callers retain independent method objects and install-record results, including schema-owned nested values. Configuration, trust, request identity, and lifecycle authority remain evaluated by their existing owners.

## User Impact

Repeated reads of an immutable installed inventory do less preparation work. Discovery precedence, setup/runtime modes, configuration, public SDK contracts, and persisted data are unchanged. No end-to-end latency improvement is claimed.

## Evidence

- Original/candidate comparison: six reads of a two-plugin immutable index reduced calls to the already-cached regex compiler from 12 to 2 and install-map parses from 6 to 1. Original preservation assertions passed; the new cost assertions failed as expected.
- Final startup/scope-selection proof: `node scripts/run-vitest.mjs src/plugins/installed-plugin-index-facts.test.ts src/plugins/channel-plugin-ids.test.ts src/agents/harness/runtime-plugin.test.ts` — 218 tests passed. Additional discovery/manifest and loader/generation runs passed.
- Live built-CLI/Gateway proof: `node scripts/run-vitest.mjs test/scripts/doctor-config-preflight-plugin-index.built-cli.e2e.test.ts` — both isolated stale-index startup and legacy-state restart fixtures passed. Temporary state and free ports were used, and fixture processes were cleaned up.
- Full `pnpm build` passed, including all 152 public SDK subpaths and built control-plane/CLI import checks. Madge reported zero cycles; targeted typed lint and complete staged-patch autoreview through P2 passed.
- `node scripts/check-changed.mjs` passed on Blacksmith Testbox `tbx_01m1wtg15j4z5wdwqfe219tt8n` with delegated exit code 0 ([backing run](https://github.com/openclaw/openclaw/actions/runs/34075807216)). The one-shot lease was stopped after success; its backing workflow can show cancellation during delegated cleanup.
- Required entrypoint profile on macOS / Node 26.8.1: `OPENCLAW_LOCAL_CHECK=0 node --import tsx scripts/profile-extension-memory.mts --extension memory-core --skip-combined --concurrency 1` — 219.25 MiB peak RSS, 39.09 MiB empty-Node baseline, 180.16 MiB import delta, no timeout or failure. This is a candidate import profile, not a before/after Gateway resource comparison.
- Synced to main `4cf8d68eec01735eab0f5cf1ff7f0b21e74c0329`; stable patch ID and all nine changed-file contents match the fully reviewed and tested implementation. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34077882600) passed at `f8631d6fd6262b815ae35220b67dedf1b8c43548`.

Production source: **197 additions, 202 deletions, net -5**. Tests add 164 lines; docs add 6. Pure type moves contribute no net reduction. No generated files, snapshots, lockfiles, vendored code, or operational tooling are included.
