### PR TITLE
fix: native declaration preparation fails from aliased checkouts

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -473,8 +473,10 @@ package manifests. Local pnpm links remain supported when their targets stay
 inside the checkout. The tsgo wrapper does not create or reuse a shared external
 install; invocations from subdirectories still use the containing checkout as
 the ownership boundary. Declared checkout junctions and platform path aliases map
-to the same native root for validation and actual snapshot reads. Native resolution
-itself is not sandboxed: an ancestor install can still enter a successful compiler
+to the same native root for validation and actual snapshot reads. Local declaration
+preparation also aligns the compiler's `PWD` with its working directory so shell
+aliases do not change emitted inventory paths. Native resolution itself is not
+sandboxed: an ancestor install can still enter a successful compiler
 receipt. Resolution can read an ancestor's candidate `package.json` while searching
 for declarations, then resolve the import to checkout-local JavaScript. This can
 happen with a complete local frozen install and no external source files in the

--- a/scripts/prepare-extension-package-boundary-artifacts.mts
+++ b/scripts/prepare-extension-package-boundary-artifacts.mts
@@ -224,6 +224,8 @@ async function runTsgoSteps(steps: NodeStep[]) {
           {
             ...step,
             ...command,
+            // Go honors PWD aliases; emitted paths must use this owner's actual cwd.
+            env: { ...command.env, PWD: repoRoot },
             timeoutMs: Math.min(step.timeoutMs, command.timeoutMs ?? step.timeoutMs),
           },
         ]

--- a/test/scripts/prepare-extension-package-boundary-artifacts.native.test.ts
+++ b/test/scripts/prepare-extension-package-boundary-artifacts.native.test.ts
@@ -90,38 +90,53 @@ function createPreparationFixture(mode: "package-boundary" | "all", signal: Abor
   }
   const recordPath = path.join(root, ".artifacts/extension-package-boundary/plugin-sdk.json");
   const output = "packages/plugin-sdk/dist";
-  const step = async (label: string, args: string[], bin?: string) => {
+  const step = async (label: string, args: string[], bin?: string, env?: NodeJS.ProcessEnv) => {
     signal.throwIfAborted();
     // Expected compiler failures cancel only their own invocation, not later repair phases.
     const abortController = new AbortController();
     const abort = () => abortController.abort(signal.reason);
     signal.addEventListener("abort", abort, { once: true });
     try {
-      await fixture.track(runNodeStep(label, args, 30_000, { bin, abortController }));
+      await fixture.track(runNodeStep(label, args, 30_000, { bin, env, abortController }));
       signal.throwIfAborted();
     } finally {
       signal.removeEventListener("abort", abort);
     }
   };
-  const run = (declared = root) =>
-    step("native-fixture", [
-      path.join(declared, "scripts/prepare-extension-package-boundary-artifacts.mts"),
-      `--mode=${mode}`,
-    ]);
+  const run = (declared = root, pwd = declared) =>
+    step(
+      "native-fixture",
+      [
+        path.join(declared, "scripts/prepare-extension-package-boundary-artifacts.mts"),
+        `--mode=${mode}`,
+      ],
+      undefined,
+      { PWD: pwd },
+    );
   return { ancestor, root, native, write, plugins, recordPath, output, step, run };
 }
 
 describe("native declaration preparation", () => {
-  it.runIf(process.platform === "win32").for([
-    { name: "short entry", entry: true, workspace: false },
-    { name: "workspace junction", entry: false, workspace: true },
-    { name: "short entry and workspace junction", entry: true, workspace: true },
+  it.for([
+    { name: "Windows 8.3 short entry", entry: true, workspace: false },
+    { name: "Windows 8.3 workspace junction", entry: false, workspace: true },
+    { name: "Windows 8.3 short entry and workspace junction", entry: true, workspace: true },
+    { name: "POSIX PWD alias (package-boundary)", mode: "package-boundary" as const },
+    { name: "POSIX PWD alias (all)", mode: "all" as const },
   ])(
-    "publishes cold native output and reuses warm receipts through Windows 8.3 $name",
+    "publishes cold native output and reuses warm receipts through $name",
     { timeout: 30_000 },
-    ({ entry, workspace }, context) => {
-      const f = createPreparationFixture("package-boundary", context.signal);
+    ({ entry, workspace, mode }, context) => {
+      if (mode ? process.platform === "win32" : process.platform !== "win32") {
+        return context.skip("Checkout alias is specific to another platform");
+      }
+      const f = createPreparationFixture(mode ?? "package-boundary", context.signal);
       let declared = f.root;
+      if (mode) {
+        declared = path.join(f.ancestor, "declared-alias");
+        fs.symlinkSync(f.root, declared, "dir");
+        expect(fs.realpathSync.native(declared)).toBe(f.root);
+      }
       if (entry) {
         const short = resolveNativeFixtureShortPath(f.root);
         if (!short) {
@@ -144,7 +159,10 @@ describe("native declaration preparation", () => {
         expect(fs.realpathSync.native(link)).toBe(sdk);
       }
       return fixture.run(async () => {
-        const cold = await f.run(declared).catch((error: unknown) => error);
+        // Relative CLI entry paths use Node's physical cwd while Go can retain shell PWD.
+        const cold = await f
+          .run(mode ? f.root : declared, declared)
+          .catch((error: unknown) => error);
         const declaration = path.join(f.root, f.output, "src/nested.d.ts");
         const metadata = path.join(f.root, f.output, ".tsbuildinfo");
         // Even the failing-before case must reach real native emit, not fail during setup.
@@ -155,18 +173,34 @@ describe("native declaration preparation", () => {
         expect(receipt.fileInfos.length).toBeGreaterThan(0);
         expect(receipt.fileNames.some((file) => file.endsWith("/src/nested.ts"))).toBe(true);
         expect(cold).toBeUndefined();
-        const record = readArtifactRecord(f.recordPath);
-        expect(record?.inputs).toContain("src/nested.ts");
-        expect(record?.outputs[`${f.output}/src/nested.d.ts`]).toBeDefined();
-        const artifacts = [f.recordPath, declaration, metadata].map((file) => ({
-          file,
-          bytes: fs.readFileSync(file),
-          mtimeMs: fs.statSync(file).mtimeMs,
-        }));
-        await f.run(declared);
-        for (const artifact of artifacts) {
-          expect(fs.readFileSync(artifact.file)).toEqual(artifact.bytes);
-          expect(fs.statSync(artifact.file).mtimeMs).toBe(artifact.mtimeMs);
+        expect(readArtifactRecord(f.recordPath)?.inputs).toContain("src/nested.ts");
+        const owners = [
+          {
+            recordPath: f.recordPath,
+            output: f.output,
+            files: [".tsbuildinfo", "src/nested.d.ts", "src/plugin-sdk/core.d.ts"],
+          },
+          ...f.plugins.map(([id, pluginEntry]) => ({
+            recordPath: path.join(f.root, `.artifacts/extension-package-boundary/${id}.json`),
+            output: `.artifacts/extension-package-boundary/plugins/${id}`,
+            files: [".tsbuildinfo", `${pluginEntry}.d.ts`],
+          })),
+        ];
+        const artifacts = owners.flatMap((owner) => {
+          const outputs = owner.files.map((file) => `${owner.output}/${file}`);
+          expect(Object.keys(readArtifactRecord(owner.recordPath)!.outputs).toSorted()).toEqual(
+            outputs.toSorted(),
+          );
+          return [owner.recordPath, ...outputs.map((file) => path.join(f.root, file))].map(
+            (file) => ({ file, bytes: fs.readFileSync(file), mtimeMs: fs.statSync(file).mtimeMs }),
+          );
+        });
+        for (const spelling of [declared, f.root]) {
+          await f.run(mode ? f.root : spelling, spelling);
+          for (const artifact of artifacts) {
+            expect(fs.readFileSync(artifact.file)).toEqual(artifact.bytes);
+            expect(fs.statSync(artifact.file).mtimeMs).toBe(artifact.mtimeMs);
+          }
         }
       });
     },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running local plugin declaration preparation from an aliased checkout would receive `Incomplete plugin-sdk native declaration inventory` even though the native compiler had emitted successfully. A cold, independently installed source snapshot reproduced this through macOS `/var/...`; the same snapshot passed through `/private/var/...` without source or dependency changes. Downstream extension lint was blocked by the failed preparation.

## Why This Change Was Made

The native compiler honors a valid inherited `PWD`, while the preparer uses the canonical checkout path as its working directory and inventory owner. An alias-spelled `PWD` therefore produces different `TSFILE` inventory keys. Set only the preparation child's `PWD` to its existing working directory, preserving the rest of the prepared environment.

Keep complete native inventories, checkout containment, input receipts, process ownership, and success-before-pruning checks unchanged. Do not broadly realpath arbitrary output paths or filter away mismatches. Extend the existing native cold/warm fixture to cover both preparation modes through a POSIX alias, and document the working-directory contract. This is separate from ancestor-install diagnostics and declaration-preparation timeout work.

## User Impact

Source-checkout developers can prepare declarations and run dependent plugin lint through a valid checkout alias. Cold and warm invocations agree on output identity; packaged runtime behavior and configuration do not change.

## Evidence

- Independently installed macOS snapshot at `d2c9a798f96`: alias cold failed after successful native emit; canonical cold passed with 8,826 outputs. Changing only `PWD` in a real native-compiler probe reproduced the path spelling difference with both the macOS alias and an ordinary directory symlink.
- Patched snapshot: alias cold produced exactly the same 8,826 output paths and hashes as the canonical control. Both alias and canonical warm invocations reused the receipt without rewriting artifacts. Downstream extension lint and `pnpm build` passed.
- Both new regression cases demonstrably failed at the inventory check on the original implementation after real declaration/build-info files existed, then passed with the fix. Focused native preparation, native receipt/containment, and preparation lifecycle suites: 37 passed; 6 Windows-only cases skipped on macOS.
- Repository changed-file checks and final isolated independent review passed. One test variable-shadowing lint error was corrected before the final checks.
- Refreshed candidate `207a8175fabb425ed42c972cb631c9f9ce1d1cf4`: the documentation conflict was resolved while preserving current main's complete ancestor-install diagnosis/provisioning guidance. Production and test changes are unchanged. Refreshed local suites passed 38 tests with 6 Windows-only skips; changed-file checks and independent review passed.
- [Crabbox-backed Blacksmith Testbox proof](https://github.com/openclaw/openclaw/actions/runs/34076803704), provider `blacksmith-testbox`, lease `tbx_01m1wvhgye1b1pqwk06g7yft3n`, Linux/Node 24.19.0: verified the refreshed candidate's exact source tree, created an owned source snapshot, and ran its frozen install. The original preparer failed through a directory alias after native emission; the canonical control passed. The patched alias cold run matched all **8,831 output paths and hashes** on this newer source revision.
- Both remote warm spellings skipped emission and preserved every output/receipt timestamp and the receipt bytes. Real downstream extension lint passed, followed by the three native/lifecycle suites: **38 passed, 6 Windows-only skips**. Crabbox's command receipt reports `exitCode: 0`, `runStatus: succeeded`; the owned fixture and lease were removed. The backing Actions session may show cancellation from normal one-shot lease cleanup, not a failed payload.

The first remote attempt stopped before compilation because the proof harness compared the source revision with Crabbox's synthetic transport commit. The harness now binds the verified transport tree to the exact candidate, and the successful rerun used a fresh lease. No product checks were relaxed.
