### PR TITLE
refactor(cli): use shared startup policy for routed commands

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -57,7 +57,6 @@ export type CliCommandCatalogEntry = {
   policy?: Partial<CliCommandPathPolicy>;
   route?: {
     id: CliRoutedCommandId;
-    preloadPlugins?: boolean;
   };
 };
 

--- a/src/cli/program/route-specs.ts
+++ b/src/cli/program/route-specs.ts
@@ -1,27 +1,17 @@
 // Preparsed route specs for commands implemented outside Commander action registration.
-import { hasFlag } from "../argv.js";
 import { cliCommandCatalog, type CliCommandCatalogEntry } from "../command-catalog.js";
 import { matchesCommandPath } from "../command-path-matches.js";
-import { resolveCliCommandPathPolicy } from "../command-path-policy.js";
 import {
   routedCommandDefinitions,
   type AnyRoutedCommandDefinition,
 } from "./routed-command-definitions.js";
 
-/** Runtime route with optional preflight and plugin-preload policy. */
+/** Runtime route with argument validation before shared CLI startup. */
 export type RouteSpec = {
   matches: (path: string[]) => boolean;
   canRun?: (argv: string[]) => boolean;
-  loadPlugins?: boolean | ((argv: string[]) => boolean);
   run: (argv: string[]) => Promise<boolean>;
 };
-
-function createCommandLoadPlugins(commandPath: readonly string[]): (argv: string[]) => boolean {
-  return (argv) => {
-    const loadPlugins = resolveCliCommandPathPolicy([...commandPath]).loadPlugins;
-    return loadPlugins === "always" || (loadPlugins === "text-only" && !hasFlag(argv, "--json"));
-  };
-}
 
 function createParsedRoute(params: {
   entry: CliCommandCatalogEntry;
@@ -31,9 +21,6 @@ function createParsedRoute(params: {
     matches: (path) =>
       matchesCommandPath(path, params.entry.commandPath, { exact: params.entry.exact }),
     canRun: (argv) => Boolean(params.definition.parseArgs(argv)),
-    loadPlugins: params.entry.route?.preloadPlugins
-      ? createCommandLoadPlugins(params.entry.commandPath)
-      : undefined,
     run: async (argv) => {
       const args = params.definition.parseArgs(argv);
       if (!args) {

--- a/src/cli/program/routes.test.ts
+++ b/src/cli/program/routes.test.ts
@@ -99,26 +99,6 @@ describe("program routes", () => {
     await expect(route.run(argv)).resolves.toBe(false);
   }
 
-  it("matches status route without plugin preload", () => {
-    const route = expectRoute(["status"]);
-    expect(route.loadPlugins).toBeUndefined();
-  });
-
-  it("matches health route without plugin preload", () => {
-    const route = expectRoute(["health"]);
-    expect(route.loadPlugins).toBeUndefined();
-  });
-
-  it("matches channel read-only routes without plugin preload", () => {
-    expect(expectRoute(["channels", "list"]).loadPlugins).toBeUndefined();
-    expect(expectRoute(["channels", "status"]).loadPlugins).toBeUndefined();
-  });
-
-  it("matches agents read-only routes without plugin preload", () => {
-    expect(expectRoute(["agents"]).loadPlugins).toBeUndefined();
-    expect(expectRoute(["agents", "list"]).loadPlugins).toBeUndefined();
-  });
-
   it("passes parsed agents list flags through", async () => {
     await expect(expectRoute(["agents"]).run(routeArgv("agents"))).resolves.toBe(true);
     expect(agentsListCommandMock).toHaveBeenCalledWith(
@@ -174,7 +154,6 @@ describe("program routes", () => {
     "routes plugins list $label without importing the full plugins CLI",
     async ({ flags, options }) => {
       const route = expectRoute(["plugins", "list"]);
-      expect(route.loadPlugins).toBeUndefined();
       expect(route.canRun?.([...routeArgv("plugins list"), ...flags])).toBe(true);
 
       await expect(route.run([...routeArgv("plugins list"), ...flags])).resolves.toBe(true);
@@ -188,14 +167,8 @@ describe("program routes", () => {
     await expectRunFalse(["plugins", "list"], routeArgv("plugins list --wat"));
   });
 
-  it("matches gateway status route without plugin preload", () => {
-    const route = expectRoute(["gateway", "status"]);
-    expect(route.loadPlugins).toBeUndefined();
-  });
-
   it("routes machine-readable gateway health without plugin preload", async () => {
     const route = expectRoute(["gateway", "health"]);
-    expect(route.loadPlugins).toBeUndefined();
     await expect(route.run(routeArgv("gateway health --json --timeout 5000"))).resolves.toBe(true);
     expect(runGatewayHealthJsonRouteMock).toHaveBeenCalledWith(
       {
@@ -505,7 +478,6 @@ describe("program routes", () => {
 
   it("routes tasks list JSON through the lean task JSON command", async () => {
     const rootRoute = expectRoute(["tasks"]);
-    expect(rootRoute.loadPlugins).toBeUndefined();
     expect(rootRoute.canRun?.(["node", "openclaw", "tasks"])).toBe(false);
     await expect(
       rootRoute.run([
@@ -524,7 +496,6 @@ describe("program routes", () => {
     );
 
     const listRoute = expectRoute(["tasks", "list"]);
-    expect(listRoute.loadPlugins).toBeUndefined();
     await expect(
       listRoute.run(["node", "openclaw", "tasks", "list", "--json", "--runtime=cron"]),
     ).resolves.toBe(true);
@@ -594,7 +565,6 @@ describe("program routes", () => {
 
   it("routes tasks audit JSON through the lean task JSON command", async () => {
     const route = expectRoute(["tasks", "audit"]);
-    expect(route.loadPlugins).toBeUndefined();
     expect(route.canRun?.(["node", "openclaw", "tasks", "audit"])).toBe(false);
     await expect(
       route.run([

--- a/src/cli/route.test.ts
+++ b/src/cli/route.test.ts
@@ -6,7 +6,6 @@ const ensureConfigReadyMock = vi.hoisted(() =>
   vi.fn(async (_params: { runtime?: unknown; commandPath?: unknown }) => {}),
 );
 const ensurePluginRegistryLoadedMock = vi.hoisted(() => vi.fn());
-const findRoutedCommandMock = vi.hoisted(() => vi.fn());
 const runRouteMock = vi.hoisted(() => vi.fn(async () => true));
 
 vi.mock("./banner.js", () => ({
@@ -21,9 +20,23 @@ vi.mock("./plugin-registry.js", () => ({
   ensurePluginRegistryLoaded: ensurePluginRegistryLoadedMock,
 }));
 
-vi.mock("./program/routes.js", () => ({
-  findRoutedCommand: findRoutedCommandMock,
+// Keep route selection and argument parsing real; replace only command side effects.
+vi.mock("../commands/status.js", () => ({ statusCommand: runRouteMock }));
+vi.mock("../commands/status-json.js", () => ({ statusJsonCommand: runRouteMock }));
+vi.mock("../commands/health.js", () => ({ healthCommand: runRouteMock }));
+vi.mock("../commands/agents.commands.list.js", () => ({ agentsListCommand: runRouteMock }));
+vi.mock("../commands/tasks-json.js", () => ({
+  tasksListJsonCommand: runRouteMock,
+  tasksAuditJsonCommand: runRouteMock,
 }));
+vi.mock("../commands/sessions.js", () => ({ sessionsCommand: runRouteMock }));
+vi.mock("../commands/channels/list.js", () => ({ channelsListCommand: runRouteMock }));
+vi.mock("../commands/channels/status.js", () => ({ channelsStatusCommand: runRouteMock }));
+vi.mock("./plugins-list-command.js", () => ({ runPluginsListCommand: runRouteMock }));
+vi.mock("./daemon-cli/status.js", () => ({ runDaemonStatus: runRouteMock }));
+vi.mock("./gateway-cli/health-route.js", () => ({ runGatewayHealthJsonRoute: runRouteMock }));
+vi.mock("./config-cli.js", () => ({ runConfigGet: runRouteMock, runConfigUnset: runRouteMock }));
+vi.mock("../commands/models/list.status-command.js", () => ({ modelsStatusCommand: runRouteMock }));
 
 vi.mock("../runtime.js", () => ({
   defaultRuntime: {
@@ -65,10 +78,6 @@ describe("tryRouteCli", () => {
     delete process.env.OPENCLAW_LOG_LEVEL;
     originalForceStderr = loggingState.forceConsoleToStderr;
     loggingState.forceConsoleToStderr = false;
-    findRoutedCommandMock.mockReturnValue({
-      loadPlugins: (argv: string[]) => !argv.includes("--json"),
-      run: runRouteMock,
-    });
   });
 
   afterEach(() => {
@@ -92,27 +101,27 @@ describe("tryRouteCli", () => {
     }
   });
 
-  it("skips config guard for routed status --json commands", async () => {
-    await expect(tryRouteCli(["node", "openclaw", "status", "--json"])).resolves.toBe(true);
+  it.each([
+    ["status"],
+    ["status", "--json"],
+    ["health"],
+    ["health", "--json"],
+    ["agents"],
+    ["agents", "list", "--json"],
+    ["channels", "list"],
+    ["channels", "status", "--json"],
+    ["plugins", "list", "--json"],
+    ["gateway", "status", "--json"],
+    ["sessions", "--json"],
+    ["tasks", "--json"],
+    ["tasks", "list", "--json"],
+    ["tasks", "audit", "--json"],
+  ])("dispatches %j without startup config observation or plugin activation", async (...args) => {
+    await expect(tryRouteCli(["node", "openclaw", ...args])).resolves.toBe(true);
 
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
-  });
-
-  it("skips config guard for the parent tasks JSON list alias", async () => {
-    await expect(tryRouteCli(["node", "openclaw", "tasks", "--json"])).resolves.toBe(true);
-
-    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
-    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
-  });
-
-  it("skips config guard but still loads requested plugins for routed text commands", async () => {
-    await expect(tryRouteCli(["node", "openclaw", "status"])).resolves.toBe(true);
-
-    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
-    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
-      scope: "channels",
-    });
+    expect(runRouteMock).toHaveBeenCalledOnce();
   });
 
   it("suppresses config get machine output without running an observing startup guard", async () => {
@@ -141,31 +150,46 @@ describe("tryRouteCli", () => {
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
   });
 
-  it("keeps config guard for routed config mutations", async () => {
+  it("finishes config readiness once before a routed config mutation", async () => {
+    const events: string[] = [];
+    ensureConfigReadyMock.mockImplementationOnce(async () => {
+      events.push("config-ready");
+    });
+    runRouteMock.mockImplementationOnce(async () => {
+      events.push("action");
+      return true;
+    });
     await expect(
       tryRouteCli(["node", "openclaw", "config", "unset", "gateway.port"]),
     ).resolves.toBe(true);
 
     expect(ensureConfigReadyMock).toHaveBeenCalledTimes(1);
     expect(firstConfigReadyCall()?.commandPath).toEqual(["config", "unset"]);
+    expect(events).toEqual(["config-ready", "action"]);
   });
 
-  it("keeps logs routed to stderr for routed --json commands", async () => {
-    findRoutedCommandMock.mockReturnValue({
-      loadPlugins: true,
-      run: runRouteMock,
-    });
+  it("propagates config failure before running the mutation", async () => {
+    const error = new Error("invalid synthetic config");
+    ensureConfigReadyMock.mockRejectedValueOnce(error);
 
-    // Capture the value inside the mock callback using the same loggingState
-    // reference that route.js sees.
+    await expect(tryRouteCli(["node", "openclaw", "config", "unset", "gateway.port"])).rejects.toBe(
+      error,
+    );
+
+    expect(runRouteMock).not.toHaveBeenCalled();
+    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps action logs routed to stderr for routed --json commands", async () => {
     const captured: boolean[] = [];
-    ensurePluginRegistryLoadedMock.mockImplementation(() => {
+    runRouteMock.mockImplementationOnce(async () => {
       captured.push(loggingState.forceConsoleToStderr);
+      return true;
     });
 
     await tryRouteCli(["node", "openclaw", "agents", "--json"]);
 
-    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);
+    expect(runRouteMock).toHaveBeenCalledOnce();
     expect(captured[0]).toBe(true);
     expect(loggingState.forceConsoleToStderr).toBe(true);
   });
@@ -185,20 +209,16 @@ describe("tryRouteCli", () => {
     expect(captured).toEqual([true]);
   });
 
-  it("does not route logs to stderr during plugin loading without --json", async () => {
-    findRoutedCommandMock.mockReturnValue({
-      loadPlugins: true,
-      run: runRouteMock,
-    });
-
+  it("keeps human action output on stdout", async () => {
     const captured: boolean[] = [];
-    ensurePluginRegistryLoadedMock.mockImplementation(() => {
+    runRouteMock.mockImplementationOnce(async () => {
       captured.push(loggingState.forceConsoleToStderr);
+      return true;
     });
 
     await tryRouteCli(["node", "openclaw", "agents"]);
 
-    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledTimes(1);
+    expect(runRouteMock).toHaveBeenCalledOnce();
     expect(captured[0]).toBe(false);
     expect(loggingState.forceConsoleToStderr).toBe(false);
   });
@@ -214,14 +234,9 @@ describe("tryRouteCli", () => {
       true,
     );
 
-    expect(findRoutedCommandMock).toHaveBeenCalledWith(
-      ["status"],
-      ["node", "openclaw", "--log-level", "debug", "status"],
-    );
+    expect(runRouteMock).toHaveBeenCalledOnce();
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
-    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
-      scope: "channels",
-    });
+    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
     expect(capturedLogLevels).toEqual(["debug"]);
     expect(process.env.OPENCLAW_LOG_LEVEL).toBe("debug");
   });
@@ -278,13 +293,9 @@ describe("tryRouteCli", () => {
   });
 
   it("falls back before bootstrap when the route cannot parse the argv", async () => {
-    findRoutedCommandMock.mockReturnValue({
-      canRun: () => false,
-      loadPlugins: true,
-      run: runRouteMock,
-    });
-
-    await expect(tryRouteCli(["node", "openclaw", "tasks", "list"])).resolves.toBe(false);
+    await expect(
+      tryRouteCli(["node", "openclaw", "tasks", "list", "--json", "--unknown"]),
+    ).resolves.toBe(false);
 
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();

--- a/src/cli/route.ts
+++ b/src/cli/route.ts
@@ -52,7 +52,6 @@ function resolveRoutedCliLogLevel(argv: string[]): LogLevel | null | undefined {
 async function prepareRoutedCommand(params: {
   argv: string[];
   commandPath: string[];
-  loadPlugins?: boolean | ((argv: string[]) => boolean);
   machineOutput?: boolean;
 }) {
   const { startupPolicy } = resolveCliExecutionStartupContext({
@@ -67,14 +66,11 @@ async function prepareRoutedCommand(params: {
     showBanner: process.stdout.isTTY && !startupPolicy.suppressDoctorStdout,
     version: VERSION,
   });
-  const shouldLoadPlugins =
-    typeof params.loadPlugins === "function" ? params.loadPlugins(params.argv) : params.loadPlugins;
   // Routed commands still honor config guards, logging policy, and plugin loading decisions.
   await ensureCliExecutionBootstrap({
     runtime: defaultRuntime,
     commandPath: params.commandPath,
     startupPolicy,
-    loadPlugins: shouldLoadPlugins ?? startupPolicy.loadPlugins,
   });
 }
 
@@ -112,7 +108,6 @@ export async function tryRouteCli(
   await prepareRoutedCommand({
     argv,
     commandPath: invocation.commandPath,
-    loadPlugins: route.loadPlugins,
     machineOutput: options.machineOutput,
   });
   return route.run(argv);


### PR DESCRIPTION
Closes #140611
Related: #140480

## What Problem This Solves

Maintainer-requested CLI startup cleanup: route-first dispatch has a separate plugin-preload policy path that no real command enables. Mocked route tests exercise that unused override instead of the catalog's actual behavior, making startup policy harder to maintain consistently.

## Why This Change Was Made

Remove the route-only preload evaluator and override fields, and rely on the existing shared startup policy and bootstrap owner. Replace synthetic route-policy tests with real route selection and argument parsing while retaining plugin-loader and Commander coverage. Production source is +1/-20, net -19 lines; tests are +68/-87, net -19.

## User Impact

No intended user-visible behavior change. Config readiness still precedes plugin activation where required; passive commands, help/version laziness, structured failures and JSON stdout retain their contracts. Config inspection, migrations, metadata discovery, activation and build-time artifact generation remain distinct. No public CLI/config, persistence, dependency or build-policy changes, and no performance claim.

## Evidence

- 176 focused tests passed across route dispatch, route definitions, startup policy/bootstrap, Commander preaction and plugin registry loading.
- Full `pnpm build` passed, including the CLI bootstrap import guard, SDK exports and generated startup metadata.
- Configured `node scripts/check-changed.mjs` passed on Testbox: https://github.com/openclaw/openclaw/actions/runs/34072965912. The native delegated result was exit 0; the one-shot lease stopped successfully.
- Eight isolated built CLI cases passed: help/version with invalid config, identical route-first/Commander JSON config reads, plugin listing, config-unset dry-run, invalid config and invalid log-level failures. All config files remained byte-identical. Plugin listing and dry-run may create command-owned SQLite state; no broader read-only claim is made.
- Independent autoreview was scoped-clean through P2; `git diff --check` passed.

The local proof used synthetic HOME/state/config directories. Live Gateway/channel/provider actions and performance benchmarking were not run.
