### PR TITLE
refactor(infra): share pinned file descriptor primitives

### DIFF
--- a/src/infra/file-descriptor.test.ts
+++ b/src/infra/file-descriptor.test.ts
@@ -1,0 +1,65 @@
+import { createHash } from "node:crypto";
+import { closeSync, openSync, readSync } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { copyFileHandle, hashFileDescriptorSync } from "./file-descriptor.js";
+
+let directory: string;
+const bytes = Buffer.concat([Buffer.alloc(1024 * 1024, 0x61), Buffer.from("tail")]);
+const expectedHash = createHash("sha256").update(bytes).digest("hex");
+
+beforeEach(async () => {
+  directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-file-descriptor-"));
+});
+
+afterEach(async () => {
+  await fs.rm(directory, { recursive: true, force: true });
+});
+
+describe("pinned file descriptors", () => {
+  it("hashes all bytes without moving or closing the borrowed descriptor", async () => {
+    const sourcePath = path.join(directory, "source");
+    await fs.writeFile(sourcePath, bytes);
+    const fd = openSync(sourcePath, "r");
+    try {
+      readSync(fd, Buffer.alloc(2));
+      expect(hashFileDescriptorSync(fd)).toEqual({
+        sha256: expectedHash,
+        sizeBytes: bytes.length,
+      });
+      const remaining = Buffer.alloc(bytes.length);
+      const count = readSync(fd, remaining);
+      expect(remaining.subarray(0, count)).toEqual(bytes.subarray(2));
+    } finally {
+      closeSync(fd);
+    }
+  });
+
+  it("copies and observes all source bytes while retaining both handle positions", async () => {
+    const source = await fs.open(path.join(directory, "source"), "wx+");
+    const targetPath = path.join(directory, "target");
+    const target = await fs.open(targetPath, "wx+");
+    try {
+      await source.writeFile(bytes);
+      await target.writeFile("seed");
+      const observed = createHash("sha256");
+      expect(
+        await copyFileHandle(source, target, {
+          noProgressMessage: "copy stalled",
+          onChunk: (chunk) => {
+            observed.update(chunk);
+          },
+        }),
+      ).toBe(bytes.length);
+      expect(observed.digest("hex")).toBe(expectedHash);
+      expect(await fs.readFile(targetPath)).toEqual(bytes);
+      expect(await source.readFile()).toHaveLength(0);
+      expect(await target.readFile()).toEqual(bytes.subarray(4));
+    } finally {
+      await target.close();
+      await source.close();
+    }
+  });
+});

--- a/src/infra/file-descriptor.test.ts
+++ b/src/infra/file-descriptor.test.ts
@@ -1,21 +1,18 @@
 import { createHash } from "node:crypto";
 import { closeSync, openSync, readSync } from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { copyFileHandle, hashFileDescriptorSync } from "./file-descriptor.js";
 
 let directory: string;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const bytes = Buffer.concat([Buffer.alloc(1024 * 1024, 0x61), Buffer.from("tail")]);
 const expectedHash = createHash("sha256").update(bytes).digest("hex");
 
-beforeEach(async () => {
-  directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-file-descriptor-"));
-});
-
-afterEach(async () => {
-  await fs.rm(directory, { recursive: true, force: true });
+beforeEach(() => {
+  directory = tempDirs.make("openclaw-file-descriptor-");
 });
 
 describe("pinned file descriptors", () => {

--- a/src/infra/file-descriptor.ts
+++ b/src/infra/file-descriptor.ts
@@ -1,0 +1,71 @@
+import { createHash } from "node:crypto";
+import { readSync, type BigIntStats } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+
+export type FileMutationFingerprint = Pick<
+  BigIntStats,
+  "birthtimeNs" | "ctimeNs" | "dev" | "ino" | "mtimeNs" | "size"
+>;
+
+/** Strict field equality; callers own any platform-specific identity tolerance. */
+export function sameFileMutationFingerprint(
+  left: FileMutationFingerprint,
+  right: FileMutationFingerprint,
+): boolean {
+  return (
+    left.birthtimeNs === right.birthtimeNs &&
+    left.ctimeNs === right.ctimeNs &&
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mtimeNs === right.mtimeNs &&
+    left.size === right.size
+  );
+}
+
+/** Hashes from offset zero without moving or closing the caller's descriptor. */
+export function hashFileDescriptorSync(fd: number): { sha256: string; sizeBytes: number } {
+  const hash = createHash("sha256");
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+  let position = 0;
+  while (true) {
+    const bytesRead = readSync(fd, buffer, 0, buffer.length, position);
+    if (bytesRead === 0) {
+      break;
+    }
+    hash.update(buffer.subarray(0, bytesRead));
+    position += bytesRead;
+  }
+  return { sha256: hash.digest("hex"), sizeBytes: position };
+}
+
+/** Copies pinned handles; their owner retains mutation checks, sync, and publication. */
+export async function copyFileHandle(
+  source: FileHandle,
+  target: FileHandle,
+  options: { noProgressMessage: string; onChunk?: (chunk: Uint8Array) => void },
+): Promise<number> {
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+  let offset = 0;
+  while (true) {
+    const { bytesRead } = await source.read(buffer, 0, buffer.length, offset);
+    if (bytesRead === 0) {
+      return offset;
+    }
+    // A source digest must observe the bytes before any awaited target write.
+    options.onChunk?.(buffer.subarray(0, bytesRead));
+    let bytesWritten = 0;
+    while (bytesWritten < bytesRead) {
+      const result = await target.write(
+        buffer,
+        bytesWritten,
+        bytesRead - bytesWritten,
+        offset + bytesWritten,
+      );
+      if (result.bytesWritten === 0) {
+        throw new Error(options.noProgressMessage);
+      }
+      bytesWritten += result.bytesWritten;
+    }
+    offset += bytesRead;
+  }
+}

--- a/src/infra/sqlite-file-generation.ts
+++ b/src/infra/sqlite-file-generation.ts
@@ -1,18 +1,12 @@
-import { createHash } from "node:crypto";
 import fs, { type BigIntStats } from "node:fs";
+import {
+  hashFileDescriptorSync,
+  sameFileMutationFingerprint,
+  type FileMutationFingerprint,
+} from "./file-descriptor.js";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
 
-const SQLITE_GENERATION_HASH_BUFFER_BYTES = 1024 * 1024;
-
-type SqliteFileFingerprint = {
-  birthtimeNs: bigint;
-  ctimeNs: bigint;
-  dev: bigint;
-  ino: bigint;
-  mtimeNs: bigint;
-  sha256: string;
-  size: bigint;
-};
+type SqliteFileFingerprint = FileMutationFingerprint & { sha256: string };
 
 type SerializedSqliteFileFingerprint = {
   birthtimeNs: string;
@@ -46,27 +40,12 @@ function sameFileState(left: BigIntStats, right: BigIntStats): boolean {
   );
 }
 
-function hashFileDescriptor(fd: number): string {
-  const hash = createHash("sha256");
-  const buffer = Buffer.allocUnsafe(SQLITE_GENERATION_HASH_BUFFER_BYTES);
-  let position = 0;
-  while (true) {
-    const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, position);
-    if (bytesRead === 0) {
-      break;
-    }
-    hash.update(buffer.subarray(0, bytesRead));
-    position += bytesRead;
-  }
-  return hash.digest("hex");
-}
-
 function fingerprintFile(pathname: string): SqliteFileFingerprint {
   const fd = fs.openSync(pathname, "r");
   try {
     const before = fs.fstatSync(fd, { bigint: true });
     assertRegularFile(before);
-    const sha256 = hashFileDescriptor(fd);
+    const { sha256 } = hashFileDescriptorSync(fd);
     const after = fs.fstatSync(fd, { bigint: true });
     const current = fs.statSync(pathname, { bigint: true });
     if (!sameFileState(before, after) || !sameFileState(after, current)) {
@@ -118,15 +97,7 @@ export function readStableSqliteFileGeneration(pathname: string): SqliteFileGene
 }
 
 function sameFileFingerprint(left: SqliteFileFingerprint, right: SqliteFileFingerprint): boolean {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.birthtimeNs === right.birthtimeNs &&
-    left.ctimeNs === right.ctimeNs &&
-    left.mtimeNs === right.mtimeNs &&
-    left.sha256 === right.sha256 &&
-    left.size === right.size
-  );
+  return sameFileMutationFingerprint(left, right) && left.sha256 === right.sha256;
 }
 
 function sameOptionalFileFingerprint(

--- a/src/infra/sqlite-snapshot.ts
+++ b/src/infra/sqlite-snapshot.ts
@@ -1,6 +1,6 @@
 // Creates compact SQLite snapshots only after verifying both source and output.
 import { createHash, randomUUID } from "node:crypto";
-import fsSync, { type BigIntStats, type Stats } from "node:fs";
+import fsSync, { type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
@@ -15,6 +15,12 @@ import {
   syncDirectory,
 } from "./directory-durability.js";
 import { formatErrorMessage } from "./errors.js";
+import {
+  copyFileHandle,
+  hashFileDescriptorSync,
+  sameFileMutationFingerprint,
+  type FileMutationFingerprint,
+} from "./file-descriptor.js";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
 import {
   openNodeSqliteDatabase,
@@ -101,30 +107,13 @@ async function copyFileExclusive(
   try {
     target = await fs.open(targetPath, "wx+", 0o600);
     targetIdentity = await target.stat();
-    const buffer = Buffer.allocUnsafe(1024 * 1024);
     const hash = createHash("sha256");
-    let offset = 0;
-    while (true) {
-      const { bytesRead } = await source.read(buffer, 0, buffer.length, offset);
-      if (bytesRead === 0) {
-        break;
-      }
-      hash.update(buffer.subarray(0, bytesRead));
-      let bytesWritten = 0;
-      while (bytesWritten < bytesRead) {
-        const result = await target.write(
-          buffer,
-          bytesWritten,
-          bytesRead - bytesWritten,
-          offset + bytesWritten,
-        );
-        if (result.bytesWritten === 0) {
-          throw new Error(`SQLite snapshot copy made no progress: ${targetPath}`);
-        }
-        bytesWritten += result.bytesWritten;
-      }
-      offset += bytesRead;
-    }
+    const offset = await copyFileHandle(source, target, {
+      noProgressMessage: `SQLite snapshot copy made no progress: ${targetPath}`,
+      onChunk: (chunk) => {
+        hash.update(chunk);
+      },
+    });
     await assertMutationFingerprintUnchanged(source, sourceFingerprint, targetPath);
     await target.sync();
     const currentIdentity = await fs.lstat(targetPath);
@@ -147,11 +136,6 @@ async function copyFileExclusive(
   }
 }
 
-type FileMutationFingerprint = Pick<
-  BigIntStats,
-  "birthtimeNs" | "ctimeNs" | "dev" | "ino" | "mtimeNs" | "size"
->;
-
 async function readMutationFingerprint(handle: FileHandle): Promise<FileMutationFingerprint> {
   const stat = await handle.stat({ bigint: true });
   return {
@@ -170,30 +154,9 @@ async function assertMutationFingerprintUnchanged(
   filePath: string,
 ): Promise<void> {
   const current = await readMutationFingerprint(handle);
-  if (
-    current.birthtimeNs !== expected.birthtimeNs ||
-    current.ctimeNs !== expected.ctimeNs ||
-    current.dev !== expected.dev ||
-    current.ino !== expected.ino ||
-    current.mtimeNs !== expected.mtimeNs ||
-    current.size !== expected.size
-  ) {
+  if (!sameFileMutationFingerprint(current, expected)) {
     throw new Error(`SQLite snapshot file changed while reading: ${filePath}`);
   }
-}
-
-function sameMutationFingerprint(
-  left: FileMutationFingerprint,
-  right: FileMutationFingerprint,
-): boolean {
-  return (
-    left.birthtimeNs === right.birthtimeNs &&
-    left.ctimeNs === right.ctimeNs &&
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mtimeNs === right.mtimeNs &&
-    left.size === right.size
-  );
 }
 
 async function syncFile(filePath: string): Promise<void> {
@@ -301,17 +264,7 @@ function hashPublishedFileSync(filePath: string, expectedIdentity: Stats): Sqlit
       mtimeNs: initialStat.mtimeNs,
       size: initialStat.size,
     };
-    const hash = createHash("sha256");
-    const buffer = Buffer.allocUnsafe(1024 * 1024);
-    let offset = 0;
-    while (true) {
-      const bytesRead = fsSync.readSync(fileDescriptor, buffer, 0, buffer.length, offset);
-      if (bytesRead === 0) {
-        break;
-      }
-      hash.update(buffer.subarray(0, bytesRead));
-      offset += bytesRead;
-    }
+    const content = hashFileDescriptorSync(fileDescriptor);
     const finalStat = fsSync.fstatSync(fileDescriptor, { bigint: true });
     const finalFingerprint: FileMutationFingerprint = {
       birthtimeNs: finalStat.birthtimeNs,
@@ -321,11 +274,11 @@ function hashPublishedFileSync(filePath: string, expectedIdentity: Stats): Sqlit
       mtimeNs: finalStat.mtimeNs,
       size: finalStat.size,
     };
-    if (!sameMutationFingerprint(initialFingerprint, finalFingerprint)) {
+    if (!sameFileMutationFingerprint(initialFingerprint, finalFingerprint)) {
       throw new Error(`SQLite snapshot file changed while reading: ${filePath}`);
     }
     assertOpenFileIdentitySync(fileDescriptor, filePath, expectedIdentity);
-    return { sha256: hash.digest("hex"), sizeBytes: offset };
+    return content;
   } finally {
     fsSync.closeSync(fileDescriptor);
   }

--- a/src/snapshot/manifest.ts
+++ b/src/snapshot/manifest.ts
@@ -1,8 +1,9 @@
-import type { BigIntStats, Stats } from "node:fs";
+import type { Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { containsAsciiControlCharacter } from "@openclaw/normalization-core/string-normalization";
 import { sha256File } from "../infra/directory-durability.js";
+import { copyFileHandle, sameFileMutationFingerprint } from "../infra/file-descriptor.js";
 import { sameFileIdentity } from "../infra/fs-safe-advanced.js";
 import { root } from "../infra/fs-safe.js";
 import { isValidAgentId, normalizeAgentId } from "../routing/session-key.js";
@@ -88,45 +89,19 @@ async function hashFileHandle(
   const initialStat = await source.stat({ bigint: true });
   let sizeBytes = 0;
   if (target) {
-    const buffer = Buffer.allocUnsafe(1024 * 1024);
-    while (true) {
-      const { bytesRead } = await source.read(buffer, 0, buffer.length, sizeBytes);
-      if (bytesRead === 0) {
-        break;
-      }
-      let bytesWritten = 0;
-      while (bytesWritten < bytesRead) {
-        const result = await target.write(
-          buffer,
-          bytesWritten,
-          bytesRead - bytesWritten,
-          sizeBytes + bytesWritten,
-        );
-        if (result.bytesWritten === 0) {
-          throw new Error("Snapshot restore staging copy made no progress.");
-        }
-        bytesWritten += result.bytesWritten;
-      }
-      sizeBytes += bytesRead;
-    }
+    sizeBytes = await copyFileHandle(source, target, {
+      noProgressMessage: "Snapshot restore staging copy made no progress.",
+    });
   }
   const hashed = await sha256File(target ?? source);
   const finalStat = await source.stat({ bigint: true });
-  if (!sameMutationFingerprint(initialStat, finalStat) || (target && sizeBytes !== hashed.bytes)) {
+  if (
+    !sameFileMutationFingerprint(initialStat, finalStat) ||
+    (target && sizeBytes !== hashed.bytes)
+  ) {
     throw new Error("Snapshot artifact changed while being read.");
   }
   return { sha256: hashed.digest, sizeBytes: hashed.bytes };
-}
-
-function sameMutationFingerprint(left: BigIntStats, right: BigIntStats): boolean {
-  return (
-    left.birthtimeNs === right.birthtimeNs &&
-    left.ctimeNs === right.ctimeNs &&
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mtimeNs === right.mtimeNs &&
-    left.size === right.size
-  );
 }
 
 export async function writeSnapshotManifest(


### PR DESCRIPTION
## What Problem This Solves

Snapshot restore, SQLite publication, and database-generation verification repeat positioned file-copy/hash loops and strict mutation-fingerprint comparisons. Keeping those primitives separately makes integrity fixes prone to drift.

## Why This Change Was Made

`src/infra/file-descriptor.ts` owns the shared pinned-handle copy loop, synchronous descriptor SHA-256 loop, and six-field fingerprint equality. It retains 1 MiB buffers, complete short writes, zero-progress errors, and reads from offset zero without changing borrowed descriptor positions.

The lifecycle owners retain every open, stat, fsync, pathname identity check, publication fence, and cleanup decision. Snapshot restore still hashes the completed destination; SQLite publication still hashes source chunks synchronously before each awaited write. Generation's Windows-tolerant identity observations remain separate from strict persisted-fingerprint equality. The serialized generation fields and recovery semantics are unchanged.

## User Impact

None intended. Backup, restore, verification, and quarantine retain their existing behavior. No configuration, dependency, schema, retention, concurrency, or public-export change.

## Evidence

- `node scripts/run-vitest.mjs src/infra/file-descriptor.test.ts src/infra/sqlite-snapshot.test.ts`: 37 passed, 2 existing Windows-only skips. New real-filesystem cases cover multi-buffer tails, borrowed handle lifetime, and unchanged descriptor positions.
- Initial broader command including `src/snapshot` and `src/state/openclaw-database-verify.test.ts`: 121 passed, 4 existing platform skips, 2 timeouts. The 256 MiB Git backup child hit its 120-second timeout; the configured external-agent backup case also hit 120 seconds. The wrapper stopped before the infra shard, which was then run separately above.
- Unchanged timeout cases retried with `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/snapshot/git-backup-streaming.test.ts src/snapshot/git-backup.test.ts -t 'creates, restores, and verifies a 256 MiB|backs up a configured external agent database'`: both passed (116.3s and 13.8s). The original timeout limits and test assertions were unchanged. This was a diagnostic retry, not a new default.
- Autoreview: implementation and test cleanup follow-up both P0–P2 scoped-clean, zero findings.
- `node scripts/check-changed.mjs --base 8bd02ac5a391cffe60c224e9e5a0c8bbbab05e49`: passed.
- Production +105/-135, net -30 lines. Tests +62/-0.

Known proof limits: the serial 256 MiB case remains close to its existing timeout on this host; exact-head CI remains required. New tests do not inject short writes or zero-progress writes; that loop is moved unchanged. Native Windows-only cases were not executed locally; hosted Windows checks passed on the prior head.

CI [34079666441](https://github.com/openclaw/openclaw/actions/runs/34079666441) passed on the prior head, including Windows. The required fresh-main rebase onto `0bca64f26abd7b7afdeda9bd9684f3e99981d8e4` preserved both commits exactly (`git range-diff`). Exact-head CI [34080681241](https://github.com/openclaw/openclaw/actions/runs/34080681241) passed, including both Windows shards. Native hosted preparation passed; merged as `f1e333d14ba2112ce0bc2b9e9eb40dbfc8165674`, verified as an ancestor of current main. No task-owned Testbox lease was created; hosted CI supplied the native gate proof.
