### PR TITLE
refactor(auth): share inline-key cooldown lookup

### DIFF
--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -37,6 +37,18 @@ export function isAuthCooldownBypassedForProvider(provider: string | undefined):
   return normalized === "openrouter" || normalized === "kilocode";
 }
 
+export function resolveInlineProviderApiKeyUsageId(provider: string): string {
+  return `inline-api-key:${normalizeProviderId(provider)}`;
+}
+
+/** Reads inline-key health using the same identity and bypass policy as its writer. */
+export function readInlineProviderApiKeyUsage(store: AuthProfileStore, provider: string) {
+  const stats = isAuthCooldownBypassedForProvider(provider)
+    ? undefined
+    : store.usageStats?.[resolveInlineProviderApiKeyUsageId(provider)];
+  return { stats, unusableUntil: stats ? resolveProfileUnusableUntil(stats) : null };
+}
+
 // Per-attempt transient failures (#87462, #116464): block only the failing
 // model so fallback models on the same auth profile can still try. A model that
 // the provider does not serve (model_not_found) says nothing about sibling

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -33,6 +33,7 @@ import {
   isAuthCooldownBypassedForProvider,
   isModelScopedCooldownReason,
   resetAuthProfileFailureState,
+  resolveInlineProviderApiKeyUsageId,
   resolveProfileUnusableUntil,
 } from "./usage-state.js";
 
@@ -41,6 +42,7 @@ export {
   clearExpiredCooldowns,
   getSoonestCooldownExpiry,
   isProfileInCooldown,
+  resolveInlineProviderApiKeyUsageId,
 } from "./usage-state.js";
 
 const authProfileUsageDeps = {
@@ -102,12 +104,6 @@ async function updateOwnedAuthProfileUsage(
     store.usageStats = { ...store.usageStats, [profileId]: usage };
   }
   return updated;
-}
-
-const INLINE_API_KEY_USAGE_ID_PREFIX = "inline-api-key:";
-
-export function resolveInlineProviderApiKeyUsageId(provider: string): string {
-  return `${INLINE_API_KEY_USAGE_ID_PREFIX}${normalizeProviderId(provider)}`;
 }
 
 const FAILURE_REASON_PRIORITY: AuthProfileFailureReason[] = [

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -47,8 +47,8 @@ import type {
 } from "./auth-profiles/types.js";
 import {
   isActiveUnusableWindow,
-  isAuthCooldownBypassedForProvider,
   isProfileInCooldown,
+  readInlineProviderApiKeyUsage,
   resolveProfileUnusableUntil,
 } from "./auth-profiles/usage-state.js";
 import { resolveBundledCliBackendAuthPolicy } from "./cli-runner/cli-backend-auth-policy.js";
@@ -658,12 +658,8 @@ export function createModelAuthAvailabilityResolver(
     // Config-backed inline provider keys have no auth profile, so a recorded
     // billing/auth cooldown must hide them from browse availability the same way
     // it blocks their resolution — otherwise a cooled key still looks usable.
-    const inlineUsageStats = isAuthCooldownBypassedForProvider(provider)
-      ? undefined
-      : store.usageStats?.[`inline-api-key:${normalizeProviderId(provider)}`];
-    const inlineKeyUnusableUntil = inlineUsageStats
-      ? resolveProfileUnusableUntil(inlineUsageStats)
-      : null;
+    const { stats: inlineUsageStats, unusableUntil: inlineKeyUnusableUntil } =
+      readInlineProviderApiKeyUsage(store, provider);
     if (inlineKeyUnusableUntil != null && inlineKeyUnusableUntil > now) {
       return {
         availability: false,

--- a/src/agents/model-auth-provider-config.ts
+++ b/src/agents/model-auth-provider-config.ts
@@ -25,10 +25,7 @@ import {
   isStoredCredentialCompatibleWithAuthProvider,
 } from "./auth-profiles/order.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./auth-profiles/types.js";
-import {
-  isAuthCooldownBypassedForProvider,
-  resolveProfileUnusableUntil,
-} from "./auth-profiles/usage-state.js";
+import { readInlineProviderApiKeyUsage } from "./auth-profiles/usage-state.js";
 import { resolveEnvApiKey, type EnvApiKeyResult } from "./model-auth-env.js";
 import {
   CUSTOM_LOCAL_AUTH_MARKER,
@@ -576,11 +573,7 @@ export function resolveInlineProviderApiKeyCooldownUntil(
   store: AuthProfileStore,
   provider: string,
 ): number | null {
-  if (isAuthCooldownBypassedForProvider(provider)) {
-    return null;
-  }
-  const stats = store.usageStats?.[`inline-api-key:${normalizeProviderId(provider)}`];
-  return stats ? resolveProfileUnusableUntil(stats) : null;
+  return readInlineProviderApiKeyUsage(store, provider).unusableUntil;
 }
 
 /** Fails closed while an inline provider API key is inside its billing/auth cooldown. */


### PR DESCRIPTION
## What Problem This Solves

Inline provider keys use the same persisted cooldown rows during credential resolution and model availability, but those readers independently repeated provider normalization, bypass policy, and unusable-window calculation.

## Why This Change Was Made

`auth-profiles/usage-state.ts` now owns the shared inline-key reader and identity constructor. Both readers consume it, while the existing writer and its exported identity helper retain the same behavior. Availability still receives the raw usage stats to distinguish permanent authentication failures from temporary cooldowns.

## User Impact

No user-visible change. The `inline-api-key:<normalized provider>` key format, OpenRouter/KiloCode bypass, clock comparisons, failure classification, and persistence are unchanged. Existing exports and signatures are retained. Production delta: -3 lines; tests unchanged.

## Evidence

- Independent Codex autoreview: no actionable P0–P2 findings.
- `node scripts/run-vitest.mjs src/agents/auth-profiles/usage.test.ts src/agents/model-auth-availability.reasons.test.ts src/agents/model-auth.test.ts`: 3 files / 228 tests passed.
- `node scripts/check-changed.mjs`: passed. The initial run found seven unrelated type errors from installed fs-safe 0.8.1 versus locked 0.8.3; a frozen install corrected the local dependency, and the complete rerun passed.
- Rebased patch-identically onto current main. Exact-head CI passed for `a19204aab0470c1264eb6a899ddfed872ae4e00b`: https://github.com/openclaw/openclaw/actions/runs/34083748294. Native hosted-proof prepare and merge completed.
- No external API contract or storage semantics changed; no live-provider proof is required for this item.
