### PR TITLE
fix(qa): preserve confidence report impact columns

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -1419,6 +1419,10 @@ producer `qa-evidence.json`. When `qa suite` is reached through `qa run
 --qa-profile`, the same `qa-evidence.json` also includes the profile
 scorecard summary for the selected taxonomy categories.
 
+`qa confidence-report` keeps `productImpact` and `qaImpact` annotations in their
+own Markdown table cells, collapsing whitespace for display. The JSON summary
+preserves the annotation values, including internal line breaks.
+
 Treat coverage output as a discovery aid, not a gate replacement; the
 selected scenario still needs the right provider mode, live transport,
 Multipass, Testbox, or release lane for the behavior under test. For

--- a/extensions/qa-lab/src/confidence-report.markdown.test.ts
+++ b/extensions/qa-lab/src/confidence-report.markdown.test.ts
@@ -1,0 +1,136 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { markdownToIRWithMeta } from "openclaw/plugin-sdk/text-chunking";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildQaConfidenceReport, renderQaConfidenceMarkdownReport } from "./confidence-report.js";
+
+describe("qa confidence report Markdown", () => {
+  let tempRoot: string;
+
+  beforeEach(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-confidence-markdown-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it.each([
+    {
+      name: "ordinary priorities",
+      productImpact: "P1",
+      qaImpact: "P2",
+      expectedImpacts: ["P1", "P2"],
+    },
+    {
+      name: "a product-impact pipe",
+      productImpact: "P1 | desktop",
+      qaImpact: "P2",
+      expectedImpacts: ["P1 | desktop", "P2"],
+    },
+    {
+      name: "a QA-impact pipe",
+      productImpact: "P1",
+      qaImpact: "P2 | harness",
+      expectedImpacts: ["P1", "P2 | harness"],
+    },
+    {
+      name: "a product-impact backslash and pipe",
+      productImpact: String.raw`P1 \| desktop`,
+      qaImpact: "P2",
+      expectedImpacts: [String.raw`P1 \| desktop`, "P2"],
+    },
+    {
+      name: "a QA-impact backslash and pipe",
+      productImpact: "P1",
+      qaImpact: String.raw`P2 \| harness`,
+      expectedImpacts: ["P1", String.raw`P2 \| harness`],
+    },
+    {
+      name: "a product-impact newline",
+      productImpact: "P1\ndesktop",
+      qaImpact: "P2",
+      expectedImpacts: ["P1 desktop", "P2"],
+    },
+    {
+      name: "a QA-impact newline",
+      productImpact: "P1",
+      qaImpact: "P2\nharness",
+      expectedImpacts: ["P1", "P2 harness"],
+    },
+  ])(
+    "preserves $name in the confidence table",
+    async ({ productImpact, qaImpact, expectedImpacts }) => {
+      const report = await buildQaConfidenceReport({
+        manifest: {
+          version: 1,
+          profile: "confidence-table",
+          lanes: [
+            {
+              id: "missing",
+              title: "Missing",
+              kind: "qa-suite-summary",
+              artifact: "missing/qa-suite-summary.json",
+              required: true,
+              missingVerdict: "environment-blocked",
+              missingReason: String.raw`path\|fallback unavailable`,
+              productImpact,
+              qaImpact,
+            },
+            {
+              id: "following-control",
+              title: "Following control",
+              kind: "qa-suite-summary",
+              artifact: "control/qa-suite-summary.json",
+              required: true,
+              missingVerdict: "environment-blocked",
+              missingReason: "Control unavailable.",
+              productImpact: "P4",
+              qaImpact: "P0",
+            },
+          ],
+        },
+        artifactRoot: tempRoot,
+        strictGlobalPass: true,
+        generatedAt: "2026-05-13T00:00:00.000Z",
+      });
+      const markdown = renderQaConfidenceMarkdownReport(report);
+      const { tables } = markdownToIRWithMeta(markdown, { tableMode: "block" });
+
+      expect(tables).toHaveLength(1);
+      expect(tables[0]?.headers).toEqual([
+        "Lane",
+        "Status",
+        "Verdict",
+        "Product impact",
+        "QA impact",
+        "Details",
+      ]);
+      expect(tables[0]?.rows).toEqual([
+        [
+          "missing",
+          "blocked",
+          "environment-blocked",
+          ...expectedImpacts,
+          String.raw`path\|fallback unavailable`,
+        ],
+        ["following-control", "blocked", "environment-blocked", "P4", "P0", "Control unavailable."],
+      ]);
+      expect(report.lanes[0]).toMatchObject({
+        productImpact,
+        qaImpact,
+        details: String.raw`path\|fallback unavailable`,
+      });
+      expect(report.counts).toEqual({
+        total: 2,
+        passed: 0,
+        failed: 0,
+        blocked: 2,
+        missing: 0,
+        unknown: 0,
+      });
+      expect(report).toMatchObject({ pass: false, zeroUnknowns: true, globalPass: false });
+    },
+  );
+});

--- a/extensions/qa-lab/src/confidence-report.test.ts
+++ b/extensions/qa-lab/src/confidence-report.test.ts
@@ -208,32 +208,6 @@ describe("qa confidence report", () => {
     expect(report.lanes[1]).toMatchObject({ id: "optional-missing", status: "missing" });
   });
 
-  it("escapes backslashes before Markdown table delimiters", async () => {
-    const report = await buildQaConfidenceReport({
-      manifest: {
-        version: 1,
-        profile: "codex-100",
-        lanes: [
-          {
-            id: "missing",
-            title: "Missing",
-            kind: "qa-suite-summary",
-            artifact: "missing/qa-suite-summary.json",
-            required: true,
-            missingVerdict: "environment-blocked",
-            missingReason: String.raw`path\|fallback unavailable`,
-          },
-        ],
-      },
-      artifactRoot: tempRoot,
-      generatedAt: "2026-05-13T00:00:00.000Z",
-    });
-
-    expect(renderQaConfidenceMarkdownReport(report)).toContain(
-      String.raw`path\\\|fallback unavailable`,
-    );
-  });
-
   it("fails strict global pass when any lane is blocked, missing, unknown, or classified failed", async () => {
     await writeJson("classified/qa-suite-summary.json", {
       counts: { total: 1, passed: 0, skipped: 0, failed: 1 },

--- a/extensions/qa-lab/src/confidence-report.ts
+++ b/extensions/qa-lab/src/confidence-report.ts
@@ -939,7 +939,7 @@ export function renderQaConfidenceMarkdownReport(report: QaConfidenceReport): st
   ];
   for (const lane of report.lanes) {
     lines.push(
-      `| ${escapeTableCell(lane.id)} | ${lane.status} | ${formatVerdict(lane)} | ${lane.productImpact ?? ""} | ${lane.qaImpact ?? ""} | ${escapeTableCell(lane.details)} |`,
+      `| ${escapeTableCell(lane.id)} | ${lane.status} | ${formatVerdict(lane)} | ${escapeTableCell(lane.productImpact ?? "")} | ${escapeTableCell(lane.qaImpact ?? "")} | ${escapeTableCell(lane.details)} |`,
     );
   }
   if (report.failures.length > 0) {


### PR DESCRIPTION
Closes #140623

## What Problem This Solves

Fixes source-checkout QA confidence reports that shift Product impact, QA impact and Details into the wrong columns when an impact annotation contains a pipe, or split a row when it contains a newline.

## Why This Change Was Made

Both impact annotations now pass through the report's existing table-cell encoder, alongside the lane ID and Details. This fixes the omitted call sites without adding a helper or changing report data and confidence decisions.

## User Impact

Impact annotations stay in their intended columns and the diagnostic remains visible. Existing whitespace folding applies to Markdown display; JSON retains the original normalized annotations. The Reporting reference documents that distinction.

## Evidence

- Before: six intended parser failures and one ordinary-priority control. Identical seven-case regression passes after the repair.
- Normal CLI before/after runs wrote actual Markdown and JSON from a synthetic two-lane manifest. Both intentionally report two blocked lanes; JSON is identical except for its timestamp.
- Both Markdown artifacts were rendered through the pinned parser and inspected in isolated Chromium. Before: the first row displays `P1`, `desktop`, `P2` in the final three columns. After: `P1 | desktop`, `P2 | harness`, and the complete diagnostic appear in the correct cells. The following control remains identical.
- All 65 final confidence/Markdown/tool-coverage tests pass; focused lint and the complete four-path changed gate pass. The first full gate caught the existing test file size limit; the seven rendering cases were moved intact into their own file, followed by fresh tests, full gate and clean independent P0–P2 review. Reviewed/signed head: `b563308a24fd9776d9e8a49c8c8cb56b0231d188`. The completed CLI proof uses identical production and documentation bytes.

Production +1/-1 (net zero), tests +136/-26 (net +110), docs +4. No schema, config, dependency, SDK or verdict changes. This uses the normal source-checkout QA command and its runtime build; no provider or live Gateway execution is claimed. Introduction is not attributed. Direct source inspection of [stable v2026.9.2](https://github.com/openclaw/openclaw/blob/3928bad9badfcb6c7d140530435e806fb8092190/extensions/qa-lab/src/confidence-report.ts#L942) confirms the same unencoded impact fields; this does not establish distribution of private QA in its package.

![Before: impact values shift columns and hide Details](https://github.com/user-attachments/assets/7db0e9cf-b98b-447a-963f-d1afafc5c41e)

![After: both impact annotations and Details stay in their intended cells](https://github.com/user-attachments/assets/ca4c7b7e-af37-449b-bb0d-2a97f086ca36)
