### PR TITLE
refactor(channels): share accepted reply delivery results

### DIFF
--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -60,6 +60,17 @@ them with `listMessageReceiptPlatformIds(...)` or
 `resolveMessageReceiptPrimaryId(...)` instead of keeping parallel `messageIds`
 fields.
 
+For turn adapters that aggregate confirmed visible sends, use
+`createAcceptedChannelDeliveryResult(...)` from
+`openclaw/plugin-sdk/channel-inbound`. It combines native `results` followed by
+logical `deliveryResults`, including a partial-delivery error's accepted subset.
+A logical result's receipt takes precedence over its legacy message IDs.
+The result carries a receipt, `messageIds` (including an empty array), and
+`visibleReplySent: true`; routing fields stay in the receipt. Optional `content`
+is passed through, and `kind` and `replyToId` use the receipt builder's rules.
+Keep acceptance side effects, content joining,
+suppression, and whether an identityless outcome needs a receipt in the adapter.
+
 Channel actions and adapter capabilities come from the selected plugin
 registration. An omitted `actions`, `message`, or `outbound` surface is not
 filled from another plugin with the same channel ID. Prepared delivery handlers

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -330,6 +330,11 @@ names. Its approved `removeAfter` date is **2026-10-01** (two release trains
 after the facts-first replacements shipped). Removal additionally requires a
 clean published-plugin artifact sweep at that time; migrate before the date.
 
+The unused `buildChannelTurnMediaPayload` alias has been removed from
+`openclaw/plugin-sdk/channel-inbound`. Its canonical
+`buildChannelInboundMediaPayload` export remains available for the compatibility
+window above. New ingress code should pass ordered media facts directly.
+
 For channel ingress, replace singular/plural `MediaPath`, `MediaUrl`,
 `MediaType`, `MediaPaths`, `MediaUrls`, `MediaTypes`,
 `MediaTranscribedIndexes`, `MediaWorkspaceDir`, and `MediaStaged` with ordered

--- a/extensions/feishu/src/reply-delivery-result.ts
+++ b/extensions/feishu/src/reply-delivery-result.ts
@@ -1,9 +1,8 @@
-import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import {
-  createMessageReceiptFromOutboundResults,
-  type MessageReceipt,
-  type MessageReceiptPartKind,
-} from "openclaw/plugin-sdk/channel-outbound";
+  createAcceptedChannelDeliveryResult,
+  createChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
+import type { MessageReceipt, MessageReceiptPartKind } from "openclaw/plugin-sdk/channel-outbound";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 export type FeishuReplyDeliverySource = {
@@ -47,25 +46,17 @@ export function createFeishuReplyDeliveryResult(params: {
   kind?: MessageReceiptPartKind;
 }): FeishuReplyDeliveryResult {
   const results = params.visibleReplySent ? (params.results ?? []).filter(hasProviderIdentity) : [];
-  const receipt =
-    results.length > 0
-      ? createMessageReceiptFromOutboundResults({
-          results,
-          ...(params.kind ? { kind: params.kind } : {}),
-        })
-      : undefined;
-  if (!receipt) {
+  if (results.length === 0) {
     return {
       visibleReplySent: params.visibleReplySent,
       ...(params.content === undefined ? {} : { content: params.content }),
     };
   }
-  return {
-    messageIds: [...receipt.platformMessageIds],
-    receipt,
-    visibleReplySent: params.visibleReplySent,
-    ...(params.content === undefined ? {} : { content: params.content }),
-  };
+  return createAcceptedChannelDeliveryResult({
+    results,
+    kind: params.kind,
+    content: params.content,
+  });
 }
 
 /** Preserves the first result's provider identity while retaining supplemental ids. */

--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -325,7 +325,7 @@ describe("deliverIMessageReply", () => {
       content: "first\nsecond",
       receipt: { platformMessageIds: ["accepted-first", "accepted-second"] },
     });
-    expect(delivered?.receipt).not.toHaveProperty("replyToId");
+    expect(delivered).not.toHaveProperty("receipt.replyToId");
   });
 
   it("preserves earlier media receipts when a later native caption fails", async () => {

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -95,7 +95,7 @@ export async function deliverIMessageReply(params: {
       suppression: { reason: "no_visible_result" as const },
     };
   }
-  const result = createAcceptedChannelDeliveryResult({
+  const deliveryResult = createAcceptedChannelDeliveryResult({
     results: accepted.map((result) => ({ receipt: result.receipt })),
     kind: delivered,
     content: accepted
@@ -104,7 +104,7 @@ export async function deliverIMessageReply(params: {
       .join("\n"),
   });
   runtime.log?.(`imessage: delivered reply to ${target}`);
-  return result;
+  return deliveryResult;
 }
 
 export function createIMessageEchoCachingSend(params: {

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -1,12 +1,9 @@
 // Imessage plugin module implements deliver behavior.
 import {
+  createAcceptedChannelDeliveryResult,
   createChannelPartialDeliveryError,
   isChannelPartialDeliveryError,
 } from "openclaw/plugin-sdk/channel-inbound";
-import {
-  createMessageReceiptFromOutboundResults,
-  listMessageReceiptPlatformIds,
-} from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   deliverTextOrMediaReply,
@@ -80,23 +77,17 @@ export async function deliverIMessageReply(params: {
     }
     // A native attachment can settle before its caption rejects; preserve every
     // previously accepted receipt plus that nested provider-visible subset.
-    const receipt = createMessageReceiptFromOutboundResults({
-      results: [
-        ...accepted.map((result) => ({ receipt: result.receipt })),
-        ...(partial?.receipt
-          ? [{ receipt: partial.receipt }]
-          : (partial?.messageIds ?? []).map((messageId) => ({ messageId }))),
-      ],
-      kind: reply.mediaUrls.length > 0 ? "media" : "text",
-    });
-    throw createChannelPartialDeliveryError(error, {
-      messageIds: listMessageReceiptPlatformIds(receipt),
-      receipt,
-      visibleReplySent: true,
-      content: [...accepted.map((result) => result.sentText), partial?.content]
-        .filter(Boolean)
-        .join("\n"),
-    });
+    throw createChannelPartialDeliveryError(
+      error,
+      createAcceptedChannelDeliveryResult({
+        results: accepted.map((result) => ({ receipt: result.receipt })),
+        deliveryResults: partial ? [partial] : [],
+        kind: reply.mediaUrls.length > 0 ? "media" : "text",
+        content: [...accepted.map((result) => result.sentText), partial?.content]
+          .filter(Boolean)
+          .join("\n"),
+      }),
+    );
   }
   if (delivered === "empty") {
     return {
@@ -104,20 +95,16 @@ export async function deliverIMessageReply(params: {
       suppression: { reason: "no_visible_result" as const },
     };
   }
-  const receipt = createMessageReceiptFromOutboundResults({
+  const result = createAcceptedChannelDeliveryResult({
     results: accepted.map((result) => ({ receipt: result.receipt })),
     kind: delivered,
-  });
-  runtime.log?.(`imessage: delivered reply to ${target}`);
-  return {
-    messageIds: listMessageReceiptPlatformIds(receipt),
-    receipt,
-    visibleReplySent: true as const,
     content: accepted
       .map((result) => result.sentText)
       .filter(Boolean)
       .join("\n"),
-  };
+  });
+  runtime.log?.(`imessage: delivered reply to ${target}`);
+  return result;
 }
 
 export function createIMessageEchoCachingSend(params: {

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -1,13 +1,10 @@
 // Matrix plugin module implements replies behavior.
 import {
+  createAcceptedChannelDeliveryResult,
   createChannelPartialDeliveryError,
   isChannelPartialDeliveryError,
 } from "openclaw/plugin-sdk/channel-inbound";
-import {
-  createMessageReceiptFromOutboundResults,
-  listMessageReceiptPlatformIds,
-  type MessageReceipt,
-} from "openclaw/plugin-sdk/channel-outbound";
+import type { MessageReceipt } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-chunking";
@@ -40,24 +37,13 @@ export function mergeMatrixReplyDeliveryResults(
       suppression: { reason: "no_visible_result" },
     };
   }
-  const receiptInputs: Array<{ receipt: MessageReceipt } | { messageId: string }> = [];
-  for (const result of visibleResults) {
-    if (result.receipt) {
-      receiptInputs.push({ receipt: result.receipt });
-      continue;
-    }
-    for (const messageId of result.messageIds ?? []) {
-      receiptInputs.push({ messageId });
-    }
+  const content = joinMatrixVisibleContent(visibleResults.map((result) => result.content));
+  if (visibleResults.some((result) => result.receipt || result.messageIds?.length)) {
+    return createAcceptedChannelDeliveryResult({ deliveryResults: visibleResults, content });
   }
-  const receipt =
-    receiptInputs.length > 0
-      ? createMessageReceiptFromOutboundResults({ results: receiptInputs })
-      : undefined;
   return {
-    ...(receipt ? { messageIds: listMessageReceiptPlatformIds(receipt), receipt } : {}),
     visibleReplySent: true,
-    content: joinMatrixVisibleContent(visibleResults.map((result) => result.content)),
+    content,
   };
 }
 
@@ -83,15 +69,10 @@ function createMatrixReplyDeliveryResult(
   if (results.length === 0) {
     return mergeMatrixReplyDeliveryResults([]);
   }
-  const receipt = createMessageReceiptFromOutboundResults({
+  return createAcceptedChannelDeliveryResult({
     results: results.map((result) => ({ receipt: result.receipt })),
-  });
-  return {
-    messageIds: listMessageReceiptPlatformIds(receipt),
-    receipt,
-    visibleReplySent: true,
     content: joinMatrixVisibleContent(results.map((result) => result.content)),
-  };
+  });
 }
 
 function resolveVisibleMatrixReplyText(text?: string): string | undefined {

--- a/extensions/mattermost/src/mattermost/monitor-draft-delivery.ts
+++ b/extensions/mattermost/src/mattermost/monitor-draft-delivery.ts
@@ -1,14 +1,13 @@
 // Mattermost plugin module owns draft-preview final delivery.
 import {
+  createAcceptedChannelDeliveryResult,
   createChannelPartialDeliveryError,
   isChannelPartialDeliveryError,
 } from "openclaw/plugin-sdk/channel-inbound";
 import {
-  createMessageReceiptFromOutboundResults,
   defineFinalizableLivePreviewAdapter,
   deliverWithFinalizableLivePreviewAdapter,
   listMessageReceiptPlatformIds,
-  type MessageReceipt,
 } from "openclaw/plugin-sdk/channel-outbound";
 import {
   buildTtsSupplementMediaPayload,
@@ -66,23 +65,12 @@ function combineMattermostVisibleDeliveryResults(
   if (visibleResults.length === 0) {
     return undefined;
   }
-  const receiptResults: Array<{ receipt: MessageReceipt } | { messageId: string }> = [];
-  for (const result of visibleResults) {
-    if (result.receipt) {
-      receiptResults.push({ receipt: result.receipt });
-    } else {
-      receiptResults.push(...(result.messageIds ?? []).map((messageId) => ({ messageId })));
-    }
-  }
-  const receipt = createMessageReceiptFromOutboundResults({
-    results: receiptResults,
-  });
   return {
     outcome: visibleResults.some((result) => result.outcome === "media") ? "media" : "text",
-    messageIds: listMessageReceiptPlatformIds(receipt),
-    receipt,
-    visibleReplySent: true,
-    content: joinMattermostVisibleContent(visibleResults.map((result) => result.content)),
+    ...createAcceptedChannelDeliveryResult({
+      deliveryResults: visibleResults,
+      content: joinMattermostVisibleContent(visibleResults.map((result) => result.content)),
+    }),
   };
 }
 
@@ -249,49 +237,30 @@ export async function deliverMattermostReplyWithDraftPreview(
   } catch (error: unknown) {
     // Preserve confirmed preview and supplemental receipts so core cannot
     // mistake a later visible-delivery failure for a safe retry.
-    const completedVisibleResults: MattermostReplyDeliveryResult[] = [];
-    const completedReceiptResults: Array<{ receipt: MessageReceipt } | { messageId: string }> = [];
-    for (const result of [
+    const completedVisibleResults = [
       confirmedPreviewDelivery,
       previewDeliveryResult,
       normalDeliveryResult,
       supplementalDeliveryResult,
-    ]) {
-      if (result?.visibleReplySent !== true) {
-        continue;
-      }
-      completedVisibleResults.push(result);
-      if (result.receipt) {
-        completedReceiptResults.push({ receipt: result.receipt });
-      } else {
-        completedReceiptResults.push(
-          ...(result.messageIds ?? []).map((messageId) => ({ messageId })),
-        );
-      }
-    }
+    ].filter(
+      (result): result is MattermostReplyDeliveryResult => result?.visibleReplySent === true,
+    );
     if (completedVisibleResults.length === 0) {
       throw error;
     }
     const failedPartial = isChannelPartialDeliveryError(error) ? error.deliveryResult : undefined;
-    const receipt = createMessageReceiptFromOutboundResults({
-      results: [
-        ...completedReceiptResults,
-        ...(failedPartial?.receipt
-          ? [{ receipt: failedPartial.receipt }]
-          : (failedPartial?.messageIds ?? []).map((messageId) => ({ messageId }))),
-      ],
-    });
-    throw createChannelPartialDeliveryError(error, {
-      messageIds: listMessageReceiptPlatformIds(receipt),
-      receipt,
-      visibleReplySent: true,
-      content: joinMattermostVisibleContent([
-        confirmedPreviewDelivery?.content,
-        previewDeliveryResult?.content,
-        normalDeliveryResult?.content,
-        supplementalDeliveryResult?.content,
-        failedPartial?.content,
-      ]),
-    });
+    throw createChannelPartialDeliveryError(
+      error,
+      createAcceptedChannelDeliveryResult({
+        deliveryResults: [...completedVisibleResults, ...(failedPartial ? [failedPartial] : [])],
+        content: joinMattermostVisibleContent([
+          confirmedPreviewDelivery?.content,
+          previewDeliveryResult?.content,
+          normalDeliveryResult?.content,
+          supplementalDeliveryResult?.content,
+          failedPartial?.content,
+        ]),
+      }),
+    );
   }
 }

--- a/extensions/mattermost/src/mattermost/reply-delivery.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.ts
@@ -1,13 +1,10 @@
 // Mattermost plugin module implements reply delivery behavior.
 import {
+  createAcceptedChannelDeliveryResult,
   createChannelPartialDeliveryError,
   isChannelPartialDeliveryError,
 } from "openclaw/plugin-sdk/channel-inbound";
-import {
-  createMessageReceiptFromOutboundResults,
-  listMessageReceiptPlatformIds,
-  type MessageReceipt,
-} from "openclaw/plugin-sdk/channel-outbound";
+import type { MessageReceipt } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk/core";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 import {
@@ -118,22 +115,16 @@ export async function deliverMattermostReplyPayload(params: {
     if (results.length === 0 && failedPartial?.visibleReplySent !== true) {
       throw error;
     }
-    const receipt = createMessageReceiptFromOutboundResults({
-      results: [
-        ...results.map((result) => ({ receipt: result.receipt })),
-        ...(failedPartial?.receipt
-          ? [{ receipt: failedPartial.receipt }]
-          : (failedPartial?.messageIds ?? []).map((messageId) => ({ messageId }))),
-      ],
-      kind: reply.mediaUrls.length > 0 ? "media" : "text",
-      ...(params.replyToId ? { replyToId: params.replyToId } : {}),
-    });
-    throw createChannelPartialDeliveryError(error, {
-      messageIds: listMessageReceiptPlatformIds(receipt),
-      receipt,
-      visibleReplySent: true,
-      content: joinMattermostVisibleContent([...acceptedContents, failedPartial?.content]),
-    });
+    throw createChannelPartialDeliveryError(
+      error,
+      createAcceptedChannelDeliveryResult({
+        results: results.map((result) => ({ receipt: result.receipt })),
+        deliveryResults: failedPartial ? [failedPartial] : [],
+        kind: reply.mediaUrls.length > 0 ? "media" : "text",
+        ...(params.replyToId ? { replyToId: params.replyToId } : {}),
+        content: joinMattermostVisibleContent([...acceptedContents, failedPartial?.content]),
+      }),
+    );
   }
 
   if (outcome === "empty") {
@@ -143,16 +134,13 @@ export async function deliverMattermostReplyPayload(params: {
       suppression: { reason: "no_visible_result" },
     };
   }
-  const receipt = createMessageReceiptFromOutboundResults({
-    results: results.map((result) => ({ receipt: result.receipt })),
-    kind: outcome,
-    ...(params.replyToId ? { replyToId: params.replyToId } : {}),
-  });
   return {
     outcome,
-    messageIds: listMessageReceiptPlatformIds(receipt),
-    receipt,
-    visibleReplySent: true,
-    content: joinMattermostVisibleContent(acceptedContents),
+    ...createAcceptedChannelDeliveryResult({
+      results: results.map((result) => ({ receipt: result.receipt })),
+      kind: outcome,
+      ...(params.replyToId ? { replyToId: params.replyToId } : {}),
+      content: joinMattermostVisibleContent(acceptedContents),
+    }),
   };
 }

--- a/src/channels/turn/delivery-result.test.ts
+++ b/src/channels/turn/delivery-result.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import type { MessageReceipt } from "../message/types.js";
 import {
+  createAcceptedChannelDeliveryResult,
   createChannelDeliveryResultFromReceipt,
   createChannelPartialDeliveryError,
   isChannelPartialDeliveryError,
@@ -11,6 +12,54 @@ import {
   hasVisibleChannelTurnDispatchFromReceipt as hasVisibleChannelTurnDispatch,
   resolveChannelTurnDispatchCounts,
 } from "./dispatch-result.js";
+
+describe("createAcceptedChannelDeliveryResult", () => {
+  it.each([true, false])(
+    "retains accepted prefixes and nested partial identities (receipt=%s)",
+    (withReceipt) => {
+      const nestedReceipt: MessageReceipt = {
+        primaryPlatformMessageId: "attachment",
+        platformMessageIds: ["attachment", "caption"],
+        parts: [
+          { platformMessageId: "attachment", kind: "media", index: 0, threadId: "native-thread" },
+        ],
+        sentAt: 123,
+      };
+      const result = createAcceptedChannelDeliveryResult({
+        results: [{ messageId: "prefix" }],
+        deliveryResults: [
+          {
+            visibleReplySent: true,
+            messageIds: withReceipt ? ["stale-legacy-id"] : ["attachment", "caption"],
+            ...(withReceipt ? { receipt: nestedReceipt } : {}),
+          },
+        ],
+        kind: "media",
+        content: "accepted prefix\naccepted attachment",
+      });
+
+      expect(result.messageIds).toEqual(["prefix", "attachment", "caption"]);
+      expect(result.content).toBe("accepted prefix\naccepted attachment");
+      expect(result.visibleReplySent).toBe(true);
+      expect(result).not.toHaveProperty("threadId");
+      expect(result.receipt.parts[0]?.platformMessageId).toBe("prefix");
+      if (withReceipt) {
+        expect(result.receipt.parts[1]).toEqual(nestedReceipt.parts[0]);
+      }
+    },
+  );
+
+  it("preserves identityless accepted delivery without inventing routing or text", () => {
+    const result = createAcceptedChannelDeliveryResult({});
+    expect(result).toMatchObject({
+      messageIds: [],
+      receipt: { platformMessageIds: [], parts: [] },
+      visibleReplySent: true,
+    });
+    expect(result).not.toHaveProperty("content");
+    expect(result).not.toHaveProperty("threadId");
+  });
+});
 
 describe("createChannelDeliveryResultFromReceipt", () => {
   it("keeps legacy messageIds while attaching the receipt", () => {

--- a/src/channels/turn/delivery-result.ts
+++ b/src/channels/turn/delivery-result.ts
@@ -1,6 +1,7 @@
 // Delivery-result adapters for channel turn receipts.
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
+  createMessageReceiptFromOutboundResults,
   listMessageReceiptPlatformIds,
   resolveMessageReceiptThreadId,
 } from "../message/receipt.js";
@@ -10,6 +11,41 @@ import type {
   ChannelDeliveryOutcome,
   ChannelDeliveryResult,
 } from "./types.js";
+
+type ReceiptParams = Parameters<typeof createMessageReceiptFromOutboundResults>[0];
+
+/** Aggregates caller-confirmed sends, preserving nested receipts before legacy message IDs. */
+export function createAcceptedChannelDeliveryResult(
+  params: Pick<ReceiptParams, "kind" | "replyToId"> & {
+    results?: ReceiptParams["results"];
+    deliveryResults?: readonly ChannelDeliveryOutcome[];
+    content?: string;
+  },
+): {
+  messageIds: string[];
+  receipt: MessageReceipt;
+  visibleReplySent: true;
+  content?: string;
+} {
+  const { deliveryResults, content, ...receiptParams } = params;
+  const results = deliveryResults
+    ? [
+        ...(receiptParams.results ?? []),
+        ...deliveryResults.flatMap((result): ReceiptParams["results"] =>
+          result.receipt
+            ? [{ receipt: result.receipt }]
+            : (result.messageIds ?? []).map((messageId) => ({ messageId })),
+        ),
+      ]
+    : (receiptParams.results ?? []);
+  const receipt = createMessageReceiptFromOutboundResults({ ...receiptParams, results });
+  return {
+    messageIds: listMessageReceiptPlatformIds(receipt),
+    receipt,
+    visibleReplySent: true,
+    ...(content === undefined ? {} : { content }),
+  };
+}
 
 /** Builds a typed non-visible channel outcome without transport identity. */
 export function createSuppressedChannelDeliveryResult(params: {

--- a/src/plugin-sdk/channel-inbound.ts
+++ b/src/plugin-sdk/channel-inbound.ts
@@ -288,8 +288,6 @@ export {
   buildChannelInboundMediaPayload,
   formatMediaPlaceholderText,
   formatInboundMediaUnavailableText,
-  /** @deprecated Pass ordered facts as the context's `media` field. */
-  buildChannelInboundMediaPayload as buildChannelTurnMediaPayload,
 } from "../channels/inbound-event/media.js";
 export type {
   ChannelInboundMediaInput,

--- a/src/plugin-sdk/channel-inbound.ts
+++ b/src/plugin-sdk/channel-inbound.ts
@@ -274,6 +274,7 @@ export {
   resolveChannelTurnDispatchCounts as resolveInboundReplyDispatchCounts,
 };
 export {
+  createAcceptedChannelDeliveryResult,
   createChannelPartialDeliveryError,
   isChannelPartialDeliveryError,
   type ChannelPartialDeliveryError,


### PR DESCRIPTION
## What Problem This Solves

Feishu, iMessage, Matrix and Mattermost repeat the same accepted-send aggregation, including preservation of the provider-visible subset when a later operation fails. Maintaining separate receipt and legacy-ID aggregation paths risks inconsistent delivery observations.

## Why This Change Was Made

Use `createAcceptedChannelDeliveryResult` in the turn delivery owner through the existing `openclaw/plugin-sdk/channel-inbound` entrypoint. It combines accepted native results before nested logical results, gives receipts precedence over legacy IDs, and leaves acceptance side effects, content joining, suppression and receipt absence with each adapter.

Keep the SDK seam budget-neutral by retiring only the unused deprecated `buildChannelTurnMediaPayload` alias from that same entrypoint. Repository searches found no consumers; GitHub-wide and organization searches returned only vendored alias definitions, with no consuming imports or calls. The canonical `buildChannelInboundMediaPayload` helper and its compatibility window remain; the migration guide names the replacement. This retirement is explicitly maintainer-authorized. No SDK budget, subpath, dependency or manifest was added or raised.

The iMessage adapter avoids result-variable shadowing, and its test asserts nested receipt metadata without dereferencing the suppressed union arm.

The requested consumer checks are complete: no consuming import or call was found. Searches cannot enumerate undisclosed private plugins. Under the maintainer's explicit instruction to retire an unused deprecated export, this PR proceeds with the canonical replacement documented. ClawSweeper identified no new correctness or security defect; its remaining note describes that residual import-compatibility possibility.

## User Impact

No intended change to channel sends, partial-result handling, echo caching or thread metadata. Plugin authors gain one shared aggregation helper. The unused deprecated media alias is removed; its canonical helper remains available.

## Evidence

- `node scripts/run-vitest.mjs extensions/feishu extensions/imessage/src/monitor/deliver extensions/mattermost/src/mattermost/reply-delivery extensions/matrix/src/matrix/monitor/replies src/channels/turn/delivery-result src/plugin-sdk/channel-inbound test/scripts/plugin-sdk-surface-report`: **2,125 tests passed** across seven shards.
- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor-draft-delivery`: **22 tests passed**.
- `pnpm plugin-sdk:sync-exports`, `pnpm plugin-sdk:check-exports`, `pnpm plugin-sdk:surface`, and `pnpm plugin-sdk:surface:check`: passed. Exactly **4,446 public exports / 2,630 callables**, matching the unchanged limits. Canonical synchronization required no manifest edits; the surface generator emits its inventory without rewriting budgets.
- `node scripts/check-changed.mjs`: passed SDK budgets, all four core/extension production/test typechecks, dead-export scans and core lint. Extension lint stopped at the documented nested-worktree `Declaration input escapes checkout` from an ancestor manifest. The ancestor installation was not modified; the hosted extension checks listed below passed.
- `pnpm build`: passed in **11m 12.2s**, including all 152 public SDK subpaths, 90 external plugins and native loads of 53 built modules.
- Final staged autoreview: zero actionable P0–P2 findings.
- Exact-head CI [34091290266](https://github.com/openclaw/openclaw/actions/runs/34091290266): passed on `c7571162422c7a1fa43d01242832f38c35fc30c4`, including [check-lint](https://github.com/openclaw/openclaw/actions/runs/34091290266/job/101645248331), [additional extension package boundary](https://github.com/openclaw/openclaw/actions/runs/34091290266/job/101645248357), and [test types](https://github.com/openclaw/openclaw/actions/runs/34091290266/job/101645248475).

Known gap: synthetic channel and lifecycle tests exercise these boundaries; no live-channel account or external send was used. Hosted extension lint/package-boundary checks passed and resolve the local nested-checkout limitation.
