### PR TITLE
refactor(channels): share native approval control ownership

### DIFF
--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -661,7 +661,7 @@ Other approval helpers:
   `matchesApprovalRequestSessionFilter` export have been retired. The core
   implementations are unchanged.
 - Use `createNativeApprovalControlRegistry` from
-  `openclaw/plugin-sdk/approval-native-runtime` for process-local native card
+  `openclaw/plugin-sdk/approval-runtime` for process-local native card
   tokens. Each instance owns a 1,024-binding FIFO registry and holds its claim
   through Gateway resolution and the terminal card update. Missing approvals
   retire their tokens; other failures release the claim for retry. Plugins
@@ -677,6 +677,8 @@ Other approval helpers:
   lookup, transport-enabled check, target normalization, and turn-source
   target resolution. Do not use it to create core-owned channel policy
   defaults; pass the channel's documented default mode explicitly.
+  The unused `createChannelApprovalForwardingEvaluator` export has been retired;
+  this route-gate helper remains the supported routing path.
 - `createNativeApprovalMessagingTargetResolvers` centralizes channel matching
   and `{ to, accountId, threadId }` normalization for messaging transports
   whose native approval target is a channel-owned normalized destination.

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -660,6 +660,14 @@ Other approval helpers:
   duplicate `approval-runtime` exports and its unused
   `matchesApprovalRequestSessionFilter` export have been retired. The core
   implementations are unchanged.
+- Use `createNativeApprovalControlRegistry` from
+  `openclaw/plugin-sdk/approval-native-runtime` for process-local native card
+  tokens. Each instance owns a 1,024-binding FIFO registry and holds its claim
+  through Gateway resolution and the terminal card update. Missing approvals
+  retire their tokens; other failures release the claim for retry. Plugins
+  validate native event scope and authorize the actor before calling `settle`,
+  retain their lookup-expiry policy through `releaseClaimOnLookupExpiry`, and
+  use `onComplete` for transport-owned cleanup such as manual-prompt suppression.
 - Use `createNativeApprovalChannelRouteGates` from
   `openclaw/plugin-sdk/approval-native-runtime` when a channel supports both
   session-origin native delivery and explicit approval forwarding targets. The

--- a/extensions/googlechat/src/approval-card-actions.test.ts
+++ b/extensions/googlechat/src/approval-card-actions.test.ts
@@ -1,11 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
-  getGoogleChatApprovalCardBinding,
+  googleChatApprovalControls,
   registerGoogleChatManualApprovalFollowupSuppression as registerGoogleChatManualApprovalFollowupSuppressionRaw,
   registerGoogleChatApprovalCardBinding as registerGoogleChatApprovalCardBindingRaw,
   shouldSuppressGoogleChatManualExecApprovalFollowupPayload,
   shouldSuppressGoogleChatManualExecApprovalFollowupText,
-  unregisterGoogleChatApprovalCardBindings,
   unregisterGoogleChatManualApprovalFollowupSuppression,
 } from "./approval-card-actions.js";
 
@@ -50,7 +49,7 @@ function registerExecApprovalCard(overrides?: {
 
 describe("Google Chat approval card action registry", () => {
   afterEach(() => {
-    unregisterGoogleChatApprovalCardBindings([...registeredTokens]);
+    googleChatApprovalControls.unregister([...registeredTokens]);
     for (const registeredApprovalId of registeredApprovalIds) {
       unregisterGoogleChatManualApprovalFollowupSuppression(registeredApprovalId);
     }
@@ -146,7 +145,7 @@ describe("Google Chat approval card action registry", () => {
       messageName: "spaces/AAA/messages/msg-1",
       expiresAtMs: Date.now() + 60_000,
     });
-    expect(getGoogleChatApprovalCardBinding(firstToken)).not.toBeNull();
+    expect(googleChatApprovalControls.get(firstToken)).not.toBeNull();
 
     for (let i = 1; i <= 1024; i += 1) {
       registerGoogleChatApprovalCardBinding({
@@ -162,8 +161,8 @@ describe("Google Chat approval card action registry", () => {
       });
     }
 
-    expect(getGoogleChatApprovalCardBinding(firstToken)).toBeNull();
-    expect(getGoogleChatApprovalCardBinding("token-fill-1024")).not.toBeNull();
+    expect(googleChatApprovalControls.get(firstToken)).toBeNull();
+    expect(googleChatApprovalControls.get("token-fill-1024")).not.toBeNull();
   });
 
   it("evicts oldest manual approval follow-up suppressions once the cache exceeds its cap", () => {

--- a/extensions/googlechat/src/approval-card-actions.ts
+++ b/extensions/googlechat/src/approval-card-actions.ts
@@ -1,6 +1,8 @@
 import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
-import { createNativeApprovalControlRegistry } from "openclaw/plugin-sdk/approval-native-runtime";
-import type { ExecApprovalDecision } from "openclaw/plugin-sdk/approval-runtime";
+import {
+  createNativeApprovalControlRegistry,
+  type ExecApprovalDecision,
+} from "openclaw/plugin-sdk/approval-runtime";
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { GoogleChatActionParameter, GoogleChatEvent } from "./types.js";

--- a/extensions/googlechat/src/approval-card-actions.ts
+++ b/extensions/googlechat/src/approval-card-actions.ts
@@ -1,5 +1,5 @@
-import crypto from "node:crypto";
 import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
+import { createNativeApprovalControlRegistry } from "openclaw/plugin-sdk/approval-native-runtime";
 import type { ExecApprovalDecision } from "openclaw/plugin-sdk/approval-runtime";
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -25,9 +25,12 @@ type GoogleChatApprovalCardBinding = {
   expiresAtMs: number;
 };
 
-const approvalCardBindings = new Map<string, GoogleChatApprovalCardBinding>();
-const approvalCardResolvingTokens = new Set<string>();
-const GOOGLECHAT_APPROVAL_CARD_BINDING_MAX_ENTRIES = 1024;
+export const googleChatApprovalControls =
+  createNativeApprovalControlRegistry<GoogleChatApprovalCardBinding>({
+    releaseClaimOnLookupExpiry: false,
+    onComplete: (binding) =>
+      unregisterGoogleChatManualApprovalFollowupSuppression(binding.approvalId),
+  });
 const GOOGLECHAT_MANUAL_APPROVAL_SUPPRESSION_MAX_ENTRIES = 1024;
 
 type GoogleChatManualApprovalSuppressionPayload = {
@@ -49,19 +52,10 @@ type GoogleChatManualApprovalFollowupSuppression = {
   expiresAtMs: number;
 };
 
-type GoogleChatApprovalCardClaim =
-  | { kind: "claimed"; binding: GoogleChatApprovalCardBinding }
-  | { kind: "missing" }
-  | { kind: "in-flight" };
-
 const manualApprovalFollowupSuppressions = new Map<
   string,
   GoogleChatManualApprovalFollowupSuppression
 >();
-
-export function createGoogleChatApprovalToken(): string {
-  return crypto.randomBytes(18).toString("base64url");
-}
 
 export function buildGoogleChatApprovalActionParameters(
   token: string,
@@ -114,14 +108,9 @@ export function readGoogleChatApprovalActionToken(event: GoogleChatEvent): strin
 export function registerGoogleChatApprovalCardBinding(
   binding: GoogleChatApprovalCardBinding,
 ): boolean {
-  if (binding.expiresAtMs <= Date.now()) {
+  if (!googleChatApprovalControls.register(binding)) {
     return false;
   }
-  if (approvalCardBindings.has(binding.token)) {
-    approvalCardBindings.delete(binding.token);
-  }
-  approvalCardBindings.set(binding.token, binding);
-  pruneMapToMaxSize(approvalCardBindings, GOOGLECHAT_APPROVAL_CARD_BINDING_MAX_ENTRIES);
   registerGoogleChatManualApprovalFollowupSuppression({
     approvalId: binding.approvalId,
     approvalKind: binding.approvalKind,
@@ -129,20 +118,6 @@ export function registerGoogleChatApprovalCardBinding(
     expiresAtMs: binding.expiresAtMs,
   });
   return true;
-}
-
-export function getGoogleChatApprovalCardBinding(
-  token: string,
-): GoogleChatApprovalCardBinding | null {
-  const binding = approvalCardBindings.get(token);
-  if (!binding) {
-    return null;
-  }
-  if (binding.expiresAtMs <= Date.now()) {
-    approvalCardBindings.delete(token);
-    return null;
-  }
-  return binding;
 }
 
 function normalizeApprovalRef(value: string): string | null {
@@ -195,12 +170,7 @@ function approvalRefMatches(bindingApprovalId: string, approvalRef: string): boo
 }
 
 function pruneExpiredGoogleChatApprovalCardBindings(nowMs: number): void {
-  for (const [token, binding] of approvalCardBindings) {
-    if (binding.expiresAtMs <= nowMs) {
-      approvalCardBindings.delete(token);
-      approvalCardResolvingTokens.delete(token);
-    }
-  }
+  googleChatApprovalControls.pruneExpired(nowMs);
   for (const [approvalId, suppression] of manualApprovalFollowupSuppressions) {
     if (suppression.expiresAtMs <= nowMs) {
       manualApprovalFollowupSuppressions.delete(approvalId);
@@ -214,7 +184,7 @@ function hasActiveGoogleChatExecApprovalCardForManualCommand(params: {
   nowMs: number;
 }): boolean {
   pruneExpiredGoogleChatApprovalCardBindings(params.nowMs);
-  for (const binding of approvalCardBindings.values()) {
+  for (const binding of googleChatApprovalControls.values()) {
     if (
       binding.approvalKind === "exec" &&
       binding.allowedDecisions.includes(params.decision) &&
@@ -277,40 +247,4 @@ export function shouldSuppressGoogleChatManualExecApprovalFollowupPayload(
     return false;
   }
   return shouldSuppressGoogleChatManualExecApprovalFollowupText(text, nowMs);
-}
-
-export function claimGoogleChatApprovalCardBinding(token: string): GoogleChatApprovalCardClaim {
-  const binding = getGoogleChatApprovalCardBinding(token);
-  if (!binding) {
-    return { kind: "missing" };
-  }
-  if (approvalCardResolvingTokens.has(token)) {
-    return { kind: "in-flight" };
-  }
-  approvalCardResolvingTokens.add(token);
-  return { kind: "claimed", binding };
-}
-
-export function completeGoogleChatApprovalCardBinding(token: string): void {
-  const binding = approvalCardBindings.get(token);
-  approvalCardResolvingTokens.delete(token);
-  approvalCardBindings.delete(token);
-  if (binding) {
-    unregisterGoogleChatManualApprovalFollowupSuppression(binding.approvalId);
-  }
-}
-
-export function releaseGoogleChatApprovalCardBinding(token: string): void {
-  approvalCardResolvingTokens.delete(token);
-}
-
-export function unregisterGoogleChatApprovalCardBindings(tokens: readonly string[]): void {
-  for (const token of tokens) {
-    const binding = approvalCardBindings.get(token);
-    approvalCardBindings.delete(token);
-    approvalCardResolvingTokens.delete(token);
-    if (binding) {
-      unregisterGoogleChatManualApprovalFollowupSuppression(binding.approvalId);
-    }
-  }
 }

--- a/extensions/googlechat/src/approval-card-click.test.ts
+++ b/extensions/googlechat/src/approval-card-click.test.ts
@@ -1,11 +1,12 @@
 import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildGoogleChatApprovalActionParameters,
-  getGoogleChatApprovalCardBinding,
+  googleChatApprovalControls,
   registerGoogleChatApprovalCardBinding,
-  unregisterGoogleChatApprovalCardBindings,
+  shouldSuppressGoogleChatManualExecApprovalFollowupText,
 } from "./approval-card-actions.js";
 import { maybeHandleGoogleChatApprovalCardClick } from "./approval-card-click.js";
 import type { WebhookTarget } from "./monitor-types.js";
@@ -125,11 +126,12 @@ describe("maybeHandleGoogleChatApprovalCardClick", () => {
   });
 
   afterEach(() => {
-    unregisterGoogleChatApprovalCardBindings([
+    googleChatApprovalControls.unregister([
       "token-1",
       "token-2",
       "token-addon",
       "token-common",
+      "token-in-flight",
       "token-loser",
       "token-retry",
       "token-stale-direct",
@@ -415,7 +417,7 @@ describe("maybeHandleGoogleChatApprovalCardClick", () => {
 
     await expect(maybeHandleGoogleChatApprovalCardClick({ event, target })).resolves.toBe(true);
 
-    expect(getGoogleChatApprovalCardBinding(token)).toBeNull();
+    expect(googleChatApprovalControls.get(token)).toBeNull();
     expect(target.runtime.log).toHaveBeenCalledWith(
       expect.stringContaining("approval expired or no longer exists"),
     );
@@ -468,6 +470,53 @@ describe("maybeHandleGoogleChatApprovalCardClick", () => {
     expect(cardJson).toContain("Already resolved");
     expect(cardJson).not.toContain("Exec Approval: Denied");
     expect(cardJson).not.toContain("buttonList");
+  });
+
+  it("keeps concurrent clicks blocked until the terminal card update completes", async () => {
+    const token = "token-in-flight";
+    registerGoogleChatApprovalCardBinding({
+      token,
+      accountId: "default",
+      approvalId: "approval-in-flight",
+      approvalKind: "exec",
+      decision: "allow-once",
+      allowedDecisions: ["allow-once", "deny"],
+      spaceName: "spaces/AAA",
+      messageName: "spaces/AAA/messages/msg-1",
+      expiresAtMs: Date.now() + 60_000,
+    });
+    const updateStarted = createDeferred<void>();
+    const finishUpdate = createDeferred<void>();
+    updateGoogleChatMessage.mockImplementationOnce(async () => {
+      updateStarted.resolve();
+      await finishUpdate.promise;
+      return { messageName: "spaces/AAA/messages/msg-1" };
+    });
+    const target = createTarget();
+    const event = createCardClickEvent(token);
+    const first = maybeHandleGoogleChatApprovalCardClick({ event, target });
+
+    try {
+      await updateStarted.promise;
+      expect(googleChatApprovalControls.get(token)).not.toBeNull();
+      expect(
+        shouldSuppressGoogleChatManualExecApprovalFollowupText(
+          "/approve approval-in-flight allow-once",
+        ),
+      ).toBe(true);
+      await expect(maybeHandleGoogleChatApprovalCardClick({ event, target })).resolves.toBe(true);
+      expect(resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
+      expect(updateGoogleChatMessage).toHaveBeenCalledTimes(1);
+    } finally {
+      finishUpdate.resolve();
+      await expect(first).resolves.toBe(true);
+    }
+    expect(googleChatApprovalControls.get(token)).toBeNull();
+    expect(
+      shouldSuppressGoogleChatManualExecApprovalFollowupText(
+        "/approve approval-in-flight allow-once",
+      ),
+    ).toBe(false);
   });
 
   it("keeps the token retryable when the canonical card update fails", async () => {

--- a/extensions/googlechat/src/approval-card-click.ts
+++ b/extensions/googlechat/src/approval-card-click.ts
@@ -1,15 +1,8 @@
-import {
-  resolveApprovalOverGateway,
-  type ApprovalResolveResult,
-} from "openclaw/plugin-sdk/approval-gateway-runtime";
-import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
+import { resolveApprovalOverGateway } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import { updateGoogleChatMessage } from "./api.js";
 import { googleChatApprovalAuth } from "./approval-auth.js";
 import {
-  claimGoogleChatApprovalCardBinding,
-  completeGoogleChatApprovalCardBinding,
-  getGoogleChatApprovalCardBinding,
-  releaseGoogleChatApprovalCardBinding,
+  googleChatApprovalControls,
   readGoogleChatApprovalActionToken,
 } from "./approval-card-actions.js";
 import { buildGoogleChatCanonicalApprovalTerminalCards } from "./approval-terminal-card.js";
@@ -33,7 +26,7 @@ export async function maybeHandleGoogleChatApprovalCardClick(params: {
     return false;
   }
 
-  const binding = getGoogleChatApprovalCardBinding(token);
+  const binding = googleChatApprovalControls.get(token);
   if (!binding) {
     logIgnored(params.target, "unknown or expired card token");
     return true;
@@ -68,20 +61,8 @@ export async function maybeHandleGoogleChatApprovalCardClick(params: {
     return true;
   }
 
-  const claim = claimGoogleChatApprovalCardBinding(token);
-  if (claim.kind === "missing") {
-    logIgnored(params.target, "card token already consumed");
-    return true;
-  }
-  if (claim.kind === "in-flight") {
-    logIgnored(params.target, "card token resolve already in flight");
-    return true;
-  }
-  const consumed = claim.binding;
-
-  let result: ApprovalResolveResult;
-  try {
-    result = await resolveApprovalOverGateway({
+  const outcome = await googleChatApprovalControls.settle(token, async (consumed) => {
+    const result = await resolveApprovalOverGateway({
       cfg: params.target.config,
       approvalId: consumed.approvalId,
       approvalKind: consumed.approvalKind,
@@ -95,21 +76,24 @@ export async function maybeHandleGoogleChatApprovalCardClick(params: {
       messageName: consumed.messageName,
       cardsV2: buildGoogleChatCanonicalApprovalTerminalCards(result),
     });
-  } catch (error) {
-    if (isApprovalNotFoundError(error)) {
-      // Missing approvals cannot recover; retire the card instead of rearming its token.
-      completeGoogleChatApprovalCardBinding(token);
-      logIgnored(params.target, `approval expired or no longer exists id=${consumed.approvalId}`);
-      return true;
-    }
-    releaseGoogleChatApprovalCardBinding(token);
-    throw error;
+    return result;
+  });
+  if (outcome.kind !== "settled") {
+    logIgnored(
+      params.target,
+      outcome.kind === "missing"
+        ? "card token already consumed"
+        : outcome.kind === "in-flight"
+          ? "card token resolve already in flight"
+          : `approval expired or no longer exists id=${outcome.binding.approvalId}`,
+    );
+    return true;
   }
-  completeGoogleChatApprovalCardBinding(token);
-  const outcome = result.applied ? "resolved" : "already resolved";
+  const { binding: consumed, result } = outcome;
+  const label = result.applied ? "resolved" : "already resolved";
   const decision = "decision" in result.approval ? result.approval.decision : "none";
   params.target.runtime.log?.(
-    `[${params.target.account.accountId}] googlechat approval ${outcome} id=${consumed.approvalId} status=${result.approval.status} decision=${decision} sender=${actor || "unknown"}`,
+    `[${params.target.account.accountId}] googlechat approval ${label} id=${consumed.approvalId} status=${result.approval.status} decision=${decision} sender=${actor || "unknown"}`,
   );
   return true;
 }

--- a/extensions/googlechat/src/approval-handler.runtime.ts
+++ b/extensions/googlechat/src/approval-handler.runtime.ts
@@ -18,12 +18,11 @@ import { resolveGoogleChatAccount, type ResolvedGoogleChatAccount } from "./acco
 import { sendGoogleChatMessage, updateGoogleChatMessage } from "./api.js";
 import {
   buildGoogleChatApprovalActionParameters,
-  createGoogleChatApprovalToken,
+  googleChatApprovalControls,
   GOOGLECHAT_APPROVAL_ACTION,
   registerGoogleChatApprovalCardBinding,
   registerGoogleChatManualApprovalFollowupSuppression,
   unregisterGoogleChatManualApprovalFollowupSuppression,
-  unregisterGoogleChatApprovalCardBindings,
 } from "./approval-card-actions.js";
 import { escapeGoogleChatApprovalCardText as escapeGoogleChatText } from "./approval-card-text.js";
 import {
@@ -190,7 +189,7 @@ function buildActionSection(params: { actionFunction: string; view: PendingAppro
 } {
   const { actionFunction, view } = params;
   const actionTokens = view.actions.map((action) => ({
-    token: createGoogleChatApprovalToken(),
+    token: googleChatApprovalControls.createToken(),
     decision: action.decision,
   }));
   return {
@@ -423,10 +422,10 @@ export const googleChatApprovalNativeRuntime = createChannelApprovalNativeRuntim
       return tokens.length > 0 ? tokens : null;
     },
     unbindPending: ({ binding }) => {
-      unregisterGoogleChatApprovalCardBindings(binding);
+      googleChatApprovalControls.unregister(binding);
     },
     cancelDelivered: ({ entry }) => {
-      unregisterGoogleChatApprovalCardBindings(
+      googleChatApprovalControls.unregister(
         entry.actionTokens.map((actionToken) => actionToken.token),
       );
     },

--- a/extensions/googlechat/src/channel-config.test.ts
+++ b/extensions/googlechat/src/channel-config.test.ts
@@ -6,14 +6,14 @@ import { afterEach, describe, expect, it } from "vitest";
 import { inspectGoogleChatAccount } from "./accounts.js";
 import {
   registerGoogleChatApprovalCardBinding,
-  unregisterGoogleChatApprovalCardBindings,
+  googleChatApprovalControls,
 } from "./approval-card-actions.js";
 import { googlechatPlugin } from "./channel.js";
 import { googlechatSetupPlugin } from "./channel.setup.js";
 
 describe("googlechatPlugin config adapter", () => {
   afterEach(() => {
-    unregisterGoogleChatApprovalCardBindings(["token-1"]);
+    googleChatApprovalControls.unregister(["token-1"]);
   });
 
   it.each([

--- a/extensions/msteams/src/approval-card-actions.ts
+++ b/extensions/msteams/src/approval-card-actions.ts
@@ -1,7 +1,6 @@
-import crypto from "node:crypto";
 import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
+import { createNativeApprovalControlRegistry } from "openclaw/plugin-sdk/approval-native-runtime";
 import type { ExecApprovalDecision } from "openclaw/plugin-sdk/approval-runtime";
-import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import {
   isRecord,
   normalizeOptionalLowercaseString,
@@ -20,18 +19,10 @@ export type MSTeamsApprovalCardBinding = {
   expiresAtMs: number;
 };
 
-type MSTeamsApprovalCardClaim =
-  | { kind: "claimed"; binding: MSTeamsApprovalCardBinding }
-  | { kind: "missing" }
-  | { kind: "in-flight" };
-
-const approvalCardBindings = new Map<string, MSTeamsApprovalCardBinding>();
-const approvalCardResolvingTokens = new Set<string>();
-const MSTEAMS_APPROVAL_CARD_BINDING_MAX_ENTRIES = 1024;
-
-export function createMSTeamsApprovalToken(): string {
-  return crypto.randomBytes(18).toString("base64url");
-}
+export const msTeamsApprovalControls =
+  createNativeApprovalControlRegistry<MSTeamsApprovalCardBinding>({
+    releaseClaimOnLookupExpiry: true,
+  });
 
 export function readMSTeamsApprovalActionToken(value: unknown): string | null {
   if (!isRecord(value)) {
@@ -48,55 +39,4 @@ export function readMSTeamsApprovalActionToken(value: unknown): string | null {
     return null;
   }
   return normalizeOptionalString(submitted.token) ?? null;
-}
-
-export function registerMSTeamsApprovalCardBinding(binding: MSTeamsApprovalCardBinding): boolean {
-  if (binding.expiresAtMs <= Date.now()) {
-    return false;
-  }
-  approvalCardBindings.delete(binding.token);
-  approvalCardBindings.set(binding.token, binding);
-  pruneMapToMaxSize(approvalCardBindings, MSTEAMS_APPROVAL_CARD_BINDING_MAX_ENTRIES);
-  return true;
-}
-
-export function getMSTeamsApprovalCardBinding(token: string): MSTeamsApprovalCardBinding | null {
-  const binding = approvalCardBindings.get(token);
-  if (!binding) {
-    return null;
-  }
-  if (binding.expiresAtMs <= Date.now()) {
-    approvalCardBindings.delete(token);
-    approvalCardResolvingTokens.delete(token);
-    return null;
-  }
-  return binding;
-}
-
-export function claimMSTeamsApprovalCardBinding(token: string): MSTeamsApprovalCardClaim {
-  const binding = getMSTeamsApprovalCardBinding(token);
-  if (!binding) {
-    return { kind: "missing" };
-  }
-  if (approvalCardResolvingTokens.has(token)) {
-    return { kind: "in-flight" };
-  }
-  // Keep the claim until resolution completes or fails so concurrent submits cannot resolve twice.
-  approvalCardResolvingTokens.add(token);
-  return { kind: "claimed", binding };
-}
-
-export function completeMSTeamsApprovalCardBinding(token: string): void {
-  approvalCardResolvingTokens.delete(token);
-  approvalCardBindings.delete(token);
-}
-
-export function releaseMSTeamsApprovalCardBinding(token: string): void {
-  approvalCardResolvingTokens.delete(token);
-}
-
-export function unregisterMSTeamsApprovalCardBindings(tokens: readonly string[]): void {
-  for (const token of tokens) {
-    completeMSTeamsApprovalCardBinding(token);
-  }
 }

--- a/extensions/msteams/src/approval-card-actions.ts
+++ b/extensions/msteams/src/approval-card-actions.ts
@@ -1,6 +1,8 @@
 import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
-import { createNativeApprovalControlRegistry } from "openclaw/plugin-sdk/approval-native-runtime";
-import type { ExecApprovalDecision } from "openclaw/plugin-sdk/approval-runtime";
+import {
+  createNativeApprovalControlRegistry,
+  type ExecApprovalDecision,
+} from "openclaw/plugin-sdk/approval-runtime";
 import {
   isRecord,
   normalizeOptionalLowercaseString,

--- a/extensions/msteams/src/approval-card-submit.test.ts
+++ b/extensions/msteams/src/approval-card-submit.test.ts
@@ -3,11 +3,7 @@ import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-r
 import type { ExecApprovalDecision } from "openclaw/plugin-sdk/approval-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  getMSTeamsApprovalCardBinding,
-  registerMSTeamsApprovalCardBinding,
-  unregisterMSTeamsApprovalCardBindings,
-} from "./approval-card-actions.js";
+import { msTeamsApprovalControls } from "./approval-card-actions.js";
 import { maybeHandleMSTeamsApprovalCardSubmit } from "./approval-card-submit.js";
 import { createMSTeamsMessageHandlerDeps } from "./monitor-handler.test-helpers.js";
 import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
@@ -112,7 +108,7 @@ function registerBinding(params: {
   conversationId?: string;
 }): void {
   testTokens.add(params.token);
-  registerMSTeamsApprovalCardBinding({
+  msTeamsApprovalControls.register({
     token: params.token,
     accountId: params.accountId ?? "default",
     approvalId: `approval-${params.token}`,
@@ -139,7 +135,7 @@ describe("maybeHandleMSTeamsApprovalCardSubmit", () => {
   });
 
   afterEach(() => {
-    unregisterMSTeamsApprovalCardBindings(Array.from(testTokens));
+    msTeamsApprovalControls.unregister(Array.from(testTokens));
     testTokens.clear();
   });
 
@@ -200,7 +196,7 @@ describe("maybeHandleMSTeamsApprovalCardSubmit", () => {
     ).resolves.toBe(true);
 
     expect(resolveApprovalOverGateway).not.toHaveBeenCalled();
-    expect(getMSTeamsApprovalCardBinding(token)).not.toBeNull();
+    expect(msTeamsApprovalControls.get(token)).not.toBeNull();
   });
 
   it("requires an allowlisted AAD identity and preserves tokens for the authorized approver", async () => {
@@ -243,7 +239,7 @@ describe("maybeHandleMSTeamsApprovalCardSubmit", () => {
     expect(JSON.stringify(vi.mocked(authorizedContext.updateActivity).mock.calls[0])).toContain(
       "Denied",
     );
-    expect(getMSTeamsApprovalCardBinding(token)).toBeNull();
+    expect(msTeamsApprovalControls.get(token)).toBeNull();
   });
 
   it("normalizes Teams conversation message suffixes before matching their card", async () => {
@@ -299,9 +295,12 @@ describe("maybeHandleMSTeamsApprovalCardSubmit", () => {
     expect(resolveApprovalOverGateway).toHaveBeenCalledTimes(2);
   });
 
-  it("releases the token when the terminal card update fails", async () => {
+  it("retries a failed terminal card update with the canonical winning decision", async () => {
     const token = "update-retry";
     registerBinding({ token });
+    resolveApprovalOverGateway.mockResolvedValue(
+      createResolution({ approvalId: `approval-${token}`, decision: "deny", applied: false }),
+    );
     const failedContext = createContext({ token });
     vi.mocked(failedContext.updateActivity).mockRejectedValueOnce(new Error("update failed"));
     const deps = createDeps();
@@ -309,11 +308,17 @@ describe("maybeHandleMSTeamsApprovalCardSubmit", () => {
     await expect(
       maybeHandleMSTeamsApprovalCardSubmit({ context: failedContext, deps }),
     ).rejects.toThrow("update failed");
+    const retriedContext = createContext({ token });
     await expect(
-      maybeHandleMSTeamsApprovalCardSubmit({ context: createContext({ token }), deps }),
+      maybeHandleMSTeamsApprovalCardSubmit({ context: retriedContext, deps }),
     ).resolves.toBe(true);
 
     expect(resolveApprovalOverGateway).toHaveBeenCalledTimes(2);
+    const cardJson = JSON.stringify(vi.mocked(retriedContext.updateActivity).mock.calls[0]?.[0]);
+    expect(cardJson).toContain("Exec Approval: Denied");
+    expect(cardJson).toContain("Already resolved");
+    expect(cardJson).not.toContain("Exec Approval: Allowed once");
+    expect(msTeamsApprovalControls.get(token)).toBeNull();
   });
 
   it("retires permanently missing approvals and ignores subsequent clicks", async () => {
@@ -328,7 +333,7 @@ describe("maybeHandleMSTeamsApprovalCardSubmit", () => {
     const context = createContext({ token });
 
     await expect(maybeHandleMSTeamsApprovalCardSubmit({ context, deps })).resolves.toBe(true);
-    expect(getMSTeamsApprovalCardBinding(token)).toBeNull();
+    expect(msTeamsApprovalControls.get(token)).toBeNull();
     expect(context.updateActivity).not.toHaveBeenCalled();
 
     await expect(maybeHandleMSTeamsApprovalCardSubmit({ context, deps })).resolves.toBe(true);

--- a/extensions/msteams/src/approval-card-submit.ts
+++ b/extensions/msteams/src/approval-card-submit.ts
@@ -1,17 +1,10 @@
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
-import {
-  resolveApprovalOverGateway,
-  type ApprovalResolveResult,
-} from "openclaw/plugin-sdk/approval-gateway-runtime";
-import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
+import { resolveApprovalOverGateway } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { msTeamsApprovalAuth } from "./approval-auth.js";
 import {
-  claimMSTeamsApprovalCardBinding,
-  completeMSTeamsApprovalCardBinding,
-  getMSTeamsApprovalCardBinding,
+  msTeamsApprovalControls,
   readMSTeamsApprovalActionToken,
-  releaseMSTeamsApprovalCardBinding,
 } from "./approval-card-actions.js";
 import { buildMSTeamsCanonicalApprovalTerminalCard } from "./approval-card.js";
 import { normalizeMSTeamsConversationId } from "./inbound.js";
@@ -45,7 +38,7 @@ export async function maybeHandleMSTeamsApprovalCardSubmit(params: {
     ignored("missing card token");
     return true;
   }
-  const binding = getMSTeamsApprovalCardBinding(token);
+  const binding = msTeamsApprovalControls.get(token);
   if (!binding) {
     ignored("unknown or expired card token");
     return true;
@@ -83,20 +76,8 @@ export async function maybeHandleMSTeamsApprovalCardSubmit(params: {
     return true;
   }
 
-  const claim = claimMSTeamsApprovalCardBinding(token);
-  if (claim.kind !== "claimed") {
-    ignored(
-      claim.kind === "in-flight"
-        ? "card token resolve already in flight"
-        : "card token already consumed",
-    );
-    return true;
-  }
-
-  const consumed = claim.binding;
-  let result: ApprovalResolveResult;
-  try {
-    result = await resolveApprovalOverGateway({
+  const outcome = await msTeamsApprovalControls.settle(token, async (consumed) => {
+    const result = await resolveApprovalOverGateway({
       cfg: deps.cfg,
       approvalId: consumed.approvalId,
       approvalKind: consumed.approvalKind,
@@ -115,18 +96,20 @@ export async function maybeHandleMSTeamsApprovalCardSubmit(params: {
         },
       ],
     });
-  } catch (error) {
-    if (isApprovalNotFoundError(error)) {
-      // Missing approvals cannot recover; retire the card instead of rearming its token.
-      completeMSTeamsApprovalCardBinding(token);
-      ignored(`approval expired or no longer exists id=${consumed.approvalId}`);
-      return true;
-    }
-    releaseMSTeamsApprovalCardBinding(token);
-    throw error;
+    return result;
+  });
+  if (outcome.kind !== "settled") {
+    ignored(
+      outcome.kind === "missing"
+        ? "card token already consumed"
+        : outcome.kind === "in-flight"
+          ? "card token resolve already in flight"
+          : `approval expired or no longer exists id=${outcome.binding.approvalId}`,
+    );
+    return true;
   }
 
-  completeMSTeamsApprovalCardBinding(token);
+  const { binding: consumed, result } = outcome;
   deps.log.info("msteams approval resolved", {
     approvalId: consumed.approvalId,
     approvalKind: consumed.approvalKind,

--- a/extensions/msteams/src/approval-card.ts
+++ b/extensions/msteams/src/approval-card.ts
@@ -12,7 +12,7 @@ import {
   type ExecApprovalDecision,
 } from "openclaw/plugin-sdk/approval-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { createMSTeamsApprovalToken } from "./approval-card-actions.js";
+import { msTeamsApprovalControls } from "./approval-card-actions.js";
 
 export type MSTeamsApprovalActionToken = {
   token: string;
@@ -102,7 +102,7 @@ export function buildMSTeamsPendingApprovalCard(params: {
         : "Exec";
   const actionTokens: MSTeamsApprovalActionToken[] = [];
   const actions = view.actions.map(({ decision, label }) => {
-    const token = createMSTeamsApprovalToken();
+    const token = msTeamsApprovalControls.createToken();
     actionTokens.push({ token, decision });
     return {
       type: "Action.Submit",

--- a/extensions/msteams/src/approval-handler.runtime.test.ts
+++ b/extensions/msteams/src/approval-handler.runtime.test.ts
@@ -11,10 +11,7 @@ import type {
 } from "openclaw/plugin-sdk/approval-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  getMSTeamsApprovalCardBinding,
-  unregisterMSTeamsApprovalCardBindings,
-} from "./approval-card-actions.js";
+import { msTeamsApprovalControls } from "./approval-card-actions.js";
 
 const sendAdaptiveCardMSTeams = vi.hoisted(() => vi.fn());
 const editAdaptiveCardMSTeams = vi.hoisted(() => vi.fn());
@@ -289,7 +286,7 @@ describe("msTeamsApprovalNativeRuntime", () => {
     }
     expect(binding).toHaveLength(2);
     for (const [index, token] of binding.entries()) {
-      expect(getMSTeamsApprovalCardBinding(token)).toEqual({
+      expect(msTeamsApprovalControls.get(token)).toEqual({
         token,
         accountId: "default",
         approvalId: "exec-approval-1",
@@ -351,7 +348,7 @@ describe("msTeamsApprovalNativeRuntime", () => {
       approvalKind: "exec",
     });
     for (const token of binding) {
-      expect(getMSTeamsApprovalCardBinding(token)).toBeNull();
+      expect(msTeamsApprovalControls.get(token)).toBeNull();
     }
   });
 
@@ -378,7 +375,7 @@ describe("msTeamsApprovalNativeRuntime", () => {
         }),
       ).resolves.toBeNull();
       for (const { token } of pendingPayload.actionTokens) {
-        expect(getMSTeamsApprovalCardBinding(token)).toBeNull();
+        expect(msTeamsApprovalControls.get(token)).toBeNull();
       }
     },
   );
@@ -449,8 +446,8 @@ describe("msTeamsApprovalNativeRuntime", () => {
       approvalKind: "plugin",
     });
     for (const token of binding) {
-      expect(getMSTeamsApprovalCardBinding(token)).toBeNull();
+      expect(msTeamsApprovalControls.get(token)).toBeNull();
     }
-    unregisterMSTeamsApprovalCardBindings(binding);
+    msTeamsApprovalControls.unregister(binding);
   });
 });

--- a/extensions/msteams/src/approval-handler.runtime.ts
+++ b/extensions/msteams/src/approval-handler.runtime.ts
@@ -2,10 +2,7 @@ import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import { createChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { buildChannelApprovalNativeTargetKey } from "openclaw/plugin-sdk/approval-native-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
-import {
-  registerMSTeamsApprovalCardBinding,
-  unregisterMSTeamsApprovalCardBindings,
-} from "./approval-card-actions.js";
+import { msTeamsApprovalControls } from "./approval-card-actions.js";
 import {
   buildMSTeamsExpiredApprovalCard,
   buildMSTeamsPendingApprovalCard,
@@ -107,7 +104,7 @@ export const msTeamsApprovalNativeRuntime = createChannelApprovalNativeRuntimeAd
       const tokens: string[] = [];
       for (const actionToken of entry.actionTokens) {
         if (
-          registerMSTeamsApprovalCardBinding({
+          msTeamsApprovalControls.register({
             token: actionToken.token,
             accountId: entry.accountId,
             approvalId: request.id,
@@ -124,9 +121,9 @@ export const msTeamsApprovalNativeRuntime = createChannelApprovalNativeRuntimeAd
       }
       return tokens.length > 0 ? tokens : null;
     },
-    unbindPending: ({ binding }) => unregisterMSTeamsApprovalCardBindings(binding),
+    unbindPending: ({ binding }) => msTeamsApprovalControls.unregister(binding),
     cancelDelivered: ({ entry }) =>
-      unregisterMSTeamsApprovalCardBindings(entry.actionTokens.map(({ token }) => token)),
+      msTeamsApprovalControls.unregister(entry.actionTokens.map(({ token }) => token)),
   },
   observe: {
     onDeliveryError: ({ cfg, error, plannedTarget, request, approvalKind, pendingPayload }) => {

--- a/src/plugin-sdk/approval-native-controls.test.ts
+++ b/src/plugin-sdk/approval-native-controls.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createNativeApprovalControlRegistry } from "./approval-native-controls.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("native approval controls", () => {
+  it.each([
+    { releaseClaimOnLookupExpiry: false, expiry: "lookup", next: "in-flight" },
+    { releaseClaimOnLookupExpiry: true, expiry: "lookup", next: "settled" },
+    { releaseClaimOnLookupExpiry: false, expiry: "sweep", next: "settled" },
+  ] as const)(
+    "preserves claim cleanup for $expiry with releaseClaimOnLookupExpiry=$releaseClaimOnLookupExpiry",
+    async ({ releaseClaimOnLookupExpiry, expiry, next }) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000);
+      const controls = createNativeApprovalControlRegistry({ releaseClaimOnLookupExpiry });
+      const finish = Promise.withResolvers<void>();
+      controls.register({ token: "rebound", expiresAtMs: 2_000 });
+      const pending = controls.settle("rebound", () => finish.promise);
+      try {
+        vi.setSystemTime(2_000);
+        if (expiry === "sweep") {
+          controls.pruneExpired(2_000);
+        } else {
+          expect(controls.get("rebound")).toBeNull();
+        }
+        controls.register({ token: "rebound", expiresAtMs: 3_000 });
+        const result = await controls.settle("rebound", async () => "replacement");
+        expect(result.kind).toBe(next);
+      } finally {
+        finish.resolve();
+        await pending;
+      }
+    },
+  );
+
+  it("keeps plugin registries independent even when tokens coincide", async () => {
+    type Binding = { token: string; expiresAtMs: number; approvalId: string };
+    const first = createNativeApprovalControlRegistry<Binding>({
+      releaseClaimOnLookupExpiry: true,
+    });
+    const second = createNativeApprovalControlRegistry<Binding>({
+      releaseClaimOnLookupExpiry: false,
+    });
+    const binding = { token: "same-token", expiresAtMs: Date.now() + 60_000 };
+    first.register({ ...binding, approvalId: "first" });
+    second.register({ ...binding, approvalId: "second" });
+
+    await expect(
+      first.settle(binding.token, async (entry) => entry.approvalId),
+    ).resolves.toMatchObject({
+      kind: "settled",
+      result: "first",
+    });
+    expect(second.get(binding.token)?.approvalId).toBe("second");
+    await expect(
+      second.settle(binding.token, async (entry) => entry.approvalId),
+    ).resolves.toMatchObject({
+      kind: "settled",
+      result: "second",
+    });
+  });
+});

--- a/src/plugin-sdk/approval-native-controls.test.ts
+++ b/src/plugin-sdk/approval-native-controls.test.ts
@@ -17,7 +17,7 @@ describe("native approval controls", () => {
       vi.useFakeTimers();
       vi.setSystemTime(1_000);
       const controls = createNativeApprovalControlRegistry({ releaseClaimOnLookupExpiry });
-      const finish = createDeferred<void>();
+      const finish = createDeferred();
       controls.register({ token: "rebound", expiresAtMs: 2_000 });
       const pending = controls.settle("rebound", () => finish.promise);
       try {

--- a/src/plugin-sdk/approval-native-controls.test.ts
+++ b/src/plugin-sdk/approval-native-controls.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createNativeApprovalControlRegistry } from "./approval-native-controls.js";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { createNativeApprovalControlRegistry } from "./approval-runtime.js";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -16,7 +17,7 @@ describe("native approval controls", () => {
       vi.useFakeTimers();
       vi.setSystemTime(1_000);
       const controls = createNativeApprovalControlRegistry({ releaseClaimOnLookupExpiry });
-      const finish = Promise.withResolvers<void>();
+      const finish = createDeferred<void>();
       controls.register({ token: "rebound", expiresAtMs: 2_000 });
       const pending = controls.settle("rebound", () => finish.promise);
       try {

--- a/src/plugin-sdk/approval-native-controls.ts
+++ b/src/plugin-sdk/approval-native-controls.ts
@@ -1,0 +1,97 @@
+import { randomBytes } from "node:crypto";
+import { isApprovalNotFoundError } from "../infra/approval-errors.js";
+import { pruneMapToMaxSize } from "../infra/map-size.js";
+
+type NativeApprovalBinding = { token: string; expiresAtMs: number };
+
+/** Own one plugin's process-local native controls through resolution and card updates. */
+export function createNativeApprovalControlRegistry<
+  TBinding extends NativeApprovalBinding,
+>(params: { releaseClaimOnLookupExpiry: boolean; onComplete?: (binding: TBinding) => void }) {
+  const bindings = new Map<string, TBinding>();
+  const resolving = new Set<string>();
+
+  const get = (token: string): TBinding | null => {
+    const binding = bindings.get(token);
+    if (!binding) {
+      return null;
+    }
+    if (binding.expiresAtMs <= Date.now()) {
+      bindings.delete(token);
+      if (params.releaseClaimOnLookupExpiry) {
+        resolving.delete(token);
+      }
+      return null;
+    }
+    return binding;
+  };
+  const complete = (token: string): void => {
+    const binding = bindings.get(token);
+    resolving.delete(token);
+    bindings.delete(token);
+    if (binding) {
+      params.onComplete?.(binding);
+    }
+  };
+
+  return {
+    createToken: () => randomBytes(18).toString("base64url"),
+    register(binding: TBinding): boolean {
+      if (binding.expiresAtMs <= Date.now()) {
+        return false;
+      }
+      bindings.delete(binding.token);
+      bindings.set(binding.token, binding);
+      // Eviction removes the binding while an awaited resolver still owns its claim.
+      pruneMapToMaxSize(bindings, 1024);
+      return true;
+    },
+    get,
+    values: () => bindings.values(),
+    pruneExpired(nowMs: number): void {
+      for (const [token, binding] of bindings) {
+        if (binding.expiresAtMs <= nowMs) {
+          bindings.delete(token);
+          resolving.delete(token);
+        }
+      }
+    },
+    unregister(tokens: readonly string[]): void {
+      for (const token of tokens) {
+        complete(token);
+      }
+    },
+    async settle<TResult>(
+      token: string,
+      resolveAndUpdate: (binding: TBinding) => Promise<TResult>,
+    ): Promise<
+      | { kind: "missing" }
+      | { kind: "in-flight" }
+      | { kind: "not-found"; binding: TBinding }
+      | { kind: "settled"; binding: TBinding; result: TResult }
+    > {
+      const binding = get(token);
+      if (!binding) {
+        return { kind: "missing" };
+      }
+      if (resolving.has(token)) {
+        return { kind: "in-flight" };
+      }
+      resolving.add(token);
+      let result: TResult;
+      try {
+        // The claim covers both Gateway resolution and the terminal card update.
+        result = await resolveAndUpdate(binding);
+      } catch (error) {
+        if (isApprovalNotFoundError(error)) {
+          complete(token);
+          return { kind: "not-found", binding };
+        }
+        resolving.delete(token);
+        throw error;
+      }
+      complete(token);
+      return { kind: "settled", binding, result };
+    },
+  };
+}

--- a/src/plugin-sdk/approval-native-helpers.ts
+++ b/src/plugin-sdk/approval-native-helpers.ts
@@ -50,30 +50,24 @@ type ApprovalResolverParams = {
   request: ApprovalRequest;
 };
 
-type ChannelApprovalForwardingEvaluatorParams = {
-  channel: string;
-  isTransportEnabled: (params: { cfg: OpenClawConfig; accountId?: string | null }) => boolean;
-  hasMatchingTarget: (params: {
-    cfg: OpenClawConfig;
-    config: ExecApprovalForwardingConfig;
-    accountId?: string | null;
-    target?: ChannelApprovalForwardTarget;
-  }) => boolean;
-  hasOriginOrSessionTarget: (params: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-    request: ApprovalRequest;
-  }) => boolean;
-};
-
-type ApprovalTransportChecker = ChannelApprovalForwardingEvaluatorParams["isTransportEnabled"];
+type ApprovalTransportChecker = (params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}) => boolean;
 type ApprovalForwardingModeResolver = (
   config: ExecApprovalForwardingConfig,
 ) => ExecApprovalForwardingMode;
-type ApprovalForwardingTargetMatcher =
-  ChannelApprovalForwardingEvaluatorParams["hasMatchingTarget"];
-type ApprovalOriginOrSessionTargetChecker =
-  ChannelApprovalForwardingEvaluatorParams["hasOriginOrSessionTarget"];
+type ApprovalForwardingTargetMatcher = (params: {
+  cfg: OpenClawConfig;
+  config: ExecApprovalForwardingConfig;
+  accountId?: string | null;
+  target?: ChannelApprovalForwardTarget;
+}) => boolean;
+type ApprovalOriginOrSessionTargetChecker = (params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  request: ApprovalRequest;
+}) => boolean;
 
 /** Inputs for checking whether one approval request can use session-native forwarding. */
 export type ChannelApprovalForwardingEligibilityParams = {
@@ -530,71 +524,6 @@ function isExplicitTargetApprovalEligibleViaForwarding(
     accountId: params.accountId,
     target: params.target,
   });
-}
-
-/** Build reusable forwarding gates for channels with custom target matching logic. */
-export function createChannelApprovalForwardingEvaluator(
-  params: ChannelApprovalForwardingEvaluatorParams,
-) {
-  const resolveForwardingMode = (config: ExecApprovalForwardingConfig) => config.mode ?? "session";
-
-  const isPotentialRoute = (input: ChannelApprovalPotentialRouteParams): boolean => {
-    return canApprovalPotentiallyRoute({
-      ...input,
-      isTransportEnabled: params.isTransportEnabled,
-      resolveMode: resolveForwardingMode,
-      hasMatchingTarget: params.hasMatchingTarget,
-    });
-  };
-
-  const isSessionEligible = (input: ChannelApprovalForwardingEligibilityParams): boolean => {
-    return isSessionApprovalEligibleViaForwarding({
-      ...input,
-      channel: params.channel,
-      isTransportEnabled: params.isTransportEnabled,
-      resolveMode: resolveForwardingMode,
-      hasOriginOrSessionTarget: params.hasOriginOrSessionTarget,
-    });
-  };
-
-  const isExplicitTargetEligible = (
-    input: ChannelApprovalExplicitTargetEligibilityParams,
-  ): boolean => {
-    return isExplicitTargetApprovalEligibleViaForwarding({
-      ...input,
-      isTransportEnabled: params.isTransportEnabled,
-      resolveMode: resolveForwardingMode,
-      hasMatchingTarget: params.hasMatchingTarget,
-    });
-  };
-
-  const canAnyPotentiallyRoute = (input: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-    nativeSessionOnly?: boolean;
-  }): boolean =>
-    isPotentialRoute({
-      ...input,
-      approvalKind: "exec",
-    }) ||
-    isPotentialRoute({
-      ...input,
-      approvalKind: "plugin",
-    });
-
-  const shouldHandleRequest = (input: ApprovalResolverParams): boolean =>
-    isSessionEligible({
-      ...input,
-      approvalKind: resolveApprovalKind(input.request, input.approvalKind),
-    });
-
-  return {
-    canAnyPotentiallyRoute,
-    isExplicitTargetEligible,
-    isPotentialRoute,
-    isSessionEligible,
-    shouldHandleRequest,
-  };
 }
 
 /** Create the standard route gates for native channel approval forwarding. */

--- a/src/plugin-sdk/approval-native-runtime.ts
+++ b/src/plugin-sdk/approval-native-runtime.ts
@@ -1,6 +1,7 @@
 /**
  * Runtime SDK subpath for native approval routing, target matching, and forwarding gates.
  */
+export { createNativeApprovalControlRegistry } from "./approval-native-controls.js";
 export {
   createChannelApprovalForwardingEvaluator,
   createChannelApproverDmTargetResolver,

--- a/src/plugin-sdk/approval-native-runtime.ts
+++ b/src/plugin-sdk/approval-native-runtime.ts
@@ -1,9 +1,7 @@
 /**
  * Runtime SDK subpath for native approval routing, target matching, and forwarding gates.
  */
-export { createNativeApprovalControlRegistry } from "./approval-native-controls.js";
 export {
-  createChannelApprovalForwardingEvaluator,
   createChannelApproverDmTargetResolver,
   createChannelNativeOriginTargetResolver,
   createNativeApprovalChannelRouteGates,

--- a/src/plugin-sdk/approval-runtime.ts
+++ b/src/plugin-sdk/approval-runtime.ts
@@ -76,3 +76,4 @@ export {
   formatApprovalDecisionLabel,
   formatChannelApprovalResolvedLabel,
 } from "./approval-terminal.js";
+export { createNativeApprovalControlRegistry } from "./approval-native-controls.js";


### PR DESCRIPTION
Related: #140645 and #140677.

## What Problem This Solves

Google Chat and Microsoft Teams duplicated native approval token registries and the claim/settle/release lifecycle. Concurrent clicks and failed terminal-card updates require that lifecycle to remain consistent while retaining each plugin's expiry policy.

## Why This Change Was Made

`createNativeApprovalControlRegistry`, exposed only through the existing `openclaw/plugin-sdk/approval-runtime` entrypoint, owns each plugin's independent in-memory bindings and claims. The 18-byte base64url tokens and 1,024-binding FIFO limit are unchanged. A claim covers Gateway resolution and terminal-card update; retryable failures release the claim while retaining the binding, and terminal/not-found results retire controls.

Google Chat keeps its lookup-expiry behavior and manual-followup suppression through its registration wrapper and completion callback. Teams keeps its distinct lookup-expiry claim release. Explicit sweeps clear claims, while eviction retains in-flight claims. Native event scope checks, actor authorization, card rendering, error propagation and Gateway first-answer authority remain with their existing owners.

The unused public `createChannelApprovalForwardingEvaluator` binding and implementation are retired to fund the single new registry export. Its shared routing predicates and public parameter types remain; equivalent direct private callback types replace the obsolete params record. Global and OpenClaw-org searches were fully paged and all matching import blobs inspected. The nine consuming matches belong to self-contained historical hosts with their own matching SDK implementation; no independent upstream consumer was found. No compatibility alias or SDK budget increase is introduced.

## User Impact

No user-visible behavior or appearance change. Approval decisions, authorization, retry behavior, expiry, persistence and configuration are unchanged.

## Evidence

Fresh validation is for `3d19045240de38ef22c327bfba72af58788536fb`, rebased onto main including #140645 and #140677. The original changes are preserved; docs, formatter imports, and SDK exports retain both earlier consolidations alongside this registry.

- `node scripts/run-vitest.mjs` with 48 concrete approval, registry, route-gate, Telegram handler, request-filter, and Google Chat configuration test files: **551 tests passed**. Coverage includes concurrent clicks, terminal-card-update failures, retry, expiry, authorization, suppression, and canonical-winner reporting.
- `node scripts/check-changed.mjs` passed ratchets, formatting, SDK checks, all core/plugin production and test types, declaration/deprecation guards, three zero-entry dead-export scans, and core lint. Local plugin lint reaches the documented nested-worktree declaration-boundary exception; exact-head hosted lint, types, and extension package-boundary checks passed.
- `pnpm build` passed in **6m16s**. `pnpm plugin-sdk:surface:check` passed with **4,445 public exports and 2,627 callables**, within unchanged budgets. The approved public replacement remains one addition on approval-runtime and one removal on approval-native-runtime.
- All nine isolated startup profiles passed with zero failures/timeouts. Command: `OPENCLAW_LOCAL_CHECK=0 node --import tsx scripts/profile-extension-memory.mts --extension <id> --skip-combined --concurrency 1`. IDs: discord, googlechat, imessage, matrix, msteams, signal, slack, telegram, whatsapp.
- Fresh final isolated Codex branch review: **zero actionable P0–P2 findings**. Production **+181/−314 = −133**; tests **+149/−33 = +116**.
- Exact-head CI and required `openclaw/ci-gate` passed: https://github.com/openclaw/openclaw/actions/runs/34123752872. No failed-job rerun was needed.

Live channel proof remains unavailable. The isolated mock-Gateway card handlers and registry tests cover the changed lifecycle boundary; they are not live transport proof.

## Maintainer-directed SDK replacement

The maintainer explicitly required a fixed SDK budget and retirement of at least as many public exports as this consolidation adds. The lane's public-contract rule authorizes removal with internal migration when the GitHub-wide and OpenClaw-org consumer check finds no external consumer, and requires a named compatibility re-export if one exists. The completed, fully paged audit found no independent consumer of this binding. This is an intentional import-level removal under that direction, not a claim that flat aggregate counts guarantee compatibility. Internal users are migrated and the retirement is documented. The bot's request for a new allocation conflicts with the explicit no-budget-increase decision; the requested build and startup evidence is now complete.

