### PR TITLE
refactor(claws): use canonical config cleanup in removal tests

### DIFF
--- a/src/claws/bootstrap.test.ts
+++ b/src/claws/bootstrap.test.ts
@@ -4,8 +4,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../agents/workspace-bootstrap-read.js";
 import { readWorkspaceStateSnapshot } from "../agents/workspace-state-store.js";
+import { withTempHomeConfig } from "../config/test-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { setTestEnvValue } from "../test-utils/env.js";
 import { applyClawAddPlan } from "./add.js";
 import { seedClawPackageBootstrap } from "./bootstrap.js";
 import { quiescentClawMonitorGateway } from "./lifecycle-remove.test-support.js";
@@ -380,16 +382,17 @@ describe("package-root BOOTSTRAP.md", () => {
       }),
     );
 
-    const removed = await applyClawRemovePlan(removePlan, {
-      monitorGateway: quiescentClawMonitorGateway,
-      env,
-      config: {},
-      consentPlanIntegrity: removePlan.planIntegrity,
-      commitConfig: async (transform) => {
-        transform({});
-      },
-      purgeSessions: async () => undefined,
-      trashPath: async () => true,
+    const removed = await withTempHomeConfig({}, async ({ configPath }) => {
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      setTestEnvValue("OPENCLAW_STATE_DIR", env.OPENCLAW_STATE_DIR);
+      return applyClawRemovePlan(removePlan, {
+        monitorGateway: quiescentClawMonitorGateway,
+        env,
+        config: {},
+        consentPlanIntegrity: removePlan.planIntegrity,
+        purgeSessions: async () => undefined,
+        trashPath: async () => true,
+      });
     });
 
     expect(removed).toMatchObject({
@@ -476,16 +479,17 @@ describe("package-root BOOTSTRAP.md", () => {
     expect(removePlan.actions).toContainEqual(
       expect.objectContaining({ kind: "workspace", action: "trash" }),
     );
-    const removed = await applyClawRemovePlan(removePlan, {
-      monitorGateway: quiescentClawMonitorGateway,
-      env,
-      config,
-      consentPlanIntegrity: removePlan.planIntegrity,
-      commitConfig: async (transform) => {
-        config = transform(config);
-      },
-      purgeSessions: async () => undefined,
-      trashPath: async () => true,
+    const removed = await withTempHomeConfig(config, async ({ configPath }) => {
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      setTestEnvValue("OPENCLAW_STATE_DIR", env.OPENCLAW_STATE_DIR);
+      return applyClawRemovePlan(removePlan, {
+        monitorGateway: quiescentClawMonitorGateway,
+        env,
+        config,
+        consentPlanIntegrity: removePlan.planIntegrity,
+        purgeSessions: async () => undefined,
+        trashPath: async () => true,
+      });
     });
 
     expect(removed).toMatchObject({
@@ -527,16 +531,17 @@ describe("package-root BOOTSTRAP.md", () => {
     expect(removePlan.actions).toContainEqual(
       expect.objectContaining({ kind: "bootstrap", action: "delete", blocked: false }),
     );
-    const removed = await applyClawRemovePlan(removePlan, {
-      monitorGateway: quiescentClawMonitorGateway,
-      env,
-      config,
-      consentPlanIntegrity: removePlan.planIntegrity,
-      commitConfig: async (transform) => {
-        config = transform(config);
-      },
-      purgeSessions: async () => undefined,
-      trashPath: async () => true,
+    const removed = await withTempHomeConfig(config, async ({ configPath }) => {
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      setTestEnvValue("OPENCLAW_STATE_DIR", env.OPENCLAW_STATE_DIR);
+      return applyClawRemovePlan(removePlan, {
+        monitorGateway: quiescentClawMonitorGateway,
+        env,
+        config,
+        consentPlanIntegrity: removePlan.planIntegrity,
+        purgeSessions: async () => undefined,
+        trashPath: async () => true,
+      });
     });
 
     expect(removed).toMatchObject({
@@ -577,16 +582,17 @@ describe("package-root BOOTSTRAP.md", () => {
     expect(removePlan.actions).toContainEqual(
       expect.objectContaining({ kind: "workspace", action: "retain" }),
     );
-    const removed = await applyClawRemovePlan(removePlan, {
-      monitorGateway: quiescentClawMonitorGateway,
-      env,
-      config,
-      consentPlanIntegrity: removePlan.planIntegrity,
-      commitConfig: async (transform) => {
-        config = transform(config);
-      },
-      purgeSessions: async () => undefined,
-      trashPath: async () => true,
+    const removed = await withTempHomeConfig(config, async ({ configPath }) => {
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      setTestEnvValue("OPENCLAW_STATE_DIR", env.OPENCLAW_STATE_DIR);
+      return applyClawRemovePlan(removePlan, {
+        monitorGateway: quiescentClawMonitorGateway,
+        env,
+        config,
+        consentPlanIntegrity: removePlan.planIntegrity,
+        purgeSessions: async () => undefined,
+        trashPath: async () => true,
+      });
     });
 
     expect(removed).toMatchObject({

--- a/src/claws/lifecycle-config-removal.ts
+++ b/src/claws/lifecycle-config-removal.ts
@@ -25,18 +25,12 @@ import {
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
 import { digestClawAgentConfig } from "./agent-config-digest.js";
-import {
-  deletionEffects,
-  type ClawCleanupTargets,
-  type ClawTrashPath,
-} from "./lifecycle-delete-support.js";
+import { deletionEffects, type ClawCleanupTargets } from "./lifecycle-delete-support.js";
 import {
   readClawInstallRecordFromDatabase,
   updateClawInstallRecordStatus,
   type PersistedClawInstall,
 } from "./provenance.js";
-
-export type ConfigCommit = (transform: (config: OpenClawConfig) => OpenClawConfig) => Promise<void>;
 
 type ClawAgentConfigRemovalParams = {
   agentId: string;
@@ -46,9 +40,7 @@ type ClawAgentConfigRemovalParams = {
   expectedState: "present" | "missing";
   fallbackWorkspace: string;
   config?: OpenClawConfig;
-  commitConfig?: ConfigCommit;
   stateDatabase?: OpenClawStateDatabaseOptions;
-  trashPath?: ClawTrashPath;
   onModified: () => Error;
   quiesceMonitors?: (operationId: string) => Promise<void>;
   drainMonitors?: (operationId: string) => Promise<void>;
@@ -56,7 +48,7 @@ type ClawAgentConfigRemovalParams = {
 
 type ClawAgentConfigRemovalResult = {
   agentRemoved: boolean;
-  cleanupTargets?: ClawCleanupTargets;
+  cleanupTargets: ClawCleanupTargets;
   configBeforeDelete: OpenClawConfig;
   nextConfig: OpenClawConfig;
 };
@@ -80,46 +72,6 @@ async function commitClawAgentConfigRemoval(
   params: ClawAgentConfigRemovalParams,
   assertCurrent: () => void,
 ): Promise<ClawAgentConfigRemovalResult> {
-  if (params.commitConfig) {
-    let result: ClawAgentConfigRemovalResult | undefined;
-    await params.commitConfig((config) => {
-      assertCurrent();
-      const effects = deletionEffects(
-        config,
-        params.agentId,
-        params.fallbackWorkspace,
-        params.stateDatabase?.env,
-      );
-      const agent = listAgentEntries(config).find((candidate) => candidate.id === params.agentId);
-      if (
-        (agent && digestClawAgentConfig(agent) !== params.expectedDigest) ||
-        digestClawAgentRemovalSurface(config, params.agentId) !==
-          params.expectedRemovalSurfaceDigest
-      ) {
-        throw params.onModified();
-      }
-      result = {
-        agentRemoved: Boolean(agent),
-        ...(params.trashPath
-          ? {
-              cleanupTargets: {
-                workspaceDir: effects.workspace,
-                agentDir: effects.agentDir,
-                sessionsDir: effects.sessionsDir,
-              },
-            }
-          : {}),
-        configBeforeDelete: config,
-        nextConfig: effects.pruned.config,
-      };
-      return effects.pruned.config;
-    });
-    if (!result) {
-      throw new Error("Claw config removal did not run its commit transform.");
-    }
-    return result;
-  }
-
   const configBeforeDelete = params.config ?? getRuntimeConfig();
   try {
     const committed = await deleteAgentConfigEntry({

--- a/src/claws/lifecycle-remove-approvals.test.ts
+++ b/src/claws/lifecycle-remove-approvals.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { once } from "node:events";
 import { rmSync, writeFileSync } from "node:fs";
-import { rm, stat } from "node:fs/promises";
+import { readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { stopChildProcess } from "../../test/helpers/stop-child-process.js";
@@ -49,7 +49,7 @@ import { parseClawManifest } from "./schema.js";
 import type { ClawSourceIdentity } from "./types.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR", "OPENCLAW_CONFIG_PATH"]);
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -290,9 +290,6 @@ describe("Claw exec approvals removal", () => {
         const removeOptions = {
           config,
           unsetMcpServer,
-          commitConfig: async (transform: (current: OpenClawConfig) => OpenClawConfig) => {
-            config = transform(config);
-          },
           trashPath,
         };
         await expect(
@@ -306,7 +303,9 @@ describe("Claw exec approvals removal", () => {
           agentRemoved: false,
           error: { message: expect.stringContaining("database is still open in another process") },
         });
-        expect(config).toEqual(configBefore);
+        expect(
+          JSON.parse(await readFile(join(home, ".openclaw", "openclaw.json"), "utf8")),
+        ).toEqual(configBefore);
         expect(loadExecApprovals()).toEqual(approvalsBefore);
         expect(readAgentProvenance("worker")).toEqual(provenanceBefore);
         expect(trashPath).not.toHaveBeenCalled();
@@ -403,8 +402,9 @@ describe("Claw exec approvals removal", () => {
         env,
         path: join(root, "relocated.sqlite"),
       });
-      let config: OpenClawConfig = {
+      const config: OpenClawConfig = {
         agents: {
+          defaults: { authInheritance: { agentId: "main" } },
           entries: {
             worker: { agentDir, workspace: join(root, "workspace") },
             ...(shared ? { kept: { workspace: root } } : {}),
@@ -412,6 +412,10 @@ describe("Claw exec approvals removal", () => {
         },
       };
       const originalConfig = structuredClone(config);
+      const configPath = join(root, "openclaw.json");
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      setTestEnvValue("OPENCLAW_STATE_DIR", env.OPENCLAW_STATE_DIR);
+      await writeFile(configPath, JSON.stringify(config));
       const agent = listAgentEntries(config)[0]!;
       const remove = () =>
         withClawAgentConfigRemoval(
@@ -423,9 +427,6 @@ describe("Claw exec approvals removal", () => {
             fallbackWorkspace: agent.workspace!,
             config,
             stateDatabase: { env },
-            commitConfig: async (transform) => {
-              config = transform(config);
-            },
             onModified: () => new Error("agent modified"),
           },
           (commitRemoval) => commitRemoval(),
@@ -435,7 +436,7 @@ describe("Claw exec approvals removal", () => {
           throw new Error("retained close failure");
         });
         await expect(remove()).rejects.toThrow("retained close failure");
-        expect(config).toEqual(originalConfig);
+        expect(JSON.parse(await readFile(configPath, "utf8"))).toEqual(originalConfig);
         expect(owned.db.isOpen).toBe(true);
         expect(readAgentDeletionJournal("worker", { env })).toBeUndefined();
       }
@@ -464,6 +465,7 @@ describe("Claw exec approvals removal", () => {
           consentPlanIntegrity: addPlan.planIntegrity,
           commitConfig,
         });
+        await writeOpenClawConfig(home, config);
         const sharedDir =
           kind === "workspace"
             ? addPlan.agent.workspace
@@ -501,7 +503,6 @@ describe("Claw exec approvals removal", () => {
           applyClawRemovePlan(plan, {
             monitorGateway: quiescentClawMonitorGateway,
             config,
-            commitConfig,
             trashPath,
             consentPlanIntegrity: plan.planIntegrity,
           }),
@@ -513,10 +514,9 @@ describe("Claw exec approvals removal", () => {
   );
 
   it.each([
-    { label: "config-file commit", commit: false, complete: true },
-    { label: "commitConfig seam", commit: true, complete: true },
-    { label: "partial cleanup", commit: false, complete: false },
-  ])("removes only the claw agent policy through the $label", async ({ commit, complete }) => {
+    { label: "complete cleanup", complete: true },
+    { label: "partial cleanup", complete: false },
+  ])("removes only the claw agent policy through $label", async ({ complete }) => {
     const addPlan = await buildApprovalFixture();
 
     await withTempHomeConfig({}, async ({ home }) => {
@@ -545,25 +545,12 @@ describe("Claw exec approvals removal", () => {
           },
         },
       });
-      const plan = commit
-        ? await buildClawRemovePlan("worker", { env, config })
-        : await buildClawRemovePlan("worker");
-      const common = {
+      const plan = await buildClawRemovePlan("worker");
+      const result = await applyClawRemovePlan(plan, {
         monitorGateway: quiescentClawMonitorGateway,
         consentPlanIntegrity: plan.planIntegrity,
         trashPath: async () => complete,
-      };
-
-      const result = commit
-        ? await applyClawRemovePlan(plan, {
-            ...common,
-            env,
-            config,
-            commitConfig: async (transform) => {
-              config = transform(config);
-            },
-          })
-        : await applyClawRemovePlan(plan, common);
+      });
 
       expect(result).toMatchObject({
         status: complete ? "complete" : "partial",
@@ -655,9 +642,6 @@ describe("Claw exec approvals removal", () => {
           consentPlanIntegrity: plan.planIntegrity,
           env,
           config,
-          commitConfig: async (transform) => {
-            config = transform(config);
-          },
           trashPath: async () => true,
         }),
       ).resolves.toMatchObject({
@@ -682,9 +666,15 @@ describe("Claw exec approvals removal", () => {
   it.each([
     { label: "keeps a pre-existing journal", seedJournal: true },
     { label: "rolls back the journal it opened", seedJournal: false },
-  ])("$label when the config commit fails", async ({ seedJournal }) => {
+  ])("$label when the config commit rejects a changed agent", async ({ seedJournal }) => {
     const root = tempDirs.make("openclaw-claw-remove-journal-");
     setTestEnvValue("OPENCLAW_STATE_DIR", join(root, "state"));
+    const config: OpenClawConfig = {
+      agents: { entries: { worker: { workspace: join(root, "workspace") } } },
+    };
+    const configPath = join(root, "openclaw.json");
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+    await writeFile(configPath, JSON.stringify(config));
     if (seedJournal) {
       beginAgentDeletion({
         agentId: "worker",
@@ -699,18 +689,16 @@ describe("Claw exec approvals removal", () => {
         {
           agentId: "worker",
           expectedDigest: "sha256:unused",
-          expectedRemovalSurfaceDigest: digestClawAgentRemovalSurface({}, "worker"),
+          expectedRemovalSurfaceDigest: digestClawAgentRemovalSurface(config, "worker"),
           expectedState: "present",
           fallbackWorkspace: join(root, "workspace"),
-          config: {},
-          commitConfig: async () => {
-            throw new Error("claw commit failed");
-          },
+          config,
           onModified: () => new Error("claw agent modified"),
         },
         (commitRemoval) => commitRemoval(),
       ),
-    ).rejects.toThrow("claw commit failed");
+    ).rejects.toThrow("claw agent modified");
+    expect(JSON.parse(await readFile(configPath, "utf8"))).toEqual(config);
 
     expect(readAgentDeletionJournal("worker") === undefined).toBe(!seedJournal);
   });

--- a/src/claws/lifecycle-remove-contract.ts
+++ b/src/claws/lifecycle-remove-contract.ts
@@ -4,7 +4,6 @@ import type { purgeAgentSessionStoreEntries } from "../config/sessions/cleanup-s
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import type { ClawCronGateway } from "./cron.js";
-import type { ConfigCommit } from "./lifecycle-config-removal.js";
 import type { ClawTrashPath, RemovedWorkspaceFile } from "./lifecycle-delete-support.js";
 import type { ClawMonitorCleanupGateway } from "./monitor-cleanup-contract.js";
 import type {
@@ -75,7 +74,6 @@ export type ClawRemovePlanOptions = OpenClawStateDatabaseOptions & {
 };
 
 export type ClawRemoveApplyOptions = ClawRemovePlanOptions & {
-  commitConfig?: ConfigCommit;
   purgeSessions?: (
     ...args: Parameters<typeof purgeAgentSessionStoreEntries>
   ) => Promise<boolean | void>;

--- a/src/claws/lifecycle-remove-ownership.test.ts
+++ b/src/claws/lifecycle-remove-ownership.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { readSourceConfigBestEffort, resetConfigRuntimeState } from "../config/config.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
 import { listOpenClawRegisteredAgentDatabases } from "../state/openclaw-agent-db-registry.js";
 import {
@@ -30,10 +30,7 @@ afterEach(async () => {
 async function fixture(withFile = false) {
   const state = await createOpenClawTestState({ prefix: "claw-removal-owner-" });
   cleanups.push(() => state.cleanup());
-  let config: OpenClawConfig = {};
-  const commitConfig = async (transform: (current: OpenClawConfig) => OpenClawConfig) => {
-    config = transform(config);
-  };
+  await state.writeConfig({});
   const install = async (name: string) => {
     const root = state.path(name);
     await fs.mkdir(root);
@@ -41,7 +38,10 @@ async function fixture(withFile = false) {
     expect(
       await applyClawAddPlan(added.plan, {
         consentPlanIntegrity: added.plan.planIntegrity,
-        commitConfig,
+        commitConfig: async (transform) => {
+          await state.writeConfig(transform(await readSourceConfigBestEffort()));
+          resetConfigRuntimeState();
+        },
       }),
     ).toMatchObject({ status: "complete" });
     return added.plan.agent.workspace;
@@ -52,11 +52,11 @@ async function fixture(withFile = false) {
     return true;
   };
   const remove = async (overrides: Partial<ClawRemoveApplyOptions> = {}) => {
+    const config = await readSourceConfigBestEffort();
     const plan = await buildClawRemovePlan("worker", { config });
     expect(plan.blockers).toEqual([]);
     return await applyClawRemovePlan(plan, {
       config,
-      commitConfig,
       monitorGateway: quiescentClawMonitorGateway,
       consentPlanIntegrity: plan.planIntegrity,
       trashPath,

--- a/src/claws/lifecycle-state-mcp.test.ts
+++ b/src/claws/lifecycle-state-mcp.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -5,6 +6,7 @@ import { withTempHomeConfig } from "../config/test-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { markClawMcpServerIndependentlyOwned } from "../state/claw-mcp-adoption.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { setTestEnvValue } from "../test-utils/env.js";
 import { applyClawAddPlan } from "./add.js";
 import { quiescentClawMonitorGateway } from "./lifecycle-remove.test-support.js";
 import { applyClawRemovePlan, buildClawRemovePlan } from "./lifecycle-state.js";
@@ -92,33 +94,43 @@ describe("Claw MCP removal", () => {
       setMcpServer: vi.fn(),
       listMcpServers: vi.fn().mockResolvedValue(listedMcpServers({}, { docs: sourceServer })),
     });
-    let config: OpenClawConfig = {
+    const config: OpenClawConfig = {
       ...current.getConfig(),
       mcp: { servers: { docs: sourceServer } },
     };
     const plan = await buildClawRemovePlan("worker", { env: current.env, config });
     const unsetMcpServer = vi.fn();
 
-    const result = await applyClawRemovePlan(plan, {
-      monitorGateway: quiescentClawMonitorGateway,
-      consentPlanIntegrity: plan.planIntegrity,
-      env: current.env,
-      config,
-      unsetMcpServer,
-      commitConfig: async (transform) => {
-        config = transform(config);
-      },
+    const result = await withTempHomeConfig(config, async ({ configPath }) => {
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      setTestEnvValue("OPENCLAW_STATE_DIR", current.env.OPENCLAW_STATE_DIR);
+      const removed = await applyClawRemovePlan(plan, {
+        monitorGateway: quiescentClawMonitorGateway,
+        consentPlanIntegrity: plan.planIntegrity,
+        env: current.env,
+        config,
+        unsetMcpServer,
+        trashPath: async () => true,
+      });
+      expect(JSON.parse(await readFile(configPath, "utf8"))).toHaveProperty(
+        "mcp.servers.docs",
+        sourceServer,
+      );
+      return removed;
     });
 
     expect(unsetMcpServer).not.toHaveBeenCalled();
-    expect(result.mcpServers).toEqual([{ name: "docs", action: "released" }]);
-    expect(config.mcp?.servers?.docs).toEqual(sourceServer);
+    expect(result).toMatchObject({
+      status: "complete",
+      agentRemoved: true,
+      mcpServers: [{ name: "docs", action: "released" }],
+    });
   });
 
   it("deletes the final unchanged Claw-created MCP server", async () => {
     const current = await addMcpFixture();
     await recordManagedMcp(current);
-    let config: OpenClawConfig = {
+    const config: OpenClawConfig = {
       ...current.getConfig(),
       mcp: {
         servers: {
@@ -138,16 +150,18 @@ describe("Claw MCP removal", () => {
       .fn()
       .mockResolvedValue({ ok: true, path: "config", config: {}, mcpServers: {}, removed: true });
 
-    const result = await applyClawRemovePlan(plan, {
-      monitorGateway: quiescentClawMonitorGateway,
-      consentPlanIntegrity: plan.planIntegrity,
-      env: current.env,
-      config,
-      sourceMcpServers: { docs: sourceServer },
-      unsetMcpServer,
-      commitConfig: async (transform) => {
-        config = transform(config);
-      },
+    const result = await withTempHomeConfig(config, async ({ configPath }) => {
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      setTestEnvValue("OPENCLAW_STATE_DIR", current.env.OPENCLAW_STATE_DIR);
+      return applyClawRemovePlan(plan, {
+        monitorGateway: quiescentClawMonitorGateway,
+        consentPlanIntegrity: plan.planIntegrity,
+        env: current.env,
+        config,
+        sourceMcpServers: { docs: sourceServer },
+        unsetMcpServer,
+        trashPath: async () => true,
+      });
     });
 
     expect(unsetMcpServer).toHaveBeenCalledWith({
@@ -155,31 +169,41 @@ describe("Claw MCP removal", () => {
       expectedServer: sourceServer,
       recordIndependentOwner: false,
     });
-    expect(result.mcpServers).toEqual([{ name: "docs", action: "removed" }]);
+    expect(result).toMatchObject({
+      status: "complete",
+      agentRemoved: true,
+      mcpServers: [{ name: "docs", action: "removed" }],
+    });
   });
 
   it("releases missing managed MCP provenance without changing the remove plan", async () => {
     const current = await addMcpFixture();
     await recordManagedMcp(current);
-    let config = current.getConfig();
+    const config = current.getConfig();
     const plan = await buildClawRemovePlan("worker", {
       env: current.env,
       config,
       sourceMcpServers: {},
     });
 
-    const result = await applyClawRemovePlan(plan, {
-      monitorGateway: quiescentClawMonitorGateway,
-      consentPlanIntegrity: plan.planIntegrity,
-      env: current.env,
-      config,
-      sourceMcpServers: {},
-      commitConfig: async (transform) => {
-        config = transform(config);
-      },
+    const result = await withTempHomeConfig(config, async ({ configPath }) => {
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      setTestEnvValue("OPENCLAW_STATE_DIR", current.env.OPENCLAW_STATE_DIR);
+      return applyClawRemovePlan(plan, {
+        monitorGateway: quiescentClawMonitorGateway,
+        consentPlanIntegrity: plan.planIntegrity,
+        env: current.env,
+        config,
+        sourceMcpServers: {},
+        trashPath: async () => true,
+      });
     });
 
-    expect(result.mcpServers).toEqual([{ name: "docs", action: "missing" }]);
+    expect(result).toMatchObject({
+      status: "complete",
+      agentRemoved: true,
+      mcpServers: [{ name: "docs", action: "missing" }],
+    });
   });
 
   it("retains a managed MCP server adopted after remove planning", async () => {
@@ -195,14 +219,18 @@ describe("Claw MCP removal", () => {
     const unsetMcpServer = vi.fn();
 
     await expect(
-      applyClawRemovePlan(plan, {
-        monitorGateway: quiescentClawMonitorGateway,
-        consentPlanIntegrity: plan.planIntegrity,
-        env: current.env,
-        config,
-        sourceMcpServers: { docs: sourceServer },
-        unsetMcpServer,
-        commitConfig: async () => undefined,
+      withTempHomeConfig(config, async ({ configPath }) => {
+        setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+        setTestEnvValue("OPENCLAW_STATE_DIR", current.env.OPENCLAW_STATE_DIR);
+        return applyClawRemovePlan(plan, {
+          monitorGateway: quiescentClawMonitorGateway,
+          consentPlanIntegrity: plan.planIntegrity,
+          env: current.env,
+          config,
+          sourceMcpServers: { docs: sourceServer },
+          unsetMcpServer,
+          trashPath: async () => true,
+        });
       }),
     ).rejects.toMatchObject({ code: "remove_changed" });
     expect(unsetMcpServer).not.toHaveBeenCalled();
@@ -212,7 +240,9 @@ describe("Claw MCP removal", () => {
     const current = await addMcpFixture();
     await recordManagedMcp(current);
 
-    await withTempHomeConfig(current.getConfig(), async () => {
+    await withTempHomeConfig(current.getConfig(), async ({ configPath }) => {
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      setTestEnvValue("OPENCLAW_STATE_DIR", current.env.OPENCLAW_STATE_DIR);
       const missing = listedMcpServers(current.getConfig(), {});
       const restored = listedMcpServers(
         { ...current.getConfig(), mcp: { servers: { docs: sourceServer } } },
@@ -231,17 +261,13 @@ describe("Claw MCP removal", () => {
       const unsetMcpServer = vi
         .fn()
         .mockResolvedValue({ ok: true, path: "config", config: {}, mcpServers: {}, removed: true });
-      let config = current.getConfig();
-
       const result = await applyClawRemovePlan(plan, {
         monitorGateway: quiescentClawMonitorGateway,
         consentPlanIntegrity: plan.planIntegrity,
         env: current.env,
         listMcpServers,
         unsetMcpServer,
-        commitConfig: async (transform) => {
-          config = transform(config);
-        },
+        trashPath: async () => true,
       });
 
       expect(unsetMcpServer).toHaveBeenCalledWith({
@@ -249,7 +275,11 @@ describe("Claw MCP removal", () => {
         expectedServer: sourceServer,
         recordIndependentOwner: false,
       });
-      expect(result.mcpServers).toEqual([{ name: "docs", action: "removed" }]);
+      expect(result).toMatchObject({
+        status: "complete",
+        agentRemoved: true,
+        mcpServers: [{ name: "docs", action: "removed" }],
+      });
     });
   });
 
@@ -258,7 +288,9 @@ describe("Claw MCP removal", () => {
     const replacementServer = { command: "node", args: ["replacement-mcp"] };
     await recordManagedMcp(current);
 
-    await withTempHomeConfig(current.getConfig(), async () => {
+    await withTempHomeConfig(current.getConfig(), async ({ configPath }) => {
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      setTestEnvValue("OPENCLAW_STATE_DIR", current.env.OPENCLAW_STATE_DIR);
       const missing = listedMcpServers(current.getConfig(), {});
       const restored = listedMcpServers(
         { ...current.getConfig(), mcp: { servers: { docs: replacementServer } } },
@@ -275,8 +307,6 @@ describe("Claw MCP removal", () => {
         listMcpServers,
       });
       const unsetMcpServer = vi.fn();
-      let config = current.getConfig();
-
       await expect(
         applyClawRemovePlan(plan, {
           monitorGateway: quiescentClawMonitorGateway,
@@ -284,9 +314,7 @@ describe("Claw MCP removal", () => {
           env: current.env,
           listMcpServers,
           unsetMcpServer,
-          commitConfig: async (transform) => {
-            config = transform(config);
-          },
+          trashPath: async () => true,
         }),
       ).resolves.toMatchObject({
         status: "partial",

--- a/src/claws/lifecycle-state.test.ts
+++ b/src/claws/lifecycle-state.test.ts
@@ -1,7 +1,8 @@
 import { link, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { loadConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { cronJobReadView } from "../cron/job-read-view.js";
 import { normalizeCronJobCreate } from "../cron/normalize.js";
@@ -16,6 +17,10 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import { applyClawAddPlan } from "./add.js";
 import { clawCronGatewayInput, markClawCronRefRemoved, readClawCronRefs } from "./cron.js";
 import { withClawAgentConfigRemoval } from "./lifecycle-config-removal.js";
@@ -30,7 +35,15 @@ import {
   readClawPackageRefs,
 } from "./provenance.js";
 
-afterEach(() => closeOpenClawStateDatabaseForTest());
+let state: OpenClawTestState;
+beforeEach(async () => {
+  state = await createOpenClawTestState({ prefix: "claw-remove-config-" });
+  await state.writeConfig({});
+});
+afterEach(async () => {
+  closeOpenClawStateDatabaseForTest();
+  await state.cleanup();
+});
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const packageIntegrity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -74,7 +87,8 @@ function seedAttachedCronJob(
 }
 
 async function fixture(params: Parameters<typeof buildClawRemovalFixture>[1] = {}) {
-  return await buildClawRemovalFixture(tempDirs.make("openclaw-claw-remove-"), params);
+  const current = await buildClawRemovalFixture(tempDirs.make("openclaw-claw-remove-"), params);
+  return { ...current, env: { OPENCLAW_STATE_DIR: state.stateDir } };
 }
 
 async function addFixture(
@@ -87,16 +101,14 @@ async function addFixture(
     env: current.env,
     commitConfig: async (transform) => {
       config = transform(config);
+      await state.writeConfig(config);
     },
     cronGateway: { add: async () => ({ id: "scheduler-daily" }) },
     ...(params.withMcp ? { installMcpServers: async () => [] } : {}),
   });
   return {
     ...current,
-    getConfig: () => config,
-    commitConfig: async (transform: (current: OpenClawConfig) => OpenClawConfig) => {
-      config = transform(config);
-    },
+    getConfig: loadConfig,
   };
 }
 
@@ -117,7 +129,6 @@ describe("Claw status and remove", () => {
       applyClawRemovePlan(plan, {
         env: current.env,
         config: current.getConfig(),
-        commitConfig: current.commitConfig,
         consentPlanIntegrity: plan.planIntegrity,
       }),
     ).rejects.toMatchObject({ code: "monitor_gateway_required" });
@@ -320,14 +331,11 @@ describe("Claw status and remove", () => {
     const remove = await buildClawRemovePlan("worker", { env: current.env, config: {} });
     const removed = await applyClawRemovePlan(remove, {
       monitorGateway: quiescentClawMonitorGateway,
+      trashPath: async () => true,
       env: current.env,
       config: {},
       consentPlanIntegrity: remove.planIntegrity,
-      commitConfig: async (transform) => {
-        transform({});
-      },
       purgeSessions: async () => undefined,
-      trashPath: async () => true,
     });
     expect(removed).toMatchObject({ status: "complete", agentRemoved: false });
     await expect(readClawStatus("worker", { env: current.env, config: {} })).resolves.toMatchObject(
@@ -374,13 +382,15 @@ describe("Claw status and remove", () => {
 
     await expect(
       applyClawRemovePlan(plan, {
-        monitorGateway: quiescentClawMonitorGateway,
+        monitorGateway: {
+          ...quiescentClawMonitorGateway,
+          quiesce: async () => {
+            await state.writeConfig(changedConfig);
+          },
+        },
         env: current.env,
         config,
         consentPlanIntegrity: plan.planIntegrity,
-        commitConfig: async (transform) => {
-          transform(changedConfig);
-        },
       }),
     ).resolves.toMatchObject({
       status: "partial",
@@ -487,15 +497,13 @@ describe("Claw status and remove", () => {
       env: current.env,
       config: current.getConfig(),
     });
-    let config = current.getConfig();
+    const config = current.getConfig();
     const result = await applyClawRemovePlan(plan, {
       monitorGateway: quiescentClawMonitorGateway,
+      trashPath: async () => true,
       consentPlanIntegrity: plan.planIntegrity,
       env: current.env,
       config,
-      commitConfig: async (transform) => {
-        config = transform(config);
-      },
     });
     expect(result).toMatchObject({
       status: "complete",
@@ -503,12 +511,14 @@ describe("Claw status and remove", () => {
       packageRefsReleased: 1,
       workspaceFiles: [{ path: "SOUL.md", action: "deleted" }],
     });
-    expect(config.agents?.entries?.worker).toBeUndefined();
+    expect(loadConfig().agents?.entries?.worker).toBeUndefined();
     expect(
       listOpenClawRegisteredAgentDatabases({ env: current.env }).map((entry) => entry.agentId),
     ).not.toContain("worker");
     await expect(readFile(join(current.plan.agent.workspace, "SOUL.md"), "utf8")).rejects.toThrow();
-    await expect(readClawStatus("worker", { env: current.env, config })).resolves.toMatchObject({
+    await expect(
+      readClawStatus("worker", { env: current.env, config: loadConfig() }),
+    ).resolves.toMatchObject({
       summary: { claws: 0 },
     });
   });
@@ -527,10 +537,11 @@ describe("Claw status and remove", () => {
         target: "scheduler-daily",
       }),
     );
-    let config = current.getConfig();
+    const config = current.getConfig();
     const order: string[] = [];
     const result = await applyClawRemovePlan(plan, {
       monitorGateway: quiescentClawMonitorGateway,
+      trashPath: async () => true,
       consentPlanIntegrity: plan.planIntegrity,
       env: current.env,
       config,
@@ -538,16 +549,14 @@ describe("Claw status and remove", () => {
         get: async () =>
           cronReadView("worker", readClawCronRefs("worker", { env: current.env })[0]!),
         remove: async (id) => {
+          expect(loadConfig().agents?.entries?.worker).toBeDefined();
           order.push(`cron:${id}`);
           return { ok: true };
         },
       },
-      commitConfig: async (transform) => {
-        order.push("config");
-        config = transform(config);
-      },
     });
-    expect(order).toEqual(["cron:scheduler-daily", "config"]);
+    expect(order).toEqual(["cron:scheduler-daily"]);
+    expect(loadConfig().agents?.entries?.worker).toBeUndefined();
     expect(result).toMatchObject({
       status: "complete",
       cronJobs: [
@@ -568,10 +577,10 @@ describe("Claw status and remove", () => {
 
     const result = await applyClawRemovePlan(plan, {
       monitorGateway: quiescentClawMonitorGateway,
+      trashPath: async () => true,
       consentPlanIntegrity: plan.planIntegrity,
       env: current.env,
       config: current.getConfig(),
-      commitConfig: current.commitConfig,
       cronGateway: {
         get: async () => ({
           ...live,
@@ -606,38 +615,6 @@ describe("Claw status and remove", () => {
     ).rejects.toMatchObject({ code: "mcp_config_unavailable" });
   });
 
-  it("removes cron before the canonical agent config lifecycle", async () => {
-    const current = await addFixture({ withCron: true });
-    const plan = await buildClawRemovePlan("worker", {
-      env: current.env,
-      config: current.getConfig(),
-    });
-    const calls: string[] = [];
-
-    const result = await applyClawRemovePlan(plan, {
-      monitorGateway: quiescentClawMonitorGateway,
-      consentPlanIntegrity: plan.planIntegrity,
-      env: current.env,
-      config: current.getConfig(),
-      commitConfig: current.commitConfig,
-      cronGateway: {
-        get: async () =>
-          cronReadView("worker", readClawCronRefs("worker", { env: current.env })[0]!),
-        remove: async (id) => {
-          calls.push(`cron:${id}`);
-          return { ok: true };
-        },
-      },
-    });
-
-    expect(calls).toEqual(["cron:scheduler-daily"]);
-    expect(result).toMatchObject({
-      status: "complete",
-      agentRemoved: true,
-      cronJobs: [{ manifestId: "daily-report", action: "removed" }],
-    });
-  });
-
   it("retains the agent when recurring work cannot be disabled", async () => {
     const current = await addFixture({ withCron: true });
     const plan = await buildClawRemovePlan("worker", {
@@ -646,6 +623,7 @@ describe("Claw status and remove", () => {
     });
     const result = await applyClawRemovePlan(plan, {
       monitorGateway: quiescentClawMonitorGateway,
+      trashPath: async () => true,
       consentPlanIntegrity: plan.planIntegrity,
       env: current.env,
       config: current.getConfig(),
@@ -674,16 +652,14 @@ describe("Claw status and remove", () => {
     });
     const ref = readClawCronRefs("worker", { env: current.env })[0]!;
     let present = true;
-    let config = current.getConfig();
+    const config = current.getConfig();
 
     const result = await applyClawRemovePlan(plan, {
       monitorGateway: quiescentClawMonitorGateway,
+      trashPath: async () => true,
       consentPlanIntegrity: plan.planIntegrity,
       env: current.env,
       config,
-      commitConfig: async (transform) => {
-        config = transform(config);
-      },
       cronGateway: {
         get: async () => (present ? cronReadView("worker", ref) : undefined),
         remove: async () => {
@@ -709,6 +685,7 @@ describe("Claw status and remove", () => {
 
     const result = await applyClawRemovePlan(plan, {
       monitorGateway: quiescentClawMonitorGateway,
+      trashPath: async () => true,
       consentPlanIntegrity: plan.planIntegrity,
       env: current.env,
       config: current.getConfig(),
@@ -736,17 +713,15 @@ describe("Claw status and remove", () => {
       env: current.env,
       config: current.getConfig(),
     });
-    let config = current.getConfig();
+    const config = current.getConfig();
     const remoteRemovals: string[] = [];
 
     const result = await applyClawRemovePlan(plan, {
       monitorGateway: quiescentClawMonitorGateway,
+      trashPath: async () => true,
       consentPlanIntegrity: plan.planIntegrity,
       env: current.env,
       config,
-      commitConfig: async (transform) => {
-        config = transform(config);
-      },
       cronGateway: {
         remove: async (id) => {
           remoteRemovals.push(id);
@@ -777,15 +752,12 @@ describe("Claw status and remove", () => {
     expect(plan.actions).toContainEqual(
       expect.objectContaining({ kind: "workspaceFile", action: "retain", blocked: false }),
     );
-    let config = current.getConfig();
+    const config = current.getConfig();
     const result = await applyClawRemovePlan(plan, {
       monitorGateway: quiescentClawMonitorGateway,
       consentPlanIntegrity: plan.planIntegrity,
       env: current.env,
       config,
-      commitConfig: async (transform) => {
-        config = transform(config);
-      },
       trashPath,
     });
     expect(result.workspaceFiles).toEqual([{ path: "SOUL.md", action: "retainedModified" }]);
@@ -810,9 +782,6 @@ describe("Claw status and remove", () => {
         env: current.env,
         config,
         consentPlanIntegrity: plan.planIntegrity,
-        commitConfig: async (transform) => {
-          transform(config);
-        },
         purgeSessions: async () => undefined,
         trashPath,
       }),
@@ -828,17 +797,20 @@ describe("Claw status and remove", () => {
       env: current.env,
       config: current.getConfig(),
     });
-    let config = current.getConfig();
+    const config = current.getConfig();
 
     const result = await applyClawRemovePlan(plan, {
-      monitorGateway: quiescentClawMonitorGateway,
+      monitorGateway: {
+        ...quiescentClawMonitorGateway,
+        drain: async () => {
+          expect(loadConfig().agents?.entries?.worker).toBeUndefined();
+          await writeFile(target, "replacement\n", "utf8");
+        },
+      },
+      trashPath: async () => true,
       consentPlanIntegrity: plan.planIntegrity,
       env: current.env,
       config,
-      commitConfig: async (transform) => {
-        config = transform(config);
-        await writeFile(target, "replacement\n", "utf8");
-      },
     });
 
     expect(result).toMatchObject({
@@ -854,18 +826,21 @@ describe("Claw status and remove", () => {
       env: current.env,
       config: current.getConfig(),
     });
-    let config = current.getConfig();
+    const config = current.getConfig();
 
     const result = await applyClawRemovePlan(plan, {
-      monitorGateway: quiescentClawMonitorGateway,
+      monitorGateway: {
+        ...quiescentClawMonitorGateway,
+        drain: async () => {
+          expect(loadConfig().agents?.entries?.worker).toBeUndefined();
+          await rm(target);
+          await link(join(current.root, "SOUL.md"), target);
+        },
+      },
+      trashPath: async () => true,
       consentPlanIntegrity: plan.planIntegrity,
       env: current.env,
       config,
-      commitConfig: async (transform) => {
-        config = transform(config);
-        await rm(target);
-        await link(join(current.root, "SOUL.md"), target);
-      },
     });
 
     expect(result).toMatchObject({
@@ -874,7 +849,9 @@ describe("Claw status and remove", () => {
       workspaceFiles: [{ path: "SOUL.md", action: "error" }],
       error: { code: "workspace_cleanup_failed" },
     });
-    await expect(readClawStatus("worker", { env: current.env, config })).resolves.toMatchObject({
+    await expect(
+      readClawStatus("worker", { env: current.env, config: loadConfig() }),
+    ).resolves.toMatchObject({
       summary: { claws: 1, missingAgents: 1 },
       records: [{ install: { status: "partial" }, workspaceFiles: [{ state: "unsafe" }] }],
     });
@@ -884,7 +861,6 @@ describe("Claw status and remove", () => {
     const current = await addFixture();
     const config = current.getConfig();
     const plan = await buildClawRemovePlan("worker", { env: current.env, config });
-    let nextConfig = config;
     let purgedAgentId: string | undefined;
 
     const result = await applyClawRemovePlan(plan, {
@@ -892,9 +868,6 @@ describe("Claw status and remove", () => {
       consentPlanIntegrity: plan.planIntegrity,
       env: current.env,
       config,
-      commitConfig: async (transform) => {
-        nextConfig = transform(nextConfig);
-      },
       purgeSessions: async (_cfg, agentId) => {
         purgedAgentId = agentId;
       },
@@ -908,7 +881,7 @@ describe("Claw status and remove", () => {
       error: { code: "workspace_cleanup_failed" },
     });
     await expect(
-      readClawStatus("worker", { env: current.env, config: nextConfig }),
+      readClawStatus("worker", { env: current.env, config: loadConfig() }),
     ).resolves.toMatchObject({ records: [{ install: { status: "partial" } }] });
   });
 
@@ -930,7 +903,7 @@ describe("Claw status and remove", () => {
         independentOwner: false,
       },
     );
-    let config = current.getConfig();
+    const config = current.getConfig();
     const resolvePlugin = vi.fn().mockResolvedValue({
       status: "found",
       pluginId: "audit",
@@ -958,13 +931,11 @@ describe("Claw status and remove", () => {
     await expect(
       applyClawRemovePlan(plan, {
         monitorGateway: quiescentClawMonitorGateway,
+        trashPath: async () => true,
         env: current.env,
         config,
         consentPlanIntegrity: plan.planIntegrity,
         packageDeps,
-        commitConfig: async (transform) => {
-          config = transform(config);
-        },
       }),
     ).resolves.toMatchObject({ status: "complete", agentRemoved: true });
   });
@@ -979,6 +950,7 @@ describe("Claw status and remove", () => {
     await expect(
       applyClawRemovePlan(plan, {
         monitorGateway: quiescentClawMonitorGateway,
+        trashPath: async () => true,
         env: current.env,
         config,
         consentPlanIntegrity: plan.planIntegrity,
@@ -996,6 +968,7 @@ describe("Claw status and remove", () => {
     await expect(
       applyClawRemovePlan(plan, {
         monitorGateway: quiescentClawMonitorGateway,
+        trashPath: async () => true,
         env: current.env,
         config,
         consentPlanIntegrity: "sha256:stale",
@@ -1040,18 +1013,17 @@ describe("Claw status and remove", () => {
     });
     const { id: firstId, ...firstConfig } = first.plan.agent.config;
     const { id: secondId, ...secondConfig } = second.plan.agent.config;
-    let config: OpenClawConfig = {
+    const config: OpenClawConfig = {
       agents: { entries: { [firstId]: firstConfig, [secondId]: secondConfig } },
     };
+    await state.writeConfig(config);
     const remove = await buildClawRemovePlan("worker-a", { env: first.env, config });
     await applyClawRemovePlan(remove, {
       monitorGateway: quiescentClawMonitorGateway,
+      trashPath: async () => true,
       consentPlanIntegrity: remove.planIntegrity,
       env: first.env,
       config,
-      commitConfig: async (transform) => {
-        config = transform(config);
-      },
     });
 
     expect(readClawPackageRefs({ env: first.env, agentId: "worker-b" })).toMatchObject([

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -526,9 +526,7 @@ export async function applyClawRemovePlan(
       expectedState: record.agentState,
       fallbackWorkspace: record.install.workspace,
       config: options.config,
-      commitConfig: options.commitConfig,
       stateDatabase: options,
-      trashPath: options.trashPath,
       onModified: () =>
         new ClawRemoveError("agent_modified", "Agent config changed during remove."),
       quiesceMonitors: (operationId) => monitorGateway.quiesce(agentId, operationId, monitors),
@@ -608,20 +606,18 @@ export async function applyClawRemovePlan(
       } catch (error) {
         return partial("monitor_cleanup_failed", coerceErrorMessage(error));
       }
-      if (!options.commitConfig || options.purgeSessions) {
-        const purgeSessions =
-          options.purgeSessions ??
-          (await import("../config/sessions/cleanup-service.js")).purgeAgentSessionStoreEntries;
-        const purgeFailed = await purgeSessions(configBeforeDelete, agentId, {
-          env: options.env,
-          runDatabaseCleanup: configRemoval.runDatabaseCleanup,
-        });
-        if (purgeFailed) {
-          return partial(
-            "session_cleanup_failed",
-            "Session cleanup failed; correct the reported error and retry Claw removal.",
-          );
-        }
+      const purgeSessions =
+        options.purgeSessions ??
+        (await import("../config/sessions/cleanup-service.js")).purgeAgentSessionStoreEntries;
+      const purgeFailed = await purgeSessions(configBeforeDelete, agentId, {
+        env: options.env,
+        runDatabaseCleanup: configRemoval.runDatabaseCleanup,
+      });
+      if (purgeFailed) {
+        return partial(
+          "session_cleanup_failed",
+          "Session cleanup failed; correct the reported error and retry Claw removal.",
+        );
       }
       result.packages = await applyClawPackageRemovals(
         packageDecisions.toSorted(
@@ -651,7 +647,7 @@ export async function applyClawRemovePlan(
       if (bootstrap?.action === "error") {
         cleanupErrors.push(bootstrap.message ?? `Could not remove ${bootstrap.path}.`);
       }
-      if (cleanupErrors.length === 0 && cleanupTargets) {
+      if (cleanupErrors.length === 0) {
         const workspaceHasRemainingEntries = await workspaceContainsUntrackedEntries(
           cleanupTargets.workspaceDir,
           record.workspaceFiles.map((file) => file.path),

--- a/src/gateway/server-claws-monitors.test.ts
+++ b/src/gateway/server-claws-monitors.test.ts
@@ -20,6 +20,7 @@ import {
   type ClawMonitorCleanupGateway,
 } from "../claws/monitor-cleanup-contract.js";
 import { parseClawManifest } from "../claws/schema.js";
+import { registerConfigWriteListener, resetConfigRuntimeState } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { applyHeartbeatMonitorJobs } from "../cron/heartbeat-monitor.js";
 import { cronJobReadView } from "../cron/job-read-view.js";
@@ -126,6 +127,8 @@ async function fixture(
     consentPlanIntegrity: addPlan.planIntegrity,
     commitConfig: async (transform) => {
       config = transform(config);
+      await state.writeConfig(config);
+      resetConfigRuntimeState();
     },
     cronGateway: {
       add: async (input) => {
@@ -137,14 +140,23 @@ async function fixture(
       },
     },
   });
+  let reconcilePending = false;
   const reconcile = async () => {
     expect((await applyHeartbeatMonitorJobs({ cron, cfg: config })).ok).toBe(true);
     expect(
       (await reconcileSkillCollectionReviewJobs({ cron, cfg: config, logger })).ok,
       JSON.stringify(logger.warn.mock.calls.slice(-3)),
     ).toBe(true);
+    reconcilePending = false;
   };
   await reconcile();
+  const unsubscribe = registerConfigWriteListener((event) => {
+    if (event.configPath === state.configPath) {
+      config = event.runtimeConfig;
+      reconcilePending = true;
+    }
+  });
+  cleanups.push(async () => unsubscribe());
   let reloadSettled = true;
   const context = {
     cron,
@@ -179,11 +191,16 @@ async function fixture(
       await invoke({ phase: "quiesce", agentId, operationId, monitors });
     },
     drain: async (agentId, operationId) => {
+      if (reconcilePending) {
+        await reconcile();
+      }
       await invoke({ phase: "drain", agentId, operationId });
     },
   };
-  const commitConfig = async (transform: (cfg: OpenClawConfig) => OpenClawConfig) => {
-    config = transform(config);
+  const writeConfig = async (nextConfig: OpenClawConfig) => {
+    config = nextConfig;
+    await state.writeConfig(config);
+    resetConfigRuntimeState();
     await reconcile();
   };
   const plan = () => buildClawRemovePlan("worker", { config, monitorGateway: gateway });
@@ -201,7 +218,10 @@ async function fixture(
         },
         remove: async (id) => await cron.remove(id),
       },
-      commitConfig,
+      trashPath: async (pathname) => {
+        await fs.rm(pathname, { recursive: true, force: true });
+        return true;
+      },
       consentPlanIntegrity: removal.planIntegrity,
       ...overrides,
     });
@@ -213,7 +233,7 @@ async function fixture(
     plan,
     apply,
     invoke,
-    commitConfig,
+    writeConfig,
     reconcile,
     replaceCron: () => {
       const replacement = new CronService(cronDeps);
@@ -261,9 +281,9 @@ describe("Claw serving monitor cleanup", () => {
 
   it("removes orphaned workspace ownership through the serving monitor handler", async () => {
     const current = await fixture(false);
-    await current.commitConfig(() => ({
+    await current.writeConfig({
       agents: { entries: { main: { workspace: current.state.path("main-workspace") } } },
-    }));
+    });
     openOpenClawStateDatabase()
       .db.prepare("DELETE FROM claw_installs WHERE agent_id = ?")
       .run("worker");
@@ -550,53 +570,59 @@ describe("Claw serving monitor cleanup", () => {
     async (failure) => {
       const current = await fixture(false);
       const plan = await current.plan();
-      const result = await current.apply(plan, {
-        ...(failure === "reload"
-          ? {
-              commitConfig: async (transform) => {
-                await current.commitConfig(transform);
-                current.setReloadSettled(false);
-              },
-            }
-          : {}),
-        ...(failure === "config-write"
-          ? {
-              commitConfig: async () => {
+      const database = openOpenClawStateDatabase();
+      if (failure === "cron-persistence") {
+        database.db.exec(`CREATE TEMP TRIGGER refuse_monitor_delete
+          BEFORE DELETE ON cron_jobs WHEN OLD.agent_id = 'worker'
+          BEGIN SELECT RAISE(ABORT, 'synthetic monitor persistence failure'); END`);
+      }
+      const rename = fs.rename.bind(fs);
+      const writeFailure =
+        failure === "config-write"
+          ? vi.spyOn(fs, "rename").mockImplementation(async (...args) => {
+              if (args[1] === current.state.configPath) {
                 throw new Error("synthetic config persistence failure");
-              },
-            }
-          : {}),
-        ...(failure === "cron-persistence"
-          ? {
-              commitConfig: async (transform) => {
-                const database = openOpenClawStateDatabase();
-                database.db.exec(`CREATE TEMP TRIGGER refuse_monitor_delete
-                  BEFORE DELETE ON cron_jobs WHEN OLD.agent_id = 'worker'
-                  BEGIN SELECT RAISE(ABORT, 'synthetic monitor persistence failure'); END`);
-                try {
-                  await current.commitConfig(transform);
-                } finally {
-                  database.db.exec("DROP TRIGGER refuse_monitor_delete");
+              }
+              await rename(...args);
+            })
+          : undefined;
+      let result: Awaited<ReturnType<typeof current.apply>>;
+      try {
+        result = await current.apply(plan, {
+          monitorGateway: {
+            ...current.gateway,
+            ...(failure === "lost-cancellation-response"
+              ? {
+                  quiesce: async (...args: Parameters<ClawMonitorCleanupGateway["quiesce"]>) => {
+                    await current.gateway.quiesce(...args);
+                    throw new Error("synthetic lost cancellation response");
+                  },
                 }
-              },
-            }
-          : {}),
-        ...(failure === "lost-cancellation-response"
-          ? {
-              monitorGateway: {
-                ...current.gateway,
-                quiesce: async (...args) => {
-                  await current.gateway.quiesce(...args);
-                  throw new Error("synthetic lost cancellation response");
-                },
-              },
-            }
-          : {}),
-      });
+              : {}),
+            ...(failure === "reload"
+              ? {
+                  drain: async (...args: Parameters<ClawMonitorCleanupGateway["drain"]>) => {
+                    current.setReloadSettled(false);
+                    await current.gateway.drain(...args);
+                  },
+                }
+              : {}),
+          },
+        });
+      } finally {
+        writeFailure?.mockRestore();
+        if (failure === "cron-persistence") {
+          database.db.exec("DROP TRIGGER refuse_monitor_delete");
+        }
+      }
       expect(result).toMatchObject({
         status: "partial",
+        agentRemoved: failure === "cron-persistence" || failure === "reload",
         error: { code: "monitor_cleanup_failed" },
       });
+      if (failure === "config-write") {
+        expect(result.error?.message).toContain("synthetic config persistence failure");
+      }
       const firstJournal = readAgentDeletionJournal("worker");
       expect(firstJournal).toBeDefined();
       await expect(fs.access(path.join(current.workspaceDir, "SOUL.md"))).resolves.toBeUndefined();


### PR DESCRIPTION
Closes #140686

## What Problem This Solves

Claw removal tests could pass through a simulated config commit that bypassed the persisted config owner and default session cleanup. This duplicated removal logic in production and let tests miss failures in the path the CLI actually uses.

## Why This Change Was Made

Remove the removal-only `commitConfig` hook and its alternate config transformation. Migrate the existing tests to isolated persisted config and SQLite fixtures, so ownership validation, monitor drainage, deletion journals and session cleanup run through the canonical owner. Add and update keep their separate commit contracts.

## User Impact

No intentional user-visible behavior change. Claw removal retains its existing config, cleanup and retry behavior, with regression coverage now exercising the production path. This removes 52 production code lines; test code grows by 26 lines.

## Evidence

The unchanged baseline passed 145 cases. The migrated suites passed 143 cases after removing two redundant simulation cases, covering config persistence failures, changed ownership, monitor cancellation and drainage, shared/cold databases, blocked foreign handles, modified files and partial/retry outcomes. Fixtures use isolated state and deterministic temporary-directory cleanup.

All 30 selected changed-code checks passed, including core and test types, lint, import and plugin boundaries, dead exports and storage guards. Independent final P2 review found no actionable issues. The final unused type deletion emits identical JavaScript to the tested version; all nine final source hashes match the reviewed patch. No running-Gateway or platform installation proof is claimed for this internal deletion.
