### PR TITLE
fix(android): keep chat input usable in short keyboard viewports

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -195,11 +195,13 @@ import androidx.compose.ui.input.key.onPreInterceptKeyBeforeSoftKeyboard
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.paneTitle
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
@@ -207,6 +209,7 @@ import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -450,6 +453,7 @@ fun ChatScreen(
   var showModelPicker by rememberSaveable { mutableStateOf(false) }
   var showBackgroundTasks by rememberSaveable { mutableStateOf(false) }
   var showBranchSwitcher by rememberSaveable { mutableStateOf(false) }
+  var detailsExpanded by rememberSaveable { mutableStateOf(false) }
   var sendMessageTooLong by rememberSaveable(composerOwner) { mutableStateOf(false) }
   var sendCheckpointFull by rememberSaveable(composerOwner) { mutableStateOf(false) }
 
@@ -722,299 +726,332 @@ fun ChatScreen(
     }
   }
 
-  Column(
-    modifier =
-      Modifier
-        .fillMaxSize()
-        .padding(vertical = 10.dp),
-    verticalArrangement = Arrangement.spacedBy(8.dp),
-  ) {
-    ChatMessageList(
-      sessionKey = sessionKey,
-      fullMessageOwner = composerOwner,
-      selectionGeneration = selectionGeneration,
-      gatewayCatalogRevision = gatewayCatalogRevision,
-      prepareFullMessageRead = { message -> viewModel.prepareFullMessageRead(composerOwner, selectionGeneration, gatewayCatalogRevision, message) },
-      session = activeSession,
-      messages = messages,
-      transcriptAnchor = transcriptAnchor,
-      historyLoading = historyLoading,
-      activeRunCount = selectedActiveRun.count,
-      activeRunId = selectedActiveRun.runId,
-      activeRunClockKey = selectedActiveRun.clockKey,
-      activeRunOutputTokens = selectedActiveRun.outputTokens,
-      pendingToolCalls = pendingToolCalls,
-      subagentActivities = subagentActivities,
-      questions = questionsForSession(questions, sessionKey, mainSessionKey, activeAgentId),
-      streamingAssistantText = streamingAssistantText,
+  val headerContent: @Composable ((() -> Unit)?, () -> Unit) -> Unit = { onJumpToLatest, dismissDetails ->
+    ChatHeader(
+      activeAgent = activeAgent,
+      projectLabel = activeProjectLabel,
+      sessionTitle = activeSessionTitle,
+      sessionColor = activeSession?.color,
+      showSidebarButton = showSidebarButton,
+      onOpenSidebar = {
+        dismissDetails()
+        onOpenSidebar()
+      },
+      onJumpToLatest =
+        onJumpToLatest?.let { jump ->
+          {
+            dismissDetails()
+            jump()
+          }
+        },
       healthOk = healthOk,
-      gatewayOffline = gatewayOffline,
-      outboxItems = currentSessionOutboxItems,
-      recoveryOutboxItems =
-        outboxItemsForRecovery(
-          items = outboxItems,
-        ),
-      onRetryOutbox = viewModel::retryChatOutboxCommand,
-      onDeleteOutbox = viewModel::deleteChatOutboxCommand,
-      onResolveQuestion = viewModel::resolveChatQuestion,
-      onQuestionDraftChanged = viewModel::updateChatQuestionDraft,
-      onSkipQuestion = viewModel::skipChatQuestion,
-      onStarterPrompt = { prompt -> inputDrafts[composerOwner] = prompt },
-      onReplyMessage = { value -> viewModel.setChatReplyDraft(value, composerOwner) },
-      sessionActionsEnabled =
-        pendingRunCount == 0 &&
-          !sessionBranchSwitching &&
-          outboxPresentationRestored &&
-          currentSessionOutboxItems.none { it.status != ChatOutboxStatus.Failed },
-      onRewindMessage = { entryId ->
-        val expectedInput = inputDrafts[composerOwner].orEmpty()
-        scope.launch {
-          val result = viewModel.rewindChatAtEntry(entryId) ?: return@launch
-          viewModel.setChatDraft(
-            ChatDraft(
-              text = result.editorText.orEmpty(),
-              placement = ChatDraftPlacement.Replace,
-              owner = composerOwner,
-              expectedExistingText = expectedInput,
-              acceptsEmptyText = true,
-              attachments = result.editorAttachments.toPendingAttachments(),
-            ),
-          )
-        }
-      },
-      onForkMessage = { entryId ->
-        scope.launch {
-          val result = viewModel.forkChatAtEntry(entryId) ?: return@launch
-          val newOwner = composerOwner.copy(sessionKey = result.sessionKey)
-          val expectedInput = inputDrafts[newOwner].orEmpty()
-          viewModel.switchChatSession(result.sessionKey, composerOwner.agentId)
-          viewModel.setChatDraft(
-            ChatDraft(
-              text = result.editorText.orEmpty(),
-              placement = ChatDraftPlacement.Replace,
-              owner = newOwner,
-              expectedExistingText = expectedInput,
-              acceptsEmptyText = true,
-              attachments = result.editorAttachments.toPendingAttachments(),
-            ),
-          )
-        }
-      },
-      speechState = messageSpeechState,
-      onToggleListen = viewModel::toggleChatMessageSpeech,
-      inlineMediaPlaybackBlocked = inlineMediaPlaybackBlocked,
-      resolveInlineWidgetResource = viewModel::resolveInlineWidgetResource,
-      loadImageArtifact = viewModel::loadChatImageArtifact,
-      loadMediaArtifact = viewModel::loadChatMediaArtifact,
-      modifier = Modifier.weight(1f),
-      header = { onJumpToLatest ->
-        ChatHeader(
-          activeAgent = activeAgent,
-          projectLabel = activeProjectLabel,
-          sessionTitle = activeSessionTitle,
-          sessionColor = activeSession?.color,
-          showSidebarButton = showSidebarButton,
-          onOpenSidebar = onOpenSidebar,
-          onJumpToLatest = onJumpToLatest,
-          healthOk = healthOk,
-          pendingRunCount = pendingRunCount,
-          sessionCreating = sessionCreating,
-          newChatEnabled = newChatEnabled,
-          workspaceGit = workspaceGit,
-          branches = sessionBranches,
-          branchesLoading = sessionBranchesLoading,
-          branchSwitchEnabled =
-            outboxPresentationRestored && pendingRunCount == 0 && !sessionBranchSwitching && currentSessionOutboxItems.isEmpty(),
-          onNewChatInWorktree = { startNewChat(true) },
-          onRefresh = {
-            viewModel.refreshChat()
-            viewModel.refreshChatSessions(limit = 100)
-          },
-          onOpenDashboard = { onOpenDashboard(sessionKey) },
-          onOpenBackgroundTasks = { showBackgroundTasks = true },
-          onOpenBranchSwitcher = {
-            showBranchSwitcher = true
-            scope.launch { viewModel.refreshChatSessionBranches() }
-          },
-        )
-
-        errorText?.takeIf { it.isNotBlank() }?.let { error ->
-          ChatNotice(
-            title = nativeString("Chat needs attention"),
-            body = userFacingChatError(error = error, gatewayConnected = gatewayConnectionDisplay.isConnected),
-          )
-        }
-      },
-    )
-
-    ChatSwarmProgress(groups = swarmGroups)
-
-    ChatComposer(
-      progressCard = progressCard,
-      value = input,
-      onValueChange = {
-        sendMessageTooLong = false
-        sendCheckpointFull = false
-        inputDrafts[composerOwner] = it
-      },
-      attachments = attachments,
-      thinkingLevel = thinkingLevel,
-      thinkingOptions = thinkingLevelSelection.options,
-      thinkingSupported = thinkingSupported,
-      thinkingLevelEnabled = canAdminSessionSettings,
-      fastMode = fastMode,
-      fastModeEnabled =
-        chatFastModeControlEnabled(
-          supported = fastModeSupported,
-          adminAuthorized = canAdminSessionSettings,
-          connected = gatewayConnectionDisplay.isConnected,
-          gatewayAvailable = healthOk,
-          loading = historyLoading || sessionCreating,
-          sending = sendInFlight,
-          activeRun = pendingRunCount > 0,
-          streaming = streamingAssistantText != null,
-          settingsMutationPending = sessionSettingsPending,
-        ),
-      contextUsage = contextUsage,
-      selectedModelLabel = selectedModelLabel,
-      modelPickerEnabled = gatewayConnectionDisplay.isConnected && canWriteSessionSettings,
-      healthOk = healthOk,
-      gatewayOffline = gatewayOffline,
-      offlineStatus = offlineStatus,
       pendingRunCount = pendingRunCount,
-      shareStaging = shareStaging,
-      sendInFlight = sendInFlight,
-      shareImportNotice = shareImportNotice,
-      modelUnavailableMessage = modelUnavailableMessage,
-      onDismissShareImportNotice = {
-        sendMessageTooLong = false
-        sendCheckpointFull = false
-        composerState.clearAttachmentOmission(composerOwner)
+      sessionCreating = sessionCreating,
+      newChatEnabled = newChatEnabled,
+      workspaceGit = workspaceGit,
+      branches = sessionBranches,
+      branchesLoading = sessionBranchesLoading,
+      branchSwitchEnabled =
+        outboxPresentationRestored && pendingRunCount == 0 && !sessionBranchSwitching && currentSessionOutboxItems.isEmpty(),
+      onNewChatInWorktree = {
+        dismissDetails()
+        startNewChat(true)
       },
-      commands = chatCommands,
-      onThinkingLevelChange = viewModel::setChatThinkingLevel,
-      onFastModeChange = { enabled ->
-        viewModel.setChatSessionFastMode(
-          sessionKey = sessionKey,
-          enabled = enabled,
-          clearOverride = !fastModeProviderSupported,
-        )
+      onRefresh = {
+        viewModel.refreshChat()
+        viewModel.refreshChatSessions(limit = 100)
       },
-      onOpenModelPicker = { showModelPicker = true },
-      onPickImages = {
-        if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
-        val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
-        imagePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
-        pickImages.launch("image/*")
+      onOpenDashboard = {
+        dismissDetails()
+        onOpenDashboard(sessionKey)
       },
-      onPickAudioOrDocument = {
-        if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
-        val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
-        filePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
-        pickMediaOrDocument.launch(SHARED_AUDIO_DOCUMENT_MIME_TYPES)
+      onOpenBackgroundTasks = {
+        dismissDetails()
+        showBackgroundTasks = true
       },
-      onPickVideo = {
-        if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
-        val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
-        filePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
-        pickMediaOrDocument.launch(SHARED_VIDEO_MIME_TYPES)
-      },
-      onRemoveAttachment = { id -> composerState.removeAttachments(composerOwner, setOf(id)) },
-      voiceNoteState = voiceNoteState,
-      voiceNoteElapsedMs = voiceNoteElapsedMs,
-      voiceNoteLevel = voiceNoteLevel,
-      recordVoiceNoteEnabled =
-        !talkActive &&
-          !composerOwner.gatewayStableId.isNullOrBlank() &&
-          pendingRunCount == 0 &&
-          !micCaptureActive &&
-          !dictationActive &&
-          !sendInFlight,
-      onStartVoiceNote = {
-        scope.launch {
-          val ownerSnapshot = composerOwner
-          val mediaAuthorizationId = composerState.beginMediaAcquisition(ownerSnapshot) ?: return@launch
-          val recordingId = UUID.randomUUID().toString()
-          if (!viewModel.isCurrentChatComposerOwner(ownerSnapshot)) {
-            composerState.cancelMediaAcquisition(mediaAuthorizationId)
-            return@launch
-          }
-          dictationController.cancel()
-          if (voiceNoteRecorder.start(recordingId)) {
-            if (
-              viewModel.isCurrentChatComposerOwner(ownerSnapshot) &&
-              composerState.isMediaAcquisitionActive(mediaAuthorizationId)
-            ) {
-              voiceNoteCommitCheckpoint.begin(ownerSnapshot, mediaAuthorizationId, recordingId)
-            } else {
-              voiceNoteRecorder.cancel()
-              composerState.cancelMediaAcquisition(mediaAuthorizationId)
-            }
-          } else {
-            composerState.cancelMediaAcquisition(mediaAuthorizationId)
-          }
-        }
-      },
-      onCancelVoiceNote = {
-        voiceNoteCommitCheckpoint.clear()?.let { lease ->
-          composerState.cancelMediaAcquisition(lease.authorizationId)
-        }
-        voiceNoteRecorder.cancel()
-      },
-      onFinishVoiceNote = voiceNoteRecorder::finish,
-      dictationState = dictationState,
-      dictationEnabled =
-        !talkActive &&
-          pendingRunCount == 0 &&
-          !micCaptureActive &&
-          !sendInFlight &&
-          (voiceNoteState is VoiceNoteRecorderState.Idle || voiceNoteState is VoiceNoteRecorderState.Failure),
-      onToggleDictation = {
-        if (dictationActive) {
-          dictationController.finish()
-        } else {
-          scope.launch {
-            val ownerSnapshot = composerOwner
-            val transcript = dictationController.start()
-            // Recognition can finish after navigation. Only the composer that started
-            // dictation may receive its transcript; otherwise a late result crosses drafts.
-            if (transcript != null && viewModel.isCurrentChatComposerOwner(ownerSnapshot)) {
-              inputDrafts[ownerSnapshot] =
-                appendChatDictationTranscript(inputDrafts[ownerSnapshot], transcript)
-            }
-          }
-        }
-      },
-      talkActive = talkActive,
-      onToggleTalk = onToggleTalk,
-      onFixConnection = onOpenGatewaySettings,
-      onOpenProvidersModels = onOpenProvidersModels,
-      onCopyDiagnostics = {
-        copyGatewayDiagnosticsReport(
-          context = context,
-          screen = "chat composer",
-          gatewayAddress = gatewayAddress,
-          statusText = offlineStatus,
-        )
-      },
-      onAbort = viewModel::abortChat,
-      onSend = {
-        // Re-read the ViewModel so a stale click callback cannot beat StateFlow recomposition.
-        val currentShare = viewModel.chatShareDraftForOwner(composerOwner, mainSessionKey)
-        if (currentShare != null || composerOwner in sendStates) {
-          return@ChatComposer
-        }
-        val ownerSnapshot = composerOwner
-        if (!viewModel.isCurrentChatComposerOwner(ownerSnapshot)) return@ChatComposer
-        val result =
-          viewModel.beginChatComposerSend(
-            owner = ownerSnapshot,
-            thinking = thinkingLevel,
-          )
-        sendMessageTooLong = result == ChatComposerSendStartResult.MessageTooLong
-        sendCheckpointFull = result == ChatComposerSendStartResult.CheckpointFull
+      onOpenBranchSwitcher = {
+        dismissDetails()
+        showBranchSwitcher = true
+        scope.launch { viewModel.refreshChatSessionBranches() }
       },
     )
+  }
+  BoxWithConstraints(Modifier.fillMaxSize().imePadding()) {
+    val contentPadding = 10.dp
+    val contentSpacing = 8.dp
+    // Keep a header target and a scrollable auxiliary target only when the complete input fits.
+    val compactHeight =
+      maxHeight < minimumChatInputHeight() + ClawTheme.spacing.touchTarget * 2 + contentPadding * 2 + contentSpacing * 2
+    Column(
+      modifier =
+        Modifier
+          .fillMaxSize()
+          .padding(vertical = if (compactHeight) 0.dp else contentPadding),
+      verticalArrangement = Arrangement.spacedBy(if (compactHeight) 0.dp else contentSpacing),
+    ) {
+      ChatMessageList(
+        sessionKey = sessionKey,
+        fullMessageOwner = composerOwner,
+        selectionGeneration = selectionGeneration,
+        gatewayCatalogRevision = gatewayCatalogRevision,
+        prepareFullMessageRead = { message -> viewModel.prepareFullMessageRead(composerOwner, selectionGeneration, gatewayCatalogRevision, message) },
+        session = activeSession,
+        messages = messages,
+        transcriptAnchor = transcriptAnchor,
+        historyLoading = historyLoading,
+        activeRunCount = selectedActiveRun.count,
+        activeRunId = selectedActiveRun.runId,
+        activeRunClockKey = selectedActiveRun.clockKey,
+        activeRunOutputTokens = selectedActiveRun.outputTokens,
+        pendingToolCalls = pendingToolCalls,
+        subagentActivities = subagentActivities,
+        questions = questionsForSession(questions, sessionKey, mainSessionKey, activeAgentId),
+        streamingAssistantText = streamingAssistantText,
+        healthOk = healthOk,
+        gatewayOffline = gatewayOffline,
+        outboxItems = currentSessionOutboxItems,
+        recoveryOutboxItems =
+          outboxItemsForRecovery(
+            items = outboxItems,
+          ),
+        onRetryOutbox = viewModel::retryChatOutboxCommand,
+        onDeleteOutbox = viewModel::deleteChatOutboxCommand,
+        onResolveQuestion = viewModel::resolveChatQuestion,
+        onQuestionDraftChanged = viewModel::updateChatQuestionDraft,
+        onSkipQuestion = viewModel::skipChatQuestion,
+        onStarterPrompt = { prompt -> inputDrafts[composerOwner] = prompt },
+        onReplyMessage = { value -> viewModel.setChatReplyDraft(value, composerOwner) },
+        sessionActionsEnabled =
+          pendingRunCount == 0 &&
+            !sessionBranchSwitching &&
+            outboxPresentationRestored &&
+            currentSessionOutboxItems.none { it.status != ChatOutboxStatus.Failed },
+        onRewindMessage = { entryId ->
+          val expectedInput = inputDrafts[composerOwner].orEmpty()
+          scope.launch {
+            val result = viewModel.rewindChatAtEntry(entryId) ?: return@launch
+            viewModel.setChatDraft(
+              ChatDraft(
+                text = result.editorText.orEmpty(),
+                placement = ChatDraftPlacement.Replace,
+                owner = composerOwner,
+                expectedExistingText = expectedInput,
+                acceptsEmptyText = true,
+                attachments = result.editorAttachments.toPendingAttachments(),
+              ),
+            )
+          }
+        },
+        onForkMessage = { entryId ->
+          scope.launch {
+            val result = viewModel.forkChatAtEntry(entryId) ?: return@launch
+            val newOwner = composerOwner.copy(sessionKey = result.sessionKey)
+            val expectedInput = inputDrafts[newOwner].orEmpty()
+            viewModel.switchChatSession(result.sessionKey, composerOwner.agentId)
+            viewModel.setChatDraft(
+              ChatDraft(
+                text = result.editorText.orEmpty(),
+                placement = ChatDraftPlacement.Replace,
+                owner = newOwner,
+                expectedExistingText = expectedInput,
+                acceptsEmptyText = true,
+                attachments = result.editorAttachments.toPendingAttachments(),
+              ),
+            )
+          }
+        },
+        speechState = messageSpeechState,
+        onToggleListen = viewModel::toggleChatMessageSpeech,
+        inlineMediaPlaybackBlocked = inlineMediaPlaybackBlocked,
+        resolveInlineWidgetResource = viewModel::resolveInlineWidgetResource,
+        loadImageArtifact = viewModel::loadChatImageArtifact,
+        loadMediaArtifact = viewModel::loadChatMediaArtifact,
+        modifier = Modifier.weight(1f),
+        header = { onJumpToLatest ->
+          if (!compactHeight && !detailsExpanded) headerContent(onJumpToLatest) { detailsExpanded = false }
+        },
+      ) { onJumpToLatest ->
+        ChatComposer(
+          compactHeight = compactHeight,
+          detailsExpanded = detailsExpanded,
+          onDetailsExpandedChange = { detailsExpanded = it },
+          conversationHeader = { dismissDetails -> headerContent(onJumpToLatest, dismissDetails) },
+          conversationStatus = {
+            errorText?.takeIf { it.isNotBlank() }?.let { error ->
+              ChatNotice(
+                title = nativeString("Chat needs attention"),
+                body = userFacingChatError(error = error, gatewayConnected = gatewayConnectionDisplay.isConnected),
+              )
+            }
+            ChatSwarmProgress(groups = swarmGroups)
+          },
+          progressCard = progressCard,
+          value = input,
+          onValueChange = {
+            sendMessageTooLong = false
+            sendCheckpointFull = false
+            inputDrafts[composerOwner] = it
+          },
+          attachments = attachments,
+          thinkingLevel = thinkingLevel,
+          thinkingOptions = thinkingLevelSelection.options,
+          thinkingSupported = thinkingSupported,
+          thinkingLevelEnabled = canAdminSessionSettings,
+          fastMode = fastMode,
+          fastModeEnabled =
+            chatFastModeControlEnabled(
+              supported = fastModeSupported,
+              adminAuthorized = canAdminSessionSettings,
+              connected = gatewayConnectionDisplay.isConnected,
+              gatewayAvailable = healthOk,
+              loading = historyLoading || sessionCreating,
+              sending = sendInFlight,
+              activeRun = pendingRunCount > 0,
+              streaming = streamingAssistantText != null,
+              settingsMutationPending = sessionSettingsPending,
+            ),
+          contextUsage = contextUsage,
+          selectedModelLabel = selectedModelLabel,
+          modelPickerEnabled = gatewayConnectionDisplay.isConnected && canWriteSessionSettings,
+          healthOk = healthOk,
+          gatewayOffline = gatewayOffline,
+          offlineStatus = offlineStatus,
+          pendingRunCount = pendingRunCount,
+          shareStaging = shareStaging,
+          sendInFlight = sendInFlight,
+          shareImportNotice = shareImportNotice,
+          modelUnavailableMessage = modelUnavailableMessage,
+          onDismissShareImportNotice = {
+            sendMessageTooLong = false
+            sendCheckpointFull = false
+            composerState.clearAttachmentOmission(composerOwner)
+          },
+          commands = chatCommands,
+          onThinkingLevelChange = viewModel::setChatThinkingLevel,
+          onFastModeChange = { enabled ->
+            viewModel.setChatSessionFastMode(
+              sessionKey = sessionKey,
+              enabled = enabled,
+              clearOverride = !fastModeProviderSupported,
+            )
+          },
+          onOpenModelPicker = { showModelPicker = true },
+          onPickImages = {
+            if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
+            val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
+            imagePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
+            pickImages.launch("image/*")
+          },
+          onPickAudioOrDocument = {
+            if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
+            val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
+            filePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
+            pickMediaOrDocument.launch(SHARED_AUDIO_DOCUMENT_MIME_TYPES)
+          },
+          onPickVideo = {
+            if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
+            val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
+            filePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
+            pickMediaOrDocument.launch(SHARED_VIDEO_MIME_TYPES)
+          },
+          onRemoveAttachment = { id -> composerState.removeAttachments(composerOwner, setOf(id)) },
+          voiceNoteState = voiceNoteState,
+          voiceNoteElapsedMs = voiceNoteElapsedMs,
+          voiceNoteLevel = voiceNoteLevel,
+          recordVoiceNoteEnabled =
+            !talkActive &&
+              !composerOwner.gatewayStableId.isNullOrBlank() &&
+              pendingRunCount == 0 &&
+              !micCaptureActive &&
+              !dictationActive &&
+              !sendInFlight,
+          onStartVoiceNote = {
+            scope.launch {
+              val ownerSnapshot = composerOwner
+              val mediaAuthorizationId = composerState.beginMediaAcquisition(ownerSnapshot) ?: return@launch
+              val recordingId = UUID.randomUUID().toString()
+              if (!viewModel.isCurrentChatComposerOwner(ownerSnapshot)) {
+                composerState.cancelMediaAcquisition(mediaAuthorizationId)
+                return@launch
+              }
+              dictationController.cancel()
+              if (voiceNoteRecorder.start(recordingId)) {
+                if (
+                  viewModel.isCurrentChatComposerOwner(ownerSnapshot) &&
+                  composerState.isMediaAcquisitionActive(mediaAuthorizationId)
+                ) {
+                  voiceNoteCommitCheckpoint.begin(ownerSnapshot, mediaAuthorizationId, recordingId)
+                } else {
+                  voiceNoteRecorder.cancel()
+                  composerState.cancelMediaAcquisition(mediaAuthorizationId)
+                }
+              } else {
+                composerState.cancelMediaAcquisition(mediaAuthorizationId)
+              }
+            }
+          },
+          onCancelVoiceNote = {
+            voiceNoteCommitCheckpoint.clear()?.let { lease ->
+              composerState.cancelMediaAcquisition(lease.authorizationId)
+            }
+            voiceNoteRecorder.cancel()
+          },
+          onFinishVoiceNote = voiceNoteRecorder::finish,
+          dictationState = dictationState,
+          dictationEnabled =
+            !talkActive &&
+              pendingRunCount == 0 &&
+              !micCaptureActive &&
+              !sendInFlight &&
+              (voiceNoteState is VoiceNoteRecorderState.Idle || voiceNoteState is VoiceNoteRecorderState.Failure),
+          onToggleDictation = {
+            if (dictationActive) {
+              dictationController.finish()
+            } else {
+              scope.launch {
+                val ownerSnapshot = composerOwner
+                val transcript = dictationController.start()
+                // Recognition can finish after navigation. Only the composer that started
+                // dictation may receive its transcript; otherwise a late result crosses drafts.
+                if (transcript != null && viewModel.isCurrentChatComposerOwner(ownerSnapshot)) {
+                  inputDrafts[ownerSnapshot] =
+                    appendChatDictationTranscript(inputDrafts[ownerSnapshot], transcript)
+                }
+              }
+            }
+          },
+          talkActive = talkActive,
+          onToggleTalk = onToggleTalk,
+          onFixConnection = onOpenGatewaySettings,
+          onOpenProvidersModels = onOpenProvidersModels,
+          onCopyDiagnostics = {
+            copyGatewayDiagnosticsReport(
+              context = context,
+              screen = "chat composer",
+              gatewayAddress = gatewayAddress,
+              statusText = offlineStatus,
+            )
+          },
+          onAbort = viewModel::abortChat,
+          onSend = {
+            // Re-read the ViewModel so a stale click callback cannot beat StateFlow recomposition.
+            val currentShare = viewModel.chatShareDraftForOwner(composerOwner, mainSessionKey)
+            if (currentShare != null || composerOwner in sendStates) {
+              return@ChatComposer
+            }
+            val ownerSnapshot = composerOwner
+            if (!viewModel.isCurrentChatComposerOwner(ownerSnapshot)) return@ChatComposer
+            val result =
+              viewModel.beginChatComposerSend(
+                owner = ownerSnapshot,
+                thinking = thinkingLevel,
+              )
+            sendMessageTooLong = result == ChatComposerSendStartResult.MessageTooLong
+            sendCheckpointFull = result == ChatComposerSendStartResult.CheckpointFull
+          },
+        )
+      }
+    }
   }
 
   if (showModelPicker) {
@@ -1362,6 +1399,7 @@ private fun ChatMessageList(
   loadMediaArtifact: suspend (String, GatewayMediaKind, Boolean) -> GatewayLoadedMedia?,
   modifier: Modifier = Modifier,
   header: @Composable ((() -> Unit)?) -> Unit,
+  composer: @Composable ((() -> Unit)?) -> Unit,
 ) {
   val baseTimeline =
     remember(messages, activeRunCount, pendingToolCalls, subagentActivities, questions, streamingAssistantText, outboxItems, recoveryOutboxItems) {
@@ -1412,7 +1450,8 @@ private fun ChatMessageList(
   }
 
   // The header stays outside the weighted transcript so composer panels cannot collapse it.
-  header(readerScroll.jumpToLatest.takeIf { readerScroll.showJumpToLatest })
+  val onJumpToLatest = readerScroll.jumpToLatest.takeIf { readerScroll.showJumpToLatest }
+  header(onJumpToLatest)
   CompositionLocalProvider(LocalChatReaderNavigation provides readerScroll.onManualNavigation) {
     ChatMessageDisclosure(
       messages = messages,
@@ -1561,6 +1600,7 @@ private fun ChatMessageList(
       }
     }
   }
+  composer(onJumpToLatest)
 }
 
 internal data class ChatWorkingRun(
@@ -2396,8 +2436,20 @@ private fun PlanStepMarker(status: ChatPlanStepStatus) {
   }
 }
 
+private val chatDraftLineHeight = 22.sp
+
+@Composable
+private fun minimumChatInputHeight(): Dp =
+  maxOf(ClawTheme.spacing.touchTarget, with(LocalDensity.current) { chatDraftLineHeight.toDp() } + 12.dp) +
+    ClawTheme.spacing.touchTarget + 8.dp
+
 @Composable
 private fun ChatComposer(
+  compactHeight: Boolean,
+  detailsExpanded: Boolean,
+  onDetailsExpandedChange: (Boolean) -> Unit,
+  conversationHeader: @Composable (() -> Unit) -> Unit,
+  conversationStatus: @Composable () -> Unit,
   progressCard: ChatProgressCard?,
   value: String,
   onValueChange: (String) -> Unit,
@@ -2466,7 +2518,9 @@ private fun ChatComposer(
       modelUnavailable = modelUnavailableMessage != null,
     )
 
-  Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp).imePadding(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+  val attachedProgress = progressCard != null && voiceNoteState !is VoiceNoteRecorderState.Recording && voiceNoteState !is VoiceNoteRecorderState.Preparing
+  val auxiliaryContent: @Composable (Dp) -> Unit = { availableHeight ->
+    conversationStatus()
     if (shareImportNotice != null) {
       Row(
         modifier = Modifier.fillMaxWidth(),
@@ -2508,16 +2562,53 @@ private fun ChatComposer(
     if (shouldShowSlashCommandMenu(value)) {
       SlashCommandPanel(
         commands = slashCommands,
-        onSelect = { command -> onValueChange(slashCommandCompletion(command)) },
-        // Reserve the editor and run controls before measuring suggestions.
-        modifier = Modifier.weight(1f, fill = false),
+        onSelect = { command ->
+          onDetailsExpandedChange(false)
+          onValueChange(slashCommandCompletion(command))
+        },
+        modifier = Modifier.heightIn(max = minOf(240.dp, availableHeight)),
       )
     }
 
-    val attachedProgress = progressCard != null && voiceNoteState !is VoiceNoteRecorderState.Recording && voiceNoteState !is VoiceNoteRecorderState.Preparing
-    Column(verticalArrangement = Arrangement.spacedBy(if (attachedProgress) (-18).dp else 4.dp)) {
-      progressCard?.let { card -> ProgressCardPill(card, pendingRunCount > 0, Modifier.weight(1f, fill = false), attachedProgress) }
-      Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    VoiceNoteRecorderError(voiceNoteState)
+    ChatDictationError(dictationState)
+    if (recordVoiceNoteEnabled && (dictationState as? ChatDictationState.Failure)?.reason == ChatDictationFailure.Unavailable) {
+      TextButton(onClick = onStartVoiceNote) { Text(voiceNoteRecordLabel()) }
+    }
+    if (!healthOk && gatewayOffline) {
+      ChatOfflineNotice(
+        status = offlineStatus,
+        onFixConnection = onFixConnection,
+        onCopyDiagnostics = onCopyDiagnostics,
+      )
+    }
+    progressCard?.let { card ->
+      ProgressCardPill(card, pendingRunCount > 0, Modifier.fillMaxWidth().heightIn(max = availableHeight), attachedProgress && !detailsExpanded)
+    }
+  }
+
+  BoxWithConstraints(Modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
+    val inputHeightLimit = if (compactHeight) maxHeight else maxOf(minimumChatInputHeight(), maxHeight - ClawTheme.spacing.touchTarget)
+    Column(
+      modifier = if (detailsExpanded) Modifier.clearAndSetSemantics {} else Modifier,
+      verticalArrangement = Arrangement.spacedBy(if (attachedProgress && !compactHeight && !detailsExpanded) (-18).dp else 4.dp),
+    ) {
+      if (!compactHeight && !detailsExpanded) {
+        BoxWithConstraints(Modifier.weight(1f, fill = false)) {
+          val auxiliaryHeight = maxHeight
+          Column(
+            modifier = Modifier.verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+          ) {
+            auxiliaryContent(auxiliaryHeight)
+          }
+        }
+      }
+      Row(
+        modifier = Modifier.fillMaxWidth().heightIn(max = inputHeightLimit),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
         if (voiceNoteState is VoiceNoteRecorderState.Recording) {
           VoiceNoteRecordingControls(
             elapsedMs = voiceNoteElapsedMs,
@@ -2530,6 +2621,8 @@ private fun ChatComposer(
           VoiceNotePreparing(modifier = Modifier.weight(1f))
         } else {
           ChatInputPill(
+            inputEnabled = !detailsExpanded,
+            onOpenDetails = if (compactHeight) ({ onDetailsExpandedChange(true) }) else null,
             value = value,
             onValueChange = onValueChange,
             onPickImages = onPickImages,
@@ -2564,19 +2657,34 @@ private fun ChatComposer(
         }
       }
     }
-
-    VoiceNoteRecorderError(voiceNoteState)
-    ChatDictationError(dictationState)
-    if (recordVoiceNoteEnabled && (dictationState as? ChatDictationState.Failure)?.reason == ChatDictationFailure.Unavailable) {
-      TextButton(onClick = onStartVoiceNote) { Text(voiceNoteRecordLabel()) }
-    }
-
-    if (!healthOk && gatewayOffline) {
-      ChatOfflineNotice(
-        status = offlineStatus,
-        onFixConnection = onFixConnection,
-        onCopyDiagnostics = onCopyDiagnostics,
-      )
+    if (detailsExpanded) {
+      BackHandler { onDetailsExpandedChange(false) }
+      val detailsTitle = nativeString("Details")
+      // Stay inside the current pane and IME constraints; a dialog would escape them.
+      Surface(
+        modifier = Modifier.fillMaxSize().semantics { paneTitle = detailsTitle },
+        color = ClawTheme.colors.surface,
+        contentColor = ClawTheme.colors.text,
+      ) {
+        Column {
+          Row(Modifier.fillMaxWidth().padding(horizontal = 12.dp), verticalAlignment = Alignment.CenterVertically) {
+            Text(detailsTitle, style = ClawTheme.type.label, modifier = Modifier.weight(1f))
+            IconButton(onClick = { onDetailsExpandedChange(false) }, modifier = Modifier.size(ClawTheme.spacing.touchTarget)) {
+              Icon(Icons.Default.Close, contentDescription = nativeString("Close"))
+            }
+          }
+          BoxWithConstraints(Modifier.weight(1f)) {
+            val auxiliaryHeight = maxHeight
+            Column(
+              modifier = Modifier.verticalScroll(rememberScrollState()),
+              verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+              conversationHeader { onDetailsExpandedChange(false) }
+              auxiliaryContent(auxiliaryHeight)
+            }
+          }
+        }
+      }
     }
   }
 }
@@ -3399,6 +3507,8 @@ internal fun canSelectChatPermissionMode(
 
 @Composable
 private fun ChatInputPill(
+  inputEnabled: Boolean,
+  onOpenDetails: (() -> Unit)?,
   value: String,
   onValueChange: (String) -> Unit,
   onPickImages: () -> Unit,
@@ -3432,7 +3542,7 @@ private fun ChatInputPill(
 ) {
   val hardwareEnterHandler = remember { PhysicalChatSendKeyHandler() }
   var attachmentMenuExpanded by rememberSaveable { mutableStateOf(false) }
-  val draftStyle = ClawTheme.type.body.copy(fontSize = 16.sp, lineHeight = 22.sp)
+  val draftStyle = ClawTheme.type.body.copy(fontSize = 16.sp, lineHeight = chatDraftLineHeight)
 
   Surface(
     modifier = modifier.testTag("chat-composer-surface"),
@@ -3450,7 +3560,9 @@ private fun ChatInputPill(
       ) { textFieldValue, updateTextFieldValue ->
         BasicTextField(
           value = textFieldValue,
-          onValueChange = updateTextFieldValue,
+          enabled = inputEnabled,
+          // A pending IME callback must not edit the draft behind Details.
+          onValueChange = { if (inputEnabled) updateTextFieldValue(it) },
           textStyle = draftStyle.copy(color = ClawTheme.colors.text),
           cursorBrush = SolidColor(ClawTheme.colors.primary),
           minLines = 1,
@@ -3463,13 +3575,14 @@ private fun ChatInputPill(
               .heightIn(min = ClawTheme.spacing.touchTarget)
               .padding(start = 14.dp, end = 14.dp, top = 8.dp, bottom = 4.dp)
               .onPreInterceptKeyBeforeSoftKeyboard { event ->
-                hardwareEnterHandler.handle(
-                  event = event,
-                  sendEnabled = sendEnabled,
-                  textEmpty = textFieldValue.text.isEmpty(),
-                  compositionActive = textFieldValue.composition != null,
-                  onSend = onSend,
-                )
+                inputEnabled &&
+                  hardwareEnterHandler.handle(
+                    event = event,
+                    sendEnabled = sendEnabled,
+                    textEmpty = textFieldValue.text.isEmpty(),
+                    compositionActive = textFieldValue.composition != null,
+                    onSend = onSend,
+                  )
               },
           decorationBox = { innerTextField ->
             Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
@@ -3486,6 +3599,11 @@ private fun ChatInputPill(
         modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
       ) {
+        if (onOpenDetails != null) {
+          IconButton(onClick = onOpenDetails, modifier = Modifier.size(ClawTheme.spacing.touchTarget)) {
+            Icon(Icons.Default.MoreVert, contentDescription = nativeString("Details"))
+          }
+        }
         Box {
           Surface(onClick = { attachmentMenuExpanded = true }, modifier = Modifier.size(ClawTheme.spacing.touchTarget), shape = CircleShape, color = Color.Transparent, contentColor = ClawTheme.colors.textMuted) {
             Box(contentAlignment = Alignment.Center) {
@@ -3540,7 +3658,7 @@ private fun ChatInputPill(
           )
         }
         when (resolveChatComposerPrimaryAction(talkActive = talkActive, runActive = runActive, hasContent = hasContent)) {
-          ChatComposerPrimaryAction.Send -> SendButton(enabled = sendEnabled, onClick = onSend)
+          ChatComposerPrimaryAction.Send -> SendButton(enabled = inputEnabled && sendEnabled, onClick = onSend)
           ChatComposerPrimaryAction.StartTalk -> LiveTalkButton(active = false, onClick = onToggleTalk)
           ChatComposerPrimaryAction.Stop -> StopButton(onClick = onAbort)
           ChatComposerPrimaryAction.None -> Unit

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
@@ -19,6 +19,7 @@ import ai.openclaw.app.gateway.GatewayRegistryEntryKind
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.i18n.NativeStringResources
 import ai.openclaw.app.i18n.nativeString
+import ai.openclaw.app.ui.UnifiedChatShellScreen
 import ai.openclaw.app.ui.design.ClawDesignTheme
 import ai.openclaw.app.ui.design.ClawTheme
 import android.Manifest
@@ -27,17 +28,27 @@ import android.content.pm.PackageManager
 import android.provider.Settings
 import android.speech.SpeechRecognizer
 import android.view.KeyEvent
+import android.view.View
+import android.view.inputmethod.EditorInfo
 import android.view.inspector.WindowInspector
+import androidx.activity.compose.LocalActivity
 import androidx.activity.findViewTreeOnBackPressedDispatcherOwner
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
@@ -51,12 +62,14 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasSetTextAction
@@ -74,16 +87,23 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeDown
+import androidx.compose.ui.test.swipeUp
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
+import androidx.core.graphics.Insets
 import androidx.core.os.LocaleListCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
@@ -130,6 +150,8 @@ class ChatComposerLayoutTest {
   private val viewModelStore = ViewModelStore()
   private var originalAnimatorScale: String? = null
   private var renderedCanvasColor = Color.Unspecified
+  private lateinit var insetView: View
+  private var observedBottomInsets: Pair<Int, Int>? = null
 
   @Before
   fun setUp() {
@@ -198,6 +220,97 @@ class ChatComposerLayoutTest {
       composeRule.onNodeWithContentDescription(nativeString("Jump to latest")).assertDoesNotExist()
       val after = transcript.getUnclippedBoundsInRoot()
       assertEquals("Using Jump does not change the transcript viewport", before, after)
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun compactDetailsJumpsToRefreshedLatestAndRetiresTheAction() {
+    val height = mutableStateOf(720.dp)
+    val additionalMessages = MutableStateFlow<List<String>>(emptyList())
+    withReaderHistory(
+      assistantCount = 24,
+      viewportWidth = 720.dp,
+      viewportHeight = { height.value },
+      useChatShell = true,
+      additionalAssistantMessages = { additionalMessages.value },
+    ) { model ->
+      val editor = composeRule.onNode(hasSetTextAction())
+      editor.performTextReplacement("Reader draft")
+      val editorId = editor.fetchSemanticsNode().id
+      val transcript = readerTranscript()
+      val readerId = transcript.fetchSemanticsNode().id
+      transcript.performTouchInput { swipeDown() }
+      composeRule.waitForIdle()
+      assertTrue(
+        "Manual reading must move away from latest before opening Details",
+        transcript.fetchSemanticsNode().config[SemanticsProperties.VerticalScrollAxisRange].value() > 0f,
+      )
+      assertReaderHeaderControl("Jump to latest")
+      applyChatImeInsets()
+      composeRule.runOnIdle { height.value = 440.dp }
+      composeRule.onNodeWithContentDescription(nativeString("Details")).assertIsDisplayed().performClick()
+      readerHeaderControl("Jump to latest").assertIsDisplayed().assertIsEnabled()
+
+      val detailsPane = SemanticsMatcher.expectValue(SemanticsProperties.PaneTitle, nativeString("Details"))
+      val compactViewport = composeRule.onNodeWithTag("chat-viewport").getUnclippedBoundsInRoot()
+      composeRule.runOnIdle { height.value = 720.dp }
+      composeRule.waitForIdle()
+      val grownViewport = composeRule.onNodeWithTag("chat-viewport").getUnclippedBoundsInRoot()
+      assertTrue(
+        "The same viewport must grow while Details remains open",
+        grownViewport.bottom - grownViewport.top > compactViewport.bottom - compactViewport.top,
+      )
+      composeRule.onNode(detailsPane).assertIsDisplayed()
+      for (label in listOf("Show Sidebar", "Chat actions", "Jump to latest")) {
+        val control = hasContentDescription(nativeString(label)) and hasClickAction() and hasAnyAncestor(hasTestTag("chat-viewport"))
+        composeRule.onAllNodes(control).assertCountEquals(1)
+        composeRule
+          .onNode(control)
+          .assertIsDisplayed()
+          .assertIsEnabled()
+          .assert(hasAnyAncestor(detailsPane))
+      }
+      assertEquals("Growth must retain the same reader", readerId, transcript.fetchSemanticsNode().id)
+
+      val newest = "Reader newest after refresh"
+      composeRule.runOnIdle { additionalMessages.value = listOf(newest) }
+      readerHeaderControl("Chat actions").performClick()
+      composeRule.onNode(hasText(nativeString("Refresh chat")) and hasClickAction()).performClick()
+      composeRule.waitUntil {
+        composeRule.runOnIdle {
+          !model.chatHistoryLoading.value &&
+            model.chatMessages.value
+              .last()
+              .content
+              .any { it.text == newest }
+        }
+      }
+      composeRule.onNode(detailsPane).assertIsDisplayed()
+      composeRule.onNodeWithContentDescription(nativeString("Close")).assertIsDisplayed()
+      readerHeaderControl("Jump to latest").assertIsDisplayed().performClick()
+      composeRule.waitForIdle()
+
+      composeRule.onNodeWithText(nativeString("Details")).assertDoesNotExist()
+      editor.assertIsEnabled().assertTextEquals("Reader draft")
+      assertEquals("Jump must retain the same editor", editorId, editor.fetchSemanticsNode().id)
+      assertEquals("Refresh and Jump must retain the same reader", readerId, transcript.fetchSemanticsNode().id)
+      for (label in listOf("Show Sidebar", "Chat actions")) {
+        val control = hasContentDescription(nativeString(label)) and hasClickAction() and hasAnyAncestor(hasTestTag("chat-viewport"))
+        composeRule.onAllNodes(control).assertCountEquals(1)
+        assertReaderHeaderControl(label)
+      }
+      assertReaderMessageVisible("OpenClaw", newest)
+      assertEquals(
+        "Jump reaches the refreshed latest edge",
+        0f,
+        transcript.fetchSemanticsNode().config[SemanticsProperties.VerticalScrollAxisRange].value(),
+        0f,
+      )
+      composeRule.runOnIdle { height.value = 440.dp }
+      composeRule.onNodeWithContentDescription(nativeString("Details")).performClick()
+      readerHeaderControl("Jump to latest").assertDoesNotExist()
+      composeRule.onNodeWithContentDescription(nativeString("Close")).performClick()
     }
   }
 
@@ -408,6 +521,45 @@ class ChatComposerLayoutTest {
   }
 
   @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun compactDetailsSlashSelectionClosesAndCompletesTheSameEditorWithoutSending() {
+    val height = mutableStateOf(720.dp)
+    val requests = ConcurrentLinkedQueue<String>()
+    withReaderHistory(
+      assistantCount = 1,
+      viewportWidth = 720.dp,
+      viewportHeight = { height.value },
+      useChatShell = true,
+      onRequest = { requests.add(it) },
+    ) { model ->
+      val editor = composeRule.onNode(hasSetTextAction())
+      editor.performClick().performTextReplacement("/")
+      val editorId = editor.fetchSemanticsNode().id
+      val owner = model.captureChatShareOwner()
+      applyChatImeInsets()
+      composeRule.runOnIdle { height.value = 360.dp }
+      composeRule.onNodeWithContentDescription(nativeString("Details")).assertIsDisplayed().performClick()
+      val suggestion = composeRule.onNodeWithText("/loop").performScrollTo()
+      composeRule
+        .onNode(
+          SemanticsMatcher.keyIsDefined(SemanticsProperties.VerticalScrollAxisRange) and
+            hasAnyDescendant(hasContentDescription(nativeString("Chat actions"))) and hasAnyDescendant(hasText("/loop")),
+        ).performTouchInput { swipeUp() }
+      suggestion.assertIsDisplayed().performClick()
+
+      composeRule.onNodeWithText(nativeString("Details")).assertDoesNotExist()
+      editor.assertIsDisplayed().assertIsEnabled().assertTextEquals("/loop ")
+      assertEquals("Completion must retain the same editor", editorId, editor.fetchSemanticsNode().id)
+      composeRule.onNodeWithContentDescription(nativeString("Send")).assertIsDisplayed().assertIsEnabled()
+      composeRule.runOnIdle {
+        assertEquals("/loop ", model.chatComposerState.textDrafts[owner])
+        assertFalse("Selecting a command must not send it", "chat.send" in requests)
+        assertFalse("Selecting a command must not begin send admission", owner in model.chatComposerState.sendStates.value)
+      }
+    }
+  }
+
+  @Test
   fun activeRunKeepsNewTextSendableAndRestoresStopForAnEmptyDraft() {
     showChat()
     assertTrue("The fixture must have an active run", controller.pendingRunCount.value > 0)
@@ -580,6 +732,296 @@ class ChatComposerLayoutTest {
     }
     assertEquals("The seventh line must scroll inside the six-line editor", heights[5], heights[6])
     assertComposerControlsVisible(primaryAction = "Send")
+  }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun shortImeViewportKeepsCompleteDraftLineAndActionsAcrossResize() {
+    val width = mutableStateOf(720.dp)
+    val height = mutableStateOf(720.dp)
+    val fontScale = mutableStateOf(1f)
+    showChat(
+      viewportHeight = { height.value },
+      fontScale = { fontScale.value },
+      useChatShell = true,
+      currentViewportWidth = { width.value },
+    )
+    val editor = composeRule.onNode(hasSetTextAction())
+    editor.performClick()
+    editor.performTextReplacement("Short viewport draft")
+    val editorId = editor.fetchSemanticsNode().id
+    applyChatImeInsets()
+
+    for (viewportWidth in listOf(720.dp, 320.dp, 360.dp, 720.dp)) {
+      composeRule.runOnIdle { width.value = viewportWidth }
+      for (scale in listOf(1f, 1.5f, 2f)) {
+        composeRule.runOnIdle { fontScale.value = scale }
+        for (viewportHeight in listOf(720.dp, 460.dp, 360.dp, 720.dp)) {
+          composeRule.runOnIdle { height.value = viewportHeight }
+          composeRule.waitForIdle()
+          editor.assertTextEquals("Short viewport draft")
+          assertEquals("Resizing must retain the same editor", editorId, editor.fetchSemanticsNode().id)
+          assertCompleteComposerLineAboveIme()
+        }
+      }
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun shortImeComposerKeepsMultilineSelectionAndAuxiliaryRecoveryThenSends() {
+    prefs.gatewayRegistry.upsert(
+      GatewayRegistryEntry(
+        stableId = AndroidScreenshotFixture.gatewayId,
+        kind = GatewayRegistryEntryKind.MANUAL,
+        name = "Test gateway",
+      ),
+    )
+    prefs.gatewayRegistry.setActive(AndroidScreenshotFixture.gatewayId)
+    val height = mutableStateOf(720.dp)
+    val viewModel = showChat(viewportWidth = 720.dp, viewportHeight = { height.value }, fontScale = { 1.5f }, useChatShell = true)
+    val owner = viewModel.captureChatShareOwner()
+    val sent = ConcurrentLinkedQueue<JsonObject>()
+    val requestField = ChatController::class.java.getDeclaredField("requestGatewayForGateway").apply { isAccessible = true }
+
+    @Suppress("UNCHECKED_CAST")
+    val originalRequest = requestField.get(controller) as suspend (String, String, String?) -> String
+    val request: suspend (String, String, String?) -> String = { gatewayId, method, params ->
+      if (method == "chat.send") {
+        val payload = Json.parseToJsonElement(requireNotNull(params)).jsonObject
+        sent.add(payload)
+        buildJsonObject {
+          put("runId", payload.getValue("idempotencyKey"))
+          put("status", JsonPrimitive("started"))
+        }.toString()
+      } else {
+        originalRequest(gatewayId, method, params)
+      }
+    }
+    try {
+      requestField.set(controller, request)
+      composeRule.runOnIdle {
+        viewModel.chatComposerState.addAttachments(
+          owner,
+          listOf(PendingAttachment(id = "draft-note", fileName = "draft-note.txt", mimeType = "text/plain", base64 = "SGVsbG8=")),
+        )
+        viewModel.chatComposerState.reportAttachmentOmission(owner, 1)
+      }
+      val steps = List(20) { "Compact viewport progress step ${it + 1}" }
+      showProgressCard(steps)
+      val editor = composeRule.onNode(hasSetTextAction())
+      val draft = "Editable first line\nSecond line\nThird line\nFourth line\nFifth line\nSixth line"
+      editor.performClick()
+      editor.performTextReplacement(draft)
+      editor.performSemanticsAction(SemanticsActions.SetSelection) { action -> assertTrue(action(4, 4, false)) }
+      val editorId = editor.fetchSemanticsNode().id
+      applyChatImeInsets()
+      composeRule.runOnIdle { height.value = 360.dp }
+      composeRule.waitForIdle()
+      editor.assertTextEquals(draft)
+      assertEquals(TextRange(4), editor.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange])
+      assertCompleteComposerLineAboveIme()
+      editor.performTextInput(" inserted")
+      val edited = draft.substring(0, 4) + " inserted" + draft.substring(4)
+      editor.assertTextEquals(edited)
+      assertCompleteComposerLineAboveIme()
+
+      composeRule.onNodeWithContentDescription(nativeString("Details")).assertIsDisplayed().performClick()
+      for (viewportHeight in listOf(720.dp, 360.dp)) {
+        composeRule.runOnIdle { height.value = viewportHeight }
+        composeRule.waitForIdle()
+        composeRule.onAllNodesWithContentDescription(nativeString("Remove attachment")).assertCountEquals(1)
+        val details =
+          composeRule
+            .onNode(SemanticsMatcher.expectValue(SemanticsProperties.PaneTitle, nativeString("Details")))
+            .assert(hasAnyAncestor(hasTestTag("chat-viewport")))
+            .getUnclippedBoundsInRoot()
+        val viewport = composeRule.onNodeWithTag("chat-viewport").getUnclippedBoundsInRoot()
+        assertTrue(
+          "Details must stay inside the current pane above the IME: $details within $viewport",
+          details.left >= viewport.left && details.right <= viewport.right &&
+            details.top >= viewport.top && details.bottom <= viewport.bottom - 220.dp,
+        )
+        composeRule.onNode(isDialog()).assertDoesNotExist()
+        val close = composeRule.onNodeWithContentDescription(nativeString("Close")).assertIsDisplayed().getUnclippedBoundsInRoot()
+        assertTrue("Close must remain a complete action target", close.bottom - close.top >= 48.dp && close.right - close.left >= 48.dp)
+      }
+      composeRule.onNodeWithContentDescription(nativeString("Dismiss shared-image warning")).performScrollTo().performClick()
+      composeRule.onNodeWithContentDescription(nativeString("Dismiss shared-image warning")).assertDoesNotExist()
+      composeRule.onNodeWithContentDescription(nativeString("Remove attachment")).performScrollTo().performClick()
+      composeRule.onNodeWithText("draft-note.txt").assertDoesNotExist()
+      composeRule.onNodeWithContentDescription(nativeString("Expand progress card")).performScrollTo().performClick()
+      composeRule.onNodeWithTag("chat-progress-card").performScrollTo()
+      composeRule.onNodeWithText(steps.last()).performScrollTo().assertIsDisplayed()
+      composeRule.onNodeWithContentDescription(nativeString("Close")).assertIsDisplayed().performClick()
+      editor.assertTextEquals(edited)
+      composeRule.onNodeWithContentDescription(nativeString("Details")).performClick()
+      composeRule.runOnIdle {
+        checkNotNull(insetView.findViewTreeOnBackPressedDispatcherOwner()).onBackPressedDispatcher.onBackPressed()
+      }
+      composeRule.onNodeWithText(nativeString("Details")).assertDoesNotExist()
+      editor.assertTextEquals(edited)
+      assertEquals("Disclosing auxiliary content must not replace the editor", editorId, editor.fetchSemanticsNode().id)
+
+      for (viewportHeight in listOf(720.dp, 360.dp)) {
+        composeRule.runOnIdle { height.value = viewportHeight }
+        composeRule.waitForIdle()
+        editor.assertTextEquals(edited)
+        assertEquals(TextRange(13), editor.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange])
+        assertCompleteComposerLineAboveIme()
+      }
+      assertTrue("The edited draft must still have a routable owner", controller.isCurrentComposerOwner(owner))
+      composeRule.onNodeWithContentDescription(nativeString("Send")).assertIsEnabled().performClick()
+      composeRule.waitUntil {
+        composeRule.runOnIdle { sent.size == 1 }
+      }
+      assertEquals(JsonPrimitive(edited), sent.single()["message"])
+      editor.assert(SemanticsMatcher.expectValue(SemanticsProperties.EditableText, AnnotatedString("")))
+    } finally {
+      requestField.set(controller, originalRequest)
+    }
+  }
+
+  private fun applyChatImeInsets() {
+    val keyboard = with(composeRule.density) { 220.dp.roundToPx() }
+    val navigation = with(composeRule.density) { 24.dp.roundToPx() }
+    composeRule.runOnIdle {
+      ViewCompat.dispatchApplyWindowInsets(
+        insetView,
+        WindowInsetsCompat
+          .Builder()
+          .setInsets(WindowInsetsCompat.Type.navigationBars(), Insets.of(0, 0, 0, navigation))
+          .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, keyboard))
+          .setVisible(WindowInsetsCompat.Type.ime(), true)
+          .build(),
+      )
+    }
+    composeRule.waitForIdle()
+    assertEquals("The real shell must receive the IME insets", keyboard to keyboard, observedBottomInsets)
+  }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun detailsBlocksPhysicalTypingUntilClosed() =
+    assertDetailsBlocksInput { view ->
+      { dispatchHardwareKey(view, KeyEvent.KEYCODE_X) }
+    }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun detailsBlocksPreImeEnterUntilClosed() =
+    assertDetailsBlocksInput { view ->
+      { dispatchHardwareKey(view, KeyEvent.KEYCODE_ENTER) }
+    }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun detailsBlocksPendingSoftwareImeCommitUntilClosed() =
+    assertDetailsBlocksInput { view ->
+      val connection = checkNotNull(view.onCreateInputConnection(EditorInfo()))
+      val commit: () -> Unit = { connection.commitText("hidden IME input", 1) }
+      commit
+    }
+
+  private fun dispatchHardwareKey(
+    view: View,
+    keyCode: Int,
+  ) {
+    for (action in listOf(KeyEvent.ACTION_DOWN, KeyEvent.ACTION_UP)) {
+      val event = KeyEvent(action, keyCode)
+      if (!view.dispatchKeyEventPreIme(event)) view.dispatchKeyEvent(event)
+    }
+  }
+
+  private fun assertDetailsBlocksInput(prepareInput: (View) -> () -> Unit) {
+    prefs.gatewayRegistry.upsert(
+      GatewayRegistryEntry(stableId = AndroidScreenshotFixture.gatewayId, kind = GatewayRegistryEntryKind.MANUAL, name = "Test gateway"),
+    )
+    prefs.gatewayRegistry.setActive(AndroidScreenshotFixture.gatewayId)
+    val height = mutableStateOf(720.dp)
+    val viewModel = showChat(viewportWidth = 720.dp, viewportHeight = { height.value }, useChatShell = true)
+    val owner = viewModel.captureChatShareOwner()
+    val sent = ConcurrentLinkedQueue<JsonObject>()
+    val requestField = ChatController::class.java.getDeclaredField("requestGatewayForGateway").apply { isAccessible = true }
+
+    @Suppress("UNCHECKED_CAST")
+    val originalRequest = requestField.get(controller) as suspend (String, String, String?) -> String
+    val request: suspend (String, String, String?) -> String = { gatewayId, method, params ->
+      if (method == "chat.send") {
+        val payload = Json.parseToJsonElement(requireNotNull(params)).jsonObject
+        sent.add(payload)
+        buildJsonObject {
+          put("runId", payload.getValue("idempotencyKey"))
+          put("status", JsonPrimitive("started"))
+        }.toString()
+      } else {
+        originalRequest(gatewayId, method, params)
+      }
+    }
+    try {
+      requestField.set(controller, request)
+      val editor = composeRule.onNode(hasSetTextAction())
+      val draft = "Visible draft"
+      editor.performClick().performTextReplacement(draft)
+      assertEquals(TextRange(draft.length), editor.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange])
+      val editorId = editor.fetchSemanticsNode().id
+      applyChatImeInsets()
+      for (viewportHeight in listOf(360.dp, 720.dp, 360.dp)) {
+        composeRule.runOnIdle { height.value = viewportHeight }
+        editor.assertIsFocused().assertTextEquals(draft)
+      }
+      val attemptInput = composeRule.runOnIdle { prepareInput(insetView) }
+      composeRule.onNodeWithContentDescription(nativeString("Details")).performClick()
+      composeRule.runOnIdle { attemptInput() }
+      composeRule.waitForIdle()
+      composeRule.runOnIdle {
+        assertEquals("Details must not permit hidden draft edits", draft, viewModel.chatComposerState.textDrafts[owner])
+        assertTrue("Details must not send the hidden draft", sent.isEmpty())
+        assertFalse("Details must not begin send admission", owner in viewModel.chatComposerState.sendStates.value)
+      }
+      composeRule.onNodeWithContentDescription(nativeString("Close")).assertIsDisplayed().performClick()
+      editor.assertTextEquals(draft)
+      assertEquals("Details must retain the same editor", editorId, editor.fetchSemanticsNode().id)
+      assertEquals(TextRange(draft.length), editor.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange])
+      editor.performClick()
+      composeRule.runOnIdle { dispatchHardwareKey(insetView, KeyEvent.KEYCODE_X) }
+      editor.assertTextEquals(draft + "x")
+      composeRule.runOnIdle {
+        checkNotNull(insetView.onCreateInputConnection(EditorInfo())).commitText(" visible IME input", 1)
+      }
+      val edited = draft + "x visible IME input"
+      editor.assertTextEquals(edited)
+      composeRule.runOnIdle { dispatchHardwareKey(insetView, KeyEvent.KEYCODE_ENTER) }
+      composeRule.waitUntil { composeRule.runOnIdle { sent.isNotEmpty() } }
+      assertEquals(listOf(JsonPrimitive(edited)), sent.map { it["message"] })
+      editor.assert(SemanticsMatcher.expectValue(SemanticsProperties.EditableText, AnnotatedString("")))
+    } finally {
+      requestField.set(controller, originalRequest)
+    }
+  }
+
+  private fun assertCompleteComposerLineAboveIme() {
+    val editor = composeRule.onNode(hasSetTextAction())
+    val layouts = mutableListOf<TextLayoutResult>()
+    editor.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { action -> assertTrue(action(layouts)) }
+    val layout = layouts.single()
+    val lineHeight = with(composeRule.density) { (layout.getLineBottom(0) - layout.getLineTop(0)).toDp() }
+    val bounds = editor.getUnclippedBoundsInRoot()
+    assertTrue(
+      "A complete editable line must fit after IME/resize: $bounds, line=$lineHeight",
+      bounds.bottom - bounds.top >= lineHeight,
+    )
+    assertComposerControlsVisible(primaryAction = "Send")
+    val visibleBottom = composeRule.onNodeWithTag("chat-viewport").getUnclippedBoundsInRoot().bottom - 220.dp
+    assertTrue("The complete line must remain above the real IME", bounds.bottom <= visibleBottom)
+    val send = composeRule.onNodeWithContentDescription(nativeString("Send")).getUnclippedBoundsInRoot()
+    assertTrue("The complete action target must remain above the real IME", send.bottom <= visibleBottom)
+    val node = editor.fetchSemanticsNode()
+    val selection = node.config[SemanticsProperties.TextSelectionRange]
+    val caret = layout.getCursorRect(selection.end).translate(node.positionInRoot)
+    val caretTop = with(composeRule.density) { caret.top.toDp() }
+    val caretBottom = with(composeRule.density) { caret.bottom.toDp() }
+    assertTrue("The whole caret must be visible inside the editor: $caret within $bounds", caretTop >= bounds.top && caretBottom <= bounds.bottom)
   }
 
   @Test
@@ -1548,17 +1990,21 @@ class ChatComposerLayoutTest {
     viewportWidth: Dp = 360.dp,
     fontScale: () -> Float = { 1f },
     onOpenSidebar: () -> Unit = {},
-    assertions: () -> Unit,
+    useChatShell: Boolean = false,
+    additionalAssistantMessages: () -> List<String> = { emptyList() },
+    onRequest: (String) -> Unit = {},
+    assertions: (MainViewModel) -> Unit,
   ) {
     val sessionKey = "agent:main:reader-history"
     val texts = listOf("Reader prompt") + List(assistantCount, assistantText)
-    val history =
+
+    fun history() =
       buildJsonObject {
         put("sessionId", JsonPrimitive("reader-history"))
         put(
           "messages",
           buildJsonArray {
-            texts.forEachIndexed { index, text ->
+            (texts + additionalAssistantMessages()).forEachIndexed { index, text ->
               add(
                 buildJsonObject {
                   put("role", JsonPrimitive(if (index == 0) "user" else "assistant"))
@@ -1574,8 +2020,9 @@ class ChatComposerLayoutTest {
     @Suppress("UNCHECKED_CAST")
     val originalRequest = requestField.get(controller) as suspend (String, String, String?) -> String
     val request: suspend (String, String, String?) -> String = { gatewayId, method, params ->
+      onRequest(method)
       when (method) {
-        "chat.history" -> history
+        "chat.history" -> history()
         "question.list" -> """{"questions":[]}"""
         "progressCard.get" -> """{"card":null}"""
         else -> originalRequest(gatewayId, method, params)
@@ -1592,6 +2039,7 @@ class ChatComposerLayoutTest {
           fontScale = fontScale,
           expectedMessageCount = texts.size,
           onOpenSidebar = onOpenSidebar,
+          useChatShell = useChatShell,
         )
       composeRule.waitUntil(timeoutMillis = 5_000) {
         composeRule.runOnIdle {
@@ -1605,7 +2053,7 @@ class ChatComposerLayoutTest {
         }
       }
       composeRule.waitForIdle()
-      assertions()
+      assertions(model)
     } finally {
       requestField.set(controller, originalRequest)
     }
@@ -1700,31 +2148,56 @@ class ChatComposerLayoutTest {
     talkActive: Boolean = false,
     expectedMessageCount: Int? = null,
     onOpenSidebar: () -> Unit = {},
+    useChatShell: Boolean = false,
+    currentViewportWidth: () -> Dp = { viewportWidth },
   ): MainViewModel {
     val viewModel = MainViewModel(app, prefs, SavedStateHandle())
     viewModelStore.put("chat", viewModel)
     viewModel.enterScreenshotFixtureMode(AndroidScreenshotScene.Chat)
     composeRule.setContent {
+      if (useChatShell) {
+        val activity = requireNotNull(LocalActivity.current)
+        val view = LocalView.current
+        val density = LocalDensity.current
+        val imeBottom = WindowInsets.ime.getBottom(density)
+        val safeBottom = WindowInsets.safeDrawing.getBottom(density)
+        LaunchedEffect(activity) { WindowCompat.setDecorFitsSystemWindows(activity.window, false) }
+        SideEffect {
+          insetView = view
+          observedBottomInsets = imeBottom to safeBottom
+        }
+      }
       DeviceConfigurationOverride(DeviceConfigurationOverride.FontScale(fontScale())) {
         ClawDesignTheme {
           renderedCanvasColor = ClawTheme.colors.canvas
           // The default viewport models a portrait phone after its IME opens.
           Box(
             Modifier
-              .size(width = viewportWidth, height = viewportHeight())
+              .size(width = currentViewportWidth(), height = viewportHeight())
               .background(ClawTheme.colors.canvas)
               .clipToBounds()
               .testTag("chat-viewport"),
           ) {
-            ChatScreen(
-              viewModel = viewModel,
-              talkActive = talkActive,
-              showSidebarButton = true,
-              onOpenSidebar = onOpenSidebar,
-              onToggleTalk = {},
-              onOpenDashboard = {},
-              onOpenGatewaySettings = {},
-            )
+            if (useChatShell) {
+              UnifiedChatShellScreen(
+                viewModel = viewModel,
+                showSidebarButton = true,
+                onOpenSidebar = onOpenSidebar,
+                onOpenDashboard = {},
+                onOpenGatewaySettings = {},
+                onOpenProvidersModels = {},
+              )
+            } else {
+              ChatScreen(
+                viewModel = viewModel,
+                talkActive = talkActive,
+                showSidebarButton = true,
+                onOpenSidebar = onOpenSidebar,
+                onToggleTalk = {},
+                onOpenDashboard = {},
+                onOpenGatewaySettings = {},
+              )
+            }
           }
         }
       }
@@ -1777,6 +2250,9 @@ class ChatComposerLayoutTest {
             ),
         )
     val controlBounds = controls.map { it.getUnclippedBoundsInRoot() }.toMutableList()
+    if (composeRule.onAllNodesWithContentDescription(nativeString("Details")).fetchSemanticsNodes().isNotEmpty()) {
+      controlBounds += composeRule.onNodeWithContentDescription(nativeString("Details")).assertIsDisplayed().getUnclippedBoundsInRoot()
+    }
     val primary = controlBounds.first()
     val dictation =
       composeRule.onNode(


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/140708

## What Problem This Solves

Fixes an issue where Android users cannot see or edit their complete draft when
the keyboard leaves a short window, including a folded cover display in
landscape. Header, status and auxiliary controls can consume the editor's space.

## Why This Change Was Made

Reserve the complete input and primary actions before auxiliary content. In a
short viewport, move the conversation header and auxiliary controls into a
scrollable, pane-contained Details view. Keep one editor and reader owner, the
current Jump action, and one Details state through resizing.

Details remains open when space grows. Its covered editor rejects pending IME
edits and hardware send; Close, Back, navigation and slash completion preserve
their explicit behavior. No recorder, draft-store, manifest, dependency or
configuration changes.

## User Impact

The draft and Send controls remain usable above the keyboard in short windows.
Users can still reach conversation actions, status, attachments and command
suggestions through Details without discarding their draft or reading position.
Ordinary-height windows retain inline controls.

## Evidence

- 55 focused composer and hardware-input tests pass on the final source.
  Coverage includes real editor/reader identity, selection and composition,
  continued typing, font-scaled layout, native input callbacks behind Details,
  current Jump after refresh, slash completion and one header after resizing.
- Original-red witnesses include the clipped-input boundary and a retained
  Details view producing two Sidebar actions after growth; the repaired
  candidate passes without weakening those assertions.
- Ordinary `lintPlayDebug`, actual two-path `check:changed`, genuine signed
  debug APK assembly and independent P2 review pass. The re-anchor onto the
  merged hinge-safe foundation preserves the complete binary diff.
- API 36 fold emulator with real Gboard: flat -> folded cover portrait ->
  cover landscape preserves the draft and accepts further typing without
  refocusing. The full draft line, caret, Send and Details remain visible.
- Native Details stays open across growth back to the full display with one
  toolbar. Input sent while the editor is covered does not alter the draft.
  Close restores the draft; explicitly focusing it again accepts further input.
- Maintainer visual and redaction inspection is complete for both captures.
  Anonymous fetches after PR attachment returned HTTP 200 with SHA-256 matching
  the inspected originals. The review environment's retrieval failure does
  not indicate missing or private evidence.

| Before: draft clipped above Gboard | After: complete input and actions remain visible |
| --- | --- |
| ![Before: short cover landscape clips the draft above the keyboard](https://github.com/user-attachments/assets/f1ec2bbd-c807-4574-9fe3-7c1ff41c6f2f) | ![After: continued draft typing in cover landscape with Gboard visible](https://github.com/user-attachments/assets/22f5f6e4-f12a-4cd5-bae7-a89936199b19) |

Captures use synthetic screenshot-mode content, not a live Gateway. No message
was sent and no recording or media capture was started. Emulator proof is not
physical-device certification. Native selection/composition ranges and Details
Back were not separately exercised in this device run; focused tests cover
those boundaries. Arbitrarily tiny viewports cannot fit complete controls.
This is not the separate tabletop two-pane or own-window menu/sheet repair.
Exact-head hosted CI remains required before landing.
