### PR TITLE
fix(agents): keep image history stable during tool loops

### DIFF
--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -91,6 +91,7 @@ Only `toolResult` messages are eligible; normal conversation text is left alone.
 OpenClaw also builds a separate idempotent replay view for sessions that persist raw image blocks or prompt-hydration media markers in history.
 
 - It preserves the **3 most recent completed turns** byte-for-byte so prompt cache prefixes for recent follow-ups stay stable. This count includes all completed turns, not just image-bearing ones, so text-only turns consume the window too.
+- The window advances only when a new user turn begins, never within a tool loop.
 - In the replay view, older already-processed image blocks from `user` or `toolResult` history are replaced with `[image data removed - already processed by model]`.
 - Older textual media references such as `[media attached: ...]`, `[Image: source: ...]`, and `media://inbound/...` are replaced with `[media reference removed - already processed by model]`. Current-turn attachment markers stay intact so vision models can still hydrate fresh images.
 - The raw session transcript is not rewritten, so history viewers can still render the original message entries and their images.

--- a/src/agents/embedded-agent-runner/run/history-image-prune.test.ts
+++ b/src/agents/embedded-agent-runner/run/history-image-prune.test.ts
@@ -77,7 +77,7 @@ function expectImageMessagePreserved(messages: AgentMessage[], errorMessage: str
 }
 
 function oldEnoughTail(): AgentMessage[] {
-  // Four assistant turns makes the first message old enough to prune while
+  // Four prior completed turns make the first message old enough to prune while
   // keeping each test focused on content rewriting instead of turn counting.
   const assistantTurn = () => castAgentMessage({ role: "assistant", content: "ack" });
   const userText = () => castAgentMessage({ role: "user", content: "more" });
@@ -89,6 +89,7 @@ function oldEnoughTail(): AgentMessage[] {
     assistantTurn(),
     userText(),
     assistantTurn(),
+    userText(),
   ];
 }
 
@@ -97,19 +98,13 @@ describe("pruneProcessedHistoryImages", () => {
   const assistantTurn = () => castAgentMessage({ role: "assistant", content: "ack" });
   const userText = () => castAgentMessage({ role: "user", content: "more" });
 
-  it("prunes image blocks from user messages older than 3 assistant turns", () => {
+  it("prunes image blocks from user messages older than 3 completed turns", () => {
     const messages: AgentMessage[] = [
       castAgentMessage({
         role: "user",
         content: [{ type: "text", text: "See /tmp/photo.png" }, { ...image }],
       }),
-      assistantTurn(),
-      userText(),
-      assistantTurn(),
-      userText(),
-      assistantTurn(),
-      userText(),
-      assistantTurn(),
+      ...oldEnoughTail(),
     ];
 
     const content = expectPrunedImageMessage(messages, "expected user array content");
@@ -431,7 +426,7 @@ describe("pruneProcessedHistoryImages", () => {
     expect(toolResult?.content).toBe(`previous ${PRUNED_HISTORY_MEDIA_REFERENCE_MARKER} result`);
   });
 
-  it("keeps image blocks that belong to the third-most-recent assistant turn", () => {
+  it("keeps image blocks that belong to the third-most-recent completed turn", () => {
     const messages: AgentMessage[] = [
       castAgentMessage({
         role: "user",
@@ -442,6 +437,7 @@ describe("pruneProcessedHistoryImages", () => {
       assistantTurn(),
       userText(),
       assistantTurn(),
+      userText(),
     ];
 
     expectImageMessagePreserved(messages, "expected user array content");
@@ -464,6 +460,7 @@ describe("pruneProcessedHistoryImages", () => {
       assistantTurn(),
       userText(),
       assistantTurn(),
+      userText(),
     ];
 
     const pruned = pruneProcessedHistoryImages(messages);
@@ -497,6 +494,7 @@ describe("pruneProcessedHistoryImages", () => {
       assistantTurn(),
       userText(),
       assistantTurn(),
+      userText(),
     ];
 
     expectImageMessagePreserved(messages, "expected user array content");
@@ -518,20 +516,63 @@ describe("pruneProcessedHistoryImages", () => {
     expectContentBlock(content[1], { type: "image", data: "abc" });
   });
 
-  it("prunes image blocks from toolResult messages older than 3 assistant turns", () => {
+  it.each([
+    { name: "image blocks", block: image, marker: PRUNED_HISTORY_IMAGE_MARKER },
+    {
+      name: "media references",
+      block: { type: "text", text: "[media attached: media://inbound/old.png]" },
+      marker: PRUNED_HISTORY_MEDIA_REFERENCE_MARKER,
+    },
+  ])("keeps $name byte-identical throughout the active tool loop", ({ block, marker }) => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: [{ type: "text", text: "look" }, block] }),
+      assistantTurn(),
+      userText(),
+      assistantTurn(),
+      userText(),
+      assistantTurn(),
+      userText(),
+    ];
+    const retainedLength = messages.length;
+    const retainedBytes = JSON.stringify(messages);
+    expect(pruneProcessedHistoryImages(messages)).toBeNull();
+
+    messages.push(
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_4", name: "read", arguments: {} }],
+      }),
+      castAgentMessage({
+        role: "toolResult",
+        toolCallId: "call_4",
+        toolName: "read",
+        content: [{ type: "text", text: "bytes" }],
+      }),
+    );
+    const duringLoop = pruneProcessedHistoryImages(messages) ?? messages;
+    expect(JSON.stringify(duringLoop.slice(0, retainedLength))).toBe(retainedBytes);
+    expect(expectArrayMessageContent(duringLoop[0], "expected retained content")[1]).toBe(block);
+
+    messages.push(assistantTurn());
+    expect(pruneProcessedHistoryImages(messages)).toBeNull();
+    messages.push(userText());
+    const nextTurn = expectPrunedMessages(messages);
+    expect(expectArrayMessageContent(nextTurn[0], "expected pruned content")[1]).toEqual({
+      type: "text",
+      text: marker,
+    });
+    expect(JSON.stringify(nextTurn.slice(2))).toBe(JSON.stringify(messages.slice(2)));
+    expect(JSON.stringify(messages.slice(0, retainedLength))).toBe(retainedBytes);
+  });
+
+  it("prunes image blocks from toolResult messages older than 3 completed turns", () => {
     const messages: AgentMessage[] = [
       castAgentMessage({
         role: "toolResult",
         toolName: "read",
         content: [{ type: "text", text: "screenshot bytes" }, { ...image }],
       }),
-      assistantTurn(),
-      userText(),
-      assistantTurn(),
-      userText(),
-      assistantTurn(),
-      userText(),
-      assistantTurn(),
+      ...oldEnoughTail(),
     ];
 
     expectPrunedImageMessage(messages, "expected toolResult array content");
@@ -553,6 +594,7 @@ describe("pruneProcessedHistoryImages", () => {
         content: [{ type: "text", text: "recent" }, { ...image }],
       }),
       assistantTurn(),
+      userText(),
     ];
 
     const pruned = expectPrunedMessages(messages);

--- a/src/agents/embedded-agent-runner/run/history-image-prune.ts
+++ b/src/agents/embedded-agent-runner/run/history-image-prune.ts
@@ -66,10 +66,8 @@ function resolvePruneBeforeIndex(messages: AgentMessage[]): number {
     }
   }
 
-  if (currentTurnStart >= 0 && currentTurnHasAssistantReply) {
-    completedTurnStarts.push(currentTurnStart);
-  }
-
+  // Only a later user message closes a turn; tool-loop replies must not move
+  // the cutoff and rewrite the warm prefix during the active turn.
   if (completedTurnStarts.length <= PRESERVE_RECENT_COMPLETED_TURNS) {
     return -1;
   }

--- a/src/gateway/server-methods/chat-send-user-turn.test.ts
+++ b/src/gateway/server-methods/chat-send-user-turn.test.ts
@@ -745,6 +745,8 @@ describe("prepareChatSendUserTurn", () => {
       { role: "user", content: "more" },
       { role: "assistant", content: "ack" },
     ] as unknown as Parameters<typeof pruneProcessedHistoryImages>[0];
+    expect(pruneProcessedHistoryImages(history)).toBeNull();
+    history.push({ role: "user", content: "next turn", timestamp: 5 });
     const pruned = pruneProcessedHistoryImages(history);
     const first = pruned?.[0] as unknown as Record<string, unknown> | undefined;
     expect(first?.content).toBe(
@@ -849,6 +851,8 @@ describe("prepareChatSendUserTurn", () => {
         { role: "user", content: "more" },
         { role: "assistant", content: "ack" },
       ] as unknown as Parameters<typeof pruneProcessedHistoryImages>[0];
+      expect(pruneProcessedHistoryImages(history)).toBeNull();
+      history.push({ role: "user", content: "next turn", timestamp: 5 });
       const pruned = pruneProcessedHistoryImages(history);
       const first = pruned?.[0] as unknown as Record<string, unknown> | undefined;
       expect(first?.content).toBe(


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users continuing a conversation with image history would lose a stable prompt-cache prefix when the assistant entered a tool loop. With three completed turns and an image in turn 1, the first request of turn 4 preserved that image, but the next request replaced it after a tool-call assistant message appeared. Media-reference text had the same defect.

## Why This Change Was Made

The shared history-cleanup owner now counts a prior answered turn only when a subsequent user message begins. Removing the end-of-history count keeps the active turn from advancing the cleanup window, including after its final assistant reply. The existing three-completed-turn retention window and replay-only cleanup remain intact.

The session-pruning documentation clarifies the user-turn boundary. Production code is +2/-4 lines; no new configuration, persistence, or provider-specific path is introduced.

## User Impact

Recent image blocks and media references stay byte-identical throughout tool-loop requests. Cleanup still removes turn 1's processed media once turn 5 begins, preserving the documented retention window while avoiding this source of mid-turn cache invalidation.

## Evidence

Before the fix, the new image and media-reference cases both failed at the retained-prefix byte comparison after a tool call/result; all 30 existing tests passed.

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/history-image-prune.test.ts src/agents/embedded-agent-runner/run/attempt-setup.test.ts
Test Files  2 passed (2)
Tests       51 passed (51)
Duration    201.43s; wrapper completed in 221.13s
```

The regression also verifies retention after the final assistant reply, cleanup at the next user message, preservation of newer turns, and an unchanged source transcript. Existing cleanup fixtures now explicitly begin the next user turn; no assertions or snapshots were weakened.

Codex autoreview against the branch merge base, through P1: `scoped-clean`, zero accepted/actionable findings. Final summary: "The change keeps the pruning cutoff stable throughout the active tool loop and advances it when a subsequent user turn begins. The updated tests cover this behavior for images and media references. No actionable P0 or P1 defects are evident in the supplied patch."

Proof covers replay bytes and the setup boundary; live provider cache-hit metrics were not measured.

`node scripts/check-changed.mjs`: PASS (exit 0), including formatting, core and core-test typechecking, changed-file lint, dead-export scans, and all selected repository guards. `git diff --check`: PASS.


The first CI run exposed two Gateway media-ownership fixtures that also needed the next user-turn boundary. Both now assert no pruning before that boundary and retain their original cleanup/ownership assertions afterward. The entire `src/gateway/server-methods/chat-send-user-turn.test.ts` file passed: **20 tests**, 459.05s.

That Gateway pass was the first phase of:

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/history-image-prune.test.ts src/agents/embedded-agent-runner/run/attempt-setup.test.ts src/gateway/server-methods/chat-send-user-turn.test.ts
```

The redundant embedded phase then stalled before test execution (idle process, no worker/assertion output for ten minutes) and was terminated; the combined rerun exited 143. The earlier **51-test pass** above covers the identical embedded source and tests. Fresh autoreview including the Gateway fixture changes is `scoped-clean`, with zero accepted/actionable findings through P1.

Final `node scripts/check-changed.mjs` rerun including the Gateway fixture update: **PASS (exit 0)**. Production LOC remains +2/-4; the additional Gateway proof is +4/-0.


Final exact-head CI: **GREEN**, [run 34079319344](https://github.com/openclaw/openclaw/actions/runs/34079319344), head `90d6174cbacb698040dfd0aae940bbbaf3b745be`. CI completed successfully with 108 successful jobs and 16 skipped jobs; the previously failing `checks-node-compact-large-3` passed. The bounded PR watcher returned `GREEN` with zero pending checks.
