### PR TITLE
fix(xai): preserve OAuth catalog and automatic selection

### DIFF
--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -95,6 +95,11 @@ subscription quota are separate billing buckets.
 - For SSH, Docker, VPS, or other remote setups, use
   `openclaw models auth login --provider xai --method oauth`; it uses
   device-code verification, not a localhost callback.
+- If a previous OAuth login left xAI using the API-key endpoint or catalog,
+  rerun `openclaw models auth login --provider xai --method oauth`. A successful
+  login refreshes the subscription catalog and proxy route from your account.
+  It preserves your primary model and fallbacks; the moving alias remains
+  discovery-owned so it can follow later default changes.
 - If sign-in succeeds but Grok is not the default model, run
   `openclaw models set xai/auto`. OAuth login preserves an existing
   primary model unless you explicitly change it.

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -331,7 +331,7 @@ describe("xai provider plugin", () => {
       modelId: "auto",
       model: { ...auto, provider: "xai" },
     } as never);
-    expect(normalizedAuto?.id).toBe("grok-build");
+    expect(normalizedAuto?.id).toBe("auto");
     const composer = result.models.find((model) => model.id === "grok-composer-2.5-fast");
     if (!composer) {
       throw new Error("expected OAuth Composer model");
@@ -937,7 +937,7 @@ describe("xai provider plugin", () => {
       model: { ...auto, provider: "xai" },
     } as never);
 
-    expect(normalized?.id).toBe("grok-4.6");
+    expect(normalized?.id).toBe("auto");
     expect(normalized?.thinkingLevelMap?.xhigh).toBe("xhigh");
     expect(normalized?.compat).toMatchObject({
       supportedReasoningEfforts: ["low", "medium", "high", "xhigh"],

--- a/extensions/xai/onboard.test.ts
+++ b/extensions/xai/onboard.test.ts
@@ -2,6 +2,7 @@
 import {
   resolveAgentModelFallbackValues,
   resolveAgentModelPrimaryValue,
+  type ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-onboard";
 import {
   createConfigWithFallbacks,
@@ -112,7 +113,14 @@ describe("xai onboard", () => {
   });
 
   it("persists the provider-owned auto ref for OAuth setup", () => {
-    const cfg = applyXaiOAuthConfig({});
+    const provider: ModelProviderConfig = {
+      api: "openai-responses",
+      auth: "oauth",
+      baseUrl: "https://cli-chat-proxy.grok.com/v1",
+      models: [],
+    };
+    const cfg = applyXaiOAuthConfig({}, provider);
+    expect(cfg.models?.providers?.xai).toMatchObject(provider);
 
     expect(XAI_OAUTH_DEFAULT_MODEL_REF).toBe("xai/auto");
     expect(resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model)).toBe("xai/auto");

--- a/extensions/xai/onboard.ts
+++ b/extensions/xai/onboard.ts
@@ -1,6 +1,11 @@
 // Xai setup module handles plugin onboarding behavior.
 import {
+  applyAgentDefaultModelPrimary,
+  applyOnboardAuthAgentModelsAndProviders,
   createModelCatalogPresetAppliers,
+  resolveAgentModelPrimaryValue,
+  withAgentModelAliases,
+  type ModelProviderConfig,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-onboard";
 import {
@@ -16,21 +21,16 @@ export const XAI_DEFAULT_MODEL_REF = `xai/${XAI_DEFAULT_MODEL_ID}`;
 // remote default setting. API-key setup stays on the pinned default above.
 export const XAI_OAUTH_DEFAULT_MODEL_REF = `xai/${XAI_OAUTH_AUTO_MODEL_ID}`;
 
-function createXaiPresetAppliers(primaryModelRef: string) {
-  return createModelCatalogPresetAppliers<["openai-completions" | "openai-responses"]>({
-    primaryModelRef,
-    resolveParams: (_cfg: OpenClawConfig, api) => ({
-      providerId: "xai",
-      api,
-      baseUrl: XAI_BASE_URL,
-      catalogModels: buildXaiCatalogModels(),
-      aliases: [{ modelRef: primaryModelRef, alias: "Grok" }],
-    }),
-  });
-}
-
-const xaiPresetAppliers = createXaiPresetAppliers(XAI_DEFAULT_MODEL_REF);
-const xaiOAuthPresetAppliers = createXaiPresetAppliers(XAI_OAUTH_DEFAULT_MODEL_REF);
+const xaiPresetAppliers = createModelCatalogPresetAppliers({
+  primaryModelRef: XAI_DEFAULT_MODEL_REF,
+  resolveParams: () => ({
+    providerId: "xai",
+    api: "openai-responses",
+    baseUrl: XAI_BASE_URL,
+    catalogModels: buildXaiCatalogModels(),
+    aliases: [{ modelRef: XAI_DEFAULT_MODEL_REF, alias: "Grok" }],
+  }),
+});
 
 function pruneRetiredXaiBuiltinModels(cfg: OpenClawConfig): OpenClawConfig {
   const provider = cfg.models?.providers?.xai;
@@ -57,16 +57,34 @@ function pruneRetiredXaiBuiltinModels(cfg: OpenClawConfig): OpenClawConfig {
 }
 
 export function applyXaiProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
-  return xaiPresetAppliers.applyProviderConfig(
-    pruneRetiredXaiBuiltinModels(cfg),
-    "openai-responses",
-  );
+  return xaiPresetAppliers.applyProviderConfig(pruneRetiredXaiBuiltinModels(cfg));
 }
 
 export function applyXaiConfig(cfg: OpenClawConfig): OpenClawConfig {
-  return xaiPresetAppliers.applyConfig(pruneRetiredXaiBuiltinModels(cfg), "openai-responses");
+  return xaiPresetAppliers.applyConfig(pruneRetiredXaiBuiltinModels(cfg));
 }
 
-export function applyXaiOAuthConfig(cfg: OpenClawConfig): OpenClawConfig {
-  return xaiOAuthPresetAppliers.applyConfig(pruneRetiredXaiBuiltinModels(cfg), "openai-responses");
+export function applyXaiOAuthConfig(
+  cfg: OpenClawConfig,
+  provider: ModelProviderConfig,
+): OpenClawConfig {
+  const next = applyOnboardAuthAgentModelsAndProviders(cfg, {
+    agentModels: withAgentModelAliases(cfg.agents?.defaults?.models, [
+      { modelRef: XAI_OAUTH_DEFAULT_MODEL_REF, alias: "Grok" },
+    ]),
+    providers: {
+      xai: {
+        ...provider,
+        apiKey: undefined,
+        authHeader: undefined,
+        headers: undefined,
+        request: { auth: undefined, headers: undefined },
+        // The moving alias must come from discovery, never a persisted target.
+        models: provider.models.filter((model) => model.id !== XAI_OAUTH_AUTO_MODEL_ID),
+      },
+    },
+  });
+  return resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model)
+    ? next
+    : applyAgentDefaultModelPrimary(next, XAI_OAUTH_DEFAULT_MODEL_REF);
 }

--- a/extensions/xai/provider-catalog.ts
+++ b/extensions/xai/provider-catalog.ts
@@ -48,15 +48,6 @@ export function buildXaiProvider(
   };
 }
 
-function buildXaiOAuthFallbackProvider(): ModelProviderConfig {
-  return {
-    baseUrl: XAI_GROK_OAUTH_BASE_URL,
-    api: "openai-responses",
-    auth: "oauth",
-    models: buildXaiCatalogModels(),
-  };
-}
-
 function normalizeXaiOAuthModelSelector(value: string): string {
   return value.trim().toLowerCase().replace(/[._]+/g, "-");
 }
@@ -108,10 +99,6 @@ function withXaiOAuthAutoModel(
   };
 }
 
-function readXaiOAuthDefaultModelId(value: unknown): string | undefined {
-  return readLiveModelCatalogStringField(value, "default_model");
-}
-
 async function fetchXaiOAuthDefaultModelId(params: {
   discoveryApiKey: string;
   fetchGuard?: LiveModelCatalogFetchGuard;
@@ -139,9 +126,9 @@ async function fetchXaiOAuthDefaultModelId(params: {
         return [body];
       },
       shouldCacheRows: (candidateRows) =>
-        readXaiOAuthDefaultModelId(candidateRows[0]) !== undefined,
+        readLiveModelCatalogStringField(candidateRows[0], "default_model") !== undefined,
     });
-    return readXaiOAuthDefaultModelId(rows[0]);
+    return readLiveModelCatalogStringField(rows[0], "default_model");
   } catch {
     // Remote settings are advisory. Catalog order remains the provider-owned fallback.
     return undefined;
@@ -249,18 +236,17 @@ export async function buildLiveXaiOAuthProvider(params: {
   fetchGuard?: LiveModelCatalogFetchGuard;
   signal?: AbortSignal;
 }): Promise<ModelProviderConfig> {
-  const fallback = buildXaiOAuthFallbackProvider();
   const [provider, preferredModelId] = await Promise.all([
     buildLiveModelProviderConfig({
       discoveryMode: "strict",
       providerId: PROVIDER_ID,
       endpoint: XAI_GROK_OAUTH_MODELS_ENDPOINT,
       providerConfig: {
-        baseUrl: fallback.baseUrl,
-        api: fallback.api,
-        auth: fallback.auth,
+        baseUrl: XAI_GROK_OAUTH_BASE_URL,
+        api: "openai-responses",
+        auth: "oauth",
       },
-      models: fallback.models,
+      models: [],
       discoveryApiKey: params.discoveryApiKey,
       fetchGuard: params.fetchGuard,
       signal: params.signal,

--- a/extensions/xai/provider-models.ts
+++ b/extensions/xai/provider-models.ts
@@ -57,5 +57,5 @@ export function resolveXaiForwardCompatModel(params: {
 export function normalizeXaiResolvedModel(model: ProviderRuntimeModel): ProviderRuntimeModel {
   const resolvedModelId = resolveXaiOAuthAutoModelId(model.id, model.params);
   const resolved = resolvedModelId === model.id ? model : { ...model, id: resolvedModelId };
-  return applyXaiRuntimeModelCompat(resolved);
+  return { ...applyXaiRuntimeModelCompat(resolved), id: model.id };
 }

--- a/extensions/xai/runtime-model-compat.ts
+++ b/extensions/xai/runtime-model-compat.ts
@@ -38,37 +38,13 @@ function isGrok43Model(id: string): boolean {
   return id === "grok-latest" || id === "grok-4.3" || id.startsWith("grok-4.3-");
 }
 
-function normalizeXaiCompatModelId(id: unknown): string {
-  return typeof id === "string" ? id.trim().toLowerCase() : "";
-}
-
-function supportsConfigurableXaiReasoningEffort(model: XaiRuntimeModelCompat): boolean {
-  const id = normalizeXaiCompatModelId(model.id);
-  const isConfigurableModel = isGrok43Model(id) || isXaiFrontierModelId(id);
-  return model.reasoning === true && isConfigurableModel;
-}
-
-function resolveXaiReasoningEffortCompat(model: XaiRuntimeModelCompat): Record<string, unknown> {
-  if (supportsConfigurableXaiReasoningEffort(model)) {
-    const id = normalizeXaiCompatModelId(model.id);
-    return {
-      supportsReasoningEffort: true,
-      supportedReasoningEfforts: [
-        ...(isGrok43Model(id) ? ["none"] : []),
-        ...XAI_SUPPORTED_REASONING_EFFORTS,
-        ...(isXaiGrok46ModelId(id) ? ["xhigh"] : []),
-      ],
-    };
-  }
-  return { supportsReasoningEffort: false };
-}
-
 export function applyXaiRuntimeModelCompat<T extends XaiRuntimeModelCompat>(
   model: T,
 ): T & { compat: Record<string, unknown>; thinkingLevelMap: XaiThinkingLevelMap } {
   const withCompat = applyXaiModelCompat(model);
-  const supportsReasoningEffort = supportsConfigurableXaiReasoningEffort(withCompat);
-  const id = normalizeXaiCompatModelId(withCompat.id);
+  const id = typeof withCompat.id === "string" ? withCompat.id.trim().toLowerCase() : "";
+  const supportsReasoningEffort =
+    withCompat.reasoning === true && (isGrok43Model(id) || isXaiFrontierModelId(id));
   const existingCompat =
     withCompat.compat && typeof withCompat.compat === "object"
       ? (withCompat.compat as Record<string, unknown>)
@@ -77,7 +53,16 @@ export function applyXaiRuntimeModelCompat<T extends XaiRuntimeModelCompat>(
     ...withCompat,
     compat: {
       ...existingCompat,
-      ...resolveXaiReasoningEffortCompat(withCompat),
+      supportsReasoningEffort,
+      ...(supportsReasoningEffort
+        ? {
+            supportedReasoningEfforts: [
+              ...(isGrok43Model(id) ? ["none"] : []),
+              ...XAI_SUPPORTED_REASONING_EFFORTS,
+              ...(isXaiGrok46ModelId(id) ? ["xhigh"] : []),
+            ],
+          }
+        : {}),
     },
     thinkingLevelMap: {
       ...withCompat.thinkingLevelMap,

--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -169,9 +169,11 @@ async function captureXaiResponsesPayloadWithThinking(
 }
 
 describe("xai stream wrappers", () => {
-  it("adds the Grok OAuth proxy request contract", () => {
+  it.each(["grok-4.5", "auto"])("adds the Grok OAuth proxy request contract for %s", (id) => {
     let capturedHeaders: Record<string, string> | undefined;
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
+    let capturedModelId: string | undefined;
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      capturedModelId = model.id;
       capturedHeaders = options?.headers;
       return {} as ReturnType<StreamFn>;
     };
@@ -187,13 +189,21 @@ describe("xai stream wrappers", () => {
       {
         api: "openai-responses",
         provider: "xai",
-        id: "grok-4.5",
+        id,
+        name: "Subscription default",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 500_000,
+        maxTokens: 64_000,
+        params: { canonicalModelId: "grok-4.5" },
         baseUrl: "https://cli-chat-proxy.grok.com/v1",
-      } as Model<"openai-responses">,
-      { messages: [] } as Context,
+      },
+      { messages: [] },
       { headers: { "X-XAI-Token-Auth": "operator-value", "X-Existing": "kept" } },
     );
 
+    expect(capturedModelId).toBe("grok-4.5");
     expect(capturedHeaders).toEqual({
       "x-existing": "kept",
       "x-grok-client-version": "2026.7.2",

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import { asOptionalRecord, filterStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { XAI_BASE_URL } from "./model-definitions.js";
+import { resolveXaiOAuthAutoModelId } from "./model-id.js";
 import { XAI_GROK_OAUTH_BASE_URL } from "./provider-catalog.js";
 import { isXaiProviderId } from "./provider-id.js";
 
@@ -35,13 +36,15 @@ function createXaiGrokOAuthHeadersWrapper(
     if (!normalizedClientVersion || !isXaiEndpoint(model, XAI_GROK_OAUTH_BASE_URL)) {
       return underlying(model, context, options);
     }
+    // Keep the selected alias stable through auth materialization; resolve only on the wire.
+    const modelId = resolveXaiOAuthAutoModelId(model.id, model.params);
     const headers = new Headers(options?.headers);
     // The Grok OAuth proxy requires its CLI identity and a concrete catalog model.
     // Keep these proxy-only so ordinary xAI API-key traffic retains its public contract.
     headers.set("X-XAI-Token-Auth", "xai-grok-cli");
     headers.set("x-grok-client-version", normalizedClientVersion);
-    headers.set("x-grok-model-override", model.id);
-    return underlying(model, context, {
+    headers.set("x-grok-model-override", modelId);
+    return underlying({ ...model, id: modelId }, context, {
       ...options,
       headers: Object.fromEntries(headers.entries()),
     });

--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -124,90 +124,121 @@ describe("xAI OAuth", () => {
     });
   });
 
-  it("revalidates live authority before following an OAuth redirect", async () => {
-    const transport = new MockAgent();
-    transport.disableNetConnect();
-    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
-      const response = await undiciFetch(requestUrl(input), {
-        method: init?.method,
-        headers: Object.fromEntries(new Headers(init?.headers)),
-        redirect: init?.redirect,
-        signal: init?.signal,
-        dispatcher: transport,
+  it.each(["OAuth", "catalog"] as const)(
+    "revalidates live authority before following a %s redirect",
+    async (boundary) => {
+      const transport = new MockAgent();
+      transport.disableNetConnect();
+      const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+        const response = await undiciFetch(requestUrl(input), {
+          method: init?.method,
+          headers: Object.fromEntries(new Headers(init?.headers)),
+          redirect: init?.redirect,
+          signal: init?.signal,
+          dispatcher: transport,
+        });
+        return new Response(await response.arrayBuffer(), {
+          status: response.status,
+          headers: Object.fromEntries(response.headers),
+        });
       });
-      return new Response(await response.arrayBuffer(), {
-        status: response.status,
-        headers: Object.fromEntries(response.headers),
+      vi.stubGlobal("fetch", fetchImpl);
+      const held = createDeferred<void>();
+      const release = createDeferred<void>();
+      const controller = new AbortController();
+      let current = true;
+      const redirectStart =
+        boundary === "OAuth"
+          ? XAI_OAUTH_DISCOVERY_URL
+          : "https://cli-chat-proxy.grok.com/v1/models";
+      if (boundary === "catalog") {
+        const auth = transport.get("https://auth.x.ai");
+        auth.intercept({ path: "/.well-known/openid-configuration" }).reply(200, {
+          device_authorization_endpoint: "https://auth.x.ai/oauth2/device/code",
+          token_endpoint: "https://auth.x.ai/oauth2/token",
+        });
+        auth.intercept({ path: "/oauth2/device/code", method: "POST" }).reply(200, {
+          device_code: "device",
+          user_code: "CODE",
+          verification_uri: "https://auth.x.ai/device",
+          expires_in: 60,
+          interval: 1,
+        });
+        auth.intercept({ path: "/oauth2/token", method: "POST" }).reply(200, {
+          access_token: "access",
+          refresh_token: "refresh",
+          expires_in: 60,
+        });
+        transport
+          .get("https://cli-chat-proxy.grok.com")
+          .intercept({ path: "/v1/settings" })
+          .reply(200, { default_model: "subscription-fixture" });
+      }
+      const origin = transport.get(new URL(redirectStart).origin);
+      origin.intercept({ path: new URL(redirectStart).pathname }).reply(async () => {
+        held.resolve();
+        await release.promise;
+        return { statusCode: 302, responseOptions: { headers: { location: "/retired" } } };
       });
-    });
-    vi.stubGlobal("fetch", fetchImpl);
-    const held = createDeferred<void>();
-    const release = createDeferred<void>();
-    const controller = new AbortController();
-    let current = true;
-    const origin = transport.get("https://auth.x.ai");
-    origin.intercept({ path: "/.well-known/openid-configuration" }).reply(async () => {
-      held.resolve();
-      await release.promise;
-      return { statusCode: 302, responseOptions: { headers: { location: "/retired" } } };
-    });
-    const redirected = vi.fn(() => ({ statusCode: 403, data: "denied" }));
-    origin.intercept({ path: "/retired" }).reply(redirected);
-    const outcome = createXaiOAuthAuthMethod()
-      .run({
-        config: {},
-        isRemote: true,
-        openUrl: async () => {},
-        prompter: createTestWizardPrompter(),
-        runtime: createRuntimeEnv(),
-        signal: controller.signal,
-        assertCurrent: () => {
-          if (!current) {
-            throw new Error("owner retired");
-          }
-        },
-        oauth: {
-          createVpsAwareHandlers: () => {
-            throw new Error("unexpected browser flow");
+      const redirected = vi.fn(() => ({ statusCode: 403, data: "denied" }));
+      origin.intercept({ path: "/retired" }).reply(redirected);
+      const outcome = createXaiOAuthAuthMethod()
+        .run({
+          config: {},
+          isRemote: true,
+          openUrl: async () => {},
+          prompter: createTestWizardPrompter(),
+          runtime: createRuntimeEnv(),
+          signal: controller.signal,
+          assertCurrent: () => {
+            if (!current) {
+              throw new Error("owner retired");
+            }
           },
-        },
-      })
-      .catch((error: unknown) => error);
-    try {
-      await Promise.race([
-        held.promise,
-        outcome.then((error) => {
-          throw new Error("login ended before the held redirect", { cause: error });
-        }),
-      ]);
-      current = false;
-      release.resolve();
-      const error = await outcome;
-      expect(redirected).not.toHaveBeenCalled();
-      expect(transport.pendingInterceptors()).toEqual([
-        expect.objectContaining({ path: "/retired" }),
-      ]);
-      expect(error).toMatchObject({ message: expect.stringContaining("owner retired") });
-      expect(fetchImpl).toHaveBeenCalledWith(
-        XAI_OAUTH_DISCOVERY_URL,
-        expect.objectContaining({
-          redirect: "manual",
-          signal: expect.any(AbortSignal),
-        }),
-      );
-      expect(controller.signal.aborted).toBe(false);
-    } finally {
-      controller.abort();
-      release.resolve();
-      await outcome;
-      await transport.close();
-    }
-  });
+          oauth: {
+            createVpsAwareHandlers: () => {
+              throw new Error("unexpected browser flow");
+            },
+          },
+        })
+        .catch((error: unknown) => error);
+      try {
+        await Promise.race([
+          held.promise,
+          outcome.then((error) => {
+            throw new Error("login ended before the held redirect", { cause: error });
+          }),
+        ]);
+        current = false;
+        release.resolve();
+        const error = await outcome;
+        expect(redirected).not.toHaveBeenCalled();
+        expect(transport.pendingInterceptors()).toEqual([
+          expect.objectContaining({ path: "/retired" }),
+        ]);
+        expect(error).toMatchObject({ message: expect.stringContaining("owner retired") });
+        expect(fetchImpl).toHaveBeenCalledWith(
+          redirectStart,
+          expect.objectContaining({
+            redirect: "manual",
+            signal: expect.any(AbortSignal),
+          }),
+        );
+        expect(controller.signal.aborted).toBe(false);
+      } finally {
+        controller.abort();
+        release.resolve();
+        await outcome;
+        await transport.close();
+      }
+    },
+  );
 
   it.each([
     { boundary: "discovery response", requests: 1 },
     { boundary: "device prompt", requests: 2 },
     { boundary: "pending poll", requests: 3 },
+    { boundary: "token response", requests: 3 },
   ])(
     "revalidates live authority after held $boundary before another request",
     async ({ boundary, requests }) => {
@@ -242,6 +273,15 @@ describe("xAI OAuth", () => {
             expires_in: 60,
             interval: 1,
           });
+        }
+        if (url.endsWith("/models")) {
+          return jsonResponse({ data: [{ id: "subscription-fixture", api_backend: "responses" }] });
+        }
+        if (url.endsWith("/settings")) {
+          return jsonResponse({ default_model: "subscription-fixture" });
+        }
+        if (boundary === "token response") {
+          await hold();
         }
         polls += 1;
         if (boundary === "pending poll" && polls === 1) {
@@ -653,6 +693,7 @@ describe("xAI OAuth", () => {
                   : {}),
               },
         isRemote: true,
+        assertCurrent: vi.fn(),
         openUrl,
         prompter: createTestWizardPrompter({
           progress: vi.fn(() => progress),

--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -6,9 +6,11 @@ import {
   createTestWizardPrompter,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { OAuthCredential } from "openclaw/plugin-sdk/provider-auth";
+import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { withProxyFixture } from "openclaw/plugin-sdk/test-env";
 import { fetch as undiciFetch, MockAgent, type Dispatcher } from "undici";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { applyXaiConfig } from "./onboard.js";
 import { createXaiDeviceCodeAuthMethod, createXaiOAuthAuthMethod } from "./xai-oauth-entry.js";
 import { refreshXaiOAuthCredential } from "./xai-oauth.js";
 
@@ -62,6 +64,7 @@ function createXaiOAuthCredential(
 
 describe("xAI OAuth", () => {
   afterEach(() => {
+    clearLiveCatalogCacheForTests();
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
     vi.useRealTimers();
@@ -561,114 +564,191 @@ describe("xAI OAuth", () => {
     expect(refreshed.expires).toBe(100);
   });
 
-  it("logs in with xAI device code without a localhost callback", async () => {
-    vi.stubEnv("OPENCLAW_VERSION", "2026.3.22");
-    const progress = {
-      update: vi.fn(),
-      stop: vi.fn(),
-    };
-    const fetchImpl = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(
-        jsonResponse({
-          authorization_endpoint: "https://auth.x.ai/oauth2/authorize",
-          device_authorization_endpoint: "https://auth.x.ai/oauth2/device/code",
-          token_endpoint: "https://auth.x.ai/oauth2/token",
-        }),
-      )
-      .mockResolvedValueOnce(
-        jsonResponse({
-          device_code: "device-code-1",
-          user_code: "ABCD-1234",
-          verification_uri: "https://accounts.x.ai/oauth2/device",
-          verification_uri_complete: "https://accounts.x.ai/oauth2/device?user_code=ABCD-1234",
-          expires_in: 900,
-          interval: 5,
-        }),
-      )
-      .mockResolvedValueOnce(
-        jsonResponse({
-          access_token: createJwt({ exp: 4, sub: "acct-1" }),
-          refresh_token: "refresh-1",
-          id_token: createJwt({
-            sub: "acct-1",
-            email: "dev@example.com",
-            name: "Dev User",
+  it.each(["fresh", "subscription", "api"] as const)(
+    "logs in with device code and refreshes the %s catalog",
+    async (setup) => {
+      vi.stubEnv("OPENCLAW_VERSION", "2026.3.22");
+      const progress = {
+        update: vi.fn(),
+        stop: vi.fn(),
+      };
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          jsonResponse({
+            authorization_endpoint: "https://auth.x.ai/oauth2/authorize",
+            device_authorization_endpoint: "https://auth.x.ai/oauth2/device/code",
+            token_endpoint: "https://auth.x.ai/oauth2/token",
           }),
-          expires_in: 120,
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            device_code: "device-code-1",
+            user_code: "ABCD-1234",
+            verification_uri: "https://accounts.x.ai/oauth2/device",
+            verification_uri_complete: "https://accounts.x.ai/oauth2/device?user_code=ABCD-1234",
+            expires_in: 900,
+            interval: 5,
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            access_token: createJwt({ exp: 4, sub: "acct-1" }),
+            refresh_token: "refresh-1",
+            id_token: createJwt({
+              sub: "acct-1",
+              email: "dev@example.com",
+              name: "Dev User",
+            }),
+            expires_in: 120,
+          }),
+        );
+      fetchImpl.mockImplementation(async (input) => {
+        const url = requestUrl(input);
+        if (url.endsWith("/models")) {
+          return jsonResponse({ data: [{ id: "subscription-fixture", api_backend: "responses" }] });
+        }
+        if (url.endsWith("/settings")) {
+          return jsonResponse({ default_model: "subscription-fixture" });
+        }
+        throw new Error(`Unexpected catalog URL: ${url}`);
+      });
+      vi.stubGlobal("fetch", fetchImpl);
+      const deviceCode = vi.fn(async () => {});
+      const openUrl = vi.fn(async () => {});
+      const log = vi.fn();
+      const runtime = { ...createRuntimeEnv(), log };
+      const ctx: ProviderAuthContext = {
+        config:
+          setup === "fresh"
+            ? {}
+            : {
+                ...applyXaiConfig({}),
+                agents: {
+                  defaults: { model: { primary: "other/selected", fallbacks: ["other/fallback"] } },
+                },
+                ...(setup === "subscription"
+                  ? {
+                      models: {
+                        providers: {
+                          xai: {
+                            baseUrl: "https://cli-chat-proxy.grok.com/v1",
+                            api: "openai-responses",
+                            auth: "oauth",
+                            models: [
+                              {
+                                id: "stale-catalog",
+                                name: "Stale",
+                                reasoning: false,
+                                input: ["text"],
+                                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                                contextWindow: 1000,
+                                maxTokens: 100,
+                              },
+                            ],
+                          },
+                        },
+                      },
+                    }
+                  : {}),
+              },
+        isRemote: true,
+        openUrl,
+        prompter: createTestWizardPrompter({
+          progress: vi.fn(() => progress),
+          deviceCode,
         }),
-      );
-    vi.stubGlobal("fetch", fetchImpl);
-    const deviceCode = vi.fn(async () => {});
-    const openUrl = vi.fn(async () => {});
-    const log = vi.fn();
-    const runtime = { ...createRuntimeEnv(), log };
-    const ctx: ProviderAuthContext = {
-      config: {},
-      isRemote: true,
-      openUrl,
-      prompter: createTestWizardPrompter({
-        progress: vi.fn(() => progress),
-        deviceCode,
-      }),
-      runtime,
-      oauth: {
-        createVpsAwareHandlers: () => {
-          throw new Error("unexpected VPS OAuth handler request");
+        runtime,
+        oauth: {
+          createVpsAwareHandlers: () => {
+            throw new Error("unexpected VPS OAuth handler request");
+          },
         },
-      },
-    };
+      };
 
-    const result = await createXaiOAuthAuthMethod().run(ctx);
+      if (setup === "api" && ctx.config.models?.providers?.xai) {
+        Object.assign(ctx.config.models.providers.xai, {
+          apiKey: "fixture-api-key",
+          headers: { Authorization: "Bearer fixture-key" },
+          request: {
+            auth: { mode: "authorization-bearer", token: "fixture-token" },
+            headers: { "x-api-key": "fixture-key" },
+            allowPrivateNetwork: false,
+          },
+        });
+      }
+      const result = await createXaiOAuthAuthMethod().run(ctx);
 
-    expect(openUrl).toHaveBeenCalledWith("https://accounts.x.ai/oauth2/device?user_code=ABCD-1234");
-    expect(deviceCode).toHaveBeenCalledWith({
-      title: "xAI OAuth",
-      code: "ABCD-1234",
-      expiresInMinutes: 15,
-      message: "Enter this one-time code on the xAI sign-in page.",
-    });
-    expect(openUrl.mock.invocationCallOrder[0]).toBeLessThan(
-      deviceCode.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER,
-    );
-    const remoteLog = log.mock.calls[0]?.[0];
-    expect(remoteLog).toContain("https://accounts.x.ai/oauth2/device");
-    expect(remoteLog).not.toContain("ABCD-1234");
-    const deviceRequest = fetchImpl.mock.calls[1]?.[1];
-    expect(deviceRequest?.method).toBe("POST");
-    const deviceBody = requireStringBody(deviceRequest);
-    expect(deviceBody).toContain(`client_id=${encodeURIComponent(XAI_OAUTH_CLIENT_ID)}`);
-    expect(deviceBody).toContain(`scope=${encodeURIComponent(XAI_OAUTH_SCOPE)}`);
+      expect(openUrl).toHaveBeenCalledWith(
+        "https://accounts.x.ai/oauth2/device?user_code=ABCD-1234",
+      );
+      expect(deviceCode).toHaveBeenCalledWith({
+        title: "xAI OAuth",
+        code: "ABCD-1234",
+        expiresInMinutes: 15,
+        message: "Enter this one-time code on the xAI sign-in page.",
+      });
+      expect(openUrl.mock.invocationCallOrder[0]).toBeLessThan(
+        deviceCode.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER,
+      );
+      const remoteLog = log.mock.calls[0]?.[0];
+      expect(remoteLog).toContain("https://accounts.x.ai/oauth2/device");
+      expect(remoteLog).not.toContain("ABCD-1234");
+      const deviceRequest = fetchImpl.mock.calls[1]?.[1];
+      expect(deviceRequest?.method).toBe("POST");
+      const deviceBody = requireStringBody(deviceRequest);
+      expect(deviceBody).toContain(`client_id=${encodeURIComponent(XAI_OAUTH_CLIENT_ID)}`);
+      expect(deviceBody).toContain(`scope=${encodeURIComponent(XAI_OAUTH_SCOPE)}`);
 
-    const tokenRequest = fetchImpl.mock.calls[2]?.[1];
-    expect(tokenRequest?.method).toBe("POST");
-    const tokenBody = requireStringBody(tokenRequest);
-    expect(tokenBody).toContain(
-      "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code",
-    );
-    expect(tokenBody).toContain("device_code=device-code-1");
+      const tokenRequest = fetchImpl.mock.calls[2]?.[1];
+      expect(tokenRequest?.method).toBe("POST");
+      const tokenBody = requireStringBody(tokenRequest);
+      expect(tokenBody).toContain(
+        "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code",
+      );
+      expect(tokenBody).toContain("device_code=device-code-1");
 
-    expect(result.profiles[0]?.credential).toMatchObject({
-      type: "oauth",
-      provider: "xai",
-      refresh: "refresh-1",
-      email: "dev@example.com",
-      displayName: "Dev User",
-      tokenEndpoint: "https://auth.x.ai/oauth2/token",
-      deviceAuthorizationEndpoint: "https://auth.x.ai/oauth2/device/code",
-      issuer: "https://auth.x.ai",
-      authFlow: "device-code",
-      accountId: "acct-1",
-      access: expect.any(String),
-    });
-    expect(result.defaultModel).toBe("xai/auto");
-    expect(result.configPatch?.agents?.defaults?.model).toEqual({
-      primary: "xai/auto",
-    });
-    expect(result.configPatch?.agents?.defaults?.models?.["xai/auto"]?.alias).toBe("Grok");
-    expect(progress.update).toHaveBeenCalledWith("Waiting for xAI device authorization...");
-    expect(progress.stop).toHaveBeenCalledWith("xAI OAuth complete");
-  });
+      expect(result.profiles[0]?.credential).toMatchObject({
+        type: "oauth",
+        provider: "xai",
+        refresh: "refresh-1",
+        email: "dev@example.com",
+        displayName: "Dev User",
+        tokenEndpoint: "https://auth.x.ai/oauth2/token",
+        deviceAuthorizationEndpoint: "https://auth.x.ai/oauth2/device/code",
+        issuer: "https://auth.x.ai",
+        authFlow: "device-code",
+        accountId: "acct-1",
+        access: expect.any(String),
+      });
+      expect(result.defaultModel).toBe("xai/auto");
+      expect(result.configPatch?.agents?.defaults?.model).toEqual(
+        setup === "fresh"
+          ? { primary: "xai/auto" }
+          : { primary: "other/selected", fallbacks: ["other/fallback"] },
+      );
+      expect(result.configPatch?.models?.providers?.xai).toMatchObject({
+        baseUrl: "https://cli-chat-proxy.grok.com/v1",
+        api: "openai-responses",
+        auth: "oauth",
+      });
+      expect(result.configPatch?.models?.providers?.xai?.models.map((model) => model.id)).toEqual([
+        "subscription-fixture",
+      ]);
+      const savedProvider = result.configPatch?.models?.providers?.xai;
+      expect(savedProvider?.models.some((model) => model.id === "auto")).toBe(false);
+      expect(savedProvider).toHaveProperty("apiKey", undefined);
+      expect(savedProvider).toHaveProperty("headers", undefined);
+      expect(savedProvider?.request).toHaveProperty("auth", undefined);
+      expect(savedProvider?.request).toHaveProperty("headers", undefined);
+      if (setup === "api") {
+        expect(savedProvider?.request?.allowPrivateNetwork).toBe(false);
+      }
+      expect(result.configPatch?.agents?.defaults?.models?.["xai/auto"]?.alias).toBe("Grok");
+      expect(progress.update).toHaveBeenCalledWith("Waiting for xAI device authorization...");
+      expect(progress.stop).toHaveBeenCalledWith("xAI OAuth complete");
+    },
+  );
 
   it("falls back for unsafe xAI device-code lifetime fields", async () => {
     const progress = {
@@ -700,6 +780,16 @@ describe("xAI OAuth", () => {
           expires_in: 120,
         }),
       );
+    fetchImpl.mockImplementation(async (input) => {
+      const url = requestUrl(input);
+      if (url.endsWith("/models")) {
+        return jsonResponse({ data: [{ id: "subscription-fixture", api_backend: "responses" }] });
+      }
+      if (url.endsWith("/settings")) {
+        return jsonResponse({ default_model: "subscription-fixture" });
+      }
+      throw new Error(`Unexpected catalog URL: ${url}`);
+    });
     vi.stubGlobal("fetch", fetchImpl);
     const note = vi.fn<(message: string, title?: string) => Promise<void>>(async () => {});
     const ctx: ProviderAuthContext = {

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -636,6 +636,7 @@ export async function loginXaiDeviceCode(ctx: ProviderAuthContext): Promise<Prov
     const provider = await buildLiveXaiOAuthProvider({
       discoveryApiKey: tokens.accessToken,
       signal: ctx.signal,
+      fetchGuard: (params) => fetchWithSsrFGuard({ ...params, beforeRequest: ctx.assertCurrent }),
     });
     progress.stop("xAI OAuth complete");
     return buildOauthProviderAuthResult({

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -21,6 +21,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { applyXaiOAuthConfig, XAI_OAUTH_DEFAULT_MODEL_REF } from "./onboard.js";
+import { buildLiveXaiOAuthProvider } from "./provider-catalog.js";
 import { xaiUserAgent } from "./src/xai-user-agent.js";
 
 const PROVIDER_ID = "xai";
@@ -632,6 +633,10 @@ export async function loginXaiDeviceCode(ctx: ProviderAuthContext): Promise<Prov
       ...requestOptions,
     });
     const identity = resolveXaiOAuthIdentity(tokens);
+    const provider = await buildLiveXaiOAuthProvider({
+      discoveryApiKey: tokens.accessToken,
+      signal: ctx.signal,
+    });
     progress.stop("xAI OAuth complete");
     return buildOauthProviderAuthResult({
       providerId: PROVIDER_ID,
@@ -642,7 +647,7 @@ export async function loginXaiDeviceCode(ctx: ProviderAuthContext): Promise<Prov
       email: identity.email,
       displayName: identity.displayName,
       profileName: identity.email ?? identity.accountId,
-      configPatch: applyXaiOAuthConfig(ctx.config),
+      configPatch: applyXaiOAuthConfig(ctx.config, provider),
       credentialExtra: {
         tokenEndpoint: discovery.tokenEndpoint,
         deviceAuthorizationEndpoint: discovery.deviceAuthorizationEndpoint,

--- a/src/agents/runtime-plan/materialize-model.xai.test.ts
+++ b/src/agents/runtime-plan/materialize-model.xai.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { registerSingleProviderPlugin } from "../../plugin-sdk/plugin-test-runtime.js";
+import { loadBundledPluginPublicSurface } from "../../plugin-sdk/test-helpers/public-surface-loader.js";
+import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import type { StreamFn } from "../runtime/index.js";
+import { materializePreparedRuntimeModel } from "./materialize-model.js";
+
+describe("xAI OAuth runtime materialization", () => {
+  it("retains the selected alias through auth resolution and sends its canonical target", async () => {
+    const plugin = await loadBundledPluginPublicSurface<{
+      default: Parameters<typeof registerSingleProviderPlugin>[0];
+    }>({ pluginId: "xai", artifactBasename: "index.js" });
+    const provider = await registerSingleProviderPlugin(plugin.default);
+    const model: ProviderRuntimeModel = {
+      provider: "xai",
+      id: "auto",
+      name: "Subscription default",
+      api: "openai-responses",
+      baseUrl: "https://cli-chat-proxy.grok.com/v1",
+      params: { canonicalModelId: "grok-4.6" },
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 500_000,
+      maxTokens: 64_000,
+    };
+    const materialized = await materializePreparedRuntimeModel({
+      provider: "xai",
+      modelId: "auto",
+      model,
+      config: {},
+      plan: {
+        providerForAuth: "xai",
+        authProfileProviderForAuth: "xai",
+        selectedAuthMode: "oauth",
+        forwardedAuthProfileId: "xai:fixture",
+      },
+      forceResolve: true,
+      resolveModel: async (request) => {
+        expect(request.authProfileId).toBe("xai:fixture");
+        expect(request.authProfileMode).toBe("oauth");
+        return {
+          model: provider.normalizeResolvedModel?.({ provider: "xai", modelId: "auto", model }),
+        };
+      },
+    });
+    expect(materialized?.id).toBe("auto");
+    expect(materialized?.thinkingLevelMap?.xhigh).toBe("xhigh");
+    let wireModelId: string | undefined;
+    let wireHeaders: Record<string, string> | undefined;
+    const streamFn: StreamFn = (wireModel, _context, options) => {
+      wireModelId = wireModel.id;
+      wireHeaders = options?.headers;
+      return {} as ReturnType<StreamFn>;
+    };
+    const wrapped = provider.wrapStreamFn?.({
+      provider: "xai",
+      modelId: "auto",
+      model: materialized,
+      streamFn,
+      extraParams: { tool_stream: false },
+    });
+    if (!materialized || !wrapped) {
+      throw new Error("expected materialized subscription stream");
+    }
+    await wrapped(materialized, { messages: [] }, {});
+    expect(wireModelId).toBe("grok-4.6");
+    expect(wireHeaders?.["x-grok-model-override"]).toBe(wireModelId);
+  });
+});


### PR DESCRIPTION
Related: #140482, #140466

## What Problem This Solves

Fixes an issue where users reconnecting an xAI subscription would receive API-key catalog settings, and where selecting the subscription's automatic default failed prepared-auth materialization before inference. Both behaviors were reported by @DonnieFi.

## Why This Change Was Made

OAuth login now obtains its catalog from the same authenticated subscription owner used by discovery (`extensions/xai/provider-catalog.ts`), and applies it through the existing onboarding merge (`extensions/xai/onboard.ts`). Reconnecting replaces stale catalog/route metadata and removes obsolete route credentials while preserving the existing primary, fallbacks, and request policy. The moving alias is omitted from persisted catalog rows so discovery can follow future account defaults.

The provider retains alias identity during runtime compatibility normalization and auth materialization, then resolves the concrete target in its existing OAuth stream wrapper (`extensions/xai/provider-models.ts`, `extensions/xai/stream.ts`). Core provider/model/endpoint validation stays strict. Login-time catalog requests also retain the existing per-request live-authority assertion through DNS and redirects; revocation does not depend on aborting the wizard signal. Removed the duplicated setup preset, unused static OAuth fallback, early alias identity rewrite, and repeated compatibility classification.

Compared the existing catalog candidate #140537: a fixed subscription inventory would duplicate the authenticated catalog and could miss account-visible models. #132487 also covers setup-probe work and a substantially broader branch. This repair uses the existing owners without either new SDK seams or relaxed runtime identity checks.

## User Impact

Subscription sign-in refreshes the correct proxy catalog, reconnecting repairs previously overwritten metadata, and automatic selection can reach inference while retaining the canonical target's reasoning capabilities. API-key onboarding retains its existing preset. No configuration options, schema changes, dependency changes, or public SDK changes.

## Evidence

Candidate head: 617a6c17dea1d22613dbe5607afe0f6385d71ad1

- Production: +72 / -74 (**net -2**). Tests: +406 / -187 (**net +219**). Documentation: +5.
- Before-fix synthetic proof: all three login transition cases wrote API metadata; the normalization/materialization fixture threw the reported error; the wire-contract regression sent the unresolved alias. Restored the patch after running those regressions against the original production files.
- `node scripts/run-vitest.mjs src/agents/runtime-plan/materialize-model.xai.test.ts src/agents/runtime-plan/materialize-model.test.ts extensions/xai/onboard.test.ts extensions/xai/index.test.ts extensions/xai/xai-oauth.test.ts extensions/xai/stream.test.ts extensions/xai/runtime-model-compat.test.ts`: **138 passed** on the initial repair. Ran with a separate temporary Vitest cache while changed checks ran.
- The original-source run used the OAuth login-transition and wire-contract filters plus the normalization/materialization boundary fixture; **five expected failures** demonstrated both defects.
- Review correction: `node scripts/run-vitest.mjs extensions/xai/xai-oauth.test.ts`: **32 passed**. The two added authority regressions failed on the prior head: a revoked caller reached the catalog redirect, and post-token revocation still allowed two catalog requests. Both now prevent that final I/O without aborting the caller signal; authorized login remains covered.
- Independent Codex review: no accepted/actionable P0–P2 findings. Reviewed with unchanged owner/SDK source context.
- `pnpm check:changed`: **passed** for the initial repair (exit 0; all selected gates, including typechecks, lint, declarations, dead exports, and runtime import cycles). The scoped follow-up `pnpm check:changed -- extensions/xai/xai-oauth.ts extensions/xai/xai-oauth.test.ts` **passed** (exit 0, all selected checks). `git diff --check`: clean.
- Live device approval and real provider inference were not exercised. Tests use synthetic credentials, intercepted HTTP responses, and the real plugin/config/materialization/stream boundaries.
- CI: the current head passed [the required CI gate](https://github.com/openclaw/openclaw/actions/runs/34077055555/job/101606332940). ClawSweeper re-reviewed this head and reports no remaining findings. Native prepare and merge completed. Landed as [69cf3182a9624979dc69a141b1ee14bb67fd4c52](https://github.com/openclaw/openclaw/commit/69cf3182a9624979dc69a141b1ee14bb67fd4c52); ancestry and the landed source were verified on main. Both linked issues are closed.

Credit: @DonnieFi for both reports and credential-free reproductions. No contributor PR commits are included.
