### PR TITLE
fix(ollama): honor per-request sampling overrides

### DIFF
--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -1005,6 +1005,12 @@ For full setup and behavior, see [Ollama Web Search](/tools/ollama-search).
     `num_predict`, `top_k`, `top_p`, `min_p`, `typical_p`, `repeat_last_n`,
     `temperature`, `repeat_penalty`, `presence_penalty`, `frequency_penalty`,
     `stop`, `num_batch`, `num_gpu`, `main_gpu`, `use_mmap`, and `num_thread`.
+    Runtime sampling controls (`temperature`, `topP`, `frequencyPenalty`,
+    `presencePenalty`, and `seed`) override the matching model defaults,
+    including explicit zero values. The Gateway's Chat Completions API maps
+    `top_p`, `frequency_penalty`, and `presence_penalty` to these controls.
+    With `temperature: 0`, OpenClaw still normalizes `top_p` to `1` for greedy
+    sampling after applying overrides.
     A few keys (`format`, `keep_alive`, `truncate`, `shift`) are forwarded as
     top-level request fields instead of nested `options`. Local native chat
     requests default to `truncate: false` and `shift: false`, so supporting

--- a/extensions/ollama/ollama.live.test.ts
+++ b/extensions/ollama/ollama.live.test.ts
@@ -283,7 +283,13 @@ describe.skipIf(!LIVE)("ollama live", () => {
           model?: string;
           think?: boolean;
           keep_alive?: string;
-          options?: { num_ctx?: number; top_p?: number };
+          options?: {
+            num_ctx?: number;
+            top_p?: number;
+            seed?: number;
+            frequency_penalty?: number;
+            presence_penalty?: number;
+          };
           tools?: Array<{
             function?: {
               parameters?: {
@@ -294,7 +300,7 @@ describe.skipIf(!LIVE)("ollama live", () => {
         }
       | undefined;
 
-    const runNativeChat = () =>
+    const runNativeChat = (temperature = 0) =>
       streamFn(
         {
           id: `${PROVIDER_ID}/${CHAT_MODEL}`,
@@ -302,7 +308,15 @@ describe.skipIf(!LIVE)("ollama live", () => {
           provider: PROVIDER_ID,
           input: ["text"],
           contextWindow: 8192,
-          params: { num_ctx: 4096, top_p: 0.9, thinking: false, keep_alive: "5m" },
+          params: {
+            num_ctx: 4096,
+            top_p: 0.9,
+            seed: 7,
+            frequency_penalty: 0.5,
+            presence_penalty: 0.75,
+            thinking: false,
+            keep_alive: "5m",
+          },
           requestTimeoutMs: 120_000,
         } as never,
         {
@@ -328,7 +342,11 @@ describe.skipIf(!LIVE)("ollama live", () => {
         } as never,
         {
           maxTokens: 32,
-          temperature: 0,
+          temperature,
+          topP: 0.7,
+          seed: 0,
+          frequencyPenalty: 0,
+          presencePenalty: 0,
           onPayload: (body: unknown) => {
             payload = body as NonNullable<typeof payload>;
           },
@@ -337,7 +355,14 @@ describe.skipIf(!LIVE)("ollama live", () => {
       );
 
     const events = await collectStreamEvents(await Promise.resolve(runNativeChat()));
-    const warmEvents = await collectStreamEvents(await Promise.resolve(runNativeChat()));
+    expect(payload?.options).toMatchObject({
+      num_ctx: 4096,
+      top_p: 1,
+      seed: 0,
+      frequency_penalty: 0,
+      presence_penalty: 0,
+    });
+    const warmEvents = await collectStreamEvents(await Promise.resolve(runNativeChat(0.8)));
     const error = events.find((event) => (event as { type?: string }).type === "error");
     const warmError = warmEvents.find((event) => (event as { type?: string }).type === "error");
     const warmDone = warmEvents.find((event) => event.type === "done");
@@ -362,8 +387,14 @@ describe.skipIf(!LIVE)("ollama live", () => {
       })}`,
     );
     expect(payload?.model).toBe(CHAT_MODEL);
-    expect(payload?.options?.num_ctx).toBe(4096);
-    expect(payload?.options?.top_p).toBe(1);
+    expect(payload?.options).toMatchObject({
+      num_ctx: 4096,
+      top_p: 0.7,
+      seed: 0,
+      frequency_penalty: 0,
+      presence_penalty: 0,
+    });
+    console.info(`[ollama:live] sampling ${JSON.stringify(payload?.options)}`);
     expect(payload?.think).toBe(false);
     expect(payload?.keep_alive).toBe("5m");
     const properties = payload?.tools?.[0]?.function?.parameters?.properties;

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1716,7 +1716,7 @@ async function createOllamaTestStream(params: {
   defaultHeaders?: Record<string, string>;
   model?: Record<string, unknown>;
   context?: Record<string, unknown>;
-  options?: Parameters<ReturnType<typeof createOllamaStreamFn>>[2];
+  options?: Parameters<ReturnType<typeof createOllamaStreamFn>>[2] & Record<string, unknown>;
 }) {
   const streamFn = createOllamaStreamFn(params.baseUrl, params.defaultHeaders);
   return streamFn(
@@ -3285,9 +3285,58 @@ describe("createOllamaStreamFn", () => {
 
   it.each([
     {
+      name: "applies native Ollama runtime sampling overrides",
+      options: { topP: 0.7, seed: 42, frequencyPenalty: -0.5, presencePenalty: 1.25 },
+      expected: { top_p: 0.7, seed: 42, frequency_penalty: -0.5, presence_penalty: 1.25 },
+    },
+    {
+      name: "preserves zero native Ollama runtime sampling overrides",
+      options: { topP: 0, seed: 0, frequencyPenalty: 0, presencePenalty: 0 },
+      expected: { top_p: 0, seed: 0, frequency_penalty: 0, presence_penalty: 0 },
+    },
+    {
+      name: "preserves native Ollama model sampling defaults without runtime overrides",
+      options: {
+        topP: undefined,
+        seed: undefined,
+        frequencyPenalty: undefined,
+        presencePenalty: undefined,
+      },
+      expected: { top_p: 0.9, seed: 7, frequency_penalty: 0.5, presence_penalty: 0.75 },
+    },
+  ])("$name", async ({ options, expected }) => {
+    await expectSuccessfulOllamaRequest(
+      {
+        baseUrl: "http://ollama-host:11434",
+        model: {
+          params: {
+            temperature: 0.8,
+            top_p: 0.9,
+            seed: 7,
+            frequency_penalty: 0.5,
+            presence_penalty: 0.75,
+          },
+        },
+        options,
+      },
+      ({ body }) => {
+        expect(body.options).toMatchObject(expected);
+      },
+    );
+  });
+
+  it.each([
+    {
       name: "sets top_p=1 for native Ollama greedy sampling requests",
       params: { num_ctx: 4096, top_p: 0.9, thinking: false },
       temperature: 0,
+      expectedTopP: 1,
+    },
+    {
+      name: "normalizes runtime topP for native Ollama greedy sampling requests",
+      params: { top_p: 0.9 },
+      temperature: 0,
+      topP: 0.6,
       expectedTopP: 1,
     },
     {
@@ -3302,9 +3351,9 @@ describe("createOllamaStreamFn", () => {
       temperature: 0.2,
       expectedTopP: 0.9,
     },
-  ])("$name", async ({ params, temperature, expectedTopP }) => {
+  ])("$name", async ({ params, temperature, topP, expectedTopP }) => {
     await expectSuccessfulOllamaRequest(
-      { baseUrl: "http://ollama-host:11434", model: { params }, options: { temperature } },
+      { baseUrl: "http://ollama-host:11434", model: { params }, options: { temperature, topP } },
       ({ body }) => {
         const options = requireRecord(body.options, "Ollama sampling options");
         expect(options.temperature).toBe(temperature);

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -972,6 +972,13 @@ function resolveOllamaRequestTimeoutMs(
   return typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : undefined;
 }
 
+type OllamaStreamOptions = NonNullable<Parameters<StreamFn>[2]> & {
+  topP?: number;
+  frequencyPenalty?: number;
+  presencePenalty?: number;
+  seed?: number;
+};
+
 function createRawOllamaStreamFn(
   baseUrl: string,
   defaultHeaders?: Record<string, string>,
@@ -980,7 +987,7 @@ function createRawOllamaStreamFn(
   const chatUrl = resolveOllamaChatUrl(baseUrl);
   const ssrfPolicy = buildOllamaBaseUrlSsrFPolicy(chatUrl);
 
-  return (model, context, options) => {
+  return (model, context, options?: OllamaStreamOptions) => {
     const stream = createAssistantMessageEventStream();
 
     const run = async () => {
@@ -1002,6 +1009,18 @@ function createRawOllamaStreamFn(
         }
         if (typeof options?.maxTokens === "number") {
           ollamaOptions.num_predict = options.maxTokens;
+        }
+        if (typeof options?.topP === "number") {
+          ollamaOptions.top_p = options.topP;
+        }
+        if (typeof options?.frequencyPenalty === "number") {
+          ollamaOptions.frequency_penalty = options.frequencyPenalty;
+        }
+        if (typeof options?.presencePenalty === "number") {
+          ollamaOptions.presence_penalty = options.presencePenalty;
+        }
+        if (typeof options?.seed === "number") {
+          ollamaOptions.seed = options.seed;
         }
         if (options?.stop && options.stop.length > 0) {
           ollamaOptions.stop = options.stop;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where callers using the Gateway's Chat Completions API could have their sampling controls silently ignored by native Ollama requests when they differed from model defaults.

## Why This Change Was Made

Map the existing per-request `topP`, `seed`, `frequencyPenalty`, and `presencePenalty` controls into native Ollama options before greedy-sampling normalization. Explicit zero values override model defaults, and `temperature: 0` retains the existing `top_p: 1` behavior.

## User Impact

Local Ollama inference now honors the sampling controls supplied for each request. This adds no configuration options and changes no default model settings.

## Evidence

- Regression cases reproduce ignored nonzero and zero overrides on the original implementation; all 194 native stream tests pass with the fix.
- Full changed-file checks pass. The extended existing live fixture also passes targeted test types, lint, and formatting; independent review reports no actionable findings.
- Direct production-adapter validation passes on Ollama 0.33.3 with `qwen3.5:4b-q4_K_M`: two real streaming requests complete successfully, and server-captured bodies exactly match the adapter payloads. The greedy request sends `top_p: 1`; the nonzero-temperature request sends `top_p: 0.7`. Both send seed and frequency/presence penalties as zero despite conflicting model defaults. Custom provider IDs, normalized tool schemas, keep-alive, and usage accounting also pass. All owned processes were cleaned up.

The standard live-fixture route was blocked by shared compiled-subprocess preparation in the companion branch's diagnostic run, before any model request. The sampling Vitest live case has not been executed; the direct proof exercises the real production adapter and mirrors that case's assertions. The fixture and watchdog deadlines remain unchanged.
