### PR TITLE
fix(canvas): show rejected A2UI action errors immediately

### DIFF
--- a/extensions/canvas/src/host/a2ui-app/bootstrap-v0.9.js
+++ b/extensions/canvas/src/host/a2ui-app/bootstrap-v0.9.js
@@ -46,13 +46,14 @@ class OpenClawA2UIV09Host extends LitElement {
     }
   `;
 
-  surfaces = [];
-  error = "";
   #processor;
   #subscriptions = [];
 
   constructor() {
     super();
+    // Native class fields would shadow Lit's reactive accessors.
+    this.surfaces = [];
+    this.error = "";
     this.#processor = this.#createProcessor();
   }
 
@@ -114,7 +115,6 @@ class OpenClawA2UIV09Host extends LitElement {
 
   #syncSurfaces() {
     this.surfaces = Array.from(this.#processor.model.surfacesMap.entries());
-    this.requestUpdate();
   }
 
   render() {

--- a/ui/src/e2e/board-a2ui.e2e.test.ts
+++ b/ui/src/e2e/board-a2ui.e2e.test.ts
@@ -112,10 +112,19 @@ describeControlUiE2e("Control UI dashboard A2UI", () => {
     await controlUi?.close();
   });
 
-  for (const colorScheme of ["dark", "light"] as const) {
-    it(`renders a v0.9 widget with the ${colorScheme} scrollbar theme`, async ({
-      onTestFailed,
-    }) => {
+  for (const { colorScheme, rejectsAction, name } of [
+    ...(["dark", "light"] as const).map((theme) => ({
+      colorScheme: theme,
+      rejectsAction: false,
+      name: `renders a v0.9 widget with the ${theme} scrollbar theme`,
+    })),
+    {
+      colorScheme: "light" as const,
+      rejectsAction: true,
+      name: "shows rejected v0.9 actions and clears the widget on reset",
+    },
+  ]) {
+    it(name, async ({ onTestFailed }) => {
       const context = await browser.newContext({
         colorScheme,
         permissions: ["local-network-access"],
@@ -252,6 +261,50 @@ describeControlUiE2e("Control UI dashboard A2UI", () => {
         .poll(() => outer.evaluate((element) => getComputedStyle(element).opacity))
         .toBe("1");
       expect(await outer.getAttribute("inert")).toBeNull();
+      if (rejectsAction) {
+        actionStage = "installing oversized action";
+        await widgetFrame.evaluate(() => {
+          Reflect.get(globalThis, "openclawA2UI").applyMessages([
+            {
+              version: "v0.9",
+              updateComponents: {
+                surfaceId: "main",
+                components: [
+                  {
+                    id: "action",
+                    component: "Button",
+                    child: "action-label",
+                    variant: "primary",
+                    action: {
+                      event: { name: "refresh", context: { diagnostic: "x".repeat(8193) } },
+                    },
+                  },
+                ],
+              },
+            },
+          ]);
+        });
+        actionStage = "clicking oversized action";
+        await clickBoardWidgetControl(page, widgetFrame.getByText("Refresh data"));
+        actionStage = "waiting for rejected-action alert";
+        await expect
+          .poll(() => widgetFrame.getByRole("alert").allTextContents())
+          .toEqual(["widget state payload exceeds 8192 UTF-8 bytes"]);
+        expect(await widgetFrame.getByRole("alert").isVisible()).toBe(true);
+        expect(await gateway.getRequests("board.event")).toHaveLength(0);
+        expect(pageErrors).toEqual([]);
+
+        actionStage = "resetting renderer after rejection";
+        await widgetFrame.evaluate(() => Reflect.get(globalThis, "openclawA2UI").reset());
+        await expect.poll(() => widgetFrame.getByRole("alert").count()).toBe(0);
+        await expect.poll(() => widgetFrame.locator("a2ui-surface").count()).toBe(0);
+        await widgetFrame.evaluate(
+          (initialMessages) =>
+            Reflect.get(globalThis, "openclawA2UI").applyMessages(initialMessages),
+          messages,
+        );
+        await widgetFrame.getByText("A2UI board widget").waitFor();
+      }
       actionStage = "waiting for native pointer entry and clicking refresh";
       await clickBoardWidgetControl(page, widgetFrame.getByText("Refresh data"));
       actionStage = "waiting for board.event";
@@ -264,6 +317,11 @@ describeControlUiE2e("Control UI dashboard A2UI", () => {
           action: { name: "refresh", surfaceId: "main", sourceComponentId: "action" },
         },
       });
+      if (rejectsAction) {
+        expect(await widgetFrame.getByRole("alert").count()).toBe(0);
+        expect(pageErrors).toEqual([]);
+        return;
+      }
       await page.mouse.move(40, 40);
 
       const scrollbar = await widgetFrame.evaluate(() => {


### PR DESCRIPTION
Related: #140626 (diagnostics only; this fixes a separate confirmed error-visibility gap).

## What Problem This Solves

Fixes an issue where users clicking an A2UI v0.9 dashboard widget action would see no error when the widget bridge rejected the action, including an oversized state payload. The host caught the rejection and stored its message, but the existing alert did not render.

## Why This Change Was Made

The production bundle preserves native JavaScript class fields. The host's `error` and `surfaces` fields shadowed Lit's reactive accessors, so assigning the caught error did not schedule a render. Initialize those properties through constructor assignments and remove the now-redundant explicit surface update. The bridge's 8192-byte limit, action routing, and dependency versions are unchanged.

The regression uses the actual bundled renderer and sandbox bridge, retains the recently landed failure diagnostics, and checks reset and successful action recovery. This does not establish the cause of the historical missing-event CI failure investigated separately in #140626.

## User Impact

Rejected A2UI v0.9 actions immediately display the existing inline error alert instead of appearing to do nothing. Oversized state events remain rejected without being delivered to the session. Reset and subsequent normal action delivery continue to work.

## Evidence

- Before the repair, the new regression failed after the existing 15-second poll: expected the payload-limit alert, received no alerts. Independent browser inspection confirmed a populated `host.error`, zero alerts, no pending Lit update, and own data properties shadowing prototype setters.
- After the repair and integration with current main, all **3/3** cases in `ui/src/e2e/board-a2ui.e2e.test.ts` pass: both scrollbar themes and the rejection/reset/recovery scenario. The latter verifies the visible error, zero `board.event` requests on rejection, reset cleanup, and one successful event after restoring normal messages.
- Pre-rebase local typecheck, lint, and guard steps passed. Lint/remaining guards were completed on a byte-identical standalone checkout to avoid ancestor-install contamination in the nested worktree. The rebased head retains main's diagnostics and passes the focused E2E again. Final independent review found no actionable P0–P2 findings.
- [Hosted CI run 34077223497, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34077223497) and the required `openclaw/ci-gate` passed at exact head `f0573eb7298412554487874180927667c257f2ca`. All three A2UI cases also passed on attempt 1. That attempt's only test failure was the unrelated Workshop blank-row-height assertion (`skill-workshop-collection.e2e.test.ts:135`); the unchanged focused Workshop test passed locally, and one same-head failed-jobs rerun passed. No code, assertion, timeout, or gate was changed for that rerun. The suspected measurement-readiness issue is flagged for separate investigation.

Focused reproduction/verification command:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/board-a2ui.e2e.test.ts
```

The attached before/after images are inspected, synthetic local renderer captures using the real production bundles and a rejected state-emission promise. They contain no real user data or credentials. The full board bridge and payload-limit behavior are exercised by the E2E regression above.

![Before: rejected action stores an error but displays no alert](https://github.com/user-attachments/assets/fd67d86f-f3e6-4e0b-80f1-1220d2049e2f)

![After: rejected action immediately displays the error alert](https://github.com/user-attachments/assets/7c1c674e-786d-4bde-9894-6e514359fa0d)
