### PR TITLE
fix(node-host): honor umask in Git transfer mode assertions

### DIFF
--- a/src/node-host/node-worker-transfer-client.git.test.ts
+++ b/src/node-host/node-worker-transfer-client.git.test.ts
@@ -332,10 +332,14 @@ describe("node worker Git transfers", () => {
           changed ? "changed on gateway\n" : "tracked from gateway\n",
         );
         if (process.platform !== "win32") {
+          // Git checkout applies the umask; downloaded replacements are explicitly chmod'ed.
+          const checkoutUmask = process.umask();
           expect((await fs.stat(path.join(workspaceDir, "tracked.txt"))).mode & 0o777).toBe(
-            changed ? 0o755 : 0o644,
+            changed ? 0o755 : 0o666 & ~checkoutUmask,
           );
-          expect((await fs.stat(path.join(workspaceDir, "script.sh"))).mode & 0o777).toBe(0o755);
+          expect((await fs.stat(path.join(workspaceDir, "script.sh"))).mode & 0o777).toBe(
+            0o777 & ~checkoutUmask,
+          );
         }
         await expect(fs.readlink(path.join(workspaceDir, "tracked-link"))).resolves.toBe(
           changed ? "script.sh" : "tracked.txt",


### PR DESCRIPTION
Related: #140696, #140628

## What Problem This Solves

Resolves a problem where native Testbox landing gates fail seven node-worker Git transfer cases under umask `0002`, including PRs that do not change node-host. The tests expected literal `0644`/`0755`, while Git correctly checked out `0664`/`0775`.

## Why This Change Was Made

Worker workspace manifests and file matching use Git executable-bit semantics, as documented in `docs/gateway/cloud-workers.md`. Git-base materialization delegates to `git checkout-index`, whose file creation uses `0666` or `0777` subject to umask. The test now derives those full permission expectations from `process.umask()`. Downloaded replacements still require exact `0755`, matching the client's explicit chmod.

The canonical materialization and matching owners remain unchanged. No production behavior, public API, configuration, or compatibility export changes.

## User Impact

No runtime behavior change. Maintainers can validate unrelated changes on Testbox without these false permission failures. Executable-bit changes, unchanged-base blob reuse, contents, symlinks, and atomic replacement remain covered.

## Evidence

- Clean-main baseline `a7f2413c4b0b899e7b9733fea6070d027bbac1b7`: focused Testbox suite failed **7 cases**, with 5 passed and 1 existing Windows-only test skipped. Errors were `436 != 420` and `509 != 493`.
- Provider `blacksmith-testbox`, lease `tbx_01m1wyd1knvd25jx20byc3zehh`, [Actions run 34079614439](https://github.com/openclaw/openclaw/actions/runs/34079614439).
- Same-lease probes: `umask` returned `0002`; `git config --show-origin --get-all core.sharedRepository` returned no values; `stat -c '%a %n'` showed a fresh regular file `664`, a Git-checked-out regular file `664`, and Git-checked-out executable `775`. Global/system config is disabled for worker Git commands.
- Baseline command: `node scripts/crabbox-wrapper.mjs run --id tbx_01m1wyd1knvd25jx20byc3zehh --timing-json -- node scripts/run-vitest.mjs src/node-host/node-worker-transfer-client.git.test.ts`.
- Local focused suite passed under the normal mask and under `umask 002`: **12 passed, 1 existing Windows-only test skipped** each. The unpatched suite reproduced all seven failures locally under `umask 002`.
- Codex autoreview through P2: no actionable findings.

- Patched Testbox focused suite: **12 passed, 1 existing Windows-only test skipped**, using `node scripts/crabbox-wrapper.mjs run --timing-json -- node scripts/run-vitest.mjs src/node-host/node-worker-transfer-client.git.test.ts`. Provider `blacksmith-testbox`, lease `tbx_01m1x0k1fqnyc6y25ksyrt3qsz`, [Actions run 34081747692](https://github.com/openclaw/openclaw/actions/runs/34081747692).

- `node scripts/check-changed.mjs`: passed. The first run encountered seven unrelated type errors from a stale local `@openclaw/fs-safe 0.8.1` install; `pnpm install --frozen-lockfile` aligned it with the branch's existing `0.8.3` pin, and the retry passed. No Windows execution was performed for this POSIX-only assertion change.

- Native review artifacts validated with `READY FOR /prepare-pr` and zero findings. `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 140771` passed using hosted evidence for published head `9ab6eef9d8a6a398447f46a2976eb9d4ba584d1e`.
- `node scripts/watch-pr-ci.mjs 140771 9ab6eef9d8a6a398447f46a2976eb9d4ba584d1e` returned **GREEN**, `pending=0`, for [CI run 34082418079](https://github.com/openclaw/openclaw/actions/runs/34082418079).
