### PR TITLE
refactor(diagnostics): share stage timing recording and formatting

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -186,6 +186,20 @@ return {
 Use `openclaw/plugin-sdk/pair-loop-guard-runtime` directly only for custom
 two-party event loops that do not go through the shared inbound reply runner.
 
+### Stage timing diagnostics
+
+`openclaw/plugin-sdk/time-runtime` exports `createStageTimingTracker(now?)` and
+`formatStageTimings(stages)`. The tracker records rounded, nonnegative
+`durationMs` and `elapsedMs` values. `mark(name)` measures since the previous
+mark; `measure(name, run)` and `measureSync(name, run)` record explicit spans,
+including failed work, and preserve the callback's result or error. Measured
+spans do not advance the checkpoint used by `mark`.
+
+`snapshot()` returns `{ totalMs, stages }` with a copied stage array. The optional
+clock defaults to `Date.now`. Formatting produces comma-separated
+`name:durationMs@elapsedMs` entries (with `ms` units) or `none`. Callers retain
+ownership of log labels, warning thresholds, and when to emit a summary.
+
 ## Plugin command runtime helpers
 
 Plugin command handlers receive request-bound capabilities through

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -25,6 +25,11 @@ import {
 } from "openclaw/plugin-sdk/codex-mcp-projection";
 import { isToolAllowed } from "openclaw/plugin-sdk/sandbox";
 import {
+  createStageTimingTracker,
+  formatStageTimings,
+  type StageTimingSummary,
+} from "openclaw/plugin-sdk/time-runtime";
+import {
   isCodexRemoteExecPlacementSandbox,
   readCodexPluginConfig,
   type CodexPluginConfig,
@@ -190,15 +195,7 @@ export function resolveCodexAppServerHookChannelId(
     messageTo: params.messageTo,
   }).channelId;
 }
-type CodexDynamicToolBuildStageTiming = {
-  name: string;
-  durationMs: number;
-  elapsedMs: number;
-};
-type CodexDynamicToolBuildStageSummary = {
-  totalMs: number;
-  stages: CodexDynamicToolBuildStageTiming[];
-};
+type CodexDynamicToolBuildStageSummary = StageTimingSummary;
 const CODEX_DYNAMIC_TOOL_BUILD_WARN_TOTAL_MS = 1_000;
 const CODEX_DYNAMIC_TOOL_BUILD_WARN_STAGE_MS = 500;
 /** Captures bounded preparation stages before a slow turn needs diagnosis. */
@@ -206,27 +203,8 @@ export function createCodexDynamicToolBuildStageTracker(): {
   mark: (name: string) => void;
   snapshot: () => CodexDynamicToolBuildStageSummary;
 } {
-  const startedAt = Date.now();
-  let previousAt = startedAt;
-  const stages: CodexDynamicToolBuildStageTiming[] = [];
-  const toMs = (value: number) => Math.max(0, Math.round(value));
-  return {
-    mark(name) {
-      const currentAt = Date.now();
-      stages.push({
-        name,
-        durationMs: toMs(currentAt - previousAt),
-        elapsedMs: toMs(currentAt - startedAt),
-      });
-      previousAt = currentAt;
-    },
-    snapshot() {
-      return {
-        totalMs: toMs(Date.now() - startedAt),
-        stages: stages.slice(),
-      };
-    },
-  };
+  const { mark, snapshot } = createStageTimingTracker();
+  return { mark, snapshot };
 }
 /** Returns true when dynamic-tool construction is slow enough to warrant a warning log. */
 export function shouldWarnCodexDynamicToolBuildStageSummary(
@@ -244,11 +222,7 @@ export function shouldWarnCodexDynamicToolBuildStageSummary(
 export function formatCodexDynamicToolBuildStageSummary(
   summary: CodexDynamicToolBuildStageSummary,
 ): string {
-  return summary.stages.length > 0
-    ? summary.stages
-        .map((stage) => `${stage.name}:${stage.durationMs}ms@${stage.elapsedMs}ms`)
-        .join(",")
-    : "none";
+  return formatStageTimings(summary.stages);
 }
 /** Builds, filters, and normalizes Codex-compatible runtime tools for a single turn. */
 export async function buildDynamicTools(

--- a/extensions/codex/src/app-server/thread-lifecycle-timing.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-timing.ts
@@ -1,14 +1,13 @@
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
-
-type CodexThreadLifecycleTimingSpan = {
-  name: string;
-  durationMs: number;
-  elapsedMs: number;
-};
+import {
+  createStageTimingTracker,
+  formatStageTimings,
+  type StageTiming,
+} from "openclaw/plugin-sdk/time-runtime";
 
 type CodexThreadLifecycleTimingSummary = {
   totalMs: number;
-  spans: CodexThreadLifecycleTimingSpan[];
+  spans: StageTiming[];
 };
 
 type CodexThreadLifecycleTimingLogger = {
@@ -65,12 +64,7 @@ function formatCodexThreadLifecycleTimingSummary(params: {
   action: CodexThreadLifecycleTimingAction;
   summary: CodexThreadLifecycleTimingSummary;
 }): string {
-  const spans =
-    params.summary.spans.length > 0
-      ? params.summary.spans
-          .map((span) => `${span.name}:${span.durationMs}ms@${span.elapsedMs}ms`)
-          .join(",")
-      : "none";
+  const spans = formatStageTimings(params.summary.spans);
   return (
     `[trace:codex-app-server] thread lifecycle: runId=${params.runId} ` +
     `sessionId=${params.sessionId} sessionKey=${params.sessionKey ?? "unknown"} ` +
@@ -83,48 +77,21 @@ export function createCodexThreadLifecycleTimingTracker(
 ): CodexThreadLifecycleTimingTracker {
   const log = options.log ?? embeddedAgentLog;
 
-  const now = options.now ?? Date.now;
-  const startedAt = now();
+  const timing = createStageTimingTracker(options.now ?? Date.now);
   let didLog = false;
-  const spans: CodexThreadLifecycleTimingSpan[] = [];
-  const toMs = (value: number) => Math.max(0, Math.round(value));
-  const record = (name: string, spanStartedAt: number) => {
-    const currentAt = now();
-    spans.push({
-      name,
-      durationMs: toMs(currentAt - spanStartedAt),
-      elapsedMs: toMs(currentAt - startedAt),
-    });
-  };
-  const snapshot = (): CodexThreadLifecycleTimingSummary => ({
-    totalMs: toMs(now() - startedAt),
-    spans: spans.slice(),
-  });
   return {
-    async measure(name, run) {
-      const spanStartedAt = now();
-      try {
-        return await run();
-      } finally {
-        record(name, spanStartedAt);
-      }
-    },
-    measureSync(name, run) {
-      const spanStartedAt = now();
-      try {
-        return run();
-      } finally {
-        record(name, spanStartedAt);
-      }
-    },
+    measure: timing.measure,
+    measureSync: timing.measureSync,
     mark(name) {
-      record(name, now());
+      // Lifecycle marks are instantaneous spans, not time since the previous mark.
+      timing.measureSync(name, () => undefined);
     },
     logSummary(params) {
       if (didLog) {
         return;
       }
-      const summary = snapshot();
+      const { totalMs, stages: spans } = timing.snapshot();
+      const summary = { totalMs, spans };
       const shouldWarn = shouldWarnCodexThreadLifecycleTimingSummary(summary, { ...options, log });
       if (!shouldWarn && !log.isEnabled?.("trace")) {
         return;

--- a/src/agents/embedded-agent-runner/run/attempt-stage-timing.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stage-timing.ts
@@ -1,15 +1,10 @@
-/** Timing for one named stage, including both stage duration and run-relative elapsed time. */
-type EmbeddedRunStageTiming = {
-  name: string;
-  durationMs: number;
-  elapsedMs: number;
-};
+import {
+  createStageTimingTracker,
+  formatStageTimings,
+  type StageTimingSummary,
+} from "../../../shared/stage-timing.js";
 
-/** Snapshot of all marked stages plus total elapsed time at snapshot creation. */
-type EmbeddedRunStageSummary = {
-  totalMs: number;
-  stages: EmbeddedRunStageTiming[];
-};
+type EmbeddedRunStageSummary = StageTimingSummary;
 
 /** Lightweight monotonic-ish stage tracker used for embedded run startup diagnostics. */
 type EmbeddedRunStageTracker = {
@@ -36,30 +31,8 @@ const EMBEDDED_RUN_STAGE_WARN_STAGE_MS = 5_000;
 export function createEmbeddedRunStageTracker(options?: {
   now?: () => number;
 }): EmbeddedRunStageTracker {
-  const now = options?.now ?? Date.now;
-  const startedAt = now();
-  let previousAt = startedAt;
-  const stages: EmbeddedRunStageTiming[] = [];
-
-  const toMs = (value: number) => Math.max(0, Math.round(value));
-
-  return {
-    mark(name) {
-      const currentAt = now();
-      stages.push({
-        name,
-        durationMs: toMs(currentAt - previousAt),
-        elapsedMs: toMs(currentAt - startedAt),
-      });
-      previousAt = currentAt;
-    },
-    snapshot() {
-      return {
-        totalMs: toMs(now() - startedAt),
-        stages: stages.slice(),
-      };
-    },
-  };
+  const { mark, snapshot } = createStageTimingTracker(options?.now ?? Date.now);
+  return { mark, snapshot };
 }
 
 /** Returns true when either total runtime or any single stage exceeds warning thresholds. */
@@ -117,11 +90,6 @@ export function formatEmbeddedRunStageSummary(
   prefix: string,
   summary: EmbeddedRunStageSummary,
 ): string {
-  const stages =
-    summary.stages.length > 0
-      ? summary.stages
-          .map((stage) => `${stage.name}:${stage.durationMs}ms@${stage.elapsedMs}ms`)
-          .join(",")
-      : "none";
+  const stages = formatStageTimings(summary.stages);
   return `${prefix} totalMs=${summary.totalMs} stages=${stages}`;
 }

--- a/src/auto-reply/reply/reply-timing-tracker.ts
+++ b/src/auto-reply/reply/reply-timing-tracker.ts
@@ -1,10 +1,15 @@
 /** Lightweight reply-stage profiler for slow-turn diagnostics. */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isDiagnosticFlagEnabled } from "../../infra/diagnostic-flags.js";
+import {
+  createStageTimingTracker,
+  formatStageTimings,
+  type StageTiming,
+} from "../../shared/stage-timing.js";
 
 type ReplyTimingSummary = {
   totalMs: number;
-  spans: Array<{ name: string; durationMs: number; elapsedMs: number }>;
+  spans: StageTiming[];
 };
 
 type ReplyTimingLogParams = {
@@ -51,43 +56,19 @@ export function createReplyTimingTracker<TLogParams extends object = ReplyTiming
 }): ReplyTimingTracker<TLogParams> {
   const profilerEnabled =
     params.enabled ?? isReplyProfilerEnabled({ config: params.config, env: params.env });
-  const startedAt = Date.now();
-  const spans: ReplyTimingSummary["spans"] = [];
+  const timing = createStageTimingTracker();
   let didLog = false;
   const totalWarnMs = params.totalWarnMs ?? (profilerEnabled ? 1_000 : 10_000);
   const stageWarnMs = params.stageWarnMs ?? (profilerEnabled ? 500 : 5_000);
-  const toMs = (value: number) => Math.max(0, Math.round(value));
-  const record = (name: string, spanStartedAt: number) => {
-    const currentAt = Date.now();
-    spans.push({
-      name,
-      durationMs: toMs(currentAt - spanStartedAt),
-      elapsedMs: toMs(currentAt - startedAt),
-    });
-  };
-
   return {
-    async measure(name, run) {
-      const spanStartedAt = Date.now();
-      try {
-        return await run();
-      } finally {
-        record(name, spanStartedAt);
-      }
-    },
-    measureSync(name, run) {
-      const spanStartedAt = Date.now();
-      try {
-        return run();
-      } finally {
-        record(name, spanStartedAt);
-      }
-    },
+    measure: timing.measure,
+    measureSync: timing.measureSync,
     logIfSlow(logParams, options) {
       if (didLog && !options?.repeat) {
         return;
       }
-      const summary = { totalMs: toMs(Date.now() - startedAt), spans: spans.slice() };
+      const { totalMs, stages: spans } = timing.snapshot();
+      const summary = { totalMs, spans };
       if (
         summary.totalMs < totalWarnMs &&
         !summary.spans.some((span) => span.durationMs >= stageWarnMs)
@@ -97,12 +78,7 @@ export function createReplyTimingTracker<TLogParams extends object = ReplyTiming
       if (!options?.repeat) {
         didLog = true;
       }
-      const formattedSpans =
-        summary.spans.length > 0
-          ? summary.spans
-              .map((span) => `${span.name}:${span.durationMs}ms@${span.elapsedMs}ms`)
-              .join(",")
-          : "none";
+      const formattedSpans = formatStageTimings(summary.spans);
       if (params.formatMessage) {
         const detailParams = logParams as Record<string, unknown>;
         const details = Object.fromEntries(

--- a/src/plugin-sdk/time-runtime.ts
+++ b/src/plugin-sdk/time-runtime.ts
@@ -8,3 +8,9 @@ export {
 } from "../infra/format-time/format-datetime.js";
 export { formatDurationCompact } from "../infra/format-time/format-duration.js";
 export { withTimeout } from "../infra/fs-safe.js";
+export {
+  createStageTimingTracker,
+  formatStageTimings,
+  type StageTiming,
+  type StageTimingSummary,
+} from "../shared/stage-timing.js";

--- a/src/shared/stage-timing.ts
+++ b/src/shared/stage-timing.ts
@@ -1,0 +1,51 @@
+/** One recorded duration and its elapsed time relative to tracker creation. */
+export type StageTiming = { name: string; durationMs: number; elapsedMs: number };
+export type StageTimingSummary = { totalMs: number; stages: StageTiming[] };
+
+/** Records checkpoints and explicit spans without owning logging policy. */
+export function createStageTimingTracker(now: () => number = () => Date.now()) {
+  const startedAt = now();
+  let previousAt = startedAt;
+  const stages: StageTiming[] = [];
+  const toMs = (value: number) => Math.max(0, Math.round(value));
+  const record = (name: string, spanStartedAt: number) => {
+    const currentAt = now();
+    stages.push({
+      name,
+      durationMs: toMs(currentAt - spanStartedAt),
+      elapsedMs: toMs(currentAt - startedAt),
+    });
+    return currentAt;
+  };
+  return {
+    mark(name: string) {
+      previousAt = record(name, previousAt);
+    },
+    async measure<T>(name: string, run: () => Promise<T> | T): Promise<T> {
+      const spanStartedAt = now();
+      try {
+        return await run();
+      } finally {
+        record(name, spanStartedAt);
+      }
+    },
+    measureSync<T>(name: string, run: () => T): T {
+      const spanStartedAt = now();
+      try {
+        return run();
+      } finally {
+        record(name, spanStartedAt);
+      }
+    },
+    snapshot(): StageTimingSummary {
+      return { totalMs: toMs(now() - startedAt), stages: stages.slice() };
+    },
+  };
+}
+
+/** Formats timing entries without choosing the caller's prefix or field label. */
+export function formatStageTimings(stages: readonly StageTiming[]): string {
+  return stages.length > 0
+    ? stages.map((stage) => `${stage.name}:${stage.durationMs}ms@${stage.elapsedMs}ms`).join(",")
+    : "none";
+}

--- a/src/shared/stage-timing.ts
+++ b/src/shared/stage-timing.ts
@@ -18,10 +18,10 @@ export function createStageTimingTracker(now: () => number = () => Date.now()) {
     return currentAt;
   };
   return {
-    mark(name: string) {
+    mark: (name: string) => {
       previousAt = record(name, previousAt);
     },
-    async measure<T>(name: string, run: () => Promise<T> | T): Promise<T> {
+    measure: async <T>(name: string, run: () => Promise<T> | T): Promise<T> => {
       const spanStartedAt = now();
       try {
         return await run();
@@ -29,7 +29,7 @@ export function createStageTimingTracker(now: () => number = () => Date.now()) {
         record(name, spanStartedAt);
       }
     },
-    measureSync<T>(name: string, run: () => T): T {
+    measureSync: <T>(name: string, run: () => T): T => {
       const spanStartedAt = now();
       try {
         return run();
@@ -37,7 +37,7 @@ export function createStageTimingTracker(now: () => number = () => Date.now()) {
         record(name, spanStartedAt);
       }
     },
-    snapshot(): StageTimingSummary {
+    snapshot: (): StageTimingSummary => {
       return { totalMs: toMs(now() - startedAt), stages: stages.slice() };
     },
   };


### PR DESCRIPTION
## What Problem This Solves

Embedded startup, Codex tool construction, Codex thread lifecycle, and reply diagnostics separately implemented duration recording and summary formatting. This maintainer-requested consolidation reduces drift in slow-turn diagnostics while preserving each caller's reporting policy.

## Why This Change Was Made

`src/shared/stage-timing.ts` now owns rounded/clamped durations, copied snapshots, explicit sync/async measurements, and compact entry formatting. Existing wrappers retain labels, warning thresholds, trace behavior, repeatable milestones and terminal logging latches. Lifecycle marks remain instantaneous spans; checkpoint-based callers still measure from the previous mark.

The lightweight helper is available through the existing `time-runtime` SDK entrypoint and documented with its clock and snapshot contracts. Existing exports remain available. No Codex protocol or lifecycle authority changes are involved.

## User Impact

No intended behavior change. Logs retain their existing text, structured fields, thresholds, and error propagation. Production code decreases by 58 lines; existing tests are retained unchanged.

## Evidence

`node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-stage-timing.test.ts src/agents/embedded-agent-runner/run/preparation-timing.test.ts src/auto-reply/reply/reply-timing-tracker.test.ts extensions/codex/src/app-server/attempt-preparation-timing.test.ts extensions/codex/src/app-server/dynamic-tool-build.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts`: 6 files / 349 tests passed. Independent Codex review found no actionable P0–P2 issues. Changed-file validation passed all four typecheck stages, SDK surface/export checks, doctor contracts, unused-export scans (zero entries), and core lint. Extension lint hit the documented nested-worktree `Declaration input escapes checkout` error from the ancestor install's `punycode`; it must run on the clean Testbox/CI checkout. No ancestor install or boundary guard was modified. `pnpm build` passed, including all package/runtime/SDK declarations, 90 local plugin distributions, built-module checks, and Control UI build (25m 55.4s).

The first CI lint run found four unbound-method warnings in delegated callbacks. The tracker now returns lexical arrow functions; a fresh independent review is clean. Corrected head `0f60a11b3e70fd09d1638f86b989c07531ed0b8f` has green [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34077293165).
