### PR TITLE
fix(gateway): preserve WebSocket close causes in file logs

### DIFF
--- a/docs/gateway/diagnostics.md
+++ b/docs/gateway/diagnostics.md
@@ -96,6 +96,15 @@ hostnames, and local usernames.
 When a log message looks like user, chat, prompt, or tool payload text, the
 export keeps only that a message was omitted plus its byte count.
 
+## WebSocket disconnect logs
+
+Connected webchat and authenticated-user disconnects include `durationMs`
+(connection lifetime in milliseconds) in default info-level file logs. The
+`cause` field contains the Gateway's recorded close cause, when known; otherwise
+it is omitted. `heartbeat-timeout` records the Gateway's missed-pong decision.
+It does not prove that a ping reached the remote peer or that the peer caused
+the transport failure.
+
 ## Stability recorder
 
 The Gateway records a bounded, payload-free stability stream by default when

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -824,8 +824,14 @@ describe("attachGatewayWsConnectionHandler", () => {
     expect(logWsControl.warn).not.toHaveBeenCalled();
   });
 
-  it("logs the authenticated user when a connection closes", async () => {
-    const { socket, logWsControl, passed } = await connectTestWs();
+  it.each([
+    { reason: "normal peer close", durationMs: 1_000, cause: undefined, code: 1000 },
+    { reason: "missed protocol pong", durationMs: 50_000, cause: "heartbeat-timeout", code: 1006 },
+  ])("records connected close ownership after $reason", async ({ durationMs, cause, code }) => {
+    vi.useFakeTimers();
+    const socket = createGatewayWsTestSocket({ ping: true });
+    socket.terminate.mockImplementation(() => socket.emit("close", 1006, Buffer.alloc(0)));
+    const { logWsControl, passed } = await connectTestWs({ socket });
     const handlerParams = passed as {
       setClient: (client: never) => boolean;
     };
@@ -833,19 +839,29 @@ describe("attachGatewayWsConnectionHandler", () => {
     expect(
       handlerParams.setClient({
         socket,
-        connect: { client: { id: "openclaw-control-ui", mode: "ui" } },
+        connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
         connId: "conn-authenticated-user",
         authenticatedUserId: "alice@example.com",
         usesSharedGatewayAuth: false,
       } as never),
     ).toBe(true);
 
-    socket.emit("close", 1000, Buffer.from("done"));
-
+    vi.advanceTimersByTime(durationMs);
+    if (!cause) {
+      socket.emit("close", code, Buffer.from("done"));
+    }
+    const closeReason = cause ? "n/a" : "done";
+    expect(logWsControl.info).toHaveBeenCalledWith(
+      expect.stringContaining(`webchat disconnected code=${code} reason=${closeReason} conn=`),
+      { cause, durationMs },
+    );
     expect(logWsControl.info).toHaveBeenCalledWith(
       expect.stringMatching(
-        /^authenticated user disconnected code=1000 reason=done conn=.+ user=alice@example\.com$/,
+        new RegExp(
+          `^authenticated user disconnected code=${code} reason=${closeReason} conn=.+ user=alice@example\\.com$`,
+        ),
       ),
+      { cause, durationMs },
     );
   });
 

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -463,11 +463,13 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       if (client && isWebchatClient(client.connect.client)) {
         logWsControl.info(
           `webchat disconnected code=${code} reason=${logReason || "n/a"} conn=${connId}`,
+          { cause: closeCause, durationMs },
         );
       }
       if (client?.authenticatedUserId) {
         logWsControl.info(
           `authenticated user disconnected code=${code} reason=${logReason || "n/a"} conn=${connId} user=${formatForLog(client.authenticatedUserId)}`,
+          { cause: closeCause, durationMs },
         );
       }
       if (connectionKind === "gateway") {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators investigating WebSocket disconnects could see a close code but lose the Gateway's recorded cause at the default log level.

## Why This Change Was Made

Preserve the existing `cause` and `durationMs` on the two connected-client info-level file records. Unknown causes remain omitted. Keepalive, authentication and transport behavior stay unchanged.

## User Impact

Operators can distinguish a recorded missed-pong decision from a close with no known Gateway cause. The diagnostics guide explains that `heartbeat-timeout` does not prove ping delivery or remote-peer fault.

## Evidence

The baseline failed the two extended regression cases and a temporary native WebSocket/file-log case. The candidate passed all 30 checks, including normal close with omitted cause and missed pong with `heartbeat-timeout` after the unchanged 25-second ping/50-second termination sequence. Native sockets, listener and temporary files were cleaned up. The native proof uses fixture registration; it does not attribute a browser or proxy failure.

Independent P2 review found no actionable issues. The full local changed gate passed; exact-head CI follows publication. An earlier Crabbox sync attempt returned no test evidence; the qualified proof ran locally on Node 24.20.0/macOS.
