### PR TITLE
refactor: simplify message batch summaries

### DIFF
--- a/src/channels/message/rendered-batch.ts
+++ b/src/channels/message/rendered-batch.ts
@@ -59,16 +59,16 @@ export function createRenderedMessageBatchPlan(
 ): RenderedMessageBatchPlan {
   const items = payloads.map(createRenderedMessageBatchPlanItem);
   return items.reduce<RenderedMessageBatchPlan>(
-    (plan, item) => ({
-      payloadCount: plan.payloadCount + 1,
-      textCount: plan.textCount + (item.text ? 1 : 0),
-      mediaCount: plan.mediaCount + item.mediaUrls.length,
-      voiceCount: plan.voiceCount + (item.audioAsVoice ? 1 : 0),
-      presentationCount: plan.presentationCount + (item.kinds.includes("presentation") ? 1 : 0),
-      interactiveCount: plan.interactiveCount + (item.hasInteractive ? 1 : 0),
-      channelDataCount: plan.channelDataCount + (item.hasChannelData ? 1 : 0),
-      items: plan.items,
-    }),
+    (plan, item) => {
+      plan.payloadCount += 1;
+      plan.textCount += item.text ? 1 : 0;
+      plan.mediaCount += item.mediaUrls.length;
+      plan.voiceCount += item.audioAsVoice ? 1 : 0;
+      plan.presentationCount += item.kinds.includes("presentation") ? 1 : 0;
+      plan.interactiveCount += item.hasInteractive ? 1 : 0;
+      plan.channelDataCount += item.hasChannelData ? 1 : 0;
+      return plan;
+    },
     {
       payloadCount: 0,
       textCount: 0,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled where applicable.

</details>

## What Problem This Solves

Message batch preparation creates a replacement summary object for every populated payload slot. This is avoidable bookkeeping in the shared batch-rendering path used by outbound delivery and live previews.

## Why This Change Was Made

Update one fresh, private accumulator per call instead of allocating a new eight-field summary at each reduction step. Keep the existing prepared-item map and sparse-array-skipping reduction. The change is +10/-10 production lines (net zero).

The original payload array, prepared-item ownership, summary property order, normalized media duplicates, voice counts, title-only presentations, and location/channel-data classification remain unchanged. Nothing is pooled between calls; public types, transports, delivery routing, and stores are untouched.

## User Impact

No intended visible behavior change. This removes per-item summary allocations, but the measured timing result is mixed: larger batches show some gains, while the 64-item workload is consistently slower. This is a small allocation cleanup, not evidence of a general channel, Gateway, network-latency, or memory-usage improvement.

## Evidence

Normal frozen installation, formatting, all **50 tests across four complete existing files**, and **28 normal changed checks** passed. The complete suites cover rendered batches, message lifecycle, durable send contexts, and media-retirement boundaries. Independent Codex P2 review was scoped-clean, confidence 0.99. Validation and measurement are attributed to base `2413c5e3dcde376a208ed866d87909a2f4b5a71d`; they are not represented as a latest-main run.

A fixed 38-row workload calls the actual `createRenderedMessageBatch` export, both alone and composed with the actual `markLiveMessagePreviewUpdated` export. It covers empty, single-kind, mixed, already-split text, and sparse payloads. Independent expected-output records check complete values, sparse holes, own-key order, input nonmutation, payload identity, and fresh result ownership. Baseline/candidate verification preceded one B0/C0/C1/B1 cohort: **76 verification calls, 10,488 checked measurement calls, and 9,728 timed calls**. All six child phases passed and closed; the candidate was restored. No selective reruns.

Each entry below is the median of eight batches of eight calls, divided by eight, in microseconds per call. The two columns retain the two comparison orders; negative percentages mean faster. These are local microbenchmarks, not production-traffic weighting or a statistical significance claim.

| Workload | B0 → C0, µs/call (change) | B1 → C1, µs/call (change) |
| --- | ---: | ---: |
| batch/mixed-512 | 131.141 → 127.672 (-2.65%) | 129.565 → 126.190 (-2.60%) |
| preview/mixed-512 | 168.492 → 147.755 (-12.31%) | 141.117 → 139.958 (-0.82%) |
| batch/mixed-64 | 18.484 → 20.198 (+9.27%) | 17.958 → 19.036 (+6.00%) |
| preview/mixed-64 | 18.286 → 19.104 (+4.47%) | 17.867 → 18.385 (+2.90%) |
| batch/split-text-32 | 5.622 → 5.120 (-8.94%) | 5.310 → 5.372 (+1.18%) |
| preview/split-text-32 | 5.664 → 5.490 (-3.08%) | 5.338 → 5.367 (+0.54%) |
| batch/sparse-mixed-8 | 0.940 → 1.000 (+6.37%) | 0.911 → 0.974 (+6.86%) |
| preview/sparse-mixed-8 | 0.987 → 1.021 (+3.43%) | 0.995 → 0.974 (-2.09%) |

Adverse measurements are retained: **32/76 paired medians and 115/304 median/mean/minimum/maximum-batch metrics were slower**. The second 512-item preview comparison had a faster median but a slower mean (+2.70%) and maximum batch mean: 164.042 → 195.828 µs/call (+19.38%). The first 64-item batch maximum rose 23.912 → 28.583 µs/call (+19.54%); the first 512-item batch maximum rose 147.125 → 151.724 µs/call (+3.13%).

Empty and all-hole arrays avoid no per-item summary objects in either version, so their timings are controls, not an optimization claim. Empty preview changed -27.27%/+3.43%; all-hole preview changed -7.80%/+49.25%, with the latter only 0.180 → 0.268 µs/call. Single-item medians also varied: the combined-flags preview changed +67.82%/-19.08% (0.526 → 0.883 and 0.628 → 0.508 µs/call). The standalone combined-flags batch route’s maximum in the second order rose 0.625 → 1.932 µs/call (+209.16%). These small-duration and order-sensitive controls argue against a universal speedup.

Whole-child resource observations include import, fixture checks, serialization, and evidence output, so they do not measure the accumulator’s allocation footprint:

| Phase | Child wall, seconds | Kernel peak RSS, MiB | Sampled tree peak RSS, MiB |
| --- | ---: | ---: | ---: |
| B0 | 1.404 | 299.56 | 273.62 |
| C0 | 1.352 | 295.36 | 281.50 |
| C1 | 1.316 | 293.30 | 279.73 |
| B1 | 1.295 | 288.59 | 302.11 |

All original row samples, complete saved outcomes, adverse metrics, and process receipts are retained locally. Independent numeric audit rebuilt all fixture expectations and verified all 10,564 retained outputs and all 304 comparisons without rerunning the target. No live channel send or Gateway latency was measured; the changed boundary is synchronous batch preparation and preview-state composition.
