### PR TITLE
refactor(ai): consolidate strict tool diagnostics

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1482,7 +1482,7 @@ packages/ai/src/transports/openai-responses-compact-request.ts	2
 packages/ai/src/transports/openai-responses-continuation.ts	2
 packages/ai/src/transports/openai-responses-contracts.ts	1
 packages/ai/src/transports/openai-responses-debug.ts	12
-packages/ai/src/transports/openai-responses-params-internal.ts	10
+packages/ai/src/transports/openai-responses-params-internal.ts	9
 packages/ai/src/transports/openai-responses-payload-policy.ts	3
 packages/ai/src/transports/openai-responses-prompt-observer-internal.ts	2
 packages/ai/src/transports/openai-responses-replay-internal.ts	11

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -1731,6 +1731,11 @@ fallback even with explicit `agentRuntime.id: "codex"`; see
       proxies such as vLLM
     - Do not force strict tool schemas or native-only headers
 
+    If a usable tool schema is incompatible with requested strict mode, the request uses
+    `strict: false`. Debug logs report the downgrade under `openai-transport`,
+    with a bounded sample of incompatible tools. Built-in and managed Responses
+    requests share duplicate suppression for the same model and schemas.
+
   </Accordion>
 </AccordionGroup>
 

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -669,9 +669,9 @@ function buildRequestBody(
   }
 
   if (context.tools) {
-    const converted = convertResponsesToolPayload(context.tools, { strict: null });
-    if (converted.tools.length > 0) {
-      body.tools = converted.tools;
+    const tools = convertResponsesToolPayload(context.tools, { strict: null });
+    if (tools.length > 0) {
+      body.tools = tools;
       body.tool_choice = "auto";
       body.parallel_tool_calls = true;
     }

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -146,7 +146,7 @@ describe("convertResponsesToolPayload", () => {
       },
     ] satisfies Tool[];
 
-    const converted = convertResponsesToolPayload(tools, { model: nativeOpenAIModel }).tools;
+    const converted = convertResponsesToolPayload(tools, { model: nativeOpenAIModel });
 
     expect(converted).toEqual([
       {
@@ -179,7 +179,7 @@ describe("convertResponsesToolPayload", () => {
         },
       ],
       { model: nativeOpenAIModel },
-    ).tools;
+    );
 
     const tool = expectResponsesFunctionTool(converted[0]);
     expect(tool.strict).toBe(false);
@@ -201,7 +201,7 @@ describe("convertResponsesToolPayload", () => {
         },
       ],
       { model: proxyOpenAIModel },
-    ).tools;
+    );
 
     const tool = expectResponsesFunctionTool(converted[0]);
     expect(tool).not.toHaveProperty("strict");
@@ -224,7 +224,7 @@ describe("convertResponsesToolPayload", () => {
     } satisfies Tool;
 
     expect(
-      convertResponsesToolPayload([zeta, alpha]).tools.map(
+      convertResponsesToolPayload([zeta, alpha]).map(
         (tool) => expectResponsesFunctionTool(tool).name,
       ),
     ).toEqual(["alpha", "zeta"]);
@@ -250,7 +250,7 @@ describe("convertResponsesToolPayload", () => {
         },
       ],
       { model: nativeOpenAIModel },
-    ).tools;
+    );
 
     expect(converted).toEqual([
       {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -200,9 +200,9 @@ export function applyCommonResponsesParams<TApi extends Api>(
   }
 
   if (context.tools) {
-    const converted = convertResponsesToolPayload(context.tools, { model });
-    if (converted.tools.length > 0) {
-      params.tools = converted.tools;
+    const tools = convertResponsesToolPayload(context.tools, { model });
+    if (tools.length > 0) {
+      params.tools = tools;
     }
   }
 

--- a/packages/ai/src/providers/openai-responses-tools.integration.test.ts
+++ b/packages/ai/src/providers/openai-responses-tools.integration.test.ts
@@ -9,12 +9,8 @@ import {
 import type { Context, Tool } from "../types.js";
 import { registerBuiltInApiProviders } from "./register-builtins.js";
 
-it.each(
-  (["provider", "transport"] as const).flatMap((entrypoint) =>
-    [true, false, undefined].map((strict) => ({ entrypoint, strict })),
-  ),
-)("serializes $entrypoint Responses tools with strict=$strict", async ({ entrypoint, strict }) => {
-  const server = await createResponsesLoopbackServer(() => [
+function completedResponseEvents() {
+  return [
     {
       type: "response.completed",
       response: {
@@ -32,7 +28,15 @@ it.each(
         usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
       },
     },
-  ]);
+  ];
+}
+
+it.each(
+  (["provider", "transport"] as const).flatMap((entrypoint) =>
+    [true, false, undefined].map((strict) => ({ entrypoint, strict })),
+  ),
+)("serializes $entrypoint Responses tools with strict=$strict", async ({ entrypoint, strict }) => {
+  const server = await createResponsesLoopbackServer(completedResponseEvents);
   configureAiTransportHost({ resolveOpenAIStrictToolSetting: () => strict });
   const parameters = Object.freeze({
     type: "object",
@@ -101,6 +105,69 @@ it.each(
     expect(descriptionReads).toBe(1);
     expect(tools.map((tool) => tool.name)).toEqual(["zeta", "alpha"]);
     expect(tools.every((tool) => tool.parameters === parameters)).toBe(true);
+  } finally {
+    configureAiTransportHost({});
+    await server.close();
+  }
+});
+
+it("reports one strict downgrade across Responses entrypoints without changing the wire schema", async () => {
+  const server = await createResponsesLoopbackServer(completedResponseEvents);
+  const diagnostics: Array<{ subsystem: string; message: string; data?: unknown }> = [];
+  configureAiTransportHost({
+    resolveOpenAIStrictToolSetting: () => true,
+    logDebug: (subsystem, build) => {
+      const entry = build();
+      if (entry?.message.includes("strict mode downgraded")) {
+        diagnostics.push({ subsystem, ...entry });
+      }
+    },
+  });
+  const model = { ...responsesLoopbackModel, id: "strict-diagnostic-loopback" };
+  const parameters = {
+    type: "object",
+    properties: { value: { type: "integer" } },
+    required: [],
+    additionalProperties: false,
+  };
+  const context: Context = {
+    messages: [{ role: "user", content: "hello", timestamp: 1 }],
+    tools: [{ name: "record_value", description: "Record", parameters }],
+  };
+  const options = { apiKey: "synthetic-key", cacheRetention: "none" as const };
+  try {
+    const runtime = createLlmRuntime();
+    registerBuiltInApiProviders(runtime.registry);
+    for (const stream of [
+      () => runtime.stream(model, context, options),
+      () => createOpenAIResponsesTransportStreamFn()(model, context, options),
+    ]) {
+      expect((await (await stream()).result()).stopReason).toBe("stop");
+    }
+    expect(server.requests.map((request) => request.tools)).toEqual(
+      Array.from({ length: 2 }, () => [
+        {
+          type: "function",
+          name: "record_value",
+          description: "Record",
+          parameters,
+          strict: false,
+        },
+      ]),
+    );
+    expect(diagnostics).toEqual([
+      {
+        subsystem: "openai-transport",
+        message: expect.stringContaining("OpenAI responses tool schema strict mode downgraded"),
+        data: expect.objectContaining({
+          transport: "responses",
+          provider: model.provider,
+          model: model.id,
+          incompatibleToolCount: 1,
+          sample: [expect.objectContaining({ tool: "record_value" })],
+        }),
+      },
+    ]);
   } finally {
     configureAiTransportHost({});
     await server.close();

--- a/packages/ai/src/providers/openai-responses-tools.ts
+++ b/packages/ai/src/providers/openai-responses-tools.ts
@@ -1,12 +1,11 @@
 // OpenAI Responses tool helpers convert runtime tools to Responses API schemas.
-import { createHash } from "node:crypto";
 import type { FunctionTool } from "openai/resources/responses/responses.js";
 import { getAiTransportHost } from "../host.js";
+import { resolveOpenAIStrictToolFlagWithDiagnostics } from "../transports/openai-transport-params.js";
 import type { Model, Tool } from "../types.js";
 import { sortPromptCacheToolsByName } from "../utils/prompt-cache-stability.js";
 import { projectOpenAITools, type OpenAIToolProjection } from "./openai-tool-projection.js";
 import {
-  findOpenAIStrictToolProjectionDiagnostics,
   normalizeOpenAIStrictToolParameters,
   resolveOpenAIProjectedToolsStrictToolFlag,
 } from "./openai-tool-schema.js";
@@ -27,35 +26,33 @@ type ResponsesFunctionTool = {
   strict?: boolean | null;
 };
 
-type ConvertedResponsesTools = {
-  projection: OpenAIToolProjection;
-  tools: FunctionTool[];
-};
-
-// Converts OpenClaw tool schemas to OpenAI Responses tools, including strict-mode compatibility.
-const LOG_SUBSYSTEM = "llm/openai-responses";
-const MAX_STRICT_TOOL_DOWNGRADE_DIAGNOSTIC_KEYS = 64;
-const loggedStrictToolDowngradeDiagnosticKeys = new Set<string>();
-
-/** Converts and returns the projection used to reconcile tool choices. */
+/** Projects direct provider descriptors before resolving their strict policy. */
 export function convertResponsesToolPayload(
   tools: Tool[],
   options?: ConvertResponsesToolsOptions,
-  resolveStrict?: (
-    projection: OpenAIToolProjection,
-    setting: boolean | null | undefined,
-  ) => boolean | undefined,
-): ConvertedResponsesTools {
+): FunctionTool[] {
   const projection = projectOpenAITools(tools);
-  const strict = resolveStrict
-    ? resolveStrict(projection, options?.strict)
-    : resolveResponsesStrictToolFlag(
-        projection,
-        resolveResponsesStrictToolSetting(options),
-        options?.model,
-      );
+  return convertProjectedResponsesTools(
+    projection,
+    resolveResponsesStrictToolSetting(options),
+    options?.model,
+  );
+}
+
+/** Uses caller-prepared facts without rereading descriptors or resolving host policy again. */
+export function convertProjectedResponsesTools(
+  projection: OpenAIToolProjection,
+  strictSetting: boolean | null | undefined,
+  model?: Model,
+): FunctionTool[] {
+  const strict = model
+    ? resolveOpenAIStrictToolFlagWithDiagnostics(projection, strictSetting, {
+        transport: "responses",
+        model,
+      })
+    : resolveOpenAIProjectedToolsStrictToolFlag(projection, strictSetting);
   // Sort tools before request construction so prompt-cache bytes stay deterministic.
-  const convertedTools = sortPromptCacheToolsByName(projection.tools).map((tool) => {
+  return sortPromptCacheToolsByName(projection.tools).map((tool) => {
     const result: ResponsesFunctionTool = {
       type: "function",
       name: tool.name,
@@ -63,7 +60,7 @@ export function convertResponsesToolPayload(
       parameters: normalizeOpenAIStrictToolParameters(
         tool.parameters,
         strict === true,
-        options?.model?.compat as OpenAIToolSchemaCompat,
+        model?.compat as OpenAIToolSchemaCompat,
       ),
     };
     if (strict !== undefined) {
@@ -72,7 +69,6 @@ export function convertResponsesToolPayload(
     // Compatible endpoints can require strict to be absent; the SDK declares it required.
     return result as FunctionTool;
   });
-  return { projection, tools: convertedTools };
 }
 
 function resolveResponsesStrictToolSetting(
@@ -88,65 +84,4 @@ function resolveResponsesStrictToolSetting(
     });
   }
   return false;
-}
-
-function resolveResponsesStrictToolFlag(
-  projection: OpenAIToolProjection,
-  strictSetting: boolean | null | undefined,
-  model: Model | undefined,
-): boolean | undefined {
-  const strict = resolveOpenAIProjectedToolsStrictToolFlag(projection, strictSetting);
-  if (strictSetting === true && strict === false && model) {
-    getAiTransportHost().logDebug(LOG_SUBSYSTEM, () => {
-      const diagnostics = findOpenAIStrictToolProjectionDiagnostics(projection);
-      if (!shouldLogStrictToolDowngradeDiagnostic(diagnostics, model)) {
-        return null;
-      }
-      const sample = diagnostics.slice(0, 5).map((entry) => ({
-        tool: entry.toolName ?? `tool[${entry.toolIndex}]`,
-        violations: entry.violations.slice(0, 8),
-      }));
-      return {
-        message:
-          `OpenAI responses tool schema strict mode downgraded to strict=false for ` +
-          `${model.provider ?? "unknown"}/${model.id ?? "unknown"} because ` +
-          `${diagnostics.length} tool schema(s) are not strict-compatible`,
-        data: {
-          provider: model.provider,
-          model: model.id,
-          incompatibleToolCount: diagnostics.length,
-          sample,
-        },
-      };
-    });
-  }
-  return strict;
-}
-
-function shouldLogStrictToolDowngradeDiagnostic(
-  diagnostics: ReturnType<typeof findOpenAIStrictToolProjectionDiagnostics>,
-  model: Model,
-): boolean {
-  // Strict downgrade diagnostics can repeat per turn; hash details and cap memory.
-  const key = createHash("sha256")
-    .update(
-      JSON.stringify({
-        provider: model.provider,
-        model: model.id,
-        diagnostics: diagnostics.map((entry) => ({
-          toolIndex: entry.toolIndex,
-          toolName: entry.toolName ?? null,
-          violations: entry.violations,
-        })),
-      }),
-    )
-    .digest("hex");
-  if (loggedStrictToolDowngradeDiagnosticKeys.has(key)) {
-    return false;
-  }
-  if (loggedStrictToolDowngradeDiagnosticKeys.size >= MAX_STRICT_TOOL_DOWNGRADE_DIAGNOSTIC_KEYS) {
-    loggedStrictToolDowngradeDiagnosticKeys.clear();
-  }
-  loggedStrictToolDowngradeDiagnosticKeys.add(key);
-  return true;
 }

--- a/packages/ai/src/transports/openai-responses-params-internal.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.ts
@@ -12,8 +12,11 @@ import {
   supportsOpenAITemperature,
   type OpenAIApiReasoningEffort,
 } from "../providers/openai-reasoning-effort.js";
-import { convertResponsesToolPayload } from "../providers/openai-responses-tools.js";
-import { reconcileOpenAIResponsesToolChoice } from "../providers/openai-tool-projection.js";
+import { convertProjectedResponsesTools } from "../providers/openai-responses-tools.js";
+import {
+  projectOpenAITools,
+  reconcileOpenAIResponsesToolChoice,
+} from "../providers/openai-tool-projection.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
 import { resolveOpenAIStrictToolSetting } from "./host-policy.js";
 import type { OpenAIResponsesReplayMode } from "./openai-responses-compaction-replay.js";
@@ -31,11 +34,7 @@ import {
   buildResponsesInputMessage,
   convertResponsesMessages,
 } from "./openai-responses-replay-internal.js";
-import {
-  getCompat,
-  resolveOpenAIStrictToolFlagWithDiagnostics,
-  usesNativeOpenAICodexResponsesBackend,
-} from "./openai-transport-params.js";
+import { getCompat, usesNativeOpenAICodexResponsesBackend } from "./openai-transport-params.js";
 import { resolvePromptCacheKey, type OpenAIModeModel } from "./openai-transport-shared.js";
 import { sanitizeTransportPayloadText } from "./transport-stream-shared.js";
 
@@ -300,31 +299,20 @@ export function buildOpenAIResponsesParams(
     params.service_tier = options.serviceTier;
   }
   if (context.tools) {
-    const converted = convertResponsesToolPayload(
-      context.tools,
-      {
-        model,
-        strict: resolveOpenAIStrictToolSetting(model as OpenAIModeModel, {
-          transport: "stream",
-        }),
-      },
-      (projection, setting) =>
-        resolveOpenAIStrictToolFlagWithDiagnostics(projection, setting, {
-          transport: "responses",
-          model: model as OpenAIModeModel,
-        }),
-    );
+    const tools = context.tools;
+    const strict = resolveOpenAIStrictToolSetting(model as OpenAIModeModel, {
+      transport: "stream",
+    });
+    const projection = projectOpenAITools(tools);
+    const converted = convertProjectedResponsesTools(projection, strict, model);
     if (
-      converted.tools.length > 0 ||
-      (converted.projection.inputToolCount === 0 && converted.projection.diagnostics.length === 0)
+      converted.length > 0 ||
+      (projection.inputToolCount === 0 && projection.diagnostics.length === 0)
     ) {
-      params.tools = converted.tools;
+      params.tools = converted;
     }
     if (options?.toolChoice) {
-      const toolChoice = reconcileOpenAIResponsesToolChoice(
-        options.toolChoice,
-        converted.projection,
-      );
+      const toolChoice = reconcileOpenAIResponsesToolChoice(options.toolChoice, projection);
       if (toolChoice !== undefined) {
         params.tool_choice = toolChoice;
       }

--- a/packages/ai/src/transports/openai-transport-params.ts
+++ b/packages/ai/src/transports/openai-transport-params.ts
@@ -237,42 +237,6 @@ export function assertCodeModeResponsesToolSurface(
   );
 }
 
-function buildOpenAIStrictToolDowngradeDiagnosticKey(
-  diagnostics: ReturnType<typeof findOpenAIStrictToolProjectionDiagnostics>,
-  context: { transport: "responses" | "completions"; model: OpenAIModeModel },
-): string {
-  return sha256Hex(
-    JSON.stringify({
-      transport: context.transport,
-      provider: context.model.provider ?? null,
-      model: context.model.id ?? null,
-      diagnostics: diagnostics.map((entry) => ({
-        toolIndex: entry.toolIndex,
-        toolName: entry.toolName ?? null,
-        violations: entry.violations,
-      })),
-    }),
-  );
-}
-
-function shouldLogOpenAIStrictToolDowngradeDiagnostic(
-  diagnostics: ReturnType<typeof findOpenAIStrictToolProjectionDiagnostics>,
-  context: { transport: "responses" | "completions"; model: OpenAIModeModel },
-): boolean {
-  const key = buildOpenAIStrictToolDowngradeDiagnosticKey(diagnostics, context);
-  if (loggedOpenAIStrictToolDowngradeDiagnosticKeys.has(key)) {
-    return false;
-  }
-  if (
-    loggedOpenAIStrictToolDowngradeDiagnosticKeys.size >=
-    MAX_OPENAI_STRICT_TOOL_DOWNGRADE_DIAGNOSTIC_KEYS
-  ) {
-    loggedOpenAIStrictToolDowngradeDiagnosticKeys.clear();
-  }
-  loggedOpenAIStrictToolDowngradeDiagnosticKeys.add(key);
-  return true;
-}
-
 export function resolveOpenAIStrictToolFlagWithDiagnostics(
   projection: OpenAIToolProjection,
   strictSetting: boolean | null | undefined,
@@ -280,11 +244,30 @@ export function resolveOpenAIStrictToolFlagWithDiagnostics(
 ): boolean | undefined {
   const strict = resolveOpenAIProjectedToolsStrictToolFlag(projection, strictSetting);
   if (strictSetting === true && strict === false) {
-    const diagnostics = findOpenAIStrictToolProjectionDiagnostics(projection);
     getAiTransportHost().logDebug("openai-transport", () => {
-      if (!shouldLogOpenAIStrictToolDowngradeDiagnostic(diagnostics, context)) {
+      const diagnostics = findOpenAIStrictToolProjectionDiagnostics(projection);
+      const key = sha256Hex(
+        JSON.stringify({
+          transport: context.transport,
+          provider: context.model.provider ?? null,
+          model: context.model.id ?? null,
+          diagnostics: diagnostics.map((entry) => ({
+            toolIndex: entry.toolIndex,
+            toolName: entry.toolName ?? null,
+            violations: entry.violations,
+          })),
+        }),
+      );
+      if (loggedOpenAIStrictToolDowngradeDiagnosticKeys.has(key)) {
         return null;
       }
+      if (
+        loggedOpenAIStrictToolDowngradeDiagnosticKeys.size >=
+        MAX_OPENAI_STRICT_TOOL_DOWNGRADE_DIAGNOSTIC_KEYS
+      ) {
+        loggedOpenAIStrictToolDowngradeDiagnosticKeys.clear();
+      }
+      loggedOpenAIStrictToolDowngradeDiagnosticKeys.add(key);
       const sample = diagnostics.slice(0, 5).map((entry) => ({
         tool: entry.toolName ?? `tool[${entry.toolIndex}]`,
         violations: entry.violations.slice(0, 8),


### PR DESCRIPTION
Closes #140692

Related: #140592

## What Problem This Solves

The same OpenAI Responses tool inventory can generate duplicate strict-downgrade warnings because built-in and managed requests keep separate diagnostic pipelines. Maintaining those pipelines also requires callback plumbing and duplicate cache/hash helpers.

## Why This Change Was Made

The existing OpenAI diagnostic helper now owns downgrade reporting and duplicate suppression. Responses assembly carries its prepared projection and strict setting directly into the serializer, eliminating the policy callback and unused result wrapper. Single-use diagnostic key/cache helpers are absorbed into their owner, and diagnostic traversal is deferred until debug logging requests it.

## User Impact

Strict-mode defaults, request bytes, ordering, tool choice, empty-tool behavior, and stream outcomes are preserved. Built-in Responses downgrade messages now use the existing openai-transport debug channel and shared 256-entry duplicate cache. No provider setting or public SDK export is added.

## Evidence

- The new cross-entrypoint diagnostic case fails on the baseline for duplicate warnings, then passes with two successful real SDK streams and unchanged wire schemas.
- 219 owner/sibling tests pass, including strict true/false/omitted, exact tool bytes, descriptor reads, caller-input preservation, Azure and ChatGPT tool behavior, SSE/cached WebSocket continuation, and hook failure/abort cases.
- Core compiler, formatting, diff whitespace check, and exact 10-to-9 assertion-ratchet shrink pass.
- Production: +67/-161, net -94. Tests: +79/-12, net +67. Docs: +5. Assertion baseline: +1/-1. No tests are removed.
- Independent P2 review: scoped-clean with no actionable findings. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34078802385) on `b4ecb9299511ea7648779d0f9e03e9f9cdec867c`, including full build/type/lint/boundary/test gates. ClawSweeper also completed its review without actionable findings. The full configured changed-code gate also passed on Blacksmith Testbox `tbx_01m1wxg8v92k7q8jzj128xc3hg` (wrapper exit 0; 14m47s command time), including core/test types, lint, guards, dead exports and zero runtime import cycles. The one-shot Testbox stopped after success; its backing Actions run is [34078713284](https://github.com/openclaw/openclaw/actions/runs/34078713284).

Runtime proof uses synthetic task-owned loopback endpoints and actual SDK streaming; no billable vendor requests or production sessions.
