### PR TITLE
fix: preserve run failure details in session status

### DIFF
--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -60,7 +60,7 @@ unchanged; click a title to rename it.
 
 Collapsed tool rows keep the tool label visible and truncate long summaries with an ellipsis. Tool and subagent activity rows use the same text size and weight. Running subagents show **Subagent** beside an animated indicator; terminal rows show **Subagent finished**, **Subagent failed**, or **Subagent cancelled**.
 
-A turn that fails before producing any reply leaves a durable notice in the thread.
+A turn that fails before producing any reply leaves a durable notice in the thread. Failed and timed-out turns also show the available failure reason in the sidebar's compact summary and run-error tooltip, including while a session refresh is still catching up.
 
 Chat error banners, including cloud runner failures, show short messages in full. Use **Copy error** beside **Details** in the header to copy the complete diagnostic received by the UI, even while collapsed. **Details** appears only when the complete diagnostic adds information beyond the preview, such as additional lines or text shortened for the preview; repeated lines and whitespace-only differences do not add details. Open it to read and select the complete diagnostic. The disclosure works with Enter or Space; the expanded text wraps long lines and can be scrolled with the keyboard. Copying does not open or close the details, and neither copying nor expanding an error retries the failed operation. Retry and other recovery actions remain separate from the disclosure.
 

--- a/src/agents/agent-run-terminal-outcome.ts
+++ b/src/agents/agent-run-terminal-outcome.ts
@@ -9,6 +9,7 @@ import {
 } from "@openclaw/normalization-core/agent-run-terminal-outcome";
 import { asFiniteNumber as asFiniteTimestamp } from "@openclaw/normalization-core/number-coercion";
 import { readNonBlankString as asNonEmptyString } from "@openclaw/normalization-core/string-coerce";
+import { formatErrorMessage } from "../infra/errors.js";
 import {
   formatAbandonedLivenessError,
   formatBlockedLivenessError,
@@ -436,7 +437,8 @@ function formatAgentRunTerminalOutcome(
   input: Pick<AgentRunTerminalInput, "error" | "startedAt" | "endedAt">,
 ): AgentRunTerminalOutcome {
   const { reason, status, ...metadata } = facts;
-  const rawError = asNonEmptyString(input.error);
+  const rawError =
+    input.error == null ? undefined : asNonEmptyString(formatErrorMessage(input.error));
   const error =
     reason === "hard_timeout"
       ? rawError

--- a/src/agents/embedded-agent-runner/run/terminal-outcome.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-outcome.test.ts
@@ -330,13 +330,14 @@ describe("embedded run attempt terminal outcome", () => {
     expect(
       resolveEmbeddedRunAttemptTerminalOutcome({
         attempt: makeAttempt({
-          terminal: { kind: "failed", source: "prompt", error: new Error("prompt failed") },
+          terminal: { kind: "failed", source: "prompt", error: new Error("database is locked") },
         }),
         assistant: makeAssistant("stop"),
       }),
     ).toMatchObject({
       reason: "failed",
       status: "error",
+      error: "database is locked",
     });
     const nullFailure = resolveEmbeddedRunAttemptTerminalOutcome({
       attempt: makeAttempt({
@@ -393,6 +394,26 @@ describe("embedded run attempt terminal outcome", () => {
         }),
         assistant: makeAssistant("stop"),
       }),
-    ).toMatchObject({ reason: "failed", status: "error" });
+    ).toMatchObject({ reason: "failed", status: "error", error: "settlement failed" });
+  });
+
+  it("preserves nested failure details without exposing credentials", () => {
+    const credential = "sk-test-" + "x".repeat(32);
+    const outcome = resolveEmbeddedRunAttemptTerminalOutcome({
+      attempt: makeAttempt({
+        terminal: {
+          kind: "failed",
+          source: "prompt",
+          error: new Error("request failed", {
+            cause: new Error(`database is locked; api_key=${credential}`),
+          }),
+        },
+      }),
+      assistant: undefined,
+    });
+
+    expect(outcome.error).toContain("request failed");
+    expect(outcome.error).toContain("database is locked");
+    expect(outcome.error).not.toContain(credential);
   });
 });

--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -415,158 +415,190 @@ suite.define(() => {
     ).toBe(0);
   });
 
-  it("clears shared session activity when chat final arrives first", async () => {
-    const context = await suite.newBrowserContext({ viewport: { height: 800, width: 1200 } });
-    const currentPage = await context.newPage();
-    page = currentPage;
-    await currentPage.clock.install();
-    const gateway = await installMockGateway(currentPage, {
-      historyMessages: [
-        {
-          content: [{ text: "Ready for run lifecycle verification.", type: "text" }],
-          role: "assistant",
-          timestamp: Date.now(),
-        },
-      ],
-    });
+  it.each(["final", "error"] as const)(
+    "clears shared session activity when chat %s arrives first",
+    async (terminalState) => {
+      const context = await suite.newBrowserContext({ viewport: { height: 800, width: 1200 } });
+      const currentPage = await context.newPage();
+      page = currentPage;
+      await currentPage.clock.install();
+      const gateway = await installMockGateway(currentPage, {
+        historyMessages: [
+          {
+            content: [{ text: "Ready for run lifecycle verification.", type: "text" }],
+            role: "assistant",
+            timestamp: Date.now(),
+          },
+        ],
+      });
 
-    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
-    await currentPage
-      .getByText("Ready for run lifecycle verification.")
-      .waitFor({ timeout: 10_000 });
-    await gateway.waitForRequest("sessions.list", { match: rosterMatch });
-    await currentPage.locator(".agent-chat__input textarea").fill("finish this run");
-    await currentPage.getByRole("button", { name: "Send message" }).click();
-    const send = await gateway.waitForRequest("chat.send");
-    const params = send.params as { idempotencyKey?: unknown };
-    expect(typeof params.idempotencyKey).toBe("string");
-    const runId = params.idempotencyKey as string;
+      await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
+      await currentPage
+        .getByText("Ready for run lifecycle verification.")
+        .waitFor({ timeout: 10_000 });
+      await gateway.waitForRequest("sessions.list", { match: rosterMatch });
+      await currentPage.locator(".agent-chat__input textarea").fill("finish this run");
+      await currentPage.getByRole("button", { name: "Send message" }).click();
+      const send = await gateway.waitForRequest("chat.send");
+      const params = send.params as { idempotencyKey?: unknown };
+      expect(typeof params.idempotencyKey).toBe("string");
+      const runId = params.idempotencyKey as string;
 
-    await currentPage.getByRole("button", { name: "Stop generating" }).waitFor();
-    const mainSession = currentPage.locator(".nav-item--home");
-    // Home mirrors session rows: active-run state lives in the trailing metadata endcap.
-    const mainSessionRunIndicator = mainSession
-      .locator(".nav-item__state")
-      .getByRole("img", { name: "Active run" });
-    await mainSession.waitFor({ state: "visible" });
-    const sessionListsBeforeActive = (await gateway.getRequests("sessions.list", rosterMatch))
-      .length;
-    await gateway.deferNext("sessions.list", rosterMatch);
-    const activeUpdatedAt = Date.now();
-    const activeStartedAt = activeUpdatedAt - 1_000;
-    await gateway.emitGatewayEvent("sessions.changed", {
-      activeRunIds: [runId],
-      hasActiveRun: true,
-      key: "agent:main:main",
-      kind: "direct",
-      reason: "lifecycle",
-      startedAt: activeStartedAt,
-      status: "running",
-      updatedAt: activeUpdatedAt,
-    });
-    await expect
-      .poll(async () => (await gateway.getRequests("sessions.list", rosterMatch)).length)
-      .toBeGreaterThan(sessionListsBeforeActive);
-    await mainSessionRunIndicator.waitFor();
+      await currentPage.getByRole("button", { name: "Stop generating" }).waitFor();
+      const mainSession = currentPage.locator(".nav-item--home");
+      // Home mirrors session rows: active-run state lives in the trailing metadata endcap.
+      const mainSessionRunIndicator = mainSession
+        .locator(".nav-item__state")
+        .getByRole("img", { name: "Active run" });
+      await mainSession.waitFor({ state: "visible" });
+      const sessionListsBeforeActive = (await gateway.getRequests("sessions.list", rosterMatch))
+        .length;
+      await gateway.deferNext("sessions.list", rosterMatch);
+      const activeUpdatedAt = Date.now();
+      const activeStartedAt = activeUpdatedAt - 1_000;
+      await gateway.emitGatewayEvent("sessions.changed", {
+        activeRunIds: [runId],
+        hasActiveRun: true,
+        key: "agent:main:main",
+        kind: "direct",
+        reason: "lifecycle",
+        startedAt: activeStartedAt,
+        status: "running",
+        updatedAt: activeUpdatedAt,
+      });
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.list", rosterMatch)).length)
+        .toBeGreaterThan(sessionListsBeforeActive);
+      await mainSessionRunIndicator.waitFor();
 
-    await gateway.emitChatFinal({ runId, text: "Run complete." });
-    await currentPage.locator(".chat-bubble").getByText("Run complete.", { exact: true }).waitFor();
-    await expect.poll(() => mainSessionRunIndicator.count()).toBe(0);
-    const staleActiveLabel = "Main stale active snapshot";
-    await gateway.resolveDeferred("sessions.list", {
-      count: 1,
-      defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
-      path: "",
-      sessions: [
-        {
-          activeRunIds: [runId],
-          displayName: staleActiveLabel,
-          hasActiveRun: true,
-          key: "agent:main:main",
-          kind: "direct",
-          label: staleActiveLabel,
-          model: "gpt-5.5",
-          modelProvider: "openai",
-          startedAt: activeStartedAt,
-          status: "running",
-          updatedAt: activeUpdatedAt,
-        },
-      ],
-      ts: activeUpdatedAt,
-    });
-    await currentPage.locator(".chat-pane__session-title", { hasText: staleActiveLabel }).waitFor();
-    expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
-    await expect.poll(() => mainSessionRunIndicator.count()).toBe(0);
+      const diagnostic =
+        "Provider request failed: session store unavailable. Retry after recovery.";
+      if (terminalState === "error") {
+        await gateway.emitGatewayEvent("chat", {
+          runId,
+          sessionKey: "agent:main:main",
+          state: "error",
+          errorMessage: diagnostic,
+        });
+        try {
+          await currentPage.getByRole("alert").filter({ hasText: diagnostic }).waitFor();
+          await mainSession.locator('[data-session-attention="error"]').waitFor();
+          expect(await mainSession.getAttribute("aria-label")).toContain(diagnostic);
+          expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(
+            0,
+          );
+          await expect.poll(() => mainSessionRunIndicator.count()).toBe(0);
+        } finally {
+          await gateway.resolveDeferred("sessions.list");
+        }
+        return;
+      }
+      await gateway.emitChatFinal({ runId, text: "Run complete." });
+      await currentPage
+        .locator(".chat-bubble")
+        .getByText("Run complete.", { exact: true })
+        .waitFor();
+      await expect.poll(() => mainSessionRunIndicator.count()).toBe(0);
+      const staleActiveLabel = "Main stale active snapshot";
+      await gateway.resolveDeferred("sessions.list", {
+        count: 1,
+        defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
+        path: "",
+        sessions: [
+          {
+            activeRunIds: [runId],
+            displayName: staleActiveLabel,
+            hasActiveRun: true,
+            key: "agent:main:main",
+            kind: "direct",
+            label: staleActiveLabel,
+            model: "gpt-5.5",
+            modelProvider: "openai",
+            startedAt: activeStartedAt,
+            status: "running",
+            updatedAt: activeUpdatedAt,
+          },
+        ],
+        ts: activeUpdatedAt,
+      });
+      await currentPage
+        .locator(".chat-pane__session-title", { hasText: staleActiveLabel })
+        .waitFor();
+      expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
+      await expect.poll(() => mainSessionRunIndicator.count()).toBe(0);
 
-    const sessionListsBeforeStaleActive = (await gateway.getRequests("sessions.list", rosterMatch))
-      .length;
-    await gateway.deferNext("sessions.list", rosterMatch);
-    await gateway.emitGatewayEvent("sessions.changed", {
-      activeRunIds: [runId],
-      hasActiveRun: true,
-      key: "agent:main:main",
-      kind: "direct",
-      reason: "lifecycle",
-      startedAt: Date.now() - 1_000,
-      status: "running",
-      updatedAt: Date.now(),
-    });
-    await expect
-      .poll(async () => (await gateway.getRequests("sessions.list", rosterMatch)).length)
-      .toBeGreaterThan(sessionListsBeforeStaleActive);
-    expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
-    await expect.poll(() => mainSessionRunIndicator.count()).toBe(0);
-    await gateway.resolveDeferred("sessions.list");
+      const sessionListsBeforeStaleActive = (
+        await gateway.getRequests("sessions.list", rosterMatch)
+      ).length;
+      await gateway.deferNext("sessions.list", rosterMatch);
+      await gateway.emitGatewayEvent("sessions.changed", {
+        activeRunIds: [runId],
+        hasActiveRun: true,
+        key: "agent:main:main",
+        kind: "direct",
+        reason: "lifecycle",
+        startedAt: Date.now() - 1_000,
+        status: "running",
+        updatedAt: Date.now(),
+      });
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.list", rosterMatch)).length)
+        .toBeGreaterThan(sessionListsBeforeStaleActive);
+      expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
+      await expect.poll(() => mainSessionRunIndicator.count()).toBe(0);
+      await gateway.resolveDeferred("sessions.list");
 
-    await currentPage.clock.fastForward(CHAT_RUN_STATUS_TOAST_DURATION_MS + 250);
-    expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
-    expect(await mainSessionRunIndicator.count()).toBe(0);
+      await currentPage.clock.fastForward(CHAT_RUN_STATUS_TOAST_DURATION_MS + 250);
+      expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
+      expect(await mainSessionRunIndicator.count()).toBe(0);
 
-    // Event timestamps must follow the page's virtual clock so freshness checks
-    // see the same elapsed suppression window that the UI just observed.
-    const otherSessionUpdatedAt = await currentPage.evaluate(() => Date.now());
-    const sessionListsBeforeOtherSession = (await gateway.getRequests("sessions.list", rosterMatch))
-      .length;
-    await gateway.deferNext("sessions.list", rosterMatch);
-    await gateway.emitGatewayEvent("sessions.changed", {
-      key: "agent:main:another-session",
-      kind: "direct",
-      label: "Another session",
-      reason: "lifecycle",
-      updatedAt: otherSessionUpdatedAt,
-    });
-    await expect
-      .poll(async () => (await gateway.getRequests("sessions.list", rosterMatch)).length)
-      .toBeGreaterThan(sessionListsBeforeOtherSession);
-    expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
-    await expect.poll(() => mainSessionRunIndicator.count()).toBe(0);
-    await gateway.resolveDeferred("sessions.list");
+      // Event timestamps must follow the page's virtual clock so freshness checks
+      // see the same elapsed suppression window that the UI just observed.
+      const otherSessionUpdatedAt = await currentPage.evaluate(() => Date.now());
+      const sessionListsBeforeOtherSession = (
+        await gateway.getRequests("sessions.list", rosterMatch)
+      ).length;
+      await gateway.deferNext("sessions.list", rosterMatch);
+      await gateway.emitGatewayEvent("sessions.changed", {
+        key: "agent:main:another-session",
+        kind: "direct",
+        label: "Another session",
+        reason: "lifecycle",
+        updatedAt: otherSessionUpdatedAt,
+      });
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.list", rosterMatch)).length)
+        .toBeGreaterThan(sessionListsBeforeOtherSession);
+      expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
+      await expect.poll(() => mainSessionRunIndicator.count()).toBe(0);
+      await gateway.resolveDeferred("sessions.list");
 
-    // Re-publish after the former 10-second suppression window. The completed
-    // run identity stays terminal until the Gateway publishes different state.
-    await currentPage.clock.fastForward(CHAT_RUN_STATUS_TOAST_DURATION_MS + 250);
-    const lateStaleActiveUpdatedAt = await currentPage.evaluate(() => Date.now());
-    const sessionListsBeforeLateStaleActive = (
-      await gateway.getRequests("sessions.list", rosterMatch)
-    ).length;
-    await gateway.deferNext("sessions.list", rosterMatch);
-    await gateway.emitGatewayEvent("sessions.changed", {
-      activeRunIds: [runId],
-      hasActiveRun: true,
-      key: "agent:main:main",
-      kind: "direct",
-      reason: "lifecycle",
-      startedAt: lateStaleActiveUpdatedAt - 11_000,
-      status: "running",
-      updatedAt: lateStaleActiveUpdatedAt,
-    });
-    await expect
-      .poll(async () => (await gateway.getRequests("sessions.list", rosterMatch)).length)
-      .toBeGreaterThan(sessionListsBeforeLateStaleActive);
-    expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
-    await expect.poll(() => mainSessionRunIndicator.count()).toBe(0);
-    await gateway.resolveDeferred("sessions.list");
-  });
+      // Re-publish after the former 10-second suppression window. The completed
+      // run identity stays terminal until the Gateway publishes different state.
+      await currentPage.clock.fastForward(CHAT_RUN_STATUS_TOAST_DURATION_MS + 250);
+      const lateStaleActiveUpdatedAt = await currentPage.evaluate(() => Date.now());
+      const sessionListsBeforeLateStaleActive = (
+        await gateway.getRequests("sessions.list", rosterMatch)
+      ).length;
+      await gateway.deferNext("sessions.list", rosterMatch);
+      await gateway.emitGatewayEvent("sessions.changed", {
+        activeRunIds: [runId],
+        hasActiveRun: true,
+        key: "agent:main:main",
+        kind: "direct",
+        reason: "lifecycle",
+        startedAt: lateStaleActiveUpdatedAt - 11_000,
+        status: "running",
+        updatedAt: lateStaleActiveUpdatedAt,
+      });
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.list", rosterMatch)).length)
+        .toBeGreaterThan(sessionListsBeforeLateStaleActive);
+      expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
+      await expect.poll(() => mainSessionRunIndicator.count()).toBe(0);
+      await gateway.resolveDeferred("sessions.list");
+    },
+  );
 
   it("does not announce Done when a yielded parent is waiting for continuation", async () => {
     const context = await suite.newBrowserContext({ viewport: { height: 800, width: 1200 } });

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -792,18 +792,30 @@ describe("createSessionCapability", () => {
       sessions.reconcileRunTerminal({
         sessionKeys: ["main"],
         runId: "run-1",
-        status: "done",
+        status: "failed",
+        errorMessage: `Provider failed.\npassword=synthetic-password\n${"x".repeat(180)}`,
         endedAt: 160,
       }),
     ).toBe(true);
+    const lastRunError = `Provider failed. password=[redacted] ${"x".repeat(123)}`;
     expect(sessions.state.result?.sessions[0]).toMatchObject({
       key,
       hasActiveRun: false,
       activeRunIds: [],
-      status: "done",
+      status: "failed",
+      lastRunError,
       endedAt: 160,
       runtimeMs: 60,
     });
+    expect(
+      sessions.reconcileRunTerminal({
+        sessionKeys: ["main"],
+        runId: "run-1",
+        status: "failed",
+        endedAt: 160,
+      }),
+    ).toBe(false);
+    expect(sessions.state.result?.sessions[0]?.lastRunError).toBe(lastRunError);
 
     expect(
       sessions.reconcile({
@@ -814,6 +826,7 @@ describe("createSessionCapability", () => {
         activeRunIds: ["run-2"],
         status: "running",
         startedAt: 200,
+        lastRunError,
       }),
     ).toBe(true);
     expect(
@@ -828,7 +841,21 @@ describe("createSessionCapability", () => {
       hasActiveRun: true,
       activeRunIds: ["run-2"],
       status: "running",
+      lastRunError,
     });
+    expect(
+      sessions.reconcileRunTerminal({
+        sessionKeys: ["main"],
+        runId: "run-2",
+        status: "done",
+        endedAt: 260,
+      }),
+    ).toBe(true);
+    expect(sessions.state.result?.sessions[0]).toMatchObject({
+      hasActiveRun: false,
+      status: "done",
+    });
+    expect(sessions.state.result?.sessions[0]?.lastRunError).toBeUndefined();
 
     expect(
       sessions.reconcile({

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -1,6 +1,8 @@
 import { asNullableRecord as recordOrNull } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString as stringValue } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { GatewaySessionRow, SessionRunStatus, SessionsListResult } from "../../api/types.ts";
+import { formatUiExternalText } from "../format-error.ts";
 import { isSessionRunActive } from "../session-run-state.ts";
 import {
   compareSessionRowsByUpdatedAt,
@@ -42,6 +44,7 @@ export type SessionRunTerminal = {
   runId?: string | null;
   /** Latest session status after this owned model run leaves the active registry. */
   status: SessionRunStatus;
+  errorMessage?: string;
   endedAt: number;
 };
 
@@ -675,6 +678,11 @@ export function reconcileSessionRunTerminal(
     return result;
   }
   const runId = terminal.runId?.trim() || null;
+  // Match the Gateway's compact session error projection, redacting before truncation.
+  const errorMessage = truncateUtf16Safe(
+    formatUiExternalText(terminal.errorMessage).replace(/\s+/g, " ").trim(),
+    160,
+  );
   let changed = false;
   const sessions = result.sessions.map((row): GatewaySessionRow => {
     if (!keys.some((key) => areUiSessionKeysEquivalent(row.key, key))) {
@@ -691,6 +699,10 @@ export function reconcileSessionRunTerminal(
       changed = true;
       return { ...row, activeRunIds: remainingRunIds, hasActiveRun: true, status: "running" };
     }
+    const lastRunError =
+      terminal.status === "failed" || terminal.status === "timeout"
+        ? errorMessage || row.lastRunError
+        : undefined;
     const endedAt = row.endedAt ?? terminal.endedAt;
     const runtimeMs =
       typeof row.startedAt === "number" ? Math.max(0, endedAt - row.startedAt) : row.runtimeMs;
@@ -704,6 +716,7 @@ export function reconcileSessionRunTerminal(
     if (
       row.hasActiveRun === false &&
       row.status === terminal.status &&
+      row.lastRunError === lastRunError &&
       row.endedAt === endedAt &&
       row.runtimeMs === runtimeMs &&
       row.activeRunIds === activeRunIds &&
@@ -717,6 +730,7 @@ export function reconcileSessionRunTerminal(
       activeRunIds,
       hasActiveRun: false,
       status: terminal.status,
+      lastRunError,
       endedAt,
       runtimeMs,
       abortedLastRun,

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -5,6 +5,7 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import { GatewayRequestError } from "../../api/gateway.ts";
+import type { SessionsListResult } from "../../api/types.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
 import { handleChatGatewayEvent, type ChatEventPayload } from "./chat-gateway.ts";
 import { getChatHistoryLoadState } from "./chat-history-state.ts";
@@ -17,6 +18,11 @@ import {
   publishChatSessionProjection,
   publishChatSessionProjectionMessages,
 } from "./history-merge.ts";
+import {
+  reconcileChatRunAfterSessionStatePublication,
+  type ChatRunUiStatus,
+  type LocalTerminalReconcile,
+} from "./run-lifecycle.ts";
 import { cacheChatSessionSnapshot, readChatMessagesFromCache } from "./session-message-cache.ts";
 import {
   visibleAssistantStreamParts,
@@ -116,40 +122,34 @@ function seedChatSnapshot(
 
 type SessionTestState = ChatState & {
   [key: string]: unknown;
-  chatRunStatus?: { phase: string; runId: string | null; sessionKey: string } | null;
+  chatRunStatus?: ChatRunUiStatus | null;
   knownAgentRunIds: Set<string>;
-  lastLocalTerminalReconcile?: {
-    phase: string;
-    runId: string | null;
-    sessionKey: string;
-    sessionStatus: string;
-  } | null;
-  sessionsResult: {
-    [key: string]: unknown;
-    sessions: Array<Record<string, unknown>>;
-  };
+  lastLocalTerminalReconcile?: LocalTerminalReconcile | null;
+  sessionsResult: SessionsListResult;
 };
 
 function createStateWithRunningSession(overrides: Partial<ChatState>): SessionTestState {
-  const state = createState(overrides) as SessionTestState;
-  state.sessionsResult = {
-    ts: 0,
-    path: "",
-    count: 1,
-    defaults: {},
-    sessions: [
-      {
-        key: "main",
-        kind: "direct",
-        updatedAt: 1,
-        hasActiveRun: true,
-        activeRunIds: ["run-1"],
-        status: "running",
-        startedAt: 100,
-      },
-    ],
+  return {
+    ...createState(overrides),
+    knownAgentRunIds: new Set(["run-1"]),
+    sessionsResult: {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: [
+        {
+          key: "main",
+          kind: "direct",
+          updatedAt: 1,
+          hasActiveRun: true,
+          activeRunIds: ["run-1"],
+          status: "running",
+          startedAt: 100,
+        },
+      ],
+    },
   };
-  return state;
 }
 
 type HistoryToolSegment = { text: string; ts: number; toolCallId?: string };
@@ -1182,6 +1182,7 @@ describe("handleChatGatewayEvent", () => {
           chatStream: "Partial assistant reply",
           chatStreamStartedAt: 100,
         });
+        const staleSessionsResult = state.sessionsResult;
 
         expect(
           handleChatGatewayEvent(state, {
@@ -1199,6 +1200,7 @@ describe("handleChatGatewayEvent", () => {
           hasActiveRun: false,
           status: sessionStatus,
         });
+        expect(state.sessionsResult.sessions[0]?.lastRunError ?? null).toBe(errorSummary);
         expect(state.lastLocalTerminalReconcile?.sessionStatus).toBe(sessionStatus);
         expect(state.chatRunStatus).toMatchObject({
           phase: "interrupted",
@@ -1209,6 +1211,14 @@ describe("handleChatGatewayEvent", () => {
         expect(state.chatRunId).toBeNull();
         expect(state.chatStream).toBeNull();
         expect(state.chatStreamStartedAt).toBeNull();
+
+        state.sessionsResult = staleSessionsResult;
+        expect(reconcileChatRunAfterSessionStatePublication(state)).toBe(true);
+        expect(state.sessionsResult.sessions[0]).toMatchObject({
+          hasActiveRun: false,
+          status: sessionStatus,
+        });
+        expect(state.sessionsResult.sessions[0]?.lastRunError ?? null).toBe(errorSummary);
       } finally {
         vi.useRealTimers();
       }

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -239,6 +239,9 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     reconcileChatRunLifecycle(state, {
       outcome: terminalStatus === "completed" ? "done" : "interrupted",
       sessionStatus,
+      errorMessage: payload.errorMessage?.trim()
+        ? resolveGatewayErrorText(payload, null)
+        : undefined,
       runId: terminalRunId,
       sessionKey: state.sessionKey,
       sessionKeys,

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -59,6 +59,7 @@ export type LocalTerminalReconcile = {
   runId: string | null;
   phase: ChatRunUiStatus["phase"];
   sessionStatus: TerminalSessionRunStatus;
+  errorMessage?: string;
 };
 
 type TimerHandle = ReturnType<typeof globalThis.setTimeout>;
@@ -93,6 +94,7 @@ type RunLifecycleHost = Omit<
 type ReconcileOptions = {
   outcome?: ChatRunUiStatus["phase"];
   sessionStatus?: TerminalSessionRunStatus;
+  errorMessage?: string;
   runId?: string | null;
   sessionKey?: string | null;
   sessionKeys?: readonly (string | null | undefined)[];
@@ -495,6 +497,7 @@ function reconcileSessionRows(
     sessionKeys: [...keys],
     runId: options.runId ?? host.chatRunId ?? null,
     status,
+    errorMessage: options.errorMessage,
     endedAt: occurredAt,
   };
   if (host.sessionsResult) {
@@ -563,6 +566,7 @@ export function reconcileChatRunLifecycle(host: RunLifecycleHost, options: Recon
         runId,
         phase: options.outcome,
         sessionStatus: options.sessionStatus ?? (options.outcome === "done" ? "done" : "killed"),
+        errorMessage: options.errorMessage,
       };
     }
     if (options.publishRunStatus !== false) {
@@ -626,6 +630,7 @@ function reconcileStaleSelectedSessionRunAfterLocalCompletion(host: RunLifecycle
     {
       outcome: recent.phase,
       sessionStatus: recent.sessionStatus,
+      errorMessage: recent.errorMessage,
       sessionKey: recent.sessionKey,
       runId: recent.runId,
     },


### PR DESCRIPTION
Related: #139409

## What Problem This Solves

Fixes an issue where users see **Run failed: Unknown error** in session status even though the failed run supplied a useful diagnostic. The chat banner could already show the reason while the sidebar lost it, especially when the chat terminal event arrived before the session snapshot.

## Why This Change Was Made

Preserve error-object messages through the canonical terminal-outcome formatter using the existing redactor. Carry the chat event's failure reason through local session terminal reconciliation and its delayed-snapshot replay path, updating both the selected pane and the shared session store. Sidebar diagnostics retain the existing compact, whitespace-normalized, 160-character contract; complete chat diagnostics remain in the existing banner and Details view.

Existing run-identity guards, cancellation/timeout precedence, and authoritative session refresh behavior stay intact. Status-only failure updates retain an existing reason, while a successful owning terminal clears old failure details. No schema, configuration, storage-concurrency, or automatic-retry policy changes are included.

## User Impact

Available failure reasons appear immediately in session status instead of being replaced with Unknown error. Reasons survive a delayed refresh, and nested errors retain useful detail without exposing credentials.

## Evidence

- Failing-first core regression: the original code returned a failed outcome without the supplied `Error("database is locked")` message (1 failed, 23 passed).
- Failing-first UI regressions: provider failure, timeout, and shared session terminal updates had no `lastRunError`, although the chat event supplied a reason (3 failures).
- Focused core terminal and Gateway lifecycle suites: **132 passed**.
- Focused chat Gateway, chat run lifecycle, shared session store, and session reconciliation suites: **286 passed**.
- Bundled Control UI browser flow with mocked Gateway WebSocket events: **2 passed** (success and failure); 9 unrelated cases excluded by the targeted filter. It verifies that a chat failure reaches the sidebar before the delayed session refresh, while the existing success/stale-row replay scenario remains intact.
- Before/after image capture was attempted twice but the synthetic Home tooltip did not become visible; no screenshots are claimed. The browser assertions verify the diagnostic in the chat alert and sidebar accessibility label. No markup or styling changed.
- Independent Codex autoreview through P2: **scoped-clean**, no accepted/actionable findings.
- `node scripts/check-changed.mjs`: **passed**, including core/test/UI typechecks, formatting, lint, dead-export scans, repository guards, and zero runtime import cycles. Typechecking exposed outdated handwritten fixture types; the fixture now uses the real lifecycle and session-result types, with complete required defaults. Its 183-test file passed again after that correction.

- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34079060254): **green** for `55e144c01543e3573d3feaa16017bc7e10692002`, no pending checks. The first attempt failed an unrelated current-main Workshop blank-line-height assertion in `skill-workshop-collection.e2e.test.ts:135`; the failed job passed on one unchanged-head rerun. No viewer code, styles, assertions, or timeouts were changed to obtain that pass.
- ClawSweeper reviewed the same head with no actionable findings or before-merge requests.

The separate SQLite reclamation lock cycle is addressed by already-landed #139469 and #139689; this PR repairs diagnostic propagation, not database locking.
