### PR TITLE
fix(tooling): correct advice for nested declaration failures

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -475,11 +475,25 @@ install; invocations from subdirectories still use the containing checkout as
 the ownership boundary. Declared checkout junctions and platform path aliases map
 to the same native root for validation and actual snapshot reads. Native resolution
 itself is not sandboxed: an ancestor install can still enter a successful compiler
-receipt. The owner then fails with `Declaration input escapes checkout`, without
-publishing a success record or pruning obsolete declarations. Warm records use
-the same input check. Use a standalone checkout outside ancestor installs with
-its own `pnpm install` when this occurs; do not remove the ancestor installation
-or weaken input checks.
+receipt. Resolution can read an ancestor's candidate `package.json` while searching
+for declarations, then resolve the import to checkout-local JavaScript. This can
+happen with a complete local frozen install and no external source files in the
+compiler Program; it does not by itself prove an undeclared dependency. Those
+manifests still affect resolution and must remain in the receipt. The owner fails
+with `Declaration input escapes checkout`, without publishing a success record or
+pruning obsolete declarations. Warm records use the same input check.
+
+Repair this at checkout provisioning: use a separate physical checkout whose
+ancestor directories do not contain `node_modules`, with the same candidate source
+(including any uncommitted changes) and its own `pnpm install --frozen-lockfile`.
+Run declaration preparation and dependent lint or package-boundary checks in that
+checkout, so the checks consume its freshly sealed receipts. A symlink to the
+nested checkout, a repeated install there, or `nodeLinker: isolated` does not bound
+native ancestor lookup. Do not alter the ancestor installation, add incidental
+dependencies, filter compiler receipts, or transplant declarations to bypass the
+checks. The pinned native compiler's filesystem callback API supports analysis,
+not declaration and build-info emission; native validation does not automatically
+create an isolated checkout.
 
 Packaged SDK declarations belong to one staged owner shared by full, package, and
 `ciArtifacts` builds. It serializes the two canonical tsdown SDK groups on a miss

--- a/scripts/lib/tsdown-declaration-boundary.mts
+++ b/scripts/lib/tsdown-declaration-boundary.mts
@@ -51,11 +51,9 @@ export function createDeclarationInputBoundary(cwd: string) {
         // Hermetic declaration inputs must not inherit an ancestor install's exposed packages.
         const ancestorInstall = findAncestorInstall(root, real);
         const diagnosis = ancestorInstall
-          ? `This checkout is nested inside another install at ${ancestorInstall}; module resolution walked out of the checkout and read a package from it. Run this lane in a checkout that is not nested inside another node_modules, or repair that ancestor install to the repository's isolated layout (nodeLinker: isolated in pnpm-workspace.yaml), which keeps transitive packages out of its root rather than exposing them to nested checkouts.`
-          : `Install declaration dependencies inside ${root}; shared installs and external symlinks are unsupported.`;
-        throw new Error(
-          `Declaration input escapes checkout: ${absolute} -> ${real}. ${diagnosis} If the checkout is not nested inside another install, the compiled package imported a dependency it does not declare, which is the boundary violation this check exists to catch.`,
-        );
+          ? `This checkout is nested inside another install at ${ancestorInstall}. Module resolution can read candidate manifests there even with a complete local install and a checkout-local final resolution. Repeating pnpm install will not isolate ancestor lookup. Provision a separate physical checkout outside ancestor node_modules installations, run pnpm install --frozen-lockfile there, and rerun declaration preparation and its dependent checks there. Do not modify the ancestor install or share its node_modules.`
+          : `Keep declaration dependencies and compiler files physically inside ${root}; shared installs and external symlinks are unsupported. Inspect the reported path and dependency links; this error alone does not establish a missing or undeclared dependency.`;
+        throw new Error(`Declaration input escapes checkout: ${absolute} -> ${real}. ${diagnosis}`);
       }
       return absolute;
     },

--- a/test/scripts/native-declaration-boundary.test.ts
+++ b/test/scripts/native-declaration-boundary.test.ts
@@ -27,14 +27,19 @@ it.each([true, false])(
     fs.mkdirSync(path.dirname(file), { recursive: true });
     fs.writeFileSync(file, "{}");
     const boundary = createDeclarationInputBoundary(root);
-    const diagnosis = ancestorInstall
-      ? `This checkout is nested inside another install at ${install}; module resolution walked out of the checkout and read a package from it. Run this lane in a checkout that is not nested inside another node_modules, or repair that ancestor install to the repository's isolated layout (nodeLinker: isolated in pnpm-workspace.yaml), which keeps transitive packages out of its root rather than exposing them to nested checkouts.`
-      : `Install declaration dependencies inside ${root}; shared installs and external symlinks are unsupported.`;
-    expect(() => boundary.assert(file)).toThrow(
-      new Error(
-        `Declaration input escapes checkout: ${file} -> ${file}. ${diagnosis} If the checkout is not nested inside another install, the compiled package imported a dependency it does not declare, which is the boundary violation this check exists to catch.`,
-      ),
-    );
+    expect(() => boundary.assert(file)).toThrow(`Declaration input escapes checkout: ${file}`);
+    if (ancestorInstall) {
+      expect(() => boundary.assert(file)).toThrow(`another install at ${install}`);
+      expect(() => boundary.assert(file)).toThrow("separate physical checkout");
+      expect(() => boundary.assert(file)).toThrow("Repeating pnpm install will not isolate");
+    } else {
+      expect(() => boundary.assert(file)).toThrow(
+        "shared installs and external symlinks are unsupported",
+      );
+      expect(() => boundary.assert(file)).toThrow(
+        "does not establish a missing or undeclared dependency",
+      );
+    }
   },
 );
 
@@ -63,7 +68,7 @@ function createNativeFixture(root: string, declared = root) {
     "src/index.ts",
     'import type { Marker } from "synthetic-wrapper";\nexport type { Marker };\nexport const inferredOrigin = declarationOrigin;\n',
   );
-  const compile = (noEmit = false) => {
+  const compile = (noEmit = false, extraArgs: string[] = []) => {
     const config = path.join(declared, "tsconfig.json");
     const buildInfo = "dist/.tsbuildinfo";
     const outputRoot = noEmit ? undefined : path.join(root, "dist");
@@ -76,6 +81,7 @@ function createNativeFixture(root: string, declared = root) {
       "--tsBuildInfoFile",
       path.join(declared, buildInfo),
       "--listEmittedFiles",
+      ...extraArgs,
     ];
     const before = new BoundaryInputSnapshot(declared);
     before.signature(config, args, [], outputRoot);
@@ -105,7 +111,7 @@ function createNativeFixture(root: string, declared = root) {
         startedAt,
         outputRoot,
       );
-    return { config, args, buildInfo, outputs, info, outputRoot, record };
+    return { config, args, buildInfo, outputs, info, outputRoot, record, trace: compiled.stdout };
   };
   return { native, write, compile };
 }
@@ -132,6 +138,66 @@ it.each([false, true])(
     expect(run.record).toThrow(/Declaration input escapes checkout/);
   },
 );
+
+it("diagnoses manifest-only ancestor probes and seals the same local inputs in a standalone checkout", () => {
+  const ancestor = fs.realpathSync.native(roots.make("native-manifest-probe-"));
+  const nested = path.join(ancestor, ".claude/worktrees/validation");
+  const standalone = fs.realpathSync.native(roots.make("native-manifest-isolated-"));
+  const manifest = JSON.stringify({ name: "synthetic-js", version: "1.0.0", main: "index.js" });
+  writeNativeFixtureFile(ancestor, "node_modules/synthetic-js/package.json", manifest);
+  writeNativeFixtureFile(
+    ancestor,
+    "node_modules/synthetic-js/index.js",
+    "exports.origin = 'ancestor';\n",
+  );
+  for (const root of [nested, standalone]) {
+    const f = createNativeFixture(root);
+    f.write("src/index.ts", 'export type { Value } from "synthetic-wrapper";\n');
+    f.write("node_modules/synthetic-wrapper/package.json", '{"types":"index.d.ts"}');
+    f.write(
+      "node_modules/synthetic-wrapper/index.d.ts",
+      'export type Value = typeof import("synthetic-js");\n',
+    );
+    f.write("node_modules/synthetic-js/package.json", manifest);
+    f.write("node_modules/synthetic-js/index.js", "exports.origin = 'local';\n");
+    const run = f.compile(false, ["--traceResolution"]);
+    const directory = path.join(root, "dist");
+    const sourceFiles = run.info.fileNames.slice(0, run.info.fileInfos.length);
+    const externalManifest = path.join(ancestor, "node_modules/synthetic-js/package.json");
+    expect(
+      sourceFiles.some((file) =>
+        path.relative(root, path.resolve(directory, file)).startsWith(`..${path.sep}`),
+      ),
+    ).toBe(false);
+    expect(run.trace.replaceAll("\\", "/")).toContain(
+      `'synthetic-js' was successfully resolved to '${root.replaceAll("\\", "/")}/node_modules/synthetic-js/index.js'`,
+    );
+    if (root === nested) {
+      // Declaration lookup visits outer manifests before falling back to local JavaScript.
+      expect(run.info.packageJsons?.map((file) => path.resolve(directory, file))).toContain(
+        externalManifest,
+      );
+      expect(run.record).toThrow("complete local install");
+      expect(run.record).toThrow("Repeating pnpm install will not isolate");
+      continue;
+    }
+    const record = run.record();
+    expect(record.inputs).toContain("node_modules/synthetic-js/package.json");
+    expect(record.inputs?.some((file) => file.startsWith("../"))).toBe(false);
+    const warm = new BoundaryInputSnapshot(root);
+    expect(warm.matches(record, run.config, run.args, run.outputs, run.outputRoot)).toBe(true);
+    f.write("node_modules/synthetic-js/package.json", `${manifest}\n`);
+    expect(
+      new BoundaryInputSnapshot(root).matches(
+        record,
+        run.config,
+        run.args,
+        run.outputs,
+        run.outputRoot,
+      ),
+    ).toBe(false);
+  }
+});
 
 for (const kind of [
   "directory alias",


### PR DESCRIPTION
Related: #139766

## What Problem This Solves

Fixes an issue where developers validating a fully installed nested worktree receive misleading instructions after declaration receipt sealing rejects an ancestor installation's package manifest. Reinstalling the worktree, changing the ancestor's linker layout, or assuming an undeclared dependency does not address the actual resolution boundary.

## Why This Change Was Made

Native declaration lookup can read candidate manifests in ancestor installations before ultimately resolving checkout-local JavaScript. This happens even with a complete frozen local install and no external source files in the compiler Program. The diagnostic now explains that distinction and directs validation to a separate physical checkout with its own frozen install, with preparation and dependent checks run in that same checkout.

The testing guide documents the supported workflow and its limitations. External affecting manifests remain in the receipt, and all containment, input hashing, cache invalidation, and publication guards are unchanged. This is a diagnostic and documentation repair, **not automatic native compiler isolation**. The pinned native filesystem callback API supports analysis but does not expose declaration/build-info emission.

## User Impact

Developers get accurate recovery guidance instead of repeated installation attempts or instructions to modify another checkout's dependencies. A rejected external input is no longer described as proof of a missing or undeclared dependency. The original contaminated nested-worktree command still fails closed; there is no new dependency, configuration option, compiler substitution, or weakening of validation.

## Evidence

- Reproduced successful native emit followed by receipt rejection for ancestor `punycode`, `qrcode`, and `string_decoder` manifests on the unchanged source baseline. The native Program had no `extensions/codex` source entries.
- Added a real native-compiler regression covering manifest-only ancestor probes with checkout-local final JavaScript resolution. It verifies the corrected diagnosis, successful standalone sealing and warm receipt reuse, and invalidation after a consumed manifest changes. The diagnostic assertions failed against the previous implementation and passed after the repair.
- `node scripts/run-vitest.mjs test/scripts/native-declaration-boundary.test.ts test/scripts/prepare-extension-package-boundary-artifacts.native.test.ts`: 15 passed; six Windows-only cases skipped on macOS. Existing negative cases still reject external sources and shared installs without publishing receipts or pruning declarations.
- `node scripts/check-changed.mjs -- scripts/lib/tsdown-declaration-boundary.mts test/scripts/native-declaration-boundary.test.ts docs/reference/test.md`: passed, including script and root-test typechecks, targeted lint, formatting, and relevant guards.
- `node scripts/check-docs-mdx.mjs docs/reference/test.md` and `git diff --check`: passed.
- Verified an independently installed standalone source snapshot against all 38,841 tracked candidate files, including this diff, with no byte differences. After `pnpm install --frozen-lockfile`, preparation emitted 8,826 files and sealed all 11,864 native inputs with zero external manifests. The warm preparation rerun and targeted plugin lint reused the freshly sealed receipt. The first attempt through the macOS `/var` alias encountered a separate output-inventory mismatch; the canonical `/private/var` path passed with no source or dependency changes. That alias issue is outside this PR.
- Independent review found no actionable P0–P2 findings in the scoped candidate.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34074884532) passed for `9ed37ba709857acd6aa8e7665142df873d2ed5fe`.

### Review clarifications

The native API limitation was checked directly in the installed pinned dependency and against its [published synchronous API declarations](https://unpkg.com/@typescript/native-preview@7.0.0-dev.20260707.2/dist/api/sync/api.d.ts). `Program` exposes diagnostics/source/checker operations, not an `emit` method. Its exported emitter has only the following operation beyond construction:

```ts
export declare class Emitter {
    private client;
    constructor(client: Client);
    printNode(node: Node, options?: PrintNodeOptions): string;
}
```

This is AST-to-text printing, not declaration-file or `.tsbuildinfo` emission with filesystem callbacks. The documented limitation is specific to the pinned compiler; no upgrade, patch, or compiler substitution is part of this PR.

The automated data-model classification is not applicable: the production diff changes only the two error-message branches and their throw expression. There is no schema, serialized receipt format, cache acceptance rule, or migration/backfill change. The existing generator-input fingerprint includes this tooling file, so its changed bytes invalidate old cache records through the normal rebuild path. Complete native membership and output validation remain unchanged; no migration or data conversion is needed.

Standalone proof commands, run from the canonical physical checkout root:

```bash
node scripts/prepare-extension-package-boundary-artifacts.mts --mode=package-boundary
```

```bash
node scripts/run-oxlint.mjs --tsconfig extensions/tsconfig.json extensions/telegram/api.ts
```
