### PR TITLE
perf(terminal): avoid eager grapheme arrays during wrapping

### DIFF
--- a/packages/terminal-core/src/ansi.ts
+++ b/packages/terminal-core/src/ansi.ts
@@ -147,6 +147,13 @@ export function stripAnsiForStreamChunk(
   });
 }
 
+/** Let sequential renderers consume graphemes without retaining a full-run array. */
+export function* iterateGraphemes(input: string): Generator<string, void> {
+  for (const { segment } of graphemeSegmenter.segment(input)) {
+    yield segment;
+  }
+}
+
 export function splitGraphemes(input: string): string[] {
   if (!input) {
     return [];

--- a/packages/terminal-core/src/note.ts
+++ b/packages/terminal-core/src/note.ts
@@ -2,7 +2,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { note as clackNote } from "@clack/prompts";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { splitGraphemes, visibleWidth } from "./ansi.js";
+import { iterateGraphemes, visibleWidth } from "./ansi.js";
 import { stylePromptTitle } from "./prompt-style.js";
 
 const MIN_NOTE_COLUMNS = 80;
@@ -31,7 +31,7 @@ function splitLongWord(word: string, maxLen: number): string[] {
   const parts: string[] = [];
   let current = "";
   let currentWidth = 0;
-  for (const grapheme of splitGraphemes(word)) {
+  for (const grapheme of iterateGraphemes(word)) {
     const width = visibleWidth(grapheme);
     if (current && currentWidth + width > maxLen) {
       parts.push(current);

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -1,5 +1,5 @@
 import { iterateAnsiSegments } from "./ansi-sequences.js";
-import { splitGraphemes, truncateToVisibleWidth, visibleWidth } from "./ansi.js";
+import { iterateGraphemes, truncateToVisibleWidth, visibleWidth } from "./ansi.js";
 import { createDisplayStringFormatter } from "./display-string.js";
 import { sanitizeTerminalText } from "./safe-text.js";
 
@@ -386,7 +386,7 @@ function wrapLine(text: string, width: number): string[] {
       acceptToken({ kind: "ansi", value, width: 0 });
       continue;
     }
-    for (const grapheme of splitGraphemes(value)) {
+    for (const grapheme of iterateGraphemes(value)) {
       acceptToken({ kind: "char", value: grapheme, width: 0 });
     }
   }


### PR DESCRIPTION
Closes #140772

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Table and note wrapping build and retain complete grapheme arrays even though both consumers only iterate sequentially. Large text runs keep that intermediate alive throughout wrapping.

## Why This Change Was Made

Add a string generator over the existing shared Intl.Segmenter and use it in the two sequential wrappers. The existing splitGraphemes array API remains unchanged, as do ANSI run boundaries, width calculation and final output construction.

## User Impact

In actual renderTable execution paused at the first accepted character of the same 450,000-character cell, a 450,000-element Array with a 5,171,424-byte backing store is absent from the candidate heap. Both resumed renders produce the same 1,200,032 output bytes. Table and note appearance and copy behavior stay identical.

This removes a concrete temporary array. It does not make complete table output streamed or constant-memory, establish a post-return leak fix or imply a general CPU improvement. The 4 KiB plugin-description fixture was approximately 0.12–0.37 ms slower per render in the measured children; large-cell baseline variance prevents a stable speedup claim. Production incidence of huge descriptions is unknown.

## Evidence

- Nine complete output fixtures match across separate baseline/candidate/candidate/baseline children: large and small plugin-shaped cells, colored rows, Unicode/OSC-8/CRLF, fitting ASCII, borderless tables, generic/CJK notes and copy-sensitive URLs.
- External Inspector receipts bind the same first-token execution state in both actual table renders. The retired Array and its backing store are identified through retainers, rather than heap-snapshot file size or post-return totals.
- 172 existing ANSI/table/note tests, the complete selected changed-file gate and fresh isolated P2 review passed on the exact final source. No full build was required by that gate and none is claimed.
- Three production files change by +11/−4 lines. No tests, configuration or existing array API behavior changes.

Related #138656 and #135918 cover distinct earlier terminal work. Timing limits remain explicit; no extra repetitions were selected to obtain a nicer result.
