### PR TITLE
fix: stop sending missing env refs as catalog credentials

### DIFF
--- a/docs/auth-credential-semantics.md
+++ b/docs/auth-credential-semantics.md
@@ -91,6 +91,12 @@ catalog discovery. Configured subscription modes remain attached to direct
 credentials, and successful OAuth preparation supplies the resolved current token
 to its catalog consumer rather than the captured store's older token.
 
+Static profile SecretRefs, including custom environment refs, use the activated
+secret snapshot. An unavailable selected ref reports `unavailable` before catalog
+HTTP; its reference name is never sent as a credential or replaced with another
+profile's credential. Restore the secret and run `openclaw secrets reload` before
+retrying discovery.
+
 When every eligible OAuth candidate fails preparation, discovery reports
 `unavailable` with the attempted profile identities instead of treating the
 provider as unconfigured. Compatible prior inventory remains available. A usable

--- a/docs/auth-credential-semantics.md
+++ b/docs/auth-credential-semantics.md
@@ -91,11 +91,12 @@ catalog discovery. Configured subscription modes remain attached to direct
 credentials, and successful OAuth preparation supplies the resolved current token
 to its catalog consumer rather than the captured store's older token.
 
-Static profile SecretRefs, including custom environment refs, use the activated
-secret snapshot. An unavailable selected ref reports `unavailable` before catalog
-HTTP; its reference name is never sent as a credential or replaced with another
-profile's credential. Restore the secret and run `openclaw secrets reload` before
-retrying discovery.
+Environment-backed profiles keep usable values from the discovery environment,
+including cold command and worker paths. When that material is missing, only the
+selected profile's activated snapshot may supply it; otherwise discovery reports
+`unavailable` before catalog HTTP. Reference names are never sent as credentials
+or replaced with another profile's credential. On a Gateway, restore the secret
+and run `openclaw secrets reload` before retrying discovery.
 
 When every eligible OAuth candidate fails preparation, discovery reports
 `unavailable` with the attempted profile identities instead of treating the

--- a/src/agents/models-config.providers.auth-provenance.test.ts
+++ b/src/agents/models-config.providers.auth-provenance.test.ts
@@ -322,7 +322,6 @@ describe("models-config provider auth provenance", () => {
         callback,
         async (fixture) => {
           const marker = refSource === "env" ? "DISCOVERY_KEY" : NON_ENV_SECRETREF_MARKER;
-          fixture.env.DISCOVERY_KEY = "unactivated-env-key";
           expect(await fixture.canonical()).toBe(fixture.runtimeKey);
           const providers = await fixture.discover();
           expect(providers?.openai?.apiKey).toBe(marker);
@@ -462,12 +461,17 @@ describe("models-config provider auth provenance", () => {
   );
 
   it.each(["resolveProviderAuth", "resolveProviderApiKey"] as const)(
-    "keeps plain and OAuth controls through %s",
+    "keeps plain, env and OAuth controls through %s",
     async (callback) => {
       await withDiscoveryFixture("api_key", callback, async (fixture) => {
         fixture.clear();
         for (const profile of [
           { type: "api_key", provider: "openai", key: "plain-key" },
+          {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "PROFILE_KEY" },
+          },
           {
             type: "oauth",
             provider: "openai",
@@ -477,6 +481,7 @@ describe("models-config provider auth provenance", () => {
           },
         ] satisfies AuthProfileCredential[]) {
           fixture.store.profiles[fixture.profileId] = profile;
+          fixture.env.PROFILE_KEY = "env-ref-key";
           if (profile.type === "oauth" && callback === "resolveProviderApiKey") {
             continue;
           }
@@ -484,8 +489,8 @@ describe("models-config provider auth provenance", () => {
         }
         expect(fixture.authorization).toEqual(
           callback === "resolveProviderAuth"
-            ? ["Bearer plain-key", "Bearer oauth-key"]
-            : ["Bearer plain-key"],
+            ? ["Bearer plain-key", "Bearer env-ref-key", "Bearer oauth-key"]
+            : ["Bearer plain-key", "Bearer env-ref-key"],
         );
         expect(fixture.errors).toEqual([]);
       });

--- a/src/agents/models-config.providers.auth-provenance.test.ts
+++ b/src/agents/models-config.providers.auth-provenance.test.ts
@@ -132,6 +132,7 @@ describe("models-config provider auth provenance", () => {
       canonical: () => Promise<string | undefined>;
     }) => Promise<void>,
     requestedProvider = " OPENAI ",
+    refSource: "store" | "env" = "store",
   ) {
     const stateDir = tempDirs.make("discovery-ref-provenance-");
     await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir, OPENAI_API_KEY: undefined }, async () => {
@@ -149,7 +150,7 @@ describe("models-config provider auth provenance", () => {
       const provider = "openai";
       const profileId = `${provider}:selected`;
       const agentDir = path.join(stateDir, "agent");
-      const ref = { source: "store", provider: "default", id: "DISCOVERY_KEY" } as const;
+      const ref = { source: refSource, provider: "default", id: "DISCOVERY_KEY" } as const;
       const profile: AuthProfileCredential =
         type === "api_key"
           ? { type, provider, keyRef: ref, key: "stale-inline-key" }
@@ -310,20 +311,31 @@ describe("models-config provider auth provenance", () => {
     ["api_key", "resolveProviderApiKey"],
     ["token", "resolveProviderApiKey"],
   ] as const;
-  it.each(discoveryCases)(
-    "authenticates published %s discovery through %s",
-    async (type, callback) => {
-      await withDiscoveryFixture(type, callback, async (fixture) => {
-        expect(await fixture.canonical()).toBe(fixture.runtimeKey);
-        const providers = await fixture.discover();
-        expect(providers?.openai?.apiKey).toBe(NON_ENV_SECRETREF_MARKER);
-        expect(JSON.stringify(providers)).not.toContain(fixture.runtimeKey);
-        expect(fixture.authorization).toEqual([`Bearer ${fixture.runtimeKey}`]);
-        const plan = await fixture.plan();
-        expect(plan.action).toBe("write");
-        expect(JSON.stringify(plan)).toContain(NON_ENV_SECRETREF_MARKER);
-        expect(JSON.stringify(plan)).not.toMatch(/runtime-discovery-key|stale-inline/);
-      });
+  const discoveryRefCases = discoveryCases.flatMap(([type, callback]) =>
+    (["store", "env"] as const).map((refSource) => ({ type, callback, refSource })),
+  );
+  it.each(discoveryRefCases)(
+    "authenticates published $refSource-backed $type discovery through $callback",
+    async ({ type, callback, refSource }) => {
+      await withDiscoveryFixture(
+        type,
+        callback,
+        async (fixture) => {
+          const marker = refSource === "env" ? "DISCOVERY_KEY" : NON_ENV_SECRETREF_MARKER;
+          fixture.env.DISCOVERY_KEY = "unactivated-env-key";
+          expect(await fixture.canonical()).toBe(fixture.runtimeKey);
+          const providers = await fixture.discover();
+          expect(providers?.openai?.apiKey).toBe(marker);
+          expect(JSON.stringify(providers)).not.toContain(fixture.runtimeKey);
+          expect(fixture.authorization).toEqual([`Bearer ${fixture.runtimeKey}`]);
+          const plan = await fixture.plan();
+          expect(plan.action).toBe("write");
+          expect(JSON.stringify(plan)).toContain(marker);
+          expect(JSON.stringify(plan)).not.toMatch(/runtime-discovery-key|stale-inline/);
+        },
+        "openai",
+        refSource,
+      );
     },
   );
 
@@ -338,80 +350,88 @@ describe("models-config provider auth provenance", () => {
     "cold",
   ] as const;
   it.each(
-    discoveryCases.flatMap(([type, callback]) =>
-      unavailableStates.map((state) => ({ type, callback, state })),
+    discoveryRefCases.flatMap(({ type, callback, refSource }) =>
+      unavailableStates
+        .filter((state) => refSource === "store" || state === "cold" || state === "unpublished")
+        .map((state) => ({ type, callback, refSource, state })),
     ),
   )(
-    "isolates $type $state through $callback without fallback or anonymous HTTP",
-    async ({ type, callback, state }) => {
-      await withDiscoveryFixture(type, callback, async (fixture) => {
-        const { SecretSurfaceUnavailableError } =
-          await import("../secrets/runtime-degraded-state.js");
-        fixture.store.profiles["openai:other"] = {
-          type: "api_key",
-          provider: "openai",
-          key: "wrong-account-key",
-        };
-        const profile = expectDefined(
-          fixture.published.profiles[fixture.profileId],
-          "published profile",
-        );
-        if (state === "cleared") {
-          await fixture.discover();
-          expect(fixture.authorization).toEqual([`Bearer ${fixture.runtimeKey}`]);
-          fixture.authorization.length = 0;
-        }
-        if (state === "unpublished" || state === "cleared") {
-          fixture.clear();
-        }
-        if (state === "agent-mismatch") {
-          fixture.clear();
-          fixture.publish(path.join(fixture.agentDir, "other"));
-        }
-        if (state === "missing-profile") {
-          delete fixture.published.profiles[fixture.profileId];
-        }
-        if (state === "provider-mismatch") {
-          profile.provider = "other-provider";
-        }
-        if (state === "ref-mismatch") {
-          const changedRef = { source: "store", provider: "default", id: "OTHER_KEY" } as const;
-          if (profile.type === "api_key") {
-            profile.keyRef = changedRef;
-          } else if (profile.type === "token") {
-            profile.tokenRef = changedRef;
+    "isolates $refSource-backed $type $state through $callback without fallback or anonymous HTTP",
+    async ({ type, callback, refSource, state }) => {
+      await withDiscoveryFixture(
+        type,
+        callback,
+        async (fixture) => {
+          const { SecretSurfaceUnavailableError } =
+            await import("../secrets/runtime-degraded-state.js");
+          fixture.store.profiles["openai:other"] = {
+            type: "api_key",
+            provider: "openai",
+            key: "wrong-account-key",
+          };
+          const profile = expectDefined(
+            fixture.published.profiles[fixture.profileId],
+            "published profile",
+          );
+          if (state === "cleared") {
+            await fixture.discover();
+            expect(fixture.authorization).toEqual([`Bearer ${fixture.runtimeKey}`]);
+            fixture.authorization.length = 0;
           }
-        }
-        if (state === "missing-value") {
-          if (profile.type === "api_key") {
-            delete profile.key;
-          } else if (profile.type === "token") {
-            delete profile.token;
+          if (state === "unpublished" || state === "cleared") {
+            fixture.clear();
           }
-        }
-        if (!["unpublished", "cleared", "agent-mismatch"].includes(state)) {
-          fixture.publish();
-        }
-        if (state === "cold") {
-          fixture.cold();
-        }
-        // Profile-first resolution must not escape to otherwise valid ambient auth.
-        if (callback === "resolveProviderAuth") {
-          fixture.env.OPENAI_API_KEY = "wrong-env-key";
-        }
-        const providers = await fixture.discover();
-        expect(fixture.authorization).toEqual([]);
-        expect(fixture.errors).toHaveLength(1);
-        expect(fixture.errors[0]).toBeInstanceOf(SecretSurfaceUnavailableError);
-        expect(fixture.outcomes).toEqual([
-          { provider: "openai", profileId: fixture.profileId, status: "unavailable" },
-        ]);
-        expect(providers?.openai).toBeUndefined();
-        expect(providers?.healthy).toBeDefined();
-        expect(JSON.stringify([providers, fixture.outcomes])).not.toMatch(
-          /stale-inline|wrong-account-key|wrong-env-key|runtime-discovery-key/,
-        );
-      });
+          if (state === "agent-mismatch") {
+            fixture.clear();
+            fixture.publish(path.join(fixture.agentDir, "other"));
+          }
+          if (state === "missing-profile") {
+            delete fixture.published.profiles[fixture.profileId];
+          }
+          if (state === "provider-mismatch") {
+            profile.provider = "other-provider";
+          }
+          if (state === "ref-mismatch") {
+            const changedRef = { source: "store", provider: "default", id: "OTHER_KEY" } as const;
+            if (profile.type === "api_key") {
+              profile.keyRef = changedRef;
+            } else if (profile.type === "token") {
+              profile.tokenRef = changedRef;
+            }
+          }
+          if (state === "missing-value") {
+            if (profile.type === "api_key") {
+              delete profile.key;
+            } else if (profile.type === "token") {
+              delete profile.token;
+            }
+          }
+          if (!["unpublished", "cleared", "agent-mismatch"].includes(state)) {
+            fixture.publish();
+          }
+          if (state === "cold") {
+            fixture.cold();
+          }
+          // Profile-first resolution must not escape to otherwise valid ambient auth.
+          if (callback === "resolveProviderAuth") {
+            fixture.env.OPENAI_API_KEY = "wrong-env-key";
+          }
+          const providers = await fixture.discover();
+          expect(fixture.authorization).toEqual([]);
+          expect(fixture.errors).toHaveLength(1);
+          expect(fixture.errors[0]).toBeInstanceOf(SecretSurfaceUnavailableError);
+          expect(fixture.outcomes).toEqual([
+            { provider: "openai", profileId: fixture.profileId, status: "unavailable" },
+          ]);
+          expect(providers?.openai).toBeUndefined();
+          expect(providers?.healthy).toBeDefined();
+          expect(JSON.stringify([providers, fixture.outcomes])).not.toMatch(
+            /stale-inline|wrong-account-key|wrong-env-key|runtime-discovery-key/,
+          );
+        },
+        "openai",
+        refSource,
+      );
     },
   );
 
@@ -442,17 +462,12 @@ describe("models-config provider auth provenance", () => {
   );
 
   it.each(["resolveProviderAuth", "resolveProviderApiKey"] as const)(
-    "keeps plain, env and OAuth controls through %s",
+    "keeps plain and OAuth controls through %s",
     async (callback) => {
       await withDiscoveryFixture("api_key", callback, async (fixture) => {
         fixture.clear();
         for (const profile of [
           { type: "api_key", provider: "openai", key: "plain-key" },
-          {
-            type: "api_key",
-            provider: "openai",
-            keyRef: { source: "env", provider: "default", id: "PROFILE_KEY" },
-          },
           {
             type: "oauth",
             provider: "openai",
@@ -462,7 +477,6 @@ describe("models-config provider auth provenance", () => {
           },
         ] satisfies AuthProfileCredential[]) {
           fixture.store.profiles[fixture.profileId] = profile;
-          fixture.env.PROFILE_KEY = "env-ref-key";
           if (profile.type === "oauth" && callback === "resolveProviderApiKey") {
             continue;
           }
@@ -470,8 +484,8 @@ describe("models-config provider auth provenance", () => {
         }
         expect(fixture.authorization).toEqual(
           callback === "resolveProviderAuth"
-            ? ["Bearer plain-key", "Bearer env-ref-key", "Bearer oauth-key"]
-            : ["Bearer plain-key", "Bearer env-ref-key"],
+            ? ["Bearer plain-key", "Bearer oauth-key"]
+            : ["Bearer plain-key"],
         );
         expect(fixture.errors).toEqual([]);
       });

--- a/src/agents/models-config.providers.discovery-auth.runtime.ts
+++ b/src/agents/models-config.providers.discovery-auth.runtime.ts
@@ -1,3 +1,4 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
 import { secretRefKey } from "../secrets/ref-contract.js";
@@ -34,11 +35,13 @@ export async function prepareProviderDiscoveryAuth(
   {
     agentDir,
     authStore,
+    env,
     resolveProviderApiKey,
     resolveProviderAuth,
   }: {
     agentDir: string;
     authStore: AuthProfileStore;
+    env: NodeJS.ProcessEnv;
     resolveProviderApiKey: ProviderApiKeyResolver;
     resolveProviderAuth: ProviderAuthResolver;
   },
@@ -58,9 +61,14 @@ export async function prepareProviderDiscoveryAuth(
     if (!ref) {
       continue;
     }
+    // Cold catalog readers can use env material without a Gateway auth snapshot.
+    const envValue = ref.source === "env" ? normalizeOptionalString(env[ref.id.trim()]) : undefined;
+    if (envValue) {
+      profiles.set(profileId, () => envValue);
+      continue;
+    }
     try {
       // Only the canonical owner may redeem this exact profile's published ref.
-      // Env ref names must not bypass activation and become credential material.
       const resolved = await resolveApiKeyForProfile({
         cfg: config,
         store: authStore,

--- a/src/agents/models-config.providers.discovery-auth.runtime.ts
+++ b/src/agents/models-config.providers.discovery-auth.runtime.ts
@@ -55,12 +55,12 @@ export async function prepareProviderDiscoveryAuth(
           : undefined,
       config?.secrets?.defaults,
     );
-    if (!ref || ref.source === "env") {
+    if (!ref) {
       continue;
     }
     try {
       // Only the canonical owner may redeem this exact profile's published ref.
-      // OAuth/env/plain profiles retain their existing discovery semantics.
+      // Env ref names must not bypass activation and become credential material.
       const resolved = await resolveApiKeyForProfile({
         cfg: config,
         store: authStore,

--- a/src/agents/prepared-model-catalog-worker.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.integration.test.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import path from "node:path";
-import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { buildModelsListResult } from "../gateway/server-methods/models-list-result.js";
@@ -949,7 +948,7 @@ describe("prepared model catalog worker boundary", () => {
     }
   });
 
-  it("preserves ref-only profiles through activation and the real worker", async () => {
+  it("preserves ref-only api-key and token profiles through the real worker", async () => {
     const fixture = await createStaticSnapshot(0);
     const authStore = {
       version: 1,
@@ -966,18 +965,6 @@ describe("prepared model catalog worker boundary", () => {
         },
       },
     };
-    const { prepareSecretsRuntimeSnapshot } = await import("../secrets/runtime.js");
-    const secrets = await prepareSecretsRuntimeSnapshot({
-      config: fixture.config,
-      env: fixture.env,
-      agentDirs: [fixture.agentDir],
-      includeConfigRefs: false,
-      loadAuthStore: () => authStore,
-    });
-    const preparedAuthStore = expectDefined(
-      secrets.authStores.find(({ agentDir }) => agentDir === fixture.agentDir),
-      "activated auth store",
-    ).store;
     const worker = createPreparedModelCatalogWorker({
       agentFacts: {
         input: {
@@ -988,7 +975,7 @@ describe("prepared model catalog worker boundary", () => {
           env: fixture.env,
         },
         env: fixture.env,
-        authStore: preparedAuthStore,
+        authStore,
         credentials: {},
         providerIds: [PROVIDER_ID],
         configuredModelRefs: [],

--- a/src/agents/prepared-model-catalog-worker.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.integration.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { buildModelsListResult } from "../gateway/server-methods/models-list-result.js";
@@ -948,7 +949,7 @@ describe("prepared model catalog worker boundary", () => {
     }
   });
 
-  it("preserves ref-only api-key and token profiles through the real worker", async () => {
+  it("preserves ref-only profiles through activation and the real worker", async () => {
     const fixture = await createStaticSnapshot(0);
     const authStore = {
       version: 1,
@@ -965,6 +966,18 @@ describe("prepared model catalog worker boundary", () => {
         },
       },
     };
+    const { prepareSecretsRuntimeSnapshot } = await import("../secrets/runtime.js");
+    const secrets = await prepareSecretsRuntimeSnapshot({
+      config: fixture.config,
+      env: fixture.env,
+      agentDirs: [fixture.agentDir],
+      includeConfigRefs: false,
+      loadAuthStore: () => authStore,
+    });
+    const preparedAuthStore = expectDefined(
+      secrets.authStores.find(({ agentDir }) => agentDir === fixture.agentDir),
+      "activated auth store",
+    ).store;
     const worker = createPreparedModelCatalogWorker({
       agentFacts: {
         input: {
@@ -975,7 +988,7 @@ describe("prepared model catalog worker boundary", () => {
           env: fixture.env,
         },
         env: fixture.env,
-        authStore,
+        authStore: preparedAuthStore,
         credentials: {},
         providerIds: [PROVIDER_ID],
         configuredModelRefs: [],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting a stored MiniMax credential backed by a custom environment SecretRef would send the environment-variable name as the credential when its value was unavailable. Catalog discovery then reported a provider authentication rejection instead of the selected account being locally unavailable.

## Why This Change Was Made

Prepare actual environment-backed material for the selected profile, preserving existing cold command and worker discovery. If that material is missing, use the same canonical profile owner as other SecretRefs: it supplies the selected profile's valid published value or fails before catalog HTTP, without borrowing another account. Provider endpoints, Bearer versus `X-Api-Key` behavior, profile ordering, literal credentials, and synchronous plugin callbacks are unchanged.

This follows MiniMax's documented [OpenAI-compatible](https://platform.minimax.io/docs/api-reference/models/openai/list-models) and [Anthropic-compatible](https://platform.minimax.io/docs/api-reference/models/anthropic/list-models) model-list authentication contracts. No vendor API changes are needed.

## User Impact

Missing environment-backed credentials remain configured but unavailable, and compatible model names remain visible. Restoring the environment value makes cold commands usable again; a running Gateway uses `openclaw secrets reload` to activate the restored secret. Real uppercase literal credentials continue to work; reference names are not inferred from their spelling.

## Evidence

- Exact-head Testbox verification at `fc31ed5c2d8409e9a12b752b31e5a0d577046ac6` passed all 224 cases in ten affected and sibling files: shared auth, the real catalog worker and secret serialization, MiniMax, Chutes, OpenAI catalog contracts, Copilot, Ollama, and configured environment handling.
- All 12 added env-ref regressions fail on the original base for the intended outgoing-header mismatch. They cover `keyRef` and `tokenRef`, both catalog callbacks, published values, missing cold/unpublished material, and selected-account identity. Existing non-env, plain, OAuth, and healthy unactivated-env controls remain intact.
- Five real MiniMax HTTP controls passed: missing built-in/custom refs sent no HTTP, including with another healthy account present; a present custom ref and a genuine uppercase literal each sent the correct credential. The original base sent the custom reference name and received HTTP 401.
- The original ref-only real-worker integration test is unchanged. `pnpm openclaw models list --all --provider minimax-portal --json` with a healthy env-backed profile produced identical model JSON and the same successful authenticated request on the base and final head.
- An isolated real Gateway with a persisted env-backed token account reported it unavailable at cold startup without HTTP. Normal `config set` and `secrets reload` commands recovered the same account; full `models.list` then authenticated discovery and reported it ready. A stopped and restarted Gateway repeated that success from persisted configuration. Temporary processes, servers, state, and the comparison worktree were cleaned up.
- The complete remote changed gate passed, including core and test type graphs, typed changed-path lint, formatting, ratchets, source boundaries, and dependency guards. [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/34079791458) is green, and the [exact-head ClawSweeper review](https://github.com/openclaw/openclaw/pull/140657#issuecomment-5564255604) is Platinum with no before-merge blockers.

No authenticated live-vendor result is claimed; the regression concerns requests that must never leave the process.
