### PR TITLE
fix(ollama): preserve prompt cache across tool catalog reordering

### DIFF
--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -188,6 +188,7 @@ If you see unexpected `cacheWrite` spikes after a config or workspace change, ch
 
 - Delivery instructions live after the system-prompt cache boundary. Native Codex carries the current delivery and target policy in late turn context, so alternating delivery modes does not rebuild its static prompt or message tool catalog when the available capabilities remain unchanged. Actual capability changes still update the catalog.
 - Bundled MCP tool catalogs are sorted deterministically (by server name, then tool name) before tool registration, so `listTools()` order changes do not churn the tools block and bust prompt-cache prefixes.
+- Native Ollama requests sort tool definitions by name, so callers returning the same catalog in a different order do not change its prompt prefix. Changed tool descriptions or schemas still update the request.
 - Legacy sessions with persisted image blocks keep the **3 most recent completed turns** intact (counting all completed turns, not just image-bearing ones). Older already-processed image blocks are replaced with a text marker so image-heavy follow-ups do not keep re-sending large stale payloads.
 
 ## Tuning patterns

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -628,6 +628,43 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
       },
     );
   });
+
+  it("keeps native tool payloads stable when callers reorder the same catalog", async () => {
+    const tools = [
+      {
+        name: "zebra",
+        description: "Look up a record",
+        parameters: { type: "object", properties: { id: { type: "string" } } },
+      },
+      {
+        name: "alpha",
+        description: "Search records",
+        parameters: { type: "object", properties: { query: { type: "string" } } },
+      },
+    ];
+    const bodies: Record<string, unknown>[] = [];
+    for (const catalog of [tools, tools.toReversed()]) {
+      fetchWithSsrFGuardMock.mockClear();
+      await expectSuccessfulOllamaRequest(
+        {
+          baseUrl: "http://ollama-host:11434",
+          context: {
+            systemPrompt: "Use the available record tools.",
+            messages: [{ role: "user", content: "Find the requested record." }],
+            tools: catalog,
+          },
+        },
+        ({ body }) => {
+          bodies.push(body);
+        },
+      );
+    }
+    expect(bodies[0]).toEqual(bodies[1]);
+    expect(bodies[0]?.tools).toEqual(
+      tools.toReversed().map((tool) => ({ type: "function", function: tool })),
+    );
+    expect(tools.map((tool) => tool.name)).toEqual(["zebra", "alpha"]);
+  });
 });
 
 describe("convertToOllamaMessages", () => {

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -32,6 +32,7 @@ import {
   MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE,
   notifyProviderHttpResponse,
   parseTerminalToolCallArguments,
+  sortPromptCacheToolsByName,
 } from "openclaw/plugin-sdk/provider-transport-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
@@ -799,7 +800,8 @@ function extractOllamaTools(tools: Tool[] | undefined): OllamaTool[] {
     return [];
   }
   const result: OllamaTool[] = [];
-  for (const tool of tools) {
+  // Tool discovery order must not invalidate the model's otherwise reusable prompt prefix.
+  for (const tool of sortPromptCacheToolsByName(tools)) {
     if (typeof tool.name !== "string" || !tool.name) {
       continue;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where local Ollama users could pay repeated prompt-processing costs when tool discovery returned an unchanged catalog in a different order.

## Why This Change Was Made

Sort native Ollama tool definitions with the existing prompt-cache stability helper before constructing the request. This matches the other provider adapters and preserves every tool definition and the caller's original array.

## User Impact

An unchanged tool catalog retains a stable prompt prefix across discovery-order changes. Actual changes to tool descriptions or schemas still reach the model.

## Evidence

- The regression fails on the original implementation because reversed discovery order changes the outbound request; the complete native stream suite passes with the fix (191 tests).
- Full changed-file checks and independent review pass.
- Native Ollama 0.33.3, `qwen3.5:4b-q4_K_M`, 32K context, eight synthetic tools, identical prompt and sampling controls. Two fresh-server arms each submitted caller order `A, A, B, B, A`; the fixed arm canonicalized both orders. All 10 requests returned the expected exact tool call. Native request captures matched every submitted body, and both owned runtimes were cleaned up.

At the first changed-order request (call 3):

| Native metric | Original order | Stable order |
| --- | ---: | ---: |
| Prompt tokens | 6,026 | 6,026 |
| Cached prompt tokens | 0 | 6,022 |
| Newly processed tokens | 6,026 | 4 |
| Prompt processing | 3.126 s | 0.038 s |
| Request wall time | 6.007 s | 0.931 s |

This is one synthetic run on one model, not a general speedup claim. The original arm reused its saved cache when it returned to order A on call 5; not every reorder necessarily misses. Cold-load and whole-arm times are excluded because background source scanning and filesystem warming confounded them.

Direct production-adapter validation also passes: two real streaming requests through `createOllamaStreamFn`, preserving the existing native live case's custom provider prefix, tool-schema normalization, keep-alive, completion, and usage assertions. Both server-captured request bodies exactly match the adapter payloads. The warm request reported 331 cached / 4 uncached tokens. Source fingerprints were unchanged and all owned processes were cleaned up.

The ordinary native Vitest invocation was attempted twice and hit the existing startup watchdog before sending any model request. The diagnostic run located the wait in shared compiled-subprocess preparation (8,529 inputs / 4,268 outputs), before collection of this test. Neither source nor test deadlines were changed; both failed runs were retained and their owned processes cleaned up.
