### PR TITLE
refactor(chat): share session placeholder construction

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
@@ -619,35 +619,12 @@ public enum ChatSessionSidebarModel {
         {
             // Sessions can lag behind a fresh switch/new-session; keep the
             // active row selectable instead of showing an empty selection.
-            entries.append(self.placeholder(key: currentSessionKey))
+            entries.append(OpenClawChatSessionEntry.placeholder(key: currentSessionKey))
         }
         // Gateway, cached lists, iOS, and macOS must share the same pin
         // chronology, stable key ties, and searchable session fields.
         return OpenClawChatSessionListOrganizer.filter(
             OpenClawChatSessionListOrganizer.organize(entries),
             search: query)
-    }
-
-    private static func placeholder(key: String) -> OpenClawChatSessionEntry {
-        OpenClawChatSessionEntry(
-            key: key,
-            kind: nil,
-            displayName: nil,
-            surface: nil,
-            subject: nil,
-            room: nil,
-            space: nil,
-            updatedAt: nil,
-            sessionId: nil,
-            systemSent: nil,
-            abortedLastRun: nil,
-            thinkingLevel: nil,
-            verboseLevel: nil,
-            inputTokens: nil,
-            outputTokens: nil,
-            totalTokens: nil,
-            modelProvider: nil,
-            model: nil,
-            contextTokens: nil)
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
@@ -698,6 +698,29 @@ public struct OpenClawChatSessionEntry: Codable, Identifiable, Sendable, Hashabl
         self.thinkingDefault = thinkingDefault
     }
 
+    static func placeholder(key: String) -> OpenClawChatSessionEntry {
+        OpenClawChatSessionEntry(
+            key: key,
+            kind: nil,
+            displayName: nil,
+            surface: nil,
+            subject: nil,
+            room: nil,
+            space: nil,
+            updatedAt: nil,
+            sessionId: nil,
+            systemSent: nil,
+            abortedLastRun: nil,
+            thinkingLevel: nil,
+            verboseLevel: nil,
+            inputTokens: nil,
+            outputTokens: nil,
+            totalTokens: nil,
+            modelProvider: nil,
+            model: nil,
+            contextTokens: nil)
+    }
+
     public var isPinned: Bool {
         self.pinned == true
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
@@ -294,7 +294,7 @@ extension OpenClawChatViewModel {
         syncSelection: Bool)
     {
         let existingIndex = self.sessionIndexForModelState(sessionKey: sessionKey)
-        var updated = existingIndex.map { self.sessions[$0] } ?? self.placeholderSession(key: sessionKey)
+        var updated = existingIndex.map { self.sessions[$0] } ?? OpenClawChatSessionEntry.placeholder(key: sessionKey)
         // Thinking metadata follows model identity; stale options must not survive a model change.
         let preservesThinkingMetadata =
             Self.normalizedModelIdentityComponent(updated.model) ==
@@ -338,29 +338,6 @@ extension OpenClawChatViewModel {
         return "\(provider)/\(modelID)"
     }
 
-    func placeholderSession(key: String) -> OpenClawChatSessionEntry {
-        OpenClawChatSessionEntry(
-            key: key,
-            kind: nil,
-            displayName: nil,
-            surface: nil,
-            subject: nil,
-            room: nil,
-            space: nil,
-            updatedAt: nil,
-            sessionId: nil,
-            systemSent: nil,
-            abortedLastRun: nil,
-            thinkingLevel: nil,
-            verboseLevel: nil,
-            inputTokens: nil,
-            outputTokens: nil,
-            totalTokens: nil,
-            modelProvider: nil,
-            model: nil,
-            contextTokens: nil)
-    }
-
     public var sessionChoices: [OpenClawChatSessionEntry] {
         let now = Date().timeIntervalSince1970 * 1000
         let cutoff = now - (24 * 60 * 60 * 1000)
@@ -375,7 +352,7 @@ extension OpenClawChatViewModel {
             result.append(main)
             included.insert(main.key)
         } else {
-            result.append(self.placeholderSession(key: mainSessionKey))
+            result.append(OpenClawChatSessionEntry.placeholder(key: mainSessionKey))
             included.insert(mainSessionKey)
         }
 
@@ -393,7 +370,7 @@ extension OpenClawChatViewModel {
             if let current = sorted.first(where: { $0.key == self.sessionKey }) {
                 result.append(current)
             } else {
-                result.append(self.placeholderSession(key: sessionKey))
+                result.append(OpenClawChatSessionEntry.placeholder(key: sessionKey))
             }
         }
 


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested deduplication: the Apple session sidebar and chat view model independently construct the same empty session row. Keeping two copies creates avoidable drift when session metadata evolves.

## Why This Change Was Made

Move the unchanged constructor into an internal `OpenClawChatSessionEntry.placeholder(key:)` factory and use it at the four existing call sites. No public API, initializer defaults, routing, persistence, or archive policy changes.

## User Impact

No user-visible behavior change. Session keys, empty metadata, lazy fallback, row ordering, and model-update behavior remain unchanged.

## Evidence

- Native `OpenClawChatUI` target build and test-bundle build passed with Swift 6.3.3.
- All 56 intended existing native tests passed using SwiftPM's prebuilt test helper inside an OS sandbox. The original qualified filter missed seven cases; those exact session-choice/model cases were run separately. Local `swift test` planning hit sandbox cache restrictions, so execution used the same compiled bundle directly.
- Disposable native baseline/current probe: all 20 cases match byte-for-byte across missing-main, missing-current, sidebar, missing-row model update, and existing-row model update; covers empty, whitespace, mixed-case, and agent-qualified keys.
- SwiftFormat 0.63.0, iOS SwiftLint 0.65.1 (407 files, zero violations), and `git diff --check` passed.
- Independent review is clean through P2; the completed exact-head ClawSweeper review has no actionable findings.
- Supplemental Linux Testbox passed at commit `449def6df3c229be546836386cf47143589e1472`: 620 tests passed, 505 platform-specific tests skipped, and all selected portable guards passed. SwiftLint was explicitly skipped on Linux. Lease `tbx_01m1wx4e3q1rk2kxa0ket9ygqy` was stopped after success and confirmed absent. [Testbox Actions run](https://github.com/openclaw/openclaw/actions/runs/34078329342). The delegated wrapper reports exit 0; its Actions run can show cancellation during normal lease cleanup.
- Local `node scripts/check-changed.mjs -- <three changed paths>` passed, including selected macOS tooling tests and the native state schema guard.
- [CI for exact PR head `449def6df3c229be546836386cf47143589e1472`](https://github.com/openclaw/openclaw/actions/runs/34078319276) passed, including required `openclaw/ci-gate`. Hosted macOS logs confirm 1,673 OpenClawKit tests and 2,079 macOS app tests passed, with the intended sidebar/session/model cases executed. The iOS consumer build reports `BUILD SUCCEEDED`. Normal PR CI tested merge-ref `cc719fcfc5f6066927dec4ba4af4cb4aa351f41d`, combining this exact head with main `8005f439db703e03888fcaca220b140c57a0817b`.
- Six nearby open PRs were checked against their live heads and diffs; none changes either factory or provides an equivalent extraction.

The local SwiftPM planning restriction described above was handled by executing the prebuilt native test bundle; hosted package tests also passed. Testbox's optional runner-portal summary sync timed out after successful execution and confirmed lease cleanup. Linux results are supplemental, not Apple proof.
