### PR TITLE
fix: keep desktop cleanup retryable after shutdown failures

### DIFF
--- a/docs/gateway/config-browser-ui-desktop.md
+++ b/docs/gateway/config-browser-ui-desktop.md
@@ -212,6 +212,13 @@ managed mode. Managed mode requires `Xtigervnc`, `tigervncpasswd`, and
 fresh temporary VNC password for each managed session, never persists it, and
 supervises both the VNC server and XFCE session.
 
+If desktop teardown fails, the Gateway retains the session's cleanup owner and
+reports the failure in its logs. A new observation retries cleanup before
+starting a replacement. For SSH-backed worker desktops, temporary connection
+files remain until the transport has closed; a late process exit triggers
+another cleanup attempt. Check the reported process or filesystem error before
+retrying an observation that cannot finish cleanup.
+
 Without managed mode, configure third-party servers to listen on loopback when
 they support it. On Linux, use loopback-only TigerVNC or `x11vnc`; GNOME Remote
 Desktop's VeNCrypt mode is not supported. On Windows, enable VNC authentication

--- a/src/gateway/desktop/attachment.test.ts
+++ b/src/gateway/desktop/attachment.test.ts
@@ -203,6 +203,106 @@ describe("RFB attachments", () => {
     await registry.stopAll();
   });
 
+  it("retains failed teardown and prevents replacement until cleanup succeeds", async () => {
+    const registry = createDesktopSessionRegistry();
+    const failure = new Error("transport still running");
+    const teardown = vi.fn().mockRejectedValue(failure);
+    await registry.activate({ sourceKey: "node:one", ownerEpoch: 1, teardown });
+    const start = vi.fn(async () => ({
+      attachment: { kind: "tcp", host: "127.0.0.1", port: 5900 } as const,
+    }));
+    try {
+      await expect(registry.stop("node:one", 1)).rejects.toBe(failure);
+      await expect(registry.acquire({ sourceKey: "node:one", ownerEpoch: 2, start })).rejects.toBe(
+        failure,
+      );
+      await expect(registry.stopAll()).rejects.toBe(failure);
+      expect(start).not.toHaveBeenCalled();
+      expect(registry.reserveObserver("node:one", 1)).toBeUndefined();
+    } finally {
+      teardown.mockResolvedValue(undefined);
+      await registry.stopAll();
+    }
+    await registry.acquire({ sourceKey: "node:one", ownerEpoch: 2, start });
+    expect(start).toHaveBeenCalledOnce();
+    await registry.stopAll();
+  });
+
+  it.each(["epoch", "source", "all"] as const)(
+    "keeps a replacement visible to %s stop while its predecessor drains",
+    async (scope) => {
+      const registry = createDesktopSessionRegistry();
+      const entered = createDeferredCore();
+      const release = createDeferredCore();
+      await registry.activate({
+        sourceKey: "node:one",
+        ownerEpoch: 1,
+        teardown: async () => {
+          entered.resolve();
+          await release.promise;
+        },
+      });
+      const start = vi.fn(async () => ({
+        attachment: { kind: "tcp", host: "127.0.0.1", port: 5900 } as const,
+      }));
+      const acquiring = registry.acquire({ sourceKey: "node:one", ownerEpoch: 2, start });
+      const outcome = acquiring.then(
+        () => "ready",
+        () => "stopped",
+      );
+      await entered.promise;
+      const stopping =
+        scope === "all"
+          ? registry.stopAll()
+          : registry.stop("node:one", scope === "epoch" ? 2 : undefined);
+      release.resolve();
+      try {
+        await stopping;
+        expect(await outcome).toBe("stopped");
+        expect(start).not.toHaveBeenCalled();
+      } finally {
+        await registry.stopAll();
+      }
+    },
+  );
+
+  it("joins sibling teardown before reporting stopAll failure", async () => {
+    const registry = createDesktopSessionRegistry();
+    const release = createDeferredCore();
+    const failure = new Error("cleanup failed");
+    const teardown = vi.fn().mockRejectedValue(failure);
+    await registry.activate({ sourceKey: "node:one", ownerEpoch: 1, teardown });
+    await registry.activate({
+      sourceKey: "node:two",
+      ownerEpoch: 1,
+      teardown: () => release.promise,
+    });
+    let settled = false;
+    const stopping = registry.stopAll().finally(() => {
+      settled = true;
+    });
+    const rejected = expect(stopping).rejects.toBe(failure);
+    try {
+      await setImmediate();
+      expect(settled).toBe(false);
+    } finally {
+      release.resolve();
+      await rejected;
+      teardown.mockResolvedValue(undefined);
+      await registry.stopAll();
+    }
+  });
+
+  it("retains failed resource disposal for a later cleanup retry", async () => {
+    const registry = createDesktopSessionRegistry();
+    const failure = new Error("directory still present");
+    const dispose = vi.fn().mockRejectedValueOnce(failure).mockResolvedValue(undefined);
+    await registry.activate({ sourceKey: "node:one", ownerEpoch: 1, dispose });
+    await expect(registry.stop("node:one", 1)).rejects.toBe(failure);
+    await registry.stopAll();
+    expect(dispose).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps a reserved observer session alive and rearms cleanup on release", async () => {
     vi.useFakeTimers();
     const teardown = vi.fn(async () => undefined);

--- a/src/gateway/desktop/session-registry.ts
+++ b/src/gateway/desktop/session-registry.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from "node:crypto";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { createDeferredCore, type Deferred } from "../../shared/deferred.js";
 import type { ConnectedRfbStream, DesktopRfbAttachment } from "./attachment.js";
 
 const DEFAULT_LINGER_MS = 60_000;
 const MAX_OBSERVERS = 8;
+const log = createSubsystemLogger("gateway/desktop");
 
 export class DesktopSessionStaleOwnerError extends Error {
   constructor() {
@@ -35,8 +37,14 @@ type DesktopSessionAcquireResult = {
 type DesktopSessionAcquireRequest = {
   sourceKey: string;
   ownerEpoch: number;
-  start: (isCurrent: () => boolean) => Promise<DesktopSessionAcquireResult>;
+  /** Lifecycle events stop this exact owner; the stop promise joins initialization. */
+  start: (
+    isCurrent: () => boolean,
+    stop: () => Promise<void>,
+  ) => Promise<DesktopSessionAcquireResult>;
   teardown?: () => Promise<void>;
+  /** Release source resources only after initialization and transport teardown have joined. */
+  dispose?: () => Promise<void>;
 };
 
 type DesktopSessionActivateRequest = Omit<DesktopSessionAcquireRequest, "start">;
@@ -55,8 +63,8 @@ type DesktopSessionEntry = {
   controller?: ObserverEntry;
   lingerTimer?: ReturnType<typeof setTimeout>;
   stopped: boolean;
-  start: (isCurrent: () => boolean) => Promise<DesktopSessionStartResult>;
   teardown?: DesktopSessionAcquireRequest["teardown"];
+  dispose?: DesktopSessionAcquireRequest["dispose"];
   pendingStreams: Map<string, { stream: ConnectedRfbStream; reservation: { release(): void } }>;
 };
 
@@ -68,6 +76,7 @@ export function createDesktopSessionRegistry(
 ) {
   const lingerMs = deps.lingerMs ?? DEFAULT_LINGER_MS;
   const entries = new Map<string, DesktopSessionEntry>();
+  const owners = new Set<DesktopSessionEntry>();
   const claimedOwnerEpochs = new Map<string, number>();
 
   const claimOwnerEpoch = (sourceKey: string, ownerEpoch: number): boolean => {
@@ -100,6 +109,10 @@ export function createDesktopSessionRegistry(
     // Publish cleanup ownership before observer callbacks can reenter Stop.
     const stopped = createDeferredCore();
     entry.stopPromise = stopped.promise;
+    // Idle expiry and transport exit have no caller to report cleanup failure to.
+    void stopped.promise.catch((error: unknown) => {
+      log.warn(`Desktop session cleanup failed: ${String(error)}`, { sourceKey: entry.sourceKey });
+    });
     void (async () => {
       entry.stopped = true;
       clearTimeout(entry.lingerTimer);
@@ -122,18 +135,36 @@ export function createDesktopSessionRegistry(
       }
       // Teardown brackets initialization so a source can stop the currently published
       // transport, then dispose anything initialization publishes before it settles.
-      await entry.teardown?.().catch(() => undefined);
+      await entry.teardown?.();
       await entry.initialization?.catch(() => undefined);
-      await entry.teardown?.().catch(() => undefined);
+      await entry.teardown?.();
+      await entry.dispose?.();
     })()
-      .finally(() => {
+      .then(() => {
+        owners.delete(entry);
         // Concurrent Stop and replacement acquisition must join the full teardown.
         if (entries.get(entry.sourceKey) === entry) {
           entries.delete(entry.sourceKey);
         }
       })
-      .then(stopped.resolve, stopped.reject);
-    return entry.stopPromise;
+      .then(stopped.resolve, (error: unknown) => {
+        // Retain cleanup custody even after a replacement leaves the active index.
+        entry.stopPromise = undefined;
+        stopped.reject(error);
+      });
+    return stopped.promise;
+  };
+
+  const stopEntries = (pending: DesktopSessionEntry[]): Promise<void> => {
+    const stopped = Promise.allSettled(pending.map(stopEntry)).then((outcomes) => {
+      const failure = outcomes.find((outcome) => outcome.status === "rejected");
+      if (failure) {
+        throw failure.reason;
+      }
+    });
+    // Each owner reports its failure; background callers may leave the joined result unawaited.
+    void stopped.catch(() => undefined);
+    return stopped;
   };
 
   const scheduleLinger = (entry: DesktopSessionEntry): void => {
@@ -160,14 +191,12 @@ export function createDesktopSessionRegistry(
     claimOwnerEpoch(request.sourceKey, request.ownerEpoch);
     const current = entries.get(request.sourceKey);
     if (current) {
-      if (request.ownerEpoch < current.ownerEpoch) {
-        throw new DesktopSessionStaleOwnerError();
-      }
       if (request.ownerEpoch === current.ownerEpoch && !current.stopped) {
         return await waitForReady(current);
       }
     }
 
+    const previous = [...owners].filter((entry) => entry.sourceKey === request.sourceKey);
     const ready = createDeferredCore<DesktopSessionStartResult>();
     void ready.promise.catch(() => undefined);
     const entry: DesktopSessionEntry = {
@@ -179,24 +208,26 @@ export function createDesktopSessionRegistry(
       observerReservations: new Set(),
       pendingStreams: new Map(),
       stopped: false,
-      start: request.start,
       ...(request.teardown ? { teardown: request.teardown } : {}),
+      ...(request.dispose ? { dispose: request.dispose } : {}),
     };
     entries.set(request.sourceKey, entry);
-    entry.initialization = (async () => {
-      if (current) {
-        await stopEntry(current);
-      }
+    owners.add(entry);
+    entry.initialization = Promise.resolve().then(async () => {
+      await stopEntries(previous);
       if (!isCurrent(entry)) {
         return;
       }
-      const result = await entry.start(() => isCurrent(entry));
+      const result = await request.start(
+        () => isCurrent(entry),
+        () => stopEntry(entry),
+      );
       if (!isCurrent(entry)) {
         return;
       }
       entry.readySettled = true;
       entry.ready.resolve(result);
-    })();
+    });
     void entry.initialization.catch((error: unknown) => {
       if (!entry.readySettled) {
         entry.readySettled = true;
@@ -347,26 +378,28 @@ export function createDesktopSessionRegistry(
     return entries.get(sourceKey)?.pendingStreams.has(attachment.streamId) ?? false;
   }
 
-  async function stop(sourceKey: string, ownerEpoch?: number): Promise<void> {
-    const entry = entries.get(sourceKey);
-    if (entry && (ownerEpoch === undefined || ownerEpoch === entry.ownerEpoch)) {
-      await stopEntry(entry);
-    }
+  function stop(sourceKey: string, ownerEpoch?: number): Promise<void> {
+    return stopEntries(
+      [...owners].filter(
+        (entry) =>
+          entry.sourceKey === sourceKey &&
+          (ownerEpoch === undefined || ownerEpoch === entry.ownerEpoch),
+      ),
+    );
   }
 
   /**
    * Retires only owners strictly older than the claimant. An equal epoch shares the
    * session, so fencing must not tear down a peer that claimed the same generation.
    */
-  async function stopSuperseded(sourceKey: string, ownerEpoch: number): Promise<void> {
-    const entry = entries.get(sourceKey);
-    if (entry && entry.ownerEpoch < ownerEpoch) {
-      await stopEntry(entry);
-    }
+  function stopSuperseded(sourceKey: string, ownerEpoch: number): Promise<void> {
+    return stopEntries(
+      [...owners].filter((entry) => entry.sourceKey === sourceKey && entry.ownerEpoch < ownerEpoch),
+    );
   }
 
-  async function stopAll(): Promise<void> {
-    await Promise.all([...entries.values()].map(stopEntry));
+  function stopAll(): Promise<void> {
+    return stopEntries([...owners]);
   }
 
   return {

--- a/src/gateway/worker-environments/desktop-tunnel.test.ts
+++ b/src/gateway/worker-environments/desktop-tunnel.test.ts
@@ -1,5 +1,6 @@
 import { access, mkdir, mkdtemp, rm, stat } from "node:fs/promises";
 import path from "node:path";
+import { setImmediate } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WorkerDesktopEndpoint, WorkerSshEndpoint } from "../../plugins/types.js";
 import type { CommandOptions, SpawnResult } from "../../process/exec.js";
@@ -295,6 +296,226 @@ describe("worker desktop tunnels", () => {
     observers.forEach((observer) => observer?.release());
     await manager.stopAll();
   });
+
+  it("retains SSH resources after failed stop and releases them on late exit", async () => {
+    const fake = fakeRunner();
+    const manager = createWorkerDesktopTunnels({ runner: fake.runner });
+    const starting = acquire(manager, 1, { protocol: "rfb", port: 5900 });
+    await waitForStarts(fake.starts, 1);
+    const child = fake.starts[0]!.process;
+    child.becomeReady();
+    const { attachment } = await starting;
+    if (attachment.kind !== "unix-socket") {
+      throw new Error("expected an SSH desktop socket");
+    }
+    const directory = path.dirname(attachment.socketPath);
+    const failure = new Error("SSH child may still be running");
+    const stop = vi.spyOn(child, "stop").mockRejectedValue(failure);
+    try {
+      await expect(manager.stop("worker:one", 1)).rejects.toBe(failure);
+      await access(directory);
+      await expect(acquire(manager, 2)).rejects.toBe(failure);
+      expect(fake.starts).toHaveLength(1);
+      stop.mockRestore();
+      child.exit();
+      await vi.waitFor(async () => {
+        await expect(access(directory)).rejects.toMatchObject({ code: "ENOENT" });
+      });
+    } finally {
+      stop.mockRestore();
+      await child.stop();
+      await manager.stopAll();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("joins identity preparation when stopped before spawning", async () => {
+    const identity = deferred<Awaited<ReturnType<typeof resolveIdentity>>>();
+    const resolving = deferred<void>();
+    const fake = fakeRunner();
+    const manager = createWorkerDesktopTunnels({ runner: fake.runner });
+    const starting = manager.acquire({
+      environmentId: "worker:one",
+      ownerEpoch: 1,
+      ssh: SSH,
+      desktop: DESKTOP,
+      resolveIdentity: () => {
+        resolving.resolve();
+        return identity.promise;
+      },
+    });
+    const rejected = expect(starting).rejects.toThrow("stopped before connecting");
+    await resolving.promise;
+    let stopped = false;
+    const stopping = manager.stop("worker:one", 1).then(() => {
+      stopped = true;
+    });
+    try {
+      await rejected;
+      await setImmediate();
+      expect(stopped).toBe(false);
+      expect(fake.starts).toHaveLength(0);
+    } finally {
+      identity.resolve(await resolveIdentity());
+      await stopping;
+      await manager.stopAll();
+    }
+    expect(fake.starts).toHaveLength(0);
+  });
+
+  it("does not cancel a same-epoch retry when its retained predecessor exits", async () => {
+    const fake = fakeRunner();
+    const start = fake.runner.start.bind(fake.runner);
+    fake.runner.start = (argv, options) => {
+      const child = start(argv, options);
+      fake.starts.at(-1)!.process.becomeReady();
+      return child;
+    };
+    const manager = createWorkerDesktopTunnels({ runner: fake.runner });
+    await acquire(manager, 1, { protocol: "rfb", port: 5900 });
+    const failure = new Error("transport still running");
+    const stop = vi.spyOn(fake.starts[0]!.process, "stop").mockRejectedValueOnce(failure);
+    try {
+      await expect(manager.stop("worker:one", 1)).rejects.toBe(failure);
+      stop.mockRestore();
+      await expect(acquire(manager, 1, { protocol: "rfb", port: 5900 })).resolves.toMatchObject({
+        attachment: { kind: "unix-socket" },
+      });
+      expect(fake.starts).toHaveLength(2);
+    } finally {
+      stop.mockRestore();
+      await manager.stopAll();
+    }
+  });
+
+  it("aborts and joins stale app launches even when predecessor teardown fails", async () => {
+    const launchResult = deferred<SpawnResult>();
+    const fake = fakeRunner(() => launchResult.promise);
+    const manager = createWorkerDesktopTunnels({ runner: fake.runner });
+    const starting = acquire(manager, 1, { protocol: "rfb", port: 5900 });
+    await waitForStarts(fake.starts, 1);
+    fake.starts[0]!.process.becomeReady();
+    await starting;
+    const launching = launchApp(manager);
+    await vi.waitFor(() => expect(fake.runs).toHaveLength(1));
+    const failure = new Error("predecessor still running");
+    const stop = vi.spyOn(fake.starts[0]!.process, "stop").mockRejectedValue(failure);
+    let settled = false;
+    const replacing = acquire(manager, 2, { protocol: "rfb", port: 5900 }).finally(() => {
+      settled = true;
+    });
+    const rejected = expect(replacing).rejects.toBe(failure);
+    try {
+      await setImmediate();
+      expect(fake.runs[0]!.options.signal?.aborted).toBe(true);
+      expect(settled).toBe(false);
+    } finally {
+      launchResult.resolve(success());
+      await Promise.all([launching, rejected]);
+      stop.mockRestore();
+      await manager.stopAll();
+    }
+    expect(fake.starts).toHaveLength(1);
+  });
+
+  it("publishes a replacement before a stale launch abort can reenter Stop", async () => {
+    let reentrantStop: Promise<void> | undefined;
+    const fake = fakeRunner(
+      (_argv, options) =>
+        new Promise<SpawnResult>((resolve) => {
+          options.signal!.addEventListener(
+            "abort",
+            () => {
+              reentrantStop = manager.stop("worker:one", 2);
+              resolve(success());
+            },
+            { once: true },
+          );
+        }),
+    );
+    const manager = createWorkerDesktopTunnels({ runner: fake.runner });
+    const launching = launchApp(manager);
+    await vi.waitFor(() => expect(fake.runs).toHaveLength(1));
+    try {
+      await expect(acquire(manager, 2, { protocol: "rfb", port: 5900 })).rejects.toThrow(
+        "stopped before connecting",
+      );
+      await Promise.all([launching, reentrantStop]);
+      expect(reentrantStop).toBeDefined();
+      expect(fake.starts).toHaveLength(0);
+    } finally {
+      await manager.stopAll();
+    }
+  });
+
+  it("cancels a replacement while the previous desktop is stopping", async () => {
+    const fake = fakeRunner();
+    const start = fake.runner.start.bind(fake.runner);
+    fake.runner.start = (argv, options) => {
+      const child = start(argv, options);
+      fake.starts.at(-1)!.process.becomeReady();
+      return child;
+    };
+    const manager = createWorkerDesktopTunnels({ runner: fake.runner });
+    await acquire(manager, 1, { protocol: "rfb", port: 5900 });
+    const child = fake.starts[0]!.process;
+    const stop = child.stop.bind(child);
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const stoppingChild = vi.spyOn(child, "stop").mockImplementation(async () => {
+      entered.resolve();
+      await release.promise;
+      await stop();
+    });
+    const replacement = acquire(manager, 2, { protocol: "rfb", port: 5900 });
+    const outcome = replacement.then(
+      () => "ready",
+      () => "stopped",
+    );
+    await entered.promise;
+    const stopping = manager.stop("worker:one", 2);
+    release.resolve();
+    try {
+      await stopping;
+      expect(await outcome).toBe("stopped");
+      expect(fake.starts).toHaveLength(1);
+    } finally {
+      stoppingChild.mockRestore();
+      await manager.stopAll();
+    }
+  });
+
+  it.each(["readiness", "password"] as const)(
+    "joins %s before disposing a cancelled desktop",
+    async (phase) => {
+      const password = deferred<SpawnResult>();
+      const fake = fakeRunner(() => password.promise);
+      const manager = createWorkerDesktopTunnels({ runner: fake.runner });
+      const starting = acquire(manager);
+      const rejected = expect(starting).rejects.toThrow("stopped before connecting");
+      await waitForStarts(fake.starts, 1);
+      const started = fake.starts[0]!;
+      const socket = started.argv[started.argv.indexOf("-L") + 1]!.split(":127.0.0.1:")[0]!;
+      const directory = path.dirname(socket);
+      if (phase === "password") {
+        started.process.becomeReady();
+        await vi.waitFor(() => expect(fake.runs).toHaveLength(1));
+      }
+      const stopping = manager.stop("worker:one", 1);
+      try {
+        await rejected;
+        if (phase === "password") {
+          await setImmediate();
+          await access(directory);
+        }
+      } finally {
+        password.resolve(success("synthetic-password"));
+        await stopping;
+        await manager.stopAll();
+      }
+      await expect(access(directory)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
 
   it("lingers after the last observer and closes observers on child exit", async () => {
     vi.useFakeTimers();

--- a/src/gateway/worker-environments/desktop-tunnel.ts
+++ b/src/gateway/worker-environments/desktop-tunnel.ts
@@ -21,6 +21,7 @@ import {
   workerSshOptions,
   workerSshRemoteCommand,
 } from "./ssh.js";
+import { joinWorkerTunnelStops } from "./tunnel-contract.js";
 import {
   type WorkerSshProcess,
   type WorkerSshRunner,
@@ -105,8 +106,10 @@ export function createWorkerDesktopTunnels(deps: {
     }
   };
 
-  const fenceReplacedOwners = async (environmentId: string, ownerEpoch: number): Promise<void> => {
-    await sessions.stopSuperseded(environmentId, ownerEpoch);
+  const stopReplacedAppLaunches = async (
+    environmentId: string,
+    ownerEpoch: number,
+  ): Promise<void> => {
     const staleLaunches = [...appLaunches.values()].filter(
       (entry) => entry.environmentId === environmentId && entry.ownerEpoch < ownerEpoch,
     );
@@ -116,136 +119,132 @@ export function createWorkerDesktopTunnels(deps: {
     await Promise.allSettled(staleLaunches.map((entry) => entry.operation));
   };
 
+  const fenceReplacedOwners = async (environmentId: string, ownerEpoch: number): Promise<void> => {
+    await joinWorkerTunnelStops([
+      sessions.stopSuperseded(environmentId, ownerEpoch),
+      stopReplacedAppLaunches(environmentId, ownerEpoch),
+    ]);
+  };
+
   const createSessionHooks = (request: DesktopAcquireRequest) => {
     let prepared: PreparedWorkerSsh | undefined;
     let child: WorkerSshProcess | undefined;
-    let stoppedChild: WorkerSshProcess | undefined;
-    let startSettled = false;
 
-    const start = async (isCurrent: () => boolean): Promise<DesktopAcquireResult> => {
-      try {
-        prepared = await prepareWorkerSsh({
-          ssh: request.ssh,
-          pinnedHostKey: request.ssh.hostKey,
-          resolveIdentity: request.resolveIdentity,
-          // macOS Unix sockets allow 103 bytes; share one short private directory with SSH credentials.
-          temporaryDirectoryPrefix: "/tmp/openclaw-worker-desktop-",
-        });
-        if (!isCurrent()) {
-          await prepared.dispose();
-          prepared = undefined;
-          throw new Error("Worker desktop tunnel stopped before connecting");
-        }
-        const localSocketPath = path.join(path.dirname(prepared.knownHostsPath), "desktop.sock");
-        child = deps.runner.start(
+    const start = async (
+      isCurrent: () => boolean,
+      stopOwner: () => Promise<void>,
+    ): Promise<DesktopAcquireResult> => {
+      if (!isCurrent()) {
+        throw new Error("Worker desktop tunnel stopped before connecting");
+      }
+      prepared = await prepareWorkerSsh({
+        ssh: request.ssh,
+        pinnedHostKey: request.ssh.hostKey,
+        resolveIdentity: request.resolveIdentity,
+        // macOS Unix sockets allow 103 bytes; share one short private directory with SSH credentials.
+        temporaryDirectoryPrefix: "/tmp/openclaw-worker-desktop-",
+      });
+      if (!isCurrent()) {
+        throw new Error("Worker desktop tunnel stopped before connecting");
+      }
+      const localSocketPath = path.join(path.dirname(prepared.knownHostsPath), "desktop.sock");
+      child = deps.runner.start(
+        [
+          "ssh",
+          ...workerSshOptions(prepared, { forwarding: "explicit" }),
+          "-a",
+          "-x",
+          "-T",
+          "-o",
+          "ServerAliveInterval=15",
+          "-o",
+          "ServerAliveCountMax=3",
+          "-o",
+          "StreamLocalBindMask=0177",
+          "-L",
+          `${localSocketPath}:127.0.0.1:${request.desktop.port}`,
+          "-p",
+          String(prepared.port),
+          "--",
+          prepared.sshTarget,
+          workerSshRemoteCommand(["sh", "-s"]),
+        ],
+        workerSshCommandOptions({
+          input: REMOTE_DESKTOP_READY_SCRIPT,
+          timeoutMs: Number.MAX_SAFE_INTEGER,
+        }),
+      );
+      const startedChild = child;
+      void startedChild.exited.then(() => {
+        void stopOwner();
+      });
+      await startedChild.ready;
+      if (!isCurrent()) {
+        throw new Error("Worker desktop tunnel stopped before connecting");
+      }
+      let vncPassword: string | undefined;
+      if (request.desktop.passwordFilePath) {
+        const result = await deps.runner.run(
           [
             "ssh",
-            ...workerSshOptions(prepared, { forwarding: "explicit" }),
+            ...workerSshOptions(prepared, { forwarding: "disabled" }),
             "-a",
             "-x",
             "-T",
-            "-o",
-            "ServerAliveInterval=15",
-            "-o",
-            "ServerAliveCountMax=3",
-            "-o",
-            "StreamLocalBindMask=0177",
-            "-L",
-            `${localSocketPath}:127.0.0.1:${request.desktop.port}`,
             "-p",
             String(prepared.port),
             "--",
             prepared.sshTarget,
-            workerSshRemoteCommand(["sh", "-s"]),
+            workerSshRemoteCommand(["cat", request.desktop.passwordFilePath]),
           ],
-          workerSshCommandOptions({
-            input: REMOTE_DESKTOP_READY_SCRIPT,
-            timeoutMs: Number.MAX_SAFE_INTEGER,
-          }),
+          workerSshCommandOptions({ timeoutMs: PASSWORD_READ_TIMEOUT_MS }),
         );
-        const startedChild = child;
-        void startedChild.exited.then(() => {
-          if (isCurrent()) {
-            void sessions.stop(request.environmentId, request.ownerEpoch);
-          }
-        });
-        await startedChild.ready;
-        if (!isCurrent()) {
-          await startedChild.stop();
-          throw new Error("Worker desktop tunnel stopped before connecting");
+        if (!successful(result)) {
+          throw workerSshProcessError(result.stderr || result.stdout);
         }
-        let vncPassword: string | undefined;
-        if (request.desktop.passwordFilePath) {
-          const result = await deps.runner.run(
-            [
-              "ssh",
-              ...workerSshOptions(prepared, { forwarding: "disabled" }),
-              "-a",
-              "-x",
-              "-T",
-              "-p",
-              String(prepared.port),
-              "--",
-              prepared.sshTarget,
-              workerSshRemoteCommand(["cat", request.desktop.passwordFilePath]),
-            ],
-            workerSshCommandOptions({ timeoutMs: PASSWORD_READ_TIMEOUT_MS }),
-          );
-          if (!successful(result)) {
-            throw workerSshProcessError(result.stderr || result.stdout);
-          }
-          vncPassword = result.stdout.replace(/(?:\r?\n)+$/u, "");
-          if (!vncPassword) {
-            throw new Error("Worker desktop password file is empty");
-          }
-          registerSecretValueForRedaction(vncPassword);
+        vncPassword = result.stdout.replace(/(?:\r?\n)+$/u, "");
+        if (!vncPassword) {
+          throw new Error("Worker desktop password file is empty");
         }
-        return {
-          attachment: { kind: "unix-socket", socketPath: localSocketPath },
-          ...(vncPassword ? { vncPassword } : {}),
-        };
-      } finally {
-        startSettled = true;
+        registerSecretValueForRedaction(vncPassword);
       }
+      return {
+        attachment: { kind: "unix-socket", socketPath: localSocketPath },
+        ...(vncPassword ? { vncPassword } : {}),
+      };
     };
 
-    const teardown = async (): Promise<void> => {
-      if (child && child !== stoppedChild) {
-        stoppedChild = child;
-        await child.stop().catch(() => undefined);
-      }
-      if (!startSettled) {
-        return;
-      }
-      if (child && child !== stoppedChild) {
-        stoppedChild = child;
-        await child?.stop().catch(() => undefined);
-      }
-      await prepared?.dispose().catch(() => undefined);
-      prepared = undefined;
+    return {
+      start,
+      teardown: async () => {
+        await child?.stop();
+      },
+      dispose: async () => {
+        await prepared?.dispose();
+      },
     };
-
-    return { start, teardown };
   };
 
   async function acquire(request: DesktopAcquireRequest): Promise<DesktopAcquireResult> {
     if (platform === "win32") {
       throw new WorkerDesktopUnsupportedError();
     }
-    const ownerAdvanced = claimOwnerEpoch(request.environmentId, request.ownerEpoch);
-    if (ownerAdvanced) {
-      await fenceReplacedOwners(request.environmentId, request.ownerEpoch);
-    }
-    if (!sessions.isOwnerEpochCurrent(request.environmentId, request.ownerEpoch)) {
-      throw new Error("Worker desktop owner epoch is stale");
-    }
     const hooks = createSessionHooks(request);
     try {
-      return await sessions.acquire({
+      claimOwnerEpoch(request.environmentId, request.ownerEpoch);
+      // Register before abort callbacks can reenter Stop; the registry defers source startup.
+      const acquiring = sessions.acquire({
         sourceKey: request.environmentId,
         ownerEpoch: request.ownerEpoch,
         ...hooks,
+        start: async (isCurrent, stopOwner) => {
+          await fencing;
+          return await hooks.start(isCurrent, stopOwner);
+        },
       });
+      const fencing = stopReplacedAppLaunches(request.environmentId, request.ownerEpoch);
+      await joinWorkerTunnelStops([acquiring.then(() => undefined), fencing]);
+      return await acquiring;
     } catch (error) {
       if (error instanceof DesktopSessionStaleOwnerError) {
         throw new Error("Worker desktop owner epoch is stale", { cause: error });
@@ -368,7 +367,7 @@ export function createWorkerDesktopTunnels(deps: {
   }
 
   async function stop(environmentId: string, ownerEpoch?: number): Promise<void> {
-    await Promise.all([
+    await joinWorkerTunnelStops([
       sessions.stop(environmentId, ownerEpoch),
       stopAppLaunches(environmentId, ownerEpoch),
     ]);
@@ -378,7 +377,7 @@ export function createWorkerDesktopTunnels(deps: {
     for (const entry of appLaunches.values()) {
       entry.abortController.abort(new Error("Worker desktop app launcher stopped"));
     }
-    await Promise.all([
+    await joinWorkerTunnelStops([
       sessions.stopAll(),
       ...[...appLaunches.values()].map((entry) => entry.operation.catch(() => undefined)),
     ]);

--- a/src/gateway/worker-environments/ssh.test.ts
+++ b/src/gateway/worker-environments/ssh.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { WorkerSshEndpoint } from "../../plugins/types.js";
 import {
@@ -27,6 +28,22 @@ function prepareTestWorkerSsh() {
 }
 
 describe("worker SSH preparation", () => {
+  it("retries disposal after a filesystem cleanup failure", async () => {
+    const prepared = await prepareTestWorkerSsh();
+    const directory = path.dirname(prepared.knownHostsPath);
+    const failure = new Error("synthetic cleanup failure");
+    const remove = vi.spyOn(fs, "rm").mockRejectedValueOnce(failure);
+    try {
+      await expect(prepared.dispose()).rejects.toBe(failure);
+      await fs.access(directory);
+      await prepared.dispose();
+      await expect(fs.access(directory)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      remove.mockRestore();
+      await fs.rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it("adapts pinned endpoint identity and every advertised port for sandbox SSH", () => {
     expect(
       resolveWorkerSshSandboxSettings({

--- a/src/gateway/worker-environments/ssh.ts
+++ b/src/gateway/worker-environments/ssh.ts
@@ -204,8 +204,8 @@ export async function prepareWorkerSsh(params: {
         if (disposed) {
           return;
         }
-        disposed = true;
         await fs.rm(temporaryDir, { recursive: true, force: true });
+        disposed = true;
       },
     };
   } catch (error) {

--- a/src/gateway/worker-environments/tunnel-ssh-runner.test.ts
+++ b/src/gateway/worker-environments/tunnel-ssh-runner.test.ts
@@ -153,6 +153,10 @@ describe("worker SSH process runner", () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(exitedSettled).toBe(false);
+
+    child.emit("close", null, "SIGKILL");
+    await expect(process.exited).resolves.toEqual({ code: null, signal: "SIGKILL" });
+    await expect(process.stop()).resolves.toBeUndefined();
   });
 
   it("keeps exited pending when a live child emits error without close", async () => {

--- a/src/gateway/worker-environments/tunnel-ssh-runner.ts
+++ b/src/gateway/worker-environments/tunnel-ssh-runner.ts
@@ -183,7 +183,10 @@ export function createWorkerSshRunner(): WorkerSshRunner {
                 );
               }
             }
-          })());
+          })().catch((error: unknown) => {
+            stopPromise = undefined;
+            throw error;
+          }));
         },
       };
     },

--- a/src/gateway/worker-environments/tunnel.test-support.ts
+++ b/src/gateway/worker-environments/tunnel.test-support.ts
@@ -200,6 +200,7 @@ class FakeProcess implements WorkerSshProcess {
   readonly ready = this.readyDeferred.promise;
   readonly exited = this.exitDeferred.promise;
   stopCount = 0;
+  private stopPromise?: Promise<void>;
   private stopBarrier: Promise<void> | undefined;
 
   becomeReady() {
@@ -219,11 +220,13 @@ class FakeProcess implements WorkerSshProcess {
     this.stopBarrier = barrier;
   }
 
-  async stop() {
-    this.stopCount += 1;
-    await this.stopBarrier;
-    this.readyDeferred.reject(new Error("stopped"));
-    this.exitDeferred.resolve({ code: null, signal: "SIGTERM" });
+  stop() {
+    return (this.stopPromise ??= (async () => {
+      this.stopCount += 1;
+      await this.stopBarrier;
+      this.readyDeferred.reject(new Error("stopped"));
+      this.exitDeferred.resolve({ code: null, signal: "SIGTERM" });
+    })());
   }
 }
 

--- a/src/gateway/worker-environments/tunnel.test.ts
+++ b/src/gateway/worker-environments/tunnel.test.ts
@@ -15,6 +15,40 @@ import {
 } from "./tunnel.test-support.js";
 
 describe("worker tunnel manager", () => {
+  it("joins workspace cleanup before reporting a desktop stopAll failure", async () => {
+    const identity = deferred<Awaited<ReturnType<typeof resolveIdentity>>>();
+    const entered = deferred<void>();
+    const manager = createWorkerTunnelManager({ runner: fakeRunner().runner });
+    const starting = manager.start({
+      environmentId: "worker:pending",
+      ownerEpoch: 1,
+      bundleHash: "a".repeat(64),
+      ssh: SSH,
+      resolveIdentity: () => {
+        entered.resolve();
+        return identity.promise;
+      },
+    });
+    const rejectedStart = expect(starting).rejects.toThrow("no longer connected");
+    await entered.promise;
+    const failure = new Error("desktop cleanup failed");
+    const desktopStop = vi.spyOn(manager.desktop, "stopAll").mockRejectedValue(failure);
+    let settled = false;
+    const stopping = manager.stopAll().finally(() => {
+      settled = true;
+    });
+    const rejectedStop = expect(stopping).rejects.toBe(failure);
+    try {
+      await setImmediate();
+      expect(settled).toBe(false);
+    } finally {
+      identity.resolve(await resolveIdentity());
+      await Promise.all([rejectedStart, rejectedStop]);
+      desktopStop.mockRestore();
+      await manager.stopAll();
+    }
+  });
+
   it("cascades only an epoch-matched environment stop into the desktop tunnel owner", async () => {
     const fake = fakeRunner();
     const manager = createWorkerTunnelManager({ runner: fake.runner });

--- a/src/gateway/worker-environments/tunnel.ts
+++ b/src/gateway/worker-environments/tunnel.ts
@@ -4,6 +4,7 @@ import type { DesktopSessionRegistry } from "../desktop/session-registry.js";
 import { createWorkerDesktopTunnels } from "./desktop-tunnel.js";
 import { prepareWorkerSsh, type PreparedWorkerSsh, type WorkerSshIdentityResolver } from "./ssh.js";
 import {
+  joinWorkerTunnelStops,
   WorkerTunnelOwnerDisconnectedError,
   type WorkerTunnelHandle,
   type WorkerTunnelRequest,
@@ -178,7 +179,7 @@ export function createWorkerTunnelManager(options: WorkerTunnelManagerOptions = 
   }
 
   async function stopAll(): Promise<void> {
-    await Promise.all([...[...owners].map(stopEntry), desktop.stopAll()]);
+    await joinWorkerTunnelStops([...[...owners].map(stopEntry), desktop.stopAll()]);
   }
 
   return {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stopping or reopening a worker desktop could report successful cleanup after SSH termination failed, while the transport was still running and its temporary connection files had already been deleted. A filesystem cleanup failure also made later disposal attempts incorrectly succeed without removing the directory.

## Why This Change Was Made

The desktop session registry now owns final resource disposal after startup and transport teardown have joined. Failed cleanup retains the stopped session and blocks replacement until a later attempt succeeds. This removes the SSH desktop hook's duplicate startup/stop flags and disposal branches. The SSH runner permits a new stop attempt after failure, including recovery after a late close, and SSH preparation marks disposal complete only after removal succeeds.

Pending acquisitions remain registered while predecessors drain; older app launches are cancelled immediately after registration and joined even if predecessor teardown fails, and worker managers join all sibling cleanup through the existing worker stop helper before reporting failure.

Readiness markers, output-drain policy, signal escalation deadlines, observer limits, and public configuration are preserved. Owner epochs continue to fence desktop access. No persistence, protocol, dependency, or public SDK changes.

## User Impact

Desktop cleanup failures remain visible and retryable. Reopening a desktop cannot replace an unresolved owner, and temporary SSH files survive an unconfirmed shutdown. A late transport exit triggers cleanup of that exact retained owner, without cancelling a same-epoch retry.

## Evidence

- The original 48 focused tests passed on the baseline. Four added/extended regressions failed before the production change for hidden stop errors, lost resources, failed disposal retry, and cached failure after real closure.
- 115 unique owner and sibling tests pass (114-case owner/sibling run followed by the final 24-case desktop suite), covering host and paired-node desktops, SSH preparation, worker desktop and workspace tunnels, cancellation before spawn and during readiness/password reads, cleanup retry, and sibling joining.
- Real synthetic subprocess fault injection: stop rejects and retains the directory while fresh child output proves the child is still running. The test then restores signal delivery, reopens in the same owner epoch, and proves predecessor exit does not cancel the replacement before joining closure and completing cleanup.
- Real loopback OpenSSH proof: generated test keys, pinned host key, remote readiness, Unix-socket RFB forwarding, natural remote exit, and directory disposal. The fixture daemon's exit was joined and its resources were removed. The macOS SSH client emitted its TCP_NODELAY warning for the Unix socket; forwarding and exit remained successful.
- Production delta: +169 / -133, net +36. Tests: +376 / -0. Test support: +8 / -5. Docs: +7. No generated output, snapshots, lockfiles, or moved files.

- Final core typecheck, all 16 selected core test type graphs, and lint across all changed TypeScript files pass. A shadowed callback name found by the remote changed gate was corrected without changing its binding.
- Isolated independent review is clean through P2; the final follow-up was only the callback rename for lint. Exact-head required CI remains a landing gate.
