### PR TITLE
refactor(signal): share legacy transport migration phases

### DIFF
--- a/extensions/signal/src/config-compat.ts
+++ b/extensions/signal/src/config-compat.ts
@@ -556,106 +556,14 @@ function hasContainerTransportWithoutEffectiveAccount(cfg: OpenClawConfig): bool
   return false;
 }
 
-export async function migrateLegacySignalTransportConfig(params: {
-  cfg: OpenClawConfig;
-  detect?: DetectTransport;
-}): Promise<ChannelDoctorConfigMutation> {
-  const signal = params.cfg.channels?.signal as unknown;
-  if (!isRecord(signal)) {
-    return { config: params.cfg, changes: [] };
-  }
-  const accounts = isRecord(signal.accounts) ? signal.accounts : {};
-  const hasLegacy =
-    Object.hasOwn(signal, "apiMode") ||
-    hasLegacyFields(signal) ||
-    Object.values(accounts).some((entry) => isRecord(entry) && hasLegacyFields(entry));
-  if (!hasLegacy) {
-    return { config: params.cfg, changes: [] };
-  }
-  const apiMode = signal.apiMode;
-  const entries = [signal, ...Object.values(accounts).filter(isRecord)];
-  const migrationEntries = entries.filter((_, index) => shouldMaterializeTransport(entries, index));
-  const legacyResolutionEntries = migrationEntries.filter(
-    (entry) => !isSignalTransportConfig(entry.transport),
-  );
-  const invalidDerivedEndpoint = findInvalidLegacyDerivedEndpoint(legacyResolutionEntries, signal);
-  if (invalidDerivedEndpoint) {
-    return {
-      config: params.cfg,
-      changes: [],
-      warnings: [
-        invalidDerivedEndpoint === "port"
-          ? PENDING_LEGACY_INVALID_PORT_WARNING
-          : PENDING_LEGACY_INVALID_HOST_WARNING,
-      ],
-    };
-  }
-  if (hasInvalidLegacyHttpUrl(legacyResolutionEntries, signal)) {
-    return {
-      config: params.cfg,
-      changes: [],
-      warnings: [PENDING_LEGACY_INVALID_URL_WARNING],
-    };
-  }
-  if (
-    !params.detect &&
-    legacyResolutionEntries.some((entry) => requiresDetection(entry, signal, apiMode))
-  ) {
-    return {
-      config: params.cfg,
-      changes: [],
-      warnings: [PENDING_LEGACY_TRANSPORT_WARNING],
-    };
-  }
-  const resolvedTransports = await Promise.all(
-    entries.map(async (entry, index) =>
-      !shouldMaterializeTransport(entries, index)
-        ? undefined
-        : await resolveLegacyTransport({ entry, parent: signal, apiMode, detect: params.detect }),
-    ),
-  );
-  if (hasInvalidManagedTransportPort(resolvedTransports)) {
-    return {
-      config: params.cfg,
-      changes: [],
-      warnings: [PENDING_LEGACY_INVALID_PORT_WARNING],
-    };
-  }
-  const transports = allocateMigratedManagedPorts({
-    entries,
-    transports: resolvedTransports,
-  });
-  if (
-    transports.some((transport, index) => shouldMaterializeTransport(entries, index) && !transport)
-  ) {
-    return {
-      config: params.cfg,
-      changes: [],
-      warnings: [PENDING_LEGACY_TRANSPORT_WARNING],
-    };
-  }
-  const next = applyMigratedSignalTransports({ cfg: params.cfg, entries, transports });
-  if (!next) {
-    return { config: params.cfg, changes: [] };
-  }
-  if (hasContainerTransportWithoutEffectiveAccount(next)) {
-    return {
-      config: params.cfg,
-      changes: [],
-      warnings: [PENDING_LEGACY_CONTAINER_ACCOUNT_WARNING],
-    };
-  }
-  return {
-    config: next,
-    changes: [
-      "Migrated channels.signal transport settings to concrete account-owned transport objects.",
-    ],
-  };
-}
-
-export function migrateLegacySignalTransportConfigSync(
-  cfg: OpenClawConfig,
-): ChannelDoctorConfigMutation {
+function prepareLegacySignalTransportMigration(cfg: OpenClawConfig):
+  | ChannelDoctorConfigMutation
+  | {
+      signal: Record<string, unknown>;
+      apiMode: unknown;
+      entries: Record<string, unknown>[];
+      legacyResolutionEntries: Record<string, unknown>[];
+    } {
   const signal = cfg.channels?.signal as unknown;
   if (!isRecord(signal)) {
     return { config: cfg, changes: [] };
@@ -668,6 +576,7 @@ export function migrateLegacySignalTransportConfigSync(
   if (!hasLegacy) {
     return { config: cfg, changes: [] };
   }
+  const apiMode = signal.apiMode;
   const entries = [signal, ...Object.values(accounts).filter(isRecord)];
   const migrationEntries = entries.filter((_, index) => shouldMaterializeTransport(entries, index));
   const legacyResolutionEntries = migrationEntries.filter(
@@ -692,16 +601,14 @@ export function migrateLegacySignalTransportConfigSync(
       warnings: [PENDING_LEGACY_INVALID_URL_WARNING],
     };
   }
-  const resolvedTransports = entries.map((entry, index) => {
-    if (!shouldMaterializeTransport(entries, index)) {
-      return undefined;
-    }
-    return resolveLegacyTransportWithoutDetection({
-      entry,
-      parent: signal,
-      apiMode: signal.apiMode,
-    });
-  });
+  return { signal, apiMode, entries, legacyResolutionEntries };
+}
+
+function finishLegacySignalTransportMigration(
+  cfg: OpenClawConfig,
+  entries: Record<string, unknown>[],
+  resolvedTransports: Array<SignalTransportConfig | undefined>,
+): ChannelDoctorConfigMutation {
   if (hasInvalidManagedTransportPort(resolvedTransports)) {
     return {
       config: cfg,
@@ -716,7 +623,11 @@ export function migrateLegacySignalTransportConfigSync(
   if (
     transports.some((transport, index) => shouldMaterializeTransport(entries, index) && !transport)
   ) {
-    return { config: cfg, changes: [], warnings: [PENDING_LEGACY_TRANSPORT_WARNING] };
+    return {
+      config: cfg,
+      changes: [],
+      warnings: [PENDING_LEGACY_TRANSPORT_WARNING],
+    };
   }
   const next = applyMigratedSignalTransports({ cfg, entries, transports });
   if (!next) {
@@ -735,4 +646,50 @@ export function migrateLegacySignalTransportConfigSync(
       "Migrated channels.signal transport settings to concrete account-owned transport objects.",
     ],
   };
+}
+
+export async function migrateLegacySignalTransportConfig(params: {
+  cfg: OpenClawConfig;
+  detect?: DetectTransport;
+}): Promise<ChannelDoctorConfigMutation> {
+  const prepared = prepareLegacySignalTransportMigration(params.cfg);
+  if ("config" in prepared) {
+    return prepared;
+  }
+  const { signal, apiMode, entries, legacyResolutionEntries } = prepared;
+  if (
+    !params.detect &&
+    legacyResolutionEntries.some((entry) => requiresDetection(entry, signal, apiMode))
+  ) {
+    return {
+      config: params.cfg,
+      changes: [],
+      warnings: [PENDING_LEGACY_TRANSPORT_WARNING],
+    };
+  }
+  const resolvedTransports = await Promise.all(
+    entries.map(async (entry, index) =>
+      !shouldMaterializeTransport(entries, index)
+        ? undefined
+        : await resolveLegacyTransport({ entry, parent: signal, apiMode, detect: params.detect }),
+    ),
+  );
+  return finishLegacySignalTransportMigration(params.cfg, entries, resolvedTransports);
+}
+
+export function migrateLegacySignalTransportConfigSync(
+  cfg: OpenClawConfig,
+): ChannelDoctorConfigMutation {
+  const prepared = prepareLegacySignalTransportMigration(cfg);
+  if ("config" in prepared) {
+    return prepared;
+  }
+  const { signal, apiMode, entries } = prepared;
+  const resolvedTransports = entries.map((entry, index) => {
+    if (!shouldMaterializeTransport(entries, index)) {
+      return undefined;
+    }
+    return resolveLegacyTransportWithoutDetection({ entry, parent: signal, apiMode });
+  });
+  return finishLegacySignalTransportMigration(cfg, entries, resolvedTransports);
 }


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested de-duplication of Signal's legacy transport migration. Synchronous config repair and asynchronous Doctor repair repeat account selection, endpoint validation, port allocation, and completion checks.

## Why This Change Was Made

Keep preparation and completion in two plugin-local helpers, with the existing synchronous resolver and asynchronous detector between them. Preserve the async entrypoint's early ambiguity guard and concurrent detection, canonical default-account ownership, port collision handling, warning ordering, and unchanged-config identity on deferred migrations.

## User Impact

No behavior, configuration, public SDK, storage, or dependency change. Both repair paths continue to support the same legacy Signal configurations.

## Evidence

- `node scripts/run-vitest.mjs extensions/signal/doctor-contract-api.test.ts`: 43 existing tests pass before and after the extraction. These cover sync/async account ownership, canonical transport precedence, invalid endpoints, ambiguous/offline detection, disabled containers, port allocation, and rerun identity.
- Production delta: 59 added, 102 removed (net −43); tests unchanged.
- Doctor declaration/closure checks: 6 tests passed. Independent Codex review: clean through P2, zero actionable findings.
- `node scripts/check-changed.mjs`: completed guards, formatting, 6 doctor tests, production/test typechecks, and all three dead-export scans passed (zero export entries). Local lint could not start: its package-boundary artifact preparation failed with `Declaration input escapes checkout` after resolving `punycode` from the ancestor install. This is the documented nested-worktree limitation; the ancestor install was not modified. The hosted extension package-boundary and lint gates passed.
- `pnpm build`: passed the full build, including all declaration batches, 90 plugin artifacts, 53 native control-plane module loads, 152 public SDK subpaths, and the UI bundle.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34075114379): passed for `acaf1b400b1d357269e5581c99eb313a30630636`; native hosted CI/Testbox preparation gates passed. No lane-created lease or live-service test.
- ClawSweeper review found no correctness or security issues.

The required main refresh rebased this unchanged patch onto `2234390ef59`. Stable patch ID and the implementation/test blob hashes are identical; all 43 Signal tests pass again at `221d9971fbdb89202c4d72cb4d0ac83ebeffa5d7`. Full local build and the first hosted gate record above are from the pre-rebase head; native hosted CI/Testbox gates passed again for the rebased head. Database-first legacy-store, media-helper, runtime-sidecar-loader and import-cycle guards also passed locally after rebase (zero runtime cycles).
