### PR TITLE
refactor(scripts): share shrink ratchet argument parsing

### DIFF
--- a/scripts/check-assertion-safety-ratchet.mts
+++ b/scripts/check-assertion-safety-ratchet.mts
@@ -9,6 +9,7 @@ import {
   loadRatchetReference,
   loadRatchetSnapshot,
   loadRatchetSources,
+  parseRatchetArgs,
   parseRatchetCounts,
   reportRatchetFailures,
   reportRatchetSuccess,
@@ -250,31 +251,6 @@ function writeBaseline(root: string, counts: ReadonlyMap<string, number>) {
   fs.writeFileSync(path.join(root, BASELINE_PATH), formatBaseline(counts));
 }
 
-function parseArgs(argv: string[]) {
-  const args: { base?: string; prune: boolean; staged: boolean } = {
-    prune: false,
-    staged: false,
-  };
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === "--prune") {
-      args.prune = true;
-      continue;
-    }
-    if (arg === "--staged") {
-      args.staged = true;
-      continue;
-    }
-    if (arg === "--base" && argv[index + 1]) {
-      args.base = argv[index + 1];
-      index += 1;
-      continue;
-    }
-    throw new Error("Unknown or incomplete argument: " + arg);
-  }
-  return args;
-}
-
 function formatDeltas(entries: RatchetCountDelta[], comparison: ">" | "<") {
   return entries.map((entry) => `${entry.entry}: ${entry.current} ${comparison} ${entry.allowed}`);
 }
@@ -285,7 +261,7 @@ function totalCount(counts: ReadonlyMap<string, number>) {
 
 export function main(root = process.cwd(), argv: string[] = process.argv.slice(2)) {
   try {
-    const args = parseArgs(argv);
+    const args = parseRatchetArgs(argv);
     if (args.staged && args.prune) {
       throw new Error("--prune cannot be combined with --staged");
     }

--- a/scripts/check-max-lines-ratchet.mts
+++ b/scripts/check-max-lines-ratchet.mts
@@ -10,6 +10,7 @@ import {
   loadRatchetReference,
   loadRatchetSnapshot,
   loadRatchetSources,
+  parseRatchetArgs,
   parseRatchetPaths,
   reportRatchetFailures,
   reportRatchetSuccess,
@@ -186,36 +187,14 @@ function writeBaseline(root: string, entries: string[]) {
   fs.writeFileSync(path.join(root, BASELINE_PATH), BASELINE_HEADER + entries.join("\n") + "\n");
 }
 
-function parseArgs(argv: string[]) {
-  const args: { base?: string; prune: boolean; staged: boolean } = { prune: false, staged: false };
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === "--prune") {
-      args.prune = true;
-      continue;
-    }
-    if (arg === "--staged") {
-      args.staged = true;
-      continue;
-    }
-    if (arg === "--base" && argv[index + 1]) {
-      args.base = argv[index + 1];
-      index += 1;
-      continue;
-    }
-    throw new Error("Unknown or incomplete argument: " + arg);
-  }
-  return args;
-}
-
 function envVarCountArgs(argv: string[]) {
-  const args = parseArgs(argv);
+  const args = parseRatchetArgs(argv);
   return [...(args.staged ? ["--staged"] : []), ...(args.base ? ["--base", args.base] : [])];
 }
 
 export function main(root = process.cwd(), argv: string[] = process.argv.slice(2)) {
   try {
-    const args = parseArgs(argv);
+    const args = parseRatchetArgs(argv);
     if (args.staged && args.prune) {
       throw new Error("--prune cannot be combined with --staged");
     }

--- a/scripts/lib/shrink-ratchet.mts
+++ b/scripts/lib/shrink-ratchet.mts
@@ -11,6 +11,28 @@ export type RatchetCountDelta = { allowed: number; current: number; entry: strin
 const GIT_MAX_BUFFER = 256 * 1024 * 1024;
 const compareEntries = (left: string, right: string) => (left < right ? -1 : left > right ? 1 : 0);
 
+export function parseRatchetArgs(argv: string[]) {
+  const args: { base?: string; prune: boolean; staged: boolean } = { prune: false, staged: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--prune") {
+      args.prune = true;
+      continue;
+    }
+    if (arg === "--staged") {
+      args.staged = true;
+      continue;
+    }
+    if (arg === "--base" && argv[index + 1]) {
+      args.base = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    throw new Error("Unknown or incomplete argument: " + arg);
+  }
+  return args;
+}
+
 function readGitText(root: string, args: string[]) {
   return execFileSync("git", args, {
     cwd: root,


### PR DESCRIPTION
## What Problem This Solves

The max-lines and assertion-safety ratchets maintain identical argument parsers separately, leaving one internal CLI contract to maintain in two places. This is a maintainer-requested, behavior-preserving extraction, not a behavioral bug fix.

## Why This Change Was Made

Move the existing parser into `scripts/lib/shrink-ratchet.mts`, which both checkers already use, and route all three call sites through it. Preserve parsing quirks, error precedence, catch boundaries, exit status, and env-budget argument and invocation ordering. No scanner, configuration, baseline, dependency, public API, or SDK changes.

Data-model compatibility: no persistent format, baseline reader/writer, schema, migration, or store semantics change in this diff. The existing baseline files are unchanged. Before/after CLI proof compares the resulting baseline bytes, including pruning, and found no difference. The automated data-model checklist item is therefore not applicable to this extraction.

## User Impact

No user-visible behavior change. The two developer ratchets now share one implementation of their existing argument contract.

## Evidence

- Existing focused suites: 4 files, 54 tests passed (`shrink-ratchet`, `check-assertion-safety-ratchet`, `check-max-lines-ratchet`, and `check-env-var-count`).
- Before/after parity: 66,430 argument vectors, including frozen inputs and env-budget forwarding, plus 46 disposable real-CLI comparisons of exit status, stdout, stderr, and baseline bytes. Includes invalid/incomplete arguments, repeated flags, flag-looking base values, pruning, staged input, and env-budget chain failures.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
- The complete selected `check:changed` gate passed on Testbox, including script typechecking, erasability, formatting, lint, and ratchet guards. Local typechecking was blocked by the worktree's shared dependency symlink, not a compiler diagnostic; clean remote proof covers that limitation.
- Fresh independent autoreview: scoped-clean through P2, no findings.
- Exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/34076664084.
- Exact-head Blacksmith Testbox proof passed on Linux/Node 24.19.0 for `b19b0180e2a18233c37dd51a8e214b0e649ca2e4`: both revisions compared, all four suites passed, and the selected changed-file gate passed. Provider `blacksmith-testbox`, lease `tbx_01m1wvasda2t5m8mks73qb6y43`, wrapper `exitCode=0`, `runStatus=succeeded`; the owned lease stopped after success. Run: https://github.com/openclaw/openclaw/actions/runs/34076603499. The backing Actions job can show cancellation because the one-shot lease was stopped; the wrapper result records the completed proof.
- No repository test files changed.
