### PR TITLE
chore(tests): remove idle wait from exec retention coverage

### DIFF
--- a/src/agents/agent-tools-agent-config.exec.test.ts
+++ b/src/agents/agent-tools-agent-config.exec.test.ts
@@ -74,10 +74,14 @@ describe("Agent-specific exec tool defaults", () => {
 
   afterEach(() => {
     resetProcessRegistryForTests();
+    vi.useRealTimers();
     tempDirs.cleanup();
   });
 
   it("keeps each actual exec result for its own agent retention after another process tool loads", async () => {
+    vi.useFakeTimers({
+      toFake: ["Date", "setTimeout", "clearTimeout", "setInterval", "clearInterval"],
+    });
     const config: OpenClawConfig = {
       tools: { exec: { host: "gateway", mode: "full", cleanupMs: 60_000 } },
       agents: {
@@ -103,7 +107,12 @@ describe("Agent-specific exec tool defaults", () => {
       if (!sessionId) {
         throw new Error("Expected an actual background process session");
       }
-      await vi.waitFor(() => expect(getFinishedSession(sessionId)).toBeDefined());
+      await vi.waitFor(() =>
+        expect(getFinishedSession(sessionId)).toMatchObject({
+          exitCode: 0,
+          terminalStatus: "completed",
+        }),
+      );
       return sessionId;
     };
     // Neither lazy process tool has run when these processes are admitted.
@@ -115,14 +124,8 @@ describe("Agent-specific exec tool defaults", () => {
       throw new Error("Expected process tools for both agents");
     }
     await shortProcess.execute("load-short-process", { action: "list" });
-    console.log(
-      "[retention-proof] Both commands completed; observing their retention for 95 seconds.",
-    );
-    const observedAt = Date.now();
     // The old 60s global TTL sweeps every 30s, so allow its next full sweep.
-    await new Promise((resolve) => {
-      setTimeout(resolve, 95_000);
-    });
+    await vi.advanceTimersByTimeAsync(95_000);
     const longResult = await longProcess.execute("long-retention-log", {
       action: "log",
       sessionId: longId,
@@ -131,21 +134,12 @@ describe("Agent-specific exec tool defaults", () => {
       action: "log",
       sessionId: shortId,
     });
-    console.log(
-      JSON.stringify({
-        retentionObservation: {
-          elapsedMs: Date.now() - observedAt,
-          longStatus: (longResult.details as { status?: string }).status,
-          shortStatus: (shortResult.details as { status?: string }).status,
-        },
-      }),
-    );
     expect(shortResult.details).toMatchObject({ status: "failed" });
     expect(longResult.details).toMatchObject({ status: "completed" });
     expect(longResult.content[0]).toMatchObject({
       text: expect.stringContaining("retention-result"),
     });
-  }, 120_000);
+  });
 
   it.each([0, 3_000])(
     "inherits the global exec approval running notice delay %i",


### PR DESCRIPTION
## What Problem This Solves

The two-agent exec-retention regression spends 95 seconds idle after both real commands have completed. It measured 95.375 seconds in [main CI](https://github.com/openclaw/openclaw/actions/runs/34070027186), while the other thirteen tests in its file totaled 514 ms.

## Why This Change Was Made

Advance the retention clock after both native `echo` processes finish successfully and the short-lived agent's lazy process tool loads. Keep the original 60-second and 180-second retention settings, tool-loading order, and final process-log assertions. Clock control includes intervals so the original global-TTL implementation's sweeper still executes in regression proof. Cleanup cancels the registry timer before restoring real timers.

Related: #127231.

## User Impact

Faster test execution with no production behavior, dependency, shard-count, or coverage reduction. The file retains all fourteen cases and now explicitly checks both native commands exited successfully. Test-only delta: +12/-18 lines; production delta: zero.

## Evidence

- Local unchanged baseline: 14 passed; retention case **95.986 s**. Candidate: 14 passed; same case **508 ms**.
- Restored candidate plus the complete process-registry suite: **41 passed**.
- Reversing the original fix's seven production-file changes makes the faster test fail at the intended assertion: the long-lived result was discarded. All seven production files were restored and their original hashes verified afterward.
- Local whole-command time: 181.73 → 68.68 s; peak RSS 2.210 → 2.221 GB. Transform overhead varied, so the scoped 95-second idle-wait removal is the attributable improvement.
- Independent P0–P2 review: no findings. Required changed checks and exact-head CI are recorded with the PR checks.
