### PR TITLE
refactor(config): share group policy evaluation

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2533,7 +2533,7 @@ src/config/doc-baseline.ts	8
 src/config/docs-config-examples.ts	1
 src/config/future-version-guard.ts	2
 src/config/gateway-dispatch-config.ts	2
-src/config/group-policy.ts	2
+src/config/group-policy.ts	1
 src/config/implicit-mentions.ts	1
 src/config/includes-scan.ts	1
 src/config/io.audit.ts	3

--- a/src/config/channel-groups.ts
+++ b/src/config/channel-groups.ts
@@ -1,0 +1,39 @@
+import type { ChannelId } from "../channels/plugins/channel-id.types.js";
+import { normalizeAccountId } from "../routing/session-key.js";
+import { resolveMergedAccountConfig } from "./channel-account-config.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
+import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
+
+export type ChannelGroupConfig = {
+  requireMention?: boolean;
+  ingest?: boolean;
+  tools?: GroupToolPolicyConfig;
+  toolsBySender?: GroupToolPolicyBySenderConfig;
+};
+
+export type ChannelGroups = Record<string, ChannelGroupConfig>;
+
+export function resolveChannelGroups(
+  cfg: OpenClawConfig,
+  channel: ChannelId,
+  accountId?: string | null,
+): ChannelGroups | undefined {
+  const normalizedAccountId = normalizeAccountId(accountId);
+  const channelConfig:
+    | {
+        accounts?: Record<string, { groups?: ChannelGroups }>;
+        groups?: ChannelGroups;
+      }
+    | undefined = cfg.channels?.[channel];
+  if (!channelConfig) {
+    return undefined;
+  }
+  // Single-account empty maps inherit; in multi-account setups they opt out.
+  return resolveMergedAccountConfig({
+    channelConfig,
+    accounts: channelConfig.accounts,
+    accountId: normalizedAccountId,
+    inheritEmptyKeys:
+      Object.keys(channelConfig.accounts ?? {}).length > 1 ? {} : { groups: "object" },
+  }).groups;
+}

--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -1,29 +1,25 @@
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { ChannelId } from "../channels/plugins/channel-id.types.js";
-import { createDedupeCache } from "../infra/dedupe.js";
 import { resolveAccountEntry } from "../routing/account-lookup.js";
 import { normalizeAccountId } from "../routing/session-key.js";
-import { normalizeMessageChannel } from "../utils/message-channel-core.js";
-import { resolveMergedAccountConfig } from "./channel-account-config.js";
-import type { OpenClawConfig } from "./types.openclaw.js";
 import {
-  parseToolsBySenderTypedKey,
-  type GroupToolPolicyBySenderConfig,
-  type GroupToolPolicyConfig,
-  type ToolsBySenderKeyType,
-} from "./types.tools.js";
+  resolveChannelGroups,
+  type ChannelGroupConfig,
+  type ChannelGroups,
+} from "./channel-groups.js";
+import {
+  resolveScopeRequireMention,
+  resolveScopeToolsPolicy,
+  type ScopeNode,
+} from "./group-scope-tree.js";
+import type { GroupToolPolicySender } from "./tools-by-sender.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
+import type { GroupToolPolicyConfig } from "./types.tools.js";
+
+export { resolveChannelGroups } from "./channel-groups.js";
+export { resolveToolsBySender } from "./tools-by-sender.js";
 
 type GroupPolicyChannel = ChannelId;
-
-type ChannelGroupConfig = {
-  requireMention?: boolean;
-  ingest?: boolean;
-  tools?: GroupToolPolicyConfig;
-  toolsBySender?: GroupToolPolicyBySenderConfig;
-};
 
 export type ChannelGroupPolicy = {
   allowlistEnabled: boolean;
@@ -31,8 +27,6 @@ export type ChannelGroupPolicy = {
   groupConfig?: ChannelGroupConfig;
   defaultConfig?: ChannelGroupConfig;
 };
-
-type ChannelGroups = Record<string, ChannelGroupConfig>;
 
 function resolveChannelGroupConfig(
   groups: ChannelGroups | undefined,
@@ -57,304 +51,6 @@ function resolveChannelGroupConfig(
     return undefined;
   }
   return groups[matchedKey];
-}
-
-type GroupToolPolicySender = {
-  /** Skip sender-specific overlays for trusted non-ingress executions. */
-  senderPolicyMode?: "always" | "never";
-  messageProvider?: string | null;
-  senderId?: string | null;
-  senderName?: string | null;
-  senderUsername?: string | null;
-  senderE164?: string | null;
-};
-
-type SenderKeyType = ToolsBySenderKeyType;
-type CompiledSenderPolicy = {
-  buckets: SenderPolicyBuckets;
-  wildcard?: GroupToolPolicyConfig;
-};
-
-const MAX_WARNED_LEGACY_TOOLS_BY_SENDER_KEYS = 4096;
-// Warning state spans fresh config snapshots; bounding it means evicted legacy keys can re-warn.
-const warnedLegacyToolsBySenderKeys = createDedupeCache({
-  ttlMs: 0,
-  maxSize: MAX_WARNED_LEGACY_TOOLS_BY_SENDER_KEYS,
-});
-const compiledToolsBySenderCache = new WeakMap<
-  GroupToolPolicyBySenderConfig,
-  CompiledSenderPolicy
->();
-
-type ParsedSenderPolicyKey =
-  | { kind: "wildcard" }
-  | { kind: "typed"; type: SenderKeyType; key: string };
-
-type SenderPolicyBuckets = Record<ToolsBySenderKeyType, Map<string, GroupToolPolicyConfig>>;
-
-function normalizeSenderKey(
-  value: string,
-  options: {
-    stripLeadingAt?: boolean;
-  } = {},
-): string {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return "";
-  }
-  const withoutAt = options.stripLeadingAt && trimmed.startsWith("@") ? trimmed.slice(1) : trimmed;
-  return normalizeLowercaseStringOrEmpty(withoutAt);
-}
-
-function normalizeTypedSenderKey(value: string, type: SenderKeyType): string {
-  if (type === "channel") {
-    return normalizeChannelSenderKey(value);
-  }
-  return normalizeSenderKey(value, {
-    stripLeadingAt: type === "username",
-  });
-}
-
-function normalizeSenderPolicyChannel(value: string | null | undefined): string {
-  const trimmed = normalizeOptionalString(value);
-  if (!trimmed) {
-    return "";
-  }
-  return normalizeMessageChannel(trimmed) ?? normalizeSenderKey(trimmed);
-}
-
-function normalizeChannelSenderKey(value: string): string {
-  const trimmed = value.trim();
-  const separatorIndex = trimmed.indexOf(":");
-  if (separatorIndex <= 0 || separatorIndex === trimmed.length - 1) {
-    return "";
-  }
-  const channel = normalizeSenderPolicyChannel(trimmed.slice(0, separatorIndex));
-  const senderId = normalizeTypedSenderKey(trimmed.slice(separatorIndex + 1), "id");
-  if (!channel || !senderId) {
-    return "";
-  }
-  return `${channel}:${senderId}`;
-}
-
-function normalizeLegacySenderKey(value: string): string {
-  return normalizeSenderKey(value, {
-    stripLeadingAt: true,
-  });
-}
-
-function warnLegacyToolsBySenderKey(rawKey: string) {
-  const trimmed = rawKey.trim();
-  if (!trimmed || warnedLegacyToolsBySenderKeys.check(trimmed)) {
-    return;
-  }
-  process.emitWarning(
-    `toolsBySender key "${trimmed}" is deprecated. Use explicit prefixes (channel:, id:, e164:, username:, name:). Legacy unprefixed keys are matched as id only.`,
-    {
-      type: "DeprecationWarning",
-      code: "OPENCLAW_TOOLS_BY_SENDER_UNTYPED_KEY",
-    },
-  );
-}
-
-function parseSenderPolicyKey(rawKey: string): ParsedSenderPolicyKey | undefined {
-  const trimmed = rawKey.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  if (trimmed === "*") {
-    return { kind: "wildcard" };
-  }
-  const typed = parseToolsBySenderTypedKey(trimmed);
-  if (typed) {
-    const key = normalizeTypedSenderKey(typed.value, typed.type);
-    if (!key) {
-      return undefined;
-    }
-    return {
-      kind: "typed",
-      type: typed.type,
-      key,
-    };
-  }
-
-  // Backward-compatible fallback: untyped keys now map to immutable sender IDs only.
-  warnLegacyToolsBySenderKey(trimmed);
-  const key = normalizeLegacySenderKey(trimmed);
-  if (!key) {
-    return undefined;
-  }
-  return {
-    kind: "typed",
-    type: "id",
-    key,
-  };
-}
-
-function createSenderPolicyBuckets(): SenderPolicyBuckets {
-  return {
-    channel: new Map<string, GroupToolPolicyConfig>(),
-    id: new Map<string, GroupToolPolicyConfig>(),
-    e164: new Map<string, GroupToolPolicyConfig>(),
-    username: new Map<string, GroupToolPolicyConfig>(),
-    name: new Map<string, GroupToolPolicyConfig>(),
-  };
-}
-
-function compileToolsBySenderPolicy(
-  toolsBySender: GroupToolPolicyBySenderConfig,
-): CompiledSenderPolicy | undefined {
-  const entries = Object.entries(toolsBySender);
-  if (entries.length === 0) {
-    return undefined;
-  }
-
-  const buckets = createSenderPolicyBuckets();
-  let wildcard: GroupToolPolicyConfig | undefined;
-  for (const [rawKey, policy] of entries) {
-    if (!policy) {
-      continue;
-    }
-    const parsed = parseSenderPolicyKey(rawKey);
-    if (!parsed) {
-      continue;
-    }
-    if (parsed.kind === "wildcard") {
-      wildcard = policy;
-      continue;
-    }
-    const bucket = buckets[parsed.type];
-    if (!bucket.has(parsed.key)) {
-      bucket.set(parsed.key, policy);
-    }
-  }
-
-  return { buckets, wildcard };
-}
-
-function resolveCompiledToolsBySenderPolicy(
-  toolsBySender: GroupToolPolicyBySenderConfig,
-): CompiledSenderPolicy | undefined {
-  const cached = compiledToolsBySenderCache.get(toolsBySender);
-  if (cached) {
-    return cached;
-  }
-  const compiled = compileToolsBySenderPolicy(toolsBySender);
-  if (!compiled) {
-    return undefined;
-  }
-  // Config is loaded once and treated as immutable; cache compiled sender policy by object identity.
-  compiledToolsBySenderCache.set(toolsBySender, compiled);
-  return compiled;
-}
-
-function normalizeCandidate(value: string | null | undefined, type: SenderKeyType): string {
-  const trimmed = normalizeOptionalString(value);
-  if (!trimmed) {
-    return "";
-  }
-  return normalizeTypedSenderKey(trimmed, type);
-}
-
-function normalizeSenderIdCandidates(value: string | null | undefined): string[] {
-  const trimmed = normalizeOptionalString(value);
-  if (!trimmed) {
-    return [];
-  }
-  const typed = normalizeTypedSenderKey(trimmed, "id");
-  const legacy = normalizeLegacySenderKey(trimmed);
-  if (!typed) {
-    return legacy ? [legacy] : [];
-  }
-  if (!legacy || legacy === typed) {
-    return [typed];
-  }
-  return [typed, legacy];
-}
-
-function matchToolsBySenderPolicy(
-  compiled: CompiledSenderPolicy,
-  params: GroupToolPolicySender,
-): GroupToolPolicyConfig | undefined {
-  const senderIdCandidates = normalizeSenderIdCandidates(params.senderId);
-  const channel = normalizeSenderPolicyChannel(params.messageProvider);
-  if (channel) {
-    for (const senderIdCandidate of senderIdCandidates) {
-      const match = compiled.buckets.channel.get(`${channel}:${senderIdCandidate}`);
-      if (match) {
-        return match;
-      }
-    }
-  }
-  for (const senderIdCandidate of senderIdCandidates) {
-    const match = compiled.buckets.id.get(senderIdCandidate);
-    if (match) {
-      return match;
-    }
-  }
-  const senderE164 = normalizeCandidate(params.senderE164, "e164");
-  if (senderE164) {
-    const match = compiled.buckets.e164.get(senderE164);
-    if (match) {
-      return match;
-    }
-  }
-  const senderUsername = normalizeCandidate(params.senderUsername, "username");
-  if (senderUsername) {
-    const match = compiled.buckets.username.get(senderUsername);
-    if (match) {
-      return match;
-    }
-  }
-  const senderName = normalizeCandidate(params.senderName, "name");
-  if (senderName) {
-    const match = compiled.buckets.name.get(senderName);
-    if (match) {
-      return match;
-    }
-  }
-  return compiled.wildcard;
-}
-
-export function resolveToolsBySender(
-  params: {
-    toolsBySender?: GroupToolPolicyBySenderConfig;
-  } & GroupToolPolicySender,
-): GroupToolPolicyConfig | undefined {
-  const toolsBySender = params.toolsBySender;
-  if (!toolsBySender) {
-    return undefined;
-  }
-  const compiled = resolveCompiledToolsBySenderPolicy(toolsBySender);
-  if (!compiled) {
-    return undefined;
-  }
-  return matchToolsBySenderPolicy(compiled, params);
-}
-
-export function resolveChannelGroups(
-  cfg: OpenClawConfig,
-  channel: GroupPolicyChannel,
-  accountId?: string | null,
-): ChannelGroups | undefined {
-  const normalizedAccountId = normalizeAccountId(accountId);
-  const channelConfig = cfg.channels?.[channel] as
-    | {
-        accounts?: Record<string, { groups?: ChannelGroups }>;
-        groups?: ChannelGroups;
-      }
-    | undefined;
-  if (!channelConfig) {
-    return undefined;
-  }
-  // Single-account empty maps inherit; in multi-account setups they opt out.
-  return resolveMergedAccountConfig({
-    channelConfig,
-    accounts: channelConfig.accounts,
-    accountId: normalizedAccountId,
-    inheritEmptyKeys:
-      Object.keys(channelConfig.accounts ?? {}).length > 1 ? {} : { groups: "object" },
-  }).groups;
 }
 
 /** Locate the authored map selected by the channel owner without changing its inheritance rules. */
@@ -448,6 +144,26 @@ export function resolveChannelGroupPolicy(params: {
   };
 }
 
+function buildSelectedGroupScope(
+  groupConfig: ChannelGroupConfig | undefined,
+  defaultConfig: ChannelGroupConfig | undefined,
+) {
+  // Flat lookup selects one whole entry, including an explicitly requested "*".
+  // Preserve its boolean/truthy fallback rules without changing native scope callers.
+  const project = (node: ChannelGroupConfig): ScopeNode => ({
+    requireMention: typeof node.requireMention === "boolean" ? node.requireMention : undefined,
+    tools: node.tools || undefined,
+    toolsBySender: node.toolsBySender,
+  });
+  return {
+    tree: {
+      scopes: groupConfig ? { selected: project(groupConfig) } : {},
+      defaults: defaultConfig ? project(defaultConfig) : undefined,
+    },
+    path: groupConfig ? ["selected"] : [],
+  };
+}
+
 export function resolveChannelGroupRequireMention(params: {
   cfg: OpenClawConfig;
   channel: GroupPolicyChannel;
@@ -458,28 +174,13 @@ export function resolveChannelGroupRequireMention(params: {
   configuredGroupDefaultsToNoMention?: boolean;
   overrideOrder?: "before-config" | "after-config";
 }): boolean {
-  const { requireMentionOverride, overrideOrder = "after-config" } = params;
   const { groupConfig, defaultConfig } = resolveChannelGroupPolicy(params);
-  const configMention =
-    typeof groupConfig?.requireMention === "boolean"
-      ? groupConfig.requireMention
-      : typeof defaultConfig?.requireMention === "boolean"
-        ? defaultConfig.requireMention
-        : undefined;
-
-  if (overrideOrder === "before-config" && typeof requireMentionOverride === "boolean") {
-    return requireMentionOverride;
-  }
-  if (typeof configMention === "boolean") {
-    return configMention;
-  }
-  if (overrideOrder !== "before-config" && typeof requireMentionOverride === "boolean") {
-    return requireMentionOverride;
-  }
-  if (params.configuredGroupDefaultsToNoMention && groupConfig) {
-    return false;
-  }
-  return true;
+  return resolveScopeRequireMention({
+    ...buildSelectedGroupScope(groupConfig, defaultConfig),
+    requireMentionOverride: params.requireMentionOverride,
+    overrideOrder: params.overrideOrder,
+    configuredScopeDefaultsToNoMention: params.configuredGroupDefaultsToNoMention,
+  });
 }
 
 export function resolveChannelGroupToolsPolicy(
@@ -509,40 +210,9 @@ export function resolveChannelGroupToolsPolicy(
       break;
     }
   }
-  const defaultConfig = groups?.["*"];
-  const groupSenderPolicy =
-    params.senderPolicyMode === "never"
-      ? undefined
-      : resolveToolsBySender({
-          toolsBySender: groupConfig?.toolsBySender,
-          messageProvider: params.messageProvider ?? params.channel,
-          senderId: params.senderId,
-          senderName: params.senderName,
-          senderUsername: params.senderUsername,
-          senderE164: params.senderE164,
-        });
-  if (groupSenderPolicy) {
-    return groupSenderPolicy;
-  }
-  if (groupConfig?.tools) {
-    return groupConfig.tools;
-  }
-  const defaultSenderPolicy =
-    params.senderPolicyMode === "never"
-      ? undefined
-      : resolveToolsBySender({
-          toolsBySender: defaultConfig?.toolsBySender,
-          messageProvider: params.messageProvider ?? params.channel,
-          senderId: params.senderId,
-          senderName: params.senderName,
-          senderUsername: params.senderUsername,
-          senderE164: params.senderE164,
-        });
-  if (defaultSenderPolicy) {
-    return defaultSenderPolicy;
-  }
-  if (defaultConfig?.tools) {
-    return defaultConfig.tools;
-  }
-  return undefined;
+  return resolveScopeToolsPolicy({
+    ...params,
+    ...buildSelectedGroupScope(groupConfig, groups?.["*"]),
+    messageProvider: params.messageProvider ?? params.channel,
+  });
 }

--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -11,6 +11,8 @@ import {
   resolveScopeRequireMention,
   resolveScopeToolsPolicy,
   type ScopeNode,
+  type ScopePath,
+  type ScopeTree,
 } from "./group-scope-tree.js";
 import type { GroupToolPolicySender } from "./tools-by-sender.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
@@ -147,7 +149,7 @@ export function resolveChannelGroupPolicy(params: {
 function buildSelectedGroupScope(
   groupConfig: ChannelGroupConfig | undefined,
   defaultConfig: ChannelGroupConfig | undefined,
-) {
+): { tree: ScopeTree; path: ScopePath } {
   // Flat lookup selects one whole entry, including an explicitly requested "*".
   // Preserve its boolean/truthy fallback rules without changing native scope callers.
   const project = (node: ChannelGroupConfig): ScopeNode => ({

--- a/src/config/group-scope-tree.test.ts
+++ b/src/config/group-scope-tree.test.ts
@@ -1,7 +1,11 @@
 // Verifies canonical group scope precedence and sender policy resolution.
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "./config.js";
-import { resolveChannelGroupRequireMention, resolveToolsBySender } from "./group-policy.js";
+import {
+  resolveChannelGroupRequireMention,
+  resolveChannelGroupToolsPolicy,
+  resolveToolsBySender,
+} from "./group-policy.js";
 import {
   resolveScopeKeyCaseInsensitive,
   resolveScopeIntroHint,
@@ -90,52 +94,60 @@ describe("resolveScopeRequireMention", () => {
   it.each([
     {
       name: "no override",
+      expected: false,
       configured: false,
       override: undefined,
       overrideOrder: undefined,
     },
     {
       name: "before-config override",
+      expected: true,
       configured: false,
       override: true,
       overrideOrder: "before-config" as const,
     },
     {
       name: "after-config override",
+      expected: false,
       configured: false,
       override: true,
       overrideOrder: "after-config" as const,
     },
     {
       name: "after-config fallback override",
+      expected: false,
       configured: undefined,
       override: false,
       overrideOrder: "after-config" as const,
     },
-  ])("matches flat group-policy behavior: $name", ({ configured, override, overrideOrder }) => {
-    const node = typeof configured === "boolean" ? { requireMention: configured } : {};
-    const tree: ScopeTree = { scopes: { room: node } };
-    const cfg = {
-      channels: { whatsapp: { groups: { room: node } } },
-    } as OpenClawConfig;
+  ])(
+    "matches flat group-policy behavior: $name",
+    ({ configured, override, overrideOrder, expected }) => {
+      const node = typeof configured === "boolean" ? { requireMention: configured } : {};
+      const tree: ScopeTree = { scopes: { room: node } };
+      const cfg = {
+        channels: { whatsapp: { groups: { room: node } } },
+      } as OpenClawConfig;
 
-    expect(
-      resolveScopeRequireMention({
-        tree,
-        path: ["room"],
-        requireMentionOverride: override,
-        overrideOrder,
-      }),
-    ).toBe(
-      resolveChannelGroupRequireMention({
-        cfg,
-        channel: "whatsapp",
-        groupId: "room",
-        requireMentionOverride: override,
-        overrideOrder,
-      }),
-    );
-  });
+      expect(
+        resolveScopeRequireMention({
+          tree,
+          path: ["room"],
+          requireMentionOverride: override,
+          overrideOrder,
+        }),
+      ).toBe(expected);
+      expect(
+        resolveChannelGroupRequireMention({
+          cfg,
+          channel: "whatsapp",
+          groupId: "room",
+          requireMentionOverride: override,
+          overrideOrder,
+        }),
+      ).toBe(expected);
+    },
+  );
 
   it("defaults configured-but-unset scopes to no mention only when requested", () => {
     const tree: ScopeTree = { scopes: { configured: {} } };
@@ -327,5 +339,103 @@ describe("resolveScopeIntroHint", () => {
 
     expect(resolveScopeIntroHint({ tree, path: ["team", "channel", "thread"] })).toBe("thread");
     expect(resolveScopeIntroHint({ tree, path: ["missing"] })).toBe("default");
+  });
+});
+
+describe("flat group policy adapters", () => {
+  it("preserves flat fallback for unvalidated values without changing scope resolution", () => {
+    const room = { requireMention: true, tools: { allow: ["read"] } };
+    Object.assign(room, { requireMention: "invalid", tools: false });
+    const defaults = { requireMention: false, tools: { deny: ["exec"] } };
+    const cfg = {
+      channels: { signal: { groups: { room, "*": defaults } } },
+    } satisfies OpenClawConfig;
+    expect(resolveChannelGroupRequireMention({ cfg, channel: "signal", groupId: "room" })).toBe(
+      false,
+    );
+    expect(resolveChannelGroupToolsPolicy({ cfg, channel: "signal", groupId: "room" })).toEqual(
+      defaults.tools,
+    );
+    const scope = { tree: { scopes: { room }, defaults }, path: ["room"] };
+    expect(resolveScopeRequireMention(scope)).toBe(true);
+    expect(resolveScopeToolsPolicy(scope)).toBe(false);
+  });
+
+  it.each([
+    { groupId: " * ", expected: false },
+    { groupId: " Room ", expected: false },
+    { groupId: " ROOM ", expected: false },
+    { groupId: "missing", expected: true },
+  ])("preserves configured-group identity for $groupId", ({ groupId, expected }) => {
+    const cfg = {
+      channels: { signal: { groups: { "*": {}, Room: {} } } },
+    } satisfies OpenClawConfig;
+    expect(
+      resolveChannelGroupRequireMention({
+        cfg,
+        channel: "signal",
+        groupId,
+        groupIdCaseInsensitive: true,
+        configuredGroupDefaultsToNoMention: true,
+      }),
+    ).toBe(expected);
+  });
+
+  it.each([
+    { groupId: " room ", expected: "fallback" },
+    { groupId: " ROOM ", expected: "fallback" },
+    { groupId: "missing", expected: "later" },
+    { groupId: " * ", expected: "fallback" },
+  ])("selects one group before resolving tools for $groupId", ({ groupId, expected }) => {
+    const cfg = {
+      channels: {
+        signal: {
+          groups: {
+            room: {},
+            later: { tools: { allow: ["later"] } },
+            "*": { tools: { allow: ["fallback"] } },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    expect(
+      resolveChannelGroupToolsPolicy({
+        cfg,
+        channel: "signal",
+        groupId,
+        groupIdCandidates: ["later"],
+        groupIdCaseInsensitive: true,
+      }),
+    ).toEqual({ allow: [expected] });
+  });
+
+  it.each([
+    { messageProvider: undefined, expected: "channel" },
+    { messageProvider: null, expected: "channel" },
+    { messageProvider: "", expected: "id" },
+  ])("preserves provider defaulting for $messageProvider", ({ messageProvider, expected }) => {
+    const cfg = {
+      channels: {
+        signal: {
+          groups: {
+            room: {
+              toolsBySender: {
+                "channel:signal:alice": { allow: ["channel"] },
+                "id:alice": { allow: ["id"] },
+              },
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    expect(
+      resolveChannelGroupToolsPolicy({
+        cfg,
+        channel: "signal",
+        groupId: "room",
+        senderId: "alice",
+        messageProvider,
+      }),
+    ).toEqual({ allow: [expected] });
   });
 });

--- a/src/config/group-scope-tree.ts
+++ b/src/config/group-scope-tree.ts
@@ -1,7 +1,8 @@
 // Resolves canonical group policy scopes prepared by channel plugins.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { ChannelId } from "../channels/plugins/channel-id.types.js";
-import { resolveChannelGroups, resolveToolsBySender } from "./group-policy.js";
+import { resolveChannelGroups } from "./channel-groups.js";
+import { resolveToolsBySender } from "./tools-by-sender.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
 

--- a/src/config/tools-by-sender.ts
+++ b/src/config/tools-by-sender.ts
@@ -1,0 +1,285 @@
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
+import { createDedupeCache } from "../infra/dedupe.js";
+import { normalizeMessageChannel } from "../utils/message-channel-core.js";
+import {
+  parseToolsBySenderTypedKey,
+  type GroupToolPolicyBySenderConfig,
+  type GroupToolPolicyConfig,
+  type ToolsBySenderKeyType,
+} from "./types.tools.js";
+
+export type GroupToolPolicySender = {
+  /** Skip sender-specific overlays for trusted non-ingress executions. */
+  senderPolicyMode?: "always" | "never";
+  messageProvider?: string | null;
+  senderId?: string | null;
+  senderName?: string | null;
+  senderUsername?: string | null;
+  senderE164?: string | null;
+};
+
+type SenderKeyType = ToolsBySenderKeyType;
+type CompiledSenderPolicy = {
+  buckets: SenderPolicyBuckets;
+  wildcard?: GroupToolPolicyConfig;
+};
+
+const MAX_WARNED_LEGACY_TOOLS_BY_SENDER_KEYS = 4096;
+// Warning state spans fresh config snapshots; bounding it means evicted legacy keys can re-warn.
+const warnedLegacyToolsBySenderKeys = createDedupeCache({
+  ttlMs: 0,
+  maxSize: MAX_WARNED_LEGACY_TOOLS_BY_SENDER_KEYS,
+});
+const compiledToolsBySenderCache = new WeakMap<
+  GroupToolPolicyBySenderConfig,
+  CompiledSenderPolicy
+>();
+
+type ParsedSenderPolicyKey =
+  | { kind: "wildcard" }
+  | { kind: "typed"; type: SenderKeyType; key: string };
+
+type SenderPolicyBuckets = Record<ToolsBySenderKeyType, Map<string, GroupToolPolicyConfig>>;
+
+function normalizeSenderKey(
+  value: string,
+  options: {
+    stripLeadingAt?: boolean;
+  } = {},
+): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const withoutAt = options.stripLeadingAt && trimmed.startsWith("@") ? trimmed.slice(1) : trimmed;
+  return normalizeLowercaseStringOrEmpty(withoutAt);
+}
+
+function normalizeTypedSenderKey(value: string, type: SenderKeyType): string {
+  if (type === "channel") {
+    return normalizeChannelSenderKey(value);
+  }
+  return normalizeSenderKey(value, {
+    stripLeadingAt: type === "username",
+  });
+}
+
+function normalizeSenderPolicyChannel(value: string | null | undefined): string {
+  const trimmed = normalizeOptionalString(value);
+  if (!trimmed) {
+    return "";
+  }
+  return normalizeMessageChannel(trimmed) ?? normalizeSenderKey(trimmed);
+}
+
+function normalizeChannelSenderKey(value: string): string {
+  const trimmed = value.trim();
+  const separatorIndex = trimmed.indexOf(":");
+  if (separatorIndex <= 0 || separatorIndex === trimmed.length - 1) {
+    return "";
+  }
+  const channel = normalizeSenderPolicyChannel(trimmed.slice(0, separatorIndex));
+  const senderId = normalizeTypedSenderKey(trimmed.slice(separatorIndex + 1), "id");
+  if (!channel || !senderId) {
+    return "";
+  }
+  return `${channel}:${senderId}`;
+}
+
+function normalizeLegacySenderKey(value: string): string {
+  return normalizeSenderKey(value, {
+    stripLeadingAt: true,
+  });
+}
+
+function warnLegacyToolsBySenderKey(rawKey: string) {
+  const trimmed = rawKey.trim();
+  if (!trimmed || warnedLegacyToolsBySenderKeys.check(trimmed)) {
+    return;
+  }
+  process.emitWarning(
+    `toolsBySender key "${trimmed}" is deprecated. Use explicit prefixes (channel:, id:, e164:, username:, name:). Legacy unprefixed keys are matched as id only.`,
+    {
+      type: "DeprecationWarning",
+      code: "OPENCLAW_TOOLS_BY_SENDER_UNTYPED_KEY",
+    },
+  );
+}
+
+function parseSenderPolicyKey(rawKey: string): ParsedSenderPolicyKey | undefined {
+  const trimmed = rawKey.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed === "*") {
+    return { kind: "wildcard" };
+  }
+  const typed = parseToolsBySenderTypedKey(trimmed);
+  if (typed) {
+    const key = normalizeTypedSenderKey(typed.value, typed.type);
+    if (!key) {
+      return undefined;
+    }
+    return {
+      kind: "typed",
+      type: typed.type,
+      key,
+    };
+  }
+
+  // Backward-compatible fallback: untyped keys now map to immutable sender IDs only.
+  warnLegacyToolsBySenderKey(trimmed);
+  const key = normalizeLegacySenderKey(trimmed);
+  if (!key) {
+    return undefined;
+  }
+  return {
+    kind: "typed",
+    type: "id",
+    key,
+  };
+}
+
+function createSenderPolicyBuckets(): SenderPolicyBuckets {
+  return {
+    channel: new Map<string, GroupToolPolicyConfig>(),
+    id: new Map<string, GroupToolPolicyConfig>(),
+    e164: new Map<string, GroupToolPolicyConfig>(),
+    username: new Map<string, GroupToolPolicyConfig>(),
+    name: new Map<string, GroupToolPolicyConfig>(),
+  };
+}
+
+function compileToolsBySenderPolicy(
+  toolsBySender: GroupToolPolicyBySenderConfig,
+): CompiledSenderPolicy | undefined {
+  const entries = Object.entries(toolsBySender);
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  const buckets = createSenderPolicyBuckets();
+  let wildcard: GroupToolPolicyConfig | undefined;
+  for (const [rawKey, policy] of entries) {
+    if (!policy) {
+      continue;
+    }
+    const parsed = parseSenderPolicyKey(rawKey);
+    if (!parsed) {
+      continue;
+    }
+    if (parsed.kind === "wildcard") {
+      wildcard = policy;
+      continue;
+    }
+    const bucket = buckets[parsed.type];
+    if (!bucket.has(parsed.key)) {
+      bucket.set(parsed.key, policy);
+    }
+  }
+
+  return { buckets, wildcard };
+}
+
+function resolveCompiledToolsBySenderPolicy(
+  toolsBySender: GroupToolPolicyBySenderConfig,
+): CompiledSenderPolicy | undefined {
+  const cached = compiledToolsBySenderCache.get(toolsBySender);
+  if (cached) {
+    return cached;
+  }
+  const compiled = compileToolsBySenderPolicy(toolsBySender);
+  if (!compiled) {
+    return undefined;
+  }
+  // Config is loaded once and treated as immutable; cache compiled sender policy by object identity.
+  compiledToolsBySenderCache.set(toolsBySender, compiled);
+  return compiled;
+}
+
+function normalizeCandidate(value: string | null | undefined, type: SenderKeyType): string {
+  const trimmed = normalizeOptionalString(value);
+  if (!trimmed) {
+    return "";
+  }
+  return normalizeTypedSenderKey(trimmed, type);
+}
+
+function normalizeSenderIdCandidates(value: string | null | undefined): string[] {
+  const trimmed = normalizeOptionalString(value);
+  if (!trimmed) {
+    return [];
+  }
+  const typed = normalizeTypedSenderKey(trimmed, "id");
+  const legacy = normalizeLegacySenderKey(trimmed);
+  if (!typed) {
+    return legacy ? [legacy] : [];
+  }
+  if (!legacy || legacy === typed) {
+    return [typed];
+  }
+  return [typed, legacy];
+}
+
+function matchToolsBySenderPolicy(
+  compiled: CompiledSenderPolicy,
+  params: GroupToolPolicySender,
+): GroupToolPolicyConfig | undefined {
+  const senderIdCandidates = normalizeSenderIdCandidates(params.senderId);
+  const channel = normalizeSenderPolicyChannel(params.messageProvider);
+  if (channel) {
+    for (const senderIdCandidate of senderIdCandidates) {
+      const match = compiled.buckets.channel.get(`${channel}:${senderIdCandidate}`);
+      if (match) {
+        return match;
+      }
+    }
+  }
+  for (const senderIdCandidate of senderIdCandidates) {
+    const match = compiled.buckets.id.get(senderIdCandidate);
+    if (match) {
+      return match;
+    }
+  }
+  const senderE164 = normalizeCandidate(params.senderE164, "e164");
+  if (senderE164) {
+    const match = compiled.buckets.e164.get(senderE164);
+    if (match) {
+      return match;
+    }
+  }
+  const senderUsername = normalizeCandidate(params.senderUsername, "username");
+  if (senderUsername) {
+    const match = compiled.buckets.username.get(senderUsername);
+    if (match) {
+      return match;
+    }
+  }
+  const senderName = normalizeCandidate(params.senderName, "name");
+  if (senderName) {
+    const match = compiled.buckets.name.get(senderName);
+    if (match) {
+      return match;
+    }
+  }
+  return compiled.wildcard;
+}
+
+export function resolveToolsBySender(
+  params: {
+    toolsBySender?: GroupToolPolicyBySenderConfig;
+  } & GroupToolPolicySender,
+): GroupToolPolicyConfig | undefined {
+  const toolsBySender = params.toolsBySender;
+  if (!toolsBySender) {
+    return undefined;
+  }
+  const compiled = resolveCompiledToolsBySenderPolicy(toolsBySender);
+  if (!compiled) {
+    return undefined;
+  }
+  return matchToolsBySenderPolicy(compiled, params);
+}


### PR DESCRIPTION
## What Problem This Solves

Flat group configuration and channel scope trees maintain separate mention and tool-policy precedence evaluators. Keeping both implementations aligned risks changes reaching only some channel paths.

## Why This Change Was Made

Route the existing flat APIs through the scope-tree evaluator after selecting one group. Preserve explicit wildcard candidates, whitespace/case matching, first-match selection, invalid-value fallback, and nullish provider defaulting. Move the unchanged sender matcher/cache and account-group lookup into dependency modules to avoid a cycle; preserve all existing public exports.

The larger diff is mostly two unchanged implementation moves. The actual precedence branches now have one owner, with no new policy parameters or SDK exports. This is part of the maintainer-requested channel de-duplication campaign.

## User Impact

No intended user-visible change. Config layouts, account inheritance, sender precedence, and mention defaults remain the same.

## Evidence

- `node scripts/run-vitest.mjs src/config/group-policy src/config/group-scope-tree extensions/discord/src/group-policy extensions/slack/src/group-policy extensions/telegram/src/group-policy extensions/whatsapp/src/group-policy`: 96 tests passed across five shards.
- Final `node scripts/run-vitest.mjs src/config/group-scope-tree`: 35 tests passed after simplifying the invalid-config fixture.
- Two isolated P0–P2 autoreviews: zero actionable findings, including the final typed-binding change.
- Rebased focused suite: all 96 tests passed again in 27.60s.
- Fresh isolated P0–P2 autoreview after the authorized shrink: zero actionable findings.
- Applied only the maintainer-approved assertion-baseline shrink, `group-policy.ts` 2 → 1. No allowance grows; the removed assertion was replaced with a typed binding.
- The core typecheck initially exposed an inferred empty-scope union mismatch (two TS2345 diagnostics). An explicit return annotation using the existing ScopeTree/ScopePath types corrected it without a cast or runtime change.
- `node scripts/check-changed.mjs`: passed, including core/test types, core/script lint, exact ratchet shrink, zero unused exports, and zero runtime import cycles.
- `pnpm build`: passed in 12m 55.6s, including 152 public SDK subpaths, 90 external plugins, and native loads of 53 built control-plane modules.
- Latest isolated P0–P2 autoreview: zero actionable findings on the staged final candidate.
- Required exact-head CI [34087859211](https://github.com/openclaw/openclaw/actions/runs/34087859211) passed on `fc9ea98ea1c7780f79c1f79ea54b9d7b227e4654`. Earlier skipped draft runs are not proof.

Known gap: focused tests exercise the policy boundary with synthetic configuration. No live channel account or external send was used.
