### PR TITLE
fix(codex): reduce stale instructions after policy withdrawal

### DIFF
--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -251,6 +251,15 @@ history, verify that Codex unloaded the previous configuration, then append a
 complete superseding policy message before admitting the turn. Historical policy
 text can remain in the transcript; the later policy explicitly supersedes it.
 
+Nonempty generic policies use an OpenClaw-labeled frame that identifies their
+replacement and withdrawal lifetime without changing the policy body. Native
+configuration and the injected refresh use the same framed text, including for
+side conversations. An empty policy remains an exactly empty native configuration
+with a separate withdrawal notice. Framing applies to new policy messages; it
+does not rewrite or retroactively label older history, and it does not replace
+independently supplied native instructions or tool and approval enforcement.
+Model instruction following remains separate from those enforced boundaries.
+
 If another client lease, subscriber, or failed native unload prevents configuration
 proof, the turn stops before inference. A prewrite ownership refusal keeps the
 healthy shared client and its other conversations available. External WebSocket,

--- a/extensions/codex/src/app-server/run-attempt-prompt.ts
+++ b/extensions/codex/src/app-server/run-attempt-prompt.ts
@@ -32,6 +32,7 @@ import {
   codexDynamicToolsFingerprint,
   codexLegacyDynamicToolsFingerprint,
 } from "./thread-lifecycle.js";
+import { frameCodexGenericPolicy } from "./thread-policy.js";
 import { hasCodexMirrorOrigin } from "./transcript-mirror-attestation.js";
 import { readMirrorIdentity } from "./upstream-prompt-provenance.js";
 
@@ -315,7 +316,12 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
   };
   const buildRenderedCodexDeveloperInstructions = () =>
     joinPresentSections(
-      turnState.promptBuild.developerInstructions,
+      frameCodexGenericPolicy(
+        joinPresentSections(
+          turnState.promptBuild.developerInstructions,
+          attemptTools.configuredMcp?.diagnosticNotice,
+        ),
+      ),
       buildTurnCollaborationMode(params, {
         turnScopedDeveloperInstructions: workspaceBootstrapContext.turnScopedDeveloperInstructions,
         skillsCollaborationInstructions,

--- a/extensions/codex/src/app-server/run-attempt-start.ts
+++ b/extensions/codex/src/app-server/run-attempt-start.ts
@@ -234,10 +234,7 @@ export async function startCodexAttemptRuntime(resources: CodexAttemptResources)
     recordCodexTrajectoryContext(trajectoryRecorder, {
       attempt: params,
       cwd: effectiveCwd,
-      developerInstructions: joinPresentSections(
-        buildRenderedCodexDeveloperInstructions(),
-        attemptTools.configuredMcp?.diagnosticNotice,
-      ),
+      developerInstructions: buildRenderedCodexDeveloperInstructions(),
       prompt: turnState.codexTurnPromptText,
       tools: toolBridge.availableSpecs,
     });

--- a/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
@@ -188,6 +188,7 @@ import {
   registerCodexTestSessionIdentity,
   writeCodexAppServerBinding,
 } from "./session-binding.test-helpers.js";
+import { frameCodexGenericPolicy } from "./thread-policy.js";
 
 setupRunAttemptTestHooks();
 
@@ -249,6 +250,7 @@ function createCronAuthorityCapabilityFixture(
 }
 
 function admitLocalOperatorCronAuthority(params: ReturnType<typeof createParams>): void {
+  params.trigger = "user";
   params.cronCreatorAuthorityCapability = createCronAuthorityCapabilityFixture(params.runId);
 }
 
@@ -868,7 +870,6 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
       path.join(tempDir, "workspace-local-operator-mutation"),
     );
     configureFakeMcp(params);
-    params.trigger = "user";
     params.senderIsOwner = false;
     admitLocalOperatorCronAuthority(params);
 
@@ -912,7 +913,6 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
       path.join(tempDir, "workspace-local-operator-incomplete-mcp"),
     );
     configureFakeMcp(params);
-    params.trigger = "user";
     params.senderIsOwner = true;
     admitLocalOperatorCronAuthority(params);
     mcpMocks.staticDiagnosticNotice =
@@ -938,7 +938,6 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
       path.join(tempDir, "workspace-local-operator-aborted-mutation"),
     );
     configureFakeMcp(params);
-    params.trigger = "user";
     params.senderIsOwner = true;
     admitLocalOperatorCronAuthority(params);
 
@@ -970,7 +969,6 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
       path.join(tempDir, "workspace-local-operator-concurrent-mutation"),
     );
     configureFakeMcp(params);
-    params.trigger = "user";
     params.senderIsOwner = true;
     admitLocalOperatorCronAuthority(params);
 
@@ -982,8 +980,7 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
     const secondResolution = resolver({ signal: new AbortController().signal });
 
     expect(secondResolution).toBe(firstResolution);
-    const [first, second] = await Promise.all([firstResolution, secondResolution]);
-    expect(second).toBe(first);
+    await firstResolution;
     expect(mcpMocks.staticCalls).toHaveLength(1);
     expect(mcpMocks.dispose).toHaveBeenCalledOnce();
 
@@ -998,7 +995,6 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
       path.join(tempDir, "workspace-local-operator-unrelated-timeout"),
     );
     configureFakeMcp(params);
-    params.trigger = "user";
     params.senderIsOwner = true;
     admitLocalOperatorCronAuthority(params);
     const failureGate = createDeferred<void>();
@@ -1045,20 +1041,24 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
       params.trigger = "cron";
       params.toolsAllow = ["*"];
       params.scheduledToolPolicy = { version: 1, mode: "trusted" };
-      mcpMocks.staticDiagnosticNotice =
+      const diagnosticNotice =
         "Configured MCP is incomplete for this scheduled run: fake: authentication required. " +
         "Do not claim MCP-backed work succeeded; report this blocker to the operator.";
+      mcpMocks.staticDiagnosticNotice = diagnosticNotice;
+      const promptReport = vi.spyOn(attemptContext, "buildCodexSystemPromptReport");
 
       const harness = createStartedThreadHarness();
       const run = runCodexAppServerAttempt(params);
       await harness.waitForMethod("turn/start");
 
       const threadStart = harness.requests.find((request) => request.method === "thread/start");
-      expect(threadStart?.params).toMatchObject({
-        developerInstructions: [systemPrompt, mcpMocks.staticDiagnosticNotice]
-          .filter(Boolean)
-          .join("\n\n"),
-      });
+      const configuredPolicy = frameCodexGenericPolicy(
+        [systemPrompt, diagnosticNotice].filter(Boolean).join("\n\n"),
+      );
+      expect(threadStart?.params).toMatchObject({ developerInstructions: configuredPolicy });
+      const reportedPolicy = promptReport.mock.calls.at(-1)?.[0].developerInstructions;
+      expect(reportedPolicy?.startsWith(configuredPolicy)).toBe(true);
+      expect(reportedPolicy?.split(diagnosticNotice)).toHaveLength(2);
       expect(harness.requests.some((request) => request.method === "thread/inject_items")).toBe(
         false,
       );

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -905,6 +905,17 @@ describe("runCodexAppServerSideQuestion", () => {
       | { content?: Array<{ text?: string }> }
       | undefined;
     const injectedText = injectedItem?.content?.[0]?.text;
+    expect(injectedText).toBe(forkParams?.developerInstructions);
+    expect(injectedText).toMatch(/^<openclaw_generic_policy>\n/);
+    expect(injectedText).toMatch(/\n<\/openclaw_generic_policy>$/);
+    expect(injectedText?.match(/<openclaw_generic_policy>/g)).toHaveLength(1);
+    expect(injectParams?.items).toEqual([
+      {
+        type: "message",
+        role: "developer",
+        content: [{ type: "input_text", text: forkParams?.developerInstructions }],
+      },
+    ]);
     expect(injectedText).toContain(
       "External tools may be available according to this thread's current permissions",
     );

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -151,6 +151,7 @@ import {
 import {
   assertCodexSupervisionThreadLineage,
   CodexThreadPolicyHandoffError,
+  frameCodexGenericPolicy,
   refreshCodexThreadPolicy,
 } from "./thread-policy.js";
 import { buildCodexTemporalAdditionalContext } from "./turn-params.js";
@@ -172,7 +173,8 @@ const CODEX_SIDE_NATIVE_HOOK_RELAY_TTL_GRACE_MS = 5 * 60_000;
 const CODEX_SIDE_NATIVE_HOOK_RELAY_STARTUP_REQUEST_COUNT = 3;
 const CODEX_SIDE_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS =
   CODEX_NATIVE_HOOK_RELAY_EVENTS.filter((event) => event !== "permission_request");
-const SIDE_DEVELOPER_INSTRUCTIONS = `You are in a side conversation, not the main thread.
+const SIDE_DEVELOPER_INSTRUCTIONS =
+  frameCodexGenericPolicy(`You are in a side conversation, not the main thread.
 
 This side conversation is for answering questions and lightweight, non-mutating exploration without disrupting the main thread. Do not present yourself as continuing the main thread's active task.
 
@@ -184,7 +186,7 @@ External tools may be available according to this thread's current permissions. 
 
 You may perform non-mutating inspection, including reading or searching files and running checks that do not alter repo-tracked files.
 
-Do not modify files, source, git state, permissions, configuration, workspace state, or external state unless the user explicitly requests that mutation in this side conversation. Do not request escalated permissions or broader sandbox access unless the user explicitly requests a mutation that requires it. If the user explicitly requests a mutation, keep it minimal, local to the request, and avoid disrupting the main thread.`;
+Do not modify files, source, git state, permissions, configuration, workspace state, or external state unless the user explicitly requests that mutation in this side conversation. Do not request escalated permissions or broader sandbox access unless the user explicitly requests a mutation that requires it. If the user explicitly requests a mutation, keep it minimal, local to the request, and avoid disrupting the main thread.`);
 
 export async function runCodexAppServerSideQuestion(
   params: AgentHarnessSideQuestionParamsV2,

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -164,6 +164,14 @@ const DEFAULT_CODEX_WEB_SEARCH_THREAD_CONFIG_FINGERPRINT = JSON.stringify({
   web_search: "cached",
 });
 
+const GENERIC_POLICY_NOTICE =
+  "The following is the complete current OpenClaw-supplied generic instruction policy. It replaces earlier OpenClaw-supplied generic policy, including OpenClaw-carried workspace text and sections now absent. Independently supplied native managed, guardian, security, collaboration, and project instructions retain their authority. User requests retain their own authority.\n\n";
+const GENERIC_POLICY_FRAME_PREFIX =
+  "<openclaw_generic_policy>\n" +
+  GENERIC_POLICY_NOTICE +
+  "This policy applies only until a later OpenClaw generic policy replaces or withdraws it, even if this block remains in history. Independently supplied native child-role instructions retain their authority.\n\n";
+const GENERIC_POLICY_FRAME_SUFFIX = "\n</openclaw_generic_policy>";
+
 function writeCodexAppServerBinding(...args: Parameters<typeof writeRawCodexAppServerBinding>) {
   const [sessionFile, binding] = args;
   registerCodexTestSessionIdentity(sessionFile, "session-1", "agent:main:session-1");
@@ -885,6 +893,11 @@ describe("Codex app-server thread lifecycle bindings", () => {
   });
   it.each([
     { developerInstructions: "replacement policy", fault: "none" },
+    {
+      developerInstructions: " \tPolicy café é 漢字\r\n\n  Preserve <literal> & whitespace.\t\n",
+      fault: "none",
+    },
+    { developerInstructions: " \t\r\n ", fault: "none" },
     { developerInstructions: "", fault: "none" },
     { developerInstructions: "replacement policy", fault: "unload" },
     { developerInstructions: "replacement policy", fault: "client retired" },
@@ -995,11 +1008,37 @@ describe("Codex app-server thread lifecycle bindings", () => {
           "thread/resume",
           "thread/inject_items",
         ]);
-        const policy = JSON.stringify(requests.at(-1)?.params);
-        expect(policy).toContain(
-          developerInstructions || "earlier OpenClaw generic policy is withdrawn",
-        );
-        expect(policy).toContain("It replaces earlier OpenClaw-supplied generic policy");
+        const resumeParams = requests.find(({ method }) => method === "thread/resume")?.params;
+        if (!isJsonObject(resumeParams) || typeof resumeParams.developerInstructions !== "string") {
+          throw new Error("Expected the native resume request's complete generic policy");
+        }
+        const configuredPolicy = resumeParams.developerInstructions;
+        if (developerInstructions === "") {
+          expect(configuredPolicy).toBe("");
+        } else {
+          expect(configuredPolicy).toBe(
+            GENERIC_POLICY_FRAME_PREFIX + developerInstructions + GENERIC_POLICY_FRAME_SUFFIX,
+          );
+          expect(configuredPolicy.match(/<openclaw_generic_policy>/g)).toHaveLength(1);
+          expect(
+            Buffer.byteLength(configuredPolicy) - Buffer.byteLength(developerInstructions),
+          ).toBeLessThan(768);
+        }
+        const injectedPolicy =
+          developerInstructions === ""
+            ? GENERIC_POLICY_NOTICE +
+              "The current OpenClaw generic policy is empty; earlier OpenClaw generic policy is withdrawn."
+            : configuredPolicy;
+        expect(requests.at(-1)?.params).toEqual({
+          threadId,
+          items: [
+            {
+              type: "message",
+              role: "developer",
+              content: [{ type: "input_text", text: injectedPolicy }],
+            },
+          ],
+        });
         expect((await readCodexAppServerBinding(sessionFile))?.threadId).toBe(threadId);
       } finally {
         releaseLeasedSharedCodexAppServerClient(wire.client);
@@ -2728,6 +2767,122 @@ describe("Codex app-server thread lifecycle bindings", () => {
       "thread/unsubscribe",
     ]);
   });
+
+  it.each([
+    { initiallyEmpty: false, replacement: "replacement policy" },
+    { initiallyEmpty: false, replacement: "" },
+    { initiallyEmpty: true, replacement: "replacement policy" },
+  ])(
+    "preserves incognito creation policy through refusal and restoration (initially empty: $initiallyEmpty, replacement: $replacement)",
+    async ({ initiallyEmpty, replacement }) => {
+      const sessionFile = path.join(tempDir, "incognito-policy-restoration.jsonl");
+      const workspaceDir = path.join(tempDir, "incognito-policy-workspace");
+      const params = createParams(sessionFile, workspaceDir);
+      params.sessionKey = "agent:main:dashboard:incognito-policy-restoration";
+      const original = initiallyEmpty ? "" : " \tOriginal café 漢字\r\n  Keep these bytes.\n ";
+      const fixture = await createLeasedCodexLifecycleHarness({
+        agentDir: path.join(tempDir, "agent"),
+        respond: async (method) => {
+          if (method === "config/read") {
+            return { config: {}, origins: {}, layers: [] };
+          }
+          if (method === "configRequirements/read") {
+            return { requirements: null };
+          }
+          if (method === "thread/start") {
+            return threadStartResult("incognito-policy-thread");
+          }
+          throw new Error(`unexpected method: ${method}`);
+        },
+      });
+      const { client, request } = fixture;
+      const abandonClient = vi.fn(async () => {});
+      const common = {
+        client,
+        abandonClient,
+        params,
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createThreadLifecycleAppServerOptions(),
+        userMcpServersEnabled: false,
+        developerInstructions: original,
+      };
+      const retain = async (binding: Awaited<ReturnType<typeof startOrResumeThread>>) => {
+        expect(
+          await retainCodexAppServerLiveThread(
+            client,
+            binding.threadId,
+            binding.liveThreadOwnership?.release,
+            binding.liveThreadConfigFingerprint,
+            null,
+            binding.liveThreadEphemeralPolicy,
+          ),
+        ).toBe(true);
+      };
+      try {
+        const created = await startOrResumeThread(common);
+        const creationRequest = request.mock.calls.find(
+          ([method]) => method === "thread/start",
+        )?.[1];
+        if (
+          !isJsonObject(creationRequest) ||
+          typeof creationRequest.developerInstructions !== "string"
+        ) {
+          throw new Error("Expected the native incognito creation policy");
+        }
+        expect(created.liveThreadEphemeralPolicy).toBe(creationRequest.developerInstructions);
+        expect(creationRequest).toMatchObject({
+          ephemeral: true,
+          developerInstructions: initiallyEmpty
+            ? ""
+            : GENERIC_POLICY_FRAME_PREFIX + original + GENERIC_POLICY_FRAME_SUFFIX,
+        });
+        await retain(created);
+        const saved = await readCodexAppServerBinding(sessionFile);
+        const unchanged = await startOrResumeThread(common);
+        expect(unchanged).toMatchObject({
+          threadId: created.threadId,
+          liveThreadEphemeralPolicy: created.liveThreadEphemeralPolicy,
+          lifecycle: { action: "resumed" },
+        });
+        await retain(unchanged);
+        const beforeRefusal = request.mock.calls.length;
+        await expect(
+          startOrResumeThread({ ...common, developerInstructions: replacement }),
+        ).rejects.toMatchObject({
+          name: "CodexIncognitoPolicyChangeError",
+          scope: undefined,
+          message: expect.stringContaining("Restore the previous instructions"),
+        });
+        expect(
+          request.mock.calls
+            .slice(beforeRefusal)
+            .filter(([method]) => method.startsWith("thread/") || method.startsWith("turn/")),
+        ).toEqual([]);
+        await expect(readCodexAppServerBinding(sessionFile)).resolves.toEqual(saved);
+        expect(abandonClient).not.toHaveBeenCalled();
+        expect(client.getCloseError()).toBeUndefined();
+
+        const restored = await startOrResumeThread(common);
+        expect(restored).toMatchObject({
+          threadId: created.threadId,
+          clientId: created.clientId,
+          liveThreadEphemeralPolicy: creationRequest.developerInstructions,
+          lifecycle: { action: "resumed" },
+        });
+        expect(restored.liveThreadOwnership).toBeDefined();
+        expect(() => restored.liveThreadOwnership!.assertCurrent()).not.toThrow();
+        await expect(readCodexAppServerBinding(sessionFile)).resolves.toEqual(saved);
+        expect(
+          request.mock.calls
+            .filter(([method]) => method.startsWith("thread/"))
+            .map(([method]) => method),
+        ).toEqual(["thread/start"]);
+      } finally {
+        client.close();
+      }
+    },
+  );
 
   it.each([
     { restricted: false, mcpDrift: false },

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -466,8 +466,11 @@ describe("Codex ring-zero thread config", () => {
 
     expect(start.environments).toEqual([]);
     expect(start.baseInstructions).toBe("");
-    expect(start.developerInstructions).toBe(developerInstructions);
-    expect(resume.developerInstructions).toBe(developerInstructions);
+    expect(start.developerInstructions).toBe(resume.developerInstructions);
+    expect(start.developerInstructions).toMatch(/^<openclaw_generic_policy>\n/);
+    expect(start.developerInstructions).toContain(
+      `\n\n${developerInstructions}\n</openclaw_generic_policy>`,
+    );
     for (const config of [start.config, resume.config]) {
       expect(config?.["agents.enabled"]).toBe(false);
       expect(config?.["tools.experimental_request_user_input.enabled"]).toBe(false);
@@ -4109,244 +4112,283 @@ describe("Codex app-server supervised branch lifecycle", () => {
     },
   );
 
-  it("materializes a model-locked canonical branch with frozen agent instructions", async () => {
-    const sourceThreadId = "thread-source";
-    const probeThreadId = "thread-probe";
-    const finalThreadId = "thread-final";
-    const lastTurnId = "turn-terminal";
-    const agentWorkspaceDeveloperInstructions = "Follow the frozen supervised AGENTS guidance.";
-    const workspaceDir = path.join(tempDir, "workspace");
-    const attempt = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);
-    attempt.agentDir = path.join(tempDir, "agent");
-    const rolloutPath = path.join(
-      resolveCodexAppServerHomeDir(attempt.agentDir),
-      "sessions",
-      `rollout-${finalThreadId}.jsonl`,
-    );
-    attempt.modelId = "outer-global-default";
-    attempt.expectedSessionRuntimeOwnership = { model: "native", auth: "native" };
-    const identity = await seedPendingSupervisionBinding({
-      attempt,
-      cwd: workspaceDir,
-      pending: { sourceThreadId, lastTurnId },
-    });
-    const terminalSource = sourceThread({
-      threadId: sourceThreadId,
-      turns: [
+  it.each([" \tGeneric café 漢字 policy.\r\n  Preserve <literal> & whitespace.\n ", ""])(
+    "materializes a model-locked canonical branch with frozen agent instructions (generic policy: %s)",
+    async (developerInstructions) => {
+      const sourceThreadId = "thread-source";
+      const probeThreadId = "thread-probe";
+      const finalThreadId = "thread-final";
+      const lastTurnId = "turn-terminal";
+      const agentWorkspaceDeveloperInstructions = "Follow the frozen supervised AGENTS guidance.";
+      const workspaceDir = path.join(tempDir, "workspace");
+      const attempt = createThreadLifecycleParams(
+        path.join(tempDir, "session.jsonl"),
+        workspaceDir,
+      );
+      attempt.agentDir = path.join(tempDir, "agent");
+      const rolloutPath = path.join(
+        resolveCodexAppServerHomeDir(attempt.agentDir),
+        "sessions",
+        `rollout-${finalThreadId}.jsonl`,
+      );
+      attempt.modelId = "outer-global-default";
+      attempt.expectedSessionRuntimeOwnership = { model: "native", auth: "native" };
+      const identity = await seedPendingSupervisionBinding({
+        attempt,
+        cwd: workspaceDir,
+        pending: { sourceThreadId, lastTurnId },
+      });
+      const terminalSource = sourceThread({
+        threadId: sourceThreadId,
+        turns: [
+          {
+            id: lastTurnId,
+            status: "completed",
+            items: [
+              {
+                id: "user-1",
+                type: "userMessage",
+                content: [{ type: "text", text: "Visible question" }],
+              },
+              { id: "reasoning-1", type: "reasoning", text: "Private reasoning" },
+              {
+                id: "assistant-1",
+                type: "agentMessage",
+                text: "Visible answer",
+                phase: "final_answer",
+              },
+              { id: "tool-1", type: "commandExecution", command: "secret-tool" },
+            ],
+          },
+        ],
+      });
+      const request = vi.fn(async (method: string, requestParams: unknown) => {
+        if (method === "config/read") {
+          return { config: {}, origins: {}, layers: [] };
+        }
+        if (method === "configRequirements/read") {
+          return { requirements: null };
+        }
+        if (method === "thread/read") {
+          const threadId = (requestParams as { threadId?: string }).threadId;
+          return {
+            thread:
+              threadId === sourceThreadId
+                ? terminalSource
+                : {
+                    ...sourceThread({ threadId: finalThreadId, status: "notLoaded" }),
+                    path: rolloutPath,
+                  },
+          };
+        }
+        if (method === "thread/fork") {
+          return nativeThreadResult(probeThreadId, "native-effective", "native-provider");
+        }
+        if (method === "thread/start" || method === "thread/resume") {
+          return nativeThreadResult(finalThreadId, "native-effective", "native-provider");
+        }
+        if (method === "thread/inject_items" || method === "thread/unsubscribe") {
+          return {};
+        }
+        throw new Error(`unexpected method: ${method}`);
+      });
+      const dynamicTools = [
         {
-          id: lastTurnId,
-          status: "completed",
-          items: [
-            {
-              id: "user-1",
-              type: "userMessage",
-              content: [{ type: "text", text: "Visible question" }],
-            },
-            { id: "reasoning-1", type: "reasoning", text: "Private reasoning" },
-            {
-              id: "assistant-1",
-              type: "agentMessage",
-              text: "Visible answer",
-              phase: "final_answer",
-            },
-            { id: "tool-1", type: "commandExecution", command: "secret-tool" },
-          ],
+          type: "function" as const,
+          name: "message",
+          description: "Send a message",
+          inputSchema: { type: "object", properties: {} },
         },
-      ],
-    });
-    const request = vi.fn(async (method: string, requestParams: unknown) => {
-      if (method === "config/read") {
-        return { config: {}, origins: {}, layers: [] };
-      }
-      if (method === "configRequirements/read") {
-        return { requirements: null };
-      }
-      if (method === "thread/read") {
-        const threadId = (requestParams as { threadId?: string }).threadId;
-        return {
-          thread:
-            threadId === sourceThreadId
-              ? terminalSource
-              : {
-                  ...sourceThread({ threadId: finalThreadId, status: "notLoaded" }),
-                  path: rolloutPath,
-                },
-        };
-      }
-      if (method === "thread/fork") {
-        return nativeThreadResult(probeThreadId, "native-effective", "native-provider");
-      }
-      if (method === "thread/start" || method === "thread/resume") {
-        return nativeThreadResult(finalThreadId, "native-effective", "native-provider");
-      }
-      if (method === "thread/inject_items" || method === "thread/unsubscribe") {
-        return {};
-      }
-      throw new Error(`unexpected method: ${method}`);
-    });
-    const dynamicTools = [
-      {
-        type: "function" as const,
-        name: "message",
-        description: "Send a message",
-        inputSchema: { type: "object", properties: {} },
-      },
-    ];
-    const commonParams = {
-      client: { request } as never,
-      params: attempt,
-      cwd: workspaceDir,
-      dynamicTools,
-      developerInstructions: agentWorkspaceDeveloperInstructions,
-      agentWorkspaceDeveloperInstructions,
-      environmentSelection: [{ environmentId: "local", cwd: workspaceDir }],
-      shellEnvironment: { GH_TOKEN: "", GITHUB_TOKEN: "" },
-      disableLoginShell: true,
-      appServer: createThreadLifecycleAppServerOptions(),
-      appServerRuntimeFingerprint: "codex-runtime-v1",
-    };
+      ];
+      const commonParams = {
+        client: { request } as never,
+        params: attempt,
+        cwd: workspaceDir,
+        dynamicTools,
+        developerInstructions,
+        agentWorkspaceDeveloperInstructions,
+        environmentSelection: [{ environmentId: "local", cwd: workspaceDir }],
+        shellEnvironment: { GH_TOKEN: "", GITHUB_TOKEN: "" },
+        disableLoginShell: true,
+        appServer: createThreadLifecycleAppServerOptions(),
+        appServerRuntimeFingerprint: "codex-runtime-v1",
+      };
 
-    const materialized = await startOrResumeThread(commonParams);
+      const materialized = await startOrResumeThread(commonParams);
 
-    expect(request.mock.calls.map(([method]) => method)).toEqual([
-      "config/read",
-      "configRequirements/read",
-      "thread/read",
-      "thread/fork",
-      "thread/unsubscribe",
-      "thread/start",
-      "thread/inject_items",
-    ]);
-    expect(request.mock.calls[2]?.[1]).toEqual({
-      threadId: sourceThreadId,
-      includeTurns: true,
-    });
-    const forkParams = request.mock.calls[3]?.[1] as Record<string, unknown>;
-    expect(forkParams).toMatchObject({
-      threadId: sourceThreadId,
-      lastTurnId,
-      excludeTurns: true,
-      developerInstructions: agentWorkspaceDeveloperInstructions,
-      config: {
-        project_doc_max_bytes: 131_072,
-        allow_login_shell: false,
-        shell_environment_policy: {
-          experimental_use_profile: false,
-          set: { GH_TOKEN: "", GITHUB_TOKEN: "" },
+      expect(request.mock.calls.map(([method]) => method)).toEqual([
+        "config/read",
+        "configRequirements/read",
+        "thread/read",
+        "thread/fork",
+        "thread/unsubscribe",
+        "thread/start",
+        "thread/inject_items",
+      ]);
+      expect(request.mock.calls[2]?.[1]).toEqual({
+        threadId: sourceThreadId,
+        includeTurns: true,
+      });
+      const forkParams = request.mock.calls[3]?.[1] as Record<string, unknown>;
+      const configuredPolicy = forkParams.developerInstructions;
+      if (typeof configuredPolicy !== "string") {
+        throw new Error("Expected the native supervision probe's complete generic policy");
+      }
+      if (developerInstructions === "") {
+        expect(configuredPolicy).toBe("");
+      } else {
+        expect(configuredPolicy).toMatch(/^<openclaw_generic_policy>\n/);
+        expect(
+          configuredPolicy.endsWith(`\n\n${developerInstructions}\n</openclaw_generic_policy>`),
+        ).toBe(true);
+        expect(configuredPolicy.match(/<openclaw_generic_policy>/g)).toHaveLength(1);
+        expect(
+          Buffer.byteLength(configuredPolicy) - Buffer.byteLength(developerInstructions),
+        ).toBeLessThan(768);
+      }
+      expect(forkParams).toMatchObject({
+        threadId: sourceThreadId,
+        lastTurnId,
+        excludeTurns: true,
+        config: {
+          project_doc_max_bytes: 131_072,
+          allow_login_shell: false,
+          shell_environment_policy: {
+            experimental_use_profile: false,
+            set: { GH_TOKEN: "", GITHUB_TOKEN: "" },
+          },
         },
-      },
-    });
-    expect(forkParams).not.toHaveProperty("model");
-    expect(forkParams).not.toHaveProperty("modelProvider");
-    expect(forkParams).not.toHaveProperty("dynamicTools");
-    expect(forkParams).not.toHaveProperty("environments");
-    const startParams = request.mock.calls.find(
-      ([method]) => method === "thread/start",
-    )?.[1] as Record<string, unknown>;
-    expect(startParams).toMatchObject({
-      model: "native-effective",
-      modelProvider: "native-provider",
-      developerInstructions: agentWorkspaceDeveloperInstructions,
-      dynamicTools,
-      environments: [{ environmentId: "local", cwd: workspaceDir }],
-      config: {
-        project_doc_max_bytes: 131_072,
-        allow_login_shell: false,
-        shell_environment_policy: {
-          experimental_use_profile: false,
-          set: { GH_TOKEN: "", GITHUB_TOKEN: "" },
+      });
+      expect(forkParams).not.toHaveProperty("model");
+      expect(forkParams).not.toHaveProperty("modelProvider");
+      expect(forkParams).not.toHaveProperty("dynamicTools");
+      expect(forkParams).not.toHaveProperty("environments");
+      const startParams = request.mock.calls.find(
+        ([method]) => method === "thread/start",
+      )?.[1] as Record<string, unknown>;
+      expect(startParams).toMatchObject({
+        model: "native-effective",
+        modelProvider: "native-provider",
+        developerInstructions: configuredPolicy,
+        dynamicTools,
+        environments: [{ environmentId: "local", cwd: workspaceDir }],
+        config: {
+          project_doc_max_bytes: 131_072,
+          allow_login_shell: false,
+          shell_environment_policy: {
+            experimental_use_profile: false,
+            set: { GH_TOKEN: "", GITHUB_TOKEN: "" },
+          },
         },
-      },
-    });
-    expect(startParams.model).not.toBe(attempt.modelId);
-    expect(request.mock.calls.find(([method]) => method === "thread/inject_items")?.[1]).toEqual({
-      threadId: finalThreadId,
-      items: [
-        {
-          type: "message",
-          role: "user",
-          content: [{ type: "input_text", text: "Visible question" }],
-        },
-        {
-          type: "message",
-          role: "assistant",
-          content: [{ type: "output_text", text: "Visible answer" }],
-          phase: "final_answer",
-        },
-      ],
-    });
-    expect(
-      JSON.stringify(request.mock.calls.find(([method]) => method === "thread/inject_items")?.[1]),
-    ).not.toContain("Private reasoning");
-    expect(
-      JSON.stringify(request.mock.calls.find(([method]) => method === "thread/inject_items")?.[1]),
-    ).not.toContain("secret-tool");
-    expect(request.mock.calls[4]?.[1]).toEqual({ threadId: probeThreadId });
-    expect(materialized).toMatchObject({
-      threadId: finalThreadId,
-      model: "native-effective",
-      modelProvider: "native-provider",
-      preserveNativeModel: true,
-      agentWorkspaceDeveloperInstructions,
-      conversationSourceTransferComplete: true,
-      lifecycle: { action: "forked" },
-    });
-    expect(materialized.pendingSupervisionBranch).toBeUndefined();
-    expect(materialized.historyCoveredThrough).not.toBe(new Date(0).toISOString());
-    expect(testCodexAppServerBindingStore.read(identity)).toMatchObject({
-      threadId: finalThreadId,
-      model: "native-effective",
-      modelProvider: "native-provider",
-      preserveNativeModel: true,
-      agentWorkspaceDeveloperInstructions,
-      conversationSourceTransferComplete: true,
-      appServerRuntimeFingerprint: buildCodexAppServerConnectionFingerprint(
-        commonParams.appServer,
-        attempt.agentDir,
-      ),
-    });
+      });
+      expect(startParams.model).not.toBe(attempt.modelId);
+      expect(request.mock.calls.find(([method]) => method === "thread/inject_items")?.[1]).toEqual({
+        threadId: finalThreadId,
+        items: [
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "Visible question" }],
+          },
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Visible answer" }],
+            phase: "final_answer",
+          },
+        ],
+      });
+      expect(
+        JSON.stringify(
+          request.mock.calls.find(([method]) => method === "thread/inject_items")?.[1],
+        ),
+      ).not.toContain("Private reasoning");
+      expect(
+        JSON.stringify(
+          request.mock.calls.find(([method]) => method === "thread/inject_items")?.[1],
+        ),
+      ).not.toContain("secret-tool");
+      expect(request.mock.calls[4]?.[1]).toEqual({ threadId: probeThreadId });
+      expect(materialized).toMatchObject({
+        threadId: finalThreadId,
+        model: "native-effective",
+        modelProvider: "native-provider",
+        preserveNativeModel: true,
+        agentWorkspaceDeveloperInstructions,
+        conversationSourceTransferComplete: true,
+        lifecycle: { action: "forked" },
+      });
+      expect(materialized.pendingSupervisionBranch).toBeUndefined();
+      expect(materialized.historyCoveredThrough).not.toBe(new Date(0).toISOString());
+      expect(testCodexAppServerBindingStore.read(identity)).toMatchObject({
+        threadId: finalThreadId,
+        model: "native-effective",
+        modelProvider: "native-provider",
+        preserveNativeModel: true,
+        agentWorkspaceDeveloperInstructions,
+        conversationSourceTransferComplete: true,
+        appServerRuntimeFingerprint: buildCodexAppServerConnectionFingerprint(
+          commonParams.appServer,
+          attempt.agentDir,
+        ),
+      });
 
-    await writeNativeCatalogFixture(rolloutPath, finalThreadId, startParams.dynamicTools);
-    request.mockClear();
-    const resumed = await withLeasedCodexTestClient({
-      agentDir: path.join(tempDir, "agent"),
-      request,
-      run: (client) =>
-        startOrResumeThread({
-          ...commonParams,
-          client,
-          signal: AbortSignal.timeout(10_000),
-          appServerRuntimeFingerprint: "codex-runtime-v2",
-        }),
-    });
+      await writeNativeCatalogFixture(rolloutPath, finalThreadId, startParams.dynamicTools);
+      request.mockClear();
+      const resumed = await withLeasedCodexTestClient({
+        agentDir: path.join(tempDir, "agent"),
+        request,
+        run: (client) =>
+          startOrResumeThread({
+            ...commonParams,
+            client,
+            signal: AbortSignal.timeout(10_000),
+            appServerRuntimeFingerprint: "codex-runtime-v2",
+          }),
+      });
 
-    expect(request.mock.calls.map(([method]) => method)).toEqual([
-      "thread/read",
-      "config/read",
-      "configRequirements/read",
-      "thread/read",
-      "thread/resume",
-      "thread/inject_items",
-    ]);
-    expect(request.mock.calls[0]?.[1]).toEqual({ threadId: finalThreadId, includeTurns: false });
-    expect(request.mock.calls[4]?.[1]).not.toHaveProperty("model");
-    expect(request.mock.calls[4]?.[1]).not.toHaveProperty("modelProvider");
-    expect(request.mock.calls[4]?.[1]).toMatchObject({
-      developerInstructions: agentWorkspaceDeveloperInstructions,
-    });
-    expect(resumed).toMatchObject({
-      threadId: finalThreadId,
-      preserveNativeModel: true,
-      conversationSourceTransferComplete: true,
-      lifecycle: { action: "resumed" },
-    });
-    expect(testCodexAppServerBindingStore.read(identity)).toMatchObject({
-      appServerRuntimeFingerprint: buildCodexAppServerConnectionFingerprint(
-        commonParams.appServer,
-        attempt.agentDir,
-      ),
-    });
-  });
+      expect(request.mock.calls.map(([method]) => method)).toEqual([
+        "thread/read",
+        "config/read",
+        "configRequirements/read",
+        "thread/read",
+        "thread/resume",
+        "thread/inject_items",
+      ]);
+      expect(request.mock.calls[0]?.[1]).toEqual({ threadId: finalThreadId, includeTurns: false });
+      expect(request.mock.calls[4]?.[1]).not.toHaveProperty("model");
+      expect(request.mock.calls[4]?.[1]).not.toHaveProperty("modelProvider");
+      expect(request.mock.calls[4]?.[1]).toMatchObject({
+        developerInstructions: configuredPolicy,
+      });
+      const injectedPolicy =
+        developerInstructions === ""
+          ? "The following is the complete current OpenClaw-supplied generic instruction policy. It replaces earlier OpenClaw-supplied generic policy, including OpenClaw-carried workspace text and sections now absent. Independently supplied native managed, guardian, security, collaboration, and project instructions retain their authority. User requests retain their own authority.\n\nThe current OpenClaw generic policy is empty; earlier OpenClaw generic policy is withdrawn."
+          : configuredPolicy;
+      expect(request.mock.calls[5]?.[1]).toEqual({
+        threadId: finalThreadId,
+        items: [
+          {
+            type: "message",
+            role: "developer",
+            content: [{ type: "input_text", text: injectedPolicy }],
+          },
+        ],
+      });
+      expect(resumed).toMatchObject({
+        threadId: finalThreadId,
+        preserveNativeModel: true,
+        conversationSourceTransferComplete: true,
+        lifecycle: { action: "resumed" },
+      });
+      expect(testCodexAppServerBindingStore.read(identity)).toMatchObject({
+        appServerRuntimeFingerprint: buildCodexAppServerConnectionFingerprint(
+          commonParams.appServer,
+          attempt.agentDir,
+        ),
+      });
+    },
+  );
 
   it("isolates both supervised threads and restores native MCP config on the next unrestricted turn", async () => {
     const sourceThreadId = "thread-source";

--- a/extensions/codex/src/app-server/thread-policy.ts
+++ b/extensions/codex/src/app-server/thread-policy.ts
@@ -11,6 +11,19 @@ import {
 } from "./request.js";
 import type { CodexAppServerThreadBinding } from "./session-binding.js";
 
+const CODEX_GENERIC_POLICY_NOTICE =
+  "The following is the complete current OpenClaw-supplied generic instruction policy. It replaces earlier OpenClaw-supplied generic policy, including OpenClaw-carried workspace text and sections now absent. Independently supplied native managed, guardian, security, collaboration, and project instructions retain their authority. User requests retain their own authority.\n\n";
+
+/** Frame final policy once; the empty string must still clear native generic configuration. */
+export function frameCodexGenericPolicy(instructions: string): string {
+  if (instructions === "") {
+    return "";
+  }
+  // Native child forks replace the exact configured string. Keep the notice inside
+  // that same frame so replacement cannot leave it around an independent child override.
+  return `<openclaw_generic_policy>\n${CODEX_GENERIC_POLICY_NOTICE}This policy applies only until a later OpenClaw generic policy replaces or withdraws it, even if this block remains in history. Independently supplied native child-role instructions retain their authority.\n\n${instructions}\n</openclaw_generic_policy>`;
+}
+
 /** A refusal, not a failed native write: the ephemeral conversation must stay alive. */
 export class CodexIncognitoPolicyChangeError extends AgentHarnessPreflightError {
   constructor() {
@@ -44,13 +57,10 @@ export async function refreshCodexThreadPolicy(params: {
   signal?: AbortSignal;
   assertCurrent: () => void;
 }): Promise<void> {
-  const notice =
-    "The following is the complete current OpenClaw-supplied generic instruction policy. It replaces earlier OpenClaw-supplied generic policy, including OpenClaw-carried workspace text and sections now absent. Independently supplied native managed, guardian, security, collaboration, and project instructions retain their authority. User requests retain their own authority.\n\n";
   const text =
-    notice +
-    (params.developerInstructions === ""
-      ? "The current OpenClaw generic policy is empty; earlier OpenClaw generic policy is withdrawn."
-      : params.developerInstructions);
+    params.developerInstructions === ""
+      ? `${CODEX_GENERIC_POLICY_NOTICE}The current OpenClaw generic policy is empty; earlier OpenClaw generic policy is withdrawn.`
+      : params.developerInstructions;
   let outcome: CodexThreadPolicyHandoffError["outcome"] = "unknown";
   try {
     await requestCodexAppServerClientJson({

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -36,6 +36,7 @@ import {
   resolveCodexAppServerModelProvider,
   resolveCodexAppServerRequestModelSelection,
 } from "./thread-model-selection.js";
+import { frameCodexGenericPolicy } from "./thread-policy.js";
 import { buildDeveloperInstructions, type CodexThreadPromptContext } from "./thread-prompt.js";
 import { applyCodexManagedShellEnvironment } from "./thread-shell-environment.js";
 import { resolveCodexWebSearchPlan, type CodexNativeWebSearchSupport } from "./web-search.js";
@@ -212,9 +213,10 @@ export function buildCodexThreadConfiguration(
       shellEnvironment: options.shellEnvironment,
       disableLoginShell: options.disableLoginShell,
     }),
-    developerInstructions:
+    developerInstructions: frameCodexGenericPolicy(
       options.developerInstructions ??
-      buildDeveloperInstructions(params, { dynamicTools: options.dynamicTools }),
+        buildDeveloperInstructions(params, { dynamicTools: options.dynamicTools }),
+    ),
   };
 }
 

--- a/extensions/codex/src/app-server/thread-supervision.ts
+++ b/extensions/codex/src/app-server/thread-supervision.ts
@@ -42,6 +42,7 @@ import {
 } from "./thread-lifecycle-errors.js";
 import type { CodexThreadLifecycleTimingTracker } from "./thread-lifecycle-timing.js";
 import type { CodexAppServerThreadLifecycleBinding } from "./thread-lifecycle-types.js";
+import { frameCodexGenericPolicy } from "./thread-policy.js";
 import { buildDeveloperInstructions } from "./thread-prompt.js";
 import {
   attestCodexRestrictedToolSurfaceMcpServersDisabled,
@@ -494,9 +495,10 @@ function buildPendingSupervisionProbeForkParams(
       ? { serviceTier: params.appServer.serviceTier }
       : {}),
     config: runtimeConfig,
-    developerInstructions:
+    developerInstructions: frameCodexGenericPolicy(
       params.developerInstructions ??
-      buildDeveloperInstructions(params.attempt, { dynamicTools: params.dynamicTools }),
+        buildDeveloperInstructions(params.attempt, { dynamicTools: params.dynamicTools }),
+    ),
     ephemeral: true,
     threadSource: "appServer",
     excludeTurns: true,

--- a/extensions/codex/src/app-server/upstream-session-fork-continuation.test.ts
+++ b/extensions/codex/src/app-server/upstream-session-fork-continuation.test.ts
@@ -24,6 +24,7 @@ import {
 import { createCodexTestBindingStateStore } from "./session-binding.test-helpers.js";
 import { createCodexTestModel } from "./test-support.js";
 import { startOrResumeThread } from "./thread-lifecycle.js";
+import { frameCodexGenericPolicy } from "./thread-policy.js";
 import { importCodexThreadHistoryToTranscript } from "./transcript-mirror.js";
 import {
   createForkTestRuntime,
@@ -325,7 +326,7 @@ describe("persistent upstream fork continuation", () => {
           model: nativeModel,
           modelProvider: "openai",
           dynamicTools,
-          developerInstructions,
+          developerInstructions: frameCodexGenericPolicy(developerInstructions),
         }),
         expect.anything(),
       );

--- a/test/canonical-descendant.integration.test.ts
+++ b/test/canonical-descendant.integration.test.ts
@@ -73,14 +73,22 @@ afterEach(() => {
 
 type CanonicalForkFixture = Awaited<ReturnType<typeof createCanonicalForkFixtureForTest>>;
 
+const GENERIC_POLICY_NOTICE =
+  "The following is the complete current OpenClaw-supplied generic instruction policy. It replaces earlier OpenClaw-supplied generic policy, including OpenClaw-carried workspace text and sections now absent. Independently supplied native managed, guardian, security, collaboration, and project instructions retain their authority. User requests retain their own authority.\n\n";
+const GENERIC_POLICY_FRAME_PREFIX = `<openclaw_generic_policy>\n${GENERIC_POLICY_NOTICE}This policy applies only until a later OpenClaw generic policy replaces or withdraws it, even if this block remains in history. Independently supplied native child-role instructions retain their authority.\n\n`;
+
 function expectPolicyHandoff(
   calls: CanonicalForkFixture["native"]["calls"],
   threadId: string,
-  body: unknown,
+  configuredPolicy: unknown,
 ) {
-  if (typeof body !== "string") {
+  if (typeof configuredPolicy !== "string") {
     throw new Error("Expected the complete generic policy, including an explicit empty body");
   }
+  const text =
+    configuredPolicy === ""
+      ? `${GENERIC_POLICY_NOTICE}The current OpenClaw generic policy is empty; earlier OpenClaw generic policy is withdrawn.`
+      : configuredPolicy;
   const refreshes = calls.filter((call) => call.method === "thread/inject_items");
   expect(refreshes).toHaveLength(1);
   expect(refreshes[0]?.params).toEqual({
@@ -89,12 +97,7 @@ function expectPolicyHandoff(
       {
         type: "message",
         role: "developer",
-        content: [
-          {
-            type: "input_text",
-            text: expect.stringContaining(body || "current OpenClaw generic policy is empty"),
-          },
-        ],
+        content: [{ type: "input_text", text }],
       },
     ],
   });
@@ -470,8 +473,10 @@ describe("canonical descendant lifecycle through real owners", () => {
           calls.find((call) => call.method === "thread/resume"),
           "cold configuration",
         );
-        expect(resume.params.developerInstructions).toBe(body);
-        expectPolicyHandoff(calls, binding.threadId, body);
+        const expectedPolicy =
+          body === "" ? "" : `${GENERIC_POLICY_FRAME_PREFIX}${body}\n</openclaw_generic_policy>`;
+        expect(resume.params.developerInstructions).toBe(expectedPolicy);
+        expectPolicyHandoff(calls, binding.threadId, resume.params.developerInstructions);
         expect(calls.findIndex((call) => call.method === "thread/inject_items")).toBeLessThan(
           calls.findIndex((call) => call.method === "turn/start"),
         );


### PR DESCRIPTION
Related: #135338. Follow-up to #135577; the native configuration/ownership repair remains intact.

## What Problem This Solves

Resolves a reliability problem where ongoing Codex conversations can keep following an earlier OpenClaw generic policy after a prompt hook replaces or withdraws it. The native configuration can already be correctly empty and the withdrawal recorded, yet the model can still return the old policy's requested output because that policy remains in append-only history.

This is an explicitly approved **model-visible policy-format change**, not a behavior-neutral cleanup or a new authorization boundary.

## Why This Change Was Made

Frame the final nonempty OpenClaw generic policy once, identifying its origin and stating that it applies only until a later OpenClaw policy replaces or withdraws it. Preserve the policy body byte-for-byte. Exactly empty configuration remains `""`, and its existing separate withdrawal notice is unchanged.

The entire nonempty injected refresh equals the native configured string, with the supersession notice inside the frame. Stock Codex V2 child overrides replace the current parent's configured literal string; leaving a notice outside it would leave text surrounding the child override. The common configuration producer covers start/resume/canonical forks; direct supervision probes and side conversations use the same framing. Prompt reports count the frame and MCP diagnostics once, with collaboration instructions kept separate.

No native patch, dependency/config/schema change, history rewriting, new runtime store, or weakening of ownership, incognito refusal/recovery, or unknown-write handling. Independent native managed/project/guardian/security/collaboration/child-role instructions retain their own authority.

## User Impact

New OpenClaw policies carry explicit replacement/withdrawal semantics, reducing ambiguity when older policy text remains in a conversation. This does **not** retroactively label legacy history, erase historical policies, guarantee model obedience, or replace enforced tool/approval boundaries. The fixed added overhead is 631 UTF-8 bytes, below the frozen 768-byte budget; empty policy adds no frame.

Production LOC: **+36/−17 (net +19)**. Tests: **+475/−261 (net +214)**. Docs: **+9**. Production growth implements one encoder and consistent final-policy/report composition, without a parallel lifecycle path.

## Evidence

### Fixed-count live comparison

Both cohorts used the same OpenClaw base `8c7e36560d11d3ed211e2aca254efd33e34cdcb0`, stock Codex **0.153.4**, public model **gpt-5.6-luna**, provider name exactly **OpenAI**, recorder hashes, and predefined scenario order. Each contained **22 scenarios and 52 HTTP-200 requests**.

| Scenario | Unchanged control | Framed candidate |
| --- | --- | --- |
| Warm withdrawal, five distinct histories | 1 stale-marker failure | 0 failures |
| Cold withdrawal, five distinct histories | 1 stale-marker failure | 0 failures |
| Warm withdrawal → compaction → empty policy | Passed | Passed |
| Cold withdrawal → compaction → empty policy | Passed | Passed |

The candidate had zero behavioral failures across all 22 scenarios. Native delivery/configuration, metadata, ownership, incognito refusal/restoration, and execution checks passed in both cohorts. Every cohort closed/exited all 31 native clients, closed both relay servers, and joined its composition process with no outstanding native PIDs.

This is finite, sequential evidence—not statistically established improvement or deterministic obedience. The candidate text was frozen before comparison; no prompt tuning or extra cohort was used to obtain green model results. An earlier 53-request control is retained separately with three marker failures; it exposed recorder response-tail handling and an obsolete contention-fixture assumption and is not pooled with the corrected comparison. Seven local recorder regressions verified the correction before the paired run. Synthetic ordered captures and source identities are retained locally; no operator conversation or credential is included in this PR.

Stock native binary SHA-256: `b973d440acac501fd2594a43e7ca9ce41e0a65b9dfb28d0d7a7837c99e1261e3`. Exact native source inspected at `3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`, including [generic fragment serialization](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/core/src/context/developer_instructions.rs) and [current-parent replacement in native child forks](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/core/src/agent/control/spawn.rs#L826-L1045). Content-kind metadata is enabled by default; non-OpenAI provider-name filtering is a separate behavior, not the explanation claimed here.

### Native child and local validation

- Stock-native, credential-free scripted-provider baseline and candidate each passed two cases / seven requests: current-parent inheritance and A→B refresh followed by a V2 child override. Independent project/permissions/collaboration fragments and native child identity were verified. These are payload tests, not child model-obedience tests; compacted-history child variants were not exercised.
- New framing regressions demonstrably failed before production edits for missing framing/configuration-injection mismatch. Coverage preserves exact empty policy, Unicode/CRLF/whitespace and long bodies, incognito same-thread restoration, and uncertain-write no-replay behavior.
- **810 tests passed across nine full Codex files**: lifecycle binding, lifecycle, side questions, upstream fork, upstream-fork continuation, run attempt, hooks, configured MCP, and compaction.
- After test-only cleanup, **71 canonical integration + 28 configured-MCP tests passed**. The 28 MCP cases overlap the 810 and must not be added again. The old canonical raw-text expectation was reproduced failing before migration; full configured/injected equality now replaces its weaker substring check.
- Final **`node scripts/check-changed.mjs` passed**, including extension/root-test types and lint, import cycles, and runtime guards. **`pnpm build` passed**, including declarations, SDK exports, plugin runtime/assets, and Control UI output. Only nonblocking upstream eval, browser-externalization, and timing advisories were emitted.
- Fresh isolated Codex autoreview of the final candidate completed **scoped-clean at P0–P2, with no findings**.

Static/build proof used an independently installed, byte-identical checkout outside the parent repository's dependency tree. The nested worktree's compiler consulted outer package manifests despite its own frozen install; no containment guard, dependency, or baseline was weakened. That tooling issue is separate from this PR.

The final validated tracked diff SHA-256 is `475d4c4f71d403894a9c6868d3218136cde038b93a85779f92f182804c2edb74`. The six-file production diff remained unchanged after live proof: `188d03447029dfabb6cf0aaf9b0290a4d646e9261829cf919b2f3cde0a0261ca`.

Documentation: https://docs.openclaw.ai/plugins/codex-harness-runtime#hook-boundaries
