### PR TITLE
fix: keep Grok token discovery on the subscription route

### DIFF
--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -113,6 +113,13 @@ subscription quota are separate billing buckets.
 - xAI decides which accounts can receive OAuth API tokens. If an account is
   not eligible, use the API-key path or check the subscription on xAI's side.
 
+For a manually managed Grok subscription token, set `models.providers.xai.auth`
+to `"token"` and `models.providers.xai.baseUrl` to
+`https://cli-chat-proxy.grok.com/v1`. Model discovery uses the subscription
+catalog and keeps token authentication; an unavailable token does not switch
+discovery to the Console API. Tokens with the default or native xAI API endpoint
+continue to use the API catalog. Prefer OAuth login for automatic token refresh.
+
 <Tip>
 Use `xai-oauth` when signing in from SSH, Docker, or a VPS. OpenClaw prints a
 URL and short code; finish sign-in in any local browser while the remote

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -119,6 +119,8 @@ to `"token"` and `models.providers.xai.baseUrl` to
 catalog and keeps token authentication; an unavailable token does not switch
 discovery to the Console API. Tokens with the default or native xAI API endpoint
 continue to use the API catalog. Prefer OAuth login for automatic token refresh.
+Resolved environment-backed tokens also work in standalone model commands without
+a running Gateway.
 
 <Tip>
 Use `xai-oauth` when signing in from SSH, Docker, or a VPS. OpenClaw prints a

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -289,98 +289,132 @@ describe("xai provider plugin", () => {
       baseUrl: "https://cli-chat-proxy.grok.com/v1",
       subscription: true,
       resolves: true,
+      prepared: true,
     },
     {
       route: "Grok proxy with trailing slash",
       baseUrl: "https://cli-chat-proxy.grok.com/v1/",
       subscription: true,
       resolves: true,
+      prepared: true,
     },
     {
       route: "equivalent Grok proxy URL",
       baseUrl: "https://CLI-CHAT-PROXY.GROK.COM:443/v1/",
       subscription: true,
       resolves: true,
+      prepared: true,
     },
-    { route: "native API", baseUrl: "https://api.x.ai/v1", subscription: false, resolves: true },
-    { route: "default API", baseUrl: undefined, subscription: false, resolves: true },
+    {
+      route: "native API",
+      baseUrl: "https://api.x.ai/v1",
+      subscription: false,
+      resolves: true,
+      prepared: true,
+    },
+    {
+      route: "default API",
+      baseUrl: undefined,
+      subscription: false,
+      resolves: true,
+      prepared: true,
+    },
     {
       route: "unavailable Grok token",
       baseUrl: "https://cli-chat-proxy.grok.com/v1",
       subscription: true,
       resolves: false,
+      prepared: false,
     },
     {
       route: "unavailable token at an equivalent Grok proxy URL",
       baseUrl: "https://CLI-CHAT-PROXY.GROK.COM:443/v1/",
       subscription: true,
       resolves: false,
+      prepared: false,
     },
-  ])("keeps token catalog discovery on the $route", async ({ baseUrl, subscription, resolves }) => {
-    const apiKey = "selected-xai-token";
-    const profileId = "xai:selected-token";
-    providerAuthRuntimeMocks.resolveApiKeyForProvider.mockResolvedValue({
-      apiKey,
-      mode: "token",
-      profileId,
-      source: `profile:${profileId}`,
-    });
-    if (!resolves) {
-      providerAuthRuntimeMocks.resolveApiKeyForProvider.mockRejectedValue(
-        new Error("Token unavailable"),
-      );
-    }
-    const fetchMock = stubXaiFetch((url) =>
-      Response.json(
-        url.endsWith("/settings")
-          ? { default_model: "grok-4.3" }
-          : { data: [{ id: "grok-4.3", api_backend: "responses" }] },
-      ),
-    );
-    const provider = await registerSingleProviderPlugin(plugin);
-    const result = await provider.catalog?.run({
-      config: baseUrl
-        ? { models: { providers: { xai: { baseUrl, auth: "token", models: [] } } } }
-        : {},
-      env: {},
-      resolveProviderAuth: () => ({
+    {
+      route: "cold prepared Grok token",
+      baseUrl: "https://cli-chat-proxy.grok.com/v1",
+      subscription: true,
+      resolves: false,
+      prepared: true,
+    },
+    {
+      route: "runtime-materialized Grok token",
+      baseUrl: "https://cli-chat-proxy.grok.com/v1",
+      subscription: true,
+      resolves: true,
+      prepared: false,
+    },
+  ])(
+    "keeps token catalog discovery on the $route",
+    async ({ baseUrl, subscription, resolves, prepared }) => {
+      const apiKey = "selected-xai-token";
+      const profileId = "xai:selected-token";
+      providerAuthRuntimeMocks.resolveApiKeyForProvider.mockResolvedValue({
         apiKey,
-        discoveryApiKey: apiKey,
         mode: "token",
         profileId,
-        source: "profile",
-      }),
-      resolveProviderApiKey: () => ({ apiKey: "unselected-api-key" }),
-    });
-    if (!resolves) {
-      expect(result).toEqual({
-        providers: {},
-        outcomes: [{ provider: "xai", profileId, status: "unavailable" }],
+        source: `profile:${profileId}`,
       });
-      expect(fetchMock).not.toHaveBeenCalled();
-      return;
-    }
-    if (!result || !("provider" in result)) {
-      throw new Error("expected xAI token catalog");
-    }
-    const expectedBaseUrl = subscription
-      ? "https://cli-chat-proxy.grok.com/v1"
-      : "https://api.x.ai/v1";
-    expect(result.provider.baseUrl).toBe(expectedBaseUrl);
-    expect(result.provider.auth).toBe(subscription ? "token" : undefined);
-    const requestedUrls = fetchMock.mock.calls.map(([input]) =>
-      typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
-    );
-    expect(requestedUrls.toSorted((left, right) => left.localeCompare(right))).toEqual(
-      (subscription
-        ? [`${expectedBaseUrl}/models`, `${expectedBaseUrl}/settings`]
-        : [`${expectedBaseUrl}/models`]
-      ).toSorted((left, right) => left.localeCompare(right)),
-    );
-    for (const [, init] of fetchMock.mock.calls) {
-      expect(new Headers(init?.headers).get("Authorization")).toBe(`Bearer ${apiKey}`);
-    }
-  });
+      if (!resolves) {
+        providerAuthRuntimeMocks.resolveApiKeyForProvider.mockRejectedValue(
+          new Error("Token unavailable"),
+        );
+      }
+      const fetchMock = stubXaiFetch((url) =>
+        Response.json(
+          url.endsWith("/settings")
+            ? { default_model: "grok-4.3" }
+            : { data: [{ id: "grok-4.3", api_backend: "responses" }] },
+        ),
+      );
+      const provider = await registerSingleProviderPlugin(plugin);
+      const result = await provider.catalog?.run({
+        config: baseUrl
+          ? { models: { providers: { xai: { baseUrl, auth: "token", models: [] } } } }
+          : {},
+        env: {},
+        resolveProviderAuth: () => ({
+          apiKey: prepared ? apiKey : "MISSING_GROK_TOKEN",
+          discoveryApiKey: prepared ? apiKey : undefined,
+          mode: "token",
+          profileId,
+          source: "profile",
+        }),
+        resolveProviderApiKey: () => ({ apiKey: "unselected-api-key" }),
+      });
+      if (!resolves && !prepared) {
+        expect(result).toEqual({
+          providers: {},
+          outcomes: [{ provider: "xai", profileId, status: "unavailable" }],
+        });
+        expect(fetchMock).not.toHaveBeenCalled();
+        return;
+      }
+      if (!result || !("provider" in result)) {
+        throw new Error("expected xAI token catalog");
+      }
+      const expectedBaseUrl = subscription
+        ? "https://cli-chat-proxy.grok.com/v1"
+        : "https://api.x.ai/v1";
+      expect(result.provider.baseUrl).toBe(expectedBaseUrl);
+      expect(result.provider.auth).toBe(subscription ? "token" : undefined);
+      const requestedUrls = fetchMock.mock.calls.map(([input]) =>
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
+      );
+      expect(requestedUrls.toSorted((left, right) => left.localeCompare(right))).toEqual(
+        (subscription
+          ? [`${expectedBaseUrl}/models`, `${expectedBaseUrl}/settings`]
+          : [`${expectedBaseUrl}/models`]
+        ).toSorted((left, right) => left.localeCompare(right)),
+      );
+      for (const [, init] of fetchMock.mock.calls) {
+        expect(new Headers(init?.headers).get("Authorization")).toBe(`Bearer ${apiKey}`);
+      }
+    },
+  );
 
   it("uses the Grok OAuth proxy catalog for xAI OAuth discovery", async () => {
     mockXaiRuntimeOAuth();

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -288,36 +288,26 @@ describe("xai provider plugin", () => {
       route: "Grok proxy",
       baseUrl: "https://cli-chat-proxy.grok.com/v1",
       subscription: true,
-      resolves: true,
-      prepared: true,
     },
     {
       route: "Grok proxy with trailing slash",
       baseUrl: "https://cli-chat-proxy.grok.com/v1/",
       subscription: true,
-      resolves: true,
-      prepared: true,
     },
     {
       route: "equivalent Grok proxy URL",
       baseUrl: "https://CLI-CHAT-PROXY.GROK.COM:443/v1/",
       subscription: true,
-      resolves: true,
-      prepared: true,
     },
     {
       route: "native API",
       baseUrl: "https://api.x.ai/v1",
       subscription: false,
-      resolves: true,
-      prepared: true,
     },
     {
       route: "default API",
       baseUrl: undefined,
       subscription: false,
-      resolves: true,
-      prepared: true,
     },
     {
       route: "unavailable Grok token",
@@ -338,18 +328,16 @@ describe("xai provider plugin", () => {
       baseUrl: "https://cli-chat-proxy.grok.com/v1",
       subscription: true,
       resolves: false,
-      prepared: true,
     },
     {
       route: "runtime-materialized Grok token",
       baseUrl: "https://cli-chat-proxy.grok.com/v1",
       subscription: true,
-      resolves: true,
       prepared: false,
     },
   ])(
     "keeps token catalog discovery on the $route",
-    async ({ baseUrl, subscription, resolves, prepared }) => {
+    async ({ baseUrl, subscription, resolves = true, prepared = true }) => {
       const apiKey = "selected-xai-token";
       const profileId = "xai:selected-token";
       providerAuthRuntimeMocks.resolveApiKeyForProvider.mockResolvedValue({

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -296,11 +296,23 @@ describe("xai provider plugin", () => {
       subscription: true,
       resolves: true,
     },
+    {
+      route: "equivalent Grok proxy URL",
+      baseUrl: "https://CLI-CHAT-PROXY.GROK.COM:443/v1/",
+      subscription: true,
+      resolves: true,
+    },
     { route: "native API", baseUrl: "https://api.x.ai/v1", subscription: false, resolves: true },
     { route: "default API", baseUrl: undefined, subscription: false, resolves: true },
     {
       route: "unavailable Grok token",
       baseUrl: "https://cli-chat-proxy.grok.com/v1",
+      subscription: true,
+      resolves: false,
+    },
+    {
+      route: "unavailable token at an equivalent Grok proxy URL",
+      baseUrl: "https://CLI-CHAT-PROXY.GROK.COM:443/v1/",
       subscription: true,
       resolves: false,
     },
@@ -356,11 +368,14 @@ describe("xai provider plugin", () => {
       : "https://api.x.ai/v1";
     expect(result.provider.baseUrl).toBe(expectedBaseUrl);
     expect(result.provider.auth).toBe(subscription ? "token" : undefined);
-    expect(fetchMock.mock.calls.map(([url]) => url).toSorted()).toEqual(
+    const requestedUrls = fetchMock.mock.calls.map(([input]) =>
+      typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
+    );
+    expect(requestedUrls.toSorted((left, right) => left.localeCompare(right))).toEqual(
       (subscription
         ? [`${expectedBaseUrl}/models`, `${expectedBaseUrl}/settings`]
         : [`${expectedBaseUrl}/models`]
-      ).toSorted(),
+      ).toSorted((left, right) => left.localeCompare(right)),
     );
     for (const [, init] of fetchMock.mock.calls) {
       expect(new Headers(init?.headers).get("Authorization")).toBe(`Bearer ${apiKey}`);

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -283,6 +283,90 @@ describe("xai provider plugin", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    {
+      route: "Grok proxy",
+      baseUrl: "https://cli-chat-proxy.grok.com/v1",
+      subscription: true,
+      resolves: true,
+    },
+    {
+      route: "Grok proxy with trailing slash",
+      baseUrl: "https://cli-chat-proxy.grok.com/v1/",
+      subscription: true,
+      resolves: true,
+    },
+    { route: "native API", baseUrl: "https://api.x.ai/v1", subscription: false, resolves: true },
+    { route: "default API", baseUrl: undefined, subscription: false, resolves: true },
+    {
+      route: "unavailable Grok token",
+      baseUrl: "https://cli-chat-proxy.grok.com/v1",
+      subscription: true,
+      resolves: false,
+    },
+  ])("keeps token catalog discovery on the $route", async ({ baseUrl, subscription, resolves }) => {
+    const apiKey = "selected-xai-token";
+    const profileId = "xai:selected-token";
+    providerAuthRuntimeMocks.resolveApiKeyForProvider.mockResolvedValue({
+      apiKey,
+      mode: "token",
+      profileId,
+      source: `profile:${profileId}`,
+    });
+    if (!resolves) {
+      providerAuthRuntimeMocks.resolveApiKeyForProvider.mockRejectedValue(
+        new Error("Token unavailable"),
+      );
+    }
+    const fetchMock = stubXaiFetch((url) =>
+      Response.json(
+        url.endsWith("/settings")
+          ? { default_model: "grok-4.3" }
+          : { data: [{ id: "grok-4.3", api_backend: "responses" }] },
+      ),
+    );
+    const provider = await registerSingleProviderPlugin(plugin);
+    const result = await provider.catalog?.run({
+      config: baseUrl
+        ? { models: { providers: { xai: { baseUrl, auth: "token", models: [] } } } }
+        : {},
+      env: {},
+      resolveProviderAuth: () => ({
+        apiKey,
+        discoveryApiKey: apiKey,
+        mode: "token",
+        profileId,
+        source: "profile",
+      }),
+      resolveProviderApiKey: () => ({ apiKey: "unselected-api-key" }),
+    });
+    if (!resolves) {
+      expect(result).toEqual({
+        providers: {},
+        outcomes: [{ provider: "xai", profileId, status: "unavailable" }],
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+      return;
+    }
+    if (!result || !("provider" in result)) {
+      throw new Error("expected xAI token catalog");
+    }
+    const expectedBaseUrl = subscription
+      ? "https://cli-chat-proxy.grok.com/v1"
+      : "https://api.x.ai/v1";
+    expect(result.provider.baseUrl).toBe(expectedBaseUrl);
+    expect(result.provider.auth).toBe(subscription ? "token" : undefined);
+    expect(fetchMock.mock.calls.map(([url]) => url).toSorted()).toEqual(
+      (subscription
+        ? [`${expectedBaseUrl}/models`, `${expectedBaseUrl}/settings`]
+        : [`${expectedBaseUrl}/models`]
+      ).toSorted(),
+    );
+    for (const [, init] of fetchMock.mock.calls) {
+      expect(new Headers(init?.headers).get("Authorization")).toBe(`Bearer ${apiKey}`);
+    }
+  });
+
   it("uses the Grok OAuth proxy catalog for xAI OAuth discovery", async () => {
     mockXaiRuntimeOAuth();
     const fetchMock = stubXaiFetch((url) => {

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -26,7 +26,7 @@ import {
   buildLiveXaiOAuthProvider,
   buildLiveXaiProvider,
   buildXaiProvider,
-  XAI_GROK_OAUTH_BASE_URL,
+  isXaiGrokProxyBaseUrl,
 } from "./provider-catalog.js";
 import { isXaiProviderId } from "./provider-id.js";
 import {
@@ -224,8 +224,7 @@ export default defineSingleProviderPluginEntry({
         // Static token storage does not distinguish subscription tokens from Console API tokens.
         const subscriptionToken =
           (runtimeAuth?.mode === "token" || auth.mode === "token") &&
-          ctx.config.models?.providers?.[PROVIDER_ID]?.baseUrl?.trim().replace(/\/+$/u, "") ===
-            XAI_GROK_OAUTH_BASE_URL;
+          isXaiGrokProxyBaseUrl(ctx.config.models?.providers?.[PROVIDER_ID]?.baseUrl);
         if (subscriptionToken && (!runtimeAuth?.apiKey || runtimeAuth.mode !== "token")) {
           return {
             providers: {},

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -26,6 +26,7 @@ import {
   buildLiveXaiOAuthProvider,
   buildLiveXaiProvider,
   buildXaiProvider,
+  XAI_GROK_OAUTH_BASE_URL,
 } from "./provider-catalog.js";
 import { isXaiProviderId } from "./provider-id.js";
 import {
@@ -220,8 +221,19 @@ export default defineSingleProviderPluginEntry({
           // Prepared direct auth must not reopen failed profile candidates.
           ...(!auth.profileId && auth.mode !== "none" ? { allowAuthProfileFallback: false } : {}),
         }).catch(() => undefined);
+        // Static token storage does not distinguish subscription tokens from Console API tokens.
+        const subscriptionToken =
+          (runtimeAuth?.mode === "token" || auth.mode === "token") &&
+          ctx.config.models?.providers?.[PROVIDER_ID]?.baseUrl?.trim().replace(/\/+$/u, "") ===
+            XAI_GROK_OAUTH_BASE_URL;
+        if (subscriptionToken && (!runtimeAuth?.apiKey || runtimeAuth.mode !== "token")) {
+          return {
+            providers: {},
+            outcomes: [{ provider: PROVIDER_ID, profileId: auth.profileId, status: "unavailable" }],
+          };
+        }
         const selectedAuth =
-          runtimeAuth?.mode === "oauth" && runtimeAuth.apiKey
+          runtimeAuth?.apiKey && (runtimeAuth.mode === "oauth" || subscriptionToken)
             ? { ...runtimeAuth, oauth: true }
             : { ...(auth.apiKey ? auth : ctx.resolveProviderApiKey(PROVIDER_ID)), oauth: false };
         if (!selectedAuth.apiKey) {
@@ -233,7 +245,10 @@ export default defineSingleProviderPluginEntry({
           profileId: selectedAuth.profileId,
           run: async () => ({
             provider: selectedAuth.oauth
-              ? await buildLiveXaiOAuthProvider({ discoveryApiKey: apiKey })
+              ? await buildLiveXaiOAuthProvider({
+                  discoveryApiKey: apiKey,
+                  authMode: selectedAuth.mode === "token" ? "token" : "oauth",
+                })
               : await buildLiveXaiProvider(selectedAuth),
           }),
         });

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -212,28 +212,36 @@ export default defineSingleProviderPluginEntry({
         }
         const { resolveApiKeyForProvider } =
           await import("openclaw/plugin-sdk/provider-auth-runtime");
-        const runtimeAuth = await resolveApiKeyForProvider({
-          provider: PROVIDER_ID,
-          cfg: ctx.config,
-          ...(ctx.agentDir ? { agentDir: ctx.agentDir } : {}),
-          ...(ctx.workspaceDir ? { workspaceDir: ctx.workspaceDir } : {}),
-          ...(auth.profileId ? { profileId: auth.profileId, lockedProfile: true } : {}),
-          // Prepared direct auth must not reopen failed profile candidates.
-          ...(!auth.profileId && auth.mode !== "none" ? { allowAuthProfileFallback: false } : {}),
-        }).catch(() => undefined);
+        const grokProxy = isXaiGrokProxyBaseUrl(
+          ctx.config.models?.providers?.[PROVIDER_ID]?.baseUrl,
+        );
+        // Static token material can already be ready in a cold command or worker.
+        const resolvedAuth =
+          auth.mode === "token" && grokProxy && auth.discoveryApiKey
+            ? { ...auth, apiKey: auth.discoveryApiKey }
+            : await resolveApiKeyForProvider({
+                provider: PROVIDER_ID,
+                cfg: ctx.config,
+                ...(ctx.agentDir ? { agentDir: ctx.agentDir } : {}),
+                ...(ctx.workspaceDir ? { workspaceDir: ctx.workspaceDir } : {}),
+                ...(auth.profileId ? { profileId: auth.profileId, lockedProfile: true } : {}),
+                // Prepared direct auth must not reopen failed profile candidates.
+                ...(!auth.profileId && auth.mode !== "none"
+                  ? { allowAuthProfileFallback: false }
+                  : {}),
+              }).catch(() => undefined);
         // Static token storage does not distinguish subscription tokens from Console API tokens.
         const subscriptionToken =
-          (runtimeAuth?.mode === "token" || auth.mode === "token") &&
-          isXaiGrokProxyBaseUrl(ctx.config.models?.providers?.[PROVIDER_ID]?.baseUrl);
-        if (subscriptionToken && (!runtimeAuth?.apiKey || runtimeAuth.mode !== "token")) {
+          (resolvedAuth?.mode === "token" || auth.mode === "token") && grokProxy;
+        if (subscriptionToken && (!resolvedAuth?.apiKey || resolvedAuth.mode !== "token")) {
           return {
             providers: {},
             outcomes: [{ provider: PROVIDER_ID, profileId: auth.profileId, status: "unavailable" }],
           };
         }
         const selectedAuth =
-          runtimeAuth?.apiKey && (runtimeAuth.mode === "oauth" || subscriptionToken)
-            ? { ...runtimeAuth, oauth: true }
+          resolvedAuth?.apiKey && (resolvedAuth.mode === "oauth" || subscriptionToken)
+            ? { ...resolvedAuth, oauth: true }
             : { ...(auth.apiKey ? auth : ctx.resolveProviderApiKey(PROVIDER_ID)), oauth: false };
         if (!selectedAuth.apiKey) {
           return null;

--- a/extensions/xai/provider-catalog.ts
+++ b/extensions/xai/provider-catalog.ts
@@ -23,7 +23,7 @@ import { XAI_OAUTH_AUTO_MODEL_ID } from "./model-id.js";
 
 const PROVIDER_ID = "xai";
 const XAI_MODELS_ENDPOINT = `${XAI_BASE_URL}/models`;
-export const XAI_GROK_OAUTH_BASE_URL = "https://cli-chat-proxy.grok.com/v1";
+const XAI_GROK_OAUTH_BASE_URL = "https://cli-chat-proxy.grok.com/v1";
 const XAI_GROK_OAUTH_MODELS_ENDPOINT = `${XAI_GROK_OAUTH_BASE_URL}/models`;
 const XAI_GROK_OAUTH_SETTINGS_ENDPOINT = `${XAI_GROK_OAUTH_BASE_URL}/settings`;
 const XAI_MODELS_CACHE_TTL_MS = 60_000;

--- a/extensions/xai/provider-catalog.ts
+++ b/extensions/xai/provider-catalog.ts
@@ -233,6 +233,7 @@ function buildXaiOauthModelFromLiveRow(row: unknown): ModelDefinitionConfig | un
 
 export async function buildLiveXaiOAuthProvider(params: {
   discoveryApiKey: string;
+  authMode?: "oauth" | "token";
   fetchGuard?: LiveModelCatalogFetchGuard;
   signal?: AbortSignal;
 }): Promise<ModelProviderConfig> {
@@ -244,7 +245,7 @@ export async function buildLiveXaiOAuthProvider(params: {
       providerConfig: {
         baseUrl: XAI_GROK_OAUTH_BASE_URL,
         api: "openai-responses",
-        auth: "oauth",
+        auth: params.authMode ?? "oauth",
       },
       models: [],
       discoveryApiKey: params.discoveryApiKey,

--- a/extensions/xai/provider-catalog.ts
+++ b/extensions/xai/provider-catalog.ts
@@ -38,6 +38,17 @@ const XAI_UNKNOWN_MODEL_COST = {
   cacheWrite: 0,
 } satisfies ModelDefinitionConfig["cost"];
 
+export function isXaiGrokProxyBaseUrl(baseUrl: string | undefined): boolean {
+  if (!baseUrl) {
+    return false;
+  }
+  try {
+    return new URL(baseUrl).href.replace(/\/+$/u, "") === XAI_GROK_OAUTH_BASE_URL;
+  } catch {
+    return false;
+  }
+}
+
 export function buildXaiProvider(
   api: ModelProviderConfig["api"] = "openai-responses",
 ): ModelProviderConfig {

--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -11,7 +11,6 @@ import {
 import { createZeroUsageFixture } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import { XAI_BASE_URL } from "./model-definitions.js";
-import { XAI_GROK_OAUTH_BASE_URL } from "./provider-catalog.js";
 import { applyXaiRuntimeModelCompat } from "./runtime-model-compat.js";
 import { wrapXaiProviderStream } from "./stream.js";
 import {
@@ -756,7 +755,7 @@ describe("xai stream wrappers", () => {
   });
 
   it.each([
-    ["Grok OAuth proxy", XAI_GROK_OAUTH_BASE_URL],
+    ["Grok OAuth proxy", "https://cli-chat-proxy.grok.com/v1"],
     ["custom endpoint", "https://proxy.example/v1"],
   ])("counts every function output before replaying sparse images for %s", (_label, baseUrl) => {
     const callIds = ["a", "b", "c", "d"].map((suffix) => `${"x".repeat(64)}${suffix}`);

--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -169,7 +169,13 @@ async function captureXaiResponsesPayloadWithThinking(
 }
 
 describe("xai stream wrappers", () => {
-  it.each(["grok-4.5", "auto"])("adds the Grok OAuth proxy request contract for %s", (id) => {
+  it.each(
+    ["grok-4.5", "auto"].flatMap((id) =>
+      ["https://cli-chat-proxy.grok.com/v1", "https://CLI-CHAT-PROXY.GROK.COM:443/v1/"].map(
+        (baseUrl) => ({ id, baseUrl }),
+      ),
+    ),
+  )("adds the Grok OAuth proxy request contract for $id at $baseUrl", ({ id, baseUrl }) => {
     let capturedHeaders: Record<string, string> | undefined;
     let capturedModelId: string | undefined;
     const baseStreamFn: StreamFn = (model, _context, options) => {
@@ -197,7 +203,7 @@ describe("xai stream wrappers", () => {
         contextWindow: 500_000,
         maxTokens: 64_000,
         params: { canonicalModelId: "grok-4.5" },
-        baseUrl: "https://cli-chat-proxy.grok.com/v1",
+        baseUrl,
       },
       { messages: [] },
       { headers: { "X-XAI-Token-Auth": "operator-value", "X-Existing": "kept" } },
@@ -215,6 +221,9 @@ describe("xai stream wrappers", () => {
   it.each([
     ["the public API-key endpoint", "xai", "https://api.x.ai/v1"],
     ["a different provider", "other", "https://cli-chat-proxy.grok.com/v1"],
+    ["a different port", "xai", "https://cli-chat-proxy.grok.com:444/v1"],
+    ["a different path", "xai", "https://cli-chat-proxy.grok.com/v10"],
+    ["a lookalike host", "xai", "https://cli-chat-proxy.grok.com.example/v1"],
   ])("does not add Grok OAuth headers for %s", (_label, provider, baseUrl) => {
     let capturedHeaders: Record<string, string> | undefined;
     const baseStreamFn: StreamFn = (_model, _context, options) => {

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -11,7 +11,7 @@ import {
 import { asOptionalRecord, filterStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { XAI_BASE_URL } from "./model-definitions.js";
 import { resolveXaiOAuthAutoModelId } from "./model-id.js";
-import { XAI_GROK_OAUTH_BASE_URL } from "./provider-catalog.js";
+import { isXaiGrokProxyBaseUrl } from "./provider-catalog.js";
 import { isXaiProviderId } from "./provider-id.js";
 
 const XAI_FAST_MODEL_IDS = new Map<string, string>([
@@ -33,7 +33,11 @@ function createXaiGrokOAuthHeadersWrapper(
   const underlying = baseStreamFn ?? streamSimple;
   const normalizedClientVersion = clientVersion?.trim();
   return (model, context, options) => {
-    if (!normalizedClientVersion || !isXaiEndpoint(model, XAI_GROK_OAUTH_BASE_URL)) {
+    if (
+      !normalizedClientVersion ||
+      !isXaiProviderId(model.provider) ||
+      !isXaiGrokProxyBaseUrl(model.baseUrl)
+    ) {
       return underlying(model, context, options);
     }
     // Keep the selected alias stable through auth materialization; resolve only on the wire.


### PR DESCRIPTION
## What Problem This Solves

Manually managed Grok subscription tokens queried the Console API model catalog
even when the configured xAI endpoint was the Grok subscription proxy. Missing
selected token material could also produce a request to that wrong endpoint.

## Why This Change Was Made

The xAI plugin selects its existing subscription catalog adapter for token auth
explicitly configured with `https://cli-chat-proxy.grok.com/v1`. It preserves the
selected token's mode, material, and account identity. Already-prepared static
material remains usable by standalone commands without a Gateway snapshot;
genuinely unavailable material produces an unavailable outcome before HTTP.

Discovery and existing subscription request headers share standard URL
normalization for hostname case, the default HTTPS port, and trailing slashes.
Other hosts, ports, and paths do not gain those headers. Native/default API
tokens, ordinary OAuth, and existing API-key fallback remain unchanged.

The six-file change stays inside the xAI plugin, its existing tests, and provider
documentation. It adds no configuration, schema, public SDK, refresh policy,
onboarding behavior, or persisted-state change. Current OAuth onboarding and
late automatic-model selection are preserved.

## User Impact

Subscription tokens discover subscription models through the configured Grok
proxy. Console API tokens continue to use the API catalog. Missing subscription
credentials no longer become a different catalog request. Valid environment-backed
tokens also work in standalone model commands.

## Evidence

Current head: `d8ceef345882331d41668cc2c40f1b3e8f8b7699`, based on
`e5e77649a94ad3124ad259f52336a0ee7f28acc1`. This includes the separately landed
shared environment-reference repair. All five xAI commits are patch-equivalent
after integration; independent review found no actionable P0-P2 issue.

- Before/fix regressions cover subscription routing, missing-material no-request
  behavior, equivalent URLs, cold prepared tokens, and runtime-only token material.
  Native/default API tokens and ordinary OAuth remain protected controls.
- The 105 focused tests and fast publication checks pass. The complete affected
  xAI/shared-auth suites, full changed gate, and [hosted CI](https://github.com/openclaw/openclaw/actions/runs/34083691793)
  also pass on this integrated head.
- The [remote command campaign](https://github.com/openclaw/openclaw/actions/runs/34083741986)
  rebuilt the baseline and candidate and verified these real CLI/Gateway paths:

  | Configuration | Original catalog | Fixed catalog |
  | --- | --- | --- |
  | Inline subscription token | Console API | Grok proxy |
  | Stored subscription token | Console API | Grok proxy |
  | Equivalent proxy URL | Console API | Grok proxy |
  | Stored env token, standalone command | Console API | Grok proxy |
  | Native API token | Console API | Console API |
  | Ordinary OAuth | Grok proxy | Grok proxy |

  All six candidate cases passed with matching selected credentials and the
  expected routes. The standalone command returned the discovered model as
  available without a Gateway. Gateway outcomes retained profile identity,
  prepared reads made no extra provider requests, and stored credentials were
  unchanged. All fixture processes, sockets, state, and build clones were removed.
  Five unchanged baseline cases reuse retained exact-source proof; the cold
  baseline command was rerun. The remote command exited 0.
- Contracts checked: [xAI authentication and endpoints](https://docs.x.ai/build/enterprise),
  [API model listing](https://docs.x.ai/developers/rest-api-reference/inference/models),
  and the [official Grok session-token documentation](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-shell/README.md#using-authjson-for-api-access).
- No authenticated live-vendor account test is claimed: no xAI credential was
  available. Real CLI/Gateway request paths use isolated controlled HTTPS and
  synthetic credentials; existing vendor adapters and headers are reused.
