### PR TITLE
fix(agents): avoid pruning warm caches during tool loops

### DIFF
--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -70,7 +70,7 @@ Amazon Bedrock, Google, Microsoft Foundry, OAuth, proxies, Vertex, and other
 cache-TTL-eligible routes keep client-side pruning. New pruning rounds are gated
 on both a time check and a context-size check:
 
-1. Wait for the cache TTL to expire (default 5 minutes when set manually; see [Smart defaults](#smart-defaults) for the Anthropic auto-default). Before the TTL elapses, no new pruning occurs; existing projections still replay unchanged.
+1. Wait for the cache TTL to expire (default 5 minutes when set manually; see [Smart defaults](#smart-defaults) for the Anthropic auto-default). Each successful model request refreshes the in-memory clock to its request start time, including tool-loop requests before turn settlement. Failed requests do not refresh it. Before the TTL elapses, no new pruning occurs; existing projections still replay unchanged.
 2. Once the TTL has elapsed, estimate total context size against the model's context window. Below roughly 30% usage, pruning is skipped and the TTL clock keeps running.
 3. **Soft-trim** oversized tool results: results over 4,000 characters keep their first and last 1,500 characters with `...` in between.
 4. If context usage is still at or above roughly 50% and at least 50,000 characters of prunable tool content remain, **hard-clear** those results: replace their content with a placeholder (default `[Old tool result content cleared]`, configurable via `agents.defaults.contextPruning.hardClear.placeholder`; set `hardClear.enabled: false` to skip this step).

--- a/src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts
@@ -1,8 +1,13 @@
 import { createHash } from "node:crypto";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
+import type { AssistantMessage, Model } from "../../../llm/types.js";
+import { createAssistantMessageEventStream } from "../../../llm/utils/event-stream.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { AgentSession } from "../../sessions/index.js";
+import { makeZeroUsageSnapshot } from "../../usage.js";
 import { createToolResultPromptProjectionState } from "../session-prompt-state.js";
+import { wrapStreamFnWithDiagnosticModelCallEvents } from "./attempt.model-diagnostic-events.js";
 import type { MidTurnPrecheckRequest } from "./midturn-precheck.js";
 
 const hoisted = vi.hoisted(() => ({
@@ -73,7 +78,49 @@ function createInput(overrides: Record<string, unknown> = {}) {
   };
 }
 
+const cacheModel: Model = {
+  id: "claude-sonnet-4-6",
+  name: "Synthetic cache model",
+  api: "anthropic-messages",
+  provider: "anthropic",
+  baseUrl: "http://127.0.0.1:1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 2_048,
+  maxTokens: 1_024,
+};
+
+function prunableHistory(): AgentMessage[] {
+  const assistant = (text: string): AssistantMessage => ({
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: cacheModel.api,
+    provider: cacheModel.provider,
+    model: cacheModel.id,
+    usage: makeZeroUsageSnapshot(),
+    stopReason: "stop",
+    timestamp: 1,
+  });
+  return [
+    { role: "user", content: "first", timestamp: 1 },
+    assistant("a1"),
+    {
+      role: "toolResult",
+      toolCallId: "old-tool",
+      toolName: "read",
+      content: [{ type: "text", text: "x".repeat(5_000) }],
+      isError: false,
+      timestamp: 1,
+    },
+    assistant("a2"),
+    assistant("a3"),
+    assistant("a4"),
+  ];
+}
+
 describe("installEmbeddedAttemptContextGuards", () => {
+  afterEach(() => vi.useRealTimers());
   beforeEach(() => {
     vi.clearAllMocks();
     hoisted.installContextEngineLoopHook.mockReturnValue(vi.fn());
@@ -210,6 +257,131 @@ describe("installEmbeddedAttemptContextGuards", () => {
     expect(input.activeSession.agent.transformContext).toBe(originalTransform);
   });
 
+  it.each([
+    { scenario: "warm cache", age: 290_000, thresholdCrossing: false, outcome: "success" },
+    { scenario: "threshold crossing", age: 310_000, thresholdCrossing: true, outcome: "success" },
+    {
+      scenario: "failure before dispatch",
+      age: 290_000,
+      thresholdCrossing: false,
+      outcome: "throw",
+    },
+    { scenario: "provider error", age: 290_000, thresholdCrossing: false, outcome: "error" },
+    { scenario: "aborted request", age: 290_000, thresholdCrossing: false, outcome: "aborted" },
+    {
+      scenario: "stream without terminal result",
+      age: 290_000,
+      thresholdCrossing: false,
+      outcome: "empty",
+    },
+  ] as const)(
+    "uses successful request start for pruning after $scenario",
+    async ({ age, thresholdCrossing, outcome }) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      const requestStart = 1_000_000;
+      vi.setSystemTime(requestStart);
+      hoisted.isCacheTtlEligibleProvider.mockReturnValue(true);
+      hoisted.readLastCacheTtlTimestamp.mockReturnValue(requestStart - age);
+      const input = createInput();
+      input.attempt = {
+        ...input.attempt,
+        contextTokenBudget: thresholdCrossing ? 10_000 : 1_024,
+        config: { agents: { defaults: { contextPruning: { mode: "cache-ttl" } } } } as never,
+      };
+      const guards = installEmbeddedAttemptContextGuards(input as never);
+      const history = prunableHistory();
+      const project = (messages: AgentMessage[]) =>
+        input.activeSession.agent.transformContext!(messages, new AbortController().signal);
+      const first = await project(history);
+      expect(JSON.stringify(first)).toBe(JSON.stringify(history));
+      const response: AssistantMessage = {
+        role: "assistant",
+        content: [{ type: "text", text: "continue" }],
+        api: "anthropic-messages",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        usage: makeZeroUsageSnapshot(),
+        stopReason: outcome === "error" || outcome === "aborted" ? outcome : "toolUse",
+        timestamp: requestStart,
+      };
+      const onSucceeded = vi.fn(guards.recordCacheTouch);
+      const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+        () => {
+          if (outcome === "throw") {
+            throw new Error("failed before dispatch");
+          }
+          const stream = createAssistantMessageEventStream();
+          // Completion is deliberately later than request start; using completion time
+          // would incorrectly keep the cache warm past the final idle check below.
+          vi.setSystemTime(Date.now() + 10_000);
+          if (outcome === "empty") {
+            stream.end();
+          } else if (outcome === "error" || outcome === "aborted") {
+            stream.push({ type: "error", reason: outcome, error: response });
+          } else {
+            stream.push({ type: "done", reason: "toolUse", message: response });
+          }
+          return stream;
+        },
+        {
+          runId: "cache-ttl-clock",
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          trace: createDiagnosticTraceContext(),
+          nextCallId: () => "cache-ttl-request",
+          onSucceeded,
+        },
+      );
+      try {
+        if (outcome === "throw") {
+          expect(() => wrapped(cacheModel, { messages: [] })).toThrow("failed before dispatch");
+        } else {
+          const stream = await wrapped(cacheModel, { messages: [] });
+          for await (const _ of stream) {
+            // Consume the provider completion.
+          }
+          if (outcome !== "empty") {
+            await stream.result();
+          }
+        }
+        vi.setSystemTime(requestStart + 20_000);
+        const expanded = thresholdCrossing
+          ? [
+              ...history,
+              {
+                role: "toolResult" as const,
+                toolCallId: "new-tool",
+                toolName: "read",
+                content: [{ type: "text" as const, text: "y".repeat(10_000) }],
+                isError: false,
+                timestamp: Date.now(),
+              },
+            ]
+          : history;
+        const second = await project(expanded);
+        if (outcome === "success") {
+          expect(JSON.stringify(second)).toBe(JSON.stringify(expanded));
+          expect(onSucceeded).toHaveBeenCalledExactlyOnceWith(requestStart);
+          // A second successful request starts its own TTL window.
+          const nextStream = await wrapped(cacheModel, { messages: [] });
+          await nextStream.result();
+          expect(onSucceeded).toHaveBeenCalledTimes(2);
+          expect(onSucceeded).toHaveBeenLastCalledWith(requestStart + 20_000);
+          vi.setSystemTime(requestStart + 320_000);
+          const expired = await project(expanded);
+          expect(JSON.stringify(expired)).toContain("[Tool result trimmed:");
+          expect(JSON.stringify(expired)).not.toBe(JSON.stringify(expanded));
+        } else {
+          expect(onSucceeded).not.toHaveBeenCalled();
+          expect(JSON.stringify(second)).toContain("[Tool result trimmed:");
+        }
+        expect(JSON.stringify(history)).toContain("x".repeat(5_000));
+      } finally {
+        guards.remove();
+      }
+    },
+  );
+
   it.each([false, true])(
     "keeps cache-TTL tool-loop bytes stable with server clearing=%s",
     async (serverClearing) => {
@@ -258,20 +430,7 @@ describe("installEmbeddedAttemptContextGuards", () => {
           agent.transformContext = previous;
         });
       });
-      const messages = [
-        { role: "user", content: "first", timestamp: 1 },
-        { role: "assistant", content: [{ type: "text", text: "a1" }], timestamp: 1 },
-        {
-          role: "toolResult",
-          toolCallId: "old-tool",
-          toolName: "read",
-          content: [{ type: "text", text: "x".repeat(5_000) }],
-          timestamp: 1,
-        },
-        { role: "assistant", content: [{ type: "text", text: "a2" }], timestamp: 1 },
-        { role: "assistant", content: [{ type: "text", text: "a3" }], timestamp: 1 },
-        { role: "assistant", content: [{ type: "text", text: "a4" }], timestamp: 1 },
-      ] as AgentMessage[];
+      const messages = prunableHistory();
 
       const guards = installEmbeddedAttemptContextGuards(input as never);
       expect(hoisted.isCacheTtlEligibleProvider).toHaveBeenCalledExactlyOnceWith(

--- a/src/agents/embedded-agent-runner/run/attempt-execution-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-phase.test.ts
@@ -144,6 +144,7 @@ async function createFixture(
     anthropicPayloadLogger: {},
     boundary: { orphanRepair: { removeLeaf: true } },
     cacheTrace: {},
+    contextGuards: { recordCacheTouch: vi.fn() },
     isOpenAIResponsesApi: true,
     sessionManager,
     settleTracker: { abortActiveSession, trackPromptSettlePromise },

--- a/src/agents/embedded-agent-runner/run/attempt-setup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.ts
@@ -283,6 +283,7 @@ export function installEmbeddedAttemptContextGuards(input: {
   sandbox?: SandboxContext | null;
 }): {
   getAfterTurnCheckpoint: () => number | null;
+  recordCacheTouch: (startedAt: number) => void;
   remove: () => void;
   takePendingMidTurnPrecheckRequest: () => MidTurnPrecheckRequest | null;
 } {
@@ -468,6 +469,9 @@ export function installEmbeddedAttemptContextGuards(input: {
 
   return {
     getAfterTurnCheckpoint: () => afterTurnCheckpoint,
+    recordCacheTouch: (startedAt) => {
+      lastCacheTouchAt = startedAt;
+    },
     remove: () => {
       activeSession.agent.transformContext = previousComputerFrameTransform;
       removeHistoryImagePruneContextTransform();

--- a/src/agents/embedded-agent-runner/run/attempt-stream.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream.ts
@@ -86,6 +86,7 @@ export function installEmbeddedAttemptStreamGuards(
     agentSession: { activeSession: session, allCustomTools, codeModeExecToolNames },
     anthropicPayloadLogger,
     cacheTrace,
+    contextGuards,
     isOpenAIResponsesApi,
     sessionManager,
     state: { systemPromptText },
@@ -360,6 +361,7 @@ export function installEmbeddedAttemptStreamGuards(
     contentCapture: resolveDiagnosticModelContentCapturePolicy(attempt.config),
     nextCallId: () => `${attempt.runId}:model:${(diagnosticModelCallSeq += 1)}`,
     ownerGeneration: callbacks.diagnosticOwner.generation,
+    onSucceeded: contextGuards.recordCacheTouch,
     onStarted: () => {
       attempt.onExecutionPhase?.({
         phase: "model_call_started",

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
@@ -52,6 +52,7 @@ export type ModelCallDiagnosticContext = {
   nextCallId: () => string;
   ownerGeneration?: CoreModelRequestOwnerGeneration;
   onStarted?: () => void;
+  onSucceeded?: (startedAt: number) => void;
   suppressPluginHooks?: boolean;
   requestTimeoutMs?: number;
 };
@@ -98,6 +99,7 @@ export type ModelCallObservationState = {
   semanticProgressEmitted?: boolean;
   terminalEventEmitted?: boolean;
   terminalError?: Error;
+  terminalSucceeded?: boolean;
   suppressPluginHooks?: boolean;
 };
 export type ModelCallObserver = {
@@ -412,6 +414,14 @@ export function createModelLifecycle(params: {
     propagatedOptions,
     startedAt,
     emitCompleted() {
+      // Iterator cleanup alone is not a successful request; require its terminal result.
+      if (
+        !observer.state.terminalEventEmitted &&
+        observer.state.terminalSucceeded &&
+        !observer.state.terminalError
+      ) {
+        params.ctx.onSucceeded?.(startedAt);
+      }
       emitModelCallEnded(
         eventBase,
         startedAt,

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-observation.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-observation.ts
@@ -156,6 +156,14 @@ function observeModelCallTerminalMessage(state: ModelCallObservationState, value
   let rawUsage: unknown;
   try {
     rawUsage = value.usage;
+    if (
+      value.role === "assistant" &&
+      (value.stopReason === "stop" ||
+        value.stopReason === "length" ||
+        value.stopReason === "toolUse")
+    ) {
+      state.terminalSucceeded = true;
+    }
     // The stream contract returns failed assistant messages without throwing.
     // Keep their terminal fact for both iterator and result-only completion.
     // Abort state takes precedence over transport errors raised during cancellation.


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users running tool loops with client-side cache-TTL pruning would lose a warm prompt prefix when the loop crossed the original transcript marker's TTL. The same unnecessary pruning could occur when new tool output crossed the context-size threshold after a successful request.

## Why This Change Was Made

Refresh the attempt-local pruning clock after each successful model request, using the request start time captured by the existing stream lifecycle owner. Require an observed successful terminal result so errors, aborts, and streams without a terminal result do not refresh the clock; deduplicate iterator/result completion.

Existing projection replay and settlement-only transcript markers remain unchanged, as does direct Anthropic API-key server-side clearing. The production change adds 24 lines to connect the existing owners, with no new configuration, timers, or persisted state.

## User Impact

Consecutive tool-loop requests retain byte-identical historical tool results while the provider cache is warm. Client-side pruning still runs when the TTL has elapsed since the last successful request's start. The session-pruning documentation now describes the per-request clock.

## Evidence

- Before the fix: the new warm-cache and threshold-crossing regressions both failed on historical prompt-byte equality; 2 failed, 13 passed.
- Focused proof: 232 tests across 11 selected files now have passing coverage, including cache-TTL eligibility, pruning/replay, settlement, stream lifecycle, and attempt execution. An initial integration run exposed an incomplete context-guard fixture; completing that fixture gave a green targeted rerun: 2 files, 27 tests passed. The other 9 files account for 205 passing tests.
- Fake-clock proof covers two consecutive successful requests, expiry measured from request start rather than completion, threshold crossing, failure before dispatch, provider error, abort, and a stream ending without a terminal result. It also checks iterator/result deduplication and result-only success.
- `node scripts/check-changed.mjs`: PASS (exit 0), including formatting, production/test typechecks, lint, and all selected guards.
- Exact-head [CI run](https://github.com/openclaw/openclaw/actions/runs/34079382479): completed successfully on `25d54add22ccaec56e4c8d6f151671746cc9d6c6`; the required watcher finished `GREEN` with zero pending checks.
- Codex autoreview against the branch merge base, P1 threshold: `scoped-clean`; 0 accepted/actionable P0 or P1 findings; overall verdict: patch is correct.

Focused commands and results:

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts src/agents/embedded-agent-runner/run/attempt-setup.test.ts src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.cache-ttl.test.ts src/agents/embedded-agent-runner/tool-result-truncation.cache-ttl.test.ts src/agents/embedded-agent-runner/tool-result-truncation.test.ts src/agents/embedded-agent-runner/cache-ttl.test.ts src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.test.ts src/agents/embedded-agent-runner/run/attempt.model-diagnostic-observation.test.ts src/agents/embedded-agent-runner/run/attempt-execution-phase.test.ts
Initial result: 229 passed, 3 failed (missing context-guard fixture member).

node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts src/agents/embedded-agent-runner/run/attempt-execution-phase.test.ts
Final targeted rerun: Test Files 2 passed (2); Tests 27 passed (27).

node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts
After the lint-only loop-variable rename: Test Files 1 passed (1); Tests 15 passed (15).
```

No live provider billing benchmark was run; the regression proof checks request-prefix bytes and pruning timing directly.
