### PR TITLE
improve(memory-wiki): skip link parsing for bracket-free pages

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -771,7 +771,6 @@ extensions/memory-wiki/src/compiled-cache.ts	1
 extensions/memory-wiki/src/gateway.ts	3
 extensions/memory-wiki/src/ingest.ts	2
 extensions/memory-wiki/src/log.ts	1
-extensions/memory-wiki/src/markdown.ts	1
 extensions/memory-wiki/src/mutation-coordinator.ts	1
 extensions/memory-wiki/src/okf.ts	1
 extensions/memory-wiki/src/source-sync-state.ts	1

--- a/extensions/memory-wiki/src/markdown-links.ts
+++ b/extensions/memory-wiki/src/markdown-links.ts
@@ -1,0 +1,75 @@
+import path from "node:path";
+import { fromMarkdown } from "mdast-util-from-markdown";
+
+export const WIKI_RELATED_START_MARKER = "<!-- openclaw:wiki:related:start -->";
+export const WIKI_RELATED_END_MARKER = "<!-- openclaw:wiki:related:end -->";
+
+const OBSIDIAN_LINK_PATTERN = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
+const MARKDOWN_LINK_PATTERN = /\[[^\]]+\]\(([^)]+)\)/g;
+const RELATED_BLOCK_PATTERN = new RegExp(
+  `${WIKI_RELATED_START_MARKER}[\\s\\S]*?${WIKI_RELATED_END_MARKER}`,
+  "g",
+);
+
+function normalizeMarkdownLinkTarget(sourceRelativePath: string, target: string): string {
+  return path.posix.normalize(path.posix.join(path.posix.dirname(sourceRelativePath), target));
+}
+
+type MarkdownAstNode = {
+  type?: string;
+  position?: {
+    start?: { offset?: number };
+    end?: { offset?: number };
+  };
+  children?: MarkdownAstNode[];
+};
+
+function maskMarkdownCode(markdown: string): string {
+  const masked = markdown.split("");
+  const visit = (node: MarkdownAstNode): void => {
+    if (node.type === "code" || node.type === "inlineCode") {
+      const start = node.position?.start?.offset;
+      const end = node.position?.end?.offset;
+      if (start !== undefined && end !== undefined) {
+        for (let index = start; index < end; index++) {
+          if (masked[index] !== "\n" && masked[index] !== "\r") {
+            masked[index] = " ";
+          }
+        }
+      }
+      return;
+    }
+    for (const child of node.children ?? []) {
+      visit(child);
+    }
+  };
+  visit(fromMarkdown(markdown));
+  return masked.join("");
+}
+
+export function extractWikiLinks(markdown: string, sourceRelativePath: string): string[] {
+  // Masking cannot add brackets, and both supported link forms require one.
+  if (!markdown.includes("[")) {
+    return [];
+  }
+  const withoutRelatedBlock = markdown.replace(RELATED_BLOCK_PATTERN, "");
+  const searchable = maskMarkdownCode(withoutRelatedBlock);
+  const links: string[] = [];
+  for (const match of searchable.matchAll(OBSIDIAN_LINK_PATTERN)) {
+    const target = match[1]?.trim();
+    if (target) {
+      links.push(target);
+    }
+  }
+  for (const match of searchable.matchAll(MARKDOWN_LINK_PATTERN)) {
+    const rawTarget = match[1]?.trim();
+    if (!rawTarget || rawTarget.startsWith("#") || /^[a-z]+:/i.test(rawTarget)) {
+      continue;
+    }
+    const target = rawTarget.split("#")[0]?.split("?")[0]?.replace(/\\/g, "/").trim();
+    if (target) {
+      links.push(normalizeMarkdownLinkTarget(sourceRelativePath, target));
+    }
+  }
+  return links;
+}

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -1,7 +1,6 @@
 // Memory Wiki plugin module implements markdown behavior.
 import { createHash } from "node:crypto";
 import path from "node:path";
-import { fromMarkdown } from "mdast-util-from-markdown";
 import {
   asFiniteNumber,
   asNullableRecord,
@@ -11,10 +10,11 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf8Prefix } from "openclaw/plugin-sdk/text-utility-runtime";
 import YAML from "yaml";
+import { extractWikiLinks } from "./markdown-links.js";
+
+export { WIKI_RELATED_END_MARKER, WIKI_RELATED_START_MARKER } from "./markdown-links.js";
 
 const WIKI_PAGE_KINDS = ["entity", "concept", "source", "synthesis", "report"] as const;
-export const WIKI_RELATED_START_MARKER = "<!-- openclaw:wiki:related:start -->";
-export const WIKI_RELATED_END_MARKER = "<!-- openclaw:wiki:related:end -->";
 export const WIKI_RAW_SOURCE_MARKER = "<!-- openclaw:wiki:raw-source -->";
 
 export type WikiPageKind = (typeof WIKI_PAGE_KINDS)[number];
@@ -124,12 +124,6 @@ type WikiPageSummaryScanResult =
   | { status: "ignored" };
 
 const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
-const OBSIDIAN_LINK_PATTERN = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
-const MARKDOWN_LINK_PATTERN = /\[[^\]]+\]\(([^)]+)\)/g;
-const RELATED_BLOCK_PATTERN = new RegExp(
-  `${WIKI_RELATED_START_MARKER}[\\s\\S]*?${WIKI_RELATED_END_MARKER}`,
-  "g",
-);
 const MAX_WIKI_SEGMENT_BYTES = 240;
 const MAX_WIKI_FILENAME_COMPONENT_BYTES = 255;
 const FS_SAFE_PINNED_WRITE_TEMP_SUFFIX = ".00000000-0000-4000-8000-000000000000.fallback.tmp";
@@ -379,65 +373,6 @@ function normalizeWikiRelationships(value: unknown): WikiRelationship[] {
     const hasAnyValue = Object.keys(relationship).length > 0;
     return hasAnyValue ? [relationship] : [];
   });
-}
-
-function normalizeMarkdownLinkTarget(sourceRelativePath: string, target: string): string {
-  return path.posix.normalize(path.posix.join(path.posix.dirname(sourceRelativePath), target));
-}
-
-type MarkdownAstNode = {
-  type?: string;
-  position?: {
-    start?: { offset?: number };
-    end?: { offset?: number };
-  };
-  children?: MarkdownAstNode[];
-};
-
-function maskMarkdownCode(markdown: string): string {
-  const masked = markdown.split("");
-  const visit = (node: MarkdownAstNode): void => {
-    if (node.type === "code" || node.type === "inlineCode") {
-      const start = node.position?.start?.offset;
-      const end = node.position?.end?.offset;
-      if (start !== undefined && end !== undefined) {
-        for (let index = start; index < end; index++) {
-          if (masked[index] !== "\n" && masked[index] !== "\r") {
-            masked[index] = " ";
-          }
-        }
-      }
-      return;
-    }
-    for (const child of node.children ?? []) {
-      visit(child);
-    }
-  };
-  visit(fromMarkdown(markdown) as MarkdownAstNode);
-  return masked.join("");
-}
-
-function extractWikiLinks(markdown: string, sourceRelativePath: string): string[] {
-  const withoutRelatedBlock = markdown.replace(RELATED_BLOCK_PATTERN, "");
-  const searchable = maskMarkdownCode(withoutRelatedBlock);
-  const links: string[] = [];
-  for (const match of searchable.matchAll(OBSIDIAN_LINK_PATTERN)) {
-    const target = match[1]?.trim();
-    if (target) {
-      links.push(target);
-    }
-  }
-  for (const match of searchable.matchAll(MARKDOWN_LINK_PATTERN)) {
-    const rawTarget = match[1]?.trim();
-    if (!rawTarget || rawTarget.startsWith("#") || /^[a-z]+:/i.test(rawTarget)) {
-      continue;
-    }
-    const target = rawTarget.split("#")[0]?.split("?")[0]?.replace(/\\/g, "/").trim();
-    if (target) {
-      links.push(normalizeMarkdownLinkTarget(sourceRelativePath, target));
-    }
-  }
-  return links;
 }
 
 function normalizeMarkdownLines(markdown: string): string[] {


### PR DESCRIPTION
## What Problem This Solves

Memory Wiki reads parse an entire Markdown syntax tree to find links even when a page contains no opening bracket. This adds substantial work when reading large plain-text pages by path, basename, or ID.

## Why This Change Was Made

Skip link parsing when the original text has no `[`: both supported link forms require it, and code masking or related-block removal cannot introduce it. Frontmatter validation still runs first. Move the pure link-processing code into a focused sibling module to keep the existing Markdown owner within its size limit, preserving its marker exports. Remove an unnecessary type assertion and its obsolete baseline entry.

## User Impact

Faster reads for bracket-free pages with unchanged link extraction and validation behavior. The change adds 10 net production lines, removes one assertion-baseline entry, and changes no test lines.

## Evidence

The same existing 16 MiB large-page case passed in **16.425s before and 0.153s on the final source**. This is one local case-level pair, not a full-suite or aggregate coverage claim. Transform caches differed: worker preparation was 3.962s before and 2.871s after; total command time was 27.59s and 6.41s, respectively, so the wrapper difference is not attributed solely to parsing.

All 155 existing Markdown, query, compile, lint, and OKF cases pass. The test files and fixture size are unchanged. The later cast removal emits identical runtime JavaScript to the tested split source, and the final filtered large-page case passes. Full changed-file checks, formatting, and independent review through P2 pass, including the exact shrink-only assertion-baseline update. No suppression or parser-call-count test was added.
