### PR TITLE
refactor(gateway): share plugin approval request delivery

### DIFF
--- a/src/gateway/node-invoke-plugin-approval.ts
+++ b/src/gateway/node-invoke-plugin-approval.ts
@@ -18,12 +18,8 @@ import {
   type NodeInvokePlacementGrantAuthorization,
 } from "./node-invoke-placement-grant.js";
 import type { NodeSession } from "./node-registry.js";
-import { runApprovalRequestDeliveries } from "./server-methods/approval-request-delivery.js";
-import {
-  bindApprovalRequesterMetadata,
-  buildRequestedApprovalEvent,
-  handlePendingApprovalRequest,
-} from "./server-methods/approval-shared.js";
+import { bindApprovalRequesterMetadata } from "./server-methods/approval-shared.js";
+import { handlePendingPluginApprovalRequest } from "./server-methods/plugin-approval-request-delivery.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./server-methods/types.js";
 
 function sanitizeOptionalMeta(value?: string | null): string | null {
@@ -153,8 +149,8 @@ export function createPluginNodeInvokeApprovalRuntime(params: {
       const { allowedDecisions, binding: placementGrant } = placementGrantResolution;
       const request: PluginApprovalRequestPayload = {
         pluginId: params.pluginId,
-        // The record feeds the same broadcast, forwarder, and push paths as
-        // RPC ingress. Normalize before escaping so empty prompts fail closed.
+        // Internal node prompts truncate; RPC ingress rejects oversized prompts.
+        // Normalize before escaping so empty prompts still fail closed.
         title: truncateUtf16Safe(
           sanitizeExecApprovalDisplayText(normalizeOptionalString(input.title) ?? ""),
           80,
@@ -201,45 +197,17 @@ export function createPluginNodeInvokeApprovalRuntime(params: {
       bindApprovalRequesterMetadata({ record, client: params.client });
       const respond: RespondFn = () => {};
       const decisionPromise = manager.register(record, timeoutMs);
-      const requestEvent = buildRequestedApprovalEvent(record, "plugin");
-      const forwardRequest = params.context.forwardPluginApprovalRequest;
-      const iosPushRequest = params.context.pluginApprovalIosPushDelivery?.handleRequested?.bind(
-        params.context.pluginApprovalIosPushDelivery,
-      );
-      await handlePendingApprovalRequest({
+      await handlePendingPluginApprovalRequest({
         manager,
         record,
         respond,
         context: params.context,
         // The carried connection is turn provenance, not the presenter. Keep
         // a sole-reviewer operator eligible for this internally minted prompt.
-        requestEventName: "plugin.approval.requested",
-        requestEvent,
         twoPhase: false,
-        approvalKind: "plugin",
-        deliverRequest: () =>
-          runApprovalRequestDeliveries({
-            context: params.context,
-            record,
-            forward: forwardRequest
-              ? [
-                  () => forwardRequest(requestEvent),
-                  "plugin approvals: forward node policy request failed",
-                ]
-              : undefined,
-            iosPush: iosPushRequest
-              ? [
-                  (isTargetVisible) => iosPushRequest(requestEvent, { isTargetVisible }),
-                  "plugin approvals: iOS push node policy request failed",
-                ]
-              : undefined,
-          }),
-        afterDecision: async (decision) => {
-          if (decision === null) {
-            await params.context.pluginApprovalIosPushDelivery?.handleExpired?.(requestEvent);
-          }
-        },
-        afterDecisionErrorLabel: "plugin approvals: iOS push node policy expire failed",
+        forwardRequest: params.context.forwardPluginApprovalRequest,
+        getIosPushDelivery: () => params.context.pluginApprovalIosPushDelivery,
+        source: "node-policy",
       });
       let decision = manager.projectDecisionIfActive(record.id, await decisionPromise);
       if (!params.isCurrent()) {

--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -851,7 +851,7 @@ describe("applyPluginNodeInvokePolicy", () => {
     await expectApprovalResolution(resultPromise, manager, record);
   });
 
-  it("sends an iOS cleanup wake when a plugin policy approval expires", async (testContext) => {
+  it("sends an iOS cleanup wake through the current delivery owner", async (testContext) => {
     const manager = createTestApprovalManager<PluginApprovalRequestPayload>(testContext, {
       approvalKind: "plugin",
     });
@@ -869,13 +869,17 @@ describe("applyPluginNodeInvokePolicy", () => {
 
     const resultPromise = invokeDemoPolicy(context, createOperatorClient());
     const record = await expectSinglePendingApproval(manager);
+    const replacementExpired = vi.fn(async () => {});
+    context.pluginApprovalIosPushDelivery = { handleExpired: replacementExpired };
     manager.expire(record.id, "timeout");
 
     await expect(resultPromise).resolves.toStrictEqual({
       ok: true,
       payload: { id: record.id, decision: null },
     });
-    expect(handleExpired).toHaveBeenCalledWith(expect.objectContaining({ id: record.id }));
+    expect(handleExpired).not.toHaveBeenCalled();
+    expect(replacementExpired).toHaveBeenCalledWith(expect.objectContaining({ id: record.id }));
+    expect(replacementExpired.mock.contexts).toEqual([context.pluginApprovalIosPushDelivery]);
   });
 
   it("ignores approval routes from unsigned node.invoke clients", async (testContext) => {

--- a/src/gateway/server-methods/plugin-approval-request-delivery.ts
+++ b/src/gateway/server-methods/plugin-approval-request-delivery.ts
@@ -1,0 +1,53 @@
+import type { PluginApprovalRequestPayload } from "../../infra/plugin-approvals.js";
+import { runApprovalRequestDeliveries } from "./approval-request-delivery.js";
+import { buildRequestedApprovalEvent, handlePendingApprovalRequest } from "./approval-shared.js";
+import type { GatewayRequestContext } from "./types.js";
+
+type PendingPluginApproval = Pick<
+  Parameters<typeof handlePendingApprovalRequest<PluginApprovalRequestPayload>>[0],
+  "manager" | "record" | "respond" | "context" | "clientConnId" | "twoPhase"
+>;
+
+export function handlePendingPluginApprovalRequest(
+  params: PendingPluginApproval & {
+    forwardRequest: GatewayRequestContext["forwardPluginApprovalRequest"];
+    getIosPushDelivery: () => GatewayRequestContext["pluginApprovalIosPushDelivery"];
+    source: "rpc" | "node-policy";
+  },
+): Promise<void> {
+  const { forwardRequest, getIosPushDelivery, source, ...pending } = params;
+  const requestEvent = buildRequestedApprovalEvent(pending.record, "plugin");
+  const iosPushDelivery = getIosPushDelivery();
+  const iosPushRequest = iosPushDelivery?.handleRequested?.bind(iosPushDelivery);
+  const logContext = source === "node-policy" ? "node policy " : "";
+  return handlePendingApprovalRequest({
+    ...pending,
+    requestEventName: "plugin.approval.requested",
+    requestEvent,
+    approvalKind: "plugin",
+    deliverRequest: () =>
+      runApprovalRequestDeliveries({
+        context: pending.context,
+        record: pending.record,
+        forward: forwardRequest
+          ? [
+              () => forwardRequest(requestEvent),
+              `plugin approvals: forward ${logContext}request failed`,
+            ]
+          : undefined,
+        iosPush: iosPushRequest
+          ? [
+              (isTargetVisible) => iosPushRequest(requestEvent, { isTargetVisible }),
+              `plugin approvals: iOS push ${logContext}request failed`,
+            ]
+          : undefined,
+      }),
+    afterDecision: async (decision) => {
+      if (decision === null) {
+        // Expiration uses the current delivery owner after the approval wait.
+        await getIosPushDelivery()?.handleExpired?.(requestEvent);
+      }
+    },
+    afterDecisionErrorLabel: `plugin approvals: iOS push ${logContext}expire failed`,
+  });
+}

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -396,8 +396,9 @@ describe("createPluginApprovalHandlers", () => {
 
     it("delivers requests to iOS push with the exec-equivalent visibility gate", async () => {
       const handleRequested = vi.fn(async () => true);
+      const iosPushDelivery = { handleRequested };
       const handlers = createPluginApprovalHandlers(manager, {
-        iosPushDelivery: { handleRequested },
+        iosPushDelivery,
       });
       const respond = vi.fn();
       const opts = createMockOptions(
@@ -425,6 +426,7 @@ describe("createPluginApprovalHandlers", () => {
       const approvalId = await waitForAcceptedApproval(respond);
 
       expect(handleRequested).toHaveBeenCalledTimes(1);
+      expect(handleRequested.mock.contexts).toEqual([iosPushDelivery]);
       const requestCall = mockCall(handleRequested, 0, "iOS request delivery");
       expect(requireRecord(requestCall[0], "iOS request").id).toBe(approvalId);
       const deliveryOptions = requireRecord(requestCall[1], "iOS delivery options");

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -17,7 +17,6 @@ import {
 import { takeMcpToolApprovalBinding } from "../../infra/mcp-tool-approval-binding.js";
 import { resolveCanonicalPluginApprovalRequestAllowedDecisions } from "../../infra/plugin-approval-canonical-decisions.js";
 import type {
-  PluginApprovalRequest,
   PluginApprovalRequestPayload,
   PluginApprovalResolved,
 } from "../../infra/plugin-approvals.js";
@@ -30,30 +29,23 @@ import {
 import type { ExecApprovalManager } from "../exec-approval-manager.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { resolveStoredSessionKeyForAgentStore } from "../session-store-key.js";
-import { runApprovalRequestDeliveries } from "./approval-request-delivery.js";
 import {
   bindApprovalRequesterMetadata,
   bindApprovalReviewerDeviceIds,
-  buildRequestedApprovalEvent,
   handleApprovalResolve,
   handleApprovalWaitDecision,
-  handlePendingApprovalRequest,
   listVisiblePendingApprovalRequests,
   registerPendingApprovalRecord,
   resolveApprovalDecisionParams,
 } from "./approval-shared.js";
-import type { GatewayRequestHandlers } from "./types.js";
+import { handlePendingPluginApprovalRequest } from "./plugin-approval-request-delivery.js";
+import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
-type PluginApprovalIosPushDelivery = {
-  handleRequested?: (
-    request: PluginApprovalRequest,
-    opts?: {
-      isTargetVisible?: (target: { deviceId: string; scopes: readonly string[] }) => boolean;
-    },
-  ) => Promise<boolean>;
+type PluginApprovalIosPushDelivery = NonNullable<
+  GatewayRequestContext["pluginApprovalIosPushDelivery"]
+> & {
   handleResolved?: (resolved: PluginApprovalResolved) => Promise<void>;
-  handleExpired?: (request: PluginApprovalRequest) => Promise<void>;
 };
 
 /** Create plugin approval handlers backed by the shared approval manager. */
@@ -267,40 +259,16 @@ export function createPluginApprovalHandlers(
         return;
       }
 
-      const requestEvent = buildRequestedApprovalEvent(record, "plugin");
-      const forwardRequest = opts?.forwarder?.handlePluginApprovalRequested?.bind(opts.forwarder);
-      const iosPushRequest = opts?.iosPushDelivery?.handleRequested?.bind(opts.iosPushDelivery);
-
-      await handlePendingApprovalRequest({
+      await handlePendingPluginApprovalRequest({
         manager,
         record,
         respond,
         context,
         clientConnId: client?.connId,
-        requestEventName: "plugin.approval.requested",
-        requestEvent,
         twoPhase,
-        approvalKind: "plugin",
-        deliverRequest: () =>
-          runApprovalRequestDeliveries({
-            context,
-            record,
-            forward: forwardRequest
-              ? [() => forwardRequest(requestEvent), "plugin approvals: forward request failed"]
-              : undefined,
-            iosPush: iosPushRequest
-              ? [
-                  (isTargetVisible) => iosPushRequest(requestEvent, { isTargetVisible }),
-                  "plugin approvals: iOS push request failed",
-                ]
-              : undefined,
-          }),
-        afterDecision: async (decision) => {
-          if (decision === null) {
-            await opts?.iosPushDelivery?.handleExpired?.(requestEvent);
-          }
-        },
-        afterDecisionErrorLabel: "plugin approvals: iOS push expire failed",
+        forwardRequest: opts?.forwarder?.handlePluginApprovalRequested?.bind(opts.forwarder),
+        getIosPushDelivery: () => opts?.iosPushDelivery,
+        source: "rpc",
       });
     },
 


### PR DESCRIPTION
## What Problem This Solves

RPC and internal node-policy plugin approvals duplicated requested-event construction, external delivery wiring, and expiry cleanup. That duplication made it easier for the two approval paths to drift in visibility and lifecycle behavior.

## Why This Change Was Made

One plugin-specific delivery helper beside the shared approval lifecycle composes the existing requested-event, first-success forwarding/push delivery, and expiration handling. Callers retain registration, requester binding, prompt normalization, RPC presenter exclusion and two-phase behavior, and node authority/consumption checks.

Request delivery stays bound to its captured iOS receiver; expiration looks up the current delivery owner after the wait. Existing log labels and event ordering are preserved. Production -11 lines; tests +6. No SDK entrypoint, export, budget, config, protocol, or store semantics change.

## User Impact

No intended behavior change. RPC and internally minted approvals preserve their distinct presentation and authorization contracts while sharing delivery assembly.

## Evidence

- Rebased onto main `5520a73e9115be31d5f710da23e9bd93ecff291f`, including worker-transfer repair #140771 and Telegram test-size repair #141148. Reviewed head: `b7629890460cc3df7d1d62441891bb8aefbff29b`. All five changed source/test files are byte-identical to the earlier reviewed head.
- Source inspection verified unchanged node post-wait projection, current-authority check, allow-once consumption, reprojection and placement-grant retention. Existing independent inspection also verified receiver binding, visibility filtering, event order and current-owner expiry lookup.
- `node scripts/run-vitest.mjs src/gateway/server-methods/plugin-approval src/gateway/node-invoke-plugin-policy src/gateway/server-methods/approval-request-delivery src/gateway/server-methods/approval-shared`: all 161 tests in nine files passed, in 38.24s.
- Fresh independent Codex branch autoreview is clean through P2.
- `node scripts/check-changed.mjs` passed fully, including typechecks, lint, dead-export scans, state/storage/auth guards and zero runtime import cycles. Exact-head CI https://github.com/openclaw/openclaw/actions/runs/34125650164 passed on attempt 1. Native preparation accepted the evidence without changing the head; native merge landed as `7cabf654ef59339b9dd3cf9a7993a9cb26725d0d`, verified ancestor of fetched main. No test retry was needed.
- Prior `pnpm build` passed in 6m44.2s, including 91 plugins and public declarations. The rebase preserves all changed source/test bytes.

The previous required CI failures were outside this PR: the Telegram test-size violation is fixed on the current base, and CLI finalization validation timeouts are the maintainer-identified compact-shard flake class. The maintainer authorized a fresh attempt and one failed-job retry for an unrelated test flake, with separate ten-minute retries for infrastructure startup failures. No baseline, timeout, assertion or required check is weakened.
