### PR TITLE
refactor(channels): reuse setup config patch helpers

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1171,7 +1171,7 @@ extensions/synology-chat/src/channel.ts	1
 extensions/synology-chat/src/client.ts	1
 extensions/synology-chat/src/inbound-event.ts	1
 extensions/synology-chat/src/outbound-media.ts	1
-extensions/synology-chat/src/setup-surface.ts	5
+extensions/synology-chat/src/setup-surface.ts	3
 extensions/synology-chat/src/test-http-utils.ts	6
 extensions/synology-chat/src/webhook-handler.ts	2
 extensions/talk-voice/index.ts	1

--- a/extensions/feishu/src/setup-core.ts
+++ b/extensions/feishu/src/setup-core.ts
@@ -2,6 +2,8 @@ import { defineChannelSetupContract } from "openclaw/plugin-sdk/channel-setup";
 // Feishu plugin module implements setup core behavior.
 import {
   DEFAULT_ACCOUNT_ID,
+  patchTopLevelChannelConfigSection,
+  setSetupChannelEnabled,
   type ChannelSetupAdapter,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/setup";
@@ -14,22 +16,19 @@ export function setFeishuNamedAccountEnabled(
   enabled: boolean,
 ): OpenClawConfig {
   const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
-  return {
-    ...cfg,
-    channels: {
-      ...cfg.channels,
-      feishu: {
-        ...feishuCfg,
-        accounts: {
-          ...feishuCfg?.accounts,
-          [accountId]: {
-            ...feishuCfg?.accounts?.[accountId],
-            enabled,
-          },
+  return patchTopLevelChannelConfigSection({
+    cfg,
+    channel: "feishu",
+    patch: {
+      accounts: {
+        ...feishuCfg?.accounts,
+        [accountId]: {
+          ...feishuCfg?.accounts?.[accountId],
+          enabled,
         },
       },
     },
-  };
+  });
 }
 
 export const feishuSetupAdapter: ChannelSetupAdapter = {
@@ -37,16 +36,7 @@ export const feishuSetupAdapter: ChannelSetupAdapter = {
   applyAccountConfig: ({ cfg, accountId }) => {
     const isDefault = !accountId || accountId === DEFAULT_ACCOUNT_ID;
     if (isDefault) {
-      return {
-        ...cfg,
-        channels: {
-          ...cfg.channels,
-          feishu: {
-            ...cfg.channels?.feishu,
-            enabled: true,
-          },
-        },
-      };
+      return setSetupChannelEnabled(cfg, "feishu", true);
     }
     return setFeishuNamedAccountEnabled(cfg, accountId, true);
   },

--- a/extensions/feishu/src/setup-surface.test.ts
+++ b/extensions/feishu/src/setup-surface.test.ts
@@ -42,6 +42,7 @@ vi.mock("./app-registration.js", () => ({
 }));
 
 import { feishuPlugin } from "./channel.js";
+import { setFeishuNamedAccountEnabled } from "./setup-core.js";
 
 const baseStatusContext = {
   accountOverrides: {},
@@ -71,6 +72,39 @@ afterAll(() => {
 });
 
 describe("feishu setup wizard", () => {
+  it.each(["", " Alert Account ", "default"])(
+    "preserves the exact named-account key %j without enabling the channel",
+    (accountId) => {
+      const result = setFeishuNamedAccountEnabled(
+        {
+          channels: {
+            feishu: {
+              enabled: false,
+              accounts: {
+                [accountId]: { appId: "kept", enabled: false },
+                sibling: { enabled: false },
+              },
+            },
+          },
+        },
+        accountId,
+        true,
+      );
+
+      expect(result).toEqual({
+        channels: {
+          feishu: {
+            enabled: false,
+            accounts: {
+              [accountId]: { appId: "kept", enabled: true },
+              sibling: { enabled: false },
+            },
+          },
+        },
+      });
+    },
+  );
+
   beforeEach(() => {
     probeFeishuMock.mockReset();
     probeFeishuMock.mockResolvedValue({ ok: false, error: "mocked" });

--- a/extensions/synology-chat/src/channel.integration.test.ts
+++ b/extensions/synology-chat/src/channel.integration.test.ts
@@ -60,6 +60,45 @@ describe("Synology channel wiring integration", () => {
     setSynologyRuntimeConfigForTest({});
   });
 
+  it("re-enables a configured named account without replacing root or sibling credentials", async () => {
+    const { synologyChatSetupAdapter } = await import("./setup-surface.js");
+    const input = { token: "replacement", url: "https://nas.example.com/alerts" };
+    const configured = synologyChatSetupAdapter.applyAccountConfig({
+      cfg: {
+        channels: {
+          "synology-chat": {
+            enabled: false,
+            token: "root-token",
+            accounts: {
+              alerts: { enabled: false, token: "old-alerts", webhookPath: "/alerts" },
+              sibling: { enabled: false, token: "sibling-token" },
+            },
+          },
+        },
+      },
+      accountId: "alerts",
+      input,
+    });
+
+    expect(configured).toEqual({
+      channels: {
+        "synology-chat": {
+          enabled: true,
+          token: "root-token",
+          accounts: {
+            alerts: {
+              enabled: true,
+              token: "replacement",
+              webhookPath: "/alerts",
+              incomingUrl: "https://nas.example.com/alerts",
+            },
+            sibling: { enabled: false, token: "sibling-token" },
+          },
+        },
+      },
+    });
+  });
+
   it("registers real webhook handler with resolved account config and enforces allowlist", async () => {
     const plugin = synologyChatPlugin;
     const abortController = new AbortController();

--- a/extensions/synology-chat/src/setup-surface.ts
+++ b/extensions/synology-chat/src/setup-surface.ts
@@ -9,6 +9,7 @@ import {
   formatDocsLink,
   mergeAllowFromEntries,
   normalizeAccountId,
+  patchScopedAccountConfig,
   setSetupChannelEnabled,
   splitSetupEntries,
   type ChannelSetupAdapter,
@@ -71,47 +72,19 @@ function patchSynologyChatAccountConfig(params: {
   clearFields?: string[];
   enabled?: boolean;
 }): OpenClawConfig {
-  const channelConfig = getChannelConfig(params.cfg);
-  if (params.accountId === DEFAULT_ACCOUNT_ID) {
-    const nextChannelConfig = { ...channelConfig } as Record<string, unknown>;
-    for (const field of params.clearFields ?? []) {
-      delete nextChannelConfig[field];
-    }
-    return {
-      ...params.cfg,
-      channels: {
-        ...params.cfg.channels,
-        [channel]: {
-          ...nextChannelConfig,
-          ...(params.enabled ? { enabled: true } : {}),
-          ...params.patch,
-        },
-      },
-    };
-  }
-
-  const nextAccounts = { ...channelConfig.accounts } as Record<string, Record<string, unknown>>;
-  const nextAccountConfig = { ...nextAccounts[params.accountId] };
-  for (const field of params.clearFields ?? []) {
-    delete nextAccountConfig[field];
-  }
-  nextAccounts[params.accountId] = {
-    ...nextAccountConfig,
-    ...(params.enabled ? { enabled: true } : {}),
-    ...params.patch,
-  };
-
-  return {
-    ...params.cfg,
-    channels: {
-      ...params.cfg.channels,
-      [channel]: {
-        ...channelConfig,
-        ...(params.enabled ? { enabled: true } : {}),
-        accounts: nextAccounts,
-      },
+  return patchScopedAccountConfig({
+    cfg: params.cfg,
+    channelKey: channel,
+    accountId: params.accountId,
+    patch: params.patch,
+    accountPatch: {
+      ...(params.enabled ? { enabled: true } : {}),
+      ...params.patch,
     },
-  };
+    clearFields: params.clearFields,
+    ensureChannelEnabled: Boolean(params.enabled),
+    ensureAccountEnabled: false,
+  });
 }
 
 function isSynologyChatConfigured(cfg: OpenClawConfig, accountId: string): boolean {


### PR DESCRIPTION
## What Problem This Solves

Synology Chat and Feishu repeat root/account configuration patching already owned by the shared setup helpers. Keeping separate mutation paths risks inconsistent field clearing, enabling and account placement.

## Why This Change Was Made

Synology delegates to `patchScopedAccountConfig` while preserving explicit enabling and clear-before-patch order. Its CLI/wizard callers already normalize account IDs. Feishu uses the shared root-enable helper and top-level section patching while preserving exact named-account keys, including the empty string, and leaving the channel-enabled flag unchanged for named-account updates.

The only follow-up code-accounting change is the maintainer-authorized assertion baseline shrink for Synology setup, **5 → 3**, reflecting two deleted casts. No baseline grows and no SDK export, configuration option or persistent-state contract changes. This is a maintainer-requested channel de-duplication.

## User Impact

No intended behavior change. Root placement, named-account credentials, sibling accounts, field clearing and enable flags remain the same.

## Evidence

Before changing the draft, a clean detached current-main checkout was created outside ancestor installations, with a frozen-lockfile install. The exact command was:

`node scripts/run-vitest.mjs extensions/synology-chat/src/channel.integration.test.ts`

| Checkout | Revision | Result | Vitest duration |
| --- | --- | --- | --- |
| Fresh physical checkout | Main `110a636dd16e48af3fa68acc11fe00215bb54e96` | 5 passed | 33.69s |
| Same checkout | Patch-identical rebased candidate `89dad4f282c3a06dc5738df37e6fafb984b42db3` | 6 passed | 25.92s |
| Original nested worktree | Same main | 5 passed | 19.30s |
| Original nested worktree | Same candidate | 6 passed | 11.80s |

The earlier 180000ms import-hook timeout did not reproduce in any control. No candidate-specific import failure was demonstrated. Its exact historical cause remains unproven; these results do not establish a pre-existing failure on current main. No test, timeout, skip or mock was changed during this attribution run. The final head differs from the tested candidate only by the assertion-baseline shrink. Timings vary with cache and host load and are not performance claims.

- `node scripts/run-vitest.mjs extensions/feishu/src/setup-surface.test.ts src/channels/plugins/setup-helpers src/channels/plugins/config-helpers`: **54 tests passed**.
- `node scripts/check-changed.mjs --base 110a636dd16e48af3fa68acc11fe00215bb54e96`: passed in the separate physical checkout, including extension production/test types, extension lint, script lint, zero unused exports and zero runtime import cycles.
- The two initial setup reviews and two fresh reviews found no actionable P0–P2 defect; the latest includes the exact shrink-only baseline update.
- Full `pnpm build`: passed in **7m 19.2s** in the separate physical checkout, including all 152 public SDK subpaths, 90 external plugins and native loads of 53 built modules.
- Exact-head hosted CI run [34094604722](https://github.com/openclaw/openclaw/actions/runs/34094604722): passed on `cffbad32c9be6ac48ae4df8e0f77217930f877e7`.

Known gap: validation uses synthetic configuration and webhook/SDK harnesses, with no live Synology or Feishu account and no external channel send. Local test runs have no hosted run URL.
