### PR TITLE
fix(memory): avoid duplicate snapshot allocation during flush preparation

### DIFF
--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -135,6 +135,19 @@ export class SessionManager extends SessionManagerBranching {
     });
   }
 
+  /** Consumes a fresh bounded read as a detached branch, without copying its owned payloads. */
+  static openDetachedBounded(
+    target: SessionTranscriptRuntimeTarget,
+    options: Parameters<typeof SessionManager.openBounded>[1],
+  ): SessionManager {
+    const source = SessionManager.openBounded(target, options);
+    // Normalize opaque parents and retained cuts before discarding persistence and bounded state.
+    return SessionManager.fromOwnedEntries(
+      [source.getHeader(), ...source.getBranch()],
+      source.getCwd(),
+    );
+  }
+
   /** Detached model view: selected payloads plus lightweight ancestry, never raw replay evidence. */
   static openModelContext(
     target: SessionTranscriptRuntimeTarget,
@@ -230,7 +243,14 @@ export class SessionManager extends SessionManagerBranching {
   }
 
   static fromEntries(entries: readonly unknown[], cwdOverride?: string): SessionManager {
-    const fileEntries = structuredClone(entries) as FileEntry[];
+    return SessionManager.fromOwnedEntries(structuredClone(entries), cwdOverride);
+  }
+
+  private static fromOwnedEntries(
+    entries: readonly unknown[],
+    cwdOverride?: string,
+  ): SessionManager {
+    const fileEntries = entries as FileEntry[];
     const header = fileEntries.find(
       (entry) => typeof entry === "object" && entry !== null && entry.type === "session",
     );

--- a/src/auto-reply/reply/memory-flush-session.test.ts
+++ b/src/auto-reply/reply/memory-flush-session.test.ts
@@ -123,9 +123,12 @@ it.each([false, true])(
       expect(checkpoint.sessionPersistence).toBe("detached");
       const first = checkpoint.sessionManager.getBranch()[0];
       if (first) {
+        if (first.type === "message" && first.message.role === "user") {
+          first.message.content = "Checkpoint-only edit";
+        }
         checkpoint.sessionManager.branch(first.id);
       }
-      checkpoint.sessionManager.appendMessage({
+      const instruction = checkpoint.sessionManager.appendMessage({
         role: "user",
         content: "Checkpoint instruction",
         timestamp: 5,
@@ -136,9 +139,82 @@ it.each([false, true])(
           stopReason: "stop",
         }),
       );
+      checkpoint.sessionManager.appendCompaction("Checkpoint-only summary", instruction, 100);
       expect(loadTranscriptEventsSync(scope)).toEqual(before);
       expect(readActiveTranscriptEntryAnchor(admission)).toEqual(anchor);
       expect(SessionManager.open(scope).getBranch().at(-1)?.id).toBe(admission.entryId);
+    });
+  },
+);
+
+it.each(["compaction", "reset"] as const)(
+  "detaches the forward %s cut across an opaque parent with retained tool pairs",
+  async (boundaryType) => {
+    await withOpenClawTestState({ label: `memory-opaque-${boundaryType}` }, async (state) => {
+      const scope = {
+        agentId: "main",
+        sessionId: "opaque-checkpoint",
+        sessionKey: "agent:main:opaque-checkpoint",
+        storePath: path.join(state.agentDir("main"), "openclaw-agent.sqlite"),
+      };
+      await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+      const source = SessionManager.open(scope, state.workspaceDir);
+      source.appendMessage({ role: "user", content: "Summarized away", timestamp: 1 });
+      const opaqueCut = source.appendMessage({
+        role: "custom",
+        customType: "display-test",
+        content: "Display only",
+        display: true,
+        excludeFromContext: true,
+        timestamp: 2,
+      });
+      const retained = source.appendMessage({ role: "user", content: "Retained", timestamp: 3 });
+      source.appendMessage(
+        makeAgentAssistantMessage({
+          content: [
+            { type: "toolCall", id: "read-call", name: "read", arguments: { path: "note" } },
+          ],
+          stopReason: "toolUse",
+        }),
+      );
+      source.appendMessage({
+        role: "toolResult",
+        toolCallId: "read-call",
+        toolName: "read",
+        content: [{ type: "text", text: "Paired result" }],
+        isError: false,
+        timestamp: 4,
+      });
+      const boundary =
+        boundaryType === "compaction"
+          ? source.appendCompaction("Summary", opaqueCut, 100)
+          : source.appendResetBoundary("reset", opaqueCut);
+      source.appendMessage({ role: "user", content: "Tail", timestamp: 5 });
+      const before = loadTranscriptEventsSync(scope);
+      const memory = await prepareMemoryFlushSession({
+        source: scope,
+        runId: "opaque-memory-helper",
+        workspaceDir: state.workspaceDir,
+      });
+      expect(memory.sessionManager.getSessionTarget()).toBeUndefined();
+      expect(memory.sessionManager.getEntry(opaqueCut)).toBeUndefined();
+      expect(memory.sessionManager.getEntry(boundary)).toMatchObject({
+        firstKeptEntryId: retained,
+      });
+      const messages = memory.sessionManager.buildSessionContext().messages;
+      expect(messages.map((message) => message.role)).toEqual([
+        ...(boundaryType === "compaction" ? ["compactionSummary"] : []),
+        "user",
+        "assistant",
+        "toolResult",
+        "user",
+      ]);
+      expect(
+        messages.filter((message) => message.role === "user").map((message) => message.content),
+      ).toEqual(["Retained", "Tail"]);
+      memory.sessionManager.appendResetBoundary("reset");
+      expect(memory.sessionManager.buildSessionContext().messages).toEqual([]);
+      expect(loadTranscriptEventsSync(scope)).toEqual(before);
     });
   },
 );
@@ -257,6 +333,43 @@ it("does not acquire a checkpoint after caller cancellation", async () => {
     expect(loadTranscriptEventsSync(scope)).toEqual(before);
   });
 });
+
+it.each(["empty", "missing", "legacy"] as const)(
+  "preserves %s transcript header handling during detached acquisition",
+  async (headerState) => {
+    await withOpenClawTestState({ label: `memory-header-${headerState}` }, async (state) => {
+      const scope = {
+        agentId: "main",
+        sessionId: "header-checkpoint",
+        sessionKey: "agent:main:header-checkpoint",
+        storePath: path.join(state.agentDir("main"), "openclaw-agent.sqlite"),
+      };
+      await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+      if (headerState !== "empty") {
+        await replaceTranscriptEvents(scope, [
+          headerState === "legacy"
+            ? { ...createSessionTranscriptHeader({ sessionId: scope.sessionId }), version: 1 }
+            : { type: "future-metadata", id: "opaque", parentId: null },
+        ]);
+      }
+      const before = loadTranscriptEventsSync(scope);
+      const pending = prepareMemoryFlushSession({
+        source: scope,
+        runId: "header-memory-helper",
+        workspaceDir: state.workspaceDir,
+      });
+      if (headerState === "empty") {
+        const memory = await pending;
+        expect(memory.sessionManager.getSessionTarget()).toBeUndefined();
+        expect(memory.sessionManager.getHeader()).toMatchObject({ id: scope.sessionId });
+        expect(memory.sessionManager.buildSessionContext().messages).toEqual([]);
+      } else {
+        await expect(pending).rejects.toThrow("doctor/import migration");
+      }
+      expect(loadTranscriptEventsSync(scope)).toEqual(before);
+    });
+  },
+);
 
 it("does not expose a processed recorder as a pending checkpoint admission", async () => {
   await withAdmittedInput(false, async ({ recorder }) => {

--- a/src/auto-reply/reply/memory-flush-session.ts
+++ b/src/auto-reply/reply/memory-flush-session.ts
@@ -21,22 +21,16 @@ export async function prepareMemoryFlushSession(params: {
   params.signal?.throwIfAborted();
   await waitForSessionTranscriptProjection(params.source, params.signal);
   params.signal?.throwIfAborted();
-  const sessionManager = withSessionContextAdmission(params.source, params.admission, () => {
-    const source = SessionManager.openBounded(params.source, {
+  const sessionManager = withSessionContextAdmission(params.source, params.admission, () =>
+    SessionManager.openDetachedBounded(params.source, {
       cwd: params.workspaceDir,
       maxBytes: MAX_VISIBLE_MESSAGE_MAX_BYTES,
       maxEvents: MAX_VISIBLE_MESSAGE_MAX_MESSAGES,
       onTruncated: () => {
         throw new Error("Memory flush exceeds the bounded conversation view.");
       },
-    });
-    // The navigation owner resolves opaque parents and retained compaction boundaries.
-    // Copy its projection, never discard those facts by copying raw bounded events.
-    return SessionManager.fromEntries(
-      [source.getHeader(), ...source.getBranch()],
-      params.workspaceDir,
-    );
-  });
+    }),
+  );
   const identity = resolveInternalSessionEffectsIdentity({
     agentId: params.source.agentId,
     runId: params.runId,


### PR DESCRIPTION
Closes #140668

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Resolves redundant transient allocation when memory-flush preparation clones the freshly read, already-owned bounded transcript before creating its detached working session.

## Why This Change Was Made

Add an acquisition factory that performs the existing bounded read, obtains the normalized header and branch, and privately adopts those owned entries into the detached manager. Public `fromEntries` still clones caller-owned input before using the same private constructor path. There is no public no-copy flag.

Both managers and index passes remain: the first normalizes opaque parents and retained cuts, while the second discards persistence and bounded-reader state. Admission, readiness, aborts, truncation rejection, cwd handling and detached run identity retain their existing contracts.

## User Impact

Large memory-flush snapshots require less redundant JavaScript allocation during preparation. The 56 MiB serialized fixture falls from 207.37 to 147.10 MiB sampled allocation per preparation, about 60 MiB less. The 4 MiB fixture falls from 21.85 to 17.26 MiB. These input sizes are serialized budgets, not heap-size claims.

Timing is mixed: small median 1.15 to 1.41 ms, medium 12.70 to 10.85 ms, and near-cap 90.22 to 116.98 ms with a wide candidate range. No general speed improvement is claimed. Both variants release held heap after the returned payload is released, so this removes a transient copy rather than repairing a leak.

## Evidence

- All 48 focused tests passed, covering detached preparation, bounded/general manager compatibility and completed/interrupted memory inference. Public frozen-input copying, admission/stale admission, aborts, rewrites and truncation checks remain covered.
- Nested mutation, append and compaction of the prepared manager preserve the original raw SQLite event bytes. Opaque-parent cuts, retained tool pairs and empty/missing/legacy headers retain their expected behavior.
- The real source-owner probe used canonical isolated SQLite state without mocks or live Gateway/provider access. All 12 matched runs preserve expected context and stored event hashes.
- Complete check:changed and isolated native P2 autoreview passed on the final three source hashes. No package/barrel/lazy-import boundary changed; a separate full build was not run locally.

Allocation uses Inspector sampling and excludes native SQLite allocation. Near-cap endpoint RSS was lower in the observed batches, but no peak or fixed whole-process memory guarantee is claimed. Both retained-heap paths return within 0.03 MiB of their starting values after release. Production grows by 14 lines to establish the explicit ownership path; tests grow by 113 lines.
