### PR TITLE
docs(telemetry): clarify inventory counts and privacy scope

### DIFF
--- a/docs/gateway/config-observability.md
+++ b/docs/gateway/config-observability.md
@@ -160,9 +160,9 @@ writer is best-effort, not a lossless compliance archive.
 }
 ```
 
-- `enabled`: include anonymous channel names, provider families, plugin count, and recent session count in the existing daily update-check request (default: `false`). Interactive setup offers an explicit opt-in with **No thanks** selected by default; non-interactive setup never enables it. `DO_NOT_TRACK=1` or `DO_NOT_TRACK=true` always disables feature statistics without disabling the update check.
+- `enabled`: include public configured channel and provider names, plugin inventory names and count, and a retained session-creation count in the existing daily update-check request (default: `false`). These fields do not measure per-plugin usage or active sessions. Interactive setup can offer an explicit opt-in with **No thanks** selected by default; non-interactive setup does not enable it automatically but can retain an explicitly enabled preference. `DO_NOT_TRACK=1` or `DO_NOT_TRACK=true` always disables feature statistics without disabling the update check.
 - `consentedAt`: ISO timestamp recording when the operator accepted or declined feature statistics. Prevents interactive setup from asking again.
-- `openclaw telemetry show` displays the exact current request; `openclaw telemetry on` and `openclaw telemetry off` update the preference and consent timestamp.
+- `openclaw telemetry show` previews the request using the CLI process's current context, which can differ from the running Gateway; `openclaw telemetry on` and `openclaw telemetry off` update the preference and consent timestamp.
 - `OPENCLAW_TELEMETRY_ENDPOINT`: optional full endpoint URL for testing or a self-hosted service. Defaults to `https://telemetry.openclaw.ai/api/latest-version`.
 
 See [Usage telemetry and update checks](/gateway/telemetry) for the complete payload, privacy guarantees, and all opt-out controls.

--- a/docs/gateway/telemetry.md
+++ b/docs/gateway/telemetry.md
@@ -8,23 +8,21 @@ read_when:
   - Disabling all automatic update-check requests
 ---
 
-**The only thing OpenClaw sends on its own is a daily update check.** It asks
-whether a newer version exists, and the request carries nothing but the version,
-operating system, and CPU architecture already visible to any package registry.
-Everything else on this page is opt-in.
+**Automatic update checks send a daily request by default.** It asks whether a
+newer version exists and includes the OpenClaw version, operating system, Node.js
+version, CPU architecture, and request surface. Feature statistics are opt-in.
+This page describes update-check telemetry, not requests made by configured
+providers, channels, or other services.
 
-Anonymous feature statistics — which channels and providers you have configured
-— are **off by default** and never turn themselves on. When you do enable them,
-they ride along with that same daily update check instead of adding a second
-request.
+Anonymous feature statistics describe configured channels and providers, plugin
+inventory, and a retained session-creation count. They are **off by default**.
+When you enable them, they ride along with that same daily update check instead
+of adding a second request.
 
-If you turn them on: thank you. Feature statistics are the only way we learn
-which channels, providers, and plugins people actually use, and they decide what
-gets improved, what gets fixed first, and what can safely be retired. A handful
-of Discord anecdotes is otherwise the entire evidence base. We publish what we
-learn back to everyone at
-[telemetry.openclaw.ai](https://telemetry.openclaw.ai), so the data you
-contribute stays visible to you.
+These reports help inform maintenance priorities. They do not measure individual
+plugin invocations, messages, model requests, or active users. Public aggregates
+are available at
+[telemetry.openclaw.ai](https://telemetry.openclaw.ai).
 
 Declining is a completely normal choice and changes nothing about how OpenClaw
 works for you.
@@ -42,8 +40,9 @@ document.
 
 The output shows whether feature statistics are enabled, why they are enabled
 or disabled, the request endpoint, and the last successful check. When feature
-statistics are enabled, it prints the exact JSON payload the next request would
-send. When only feature statistics are disabled, it shows the update-only request
+statistics are enabled, it prints a JSON payload preview built in the CLI
+process. It does not retrieve a payload from the running Gateway. When only
+feature statistics are disabled, it shows the update-only request
 and its `User-Agent` header instead. When automation or update-check policy
 disables all requests, it shows `Request: none` with the reason (`request: null`
 in JSON).
@@ -78,13 +77,16 @@ replacement endpoint URL. The public server source is available at
 
 ## Optional anonymous feature statistics
 
-Feature statistics are **off by default**. Interactive setup offers a one-time
-opt-in with **No thanks** selected by default. Non-interactive and scripted
-installations never opt in automatically. OpenClaw records when you accepted or
-declined so it does not ask again.
+Feature statistics are **off by default**. Interactive setup can offer a one-time
+opt-in with **No thanks** selected by default; guided Quick Start skips that
+prompt. OpenClaw records a prompt response so setup does not ask again.
+Non-interactive and scripted installations do not opt in automatically, but
+operators can explicitly enable statistics with `openclaw telemetry on` or
+`telemetry.enabled: true`. The enabled setting, not the presence of a prompt
+response, controls whether feature statistics are included.
 
 When you explicitly enable feature statistics, the same daily request becomes a
-`POST` with this complete JSON payload:
+`POST` with a JSON payload in this shape (values are illustrative):
 
 ```json
 {
@@ -103,42 +105,56 @@ When you explicitly enable feature statistics, the same daily request becomes a
 }
 ```
 
-| Field                       | Meaning                                                                   |
-| --------------------------- | ------------------------------------------------------------------------- |
-| `schema`                    | Payload format version, currently `1`.                                    |
-| `version`                   | Installed OpenClaw version.                                               |
-| `platform`                  | Operating system and CPU architecture.                                    |
-| `node`                      | Running Node.js version.                                                  |
-| `surface`                   | Request origin: `gateway` or `cli`.                                       |
-| `features.channels`         | Publicly known enabled channel plugin names, sorted alphabetically.       |
-| `features.providerFamilies` | Publicly known configured provider names; never model names.              |
-| `features.plugins`          | Publicly known enabled plugin names, sorted alphabetically.               |
-| `features.pluginsEnabled`   | Total enabled plugins, including privately developed plugins never named. |
-| `features.sessionsLast24h`  | Number of sessions observed during the preceding 24 hours.                |
+| Field                       | Meaning                                                                                           |
+| --------------------------- | ------------------------------------------------------------------------------------------------- |
+| `schema`                    | Payload format version, currently `1`.                                                            |
+| `version`                   | Installed OpenClaw version.                                                                       |
+| `platform`                  | Operating system and CPU architecture.                                                            |
+| `node`                      | Running Node.js version.                                                                          |
+| `surface`                   | Request surface: `gateway` or `cli`; the CLI preview uses `gateway`.                              |
+| `features.channels`         | Configured, not explicitly disabled channel IDs backed by public plugins in the inventory.        |
+| `features.providerFamilies` | Public provider IDs from configuration, auth profiles, and configured model references.           |
+| `features.plugins`          | Public plugin IDs from the enabled inventory, sorted alphabetically.                              |
+| `features.pluginsEnabled`   | Total plugins in that inventory, including plugins not named in `features.plugins`.               |
+| `features.sessionsLast24h`  | Retained session-creation events timestamped within the preceding 24 hours, not session activity. |
 
-OpenClaw names only plugins and channels that are bundled with OpenClaw or
-already appear in its official plugin catalog. Privately developed plugins are
-counted but never named because a private plugin name could identify its
-organization. Subtract `features.plugins.length` from `features.pluginsEnabled`
-to find the number of unnamed private plugins.
+With an active plugin registry, the inventory includes enabled, loaded plugins
+whose code was imported, plus loaded bundle-format plugins. Without that
+registry, it falls back to configured manifest enablement. Neither path records
+whether a plugin was invoked or a configured channel or provider handled work.
 
-The sender and `openclaw telemetry show` use the same payload builder, so the
-JSON displayed by the CLI is the same payload the sender would use at that
-moment.
+Named plugins must be bundled, trusted official installs, or match the official
+plugin catalog. Private plugin identities are not named. Names are also filtered
+and deduplicated, and the service validates them independently. The difference
+between `features.pluginsEnabled` and the number of reported names is therefore
+not a reliable count of private plugins.
 
-Reports carry no identifier of any kind, which means they cannot be linked to
-each other. We can see that some install runs Telegram with Anthropic models; we
-cannot see that it is the same install as yesterday, and we cannot build a
-history of any single machine. That costs us retention analysis, and we consider
-it worth paying.
+The session count depends on locally recorded creation events that remain in
+the bounded event store. Missing or unreadable state produces zero. It is not
+a count of active sessions, messages, or all sessions that existed that day.
+
+The sender and `openclaw telemetry show` use the same payload builder, but their
+plugin registry, configuration, and collection time can differ. The CLI preview
+is not a guarantee of the exact next Gateway payload.
+
+Reports have no persistent client identifier. Repeated reports are not unique
+installations or users, and the reported fields do not provide a per-install
+history or retention measure.
 
 ### What is never collected
 
-Neither request tier includes message content, prompts, model names, API keys,
-credentials, secret references, file paths, hostnames, account identifiers,
-user identifiers, or installation and machine identifiers. OpenClaw does not
-create a random UUID or other persistent request identifier, so daily requests
-cannot be linked through an OpenClaw-issued identifier.
+Neither the update-check `User-Agent` nor the feature-statistics body includes
+message content, prompts, model names, API keys, credentials, secret references,
+file paths, hostnames, account identifiers, user identifiers, or installation
+and machine identifiers. OpenClaw does not create a random UUID or other
+persistent client identifier for these requests.
+
+The service's Analytics Engine rows exclude those identifying fields and client
+IP addresses. Cloudflare still handles TLS and network requests and sees the
+client IP. The Worker reads that IP transiently for rate limiting without writing
+it to Analytics Engine. The service's deployment configuration disables Worker
+observability, logs, and invocation logs; those settings do not describe or
+control Cloudflare's separate infrastructure-level processing.
 
 Anonymous feature statistics are separate from optional, operator-configured
 [OpenTelemetry export](/gateway/opentelemetry).


### PR DESCRIPTION
Related: https://github.com/openclaw/telemetry/pull/7

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where operators reading the telemetry docs could mistake configured or loaded features for observed usage, retained session-creation events for active sessions, and a CLI-process preview for the exact running Gateway payload. The page also overstated request unlinkability and omitted the distinction between Analytics Engine storage and network-level IP handling.

## Why This Change Was Made

Align the telemetry topic and its directly linked configuration reference with current client source and the merged service privacy correction. Explain explicit CLI/config enablement as well as the optional setup prompt, remove the unsupported private-plugin subtraction, and scope privacy statements to the fields and storage they describe.

This changes documentation only. It does not change runtime behavior, consent defaults, payloads, configuration, schemas, service aggregation, or versions. It makes no historical logging or infrastructure-wide no-IP guarantee.

## User Impact

Operators can make an informed telemetry choice and interpret feature reports without treating them as invocation counts, active sessions, unique installations, or a per-install history. The documented commands and opt-out controls are unchanged.

## Evidence

- Source-audited inventory and payload semantics: [payload builder](https://github.com/openclaw/openclaw/blob/f1e333d14ba2112ce0bc2b9e9eb40dbfc8165674/src/infra/telemetry.ts#L175) and [runtime inventory](https://github.com/openclaw/openclaw/blob/f1e333d14ba2112ce0bc2b9e9eb40dbfc8165674/src/plugins/plugin-runtime-inventory.ts#L14).
- Source-audited session count and retention: [creation-event query](https://github.com/openclaw/openclaw/blob/f1e333d14ba2112ce0bc2b9e9eb40dbfc8165674/src/infra/telemetry.ts#L106) and [event pruning](https://github.com/openclaw/openclaw/blob/f1e333d14ba2112ce0bc2b9e9eb40dbfc8165674/src/sessions/session-state-events.ts#L697).
- Source-audited [CLI preview and preference writes](https://github.com/openclaw/openclaw/blob/f1e333d14ba2112ce0bc2b9e9eb40dbfc8165674/src/cli/telemetry-cli.ts#L20), [setup prompt](https://github.com/openclaw/openclaw/blob/f1e333d14ba2112ce0bc2b9e9eb40dbfc8165674/src/wizard/setup.shared.ts#L172), and [guided Quick Start behavior](https://github.com/openclaw/openclaw/blob/f1e333d14ba2112ce0bc2b9e9eb40dbfc8165674/src/commands/onboard-guided-consent.ts#L64).
- Privacy wording personally checked against exact source at the merged [service correction](https://github.com/openclaw/telemetry/pull/7), commit `dd09e84023433ab1d01414905d9e55c40b836524`: [`src/index.ts`](https://github.com/openclaw/telemetry/blob/dd09e84023433ab1d01414905d9e55c40b836524/src/index.ts) reads `cf-connecting-ip` only for the rate-limiting binding; [`src/analytics.ts`](https://github.com/openclaw/telemetry/blob/dd09e84023433ab1d01414905d9e55c40b836524/src/analytics.ts) defines the Analytics Engine columns without IP or client identifiers; [`wrangler.jsonc`](https://github.com/openclaw/telemetry/blob/dd09e84023433ab1d01414905d9e55c40b836524/wrangler.jsonc) explicitly sets observability, logs, and invocation logs to false. This resolves the reviewer's reported source-access gap without relying on historical logs or pending statistics changes.
- Passed: targeted `oxfmt --check`, MDX check for both pages, changed-page i18n glossary check, docs-list discovery, and `git diff --check`. No runtime tests are required for this docs-only change.
- Link/anchor audit with the actual ClawHub source mirror checked 8,822 links. No failures involve either changed page. The full audit remains nonzero for 12 pre-existing cross-repository anchors in `clawhub/plugin-validation-fixes.md`; that unrelated page is outside this correction.
- Fresh independent source-backed review: scoped-clean through P2, with no actionable findings.
