### PR TITLE
fix: show effective GitHub auth for agent dashboards

### DIFF
--- a/docs/tools/show-widget.md
+++ b/docs/tools/show-widget.md
@@ -237,6 +237,18 @@ case-insensitive and grants use lowercase spelling. A grant for one repository
 cannot read another; granting only `https://api.github.com` network access does
 not authorize this binding.
 
+Direct browser fetches to `api.github.com` do not inherit the agent's login and
+share GitHub's anonymous IP quota. Existing widgets using `fetch` should replace
+that call with the binding and replace their GitHub `netOrigins` declaration with
+the repository-scoped tool grant. Check the effective account in **Agent settings
+→ Tools → GitHub account**; administrators can also reach it from **Settings →
+Profile → GitHub connections**.
+
+For refreshable widgets, keep the last successful data and a separate error
+element. Clear the error after a successful read, and keep result containers in
+the document so later refreshes can recover. Show a **Refresh** control for an
+immediate retry.
+
 **Approval shares Actions metadata with the widget and its session audience,
 including metadata from private repositories accessible to the selected agent
 identity.** The host selects the agent override, then the configured System

--- a/docs/web/control-ui/settings.md
+++ b/docs/web/control-ui/settings.md
@@ -52,6 +52,10 @@ GitHub-backed sign-in through Cloudflare Access or Tailscale Serve fills the rea
 
 **Settings → Profile → GitHub connections** separately shows **My GitHub** and **System GitHub**. Identified people, including read-scoped operators, can connect and disconnect only their own account; administrators can also change the shared System account. Connecting defaults to **For me** for identified users and never changes their sign-in identity, co-author preference, or shared execution defaults. Personal credentials support explicit Gateway-brokered **Publish PR** actions, not ordinary agent shell commands. See [GitHub connections](/concepts/user-model#github-connections).
 
+Administrators also see the default agent's effective GitHub account and verification status here. **View agent account** opens **Agent settings → Tools → GitHub account**, where any agent's account source, credential type, OAuth expiry, and refresh state are available. Authenticated [GitHub Actions widgets](/tools/show-widget#read-github-actions-runs) use this effective agent account. **Verified** confirms the account with GitHub; repository permissions are checked on each data request.
+
+Credentials reserved for Control UI link previews are excluded from both agent authentication and its displayed status, including when the preview credential uses a SecretRef.
+
 Set an agent's display name, emoji, and avatar under **Agent settings → Overview → Identity**. The identity is stored with that agent and is shared by Control UI clients. Where the transcript shows avatars, saved and streaming assistant replies use the configured agent image or text avatar. Agents without a configured avatar omit the repeated fallback icon.
 
 ## Gateway host status

--- a/src/agents/github-tool-identity.test.ts
+++ b/src/agents/github-tool-identity.test.ts
@@ -21,6 +21,7 @@ import {
   resolveGitHubToolIdentityStatus,
   resolveManagedGitHubAgentKey,
   resolveManagedGitHubProfileDir,
+  resolveSystemGitHubIdentityStatus,
 } from "./github-tool-identity.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -497,6 +498,47 @@ describe("GitHub tool identity", () => {
     });
     expect(gitCall?.[1]).toMatchObject({ cwd: workspace });
   });
+
+  it.each([
+    { surface: "agent", source: "env" },
+    { surface: "agent", source: "store" },
+    { surface: "system", source: "env" },
+    { surface: "system", source: "store" },
+  ] as const)(
+    "reports the native execution account in $surface status when $source owns the preview token",
+    async ({ surface, source }) => {
+      const params = {
+        config: { gateway: { controlUi: { github: { token: "resolved-preview-status" } } } },
+        sourceConfig: {
+          gateway: {
+            controlUi: {
+              github: { token: { source, provider: "default", id: "GH_TOKEN" } },
+            },
+          },
+        },
+        env: {
+          GH_TOKEN: "preview-status-only",
+          GITHUB_TOKEN: `native-status-${surface}-${source}`,
+        },
+      };
+      const identity =
+        surface === "system"
+          ? await resolveSystemGitHubIdentityStatus(params)
+          : (
+              await resolveGitHubToolIdentityStatus({
+                ...params,
+                agentId: "main",
+                selectedScope: "agent",
+              })
+            ).effective;
+
+      expect(identity).toMatchObject({
+        source: "system-detected",
+        credentialState: "available",
+        account: { login: "native-user" },
+      });
+    },
+  );
 
   it("removes ambient tokens from the actual managed publication child environment", async () => {
     const root = tempDirs.make("openclaw-github-publication-env-");

--- a/src/agents/github-tool-identity.ts
+++ b/src/agents/github-tool-identity.ts
@@ -131,18 +131,6 @@ export type PreparedGitHubToolEnvironment = Readonly<{
   managedLocalIdentity: boolean;
 }>;
 
-function localIdentityEnvironmentForIdentity(
-  identity: ResolvedGitHubToolIdentity,
-): Readonly<Record<string, string>> {
-  if (identity.source === "system-detected") {
-    return {};
-  }
-  return managedGitHubIdentityEnvironment({
-    profileDir: identity.profileDir,
-    gitAuthor: identity.config.gitAuthor,
-  });
-}
-
 export function managedGitHubIdentityEnvironment(params: {
   profileDir: string;
   gitAuthor?: { name?: string; email?: string };
@@ -176,7 +164,13 @@ export function managedGitHubIdentityEnvironment(params: {
 export function prepareGitHubToolEnvironment(
   params: GitHubIdentityPreparation,
 ): PreparedGitHubToolEnvironment {
-  const identity = resolveGitHubToolIdentity(params);
+  return prepareGitHubToolEnvironmentForIdentity(params, resolveGitHubToolIdentity(params));
+}
+
+function prepareGitHubToolEnvironmentForIdentity(
+  params: Pick<GitHubIdentityPreparation, "config" | "sourceConfig">,
+  identity: ResolvedGitHubToolIdentity,
+): PreparedGitHubToolEnvironment {
   const managedLocalIdentity = identity.source !== "system-detected";
   const previewToken =
     params.sourceConfig?.gateway?.controlUi?.github?.token ??
@@ -195,10 +189,29 @@ export function prepareGitHubToolEnvironment(
   }
   return Object.freeze({
     credentialScrubEnv: Object.freeze(credentialScrubEnv),
-    localIdentityEnv: Object.freeze({ ...localIdentityEnvironmentForIdentity(identity) }),
+    localIdentityEnv: Object.freeze(
+      managedLocalIdentity
+        ? managedGitHubIdentityEnvironment({
+            profileDir: identity.profileDir,
+            gitAuthor: identity.config.gitAuthor,
+          })
+        : {},
+    ),
     excludedStoreNames: Object.freeze(excludedStoreNames),
     managedLocalIdentity,
   });
+}
+
+function githubIdentityProbeEnvironment(
+  params: Pick<GitHubIdentityPreparation, "config" | "sourceConfig" | "env">,
+  identity: ResolvedGitHubToolIdentity,
+): NodeJS.ProcessEnv {
+  const overlay = prepareGitHubToolEnvironmentForIdentity(params, identity);
+  return {
+    ...(params.env ?? process.env),
+    ...Object.fromEntries(Object.keys(overlay.credentialScrubEnv).map((name) => [name, undefined])),
+    ...overlay.localIdentityEnv,
+  };
 }
 
 async function runIdentityCommand(argv: string[], env?: NodeJS.ProcessEnv, cwd?: string) {
@@ -320,18 +333,20 @@ async function isPrivateManagedGitHubProfile(profileDir: string): Promise<boolea
   }
 }
 
-export async function resolveGitHubToolIdentityStatus(params: {
-  config: OpenClawConfig;
-  agentId: string;
-  selectedScope: "system" | "agent";
-  env?: NodeJS.ProcessEnv;
-}): Promise<ToolsGitHubStatusResult> {
+export async function resolveGitHubToolIdentityStatus(
+  params: GitHubIdentityPreparation & { selectedScope: "system" | "agent" },
+): Promise<ToolsGitHubStatusResult> {
   const effectiveIdentity = resolveGitHubToolIdentity(params);
   const selectedIdentity = resolveScopedGitHubToolIdentity({
     ...params,
     scope: params.selectedScope,
   });
-  const probe = { cwd: resolveAgentWorkspaceDir(params.config, params.agentId), env: params.env };
+  const probe = {
+    config: params.config,
+    sourceConfig: params.sourceConfig,
+    cwd: resolveAgentWorkspaceDir(params.config, params.agentId),
+    env: params.env,
+  };
   const effective = await resolveGitHubIdentityFacts({ ...probe, identity: effectiveIdentity });
   const selectedMatchesEffective =
     selectedIdentity?.source === effectiveIdentity.source &&
@@ -356,28 +371,25 @@ export async function resolveGitHubToolIdentityStatus(params: {
 }
 
 export async function resolveSystemGitHubIdentityStatus(
-  params: Pick<GitHubIdentityPreparation, "config" | "env">,
+  params: Pick<GitHubIdentityPreparation, "config" | "sourceConfig" | "env">,
 ): Promise<GitHubIdentityFacts> {
   // Profile settings have no agent owner. Probe the shared identity outside agent workspaces.
   return resolveGitHubIdentityFacts({
+    ...params,
     identity: resolveSystemGitHubToolIdentity(params),
     cwd: resolveStateDir(params.env),
-    env: params.env,
   });
 }
 
-async function resolveGitHubIdentityFacts(params: {
-  cwd: string;
-  identity: ResolvedGitHubToolIdentity;
-  env?: NodeJS.ProcessEnv;
-}): Promise<GitHubIdentityFacts> {
+async function resolveGitHubIdentityFacts(
+  params: Pick<GitHubIdentityPreparation, "config" | "sourceConfig" | "env"> & {
+    cwd: string;
+    identity: ResolvedGitHubToolIdentity;
+  },
+): Promise<GitHubIdentityFacts> {
   const identity = params.identity;
   const managed = identity.source !== "system-detected";
-  const localIdentityEnv = localIdentityEnvironmentForIdentity(identity);
-  const nativeEnv = params.env ?? {};
-  const probeEnv: NodeJS.ProcessEnv = managed
-    ? { ...nativeEnv, GH_TOKEN: undefined, GITHUB_TOKEN: undefined, ...localIdentityEnv }
-    : nativeEnv;
+  const probeEnv = githubIdentityProbeEnvironment(params, identity);
   const token = managed
     ? await readManagedGitHubToken(identity.profileDir)
     : await readNativeGitHubToken(probeEnv);
@@ -518,20 +530,8 @@ async function prepareSharedGitHubIdentity(
 ) {
   const identity = resolveGitHubToolIdentity(params);
   const managed = identity.source !== "system-detected";
-  const hostEnv = params.env ?? process.env;
-  const overlay = prepareGitHubToolEnvironment({
-    config: params.config,
-    sourceConfig: params.sourceConfig,
-    agentId: params.agentId,
-    env: hostEnv,
-  });
-  const directScrubEnv = Object.fromEntries(
-    Object.keys(overlay.credentialScrubEnv).map((name) => [name, undefined]),
-  );
   const currentEnvironment = (): NodeJS.ProcessEnv => ({
-    ...(params.env ?? process.env),
-    ...directScrubEnv,
-    ...overlay.localIdentityEnv,
+    ...githubIdentityProbeEnvironment(params, identity),
     GH_PROMPT_DISABLED: "1",
   });
   const env = currentEnvironment();

--- a/src/boards/github-actions-capability.ts
+++ b/src/boards/github-actions-capability.ts
@@ -5,7 +5,7 @@ import { BoardValidationError } from "./board-layout.js";
 export const GITHUB_ACTIONS_BINDING_ID = "github.actions.runs";
 export const GITHUB_ACTIONS_GRANT_PREFIX = `${GITHUB_ACTIONS_BINDING_ID}:`;
 export const GITHUB_ACTIONS_AUTHOR_GUIDANCE =
-  'With a usable connected agent GitHub identity: await openclaw.data.read("github.actions.runs",{repository:"owner/repo",perPage:20}); grant capabilities.tools:["github.actions.runs:owner/repo"]. Identity is checked before save; reconnect in Settings if unavailable. Optional workflow (ID/filename), branch, status, created (ISO day/comparison/range), excludePullRequests=true (omits PR objects); perPage 1..30. Shares private Actions metadata with the widget/session audience; never preview or My GitHub auth. No netOrigins needed.';
+  'With a usable connected agent GitHub identity: await openclaw.data.read("github.actions.runs",{repository:"owner/repo",perPage:20}); grant capabilities.tools:["github.actions.runs:owner/repo"]. Uses the agent GitHub identity and cached server reads; direct fetch(api.github.com) is anonymous and rate limited. Identity is checked before save; reconnect in Settings if unavailable. Optional workflow (ID/filename), branch, status, created (ISO day/comparison/range), excludePullRequests=true (omits PR objects); perPage 1..30. Shares private Actions metadata with the widget/session audience; never preview or My GitHub auth. No netOrigins needed.';
 
 const repositorySchema = z
   .string()

--- a/src/gateway/server-methods/tools-github.test.ts
+++ b/src/gateway/server-methods/tools-github.test.ts
@@ -117,6 +117,7 @@ describe("tools.github handlers", () => {
     expect(oauth.refreshEffectiveIdentity).not.toHaveBeenCalled();
     expect(github.status).toHaveBeenCalledWith({
       config: {},
+      sourceConfig: {},
       agentId: "main",
       selectedScope: "system",
     });

--- a/src/gateway/server-methods/tools-github.ts
+++ b/src/gateway/server-methods/tools-github.ts
@@ -15,6 +15,7 @@ import {
   resolveGitHubToolIdentityStatus,
   resolveManagedGitHubProfileDir,
 } from "../../agents/github-tool-identity.js";
+import { getActiveSecretsRuntimeConfigSnapshot } from "../../secrets/runtime-state.js";
 import { consumeGitHubSetupHandoff } from "../../secrets/store/secret-store.js";
 import { GitHubCliUnavailableError } from "../github-cli-preflight.js";
 import { updateGitHubToolIdentityConfig } from "../github-tool-identity-config.js";
@@ -41,7 +42,8 @@ export const toolsGitHubHandlers: GatewayRequestHandlers = {
     respond(
       true,
       await resolveGitHubToolIdentityStatus({
-        config: context.getRuntimeConfig(),
+        config: resolved.cfg,
+        sourceConfig: getActiveSecretsRuntimeConfigSnapshot()?.sourceConfig ?? resolved.cfg,
         agentId: resolved.agentId,
         selectedScope: params.selectedScope,
       }),

--- a/src/gateway/server-methods/users-github.test.ts
+++ b/src/gateway/server-methods/users-github.test.ts
@@ -15,6 +15,8 @@ import {
 } from "../../agents/github-tool-identity.js";
 import { cleanupRetiredManagedGitHubProfiles } from "../../agents/github-tool-profile-cleanup.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveCommandEnv } from "../../process/exec-spawn.js";
+import * as secretsRuntime from "../../secrets/runtime-state.js";
 import {
   listSecretStoreEntries,
   readSecretStoreExecEnvironment,
@@ -218,6 +220,60 @@ afterEach(async () => {
 });
 
 describe("personal GitHub through authenticated Gateway RPC", () => {
+  it.each(["users.github.status", "tools.github.status"])(
+    "%s reports execution authentication instead of a resolved preview credential",
+    async (method) => {
+      const sourceConfig: OpenClawConfig = {
+        ...config,
+        gateway: {
+          controlUi: {
+            github: { token: { source: "env", provider: "default", id: "GH_TOKEN" } },
+          },
+        },
+      };
+      config = {
+        ...config,
+        gateway: { controlUi: { github: { token: "synthetic-preview" } } },
+      };
+      const snapshot = vi
+        .spyOn(secretsRuntime, "getActiveSecretsRuntimeConfigSnapshot")
+        .mockReturnValue({ config, sourceConfig, configRefsPrepared: true });
+      vi.stubEnv("GH_TOKEN", "synthetic-preview");
+      vi.stubEnv("GITHUB_TOKEN", "synthetic-native");
+      network.command.mockImplementation(
+        async (argv: string[], options: { env?: NodeJS.ProcessEnv }) => {
+          const env = resolveCommandEnv({ argv, env: options.env });
+          return {
+            code: argv[0] === "git" ? 1 : 0,
+            stdout: Buffer.from(
+              argv[0] === "gh" ? env.GH_TOKEN || env.GITHUB_TOKEN || "synthetic-native" : "",
+            ),
+            stderr: Buffer.alloc(0),
+          };
+        },
+      );
+      try {
+        const response = await rpc(
+          alice,
+          method,
+          method === "tools.github.status" ? { agentId: "main", selectedScope: "agent" } : {},
+        );
+        expect(response.mock.calls[0]?.[0]).toBe(true);
+        expect(response.mock.calls[0]?.[1]).toMatchObject({
+          [method === "users.github.status" ? "system" : "effective"]: {
+            source: "system-detected",
+            credentialState: "available",
+            account: { login: "system-bot" },
+          },
+        });
+        expect(network.refresh).not.toHaveBeenCalled();
+      } finally {
+        snapshot.mockRestore();
+        vi.unstubAllEnvs();
+      }
+    },
+  );
+
   it.each(["native", "managed"] as const)(
     "reads personal and %s system status without selecting an agent",
     async (systemKind) => {

--- a/src/gateway/server-methods/users-github.ts
+++ b/src/gateway/server-methods/users-github.ts
@@ -8,6 +8,7 @@ import {
   validateUsersGitHubDisconnectParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveSystemGitHubIdentityStatus } from "../../agents/github-tool-identity.js";
+import { getActiveSecretsRuntimeConfigSnapshot } from "../../secrets/runtime-state.js";
 import type { PersonalGitHubAction } from "../github-personal-oauth.js";
 import { preparePersonalGitHubAction } from "./github-personal-authorization.js";
 import type {
@@ -61,6 +62,7 @@ export const usersGitHubHandlers: GatewayRequestHandlers = {
         const config = options.context.getRuntimeConfig();
         const system = await resolveSystemGitHubIdentityStatus({
           config,
+          sourceConfig: getActiveSecretsRuntimeConfigSnapshot()?.sourceConfig ?? config,
         });
         const personal = await service.status(action);
         return { personal, system };

--- a/ui/src/e2e/agent-github-device-authorization.e2e.test.ts
+++ b/ui/src/e2e/agent-github-device-authorization.e2e.test.ts
@@ -150,7 +150,12 @@ suite.define(() => {
       await expect(section.locator('[data-github-connection="system"]')).toContainText(
         "@system-octocat",
       );
-      await expect(section).not.toContainText("@agent-octocat");
+      await expect(section.locator('[data-github-connection="system"]')).not.toContainText(
+        "@agent-octocat",
+      );
+      await expect(section.locator('[data-github-connection="agent"]')).toContainText(
+        "@agent-octocat",
+      );
       expect(await gateway.getRequests("users.github.status")).toHaveLength(0);
       await capture(page, "01-unidentified-system.png");
       await section.getByRole("button", { name: "Change System GitHub" }).click();
@@ -194,7 +199,8 @@ suite.define(() => {
       await expect(section.getByLabel("Fine-grained PAT", { exact: true })).toBeVisible();
       await expect(section.getByRole("button", { name: "Continue with GitHub" })).toHaveCount(0);
       await capture(page, "05-system-pat.png");
-      await page.goto(`${suite.server.baseUrl}settings/agents/main/tools`);
+      await section.getByRole("button", { name: "View agent account", exact: true }).click();
+      await expect(page).toHaveURL(/settings\/agents\/main\/tools$/);
       await expect(page.getByText("@agent-octocat", { exact: true })).toBeVisible();
       await expect(page.getByRole("button", { name: "Continue with GitHub" })).not.toBeVisible();
       await page.getByText("Advanced: agent GitHub override", { exact: true }).click();
@@ -218,6 +224,7 @@ suite.define(() => {
         "@system-octocat",
       );
       await expect(section.getByRole("button", { name: "Change System GitHub" })).toHaveCount(0);
+      await expect(section.locator('[data-github-connection="agent"]')).toHaveCount(0);
       expect(await gateway.getRequests("users.self")).toHaveLength(0);
       const configReads = (await gateway.getRequests("config.get")).length;
       const configWrites = (await gateway.getRequests("config.set")).length;

--- a/ui/src/features/github-connections/github-connections.test.ts
+++ b/ui/src/features/github-connections/github-connections.test.ts
@@ -38,6 +38,8 @@ function mount(scopes: string[], profileId: string | null, request: ReturnType<t
     selfUser: profileId ? { id: profileId } : null,
   } as ApplicationGatewaySnapshot;
   const context = {
+    basePath: "/ui",
+    navigate: vi.fn(),
     gateway: {
       snapshot,
       subscribe: (listener: (snapshot: ApplicationGatewaySnapshot) => void) => {
@@ -91,14 +93,24 @@ it("uses explicit unbound admin context for System without probing personal stat
     selected: { scope: "system", configured: true, identity: system },
     effective: { ...system, source: "agent-override", account: { login: "agent-account" } },
   }));
-  const { element } = mount(["operator.admin"], null, request);
+  const { element, context } = mount(["operator.admin"], null, request);
   await waitForFast(() => expect(element.textContent).toContain("@system-account"));
   expect(request.mock.calls).toEqual([
     ["tools.github.status", { agentId: "main", selectedScope: "system" }],
   ]);
   expect(element.textContent).toContain("Personal sign-in required");
   expect(element.textContent).not.toContain("Connect My GitHub");
-  expect(element.textContent).not.toContain("@agent-account");
+  const shared = element.querySelector('[data-github-connection="system"]');
+  const agent = element.querySelector('[data-github-connection="agent"]');
+  expect(shared?.textContent).toContain("@system-account");
+  expect(shared?.textContent).not.toContain("@agent-account");
+  expect(agent?.textContent).toContain("@agent-account");
+  expect(agent?.textContent).toContain("Agent override");
+  expect(agent?.textContent).toContain("Verified");
+  agent?.querySelector("button")?.click();
+  expect(context.navigate).toHaveBeenCalledWith("agents", {
+    pathname: "/ui/settings/agents/main/tools",
+  });
 });
 
 it("shows an identified status failure once while opening personal setup", async () => {

--- a/ui/src/features/github-connections/github-connections.ts
+++ b/ui/src/features/github-connections/github-connections.ts
@@ -1,6 +1,7 @@
 import { consume } from "@lit/context";
 import { html, nothing } from "lit";
 import { state } from "lit/decorators.js";
+import { pathForAgentPanel } from "../../app-route-paths.ts";
 import {
   applicationContext,
   type ApplicationContext,
@@ -174,6 +175,11 @@ export class GitHubConnections extends OpenClawLightDomElement {
   override render() {
     const personal = this.personal.personal;
     const system = this.system.status?.selected.identity ?? this.personal.system;
+    const agentId = this.context.agents.state.agentsList?.defaultId;
+    const agent = this.context.agents.state.agentsList?.agents?.find(
+      (entry) => entry.id === agentId,
+    );
+    const effective = this.system.status?.effective ?? null;
     const active = this.purpose === "personal" ? this.personal : this.system;
     const showSetup =
       this.setupOpen || this.personal.authorizationActive || this.system.authorizationActive;
@@ -271,6 +277,35 @@ export class GitHubConnections extends OpenClawLightDomElement {
               }`,
             })}
           </div>
+          ${
+            this.canAdmin && agentId
+              ? html`<div data-github-connection="agent">
+                  ${renderSettingsRow({
+                    title: t("githubConnections.agentFor", {
+                      agent: agent?.identity?.name ?? agent?.name ?? agentId,
+                    }),
+                    description: html`${effective?.account ? `@${effective.account.login} · ` : ""}${
+                        effective
+                          ? t(
+                              effective.source === "agent-override"
+                                ? "githubConnections.agentOverride"
+                                : "githubConnections.system",
+                            )
+                          : ""
+                      }<br />${t("githubConnections.agentDescription")}`,
+                    control: html`${renderGitHubHealth(effective, this.system)}<button
+                        class="btn btn--sm"
+                        @click=${() =>
+                          this.context.navigate("agents", {
+                            pathname: pathForAgentPanel(agentId, "tools", this.context.basePath),
+                          })}
+                      >
+                        ${t("githubConnections.viewAgent")}
+                      </button>`,
+                  })}
+                </div>`
+              : nothing
+          }
           ${renderGitHubConnectionError(
             this.personal.error ?? this.system.error,
             html`<button

--- a/ui/src/features/github-connections/github-identity-view.ts
+++ b/ui/src/features/github-connections/github-identity-view.ts
@@ -384,6 +384,7 @@ export function renderGitHubIdentity(
   return renderSettingsSection(
     {
       title: t("githubConnections.agentTitle"),
+      description: t("githubConnections.agentDescription"),
       actions: controller.statusReadable
         ? html`<button
             class="btn btn--sm"

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3425,11 +3425,12 @@ export const en: TranslationMap & {
   githubConnections: {
     title: "GitHub connections",
     description:
-      "Publishing access is separate from your verified GitHub sign-in and co-author credit. Connect an account here to publish with it.",
+      "Check the accounts used for agent commands, dashboard data, and publishing. These connections are separate from your GitHub sign-in and co-author credit.",
     mine: "My GitHub",
     system: "System GitHub",
     personalDescription: "Your account for explicitly selected Publish PR actions.",
-    systemDescription: "Shared account for agents and default publication.",
+    systemDescription:
+      "Default account for agent commands, authenticated dashboards, and publishing.",
     unboundDescription:
       "Sign in with a personal Gateway profile to connect My GitHub. Administrators can still manage System GitHub.",
     signInRequired: "Personal sign-in required",
@@ -3457,6 +3458,10 @@ export const en: TranslationMap & {
       "My GitHub is used only when you explicitly select it for Gateway-brokered Publish PR on an idle, reconciled local workspace. Publication still needs write access to the session. Agent git/gh, model actions, previews, and workers keep the shared account. Finish and reclaim remote work before personal publication. Connecting My GitHub changes no defaults.",
     details: "Connection details",
     agentTitle: "GitHub account",
+    agentFor: "GitHub for {agent}",
+    agentDescription:
+      "Used for this agent's commands and authenticated dashboard data. Verified confirms the account; repository access is checked when data is requested.",
+    viewAgent: "View agent account",
     agentOverride: "Agent override",
     advancedOverride: "Advanced: agent GitHub override",
     manageCommon: "Manage connections in Profile",

--- a/ui/src/pages/config/settings-targets.ts
+++ b/ui/src/pages/config/settings-targets.ts
@@ -139,7 +139,8 @@ export const SETTINGS_SEARCH_TARGETS = {
       "githubConnections.forMe",
       "githubConnections.forSystem",
     ],
-    aliases: "github oauth account connection publication",
+    aliases:
+      "github oauth account connection publication authentication auth status dashboard actions",
   },
   modelBehavior: {
     ...SETTINGS_ROUTE_TARGETS.modelBehavior,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators checking GitHub authentication could see a different account from the one used by agent commands and authenticated dashboard reads when a preview-only credential was supplied through a SecretRef. Profile Settings also showed only personal and System connections, making an agent override difficult to discover while diagnosing dashboard failures.

## Why This Change Was Made

Status probes now share the credential-environment preparation used by authenticated agent reads, including exclusion of credentials reserved for Control UI previews. Status remains read-only. Profile Settings shows the default agent's effective account and health to administrators, with a direct link to its account settings; personal, System, and agent identities remain distinct.

Widget authoring guidance recommends the existing authenticated, cached GitHub Actions binding and documents recoverable refresh behavior. This PR does not automatically rewrite existing saved widgets or change their repository grants.

## User Impact

Operators can identify which GitHub account supplies agent commands and dashboard data, see whether that account is verified, and open its connection details directly. Account verification remains distinct from repository access, which is checked when fetching data. Widget authors have clear guidance for avoiding anonymous GitHub quota failures.

## Evidence

- Six credential-status regressions failed before the repair and passed afterward, covering both environment- and store-backed preview credentials through agent/System resolvers and authenticated status RPCs. The focused backend suites passed 121 tests.
- Profile/controller/search tests passed, including separation of System and agent identities and navigation with a configured UI base path. The new Profile-row assertion failed before implementation.
- GitHub Actions board-boundary tests and widget capability-guidance tests passed.
- Initial CI caught an E2E assertion that forbade the agent account across the entire Profile section. It now verifies the System and agent rows separately, follows the new account-settings button, and preserves reader-only restrictions. All four GitHub device-authorization E2E flows passed after the correction.
- Synthetic browser proof verified the Settings before/after states and navigation to the agent's account settings. Screenshots below contain fixture accounts only.
- Maintainer visual verification is complete: both attached before/after captures were inspected for layout, correct account separation, and synthetic-only contents. Both published image URLs return image/png for GET requests. ClawSweeper could not retrieve the images in its review environment; its visual-verification concern is addressed by this inspection and the browser/navigation proof.
- Existing saved-widget migration was separately exercised on a deployed Gateway: three GitHub widgets loaded successfully through the existing authenticated binding. Synthetic failure → recovery checks confirmed zero direct GitHub browser fetches and retention of previous data after a failed refresh. Those saved-widget edits are operational state, outside this source diff.
- `node scripts/check-changed.mjs` and `git diff --check` passed. Independent Codex review found no actionable P0–P2 findings.

![Before: agent override absent from Profile GitHub connections (synthetic accounts)](https://github.com/user-attachments/assets/8b27104e-422d-4dc5-8171-126256f86a7f)

![After: effective agent account, verification status, and account-settings link (synthetic accounts)](https://github.com/user-attachments/assets/1aa8bdae-6f33-4616-b5ea-3f5acc0fbb9a)
