### PR TITLE
fix(ui): dashboard pane shows unstyled "Loading…" text while the board loads

### DIFF
--- a/ui/src/components/board/board-document.ts
+++ b/ui/src/components/board/board-document.ts
@@ -262,7 +262,7 @@ export class OpenClawBoardDocument extends OpenClawLightDomElement {
 
   private renderState() {
     if (this.documentState === "loading") {
-      return renderPanelLoadingSkeleton("discussion", t("common.loading"));
+      return renderPanelLoadingSkeleton("board", t("common.loading"));
     }
     if (this.documentState === "missing-session") {
       return html`<div class="board-document__state" role="status">

--- a/ui/src/components/panel-loading-skeleton.test.ts
+++ b/ui/src/components/panel-loading-skeleton.test.ts
@@ -7,6 +7,7 @@ import {
 } from "./panel-loading-skeleton.ts";
 
 const variants = [
+  "board",
   "browser",
   "chat",
   "desktop",

--- a/ui/src/components/panel-loading-skeleton.ts
+++ b/ui/src/components/panel-loading-skeleton.ts
@@ -3,6 +3,7 @@ import { property } from "lit/decorators.js";
 import { OpenClawLitElement } from "../lit/openclaw-element.ts";
 
 export type PanelLoadingSkeletonVariant =
+  | "board"
   | "browser"
   | "chat"
   | "desktop"
@@ -211,6 +212,63 @@ class PanelLoadingSkeleton extends OpenClawLitElement {
       border-radius: 8px;
     }
 
+    /* Mirrors board.css: a 38px tab strip over a 12-column grid with 56px rows,
+       so the placeholder occupies the same footprint as the widgets it precedes. */
+    .board-tabs {
+      display: flex;
+      gap: 14px;
+      align-items: center;
+      min-height: 38px;
+      margin-bottom: 12px;
+      padding: 0 13px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .tab {
+      width: 64px;
+      height: 10px;
+      border-radius: 5px;
+    }
+
+    .board-grid {
+      container-type: inline-size;
+      display: grid;
+      gap: 12px;
+      grid-auto-rows: 56px;
+      grid-template-columns: repeat(12, minmax(0, 1fr));
+    }
+
+    .widget {
+      display: grid;
+      grid-template-rows: 38px minmax(0, 1fr);
+      min-height: 0;
+      min-width: 0;
+      overflow: hidden;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+    }
+
+    @container (max-width: 560px) {
+      .widget {
+        grid-column: 1 / -1 !important;
+      }
+    }
+
+    .widget-bar {
+      display: flex;
+      gap: 7px;
+      align-items: center;
+      padding: 0 12px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .widget-body {
+      display: grid;
+      gap: 10px;
+      align-content: start;
+      padding: 12px;
+    }
+
     @keyframes shimmer {
       from {
         transform: translateX(-100%);
@@ -247,8 +305,32 @@ class PanelLoadingSkeleton extends OpenClawLitElement {
     );
   }
 
+  private widget(columns: number, rows: number, lines: Array<"short" | "medium" | "long">) {
+    return html`
+      <div class="widget" style=${`grid-column: span ${columns}; grid-row: span ${rows}`}>
+        <div class="widget-bar">
+          <div class="skeleton icon"></div>
+          ${this.line("short")}
+        </div>
+        <div class="widget-body">${lines.map((width) => this.line(width))}</div>
+      </div>
+    `;
+  }
+
   private renderContent() {
     switch (this.variant) {
+      case "board":
+        return html`
+          <div class="board-tabs">
+            <div class="skeleton tab"></div>
+            <div class="skeleton tab"></div>
+          </div>
+          <div class="board-grid">
+            ${this.widget(6, 4, ["long", "medium", "short"])}
+            ${this.widget(6, 4, ["medium", "long"])} ${this.widget(4, 3, ["medium", "short"])}
+            ${this.widget(8, 3, ["long", "medium", "long"])}
+          </div>
+        `;
       case "browser":
         return html`
           <div class="toolbar">

--- a/ui/src/pages/chat/chat-pane-board.loading.test.ts
+++ b/ui/src/pages/chat/chat-pane-board.loading.test.ts
@@ -1,0 +1,111 @@
+/* @vitest-environment jsdom */
+
+import { html, render, type nothing, type TemplateResult } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import type { BoardProvider } from "../../lib/board/provider.ts";
+import type { ResolvedBoardView } from "./chat-pane-shared.ts";
+import { createSessionCapabilityFixture, createTestChatPane } from "./chat-pane.test-support.ts";
+import type { ChatPageHost } from "./chat-state-host.ts";
+import { openSlot } from "./sidebar-layout.ts";
+
+type BoardTestPane = HTMLElement & {
+  context: ApplicationContext;
+  state: ChatPageHost;
+  resolveBoardProvider: () => BoardProvider;
+  resolveBoardView: () => ResolvedBoardView;
+  renderBoardPanel: (
+    board: ResolvedBoardView,
+    layout: ChatPageHost["sidebarLayout"],
+  ) => TemplateResult | typeof nothing;
+  releaseBoardProviderLease: () => void;
+};
+
+type BoardSnapshot = BoardProvider["snapshot$"]["value"];
+
+function createGatewayBoardPane(sessionKey: string) {
+  const snapshot: BoardSnapshot = { sessionKey, revision: 1, tabs: [], widgets: [] };
+  const request = vi.fn<(method: string, params: unknown) => Promise<BoardSnapshot>>(
+    async () => snapshot,
+  );
+  const client = {
+    request,
+    addEventListener: vi.fn(() => vi.fn()),
+  } as unknown as GatewayBrowserClient;
+  const { pane: base } = createTestChatPane({ client, sessions: createSessionCapabilityFixture() });
+  const pane = base as unknown as BoardTestPane;
+  pane.state.sessionKey = sessionKey;
+  Reflect.set(pane, "boardProviderLifecycleConnected", true);
+  pane.context = {
+    ...pane.context,
+    gateway: {
+      ...pane.context.gateway,
+      snapshot: { client, phase: "connected", hello: { features: { methods: ["board.get"] } } },
+    },
+  } as unknown as ApplicationContext;
+  // Lit only starts updating once connected, so the skeleton's reflected
+  // attributes need a container that lives in the document.
+  const container = document.body.appendChild(document.createElement("div"));
+  const layout = openSlot({ columns: [] }, "dashboard");
+  return {
+    pane,
+    request,
+    snapshot,
+    container,
+    draw: () => render(pane.renderBoardPanel(pane.resolveBoardView(), layout), container),
+    cleanup: () => {
+      render(html``, container);
+      container.remove();
+      pane.releaseBoardProviderLease();
+    },
+  };
+}
+
+describe("chat pane board loading states", () => {
+  it("shows a board skeleton until the snapshot arrives", async () => {
+    const sessionKey = "agent:main:pending-board";
+    const { pane, request, snapshot, container, draw, cleanup } =
+      createGatewayBoardPane(sessionKey);
+    let complete!: (snapshot: BoardSnapshot) => void;
+    request.mockReturnValueOnce(
+      new Promise((resolve) => {
+        complete = resolve;
+      }),
+    );
+    const provider = pane.resolveBoardProvider();
+    try {
+      draw();
+      const skeleton = container.querySelector("openclaw-panel-loading-skeleton");
+      await skeleton?.updateComplete;
+      expect(skeleton?.getAttribute("data-panel-skeleton")).toBe("board");
+      expect(skeleton?.getAttribute("role")).toBe("status");
+      expect(container.textContent?.trim()).toBe("");
+      complete(snapshot);
+      await vi.waitFor(() => expect(provider.hasLoadedSnapshot).toBe(true));
+      draw();
+      expect(container.querySelector("openclaw-panel-loading-skeleton")).toBeNull();
+      expect(container.querySelector("openclaw-board-view")).not.toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("replaces the skeleton with a styled alert when the snapshot fails to load", async () => {
+    const { pane, request, container, draw, cleanup } = createGatewayBoardPane(
+      "agent:main:failing-board",
+    );
+    request.mockRejectedValueOnce(new Error("gateway offline"));
+    const provider = pane.resolveBoardProvider();
+    try {
+      await vi.waitFor(() => expect(provider.loadError$.value).toBeTruthy());
+      draw();
+      const alert = container.querySelector('[role="alert"]');
+      expect(container.querySelector("openclaw-panel-loading-skeleton")).toBeNull();
+      expect(alert?.classList.contains("board-session-surface__state--error")).toBe(true);
+      expect(alert?.textContent).toContain("gateway offline");
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/ui/src/pages/chat/chat-pane-board.ts
+++ b/ui/src/pages/chat/chat-pane-board.ts
@@ -4,6 +4,7 @@ import { GATEWAY_SERVER_CAPS } from "../../../../packages/gateway-protocol/src/i
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { hasOperatorApprovalsAccess, hasOperatorWriteAccess } from "../../app/operator-access.ts";
 import { patchSettings } from "../../app/settings.ts";
+import { renderPanelLoadingSkeleton } from "../../components/panel-loading-skeleton.ts";
 import { t } from "../../i18n/index.ts";
 import {
   acquireBoardProviderForSession,
@@ -320,9 +321,14 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
     }
     if (!board.provider.hasLoadedSnapshot) {
       const error = board.provider.loadError$.value;
-      return html`<div class="rail-empty" role=${error ? "alert" : "status"}>
-        ${error ? t("dashboardDocument.loadFailed", { error }) : t("common.loading")}
-      </div>`;
+      return error
+        ? html`<div
+            class="board-session-surface__state board-session-surface__state--error"
+            role="alert"
+          >
+            ${t("dashboardDocument.loadFailed", { error })}
+          </div>`
+        : renderPanelLoadingSkeleton("board", t("common.loading"));
     }
     // Only the loaded board acknowledgment supplies a missing owner; its display key
     // must not replace the original session target (notably global versus a literal key).

--- a/ui/src/pages/chat/chat-pane-embedded-panels.test.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.test.ts
@@ -142,7 +142,7 @@ describe("chat pane embedded panels", () => {
       browser: "browser",
       companion: "chat",
       conversation: "chat",
-      dashboard: "review",
+      dashboard: "board",
       desktop: "desktop",
       detail: "review",
       discussion: "discussion",

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -112,7 +112,7 @@ export function sidebarPanelDefinitions(
       textKey === "conversation" || textKey === "companion"
         ? "chat"
         : textKey === "dashboard"
-          ? "review"
+          ? "board"
           : textKey,
       t("common.loading"),
     ),

--- a/ui/src/styles/chat/board.css
+++ b/ui/src/styles/chat/board.css
@@ -39,3 +39,19 @@
 .board-session-surface__board .board-view {
   padding-inline: 16px;
 }
+
+.board-session-surface__state {
+  display: grid;
+  flex: 1 1 0;
+  place-items: center;
+  min-width: 0;
+  min-height: 0;
+  padding: 32px;
+  color: var(--muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+.board-session-surface__state--error {
+  color: var(--danger);
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a session on its dashboard face (`/dashboard/<agent>/<session>`) would see a bare, unstyled "Loading…" string stuck to the top-left of an otherwise empty pane until the Gateway answered `board.get`. On slower connections or larger boards that sat there long enough to look broken, and it stood out next to the rest of the Control UI, which shows shimmer skeletons for pending surfaces.

## Why This Change Was Made

The dashboard face's pending state rendered through a `rail-empty` class that no stylesheet defines, so the label had no layout, color, or spacing at all. Rather than style a text label, this adds a `board` variant to the shared panel loading skeleton (a tab strip over a 12-column widget grid mirroring `board.css`, collapsing to a single column under 560px like the real grid) and renders it while the board snapshot is pending. The load-error branch gets a centered, styled alert. The standalone fullscreen board document and the dashboard side-panel lazy placeholder switch to the same variant so every dashboard loading state looks alike.

## User Impact

Opening a session dashboard now shows a board-shaped shimmer immediately, in both the expanded face and the side-panel layout, until the widgets arrive. Load failures render as a readable centered message instead of raw text. Nothing changes once the board has loaded.

## Evidence

Before/after on the expanded dashboard face against the mocked Gateway with `board.get` held (fixture data only):

![Before: bare Loading text at the top-left of an empty pane](https://github.com/user-attachments/assets/d2b57da6-3d4e-409a-ab85-846ec8463984)

![After: board-shaped shimmer skeleton](https://github.com/user-attachments/assets/2a50fb1e-857c-48cd-b87d-4cb0bf0a03ee)

- New `ui/src/pages/chat/chat-pane-board.loading.test.ts` asserts the skeleton renders while the snapshot is pending and the styled alert renders on load failure. Both tests fail on the previous code (`expected undefined to be 'board'`; alert class missing).
- `panel-loading-skeleton.test.ts` now covers the new variant (structure plus shimmer-primitive parity with `base.css`); `chat-pane-embedded-panels.test.ts` updated for the dashboard placeholder variant.
- `node scripts/check-changed.mjs` green (typecheck core/UI, i18n catalog, dead-export scan, stylelint, oxlint). Codex autoreview scoped-clean at P2.

Known gap: the still capture shows the skeleton blocks but not the animated shimmer band; that is the shared `.skeleton::after` animation already used by the other panel skeletons.
