### PR TITLE
refactor(cli): share daemon status JSON projection

### DIFF
--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -113,7 +113,7 @@ const SAFE_DAEMON_ENV_KEYS = [
 ];
 
 /** Keep only daemon env keys safe to print in diagnostics. */
-export function filterDaemonEnv(env: Record<string, string> | undefined): Record<string, string> {
+function filterDaemonEnv(env: Record<string, string> | undefined): Record<string, string> {
   if (!env) {
     return {};
   }

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -9,6 +9,7 @@ import {
 import { resolveDaemonContainerContext } from "../../daemon/container-context.js";
 import { formatRuntimeStatus } from "../../daemon/runtime-format.js";
 import { buildPlatformServiceStartHints } from "../../daemon/runtime-hints.js";
+import type { GatewayServiceCommandConfig } from "../../daemon/service-types.js";
 import { hasSudoToRootSystemdUserManagerMismatch } from "../../daemon/systemd-exec.js";
 import { resolveGatewayServiceMutationError } from "../../infra/gateway-supervision.js";
 import { formatCliCommand } from "../command-format.js";
@@ -125,6 +126,27 @@ export function filterDaemonEnv(env: Record<string, string> | undefined): Record
     filtered[key] = value.trim();
   }
   return filtered;
+}
+
+export function projectDaemonServiceForJson<
+  T extends { command?: GatewayServiceCommandConfig | null },
+>(service: T, { includeDefinitionPaths }: { includeDefinitionPaths: boolean }) {
+  const command = service.command;
+  if (!command) {
+    return service;
+  }
+  const environment = filterDaemonEnv(command.environment);
+  const publicCommand = {
+    ...command,
+    environment: Object.keys(environment).length > 0 ? environment : undefined,
+  };
+  delete publicCommand.managedDefinition;
+  delete publicCommand.managedOverrides;
+  // Node status retains definition paths in its shipped JSON contract.
+  if (!includeDefinitionPaths) {
+    delete publicCommand.definitionPaths;
+  }
+  return { ...service, command: publicCommand };
 }
 
 /** Format safe daemon env entries for status output. */

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -105,7 +105,6 @@ vi.mock("./shared.js", async (importOriginal) => ({
     warnText: (text: string) => text,
     errorText: (text: string) => text,
   }),
-  filterDaemonEnv: () => ({}),
   formatRuntimeStatus: () => "running (pid 8000)",
   resolveRuntimeStatusColor: () => "",
   safeDaemonEnv: () => [],

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -181,6 +181,10 @@ describe("printDaemonStatus", () => {
       expect(payload).toHaveProperty("service.command.reloadPending", true);
       expect(JSON.stringify(payload)).not.toContain("gateway-token");
     }
+    expect(command.definitionPaths).toEqual(["/etc/systemd/user/private-definition.conf"]);
+    expect(command.environment?.OPENCLAW_GATEWAY_TOKEN).toBe("effective-gateway-token");
+    expect(command.managedDefinition).toBeDefined();
+    expect(command.managedOverrides).toBeDefined();
   });
 
   it("prints user-manager pending reload guidance after the service file", () => {

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -13,7 +13,6 @@ import {
 } from "../../daemon/restart-logs.js";
 import { buildGatewayRuntimeRecoveryHints } from "../../daemon/runtime-hints.js";
 import { isSystemdStartLimitHit } from "../../daemon/service-runtime.js";
-import type { GatewayServiceCommandConfig } from "../../daemon/service-types.js";
 import {
   isSystemdUnavailableDetail,
   renderSystemdUnavailableHints,
@@ -28,8 +27,8 @@ import { shortenHomePath } from "../../utils.js";
 import { formatCliCommand } from "../command-format.js";
 import {
   createCliStatusTextStyles,
-  filterDaemonEnv,
   formatRuntimeStatus,
+  projectDaemonServiceForJson,
   resolveDaemonInstallBlockMessage,
   resolveRuntimeStatusColor,
   safeDaemonEnv,
@@ -39,29 +38,6 @@ import {
   renderPortDiagnosticsForCli,
   resolvePortListeningAddresses,
 } from "./status.gather.js";
-
-function sanitizeDaemonStatusForJson(status: DaemonStatus): DaemonStatus {
-  // JSON output can be copied into issues; redact service env before serialization.
-  const command = status.service.command;
-  if (!command) {
-    return status;
-  }
-  const safeEnv = filterDaemonEnv(command.environment);
-  const nextCommand: GatewayServiceCommandConfig = {
-    ...command,
-    environment: Object.keys(safeEnv).length > 0 ? safeEnv : undefined,
-  };
-  delete nextCommand.managedDefinition;
-  delete nextCommand.managedOverrides;
-  delete nextCommand.definitionPaths;
-  return {
-    ...status,
-    service: {
-      ...status.service,
-      command: nextCommand,
-    },
-  };
-}
 
 function formatProbeKindLabel(kind?: "connect" | "read") {
   return kind === "read" ? "Read probe:" : "Connectivity probe:";
@@ -97,8 +73,10 @@ function formatConnectionLine(
 
 export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; deep?: boolean }) {
   if (opts.json) {
-    const sanitized = sanitizeDaemonStatusForJson(status);
-    defaultRuntime.writeJson(sanitized);
+    defaultRuntime.writeJson({
+      ...status,
+      service: projectDaemonServiceForJson(status.service, { includeDefinitionPaths: false }),
+    });
     return;
   }
 

--- a/src/cli/node-cli/daemon.test.ts
+++ b/src/cli/node-cli/daemon.test.ts
@@ -592,7 +592,7 @@ describe("runNodeDaemonStatus", () => {
   });
 
   it("redacts service credentials from JSON status output", async () => {
-    mocks.service.readCommand.mockResolvedValue({
+    const command: GatewayServiceCommandConfig = {
       programArguments: ["node", "node-host"],
       environment: {
         OPENCLAW_PROFILE: "work",
@@ -604,7 +604,11 @@ describe("runNodeDaemonStatus", () => {
         environment: { OPENCLAW_GATEWAY_TOKEN: "managed-base-token" },
       },
       managedOverrides: { launcher: "command", environment: { keys: ["OPENCLAW_GATEWAY_TOKEN"] } },
-    });
+      definitionPaths: ["/etc/systemd/user/node-definition.conf"],
+      environmentValueSources: { OPENCLAW_PROFILE: "file" },
+      reloadPending: true,
+    };
+    mocks.service.readCommand.mockResolvedValue(command);
 
     await runNodeDaemonStatus({ json: true });
 
@@ -612,6 +616,9 @@ describe("runNodeDaemonStatus", () => {
       service: expect.objectContaining({
         command: expect.objectContaining({
           environment: { OPENCLAW_PROFILE: "work" },
+          definitionPaths: command.definitionPaths,
+          environmentValueSources: command.environmentValueSources,
+          reloadPending: true,
         }),
       }),
     });
@@ -621,5 +628,8 @@ describe("runNodeDaemonStatus", () => {
     expect(payload).not.toContain("managed-base-token");
     expect(payload).not.toContain("managedDefinition");
     expect(payload).not.toContain("managedOverrides");
+    expect(command.environment?.OPENCLAW_GATEWAY_TOKEN).toBe("gateway-token");
+    expect(command.managedDefinition).toBeDefined();
+    expect(command.managedOverrides).toBeDefined();
   });
 });

--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -36,8 +36,8 @@ import {
   createCliStatusTextStyles,
   createDaemonInstallActionContext,
   resolveDaemonInstallBlockMessage,
-  filterDaemonEnv,
   formatRuntimeStatus,
+  projectDaemonServiceForJson,
   resolveRuntimeStatusColor,
 } from "../daemon-cli/shared.js";
 import { formatInvalidConfigPort, formatInvalidPortOption } from "../error-format.js";
@@ -298,20 +298,8 @@ export async function runNodeDaemonStatus(opts: NodeDaemonStatusOptions = {}) {
   };
 
   if (json) {
-    const safeEnvironment = filterDaemonEnv(command?.environment);
-    const publicCommand = command && {
-      ...command,
-      environment: Object.keys(safeEnvironment).length > 0 ? safeEnvironment : undefined,
-    };
-    if (publicCommand) {
-      delete publicCommand.managedDefinition;
-      delete publicCommand.managedOverrides;
-    }
     defaultRuntime.writeJson({
-      service: {
-        ...payload.service,
-        command: publicCommand,
-      },
+      service: projectDaemonServiceForJson(payload.service, { includeDefinitionPaths: true }),
     });
     return;
   }


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested lifecycle de-duplication: Node and Gateway status independently redact service-command metadata before writing JSON. Keeping separate projections risks changing one CLI's shipped fields when the other is updated.

## Why This Change Was Made

Use `projectDaemonServiceForJson` in `src/cli/daemon-cli/shared.ts` for both status commands. It preserves service metadata, filters command environment through the existing allowlist, removes internal managed-definition metadata from a copy, and explicitly retains `definitionPaths` for Node while omitting it for Gateway.

Native observation remains separate: Node checks loaded state first and fails before further reads; Gateway probes absence, reads the command first, merges its environment, and projects failures differently. Their text output also has distinct path and diagnostic policies. Sharing those flows would change behavior, so this consolidation only owns the common JSON projection.

## User Impact

No CLI field, error, exit-status, or text-output change. Node keeps `service.command.definitionPaths`; Gateway continues omitting it. No configuration or persistent-state change. Production code shrinks by 12 lines; tests add 13 lines of contract coverage.

## Evidence

- `node scripts/run-vitest.mjs src/cli/node-cli/daemon.test.ts src/cli/daemon-cli/status.print.test.ts`: 2 files, 69 passed, 1 existing platform skip.
- Existing tests now explicitly check Node metadata retention and that neither projection mutates the original command.
- Targeted oxlint for all changed files: passed.
- Independent Codex autoreview: no actionable P0–P2 findings.
- `git diff --check`: passed.
- `node scripts/check-changed.mjs`: passed in full after the permitted frozen dependency install. The final removal of an unused test mock passed the printer suite (35 passed, 1 existing skip), formatting, and focused autoreview; production code is unchanged.
- Packed-CLI proof passed on Blacksmith Testbox `tbx_01m1x15yf25xpypyar2paa19qw`, [run 34082344305](https://github.com/openclaw/openclaw/actions/runs/34082344305). Both baseline and candidate ran `pnpm build:package`, were packed with the repository source packer, and installed into separate temporary npm prefixes and state directories.

### Native status JSON comparison

Each packed CLI ran against absent units and enabled task-owned systemd definitions. The definitions were never started: `ExecMainStartTimestampMonotonic` stayed zero. Fixtures were disabled/removed afterward and the Testbox lease was stopped.

| Scenario | Baseline key paths | Candidate key paths | Key diff |
| --- | ---: | ---: | --- |
| Absent daemon | 77 | 77 | `[]` |
| Absent Node | 19 | 19 | `[]` |
| Defined daemon | 97 | 97 | `[]` |
| Defined Node | 27 | 27 | `[]` |

The live assertions also verify Node retains `service.command.definitionPaths`, Gateway omits it, managed-definition metadata is absent, and a synthetic credential never appears in JSON. Exact commands, run once in each scenario:

```sh
# Baseline
openclaw daemon status --json --port 50305 --timeout 2000
openclaw node status --json
# Candidate
openclaw daemon status --json --port 56691 --timeout 2000
openclaw node status --json
```

Baseline source: `f9237c68d428ac07661803d14cca19150723fec8`. The packed candidate is `632192cdd184f708b13f4e6c38a6d1840d0de042`, tree `ccf5fb69c8a3b46ffd2c8127a74af158ae6e8ff4`. Follow-ups remove the unused internal export modifier from `filterDaemonEnv` and its stale test mock; the projection logic is unchanged. Final reviewed head: `3bbf271f874ecdda0373120c9bee0fd2604b67a2`.

## Known Gaps

The internal-export cleanup is reviewed and the fresh-main rebase onto `0f087c96251` preserved the reviewed binary branch diff exactly. A final test-only change removes its unused mock. Exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/34084661462. Observation consolidation is deliberately excluded because its differences are contractual; the initial linked-only fixture reproduced Node’s existing loaded-check refusal, so normal enabled definitions were used for the successful comparison.
