### PR TITLE
fix(openshell): report preserved shadows after mirror failures

### DIFF
--- a/docs/gateway/openshell.md
+++ b/docs/gateway/openshell.md
@@ -536,6 +536,15 @@ openclaw logs --follow
 - **An image or attachment cannot be sent:** Use a path under the configured
   `remoteWorkspaceDir`, such as `/sandbox/report.png`, rather than assuming
   every backend uses Docker's `/workspace` directory.
+- **Mirror synchronization reports recovery paths:** OpenClaw kept a host shadow
+  outside the workspace because its move or restoration could not finish. The
+  error identifies the preserved path and the workspace path and retains the
+  original failure. Compare both paths and recover the needed files before
+  deleting either copy. A partial move can leave different files in each path;
+  OpenClaw preserves remaining workspace entries instead of overwriting them
+  with an incomplete or unverified backup. If restoration completed and only
+  cleanup of the preservation directory failed, the error confirms the restored
+  workspace path and identifies the leftover directory instead.
 - **Recreate or prune cannot delete a sandbox:** Restore access to the original
   OpenShell gateway and workspace, confirm the sandbox still exists with
   `openshell --workspace <workspace-name> sandbox get <sandbox-name>`, and retry

--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -8,6 +8,7 @@
   },
   "type": "module",
   "dependencies": {
+    "@openclaw/fs-safe": "0.8.3",
     "p-limit": "7.3.1",
     "zod": "4.4.3"
   },

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -1,7 +1,12 @@
 // Openshell plugin module implements backend behavior.
 import { createHash } from "node:crypto";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import {
+  movePathWithCopyFallback,
+  type MovePathPublicationReceipt,
+} from "@openclaw/fs-safe/atomic";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import type {
@@ -38,7 +43,6 @@ import { resolveOpenShellPluginConfig, type ResolvedOpenShellPluginConfig } from
 import { createOpenShellFsBridge } from "./fs-bridge.js";
 import {
   DEFAULT_OPEN_SHELL_MIRROR_EXCLUDE_DIRS,
-  movePathWithCopyFallback,
   replaceDirectoryContents,
   stageDirectoryContents,
 } from "./mirror.js";
@@ -1077,6 +1081,7 @@ class OpenShellSandboxBackendImpl {
             throw new Error(result.stderr.trim() || "openshell sandbox download failed");
           }
           const preservedShadows: PreservedLocalShadow[] = [];
+          const failures: unknown[] = [];
           try {
             for (const shadowedRoot of roots.slice(index + 1)) {
               if (
@@ -1090,14 +1095,12 @@ class OpenShellSandboxBackendImpl {
                 .split("/")
                 .filter(Boolean);
               await removeDownloadedWorkspacePath(tmpDir, relativeParts);
-              const preserved = await moveLocalShadowAside({
+              await moveLocalShadowAside({
                 workspaceDir: root.local,
                 tmpDir,
                 relativeParts,
+                preservedShadows,
               });
-              if (preserved) {
-                preservedShadows.push(preserved);
-              }
             }
             const relativeSkillsPath = path.posix.relative(root.remote, remoteSkillsWorkspaceDir);
             if (
@@ -1110,14 +1113,12 @@ class OpenShellSandboxBackendImpl {
               );
             }
             if (root.owner === "workspace") {
-              const preserved = await moveLocalShadowAside({
+              await moveLocalShadowAside({
                 workspaceDir: root.local,
                 tmpDir,
                 relativeParts: MATERIALIZED_SKILLS_REMOTE_PARTS,
+                preservedShadows,
               });
-              if (preserved) {
-                preservedShadows.push(preserved);
-              }
             }
             await replaceDirectoryContents({
               sourceDir: tmpDir,
@@ -1126,10 +1127,38 @@ class OpenShellSandboxBackendImpl {
               // the remote sandbox.
               excludeDirs: DEFAULT_OPEN_SHELL_MIRROR_EXCLUDE_DIRS,
             });
-          } finally {
-            for (const preserved of preservedShadows.toReversed()) {
-              await restoreLocalShadow({ workspaceDir: root.local, preserved });
+          } catch (error) {
+            failures.push(error);
+          }
+          const retained: string[] = [];
+          for (const preserved of preservedShadows.toReversed()) {
+            if (preserved.sourceRetired) {
+              try {
+                const cleanupFailure = await restoreLocalShadow(preserved);
+                if (cleanupFailure) {
+                  failures.push(cleanupFailure);
+                }
+                continue;
+              } catch (error) {
+                failures.push(error);
+              }
             }
+            retained.push(`${preserved.receipt.path} (workspace path: ${preserved.shadowPath})`);
+          }
+          if (retained.length > 0 || failures.length > 1) {
+            const recovery =
+              retained.length > 0
+                ? ` Inspect the recovery paths ${retained.join("; ")}. ` +
+                  "Remaining workspace entries were preserved; compare both paths before recovering or deleting either copy."
+                : "";
+            throw new AggregateError(
+              failures,
+              `OpenShell mirror synchronization failed: ${failures.map(String).join("; ")}.${recovery}`,
+              { cause: failures[0] },
+            );
+          }
+          if (failures.length > 0) {
+            throw failures[0];
           }
         },
       );
@@ -1319,60 +1348,85 @@ async function removeDownloadedWorkspacePath(
 }
 
 type PreservedLocalShadow = {
-  preservedPath: string;
-  preserveRoot: string;
-  relativeParts: readonly string[];
+  receipt: MovePathPublicationReceipt;
+  shadowPath: string;
+  sourceRetired: boolean;
 };
 
 async function moveLocalShadowAside(params: {
   workspaceDir: string;
   tmpDir: string;
   relativeParts: readonly string[];
-}): Promise<PreservedLocalShadow | undefined> {
+  preservedShadows: PreservedLocalShadow[];
+}): Promise<void> {
   const shadowPath = path.join(params.workspaceDir, ...params.relativeParts);
   const parentStats = await fs.lstat(path.dirname(shadowPath)).catch(() => null);
   if (!parentStats?.isDirectory() || parentStats.isSymbolicLink()) {
-    return undefined;
+    return;
   }
   const shadowStats = await fs.lstat(shadowPath).catch(() => null);
   if (!shadowStats || shadowStats.isSymbolicLink()) {
-    return undefined;
+    return;
   }
   const preserveRoot = await fs.mkdtemp(
     path.join(path.dirname(params.tmpDir), "openclaw-openshell-preserve-"),
   );
-  const preservedPath = path.join(preserveRoot, "shadow");
-  await movePathWithCopyFallback({ from: shadowPath, to: preservedPath });
-  return { preservedPath, preserveRoot, relativeParts: params.relativeParts };
+  let preserved: PreservedLocalShadow | undefined;
+  await movePathWithCopyFallback({
+    from: shadowPath,
+    to: path.join(preserveRoot, "shadow"),
+    onDestinationPublished: (receipt) => {
+      preserved = { receipt, shadowPath, sourceRetired: false };
+      params.preservedShadows.push(preserved);
+    },
+  });
+  if (preserved) {
+    preserved.sourceRetired = true;
+  }
 }
 
-async function restoreLocalShadow(params: {
-  workspaceDir: string;
-  preserved: PreservedLocalShadow;
-}): Promise<void> {
-  let restored = false;
-  try {
-    const shadowPath = path.join(params.workspaceDir, ...params.preserved.relativeParts);
-    const parentPath = path.dirname(shadowPath);
-    const parentStats = await fs.lstat(parentPath).catch(() => null);
-    if (parentStats?.isSymbolicLink()) {
-      throw new Error(`Refusing to restore workspace shadow through symlink parent: ${parentPath}`);
-    }
-    if (parentStats && !parentStats.isDirectory()) {
-      await fs.rm(parentPath, { recursive: true, force: true });
-    }
-    await fs.mkdir(parentPath, { recursive: true });
-    await fs.rm(shadowPath, { recursive: true, force: true });
-    await movePathWithCopyFallback({
-      from: params.preserved.preservedPath,
-      to: shadowPath,
-    });
-    restored = true;
-  } finally {
-    if (restored) {
-      await fs.rm(params.preserved.preserveRoot, { recursive: true, force: true });
-    }
+function assertPreservedShadowIdentity(receipt: MovePathPublicationReceipt): void {
+  const stat = fsSync.lstatSync(receipt.path, { bigint: true });
+  if (
+    stat.isSymbolicLink() ||
+    stat.dev !== receipt.dev ||
+    stat.ino !== receipt.ino ||
+    (process.platform === "win32" && (stat.dev === 0n || stat.ino === 0n))
+  ) {
+    throw new Error(`Refusing to restore an unverified workspace shadow: ${receipt.path}`);
   }
+}
+
+async function restoreLocalShadow(preserved: PreservedLocalShadow): Promise<Error | undefined> {
+  const { shadowPath, receipt } = preserved;
+  const assertBackup = () => assertPreservedShadowIdentity(receipt);
+  const parentPath = path.dirname(shadowPath);
+  const parentStats = await fs.lstat(parentPath).catch(() => null);
+  if (parentStats?.isSymbolicLink()) {
+    throw new Error(`Refusing to restore workspace shadow through symlink parent: ${parentPath}`);
+  }
+  if (parentStats && !parentStats.isDirectory()) {
+    assertBackup();
+    await fs.rm(parentPath, { recursive: true, force: true });
+  }
+  assertBackup();
+  await fs.mkdir(parentPath, { recursive: true });
+  assertBackup();
+  await fs.rm(shadowPath, { recursive: true, force: true });
+  await movePathWithCopyFallback({
+    from: receipt.path,
+    to: shadowPath,
+    assertBeforeMutation: assertBackup,
+  });
+  try {
+    await fs.rmdir(path.dirname(receipt.path));
+  } catch (error) {
+    return new Error(
+      `Workspace shadow was restored at ${shadowPath}, but preservation directory cleanup failed at ${path.dirname(receipt.path)}`,
+      { cause: error },
+    );
+  }
+  return undefined;
 }
 
 function resolveOpenShellTmpRoot(): string {

--- a/extensions/openshell/src/mirror.ts
+++ b/extensions/openshell/src/mirror.ts
@@ -1,7 +1,7 @@
 // Openshell plugin module implements mirror behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { extractErrorCode, movePathWithCopyFallback } from "openclaw/plugin-sdk/security-runtime";
+import { extractErrorCode } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import pLimit from "p-limit";
 
@@ -121,5 +121,3 @@ export async function stageDirectoryContents(params: {
 }): Promise<void> {
   await reconcileMirrorDirectory({ ...params, replace: false });
 }
-
-export { movePathWithCopyFallback };

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -763,62 +763,168 @@ describe("openshell backend manager", () => {
     expect(sandboxMocks.disposeSshSandboxSession).toHaveBeenCalledTimes(2);
   });
 
-  it("preserves a local sandbox skills shadow when mirror sync crosses filesystems", async () => {
-    await using workspace = await createOpenShellTestWorkspace("workspace");
-    const workspaceDir = workspace.dir;
-    const shadowFile = path.join(workspaceDir, ".openclaw", "sandbox-skills", "user-note.txt");
-    await fs.mkdir(path.dirname(shadowFile), { recursive: true });
-    await fs.writeFile(shadowFile, "local shadow", "utf8");
-
-    const originalRename = fs.rename.bind(fs);
-    const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
-      const source = String(from);
-      const target = String(to);
-      const shadowDir = path.dirname(shadowFile);
-      const isFallbackStagedMove = path.basename(source).startsWith(".fs-safe-move-");
-      if (source === shadowDir || (target === shadowDir && !isFallbackStagedMove)) {
-        throw Object.assign(new Error("cross-device link not permitted"), { code: "EXDEV" });
+  it.each([
+    "success",
+    "source cleanup failure",
+    "retained source replacement",
+    "restore cleanup failure",
+  ] as const)(
+    "preserves and reports a local shadow when cross-filesystem mirror sync ends with %s",
+    async (outcome) => {
+      await using workspace = await createOpenShellTestWorkspace("workspace");
+      const workspaceDir = workspace.dir;
+      const shadowFile = path.join(workspaceDir, ".openclaw", "sandbox-skills", "user-note.txt");
+      await fs.mkdir(path.dirname(shadowFile), { recursive: true });
+      await fs.writeFile(shadowFile, "local shadow", "utf8");
+      const sourceContents = new Map([["user-note.txt", "local shadow"]]);
+      if (outcome === "source cleanup failure" || outcome === "restore cleanup failure") {
+        sourceContents.set("second-note.txt", "second shadow");
+        await fs.writeFile(path.join(path.dirname(shadowFile), "second-note.txt"), "second shadow");
       }
-      return await originalRename(from, to);
-    });
-    cliMocks.runOpenShellCli.mockImplementation(async ({ args }: { args: string[] }) => {
-      if (args[0] === "sandbox" && args[1] === "download") {
-        const tmpDir = expectDefined(args[4], "OpenShell download destination");
-        await fs.writeFile(path.join(tmpDir, "from-remote.txt"), "remote", "utf8");
-        await fs.mkdir(path.join(tmpDir, ".openclaw", "sandbox-skills", "skills"), {
-          recursive: true,
-        });
-        await fs.writeFile(
-          path.join(tmpDir, ".openclaw", "sandbox-skills", "skills", "generated.txt"),
-          "generated",
-          "utf8",
-        );
-      }
-      return { code: 0, stdout: "", stderr: "" };
-    });
 
-    const backend = await createOpenShellBackendFixture({ workspaceDir, mode: "mirror" });
-
-    try {
-      await backend.finalizeExec?.({
-        status: "completed",
-        exitCode: 0,
-        timedOut: false,
-        token: undefined,
+      let preservedPath: string | undefined;
+      let sourceCleanupFailed = false;
+      const removedSourceFiles: string[] = [];
+      let retainedSourceFile: string | undefined;
+      let sourceAtCleanupFailure: string[] = [];
+      const originalRename = fs.rename.bind(fs);
+      const originalUnlink = fs.unlink.bind(fs);
+      const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
+        const source = String(from);
+        const target = String(to);
+        const shadowDir = path.dirname(shadowFile);
+        const isFallbackStagedMove = path.basename(source).startsWith(".fs-safe-move-");
+        if (source === shadowDir || (target === shadowDir && !isFallbackStagedMove)) {
+          throw Object.assign(new Error("cross-device link not permitted"), { code: "EXDEV" });
+        }
+        await originalRename(from, to);
+        if (isFallbackStagedMove && path.basename(target) === "shadow") {
+          // Observe a real completed destination publication before injecting a source race.
+          preservedPath = target;
+          if (outcome === "retained source replacement") {
+            await originalUnlink(shadowFile);
+            await fs.writeFile(shadowFile, "concurrent replacement", "utf8");
+          }
+        }
+      });
+      const unlinkSpy = vi.spyOn(fs, "unlink").mockImplementation(async (target) => {
+        const cleanupRoot =
+          outcome === "source cleanup failure"
+            ? path.dirname(shadowFile)
+            : outcome === "restore cleanup failure"
+              ? preservedPath
+              : undefined;
+        const sourceCleanup =
+          cleanupRoot !== undefined && path.dirname(String(target)) === cleanupRoot;
+        if (sourceCleanup && removedSourceFiles.length === 1 && !sourceCleanupFailed) {
+          retainedSourceFile = String(target);
+          sourceAtCleanupFailure = await fs.readdir(
+            expectDefined(cleanupRoot, "source cleanup root"),
+          );
+          sourceCleanupFailed = true;
+          // The first source unlink completed; the second is refused before dispatch.
+          throw Object.assign(new Error("source cleanup failed after publication"), {
+            code: "EACCES",
+          });
+        }
+        await originalUnlink(target);
+        if (sourceCleanup) {
+          removedSourceFiles.push(String(target));
+        }
+      });
+      cliMocks.runOpenShellCli.mockImplementation(async ({ args }: { args: string[] }) => {
+        if (args[0] === "sandbox" && args[1] === "download") {
+          const tmpDir = expectDefined(args[4], "OpenShell download destination");
+          await fs.writeFile(path.join(tmpDir, "from-remote.txt"), "remote", "utf8");
+          await fs.mkdir(path.join(tmpDir, ".openclaw", "sandbox-skills", "skills"), {
+            recursive: true,
+          });
+          await fs.writeFile(
+            path.join(tmpDir, ".openclaw", "sandbox-skills", "skills", "generated.txt"),
+            "generated",
+            "utf8",
+          );
+        }
+        return { code: 0, stdout: "", stderr: "" };
       });
 
-      expect(renameSpy).toHaveBeenCalled();
-      await expect(fs.readFile(shadowFile, "utf8")).resolves.toBe("local shadow");
-      await expect(fs.readFile(path.join(workspaceDir, "from-remote.txt"), "utf8")).resolves.toBe(
-        "remote",
-      );
-      await expectPathMissing(
-        path.join(workspaceDir, ".openclaw", "sandbox-skills", "skills", "generated.txt"),
-      );
-    } finally {
-      renameSpy.mockRestore();
-    }
-  });
+      const backend = await createOpenShellBackendFixture({ workspaceDir, mode: "mirror" });
+
+      try {
+        let finalizeError: unknown;
+        try {
+          await backend.finalizeExec?.({
+            status: "completed",
+            exitCode: 0,
+            timedOut: false,
+            token: undefined,
+          });
+        } catch (error) {
+          finalizeError = error;
+        }
+
+        expect(renameSpy).toHaveBeenCalled();
+        expect(preservedPath).toBeDefined();
+        if (outcome === "success") {
+          expect(finalizeError).toBeUndefined();
+          await expect(fs.readFile(shadowFile, "utf8")).resolves.toBe("local shadow");
+          await expect(
+            fs.readFile(path.join(workspaceDir, "from-remote.txt"), "utf8"),
+          ).resolves.toBe("remote");
+        } else {
+          expect(finalizeError).toMatchObject({
+            cause: { code: outcome === "retained source replacement" ? "ESTALE" : "EACCES" },
+          });
+          const backup = expectDefined(preservedPath, "completed shadow publication");
+          const completeCopy =
+            outcome === "restore cleanup failure" ? path.dirname(shadowFile) : backup;
+          for (const [name, contents] of sourceContents) {
+            await expect(fs.readFile(path.join(completeCopy, name), "utf8")).resolves.toBe(
+              contents,
+            );
+          }
+          if (outcome === "restore cleanup failure") {
+            await expect(
+              fs.readFile(path.join(workspaceDir, "from-remote.txt"), "utf8"),
+            ).resolves.toBe("remote");
+          } else {
+            await expectPathMissing(path.join(workspaceDir, "from-remote.txt"));
+          }
+          if (outcome === "source cleanup failure" || outcome === "restore cleanup failure") {
+            expect(sourceCleanupFailed).toBe(true);
+            expect(removedSourceFiles).toHaveLength(1);
+            await expectPathMissing(expectDefined(removedSourceFiles[0], "removed source file"));
+            const retained = expectDefined(retainedSourceFile, "refused source unlink");
+            expect(sourceAtCleanupFailure).toEqual([path.basename(retained)]);
+            await expect(fs.readFile(retained, "utf8")).resolves.toBe(
+              sourceContents.get(path.basename(retained)),
+            );
+          } else {
+            await expect(fs.readFile(shadowFile, "utf8")).resolves.toBe("concurrent replacement");
+          }
+          // The caller must be able to locate its retained original after a partial move.
+          expect(
+            String(finalizeError),
+            JSON.stringify({
+              outcome,
+              sourceFiles: await fs.readdir(path.dirname(shadowFile)),
+              backupFiles: await fs.readdir(backup),
+              sourceAtCleanupFailure,
+            }),
+          ).toContain(backup);
+        }
+        await expectPathMissing(
+          path.join(workspaceDir, ".openclaw", "sandbox-skills", "skills", "generated.txt"),
+        );
+      } finally {
+        renameSpy.mockRestore();
+        unlinkSpy.mockRestore();
+        if (preservedPath) {
+          await fs.rm(path.dirname(preservedPath), { recursive: true, force: true });
+        }
+      }
+    },
+  );
 
   it("drops non-directory materialized sandbox skills from mirror downloads", async () => {
     await using workspace = await createOpenShellTestWorkspace("workspace");
@@ -848,35 +954,181 @@ describe("openshell backend manager", () => {
     await expectPathMissing(path.join(workspaceDir, ".openclaw", "sandbox-skills"));
   });
 
-  it("restores a local sandbox skills shadow when mirror download has a file parent", async () => {
-    await using workspace = await createOpenShellTestWorkspace("workspace");
-    const workspaceDir = workspace.dir;
-    const shadowFile = path.join(workspaceDir, ".openclaw", "sandbox-skills", "user-note.txt");
-    await fs.mkdir(path.dirname(shadowFile), { recursive: true });
-    await fs.writeFile(shadowFile, "local shadow", "utf8");
-    cliMocks.runOpenShellCli.mockImplementation(async ({ args }: { args: string[] }) => {
-      if (args[0] === "sandbox" && args[1] === "download") {
-        const tmpDir = expectDefined(args[4], "OpenShell download destination");
-        await fs.writeFile(path.join(tmpDir, "from-remote.txt"), "remote", "utf8");
-        await fs.writeFile(path.join(tmpDir, ".openclaw"), "poison", "utf8");
+  it.each(["original", "replaced"] as const)(
+    "restores only the %s backup when mirror download has a file parent",
+    async (backupState) => {
+      await using workspace = await createOpenShellTestWorkspace("workspace");
+      const workspaceDir = workspace.dir;
+      const shadowFile = path.join(workspaceDir, ".openclaw", "sandbox-skills", "user-note.txt");
+      const parentPath = path.join(workspaceDir, ".openclaw");
+      await fs.mkdir(path.dirname(shadowFile), { recursive: true });
+      await fs.writeFile(shadowFile, "local shadow", "utf8");
+      cliMocks.runOpenShellCli.mockImplementation(async ({ args }: { args: string[] }) => {
+        if (args[0] === "sandbox" && args[1] === "download") {
+          const tmpDir = expectDefined(args[4], "OpenShell download destination");
+          await fs.writeFile(path.join(tmpDir, "from-remote.txt"), "remote", "utf8");
+          await fs.writeFile(path.join(tmpDir, ".openclaw"), "poison", "utf8");
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      });
+      let preservedPath: string | undefined;
+      let replaced = false;
+      const rename = fs.rename;
+      const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
+        await rename(from, to);
+        if (path.basename(String(to)) === "shadow") {
+          preservedPath = String(to);
+        }
+      });
+      const lstat = fs.lstat;
+      let parentConflictCreated = false;
+      const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+        let stat;
+        try {
+          stat = await lstat(...args);
+        } catch (error) {
+          if (
+            !preservedPath ||
+            parentConflictCreated ||
+            String(args[0]) !== parentPath ||
+            !(error instanceof Error) ||
+            !("code" in error) ||
+            error.code !== "ENOENT"
+          ) {
+            throw error;
+          }
+          // Mirror removed the empty ancestor; exercise restoration's file-parent contract.
+          await fs.writeFile(parentPath, "poison", "utf8");
+          parentConflictCreated = true;
+          stat = await lstat(...args);
+        }
+        if (
+          backupState === "replaced" &&
+          !replaced &&
+          preservedPath &&
+          String(args[0]) === parentPath &&
+          stat.isFile()
+        ) {
+          // Change backup ownership during the last awaited parent check before restoration.
+          await rename(preservedPath, `${preservedPath}-original`);
+          await fs.mkdir(preservedPath);
+          await fs.writeFile(path.join(preservedPath, "replacement.txt"), "replacement backup");
+          replaced = true;
+        }
+        return stat;
+      });
+      const backend = await createOpenShellBackendFixture({ workspaceDir, mode: "mirror" });
+      try {
+        const finalization = backend.finalizeExec?.({
+          status: "completed",
+          exitCode: 0,
+          timedOut: false,
+          token: undefined,
+        });
+        if (backupState === "replaced") {
+          await expect(finalization).rejects.toThrow("unverified workspace shadow");
+          expect(replaced).toBe(true);
+          const backup = expectDefined(preservedPath, "published original shadow");
+          await expect(fs.readFile(parentPath, "utf8")).resolves.toBe("poison");
+          await expect(fs.readFile(path.join(backup, "replacement.txt"), "utf8")).resolves.toBe(
+            "replacement backup",
+          );
+          await expect(
+            fs.readFile(path.join(`${backup}-original`, "user-note.txt"), "utf8"),
+          ).resolves.toBe("local shadow");
+        } else {
+          await finalization;
+          await expect(fs.readFile(shadowFile, "utf8")).resolves.toBe("local shadow");
+          expect((await fs.stat(parentPath)).isDirectory()).toBe(true);
+        }
+        expect(parentConflictCreated).toBe(true);
+        await expect(fs.readFile(path.join(workspaceDir, "from-remote.txt"), "utf8")).resolves.toBe(
+          "remote",
+        );
+      } finally {
+        renameSpy.mockRestore();
+        lstatSpy.mockRestore();
+        if (preservedPath) {
+          await fs.rm(path.dirname(preservedPath), { recursive: true, force: true });
+        }
       }
-      return { code: 0, stdout: "", stderr: "" };
+    },
+  );
+  it("reports completed restoration cleanup accurately and restores earlier shadows", async () => {
+    await using workspace = await createOpenShellTestWorkspace("workspace");
+    await using agentWorkspace = await createOpenShellTestWorkspace("agent-workspace");
+    const skillsDir = path.join(workspace.dir, ".openclaw", "sandbox-skills");
+    const agentShadowDir = path.join(workspace.dir, "nested", "agent");
+    for (const directory of [skillsDir, agentShadowDir]) {
+      await fs.mkdir(directory, { recursive: true });
+      await fs.writeFile(path.join(directory, "note.txt"), path.basename(directory), "utf8");
+    }
+    cliMocks.runOpenShellCli.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    const preservationRoots = new Set<string>();
+    let failedCleanupRoot: string | undefined;
+    let cleanupFailed = false;
+    const cleanupError = Object.assign(new Error("preservation directory cleanup denied"), {
+      code: "EACCES",
     });
-
-    const backend = await createOpenShellBackendFixture({ workspaceDir, mode: "mirror" });
-
-    await backend.finalizeExec?.({
-      status: "completed",
-      exitCode: 0,
-      timedOut: false,
-      token: undefined,
+    const rename = fs.rename;
+    const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
+      await rename(from, to);
+      if (path.basename(String(to)) === "shadow") {
+        const preserveRoot = path.dirname(String(to));
+        preservationRoots.add(preserveRoot);
+        if (String(from) === skillsDir) {
+          failedCleanupRoot = preserveRoot;
+        }
+      }
     });
-
-    await expect(fs.readFile(path.join(workspaceDir, "from-remote.txt"), "utf8")).resolves.toBe(
-      "remote",
-    );
-    await expect(fs.readFile(shadowFile, "utf8")).resolves.toBe("local shadow");
-    expect((await fs.stat(path.join(workspaceDir, ".openclaw"))).isDirectory()).toBe(true);
+    const rmdir = fs.rmdir;
+    const rmdirSpy = vi.spyOn(fs, "rmdir").mockImplementation(async (...args) => {
+      if (String(args[0]) === failedCleanupRoot) {
+        const leftover = expectDefined(failedCleanupRoot, "completed restoration cleanup root");
+        await expect(fs.readdir(leftover)).resolves.toEqual([]);
+        await expectPathMissing(path.join(leftover, "shadow"));
+        await expect(fs.readFile(path.join(skillsDir, "note.txt"), "utf8")).resolves.toBe(
+          "sandbox-skills",
+        );
+        cleanupFailed = true;
+        throw cleanupError;
+      }
+      return await rmdir(...args);
+    });
+    const backend = await createOpenShellBackendFixture({
+      workspaceDir: workspace.dir,
+      agentWorkspaceDir: agentWorkspace.dir,
+      remoteAgentWorkspaceDir: "/sandbox/nested/agent",
+      mode: "mirror",
+    });
+    try {
+      const result = await backend
+        .finalizeExec?.({
+          status: "completed",
+          exitCode: 0,
+          timedOut: false,
+          token: undefined,
+        })
+        .catch((error: unknown) => error);
+      expect(cleanupFailed).toBe(true);
+      expect(preservationRoots.size).toBe(2);
+      expect(result).toMatchObject({ cause: cleanupError });
+      for (const directory of [skillsDir, agentShadowDir]) {
+        await expect(fs.readFile(path.join(directory, "note.txt"), "utf8")).resolves.toBe(
+          path.basename(directory),
+        );
+      }
+      const leftover = expectDefined(failedCleanupRoot, "retained preservation directory");
+      expect(String(result)).toContain(leftover);
+      expect(String(result)).not.toContain(path.join(leftover, "shadow"));
+      expect(String(result)).toContain("was restored");
+    } finally {
+      renameSpy.mockRestore();
+      rmdirSpy.mockRestore();
+      for (const directory of preservationRoots) {
+        await fs.rm(directory, { recursive: true, force: true });
+      }
+    }
   });
 });
 
@@ -954,15 +1206,23 @@ async function createOpenShellBackendFixture(params: {
   workspaceDir: string;
   mode: "mirror" | "remote";
   skillsWorkspaceDir?: string;
+  agentWorkspaceDir?: string;
+  remoteAgentWorkspaceDir?: string;
 }): Promise<OpenShellSandboxBackend> {
   const factory = createOpenShellSandboxBackendFactory({
-    pluginConfig: resolveOpenShellPluginConfig({ command: "openshell", mode: params.mode }),
+    pluginConfig: resolveOpenShellPluginConfig({
+      command: "openshell",
+      mode: params.mode,
+      ...(params.remoteAgentWorkspaceDir
+        ? { remoteAgentWorkspaceDir: params.remoteAgentWorkspaceDir }
+        : {}),
+    }),
   });
   return (await factory({
     sessionKey: "agent:main:turn",
     scopeKey: "agent:main",
     workspaceDir: params.workspaceDir,
-    agentWorkspaceDir: params.workspaceDir,
+    agentWorkspaceDir: params.agentWorkspaceDir ?? params.workspaceDir,
     ...(params.skillsWorkspaceDir ? { skillsWorkspaceDir: params.skillsWorkspaceDir } : {}),
     cfg: createOpenShellBackendSandboxConfig(),
   })) as OpenShellSandboxBackend;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1743,6 +1743,9 @@ importers:
 
   extensions/openshell:
     dependencies:
+      '@openclaw/fs-safe':
+        specifier: 0.8.3
+        version: 0.8.3
       p-limit:
         specifier: 7.3.1
         version: 7.3.1

--- a/src/infra/fs-safe-import-boundary.test.ts
+++ b/src/infra/fs-safe-import-boundary.test.ts
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 import { expectNoReaddirSyncDuring } from "../test-utils/fs-scan-assertions.js";
 import { listGitTrackedFiles, toRepoRelativePath } from "../test-utils/repo-files.js";
@@ -69,7 +70,122 @@ function walkSourceFiles(dir: string): string[] {
   return files;
 }
 
+function sourceWithoutOpenShellMoveImports(filePath: string, source: string): string {
+  if (filePath !== "extensions/openshell/src/backend.ts") {
+    return source;
+  }
+  const parsed = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest);
+  let checkedSource = source;
+  for (const statement of parsed.statements.toReversed()) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      statement.moduleSpecifier.text !== "@openclaw/fs-safe/atomic"
+    ) {
+      continue;
+    }
+    const clause = statement.importClause;
+    const bindings = clause?.namedBindings;
+    if (
+      !clause ||
+      clause.name ||
+      !bindings ||
+      !ts.isNamedImports(bindings) ||
+      bindings.elements.length === 0 ||
+      !bindings.elements.every((element) => {
+        const name = (element.propertyName ?? element.name).text;
+        return (
+          name === "movePathWithCopyFallback" ||
+          (name === "MovePathPublicationReceipt" && (clause.isTypeOnly || element.isTypeOnly))
+        );
+      })
+    ) {
+      continue;
+    }
+    // This plugin owns the move dependency to preserve its supported host floor.
+    const specifier = statement.moduleSpecifier;
+    checkedSource =
+      checkedSource.slice(0, specifier.getStart(parsed)) + checkedSource.slice(specifier.end);
+  }
+  return checkedSource;
+}
+
+function hasDisallowedFsSafeImport(filePath: string, source: string): boolean {
+  if (ALLOWED_PREFIXES.some((prefix) => filePath.startsWith(prefix))) {
+    return false;
+  }
+  const checked = sourceWithoutOpenShellMoveImports(filePath, source);
+  return checked.includes('"@openclaw/fs-safe') || checked.includes("'@openclaw/fs-safe");
+}
+
 describe("fs-safe import boundary", () => {
+  it.each([
+    [
+      "move and receipt",
+      'import { movePathWithCopyFallback, type MovePathPublicationReceipt } from "@openclaw/fs-safe/atomic";',
+      false,
+    ],
+    [
+      "move alias",
+      'import { movePathWithCopyFallback as move } from "@openclaw/fs-safe/atomic";',
+      false,
+    ],
+    [
+      "receipt alias",
+      'import type { MovePathPublicationReceipt as Receipt } from "@openclaw/fs-safe/atomic";',
+      false,
+    ],
+    [
+      "receipt value",
+      'import { MovePathPublicationReceipt } from "@openclaw/fs-safe/atomic";',
+      true,
+    ],
+    ["other atomic helper", 'import { replaceFileAtomic } from "@openclaw/fs-safe/atomic";', true],
+    [
+      "misleading alias",
+      'import { replaceFileAtomic as movePathWithCopyFallback } from "@openclaw/fs-safe/atomic";',
+      true,
+    ],
+    [
+      "mixed imports",
+      'import { movePathWithCopyFallback, replaceFileAtomic } from "@openclaw/fs-safe/atomic";',
+      true,
+    ],
+    ["namespace", 'import * as atomic from "@openclaw/fs-safe/atomic";', true],
+    ["default", 'import atomic from "@openclaw/fs-safe/atomic";', true],
+    ["side effect", 'import "@openclaw/fs-safe/atomic";', true],
+    ["empty import", 'import {} from "@openclaw/fs-safe/atomic";', true],
+    ["re-export", 'export { movePathWithCopyFallback } from "@openclaw/fs-safe/atomic";', true],
+    ["quoted dynamic import", 'const atomic = await import("@openclaw/fs-safe/atomic");', true],
+    ["require", 'const atomic = require("@openclaw/fs-safe/atomic");', true],
+    ["other subpath", 'import { root } from "@openclaw/fs-safe/root";', true],
+  ] as const)("limits the OpenShell exception: %s", (_label, source, expected) => {
+    expect(hasDisallowedFsSafeImport("extensions/openshell/src/backend.ts", source)).toBe(expected);
+  });
+
+  it.each([
+    ["extensions/openshell/src/elsewhere.ts", true],
+    ["extensions/example/src/backend.ts", true],
+    ["src/infra/replace-file.ts", false],
+  ] as const)("preserves the file boundary for %s", (filePath, expected) => {
+    expect(
+      hasDisallowedFsSafeImport(
+        filePath,
+        'import { movePathWithCopyFallback } from "@openclaw/fs-safe/atomic";',
+      ),
+    ).toBe(expected);
+  });
+
+  it("still rejects another direct import beside the allowed move", () => {
+    expect(
+      hasDisallowedFsSafeImport(
+        "extensions/openshell/src/backend.ts",
+        'import { movePathWithCopyFallback } from "@openclaw/fs-safe/atomic";\n' +
+          'import { root } from "@openclaw/fs-safe/root";',
+      ),
+    ).toBe(true);
+  });
+
   it("lists source files without scanning boundary roots in-process", () => {
     expectNoReaddirSyncDuring(() => {
       const files = listSourceFiles();
@@ -82,13 +198,12 @@ describe("fs-safe import boundary", () => {
   it("keeps direct fs-safe imports behind OpenClaw policy wrappers", () => {
     const violations = listSourceFiles()
       .map((filePath) => toRepoRelativePath(REPO_ROOT, filePath))
-      .filter((filePath) => {
-        if (ALLOWED_PREFIXES.some((prefix) => filePath.startsWith(prefix))) {
-          return false;
-        }
-        const source = fs.readFileSync(path.join(REPO_ROOT, filePath), "utf8");
-        return source.includes('"@openclaw/fs-safe') || source.includes("'@openclaw/fs-safe");
-      });
+      .filter((filePath) =>
+        hasDisallowedFsSafeImport(
+          filePath,
+          fs.readFileSync(path.join(REPO_ROOT, filePath), "utf8"),
+        ),
+      );
 
     expect(violations).toStrictEqual([]);
   });


### PR DESCRIPTION
Closes #140703

## What Problem This Solves

Fixes an issue where OpenShell mirror synchronization could leave a complete local-shadow backup on disk but omit its recovery location when source cleanup failed after publication. A partial source or concurrent replacement could remain beside that backup, making recovery unclear.

## Why This Change Was Made

Register each shadow's exact identity as soon as fs-safe publishes its backup. Treat incomplete source cleanup separately from a completed move: retain and report both paths for incomplete moves, and restore completed moves in reverse order with verified backup identity. Continue restoring earlier shadows after an independent failure, preserving all failure causes.

When restoration succeeds and only removal of the empty preservation directory fails, report the restored workspace and leftover directory accurately. The plugin owns exact `@openclaw/fs-safe@0.8.3`, so supported older hosts cannot silently ignore its publication callback. Existing SDK seams and the minimum host version remain unchanged. The root dependency adoption already landed in #138870.

## User Impact

Mirror failures identify the recovery copies and remaining workspace entries. Concurrent replacements and unverified backups are preserved. Operators can distinguish incomplete restoration from successful restoration followed by directory-cleanup failure. This adds necessary recovery logic rather than claiming a net production-code reduction.

## Evidence

The original source failed two real-filesystem cases while two controls passed: partial source cleanup after a completed publication, and a source replacement rejected with ESTALE. Both retained a complete backup but omitted its path. A separate regression reproduced the misleading missing-backup diagnostic after successful restoration and failed empty-directory cleanup.

The final OpenShell sibling group passed 141 cases; seven focused failure/control cases also passed. The generic extension runtime-dependency contract passed 451 cases. The final plugin runtime build, manifest-overlay npm pack, transient npm lock validation and normal managed plugin installation passed in isolated state. Importing the actual installed runtime verified the final tarball bytes, its unchanged host minimum and its own fs-safe 0.8.3 dependency; a real staged move returned the expected publication receipt.

The tests use synthetic workspaces, actual local filesystem operations and a mocked OpenShell CLI. No live OpenShell environment or operator Gateway was used; no native Windows OpenShell run is claimed. The final source/test/docs gate passed without skip flags; unchanged manifest and dependency checks passed in the preceding validation runs. Formatting and targeted type-aware lint passed. Review triage left no accepted/actionable findings: one automated suggestion was rejected against the caller flow and its existing passing reverse-cleanup regression. After alignment onto current main, all five reviewed owner files remain byte-identical; the lockfile adds only this plugin's existing 0.8.3 dependency entry.

Published dependency contract: fs-safe v0.8.3 defines the [frozen bigint receipt and synchronous callbacks](https://github.com/openclaw/fs-safe/blob/v0.8.3/src/move-path.ts#L21), captures the callbacks and [reports publication before source cleanup](https://github.com/openclaw/fs-safe/blob/v0.8.3/src/move-path.ts#L299), and [guards copied-source cleanup](https://github.com/openclaw/fs-safe/blob/v0.8.3/src/move-path-cleanup.ts#L192). The move retains `Promise<void>` and EXDEV/Windows EPERM fallback. The [verified 0.8.3 release](https://github.com/openclaw/fs-safe/releases/tag/v0.8.3) includes the cross-platform proof.


The maintainer-approved import exception is now implemented: only the named atomic move and type-only publication receipt are allowed in OpenShell's backend. Existing prefix exemptions and detection remain. The boundary suite passes 21 cases covering allowed aliases, prohibited broader imports, other owners and additional direct imports; fresh P2 review found no actionable issues. All selected changed checks passed except a parameter-reassignment lint issue, corrected with an equivalent local string variable; final type-aware lint and the 21-case rerun pass. No production code changed in this follow-up.
