### PR TITLE
fix(ui): palette hides chat search failures beside navigation results

### DIFF
--- a/ui/src/components/command-palette.test.ts
+++ b/ui/src/components/command-palette.test.ts
@@ -874,22 +874,23 @@ describe("CommandPalette lifecycle", () => {
     expect(palette.textContent).toContain("Unrelated title");
   });
 
-  it("shows a search failure instead of a false empty result", async () => {
+  it.each(["zzz-unmatched", "plugins"])("shows a chat search failure for %s", async (query) => {
     const { gateway } = createGateway(true);
     const list = vi
       .fn<ApplicationContext<RouteId>["sessions"]["list"]>()
       .mockRejectedValueOnce(new Error("store needs doctor migration"))
       .mockResolvedValueOnce(createSessionResult("agent:main:zz", "Recovered chat"));
     const { palette } = await mountPalette(createContext(gateway, list));
-    // The query matches no navigation item, so a swallowed search failure
-    // would render the plain "No results" empty state.
-    await enterQuery(palette, "zzz-unmatched");
+    await enterQuery(palette, query);
     await vi.advanceTimersByTimeAsync(50);
     await palette.updateComplete;
 
     expect(list).toHaveBeenCalledOnce();
     expect(palette.textContent).toContain("Chat search failed");
     expect(palette.textContent).not.toContain("No results");
+    if (query === "plugins") {
+      expect(findPaletteOption(palette, "Plugins")).toBeDefined();
+    }
 
     // A new keystroke clears the failure state and retries cleanly.
     await enterQuery(palette, "zz");

--- a/ui/src/components/command-palette.ts
+++ b/ui/src/components/command-palette.ts
@@ -227,27 +227,25 @@ function renderCommandPalette(props: CommandPaletteProps) {
               : nothing
           }
           ${
-            props.sessionSearchPartial || props.sessionSearchIncomplete
+            props.sessionSearchFailed || props.sessionSearchPartial || props.sessionSearchIncomplete
               ? html`<div class="cmd-palette__empty" role="status">
                   ${t(
-                    props.sessionSearchIncomplete
-                      ? "palette.searchIncomplete"
-                      : "palette.searchPartial",
+                    props.sessionSearchFailed
+                      ? "palette.searchFailed"
+                      : props.sessionSearchIncomplete
+                        ? "palette.searchIncomplete"
+                        : "palette.searchPartial",
                   )}
                 </div>`
               : nothing
           }
           ${
-            grouped.length === 0
+            grouped.length === 0 && !props.sessionSearchFailed
               ? html`<div class="cmd-palette__empty">
                   <span class="nav-item__icon" style="opacity:0.3;width:20px;height:20px"
                     >${icons.search}</span
                   >
-                  <span
-                    >${
-                      props.sessionSearchFailed ? t("palette.searchFailed") : t("palette.noResults")
-                    }</span
-                  >
+                  <span>${t("palette.noResults")}</span>
                 </div>`
               : grouped.map(
                   ([category, groupedItems]) => html`


### PR DESCRIPTION
Related: #124648

<details>
<summary>Additional instructions</summary>

This branch is in the main repository and remains editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where users searching chats in the command palette would see no failure notice when chat search failed and the query also matched navigation or catalog entries. For example, searching for `plugins` left the Plugins destination visible but silently omitted the failed Chats search.

## Why This Change Was Made

Render the recorded chat-search failure in the existing search-status region, alongside partial and incomplete transcript-search notices. Remove the empty-state-only failure branch and reuse the existing translated message. Successful results remain available, and failed empty searches do not display a contradictory “No results” message.

## User Impact

Users can distinguish a failed chat search from a successful search with no matching chats, while continuing to use navigation and catalog results. Editing the query clears the failure and retries normally.

## Evidence

The existing failure-and-retry regression now covers both an unmatched query and `plugins`. Before the fix, the matching-query case fails because the error is absent; afterward, all 44 palette and catalog tests pass.

Synthetic Chromium runs through the real Control UI with a mocked Gateway confirm the error changes from absent to visible. Clicking Plugins reaches `/settings/plugins` both before and after the fix. These runs used isolated browser contexts and a source-mode UI server, without a live provider or operator Gateway.

Owning UI test types, full-file lint/format/style checks, and `check:changed` pass. Independent P2 review found no actionable issues. Integration onto current main is patch-identical, with no upstream changes to the palette owner, its tests, or search helpers.

Production: 8 added / 10 removed lines (net −2). Tests: 5 added / 4 removed lines (net +1).

Before:

![Failed chat search hidden behind navigation and catalog results](https://github.com/user-attachments/assets/ec24fd80-ed84-4c8e-bfa5-78aee9594c7e)

After:

![Chat search failure visible above usable navigation and catalog results](https://github.com/user-attachments/assets/7cc1f359-4932-4188-864c-e59dc29197f3)
