### PR TITLE
refactor(ai): share Chat Completions request assembly

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1455,7 +1455,7 @@ packages/ai/src/providers/mistral.ts	6
 packages/ai/src/providers/openai-chatgpt-responses-protocol.ts	1
 packages/ai/src/providers/openai-chatgpt-responses.ts	26
 packages/ai/src/providers/openai-completions-tool-calls.ts	5
-packages/ai/src/providers/openai-completions.ts	9
+packages/ai/src/providers/openai-completions.ts	6
 packages/ai/src/providers/openai-reasoning-effort.ts	6
 packages/ai/src/providers/openai-responses-shared.ts	6
 packages/ai/src/providers/openai-responses-tools.ts	2
@@ -1472,7 +1472,7 @@ packages/ai/src/transports/anthropic-payload-policy.ts	7
 packages/ai/src/transports/anthropic-transport-stream.ts	5
 packages/ai/src/transports/openai-compatible-conversation-turn.ts	2
 packages/ai/src/transports/openai-completions-compat.ts	2
-packages/ai/src/transports/openai-completions-params.ts	9
+packages/ai/src/transports/openai-completions-params.ts	7
 packages/ai/src/transports/openai-completions-replay.ts	9
 packages/ai/src/transports/openai-completions-stream.ts	8
 packages/ai/src/transports/openai-completions-string-content.ts	5

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -2,21 +2,15 @@
 import type OpenAI from "openai";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { clampThinkingLevel } from "../model-utils.js";
-import { convertMessages, hasToolCallHistory } from "../openai-completions-messages.js";
 import { reasoningTagTextPolicy, type OpenAICompletionsOptions } from "../provider-options.js";
 // OpenAI completions provider adapts chat completions to the agent runtime.
 import { createAssistantOutput } from "../transports/assistant-output.js";
 import {
-  applyCompletionsAnthropicCacheControl,
-  resolveCompletionsCacheControl,
-} from "../transports/openai-completions-cache-control.js";
-import {
-  detectOpenAICompletionsCompat,
   resolveOpenAICompletionsCompat,
   type ResolvedOpenAICompletionsCompat,
 } from "../transports/openai-completions-compat.js";
+import { buildOpenAICompletionsRequest } from "../transports/openai-completions-params.js";
 import { processCompletionsStream } from "../transports/openai-completions-stream.js";
-import { resolveOpenAIReasoningEffortMap } from "../transports/openai-reasoning-compat.js";
 import {
   createOpenAIProviderAcceptanceHook,
   isOpenAICompletionsThinkingEnabled,
@@ -29,12 +23,10 @@ import {
 } from "../transports/transport-stream-shared.js";
 import type {
   AssistantMessage,
-  CacheRetention,
   Context,
   Model,
   SimpleStreamOptions,
   StreamFunction,
-  Tool,
 } from "../types.js";
 import {
   clearPendingCommentaryText,
@@ -42,7 +34,6 @@ import {
   type PendingCommentaryTags,
 } from "../utils/assistant-text-phase.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
-import { sortPromptCacheToolsByName } from "../utils/prompt-cache-stability.js";
 import {
   createFirstStreamEventAbortController,
   getFirstStreamEventTimeoutHandler,
@@ -51,20 +42,7 @@ import {
 import { resolveCacheRetention } from "./cache-retention.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { finalizeOpenAICompletionsToolCalls } from "./openai-completions-tool-calls.js";
-import {
-  clampOpenAIPromptCacheKey,
-  resolveOpenAIPromptCacheParams,
-} from "./openai-prompt-cache.js";
 import { createOpenAIProviderClient } from "./openai-provider-client.js";
-import {
-  resolveOpenAICompletionsResponseFormat,
-  shouldOmitOllamaCompatResponseFormat,
-} from "./openai-response-format.js";
-import {
-  projectOpenAITools,
-  reconcileOpenAICompletionsToolChoice,
-  type OpenAIToolProjection,
-} from "./openai-tool-projection.js";
 import { buildBaseOptions } from "./simple-options.js";
 
 export type { OpenAICompletionsOptions } from "../provider-options.js";
@@ -98,7 +76,11 @@ export const streamOpenAICompletions: StreamFunction<
         cacheSessionId,
         compat,
       );
-      let params = buildParams(model, context, options, compat, cacheRetention);
+      let params = buildOpenAICompletionsRequest(model, context, options, {
+        mode: "direct",
+        compat,
+        cacheRetention,
+      });
       const nextParams = await options?.onPayload?.(params, model);
       if (nextParams !== undefined) {
         params = nextParams as typeof params;
@@ -297,255 +279,4 @@ function createClient(
   }
 
   return createOpenAIProviderClient(model, apiKey, headers, optionsHeaders);
-}
-
-function buildParams(
-  model: Model<"openai-completions">,
-  context: Context,
-  options?: OpenAICompletionsOptions,
-  compat: ResolvedOpenAICompletionsCompat = resolveOpenAICompletionsCompat(model),
-  cacheRetention: CacheRetention = resolveCacheRetention(options?.cacheRetention),
-) {
-  const { endpointClass } = detectOpenAICompletionsCompat(model).capabilities;
-  const cacheControl = resolveCompletionsCacheControl(
-    compat,
-    cacheRetention,
-    endpointClass === "openrouter" ||
-      (endpointClass === "default" && model.provider === "openrouter"),
-  );
-  // Transient runtime-context carrier indexes skip cache anchoring so the breakpoint
-  // stays on the last stable user turn; conversion-to-policy must not splice messages.
-  const cacheOptOutIndexes = new Set<number>();
-  const messages = convertMessages(model, context, compat, {
-    cacheOptOutIndexes,
-    preserveSystemPromptCacheBoundary: cacheControl !== undefined,
-  });
-
-  type ChatCompletionRequestParams = Omit<
-    OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
-    "reasoning_effort" | "response_format"
-  > & {
-    reasoning_effort?: string;
-    response_format?: Record<string, unknown>;
-    stream_options?: { include_usage: boolean };
-    max_tokens?: number;
-    prompt_cache_key?: string;
-    prompt_cache_retention?: "24h";
-    tool_stream?: boolean;
-    enable_thinking?: boolean;
-    chat_template_kwargs?: { enable_thinking: boolean; preserve_thinking: boolean };
-    thinking?: { type: string; clear_thinking?: boolean };
-    provider?: unknown;
-    providerOptions?: unknown;
-  };
-
-  const promptCacheKey =
-    compat.supportsPromptCacheKey && cacheRetention !== "none"
-      ? clampOpenAIPromptCacheKey(options?.promptCacheKey ?? options?.sessionId)
-      : undefined;
-  const params: ChatCompletionRequestParams = {
-    model: model.id,
-    messages,
-    stream: true,
-    prompt_cache_key: promptCacheKey,
-    ...resolveOpenAIPromptCacheParams(model, cacheRetention, compat),
-  };
-
-  if (compat.supportsUsageInStreaming) {
-    params.stream_options = { include_usage: true };
-  }
-
-  if (compat.supportsStore) {
-    params.store = false;
-  }
-
-  if (options?.maxTokens) {
-    const maxTokens = clampOpenAICompletionsMaxTokens(model, options.maxTokens);
-    if (compat.maxTokensField === "max_tokens") {
-      params.max_tokens = maxTokens;
-    } else {
-      params.max_completion_tokens = maxTokens;
-    }
-  }
-
-  if (options?.temperature !== undefined) {
-    params.temperature = options.temperature;
-  }
-
-  if (options?.stop !== undefined && options.stop.length > 0) {
-    params.stop = options.stop;
-  }
-
-  const requestedResponseFormat = options?.responseFormat;
-  const responseFormat =
-    requestedResponseFormat === undefined
-      ? undefined
-      : resolveOpenAICompletionsResponseFormat(
-          shouldOmitOllamaCompatResponseFormat({
-            provider: model.provider,
-            baseUrl: model.baseUrl,
-            hasTools: () => Boolean(context.tools?.length),
-          })
-            ? undefined
-            : requestedResponseFormat,
-          compat.supportsJsonSchemaResponseFormat,
-        );
-  if (responseFormat !== undefined) {
-    params.response_format = responseFormat;
-  }
-
-  let toolProjection: OpenAIToolProjection | undefined;
-  if (context.tools) {
-    const converted = convertTools(context.tools, compat);
-    toolProjection = converted.projection;
-    if (converted.tools.length > 0) {
-      params.tools = converted.tools;
-    } else if (hasToolCallHistory(context.messages)) {
-      params.tools = [];
-    }
-    if (compat.zaiToolStream && converted.tools.length > 0) {
-      params.tool_stream = true;
-    }
-  } else if (hasToolCallHistory(context.messages)) {
-    // Anthropic (via LiteLLM/proxy) requires tools param when conversation has tool_calls/tool_results
-    params.tools = [];
-  }
-
-  if (compat.cacheControlFormat === "anthropic") {
-    applyCompletionsAnthropicCacheControl(
-      params,
-      cacheControl ?? null,
-      cacheOptOutIndexes,
-      endpointClass !== "modelstudio-native" &&
-        !(
-          endpointClass === "default" &&
-          ["modelstudio", "dashscope", "qwen"].includes(model.provider)
-        ),
-    );
-  }
-
-  if (options?.toolChoice) {
-    const toolChoice = reconcileOpenAICompletionsToolChoice(
-      options.toolChoice,
-      toolProjection ?? projectOpenAITools([]),
-    );
-    if (toolChoice !== undefined) {
-      params.tool_choice = toolChoice;
-    }
-  }
-
-  // Provider compat is authoritative; keep model-level and literal values as fallbacks
-  // for catalogs that have not adopted reasoningEffortMap.
-  const reasoningEffortMap = resolveOpenAIReasoningEffortMap(model);
-  const thinkingLevelMap = model.thinkingLevelMap as
-    | Partial<Record<NonNullable<OpenAICompletionsOptions["reasoningEffort"]>, string | null>>
-    | undefined;
-  const offReasoningEffort = reasoningEffortMap.off ?? model.thinkingLevelMap?.off;
-  const reasoningEffort =
-    options?.reasoningEffort === undefined
-      ? (offReasoningEffort ?? undefined)
-      : (reasoningEffortMap[options.reasoningEffort] ??
-        thinkingLevelMap?.[options.reasoningEffort] ??
-        options.reasoningEffort);
-  const reasoningEnabled = reasoningEffort !== undefined && reasoningEffort !== "none";
-
-  if (compat.thinkingFormat === "zai" && model.reasoning) {
-    params.thinking = reasoningEnabled
-      ? { type: "enabled", clear_thinking: false }
-      : { type: "disabled" };
-  } else if (compat.thinkingFormat === "qwen" && model.reasoning) {
-    params.enable_thinking = reasoningEnabled;
-  } else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {
-    params.chat_template_kwargs = {
-      enable_thinking: reasoningEnabled,
-      preserve_thinking: true,
-    };
-  } else if (compat.thinkingFormat === "deepseek" && model.reasoning) {
-    params.thinking = { type: reasoningEnabled ? "enabled" : "disabled" };
-    if (reasoningEnabled && compat.supportsReasoningEffort) {
-      params.reasoning_effort = reasoningEffort;
-    }
-  } else if (compat.thinkingFormat === "openrouter" && model.reasoning) {
-    // OpenRouter normalizes reasoning across providers via a nested reasoning object.
-    const openRouterParams = params as typeof params & { reasoning?: { effort?: string } };
-    if (reasoningEnabled) {
-      openRouterParams.reasoning = { effort: reasoningEffort };
-    } else if (offReasoningEffort !== null) {
-      openRouterParams.reasoning = { effort: offReasoningEffort ?? "none" };
-    }
-  } else if (compat.thinkingFormat === "together" && model.reasoning) {
-    const togetherParams = params as Omit<typeof params, "reasoning_effort"> & {
-      reasoning?: { enabled: boolean };
-      reasoning_effort?: string;
-    };
-    togetherParams.reasoning = { enabled: reasoningEnabled };
-    if (reasoningEnabled && compat.supportsReasoningEffort) {
-      togetherParams.reasoning_effort = reasoningEffort;
-    }
-  } else if (reasoningEnabled && model.reasoning && compat.supportsReasoningEffort) {
-    // OpenAI-style reasoning_effort
-    params.reasoning_effort = reasoningEffort;
-  } else if (model.reasoning && compat.supportsReasoningEffort) {
-    if (typeof offReasoningEffort === "string") {
-      params.reasoning_effort = offReasoningEffort;
-    }
-  }
-
-  // OpenRouter provider routing preferences
-  if (compat.openRouterRouting) {
-    params.provider = compat.openRouterRouting;
-  }
-
-  // Vercel AI Gateway provider routing preferences
-  if (model.baseUrl.includes("ai-gateway.vercel.sh") && model.compat?.vercelGatewayRouting) {
-    const routing = model.compat.vercelGatewayRouting;
-    if (routing.only || routing.order) {
-      const gatewayOptions: Record<string, string[]> = {};
-      if (routing.only) {
-        gatewayOptions.only = routing.only;
-      }
-      if (routing.order) {
-        gatewayOptions.order = routing.order;
-      }
-      params.providerOptions = { gateway: gatewayOptions };
-    }
-  }
-
-  return params;
-}
-
-function clampOpenAICompletionsMaxTokens(
-  model: Model<"openai-completions">,
-  requestedMaxTokens: number,
-): number {
-  const modelMaxTokens =
-    typeof model.maxTokens === "number" && Number.isFinite(model.maxTokens) && model.maxTokens > 0
-      ? Math.floor(model.maxTokens)
-      : undefined;
-  return modelMaxTokens === undefined || requestedMaxTokens <= modelMaxTokens
-    ? requestedMaxTokens
-    : modelMaxTokens;
-}
-
-function convertTools(
-  tools: Tool[],
-  compat: ResolvedOpenAICompletionsCompat,
-): {
-  projection: OpenAIToolProjection;
-  tools: OpenAI.Chat.Completions.ChatCompletionTool[];
-} {
-  const projection = projectOpenAITools(tools);
-  return {
-    projection,
-    tools: sortPromptCacheToolsByName(projection.tools).map((tool) => ({
-      type: "function",
-      function: {
-        name: tool.name,
-        description: tool.description,
-        parameters: tool.parameters,
-        // Only include strict if provider supports it. Some reject unknown fields.
-        ...(compat.supportsStrictMode && { strict: false }),
-      },
-    })),
-  };
 }

--- a/packages/ai/src/transports/openai-completions-direct-policy.ts
+++ b/packages/ai/src/transports/openai-completions-direct-policy.ts
@@ -1,0 +1,83 @@
+import type { OpenAICompletionsOptions } from "../provider-options.js";
+import type { ResolvedOpenAICompletionsCompat } from "./openai-completions-compat.js";
+import { resolveOpenAIReasoningEffortMap } from "./openai-reasoning-compat.js";
+import type { OpenAIModeModel } from "./openai-transport-shared.js";
+
+export function applyDirectCompletionsReasoningAndRouting(
+  params: Record<string, unknown>,
+  model: OpenAIModeModel,
+  options: OpenAICompletionsOptions | undefined,
+  compat: ResolvedOpenAICompletionsCompat,
+): void {
+  // Provider compat is authoritative; keep model-level and literal values as fallbacks
+  // for catalogs that have not adopted reasoningEffortMap.
+  const reasoningEffortMap = resolveOpenAIReasoningEffortMap(model);
+  const thinkingLevelMap:
+    | Partial<Record<NonNullable<OpenAICompletionsOptions["reasoningEffort"]>, string | null>>
+    | undefined = model.thinkingLevelMap;
+  const offReasoningEffort = reasoningEffortMap.off ?? model.thinkingLevelMap?.off;
+  const reasoningEffort =
+    options?.reasoningEffort === undefined
+      ? (offReasoningEffort ?? undefined)
+      : (reasoningEffortMap[options.reasoningEffort] ??
+        thinkingLevelMap?.[options.reasoningEffort] ??
+        options.reasoningEffort);
+  const reasoningEnabled = reasoningEffort !== undefined && reasoningEffort !== "none";
+
+  if (compat.thinkingFormat === "zai" && model.reasoning) {
+    params.thinking = reasoningEnabled
+      ? { type: "enabled", clear_thinking: false }
+      : { type: "disabled" };
+  } else if (compat.thinkingFormat === "qwen" && model.reasoning) {
+    params.enable_thinking = reasoningEnabled;
+  } else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {
+    params.chat_template_kwargs = {
+      enable_thinking: reasoningEnabled,
+      preserve_thinking: true,
+    };
+  } else if (compat.thinkingFormat === "deepseek" && model.reasoning) {
+    params.thinking = { type: reasoningEnabled ? "enabled" : "disabled" };
+    if (reasoningEnabled && compat.supportsReasoningEffort) {
+      params.reasoning_effort = reasoningEffort;
+    }
+  } else if (compat.thinkingFormat === "openrouter" && model.reasoning) {
+    // OpenRouter normalizes reasoning across providers via a nested reasoning object.
+    if (reasoningEnabled) {
+      params.reasoning = { effort: reasoningEffort };
+    } else if (offReasoningEffort !== null) {
+      params.reasoning = { effort: offReasoningEffort ?? "none" };
+    }
+  } else if (compat.thinkingFormat === "together" && model.reasoning) {
+    params.reasoning = { enabled: reasoningEnabled };
+    if (reasoningEnabled && compat.supportsReasoningEffort) {
+      params.reasoning_effort = reasoningEffort;
+    }
+  } else if (reasoningEnabled && model.reasoning && compat.supportsReasoningEffort) {
+    // OpenAI-style reasoning_effort
+    params.reasoning_effort = reasoningEffort;
+  } else if (model.reasoning && compat.supportsReasoningEffort) {
+    if (typeof offReasoningEffort === "string") {
+      params.reasoning_effort = offReasoningEffort;
+    }
+  }
+
+  // OpenRouter provider routing preferences
+  if (compat.openRouterRouting) {
+    params.provider = compat.openRouterRouting;
+  }
+
+  // Vercel AI Gateway provider routing preferences
+  if (model.baseUrl.includes("ai-gateway.vercel.sh") && model.compat?.vercelGatewayRouting) {
+    const routing = model.compat.vercelGatewayRouting;
+    if (routing.only || routing.order) {
+      const gatewayOptions: Record<string, string[]> = {};
+      if (routing.only) {
+        gatewayOptions.only = routing.only;
+      }
+      if (routing.order) {
+        gatewayOptions.order = routing.order;
+      }
+      params.providerOptions = { gateway: gatewayOptions };
+    }
+  }
+}

--- a/packages/ai/src/transports/openai-completions-params.ts
+++ b/packages/ai/src/transports/openai-completions-params.ts
@@ -1,4 +1,4 @@
-import type { Context, Model } from "@openclaw/llm-core";
+import type { CacheRetention, Context, Model } from "@openclaw/llm-core";
 import { convertMessages, hasToolCallHistory } from "../openai-completions-messages.js";
 import type { OpenAICompletionsOptions } from "../provider-options.js";
 import { resolveCacheRetention } from "../providers/cache-retention.js";
@@ -26,7 +26,11 @@ import {
   applyCompletionsAnthropicCacheControl,
   resolveCompletionsCacheControl,
 } from "./openai-completions-cache-control.js";
-import { detectOpenAICompletionsCompat } from "./openai-completions-compat.js";
+import {
+  detectOpenAICompletionsCompat,
+  type ResolvedOpenAICompletionsCompat,
+} from "./openai-completions-compat.js";
+import { applyDirectCompletionsReasoningAndRouting } from "./openai-completions-direct-policy.js";
 import { isAzureOpenAICompatibleHost } from "./openai-completions-host.js";
 import {
   applyCompletionsReplay,
@@ -250,21 +254,27 @@ function applyTogetherOpenAICompletionsThinkingParams(params: {
 
 function convertTools(
   tools: NonNullable<Context["tools"]>,
-  compat: ReturnType<typeof getCompat>,
+  compat: ResolvedOpenAICompletionsCompat,
   model: OpenAIModeModel,
+  mode: "direct" | "managed",
 ) {
   const projection = projectOpenAITools(tools);
-  const strict = resolveOpenAIStrictToolFlagWithDiagnostics(
-    projection,
-    resolveOpenAIStrictToolSetting(model, {
-      transport: "stream",
-      supportsStrictMode: compat?.supportsStrictMode,
-    }),
-    {
-      transport: "completions",
-      model,
-    },
-  );
+  const strict =
+    mode === "direct"
+      ? compat.supportsStrictMode
+        ? false
+        : undefined
+      : resolveOpenAIStrictToolFlagWithDiagnostics(
+          projection,
+          resolveOpenAIStrictToolSetting(model, {
+            transport: "stream",
+            supportsStrictMode: compat?.supportsStrictMode,
+          }),
+          {
+            transport: "completions",
+            model,
+          },
+        );
   return {
     projection,
     tools: sortTransportToolsByName(projection.tools).map((tool) => {
@@ -276,17 +286,16 @@ function convertTools(
       } = {
         name: tool.name,
         description: tool.description,
-        parameters: normalizeOpenAIStrictToolParameters(
-          tool.parameters,
-          strict === true,
-          model.compat,
-        ),
+        parameters:
+          mode === "direct"
+            ? tool.parameters
+            : normalizeOpenAIStrictToolParameters(tool.parameters, strict === true, model.compat),
       };
       if (strict !== undefined) {
         functionTool.strict = strict;
       }
       return {
-        type: "function",
+        type: "function" as const,
         function: functionTool,
       };
     }),
@@ -298,31 +307,65 @@ export function buildOpenAICompletionsParams(
   context: Context,
   options: OpenAICompletionsOptions | undefined,
 ) {
-  const compat = getCompat(model);
-  const compatDetection = detectOpenAICompletionsCompat(model);
-  const cacheRetention = resolveCacheRetention(options?.cacheRetention);
-  const { endpointClass } = compatDetection.capabilities;
+  return buildOpenAICompletionsRequest(model, context, options, { mode: "managed" });
+}
+
+type CompletionsRequestPolicy =
+  | { mode: "managed" }
+  | { mode: "direct"; compat: ResolvedOpenAICompletionsCompat; cacheRetention: CacheRetention };
+
+type CompletionsRequest = Record<string, unknown> & {
+  model: string;
+  messages: unknown[];
+  stream: true;
+  tools?: ReturnType<typeof convertTools>["tools"];
+};
+
+export function buildOpenAICompletionsRequest(
+  model: OpenAIModeModel,
+  context: Context,
+  options: OpenAICompletionsOptions | undefined,
+  policy: CompletionsRequestPolicy,
+): CompletionsRequest {
+  const resolvedPolicy =
+    policy.mode === "direct" ? policy : { ...policy, compat: getCompat(model) };
+  const compat = resolvedPolicy.compat;
+  const managedCompat = resolvedPolicy.mode === "managed" ? resolvedPolicy.compat : undefined;
+  const endpointDetection = detectOpenAICompletionsCompat(model);
+  const compatDetection = policy.mode === "managed" ? endpointDetection : undefined;
+  const { endpointClass } = endpointDetection.capabilities;
+  const cacheRetention =
+    policy.mode === "direct"
+      ? policy.cacheRetention
+      : resolveCacheRetention(options?.cacheRetention);
   const cacheControl = resolveCompletionsCacheControl(
     compat,
     cacheRetention,
     endpointClass === "openrouter" ||
       (endpointClass === "default" && model.provider === "openrouter"),
   );
+  const markTools =
+    endpointClass !== "modelstudio-native" &&
+    !(endpointClass === "default" && ["modelstudio", "dashscope", "qwen"].includes(model.provider));
   const cacheOptOutIndexes = new Set<number>();
-  let messages = convertMessages(model as never, context, compat as never, {
+  let messages: unknown[] = convertMessages(model as never, context, compat as never, {
     cacheOptOutIndexes,
-    preserveSystemPromptCacheBoundary: cacheControl !== undefined && !compat.requiresStringContent,
+    preserveSystemPromptCacheBoundary:
+      cacheControl !== undefined && !managedCompat?.requiresStringContent,
   });
-  applyCompletionsReplay(messages as unknown[], context, model, compat);
-  if (compat.strictMessageKeys) {
-    messages = stripCompletionMessagesToRoleContent(messages) as typeof messages;
+  if (managedCompat) {
+    applyCompletionsReplay(messages, context, model, managedCompat);
+    if (managedCompat.strictMessageKeys) {
+      messages = stripCompletionMessagesToRoleContent(messages);
+    }
+    if (managedCompat.requiresStringContent) {
+      messages = flattenCompletionMessagesToStringContent(messages);
+    }
   }
   const promptCacheKey = resolvePromptCacheKey(options, cacheRetention);
-  const params: Record<string, unknown> = {
+  const params: CompletionsRequest = {
     model: model.id,
-    messages: compat.requiresStringContent
-      ? flattenCompletionMessagesToStringContent(messages)
-      : messages,
+    messages,
     stream: true,
     ...resolveOpenAIPromptCacheParams(model, cacheRetention, compat),
   };
@@ -332,52 +375,65 @@ export function buildOpenAICompletionsParams(
   if (compat.supportsStore) {
     params.store = false;
   }
-  if (compat.supportsPromptCacheKey && promptCacheKey) {
-    params.prompt_cache_key = promptCacheKey;
+  if (policy.mode === "direct" || (compat.supportsPromptCacheKey && promptCacheKey)) {
+    params.prompt_cache_key = compat.supportsPromptCacheKey ? promptCacheKey : undefined;
   }
   if (options?.temperature !== undefined) {
     params.temperature = options.temperature;
   }
-  if (options?.topP !== undefined) {
+  if (policy.mode === "managed" && options?.topP !== undefined) {
     params.top_p = options.topP;
   }
-  const responseFormat = resolveOpenAICompletionsResponseFormat(
-    shouldOmitOllamaCompatResponseFormat({
-      provider: model.provider,
-      baseUrl: model.baseUrl,
-      hasTools: () => Boolean(context.tools?.length),
-    })
+  const requestedResponseFormat = options?.responseFormat;
+  const responseFormat =
+    policy.mode === "direct" && requestedResponseFormat === undefined
       ? undefined
-      : options?.responseFormat,
-    compat.supportsJsonSchemaResponseFormat,
-  );
+      : resolveOpenAICompletionsResponseFormat(
+          shouldOmitOllamaCompatResponseFormat({
+            provider: model.provider,
+            baseUrl: model.baseUrl,
+            hasTools: () => Boolean(context.tools?.length),
+          })
+            ? undefined
+            : requestedResponseFormat,
+          compat.supportsJsonSchemaResponseFormat,
+        );
   if (responseFormat !== undefined) {
     params.response_format = responseFormat;
   }
-  if (options?.frequencyPenalty !== undefined) {
+  if (policy.mode === "managed" && options?.frequencyPenalty !== undefined) {
     params.frequency_penalty = options.frequencyPenalty;
   }
-  if (options?.presencePenalty !== undefined) {
+  if (policy.mode === "managed" && options?.presencePenalty !== undefined) {
     params.presence_penalty = options.presencePenalty;
   }
-  if (options?.seed !== undefined) {
+  if (policy.mode === "managed" && options?.seed !== undefined) {
     params.seed = options.seed;
   }
   if (options?.stop !== undefined && options.stop.length > 0) {
     params.stop = options.stop;
   }
-  if (supportsModelTools(model)) {
+  let directToolProjection: ReturnType<typeof projectOpenAITools> | undefined;
+  if (policy.mode === "direct" || supportsModelTools(model)) {
     if (context.tools) {
-      const converted = convertTools(context.tools, compat, model);
+      const converted = convertTools(context.tools, compat, model, policy.mode);
+      if (policy.mode === "direct") {
+        directToolProjection = converted.projection;
+      }
       if (
         converted.tools.length > 0 ||
-        (converted.projection.inputToolCount === 0 && converted.projection.diagnostics.length === 0)
+        (policy.mode === "managed" &&
+          converted.projection.inputToolCount === 0 &&
+          converted.projection.diagnostics.length === 0)
       ) {
         params.tools = converted.tools;
       } else if (hasToolCallHistory(context.messages)) {
         params.tools = [];
       }
-      if (options?.toolChoice) {
+      if (policy.mode === "direct" && compat.zaiToolStream && converted.tools.length > 0) {
+        params.tool_stream = true;
+      }
+      if (policy.mode === "managed" && options?.toolChoice) {
         const toolChoice = reconcileOpenAICompletionsToolChoice(
           options.toolChoice,
           converted.projection,
@@ -386,17 +442,19 @@ export function buildOpenAICompletionsParams(
           params.tool_choice = toolChoice;
         }
       } else if (
-        compatDetection.capabilities.usesExplicitProxyLikeEndpoint &&
+        compatDetection?.capabilities.usesExplicitProxyLikeEndpoint &&
         Array.isArray(params.tools) &&
         params.tools.length > 0
       ) {
         params.tool_choice = "auto";
       }
-    } else if (hasToolCallHistory(context.messages)) {
-      params.tools = [];
+    } else {
+      if (hasToolCallHistory(context.messages)) {
+        params.tools = [];
+      }
     }
     if (
-      compatDetection.capabilities.usesExplicitProxyLikeEndpoint &&
+      compatDetection?.capabilities.usesExplicitProxyLikeEndpoint &&
       Array.isArray(params.tools) &&
       params.tools.length === 0
     ) {
@@ -404,8 +462,28 @@ export function buildOpenAICompletionsParams(
       delete params.tool_choice;
     }
   }
+  if (policy.mode === "direct" && compat.cacheControlFormat === "anthropic") {
+    applyCompletionsAnthropicCacheControl(
+      params,
+      cacheControl ?? null,
+      cacheOptOutIndexes,
+      markTools,
+    );
+  }
+  if (policy.mode === "direct" && options?.toolChoice) {
+    const toolChoice = reconcileOpenAICompletionsToolChoice(
+      options.toolChoice,
+      directToolProjection ?? projectOpenAITools([]),
+    );
+    if (toolChoice !== undefined) {
+      params.tool_choice = toolChoice;
+    }
+  }
   {
-    const maxTokenBudget = resolveOpenAICompletionsMaxTokens(model, options);
+    const maxTokenBudget =
+      policy.mode === "direct"
+        ? { maxTokens: options?.maxTokens, clampToModelMaxTokens: true }
+        : resolveOpenAICompletionsMaxTokens(model, options);
     const effectiveMaxTokens = maxTokenBudget.maxTokens;
     const effectiveContextTokens = resolveOpenAICompletionsEffectiveContextTokens(model);
     let clampedMaxTokens = effectiveMaxTokens;
@@ -417,15 +495,17 @@ export function buildOpenAICompletionsParams(
       clampedMaxTokens > modelMaxTokens
     ) {
       clampedMaxTokens = modelMaxTokens;
-      emitModelTransportDebug(
-        log,
-        `[completions] clamp_max_tokens provider=${model.provider} api=${model.api} ` +
-          `model=${model.id} requested=${effectiveMaxTokens} output=${clampedMaxTokens} ` +
-          `modelMaxTokens=${modelMaxTokens}`,
-      );
+      if (policy.mode === "managed") {
+        emitModelTransportDebug(
+          log,
+          `[completions] clamp_max_tokens provider=${model.provider} api=${model.api} ` +
+            `model=${model.id} requested=${effectiveMaxTokens} output=${clampedMaxTokens} ` +
+            `modelMaxTokens=${modelMaxTokens}`,
+        );
+      }
     }
     if (
-      compatDetection.capabilities.usesExplicitProxyLikeEndpoint &&
+      compatDetection?.capabilities.usesExplicitProxyLikeEndpoint &&
       clampedMaxTokens !== undefined &&
       effectiveContextTokens !== undefined
     ) {
@@ -441,7 +521,7 @@ export function buildOpenAICompletionsParams(
         );
       }
     }
-    if (clampedMaxTokens) {
+    if (policy.mode === "direct" ? options?.maxTokens : clampedMaxTokens) {
       if (compat.maxTokensField === "max_tokens") {
         params.max_tokens = clampedMaxTokens;
       } else {
@@ -449,12 +529,16 @@ export function buildOpenAICompletionsParams(
       }
     }
   }
+  if (policy.mode === "direct") {
+    applyDirectCompletionsReasoningAndRouting(params, model, options, compat);
+    return params;
+  }
   const completionsReasoningEffort = resolveOpenAICompletionsReasoningEffort(options);
   const resolvedCompletionsReasoningEffort = completionsReasoningEffort
     ? resolveOpenAIReasoningEffortForModel({
         model,
         effort: completionsReasoningEffort,
-        fallbackMap: compat.reasoningEffortMap,
+        fallbackMap: managedCompat?.reasoningEffortMap,
       })
     : undefined;
   const omitChatCompletionsToolReasoningEffort =
@@ -505,12 +589,8 @@ export function buildOpenAICompletionsParams(
       params,
       cacheControl ?? null,
       cacheOptOutIndexes,
-      endpointClass !== "modelstudio-native" &&
-        !(
-          endpointClass === "default" &&
-          ["modelstudio", "dashscope", "qwen"].includes(model.provider)
-        ),
-      !compat.requiresStringContent,
+      markTools,
+      !managedCompat?.requiresStringContent,
     );
   }
   return params;

--- a/packages/ai/src/transports/openai-completions-params.ts
+++ b/packages/ai/src/transports/openai-completions-params.ts
@@ -448,10 +448,8 @@ export function buildOpenAICompletionsRequest(
       ) {
         params.tool_choice = "auto";
       }
-    } else {
-      if (hasToolCallHistory(context.messages)) {
-        params.tools = [];
-      }
+    } else if (hasToolCallHistory(context.messages)) {
+      params.tools = [];
     }
     if (
       compatDetection?.capabilities.usesExplicitProxyLikeEndpoint &&


### PR DESCRIPTION
## What Problem This Solves

Chat Completions request assembly had two implementations, so fixes to shared message, response-format, tool and generation fields could drift between direct provider calls and managed transports. This is a maintainer-requested consolidation from the provider/runner de-duplication campaign.

## Why This Change Was Made

Both entrypoints now use one request builder in `packages/ai/src/transports/openai-completions-params.ts`, with explicit direct and managed policies. Direct reasoning/routing remains a policy helper; managed replay, strict tool shaping, proxy tool omission and context-aware output budgeting retain their existing rules. Client creation, payload hooks and stream terminal handling remain with their lifecycle owners.

This incorporates the shared cache-marker owner from #140781 and the native prompt-cache capability/lifetime policy from #140853. Cache opt-outs, stable-prefix and history anchors, Model Studio tool-marker omission, string-only endpoints, and payload identity remain intact. All existing exported signatures remain available. The nearby #138329 was inspected and does not overlap this package-level change.

## User Impact

No intended behavior change. Direct and managed requests retain their reasoning defaults, cache policy, tool behavior and output caps. Production code decreases by 108 lines; no tests are removed. Maintainer-approved assertion baseline maintenance only shrinks the provider count from 9 to 6 (main had already reduced 10 to 9) and params from 9 to 7.

## Evidence

- Refreshed focused provider, transport, cache and wrapper tests: 30 files, 575 tests passed. Command: `node scripts/run-vitest.mjs packages/ai/src/providers/openai-completions{.,-}*.test.ts packages/ai/src/transports/openai-completions-*.test.ts src/llm/providers/stream-wrappers/proxy.test.ts extensions/deepinfra/cache-wrapper.test.ts src/agents/embedded-agent-runner/extra-params.openrouter-cache-control.test.ts`.
- Core typecheck passed after correcting the shared request type to retain required request fields and derive tools from the actual schema projection. No suppression or double assertion was added.
- Final independent Codex autoreview: scoped-clean, zero actionable P0–P2 findings. The final syntax-only lint correction passed all 9 focused compat/tool-choice tests.
- Full `pnpm build` passed on Blacksmith Testbox in 3m24.2s. The earlier local full build also passed.
- Credentialed live proof: Blacksmith Testbox `tbx_01m1x95npamnzvcdhaew94ahra`, [Actions run](https://github.com/openclaw/openclaw/actions/runs/34091412313), wrapper exit 0. Both OpenAI suites made real provider round-trips: direct completion with nonempty output/positive usage (571ms), plus the profile suite's prompt, file-read and image probes for `openai/gpt-5.6-luna` (5.564s). Two files, 38 tests passed; two unrelated OpenRouter/Z.AI tests were deliberately excluded. No OpenAI test skipped or passed vacuously. The lease stopped successfully. A subsequent runner-portal sync warning did not affect command success.
- Full build/live proof used commit `4e351e779a43e183cd037c90b5ea153b6d30137d`; the only subsequent source change flattens an equivalent nested `else`/`if` to satisfy lint. The initial CI lint stripe reported that one error and zero warnings; exact-head CI passed after its correction: [run 34092022603](https://github.com/openclaw/openclaw/actions/runs/34092022603), head `b2d28d06ffa4a39c41efc05a5ebc153fea697755`.
- `node scripts/check-changed.mjs` passed completely after the lint correction, including core/core-test typechecks, all three dead-export scans, core/script lint and every remaining guard. A direct lint-wrapper attempt hit the documented nested-worktree `Declaration input escapes checkout` boundary. No boundary or ancestor installation was modified.

The profile allowlist alone defaults to Responses, so the command uses a temporary secret-free config selecting Chat Completions at both provider and model levels. Credentials come only from the remote hydration helper. The command below is the argument to `node scripts/crabbox-wrapper.mjs run --timing-json -- bash -lc` (quoted to expand `$HOME` remotely):

```bash
set -euo pipefail
pnpm build
L03_LIVE_DIR=$(mktemp -d /tmp/openclaw-L03-live.XXXXXX)
trap 'rm -rf "$L03_LIVE_DIR"' EXIT
cat > "$L03_LIVE_DIR/openclaw.json" <<'JSON'
{"models":{"mode":"merge","providers":{"openai":{"baseUrl":"https://api.openai.com/v1","auth":"api-key","api":"openai-completions","models":[{"id":"gpt-5.6-luna","name":"GPT-5.6 Luna","api":"openai-completions"}]}}}}
JSON
"$HOME/.local/bin/openclaw-testbox-env" env -u OPENROUTER_API_KEY -u ZAI_API_KEY OPENCLAW_CONFIG_PATH="$L03_LIVE_DIR/openclaw.json" OPENCLAW_STATE_DIR="$L03_LIVE_DIR/state" OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_MODELS="openai/gpt-5.6-luna" OPENCLAW_LIVE_PROVIDERS=openai node --import ./scripts/tsx.mjs scripts/test-live.mts --no-quiet -- packages/ai/src/providers/openai-completions.live.test.ts src/agents/models.profiles.live.test.ts
```
