### PR TITLE
chore(tests): avoid retry waits in startup tracing coverage

### DIFF
--- a/src/gateway/server-startup-lifetime.test.ts
+++ b/src/gateway/server-startup-lifetime.test.ts
@@ -123,16 +123,26 @@ describe("Gateway startup lifetime", () => {
     });
     state.applyEnv();
     try {
-      const { startGatewayServerCore } = await import("./server-start.js");
-      await expect(
-        startGatewayServerCore(port, {
-          auth: { mode: "token", token },
-          bind: "loopback",
-          controlUiEnabled: false,
-          sidecarStartup: "defer",
-        }),
-      ).rejects.toThrow("another gateway instance is already listening");
-      expect(startupTraceEventLoopDelay.instances[0]?.disable).toHaveBeenCalledOnce();
+      const listenModule = await import("./server/http-listen.js");
+      const listen = listenModule.listenGatewayHttpServer;
+      // The owned blocker cannot leave; retry policy has its own listener tests.
+      const listenSpy = vi
+        .spyOn(listenModule, "listenGatewayHttpServer")
+        .mockImplementation((params) => listen({ ...params, retryEaddrinuse: false }));
+      try {
+        const { startGatewayServerCore } = await import("./server-start.js");
+        await expect(
+          startGatewayServerCore(port, {
+            auth: { mode: "token", token },
+            bind: "loopback",
+            controlUiEnabled: false,
+            sidecarStartup: "defer",
+          }),
+        ).rejects.toThrow("another gateway instance is already listening");
+        expect(startupTraceEventLoopDelay.instances[0]?.disable).toHaveBeenCalledOnce();
+      } finally {
+        listenSpy.mockRestore();
+      }
     } finally {
       await new Promise<void>((resolve) => {
         blocker.close(() => resolve());


### PR DESCRIPTION
## What Problem This Solves

The public-startup tracing regression retries an occupied port twenty times even though its own blocker remains open until cleanup. The case took 10.361 seconds in [main CI](https://github.com/openclaw/openclaw/actions/runs/34070027186).

## Why This Change Was Made

For this case only, delegate to the real listener with its existing `retryEaddrinuse: false` option. The real TCP blocker, public Gateway startup, native bind failure, exact-once trace shutdown assertion, and awaited cleanup remain intact. A case-local spy is restored in `finally` before the blocker and state are cleaned up.

Default retries retain their independent listener tests. This follows the same permanently occupied fixture-port approach already used in #139897. Related tracing repair: #122595.

## User Impact

Faster tracing regression coverage, with no production behavior, timeout, dependency, shard-count, or test-inventory change. The test-only diff is +20/-10 lines, including indentation; production delta is zero.

## Evidence

- Full startup-lifetime file: all six cases passed before and after. Four standalone listener-policy tests also passed. Cleanup was subsequently spelled with explicit `finally` to satisfy lint; the listener delegation and original assertions are unchanged.
- Existing startup trace: `http.listen` **10,145.4 ms → 0.7 ms**, preserving the native failure and trace-close assertion.
- Local whole-command timing was noisy: 328.69 → 352.83 seconds, RSS 2.213 → 2.167 GB. No whole-command speedup is claimed from that comparison; CI will provide the representative case timing.
- Earlier local attempts stalled during setup or timed out in the preceding, unchanged TLS case. The full file subsequently passed without changing its deadline. An optional trace-close counterfactual did not reach an assertion and is not counted as regression proof; the original lifecycle source was restored and hash-verified.
- Required changed checks passed through typecheck and all dead-export guards; final lint passed after the naming/cleanup follow-up. Fresh independent P0–P2 review of the final bytes found no actionable defect.
