### PR TITLE
fix(ci): stabilize Workshop blank-line height checks

### DIFF
--- a/ui/src/e2e/skill-workshop-collection.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-collection.e2e.test.ts
@@ -105,12 +105,14 @@ describe("Workshop current collection", () => {
         const displayed = await reader
           .locator("details[open] .chat-diff__row:not(.chat-diff__row--del) .chat-diff__text")
           .allTextContents();
-        const rowHeights = await reader.locator(".chat-diff__row").evaluateAll((rows) => ({
-          first: rows[0]!.getBoundingClientRect().height,
-          blank: rows
-            .filter((row) => row.querySelector(".chat-diff__text")?.textContent === "")
-            .map((row) => row.getBoundingClientRect().height),
-        }));
+        const rowHeights = await reader
+          .locator(".chat-diff__row")
+          .evaluateAll((rows: HTMLElement[]) => ({
+            first: rows[0]!.offsetHeight,
+            blank: rows
+              .filter((row) => row.querySelector(".chat-diff__text")?.textContent === "")
+              .map((row) => row.offsetHeight),
+          }));
         writeFileSync(
           path.join(proof, "document.json"),
           JSON.stringify(


### PR DESCRIPTION
Closes #140700

## What Problem This Solves

Workshop document E2E checks intermittently reject full-height blank lines because browser rectangle measurements differ by a tiny fraction of a pixel. The inherited main failure blocked unrelated PR CI, including #138870; #140654 also recorded the same failure followed by a successful unchanged rerun.

## Why This Change Was Made

Measure each diff row's untransformed layout height with `offsetHeight`. Keep the existing requirement that every blank row is at least as tall as the first row. Production CSS and reader behavior are unchanged.

## User Impact

More reliable Workshop CI, with the regression check for collapsed blank lines retained. No product behavior change.

## Evidence

The unchanged real page reproduced the failure on the 700-line document at a 390px viewport: the first row measured 18.59375px and one blank row measured 18.593505859375px, a difference of 0.000244140625px. The displayed document still matched every expected line.

All 12 Workshop E2E cases passed after the correction, including a final run against the worktree's own frozen dependency install. Deliberately removing the minimum height from blank context rows made them measure 0px against a 19px first row and failed the unchanged assertion. The temporary sensitivity injection was removed.

Independent P2 review found no actionable issues. The complete selected changed-code gate passed, including the UI E2E type graph, i18n, three dead-export scans and targeted lint.
