### PR TITLE
refactor(logging): share portable redaction pattern mechanics

### DIFF
--- a/src/logging/redact-pattern-runtime.ts
+++ b/src/logging/redact-pattern-runtime.ts
@@ -1,0 +1,34 @@
+// Browser-safe pattern mechanics; callers retain compilation and masking policy.
+export function parseRedactPatternSource(raw: string): [source: string, flags: string] {
+  const literal = raw.match(/^\/(.+)\/([gimsuy]*)$/);
+  if (!literal) {
+    return [raw, "gi"];
+  }
+  const source = literal[1] ?? "";
+  const flags = literal[2] ?? "";
+  return [source, flags.includes("g") ? flags : `${flags}g`];
+}
+
+export function readRedactMatch(args: unknown[]) {
+  const hasNamedGroups =
+    args.length > 0 && typeof args[args.length - 1] === "object" && args[args.length - 1] !== null;
+  const inputIndex = hasNamedGroups ? args.length - 2 : args.length - 1;
+  const offsetIndex = inputIndex - 1;
+  const match = typeof args[0] === "string" ? args[0] : "";
+  const groups = args
+    .slice(1, offsetIndex)
+    .map((value) => (typeof value === "string" ? value : ""));
+  const offset = typeof args[offsetIndex] === "number" ? args[offsetIndex] : -1;
+  const input = typeof args[inputIndex] === "string" ? args[inputIndex] : "";
+  return { match, groups, input, offset };
+}
+
+export type RedactMatch = ReturnType<typeof readRedactMatch>;
+
+export function redactPemBlock(block: string, marker: string): string {
+  const lines = block.split(/\r?\n/).filter(Boolean);
+  if (lines.length < 2) {
+    return "***";
+  }
+  return `${lines[0]}\n${marker}\n${lines[lines.length - 1]}`;
+}

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -1,5 +1,4 @@
 import { isSensitiveUrlQueryParamName } from "@openclaw/net-policy/redact-sensitive-url";
-import { expectDefined } from "@openclaw/normalization-core";
 // Redaction helpers scrub secrets and sensitive identifiers from log output.
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
@@ -11,6 +10,12 @@ import { compileConfigRegex } from "../security/config-regex.js";
 import { readLoggingConfig } from "./config.js";
 import { replacePatternBounded } from "./redact-bounded.js";
 import { isFullContextToolPayloadRedaction } from "./redact-internal.js";
+import {
+  parseRedactPatternSource,
+  readRedactMatch,
+  redactPemBlock,
+  type RedactMatch,
+} from "./redact-pattern-runtime.js";
 import {
   AWS_SECRET_ACCESS_KEY_FIELD_KEYS,
   AWS_SECRET_ACCESS_KEY_VALUE_PATTERN,
@@ -162,16 +167,7 @@ function parsePattern(raw: RedactPattern): RegExp | null {
       pattern = new RegExp(raw.source, `${raw.flags}g`);
     }
   } else if (raw.trim()) {
-    const match = raw.match(/^\/(.+)\/([gimsuy]*)$/);
-    if (match) {
-      const flags = expectDefined(match[2], "redact regex capture 2").includes("g")
-        ? match[2]
-        : `${match[2]}g`;
-      pattern =
-        compileConfigRegex(expectDefined(match[1], "redact regex capture 1"), flags)?.regex ?? null;
-    } else {
-      pattern = compileConfigRegex(raw, "gi")?.regex ?? null;
-    }
+    pattern = compileConfigRegex(...parseRedactPatternSource(raw))?.regex ?? null;
   }
   if (pattern && typeof raw === "string" && SHELL_REFERENCE_PRESERVING_PATTERN_SOURCES.has(raw)) {
     shellReferencePreservingPatterns.add(pattern);
@@ -577,14 +573,6 @@ function markFormBodyRedactions(text: string, bitmap: boolean[]): void {
   }
 }
 
-function redactPemBlock(block: string): string {
-  const lines = block.split(/\r?\n/).filter(Boolean);
-  if (lines.length < 2) {
-    return "***";
-  }
-  return `${lines[0]}\n…redacted…\n${lines[lines.length - 1]}`;
-}
-
 function isShellReferenceToKey(key: string, value: string): boolean {
   if (!/^[A-Z_][A-Z0-9_]*$/.test(key)) {
     return false;
@@ -689,26 +677,20 @@ function getSecretCaptureStart(
 }
 
 function redactMatch(
-  match: string,
-  groups: string[],
+  { match, groups, input, offset }: RedactMatch,
   pattern: RegExp,
-  context?: {
-    input?: string;
-    offset?: number;
-    preserveSourceAssignment?: (text: string, offset: number) => boolean;
-  },
+  preserveSourceAssignment?: (text: string, offset: number) => boolean,
 ): string {
   if (match.includes("PRIVATE KEY-----")) {
-    return redactPemBlock(match);
+    return redactPemBlock(match, "…redacted…");
   }
   const selected = selectSecretCapture(match, groups);
   const token = selected.value;
   if (
     sourceAssignmentPatterns.has(pattern) &&
-    context?.preserveSourceAssignment?.(
-      context.input ?? "",
-      (context.offset ?? -1) +
-        getSecretCaptureStart(pattern, context.input ?? "", match, context.offset ?? -1, selected),
+    preserveSourceAssignment?.(
+      input,
+      offset + getSecretCaptureStart(pattern, input, match, offset, selected),
     )
   ) {
     return match;
@@ -737,7 +719,7 @@ function redactMatch(
   // Source goes through both the guard and SQLite. Full assignment masks keep
   // those copies identical; diagnostic hints otherwise shrink on the second pass.
   const masked =
-    context?.preserveSourceAssignment && sourceAssignmentPatterns.has(pattern)
+    preserveSourceAssignment && sourceAssignmentPatterns.has(pattern)
       ? maskSecretValue(token)
       : isShellReferencePattern
         ? maskToken(token)
@@ -745,13 +727,7 @@ function redactMatch(
   if (token === match) {
     return masked;
   }
-  const tokenIndex = getSecretCaptureStart(
-    pattern,
-    context?.input ?? "",
-    match,
-    context?.offset ?? -1,
-    selected,
-  );
+  const tokenIndex = getSecretCaptureStart(pattern, input, match, offset, selected);
   if (tokenIndex < 0) {
     return match;
   }
@@ -777,25 +753,8 @@ function redactText(
     next = redactFormBody(next);
   }
   for (const pattern of patterns) {
-    const replacer = (...args: unknown[]) => {
-      const hasNamedGroups =
-        args.length > 0 &&
-        typeof args[args.length - 1] === "object" &&
-        args[args.length - 1] !== null;
-      const inputIndex = hasNamedGroups ? args.length - 2 : args.length - 1;
-      const offsetIndex = inputIndex - 1;
-      const match = typeof args[0] === "string" ? args[0] : "";
-      const groups = args
-        .slice(1, offsetIndex)
-        .map((value) => (typeof value === "string" ? value : ""));
-      const offset = typeof args[offsetIndex] === "number" ? args[offsetIndex] : -1;
-      const input = typeof args[inputIndex] === "string" ? args[inputIndex] : "";
-      return redactMatch(match, groups, pattern, {
-        input,
-        offset,
-        preserveSourceAssignment: options?.preserveSourceAssignment,
-      });
-    };
+    const replacer = (...args: unknown[]) =>
+      redactMatch(readRedactMatch(args), pattern, options?.preserveSourceAssignment);
     next =
       options?.fullContext || chunkUnsafePatterns.has(pattern)
         ? next.replace(pattern, replacer)
@@ -882,9 +841,7 @@ function looksLikeAppSpecificPassword(candidate: string): boolean {
 
 function redactAppSpecificPasswords(text: string): string {
   return replacePatternBounded(text, APP_SPECIFIC_PASSWORD_RE, (match: string, token: string) =>
-    looksLikeAppSpecificPassword(token)
-      ? redactMatch(match, [token], APP_SPECIFIC_PASSWORD_RE)
-      : match,
+    looksLikeAppSpecificPassword(token) ? maskToken(token) : match,
   );
 }
 

--- a/ui/src/lib/browser-redact.ts
+++ b/ui/src/lib/browser-redact.ts
@@ -1,19 +1,18 @@
 // Browser-safe redaction for tool details rendered by the Control UI.
 import { isSensitiveUrlQueryParamName } from "@openclaw/net-policy/redact-sensitive-url";
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import {
+  parseRedactPatternSource,
+  readRedactMatch,
+  redactPemBlock,
+  type RedactMatch,
+} from "../../../src/logging/redact-pattern-runtime.js";
 import { DEFAULT_REDACT_PATTERNS } from "../../../src/logging/redact-patterns.js";
 
 const URL_QUERY_PAIR_RE = /([?&])([^=&#\s]+)=([^&#\s"'<>]+)/gu;
-const SECRET_DETAIL_PATTERNS = DEFAULT_REDACT_PATTERNS.map((source) => {
-  const literal = source.match(/^\/(.+)\/([gimsuy]*)$/);
-  if (!literal) {
-    return new RegExp(source, "gi");
-  }
-  const patternSource = literal[1] ?? "";
-  const patternFlags = literal[2] ?? "";
-  const flags = patternFlags.includes("g") ? patternFlags : `${patternFlags}g`;
-  return new RegExp(patternSource, flags);
-});
+const SECRET_DETAIL_PATTERNS = DEFAULT_REDACT_PATTERNS.map(
+  (source) => new RegExp(...parseRedactPatternSource(source)),
+);
 const SENSITIVE_TEXT_PATTERNS: Array<[RegExp, string]> = [
   [/\b(Authorization|Cookie|Set-Cookie)\s*:\s*[^\n\r]+/gi, "$1: [redacted]"],
   [/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, "$1[redacted]"],
@@ -48,21 +47,10 @@ function redactToken(value: string): string {
   return `${sliceUtf16Safe(value, 0, 6)}...${sliceUtf16Safe(value, -4)}`;
 }
 
-function redactPemBlock(block: string): string {
-  const lines = block.split(/\r?\n/).filter(Boolean);
-  if (lines.length < 2) {
-    return "***";
-  }
-  return `${lines[0]}\n...redacted...\n${lines[lines.length - 1]}`;
-}
-
-function redactMatch(
-  match: string,
-  groups: Array<string | undefined>,
-  followingText: string,
-): string {
+function redactMatch({ match, groups, input, offset }: RedactMatch): string {
+  const followingText = offset < 0 ? "" : input.slice(offset + match.length);
   if (match.includes("PRIVATE KEY-----")) {
-    return redactPemBlock(match);
+    return redactPemBlock(match, "...redacted...");
   }
   const token = groups.findLast((group) => typeof group === "string" && group.length > 0) ?? match;
   // Replacement-template syntax can make a later pattern see only the leading `$` after an
@@ -90,17 +78,9 @@ function redactUrlQueryPairs(detail: string): string {
 export function redactToolDetail(detail: string): string {
   let redacted = redactUrlQueryPairs(detail);
   for (const pattern of SECRET_DETAIL_PATTERNS) {
-    redacted = redacted.replace(pattern, (...args: unknown[]) => {
-      const match = typeof args[0] === "string" ? args[0] : "";
-      const offsetCandidate = args[args.length - 2];
-      const inputCandidate = args[args.length - 1];
-      const offset = typeof offsetCandidate === "number" ? offsetCandidate : -1;
-      const input = typeof inputCandidate === "string" ? inputCandidate : "";
-      const groups = args
-        .slice(1, -2)
-        .map((value) => (typeof value === "string" ? value : undefined));
-      return redactMatch(match, groups, offset < 0 ? "" : input.slice(offset + match.length));
-    });
+    redacted = redacted.replace(pattern, (...args: unknown[]) =>
+      redactMatch(readRedactMatch(args)),
+    );
   }
   return SENSITIVE_TEXT_PATTERNS.reduce(
     (text, [pattern, replacement]) => text.replace(pattern, replacement),


### PR DESCRIPTION
## What Problem This Solves

Dashboard and backend redaction independently parse the same pattern literals, decode replacement callback arguments, and mask PEM blocks. Maintaining those mechanics twice risks drift while each surface intentionally has different privacy rules.

## Why This Change Was Made

A browser-safe leaf under the logging owner shares pattern source/flag parsing, concrete match context, and PEM framing. Backend compilation still uses the safe-regex validator and retains capture indexing, source-assignment preservation, bounded execution, registered secrets, and structured-field policy. Dashboard token hints, aggressive field/path masking, and literal replacement handling stay local. Each caller supplies its existing PEM marker.

The app-password path uses its existing token mask directly; its fixed pattern captures the entire unquoted password. No masking thresholds, suffixes, pattern order, or config semantics changed.

## User Impact

None intended. Existing redaction outputs and public entry points are preserved. No config option, dependency, protocol, or schema change.

## Evidence

Fresh validation at `e3da26703216b1de2c5dbc759a42d51d3415d5e7`, rebased onto main `4b1195fb3566a79a8a644e692b4b7f7f7ac26546`. `git range-diff` confirms an identical patch.

- `node scripts/run-vitest.mjs src/logging/redact ui/src/lib/browser-redact`: 3 files, 219 tests passed, including named captures, source preservation, app passwords, UTF-16 boundaries, literal replacements, and distinct browser masking.
- `node scripts/check-changed.mjs`: passed; no baseline edits.
- `pnpm build`: passed in 7m 50s, including declarations, 91 plugins, runtime closure checks, and Dashboard asset budgets. Startup JS was 349,600 / 350,953 B gzip, with 8 / 18 requests.
- Fresh Codex autoreview: scoped-clean at the requested command's default P0 threshold, zero findings. The original validation also recorded a clean P0–P2 review.
- Production +67/-96, net -29 lines; no test changes. No existing public export removed or renamed.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34120339859) passed on the exact reviewed head without reruns.

The previous Workshop geometry failure is historical; this revision is being verified on current main. No redaction thresholds, regex order, configured-pattern semantics, or stored output policies change.
