### PR TITLE
refactor(e2e): share environment limit parsing

### DIFF
--- a/scripts/e2e/lib/browser-cdp-snapshot/assert-snapshot.mjs
+++ b/scripts/e2e/lib/browser-cdp-snapshot/assert-snapshot.mjs
@@ -1,25 +1,10 @@
 // Assertions for browser CDP snapshot E2E fixtures.
 import fs from "node:fs";
+import { readPositiveIntEnvWithEmptyFallback } from "../env-limits.mjs";
 
 const DEFAULT_SNAPSHOT_MAX_BYTES = 512 * 1024;
 const SNAPSHOT_DIAGNOSTIC_MAX_BYTES = 32 * 1024;
 const snapshotPath = process.argv[2] ?? "/tmp/browser-cdp-snapshot.txt";
-
-function readPositiveIntEnv(name, fallback) {
-  const raw = process.env[name];
-  if (raw === undefined || raw === "") {
-    return fallback;
-  }
-  const text = raw.trim();
-  if (!/^\d+$/u.test(text)) {
-    throw new Error(`${name} must be a positive integer; got: ${raw}`);
-  }
-  const parsed = Number(text);
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    throw new Error(`${name} must be a positive integer; got: ${raw}`);
-  }
-  return parsed;
-}
 
 function readBoundedSnapshot(file, maxBytes) {
   const stats = fs.statSync(file);
@@ -47,7 +32,7 @@ function snapshotDiagnostic(snapshot) {
     .toString("utf8")}`;
 }
 
-const snapshotMaxBytes = readPositiveIntEnv(
+const snapshotMaxBytes = readPositiveIntEnvWithEmptyFallback(
   "OPENCLAW_BROWSER_CDP_SNAPSHOT_MAX_BYTES",
   DEFAULT_SNAPSHOT_MAX_BYTES,
 );

--- a/scripts/e2e/lib/env-limits.mjs
+++ b/scripts/e2e/lib/env-limits.mjs
@@ -21,3 +21,19 @@ export function readTcpPortEnv(name, fallback, env = process.env) {
   }
   return value;
 }
+
+export function readPositiveIntEnvWithEmptyFallback(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    return fallback;
+  }
+  const text = raw.trim();
+  if (!/^\d+$/u.test(text)) {
+    throw new Error(`${name} must be a positive integer; got: ${raw}`);
+  }
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer; got: ${raw}`);
+  }
+  return parsed;
+}

--- a/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
+++ b/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { readPositiveIntEnvWithEmptyFallback } from "../env-limits.mjs";
 import { readPluginInstallRecords } from "../plugin-index-sqlite.mjs";
 import { isExplicitPluginDisableMarker } from "../plugin-uninstall-assertions.mjs";
 
@@ -10,12 +11,15 @@ const scratchRoot = process.env.KITCHEN_SINK_TMP_DIR || os.tmpdir();
 
 const LOG_SCAN_CHUNK_BYTES = 64 * 1024;
 const LOG_SCAN_FINDING_CONTEXT_CHARS = 2048;
-const LOG_SCAN_MAX_ENTRIES = readPositiveIntEnv("KITCHEN_SINK_LOG_SCAN_MAX_ENTRIES", 20_000);
+const LOG_SCAN_MAX_ENTRIES = readPositiveIntEnvWithEmptyFallback(
+  "KITCHEN_SINK_LOG_SCAN_MAX_ENTRIES",
+  20_000,
+);
 const LOG_SCAN_MAX_FILES = 5000;
 const LOG_SCAN_MAX_FINDINGS = 100;
 const LOG_SCAN_MAX_LINE_CHARS = 16 * 1024;
 const LOG_SCAN_SEGMENT_OVERLAP_CHARS = 256;
-const EXPECT_FAILURE_OUTPUT_MAX_BYTES = readPositiveIntEnv(
+const EXPECT_FAILURE_OUTPUT_MAX_BYTES = readPositiveIntEnvWithEmptyFallback(
   "KITCHEN_SINK_EXPECT_FAILURE_OUTPUT_MAX_BYTES",
   1024 * 1024,
 );
@@ -23,22 +27,6 @@ const EXPECT_FAILURE_OUTPUT_MAX_BYTES = readPositiveIntEnv(
 const readJson = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
 const scratchFile = (name) => path.join(scratchRoot, name);
 const normalizedPath = (filePath) => filePath.replaceAll("\\", "/");
-
-function readPositiveIntEnv(name, fallback) {
-  const raw = process.env[name];
-  if (raw === undefined || raw === "") {
-    return fallback;
-  }
-  const text = raw.trim();
-  if (!/^\d+$/u.test(text)) {
-    throw new Error(`${name} must be a positive integer; got: ${raw}`);
-  }
-  const parsed = Number(text);
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    throw new Error(`${name} must be a positive integer; got: ${raw}`);
-  }
-  return parsed;
-}
 
 function resolveHomePath(value) {
   if (value === "~") {

--- a/scripts/e2e/openwebui-probe.mjs
+++ b/scripts/e2e/openwebui-probe.mjs
@@ -6,6 +6,7 @@ import {
 } from "../lib/bounded-response.mjs";
 import { escapeRegExp } from "../lib/regexp.mjs";
 import { createTimeoutError } from "../lib/timeout-error.mjs";
+import { readPositiveIntEnvWithEmptyFallback } from "./lib/env-limits.mjs";
 
 const baseUrl = process.env.OPENWEBUI_BASE_URL ?? "";
 const email = process.env.OPENWEBUI_ADMIN_EMAIL ?? "";
@@ -13,7 +14,7 @@ const password = process.env.OPENWEBUI_ADMIN_PASSWORD ?? "";
 const expectedNonce = process.env.OPENWEBUI_EXPECTED_NONCE ?? "";
 const prompt = process.env.OPENWEBUI_PROMPT ?? "";
 const MAX_TIMER_TIMEOUT_MS = 2_147_000_000;
-const modelAttempts = readPositiveInt("OPENWEBUI_MODEL_ATTEMPTS", 72);
+const modelAttempts = readPositiveIntEnvWithEmptyFallback("OPENWEBUI_MODEL_ATTEMPTS", 72);
 const modelRetryMs = readNonNegativeTimerMs("OPENWEBUI_MODEL_RETRY_MS", 5000);
 const fetchTimeoutMs = readPositiveTimerMs("OPENWEBUI_FETCH_TIMEOUT_MS", 720000);
 const controlTimeoutMs = readPositiveTimerMs(
@@ -21,7 +22,10 @@ const controlTimeoutMs = readPositiveTimerMs(
   Math.min(fetchTimeoutMs, 30000),
 );
 const chatTimeoutMs = readPositiveTimerMs("OPENWEBUI_CHAT_TIMEOUT_MS", fetchTimeoutMs);
-const responseBodyMaxBytes = readPositiveInt("OPENWEBUI_RESPONSE_BODY_MAX_BYTES", 1024 * 1024);
+const responseBodyMaxBytes = readPositiveIntEnvWithEmptyFallback(
+  "OPENWEBUI_RESPONSE_BODY_MAX_BYTES",
+  1024 * 1024,
+);
 const smokeMode =
   process.env.OPENWEBUI_SMOKE_MODE ?? process.env.OPENCLAW_OPENWEBUI_SMOKE_MODE ?? "chat";
 
@@ -37,22 +41,6 @@ if (!baseUrl || !email || !password || !expectedNonce || !prompt) {
 }
 if (smokeMode !== "models" && smokeMode !== "chat") {
   throw new Error(`Unsupported OPENWEBUI_SMOKE_MODE: ${smokeMode}`);
-}
-
-function readPositiveInt(name, fallback) {
-  const raw = process.env[name];
-  if (raw === undefined || raw === "") {
-    return fallback;
-  }
-  const text = raw.trim();
-  if (!/^\d+$/u.test(text)) {
-    throw new Error(`${name} must be a positive integer; got: ${raw}`);
-  }
-  const parsed = Number(text);
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    throw new Error(`${name} must be a positive integer; got: ${raw}`);
-  }
-  return parsed;
 }
 
 function readNonNegativeInt(name, fallback) {
@@ -78,7 +66,7 @@ function clampOpenWebUiTimerTimeoutMs(valueMs, minMs = 1) {
 }
 
 function readPositiveTimerMs(name, fallback) {
-  return clampOpenWebUiTimerTimeoutMs(readPositiveInt(name, fallback));
+  return clampOpenWebUiTimerTimeoutMs(readPositiveIntEnvWithEmptyFallback(name, fallback));
 }
 
 function readNonNegativeTimerMs(name, fallback) {

--- a/test/scripts/browser-cdp-snapshot.test.ts
+++ b/test/scripts/browser-cdp-snapshot.test.ts
@@ -8,14 +8,68 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 const SCRIPT_PATH = "scripts/e2e/lib/browser-cdp-snapshot/assert-snapshot.mjs";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-function runAssertSnapshot(snapshotPath: string, env: Record<string, string> = {}) {
+function runAssertSnapshot(snapshotPath: string, env: Record<string, string | undefined> = {}) {
   return spawnSync(process.execPath, [SCRIPT_PATH, snapshotPath], {
     encoding: "utf8",
-    env: { ...process.env, ...env },
+    env: { ...process.env, OPENCLAW_BROWSER_CDP_SNAPSHOT_MAX_BYTES: undefined, ...env },
   });
 }
 
 describe("browser CDP snapshot assertions", () => {
+  it.each([undefined, "", " 1024 ", "9007199254740991"])("accepts snapshot limit %j", (limit) => {
+    const root = tempDirs.make("openclaw-browser-cdp-snapshot-");
+    const snapshotPath = path.join(root, "snapshot.txt");
+    writeFileSync(
+      snapshotPath,
+      [
+        'button "Save"',
+        'link "Docs" https://docs.openclaw.ai/browser-cdp-live',
+        'generic "Clickable Card" cursor:pointer',
+        'Iframe "Child"',
+        'button "Inside"',
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = runAssertSnapshot(snapshotPath, {
+      OPENCLAW_BROWSER_CDP_SNAPSHOT_MAX_BYTES: limit,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("ok\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it.each([" \t ", "0", "-1", "1.5", "1e3", "1kb", "9007199254740992"])(
+    "rejects snapshot limit %j with the untrimmed value",
+    (limit) => {
+      const root = tempDirs.make("openclaw-browser-cdp-snapshot-");
+      const result = runAssertSnapshot(path.join(root, "snapshot.txt"), {
+        OPENCLAW_BROWSER_CDP_SNAPSHOT_MAX_BYTES: limit,
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr.split("\n").find((line) => line.startsWith("Error: "))).toBe(
+        `Error: OPENCLAW_BROWSER_CDP_SNAPSHOT_MAX_BYTES must be a positive integer; got: ${limit}`,
+      );
+    },
+  );
+
+  it.each([undefined, ""])("keeps the default snapshot limit for %j", (limit) => {
+    const root = tempDirs.make("openclaw-browser-cdp-snapshot-");
+    const snapshotPath = path.join(root, "snapshot.txt");
+    writeFileSync(snapshotPath, "x".repeat(512 * 1024 + 1), "utf8");
+
+    const result = runAssertSnapshot(snapshotPath, {
+      OPENCLAW_BROWSER_CDP_SNAPSHOT_MAX_BYTES: limit,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr.split("\n").find((line) => line.startsWith("Error: "))).toBe(
+      "Error: browser CDP snapshot exceeded 524288 bytes: 524289 bytes",
+    );
+  });
+
   it("rejects oversized snapshots before reading them into diagnostics", () => {
     const root = tempDirs.make("openclaw-browser-cdp-snapshot-");
     const snapshotPath = path.join(root, "snapshot.txt");


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested deduplication of E2E environment-limit validation. Browser snapshot assertions, kitchen-sink assertions, and the OpenWebUI probe maintain identical positive-integer parsing separately, allowing their accepted values and diagnostics to drift.

## Why This Change Was Made

Reuse one internal E2E helper for the existing empty-value-fallback contract. Preserve the distinct strict parser, per-call environment reads, defaults, raw-value diagnostics, integer bounds, and timer clamping. No new package/SDK export or runtime configuration.

## User Impact

No intended behavior change. E2E tooling retains its current limits, validation, and error messages; the shared implementation reduces maintenance duplication.

## Evidence

- Acorn-located comparison confirms all three original bodies are byte-identical to the extracted helper; existing strict and port helper source remains unchanged.
- Browser subprocess characterization: 15 tests pass before and after extraction, including missing/empty fallback, padded digits, safe-integer bounds, rejected numeric forms, raw diagnostics, and the unchanged 512 KiB default.
- All four focused suites pass: 69 tests. Existing Docker helper mount test passes; 277 unrelated cases excluded by the name filter.
- Four MJS syntax checks, targeted formatting/lint, coercion and Docker E2E boundary guards, and whitespace checks pass.
- The focused suites use their own subprocess/HTTP fixtures and the supported `OPENCLAW_E2E_SKIP_BUILD=1` route. The initial generic E2E build prerequisite could not resolve unrelated plugin dependencies in the linked worktree.
- Local changed checks pass except root test typechecking, whose declaration guard rejects the required external shared dependency link. The complete selected changed-file gate, including root test typechecking, passed on Linux.
- Exact-source Linux Testbox proof: https://github.com/openclaw/openclaw/actions/runs/34080512362. All 69 focused tests, the Docker mount test, and selected changed checks passed; exit 0 and lease stopped. The canonical source receiver verified commit `04603151597ac9a088cdde0f0b031f4af4668909`, and the proof additionally verified its complete Git tree. An earlier attempt stopped before tests because an extra assertion confused the carrier commit with the source commit; the corrected retry did not change product code.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/34080314738.
- Fresh independent autoreview and ClawSweeper review found no actionable correctness issues.
- Authenticated OpenWebUI, full release validation, and native apps are outside this behavior-preserving tooling change. No provider credentials are needed for the exercised boundaries.
