### PR TITLE
fix(ci): prevent idle gateway fixture port collisions

### DIFF
--- a/test/helpers/openclaw-test-instance.acquisition.test.ts
+++ b/test/helpers/openclaw-test-instance.acquisition.test.ts
@@ -1,25 +1,44 @@
 import fs from "node:fs/promises";
+import net from "node:net";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { captureFullEnv } from "../../src/test-utils/env.js";
 import { createOpenClawTestInstance } from "./openclaw-test-instance.js";
 
 describe("createOpenClawTestInstance acquisition", () => {
-  it.each(["merge", "serialization", "write"] as const)(
-    "releases acquired state when initial config %s fails",
+  it.each(["state", "merge", "serialization", "write", "cleanup"] as const)(
+    "cleans up available resources after %s acquisition failure",
     async (stage) => {
       const previousEnv = { ...process.env };
       const snapshot = captureFullEnv();
       const failure = new Error(`config ${stage} failed`);
       let root: string | undefined;
       let writeFailure: unknown;
+      const cleanupFailure = new Error("state cleanup failed");
+      const serverSpy = vi.spyOn(net, "createServer");
+      let reservedPort: number | undefined;
       const mkdtemp = fs.mkdtemp;
       const allocationSpy = vi.spyOn(fs, "mkdtemp").mockImplementation(async (...args) => {
+        if (args[0].endsWith("instance-wrapper-failure-")) {
+          const address = serverSpy.mock.results[0]?.value.address();
+          reservedPort = address && typeof address !== "string" ? address.port : undefined;
+          expect(reservedPort).toBeTypeOf("number");
+          if (stage === "state") {
+            throw failure;
+          }
+        }
         const allocated = await mkdtemp(...args);
         if (args[0].endsWith("instance-wrapper-failure-")) {
           root = await fs.realpath(allocated);
         }
         return allocated;
+      });
+      const rm = fs.rm;
+      const cleanupSpy = vi.spyOn(fs, "rm").mockImplementation(async (...args) => {
+        if (stage === "cleanup" && args[0] === root) {
+          throw cleanupFailure;
+        }
+        return rm(...args);
       });
       const writeFile = fs.writeFile;
       const writeSpy = vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
@@ -45,7 +64,7 @@ describe("createOpenClawTestInstance acquisition", () => {
         throw failure;
       };
       const config =
-        stage === "merge"
+        stage === "merge" || stage === "cleanup"
           ? {
               get gateway() {
                 return failConfig();
@@ -57,22 +76,45 @@ describe("createOpenClawTestInstance acquisition", () => {
       try {
         const rejected = await createOpenClawTestInstance({
           name: "acquisition-failure",
-          port: 12345,
           state: { prefix: "instance-wrapper-failure-" },
           config,
         }).catch((error: unknown) => error);
         if (stage === "write") {
           expect(writeFailure).toMatchObject({ code: "EISDIR" });
           expect(rejected).toBe(writeFailure);
+        } else if (stage === "cleanup") {
+          expect(rejected).toBeInstanceOf(AggregateError);
+          expect((rejected as AggregateError).errors).toEqual([failure, cleanupFailure]);
         } else {
           expect(rejected).toBe(failure);
         }
         expect(process.env).toEqual(previousEnv);
-        expect(root).toBeDefined();
-        await expect(fs.stat(root!)).rejects.toMatchObject({ code: "ENOENT" });
+        if (stage !== "state") {
+          expect(root).toBeDefined();
+          if (stage === "cleanup") {
+            await expect(fs.stat(root!)).resolves.toBeDefined();
+          } else {
+            await expect(fs.stat(root!)).rejects.toMatchObject({ code: "ENOENT" });
+          }
+        }
+        const competitor = net.createServer();
+        try {
+          await new Promise<void>((resolve, reject) => {
+            competitor.once("error", reject);
+            competitor.listen(reservedPort!, "127.0.0.1", resolve);
+          });
+        } finally {
+          if (competitor.listening) {
+            await new Promise<void>((resolve, reject) => {
+              competitor.close((error) => (error ? reject(error) : resolve()));
+            });
+          }
+        }
       } finally {
         allocationSpy.mockRestore();
         writeSpy.mockRestore();
+        cleanupSpy.mockRestore();
+        serverSpy.mockRestore();
         snapshot.restore();
         if (root) {
           await fs.rm(root, { recursive: true, force: true });

--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -4,7 +4,7 @@ import { execFile, spawn } from "node:child_process";
 import { EventEmitter, once } from "node:events";
 import fs from "node:fs/promises";
 import { createServer } from "node:http";
-import type { Socket } from "node:net";
+import net, { type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
@@ -309,7 +309,8 @@ if (kind === "near") { process.stderr.write(refusal.slice(0, -1) + " fixture\\n"
 if (kind === "stdout") { process.stdout.write(refusal + " fixture\\n"); process.exit(1); }
 if (kind === "status2") { process.stderr.write(refusal + " fixture\\n"); process.exit(2); }
 if (kind === "signal") { process.stderr.write(refusal + " fixture\\n"); process.kill(process.pid, "SIGTERM"); }
-if (kind === "unrelated") { process.stderr.write("unrelated startup failure\\n"); process.exit(1); }
+if (kind === "held-unrelated") await (await fetch(controlUrl + "/wait")).text();
+if (kind === "unrelated" || kind === "held-unrelated") { process.stderr.write("unrelated startup failure\\n"); process.exit(1); }
 const server = createServer(async (req, res) => {
   if (req.url === "/readyz" && kind === "held-ready") await (await fetch(controlUrl + "/wait")).text();
   res.writeHead(req.url === "/readyz" ? 200 : 404, { "content-type": "application/json" });
@@ -375,6 +376,28 @@ async function expectPathMissing(targetPath: string): Promise<void> {
   throw new Error(`Expected missing path: ${targetPath}`);
 }
 
+async function isPortReserved(port: number): Promise<boolean> {
+  const competitor = net.createServer();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      competitor.once("error", reject);
+      competitor.listen(port, "127.0.0.1", resolve);
+    });
+    return false;
+  } catch (error) {
+    if (!hasErrnoCode(error, "EADDRINUSE")) {
+      throw error;
+    }
+    return true;
+  } finally {
+    if (competitor.listening) {
+      await new Promise<void>((resolve, reject) => {
+        competitor.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  }
+}
+
 function createGatewayProcessState(
   overrides: Partial<{ exitCode: number | null; signalCode: NodeJS.Signals | null }> = {},
 ) {
@@ -386,6 +409,111 @@ function createGatewayProcessState(
 }
 
 describe("openclaw test instance", () => {
+  it("reserves its idle port through refusal, CLI work, and stopped restarts", async () => {
+    const { instance, readAttempts } = await createFakeGateway("unrelated,cli,ready,ready");
+    const reserved = {
+      created: await isPortReserved(instance.port),
+      refused: false,
+      stopped: false,
+    };
+    await expect(instance.startGateway()).rejects.toThrow("unrelated startup failure");
+    expect(instance.child).toBeUndefined();
+    reserved.refused = await isPortReserved(instance.port);
+    await expect(instance.cli(["0"])).resolves.toMatchObject({ code: 0, signal: null });
+    await instance.startGateway();
+    await instance.stopGateway();
+    reserved.stopped = await isPortReserved(instance.port);
+    await instance.startGateway();
+    const attempts = await readAttempts();
+    expect(attempts).toHaveLength(4);
+    expect(
+      attempts.filter((attempt) => attempt.argv[0] === "gateway").map((attempt) => attempt.port),
+    ).toEqual([instance.port, instance.port, instance.port]);
+    await instance.cleanup();
+    await instance.cleanup();
+    await instance.stopGateway();
+    await expect(isPortReserved(instance.port)).resolves.toBe(false);
+    await expectPathMissing(instance.state.root);
+    expect(reserved).toEqual({ created: true, refused: true, stopped: true });
+  });
+
+  it("releases reservation probe connections before startup and terminal cleanup", async () => {
+    const { instance } = await createFakeGateway("ready");
+    const probe = net.connect(instance.port, "127.0.0.1");
+    try {
+      await withTestTimeout(once(probe, "close"), 1_000, "reservation retained a probe connection");
+      await instance.startGateway();
+      await instance.stopGateway();
+      await instance.cleanup();
+      await expect(isPortReserved(instance.port)).resolves.toBe(false);
+    } finally {
+      probe.destroy();
+    }
+  });
+
+  it("preserves the refusal when reacquiring the same port fails", async () => {
+    const control = await createGatewayControl();
+    const { instance } = await createFakeGateway("held-unrelated", 1_000, 1_500, control);
+    const competitor = net.createServer((socket) => socket.destroy());
+    const startup = trackOperation(instance.startGateway());
+    const outcome = startup.catch((error: unknown) => error);
+    try {
+      await Promise.race([control.reached, startup]);
+      await new Promise<void>((resolve, reject) => {
+        competitor.once("error", reject);
+        competitor.listen(instance.port, "127.0.0.1", resolve);
+      });
+      await control.release();
+      const error = await outcome;
+      expect(error).toBeInstanceOf(AggregateError);
+      expect((error as AggregateError).errors).toEqual([
+        expect.objectContaining({ message: expect.stringContaining("unrelated startup failure") }),
+        expect.objectContaining({ code: "EADDRINUSE" }),
+      ]);
+      expect(instance.child).toBeUndefined();
+      await instance.cleanup();
+      await instance.stopGateway();
+      expect(competitor.listening).toBe(true);
+      await expectPathMissing(instance.state.root);
+    } finally {
+      control.unblock();
+      await outcome;
+      if (competitor.listening) {
+        await new Promise<void>((resolve, reject) => {
+          competitor.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    }
+  });
+
+  it("leaves explicitly supplied ports owned by the caller", async () => {
+    const caller = net.createServer();
+    await new Promise<void>((resolve, reject) => {
+      caller.once("error", reject);
+      caller.listen(0, "127.0.0.1", resolve);
+    });
+    const address = caller.address();
+    if (!address || typeof address === "string") {
+      throw new Error("caller has no port");
+    }
+    try {
+      const instance = await createOpenClawTestInstance({
+        name: "caller-owned-port",
+        port: address.port,
+      });
+      fakeInstances.push({ instance });
+      await instance.stopGateway();
+      await instance.cleanup();
+      expect(caller.listening).toBe(true);
+      await expect(isPortReserved(address.port)).resolves.toBe(true);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        caller.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+    await expect(isPortReserved(address.port)).resolves.toBe(false);
+  });
+
   it.each(["complete", "overflow", "overflow-close"] as const)(
     "owns complete CLI JSON and diagnostic tails (%s)",
     async (mode) => {
@@ -784,6 +912,7 @@ describe("openclaw test instance", () => {
       });
       const firstStart = trackOperation(instance.startGateway());
       await Promise.race([control.reached, firstStart]);
+      await expect(isPortReserved(instance.port)).resolves.toBe(true);
       let teardownSettled = false;
       let launchedAfterTeardown = false;
       control.observers.onLaunch = () => {
@@ -1251,6 +1380,9 @@ describe("openclaw test instance", () => {
         expect(firstChild.stderr.closed).toBe(false);
         expect(isProcessAlive(drainingPid)).toBe(true);
         expect(await readAttempts()).toHaveLength(1);
+        await expect(fs.stat(instance.state.root)).resolves.toBeDefined();
+        // A free socket is not evidence that the retained process owner has closed.
+        await expect(isPortReserved(instance.port)).resolves.toBe(false);
 
         // Register before release, but charge only post-release drain to the stop budget.
         const closed = trackOperation(once(firstChild, "close"));

--- a/test/helpers/openclaw-test-instance.ts
+++ b/test/helpers/openclaw-test-instance.ts
@@ -231,21 +231,35 @@ async function resolveGatewayEntrypoint(cwd: string): Promise<string[]> {
   return await promise;
 }
 
-const getFreePort = async () => {
-  const srv = net.createServer();
-  await new Promise<void>((resolve) => {
-    srv.listen(0, "127.0.0.1", resolve);
-  });
-  const addr = srv.address();
-  if (!addr || typeof addr === "string") {
-    srv.close();
-    throw new Error("failed to bind ephemeral port");
+async function reserveGatewayPort(port = 0) {
+  // A probe must not retain a connection that can delay release before spawn.
+  const server = net.createServer((socket) => socket.destroy());
+  const release = () =>
+    new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(port, "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("failed to reserve gateway port");
+    }
+    return { port: address.port, release };
+  } catch (error) {
+    return await runQaGatewayFixture(
+      async (): Promise<never> => {
+        throw error;
+      },
+      () => (server.listening ? release() : undefined),
+    );
   }
-  await new Promise<void>((resolve) => {
-    srv.close(() => resolve());
-  });
-  return addr.port;
-};
+}
 
 async function waitForGatewayReady(
   proc: OpenClawTestProcessReadiness,
@@ -553,17 +567,26 @@ export async function createOpenClawTestInstance(
   options: OpenClawTestInstanceOptions,
 ): Promise<OpenClawTestInstance> {
   const cwd = options.cwd ?? process.cwd();
-  const port = options.port ?? (await getFreePort());
+  let reservation: Awaited<ReturnType<typeof reserveGatewayPort>> | undefined;
+  const releasePort = async () => {
+    if (reservation) {
+      await reservation.release();
+      reservation = undefined;
+    }
+  };
+  let port: number;
   const gatewayToken = options.gatewayToken ?? `gateway-${options.name}-${randomUUID()}`;
   const hookToken = options.hookToken ?? `token-${options.name}-${randomUUID()}`;
-  const state = await createOpenClawTestState({
-    label: options.name,
-    layout: "home",
-    ...options.state,
-    applyEnv: false,
-    env: options.env,
-  });
+  let state: OpenClawTestState | undefined;
   try {
+    port = options.port ?? (reservation = await reserveGatewayPort()).port;
+    state = await createOpenClawTestState({
+      label: options.name,
+      layout: "home",
+      ...options.state,
+      applyEnv: false,
+      env: options.env,
+    });
     await state.writeConfig(
       mergeConfig(
         {
@@ -578,9 +601,15 @@ export async function createOpenClawTestInstance(
       ),
     );
   } catch (error) {
-    // Config staging can fail before the instance exposes its cleanup handle.
-    await state.cleanup();
-    throw error;
+    // Neither owner is exposed until configuration succeeds; roll both back,
+    // retaining the acquisition error even when a cleanup phase also fails.
+    return await runQaGatewayFixture(
+      async (): Promise<never> => {
+        throw error;
+      },
+      () => state?.cleanup(),
+      releasePort,
+    );
   }
 
   const stdout = createBoundedStringLog();
@@ -592,6 +621,11 @@ export async function createOpenClawTestInstance(
   let child: { process: OpenClawTestProcess; ready: boolean } | undefined;
   const commands = new Set<Promise<OpenClawTestInstanceCommandResult>>();
   let acceptingWork = true;
+  const reserveIdlePort = async () => {
+    if (options.port === undefined && acceptingWork && !reservation) {
+      reservation = await reserveGatewayPort(port);
+    }
+  };
   let cleanupPromise: Promise<void> | undefined;
   let operation: { kind: "start" | "stop" | "cleanup"; promise: Promise<void> } | undefined;
   const enqueue = (kind: NonNullable<typeof operation>["kind"], action: () => Promise<void>) => {
@@ -647,6 +681,7 @@ export async function createOpenClawTestInstance(
   const stopGatewayChild = async (stopOptions: GatewayProcessStopOptions = {}) => {
     const target = child;
     if (!target) {
+      await reserveIdlePort();
       return;
     }
     // A failed stop retains ownership, never the old readiness observation.
@@ -661,6 +696,7 @@ export async function createOpenClawTestInstance(
         `gateway process did not close before stop deadline\n${formatLogs(stdout, stderr)}`,
       );
     }
+    await reserveIdlePort();
   };
 
   const instance: OpenClawTestInstance = {
@@ -739,7 +775,16 @@ export async function createOpenClawTestInstance(
             );
           }
           const attemptStderr = createBoundedStringLog();
-          const attempt = spawnGatewayProcess(gatewayArgs, attemptStderr);
+          await releasePort();
+          let attempt: OpenClawTestProcess;
+          try {
+            attempt = spawnGatewayProcess(gatewayArgs, attemptStderr);
+          } catch (error) {
+            await runQaGatewayFixture(async (): Promise<never> => {
+              throw error;
+            }, reserveIdlePort);
+            return;
+          }
           const owner = { process: attempt, ready: false };
           child = owner;
           try {
@@ -751,9 +796,19 @@ export async function createOpenClawTestInstance(
             const signalCode = attempt.signalCode;
             // Startup expiry stops retry admission, not ownership cleanup. Use the
             // same separate shutdown budget as explicit stop, retaining failed owners.
-            const closed = await releaseGatewayChild(attempt, Date.now() + stopTimeoutMs * 2, {
-              forceWindowsTree: true,
-            });
+            let closed: boolean;
+            try {
+              closed = await releaseGatewayChild(attempt, Date.now() + stopTimeoutMs * 2, {
+                forceWindowsTree: true,
+              });
+              if (closed) {
+                await reserveIdlePort();
+              }
+            } catch (cleanupError) {
+              throw new AggregateError([err, cleanupError], "gateway startup and cleanup failed", {
+                cause: cleanupError,
+              });
+            }
             const shouldRestart =
               restarts < GATEWAY_MIGRATION_CONVERGENCE_MAX_RESTARTS &&
               isGatewayMigrationConvergenceRefusal(
@@ -799,6 +854,7 @@ export async function createOpenClawTestInstance(
             // tree so inherited pipes cannot outlive the completed test instance.
             return stopGatewayChild({ forceWindowsTree: true });
           },
+          releasePort,
         );
         await state.cleanup();
       }));


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/140632

## What Problem This Solves

Resolves a problem where parallel CI fixtures could claim an isolated Gateway's automatically selected port while that Gateway was being prepared, stopped for Doctor work, or restarted after a startup refusal.

## Why This Change Was Made

The test instance now reserves its automatically allocated loopback port throughout idle phases, releases it immediately before spawning, and reacquires the same port only after verified child teardown. Terminal cleanup releases the reservation independently of process cleanup and never reopens it. Acquisition rollback preserves the original failure while still attempting both state and socket cleanup.

Caller-supplied ports remain caller-owned. Existing convergence retries, deadlines, process ownership checks, runtime storage behavior, and CI parallelism are unchanged. The release-to-child-bind handoff is still non-atomic; this closes long idle ownership gaps, not every possible port race.

Review disposition: the remaining handoff race predates this patch. The selected mitigation is to repair idle ownership now and retain the broader collision issue for controlled concurrent verification. This is the bounded maintainer-reviewed scope, not a claim of complete race elimination.

## User Impact

More reliable parallel Gateway lifecycle proofs without serializing CI or masking startup failures. No end-user runtime behavior changes.

## Evidence

- Before the fix, real competing listeners acquired the instance port after creation, during held entrypoint preparation, after terminal refusal, and after verified stop. The new regression assertions failed at those boundaries.
- The focused helper suites pass: 57 tests, with the native Windows-only case skipped on macOS. Coverage includes refusal, CLI work, repeated same-port restarts, connection disposal, reacquisition failure diagnostics, acquisition rollback, retained failed process ownership, explicit ports, and terminal cleanup.
- Independent P1/P2 review found no actionable defects. Subsequent edits are mechanical lint corrections.
- Targeted formatting, lint, script lint, coercion and ownership guards pass. The local changed-check gate reached test typechecking but was blocked by its shared-dependency checkout restriction. All three hosted test-typecheck jobs passed on the exact head in [ready CI](https://github.com/openclaw/openclaw/actions/runs/34081004347).
- The matching-artifact SQLite lifecycle proof passed in [build-artifacts](https://github.com/openclaw/openclaw/actions/runs/34081004347/job/101616236448): `RUN_SQLITE_SESSION_LIFECYCLE=true`, with the unchanged built-CLI test passing in 34.1 seconds. No local build was substituted.
- [Windows job 2](https://github.com/openclaw/openclaw/actions/runs/34081004347/job/101616236537) passed the actual helper suite, including the new reservation cases and the native inherited-stderr ownership test that was skipped on macOS. Windows job 1 also passed.
- [Ready CI](https://github.com/openclaw/openclaw/actions/runs/34081004347) completed successfully on its first attempt at `8d9052c5697caab0847b48a4777b3fede1300970`. The draft-only skipped run is not used as evidence.

The linked issue stays open: the original concurrent SQLite/Discord collision sequence has not been reproduced end to end.
