### PR TITLE
fix(google-meet): serialize caption state without crashing on __soy circular JSON

### DIFF
--- a/extensions/google-meet/src/transports/google-meet-page-scripts.ts
+++ b/extensions/google-meet/src/transports/google-meet-page-scripts.ts
@@ -483,7 +483,13 @@ export function meetStatusScript(params: {
     lastCaptionAt = last?.at;
     lastCaptionSpeaker = last?.speaker;
     lastCaptionText = last?.text;
-    recentTranscript = lines.slice(-5);
+    // Visible caption rows carry a live DOM node for lifecycle tracking;
+    // strip it so JSON.stringify never encounters a __soy circular reference. (#140455)
+    recentTranscript = lines.slice(-5).map((entry) => ({
+      at: entry.at,
+      speaker: entry.speaker,
+      text: entry.text,
+    }));
   }
   const lobbyWaiting = !inCall && /asking to be let in|you.?ll join when someone lets you in|waiting to be let in|ask to join/i.test(pageText);
   const leaveReason = !inCall && /you left the meeting|you.?ve left the meeting|removed from the meeting|you were removed|call ended|meeting ended/i.test(pageText)
@@ -530,7 +536,7 @@ export function meetStatusScript(params: {
     title: document.title,
     url: pageUrl,
     notes
-  });
+  }, (function(){var seen=new WeakSet();return function(k,v){if(v&&typeof v==='object'){if(typeof v.nodeType==='number')return undefined;if(seen.has(v))return undefined;seen.add(v);}return v;};})());
 }`;
 }
 

--- a/extensions/google-meet/src/transports/google-meet-platform-adapter.test.ts
+++ b/extensions/google-meet/src/transports/google-meet-platform-adapter.test.ts
@@ -210,3 +210,96 @@ describe("GOOGLE_MEET_PLATFORM_ADAPTER audio routing", () => {
     expect(MeetingPlatformAdapter.isRealtimeRouteReady("agent", health)).toBe(false);
   });
 });
+
+describe("meetStatusScript circular JSON safety", () => {
+  it("serializes caption state without crashing on __soy circular references (#140455)", async () => {
+    // Google Meet DOM nodes carry a __soy property whose object closes a cycle
+    // back to the node, causing JSON.stringify to throw “Converting circular
+    // structure to JSON”.
+    const captionRegion: Record<string, unknown> = {
+      nodeType: 1,
+      textContent: "Alice\nHello world",
+      innerText: "Alice\nHello world",
+      getAttribute: () => "Captions",
+    };
+    captionRegion["__soy"] = { node: captionRegion };
+
+    const leave = pageNode("Leave call");
+    const media = {
+      sinkId: "",
+      setSinkId: vi.fn(async () => {}),
+    };
+    const document = {
+      body: { textContent: "" },
+      title: "Meet",
+      querySelector() {
+        return null;
+      },
+      querySelectorAll(selector: string) {
+        if (selector === "button") {
+          return [leave];
+        }
+        if (selector === "input") {
+          return [];
+        }
+        if (selector === "audio, video") {
+          return [media];
+        }
+        if (selector.includes("aption") || selector.includes("aria-live")) {
+          return [captionRegion];
+        }
+        if (selector.includes("button") || selector.includes('[role="')) {
+          return [leave];
+        }
+        return [];
+      },
+    };
+
+    const result = await runInNewContext(
+      `(${meetStatusScript({
+        allowMicrophone: true,
+        autoJoin: false,
+        captureCaptions: true,
+        guestName: "OpenClaw Agent",
+      })})()`,
+      {
+        Event: globalThis.Event,
+        JSON,
+        String,
+        Date,
+        WeakSet,
+        crypto: globalThis.crypto,
+        MutationObserver: class MockMutationObserver {
+          observe() {}
+          disconnect() {}
+        },
+        document,
+        location: { href: MEETING_URL, hostname: "meet.google.com" },
+        navigator: {
+          mediaDevices: {
+            enumerateDevices: async () => [
+              { deviceId: "input-1", kind: "audioinput", label: "BlackHole 2ch" },
+              { deviceId: "output-1", kind: "audiooutput", label: "OpenClaw Meeting Audio" },
+            ],
+          },
+        },
+        setTimeout: (callback: () => void) => {
+          callback();
+          return 1;
+        },
+        clearTimeout,
+        window: {},
+      },
+    );
+
+    // The key assertion: JSON.parse must not throw on the result.
+    const health = JSON.parse(result) as Record<string, unknown>;
+    expect(health.inCall).toBe(true);
+    // recentTranscript must not carry the live DOM node.
+    const transcript = health.recentTranscript as Array<Record<string, unknown>>;
+    expect(transcript).toHaveLength(1);
+    expect(transcript[0]?.speaker).toBe("Alice");
+    expect(transcript[0]?.text).toBe("Hello world");
+    expect(transcript[0]?.node).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Closes #140455 (Bug 1 — CRITICAL, clean fix).

Google Meet's DOM attaches a `__soy` property whose object closes a cycle back to the node. The in-call status script (`meetStatusScript`) stored the live DOM node in each visible caption row for lifecycle tracking, then passed those rows into `JSON.stringify` via `recentTranscript` — throwing:

```
TypeError: Converting circular structure to JSON
  --> starting at object with constructor 'HTMLDivElement'
  |     property '__soy' -> object with constructor '_.AGx'
  --- property 'node' closes the circle
```

**Effect:** `page.evaluate` returns HTTP 500; the plugin can never confirm in-call (`inCall` reported `no` despite the agent being a participant), never establishes the audio bridge, and reports `manualAction: browser-control-unavailable`.

## Root Cause

In `scrapeCaptions()`, each visible caption row is pushed as `{ ...row, node: region }` where `region` is a live DOM element. When `recentTranscript = lines.slice(-5)` copies these rows (including the `node` property) into the serialized payload, `JSON.stringify` encounters the `__soy` → `node` cycle and throws.

## Fix

**1. Root cause — strip the live DOM node from `recentTranscript` entries:**

```diff
- recentTranscript = lines.slice(-5);
+ // Visible caption rows carry a live DOM node for lifecycle tracking;
+ // strip it so JSON.stringify never encounters a __soy circular reference. (#140455)
+ recentTranscript = lines.slice(-5).map((entry) => ({
+   at: entry.at,
+   speaker: entry.speaker,
+   text: entry.text,
+ }));
```

This keeps only the serializable `{ at, speaker, text }` fields and drops the `node`, `seenAt`, etc. The `node` property remains on the internal `captionState.visible` array for lifecycle tracking — only the serialized copy is cleaned.

**2. Defensive — add a circular-safe replacer to `JSON.stringify`:**

```diff
- return JSON.stringify({ ... });
+ return JSON.stringify({ ... }, (function(){
+   var seen = new WeakSet();
+   return function(k, v) {
+     if (v && typeof v === 'object') {
+       if (typeof v.nodeType === 'number') return undefined;  // drop DOM nodes
+       if (seen.has(v)) return undefined;                      // break cycles
+       seen.add(v);
+     }
+     return v;
+   };
+ })());
```

This is a belt-and-suspenders guard that handles any future edge case where a DOM node or circular reference might sneak into the serialized payload.

## Evidence

### Regression test

Added a test in `google-meet-platform-adapter.test.ts` that:
- Creates a mock caption region with `__soy = { node: <self> }` (circular reference) and `nodeType: 1` (DOM element)
- Enables caption capture (`captureCaptions: true`) and in-call state
- Calls `meetStatusScript` in a sandboxed VM context
- Verifies `JSON.parse(result)` succeeds, `inCall` is `true`, and `recentTranscript` entries have no `node` property

**Before the fix (test catches the bug):**
```
FAIL: TypeError: Converting circular structure to JSON
```

**After the fix:**
```
✓ serializes caption state without crashing on __soy circular references (#140455)
Test Files  1 passed (1)
Tests  6 passed (6)
```

### All existing tests pass

The existing 5 tests (caption capture, audio routing) continue to pass with no regression.
