### PR TITLE
refactor(media): simplify remote attachment filename selection

### DIFF
--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -462,22 +462,18 @@ function resolveRemoteFileName(params: {
   finalUrl: string;
   filePathHint?: string;
 }): string | undefined {
-  let fileNameFromUrl: string | undefined;
+  const fileName =
+    parseContentDispositionFileName(params.res.headers.get("content-disposition")) ||
+    (params.filePathHint ? basenameFromAnyPath(params.filePathHint) : undefined);
+  if (fileName) {
+    return fileName;
+  }
   try {
     const parsed = new URL(params.finalUrl);
-    const base = basenameFromUrlPathname(parsed.pathname);
-    fileNameFromUrl = base || undefined;
+    return basenameFromUrlPathname(parsed.pathname) || undefined;
   } catch {
-    // ignore parse errors; leave undefined
+    return undefined;
   }
-  const headerFileName = parseContentDispositionFileName(
-    params.res.headers.get("content-disposition"),
-  );
-  return (
-    headerFileName ||
-    (params.filePathHint ? basenameFromAnyPath(params.filePathHint) : undefined) ||
-    fileNameFromUrl
-  );
 }
 
 function isGenericResponseContentType(value?: string | null): boolean {
@@ -743,14 +739,14 @@ async function readRemoteMediaBufferOnce(options: FetchMediaOptions): Promise<Fe
       filePathHint: options.filePathHint,
     });
 
-    const filePathForMime =
-      fileName && extnameFromAnyPath(fileName) ? fileName : (options.filePathHint ?? finalUrl);
+    const fileNameExt = fileName ? extnameFromAnyPath(fileName) : undefined;
+    const filePathForMime = fileNameExt ? fileName : (options.filePathHint ?? finalUrl);
     const contentType = await detectMime({
       buffer,
       headerMime: res.headers.get("content-type"),
       filePath: filePathForMime,
     });
-    if (fileName && !extnameFromAnyPath(fileName) && contentType) {
+    if (fileName && !fileNameExt && contentType) {
       const ext = extensionForMime(contentType);
       if (ext) {
         fileName = `${fileName}${ext}`;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled where applicable.

</details>

## What Problem This Solves

Remote attachment downloads prepare a fallback filename even when a response header or caller hint already supplies the selected name.

## Why This Change Was Made

Return the existing Content-Disposition/caller-hint winner before deriving the unused URL fallback. Reuse the buffered filename's extension across MIME detection, while that local filename remains unchanged. The single-file change removes four production lines (+11/−15), with no new helper, cache, option, or dependency.

## User Impact

No intended visible change. Filename precedence, decoding, buffered-versus-streamed MIME hints, byte detection, network guards, redirects, limits, cancellation, and storage permissions remain unchanged. Measurements are mixed and do **not** demonstrate a general fetch speedup or throughput improvement.

## Evidence

151 existing tests passed (89 fetch, 56 store, 6 Teams), as did all 28 normal changed checks. Managed P2 review was scoped-clean with 0.98 confidence. Checks and measurements use `faec7a7c`; the changed owner and filename/MIME helpers remain unchanged on main `33ca4b1e`. No fresh-main runtime proof is claimed.

R2 ran the actual guarded fetch, body reader, MIME detection, and result construction with injected synthetic transport/DNS. Its six hosts completed 1,540 operations with full recorded output parity: 60 buffered/streamed proof operations and 1,480 buffered timing operations, including 1,280 measured calls. Timed order was B0/C0/C1/B1. Each table value is the median of eight group means, each averaging four individual operation times. Positive changes are slower.

| Row | B0 → C0 (µs; change) | B1 → C1 (µs; change) |
| --- | ---: | ---: |
| Header CSV | 161.86 → 167.61 (+3.55%) | 174.43 → 168.46 (-3.42%) |
| Caller hint CSV | 138.17 → 116.13 (-15.95%) | 120.81 → 134.61 (+11.42%) |
| URL-only CSV control | 129.69 → 114.09 (-12.03%) | 122.12 → 111.03 (-9.08%) |
| Extensionless header | 115.16 → 113.08 (-1.80%) | 113.61 → 121.05 (+6.55%) |
| Extended UTF-8 header | 100.81 → 106.22 (+5.36%) | 114.64 → 103.66 (-9.58%) |
| Empty header basename | 103.11 → 125.30 (+21.51%) | 107.88 → 118.81 (+10.14%) |
| Empty hint basename | 92.54 → 99.10 (+7.09%) | 96.17 → 103.05 (+7.15%) |
| Absent filename control | 91.96 → 89.15 (-3.06%) | 93.93 → 89.37 (-4.86%) |
| Buffered/streamed precedence | 99.72 → 100.79 (+1.07%) | 94.48 → 86.01 (-8.97%) |
| Larger CSV body | 98.28 → 108.37 (+10.27%) | 102.70 → 107.56 (+4.73%) |

11/20 paired row medians and 481/994 recorded comparison metrics were adverse; the latter includes overlapping aggregates, not independent samples. Summed measured times for the fixed mixture changed **+1.75% / −3.26%**. First calls, warm calls, individual timings, group maxima, and resource measurements remain retained; controls are included above.

Forward/reverse resource changes: child wall time +1.93%/−0.32%; import time +1.26%/+0.18%; kernel peak RSS +9.75%/−1.27%; observed process-tree peak RSS +9.85%/−1.28%; user CPU +2.14%/−1.16%; system CPU −0.11%/+1.32%. No startup or memory improvement is established.

Capture, assertions, and file readback are outside operation clocks but occur between calls. This is a local synthetic study, not live network or Gateway latency; group maxima are not population tails and the mixture is not traffic-weighted. Fixed caps were 55 seconds, 2 GiB RSS, and 32 processes per child, with a 360-second parent deadline. All six native runs closed successfully. Independent numeric audit reconstructed every output and all 994 comparisons, including all 40 stored files; no target was rerun.

R1 stopped after two returned operations because its harness incorrectly expected file mode `0600`. The existing contract is `0644` files inside a private `0700` directory. R2 corrected only the oracle, added the parent-directory check outside timing, and ran the complete cohort afresh. Production permissions and umask were unchanged; R1 evidence is retained and no results were pooled.
