### PR TITLE
fix(agents): keep tool schema ordering deterministic for prompt caching

### DIFF
--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -188,6 +188,8 @@ If you see unexpected `cacheWrite` spikes after a config or workspace change, ch
 
 - Delivery instructions live after the system-prompt cache boundary. Native Codex carries the current delivery and target policy in late turn context, so alternating delivery modes does not rebuild its static prompt or message tool catalog when the available capabilities remain unchanged. Actual capability changes still update the catalog.
 - Bundled MCP tool catalogs are sorted deterministically (by server name, then tool name) before tool registration, so `listTools()` order changes do not churn the tools block and bust prompt-cache prefixes.
+- Message-tool action enums are sorted after policy filtering, keeping identical capabilities stable across channel discovery order changes.
+- Native Ollama requests sort tools by name so discovery order changes do not churn the tools prefix.
 - Legacy sessions with persisted image blocks keep the **3 most recent completed turns** intact (counting all completed turns, not just image-bearing ones). Older already-processed image blocks are replaced with a text marker so image-heavy follow-ups do not keep re-sending large stale payloads.
 
 ## Tuning patterns

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -3194,6 +3194,49 @@ describe("createOllamaStreamFn", () => {
     );
   });
 
+  it("keeps serialized native Ollama tools stable when discovery order changes", async () => {
+    const tools = [
+      {
+        name: "write",
+        description: "Write a file",
+        parameters: {
+          type: "object",
+          properties: { content: { type: "string" } },
+        },
+      },
+      {
+        name: "read",
+        description: "Read a file",
+        parameters: {
+          type: "object",
+          properties: { path: { type: "string" } },
+        },
+      },
+    ];
+    const serializedTools: string[] = [];
+    for (const orderedTools of [tools, tools.toReversed()]) {
+      fetchWithSsrFGuardMock.mockClear();
+      await expectSuccessfulOllamaRequest(
+        {
+          baseUrl: "http://ollama-host:11434",
+          context: {
+            messages: [{ role: "user", content: "hello" }],
+            tools: orderedTools,
+          },
+        },
+        ({ body }) => {
+          expect(body.tools).toHaveLength(2);
+          expect(body.tools).toEqual(
+            expect.arrayContaining(tools.map((tool) => ({ type: "function", function: tool }))),
+          );
+          serializedTools.push(JSON.stringify(body.tools));
+        },
+      );
+    }
+    expect(serializedTools[1]).toBe(serializedTools[0]);
+    expect(tools.map((tool) => tool.name)).toEqual(["write", "read"]);
+  });
+
   it("lets native Ollama tools win over responseFormat", async () => {
     await expectSuccessfulOllamaRequest(
       {

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -32,6 +32,7 @@ import {
   MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE,
   notifyProviderHttpResponse,
   parseTerminalToolCallArguments,
+  sortPromptCacheToolsByName,
 } from "openclaw/plugin-sdk/provider-transport-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
@@ -799,7 +800,7 @@ function extractOllamaTools(tools: Tool[] | undefined): OllamaTool[] {
     return [];
   }
   const result: OllamaTool[] = [];
-  for (const tool of tools) {
+  for (const tool of sortPromptCacheToolsByName(tools)) {
     if (typeof tool.name !== "string" || !tool.name) {
       continue;
     }

--- a/src/agents/tools/message-tool-discovery.test.ts
+++ b/src/agents/tools/message-tool-discovery.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { PreparedMessageToolCatalog } from "../../channels/plugins/message-action-discovery.js";
+import {
+  buildMessageToolDescription,
+  buildMessageToolSchema,
+  resolveMessageToolActionSchemaActions,
+} from "./message-tool-discovery.js";
+
+describe("message tool discovery cache stability", () => {
+  it.each([
+    { allow: undefined, expected: ["poll", "poll-vote", "react", "send"] },
+    { allow: ["send", "react", "poll", "react"], expected: ["poll", "react", "send"] },
+    { allow: ["read", "edit", "read"], expected: ["edit", "read"] },
+  ])("keeps schema bytes stable across channel discovery order ($allow)", ({ allow, expected }) => {
+    const channels: PreparedMessageToolCatalog["channels"] = [
+      {
+        id: "telegram",
+        reconcilesUnknownSend: false,
+        actions: { describeMessageTool: () => ({ actions: ["send", "react", "poll"] }) },
+      },
+      {
+        id: "discord",
+        reconcilesUnknownSend: false,
+        actions: { describeMessageTool: () => ({ actions: ["send", "poll", "poll-vote"] }) },
+      },
+    ];
+    const createTool = (
+      orderedChannels: PreparedMessageToolCatalog["channels"],
+      currentChannelProvider: string,
+    ) => {
+      const params = {
+        cfg: { tools: { message: { actions: { allow } } } },
+        currentChannelProvider,
+        preparedMessageToolCatalog: {
+          version: 1,
+          channels: orderedChannels,
+          getChannel: (id: string) => orderedChannels.find((channel) => channel.id === id),
+        },
+      };
+      const actions = resolveMessageToolActionSchemaActions(params);
+      return {
+        parameters: buildMessageToolSchema(params, actions),
+        description: buildMessageToolDescription(actions),
+      };
+    };
+    const tools = [
+      createTool(channels, "telegram"),
+      createTool(channels.toReversed(), "discord"),
+    ] as const;
+
+    expect(tools[0].description).toBe(tools[1].description);
+    expect(JSON.stringify(tools[0].parameters)).toBe(JSON.stringify(tools[1].parameters));
+    for (const tool of tools) {
+      expect(tool.parameters.properties.action).toMatchObject({ enum: expected });
+      if (allow) {
+        expect(tool.description).not.toContain("poll-vote");
+      }
+    }
+  });
+});

--- a/src/agents/tools/message-tool-discovery.ts
+++ b/src/agents/tools/message-tool-discovery.ts
@@ -187,11 +187,11 @@ export function resolveMessageToolActionSchemaActions(
     agentId: params.agentId,
   });
   if (!allowedActions) {
-    return discoveredActions;
+    return sortUniqueStrings(discoveredActions);
   }
   const allow = new Set(allowedActions);
   const filtered = discoveredActions.filter((action) => allow.has(action));
-  return filtered.length > 0 ? filtered : allowedActions;
+  return sortUniqueStrings(filtered.length > 0 ? filtered : allowedActions);
 }
 
 function listAllMessageToolActions(params: MessageToolDiscoveryParams): ChannelMessageActionName[] {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can update this branch in the OpenClaw repository.

</details>

## What Problem This Solves

Fixes an issue where users switching message channels or changing tool discovery order would lose a stable prompt-cache prefix even when the available capabilities stayed identical. Message action enums and native Ollama tool lists could serialize in different orders between requests.

## Why This Change Was Made

Sort and deduplicate the final message action list with the helper already used by its description, preserving allowlist filtering and the existing empty-intersection fallback. Native Ollama now uses the shared tool-name sorter through its existing public `openclaw/plugin-sdk/provider-transport-runtime` import.

## User Impact

Equivalent capabilities produce stable message-tool schema bytes and stable native Ollama tool payloads across discovery-order changes. Action membership and tool descriptors are preserved. Production code changes total +4/-3 lines (net +1); no new configuration, storage, dependency, or SDK surface is introduced.

## Evidence

Both regressions failed before the production fixes: message schemas differed in action enum order (three failing cases, including policy fallback), and reversed Ollama descriptors produced different serialized request `tools` (one failing case).

```text
node scripts/run-vitest.mjs src/agents/tools/message-tool-discovery.test.ts extensions/ollama/src/stream-runtime.test.ts extensions/ollama/src/stream.test.ts extensions/ollama/src/stream-plain-text-tool-call.transport.test.ts
Test Files: 4 passed
Tests: 234 passed (3 message discovery + 231 Ollama)
[test] passed 2 Vitest shards in 94.84s
```

After test fixture typing was corrected, the message discovery suite was rerun: 3/3 passed.

`node scripts/check-changed.mjs` passed every local gate through core lint, including all core/extension production and test typechecks, formatting, six plugin contract tests, and all dead-export scans. Extension lint stopped during declaration preparation with `Declaration input escapes checkout`, resolving `qrcode` from the ancestor installation. This is the known nested-checkout limitation covered by 2329399cf6a and 2bc46990ba6; the boundary guard remains unchanged. Per coordinator direction, exact-head CI in a fresh checkout is the authoritative proof for the extension lint lane. Exact-head CI [run 34078702729](https://github.com/openclaw/openclaw/actions/runs/34078702729) passed on `eb18e89e689d16e1f91bc4dc133fb5aef75d8037`, including [check-lint](https://github.com/openclaw/openclaw/actions/runs/34078702729/job/101609846591). The exact-head watcher finished `GREEN` with zero pending checks.

Final Codex autoreview: scoped-clean; zero accepted/actionable P0 or P1 findings; exit 0.

`docs/reference/prompt-caching.md` documents both ordering guards in two short bullets. No live cache-hit benchmark was run; regression proof covers the schema and native request bytes. The message regression uses the existing discovery/schema owners directly with a typed prepared channel catalog and no execution-runtime mocks.
