### PR TITLE
improve(ui): render chat avatars as circles to match the sidebar and native apps

### DIFF
--- a/ui/src/styles/chat/composer.css
+++ b/ui/src/styles/chat/composer.css
@@ -4357,7 +4357,7 @@
 .agent-chat__avatar--text {
   width: 80px;
   height: 80px;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-full);
   background: var(--secondary);
   border: 1px solid var(--border);
   color: var(--text);

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -621,11 +621,12 @@
   color: inherit;
 }
 
-/* Avatar Styles */
+/* Avatar Styles. Identity avatars are circles everywhere (sidebar, pickers,
+   profile, native apps); square tiles expose opaque avatar corners. */
 .chat-avatar {
   width: 36px;
   height: 36px;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-full);
   background: var(--panel-strong);
   display: grid;
   place-items: center;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1555,7 +1555,6 @@ openclaw-chat-video-player {
   width: 36px;
   height: 36px;
   border: 0;
-  border-radius: 50%;
   box-shadow: none;
   margin-bottom: 0;
 }
@@ -1568,7 +1567,6 @@ openclaw-chat-video-player {
 
 .agent-chat__typing-avatars > :is(.chat-avatar, .chat-avatar-slot) {
   box-shadow: 0 0 0 2px var(--bg);
-  border-radius: 50%;
 }
 
 @media (max-width: 640px) {

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -202,11 +202,6 @@ html.openclaw-native-macos .new-session-page__incognito-rail {
   border-style: dashed;
 }
 
-/* Image and emoji fallbacks carry the same welcome-avatar silhouette. */
-.new-session-page .agent-chat__avatar--text {
-  border-radius: 50%;
-}
-
 @media (prefers-reduced-motion: reduce) {
   .new-session-page__incognito-notice {
     transition-duration: 0ms;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing a chat transcript would see agent and user avatars as rounded squares while every other identity surface (sidebar agent card, agent pickers, profile, settings, presence facepile, hovercards, the chat welcome image, the typing indicator, and the iOS, macOS, and Android apps) shows a circle. With an avatar image whose corners are opaque, the transcript tile exposed those corners as a white frame that the circular sidebar avatar clipped away, so the same avatar looked broken in one place and fine in the next.

## Why This Change Was Made

A survey of the Control UI stylesheets and the native apps showed one identity shape everywhere except two chat tiles: the transcript `.chat-avatar` and the chat empty-state text avatar, and both already carried circle overrides bolted on elsewhere (the typing indicator re-rounded `.chat-avatar` to 50%, and the New Session page forced the text avatar to 50%). This change moves both tiles to the shared `--radius-full` token and deletes the now-redundant overrides. Session-kind glyph tiles (`.session-avatar`) are not identity avatars and keep their rounded square. No markup, sizing, or loading behavior changes.

## User Impact

Transcript avatars (assistant, user, forwarded, initials, and glyph fallbacks) and the chat empty-state emoji avatar now render as circles, matching the sidebar and the native apps. Avatar images with opaque corners no longer show a square frame in the transcript.

## Evidence

Mocked Control UI (Vitest E2E harness, dark scheme), same fixture avatar and emoji identity before and after; a throwaway driver asserted the computed `border-radius` of `img.chat-avatar.assistant` and `.agent-chat__avatar--text` is `9999px` after the change. Fixtures are synthetic (Molty, Riley, generated emblem).

![Before and after: transcript avatars unified on the sidebar circle](https://github.com/user-attachments/assets/b0b16517-4c41-4d6e-ac0a-2a03657d259f)

Net CSS: +4 / -10 lines across four stylesheets.

Known gap: `checks-ui-e2e (5/7)` can fail on the Skill Workshop 700-line/390px blank-row height assertion added by #140300. It is unrelated to this change, reproduces on plain `origin/main`, and is tracked in #140687.
