### PR TITLE
fix(openai): default Astra reasoning to low

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -163,6 +163,7 @@ Claude CLI reuse (`claude -p`) is a sanctioned OpenClaw integration path. Anthro
 - Auth: OAuth (ChatGPT)
 - Fresh native Codex app-server harness ref: `openai/gpt-5.6-sol`
 - Native Codex app-server harness docs: [Codex harness](/plugins/codex-harness)
+- Astra (`openai/gpt-6-astra`) defaults to `low` reasoning effort to limit routine budget use. The [OpenAI provider default](/providers/openai#gpt-6-astra) is shared by model controls and both runtimes; explicit thinking settings take precedence.
 - Legacy model refs: `codex/gpt-*`, `openai-codex/gpt-*`
 - Plugin boundary: `openai/*` loads the OpenAI plugin; explicit runtime policy or the provider-owned effective route decides whether the native Codex app-server plugin is selected.
 - CLI: `openclaw onboard --auth-choice openai` or `openclaw models auth login --provider openai`

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -748,6 +748,14 @@ surprising, see
 
 ## Routing and model selection
 
+`openai/gpt-6-astra` defaults to `low` reasoning effort through the shared
+OpenAI provider policy. This limits routine reasoning cost and subscription
+budget use. For OpenClaw-managed turns, the resolved effort is sent in Codex `turn/start` requests,
+including `collaborationMode.settings.reasoning_effort`, so the native thread
+uses the same default as Control UI. Explicit thinking settings still win;
+an existing session or agent configured for `high` stays at `high`. Threads
+attached with native settings preserved retain their native effort.
+
 Keep provider refs and runtime policy separate:
 
 - Use `openai/gpt-*` for canonical OpenAI model selection. The prefix alone

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -78,6 +78,12 @@ Astra uses the Responses API for agent tool calls. It supports text and image
 input, a 1,050,000-token context window, and up to 128,000 output tokens.
 OpenClaw retains its ordinary 272,000-token active input budget by default.
 The supported reasoning efforts are `low`, `medium`, `high`, `xhigh`, and `max`.
+OpenClaw defaults Astra to `low` on both the OpenClaw and Codex runtimes to
+limit reasoning cost and subscription-budget consumption on ordinary prompts.
+The OpenAI provider owns this default, so model selection, Control UI, and
+Codex turn requests share it. Explicit agent, model, global, and session
+thinking settings still take precedence; switching models does not clear an
+existing `high` override. Use `/think default` to clear a session override.
 An existing `minimal` setting maps to `low`. Astra cannot disable reasoning;
 `off` never sends the unsupported `none` effort.
 Temperature and `top_p` are not sent.

--- a/extensions/codex/src/app-server/turn-params.test.ts
+++ b/extensions/codex/src/app-server/turn-params.test.ts
@@ -1,3 +1,4 @@
+import { resolveThinkingDefault } from "openclaw/plugin-sdk/agent-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createAppServerOptions,
@@ -9,6 +10,48 @@ import { buildTurnStartParams } from "./turn-params.js";
 afterEach(() => {
   resetThreadLifecycleTestFixtures();
   vi.restoreAllMocks();
+});
+
+describe("buildTurnStartParams model thinking defaults", () => {
+  it.each([
+    { thinking: undefined, thinkingDefault: undefined, expected: "low" },
+    { thinking: undefined, thinkingDefault: "high" as const, expected: "high" },
+    { thinking: "medium", thinkingDefault: "high" as const, expected: "medium" },
+  ])("sends $expected for Astra with configured effort $thinking/$thinkingDefault", (testCase) => {
+    const modelId = "gpt-6-astra";
+    const config = {
+      agents: {
+        defaults: {
+          thinkingDefault: testCase.thinkingDefault,
+          models: { [`openai/${modelId}`]: { params: { thinking: testCase.thinking } } },
+        },
+      },
+    };
+    const params = createParams("/tmp/session.jsonl", "/repo", config);
+    params.provider = "openai";
+    params.modelId = modelId;
+    params.model = {
+      ...params.model,
+      provider: "openai",
+      id: modelId,
+      compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"] },
+    };
+    params.thinkLevel = resolveThinkingDefault({
+      cfg: config,
+      provider: params.provider,
+      model: modelId,
+      agentRuntime: "codex",
+      catalog: [{ provider: "openai", id: modelId, name: "Astra", reasoning: true }],
+    });
+
+    const turn = buildTurnStartParams(params, {
+      threadId: "thread-1",
+      cwd: "/repo",
+      appServer: createAppServerOptions(),
+    });
+    expect(turn.effort).toBe(testCase.expected);
+    expect(turn.collaborationMode?.settings.reasoning_effort).toBe(testCase.expected);
+  });
 });
 
 describe("buildTurnStartParams temporal context", () => {

--- a/extensions/openai/provider-policy-api.test.ts
+++ b/extensions/openai/provider-policy-api.test.ts
@@ -92,6 +92,9 @@ describe("OpenAI provider policy artifact", () => {
   });
 
   it.each([
+    ["gpt-6-astra", "codex", "low"],
+    ["gpt-6-astra", "openclaw", "low"],
+    ["gpt-6-astra", "auto", "low"],
     ["gpt-5.6-sol", "codex", "medium"],
     ["gpt-5.6-sol", "openclaw", "medium"],
     ["gpt-5.6-terra", "codex", "medium"],

--- a/extensions/openai/thinking-policy.test.ts
+++ b/extensions/openai/thinking-policy.test.ts
@@ -37,16 +37,17 @@ describe("OpenAI thinking route provenance", () => {
     },
   );
 
-  it.each([{ efforts: [] }, { efforts: ["low", "high"] }])(
-    "retains Astra account efforts $efforts",
-    ({ efforts }) => {
-      expect(
-        resolveUnifiedOpenAIThinkingProfile("gpt-6-astra", "codex", {
-          supportedReasoningEfforts: efforts,
-        }).levels.map((level) => level.id),
-      ).toEqual(["off", ...efforts]);
-    },
-  );
+  it.each([
+    { efforts: [], defaultLevel: undefined },
+    { efforts: ["high"], defaultLevel: undefined },
+    { efforts: ["low", "high"], defaultLevel: "low" },
+  ])("retains Astra account efforts $efforts", ({ efforts, defaultLevel }) => {
+    const profile = resolveUnifiedOpenAIThinkingProfile("gpt-6-astra", "codex", {
+      supportedReasoningEfforts: efforts,
+    });
+    expect(profile.levels.map((level) => level.id)).toEqual(["off", ...efforts]);
+    expect(profile.defaultLevel).toBe(defaultLevel);
+  });
 
   it.each([
     { efforts: ["low", "high", "ultra"], expected: ["off", "low", "high", "ultra"] },

--- a/extensions/openai/thinking-policy.ts
+++ b/extensions/openai/thinking-policy.ts
@@ -105,7 +105,10 @@ function buildOpenAIThinkingProfile(params: {
     // Preserve narrower account capabilities while exposing the supported runtime mode.
     const supportsUltra =
       ["openclaw", "codex", "auto"].includes(agentRuntime) && efforts.includes("max");
-    return { levels: buildCodexLevels(supportsUltra ? [...efforts, "ultra"] : efforts) };
+    return {
+      levels: buildCodexLevels(supportsUltra ? [...efforts, "ultra"] : efforts),
+      ...(efforts.includes("low") ? { defaultLevel: "low" as const } : {}),
+    };
   }
   const resolvedCodexEfforts =
     params.api === undefined || params.api === "openai-chatgpt-responses"

--- a/src/gateway/session-utils-model.thinking-default.test.ts
+++ b/src/gateway/session-utils-model.thinking-default.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveGatewayModelThinkingProfile } from "./session-utils-model.js";
+
+describe.each([
+  { agentRuntime: "openclaw", api: "openai-responses" as const },
+  { agentRuntime: "codex", api: "openai-chatgpt-responses" as const },
+])("Gateway model thinking defaults on $agentRuntime", ({ agentRuntime, api }) => {
+  it.each<{ name: string; cfg: OpenClawConfig; expected: string }>([
+    { name: "provider default", cfg: {}, expected: "low" },
+    {
+      name: "global override",
+      cfg: { agents: { defaults: { thinkingDefault: "high" } } },
+      expected: "high",
+    },
+    {
+      name: "model override",
+      cfg: {
+        agents: {
+          defaults: {
+            thinkingDefault: "high",
+            models: { "openai/gpt-6-astra": { params: { thinking: "medium" } } },
+          },
+        },
+      },
+      expected: "medium",
+    },
+    {
+      name: "agent override",
+      cfg: { agents: { entries: { main: { thinkingDefault: "xhigh" } } } },
+      expected: "xhigh",
+    },
+  ])("projects $name for Control UI", ({ cfg, expected }) => {
+    const profile = resolveGatewayModelThinkingProfile({
+      cfg,
+      agentId: "main",
+      provider: "openai",
+      model: "gpt-6-astra",
+      agentRuntime,
+      modelCatalog: [
+        { provider: "openai", id: "gpt-6-astra", name: "Astra", reasoning: true, api },
+      ],
+    });
+    expect(profile.thinkingDefault).toBe(expected);
+    expect(profile.thinkingLevels.map(({ id }) => id)).toContain(expected);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting Astra without an explicit thinking setting received the generic medium default. Community members on Discord also reported rapid subscription-budget consumption with inherited high effort. This change implements the maintainer decision to use low for ordinary prompts; authored high settings remain explicit overrides.

## Why This Change Was Made

The OpenAI provider's shared thinking profile omitted its model default, so generic resolution selected medium and passed it into native Codex turns, overriding Codex's own low catalog default. The owner now supplies low when the account's supported effort list includes it. Existing model controls, Gateway catalog projection, and Codex request construction consume that same policy. No surface-specific model checks, new config, SDK changes, or migrations are needed.

Root cause: `extensions/openai/thinking-policy.ts` and the generic fallback in `src/auto-reply/thinking.ts`. Explicit configuration stays ahead of the provider default in `src/agents/model-thinking-default-core.ts`. The native request consumes that resolved value in `extensions/codex/src/app-server/turn-params.ts`. Adding independent UI or harness defaults was rejected because it would duplicate the provider policy.

## User Impact

New Astra sessions inherit low effort across OpenClaw and Codex. Model, global, agent, and session thinking overrides remain authoritative, and attached native threads retain native settings when requested. The provider, model-provider, and Codex harness docs explain the default and budget rationale. No UI layout changes.

## Evidence

- Pre-fix synthetic Codex request regression: expected low, received medium. Both explicit override cases passed before the fix.
- `node scripts/run-vitest.mjs extensions/openai/provider-policy-api.test.ts extensions/openai/thinking-policy.test.ts extensions/codex/src/app-server/turn-params.test.ts src/gateway/session-utils-model.thinking-default.test.ts`: **94 passed**, covering both runtimes, narrow account effort lists, Gateway projection, and actual Codex turn payloads.
- Independent Codex autoreview against the branch merge base: **scoped-clean, P0–P2**, no accepted/actionable findings.
- Personally inspected sibling Codex source: `codex-rs/models-manager/models.json:39` declares low; `codex-rs/app-server/src/request_processors/turn_processor.rs:630-632` carries the supplied effort and collaboration mode; `codex-rs/core/src/client.rs:906-915` prefers explicit effort to its native model default.
- `pnpm check:changed`: **passed**, including selected typechecks, lint, boundary guards, and zero runtime import cycles.
- `node scripts/check-docs-mdx.mjs docs/providers/openai.md docs/plugins/codex-harness.md docs/concepts/model-providers.md`: **passed (3 files)**.
- `git diff --check`: **passed**.
- Exact reviewed/tested head: `4aa3a3b1115dd2104c616879581a7c07d13a77a0`. Exact-head [CI run 34074981325](https://github.com/openclaw/openclaw/actions/runs/34074981325): **green**, confirmed by the native CI watcher.
- ClawSweeper completed its review of this head: **no actionable findings**, no before-merge items.
- Boundary proof used synthetic configuration. No live Gateway or paid inference was used.

Production delta: +4/-1 (net +3). Tests: +104/-10 (net +94). Docs: +15/-0. Small production growth was explicitly approved for this task. No contributor PR was incorporated.
