### PR TITLE
refactor: remove MCP resolver test overrides

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1857,7 +1857,6 @@ src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.ts	
 src/agents/mcp-app-model-context.ts	1
 src/agents/mcp-auth-profile.ts	2
 src/agents/mcp-codex-tool-approval.ts	4
-src/agents/mcp-connection-resolver.ts	2
 src/agents/mcp-http-fetch.ts	3
 src/agents/mcp-json-schema-validator.ts	6
 src/agents/mcp-oauth-store.ts	2

--- a/src/agents/agent-bundle-mcp-manager-install.ts
+++ b/src/agents/agent-bundle-mcp-manager-install.ts
@@ -15,8 +15,8 @@ import type {
 } from "./agent-bundle-mcp-types.js";
 import { allowMcpAppModelContext, revokeMcpAppModelContext } from "./mcp-app-model-context.js";
 import {
+  MCP_CONNECTION_REVALIDATE_MS,
   hashMcpResolvedConnections,
-  resolveMcpConnectionRevalidateMs,
   resolveRequesterScopedMcpConnections,
   type McpServerConnectionResolved,
 } from "./mcp-connection-resolver.js";
@@ -189,12 +189,11 @@ export function createSessionMcpRuntimeManagerInstall(
     );
     const existing = store.runtimesBySessionId.get(params.runtimeKey);
     const meta = store.connectionMetaByRuntimeKey.get(params.runtimeKey);
-    const revalidateMs = resolveMcpConnectionRevalidateMs();
     // Full-set + within revalidation window: skip resolver I/O.
     // Revocation/rotation takes effect within MCP_CONNECTION_REVALIDATE_MS even for
     // continuously active requesters (markUsed does not extend this clock alone).
     const withinRevalidateWindow =
-      meta !== undefined && store.now() - meta.resolvedAt < revalidateMs;
+      meta !== undefined && store.now() - meta.resolvedAt < MCP_CONNECTION_REVALIDATE_MS;
     if (withinRevalidateWindow && existing && matchesRuntime(existing, params, scopedFingerprint)) {
       reconcileReusableRetirement(params.sessionId, existing);
       existing.markUsed();

--- a/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
+++ b/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import { createSessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.test-support.js";
 import type { SessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.test-support.js";
 import {
@@ -9,7 +10,7 @@ import {
   type CreateSessionMcpRuntime,
 } from "./agent-bundle-mcp-runtime-shared.js";
 import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
-import { testing as resolverTesting } from "./mcp-connection-resolver.js";
+import { createMcpProofPluginRegistry } from "./mcp-connection-resolver.test-fixtures.js";
 import { createAgentCleanupScope } from "./run-cleanup-timeout.js";
 
 vi.mock("./agent-bundle-mcp-runtime.js", () => {
@@ -108,8 +109,6 @@ afterEach(async () => {
     release();
   }
   await Promise.all(managers.splice(0).map((manager) => manager.disposeAll()));
-  resolverTesting.setMcpServerConnectionResolversForTest();
-  resolverTesting.setMcpConnectionRevalidateMsForTest();
 });
 
 describe("MCP manager creation ownership", () => {
@@ -155,57 +154,62 @@ describe("MCP manager creation ownership", () => {
   it.each(["static", "requester"] as const)(
     "keeps the native idle timer outside %s requesting turns across disposal",
     async (entrypoint) => {
-      const turnContext = new AsyncLocalStorage<string>();
-      const pendingInputContext = new AsyncLocalStorage<string>();
-      const readContext = () => ({
-        turn: turnContext.getStore(),
-        pendingInput: pendingInputContext.getStore(),
-      });
-      const timerContexts: ReturnType<typeof readContext>[] = [];
-      const factoryContexts: ReturnType<typeof readContext>[] = [];
-      const nativeSetInterval = globalThis.setInterval;
-      const intervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation((...args) => {
-        if (args[1] === SESSION_MCP_RUNTIME_SWEEP_INTERVAL_MS) {
-          timerContexts.push(readContext());
-        }
-        return nativeSetInterval(...args);
-      });
-      const manager = createSessionMcpRuntimeManager({
-        createRuntime(input) {
-          factoryContexts.push(readContext());
-          return createRuntimeFixture(input);
-        },
-      });
-      managers.push(manager);
-      resolverTesting.setMcpServerConnectionResolversForTest([
-        { serverName: "scoped", resolve: async () => ({ url: "https://mcp.example.test/scoped" }) },
-      ]);
+      const resolverRegistry = createMcpProofPluginRegistry();
+      await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+        const turnContext = new AsyncLocalStorage<string>();
+        const pendingInputContext = new AsyncLocalStorage<string>();
+        const readContext = () => ({
+          turn: turnContext.getStore(),
+          pendingInput: pendingInputContext.getStore(),
+        });
+        const timerContexts: ReturnType<typeof readContext>[] = [];
+        const factoryContexts: ReturnType<typeof readContext>[] = [];
+        const nativeSetInterval = globalThis.setInterval;
+        const intervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation((...args) => {
+          if (args[1] === SESSION_MCP_RUNTIME_SWEEP_INTERVAL_MS) {
+            timerContexts.push(readContext());
+          }
+          return nativeSetInterval(...args);
+        });
+        const manager = createSessionMcpRuntimeManager({
+          createRuntime(input) {
+            factoryContexts.push(readContext());
+            return createRuntimeFixture(input);
+          },
+        });
+        managers.push(manager);
+        const resolverApi = resolverRegistry.apiFor("test-plugin");
+        resolverApi.registerMcpServerConnectionResolver({
+          serverName: "scoped",
+          resolve: async () => ({ url: "https://mcp.example.test/scoped" }),
+        });
 
-      try {
-        for (const turn of ["first turn", "later turn"]) {
-          const pendingInput = `${turn} input`;
-          await turnContext.run(turn, () =>
-            pendingInputContext.run(pendingInput, async () => {
-              if (entrypoint === "static") {
-                await manager.getOrCreate(params);
-              } else {
-                await manager.getOrCreateRequesterScoped({
-                  ...params,
-                  requesterSenderId: "sender",
-                  cfg: { mcp: { servers: { scoped: { transport: "streamable-http" } } } },
-                });
-              }
-              expect(readContext()).toEqual({ turn, pendingInput });
-            }),
-          );
-          expect(factoryContexts.splice(0)).toEqual([{ turn, pendingInput }]);
-          expect(timerContexts.splice(0)).toEqual([{ turn: undefined, pendingInput: undefined }]);
+        try {
+          for (const turn of ["first turn", "later turn"]) {
+            const pendingInput = `${turn} input`;
+            await turnContext.run(turn, () =>
+              pendingInputContext.run(pendingInput, async () => {
+                if (entrypoint === "static") {
+                  await manager.getOrCreate(params);
+                } else {
+                  await manager.getOrCreateRequesterScoped({
+                    ...params,
+                    requesterSenderId: "sender",
+                    cfg: { mcp: { servers: { scoped: { transport: "streamable-http" } } } },
+                  });
+                }
+                expect(readContext()).toEqual({ turn, pendingInput });
+              }),
+            );
+            expect(factoryContexts.splice(0)).toEqual([{ turn, pendingInput }]);
+            expect(timerContexts.splice(0)).toEqual([{ turn: undefined, pendingInput: undefined }]);
+            await manager.disposeAll();
+          }
+        } finally {
           await manager.disposeAll();
+          intervalSpy.mockRestore();
         }
-      } finally {
-        await manager.disposeAll();
-        intervalSpy.mockRestore();
-      }
+      });
     },
   );
 
@@ -292,86 +296,93 @@ describe("MCP manager creation ownership", () => {
   it.each(["session", "all"] as const)(
     "drains the requester partition of a pending full acquisition during %s disposal",
     async (scope) => {
-      const first = holdFactory();
-      const resolutionStarted = createDeferred();
-      const releaseResolution = createDeferred();
-      releaseHeldWork.push(() => releaseResolution.resolve());
-      resolverTesting.setMcpServerConnectionResolversForTest([
-        {
+      const resolverRegistry = createMcpProofPluginRegistry();
+      await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+        const first = holdFactory();
+        const resolutionStarted = createDeferred();
+        const releaseResolution = createDeferred();
+        releaseHeldWork.push(() => releaseResolution.resolve());
+        const resolverApi = resolverRegistry.apiFor("test-plugin");
+        resolverApi.registerMcpServerConnectionResolver({
           serverName: "scoped",
           resolve: async () => {
             resolutionStarted.resolve();
             await releaseResolution.promise;
             return { url: "https://mcp.example.test/scoped" };
           },
-        },
-      ]);
-      const created: SessionMcpRuntime[] = [];
-      const manager = createManager(async (input) => {
-        const runtime = created.length
-          ? createRuntimeFixture(input)
-          : await first.createRuntime(input);
-        created.push(runtime);
-        return runtime;
+        });
+        const created: SessionMcpRuntime[] = [];
+        const manager = createManager(async (input) => {
+          const runtime = created.length
+            ? createRuntimeFixture(input)
+            : await first.createRuntime(input);
+          created.push(runtime);
+          return runtime;
+        });
+        const pending = manager.acquire(requesterParams("sender"));
+        await first.started;
+        let drained = false;
+        const disposal = (
+          scope === "session" ? manager.disposeSession(params.sessionId) : manager.disposeAll()
+        ).then(() => {
+          drained = true;
+        });
+        first.release();
+        await resolutionStarted.promise;
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(drained).toBe(false);
+        releaseResolution.resolve();
+        const acquired = await pending;
+        acquired.releaseLease();
+        await disposal;
+        expect(created).toHaveLength(2);
+        for (const runtime of created) {
+          expect(runtime.dispose).toHaveBeenCalledOnce();
+        }
+        expect(manager.listRuntimeKeys()).toEqual([]);
+        expect(manager.resolveSessionId(params.sessionKey)).toBeUndefined();
       });
-      const pending = manager.acquire(requesterParams("sender"));
-      await first.started;
-      let drained = false;
-      const disposal = (
-        scope === "session" ? manager.disposeSession(params.sessionId) : manager.disposeAll()
-      ).then(() => {
-        drained = true;
-      });
-      first.release();
-      await resolutionStarted.promise;
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
-      expect(drained).toBe(false);
-      releaseResolution.resolve();
-      const acquired = await pending;
-      acquired.releaseLease();
-      await disposal;
-      expect(created).toHaveLength(2);
-      for (const runtime of created) {
-        expect(runtime.dispose).toHaveBeenCalledOnce();
-      }
-      expect(manager.listRuntimeKeys()).toEqual([]);
-      expect(manager.resolveSessionId(params.sessionKey)).toBeUndefined();
     },
   );
 
   it.each(["session", "all"] as const)(
     "queues a new requester key behind %s teardown",
     async (scope) => {
-      resolverTesting.setMcpServerConnectionResolversForTest([
-        { serverName: "scoped", resolve: async () => ({ url: "https://mcp.example.test/scoped" }) },
-      ]);
-      const createRuntime = vi.fn<CreateSessionMcpRuntime>(createRuntimeFixture);
-      const manager = createManager(createRuntime);
-      const old = expectDefined(
-        await manager.acquireRequesterScoped(requesterParams("first")),
-        "first requester",
-      );
-      old.releaseLease();
-      const closing = holdDisposal(old.runtime);
-      const disposal =
-        scope === "session" ? manager.disposeSession(params.sessionId) : manager.disposeAll();
-      await closing.started;
-      const next = manager.acquireRequesterScoped({
-        ...requesterParams("next"),
-        ...(scope === "all" ? { sessionId: "another-session", sessionKey: "another-key" } : {}),
+      const resolverRegistry = createMcpProofPluginRegistry();
+      await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+        const resolverApi = resolverRegistry.apiFor("test-plugin");
+        resolverApi.registerMcpServerConnectionResolver({
+          serverName: "scoped",
+          resolve: async () => ({ url: "https://mcp.example.test/scoped" }),
+        });
+        const createRuntime = vi.fn<CreateSessionMcpRuntime>(createRuntimeFixture);
+        const manager = createManager(createRuntime);
+        const old = expectDefined(
+          await manager.acquireRequesterScoped(requesterParams("first")),
+          "first requester",
+        );
+        old.releaseLease();
+        const closing = holdDisposal(old.runtime);
+        const disposal =
+          scope === "session" ? manager.disposeSession(params.sessionId) : manager.disposeAll();
+        await closing.started;
+        const next = manager.acquireRequesterScoped({
+          ...requesterParams("next"),
+          ...(scope === "all" ? { sessionId: "another-session", sessionKey: "another-key" } : {}),
+        });
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(createRuntime).toHaveBeenCalledOnce();
+        closing.release();
+        await disposal;
+        const acquired = expectDefined(await next, "next requester");
+        acquired.releaseLease();
+        expect(acquired.runtime.dispose).not.toHaveBeenCalled();
+        expect(manager.listSessionIds()).toEqual([acquired.runtime.sessionId]);
       });
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
-      expect(createRuntime).toHaveBeenCalledOnce();
-      closing.release();
-      await disposal;
-      const acquired = expectDefined(await next, "next requester");
-      acquired.releaseLease();
-      expect(acquired.runtime.dispose).not.toHaveBeenCalled();
-      expect(manager.listSessionIds()).toEqual([acquired.runtime.sessionId]);
     },
   );
 
@@ -423,53 +434,60 @@ describe("MCP manager creation ownership", () => {
   });
 
   it("serializes requester replacement behind global disposal instead of clearing its lock", async () => {
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      { serverName: "scoped", resolve: async () => ({ url: "https://mcp.example.test/scoped" }) },
-    ]);
-    const first = holdFactory();
-    const next = holdFactory();
-    const createRuntime = vi
-      .fn<CreateSessionMcpRuntime>(createRuntimeFixture)
-      .mockImplementationOnce(first.createRuntime)
-      .mockImplementationOnce(next.createRuntime);
-    const manager = createManager(createRuntime);
-    const scoped = {
-      ...params,
-      requesterSenderId: "sender",
-      cfg: { mcp: { servers: { scoped: { transport: "streamable-http" as const } } } },
-    };
-    const firstRequest = manager.getOrCreateRequesterScoped(scoped);
-    const oldRuntime = await first.started;
-    const closing = holdDisposal(oldRuntime);
-    const disposal = manager.disposeAll();
-    const nextRequest = manager.getOrCreateRequesterScoped(scoped);
-    first.release();
-    await closing.started;
-    expect(createRuntime).toHaveBeenCalledOnce();
-    closing.release();
-    await disposal;
-    await firstRequest;
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
+        serverName: "scoped",
+        resolve: async () => ({ url: "https://mcp.example.test/scoped" }),
+      });
+      const first = holdFactory();
+      const next = holdFactory();
+      const createRuntime = vi
+        .fn<CreateSessionMcpRuntime>(createRuntimeFixture)
+        .mockImplementationOnce(first.createRuntime)
+        .mockImplementationOnce(next.createRuntime);
+      const manager = createManager(createRuntime);
+      const scoped = {
+        ...params,
+        requesterSenderId: "sender",
+        cfg: { mcp: { servers: { scoped: { transport: "streamable-http" as const } } } },
+      };
+      const firstRequest = manager.getOrCreateRequesterScoped(scoped);
+      const oldRuntime = await first.started;
+      const closing = holdDisposal(oldRuntime);
+      const disposal = manager.disposeAll();
+      const nextRequest = manager.getOrCreateRequesterScoped(scoped);
+      first.release();
+      await closing.started;
+      expect(createRuntime).toHaveBeenCalledOnce();
+      closing.release();
+      await disposal;
+      await firstRequest;
 
-    const nextRuntime = await next.started;
-    next.release();
-    expect((await nextRequest)?.runtime).toBe(nextRuntime);
-    expect(createRuntime).toHaveBeenCalledTimes(2);
-    expect(oldRuntime.dispose).toHaveBeenCalledOnce();
-    expect(nextRuntime.dispose).not.toHaveBeenCalled();
-    expect(manager.listSessionIds()).toEqual([params.sessionId]);
-    expect(manager.resolveSessionId(params.sessionKey)).toBe(params.sessionId);
+      const nextRuntime = await next.started;
+      next.release();
+      expect((await nextRequest)?.runtime).toBe(nextRuntime);
+      expect(createRuntime).toHaveBeenCalledTimes(2);
+      expect(oldRuntime.dispose).toHaveBeenCalledOnce();
+      expect(nextRuntime.dispose).not.toHaveBeenCalled();
+      expect(manager.listSessionIds()).toEqual([params.sessionId]);
+      expect(manager.resolveSessionId(params.sessionKey)).toBe(params.sessionId);
+    });
   });
 
   it("does not queue cap eviction behind active requester work", async () => {
-    let nowMs = 100_000;
-    const resolutionStarted = createDeferred();
-    const releaseResolution = createDeferred();
-    releaseHeldWork.push(() => releaseResolution.resolve());
-    const secondRuntimeCreated = createDeferred();
-    let senderACalls = 0;
-    resolverTesting.setMcpConnectionRevalidateMsForTest(1);
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      let nowMs = 100_000;
+      const resolutionStarted = createDeferred();
+      const releaseResolution = createDeferred();
+      releaseHeldWork.push(() => releaseResolution.resolve());
+      const secondRuntimeCreated = createDeferred();
+      let senderACalls = 0;
+
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "scoped",
         resolve: async ({ requesterSenderId }) => {
           if (requesterSenderId === "sender-a" && ++senderACalls === 2) {
@@ -478,42 +496,42 @@ describe("MCP manager creation ownership", () => {
           }
           return { url: `https://mcp.example.test/${requesterSenderId}` };
         },
-      },
-    ]);
-    const createRuntime = vi.fn<CreateSessionMcpRuntime>((input) => {
-      const runtime = createRuntimeFixture(input);
-      if (input.requesterScope?.requesterSenderId === "sender-b") {
-        secondRuntimeCreated.resolve();
-      }
-      return runtime;
-    });
-    const manager = createSessionMcpRuntimeManager({
-      createRuntime,
-      now: () => nowMs,
-      enableIdleSweepTimer: false,
-      maxIdleRequesterRuntimesPerSession: 1,
-    });
-    managers.push(manager);
+      });
+      const createRuntime = vi.fn<CreateSessionMcpRuntime>((input) => {
+        const runtime = createRuntimeFixture(input);
+        if (input.requesterScope?.requesterSenderId === "sender-b") {
+          secondRuntimeCreated.resolve();
+        }
+        return runtime;
+      });
+      const manager = createSessionMcpRuntimeManager({
+        createRuntime,
+        now: () => nowMs,
+        enableIdleSweepTimer: false,
+        maxIdleRequesterRuntimesPerSession: 1,
+      });
+      managers.push(manager);
 
-    const first = expectDefined(
-      (await manager.getOrCreateRequesterScoped(requesterParams("sender-a")))?.runtime,
-      "first requester runtime",
-    );
-    nowMs += 2;
-    const refreshed = manager.getOrCreateRequesterScoped(requesterParams("sender-a"));
-    await resolutionStarted.promise;
-    const competing = manager.getOrCreateRequesterScoped(requesterParams("sender-b"));
-    await secondRuntimeCreated.promise;
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
-    releaseResolution.resolve();
+      const first = expectDefined(
+        (await manager.getOrCreateRequesterScoped(requesterParams("sender-a")))?.runtime,
+        "first requester runtime",
+      );
+      nowMs += 300_000;
+      const refreshed = manager.getOrCreateRequesterScoped(requesterParams("sender-a"));
+      await resolutionStarted.promise;
+      const competing = manager.getOrCreateRequesterScoped(requesterParams("sender-b"));
+      await secondRuntimeCreated.promise;
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      releaseResolution.resolve();
 
-    expect((await refreshed)?.runtime).toBe(first);
-    await competing;
-    expect(first.dispose).not.toHaveBeenCalled();
-    expect(manager.listRuntimeKeys()).toEqual([
-      expect.stringContaining('"requesterSenderId":"sender-a"'),
-    ]);
+      expect((await refreshed)?.runtime).toBe(first);
+      await competing;
+      expect(first.dispose).not.toHaveBeenCalled();
+      expect(manager.listRuntimeKeys()).toEqual([
+        expect.stringContaining('"requesterSenderId":"sender-a"'),
+      ]);
+    });
   });
 });

--- a/src/agents/agent-bundle-mcp-reload.test.ts
+++ b/src/agents/agent-bundle-mcp-reload.test.ts
@@ -8,6 +8,7 @@ import { createDeferred } from "../../test/helpers/promise.js";
 import { cleanupTempDirs } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createPluginManifestRecordFixture } from "../plugins/plugin-metadata.test-support.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import { createCombinedSessionMcpRuntime } from "./agent-bundle-mcp-combined.js";
 import { createSessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.test-support.js";
 import { materializeBundleMcpToolsForRun } from "./agent-bundle-mcp-materialize.js";
@@ -17,7 +18,7 @@ import {
 } from "./agent-bundle-mcp-probe.test-support.js";
 import { createSessionMcpRuntime } from "./agent-bundle-mcp-runtime.js";
 import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
-import { testing as resolverTesting } from "./mcp-connection-resolver.js";
+import { createMcpProofPluginRegistry } from "./mcp-connection-resolver.test-fixtures.js";
 
 const startAuthorization = vi.hoisted(() => vi.fn(async () => ({ status: "authorized" })));
 const readAuthorization = vi.hoisted(() => vi.fn(async () => ({ state: "unauthenticated" })));
@@ -40,13 +41,11 @@ afterEach(async () => {
   cleanupTempDirs(tempDirs);
   startAuthorization.mockClear();
   readAuthorization.mockReset().mockResolvedValue({ state: "unauthenticated" });
-  resolverTesting.setMcpServerConnectionResolversForTest();
-  resolverTesting.setMcpConnectionRevalidateMsForTest();
 });
 
-async function fixture() {
+async function fixture(now?: () => number) {
   const source = await createMcpProbeFixture(tempDirs);
-  const manager = createSessionMcpRuntimeManager({ enableIdleSweepTimer: false });
+  const manager = createSessionMcpRuntimeManager({ enableIdleSweepTimer: false, now });
   managers.push(manager);
   return { ...source, manager };
 }
@@ -368,71 +367,79 @@ it.each(["remove", "disable", "public origin"])(
 );
 
 it("rotates one requester's changed server while retaining sibling connections and requesters", async () => {
-  const url = await httpProbe();
-  let generation = 0;
-  resolverTesting.setMcpConnectionRevalidateMsForTest(1);
-  resolverTesting.setMcpServerConnectionResolversForTest(
-    ["first", "second"].map((serverName) => ({
-      serverName,
-      resolve: async ({ requesterSenderId }) => ({
-        url,
-        headers: {
-          Authorization: `proof-${requesterSenderId}-${serverName === "first" && requesterSenderId === "alice" ? generation : 0}`,
+  const resolverRegistry = createMcpProofPluginRegistry();
+  await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+    const url = await httpProbe();
+    let generation = 0;
+
+    const resolverApi = resolverRegistry.apiFor("test-plugin");
+    for (const serverName of ["first", "second"]) {
+      resolverApi.registerMcpServerConnectionResolver({
+        serverName,
+        resolve: async ({ requesterSenderId }) => ({
+          url,
+          headers: {
+            Authorization: `proof-${requesterSenderId}-${serverName === "first" && requesterSenderId === "alice" ? generation : 0}`,
+          },
+        }),
+      });
+    }
+    let nowMs = 100_000;
+    const { manager, params } = await fixture(() => nowMs);
+    const cfg: OpenClawConfig = {
+      plugins: { enabled: false },
+      mcp: {
+        servers: {
+          first: { transport: "streamable-http" },
+          second: { transport: "streamable-http" },
         },
-      }),
-    })),
-  );
-  const { manager, params } = await fixture();
-  const cfg: OpenClawConfig = {
-    plugins: { enabled: false },
-    mcp: {
-      servers: {
-        first: { transport: "streamable-http" },
-        second: { transport: "streamable-http" },
       },
-    },
-  };
-  const aliceParams = { ...params, cfg, requesterSenderId: "alice" };
-  const bobParams = { ...params, cfg, requesterSenderId: "bob" };
-  const alice = await manager.getOrCreate(aliceParams);
-  const bob = await manager.getOrCreate(bobParams);
-  const before = await Promise.all([
-    probe(alice, "first"),
-    probe(alice, "second"),
-    probe(bob, "first"),
-    probe(bob, "second"),
-  ]);
-  generation++;
-  const nextAlice = await manager.getOrCreate(aliceParams);
-  const nextBob = await manager.getOrCreate(bobParams);
-  const after = await Promise.all([
-    probe(nextAlice, "first"),
-    probe(nextAlice, "second"),
-    probe(nextBob, "first"),
-    probe(nextBob, "second"),
-  ]);
-  expect(after[0]).not.toEqual(before[0]);
-  expect(after.slice(1)).toEqual(before.slice(1));
-  const oldHandle = await manager.getOrCreateRequesterScoped(aliceParams);
-  expect(oldHandle).toBeDefined();
-  await manager.reloadConfig({
-    cfg,
-    manifestRegistry: params.manifestRegistry,
-    reloadPlugins: true,
+    };
+    const aliceParams = { ...params, cfg, requesterSenderId: "alice" };
+    const bobParams = { ...params, cfg, requesterSenderId: "bob" };
+    const alice = await manager.getOrCreate(aliceParams);
+    const bob = await manager.getOrCreate(bobParams);
+    const before = await Promise.all([
+      probe(alice, "first"),
+      probe(alice, "second"),
+      probe(bob, "first"),
+      probe(bob, "second"),
+    ]);
+    generation++;
+    nowMs += 300_000;
+    const nextAlice = await manager.getOrCreate(aliceParams);
+    const nextBob = await manager.getOrCreate(bobParams);
+    const after = await Promise.all([
+      probe(nextAlice, "first"),
+      probe(nextAlice, "second"),
+      probe(nextBob, "first"),
+      probe(nextBob, "second"),
+    ]);
+    expect(after[0]).not.toEqual(before[0]);
+    expect(after.slice(1)).toEqual(before.slice(1));
+    const oldHandle = await manager.getOrCreateRequesterScoped(aliceParams);
+    expect(oldHandle).toBeDefined();
+    await manager.reloadConfig({
+      cfg,
+      manifestRegistry: params.manifestRegistry,
+      reloadPlugins: true,
+    });
+    await expect(probe(nextAlice, "first")).rejects.toThrow();
+    const currentHandle = await manager.getOrCreateRequesterScoped(bobParams);
+    expect(currentHandle).toBeDefined();
+    const currentCatalog = await currentHandle!.runtime.getCatalog();
+    manager.rememberAdvertisedScopedCatalog(currentHandle!, currentCatalog);
+    manager.rememberAdvertisedScopedCatalog(oldHandle!, {
+      ...currentCatalog,
+      servers: {
+        retired: { serverName: "retired", launchSummary: "retired plugin", toolCount: 0 },
+      },
+      tools: [],
+    });
+    expect(manager.getAdvertisedScopedCatalog(params.sessionId)?.servers.retired).toBeUndefined();
+    const successor = await manager.getOrCreate(aliceParams);
+    expect(await probe(successor, "first")).not.toEqual(after[0]);
   });
-  await expect(probe(nextAlice, "first")).rejects.toThrow();
-  const currentHandle = await manager.getOrCreateRequesterScoped(bobParams);
-  expect(currentHandle).toBeDefined();
-  const currentCatalog = await currentHandle!.runtime.getCatalog();
-  manager.rememberAdvertisedScopedCatalog(currentHandle!, currentCatalog);
-  manager.rememberAdvertisedScopedCatalog(oldHandle!, {
-    ...currentCatalog,
-    servers: { retired: { serverName: "retired", launchSummary: "retired plugin", toolCount: 0 } },
-    tools: [],
-  });
-  expect(manager.getAdvertisedScopedCatalog(params.sessionId)?.servers.retired).toBeUndefined();
-  const successor = await manager.getOrCreate(aliceParams);
-  expect(await probe(successor, "first")).not.toEqual(after[0]);
 });
 
 it.each(["removal", "public origin change", "plugin replacement with explicit shadow"])(
@@ -524,54 +531,57 @@ it("preserves transferred servers across queued replacements", async () => {
 });
 
 it("retains plugin retirement across a later config-only publication during creation", async () => {
-  const url = await httpProbe();
-  const { params } = await fixture();
-  const cfg: OpenClawConfig = {
-    plugins: { enabled: false },
-    mcp: { servers: { scoped: { transport: "streamable-http" } } },
-  };
-  resolverTesting.setMcpServerConnectionResolversForTest([
-    { serverName: "scoped", resolve: async () => ({ url }) },
-  ]);
-  const started = createDeferred();
-  const released = createDeferred();
-  let retired: SessionMcpRuntime | undefined;
-  let firstConnection: Awaited<ReturnType<typeof probe>> | undefined;
-  releaseHeld.push(() => released.resolve());
-  const manager = createSessionMcpRuntimeManager({
-    enableIdleSweepTimer: false,
-    async createRuntime(input) {
-      const runtime = createSessionMcpRuntime(input);
-      if (input.requesterScope && !retired) {
-        retired = runtime;
-        firstConnection = await probe(runtime, "scoped");
-        started.resolve();
-        await released.promise;
-      }
-      return runtime;
-    },
-  });
-  managers.push(manager);
-  const pending = manager.getOrCreate({ ...params, cfg, requesterSenderId: "alice" });
-  await started.promise;
-  resolverTesting.setMcpServerConnectionResolversForTest([
-    {
+  const resolverRegistry = createMcpProofPluginRegistry();
+  await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+    const url = await httpProbe();
+    const { params } = await fixture();
+    const cfg: OpenClawConfig = {
+      plugins: { enabled: false },
+      mcp: { servers: { scoped: { transport: "streamable-http" } } },
+    };
+    const resolverApi = resolverRegistry.apiFor("test-plugin");
+    resolverApi.registerMcpServerConnectionResolver({
+      serverName: "scoped",
+      resolve: async () => ({ url }),
+    });
+    const started = createDeferred();
+    const released = createDeferred();
+    let retired: SessionMcpRuntime | undefined;
+    let firstConnection: Awaited<ReturnType<typeof probe>> | undefined;
+    releaseHeld.push(() => released.resolve());
+    const manager = createSessionMcpRuntimeManager({
+      enableIdleSweepTimer: false,
+      async createRuntime(input) {
+        const runtime = createSessionMcpRuntime(input);
+        if (input.requesterScope && !retired) {
+          retired = runtime;
+          firstConnection = await probe(runtime, "scoped");
+          started.resolve();
+          await released.promise;
+        }
+        return runtime;
+      },
+    });
+    managers.push(manager);
+    const pending = manager.getOrCreate({ ...params, cfg, requesterSenderId: "alice" });
+    await started.promise;
+    resolverApi.registerMcpServerConnectionResolver({
       serverName: "scoped",
       resolve: async () => ({ url, headers: { Authorization: "replacement" } }),
-    },
-  ]);
-  await manager.reloadConfig({
-    cfg,
-    manifestRegistry: params.manifestRegistry,
-    reloadPlugins: true,
+    });
+    await manager.reloadConfig({
+      cfg,
+      manifestRegistry: params.manifestRegistry,
+      reloadPlugins: true,
+    });
+    await manager.reloadConfig({
+      cfg: structuredClone(cfg),
+      manifestRegistry: params.manifestRegistry,
+    });
+    released.resolve();
+    expect(await probe(await pending, "scoped")).not.toEqual(firstConnection);
+    await expect(probe(expectDefined(retired, "retired plugin owner"), "scoped")).rejects.toThrow();
   });
-  await manager.reloadConfig({
-    cfg: structuredClone(cfg),
-    manifestRegistry: params.manifestRegistry,
-  });
-  released.resolve();
-  expect(await probe(await pending, "scoped")).not.toEqual(firstConnection);
-  await expect(probe(expectDefined(retired, "retired plugin owner"), "scoped")).rejects.toThrow();
 });
 
 it.each(["no shadow", "shadow at publication", "shadow before transfer"])(

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -17,6 +17,7 @@ import {
   makeTempDir,
   useAutoCleanupTempDirTracker,
 } from "../../test/helpers/temp-dir.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import { createCombinedSessionMcpRuntime } from "./agent-bundle-mcp-combined.js";
 import { completeDeferredSessionMcpRuntimeRetirement } from "./agent-bundle-mcp-manager-api.js";
 import {
@@ -39,6 +40,7 @@ import {
 import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
 import { writeExecutable } from "./bundle-mcp-shared.test-harness.js";
 import { updateMcpAppModelContext } from "./mcp-app-model-context.js";
+import { createMcpProofPluginRegistry } from "./mcp-connection-resolver.test-fixtures.js";
 import { fetchMcpAppView, getMcpAppViewLease } from "./mcp-ui-resource.js";
 import { testing as mcpUiResourceTesting } from "./mcp-ui-resource.test-support.js";
 import { createAgentCleanupScope } from "./run-cleanup-timeout.js";
@@ -3387,17 +3389,19 @@ process.on("SIGINT", shutdown);`,
   });
 
   it("keeps a real requester-scoped MCP transport alive during an idle sweep", async () => {
-    const proof = await startRequesterScopedMcpProofServer();
-    const resolverTesting = await import("./mcp-connection-resolver.js");
-    let firstTools: Awaited<ReturnType<typeof materializeRequesterScopedMcpToolsForHarnessRun>>;
-    let secondTools: Awaited<ReturnType<typeof materializeRequesterScopedMcpToolsForHarnessRun>>;
-    let nowMs = 100_000;
-    const clock = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
-    let resolveCount = 0;
-    const releaseResolution = createDeferred();
-    const resolutionStarted = createDeferred();
-    resolverTesting.testing.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const proof = await startRequesterScopedMcpProofServer();
+
+      let firstTools: Awaited<ReturnType<typeof materializeRequesterScopedMcpToolsForHarnessRun>>;
+      let secondTools: Awaited<ReturnType<typeof materializeRequesterScopedMcpToolsForHarnessRun>>;
+      let nowMs = 100_000;
+      const clock = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+      let resolveCount = 0;
+      const releaseResolution = createDeferred();
+      const resolutionStarted = createDeferred();
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "real-requester",
         resolve: async () => {
           resolveCount += 1;
@@ -3410,83 +3414,86 @@ process.on("SIGINT", shutdown);`,
             headers: { Authorization: "Bearer proof-token" },
           };
         },
-      },
-    ]);
-    resolverTesting.testing.setMcpConnectionRevalidateMsForTest(1);
-    const declaredServer = {
-      transport: "streamable-http" as const,
-      url: "https://placeholder.invalid/mcp",
-    };
-    const params = makeRequesterParams(
-      "session-real-requester-sweep",
-      {
-        mcp: { servers: { "real-requester": declaredServer } },
-      },
-      "proof-requester",
-    );
-    const singletonStore = globalThis as Record<PropertyKey, unknown>;
-    const hadRuntimeManager = Object.hasOwn(singletonStore, SESSION_MCP_RUNTIME_MANAGER_KEY);
-    const previousRuntimeManager = singletonStore[SESSION_MCP_RUNTIME_MANAGER_KEY];
-    const manager = createSessionMcpRuntimeManager({
-      now: () => nowMs,
-      enableIdleSweepTimer: false,
-    });
-    singletonStore[SESSION_MCP_RUNTIME_MANAGER_KEY] = manager;
+      });
 
-    try {
-      firstTools = expectDefined(
-        await materializeRequesterScopedMcpToolsForHarnessRun(params),
-        "first requester tools",
+      const declaredServer = {
+        transport: "streamable-http" as const,
+        url: "https://placeholder.invalid/mcp",
+      };
+      const params = makeRequesterParams(
+        "session-real-requester-sweep",
+        {
+          mcp: { servers: { "real-requester": declaredServer } },
+        },
+        "proof-requester",
       );
-      const runtimeKey = expectDefined(manager.listRuntimeKeys()[0], "first requester runtime key");
-      const firstRuntime = expectDefined(
-        manager.peekSession({ sessionId: runtimeKey }),
-        "first requester runtime",
-      );
-      const firstTool = expectDefined(firstTools.tools[0], "first requester tool");
-      const firstSessionId = readMcpText(
-        await firstTool.execute("first-requester-call", {}),
-        "first MCP result",
-      );
-      await firstTools.dispose();
-      firstTools = undefined;
+      const singletonStore = globalThis as Record<PropertyKey, unknown>;
+      const hadRuntimeManager = Object.hasOwn(singletonStore, SESSION_MCP_RUNTIME_MANAGER_KEY);
+      const previousRuntimeManager = singletonStore[SESSION_MCP_RUNTIME_MANAGER_KEY];
+      const manager = createSessionMcpRuntimeManager({
+        now: () => nowMs,
+        enableIdleSweepTimer: false,
+      });
+      singletonStore[SESSION_MCP_RUNTIME_MANAGER_KEY] = manager;
 
-      nowMs += 2;
-      const secondRequest = materializeRequesterScopedMcpToolsForHarnessRun(params);
-      await resolutionStarted.promise;
+      try {
+        firstTools = expectDefined(
+          await materializeRequesterScopedMcpToolsForHarnessRun(params),
+          "first requester tools",
+        );
+        const runtimeKey = expectDefined(
+          manager.listRuntimeKeys()[0],
+          "first requester runtime key",
+        );
+        const firstRuntime = expectDefined(
+          manager.peekSession({ sessionId: runtimeKey }),
+          "first requester runtime",
+        );
+        const firstTool = expectDefined(firstTools.tools[0], "first requester tool");
+        const firstSessionId = readMcpText(
+          await firstTool.execute("first-requester-call", {}),
+          "first MCP result",
+        );
+        await firstTools.dispose();
+        firstTools = undefined;
 
-      const idleTtlMs = 10 * 60 * 1000;
-      nowMs += idleTtlMs;
-      expect(await manager.sweepIdleRuntimes()).toBe(0);
-      expect(manager.listRuntimeKeys()).toHaveLength(1);
+        nowMs += 300_000;
+        const secondRequest = materializeRequesterScopedMcpToolsForHarnessRun(params);
+        await resolutionStarted.promise;
 
-      releaseResolution.resolve();
-      secondTools = expectDefined(await secondRequest, "second requester tools");
-      expect(manager.peekSession({ sessionId: runtimeKey })).toBe(firstRuntime);
-      const secondTool = expectDefined(secondTools.tools[0], "second requester tool");
-      expect(
-        readMcpText(await secondTool.execute("second-requester-call", {}), "second MCP result"),
-      ).toBe(firstSessionId);
-      expect(proof.session.current).toBe(firstSessionId);
-      await secondTools.dispose();
-      secondTools = undefined;
+        const idleTtlMs = 10 * 60 * 1000;
+        nowMs += idleTtlMs;
+        expect(await manager.sweepIdleRuntimes()).toBe(0);
+        expect(manager.listRuntimeKeys()).toHaveLength(1);
 
-      nowMs += idleTtlMs;
-      expect(await manager.sweepIdleRuntimes()).toBe(1);
-      expect(manager.listRuntimeKeys()).toEqual([]);
-      expect(proof.session.closed).toBe(firstSessionId);
-    } finally {
-      releaseResolution.resolve();
-      await Promise.allSettled([firstTools?.dispose(), secondTools?.dispose()]);
-      await testing.resetSessionMcpRuntimeManager();
-      if (hadRuntimeManager) {
-        singletonStore[SESSION_MCP_RUNTIME_MANAGER_KEY] = previousRuntimeManager;
-      } else {
-        delete singletonStore[SESSION_MCP_RUNTIME_MANAGER_KEY];
+        releaseResolution.resolve();
+        secondTools = expectDefined(await secondRequest, "second requester tools");
+        expect(manager.peekSession({ sessionId: runtimeKey })).toBe(firstRuntime);
+        const secondTool = expectDefined(secondTools.tools[0], "second requester tool");
+        expect(
+          readMcpText(await secondTool.execute("second-requester-call", {}), "second MCP result"),
+        ).toBe(firstSessionId);
+        expect(proof.session.current).toBe(firstSessionId);
+        await secondTools.dispose();
+        secondTools = undefined;
+
+        nowMs += idleTtlMs;
+        expect(await manager.sweepIdleRuntimes()).toBe(1);
+        expect(manager.listRuntimeKeys()).toEqual([]);
+        expect(proof.session.closed).toBe(firstSessionId);
+      } finally {
+        releaseResolution.resolve();
+        await Promise.allSettled([firstTools?.dispose(), secondTools?.dispose()]);
+        await testing.resetSessionMcpRuntimeManager();
+        if (hadRuntimeManager) {
+          singletonStore[SESSION_MCP_RUNTIME_MANAGER_KEY] = previousRuntimeManager;
+        } else {
+          delete singletonStore[SESSION_MCP_RUNTIME_MANAGER_KEY];
+        }
+        clock.mockRestore();
+        await proof.close();
       }
-      clock.mockRestore();
-      await proof.close();
-    }
+    });
   });
 
   it("retires global session runtimes by session key", async () => {
@@ -3528,10 +3535,6 @@ process.on("SIGINT", shutdown);`,
 
 describe("requester-scoped MCP connection resolution", () => {
   afterEach(async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest();
-    resolverTesting.setMcpConnectionResolverTimeoutMsForTest();
-    resolverTesting.setMcpConnectionRevalidateMsForTest();
     vi.useRealTimers();
   });
 
@@ -3542,59 +3545,61 @@ describe("requester-scoped MCP connection resolution", () => {
   ] as const)(
     "expires %s runtimes at ten idle minutes while preserving reuse and active leases",
     async (entrypoint, expectedExpired) => {
-      let nowMs = 100_000;
-      const clock = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
-      const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-      resolverTesting.setMcpServerConnectionResolversForTest([
-        {
+      const resolverRegistry = createMcpProofPluginRegistry();
+      await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+        let nowMs = 100_000;
+        const clock = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+
+        const resolverApi = resolverRegistry.apiFor("test-plugin");
+        resolverApi.registerMcpServerConnectionResolver({
           serverName: "user-mail",
           resolve: async () => ({ url: "https://mcp.example.test/user" }),
-        },
-      ]);
-      const manager = createSessionMcpRuntimeManager({ enableIdleSweepTimer: false });
-      const sessionKey = "agent:test:session-fixed-idle";
-      const params: RuntimeParams = {
-        sessionId: "session-fixed-idle",
-        sessionKey,
-        workspaceDir: "/workspace",
-        ...(entrypoint === "static" ? {} : { requesterSenderId: "sender-a" }),
-        cfg: {
-          mcp: {
-            servers: {
-              shared: { command: "true" },
-              ...(entrypoint === "static"
-                ? {}
-                : { "user-mail": { transport: "streamable-http" as const } }),
+        });
+        const manager = createSessionMcpRuntimeManager({ enableIdleSweepTimer: false });
+        const sessionKey = "agent:test:session-fixed-idle";
+        const params: RuntimeParams = {
+          sessionId: "session-fixed-idle",
+          sessionKey,
+          workspaceDir: "/workspace",
+          ...(entrypoint === "static" ? {} : { requesterSenderId: "sender-a" }),
+          cfg: {
+            mcp: {
+              servers: {
+                shared: { command: "true" },
+                ...(entrypoint === "static"
+                  ? {}
+                  : { "user-mail": { transport: "streamable-http" as const } }),
+              },
             },
           },
-        },
-      };
-      const getRuntime = () =>
-        entrypoint === "requester-only"
-          ? manager.getOrCreateRequesterScoped(params).then((handle) => handle?.runtime)
-          : manager.getOrCreate(params);
-      try {
-        await getRuntime();
-        nowMs += 10 * 60 * 1000 - 1;
-        expect(await manager.sweepIdleRuntimes()).toBe(0);
+        };
+        const getRuntime = () =>
+          entrypoint === "requester-only"
+            ? manager.getOrCreateRequesterScoped(params).then((handle) => handle?.runtime)
+            : manager.getOrCreate(params);
+        try {
+          await getRuntime();
+          nowMs += 10 * 60 * 1000 - 1;
+          expect(await manager.sweepIdleRuntimes()).toBe(0);
 
-        const reused = expectDefined(await getRuntime(), "admitted MCP runtime");
-        expect(reused.lastUsedAt).toBe(nowMs);
-        nowMs += 10 * 60 * 1000 - 1;
-        expect(await manager.sweepIdleRuntimes()).toBe(0);
-        const release = expectDefined(reused.acquireLease, "MCP runtime lease")();
-        nowMs += 1;
-        expect(await manager.sweepIdleRuntimes()).toBe(0);
-        expect(manager.listSessionIds()).toContain(params.sessionId);
+          const reused = expectDefined(await getRuntime(), "admitted MCP runtime");
+          expect(reused.lastUsedAt).toBe(nowMs);
+          nowMs += 10 * 60 * 1000 - 1;
+          expect(await manager.sweepIdleRuntimes()).toBe(0);
+          const release = expectDefined(reused.acquireLease, "MCP runtime lease")();
+          nowMs += 1;
+          expect(await manager.sweepIdleRuntimes()).toBe(0);
+          expect(manager.listSessionIds()).toContain(params.sessionId);
 
-        release();
-        expect(await manager.sweepIdleRuntimes()).toBe(expectedExpired);
-        expect(manager.listRuntimeKeys()).toEqual([]);
-        expect(manager.resolveSessionId(sessionKey)).toBeUndefined();
-      } finally {
-        await manager.disposeAll();
-        clock.mockRestore();
-      }
+          release();
+          expect(await manager.sweepIdleRuntimes()).toBe(expectedExpired);
+          expect(manager.listRuntimeKeys()).toEqual([]);
+          expect(manager.resolveSessionId(sessionKey)).toBeUndefined();
+        } finally {
+          await manager.disposeAll();
+          clock.mockRestore();
+        }
+      });
     },
   );
 
@@ -3629,191 +3634,197 @@ describe("requester-scoped MCP connection resolution", () => {
   });
 
   it("keys requester-scoped runtimes per sender while sharing static servers", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async (ctx) => ({
           url: `https://mcp.example.test/${ctx.requesterSenderId}`,
           headers: { Authorization: `Bearer ${ctx.requesterSenderId}` },
         }),
-      },
-    ]);
-
-    const created: Array<{
-      sessionId: string;
-      requesterScope?: SessionMcpRuntime["requesterScope"];
-      include?: string[];
-      exclude?: string[];
-    }> = [];
-    const createRuntime: RuntimeFactory = (params) => {
-      created.push({
-        sessionId: params.sessionId,
-        requesterScope: params.requesterScope,
-        include: params.includeServerNames ? [...params.includeServerNames] : undefined,
-        exclude: params.excludeServerNames ? [...params.excludeServerNames] : undefined,
       });
-      return makeManagedRuntime(params);
-    };
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const cfg = {
-      mcp: {
-        servers: {
-          shared: { command: "true" },
-          "user-mail": { transport: "streamable-http" },
+
+      const created: Array<{
+        sessionId: string;
+        requesterScope?: SessionMcpRuntime["requesterScope"];
+        include?: string[];
+        exclude?: string[];
+      }> = [];
+      const createRuntime: RuntimeFactory = (params) => {
+        created.push({
+          sessionId: params.sessionId,
+          requesterScope: params.requesterScope,
+          include: params.includeServerNames ? [...params.includeServerNames] : undefined,
+          exclude: params.excludeServerNames ? [...params.excludeServerNames] : undefined,
+        });
+        return makeManagedRuntime(params);
+      };
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const cfg = {
+        mcp: {
+          servers: {
+            shared: { command: "true" },
+            "user-mail": { transport: "streamable-http" },
+          },
         },
-      },
-    };
+      };
 
-    const params = (sender: string) =>
-      makeRequesterParams("session-shared", cfg as never, sender, {
-        sessionKey: "agent:test:session-shared",
-        agentAccountId: "bot-1",
-      });
-    await manager.getOrCreate(params("sender-a"));
-    await manager.getOrCreate(params("sender-a"));
-    await manager.getOrCreate(params("sender-b"));
-
-    // Same requester reuses both static and requester-scoped entries; other sender adds one.
-    expect(created).toEqual([
-      {
-        sessionId: "session-shared",
-        requesterScope: undefined,
-        include: undefined,
-        exclude: ["user-mail"],
-      },
-      {
-        sessionId: "session-shared",
-        requesterScope: {
-          requesterSenderId: "sender-a",
+      const params = (sender: string) =>
+        makeRequesterParams("session-shared", cfg as never, sender, {
+          sessionKey: "agent:test:session-shared",
           agentAccountId: "bot-1",
-          messageChannel: "telegram",
-        },
-        include: ["user-mail"],
-        exclude: undefined,
-      },
-      {
-        sessionId: "session-shared",
-        requesterScope: {
-          requesterSenderId: "sender-b",
-          agentAccountId: "bot-1",
-          messageChannel: "telegram",
-        },
-        include: ["user-mail"],
-        exclude: undefined,
-      },
-    ]);
-    expect(manager.listSessionIds()).toEqual(["session-shared"]);
-    expect(manager.listRuntimeKeys()).toHaveLength(3);
+        });
+      await manager.getOrCreate(params("sender-a"));
+      await manager.getOrCreate(params("sender-a"));
+      await manager.getOrCreate(params("sender-b"));
 
-    await manager.disposeAll();
+      // Same requester reuses both static and requester-scoped entries; other sender adds one.
+      expect(created).toEqual([
+        {
+          sessionId: "session-shared",
+          requesterScope: undefined,
+          include: undefined,
+          exclude: ["user-mail"],
+        },
+        {
+          sessionId: "session-shared",
+          requesterScope: {
+            requesterSenderId: "sender-a",
+            agentAccountId: "bot-1",
+            messageChannel: "telegram",
+          },
+          include: ["user-mail"],
+          exclude: undefined,
+        },
+        {
+          sessionId: "session-shared",
+          requesterScope: {
+            requesterSenderId: "sender-b",
+            agentAccountId: "bot-1",
+            messageChannel: "telegram",
+          },
+          include: ["user-mail"],
+          exclude: undefined,
+        },
+      ]);
+      expect(manager.listSessionIds()).toEqual(["session-shared"]);
+      expect(manager.listRuntimeKeys()).toHaveLength(3);
+
+      await manager.disposeAll();
+    });
   });
 
   it("keeps the tools.effective config summary in fingerprint parity with the peeked runtime", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    const { resolveSessionMcpConfigSummary } = await import("./agent-bundle-mcp-tools.js");
-    const manager = createSessionMcpRuntimeManager();
-    const expectBareRuntimeParity = async (params: {
-      sessionId: string;
-      cfg: NonNullable<RuntimeParams["cfg"]>;
-      expectedServerNames: string[];
-      toolOverrides?: RuntimeParams["toolOverrides"];
-      requesterSenderId?: string;
-    }) => {
-      const summary = resolveSessionMcpConfigSummary({
-        workspaceDir: "/workspace",
-        cfg: params.cfg,
-        ...(params.toolOverrides ? { toolOverrides: params.toolOverrides } : {}),
-      });
-      await manager.getOrCreate({
-        sessionId: params.sessionId,
-        workspaceDir: "/workspace",
-        cfg: params.cfg,
-        ...(params.toolOverrides ? { toolOverrides: params.toolOverrides } : {}),
-        ...(params.requesterSenderId ? { requesterSenderId: params.requesterSenderId } : {}),
-      });
-      expect(summary.serverNames).toEqual(params.expectedServerNames);
-      expect(summary.fingerprint).toBe(
-        manager.peekSession({ sessionId: params.sessionId })?.configFingerprint,
-      );
-    };
-    const cfg = {
-      mcp: {
-        servers: {
-          shared: { command: "true" },
-          "user-mail": { transport: "streamable-http", url: "https://static.example.test" },
-        },
-      },
-    } satisfies NonNullable<RuntimeParams["cfg"]>;
-
-    await expectBareRuntimeParity({
-      sessionId: "session-parity-static",
-      cfg,
-      expectedServerNames: ["shared", "user-mail"],
-    });
-
-    const toolOverrides = { mcpServers: { shared: false } };
-    await expectBareRuntimeParity({
-      sessionId: "session-parity-overridden",
-      cfg,
-      expectedServerNames: ["user-mail"],
-      toolOverrides,
-    });
-
-    await expectBareRuntimeParity({
-      sessionId: "session-parity-denials",
-      cfg,
-      expectedServerNames: ["shared", "user-mail"],
-      toolOverrides: { mcpToolsDeny: { shared: ["private", "private"] } },
-    });
-
-    await expectBareRuntimeParity({
-      sessionId: "session-parity-empty",
-      cfg: {},
-      expectedServerNames: [],
-    });
-
-    // Full-set declaration order owns safe-name collision suffixes even though
-    // requester-scoped OAuth servers stay out of the bare runtime partition.
-    await expectBareRuntimeParity({
-      sessionId: "session-parity-oauth",
-      cfg: {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const { resolveSessionMcpConfigSummary } = await import("./agent-bundle-mcp-tools.js");
+      const manager = createSessionMcpRuntimeManager();
+      const expectBareRuntimeParity = async (params: {
+        sessionId: string;
+        cfg: NonNullable<RuntimeParams["cfg"]>;
+        expectedServerNames: string[];
+        toolOverrides?: RuntimeParams["toolOverrides"];
+        requesterSenderId?: string;
+      }) => {
+        const summary = resolveSessionMcpConfigSummary({
+          workspaceDir: "/workspace",
+          cfg: params.cfg,
+          ...(params.toolOverrides ? { toolOverrides: params.toolOverrides } : {}),
+        });
+        await manager.getOrCreate({
+          sessionId: params.sessionId,
+          workspaceDir: "/workspace",
+          cfg: params.cfg,
+          ...(params.toolOverrides ? { toolOverrides: params.toolOverrides } : {}),
+          ...(params.requesterSenderId ? { requesterSenderId: params.requesterSenderId } : {}),
+        });
+        expect(summary.serverNames).toEqual(params.expectedServerNames);
+        expect(summary.fingerprint).toBe(
+          manager.peekSession({ sessionId: params.sessionId })?.configFingerprint,
+        );
+      };
+      const cfg = {
         mcp: {
           servers: {
-            "shared name": { command: "true" },
-            "shared-name": {
-              transport: "streamable-http",
-              auth: "oauth",
-              oauth: { identity: "per-requester" },
-              url: "https://scoped.example.test",
+            shared: { command: "true" },
+            "user-mail": { transport: "streamable-http", url: "https://static.example.test" },
+          },
+        },
+      } satisfies NonNullable<RuntimeParams["cfg"]>;
+
+      await expectBareRuntimeParity({
+        sessionId: "session-parity-static",
+        cfg,
+        expectedServerNames: ["shared", "user-mail"],
+      });
+
+      const toolOverrides = { mcpServers: { shared: false } };
+      await expectBareRuntimeParity({
+        sessionId: "session-parity-overridden",
+        cfg,
+        expectedServerNames: ["user-mail"],
+        toolOverrides,
+      });
+
+      await expectBareRuntimeParity({
+        sessionId: "session-parity-denials",
+        cfg,
+        expectedServerNames: ["shared", "user-mail"],
+        toolOverrides: { mcpToolsDeny: { shared: ["private", "private"] } },
+      });
+
+      await expectBareRuntimeParity({
+        sessionId: "session-parity-empty",
+        cfg: {},
+        expectedServerNames: [],
+      });
+
+      // Full-set declaration order owns safe-name collision suffixes even though
+      // requester-scoped OAuth servers stay out of the bare runtime partition.
+      await expectBareRuntimeParity({
+        sessionId: "session-parity-oauth",
+        cfg: {
+          mcp: {
+            servers: {
+              "shared name": { command: "true" },
+              "shared-name": {
+                transport: "streamable-http",
+                auth: "oauth",
+                oauth: { identity: "per-requester" },
+                url: "https://scoped.example.test",
+              },
             },
           },
         },
-      },
-      expectedServerNames: ["shared name", "shared-name"],
-    });
+        expectedServerNames: ["shared name", "shared-name"],
+      });
 
-    // With a resolver registered, tools.effective peeks the bare static-partition
-    // runtime; summary parity keeps it from reporting stale-config forever.
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      { serverName: "user-mail", resolve: async () => null },
-    ]);
-    await expectBareRuntimeParity({
-      sessionId: "session-parity-scoped",
-      cfg,
-      expectedServerNames: ["shared", "user-mail"],
-      requesterSenderId: "sender-a",
-    });
+      // With a resolver registered, tools.effective peeks the bare static-partition
+      // runtime; summary parity keeps it from reporting stale-config forever.
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
+        serverName: "user-mail",
+        resolve: async () => null,
+      });
+      await expectBareRuntimeParity({
+        sessionId: "session-parity-scoped",
+        cfg,
+        expectedServerNames: ["shared", "user-mail"],
+        requesterSenderId: "sender-a",
+      });
 
-    await manager.disposeAll();
+      await manager.disposeAll();
+    });
   });
 
   it("skips connection resolve on requester cache hits", async () => {
-    let resolveCalls = 0;
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
-        pluginId: "mail-plugin",
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      let resolveCalls = 0;
+
+      const resolverApi = resolverRegistry.apiFor("mail-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async (ctx) => {
           resolveCalls += 1;
@@ -3822,327 +3833,336 @@ describe("requester-scoped MCP connection resolution", () => {
             headers: { Authorization: `Bearer ${ctx.requesterSenderId}` },
           };
         },
-      },
-    ]);
+      });
 
-    const createRuntime: RuntimeFactory = makeManagedRuntime;
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const cfg = {
-      mcp: {
-        servers: {
-          "user-mail": { transport: "streamable-http" },
+      const createRuntime: RuntimeFactory = makeManagedRuntime;
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const cfg = {
+        mcp: {
+          servers: {
+            "user-mail": { transport: "streamable-http" },
+          },
         },
-      },
-    };
+      };
 
-    const params = makeRequesterParams("session-resolve-once", cfg as never, "sender-a");
-    await manager.getOrCreate(params);
-    await manager.getOrCreate(params);
+      const params = makeRequesterParams("session-resolve-once", cfg as never, "sender-a");
+      await manager.getOrCreate(params);
+      await manager.getOrCreate(params);
 
-    expect(resolveCalls).toBe(1);
-    await manager.disposeAll();
+      expect(resolveCalls).toBe(1);
+      await manager.disposeAll();
+    });
   });
 
   it("omits a throwing resolver without rejecting static MCP materialization", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
-        pluginId: "broken-plugin",
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("broken-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async () => {
           throw new Error("provider unavailable");
         },
-      },
-    ]);
-
-    const created: Array<{ include?: string[]; exclude?: string[] }> = [];
-    const createRuntime: RuntimeFactory = (params) => {
-      created.push({
-        include: params.includeServerNames ? [...params.includeServerNames] : undefined,
-        exclude: params.excludeServerNames ? [...params.excludeServerNames] : undefined,
       });
-      return makeManagedRuntime(params);
-    };
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const cfg = {
-      mcp: {
-        servers: {
-          shared: { command: "true" },
-          "user-mail": { transport: "streamable-http" },
-        },
-      },
-    };
 
-    await expect(
-      manager.getOrCreate({
-        sessionId: "session-throw",
-        workspaceDir: "/workspace",
-        cfg: cfg as never,
-        requesterSenderId: "sender-a",
-        messageChannel: "telegram",
-      }),
-    ).resolves.toBeDefined();
-
-    expect(created).toEqual([{ include: undefined, exclude: ["user-mail"] }]);
-    expect(manager.listRuntimeKeys()).toHaveLength(1);
-
-    await manager.disposeAll();
-  });
-
-  it("omits requester-scoped servers without requester context or when resolve returns null", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
-        serverName: "user-mail",
-        resolve: async (ctx) =>
-          ctx.requesterSenderId === "allowed" ? { url: "https://mcp.example.test/allowed" } : null,
-      },
-    ]);
-
-    const created: Array<{ include?: string[]; exclude?: string[] }> = [];
-    const createRuntime: RuntimeFactory = (params) => {
-      created.push({
-        include: params.includeServerNames ? [...params.includeServerNames] : undefined,
-        exclude: params.excludeServerNames ? [...params.excludeServerNames] : undefined,
-      });
-      return makeManagedRuntime(params);
-    };
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const cfg = {
-      mcp: {
-        servers: {
-          shared: { command: "true" },
-          "user-mail": { transport: "streamable-http" },
-        },
-      },
-    };
-
-    await manager.getOrCreate({
-      sessionId: "session-fail-closed",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-    });
-    await manager.getOrCreate(
-      makeRequesterParams("session-fail-closed", cfg as never, "denied", {
-        messageChannel: "slack",
-      }),
-    );
-    await manager.getOrCreate(
-      makeRequesterParams("session-fail-closed", cfg as never, "allowed", {
-        messageChannel: "slack",
-      }),
-    );
-
-    // Static entry is reused; only the allowed requester materializes a scoped runtime.
-    expect(created).toEqual([
-      { include: undefined, exclude: ["user-mail"] },
-      { include: ["user-mail"], exclude: undefined },
-    ]);
-
-    await manager.disposeAll();
-  });
-
-  it("keeps config fingerprints stable across alternating requesters", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
-        serverName: "user-mail",
-        resolve: async (ctx) => ({
-          url: `https://mcp.example.test/${ctx.requesterSenderId}`,
-          headers: { Authorization: `Bearer ${ctx.requesterSenderId}` },
-        }),
-      },
-    ]);
-
-    const fingerprints: string[] = [];
-    const createRuntime: RuntimeFactory = (params) => {
-      fingerprints.push(params.configFingerprint ?? "missing");
-      return makeManagedRuntime(params);
-    };
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const cfg = {
-      mcp: {
-        servers: {
-          "user-mail": {
-            transport: "streamable-http",
-            toolFilter: { include: ["send*"] },
-          },
-        },
-      },
-    };
-
-    await manager.getOrCreate(makeRequesterParams("session-fingerprint", cfg as never, "alice"));
-    await manager.getOrCreate(makeRequesterParams("session-fingerprint", cfg as never, "bob"));
-    await manager.getOrCreate(makeRequesterParams("session-fingerprint", cfg as never, "alice"));
-
-    // Empty static reconcile + two requester creates; requester fingerprints match.
-    expect(fingerprints).toHaveLength(3);
-    expect(fingerprints[0]).toMatch(SHA256_HEX_PATTERN);
-    expect(fingerprints[1]).toBe(fingerprints[2]);
-    expect(fingerprints[1]).toMatch(SHA256_HEX_PATTERN);
-    expect(fingerprints[0]).not.toBe(fingerprints[1]);
-    expect(manager.listRuntimeKeys()).toHaveLength(3);
-
-    await manager.disposeAll();
-  });
-
-  it("omits a stalled resolver without hanging static materialization", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpConnectionResolverTimeoutMsForTest(25);
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
-        pluginId: "hang-plugin",
-        serverName: "user-mail",
-        resolve: () => new Promise(() => {}),
-      },
-    ]);
-
-    const created: Array<{ include?: string[]; exclude?: string[] }> = [];
-    const createRuntime: RuntimeFactory = (params) => {
-      created.push({
-        include: params.includeServerNames ? [...params.includeServerNames] : undefined,
-        exclude: params.excludeServerNames ? [...params.excludeServerNames] : undefined,
-      });
-      return makeManagedRuntime(params);
-    };
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const cfg = {
-      mcp: {
-        servers: {
-          shared: { command: "true" },
-          "user-mail": { transport: "streamable-http" },
-        },
-      },
-    };
-
-    vi.useFakeTimers();
-    const pending = manager.getOrCreate(
-      makeRequesterParams("session-timeout", cfg as never, "sender-a"),
-    );
-    await vi.advanceTimersByTimeAsync(25);
-    await expect(pending).resolves.toBeDefined();
-    expect(created).toEqual([{ include: undefined, exclude: ["user-mail"] }]);
-    await manager.disposeAll();
-  });
-
-  it("upgrades a partially resolved requester runtime when more servers resolve", async () => {
-    let resolveRound = 0;
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
-        serverName: "mail-a",
-        resolve: async () => ({ url: "https://mcp.example.test/a" }),
-      },
-      {
-        serverName: "mail-b",
-        resolve: async () => {
-          resolveRound += 1;
-          return resolveRound >= 2 ? { url: "https://mcp.example.test/b" } : null;
-        },
-      },
-    ]);
-
-    const createdIncludes: string[][] = [];
-    const createRuntime: RuntimeFactory = (params) => {
-      if (params.includeServerNames) {
-        createdIncludes.push([...params.includeServerNames].toSorted());
-      }
-      return makeManagedRuntime(params);
-    };
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const cfg = {
-      mcp: {
-        servers: {
-          shared: { command: "true" },
-          "mail-a": { transport: "streamable-http" },
-          "mail-b": { transport: "streamable-http" },
-        },
-      },
-    };
-
-    const params = makeRequesterParams("session-partial", cfg as never, "sender-a");
-    await manager.getOrCreate(params);
-    expect(createdIncludes).toEqual([["mail-a"]]);
-
-    await manager.getOrCreate(params);
-    expect(createdIncludes).toEqual([["mail-a"], ["mail-a", "mail-b"]]);
-    // Static part was created once and not rebuilt when the requester side upgraded.
-    expect(manager.listRuntimeKeys().filter((key) => !key.startsWith("{"))).toEqual([
-      "session-partial",
-    ]);
-
-    await manager.disposeAll();
-  });
-
-  it("routes callTool on a fresh combined runtime without a prior getCatalog", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
-        serverName: "user-mail",
-        resolve: async () => ({ url: "https://mcp.example.test/user" }),
-      },
-    ]);
-
-    const createRuntime: RuntimeFactory = (params) => {
-      const serverName = params.includeServerNames?.has("user-mail")
-        ? "user-mail"
-        : params.excludeServerNames?.has("user-mail")
-          ? "shared"
-          : "shared";
-      const toolName = serverName === "user-mail" ? "send" : "shared_tool";
-      return {
-        ...makeManagedRuntime(params, [{ toolName, description: toolName }], serverName),
-        getCatalog: async () => ({
-          version: 1,
-          generatedAt: 0,
-          servers: {
-            [serverName]: {
-              serverName,
-              launchSummary: serverName,
-              toolCount: 1,
-            },
-          },
-          tools: [
-            {
-              serverName,
-              safeServerName: serverName,
-              toolName,
-              description: toolName,
-              inputSchema: { type: "object", properties: {} },
-              fallbackDescription: toolName,
-            },
-          ],
-        }),
-        callTool: async (calledServer, calledTool) => ({
-          content: [{ type: "text", text: `${calledServer}:${calledTool}` }],
-          isError: false,
-        }),
+      const created: Array<{ include?: string[]; exclude?: string[] }> = [];
+      const createRuntime: RuntimeFactory = (params) => {
+        created.push({
+          include: params.includeServerNames ? [...params.includeServerNames] : undefined,
+          exclude: params.excludeServerNames ? [...params.excludeServerNames] : undefined,
+        });
+        return makeManagedRuntime(params);
       };
-    };
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const runtime = await manager.getOrCreate({
-      sessionId: "session-combined-call",
-      workspaceDir: "/workspace",
-      cfg: {
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const cfg = {
         mcp: {
           servers: {
             shared: { command: "true" },
             "user-mail": { transport: "streamable-http" },
           },
         },
-      } as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+      };
 
-    await expect(runtime.callTool("user-mail", "send", {})).resolves.toMatchObject({
-      content: [{ type: "text", text: "user-mail:send" }],
-    });
-    await expect(runtime.callTool("shared", "shared_tool", {})).resolves.toMatchObject({
-      content: [{ type: "text", text: "shared:shared_tool" }],
-    });
+      await expect(
+        manager.getOrCreate({
+          sessionId: "session-throw",
+          workspaceDir: "/workspace",
+          cfg: cfg as never,
+          requesterSenderId: "sender-a",
+          messageChannel: "telegram",
+        }),
+      ).resolves.toBeDefined();
 
-    await manager.disposeAll();
+      expect(created).toEqual([{ include: undefined, exclude: ["user-mail"] }]);
+      expect(manager.listRuntimeKeys()).toHaveLength(1);
+
+      await manager.disposeAll();
+    });
+  });
+
+  it("omits requester-scoped servers without requester context or when resolve returns null", async () => {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
+        serverName: "user-mail",
+        resolve: async (ctx) =>
+          ctx.requesterSenderId === "allowed" ? { url: "https://mcp.example.test/allowed" } : null,
+      });
+
+      const created: Array<{ include?: string[]; exclude?: string[] }> = [];
+      const createRuntime: RuntimeFactory = (params) => {
+        created.push({
+          include: params.includeServerNames ? [...params.includeServerNames] : undefined,
+          exclude: params.excludeServerNames ? [...params.excludeServerNames] : undefined,
+        });
+        return makeManagedRuntime(params);
+      };
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const cfg = {
+        mcp: {
+          servers: {
+            shared: { command: "true" },
+            "user-mail": { transport: "streamable-http" },
+          },
+        },
+      };
+
+      await manager.getOrCreate({
+        sessionId: "session-fail-closed",
+        workspaceDir: "/workspace",
+        cfg: cfg as never,
+      });
+      await manager.getOrCreate(
+        makeRequesterParams("session-fail-closed", cfg as never, "denied", {
+          messageChannel: "slack",
+        }),
+      );
+      await manager.getOrCreate(
+        makeRequesterParams("session-fail-closed", cfg as never, "allowed", {
+          messageChannel: "slack",
+        }),
+      );
+
+      // Static entry is reused; only the allowed requester materializes a scoped runtime.
+      expect(created).toEqual([
+        { include: undefined, exclude: ["user-mail"] },
+        { include: ["user-mail"], exclude: undefined },
+      ]);
+
+      await manager.disposeAll();
+    });
+  });
+
+  it("keeps config fingerprints stable across alternating requesters", async () => {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
+        serverName: "user-mail",
+        resolve: async (ctx) => ({
+          url: `https://mcp.example.test/${ctx.requesterSenderId}`,
+          headers: { Authorization: `Bearer ${ctx.requesterSenderId}` },
+        }),
+      });
+
+      const fingerprints: string[] = [];
+      const createRuntime: RuntimeFactory = (params) => {
+        fingerprints.push(params.configFingerprint ?? "missing");
+        return makeManagedRuntime(params);
+      };
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const cfg = {
+        mcp: {
+          servers: {
+            "user-mail": {
+              transport: "streamable-http",
+              toolFilter: { include: ["send*"] },
+            },
+          },
+        },
+      };
+
+      await manager.getOrCreate(makeRequesterParams("session-fingerprint", cfg as never, "alice"));
+      await manager.getOrCreate(makeRequesterParams("session-fingerprint", cfg as never, "bob"));
+      await manager.getOrCreate(makeRequesterParams("session-fingerprint", cfg as never, "alice"));
+
+      // Empty static reconcile + two requester creates; requester fingerprints match.
+      expect(fingerprints).toHaveLength(3);
+      expect(fingerprints[0]).toMatch(SHA256_HEX_PATTERN);
+      expect(fingerprints[1]).toBe(fingerprints[2]);
+      expect(fingerprints[1]).toMatch(SHA256_HEX_PATTERN);
+      expect(fingerprints[0]).not.toBe(fingerprints[1]);
+      expect(manager.listRuntimeKeys()).toHaveLength(3);
+
+      await manager.disposeAll();
+    });
+  });
+
+  it("omits a stalled resolver without hanging static materialization", async () => {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("hang-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
+        serverName: "user-mail",
+        resolve: () => new Promise(() => {}),
+      });
+
+      const created: Array<{ include?: string[]; exclude?: string[] }> = [];
+      const createRuntime: RuntimeFactory = (params) => {
+        created.push({
+          include: params.includeServerNames ? [...params.includeServerNames] : undefined,
+          exclude: params.excludeServerNames ? [...params.excludeServerNames] : undefined,
+        });
+        return makeManagedRuntime(params);
+      };
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const cfg = {
+        mcp: {
+          servers: {
+            shared: { command: "true" },
+            "user-mail": { transport: "streamable-http" },
+          },
+        },
+      };
+
+      vi.useFakeTimers();
+      const pending = manager.getOrCreate(
+        makeRequesterParams("session-timeout", cfg as never, "sender-a"),
+      );
+      const settled = vi.fn();
+      void pending.then(settled);
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(settled).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(settled).toHaveBeenCalledOnce();
+      await expect(pending).resolves.toBeDefined();
+      expect(created).toEqual([{ include: undefined, exclude: ["user-mail"] }]);
+      await manager.disposeAll();
+    });
+  });
+
+  it("upgrades a partially resolved requester runtime when more servers resolve", async () => {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      let resolveRound = 0;
+
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
+        serverName: "mail-a",
+        resolve: async () => ({ url: "https://mcp.example.test/a" }),
+      });
+      resolverApi.registerMcpServerConnectionResolver({
+        serverName: "mail-b",
+        resolve: async () => {
+          resolveRound += 1;
+          return resolveRound >= 2 ? { url: "https://mcp.example.test/b" } : null;
+        },
+      });
+
+      const createdIncludes: string[][] = [];
+      const createRuntime: RuntimeFactory = (params) => {
+        if (params.includeServerNames) {
+          createdIncludes.push([...params.includeServerNames].toSorted());
+        }
+        return makeManagedRuntime(params);
+      };
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const cfg = {
+        mcp: {
+          servers: {
+            shared: { command: "true" },
+            "mail-a": { transport: "streamable-http" },
+            "mail-b": { transport: "streamable-http" },
+          },
+        },
+      };
+
+      const params = makeRequesterParams("session-partial", cfg as never, "sender-a");
+      await manager.getOrCreate(params);
+      expect(createdIncludes).toEqual([["mail-a"]]);
+
+      await manager.getOrCreate(params);
+      expect(createdIncludes).toEqual([["mail-a"], ["mail-a", "mail-b"]]);
+      // Static part was created once and not rebuilt when the requester side upgraded.
+      expect(manager.listRuntimeKeys().filter((key) => !key.startsWith("{"))).toEqual([
+        "session-partial",
+      ]);
+
+      await manager.disposeAll();
+    });
+  });
+
+  it("routes callTool on a fresh combined runtime without a prior getCatalog", async () => {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
+        serverName: "user-mail",
+        resolve: async () => ({ url: "https://mcp.example.test/user" }),
+      });
+
+      const createRuntime: RuntimeFactory = (params) => {
+        const serverName = params.includeServerNames?.has("user-mail")
+          ? "user-mail"
+          : params.excludeServerNames?.has("user-mail")
+            ? "shared"
+            : "shared";
+        const toolName = serverName === "user-mail" ? "send" : "shared_tool";
+        return {
+          ...makeManagedRuntime(params, [{ toolName, description: toolName }], serverName),
+          getCatalog: async () => ({
+            version: 1,
+            generatedAt: 0,
+            servers: {
+              [serverName]: {
+                serverName,
+                launchSummary: serverName,
+                toolCount: 1,
+              },
+            },
+            tools: [
+              {
+                serverName,
+                safeServerName: serverName,
+                toolName,
+                description: toolName,
+                inputSchema: { type: "object", properties: {} },
+                fallbackDescription: toolName,
+              },
+            ],
+          }),
+          callTool: async (calledServer, calledTool) => ({
+            content: [{ type: "text", text: `${calledServer}:${calledTool}` }],
+            isError: false,
+          }),
+        };
+      };
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const runtime = await manager.getOrCreate({
+        sessionId: "session-combined-call",
+        workspaceDir: "/workspace",
+        cfg: {
+          mcp: {
+            servers: {
+              shared: { command: "true" },
+              "user-mail": { transport: "streamable-http" },
+            },
+          },
+        } as never,
+        requesterSenderId: "sender-a",
+        messageChannel: "telegram",
+      });
+
+      await expect(runtime.callTool("user-mail", "send", {})).resolves.toMatchObject({
+        content: [{ type: "text", text: "user-mail:send" }],
+      });
+      await expect(runtime.callTool("shared", "shared_tool", {})).resolves.toMatchObject({
+        content: [{ type: "text", text: "shared:shared_tool" }],
+      });
+
+      await manager.disposeAll();
+    });
   });
 
   it.each([
@@ -4151,149 +4171,155 @@ describe("requester-scoped MCP connection resolution", () => {
   ] as const)(
     "evicts LRU idle requester runtimes past the per-session cap via %s materialization",
     async (entrypoint, expectedRuntimeCount) => {
-      const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-      resolverTesting.setMcpServerConnectionResolversForTest([
-        {
+      const resolverRegistry = createMcpProofPluginRegistry();
+      await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+        const resolverApi = resolverRegistry.apiFor("test-plugin");
+        resolverApi.registerMcpServerConnectionResolver({
           serverName: "user-mail",
           resolve: async (ctx) => ({ url: `https://mcp.example.test/${ctx.requesterSenderId}` }),
-        },
-      ]);
+        });
 
-      const disposedSenders: string[] = [];
-      let syntheticLastUsedAt = 100_000;
-      const createRuntime: RuntimeFactory = (params) => {
-        const sender = params.requesterScope?.requesterSenderId;
-        // Distinct ascending lastUsedAt per runtime so LRU ordering is deterministic.
-        const lastUsedAt = (syntheticLastUsedAt += 1_000);
-        return {
-          ...makeManagedRuntime(params),
-          get lastUsedAt() {
-            return lastUsedAt;
-          },
-          markUsed: () => {},
-          dispose: async () => {
-            if (sender) {
-              disposedSenders.push(sender);
-            }
-          },
+        const disposedSenders: string[] = [];
+        let syntheticLastUsedAt = 100_000;
+        const createRuntime: RuntimeFactory = (params) => {
+          const sender = params.requesterScope?.requesterSenderId;
+          // Distinct ascending lastUsedAt per runtime so LRU ordering is deterministic.
+          const lastUsedAt = (syntheticLastUsedAt += 1_000);
+          return {
+            ...makeManagedRuntime(params),
+            get lastUsedAt() {
+              return lastUsedAt;
+            },
+            markUsed: () => {},
+            dispose: async () => {
+              if (sender) {
+                disposedSenders.push(sender);
+              }
+            },
+          };
         };
-      };
-      const manager = createSessionMcpRuntimeManager({
-        createRuntime,
-        // Pin the sweep clock near the synthetic lastUsedAt values so the idle
-        // TTL sweep never fires; this test exercises only the cap eviction.
-        now: () => 150_000,
-        maxIdleRequesterRuntimesPerSession: 2,
-      });
-      const cfg = {
-        mcp: { servers: { "user-mail": { transport: "streamable-http" } } },
-      };
+        const manager = createSessionMcpRuntimeManager({
+          createRuntime,
+          // Pin the sweep clock near the synthetic lastUsedAt values so the idle
+          // TTL sweep never fires; this test exercises only the cap eviction.
+          now: () => 150_000,
+          maxIdleRequesterRuntimesPerSession: 2,
+        });
+        const cfg = {
+          mcp: { servers: { "user-mail": { transport: "streamable-http" } } },
+        };
 
-      for (const sender of ["sender-a", "sender-b", "sender-c"]) {
-        const runtimeParams = makeRequesterParams("session-cap", cfg as never, sender);
-        if (entrypoint === "full") {
-          await manager.getOrCreate(runtimeParams);
-        } else {
-          await manager.getOrCreateRequesterScoped(runtimeParams);
+        for (const sender of ["sender-a", "sender-b", "sender-c"]) {
+          const runtimeParams = makeRequesterParams("session-cap", cfg as never, sender);
+          if (entrypoint === "full") {
+            await manager.getOrCreate(runtimeParams);
+          } else {
+            await manager.getOrCreateRequesterScoped(runtimeParams);
+          }
         }
-      }
 
-      // sender-a is the least recently used zero-lease scoped runtime.
-      expect(disposedSenders).toEqual(["sender-a"]);
-      const runtimeKeys = manager.listRuntimeKeys();
-      expect(runtimeKeys).toHaveLength(expectedRuntimeCount);
-      expect(runtimeKeys.includes("session-cap")).toBe(entrypoint === "full");
-      expect(
-        runtimeKeys
-          .filter((key) => key.startsWith("{"))
-          .map((key) => (JSON.parse(key) as { requesterSenderId: string }).requesterSenderId),
-      ).toEqual(["sender-b", "sender-c"]);
+        // sender-a is the least recently used zero-lease scoped runtime.
+        expect(disposedSenders).toEqual(["sender-a"]);
+        const runtimeKeys = manager.listRuntimeKeys();
+        expect(runtimeKeys).toHaveLength(expectedRuntimeCount);
+        expect(runtimeKeys.includes("session-cap")).toBe(entrypoint === "full");
+        expect(
+          runtimeKeys
+            .filter((key) => key.startsWith("{"))
+            .map((key) => (JSON.parse(key) as { requesterSenderId: string }).requesterSenderId),
+        ).toEqual(["sender-b", "sender-c"]);
 
-      await manager.disposeAll();
+        await manager.disposeAll();
+      });
     },
   );
 
   it("re-merges the combined catalog after a part refreshes on tools/list_changed", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async () => ({ url: "https://mcp.example.test/user" }),
-      },
-    ]);
-
-    const makeCatalog = (serverName: string, toolName: string) => ({
-      version: 1,
-      generatedAt: 0,
-      servers: {
-        [serverName]: { serverName, launchSummary: serverName, toolCount: 1 },
-      },
-      tools: [
-        {
-          serverName,
-          safeServerName: serverName,
-          toolName,
-          description: toolName,
-          inputSchema: { type: "object", properties: {} },
-          fallbackDescription: toolName,
-        },
-      ],
-    });
-    const swapCatalogByServer = new Map<string, (toolName: string) => void>();
-    const createRuntime: RuntimeFactory = (params) => {
-      const serverName = params.includeServerNames?.has("user-mail") ? "user-mail" : "shared";
-      let current = makeCatalog(serverName, serverName === "user-mail" ? "send" : "shared_tool");
-      swapCatalogByServer.set(serverName, (toolName) => {
-        current = makeCatalog(serverName, toolName);
       });
-      return {
-        ...makeManagedRuntime(params, [{ toolName: "unused", description: "unused" }]),
-        peekCatalog: () => current,
-        getCatalog: async () => current,
-        getServerRequestTimeoutMs: () => (serverName === "user-mail" ? 90_000 : 60_000),
-      };
-    };
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const runtime = await manager.getOrCreate({
-      sessionId: "session-combined-refresh",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            shared: { command: "true" },
-            "user-mail": { transport: "streamable-http" },
-          },
+
+      const makeCatalog = (serverName: string, toolName: string) => ({
+        version: 1,
+        generatedAt: 0,
+        servers: {
+          [serverName]: { serverName, launchSummary: serverName, toolCount: 1 },
         },
-      } as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
+        tools: [
+          {
+            serverName,
+            safeServerName: serverName,
+            toolName,
+            description: toolName,
+            inputSchema: { type: "object", properties: {} },
+            fallbackDescription: toolName,
+          },
+        ],
+      });
+      const swapCatalogByServer = new Map<string, (toolName: string) => void>();
+      const createRuntime: RuntimeFactory = (params) => {
+        const serverName = params.includeServerNames?.has("user-mail") ? "user-mail" : "shared";
+        let current = makeCatalog(serverName, serverName === "user-mail" ? "send" : "shared_tool");
+        swapCatalogByServer.set(serverName, (toolName) => {
+          current = makeCatalog(serverName, toolName);
+        });
+        return {
+          ...makeManagedRuntime(params, [{ toolName: "unused", description: "unused" }]),
+          peekCatalog: () => current,
+          getCatalog: async () => current,
+          getServerRequestTimeoutMs: () => (serverName === "user-mail" ? 90_000 : 60_000),
+        };
+      };
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const runtime = await manager.getOrCreate({
+        sessionId: "session-combined-refresh",
+        workspaceDir: "/workspace",
+        cfg: {
+          mcp: {
+            servers: {
+              shared: { command: "true" },
+              "user-mail": { transport: "streamable-http" },
+            },
+          },
+        } as never,
+        requesterSenderId: "sender-a",
+        messageChannel: "telegram",
+      });
+
+      const before = await runtime.getCatalog();
+      expect(before.tools.map((tool) => tool.toolName).toSorted()).toEqual(["send", "shared_tool"]);
+
+      // A part replacing its catalog (tools/list_changed refresh) must invalidate
+      // the merged facade cache instead of serving the stale combined catalog.
+      swapCatalogByServer.get("user-mail")?.("send_v2");
+      const after = await runtime.getCatalog();
+      expect(after.tools.map((tool) => tool.toolName).toSorted()).toEqual([
+        "send_v2",
+        "shared_tool",
+      ]);
+      expect(runtime.getServerRequestTimeoutMs?.("user-mail")).toBe(90_000);
+      expect(
+        runtime
+          .peekCatalog()
+          ?.tools.map((tool) => tool.toolName)
+          .toSorted(),
+      ).toEqual(["send_v2", "shared_tool"]);
+
+      await manager.disposeAll();
     });
-
-    const before = await runtime.getCatalog();
-    expect(before.tools.map((tool) => tool.toolName).toSorted()).toEqual(["send", "shared_tool"]);
-
-    // A part replacing its catalog (tools/list_changed refresh) must invalidate
-    // the merged facade cache instead of serving the stale combined catalog.
-    swapCatalogByServer.get("user-mail")?.("send_v2");
-    const after = await runtime.getCatalog();
-    expect(after.tools.map((tool) => tool.toolName).toSorted()).toEqual(["send_v2", "shared_tool"]);
-    expect(runtime.getServerRequestTimeoutMs?.("user-mail")).toBe(90_000);
-    expect(
-      runtime
-        .peekCatalog()
-        ?.tools.map((tool) => tool.toolName)
-        .toSorted(),
-    ).toEqual(["send_v2", "shared_tool"]);
-
-    await manager.disposeAll();
   });
 
   it("disposes cached scoped runtime when revalidation resolves empty", async () => {
-    let allow = true;
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpConnectionRevalidateMsForTest(1_000);
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      let allow = true;
+
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async () =>
           allow
@@ -4302,113 +4328,120 @@ describe("requester-scoped MCP connection resolution", () => {
                 headers: { Authorization: "Bearer test-auth-token" },
               }
             : null,
-      },
-    ]);
+      });
 
-    let nowMs = 50_000;
-    const disposed: string[] = [];
-    const createRuntime: RuntimeFactory = (params) => {
-      const label = params.requesterScope ? "scoped" : "static";
-      return {
-        ...makeManagedRuntime(params),
-        dispose: async () => {
-          disposed.push(label);
-        },
+      let nowMs = 50_000;
+      const disposed: string[] = [];
+      const createRuntime: RuntimeFactory = (params) => {
+        const label = params.requesterScope ? "scoped" : "static";
+        return {
+          ...makeManagedRuntime(params),
+          dispose: async () => {
+            disposed.push(label);
+          },
+        };
       };
-    };
-    const manager = createSessionMcpRuntimeManager({
-      createRuntime,
-      now: () => nowMs,
-      enableIdleSweepTimer: false,
-    });
-    const cfg = {
-      mcp: {
-        servers: {
-          shared: { command: "true" },
-          "user-mail": { transport: "streamable-http" },
-        },
-      },
-    };
-
-    const params = makeRequesterParams("session-revoke", cfg as never, "sender-a");
-    await manager.getOrCreate(params);
-    expect(manager.listRuntimeKeys().some((key) => key.startsWith("{"))).toBe(true);
-
-    allow = false;
-    nowMs += 2_000;
-    const after = await manager.getOrCreate(params);
-
-    expect(disposed).toContain("scoped");
-    expect(manager.listRuntimeKeys().some((key) => key.startsWith("{"))).toBe(false);
-    expect(manager.listRuntimeKeys()).toEqual(["session-revoke"]);
-    // Static part still works.
-    const catalog = await after.getCatalog();
-    expect(Object.keys(catalog.servers)).toEqual(["bundleProbe"]);
-
-    await manager.disposeAll();
-  });
-
-  it("serializes disposeSession with in-flight requester resolve", async () => {
-    let releaseResolve: (() => void) | undefined;
-    const gate = new Promise<void>((resolve) => {
-      releaseResolve = resolve;
-    });
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
-        serverName: "user-mail",
-        resolve: async () => {
-          await gate;
-          return { url: "https://mcp.example.test/user" };
-        },
-      },
-    ]);
-
-    const createRuntime: RuntimeFactory = makeManagedRuntime;
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const pending = manager.getOrCreate({
-      sessionId: "session-race-dispose",
-      workspaceDir: "/workspace",
-      cfg: {
+      const manager = createSessionMcpRuntimeManager({
+        createRuntime,
+        now: () => nowMs,
+        enableIdleSweepTimer: false,
+      });
+      const cfg = {
         mcp: {
           servers: {
             shared: { command: "true" },
             "user-mail": { transport: "streamable-http" },
           },
         },
-      } as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+      };
 
-    // Static may install; dispose is chained after the exclusive requester section.
-    await new Promise((resolve) => {
-      setTimeout(resolve, 20);
-    });
-    const disposePromise = manager.disposeSession("session-race-dispose");
-    releaseResolve?.();
-    await pending;
-    await disposePromise;
-    expect(manager.listRuntimeKeys()).toEqual([]);
-    expect(testing.getBookkeepingSizes(manager).runtimeWorkChains).toBe(0);
+      const params = makeRequesterParams("session-revoke", cfg as never, "sender-a");
+      await manager.getOrCreate(params);
+      expect(manager.listRuntimeKeys().some((key) => key.startsWith("{"))).toBe(true);
 
-    await manager.disposeAll();
+      allow = false;
+      nowMs += 299_999;
+      await manager.getOrCreate(params);
+      expect(disposed).toEqual([]);
+      expect(manager.listRuntimeKeys().some((key) => key.startsWith("{"))).toBe(true);
+      nowMs += 1;
+      const after = await manager.getOrCreate(params);
+
+      expect(disposed).toContain("scoped");
+      expect(manager.listRuntimeKeys().some((key) => key.startsWith("{"))).toBe(false);
+      expect(manager.listRuntimeKeys()).toEqual(["session-revoke"]);
+      // Static part still works.
+      const catalog = await after.getCatalog();
+      expect(Object.keys(catalog.servers)).toEqual(["bundleProbe"]);
+
+      await manager.disposeAll();
+    });
+  });
+
+  it("serializes disposeSession with in-flight requester resolve", async () => {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      let releaseResolve: (() => void) | undefined;
+      const gate = new Promise<void>((resolve) => {
+        releaseResolve = resolve;
+      });
+
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
+        serverName: "user-mail",
+        resolve: async () => {
+          await gate;
+          return { url: "https://mcp.example.test/user" };
+        },
+      });
+
+      const createRuntime: RuntimeFactory = makeManagedRuntime;
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const pending = manager.getOrCreate({
+        sessionId: "session-race-dispose",
+        workspaceDir: "/workspace",
+        cfg: {
+          mcp: {
+            servers: {
+              shared: { command: "true" },
+              "user-mail": { transport: "streamable-http" },
+            },
+          },
+        } as never,
+        requesterSenderId: "sender-a",
+        messageChannel: "telegram",
+      });
+
+      // Static may install; dispose is chained after the exclusive requester section.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 20);
+      });
+      const disposePromise = manager.disposeSession("session-race-dispose");
+      releaseResolve?.();
+      await pending;
+      await disposePromise;
+      expect(manager.listRuntimeKeys()).toEqual([]);
+      expect(testing.getBookkeepingSizes(manager).runtimeWorkChains).toBe(0);
+
+      await manager.disposeAll();
+    });
   });
 
   it("serializes concurrent requester installs so the last resolution wins", async () => {
-    let call = 0;
-    let clock = 0;
-    let releaseFirst: (() => void) | undefined;
-    const firstGate = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
-    const { hashMcpResolvedConnections, testing: resolverTesting } =
-      await import("./mcp-connection-resolver.js");
-    // Tiny revalidate window; monotonic clock advances every now() so the next
-    // exclusive section is past the window and re-resolves.
-    resolverTesting.setMcpConnectionRevalidateMsForTest(1);
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      let call = 0;
+      let clock = 0;
+      let releaseFirst: (() => void) | undefined;
+      const firstGate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const { hashMcpResolvedConnections } = await import("./mcp-connection-resolver.js");
+      // Advance the injected clock past the documented five-minute window for
+      // each queued installation without advancing transport timers.
+
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async () => {
           call += 1;
@@ -4421,96 +4454,99 @@ describe("requester-scoped MCP connection resolution", () => {
             headers: { Authorization: `Bearer ${token}` },
           };
         },
-      },
-    ]);
+      });
 
-    const builtHashes: string[] = [];
-    const createRuntime: RuntimeFactory = (params) => {
-      if (params.connectionOverrides) {
-        builtHashes.push(hashMcpResolvedConnections(params.connectionOverrides));
-      }
-      return makeManagedRuntime(params);
-    };
-    const manager = createSessionMcpRuntimeManager({
-      createRuntime,
-      now: () => {
-        clock += 10;
-        return clock;
-      },
-      enableIdleSweepTimer: false,
-    });
-    const cfg = {
-      mcp: {
-        servers: {
-          "user-mail": { transport: "streamable-http" },
+      const builtHashes: string[] = [];
+      const createRuntime: RuntimeFactory = (params) => {
+        if (params.connectionOverrides) {
+          builtHashes.push(hashMcpResolvedConnections(params.connectionOverrides));
+        }
+        return makeManagedRuntime(params);
+      };
+      const manager = createSessionMcpRuntimeManager({
+        createRuntime,
+        now: () => {
+          clock += 300_001;
+          return clock;
         },
-      },
-    };
+        enableIdleSweepTimer: false,
+      });
+      const cfg = {
+        mcp: {
+          servers: {
+            "user-mail": { transport: "streamable-http" },
+          },
+        },
+      };
 
-    const params = makeRequesterParams("session-serialize", cfg as never, "sender-a");
-    const first = manager.getOrCreate(params);
-    await new Promise((resolve) => {
-      setTimeout(resolve, 20);
+      const params = makeRequesterParams("session-serialize", cfg as never, "sender-a");
+      const first = manager.getOrCreate(params);
+      await new Promise((resolve) => {
+        setTimeout(resolve, 20);
+      });
+
+      const second = manager.getOrCreate(params);
+
+      // Second is queued behind the first exclusive section. First installs the first credential, then
+      // second re-resolves the rotated credential and replaces — last serialized resolution wins.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 20);
+      });
+      expect(call).toBe(1);
+      releaseFirst?.();
+      await Promise.all([first, second]);
+
+      expect(call).toBe(2);
+      expect(builtHashes).toHaveLength(2);
+      expect(builtHashes[0]).not.toBe(builtHashes[1]);
+      expect(manager.listRuntimeKeys().filter((key) => key.startsWith("{"))).toHaveLength(1);
+
+      await manager.disposeAll();
+      expect(Object.values(testing.getBookkeepingSizes(manager)).every((n) => n === 0)).toBe(true);
     });
-
-    const second = manager.getOrCreate(params);
-
-    // Second is queued behind the first exclusive section. First installs the first credential, then
-    // second re-resolves the rotated credential and replaces — last serialized resolution wins.
-    await new Promise((resolve) => {
-      setTimeout(resolve, 20);
-    });
-    releaseFirst?.();
-    await Promise.all([first, second]);
-
-    expect(call).toBe(2);
-    expect(builtHashes).toHaveLength(2);
-    expect(builtHashes[0]).not.toBe(builtHashes[1]);
-    expect(manager.listRuntimeKeys().filter((key) => key.startsWith("{"))).toHaveLength(1);
-
-    await manager.disposeAll();
-    expect(Object.values(testing.getBookkeepingSizes(manager)).every((n) => n === 0)).toBe(true);
   });
 
   it("clears internal bookkeeping maps after disposeAll", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async () => ({ url: "https://mcp.example.test/user" }),
-      },
-    ]);
-    const manager = createSessionMcpRuntimeManager({
-      createRuntime: makeManagedRuntime,
-    });
-    await manager.getOrCreate({
-      sessionId: "session-bookkeeping",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: { servers: { "user-mail": { transport: "streamable-http" } } },
-      } as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
-    expect(testing.getBookkeepingSizes(manager).runtimes).toBeGreaterThan(0);
-    await manager.disposeAll();
-    expect(testing.getBookkeepingSizes(manager)).toEqual({
-      runtimes: 0,
-      connectionMeta: 0,
-      runtimeWorkChains: 0,
-      sessionKeys: 0,
-      deferredRetirement: 0,
-      advertisedScopedCatalogs: 0,
+      });
+      const manager = createSessionMcpRuntimeManager({
+        createRuntime: makeManagedRuntime,
+      });
+      await manager.getOrCreate({
+        sessionId: "session-bookkeeping",
+        workspaceDir: "/workspace",
+        cfg: {
+          mcp: { servers: { "user-mail": { transport: "streamable-http" } } },
+        } as never,
+        requesterSenderId: "sender-a",
+        messageChannel: "telegram",
+      });
+      expect(testing.getBookkeepingSizes(manager).runtimes).toBeGreaterThan(0);
+      await manager.disposeAll();
+      expect(testing.getBookkeepingSizes(manager)).toEqual({
+        runtimes: 0,
+        connectionMeta: 0,
+        runtimeWorkChains: 0,
+        sessionKeys: 0,
+        deferredRetirement: 0,
+        advertisedScopedCatalogs: 0,
+      });
     });
   });
 
   it("revalidates credentials past the revalidation window without rebuilding on unchanged hash", async () => {
-    let resolveCalls = 0;
-    let token = "test-auth-token";
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpConnectionRevalidateMsForTest(1_000);
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      let resolveCalls = 0;
+      let token = "test-auth-token";
+
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async () => {
           resolveCalls += 1;
@@ -4519,229 +4555,232 @@ describe("requester-scoped MCP connection resolution", () => {
             headers: { Authorization: `Bearer ${token}` },
           };
         },
-      },
-    ]);
+      });
 
-    let nowMs = 10_000;
-    let createCount = 0;
-    const createRuntime: RuntimeFactory = (params) => {
-      createCount += 1;
-      return makeManagedRuntime(params);
-    };
-    const manager = createSessionMcpRuntimeManager({
-      createRuntime,
-      now: () => nowMs,
-      enableIdleSweepTimer: false,
-    });
-    const cfg = {
-      mcp: {
-        servers: {
-          "user-mail": { transport: "streamable-http" },
-        },
-      },
-    };
-
-    const params = makeRequesterParams("session-revalidate", cfg as never, "sender-a");
-    await manager.getOrCreate(params);
-    expect(resolveCalls).toBe(1);
-    expect(createCount).toBe(2); // empty static + requester
-
-    // Within revalidation window: no resolver call.
-    nowMs += 500;
-    await manager.getOrCreate(params);
-    expect(resolveCalls).toBe(1);
-    expect(createCount).toBe(2);
-
-    // Past window, unchanged credentials: resolve once, no rebuild.
-    nowMs += 1_000;
-    await manager.getOrCreate(params);
-    expect(resolveCalls).toBe(2);
-    expect(createCount).toBe(2);
-
-    // Past window with rotated header: rebuild requester runtime.
-    token = "secret-token";
-    nowMs += 1_000;
-    await manager.getOrCreate(params);
-    expect(resolveCalls).toBe(3);
-    expect(createCount).toBe(3);
-
-    await manager.disposeAll();
-  });
-
-  it("uses full-set safe names independent of which servers resolve", async () => {
-    const { assignSafeServerNames } = await import("./agent-bundle-mcp-names.js");
-    const fullSet = assignSafeServerNames(["mail.prod", "mail-prod", "shared"]);
-    // Declaration order: mail.prod declared first claims the unsuffixed base,
-    // matching legacy collision ownership for existing configs.
-    expect(fullSet.get("mail.prod")).toBe("mail-prod");
-    expect(fullSet.get("mail-prod")).toBe("mail-prod-2");
-    expect(fullSet.get("shared")).toBe("shared");
-
-    let resolveBoth = true;
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
-        serverName: "mail-prod",
-        resolve: async () => (resolveBoth ? { url: "https://mcp.example.test/mail-prod" } : null),
-      },
-    ]);
-
-    const passedMaps: Array<ReadonlyMap<string, string> | undefined> = [];
-    const createRuntime: RuntimeFactory = (params) => {
-      passedMaps.push(params.safeServerNamesByServer);
-      const isScoped = Boolean(params.requesterScope);
-      const serverName = isScoped ? "mail-prod" : "mail.prod";
-      const safe = params.safeServerNamesByServer?.get(serverName) ?? serverName;
-      return {
-        ...makeManagedRuntime(params, [{ toolName: "send", description: "send" }], serverName),
-        getCatalog: async () => ({
-          version: 1,
-          generatedAt: 0,
-          servers: {
-            [serverName]: {
-              serverName,
-              safeServerName: safe,
-              launchSummary: serverName,
-              toolCount: 1,
-            },
-          },
-          tools: [
-            {
-              serverName,
-              safeServerName: safe,
-              toolName: "send",
-              inputSchema: { type: "object", properties: {} },
-              fallbackDescription: "send",
-            },
-          ],
-          policyTools: [
-            {
-              serverName,
-              safeServerName: safe,
-              toolName: "send",
-              inputSchema: { type: "object", properties: {} },
-              fallbackDescription: "send",
-            },
-            {
-              serverName,
-              safeServerName: safe,
-              toolName: "delete",
-              inputSchema: { type: "object", properties: {} },
-              fallbackDescription: "delete",
-              excludedFromOpenClawCatalog: true,
-            },
-          ],
-        }),
+      let nowMs = 10_000;
+      let createCount = 0;
+      const createRuntime: RuntimeFactory = (params) => {
+        createCount += 1;
+        return makeManagedRuntime(params);
       };
-    };
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const cfg = {
-      mcp: {
-        servers: {
-          "mail.prod": { command: "true" },
-          "mail-prod": { transport: "streamable-http" },
-        },
-      },
-    };
-
-    const runtimeA = await manager.getOrCreate(
-      makeRequesterParams("session-safe-names", cfg as never, "sender-a"),
-    );
-    resolveBoth = false;
-    const runtimeB = await manager.getOrCreate(
-      makeRequesterParams("session-safe-names", cfg as never, "sender-b"),
-    );
-
-    // Every create for this session received the same full-set assignments;
-    // declaration order gives "mail.prod" (declared first) the unsuffixed base.
-    expect(passedMaps.length).toBeGreaterThan(1);
-    for (const map of passedMaps) {
-      expect(map?.get("mail.prod")).toBe("mail-prod");
-      expect(map?.get("mail-prod")).toBe("mail-prod-2");
-    }
-
-    const catalogA = await runtimeA.getCatalog();
-    const catalogB = await runtimeB.getCatalog();
-    expect(catalogA.servers["mail.prod"]?.safeServerName).toBe("mail-prod");
-    // B may only have static part if scoped omitted; shared names still match full-set map.
-    if (catalogA.servers["mail-prod"]) {
-      expect(catalogA.servers["mail-prod"]?.safeServerName).toBe("mail-prod-2");
-    }
-    expect(catalogB.servers["mail.prod"]?.safeServerName).toBe("mail-prod");
-
-    // Merge preserves precomputed names (no further re-suffix).
-    const merged = testing.mergeMcpToolCatalogs([catalogA, catalogB]);
-    expect(merged.servers["mail.prod"]?.safeServerName).toBe("mail-prod");
-    expect(
-      new Set(
-        merged.policyTools
-          ?.filter((tool) => tool.toolName === "delete")
-          .map((tool) => tool.safeServerName),
-      ),
-    ).toEqual(new Set(["mail-prod", "mail-prod-2"]));
-
-    await manager.disposeAll();
-  });
-
-  it("reconciles a stale bare runtime when every server becomes requester-scoped", async () => {
-    const disposed: string[] = [];
-    const createRuntime: RuntimeFactory = (params) => ({
-      ...makeManagedRuntime(params),
-      dispose: async () => {
-        disposed.push(
-          params.includeServerNames
-            ? `include:${[...params.includeServerNames].toSorted().join(",") || "empty"}`
-            : "full",
-        );
-      },
-    });
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-
-    // No resolver yet: bare session runtime owns the only server.
-    await manager.getOrCreate({
-      sessionId: "session-stale-bare",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            "user-mail": { command: "true" },
-          },
-        },
-      } as never,
-    });
-    expect(manager.listRuntimeKeys()).toEqual(["session-stale-bare"]);
-    expect(manager.peekSession({ sessionId: "session-stale-bare" })).toBeDefined();
-
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
-        serverName: "user-mail",
-        resolve: async () => ({ url: "https://mcp.example.test/user" }),
-      },
-    ]);
-
-    await manager.getOrCreate({
-      sessionId: "session-stale-bare",
-      workspaceDir: "/workspace",
-      cfg: {
+      const manager = createSessionMcpRuntimeManager({
+        createRuntime,
+        now: () => nowMs,
+        enableIdleSweepTimer: false,
+      });
+      const cfg = {
         mcp: {
           servers: {
             "user-mail": { transport: "streamable-http" },
           },
         },
-      } as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
+      };
+
+      const params = makeRequesterParams("session-revalidate", cfg as never, "sender-a");
+      await manager.getOrCreate(params);
+      expect(resolveCalls).toBe(1);
+      expect(createCount).toBe(2); // empty static + requester
+
+      // Within revalidation window: no resolver call.
+      nowMs += 299_999;
+      await manager.getOrCreate(params);
+      expect(resolveCalls).toBe(1);
+      expect(createCount).toBe(2);
+
+      // Past window, unchanged credentials: resolve once, no rebuild.
+      nowMs += 1;
+      await manager.getOrCreate(params);
+      expect(resolveCalls).toBe(2);
+      expect(createCount).toBe(2);
+
+      // Past window with rotated header: rebuild requester runtime.
+      token = "secret-token";
+      nowMs += 300_000;
+      await manager.getOrCreate(params);
+      expect(resolveCalls).toBe(3);
+      expect(createCount).toBe(3);
+
+      await manager.disposeAll();
     });
+  });
 
-    // Stale bare runtime is disposed and replaced by the empty static entry.
-    expect(disposed).toContain("full");
-    expect(manager.peekSession({ sessionId: "session-stale-bare" })).toBeDefined();
-    const bare = manager.peekSession({ sessionId: "session-stale-bare" });
-    expect(bare?.requesterScope).toBeUndefined();
-    expect(manager.listRuntimeKeys().some((key) => key.startsWith("{"))).toBe(true);
+  it("uses full-set safe names independent of which servers resolve", async () => {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const { assignSafeServerNames } = await import("./agent-bundle-mcp-names.js");
+      const fullSet = assignSafeServerNames(["mail.prod", "mail-prod", "shared"]);
+      // Declaration order: mail.prod declared first claims the unsuffixed base,
+      // matching legacy collision ownership for existing configs.
+      expect(fullSet.get("mail.prod")).toBe("mail-prod");
+      expect(fullSet.get("mail-prod")).toBe("mail-prod-2");
+      expect(fullSet.get("shared")).toBe("shared");
 
-    await manager.disposeAll();
+      let resolveBoth = true;
+
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
+        serverName: "mail-prod",
+        resolve: async () => (resolveBoth ? { url: "https://mcp.example.test/mail-prod" } : null),
+      });
+
+      const passedMaps: Array<ReadonlyMap<string, string> | undefined> = [];
+      const createRuntime: RuntimeFactory = (params) => {
+        passedMaps.push(params.safeServerNamesByServer);
+        const isScoped = Boolean(params.requesterScope);
+        const serverName = isScoped ? "mail-prod" : "mail.prod";
+        const safe = params.safeServerNamesByServer?.get(serverName) ?? serverName;
+        return {
+          ...makeManagedRuntime(params, [{ toolName: "send", description: "send" }], serverName),
+          getCatalog: async () => ({
+            version: 1,
+            generatedAt: 0,
+            servers: {
+              [serverName]: {
+                serverName,
+                safeServerName: safe,
+                launchSummary: serverName,
+                toolCount: 1,
+              },
+            },
+            tools: [
+              {
+                serverName,
+                safeServerName: safe,
+                toolName: "send",
+                inputSchema: { type: "object", properties: {} },
+                fallbackDescription: "send",
+              },
+            ],
+            policyTools: [
+              {
+                serverName,
+                safeServerName: safe,
+                toolName: "send",
+                inputSchema: { type: "object", properties: {} },
+                fallbackDescription: "send",
+              },
+              {
+                serverName,
+                safeServerName: safe,
+                toolName: "delete",
+                inputSchema: { type: "object", properties: {} },
+                fallbackDescription: "delete",
+                excludedFromOpenClawCatalog: true,
+              },
+            ],
+          }),
+        };
+      };
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const cfg = {
+        mcp: {
+          servers: {
+            "mail.prod": { command: "true" },
+            "mail-prod": { transport: "streamable-http" },
+          },
+        },
+      };
+
+      const runtimeA = await manager.getOrCreate(
+        makeRequesterParams("session-safe-names", cfg as never, "sender-a"),
+      );
+      resolveBoth = false;
+      const runtimeB = await manager.getOrCreate(
+        makeRequesterParams("session-safe-names", cfg as never, "sender-b"),
+      );
+
+      // Every create for this session received the same full-set assignments;
+      // declaration order gives "mail.prod" (declared first) the unsuffixed base.
+      expect(passedMaps.length).toBeGreaterThan(1);
+      for (const map of passedMaps) {
+        expect(map?.get("mail.prod")).toBe("mail-prod");
+        expect(map?.get("mail-prod")).toBe("mail-prod-2");
+      }
+
+      const catalogA = await runtimeA.getCatalog();
+      const catalogB = await runtimeB.getCatalog();
+      expect(catalogA.servers["mail.prod"]?.safeServerName).toBe("mail-prod");
+      // B may only have static part if scoped omitted; shared names still match full-set map.
+      if (catalogA.servers["mail-prod"]) {
+        expect(catalogA.servers["mail-prod"]?.safeServerName).toBe("mail-prod-2");
+      }
+      expect(catalogB.servers["mail.prod"]?.safeServerName).toBe("mail-prod");
+
+      // Merge preserves precomputed names (no further re-suffix).
+      const merged = testing.mergeMcpToolCatalogs([catalogA, catalogB]);
+      expect(merged.servers["mail.prod"]?.safeServerName).toBe("mail-prod");
+      expect(
+        new Set(
+          merged.policyTools
+            ?.filter((tool) => tool.toolName === "delete")
+            .map((tool) => tool.safeServerName),
+        ),
+      ).toEqual(new Set(["mail-prod", "mail-prod-2"]));
+
+      await manager.disposeAll();
+    });
+  });
+
+  it("reconciles a stale bare runtime when every server becomes requester-scoped", async () => {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const disposed: string[] = [];
+      const createRuntime: RuntimeFactory = (params) => ({
+        ...makeManagedRuntime(params),
+        dispose: async () => {
+          disposed.push(
+            params.includeServerNames
+              ? `include:${[...params.includeServerNames].toSorted().join(",") || "empty"}`
+              : "full",
+          );
+        },
+      });
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+
+      // No resolver yet: bare session runtime owns the only server.
+      await manager.getOrCreate({
+        sessionId: "session-stale-bare",
+        workspaceDir: "/workspace",
+        cfg: {
+          mcp: {
+            servers: {
+              "user-mail": { command: "true" },
+            },
+          },
+        } as never,
+      });
+      expect(manager.listRuntimeKeys()).toEqual(["session-stale-bare"]);
+      expect(manager.peekSession({ sessionId: "session-stale-bare" })).toBeDefined();
+
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
+        serverName: "user-mail",
+        resolve: async () => ({ url: "https://mcp.example.test/user" }),
+      });
+
+      await manager.getOrCreate({
+        sessionId: "session-stale-bare",
+        workspaceDir: "/workspace",
+        cfg: {
+          mcp: {
+            servers: {
+              "user-mail": { transport: "streamable-http" },
+            },
+          },
+        } as never,
+        requesterSenderId: "sender-a",
+        messageChannel: "telegram",
+      });
+
+      // Stale bare runtime is disposed and replaced by the empty static entry.
+      expect(disposed).toContain("full");
+      expect(manager.peekSession({ sessionId: "session-stale-bare" })).toBeDefined();
+      const bare = manager.peekSession({ sessionId: "session-stale-bare" });
+      expect(bare?.requesterScope).toBeUndefined();
+      expect(manager.listRuntimeKeys().some((key) => key.startsWith("{"))).toBe(true);
+
+      await manager.disposeAll();
+    });
   });
 
   it("does not put resolved URLs into catalog descriptions for overridden servers", async () => {
@@ -4783,419 +4822,433 @@ describe("requester-scoped MCP connection resolution", () => {
   });
 
   it("preserves active leases on requester-scoped runtimes when retiring a session", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async () => ({ url: "https://mcp.example.test/user" }),
-      },
-    ]);
+      });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-lease-scoped",
-      sessionKey: "agent:test:session-lease-scoped",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            "user-mail": { transport: "streamable-http" },
+      const runtime = await getOrCreateSessionMcpRuntime({
+        sessionId: "session-lease-scoped",
+        sessionKey: "agent:test:session-lease-scoped",
+        workspaceDir: "/workspace",
+        cfg: {
+          mcp: {
+            servers: {
+              "user-mail": { transport: "streamable-http" },
+            },
           },
         },
-      },
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
+        requesterSenderId: "sender-a",
+        messageChannel: "telegram",
+      });
+      // Returned runtime is the scoped part; bare empty runtime has zero leases.
+      expect(runtime.requesterScope?.requesterSenderId).toBe("sender-a");
+      const release = runtime.acquireLease?.();
+      expect(runtime.activeLeases).toBeGreaterThan(0);
+
+      await expect(
+        retireSessionMcpRuntime({
+          sessionId: "session-lease-scoped",
+          reason: "test-preserve-scoped-lease",
+          preserveActiveLeases: true,
+        }),
+      ).resolves.toBe(true);
+      expect(testing.getCachedSessionIds()).toContain("session-lease-scoped");
+      expect(testing.getCachedRuntimeKeys().some((key) => key.startsWith("{"))).toBe(true);
+
+      release?.();
+      await completeDeferredSessionMcpRuntimeRetirement(runtime);
+      expect(testing.getCachedSessionIds()).not.toContain("session-lease-scoped");
     });
-    // Returned runtime is the scoped part; bare empty runtime has zero leases.
-    expect(runtime.requesterScope?.requesterSenderId).toBe("sender-a");
-    const release = runtime.acquireLease?.();
-    expect(runtime.activeLeases).toBeGreaterThan(0);
-
-    await expect(
-      retireSessionMcpRuntime({
-        sessionId: "session-lease-scoped",
-        reason: "test-preserve-scoped-lease",
-        preserveActiveLeases: true,
-      }),
-    ).resolves.toBe(true);
-    expect(testing.getCachedSessionIds()).toContain("session-lease-scoped");
-    expect(testing.getCachedRuntimeKeys().some((key) => key.startsWith("{"))).toBe(true);
-
-    release?.();
-    await completeDeferredSessionMcpRuntimeRetirement(runtime);
-    expect(testing.getCachedSessionIds()).not.toContain("session-lease-scoped");
   });
 
   it("rebuilds partitions when full-set safe-name assignments change", async () => {
-    const fingerprints: string[] = [];
-    const createRuntime: RuntimeFactory = (params) => {
-      fingerprints.push(params.configFingerprint ?? "");
-      return makeManagedRuntime(params);
-    };
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const fingerprints: string[] = [];
+      const createRuntime: RuntimeFactory = (params) => {
+        fingerprints.push(params.configFingerprint ?? "");
+        return makeManagedRuntime(params);
+      };
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "mail-prod",
         resolve: async () => ({ url: "https://mcp.example.test/mail" }),
-      },
-    ]);
+      });
 
-    await manager.getOrCreate({
-      sessionId: "session-fp-safe",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            "mail.prod": { command: "true" },
-            "mail-prod": { transport: "streamable-http" },
+      await manager.getOrCreate({
+        sessionId: "session-fp-safe",
+        workspaceDir: "/workspace",
+        cfg: {
+          mcp: {
+            servers: {
+              "mail.prod": { command: "true" },
+              "mail-prod": { transport: "streamable-http" },
+            },
           },
-        },
-      } as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
-    const afterFirst = fingerprints.length;
-    expect(afterFirst).toBeGreaterThanOrEqual(2);
+        } as never,
+        requesterSenderId: "sender-a",
+        messageChannel: "telegram",
+      });
+      const afterFirst = fingerprints.length;
+      expect(afterFirst).toBeGreaterThanOrEqual(2);
 
-    await manager.getOrCreate({
-      sessionId: "session-fp-safe",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            "mail.prod": { command: "true" },
-            "mail-prod": { transport: "streamable-http" },
-            // New colliding base changes full-set safe-name assignments.
-            mail_prod: { command: "true" },
+      await manager.getOrCreate({
+        sessionId: "session-fp-safe",
+        workspaceDir: "/workspace",
+        cfg: {
+          mcp: {
+            servers: {
+              "mail.prod": { command: "true" },
+              "mail-prod": { transport: "streamable-http" },
+              // New colliding base changes full-set safe-name assignments.
+              mail_prod: { command: "true" },
+            },
           },
-        },
-      } as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
-    expect(fingerprints.length).toBeGreaterThan(afterFirst);
-    // New partition fingerprints differ from the first create batch.
-    expect(
-      fingerprints.slice(afterFirst).some((fp) => !fingerprints.slice(0, afterFirst).includes(fp)),
-    ).toBe(true);
+        } as never,
+        requesterSenderId: "sender-a",
+        messageChannel: "telegram",
+      });
+      expect(fingerprints.length).toBeGreaterThan(afterFirst);
+      // New partition fingerprints differ from the first create batch.
+      expect(
+        fingerprints
+          .slice(afterFirst)
+          .some((fp) => !fingerprints.slice(0, afterFirst).includes(fp)),
+      ).toBe(true);
 
-    await manager.disposeAll();
+      await manager.disposeAll();
+    });
   });
 
   it("rejects anonymous requester identities before touching existing requester state", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async (ctx) => ({
           url: `https://mcp.example.test/${ctx.requesterSenderId}`,
         }),
-      },
-    ]);
-    const created: Array<{
-      requesterScope?: SessionMcpRuntime["requesterScope"];
-      include?: string[];
-      exclude?: string[];
-    }> = [];
-    const dispose = vi.fn(async () => {});
-    let nowMs = 100_000;
-    const createRuntime: RuntimeFactory = (params) => {
-      const createdAt = nowMs;
-      created.push({
-        requesterScope: params.requesterScope,
-        include: params.includeServerNames ? [...params.includeServerNames] : undefined,
-        exclude: params.excludeServerNames ? [...params.excludeServerNames] : undefined,
       });
-      return {
-        ...makeManagedRuntime(params, [{ toolName: "probe", description: "probe" }], "user-mail"),
-        get lastUsedAt() {
-          return createdAt;
-        },
-        markUsed: () => {},
-        dispose,
+      const created: Array<{
+        requesterScope?: SessionMcpRuntime["requesterScope"];
+        include?: string[];
+        exclude?: string[];
+      }> = [];
+      const dispose = vi.fn(async () => {});
+      let nowMs = 100_000;
+      const createRuntime: RuntimeFactory = (params) => {
+        const createdAt = nowMs;
+        created.push({
+          requesterScope: params.requesterScope,
+          include: params.includeServerNames ? [...params.includeServerNames] : undefined,
+          exclude: params.excludeServerNames ? [...params.excludeServerNames] : undefined,
+        });
+        return {
+          ...makeManagedRuntime(params, [{ toolName: "probe", description: "probe" }], "user-mail"),
+          get lastUsedAt() {
+            return createdAt;
+          },
+          markUsed: () => {},
+          dispose,
+        };
       };
-    };
-    const now = vi.fn(() => nowMs);
-    const manager = createSessionMcpRuntimeManager({ createRuntime, now });
-    const cfg = {
-      mcp: {
-        servers: {
-          shared: { command: "true" },
-          "user-mail": { transport: "streamable-http" },
+      const now = vi.fn(() => nowMs);
+      const manager = createSessionMcpRuntimeManager({ createRuntime, now });
+      const cfg = {
+        mcp: {
+          servers: {
+            shared: { command: "true" },
+            "user-mail": { transport: "streamable-http" },
+          },
         },
-      },
-    };
+      };
 
-    const sessionId = "session-scoped-only";
-    const sessionKey = "agent:main:session-scoped-only";
-    const scoped = await manager.getOrCreateRequesterScoped(
-      makeRequesterParams(sessionId, cfg as never, "sender-a", { sessionKey }),
-    );
-    expect(scoped?.runtime.requesterScope?.requesterSenderId).toBe("sender-a");
-    await vi.waitFor(() => expect(testing.getBookkeepingSizes(manager).runtimeWorkChains).toBe(0));
-    const runtimeKeys = manager.listRuntimeKeys();
-    const bookkeeping = testing.getBookkeepingSizes(manager);
-    expect(runtimeKeys).toHaveLength(1);
-    expect(runtimeKeys[0]).toMatch(/^\{/);
-    expect(manager.resolveSessionId(sessionKey)).toBe(sessionId);
-    expect(created).toHaveLength(1);
-    expect(bookkeeping).toMatchObject({
-      runtimes: 1,
-      connectionMeta: 1,
-      runtimeWorkChains: 0,
-      sessionKeys: 1,
-    });
-
-    now.mockClear();
-    nowMs += 10 * 60 * 1000 + 1;
-    for (const [requesterSenderId, attemptedSessionId] of [
-      [undefined, "session-missing"],
-      ["  ", "session-blank"],
-      [null, "session-null"],
-    ] as const) {
-      await expect(
-        manager.getOrCreateRequesterScoped({
-          sessionId: attemptedSessionId,
-          sessionKey,
-          requesterSenderId,
-          workspaceDir: "/workspace",
-          cfg: cfg as never,
-        }),
-      ).resolves.toBeUndefined();
+      const sessionId = "session-scoped-only";
+      const sessionKey = "agent:main:session-scoped-only";
+      const scoped = await manager.getOrCreateRequesterScoped(
+        makeRequesterParams(sessionId, cfg as never, "sender-a", { sessionKey }),
+      );
+      expect(scoped?.runtime.requesterScope?.requesterSenderId).toBe("sender-a");
+      await vi.waitFor(() =>
+        expect(testing.getBookkeepingSizes(manager).runtimeWorkChains).toBe(0),
+      );
+      const runtimeKeys = manager.listRuntimeKeys();
+      const bookkeeping = testing.getBookkeepingSizes(manager);
+      expect(runtimeKeys).toHaveLength(1);
+      expect(runtimeKeys[0]).toMatch(/^\{/);
       expect(manager.resolveSessionId(sessionKey)).toBe(sessionId);
-    }
+      expect(created).toHaveLength(1);
+      expect(bookkeeping).toMatchObject({
+        runtimes: 1,
+        connectionMeta: 1,
+        runtimeWorkChains: 0,
+        sessionKeys: 1,
+      });
 
-    expect(now).not.toHaveBeenCalled();
-    expect(dispose).not.toHaveBeenCalled();
-    expect(manager.listRuntimeKeys()).toEqual(runtimeKeys);
-    expect(testing.getBookkeepingSizes(manager)).toEqual(bookkeeping);
-    // The existing requester partition remains the only runtime; no static or
-    // anonymous replacement runtime was created.
-    expect(created).toEqual([
-      {
-        requesterScope: {
-          requesterSenderId: "sender-a",
-          messageChannel: "telegram",
+      now.mockClear();
+      nowMs += 10 * 60 * 1000 + 1;
+      for (const [requesterSenderId, attemptedSessionId] of [
+        [undefined, "session-missing"],
+        ["  ", "session-blank"],
+        [null, "session-null"],
+      ] as const) {
+        await expect(
+          manager.getOrCreateRequesterScoped({
+            sessionId: attemptedSessionId,
+            sessionKey,
+            requesterSenderId,
+            workspaceDir: "/workspace",
+            cfg: cfg as never,
+          }),
+        ).resolves.toBeUndefined();
+        expect(manager.resolveSessionId(sessionKey)).toBe(sessionId);
+      }
+
+      expect(now).not.toHaveBeenCalled();
+      expect(dispose).not.toHaveBeenCalled();
+      expect(manager.listRuntimeKeys()).toEqual(runtimeKeys);
+      expect(testing.getBookkeepingSizes(manager)).toEqual(bookkeeping);
+      // The existing requester partition remains the only runtime; no static or
+      // anonymous replacement runtime was created.
+      expect(created).toEqual([
+        {
+          requesterScope: {
+            requesterSenderId: "sender-a",
+            messageChannel: "telegram",
+          },
+          include: ["user-mail"],
+          exclude: undefined,
         },
-        include: ["user-mail"],
-        exclude: undefined,
-      },
-    ]);
+      ]);
 
-    await manager.disposeAll();
+      await manager.disposeAll();
+    });
   });
 
   it("reuses one requester runtime across full and requester-only entrypoints", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    let resolveCount = 0;
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      let resolveCount = 0;
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async (ctx) => {
           resolveCount += 1;
           return { url: `https://mcp.example.test/${ctx.requesterSenderId}` };
         },
-      },
-    ]);
-    const createRuntime: RuntimeFactory = (params) =>
-      makeManagedRuntime(params, [{ toolName: "probe", description: "probe" }], "user-mail");
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const cfg = {
-      mcp: {
-        servers: {
-          "user-mail": { transport: "streamable-http" },
+      });
+      const createRuntime: RuntimeFactory = (params) =>
+        makeManagedRuntime(params, [{ toolName: "probe", description: "probe" }], "user-mail");
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const cfg = {
+        mcp: {
+          servers: {
+            "user-mail": { transport: "streamable-http" },
+          },
         },
-      },
-    };
+      };
 
-    const params = makeRequesterParams("session-reuse", cfg as never, "sender-a");
-    const full = await manager.getOrCreate(params);
-    const fullRuntimeKey = manager.listRuntimeKeys().find((key) => key.startsWith("{"));
-    const requesterOnly = await manager.getOrCreateRequesterScoped(params);
-    const requesterOnlyRuntimeKey = manager.listRuntimeKeys().find((key) => key.startsWith("{"));
-    expect(requesterOnly?.runtime).toBe(full);
-    expect(resolveCount).toBe(1);
-    expect(requesterOnlyRuntimeKey).toBe(fullRuntimeKey);
-    expect(requesterOnly?.runtime.configFingerprint).toBe(full.configFingerprint);
-    expect(manager.listRuntimeKeys()).toHaveLength(2);
+      const params = makeRequesterParams("session-reuse", cfg as never, "sender-a");
+      const full = await manager.getOrCreate(params);
+      const fullRuntimeKey = manager.listRuntimeKeys().find((key) => key.startsWith("{"));
+      const requesterOnly = await manager.getOrCreateRequesterScoped(params);
+      const requesterOnlyRuntimeKey = manager.listRuntimeKeys().find((key) => key.startsWith("{"));
+      expect(requesterOnly?.runtime).toBe(full);
+      expect(resolveCount).toBe(1);
+      expect(requesterOnlyRuntimeKey).toBe(fullRuntimeKey);
+      expect(requesterOnly?.runtime.configFingerprint).toBe(full.configFingerprint);
+      expect(manager.listRuntimeKeys()).toHaveLength(2);
 
-    await manager.disposeAll();
+      await manager.disposeAll();
+    });
   });
 
   it("keeps advertised scoped catalog stable across senders and clears on dispose", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async (ctx) =>
           ctx.requesterSenderId === "authed" ? { url: "https://mcp.example.test/authed" } : null,
-      },
-    ]);
-    const createRuntime: RuntimeFactory = (params) =>
-      makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const cfg = {
-      mcp: {
-        servers: {
-          "user-mail": { transport: "streamable-http" },
+      });
+      const createRuntime: RuntimeFactory = (params) =>
+        makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const cfg = {
+        mcp: {
+          servers: {
+            "user-mail": { transport: "streamable-http" },
+          },
         },
-      },
-    };
+      };
 
-    expect(manager.getAdvertisedScopedCatalog("session-adv")).toBeNull();
+      expect(manager.getAdvertisedScopedCatalog("session-adv")).toBeNull();
 
-    const authed = await manager.getOrCreateRequesterScoped(
-      makeRequesterParams("session-adv", cfg as never, "authed"),
-    );
-    expect(authed).toBeDefined();
-    const catalog = await authed!.runtime.getCatalog();
-    manager.rememberAdvertisedScopedCatalog(authed!, catalog);
+      const authed = await manager.getOrCreateRequesterScoped(
+        makeRequesterParams("session-adv", cfg as never, "authed"),
+      );
+      expect(authed).toBeDefined();
+      const catalog = await authed!.runtime.getCatalog();
+      manager.rememberAdvertisedScopedCatalog(authed!, catalog);
 
-    const advertised = manager.getAdvertisedScopedCatalog("session-adv");
-    expect(advertised?.tools.map((tool) => tool.toolName)).toEqual(["inbox"]);
+      const advertised = manager.getAdvertisedScopedCatalog("session-adv");
+      expect(advertised?.tools.map((tool) => tool.toolName)).toEqual(["inbox"]);
 
-    // Unauthed sender: no runtime, but advertised catalog stays.
-    await expect(
-      manager.getOrCreateRequesterScoped({
-        sessionId: "session-adv",
-        workspaceDir: "/workspace",
-        cfg: cfg as never,
-        requesterSenderId: "guest",
-        messageChannel: "telegram",
-      }),
-    ).resolves.toBeUndefined();
-    expect(manager.getAdvertisedScopedCatalog("session-adv")?.tools.map((t) => t.toolName)).toEqual(
-      ["inbox"],
-    );
+      // Unauthed sender: no runtime, but advertised catalog stays.
+      await expect(
+        manager.getOrCreateRequesterScoped({
+          sessionId: "session-adv",
+          workspaceDir: "/workspace",
+          cfg: cfg as never,
+          requesterSenderId: "guest",
+          messageChannel: "telegram",
+        }),
+      ).resolves.toBeUndefined();
+      expect(
+        manager.getAdvertisedScopedCatalog("session-adv")?.tools.map((t) => t.toolName),
+      ).toEqual(["inbox"]);
 
-    await manager.disposeSession("session-adv");
-    expect(manager.getAdvertisedScopedCatalog("session-adv")).toBeNull();
+      await manager.disposeSession("session-adv");
+      expect(manager.getAdvertisedScopedCatalog("session-adv")).toBeNull();
+    });
   });
 
   it("clears advertised scoped catalog when its MCP config changes", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async () => ({ url: "https://mcp.example.test/authed" }),
-      },
-    ]);
-    const createRuntime: RuntimeFactory = (params) =>
-      makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const cfgA = {
-      mcp: {
-        servers: {
-          "user-mail": { transport: "streamable-http", toolFilter: { include: ["read*"] } },
+      });
+      const createRuntime: RuntimeFactory = (params) =>
+        makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const cfgA = {
+        mcp: {
+          servers: {
+            "user-mail": { transport: "streamable-http", toolFilter: { include: ["read*"] } },
+          },
         },
-      },
-    };
-    const cfgB = {
-      mcp: {
-        servers: {
-          "user-mail": { transport: "streamable-http", toolFilter: { include: ["send*"] } },
+      };
+      const cfgB = {
+        mcp: {
+          servers: {
+            "user-mail": { transport: "streamable-http", toolFilter: { include: ["send*"] } },
+          },
         },
-      },
-    };
+      };
 
-    const runtime = await manager.getOrCreateRequesterScoped(
-      makeRequesterParams("session-adv-config", cfgA as never, "authed"),
-    );
-    manager.rememberAdvertisedScopedCatalog(runtime!, await runtime!.runtime.getCatalog());
-    expect(manager.getAdvertisedScopedCatalog("session-adv-config")?.tools).toHaveLength(1);
+      const runtime = await manager.getOrCreateRequesterScoped(
+        makeRequesterParams("session-adv-config", cfgA as never, "authed"),
+      );
+      manager.rememberAdvertisedScopedCatalog(runtime!, await runtime!.runtime.getCatalog());
+      expect(manager.getAdvertisedScopedCatalog("session-adv-config")?.tools).toHaveLength(1);
 
-    await manager.getOrCreateRequesterScoped(
-      makeRequesterParams("session-adv-config", cfgB as never, "authed"),
-    );
-    expect(manager.getAdvertisedScopedCatalog("session-adv-config")).toBeNull();
+      await manager.getOrCreateRequesterScoped(
+        makeRequesterParams("session-adv-config", cfgB as never, "authed"),
+      );
+      expect(manager.getAdvertisedScopedCatalog("session-adv-config")).toBeNull();
+    });
   });
 
   it("clears advertised scoped catalog when the last scoped server is removed", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async () => ({ url: "https://mcp.example.test/authed" }),
-      },
-    ]);
-    const createRuntime: RuntimeFactory = (params) =>
-      makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const scopedConfig = {
-      mcp: {
-        servers: {
-          "user-mail": { transport: "streamable-http" },
+      });
+      const createRuntime: RuntimeFactory = (params) =>
+        makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const scopedConfig = {
+        mcp: {
+          servers: {
+            "user-mail": { transport: "streamable-http" },
+          },
         },
-      },
-    };
-    const staticConfig = {
-      mcp: {
-        servers: {
-          shared: { command: "true" },
+      };
+      const staticConfig = {
+        mcp: {
+          servers: {
+            shared: { command: "true" },
+          },
         },
-      },
-    };
+      };
 
-    const runtime = await manager.getOrCreateRequesterScoped(
-      makeRequesterParams("session-adv-removal", scopedConfig as never, "authed"),
-    );
-    manager.rememberAdvertisedScopedCatalog(runtime!, await runtime!.runtime.getCatalog());
-    expect(manager.getAdvertisedScopedCatalog("session-adv-removal")?.tools).toHaveLength(1);
+      const runtime = await manager.getOrCreateRequesterScoped(
+        makeRequesterParams("session-adv-removal", scopedConfig as never, "authed"),
+      );
+      manager.rememberAdvertisedScopedCatalog(runtime!, await runtime!.runtime.getCatalog());
+      expect(manager.getAdvertisedScopedCatalog("session-adv-removal")?.tools).toHaveLength(1);
 
-    await expect(
-      manager.getOrCreateRequesterScoped(
-        makeRequesterParams("session-adv-removal", staticConfig as never, "guest"),
-      ),
-    ).resolves.toBeUndefined();
-    expect(manager.getAdvertisedScopedCatalog("session-adv-removal")).toBeNull();
+      await expect(
+        manager.getOrCreateRequesterScoped(
+          makeRequesterParams("session-adv-removal", staticConfig as never, "guest"),
+        ),
+      ).resolves.toBeUndefined();
+      expect(manager.getAdvertisedScopedCatalog("session-adv-removal")).toBeNull();
+    });
   });
 
   it("reconciles cached scoped catalog before a senderless turn", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async () => ({ url: "https://mcp.example.test/authed" }),
-      },
-    ]);
-    const createRuntime: RuntimeFactory = (params) =>
-      makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const scopedConfig = {
-      mcp: { servers: { "user-mail": { transport: "streamable-http" } } },
-    };
-    const staticConfig = {
-      mcp: { servers: { shared: { command: "true" } } },
-    };
+      });
+      const createRuntime: RuntimeFactory = (params) =>
+        makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const scopedConfig = {
+        mcp: { servers: { "user-mail": { transport: "streamable-http" } } },
+      };
+      const staticConfig = {
+        mcp: { servers: { shared: { command: "true" } } },
+      };
 
-    const runtime = await manager.getOrCreateRequesterScoped(
-      makeRequesterParams("session-adv-senderless", scopedConfig as never, "authed"),
-    );
-    manager.rememberAdvertisedScopedCatalog(runtime!, await runtime!.runtime.getCatalog());
+      const runtime = await manager.getOrCreateRequesterScoped(
+        makeRequesterParams("session-adv-senderless", scopedConfig as never, "authed"),
+      );
+      manager.rememberAdvertisedScopedCatalog(runtime!, await runtime!.runtime.getCatalog());
 
-    await expect(
-      manager.getOrCreateRequesterScoped(
-        makeRequesterParams("session-adv-senderless", staticConfig as never, "", {
-          requesterSenderId: undefined,
-        }),
-      ),
-    ).resolves.toBeUndefined();
-    expect(manager.getAdvertisedScopedCatalog("session-adv-senderless")).toBeNull();
+      await expect(
+        manager.getOrCreateRequesterScoped(
+          makeRequesterParams("session-adv-senderless", staticConfig as never, "", {
+            requesterSenderId: undefined,
+          }),
+        ),
+      ).resolves.toBeUndefined();
+      expect(manager.getAdvertisedScopedCatalog("session-adv-senderless")).toBeNull();
+    });
   });
 
   it("rejects a late catalog publication from an older configuration", async () => {
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    let releaseOldResolve!: () => void;
-    const oldResolve = new Promise<void>((resolve) => {
-      releaseOldResolve = resolve;
-    });
-    let markOldStarted!: () => void;
-    const oldStarted = new Promise<void>((resolve) => {
-      markOldStarted = resolve;
-    });
-    let resolveCount = 0;
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      let releaseOldResolve!: () => void;
+      const oldResolve = new Promise<void>((resolve) => {
+        releaseOldResolve = resolve;
+      });
+      let markOldStarted!: () => void;
+      const oldStarted = new Promise<void>((resolve) => {
+        markOldStarted = resolve;
+      });
+      let resolveCount = 0;
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async () => {
           resolveCount += 1;
@@ -5205,138 +5258,140 @@ describe("requester-scoped MCP connection resolution", () => {
           }
           return { url: "https://mcp.example.test/authed" };
         },
-      },
-    ]);
-    const createRuntime: RuntimeFactory = (params) =>
-      makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
-    const manager = createSessionMcpRuntimeManager({ createRuntime });
-    const oldConfig = {
-      mcp: {
-        servers: {
-          "user-mail": { transport: "streamable-http" },
-          shared: { command: "first" },
+      });
+      const createRuntime: RuntimeFactory = (params) =>
+        makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
+      const manager = createSessionMcpRuntimeManager({ createRuntime });
+      const oldConfig = {
+        mcp: {
+          servers: {
+            "user-mail": { transport: "streamable-http" },
+            shared: { command: "first" },
+          },
         },
-      },
-    };
-    const newConfig = {
-      mcp: {
-        servers: {
-          "user-mail": { transport: "streamable-http" },
-          shared: { command: "second" },
+      };
+      const newConfig = {
+        mcp: {
+          servers: {
+            "user-mail": { transport: "streamable-http" },
+            shared: { command: "second" },
+          },
         },
-      },
-    };
+      };
 
-    const oldRequest = manager.getOrCreateRequesterScoped(
-      makeRequesterParams("session-adv-race", oldConfig as never, "same-requester"),
-    );
-    await oldStarted;
-    const newRequest = manager.getOrCreateRequesterScoped(
-      makeRequesterParams("session-adv-race", newConfig as never, "same-requester"),
-    );
-    releaseOldResolve();
-    const oldRuntime = await oldRequest;
-    const newRuntime = await newRequest;
-    expect(newRuntime!.runtime).toBe(oldRuntime!.runtime);
-    manager.rememberAdvertisedScopedCatalog(oldRuntime!, await oldRuntime!.runtime.getCatalog());
-    expect(manager.getAdvertisedScopedCatalog("session-adv-race")).toBeNull();
+      const oldRequest = manager.getOrCreateRequesterScoped(
+        makeRequesterParams("session-adv-race", oldConfig as never, "same-requester"),
+      );
+      await oldStarted;
+      const newRequest = manager.getOrCreateRequesterScoped(
+        makeRequesterParams("session-adv-race", newConfig as never, "same-requester"),
+      );
+      releaseOldResolve();
+      const oldRuntime = await oldRequest;
+      const newRuntime = await newRequest;
+      expect(newRuntime!.runtime).toBe(oldRuntime!.runtime);
+      manager.rememberAdvertisedScopedCatalog(oldRuntime!, await oldRuntime!.runtime.getCatalog());
+      expect(manager.getAdvertisedScopedCatalog("session-adv-race")).toBeNull();
+    });
   });
 
   it(
     "clears removed scoped catalog through the harness after a real MCP transport run",
     { timeout: 15_000 },
     async () => {
-      const server = http.createServer((request, response) => {
-        if (request.method === "DELETE") {
-          response.writeHead(204).end();
-          return;
-        }
-        if (request.method !== "POST") {
-          response.writeHead(405).end();
-          return;
-        }
-        let body = "";
-        request.setEncoding("utf8");
-        request.on("data", (chunk) => {
-          body += chunk;
-        });
-        request.on("end", () => {
-          const message = JSON.parse(body) as { id?: string | number; method?: string };
-          if (message.method === "notifications/initialized") {
-            response.writeHead(202).end();
+      const resolverRegistry = createMcpProofPluginRegistry();
+      await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+        const server = http.createServer((request, response) => {
+          if (request.method === "DELETE") {
+            response.writeHead(204).end();
             return;
           }
-          response.setHeader("content-type", "application/json");
-          response.setHeader("mcp-session-id", "session-proof");
-          response.writeHead(200).end(
-            JSON.stringify(
-              message.method === "initialize"
-                ? {
-                    jsonrpc: "2.0",
-                    id: message.id,
-                    result: {
-                      protocolVersion: "2025-03-26",
-                      capabilities: { tools: {} },
-                      serverInfo: { name: "catalog-proof-server", version: "1.0.0" },
+          if (request.method !== "POST") {
+            response.writeHead(405).end();
+            return;
+          }
+          let body = "";
+          request.setEncoding("utf8");
+          request.on("data", (chunk) => {
+            body += chunk;
+          });
+          request.on("end", () => {
+            const message = JSON.parse(body) as { id?: string | number; method?: string };
+            if (message.method === "notifications/initialized") {
+              response.writeHead(202).end();
+              return;
+            }
+            response.setHeader("content-type", "application/json");
+            response.setHeader("mcp-session-id", "session-proof");
+            response.writeHead(200).end(
+              JSON.stringify(
+                message.method === "initialize"
+                  ? {
+                      jsonrpc: "2.0",
+                      id: message.id,
+                      result: {
+                        protocolVersion: "2025-03-26",
+                        capabilities: { tools: {} },
+                        serverInfo: { name: "catalog-proof-server", version: "1.0.0" },
+                      },
+                    }
+                  : {
+                      jsonrpc: "2.0",
+                      id: message.id,
+                      result: {
+                        tools: [
+                          {
+                            name: "inbox",
+                            description: "read inbox",
+                            inputSchema: { type: "object", properties: {} },
+                          },
+                        ],
+                      },
                     },
-                  }
-                : {
-                    jsonrpc: "2.0",
-                    id: message.id,
-                    result: {
-                      tools: [
-                        {
-                          name: "inbox",
-                          description: "read inbox",
-                          inputSchema: { type: "object", properties: {} },
-                        },
-                      ],
-                    },
-                  },
-            ),
-          );
+              ),
+            );
+          });
         });
-      });
-      await new Promise<void>((resolve) => {
-        server.listen(0, "127.0.0.1", resolve);
-      });
-      const address = server.address() as { port: number };
-      const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-      resolverTesting.setMcpServerConnectionResolversForTest([
-        {
+        await new Promise<void>((resolve) => {
+          server.listen(0, "127.0.0.1", resolve);
+        });
+        const address = server.address() as { port: number };
+
+        const resolverApi = resolverRegistry.apiFor("test-plugin");
+        resolverApi.registerMcpServerConnectionResolver({
           serverName: "user-mail",
           resolve: async () => ({ url: `http://127.0.0.1:${address.port}/mcp` }),
-        },
-      ]);
-      const scopedConfig = {
-        mcp: { servers: { "user-mail": { transport: "streamable-http" } } },
-      };
-      const staticConfig = {
-        mcp: { servers: { shared: { command: "true" } } },
-      };
+        });
+        const scopedConfig = {
+          mcp: { servers: { "user-mail": { transport: "streamable-http" } } },
+        };
+        const staticConfig = {
+          mcp: { servers: { shared: { command: "true" } } },
+        };
 
-      try {
-        const first = await materializeRequesterScopedMcpToolsForHarnessRun({
-          sessionId: "session-harness-removal",
-          workspaceDir: "/workspace",
-          cfg: scopedConfig as never,
-          requesterSenderId: "authed",
-        });
-        expect(first?.advertisedTools.map((tool) => tool.name)).toEqual(["user-mail__inbox"]);
-        await first?.dispose();
+        try {
+          const first = await materializeRequesterScopedMcpToolsForHarnessRun({
+            sessionId: "session-harness-removal",
+            workspaceDir: "/workspace",
+            cfg: scopedConfig as never,
+            requesterSenderId: "authed",
+          });
+          expect(first?.advertisedTools.map((tool) => tool.name)).toEqual(["user-mail__inbox"]);
+          await first?.dispose();
 
-        const afterRemoval = await materializeRequesterScopedMcpToolsForHarnessRun({
-          sessionId: "session-harness-removal",
-          workspaceDir: "/workspace",
-          cfg: staticConfig as never,
-          requesterSenderId: "guest",
-        });
-        expect(afterRemoval).toBeUndefined();
-      } finally {
-        await new Promise<void>((resolve, reject) => {
-          server.close((error) => (error ? reject(error) : resolve()));
-        });
-      }
+          const afterRemoval = await materializeRequesterScopedMcpToolsForHarnessRun({
+            sessionId: "session-harness-removal",
+            workspaceDir: "/workspace",
+            cfg: staticConfig as never,
+            requesterSenderId: "guest",
+          });
+          expect(afterRemoval).toBeUndefined();
+        } finally {
+          await new Promise<void>((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()));
+          });
+        }
+      });
     },
   );
 });

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -1183,10 +1183,6 @@ export const testing = {
     await disposeAllSessionMcpRuntimes();
     setBundleMcpCatalogListTimeoutMsForTest();
     setBundleMcpDisposeTimeoutMsForTest();
-    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
-    resolverTesting.setMcpServerConnectionResolversForTest();
-    resolverTesting.setMcpConnectionResolverTimeoutMsForTest();
-    resolverTesting.setMcpConnectionRevalidateMsForTest();
   },
   getCachedSessionIds() {
     return getSessionMcpRuntimeManagerForTesting().listSessionIds();

--- a/src/agents/codex-mcp-config.test.ts
+++ b/src/agents/codex-mcp-config.test.ts
@@ -4,12 +4,13 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import {
   buildCodexMcpServersConfig,
   loadCodexBundleMcpApprovalConfig,
   loadCodexBundleMcpThreadConfigCore,
 } from "./codex-mcp-config.js";
-import { testing as resolverTesting } from "./mcp-connection-resolver.js";
+import { createMcpProofPluginRegistry } from "./mcp-connection-resolver.test-fixtures.js";
 
 const mocks = vi.hoisted(() => ({
   loadExecApprovalsReadOnly: vi.fn(),
@@ -46,7 +47,6 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
-  resolverTesting.setMcpServerConnectionResolversForTest();
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
 
@@ -378,63 +378,65 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
   });
 
   it("excludes requester-scoped servers from projection and fingerprint", () => {
-    resolverTesting.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    withPluginRuntimeRegistryScope(resolverRegistry.registry, () => {
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async () => ({ url: "https://should-never-project.example/mcp" }),
-      },
-    ]);
-    mocks.bundleMcp = {
-      config: {
-        mcpServers: {
+      });
+      mocks.bundleMcp = {
+        config: {
+          mcpServers: {
+            search: {
+              type: "http",
+              url: "https://mcp.example.com/mcp",
+            },
+            "user-mail": {
+              type: "http",
+              url: "https://unresolved.invalid",
+            },
+          },
+        },
+        diagnostics: [],
+      };
+
+      const loaded = loadCodexBundleMcpThreadConfigCore({
+        workspaceDir: "/workspace",
+        cfg: {},
+        toolsEnabled: true,
+      });
+      // Same static set without a scoped entry must fingerprint identically.
+      mocks.bundleMcp = {
+        config: {
+          mcpServers: {
+            search: {
+              type: "http",
+              url: "https://mcp.example.com/mcp",
+            },
+          },
+        },
+        diagnostics: [],
+      };
+      const withoutScopedConfig = loadCodexBundleMcpThreadConfigCore({
+        workspaceDir: "/workspace",
+        cfg: {},
+        toolsEnabled: true,
+      });
+
+      expect(loaded.configPatch).toEqual({
+        mcp_servers: {
           search: {
-            type: "http",
             url: "https://mcp.example.com/mcp",
           },
-          "user-mail": {
-            type: "http",
-            url: "https://unresolved.invalid",
-          },
         },
-      },
-      diagnostics: [],
-    };
-
-    const loaded = loadCodexBundleMcpThreadConfigCore({
-      workspaceDir: "/workspace",
-      cfg: {},
-      toolsEnabled: true,
+      });
+      expect(JSON.stringify(loaded.configPatch)).not.toContain("unresolved.invalid");
+      expect(JSON.stringify(loaded.configPatch)).not.toContain("user-mail");
+      expect(loaded.configPatch).toEqual(withoutScopedConfig.configPatch);
+      expect(loaded.fingerprint).toBe(withoutScopedConfig.fingerprint);
+      expect(loaded.staticServerNames).toEqual(["search"]);
     });
-    // Same static set without a scoped entry must fingerprint identically.
-    mocks.bundleMcp = {
-      config: {
-        mcpServers: {
-          search: {
-            type: "http",
-            url: "https://mcp.example.com/mcp",
-          },
-        },
-      },
-      diagnostics: [],
-    };
-    const withoutScopedConfig = loadCodexBundleMcpThreadConfigCore({
-      workspaceDir: "/workspace",
-      cfg: {},
-      toolsEnabled: true,
-    });
-
-    expect(loaded.configPatch).toEqual({
-      mcp_servers: {
-        search: {
-          url: "https://mcp.example.com/mcp",
-        },
-      },
-    });
-    expect(JSON.stringify(loaded.configPatch)).not.toContain("unresolved.invalid");
-    expect(JSON.stringify(loaded.configPatch)).not.toContain("user-mail");
-    expect(loaded.configPatch).toEqual(withoutScopedConfig.configPatch);
-    expect(loaded.fingerprint).toBe(withoutScopedConfig.fingerprint);
-    expect(loaded.staticServerNames).toEqual(["search"]);
   });
 
   it("keeps static projection byte-identical when no resolver exists", () => {

--- a/src/agents/mcp-connection-resolver.test-fixtures.ts
+++ b/src/agents/mcp-connection-resolver.test-fixtures.ts
@@ -1,0 +1,24 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginRegistry } from "../plugins/registry.js";
+import type { PluginRuntime } from "../plugins/runtime/types.js";
+import { createPluginRecord } from "../plugins/status.test-fixtures.js";
+
+export function createMcpProofPluginRegistry() {
+  const pluginRegistry = createPluginRegistry({
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    runtime: {} as PluginRuntime,
+    activateGlobalSideEffects: false,
+  });
+
+  return {
+    registry: pluginRegistry.registry,
+    apiFor: (pluginId: string) => {
+      const record = createPluginRecord({
+        id: pluginId,
+        source: `/plugins/${pluginId}/index.ts`,
+      });
+      pluginRegistry.registry.plugins.push(record);
+      return pluginRegistry.createApi(record, { config: {} as OpenClawConfig });
+    },
+  };
+}

--- a/src/agents/mcp-connection-resolver.test.ts
+++ b/src/agents/mcp-connection-resolver.test.ts
@@ -14,11 +14,8 @@ import {
 } from "../infra/restart.js";
 import { isSecretValueRegisteredForRedaction } from "../logging/secret-redaction-registry.js";
 import { isPluginRegistryRetired } from "../plugins/registry-lifecycle.js";
-import { createPluginRegistry } from "../plugins/registry.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
-import type { PluginRuntime } from "../plugins/runtime/types.js";
-import { createPluginRecord } from "../plugins/status.test-fixtures.js";
 import { getOrCreateSessionMcpRuntime } from "./agent-bundle-mcp-manager.test-support.js";
 import { disposeAllSessionMcpRuntimes, peekSessionMcpRuntime } from "./agent-bundle-mcp-tools.js";
 import {
@@ -28,8 +25,8 @@ import {
   partitionMcpServersByConnectionScope,
   redactMcpServersForFingerprint,
   resolveRequesterScopedMcpConnections,
-  testing,
 } from "./mcp-connection-resolver.js";
+import { createMcpProofPluginRegistry } from "./mcp-connection-resolver.test-fixtures.js";
 import { clearCurrentProviderAuthState } from "./model-provider-auth.js";
 import { resetPreparedModelRuntimeSnapshotsForTest } from "./prepared-model-runtime.test-support.js";
 
@@ -149,30 +146,7 @@ async function startAuthenticatedMcpProofServer() {
   };
 }
 
-function createMcpProofPluginRegistry() {
-  const pluginRegistry = createPluginRegistry({
-    logger: { info() {}, warn() {}, error() {}, debug() {} },
-    runtime: {} as PluginRuntime,
-    activateGlobalSideEffects: false,
-  });
-
-  return {
-    registry: pluginRegistry.registry,
-    apiFor: (pluginId: string) => {
-      const record = createPluginRecord({
-        id: pluginId,
-        source: `/plugins/${pluginId}/index.ts`,
-      });
-      pluginRegistry.registry.plugins.push(record);
-      return pluginRegistry.createApi(record, { config: {} as OpenClawConfig });
-    },
-  };
-}
-
 afterEach(() => {
-  testing.setMcpServerConnectionResolversForTest();
-  testing.setMcpConnectionResolverTimeoutMsForTest();
-  testing.setMcpConnectionRevalidateMsForTest();
   resetPluginRuntimeStateForTest();
   vi.useRealTimers();
   vi.restoreAllMocks();
@@ -180,19 +154,21 @@ afterEach(() => {
 
 describe("mcp connection resolver helpers", () => {
   it("partitions static vs requester-scoped servers deterministically", () => {
-    testing.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    withPluginRuntimeRegistryScope(resolverRegistry.registry, () => {
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async () => ({ url: "https://example.test" }),
-      },
-    ]);
-    const { staticServers, requesterScopedServerNames } = partitionMcpServersByConnectionScope({
-      shared: { command: "true" },
-      "user-mail": { transport: "streamable-http" },
-      zebra: { command: "z" },
+      });
+      const { staticServers, requesterScopedServerNames } = partitionMcpServersByConnectionScope({
+        shared: { command: "true" },
+        "user-mail": { transport: "streamable-http" },
+        zebra: { command: "z" },
+      });
+      expect(Object.keys(staticServers)).toEqual(["shared", "zebra"]);
+      expect(requesterScopedServerNames).toEqual(["user-mail"]);
     });
-    expect(Object.keys(staticServers)).toEqual(["shared", "zebra"]);
-    expect(requesterScopedServerNames).toEqual(["user-mail"]);
   });
 
   it("preserves own __proto__ server entries while keeping deterministic order", () => {
@@ -447,140 +423,157 @@ describe("mcp connection resolver helpers", () => {
   });
 
   it("fails closed without requesterSenderId and drops null resolutions", async () => {
-    testing.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async (ctx) =>
           ctx.requesterSenderId === "ok" ? { url: "https://example.test/ok" } : null,
-      },
-    ]);
-    await expect(
-      resolveRequesterScopedMcpConnections({
-        serverNames: ["user-mail"],
-      }),
-    ).resolves.toEqual(new Map());
-    await expect(
-      resolveRequesterScopedMcpConnections({
-        serverNames: ["user-mail"],
-        requesterSenderId: "nope",
-      }),
-    ).resolves.toEqual(new Map());
-    await expect(
-      resolveRequesterScopedMcpConnections({
-        serverNames: ["user-mail"],
-        requesterSenderId: "ok",
-      }),
-    ).resolves.toEqual(new Map([["user-mail", { url: "https://example.test/ok" }]]));
+      });
+      await expect(
+        resolveRequesterScopedMcpConnections({
+          serverNames: ["user-mail"],
+        }),
+      ).resolves.toEqual(new Map());
+      await expect(
+        resolveRequesterScopedMcpConnections({
+          serverNames: ["user-mail"],
+          requesterSenderId: "nope",
+        }),
+      ).resolves.toEqual(new Map());
+      await expect(
+        resolveRequesterScopedMcpConnections({
+          serverNames: ["user-mail"],
+          requesterSenderId: "ok",
+        }),
+      ).resolves.toEqual(new Map([["user-mail", { url: "https://example.test/ok" }]]));
+    });
   });
 
   it("registers resolved header and signed-URL credentials for redaction", async () => {
-    const { resetSecretRedactionRegistryForTest } =
-      await import("../logging/secret-redaction-registry.test-support.js");
-    resetSecretRedactionRegistryForTest();
-    testing.setMcpServerConnectionResolversForTest([
-      {
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const { resetSecretRedactionRegistryForTest } =
+        await import("../logging/secret-redaction-registry.test-support.js");
+      resetSecretRedactionRegistryForTest();
+      const resolverApi = resolverRegistry.apiFor("test-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async () => ({
           url: "https://mcp.example.test/mail?sig=placeholder-signature",
           headers: { Authorization: "Bearer test-auth-token" },
         }),
-      },
-    ]);
-    await resolveRequesterScopedMcpConnections({
-      serverNames: ["user-mail"],
-      requesterSenderId: "sender",
+      });
+      await resolveRequesterScopedMcpConnections({
+        serverNames: ["user-mail"],
+        requesterSenderId: "sender",
+      });
+      expect(isSecretValueRegisteredForRedaction("Bearer test-auth-token")).toBe(true);
+      expect(isSecretValueRegisteredForRedaction("test-auth-token")).toBe(true);
+      expect(isSecretValueRegisteredForRedaction("placeholder-signature")).toBe(true);
+      // Full URL too: transport connect errors embed it verbatim (path-borne
+      // session tokens would otherwise leak through fetch/undici error strings).
+      expect(
+        isSecretValueRegisteredForRedaction(
+          "https://mcp.example.test/mail?sig=placeholder-signature",
+        ),
+      ).toBe(true);
+      resetSecretRedactionRegistryForTest();
     });
-    expect(isSecretValueRegisteredForRedaction("Bearer test-auth-token")).toBe(true);
-    expect(isSecretValueRegisteredForRedaction("test-auth-token")).toBe(true);
-    expect(isSecretValueRegisteredForRedaction("placeholder-signature")).toBe(true);
-    // Full URL too: transport connect errors embed it verbatim (path-borne
-    // session tokens would otherwise leak through fetch/undici error strings).
-    expect(
-      isSecretValueRegisteredForRedaction(
-        "https://mcp.example.test/mail?sig=placeholder-signature",
-      ),
-    ).toBe(true);
-    resetSecretRedactionRegistryForTest();
   });
 
   it("contains per-server resolve throws without rejecting the map", async () => {
-    const logWarn = vi.spyOn(await import("../logger.js"), "logWarn").mockImplementation(() => {});
-    testing.setMcpServerConnectionResolversForTest([
-      {
-        pluginId: "broken-plugin",
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const logWarn = vi
+        .spyOn(await import("../logger.js"), "logWarn")
+        .mockImplementation(() => {});
+      const resolverApi = resolverRegistry.apiFor("broken-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: async () => {
           throw new Error("Authorization: Bearer secret-token");
         },
-      },
-      {
-        pluginId: "ok-plugin",
+      });
+      const resolverApi2 = resolverRegistry.apiFor("ok-plugin");
+      resolverApi2.registerMcpServerConnectionResolver({
         serverName: "other",
         resolve: async () => ({ url: "https://example.test/other" }),
-      },
-    ]);
-    await expect(
-      resolveRequesterScopedMcpConnections({
-        serverNames: ["user-mail", "other"],
-        requesterSenderId: "sender",
-      }),
-    ).resolves.toEqual(new Map([["other", { url: "https://example.test/other" }]]));
-    expect(logWarn).toHaveBeenCalledWith(
-      'bundle-mcp: connection resolver for server "user-mail" (plugin "broken-plugin") failed with resolver error',
-    );
-    const logged = JSON.stringify(logWarn.mock.calls);
-    expect(logged).not.toContain("secret-token");
-    expect(logged).not.toContain("Bearer");
-    expect(logged).not.toContain("Authorization");
+      });
+      await expect(
+        resolveRequesterScopedMcpConnections({
+          serverNames: ["user-mail", "other"],
+          requesterSenderId: "sender",
+        }),
+      ).resolves.toEqual(new Map([["other", { url: "https://example.test/other" }]]));
+      expect(logWarn).toHaveBeenCalledWith(
+        'bundle-mcp: connection resolver for server "user-mail" (plugin "broken-plugin") failed with resolver error',
+      );
+      const logged = JSON.stringify(logWarn.mock.calls);
+      expect(logged).not.toContain("secret-token");
+      expect(logged).not.toContain("Bearer");
+      expect(logged).not.toContain("Authorization");
+    });
   });
 
   it("resolves stalled servers concurrently within one timeout window", async () => {
-    testing.setMcpConnectionResolverTimeoutMsForTest(50);
-    testing.setMcpServerConnectionResolversForTest([
-      {
-        pluginId: "hang-a",
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("hang-a");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "mail-a",
         resolve: () => new Promise(() => {}),
-      },
-      {
-        pluginId: "hang-b",
+      });
+      const resolverApi2 = resolverRegistry.apiFor("hang-b");
+      resolverApi2.registerMcpServerConnectionResolver({
         serverName: "mail-b",
         resolve: () => new Promise(() => {}),
-      },
-    ]);
-    vi.useFakeTimers();
-    const pending = resolveRequesterScopedMcpConnections({
-      serverNames: ["mail-a", "mail-b"],
-      requesterSenderId: "sender",
+      });
+      vi.useFakeTimers();
+      const pending = resolveRequesterScopedMcpConnections({
+        serverNames: ["mail-a", "mail-b"],
+        requesterSenderId: "sender",
+      });
+      // Concurrent resolves: one timeout window covers both stalls, not two sequential waits.
+      const settled = vi.fn();
+      void pending.then(settled);
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(settled).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(settled).toHaveBeenCalledOnce();
+      await expect(pending).resolves.toEqual(new Map());
     });
-    // Concurrent resolves: one timeout window covers both stalls, not two sequential waits.
-    await vi.advanceTimersByTimeAsync(50);
-    await expect(pending).resolves.toEqual(new Map());
   });
 
   it("omits stalled resolvers after the resolve timeout", async () => {
-    testing.setMcpConnectionResolverTimeoutMsForTest(50);
-    testing.setMcpServerConnectionResolversForTest([
-      {
-        pluginId: "hang-plugin",
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolverApi = resolverRegistry.apiFor("hang-plugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "user-mail",
         resolve: () => new Promise(() => {}),
-      },
-      {
-        pluginId: "ok-plugin",
+      });
+      const resolverApi2 = resolverRegistry.apiFor("ok-plugin");
+      resolverApi2.registerMcpServerConnectionResolver({
         serverName: "other",
         resolve: async () => ({ url: "https://example.test/other" }),
-      },
-    ]);
-    vi.useFakeTimers();
-    const pending = resolveRequesterScopedMcpConnections({
-      serverNames: ["user-mail", "other"],
-      requesterSenderId: "sender",
+      });
+      vi.useFakeTimers();
+      const pending = resolveRequesterScopedMcpConnections({
+        serverNames: ["user-mail", "other"],
+        requesterSenderId: "sender",
+      });
+      const settled = vi.fn();
+      void pending.then(settled);
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(settled).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(settled).toHaveBeenCalledOnce();
+      await expect(pending).resolves.toEqual(
+        new Map([["other", { url: "https://example.test/other" }]]),
+      );
     });
-    await vi.advanceTimersByTimeAsync(50);
-    await expect(pending).resolves.toEqual(
-      new Map([["other", { url: "https://example.test/other" }]]),
-    );
   });
 
   it("uses an ephemeral keyed digest, not a plain SHA-256 of credentials", async () => {

--- a/src/agents/mcp-connection-resolver.ts
+++ b/src/agents/mcp-connection-resolver.ts
@@ -28,46 +28,7 @@ const MCP_CONNECTION_RESOLVER_TIMEOUT_MS = 10_000;
  * How long a full-set requester runtime may skip re-resolve while active.
  * Revocation/rotation takes effect within this window even for continuously active requesters.
  */
-const MCP_CONNECTION_REVALIDATE_MS = 5 * 60 * 1000;
-
-const MCP_CONNECTION_RESOLVER_TEST_STATE_KEY = Symbol.for(
-  "openclaw.mcpServerConnectionResolverTestState",
-);
-
-type McpConnectionResolverTestState = {
-  resolversByServerName?: Map<string, McpServerConnectionResolverEntry>;
-  resolveTimeoutMs?: number;
-  revalidateMs?: number;
-};
-
-function getTestState(): McpConnectionResolverTestState {
-  const globalStore = globalThis as Record<PropertyKey, unknown>;
-  const existing = globalStore[MCP_CONNECTION_RESOLVER_TEST_STATE_KEY] as
-    | McpConnectionResolverTestState
-    | undefined;
-  if (existing) {
-    return existing;
-  }
-  const state: McpConnectionResolverTestState = {};
-  globalStore[MCP_CONNECTION_RESOLVER_TEST_STATE_KEY] = state;
-  return state;
-}
-
-function resolveConnectionResolverTimeoutMs(): number {
-  const override = getTestState().resolveTimeoutMs;
-  if (typeof override === "number" && Number.isFinite(override) && override > 0) {
-    return Math.floor(override);
-  }
-  return MCP_CONNECTION_RESOLVER_TIMEOUT_MS;
-}
-
-export function resolveMcpConnectionRevalidateMs(): number {
-  const override = getTestState().revalidateMs;
-  if (typeof override === "number" && Number.isFinite(override) && override > 0) {
-    return Math.floor(override);
-  }
-  return MCP_CONNECTION_REVALIDATE_MS;
-}
+export const MCP_CONNECTION_REVALIDATE_MS = 5 * 60 * 1000;
 
 /**
  * Ephemeral per-process HMAC key for connection digests. Never exported, logged,
@@ -133,10 +94,6 @@ function listMcpServerConnectionResolversByServerName(): Map<
   string,
   McpServerConnectionResolverEntry
 > {
-  const testOverrides = getTestState().resolversByServerName;
-  if (testOverrides) {
-    return new Map([...testOverrides.entries()].toSorted(([a], [b]) => a.localeCompare(b)));
-  }
   const byName = new Map<string, McpServerConnectionResolverEntry>();
   const registry =
     getPluginRuntimeGatewayRequestScope()?.pluginRegistry ?? getActivePluginRegistry();
@@ -254,7 +211,7 @@ export async function resolveRequesterScopedMcpConnections(params: {
       ? { messageChannel: normalizeOptionalString(params.messageChannel) }
       : {}),
   };
-  const timeoutMs = resolveConnectionResolverTimeoutMs();
+  const timeoutMs = MCP_CONNECTION_RESOLVER_TIMEOUT_MS;
   const sortedNames = [...params.serverNames].toSorted((a, b) => a.localeCompare(b));
   const settled = await Promise.all(
     sortedNames.map(async (serverName) => {
@@ -388,39 +345,3 @@ export function buildMcpRequesterRuntimeCacheKey(params: {
     requesterSenderId: params.requesterSenderId,
   });
 }
-
-export const testing = {
-  setMcpServerConnectionResolversForTest(
-    resolvers?: Iterable<OpenClawPluginMcpServerConnectionResolver & { pluginId?: string }> | null,
-  ): void {
-    if (!resolvers) {
-      getTestState().resolversByServerName = undefined;
-      return;
-    }
-    const map = new Map<string, McpServerConnectionResolverEntry>();
-    for (const resolver of resolvers) {
-      const serverName = normalizeOptionalString(resolver.serverName);
-      if (!serverName || typeof resolver.resolve !== "function") {
-        continue;
-      }
-      map.set(serverName, {
-        pluginId: normalizeOptionalString(resolver.pluginId) ?? "test-plugin",
-        serverName,
-        resolve: resolver.resolve,
-      });
-    }
-    getTestState().resolversByServerName = map;
-  },
-  setMcpConnectionResolverTimeoutMsForTest(timeoutMs?: number): void {
-    getTestState().resolveTimeoutMs =
-      typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
-        ? Math.floor(timeoutMs)
-        : undefined;
-  },
-  setMcpConnectionRevalidateMsForTest(revalidateMs?: number): void {
-    getTestState().revalidateMs =
-      typeof revalidateMs === "number" && Number.isFinite(revalidateMs) && revalidateMs > 0
-        ? Math.floor(revalidateMs)
-        : undefined;
-  },
-};

--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -2,10 +2,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayClientRequestError } from "../../packages/gateway-client/src/index.js";
 import { retainGatewayResponsePayload } from "../../packages/gateway-client/src/protocol-request.js";
-import { testing as mcpResolverTesting } from "../agents/mcp-connection-resolver.js";
+import { createMcpProofPluginRegistry } from "../agents/mcp-connection-resolver.test-fixtures.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { GATEWAY_HEALTH_RATE_LIMITED_MESSAGE } from "../commands/gateway-health-auth-diagnostic.js";
 import { GatewaySecretRefUnavailableError } from "../gateway/credentials.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 
 const mocks = vi.hoisted(() => ({
@@ -109,7 +110,6 @@ function bundleMcpTool(name: string, parameters: unknown): AnyAgentTool {
 
 describe("doctor runtime tool schema checks", () => {
   beforeEach(() => {
-    mcpResolverTesting.setMcpServerConnectionResolversForTest(undefined);
     mocks.createOpenClawCodingTools.mockReset().mockReturnValue([]);
     mocks.createBundleMcpToolRuntime.mockReset().mockReturnValue({
       tools: [],
@@ -497,42 +497,43 @@ describe("doctor runtime tool schema checks", () => {
   });
 
   it("does not probe requester-scoped MCP servers without a requester", async () => {
-    const resolveConnection = vi.fn();
-    mcpResolverTesting.setMcpServerConnectionResolversForTest([
-      {
-        pluginId: "fuzzplugin",
+    const resolverRegistry = createMcpProofPluginRegistry();
+    await withPluginRuntimeRegistryScope(resolverRegistry.registry, async () => {
+      const resolveConnection = vi.fn();
+      const resolverApi = resolverRegistry.apiFor("fuzzplugin");
+      resolverApi.registerMcpServerConnectionResolver({
         serverName: "fuzzplugin",
         resolve: resolveConnection,
-      },
-    ]);
+      });
 
-    await expect(
-      collectRuntimeToolSchemaFindings({
-        mcp: {
-          servers: {
-            fuzzplugin: {
-              url: "https://placeholder.invalid/mcp",
-              transport: "streamable-http",
-              auth: "oauth",
+      await expect(
+        collectRuntimeToolSchemaFindings({
+          mcp: {
+            servers: {
+              fuzzplugin: {
+                url: "https://placeholder.invalid/mcp",
+                transport: "streamable-http",
+                auth: "oauth",
+              },
             },
           },
-        },
-      }),
-    ).resolves.toContainEqual({
-      checkId: "core/doctor/runtime-tool-schemas",
-      severity: "info",
-      message:
-        'Configured requester-scoped MCP server "fuzzplugin" was not probed without an authenticated requester.',
-      path: "mcp.servers.fuzzplugin",
-      requirement: "authenticated requester context",
-      fixHint: "Verify this server from an authenticated agent turn.",
+        }),
+      ).resolves.toContainEqual({
+        checkId: "core/doctor/runtime-tool-schemas",
+        severity: "info",
+        message:
+          'Configured requester-scoped MCP server "fuzzplugin" was not probed without an authenticated requester.',
+        path: "mcp.servers.fuzzplugin",
+        requirement: "authenticated requester context",
+        fixHint: "Verify this server from an authenticated agent turn.",
+      });
+      expect(resolveConnection).not.toHaveBeenCalled();
+      expect(mocks.createBundleMcpToolRuntime).toHaveBeenCalledWith(
+        expect.objectContaining({
+          excludeServerNames: new Set(["fuzzplugin"]),
+        }),
+      );
     });
-    expect(resolveConnection).not.toHaveBeenCalled();
-    expect(mocks.createBundleMcpToolRuntime).toHaveBeenCalledWith(
-      expect.objectContaining({
-        excludeServerNames: new Set(["fuzzplugin"]),
-      }),
-    );
   });
 
   it("does not report bundle MCP schemas filtered out by the final runtime tool policy", async () => {

--- a/src/plugins/registry-registrars-network.mcp-resolver.test.ts
+++ b/src/plugins/registry-registrars-network.mcp-resolver.test.ts
@@ -1,7 +1,9 @@
 /** Verifies MCP connection resolver registration ownership is fail-closed. */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { resolveRequesterScopedMcpConnections } from "../agents/mcp-connection-resolver.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createPluginRegistry } from "./registry.js";
+import { withPluginRuntimeRegistryScope } from "./runtime/gateway-request-scope.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import { createPluginRecord } from "./status.test-fixtures.js";
 
@@ -27,16 +29,17 @@ function createRegistryHarness(allowProcessHomeSessionCatalogs = true) {
 }
 
 describe("registerMcpServerConnectionResolver ownership", () => {
-  it("rejects a duplicate serverName from another plugin with an error diagnostic", () => {
+  it("rejects a duplicate serverName from another plugin with an error diagnostic", async () => {
     const { pluginRegistry, apiFor } = createRegistryHarness();
-    const firstResolve = async () => null;
+    const firstResolve = vi.fn(async () => ({ url: "https://mcp.example.test/owner" }));
+    const rejectedResolve = vi.fn(async () => ({ url: "https://mcp.example.test/hijack" }));
     apiFor("plugin-a").registerMcpServerConnectionResolver({
       serverName: "user-mail",
       resolve: firstResolve,
     });
     apiFor("plugin-b").registerMcpServerConnectionResolver({
       serverName: "user-mail",
-      resolve: async () => ({ url: "https://mcp.example.test/hijack" }),
+      resolve: rejectedResolve,
     });
 
     expect(pluginRegistry.registry.mcpServerConnectionResolvers).toHaveLength(1);
@@ -51,12 +54,22 @@ describe("registerMcpServerConnectionResolver ownership", () => {
         message: expect.stringContaining('already registered by plugin "plugin-a"'),
       }),
     );
+    await withPluginRuntimeRegistryScope(pluginRegistry.registry, async () => {
+      await expect(
+        resolveRequesterScopedMcpConnections({
+          serverNames: ["user-mail"],
+          requesterSenderId: "sender",
+        }),
+      ).resolves.toEqual(new Map([["user-mail", { url: "https://mcp.example.test/owner" }]]));
+    });
+    expect(firstResolve).toHaveBeenCalledOnce();
+    expect(rejectedResolve).not.toHaveBeenCalled();
   });
 
-  it("lets the owning plugin replace its own resolver", () => {
+  it("lets the owning plugin replace its own resolver", async () => {
     const { pluginRegistry, apiFor } = createRegistryHarness();
     const api = apiFor("plugin-a");
-    const replacement = async () => null;
+    const replacement = vi.fn(async () => ({ url: "https://mcp.example.test/replacement" }));
     api.registerMcpServerConnectionResolver({
       serverName: "user-mail",
       resolve: async () => null,
@@ -73,6 +86,15 @@ describe("registerMcpServerConnectionResolver ownership", () => {
     expect(
       pluginRegistry.registry.diagnostics.filter((diagnostic) => diagnostic.level === "error"),
     ).toEqual([]);
+    await withPluginRuntimeRegistryScope(pluginRegistry.registry, async () => {
+      await expect(
+        resolveRequesterScopedMcpConnections({
+          serverNames: ["user-mail"],
+          requesterSenderId: "sender",
+        }),
+      ).resolves.toEqual(new Map([["user-mail", { url: "https://mcp.example.test/replacement" }]]));
+    });
+    expect(replacement).toHaveBeenCalledOnce();
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

The MCP resolver carries test-only registry and timer overrides alongside its production path. That duplicates policy and lets tests bypass the plugin registration and request-scope boundaries they are intended to protect.

## Why This Change Was Made

Remove the test-only global state and exercise the existing plugin registration API in scoped test registries. Production keeps its request-scope-first registry selection and normal active-registry fallback. The manager reads the existing revalidation constant directly instead of calling a constant-return wrapper.

The resolver timeout, strict revalidation comparison, requester isolation, replacement ownership, lifecycle ordering and credential-sensitive cache keys remain unchanged. No new production injection hook, configuration, public SDK export or external service is added.

Production runtime LOC: net -44. Removed test-support setters/reset code: net -40, counted separately. Tests and fixture changes: net +125. The one stale assertion-baseline row is removed without changing any other row and contributes no production credit.

## User Impact

No intended user-visible behavior change. Maintainers get fewer alternate paths and tests that use the same registration ownership rules as production.

## Evidence

- Original, fixture-only and final candidate runs each passed 232 cases. The candidate's complete printed order matches the fixture-only run; that fixture migration intentionally changed one suite's ordinary project routing.
- Seven restored synthetic controls produced 13 expected failures for early/late timeout and revalidation, registry precedence, foreign-owner overwrite and dropped same-owner replacement. The final source contains none of those controls.
- The normal configured changed gate passed all 31 selected checks. Its predecessor correctly stopped on the now-obsolete resolver assertion-baseline row; the narrowly corrected row and final successful run are retained as separate evidence.
- One ordinary full local build passed all 16 phases, including cold declarations, plugin runtimes, runtime/Doctor closure checks, public SDK checks, UI and isolated CLI-help metadata.
- Independent P2 precommit review and the separate exact-signed-commit P2 review each completed all six parts with no actionable findings. Each part was a static review of the complete patch with its assigned context; the first report in each review explicitly retained a provisional, batch-context limitation. The reviewers did not independently rerun the tests.

The signed commit is `2448e17e5c89563e1424479e67bde73768201599`; its complete tree and twelve changed paths match the tested and reviewed source. Hosted exact-head [CI run 34080852997](https://github.com/openclaw/openclaw/actions/runs/34080852997) passed. Its CLI watcher stopped on a pagination error; the completed run was reconciled read-only, with no CI rerun. Native review metadata is complete; normal hosted preparation and merge remain pending.

