### PR TITLE
fix(cli): preserve plugin manifests when builds fail

### DIFF
--- a/src/cli/plugins-authoring-command.test.ts
+++ b/src/cli/plugins-authoring-command.test.ts
@@ -687,7 +687,7 @@ describe("plugin authoring commands", () => {
       const originalPackage = fs.readFileSync(packagePath);
       const originalMode = fs.statSync(packagePath).mode & 0o7777;
       const originalDirectoryMode = fs.statSync(tmpDir).mode & 0o7777;
-      const originalEntries = fs.readdirSync(tmpDir).sort();
+      const originalEntries = fs.readdirSync(tmpDir).toSorted();
       const error = Object.assign(new Error("publication failed"), {
         code: failure === "write" ? "ENOSPC" : "EPERM",
       });
@@ -734,7 +734,7 @@ describe("plugin authoring commands", () => {
         expect(fs.readFileSync(packagePath)).toEqual(originalPackage);
         expect(fs.statSync(packagePath).mode & 0o7777).toBe(originalMode);
         expect(fs.statSync(tmpDir).mode & 0o7777).toBe(originalDirectoryMode);
-        expect(fs.readdirSync(tmpDir).sort()).toEqual(originalEntries);
+        expect(fs.readdirSync(tmpDir).toSorted()).toEqual(originalEntries);
         expect(log).not.toHaveBeenCalled();
       } finally {
         vi.restoreAllMocks();

--- a/src/cli/plugins-authoring-command.test.ts
+++ b/src/cli/plugins-authoring-command.test.ts
@@ -1,5 +1,6 @@
 // Plugins authoring command tests cover plugin authoring command output and file generation.
 import fs from "node:fs";
+import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
@@ -638,7 +639,6 @@ describe("plugin authoring commands", () => {
       toolName: "deleted_cwd_echo",
     });
     const originalCwd = process.cwd();
-    const originalWriteFileSync = fs.writeFileSync.bind(fs);
     let cwdRemoved = false;
     const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
     const cwd = vi.spyOn(process, "cwd").mockImplementation(() => {
@@ -647,14 +647,16 @@ describe("plugin authoring commands", () => {
       }
       return originalCwd;
     });
-    const writeFileSync = vi
-      .spyOn(fs, "writeFileSync")
-      .mockImplementation((file, data, options) => {
-        originalWriteFileSync(file, data, options);
-        if (file === packagePath) {
-          cwdRemoved = true;
-        }
-      });
+    // The package.json write is staged through an atomic temp file, so hook the
+    // temp open instead of the final path.
+    const realOpen = fsp.open.bind(fsp);
+    const openSpy = vi.spyOn(fsp, "open").mockImplementation(async (file, flags, mode) => {
+      const handle = await realOpen(file, flags, mode as never);
+      if (String(file).startsWith(tmpDir) && String(file).endsWith(".tmp")) {
+        cwdRemoved = true;
+      }
+      return handle;
+    });
 
     try {
       await runPluginsBuildCommand({ root: tmpDir, entry: entryPath });
@@ -662,10 +664,59 @@ describe("plugin authoring commands", () => {
       expect(fs.existsSync(path.join(tmpDir, "openclaw.plugin.json"))).toBe(true);
       expect(log).toHaveBeenCalledWith(`Wrote ${path.join(tmpDir, "openclaw.plugin.json")}`);
       expect(log).toHaveBeenCalledWith(`Updated ${packagePath}`);
+      expect(cwdRemoved).toBe(true);
     } finally {
-      writeFileSync.mockRestore();
+      openSpy.mockRestore();
       cwd.mockRestore();
       log.mockRestore();
+      fs.rmSync(tmpDir, { force: true, recursive: true });
+    }
+  });
+
+  it("keeps the original package.json intact when the build write fails mid-flight", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-build-write-fail-"));
+    const packagePath = path.join(tmpDir, "package.json");
+    const entryPath = writeSourceToolPluginProject({
+      tmpDir,
+      packageName: "openclaw-plugin-build-write-fail",
+      pluginId: "build-write-fail",
+      toolName: "build_write_fail_echo",
+    });
+    const originalPackage = fs.readFileSync(packagePath, "utf8");
+    const originalMode = fs.statSync(packagePath).mode & 0o777;
+
+    // Fail the staged package.json write halfway through, as a full disk does.
+    // fs-safe writes via fs.promises.writeFile(handle, content), so track the
+    // staged temp handle at open time and fail its writeFile.
+    const stagedHandles = new Set<unknown>();
+    const realOpen = fsp.open.bind(fsp);
+    const realWriteFile = fsp.writeFile.bind(fsp);
+    const openSpy = vi.spyOn(fsp, "open").mockImplementation(async (file, flags, mode) => {
+      const handle = await realOpen(file, flags, mode as never);
+      if (String(file).startsWith(tmpDir) && String(file).endsWith(".tmp")) {
+        stagedHandles.add(handle);
+      }
+      return handle;
+    });
+    const writeSpy = vi.spyOn(fsp, "writeFile").mockImplementation(async (file, data, options) => {
+      if (stagedHandles.has(file)) {
+        const text = typeof data === "string" ? data : Buffer.from(data as Uint8Array);
+        await realWriteFile(file as never, text.slice(0, 16), options as never);
+        throw Object.assign(new Error("no space left on device"), { code: "ENOSPC" });
+      }
+      return realWriteFile(file as never, data as never, options as never);
+    });
+
+    try {
+      await expect(
+        runPluginsBuildCommand({ root: tmpDir, entry: entryPath }),
+      ).rejects.toMatchObject({ code: "ENOSPC" });
+      expect(fs.readFileSync(packagePath, "utf8")).toBe(originalPackage);
+      expect(fs.statSync(packagePath).mode & 0o777).toBe(originalMode);
+      expect(fs.readdirSync(tmpDir).filter((entry) => entry.includes(".tmp"))).toEqual([]);
+    } finally {
+      writeSpy.mockRestore();
+      openSpy.mockRestore();
       fs.rmSync(tmpDir, { force: true, recursive: true });
     }
   });

--- a/src/cli/plugins-authoring-command.test.ts
+++ b/src/cli/plugins-authoring-command.test.ts
@@ -647,11 +647,9 @@ describe("plugin authoring commands", () => {
       }
       return originalCwd;
     });
-    // The package.json write is staged through an atomic temp file, so hook the
-    // temp open instead of the final path.
     const realOpen = fsp.open.bind(fsp);
     const openSpy = vi.spyOn(fsp, "open").mockImplementation(async (file, flags, mode) => {
-      const handle = await realOpen(file, flags, mode as never);
+      const handle = await realOpen(file, flags, mode);
       if (String(file).startsWith(tmpDir) && String(file).endsWith(".tmp")) {
         cwdRemoved = true;
       }
@@ -673,53 +671,76 @@ describe("plugin authoring commands", () => {
     }
   });
 
-  it("keeps the original package.json intact when the build write fails mid-flight", async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-build-write-fail-"));
-    const packagePath = path.join(tmpDir, "package.json");
-    const entryPath = writeSourceToolPluginProject({
-      tmpDir,
-      packageName: "openclaw-plugin-build-write-fail",
-      pluginId: "build-write-fail",
-      toolName: "build_write_fail_echo",
-    });
-    const originalPackage = fs.readFileSync(packagePath, "utf8");
-    const originalMode = fs.statSync(packagePath).mode & 0o777;
+  it.each(["write", "rename"] as const)(
+    "keeps the project intact when package publication fails during %s",
+    async (failure) => {
+      const tmpDir = tempDirs.make("openclaw-plugin-build-failure-");
+      const packagePath = path.join(tmpDir, "package.json");
+      const entryPath = writeSourceToolPluginProject({
+        tmpDir,
+        packageName: "openclaw-plugin-build-failure",
+        pluginId: "build-failure",
+        toolName: "build_failure_echo",
+      });
+      fs.chmodSync(packagePath, 0o640);
+      fs.chmodSync(tmpDir, 0o3770);
+      const originalPackage = fs.readFileSync(packagePath);
+      const originalMode = fs.statSync(packagePath).mode & 0o7777;
+      const originalDirectoryMode = fs.statSync(tmpDir).mode & 0o7777;
+      const originalEntries = fs.readdirSync(tmpDir).sort();
+      const error = Object.assign(new Error("publication failed"), {
+        code: failure === "write" ? "ENOSPC" : "EPERM",
+      });
+      let stagedHandle: Awaited<ReturnType<typeof fsp.open>> | undefined;
+      const realOpen = fsp.open.bind(fsp);
+      vi.spyOn(fsp, "open").mockImplementation(async (file, flags, mode) => {
+        const handle = await realOpen(file, flags, mode);
+        if (String(file).startsWith(tmpDir) && String(file).endsWith(".tmp")) {
+          stagedHandle = handle;
+        }
+        return handle;
+      });
+      const realWrite = fsp.writeFile.bind(fsp);
+      vi.spyOn(fsp, "writeFile").mockImplementation(async (file, data, options) => {
+        if (failure === "write" && file === stagedHandle) {
+          await realWrite(file, "partial");
+          throw error;
+        }
+        return realWrite(file, data, options);
+      });
+      const realWriteSync = fs.writeFileSync.bind(fs);
+      vi.spyOn(fs, "writeFileSync").mockImplementation((file, data, options) => {
+        if (failure === "write" && file === packagePath) {
+          realWriteSync(file, "partial");
+          throw error;
+        }
+        return realWriteSync(file, data, options);
+      });
+      const realRename = fsp.rename.bind(fsp);
+      vi.spyOn(fsp, "rename").mockImplementation(async (from, to) => {
+        if (failure === "rename" && to === packagePath) {
+          throw error;
+        }
+        return realRename(from, to);
+      });
+      const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
 
-    // Fail the staged package.json write halfway through, as a full disk does.
-    // fs-safe writes via fs.promises.writeFile(handle, content), so track the
-    // staged temp handle at open time and fail its writeFile.
-    const stagedHandles = new Set<unknown>();
-    const realOpen = fsp.open.bind(fsp);
-    const realWriteFile = fsp.writeFile.bind(fsp);
-    const openSpy = vi.spyOn(fsp, "open").mockImplementation(async (file, flags, mode) => {
-      const handle = await realOpen(file, flags, mode as never);
-      if (String(file).startsWith(tmpDir) && String(file).endsWith(".tmp")) {
-        stagedHandles.add(handle);
+      try {
+        await expect(
+          runPluginsBuildCommand({ root: tmpDir, entry: entryPath }),
+        ).rejects.toMatchObject({
+          code: error.code,
+        });
+        expect(fs.readFileSync(packagePath)).toEqual(originalPackage);
+        expect(fs.statSync(packagePath).mode & 0o7777).toBe(originalMode);
+        expect(fs.statSync(tmpDir).mode & 0o7777).toBe(originalDirectoryMode);
+        expect(fs.readdirSync(tmpDir).sort()).toEqual(originalEntries);
+        expect(log).not.toHaveBeenCalled();
+      } finally {
+        vi.restoreAllMocks();
       }
-      return handle;
-    });
-    const writeSpy = vi.spyOn(fsp, "writeFile").mockImplementation(async (file, data, options) => {
-      if (stagedHandles.has(file)) {
-        const text = typeof data === "string" ? data : Buffer.from(data as Uint8Array);
-        await realWriteFile(file as never, text.slice(0, 16), options as never);
-        throw Object.assign(new Error("no space left on device"), { code: "ENOSPC" });
-      }
-      return realWriteFile(file as never, data as never, options as never);
-    });
-
-    try {
-      await expect(
-        runPluginsBuildCommand({ root: tmpDir, entry: entryPath }),
-      ).rejects.toMatchObject({ code: "ENOSPC" });
-      expect(fs.readFileSync(packagePath, "utf8")).toBe(originalPackage);
-      expect(fs.statSync(packagePath).mode & 0o777).toBe(originalMode);
-      expect(fs.readdirSync(tmpDir).filter((entry) => entry.includes(".tmp"))).toEqual([]);
-    } finally {
-      writeSpy.mockRestore();
-      openSpy.mockRestore();
-      fs.rmSync(tmpDir, { force: true, recursive: true });
-    }
-  });
+    },
+  );
 
   it("finishes init with an absolute directory after the launch directory is removed", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-deleted-cwd-init-"));

--- a/src/cli/plugins-authoring-command.test.ts
+++ b/src/cli/plugins-authoring-command.test.ts
@@ -671,6 +671,41 @@ describe("plugin authoring commands", () => {
     }
   });
 
+  it("builds and checks metadata through a symlink project root", async () => {
+    const tmpDir = tempDirs.make("openclaw-plugin-symlink-root-");
+    const projectDir = path.join(tmpDir, "project");
+    fs.mkdirSync(projectDir);
+    writeSourceToolPluginProject({
+      tmpDir: projectDir,
+      packageName: "openclaw-plugin-symlink-root",
+      pluginId: "symlink-root",
+      toolName: "symlink_root_echo",
+    });
+    const linkedRoot = path.join(tmpDir, "linked-project");
+    fs.symlinkSync(projectDir, linkedRoot, process.platform === "win32" ? "junction" : "dir");
+    const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    const opts = { root: linkedRoot, entry: path.join(linkedRoot, "src", "index.ts") };
+
+    try {
+      await runPluginsBuildCommand(opts);
+      expect(
+        JSON.parse(fs.readFileSync(path.join(projectDir, "package.json"), "utf8")),
+      ).toMatchObject({
+        openclaw: { extensions: ["./src/index.ts"] },
+      });
+      expect(
+        JSON.parse(fs.readFileSync(path.join(projectDir, "openclaw.plugin.json"), "utf8")),
+      ).toMatchObject({
+        id: "symlink-root",
+        contracts: { tools: ["symlink_root_echo"] },
+      });
+      await runPluginsBuildCommand({ ...opts, check: true });
+      expect(log).toHaveBeenCalledWith("Plugin metadata is up to date.");
+    } finally {
+      log.mockRestore();
+    }
+  });
+
   it.each(["write", "rename"] as const)(
     "keeps the project intact when package publication fails during %s",
     async (failure) => {

--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { jsonSchemaValuesEqual } from "@openclaw/normalization-core/json-schema";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { replaceFileAtomic } from "../infra/replace-file.js";
 import { formatCwdRelativePathOrAbsolute as formatOutputPath } from "../infra/safe-cwd.js";
 import { getToolPluginMetadata, type ToolPluginMetadata } from "../plugin-sdk/tool-plugin.js";
 import {
@@ -328,7 +329,19 @@ export async function runPluginsBuildCommand(opts: PluginsBuildOptions): Promise
     return;
   }
 
-  writeJsonFile(packagePath, nextPackageManifest);
+  // The build rewrites the user's hand-maintained package.json in place; publish
+  // it atomically (preserving the existing file and directory modes) so a
+  // mid-write failure cannot truncate the manifest, matching the adjacent
+  // openclaw.plugin.json tmp+rename write.
+  await replaceFileAtomic({
+    filePath: packagePath,
+    content: `${JSON.stringify(nextPackageManifest, null, 2)}\n`,
+    preserveExistingMode: true,
+    dirMode: (await fs.promises.stat(rootDir)).mode & 0o777,
+    copyFallbackOnPermissionError: true,
+    syncTempFile: true,
+    syncParentDir: true,
+  });
   await writePluginBuildManifest(rootDir, manifest);
   defaultRuntime.log(`Wrote ${formatOutputPath(manifestPath, PLUGIN_MANIFEST_FILENAME)}`);
   defaultRuntime.log(`Updated ${formatOutputPath(packagePath, "package.json")}`);

--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -329,15 +329,16 @@ export async function runPluginsBuildCommand(opts: PluginsBuildOptions): Promise
     return;
   }
 
+  const realRootDir = fs.realpathSync(rootDir);
   await replaceFileAtomic({
-    filePath: packagePath,
+    filePath: path.join(realRootDir, "package.json"),
     content: `${JSON.stringify(nextPackageManifest, null, 2)}\n`,
     preserveExistingMode: true,
-    dirMode: (await fs.promises.stat(rootDir)).mode & 0o7777,
+    dirMode: (await fs.promises.stat(realRootDir)).mode & 0o7777,
     syncTempFile: true,
     syncParentDir: true,
   });
-  await writePluginBuildManifest(rootDir, manifest);
+  await writePluginBuildManifest(realRootDir, manifest);
   defaultRuntime.log(`Wrote ${formatOutputPath(manifestPath, PLUGIN_MANIFEST_FILENAME)}`);
   defaultRuntime.log(`Updated ${formatOutputPath(packagePath, "package.json")}`);
 }

--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -329,16 +329,11 @@ export async function runPluginsBuildCommand(opts: PluginsBuildOptions): Promise
     return;
   }
 
-  // The build rewrites the user's hand-maintained package.json in place; publish
-  // it atomically (preserving the existing file and directory modes) so a
-  // mid-write failure cannot truncate the manifest, matching the adjacent
-  // openclaw.plugin.json tmp+rename write.
   await replaceFileAtomic({
     filePath: packagePath,
     content: `${JSON.stringify(nextPackageManifest, null, 2)}\n`,
     preserveExistingMode: true,
-    dirMode: (await fs.promises.stat(rootDir)).mode & 0o777,
-    copyFallbackOnPermissionError: true,
+    dirMode: (await fs.promises.stat(rootDir)).mode & 0o7777,
     syncTempFile: true,
     syncParentDir: true,
   });


### PR DESCRIPTION
## What Problem This Solves

A failed `openclaw plugins build` could truncate the user's hand-maintained `package.json`, leaving invalid JSON and breaking the plugin project.

## Solution

Publish the complete package manifest through the existing atomic replacement helper. Preserve the file mode and all parent-directory permission bits, including setgid and sticky bits. A failed rename reports an error without falling back to an in-place copy. Resolve a selected symlink project root for publication while preserving entry validation and displayed paths.

## User Impact

A failed package-manifest write preserves the original file. After the filesystem problem is resolved, the same build can succeed. Successful JSON output, `--check`, initialization, and adjacent plugin-manifest publication retain their behavior.

## Evidence

- Real CLI under a file-size limit: the original publication code truncated a 5,164-byte manifest to 2,048 bytes of invalid JSON. The repaired runtime preserved all 5,164 bytes through both physical and symlink project roots.
- Partial disk-full writes and rename permission failures preserve bytes, file mode `02640`, directory mode `03770`, and remove owned temporary files. Successful retries generate both manifests.
- Staged-file symlink, hardlink, file replacement, and directory replacement are rejected without modifying unrelated targets. Entries whose ownership can no longer be verified remain protected instead of being deleted.
- Fresh independent CLI checks cover relative and absolute entries through symlink roots, failures, retries, modes, checks, and initialization. Adjacent-manifest failure remains visible; no transaction across both manifests is promised.
- All 28 focused authoring tests passed, including the symlink-root regression. The two interrupted-publication cases fail against the original publication code for the expected reasons.
- Formatting, lint, source review, build, type checks, and [CI for this head](https://github.com/openclaw/openclaw/actions/runs/34087634188) passed. Runtime proof used the compiled merge artifact from that run.
