### PR TITLE
refactor(ui): share promise modal host lifecycle

### DIFF
--- a/ui/src/components/confirm-dialog.ts
+++ b/ui/src/components/confirm-dialog.ts
@@ -1,7 +1,7 @@
 // Control UI helper presents Promise-based confirmation without relying on a native dialog bridge.
-import { html, nothing, render } from "lit";
+import { html, nothing } from "lit";
 import { t } from "../i18n/index.ts";
-import "./modal-dialog.ts";
+import { withPromiseModalHost } from "./promise-modal-host.ts";
 
 /**
  * Opt-out for confirms whose action is repeatable and recoverable. Callers own
@@ -29,29 +29,11 @@ export type ConfirmDialogOptions = {
 let confirmationActive = false;
 
 function presentConfirmDialog(options: ConfirmDialogOptions): Promise<boolean> {
-  if (options.signal?.aborted) {
-    return Promise.resolve(false);
-  }
-  const host = document.createElement("div");
-  document.body.append(host);
-  return new Promise((resolve) => {
-    let settled = false;
+  return withPromiseModalHost({ signal: options.signal, value: false }, ({ render, finish }) => {
     let skipRequested = false;
-    const finish = (confirmed: boolean) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      options.signal?.removeEventListener("abort", handleAbort);
-      render(nothing, host);
-      host.remove();
-      resolve(confirmed);
-    };
-    const handleAbort = () => finish(false);
-    options.signal?.addEventListener("abort", handleAbort, { once: true });
     const title = options.title ?? t("common.confirm");
-    render(
-      html`
+    render(() => {
+      return html`
         <openclaw-modal-dialog
           label=${title}
           description=${options.message}
@@ -103,9 +85,8 @@ function presentConfirmDialog(options: ConfirmDialogOptions): Promise<boolean> {
             </div>
           </div>
         </openclaw-modal-dialog>
-      `,
-      host,
-    );
+      `;
+    });
   });
 }
 

--- a/ui/src/components/input-dialog.ts
+++ b/ui/src/components/input-dialog.ts
@@ -1,8 +1,8 @@
 // Control UI helper presents Promise-based text input without relying on a native prompt bridge.
-import { html, nothing, render } from "lit";
+import { html, nothing } from "lit";
 import { t } from "../i18n/index.ts";
 import { formatUiError } from "../lib/format-error.ts";
-import "./modal-dialog.ts";
+import { withPromiseModalHost } from "./promise-modal-host.ts";
 
 type InputDialogOptions = {
   title: string;
@@ -33,13 +33,8 @@ type InputDialogOptions = {
 let inputActive = false;
 
 function presentInputDialog(options: InputDialogOptions): Promise<string | null> {
-  if (options.signal?.aborted) {
-    return Promise.resolve(null);
-  }
-  const host = document.createElement("div");
-  document.body.append(host);
-  return new Promise((resolve) => {
-    let settled = false;
+  return withPromiseModalHost<string | null>({ signal: options.signal, value: null }, (modal) => {
+    const { host, finish, render } = modal;
     let submitting = false;
     let failure: string | null = null;
     const entryValue = (raw: string) => (options.requireValue === true ? raw.trim() : raw);
@@ -56,17 +51,6 @@ function presentInputDialog(options: InputDialogOptions): Promise<string | null>
     // composition across the repaints this triggers.
     let blocked = submitBlocked(options.defaultValue ?? "");
 
-    const finish = (value: string | null) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      options.signal?.removeEventListener("abort", handleAbort);
-      render(nothing, host);
-      host.remove();
-      resolve(value);
-    };
-    const handleAbort = () => finish(null);
     const inputElement = () => host.querySelector<HTMLInputElement>('input[name="value"]');
 
     const handleInput = (event: Event) => {
@@ -107,7 +91,7 @@ function presentInputDialog(options: InputDialogOptions): Promise<string | null>
       } catch (error) {
         message = formatUiError(error);
       }
-      if (settled) {
+      if (modal.settled) {
         return;
       }
       submitting = false;
@@ -130,12 +114,11 @@ function presentInputDialog(options: InputDialogOptions): Promise<string | null>
       finish(null);
     }
 
-    options.signal?.addEventListener("abort", handleAbort, { once: true });
     const label = options.label ?? options.title;
 
     function paint() {
-      render(
-        html`
+      render(() => {
+        return html`
           <openclaw-modal-dialog
             label=${options.title}
             description=${label}
@@ -179,9 +162,8 @@ function presentInputDialog(options: InputDialogOptions): Promise<string | null>
               </div>
             </form>
           </openclaw-modal-dialog>
-        `,
-        host,
-      );
+        `;
+      });
     }
 
     paint();

--- a/ui/src/components/promise-modal-host.ts
+++ b/ui/src/components/promise-modal-host.ts
@@ -1,0 +1,45 @@
+import { nothing, render } from "lit";
+import "./modal-dialog.ts";
+
+type PromiseModalHost<T> = {
+  host: HTMLDivElement;
+  finish: (value: T) => void;
+  render: (content: () => unknown) => void;
+  readonly settled: boolean;
+};
+
+/** Owns one imperative modal host; dismissal and reentrancy stay with its dialog. */
+export function withPromiseModalHost<T>(
+  abort: { signal?: AbortSignal; value: T } | undefined,
+  initialize: (modal: PromiseModalHost<T>) => void,
+): Promise<T> {
+  if (abort?.signal?.aborted) {
+    return Promise.resolve(abort.value);
+  }
+  const host = document.createElement("div");
+  document.body.append(host);
+  return new Promise((resolve) => {
+    const modal = {
+      host,
+      settled: false,
+      render(content: () => unknown) {
+        if (!modal.settled) {
+          render(content(), host);
+        }
+      },
+      finish(value: T) {
+        if (modal.settled) {
+          return;
+        }
+        modal.settled = true;
+        abort?.signal?.removeEventListener("abort", handleAbort);
+        render(nothing, host);
+        host.remove();
+        resolve(value);
+      },
+    };
+    const handleAbort = () => abort && modal.finish(abort.value);
+    abort?.signal?.addEventListener("abort", handleAbort, { once: true });
+    initialize(modal);
+  });
+}

--- a/ui/src/components/secret-reveal-dialog.ts
+++ b/ui/src/components/secret-reveal-dialog.ts
@@ -1,11 +1,11 @@
 // Control UI helper reveals a one-time secret in-app. window.prompt cannot do this job:
 // it is unstyled, unlabeled, uncopyable on touch, and never renders at all in a webview
 // without a dialog bridge, which drops the only copy of a freshly issued credential.
-import { html, nothing, render } from "lit";
+import { html, nothing } from "lit";
 import { t } from "../i18n/index.ts";
 import { renderCopyButton } from "./copy-button.ts";
 import { icons } from "./icons.ts";
-import "./modal-dialog.ts";
+import { withPromiseModalHost } from "./promise-modal-host.ts";
 
 type SecretRevealDialogOptions = {
   title: string;
@@ -31,15 +31,9 @@ type SecretRevealDialogOptions = {
  * settle it; without one there is nothing to lose, so they close it like any dialog.
  */
 export function showSecretRevealDialog(options: SecretRevealDialogOptions): Promise<void> {
-  const host = document.createElement("div");
-  document.body.append(host);
-  return new Promise((resolve) => {
+  return withPromiseModalHost<void>(undefined, ({ render, finish }) => {
     let dismissRefused = false;
-    const acknowledge = () => {
-      render(nothing, host);
-      host.remove();
-      resolve();
-    };
+    const acknowledge = () => finish();
     // The secret is shown once, so a stray Escape or backdrop click must not be the last
     // thing that happens to it. Web Awesome pulses the refused dialog; the hint is the
     // accessible half of that answer, because a silent no-op reads as a broken control.
@@ -62,8 +56,8 @@ export function showSecretRevealDialog(options: SecretRevealDialogOptions): Prom
     // border sits within ~4/255 of --card in dark and vanishes on this surface.
     const acknowledgeClass = options.secret ? "btn primary" : "btn secret-reveal__dismiss";
     const paint = () => {
-      render(
-        html`
+      render(() => {
+        return html`
           <openclaw-modal-dialog
             label=${options.title}
             description=${options.message}
@@ -109,9 +103,8 @@ export function showSecretRevealDialog(options: SecretRevealDialogOptions): Prom
               </div>
             </div>
           </openclaw-modal-dialog>
-        `,
-        host,
-      );
+        `;
+      });
     };
     paint();
   });

--- a/ui/src/components/session-group-defaults-dialog.ts
+++ b/ui/src/components/session-group-defaults-dialog.ts
@@ -1,4 +1,4 @@
-import { html, nothing, render } from "lit";
+import { html, nothing } from "lit";
 import { ref } from "lit/directives/ref.js";
 import type {
   FsListDirResult,
@@ -12,7 +12,7 @@ import { PlaceBrowserState } from "../pages/new-session/place-browser-state.ts";
 import { renderPlaceBrowser } from "../pages/new-session/place-browser.ts";
 import "../styles/new-session.css";
 import { icons } from "./icons.ts";
-import "./modal-dialog.ts";
+import { withPromiseModalHost } from "./promise-modal-host.ts";
 import { syncDropdownItemRadio } from "./web-awesome.ts";
 import "./web-awesome-popover.ts";
 
@@ -33,9 +33,7 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
     return Promise.resolve();
   }
   active = true;
-  const host = document.createElement("div");
-  document.body.append(host);
-  return new Promise<void>((resolve) => {
+  return withPromiseModalHost<void>(undefined, ({ host, render, finish: settle }) => {
     let cwd = options.defaults.cwd;
     let worktree = false;
     let repositoryStatus: WorktreeRepositoryStatus | "checking" = "checking";
@@ -48,10 +46,8 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
     const finish = () => {
       browser.reset();
       repositoryRequestToken += 1;
-      render(nothing, host);
-      host.remove();
+      settle();
       active = false;
-      resolve();
     };
 
     const handleSubmit = async (event: Event) => {
@@ -199,8 +195,8 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
         },
       ] as const;
       const selectedEnvironment = environmentOptions[worktree ? 1 : 0];
-      render(
-        html`
+      render(() => {
+        return html`
           <openclaw-modal-dialog
             label=${t("sessionsView.groupDefaultsTitle", { group: options.group })}
             @modal-cancel=${(event: Event) => {
@@ -436,9 +432,8 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
               </div>
             </form>
           </openclaw-modal-dialog>
-        `,
-        host,
-      );
+        `;
+      });
     }
 
     void inspectRepository(true);

--- a/ui/src/components/session-placement-move-dialog.test.ts
+++ b/ui/src/components/session-placement-move-dialog.test.ts
@@ -1,0 +1,43 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { getRenderedModalDialog, installDialogPolyfill } from "../test-helpers/modal-dialog.ts";
+import { showSessionPlacementTargetDialog } from "./session-placement-move-dialog.ts";
+
+let restoreDialogPolyfill: () => void;
+
+beforeEach(() => {
+  restoreDialogPolyfill = installDialogPolyfill();
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+  restoreDialogPolyfill();
+});
+
+it("does not repaint a cancelled placement dialog when its catalog finishes loading", async () => {
+  const catalog = createDeferred<{ profiles: []; devices: [] }>();
+  const result = showSessionPlacementTargetDialog({
+    mode: "move",
+    sessionLabel: "Example session",
+    activeRun: false,
+    loadCatalog: () => catalog.promise,
+  });
+  const { modal } = await getRenderedModalDialog(document.body);
+  const host = modal.parentElement;
+  if (!host) {
+    throw new Error("Expected the placement dialog's host");
+  }
+
+  modal.dispatchEvent(new CustomEvent("modal-cancel", { cancelable: true }));
+  await expect(result).resolves.toBeNull();
+  expect(host.isConnected).toBe(false);
+
+  catalog.resolve({ profiles: [], devices: [] });
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+  expect(host.childElementCount).toBe(0);
+});

--- a/ui/src/components/session-placement-move-dialog.ts
+++ b/ui/src/components/session-placement-move-dialog.ts
@@ -1,4 +1,4 @@
-import { html, nothing, render } from "lit";
+import { html, nothing } from "lit";
 import type { SessionMoveTarget } from "../../../packages/gateway-protocol/src/index.js";
 import { t } from "../i18n/index.ts";
 import { formatUiError } from "../lib/format-error.ts";
@@ -12,7 +12,7 @@ import type { DraftCloudProfile } from "../pages/new-session/discovery.ts";
 import { DraftCloudMachineState } from "../pages/new-session/draft-cloud-machine-state.ts";
 import "../styles/new-session.css";
 import { icons } from "./icons.ts";
-import "./modal-dialog.ts";
+import { withPromiseModalHost } from "./promise-modal-host.ts";
 
 type Catalog = {
   profiles: readonly DraftCloudProfile[];
@@ -52,9 +52,7 @@ export function showSessionPlacementTargetDialog(
     return Promise.resolve(null);
   }
   active = true;
-  const host = document.createElement("div");
-  document.body.append(host);
-  return new Promise((resolve) => {
+  return withPromiseModalHost<SessionMoveTarget | null>(undefined, ({ render, finish: settle }) => {
     let loading = true;
     let loadError: string | null = null;
     let catalog: Catalog = { profiles: [], devices: [] };
@@ -62,10 +60,8 @@ export function showSessionPlacementTargetDialog(
     const cloudMachines = new DraftCloudMachineState();
 
     const finish = (result: SessionMoveTarget | null) => {
-      render(nothing, host);
-      host.remove();
+      settle(result);
       active = false;
-      resolve(result);
     };
 
     const select = (target: SessionMoveTarget) => {
@@ -92,8 +88,8 @@ export function showSessionPlacementTargetDialog(
     function paint() {
       const selectedKey = targetKey(selected);
       const restart = options.mode === "restart";
-      render(
-        html`
+      render(() => {
+        return html`
           <openclaw-modal-dialog
             label=${t(
               restart ? "sessionsView.restartSessionTitle" : "sessionsView.moveSessionTitle",
@@ -255,9 +251,8 @@ export function showSessionPlacementTargetDialog(
               </div>
             </form>
           </openclaw-modal-dialog>
-        `,
-        host,
-      );
+        `;
+      });
     }
 
     paint();


### PR DESCRIPTION
## What Problem This Solves

The confirmation, text input, secret reveal, group-defaults, and placement dialogs duplicate imperative host creation, promise settlement, and teardown. The placement dialog can also recreate a modal subtree inside its detached host when a catalog request completes after cancellation.

## Why This Change Was Made

`components/promise-modal-host.ts`, beside `modal-dialog.ts`, now owns one host, abort-listener cleanup, once-only settlement, synchronous Lit unmount, and rejection of late rendering. Each dialog retains its dismissal rules, module reentrancy gate, validation, request generations, and submission policy. Production changes total +85/-94 (net -9); the placement regression adds 43 test lines.

## User Impact

Dialog appearance and interactions are preserved. All 30 tagged templates are byte-identical. Cancelled placement dialogs leave their retired host empty even if catalog loading completes later. Secret acknowledgment still requires the explicit action, and busy input submission still refuses incidental dismissal.

## Evidence

- The placement regression fails on the original implementation (detached host has 1 child instead of 0) and passes with the shared host.
- Focused confirmation, input, modal, placement, and chat-placement proof: 47 unit and 9 browser cases passed. A warmed browser rerun passed all 9 cases without the initial Vite optimization/reload warning.
- Mocked Gateway Playwright suites for group defaults, placement moves, and device-token reconnect: 22/22 passed.
- UI typecheck and UI build passed; startup performance passed at 346193 B gzip and 8 JavaScript requests, with no baseline edits.
- Independent Codex review: no actionable P0–P2 findings.

No protocol, persistent-state, configuration, or public SDK contract changes. This is the modal-host item in the maintainer-requested UI consolidation campaign.

Full `pnpm build` passed in 43m 5.6s. `node scripts/check-changed.mjs` and explicit `pnpm ui:check-performance` passed; final startup JavaScript is 346197 B gzip across 8 requests, with no baseline edit. The first changed-check run caught an implicit timer return in the new regression; the block-body correction preserves its assertions and timing. Both independent reviews were clean through P2.

Local proof ran before rebasing onto `b7ec235a5cc05ae9577095498de5cfd6b8e2d293`; complete pre/post-rebase patches compare byte-identically. Current head `b8d3bdecb865ca9932f03b502dd16b958bacd636` passed [hosted CI](https://github.com/openclaw/openclaw/actions/runs/34082971759), native review validation, and native prepare. Prepare used the repository's hosted-proof mode (`OPENCLAW_TESTBOX=1`); no separate Testbox lease was allocated.

Focused commands:

```sh
node scripts/run-vitest.mjs ui/src/components/confirm-dialog.test.ts ui/src/components/input-dialog.test.ts ui/src/components/modal-dialog.test.ts ui/src/components/session-placement-move-dialog.test.ts ui/src/pages/chat/chat-pane-placement.test.ts ui/src/pages/chat/chat-pane-placement-restart.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-management.group-defaults.e2e.test.ts ui/src/e2e/session-placement.move.e2e.test.ts ui/src/e2e/device-token-reconnect.e2e.test.ts
```
