### PR TITLE
fix(update): refuse before downtime when a plugin target is unavailable

### DIFF
--- a/docs/install/update-troubleshooting.md
+++ b/docs/install/update-troubleshooting.md
@@ -80,6 +80,14 @@ the CLI fallback on the Gateway host.
 ## Reason codes
 
 - `dirty`, `no-upstream`: repair the source checkout before retrying.
+- `plugin-target-unavailable`: an enabled configured npm plugin has no resolvable
+  target for the selected core, or its registry metadata could not be read. The
+  refusal identifies the plugin, package target, and registry error before the
+  serving Gateway stops or the core package changes. Retry after publication or
+  registry recovery, use `openclaw update --tag <older-version>`, or disable the
+  affected plugin and retry. If the core version is unknown, select an exact
+  registry version. Extended-stable rejects `--tag`; retry later or explicitly
+  switch channels. `--dry-run` performs the same availability check.
 - `preflight-insufficient-space`: free space on the filesystems containing
   preflight staging (the checkout's `.artifacts` area on POSIX) and the
   package-manager store, then retry. The updater stops on

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -39,6 +39,20 @@ another full Doctor pass. The final report records downtime and verification
 results. See
 [Validation and activation](/cli/update#validation-and-activation) for the checks.
 
+Package updates also check npm availability for enabled configured plugins before
+stopping the serving Gateway or replacing the installed core. The check uses the
+same plugin version rules as post-update synchronization, including release-cohort
+tracking, beta selection, and extended-stable targets. A missing version or registry
+error refuses the update with `plugin-target-unavailable`; `--dry-run` reports the
+same refusal. Retry when the registry or mirror is ready, select an older available
+core with `openclaw update --tag <version>`, or disable the affected plugin before
+retrying. Extended-stable does not accept `--tag`; retry later or explicitly switch
+channels. Bundled and path-installed plugins do not require registry requests.
+When enabled npm plugins need admission, a package spec whose core version cannot
+be resolved before staging is also refused; select an exact registry version.
+This metadata check does not reserve downloads, so later download failures can
+still require recovery.
+
 Switch channels or target a specific version:
 
 ```bash

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -86,6 +86,10 @@ const managedUpdateHandoff = vi.hoisted(() => ({
   activate: vi.fn(async () => false),
 }));
 const candidateValidation = vi.hoisted(() => vi.fn());
+const pluginAvailabilityPreflight = vi.hoisted(() => vi.fn());
+vi.mock("./update-cli/update-command-plugin-preflight.js", () => ({
+  preflightConfiguredNpmPluginTargets: pluginAvailabilityPreflight,
+}));
 const unattendedRepair = vi.hoisted(() =>
   vi.fn<typeof import("../infra/update-repair-agent.js").prepareUnattendedUpdateRepair>(),
 );
@@ -1873,6 +1877,7 @@ describe("update-cli", () => {
     }
     restartHealthTestControl.snapshot = undefined;
     vi.resetAllMocks();
+    pluginAvailabilityPreflight.mockResolvedValue(undefined);
     triageAfterFailure.mockResolvedValue(undefined);
     managedUpdateHandoff.activate.mockResolvedValue(false);
     unattendedRepair.mockResolvedValue({
@@ -11433,6 +11438,43 @@ describe("update-cli", () => {
     expect(cleanupStaleManagedServiceUpdateHandoffs).not.toHaveBeenCalled();
     expect(defaultRuntime.exit).not.toHaveBeenCalled();
   });
+
+  it.each([false, true])(
+    "reports plugin admission refusal without changing the serving install (dryRun=%s)",
+    async (dryRun) => {
+      const detail =
+        'Plugin "example" requires @openclaw/example@1.0.1: Package not found on npm. Retry later.';
+      const sentinel = await runControlPlaneUpdate({
+        expectedExitCode: 1,
+        meta: {
+          sessionKey: "agent:main:webchat:dm:user-123",
+          handoffId: "plugin-admission",
+        },
+        options: { dryRun, yes: true, json: true },
+        beforeUpdate: async () => {
+          await mockPackageInstallAtCaseDir();
+          const { UpdatePreMutationError } = await import("./update-cli/shared.js");
+          pluginAvailabilityPreflight.mockRejectedValue(
+            new UpdatePreMutationError("plugin-target-unavailable", detail),
+          );
+        },
+      });
+
+      expect(lastWriteJsonCall()).toMatchObject({
+        status: "error",
+        reason: "plugin-target-unavailable",
+      });
+      expect(getErrorOutput()).toContain(detail);
+      expectNoSideEffects(serviceStop, serviceStart, serviceRestart, replaceConfigFile);
+      expect(cleanupStaleManagedServiceUpdateHandoffs).not.toHaveBeenCalled();
+      expect(packageInstallCommandCall()?.[0]).toBeUndefined();
+      if (dryRun) {
+        expect(sentinel).toBeNull();
+      } else {
+        expect(sentinel?.payload.stats?.reason).toBe("plugin-target-unavailable");
+      }
+    },
+  );
 
   it("writes an extended-stable selector failure to the control-plane sentinel", async () => {
     const sentinel = await runControlPlaneUpdate({

--- a/src/cli/update-cli/update-command-execution.test.ts
+++ b/src/cli/update-cli/update-command-execution.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   maybeRestartService: vi.fn(),
   maybeStopService: vi.fn(),
   prepareMutableUpdate: vi.fn<(env?: NodeJS.ProcessEnv) => Promise<void>>(),
+  pluginPreflight: vi.fn(),
   readGitRecovery: vi.fn(),
   runGitUpdate: vi.fn(),
   runPackageUpdate: vi.fn(),
@@ -32,6 +33,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../../infra/update-global.js", () => ({
   verifyPackageUpdateRecovery: mocks.verifyPackageRecovery,
+}));
+
+vi.mock("./update-command-plugin-preflight.js", () => ({
+  preflightConfiguredNpmPluginTargets: mocks.pluginPreflight,
 }));
 
 vi.mock("../../infra/update-runner-git-recovery.js", () => ({
@@ -81,6 +86,7 @@ vi.mock("./update-command-service.js", async () => {
   };
 });
 
+import { UpdatePreMutationError } from "./shared.js";
 import { executeMutableUpdate } from "./update-command-execution.js";
 
 const successfulUpdate: UpdateRunResult = {
@@ -111,6 +117,7 @@ function executionParams(
     opts: { json: true },
     shouldRestart: true,
     packageInstallSpec: "openclaw@1.0.1",
+    packageTargetVersion: "1.0.1",
     managedServiceRootRedirect: null,
     invocationCwd: "/work",
     recoveryState: { triageTarget: { env: {} } },
@@ -179,6 +186,7 @@ beforeEach(() => {
   mocks.maybeRestartService.mockResolvedValue(undefined);
   mocks.maybeStopService.mockImplementation(async ({ phase }) => inspectOrStopService(phase));
   mocks.prepareMutableUpdate.mockResolvedValue(undefined);
+  mocks.pluginPreflight.mockResolvedValue(undefined);
   mocks.readGitRecovery.mockResolvedValue({ serviceRestartSafe: true });
   mocks.runGitUpdate.mockResolvedValue({ ...successfulUpdate, mode: "git" });
   mocks.runPackageUpdate.mockResolvedValue(successfulUpdate);
@@ -187,6 +195,65 @@ beforeEach(() => {
 });
 
 describe("mutable update execution", () => {
+  it.each([
+    "@openclaw/example@1.0.1: Package not found on npm",
+    "@openclaw/example@1.0.1: npm view failed: ECONNRESET",
+  ])("keeps the serving package unchanged when plugin admission fails: %s", async (detail) => {
+    mocks.pluginPreflight.mockRejectedValue(
+      new UpdatePreMutationError("plugin-target-unavailable", detail),
+    );
+
+    const execution = await executeMutableUpdate(executionParams("package"));
+
+    expect(execution).toMatchObject({
+      mutationStarted: false,
+      result: {
+        status: "error",
+        reason: "plugin-target-unavailable",
+        steps: [expect.objectContaining({ stderrTail: detail })],
+      },
+    });
+    expect(mocks.serviceStopped).toBe(false);
+    expect(mocks.prepareMutableUpdate).not.toHaveBeenCalled();
+    expect(mocks.runPackageUpdate).not.toHaveBeenCalled();
+  });
+
+  it("waits for plugin availability before preparing a package update", async () => {
+    const available = createDeferred();
+    mocks.pluginPreflight.mockImplementation(() => available.promise);
+    const execution = executeMutableUpdate(executionParams("package"));
+    try {
+      await vi.waitFor(() => expect(mocks.pluginPreflight).toHaveBeenCalledOnce());
+      expect(mocks.serviceStopped).toBe(false);
+      expect(mocks.prepareMutableUpdate).not.toHaveBeenCalled();
+      expect(mocks.runPackageUpdate).not.toHaveBeenCalled();
+    } finally {
+      available.resolve();
+    }
+    expect((await execution)?.result).toBe(successfulUpdate);
+    expect(mocks.runPackageUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("refuses configuration drift during plugin admission before mutable preparation", async () => {
+    let configChanged = false;
+    mocks.pluginPreflight.mockImplementation(async () => {
+      configChanged = true;
+    });
+    mocks.revalidateSchemaContext.mockImplementation(async (context) => {
+      if (configChanged) {
+        throw new UpdatePreMutationError("database-schema-preflight", "Configuration changed");
+      }
+      return context;
+    });
+
+    const execution = await executeMutableUpdate(executionParams("package"));
+
+    expect(execution?.result.reason).toBe("database-schema-preflight");
+    expect(mocks.prepareMutableUpdate).not.toHaveBeenCalled();
+    expect(mocks.serviceStopped).toBe(false);
+    expect(mocks.runPackageUpdate).not.toHaveBeenCalled();
+  });
+
   it("captures the package target before schema revalidation and binds the latest service environment", async () => {
     const events: string[] = [];
     mocks.runPackageUpdate.mockImplementation(async () => {
@@ -224,11 +291,10 @@ describe("mutable update execution", () => {
     const pendingExecution = executeMutableUpdate(params);
     try {
       await vi.waitFor(() => expect(events).toContain("schema-after-inspection"));
-      expect(events).toEqual([
-        "schema-before-inspection",
-        "mutable-prepare",
-        "schema-after-inspection",
-      ]);
+      expect(events.indexOf("schema-before-inspection")).toBeLessThan(
+        events.indexOf("mutable-prepare"),
+      );
+      expect(events.at(-1)).toBe("schema-after-inspection");
       expect(mocks.serviceStopped).toBe(false);
       expect(mocks.runPackageUpdate).not.toHaveBeenCalled();
       params.packageInstallSpec = "openclaw@changed-during-schema-check";

--- a/src/cli/update-cli/update-command-execution.ts
+++ b/src/cli/update-cli/update-command-execution.ts
@@ -112,6 +112,7 @@ export async function executeMutableUpdate(params: {
   packageInstallSpec: string | null;
   packageInstallEnv?: NodeJS.ProcessEnv;
   packageInstallTarget?: ResolvedGlobalInstallTarget;
+  packageTargetVersion?: string;
   packageTargetSchemaVersions?: OpenClawSchemaVersions;
   packageUpdateNodeRunner?: string;
   managedServiceNodeRunner?: string;
@@ -508,6 +509,17 @@ export async function executeMutableUpdate(params: {
       });
     }
     if (params.updateInstallKind === "package") {
+      await recheckSchemas(params.packageTargetSchemaVersions);
+      const { preflightConfiguredNpmPluginTargets } =
+        await import("./update-command-plugin-preflight.js");
+      const context = admission!.contexts.at(-1)!;
+      await preflightConfiguredNpmPluginTargets({
+        config: context.configSnapshot.sourceConfig,
+        env: context.env,
+        targetVersion: params.packageTargetVersion ?? null,
+        channel: params.channel,
+        timeoutMs: params.updateStepTimeoutMs,
+      });
       await recheckSchemas(params.packageTargetSchemaVersions);
       await params.prepareMutableUpdate(admission?.managedEnv);
       await stopManagedServiceBeforeMutableUpdate(undefined, "inspect");

--- a/src/cli/update-cli/update-command-plugin-preflight.ts
+++ b/src/cli/update-cli/update-command-plugin-preflight.ts
@@ -1,0 +1,75 @@
+import { collectConfiguredNpmPluginTargets } from "../../commands/doctor/shared/missing-configured-plugin-install.targets.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { resolveNpmSpecMetadata } from "../../infra/install-source-utils.js";
+import { resolveRegistryUpdateChannel, type UpdateChannel } from "../../infra/update-channels.js";
+import { resolveNpmInstallSpecsForUpdateChannel } from "../../plugins/install-channel-specs.js";
+import { UpdatePreMutationError } from "./shared.js";
+import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
+
+/** Admit configured npm targets without installing plugins or changing live state. */
+export async function preflightConfiguredNpmPluginTargets(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  targetVersion: string | null;
+  channel: UpdateChannel;
+  timeoutMs: number;
+}): Promise<void> {
+  const failures: string[] = [];
+  try {
+    await withOwnedManagedUpdateEnv(params.env, async () => {
+      const targets = await collectConfiguredNpmPluginTargets({
+        config: params.config,
+        env: params.env,
+        targetVersion: params.targetVersion ?? "",
+        channel: resolveRegistryUpdateChannel({
+          configChannel: params.channel,
+          currentVersion: params.targetVersion,
+        }),
+      });
+      for (const target of targets) {
+        if (!params.targetVersion) {
+          failures.push(
+            `Plugin "${target.pluginId}" (${target.spec}): cannot determine the required version because the target core version is unknown. Select an exact registry target.`,
+          );
+          continue;
+        }
+        let requiredSpec = target.spec;
+        try {
+          const selected = await resolveNpmInstallSpecsForUpdateChannel({
+            ...target,
+            timeoutMs: params.timeoutMs,
+          });
+          requiredSpec = selected.installSpec;
+          const resolution = selected.npmResolution
+            ? { ok: true as const, metadata: selected.npmResolution }
+            : await resolveNpmSpecMetadata({ spec: requiredSpec, timeoutMs: params.timeoutMs });
+          if (!resolution.ok) {
+            failures.push(
+              `Plugin "${target.pluginId}" requires ${requiredSpec} for core ${params.targetVersion}: ${resolution.error}`,
+            );
+          }
+        } catch (error) {
+          failures.push(
+            `Plugin "${target.pluginId}" requires ${requiredSpec} for core ${params.targetVersion}: ${formatErrorMessage(error)}`,
+          );
+        }
+      }
+    });
+  } catch (error) {
+    failures.push(`Could not inspect configured npm plugins: ${formatErrorMessage(error)}`);
+  }
+  if (failures.length > 0) {
+    throw new UpdatePreMutationError(
+      "plugin-target-unavailable",
+      [
+        "Update refused: configured npm plugin targets are unavailable.",
+        ...failures,
+        "Retry after the packages or registry are available, use `openclaw update --tag <older-version>`, or disable the affected plugin and retry.",
+        ...(params.channel === "extended-stable"
+          ? ["Extended-stable does not accept --tag; retry later or explicitly switch channels."]
+          : []),
+      ].join("\n"),
+    );
+  }
+}

--- a/src/cli/update-cli/update-command-schema.ts
+++ b/src/cli/update-cli/update-command-schema.ts
@@ -28,6 +28,7 @@ export async function preflightUpdateCommandSchemas(params: {
   channel: UpdateChannel;
   devTarget?: DevUpdateTarget;
   packageTargetSchemaVersions?: OpenClawSchemaVersions;
+  packageTargetVersion?: string;
   opts: Pick<UpdateCommandOptions, "dryRun" | "json" | "run">;
   refuseUpdate: (reason: string, message?: string) => Promise<void>;
 }): Promise<
@@ -87,6 +88,18 @@ export async function preflightUpdateCommandSchemas(params: {
         target.schemaVersions,
         admission.contexts,
       );
+      if (opts.dryRun && updateInstallKind === "package") {
+        const { preflightConfiguredNpmPluginTargets } =
+          await import("./update-command-plugin-preflight.js");
+        const context = admission.contexts.at(-1)!;
+        await preflightConfiguredNpmPluginTargets({
+          config: context.configSnapshot.sourceConfig,
+          env: context.env,
+          targetVersion: params.packageTargetVersion ?? null,
+          channel,
+          timeoutMs: updateStepTimeoutMs,
+        });
+      }
     } catch (error) {
       if (!opts.dryRun) {
         if (error instanceof UpdatePreMutationError) {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -269,7 +269,6 @@ async function updateCommandInternal(
   let fallbackToLatest = false;
   let packageInstallSpec: string | null = null;
   let packageInstallEnv: NodeJS.ProcessEnv | undefined;
-  let packageInstallCwd: string | undefined;
   let packageInstallTarget: ResolvedGlobalInstallTarget | undefined;
   let installedPackageName = DEFAULT_PACKAGE_NAME;
   let packageAlreadyCurrent = false;
@@ -328,7 +327,6 @@ async function updateCommandInternal(
     recoveryState.triageTarget.root = root;
     recoveryState.triageTarget.nodeRunner = packageUpdateNodeRunner;
     packageInstallEnv = await createGlobalInstallEnv();
-    packageInstallCwd = invocationCwd;
     if (updateInstallKind === "package") {
       installedPackageName = (await readPackageName(root)) ?? DEFAULT_PACKAGE_NAME;
       const manager = await resolveGlobalManager({
@@ -376,7 +374,7 @@ async function updateCommandInternal(
       targetVersion = await resolveTargetVersion(tag, timeoutMs, {
         spec: explicitSpec,
         command: npmMetadataCommand,
-        cwd: packageInstallCwd,
+        cwd: invocationCwd,
         env: packageInstallEnv,
       });
     } else {
@@ -384,7 +382,7 @@ async function updateCommandInternal(
         channel,
         timeoutMs,
         command: npmMetadataCommand,
-        cwd: packageInstallCwd,
+        cwd: invocationCwd,
         env: packageInstallEnv,
       }).then((resolved) => {
         tag = resolved.tag;
@@ -420,7 +418,7 @@ async function updateCommandInternal(
         }),
         command: npmMetadataCommand,
         timeoutMs,
-        cwd: packageInstallCwd,
+        cwd: invocationCwd,
         env: packageInstallEnv,
       });
       if (targetMetadata.error || targetMetadata.version !== targetVersion) {
@@ -474,6 +472,7 @@ async function updateCommandInternal(
     channel,
     devTarget,
     packageTargetSchemaVersions,
+    packageTargetVersion: targetVersion ?? undefined,
     opts,
     refuseUpdate,
   });
@@ -654,6 +653,7 @@ async function updateCommandInternal(
     packageInstallEnv,
     packageInstallTarget,
     packageTargetSchemaVersions,
+    packageTargetVersion: targetVersion ?? undefined,
     packageUpdateNodeRunner,
     managedServiceNodeRunner,
     managedServiceRootRedirect,

--- a/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
@@ -67,6 +67,7 @@ export async function resolveConfiguredPluginInstallContext(params: {
   configuredChannelIds: ReadonlySet<string>;
   blockedPluginIds?: ReadonlySet<string>;
   baselineRecords?: Record<string, PluginInstallRecord>;
+  coreVersion?: string;
 }) {
   const realpathCache = new Map<string, string>();
   const resolvePathIdentity = (value: string): string => {
@@ -102,7 +103,7 @@ export async function resolveConfiguredPluginInstallContext(params: {
     });
   const records =
     params.baselineRecords ?? (await loadInstalledPluginIndexInstallRecords({ env: params.env }));
-  const currentVersion = resolveCompatibilityHostVersion(params.env);
+  const currentVersion = params.coreVersion ?? resolveCompatibilityHostVersion(params.env);
   const updateChannel = resolveRegistryUpdateChannel({
     configChannel: normalizeUpdateChannel(params.cfg.update?.channel),
     currentVersion,

--- a/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
@@ -8,7 +8,6 @@ import { parseClawHubPluginSpec } from "../../../infra/clawhub-spec.js";
 import { parseRegistryNpmSpec } from "../../../infra/npm-registry-spec.js";
 import {
   comparePackageUpdateVersions,
-  expectedIntegrityForUpdate,
   readInstalledPackageVersion,
 } from "../../../infra/package-update-utils.js";
 import type { UpdateChannel } from "../../../infra/update-channels.js";
@@ -48,6 +47,10 @@ import {
   resolveLegacyNpmPackageInstallPath,
   resolveNpmPackageInstallPath,
 } from "./missing-configured-plugin-install.records.js";
+import {
+  resolveRecordedInstallCandidate,
+  type InstallCandidateRepairReason,
+} from "./missing-configured-plugin-install.targets.js";
 
 export function isActionableClawHubSkippedOutcome(outcome: {
   status: string;
@@ -60,8 +63,6 @@ export function isClawHubReviewNotice(message: string): boolean {
   const audit = stripAnsi(message);
   return audit.includes("ClawHub Security Audit") && audit.includes("Outcome: Review");
 }
-
-type InstallCandidateRepairReason = "stale-version-bound-runtime";
 
 function formatInstalledConfiguredPluginChange(params: {
   pluginId: string;
@@ -130,35 +131,11 @@ async function installCandidatePackage(
   const recordedSource =
     record?.source === "npm" || record?.source === "clawhub" ? record.source : undefined;
   const staleRuntimeRepair = params.repairReason === "stale-version-bound-runtime";
-  const declaredSource = recordedSource
-    ? resolvePluginInstallSources(params.candidate, recordedSource)[0]
-    : undefined;
-  // Only the admitted cohort repair replaces a recorded target. Its new artifact
-  // uses the declared source's integrity; ordinary payload repair retains both pins.
-  const recordedSpec = staleRuntimeRepair
-    ? declaredSource?.spec
-    : (record?.spec ?? declaredSource?.spec);
-  const candidate =
-    record && recordedSource
-      ? {
-          ...params.candidate,
-          defaultChoice: recordedSource,
-          ...(recordedSource === "npm"
-            ? { npmSpec: recordedSpec, clawhubSpec: undefined }
-            : { clawhubSpec: recordedSpec, npmSpec: undefined }),
-          expectedIntegrity: staleRuntimeRepair
-            ? declaredSource?.expectedIntegrity
-            : expectedIntegrityForUpdate(record.spec, record.integrity),
-          trustedSourceLinkedOfficialInstall:
-            params.candidate.trustedSourceLinkedOfficialInstall &&
-            (!record.spec ||
-              (recordedSource === "npm"
-                ? parseRegistryNpmSpec(record.spec)?.name ===
-                  parseRegistryNpmSpec(params.candidate.npmSpec ?? "")?.name
-                : parseClawHubPluginSpec(record.spec)?.name ===
-                  parseClawHubPluginSpec(params.candidate.clawhubSpec ?? "")?.name)),
-        }
-      : params.candidate;
+  const candidate = resolveRecordedInstallCandidate({
+    candidate: params.candidate,
+    record,
+    repairReason: params.repairReason,
+  });
   const extensionsDir = resolveDefaultPluginExtensionsDir(params.env);
   const warnings: string[] = [];
   // A channel fallback changes which artifact the operator gets, so it must stay

--- a/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
@@ -32,11 +32,11 @@ import {
 } from "./missing-configured-plugin-install.install.js";
 import {
   forceNpmInstallRecordRepair,
-  isTrustedOfficialInstallRecordForCandidate,
   installPathsEqual,
   recordMatchesBundledPackage,
   resolveSafeBrokenOfficialInstallRemovalPath,
 } from "./missing-configured-plugin-install.records.js";
+import { resolveConfiguredPluginCandidateRepair } from "./missing-configured-plugin-install.targets.js";
 import {
   isLegacyPackageUpdateDoctorPass,
   shouldDeferConfiguredPluginInstallRepair,
@@ -359,29 +359,24 @@ async function repairMissingPluginInstallsWithLease(
         ? new Set([...(params.blockedPluginIds ?? []), ...deferredPluginIds])
         : params.blockedPluginIds,
   })) {
-    if (bundledPluginsById.has(candidate.pluginId)) {
+    const repair = resolveConfiguredPluginCandidateRepair({
+      candidate,
+      records: nextRecords,
+      env,
+      context: {
+        bundledPluginsById,
+        officialReplacementPluginIds,
+        knownIds,
+        installedPluginIdsWithStaleVersionBoundRuntimePackages,
+        installedPluginIdsWithRepairablePackageDiagnostics,
+        configuredPluginIdsWithStaleDescriptors,
+      },
+    });
+    if (!repair) {
       continue;
     }
-    const shouldReplaceBrokenOfficialInstall = officialReplacementPluginIds.has(candidate.pluginId);
-    if (shouldReplaceBrokenOfficialInstall && !candidate.trustedSourceLinkedOfficialInstall) {
-      continue;
-    }
+    const { shouldReplaceBrokenOfficialInstall, repairReason } = repair;
     const record = nextRecords[candidate.pluginId];
-    if (
-      shouldReplaceBrokenOfficialInstall &&
-      !isTrustedOfficialInstallRecordForCandidate({ record, candidate })
-    ) {
-      continue;
-    }
-    const hasRecord = Object.hasOwn(nextRecords, candidate.pluginId);
-    const hasUsableRecord =
-      hasRecord && !isPayloadMissing(env, nextRecords[candidate.pluginId]?.installPath);
-    if (
-      !shouldReplaceBrokenOfficialInstall &&
-      (hasUsableRecord || (knownIds.has(candidate.pluginId) && !hasRecord))
-    ) {
-      continue;
-    }
     const removalPath = shouldReplaceBrokenOfficialInstall
       ? resolveSafeBrokenOfficialInstallRemovalPath({
           pluginId: candidate.pluginId,
@@ -399,12 +394,7 @@ async function repairMissingPluginInstallsWithLease(
       updateChannel,
       mode: shouldReplaceBrokenOfficialInstall ? "update" : "install",
       preferNpm: preferNpmInstalls,
-      ...(installedPluginIdsWithStaleVersionBoundRuntimePackages.has(candidate.pluginId) &&
-      !installedPluginIdsWithRepairablePackageDiagnostics.has(candidate.pluginId) &&
-      !configuredPluginIdsWithStaleDescriptors.has(candidate.pluginId) &&
-      hasUsableRecord
-        ? { repairReason: "stale-version-bound-runtime" as const }
-        : {}),
+      repairReason,
       ...(params.onCapabilityConsent ? { onCapabilityConsent: params.onCapabilityConsent } : {}),
       beforePersistentEffect: params.beforePersistentEffect,
     });

--- a/src/commands/doctor/shared/missing-configured-plugin-install.targets.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.targets.ts
@@ -1,0 +1,227 @@
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../../../config/types.plugins.js";
+import { parseClawHubPluginSpec } from "../../../infra/clawhub-spec.js";
+import { parseRegistryNpmSpec } from "../../../infra/npm-registry-spec.js";
+import { expectedIntegrityForUpdate } from "../../../infra/package-update-utils.js";
+import type { UpdateChannel } from "../../../infra/update-channels.js";
+import {
+  normalizePluginsConfig,
+  resolveEffectiveEnableState,
+} from "../../../plugins/config-state.js";
+import {
+  resolvePluginInstallSources,
+  type resolveNpmInstallSpecsForUpdateChannel,
+} from "../../../plugins/install-channel-specs.js";
+import { resolveTrustedSourceLinkedOfficialNpmInstall } from "../../../plugins/official-external-install-records.js";
+import { isPayloadMissing } from "../../../plugins/payload-verification.js";
+import { resolveNpmUpdateTarget } from "../../../plugins/update-source.js";
+import {
+  collectDownloadableInstallCandidates,
+  resolveConfiguredPluginInstallContext,
+  type DownloadableInstallCandidate,
+} from "./missing-configured-plugin-install.candidates.js";
+import {
+  collectBlockedPluginIds,
+  collectConfiguredChannelIds,
+  collectConfiguredPluginIds,
+} from "./missing-configured-plugin-install.ids.js";
+import { isTrustedOfficialInstallRecordForCandidate } from "./missing-configured-plugin-install.records.js";
+
+export type InstallCandidateRepairReason = "stale-version-bound-runtime";
+type InstallContext = Awaited<ReturnType<typeof resolveConfiguredPluginInstallContext>>;
+
+export function resolveRecordedInstallCandidate(params: {
+  candidate: DownloadableInstallCandidate;
+  record?: PluginInstallRecord;
+  repairReason?: InstallCandidateRepairReason;
+}): DownloadableInstallCandidate {
+  const record = params.record;
+  const recordedSource =
+    record?.source === "npm" || record?.source === "clawhub" ? record.source : undefined;
+  const staleRuntimeRepair = params.repairReason === "stale-version-bound-runtime";
+  const declaredSource = recordedSource
+    ? resolvePluginInstallSources(params.candidate, recordedSource)[0]
+    : undefined;
+  // Only the admitted cohort repair replaces a recorded target. Its new artifact
+  // uses the declared source's integrity; ordinary payload repair retains both pins.
+  const recordedSpec = staleRuntimeRepair
+    ? declaredSource?.spec
+    : (record?.spec ?? declaredSource?.spec);
+  return record && recordedSource
+    ? {
+        ...params.candidate,
+        defaultChoice: recordedSource,
+        ...(recordedSource === "npm"
+          ? { npmSpec: recordedSpec, clawhubSpec: undefined }
+          : { clawhubSpec: recordedSpec, npmSpec: undefined }),
+        expectedIntegrity: staleRuntimeRepair
+          ? declaredSource?.expectedIntegrity
+          : expectedIntegrityForUpdate(record.spec, record.integrity),
+        trustedSourceLinkedOfficialInstall:
+          params.candidate.trustedSourceLinkedOfficialInstall &&
+          (!record.spec ||
+            (recordedSource === "npm"
+              ? parseRegistryNpmSpec(record.spec)?.name ===
+                parseRegistryNpmSpec(params.candidate.npmSpec ?? "")?.name
+              : parseClawHubPluginSpec(record.spec)?.name ===
+                parseClawHubPluginSpec(params.candidate.clawhubSpec ?? "")?.name)),
+      }
+    : params.candidate;
+}
+
+/** Keep stale-runtime pin replacement behind the same repair admission as doctor. */
+export function resolveConfiguredPluginCandidateRepair(params: {
+  candidate: DownloadableInstallCandidate;
+  records: Record<string, PluginInstallRecord>;
+  env: NodeJS.ProcessEnv;
+  context: Pick<
+    InstallContext,
+    | "bundledPluginsById"
+    | "officialReplacementPluginIds"
+    | "knownIds"
+    | "installedPluginIdsWithStaleVersionBoundRuntimePackages"
+    | "installedPluginIdsWithRepairablePackageDiagnostics"
+    | "configuredPluginIdsWithStaleDescriptors"
+  >;
+}):
+  | { shouldReplaceBrokenOfficialInstall: boolean; repairReason?: InstallCandidateRepairReason }
+  | undefined {
+  const { candidate, context } = params;
+  if (context.bundledPluginsById.has(candidate.pluginId)) {
+    return undefined;
+  }
+  const shouldReplaceBrokenOfficialInstall = context.officialReplacementPluginIds.has(
+    candidate.pluginId,
+  );
+  const record = params.records[candidate.pluginId];
+  if (
+    shouldReplaceBrokenOfficialInstall &&
+    (!candidate.trustedSourceLinkedOfficialInstall ||
+      !isTrustedOfficialInstallRecordForCandidate({ record, candidate }))
+  ) {
+    return undefined;
+  }
+  const hasRecord = Object.hasOwn(params.records, candidate.pluginId);
+  const hasUsableRecord = hasRecord && !isPayloadMissing(params.env, record?.installPath);
+  if (
+    !shouldReplaceBrokenOfficialInstall &&
+    (hasUsableRecord || (context.knownIds.has(candidate.pluginId) && !hasRecord))
+  ) {
+    return undefined;
+  }
+  return {
+    shouldReplaceBrokenOfficialInstall,
+    ...(context.installedPluginIdsWithStaleVersionBoundRuntimePackages.has(candidate.pluginId) &&
+    !context.installedPluginIdsWithRepairablePackageDiagnostics.has(candidate.pluginId) &&
+    !context.configuredPluginIdsWithStaleDescriptors.has(candidate.pluginId) &&
+    hasUsableRecord
+      ? { repairReason: "stale-version-bound-runtime" as const }
+      : {}),
+  };
+}
+
+type ConfiguredNpmPluginTarget = Parameters<typeof resolveNpmInstallSpecsForUpdateChannel>[0] & {
+  pluginId: string;
+};
+
+/** Metadata-only inventory for the same npm targets used by post-core sync and repair. */
+export async function collectConfiguredNpmPluginTargets(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  targetVersion: string;
+  channel: UpdateChannel;
+  installRecords?: Record<string, PluginInstallRecord>;
+}): Promise<ConfiguredNpmPluginTarget[]> {
+  const configuredPluginIds = collectConfiguredPluginIds(params.config, params.env);
+  const configuredChannelIds = collectConfiguredChannelIds(params.config, params.env);
+  if (configuredPluginIds.size === 0 && configuredChannelIds.size === 0) {
+    return [];
+  }
+  const blockedPluginIds = collectBlockedPluginIds(params.config);
+  const context = await resolveConfiguredPluginInstallContext({
+    cfg: params.config,
+    env: params.env,
+    configuredPluginIds,
+    configuredChannelIds,
+    blockedPluginIds,
+    baselineRecords: params.installRecords,
+    coreVersion: params.targetVersion,
+  });
+  const candidates = new Map(
+    collectDownloadableInstallCandidates({
+      cfg: params.config,
+      env: params.env,
+      configuredPluginIds,
+      configuredChannelIds,
+      configuredChannelOwnerPluginIds: context.configuredChannelOwnerPluginIds,
+      blockedPluginIds,
+      missingPluginIds: new Set(),
+    }).map((candidate) => [candidate.pluginId, candidate]),
+  );
+  const normalizedConfig = normalizePluginsConfig(params.config.plugins);
+  const targets: ConfiguredNpmPluginTarget[] = [];
+  const pluginIds = new Set([
+    ...configuredPluginIds,
+    ...candidates.keys(),
+    ...[...context.configuredChannelOwnerPluginIds.values()].flatMap((ids) => Array.from(ids)),
+  ]);
+  for (const pluginId of pluginIds) {
+    const record = context.records[pluginId];
+    if (
+      context.bundledPluginsById.has(pluginId) ||
+      (record && (record.source !== "npm" || record.artifactKind || record.sourcePath)) ||
+      !resolveEffectiveEnableState({
+        id: pluginId,
+        origin: "global",
+        config: normalizedConfig,
+        rootConfig: params.config,
+      }).enabled
+    ) {
+      continue;
+    }
+    const candidate = candidates.get(pluginId);
+    const repair =
+      candidate &&
+      resolveConfiguredPluginCandidateRepair({
+        candidate,
+        records: context.records,
+        env: params.env,
+        context,
+      });
+    if (candidate && repair) {
+      const selected = resolveRecordedInstallCandidate({
+        candidate,
+        record,
+        repairReason: repair.repairReason,
+      });
+      const source = resolvePluginInstallSources(
+        selected,
+        record?.source === "npm" ? "npm" : undefined,
+      )[0];
+      if (source?.source === "npm" && parseRegistryNpmSpec(source.spec)) {
+        targets.push({
+          pluginId,
+          spec: source.spec,
+          updateChannel: params.channel,
+          coreVersion: params.targetVersion,
+          officialPackageName: selected.trustedSourceLinkedOfficialInstall
+            ? parseRegistryNpmSpec(source.spec)?.name
+            : undefined,
+          versionBoundToCore: selected.versionBoundToOpenClaw,
+        });
+      }
+    } else if (record?.source === "npm") {
+      const { target } = resolveNpmUpdateTarget({
+        record,
+        trustedOfficialInstall: resolveTrustedSourceLinkedOfficialNpmInstall({ pluginId, record }),
+        syncOfficialPluginInstalls: true,
+        updateChannel: params.channel,
+        coreVersion: params.targetVersion,
+      });
+      if (target && parseRegistryNpmSpec(target.spec)) {
+        targets.push({ pluginId, ...target });
+      }
+    }
+  }
+  return targets.toSorted((left, right) => left.pluginId.localeCompare(right.pluginId));
+}

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -874,6 +874,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     // The doctor module owns a broad install/catalog graph. Its cold import is
     // suite setup; individual cases measure detection and repair behavior.
     await import("./missing-configured-plugin-install.js");
+    await import("../../../cli/update-cli/update-command-plugin-preflight.js");
   });
 
   beforeEach(() => {
@@ -3115,6 +3116,139 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     ]);
     expect(result.warnings).toStrictEqual([]);
   });
+
+  it.each([
+    {
+      availability: "missing version",
+      channel: "stable",
+      error: "Package not found on npm: @openclaw/codex@2026.9.3.",
+    },
+    { availability: "registry outage", channel: "stable", error: "registry connection timed out" },
+    { availability: "published version", channel: "stable" },
+    { availability: "beta-only package", channel: "beta" },
+    { availability: "unknown core version", channel: "stable" },
+  ] as const)(
+    "preflights a stale exact Codex pin with $availability before any plugin mutation",
+    async ({ availability, channel, ...outcome }) => {
+      const installDir = tempDirs.make("openclaw-plugin-availability-");
+      createColdPluginFixture({
+        rootDir: installDir,
+        pluginId: "codex",
+        packageName: "@openclaw/codex",
+        packageVersion: "2026.9.1",
+      });
+      const packageFile = path.join(installDir, "package.json");
+      const originalPackage = fs.readFileSync(packageFile, "utf8");
+      const records = installedRecords("codex", {
+        spec: "@openclaw/codex@2026.9.1",
+        resolvedVersion: "2026.9.1",
+        installPath: installDir,
+      });
+      const config: OpenClawConfig = { plugins: { entries: { codex: { enabled: true } } } };
+      const originalConfig = structuredClone(config);
+      const originalRecords = structuredClone(records);
+      mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+      mocks.loadPluginMetadataSnapshot.mockReturnValue({
+        plugins: [{ id: "codex", packageVersion: "2026.9.1", channels: [] }],
+        diagnostics: [],
+      });
+      mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+        officialPluginEntry({ id: "codex", npmSpec: "@openclaw/codex" }),
+      ]);
+      mocks.resolveNpmSpecMetadata.mockImplementation(async ({ spec }: { spec: string }) => {
+        if (spec === "@openclaw/codex@2026.9.3" && "error" in outcome) {
+          return { ok: false, error: outcome.error };
+        }
+        if (availability === "beta-only package" && spec === "@openclaw/codex@latest") {
+          return { ok: false, error: "No latest release for @openclaw/codex." };
+        }
+        const version = spec.endsWith("@beta") ? "2026.9.3-beta.1" : spec.split("@").at(-1);
+        return {
+          ok: true,
+          metadata: {
+            name: "@openclaw/codex",
+            version,
+            resolvedSpec: `@openclaw/codex@${version}`,
+          },
+        };
+      });
+      const { preflightConfiguredNpmPluginTargets } =
+        await import("../../../cli/update-cli/update-command-plugin-preflight.js");
+      const result = preflightConfiguredNpmPluginTargets({
+        config,
+        env: testEnv,
+        targetVersion: availability === "unknown core version" ? null : "2026.9.3",
+        channel,
+        timeoutMs: 1000,
+      });
+      if (availability === "unknown core version") {
+        await expect(result).rejects.toMatchObject({
+          reason: "plugin-target-unavailable",
+          message: expect.stringContaining("target core version is unknown"),
+        });
+      } else if ("error" in outcome) {
+        await expect(result).rejects.toMatchObject({
+          reason: "plugin-target-unavailable",
+          message: expect.stringContaining(
+            `Plugin "codex" requires @openclaw/codex@2026.9.3 for core 2026.9.3: ${outcome.error}`,
+          ),
+        });
+      } else {
+        await expect(result).resolves.toBeUndefined();
+      }
+      expect(
+        mocks.resolveNpmSpecMetadata.mock.calls
+          .map(([params]) => params.spec)
+          .toSorted((left, right) => left.localeCompare(right)),
+      ).toEqual(
+        availability === "unknown core version"
+          ? []
+          : channel === "beta"
+            ? ["@openclaw/codex@beta", "@openclaw/codex@latest"]
+            : ["@openclaw/codex@2026.9.3"],
+      );
+      expect(config).toEqual(originalConfig);
+      expect(records).toEqual(originalRecords);
+      expect(fs.readFileSync(packageFile, "utf8")).toBe(originalPackage);
+      expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+      expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
+      expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
+      expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["disabled", "path", "bundled", "local npm archive"] as const)(
+    "does not query npm while preflighting a %s configured plugin",
+    async (kind) => {
+      const records = installedRecords("fixture", {
+        source: kind === "path" ? "path" : "npm",
+        spec: kind === "local npm archive" ? "file:/tmp/fixture.tgz" : "@example/fixture@1.0.0",
+        installPath: process.cwd(),
+      });
+      mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+      mocks.loadPluginMetadataSnapshot.mockReturnValue({
+        plugins: [{ id: "fixture", channels: [] }],
+        diagnostics: [],
+      });
+      if (kind === "bundled") {
+        mockCurrentBundledPlugin("fixture", "@example/fixture");
+      }
+      const { preflightConfiguredNpmPluginTargets } =
+        await import("../../../cli/update-cli/update-command-plugin-preflight.js");
+      await expect(
+        preflightConfiguredNpmPluginTargets({
+          config: { plugins: { entries: { fixture: { enabled: kind !== "disabled" } } } },
+          env: testEnv,
+          targetVersion: "2026.9.3",
+          channel: "stable",
+          timeoutMs: 1000,
+        }),
+      ).resolves.toBeUndefined();
+      expect(mocks.resolveNpmSpecMetadata).not.toHaveBeenCalled();
+      expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+      expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([
     {

--- a/src/plugins/update-installed.ts
+++ b/src/plugins/update-installed.ts
@@ -15,7 +15,10 @@ import {
 } from "./capability-consent.js";
 import { buildClawHubPluginInstallRecordFields } from "./clawhub-install-records.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
-import { NpmChannelResolutionError } from "./install-channel-specs.js";
+import {
+  NpmChannelResolutionError,
+  resolveNpmInstallSpecsForUpdateChannel,
+} from "./install-channel-specs.js";
 import type { InstallSafetyOverrides } from "./install-security-scan.types.js";
 import { copyPluginInstallTransactionRequest } from "./install-transaction.js";
 import { PLUGIN_INSTALL_ERROR_CODE, resolvePluginInstallDir } from "./install.js";
@@ -66,8 +69,7 @@ import {
   isPluginInstallRecordUpdateSource,
   isTrustedSourceLinkedOfficialNpmUpdate,
   resolveClawHubUpdateSpecs,
-  resolveNpmSpecPackageName,
-  resolveNpmUpdateSpecs,
+  resolveNpmUpdateTarget,
   resolveTrustedOfficialPrereleaseFallbackMetadataForUpdate,
   shouldBypassTrustedOfficialUnchangedNpmCheck,
   shouldSkipUnchangedNpmInstall,
@@ -180,11 +182,6 @@ export async function updateNpmInstalledPlugins(params: {
       continue;
     }
     const trustedOfficialNpmSpec = trustedOfficialNpmInstall?.npmSpec;
-    const npmSpecOverride =
-      params.specOverrides?.[pluginId] ??
-      (replacementPluginId || trustedOfficialNpmInstall?.replaceNpmPackage
-        ? trustedOfficialNpmSpec
-        : undefined);
     const trustedOfficialClawHubInstall = resolveOfficialClawHubInstall({ pluginId, record });
     const recordClawHubPackage = resolveRecordedClawHubPackage(record);
     const officialNpmSpec = params.syncOfficialPluginInstalls ? trustedOfficialNpmSpec : undefined;
@@ -197,6 +194,15 @@ export async function updateNpmInstalledPlugins(params: {
       (trustedOfficialNpmSpec || trustedOfficialClawHubInstall
         ? params.officialPluginUpdateChannel
         : undefined);
+    const { specOverride: npmSpecOverride, target: npmTarget } = resolveNpmUpdateTarget({
+      record,
+      trustedOfficialInstall: trustedOfficialNpmInstall,
+      specOverride: params.specOverrides?.[pluginId],
+      syncOfficialPluginInstalls: params.syncOfficialPluginInstalls,
+      updateChannel,
+      coreVersion: params.coreVersion,
+      timeoutMs: params.timeoutMs,
+    });
     if (normalizedPluginConfig) {
       const enableState = resolveEffectiveEnableState({
         id: pluginId,
@@ -218,19 +224,11 @@ export async function updateNpmInstalledPlugins(params: {
       continue;
     }
 
-    let npmSpecs: Awaited<ReturnType<typeof resolveNpmUpdateSpecs>> | undefined;
+    let npmSpecs: Awaited<ReturnType<typeof resolveNpmInstallSpecsForUpdateChannel>> | undefined;
     try {
       npmSpecs =
-        record.source === "npm"
-          ? await resolveNpmUpdateSpecs({
-              record,
-              specOverride: npmSpecOverride,
-              officialSpecOverride: officialNpmSpec,
-              updateChannel,
-              officialPackageName: resolveNpmSpecPackageName(trustedOfficialNpmSpec),
-              coreVersion: params.coreVersion,
-              timeoutMs: params.timeoutMs,
-            })
+        record.source === "npm" && npmTarget
+          ? await resolveNpmInstallSpecsForUpdateChannel(npmTarget)
           : undefined;
     } catch (error) {
       if (!(error instanceof NpmChannelResolutionError)) {

--- a/src/plugins/update-source.ts
+++ b/src/plugins/update-source.ts
@@ -444,33 +444,38 @@ export function isTrustedSourceLinkedOfficialBridgeNpmInstall(params: {
   return Boolean(officialPackageName && requestedPackageName === officialPackageName);
 }
 
-export async function resolveNpmUpdateSpecs(params: {
+/** Shares recorded target and catalog replacement precedence with update admission. */
+export function resolveNpmUpdateTarget(params: {
   record: PluginInstallRecord;
+  trustedOfficialInstall?: ReturnType<
+    typeof officialInstallRecords.resolveTrustedSourceLinkedOfficialNpmInstall
+  >;
   specOverride?: string;
-  officialSpecOverride?: string;
+  syncOfficialPluginInstalls?: boolean;
   updateChannel?: UpdateChannel;
-  officialPackageName?: string;
   coreVersion?: string;
   timeoutMs?: number;
-}): Promise<{
-  installSpec?: string;
-  recordSpec?: string;
-  fallbackSpec?: string;
-  fallbackLabel?: string;
-  npmResolution?: NpmSpecResolution;
-  channelReason?: "tag-behind-latest";
-}> {
-  const recordSpec = params.specOverride ?? params.record.spec ?? params.officialSpecOverride;
-  if (!recordSpec) {
-    return {};
-  }
-  return resolveNpmInstallSpecsForUpdateChannel({
-    spec: recordSpec,
-    updateChannel: params.updateChannel,
-    officialPackageName: params.officialPackageName,
-    coreVersion: params.coreVersion,
-    timeoutMs: params.timeoutMs,
-  });
+}) {
+  const official = params.trustedOfficialInstall;
+  const specOverride =
+    params.specOverride ??
+    (official?.replacementPluginId || official?.replaceNpmPackage ? official.npmSpec : undefined);
+  const spec =
+    specOverride ??
+    params.record.spec ??
+    (params.syncOfficialPluginInstalls ? official?.npmSpec : undefined);
+  return {
+    specOverride,
+    target: spec
+      ? {
+          spec,
+          updateChannel: params.updateChannel,
+          officialPackageName: resolveNpmSpecPackageName(official?.npmSpec),
+          coreVersion: params.coreVersion,
+          timeoutMs: params.timeoutMs,
+        }
+      : undefined,
+  };
 }
 
 export function resolveClawHubUpdateSpecs(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators updating a package installation could lose the serving Gateway when an enabled configured npm plugin had no package available for the selected core version. The missing target was discovered only after core activation, when plugin synchronization or repair tried to fetch it.

## Why This Change Was Made

The package update flow in `src/cli/update-cli/update-command-execution.ts` now performs metadata-only plugin admission alongside database/service inspection, before `prepareMutableUpdate` or service stop. Unavailable versions and registry failures produce the typed `plugin-target-unavailable` refusal, with plugin identity, required package target, registry error, and recovery guidance. Dry-run and managed/RPC updates use the existing failure-reporting fields.

The target must match final plugin convergence: `src/plugins/install-channel-specs.ts` owns channel/version selection, while `src/commands/doctor/shared/missing-configured-plugin-install.install.ts` can replace an old runtime pin with the target release cohort during admitted stale-runtime repair. The change extracts that existing repair/source decision and generic npm update target precedence for reuse by the preflight. The shared inventory and refusal reporting account for most of the roughly 300 net added production lines; no registry transport or selection policy is replaced. Beta uses the existing beta/latest reads and reuses the selected metadata.

## User Impact

The old Gateway remains available when required plugin metadata cannot be resolved. The preflight performs no package installation or configuration writes and runs before mutable update preparation. Disabled, bundled, path-installed, and local-artifact plugins do not trigger npm metadata requests. Updating and troubleshooting docs explain retrying, selecting an older available target, or disabling the affected plugin. A core package spec with an unknown version is also refused when enabled npm plugins need admission; use an exact registry version in that case.

The readiness refusal in `src/commands/doctor-config-preflight-plugin-verification.ts` is unchanged. Metadata availability does not reserve tarballs or guarantee that the registry remains available later in the update.

## Evidence

- Reported AWS reproduction: an npm installation on 2026.9.1 with the Codex and Brave plugins updated to a build versioned 2026.9.3. Core installation and Doctor completed, then `@openclaw/codex@2026.9.3` was unavailable. Gateway readiness refused and systemd entered a restart loop. This PR adds local boundary proof; it does not claim a new live Gateway campaign.
- Both new refusal regressions fail against the original execution code because it returns `status: ok`; they pass with preflight admission.
- `pnpm test src/cli/update-cli/update-command-execution.test.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/plugins/update.test.ts src/cli/update-cli.test.ts` — 744 tests passed across four files.
- After adding the post-registry configuration fence, `pnpm test src/cli/update-cli/update-command-execution.test.ts` — 9 tests passed. The new configuration-drift regression failed before that fence because mutable preparation had already run.
- `pnpm check:changed` — passed, including formatting, core/test type checks, lint, unused exports, and architecture guards.
- Independent review through P2 is clean after fixing configuration revalidation during registry awaits. The final lint cleanup is behavior-preserving.
