### PR TITLE
fix(ports): reduce duplicate process probes during diagnostics

### DIFF
--- a/src/infra/ports-inspect.env.test.ts
+++ b/src/infra/ports-inspect.env.test.ts
@@ -60,7 +60,7 @@ if (command === 'lsof') {
 } else if (command === 'ss') {
   process.stdout.write(${JSON.stringify(ssOutput)});
 } else {
-  process.stdout.write(process.argv.includes('ppid=') ? '1\n' : process.argv.includes('user=') ? 'fixture-user\n' : 'node fixture-server\n');
+  process.stdout.write(process.argv.includes('user=') ? 'fixture-user\n' : '1 node fixture-server\n');
 }
 `,
         { mode: 0o755 },
@@ -102,9 +102,7 @@ if (command === 'lsof') {
         .map((line) => JSON.parse(line));
       expect(
         reports.map((entry) => entry.command).toSorted((left, right) => left.localeCompare(right)),
-      ).toEqual(
-        (fallback ? ["lsof", "ss", "ps", "ps", "ps"] : ["lsof", "ps", "ps", "ps"]).toSorted(),
-      );
+      ).toEqual((fallback ? ["lsof", "ss", "ps", "ps"] : ["lsof", "ps", "ps"]).toSorted());
       for (const entry of reports) {
         expect(entry, `${entry.command} inherited canary presence`).toEqual({
           command: entry.command,

--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -53,8 +53,7 @@ type UnixListenerSnapshot = {
   lsofUnavailable: boolean;
 };
 
-// Each Unix mapper starts three child processes; cap mapper slots so port
-// diagnostics cannot fan out one process batch per socket record.
+// Each enrichment batch bounds its native process-metadata subprocesses.
 const PORT_PROCESS_ENRICHMENT_CONCURRENCY = 20;
 
 async function runCommandSafe(argv: string[], timeoutMs = 5_000): Promise<CommandResult> {
@@ -218,29 +217,17 @@ function parseSsConnections(output: string, port: number): PortConnection[] {
 }
 
 async function enrichUnixListenerProcessInfo(listeners: PortListener[]): Promise<void> {
-  await pMap(
-    listeners,
-    async (listener) => {
-      if (!listener.pid) {
-        return;
-      }
-      const [commandLine, user, parentPid] = await Promise.all([
-        resolveUnixCommandLine(listener.pid),
-        resolveUnixUser(listener.pid),
-        resolveUnixParentPid(listener.pid),
-      ]);
-      if (commandLine) {
-        listener.commandLine = commandLine;
-      }
-      if (user) {
-        listener.user = user;
-      }
-      if (parentPid !== undefined) {
-        listener.ppid = parentPid;
-      }
-    },
-    { concurrency: PORT_PROCESS_ENRICHMENT_CONCURRENCY },
+  const pids = [...new Set(listeners.flatMap(({ pid }) => (pid ? [pid] : [])))];
+  const metadata = new Map(
+    await pMap(pids, async (pid) => [pid, await resolveUnixProcessInfo(pid)] as const, {
+      concurrency: PORT_PROCESS_ENRICHMENT_CONCURRENCY,
+    }),
   );
+  for (const listener of listeners) {
+    if (listener.pid) {
+      Object.assign(listener, metadata.get(listener.pid));
+    }
+  }
 }
 
 async function readUnixEstablishedConnectionsFromSs(
@@ -257,7 +244,6 @@ async function readUnixEstablishedConnectionsFromSs(
   ]);
   if (res.code === 0) {
     const connections = parseSsConnections(res.stdout, port);
-    await enrichUnixListenerProcessInfo(connections);
     return { connections, detail: res.stdout.trim() || undefined, errors };
   }
   const stderr = res.stderr.trim();
@@ -281,7 +267,6 @@ async function readUnixEstablishedConnections(
   const res = await runCommandSafe([lsof, "-nP", `-iTCP:${port}`, "-sTCP:ESTABLISHED", "-FpFcn"]);
   if (res.code === 0) {
     const connections = parseLsofConnectionFieldOutput(res.stdout, port);
-    await enrichUnixListenerProcessInfo(connections);
     return { connections, detail: res.stdout.trim() || undefined, errors: [] };
   }
   const stderr = res.stderr.trim();
@@ -308,32 +293,31 @@ async function readUnixEstablishedConnections(
   };
 }
 
-async function resolveUnixCommandLine(pid: number): Promise<string | undefined> {
-  const res = await runCommandSafe(["ps", "-p", String(pid), "-o", "command="]);
-  if (res.code !== 0) {
-    return undefined;
-  }
-  const line = res.stdout.trim();
-  return line || undefined;
-}
-
-async function resolveUnixUser(pid: number): Promise<string | undefined> {
-  const res = await runCommandSafe(["ps", "-p", String(pid), "-o", "user="]);
-  if (res.code !== 0) {
-    return undefined;
-  }
-  const line = res.stdout.trim();
-  return line || undefined;
-}
-
-async function resolveUnixParentPid(pid: number): Promise<number | undefined> {
-  const res = await runCommandSafe(["ps", "-p", String(pid), "-o", "ppid="]);
-  if (res.code !== 0) {
-    return undefined;
-  }
-  const line = res.stdout.trim();
-  const parentPid = Number.parseInt(line, 10);
-  return Number.isFinite(parentPid) && parentPid > 0 ? parentPid : undefined;
+async function resolveUnixProcessInfo(
+  pid: number,
+): Promise<Pick<PortListener, "commandLine" | "user" | "ppid">> {
+  // Keep usernames separate: native ps pads them by bytes on macOS and display
+  // columns on Linux, and directory-service names can themselves contain spaces.
+  const res = await runCommandSafe([
+    "ps",
+    "-p",
+    String(pid),
+    "-ww",
+    "-o",
+    "ppid=",
+    "-o",
+    "command=",
+  ]);
+  const userResult = await runCommandSafe(["ps", "-p", String(pid), "-o", "user="]);
+  const fields = res.code === 0 ? /^\s*(\S+)(?:\s+([\s\S]*))?$/.exec(res.stdout) : null;
+  const parentPid = Number.parseInt(fields?.[1] ?? "", 10);
+  const commandLine = fields?.[2]?.trim();
+  const user = userResult.code === 0 ? userResult.stdout.trim() : "";
+  return {
+    ...(user ? { user } : {}),
+    ...(commandLine ? { commandLine } : {}),
+    ...(Number.isFinite(parentPid) && parentPid > 0 ? { ppid: parentPid } : {}),
+  };
 }
 
 function parseSsListeners(output: string, port: number): PortListener[] {
@@ -372,7 +356,6 @@ async function readUnixListenersFromSs(port: number): Promise<ListenerReadResult
   const res = await runCommandSafe(["ss", "-H", "-ltnp", `sport = :${port}`]);
   if (res.code === 0) {
     const listeners = parseSsListeners(res.stdout, port);
-    await enrichUnixListenerProcessInfo(listeners);
     return { listeners, detail: res.stdout.trim() || undefined, errors };
   }
   const stderr = res.stderr.trim();
@@ -423,7 +406,6 @@ async function readUnixListeners(
   const listenerSnapshot = snapshot ?? (await readUnixListenerSnapshot(port));
   if (!listenerSnapshot.lsofUnavailable) {
     const result = readLsofListenersForPort(listenerSnapshot.recordsByPort, port);
-    await enrichUnixListenerProcessInfo(result.listeners);
     return { ...result, errors: listenerSnapshot.errors };
   }
   const ssFallback = await readUnixListenersFromSs(port);
@@ -592,6 +574,9 @@ export async function inspectPortUsage(
 ): Promise<PortUsage> {
   const result =
     process.platform === "win32" ? await readWindowsListeners(port) : await readUnixListeners(port);
+  if (process.platform !== "win32") {
+    await enrichUnixListenerProcessInfo(result.listeners);
+  }
   return buildPortUsage(port, result, options?.probeHosts);
 }
 
@@ -682,16 +667,14 @@ export async function inspectPortUsages(
   }
 
   const snapshot = await readUnixListenerSnapshot();
+  const results = await Promise.all(uniquePorts.map((port) => readUnixListeners(port, snapshot)));
+  await enrichUnixListenerProcessInfo(results.flatMap(({ listeners }) => listeners));
   const entries = await Promise.all(
     uniquePorts.map(
-      async (port) =>
+      async (port, index) =>
         [
           port,
-          await buildPortUsage(
-            port,
-            await readUnixListeners(port, snapshot),
-            options?.probeHostsByPort?.get(port),
-          ),
+          await buildPortUsage(port, results[index]!, options?.probeHostsByPort?.get(port)),
         ] as const,
     ),
   );
@@ -703,6 +686,9 @@ export async function inspectPortConnections(port: number): Promise<PortConnecti
     process.platform === "win32"
       ? await readWindowsEstablishedConnections(port)
       : await readUnixEstablishedConnections(port);
+  if (process.platform !== "win32") {
+    await enrichUnixListenerProcessInfo(result.connections);
+  }
   return {
     port,
     connections: result.connections,

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -50,6 +50,7 @@ function mockUnixCommands(params: {
   commandLine?: string | ((pid: string | undefined) => string);
   user?: string;
   parentPid?: string;
+  processInfo?: CommandReply;
 }): void {
   runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
     const command = argv[0];
@@ -63,19 +64,20 @@ function mockUnixCommands(params: {
       return resolveCommandReply(params.ss);
     }
     if (command === "ps") {
-      if (argv.includes("command=") && params.commandLine !== undefined) {
-        const value =
-          typeof params.commandLine === "function"
-            ? params.commandLine(argv[2])
-            : params.commandLine;
-        return commandOutput(`${value}\n`);
+      if (argv.includes("user=")) {
+        return params.user === undefined ? failedCommand() : commandOutput(`${params.user}\n`);
       }
-      if (argv.includes("user=") && params.user !== undefined) {
-        return commandOutput(`${params.user}\n`);
+      if (params.processInfo !== undefined) {
+        return resolveCommandReply(params.processInfo);
       }
-      if (argv.includes("ppid=") && params.parentPid !== undefined) {
-        return commandOutput(`${params.parentPid}\n`);
+      if (params.commandLine === undefined && params.parentPid === undefined) {
+        return failedCommand();
       }
+      const commandLine =
+        typeof params.commandLine === "function"
+          ? params.commandLine(argv[2])
+          : (params.commandLine ?? "");
+      return commandOutput(`${params.parentPid ?? "0"} ${commandLine}\n`);
     }
     return failedCommand();
   });
@@ -465,45 +467,130 @@ describeUnix("inspectPortUsage", () => {
     }
   });
 
-  it("limits concurrent Unix process metadata lookups", async () => {
-    const listenerCount = 25;
-    let activeProcessLookups = 0;
-    let maxConcurrentProcessLookups = 0;
-    let processLookupCount = 0;
-    runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
-      const command = argv[0];
-      if (typeof command !== "string") {
+  it.each(["lsof", "ss"])(
+    "shares bounded Unix process metadata lookups across ports (%s)",
+    async (source) => {
+      const listenerCount = 25;
+      let activeProcessLookups = 0;
+      let maxConcurrentProcessLookups = 0;
+      let processLookupCount = 0;
+      runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
+        const command = argv[0];
+        if (typeof command !== "string") {
+          return { stdout: "", stderr: "", code: 1 };
+        }
+        if (command.includes("lsof")) {
+          if (source === "ss") {
+            return commandOutput("", 2);
+          }
+          return {
+            stdout: Array.from(
+              { length: listenerCount },
+              (_, index) =>
+                `p${1_000 + index}\ncnode\nnTCP 127.0.0.1:18789 (LISTEN)\nnTCP 127.0.0.1:19001 (LISTEN)`,
+            ).join("\n"),
+            stderr: "",
+            code: 0,
+          };
+        }
+        if (command === "ss") {
+          const port = argv.at(-1)?.split(":").at(-1);
+          return commandOutput(
+            Array.from(
+              { length: listenerCount },
+              (_, index) =>
+                `LISTEN 0 128 127.0.0.1:${port} 0.0.0.0:* users:(("node",pid=${1_000 + index},fd=1))`,
+            ).join("\n"),
+          );
+        }
+        if (command === "ps") {
+          processLookupCount += 1;
+          activeProcessLookups += 1;
+          maxConcurrentProcessLookups = Math.max(maxConcurrentProcessLookups, activeProcessLookups);
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 1);
+          });
+          activeProcessLookups -= 1;
+          return commandOutput(
+            argv.includes("user=") ? "fixture-user\n" : `1 node fixture-${argv[2]}\n`,
+          );
+        }
         return { stdout: "", stderr: "", code: 1 };
+      });
+
+      const results = await inspectPortUsages([18789, 19001]);
+
+      expect(processLookupCount).toBeLessThanOrEqual(listenerCount * 2);
+      expect(maxConcurrentProcessLookups).toBeLessThanOrEqual(20);
+      for (const result of results.values()) {
+        expect(result.listeners).toHaveLength(listenerCount);
+        expect(
+          result.listeners.map(({ pid, commandLine, user, ppid }) => ({
+            pid,
+            commandLine,
+            user,
+            ppid,
+          })),
+        ).toEqual(
+          Array.from({ length: listenerCount }, (_, index) => ({
+            pid: 1_000 + index,
+            commandLine: `node fixture-${1_000 + index}`,
+            user: "fixture-user",
+            ppid: 1,
+          })),
+        );
       }
-      if (command.includes("lsof")) {
-        return {
-          stdout: Array.from(
-            { length: listenerCount },
-            (_, index) => `p${1_000 + index}\ncnode\nnTCP 127.0.0.1:18789 (LISTEN)`,
-          ).join("\n"),
-          stderr: "",
-          code: 0,
-        };
-      }
-      if (command === "ps") {
-        processLookupCount += 1;
-        activeProcessLookups += 1;
-        maxConcurrentProcessLookups = Math.max(maxConcurrentProcessLookups, activeProcessLookups);
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 1);
-        });
-        activeProcessLookups -= 1;
-        return { stdout: "value\n", stderr: "", code: 0 };
-      }
-      return { stdout: "", stderr: "", code: 1 };
+    },
+  );
+
+  it.each([
+    {
+      name: "PPID zero",
+      output: commandOutput("  0 node argument with  spaces\n"),
+      user: "fixture-user",
+      metadata: { user: "fixture-user", commandLine: "node argument with  spaces" },
+    },
+    {
+      name: "missing command",
+      output: commandOutput("  1\n"),
+      user: "fixture-user",
+      metadata: { user: "fixture-user", ppid: 1 },
+    },
+    {
+      name: "spaced directory-service username",
+      output: commandOutput("  1 node argument with  spaces\n"),
+      user: "  DOMAIN user  ",
+      metadata: { user: "DOMAIN user", commandLine: "node argument with  spaces", ppid: 1 },
+    },
+    {
+      name: "UTF-8 username",
+      output: commandOutput("  1 node argument with  spaces\n"),
+      user: "用戶 é name",
+      metadata: { user: "用戶 é name", commandLine: "node argument with  spaces", ppid: 1 },
+    },
+    { name: "missing process", output: commandOutput("", 1), metadata: {} },
+    {
+      name: "command query failure",
+      output: commandOutput("", 1),
+      user: "fixture-user",
+      metadata: { user: "fixture-user" },
+    },
+    {
+      name: "user query failure",
+      output: commandOutput("  1 node fixture\n"),
+      metadata: { ppid: 1, commandLine: "node fixture" },
+    },
+    { name: "malformed row", output: commandOutput("\n"), metadata: {} },
+  ])("preserves socket evidence with $name metadata", async ({ output, user, metadata }) => {
+    mockUnixCommands({
+      lsof: commandOutput("p111\ncnode\nnTCP *:18789 (LISTEN)\n"),
+      processInfo: output,
+      user,
     });
-
     const result = await inspectPortUsage(18789);
-
-    expect(result.listeners).toHaveLength(listenerCount);
-    expect(processLookupCount).toBe(listenerCount * 3);
-    expect(maxConcurrentProcessLookups).toBeLessThan(processLookupCount);
-    expect(maxConcurrentProcessLookups).toBeLessThanOrEqual(60);
+    expect(result.listeners).toEqual([
+      { pid: 111, command: "node", address: "TCP *:18789 (LISTEN)", ...metadata },
+    ]);
   });
 
   it("does not match ss listener ports by substring", async () => {
@@ -732,13 +819,38 @@ describeUnix("inspectPortUsage", () => {
         pid: 111,
         direction: "client",
         address: "TCP 127.0.0.1:50123->127.0.0.1:18789 (ESTABLISHED)",
+        commandLine: "node /tmp/newer-openclaw/dist/index.js logs --follow",
+        user: "tester",
+        ppid: 1,
       }),
       expect.objectContaining({
         pid: 111,
         direction: "client",
         address: "TCP 127.0.0.1:50124->127.0.0.1:18789 (ESTABLISHED)",
+        commandLine: "node /tmp/newer-openclaw/dist/index.js logs --follow",
+        user: "tester",
+        ppid: 1,
       }),
     ]);
+    expect(
+      runCommandWithTimeoutMock.mock.calls.filter(([argv]) => argv[0] === "ps").length,
+    ).toBeLessThanOrEqual(2);
+
+    mockUnixCommands({
+      lsof: commandOutput("p111\ncnode\nnTCP 127.0.0.1:50123->127.0.0.1:18789 (ESTABLISHED)\n"),
+      commandLine: "node replacement-process",
+      user: "replacement-user",
+      parentPid: "7",
+    });
+    const refreshed = await inspectPortConnections(18789);
+    expect(refreshed.connections[0]).toMatchObject({
+      commandLine: "node replacement-process",
+      user: "replacement-user",
+      ppid: 7,
+    });
+    expect(
+      runCommandWithTimeoutMock.mock.calls.filter(([argv]) => argv[0] === "ps").length,
+    ).toBeLessThanOrEqual(4);
   });
 
   it("falls back to ss for established gateway client connections", async () => {


### PR DESCRIPTION
Closes #140606

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Resolves repeated process launches during Unix port diagnostics when several socket rows or requested ports belong to the same PID. The old inspector runs three metadata queries for every row.

## Why This Change Was Made

Collect unique PIDs at the public inspection boundary and share primitive metadata across the original rows for that invocation. Each PID uses two sequential queries: PPID plus the complete command, and the existing user-only query so usernames containing spaces or Unicode remain intact. One bounded batch limits active metadata subprocesses to 20.

The invocation-local map expires with the call. Listener/connection ordering, per-port details, partial metadata, bind-host filtering, lsof/ss fallback, diagnostic environment projection and subsequent-call freshness remain intact.

## User Impact

A 40-row inspection with one PID launches two `ps` children instead of 120, including the same PID across two ports or `ss` fallback. With 40 distinct PIDs it launches 80 instead of 120. All socket rows and complete metadata outputs match. Production shrinks by 14 lines; test coverage grows by 110 lines.

## Evidence

- 188 focused owner/status/restart tests passed; one existing Windows-only native test was skipped on the local platform. Resource-budget regressions fail against the exact original owner because 150 launches exceed the 50-launch ceiling for both lsof and ss cases.
- All six component scenarios have complete before/after output equality with native Execa and task-owned lsof/ss/ps fixture executables. They include repeated/distinct PIDs, multiple ports, fallback, spaced usernames and wide/combining Unicode usernames. Socket-query counts are unchanged.
- The final two-query format was independently exercised on native macOS and Linux with owned synthetic processes. A 6.7 KB command and interior spaces survive, and both queries return nonzero/empty output after the process is reaped. The three task-owned Testbox leases are stopped.
- Complete check:changed and native isolated P2 autoreview passed on the final source hashes. No actionable review findings remain.

The measurements establish subprocess-count reductions, not general Gateway latency, RSS or throughput gains. Native PPID-zero and unusual account records were not manufactured; partial/zero/missing metadata and complete spaced/Unicode usernames are covered at the actual inspection owner with synthetic inputs. Related #90548 has a broader polling scope; this change does not alter it.
