### PR TITLE
refactor(subagents): share latest-generation indexing

### DIFF
--- a/src/agents/subagents/announce/subagent-announce-output.ts
+++ b/src/agents/subagents/announce/subagent-announce-output.ts
@@ -15,7 +15,7 @@ import { wrapPromptDataBlock } from "../../sanitize-for-prompt.js";
 import { extractStoredAssistantText } from "../../tools/chat-history-text.js";
 import { isAnnounceSkip } from "../../tools/sessions-send-tokens.js";
 import { resolveSubagentCompletionResultText } from "../completion/subagent-completion-result.js";
-import { compareSubagentRunGeneration } from "../registry/subagent-run-generation.js";
+import { recordLatestSubagentRun } from "../registry/subagent-registry-queries.js";
 import { classifySubagentTerminalOutcome } from "../subagent-terminal-outcome.js";
 import {
   captureSubagentCompletionReplyUsing,
@@ -553,10 +553,7 @@ export function dedupeLatestChildCompletionRows(
 ) {
   const latestByChildSessionKey = new Map<string, (typeof children)[number]>();
   for (const child of children) {
-    const existing = latestByChildSessionKey.get(child.childSessionKey);
-    if (!existing || compareSubagentRunGeneration(child, existing) > 0) {
-      latestByChildSessionKey.set(child.childSessionKey, child);
-    }
+    recordLatestSubagentRun(latestByChildSessionKey, child.childSessionKey, child);
   }
   return [...latestByChildSessionKey.values()];
 }

--- a/src/agents/subagents/announce/subagent-announce-output.ts
+++ b/src/agents/subagents/announce/subagent-announce-output.ts
@@ -15,7 +15,7 @@ import { wrapPromptDataBlock } from "../../sanitize-for-prompt.js";
 import { extractStoredAssistantText } from "../../tools/chat-history-text.js";
 import { isAnnounceSkip } from "../../tools/sessions-send-tokens.js";
 import { resolveSubagentCompletionResultText } from "../completion/subagent-completion-result.js";
-import { recordLatestSubagentRun } from "../registry/subagent-registry-queries.js";
+import { recordLatestSubagentRun } from "../registry/subagent-run-generation.js";
 import { classifySubagentTerminalOutcome } from "../subagent-terminal-outcome.js";
 import {
   captureSubagentCompletionReplyUsing,

--- a/src/agents/subagents/registry/subagent-registry-queries.ts
+++ b/src/agents/subagents/registry/subagent-registry-queries.ts
@@ -6,7 +6,10 @@
 import type { DeliveryContext } from "../../../utils/delivery-context.types.js";
 import { isDeliverySuspended } from "./subagent-delivery-state.js";
 import type { SubagentRunReadRecord, SubagentRunRecord } from "./subagent-registry.types.js";
-import { compareSubagentRunGeneration } from "./subagent-run-generation.js";
+import {
+  compareSubagentRunGeneration,
+  recordLatestSubagentRun,
+} from "./subagent-run-generation.js";
 import { hasSubagentRunEnded, isLiveUnendedSubagentRun } from "./subagent-run-liveness.js";
 
 function resolveControllerSessionKey(
@@ -104,16 +107,6 @@ export type SubagentRunReadIndex<T extends SubagentRunReadRecord = SubagentRunRe
 export type LatestSubagentRunReadIndex = {
   getLatestSubagentRun(childSessionKey: string): SubagentRunRecord | null;
 };
-
-/** Keeps the newest generation at the grouping key prepared by the caller. */
-export function recordLatestSubagentRun<
-  T extends Pick<SubagentRunReadRecord, "runId" | "createdAt" | "generation">,
->(map: Map<string, T>, key: string, entry: T): void {
-  const existing = map.get(key);
-  if (!existing || compareSubagentRunGeneration(entry, existing) > 0) {
-    map.set(key, entry);
-  }
-}
 
 /** Builds a reusable latest-generation lookup from one registry snapshot. */
 export function buildLatestSubagentRunReadIndexFromRuns(

--- a/src/agents/subagents/registry/subagent-registry-queries.ts
+++ b/src/agents/subagents/registry/subagent-registry-queries.ts
@@ -105,11 +105,10 @@ export type LatestSubagentRunReadIndex = {
   getLatestSubagentRun(childSessionKey: string): SubagentRunRecord | null;
 };
 
-function rememberLatestRunEntry<T extends SubagentRunReadRecord>(
-  map: Map<string, T>,
-  key: string,
-  entry: T,
-): void {
+/** Keeps the newest generation at the grouping key prepared by the caller. */
+export function recordLatestSubagentRun<
+  T extends Pick<SubagentRunReadRecord, "runId" | "createdAt" | "generation">,
+>(map: Map<string, T>, key: string, entry: T): void {
   const existing = map.get(key);
   if (!existing || compareSubagentRunGeneration(entry, existing) > 0) {
     map.set(key, entry);
@@ -126,7 +125,7 @@ export function buildLatestSubagentRunReadIndexFromRuns(
     if (!childSessionKey) {
       continue;
     }
-    rememberLatestRunEntry(latestRunByChildSessionKey, childSessionKey, entry);
+    recordLatestSubagentRun(latestRunByChildSessionKey, childSessionKey, entry);
   }
   return {
     getLatestSubagentRun: (childSessionKey) =>
@@ -157,7 +156,7 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
     if (!childSessionKey) {
       continue;
     }
-    rememberLatestRunEntry(inMemoryDisplayByChildSessionKey, childSessionKey, entry);
+    recordLatestSubagentRun(inMemoryDisplayByChildSessionKey, childSessionKey, entry);
   }
 
   for (const [, entry] of runs.entries()) {
@@ -183,8 +182,8 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
     const displayRuns = isLiveUnendedSubagentRun(entry, now)
       ? latestSnapshotActiveByChildSessionKey
       : latestSnapshotEndedByChildSessionKey;
-    rememberLatestRunEntry(displayRuns, childSessionKey, entry);
-    rememberLatestRunEntry(latestRunsByChildSessionKey, childSessionKey, entry);
+    recordLatestSubagentRun(displayRuns, childSessionKey, entry);
+    recordLatestSubagentRun(latestRunsByChildSessionKey, childSessionKey, entry);
 
     const requesterSessionKey = entry.requesterSessionKey;
     if (!requesterSessionKey) {
@@ -195,7 +194,7 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
       latestByChild = new Map<string, T>();
       latestRunByRequesterAndChildSessionKey.set(requesterSessionKey, latestByChild);
     }
-    rememberLatestRunEntry(latestByChild, childSessionKey, entry);
+    recordLatestSubagentRun(latestByChild, childSessionKey, entry);
   }
 
   const getDisplaySubagentRun = (childSessionKey: string): T | null => {
@@ -463,7 +462,7 @@ export function countActiveRunsForSessionFromRuns(
     if (options?.requesterAgentId && entry.requesterAgentId !== options.requesterAgentId) {
       continue;
     }
-    rememberLatestRunEntry(latestByChildSessionKey, entry.childSessionKey, entry);
+    recordLatestSubagentRun(latestByChildSessionKey, entry.childSessionKey, entry);
   }
 
   let count = 0;

--- a/src/agents/subagents/registry/subagent-run-generation.ts
+++ b/src/agents/subagents/registry/subagent-run-generation.ts
@@ -30,6 +30,18 @@ export function compareSubagentRunGeneration(
   return left.runId.localeCompare(right.runId);
 }
 
+/** Keeps the newest generation at the grouping key prepared by the caller. */
+export function recordLatestSubagentRun<T extends ComparableSubagentRun>(
+  map: Map<string, T>,
+  key: string,
+  entry: T,
+): void {
+  const existing = map.get(key);
+  if (!existing || compareSubagentRunGeneration(entry, existing) > 0) {
+    map.set(key, entry);
+  }
+}
+
 /** Allocates a durable monotonic generation within one child session. */
 export function nextSubagentRunGeneration(
   runs: Iterable<GenerationalSubagentRun>,

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -26,34 +26,20 @@ export async function readDescendantSubagentFallbackReply(params: {
   sessionKey: string;
   runStartedAt: number;
 }): Promise<string | undefined> {
-  const descendants = listDescendantRunsForRequester(params.sessionKey)
-    .filter(
-      (entry) =>
-        typeof entry.execution.endedAt === "number" &&
-        entry.execution.endedAt >= params.runStartedAt &&
-        entry.childSessionKey.trim().length > 0,
-    )
-    .toSorted((a, b) => (a.execution.endedAt ?? 0) - (b.execution.endedAt ?? 0));
+  const descendants = listDescendantRunsForRequester(params.sessionKey).filter(
+    (entry) =>
+      typeof entry.execution.endedAt === "number" &&
+      entry.execution.endedAt >= params.runStartedAt &&
+      entry.childSessionKey.trim().length > 0,
+  );
   if (descendants.length === 0) {
     return undefined;
-  }
-
-  const latestByChild = new Map<string, (typeof descendants)[number]>();
-  for (const entry of descendants) {
-    const childKey = entry.childSessionKey.trim();
-    if (!childKey) {
-      continue;
-    }
-    const current = latestByChild.get(childKey);
-    if (!current || (entry.execution.endedAt ?? 0) >= (current.execution.endedAt ?? 0)) {
-      latestByChild.set(childKey, entry);
-    }
   }
 
   const replies: string[] = [];
   // Limit fallback synthesis to the latest few children so a noisy run does not
   // flood the cron announce with stale descendant output.
-  const latestRuns = [...latestByChild.values()]
+  const latestRuns = descendants
     .toSorted((a, b) => (a.execution.endedAt ?? 0) - (b.execution.endedAt ?? 0))
     .slice(-4);
   for (const entry of latestRuns) {


### PR DESCRIPTION
## What Problem This Solves

Registry indexing and announcement projection repeated the same latest-generation selection, while cron regrouped an already unique descendant traversal. This is a maintainer-requested consolidation of that ownership boundary.

## Why This Change Was Made

The registry generation leaf (`subagent-run-generation.ts`) now owns incremental indexing beside the comparator. Its callers retain their existing normalized or exact grouping keys, generation/creation/run-ID comparison and insertion order. Cron uses the canonical unique traversal, retaining completed-since filtering, chronological ordering, the four-child cap, and producer-owned terminal/transcript policy.

`subagent-run-view.ts` is unchanged: its timestamp ordering intentionally aligns displayed indices and command targets, as introduced by #133461 and protected by the existing display tests. All current exports remain available.

## User Impact

No intended behavior change. Production code decreases by 13 lines; no tests are removed or changed.

## Evidence

- `node scripts/run-vitest.mjs src/agents/subagents/registry/subagent-registry-queries.test.ts src/agents/subagents/announce/subagent-announce-output.test.ts src/cron/isolated-agent/subagent-followup.test.ts src/auto-reply/reply/subagents-utils.test.ts`: 4 files / 147 tests passed.
- Independent Codex review: no actionable P0–P2 findings.
- The first CI architecture run detected one import cycle through registry types. Moving the selector into the generation leaf restores the original import direction; `node --import ./scripts/tsx.mjs scripts/check-madge-import-cycles.ts` now reports 0 cycles.
- `node scripts/check-changed.mjs` passed. The 92 registry/announcement tests passed again after the import fix. A separate explicit leaf-lint invocation hit the documented nested-worktree ancestor declaration boundary; clean CI provides final leaf lint.
- Corrected head `e12c66ad15932ba9ba58c00c259bfef25f4b1ce3` has green [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34080901068), including clean hosted lint and architecture checks.
