### PR TITLE
feat(android): keep content clear of separating hinges

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -24,6 +24,18 @@ OpenClaw Android is the officially released Google Play app. It connects to an O
 
 Long-press a row on the **Threads** page and choose **Color**, then select a swatch or **Default** to clear it. The eight colors are red, blue, green, yellow, purple, orange, pink, and cyan. Colored sessions show a narrow leading stripe in the sidebar and Threads page, plus a colored ring around the agent avatar in the open chat header. Unset colors add no indicator. Colors sync through the Gateway and remain visible in the local session cache while offline.
 
+## Foldable layout
+
+Onboarding and the main app stay within the largest rectangular region clear of
+separating folds and fully occluding hinges reported by AndroidX WindowManager.
+Equal regions prefer the top, then the reading-direction start side. Opening the
+keyboard does not select a different region. Without an intersecting separator,
+the app keeps its full-window layout.
+
+This is an initial hinge-safety fallback, not a complete foldable layout. The
+other region is temporarily unused. Book-mode companion panes, a tabletop
+transcript/composer split, and separate-window dialogs are not adapted yet.
+
 ## Wear OS companion
 
 The `wear` app is a paired-phone companion with the same application ID and signing identity as the phone app. The watch discovers the phone through Wear OS Data Layer, then uses the phone's existing authenticated operator session. It never receives or stores Gateway tokens, passwords, TLS pins, or device-signing identity.

--- a/apps/android/THIRD_PARTY_LICENSES/openclaw/licenses/AndroidX WindowManager.txt
+++ b/apps/android/THIRD_PARTY_LICENSES/openclaw/licenses/AndroidX WindowManager.txt
@@ -1,0 +1,15 @@
+AndroidX WindowManager
+Artifacts:
+- androidx.window:window:1.5.1
+- androidx.window:window-core:1.5.1
+
+Copyright 2021 The Android Open Source Project
+
+Licensed under the Apache License, Version 2.0.
+You may obtain a copy of the License at:
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -330,6 +330,7 @@ dependencies {
   implementation(libs.androidx.lifecycle.runtime.ktx)
   implementation(libs.androidx.activity.compose)
   implementation(libs.androidx.webkit)
+  implementation(libs.androidx.window)
 
   implementation(libs.androidx.compose.ui)
   implementation(libs.androidx.compose.ui.tooling.preview)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareContent.kt
@@ -1,0 +1,43 @@
+package ai.openclaw.app.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.recalculateWindowInsets
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.round
+import androidx.window.layout.DisplayFeature
+
+@Composable
+internal fun FoldAwareContent(
+  features: List<DisplayFeature>,
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit,
+) {
+  Layout(
+    modifier = modifier.fillMaxSize(),
+    content = {
+      Box(Modifier.recalculateWindowInsets().clipToBounds()) { content() }
+    },
+  ) { measurables, constraints ->
+    val width = constraints.maxWidth
+    val height = constraints.maxHeight
+    layout(width, height) {
+      // Read the stationary host, not the moving pane. Measuring during placement uses the
+      // current window offset even when an ancestor moves without changing our constraints.
+      val origin = coordinates?.positionInWindow()?.round() ?: IntOffset.Zero
+      val pane = foldSafeRegion(IntRect(origin, IntSize(width, height)), features, layoutDirection)
+      measurables
+        .single()
+        .measure(Constraints.fixed(pane.width, pane.height))
+        .place(pane.left - origin.x, pane.top - origin.y)
+    }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/RootScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/RootScreen.kt
@@ -1,7 +1,9 @@
 package ai.openclaw.app.ui
 
 import ai.openclaw.app.MainViewModel
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -12,10 +14,14 @@ import androidx.compose.ui.Modifier
 fun RootScreen(viewModel: MainViewModel) {
   val onboardingCompleted by viewModel.onboardingCompleted.collectAsState()
 
-  if (!onboardingCompleted) {
-    OnboardingFlow(viewModel = viewModel, modifier = Modifier.fillMaxSize())
-    return
+  FoldAwareContent(
+    features = rememberWindowDisplayFeatures(),
+    modifier = Modifier.background(MaterialTheme.colorScheme.background),
+  ) {
+    if (!onboardingCompleted) {
+      OnboardingFlow(viewModel = viewModel, modifier = Modifier.fillMaxSize())
+    } else {
+      ShellScreen(viewModel = viewModel, modifier = Modifier.fillMaxSize())
+    }
   }
-
-  ShellScreen(viewModel = viewModel, modifier = Modifier.fillMaxSize())
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/WindowLayout.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/WindowLayout.kt
@@ -1,0 +1,72 @@
+package ai.openclaw.app.ui
+
+import androidx.activity.compose.LocalActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.window.layout.DisplayFeature
+import androidx.window.layout.FoldingFeature
+import androidx.window.layout.WindowInfoTracker
+
+@Composable
+internal fun rememberWindowDisplayFeatures(): List<DisplayFeature> {
+  val activity = LocalActivity.current
+  val lifecycle = LocalLifecycleOwner.current.lifecycle
+  var features by remember(activity) { mutableStateOf(emptyList<DisplayFeature>()) }
+  LaunchedEffect(activity, lifecycle) {
+    if (activity != null) {
+      // The flow belongs to this Activity, never to a retained ViewModel or application.
+      lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        WindowInfoTracker.getOrCreate(activity).windowLayoutInfo(activity).collect {
+          features = it.displayFeatures
+        }
+      }
+    }
+  }
+  return features
+}
+
+/** The largest hinge-free rectangle, in physical window coordinates. */
+internal fun foldSafeRegion(
+  host: IntRect,
+  features: List<DisplayFeature>,
+  direction: LayoutDirection,
+): IntRect {
+  var regions = listOf(host)
+  for (feature in features.filterIsInstance<FoldingFeature>()) {
+    if (!feature.isSeparating && feature.occlusionType != FoldingFeature.OcclusionType.FULL) continue
+    val bounds = feature.bounds
+    regions =
+      regions
+        .flatMap { region ->
+          // Strict comparisons keep zero-thickness interior folds, but exclude boundary-only contact.
+          if (bounds.left >= region.right || bounds.right <= region.left ||
+            bounds.top >= region.bottom || bounds.bottom <= region.top
+          ) {
+            listOf(region)
+          } else {
+            // Keep every candidate until all separators are applied. Choosing early can discard
+            // the eventual largest pane. Overlapping candidates also preserve space around fold ends.
+            buildList {
+              if (bounds.left > region.left) add(region.copy(right = bounds.left))
+              if (bounds.right < region.right) add(region.copy(left = bounds.right))
+              if (bounds.top > region.top) add(region.copy(bottom = bounds.top))
+              if (bounds.bottom < region.bottom) add(region.copy(top = bounds.bottom))
+            }
+          }
+        }.distinct()
+  }
+  return regions.minWithOrNull(
+    compareByDescending<IntRect> { it.width.toLong() * it.height }
+      .thenBy { it.top }
+      .thenBy { if (direction == LayoutDirection.Ltr) it.left else -it.right },
+  ) ?: IntRect(host.left, host.top, host.left, host.top)
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/AndroidLicenseNoticesTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/AndroidLicenseNoticesTest.kt
@@ -44,6 +44,7 @@ class AndroidLicenseNoticesTest {
         "AndroidX Room",
         "AndroidX SQLite",
         "AndroidX Wear",
+        "AndroidX WindowManager",
         "Bouncy Castle Provider",
         "CodexBar",
         "Coil",

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareContentTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareContentTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.window.layout.DisplayFeature
@@ -47,7 +48,7 @@ class FoldAwareContentTest {
     composeRule.setContent {
       CompositionLocalProvider(LocalLayoutDirection provides direction) {
         Box(Modifier.fillMaxSize(), contentAlignment = AbsoluteAlignment.TopLeft) {
-          FoldAwareContent(folds, Modifier.absoluteOffset(x, 50.dp).size(800.dp, 800.dp)) {
+          FoldAwareContent(folds, Modifier.absoluteOffset { IntOffset(x.roundToPx(), 50.dp.roundToPx()) }.size(800.dp, 800.dp)) {
             var draft by remember { mutableStateOf("") }
             DisposableEffect(Unit) {
               starts++

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareContentTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareContentTest.kt
@@ -1,0 +1,83 @@
+package ai.openclaw.app.ui
+
+import android.graphics.Rect
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.absoluteOffset
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.AbsoluteAlignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.window.layout.DisplayFeature
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(minSdk = 34, maxSdk = 34, qualifiers = "w1000dp-h1000dp-mdpi")
+class FoldAwareContentTest {
+  @get:Rule val composeRule = createComposeRule()
+
+  @Test
+  fun movingHostAndRtlPlaceOneLiveEditorInPhysicalWindowCoordinates() {
+    var folds by mutableStateOf(emptyList<DisplayFeature>())
+    var direction by mutableStateOf(LayoutDirection.Ltr)
+    var x by mutableStateOf(100.dp)
+    var starts = 0
+    var disposals = 0
+    composeRule.setContent {
+      CompositionLocalProvider(LocalLayoutDirection provides direction) {
+        Box(Modifier.fillMaxSize(), contentAlignment = AbsoluteAlignment.TopLeft) {
+          FoldAwareContent(folds, Modifier.absoluteOffset(x, 50.dp).size(800.dp, 800.dp)) {
+            var draft by remember { mutableStateOf("") }
+            DisposableEffect(Unit) {
+              starts++
+              onDispose { disposals++ }
+            }
+            Box(Modifier.fillMaxSize().testTag("pane")) {
+              BasicTextField(draft, { draft = it }, Modifier.testTag("editor"))
+            }
+          }
+        }
+      }
+    }
+    val pane = composeRule.onNodeWithTag("pane")
+    val original = pane.getUnclippedBoundsInRoot()
+    composeRule.onNodeWithTag("editor").performTextReplacement("retained draft")
+    // Features use window coordinates; this host starts away from the window origin.
+    val foldX = original.left.value.toInt() + 390
+    val feature = testFold(Rect(foldX, 0, foldX + 20, 2000))
+    composeRule.runOnIdle { folds = listOf(feature) }
+    assertEquals(DpRect(original.left, original.top, original.left + 390.dp, original.bottom), pane.getUnclippedBoundsInRoot())
+    composeRule.runOnIdle { direction = LayoutDirection.Rtl }
+    assertEquals(DpRect(original.left + 410.dp, original.top, original.right, original.bottom), pane.getUnclippedBoundsInRoot())
+    composeRule.runOnIdle { x = 120.dp }
+    assertEquals(DpRect(original.left + 410.dp, original.top, original.right + 20.dp, original.bottom), pane.getUnclippedBoundsInRoot())
+    composeRule.runOnIdle { folds = emptyList() }
+    assertEquals(DpRect(original.left + 20.dp, original.top, original.right + 20.dp, original.bottom), pane.getUnclippedBoundsInRoot())
+    composeRule.onNodeWithTag("editor").assertTextEquals("retained draft")
+    composeRule.runOnIdle {
+      assertEquals("Fold changes must not recreate the editor composition", 1, starts)
+      assertEquals(0, disposals)
+    }
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/RootScreenFoldTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/RootScreenFoldTest.kt
@@ -1,0 +1,263 @@
+package ai.openclaw.app.ui
+
+import ai.openclaw.app.HomeDestination
+import ai.openclaw.app.MainViewModel
+import ai.openclaw.app.NodeApp
+import ai.openclaw.app.NodeRuntime
+import ai.openclaw.app.NodeRuntimeMode
+import ai.openclaw.app.SecurePrefs
+import ai.openclaw.app.closeNodeRuntimeTestFixture
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.content.Context
+import android.graphics.Rect
+import android.provider.Settings
+import android.view.View
+import androidx.activity.ComponentActivity
+import androidx.activity.OnBackPressedDispatcher
+import androidx.activity.compose.LocalActivity
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextReplacement
+import androidx.core.view.WindowCompat
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.window.layout.DisplayFeature
+import androidx.window.layout.WindowInfoTracker
+import androidx.window.layout.WindowInfoTrackerDecorator
+import androidx.window.layout.WindowLayoutInfo
+import com.google.mlkit.common.internal.MlKitInitProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+@Config(minSdk = 34, maxSdk = 34, qualifiers = "w1000dp-h1000dp-mdpi")
+class RootScreenFoldTest {
+  @get:Rule val composeRule = createComposeRule()
+
+  private val layouts = MutableSharedFlow<WindowLayoutInfo>(replay = 1)
+  private val activeActivities = mutableSetOf<Activity>()
+  private lateinit var view: View
+  private lateinit var backDispatcher: OnBackPressedDispatcher
+
+  @Before
+  @SuppressLint("RestrictedApi") // Use WindowManager's own decorator boundary, not a production test hook.
+  fun installWindowTracker() {
+    WindowInfoTracker.overrideDecorator(
+      object : WindowInfoTrackerDecorator {
+        override fun decorate(tracker: WindowInfoTracker): WindowInfoTracker =
+          object : WindowInfoTracker by tracker {
+            override fun windowLayoutInfo(activity: Activity): Flow<WindowLayoutInfo> =
+              flow {
+                check(activeActivities.add(activity))
+                try {
+                  emitAll(layouts)
+                } finally {
+                  activeActivities.remove(activity)
+                }
+              }
+          }
+      },
+    )
+    val app = RuntimeEnvironment.getApplication()
+    Settings.Global.putFloat(app.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 0f)
+  }
+
+  @After
+  @SuppressLint("RestrictedApi")
+  fun resetWindowTracker() {
+    WindowInfoTracker.reset()
+  }
+
+  @Test
+  fun onboardingActionsAvoidTheHingeAndKeepDraftFocusAndBackNavigation() {
+    withRoot(completed = false) {
+      // No WindowLayoutInfo emission yet: onboarding must render normally.
+      val action = composeRule.onNodeWithText("Continue").assertIsDisplayed()
+      val original = windowBounds(action)
+      val hinge = Rect(original.centerX() - 10, 0, original.centerX() + 10, view.height)
+      assertTrue("The baseline action must cross the future hinge", Rect.intersects(original, hinge))
+      emit(listOf(testFold(hinge)))
+      assertClearOfHinge(action, hinge)
+      action.performClick()
+      composeRule.onNodeWithText("Set up manually").performClick()
+      val input = composeRule.onNode(hasSetTextAction() and hasText("Host"))
+      input.performScrollTo().performClick().performTextReplacement("gateway.test")
+      val draft = composeRule.onNode(hasSetTextAction() and hasText("gateway.test"))
+      val editorId = draft.fetchSemanticsNode().id
+      for (features in listOf(emptyList(), listOf(testFold(hinge)), emptyList())) {
+        emit(features)
+        draft.assertTextEquals("gateway.test").assertIsFocused()
+        assertEquals("Fold changes must keep the live input node", editorId, draft.fetchSemanticsNode().id)
+      }
+      composeRule.runOnIdle { backDispatcher.onBackPressed() }
+      composeRule.onNodeWithText("Set up manually").assertIsDisplayed().performClick()
+      composeRule.onNode(hasSetTextAction() and hasText("gateway.test")).performScrollTo().assertIsDisplayed()
+    }
+  }
+
+  @Test
+  fun authenticatedSettingsKeepSearchDraftAndReturnRouteAcrossFoldChanges() {
+    withRoot(completed = true) {
+      composeRule.onNodeWithContentDescription("Search settings").performClick()
+      val search = composeRule.onNode(hasSetTextAction())
+      search.performClick().performTextReplacement("Appearance")
+      val editorId = search.fetchSemanticsNode().id
+      val initial = windowBounds(search)
+      val hinge = Rect(initial.centerX() - 10, 0, initial.centerX() + 10, view.height)
+      for (features in listOf(listOf(testFold(hinge)), emptyList(), listOf(testFold(hinge)))) {
+        emit(features)
+        search.assertTextEquals("Appearance").assertIsFocused()
+        assertEquals(editorId, search.fetchSemanticsNode().id)
+        if (features.isNotEmpty()) assertClearOfHinge(search, hinge)
+      }
+      composeRule.onNodeWithContentDescription("Close search").performClick()
+      composeRule.onNodeWithTag("sidebar-open-settings").assertIsDisplayed()
+      composeRule.onNodeWithText("Theme family").assertDoesNotExist()
+    }
+  }
+
+  @Test
+  fun activityReplacementCancelsOldCollectionAndWaitsForTheNewLifecycle() {
+    val first = Robolectric.buildActivity(ComponentActivity::class.java).setup()
+    val second = Robolectric.buildActivity(ComponentActivity::class.java).create()
+    var activity by mutableStateOf(first.get())
+    var observed = emptyList<DisplayFeature>()
+    try {
+      composeRule.setContent {
+        CompositionLocalProvider(LocalActivity provides activity, LocalLifecycleOwner provides activity) {
+          val features = rememberWindowDisplayFeatures()
+          SideEffect { observed = features }
+        }
+      }
+      composeRule.runOnIdle { assertEquals(setOf(first.get()), activeActivities) }
+      val fold = testFold(Rect(490, 0, 510, 1000))
+      emit(listOf(fold))
+      composeRule.runOnIdle { assertEquals(listOf(fold), observed) }
+      composeRule.runOnIdle {
+        first.pause().stop()
+      }
+      composeRule.runOnIdle { assertTrue(activeActivities.isEmpty()) }
+      composeRule.runOnIdle { first.start().resume() }
+      composeRule.runOnIdle { assertEquals(setOf(first.get()), activeActivities) }
+      composeRule.runOnIdle { activity = second.get() }
+      composeRule.runOnIdle {
+        assertTrue("The stopped replacement must not collect", activeActivities.isEmpty())
+        assertTrue("Do not retain old-Activity features while awaiting an emission", observed.isEmpty())
+        first.pause().stop().destroy()
+        second.start().resume()
+      }
+      composeRule.runOnIdle { assertEquals(setOf(second.get()), activeActivities) }
+      emit(emptyList())
+      composeRule.runOnIdle {
+        assertTrue(observed.isEmpty())
+        second.pause().stop().destroy()
+      }
+      composeRule.runOnIdle { assertTrue(activeActivities.isEmpty()) }
+    } finally {
+      if (!first.get().isDestroyed) first.pause().stop().destroy()
+      if (!second.get().isDestroyed) second.pause().stop().destroy()
+    }
+  }
+
+  private fun emit(features: List<DisplayFeature>) {
+    composeRule.runOnIdle { assertTrue(layouts.tryEmit(WindowLayoutInfo(features))) }
+    composeRule.waitForIdle()
+  }
+
+  private fun withRoot(
+    completed: Boolean,
+    verify: () -> Unit,
+  ) {
+    val app = RuntimeEnvironment.getApplication() as NodeApp
+    val prefs = SecurePrefs(app, app.getSharedPreferences("root-fold-${UUID.randomUUID()}", Context.MODE_PRIVATE))
+    prefs.setOnboardingCompleted(completed)
+    val runtime = NodeRuntime(app, prefs, NodeRuntimeMode.ScreenshotFixture)
+    val models = ViewModelStore()
+    try {
+      if (!completed) Robolectric.buildContentProvider(MlKitInitProvider::class.java).create()
+      val model = MainViewModel(app, prefs, SavedStateHandle())
+      models.put("root-fold", model)
+      ReflectionHelpers.getField<MutableStateFlow<NodeRuntime?>>(model, "runtimeRef").value = runtime
+      if (completed) model.requestHomeDestination(HomeDestination.Settings)
+      composeRule.setContent {
+        val activity = requireNotNull(LocalActivity.current)
+        view = LocalView.current
+        backDispatcher = requireNotNull(LocalOnBackPressedDispatcherOwner.current).onBackPressedDispatcher
+        LaunchedEffect(activity) { WindowCompat.setDecorFitsSystemWindows(activity.window, false) }
+        RootScreen(model)
+      }
+      composeRule.waitForIdle()
+      val originalRoot = composeRule.onRoot().getUnclippedBoundsInRoot()
+      verify()
+      assertEquals("Only the pane may move, never the window host", originalRoot, composeRule.onRoot().getUnclippedBoundsInRoot())
+    } finally {
+      try {
+        models.clear()
+      } finally {
+        closeNodeRuntimeTestFixture(runtime)
+      }
+    }
+  }
+
+  private fun windowBounds(node: SemanticsNodeInteraction): Rect {
+    val bounds = node.getUnclippedBoundsInRoot()
+    val offset = IntArray(2).also(view::getLocationInWindow)
+    val density = view.resources.displayMetrics.density
+    return Rect(
+      (bounds.left.value * density).toInt() + offset[0],
+      (bounds.top.value * density).toInt() + offset[1],
+      (bounds.right.value * density).toInt() + offset[0],
+      (bounds.bottom.value * density).toInt() + offset[1],
+    )
+  }
+
+  private fun assertClearOfHinge(
+    node: SemanticsNodeInteraction,
+    hinge: Rect,
+  ) {
+    node.assertIsDisplayed()
+    val bounds = windowBounds(node)
+    assertNotEquals("The witness must have real geometry", 0, bounds.width())
+    assertFalse("Interactive content overlaps the separating hinge: content=$bounds hinge=$hinge", Rect.intersects(bounds, hinge))
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsDetailInsetsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsDetailInsetsTest.kt
@@ -15,6 +15,7 @@ import android.accessibilityservice.AccessibilityServiceInfo
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.graphics.Rect
 import android.text.InputType
 import android.view.View
 import android.view.accessibility.AccessibilityManager
@@ -33,6 +34,9 @@ import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.InterceptPlatformTextInput
 import androidx.compose.ui.platform.LocalDensity
@@ -78,6 +82,7 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelStore
+import androidx.window.layout.DisplayFeature
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.serialization.json.Json
@@ -606,6 +611,9 @@ class SettingsDetailInsetsTest {
   fun keyboardInsetsResizeSettingsInWideSidebarShell() = verifyInsets()
 
   @Test
+  fun keyboardInsetsRemainPaneRelativeAcrossHorizontalAndVerticalFolds() = verifyInsets(foldChanges = true)
+
+  @Test
   @Config(qualifiers = "w320dp-h800dp-mdpi")
   fun appearanceSwatchesKeepAccessibleTouchTargetsInANarrowWindow() {
     val app = RuntimeEnvironment.getApplication() as NodeApp
@@ -1048,9 +1056,10 @@ class SettingsDetailInsetsTest {
     }
   }
 
-  private fun verifyInsets() {
+  private fun verifyInsets(foldChanges: Boolean = false) {
     lateinit var view: View
     var observedBottomInsets: Pair<Int, Int>? = null
+    var features by mutableStateOf(emptyList<DisplayFeature>())
     composeRule.setContent {
       val activity = requireNotNull(LocalActivity.current)
       val localView = LocalView.current
@@ -1064,14 +1073,18 @@ class SettingsDetailInsetsTest {
       }
       ClawDesignTheme {
         Box(Modifier.fillMaxSize().testTag("settings-host")) {
-          SidebarNavigationShell(
-            drawerState = rememberDrawerState(initialValue = DrawerValue.Closed),
-            drawerContent = {},
-          ) {
-            SettingsDetailFrame(title = "Gateway", subtitle = "", icon = Icons.Default.Settings, onBack = {}) {
-              repeat(20) { index -> ClawTextField("Field $index", {}, "") }
-              ClawTextField("Unsubmitted draft", {}, "Password", modifier = Modifier.testTag("last-field"))
-              ClawPrimaryButton(text = "Save", onClick = {})
+          FoldAwareContent(features) {
+            Box(Modifier.fillMaxSize().testTag("settings-pane")) {
+              SidebarNavigationShell(
+                drawerState = rememberDrawerState(initialValue = DrawerValue.Closed),
+                drawerContent = {},
+              ) {
+                SettingsDetailFrame(title = "Gateway", subtitle = "", icon = Icons.Default.Settings, onBack = {}) {
+                  repeat(20) { index -> ClawTextField("Field $index", {}, "") }
+                  ClawTextField("Unsubmitted draft", {}, "Password", modifier = Modifier.testTag("last-field"))
+                  ClawPrimaryButton(text = "Save", onClick = {})
+                }
+              }
             }
           }
         }
@@ -1081,37 +1094,70 @@ class SettingsDetailInsetsTest {
     val density = view.resources.displayMetrics.density
     val navigationBottom = (24 * density).toInt()
     val keyboardBottom = (320 * density).toInt()
+    val hostBounds = composeRule.onNodeWithTag("settings-host").getUnclippedBoundsInRoot()
+    val windowOffset = IntArray(2).also(view::getLocationInWindow)
+    val top = (hostBounds.top.value * density).toInt() + windowOffset[1]
+    val left = (hostBounds.left.value * density).toInt() + windowOffset[0]
+    val bottom = (hostBounds.bottom.value * density).toInt() + windowOffset[1]
+    val right = (hostBounds.right.value * density).toInt() + windowOffset[0]
+    // Round toward the top/start pane when an odd pixel count prevents an exact tie.
+    val middleY = (top + bottom + 1) / 2
+    val middleX = (left + right + 1) / 2
+    val horizontal = listOf(testFold(Rect(left, middleY - 10, right, middleY + 10)))
+    val vertical = listOf(testFold(Rect(middleX - 10, top, middleX + 10, bottom)))
+    val postures = if (foldChanges) listOf(emptyList(), horizontal, vertical, emptyList()) else listOf(emptyList())
 
     // Deliver platform insets, rather than shrinking a fake viewport that would hide the defect.
-    for (imeBottom in listOf(0, keyboardBottom, 0)) {
-      composeRule.runOnIdle {
-        val insets =
-          WindowInsetsCompat
-            .Builder()
-            .setInsets(WindowInsetsCompat.Type.navigationBars(), Insets.of(0, 0, 0, navigationBottom))
-            .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, imeBottom))
-            .setVisible(WindowInsetsCompat.Type.ime(), imeBottom > 0)
-            .build()
-        ViewCompat.dispatchApplyWindowInsets(view, insets)
+    for (posture in postures) {
+      composeRule.runOnIdle { features = posture }
+      val stationaryPane = composeRule.onNodeWithTag("settings-pane").getUnclippedBoundsInRoot()
+      if (posture == horizontal) {
+        assertEquals(hostBounds.top, stationaryPane.top)
+        assertEquals(
+          "The upper pane must leave room for a keyboard that partially overlaps it",
+          (middleY - 10 - windowOffset[1]) / density,
+          stationaryPane.bottom.value,
+          1f / density,
+        )
       }
-      composeRule.waitForIdle()
-      composeRule.runOnIdle {
-        assertEquals("Compose must observe the delivered insets before geometry is judged", imeBottom to maxOf(navigationBottom, imeBottom), observedBottomInsets)
+      val keyboardSizes =
+        if (foldChanges) {
+          listOf(0, keyboardBottom, (hostBounds.height.value * density * 0.6f).toInt(), 0)
+        } else {
+          listOf(0, keyboardBottom, 0)
+        }
+      for (imeBottom in keyboardSizes) {
+        composeRule.runOnIdle {
+          val insets =
+            WindowInsetsCompat
+              .Builder()
+              .setInsets(WindowInsetsCompat.Type.navigationBars(), Insets.of(0, 0, 0, navigationBottom))
+              .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, imeBottom))
+              .setVisible(WindowInsetsCompat.Type.ime(), imeBottom > 0)
+              .build()
+          ViewCompat.dispatchApplyWindowInsets(view, insets)
+        }
+        composeRule.waitForIdle()
+        composeRule.runOnIdle {
+          assertEquals("Compose must observe the delivered insets before geometry is judged", imeBottom to maxOf(navigationBottom, imeBottom), observedBottomInsets)
+        }
+        composeRule.onNodeWithText("Save").performScrollTo()
+        val host = composeRule.onNodeWithTag("settings-host").getUnclippedBoundsInRoot()
+        val pane = composeRule.onNodeWithTag("settings-pane").getUnclippedBoundsInRoot()
+        val viewport = composeRule.onNode(hasScrollAction()).getUnclippedBoundsInRoot()
+        assertEquals("Keyboard visibility must not move or resize the selected pane", stationaryPane, pane)
+        val safeBottom = minOf(pane.bottom.value, host.bottom.value - maxOf(navigationBottom, imeBottom) / density)
+        assertEquals(
+          "Sidebar settings must consume the bottom inset once (IME=$imeBottom)",
+          safeBottom - settingsFrameBottomPadding.value,
+          viewport.bottom.value,
+          1f / density,
+        )
+        val button = composeRule.onNodeWithText("Save").getUnclippedBoundsInRoot()
+        val editor = composeRule.onNodeWithTag("last-field").getUnclippedBoundsInRoot()
+        org.junit.Assert.assertTrue("Save must be reachable", button.bottom <= viewport.bottom)
+        org.junit.Assert.assertTrue("Last field must be reachable with Save", editor.top >= viewport.top && editor.bottom <= viewport.bottom)
       }
-      composeRule.onNodeWithText("Save").performScrollTo()
-      val host = composeRule.onNodeWithTag("settings-host").getUnclippedBoundsInRoot()
-      val viewport = composeRule.onNode(hasScrollAction()).getUnclippedBoundsInRoot()
-      val remainingBottom = maxOf(navigationBottom, imeBottom) / density
-      assertEquals(
-        "Sidebar settings must consume the bottom inset once (IME=$imeBottom)",
-        host.bottom.value - remainingBottom - settingsFrameBottomPadding.value,
-        viewport.bottom.value,
-        1f / density,
-      )
-      val button = composeRule.onNodeWithText("Save").getUnclippedBoundsInRoot()
-      val editor = composeRule.onNodeWithTag("last-field").getUnclippedBoundsInRoot()
-      org.junit.Assert.assertTrue("Save must be reachable", button.bottom <= viewport.bottom)
-      org.junit.Assert.assertTrue("Last field must be reachable with Save", editor.top >= viewport.top && editor.bottom <= viewport.bottom)
     }
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/WindowLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/WindowLayoutTest.kt
@@ -1,0 +1,102 @@
+package ai.openclaw.app.ui
+
+import android.graphics.Rect
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.window.layout.FoldingFeature
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WindowLayoutTest {
+  private val host = IntRect(0, 0, 1000, 800)
+
+  @Test
+  fun absentOutsideAndNonSeparatingFeaturesPreserveTheWholeHost() {
+    for (features in listOf(
+      emptyList(),
+      listOf(testFold(Rect(1100, 0, 1120, 800))),
+      listOf(testFold(Rect(0, 900, 1000, 920))),
+      listOf(testFold(Rect(1000, 0, 1000, 800))),
+      listOf(testFold(Rect(500, 0, 500, 800), separating = false, state = FoldingFeature.State.FLAT)),
+    )) {
+      assertEquals(host, foldSafeRegion(host, features, LayoutDirection.Ltr))
+    }
+  }
+
+  @Test
+  fun hingeBoundsDetermineTheLargestRegionIncludingFlatAndZeroThicknessSeparators() {
+    val cases =
+      listOf(
+        testFold(Rect(490, 0, 510, 800)) to IntRect(0, 0, 490, 800),
+        testFold(Rect(0, 390, 1000, 410)) to IntRect(0, 0, 1000, 390),
+        testFold(Rect(200, 0, 220, 800)) to IntRect(220, 0, 1000, 800),
+        testFold(Rect(0, 200, 1000, 230)) to IntRect(0, 230, 1000, 800),
+        testFold(Rect(500, 0, 500, 800)) to IntRect(0, 0, 500, 800),
+        testFold(Rect(0, 400, 1000, 400)) to IntRect(0, 0, 1000, 400),
+        testFold(Rect(490, 0, 510, 800), state = FoldingFeature.State.FLAT) to IntRect(0, 0, 490, 800),
+        testFold(Rect(200, 0, 230, 800), separating = false, occlusion = FoldingFeature.OcclusionType.FULL) to IntRect(230, 0, 1000, 800),
+      )
+    for ((fold, expected) in cases) {
+      assertEquals("Feature ${fold.bounds}", expected, foldSafeRegion(host, listOf(fold), LayoutDirection.Ltr))
+    }
+  }
+
+  @Test
+  fun tiesPreferTopThenLogicalStartWithoutMirroringPhysicalBounds() {
+    val vertical = listOf(testFold(Rect(490, 0, 510, 800)))
+    assertEquals(IntRect(510, 0, 1000, 800), foldSafeRegion(host, vertical, LayoutDirection.Rtl))
+    val horizontal = listOf(testFold(Rect(0, 390, 1000, 410)))
+    assertEquals(IntRect(0, 0, 1000, 390), foldSafeRegion(host, horizontal, LayoutDirection.Rtl))
+  }
+
+  @Test
+  fun translatedHostsIntersectActualFeatureBoundsIncludingPartialEnds() {
+    val translated = IntRect(100, 200, 1100, 1000)
+    assertEquals(
+      IntRect(620, 200, 1100, 1000),
+      foldSafeRegion(translated, listOf(testFold(Rect(580, 0, 620, 1200))), LayoutDirection.Rtl),
+    )
+    assertEquals(
+      IntRect(100, 300, 1100, 1000),
+      foldSafeRegion(translated, listOf(testFold(Rect(580, 0, 620, 300))), LayoutDirection.Ltr),
+    )
+    assertEquals(
+      translated,
+      foldSafeRegion(translated, listOf(testFold(Rect(580, 0, 620, 190))), LayoutDirection.Ltr),
+    )
+  }
+
+  @Test
+  fun laterSeparatorsCanMakeTheInitiallySmallerRegionWin() {
+    val folds =
+      listOf(
+        testFold(Rect(400, 0, 420, 800)),
+        testFold(Rect(650, 0, 670, 800)),
+        testFold(Rect(800, 0, 820, 800)),
+      )
+    for (order in listOf(folds, folds.reversed(), listOf(folds[1], folds[0], folds[2]))) {
+      assertEquals(IntRect(0, 0, 400, 800), foldSafeRegion(host, order, LayoutDirection.Ltr))
+    }
+    val cross = listOf(testFold(Rect(490, 0, 510, 800)), testFold(Rect(0, 300, 1000, 320)))
+    assertEquals(IntRect(0, 320, 490, 800), foldSafeRegion(host, cross, LayoutDirection.Ltr))
+    assertEquals(IntRect(510, 320, 1000, 800), foldSafeRegion(host, cross.reversed(), LayoutDirection.Rtl))
+  }
+}
+
+internal fun testFold(
+  bounds: Rect,
+  separating: Boolean = true,
+  occlusion: FoldingFeature.OcclusionType = FoldingFeature.OcclusionType.NONE,
+  state: FoldingFeature.State = FoldingFeature.State.HALF_OPENED,
+): FoldingFeature =
+  object : FoldingFeature {
+    override val bounds = Rect(bounds)
+    override val isSeparating = separating
+    override val occlusionType = occlusion
+    override val state = state
+    override val orientation =
+      if (bounds.width() > bounds.height()) FoldingFeature.Orientation.HORIZONTAL else FoldingFeature.Orientation.VERTICAL
+  }

--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ androidx-wear-compose = "1.6.2"
 androidx-wear-input = "1.2.0"
 androidx-wear-protolayout = "1.4.2"
 androidx-wear-tiles = "1.6.2"
+androidx-window = "1.5.1"
 bcprov = "1.85.2"
 commonmark = "0.30.0"
 coil = "3.6.1"
@@ -71,6 +72,7 @@ androidx-wear-input = { module = "androidx.wear:wear-input", version.ref = "andr
 androidx-wear-protolayout = { module = "androidx.wear.protolayout:protolayout", version.ref = "androidx-wear-protolayout" }
 androidx-wear-protolayout-material = { module = "androidx.wear.protolayout:protolayout-material3", version.ref = "androidx-wear-protolayout" }
 androidx-wear-tiles = { module = "androidx.wear.tiles:tiles", version.ref = "androidx-wear-tiles" }
+androidx-window = { module = "androidx.window:window", version.ref = "androidx-window" }
 bcprov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bcprov" }
 barcode-scanning = { module = "com.google.mlkit:barcode-scanning", version.ref = "barcode-scanning" }
 commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users encounter chat, onboarding, and navigation controls crossing a separating fold or fully occluding hinge.

## Why This Change Was Made

Observe AndroidX WindowManager layout features for the current Activity and constrain the existing screen to the largest hinge-free region. The screen keeps one composition while the window changes, with pane-relative system and keyboard insets.

This is a foundation, not complete foldable UX: the other region is temporarily unused. Purposeful book-mode navigation/content panes, tabletop transcript/composer placement, short-height composer improvements, and separate-window dialogs are separate work. Ordinary windows retain the existing layout.

## User Impact

Onboarding, navigation, settings, and chat content no longer straddle a reported separating hinge. Drafts, focus, and the current route survive supported live layout changes. The unused region follows the app theme.

No device-model assumptions, manifest/configuration-change changes, storage changes, or audio lifecycle changes.

## Evidence

- Android API 36 Pixel Fold emulator, real Gboard, synthetic screenshot-mode content. A retained unsent draft is visible before and after the book-mode change.
- 16 focused tests passed: geometry (including zero-width, off-center, horizontal/vertical, translated hosts, RTL, and multiple separators), real root integration, Activity lifecycle, keyboard insets, and license inventory.
- A negative integration witness with only the root fold host removed failed on a live onboarding control crossing the hinge. Restoring the host passed.
- After the theme-background amendment, all 4 root/host tests passed again, along with ordinary Kotlin lint and the debug APK build.
- `check:changed` passed for all 12 changed files, including mobile guards, dependency pins, Android module lint, and the native state schema check. Two scoped reviews found no actionable P2-or-higher issues.
- Hosted CI caught a test-only eager offset lint error. The correction uses Compose's placement-phase offset API without changing assertions or production code; the moving-host test, `lintPlayDebug`, changed-file checks, and a scoped review passed locally. Fresh exact-head CI is required.
- Final emulator APK SHA-256: `8b2b579c2ae869a6b6fc44c4bdf7c4f7c2b09e31dc5c52d725510403775732a3`.
- The APK reused unchanged Mermaid assets from the successful baseline build; it did not regenerate them. Hosted exact-head CI remains the landing gate.

### Before

Book posture leaves the screen and composer spanning the fold.

![Before: chat and keyboard span the book-mode fold](https://github.com/user-attachments/assets/c88d755b-5b94-4470-8b8e-c6ef74c261ba)

### After

The same draft remains visible in one hinge-free pane. The second pane is deliberately unused in this foundation.

![After: retained draft and composer stay within one book-mode pane](https://github.com/user-attachments/assets/2302bb10-a855-46a7-8365-1a2cbbdb65ef)

These captures are emulator approximations, not physical-device certification. The separate closed-landscape editor-height defect is not claimed fixed here.
