### PR TITLE
fix: Windows cleanup targets child PIDs after they exit

### DIFF
--- a/scripts/lib/managed-child-process.mts
+++ b/scripts/lib/managed-child-process.mts
@@ -112,7 +112,7 @@ export function signalExitCode(signal: NodeJS.Signals) {
 }
 
 export function terminateManagedChild(
-  child: { kill(signal: NodeJS.Signals): unknown; pid?: number },
+  child: ManagedProcessGroupChild & { kill(signal: NodeJS.Signals): unknown },
   signal: NodeJS.Signals = "SIGTERM",
   {
     onChildSignalError,
@@ -166,6 +166,11 @@ export function terminateManagedChild(
     }
   }
 
+  // After exit this PID can name another process. Keep descendant cleanup
+  // unverified instead of targeting that potentially unrelated owner.
+  if (child.exitCode != null || child.signalCode != null) {
+    return { processTreeState: "indeterminate" };
+  }
   const taskkillPath = resolveWindowsTaskkillPath();
   const args = ["/PID", String(child.pid), "/T"];
   if (signal === "SIGKILL") {

--- a/test/helpers/openclaw-test-instance.cli.test-support.mjs
+++ b/test/helpers/openclaw-test-instance.cli.test-support.mjs
@@ -116,6 +116,7 @@ process.exit(1);
   assert.equal(isProcessAlive(writerPid), true);
   facts.boundaryEstablished = true;
   const result = await outcome;
+  assert.deepEqual(taskkills, [], "an exited CLI PID must not be targeted again");
   const error = result.error;
   retainedFailure = error;
   facts.commandError = error

--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -17,7 +17,6 @@ import {
   runManagedCommand,
   terminateManagedChild,
 } from "../../scripts/lib/managed-child-process.mts";
-import { resolveWindowsTaskkillPath } from "../../scripts/lib/windows-taskkill.mjs";
 import { hasErrnoCode } from "../../src/infra/errno.js";
 import { resolveMaxOutputBytes } from "../../src/process/exec-output.js";
 import { withEnvAsync } from "../../src/test-utils/env.js";
@@ -1284,7 +1283,7 @@ describe("openclaw test instance", () => {
   );
 
   it.each([true, false])(
-    "joins Windows gateway closure before retry cleanup (inherited pipes=%s)",
+    "does not target an exited Windows gateway (inherited pipes=%s)",
     async (inheritedPipes) => {
       const stdout = new PassThrough();
       const stderr = new PassThrough();
@@ -1310,31 +1309,25 @@ describe("openclaw test instance", () => {
         setImmediate(closePipes);
       }
 
-      await expect(
-        testing.stopGatewayProcess(child, Date.now() + 500, 250, {
-          forceWindowsTree: true,
-          platform: "win32",
-          runTaskkill,
-        }),
-      ).resolves.toBe(true);
-
-      if (inheritedPipes) {
-        expect(runTaskkill).toHaveBeenCalledOnce();
-        expect(runTaskkill).toHaveBeenCalledWith(
-          resolveWindowsTaskkillPath(),
-          ["/PID", "12345", "/T", "/F"],
-          {
-            killSignal: "SIGKILL",
-            stdio: "ignore",
-            timeout: 10_000,
-          },
-        );
-      } else {
+      try {
+        await expect(
+          testing.stopGatewayProcess(child, Date.now() + 500, 250, {
+            forceWindowsTree: true,
+            platform: "win32",
+            runTaskkill,
+          }),
+        ).resolves.toBe(!inheritedPipes);
         expect(runTaskkill).not.toHaveBeenCalled();
+        expect(kill).not.toHaveBeenCalled();
+        expect(stdout.closed).toBe(!inheritedPipes);
+        expect(stderr.closed).toBe(!inheritedPipes);
+      } finally {
+        const closed = Promise.all(
+          [stdout, stderr].map((pipe) => (pipe.closed ? Promise.resolve() : once(pipe, "close"))),
+        );
+        closePipes();
+        await closed;
       }
-      expect(kill).not.toHaveBeenCalled();
-      expect(stdout.closed).toBe(true);
-      expect(stderr.closed).toBe(true);
     },
   );
 
@@ -1405,7 +1398,9 @@ describe("openclaw test instance", () => {
       );
       expect(stopped).toBe(scenario.stopped);
       const threw = scenario.label === "taskkill exception";
-      expect(runTaskkill).toHaveBeenCalledTimes(scenario.taskkillStatus === 0 || threw ? 1 : 2);
+      expect(runTaskkill).toHaveBeenCalledTimes(
+        exitedLeader ? 0 : scenario.taskkillStatus === 0 || threw ? 1 : 2,
+      );
       if (!scenario.closePipes) {
         expect(stderr.closed).toBe(false);
       }
@@ -1421,10 +1416,12 @@ describe("openclaw test instance", () => {
           stopLog[0]!.slice(prefix.length),
         );
         const attempt = { force: false, elapsedMs: expect.any(Number) };
-        const taskkill: Record<string, unknown>[] = threw
-          ? [{ ...attempt, threw: true, errorCode: "EACCES" }]
-          : [{ ...attempt, status: scenario.taskkillStatus, signal: null }];
-        if (!heldPipe && !threw) {
+        const taskkill: Record<string, unknown>[] = exitedLeader
+          ? []
+          : threw
+            ? [{ ...attempt, threw: true, errorCode: "EACCES" }]
+            : [{ ...attempt, status: scenario.taskkillStatus, signal: null }];
+        if (!exitedLeader && !heldPipe && !threw) {
           taskkill.push({
             ...attempt,
             force: true,

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -510,6 +510,31 @@ setInterval(() => {}, 1_000);
     });
   });
 
+  it.each<{
+    exitCode: number | null;
+    signalCode: NodeJS.Signals | null;
+    signal: NodeJS.Signals;
+  }>([
+    { exitCode: 0, signalCode: null, signal: "SIGTERM" },
+    { exitCode: null, signalCode: "SIGTERM", signal: "SIGKILL" },
+  ])(
+    "does not target a known-exited Windows child ($exitCode/$signalCode)",
+    ({ exitCode, signalCode, signal }) => {
+      const child = { exitCode, signalCode, kill: vi.fn(() => true), pid: 12345 };
+      const runTaskkill = vi.fn(() => ({ status: 0 }));
+
+      const result = terminateManagedChild(child, signal, {
+        platform: "win32",
+        runTaskkill,
+      });
+
+      expect(runTaskkill).not.toHaveBeenCalled();
+      expect(child.kill).not.toHaveBeenCalled();
+      // Exit retires PID authority, not proof that inherited descendants are gone.
+      expect(result).toEqual({ processTreeState: "indeterminate" });
+    },
+  );
+
   it("force-kills Windows managed process trees when graceful taskkill fails", () => {
     withDefaultWindowsSystemRoot(() => {
       const child = {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/132180

## What Problem This Solves

Resolves a problem where Windows tooling and test-instance cleanup could target a process ID again after its original child had already exited, while inherited output was still open. That ID may no longer belong to the child being cleaned up.

## Why This Change Was Made

The shared managed-child terminator now checks the child's recorded exit before invoking `taskkill` and returns its existing indeterminate-cleanup result. Existing callers retain unresolved cleanup and its diagnostic state instead of targeting a retired PID or declaring descendants gone. POSIX process groups, live Windows termination, and explicit direct-child signaling remain unchanged.

This is the Windows process-ownership slice of the original PR, applied to current main without its unrelated CLI deadline-test rewrite. No new configuration, schema, public API, retries, or timeout changes.

## User Impact

Windows development and test workflows no longer reuse a known-exited child's numeric PID for tree termination. When inherited output remains open and descendant cleanup cannot be verified, callers continue to report incomplete cleanup and retain their state rather than claiming success. Ordinary completed commands, successful output drainage, and live-child shutdown retain their existing behavior.

## Evidence

- Tests-only reproduction on main `4648bb0a70c54599630f21ace2a28c017ca65f8b`: four intended failures and one pass. Both exited-child variants invoked `taskkill`; the held-pipe Gateway case reported success; the exited-leader diagnostic case attempted `taskkill` twice.
- With the owner fix, the complete three-file suite passed **147 tests**, with **two platform skips** on macOS. This includes the previously failing cases, live Windows termination via platform-controlled unit tests, POSIX descendant cleanup, `run-with-env`, and unchanged successful-drain/large-output deadline cases.
- **Native Windows proof passed** in [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34081514762), [Windows test-2 job](https://github.com/openclaw/openclaw/actions/runs/34081514762/job/101617673209). The actual inherited-stderr retention fixture passed with its new no-`taskkill` assertion (13.635 seconds), along with the successful-drain, large-output deadline, exited-Gateway, and diagnostic cases. This is native Windows execution, separate from the local platform-override tests.
- Dependency contracts inspected directly: [Node child exit versus stdio close and PID-reuse warning](https://nodejs.org/api/child_process.html) and [Microsoft taskkill's numeric PID and tree-selection contract](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/taskkill). Stable tag `v2026.9.2` also lacks the guard.

Reproduction:
```bash
node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts test/helpers/openclaw-test-instance.test.ts -t 'does not target a known-exited Windows child|does not target an exited Windows gateway|observes Windows unverified exited leader'
```

Post-fix owner and sibling proof:
```bash
node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts test/helpers/openclaw-test-instance.test.ts test/scripts/run-with-env.test.ts
```

Changed checks:
```bash
node scripts/check-changed.mjs -- scripts/lib/managed-child-process.mts test/scripts/managed-child-process.test.ts test/helpers/openclaw-test-instance.test.ts test/helpers/openclaw-test-instance.cli.test-support.mjs
```

Changed formatting/type/lint/guard checks passed (117 seconds), and a fresh isolated Codex review returned scoped-clean at P0 on tree `44ed5a9c9b8cb2b7ad4f96b2c033ce55b91b22cb`. Production/tooling **+6/-1 (net +5)**; tests/test support **+53/-30 (net +23)**. The small owner-level guard and its explanation protect the concrete retired-PID boundary; no consumer workaround or parallel cleanup path is added. The original PR remains open for its other replacements.
