### PR TITLE
improve: speed up Feishu Markdown document planning

### DIFF
--- a/extensions/feishu/src/docx-markdown.ts
+++ b/extensions/feishu/src/docx-markdown.ts
@@ -48,29 +48,27 @@ function resolveRemoteImageUrl(value: string | undefined): string | undefined {
 
 function collectMarkdownImages(root: FeishuMarkdownNode): DocxMarkdownImage[] {
   const definitions = new Map<string, string>();
+  const imageNodes: FeishuMarkdownNode[] = [];
   visitMarkdown(root, (node) => {
-    if (node.type !== "definition" || !node.identifier || !node.url) {
-      return;
-    }
-    // CommonMark resolves the first matching definition.
-    if (!definitions.has(node.identifier)) {
-      definitions.set(node.identifier, node.url);
+    if (node.type === "definition" && node.identifier && node.url) {
+      // CommonMark resolves the first matching definition.
+      if (!definitions.has(node.identifier)) {
+        definitions.set(node.identifier, node.url);
+      }
+    } else if (node.type === "image" || node.type === "imageReference") {
+      imageNodes.push(node);
     }
   });
-
-  const images: DocxMarkdownImage[] = [];
-  visitMarkdown(root, (node) => {
-    if (node.type === "image") {
-      images.push({ url: resolveRemoteImageUrl(node.url) });
-      return;
-    }
-    if (node.type === "imageReference") {
-      images.push({
-        url: resolveRemoteImageUrl(node.identifier ? definitions.get(node.identifier) : undefined),
-      });
-    }
-  });
-  return images;
+  // Resolve after collecting every definition so forward image references work.
+  return imageNodes.map((node) => ({
+    url: resolveRemoteImageUrl(
+      node.type === "image"
+        ? node.url
+        : node.identifier
+          ? definitions.get(node.identifier)
+          : undefined,
+    ),
+  }));
 }
 
 function splitSourceAtOffsets(source: string, offsets: number[]): string[] {
@@ -230,10 +228,12 @@ export function createDocxMarkdownChunk(markdown: string): DocxMarkdownChunk {
 export function createDocxMarkdownPlan(markdown: string): DocxMarkdownPlan {
   const root = parseFeishuMarkdown(markdown);
   return {
-    // Feishu converts each request independently. Parse each exact chunk again
-    // so cross-chunk reference definitions cannot shift later image block mapping.
-    chunks: splitSourceAtOffsets(markdown, headingOffsets(markdown, root)).map(
-      createDocxMarkdownChunk,
+    // Reparse split chunks so references cannot cross independent request boundaries.
+    // The unchanged whole input can reuse its already parsed tree.
+    chunks: splitSourceAtOffsets(markdown, headingOffsets(markdown, root)).map((chunk) =>
+      chunk === markdown
+        ? { markdown, images: collectMarkdownImages(root) }
+        : createDocxMarkdownChunk(chunk),
     ),
   };
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Feishu document creation and updates spend unnecessary CPU time preparing Markdown, especially for large documents and documents containing many images. This adds local processing latency before document conversion and upload.

## Why This Change Was Made

Document planning already parses the complete Markdown to find heading boundaries. When the resulting chunk is exactly the original input, reuse that parsed tree instead of parsing the identical string again. Actual split chunks still receive independent parses so reference definitions cannot leak between document requests.

Image collection also gathers definitions and image nodes in one ordered traversal, then resolves images after the complete definition table exists. This preserves forward references, first-definition precedence, image order, and explicit placeholders for nonremote or invalid image URLs. Public APIs and URL handling remain unchanged. The combined change adds 24 and removes 24 production lines in one file, with no test changes.

## User Impact

Local Markdown planning takes roughly half as long for the measured large unsplit and image-heavy documents. Document content, heading boundaries, image alignment, and reference scope remain unchanged. Network transport logic is unchanged; these measurements do not include Feishu service latency.

## Evidence

All 59 existing tests across the complete `docx-markdown.test.ts`, `markdown.test.ts`, and `docx.test.ts` files passed. All 24 normal changed-gate checks passed. A fresh Codex review found no actionable P0–P2 issues.

A fresh baseline/candidate/candidate/baseline cohort exercised the complete `createDocxMarkdownPlan` operation on 11 fixed synthetic documents, including image-free inputs, direct and forward-reference images, duplicate/invalid/missing definitions, independent heading chunks, Unicode, and CRLF. Each case used one initial call, eight warm calls, and 32 measured one-call batches per phase. Every one of the 1,804 returned plans matched its complete literal expected output; retained results and input preservation were rechecked. Full output parity also held across all four phases.

Representative batch medians, with both baseline/candidate pairings shown independently:

| Workload | First pairing, baseline → candidate | Second pairing, baseline → candidate | Reduction |
| --- | ---: | ---: | ---: |
| Large image-free document | 39.106 → 19.661 ms | 39.214 → 19.786 ms | 49.73% / 49.54% |
| 96 inline images | 3.411 → 1.736 ms | 3.538 → 1.792 ms | 49.11% / 49.34% |
| 96 forward-reference images | 5.382 → 2.570 ms | 5.401 → 2.666 ms | 52.26% / 50.64% |
| Eight independent heading chunks | 0.693 → 0.677 ms | 0.705 → 0.691 ms | 2.24% / 2.04% |

All 22 batch-median comparisons improved. This is not a claim that every statistic improved: 37 of the 198 recorded first-call, warm-call, and batch statistics were adverse and remain retained. The split-chunk controls had slightly better medians but 2.14–14.46% worse means; reverse-order peak RSS increased 2.15–2.72%. No memory improvement is claimed. The earlier single-traversal-only experiment had mixed, weak results; its timings were not pooled with this cohort.

These are local synthetic planning measurements on Node 26.8.1, not an authenticated Feishu API roundtrip or an end-to-end upload benchmark. An initial validation attempt stopped at the disk admission floor before launching tests; after disk recovery, the actual test and gate runs passed without retries or relaxed limits.
