### PR TITLE
fix(memory): avoid slow reads of large note excerpts

### DIFF
--- a/packages/memory-host-sdk/src/host/read-file-shared.test.ts
+++ b/packages/memory-host-sdk/src/host/read-file-shared.test.ts
@@ -65,6 +65,25 @@ describe("memory read result slicing", () => {
     });
   });
 
+  it.each([
+    { content: "ab\nc\n", maxChars: 2, text: "ab", lines: 1, nextFrom: 2 },
+    { content: "a\n\nb\n", maxChars: 2, text: "a\n", lines: 2, nextFrom: 3 },
+    { content: "ab\nc\n", maxChars: 4, text: "ab\nc", lines: 2 },
+    { content: "\n\n", maxChars: 1, text: "\n", lines: 2 },
+  ])("preserves whole and blank lines at a $maxChars-character boundary", (fixture) => {
+    const { content, maxChars, text, lines, nextFrom } = fixture;
+    expect(buildMemoryReadResult({ content, maxChars, relPath: "memory/test.md" })).toEqual({
+      status: "ok",
+      path: "memory/test.md",
+      from: 1,
+      lines,
+      text: nextFrom
+        ? `${text}\n\n[More content available. Use from=${nextFrom} to continue.]`
+        : text,
+      ...(nextFrom ? { truncated: true, nextFrom } : {}),
+    });
+  });
+
   it("uses the default character budget for non-finite maxChars values", () => {
     expect(
       buildMemoryReadResultFromSlice({

--- a/packages/memory-host-sdk/src/host/read-file-shared.ts
+++ b/packages/memory-host-sdk/src/host/read-file-shared.ts
@@ -34,25 +34,22 @@ function fitLinesToCharBudget(params: { lines: string[]; maxChars: number }): {
   hardTruncatedSingleLine: boolean;
 } {
   const { lines, maxChars } = params;
-  if (lines.length === 0) {
-    return { text: "", includedLines: 0, hardTruncatedSingleLine: false };
-  }
-
-  let includedLines = lines.length;
-  let text = lines.join("\n");
-  while (includedLines > 1 && text.length > maxChars) {
-    includedLines -= 1;
-    text = lines.slice(0, includedLines).join("\n");
-  }
-
-  if (text.length <= maxChars) {
-    return { text, includedLines, hardTruncatedSingleLine: false };
+  let includedLines = 0;
+  let chars = 0;
+  for (const line of lines) {
+    const nextChars = chars + line.length + (includedLines > 0 ? 1 : 0);
+    // Keep an oversized first line for the existing single-line truncation contract.
+    if (includedLines > 0 && nextChars > maxChars) {
+      break;
+    }
+    includedLines += 1;
+    chars = nextChars;
   }
 
   return {
-    text: truncateUtf16Safe(text, maxChars),
-    includedLines: 1,
-    hardTruncatedSingleLine: true,
+    text: truncateUtf16Safe(lines.slice(0, includedLines).join("\n"), maxChars),
+    includedLines,
+    hardTruncatedSingleLine: chars > maxChars,
   };
 }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in the upstream repository, where maintainers can update it directly.

</details>

## What Problem This Solves

Fixes an issue where users reading a large memory note with an explicit line count would wait seconds for a small, bounded excerpt. A normal 10,000-line, 1.25 MB note exposed the delay through the public memory excerpt builder.

## Why This Change Was Made

The shared excerpt fitter repeatedly rebuilt prefixes that the existing character budget would discard. It now scans forward until the budget is filled and joins the selected lines once, retaining the existing oversized-first-line truncation contract. Direct memory tools and manager-backed reads share this owner.

## User Impact

Large explicit memory reads return promptly with the same text, blank lines, Unicode handling, and continuation offsets. The response budget and read behavior remain unchanged.

## Evidence

The public excerpt builder took 2,049 ms before and 0.234 ms after the change for a synthetic 10,000-line note. The actual filesystem reader completed in 7.605 ms. Both returned the expected 96 lines with `nextFrom=97`; these are local measurements, not a cross-platform latency guarantee.

All 33 focused memory-read tests pass, including four added exact-boundary and blank-line cases. Another 20,000 complete public-result comparisons matched the original implementation. The package test type graph, full-file type-aware lint, formatting, and independent P2 review passed.

Production changes remove three lines; tests add nineteen. No storage, configuration, or dependency changes.

The review requested data-model compatibility proof after classifying this file as vector/embedding metadata. That classification does not apply to this diff: the changed function only selects and joins in-memory strings; it does not read or write stored metadata, change a schema, or change public result fields. The existing reader and UTF-16 helper are unchanged. Compatibility is covered by the 20,000 complete result comparisons plus the focused reader tests above; no migration is needed.
