### PR TITLE
refactor(ai): normalize array item policy in one traversal

### DIFF
--- a/packages/ai/src/providers/agent-tools-parameter-schema.ts
+++ b/packages/ai/src/providers/agent-tools-parameter-schema.ts
@@ -246,166 +246,76 @@ function isTrulyEmptySchema(schemaRecord: Record<string, unknown>): boolean {
   return Object.keys(schemaRecord).length === 0;
 }
 
-function normalizeArraySchemasMissingItems(schema: unknown): unknown {
-  if (!isSchemaRecord(schema)) {
-    return schema;
-  }
+type ArrayItemsMode = "add" | "omit" | "normalize";
 
-  let changed = false;
-  const nextSchema: Record<string, unknown> = { ...schema };
-  if (nextSchema.type === "array" && nextSchema.items === undefined) {
-    nextSchema.items = {};
-    changed = true;
-  }
-
-  const normalizeSchemaValue = (key: string): void => {
-    if (!(key in nextSchema)) {
-      return;
-    }
-    const value = nextSchema[key];
-    if (Array.isArray(value)) {
-      const normalized = value.map(normalizeArraySchemasMissingItems);
-      if (normalized.some((entry, index) => entry !== value[index])) {
-        nextSchema[key] = normalized;
-        changed = true;
-      }
-      return;
-    }
-
-    const normalized = normalizeArraySchemasMissingItems(value);
-    if (normalized !== value) {
-      nextSchema[key] = normalized;
-      changed = true;
-    }
-  };
-
-  for (const key of [
-    "items",
-    "contains",
-    "additionalProperties",
-    "propertyNames",
-    "not",
-    "if",
-    "then",
-    "else",
-  ]) {
-    normalizeSchemaValue(key);
-  }
-
-  for (const key of ["anyOf", "oneOf", "allOf", "prefixItems"]) {
-    normalizeSchemaValue(key);
-  }
-
-  for (const key of [
-    "properties",
-    "patternProperties",
-    "dependentSchemas",
-    "$defs",
-    "definitions",
-  ]) {
-    const value = nextSchema[key];
-    if (!isSchemaRecord(value)) {
-      continue;
-    }
-    let entriesChanged = false;
-    const normalizedEntries: Array<[string, unknown]> = Object.entries(value).map(
-      ([entryKey, entryValue]) => {
-        const normalizedEntryValue = normalizeArraySchemasMissingItems(entryValue);
-        if (normalizedEntryValue !== entryValue) {
-          entriesChanged = true;
-        }
-        return [entryKey, normalizedEntryValue];
-      },
-    );
-    if (entriesChanged) {
-      nextSchema[key] = Object.fromEntries(normalizedEntries);
-      changed = true;
-    }
-  }
-
-  return changed ? nextSchema : schema;
-}
-
-function schemaAllowsArrayType(schema: Record<string, unknown>): boolean {
-  const type = schema.type;
-  return type === "array" || (Array.isArray(type) && type.includes("array"));
-}
-
-const ARRAY_ITEMS_SCHEMA_OBJECT_KEYS = new Set([
-  "additionalProperties",
-  "contains",
-  "else",
-  "if",
-  "items",
-  "not",
-  "propertyNames",
-  "then",
-]);
-
-const ARRAY_ITEMS_SCHEMA_ARRAY_KEYS = new Set(["allOf", "anyOf", "oneOf", "prefixItems"]);
-
-const ARRAY_ITEMS_SCHEMA_MAP_KEYS = new Set([
-  "$defs",
-  "definitions",
-  "dependentSchemas",
-  "patternProperties",
-  "properties",
-]);
-
-function stripEmptyArrayItemsFromArraySchemas(schema: unknown): unknown {
+function normalizeArraySchemaItems(schema: unknown, mode: ArrayItemsMode): unknown {
   if (Array.isArray(schema)) {
-    let changed = false;
-    const entries = schema.map((entry) => {
-      const next = stripEmptyArrayItemsFromArraySchemas(entry);
-      changed ||= next !== entry;
-      return next;
-    });
-    return changed ? entries : schema;
+    // Only omission descends through a malformed array used as a schema node.
+    // Addition visits direct tuple/composition entries through normalizeValue below.
+    if (mode === "add") {
+      return schema;
+    }
+    const entries = schema.map((entry) => normalizeArraySchemaItems(entry, "omit"));
+    return entries.some((entry, index) => entry !== schema[index]) ? entries : schema;
   }
   if (!isSchemaRecord(schema)) {
     return schema;
   }
 
-  let changed = false;
-  const entries = Object.entries(schema).flatMap(([key, value]) => {
+  const missingItems = mode !== "omit" && schema.type === "array" && schema.items === undefined;
+  let changed = missingItems;
+  const normalized: Record<string, unknown> = { ...schema };
+  if (missingItems) {
+    if (mode === "add") {
+      normalized.items = {};
+    } else {
+      // The former add-then-omit flow also removed an explicitly undefined items key.
+      delete normalized.items;
+    }
+  }
+  const allowsArray =
+    schema.type === "array" || (Array.isArray(schema.type) && schema.type.includes("array"));
+  const normalizeValue = (value: unknown, valueMode: ArrayItemsMode): unknown => {
+    if (!Array.isArray(value)) {
+      return normalizeArraySchemaItems(value, valueMode);
+    }
+    const entries = value.map((entry) => normalizeArraySchemaItems(entry, valueMode));
+    return entries.some((entry, index) => entry !== value[index]) ? entries : value;
+  };
+  for (const [key, value] of Object.entries(normalized)) {
     if (
+      mode !== "add" &&
       key === "items" &&
-      schemaAllowsArrayType(schema) &&
+      allowsArray &&
       isSchemaRecord(value) &&
       isTrulyEmptySchema(value)
     ) {
+      delete normalized.items;
       changed = true;
-      return [];
+      continue;
     }
-
-    if (ARRAY_ITEMS_SCHEMA_OBJECT_KEYS.has(key)) {
-      const next = stripEmptyArrayItemsFromArraySchemas(value);
-      changed ||= next !== value;
-      return [[key, next] as const];
-    }
-
-    if (ARRAY_ITEMS_SCHEMA_ARRAY_KEYS.has(key) && Array.isArray(value)) {
-      const next = stripEmptyArrayItemsFromArraySchemas(value);
-      changed ||= next !== value;
-      return [[key, next] as const];
-    }
-
-    if (ARRAY_ITEMS_SCHEMA_MAP_KEYS.has(key) && isSchemaRecord(value)) {
-      let mapChanged = false;
-      const next = Object.fromEntries(
-        Object.entries(value).map(([entryKey, entryValue]) => {
-          const entryNext = stripEmptyArrayItemsFromArraySchemas(entryValue);
-          mapChanged ||= entryNext !== entryValue;
-          return [entryKey, entryNext] as const;
-        }),
+    let next = value;
+    if (SCHEMA_MAP_KEYS.has(key) && isSchemaRecord(value)) {
+      const entries = Object.entries(value).map(
+        ([entryKey, entry]) => [entryKey, normalizeArraySchemaItems(entry, mode)] as const,
       );
-      changed ||= mapChanged;
-      return [[key, mapChanged ? next : value] as const];
+      if (entries.some(([entryKey, entry]) => entry !== value[entryKey])) {
+        next = Object.fromEntries(entries);
+      }
+    } else if (SCHEMA_OBJECT_KEYS.has(key) || SCHEMA_ARRAY_KEYS.has(key)) {
+      // Addition historically accepts a schema object in a composition slot;
+      // omission only traverses composition arrays. Keep that malformed-input boundary.
+      const valueMode = SCHEMA_OBJECT_KEYS.has(key) || Array.isArray(value) ? mode : "add";
+      if (valueMode === mode || mode !== "omit") {
+        next = normalizeValue(value, valueMode);
+      }
     }
-
-    return [[key, value] as const];
-  });
-  return changed ? Object.fromEntries(entries) : schema;
+    if (next !== value) {
+      setOwnSchemaProperty(normalized, key, next);
+      changed = true;
+    }
+  }
+  return changed ? normalized : schema;
 }
 
 type SchemaDefs = {
@@ -835,10 +745,10 @@ function normalizeToolParameterSchemaUncached(
   const isLlamacppGbnfProfile = normalizedToolSchemaProfile === "llamacpp";
 
   function applyProviderCleaning(s: unknown): TSchema {
-    const normalizedSchema = normalizeArraySchemasMissingItems(s);
-    let arrayItemsCompatibleSchema = omitEmptyArrayItems
-      ? stripEmptyArrayItemsFromArraySchemas(normalizedSchema)
-      : normalizedSchema;
+    let arrayItemsCompatibleSchema = normalizeArraySchemaItems(
+      s,
+      omitEmptyArrayItems ? "normalize" : "add",
+    );
     if (isLlamacppGbnfProfile) {
       arrayItemsCompatibleSchema = cleanSchemaForLlamacppGbnf(arrayItemsCompatibleSchema);
     }

--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -1369,6 +1369,9 @@ describe("normalizeToolParameters", () => {
         properties: Object.fromEntries([
           ["__proto__", { type: "array", items: {} }],
           ["emptyItems", { type: "array" }],
+          ["undefinedItems", { type: "array", items: undefined }],
+          ["unionItems", { type: ["array", "null"], items: {} }],
+          ["unionUndefinedItems", { type: ["array", "null"], items: undefined }],
           ["typedItems", { type: "array", items: { type: "string" } }],
           ["falseItems", { type: "array", items: false }],
           ["nullItems", { type: "array", items: null }],
@@ -1388,6 +1391,9 @@ describe("normalizeToolParameters", () => {
       properties: Object.fromEntries([
         ["__proto__", { type: "array" }],
         ["emptyItems", { type: "array" }],
+        ["undefinedItems", { type: "array" }],
+        ["unionItems", { type: ["array", "null"] }],
+        ["unionUndefinedItems", { type: ["array", "null"], items: undefined }],
         ["typedItems", { type: "array", items: { type: "string" } }],
         ["falseItems", { type: "array", items: false }],
         ["nullItems", { type: "array", items: null }],


### PR DESCRIPTION
Related: #140591.

## What Problem This Solves

Tool-schema normalization walks schemas to insert missing array items, then walks them again to remove empty items for models that require omission. Two implementations duplicate the same schema-container inventory and ownership rules.

## Why This Change Was Made

Use one array-items traversal for the existing addition and omission policies. Preserve the established differences for exact array types, nullable unions, explicit undefined items and malformed containers. Ref inlining, OpenAPI normalization, provider cleaning order, literal metadata and cache ownership remain unchanged.

This maintainer-requested refactor removes 90 production lines (+58/-148). Six test lines extend an existing owner-boundary case; no public API, configuration or provider payload changes.

## User Impact

Models receive the same tool schemas. Omission no longer requires a separate full add-then-remove traversal, and the array-items policy has one implementation.

## Evidence

- 95 focused tests passed: agent tool schemas, plugin-SDK provider tools and schema keyword stripping.
- A standalone original/candidate comparison passed 14,553 deterministic combinations through the production normalization export, checking deep output, serialized property order, ownership/alias identity, input immutability and cached identity.
- Direct Codex contract inspection used `rust-v0.153.4` (`3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`): `codex-rs/protocol/src/dynamic_tools.rs:20` carries JSON input schemas; `codex-rs/tools/src/json_schema.rs:25` owns its preparation and `:185` owns missing array-item defaults. Those dependency contracts are unchanged.
- Independent P2 review found no actionable findings. Repository changed-code checks are recorded before landing. This is production normalization proof; no external model request is claimed.
