### PR TITLE
refactor(discord): share prepared binding expiry selection

### DIFF
--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -490,6 +490,14 @@ metadata. Replacing either starts fresh target metadata, so a new session cannot
 inherit the previous plugin owner, agent, or label. Keep conversation transport
 details and explicit lifecycle settings separate from target metadata.
 
+Use `resolveThreadBindingLifecycle(...)` from
+`openclaw/plugin-sdk/thread-bindings-session-runtime` for standard idle and
+maximum-age expiration. Plugins with a different legacy timestamp contract can
+pass prepared `inactivityExpiresAt` and `maxAgeExpiresAt` values to
+`resolveThreadBindingExpiry(...)` on the same subpath. It selects the earlier
+deadline and its reason, preferring idle expiration on ties; omitted deadlines
+are disabled. The plugin still owns timestamp validation and duration defaults.
+
 Preserve opaque plugin ownership metadata when projecting binding records.
 Plugin-owned targets do not require an OpenClaw agent id; use
 `isPluginOwnedSessionBindingRecord(...)` from

--- a/extensions/discord/src/monitor/thread-bindings.manager.ts
+++ b/extensions/discord/src/monitor/thread-bindings.manager.ts
@@ -44,8 +44,7 @@ import {
   resolveBindingIdsForSession,
   resolveBindingRecordKey,
   resolveThreadBindingIdleTimeoutMs,
-  resolveThreadBindingInactivityExpiresAt,
-  resolveThreadBindingMaxAgeExpiresAt,
+  resolvePreparedThreadBindingLifecycle,
   resolveThreadBindingMaxAgeMs,
   saveBindingsToDisk,
   setBindingRecord,
@@ -133,41 +132,21 @@ export function createThreadBindingManager(params: {
         continue;
       }
       const now = Date.now();
-      const inactivityExpiresAt = resolveThreadBindingInactivityExpiresAt({
+      const lifecycle = resolvePreparedThreadBindingLifecycle({
         record: binding,
-        defaultIdleTimeoutMs: idleTimeoutMs,
+        idleTimeoutMs,
+        maxAgeMs,
       });
-      const maxAgeExpiresAt = resolveThreadBindingMaxAgeExpiresAt({
-        record: binding,
-        defaultMaxAgeMs: maxAgeMs,
-      });
-      const expirationCandidates: Array<{
-        reason: "idle-expired" | "max-age-expired";
-        at: number;
-      }> = [];
-      if (inactivityExpiresAt != null && now >= inactivityExpiresAt) {
-        expirationCandidates.push({ reason: "idle-expired", at: inactivityExpiresAt });
-      }
-      if (maxAgeExpiresAt != null && now >= maxAgeExpiresAt) {
-        expirationCandidates.push({ reason: "max-age-expired", at: maxAgeExpiresAt });
-      }
-      if (expirationCandidates.length > 0) {
-        expirationCandidates.sort((a, b) => a.at - b.at);
-        const reason = expirationCandidates[0]?.reason ?? "idle-expired";
+      const { expiresAt, reason } = lifecycle;
+      if (expiresAt != null && reason && now >= expiresAt) {
         manager.unbindThread({
           threadId: binding.threadId,
           reason,
           sendFarewell: true,
           farewellText: resolveThreadBindingFarewellText({
             reason,
-            idleTimeoutMs: resolveThreadBindingIdleTimeoutMs({
-              record: binding,
-              defaultIdleTimeoutMs: idleTimeoutMs,
-            }),
-            maxAgeMs: resolveThreadBindingMaxAgeMs({
-              record: binding,
-              defaultMaxAgeMs: maxAgeMs,
-            }),
+            idleTimeoutMs: lifecycle.idleTimeoutMs,
+            maxAgeMs: lifecycle.maxAgeMs,
           }),
         });
         continue;

--- a/extensions/discord/src/monitor/thread-bindings.session-adapter.ts
+++ b/extensions/discord/src/monitor/thread-bindings.session-adapter.ts
@@ -11,10 +11,7 @@ import { resolveDiscordChannelId } from "../target-parsing.js";
 import { resolveChannelIdForBinding } from "./thread-bindings.discord-api.js";
 import {
   resolveBindingRecordKey,
-  resolveThreadBindingIdleTimeoutMs,
-  resolveThreadBindingInactivityExpiresAt,
-  resolveThreadBindingMaxAgeExpiresAt,
-  resolveThreadBindingMaxAgeMs,
+  resolvePreparedThreadBindingLifecycle,
 } from "./thread-bindings.state.js";
 import type { ThreadBindingManager, ThreadBindingRecord } from "./thread-bindings.types.js";
 
@@ -43,25 +40,6 @@ function toThreadBindingTargetKind(raw: BindingTargetKind): "subagent" | "acp" {
   return raw === "subagent" ? "subagent" : "acp";
 }
 
-function resolveEffectiveBindingExpiresAt(params: {
-  record: ThreadBindingRecord;
-  defaultIdleTimeoutMs: number;
-  defaultMaxAgeMs: number;
-}): number | undefined {
-  const inactivityExpiresAt = resolveThreadBindingInactivityExpiresAt({
-    record: params.record,
-    defaultIdleTimeoutMs: params.defaultIdleTimeoutMs,
-  });
-  const maxAgeExpiresAt = resolveThreadBindingMaxAgeExpiresAt({
-    record: params.record,
-    defaultMaxAgeMs: params.defaultMaxAgeMs,
-  });
-  if (inactivityExpiresAt != null && maxAgeExpiresAt != null) {
-    return Math.min(inactivityExpiresAt, maxAgeExpiresAt);
-  }
-  return inactivityExpiresAt ?? maxAgeExpiresAt;
-}
-
 function toSessionBindingRecord(
   record: ThreadBindingRecord,
   defaults: ThreadBindingDefaults,
@@ -71,6 +49,7 @@ function toSessionBindingRecord(
       accountId: record.accountId,
       threadId: record.threadId,
     }) ?? `${record.accountId}:${record.threadId}`;
+  const lifecycle = resolvePreparedThreadBindingLifecycle({ record, ...defaults });
   return {
     bindingId,
     targetSessionKey: record.targetSessionKey,
@@ -83,11 +62,7 @@ function toSessionBindingRecord(
     },
     status: "active",
     boundAt: record.boundAt,
-    expiresAt: resolveEffectiveBindingExpiresAt({
-      record,
-      defaultIdleTimeoutMs: defaults.idleTimeoutMs,
-      defaultMaxAgeMs: defaults.maxAgeMs,
-    }),
+    expiresAt: lifecycle.expiresAt,
     metadata: {
       agentId: record.agentId,
       label: record.label,
@@ -95,14 +70,8 @@ function toSessionBindingRecord(
       webhookToken: record.webhookToken,
       boundBy: record.boundBy,
       lastActivityAt: record.lastActivityAt,
-      idleTimeoutMs: resolveThreadBindingIdleTimeoutMs({
-        record,
-        defaultIdleTimeoutMs: defaults.idleTimeoutMs,
-      }),
-      maxAgeMs: resolveThreadBindingMaxAgeMs({
-        record,
-        defaultMaxAgeMs: defaults.maxAgeMs,
-      }),
+      idleTimeoutMs: lifecycle.idleTimeoutMs,
+      maxAgeMs: lifecycle.maxAgeMs,
       ...record.metadata,
     },
   };

--- a/extensions/discord/src/monitor/thread-bindings.state.ts
+++ b/extensions/discord/src/monitor/thread-bindings.state.ts
@@ -6,6 +6,7 @@ import {
   normalizeOptionalString,
   normalizeOptionalStringifiedId,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveThreadBindingExpiry } from "openclaw/plugin-sdk/thread-bindings-session-runtime";
 import { getDiscordRuntime } from "../runtime.js";
 import type {
   PersistedThreadBindingRecord,
@@ -241,6 +242,37 @@ export function resolveThreadBindingMaxAgeMs(params: {
   return Math.max(0, Math.floor(params.defaultMaxAgeMs));
 }
 
+function resolveTimestampExpiry(timestamp: number, durationMs: number): number | undefined {
+  if (durationMs <= 0) {
+    return undefined;
+  }
+  const at = Math.floor(timestamp);
+  return Number.isFinite(at) && at > 0 ? at + durationMs : undefined;
+}
+
+export function resolvePreparedThreadBindingLifecycle(params: {
+  record: ThreadBindingRecord;
+  idleTimeoutMs: number;
+  maxAgeMs: number;
+}) {
+  const idleTimeoutMs = resolveThreadBindingIdleTimeoutMs({
+    record: params.record,
+    defaultIdleTimeoutMs: params.idleTimeoutMs,
+  });
+  const maxAgeMs = resolveThreadBindingMaxAgeMs({
+    record: params.record,
+    defaultMaxAgeMs: params.maxAgeMs,
+  });
+  return {
+    idleTimeoutMs,
+    maxAgeMs,
+    ...resolveThreadBindingExpiry({
+      inactivityExpiresAt: resolveTimestampExpiry(params.record.lastActivityAt, idleTimeoutMs),
+      maxAgeExpiresAt: resolveTimestampExpiry(params.record.boundAt, maxAgeMs),
+    }),
+  };
+}
+
 export function resolveThreadBindingInactivityExpiresAt(params: {
   record: Pick<ThreadBindingRecord, "lastActivityAt" | "idleTimeoutMs">;
   defaultIdleTimeoutMs: number;
@@ -249,14 +281,7 @@ export function resolveThreadBindingInactivityExpiresAt(params: {
     record: params.record,
     defaultIdleTimeoutMs: params.defaultIdleTimeoutMs,
   });
-  if (idleTimeoutMs <= 0) {
-    return undefined;
-  }
-  const lastActivityAt = Math.floor(params.record.lastActivityAt);
-  if (!Number.isFinite(lastActivityAt) || lastActivityAt <= 0) {
-    return undefined;
-  }
-  return lastActivityAt + idleTimeoutMs;
+  return resolveTimestampExpiry(params.record.lastActivityAt, idleTimeoutMs);
 }
 
 export function resolveThreadBindingMaxAgeExpiresAt(params: {
@@ -267,14 +292,7 @@ export function resolveThreadBindingMaxAgeExpiresAt(params: {
     record: params.record,
     defaultMaxAgeMs: params.defaultMaxAgeMs,
   });
-  if (maxAgeMs <= 0) {
-    return undefined;
-  }
-  const boundAt = Math.floor(params.record.boundAt);
-  if (!Number.isFinite(boundAt) || boundAt <= 0) {
-    return undefined;
-  }
-  return boundAt + maxAgeMs;
+  return resolveTimestampExpiry(params.record.boundAt, maxAgeMs);
 }
 
 function linkSessionBinding(targetSessionKey: string, bindingKey: string) {

--- a/src/plugin-sdk/thread-bindings-session-runtime.ts
+++ b/src/plugin-sdk/thread-bindings-session-runtime.ts
@@ -4,6 +4,7 @@
 export { resolveThreadBindingFarewellText } from "../channels/thread-bindings-messages.js";
 export {
   resolveThreadBindingLifecycle,
+  resolveThreadBindingExpiry,
   type ThreadBindingLifecycleRecord,
 } from "../shared/thread-binding-lifecycle.js";
 export {

--- a/src/shared/thread-binding-lifecycle.test.ts
+++ b/src/shared/thread-binding-lifecycle.test.ts
@@ -1,8 +1,62 @@
 // Thread binding lifecycle tests cover binding states across channel threads.
 import { describe, expect, it } from "vitest";
-import { resolveThreadBindingLifecycle } from "./thread-binding-lifecycle.js";
+import {
+  resolveThreadBindingExpiry,
+  resolveThreadBindingLifecycle,
+} from "./thread-binding-lifecycle.js";
 
 describe("resolveThreadBindingLifecycle", () => {
+  it.each([
+    {
+      boundAt: 100,
+      lastActivityAt: 50,
+      idleTimeoutMs: 10,
+      maxAgeMs: 10,
+      expected: { expiresAt: 110, reason: "idle-expired" },
+    },
+    {
+      boundAt: -100,
+      lastActivityAt: -50,
+      idleTimeoutMs: 10.9,
+      maxAgeMs: 0,
+      expected: { expiresAt: -40, reason: "idle-expired" },
+    },
+    { boundAt: 0, lastActivityAt: 0, idleTimeoutMs: 0, maxAgeMs: 0, expected: {} },
+    {
+      boundAt: 100,
+      lastActivityAt: 100,
+      idleTimeoutMs: Number.NaN,
+      maxAgeMs: 10,
+      expected: { expiresAt: 110, reason: "max-age-expired" },
+    },
+    {
+      boundAt: 100,
+      lastActivityAt: 100,
+      idleTimeoutMs: Infinity,
+      maxAgeMs: 0,
+      expected: { expiresAt: Infinity, reason: "idle-expired" },
+    },
+  ])("preserves stored lifecycle semantics for %j", ({ expected, ...record }) => {
+    expect(
+      resolveThreadBindingLifecycle({ record, defaultIdleTimeoutMs: 500, defaultMaxAgeMs: 500 }),
+    ).toEqual(expected);
+  });
+
+  it("selects caller-prepared deadlines without normalizing legacy activity", () => {
+    expect(resolveThreadBindingExpiry({ inactivityExpiresAt: 60, maxAgeExpiresAt: 110 })).toEqual({
+      expiresAt: 60,
+      reason: "idle-expired",
+    });
+    expect(resolveThreadBindingExpiry({ inactivityExpiresAt: 110, maxAgeExpiresAt: 110 })).toEqual({
+      expiresAt: 110,
+      reason: "idle-expired",
+    });
+    expect(resolveThreadBindingExpiry({ maxAgeExpiresAt: 110 })).toEqual({
+      expiresAt: 110,
+      reason: "max-age-expired",
+    });
+  });
+
   it("prefers the earliest idle or max-age expiration", () => {
     expect(
       resolveThreadBindingLifecycle({

--- a/src/shared/thread-binding-lifecycle.ts
+++ b/src/shared/thread-binding-lifecycle.ts
@@ -40,6 +40,17 @@ export function resolveThreadBindingLifecycle(params: {
       : undefined;
   const maxAgeExpiresAt = maxAgeMs > 0 ? params.record.boundAt + maxAgeMs : undefined;
 
+  return resolveThreadBindingExpiry({ inactivityExpiresAt, maxAgeExpiresAt });
+}
+
+/** Selects prepared expiry candidates; the caller owns timestamp and duration normalization. */
+export function resolveThreadBindingExpiry({
+  inactivityExpiresAt,
+  maxAgeExpiresAt,
+}: {
+  inactivityExpiresAt?: number;
+  maxAgeExpiresAt?: number;
+}): { expiresAt?: number; reason?: "idle-expired" | "max-age-expired" } {
   // The lifecycle reports the first real reason so callers can prune or surface it accurately.
   if (inactivityExpiresAt != null && maxAgeExpiresAt != null) {
     return inactivityExpiresAt <= maxAgeExpiresAt


### PR DESCRIPTION
## What Problem This Solves

Discord computed binding deadlines independently in its session adapter and expiry sweeper, duplicating the shared lifecycle's earliest-deadline selection. Keeping those paths separate makes lifecycle reporting and removal reasons easier to diverge.

Related: #140073, #129801, #138007. All three diffs were inspected before this change. Their configured-binding provenance, native Discord reply routing, and Feishu live-config refresh remain with their respective owners.

## Why This Change Was Made

The shared binding lifecycle now selects prepared expiry candidates. Discord prepares its effective durations and guarded timestamps once for both adapter projection and sweeping. Idle expiration continues to win ties. Native timestamp validation and metadata projection remain with their channel owners: Discord's positive finite timestamp rules differ from the standard lifecycle's binding-time clamp.

## User Impact

No user-visible behavior change. Binding identity, metadata precedence, persistence, expiration, and asynchronous sweeper fencing remain unchanged. Existing exports remain available.

## Evidence

- `node scripts/run-vitest.mjs src/shared/thread-binding-lifecycle.test.ts extensions/discord/src/monitor/thread-bindings`: 57 tests passed across five files, including async sweeper fencing, same-target metadata preservation, legacy timestamps, non-finite overrides, disabled limits, and expiry ties.
- Independent Codex autoreview: zero P0–P2 findings. The fresh-main rebase is patch-identical, verified with `git range-diff`.
- `node scripts/check-changed.mjs` plus targeted continuation: all four typecheck lanes, core lint, SDK/doctor/dependency guards, export scans, and remaining architecture guards passed. Local extension lint encountered the documented nested-checkout `Declaration input escapes checkout` limitation; no ancestor install or guard was changed.
- `pnpm build`: passed, including all 152 public SDK subpaths and 90 external plugins. A native Node probe imported the built `openclaw/plugin-sdk/thread-bindings-session-runtime` helper and verified idle-expiry tie behavior.
- Exact-head hosted CI passed on `5e3dbbc8835869c077c6a59be37f30443fd9e5b1`: https://github.com/openclaw/openclaw/actions/runs/34077676325
- The hosted extension-package-boundary job passed: https://github.com/openclaw/openclaw/actions/runs/34077676325/job/101606977476
- Production delta: -22 lines; tests: +54 lines; documentation: +8 lines.
- Live-channel gap: no live Discord transport was exercised. Synthetic adapter/lifecycle tests provide boundary proof; no live Gateway was touched.
