### PR TITLE
refactor(http): share bounded response byte consumption

### DIFF
--- a/packages/ai/src/transports/transport-utils.ts
+++ b/packages/ai/src/transports/transport-utils.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import type { Model } from "@openclaw/llm-core";
+import { consumeResponseBytes } from "@openclaw/normalization-core";
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
@@ -132,24 +133,21 @@ export async function readResponseTextSnippet(
   let bytes = 0;
   let truncated = false;
   try {
-    while (bytes < maxBytes) {
-      const result = options?.chunkTimeoutMs
-        ? await readChunkWithIdleTimeout(reader, options.chunkTimeoutMs, options.onIdleTimeout)
-        : await reader.read();
-      if (result.done) {
-        break;
-      }
-      if (!result.value?.length) {
-        continue;
-      }
-      const remaining = maxBytes - bytes;
-      chunks.push(result.value.subarray(0, remaining));
-      bytes += Math.min(result.value.length, remaining);
-      if (result.value.length >= remaining) {
-        truncated = true;
-        await reader.cancel().catch(() => undefined);
-        break;
-      }
+    if (bytes < maxBytes) {
+      const result = await consumeResponseBytes({
+        maxBytes,
+        stopAtLimit: true,
+        read: () =>
+          options?.chunkTimeoutMs
+            ? readChunkWithIdleTimeout(reader, options.chunkTimeoutMs, options.onIdleTimeout)
+            : reader.read(),
+        onChunk: (chunk) => chunks.push(chunk),
+        onLimit: async () => {
+          await reader.cancel().catch(() => undefined);
+        },
+      });
+      bytes = Math.min(result.size, maxBytes);
+      truncated = result.truncated;
     }
   } catch (error) {
     await reader.cancel(error).catch(() => undefined);

--- a/packages/memory-host-sdk/src/host/response-snippet.ts
+++ b/packages/memory-host-sdk/src/host/response-snippet.ts
@@ -1,5 +1,5 @@
 // Memory Host SDK module implements response snippet behavior.
-import { decodeTextPrefix } from "@openclaw/normalization-core";
+import { consumeResponseBytes, decodeTextPrefix } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 
 const DEFAULT_ERROR_BODY_MAX_BYTES = 8 * 1024;
@@ -63,7 +63,10 @@ export async function readResponseJsonWithLimit(
     throw responseTooLarge(options.errorPrefix, contentLength, maxBytes);
   }
 
-  const text = await readResponseTextWithLimit(res, maxBytes, options.errorPrefix, options.signal);
+  const prefix = await readResponsePrefix(res, maxBytes, options.signal, options.errorPrefix);
+  const text = new TextDecoder("utf-8", { fatal: true }).decode(
+    joinChunks(prefix.bytes, prefix.length),
+  );
 
   try {
     return JSON.parse(text);
@@ -110,6 +113,7 @@ async function readResponsePrefix(
   res: Response,
   maxBytes: number,
   signal?: AbortSignal,
+  errorPrefix?: string,
 ): Promise<ResponsePrefix> {
   const body = res.body;
   if (!body || typeof body.getReader !== "function") {
@@ -118,94 +122,38 @@ async function readResponsePrefix(
 
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
-  let length = 0;
-  let truncated = false;
-
+  let result: { size: number; truncated: boolean };
   try {
-    while (true) {
-      const { done, value } = await readChunkWithAbort(
-        reader,
-        signal,
-        "Response snippet body read aborted",
-      );
-      if (done) {
-        break;
-      }
-      if (!value?.length) {
-        continue;
-      }
-
-      const remaining = maxBytes - length;
-      if (value.length >= remaining) {
-        // Keep only the configured prefix and cancel the body so callers do not
-        // accidentally buffer large provider error responses.
-        if (remaining > 0) {
-          chunks.push(value.subarray(0, remaining));
-          length += remaining;
+    result = await consumeResponseBytes({
+      maxBytes,
+      stopAtLimit: errorPrefix === undefined,
+      read: () =>
+        readChunkWithAbort(
+          reader,
+          signal,
+          errorPrefix === undefined
+            ? "Response snippet body read aborted"
+            : `${errorPrefix}: response body read aborted`,
+        ),
+      onChunk: (chunk) => chunks.push(chunk),
+      onLimit: (size) => {
+        void reader.cancel().catch(() => undefined);
+        if (errorPrefix !== undefined) {
+          throw responseTooLarge(errorPrefix, size, maxBytes);
         }
-        truncated = true;
-        // A capture tee can retain cancellation until the request owner releases.
-        void reader.cancel().catch(() => undefined);
-        break;
-      }
-
-      chunks.push(value);
-      length += value.length;
-    }
+      },
+    });
   } finally {
     try {
       reader.releaseLock();
     } catch {}
   }
 
-  return { bytes: chunks, length, truncated };
-}
-
-async function readResponseTextWithLimit(
-  res: Response,
-  maxBytes: number,
-  errorPrefix: string,
-  signal?: AbortSignal,
-): Promise<string> {
-  const body = res.body;
-  if (!body || typeof body.getReader !== "function") {
-    return "";
-  }
-
-  const reader = body.getReader();
-  const chunks: Uint8Array[] = [];
-  let length = 0;
-
-  try {
-    while (true) {
-      const { done, value } = await readChunkWithAbort(
-        reader,
-        signal,
-        `${errorPrefix}: response body read aborted`,
-      );
-      if (done) {
-        break;
-      }
-      if (!value?.length) {
-        continue;
-      }
-
-      const nextLength = length + value.length;
-      if (nextLength > maxBytes) {
-        void reader.cancel().catch(() => undefined);
-        throw responseTooLarge(errorPrefix, nextLength, maxBytes);
-      }
-
-      chunks.push(value);
-      length = nextLength;
-    }
-  } finally {
-    try {
-      reader.releaseLock();
-    } catch {}
-  }
-
-  return new TextDecoder("utf-8", { fatal: true }).decode(joinChunks(chunks, length));
+  return {
+    bytes: chunks,
+    length: result.truncated ? Math.max(0, maxBytes) : result.size,
+    truncated: result.truncated,
+  };
 }
 
 async function cancelResponseBody(res: Response): Promise<void> {

--- a/packages/normalization-core/src/index.ts
+++ b/packages/normalization-core/src/index.ts
@@ -10,6 +10,7 @@ export * from "./format.js";
 export * from "./json-coercion.js";
 export * from "./number-coercion.js";
 export * from "./record-coerce.js";
+export * from "./response-bytes.js";
 export * from "./stable-stringify.js";
 export * from "./string-coerce.js";
 export * from "./string-normalization.js";

--- a/packages/normalization-core/src/response-bytes.ts
+++ b/packages/normalization-core/src/response-bytes.ts
@@ -1,0 +1,30 @@
+// Byte accounting is shared; callers own decoding, deadlines, and reader cleanup.
+export async function consumeResponseBytes(options: {
+  maxBytes: number;
+  stopAtLimit?: boolean;
+  skipEmptyChunks?: boolean;
+  read: () => Promise<ReadableStreamReadResult<Uint8Array>>;
+  onChunk: (chunk: Uint8Array) => void;
+  onLimit: (size: number) => void | Promise<void>;
+}): Promise<{ size: number; truncated: boolean }> {
+  let size = 0;
+  while (true) {
+    const { done, value } = await options.read();
+    if (done) {
+      return { size, truncated: false };
+    }
+    if (options.skipEmptyChunks !== false && !value?.length) {
+      continue;
+    }
+    const remaining = options.maxBytes - size;
+    size += value.length;
+    if (size > options.maxBytes || (options.stopAtLimit && size === options.maxBytes)) {
+      if (remaining > 0) {
+        options.onChunk(value.subarray(0, remaining));
+      }
+      await options.onLimit(size);
+      return { size, truncated: true };
+    }
+    options.onChunk(value);
+  }
+}

--- a/src/infra/http-response-body.ts
+++ b/src/infra/http-response-body.ts
@@ -1,5 +1,5 @@
 // Response readers do not depend on inbound request lifecycle or logging policy.
-import { decodeTextPrefix } from "@openclaw/normalization-core";
+import { consumeResponseBytes, decodeTextPrefix } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   withResponseBodyIdleTimeout,
@@ -38,37 +38,26 @@ async function readResponsePrefixFromReader(
   options?: ReadResponsePrefixOptions,
 ): Promise<ReadResponsePrefixResult> {
   const chunks: Uint8Array[] = [];
-  let size = 0;
-  let truncated = false;
+  let result: { size: number; truncated: boolean };
   try {
-    await withResponseBodyIdleTimeout(
+    result = await withResponseBodyIdleTimeout(
       reader,
       options?.chunkTimeoutMs || undefined,
       options?.onIdleTimeout,
-      async (refreshTimeout) => {
-        while (true) {
-          refreshTimeout?.();
-          const { done, value } = await reader.read();
-          if (done) {
-            break;
-          }
-          if (!value?.length) {
-            continue;
-          }
-          const remaining = maxBytes - size;
-          size += value.length;
-          if (size > maxBytes || (options?.stopAtLimit && size === maxBytes)) {
-            if (remaining > 0) {
-              chunks.push(value.subarray(0, remaining));
-            }
-            truncated = true;
-            // A capture tee can retain cancellation until the caller releases its request.
+      (refreshTimeout) =>
+        consumeResponseBytes({
+          maxBytes,
+          stopAtLimit: options?.stopAtLimit,
+          read: () => {
+            refreshTimeout?.();
+            return reader.read();
+          },
+          onChunk: (chunk) => chunks.push(chunk),
+          onLimit: () => {
+            // Capture tees must not delay bounded dispatcher release.
             void reader.cancel().catch(() => undefined);
-            break;
-          }
-          chunks.push(value);
-        }
-      },
+          },
+        }),
     );
   } finally {
     try {
@@ -79,9 +68,8 @@ async function readResponsePrefixFromReader(
   return {
     // Full-body readers reject overflow before allocating a contiguous copy.
     // MiB limits can yield fractional bytes; retained slices contain only whole bytes.
-    materializeBuffer: () => Buffer.concat(chunks, Math.floor(Math.min(size, maxBytes))),
-    size,
-    truncated,
+    materializeBuffer: () => Buffer.concat(chunks, Math.floor(Math.min(result.size, maxBytes))),
+    ...result,
   };
 }
 

--- a/ui/src/lib/response-body.test.ts
+++ b/ui/src/lib/response-body.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { readResponseTextWithLimit } from "./response-body.js";
+
+describe("readResponseTextWithLimit", () => {
+  it.each([-1, Number.NEGATIVE_INFINITY])(
+    "rejects an empty streamed chunk against a negative byte budget (%s)",
+    async (maxBytes) => {
+      const response = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new Uint8Array());
+            controller.close();
+          },
+        }),
+      );
+
+      await expect(
+        readResponseTextWithLimit(response, {
+          maxBytes,
+          tooLargeMessage: "response exceeds its byte budget",
+        }),
+      ).rejects.toThrow("response exceeds its byte budget");
+      expect(response.body?.locked).toBe(false);
+    },
+  );
+});

--- a/ui/src/lib/response-body.ts
+++ b/ui/src/lib/response-body.ts
@@ -1,4 +1,5 @@
 // Control UI response helpers own bounded browser body consumption.
+import { consumeResponseBytes } from "@openclaw/normalization-core";
 
 type ResponseTextLimitOptions = {
   maxBytes: number;
@@ -37,24 +38,22 @@ export async function readResponseTextWithLimit(
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   const chunks: string[] = [];
-  let totalBytes = 0;
   try {
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) {
-        const tail = decoder.decode();
-        if (tail) {
-          chunks.push(tail);
-        }
-        break;
-      }
-      totalBytes += value.byteLength;
-      if (totalBytes > options.maxBytes) {
-        // Cancellation is best-effort; finally always releases this reader's lock.
+    await consumeResponseBytes({
+      maxBytes: options.maxBytes,
+      skipEmptyChunks: false,
+      read: () => reader.read(),
+      onChunk: (chunk) => {
+        chunks.push(decoder.decode(chunk, { stream: true }));
+      },
+      onLimit: () => {
         void reader.cancel().catch(() => undefined);
         throw new Error(options.tooLargeMessage);
-      }
-      chunks.push(decoder.decode(value, { stream: true }));
+      },
+    });
+    const tail = decoder.decode();
+    if (tail) {
+      chunks.push(tail);
     }
   } finally {
     reader.releaseLock();


### PR DESCRIPTION
## What Problem This Solves

Bounded HTTP response readers in core, AI transports, the memory host, and the Dashboard repeat their chunk loop and byte accounting. Fixes to exact-byte limits can drift between these paths.

## Why This Change Was Made

A browser-safe `consumeResponseBytes` leaf in `@openclaw/normalization-core` owns the shared loop, retained byte prefix, and limit notification. Callers keep their decoding, header validation, timeout and abort errors, cancellation lifetime, and reader cleanup. Memory JSON and snippet reads also share their existing reader adapter.

The core operation timer and AI per-read timer remain separate: they have different clamping, refresh, error, and cancellation contracts. Core/memory snippets still discard partial UTF-8; AI still emits the decoder replacement character; memory JSON still uses fatal UTF-8 decoding. Dashboard streaming decoding and its empty-chunk accounting are retained.

Related: #109245. That open PR correctly bounds the body-less error-snippet path by changing its fallback to empty text. This consolidation builds around it and does not duplicate that policy change. Inspected #136508 and #137230 too; those concern inbound Slack/Feishu request admission and do not overlap this response-reader change.

## User Impact

None intended. Existing exported reader names and caller behavior are preserved. No configuration, dependency, schema, or protocol change.

## Evidence

Fresh validation at `8b1054c820bebec32381a78515aba973e25722b6`, rebased onto main `e9a2a0298557451d28704b900bf3c4dfb0a4a99d`. `git range-diff` confirms an identical patch; concurrent AI transport changes and the node-host umask correction (#140771) are retained.

- `node scripts/run-vitest.mjs src/infra/http-body.response.test.ts src/infra/http-error-body.test.ts packages/memory-host-sdk/src/host/response-snippet.test.ts ui/src/lib/response-body.test.ts ui/src/app/browser-bootstrap.test.ts ui/src/pages/chat/realtime-talk-webrtc-support.test.ts`: 6 files, 103 tests passed.
- `node scripts/check-changed.mjs`: passed, including core/test/UI types, lint, dead-export scans and ratchets. No baseline change.
- `pnpm build`: passed in 7m 15.6s, including package and SDK declarations, plugin builds, runtime closure checks, and Dashboard assets/performance budgets.
- Fresh Codex autoreview: scoped-clean at the requested command's default P0 threshold, zero findings. Prior P0–P2 review and 1,232 old/new reader comparisons are recorded in the original validation.
- Production +109/-145 (net -36); tests +26/-0.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34118348559) passed on this exact head, with no reruns.

The former Workshop geometry CI failures are historical; this revision is being verified on current main. The ClawSweeper migration-proof checklist is inapplicable: only transient HTTP body consumption changes, with no schema or persistent-store semantics. No existing public export was removed or renamed. No live external-provider test is required for the unchanged transport policy; proof is at the response-reader/caller boundary.
