### PR TITLE
refactor(format): share compact token unit ladder

### DIFF
--- a/packages/normalization-core/src/format.test.ts
+++ b/packages/normalization-core/src/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { bucketRelativeTimeMs, formatByteSize } from "./format.js";
+import { bucketRelativeTimeMs, formatByteSize, formatCompactTokenCount } from "./format.js";
 
 describe("bucketRelativeTimeMs", () => {
   it.each([
@@ -38,5 +38,33 @@ describe("formatByteSize", () => {
         floorUnits: ["kilo", "mega"],
       }),
     ).toBe("99 MB");
+  });
+});
+
+describe("formatCompactTokenCount", () => {
+  it.each([
+    [999_500, { thousandsPrecision: 0 }, "1.0m"],
+    [999_500, { thousandsPrecision: 1 }, "999.5k"],
+    [999_950, { thousandsPrecision: 1 }, "1.0m"],
+    [999_500, { thousandsPrecision: 0, trimTrailingZero: true }, "1m"],
+  ] as const)("preserves precision-dependent rollover for %s", (tokens, options, expected) => {
+    expect(formatCompactTokenCount(tokens, options)).toBe(expected);
+  });
+
+  it.each([
+    [999_999_999, "1000M"],
+    [1_000_000_000, "1B"],
+  ] as const)("selects the billion unit from the unrounded count %s", (tokens, expected) => {
+    expect(
+      formatCompactTokenCount(tokens, {
+        maxUnit: "billion",
+        millionsSuffix: "M",
+        trimTrailingZero: true,
+      }),
+    ).toBe(expected);
+  });
+
+  it("retains million-only displays for billion-scale counts", () => {
+    expect(formatCompactTokenCount(1_000_000_000)).toBe("1000.0m");
   });
 });

--- a/packages/normalization-core/src/format.ts
+++ b/packages/normalization-core/src/format.ts
@@ -63,3 +63,31 @@ export function formatByteSize(bytes: number, options: ByteSizeFormatOptions): s
   }
   return `${value.toFixed(fractionDigits)}${options.separator}${label}`;
 }
+
+/** Formats token units while callers retain input validation and whole-token rounding. */
+export function formatCompactTokenCount(
+  tokens: number,
+  options: {
+    thousandsPrecision?: 0 | 1;
+    thousandsSuffix?: string;
+    millionsSuffix?: string;
+    trimTrailingZero?: boolean;
+    maxUnit?: "million" | "billion";
+  } = {},
+): string {
+  if (tokens < 1_000) {
+    return String(Math.round(tokens));
+  }
+  const trim = (value: string) => (options.trimTrailingZero ? value.replace(/\.0$/, "") : value);
+  // Billion presentation is based on the count, not rounded millions.
+  if (options.maxUnit === "billion" && tokens >= 1_000_000_000) {
+    return `${trim((tokens / 1_000_000_000).toFixed(1))}B`;
+  }
+  if (tokens < 1_000_000) {
+    const thousands = (tokens / 1_000).toFixed(options.thousandsPrecision ?? 1);
+    if (Number(thousands) < 1_000) {
+      return `${trim(thousands)}${options.thousandsSuffix ?? "k"}`;
+    }
+  }
+  return `${trim((tokens / 1_000_000).toFixed(1))}${options.millionsSuffix ?? "m"}`;
+}

--- a/src/agents/subagents/announce/subagent-announce-output.ts
+++ b/src/agents/subagents/announce/subagent-announce-output.ts
@@ -3,6 +3,7 @@
  *
  * Reads child session output, detects waiting states, and formats completion findings for announcements.
  */
+import { formatCompactTokenCount } from "@openclaw/normalization-core";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
@@ -599,19 +600,7 @@ function formatTokenCount(value?: number) {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     return "0";
   }
-  if (value >= 1_000_000) {
-    return `${(value / 1_000_000).toFixed(1)}m`;
-  }
-  if (value >= 1_000) {
-    const formattedThousands = (value / 1_000).toFixed(1);
-    // Keep the compact stats unit scheme stable when one-decimal rounding
-    // reaches the next unit, e.g. 999_999 -> 1000.0k.
-    if (Number(formattedThousands) >= 1_000) {
-      return `${(value / 1_000_000).toFixed(1)}m`;
-    }
-    return `${formattedThousands}k`;
-  }
-  return String(Math.round(value));
+  return formatCompactTokenCount(value);
 }
 
 export async function buildCompactAnnounceStatsLine(params: {

--- a/src/shared/subagents-format.ts
+++ b/src/shared/subagents-format.ts
@@ -1,4 +1,5 @@
 // Subagent formatting helpers expose compact durations and status text.
+import { formatCompactTokenCount } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 
 /** Formats token counts using compact k/m suffixes for subagent summaries. */
@@ -7,21 +8,10 @@ function formatTokenShort(value?: number) {
     return undefined;
   }
   const n = Math.floor(value);
-  if (n < 1_000) {
-    return `${n}`;
-  }
-  if (n < 10_000) {
-    return `${(n / 1_000).toFixed(1).replace(/\.0$/, "")}k`;
-  }
-  if (n < 1_000_000) {
-    const thousands = Math.round(n / 1_000);
-    // Rounding can reach 1000 (e.g. 999_500 -> 1000); fall through to the
-    // million branch instead of emitting an out-of-scheme "1000k".
-    if (thousands < 1_000) {
-      return `${thousands}k`;
-    }
-  }
-  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}m`;
+  return formatCompactTokenCount(n, {
+    thousandsPrecision: n >= 10_000 ? 0 : 1,
+    trimTrailingZero: true,
+  });
 }
 
 /** Truncates a single-line display string without preserving trailing whitespace. */

--- a/src/utils/token-format.ts
+++ b/src/utils/token-format.ts
@@ -1,19 +1,10 @@
+import { formatCompactTokenCount } from "@openclaw/normalization-core";
+
 /** Formats a token count for compact human-facing status text. */
 export function formatTokenCount(value?: number): string {
   if (value === undefined || !Number.isFinite(value)) {
     return "0";
   }
   const safe = Math.max(0, value);
-  if (safe >= 1_000_000) {
-    return `${(safe / 1_000_000).toFixed(1)}m`;
-  }
-  if (safe >= 1_000) {
-    const precision = safe >= 10_000 ? 0 : 1;
-    const formattedThousands = (safe / 1_000).toFixed(precision);
-    if (Number(formattedThousands) >= 1_000) {
-      return `${(safe / 1_000_000).toFixed(1)}m`;
-    }
-    return `${formattedThousands}k`;
-  }
-  return String(Math.round(safe));
+  return formatCompactTokenCount(safe, { thousandsPrecision: safe >= 10_000 ? 0 : 1 });
 }

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -1,4 +1,8 @@
-import { bucketRelativeTimeMs, type RelativeTimeUnit } from "@openclaw/normalization-core";
+import {
+  bucketRelativeTimeMs,
+  formatCompactTokenCount as formatTokenUnits,
+  type RelativeTimeUnit,
+} from "@openclaw/normalization-core";
 // Control UI module implements format behavior.
 import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
@@ -259,8 +263,7 @@ export function formatCost(cost: number | null | undefined, fallback = "$0.00"):
   return `$${cost.toFixed(2)}`;
 }
 
-// The one token formatter: every surface showing the same count must render the
-// same string, or a session reads "16k" in one pane and "15.6k" in another.
+// Keep token presentation consistent across UI session and usage surfaces.
 export function formatCompactTokenCount(
   tokens: number | null | undefined,
   options: { thousandsSuffix?: string; millionsSuffix?: string; trimTrailingZero?: boolean } = {},
@@ -268,25 +271,12 @@ export function formatCompactTokenCount(
   if (tokens == null || !Number.isFinite(tokens)) {
     return "0";
   }
-  const thousandsSuffix = options.thousandsSuffix ?? "k";
-  const millionsSuffix = options.millionsSuffix ?? "M";
-  const trimTrailingZero = options.trimTrailingZero ?? true;
-  const trim = (value: string) => (trimTrailingZero ? value.replace(/\.0$/, "") : value);
-  // Month-scale provider totals can cross a billion; keep the suffix ladder closed.
-  if (tokens >= 1_000_000_000) {
-    return `${trim((tokens / 1_000_000_000).toFixed(1))}B`;
-  }
-  if (tokens >= 1_000_000) {
-    return `${trim((tokens / 1_000_000).toFixed(1))}${millionsSuffix}`;
-  }
-  if (tokens >= 1_000) {
-    const thousands = (tokens / 1_000).toFixed(1);
-    if (Number(thousands) >= 1_000) {
-      return `${trim((tokens / 1_000_000).toFixed(1))}${millionsSuffix}`;
-    }
-    return `${trim(thousands)}${thousandsSuffix}`;
-  }
-  return String(Math.round(tokens));
+  return formatTokenUnits(tokens, {
+    thousandsSuffix: options.thousandsSuffix,
+    millionsSuffix: options.millionsSuffix ?? "M",
+    trimTrailingZero: options.trimTrailingZero ?? true,
+    maxUnit: "billion",
+  });
 }
 
 export function formatContextTokenCapacity(tokens: number): string {


### PR DESCRIPTION
## What Problem This Solves

Status utilities, subagent summaries, announcements, and the Dashboard independently repeat compact token-unit rollover. Their precision and display policies intentionally differ, so maintaining four ladders risks accidental drift.

## Why This Change Was Made

The existing normalization-core format owner shares the k/m/B ladder. Adapters retain their validation, flooring/clamping, precision, suffixes and trailing-zero choices. For example, 999,500 remains `1.0m` in utility status, `1m` in subagent summaries, and `999.5k` in announcements and the Dashboard. The Dashboard selects billions from the unrounded count, preserving `1000M` immediately below one billion.

## User Impact

None intended. Existing displayed strings and exported caller signatures remain unchanged. No configuration, dependency, protocol, schema, or existing public-export removal.

## Evidence

- `node scripts/run-vitest.mjs packages/normalization-core/src/format src/utils/token-format src/shared/subagents-format src/agents/subagents/announce/subagent-announce-output ui/src/lib/format`: 164 tests passed across five files and four shards.
- Standalone comparison of original and candidate function declarations: 96,660 boundary and varied-input cases passed, including negative/non-finite input, fractional counts, precision-dependent rollover, custom suffixes, and billion selection.
- Autoreview: P0-P2 scoped-clean, zero findings.
- `node scripts/check-changed.mjs --base 05182b6ad8a5e115fb3424873e7b21a073701c85`: passed after refreshing the locked install. The first attempt reported seven errors in unchanged installer code because main requires `@openclaw/fs-safe` 0.8.3 while the worktree had 0.8.1. `pnpm install --frozen-lockfile` installed the declared 0.8.3; no source, dependency declaration or lockfile change.
- Full `pnpm build`: passed in 21m 42.5s, including packages, 90 plugins, SDK declarations and UI.
- `pnpm ui:check-performance`: passed; startup JS 346,394/350,953 B gzip and 8/18 requests; CSS 43,989/51,200 B. No baseline edits.
- Production +50/-62 (net -12); tests +29/-1 (net +28). The owner tests protect precision-dependent rollover and billion selection; existing adapter tests remain.

Original-head CI [34082319938](https://github.com/openclaw/openclaw/actions/runs/34082319938) passed in full. The required fresh-main rebase onto `40ade7f1e88e0e8cbfcd9a16379791328c734a1b` preserved the patch exactly (`git range-diff`). Current head is `bfaf60b4d9f80ad1066196671de8ddcd4508decd`; its exact-head CI [34083138844](https://github.com/openclaw/openclaw/actions/runs/34083138844) passed. Local build/check/performance proof ran against the original patch-identical head. Native hosted preparation and merge passed. Landed as `abc35e08c1a2efd29f356354b7fa0d8374429889`, verified as an ancestor of current main.
