### PR TITLE
perf(ui): compute selected-day session metrics once per render

### DIFF
--- a/ui/src/pages/usage/view-overview.test.ts
+++ b/ui/src/pages/usage/view-overview.test.ts
@@ -559,6 +559,42 @@ describe("renderCostWindowComparison", () => {
 
 describe("renderSessionsCard", () => {
   const noop = () => {};
+  const renderCard = (
+    sessions: UsageSessionEntry[],
+    options: {
+      selected?: string[];
+      days?: string[];
+      tokens?: boolean;
+      sort?: Parameters<typeof renderSessionsCard>[4];
+      direction?: Parameters<typeof renderSessionsCard>[5];
+      recent?: string[];
+      tab?: Parameters<typeof renderSessionsCard>[7];
+      onSelect?: Parameters<typeof renderSessionsCard>[8];
+    } = {},
+  ) => {
+    const container = document.createElement("div");
+    render(
+      renderSessionsCard(
+        sessions,
+        options.selected ?? [],
+        options.days ?? [],
+        options.tokens ?? true,
+        options.sort ?? "tokens",
+        options.direction ?? "desc",
+        options.recent ?? [],
+        options.tab ?? "all",
+        options.onSelect ?? noop,
+        noop,
+        noop,
+        noop,
+        [],
+        sessions.length,
+        noop,
+      ),
+      container,
+    );
+    return container;
+  };
 
   it.each([
     { copied: true, feedback: "Copied!" },
@@ -644,8 +680,36 @@ describe("renderSessionsCard", () => {
     );
   });
 
-  it("sorts cost by the selected day values when day filters are active", () => {
-    const container = document.createElement("div");
+  it.each([
+    {
+      tokens: true,
+      sort: "tokens",
+      names: ["All time winner", "Day winner"],
+      values: ["30", "10"],
+      avg: "20",
+    },
+    {
+      tokens: true,
+      sort: "cost",
+      names: ["Day winner", "All time winner"],
+      values: ["10", "30"],
+      avg: "20",
+    },
+    {
+      tokens: false,
+      sort: "tokens",
+      names: ["All time winner", "Day winner"],
+      values: ["$1.00", "$10.00"],
+      avg: "$5.50",
+    },
+    {
+      tokens: false,
+      sort: "cost",
+      names: ["Day winner", "All time winner"],
+      values: ["$10.00", "$1.00"],
+      avg: "$5.50",
+    },
+  ] as const)("uses selected-day display and sort metrics independently (%j)", (scenario) => {
     const sessions: UsageSessionEntry[] = [
       {
         key: "all-time-winner",
@@ -656,7 +720,8 @@ describe("renderSessionsCard", () => {
           totalCost: 100,
           totalTokens: 100,
           dailyBreakdown: [
-            { ...totals, date: "2026-02-05", cost: 1, tokens: 1, totalCost: 1, totalTokens: 1 },
+            { ...totals, date: "2026-02-05", cost: 1, tokens: 30 },
+            { ...totals, date: "2026-02-04", cost: 90, tokens: 900 },
           ],
         },
       } as UsageSessionEntry,
@@ -668,37 +733,195 @@ describe("renderSessionsCard", () => {
           ...totals,
           totalCost: 50,
           totalTokens: 50,
-          dailyBreakdown: [
-            { ...totals, date: "2026-02-05", cost: 10, tokens: 10, totalCost: 10, totalTokens: 10 },
-          ],
+          dailyBreakdown: [{ ...totals, date: "2026-02-05", cost: 10, tokens: 10 }],
         },
       } as UsageSessionEntry,
     ];
 
-    render(
-      renderSessionsCard(
-        sessions,
-        [],
-        ["2026-02-05"],
-        false,
-        "cost",
-        "desc",
-        [],
-        "all",
-        noop,
-        noop,
-        noop,
-        noop,
-        [],
-        sessions.length,
-        noop,
-      ),
-      container,
-    );
-
-    const titles = Array.from(container.querySelectorAll(".session-bar-title")).map((el) =>
-      el.textContent?.trim(),
-    );
-    expect(titles.slice(0, 2)).toEqual(["Day winner", "All time winner"]);
+    const container = renderCard(sessions, { ...scenario, days: ["2026-02-05"] });
+    expect(
+      [...container.querySelectorAll(".session-bar-title")].map((el) => el.textContent?.trim()),
+    ).toEqual(scenario.names);
+    expect(
+      [...container.querySelectorAll(".session-bar-value")].map((el) => el.textContent?.trim()),
+    ).toEqual(scenario.values);
+    expect(
+      container
+        .querySelector(".sessions-card-stats span")
+        ?.textContent?.replace(/\s+/g, " ")
+        .trim(),
+    ).toBe(`${scenario.avg} avg`);
   });
+
+  it("reads each daily bucket once across sorting, totals, recent and selected rows", () => {
+    const reads = { dates: 0, tokens: 0, cost: 0 };
+    const sessions = Array.from({ length: 3 }, (_, index): UsageSessionEntry => ({
+      key: `session-${index}`,
+      label: `Session ${index}`,
+      usage: {
+        ...totals,
+        totalTokens: (index + 1) * 100,
+        dailyBreakdown: ["2026-02-04", "2026-02-05"].map((date) =>
+          Object.assign(
+            {
+              get date() {
+                reads.dates += 1;
+                return date;
+              },
+              get tokens() {
+                reads.tokens += 1;
+                return (index + 1) * 10;
+              },
+              get cost() {
+                reads.cost += 1;
+                return 3 - index;
+              },
+            },
+            totals,
+          ),
+        ),
+      },
+    }));
+    const container = renderCard(sessions, {
+      days: ["2026-02-05"],
+      sort: "cost",
+      selected: ["session-0", "session-2"],
+      recent: ["session-2", "session-0"],
+      tab: "recent",
+    });
+    expect(
+      [...container.querySelectorAll(".session-bar-title")].map((el) => el.textContent?.trim()),
+    ).toEqual(["Session 2", "Session 0", "Session 0", "Session 2"]);
+    expect(
+      [...container.querySelectorAll(".session-bar-value")].map((el) => el.textContent?.trim()),
+    ).toEqual(["30", "10", "10", "30"]);
+    expect(
+      container
+        .querySelector(".sessions-card-stats span")
+        ?.textContent?.replace(/\s+/g, " ")
+        .trim(),
+    ).toBe("20 avg");
+    expect(reads.dates).toBeLessThanOrEqual(6);
+    expect(reads.tokens).toBeLessThanOrEqual(3);
+    expect(reads.cost).toBeLessThanOrEqual(3);
+  });
+
+  it.each([true, false])(
+    "preserves missing, empty, unmatched and zero daily values (tokens=%s)",
+    (tokens) => {
+      const sessions: UsageSessionEntry[] = [
+        { key: "missing-usage", usage: null },
+        { key: "missing-breakdown", usage: { ...totals, totalTokens: 10, totalCost: 1 } },
+        {
+          key: "empty-breakdown",
+          usage: { ...totals, totalTokens: 20, totalCost: 2, dailyBreakdown: [] },
+        },
+        {
+          key: "unmatched",
+          usage: {
+            ...totals,
+            totalTokens: 900,
+            totalCost: 90,
+            dailyBreakdown: [{ ...totals, date: "2026-02-04", tokens: 300, cost: 30 }],
+          },
+        },
+        {
+          key: "zero",
+          usage: {
+            ...totals,
+            totalTokens: 500,
+            totalCost: 50,
+            dailyBreakdown: [{ ...totals, date: "2026-02-05", tokens: 0, cost: 0 }],
+          },
+        },
+        {
+          key: "duplicate-days",
+          usage: {
+            ...totals,
+            totalTokens: 60,
+            totalCost: 6,
+            dailyBreakdown: [
+              { ...totals, date: "2026-02-05", tokens: 2, cost: 0.2 },
+              { ...totals, date: "2026-02-05", tokens: 3, cost: 0.3 },
+            ],
+          },
+        },
+      ];
+      const values = (container: HTMLElement) =>
+        Object.fromEntries(
+          [...container.querySelectorAll(".session-bar-row")].map((row) => [
+            row.getAttribute("title"),
+            row.querySelector(".session-bar-value")?.textContent?.trim(),
+          ]),
+        );
+      const formatted = (amounts: number[]) =>
+        Object.fromEntries(
+          sessions.map((session, index) => [
+            session.key,
+            tokens ? String(amounts[index]) : `$${amounts[index]!.toFixed(2)}`,
+          ]),
+        );
+      expect(values(renderCard(sessions, { tokens, days: ["2026-02-05", "2026-02-05"] }))).toEqual(
+        formatted(tokens ? [0, 10, 20, 0, 0, 5] : [0, 1, 2, 0, 0, 0.5]),
+      );
+      expect(values(renderCard(sessions, { tokens }))).toEqual(
+        formatted(tokens ? [0, 10, 20, 900, 500, 60] : [0, 1, 2, 90, 50, 6]),
+      );
+    },
+  );
+
+  it.each(["desc", "asc"] as const)(
+    "preserves ties, duplicate keys and each selection group's %s order",
+    (direction) => {
+      const sessions: UsageSessionEntry[] = [
+        { key: "shared", label: "Alpha", updatedAt: 1, usage: { ...totals, totalTokens: 10 } },
+        { key: "shared", label: "Beta", updatedAt: 1, usage: { ...totals, totalTokens: 10 } },
+        { key: "newest", label: "Newest", updatedAt: 2, usage: { ...totals, totalTokens: 10 } },
+        { key: "other", label: "Other", updatedAt: 0, usage: { ...totals, totalTokens: 10 } },
+      ];
+      const titles = (container: Element) =>
+        [...container.querySelectorAll(".session-bar-title")].map((entry) =>
+          entry.textContent?.trim(),
+        );
+      expect(titles(renderCard(sessions, { direction }))).toEqual(
+        direction === "desc"
+          ? ["Newest", "Alpha", "Beta", "Other"]
+          : ["Other", "Beta", "Alpha", "Newest"],
+      );
+      expect(sessions.map((session) => session.label)).toEqual([
+        "Alpha",
+        "Beta",
+        "Newest",
+        "Other",
+      ]);
+      const onSelect = vi.fn();
+      const container = renderCard(sessions, {
+        direction,
+        tab: "recent",
+        recent: ["shared", "newest", "shared"],
+        selected: ["shared", "newest"],
+        onSelect,
+      });
+      const recent = container.querySelector(".session-bars--recent")!;
+      const selected = container.querySelector(".session-bars--selected")!;
+      expect(titles(recent)).toEqual(
+        direction === "desc" ? ["Beta", "Newest", "Beta"] : ["Alpha", "Newest", "Alpha"],
+      );
+      expect(titles(selected)).toEqual(
+        direction === "desc" ? ["Newest", "Alpha", "Beta"] : ["Beta", "Alpha", "Newest"],
+      );
+      recent
+        .querySelector(".session-bar-selection")!
+        .dispatchEvent(new MouseEvent("click", { bubbles: true, shiftKey: true }));
+      expect(onSelect).toHaveBeenLastCalledWith("shared", true, ["shared", "newest", "shared"]);
+      selected
+        .querySelector(".session-bar-selection")!
+        .dispatchEvent(new MouseEvent("click", { bubbles: true, shiftKey: true }));
+      expect(onSelect).toHaveBeenLastCalledWith(
+        direction === "desc" ? "newest" : "shared",
+        true,
+        direction === "desc" ? ["newest", "shared", "shared"] : ["shared", "shared", "newest"],
+      );
+    },
+  );
 });

--- a/ui/src/pages/usage/view-overview.ts
+++ b/ui/src/pages/usage/view-overview.ts
@@ -842,72 +842,73 @@ function renderSessionsCard(
 
   const selectedDaySet = new Set(selectedDays);
 
-  const getSessionMetricValue = (s: UsageSessionEntry, metric: "tokens" | "cost"): number => {
-    const usage = s.usage;
-    if (!usage) {
-      return 0;
-    }
-
-    if (selectedDaySet.size > 0 && usage.dailyBreakdown && usage.dailyBreakdown.length > 0) {
-      return usage.dailyBreakdown.reduce((sum, day) => {
-        if (!selectedDaySet.has(day.date)) {
-          return sum;
+  const sortedSessions = sessions
+    .map((session) => {
+      const usage = session.usage;
+      let tokens = usage?.totalTokens ?? 0;
+      let cost = usage?.totalCost ?? 0;
+      const daily = selectedDaySet.size > 0 ? usage?.dailyBreakdown : undefined;
+      if (daily?.length) {
+        tokens = 0;
+        cost = 0;
+        for (const day of daily) {
+          if (selectedDaySet.has(day.date)) {
+            tokens += day.tokens;
+            cost += day.cost;
+          }
         }
-        return sum + (metric === "tokens" ? day.tokens : day.cost);
-      }, 0);
-    }
-
-    return metric === "tokens" ? (usage.totalTokens ?? 0) : (usage.totalCost ?? 0);
-  };
-
-  const getSessionValue = (s: UsageSessionEntry): number => {
-    return getSessionMetricValue(s, isTokenMode ? "tokens" : "cost");
-  };
-
-  const getSessionSortValue = (s: UsageSessionEntry): number => {
-    switch (sessionSort) {
-      case "recent":
-        return s.updatedAt ?? 0;
-      case "messages":
-        return s.usage?.messageCounts?.total ?? 0;
-      case "errors":
-        return s.usage?.messageCounts?.errors ?? 0;
-      case "cost":
-        return getSessionMetricValue(s, "cost");
-      case "tokens":
-        return getSessionMetricValue(s, "tokens");
-    }
-    const exhaustiveSort: never = sessionSort;
-    return exhaustiveSort;
-  };
-
-  const sortedSessions = [...sessions].toSorted((a, b) => {
-    const valueDiff = getSessionSortValue(b) - getSessionSortValue(a);
-    if (valueDiff !== 0) {
-      return valueDiff;
-    }
-    const recentDiff = (b.updatedAt ?? 0) - (a.updatedAt ?? 0);
-    if (recentDiff !== 0) {
-      return recentDiff;
-    }
-    return formatSessionListLabel(a).localeCompare(formatSessionListLabel(b));
-  });
+      }
+      let sortValue: number;
+      switch (sessionSort) {
+        case "recent":
+          sortValue = session.updatedAt ?? 0;
+          break;
+        case "messages":
+          sortValue = usage?.messageCounts?.total ?? 0;
+          break;
+        case "errors":
+          sortValue = usage?.messageCounts?.errors ?? 0;
+          break;
+        case "cost":
+          sortValue = cost;
+          break;
+        case "tokens":
+          sortValue = tokens;
+          break;
+      }
+      return {
+        session,
+        displayLabel: formatSessionListLabel(session),
+        value: isTokenMode ? tokens : cost,
+        sortValue,
+      };
+    })
+    .toSorted((a, b) => {
+      const valueDiff = b.sortValue - a.sortValue;
+      if (valueDiff !== 0) {
+        return valueDiff;
+      }
+      const recentDiff = (b.session.updatedAt ?? 0) - (a.session.updatedAt ?? 0);
+      if (recentDiff !== 0) {
+        return recentDiff;
+      }
+      return a.displayLabel.localeCompare(b.displayLabel);
+    });
   const sortedWithDir = sessionSortDir === "asc" ? sortedSessions.toReversed() : sortedSessions;
 
-  const totalValue = sortedWithDir.reduce((sum, session) => sum + getSessionValue(session), 0);
+  const totalValue = sortedWithDir.reduce((sum, entry) => sum + entry.value, 0);
   const avgValue = sortedWithDir.length ? totalValue / sortedWithDir.length : 0;
   const totalErrors = sortedWithDir.reduce(
-    (sum, session) => sum + (session.usage?.messageCounts?.errors ?? 0),
+    (sum, entry) => sum + (entry.session.usage?.messageCounts?.errors ?? 0),
     0,
   );
 
   const renderSessionBarRow = (
-    s: UsageSessionEntry,
+    entry: (typeof sortedSessions)[number],
     isSelected: boolean,
     orderedKeys: string[],
   ) => {
-    const value = getSessionValue(s);
-    const displayLabel = formatSessionListLabel(s);
+    const { session: s, value, displayLabel } = entry;
     const meta = buildSessionMeta(s);
     return html`
       <div
@@ -942,7 +943,7 @@ function renderSessionsCard(
             class="btn btn--sm btn--ghost"
             @click=${(e: MouseEvent) => {
               e.stopPropagation();
-              void handleCopyButton(e, formatSessionListLabel(s), t("usage.sessions.copy"));
+              void handleCopyButton(e, displayLabel, t("usage.sessions.copy"));
             }}
           >
             <span data-copy-label>${t("usage.sessions.copy")}</span>
@@ -956,17 +957,17 @@ function renderSessionsCard(
   };
 
   const selectedSet = new Set(selectedSessions);
-  const selectedEntries = sortedWithDir.filter((s) => selectedSet.has(s.key));
+  const selectedEntries = sortedWithDir.filter((entry) => selectedSet.has(entry.session.key));
   const selectedCount = selectedEntries.length;
-  const sessionMap = new Map(sortedWithDir.map((s) => [s.key, s]));
+  const sessionMap = new Map(sortedWithDir.map((entry) => [entry.session.key, entry]));
   const recentEntries = recentSessions
     .map((key) => sessionMap.get(key))
-    .filter((entry): entry is UsageSessionEntry => Boolean(entry));
-  const renderSessionBarRows = (entries: UsageSessionEntry[]) => {
+    .filter((entry) => entry !== undefined);
+  const renderSessionBarRows = (entries: typeof sortedSessions) => {
     // Selection follows this rendered group, before a click reorders recently viewed sessions.
-    const orderedKeys = entries.map((entry) => entry.key);
+    const orderedKeys = entries.map((entry) => entry.session.key);
     return entries.map((entry) =>
-      renderSessionBarRow(entry, selectedSet.has(entry.key), orderedKeys),
+      renderSessionBarRow(entry, selectedSet.has(entry.session.key), orderedKeys),
     );
   };
 


### PR DESCRIPTION
Closes #140731

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Resolves repeated selected-day metric scans in Usage session cards. Sorting, averages and all/recent/selected rows repeatedly derive token and cost values from the same daily buckets during one render.

## Why This Change Was Made

Compute both metrics once per session and carry the chosen display value, sort value and label through the render. Remove three nested derivation functions and the redundant raw-row copy, while keeping rendered metadata lazy. The prepared values are local to the render; no retained cache is added.

## User Impact

The 1,000-session × 30-day selected fixture reduces bucket visits from 544,530 to 30,000. Observed renderer plus synchronous DOM median changes from 7.3 to 0.9 ms in that component fixture. Display/sort independence, tie order, reversal, fallback values, duplicate keys and group-local selection stay intact.

Those timings exclude layout, paint and asynchronous custom-element updates. This is not full-page or live-Gateway performance proof, and small controls do not show uniform allocation improvements.

## Evidence

- The original owner fails the independent operation ceiling (`22 > 6`) while rendered values remain correct. Final ceilings allow cheaper correct implementations and still enforce numeric-value/order/average behavior.
- All 28 final owner tests, the full changed-file gate and fresh isolated P2 autoreview passed on the final test hash. The prior 56 owner/sibling tests remain valid because production and sibling source are unchanged.
- All 22 complete behavior fingerprints and eight Shift/copy interaction scenarios match. All eight before/after image pairs are byte-identical.
- Only two files change: production net +1 line, tests net +223. No configuration, API, persistence or import-boundary change was made.

The two approved synthetic cost-view component captures below demonstrate rendering/interaction parity. Images do not prove CPU or allocation improvements. Related #96945, #140218 and #137396 address distinct costs and accounting behavior.

![Before: synthetic Usage session card; component parity only](https://github.com/user-attachments/assets/78e464a3-8620-4c72-a118-d711e4fdfc5e)

![After: synthetic Usage session card; component parity only](https://github.com/user-attachments/assets/442965b9-d2d5-4a07-9b39-707451e6807e)