### PR TITLE
fix(discord): restore session resets for sender aliases

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -152,7 +152,8 @@ Channel plugins can enforce owner-only command access through their
 <ParamField path="commands.allowFrom" type="object">
   Per-provider allowlist for command authorization. When configured, it is the
   **only** authorization source for commands and directives. Use `"*"` for a
-  global default; provider-specific keys override it.
+  global default; provider-specific keys override it. Discord sender entries
+  accept bare user IDs or `user:<id>` and `discord:<id>` aliases.
 </ParamField>
 
 When `commands.allowFrom` is not configured, command authorization follows

--- a/extensions/discord/src/monitor/inbound-context.ts
+++ b/extensions/discord/src/monitor/inbound-context.ts
@@ -46,10 +46,7 @@ export function createDiscordSupplementalContextAccessChecker(params: {
 export function buildDiscordGroupSystemPrompt(
   channelConfig?: DiscordChannelConfigResolved | null,
 ): string | undefined {
-  const systemPromptParts = [channelConfig?.systemPrompt?.trim() || null].filter(
-    (entry): entry is string => Boolean(entry),
-  );
-  return systemPromptParts.length > 0 ? systemPromptParts.join("\n\n") : undefined;
+  return channelConfig?.systemPrompt?.trim() || undefined;
 }
 
 function buildDiscordChannelStructuredContext(params: {

--- a/extensions/discord/src/monitor/native-command.reset.test.ts
+++ b/extensions/discord/src/monitor/native-command.reset.test.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { ChannelType } from "discord-api-types/v10";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  createTestRegistry,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
+import {
+  getSessionEntry,
+  loadTranscriptEventsSync,
+  upsertSessionEntry,
+} from "openclaw/plugin-sdk/session-store-runtime";
+import { afterEach, describe, expect, it } from "vitest";
+import { discordPlugin } from "../channel.js";
+import type { CommandInteraction } from "../internal/discord.js";
+import { createDiscordNativeCommand } from "./native-command.js";
+import { createMockCommandInteraction } from "./native-command.test-helpers.js";
+import { createNoopThreadBindingManager } from "./thread-bindings.manager.js";
+
+const directories: string[] = [];
+const userId = "100000000000000003";
+const sessionId = "existing-channel-session";
+
+afterEach(async () => {
+  clearRuntimeConfigSnapshot();
+  setActivePluginRegistry(createTestRegistry());
+  await Promise.all(
+    directories.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+async function runReset(commandName: "new" | "reset", allowFrom: string[]) {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "discord-native-reset-"));
+  directories.push(home);
+  const channelId = "100000000000000001";
+  const guildId = "100000000000000002";
+  const storePath = path.join(home, "sessions.json");
+  const sessionKey = `agent:main:discord:channel:${channelId}`;
+  const scope = { agentId: "main", storePath, sessionKey };
+  const cfg: OpenClawConfig = {
+    agents: { defaults: { workspace: home } },
+    session: { store: storePath },
+    commands: { allowFrom: { discord: allowFrom } },
+    channels: {
+      discord: {
+        commands: { native: true },
+        guilds: { [guildId]: { channels: { [channelId]: { enabled: true } } } },
+      },
+    },
+  };
+  setActivePluginRegistry(
+    createTestRegistry([{ pluginId: "discord", plugin: discordPlugin, source: "test" }]),
+  );
+  await upsertSessionEntry({
+    ...scope,
+    entry: {
+      sessionId,
+      lifecycleRevision: "before-reset",
+      updatedAt: Date.now(),
+      totalTokens: 100,
+    },
+  });
+  // Native commands reread the Gateway's published configuration before dispatch.
+  setRuntimeConfigSnapshot(cfg);
+  const interaction = createMockCommandInteraction({
+    channelType: ChannelType.GuildText,
+    channelId,
+    guildId,
+    userId,
+    interactionId: `${commandName}-${allowFrom.join("-")}`,
+  });
+  const command = createDiscordNativeCommand({
+    command: { name: commandName, description: "Reset the session.", acceptsArgs: true },
+    cfg,
+    discordConfig: cfg.channels!.discord!,
+    accountId: "default",
+    sessionPrefix: "discord:slash",
+    ephemeralDefault: true,
+    threadBindings: createNoopThreadBindingManager("default"),
+  });
+  await command.run(interaction as unknown as CommandInteraction);
+  return {
+    entry: getSessionEntry(scope),
+    events: loadTranscriptEventsSync({ ...scope, sessionId }),
+    replies: [...interaction.reply.mock.calls, ...interaction.followUp.mock.calls].map(
+      ([payload]) => payload.content,
+    ),
+  };
+}
+
+describe.each(["new", "reset"] as const)(
+  "Discord native /%s through the reply pipeline",
+  (name) => {
+    it.each(["", "user:", "discord:", "pk:", "<@", "<@!"])(
+      "resets the channel and acknowledges a matching %s sender entry",
+      async (prefix) => {
+        const entry = `${prefix}${userId}${prefix.startsWith("<") ? ">" : ""}`;
+        const result = await runReset(name, [entry]);
+        expect(result.entry?.sessionId).toBe(sessionId);
+        expect(result.entry?.lifecycleRevision).toBeTruthy();
+        expect(result.entry?.lifecycleRevision).not.toBe("before-reset");
+        expect(result.events).toEqual(
+          expect.arrayContaining([expect.objectContaining({ type: "reset", reason: name })]),
+        );
+        expect(result.replies).toEqual([
+          name === "new" ? "✅ New session started." : "✅ Session reset.",
+        ]);
+      },
+    );
+
+    it.each([
+      { reason: "a different user", allowFrom: ["user:100000000000000004"] },
+      { reason: "an empty allowlist", allowFrom: [] },
+    ])("preserves the session when denied by $reason", async ({ allowFrom }) => {
+      const result = await runReset(name, allowFrom);
+      expect(result.entry?.lifecycleRevision).toBe("before-reset");
+      expect(result.events).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: "reset" })]),
+      );
+    });
+  },
+);

--- a/extensions/discord/src/shared.ts
+++ b/extensions/discord/src/shared.ts
@@ -90,7 +90,10 @@ export const discordConfigAdapter = createScopedChannelConfigAdapter<
   defaultAccountId: resolveDefaultDiscordAccountId,
   clearBaseFields: ["token", "name"],
   resolveAllowFrom: (account) => account.allowFrom,
-  formatAllowFrom: (allowFrom) => formatAllowFromLowercase({ allowFrom }),
+  formatAllowFrom: (allowFrom) =>
+    formatAllowFromLowercase({ allowFrom, stripPrefixRe: /^(discord|user|pk):/i }).map((entry) =>
+      entry.replace(/^<@!?(\d+)>$/, "$1"),
+    ),
   resolveDefaultTo: (account) => account.defaultTo,
 });
 

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -11,7 +11,7 @@ import {
 } from "../channels/plugins/registry-loaded.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { ChannelId } from "../channels/plugins/types.public.js";
-import { normalizeAnyChannelId } from "../channels/registry.js";
+import { normalizeAnyChannelId, normalizeChatChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAccountEntry } from "../routing/account-lookup.js";
 import {
@@ -232,28 +232,26 @@ function resolveOwnerAllowFromList(
     return [];
   }
   const filtered: string[] = [];
-  for (const entry of raw) {
-    const trimmed = normalizeOptionalString(String(entry ?? "")) ?? "";
-    if (!trimmed) {
+  for (const trimmed of normalizeStringEntries(raw.map((entry) => entry ?? ""))) {
+    const separatorIndex = trimmed.indexOf(":");
+    const prefix = trimmed.slice(0, separatorIndex);
+    const channel = separatorIndex > 0 ? normalizeAnyChannelId(prefix) : undefined;
+    if (!channel) {
+      filtered.push(trimmed);
       continue;
     }
-    const separatorIndex = trimmed.indexOf(":");
-    if (separatorIndex > 0) {
-      const prefix = trimmed.slice(0, separatorIndex);
-      const channel = normalizeAnyChannelId(prefix);
-      if (channel) {
-        // Channel-prefixed entries require a known matching provider; webchat leaves it unset.
-        if (!params.providerId || channel !== params.providerId) {
-          continue;
-        }
-        const remainder = trimmed.slice(separatorIndex + 1).trim();
-        if (remainder) {
-          filtered.push(remainder);
-        }
-        continue;
-      }
+    // Doctor owns bundled channel:user:id migration; third-party native identities stay intact.
+    if (
+      !params.providerId ||
+      channel !== params.providerId ||
+      (normalizeChatChannelId(prefix) && /^[^:]+:user:[^:\s*]+$/i.test(trimmed))
+    ) {
+      continue;
     }
-    filtered.push(trimmed);
+    const remainder = trimmed.slice(separatorIndex + 1).trim();
+    if (remainder) {
+      filtered.push(remainder);
+    }
   }
   return formatAllowFromList({ ...params, allowFrom: filtered });
 }

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -380,6 +380,13 @@ describe("resolveCommandAuthorization", () => {
       expectedOwner: true,
     },
     {
+      name: "leaves retired channel-qualified owner migration to Doctor",
+      owner: "discord:user:123456789012345678",
+      provider: "discord",
+      expectedProvider: "discord",
+      expectedOwner: false,
+    },
+    {
       name: "does not apply channel-prefixed owner wildcards to mismatched providers",
       owner: "telegram:*",
       provider: "discord",
@@ -403,6 +410,16 @@ describe("resolveCommandAuthorization", () => {
 
     expect(auth.providerId).toBe(expectedProvider);
     expect(auth.senderIsOwner).toBe(expectedOwner);
+  });
+
+  it("preserves third-party native owner identities outside the bundled Doctor migration", () => {
+    registerAllowFromPlugins(createAllowFromPlugin("custom-chat", () => []));
+    const auth = resolveCommandAuthorization({
+      ctx: { Provider: "custom-chat", SenderId: "user:123" },
+      cfg: { commands: { ownerAllowFrom: ["custom-chat:user:123"] } },
+      commandAuthorized: true,
+    });
+    expect(auth.senderIsOwner).toBe(true);
   });
 
   it("preserves external channel command auth in mixed webchat contexts", () => {


### PR DESCRIPTION
Related: #140535

## What Problem This Solves

Fixes an issue where Discord users invoking `/new` or `/reset` receive “No reply was generated” and retain their conversation context when the command allowlist uses the documented `user:<id>` form. The same normalization gap affects existing `discord:` and `pk:` aliases and Discord mentions. This reproduces the symptom reported by @chrismanderson in #140535; the report does not include its exact allowlist configuration.

## Why This Change Was Made

Discord's native command authorizer recognizes sender prefixes, but the shared Discord config adapter only lowercased the entries. Core reset authorization therefore compared a prefixed allowlist entry with the bare sender ID and rejected an already admitted command (`extensions/discord/src/shared.ts:93`, `src/auto-reply/command-auth.ts:359`, `src/auto-reply/reply/commands-reset.ts:44`). Normalize the existing aliases and mentions in the owning adapter, using the same SDK formatter option already used by Telegram. Preserve the existing Doctor-only migration of retired bundled-channel owner entries in the canonical core owner parser, without changing third-party native identities.

The reset target is already carried correctly, so changing slash-session routing or adding a retry/fallback would not repair this failure. #137313 is not the introduction: its merge commit is not an ancestor of the 2026.9.2 release commit. The adjacent group-system-prompt helper now returns its single trimmed value directly instead of constructing, filtering, and joining a one-element array.

## User Impact

Authorized Discord reset commands clear the routed channel context and return their normal acknowledgement. Durable session IDs remain stable; the lifecycle revision and reset event prove the context reset. Explicit denial still prevents reset. Retired global-owner entries still require `openclaw doctor --fix`, and native third-party owner identities remain supported. The command documentation now names the supported user-ID aliases.

## Evidence

Head: 5f4815fe901108ca489c1826c60019b0320672a0

- Baseline synthetic native interaction: bare sender ID passes; `user:`, `discord:`, and `pk:` each return the generic fallback with the original lifecycle revision unchanged.
- Fixed regression executes the real Discord native handler, channel dispatch, shared authorization/reset owner, SQLite session store, and reply pipeline. Only the interaction transport is synthetic. It checks both `/new` and `/reset`, durable reset events, normal acknowledgements, a mismatched sender, and an empty allowlist.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/command-control.test.ts extensions/discord/src/monitor/native-command.reset.test.ts extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts extensions/discord/src/monitor/inbound-context.test.ts extensions/discord/src/shared.test.ts`: 112 passed across five files (52 core authorization tests and 60 Discord tests).
- `pnpm check:changed`: passed.
- `git diff --check`: clean.
- Independent Codex review at P0–P2: scoped-clean; no accepted/actionable findings.
- Production: +23/-25, net -2. Tests: +145/-0. Docs: +2/-1.
- CI: [run 34075676397](https://github.com/openclaw/openclaw/actions/runs/34075676397) passed on the exact head. ClawSweeper reviewed the same head with no actionable findings or security concerns.

No live Discord or full mock Gateway socket proof is claimed. There is no existing Discord native reset socket harness; this covers the handler-to-durable-reset boundary with isolated state. Guild-wide command authorization and generic denial-message wording are separate observed gaps and are not fixed here. No new configuration options, schema, SDK, protocol, dependency, or changelog changes.

Thanks to @chrismanderson for the report.
