### PR TITLE
refactor(channels): avoid duplicate bundled path probes

### DIFF
--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -197,19 +197,12 @@ function resolveGeneratedBundledChannelModulePath(params: {
   if (!packageRoot || !pluginRoot || !isPathInside(packageRoot, pluginRoot)) {
     return null;
   }
-  for (const rawEntry of [params.entry.built, params.entry.source]) {
-    if (!rawEntry) {
-      continue;
-    }
-    const candidate = path.isAbsolute(rawEntry)
-      ? path.normalize(rawEntry)
-      : path.resolve(pluginRoot, rawEntry);
-    const realCandidate = pluginCacheRealpathSync(candidate, true);
-    if (realCandidate && isPathInside(pluginRoot, realCandidate)) {
-      return realCandidate;
-    }
-  }
-  return null;
+  const rawEntry = params.entry.source;
+  const candidate = path.isAbsolute(rawEntry)
+    ? path.normalize(rawEntry)
+    : path.resolve(pluginRoot, rawEntry);
+  const realCandidate = pluginCacheRealpathSync(candidate, true);
+  return realCandidate && isPathInside(pluginRoot, realCandidate) ? realCandidate : null;
 }
 
 function loadGeneratedBundledChannelModule(params: {


### PR DESCRIPTION
## What Problem This Solves

The bundled-channel registry-root fallback probes the same source path twice when it is unavailable. This is a maintainer-requested production simplification in the #135868 split campaign.

## Why This Change Was Made

The sole runtime metadata constructor, `toBundledChannelEntryPair` in `src/plugins/bundled-channel-runtime.ts`, rejects an empty source and sets both `built` and `source` to that same string. Source and setup entries reach this private resolver directly from that metadata. Resolve the single source candidate once instead of looping over identical values.

Deletion evidence: the second probe cannot name another artifact, and the empty-element branch is unreachable for produced entries. Absolute/relative path handling and both realpath containment checks are unchanged. The full registry-root fallback remains because shipped source-only and package-symlink layouts still need it; outer retry-after-error behavior also remains.

## User Impact

No supported behavior change. Bundled channel loading retains its source-root fallback, containment checks, setup behavior and cache ownership.

## Evidence

- Before/after owner suites: 2 files, 29 cases each (15.34s / 19.08s). Source-only, symlink containment, root-cache and retry cases are unchanged.
- After main changed the lockfile, ran the required frozen offline install and repeated proof on clean **Blacksmith Testbox**: `pnpm build` passed (3m 12.8s), both owner files passed all 29 cases (5.93s), and the Signal import profile passed (108.0 MiB peak RSS).
- Full `node scripts/check-changed.mjs`: **exit 0**, including core, core-test, extension and extension-test types, all export scans, extension lint and remaining guards. Local extension lint had encountered the unrelated parent-checkout `node_modules/punycode` boundary; the clean run preserved that guard and passed 9,095 extension files with no warnings/errors.
- [Testbox provisioning run](https://github.com/openclaw/openclaw/actions/runs/34076049484); the one-shot proof command exited 0 and the lease stopped normally. Source commit/tree and the changed file's hash were verified before proof. The later rebase preserved the file, its metadata producer, and the lockfile.
- Fresh independent autoreview: scoped-clean, no accepted/actionable findings.
- Production +6/−13 = **−7**; tests/tooling/docs zero.
