### PR TITLE
refactor(config): share fill-missing migration primitive

### DIFF
--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -143,6 +143,18 @@ including empty results without range metadata. Only an explicit
 missing files; registered-input normalization remains available through the
 next Plugin SDK major.
 
+### Config record migrations
+
+Use `mergeMissing(canonical, legacy)` from
+`openclaw/plugin-sdk/runtime-doctor-migrations` to fill undefined fields without
+replacing authored values. It fills existing nested records in place and keeps
+authored arrays, nulls, and scalars. Missing values are assigned by reference;
+callers own any cloning needed to isolate the migration from its input.
+
+The helper skips undefined source values and `__proto__`, `prototype`, and
+`constructor` keys at each level it merges. It does not recursively sanitize
+newly assigned subtrees.
+
 ### Plugin state migration declarations
 
 Bundled plugins should list every migration under

--- a/extensions/amazon-bedrock/config-compat.ts
+++ b/extensions/amazon-bedrock/config-compat.ts
@@ -2,17 +2,13 @@
  * Legacy config migration for Amazon Bedrock discovery settings. It moves
  * old `models.bedrockDiscovery` config into plugin-local config shape.
  */
+import { mergeMissing } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 type JsonRecord = Record<string, unknown>;
 
 const LEGACY_PATH = "models.bedrockDiscovery";
 const TARGET_PATH = "plugins.entries.amazon-bedrock.config.discovery";
-const BLOCKED_OBJECT_KEYS = new Set(["__proto__", "prototype", "constructor"]);
-
-function isBlockedObjectKey(key: string): boolean {
-  return BLOCKED_OBJECT_KEYS.has(key);
-}
 
 function getRecord(value: unknown): JsonRecord | null {
   return isRecord(value) ? value : null;
@@ -26,22 +22,6 @@ function ensureRecord(root: JsonRecord, key: string): JsonRecord {
   const next: JsonRecord = {};
   root[key] = next;
   return next;
-}
-
-function mergeMissing(target: JsonRecord, source: JsonRecord): void {
-  for (const [key, value] of Object.entries(source)) {
-    if (value === undefined || isBlockedObjectKey(key)) {
-      continue;
-    }
-    const existing = target[key];
-    if (existing === undefined) {
-      target[key] = value;
-      continue;
-    }
-    if (isRecord(existing) && isRecord(value)) {
-      mergeMissing(existing, value);
-    }
-  }
 }
 
 function cloneRecord<T extends JsonRecord>(value: T | undefined): T {

--- a/extensions/elevenlabs/config-compat.ts
+++ b/extensions/elevenlabs/config-compat.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { mergeMissing } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 const ELEVENLABS_API_KEY_ENV = "ELEVENLABS_API_KEY";
@@ -40,22 +41,6 @@ function ensureRecord(root: JsonRecord, key: string): JsonRecord {
 
 function isBlockedObjectKey(key: string): boolean {
   return key === "__proto__" || key === "prototype" || key === "constructor";
-}
-
-function mergeMissing(target: JsonRecord, source: JsonRecord): void {
-  for (const [key, value] of Object.entries(source)) {
-    if (value === undefined || isBlockedObjectKey(key)) {
-      continue;
-    }
-    const existing = target[key];
-    if (existing === undefined) {
-      target[key] = value;
-      continue;
-    }
-    if (isRecord(existing) && isRecord(value)) {
-      mergeMissing(existing, value);
-    }
-  }
 }
 
 function hasLegacyTalkFields(value: unknown): value is JsonRecord {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
@@ -15,10 +15,10 @@ import {
   defineLegacyConfigMigration,
   ensureRecord,
   getRecord,
-  mergeMissing,
   type LegacyConfigMigrationSpec,
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
+import { mergeMissing } from "../../../config/merge-missing.js";
 import { isBlockedObjectKey } from "../../../infra/prototype-keys.js";
 import { visitAgentConfigScopes, visitAgentEntries } from "./legacy-config-record-shared.js";
 import {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.providers.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.providers.ts
@@ -1,10 +1,10 @@
 // Legacy provider runtime config migrations for plugin ids and bundled discovery policy.
 import {
   defineLegacyConfigMigration,
-  mergeMissing,
   type LegacyConfigMigrationSpec,
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
+import { mergeMissing } from "../../../config/merge-missing.js";
 import { isRecord } from "./legacy-config-record-shared.js";
 import {
   migrateLegacyXSearchConfig,

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.retired-memory-qmd.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.retired-memory-qmd.ts
@@ -2,10 +2,10 @@ import {
   defineLegacyConfigMigration,
   ensureRecord,
   getRecord,
-  mergeMissing,
   type LegacyConfigMigrationSpec,
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
+import { mergeMissing } from "../../../config/merge-missing.js";
 import { normalizeConfiguredMemoryExtraPaths } from "../../../memory-host-sdk/host/config-utils.js";
 import type { MemoryExtraPath } from "../../../memory-host-sdk/host/types.js";
 import { deleteRetiredPath, visitAgentConfigScopes } from "./legacy-config-record-shared.js";

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.ts
@@ -3,10 +3,10 @@ import {
   defineLegacyConfigMigration,
   ensureRecord,
   getRecord,
-  mergeMissing,
   type LegacyConfigMigrationSpec,
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
+import { mergeMissing } from "../../../config/merge-missing.js";
 import {
   hasConfigTrancheLegacyKeys,
   migrateConfigTranche,

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.tts.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.tts.ts
@@ -2,10 +2,10 @@
 import {
   defineLegacyConfigMigration,
   getRecord,
-  mergeMissing,
   type LegacyConfigMigrationSpec,
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
+import { mergeMissing } from "../../../config/merge-missing.js";
 import { isBlockedObjectKey } from "../../../infra/prototype-keys.js";
 import { visitAgentEntries } from "./legacy-config-record-shared.js";
 

--- a/src/commands/doctor/shared/legacy-web-tools-migrate.ts
+++ b/src/commands/doctor/shared/legacy-web-tools-migrate.ts
@@ -1,5 +1,6 @@
 // Legacy web tool config migrations into plugin-owned provider config.
-import { ensureRecord, mergeMissing } from "../../../config/legacy.shared.js";
+import { ensureRecord } from "../../../config/legacy.shared.js";
+import { mergeMissing } from "../../../config/merge-missing.js";
 import {
   cloneRecord,
   hasOwnKey,

--- a/src/config/legacy.shared.test.ts
+++ b/src/config/legacy.shared.test.ts
@@ -1,6 +1,7 @@
 // Covers shared legacy config rule detection helpers.
 import { afterEach, describe, expect, it } from "vitest";
-import { mapLegacyAudioTranscription, mergeMissing } from "./legacy.shared.js";
+import { mapLegacyAudioTranscription } from "./legacy.shared.js";
+import { mergeMissing } from "./merge-missing.js";
 
 describe("legacy audio transcription migration", () => {
   it("migrates deprecated input placeholders to the documented attachment path", () => {
@@ -34,5 +35,64 @@ describe("mergeMissing prototype pollution guard", () => {
     expect((target.safe as Record<string, unknown>).next).toBe(1);
     expect(target.polluted).toBeUndefined();
     expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it.each(["__proto__", "prototype", "constructor"])(
+    "keeps an explicitly missing %s key untouched at each merged level",
+    (key) => {
+      const nested = { [key]: undefined, keep: true };
+      const target: Record<string, unknown> = { [key]: undefined, nested };
+      const source = {
+        [key]: { polluted: true },
+        nested: { [key]: { polluted: true }, next: 1 },
+      };
+
+      mergeMissing(target, source);
+
+      expect(target[key]).toBeUndefined();
+      expect(target.nested).toEqual({ [key]: undefined, keep: true, next: 1 });
+      expect(target.nested).toBe(nested);
+    },
+  );
+
+  it("fills missing fields by reference while preserving authored values and records", () => {
+    const inserted = { value: 1 };
+    const nested = { keep: "canonical" };
+    const array = ["canonical"];
+    const target: Record<string, unknown> = {
+      nested,
+      array,
+      nil: null,
+      zero: 0,
+      disabled: false,
+      empty: "",
+    };
+    const source = {
+      missing: inserted,
+      nested: { keep: "legacy", added: inserted },
+      array: ["legacy"],
+      nil: { value: 2 },
+      zero: 3,
+      disabled: true,
+      empty: "legacy",
+      omitted: undefined,
+    };
+
+    mergeMissing(target, source);
+
+    expect(target).toEqual({
+      nested: { keep: "canonical", added: inserted },
+      array: ["canonical"],
+      nil: null,
+      zero: 0,
+      disabled: false,
+      empty: "",
+      missing: inserted,
+    });
+    expect(target.missing).toBe(inserted);
+    expect(target.nested).toBe(nested);
+    expect(target.nested).toHaveProperty("added", inserted);
+    expect(target.array).toBe(array);
+    expect(Object.hasOwn(target, "omitted")).toBe(false);
   });
 });

--- a/src/config/legacy.shared.ts
+++ b/src/config/legacy.shared.ts
@@ -1,6 +1,5 @@
 // Defines shared legacy config rule contracts for detection and migration.
 import { isSafeExecutableValue } from "../infra/exec-safety.js";
-import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { isRecord } from "../utils.js";
 export type LegacyConfigRule = {
   path: string[];
@@ -46,22 +45,6 @@ export const ensureRecord = (
   const next: Record<string, unknown> = {};
   root[key] = next;
   return next;
-};
-
-export const mergeMissing = (target: Record<string, unknown>, source: Record<string, unknown>) => {
-  for (const [key, value] of Object.entries(source)) {
-    if (value === undefined || isBlockedObjectKey(key)) {
-      continue;
-    }
-    const existing = target[key];
-    if (existing === undefined) {
-      target[key] = value;
-      continue;
-    }
-    if (isRecord(existing) && isRecord(value)) {
-      mergeMissing(existing, value);
-    }
-  }
 };
 
 export const mapLegacyAudioTranscription = (value: unknown): Record<string, unknown> | null => {

--- a/src/config/merge-missing.ts
+++ b/src/config/merge-missing.ts
@@ -1,0 +1,22 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { isBlockedObjectKey } from "../infra/prototype-keys.js";
+
+/** Fill undefined fields in place; newly assigned values retain their source references. */
+export function mergeMissing(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): void {
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined || isBlockedObjectKey(key)) {
+      continue;
+    }
+    const existing = target[key];
+    if (existing === undefined) {
+      target[key] = value;
+      continue;
+    }
+    if (isRecord(existing) && isRecord(value)) {
+      mergeMissing(existing, value);
+    }
+  }
+}

--- a/src/plugin-sdk/runtime-doctor-migrations.ts
+++ b/src/plugin-sdk/runtime-doctor-migrations.ts
@@ -15,6 +15,7 @@ import type { OpenKeyedStoreOptions } from "../plugin-state/plugin-state-store.j
 import type { PluginDoctorStateMigration } from "../plugins/doctor-contract-module.js";
 import { archiveLegacyStateSource } from "../plugins/doctor-state-migration-fs.js";
 
+export { mergeMissing } from "../config/merge-missing.js";
 export { collectProviderDangerousNameMatchingScopes } from "../config/dangerous-name-matching.js";
 export { defineChannelAliasMigration } from "../config/channel-alias-migration.js";
 export {


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested de-duplication of the fill-missing policy used by core Doctor migrations, Amazon Bedrock discovery migration, and ElevenLabs Talk migration. Each had its own implementation of canonical-value precedence, record recursion, and blocked-key handling.

## Why This Change Was Made

`src/config/merge-missing.ts` now owns the primitive. Core migration callers import the dependency-light leaf directly; the plugins use its export from the existing `openclaw/plugin-sdk/runtime-doctor-migrations` subpath. The old internal export and both plugin copies are removed together. Provider selection, migration order, and caller-owned cloning stay unchanged.

The primitive mutates existing records, preserves authored arrays/null/scalars, skips undefined source values and blocked keys, and assigns missing values by reference. Its SDK documentation explicitly distinguishes that behavior from recursive sanitization or cloning.

## User Impact

No CLI, configuration, or persisted-data behavior change. Plugin authors can reuse the documented primitive through the doctor-migration SDK. No public export was removed or renamed, and no compatibility alias, dependency, schema, or option was added.

## Evidence

- Expanded core and plugin preservation suites: 12 tests passed before moving the primitive.
- `node scripts/run-vitest.mjs src/config/legacy.shared.test.ts extensions/amazon-bedrock/config-compat.test.ts extensions/elevenlabs/config-compat.test.ts src/commands/doctor/shared/legacy-config-migrate.provider-shapes.test.ts src/plugins/doctor-contract-closure-guard.test.ts`: 44 tests passed after extraction, including the four import-closure guards.
- Independent Codex review: clean through P2, zero actionable findings.
- Production: 32 added / 60 removed, net −28. Tests: net +60. Docs: +12.
- Isolated full build and complete changed-file proof passed through the repository Crabbox wrapper on Blacksmith Testbox `tbx_01m1wwjv7kftebkh4evshggjg2`, [workflow run](https://github.com/openclaw/openclaw/actions/runs/34077810117). The command was `pnpm build && OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 node scripts/check-changed.mjs`; wrapper exit code 0, run status succeeded. This includes all core/extension test types, package-boundary lint, SDK surface/export checks, all three export scans (zero entries), and architecture guards. It avoids the documented ancestor-install failure in the nested local worktree. No live-service proof claimed.

All 13 remote candidate file hashes matched the frozen local candidate. The owned Testbox was stopped after proof. The pre-publication rebase onto `afb7d393d734` retained the stable patch ID, all 13 file blobs, lockfile, and record/prototype guard dependency sources. Rebased head: `ce52eb7dc592f5824e64b4cf648947233dc6e1fe`; all 44 focused tests pass again on that head. The isolated proof tree `f194a99e175370f4850cd4287673fe9068acea1e` exactly matches the pre-rebase commit tree.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34080046143) passed for `ce52eb7dc592f5824e64b4cf648947233dc6e1fe`. ClawSweeper reviewed that head with no actionable correctness findings or before-merge requests.
