### PR TITLE
improve: reduce Google tool-history preparation overhead

### DIFF
--- a/packages/ai/src/providers/google-messages.ts
+++ b/packages/ai/src/providers/google-messages.ts
@@ -50,16 +50,12 @@ function sanitizeGeminiThoughtSignature(value: string | undefined): string | und
     : undefined;
 }
 
-function toolCallThoughtSignatureReplayKey(block: {
-  id: string;
-  name: string;
-  arguments: unknown;
-}): string {
-  return [
-    block.id,
-    block.name,
-    stableStringifyGoogleToolCallValue(coerceTransportToolCallArguments(block.arguments)),
-  ].join("\u0000");
+function toolCallThoughtSignatureReplayKey(
+  id: string,
+  name: string,
+  args: Record<string, unknown>,
+): string {
+  return [id, name, stableStringifyGoogleToolCallValue(args)].join("\u0000");
 }
 
 export function requiresGoogleToolCallId(modelId: string): boolean {
@@ -192,7 +188,15 @@ export function projectGoogleMessages(params: {
           const ownSignature = isSameProviderAndModel
             ? signature(block.thoughtSignature)
             : undefined;
-          const replayKey = managed ? toolCallThoughtSignatureReplayKey(block) : "";
+          // Keys serve managed signature recording or a possible earlier-turn replay lookup.
+          const replayKey =
+            managed &&
+            (ownSignature ||
+              (params.requiresToolCallSignature &&
+                isSameProviderAndModel &&
+                replaySignatures.size > 0))
+              ? toolCallThoughtSignatureReplayKey(block.id, block.name, args)
+              : "";
           if (managed && ownSignature) {
             nextReplaySignatures.set(replayKey, ownSignature);
           }

--- a/packages/ai/src/providers/google-shared.convert.test.ts
+++ b/packages/ai/src/providers/google-shared.convert.test.ts
@@ -1,7 +1,8 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
+import { createEmptyTransportUsage } from "../transports/transport-stream-shared.js";
 import type { Context, Tool } from "../types.js";
-import { convertGoogleTools } from "./google-messages.js";
+import { convertGoogleTools, projectGoogleMessages } from "./google-messages.js";
 import {
   assertRecord,
   convertMessages,
@@ -156,20 +157,125 @@ describe("google-shared convertTools", () => {
 
 describe("google-shared convertMessages", () => {
   it.each([
+    {
+      replay: "managed" as const,
+      required: true,
+      expected: [
+        "c2lnXzE=",
+        "skip_thought_signature_validator",
+        "c2lnXzI=",
+        "c2lnXzE=",
+        "c2lnXzI=",
+      ],
+    },
+    {
+      replay: "managed" as const,
+      required: false,
+      expected: ["c2lnXzE=", undefined, "c2lnXzI=", undefined, undefined],
+    },
+    {
+      replay: "signed-parts" as const,
+      required: true,
+      expected: ["c2lnXzE=", undefined, "c2lnXzI=", undefined, "skip_thought_signature_validator"],
+    },
+    {
+      replay: "signed-parts" as const,
+      required: false,
+      expected: ["c2lnXzE=", undefined, "c2lnXzI=", undefined, undefined],
+    },
+  ])(
+    "preserves $replay signature ownership with required=$required",
+    ({ replay, required, expected }) => {
+      const model = makeModel(required ? "gemini-3-flash" : "gemini-2.5-pro");
+      const args = { first: 1, nested: { alpha: 2, beta: 3 } };
+      const reordered = { nested: { beta: 3, alpha: 2 }, first: 1 };
+      const originalBytes = JSON.stringify([args, reordered]);
+      const call = { type: "toolCall" as const, id: "call_1", name: "lookup", arguments: args };
+      const turn = {
+        role: "assistant" as const,
+        api: model.api,
+        provider: model.provider,
+        model: model.id,
+        stopReason: "toolUse" as const,
+        usage: createEmptyTransportUsage(),
+        timestamp: 0,
+      };
+      const result = {
+        role: "toolResult" as const,
+        toolCallId: "call_1",
+        toolName: "lookup",
+        content: [{ type: "text" as const, text: "ok" }],
+        isError: false,
+        timestamp: 1,
+      };
+      const contents = projectGoogleMessages({
+        model,
+        replay,
+        requiresToolCallSignature: required,
+        messages: [
+          {
+            ...turn,
+            content: [
+              { ...call, thoughtSignature: "c2lnXzE=" },
+              { ...call, arguments: reordered },
+            ],
+          },
+          result,
+          result,
+          {
+            ...turn,
+            content: [
+              { ...call, thoughtSignature: "c2lnXzI=" },
+              { ...call, arguments: reordered },
+            ],
+          },
+          result,
+          result,
+          { ...turn, content: [{ ...call, arguments: reordered }] },
+          result,
+        ],
+      });
+      const parts = contents
+        .flatMap((content) => content.parts)
+        .filter((part) => part.functionCall);
+      expect(parts.map((part) => part.thoughtSignature)).toEqual(expected);
+      expect(parts.map((part) => part.functionCall?.args)).toEqual([
+        args,
+        reordered,
+        args,
+        reordered,
+        reordered,
+      ]);
+      expect(parts[1]?.functionCall?.args).toBe(reordered);
+      expect(JSON.stringify([args, reordered])).toBe(originalBytes);
+    },
+  );
+
+  it.each([
     { label: "serialized object", value: '{"query":"cats"}', expected: { query: "cats" } },
     { label: "malformed JSON", value: "{not valid json", expected: {} },
     { label: "JSON array", value: ["not", "an", "object"], expected: {} },
   ])("coerces $label tool-call arguments to the SDK object contract", ({ value, expected }) => {
     const model = makeModel("gemini-3-flash");
-    const contents = convertMessagesForTest(model, {
+    const context = {
       messages: [
         makeGoogleAssistantMessage(model.id, [
           { type: "toolCall", id: "call_1", name: "lookup", arguments: value },
         ]),
       ],
-    } as Context);
+    } as Context;
 
-    expect(contents[0]?.parts?.[0]?.functionCall?.args).toEqual(expected);
+    for (const contents of [
+      convertMessagesForTest(model, context),
+      projectGoogleMessages({
+        model,
+        messages: context.messages,
+        replay: "managed",
+        requiresToolCallSignature: true,
+      }),
+    ]) {
+      expect(contents[0]?.parts?.[0]?.functionCall?.args).toEqual(expected);
+    }
   });
 
   it.each([


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled where applicable.

</details>

## What Problem This Solves

Preparing Google requests with tool-call history does unnecessary work even when earlier thought signatures cannot be reused. This adds local request-building cost for unsigned Gemini 2.5 calls, foreign-provider history, and calls with no prior signature to replay.

## Why This Change Was Made

Reuse the already prepared argument record when constructing a replay key, and construct that key only when a managed call can record its own signature or consult an eligible replay map. Signature bytes, per-assistant staging, argument identity, route checks, and the separate signed-parts policy remain unchanged.

## User Impact

Google request preparation does less work for these histories, with no intended change to request contents or configuration. This is a local request-building improvement; it does not establish faster provider responses or Gateway turns.

## Evidence

282 tests passed across four complete Google conversion/transport test files; the normal changed-file gate passed all 28 stages. Independent P2 review reported no findings (0.98 confidence). The formatted diff adds 4 production lines and 106 test lines; the added tests protect preserved behavior rather than assert implementation counters.

A fixed 18-history corpus exercised both actual request builders, each with and without JSON serialization, in baseline/candidate/candidate/baseline order. Each row/mode used eight warmups and 24 batches of 16 calls. All 56,448 returned wire outputs matched independently authored full expectations; 64 deduplicated full JSON payload definitions plus every return's reference were retained. Full-object equality, original argument-record references, own undefined fields, and unchanged frozen inputs were checked in-process; serialized evidence cannot independently reconstruct JavaScript identity.

Selected medians of batch means, milliseconds per call (forward / reverse pair):

| Managed history | Builder before → after | Builder + JSON before → after |
| --- | --- | --- |
| Unsigned Gemini 2.5, stored JSON arguments | 0.2020 → 0.0991 / 0.2122 → 0.1016 | 0.2265 → 0.1252 / 0.2485 → 0.1236 |
| Foreign history | 0.4644 → 0.0390 / 0.5113 → 0.0384 | 0.5623 → 0.1364 / 0.6049 → 0.1351 |
| Empty replay map | 0.4639 → 0.0344 / 0.4986 → 0.0349 | 0.5635 → 0.1375 / 0.6185 → 0.1315 |
| Mixed malformed arguments | 0.0926 → 0.0624 / 0.0938 → 0.0615 | 0.0966 → 0.0727 / 0.0970 → 0.0748 |

Results are not uniformly faster: 30/72 median, 34/72 mean, and 35/72 maximum batch-mean comparisons were adverse. Reverse-pair tiny Vertex/alias medians regressed 22.28–38.83% (0.00127–0.00158 ms); assistant staging rose 2.94% for builder-only. Signed-parts controls ranged from 4.27% faster to 18.04% slower. The largest mean regression was tiny Vertex builder, 0.004920 → 0.010631 ms (+116.05%); the largest maximum batch-mean regression was tiny Gemini 2.5 with JSON, 0.007536 → 0.141320 ms (+1775.16%). Warmup median/mean/maximum comparisons were adverse in 24/28/31 of 72 cases, and first warmups in 29/72; no warmup is claimed as a cold start, and batch maxima are not individual-call tail latency.

Whole proof-process wall time fell 13.83% / 14.74%, including imports, checking, and journaling. Memory did not improve: kernel child maximum RSS rose 3.27% / 3.00%, sampled process-tree peak 2.88% / 2.89%, and end-workload RSS 3.19% / 2.84%. All measured children exited successfully and closed, and the candidate source was restored. No external Google requests, provider-latency, Gateway, or memory-benefit claim is made.
