### PR TITLE
refactor(tui): test the displayed session filter

### DIFF
--- a/src/tui/components/filterable-select-list.test.ts
+++ b/src/tui/components/filterable-select-list.test.ts
@@ -1,6 +1,7 @@
 // Filterable select list tests cover keyboard filtering and cursor behavior.
 import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
+import { stripAnsi } from "../../../packages/terminal-core/src/ansi.js";
 import { FilterableSelectList, type FilterableSelectItem } from "./filterable-select-list.js";
 
 type FilterableSelectListTheme = ConstructorParameters<typeof FilterableSelectList>[2];
@@ -92,7 +93,7 @@ describe("FilterableSelectList", () => {
 
     list.handleInput(query);
 
-    expect(list.getFilterText()).toBe(query);
+    expect(stripAnsi(list.render(80)[0] ?? "").trimEnd()).toBe(`>Filter: <> ${query}`);
     expect(list.getSelectedItem()?.value).toBe(expectedValue);
   });
 
@@ -125,13 +126,13 @@ describe("FilterableSelectList", () => {
     };
 
     typeInput(list, "beta");
-    expect(list.getFilterText()).toBe("beta");
+    expect(stripAnsi(list.render(80)[0] ?? "").trimEnd()).toBe(">Filter: <> beta");
     expect(list.getSelectedItem()?.value).toBe("session-2");
 
     list.handleInput(key);
 
     expect(cancelled).toBe(false);
-    expect(list.getFilterText()).toBe("");
+    expect(stripAnsi(list.render(80)[0] ?? "").trimEnd()).toBe(">Filter: <>");
     expect(list.getSelectedItem()?.value).toBe("session-1");
     expect(list.render(80).join("\n")).toContain("first session");
     expect(list.render(80).join("\n")).toContain("second session");

--- a/src/tui/components/filterable-select-list.ts
+++ b/src/tui/components/filterable-select-list.ts
@@ -144,8 +144,4 @@ export class FilterableSelectList implements Component, Focusable {
   getSelectedItem(): SelectItem | null {
     return this.selectList.getSelectedItem();
   }
-
-  getFilterText(): string {
-    return this.input.getValue();
-  }
 }


### PR DESCRIPTION
## What Problem This Solves

Session-picker regression tests read the filter through an otherwise unused getter, keeping a test-only observation method in the component.

## Why This Change Was Made

Assert the exact displayed filter row through the existing render boundary and remove `getFilterText()`. The three migrated assertions still check typed text and clearing; selected-value assertions remain separate because displayed labels cannot recover opaque values. All tests remain. Production decreases by four lines; tests change by +4/-3.

## User Impact

No intended user-visible behavior change. Keyboard filtering, clear-before-cancel behavior, navigation, cursor markers and Unicode rendering are unchanged.

## Evidence

- Baseline and candidate picker component suites: **72/72** each, identical case inventories. All four cancellation encodings, selection, cursor, Unicode/column-width and terminal-sanitization coverage remain.
- Independent applied review: no findings through P2; pinned Pi TUI input rendering and package export boundaries inspected.
- All **29 required changed-file checks passed** on [Testbox](https://github.com/openclaw/openclaw/actions/runs/34074319075); the one-shot command returned 0 and its lease/source capsule were cleaned up.
- Additional existing PTY suite: candidate **5/8**, unchanged baseline **4/8**. Failures on both sources time out waiting for the fixture's `local ready`, before any picker command/key is sent. The baseline includes model-picker failures that do not construct this component. This does **not** claim a passing end-to-end run or a diagnosed startup cause. The separate follow-up is TUI PTY pre-readiness diagnostics, including retaining the existing fixture action log before cleanup; no timeout, retry or assertion changes are included here.

The PTY fixture uses the real TUI with a fake backend; no Gateway, provider or persistence-transport proof is claimed.
