### PR TITLE
refactor(channels): share terminal approval interpretation

### DIFF
--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -648,13 +648,18 @@ Other approval helpers:
   their own validation.
 - Use `formatChannelApprovalResolvedLabel` and
   `buildSystemAgentApprovalResolvedText` from
-  `openclaw/plugin-sdk/approval-handler-runtime` for terminal presentation.
+  `openclaw/plugin-sdk/approval-runtime` for terminal presentation.
   Rich labels preserve application-status precedence; prose preserves denial
   precedence, because a denied system change can also report `not-applied`.
   Both prioritize cancellation. Pass a decision formatter for transport-specific
   label spelling, and prepare any bounded operation summary before building prose.
   Use `formatApprovalDecisionLabel` for a recorded decision without implying
   application completion.
+- Approval account lookup helpers `resolveApprovalRequestAccountId` and
+  `resolveApprovalRequestChannelAccountId` use `approval-native-runtime`. Their
+  duplicate `approval-runtime` exports and its unused
+  `matchesApprovalRequestSessionFilter` export have been retired. The core
+  implementations are unchanged.
 - Use `createNativeApprovalChannelRouteGates` from
   `openclaw/plugin-sdk/approval-native-runtime` when a channel supports both
   session-origin native delivery and explicit approval forwarding targets. The

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -646,6 +646,15 @@ Other approval helpers:
   ingress or poller for replay. `readApprovalReactionTargetRecord` validates the
   shared persisted fields; transport-specific route and author fields still need
   their own validation.
+- Use `formatChannelApprovalResolvedLabel` and
+  `buildSystemAgentApprovalResolvedText` from
+  `openclaw/plugin-sdk/approval-handler-runtime` for terminal presentation.
+  Rich labels preserve application-status precedence; prose preserves denial
+  precedence, because a denied system change can also report `not-applied`.
+  Both prioritize cancellation. Pass a decision formatter for transport-specific
+  label spelling, and prepare any bounded operation summary before building prose.
+  Use `formatApprovalDecisionLabel` for a recorded decision without implying
+  application completion.
 - Use `createNativeApprovalChannelRouteGates` from
   `openclaw/plugin-sdk/approval-native-runtime` when a channel supports both
   session-origin native delivery and explicit approval forwarding targets. The

--- a/extensions/discord/src/approval-handler.runtime.test.ts
+++ b/extensions/discord/src/approval-handler.runtime.test.ts
@@ -199,12 +199,31 @@ describe("discordApprovalNativeRuntime", () => {
       label: "Denied",
       accentColor: 0xed4245,
     },
+    {
+      approvalKind: "system-agent",
+      phase: "resolved",
+      decision: "deny",
+      applicationStatus: "not-applied",
+      terminalStatus: undefined,
+      label: "Not applied",
+      accentColor: 0xed4245,
+    },
+    {
+      approvalKind: "system-agent",
+      phase: "resolved",
+      decision: "deny",
+      applicationStatus: "not-applied",
+      terminalStatus: "cancelled",
+      label: "Cancelled",
+      accentColor: 0xed4245,
+    },
     { approvalKind: "exec", phase: "expired", label: "Expired", accentColor: 0x99aab5 },
     { approvalKind: "plugin", phase: "expired", label: "Expired", accentColor: 0x99aab5 },
   ] as const)(
     "preserves $approvalKind $phase approval components and terminal preview limits ($label)",
     async (scenario) => {
       const plugin = scenario.approvalKind === "plugin";
+      const systemAgent = scenario.approvalKind === "system-agent";
       const commandLimit = plugin ? 700 : 500;
       const secondaryLimit = plugin ? 1_000 : 300;
       const command = `${"x".repeat(commandLimit)}😀`;
@@ -220,6 +239,13 @@ describe("discordApprovalNativeRuntime", () => {
           : { commandText: command, commandPreview: secondary }),
         ...(scenario.phase === "resolved"
           ? { decision: scenario.decision, resolvedBy: "<@456>" }
+          : {}),
+        ...(systemAgent
+          ? {
+              operationSummary: command,
+              applicationStatus: scenario.applicationStatus,
+              terminalStatus: scenario.terminalStatus,
+            }
           : {}),
       };
       const args = {
@@ -245,8 +271,14 @@ describe("discordApprovalNativeRuntime", () => {
       expect(container).toMatchObject({
         accent_color: scenario.accentColor,
         components: expect.arrayContaining([
-          { content: `## ${plugin ? "Plugin" : "Exec"} Approval: ${scenario.label}`, type: 10 },
-          { content: `### Command\n\`\`\`\n${"x".repeat(commandLimit)}...\n\`\`\``, type: 10 },
+          {
+            content: `## ${plugin ? "Plugin" : systemAgent ? "OpenClaw Change" : "Exec"} Approval: ${scenario.label}`,
+            type: 10,
+          },
+          {
+            content: `### ${systemAgent ? "Change" : "Command"}\n\`\`\`\n${"x".repeat(commandLimit)}...\n\`\`\``,
+            type: 10,
+          },
           {
             content: `### Shell Preview\n\`\`\`\n${"y".repeat(secondaryLimit)}...\n\`\`\``,
             type: 10,

--- a/extensions/discord/src/approval-handler.runtime.ts
+++ b/extensions/discord/src/approval-handler.runtime.ts
@@ -2,12 +2,12 @@
 import { ButtonStyle } from "discord-api-types/v10";
 import {
   createChannelApprovalNativeRuntimeAdapter,
-  formatChannelApprovalResolvedLabel,
   type ApprovalViewModel,
   type ChannelApprovalCapabilityHandlerContext,
   type PendingApprovalView,
 } from "openclaw/plugin-sdk/approval-handler-runtime";
 import type { ExecApprovalActionDescriptor } from "openclaw/plugin-sdk/approval-reply-runtime";
+import { formatChannelApprovalResolvedLabel } from "openclaw/plugin-sdk/approval-runtime";
 import type {
   DiscordExecApprovalConfig,
   OpenClawConfig,

--- a/extensions/discord/src/approval-handler.runtime.ts
+++ b/extensions/discord/src/approval-handler.runtime.ts
@@ -1,11 +1,12 @@
 // Discord plugin module implements approval handler behavior.
 import { ButtonStyle } from "discord-api-types/v10";
-import type {
-  ApprovalViewModel,
-  ChannelApprovalCapabilityHandlerContext,
-  PendingApprovalView,
+import {
+  createChannelApprovalNativeRuntimeAdapter,
+  formatChannelApprovalResolvedLabel,
+  type ApprovalViewModel,
+  type ChannelApprovalCapabilityHandlerContext,
+  type PendingApprovalView,
 } from "openclaw/plugin-sdk/approval-handler-runtime";
-import { createChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
 import type { ExecApprovalActionDescriptor } from "openclaw/plugin-sdk/approval-reply-runtime";
 import type {
   DiscordExecApprovalConfig,
@@ -266,19 +267,15 @@ function createApprovalContainer(params: {
         pending ? 500 : 300,
       );
   const decisionLabel =
-    view.phase !== "resolved"
-      ? undefined
-      : systemAgent && view.terminalStatus === "cancelled"
-        ? "Cancelled"
-        : systemAgent && view.applicationStatus === "applied"
-          ? "Applied"
-          : systemAgent && view.applicationStatus === "not-applied"
-            ? "Not applied"
-            : view.decision === "allow-once"
-              ? "Allowed (once)"
-              : view.decision === "allow-always"
-                ? "Allowed (always)"
-                : "Denied";
+    view.phase === "resolved"
+      ? formatChannelApprovalResolvedLabel(view, (decision) =>
+          decision === "allow-once"
+            ? "Allowed (once)"
+            : decision === "allow-always"
+              ? "Allowed (always)"
+              : "Denied",
+        )
+      : undefined;
   const title = pending
     ? `${approvalLabel} Approval Required`
     : `${approvalLabel} Approval: ${view.phase === "expired" ? "Expired" : decisionLabel}`;

--- a/extensions/googlechat/src/approval-handler.runtime.test.ts
+++ b/extensions/googlechat/src/approval-handler.runtime.test.ts
@@ -357,6 +357,61 @@ describe("googleChatApprovalNativeRuntime", () => {
     expect(JSON.stringify(final.payload)).not.toContain("buttonList");
   });
 
+  it.each([
+    { terminalStatus: undefined, label: "Not applied" },
+    { terminalStatus: "cancelled", label: "Cancelled" },
+  ] as const)(
+    "preserves the $label system-agent heading after denial",
+    async ({ terminalStatus, label }) => {
+      const result = await googleChatApprovalNativeRuntime.presentation.buildResolvedResult({
+        cfg,
+        accountId: "default",
+        context: { account },
+        request: {
+          approvalKind: "system-agent",
+          id: "system-agent:change-1",
+          request: {
+            title: "OpenClaw change",
+            description: "restart the Gateway",
+            command: "restart the Gateway",
+            proposalHash: "a".repeat(64),
+            allowedDecisions: ["allow-once", "deny"],
+            sessionId: "delegation-1",
+          },
+          createdAtMs: 0,
+          expiresAtMs: 60_000,
+        },
+        resolved: {
+          id: "system-agent:change-1",
+          decision: "deny",
+          applicationStatus: "not-applied",
+          terminalStatus,
+          ts: 1,
+        },
+        view: {
+          approvalKind: "system-agent",
+          approvalId: "system-agent:change-1",
+          phase: "resolved",
+          title: "OpenClaw change",
+          metadata: [],
+          commandText: "restart the Gateway",
+          operationSummary: "restart the Gateway",
+          decision: "deny",
+          applicationStatus: "not-applied",
+          terminalStatus,
+        },
+        entry: null,
+      });
+
+      expect(result).toMatchObject({
+        kind: "update",
+        payload: {
+          cardsV2: [{ card: { header: { title: `OpenClaw Change Approval: ${label}` } } }],
+        },
+      });
+    },
+  );
+
   it("suppresses manual approval follow-ups while the native card send is in flight", async () => {
     const deferred = createDeferred<{ messageName: string }>();
     sendGoogleChatMessage.mockReturnValue(deferred.promise);

--- a/extensions/googlechat/src/approval-handler.runtime.ts
+++ b/extensions/googlechat/src/approval-handler.runtime.ts
@@ -1,11 +1,12 @@
-import type {
-  ChannelApprovalCapabilityHandlerContext,
-  ChannelApprovalKind,
-  ExpiredApprovalView,
-  PendingApprovalView,
-  ResolvedApprovalView,
+import {
+  createChannelApprovalNativeRuntimeAdapter,
+  formatChannelApprovalResolvedLabel,
+  type ChannelApprovalCapabilityHandlerContext,
+  type ChannelApprovalKind,
+  type ExpiredApprovalView,
+  type PendingApprovalView,
+  type ResolvedApprovalView,
 } from "openclaw/plugin-sdk/approval-handler-runtime";
-import { createChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { buildChannelApprovalNativeTargetKey } from "openclaw/plugin-sdk/approval-native-runtime";
 import type { ExecApprovalDecision } from "openclaw/plugin-sdk/approval-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
@@ -99,14 +100,6 @@ function buildMetadataText(metadata: readonly { label: string; value: string }[]
       (item) => `<b>${escapeGoogleChatText(item.label)}:</b> ${escapeGoogleChatText(item.value)}`,
     )
     .join("<br>");
-}
-
-function formatDecision(decision: ExecApprovalDecision): string {
-  return decision === "allow-once"
-    ? "Allowed once"
-    : decision === "allow-always"
-      ? "Allowed always"
-      : "Denied";
 }
 
 function buildMainTextWidget(text: string) {
@@ -275,14 +268,7 @@ function resolveApprovalActionFunction(params: ChannelApprovalCapabilityHandlerC
 
 function buildResolvedPayload(view: ResolvedApprovalView): GoogleChatFinalDelivery {
   const resolvedBy = normalizeOptionalString(view.resolvedBy);
-  const decisionLabel =
-    view.approvalKind === "system-agent" && view.terminalStatus === "cancelled"
-      ? "Cancelled"
-      : view.approvalKind === "system-agent" && view.applicationStatus === "applied"
-        ? "Applied"
-        : view.approvalKind === "system-agent" && view.applicationStatus === "not-applied"
-          ? "Not applied"
-          : formatDecision(view.decision);
+  const decisionLabel = formatChannelApprovalResolvedLabel(view);
   const card: GoogleChatCardV2 = {
     cardId: GOOGLECHAT_APPROVAL_CARD_ID,
     card: {

--- a/extensions/googlechat/src/approval-handler.runtime.ts
+++ b/extensions/googlechat/src/approval-handler.runtime.ts
@@ -1,6 +1,5 @@
 import {
   createChannelApprovalNativeRuntimeAdapter,
-  formatChannelApprovalResolvedLabel,
   type ChannelApprovalCapabilityHandlerContext,
   type ChannelApprovalKind,
   type ExpiredApprovalView,
@@ -8,7 +7,10 @@ import {
   type ResolvedApprovalView,
 } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { buildChannelApprovalNativeTargetKey } from "openclaw/plugin-sdk/approval-native-runtime";
-import type { ExecApprovalDecision } from "openclaw/plugin-sdk/approval-runtime";
+import {
+  formatChannelApprovalResolvedLabel,
+  type ExecApprovalDecision,
+} from "openclaw/plugin-sdk/approval-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";

--- a/extensions/matrix/src/approval-handler.runtime.test.ts
+++ b/extensions/matrix/src/approval-handler.runtime.test.ts
@@ -559,6 +559,58 @@ describe("matrixApprovalNativeRuntime", () => {
     ).toBeNull();
   });
 
+  it.each([
+    { terminalStatus: undefined, label: "Not applied" },
+    { terminalStatus: "cancelled", label: "Cancelled" },
+  ] as const)(
+    "preserves the $label system-agent heading after denial",
+    async ({ terminalStatus, label }) => {
+      const result = await matrixApprovalNativeRuntime.presentation.buildResolvedResult({
+        cfg: {},
+        accountId: "default",
+        request: {
+          approvalKind: "system-agent",
+          id: "system-agent:change-1",
+          request: {
+            title: "OpenClaw change",
+            description: "restart the Gateway",
+            command: "restart the Gateway",
+            proposalHash: "a".repeat(64),
+            allowedDecisions: ["allow-once", "deny"],
+            sessionId: "delegation-1",
+          },
+          createdAtMs: 0,
+          expiresAtMs: 60_000,
+        },
+        resolved: {
+          id: "system-agent:change-1",
+          decision: "deny",
+          applicationStatus: "not-applied",
+          terminalStatus,
+          ts: 1,
+        },
+        view: {
+          approvalKind: "system-agent",
+          approvalId: "system-agent:change-1",
+          phase: "resolved",
+          title: "OpenClaw change",
+          metadata: [],
+          commandText: "restart the Gateway",
+          operationSummary: "restart the Gateway",
+          decision: "deny",
+          applicationStatus: "not-applied",
+          terminalStatus,
+        },
+        entry: null,
+      });
+
+      expect(result).toEqual({
+        kind: "update",
+        payload: `OpenClaw change: ${label}\n\nChange\n\`\`\`\nrestart the Gateway\n\`\`\``,
+      });
+    },
+  );
+
   it("uses a longer code fence when resolved commands contain triple backticks", async () => {
     const result = await matrixApprovalNativeRuntime.presentation.buildResolvedResult({
       cfg: {} as never,

--- a/extensions/matrix/src/approval-handler.runtime.ts
+++ b/extensions/matrix/src/approval-handler.runtime.ts
@@ -1,7 +1,6 @@
 // Matrix plugin module implements approval handler behavior.
 import {
   createChannelApprovalNativeRuntimeAdapter,
-  formatChannelApprovalResolvedLabel,
   type ChannelApprovalCapabilityHandlerContext,
   type PendingApprovalView,
   type ResolvedApprovalView,
@@ -15,10 +14,9 @@ import {
 import {
   buildApprovalPendingReplyPayload,
   buildPluginApprovalResolvedReplyPayload,
-} from "openclaw/plugin-sdk/approval-runtime";
-import type {
-  ExecApprovalRequest,
-  PluginApprovalRequest,
+  formatChannelApprovalResolvedLabel,
+  type ExecApprovalRequest,
+  type PluginApprovalRequest,
 } from "openclaw/plugin-sdk/approval-runtime";
 import {
   listMessageReceiptPlatformIds,

--- a/extensions/matrix/src/approval-handler.runtime.ts
+++ b/extensions/matrix/src/approval-handler.runtime.ts
@@ -1,10 +1,11 @@
 // Matrix plugin module implements approval handler behavior.
-import type {
-  ChannelApprovalCapabilityHandlerContext,
-  PendingApprovalView,
-  ResolvedApprovalView,
+import {
+  createChannelApprovalNativeRuntimeAdapter,
+  formatChannelApprovalResolvedLabel,
+  type ChannelApprovalCapabilityHandlerContext,
+  type PendingApprovalView,
+  type ResolvedApprovalView,
 } from "openclaw/plugin-sdk/approval-handler-runtime";
-import { createChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { buildChannelApprovalNativeTargetKey } from "openclaw/plugin-sdk/approval-native-runtime";
 import {
   buildExecApprovalPendingReplyPayload,
@@ -394,18 +395,7 @@ function buildResolvedApprovalText(view: ResolvedApprovalView): string {
       }).text ?? ""
     );
   }
-  const decisionLabel =
-    view.approvalKind === "system-agent" && view.terminalStatus === "cancelled"
-      ? "Cancelled"
-      : view.approvalKind === "system-agent" && view.applicationStatus === "applied"
-        ? "Applied"
-        : view.approvalKind === "system-agent" && view.applicationStatus === "not-applied"
-          ? "Not applied"
-          : view.decision === "allow-once"
-            ? "Allowed once"
-            : view.decision === "allow-always"
-              ? "Allowed always"
-              : "Denied";
+  const decisionLabel = formatChannelApprovalResolvedLabel(view);
   return [
     `${view.approvalKind === "system-agent" ? "OpenClaw change" : "Exec approval"}: ${decisionLabel}`,
     "",

--- a/extensions/msteams/src/approval-card.test.ts
+++ b/extensions/msteams/src/approval-card.test.ts
@@ -169,6 +169,33 @@ describe("Microsoft Teams approval Adaptive Cards", () => {
     expect(expired).not.toHaveProperty("actions");
   });
 
+  it.each([
+    { terminalStatus: undefined, label: "Not applied" },
+    { terminalStatus: "cancelled", label: "Cancelled" },
+  ] as const)(
+    "preserves the $label system-agent heading after denial",
+    ({ terminalStatus, label }) => {
+      const card = buildMSTeamsResolvedApprovalCard({
+        approvalKind: "system-agent",
+        approvalId: "system-agent:change-1",
+        phase: "resolved",
+        title: "OpenClaw change",
+        metadata: [],
+        commandText: "restart the Gateway",
+        operationSummary: "restart the Gateway",
+        decision: "deny",
+        applicationStatus: "not-applied",
+        terminalStatus,
+      });
+
+      expect(card.body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ text: `OpenClaw Change Approval: ${label}` }),
+        ]),
+      );
+    },
+  );
+
   it("displays the canonical winning decision when another surface resolved the approval first", () => {
     const result: ApprovalResolveResult = {
       applied: false,

--- a/extensions/msteams/src/approval-card.ts
+++ b/extensions/msteams/src/approval-card.ts
@@ -1,14 +1,16 @@
 import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type {
+  ApprovalMetadataView,
+  ChannelApprovalKind,
+  ExpiredApprovalView,
+  PendingApprovalView,
+  ResolvedApprovalView,
+} from "openclaw/plugin-sdk/approval-handler-runtime";
 import {
   formatApprovalDecisionLabel,
   formatChannelApprovalResolvedLabel,
-  type ApprovalMetadataView,
-  type ChannelApprovalKind,
-  type ExpiredApprovalView,
-  type PendingApprovalView,
-  type ResolvedApprovalView,
-} from "openclaw/plugin-sdk/approval-handler-runtime";
-import type { ExecApprovalDecision } from "openclaw/plugin-sdk/approval-runtime";
+  type ExecApprovalDecision,
+} from "openclaw/plugin-sdk/approval-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { createMSTeamsApprovalToken } from "./approval-card-actions.js";
 

--- a/extensions/msteams/src/approval-card.ts
+++ b/extensions/msteams/src/approval-card.ts
@@ -1,10 +1,12 @@
 import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
-import type {
-  ApprovalMetadataView,
-  ChannelApprovalKind,
-  ExpiredApprovalView,
-  PendingApprovalView,
-  ResolvedApprovalView,
+import {
+  formatApprovalDecisionLabel,
+  formatChannelApprovalResolvedLabel,
+  type ApprovalMetadataView,
+  type ChannelApprovalKind,
+  type ExpiredApprovalView,
+  type PendingApprovalView,
+  type ResolvedApprovalView,
 } from "openclaw/plugin-sdk/approval-handler-runtime";
 import type { ExecApprovalDecision } from "openclaw/plugin-sdk/approval-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -85,14 +87,6 @@ function buildAdaptiveCard(
   };
 }
 
-function formatApprovalDecision(decision: ExecApprovalDecision): string {
-  return decision === "allow-once"
-    ? "Allowed once"
-    : decision === "allow-always"
-      ? "Allowed always"
-      : "Denied";
-}
-
 export function buildMSTeamsPendingApprovalCard(params: {
   view: PendingApprovalView;
   nowMs: number;
@@ -140,14 +134,7 @@ export function buildMSTeamsResolvedApprovalCard(
         ? "OpenClaw Change"
         : "Exec";
   const resolvedBy = normalizeOptionalString(view.resolvedBy);
-  const decisionLabel =
-    view.approvalKind === "system-agent" && view.terminalStatus === "cancelled"
-      ? "Cancelled"
-      : view.approvalKind === "system-agent" && view.applicationStatus === "applied"
-        ? "Applied"
-        : view.approvalKind === "system-agent" && view.applicationStatus === "not-applied"
-          ? "Not applied"
-          : formatApprovalDecision(view.decision);
+  const decisionLabel = formatChannelApprovalResolvedLabel(view);
   return buildAdaptiveCard([
     ...buildCardHeading(
       `${kindLabel} Approval: ${decisionLabel}`,
@@ -190,7 +177,7 @@ export function buildMSTeamsCanonicalApprovalTerminalCard(
         : "System Agent";
   const outcome =
     approval.status === "allowed"
-      ? formatApprovalDecision(approval.decision)
+      ? formatApprovalDecisionLabel(approval.decision)
       : approval.status === "denied"
         ? "Denied"
         : approval.status === "expired"

--- a/extensions/slack/src/approval-handler.runtime.test.ts
+++ b/extensions/slack/src/approval-handler.runtime.test.ts
@@ -544,6 +544,63 @@ describe("slackApprovalNativeRuntime", () => {
     ).toBe(false);
   });
 
+  it.each([
+    { terminalStatus: undefined, label: "Not applied" },
+    { terminalStatus: "cancelled", label: "Cancelled" },
+  ] as const)(
+    "preserves the $label system-agent heading after denial",
+    async ({ terminalStatus, label }) => {
+      const result = await slackApprovalNativeRuntime.presentation.buildResolvedResult({
+        ...APPROVAL_CONTEXT,
+        request: {
+          approvalKind: "system-agent",
+          id: "system-agent:change-1",
+          request: {
+            title: "OpenClaw change",
+            description: "restart the Gateway",
+            command: "restart the Gateway",
+            proposalHash: "a".repeat(64),
+            allowedDecisions: ["allow-once", "deny"],
+            sessionId: "delegation-1",
+          },
+          createdAtMs: 0,
+          expiresAtMs: 60_000,
+        },
+        resolved: {
+          id: "system-agent:change-1",
+          decision: "deny",
+          applicationStatus: "not-applied",
+          terminalStatus,
+          ts: 1,
+        },
+        view: {
+          approvalKind: "system-agent",
+          approvalId: "system-agent:change-1",
+          phase: "resolved",
+          title: "OpenClaw change",
+          metadata: [],
+          commandText: "restart the Gateway",
+          operationSummary: "restart the Gateway",
+          decision: "deny",
+          applicationStatus: "not-applied",
+          terminalStatus,
+        },
+        entry: null,
+      });
+
+      expect(result).toMatchObject({
+        kind: "update",
+        payload: {
+          text: `*OpenClaw change approval: ${label}*\nResolved.\n\n*Change*\n\`\`\`\nrestart the Gateway\n\`\`\``,
+          blocks: [
+            { text: { text: `*OpenClaw change approval: ${label}*\nResolved.` } },
+            { text: { text: "*Change*\n```\nrestart the Gateway\n```" } },
+          ],
+        },
+      });
+    },
+  );
+
   it("renders expired exec approvals without interactive controls", async () => {
     const result = await buildExecExpiredResult();
 

--- a/extensions/slack/src/approval-handler.runtime.ts
+++ b/extensions/slack/src/approval-handler.runtime.ts
@@ -1,16 +1,17 @@
 // Slack plugin module implements approval handler behavior.
 import type { App } from "@slack/bolt";
 import type { Block, KnownBlock, WebClient } from "@slack/web-api";
-import type {
-  ChannelApprovalCapabilityHandlerContext,
-  ExpiredApprovalView,
-  PendingApprovalView,
-  PluginApprovalExpiredView,
-  PluginApprovalPendingView,
-  PluginApprovalResolvedView,
-  ResolvedApprovalView,
+import {
+  createChannelApprovalNativeRuntimeAdapter,
+  formatChannelApprovalResolvedLabel,
+  type ChannelApprovalCapabilityHandlerContext,
+  type ExpiredApprovalView,
+  type PendingApprovalView,
+  type PluginApprovalExpiredView,
+  type PluginApprovalPendingView,
+  type PluginApprovalResolvedView,
+  type ResolvedApprovalView,
 } from "openclaw/plugin-sdk/approval-handler-runtime";
-import { createChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { buildChannelApprovalNativeTargetKey } from "openclaw/plugin-sdk/approval-native-runtime";
 import { buildApprovalPresentationFromActionDescriptors } from "openclaw/plugin-sdk/approval-reply-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -155,16 +156,6 @@ function buildSlackMetadataContextBlocks(metadata: readonly SlackMetadataItem[])
     : [];
 }
 
-function resolveSlackApprovalDecisionLabel(
-  decision: "allow-once" | "allow-always" | "deny",
-): string {
-  return decision === "allow-once"
-    ? "Allowed once"
-    : decision === "allow-always"
-      ? "Allowed always"
-      : "Denied";
-}
-
 function buildSlackPluginMetadata(view: SlackPluginApprovalView): SlackMetadataItem[] {
   return [{ label: "Approval ID", value: view.approvalId }, ...view.metadata];
 }
@@ -207,14 +198,7 @@ function buildSlackApprovalPayload(input: SlackApprovalRenderInput): SlackPendin
           ? "An OpenClaw change needs your approval."
           : "A command needs your approval.";
   } else if (phase === "resolved") {
-    const decisionLabel =
-      isSystemAgent && view.terminalStatus === "cancelled"
-        ? "Cancelled"
-        : isSystemAgent && view.applicationStatus === "applied"
-          ? "Applied"
-          : isSystemAgent && view.applicationStatus === "not-applied"
-            ? "Not applied"
-            : resolveSlackApprovalDecisionLabel(view.decision);
+    const decisionLabel = formatChannelApprovalResolvedLabel(view);
     heading = `*${approvalName} approval: ${decisionLabel}*`;
     const resolvedBy = formatSlackApprover(view.resolvedBy);
     description = resolvedBy ? `Resolved by ${resolvedBy}.` : "Resolved.";

--- a/extensions/slack/src/approval-handler.runtime.ts
+++ b/extensions/slack/src/approval-handler.runtime.ts
@@ -3,7 +3,6 @@ import type { App } from "@slack/bolt";
 import type { Block, KnownBlock, WebClient } from "@slack/web-api";
 import {
   createChannelApprovalNativeRuntimeAdapter,
-  formatChannelApprovalResolvedLabel,
   type ChannelApprovalCapabilityHandlerContext,
   type ExpiredApprovalView,
   type PendingApprovalView,
@@ -14,6 +13,7 @@ import {
 } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { buildChannelApprovalNativeTargetKey } from "openclaw/plugin-sdk/approval-native-runtime";
 import { buildApprovalPresentationFromActionDescriptors } from "openclaw/plugin-sdk/approval-reply-runtime";
+import { formatChannelApprovalResolvedLabel } from "openclaw/plugin-sdk/approval-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { logError } from "openclaw/plugin-sdk/logging-core";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";

--- a/extensions/telegram/src/approval-handler.runtime.test.ts
+++ b/extensions/telegram/src/approval-handler.runtime.test.ts
@@ -412,53 +412,78 @@ describe("telegramApprovalNativeRuntime", () => {
     });
   });
 
-  it("renders exact system-agent terminal receipts", async () => {
-    const request = {
-      approvalKind: "system-agent" as const,
-      id: "system-agent:change-3",
-      request: {
-        title: "OpenClaw change",
-        description: "set config gateway.port to 19001",
-        command: "set config gateway.port to 19001",
-        proposalHash: "c".repeat(64),
-        allowedDecisions: ["allow-once", "deny"] as const,
-        sessionId: "delegation-3",
-      },
-      createdAtMs: 0,
-      expiresAtMs: 60_000,
-    };
-    await expect(
-      telegramApprovalNativeRuntime.presentation.buildResolvedResult({
-        cfg: {} as never,
-        accountId: "default",
-        context: { token: "tg-token" },
-        request,
-        resolved: {
-          id: request.id,
-          decision: "allow-once",
-          ts: 1,
-          applicationStatus: "applied",
-        },
-        view: {
-          approvalKind: "system-agent",
-          approvalId: request.id,
-          phase: "resolved",
+  it.each([
+    {
+      name: "applied",
+      decision: "allow-once",
+      applicationStatus: "applied",
+      summary: "set config gateway.port to 19001",
+      expected: "✅ OpenClaw change approved and applied: set config gateway.port to 19001",
+    },
+    {
+      name: "denied and not applied",
+      decision: "deny",
+      applicationStatus: "not-applied",
+      summary: "set config gateway.port to 19001",
+      expected: "❌ OpenClaw change denied. No change was made.",
+    },
+    {
+      name: "applied with a bounded UTF-16 summary",
+      decision: "allow-once",
+      applicationStatus: "applied",
+      summary: ` ${"x".repeat(2798)}😀tail `,
+      expected: `✅ OpenClaw change approved and applied: ${"x".repeat(2798)}…`,
+    },
+  ] as const)(
+    "renders exact system-agent terminal receipts: $name",
+    async ({ decision, applicationStatus, summary, expected }) => {
+      const request = {
+        approvalKind: "system-agent" as const,
+        id: "system-agent:change-3",
+        request: {
           title: "OpenClaw change",
-          metadata: [],
-          commandText: "set config gateway.port to 19001",
-          operationSummary: "set config gateway.port to 19001",
-          decision: "allow-once",
-          applicationStatus: "applied",
+          description: summary,
+          command: summary,
+          proposalHash: "c".repeat(64),
+          allowedDecisions: ["allow-once", "deny"] as const,
+          sessionId: "delegation-3",
         },
-        entry: { chatId: "9", messageId: "m1" },
-      }),
-    ).resolves.toEqual({
-      kind: "update",
-      payload: {
-        text: "✅ OpenClaw change approved and applied: set config gateway.port to 19001",
-      },
-    });
-  });
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      };
+      await expect(
+        telegramApprovalNativeRuntime.presentation.buildResolvedResult({
+          cfg: {} as never,
+          accountId: "default",
+          context: { token: "tg-token" },
+          request,
+          resolved: {
+            id: request.id,
+            decision,
+            ts: 1,
+            applicationStatus,
+          },
+          view: {
+            approvalKind: "system-agent",
+            approvalId: request.id,
+            phase: "resolved",
+            title: "OpenClaw change",
+            metadata: [],
+            commandText: summary,
+            operationSummary: summary,
+            decision,
+            applicationStatus,
+          },
+          entry: { chatId: "9", messageId: "m1" },
+        }),
+      ).resolves.toEqual({
+        kind: "update",
+        payload: {
+          text: expected,
+        },
+      });
+    },
+  );
 
   it("updates the pending message and removes actions for terminal events", async () => {
     const editMessage = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/approval-terminal.ts
+++ b/extensions/telegram/src/approval-terminal.ts
@@ -1,8 +1,10 @@
 // Telegram plugin module renders terminal operator approval receipts.
 import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
-import type {
-  ExpiredApprovalView,
-  ResolvedApprovalView,
+import {
+  buildSystemAgentApprovalResolvedText,
+  formatApprovalDecisionLabel,
+  type ExpiredApprovalView,
+  type ResolvedApprovalView,
 } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
@@ -10,14 +12,8 @@ const TELEGRAM_APPROVAL_DETAIL_MAX_CHARS = 2_800;
 const TELEGRAM_APPROVAL_ID_MAX_CHARS = 512;
 const TELEGRAM_APPROVAL_TERMINAL_MAX_CHARS = 4_000;
 
-function formatApprovalDecision(decision: string | undefined): string {
-  if (decision === "allow-always") {
-    return "Allowed always";
-  }
-  if (decision === "allow-once") {
-    return "Allowed once";
-  }
-  return decision === "deny" ? "Denied" : "Resolved";
+function formatApprovalDecision(decision: ResolvedApprovalView["decision"] | undefined): string {
+  return decision ? formatApprovalDecisionLabel(decision) : "Resolved";
 }
 
 function formatCanonicalResult(approval: ApprovalResolveResult["approval"]): string {
@@ -153,15 +149,10 @@ function appendViewSubject(
 /** Render a canonical native resolved event while retaining safe request context. */
 export function buildTelegramNativeResolvedApprovalText(view: ResolvedApprovalView): string {
   if (view.approvalKind === "system-agent") {
-    return view.terminalStatus === "cancelled"
-      ? "⚠️ OpenClaw change was cancelled because its run ended. No change was made. Retry."
-      : view.decision === "deny"
-        ? "❌ OpenClaw change denied. No change was made."
-        : view.applicationStatus === "applied"
-          ? `✅ OpenClaw change approved and applied: ${truncateDetail(view.operationSummary)}`
-          : view.applicationStatus === "not-applied"
-            ? "⚠️ OpenClaw change approved, but it was not applied. Check the Gateway and retry."
-            : `✅ OpenClaw change approved. Applying: ${truncateDetail(view.operationSummary)}`;
+    return buildSystemAgentApprovalResolvedText({
+      ...view,
+      operationSummary: truncateDetail(view.operationSummary),
+    });
   }
   const label = view.approvalKind === "exec" ? "Exec" : "Plugin";
   const lines = [

--- a/extensions/telegram/src/approval-terminal.ts
+++ b/extensions/telegram/src/approval-terminal.ts
@@ -1,11 +1,13 @@
 // Telegram plugin module renders terminal operator approval receipts.
 import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type {
+  ExpiredApprovalView,
+  ResolvedApprovalView,
+} from "openclaw/plugin-sdk/approval-handler-runtime";
 import {
   buildSystemAgentApprovalResolvedText,
   formatApprovalDecisionLabel,
-  type ExpiredApprovalView,
-  type ResolvedApprovalView,
-} from "openclaw/plugin-sdk/approval-handler-runtime";
+} from "openclaw/plugin-sdk/approval-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 const TELEGRAM_APPROVAL_DETAIL_MAX_CHARS = 2_800;

--- a/src/infra/approval-request-filters.test.ts
+++ b/src/infra/approval-request-filters.test.ts
@@ -1,9 +1,6 @@
 // Covers approval request agent and session filters.
 import { describe, expect, it } from "vitest";
-import {
-  matchesApprovalRequestFilters,
-  matchesApprovalRequestSessionFilter,
-} from "./approval-request-filters.js";
+import { matchesApprovalRequestFilters } from "./approval-request-filters.js";
 
 describe("approval request filters", () => {
   it("matches explicit agent ids and session substrings", () => {
@@ -40,6 +37,11 @@ describe("approval request filters", () => {
   });
 
   it("rejects unsafe regex patterns in session filters", () => {
-    expect(matchesApprovalRequestSessionFilter(`${"a".repeat(28)}!`, ["(a+)+$"])).toBe(false);
+    expect(
+      matchesApprovalRequestFilters({
+        request: { sessionKey: `${"a".repeat(28)}!` },
+        sessionFilter: ["(a+)+$"],
+      }),
+    ).toBe(false);
   });
 });

--- a/src/infra/approval-request-filters.ts
+++ b/src/infra/approval-request-filters.ts
@@ -10,10 +10,7 @@ export type ApprovalRequestFilterInput = {
 };
 
 /** Matches session filters as literal substrings first, then bounded safe regexes. */
-export function matchesApprovalRequestSessionFilter(
-  sessionKey: string,
-  patterns: string[],
-): boolean {
+function matchesApprovalRequestSessionFilter(sessionKey: string, patterns: string[]): boolean {
   return patterns.some((pattern) => {
     if (sessionKey.includes(pattern)) {
       return true;

--- a/src/plugin-sdk/approval-handler-runtime.test.ts
+++ b/src/plugin-sdk/approval-handler-runtime.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import type { SystemAgentApprovalRequest } from "../infra/system-agent-approvals.js";
 import {
   buildChannelApprovalResolvedText,
-  buildSystemAgentApprovalResolvedText,
-  formatChannelApprovalResolvedLabel,
   type ResolvedApprovalView,
 } from "./approval-handler-runtime.js";
+import {
+  buildSystemAgentApprovalResolvedText,
+  formatChannelApprovalResolvedLabel,
+} from "./approval-runtime.js";
 
 type SystemAgentView = Extract<ResolvedApprovalView, { approvalKind: "system-agent" }>;
 

--- a/src/plugin-sdk/approval-handler-runtime.test.ts
+++ b/src/plugin-sdk/approval-handler-runtime.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { SystemAgentApprovalRequest } from "../infra/system-agent-approvals.js";
+import {
+  buildChannelApprovalResolvedText,
+  buildSystemAgentApprovalResolvedText,
+  formatChannelApprovalResolvedLabel,
+  type ResolvedApprovalView,
+} from "./approval-handler-runtime.js";
+
+type SystemAgentView = Extract<ResolvedApprovalView, { approvalKind: "system-agent" }>;
+
+function systemAgentView(state: Partial<SystemAgentView> = {}): SystemAgentView {
+  return {
+    approvalKind: "system-agent",
+    approvalId: "system-agent:change",
+    phase: "resolved",
+    title: "OpenClaw change",
+    metadata: [],
+    commandText: "restart the Gateway",
+    operationSummary: "restart the Gateway",
+    decision: "allow-once",
+    ...state,
+  };
+}
+
+const cases: Array<{ state: Partial<SystemAgentView>; label: string; text: string }> = [
+  {
+    state: {},
+    label: "Allowed once",
+    text: "✅ OpenClaw change approved. Applying: restart the Gateway",
+  },
+  {
+    state: { decision: "allow-always" },
+    label: "Allowed always",
+    text: "✅ OpenClaw change approved. Applying: restart the Gateway",
+  },
+  {
+    state: { decision: "deny" },
+    label: "Denied",
+    text: "❌ OpenClaw change denied. No change was made.",
+  },
+  {
+    state: { applicationStatus: "applied" },
+    label: "Applied",
+    text: "✅ OpenClaw change approved and applied: restart the Gateway",
+  },
+  {
+    state: { applicationStatus: "not-applied" },
+    label: "Not applied",
+    text: "⚠️ OpenClaw change approved, but it was not applied. Check the Gateway and retry.",
+  },
+  {
+    state: { decision: "deny", applicationStatus: "not-applied" },
+    label: "Not applied",
+    text: "❌ OpenClaw change denied. No change was made.",
+  },
+  {
+    state: { decision: "deny", applicationStatus: "applied" },
+    label: "Applied",
+    text: "❌ OpenClaw change denied. No change was made.",
+  },
+  {
+    state: { decision: "deny", applicationStatus: "applied", terminalStatus: "cancelled" },
+    label: "Cancelled",
+    text: "⚠️ OpenClaw change was cancelled because its run ended. No change was made. Retry.",
+  },
+];
+
+describe("approval terminal presentation", () => {
+  it.each(cases)("preserves rich and prose precedence for $state", ({ state, label, text }) => {
+    const view = systemAgentView(state);
+    expect(formatChannelApprovalResolvedLabel(view)).toBe(label);
+    expect(buildSystemAgentApprovalResolvedText(view)).toBe(text);
+  });
+
+  it("keeps decision spelling local without overriding application results", () => {
+    const formatDecision = (decision: ResolvedApprovalView["decision"]) => `Decision: ${decision}`;
+    expect(formatChannelApprovalResolvedLabel(systemAgentView(), formatDecision)).toBe(
+      "Decision: allow-once",
+    );
+    expect(
+      formatChannelApprovalResolvedLabel(
+        systemAgentView({ applicationStatus: "not-applied" }),
+        formatDecision,
+      ),
+    ).toBe("Not applied");
+  });
+
+  it("uses the resolved event's decision for channel prose", () => {
+    const request: SystemAgentApprovalRequest = {
+      approvalKind: "system-agent",
+      id: "system-agent:change",
+      request: {
+        title: "OpenClaw change",
+        description: "restart the Gateway",
+        command: "restart the Gateway",
+        proposalHash: "a".repeat(64),
+        allowedDecisions: ["allow-once", "deny"],
+        sessionId: "test-session",
+      },
+      createdAtMs: 0,
+      expiresAtMs: 60_000,
+    };
+    expect(
+      buildChannelApprovalResolvedText({
+        request,
+        resolved: { id: request.id, decision: "deny", ts: 1 },
+        view: systemAgentView({ applicationStatus: "applied" }),
+      }),
+    ).toBe("❌ OpenClaw change denied. No change was made.");
+  });
+});

--- a/src/plugin-sdk/approval-handler-runtime.ts
+++ b/src/plugin-sdk/approval-handler-runtime.ts
@@ -16,6 +16,7 @@ import {
 } from "../infra/plugin-approvals.js";
 import type { SystemAgentApprovalResolved } from "../infra/system-agent-approvals.js";
 import { buildApprovalResolvedReplyPayload } from "./approval-renderers.js";
+import { buildSystemAgentApprovalResolvedText } from "./approval-terminal.js";
 export {
   createChannelApprovalHandler,
   createChannelApprovalNativeRuntimeAdapter,
@@ -51,68 +52,6 @@ export { resolveApprovalOverGateway } from "./approval-gateway-runtime.js";
 
 type ApprovalRequest = ApprovalRequestInput;
 type ApprovalResolved = ExecApprovalResolved | PluginApprovalResolved | SystemAgentApprovalResolved;
-
-type SystemAgentResolvedView = Extract<ResolvedApprovalView, { approvalKind: "system-agent" }>;
-type ApprovalTerminalOutcome =
-  | ResolvedApprovalView["decision"]
-  | "cancelled"
-  | "applied"
-  | "not-applied";
-
-const TERMINAL_LABELS = {
-  "allow-once": "Allowed once",
-  "allow-always": "Allowed always",
-  deny: "Denied",
-  cancelled: "Cancelled",
-  applied: "Applied",
-  "not-applied": "Not applied",
-};
-
-/** Label a recorded decision without implying that a system change was applied. */
-export function formatApprovalDecisionLabel(decision: ResolvedApprovalView["decision"]): string {
-  return TERMINAL_LABELS[decision];
-}
-
-function interpretApprovalTerminalOutcome(
-  view: ResolvedApprovalView,
-  precedence: "application" | "denial",
-): ApprovalTerminalOutcome {
-  if (view.approvalKind !== "system-agent") {
-    return view.decision;
-  }
-  if (view.terminalStatus === "cancelled") {
-    return "cancelled";
-  }
-  // Denied changes also publish not-applied. Preserve rich-label and prose precedence.
-  return precedence === "denial" && view.decision === "deny"
-    ? "deny"
-    : (view.applicationStatus ?? view.decision);
-}
-
-/** Format a rich terminal label, retaining transport-specific decision spelling. */
-export function formatChannelApprovalResolvedLabel(
-  view: ResolvedApprovalView,
-  formatDecision?: (decision: ResolvedApprovalView["decision"]) => string,
-): string {
-  const outcome = interpretApprovalTerminalOutcome(view, "application");
-  return formatDecision && outcome === view.decision
-    ? formatDecision(view.decision)
-    : TERMINAL_LABELS[outcome];
-}
-
-/** Describe a system change using denial-first prose and a prepared operation summary. */
-export function buildSystemAgentApprovalResolvedText(view: SystemAgentResolvedView): string {
-  const outcome = interpretApprovalTerminalOutcome(view, "denial");
-  return outcome === "cancelled"
-    ? "⚠️ OpenClaw change was cancelled because its run ended. No change was made. Retry."
-    : outcome === "deny"
-      ? "❌ OpenClaw change denied. No change was made."
-      : outcome === "applied"
-        ? `✅ OpenClaw change approved and applied: ${view.operationSummary}`
-        : outcome === "not-applied"
-          ? "⚠️ OpenClaw change approved, but it was not applied. Check the Gateway and retry."
-          : `✅ OpenClaw change approved. Applying: ${view.operationSummary}`;
-}
 
 /** Builds channel-visible resolved approval text for every approval kind. */
 export function buildChannelApprovalResolvedText(params: {

--- a/src/plugin-sdk/approval-handler-runtime.ts
+++ b/src/plugin-sdk/approval-handler-runtime.ts
@@ -52,22 +52,79 @@ export { resolveApprovalOverGateway } from "./approval-gateway-runtime.js";
 type ApprovalRequest = ApprovalRequestInput;
 type ApprovalResolved = ExecApprovalResolved | PluginApprovalResolved | SystemAgentApprovalResolved;
 
-/** Builds channel-visible resolved approval text for exec and plugin approvals. */
+type SystemAgentResolvedView = Extract<ResolvedApprovalView, { approvalKind: "system-agent" }>;
+type ApprovalTerminalOutcome =
+  | ResolvedApprovalView["decision"]
+  | "cancelled"
+  | "applied"
+  | "not-applied";
+
+const TERMINAL_LABELS = {
+  "allow-once": "Allowed once",
+  "allow-always": "Allowed always",
+  deny: "Denied",
+  cancelled: "Cancelled",
+  applied: "Applied",
+  "not-applied": "Not applied",
+};
+
+/** Label a recorded decision without implying that a system change was applied. */
+export function formatApprovalDecisionLabel(decision: ResolvedApprovalView["decision"]): string {
+  return TERMINAL_LABELS[decision];
+}
+
+function interpretApprovalTerminalOutcome(
+  view: ResolvedApprovalView,
+  precedence: "application" | "denial",
+): ApprovalTerminalOutcome {
+  if (view.approvalKind !== "system-agent") {
+    return view.decision;
+  }
+  if (view.terminalStatus === "cancelled") {
+    return "cancelled";
+  }
+  // Denied changes also publish not-applied. Preserve rich-label and prose precedence.
+  return precedence === "denial" && view.decision === "deny"
+    ? "deny"
+    : (view.applicationStatus ?? view.decision);
+}
+
+/** Format a rich terminal label, retaining transport-specific decision spelling. */
+export function formatChannelApprovalResolvedLabel(
+  view: ResolvedApprovalView,
+  formatDecision?: (decision: ResolvedApprovalView["decision"]) => string,
+): string {
+  const outcome = interpretApprovalTerminalOutcome(view, "application");
+  return formatDecision && outcome === view.decision
+    ? formatDecision(view.decision)
+    : TERMINAL_LABELS[outcome];
+}
+
+/** Describe a system change using denial-first prose and a prepared operation summary. */
+export function buildSystemAgentApprovalResolvedText(view: SystemAgentResolvedView): string {
+  const outcome = interpretApprovalTerminalOutcome(view, "denial");
+  return outcome === "cancelled"
+    ? "⚠️ OpenClaw change was cancelled because its run ended. No change was made. Retry."
+    : outcome === "deny"
+      ? "❌ OpenClaw change denied. No change was made."
+      : outcome === "applied"
+        ? `✅ OpenClaw change approved and applied: ${view.operationSummary}`
+        : outcome === "not-applied"
+          ? "⚠️ OpenClaw change approved, but it was not applied. Check the Gateway and retry."
+          : `✅ OpenClaw change approved. Applying: ${view.operationSummary}`;
+}
+
+/** Builds channel-visible resolved approval text for every approval kind. */
 export function buildChannelApprovalResolvedText(params: {
   request: ApprovalRequest;
   resolved: ApprovalResolved;
   view: ResolvedApprovalView;
 }): string {
   if (params.view.approvalKind === "system-agent") {
-    return params.view.terminalStatus === "cancelled"
-      ? "⚠️ OpenClaw change was cancelled because its run ended. No change was made. Retry."
-      : params.resolved.decision === "deny"
-        ? "❌ OpenClaw change denied. No change was made."
-        : params.view.applicationStatus === "applied"
-          ? `✅ OpenClaw change approved and applied: ${params.view.operationSummary}`
-          : params.view.applicationStatus === "not-applied"
-            ? "⚠️ OpenClaw change approved, but it was not applied. Check the Gateway and retry."
-            : `✅ OpenClaw change approved. Applying: ${params.view.operationSummary}`;
+    return buildSystemAgentApprovalResolvedText({
+      ...params.view,
+      decision: params.resolved.decision,
+    });
   }
   if (params.view.approvalKind === "plugin") {
     return buildPluginApprovalResolvedMessage(params.resolved as PluginApprovalResolved);

--- a/src/plugin-sdk/approval-runtime.ts
+++ b/src/plugin-sdk/approval-runtime.ts
@@ -31,11 +31,7 @@ export {
   resolveExecApprovalSessionTarget,
   type ExecApprovalSessionTarget,
 } from "../infra/exec-approval-session-target.js";
-export {
-  doesApprovalRequestMatchChannelAccount,
-  resolveApprovalRequestAccountId,
-  resolveApprovalRequestChannelAccountId,
-} from "../infra/approval-request-account-binding.js";
+export { doesApprovalRequestMatchChannelAccount } from "../infra/approval-request-account-binding.js";
 export {
   buildPluginApprovalExpiredMessage,
   buildPluginApprovalRequestMessage,
@@ -67,7 +63,6 @@ export {
 export { resolveApprovalApprovers } from "./approval-approvers.js";
 export {
   matchesApprovalRequestFilters,
-  matchesApprovalRequestSessionFilter,
   type ApprovalRequestFilterInput,
 } from "../infra/approval-request-filters.js";
 export {
@@ -76,3 +71,8 @@ export {
   buildPluginApprovalPendingReplyPayload,
   buildPluginApprovalResolvedReplyPayload,
 } from "./approval-renderers.js";
+export {
+  buildSystemAgentApprovalResolvedText,
+  formatApprovalDecisionLabel,
+  formatChannelApprovalResolvedLabel,
+} from "./approval-terminal.js";

--- a/src/plugin-sdk/approval-terminal.ts
+++ b/src/plugin-sdk/approval-terminal.ts
@@ -1,0 +1,63 @@
+import type { ResolvedApprovalView } from "../infra/approval-view-model.types.js";
+
+type SystemAgentResolvedView = Extract<ResolvedApprovalView, { approvalKind: "system-agent" }>;
+type ApprovalTerminalOutcome =
+  | ResolvedApprovalView["decision"]
+  | "cancelled"
+  | "applied"
+  | "not-applied";
+
+const TERMINAL_LABELS = {
+  "allow-once": "Allowed once",
+  "allow-always": "Allowed always",
+  deny: "Denied",
+  cancelled: "Cancelled",
+  applied: "Applied",
+  "not-applied": "Not applied",
+};
+
+/** Label a recorded decision without implying that a system change was applied. */
+export function formatApprovalDecisionLabel(decision: ResolvedApprovalView["decision"]): string {
+  return TERMINAL_LABELS[decision];
+}
+
+function interpretApprovalTerminalOutcome(
+  view: ResolvedApprovalView,
+  precedence: "application" | "denial",
+): ApprovalTerminalOutcome {
+  if (view.approvalKind !== "system-agent") {
+    return view.decision;
+  }
+  if (view.terminalStatus === "cancelled") {
+    return "cancelled";
+  }
+  // Denied changes also publish not-applied. Preserve rich-label and prose precedence.
+  return precedence === "denial" && view.decision === "deny"
+    ? "deny"
+    : (view.applicationStatus ?? view.decision);
+}
+
+/** Format a rich terminal label, retaining transport-specific decision spelling. */
+export function formatChannelApprovalResolvedLabel(
+  view: ResolvedApprovalView,
+  formatDecision?: (decision: ResolvedApprovalView["decision"]) => string,
+): string {
+  const outcome = interpretApprovalTerminalOutcome(view, "application");
+  return formatDecision && outcome === view.decision
+    ? formatDecision(view.decision)
+    : TERMINAL_LABELS[outcome];
+}
+
+/** Describe a system change using denial-first prose and a prepared operation summary. */
+export function buildSystemAgentApprovalResolvedText(view: SystemAgentResolvedView): string {
+  const outcome = interpretApprovalTerminalOutcome(view, "denial");
+  return outcome === "cancelled"
+    ? "⚠️ OpenClaw change was cancelled because its run ended. No change was made. Retry."
+    : outcome === "deny"
+      ? "❌ OpenClaw change denied. No change was made."
+      : outcome === "applied"
+        ? `✅ OpenClaw change approved and applied: ${view.operationSummary}`
+        : outcome === "not-applied"
+          ? "⚠️ OpenClaw change approved, but it was not applied. Check the Gateway and retry."
+          : `✅ OpenClaw change approved. Applying: ${view.operationSummary}`;
+}


### PR DESCRIPTION
Related: #140645 and #140695.

## What Problem This Solves

Approval results were interpreted independently in Discord, Slack, Matrix, Google Chat, Teams, Telegram, and the SDK text helper. Denied system changes also publish `not-applied`, so consolidating those copies without preserving their precedence would change existing receipts.

## Why This Change Was Made

One private SDK interpreter now supplies terminal labels and system-agent prose through the existing `openclaw/plugin-sdk/approval-runtime` entrypoint. Rich labels retain application-status precedence; prose retains denial precedence; both prioritize cancellation. Discord's decision spelling/colors, Telegram's UTF-16 limits, and the SDK wrapper's resolved-event decision override remain intact.

The three new helpers replace three unused bindings on that same public entrypoint: `matchesApprovalRequestSessionFilter`, `resolveApprovalRequestAccountId`, and `resolveApprovalRequestChannelAccountId`. Account lookup remains available through `approval-native-runtime`; the session predicate is private behind the retained full request-filter API. Its unsafe-regex test now exercises that public filtering path.

Global and OpenClaw-org consumer searches were fully paged and import blobs inspected. No independent consumer of the retired broad bindings was found; matches were self-contained hosts or generated/historical artifacts. The verified [Inline consumer](https://github.com/inline-chat/inline/blob/0d1d42383b3f807a72b80bf526c3a4d2914e0337/openclaw/src/inline/exec-approvals.ts) uses the retained narrow binding. No compatibility alias or budget increase is introduced.

## User Impact

No user-visible behavior or appearance change. Approval authorization, settlement, persistence, decision/application precedence, and message limits remain unchanged. Plugin authors use the existing approval runtime entrypoint for the shared presentation helpers and the native runtime entrypoint for account lookup.

## Evidence

Fresh validation is for `6e96706af6e941aa8226b29174b8971ce5af38be`, rebased onto main including #140645. Production patches are unchanged; the docs conflict was resolved by retaining both consolidations' guidance.

- `node scripts/run-vitest.mjs` with 46 concrete approval, Telegram handler, and public request-filter test files: **535 tests passed**. Tests preserve cancellation, denial/application precedence, channel-specific receipt text, UTF-16 bounds, and the resolved-event decision override.
- `node scripts/check-changed.mjs` passed ratchets, formatting, SDK checks, core/plugin production and test typechecks, declaration/deprecation guards, all three dead-export scans (zero entries), and core lint. Local plugin lint reaches the documented nested-worktree declaration-boundary exception; exact-head hosted lint, typechecks, and extension package-boundary checks passed.
- `pnpm build` passed in **6m29s**. `pnpm plugin-sdk:surface:check` passed with **4,446 public exports and 2,629 callables**, within unchanged budgets. The public replacement remains three additions/three removals on the existing approval-runtime entrypoint.
- All nine isolated startup profiles passed, with zero failures/timeouts. The command was `OPENCLAW_LOCAL_CHECK=0 node --import tsx scripts/profile-extension-memory.mts --extension <id> --skip-combined --concurrency 1`, for Discord, Google Chat, iMessage, Matrix, Teams, Signal, Slack, Telegram, and WhatsApp.
- Fresh isolated Codex branch review: **zero actionable P0–P2 findings**. Production **+140/−145 = −5**; tests **+416/−52 = +364**.
- Exact-head CI passed, including required `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/34121243751. No CI rerun was needed.

Live channel proof remains unavailable. Mock-Gateway handler suites verify the changed presentation boundary; they are not live transport proof.

## Maintainer-directed SDK replacement

The maintainer explicitly required this consolidation to use the existing approval runtime entrypoint and replace at least as many public exports as it adds, without increasing SDK budgets. The lane's public-contract rule authorizes removal and internal migration after a GitHub-wide plus OpenClaw-org audit finds no external consumer. All search variants were paged to completion; the retiring broad bindings have no independent upstream consumer. Existing narrow account helpers remain available and the observed independent Inline consumer retains its import path. This is an intentional import-level removal under that direction, with migration documented; flat counts alone are not the compatibility argument. The bot's request to retain all broad bindings would conflict with the explicit replacement decision.
