### PR TITLE
refactor(ui): share segmented control rendering

### DIFF
--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -308,17 +308,71 @@ export function renderSettingsDefaultDescription(value: string, overridden: bool
   return html`${t(overridden ? "configForm.defaultValue" : "configForm.usingDefault", { value })}`;
 }
 
-export function renderSettingsSegmented<T extends string>(props: {
-  value: T;
-  options: ReadonlyArray<{ value: T; label: unknown; title?: string; testId?: string }>;
-  /** The selected radio is passed so callers can anchor visual transitions. */
-  onChange: (value: T, element: HTMLElement) => boolean | void;
-  /** Optional activation for an already-selected value, such as clearing an explicit default. */
-  onReselect?: (value: T, element: HTMLElement) => void;
-  disabled?: boolean;
-  ariaLabel?: string;
-  className?: string;
-}): TemplateResult {
+export function renderSettingsSegmented<T extends string>(
+  props: {
+    value: T;
+    options: ReadonlyArray<{
+      value: T;
+      label: unknown;
+      title?: string;
+      testId?: string;
+      disabled?: boolean;
+      compactLabel?: string;
+      ariaLabel?: string;
+    }>;
+    disabled?: boolean;
+    ariaLabel?: string;
+    className?: string;
+  } & (
+    | {
+        mode?: undefined;
+        /** The selected radio is passed so callers can anchor visual transitions. */
+        onChange: (value: T, element: HTMLElement) => boolean | void;
+        onReselect?: (value: T, element: HTMLElement) => void;
+      }
+    | {
+        mode: "buttons";
+        variant?: "accent" | "primary" | "compact";
+        ariaPressed?: false;
+        onClick?: (event: MouseEvent, value: T) => void;
+        onChange: (value: T) => void;
+        onReselect?: (value: T) => void;
+      }
+  ),
+): TemplateResult<1> {
+  if (props.mode === "buttons") {
+    return html`<div
+      class="settings-segmented ${props.variant ? `settings-segmented--${props.variant}` : ""} ${props.className ?? ""}"
+      role=${props.ariaLabel ? "group" : nothing}
+      aria-label=${props.ariaLabel ?? nothing}
+    >
+      ${props.options.map(
+        (option) => html`<button
+          type="button"
+          class="settings-segmented__btn ${option.value === props.value ? "settings-segmented__btn--active" : ""} ${props.variant === "accent" ? "btn btn--sm" : ""}"
+          aria-pressed=${props.ariaPressed === false ? nothing : String(option.value === props.value)}
+          aria-label=${option.ariaLabel ?? nothing}
+          data-compact-label=${option.compactLabel ?? nothing}
+          data-test-id=${option.testId ?? nothing}
+          title=${option.title ?? nothing}
+          ?disabled=${props.disabled || option.disabled}
+          @click=${(event: MouseEvent) => {
+            props.onClick?.(event, option.value);
+            if (event.defaultPrevented || props.disabled || option.disabled) {
+              return;
+            }
+            if (option.value === props.value) {
+              props.onReselect?.(option.value);
+            } else {
+              props.onChange(option.value);
+            }
+          }}
+        >
+          ${option.label}
+        </button>`,
+      )}
+    </div>`;
+  }
   return html`
     <wa-radio-group
       class="settings-segmented ${props.className ?? ""}"
@@ -353,6 +407,7 @@ export function renderSettingsSegmented<T extends string>(props: {
             appearance="button"
             value=${option.value}
             .checked=${live(option.value === props.value)}
+            ?disabled=${option.disabled ?? false}
             title=${option.title ?? nothing}
             data-test-id=${option.testId ?? nothing}
             @click=${(event: Event) => {

--- a/ui/src/e2e/config-controls-visual.e2e.test.ts
+++ b/ui/src/e2e/config-controls-visual.e2e.test.ts
@@ -133,6 +133,86 @@ async function captureBrowserSettingProof(
 }
 
 suite.define(() => {
+  it.each(["light", "dark"] as const)(
+    "keeps selected Usage accents at rest and on hover in %s mode",
+    async (colorScheme) => {
+      await suite.withPage(
+        { colorScheme, locale: "en-US", viewport: { width: 1280, height: 900 } },
+        async ({ page }) => {
+          const totals = {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            totalCost: 0,
+            inputCost: 0,
+            outputCost: 0,
+            cacheReadCost: 0,
+            cacheWriteCost: 0,
+            missingCostEntries: 0,
+          };
+          const gateway = await installMockGateway(page, {
+            methodResponses: {
+              "sessions.usage": {
+                updatedAt: Date.now(),
+                startDate: "2026-09-01",
+                endDate: "2026-09-07",
+                sessions: [],
+                totals,
+                aggregates: {
+                  messages: {
+                    total: 0,
+                    user: 0,
+                    assistant: 0,
+                    toolCalls: 0,
+                    toolResults: 0,
+                    errors: 0,
+                  },
+                  tools: { totalCalls: 0, uniqueTools: 0, tools: [] },
+                  byModel: [],
+                  byProvider: [],
+                  byAgent: [],
+                  byChannel: [],
+                  daily: [],
+                },
+              },
+              "usage.cost": { updatedAt: Date.now(), days: 7, daily: [], totals },
+            },
+          });
+          await page.goto(`${suite.server.baseUrl}usage`);
+          await gateway.waitForRequest("sessions.usage");
+          await expect
+            .poll(() => page.locator("html").getAttribute("data-theme-mode"))
+            .toBe(colorScheme);
+          const expected = await resolvedBackground(page, "var(--accent-subtle)");
+          const filters = page.locator(".usage-controls");
+          for (const label of ["Cost", "Tokens"]) {
+            const selected = filters.getByRole("button", { name: label, exact: true });
+            await selected.click();
+            await page.mouse.move(0, 0);
+            for (const state of ["rest", "hover"]) {
+              if (state === "hover") {
+                await selected.hover();
+              }
+              if (captureUiProofEnabled) {
+                await filters.screenshot({
+                  animations: "disabled",
+                  path: path.join(uiProofArtifactDir, `usage-${colorScheme}-${label}-${state}.png`),
+                });
+              }
+              await expect
+                .poll(() =>
+                  selected.evaluate((element) => getComputedStyle(element).backgroundColor),
+                )
+                .toBe(expected);
+            }
+          }
+        },
+      );
+    },
+  );
+
   it("keeps selected segmented options distinct in forced colors", async () => {
     const cases = [
       {

--- a/ui/src/e2e/control-ui-auth-proof.test-support.ts
+++ b/ui/src/e2e/control-ui-auth-proof.test-support.ts
@@ -58,7 +58,9 @@ export async function captureConfigReadbackFailure(page: Page): Promise<void> {
             outletInert:
               document.querySelector<HTMLElement>("openclaw-router-outlet")?.inert ?? null,
             rawButtons: [
-              ...document.querySelectorAll<HTMLButtonElement>(".config-mode-toggle button"),
+              ...document.querySelectorAll<HTMLButtonElement>(
+                ".settings-segmented--primary button",
+              ),
             ]
               .filter((button) => button.textContent?.trim() === "Raw")
               .slice(0, 3)

--- a/ui/src/pages/activity/session-activity-view.ts
+++ b/ui/src/pages/activity/session-activity-view.ts
@@ -5,7 +5,7 @@ import { icons } from "../../components/icons.ts";
 import "../../components/ip-location.ts";
 import "../../components/viewer-facepile.ts";
 import "../../components/web-awesome-popover.ts";
-import { renderSettingsStatus } from "../../components/settings-ui.ts";
+import { renderSettingsStatus, renderSettingsSegmented } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { formatRelativeTimestamp, formatTimeAgo } from "../../lib/format.ts";
 import { shouldHandleNavigationClick } from "../../lib/navigation-click.ts";
@@ -480,26 +480,20 @@ export function renderSessionActivityView(props: SessionActivityViewProps) {
             }}
           />
         </label>
-        <div
-          class="settings-segmented activity-feed__time-filter"
-          role="group"
-          aria-label=${t("activityFeed.time")}
-        >
-          ${ACTIVITY_TIME_FILTERS.map(
-            (time) => html`<button
-              type="button"
-              class="settings-segmented__btn ${
-                props.filters.time === time ? "settings-segmented__btn--active" : ""
-              }"
-              data-compact-label=${time === "all" ? t(TIME_LABELS[time]) : time}
-              aria-label=${t(TIME_LABELS[time])}
-              aria-pressed=${String(props.filters.time === time)}
-              @click=${() => props.onFiltersChange({ ...props.filters, time })}
-            >
-              ${t(TIME_LABELS[time])}
-            </button>`,
-          )}
-        </div>
+        ${renderSettingsSegmented({
+          mode: "buttons",
+          className: "activity-feed__time-filter",
+          value: props.filters.time,
+          ariaLabel: t("activityFeed.time"),
+          options: ACTIVITY_TIME_FILTERS.map((time) => ({
+            value: time,
+            label: t(TIME_LABELS[time]),
+            ariaLabel: t(TIME_LABELS[time]),
+            compactLabel: time === "all" ? t(TIME_LABELS[time]) : time,
+          })),
+          onChange: (time) => props.onFiltersChange({ ...props.filters, time }),
+          onReselect: (time) => props.onFiltersChange({ ...props.filters, time }),
+        })}
         ${renderPeopleControl(props, people, selectedPerson, projection.timeCount)}
       </div>
       <div class="activity-feed__feedback">

--- a/ui/src/pages/chat/components/chat-context-window-control.test.ts
+++ b/ui/src/pages/chat/components/chat-context-window-control.test.ts
@@ -1,0 +1,56 @@
+/* @vitest-environment jsdom */
+import { nothing, render } from "lit";
+import { expect, it, vi } from "vitest";
+import {
+  renderContextWindowControl,
+  type ChatContextWindowControlParams,
+} from "./chat-context-window-control.ts";
+
+it("keeps multi-option context selection contained and ignores current or disabled choices", () => {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const onSelect = vi.fn(async (_next: string, _sessionKey: string) => {});
+  const bubbled = vi.fn();
+  host.addEventListener("click", bubbled);
+  const props: ChatContextWindowControlParams = {
+    options: [
+      { id: "200k", label: "200K", contextWindow: 200_000 },
+      { id: "500k", label: "500K", contextWindow: 500_000 },
+      { id: "1m", label: "1M", contextWindow: 1_000_000 },
+    ],
+    selected: "1m",
+    disabled: false,
+    onSelect,
+  };
+  const paint = () => render(renderContextWindowControl(props, "agent:main:synthetic"), host);
+  const click = (label: string) => {
+    const button = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
+      (entry) => entry.textContent?.trim() === label,
+    );
+    if (!button) {
+      throw new Error(`Missing context option ${label}`);
+    }
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    button.dispatchEvent(event);
+    return event;
+  };
+  try {
+    paint();
+    expect(host.querySelector('[aria-pressed="true"]')?.textContent?.trim()).toBe("1M");
+    expect(click("1M").defaultPrevented).toBe(true);
+    expect(onSelect).not.toHaveBeenCalled();
+    click("200K");
+    expect(onSelect).toHaveBeenCalledExactlyOnceWith("200k", "agent:main:synthetic");
+    props.disabled = true;
+    paint();
+    expect(
+      [...host.querySelectorAll<HTMLButtonElement>("button")].every((button) => button.disabled),
+    ).toBe(true);
+    expect(click("500K").defaultPrevented).toBe(true);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(bubbled).not.toHaveBeenCalled();
+  } finally {
+    render(nothing, host);
+    host.remove();
+  }
+});

--- a/ui/src/pages/chat/components/chat-context-window-control.ts
+++ b/ui/src/pages/chat/components/chat-context-window-control.ts
@@ -1,6 +1,7 @@
 import { html, nothing } from "lit";
 import type { GatewayContextWindowOption } from "../../../api/types.ts";
 import { icons } from "../../../components/icons.ts";
+import { renderSettingsSegmented } from "../../../components/settings-ui.ts";
 import { t } from "../../../i18n/index.ts";
 
 export type ChatContextWindowControlParams = {
@@ -56,37 +57,24 @@ export function renderContextWindowControl(
       </button>
     `;
   } else {
-    control = html`
-      <div
-        class="settings-segmented chat-controls__context-window-options"
-        role="group"
-        aria-label=${ariaLabel}
-      >
-        ${contextWindow.options.map(
-          (option) => html`
-            <button
-              class="settings-segmented__btn ${
-                option.id === selectedOption.id ? "settings-segmented__btn--active" : ""
-              }"
-              data-chat-context-window-option=${option.id}
-              type="button"
-              aria-pressed=${option.id === selectedOption.id ? "true" : "false"}
-              ?disabled=${contextWindow.disabled}
-              @click=${(event: MouseEvent) => {
-                event.stopPropagation();
-                if (contextWindow.disabled || option.id === selectedOption.id) {
-                  event.preventDefault();
-                  return;
-                }
-                void contextWindow.onSelect(option.id, sessionKey);
-              }}
-            >
-              ${option.label}
-            </button>
-          `,
-        )}
-      </div>
-    `;
+    control = renderSettingsSegmented({
+      mode: "buttons",
+      variant: "compact",
+      className: "chat-controls__context-window-options",
+      value: selectedOption.id,
+      ariaLabel,
+      disabled: contextWindow.disabled,
+      options: contextWindow.options.map((option) => ({ value: option.id, label: option.label })),
+      onClick: (event, value) => {
+        event.stopPropagation();
+        if (contextWindow.disabled || value === selectedOption.id) {
+          event.preventDefault();
+        }
+      },
+      onChange: (value) => {
+        void contextWindow.onSelect(value, sessionKey);
+      },
+    });
   }
   return html`
     <div class="chat-controls__fast-mode-row chat-controls__context-window-row">

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -877,7 +877,6 @@ describe("config view", () => {
 
     const formButton = findButtonByText(container, "Form");
     const rawButton = findButtonByText(container, "Raw");
-    expect([...formButton.classList]).toEqual(["config-mode-toggle__btn", "active"]);
     expect(formButton.getAttribute("aria-pressed")).toBe("true");
     expect(rawButton.getAttribute("aria-pressed")).toBe("false");
     expect(rawButton.disabled).toBe(true);

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -1,14 +1,15 @@
+import { html, nothing } from "lit";
 // Control UI view renders config screen content.
 import "../../styles/lobster-pet.css";
-import { html, nothing } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { normalizeChatMessageMaxWidth } from "../../app/settings.ts";
 import { countSensitiveConfigValues } from "../../components/config-form.shared.ts";
 import { renderConfigForm } from "../../components/config-form.ts";
 import { renderHubTabs } from "../../components/hub-tabs.ts";
-import "../../components/tooltip.ts";
 import { icons } from "../../components/icons.ts";
+import "../../components/tooltip.ts";
 import { highlightJsonHtml } from "../../components/markdown-code-blocks.ts";
+import { renderSettingsSegmented } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { registerSettingsEnglish } from "../../i18n/locales/en-settings.ts";
 import { isJson5Warm, warmJson5 } from "../../lib/json5-runtime.ts";
@@ -355,36 +356,33 @@ export function renderConfig(props: ConfigProps) {
         ? html`<div class="config-toolbar">
             ${
               showModeToggle
-                ? html`<div class="config-mode-toggle">
-                    <button
-                      class="config-mode-toggle__btn ${formMode === "form" ? "active" : ""}"
-                      aria-pressed=${formMode === "form" ? "true" : "false"}
-                      ?disabled=${props.schemaLoading || !props.schema || rawDraftPending}
-                      title=${
-                        rawDraftPending
+                ? renderSettingsSegmented({
+                    mode: "buttons",
+                    variant: "primary",
+                    value: formMode,
+                    onChange: props.onFormModeChange,
+                    onReselect: props.onFormModeChange,
+                    options: [
+                      {
+                        value: "form",
+                        label: t("configView.form"),
+                        disabled: props.schemaLoading || !props.schema || rawDraftPending,
+                        title: rawDraftPending
                           ? t("configView.rawDraftPendingFormTitle")
                           : formUnsafe
                             ? t("configView.formUnsafeTitle")
-                            : ""
-                      }
-                      @click=${() => props.onFormModeChange("form")}
-                    >
-                      ${t("configView.form")}
-                    </button>
-                    <button
-                      class="config-mode-toggle__btn ${formMode === "raw" ? "active" : ""}"
-                      aria-pressed=${formMode === "raw" ? "true" : "false"}
-                      ?disabled=${!rawAvailable}
-                      title=${
-                        rawAvailable
-                          ? t("configView.rawTitle")
-                          : t("configView.rawUnavailableTitle")
-                      }
-                      @click=${() => props.onFormModeChange("raw")}
-                    >
-                      ${t("configView.raw")}
-                    </button>
-                  </div>`
+                            : "",
+                      },
+                      {
+                        value: "raw",
+                        label: t("configView.raw"),
+                        disabled: !rawAvailable,
+                        title: t(
+                          rawAvailable ? "configView.rawTitle" : "configView.rawUnavailableTitle",
+                        ),
+                      },
+                    ],
+                  })
                 : nothing
             }
             ${sectionTabs}

--- a/ui/src/pages/usage/view-details.ts
+++ b/ui/src/pages/usage/view-details.ts
@@ -7,6 +7,7 @@ import {
   renderPanelRefreshStatus,
   type PanelRefreshStatus,
 } from "../../components/panel-refresh-status.ts";
+import { renderSettingsSegmented } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import "../../components/tooltip.ts";
 import {
@@ -24,7 +25,7 @@ import type {
   UsageContextDetail,
   UsageSessionEntry,
 } from "./types.ts";
-import { renderInsightList, renderUsageToggle, USAGE_TOKEN_CATEGORIES } from "./view-overview.ts";
+import { renderInsightList, USAGE_TOKEN_CATEGORIES } from "./view-overview.ts";
 
 // Chart constants
 const CHART_BAR_WIDTH_RATIO = 0.75; // Fraction of slot used for bar (rest is gap)
@@ -534,9 +535,9 @@ function renderTimeSeriesCompact(
           ${
             hasSelection
               ? html`
-                  <div class="chart-toggle small">
+                  <div class="settings-segmented settings-segmented--accent small">
                     <button
-                      class="btn btn--sm toggle-btn active"
+                      class="btn btn--sm settings-segmented__btn settings-segmented__btn--active"
                       @click=${() => onCursorRangeChange?.(null, null)}
                     >
                       ${t("usage.details.reset")}
@@ -545,16 +546,34 @@ function renderTimeSeriesCompact(
                 `
               : nothing
           }
-          ${renderUsageToggle(mode, onModeChange, [
-            { value: "per-turn", labelKey: "usage.details.perTurn" },
-            { value: "cumulative", labelKey: "usage.details.cumulative" },
-          ])}
+          ${renderSettingsSegmented({
+            mode: "buttons",
+            variant: "accent",
+            ariaPressed: false,
+            className: "small",
+            value: mode,
+            onChange: onModeChange,
+            onReselect: onModeChange,
+            options: [
+              { value: "per-turn", label: t("usage.details.perTurn") },
+              { value: "cumulative", label: t("usage.details.cumulative") },
+            ],
+          })}
           ${
             !isCumulative
-              ? renderUsageToggle(breakdownMode, onBreakdownChange, [
-                  { value: "total", labelKey: "usage.daily.total" },
-                  { value: "by-type", labelKey: "usage.daily.byType" },
-                ])
+              ? renderSettingsSegmented({
+                  mode: "buttons",
+                  variant: "accent",
+                  ariaPressed: false,
+                  className: "small",
+                  value: breakdownMode,
+                  onChange: onBreakdownChange,
+                  onReselect: onBreakdownChange,
+                  options: [
+                    { value: "total", label: t("usage.daily.total") },
+                    { value: "by-type", label: t("usage.daily.byType") },
+                  ],
+                })
               : nothing
           }
         </div>

--- a/ui/src/pages/usage/view-overview.ts
+++ b/ui/src/pages/usage/view-overview.ts
@@ -5,7 +5,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { handleCopyButton } from "../../components/copy-button.ts";
-import { renderSettingsSection } from "../../components/settings-ui.ts";
+import { renderSettingsSection, renderSettingsSegmented } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import "../../components/tooltip.ts";
 import { formatDurationCompact } from "../../lib/format.ts";
@@ -69,28 +69,6 @@ function handleDailyBarKeydown(
 
   event.preventDefault();
   onSelectDay(day, event.shiftKey);
-}
-
-function renderUsageToggle<Value extends string>(
-  current: Value,
-  onChange: (value: Value) => void,
-  options: ReadonlyArray<{ value: Value; labelKey: string }>,
-  className = "chart-toggle small",
-) {
-  return html`
-    <div class=${className}>
-      ${options.map(
-        ({ value, labelKey }) => html`
-          <button
-            class="btn btn--sm toggle-btn ${current === value ? "active" : ""}"
-            @click=${() => onChange(value)}
-          >
-            ${t(labelKey)}
-          </button>
-        `,
-      )}
-    </div>
-  `;
 }
 
 function renderFilterChips(
@@ -294,15 +272,19 @@ function renderDailyChartCompact(
   return html`
     <div class="daily-chart-compact">
       <div class="daily-chart-header">
-        ${renderUsageToggle(
-          dailyChartMode,
-          onDailyChartModeChange,
-          [
-            { value: "total", labelKey: "usage.daily.total" },
-            { value: "by-type", labelKey: "usage.daily.byType" },
+        ${renderSettingsSegmented({
+          mode: "buttons",
+          variant: "accent",
+          ariaPressed: false,
+          className: "small sessions-toggle",
+          value: dailyChartMode,
+          onChange: onDailyChartModeChange,
+          onReselect: onDailyChartModeChange,
+          options: [
+            { value: "total", label: t("usage.daily.total") },
+            { value: "by-type", label: t("usage.daily.byType") },
           ],
-          "chart-toggle small sessions-toggle",
-        )}
+        })}
         <div class="card-title">
           ${isTokenMode ? t("usage.daily.tokensTitle") : t("usage.daily.costTitle")}
           ${
@@ -995,10 +977,19 @@ function renderSessionsCard(
               >${totalErrors} ${normalizeLowercaseStringOrEmpty(t("usage.overview.errors"))}</span
             >
           </div>
-          ${renderUsageToggle(sessionsTab, onSessionsTabChange, [
-            { value: "all", labelKey: "usage.sessions.all" },
-            { value: "recent", labelKey: "usage.sessions.recent" },
-          ])}
+          ${renderSettingsSegmented({
+            mode: "buttons",
+            variant: "accent",
+            ariaPressed: false,
+            className: "small",
+            value: sessionsTab,
+            onChange: onSessionsTabChange,
+            onReselect: onSessionsTabChange,
+            options: [
+              { value: "all", label: t("usage.sessions.all") },
+              { value: "recent", label: t("usage.sessions.recent") },
+            ],
+          })}
           <label class="sessions-sort">
             <span>${t("usage.sessions.sort")}</span>
             <select
@@ -1102,7 +1093,6 @@ export {
   renderInsightList,
   renderSessionsCard,
   renderUsageInsights,
-  renderUsageToggle,
   USAGE_TOKEN_CATEGORIES,
 };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/pages/usage/view.ts
+++ b/ui/src/pages/usage/view.ts
@@ -5,7 +5,11 @@ import {
   createEmptyCostUsageTotals,
 } from "../../../../src/infra/session-cost-usage-totals.js";
 import { renderProviderUsageDetails } from "../../components/provider-usage.ts";
-import { renderSettingsPage, renderSettingsSection } from "../../components/settings-ui.ts";
+import {
+  renderSettingsPage,
+  renderSettingsSection,
+  renderSettingsSegmented,
+} from "../../components/settings-ui.ts";
 import "../../components/tooltip.ts";
 import "../../components/web-awesome.ts";
 import { t } from "../../i18n/index.ts";
@@ -555,36 +559,38 @@ export function renderUsage(props: UsageProps) {
                   <option value="local">${t("usage.filters.timeZoneLocal")}</option>
                   <option value="utc">${t("usage.filters.timeZoneUtc")}</option>
                 </select>
-                <div class="chart-toggle">
-                  <button
-                    class="btn btn--sm toggle-btn ${filters.scope === "instance" ? "active" : ""}"
-                    title=${t("usage.scope.instanceHint")}
-                    @click=${() => filterActions.onScopeChange("instance")}
-                  >
-                    ${t("usage.scope.instance")}
-                  </button>
-                  <button
-                    class="btn btn--sm toggle-btn ${filters.scope === "family" ? "active" : ""}"
-                    title=${t("usage.scope.familyHint")}
-                    @click=${() => filterActions.onScopeChange("family")}
-                  >
-                    ${t("usage.scope.family")}
-                  </button>
-                </div>
-                <div class="chart-toggle">
-                  <button
-                    class="btn btn--sm toggle-btn ${isTokenMode ? "active" : ""}"
-                    @click=${() => displayActions.onChartModeChange("tokens")}
-                  >
-                    ${t("usage.metrics.tokens")}
-                  </button>
-                  <button
-                    class="btn btn--sm toggle-btn ${!isTokenMode ? "active" : ""}"
-                    @click=${() => displayActions.onChartModeChange("cost")}
-                  >
-                    ${t("usage.metrics.cost")}
-                  </button>
-                </div>
+                ${renderSettingsSegmented({
+                  mode: "buttons",
+                  variant: "accent",
+                  ariaPressed: false,
+                  value: filters.scope,
+                  onChange: filterActions.onScopeChange,
+                  onReselect: filterActions.onScopeChange,
+                  options: [
+                    {
+                      value: "instance",
+                      label: t("usage.scope.instance"),
+                      title: t("usage.scope.instanceHint"),
+                    },
+                    {
+                      value: "family",
+                      label: t("usage.scope.family"),
+                      title: t("usage.scope.familyHint"),
+                    },
+                  ],
+                })}
+                ${renderSettingsSegmented({
+                  mode: "buttons",
+                  variant: "accent",
+                  ariaPressed: false,
+                  value: isTokenMode ? "tokens" : "cost",
+                  onChange: displayActions.onChartModeChange,
+                  onReselect: displayActions.onChartModeChange,
+                  options: [
+                    { value: "tokens", label: t("usage.metrics.tokens") },
+                    { value: "cost", label: t("usage.metrics.cost") },
+                  ],
+                })}
                 <button
                   class="btn btn--sm primary"
                   @click=${filterActions.onRefresh}

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -949,15 +949,6 @@ a.activity-current-work__row:hover {
     margin-left: auto;
   }
 
-  .activity-feed__time-filter .settings-segmented__btn {
-    font-size: 0;
-  }
-
-  .activity-feed__time-filter .settings-segmented__btn::after {
-    content: attr(data-compact-label);
-    font-size: var(--control-ui-text-sm);
-  }
-
   .activity-feed__main {
     overflow: visible;
     padding: var(--space-4);

--- a/ui/src/styles/chat/composer.css
+++ b/ui/src/styles/chat/composer.css
@@ -3669,15 +3669,7 @@
 }
 
 .chat-controls__context-window-options {
-  --settings-control-height: 24px;
-
   flex: 0 0 auto;
-  flex-wrap: nowrap;
-}
-
-.chat-controls__context-window-options .settings-segmented__btn {
-  padding: 0 6px;
-  font-size: 10px;
 }
 
 .chat-controls__speed-toggle {

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -8,46 +8,6 @@
    chrome (tabs, actions, diff, raw editor) plus genuinely form-specific
    pieces layered on top of the settings primitives. */
 
-/* Mode Toggle */
-.config-mode-toggle {
-  display: flex;
-  padding: 3px;
-  background: var(--bg-elevated);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border);
-  gap: 1px;
-}
-
-:root[data-theme-mode="light"] .config-mode-toggle {
-  background: white;
-}
-
-.config-mode-toggle__btn {
-  flex: 1;
-  padding: 6px 12px;
-  border: none;
-  border-radius: calc(var(--radius-md) - 3px);
-  background: transparent;
-  color: var(--muted);
-  font-size: 12px; /* was 11px */
-  font-weight: 600;
-  transition:
-    background var(--duration-fast) ease,
-    color var(--duration-fast) ease,
-    box-shadow var(--duration-fast) ease;
-}
-
-.config-mode-toggle__btn:hover:not(.active) {
-  color: var(--text);
-  background: var(--bg-hover);
-}
-
-.config-mode-toggle__btn.active {
-  background: var(--primary);
-  color: var(--primary-foreground);
-  box-shadow: 0 1px 3px var(--accent-subtle);
-}
-
 /* ===========================================
    Lead column (toolbar / banner / nav above the form)
    =========================================== */

--- a/ui/src/styles/settings-controls.css
+++ b/ui/src/styles/settings-controls.css
@@ -5,8 +5,7 @@
 /* Settings controls also appear outside the settings workspace: the login
    gate, chat board controls, and the chat MCP form all use these primitives. */
 
-/* Segmented keeps its 2px track inset; the buttons fill the inner height.
-   min-height (not height) so many-option enums can still wrap to two lines. */
+/* The neutral track keeps its 2px inset; many-option enums may wrap. */
 .settings-segmented {
   min-height: var(--settings-control-height);
   box-sizing: border-box;
@@ -21,10 +20,34 @@
   padding: 2px;
 }
 
-.settings-segmented > .settings-segmented__btn {
-  display: inline-flex;
+.settings-segmented:is(.settings-segmented--accent, .settings-segmented--primary) {
+  min-height: auto;
+  max-width: none;
+  flex-wrap: nowrap;
+  border-color: var(--border);
+  padding: 3px;
+}
+
+.settings-segmented--accent {
   align-items: center;
-  padding-block: 0;
+  background: var(--bg-muted);
+}
+
+.settings-segmented--primary {
+  display: flex;
+  align-items: normal;
+  gap: 1px;
+  background: var(--bg-elevated);
+}
+
+:root[data-theme-mode="light"] .settings-segmented--primary {
+  background: white;
+}
+
+.settings-segmented--compact {
+  --settings-control-height: 24px;
+
+  flex-wrap: nowrap;
 }
 
 .settings-control__sr-label {
@@ -47,10 +70,13 @@ wa-radio-group.settings-segmented::part(form-control-label) {
   clip: rect(0, 0, 0, 0);
 }
 
-.settings-segmented__btn {
+/* The parent selector also wins over the shared .btn hover/active chrome. */
+.settings-segmented > .settings-segmented__btn {
+  display: inline-flex;
+  align-items: center;
   font-size: var(--control-ui-text-sm);
   font-weight: 550;
-  padding: 4px 12px;
+  padding: 0 12px;
   border: none;
   border-radius: calc(var(--radius-md) - 3px);
   background: transparent;
@@ -63,36 +89,102 @@ wa-radio-group.settings-segmented::part(form-control-label) {
     box-shadow var(--duration-normal) var(--ease-out);
 }
 
-.settings-segmented__btn:hover {
+.settings-segmented--accent > .settings-segmented__btn {
+  min-height: 28px;
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 500;
   color: var(--text);
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    background var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-fast) var(--ease-out);
 }
 
-.settings-segmented__btn:focus-visible {
-  outline: none;
-  color: var(--text);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 22%, transparent);
+.settings-segmented--primary > .settings-segmented__btn {
+  display: block;
+  align-items: normal;
+  flex: 1;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: normal;
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
 }
 
-.settings-segmented__btn--active {
+.settings-segmented--compact > .settings-segmented__btn {
+  padding: 0 6px;
+  font-size: 10px;
+}
+
+.settings-segmented > .settings-segmented__btn--active {
   background: var(--bg-elevated);
   color: var(--text-strong);
   box-shadow: var(--shadow-sm);
 }
 
-.settings-segmented__btn:disabled {
+.settings-segmented--accent > .settings-segmented__btn--active {
+  border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
+  background: var(--accent-subtle);
+  color: var(--accent);
+  font-weight: 600;
+  box-shadow: 0 1px 3px color-mix(in srgb, var(--accent) 20%, transparent);
+}
+
+.settings-segmented--primary > .settings-segmented__btn--active {
+  background: var(--primary);
+  color: var(--primary-foreground);
+  box-shadow: 0 1px 3px var(--accent-subtle);
+}
+
+:is(.settings-segmented--accent, .settings-segmented--primary)
+  > .settings-segmented__btn:hover:not(.settings-segmented__btn--active) {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+:where(.settings-segmented:not(.settings-segmented--accent, .settings-segmented--primary))
+  > .settings-segmented__btn:hover {
+  color: var(--text);
+}
+
+:where(.settings-segmented:not(.settings-segmented--accent, .settings-segmented--primary))
+  > .settings-segmented__btn:focus-visible {
+  outline: none;
+  color: var(--text);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+:where(.settings-segmented:not(.settings-segmented--primary)) > .settings-segmented__btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
 @media (forced-colors: active) {
-  .settings-segmented__btn--active {
+  :where(.settings-segmented:not(.settings-segmented--accent, .settings-segmented--primary))
+    > .settings-segmented__btn--active {
     text-decoration: underline 2px;
     text-underline-offset: 3px;
   }
 
-  .settings-segmented__btn:focus-visible {
+  :where(.settings-segmented:not(.settings-segmented--accent, .settings-segmented--primary))
+    > .settings-segmented__btn:focus-visible {
     outline: 2px solid Highlight;
     outline-offset: 2px;
+  }
+}
+
+@media (max-width: 768px) {
+  .settings-segmented__btn[data-compact-label] {
+    font-size: 0;
+  }
+
+  .settings-segmented__btn[data-compact-label]::after {
+    content: attr(data-compact-label);
+    font-size: var(--control-ui-text-sm);
   }
 }
 

--- a/ui/src/styles/settings-controls.css
+++ b/ui/src/styles/settings-controls.css
@@ -134,6 +134,11 @@ wa-radio-group.settings-segmented::part(form-control-label) {
   box-shadow: 0 1px 3px color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
+:root[data-theme-mode="light"] .settings-segmented--accent > .settings-segmented__btn--active {
+  border-color: var(--accent);
+  background: var(--accent-subtle);
+}
+
 .settings-segmented--primary > .settings-segmented__btn--active {
   background: var(--primary);
   color: var(--primary-foreground);

--- a/ui/src/styles/usage.css
+++ b/ui/src/styles/usage.css
@@ -334,33 +334,10 @@
 
 .usage-presets,
 .usage-date-range,
-.chart-toggle,
 .usage-query-actions {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-}
-
-.chart-toggle {
-  padding: 3px;
-  background: var(--bg-muted);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  gap: 2px;
-}
-
-.chart-toggle .toggle-btn {
-  border: none;
-  border-radius: calc(var(--radius-md) - 3px);
-  background: transparent;
-  min-height: 28px;
-  padding: 4px 12px;
-  font-size: 12px;
-}
-
-.chart-toggle .toggle-btn:hover:not(.active) {
-  background: var(--bg-hover);
-  color: var(--text);
 }
 
 .usage-date-range {
@@ -450,21 +427,12 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* Toggle-btn active state layers on .btn for segmented controls */
-.usage-pin-btn.active,
-.chart-toggle .toggle-btn.active {
+.usage-pin-btn.active {
   border-color: var(--accent);
   background: var(--primary);
   color: var(--primary-foreground);
   font-weight: 600;
   box-shadow: 0 1px 3px color-mix(in srgb, var(--accent) 20%, transparent);
-}
-
-.chart-toggle .toggle-btn.active {
-  border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
-  background: var(--accent-subtle);
-  color: var(--accent);
-  font-weight: 600;
 }
 
 .usage-query-section {


### PR DESCRIPTION
## Maintainer decision

Landed by maintainer decision: one owner for segmented controls outweighs the +53 production lines.

This refactor preserves the existing interactions by adding an explicit `buttons` mode to `renderSettingsSegmented`. Existing Settings callers keep Web Awesome radios; Usage, Config, Activity, and the multi-option Chat context selector keep native buttons. Radio callbacks retain their element argument, while native callbacks retain their value-only contract.

The maintainer accepts this additional component mode and one CSS owner despite **+53 production lines** (+329/-276). Preserving the distinct focus, disabled, transition, and visual contracts did not produce the survey's anticipated line reduction. Standardizing the interactions is outside this proposal. No user configuration option is added. The maintainer has authorized landing after validation.

## What Problem This Solves

Exclusive-value selectors repeat page-local rendering and styling across Usage, Config, Activity, and Chat, despite an existing shared Settings control. This maintainer-requested proposal centralizes their owner while retaining current behavior.

## Why This Change Was Made

The shared renderer handles per-option disabling, current-value activation, compact labels, and event containment. `settings-controls.css` owns the neutral, accent, primary, and compact treatments; the corresponding page-specific chrome is removed. The Usage Reset button remains an ordinary action, and Chat's binary context switch remains unchanged.

## User Impact

No intended appearance, keyboard, selection, callback, or focus change. No public SDK export, wire format, persisted data, dependency, or user configuration change.

## Evidence

Closeout validation on the rebased candidate:

- Preserves current main's radio callback rejection contract (`false` restores the prior value).
- The requested focused command selected all three UI lanes: 15,896 cases passed (15,379 shared, 69 isolated, 448 browser).
- All four requested mocked Gateway Chromium suites pass: 31 cases, including two new light/dark Usage regressions.
- Verified and repaired the review finding: light-theme generic button backgrounds overrode selected Usage fills. The new regression fails before the repair with `rgb(250, 249, 247)` instead of the expected accent fill, and passes after it. Cost and Tokens remain selected at rest and on hover in both themes. The fix adds five production lines; final production delta is +58.
- Full `pnpm build` passed in 9m 36.6s. Final `pnpm ui:check-performance` passed: startup JavaScript 350757 B gzip in 8 requests, below the unchanged 350953 B enforcement limit (350377 B baseline plus its existing allowances); startup CSS 44972 B gzip. No baseline was edited.
- Both pinned local and committed-branch Codex autoreviews are scoped-clean through P2, with zero accepted/actionable findings.
- `node scripts/check-changed.mjs` passed, including typechecks, all three dead-export scans, and lint. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/34150623102) is green for `f27f00bf04e0a83c0b68f7b44cebcedbd1d17b3b`. Native review, `OPENCLAW_TESTBOX=1` prepare, and merge completed. Landed as `517e9935ff9f3c978ae1b3aafc4bf24f01196ec2`, verified as an ancestor of freshly fetched `origin/main`. The first merge request received HTTP 405 because main moved; one investigated native recovery merged the same prepared head. No CI rerun, admin bypass, or baseline change was used.

Original proposal evidence follows; the new light-theme proof supplements the earlier captures:

- Final focused proof: 318/318 cases pass (252 unit and 66 browser) with `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-context-window-control.test.ts ui/src/pages/config/view.browser.test.ts ui/src/pages/usage ui/src/pages/activity`.
- Mocked Gateway Chromium: 29/29 cases pass using `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner` on `config-controls-visual`, `usage-cost-analysis`, `activity-session-refresh`, and `chat-flow.models-reasoning` E2E files, including the existing forced-colors proof.
- The new three-option context test passes on the original implementation and this proposal; it protects current/disabled selection and click containment. One Config class-name assertion was removed while retaining its pressed-state, disabled-state, tooltip, and behavior assertions.
- UI typecheck, `pnpm ui:build`, and `pnpm ui:check-performance` pass. Startup JS is 346199 B gzip in 8 requests, below the untouched 350377 B baseline. Startup CSS is 44279 B gzip.
- Codex autoreview is scoped-clean through P2, with zero accepted/actionable findings. `git diff --check` passes.
- `node scripts/check-changed.mjs` passes, including both typecheck lanes, dead-export scans, and style checks. This original local proof predates closeout; completed full-build and native hosted-gate validation is recorded above.

An initial focused run reported three Activity session-snapshot teardown errors after its 252 assertions passed. Subsequent complete runs had no teardown errors; no loader, timeout, or mock relaxation was made. An existing Config browser assertion also caught callback arity during implementation; the native callback contract was corrected instead of weakening the assertion.

Visual proof covers 16 surfaces and 37 options/actions: zero differences across 5500 computed-style values, 500 geometry values, 375 pseudo-element values, and 1298 semantic/state values. Ten of fourteen screenshot pairs are pixel-identical; the other four contain 46 differing edge pixels total (maximum channel delta 5), without a measured style or geometry difference. The comparison records those differences rather than masking them.

All 28 full captures were inspected and contain only synthetic fixtures (Synthetic Viewer, fabricated usage/config data, and public GPT-5.5). The browser and Gateway are isolated mocks. The screenshot comparisons cover normal colors; forced colors additionally use the existing E2E test and source review.

| Surface | Before | After |
| --- | --- | --- |
| Settings radio group | ![Settings radio group before](https://github.com/user-attachments/assets/19b9dddc-4e9f-46a3-a65e-f621960d8d07) | ![Settings radio group after](https://github.com/user-attachments/assets/b8574273-a618-4c16-96e2-d4f94056c0fb) |
| Config Form, dark | ![Config Form, dark before](https://github.com/user-attachments/assets/a10a46c9-3828-47f5-b3e1-3c0fa79f4be9) | ![Config Form, dark after](https://github.com/user-attachments/assets/3ee5bbca-365c-44b9-a794-9868898db7a6) |
| Config Raw, dark | ![Config Raw, dark before](https://github.com/user-attachments/assets/1963fbf2-d1d3-42b6-920f-c8b89d77f78d) | ![Config Raw, dark after](https://github.com/user-attachments/assets/2532279f-f651-474a-b255-db821d2615ff) |
| Config with disabled Form | ![Config with disabled Form before](https://github.com/user-attachments/assets/be9f0584-78ef-4904-8c54-cabf1f84964a) | ![Config with disabled Form after](https://github.com/user-attachments/assets/32873cf0-38aa-41dc-8971-56745a1ee14b) |
| Config Form, light | ![Config Form, light before](https://github.com/user-attachments/assets/de80deb2-21ac-480a-9b34-1e09e177518b) | ![Config Form, light after](https://github.com/user-attachments/assets/a3e9255c-64bd-45c4-a897-5bd95c1b1474) |
| Config Raw, light | ![Config Raw, light before](https://github.com/user-attachments/assets/616ecb81-715e-461c-88b7-44c419224909) | ![Config Raw, light after](https://github.com/user-attachments/assets/581c94b1-7109-46c3-a29b-f1dd49b1ccf8) |
| Activity desktop | ![Activity desktop before](https://github.com/user-attachments/assets/f2461865-60e8-4454-b235-da2e82094604) | ![Activity desktop after](https://github.com/user-attachments/assets/245423e6-342a-4dee-806b-66af832ab3f9) |
| Activity mobile labels | ![Activity mobile labels before](https://github.com/user-attachments/assets/64e3e989-7bcd-4500-92b3-87cc4d6a2f98) | ![Activity mobile labels after](https://github.com/user-attachments/assets/af6034f6-089c-46a3-8a76-5f4ea82329ed) |
| Usage scope and metric | ![Usage scope and metric before](https://github.com/user-attachments/assets/cc171bb5-6e9f-44b8-b643-1abaf8ac85a9) | ![Usage scope and metric after](https://github.com/user-attachments/assets/9e713330-9d02-4002-b365-622b06ec23ae) |
| Usage daily breakdown | ![Usage daily breakdown before](https://github.com/user-attachments/assets/8f796c8f-21fb-403a-8d25-4c9787f27b35) | ![Usage daily breakdown after](https://github.com/user-attachments/assets/22a9842b-981d-4203-8447-87668de099bc) |
| Usage session selection | ![Usage session selection before](https://github.com/user-attachments/assets/ba43a0c6-2eff-4aab-89a2-0017206daefa) | ![Usage session selection after](https://github.com/user-attachments/assets/2e710f17-8db5-4888-9ffb-c5ec58b84386) |
| Usage detail controls | ![Usage detail controls before](https://github.com/user-attachments/assets/c22654e5-dd0a-4236-b383-e06311b571fa) | ![Usage detail controls after](https://github.com/user-attachments/assets/74973436-d95b-44fa-bd24-54eb3ea94ef9) |
| Usage Reset action | ![Usage Reset action before](https://github.com/user-attachments/assets/b0b75b5f-5ee0-49dc-8125-b2f38ccc12ae) | ![Usage Reset action after](https://github.com/user-attachments/assets/b1a5fc96-b442-4a0d-8991-79f3d606aae1) |
| Chat context options | ![Chat context options before](https://github.com/user-attachments/assets/badb3bb7-db1a-4df6-8a97-0a80fe1b9515) | ![Chat context options after](https://github.com/user-attachments/assets/4e1d8c8a-b8e6-404a-89e5-34c3cd7ddabb) |

## Light-theme selected Usage regression proof

Fresh captures use an isolated mocked Gateway, empty synthetic Usage data, and no real account or session data. All nine new captures were inspected. The first image shows the defect before repair; the following images show the restored Cost selection at rest and on hover.

![Before repair: selected Cost loses its accent fill in light mode](https://github.com/user-attachments/assets/bff2ac9e-5392-4557-b528-bbb00cfc7d2b)

![After repair: selected Cost retains its accent fill in light mode](https://github.com/user-attachments/assets/8c4f0bc9-dd57-4741-9f94-4c4df69c5890)

![After repair: selected Cost retains its accent fill on hover](https://github.com/user-attachments/assets/046db375-b376-426a-b1a1-bdfc622ad75f)