### PR TITLE
fix(onboarding): load installed runtime for first dashboard chat

### DIFF
--- a/src/commands/onboard-quickstart-host.plugin-generation.test.ts
+++ b/src/commands/onboard-quickstart-host.plugin-generation.test.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { readConfigFileSnapshotWithPluginMetadata } from "../config/config.js";
+import { resolveConfigWidePluginMetadataSnapshot } from "../config/io.plugin-metadata.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { writePersistedInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-records.js";
+import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
+import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { invalidatePluginRuntimeDiscoveryAfterConfigMutation } from "../plugins/registry-refresh.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { runQuickstartForegroundGateway } from "./onboard-quickstart-host.js";
+
+afterEach(() => clearPluginMetadataLifecycleCaches());
+
+it("carries a plugin installed during onboarding into the first foreground Gateway inventory", async () => {
+  await withOpenClawTestState(
+    { label: "onboarding-plugin-generation", env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" } },
+    async (state) => {
+      const config: OpenClawConfig = {
+        gateway: { mode: "local", auth: { mode: "none" } },
+        agents: { defaults: { workspace: state.workspaceDir } },
+        plugins: { entries: { codex: { enabled: true } } },
+      };
+      await state.writeConfig(config);
+      // The CLI keeps this operation alive from provider selection through browser handoff.
+      await withPluginCache(createPluginCache(), async () => {
+        const readMetadata = () =>
+          resolveConfigWidePluginMetadataSnapshot({
+            config,
+            env: process.env,
+            allowCurrent: false,
+          });
+        expect(readMetadata().byPluginId.has("codex")).toBe(false);
+        const pluginRoot = state.statePath(
+          "npm",
+          "projects",
+          "codex-fixture",
+          "node_modules",
+          "@fixture",
+          "codex",
+        );
+        await fs.mkdir(pluginRoot, { recursive: true });
+        await fs.writeFile(
+          path.join(pluginRoot, "package.json"),
+          JSON.stringify({
+            name: "@fixture/codex",
+            version: "1.0.0",
+            openclaw: { extensions: ["./index.cjs"] },
+          }),
+        );
+        await fs.writeFile(
+          path.join(pluginRoot, "openclaw.plugin.json"),
+          JSON.stringify({
+            id: "codex",
+            activation: { onAgentHarnesses: ["codex"] },
+            configSchema: { type: "object", properties: {}, additionalProperties: false },
+          }),
+        );
+        await fs.writeFile(
+          path.join(pluginRoot, "index.cjs"),
+          'module.exports = { id: "codex", register() {} };\n',
+        );
+        // Package acquisition is synthetic; the install ledger and post-install invalidation are real.
+        await withPluginLifecycleLease({}, async () => {
+          await writePersistedInstalledPluginIndexInstallRecords(
+            {
+              codex: {
+                source: "npm",
+                spec: "@fixture/codex@1.0.0",
+                installPath: pluginRoot,
+                resolvedName: "@fixture/codex",
+                resolvedVersion: "1.0.0",
+              },
+            },
+            { config, env: process.env },
+          );
+          clearPluginMetadataLifecycleCaches();
+          await invalidatePluginRuntimeDiscoveryAfterConfigMutation({});
+        });
+        expect(withPluginCache(createPluginCache(), readMetadata).byPluginId.has("codex")).toBe(
+          true,
+        );
+        const inventories: boolean[] = [];
+        const readStartupConfig = async () => {
+          const read = await readConfigFileSnapshotWithPluginMetadata({ isolateEnv: true });
+          inventories.push(read.pluginMetadataSnapshot?.byPluginId.has("codex") ?? false);
+          return { config: read.snapshot.config };
+        };
+        await runQuickstartForegroundGateway(
+          { runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() } },
+          {
+            readConfigSnapshot: readStartupConfig,
+            runGateway: async () => {
+              await readStartupConfig();
+            },
+            waitForGateway: async () => ({ ok: false }),
+            runBrowserHandoff: async () => ({ handedOff: false, reason: "timeout" }),
+          },
+        );
+        expect(inventories).toEqual([true, true]);
+        // The handoff must not mutate an older generation still held by another owner.
+        expect(readMetadata().byPluginId.has("codex")).toBe(false);
+      });
+    },
+  );
+});

--- a/src/commands/onboard-quickstart-host.ts
+++ b/src/commands/onboard-quickstart-host.ts
@@ -4,6 +4,7 @@ import { getGatewayRunRuntimeHooks } from "../cli/gateway-cli/runtime-hooks.js";
 import { readConfigFileSnapshot, resolveGatewayPort } from "../config/config.js";
 import type { ConfigFileSnapshot } from "../config/types.openclaw.js";
 import { resolveGatewayCredentialsWithSecretInputs } from "../gateway/credentials-secret-inputs.js";
+import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createQuickstartNotePrompter } from "../system-agent/setup-apply.js";
 import { t } from "../wizard/i18n/index.js";
@@ -18,63 +19,65 @@ type QuickstartForegroundGatewayDeps = {
   runBrowserHandoff?: typeof runBrowserHatchHandoff;
 };
 
-/** Own the foreground Gateway after the wizard has restored terminal input. */
+/** Start the foreground Gateway with fresh plugin facts after onboarding installs. */
 export async function runQuickstartForegroundGateway(
   params: { runtime: RuntimeEnv; suppressTokenOutput?: boolean },
   deps: QuickstartForegroundGatewayDeps = {},
 ): Promise<void> {
-  const { runtime } = params;
-  const { config } = await (deps.readConfigSnapshot ?? readConfigFileSnapshot)();
-  const links = resolveLocalControlUiProbeLinks({
-    bind: config.gateway?.bind,
-    port: resolveGatewayPort(config),
-    customBindHost: config.gateway?.customBindHost,
-    basePath: config.gateway?.controlUi?.basePath,
-    tlsEnabled: config.gateway?.tls?.enabled === true,
-  });
-  const credentials = await resolveGatewayCredentialsWithSecretInputs({
-    config,
-    modeOverride: "local",
-  });
-  const authMode = config.gateway?.auth?.mode ?? (credentials.password ? "password" : "token");
-  const runGateway =
-    deps.runGateway ?? (await import("../cli/gateway-cli/run.js")).runGatewayCommand;
-  const gateway = runGateway(resolveGatewayRunOptions({}), getGatewayRunRuntimeHooks());
-  const stopped = gateway.then(() => null);
-  const reachable = await Promise.race([
-    stopped,
-    (deps.waitForGateway ?? waitForGatewayReachable)({
-      url: links.wsUrl,
-      token: authMode === "token" ? credentials.token : undefined,
-      password: authMode === "password" ? credentials.password : undefined,
-      ...resolveGatewayStartupTiming(),
-    }),
-  ]);
-  if (!reachable) {
-    return;
-  }
-  if (reachable.ok) {
-    // Browser failure must not end the process that now owns the Gateway.
-    const handoff = await Promise.race([
+  return await withPluginCache(createPluginCache(), async () => {
+    const { runtime } = params;
+    const { config } = await (deps.readConfigSnapshot ?? readConfigFileSnapshot)();
+    const links = resolveLocalControlUiProbeLinks({
+      bind: config.gateway?.bind,
+      port: resolveGatewayPort(config),
+      customBindHost: config.gateway?.customBindHost,
+      basePath: config.gateway?.controlUi?.basePath,
+      tlsEnabled: config.gateway?.tls?.enabled === true,
+    });
+    const credentials = await resolveGatewayCredentialsWithSecretInputs({
+      config,
+      modeOverride: "local",
+    });
+    const authMode = config.gateway?.auth?.mode ?? (credentials.password ? "password" : "token");
+    const runGateway =
+      deps.runGateway ?? (await import("../cli/gateway-cli/run.js")).runGatewayCommand;
+    const gateway = runGateway(resolveGatewayRunOptions({}), getGatewayRunRuntimeHooks());
+    const stopped = gateway.then(() => null);
+    const reachable = await Promise.race([
       stopped,
-      (deps.runBrowserHandoff ?? runBrowserHatchHandoff)({
-        config,
-        prompter: createQuickstartNotePrompter(runtime),
-        suppressTokenOutput: params.suppressTokenOutput,
-      }).catch(() => ({ handedOff: false })),
+      (deps.waitForGateway ?? waitForGatewayReachable)({
+        url: links.wsUrl,
+        token: authMode === "token" ? credentials.token : undefined,
+        password: authMode === "password" ? credentials.password : undefined,
+        ...resolveGatewayStartupTiming(),
+      }),
     ]);
-    if (!handoff) {
+    if (!reachable) {
       return;
     }
-    if (!handoff.handedOff) {
-      runtime.log(t("wizard.guided.quickstartBrowserUnavailable"));
+    if (reachable.ok) {
+      // Browser failure must not end the process that now owns the Gateway.
+      const handoff = await Promise.race([
+        stopped,
+        (deps.runBrowserHandoff ?? runBrowserHatchHandoff)({
+          config,
+          prompter: createQuickstartNotePrompter(runtime),
+          suppressTokenOutput: params.suppressTokenOutput,
+        }).catch(() => ({ handedOff: false })),
+      ]);
+      if (!handoff) {
+        return;
+      }
+      if (!handoff.handedOff) {
+        runtime.log(t("wizard.guided.quickstartBrowserUnavailable"));
+      }
+    } else {
+      runtime.log(t("wizard.guided.quickstartGatewayPending"));
     }
-  } else {
-    runtime.log(t("wizard.guided.quickstartGatewayPending"));
-  }
-  runtime.log(t("wizard.guided.quickstartDashboard", { url: links.httpUrl }));
-  runtime.log(t("wizard.guided.quickstartForeground"));
-  runtime.log(t("wizard.guided.quickstartBackground"));
-  runtime.log(t("wizard.guided.quickstartReopen"));
-  await gateway;
+    runtime.log(t("wizard.guided.quickstartDashboard", { url: links.httpUrl }));
+    runtime.log(t("wizard.guided.quickstartForeground"));
+    runtime.log(t("wizard.guided.quickstartBackground"));
+    runtime.log(t("wizard.guided.quickstartReopen"));
+    await gateway;
+  });
 }


### PR DESCRIPTION
Related: #140393. Reported by @DonnieFi.

## What Problem This Solves

Fixes an issue where users installing the Codex plugin during onboarding could reach the dashboard but have their first chat fail because the foreground Gateway's prepared plugin inventory omitted the newly installed runtime.

## Why This Change Was Made

Onboarding runs inside the CLI's operation-scoped plugin cache (`src/cli/run-main.ts:1025`). Plugin installation refreshes its own generation and clears process caches, while the enclosing onboarding cache can retain the pre-install inventory. The foreground host then reads config and starts the Gateway inside that older cache (`src/commands/onboard-quickstart-host.ts`).

Start a fresh plugin-cache scope at the foreground handoff, before its first config read, and retain it for the Gateway lifetime. This preserves the normal Gateway CLI preflight and older immutable generations. Global invalidation, retries, and Doctor recovery do not repair this ownership transition. No connected dead branches or duplicate flows remain to remove; the existing readiness and stopped-Gateway races protect distinct behavior.

## User Impact

Plugins installed during setup are visible to the first foreground Gateway generation. Users can continue to their selected runtime without a recovery restart caused by stale onboarding discovery.

## Evidence

- Regression uses an isolated synthetic npm-layout plugin and real install-index mutation, invalidation, and startup metadata reads within one CLI-like operation scope. On the original source, both foreground inventories omit the installed runtime (`[false, false]`); after the repair, both contain it (`[true, true]`). The older generation remains unchanged.
- `node scripts/run-vitest.mjs src/commands/onboard-quickstart-host.plugin-generation.test.ts src/commands/onboard-quickstart-host.test.ts src/commands/onboarding-plugin-install.test.ts src/commands/codex-runtime-plugin-install.test.ts`: 4 files, 110 tests passed.
- `pnpm check:changed`: passed after correcting the regression fixture's required unsuccessful-handoff reason field. Production and test types, lint, formatting, dead-export scans, and architecture guards passed.
- Independent Codex autoreview: final scoped-clean result through P2, no accepted/actionable findings.
- Final handoff regression/sibling rerun: 2 files, 8 tests passed.
- Linux `pnpm build`: passed on the exact PR source.
- Fresh registry install through first chat: passed on Blacksmith Testbox ([run 34081898301](https://github.com/openclaw/openclaw/actions/runs/34081898301), command receipt exit 0). The normal version-bound installer established official plugin trust, the real foreground Gateway loaded the runtime, and WebSocket `chat.send` produced the synthetic marker in an assistant history message; app-server `turn/start` was observed. The source-checkout Codex copies were hidden during this isolated fixture so they could not mask a missing install. The owned Gateway and Testbox stopped cleanly.
- Scope of that proof: real package acquisition, canonical install/config persistence, Gateway startup, and chat API; synthetic OAuth and app-server inference. Terminal wizard interaction and browser rendering were not exercised.
- `git diff --check`: clean.
- Production delta: +53/-50 = **+3 lines**. Tests: +108/-0 = **+108 lines**. No behavior or test coverage was removed to offset the added scope.
- Exact reviewed head: a16e47f0d859cdf17c3672ecc581638d813bc00d.
- Exact-head CI: passed for `a16e47f0d859cdf17c3672ecc581638d813bc00d` ([run 34074338070](https://github.com/openclaw/openclaw/actions/runs/34074338070)). ClawSweeper reviewed the same head and reported no actionable findings.

Release-note context: repair the onboarding plugin-install to foreground-runtime handoff so the first dashboard chat can use the installed runtime. No visual UI change, new configuration, SDK/API change, dependency change, or persistence semantics change.
