### PR TITLE
perf(meeting): retire completed loopback correlation scratch

### DIFF
--- a/src/meeting-bot/output-loopback-verifier.test.ts
+++ b/src/meeting-bot/output-loopback-verifier.test.ts
@@ -69,6 +69,49 @@ describe("meeting output loopback verifier", () => {
     expect(verifier.getHealth().outputLoopbackSignalBytes).toBeGreaterThan(verifiedBytes);
   });
 
+  it.each(["pcm16-24khz", "g711-ulaw-8khz"] as const)(
+    "keeps the rolling deadline after verification and starts fresh after expiry (%s)",
+    (audioFormat) => {
+      let nowMs = 0;
+      const verifier = createMeetingOutputLoopbackVerifier({
+        audioFormat,
+        now: () => nowMs,
+      });
+      const output =
+        audioFormat === "pcm16-24khz"
+          ? pcmEnergyFrames(outputEnvelope)
+          : Buffer.concat(outputEnvelope.map((_, index) => Buffer.alloc(80, (index * 37) % 220)));
+      verifier.beginOutput();
+      verifier.recordOutput(output);
+      verifier.recordInput(output);
+      const verified = verifier.getHealth();
+      expect(verified.verifiedOutputGeneration).toBe(1);
+
+      // Six seconds queued after the match keep the same generation past its original deadline.
+      verifier.recordOutput(Buffer.concat(Array<Buffer>(7).fill(output)));
+      verifier.recordOutput(output.subarray(0, output.byteLength / 2));
+      nowMs = 6_000;
+      verifier.recordOutput(output);
+      verifier.recordInput(output);
+      expect(verifier.getHealth()).toEqual(verified);
+      nowMs = 12_600;
+      verifier.recordOutput(Buffer.alloc(0));
+      expect(verifier.getHealth()).toEqual(verified);
+
+      nowMs += 1;
+      verifier.recordOutput(output);
+      expect(verifier.getHealth().outputGeneration).toBe(2);
+      expect(verifier.getHealth().verifiedOutputGeneration).toBe(1);
+      verifier.recordInput(output);
+      expect(verifier.getHealth().verifiedOutputGeneration).toBe(2);
+      expect(verifier.getHealth().outputLoopbackSignalBytes).toBe(output.byteLength * 2);
+      const nextVerified = verifier.getHealth();
+      verifier.cancelOutput();
+      verifier.recordInput(output);
+      expect(verifier.getHealth()).toEqual(nextVerified);
+    },
+  );
+
   it("uses a stricter full-envelope match for short output generations", () => {
     const verifier = createMeetingOutputLoopbackVerifier({ audioFormat: "pcm16-24khz" });
     const shortOutput = pcmEnergyFrames(outputEnvelope.slice(0, 20));

--- a/src/meeting-bot/output-loopback-verifier.ts
+++ b/src/meeting-bot/output-loopback-verifier.ts
@@ -151,16 +151,20 @@ export function createMeetingOutputLoopbackVerifier(options: {
   let lastOutputLoopbackPeak: number | undefined;
   let lastOutputLoopbackRms: number | undefined;
 
+  const clearCorrelationScratch = () => {
+    inputPcm = Buffer.alloc(0);
+    nextInputStartSample = 0;
+    outputFingerprint = undefined;
+    pendingOutputPcm = Buffer.alloc(0);
+  };
+
   const resetGeneration = (started: boolean) => {
     generationStarted = started;
     generationVerified = false;
     if (started) {
       outputGeneration += 1;
     }
-    inputPcm = Buffer.alloc(0);
-    nextInputStartSample = 0;
-    outputFingerprint = undefined;
-    pendingOutputPcm = Buffer.alloc(0);
+    clearCorrelationScratch();
     outputObservationDeadlineMs = Number.NEGATIVE_INFINITY;
     outputQueuedUntilMs = Number.NEGATIVE_INFINITY;
   };
@@ -264,6 +268,7 @@ export function createMeetingOutputLoopbackVerifier(options: {
         lastOutputLoopbackCorrelation = matchedCorrelation;
         lastOutputLoopbackPeak = matchedStats.peak;
         lastOutputLoopbackRms = matchedStats.rms;
+        clearCorrelationScratch();
         return;
       }
       nextInputStartSample = Math.max(0, lastStartSample + 1);
@@ -280,19 +285,25 @@ export function createMeetingOutputLoopbackVerifier(options: {
       if (audio.byteLength === 0) {
         return;
       }
-      const decoded = decodeMeetingAudio(audio, options.audioFormat);
-      const durationMs = decoded.byteLength * 0.5 * sampleRate ** -1 * 1_000;
+      const samples =
+        options.audioFormat === "g711-ulaw-8khz" ? audio.byteLength : audio.byteLength * 0.5;
+      const durationMs = samples * sampleRate ** -1 * 1_000;
       outputQueuedUntilMs = Math.max(outputAtMs, outputQueuedUntilMs) + durationMs;
+      outputObservationDeadlineMs = Math.max(
+        outputObservationDeadlineMs,
+        outputQueuedUntilMs + OUTPUT_LOOPBACK_OBSERVATION_WINDOW_MS,
+      );
+      // Verified generations still extend their deadline, but no longer need correlation data.
+      if (generationVerified) {
+        return;
+      }
+      const decoded = decodeMeetingAudio(audio, options.audioFormat);
       pendingOutputPcm = Buffer.concat([pendingOutputPcm, decoded]);
       if (!outputFingerprint) {
         consumePendingOutput(true);
       } else if (pendingOutputPcm.byteLength >= fullReferenceBytes) {
         consumePendingOutput(false);
       }
-      outputObservationDeadlineMs = Math.max(
-        outputObservationDeadlineMs,
-        outputQueuedUntilMs + OUTPUT_LOOPBACK_OBSERVATION_WINDOW_MS,
-      );
     },
     getHealth(): MeetingOutputLoopbackHealth {
       return {

--- a/src/meeting-bot/realtime-local-audio-transport.ts
+++ b/src/meeting-bot/realtime-local-audio-transport.ts
@@ -239,6 +239,7 @@ export function createLocalMeetingRealtimeAudioTransport(params: {
     stop: () => {
       stopPromise ??= (async () => {
         stopped = true;
+        outputLoopbackVerifier.cancelOutput();
         releaseOutputWriteWaiters();
         await Promise.all([
           terminateMeetingBridgeProcess(inputProcess, {

--- a/src/meeting-bot/realtime-node-audio-transport.test.ts
+++ b/src/meeting-bot/realtime-node-audio-transport.test.ts
@@ -1,4 +1,6 @@
+import { setImmediate } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../shared/deferred.js";
 import { createNodeMeetingRealtimeAudioTransport } from "./realtime-node-audio-transport.js";
 
 function createTransport(
@@ -100,6 +102,27 @@ describe("node meeting realtime audio transport", () => {
     });
 
     await transport.stop();
+  });
+
+  it("cannot verify stopped output from a pending input pull", async () => {
+    const pendingPull = createDeferredCore<{ base64: string }>();
+    const invoke = vi.fn(async ({ params }: { params: { action: string } }) =>
+      params.action === "pullAudio" ? pendingPull.promise : {},
+    );
+    const transport = createTransport(invoke);
+    const output = Buffer.alloc(80 * 240 * 2);
+    for (let sample = 0; sample < output.byteLength / 2; sample += 1) {
+      const amplitude = 400 + ((Math.floor(sample / 240) * 7919) % 12_000);
+      output.writeInt16LE(sample % 2 === 0 ? amplitude : -amplitude, sample * 2);
+    }
+    await transport.writeOutput(output);
+    const health = transport.getHealth?.();
+    transport.startInput(() => {});
+    await transport.stop();
+    pendingPull.resolve({ base64: output.toString("base64") });
+    await setImmediate();
+
+    expect(transport.getHealth?.()).toEqual(health);
   });
 
   it("fences output writes across clear and stop", async () => {

--- a/src/meeting-bot/realtime-node-audio-transport.ts
+++ b/src/meeting-bot/realtime-node-audio-transport.ts
@@ -121,6 +121,7 @@ export function createNodeMeetingRealtimeAudioTransport(params: {
         return;
       }
       stopped = true;
+      outputLoopbackVerifier.cancelOutput();
       try {
         await params.runtime.nodes.invoke({
           nodeId: params.nodeId,


### PR DESCRIPTION
Closes #140749

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Meeting loopback verification keeps correlation scratch after a successful waveform match or transport stop. Later output in an already verified generation keeps decoding and rebuilding references the verifier will no longer consume. A pending node input pull can also update loopback health after stop.

## Why This Change Was Made

Release correlation scratch after complete match statistics and reuse that release at generation reset. Cancel verification at local and node stop before asynchronous teardown. Advance scalar playback duration and the rolling deadline before returning from verified output, preserving generation rollover without decoding or rebuilding references.

## User Impact

In actual local/node transport probes kept reachable through completion and stop, the measured completed/stopped PCM views drop to zero; live unverified controls retain the same views. Subsequent verified output no longer performs the tracked verifier concatenation, sample reads or mu-law decode allocation. Initial matching work, historical health and generation sequences remain unchanged.

These are synthetic owner reachability and operation-count results. They are not whole-Gateway RSS, general timing, configured-cap savings or a broad transport/consult shutdown repair. Shared mu-law backing slabs are not treated as reclaimable-byte totals.

## Evidence

- The new pending-node-pull regression fails on the original owner because stopped loopback health changes; the repair preserves it.
- 83 focused tests across seven relevant files passed. The final seven-test node suite, complete changed-file gate and fresh isolated P2 review passed after the final test refinement.
- Twelve actual local/node PCM/mu-law matching and control scenarios preserve normalized complete health; two deterministic generation sequences match through deadline equality, expiry, cancellation and fresh output.
- Another 100 × 200 ms output chunks in each verified transport reduce tracked PCM concatenations/sample reads and mu-law decode allocation to zero. The timing arithmetic and expiry-before-empty ordering stay intact.
- Production is net +13 lines across three owners; two test files add 66 lines. No configuration, protocol, persistence or plugin API changes.

Related #112939 and #116589 establish preserved waveform/generation contracts. Broader #116201 provider/consult lifetime work remains separate.
