### PR TITLE
fix(read): avoid full-file line arrays before paging

### DIFF
--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -847,30 +847,33 @@ describe("read tool", () => {
     expect(textContent(result)).toBe("import value\nconst marker = '\uFEFF';");
   });
 
-  it("preserves an injected backend decoder's exact UTF-16 text", async () => {
-    const bytes = Buffer.from([0xc4, 0xe3, 0xba, 0xc3]);
-    const tool = createReadToolDefinition("/workspace", {
-      operations: {
-        decodeText: ({ buffer, absolutePath }) =>
-          `${absolutePath}:${buffer.toString("hex")}:\ud800a🦞b\udc00`,
-        access: async () => {},
-        detectImageMimeType: async () => null,
-        readFile: async () => bytes,
-      },
-    });
-    const result = await tool.execute(
-      "call-1",
-      { path: "legacy.txt" },
-      undefined,
-      undefined,
-      {} as never,
-    );
+  it.each(["\ud800a🦞b\udc00", "\ud800first\udc00\nsecond🦞\ud800\n"])(
+    "preserves an injected backend decoder's exact UTF-16 text: %j",
+    async (decoded) => {
+      const bytes = Buffer.from([0xc4, 0xe3, 0xba, 0xc3]);
+      const tool = createReadToolDefinition("/workspace", {
+        operations: {
+          decodeText: ({ buffer, absolutePath }) =>
+            `${absolutePath}:${buffer.toString("hex")}:${decoded}`,
+          access: async () => {},
+          detectImageMimeType: async () => null,
+          readFile: async () => bytes,
+        },
+      });
+      const result = await tool.execute(
+        "call-1",
+        { path: "legacy.txt" },
+        undefined,
+        undefined,
+        {} as never,
+      );
 
-    expect(decodeWindowsTextFileBufferMock).not.toHaveBeenCalled();
-    expect(textContent(result)).toBe(
-      `${path.resolve("/workspace", "legacy.txt")}:c4e3bac3:\ud800a🦞b\udc00`,
-    );
-  });
+      expect(decodeWindowsTextFileBufferMock).not.toHaveBeenCalled();
+      expect(textContent(result)).toBe(
+        `${path.resolve("/workspace", "legacy.txt")}:c4e3bac3:${decoded}`,
+      );
+    },
+  );
 
   it("waits for an aliased queued write before reading the same new file", async () => {
     const tempDir = tempDirs.make("openclaw-read-write-order-");

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -523,29 +523,32 @@ export function createReadToolDefinition(
               const startLineDisplay = startLine + 1;
               const requestedLines =
                 limit === undefined ? undefined : normalizePositiveLimit(limit, DEFAULT_MAX_LINES);
-              let selectedLines: string[] = [];
               let totalFileLines = 0;
-              if (startLine === 0 && requestedLines === undefined) {
-                selectedLines = textContent.split("\n");
-                if (selectedLines.at(-1) === "") {
-                  selectedLines.pop();
-                }
-                totalFileLines = selectedLines.length;
-              } else {
-                // Count through EOF for continuation metadata, retaining only the requested range.
-                for (let start = 0; start < textContent.length;) {
-                  const newline = textContent.indexOf("\n", start);
-                  const end = newline === -1 ? textContent.length : newline;
-                  if (
-                    totalFileLines >= startLine &&
-                    (requestedLines === undefined || selectedLines.length < requestedLines)
-                  ) {
-                    selectedLines.push(textContent.slice(start, end));
+              let selectedStart = 0;
+              let selectedEnd = 0;
+              let selectedLineCount = 0;
+              let firstLineEnd = 0;
+              let selectedHasText = false;
+              // Count through EOF without materializing lines that the page budget may discard.
+              for (let start = 0; start < textContent.length;) {
+                const newline = textContent.indexOf("\n", start);
+                const end = newline === -1 ? textContent.length : newline;
+                if (
+                  totalFileLines >= startLine &&
+                  (requestedLines === undefined || selectedLineCount < requestedLines)
+                ) {
+                  if (selectedLineCount === 0) {
+                    selectedStart = start;
+                    firstLineEnd = end;
                   }
-                  totalFileLines += 1;
-                  start = end + 1;
+                  selectedEnd = end;
+                  selectedLineCount += 1;
+                  selectedHasText ||= end > start;
                 }
+                totalFileLines += 1;
+                start = end + 1;
               }
+              const firstLineLength = firstLineEnd - selectedStart;
               let outputText: string;
               if (totalFileLines === 0) {
                 outputText =
@@ -554,24 +557,21 @@ export function createReadToolDefinition(
                     : `File contains no readable text (${buffer.length} bytes).`;
               } else if (startLine >= totalFileLines) {
                 outputText = `Offset ${offset} is beyond end of file (${totalFileLines} lines total). Retry with offset <= ${totalFileLines}.`;
-              } else if (cursor > 0 && cursor >= selectedLines[0]!.length) {
+              } else if (cursor > 0 && cursor >= firstLineLength) {
                 const nextLine =
                   startLine + 1 < totalFileLines
                     ? ` Use offset=${startLineDisplay + 1} to continue.`
                     : "";
-                outputText = `Cursor ${cursor} is at or beyond the end of line ${startLineDisplay} (${selectedLines[0]!.length} characters).${nextLine}`;
+                outputText = `Cursor ${cursor} is at or beyond the end of line ${startLineDisplay} (${firstLineLength} characters).${nextLine}`;
               } else {
-                const firstLine = selectedLines[0]!;
-                if (cursor > 0 && firstLine.codePointAt(cursor - 1)! > 0xffff) {
+                if (cursor > 0 && textContent.codePointAt(selectedStart + cursor - 1)! > 0xffff) {
                   throw new Error(
                     `Cursor ${cursor} splits a UTF-16 surrogate pair; retry with cursor=${cursor - 1} or cursor=${cursor + 1}.`,
                   );
                 }
-                const endLine = startLine + selectedLines.length;
-                selectedLines[0] = firstLine.slice(cursor);
-                const userLimitedLines = limit === undefined ? undefined : endLine - startLine;
-                if (selectedLines.every((line) => line.length === 0)) {
-                  const selectedLineCount = selectedLines.length;
+                const endLine = startLine + selectedLineCount;
+                const userLimitedLines = limit === undefined ? undefined : selectedLineCount;
+                if (!selectedHasText) {
                   const subject =
                     startLine === 0 && endLine === totalFileLines ? "File" : "Selected range";
                   outputText = `${subject} contains ${selectedLineCount} blank line${selectedLineCount === 1 ? "" : "s"}.`;
@@ -580,10 +580,10 @@ export function createReadToolDefinition(
                     outputText += `\n\n[${remaining} more line${remaining === 1 ? "" : "s"} in file. Use offset=${endLine + 1} to continue.]`;
                   }
                 } else {
-                  let selectedContent = selectedLines.join("\n");
-                  if (endLine === totalFileLines && textContent.endsWith("\n")) {
-                    selectedContent += "\n";
-                  }
+                  const selectedContent = textContent.slice(
+                    selectedStart + cursor,
+                    endLine === totalFileLines ? textContent.length : selectedEnd,
+                  );
                   const noteBytes = note ? Buffer.byteLength(`${note}\n`, "utf8") : 0;
                   const page = createBoundedReadTextPage({
                     content: selectedContent,
@@ -598,16 +598,15 @@ export function createReadToolDefinition(
                     pageMaxBytes: Math.min(DEFAULT_MAX_BYTES, maxBytes) - noteBytes,
                     adaptive: options?.maxBytes !== undefined,
                   });
-                  outputText = page.content;
                   if (page.kind === "truncated") {
                     truncated = page;
+                    outputText = page.content;
+                  } else {
+                    // Even full-fit custom decoder text can borrow a larger source. Copy only
+                    // the bounded result, preserving UTF-16 units including lone surrogates.
+                    outputText = Buffer.from(page.content, "utf16le").toString("utf16le");
                   }
                 }
-              }
-              if (selectedLines.length === 1 && truncated === undefined) {
-                // A singleton join can retain the decoded file. Copy only the bounded result,
-                // preserving UTF-16 code units from custom decoders, including lone surrogates.
-                outputText = Buffer.from(outputText, "utf16le").toString("utf16le");
               }
               content = [{ type: "text", text: outputText }];
             }


### PR DESCRIPTION
Closes #140709

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Resolves avoidable allocation during large file reads: the reader builds full line arrays and reconstructed text before it applies bounded paging, and explicit ranges also retain collected line strings.

## Why This Change Was Made

Scan contiguous line-span boundaries through EOF and give the existing page owner that selection. Carry line counts and blank/cursor facts without materializing individual lines. Copy full-fit text only after page and model budgets apply, preserving exact UTF-16 ownership for custom-decoder slices.

## User Impact

Fresh current-main proof reduces sampled JavaScript allocation for twenty native 4 MB default reads from 242,486,676 to 4,633,372 bytes (-98.09%). Exact text, Unicode units, cursor/EOF diagnostics, continuation metadata and model/footer limits are preserved. Full decoding and file I/O remain necessary.

This is reader allocation improvement. Both current-main baseline and candidate already pass bounded-retention controls; the earlier shared-truncator retention fix belongs to #140570 and is unchanged. No whole-Gateway or reliable RSS improvement is claimed.

## Evidence

- All 662 complete reader output/error records and 1,440 canonical truncation records match. The same dependency graph, canonical source and actual executed reader hashes are verified in both arms.
- Interleaved small-file and first-range timing controls are effectively unchanged; large default reads improve in the synthetic local fixture. Timing regimes are reported separately, without a universal latency claim.
- Fresh frozen-lockfile installation, 111 focused tests, the complete changed-file gate, normal build and new isolated P2 autoreview all passed.
- Only the reader and its existing decoder test change: production net -1 line, tests net +3. The four canonical truncator code/test files remain unchanged.

Related #140200 and #140570 establish earlier ownership work. Open #129539 concerns a distinct binary-document interception path that should be preserved during integration. Browser-engine retention is outside this proof.
