### PR TITLE
fix(channels): explain blocked Discord policy and deferred reloads

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -15063,6 +15063,7 @@ public struct ChannelsStatusResult: Codable, Sendable {
     public let eventloop: [String: AnyCodable]?
     public let partial: Bool?
     public let warnings: [String]?
+    public let statusissues: [[String: AnyCodable]]?
 
     public init(
         ts: Int,
@@ -15076,7 +15077,8 @@ public struct ChannelsStatusResult: Codable, Sendable {
         channeldefaultaccountid: [String: AnyCodable],
         eventloop: [String: AnyCodable]? = nil,
         partial: Bool? = nil,
-        warnings: [String]? = nil)
+        warnings: [String]? = nil,
+        statusissues: [[String: AnyCodable]]? = nil)
     {
         self.ts = ts
         self.channelorder = channelorder
@@ -15090,6 +15092,7 @@ public struct ChannelsStatusResult: Codable, Sendable {
         self.eventloop = eventloop
         self.partial = partial
         self.warnings = warnings
+        self.statusissues = statusissues
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -15105,6 +15108,7 @@ public struct ChannelsStatusResult: Codable, Sendable {
         case eventloop = "eventLoop"
         case partial
         case warnings
+        case statusissues = "statusIssues"
     }
 }
 

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1747,6 +1747,18 @@ message(action="send", channel="discord", target="channel:123", path="/path/to/a
     - if a guild `channels` map exists, only listed channels are allowed
     - verify `requireMention` behavior and mention patterns
 
+    The Control UI channel details and `openclaw channels status` warn when the
+    effective policy is `allowlist` but no guilds are configured. Add your server
+    under `channels.discord.guilds`, or the account's `guilds` map when overridden.
+    An explicit `channels.discord.accounts.default.guilds` map also overrides the
+    top-level map, even when the account map is empty.
+
+    If status reports a deferred configuration reload, wait for active work to
+    finish and refresh. A successful channel stop/start does not apply unpublished
+    configuration. The warning distinguishes waiting to publish configuration
+    from channel work deferred after publication; connection health alone does
+    not confirm that a policy change has applied.
+
     Useful checks:
 
 ```bash

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -793,6 +793,14 @@ through replay; persistence alone is not an application acknowledgment. Shutdown
 supersession by different content, or failed application returns `UNAVAILABLE`
 with recovery guidance. `config.set` acknowledges persistence only.
 
+`channels.status` reports active-work deferrals in `statusIssues`, alongside
+channel policy diagnostics shown in the Control UI and `openclaw channels status`.
+`channels.start` also returns a diagnostic when that channel's reload is deferred;
+manual stop/start continues to use the published runtime configuration. Wait for
+active work to finish and refresh status, or use `config.get` to inspect the active
+configuration. These diagnostics describe deferred channel reloads, not every
+persisted-but-unapplied configuration state.
+
 Once a reload has committed, it finishes its model and channel work before a
 newer config is applied. If that work needs restart recovery, the RPC returns
 `UNAVAILABLE`; wait for the Gateway to restart, then use `config.get` to verify

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -797,9 +797,8 @@ with recovery guidance. `config.set` acknowledges persistence only.
 channel policy diagnostics shown in the Control UI and `openclaw channels status`.
 `channels.start` also returns a diagnostic when that channel's reload is deferred;
 manual stop/start continues to use the published runtime configuration. Wait for
-active work to finish and refresh status, or use `config.get` to inspect the active
-configuration. These diagnostics describe deferred channel reloads, not every
-persisted-but-unapplied configuration state.
+active work to finish and refresh status. These diagnostics describe deferred
+channel reloads, not every persisted-but-unapplied configuration state.
 
 Once a reload has committed, it finishes its model and channel work before a
 newer config is applied. If that work needs restart recovery, the RPC returns

--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -171,6 +171,96 @@ beforeAll(async () => {
   ({ setDiscordRuntime } = await import("./runtime.js"));
 });
 
+describe("discordPlugin policy status", () => {
+  it.each([
+    {
+      name: "explicit empty allowlist",
+      accountId: "default",
+      warning: true,
+      channels: { discord: { token: "discord-token", groupPolicy: "allowlist" } },
+    },
+    {
+      name: "inherited default policy",
+      accountId: "default",
+      warning: true,
+      channels: { defaults: { groupPolicy: "allowlist" }, discord: { token: "discord-token" } },
+    },
+    {
+      name: "named account override",
+      accountId: "ops",
+      warning: true,
+      channels: {
+        discord: {
+          groupPolicy: "open",
+          accounts: {
+            ops: {
+              token: "discord-token",
+              groupPolicy: "allowlist",
+              guilds: {},
+            },
+          },
+        },
+      },
+    },
+    {
+      name: "explicit default account overrides top-level guilds",
+      accountId: "default",
+      warning: true,
+      channels: {
+        discord: {
+          token: "discord-token",
+          groupPolicy: "allowlist",
+          guilds: { "*": {} },
+          accounts: { default: { guilds: {} } },
+        },
+      },
+    },
+    {
+      name: "wildcard guild",
+      accountId: "default",
+      warning: false,
+      channels: {
+        discord: { token: "discord-token", groupPolicy: "allowlist", guilds: { "*": {} } },
+      },
+    },
+    {
+      name: "open policy",
+      accountId: "default",
+      warning: false,
+      channels: { discord: { token: "discord-token", groupPolicy: "open" } },
+    },
+    {
+      name: "disabled account",
+      accountId: "default",
+      warning: false,
+      channels: { discord: { token: "discord-token", groupPolicy: "allowlist", enabled: false } },
+    },
+  ])(
+    "reports effective guild policy for $name without probing",
+    async ({ channels, accountId, warning }) => {
+      const cfg = { channels } as OpenClawConfig;
+      const account = resolveAccount(cfg, accountId);
+      const snapshot = await discordPlugin.status!.buildAccountSnapshot!({
+        account,
+        cfg,
+        runtime: { accountId, running: true, connected: true, lastError: null },
+      });
+      const issues = discordPlugin.status!.collectStatusIssues!([snapshot]);
+      expect(
+        issues.some((issue) => issue.kind === "config" && issue.message.includes("no guilds")),
+      ).toBe(warning);
+      expect(snapshot).toMatchObject({ running: account.enabled, lastError: null });
+      if (account.enabled) {
+        expect(snapshot.connected).toBe(true);
+      }
+      if (warning && accountId === "default") {
+        expect(issues[0]?.fix).toContain("channels.discord.accounts.default.guilds");
+      }
+      expect(probeDiscordMock).not.toHaveBeenCalled();
+    },
+  );
+});
+
 describe("discordPlugin outbound", () => {
   it("builds tool context with separate native and routable DM targets", () => {
     const buildToolContext = discordPlugin.threading?.buildToolContext;

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -14,6 +14,10 @@ import {
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import {
+  resolveDefaultGroupPolicy,
+  resolveOpenProviderRuntimeGroupPolicy,
+} from "openclaw/plugin-sdk/runtime-group-policy";
+import {
   createComputedAccountStatusAdapter,
   createDefaultChannelRuntimeState,
 } from "openclaw/plugin-sdk/status-helpers";
@@ -615,11 +619,16 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount, DiscordProbe> 
           });
           return { ...audit, unresolvedChannels };
         },
-        resolveAccountSnapshot: ({ account, runtime, probe, audit }) => {
+        resolveAccountSnapshot: ({ account, cfg, runtime, probe, audit }) => {
           const configured =
             resolveConfiguredFromCredentialStatuses(account) ?? Boolean(account.token?.trim());
           const app = runtime?.application ?? (probe as { application?: unknown })?.application;
           const bot = runtime?.bot ?? (probe as { bot?: unknown })?.bot;
+          const { groupPolicy } = resolveOpenProviderRuntimeGroupPolicy({
+            providerConfigPresent: cfg.channels?.discord !== undefined,
+            groupPolicy: account.config.groupPolicy,
+            defaultGroupPolicy: resolveDefaultGroupPolicy(cfg),
+          });
           return {
             accountId: account.accountId,
             name: account.name,
@@ -635,6 +644,8 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount, DiscordProbe> 
               application: app ?? undefined,
               bot: bot ?? undefined,
               audit,
+              groupPolicy,
+              guildsConfigured: Object.keys(account.config.guilds ?? {}).length,
             },
           };
         },

--- a/extensions/discord/src/status-issues.test.ts
+++ b/extensions/discord/src/status-issues.test.ts
@@ -4,6 +4,47 @@ import { describe, expect, it } from "vitest";
 import { collectDiscordStatusIssues } from "./status-issues.js";
 
 describe("collectDiscordStatusIssues", () => {
+  it("reports an empty guild allowlist with the resolved account config path", () => {
+    const issues = collectDiscordStatusIssues([
+      {
+        accountId: "ops",
+        enabled: true,
+        configured: true,
+        groupPolicy: "allowlist",
+        guildsConfigured: 0,
+      } as ChannelAccountSnapshot,
+    ]);
+
+    expect(issues).toEqual([
+      {
+        channel: "discord",
+        accountId: "ops",
+        kind: "config",
+        message:
+          'Discord guild messages are blocked: effective groupPolicy is "allowlist", but no guilds are configured.',
+        fix: "Add your server under channels.discord.accounts.ops.guilds. Refresh channel status after the configuration reload applies.",
+      },
+    ]);
+  });
+
+  it("explains the top-level and explicit default-account guild config paths", () => {
+    const issues = collectDiscordStatusIssues([
+      {
+        accountId: "default",
+        enabled: true,
+        configured: true,
+        groupPolicy: "allowlist",
+        guildsConfigured: 0,
+      } as ChannelAccountSnapshot,
+    ]);
+
+    expect(issues[0]?.fix).toContain("channels.discord.guilds");
+    expect(issues[0]?.fix).toContain(
+      "If channels.discord.accounts.default.guilds is set, add it there instead.",
+    );
+    expect(issues[0]?.fix).toContain("after the configuration reload applies");
+  });
+
   it("reports disabled message content intent and unresolved channel ids", () => {
     const issues = collectDiscordStatusIssues([
       {

--- a/extensions/discord/src/status-issues.ts
+++ b/extensions/discord/src/status-issues.ts
@@ -96,7 +96,12 @@ export function collectDiscordStatusIssues(
 ): ChannelStatusIssue[] {
   const issues: ChannelStatusIssue[] = [];
   for (const entry of accounts) {
-    const account = readAccountStatusSnapshot(entry, ["application", "audit"]);
+    const account = readAccountStatusSnapshot(entry, [
+      "application",
+      "audit",
+      "groupPolicy",
+      "guildsConfigured",
+    ]);
     if (!account) {
       continue;
     }
@@ -106,6 +111,21 @@ export function collectDiscordStatusIssues(
     }
 
     const app = readDiscordApplicationSummary(account.application);
+    if (account.groupPolicy === "allowlist" && account.guildsConfigured === 0) {
+      const guildGuidance =
+        accountId === "default"
+          ? "Add your server under channels.discord.guilds. If channels.discord.accounts.default.guilds is set, add it there instead."
+          : `Add your server under channels.discord.accounts.${accountId}.guilds.`;
+      issues.push({
+        channel: "discord",
+        accountId,
+        kind: "config",
+        message:
+          'Discord guild messages are blocked: effective groupPolicy is "allowlist", but no guilds are configured.',
+        fix: `${guildGuidance} Refresh channel status after the configuration reload applies.`,
+      });
+    }
+
     const messageContent = app.intents?.messageContent;
     if (messageContent === "disabled") {
       issues.push({

--- a/packages/gateway-protocol/src/channels.schema.test.ts
+++ b/packages/gateway-protocol/src/channels.schema.test.ts
@@ -116,6 +116,15 @@ describe("ChannelsStatusResultSchema", () => {
         channelDefaultAccountId: { discord: "default" },
         partial: true,
         warnings: ["discord:default probe timed out after 1000ms"],
+        statusIssues: [
+          {
+            channel: "discord",
+            accountId: "default",
+            kind: "config",
+            message: "No guilds are allowed.",
+            fix: "Add an allowed guild.",
+          },
+        ],
         eventLoop: {
           degraded: true,
           degradedSinceMs: 61_000,

--- a/packages/gateway-protocol/src/schema/channels.ts
+++ b/packages/gateway-protocol/src/schema/channels.ts
@@ -692,6 +692,24 @@ export const ChannelsStatusResultSchema = closedObject({
   eventLoop: Type.Optional(ChannelEventLoopHealthSchema),
   partial: Type.Optional(Type.Boolean()),
   warnings: Type.Optional(Type.Array(Type.String())),
+  statusIssues: Type.Optional(
+    Type.Array(
+      closedObject({
+        channel: NonEmptyString,
+        accountId: NonEmptyString,
+        kind: Type.Union([
+          Type.Literal("intent"),
+          Type.Literal("permissions"),
+          Type.Literal("config"),
+          Type.Literal("auth"),
+          Type.Literal("runtime"),
+        ]),
+        message: Type.String(),
+        fix: Type.Optional(Type.String()),
+      }),
+      { maxItems: 50 },
+    ),
+  ),
 });
 
 /** Logs out one channel account. */

--- a/src/commands/channels.surfaces-signal-runtime-errors-channels-status-output.test.ts
+++ b/src/commands/channels.surfaces-signal-runtime-errors-channels-status-output.test.ts
@@ -131,6 +131,25 @@ describe("channels command", () => {
     expect(lines.join("\n")).toContain("whatsapp:default status failed: snapshot failed");
   });
 
+  it("renders Gateway policy diagnostics and recovery without calling status partial", () => {
+    const lines = formatGatewayChannelsStatusLines({
+      channelAccounts: { signal: [{ accountId: "default", configured: true, running: true }] },
+      statusIssues: [
+        {
+          channel: "signal",
+          accountId: "default",
+          kind: "config",
+          message: "Channel configuration reload is deferred while active work finishes.",
+          fix: "Wait for active work to finish, then refresh channel status.",
+        },
+      ],
+    }).join("\n");
+    expect(lines).toContain("running");
+    expect(lines).toContain("configuration reload is deferred");
+    expect(lines).toContain("Wait for active work to finish");
+    expect(lines).not.toContain("status is partial");
+  });
+
   it("surfaces transport liveness timestamps in channels status output", () => {
     const lines = formatGatewayChannelsStatusLines({
       channelLabels: {

--- a/src/gateway/config-reload-status.types.ts
+++ b/src/gateway/config-reload-status.types.ts
@@ -9,3 +9,10 @@
 export type GatewayHotReloadStatus = "active" | "disabled";
 
 export type GatewayHotReloadApplicationStatus = "applied" | "applied-restart-required";
+
+/** Channel reload work currently waiting for active Gateway work to drain. */
+export type GatewayDeferredChannelReload = {
+  channel: string;
+  /** False when plugin publication committed before newly activated channels wait to start. */
+  publicationPending: boolean;
+};

--- a/src/gateway/server-methods/channels-status-issues.ts
+++ b/src/gateway/server-methods/channels-status-issues.ts
@@ -1,0 +1,53 @@
+import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
+import type { ChannelId, ChannelStatusIssue } from "../../channels/plugins/types.public.js";
+import { collectChannelStatusIssues } from "../../infra/channels-status-issues.js";
+import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
+import { formatForLog } from "../ws-log.js";
+import type { GatewayRequestContext } from "./types.js";
+
+export function resolveDeferredChannelReloadIssue(
+  context: GatewayRequestContext,
+  channel: ChannelId,
+  accountId: string,
+): ChannelStatusIssue | undefined {
+  const deferred = context.getDeferredChannelReloads?.().find((entry) => entry.channel === channel);
+  if (!deferred) {
+    return undefined;
+  }
+  return {
+    channel,
+    accountId,
+    kind: "config",
+    message: deferred.publicationPending
+      ? "Channel configuration reload is deferred while active work finishes. The previous configuration is still in use."
+      : "Channel reload is deferred while active work finishes.",
+    fix: "Wait for active work to finish, then refresh channel status. Stopping and starting the channel does not apply unpublished configuration; use config.get to inspect the active configuration.",
+  };
+}
+
+export function collectGatewayChannelStatusIssues(params: {
+  payload: Record<string, unknown>;
+  plugins: readonly ChannelPlugin[];
+  defaultAccountIds: Record<string, unknown>;
+  context: GatewayRequestContext;
+  warnings: string[];
+}): ChannelStatusIssue[] {
+  const issues: ChannelStatusIssue[] = [];
+  for (const plugin of params.plugins) {
+    try {
+      issues.push(...collectChannelStatusIssues(params.payload, [plugin]));
+    } catch (error) {
+      params.warnings.push(`${plugin.id} status diagnostics failed: ${formatForLog(error)}`);
+    }
+    const defaultAccountId = params.defaultAccountIds[plugin.id];
+    const deferredIssue = resolveDeferredChannelReloadIssue(
+      params.context,
+      plugin.id,
+      typeof defaultAccountId === "string" ? defaultAccountId : DEFAULT_ACCOUNT_ID,
+    );
+    if (deferredIssue) {
+      issues.push(deferredIssue);
+    }
+  }
+  return issues.slice(0, 50);
+}

--- a/src/gateway/server-methods/channels-status-issues.ts
+++ b/src/gateway/server-methods/channels-status-issues.ts
@@ -21,7 +21,7 @@ export function resolveDeferredChannelReloadIssue(
     message: deferred.publicationPending
       ? "Channel configuration reload is deferred while active work finishes. The previous configuration is still in use."
       : "Channel reload is deferred while active work finishes.",
-    fix: "Wait for active work to finish, then refresh channel status. Stopping and starting the channel does not apply unpublished configuration; use config.get to inspect the active configuration.",
+    fix: "Wait for active work to finish, then refresh channel status. Stopping and starting the channel does not apply unpublished configuration.",
   };
 }
 

--- a/src/gateway/server-methods/channels.start.test.ts
+++ b/src/gateway/server-methods/channels.start.test.ts
@@ -71,7 +71,7 @@ function createOptions(
   } as unknown as GatewayRequestHandlerOptions;
 }
 
-async function runChannelsStart(running: boolean) {
+async function runChannelsStart(running: boolean, publicationPending?: boolean) {
   const startChannel = vi.fn(async () => new Map([["default-account", { status: "handed-off" }]]));
   const respond = vi.fn();
 
@@ -87,6 +87,8 @@ async function runChannelsStart(running: boolean) {
           getRuntimeConfig: mocks.getRuntimeConfig,
           startChannel,
           getRuntimeSnapshot: vi.fn(() => createChannelRuntimeSnapshot(running)),
+          getDeferredChannelReloads: () =>
+            publicationPending === undefined ? [] : [{ channel: "whatsapp", publicationPending }],
         } as unknown as GatewayRequestHandlerOptions["context"],
       },
     ),
@@ -142,6 +144,26 @@ describe("channelsHandlers channels.start", () => {
         started: false,
         outcome: { status: "handed-off" },
       },
+      undefined,
+    );
+  });
+
+  it("explains a successful manual start while configuration publication is deferred", async () => {
+    const { respond, startChannel } = await runChannelsStart(true, true);
+    expect(startChannel).toHaveBeenCalledWith("whatsapp", "default-account", { manual: true });
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        started: true,
+        statusIssues: [
+          expect.objectContaining({
+            channel: "whatsapp",
+            accountId: "default-account",
+            kind: "config",
+            message: expect.stringContaining("previous configuration is still in use"),
+          }),
+        ],
+      }),
       undefined,
     );
   });

--- a/src/gateway/server-methods/channels.status.test.ts
+++ b/src/gateway/server-methods/channels.status.test.ts
@@ -4,6 +4,7 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelStatusIssue } from "../../channels/plugins/types.public.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createPluginRecord } from "../../plugins/status.test-fixtures.js";
 import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
@@ -22,6 +23,7 @@ type ChannelTestPlugin = {
   status?: {
     probeAccount?: (params?: unknown) => unknown;
     buildChannelSummary?: () => unknown;
+    collectStatusIssues?: () => ChannelStatusIssue[];
   };
 };
 
@@ -100,6 +102,7 @@ function createChannelPlugin(
     id?: string;
     probeAccount?: (params?: unknown) => unknown;
     buildChannelSummary?: () => unknown;
+    collectStatusIssues?: () => ChannelStatusIssue[];
   } = {},
 ): ChannelTestPlugin {
   return {
@@ -110,12 +113,15 @@ function createChannelPlugin(
       isEnabled: () => true,
       isConfigured: async (_account, cfg) => Boolean(cfg.autoEnabled),
     },
-    ...(params.probeAccount || params.buildChannelSummary
+    ...(params.probeAccount || params.buildChannelSummary || params.collectStatusIssues
       ? {
           status: {
             ...(params.probeAccount ? { probeAccount: params.probeAccount } : {}),
             ...(params.buildChannelSummary
               ? { buildChannelSummary: params.buildChannelSummary }
+              : {}),
+            ...(params.collectStatusIssues
+              ? { collectStatusIssues: params.collectStatusIssues }
               : {}),
           },
         }
@@ -228,6 +234,83 @@ describe("channelsHandlers channels.status", () => {
     const channels = requireGatewayRecord(payload.channels, "channels payload");
     const whatsapp = requireGatewayRecord(channels.whatsapp, "whatsapp channel");
     expect(whatsapp.configured).toBe(true);
+  });
+
+  it("reports policy and deferred publication without changing healthy transport status", async () => {
+    const policyIssue: ChannelStatusIssue = {
+      channel: "guildchat",
+      accountId: "default",
+      kind: "config",
+      message: "No groups are allowed.",
+      fix: "Add an allowed group.",
+    };
+    configureAutoEnabledChannels([
+      createChannelPlugin({ id: "guildchat", collectStatusIssues: () => [policyIssue] }),
+      createChannelPlugin({ id: "sibling" }),
+    ]);
+    mocks.buildChannelAccountSnapshotFromAccount.mockResolvedValue({
+      accountId: "default",
+      enabled: true,
+      configured: true,
+      running: true,
+      connected: true,
+      lastError: null,
+    });
+    const options = createOptions({});
+    options.context.getDeferredChannelReloads = () => [
+      { channel: "guildchat", publicationPending: true },
+      { channel: "unselected", publicationPending: true },
+    ];
+
+    const payload = await runChannelsStatus({ channel: "guildchat" }, { context: options.context });
+
+    expect(payload.statusIssues).toEqual([
+      policyIssue,
+      expect.objectContaining({
+        channel: "guildchat",
+        kind: "config",
+        message: expect.stringContaining("previous configuration is still in use"),
+        fix: expect.stringContaining("Stopping and starting the channel does not apply"),
+      }),
+    ]);
+    expect(firstChannelAccount(payload, "guildchat")).toMatchObject({
+      running: true,
+      connected: true,
+      lastError: null,
+    });
+    expect(payload.partial).toBeUndefined();
+    expect(payload.warnings).toBeUndefined();
+  });
+
+  it("clears deferred diagnostics and distinguishes work after publication", async () => {
+    const options = createOptions({});
+    options.context.getDeferredChannelReloads = () => [
+      { channel: "whatsapp", publicationPending: false },
+    ];
+    const payload = await runChannelsStatus({}, { context: options.context });
+    expect(payload.statusIssues).toEqual([
+      expect.objectContaining({
+        message: "Channel reload is deferred while active work finishes.",
+      }),
+    ]);
+    options.context.getDeferredChannelReloads = () => [];
+    expect((await runChannelsStatus({}, { context: options.context })).statusIssues).toEqual([]);
+  });
+
+  it("retains account status when a plugin diagnostic collector fails", async () => {
+    configureAutoEnabledChannels([
+      createChannelPlugin({
+        collectStatusIssues: () => {
+          throw new Error("diagnostic unavailable");
+        },
+      }),
+    ]);
+    const payload = await runChannelsStatus({});
+    expect(firstChannelAccount(payload, "whatsapp").configured).toBe(true);
+    expect(payload.partial).toBe(true);
+    expect(payload.warnings).toContain(
+      "whatsapp status diagnostics failed: Error: diagnostic unavailable",
+    );
   });
 
   it("redacts base URL credentials returned by channel summary hooks", async () => {

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -19,11 +19,15 @@ import {
 import { listReadOnlyChannelPluginsForConfig } from "../../channels/plugins/read-only.js";
 import { buildChannelAccountSnapshotFromAccount } from "../../channels/plugins/status.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
-import type { ChannelAccountSnapshot } from "../../channels/plugins/types.public.js";
+import type {
+  ChannelAccountSnapshot,
+  ChannelStatusIssue,
+} from "../../channels/plugins/types.public.js";
 import { resolveUnavailableChannelAccountSnapshot } from "../../channels/status/account-state.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getChannelActivity } from "../../infra/channel-activity.js";
+import { collectChannelStatusIssues } from "../../infra/channels-status-issues.js";
 import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import { isAccountEnabled } from "../../shared/account-enabled.js";
@@ -54,6 +58,7 @@ type ChannelStartPayload = {
   accountId: string;
   started: boolean;
   outcome: ChannelAccountStartOutcome;
+  statusIssues?: ChannelStatusIssue[];
 };
 
 type ChannelStopPayload = {
@@ -66,6 +71,26 @@ type ChannelOperationParams = {
   channel?: unknown;
   accountId?: unknown;
 };
+
+function resolveDeferredChannelReloadIssue(
+  context: GatewayRequestContext,
+  channel: ChannelId,
+  accountId: string,
+): ChannelStatusIssue | undefined {
+  const deferred = context.getDeferredChannelReloads?.().find((entry) => entry.channel === channel);
+  if (!deferred) {
+    return undefined;
+  }
+  return {
+    channel,
+    accountId,
+    kind: "config",
+    message: deferred.publicationPending
+      ? "Channel configuration reload is deferred while active work finishes. The previous configuration is still in use."
+      : "Channel reload is deferred while active work finishes.",
+    fix: "Wait for active work to finish, then refresh channel status. Stopping and starting the channel does not apply unpublished configuration; use config.get to inspect the active configuration.",
+  };
+}
 
 function resolveChannelOperationParams<TParams extends ChannelOperationParams>(params: {
   method: string;
@@ -314,11 +339,17 @@ async function startChannelAccount(params: {
       channelId: params.channelId,
       accountId: resolvedAccountId,
     })?.running === true;
+  const deferredIssue = resolveDeferredChannelReloadIssue(
+    params.context,
+    params.channelId,
+    resolvedAccountId,
+  );
   return {
     channel: params.channelId,
     accountId: resolvedAccountId,
     started,
     outcome,
+    ...(deferredIssue ? { statusIssues: [deferredIssue] } : {}),
   };
 }
 
@@ -585,6 +616,24 @@ export const channelsHandlers: GatewayRequestHandlers = {
         defaultAccountIdMap[result.pluginId] = result.defaultAccountId;
       }
     }
+    const statusIssues: ChannelStatusIssue[] = [];
+    for (const plugin of statusPlugins) {
+      try {
+        statusIssues.push(...collectChannelStatusIssues(payload, [plugin]));
+      } catch (error) {
+        statusWarnings.push(`${plugin.id} status diagnostics failed: ${formatForLog(error)}`);
+      }
+      const defaultAccountId = defaultAccountIdMap[plugin.id];
+      const deferredIssue = resolveDeferredChannelReloadIssue(
+        context,
+        plugin.id,
+        typeof defaultAccountId === "string" ? defaultAccountId : DEFAULT_ACCOUNT_ID,
+      );
+      if (deferredIssue) {
+        statusIssues.push(deferredIssue);
+      }
+    }
+    payload.statusIssues = statusIssues.slice(0, 50);
     if (statusWarnings.length > 0) {
       payload.partial = true;
       payload.warnings = statusWarnings.toSorted().slice(0, 50);

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -27,7 +27,6 @@ import { resolveUnavailableChannelAccountSnapshot } from "../../channels/status/
 import { readConfigFileSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getChannelActivity } from "../../infra/channel-activity.js";
-import { collectChannelStatusIssues } from "../../infra/channels-status-issues.js";
 import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import { isAccountEnabled } from "../../shared/account-enabled.js";
@@ -43,6 +42,10 @@ import type {
   ChannelRuntimeSnapshot,
 } from "../server-channel-runtime.types.js";
 import { formatForLog } from "../ws-log.js";
+import {
+  collectGatewayChannelStatusIssues,
+  resolveDeferredChannelReloadIssue,
+} from "./channels-status-issues.js";
 import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams, type Validator } from "./validation.js";
 
@@ -71,26 +74,6 @@ type ChannelOperationParams = {
   channel?: unknown;
   accountId?: unknown;
 };
-
-function resolveDeferredChannelReloadIssue(
-  context: GatewayRequestContext,
-  channel: ChannelId,
-  accountId: string,
-): ChannelStatusIssue | undefined {
-  const deferred = context.getDeferredChannelReloads?.().find((entry) => entry.channel === channel);
-  if (!deferred) {
-    return undefined;
-  }
-  return {
-    channel,
-    accountId,
-    kind: "config",
-    message: deferred.publicationPending
-      ? "Channel configuration reload is deferred while active work finishes. The previous configuration is still in use."
-      : "Channel reload is deferred while active work finishes.",
-    fix: "Wait for active work to finish, then refresh channel status. Stopping and starting the channel does not apply unpublished configuration; use config.get to inspect the active configuration.",
-  };
-}
 
 function resolveChannelOperationParams<TParams extends ChannelOperationParams>(params: {
   method: string;
@@ -616,24 +599,13 @@ export const channelsHandlers: GatewayRequestHandlers = {
         defaultAccountIdMap[result.pluginId] = result.defaultAccountId;
       }
     }
-    const statusIssues: ChannelStatusIssue[] = [];
-    for (const plugin of statusPlugins) {
-      try {
-        statusIssues.push(...collectChannelStatusIssues(payload, [plugin]));
-      } catch (error) {
-        statusWarnings.push(`${plugin.id} status diagnostics failed: ${formatForLog(error)}`);
-      }
-      const defaultAccountId = defaultAccountIdMap[plugin.id];
-      const deferredIssue = resolveDeferredChannelReloadIssue(
-        context,
-        plugin.id,
-        typeof defaultAccountId === "string" ? defaultAccountId : DEFAULT_ACCOUNT_ID,
-      );
-      if (deferredIssue) {
-        statusIssues.push(deferredIssue);
-      }
-    }
-    payload.statusIssues = statusIssues.slice(0, 50);
+    payload.statusIssues = collectGatewayChannelStatusIssues({
+      payload,
+      plugins: statusPlugins,
+      defaultAccountIds: defaultAccountIdMap,
+      context,
+      warnings: statusWarnings,
+    });
     if (statusWarnings.length > 0) {
       payload.partial = true;
       payload.warnings = statusWarnings.toSorted().slice(0, 50);

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -26,7 +26,10 @@ import type { WizardSession } from "../../wizard/session.js";
 import type { AgentRuntimeApprovalAuthorityValidator } from "../agent-runtime-identity-token.js";
 import type { InternalAgentTurnFacadeFactory } from "../agent-turn/internal-facade.types.js";
 import type { ChatAbortControllerEntry } from "../chat-abort.js";
-import type { GatewayHotReloadStatus } from "../config-reload-status.types.js";
+import type {
+  GatewayDeferredChannelReload,
+  GatewayHotReloadStatus,
+} from "../config-reload-status.types.js";
 import type { GatewayConfigRevisionProjector } from "../config-revision-token.js";
 import type { ScopeUpgradeCoordinator } from "../device-scope-upgrade.js";
 import type { ExecApprovalManager, ExecApprovalRecord } from "../exec-approval-manager.js";
@@ -374,6 +377,7 @@ type GatewayResidentBridgeContext = {
   getRuntimeSnapshot: () => ChannelRuntimeSnapshot;
   getEventLoopHealth?: () => GatewayEventLoopHealth | undefined;
   getConfigReloaderHotReloadStatus?: () => GatewayHotReloadStatus | undefined;
+  getDeferredChannelReloads?: () => readonly GatewayDeferredChannelReload[];
   startChannel: (
     channel: import("../../channels/plugins/types.public.js").ChannelId,
     accountId?: string,

--- a/src/gateway/server-reload-active-work.ts
+++ b/src/gateway/server-reload-active-work.ts
@@ -7,8 +7,12 @@ import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission
 import { getInspectableActiveTaskRestartBlockers } from "../tasks/task-registry.maintenance.js";
 import { formatActiveTaskRestartBlocker } from "../tasks/task-restart-blocker.js";
 import type { ChannelKind } from "./config-reload-plan.js";
+import type { GatewayDeferredChannelReload } from "./config-reload-status.types.js";
 import type { GatewayReloadHandlerParams } from "./server-reload-contracts.js";
-import { isGatewayReloadGenerationAborted } from "./server-reload-generation.js";
+import {
+  isCurrentGatewayReloadGeneration,
+  isGatewayReloadGenerationAborted,
+} from "./server-reload-generation.js";
 
 const CHANNEL_RELOAD_DEFERRAL_POLL_MS = 500;
 const CHANNEL_RELOAD_STILL_PENDING_WARN_MS = 30_000;
@@ -18,6 +22,25 @@ export function createGatewayActiveWorkTracker(options: {
   myGeneration: number;
 }) {
   const { params, myGeneration } = options;
+  let deferredChannelReload:
+    | {
+        channels: ChannelKind[];
+        publicationPending: boolean;
+        isCurrent: () => boolean;
+      }
+    | undefined;
+  const getDeferredChannelReloads = (): readonly GatewayDeferredChannelReload[] => {
+    if (
+      !deferredChannelReload ||
+      !isCurrentGatewayReloadGeneration(myGeneration) ||
+      isGatewayReloadGenerationAborted(myGeneration) ||
+      !deferredChannelReload.isCurrent()
+    ) {
+      return [];
+    }
+    const { channels, publicationPending } = deferredChannelReload;
+    return channels.map((channel) => ({ channel, publicationPending }));
+  };
   const getActiveCounts = () => {
     const queueSize = getTotalQueueSize();
     const pendingReplies = getTotalPendingReplies();
@@ -80,6 +103,7 @@ export function createGatewayActiveWorkTracker(options: {
   const waitForActiveWorkBeforeChannelReload = async (
     channels: Iterable<ChannelKind>,
     isTransactionCurrent: () => boolean,
+    publicationPending: boolean,
   ): Promise<boolean> => {
     // Returns true when the wait was cancelled (restart or config supersession),
     // false when active work drained or timed out and channel reload may proceed.
@@ -90,7 +114,8 @@ export function createGatewayActiveWorkTracker(options: {
     if (initial.totalActive <= 0) {
       return false;
     }
-    const channelNames = [...channels].join(", ");
+    const channelIds = [...new Set(channels)];
+    const channelNames = channelIds.join(", ");
     const initialDetails = formatActiveDetails(initial);
     params.logReload.warn(
       `config change requires channel reload (${channelNames}) — deferring until ${initialDetails.join(
@@ -100,37 +125,50 @@ export function createGatewayActiveWorkTracker(options: {
     const timeoutMs = resolveGatewayRestartDeferralTimeoutMs();
     const startedAt = Date.now();
     let nextStillPendingAt = startedAt + CHANNEL_RELOAD_STILL_PENDING_WARN_MS;
-    while (true) {
-      if (!isTransactionCurrent() || isGatewayReloadGenerationAborted(myGeneration)) {
-        return true;
+    const deferred = {
+      channels: channelIds,
+      publicationPending,
+      isCurrent: isTransactionCurrent,
+    };
+    deferredChannelReload = deferred;
+    try {
+      while (true) {
+        if (!isTransactionCurrent() || isGatewayReloadGenerationAborted(myGeneration)) {
+          return true;
+        }
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, CHANNEL_RELOAD_DEFERRAL_POLL_MS);
+          timer.unref?.();
+        });
+        if (!isTransactionCurrent() || isGatewayReloadGenerationAborted(myGeneration)) {
+          return true;
+        }
+        const current = getActiveCounts();
+        if (current.totalActive <= 0) {
+          return false;
+        }
+        const elapsedMs = Date.now() - startedAt;
+        if (timeoutMs !== undefined && elapsedMs >= timeoutMs) {
+          const remaining = formatActiveDetails(current);
+          params.logReload.warn(
+            `channel reload timeout after ${elapsedMs}ms with ${remaining.join(
+              ", ",
+            )} still active; reloading channels anyway`,
+          );
+          return false;
+        }
+        if (Date.now() >= nextStillPendingAt) {
+          const remaining = formatActiveDetails(current);
+          params.logReload.warn(
+            `channel reload still deferred after ${elapsedMs}ms with ${remaining.join(", ")} active`,
+          );
+          nextStillPendingAt = Date.now() + CHANNEL_RELOAD_STILL_PENDING_WARN_MS;
+        }
       }
-      await new Promise<void>((resolve) => {
-        const timer = setTimeout(resolve, CHANNEL_RELOAD_DEFERRAL_POLL_MS);
-        timer.unref?.();
-      });
-      if (!isTransactionCurrent() || isGatewayReloadGenerationAborted(myGeneration)) {
-        return true;
-      }
-      const current = getActiveCounts();
-      if (current.totalActive <= 0) {
-        return false;
-      }
-      const elapsedMs = Date.now() - startedAt;
-      if (timeoutMs !== undefined && elapsedMs >= timeoutMs) {
-        const remaining = formatActiveDetails(current);
-        params.logReload.warn(
-          `channel reload timeout after ${elapsedMs}ms with ${remaining.join(
-            ", ",
-          )} still active; reloading channels anyway`,
-        );
-        return false;
-      }
-      if (Date.now() >= nextStillPendingAt) {
-        const remaining = formatActiveDetails(current);
-        params.logReload.warn(
-          `channel reload still deferred after ${elapsedMs}ms with ${remaining.join(", ")} active`,
-        );
-        nextStillPendingAt = Date.now() + CHANNEL_RELOAD_STILL_PENDING_WARN_MS;
+    } finally {
+      // A cancelled wait must not clear a newer transaction's diagnostic lease.
+      if (deferredChannelReload === deferred) {
+        deferredChannelReload = undefined;
       }
     }
   };
@@ -140,6 +178,7 @@ export function createGatewayActiveWorkTracker(options: {
     formatDeferredWorkStatus,
     formatTaskBlockers,
     getActiveCounts,
+    getDeferredChannelReloads,
     waitForActiveWorkBeforeChannelReload,
   };
 }

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -4280,7 +4280,7 @@ describe("gateway restart deferral preflight", () => {
     const setState = vi.fn();
     let runtimePublished = false;
     const logReload = { info: vi.fn(), warn: vi.fn() };
-    const { applyHotReload } = createGatewayReloadHandlers({
+    const { applyHotReload, getDeferredChannelReloads } = createGatewayReloadHandlers({
       setState,
       startChannel,
       stopChannel,
@@ -4317,6 +4317,9 @@ describe("gateway restart deferral preflight", () => {
       expect(startChannel).not.toHaveBeenCalled();
       expect(runtimePublished).toBe(false);
       expect(setState).not.toHaveBeenCalled();
+      expect(getDeferredChannelReloads?.()).toEqual([
+        { channel: "discord", publicationPending: true },
+      ]);
 
       hoisted.activeEmbeddedRunCount.value = 0;
       await vi.advanceTimersByTimeAsync(500);
@@ -4339,6 +4342,7 @@ describe("gateway restart deferral preflight", () => {
     });
     expect(runtimePublished).toBe(true);
     expect(setState).toHaveBeenCalledTimes(1);
+    expect(getDeferredChannelReloads?.()).toEqual([]);
   });
 
   it("uses the default channel reload deferral timeout when config omits deferralTimeoutMs", async () => {
@@ -4346,7 +4350,7 @@ describe("gateway restart deferral preflight", () => {
     const startChannel = vi.fn(async () => new Map());
     const stopChannel = vi.fn(async () => {});
     const logReload = { info: vi.fn(), warn: vi.fn() };
-    const { applyHotReload } = createGatewayReloadHandlers({
+    const { applyHotReload, getDeferredChannelReloads } = createGatewayReloadHandlers({
       startChannel,
       stopChannel,
       logReload,
@@ -4368,6 +4372,9 @@ describe("gateway restart deferral preflight", () => {
       await vi.advanceTimersByTimeAsync(299_500);
       expect(stopChannel).not.toHaveBeenCalled();
       expect(startChannel).not.toHaveBeenCalled();
+      expect(getDeferredChannelReloads?.()).toEqual([
+        { channel: "telegram", publicationPending: true },
+      ]);
 
       await vi.advanceTimersByTimeAsync(500);
       await reloadPromise;
@@ -4390,6 +4397,7 @@ describe("gateway restart deferral preflight", () => {
     expect(logReload.warn).toHaveBeenCalledWith(
       expect.stringContaining("channel reload timeout after"),
     );
+    expect(getDeferredChannelReloads?.()).toEqual([]);
   });
 
   it("logs active task run ids before waiting and when forcing after timeout", async () => {
@@ -4811,7 +4819,11 @@ describe("gateway channel hot reload handlers", () => {
       return makePluginReloadResult({ activeChannels: new Set(["discord"]) });
     });
     const logReload = { info: vi.fn(), warn: vi.fn() };
-    const { applyHotReload } = createReloadHandlersForTest(logReload, channels, reloadPlugins);
+    const { applyHotReload, getDeferredChannelReloads } = createReloadHandlersForTest(
+      logReload,
+      channels,
+      reloadPlugins,
+    );
     vi.useFakeTimers();
     let reload: Promise<GatewayHotReloadApplicationStatus> | undefined;
 
@@ -4822,6 +4834,9 @@ describe("gateway channel hot reload handlers", () => {
         await vi.advanceTimersByTimeAsync(0);
         expect(events).toEqual([]);
         expect(logReload.warn).toHaveBeenCalledWith(expect.stringContaining("(discord)"));
+        expect(getDeferredChannelReloads?.()).toEqual([
+          { channel: "discord", publicationPending: false },
+        ]);
 
         hoisted.activeEmbeddedRunCount.value = 0;
         await vi.advanceTimersByTimeAsync(500);
@@ -4836,6 +4851,7 @@ describe("gateway channel hot reload handlers", () => {
 
     expect(events).toEqual(["stop:discord:undefined", "start:discord:undefined"]);
     expect(reloadPlugins).toHaveBeenCalledOnce();
+    expect(getDeferredChannelReloads?.()).toEqual([]);
   });
 
   it("requires a recovery owner for targeted account reloads", async () => {
@@ -7790,9 +7806,14 @@ describe("deferred channel reload abort generation", () => {
 
     try {
       await vi.advanceTimersByTimeAsync(10);
+      expect(oldHandlers.getDeferredChannelReloads?.()).toEqual([
+        { channel: "whatsapp", publicationPending: true },
+      ]);
       resetGatewayRestartStateForInProcessRestart();
+      expect(oldHandlers.getDeferredChannelReloads?.()).toEqual([]);
       hoisted.activeTaskBlockers.length = 0;
       const nextHandlers = createTestHandlers(logChannels, nextChannels);
+      expect(nextHandlers.getDeferredChannelReloads?.()).toEqual([]);
       const nextReload = nextHandlers
         .applyHotReload({ ...abortChannelReloadPlan, reloadInternalHooks: true }, {})
         .then(
@@ -7978,7 +7999,11 @@ describe("deferred channel reload abort generation", () => {
           activeChannels: new Set(["whatsapp"]),
         });
       };
-      const { applyHotReload } = createTestHandlers(logChannels, channels, { reloadPlugins });
+      const { applyHotReload, getDeferredChannelReloads } = createTestHandlers(
+        logChannels,
+        channels,
+        { reloadPlugins },
+      );
       hoisted.activeTaskBlockers.push(
         makeActiveTaskBlocker({ taskId: "task-blocking-superseded-reload" }),
       );
@@ -8004,14 +8029,20 @@ describe("deferred channel reload abort generation", () => {
           (error: unknown) => error,
         );
         await vi.advanceTimersByTimeAsync(10);
+        expect(getDeferredChannelReloads?.()).toEqual([
+          { channel: "whatsapp", publicationPending: !committed },
+        ]);
 
         if (cancellationKind === "lifecycle") {
           abortPendingChannelReloads();
         } else {
           transactionCurrent = false;
         }
+        // Status follows the live owner immediately, not the next 500 ms poll.
+        expect(getDeferredChannelReloads?.()).toEqual([]);
         await vi.advanceTimersByTimeAsync(500);
         const error = await reloadError;
+        expect(getDeferredChannelReloads?.()).toEqual([]);
         if (committed && cancellationKind === "config") {
           expect(error).toBeNull();
           expect(channels.stop).toHaveBeenCalledOnce();
@@ -8139,12 +8170,16 @@ describe("deferred channel reload abort generation", () => {
         );
         expect(application.claimed).toBe(true);
         expect(settled).not.toHaveBeenCalled();
+        expect(reloader.getDeferredChannelReloads?.()).toEqual([
+          { channel: "whatsapp", publicationPending: true },
+        ]);
 
         // Revoke the write epoch while real hot reload is waiting on unrelated work.
         // Hold the disk reread so cancellation settles before exact-candidate replay.
         const watcher = watch.mock.results[0]?.value;
         expect(watcher).toBeDefined();
         watcher.emit("change", "/tmp/openclaw.json");
+        expect(reloader.getDeferredChannelReloads?.()).toEqual([]);
         await vi.advanceTimersByTimeAsync(500);
         await vi.advanceTimersByTimeAsync(300);
         await snapshotStarted.promise;
@@ -8159,6 +8194,7 @@ describe("deferred channel reload abort generation", () => {
           await expect(application.result).resolves.toBe("stopped");
           snapshotGate.resolve();
           await stopping;
+          expect(reloader.getDeferredChannelReloads?.()).toEqual([]);
           expect(setState).not.toHaveBeenCalled();
           expect(startChannel).not.toHaveBeenCalled();
         } else {
@@ -8173,6 +8209,9 @@ describe("deferred channel reload abort generation", () => {
             expect(settled).not.toHaveBeenCalled();
             expect(setState).not.toHaveBeenCalled();
             expect(logReload.warn).toHaveBeenCalledTimes(2);
+            expect(reloader.getDeferredChannelReloads?.()).toEqual([
+              { channel: "whatsapp", publicationPending: true },
+            ]);
           }
           unrelatedRequest.release();
           await vi.advanceTimersByTimeAsync(500);
@@ -8183,6 +8222,7 @@ describe("deferred channel reload abort generation", () => {
                 ? "failed"
                 : "applied",
           );
+          expect(reloader.getDeferredChannelReloads?.()).toEqual([]);
           if (outcome === "same write") {
             expect(setState).toHaveBeenCalledOnce();
             expect(commitRuntimePolicy).toHaveBeenCalledWith(nextConfig);

--- a/src/gateway/server-reload-hot.ts
+++ b/src/gateway/server-reload-hot.ts
@@ -61,6 +61,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     formatDeferredWorkStatus,
     formatTaskBlockers,
     getActiveCounts,
+    getDeferredChannelReloads,
     waitForActiveWorkBeforeChannelReload,
   } = createGatewayActiveWorkTracker({ params, myGeneration });
 
@@ -406,7 +407,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         if (targets.size === 0 || shouldSkipChannelRestart) {
           return;
         }
-        if (await waitForActiveWorkBeforeChannelReload(targets, isCurrent)) {
+        if (await waitForActiveWorkBeforeChannelReload(targets, isCurrent, !runtimeCommitted)) {
           params.logChannels.info(
             "channel reload before plugin replace cancelled by config supersession or restart",
           );
@@ -513,7 +514,11 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     // Newly activated channels can follow plugin services that already admitted agent work.
     // Recheck before their startup; existing channels were drained before registry replacement.
     if (!pluginReloadAborted && hasLiveChannelTargets && !shouldSkipChannelRestart) {
-      const waitCancelled = await waitForActiveWorkBeforeChannelReload(channelTargets, isCurrent);
+      const waitCancelled = await waitForActiveWorkBeforeChannelReload(
+        channelTargets,
+        isCurrent,
+        !runtimeCommitted,
+      );
       // A committed owner must finish its model/channel tail before the next config runs.
       // Supersession ends this wait: a newer writer may itself be awaiting that next reload.
       pluginReloadAborted =
@@ -650,6 +655,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
 
   return {
     applyHotReload,
+    getDeferredChannelReloads,
     acceptRestartConfig,
     publishAppliedConfigHash,
     publishDeferredAppliedConfigHash,

--- a/src/gateway/server-reload-managed.ts
+++ b/src/gateway/server-reload-managed.ts
@@ -136,6 +136,7 @@ export function startManagedGatewayConfigReloader(
   };
   const {
     applyHotReload,
+    getDeferredChannelReloads,
     acceptRestartConfig,
     beginGatewayRestartLifecycle,
     hasOutstandingGatewayRestart,
@@ -526,6 +527,7 @@ export function startManagedGatewayConfigReloader(
       await configReloader.stop();
     },
     hotReloadStatus: configReloader.hotReloadStatus,
+    getDeferredChannelReloads,
     notifyPluginMetadataChanged: configReloader.notifyPluginMetadataChanged,
     // Equal config revisions can still owe a plugin/runtime restart.
     isConfigReloadSettled: () =>

--- a/src/gateway/server-request-context.test.ts
+++ b/src/gateway/server-request-context.test.ts
@@ -286,6 +286,7 @@ describe("createGatewayRequestContext", () => {
     const context = createGatewayRequestContext(params);
 
     expect(context.getConfigReloaderHotReloadStatus?.()).toBeUndefined();
+    expect(context.getDeferredChannelReloads?.()).toEqual([]);
 
     status = "active";
     expect(context.getConfigReloaderHotReloadStatus?.()).toBe("active");
@@ -295,6 +296,16 @@ describe("createGatewayRequestContext", () => {
 
     status = "disabled";
     expect(context.getConfigReloaderHotReloadStatus?.()).toBe("disabled");
+
+    const deferred = [{ channel: "discord", publicationPending: true }];
+    params.runtime.runtimeState.configReloader = {
+      isConfigReloadSettled: () => false,
+      getDeferredChannelReloads: () => deferred,
+    };
+    expect(context.getDeferredChannelReloads?.()).toEqual(deferred);
+
+    params.runtime.lifecycle.closePreludeStarted = true;
+    expect(context.getDeferredChannelReloads?.()).toEqual([]);
   });
 
   it("publishes worker services through the kernel bridge", () => {

--- a/src/gateway/server-request-context.ts
+++ b/src/gateway/server-request-context.ts
@@ -109,7 +109,7 @@ type GatewayRequestContextRuntime = Pick<
     > & {
       configReloader: Pick<
         GatewayCoreRuntime["runtimeState"]["configReloader"],
-        "isConfigReloadSettled"
+        "isConfigReloadSettled" | "getDeferredChannelReloads"
       >;
     };
     lifecycle: Pick<GatewayCoreRuntime["lifecycle"], "closePreludeStarted">;
@@ -245,6 +245,10 @@ export function createGatewayRequestContext(
     getRuntimeConfig,
     isConfigReloadSettled: () =>
       !lifecycle.closePreludeStarted && runtimeState.configReloader.isConfigReloadSettled(),
+    getDeferredChannelReloads: () =>
+      lifecycle.closePreludeStarted
+        ? []
+        : (runtimeState.configReloader.getDeferredChannelReloads?.() ?? []),
     getGatewayMethodRegistry: runtime.getAttachedGatewayMethodRegistry,
     gatewayTlsFingerprint: runtime.gatewayTls.enabled
       ? runtime.gatewayTls.fingerprintSha256

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -2,7 +2,10 @@
 // Provides stop-safe defaults for timers, sidecars, subscriptions, and services.
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
-import type { GatewayHotReloadStatus } from "./config-reload-status.types.js";
+import type {
+  GatewayDeferredChannelReload,
+  GatewayHotReloadStatus,
+} from "./config-reload-status.types.js";
 import type { GatewayDiscovery } from "./server-discovery-runtime.js";
 import {
   MEDIA_CLEANUP_STOP_TIMEOUT_MS,
@@ -21,6 +24,7 @@ import type { GatewayPostReadySidecarHandle } from "./server-startup-post-attach
 export type GatewayConfigReloaderHandle = {
   stop: () => Promise<void>;
   hotReloadStatus?: () => GatewayHotReloadStatus;
+  getDeferredChannelReloads?: () => readonly GatewayDeferredChannelReload[];
   notifyPluginMetadataChanged: () => void;
   isConfigReloadSettled: () => boolean;
 };

--- a/src/infra/channels-status-issues.test.ts
+++ b/src/infra/channels-status-issues.test.ts
@@ -47,6 +47,35 @@ describe("collectChannelStatusIssues", () => {
     expect(collectTelegramIssues).not.toHaveBeenCalled();
   });
 
+  it("uses Gateway-owned diagnostics without loading local plugins or duplicating issues", () => {
+    const statusIssues: ChannelStatusIssue[] = [
+      {
+        channel: "guildchat",
+        accountId: "work",
+        kind: "config",
+        message: "Channel configuration reload is deferred while active work finishes.",
+      },
+    ];
+    expect(collectChannelStatusIssues({ statusIssues })).toEqual(statusIssues);
+    expect(collectChannelStatusIssues({ statusIssues: [] })).toEqual([]);
+    expect(mocks.listChannelPlugins).not.toHaveBeenCalled();
+  });
+
+  it("does not let malformed remote diagnostics hide a stopped account", () => {
+    mocks.listChannelPlugins.mockReturnValue([createPlugin("discord")]);
+    const issues = collectChannelStatusIssues({
+      statusIssues: [null],
+      channelAccounts: { discord: [{ accountId: "default", running: false }] },
+    });
+    expect(issues).toEqual([
+      expect.objectContaining({
+        channel: "discord",
+        kind: "runtime",
+        message: expect.stringContaining("not running"),
+      }),
+    ]);
+  });
+
   it("skips plugins without collectors and concatenates collector output in plugin order", () => {
     const collectTelegramIssues = vi.fn((): ChannelStatusIssue[] => [
       {

--- a/src/infra/channels-status-issues.ts
+++ b/src/infra/channels-status-issues.ts
@@ -1,8 +1,11 @@
 // Collects channel account status issues for diagnostics.
+import { Value } from "typebox/value";
+import { ChannelsStatusResultSchema } from "../../packages/gateway-protocol/src/schema/channels.js";
 import { listChannelPlugins } from "../channels/plugins/index.js";
 import type {
   ChannelAccountSnapshot,
   ChannelId,
+  ChannelPlugin,
   ChannelStatusIssue,
 } from "../channels/plugins/types.public.js";
 import {
@@ -92,10 +95,20 @@ function collectGenericRuntimeStatusIssues(
 }
 
 /** Collects generic and plugin-specific issues from a channels status payload. */
-export function collectChannelStatusIssues(payload: Record<string, unknown>): ChannelStatusIssue[] {
+export function collectChannelStatusIssues(
+  payload: Record<string, unknown>,
+  plugins?: readonly ChannelPlugin[],
+): ChannelStatusIssue[] {
+  // The Gateway owns live diagnostics, including reload state unavailable to CLI readers.
+  if (
+    Array.isArray(payload.statusIssues) &&
+    Value.Check(ChannelsStatusResultSchema.properties.statusIssues, payload.statusIssues)
+  ) {
+    return payload.statusIssues;
+  }
   const issues: ChannelStatusIssue[] = [];
   const accountsByChannel = payload.channelAccounts as Record<string, unknown> | undefined;
-  for (const plugin of listChannelPlugins()) {
+  for (const plugin of plugins ?? listChannelPlugins()) {
     const raw = accountsByChannel?.[plugin.id];
     if (!Array.isArray(raw)) {
       continue;

--- a/ui/src/pages/channels/view.detail.ts
+++ b/ui/src/pages/channels/view.detail.ts
@@ -8,6 +8,7 @@ import { renderSettingsSection } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import "../../components/modal-dialog.ts";
 import { resolveChannelAccounts } from "../../lib/channels/index.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import { formatRelativeTimestamp } from "../../lib/format.ts";
 import { channelDocsUrl } from "./hub-meta.ts";
 import { renderChannelConfigSection } from "./view.config.ts";
@@ -231,6 +232,9 @@ export function renderChannelDetail(params: {
   onSetup: () => void;
 }): TemplateResult {
   const body = renderChannelBody(params.channelId, params.props, params.data);
+  const statusIssues = params.props.snapshot?.statusIssues?.filter(
+    (issue) => issue.channel === params.channelId,
+  );
   return html`
     <openclaw-modal-dialog label=${params.label} @modal-cancel=${() => params.onClose()}>
       <div class="channels-detail">
@@ -273,6 +277,17 @@ export function renderChannelDetail(params: {
               ? html`<div class="callout warn">${t("channels.hub.saveBeforeSetup")}</div>`
               : nothing
           }
+          ${statusIssues?.map(
+            (issue) => html`
+              <div class="callout warn" role="note">
+                <strong>
+                  ${t("channels.hub.stateAttention")} · ${formatUiExternalText(issue.accountId)}
+                </strong>
+                <div>${formatUiExternalText(issue.message)}</div>
+                ${issue.fix ? html`<div>${formatUiExternalText(issue.fix)}</div>` : nothing}
+              </div>
+            `,
+          )}
           ${renderChannelPairingDetail(params.channelId, params.props)} ${body}
         </div>
       </div>

--- a/ui/src/pages/channels/view.test.ts
+++ b/ui/src/pages/channels/view.test.ts
@@ -1,7 +1,7 @@
 // Channels page view tests.
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
-import type { WhatsAppStatus } from "../../api/types.ts";
+import type { ChannelsStatusSnapshot, WhatsAppStatus } from "../../api/types.ts";
 import type { PluginCatalogItem } from "../../lib/plugins/index.ts";
 import { renderChannelDetail } from "./view.detail.ts";
 import {
@@ -246,6 +246,145 @@ describe("channel row actions", () => {
       expect(onAction).toHaveBeenCalledExactlyOnceWith("telegram");
     },
   );
+});
+
+describe("channel status issues", () => {
+  function createRunningSnapshot(): ChannelsStatusSnapshot {
+    return {
+      ts: 1,
+      channelOrder: ["discord", "slack"],
+      channelLabels: { discord: "Discord", slack: "Slack" },
+      channels: {
+        discord: { configured: true, running: true, connected: true, lastError: null },
+        slack: { configured: true, running: true },
+      },
+      channelAccounts: {
+        discord: [
+          { accountId: "default", configured: true, running: true, lastError: null },
+          { accountId: "community", configured: true, running: true, lastError: null },
+        ],
+      },
+      channelDefaultAccountId: { discord: "default" },
+    };
+  }
+
+  function findChannelRow(container: HTMLElement, label: string) {
+    return Array.from(container.querySelectorAll<HTMLButtonElement>("button.channels-item")).find(
+      (row) => row.querySelector(".settings-row__title")?.textContent === label,
+    )!;
+  }
+
+  it("shows account policy and pending reload issues without hiding a running transport", () => {
+    const snapshot = createRunningSnapshot();
+    snapshot.statusIssues = [
+      {
+        channel: "discord",
+        accountId: "community",
+        kind: "config",
+        message: "Guild messages are blocked because the guild allowlist is empty.",
+        fix: "Add the intended guild to the allowlist.",
+      },
+      {
+        channel: "discord",
+        accountId: "community",
+        kind: "runtime",
+        message: "Channel restart is pending while active work drains.",
+        fix: "Wait for active work to finish, then refresh status.",
+      },
+    ];
+    const props = createProps(snapshot);
+    const container = document.createElement("div");
+    props.onShowDetail = (channel) => {
+      props.selectedChannel = channel;
+      render(renderChannels(props), container);
+    };
+
+    render(renderChannels(props), container);
+
+    const discord = findChannelRow(container, "Discord");
+    expect(discord.querySelector(".settings-status")?.textContent?.trim()).toBe("Needs attention");
+    expect(discord.querySelector(".settings-row__desc")?.textContent).toBe(
+      snapshot.statusIssues[0]!.message,
+    );
+    expect(
+      findChannelRow(container, "Slack").querySelector(".settings-status")?.textContent?.trim(),
+    ).toBe("Running");
+    expect(container.textContent).not.toContain("Some channel checks did not finish");
+
+    discord.click();
+
+    const detail = container.querySelector(".channels-detail")!;
+    const notices = detail.querySelectorAll('[role="note"]');
+    expect(notices).toHaveLength(2);
+    snapshot.statusIssues.forEach((issue, index) => {
+      expect(notices[index]!.textContent).toContain("Needs attention · community");
+      expect(notices[index]!.textContent).toContain(issue.message);
+      expect(notices[index]!.textContent).toContain(issue.fix);
+    });
+    const running = Array.from(detail.querySelectorAll("dt")).find(
+      (node) => node.textContent?.trim() === "Running",
+    );
+    expect(running?.nextElementSibling?.textContent?.trim()).toBe("Yes");
+
+    props.snapshot = { ...snapshot, ts: 2, statusIssues: [] };
+    render(renderChannels(props), container);
+
+    expect(
+      findChannelRow(container, "Discord").querySelector(".settings-status")?.textContent?.trim(),
+    ).toBe("Running");
+    expect(container.querySelectorAll('.channels-detail [role="note"]')).toHaveLength(0);
+    expect(container.textContent).not.toContain(snapshot.statusIssues[0]!.message);
+  });
+
+  it("escapes and redacts plugin issue text in the row and recovery notice", () => {
+    const snapshot = createRunningSnapshot();
+    snapshot.statusIssues = [
+      {
+        channel: "discord",
+        accountId: "<b>community</b>",
+        kind: "config",
+        message: 'Policy blocks <img src="x" onerror="alert(1)"> with Bearer abcdefghijkl',
+        fix: "Check <script>alert(1)</script> with Bearer mnopqrstuvwxyz",
+      },
+    ];
+    const props = createProps(snapshot);
+    props.selectedChannel = "discord";
+    const container = document.createElement("div");
+
+    render(renderChannels(props), container);
+
+    const row = findChannelRow(container, "Discord");
+    const notice = container.querySelector('.channels-detail [role="note"]')!;
+    expect(row.textContent).toContain('<img src="x" onerror="alert(1)"> with Bearer [redacted]');
+    expect(notice.textContent).toContain("<b>community</b>");
+    expect(notice.textContent).toContain("<script>alert(1)</script> with Bearer [redacted]");
+    expect(container.textContent).not.toContain("abcdefghijkl");
+    expect(container.textContent).not.toContain("mnopqrstuvwxyz");
+    expect(row.querySelector(".settings-row__desc img")).toBeNull();
+    expect(notice.querySelector("b, img, script")).toBeNull();
+  });
+
+  it("keeps transport failures and partial probe diagnostics distinct from policy issues", () => {
+    const snapshot = createRunningSnapshot();
+    snapshot.channels.discord = { configured: true, running: true, lastError: "Connection closed" };
+    snapshot.partial = true;
+    snapshot.warnings = ["Slack probe timed out."];
+    const props = createProps(snapshot);
+    props.selectedChannel = "discord";
+    const container = document.createElement("div");
+
+    render(renderChannels(props), container);
+
+    expect(
+      findChannelRow(container, "Discord").querySelector(".settings-status")?.textContent?.trim(),
+    ).toBe("Needs attention");
+    expect(
+      findChannelRow(container, "Slack").querySelector(".settings-status")?.textContent?.trim(),
+    ).toBe("Running");
+    expect(container.textContent).toContain("Connection closed");
+    expect(container.textContent).toContain("Slack probe timed out.");
+    expect(container.querySelectorAll('.channels-detail [role="note"]')).toHaveLength(0);
+  });
 });
 
 function createWhatsAppStatus(overrides: Partial<WhatsAppStatus> = {}): WhatsAppStatus {

--- a/ui/src/pages/channels/view.ts
+++ b/ui/src/pages/channels/view.ts
@@ -263,10 +263,12 @@ function lastActivityLine(key: ChannelKey, props: ChannelsProps): string | null 
 
 function renderConnectedRow(key: ChannelKey, props: ChannelsProps) {
   const label = resolveChannelLabel(props, key);
-  const description =
-    lastActivityLine(key, props) ??
-    resolveChannelDetailLabel(props, key) ??
-    t("channels.hub.openDetails");
+  const statusIssue = props.snapshot?.statusIssues?.find((issue) => issue.channel === key);
+  const description = statusIssue
+    ? formatUiExternalText(statusIssue.message)
+    : (lastActivityLine(key, props) ??
+      resolveChannelDetailLabel(props, key) ??
+      t("channels.hub.openDetails"));
   return html`
     <button
       type="button"
@@ -282,7 +284,7 @@ function renderConnectedRow(key: ChannelKey, props: ChannelsProps) {
         <span class="settings-row__desc">${description}</span>
       </div>
       <div class="settings-row__control">
-        ${rowStatus(resolveRowState(key, props))}
+        ${rowStatus(statusIssue ? "attention" : resolveRowState(key, props))}
         <span class="settings-row__chevron">${icons.chevronRight}</span>
       </div>
     </button>


### PR DESCRIPTION
Related: #140550

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled.

</details>

## What Problem This Solves

Resolves a problem where operators see Discord as running even though an empty effective guild allowlist blocks all guild messages. During an active-work-deferred reload, manual stop/start can also appear healthy while the intended configuration remains unpublished, without explaining that distinction in channel status.

## Why This Change Was Made

Publish account diagnostics through the existing Gateway status flow and expose active-work deferrals from the reload owner, distinguishing waits before and after configuration publication. CLI and Control UI show actionable guidance, and manual start reports pending reloads without changing access policy, transactional publication, the deferral deadline, or start/stop behavior.

## User Impact

- See empty Discord guild allowlists in the channel list, channel details, and `openclaw channels status`, including inherited policies and named/default-account overrides.
- Understand when a reload is waiting and why stop/start does not apply unpublished configuration.
- Refresh status after recovery to clear the warnings; transport status remains independently visible.

This implements the narrowed diagnostics direction, not a force-apply action or a fix for indefinite deferral. It does not change `config.set` restart-hint selection. Absence of a warning is not a general guarantee that persisted and active configuration match.

## Evidence

### Maintainer correction and final validation

At `4e73d814b50a847472a6b4f0b987ee912c7ef40e`, the deferred-reload hint and matching documentation no longer describe `config.get` as inspecting active runtime configuration. It reads the on-disk snapshot. The correction retains wait/refresh guidance and the warning that stop/start does not publish pending configuration.

Independent full-candidate review found one wording issue, accepted and resolved in those two files. Targeted formatting and whitespace checks passed. The [exact-head CI run, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34080597051/attempts/2) passed after one targeted rerun of an unrelated Workshop blank-row-height failure; the PR source was unchanged during that rerun.

The producer trace and screenshots below are earlier evidence at their stated revisions, preserved rather than rewritten. Their original `config.get` wording is superseded by the correction above. No new live Discord or native-service proof is claimed for this wording-only correction.

### Production diagnostic generation and recovery — after-fix proof

Addresses the [ClawSweeper producer-proof request](https://github.com/openclaw/openclaw/pull/140635#issuecomment-5564106779). **Passed on `6870c608af3a6ab0c09423d9486357441227a772`**, with a clean worktree and SHA-256 checks of all six changed producer files shown in the trace below. This proof is separate from the earlier UI rendering demonstration.

| Observed stage | Published guild count | Policy warning | Deferred-reload warning |
| --- | ---: | --- | --- |
| Initial empty allowlist | 0 | Present | Absent |
| Corrected candidate waiting on active work | 0 | Present | Present (`publicationPending: true`) |
| Manual stop/start while still waiting | 0 | Present | Present; also returned by `channels.start` |
| Work released, reload applied, status refreshed | 1 | **Cleared** | **Cleared**; live reload getter is empty |

**What executed:** the unmodified Discord plugin selected by the real channel registry; its real account resolver/snapshot/issue collector; the real reload planner and `createGatewayReloadHandlers`; a real `tryBeginGatewayIndependentRootWorkAdmission` lease; the real 500 ms active-work wait and diagnostic getter; the production runtime-config snapshot setter/getter; and the production `channels.status`, `channels.stop`, and `channels.start` RPC handlers. The script asserts plugin identity and every transition. It never assigns or mocks `statusIssues`, the Discord snapshot, active-work counts, reload diagnostics, or their timers.

**Boundary:** an isolated **in-process production-owner integration**, not a listening Gateway/WebSocket/auth test or live Discord proof. The publication adapter calls the production snapshot setter only after the reload owner's commit callback; it does not exercise disk watching or `config.set`. Transport start/stop effects are explicit no-network stubs. The synthetic account has a nonsecret placeholder credential, and the empty transport snapshot truthfully reports `running: false`, `connected: false` throughout. Its separate runtime warning remains after recovery; the two new configuration warnings clear. No existing Gateway or operator config was used. Node ran with an empty inherited environment plus PATH and task-owned state/config paths.

**Configuration/upgrade impact:** no new configuration option, default change, schema migration, or access-policy change. The same effective guild map/account precedence is used before and after the reload. `statusIssues` and account snapshot fields `groupPolicy` / `guildsConfigured` are additive diagnostic outputs; existing start outcomes and configuration publication semantics remain unchanged. This does not claim that every possible persisted/active-config mismatch is covered.

<details>
<summary>Actual after-fix JSONL trace, including owner logs and source hashes</summary>

```jsonl
{"event":"source","value":{"head":"6870c608af3a6ab0c09423d9486357441227a772","files":{"extensions/discord/src/channel.ts":"72a333788c6995569659e110337a984dc826dc2845c8397d83f692a99f9656b1","extensions/discord/src/status-issues.ts":"9a3c1657ba402146ac34c06a2b917e7828d0a9ee5084ddaded9a6924f0bbf77c","src/gateway/server-reload-active-work.ts":"b3211742ab061014ba153a3eaa59b29753355eb36b6dabe9c037f3b13a53147a","src/gateway/server-reload-hot.ts":"4c56ba75d1f7d049b98c66fb6a986837050e6fb6cbc4cf461dbb876cbc5b8e3a","src/gateway/server-methods/channels.ts":"9b89f7a223c8f4ae250ae87cbc3b8306fe650290b10857269ecdf9ed959c1094","src/gateway/server-methods/channels-status-issues.ts":"b88523913167bc8cfd94f6cc1476fd8f1118493d21820c34bab66d6fe7153d3a"}}}
{"event":"before-correction","value":{"account":{"configured":true,"running":false,"connected":false,"groupPolicy":"allowlist","guildsConfigured":0},"configIssues":[{"channel":"discord","accountId":"default","kind":"config","message":"Discord guild messages are blocked: effective groupPolicy is \"allowlist\", but no guilds are configured.","fix":"Add your server under channels.discord.guilds. If channels.discord.accounts.default.guilds is set, add it there instead. Refresh channel status after the configuration reload applies."}],"otherIssueKinds":["runtime"],"liveReloads":[],"activeGuildCount":0}}
{"event":"reload.owner","value":["active-work.admitted",{"count":1}]}
{"event":"reload.owner","value":["reload.plan",{"changedPaths":["channels.discord.guilds.111111111111111111"],"restartChannels":["discord"],"restartChannelAccounts":[]}]}
{"event":"reload.owner","value":["reload.warn",{"message":"config change requires channel reload (discord) — deferring until 1 gateway request(s) complete"}]}
{"event":"correction-pending-active-work","value":{"account":{"configured":true,"running":false,"connected":false,"groupPolicy":"allowlist","guildsConfigured":0},"configIssues":[{"channel":"discord","accountId":"default","kind":"config","message":"Discord guild messages are blocked: effective groupPolicy is \"allowlist\", but no guilds are configured.","fix":"Add your server under channels.discord.guilds. If channels.discord.accounts.default.guilds is set, add it there instead. Refresh channel status after the configuration reload applies."},{"channel":"discord","accountId":"default","kind":"config","message":"Channel configuration reload is deferred while active work finishes. The previous configuration is still in use.","fix":"Wait for active work to finish, then refresh channel status. Stopping and starting the channel does not apply unpublished configuration; use config.get to inspect the active configuration."}],"otherIssueKinds":["runtime"],"liveReloads":[{"channel":"discord","publicationPending":true}],"activeGuildCount":0}}
{"event":"transport.stub.manual-stop","value":{}}
{"event":"transport.stub.manual-start","value":{"accountId":"default"}}
{"event":"manual-start-while-pending","value":{"started":false,"outcome":{"status":"handed-off"},"statusIssues":[{"channel":"discord","accountId":"default","kind":"config","message":"Channel configuration reload is deferred while active work finishes. The previous configuration is still in use.","fix":"Wait for active work to finish, then refresh channel status. Stopping and starting the channel does not apply unpublished configuration; use config.get to inspect the active configuration."}]}}
{"event":"after-manual-stop-start","value":{"account":{"configured":true,"running":false,"connected":false,"groupPolicy":"allowlist","guildsConfigured":0},"configIssues":[{"channel":"discord","accountId":"default","kind":"config","message":"Discord guild messages are blocked: effective groupPolicy is \"allowlist\", but no guilds are configured.","fix":"Add your server under channels.discord.guilds. If channels.discord.accounts.default.guilds is set, add it there instead. Refresh channel status after the configuration reload applies."},{"channel":"discord","accountId":"default","kind":"config","message":"Channel configuration reload is deferred while active work finishes. The previous configuration is still in use.","fix":"Wait for active work to finish, then refresh channel status. Stopping and starting the channel does not apply unpublished configuration; use config.get to inspect the active configuration."}],"otherIssueKinds":["runtime"],"liveReloads":[{"channel":"discord","publicationPending":true}],"activeGuildCount":0}}
{"event":"reload.owner","value":["active-work.released",{"count":0}]}
{"event":"reload.owner","value":["publication.entered"]}
{"event":"publication.commit","value":{"activeGuildCount":1}}
{"event":"reload.owner","value":["publication.committed"]}
{"event":"reload.owner","value":["channels.info",{"message":"restarting discord channel"}]}
{"event":"reload.owner","value":["transport.boundary",{"action":"stop","channel":"discord","options":{"manual":false,"routeHandoff":true},"boundary":"no-network transport"}]}
{"event":"reload.owner","value":["transport.boundary",{"action":"start","channel":"discord","options":{"preserveManualStop":true,"skipUnavailableAccounts":true},"boundary":"no-network transport"}]}
{"event":"reload.owner","value":["reload.info",{"message":"config hot reload applied (channels.discord.guilds.111111111111111111)"}]}
{"event":"reload.owner","value":["reload.settled",{"result":"applied","deferred":[]}]}
{"event":"after-work-drains","value":{"account":{"configured":true,"running":false,"connected":false,"groupPolicy":"allowlist","guildsConfigured":1},"configIssues":[],"otherIssueKinds":["runtime"],"liveReloads":[],"activeGuildCount":1}}
{"event":"PASS","value":{"realDiagnosticProducers":true,"realActiveWorkLeaseAndTimers":true,"configIssuesBefore":1,"configIssuesDuring":2,"configIssuesAfter":0,"transport":"stubbed; no Discord network connection","transportCalls":[{"action":"stop","channel":"discord","options":{"manual":false,"routeHandoff":true},"boundary":"no-network transport"},{"action":"start","channel":"discord","options":{"preserveManualStop":true,"skipUnavailableAccounts":true},"boundary":"no-network transport"}]}}
{"event":"reload.owner","value":["active-work.released",{"count":0}]}
```

</details>

<details>
<summary>Audit/reproduction harness used for this trace</summary>

Save the two files below beside each other outside the checkout. In the second file replace `CHECKOUT/` with the absolute checkout path. Run from the pinned checkout; `PROOF_DIR` is a temporary directory containing the two saved scripts:

```bash
env -i PATH="$PATH" \
  OPENCLAW_STATE_DIR="$PROOF_DIR/issue-140550-proof/producer-state" \
  OPENCLAW_CONFIG_PATH="$PROOF_DIR/issue-140550-proof/producer-state/openclaw.json" \
  node --import ./scripts/tsx.mjs "$PROOF_DIR/producer-trace.mts"
```

`producer-trace.mts`:

```typescript
import assert from "node:assert/strict";
import { createHash } from "node:crypto";
import { readFileSync, mkdirSync } from "node:fs";
import path from "node:path";
import { pathToFileURL } from "node:url";
import { setTimeout as delay } from "node:timers/promises";

const root = process.cwd();
const load = (file: string) => import(pathToFileURL(path.join(root, file)).href);
const log = (event: string, value: unknown) => console.log(JSON.stringify({ event, value }));
const stateDir = process.env.OPENCLAW_STATE_DIR!;
assert(stateDir?.includes("issue-140550-proof/producer-state"));
assert.equal(process.env.OPENCLAW_SKIP_CHANNELS, undefined);
assert.equal(process.env.OPENCLAW_SKIP_PROVIDERS, undefined);
mkdirSync(path.join(stateDir, "workspace"), { recursive: true });
// This process has an empty environment except PATH and task-owned state paths.
// No Discord transport is started. The credential is deliberately synthetic.
const initialConfig = {
  agents: { entries: {}, defaults: { workspace: path.join(stateDir, "workspace") } },
  plugins: { allow: ["discord"], entries: { discord: { enabled: true } } },
  channels: { discord: { enabled: true, token: "synthetic-proof-not-a-credential", groupPolicy: "allowlist", guilds: {} } },
};
const { discordPlugin } = await load("extensions/discord/api.ts");
const { createEmptyPluginRegistry } = await load("src/plugins/registry-empty.ts");
const { setActivePluginRegistry } = await load("src/plugins/runtime.ts");
const { setAppliedRuntimeConfigSnapshot, getRuntimeConfigSnapshot } = await load("src/config/runtime-snapshot.ts");
const { listReadOnlyChannelPluginsForConfig } = await load("src/channels/plugins/read-only.ts");
const { channelsHandlers } = await load("src/gateway/server-methods/channels.ts");
const registry = createEmptyPluginRegistry();
registry.channels.push({ pluginId: "discord", plugin: discordPlugin, source: "extensions/discord/api.ts", origin: "bundled" });
setActivePluginRegistry(registry, "producer-proof", "default", initialConfig.agents.defaults.workspace);
setAppliedRuntimeConfigSnapshot(initialConfig, initialConfig);
assert.equal(listReadOnlyChannelPluginsForConfig(initialConfig).find((p: any) => p.id === "discord"), discordPlugin);

const files = ["extensions/discord/src/channel.ts", "extensions/discord/src/status-issues.ts", "src/gateway/server-reload-active-work.ts", "src/gateway/server-reload-hot.ts", "src/gateway/server-methods/channels.ts", "src/gateway/server-methods/channels-status-issues.ts"];
log("source", { head: "6870c608af3a6ab0c09423d9486357441227a772", files: Object.fromEntries(files.map(file => [file, createHash("sha256").update(readFileSync(path.join(root, file))).digest("hex")])) });

let reload: any;
const context = {
  getRuntimeConfig: () => getRuntimeConfigSnapshot(),
  // Absent transport runtime is intentional: no claimed Discord connection.
  getRuntimeSnapshot: () => ({ channels: {}, channelAccounts: {} }),
  getDeferredChannelReloads: () => reload?.getDeferredChannelReloads() ?? [],
  startChannel: async (_channel: string, accountId: string) => {
    log("transport.stub.manual-start", { accountId });
    return new Map([[accountId, { status: "handed-off" }]]);
  },
  stopChannel: async () => { log("transport.stub.manual-stop", {}); },
};
async function rpc(method: string, params: Record<string, unknown>) {
  let result: any;
  await channelsHandlers[method]({
    req: { type: "req", id: method, method, params }, params, context,
    client: null, isWebchatConnect: () => false,
    respond: (ok: boolean, payload: unknown, error: unknown) => {
      assert.equal(ok, true, JSON.stringify(error));
      assert.equal(error, undefined);
      result = payload;
    },
  });
  assert(result, `${method} did not respond`);
  return result;
}
function configIssues(payload: any) { return payload.statusIssues.filter((i: any) => i.kind === "config"); }
function policy(payload: any) { return configIssues(payload).find((i: any) => i.message.includes("no guilds are configured")); }
function deferred(payload: any) { return configIssues(payload).find((i: any) => i.message.includes("reload is deferred")); }
async function status(stage: string) {
  const result = await rpc("channels.status", { channel: "discord", probe: false });
  const account = result.channelAccounts.discord[0];
  log(stage, {
    account: { configured: account.configured, running: account.running, connected: account.connected, groupPolicy: account.groupPolicy, guildsConfigured: account.guildsConfigured },
    configIssues: configIssues(result),
    otherIssueKinds: result.statusIssues.filter((i: any) => i.kind !== "config").map((i: any) => i.kind),
    liveReloads: context.getDeferredChannelReloads(),
    activeGuildCount: Object.keys(context.getRuntimeConfig().channels.discord.guilds).length,
  });
  return result;
}

const before = await status("before-correction");
assert(policy(before));
assert.equal(deferred(before), undefined);

const { createProofReloadOwner } = await import("./reload-owner-harness.mts");
reload = createProofReloadOwner({
  initialConfig,
  publishConfig: (next: any) => { setAppliedRuntimeConfigSnapshot(next, next); log("publication.commit", { activeGuildCount: Object.keys(next.channels.discord.guilds).length }); },
  log: (...args: unknown[]) => log("reload.owner", args),
});
const nextConfig = structuredClone(initialConfig);
nextConfig.channels.discord.guilds = { "111111111111111111": {} };
reload.beginHold();
const applying = reload.apply(nextConfig);
let settled = false;
void applying.then(() => { settled = true; }, () => { settled = true; });
const deadline = Date.now() + 10_000;
while (reload.getDeferredChannelReloads().length === 0) {
  assert(!settled, "Reload settled without publishing a deferral");
  assert(Date.now() < deadline, "Reload never reached active-work deferral");
  await delay(20);
}
const waiting = await status("correction-pending-active-work");
assert(policy(waiting));
assert(deferred(waiting));
assert.equal(waiting.channelAccounts.discord[0].guildsConfigured, 0);
assert.deepEqual(reload.getDeferredChannelReloads(), [{ channel: "discord", publicationPending: true }]);

await rpc("channels.stop", { channel: "discord", accountId: "default" });
const started = await rpc("channels.start", { channel: "discord", accountId: "default" });
assert(deferred(started));
log("manual-start-while-pending", { started: started.started, outcome: started.outcome, statusIssues: started.statusIssues });
const stillWaiting = await status("after-manual-stop-start");
assert(policy(stillWaiting));
assert(deferred(stillWaiting));
assert.equal(stillWaiting.channelAccounts.discord[0].guildsConfigured, 0);

reload.release();
await Promise.race([applying, delay(15_000).then(() => { throw new Error("Reload failed to drain"); })]);
const recovered = await status("after-work-drains");
assert.equal(recovered.channelAccounts.discord[0].guildsConfigured, 1);
assert.equal(policy(recovered), undefined);
assert.equal(deferred(recovered), undefined);
assert.deepEqual(reload.getDeferredChannelReloads(), []);
assert.equal(configIssues(recovered).length, 0);
log("PASS", { realDiagnosticProducers: true, realActiveWorkLeaseAndTimers: true, configIssuesBefore: 1, configIssuesDuring: 2, configIssuesAfter: 0, transport: "stubbed; no Discord network connection", transportCalls: reload.transportCalls });
reload.stop();
```

`reload-owner-harness.mts` (checkout path abbreviated only):

```typescript
/**
 * Isolated producer proof. Real reload planner, active-work registry, reload
 * owner, publication sequencing, diagnostic getter and 500 ms wait timers.
 * Only unrelated services and Discord transport effects are test boundaries.
 * This is not a live Discord or full Gateway startup test.
 */
import { listAgentIds } from "CHECKOUT/src/agents/agent-scope-config.ts";
import type { OpenClawConfig } from "CHECKOUT/src/config/types.openclaw.ts";
import { diffConfigPaths } from "CHECKOUT/src/gateway/config-diff.ts";
import { buildGatewayReloadPlan } from "CHECKOUT/src/gateway/config-reload-plan.ts";
import type { GatewayReloadHandlerParams } from "CHECKOUT/src/gateway/server-reload-contracts.ts";
import { createGatewayReloadHandlers } from "CHECKOUT/src/gateway/server-reload-hot.ts";
import { getPluginRegistryForContext } from "CHECKOUT/src/plugins/runtime.ts";
import {
  getActiveGatewayRootWorkCount,
  tryBeginGatewayIndependentRootWorkAdmission,
} from "CHECKOUT/src/process/gateway-work-admission.ts";

type ProofLog = (event: string, details?: unknown) => void;

export function createProofReloadOwner(params: {
  initialConfig: OpenClawConfig;
  publishConfig: (config: OpenClawConfig) => void | Promise<void>;
  log: ProofLog;
}) {
  const fail = (operation: string): never => {
    throw new Error(`Proof boundary unexpectedly invoked: ${operation}`);
  };
  const assertIsolatedConfig = (config: OpenClawConfig) => {
    if (listAgentIds(config).length !== 0) {
      fail("model owner discovery; use an explicit empty agents.entries roster");
    }
    if (process.env.OPENCLAW_SKIP_CHANNELS || process.env.OPENCLAW_SKIP_PROVIDERS) {
      fail("skip-channel environment would bypass the production deferral path");
    }
  };
  assertIsolatedConfig(params.initialConfig);
  let publishedConfig = params.initialConfig;
  let closed = false;
  let applying = false;
  let hold: ReturnType<typeof tryBeginGatewayIndependentRootWorkAdmission> = null;
  const transportCalls: Array<Record<string, unknown>> = [];
  const serviceLog = (scope: string) => ({
    info: (message: string) => params.log(`${scope}.info`, { message }),
    warn: (message: string) => params.log(`${scope}.warn`, { message }),
    error: (message: string) => params.log(`${scope}.error`, { message }),
  });
  let state = {
    hooksConfig: null,
    hookClientIpConfig: { allowRealIpFallback: false },
    heartbeatRunner: {
      updateConfig: () => fail("heartbeat config"),
      stop: () => fail("heartbeat stop"),
    },
    cronState: {
      cron: {},
      cronEnabled: false,
      storePath: "/isolated-proof/no-cron-store",
      reconcileSystemJobs: () => fail("cron reconciliation"),
      reconcileExitWatchers: () => fail("cron exit watchers"),
      reconcileStreamWatchers: () => fail("cron stream watchers"),
      stopStreamWatchers: () => fail("cron stream watcher stop"),
    },
  } as unknown as ReturnType<GatewayReloadHandlerParams["getState"]>;

  const owner = createGatewayReloadHandlers({
    deps: {} as GatewayReloadHandlerParams["deps"],
    broadcast: () => fail("broadcast"),
    getState: () => state,
    setState: (nextState) => { state = nextState; },
    getPluginRegistry: () => getPluginRegistryForContext() ?? fail("missing real plugin registry"),
    startChannel: async (channel, accountId, options) => {
      const call = { action: "start", channel, accountId, options, boundary: "no-network transport" };
      transportCalls.push(call);
      params.log("transport.boundary", call);
      // The reload owner consumes admission outcomes, not fabricated diagnostics.
      return new Map();
    },
    stopChannel: async (channel, accountId, options) => {
      const call = { action: "stop", channel, accountId, options, boundary: "no-network transport" };
      transportCalls.push(call);
      params.log("transport.boundary", call);
    },
    releaseChannelRouteHandoffs: () => fail("route handoff rollback"),
    pruneInactiveChannelAccountState: () => fail("plugin account pruning"),
    reloadPlugins: async () => fail("plugin replacement"),
    requestRecoveryRestart: () => fail("recovery restart"),
    logHooks: serviceLog("hooks"),
    logChannels: serviceLog("channels"),
    logCron: serviceLog("cron"),
    logReload: serviceLog("reload"),
    cronReconciliation: {
      arm: () => fail("cron reconciliation arm"),
      invalidate: () => fail("cron reconciliation invalidation"),
    },
  });

  const release = () => {
    hold?.release();
    hold = null;
    params.log("active-work.released", { count: getActiveGatewayRootWorkCount() });
  };

  return {
    getDeferredChannelReloads: owner.getDeferredChannelReloads,
    transportCalls,
    beginHold() {
      if (closed || hold) fail("closed owner or duplicate active-work hold");
      // Deliberately do not enter hold.run(): reload excludes its own root.
      hold = tryBeginGatewayIndependentRootWorkAdmission("proof:active-work");
      if (!hold) fail("root-work admission refused");
      params.log("active-work.admitted", { count: getActiveGatewayRootWorkCount() });
      return release;
    },
    release,
    async apply(nextConfig: OpenClawConfig) {
      if (closed || applying) fail("closed owner or concurrent reload");
      assertIsolatedConfig(nextConfig);
      const changedPaths = diffConfigPaths(publishedConfig, nextConfig);
      if (!changedPaths.length || changedPaths.some((path) => !path.startsWith("channels.discord."))) {
        fail("proof requires only Discord configuration changes");
      }
      const plan = buildGatewayReloadPlan(changedPaths, {
        previousConfig: publishedConfig,
        candidateConfig: nextConfig,
      });
      if (
        plan.restartGateway || plan.reloadPlugins || plan.restartCron ||
        plan.restartHeartbeat || plan.restartGmailWatcher || plan.reloadHooks ||
        plan.reloadInternalHooks || plan.refreshHooksPolicy || plan.reconcileSystemJobs ||
        plan.disposeMcpRuntimes || (plan.restartServices?.size ?? 0) > 0
      ) fail("non-channel reload plan");
      if (!plan.restartChannels.has("discord") && !plan.restartChannelAccounts?.has("discord")) {
        fail("real planner did not select Discord; load the real plugin registry first");
      }
      params.log("reload.plan", {
        changedPaths,
        restartChannels: [...plan.restartChannels],
        restartChannelAccounts: [...(plan.restartChannelAccounts ?? [])].map(([id, ids]) => [id, [...ids]]),
      });
      applying = true;
      // The real owner intentionally unrefs its poll; this CLI-only keepalive
      // prevents Node exiting before that unchanged production poll settles.
      const keepAlive = setInterval(() => {}, 1_000);
      try {
        const result = await owner.applyHotReload(plan, nextConfig, {
          sourceConfig: nextConfig,
          isCurrent: () => !closed,
          publish: async (commit, isCommitted) => {
            params.log("publication.entered");
            await commit();
            if (!isCommitted()) fail("publication callback before commit");
            await params.publishConfig(nextConfig);
            publishedConfig = nextConfig;
            params.log("publication.committed");
          },
        });
        if (result !== "applied") fail(`reload result ${result}`);
        params.log("reload.settled", { result, deferred: owner.getDeferredChannelReloads() });
        return result;
      } finally {
        applying = false;
        clearInterval(keepAlive);
      }
    },
    stop() {
      closed = true;
      release();
      owner.stopRestartRetries();
    },
  };
}
```

</details>


- `pnpm build`: **passed**, including generated declarations, CLI bootstrap, SDK exports, and Control UI performance checks.

- `pnpm test:contracts:channels`: **494 tests passed across 50 files**.

Follow-up `6870c608af3` extracts Gateway channel diagnostics into their own module to satisfy the file-length lint limit. The 29 status/start tests pass before and after extraction; targeted lint, formatting, and independent review pass. Full build and shared channel-contract results above are from the initial implementation (`db3facc9213`); hosted CI is rerunning for the follow-up.

The previous [UI CI failure](https://github.com/openclaw/openclaw/actions/runs/34076048681/job/101602369692) involved two unrelated Workshop long-skill tests at `ui/src/e2e/skill-workshop-collection.e2e.test.ts:135` (blank-row height). Those tests were added on newer main via [#140300](https://github.com/openclaw/openclaw/pull/140300) and are absent from this branch. This PR changes no Workshop test, renderer, stylesheet, or harness; a baseline reproduction was not run.

- New policy and pending-status regressions fail against the original production source. Focused Discord, Gateway lifecycle/status/start, protocol, CLI, and UI tests pass, including timeout, supersession, lifecycle shutdown, postpublication waits, account overrides, malformed remote diagnostics, text escaping/redaction, and recovery clearing.
- Before/after proof uses real Chromium running the source Control UI with deterministic mocked Gateway responses. The browser traverses Settings → Channels → Discord and refreshes through Probe; both warnings disappear after the recovery response.
- No live Discord connection was used and no existing Gateway was restarted.

### Before / after

| Before: running with no policy explanation | After: policy needs attention |
| --- | --- |
| ![Discord status before the fix](https://github.com/user-attachments/assets/3e793725-101a-4a1a-9fcb-ccbee0cb3512) | ![Discord status after the fix](https://github.com/user-attachments/assets/6aa836f5-a255-4ee2-bc13-db711bb6b85e) |

<details>
<summary>Account-specific policy and deferred-reload recovery guidance</summary>

![Discord account diagnostics and recovery guidance](https://github.com/user-attachments/assets/3dbf444d-3cc0-4716-9d82-c7e3d2ce7b0e)

The mock omits the configuration-editor schema; that unrelated editor placeholder is unchanged.

</details>


