### PR TITLE
refactor(ui): share composer suggestion menu behavior

### DIFF
--- a/ui/src/components/composer-menu.ts
+++ b/ui/src/components/composer-menu.ts
@@ -1,0 +1,133 @@
+import { html, nothing } from "lit";
+import { ref } from "lit/directives/ref.js";
+
+export function handleComposerMenuKeydown(
+  event: KeyboardEvent,
+  menu: {
+    count: number;
+    index: number;
+    consumeEmpty: boolean;
+    close: () => void;
+    move: (index: number) => string | null;
+    select: (key: "Enter" | "Tab") => void;
+  },
+): boolean {
+  if (event.key === "Escape") {
+    event.preventDefault();
+    menu.close();
+    return true;
+  }
+  if (
+    !["ArrowDown", "ArrowUp", "Enter", "Tab"].includes(event.key) ||
+    (menu.count === 0 && !menu.consumeEmpty)
+  ) {
+    return false;
+  }
+  event.preventDefault();
+  if (menu.count > 0) {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      const offset = event.key === "ArrowDown" ? 1 : menu.count - 1;
+      scrollActiveOptionIntoView(menu.move((menu.index + offset) % menu.count));
+    } else if (event.key === "Enter" || event.key === "Tab") {
+      menu.select(event.key);
+    }
+  }
+  return true;
+}
+
+export function renderComposerMenu(options: {
+  id: string;
+  label: string;
+  className?: string;
+  trackScroll?: boolean;
+  content: unknown;
+}) {
+  return html`<div
+    id=${options.id}
+    class="slash-menu ${options.className ?? ""}"
+    role="listbox"
+    aria-label=${options.label}
+  >
+    <div
+      class="slash-menu__scroll"
+      ${ref(syncMenuScroll)}
+      @scroll=${
+        options.trackScroll === false
+          ? nothing
+          : (event: Event) =>
+              syncMenuScroll(
+                event.currentTarget instanceof Element ? event.currentTarget : undefined,
+              )
+      }
+    >
+      ${options.content}
+    </div>
+  </div>`;
+}
+
+export function renderComposerMenuOption(options: {
+  id: string;
+  active: boolean;
+  select: () => void;
+  hover: () => void;
+  preserveFocus?: boolean;
+  icon: unknown;
+  iconHidden?: boolean;
+  name: unknown;
+  description: unknown;
+}) {
+  return html`<div
+    id=${options.id}
+    class="slash-menu-item ${options.active ? "slash-menu-item--active" : ""}"
+    role="option"
+    aria-selected=${options.active}
+    @mousedown=${options.preserveFocus === false ? nothing : (event: MouseEvent) => event.preventDefault()}
+    @click=${options.select}
+    @mouseenter=${options.hover}
+  >
+    <span class="slash-menu-icon" aria-hidden=${options.iconHidden ? "true" : nothing}
+      >${options.icon}</span
+    >
+    <span class="slash-menu-copy">
+      <span class="slash-menu-name">${options.name}</span>
+      <span class="slash-menu-desc">${options.description}</span>
+    </span>
+  </div>`;
+}
+
+function scrollActiveOptionIntoView(activeId: string | null): void {
+  if (!activeId) {
+    return;
+  }
+  requestAnimationFrame(() => {
+    const activeOption = document.getElementById(activeId);
+    const scrollRegion = activeOption?.closest<HTMLElement>(".slash-menu__scroll");
+    if (!activeOption || !scrollRegion) {
+      return;
+    }
+    const menuBounds = scrollRegion.getBoundingClientRect();
+    const optionBounds = activeOption.getBoundingClientRect();
+    // scrollIntoView also moves the short-landscape composer and page.
+    if (optionBounds.top < menuBounds.top) {
+      scrollRegion.scrollTop -= menuBounds.top - optionBounds.top;
+    } else if (optionBounds.bottom > menuBounds.bottom) {
+      scrollRegion.scrollTop += optionBounds.bottom - menuBounds.bottom;
+    }
+  });
+}
+
+function syncMenuScroll(element: Element | undefined): void {
+  if (!(element instanceof HTMLElement)) {
+    return;
+  }
+  const sync = () => {
+    const scrollable = element.scrollHeight > element.clientHeight + 1;
+    element.dataset.scrollable = String(scrollable);
+    element.dataset.atStart = String(!scrollable || element.scrollTop <= 1);
+    element.dataset.atEnd = String(
+      !scrollable || element.scrollTop + element.clientHeight >= element.scrollHeight - 1,
+    );
+  };
+  sync();
+  requestAnimationFrame(sync);
+}

--- a/ui/src/components/web-awesome-migration.node.test.ts
+++ b/ui/src/components/web-awesome-migration.node.test.ts
@@ -47,9 +47,7 @@ describe("Web Awesome control ownership", () => {
     // This inventory tracks literal ARIA roles, not Web Awesome elements that own roles internally.
     expect(matchingFiles(/<[a-z][^>]*\srole=["'](?:combobox|listbox|option)["']/u)).toEqual([
       "components/command-palette.ts",
-      "pages/chat/components/chat-composer-mention-menu.ts",
-      "pages/chat/components/chat-composer-skill-menu.ts",
-      "pages/chat/components/chat-composer-slash-menu.ts",
+      "components/composer-menu.ts",
       "pages/chat/components/chat-model-picker-options.ts",
       "pages/chat/components/chat-model-picker.ts",
       "pages/new-session/place-browser.ts",

--- a/ui/src/e2e/chat-slash-command-ranking.e2e.test.ts
+++ b/ui/src/e2e/chat-slash-command-ranking.e2e.test.ts
@@ -104,6 +104,116 @@ suite.define(() => {
     });
   });
 
+  it.each(["Enter", "Tab", "pointer"])(
+    "shows the first argument after selecting from a scrolled command menu with %s",
+    async (selection) => {
+      await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+        const choices = Array.from(
+          { length: 16 },
+          (_, index) => `choice-${String(index).padStart(2, "0")}`,
+        );
+        const commands = Array.from({ length: 16 }, (_, index) => ({
+          acceptsArgs: true,
+          args: [{ name: "choice", choices }],
+          category: "tools",
+          description: "Choose a synthetic viewport option.",
+          name: `viewport-${String(index).padStart(2, "0")}`,
+          scope: "both",
+          source: "plugin",
+          textAliases: [`/viewport-${String(index).padStart(2, "0")}`],
+        }));
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "chat.startup": {
+              agentsList: {
+                agents: [{ id: "main", name: "OpenClaw" }],
+                defaultId: "main",
+                mainKey: "main",
+                scope: "agent",
+              },
+              messages: [],
+              metadata: { commands, models: [] },
+              sessionId: "slash-viewport-session",
+              thinkingLevel: null,
+            },
+            "chat.metadata": { commands, models: [] },
+            "commands.list": { commands },
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await gateway.waitForRequest("chat.startup");
+        const composer = page.locator(".agent-chat__composer-combobox textarea");
+        await composer.waitFor({ state: "visible" });
+        await expect.poll(() => composer.isEnabled()).toBe(true);
+        await composer.fill("/viewport-");
+
+        const picker = page.locator(".slash-menu[role='listbox']");
+        const scroll = picker.locator(".slash-menu__scroll");
+        const options = picker.getByRole("option");
+        await expect.poll(() => options.count()).toBeGreaterThanOrEqual(commands.length);
+        const targetIndex = await options
+          .locator(".slash-menu-name")
+          .evaluateAll((names) =>
+            names.findIndex((name) => name.textContent?.trim().startsWith("/viewport-15")),
+          );
+        expect(targetIndex).toBeGreaterThan(10);
+        for (let index = 0; index < targetIndex; index += 1) {
+          await composer.press("ArrowDown");
+        }
+        await expect
+          .poll(() => options.nth(targetIndex).getAttribute("aria-selected"))
+          .toBe("true");
+        await expect.poll(() => scroll.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+        if (selection === "pointer") {
+          await options.nth(targetIndex).click();
+          await page.mouse.move(0, 0);
+        } else {
+          await composer.press(selection);
+        }
+
+        await expect.poll(() => composer.inputValue()).toBe("/viewport-15 ");
+        const active = picker.locator("[role='option'][aria-selected='true']");
+        const first = options.first();
+        await expect.poll(() => first.locator(".slash-menu-name").textContent()).toBe("choice-00");
+        // Pointer selection may activate the option under the cursor after the viewport changes.
+        if (selection !== "pointer") {
+          await expect
+            .poll(() => active.locator(".slash-menu-name").textContent())
+            .toBe("choice-00");
+        }
+        expect(
+          await scroll.evaluate((element) => element.scrollHeight > element.clientHeight),
+        ).toBe(true);
+        await expect
+          .poll(() =>
+            first.evaluate((element) => {
+              const viewport = element.closest(".slash-menu__scroll")?.getBoundingClientRect();
+              const option = element.getBoundingClientRect();
+              return Boolean(
+                viewport && option.top >= viewport.top && option.bottom <= viewport.bottom,
+              );
+            }),
+          )
+          .toBe(true);
+
+        const activeIndex = choices.indexOf(
+          (await active.locator(".slash-menu-name").textContent())?.trim() ?? "",
+        );
+        expect(activeIndex).toBeGreaterThanOrEqual(0);
+        for (let index = activeIndex; index < choices.length - 1; index += 1) {
+          await composer.press("ArrowDown");
+        }
+        await expect.poll(() => scroll.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+        await composer.fill("/viewport-");
+        await expect
+          .poll(() => active.locator(".slash-menu-name").textContent())
+          .toContain("/viewport-00");
+        await expect.poll(() => scroll.evaluate((element) => element.scrollTop)).toBe(0);
+        expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+      });
+    },
+  );
+
   it("keeps visible search results and keyboard selection in relevance order", async () => {
     const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
     const artifactDir = artifactRoot

--- a/ui/src/pages/chat/components/chat-composer-dom.ts
+++ b/ui/src/pages/chat/components/chat-composer-dom.ts
@@ -277,46 +277,6 @@ export function restoreHistoryCaret(target: HTMLTextAreaElement, direction: "up"
   });
 }
 
-// Shared by the slash and skill composer menus, which resolve their own
-// active-option id but scroll the same ".slash-menu__scroll" viewport shape.
-export function scrollActiveMenuOptionIntoView(activeId: string | null): void {
-  if (!activeId) {
-    return;
-  }
-  requestAnimationFrame(() => {
-    const activeOption = document.getElementById(activeId);
-    const scrollRegion = activeOption?.closest<HTMLElement>(".slash-menu__scroll");
-    if (!activeOption || !scrollRegion) {
-      return;
-    }
-    const menuBounds = scrollRegion.getBoundingClientRect();
-    const optionBounds = activeOption.getBoundingClientRect();
-    // scrollIntoView also moves the short-landscape composer and page. Keep
-    // keyboard navigation owned by the menu so textarea focus stays stable.
-    if (optionBounds.top < menuBounds.top) {
-      scrollRegion.scrollTop -= menuBounds.top - optionBounds.top;
-    } else if (optionBounds.bottom > menuBounds.bottom) {
-      scrollRegion.scrollTop += optionBounds.bottom - menuBounds.bottom;
-    }
-  });
-}
-
-export function syncComposerMenuScroll(element: Element | undefined): void {
-  if (!(element instanceof HTMLElement)) {
-    return;
-  }
-  const sync = () => {
-    const scrollable = element.scrollHeight > element.clientHeight + 1;
-    element.dataset.scrollable = String(scrollable);
-    element.dataset.atStart = String(!scrollable || element.scrollTop <= 1);
-    element.dataset.atEnd = String(
-      !scrollable || element.scrollTop + element.clientHeight >= element.scrollHeight - 1,
-    );
-  };
-  sync();
-  requestAnimationFrame(sync);
-}
-
 export function paneDomId(paneId: string, suffix: string): string {
   return `chat-${encodeURIComponent(paneId)}-${suffix}`;
 }

--- a/ui/src/pages/chat/components/chat-composer-mention-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-mention-menu.ts
@@ -1,18 +1,18 @@
 import type { UsersMentionableParams, UsersMentionableResult } from "@openclaw/gateway-protocol";
 import { html, nothing } from "lit";
-import { ref } from "lit/directives/ref.js";
 import type { GatewayBrowserClient } from "../../../api/gateway.ts";
+import {
+  handleComposerMenuKeydown,
+  renderComposerMenu,
+  renderComposerMenuOption,
+} from "../../../components/composer-menu.ts";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import type { HumanMention } from "../../../lib/chat/chat-types.ts";
 import { MAX_HUMAN_MENTIONS, updateHumanMentions } from "../../../lib/chat/human-mentions.ts";
 import "../../../styles/chat/reply-preview.css";
 import { renderChatAuthorAvatar } from "./chat-author-avatar.ts";
-import {
-  paneDomId,
-  scrollActiveMenuOptionIntoView,
-  syncComposerMenuScroll,
-} from "./chat-composer-dom.ts";
+import { paneDomId } from "./chat-composer-dom.ts";
 
 export type HumanMentionDirectory = {
   client: GatewayBrowserClient;
@@ -163,28 +163,22 @@ export class HumanMentionMenu {
     if (!this.open || event.defaultPrevented || event.isComposing || event.keyCode === 229) {
       return false;
     }
-    if (event.key === "Escape") {
-      event.preventDefault();
-      this.close();
-      requestUpdate();
-      return true;
-    }
-    if (!["ArrowDown", "ArrowUp", "Enter", "Tab"].includes(event.key)) {
-      return false;
-    }
-    event.preventDefault();
     const users = this.search?.kind === "ready" ? this.search.result.users : [];
-    if (users.length > 0) {
-      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-        this.index =
-          (this.index + (event.key === "ArrowDown" ? 1 : users.length - 1)) % users.length;
+    return handleComposerMenuKeydown(event, {
+      count: users.length,
+      index: this.index,
+      consumeEmpty: true,
+      close: () => {
+        this.close();
         requestUpdate();
-        scrollActiveMenuOptionIntoView(this.activeId(host.paneId));
-      } else {
-        this.select(users[this.index]!, host, requestUpdate);
-      }
-    }
-    return true;
+      },
+      move: (index) => {
+        this.index = index;
+        requestUpdate();
+        return this.activeId(host.paneId);
+      },
+      select: () => this.select(users[this.index]!, host, requestUpdate),
+    });
   }
 
   private select(
@@ -238,59 +232,47 @@ export class HumanMentionMenu {
           : !result?.users.length
             ? t("chat.mentions.empty")
             : null;
-    return html`<div
-      id=${paneDomId(host.paneId, "mention-menu-listbox")}
-      class="slash-menu mention-menu"
-      role="listbox"
-      aria-label=${t("chat.mentions.menu")}
-    >
-      <div class="slash-menu__scroll" ${ref(syncComposerMenuScroll)}>
-        <div class="slash-menu-group">
-          <div class="slash-menu-group__label" role="status">
-            ${message ?? t("chat.mentions.menu")}
-          </div>
-          ${
-            message
-              ? nothing
-              : result?.users.map(
-                  (person, index) => html`<div
-                    id=${paneDomId(host.paneId, `mention-option-${index}`)}
-                    class="slash-menu-item ${index === this.index ? "slash-menu-item--active" : ""}"
-                    role="option"
-                    aria-selected=${index === this.index}
-                    @mousedown=${(event: MouseEvent) => event.preventDefault()}
-                    @click=${() => this.select(person, host, requestUpdate)}
-                    @mouseenter=${() => {
-                      this.index = index;
-                      requestUpdate();
-                    }}
-                  >
-                    <span class="slash-menu-icon" aria-hidden="true"
-                      >${renderChatAuthorAvatar({
-                        id: person.profileId,
-                        name: person.displayName,
-                        identity: { type: "profile", id: person.profileId },
-                        profileAvatarUrl: person.avatarUrl,
-                      })}</span
-                    >
-                    <span class="slash-menu-copy">
-                      <span class="slash-menu-name">${person.displayName}</span>
-                      <span class="slash-menu-desc"
-                        >${person.online ? t("chat.mentions.online") : t("chat.mentions.offline")} ·
-                        ${person.profileId.slice(-8)}</span
-                      >
-                    </span>
-                  </div>`,
-                )
-          }
-          ${
-            result?.truncated
-              ? html`<div class="slash-menu-group__label">${t("chat.mentions.truncated")}</div>`
-              : nothing
-          }
+    return renderComposerMenu({
+      id: paneDomId(host.paneId, "mention-menu-listbox"),
+      className: "mention-menu",
+      label: t("chat.mentions.menu"),
+      trackScroll: false,
+      content: html` <div class="slash-menu-group">
+        <div class="slash-menu-group__label" role="status">
+          ${message ?? t("chat.mentions.menu")}
         </div>
-      </div>
-    </div>`;
+        ${
+          message
+            ? nothing
+            : result?.users.map((person, index) =>
+                renderComposerMenuOption({
+                  id: paneDomId(host.paneId, `mention-option-${index}`),
+                  active: index === this.index,
+                  select: () => this.select(person, host, requestUpdate),
+                  hover: () => {
+                    this.index = index;
+                    requestUpdate();
+                  },
+                  icon: renderChatAuthorAvatar({
+                    id: person.profileId,
+                    name: person.displayName,
+                    identity: { type: "profile", id: person.profileId },
+                    profileAvatarUrl: person.avatarUrl,
+                  }),
+                  iconHidden: true,
+                  name: person.displayName,
+                  description: html`${person.online ? t("chat.mentions.online") : t("chat.mentions.offline")}
+                  · ${person.profileId.slice(-8)}`,
+                }),
+              )
+        }
+        ${
+          result?.truncated
+            ? html`<div class="slash-menu-group__label">${t("chat.mentions.truncated")}</div>`
+            : nothing
+        }
+      </div>`,
+    });
   }
 }
 

--- a/ui/src/pages/chat/components/chat-composer-menus.ts
+++ b/ui/src/pages/chat/components/chat-composer-menus.ts
@@ -1,0 +1,50 @@
+import { paneDomId } from "./chat-composer-dom.ts";
+import type { HumanMentionMenu } from "./chat-composer-mention-menu.ts";
+import {
+  getActiveSkillMenuOptionId,
+  getActiveSkillMenuOptionLabel,
+  isSkillMenuVisible,
+  type SkillMenuState,
+} from "./chat-composer-skill-menu.ts";
+import {
+  getActiveSlashMenuOptionId,
+  getActiveSlashMenuOptionLabel,
+  isSlashMenuVisible,
+  type SlashMenuState,
+} from "./chat-composer-slash-menu.ts";
+
+/** Hosts own admission; both editors expose the same active suggestion to assistive technology. */
+export function resolveComposerMenus(
+  paneId: string,
+  commandsVisible: boolean,
+  skill: SkillMenuState,
+  slash: SlashMenuState,
+  mention: HumanMentionMenu,
+) {
+  const skillMenuVisible = commandsVisible && isSkillMenuVisible(skill);
+  const slashMenuVisible = commandsVisible && isSlashMenuVisible(slash);
+  return {
+    skillMenuVisible,
+    slashMenuVisible,
+    mentionMenuVisible: mention.open,
+    menuVisible: skillMenuVisible || slashMenuVisible || mention.open,
+    activeMenuOptionId: mention.open
+      ? mention.activeId(paneId)
+      : skillMenuVisible
+        ? getActiveSkillMenuOptionId(skill, paneId)
+        : getActiveSlashMenuOptionId(slash, paneId),
+    activeMenuOptionLabel: mention.open
+      ? mention.activeLabel()
+      : skillMenuVisible
+        ? getActiveSkillMenuOptionLabel(skill)
+        : getActiveSlashMenuOptionLabel(slash),
+    menuListboxId: paneDomId(
+      paneId,
+      mention.open
+        ? "mention-menu-listbox"
+        : skillMenuVisible
+          ? "skill-menu-listbox"
+          : "slash-menu-listbox",
+    ),
+  };
+}

--- a/ui/src/pages/chat/components/chat-composer-skill-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-skill-menu.ts
@@ -1,5 +1,9 @@
 import { html, nothing, type TemplateResult } from "lit";
-import { ref } from "lit/directives/ref.js";
+import {
+  handleComposerMenuKeydown,
+  renderComposerMenu,
+  renderComposerMenuOption,
+} from "../../../components/composer-menu.ts";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import {
@@ -8,11 +12,7 @@ import {
   getSlashCommandDescription,
   type SlashCommandDef,
 } from "../../../lib/chat/commands.ts";
-import {
-  paneDomId,
-  scrollActiveMenuOptionIntoView,
-  syncComposerMenuScroll,
-} from "./chat-composer-dom.ts";
+import { paneDomId } from "./chat-composer-dom.ts";
 
 const SKILL_MENTION_CHAR = /[-a-zA-Z0-9_:]/u;
 
@@ -251,37 +251,27 @@ export function handleSkillMenuKeydown(
   if (!state.skillMenuOpen) {
     return false;
   }
-  if (event.key === "Escape") {
-    event.preventDefault();
-    resetSkillMenuState(state);
-    requestUpdate();
-    return true;
-  }
   const items = state.skillCommandRefreshPending ? [] : state.skillMenuItems;
-  if (items.length === 0) {
-    if (["ArrowDown", "ArrowUp", "Enter", "Tab"].includes(event.key)) {
-      event.preventDefault();
-      return true;
-    }
-    return false;
-  }
-  if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-    event.preventDefault();
-    const offset = event.key === "ArrowDown" ? 1 : items.length - 1;
-    state.skillMenuIndex = (state.skillMenuIndex + offset) % items.length;
-    requestUpdate();
-    scrollActiveMenuOptionIntoView(getActiveSkillMenuOptionId(state, host.paneId));
-    return true;
-  }
-  if (event.key === "Tab" || event.key === "Enter") {
-    event.preventDefault();
-    const command = items[state.skillMenuIndex];
-    if (command) {
-      selectSkillMention(command, state, host, requestUpdate);
-    }
-    return true;
-  }
-  return false;
+  return handleComposerMenuKeydown(event, {
+    count: items.length,
+    index: state.skillMenuIndex,
+    consumeEmpty: true,
+    close: () => {
+      resetSkillMenuState(state);
+      requestUpdate();
+    },
+    move: (index) => {
+      state.skillMenuIndex = index;
+      requestUpdate();
+      return getActiveSkillMenuOptionId(state, host.paneId);
+    },
+    select: () => {
+      const command = items[state.skillMenuIndex];
+      if (command) {
+        selectSkillMention(command, state, host, requestUpdate);
+      }
+    },
+  });
 }
 
 export function renderSkillMenu(
@@ -292,61 +282,36 @@ export function renderSkillMenu(
   if (!isSkillMenuVisible(state)) {
     return nothing;
   }
-  const listboxId = paneDomId(host.paneId, "skill-menu-listbox");
-  return html`
-    <div
-      id=${listboxId}
-      class="slash-menu skill-menu"
-      role="listbox"
-      aria-label=${t("chat.skills.menu")}
-    >
-      <div
-        class="slash-menu__scroll"
-        ${ref(syncComposerMenuScroll)}
-        @scroll=${(event: Event) =>
-          syncComposerMenuScroll(
-            event.currentTarget instanceof Element ? event.currentTarget : undefined,
-          )}
-      >
-        ${
-          state.skillCommandRefreshPending || state.skillMenuItems.length === 0
-            ? html`<div class="slash-menu-group">
-                <div class="slash-menu-group__label">${t("chat.skills.loading")}</div>
-              </div>`
-            : html`<div class="slash-menu-group">
-                <div class="slash-menu-group__label">${t("chat.skills.label")}</div>
-                ${state.skillMenuItems.map(
-                  (command, index) => html`
-                    <div
-                      id=${skillOptionId(host.paneId, command)}
-                      class="slash-menu-item ${
-                        index === state.skillMenuIndex ? "slash-menu-item--active" : ""
-                      }"
-                      role="option"
-                      aria-selected=${index === state.skillMenuIndex}
-                      @mousedown=${(event: MouseEvent) => event.preventDefault()}
-                      @click=${() => selectSkillMention(command, state, host, requestUpdate)}
-                      @mouseenter=${() => {
-                        state.skillMenuIndex = index;
-                        requestUpdate();
-                      }}
-                    >
-                      <span class="slash-menu-icon">${icons.pencilSparkles}</span>
-                      <span class="slash-menu-copy">
-                        <span class="slash-menu-name"
-                          >${renderSkillName(
-                            getSkillDisplayName(command),
-                            state.skillMenuTarget?.query ?? "",
-                          )}</span
-                        >
-                        <span class="slash-menu-desc">${getSlashCommandDescription(command)}</span>
-                      </span>
-                    </div>
-                  `,
-                )}
-              </div>`
-        }
+  const loading = state.skillCommandRefreshPending || state.skillMenuItems.length === 0;
+  return renderComposerMenu({
+    id: paneDomId(host.paneId, "skill-menu-listbox"),
+    className: "skill-menu",
+    label: t("chat.skills.menu"),
+    content: html`<div class="slash-menu-group">
+      <div class="slash-menu-group__label">
+        ${t(loading ? "chat.skills.loading" : "chat.skills.label")}
       </div>
-    </div>
-  `;
+      ${
+        loading
+          ? nothing
+          : state.skillMenuItems.map((command, index) =>
+              renderComposerMenuOption({
+                id: skillOptionId(host.paneId, command),
+                active: index === state.skillMenuIndex,
+                select: () => selectSkillMention(command, state, host, requestUpdate),
+                hover: () => {
+                  state.skillMenuIndex = index;
+                  requestUpdate();
+                },
+                icon: icons.pencilSparkles,
+                name: renderSkillName(
+                  getSkillDisplayName(command),
+                  state.skillMenuTarget?.query ?? "",
+                ),
+                description: getSlashCommandDescription(command),
+              }),
+            )
+      }
+    </div>`,
+  });
 }

--- a/ui/src/pages/chat/components/chat-composer-slash-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-slash-menu.ts
@@ -1,6 +1,10 @@
 import { html, nothing, type TemplateResult } from "lit";
-import { ref } from "lit/directives/ref.js";
 import type { ChatSendShortcut } from "../../../app/settings.ts";
+import {
+  handleComposerMenuKeydown,
+  renderComposerMenu,
+  renderComposerMenuOption,
+} from "../../../components/composer-menu.ts";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import {
@@ -14,11 +18,7 @@ import {
   type SlashCommandCategory,
   type SlashCommandDef,
 } from "../../../lib/chat/commands.ts";
-import {
-  paneDomId,
-  scrollActiveMenuOptionIntoView,
-  syncComposerMenuScroll,
-} from "./chat-composer-dom.ts";
+import { paneDomId } from "./chat-composer-dom.ts";
 import {
   beginInlineFreeformSlashArguments,
   commitInlineSlashSelection,
@@ -260,11 +260,17 @@ function selectSlashCommand(
   state: SlashMenuState,
   host: SlashMenuHost,
   requestUpdate: () => void,
+  completeOnly = false,
 ): void {
-  if (host.activateComposerMode?.(cmd)) {
+  if (!completeOnly && host.activateComposerMode?.(cmd)) {
     return;
   }
-  if (cmd.source !== "skill" && !host.canRun(true) && state.slashMenuCompletion?.inline) {
+  if (
+    !completeOnly &&
+    cmd.source !== "skill" &&
+    !host.canRun(true) &&
+    state.slashMenuCompletion?.inline
+  ) {
     return;
   }
   const inlineReplacement = cmd.source === "skill" ? `$${cmd.name}` : `/${cmd.name}`;
@@ -272,6 +278,7 @@ function selectSlashCommand(
     return;
   }
   if (
+    !completeOnly &&
     state.slashMenuCompletion?.inline &&
     executesInlineImmediately(cmd) &&
     host.canRun(true) &&
@@ -301,7 +308,11 @@ function selectSlashCommand(
     requestUpdate();
     return;
   }
-  if (cmd.executeLocal && !cmd.args) {
+  if (completeOnly) {
+    host.commitDraft(cmd.args ? `/${cmd.name} ` : `/${cmd.name}`);
+    resetSlashMenuState(state);
+    requestUpdate();
+  } else if (cmd.executeLocal && !cmd.args) {
     resetSlashMenuState(state);
     host.commitDraft(`/${cmd.name}`);
     host.runCommand();
@@ -309,38 +320,6 @@ function selectSlashCommand(
     host.commitDraft(`/${cmd.name} `);
     closeSlashMenuIfNeeded(state, requestUpdate);
   }
-}
-
-function tabCompleteSlashCommand(
-  cmd: SlashCommandDef,
-  state: SlashMenuState,
-  host: SlashMenuHost,
-  requestUpdate: () => void,
-): void {
-  const inlineReplacement = cmd.source === "skill" ? `$${cmd.name}` : `/${cmd.name}`;
-  if (beginInlineSlashArguments(cmd, state, host, requestUpdate)) {
-    return;
-  }
-  if (commitInlineSlashSelection(inlineReplacement, state, host)) {
-    resetSlashMenuState(state);
-    requestUpdate();
-    return;
-  }
-  const argOptions = host.resolveArgOptions(cmd);
-  if (argOptions.length > 0) {
-    host.commitDraft(`/${cmd.name} `);
-    state.slashMenuMode = "args";
-    state.slashMenuCommand = cmd;
-    state.slashMenuArgItems = argOptions;
-    state.slashMenuOpen = true;
-    state.slashMenuIndex = 0;
-    state.slashMenuItems = [];
-    requestUpdate();
-    return;
-  }
-  host.commitDraft(cmd.args ? `/${cmd.name} ` : `/${cmd.name}`);
-  resetSlashMenuState(state);
-  requestUpdate();
 }
 
 function selectSlashArg(
@@ -473,48 +452,34 @@ export function handleSlashMenuKeydown(
   if (!state.slashMenuOpen) {
     return false;
   }
-  if (event.key === "Escape") {
-    event.preventDefault();
-    resetSlashMenuState(state);
-    requestUpdate();
-    return true;
-  }
   const items = state.slashMenuMode === "args" ? state.slashMenuArgItems : state.slashMenuItems;
-  if (items.length === 0) {
-    return false;
-  }
-  if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-    event.preventDefault();
-    const offset = event.key === "ArrowDown" ? 1 : items.length - 1;
-    state.slashMenuIndex = (state.slashMenuIndex + offset) % items.length;
-    requestUpdate();
-    scrollActiveMenuOptionIntoView(getActiveSlashMenuOptionId(state, host.paneId));
-    return true;
-  }
-  if (event.key !== "Tab" && event.key !== "Enter") {
-    return false;
-  }
-  event.preventDefault();
-  if (state.slashMenuMode === "args") {
-    const arg = state.slashMenuArgItems[state.slashMenuIndex];
-    if (arg !== undefined) {
-      selectSlashArg(arg, state, host, requestUpdate, event.key === "Enter");
-    }
-  } else {
-    const command = state.slashMenuItems[state.slashMenuIndex];
-    if (command) {
-      if (event.key === "Enter") {
-        selectSlashCommand(command, state, host, requestUpdate);
+  return handleComposerMenuKeydown(event, {
+    count: items.length,
+    index: state.slashMenuIndex,
+    consumeEmpty: false,
+    close: () => {
+      resetSlashMenuState(state);
+      requestUpdate();
+    },
+    move: (index) => {
+      state.slashMenuIndex = index;
+      requestUpdate();
+      return getActiveSlashMenuOptionId(state, host.paneId);
+    },
+    select: (key) => {
+      if (state.slashMenuMode === "args") {
+        const arg = state.slashMenuArgItems[state.slashMenuIndex];
+        if (arg !== undefined) {
+          selectSlashArg(arg, state, host, requestUpdate, key === "Enter");
+        }
       } else {
-        tabCompleteSlashCommand(command, state, host, requestUpdate);
+        const command = state.slashMenuItems[state.slashMenuIndex];
+        if (command) {
+          selectSlashCommand(command, state, host, requestUpdate, key === "Tab");
+        }
       }
-    }
-  }
-  return true;
-}
-
-function syncComposerMenuScrollEvent(event: Event): void {
-  syncComposerMenuScroll(event.currentTarget instanceof Element ? event.currentTarget : undefined);
+    },
+  });
 }
 
 export function isSlashMenuVisible(state: SlashMenuState): boolean {
@@ -561,38 +526,23 @@ function renderSlashCommandOption(params: {
   state: SlashMenuState;
 }): TemplateResult {
   const { cmd, index, query, requestUpdate, host, state } = params;
-  return html`
-    <div
-      id=${getSlashCommandOptionId(host.paneId, cmd)}
-      class="slash-menu-item ${index === state.slashMenuIndex ? "slash-menu-item--active" : ""}"
-      role="option"
-      aria-selected=${index === state.slashMenuIndex}
-      @mousedown=${(event: MouseEvent) => event.preventDefault()}
-      @click=${() => selectSlashCommand(cmd, state, host, requestUpdate)}
-      @mouseenter=${() => {
-        state.slashMenuIndex = index;
-        requestUpdate();
-      }}
-    >
-      <span class="slash-menu-icon"
-        >${
-          cmd.source === "skill"
-            ? icons.pencilSparkles
-            : cmd.icon
-              ? renderSlashIcon(cmd.icon)
-              : icons.terminal
-        }</span
-      >
-      <span class="slash-menu-copy">
-        <span class="slash-menu-name"
-          >/${renderSlashMatchedName(cmd.name, query)}${
-            cmd.args ? html`<span class="slash-menu-args"> ${cmd.args}</span>` : nothing
-          }</span
-        >
-        <span class="slash-menu-desc">${getSlashCommandDescription(cmd)}</span>
-      </span>
-    </div>
-  `;
+  return renderComposerMenuOption({
+    id: getSlashCommandOptionId(host.paneId, cmd),
+    active: index === state.slashMenuIndex,
+    select: () => selectSlashCommand(cmd, state, host, requestUpdate),
+    hover: () => {
+      state.slashMenuIndex = index;
+      requestUpdate();
+    },
+    icon:
+      cmd.source === "skill"
+        ? icons.pencilSparkles
+        : cmd.icon
+          ? renderSlashIcon(cmd.icon)
+          : icons.terminal,
+    name: html`/${renderSlashMatchedName(cmd.name, query)}${cmd.args ? html`<span class="slash-menu-args"> ${cmd.args}</span>` : nothing}`,
+    description: getSlashCommandDescription(cmd),
+  });
 }
 
 export function renderSlashMenu(
@@ -611,55 +561,32 @@ export function renderSlashMenu(
     state.slashMenuCommand &&
     state.slashMenuArgItems.length > 0
   ) {
-    return html`
-      <div
-        id=${listboxId}
-        class="slash-menu"
-        role="listbox"
-        aria-label=${t("chat.commands.arguments")}
-      >
-        <div
-          class="slash-menu__scroll"
-          ${ref(syncComposerMenuScroll)}
-          @scroll=${syncComposerMenuScrollEvent}
-        >
-          <div class="slash-menu-group">
-            <div class="slash-menu-group__label">
-              /${state.slashMenuCommand.name} ${getSlashCommandDescription(state.slashMenuCommand)}
-            </div>
-            ${state.slashMenuArgItems.map(
-              (arg, i) => html`
-                <div
-                  id=${getSlashArgOptionId(host.paneId, state.slashMenuCommand?.name ?? "", arg)}
-                  class="slash-menu-item ${
-                    i === state.slashMenuIndex ? "slash-menu-item--active" : ""
-                  }"
-                  role="option"
-                  aria-selected=${i === state.slashMenuIndex}
-                  @click=${() => selectSlashArg(arg, state, host, requestUpdate, true)}
-                  @mouseenter=${() => {
-                    state.slashMenuIndex = i;
-                    requestUpdate();
-                  }}
-                >
-                  <span class="slash-menu-icon"
-                    >${
-                      state.slashMenuCommand?.icon
-                        ? renderSlashIcon(state.slashMenuCommand.icon)
-                        : icons.terminal
-                    }</span
-                  >
-                  <span class="slash-menu-copy">
-                    <span class="slash-menu-name">${arg}</span>
-                    <span class="slash-menu-desc">/${state.slashMenuCommand?.name} ${arg}</span>
-                  </span>
-                </div>
-              `,
-            )}
-          </div>
+    return renderComposerMenu({
+      id: listboxId,
+      label: t("chat.commands.arguments"),
+      content: html` <div class="slash-menu-group">
+        <div class="slash-menu-group__label">
+          /${state.slashMenuCommand.name} ${getSlashCommandDescription(state.slashMenuCommand)}
         </div>
-      </div>
-    `;
+        ${state.slashMenuArgItems.map((arg, i) =>
+          renderComposerMenuOption({
+            id: getSlashArgOptionId(host.paneId, state.slashMenuCommand?.name ?? "", arg),
+            active: i === state.slashMenuIndex,
+            preserveFocus: false,
+            select: () => selectSlashArg(arg, state, host, requestUpdate, true),
+            hover: () => {
+              state.slashMenuIndex = i;
+              requestUpdate();
+            },
+            icon: state.slashMenuCommand?.icon
+              ? renderSlashIcon(state.slashMenuCommand.icon)
+              : icons.terminal,
+            name: arg,
+            description: html`/${state.slashMenuCommand?.name} ${arg}`,
+          }),
+        )}
+      </div>`,
+    });
   }
 
   if (state.slashMenuItems.length === 0) {
@@ -682,46 +609,42 @@ export function renderSlashMenu(
     }
   }
 
-  return html`
-    <div id=${listboxId} class="slash-menu" role="listbox" aria-label=${t("chat.commands.menu")}>
-      <div
-        class="slash-menu__scroll"
-        ${ref(syncComposerMenuScroll)}
-        @scroll=${syncComposerMenuScrollEvent}
-      >
-        ${groups.map(
-          ([category, entries]) => html`<div class="slash-menu-group">
-            <div class="slash-menu-group__label">${getSlashCommandCategoryLabel(category)}</div>
-            ${entries.map(({ command, index }) =>
-              renderSlashCommandOption({
-                cmd: command,
-                index,
-                query,
-                requestUpdate,
-                host,
-                state,
-              }),
-            )}
-          </div>`,
-        )}
-        ${
-          skills.length > 0
-            ? html`<div class="slash-menu-group slash-menu-group--skills">
-                <div class="slash-menu-group__label">${t("chat.skills.label")}</div>
-                ${skills.map((cmd, index) =>
-                  renderSlashCommandOption({
-                    cmd,
-                    index: commands.length + index,
-                    query,
-                    requestUpdate,
-                    host,
-                    state,
-                  }),
-                )}
-              </div>`
-            : nothing
-        }
-      </div>
-    </div>
-  `;
+  return renderComposerMenu({
+    id: listboxId,
+    label: t("chat.commands.menu"),
+    content: html`
+      ${groups.map(
+        ([category, entries]) => html`<div class="slash-menu-group">
+          <div class="slash-menu-group__label">${getSlashCommandCategoryLabel(category)}</div>
+          ${entries.map(({ command, index }) =>
+            renderSlashCommandOption({
+              cmd: command,
+              index,
+              query,
+              requestUpdate,
+              host,
+              state,
+            }),
+          )}
+        </div>`,
+      )}
+      ${
+        skills.length > 0
+          ? html`<div class="slash-menu-group slash-menu-group--skills">
+              <div class="slash-menu-group__label">${t("chat.skills.label")}</div>
+              ${skills.map((cmd, index) =>
+                renderSlashCommandOption({
+                  cmd,
+                  index: commands.length + index,
+                  query,
+                  requestUpdate,
+                  host,
+                  state,
+                }),
+              )}
+            </div>`
+          : nothing
+      }
+    `,
+  });
 }

--- a/ui/src/pages/chat/components/chat-composer-slash-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-slash-menu.ts
@@ -1,4 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
+import { keyed } from "lit/directives/keyed.js";
 import type { ChatSendShortcut } from "../../../app/settings.ts";
 import {
   handleComposerMenuKeydown,
@@ -550,43 +551,47 @@ export function renderSlashMenu(
   host: SlashMenuHost,
   draft: string,
   requestUpdate: () => void,
-): TemplateResult | typeof nothing {
+): ReturnType<typeof keyed> | typeof nothing {
   const listboxId = paneDomId(host.paneId, "slash-menu-listbox");
   if (!state.slashMenuOpen) {
     return nothing;
   }
 
+  // Each mode owns its scroll viewport; switching modes starts at the first option.
   if (
     state.slashMenuMode === "args" &&
     state.slashMenuCommand &&
     state.slashMenuArgItems.length > 0
   ) {
-    return renderComposerMenu({
-      id: listboxId,
-      label: t("chat.commands.arguments"),
-      content: html` <div class="slash-menu-group">
-        <div class="slash-menu-group__label">
-          /${state.slashMenuCommand.name} ${getSlashCommandDescription(state.slashMenuCommand)}
-        </div>
-        ${state.slashMenuArgItems.map((arg, i) =>
-          renderComposerMenuOption({
-            id: getSlashArgOptionId(host.paneId, state.slashMenuCommand?.name ?? "", arg),
-            active: i === state.slashMenuIndex,
-            preserveFocus: false,
-            select: () => selectSlashArg(arg, state, host, requestUpdate, true),
-            hover: () => {
-              state.slashMenuIndex = i;
-              requestUpdate();
-            },
-            icon: state.slashMenuCommand?.icon
-              ? renderSlashIcon(state.slashMenuCommand.icon)
-              : icons.terminal,
-            name: arg,
-            description: html`/${state.slashMenuCommand?.name} ${arg}`,
-          }),
-        )}
-      </div>`,
-    });
+    return keyed(
+      "args",
+      renderComposerMenu({
+        id: listboxId,
+        label: t("chat.commands.arguments"),
+        content: html` <div class="slash-menu-group">
+          <div class="slash-menu-group__label">
+            /${state.slashMenuCommand.name} ${getSlashCommandDescription(state.slashMenuCommand)}
+          </div>
+          ${state.slashMenuArgItems.map((arg, i) =>
+            renderComposerMenuOption({
+              id: getSlashArgOptionId(host.paneId, state.slashMenuCommand?.name ?? "", arg),
+              active: i === state.slashMenuIndex,
+              preserveFocus: false,
+              select: () => selectSlashArg(arg, state, host, requestUpdate, true),
+              hover: () => {
+                state.slashMenuIndex = i;
+                requestUpdate();
+              },
+              icon: state.slashMenuCommand?.icon
+                ? renderSlashIcon(state.slashMenuCommand.icon)
+                : icons.terminal,
+              name: arg,
+              description: html`/${state.slashMenuCommand?.name} ${arg}`,
+            }),
+          )}
+        </div>`,
+      }),
+    );
   }
 
   if (state.slashMenuItems.length === 0) {
@@ -609,42 +614,45 @@ export function renderSlashMenu(
     }
   }
 
-  return renderComposerMenu({
-    id: listboxId,
-    label: t("chat.commands.menu"),
-    content: html`
-      ${groups.map(
-        ([category, entries]) => html`<div class="slash-menu-group">
-          <div class="slash-menu-group__label">${getSlashCommandCategoryLabel(category)}</div>
-          ${entries.map(({ command, index }) =>
-            renderSlashCommandOption({
-              cmd: command,
-              index,
-              query,
-              requestUpdate,
-              host,
-              state,
-            }),
-          )}
-        </div>`,
-      )}
-      ${
-        skills.length > 0
-          ? html`<div class="slash-menu-group slash-menu-group--skills">
-              <div class="slash-menu-group__label">${t("chat.skills.label")}</div>
-              ${skills.map((cmd, index) =>
-                renderSlashCommandOption({
-                  cmd,
-                  index: commands.length + index,
-                  query,
-                  requestUpdate,
-                  host,
-                  state,
-                }),
-              )}
-            </div>`
-          : nothing
-      }
-    `,
-  });
+  return keyed(
+    "command",
+    renderComposerMenu({
+      id: listboxId,
+      label: t("chat.commands.menu"),
+      content: html`
+        ${groups.map(
+          ([category, entries]) => html`<div class="slash-menu-group">
+            <div class="slash-menu-group__label">${getSlashCommandCategoryLabel(category)}</div>
+            ${entries.map(({ command, index }) =>
+              renderSlashCommandOption({
+                cmd: command,
+                index,
+                query,
+                requestUpdate,
+                host,
+                state,
+              }),
+            )}
+          </div>`,
+        )}
+        ${
+          skills.length > 0
+            ? html`<div class="slash-menu-group slash-menu-group--skills">
+                <div class="slash-menu-group__label">${t("chat.skills.label")}</div>
+                ${skills.map((cmd, index) =>
+                  renderSlashCommandOption({
+                    cmd,
+                    index: commands.length + index,
+                    query,
+                    requestUpdate,
+                    host,
+                    state,
+                  }),
+                )}
+              </div>`
+            : nothing
+        }
+      `,
+    }),
+  );
 }

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -31,18 +31,14 @@ import {
 import { createGoalComposerController } from "./chat-composer-goal-mode.ts";
 import { createComposerKeyDownHandler } from "./chat-composer-keydown.ts";
 import type { HumanMentionMenuHost } from "./chat-composer-mention-menu.ts";
+import { resolveComposerMenus } from "./chat-composer-menus.ts";
 import {
-  getActiveSkillMenuOptionId,
-  getActiveSkillMenuOptionLabel,
   isSkillMenuVisible,
   resetSkillMenuState,
   type SkillMenuHost,
   updateSkillMenu,
 } from "./chat-composer-skill-menu.ts";
 import {
-  getActiveSlashMenuOptionId,
-  getActiveSlashMenuOptionLabel,
-  isSlashMenuVisible,
   resetSlashMenuState,
   type SlashMenuHost,
   updateSlashMenu,
@@ -664,30 +660,22 @@ export function renderChatComposer(props: ChatComposerProps) {
   if (props.modelSwitching && state.slashMenuCommand?.key === "think") {
     resetSlashMenuState(state);
   }
-  const slashMenuVisible = props.connected && canCompose && isSlashMenuVisible(state);
-  const skillMenuVisible = props.connected && canCompose && isSkillMenuVisible(state);
-  const mentionMenuVisible = state.mentionMenu.open;
-  if (!skillMenuVisible && state.skillMenuOpen && !state.skillCommandRefreshPending) {
+  const commandsVisible = props.connected && canCompose;
+  if (
+    !(commandsVisible && isSkillMenuVisible(state)) &&
+    state.skillMenuOpen &&
+    !state.skillCommandRefreshPending
+  ) {
     resetSkillMenuState(state);
   }
-  const activeSlashMenuOptionId = mentionMenuVisible
-    ? state.mentionMenu.activeId(props.paneId)
-    : skillMenuVisible
-      ? getActiveSkillMenuOptionId(state, props.paneId)
-      : getActiveSlashMenuOptionId(state, props.paneId);
-  const activeSlashMenuOptionLabel = mentionMenuVisible
-    ? state.mentionMenu.activeLabel()
-    : skillMenuVisible
-      ? getActiveSkillMenuOptionLabel(state)
-      : getActiveSlashMenuOptionLabel(state);
-  const slashMenuListboxId = paneDomId(
-    props.paneId,
-    mentionMenuVisible
-      ? "mention-menu-listbox"
-      : skillMenuVisible
-        ? "skill-menu-listbox"
-        : "slash-menu-listbox",
-  );
+  const {
+    slashMenuVisible,
+    skillMenuVisible,
+    mentionMenuVisible,
+    activeMenuOptionId: activeSlashMenuOptionId,
+    activeMenuOptionLabel: activeSlashMenuOptionLabel,
+    menuListboxId: slashMenuListboxId,
+  } = resolveComposerMenus(props.paneId, commandsVisible, state, state, state.mentionMenu);
   const slashMenuAnnouncementId = paneDomId(props.paneId, "slash-active-announcement");
 
   return renderChatComposerView({

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -30,13 +30,11 @@ import {
   type HumanMentionDirectory,
   type HumanMentionMenuHost,
 } from "../chat/components/chat-composer-mention-menu.ts";
+import { resolveComposerMenus } from "../chat/components/chat-composer-menus.ts";
 import type { ChatComposerPlusMenuView } from "../chat/components/chat-composer-plus-menu.ts";
 import {
   createSkillMenuState,
-  getActiveSkillMenuOptionId,
-  getActiveSkillMenuOptionLabel,
   handleSkillMenuKeydown,
-  isSkillMenuVisible,
   renderSkillMenu,
   resetSkillMenuState,
   updateSkillMenu,
@@ -44,10 +42,7 @@ import {
 } from "../chat/components/chat-composer-skill-menu.ts";
 import {
   createSlashMenuState,
-  getActiveSlashMenuOptionId,
-  getActiveSlashMenuOptionLabel,
   handleSlashMenuKeydown,
-  isSlashMenuVisible,
   renderSlashMenu,
   resetSlashMenuState,
   type SlashMenuHost,
@@ -523,32 +518,23 @@ export function renderNewSessionComposer(options: NewSessionComposerOptions) {
         options.message,
         options.requestUpdate,
       );
-  const skillMenuVisible =
-    !options.nativeTerminal && !composerLocked && isSkillMenuVisible(skillMenuState);
-  const slashMenuVisible =
-    !options.nativeTerminal && !composerLocked && isSlashMenuVisible(slashMenuState);
-  const menuVisible = skillMenuVisible || slashMenuVisible || mentionMenu.open;
+  const {
+    skillMenuVisible,
+    slashMenuVisible,
+    menuVisible,
+    menuListboxId,
+    activeMenuOptionId,
+    activeMenuOptionLabel,
+  } = resolveComposerMenus(
+    skillMenuHost.paneId,
+    !options.nativeTerminal && !composerLocked,
+    skillMenuState,
+    slashMenuState,
+    mentionMenu,
+  );
   if (mentionMenu.open) {
     ensureChatComposerPickerDismissal();
   }
-  const menuListboxId = paneDomId(
-    skillMenuHost.paneId,
-    mentionMenu.open
-      ? "mention-menu-listbox"
-      : skillMenuVisible
-        ? "skill-menu-listbox"
-        : "slash-menu-listbox",
-  );
-  const activeMenuOptionId = mentionMenu.open
-    ? mentionMenu.activeId(skillMenuHost.paneId)
-    : skillMenuVisible
-      ? getActiveSkillMenuOptionId(skillMenuState, skillMenuHost.paneId)
-      : getActiveSlashMenuOptionId(slashMenuState, slashMenuHost.paneId);
-  const activeMenuOptionLabel = mentionMenu.open
-    ? mentionMenu.activeLabel()
-    : skillMenuVisible
-      ? getActiveSkillMenuOptionLabel(skillMenuState)
-      : getActiveSlashMenuOptionLabel(slashMenuState);
   const menuAnnouncementId = paneDomId(skillMenuHost.paneId, "active-menu-announcement");
   const ordinaryShortcut = options.requiresModifier ? "Control+Enter Meta+Enter" : "Enter";
   const backgroundShortcut = options.requiresModifier


### PR DESCRIPTION
Related: #133011, #138274

## What Problem This Solves

The Chat and New Session suggestion menus maintain the same listbox, option interaction, and keyboard navigation in three places. This maintainer-requested consolidation gives slash commands, skill references, and people mentions one presentation owner so future interaction repairs apply consistently.

## Why This Change Was Made

`ui/src/components/composer-menu.ts` owns listbox/option rendering, bounded scrolling, and navigation. `chat-composer-menus.ts` owns the active-menu accessibility projection for both composers. The adjacent duplicated slash selection paths now share their common operations while preserving Tab completion and Enter execution. Stable command/argument keys preserve the separate viewport lifetimes, resetting scroll when the mode changes and retaining it within a mode.

Parsers, asynchronous lookups and refresh generations, loading/empty states, mention payloads, and composer admission remain with their current owners. Existing differences in empty-menu key handling, argument-option pointer focus, and mention scrolling are preserved. The production change is +432/-437 (net -5); the survey's larger estimate did not survive preserving those policies and keeping the editor separate.

Both sibling diffs were inspected. #133011 remains the appropriate home for shared textarea/editor behavior and New Session menu placement; this change stays beneath that work and can be rebased with it. #138274's dead-key focus owner is untouched. Neither sibling PR was modified.

## User Impact

No intended behavior or appearance change. Enter versus Tab, IME handling, focus/caret retention, menu ordering, and both composers' gates remain unchanged. No public exports, configuration, wire contracts, or persistent state change.

## Evidence

- 161/161 focused unit cases pass: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-composer-actions.test.ts ui/src/pages/chat/chat-composer-mentions.test.ts ui/src/pages/chat/chat-composer.test.ts ui/src/pages/new-session/composer.test.ts`.
- 21/21 mocked Gateway Chromium cases pass using `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner` with `chat-skill-references`, `chat-slash-command-ranking`, `chat-flow.composer-shortcuts`, `chat-composer-focus`, and `new-session-page.responsive-welcome` E2E files.
- Baseline skill-reference E2E passed before editing; existing regression suites remain intact.
- Codex autoreview: scoped clean through P2, no accepted/actionable findings.
- `git diff --check` passes.
- CI initially reported one stale architectural inventory in `checks-ui (2/3)` (5,647 other tests passed). It reproduced locally (1 failed, 2 passed); replacing the three old owners with the shared renderer shrinks the permitted inventory from seven to five, and all 3 cases now pass. A second full-diff Codex autoreview is clean through P2. No runtime changes were needed for that correction.
- `pnpm build` passes on the updated head (11m 21.4s). `pnpm ui:check-performance` passes at 348073 B startup JavaScript gzip across 8 requests; the baseline is unchanged. `node scripts/check-changed.mjs` passed before the mechanical rebase; the inventory guard and all 21 mocked Gateway E2E cases passed again afterward. Exact-head CI is green.

Screenshots below were captured from a source dev server with a synthetic mocked Gateway and inspected in full before upload. Alice, Bob, and the Review skill are fixtures. There is no real Gateway or private desktop content.

| Menu | Before | After |
| --- | --- | --- |
| Slash | ![Slash menu before](https://github.com/user-attachments/assets/a6eb23f6-2c52-434d-bd14-d6d8a22b4089) | ![Slash menu after](https://github.com/user-attachments/assets/3c9372b0-0317-457e-9416-900426b60e60) |
| Skill | ![Skill menu before](https://github.com/user-attachments/assets/d3fc5f2d-e87a-4bb3-b664-9881dda28b70) | ![Skill menu after](https://github.com/user-attachments/assets/72d81537-c8f7-408d-8b0d-4f1a8b055f2f) |
| Mention | ![Mention menu before](https://github.com/user-attachments/assets/c7f6f230-7535-40c5-a859-6848dbc09d67) | ![Mention menu after](https://github.com/user-attachments/assets/0577d52f-8dd9-415c-9157-ab2199b85985) |

## Review and CI follow-up

The unrelated compact-shard child-exit failure on `c368517faaf24ac455c18d2d491a51ab4c4cc4b5` passed the single maintainer-authorized failed-job rerun: [attempt 1](https://github.com/openclaw/openclaw/actions/runs/34075985832/attempts/1), [successful attempt 2](https://github.com/openclaw/openclaw/actions/runs/34075985832/attempts/2). No CLI code or timeout changed, and no second rerun was requested.

The substantive review finding was reproduced and repaired before landing. Reusing the outer Lit template retained scroll between command and argument modes; the first active argument could be above the viewport. Stable keys at the slash renderer restore the original separate lifetimes in both directions. Three overflowing-list browser cases for Enter, Tab, and pointer selection fail before the repair and pass afterward. Pointer hover activation matches the original implementation. All 161 focused composer cases and all 21 mocked Gateway E2E cases pass; the fresh full-diff review is clean through P2.

The additional images show the same synthetic overflowing argument menu before and after the repair. Before: scrollTop 539 and active choice-00 above the viewport. After: scrollTop 0 and choice-00 visible. Both full captures were inspected; they contain no private data or real Gateway state.

Updated head: `c0d44f9f2e14de1d0c343f82c4e6e3e3996fdedf`, rebased onto `8e3f572ffa25a3c02a732950c74c75c16516d7e7`. The production code and browser regression are byte-identical to the reviewed candidate; main's synchronous inventory helper is retained. Full build and [fresh exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34090663442) passed. Final startup JavaScript is 348073 B gzip in 8 requests, without a baseline edit. Native review artifacts and the completed ClawSweeper review record the viewport finding as resolved.

![Before: the first active argument is above the viewport](https://github.com/user-attachments/assets/781788a6-da2f-4a0c-a501-55d7fa8900be)

![After: the first argument is visible when the mode changes](https://github.com/user-attachments/assets/9932cd66-854e-476b-9b28-1a9c9482b31f)