### PR TITLE
refactor(infra): unify Unix port diagnostic collection

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3066,7 +3066,6 @@ src/infra/package-dist-inventory.ts	2
 src/infra/package-json.ts	1
 src/infra/pairing-files.ts	1
 src/infra/path-case.ts	3
-src/infra/ports-inspect.ts	1
 src/infra/ports.ts	2
 src/infra/private-mode.ts	2
 src/infra/provider-usage.auth.ts	2

--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -123,45 +123,31 @@ function resolveLocalNetworkAddresses(): Set<string> {
   return addresses;
 }
 
-function isGatewayConnectionAddress(
+function resolveGatewayConnectionDirection(
   address: string | undefined,
   port: number,
   localAddresses: Set<string>,
-): boolean {
+): PortConnectionDirection | undefined {
   const parsed = parseLsofTcpConnectionAddress(address);
   if (!parsed) {
-    return false;
-  }
-  if (parsed.local.port === port) {
-    return true;
-  }
-  return parsed.remote.port === port && localAddresses.has(parsed.remote.host);
-}
-
-function resolveLsofTcpDirection(
-  address: string | undefined,
-  port: number,
-): PortConnectionDirection {
-  const parsed = parseLsofTcpConnectionAddress(address);
-  if (!parsed) {
-    return "unknown";
+    return undefined;
   }
   if (parsed.local.port === port) {
     return "server";
   }
-  return parsed.remote.port === port ? "client" : "unknown";
+  return parsed.remote.port === port && localAddresses.has(parsed.remote.host)
+    ? "client"
+    : undefined;
 }
 
 function parseLsofConnectionFieldOutput(output: string, port: number): PortConnection[] {
   const connections: PortConnection[] = [];
   const localAddresses = resolveLocalNetworkAddresses();
   for (const entry of parseLsofFieldOutput(output)) {
-    if (!isGatewayConnectionAddress(entry.address, port, localAddresses)) {
-      continue;
+    const direction = resolveGatewayConnectionDirection(entry.address, port, localAddresses);
+    if (direction) {
+      connections.push({ ...entry, direction });
     }
-    const connection = entry as PortConnection;
-    connection.direction = resolveLsofTcpDirection(entry.address, port);
-    connections.push(connection);
   }
   return connections;
 }
@@ -193,12 +179,13 @@ function parseSsConnections(output: string, port: number): PortConnection[] {
     }
     const [local, remote] = endpoints.slice(-2);
     const address = `TCP ${local}->${remote} (ESTABLISHED)`;
-    if (!isGatewayConnectionAddress(address, port, localAddresses)) {
+    const direction = resolveGatewayConnectionDirection(address, port, localAddresses);
+    if (!direction) {
       continue;
     }
     const connection: PortConnection = {
       address,
-      direction: resolveLsofTcpDirection(address, port),
+      direction,
     };
     const pidMatch = line.match(/pid=(\d+)/);
     if (pidMatch) {
@@ -230,66 +217,60 @@ async function enrichUnixListenerProcessInfo(listeners: PortListener[]): Promise
   }
 }
 
-async function readUnixEstablishedConnectionsFromSs(
-  port: number,
-): Promise<{ connections: PortConnection[]; detail?: string; errors: string[] }> {
-  const errors: string[] = [];
-  const res = await runCommandSafe([
-    "ss",
-    "-H",
-    "-tnp",
-    "state",
-    "established",
-    `( sport = :${port} or dport = :${port} )`,
-  ]);
+async function readUnixSocketOutput(argv: string[]): Promise<{
+  stdout?: string;
+  errors: string[];
+  unavailable: boolean;
+}> {
+  const res = await runCommandSafe(argv);
   if (res.code === 0) {
-    const connections = parseSsConnections(res.stdout, port);
-    return { connections, detail: res.stdout.trim() || undefined, errors };
+    return { stdout: res.stdout, errors: [], unavailable: false };
   }
   const stderr = res.stderr.trim();
+  // lsof/ss use a quiet exit 1 for no matches; it must not trigger another collector.
   if (res.code === 1 && !res.error && !stderr) {
-    return { connections: [], detail: undefined, errors };
-  }
-  if (res.error) {
-    errors.push(res.error);
+    return { errors: [], unavailable: false };
   }
   const detail = [stderr, res.stdout.trim()].filter(Boolean).join("\n");
-  if (detail) {
-    errors.push(detail);
-  }
-  return { connections: [], detail: undefined, errors };
+  return {
+    errors: [...(res.error ? [res.error] : []), ...(detail ? [detail] : [])],
+    unavailable: true,
+  };
+}
+
+async function readUnixSocketEntries<T extends PortListener>(
+  argv: string[],
+  parse: (output: string) => T[],
+) {
+  const result = await readUnixSocketOutput(argv);
+  const entries = result.stdout === undefined ? [] : parse(result.stdout);
+  return {
+    entries,
+    detail: result.stdout?.trim() || undefined,
+    errors: result.errors,
+    unavailable: result.unavailable,
+  };
 }
 
 async function readUnixEstablishedConnections(
   port: number,
 ): Promise<{ connections: PortConnection[]; detail?: string; errors: string[] }> {
   const lsof = await resolveLsofCommand();
-  const res = await runCommandSafe([lsof, "-nP", `-iTCP:${port}`, "-sTCP:ESTABLISHED", "-FpFcn"]);
-  if (res.code === 0) {
-    const connections = parseLsofConnectionFieldOutput(res.stdout, port);
-    return { connections, detail: res.stdout.trim() || undefined, errors: [] };
+  const primary = await readUnixSocketEntries(
+    [lsof, "-nP", `-iTCP:${port}`, "-sTCP:ESTABLISHED", "-FpFcn"],
+    (output) => parseLsofConnectionFieldOutput(output, port),
+  );
+  if (!primary.unavailable) {
+    return { connections: primary.entries, detail: primary.detail, errors: primary.errors };
   }
-  const stderr = res.stderr.trim();
-  if (res.code === 1 && !res.error && !stderr) {
-    return { connections: [], detail: undefined, errors: [] };
-  }
-  const errors: string[] = [];
-  if (res.error) {
-    errors.push(res.error);
-  }
-  const detail = [stderr, res.stdout.trim()].filter(Boolean).join("\n");
-  if (detail) {
-    errors.push(detail);
-  }
-
-  const ssFallback = await readUnixEstablishedConnectionsFromSs(port);
-  if (ssFallback.connections.length > 0) {
-    return ssFallback;
-  }
+  const fallback = await readUnixSocketEntries(
+    ["ss", "-H", "-tnp", "state", "established", `( sport = :${port} or dport = :${port} )`],
+    (output) => parseSsConnections(output, port),
+  );
   return {
-    connections: [],
-    detail: undefined,
-    errors: [...errors, ...ssFallback.errors],
+    connections: fallback.entries,
+    detail: fallback.entries.length > 0 ? fallback.detail : undefined,
+    errors: fallback.entries.length > 0 ? fallback.errors : [...primary.errors, ...fallback.errors],
   };
 }
 
@@ -351,52 +332,17 @@ function parseSsListeners(output: string, port: number): PortListener[] {
   return listeners;
 }
 
-async function readUnixListenersFromSs(port: number): Promise<ListenerReadResult> {
-  const errors: string[] = [];
-  const res = await runCommandSafe(["ss", "-H", "-ltnp", `sport = :${port}`]);
-  if (res.code === 0) {
-    const listeners = parseSsListeners(res.stdout, port);
-    return { listeners, detail: res.stdout.trim() || undefined, errors };
-  }
-  const stderr = res.stderr.trim();
-  if (res.code === 1 && !res.error && !stderr) {
-    return { listeners: [], detail: undefined, errors };
-  }
-  if (res.error) {
-    errors.push(res.error);
-  }
-  const detail = [stderr, res.stdout.trim()].filter(Boolean).join("\n");
-  if (detail) {
-    errors.push(detail);
-  }
-  return { listeners: [], detail: undefined, errors };
-}
-
 async function readUnixListenerSnapshot(port?: number): Promise<UnixListenerSnapshot> {
   const lsof = await resolveLsofCommand();
   // Keep single-port lifecycle checks targeted; batches share one all-port scan.
   const tcpSelector = port === undefined ? "-iTCP" : `-iTCP:${port}`;
-  const res = await runCommandSafe([lsof, "-nP", tcpSelector, "-sTCP:LISTEN", "-FpFcn"]);
-  if (res.code === 0) {
-    return {
-      recordsByPort: parseLsofListenerRecordsByPort(res.stdout),
-      errors: [],
-      lsofUnavailable: false,
-    };
-  }
-  const errors: string[] = [];
-  const stderr = res.stderr.trim();
-  if (res.code === 1 && !res.error && !stderr) {
-    return { recordsByPort: new Map(), errors, lsofUnavailable: false };
-  }
-  if (res.error) {
-    errors.push(res.error);
-  }
-  const detail = [stderr, res.stdout.trim()].filter(Boolean).join("\n");
-  if (detail) {
-    errors.push(detail);
-  }
-  return { recordsByPort: new Map(), errors, lsofUnavailable: true };
+  const result = await readUnixSocketOutput([lsof, "-nP", tcpSelector, "-sTCP:LISTEN", "-FpFcn"]);
+  return {
+    recordsByPort:
+      result.stdout === undefined ? new Map() : parseLsofListenerRecordsByPort(result.stdout),
+    errors: result.errors,
+    lsofUnavailable: result.unavailable,
+  };
 }
 
 async function readUnixListeners(
@@ -408,19 +354,18 @@ async function readUnixListeners(
     const result = readLsofListenersForPort(listenerSnapshot.recordsByPort, port);
     return { ...result, errors: listenerSnapshot.errors };
   }
-  const ssFallback = await readUnixListenersFromSs(port);
-  if (ssFallback.listeners.length > 0) {
-    return ssFallback;
-  }
+  const fallback = await readUnixSocketEntries(
+    ["ss", "-H", "-ltnp", `sport = :${port}`],
+    (output) => parseSsListeners(output, port),
+  );
   return {
-    listeners: [],
-    detail: undefined,
-    errors: [...listenerSnapshot.errors, ...ssFallback.errors],
+    listeners: fallback.entries,
+    detail: fallback.entries.length > 0 ? fallback.detail : undefined,
+    errors:
+      fallback.entries.length > 0
+        ? fallback.errors
+        : [...listenerSnapshot.errors, ...fallback.errors],
   };
-}
-
-function parseNetstatListeners(output: string, port: number): PortListener[] {
-  return parseWindowsNetstatListeners(output, port);
 }
 
 function parseNetstatConnections(output: string, port: number): PortConnection[] {
@@ -442,12 +387,13 @@ function parseNetstatConnections(output: string, port: number): PortConnection[]
       continue;
     }
     const address = `TCP ${local}->${remote} (ESTABLISHED)`;
-    if (!isGatewayConnectionAddress(address, port, localAddresses)) {
+    const direction = resolveGatewayConnectionDirection(address, port, localAddresses);
+    if (!direction) {
       continue;
     }
     const connection: PortConnection = {
       address,
-      direction: resolveLsofTcpDirection(address, port),
+      direction,
     };
     const pid = parseStrictPositiveInteger(pidRaw);
     if (pid !== undefined) {
@@ -557,7 +503,7 @@ async function readWindowsNetstatEntries<T extends PortListener>(
 }
 
 async function readWindowsListeners(port: number): Promise<ListenerReadResult> {
-  const result = await readWindowsNetstatEntries(port, parseNetstatListeners);
+  const result = await readWindowsNetstatEntries(port, parseWindowsNetstatListeners);
   return { listeners: result.entries, detail: result.detail, errors: result.errors };
 }
 


### PR DESCRIPTION
Related: #140591, #140608, #131398, #138047.

## What Problem This Solves

Port diagnostics maintain duplicate Unix command-result handling for listeners and established connections. The copies must agree on quiet empty scans, fallback failures and client/server attribution whenever diagnostic behavior changes.

## Why This Change Was Made

Share Unix socket collection and classify each connection once at the endpoint owner. Keep targeted single-port lsof queries, shared batch snapshots and diagnostic-only child environments. Preserve #140608's public-boundary enrichment, unique-PID collection and two-query metadata policy. Windows retains its separate command-error policy. Remove the obsolete netstat forwarding helper and connection type assertion; shrink its exact assertion-baseline entry.

This maintainer-requested refactor removes 54 production lines (+73/-127). No test code is deleted, and no public API, configuration or storage behavior changes.

## User Impact

Gateway status and troubleshooting retain existing listener and established-client diagnostics, including original errors when fallback inspection cannot produce entries. The recent process-query reduction remains intact.

## Evidence

- 68 current tests passed: `node scripts/run-vitest.mjs src/infra/ports.test.ts src/infra/ports-probe.test.ts src/infra/ports-inspect.env.test.ts`. One Windows-only native tasklist test is skipped on macOS; mocked Windows contract tests pass.
- The suites include the merged unique-PID/process-budget regressions and six real subprocess fixture cases through lsof/ss and ps.
- Real local TCP listener/client proof passed through all three inspection APIs using native lsof and ps: matching PID/parent/command metadata, both client/server directions, deduplicated batch inspection, then free port and no connections after owned socket cleanup. Native Linux ss was not exercised on this macOS host.
- Fresh independent P2 review found no actionable issues in the adapted candidate. Its full local changed-code gate and exact-head required CI passed.
