### PR TITLE
refactor: derive private node invocation result types

### DIFF
--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -1068,12 +1068,7 @@ function decodeParams<T>(raw?: string | null): T {
 async function sendInvokeResult(
   client: NodeHostClient,
   frame: NodeInvokeRequestPayload,
-  result: {
-    ok: boolean;
-    payload?: unknown;
-    payloadJSON?: string | null;
-    error?: { code?: string; message?: string } | null;
-  },
+  result: Parameters<typeof buildNodeInvokeResultParams>[1],
 ) {
   try {
     await client.request("node.invoke.result", buildNodeInvokeResultParams(frame, result));
@@ -1098,14 +1093,7 @@ function buildNodeInvokeResultParams(
   payloadJSON?: string;
   error?: { code?: string; message?: string };
 } {
-  const params: {
-    id: string;
-    nodeId: string;
-    ok: boolean;
-    payload?: unknown;
-    payloadJSON?: string;
-    error?: { code?: string; message?: string };
-  } = {
+  const params: ReturnType<typeof buildNodeInvokeResultParams> = {
     id: frame.id,
     nodeId: frame.nodeId,
     ok: result.ok,


### PR DESCRIPTION
## What Problem This Solves

The node invocation result path repeats two private record shapes already owned by its result builder. Those copies can drift independently when the builder's contract changes. This is a maintainer-requested internal cleanup, not a claim of a currently failing user operation.

## Why This Change Was Made

Derive the sender's result argument and the builder's local record from the builder's existing parameter and explicit return types. The builder remains the single owner; serialization, optional fields, null normalization, request handling and error handling are unchanged. No new export, SDK surface, configuration or protocol field is introduced.

Production LOC: +2/-14 (net -12). Tests and test support: unchanged.

## User Impact

No user-visible behavior change. The node result wire format and execution behavior remain unchanged.

## Evidence

- Original and derived record contracts agree with exact optional-property checking both enabled and disabled. Each setting rejects six deliberately incompatible type changes.
- The complete module's erased JavaScript is byte-identical before and after (33,436 bytes).
- The normal configured changed gate passed all 28 checks on the exact candidate: core typechecking, all 16 serial core-test graphs, formatting, lint, all three dead-export scans and the remaining selected guards. The delegated Linux worker used Node 24.19.0 and the repository-pinned pnpm version; its lease and source capsule were closed normally.

- Independent P2 precommit review and separate P2 review of the exact signed commit both passed with no findings.

Hosted exact-head [CI run 34081269382](https://github.com/openclaw/openclaw/actions/runs/34081269382) passed on the signed commit, including `openclaw/ci-gate`. Native preparation and merge remain pending.
