### PR TITLE
refactor(ui): simplify first-run activation outcomes

### DIFF
--- a/ui/src/pages/model-setup/first-run-setup.ts
+++ b/ui/src/pages/model-setup/first-run-setup.ts
@@ -21,6 +21,7 @@ import {
   type ModelSetupActivationState,
   type ModelSetupPageState,
   type ModelSetupVerifyState,
+  type ModelSetupWizardResult,
 } from "./state.ts";
 
 export type ModelSetupConnection = Pick<
@@ -282,14 +283,18 @@ export class FirstRunSetup {
     return this.pending;
   }
 
-  recordActivation(
-    activation: FirstRunActivation | null,
-    result: SystemAgentSetupActivateResult,
-  ): void {
+  recordActivation(activation: FirstRunActivation | null, result: ModelSetupWizardResult): void {
     if (!activation) {
       return;
     }
-    if (!result.ok) {
+    // Generic errors can follow committed settings; only proven rejection or
+    // non-admission permits replacement setup.
+    if (
+      result.status === "cancelled" ||
+      result.status === "not-admitted" ||
+      (result.status === "error" &&
+        result.activationRejection?.disposition === "rejected-before-promotion")
+    ) {
       // Retiring the receipt must not discard an active, definitive failure.
       if (this.ownsActivation(activation)) {
         activation.outcome = "rejected";
@@ -300,12 +305,13 @@ export class FirstRunSetup {
       }
       return;
     }
-    if (!result.modelRef || this.pending !== activation || !this.ownsActivation(activation)) {
+    const modelRef = result.status === "done" ? result.modelActivation?.modelRef : undefined;
+    if (!modelRef || this.pending !== activation || !this.ownsActivation(activation)) {
       return;
     }
     // Capture the verified target before config refresh can replace the hello
     // and retire the Lit task that otherwise owns this response.
-    activation.modelRef = result.modelRef;
+    activation.modelRef = modelRef;
     activation.outcome = "verified";
     activation.receipt = persistFirstRunActivationReceipt(this.host.context(), activation);
   }

--- a/ui/src/pages/model-setup/model-setup-activation.test.ts
+++ b/ui/src/pages/model-setup/model-setup-activation.test.ts
@@ -573,9 +573,11 @@ describe("ModelSetupPage first-run activation ownership", () => {
       const activation = setup.beginActivation({ kind: "provider-auth" });
       expect(activation).not.toBeNull();
       vi.spyOn(Date, "now").mockReturnValue(activation!.deadlineMs + 1);
-      expect(() =>
-        setup.recordActivation(activation, { ok: true, modelRef: "synthetic/model" }),
-      ).not.toThrow();
+      setup.recordActivation(activation, {
+        done: true,
+        status: "done",
+        modelActivation: { modelRef: "synthetic/model" },
+      });
       expect(notify).toHaveBeenCalledOnce();
       expect(setup.unresolved).toBe(false);
       expect(setup.ownsActivation(activation)).toBe(false);

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -131,20 +131,9 @@ export class ModelSetupPage extends OpenClawLightDomElement {
         return undefined;
       }
       const activation = this.firstRun.beginActivation(intent ?? { kind: "provider-auth" });
-      return (result, admissionRejected) => {
-        if (result.status === "done" && result.modelActivation) {
-          this.firstRun.recordActivation(activation, { ok: true, ...result.modelActivation });
-        } else if (
-          result.status === "cancelled" ||
-          admissionRejected ||
-          (result.status === "error" &&
-            result.activationRejection?.disposition === "rejected-before-promotion")
-        ) {
-          // A terminal error can follow committed settings. Only the owning
-          // Gateway's rejection or non-admission makes replacement setup safe.
-          this.firstRun.recordActivation(activation, { ok: false });
-          this.requestUpdate();
-        }
+      return (result) => {
+        this.firstRun.recordActivation(activation, result);
+        this.requestUpdate();
         return () => this.firstRun.ownsActivation(activation);
       };
     },

--- a/ui/src/pages/model-setup/state.ts
+++ b/ui/src/pages/model-setup/state.ts
@@ -38,6 +38,10 @@ export type ModelSetupVerifyState =
   | { phase: "ok"; modelRef: string; latencyMs?: number }
   | { phase: "failed"; status: ModelSetupVerifyFailure["status"]; error: string };
 
+export type ModelSetupWizardResult =
+  | WizardNextResult
+  | { done: true; status: "not-admitted"; error: string };
+
 export type ModelSetupWizardState =
   | { phase: "idle" }
   | { phase: "starting"; authChoice: string }
@@ -107,7 +111,7 @@ export function mapVerifyResult(result: SystemAgentSetupVerifyResult): ModelSetu
 
 export function wizardStateFromResult(
   authChoice: string,
-  result: WizardNextResult,
+  result: ModelSetupWizardResult,
   fallbackError: string,
 ): ModelSetupWizardState {
   if (!result.done && result.step) {

--- a/ui/src/pages/model-setup/wizard-runner.test.ts
+++ b/ui/src/pages/model-setup/wizard-runner.test.ts
@@ -843,10 +843,11 @@ describe("ModelSetupWizardRunner", () => {
       expect(request.mock.calls.map(([requestMethod]) => requestMethod)).toEqual([method]);
       expect(runner.state).toEqual({ phase: "idle" });
       if (status === "busy") {
-        expect(terminalResult).toHaveBeenCalledExactlyOnceWith(
-          expect.objectContaining({ done: true, status: "error", error: "Setup busy" }),
-          true,
-        );
+        expect(terminalResult).toHaveBeenCalledExactlyOnceWith({
+          done: true,
+          status: "not-admitted",
+          error: "Setup busy",
+        });
       } else if (lifecycle === "open") {
         expect(terminalResult).toHaveBeenCalledExactlyOnceWith(
           expect.objectContaining({ done: true, status: "done" }),

--- a/ui/src/pages/model-setup/wizard-runner.ts
+++ b/ui/src/pages/model-setup/wizard-runner.ts
@@ -10,6 +10,7 @@ import { generateUUID } from "../../lib/uuid.ts";
 import {
   MODEL_SETUP_AUTH_START_TIMEOUT_MS,
   MODEL_SETUP_WIZARD_NEXT_TIMEOUT_MS,
+  type ModelSetupWizardResult,
   type ModelSetupWizardState,
   wizardStateFromResult,
 } from "./state.ts";
@@ -27,10 +28,7 @@ export type ModelSetupWizardCompletion = {
   isCurrent?: () => boolean;
 };
 
-type WizardTerminalObserver = (
-  result: WizardNextResult,
-  admissionRejected?: true,
-) => (() => boolean) | void;
+type WizardTerminalObserver = (result: ModelSetupWizardResult) => (() => boolean) | void;
 
 type WizardRunnerOptions = {
   getClient: () => GatewayBrowserClient | null;
@@ -53,12 +51,11 @@ type WizardSession = {
   suspended?: boolean;
   retired?: boolean;
   retirementGeneration: number;
-  terminalResult?: WizardNextResult;
+  terminalResult?: ModelSetupWizardResult;
   cancellationPromise?: Promise<WizardStatusResult>;
   abortController: AbortController;
   startMethod: ModelSetupWizardStartMethod;
   activationTargetId?: string;
-  admissionRejected?: true;
   onTerminalResult?: WizardTerminalObserver;
 };
 
@@ -177,17 +174,15 @@ export class ModelSetupWizardRunner {
           },
           { timeoutMs: null },
         )
-        .catch((error: unknown): WizardStartResult => {
+        .catch((error: unknown): ModelSetupWizardResult => {
           if (!isSetupAdmissionBusyError(error)) {
             throw error;
           }
-          session.admissionRejected = true;
           // Normalize only the retained start's proven non-admission, including
           // late replies after deadline/disposal, through exact terminal cleanup.
           return {
-            sessionId: session.sessionId,
             done: true,
-            status: "error",
+            status: "not-admitted",
             error: formatUiError(error, this.options.requestFailedMessage()),
           };
         });
@@ -290,8 +285,8 @@ export class ModelSetupWizardRunner {
 
   private async awaitWizardStart(
     session: WizardSession,
-    request: Promise<WizardStartResult>,
-  ): Promise<WizardStartResult> {
+    request: Promise<ModelSetupWizardResult>,
+  ): Promise<ModelSetupWizardResult> {
     let timedOut = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
     // Gateway request abort/deadline retirement discards the late session needed for cleanup.
@@ -358,7 +353,7 @@ export class ModelSetupWizardRunner {
   private applyResult(
     session: WizardSession,
     authChoice: string,
-    result: WizardNextResult,
+    result: ModelSetupWizardResult,
   ): ModelSetupWizardCompletion | null {
     if (session === this.session && session.suspended && result.done) {
       session.terminalResult = result;
@@ -383,14 +378,14 @@ export class ModelSetupWizardRunner {
       this.session = null;
     }
     this.setState(next);
-    if (next.phase !== "done") {
+    if (!result.done || result.status !== "done") {
       return null;
     }
     return {
       startMethod: session.startMethod,
       ...(session.activationTargetId ? { activationTargetId: session.activationTargetId } : {}),
       ...(isCurrent ? { isCurrent } : {}),
-      ...(next.preparedModelRef ? { preparedModelRef: next.preparedModelRef } : {}),
+      ...(result.preparedModelRef ? { preparedModelRef: result.preparedModelRef } : {}),
       ...(result.modelActivation ? { modelActivation: result.modelActivation } : {}),
     };
   }
@@ -447,18 +442,19 @@ export class ModelSetupWizardRunner {
 
   private reportTerminalResult(
     session: WizardSession,
-    result: WizardNextResult,
+    result: ModelSetupWizardResult,
   ): (() => boolean) | void {
     // Confirmed failure/cancellation owns exact receipt cleanup after presentation retires.
     // Success and visible state still require this runner's live session.
     if (this.isRetired(session) || session.suspended) {
       return;
     }
-    const failed = result.status === "cancelled" || result.status === "error";
+    const failed =
+      result.status === "cancelled" ||
+      result.status === "error" ||
+      result.status === "not-admitted";
     if (result.done && (session === this.session || failed)) {
-      return session.admissionRejected
-        ? session.onTerminalResult?.(result, true)
-        : session.onTerminalResult?.(result);
+      return session.onTerminalResult?.(result);
     }
   }
 


### PR DESCRIPTION
Related: #139140 — recoverable onboarding and model-result verification

## What Problem This Solves

Maintainer-requested cleanup of the existing Control UI first-run recovery fix. The already-landed fix carried start non-admission as a separate session flag and observer argument, while the page translated wizard results into another outcome shape before updating the receipt owner.

## Why This Change Was Made

Pass the wizard outcome directly to the first-run owner, which now decides whether to retain, reject, or verify its receipt. Exact start non-admission uses a local discriminated outcome; it does not manufacture a Gateway-owned rejection fact. This removes the mutable admission flag, extra callback argument, and page-level projection.

## User Impact

No intended user-visible change. Generic errors remain unresolved, confirmed cancellation and pre-promotion rejection retain their existing retry semantics, and start non-admission remains distinct from an error after admission. Suspension, retirement, stale/replacement ownership, and the existing verification deadline are unchanged. No Gateway, protocol, configuration, schema, or native changes.

## Evidence

- Model Setup suite before and after: **315 tests passed across 19 files**. No new test cases; only existing fixtures/assertions changed for the internal result shape.
- Chromium activation-feedback, cancellation, and reconnect suites: **17 tests passed across 3 files**.
- `pnpm ui:build` passed.
- `node scripts/check-changed.mjs -- <six changed files>` passed, including formatting, core-test/UI typechecks, lint, i18n, and applicable guards.
- Fresh isolated Codex autoreview: no actionable P0–P2 findings.
- `git diff --check` passed.

Production **+37/-42 (net -5)**; tests **+10/-7 (net +3)**. The larger alternative test matrix and documentation prose were not carried forward. One redundant exception assertion was removed; an unexpected exception still fails the test. No new helpers or compatibility paths.

This is a behavior-neutral follow-up, not a second claim to fix the original bug. The relevant real-Gateway history is on the linked onboarding PR; this candidate's proof is the existing owner tests, real-browser E2Es, build, and checks. No appearance changes require new screenshots.

Focused commands:

```bash
node scripts/run-vitest.mjs ui/src/pages/model-setup
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/model-setup-activation-feedback.e2e.test.ts ui/src/e2e/model-setup-cancel.e2e.test.ts ui/src/e2e/model-setup-reconnect.e2e.test.ts
```
