### PR TITLE
refactor(chat): share markdown escape detection

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineMath.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineMath.swift
@@ -46,7 +46,7 @@ enum ChatInlineMathScanner {
             }
 
             guard markdown[cursor...].hasPrefix(#"\("#),
-                  !self.isEscaped(at: cursor, in: markdown)
+                  !ChatMarkdownBlockSyntax.isEscaped(at: cursor, in: markdown)
             else {
                 cursor = markdown.index(after: cursor)
                 continue
@@ -114,7 +114,7 @@ enum ChatInlineMathScanner {
                 containsNewline = true
             }
             if markdown[cursor...].hasPrefix(#"\)"#),
-               !self.isEscaped(at: cursor, in: markdown)
+               !ChatMarkdownBlockSyntax.isEscaped(at: cursor, in: markdown)
             {
                 return Candidate(
                     closeStart: cursor,
@@ -146,7 +146,7 @@ enum ChatInlineMathScanner {
                 start: cursor,
                 end: end,
                 length: markdown.distance(from: cursor, to: end),
-                canOpen: !self.isEscaped(at: cursor, in: markdown)))
+                canOpen: !ChatMarkdownBlockSyntax.isEscaped(at: cursor, in: markdown)))
             cursor = end
         }
 
@@ -195,18 +195,6 @@ enum ChatInlineMathScanner {
             end = markdown.index(after: end)
         }
         return end
-    }
-
-    private static func isEscaped(at index: String.Index, in markdown: String) -> Bool {
-        var cursor = index
-        var slashCount = 0
-        while cursor > markdown.startIndex {
-            let previous = markdown.index(before: cursor)
-            guard markdown[previous] == "\\" else { break }
-            slashCount += 1
-            cursor = previous
-        }
-        return slashCount.isMultiple(of: 2) == false
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
@@ -94,6 +94,18 @@ enum ChatMarkdownBlockSyntax {
             || (includesSetextUnderline && self.matches(line, #"^\s{0,3}={3,}$"#))
     }
 
+    static func isEscaped(at index: String.Index, in source: String) -> Bool {
+        var cursor = index
+        var count = 0
+        while cursor > source.startIndex {
+            let previous = source.index(before: cursor)
+            guard source[previous] == "\\" else { break }
+            count += 1
+            cursor = previous
+        }
+        return count.isMultiple(of: 2) == false
+    }
+
     private static func matches(_ line: String, _ pattern: String) -> Bool {
         line.range(of: pattern, options: .regularExpression) != nil
     }
@@ -705,7 +717,7 @@ enum ChatMarkdownBlockSegmenter {
             let matches = self.tagExpression.matches(in: line, range: fullRange)
             let tags = matches.compactMap { match -> Tag? in
                 guard let range = Range(match.range, in: line),
-                      !self.isEscaped(line, at: range.lowerBound),
+                      !ChatMarkdownBlockSyntax.isEscaped(at: range.lowerBound, in: line),
                       !codeRanges.contains(where: { $0.contains(range.lowerBound) })
                 else { return nil }
                 let raw = String(line[range])
@@ -727,18 +739,6 @@ enum ChatMarkdownBlockSegmenter {
                 if lower.hasPrefix("<details") { return .unsupportedDetailsOpen }
                 return .unsupportedSummary
             }
-        }
-
-        private static func isEscaped(_ line: String, at index: String.Index) -> Bool {
-            var cursor = index
-            var count = 0
-            while cursor > line.startIndex {
-                let previous = line.index(before: cursor)
-                guard line[previous] == "\\" else { break }
-                count += 1
-                cursor = previous
-            }
-            return count.isMultiple(of: 2) == false
         }
 
         private static func inlineCodeRanges(in line: String) -> [Range<String.Index>] {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatInlineMathTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatInlineMathTests.swift
@@ -29,9 +29,40 @@ struct ChatInlineMathTests {
         ])
     }
 
-    @Test func `escaped delimiters stay markdown`() {
-        let source = #"escaped \\(x\\)"#
-        #expect(ChatInlineMathScanner.pieces(in: source) == [.markdown(source)])
+    @Test func `escape parity preserves math and code span boundaries`() {
+        let cases: [(String, [ChatInlineMathScanner.Piece])] = [
+            (#"\(x\)"#, [.math(latex: "x", source: #"\(x\)"#)]),
+            (#"escaped \\(x\\)"#, [.markdown(#"escaped \\(x\\)"#)]),
+            (#"\\\(x\)"#, [.markdown(#"\\"#), .math(latex: "x", source: #"\(x\)"#)]),
+            (#"\\\\(x\)"#, [.markdown(#"\\\\(x\)"#)]),
+            (#"\(x\\)y\)"#, [.math(latex: #"x\\)y"#, source: #"\(x\\)y\)"#)]),
+            (#"\(x\\\) tail"#, [
+                .math(latex: #"x\\"#, source: #"\(x\\\)"#),
+                .markdown(" tail"),
+            ]),
+            (#"\(x\\\\)y\)"#, [.math(latex: #"x\\\\)y"#, source: #"\(x\\\\)y\)"#)]),
+            (#"`\(x\)`"#, [.markdown(#"`\(x\)`"#)]),
+            (#"\`\(x\)`"#, [
+                .markdown(#"\`"#), .math(latex: "x", source: #"\(x\)"#), .markdown("`"),
+            ]),
+            (#"\\`\(x\)`"#, [.markdown(#"\\`\(x\)`"#)]),
+            (#"\\\`\(x\)`"#, [
+                .markdown(#"\\\`"#), .math(latex: "x", source: #"\(x\)"#), .markdown("`"),
+            ]),
+        ]
+        for prefix in ["", "\u{1F680}e\u{301} "] {
+            for (source, pieces) in cases {
+                var expected = pieces
+                if !prefix.isEmpty {
+                    if case let .markdown(first) = expected[0] {
+                        expected[0] = .markdown(prefix + first)
+                    } else {
+                        expected.insert(.markdown(prefix), at: 0)
+                    }
+                }
+                #expect(ChatInlineMathScanner.pieces(in: prefix + source) == expected)
+            }
+        }
     }
 
     @Test func `unclosed opener stays literal`() {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownBlockSegmenterTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownBlockSegmenterTests.swift
@@ -265,6 +265,21 @@ struct ChatMarkdownBlockSegmenterTests {
         #expect(self.segments("`<details>`") == [.prose("`<details>`")])
     }
 
+    @Test func `details closing tags preserve escape parity and source`() {
+        for prefix in ["Body ", "\u{1F680}e\u{301} "] {
+            for (slashes, closes) in [("", true), (#"\"#, false), (#"\\"#, true), (#"\\\"#, false)] {
+                let body = prefix + slashes
+                let source = "<details><summary>More</summary>\(body)</details>tail"
+                let disclosure = ChatMarkdownBlock.disclosure(ChatMarkdownDisclosure(
+                    summary: "More",
+                    isExpanded: false,
+                    blocks: [.prose(closes ? body : body + "</details>tail")]))
+                let expected = closes ? [disclosure, .prose("tail")] : [disclosure]
+                #expect(self.segments(source) == expected)
+            }
+        }
+    }
+
     @Test func `details in raw HTML contexts stay literal`() {
         let commented = """
         <!--


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested deduplication of native chat Markdown parsing. Inline math and collapsible details maintained separate copies of the same escape-parity rule, making future parsing fixes easy to apply inconsistently.

## Why This Change Was Made

Both parsers now use the existing module-internal `ChatMarkdownBlockSyntax` owner. The disclosure predicate's Character-based loop is unchanged apart from parameter naming, and all four callers retain their source/index pairing and evaluation order.

No public or package API, dependencies, rendering, caches, limits, streaming behavior, or SDK surface changes.

## User Impact

No intended user-visible change. Escaped math delimiters, code spans, and details closing tags retain their existing interpretation and source text.

## Evidence

- The same 124 tests in `ChatInlineMathTests` and `ChatMarkdownBlockSegmenterTests` passed before and after extraction, including 30 characterization cases for odd/even escape runs, source-start behavior, and Unicode prefixes. Both test files were byte-identical between runs. This is characterization of existing behavior, not a claimed bug regression.
- `OpenClawChatUI` target and test-bundle builds passed with Swift 6.3.3.
- Local tests ran through SwiftPM's prebuilt test helper inside an OS sandbox blocking operator files, preferences/Keychain services, network, and desktop access. The regular `swift test` launcher could not perform nested sandbox planning; this local limitation does not replace the required hosted Apple tests.
- Pinned SwiftFormat 0.63.0, iOS SwiftLint 0.65.1, and whitespace checks passed.
- All gates selected by `check-changed` for the four changed files passed, including the macOS tooling contract suites.
- Independent review through P2 found no actionable defects.
- Initial live overlap audit covered 2,341 open PRs, with all 49 truncated file lists resolved and no competing change to these four files.

- Exact-head CI for `feae348e76711a48f6dcf1efe015f8282ea636fa` passed `macos-swift (tests)`, `ios-build (smoke)`, and `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/34082559724. Logs confirm both characterization tables executed, all 1,674 OpenClawKit tests passed, and the iOS app build succeeded. The macOS app suite also passed 2,079 tests plus two isolation tests.
- Supplemental Linux `blacksmith-testbox` proof through the Crabbox wrapper verified the exact candidate SHA and passed the selected gates: 620 tests passed, 505 platform skips, exit 0. SwiftLint/native-only coverage was not claimed on Linux. The owned lease was stopped and independently confirmed completed: https://github.com/openclaw/openclaw/actions/runs/34082606263. A subsequent external portal-sync timeout is an observability warning; command execution and cleanup had already succeeded.
- Pre-prepare and pre-merge live overlap refreshes covered 87 and 94 updated PRs respectively and found only this PR, with no competing ownership.
- ClawSweeper's completed exact-head review found no actionable defects.
- Landed through native review/prepare/merge as verified squash `faa9d1ea70172e9a8d64e81d2a367bef43afb2cd`, preserving Vincent Koc's author credit. All four landed files match the reviewed head. Post-merge checks finished without failures; current main at the September 7, 2026 04:41 UTC verification was `67480b59ae5d543ded35c5359ef8624cfdaa9b6a`, with the landed parser files unchanged.

Linux does not substitute for the successful Apple proof. No provider credentials or live Gateway were needed for this parsing change.
