### PR TITLE
refactor(test): simplify Parallels exec regression coverage

### DIFF
--- a/scripts/e2e/parallels/parallels-exec.py
+++ b/scripts/e2e/parallels/parallels-exec.py
@@ -220,7 +220,6 @@ def main() -> int:
         deadline = time.monotonic() + options.timeout_ms / 1000
         if not uses_verified_sdk():
             os.execvp("prlctl", ["prlctl", *argv])
-            raise RuntimeError("prlctl exec unexpectedly returned")
         if len(argv) < 3 or argv[0] != "exec":
             raise ValueError("SDK route supports only exec VM [--current-user] COMMAND...")
         vm_name, command_args = argv[1], argv[2:]

--- a/test/scripts/parallels-exec.test.py
+++ b/test/scripts/parallels-exec.test.py
@@ -215,10 +215,6 @@ class ParallelsExecTests(unittest.TestCase):
         self.assertLess(names.index("PrlVmGuest_Logout"), names.index("PrlVm_TerminalDisconnect"))
         self.assertLess(names.index("PrlVm_TerminalDisconnect"), names.index("PrlSrv_Logoff"))
         self.assertEqual(names[-1], "PrlApi_Deinit")
-        for owner, logout in [("guest", "PrlVmGuest_Logout"), ("vm", "PrlVm_TerminalDisconnect"), ("server", "PrlSrv_Logoff")]:
-            handle = next(key for key, value in fake.handles.items() if value["kind"] == owner)
-            free_index = next(i for i, event in enumerate(fake.events) if event == ("PrlHandle_Free", (handle,)))
-            self.assertLess(names.index(logout), free_index)
 
     def test_root_current_user_and_name_uuid_lookup(self):
         for vm in ["Synthetic VM", "{11111111-2222-3333-4444-555555555555}"]:

--- a/test/scripts/parallels-npm-update-smoke.test.ts
+++ b/test/scripts/parallels-npm-update-smoke.test.ts
@@ -492,16 +492,7 @@ exit 1
             provider: "openai",
             updateTarget: "local-main",
           });
-          const guestMacos = Reflect.get(smoke, "guestMacos") as (
-            script: string,
-            timeoutMs: number,
-            ctx: {
-              append: (chunk: string | Uint8Array) => void;
-              logPath: string;
-              signal: AbortSignal;
-            },
-          ) => Promise<void>;
-          const result = guestMacos.call(smoke, "echo update", 30_000, {
+          const result = smoke["guestMacos"]("echo update", 30_000, {
             append: (chunk) =>
               output.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8")),
             logPath: path.join(root, "update.log"),
@@ -531,7 +522,6 @@ exit 1
       expect(output.join("")).toContain("update-diagnostic\n");
       const log = readFileSync(logPath, "utf8");
       expect(log).toContain("--current-user whoami");
-      expect(log).toContain("--current-user /usr/bin/env PATH=");
       expect(log).toContain("/usr/bin/tee /tmp/openclaw-parallels-npm-update-macos-");
       expect(log).toContain("/bin/chmod 700 /tmp/openclaw-parallels-npm-update-macos-");
       expect(log).toContain("/usr/sbin/chown desktop-user");


### PR DESCRIPTION
Related: #139418 (Parallels 27 guest-execution repair), #139303 (original intermittent guest-execution failure).

<details>
<summary>Additional instructions</summary>

Maintainer-requested follow-up cleanup. This same-repository branch is editable by maintainers.

</details>

## What Problem This Solves

Reduces redundant code and test scaffolding left in the Parallels guest-execution repair without changing the tested transport behavior. The update test currently copies a private method's signature through a type assertion, which can drift from the implementation.

## Why This Change Was Made

Call the actual typed method directly, remove an unreachable exception after Python's process-replacing `os.execvp`, and remove two assertions already covered by stronger checks at the execution boundary. Keep every test scenario and all installed-binary selection, handle lifetime, cleanup ordering, command identity, stream, timeout, and no-replay contracts.

The deleted free-order reconstruction is redundant with `FakeSdk.live` checking each handle at logout/disconnect/logoff, the retained successful-result assertion, and final release checks. Exact NUL-separated argv verification supersedes the deleted weaker log substring assertion.

## User Impact

No product or operator behavior change. Product runtime delta: 0. Test tooling: +0/-1. Tests: +1/-15 (net -14). Total: **net -15 lines across three files**; no test scenarios removed.

## Evidence

- Before and after: `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs test/scripts/parallels-exec.test.ts test/scripts/parallels-npm-update-smoke.test.ts` — **56 Vitest cases passed**, including the case that runs all **17 Python SDK-boundary tests**.
- `node scripts/check-changed.mjs -- scripts/e2e/parallels/parallels-exec.py test/scripts/parallels-exec.test.py test/scripts/parallels-npm-update-smoke.test.ts` — **passed**, including test-root typechecking, scripts lint, targeted test lint, formatting, and selected repository guards.
- `git diff --check` — **passed**.
- Fresh isolated Codex autoreview through P2 — **scoped-clean**, no accepted/actionable findings.
- Direct CPython `os.execvp` / `_execvpe` source inspection confirms that successful execution replaces the process and failure raises; the removed post-call exception is unreachable.

This is a behavior-preserving cleanup, not a new SDK integration or external-API change. No new VM run is claimed or needed for the removed unreachable line and redundant test scaffolding; the original repair's native proof remains documented in #139418. No VM, vendor installation, product configuration, dependency, or persistence changes.
