### PR TITLE
fix(agents): preserve hook instructions in Gemini cached requests

### DIFF
--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -153,7 +153,7 @@ DeepSeek cache construction on OpenRouter is best-effort and can take a few seco
 
 - Direct Gemini transport (`api: "google-generative-ai"`) reports cache hits through upstream `cachedContentTokenCount`, mapped to `cacheRead`.
 - Eligible model families: `gemini-2.5*` and `gemini-3*` (excludes Live/preview variants outside that prefix match, for example `gemini-live-2.5-flash-preview`).
-- When `cacheRetention` is set on an eligible model, OpenClaw automatically creates, reuses, and refreshes a `cachedContents` resource for the system prompt - no manual cached-content handle needed. TTL is `300s` for `cacheRetention: "short"` and `3600s` for `"long"`.
+- When `cacheRetention` is set on an eligible model, OpenClaw automatically creates, reuses, and refreshes a `cachedContents` resource for the final assembled system prompt, including hook-added instructions - no manual cached-content handle needed. TTL is `300s` for `cacheRetention: "short"` and `3600s` for `"long"`.
 - You can still pass a pre-existing Gemini cached-content handle through as `params.cachedContent` (or legacy `params.cached_content`); an explicit handle skips the automatic cache-management path entirely.
 - This is separate from Anthropic/OpenAI prompt-prefix caching: OpenClaw manages a provider-native `cachedContents` resource for Gemini instead of injecting inline cache markers.
 

--- a/src/agents/embedded-agent-runner/google-prompt-cache.test-support.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.test-support.ts
@@ -160,7 +160,6 @@ export function preparePromptCacheStream(params: {
       sessionManager: params.sessionManager,
       signal: params.signal,
       streamFn: params.streamFn,
-      systemPrompt: "Follow policy.",
     },
     {
       ...(params.buildGuardedFetch

--- a/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
@@ -1,6 +1,7 @@
 // Coverage for Google prompt-cache creation, reuse, and request rewriting.
 import crypto from "node:crypto";
 import { expectDefined } from "@openclaw/normalization-core";
+import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
 import { SessionTranscriptWriterClaimReboundError } from "../../config/sessions/transcript-write-context.js";
 import { isSecretValueRegisteredForRedaction } from "../../logging/secret-redaction-registry.js";
@@ -22,6 +23,103 @@ import {
 } from "./google-prompt-cache.test-support.js";
 
 describe("google prompt cache", () => {
+  it.each([200, 503])(
+    "preserves the final assembled prompt when cache creation returns %s",
+    async (statusCode) => {
+      const systemPrompt = "hook-before\nbase\nhook-after";
+      const fetchMock = vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              name: "cachedContents/final-prompt",
+              expireTime: new Date(4_600_000).toISOString(),
+            }),
+            { status: statusCode },
+          ),
+      );
+      const { streamFn, getCapturedPayload } = createCapturingStreamFn();
+      const wrapped = expectDefined(
+        await preparePromptCacheStream({
+          fetchMock,
+          now: 1_000_000,
+          sessionManager: makeSessionManager(),
+          streamFn,
+        }),
+        "managed cache wrapper",
+      );
+      const context = { systemPrompt, messages: [] };
+
+      await wrapped(makeGoogleModel(), context, {});
+
+      const body = fetchInit(fetchMock).body;
+      if (typeof body !== "string") {
+        throw new Error("Expected a JSON cache request body");
+      }
+      expect(JSON.parse(body).systemInstruction).toEqual({
+        parts: [{ text: systemPrompt }],
+      });
+      if (statusCode === 200) {
+        expect(streamContext(streamFn).systemPrompt).toBeUndefined();
+        expect(getCapturedPayload()?.cachedContent).toBe("cachedContents/final-prompt");
+      } else {
+        expect(streamContext(streamFn)).toBe(context);
+        expect(getCapturedPayload()).not.toHaveProperty("cachedContent");
+      }
+    },
+  );
+
+  it.each(["prompt", "tools"])(
+    "rebuilds the cache when final %s changes and reuses it after restart",
+    async (changed) => {
+      const entries: SessionCustomEntry[] = [];
+      const fetchMock = vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              name: `cachedContents/final-${fetchMock.mock.calls.length}`,
+              expireTime: new Date(4_600_000).toISOString(),
+            }),
+          ),
+      );
+      const { streamFn, getCapturedPayload } = createCapturingStreamFn();
+      const prepare = () =>
+        preparePromptCacheStream({
+          fetchMock,
+          now: 1_000_000,
+          sessionManager: makeSessionManager(entries),
+          streamFn,
+        });
+      const wrapped = expectDefined(await prepare(), "managed cache wrapper");
+      const tool = {
+        name: "lookup",
+        description: "Look up a value",
+        parameters: Type.Object({}),
+      };
+      const context = {
+        systemPrompt: "hook-before\nbase\nhook-after",
+        messages: [],
+        tools: [tool],
+      };
+      await wrapped(makeGoogleModel(), context, {});
+      expect(getCapturedPayload()?.cachedContent).toBe("cachedContents/final-1");
+
+      const changedContext = {
+        ...context,
+        ...(changed === "prompt"
+          ? { systemPrompt: `${context.systemPrompt}\nnew-hook-instruction` }
+          : { tools: [{ ...tool, description: "Look up the updated value" }] }),
+      };
+      await wrapped(makeGoogleModel(), changedContext, {});
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(getCapturedPayload()?.cachedContent).toBe("cachedContents/final-2");
+
+      const restarted = expectDefined(await prepare(), "restarted managed cache wrapper");
+      await restarted(makeGoogleModel(), changedContext, {});
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(getCapturedPayload()?.cachedContent).toBe("cachedContents/final-2");
+    },
+  );
+
   it("parses sentinel-backed OAuth JSON before guarded cache egress", async () => {
     const fetchMock = createCacheFetchMock({
       name: "cachedContents/oauth-cache",
@@ -535,7 +633,6 @@ describe("google prompt cache", () => {
         provider: "google",
         sessionManager: makeSessionManager(),
         streamFn: vi.fn(() => "stream" as never),
-        systemPrompt: "Follow policy.",
       },
       {
         buildGuardedFetch: () => fetchMock as typeof fetch,

--- a/src/agents/embedded-agent-runner/google-prompt-cache.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.ts
@@ -88,7 +88,6 @@ type PrepareGooglePromptCacheStreamFnParams = {
   sessionManager: GooglePromptCacheSessionManager;
   signal?: AbortSignal;
   streamFn: StreamFn | undefined;
-  systemPrompt?: string;
 };
 
 type GooglePromptCacheDeps = {
@@ -586,14 +585,17 @@ export async function prepareGooglePromptCacheStreamFn(
   if (resolvedRetention !== "short" && resolvedRetention !== "long") {
     return undefined;
   }
-  const systemPrompt = resolveManagedSystemPrompt(params.systemPrompt);
   const apiKey = params.apiKey?.trim();
-  if (!systemPrompt || !apiKey) {
+  if (!apiKey) {
     return undefined;
   }
 
   const inner = params.streamFn;
   return async (model, context, options) => {
+    const systemPrompt = resolveManagedSystemPrompt(context.systemPrompt);
+    if (!systemPrompt) {
+      return inner(model, context, options);
+    }
     const cacheConfig = buildManagedGooglePromptCacheConfig(context, options);
     const cachedContent = await ensureGooglePromptCache(
       {

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -103,7 +103,7 @@ export async function runEmbeddedAttemptPromptPhase(
   const { withOwnedTranscriptWrite } = input.sessionLock;
   const { diagnosticTrace, runTrace } = input.diagnostics;
   const { systemPromptReport, runtimeInfo } = prepared.systemPrompt;
-  // Hook phases retain the prompt/cache snapshot prepared before assembly.
+  // Hook phases retain the prompt snapshot prepared before assembly.
   const systemPromptText = sessionRuntimeState.systemPromptText;
   const toolSearchCompacted = prepared.toolCatalog.toolSearch.compacted;
   let skipPromptSubmission = false;
@@ -268,7 +268,6 @@ export async function runEmbeddedAttemptPromptPhase(
         },
         signal: runAbortController.signal,
         streamFn: activeSession.agent.streamFn,
-        systemPrompt: systemPromptText,
       });
       if (googlePromptCacheStreamFn) {
         activeSession.agent.streamFn = googlePromptCacheStreamFn;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users with prompt-build hooks would lose hook-added system instructions when managed explicit Gemini caching succeeded. The same instructions were present when cache creation failed, so model behavior depended on cache availability.

## Why This Change Was Made

Managed cache creation and identity now use the final assembled system prompt from each stream invocation, alongside its final tools. The obsolete pre-assembly prompt argument is removed. Model/API/base-URL identity, persisted transcript reuse, TTL behavior, and explicit user-supplied cache handles retain their existing contracts.

## User Impact

Eligible direct Gemini models with explicit `cacheRetention` retain the final assembled instructions, including hooks, whether generation uses a managed cache or falls back to inline instructions. Changes to the final prompt or tools select a new resource; unchanged instructions can reuse a persisted resource after restart.

## Evidence

Before the fix, the new wrapper tests failed for the intended reasons: cache creation sent `base` instead of `hook-before\nbase\nhook-after` for both successful and failed creation, and a later final-prompt change reused the old resource. Result: **3 failed, 14 passed**.

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/google-prompt-cache.test.ts src/agents/embedded-agent-runner/google-prompt-cache.failures.test.ts src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
Google cache suites: 2 files passed, 77 tests passed.
Attempt prompt phase: 1 file passed, 20 tests passed.
Overall: 2 Vitest shards passed, 97 tests passed.

node scripts/run-vitest.mjs src/agents/embedded-agent-runner/google-prompt-cache.test.ts
Final fixture cleanup rerun: 1 file passed, 17 tests passed.

node scripts/check-changed.mjs
Passed (exit 0): formatting, production/test TypeScript, lint, and all selected repository guards.

Autoreview (Codex, local diff against merge base, through P1):
scoped-clean; zero accepted/actionable findings; patch is correct.
```

The final focused rerun used a separate filesystem module-cache path because the changed-file checks were running concurrently. Proof uses injected fetch at the real wrapper boundary; no live Google API call was made. The existing Google caching protocol is unchanged.

The first changed-file gate caught a `no-base-to-string` violation in the new test's request-body assertion. The test now requires a string body before parsing JSON; the focused test rerun and fresh autoreview passed after that correction.

[Exact-head CI run 34080642084](https://github.com/openclaw/openclaw/actions/runs/34080642084) passed on `5fa7f1f771e09b681dab5ae3839773e2d7192e50`: 108 successful jobs and 16 skipped jobs. The bounded PR watcher finished `SUCCESS` with zero pending checks and exit 0. The PR remains unmerged for coordinator review.

Updated `docs/reference/prompt-caching.md` to specify that managed caching includes the final assembled prompt and hook-added instructions. Production diff: **+6/-5 lines (net +1)**. No configuration, schema, store, dependency, or snapshot changes.
