### PR TITLE
fix(openrouter): avoid rescanning fragmented music response lines

### DIFF
--- a/extensions/openrouter/music-generation-provider.test.ts
+++ b/extensions/openrouter/music-generation-provider.test.ts
@@ -185,6 +185,37 @@ describe("openrouter music generation provider", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    { ending: "\n", terminated: true },
+    { ending: "\r\n", terminated: false },
+  ])(
+    "preserves fragmented UTF-8 lines with $ending and terminated=$terminated",
+    async ({ ending, terminated }) => {
+      const lines = sseResponseLines({
+        audio: Buffer.from("wav-bytes").toString("base64"),
+        transcript: "café 🦞 soundtrack",
+        done: true,
+      });
+      const bytes = new TextEncoder().encode(
+        lines.map((line) => line.trimEnd()).join(ending) + (terminated ? ending : ""),
+      );
+      postJsonRequestMock.mockResolvedValue({
+        response: sseResponse(Array.from(bytes, (byte) => Uint8Array.of(byte))),
+        release: vi.fn(async () => {}),
+      });
+
+      const result = await buildOpenRouterMusicGenerationProvider().generateMusic({
+        provider: "openrouter",
+        model: "",
+        prompt: "fragmented soundtrack",
+        cfg: {},
+      });
+
+      expect(result.tracks[0]?.buffer).toEqual(Buffer.from("wav-bytes"));
+      expect(result.lyrics).toEqual(["café 🦞 soundtrack"]);
+    },
+  );
+
   it("preserves completed OpenRouter audio when reader cleanup fails", async () => {
     const cancel = vi.fn(async () => {
       throw new Error("cancel failed");
@@ -379,93 +410,118 @@ describe("openrouter music generation provider", () => {
     }
   });
 
-  it("rejects OpenRouter streams that end before completion", async () => {
-    postJsonRequestMock.mockResolvedValue({
-      response: sseResponse([
-        `data: ${JSON.stringify({ choices: [{ delta: { audio: { data: Buffer.from("partial").toString("base64") } } }] })}\n`,
-      ]),
-      release: vi.fn(async () => {}),
-    });
+  it.each(["\n", ""])(
+    "rejects OpenRouter streams that end before completion with ending %j",
+    async (ending) => {
+      postJsonRequestMock.mockResolvedValue({
+        response: sseResponse([
+          `data: ${JSON.stringify({ choices: [{ delta: { audio: { data: Buffer.from("partial").toString("base64") } } }] })}${ending}`,
+        ]),
+        release: vi.fn(async () => {}),
+      });
 
-    await expect(
-      buildOpenRouterMusicGenerationProvider().generateMusic({
-        provider: "openrouter",
-        model: "google/lyria-3-clip-preview",
-        prompt: "interrupted",
-        cfg: {},
-      }),
-    ).rejects.toThrow("OpenRouter music generation stream ended before completion");
-  });
+      await expect(
+        buildOpenRouterMusicGenerationProvider().generateMusic({
+          provider: "openrouter",
+          model: "google/lyria-3-clip-preview",
+          prompt: "interrupted",
+          cfg: {},
+        }),
+      ).rejects.toThrow("OpenRouter music generation stream ended before completion");
+    },
+  );
 
-  it("preserves OpenRouter mid-stream errors when reader cleanup fails", async () => {
-    const cancel = vi.fn(async () => {
-      throw new Error("cancel failed");
-    });
-    postJsonRequestMock.mockResolvedValue({
-      response: sseResponse(
-        [
-          `data: ${JSON.stringify({
-            error: { code: "provider_error", message: "provider disconnected" },
-            choices: [{ delta: {}, finish_reason: "error" }],
-          })}\n`,
-        ],
-        { cancel },
-      ),
-      release: vi.fn(async () => {}),
-    });
+  it.each(["\n", ""])(
+    "preserves OpenRouter errors with ending %j when reader cleanup fails",
+    async (ending) => {
+      const cancel = vi.fn(async () => {
+        throw new Error("cancel failed");
+      });
+      postJsonRequestMock.mockResolvedValue({
+        response: sseResponse(
+          [
+            `data: ${JSON.stringify({
+              error: { code: "provider_error", message: "provider disconnected" },
+              choices: [{ delta: {}, finish_reason: "error" }],
+            })}${ending}`,
+          ],
+          { cancel },
+        ),
+        release: vi.fn(async () => {}),
+      });
 
-    await expect(
-      buildOpenRouterMusicGenerationProvider().generateMusic({
-        provider: "openrouter",
-        model: "google/lyria-3-clip-preview",
-        prompt: "surface provider failure",
-        cfg: {},
-      }),
-    ).rejects.toThrow("OpenRouter music generation failed: provider disconnected");
-    expect(cancel).toHaveBeenCalledOnce();
-  });
+      await expect(
+        buildOpenRouterMusicGenerationProvider().generateMusic({
+          provider: "openrouter",
+          model: "google/lyria-3-clip-preview",
+          prompt: "surface provider failure",
+          cfg: {},
+        }),
+      ).rejects.toThrow("OpenRouter music generation failed: provider disconnected");
+      expect(cancel).toHaveBeenCalledOnce();
+    },
+  );
 
-  it("accepts valid SSE events above the old fixed two-megabyte cap", async () => {
-    const audio = Buffer.alloc(1_600_000, 0x61);
-    postJsonRequestMock.mockResolvedValue({
-      response: sseResponse([
+  it.each([16 * 1024, Infinity])(
+    "accepts valid SSE events above two megabytes with %s-byte transport chunks",
+    async (chunkBytes) => {
+      const audio = Buffer.alloc(1_600_000, 0x61);
+      const event = Buffer.from(
         `data: ${JSON.stringify({ choices: [{ delta: { audio: { data: audio.toString("base64") } } }] })}\n`,
-        "data: [DONE]\n",
-      ]),
-      release: vi.fn(async () => {}),
-    });
+      );
+      const chunks: Uint8Array[] = [];
+      for (let offset = 0; offset < event.length; offset += chunkBytes) {
+        chunks.push(event.subarray(offset, offset + chunkBytes));
+      }
+      postJsonRequestMock.mockResolvedValue({
+        response: sseResponse([...chunks, "data: [DONE]\n"]),
+        release: vi.fn(async () => {}),
+      });
 
-    const result = await buildOpenRouterMusicGenerationProvider().generateMusic({
-      provider: "openrouter",
-      model: "google/lyria-3-clip-preview",
-      prompt: "large valid audio event",
-      cfg: { agents: { defaults: { mediaMaxMb: 2 } } },
-    });
-
-    expect(result.tracks[0]?.buffer).toEqual(audio);
-  });
-
-  it("rejects OpenRouter music SSE events outside the configured media envelope", async () => {
-    const maxBytes = 8;
-    const maxEventBytes = Math.ceil(maxBytes / 3) * 4 + maxBytes + 64 * 1024;
-    const cancel = vi.fn();
-    postJsonRequestMock.mockResolvedValue({
-      response: sseResponse([new Uint8Array(maxEventBytes + 1)], { cancel }),
-      release: vi.fn(async () => {}),
-    });
-
-    await expect(
-      buildOpenRouterMusicGenerationProvider().generateMusic({
+      const result = await buildOpenRouterMusicGenerationProvider().generateMusic({
         provider: "openrouter",
         model: "google/lyria-3-clip-preview",
-        prompt: "unterminated event",
-        cfg: { agents: { defaults: { mediaMaxMb: maxBytes / (1024 * 1024) } } },
-      }),
-    ).rejects.toThrow(
-      `OpenRouter music generation SSE event exceeded ${maxEventBytes} bytes for a ${maxBytes}-byte media limit`,
-    );
-    expect(cancel).toHaveBeenCalledOnce();
-  });
+        prompt: "large valid audio event",
+        cfg: { agents: { defaults: { mediaMaxMb: 2 } } },
+      });
+
+      expect(result.tracks[0]?.buffer).toEqual(audio);
+    },
+  );
+
+  it.each(["one chunk", "fragmented", "after completion", "decoder flush"])(
+    "rejects SSE events outside the media envelope: %s",
+    async (boundary) => {
+      const maxBytes = 8;
+      const maxEventBytes = Math.ceil(maxBytes / 3) * 4 + maxBytes + 64 * 1024;
+      const cancel = vi.fn();
+      const oversized = new Uint8Array(maxEventBytes + 1);
+      const chunks =
+        boundary === "fragmented"
+          ? [oversized.subarray(0, 32 * 1024), oversized.subarray(32 * 1024)]
+          : boundary === "after completion"
+            ? [Buffer.concat([Buffer.from("data: [DONE]\n"), oversized])]
+            : boundary === "decoder flush"
+              ? [Buffer.alloc(maxEventBytes - 1, 0x20), Uint8Array.of(0xe2)]
+              : [oversized];
+      postJsonRequestMock.mockResolvedValue({
+        response: sseResponse(chunks, { cancel }),
+        release: vi.fn(async () => {}),
+      });
+
+      await expect(
+        buildOpenRouterMusicGenerationProvider().generateMusic({
+          provider: "openrouter",
+          model: "google/lyria-3-clip-preview",
+          prompt: "unterminated event",
+          cfg: { agents: { defaults: { mediaMaxMb: maxBytes / (1024 * 1024) } } },
+        }),
+      ).rejects.toThrow(
+        `OpenRouter music generation SSE event exceeded ${maxEventBytes} bytes for a ${maxBytes}-byte media limit`,
+      );
+      expect(cancel).toHaveBeenCalledOnce();
+    },
+  );
 
   it.each([
     {

--- a/extensions/openrouter/music-generation-provider.ts
+++ b/extensions/openrouter/music-generation-provider.ts
@@ -269,9 +269,8 @@ async function readOpenRouterAudioStream(
     maxBytes,
   };
   const maxEventBytes = resolveOpenRouterSseEventMaxBytes(maxBytes);
-  let buffer = "";
+  const lineFragments: string[] = [];
   let pendingBytes = 0;
-  let doneSeen = false;
   try {
     for (;;) {
       const { value, done } = await readOpenRouterStreamChunk(reader, deadline);
@@ -286,10 +285,17 @@ async function readOpenRouterAudioStream(
           );
         }
       }
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split(/\r?\n/u);
-      buffer = lines.pop() ?? "";
-      for (const line of lines) {
+      const chunk = decoder.decode(value, { stream: true });
+      let start = 0;
+      // Audio events can span many chunks; scan only new text and join each line once.
+      for (let end = chunk.indexOf("\n"); end !== -1; end = chunk.indexOf("\n", start)) {
+        let line = chunk.slice(start, end);
+        start = end + 1;
+        if (lineFragments.length > 0) {
+          lineFragments.push(line);
+          line = lineFragments.join("");
+          lineFragments.length = 0;
+        }
         if (processOpenRouterSseLine(line.trim(), result)) {
           flushOpenRouterMusicAudio(result);
           // Once [DONE] is observed, the generated result is authoritative.
@@ -301,23 +307,20 @@ async function readOpenRouterAudioStream(
           };
         }
       }
+      if (start < chunk.length) {
+        lineFragments.push(chunk.slice(start));
+      }
     }
     resolveOpenRouterStreamRemainingMs(deadline);
-    buffer += decoder.decode();
+    lineFragments.push(decoder.decode());
+    const buffer = lineFragments.join("");
     pendingBytes = Buffer.byteLength(buffer, "utf8");
     if (pendingBytes > maxEventBytes) {
       throw new Error(
         `OpenRouter music generation SSE event exceeded ${maxEventBytes} bytes for a ${maxBytes}-byte media limit`,
       );
     }
-    if (buffer.trim()) {
-      for (const line of buffer.split(/\r?\n/u)) {
-        if (processOpenRouterSseLine(line.trim(), result)) {
-          doneSeen = true;
-        }
-      }
-    }
-    if (!doneSeen) {
+    if (!processOpenRouterSseLine(buffer.trim(), result)) {
       throw new Error("OpenRouter music generation stream ended before completion");
     }
     flushOpenRouterMusicAudio(result);


### PR DESCRIPTION
Closes #140715

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Resolves repeated rescanning of large, fragmented OpenRouter music responses. Each transport chunk previously caused the parser to split the complete unfinished JSON audio line again.

## Why This Change Was Made

Scan newly decoded chunks for LF delimiters and join unfinished fragments once when a line completes. EOF contains only one pending line, so its redundant split/loop and completion flag are removed. Raw byte limits still run before any chunk lines are processed, and the final decoder byte recheck remains.

## User Impact

A 4.2 MB wire event over 257 chunks reduces delimiter-range work from 543,162,472 to 4,194,408 characters. Local processing median in that fixture falls from 101.21 to 44.19 ms. Audio, transcript, metadata, completion/error behavior and cleanup stay the same. This does not measure external provider generation speed or RSS.

## Evidence

- All 15 complete before/after result and error records match, including bytewise UTF-8/CRLF, unterminated DONE, errors at EOF, completion suffixes, cumulative limits and decoder replacement-character expansion.
- The fragmented large event fails the original two-times-input work budget and passes after the repair. Single-chunk and small-event controls pass in both versions.
- All 23 focused tests, the complete changed-file gate and fresh isolated P2 autoreview passed. The actual provider and media/base64/deadline helpers run with synthetic HTTP/stream boundaries; no provider credentials or calls were used.
- No API, plugin/import boundary, configuration, authentication or network-policy change was made; a separate full local build was not run. Production is net +3 lines and tests net +56, including table reindentation.

The five-sample timing and separate V8 allocation profiles are local component observations. Allocation sampling is not exact native allocation or retained memory; small controls have ordinary noise. Existing #101488 limit and #111056 cleanup contracts remain intact.
