### PR TITLE
refactor(memory): remove dreaming coercion wrappers

### DIFF
--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -176,23 +176,6 @@ const DEFAULT_MEMORY_DEEP_DREAMING_SOURCES: MemoryDeepDreamingSource[] = [
 ];
 const DEFAULT_MEMORY_REM_DREAMING_SOURCES: MemoryRemDreamingSource[] = ["memory", "daily", "deep"];
 
-function normalizeNonNegativeInt(value: unknown, fallback: number): number {
-  // Config integers are decimal-only; Number() would accept hex/exponent forms.
-  return parseStrictNonNegativeInteger(value) ?? fallback;
-}
-
-function normalizeOptionalPositiveInt(value: unknown): number | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  // Same strict decimal contract as normalizeNonNegativeInt for optional fields.
-  return parseStrictPositiveInteger(value);
-}
-
-function normalizeBoolean(value: unknown, fallback: boolean): boolean {
-  return parseBoolean(value) ?? fallback;
-}
-
 function normalizeScore(value: unknown, fallback: number): number {
   const normalized = normalizeStringifiedOptionalString(value);
   if (typeof value === "string" && !normalized) {
@@ -203,10 +186,6 @@ function normalizeScore(value: unknown, fallback: number): number {
     return fallback;
   }
   return num;
-}
-
-function normalizeSimilarity(value: unknown, fallback: number): number {
-  return normalizeScore(value, fallback);
 }
 
 function normalizeStringArray<T extends string>(
@@ -268,8 +247,8 @@ function resolveExecutionConfig(
   fallback: MemoryDreamingExecutionConfig,
 ): MemoryDreamingExecutionConfig {
   const record = asNullableRecord(value);
-  const maxOutputTokens = normalizeOptionalPositiveInt(record?.maxOutputTokens);
-  const timeoutMs = normalizeOptionalPositiveInt(record?.timeoutMs);
+  const maxOutputTokens = parseStrictPositiveInteger(record?.maxOutputTokens);
+  const timeoutMs = parseStrictPositiveInteger(record?.timeoutMs);
   const temperatureRaw = record?.temperature;
   const temperature =
     typeof temperatureRaw === "number" && Number.isFinite(temperatureRaw) && temperatureRaw >= 0
@@ -347,37 +326,32 @@ export function resolveMemoryDreamingConfig(params: {
   const deep = asNullableRecord(phases?.deep);
   const rem = asNullableRecord(phases?.rem);
   const deepRecovery = asNullableRecord(deep?.recovery);
-  const maxAgeDays = normalizeOptionalPositiveInt(deep?.maxAgeDays);
-  const maxPromotedSnippetTokens = normalizeOptionalPositiveInt(deep?.maxPromotedSnippetTokens);
+  const maxAgeDays = parseStrictPositiveInteger(deep?.maxAgeDays);
+  const maxPromotedSnippetTokens = parseStrictPositiveInteger(deep?.maxPromotedSnippetTokens);
 
   return {
-    enabled: normalizeBoolean(dreaming?.enabled, DEFAULT_MEMORY_DREAMING_ENABLED),
+    enabled: parseBoolean(dreaming?.enabled) ?? DEFAULT_MEMORY_DREAMING_ENABLED,
     frequency,
     ...(timezone ? { timezone } : {}),
-    verboseLogging: normalizeBoolean(
-      dreaming?.verboseLogging,
-      DEFAULT_MEMORY_DREAMING_VERBOSE_LOGGING,
-    ),
+    verboseLogging:
+      parseBoolean(dreaming?.verboseLogging) ?? DEFAULT_MEMORY_DREAMING_VERBOSE_LOGGING,
     storage: {
       mode: normalizeStorageMode(storage?.mode),
-      separateReports: normalizeBoolean(
-        storage?.separateReports,
-        DEFAULT_MEMORY_DREAMING_SEPARATE_REPORTS,
-      ),
+      separateReports:
+        parseBoolean(storage?.separateReports) ?? DEFAULT_MEMORY_DREAMING_SEPARATE_REPORTS,
     },
     execution: {
       defaults: defaultExecution,
     },
     phases: {
       light: {
-        enabled: normalizeBoolean(light?.enabled, true),
+        enabled: parseBoolean(light?.enabled) ?? true,
         cron: frequency,
-        lookbackDays: normalizeNonNegativeInt(
-          light?.lookbackDays,
+        lookbackDays:
+          parseStrictNonNegativeInteger(light?.lookbackDays) ??
           DEFAULT_MEMORY_LIGHT_DREAMING_LOOKBACK_DAYS,
-        ),
-        limit: normalizeNonNegativeInt(light?.limit, DEFAULT_MEMORY_LIGHT_DREAMING_LIMIT),
-        dedupeSimilarity: normalizeSimilarity(
+        limit: parseStrictNonNegativeInteger(light?.limit) ?? DEFAULT_MEMORY_LIGHT_DREAMING_LIMIT,
+        dedupeSimilarity: normalizeScore(
           light?.dedupeSimilarity,
           DEFAULT_MEMORY_LIGHT_DREAMING_DEDUPE_SIMILARITY,
         ),
@@ -394,22 +368,19 @@ export function resolveMemoryDreamingConfig(params: {
         }),
       },
       deep: {
-        enabled: normalizeBoolean(deep?.enabled, true),
+        enabled: parseBoolean(deep?.enabled) ?? true,
         cron: frequency,
-        limit: normalizeNonNegativeInt(deep?.limit, DEFAULT_MEMORY_DEEP_DREAMING_LIMIT),
+        limit: parseStrictNonNegativeInteger(deep?.limit) ?? DEFAULT_MEMORY_DEEP_DREAMING_LIMIT,
         minScore: normalizeScore(deep?.minScore, DEFAULT_MEMORY_DEEP_DREAMING_MIN_SCORE),
-        minRecallCount: normalizeNonNegativeInt(
-          deep?.minRecallCount,
+        minRecallCount:
+          parseStrictNonNegativeInteger(deep?.minRecallCount) ??
           DEFAULT_MEMORY_DEEP_DREAMING_MIN_RECALL_COUNT,
-        ),
-        minUniqueQueries: normalizeNonNegativeInt(
-          deep?.minUniqueQueries,
+        minUniqueQueries:
+          parseStrictNonNegativeInteger(deep?.minUniqueQueries) ??
           DEFAULT_MEMORY_DEEP_DREAMING_MIN_UNIQUE_QUERIES,
-        ),
-        recencyHalfLifeDays: normalizeNonNegativeInt(
-          deep?.recencyHalfLifeDays,
+        recencyHalfLifeDays:
+          parseStrictNonNegativeInteger(deep?.recencyHalfLifeDays) ??
           DEFAULT_MEMORY_DEEP_DREAMING_RECENCY_HALF_LIFE_DAYS,
-        ),
         ...(typeof maxAgeDays === "number"
           ? { maxAgeDays }
           : typeof DEFAULT_MEMORY_DEEP_DREAMING_MAX_AGE_DAYS === "number"
@@ -427,22 +398,18 @@ export function resolveMemoryDreamingConfig(params: {
           DEFAULT_MEMORY_DEEP_DREAMING_SOURCES,
         ),
         recovery: {
-          enabled: normalizeBoolean(
-            deepRecovery?.enabled,
-            DEFAULT_MEMORY_DEEP_DREAMING_RECOVERY_ENABLED,
-          ),
+          enabled:
+            parseBoolean(deepRecovery?.enabled) ?? DEFAULT_MEMORY_DEEP_DREAMING_RECOVERY_ENABLED,
           triggerBelowHealth: normalizeScore(
             deepRecovery?.triggerBelowHealth,
             DEFAULT_MEMORY_DEEP_DREAMING_RECOVERY_TRIGGER_BELOW_HEALTH,
           ),
-          lookbackDays: normalizeNonNegativeInt(
-            deepRecovery?.lookbackDays,
+          lookbackDays:
+            parseStrictNonNegativeInteger(deepRecovery?.lookbackDays) ??
             DEFAULT_MEMORY_DEEP_DREAMING_RECOVERY_LOOKBACK_DAYS,
-          ),
-          maxRecoveredCandidates: normalizeNonNegativeInt(
-            deepRecovery?.maxRecoveredCandidates,
+          maxRecoveredCandidates:
+            parseStrictNonNegativeInteger(deepRecovery?.maxRecoveredCandidates) ??
             DEFAULT_MEMORY_DEEP_DREAMING_RECOVERY_MAX_CANDIDATES,
-          ),
           minRecoveryConfidence: normalizeScore(
             deepRecovery?.minRecoveryConfidence,
             DEFAULT_MEMORY_DEEP_DREAMING_RECOVERY_MIN_CONFIDENCE,
@@ -460,13 +427,12 @@ export function resolveMemoryDreamingConfig(params: {
         }),
       },
       rem: {
-        enabled: normalizeBoolean(rem?.enabled, true),
+        enabled: parseBoolean(rem?.enabled) ?? true,
         cron: frequency,
-        lookbackDays: normalizeNonNegativeInt(
-          rem?.lookbackDays,
+        lookbackDays:
+          parseStrictNonNegativeInteger(rem?.lookbackDays) ??
           DEFAULT_MEMORY_REM_DREAMING_LOOKBACK_DAYS,
-        ),
-        limit: normalizeNonNegativeInt(rem?.limit, DEFAULT_MEMORY_REM_DREAMING_LIMIT),
+        limit: parseStrictNonNegativeInteger(rem?.limit) ?? DEFAULT_MEMORY_REM_DREAMING_LIMIT,
         minPatternStrength: normalizeScore(
           rem?.minPatternStrength,
           DEFAULT_MEMORY_REM_DREAMING_MIN_PATTERN_STRENGTH,


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Dreaming configuration keeps four private wrappers around its existing canonical integer/boolean parsers and score normalizer. This is a standalone maintainer-requested cleanup in the #135868 split campaign; it extracts no recovery feature content.

## Why This Change Was Made

Call the existing parsers directly at all 22 wrapper call sites, retaining each local fallback. Remove the redundant null guard before the strict positive-integer parser, which already rejects null and undefined without coercion, and call the existing score normalizer directly for similarity.

These helpers have only owner-local callers and no public export. The complete baseline owner matches stable v2026.9.2, so this preserves its shipped configuration contract. Public resolver signatures and the SDK re-exports stay unchanged.

## User Impact

No intended behavior change. False and zero remain valid, integer strings stay decimal-only, optional execution fields stay omitted when invalid, and phase defaults and model inheritance remain the same. Score coercion, source allowlists, scheduling, storage, workspace resolution, and date formatting are unchanged.

## Evidence

- All 76 unchanged tests passed before and after: the dreaming owner, canonical number/boolean parsers, `/dreaming` command behavior, and promotion-score/default boundaries.
- A temporary actual-owner comparison passed 4,628 calls across all four public config resolvers, covering full output and key order, input reads/coercion traces, 164 exact sentinel errors, and 28 matching TypeErrors. Independent anchors preserve false, signed zero, integer grammar, permissive score coercion, optional-key omission, and execution inheritance. Both falsy-fallback and permissive-integer mutants were detected. This is bounded configuration proof; it does not claim live scheduling or memory writes.

- The full local `node scripts/check-changed.mjs` plan passed in 1,413.66 seconds, including core and core-test type graphs, three zero-entry Knip scans, and zero runtime value cycles. Full `pnpm build` passed in 1,662.46 seconds, including SDK exports, native plugin control-plane loads, and Control UI performance limits. All 15 recorded test/build inputs and seven comparison inputs stayed unchanged during proof.
- Pinned local and committed-branch Codex reviews found no actionable P0–P2 issue. All 76 focused tests passed again after rebase (65.4 seconds).

Production +32/−66, net −34; one file, 614→580 lines. Tests, tooling, docs, and baselines unchanged.

Pre-publication refresh rebased onto `a471ab0b49a8`. The lockfile, changed owner, focused test files, and all directly recorded comparison inputs are unchanged. The sole recorded-input difference is two added Windows CI test paths in package.json. Main also improved literal Git-path handling in changed-check tooling and diagnostic wording in the declaration boundary; the current dry-run still selects the same core/core-test checks as the completed run. The complete check/build proof above ran on base `9da1f244bfd`; exact-head CI is required before native landing.

## Review Disposition

ClawSweeper's [technical review](https://github.com/openclaw/openclaw/pull/140707#issuecomment-5564589017) found no actionable correctness or security issue and confirmed preserved configuration semantics. Its path-based stored-data checklist classified this file as an unknown/vector metadata change. That classification does not describe the introduced diff: no SQLite schema, vector or embedding record, serialized format, migration, storage reader/writer, or scheduling path changes.

Compatibility is checked at the boundary this patch changes: the same existing configuration values produce identical complete results, optional-property presence, coercions, and errors through all four real public resolvers, including phase storage preferences and promotion thresholds. The request for a new migration/upgrade fixture is skipped as inapplicable to this unchanged data model; no new format needs migration. The weaker historical-reference sentence was removed because the private-helper/source proof and unchanged stable owner establish this cleanup without attributing its origin to an unrelated PR subject.

Final landing refresh: rebased onto `a7f2413c4b0b`; all published-head test/build inputs and all seven comparison pins remain unchanged, with no lockfile change. All 76 focused tests passed again in 65.71 seconds, and final branch Codex autoreview is scoped-clean through P2. Initial exact-head CI passed; final-head CI is required before native prepare.
