### PR TITLE
fix: pure Claude CLI runs are missing from trajectory exports

### DIFF
--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -47,7 +47,6 @@ import {
   resolveCliSourceReplyMirror,
   settleCliBackendOutcome,
   settleCliPreparationError,
-  settlePreparedCliRun,
 } from "./cli-runner/cli-run-settlement.js";
 import {
   buildCliHookAssistantMessage,
@@ -73,6 +72,7 @@ import {
   loadCliSessionContextEngineMessages,
   loadCliSessionHistoryMessages,
 } from "./cli-runner/session-history.js";
+import type { CliTrajectoryRecorder } from "./cli-runner/trajectory.js";
 import type { PreparedCliRunContext, RunCliAgentParams } from "./cli-runner/types.js";
 import { claudeCliSessionTranscriptHasContent as claudeCliSessionTranscriptHasContentImpl } from "./command/attempt-execution.helpers.js";
 import type { EmbeddedAgentRunResult } from "./embedded-agent-runner.js";
@@ -236,25 +236,24 @@ async function runCliAgentInternal(
     await settleCliPreparationError(error, params);
     throw error;
   }
-  return await settlePreparedCliRun({
-    context,
-    diagnosticLifecycle,
-    run: async () => await runPreparedCliAgent(context, diagnosticLifecycle),
-  });
+  const { settlePreparedCliRunWithTrajectory } = await import("./cli-runner/trajectory.js");
+  return await settlePreparedCliRunWithTrajectory(context, diagnosticLifecycle);
 }
 
 /** Runs an already-prepared CLI agent context through hooks and execution. */
 export async function runPreparedCliAgent(
   context: PreparedCliRunContext,
   diagnosticLifecycle?: ClaudeCliRunDiagnosticLifecycle,
+  trajectoryRecorder?: CliTrajectoryRecorder,
 ): Promise<EmbeddedAgentRunResult> {
-  const run = () => runPreparedCliAgentOwned(context, diagnosticLifecycle);
+  const run = () => runPreparedCliAgentOwned(context, diagnosticLifecycle, trajectoryRecorder);
   return await runWithCliHistoryWriter(context.cliHistoryWriter, run);
 }
 
 async function runPreparedCliAgentOwned(
   context: PreparedCliRunContext,
   diagnosticLifecycle?: ClaudeCliRunDiagnosticLifecycle,
+  trajectoryRecorder?: CliTrajectoryRecorder,
 ): Promise<EmbeddedAgentRunResult> {
   const { executePreparedCliRun } = await import("./cli-runner/execute.runtime.js");
   const { params } = context;
@@ -388,11 +387,11 @@ async function runPreparedCliAgentOwned(
             },
           };
     diagnosticLifecycle?.setPhase("send");
-    const output = await executePreparedCliRun(
-      attemptContext,
-      cliSessionIdToUse,
-      diagnosticLifecycle ? { onPhase: diagnosticLifecycle.setPhase } : undefined,
-    );
+    const executeOptions =
+      diagnosticLifecycle || trajectoryRecorder
+        ? { onPhase: diagnosticLifecycle?.setPhase, trajectoryRecorder }
+        : undefined;
+    const output = await executePreparedCliRun(attemptContext, cliSessionIdToUse, executeOptions);
     // Test facades and non-instrumented executors may not signal the boundary.
     diagnosticLifecycle?.setPhase("resolve");
     const sourceReplyMirror = resolveCliSourceReplyMirror({

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -236,8 +236,8 @@ async function runCliAgentInternal(
     await settleCliPreparationError(error, params);
     throw error;
   }
-  const { settlePreparedCliRunWithTrajectory } = await import("./cli-runner/trajectory.js");
-  return await settlePreparedCliRunWithTrajectory(context, diagnosticLifecycle);
+  const { settlePreparedCliRunWithTrajectory: settle } = await import("./cli-runner/trajectory.js");
+  return await settle(context, diagnosticLifecycle, runPreparedCliAgent);
 }
 
 /** Runs an already-prepared CLI agent context through hooks and execution. */

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -68,6 +68,11 @@ import {
 } from "./log.js";
 import { createClaudeCliModelCallDiagnostics } from "./model-call-diagnostics.js";
 import { composeCliPromptContext } from "./prompt-context.js";
+import {
+  recordCliModelCompleted,
+  recordCliTrajectoryEvent,
+  type CliTrajectoryRecorder,
+} from "./trajectory.js";
 import type { PreparedCliRunContext } from "./types.js";
 
 function normalizeCliBackendThinkingLevel(
@@ -122,6 +127,7 @@ function assertExactToolAvailabilityRuntimeVersion(params: {
 
 type ExecutePreparedCliRunOptions = {
   onPhase?: (phase: "send" | "resolve" | "cleanup") => void;
+  trajectoryRecorder?: CliTrajectoryRecorder;
 };
 
 type PreparedCliRunInternalParams = PreparedCliRunContext["params"] & {
@@ -574,6 +580,11 @@ export async function executePreparedCliRun(
       if (!useManagedClaudeLiveSession) {
         toolTracking.beginGatewayCapture(initialGatewayCaptureKey);
       }
+      recordCliTrajectoryEvent(options?.trajectoryRecorder ?? null, "prompt.submitted", {
+        prompt: composeCliPromptContext(prompt, promptContext),
+        systemPrompt: systemPromptArg ?? undefined,
+        imagesCount: imagePayload.imagePaths?.length ?? 0,
+      });
       runOutput = await executeCliProcess({
         context,
         assertCurrent,
@@ -709,5 +720,6 @@ export async function executePreparedCliRun(
   // Success stays provisional until persistence and cleanup finish; otherwise
   // a rejected turn would be exported as completed.
   diagnostics?.emitCompleted(completedOutput);
+  recordCliModelCompleted(options?.trajectoryRecorder ?? null, completedOutput);
   return completedOutput;
 }

--- a/src/agents/cli-runner/trajectory.test.ts
+++ b/src/agents/cli-runner/trajectory.test.ts
@@ -1,0 +1,274 @@
+/** CLI trajectory proof uses real child processes and the canonical SQLite store. */
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import path from "node:path";
+import { text } from "node:stream/consumers";
+import { afterEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import * as trajectoryMetadata from "../../trajectory/metadata.js";
+import { loadSqliteTrajectoryRuntimeEvents } from "../../trajectory/runtime-store.sqlite.js";
+import { prepareSystemAgentRunAdmission } from "../admitted-run-context.js";
+import { runCliAgent as runCliAgentImpl } from "../cli-runner.js";
+import { buildPreparedCliRunContext } from "../cli-runner.test-helpers.js";
+import { FailoverError } from "../failover-error.js";
+import type { RunCliAgentParams } from "./types.js";
+
+const { prepareContext } = vi.hoisted(() => ({ prepareContext: vi.fn() }));
+// Replace credential/plugin discovery only; runner, recovery, executor, and SQLite stay real.
+vi.mock("./prepare.runtime.js", () => ({ prepareCliRunContext: prepareContext }));
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+async function runCliAgent(params: RunCliAgentParams) {
+  const admission = prepareSystemAgentRunAdmission({}, params.runId, "main", "trajectory-fixture");
+  try {
+    return await runCliAgentImpl({
+      ...params,
+      admittedRunContext: await admission.admit("embedded"),
+    });
+  } finally {
+    admission.close();
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  prepareContext.mockReset();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+async function fixture(
+  options: {
+    fail?: boolean;
+    disabled?: boolean;
+    recover?: boolean;
+    abortKind?: "manual" | "timeout";
+  } = {},
+) {
+  vi.stubEnv("OPENCLAW_TRAJECTORY", options.disabled ? "0" : "1");
+  const root = tempDirs.make("openclaw-cli-trajectory-");
+  const target = {
+    agentId: "main",
+    sessionId: "openclaw-session",
+    sessionKey: "agent:main:trajectory",
+    storePath: path.join(root, "agents", "main", "sessions", "sessions.json"),
+  };
+  await replaceSessionEntry(target, { sessionId: target.sessionId, updatedAt: 1 });
+  const abortController = options.abortKind ? new AbortController() : undefined;
+  const script = options.abortKind
+    ? "setTimeout(() => {}, 30_000)"
+    : options.fail
+      ? 'process.stderr.write("fixture process failed"); process.exitCode = 1'
+      : options.recover
+        ? 'if (process.env.FIXTURE_SESSION === "stale-session") { process.stderr.write("fixture session expired"); process.exitCode = 1; } else { process.stdout.write("fixture reply"); }'
+        : 'process.stdout.write("fixture reply")';
+  const context = buildPreparedCliRunContext({
+    sessionTarget: target,
+    workspaceDir: root,
+    runId: "trajectory-run",
+    prompt: "Explain the fixture",
+    timeoutMs: 10_000,
+    backend: {
+      command: process.execPath,
+      args: ["-e", script],
+      ...(options.recover ? { resumeArgs: ["-e", script] } : {}),
+      modelArg: undefined,
+      sessionArgs: undefined,
+      systemPromptFileArg: undefined,
+      sessionMode: "existing",
+      input: "stdin",
+    },
+  });
+  context.backendResolved.bundleMcp = false;
+  if (abortController) {
+    context.params.abortSignal = abortController.signal;
+  }
+  if (options.recover) {
+    context.reusableCliSession = { mode: "reuse", sessionId: "stale-session" };
+    context.openClawHistoryPrompt = "Earlier history\nExplain the fixture";
+  }
+  context.executionTarget = {
+    kind: "plugin",
+    async *execute(execution) {
+      const child = spawn(execution.command, execution.args, {
+        cwd: execution.cwd,
+        // The fixture needs no credentials or external services.
+        env: { FIXTURE_SESSION: execution.sessionId ?? "" },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const abortSignal = execution.abortSignal;
+      const abortChild = () => child.kill();
+      abortSignal?.addEventListener("abort", abortChild, { once: true });
+      if (abortController) {
+        queueMicrotask(() => {
+          if (options.abortKind === "timeout") {
+            const timeout = new Error("fixture deadline exceeded");
+            timeout.name = "TimeoutError";
+            abortController.abort(timeout);
+          } else {
+            abortController.abort();
+          }
+        });
+      }
+      const [[code], stdout, stderr] = await Promise.all([
+        once(child, "close"),
+        text(child.stdout),
+        text(child.stderr),
+      ]).finally(() => abortSignal?.removeEventListener("abort", abortChild));
+      if (code !== 0) {
+        if (options.recover) {
+          throw new FailoverError(stderr, { reason: "session_expired", provider: "claude-cli" });
+        }
+        throw new Error(stderr || `Fixture exited with code ${code}`);
+      }
+      yield { type: "result", subtype: "success", result: stdout };
+    },
+  };
+  prepareContext.mockImplementation(async (params: RunCliAgentParams) => ({ ...context, params }));
+  return {
+    context,
+    events: () => loadSqliteTrajectoryRuntimeEvents(target),
+  };
+}
+
+it("persists a complete CLI turn in SQLite before resolving", async () => {
+  const { context, events } = await fixture();
+  await expect(runCliAgent(context.params)).resolves.toMatchObject({
+    payloads: [{ text: "fixture reply" }],
+  });
+  const recorded = await events();
+  expect(recorded.map((event) => event.type)).toEqual([
+    "session.started",
+    "trace.metadata",
+    "prompt.submitted",
+    "model.completed",
+    "session.ended",
+  ]);
+  expect(recorded.find((event) => event.type === "prompt.submitted")?.data).toMatchObject({
+    prompt: "Explain the fixture",
+  });
+  expect(recorded.find((event) => event.type === "model.completed")?.data).toMatchObject({
+    assistantTexts: ["fixture reply"],
+    stopReason: "completed",
+  });
+  expect(recorded.at(-1)?.data).toMatchObject({ status: "success" });
+  expect(recorded.every((event) => event.sessionId === "openclaw-session")).toBe(true);
+});
+
+it("captures transformed prompt context at the CLI dispatch boundary", async () => {
+  const { context, events } = await fixture();
+  context.backendResolved.textTransforms = { input: [{ from: "fixture", to: "example" }] };
+  context.promptContext = { prependContext: "fixture guidance", appendContext: "fixture reminder" };
+  await runCliAgent(context.params);
+  expect((await events()).find((event) => event.type === "prompt.submitted")?.data).toMatchObject({
+    prompt: "example guidance\n\nExplain the example\n\nexample reminder",
+  });
+});
+
+it("still executes and cleans up when trajectory metadata capture fails", async () => {
+  const { context, events } = await fixture();
+  vi.spyOn(trajectoryMetadata, "buildTrajectoryRunMetadata").mockImplementationOnce(() => {
+    throw new Error("fixture metadata failure");
+  });
+  let cleanedUp = false;
+  context.preparedBackend.cleanup = async () => {
+    cleanedUp = true;
+  };
+  await expect(runCliAgent(context.params)).resolves.toMatchObject({
+    payloads: [{ text: "fixture reply" }],
+  });
+  expect(cleanedUp).toBe(true);
+  expect(await events()).toEqual([]);
+});
+
+it("does not persist isolated completion into a borrowed session target", async () => {
+  const { context, events } = await fixture();
+  context.params.isolatedCompletion = true;
+  await expect(runCliAgent(context.params)).resolves.toMatchObject({
+    payloads: [{ text: "fixture reply" }],
+  });
+  expect(await events()).toEqual([]);
+});
+
+it("flushes a terminal CLI process failure without reporting completion", async () => {
+  const { context, events } = await fixture({ fail: true });
+  await expect(runCliAgent(context.params)).rejects.toThrow("fixture process failed");
+  const recorded = await events();
+  expect(recorded.map((event) => event.type)).toEqual([
+    "session.started",
+    "trace.metadata",
+    "prompt.submitted",
+    "session.ended",
+  ]);
+  expect(recorded.at(-1)?.data).toMatchObject({
+    status: "error",
+    promptError: "fixture process failed",
+  });
+});
+
+it.each([
+  { abortKind: "manual" as const, timedOut: false },
+  { abortKind: "timeout" as const, timedOut: true },
+])("distinguishes $abortKind cancellation in the final trajectory event", async (testCase) => {
+  const { context, events } = await fixture({ abortKind: testCase.abortKind });
+  await expect(runCliAgent(context.params)).rejects.toMatchObject({ name: "AbortError" });
+  expect((await events()).at(-1)).toMatchObject({
+    type: "session.ended",
+    data: {
+      status: "interrupted",
+      aborted: true,
+      timedOut: testCase.timedOut,
+    },
+  });
+});
+
+it("leaves trajectory disabled while still executing the CLI", async () => {
+  const { context, events } = await fixture({ disabled: true });
+  await expect(runCliAgent(context.params)).resolves.toMatchObject({
+    payloads: [{ text: "fixture reply" }],
+  });
+  expect(await events()).toEqual([]);
+});
+
+it("records both retry prompts but ends a recovered CLI turn only once", async () => {
+  const { context, events } = await fixture({ recover: true });
+  await expect(runCliAgent(context.params)).resolves.toMatchObject({
+    payloads: [{ text: "fixture reply" }],
+  });
+  const recorded = await events();
+  expect(recorded.map((event) => event.type)).toEqual([
+    "session.started",
+    "trace.metadata",
+    "prompt.submitted",
+    "prompt.submitted",
+    "model.completed",
+    "session.ended",
+  ]);
+  expect(
+    recorded
+      .filter((event) => event.type === "prompt.submitted")
+      .map((event) => event.data?.prompt),
+  ).toEqual(["Explain the fixture", "Earlier history\nExplain the fixture"]);
+  expect(recorded.at(-1)?.data).toMatchObject({ status: "success" });
+});
+
+it("records cleanup failure as the final outcome after successful CLI output", async () => {
+  const { context, events } = await fixture();
+  context.preparedBackend.cleanup = async () => {
+    throw new Error("fixture cleanup failed");
+  };
+  await expect(runCliAgent(context.params)).rejects.toThrow("fixture cleanup failed");
+  const recorded = await events();
+  expect(recorded.find((event) => event.type === "model.completed")?.data).toMatchObject({
+    assistantTexts: ["fixture reply"],
+  });
+  expect(recorded.filter((event) => event.type === "session.ended")).toHaveLength(1);
+  expect(recorded.at(-1)?.data).toMatchObject({
+    status: "error",
+    promptError: "fixture cleanup failed",
+  });
+});

--- a/src/agents/cli-runner/trajectory.ts
+++ b/src/agents/cli-runner/trajectory.ts
@@ -88,7 +88,7 @@ function prepareCliTrajectory(context: PreparedCliRunContext): CliTrajectoryReco
   return recorder;
 }
 
-export async function withCliRunTrajectory(
+async function withCliRunTrajectory(
   context: PreparedCliRunContext,
   run: (recorder: CliTrajectoryRecorder) => Promise<EmbeddedAgentRunResult>,
 ): Promise<EmbeddedAgentRunResult> {

--- a/src/agents/cli-runner/trajectory.ts
+++ b/src/agents/cli-runner/trajectory.ts
@@ -1,0 +1,164 @@
+/** Owns one durable trajectory across CLI recovery and final settlement. */
+import { isAbortError } from "../../infra/abort-signal.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { buildTrajectoryRunMetadata } from "../../trajectory/metadata.js";
+import { createTrajectoryRuntimeRecorder } from "../../trajectory/runtime.js";
+import type { CliOutput } from "../cli-output-contracts.js";
+import type { EmbeddedAgentRunResult } from "../embedded-agent-runner.js";
+import { isFailoverError, isSignalTimeoutReason } from "../failover-error.js";
+import { runAgentCleanupStep } from "../run-cleanup-timeout.js";
+import { settlePreparedCliRun } from "./cli-run-settlement.js";
+import { cliBackendLog } from "./log.js";
+import type { ClaudeCliRunDiagnosticLifecycle } from "./run-diagnostics.js";
+import type { PreparedCliRunContext } from "./types.js";
+
+export type CliTrajectoryRecorder = ReturnType<typeof createTrajectoryRuntimeRecorder>;
+
+export function recordCliTrajectoryEvent(
+  recorder: CliTrajectoryRecorder,
+  type: string,
+  data?: Record<string, unknown>,
+): void {
+  try {
+    recorder?.recordEvent(type, data);
+  } catch (error) {
+    cliBackendLog.warn(
+      `cli trajectory event failed: type=${type} error=${formatErrorMessage(error)}`,
+    );
+  }
+}
+
+export function recordCliModelCompleted(recorder: CliTrajectoryRecorder, output: CliOutput): void {
+  recordCliTrajectoryEvent(recorder, "model.completed", {
+    assistantTexts: output.text ? [output.text] : [],
+    usage: output.usage,
+    finalPromptText: output.finalPromptText,
+    stopReason: output.terminalInterruption?.reason ?? (output.yielded ? "end_turn" : "completed"),
+  });
+}
+
+function prepareCliTrajectory(context: PreparedCliRunContext): CliTrajectoryRecorder {
+  // Preparation removes borrowed durable identity from caller-owned helper sessions.
+  const { params } = context;
+  const recorder =
+    params.isolatedCompletion || params.controlOperation || params.sessionManager
+      ? null
+      : createTrajectoryRuntimeRecorder({
+          cfg: params.config,
+          runId: params.runId,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          sessionFile: params.sessionFile,
+          sessionTarget: params.sessionTarget,
+          provider: params.provider,
+          modelId: context.modelId,
+          workspaceDir: context.workspaceDir,
+        });
+  if (!recorder) {
+    return null;
+  }
+  recordCliTrajectoryEvent(recorder, "session.started", {
+    trigger: params.trigger,
+    sessionFile: params.sessionFile,
+    workspaceDir: context.workspaceDir,
+    agentId: params.agentId,
+    messageProvider: params.messageProvider,
+    messageChannel: params.messageChannel,
+  });
+  recordCliTrajectoryEvent(
+    recorder,
+    "trace.metadata",
+    buildTrajectoryRunMetadata({
+      config: params.config,
+      workspaceDir: context.workspaceDir,
+      sessionFile: params.sessionFile,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      trigger: params.trigger,
+      messageProvider: params.messageProvider,
+      messageChannel: params.messageChannel,
+      provider: params.provider,
+      modelId: context.modelId,
+      timeoutMs: params.timeoutMs,
+      thinkLevel: params.thinkLevel,
+      skillsSnapshot: params.skillsSnapshot,
+      systemPromptReport: context.systemPromptReport,
+    }),
+  );
+  return recorder;
+}
+
+export async function withCliRunTrajectory(
+  context: PreparedCliRunContext,
+  run: (recorder: CliTrajectoryRecorder) => Promise<EmbeddedAgentRunResult>,
+): Promise<EmbeddedAgentRunResult> {
+  const { params } = context;
+  let recorder: CliTrajectoryRecorder = null;
+  try {
+    recorder = prepareCliTrajectory(context);
+  } catch (error) {
+    // Observability setup must not prevent the prepared backend from reaching cleanup.
+    cliBackendLog.warn(`cli trajectory setup failed: ${formatErrorMessage(error)}`);
+  }
+  if (!recorder) {
+    return await run(null);
+  }
+  let result: EmbeddedAgentRunResult | undefined;
+  let failed = false;
+  let runError: unknown;
+  try {
+    result = await run(recorder);
+    return result;
+  } catch (error) {
+    failed = true;
+    runError = error;
+    throw error;
+  } finally {
+    const stopReason = result?.meta.completion?.stopReason ?? result?.meta.stopReason;
+    const timedOut =
+      stopReason === "timeout" ||
+      (isFailoverError(runError) && runError.reason === "timeout") ||
+      (failed &&
+        params.abortSignal?.aborted === true &&
+        isSignalTimeoutReason(params.abortSignal.reason));
+    const aborted = result?.meta.aborted === true || isAbortError(runError);
+    const terminalAttempt = result?.meta.executionTrace?.attempts?.at(-1);
+    const status =
+      timedOut || aborted
+        ? "interrupted"
+        : failed || result?.meta.error || terminalAttempt?.result === "error"
+          ? "error"
+          : "success";
+    recordCliTrajectoryEvent(recorder, "session.ended", {
+      status,
+      aborted,
+      timedOut,
+      stopReason,
+      promptError: failed ? formatErrorMessage(runError) : undefined,
+      terminalError:
+        result?.meta.error?.message ?? (status === "error" ? terminalAttempt?.reason : undefined),
+    });
+    await runAgentCleanupStep({
+      runId: params.runId,
+      sessionId: params.sessionId,
+      step: "openclaw-trajectory-flush",
+      log: cliBackendLog,
+      getTimeoutDetails: () => recorder.describeFlushState(),
+      cleanup: () => recorder.flush(),
+    });
+  }
+}
+
+export async function settlePreparedCliRunWithTrajectory(
+  context: PreparedCliRunContext,
+  diagnosticLifecycle?: ClaudeCliRunDiagnosticLifecycle,
+): Promise<EmbeddedAgentRunResult> {
+  const { runPreparedCliAgent } = await import("../cli-runner.js");
+  return await withCliRunTrajectory(context, (trajectoryRecorder) =>
+    settlePreparedCliRun({
+      context,
+      diagnosticLifecycle,
+      run: async () => await runPreparedCliAgent(context, diagnosticLifecycle, trajectoryRecorder),
+    }),
+  );
+}

--- a/src/agents/cli-runner/trajectory.ts
+++ b/src/agents/cli-runner/trajectory.ts
@@ -13,6 +13,11 @@ import type { ClaudeCliRunDiagnosticLifecycle } from "./run-diagnostics.js";
 import type { PreparedCliRunContext } from "./types.js";
 
 export type CliTrajectoryRecorder = ReturnType<typeof createTrajectoryRuntimeRecorder>;
+type PreparedCliRunner = (
+  context: PreparedCliRunContext,
+  diagnosticLifecycle?: ClaudeCliRunDiagnosticLifecycle,
+  recorder?: CliTrajectoryRecorder,
+) => Promise<EmbeddedAgentRunResult>;
 
 export function recordCliTrajectoryEvent(
   recorder: CliTrajectoryRecorder,
@@ -151,14 +156,14 @@ async function withCliRunTrajectory(
 
 export async function settlePreparedCliRunWithTrajectory(
   context: PreparedCliRunContext,
-  diagnosticLifecycle?: ClaudeCliRunDiagnosticLifecycle,
+  diagnosticLifecycle: ClaudeCliRunDiagnosticLifecycle | undefined,
+  runPrepared: PreparedCliRunner,
 ): Promise<EmbeddedAgentRunResult> {
-  const { runPreparedCliAgent } = await import("../cli-runner.js");
   return await withCliRunTrajectory(context, (trajectoryRecorder) =>
     settlePreparedCliRun({
       context,
       diagnosticLifecycle,
-      run: async () => await runPreparedCliAgent(context, diagnosticLifecycle, trajectoryRecorder),
+      run: async () => await runPrepared(context, diagnosticLifecycle, trajectoryRecorder),
     }),
   );
 }


### PR DESCRIPTION
Closes #80667

## What Problem This Solves

Fixes an issue where operators using pure Claude CLI sessions would have no persisted runtime trajectory rows, so trajectory exports and post-mortem tooling could omit otherwise successful runs unless provider fallback occurred.

## Why This Change Was Made

This reuses the existing SQLite-backed trajectory recorder around the complete prepared CLI lifecycle. It records the transformed prompt at the actual dispatch boundary, completion after executor cleanup, and one terminal outcome after recovery and settlement.

Isolated completions, control operations, and caller-owned session managers remain excluded. Recorder setup, event, and flush failures do not replace the CLI run's own outcome. No legacy JSONL sidecar is restored.

## User Impact

Operators can inspect and export trajectory evidence for successful pure Claude CLI runs using the same canonical storage as sibling runtimes. CLI authentication, session reuse, fallback selection, and response behavior are unchanged.

## Evidence

- Added an integration test using a real Node child process and the canonical SQLite store; credential and plugin discovery are the only mocked boundaries.
- The 10 cases cover success, transformed prompts, recorder setup failure, isolated completion, process failure, manual cancellation, timeout cancellation, disabled capture, session-expired recovery, and cleanup failure.
- `pnpm exec vitest run src/agents/cli-runner.context-engine.test.ts src/agents/cli-runner.interrupted-partial-output.test.ts src/agents/cli-runner/trajectory.test.ts src/agents/cli-runner/execute.executable-invocation.test.ts` — 36 passed.
- `pnpm test src/trajectory/runtime.test.ts` — 22 passed.
- Production tsgo and all 16 changed-path core test type graphs passed.
- Changed-files type-aware oxlint and formatting passed.
- `pnpm build` passed.
- `git diff --check` passed.