### PR TITLE
refactor(daemon): remove redundant LaunchAgent plist facade

### DIFF
--- a/src/daemon/launchd-service-files.ts
+++ b/src/daemon/launchd-service-files.ts
@@ -3,11 +3,11 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { normalizeEnvVarKey } from "../infra/host-env-security.js";
-import { GATEWAY_LAUNCH_AGENT_LABEL, resolveGatewayServiceDescription } from "./constants.js";
+import { resolveGatewayServiceDescription } from "./constants.js";
 import { resolveLaunchAgentLabel } from "./launchd-label.js";
 import {
   LAUNCH_AGENT_ENV_WRAPPER_SHELL,
-  buildLaunchAgentPlist as buildLaunchAgentPlistImpl,
+  buildLaunchAgentPlist,
   quoteLaunchAgentEnvironmentValue,
   readLaunchAgentProgramArgumentsFromFile,
 } from "./launchd-plist.js";
@@ -198,33 +198,6 @@ export function resolveLaunchAgentEnvironmentReadOptions(env: GatewayServiceEnv,
   };
 }
 
-function buildLaunchAgentPlist({
-  label = GATEWAY_LAUNCH_AGENT_LABEL,
-  comment,
-  programArguments,
-  workingDirectory,
-  stdoutPath,
-  stderrPath,
-  environment,
-}: {
-  label?: string;
-  comment?: string;
-  programArguments: string[];
-  workingDirectory?: string;
-  stdoutPath: string;
-  stderrPath: string;
-  environment?: Record<string, string | undefined>;
-}): string {
-  return buildLaunchAgentPlistImpl({
-    label,
-    comment,
-    programArguments,
-    workingDirectory,
-    stdoutPath,
-    stderrPath,
-    environment,
-  });
-}
 async function ensureLaunchAgentPlistReadable(plistPath: string): Promise<void> {
   await fs.chmod(plistPath, LAUNCH_AGENT_PLIST_MODE).catch(() => undefined);
 }


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested lifecycle de-duplication: LaunchAgent installation and restart rewriting carry a private forwarding facade that repeats the canonical plist renderer's argument contract. Its only added behavior is a default label that neither caller uses.

## Why This Change Was Made

Call `buildLaunchAgentPlist` from `src/daemon/launchd-plist.ts` directly and remove the unused facade and default-label import. Both callers continue supplying their resolved labels. Native ownership checks, environment-file handling, atomic publication, and rollback stay with the service-file owner.

## User Impact

No user-visible behavior or public API change. Production code shrinks by 27 lines; existing tests are retained.

## Evidence

- `node scripts/run-vitest.mjs src/daemon/launchd.test.ts src/daemon/launchd-plist.test.ts src/daemon/service-command-read.test.ts`: 3 files, 226 tests passed, including install and restart rewrite coverage.
- Independent Codex autoreview: no actionable P0–P2 findings. The lead verified both explicit-label call sites and the canonical renderer.
- `git diff --check`: passed.
- `pnpm build`: passed (32m 15s, cold declaration build).
- `node scripts/check-changed.mjs`: core typecheck and preceding guards passed. Stopped at core-test typechecking after the unrelated required CI failure blocked this item; remaining typecheck/lint are unverified.

Related lifecycle work: inspected #122388; its reply recovery changes do not overlap this patch. PID liveness is outside this consolidation.

## CI-BLOCKED

Exact-head CI run [34075010500](https://github.com/openclaw/openclaw/actions/runs/34075010500) failed in [checks-node-compact-large-7](https://github.com/openclaw/openclaw/actions/runs/34075010500/job/101599402236). The unrelated `src/agents/subagents/spawn/acp-spawn.authority.test.ts` case `transfers initialized ACP work only from its live parent: runtime / abort` expected child-session cleanup before spawn returned, but found the session row. That shard reported 1 failed, 1,897 passed, and 1 skipped test. A single local reproduction attempt, `node scripts/run-vitest.mjs src/agents/subagents/spawn/acp-spawn.authority.test.ts`, passed all 10 tests in 205s. The CI failure was not reproduced locally. This PR does not alter ACP spawning; the exact-head required check remains red, so landing is blocked.
