### PR TITLE
test(ui): retain A2UI action-delivery failure diagnostics

### DIFF
--- a/ui/src/e2e/board-a2ui.e2e.test.ts
+++ b/ui/src/e2e/board-a2ui.e2e.test.ts
@@ -20,6 +20,7 @@ import {
   startControlUiE2eServer,
   type ControlUiE2eServer,
 } from "../test-helpers/control-ui-e2e.ts";
+import { installA2uiFailureDiagnostics } from "./board-a2ui.test-support.ts";
 
 const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
@@ -112,7 +113,9 @@ describeControlUiE2e("Control UI dashboard A2UI", () => {
   });
 
   for (const colorScheme of ["dark", "light"] as const) {
-    it(`renders a v0.9 widget with the ${colorScheme} scrollbar theme`, async () => {
+    it(`renders a v0.9 widget with the ${colorScheme} scrollbar theme`, async ({
+      onTestFailed,
+    }) => {
       const context = await browser.newContext({
         colorScheme,
         permissions: ["local-network-access"],
@@ -121,7 +124,27 @@ describeControlUiE2e("Control UI dashboard A2UI", () => {
       contexts.add(context);
       const page = await context.newPage();
       const pageErrors: string[] = [];
-      page.on("pageerror", (error) => pageErrors.push(error.message));
+      let pageErrorCount = 0;
+      page.on("pageerror", (error) => {
+        pageErrorCount += 1;
+        if (pageErrors.length < 8) {
+          pageErrors.push(error.message.slice(0, 512));
+        }
+      });
+      const diagnostics = await installA2uiFailureDiagnostics(page);
+      let actionStage = "opening dashboard";
+      onTestFailed(async () => {
+        console.error(
+          "[board-a2ui] action diagnostics",
+          JSON.stringify({
+            colorScheme,
+            actionStage,
+            pageErrorCount,
+            pageErrors,
+            ...(await diagnostics.snapshot()),
+          }),
+        );
+      });
       const origin = new URL(controlUi.baseUrl).origin;
       const rendererUrl = `${rendererOrigin}/__openclaw__/cap/canvas-proof/__openclaw__/a2ui/a2ui-v0.9.bundle.js`;
       const messages = [
@@ -223,13 +246,17 @@ describeControlUiE2e("Control UI dashboard A2UI", () => {
         )
         .toBe(true);
       const widgetFrame = outerFrame!.childFrames()[0]!;
+      diagnostics.target(widgetFrame);
       await widgetFrame.getByText("A2UI board widget").waitFor();
       await expect
         .poll(() => outer.evaluate((element) => getComputedStyle(element).opacity))
         .toBe("1");
       expect(await outer.getAttribute("inert")).toBeNull();
+      actionStage = "waiting for native pointer entry and clicking refresh";
       await clickBoardWidgetControl(page, widgetFrame.getByText("Refresh data"));
+      actionStage = "waiting for board.event";
       await expect.poll(async () => (await gateway.getRequests("board.event")).length).toBe(1);
+      actionStage = "validating delivered action and scrollbar";
       expect((await gateway.getRequests("board.event"))[0]?.params).toMatchObject({
         ticket: "ticket",
         payload: {

--- a/ui/src/e2e/board-a2ui.test-support.ts
+++ b/ui/src/e2e/board-a2ui.test-support.ts
@@ -1,0 +1,157 @@
+import type { Frame, Page } from "playwright";
+
+/** Passive, failure-only evidence; never starts ports or changes input/readiness. */
+export async function installA2uiFailureDiagnostics(page: Page) {
+  const frames = new WeakMap<Frame, number>();
+  const lifecycle: { event: string; frame: number; parent?: number }[] = [];
+  const errors: string[] = [];
+  let nextFrameId = 0;
+  let clickFrame: Frame | undefined;
+  const frameId = (frame: Frame): number => {
+    let id = frames.get(frame);
+    if (id === undefined) {
+      id = ++nextFrameId;
+      frames.set(frame, id);
+    }
+    return id;
+  };
+  const recordLifecycle = (event: string, frame: Frame) => {
+    if (lifecycle.length < 32) {
+      const parent = frame.parentFrame();
+      lifecycle.push({
+        event,
+        frame: frameId(frame),
+        parent: parent ? frameId(parent) : undefined,
+      });
+    }
+  };
+  page.on("frameattached", (frame) => recordLifecycle("frameattached", frame));
+  page.on("framenavigated", (frame) => recordLifecycle("framenavigated", frame));
+  page.on("framedetached", (frame) => recordLifecycle("framedetached", frame));
+  page.on("console", (message) => {
+    if (message.type() === "error" && errors.length < 8) {
+      errors.push(message.text().slice(0, 512));
+    }
+  });
+  await page.addInitScript(() => {
+    const input: { type: string; trusted: boolean; path: string[] }[] = [];
+    const bridge: string[] = [];
+    let observedPorts = 0;
+    const recordBridge = (value: string) => {
+      if (bridge.length < 24) {
+        bridge.push(value);
+      }
+    };
+    for (const type of ["pointerdown", "pointerup", "click"]) {
+      window.addEventListener(
+        type,
+        (event) => {
+          if (input.length < 12) {
+            input.push({
+              type,
+              trusted: event.isTrusted,
+              path: event
+                .composedPath()
+                .filter((entry): entry is Element => entry instanceof Element)
+                .slice(0, 8)
+                .map((entry) => entry.tagName.slice(0, 64)),
+            });
+          }
+        },
+        { capture: true, passive: true },
+      );
+    }
+    window.addEventListener("message", (event) => {
+      const kind = event.data?.type ?? event.data?.method;
+      if (
+        kind === "openclaw:widget-bridge-ready" ||
+        kind === "ui/notifications/sandbox-proxy-ready" ||
+        kind === "ui/notifications/sandbox-resource-loaded"
+      ) {
+        recordBridge(kind);
+      }
+      if (
+        window !== window.top ||
+        kind !== "openclaw:widget-bridge-port-offer" ||
+        observedPorts >= 8
+      ) {
+        return;
+      }
+      observedPorts += 1;
+      recordBridge(kind);
+      // Observe the host's incoming traffic without starting the port, adopting
+      // its ticket, wrapping frozen APIs, or recording authority/payload bytes.
+      event.ports[0]?.addEventListener("message", (message) => {
+        if (message.data?.type === "openclaw:widget-host-init-ack") {
+          recordBridge("host-init-ack");
+        } else if (message.data?.type === "openclaw:widget-bridge-request") {
+          recordBridge(
+            message.data.method === "state.emit" ? "request:state.emit" : "request:other",
+          );
+        }
+      });
+    });
+    Reflect.set(window, "__a2uiFailureSnapshot", () => {
+      const host = document.querySelector("openclaw-a2ui-host");
+      const rendererError = host ? Reflect.get(host, "error") : undefined;
+      const api = Reflect.get(window, "openclaw");
+      const outer = document.querySelector(".board-widget__frame");
+      return {
+        input,
+        bridge,
+        readyState: document.readyState,
+        rendererDefined: Boolean(customElements.get("openclaw-a2ui-host")),
+        rendererConnected: host?.isConnected ?? false,
+        rendererError: typeof rendererError === "string" ? rendererError.slice(0, 512) : undefined,
+        rendererAlert: host?.shadowRoot
+          ?.querySelector('[role="alert"]')
+          ?.textContent?.slice(0, 512),
+        stateEmitAvailable: typeof api?.state?.emit === "function",
+        hostInitialized: typeof api?.host?.controlUiBaseUrl === "string",
+        outer: outer
+          ? { inert: outer.hasAttribute("inert"), opacity: getComputedStyle(outer).opacity }
+          : undefined,
+      };
+    });
+  });
+  return {
+    target(frame: Frame) {
+      clickFrame = frame;
+      frameId(frame);
+    },
+    async snapshot() {
+      // Diagnostic collection has its own budget, not a longer action assertion.
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const snapshots = await Promise.race([
+          Promise.all(
+            page
+              .frames()
+              .slice(0, 8)
+              .map(async (frame) => ({
+                frame: frameId(frame),
+                snapshot: await frame
+                  .evaluate(() => {
+                    const read = Reflect.get(window, "__a2uiFailureSnapshot");
+                    return typeof read === "function" ? read() : { observerMissing: true };
+                  })
+                  .catch(() => ({ frameUnavailable: true })),
+              })),
+          ),
+          new Promise<"diagnostic collection timed out">((resolve) => {
+            timer = setTimeout(() => resolve("diagnostic collection timed out"), 2_000);
+          }),
+        ]);
+        return {
+          clickFrame: clickFrame ? frameId(clickFrame) : undefined,
+          clickFrameDetached: clickFrame?.isDetached(),
+          lifecycle,
+          errors,
+          snapshots,
+        };
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}


### PR DESCRIPTION
Related: #139076, #139506, #139635

## What Problem This Solves

The Control UI A2UI action test can report only that a click was followed by zero `board.event` requests, leaving no evidence of whether native input reached the widget, the renderer rejected the action, the private bridge initialized, or the document was replaced.

The historical failure occurred in [main run 33965832570](https://github.com/openclaw/openclaw/actions/runs/33965832570/job/101306012044) at `2299d11045d35ae1032bf43f75a1faaab204a231`: dark passed immediately before light timed out waiting for one event. This PR improves evidence for a recurrence; it does **not** claim to establish or repair that historical cause.

## Why This Change Was Made

Add passive, bounded observers to the existing two theme cases and print their snapshots only when a test fails. Evidence includes trusted native input paths, bridge offer/readiness/initialization acknowledgment and state-emission arrival, renderer error state and alert text, outer-frame presentation, and the selected frame's identity/lifecycle.

Keep input and transport with their existing owners. In particular, preserve current main's `clickBoardWidgetControl`, the single click, existing waits, event count/payload expectations, and scrollbar assertions. Diagnostics never start ports, wrap the frozen API, or record ticket/action payload bytes. Collection has its own two-second bound; it does not extend the action assertion's timeout.

## User Impact

No product or UI appearance change. A future failing CI run will retain enough boundary evidence to investigate the missing action instead of inviting a speculative bridge rewrite or retry. Only the existing E2E test and a test-only support file change.

## Evidence

- Original current-main dark/light cases passed before and after adding diagnostics. Focused UI E2E typechecking, lint, formatting, and independent review through P2 passed during the investigation.
- Temporary fault probes, removed from the final source, distinguished an omitted click from a real trusted click whose oversized state payload was rejected. The latter recorded `state.emit` arrival and the caught renderer error while page errors remained empty.
- A [Blacksmith Testbox replay](https://github.com/openclaw/openclaw/actions/runs/34014028436) used the original historical source/configuration/lockfile with Node 24.19.0, pnpm 12.3.4, Vitest 4.1.11, and Playwright 1.62.1. Three original dark-to-light pairs passed, as did the historical shard: 64 files and 289 tests. The job labeled 2/7 actually ran Vitest shard 2/6. The delegated command succeeded and its lease was stopped; backing Actions cleanup is not the test result.
- Shard membership and the set of 28 preceding bundled-file completions matched the saved failure. Exact concurrent interleaving, warm caches, and the original Chromium build were unavailable; the replay used Chromium 144. These passes constrain the investigation but do not prove a historical root cause or attribute recovery to #139076.
- The candidate retains the later native-input helper from #139635 rather than restoring the older hover sequence. At reviewed head `b453c838fd4211c00c81657a8d56f73224a28415`, changed-check passed in full, including core-test typechecking, i18n, formatting, dead-export scans, and scoped lint. The original dark/light E2E pair passed 2/2 (37.46 seconds including bundle preparation), and fresh isolated independent review was clean through P2. Hosted validation is tracked in [exact-head CI run 34075118948](https://github.com/openclaw/openclaw/actions/runs/34075118948).
