### PR TITLE
fix: workspace sync changes LF files when Git autocrlf is enabled

### DIFF
--- a/src/gateway/worker-environments/workspace-reconcile-publication.test.ts
+++ b/src/gateway/worker-environments/workspace-reconcile-publication.test.ts
@@ -33,73 +33,93 @@ vi.mock("../../logging/subsystem.js", async (importOriginal) => {
 });
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-afterEach(() => workspaceWarning.mockReset());
+afterEach(() => {
+  workspaceWarning.mockReset();
+  vi.unstubAllEnvs();
+});
 
 async function manifestFor(root: string) {
   return (await readActualWorkspaceManifest({ root, baseCommit: null })).manifest;
 }
 
 describe("worker workspace reconciliation publication", () => {
-  it("keeps local bytes and the journal pending when accepted publication is indeterminate", async () => {
-    const local = tempDirs.make("openclaw-workspace-indeterminate-publication-");
-    const staged = tempDirs.make("openclaw-workspace-indeterminate-publication-staged-");
-    await fs.writeFile(path.join(local, "result.txt"), "base\n");
-    const base = await manifestFor(local);
-    await Promise.all([
-      fs.writeFile(path.join(staged, "result.txt"), "worker\n"),
-      fs.writeFile(path.join(staged, "added.txt"), "added\n"),
-    ]);
-    const current = await manifestFor(staged);
-    let pending: WorkerWorkspaceReconciliationJournal | undefined;
-    const abort = vi.fn(() => {
-      pending = undefined;
-    });
-    const commit = vi.fn(() => {
-      pending = undefined;
-    });
-    const journal = {
-      load: () => pending,
-      begin: (value: WorkerWorkspaceReconciliationJournal) => {
-        pending = value;
-      },
-      commit,
-      abort,
-    };
-    const publicationFailure = new AcceptedWorkspacePublicationIndeterminateError(
-      "apply",
-      new Error("apply transport lost"),
-      new Error("settlement timed out"),
-    );
-
-    await expect(
-      applyStagedWorkerWorkspace({
-        root: local,
-        stagingRoot: staged,
-        baseManifestRef: `sha256:${"a".repeat(64)}`,
-        currentManifestRef: `sha256:${"b".repeat(64)}`,
-        base,
-        current,
-        journal,
-        publishAcceptedManifest: async () => {
-          throw publicationFailure;
+  it.each([
+    ["true", "\n"],
+    ["true", "\r\n"],
+    ["input", "\n"],
+    ["input", "\r\n"],
+    ["false", "\n"],
+    ["false", "\r\n"],
+  ])(
+    "keeps raw bytes and the pending journal with autocrlf=%s and EOL=%j",
+    async (autocrlf, eol) => {
+      vi.stubEnv("GIT_CONFIG_COUNT", "3");
+      vi.stubEnv("GIT_CONFIG_KEY_0", "core.autocrlf");
+      vi.stubEnv("GIT_CONFIG_VALUE_0", autocrlf);
+      vi.stubEnv("GIT_CONFIG_KEY_1", "core.eol");
+      vi.stubEnv("GIT_CONFIG_VALUE_1", "crlf");
+      vi.stubEnv("GIT_CONFIG_KEY_2", "core.safecrlf");
+      vi.stubEnv("GIT_CONFIG_VALUE_2", "true");
+      const local = tempDirs.make("openclaw-workspace-indeterminate-publication-");
+      const staged = tempDirs.make("openclaw-workspace-indeterminate-publication-staged-");
+      const baseBytes = Buffer.from(`base${eol}`);
+      const workerBytes = Buffer.from(`worker${eol}`);
+      const addedBytes = Buffer.from(`added${eol}`);
+      await fs.writeFile(path.join(local, "result.txt"), baseBytes);
+      const base = await manifestFor(local);
+      await Promise.all([
+        fs.writeFile(path.join(staged, "result.txt"), workerBytes),
+        fs.writeFile(path.join(staged, "added.txt"), addedBytes),
+      ]);
+      const current = await manifestFor(staged);
+      let pending: WorkerWorkspaceReconciliationJournal | undefined;
+      const abort = vi.fn(() => {
+        pending = undefined;
+      });
+      const commit = vi.fn(() => {
+        pending = undefined;
+      });
+      const journal = {
+        load: () => pending,
+        begin: (value: WorkerWorkspaceReconciliationJournal) => {
+          pending = value;
         },
-      }),
-    ).rejects.toBe(publicationFailure);
+        commit,
+        abort,
+      };
+      const publicationFailure = new AcceptedWorkspacePublicationIndeterminateError(
+        "apply",
+        new Error("apply transport lost"),
+        new Error("settlement timed out"),
+      );
 
-    expect(pending).toBeDefined();
-    expect(commit).not.toHaveBeenCalled();
-    expect(abort).not.toHaveBeenCalled();
-    await expect(fs.readFile(path.join(local, "result.txt"), "utf8")).resolves.toBe("worker\n");
-    await expect(fs.readFile(path.join(local, "added.txt"), "utf8")).resolves.toBe("added\n");
+      await expect(
+        applyStagedWorkerWorkspace({
+          root: local,
+          stagingRoot: staged,
+          baseManifestRef: `sha256:${"a".repeat(64)}`,
+          currentManifestRef: `sha256:${"b".repeat(64)}`,
+          base,
+          current,
+          journal,
+          publishAcceptedManifest: async () => {
+            throw publicationFailure;
+          },
+        }),
+      ).rejects.toBe(publicationFailure);
 
-    await recoverWorkerWorkspaceReconciliation({ root: local, journal: pending! });
-    await expect(fs.readFile(path.join(local, "result.txt"), "utf8")).resolves.toBe("base\n");
-    await expect(fs.access(path.join(local, "added.txt"))).rejects.toThrow();
-    expect(pending).toBeDefined();
-    journal.abort();
-    expect(pending).toBeUndefined();
-    expect(abort).toHaveBeenCalledOnce();
-  });
+      expect(pending).toBeDefined();
+      expect(commit).not.toHaveBeenCalled();
+      expect(abort).not.toHaveBeenCalled();
+      await expect(fs.readFile(path.join(local, "result.txt"))).resolves.toEqual(workerBytes);
+      await expect(fs.readFile(path.join(local, "added.txt"))).resolves.toEqual(addedBytes);
+
+      await recoverWorkerWorkspaceReconciliation({ root: local, journal: pending! });
+      await expect(fs.readFile(path.join(local, "result.txt"))).resolves.toEqual(baseBytes);
+      await expect(fs.access(path.join(local, "added.txt"))).rejects.toThrow();
+      expect(pending).toBeDefined();
+    },
+  );
 
   it("rolls local bytes back immediately when accepted publication fails definitively", async () => {
     const local = tempDirs.make("openclaw-workspace-definitive-publication-failure-");

--- a/src/gateway/worker-environments/workspace-reconcile-recovery.ts
+++ b/src/gateway/worker-environments/workspace-reconcile-recovery.ts
@@ -245,7 +245,8 @@ export async function applyWorkspacePatch(params: {
     return;
   }
   // Run no-index with discovery disabled so workspace .gitattributes and
-  // repository filter config cannot reinterpret authenticated patch bytes.
+  // repository filters cannot reinterpret authenticated bytes. Disable inherited
+  // autocrlf too: no-index still runs Git's working-tree newline conversion.
   const temporary = await fs.mkdtemp(
     path.join(resolvePreferredOpenClawTmpDir(), "openclaw-no-git-"),
   );
@@ -253,6 +254,8 @@ export async function applyWorkspacePatch(params: {
     await requireGit(
       params.root,
       [
+        "-c",
+        "core.autocrlf=false",
         "apply",
         "--no-index",
         "--binary",


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/132180 — first independent replacement from the node-session completion series. The original remains open until the remaining parts are landed or otherwise accounted for.

## What Problem This Solves

Fixes an issue where users synchronizing worker workspace results would receive LF files rewritten as CRLF when inherited Git configuration enables `core.autocrlf`. That changes the worker's bytes even though workspace reconciliation is meant to preserve them exactly.

## Why This Change Was Made

Disable newline conversion only for the shared Git patch-application command used by forward sync and recovery. `--no-index` plus disabled repository discovery already excludes repository attributes and filters, but does not prevent inherited Git newline conversion.

This two-file slice preserves conflict handling, publication outcomes, journal representation, bounds, and user/global Git configuration. It does not include node approval/publication, process lifetime, finalization batching, or other work from the original PR.

## User Impact

LF and CRLF content now retain their exact bytes through workspace application and journal recovery, regardless of inherited `core.autocrlf=true`, `input`, or `false`. No new configuration, schema, public protocol, or enablement step is introduced.

## Evidence

- **Failing before the fix:** against current-main production at `ae2f990dccb7ef7cfd289fd117afc728cc6d078a`, the six-row real-Git matrix failed for `autocrlf=true` with LF: the observed `worker\n` bytes gained a carriage return. The other five rows passed. This was a test-only patch before the production change.
- **Passing after the fix:** all 10 tests in `workspace-reconcile-publication.test.ts` passed, including LF/CRLF application and recovery, definitive/indeterminate publication failures, and current-main scratch-cleanup behavior.
- **Commands:** `node scripts/run-vitest.mjs src/gateway/worker-environments/workspace-reconcile-publication.test.ts -t 'raw bytes'` before the production fix; then the same file without a filter. `node scripts/check-changed.mjs -- src/gateway/worker-environments/workspace-reconcile-recovery.ts src/gateway/worker-environments/workspace-reconcile-publication.test.ts` passed.
- **Git contract:** `GIT_CONFIG_COUNT` settings override configuration files but are themselves overridden by command-local `git -c` options. The regression exercises the actual Git process rather than mocking its conversion.
- **Independent review:** fresh isolated Codex review passed with no accepted/actionable P0 findings. This review covered only this two-file split, not the original monolithic PR.

Production LOC: +4/−1 (net +3). Tests: +78/−58. The production growth is the necessary command-local override and a comment explaining why `--no-index` alone was insufficient. The existing indeterminate-publication test became the six-row matrix; no test-only production seam was added.

Provenance: the current patch-application module's affected lines are blamed to [the workspace-divergence repair, #111244](https://github.com/openclaw/openclaw/pull/111244), authored and merged by @steipete on July 19, 2026 ([commit](https://github.com/openclaw/openclaw/commit/8631832048cfd5f08f33e1899a373914e515c579)). The same omission is present in stable tag `v2026.9.2`. This identifies the current module's provenance, not an independently established earlier introduction date.
