### PR TITLE
refactor(channels): share approval reaction settlement

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -547,7 +547,7 @@ extensions/imessage/src/approval-handler.runtime.ts	2
 extensions/imessage/src/approval-native.ts	1
 extensions/imessage/src/approval-polls.ts	6
 extensions/imessage/src/approval-reaction-poller.ts	1
-extensions/imessage/src/approval-reactions.ts	3
+extensions/imessage/src/approval-reactions.ts	2
 extensions/imessage/src/approval-target-keys.ts	1
 extensions/imessage/src/channel.runtime.ts	1
 extensions/imessage/src/channel.ts	4
@@ -1326,7 +1326,6 @@ extensions/whatsapp/src/agent-tools-call.ts	1
 extensions/whatsapp/src/agent-tools-login.ts	6
 extensions/whatsapp/src/approval-handler.runtime.ts	1
 extensions/whatsapp/src/approval-native.ts	1
-extensions/whatsapp/src/approval-reactions.ts	1
 extensions/whatsapp/src/auth-store.ts	3
 extensions/whatsapp/src/auto-reply/monitor.ts	2
 extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts	4

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -636,6 +636,16 @@ do not treat the recorded approval alone as proof that the change completed.
 
 Other approval helpers:
 
+- Use `settleApprovalReaction` from
+  `openclaw/plugin-sdk/approval-reaction-runtime` for explicitly authorized
+  reaction decisions. It checks the supplied approvers and actor authorization,
+  loads the Gateway resolver lazily, and calls `clearTarget` for every terminal
+  result (including a losing click) or approval-not-found error. Keep transport
+  identity, route checks, cleanup, and result logging in the plugin. Other errors
+  propagate with the binding intact; the channel must hand them to its durable
+  ingress or poller for replay. `readApprovalReactionTargetRecord` validates the
+  shared persisted fields; transport-specific route and author fields still need
+  their own validation.
 - Use `createNativeApprovalChannelRouteGates` from
   `openclaw/plugin-sdk/approval-native-runtime` when a channel supports both
   session-origin native delivery and explicit approval forwarding targets. The

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -7,9 +7,10 @@ import {
   buildApprovalReactionHint,
   buildApprovalReactionDeliveredBindingMarker,
   createApprovalReactionTargetStore,
+  readApprovalReactionTargetRecord,
+  settleApprovalReaction,
   listApprovalReactionBindings,
   normalizeApprovalReactionDecision,
-  readApprovalReactionDecisionList,
   readApprovalReactionDeliveredBinding,
   readApprovalReactionPresentationBinding,
   resolveTypedApprovalReactionTarget,
@@ -19,7 +20,6 @@ import {
 import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
 import type { OutboundDeliveryResult } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
 import { createLazyRuntimeSurface } from "openclaw/plugin-sdk/lazy-runtime";
 import { createPluginStateErrorReporter } from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
@@ -96,26 +96,6 @@ function reportApprovalBindingCorrelationMismatch(binding: {
   }
 }
 
-function readPersistedTarget(value: unknown): IMessageApprovalReactionTarget | null {
-  const target = value as Partial<IMessageApprovalReactionTarget> | undefined;
-  if (
-    !target ||
-    typeof target.approvalId !== "string" ||
-    (target.approvalKind !== "exec" && target.approvalKind !== "plugin")
-  ) {
-    return null;
-  }
-  const allowedDecisions = readApprovalReactionDecisionList(target.allowedDecisions);
-  if (!allowedDecisions) {
-    return null;
-  }
-  return {
-    approvalId: target.approvalId,
-    approvalKind: target.approvalKind,
-    allowedDecisions,
-  };
-}
-
 const imessageApprovalReactionTargets =
   createApprovalReactionTargetStore<IMessageApprovalReactionTarget>({
     namespace: PERSISTENT_NAMESPACE,
@@ -123,7 +103,7 @@ const imessageApprovalReactionTargets =
     defaultTtlMs: DEFAULT_REACTION_TARGET_TTL_MS,
     openStore: (params) => getOptionalIMessageRuntime()?.state.openKeyedStore(params),
     logPersistentError: reportPersistentApprovalReactionError,
-    readPersistedTarget,
+    readPersistedTarget: readApprovalReactionTargetRecord,
   });
 
 type IMessageApprovalDeliveryBinding = ApprovalReactionDeliveryBinding & {
@@ -496,48 +476,27 @@ export async function handleIMessageApprovalReaction(params: {
   if (event.action === "removed") {
     return { handled: false, stopPolling: false };
   }
-  let target: IMessageApprovalReactionResolution | null = null;
+  let matchedTarget: IMessageApprovalReactionResolution | null = null;
   let matchedMessageId: string | null = null;
   for (const candidate of event.messageIdCandidates) {
-    target = await resolveIMessageApprovalReactionTargetWithPersistence({
+    matchedTarget = await resolveIMessageApprovalReactionTargetWithPersistence({
       accountId: params.accountId,
       conversation: event.conversation,
       messageId: candidate,
       reactionKey: event.reactionKey,
     });
-    if (target) {
+    if (matchedTarget) {
       matchedMessageId = candidate;
       break;
     }
   }
+  const target = matchedTarget;
   if (!target) {
     return { handled: false, stopPolling: false };
   }
 
-  const approvers = getIMessageApprovalApprovers({ cfg: params.cfg, accountId: params.accountId });
-  if (approvers.length === 0) {
-    params.logVerboseMessage?.(
-      `imessage: approval reaction denied id=${target.approvalId}; reactions require explicit approvers`,
-    );
-    return { handled: true, stopPolling: false };
-  }
-  const auth = imessageApprovalAuth.authorizeActorAction({
-    cfg: params.cfg,
-    accountId: params.accountId,
-    senderId: event.actorHandle,
-    action: "approve",
-    approvalKind: target.approvalKind,
-  });
-  if (!auth.authorized) {
-    params.logVerboseMessage?.(
-      `imessage: approval reaction denied id=${target.approvalId} sender=${event.actorHandle}`,
-    );
-    return { handled: true, stopPolling: false };
-  }
-
-  const resolveApprovalOverGateway = await loadResolveApprovalOverGateway();
-  try {
-    const result = await resolveApprovalOverGateway({
+  const outcome = await settleApprovalReaction({
+    request: {
       cfg: params.cfg,
       approvalId: target.approvalId,
       approvalKind: target.approvalKind,
@@ -547,24 +506,12 @@ export async function handleIMessageApprovalReaction(params: {
       senderId: event.actorHandle,
       gatewayUrl: params.gatewayUrl,
       ...(params.gatewayRuntime ? { gatewayRuntime: params.gatewayRuntime } : {}),
-    });
-    // Every terminal result clears the binding. Losing surfaces receive applied:false
-    // without a new event, so retaining their controls would keep polling stale state.
-    // Iterate every GUID candidate so prefixed/unprefixed forms are both cleared.
-    for (const candidate of event.messageIdCandidates) {
-      unregisterIMessageApprovalReactionTarget({
-        accountId: params.accountId,
-        conversation: event.conversation,
-        messageId: candidate,
-      });
-    }
-    const outcome = result.applied ? "resolved" : "already resolved";
-    params.logVerboseMessage?.(
-      `imessage: approval reaction ${outcome} id=${target.approvalId} sender=${event.actorHandle} ${formatCanonicalApprovalTerminalState(result.approval)} via messageId=${matchedMessageId ?? event.messageId}`,
-    );
-    return { handled: true, stopPolling: true, stopPollingReason: "resolved" };
-  } catch (error) {
-    if (isApprovalNotFoundError(error)) {
+    },
+    approvers: getIMessageApprovalApprovers({ cfg: params.cfg, accountId: params.accountId }),
+    authorizeActorAction: imessageApprovalAuth.authorizeActorAction,
+    loadResolver: loadResolveApprovalOverGateway,
+    clearTarget: () => {
+      // Retire every GUID alias and its poll target, including losing surfaces.
       for (const candidate of event.messageIdCandidates) {
         unregisterIMessageApprovalReactionTarget({
           accountId: params.accountId,
@@ -572,31 +519,31 @@ export async function handleIMessageApprovalReaction(params: {
           messageId: candidate,
         });
       }
+    },
+    onResolved: (result) => {
+      const outcome = result.applied ? "resolved" : "already resolved";
       params.logVerboseMessage?.(
-        `imessage: approval reaction ignored for expired approval id=${target.approvalId} sender=${event.actorHandle}`,
+        `imessage: approval reaction ${outcome} id=${target.approvalId} sender=${event.actorHandle} ${formatCanonicalApprovalTerminalState(result.approval)} via messageId=${matchedMessageId ?? event.messageId}`,
       );
-      return { handled: true, stopPolling: true, stopPollingReason: "not-found" };
-    }
-    // Surface non-NotFound errors at warn level so a gateway 5xx / network
-    // outage / auth failure is visible without OPENCLAW_LOG_LEVEL=debug.
-    try {
-      getOptionalIMessageRuntime()
-        ?.logging.getChildLogger({ plugin: "imessage", feature: "approval-reactions" })
-        .warn("approval reaction failed", {
-          approvalId: target.approvalId,
-          senderId: event.actorHandle,
-          error: String(error),
-        });
-    } catch {
-      // Logger surface is optional in tests; never let logging mask the error.
-    }
-    params.logVerboseMessage?.(
-      `imessage: approval reaction failed id=${target.approvalId} sender=${event.actorHandle}: ${String(error)}`,
-    );
-    // Non-terminal resolver errors must reach the durable ingress drain.
-    // Returning here would commit the claim and lose the operator's reaction.
-    throw error;
-  }
+    },
+    onError: (error) => {
+      try {
+        getOptionalIMessageRuntime()
+          ?.logging.getChildLogger({ plugin: "imessage", feature: "approval-reactions" })
+          .warn("approval reaction failed", {
+            approvalId: target.approvalId,
+            senderId: event.actorHandle,
+            error: String(error),
+          });
+      } catch {
+        // Optional logging must not mask a replayable resolver failure.
+      }
+    },
+    logVerboseMessage: params.logVerboseMessage,
+  });
+  return outcome === "denied"
+    ? { handled: true, stopPolling: false }
+    : { handled: true, stopPolling: true, stopPollingReason: outcome };
 }
 
 export async function maybeResolveIMessageApprovalReaction(params: {

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -495,7 +495,7 @@ export async function handleIMessageApprovalReaction(params: {
     return { handled: false, stopPolling: false };
   }
 
-  const outcome = await settleApprovalReaction({
+  const settlement = await settleApprovalReaction({
     request: {
       cfg: params.cfg,
       approvalId: target.approvalId,
@@ -508,7 +508,7 @@ export async function handleIMessageApprovalReaction(params: {
       ...(params.gatewayRuntime ? { gatewayRuntime: params.gatewayRuntime } : {}),
     },
     approvers: getIMessageApprovalApprovers({ cfg: params.cfg, accountId: params.accountId }),
-    authorizeActorAction: imessageApprovalAuth.authorizeActorAction,
+    authorizeActorAction: (input) => imessageApprovalAuth.authorizeActorAction(input),
     loadResolver: loadResolveApprovalOverGateway,
     clearTarget: () => {
       // Retire every GUID alias and its poll target, including losing surfaces.
@@ -541,9 +541,9 @@ export async function handleIMessageApprovalReaction(params: {
     },
     logVerboseMessage: params.logVerboseMessage,
   });
-  return outcome === "denied"
+  return settlement === "denied"
     ? { handled: true, stopPolling: false }
-    : { handled: true, stopPolling: true, stopPollingReason: outcome };
+    : { handled: true, stopPolling: true, stopPollingReason: settlement };
 }
 
 export async function maybeResolveIMessageApprovalReaction(params: {

--- a/extensions/signal/src/approval-reactions.ts
+++ b/extensions/signal/src/approval-reactions.ts
@@ -523,7 +523,7 @@ export async function maybeResolveSignalApprovalReaction(params: {
       gatewayUrl: params.gatewayUrl,
     },
     approvers: getSignalApprovalApprovers({ cfg: params.cfg, accountId: params.accountId }),
-    authorizeActorAction: signalApprovalAuth.authorizeActorAction,
+    authorizeActorAction: (input) => signalApprovalAuth.authorizeActorAction(input),
     loadResolver: loadResolveApprovalOverGateway,
     clearTarget: () =>
       unregisterSignalApprovalReactionTarget({

--- a/extensions/signal/src/approval-reactions.ts
+++ b/extensions/signal/src/approval-reactions.ts
@@ -4,9 +4,10 @@ import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-r
 import {
   addApprovalReactionHintToText,
   createApprovalReactionTargetStore,
+  readApprovalReactionTargetRecord,
+  settleApprovalReaction,
   hasApprovalReactionHintText,
   listApprovalReactionBindings,
-  readApprovalReactionDecisionList,
   resolveTypedApprovalReactionTarget,
   type ApprovalReactionTargetRecord,
 } from "openclaw/plugin-sdk/approval-reaction-runtime";
@@ -15,7 +16,6 @@ import {
   type ExecApprovalReplyDecision,
 } from "openclaw/plugin-sdk/approval-reply-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
 import { createLazyRuntimeSurface } from "openclaw/plugin-sdk/lazy-runtime";
 import { createPluginStateErrorReporter } from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
@@ -141,19 +141,14 @@ function buildReactionTargetKey(params: {
 }
 
 function readPersistedTarget(target: unknown): SignalApprovalReactionTarget | null {
+  const record = readApprovalReactionTargetRecord(target);
   const value = target as Partial<SignalApprovalReactionTarget> | null | undefined;
   if (
-    !value ||
-    typeof value.approvalId !== "string" ||
-    (value.approvalKind !== "exec" && value.approvalKind !== "plugin") ||
-    !value.route ||
+    !record ||
+    !value?.route ||
     (value.route.deliveryMode !== "session" && value.route.deliveryMode !== "target") ||
     !Array.isArray(value.targetAuthorKeys)
   ) {
-    return null;
-  }
-  const allowedDecisions = readApprovalReactionDecisionList(value.allowedDecisions);
-  if (!allowedDecisions) {
     return null;
   }
   const targetRouteTo =
@@ -184,9 +179,7 @@ function readPersistedTarget(target: unknown): SignalApprovalReactionTarget | nu
             : {}),
         };
   return {
-    approvalId: value.approvalId,
-    approvalKind: value.approvalKind,
-    allowedDecisions,
+    ...record,
     targetAuthorKeys: value.targetAuthorKeys,
     route,
   };
@@ -518,30 +511,8 @@ export async function maybeResolveSignalApprovalReaction(params: {
     return true;
   }
 
-  const approvers = getSignalApprovalApprovers({ cfg: params.cfg, accountId: params.accountId });
-  if (approvers.length === 0) {
-    params.logVerboseMessage?.(
-      `signal: approval reaction denied id=${target.approvalId}; reactions require explicit approvers`,
-    );
-    return true;
-  }
-  const auth = signalApprovalAuth.authorizeActorAction({
-    cfg: params.cfg,
-    accountId: params.accountId,
-    senderId: actorId,
-    action: "approve",
-    approvalKind: target.approvalKind,
-  });
-  if (!auth.authorized) {
-    params.logVerboseMessage?.(
-      `signal: approval reaction denied id=${target.approvalId} sender=${actorId}`,
-    );
-    return true;
-  }
-
-  const resolveApprovalOverGateway = await loadResolveApprovalOverGateway();
-  try {
-    const result = await resolveApprovalOverGateway({
+  await settleApprovalReaction({
+    request: {
       cfg: params.cfg,
       approvalId: target.approvalId,
       approvalKind: target.approvalKind,
@@ -550,40 +521,25 @@ export async function maybeResolveSignalApprovalReaction(params: {
       accountId: params.accountId,
       senderId: actorId,
       gatewayUrl: params.gatewayUrl,
-    });
-    const terminalTruth = formatSignalApprovalTerminalTruth(result.approval);
-    unregisterSignalApprovalReactionTarget({
-      accountId: params.accountId,
-      conversationKey: params.conversationKey,
-      messageId: params.messageId,
-    });
-    if (!result.applied) {
-      params.logVerboseMessage?.(
-        `signal: approval reaction already resolved id=${target.approvalId} sender=${actorId} ${terminalTruth}`,
-      );
-      return true;
-    }
-    params.logVerboseMessage?.(
-      `signal: approval reaction resolved id=${target.approvalId} sender=${actorId} ${terminalTruth}`,
-    );
-    return true;
-  } catch (error) {
-    if (isApprovalNotFoundError(error)) {
+    },
+    approvers: getSignalApprovalApprovers({ cfg: params.cfg, accountId: params.accountId }),
+    authorizeActorAction: signalApprovalAuth.authorizeActorAction,
+    loadResolver: loadResolveApprovalOverGateway,
+    clearTarget: () =>
       unregisterSignalApprovalReactionTarget({
         accountId: params.accountId,
         conversationKey: params.conversationKey,
         messageId: params.messageId,
-      });
+      }),
+    onResolved: (result) => {
+      const outcome = result.applied ? "resolved" : "already resolved";
       params.logVerboseMessage?.(
-        `signal: approval reaction ignored for expired approval id=${target.approvalId} sender=${actorId}`,
+        `signal: approval reaction ${outcome} id=${target.approvalId} sender=${actorId} ${formatSignalApprovalTerminalTruth(result.approval)}`,
       );
-      return true;
-    }
-    params.logVerboseMessage?.(
-      `signal: approval reaction failed id=${target.approvalId} sender=${actorId}: ${String(error)}`,
-    );
-    throw error;
-  }
+    },
+    logVerboseMessage: params.logVerboseMessage,
+  });
+  return true;
 }
 
 export function clearSignalApprovalReactionTargetsForTest(): void {

--- a/extensions/whatsapp/src/approval-reactions.test.ts
+++ b/extensions/whatsapp/src/approval-reactions.test.ts
@@ -423,6 +423,26 @@ describe("WhatsApp approval reactions", () => {
     ).resolves.toBeNull();
   });
 
+  it("retains the target and propagates transient failures for durable replay", async () => {
+    registerExecApprovalTarget({ remoteJid: "15551230000@s.whatsapp.net" });
+    const gatewayError = new Error("Gateway 503 Service Unavailable");
+    resolverMocks.resolveWhatsAppApproval.mockRejectedValueOnce(gatewayError);
+    const reaction = {
+      cfg: approvalConfig(["+15551230000"]),
+      accountId: "default",
+      msg: buildReactionMessage({ remoteJid: "15551230000@s.whatsapp.net" }),
+      resolveInboundJid: async () => "+15551230000",
+    };
+
+    await expect(maybeResolveWhatsAppApprovalReaction(reaction)).rejects.toBe(gatewayError);
+    await expect(maybeResolveWhatsAppApprovalReaction(reaction)).resolves.toBe(true);
+    expect(resolverMocks.resolveWhatsAppApproval).toHaveBeenCalledTimes(2);
+    expect(resolverMocks.resolveWhatsAppApproval.mock.calls[1]).toEqual(
+      resolverMocks.resolveWhatsAppApproval.mock.calls[0],
+    );
+    await expect(maybeResolveWhatsAppApprovalReaction(reaction)).resolves.toBe(false);
+  });
+
   it("does not attribute a peer DM fromMe reaction to the peer", async () => {
     registerWhatsAppApprovalReactionTarget({
       accountId: "default",

--- a/extensions/whatsapp/src/approval-reactions.ts
+++ b/extensions/whatsapp/src/approval-reactions.ts
@@ -5,6 +5,8 @@ import {
   approvalReactionDecisionSetsMatch,
   buildApprovalReactionDeliveredBindingMarker,
   createApprovalReactionTargetStore,
+  readApprovalReactionTargetRecord,
+  settleApprovalReaction,
   listApprovalReactionBindings,
   readApprovalReactionDecisionList,
   readApprovalReactionDeliveredBinding,
@@ -16,7 +18,6 @@ import {
 import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
 import type { OutboundDeliveryResult } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
 import type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 import { createLazyRuntimeSurface } from "openclaw/plugin-sdk/lazy-runtime";
 import { createPluginStateErrorReporter } from "openclaw/plugin-sdk/plugin-state-runtime";
@@ -72,7 +73,7 @@ const whatsappApprovalReactionTargets =
     defaultTtlMs: DEFAULT_REACTION_TARGET_TTL_MS,
     openStore: (storeParams) => getOptionalWhatsAppRuntime()?.state.openKeyedStore(storeParams),
     logPersistentError: reportPersistentApprovalReactionError,
-    readPersistedTarget,
+    readPersistedTarget: readApprovalReactionTargetRecord,
   });
 
 function buildReactionTargetKey(params: {
@@ -112,26 +113,6 @@ function reportApprovalBindingCorrelationMismatch(binding: {
   } catch {
     // Best effort only.
   }
-}
-
-function readPersistedTarget(target: unknown): WhatsAppApprovalReactionTarget | null {
-  const value = target as Partial<WhatsAppApprovalReactionTarget> | null | undefined;
-  if (
-    !value ||
-    typeof value.approvalId !== "string" ||
-    (value.approvalKind !== "exec" && value.approvalKind !== "plugin")
-  ) {
-    return null;
-  }
-  const allowedDecisions = readApprovalReactionDecisionList(value.allowedDecisions);
-  if (!allowedDecisions) {
-    return null;
-  }
-  return {
-    approvalId: value.approvalId,
-    approvalKind: value.approvalKind,
-    allowedDecisions,
-  };
 }
 
 const APPROVAL_ID_LINE_RE = /^\s*ID:\s*(\S(?:.*\S)?)\s*$/i;
@@ -481,30 +462,8 @@ export async function maybeResolveWhatsAppApprovalReaction(params: {
     return true;
   }
 
-  const approvers = getWhatsAppApprovalApprovers({ cfg: params.cfg, accountId: params.accountId });
-  if (approvers.length === 0) {
-    params.logVerboseMessage?.(
-      `whatsapp: approval reaction denied id=${target.approvalId}; reactions require explicit approvers`,
-    );
-    return true;
-  }
-  const auth = whatsappApprovalAuth.authorizeActorAction({
-    cfg: params.cfg,
-    accountId: params.accountId,
-    senderId: actorId,
-    action: "approve",
-    approvalKind: target.approvalKind,
-  });
-  if (!auth.authorized) {
-    params.logVerboseMessage?.(
-      `whatsapp: approval reaction denied id=${target.approvalId} sender=${actorId}`,
-    );
-    return true;
-  }
-
-  const resolveApprovalOverGateway = await loadResolveApprovalOverGateway();
-  try {
-    const result = await resolveApprovalOverGateway({
+  await settleApprovalReaction({
+    request: {
       cfg: params.cfg,
       approvalId: target.approvalId,
       approvalKind: target.approvalKind,
@@ -513,37 +472,28 @@ export async function maybeResolveWhatsAppApprovalReaction(params: {
       accountId: params.accountId,
       senderId: actorId,
       gatewayUrl: params.gatewayUrl,
-    });
-    unregisterWhatsAppApprovalReactionTarget({
-      accountId: params.accountId,
-      remoteJid: target.remoteJid,
-      messageId: event.messageId,
-    });
-    const canonicalDecision =
-      "decision" in result.approval ? ` decision=${result.approval.decision}` : "";
-    params.logVerboseMessage?.(
-      result.applied
-        ? `whatsapp: approval reaction applied id=${target.approvalId} sender=${actorId} status=${result.approval.status}${canonicalDecision}`
-        : `whatsapp: approval reaction already resolved id=${target.approvalId} sender=${actorId} status=${result.approval.status}${canonicalDecision}`,
-    );
-    return true;
-  } catch (error) {
-    if (isApprovalNotFoundError(error)) {
+    },
+    approvers: getWhatsAppApprovalApprovers({ cfg: params.cfg, accountId: params.accountId }),
+    authorizeActorAction: whatsappApprovalAuth.authorizeActorAction,
+    loadResolver: loadResolveApprovalOverGateway,
+    clearTarget: () =>
       unregisterWhatsAppApprovalReactionTarget({
         accountId: params.accountId,
         remoteJid: target.remoteJid,
         messageId: event.messageId,
-      });
+      }),
+    onResolved: (result) => {
+      const canonicalDecision =
+        "decision" in result.approval ? ` decision=${result.approval.decision}` : "";
       params.logVerboseMessage?.(
-        `whatsapp: approval reaction ignored for expired approval id=${target.approvalId} sender=${actorId}`,
+        result.applied
+          ? `whatsapp: approval reaction applied id=${target.approvalId} sender=${actorId} status=${result.approval.status}${canonicalDecision}`
+          : `whatsapp: approval reaction already resolved id=${target.approvalId} sender=${actorId} status=${result.approval.status}${canonicalDecision}`,
       );
-      return true;
-    }
-    params.logVerboseMessage?.(
-      `whatsapp: approval reaction failed id=${target.approvalId} sender=${actorId}: ${String(error)}`,
-    );
-    return true;
-  }
+    },
+    logVerboseMessage: params.logVerboseMessage,
+  });
+  return true;
 }
 
 export function clearWhatsAppApprovalReactionTargetsForTest(): void {

--- a/extensions/whatsapp/src/approval-reactions.ts
+++ b/extensions/whatsapp/src/approval-reactions.ts
@@ -474,7 +474,7 @@ export async function maybeResolveWhatsAppApprovalReaction(params: {
       gatewayUrl: params.gatewayUrl,
     },
     approvers: getWhatsAppApprovalApprovers({ cfg: params.cfg, accountId: params.accountId }),
-    authorizeActorAction: whatsappApprovalAuth.authorizeActorAction,
+    authorizeActorAction: (input) => whatsappApprovalAuth.authorizeActorAction(input),
     loadResolver: loadResolveApprovalOverGateway,
     clearTarget: () =>
       unregisterWhatsAppApprovalReactionTarget({

--- a/extensions/whatsapp/src/inbound/message-delivery.ts
+++ b/extensions/whatsapp/src/inbound/message-delivery.ts
@@ -427,6 +427,22 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
     if (context.skipRecentOutboundEcho === true) {
       return "completed";
     }
+    // Reactions do not normalize into chat messages. Resolve them while the drain
+    // owns the claim so transient failures remain replayable.
+    if (
+      await maybeResolveWhatsAppApprovalReaction({
+        cfg: options.loadConfig?.() ?? options.cfg,
+        accountId: options.accountId,
+        msg,
+        selfJid: self.jid,
+        selfLid: self.lid,
+        resolveInboundJid,
+        resolveReactionTargetJids,
+        logVerboseMessage: (message) => logWhatsAppVerbose(options.verbose, message),
+      })
+    ) {
+      return "completed";
+    }
     const prepared = await preparation;
     if (prepared === null) {
       return "completed";
@@ -497,8 +513,9 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
       rememberBaileysMessage(msg.key?.remoteJid, msg.key?.id, msg.message);
 
       const receiveOrder = nextReceiveOrder++;
-      if (
-        await maybeResolveWhatsAppApprovalReaction({
+      let approvalReactionResolved = false;
+      try {
+        approvalReactionResolved = await maybeResolveWhatsAppApprovalReaction({
           cfg: options.loadConfig?.() ?? options.cfg,
           accountId: options.accountId,
           msg,
@@ -507,8 +524,15 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
           resolveInboundJid,
           resolveReactionTargetJids,
           logVerboseMessage: (message) => logWhatsAppVerbose(options.verbose, message),
-        })
-      ) {
+        });
+      } catch (error) {
+        // Admit this reaction for durable replay without aborting its batch siblings.
+        inboundLogger.warn(
+          { error: formatError(error) },
+          "whatsapp approval reaction resolution failed; admitting reaction for durable replay",
+        );
+      }
+      if (approvalReactionResolved) {
         continue;
       }
 

--- a/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
@@ -1,4 +1,5 @@
 // WhatsApp monitor inbox behavior split by ownership.
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearWhatsAppApprovalReactionTargetsForTest,
@@ -44,8 +45,8 @@ describe("web monitor inbox delivery and dedupe", () => {
       approvalKind: "exec",
       allowedDecisions: ["allow-once", "deny"],
     });
-    const replayStarted = Promise.withResolvers<void>();
-    const finishReplay = Promise.withResolvers<void>();
+    const replayStarted = createDeferred<void>();
+    const finishReplay = createDeferred<void>();
     approvalResolver
       .mockRejectedValueOnce(new Error("gateway 503"))
       .mockRejectedValueOnce(new Error("gateway still unavailable"))

--- a/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
@@ -1,5 +1,9 @@
 // WhatsApp monitor inbox behavior split by ownership.
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearWhatsAppApprovalReactionTargetsForTest,
+  registerWhatsAppApprovalReactionTarget,
+} from "./approval-reactions.js";
 import { createWhatsAppDurableInboundQueue } from "./inbound/durable-receive.js";
 import { resolveWhatsAppIngressLifecycle } from "./inbound/ingress-lifecycle.js";
 import type { WebInboundMessage } from "./inbound/types.js";
@@ -15,11 +19,91 @@ import {
   settleInboundWork,
   startInboxMonitor,
   waitForMessageCalls,
+  waitForInboundWorkDrained,
   type InboxOnMessage,
 } from "./monitor-inbox.test-harness.js";
 
+const approvalResolver = vi.hoisted(() => vi.fn());
+vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
+  resolveApprovalOverGateway: approvalResolver,
+}));
+
 describe("web monitor inbox delivery and dedupe", () => {
   installStreamsInboundMessageHooks();
+  beforeEach(() => {
+    clearWhatsAppApprovalReactionTargetsForTest();
+    approvalResolver.mockReset();
+  });
+
+  it("replays approval reactions after Gateway loss without losing batch siblings", async () => {
+    registerWhatsAppApprovalReactionTarget({
+      accountId: DEFAULT_ACCOUNT_ID,
+      remoteJid: "15551230000@s.whatsapp.net",
+      messageId: "approval-message",
+      approvalId: "exec-replay",
+      approvalKind: "exec",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+    const replayStarted = Promise.withResolvers<void>();
+    const finishReplay = Promise.withResolvers<void>();
+    approvalResolver
+      .mockRejectedValueOnce(new Error("gateway 503"))
+      .mockRejectedValueOnce(new Error("gateway still unavailable"))
+      .mockImplementationOnce(async () => {
+        replayStarted.resolve();
+        await finishReplay.promise;
+        return { applied: true, approval: { status: "allowed", decision: "allow-once" } };
+      });
+    const onMessage = vi.fn();
+    const queue = createWhatsAppDurableInboundQueue(DEFAULT_ACCOUNT_ID);
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      durableInboundQueue: queue,
+    });
+    try {
+      sock.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: { id: "reaction-replay", remoteJid: "15551230000@s.whatsapp.net", fromMe: false },
+            message: {
+              reactionMessage: {
+                text: "👍",
+                key: { id: "approval-message", remoteJid: "15551230000@s.whatsapp.net" },
+              },
+            },
+            messageTimestamp: 1_700_000_000,
+          },
+          ...buildNotifyMessageUpsert({
+            id: "batch-survivor",
+            remoteJid: "999@s.whatsapp.net",
+            text: "batch survivor",
+            timestamp: 1_700_000_001,
+          }).messages,
+        ],
+      });
+      await replayStarted.promise;
+      const claim = (await queue.listClaims()).find((entry) => entry.attempts === 1);
+      expect(claim).toBeDefined();
+      if (!claim) {
+        throw new Error("expected the replayed approval claim");
+      }
+      finishReplay.resolve();
+      await waitForInboundWorkDrained();
+      expect(approvalResolver).toHaveBeenCalledTimes(3);
+      expect(approvalResolver.mock.calls[1]).toEqual(approvalResolver.mock.calls[0]);
+      expect(approvalResolver.mock.calls[2]).toEqual(approvalResolver.mock.calls[0]);
+      expect(onMessage).toHaveBeenCalledTimes(1);
+      expect(inboundMessage(onMessage).payload.body).toBe("batch survivor");
+      expect(await queue.listClaims()).toEqual([]);
+      expect(await queue.listPending({ limit: "all" })).toEqual([]);
+      await expect(
+        queue.enqueue(claim.id, claim.payload, { laneKey: claim.laneKey }),
+      ).resolves.toMatchObject({ kind: "completed" });
+    } finally {
+      finishReplay.resolve();
+      await listener.close();
+    }
+  });
 
   it("delivery coordinator streams inbound messages", async () => {
     const onMessage = vi.fn(async (msg) => {

--- a/src/plugin-sdk/approval-reaction-runtime.test.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.test.ts
@@ -5,6 +5,10 @@ import { describe, expect, it, vi } from "vitest";
 import type { ExecApprovalRequest } from "../infra/exec-approvals.js";
 import type { PluginApprovalRequest } from "../infra/plugin-approvals.js";
 import {
+  resolveApprovalOverGateway,
+  type ApprovalResolveResult,
+} from "./approval-gateway-runtime.js";
+import {
   APPROVAL_REACTION_BINDINGS,
   buildApprovalPendingPromptPayload,
   buildApprovalReactionDeliveredBindingMarker,
@@ -19,10 +23,67 @@ import {
   readApprovalReactionPresentationBinding,
   resolveApprovalReactionDecision,
   resolveTypedApprovalReactionTarget,
+  settleApprovalReaction,
   shouldSuppressLocalNativeExecApprovalPrompt,
 } from "./approval-reaction-runtime.js";
 
+vi.mock("./approval-gateway-runtime.js", () => ({ resolveApprovalOverGateway: vi.fn() }));
+
 describe("plugin-sdk/approval-reaction-runtime", () => {
+  it.each(["imessage", "signal", "whatsapp"])(
+    "leaves concurrent %s decisions to the Gateway and retires both terminal surfaces",
+    async (channel) => {
+      const winner = Promise.withResolvers<ApprovalResolveResult>();
+      const resolver = vi.mocked(resolveApprovalOverGateway).mockReset();
+      resolver.mockReturnValue(winner.promise);
+      const clearTarget = vi.fn();
+      const onResolved = vi.fn();
+      const settle = (decision: "allow-once" | "deny") =>
+        settleApprovalReaction({
+          request: {
+            cfg: {},
+            channel,
+            accountId: "default",
+            senderId: "operator",
+            approvalId: "race",
+            approvalKind: "exec",
+            decision,
+          },
+          approvers: ["operator"],
+          authorizeActorAction: () => ({ authorized: true }),
+          loadResolver: async () => resolveApprovalOverGateway,
+          clearTarget,
+          onResolved,
+        });
+      const attempts = [settle("allow-once"), settle("deny")];
+      await Promise.resolve();
+      expect(resolver).toHaveBeenCalledTimes(2);
+      expect(clearTarget).not.toHaveBeenCalled();
+      const result: ApprovalResolveResult = {
+        applied: false,
+        approval: {
+          id: "race",
+          urlPath: "/approvals/race",
+          createdAtMs: 1,
+          expiresAtMs: 100,
+          resolvedAtMs: 2,
+          status: "denied",
+          decision: "deny",
+          reason: "user",
+          presentation: {
+            kind: "exec",
+            commandText: "echo example",
+            allowedDecisions: ["allow-once", "deny"],
+          },
+        },
+      };
+      winner.resolve(result);
+      await expect(Promise.all(attempts)).resolves.toEqual(["resolved", "resolved"]);
+      expect(clearTarget).toHaveBeenCalledTimes(2);
+      expect(onResolved.mock.calls).toEqual([[result], [result]]);
+    },
+  );
+
   const execRequest: ExecApprovalRequest = {
     id: "exec-approval-123",
     request: {

--- a/src/plugin-sdk/approval-reaction-runtime.test.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.test.ts
@@ -2,6 +2,7 @@
  * Tests approval reaction runtime helper behavior.
  */
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import type { ExecApprovalRequest } from "../infra/exec-approvals.js";
 import type { PluginApprovalRequest } from "../infra/plugin-approvals.js";
 import {
@@ -33,7 +34,7 @@ describe("plugin-sdk/approval-reaction-runtime", () => {
   it.each(["imessage", "signal", "whatsapp"])(
     "leaves concurrent %s decisions to the Gateway and retires both terminal surfaces",
     async (channel) => {
-      const winner = Promise.withResolvers<ApprovalResolveResult>();
+      const winner = createDeferred<ApprovalResolveResult>();
       const resolver = vi.mocked(resolveApprovalOverGateway).mockReset();
       resolver.mockReturnValue(winner.promise);
       const clearTarget = vi.fn();

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "../../packages/normalization-core/src/record-coerce.js";
 import { sanitizeForPromptLiteral } from "../agents/sanitize-for-prompt.js";
 import { formatApprovalDisplayPath } from "../infra/approval-display-paths.js";
 import { summarizeApprovalScope } from "../infra/approval-scope.js";
@@ -12,10 +13,17 @@ import {
 } from "../infra/exec-approval-reply.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { formatFencedCodeBlock } from "../shared/markdown-code.js";
+import type { createChannelApprovalAuth } from "./approval-auth-helpers.js";
+import type {
+  ApprovalResolveResult,
+  resolveApprovalOverGateway,
+} from "./approval-gateway-runtime.js";
+import { readApprovalReactionDecisionList } from "./approval-reaction-binding.js";
 import {
   buildApprovalPendingReplyPayload,
   buildPluginApprovalPendingReplyPayload,
 } from "./approval-renderers.js";
+import { isApprovalNotFoundError } from "./error-runtime.js";
 import type { ReplyPayload } from "./reply-payload.js";
 export { shouldSuppressLocalNativeExecApprovalPrompt } from "./approval-native-helpers.js";
 export {
@@ -83,6 +91,76 @@ export type ApprovalReactionTargetResolution<TRoute = unknown> =
     approvalKind: ChannelApprovalKind;
     route?: TRoute;
   };
+
+/** Validate the shared persisted fields without changing transport-owned metadata. */
+export function readApprovalReactionTargetRecord(
+  target: unknown,
+): (ApprovalReactionTargetRecord & { approvalKind: ChannelApprovalKind }) | null {
+  if (
+    !isRecord(target) ||
+    typeof target.approvalId !== "string" ||
+    (target.approvalKind !== "exec" && target.approvalKind !== "plugin")
+  ) {
+    return null;
+  }
+  const allowedDecisions = readApprovalReactionDecisionList(target.allowedDecisions);
+  return allowedDecisions
+    ? { approvalId: target.approvalId, approvalKind: target.approvalKind, allowedDecisions }
+    : null;
+}
+
+/** Admit an explicit approver and retire transport bindings only on terminal resolution. */
+export async function settleApprovalReaction(params: {
+  request: Parameters<typeof resolveApprovalOverGateway>[0] & {
+    channel: string;
+    accountId: string;
+    senderId: string;
+  };
+  approvers: readonly string[];
+  authorizeActorAction: ReturnType<
+    typeof createChannelApprovalAuth
+  >["approvalAuth"]["authorizeActorAction"];
+  loadResolver: () => Promise<typeof resolveApprovalOverGateway>;
+  clearTarget: () => void;
+  onResolved: (result: ApprovalResolveResult) => void;
+  onError?: (error: unknown) => void;
+  logVerboseMessage?: (message: string) => void;
+}): Promise<"denied" | "resolved" | "not-found"> {
+  const { request, logVerboseMessage } = params;
+  const { channel, approvalId, senderId } = request;
+  if (params.approvers.length === 0) {
+    logVerboseMessage?.(
+      `${channel}: approval reaction denied id=${approvalId}; reactions require explicit approvers`,
+    );
+    return "denied";
+  }
+  if (!params.authorizeActorAction({ ...request, action: "approve" }).authorized) {
+    logVerboseMessage?.(`${channel}: approval reaction denied id=${approvalId} sender=${senderId}`);
+    return "denied";
+  }
+  const resolve = await params.loadResolver();
+  try {
+    const result = await resolve(request);
+    // Losing surfaces receive the canonical winner too; both outcomes retire controls.
+    params.clearTarget();
+    params.onResolved(result);
+    return "resolved";
+  } catch (error) {
+    if (isApprovalNotFoundError(error)) {
+      params.clearTarget();
+      logVerboseMessage?.(
+        `${channel}: approval reaction ignored for expired approval id=${approvalId} sender=${senderId}`,
+      );
+      return "not-found";
+    }
+    params.onError?.(error);
+    logVerboseMessage?.(
+      `${channel}: approval reaction failed id=${approvalId} sender=${senderId}: ${String(error)}`,
+    );
+    // The channel's ingress/poller owns replay; retain the binding and propagate failure.
+    throw error;
+  }
+}
 
 /** Reply payload enriched with reaction decision metadata. */
 export type ApprovalReactionPromptPayload = ReplyPayload & {


### PR DESCRIPTION
Closes #131004. Related: #130969.

## What Problem This Solves

WhatsApp approval reactions were silently consumed when Gateway resolution failed transiently, so the operator's click never reached durable ingress. The iMessage, Signal, and WhatsApp plugins also duplicated explicit-approver admission, persisted target validation, and terminal settlement.

## Why This Change Was Made

A stateless `settleApprovalReaction` operation and base-record decoder now live behind the existing `openclaw/plugin-sdk/approval-reaction-runtime` seam. Plugins retain transport identity, Signal route/target-author checks, iMessage GUID/poll cleanup, diagnostics, and replay ownership. Authorizer calls retain their receivers. Terminal results—including concurrent losing clicks—retire bindings; nonterminal failures retain them and propagate to the existing replay owner. The Gateway remains the first-answer authority.

This incorporates the WhatsApp durable-admission repair from #130969 by @wangmiao0668000666: a failed fast path preserves batch siblings, and the drain resolves reactions before ordinary message normalization. No sibling PR was modified.

The existing reaction seam is private-local and consumes no public SDK slots. No public export was removed or renamed. Store namespaces, versions, expiry, and persistence semantics are unchanged. Production delta: -45 lines; tests: +167. The assertion baseline shrinks exactly as required after deleting duplicate decoders: iMessage 3→2, WhatsApp 1→0. No baseline or budget increases.

## User Impact

WhatsApp approval reactions survive transient Gateway loss and replay after recovery. Existing iMessage and Signal authorization, canonical-winner reporting, and polling behavior remain intact. There are no new settings or UI appearance changes.

## Evidence

Fresh validation is for `cd1f7612c7dd16f00671f85911736a610752ea2d`, rebased patch-identically onto main containing #140974, #140997, and #141148.

- Focused approval and WhatsApp ingress suites: 44 files, 512 tests passed. Concrete approval test files were passed to `node scripts/run-vitest.mjs`, including `extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts`.
- Boundary proof uses real SQLite ingress queues and settlement paths with a mocked Gateway. It covers transient fast-path failure, batch sibling preservation, claim release/replay, completion tombstones, concurrent resolution, and terminal-card-update failures. The original WhatsApp regression previously failed for the intended swallowed-Gateway-503 defect.
- `node scripts/check-changed.mjs` passed ratchets, formatting, SDK checks, core/plugin production and test types, declaration/deprecation checks, all three dead-export scans (zero entries), and core lint. Local plugin lint reaches the documented nested-worktree `Declaration input escapes checkout` exception for ancestor `punycode/package.json`; exact-head hosted lint, typechecks, and extension package-boundary checks passed.
- The SDK surface check passes against current main: 4,447 public exports and 2,631 callables; this PR changes no budget.
- Fresh isolated Codex branch review: zero actionable P0–P2 findings.

`pnpm build` passed in 6m28s, and `pnpm plugin-sdk:surface:check` passed. Isolated iMessage, Signal, and WhatsApp startup profiles passed with zero failures/timeouts (peak RSS 99.16, 98.83, and 98.28 MiB). Exact-head hosted CI passed: https://github.com/openclaw/openclaw/actions/runs/34119401075. The required `openclaw/ci-gate` is green, and native prepare completed on the unchanged reviewed head. The earlier CI hold was caused by unrelated tests whose fixes are now in the base.

Live transport proof is unavailable. The SQLite/mock-Gateway harness is the available boundary proof; it is not a live channel test.
