### PR TITLE
fix(cli): preserve whitespace in skills JSON output

### DIFF
--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -100,6 +100,8 @@ default agent.
 
 The skills table renders horizontal tabs as single spaces so descriptions
 stay aligned with the neighboring columns.
+JSON output preserves tabs and line endings in descriptions and paths as escaped
+characters.
 
 `info` resolves an exact skill name before a metadata key. Key, case-insensitive,
 and separator-normalized matches must identify one skill; ambiguous selectors

--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -68,7 +68,11 @@ const REMAINING_ESC_SEQUENCE_REGEX = new RegExp(
   String.raw`\u001b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])`,
   "g",
 );
-const JSON_CONTROL_CHAR_REGEX = new RegExp(String.raw`[\u0000-\u001f\u007f-\u009f]`, "g");
+// JSON escapes tabs and line endings; preserve their meaning in descriptions and paths.
+const JSON_CONTROL_CHAR_REGEX = new RegExp(
+  String.raw`[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]`,
+  "g",
+);
 
 function sanitizeJsonString(value: string): string {
   return stripAnsi(value)
@@ -76,8 +80,12 @@ function sanitizeJsonString(value: string): string {
     .replace(JSON_CONTROL_CHAR_REGEX, "");
 }
 
-function sanitizeJsonValue(_key: string, value: unknown): unknown {
-  return typeof value === "string" ? sanitizeJsonString(value) : value;
+function formatSkillsJson(value: unknown): string {
+  return JSON.stringify(
+    value,
+    (_key, entry: unknown) => (typeof entry === "string" ? sanitizeJsonString(entry) : entry),
+    2,
+  );
 }
 function formatSkillName(skill: SkillStatusEntry): string {
   const emoji = normalizeSkillEmoji(skill.emoji);
@@ -106,7 +114,7 @@ export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOpti
   const skills = opts.eligible ? report.skills.filter(isReadyForAgent) : report.skills;
 
   if (opts.json) {
-    const jsonReport = {
+    return formatSkillsJson({
       workspaceDir: report.workspaceDir,
       managedSkillsDir: report.managedSkillsDir,
       skills: skills.map((s) => ({
@@ -126,8 +134,7 @@ export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOpti
         homepage: s.homepage,
         missing: s.missing,
       })),
-    };
-    return JSON.stringify(jsonReport, sanitizeJsonValue, 2);
+    });
   }
 
   if (skills.length === 0) {
@@ -183,14 +190,10 @@ export function formatSkillInfo(
 
   if (!skill) {
     if (opts.json) {
-      return JSON.stringify(
-        {
-          ...formatCliJsonFailure(`Skill "${requestedName}" not found.`),
-          skill: requestedName,
-        },
-        sanitizeJsonValue,
-        2,
-      );
+      return formatSkillsJson({
+        ...formatCliJsonFailure(`Skill "${requestedName}" not found.`),
+        skill: requestedName,
+      });
     }
     const safeRequestedName = sanitizeJsonString(sanitizeForLog(requestedName));
     return appendClawHubHint(
@@ -200,7 +203,7 @@ export function formatSkillInfo(
   }
 
   if (opts.json) {
-    return JSON.stringify(skill, sanitizeJsonValue, 2);
+    return formatSkillsJson(skill);
   }
 
   const lines: string[] = [];
@@ -309,42 +312,38 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
   const agentId = report.agentId ?? opts.agent;
 
   if (opts.json) {
-    return JSON.stringify(
-      {
-        agentId,
-        agentSkillFilter: report.agentSkillFilter,
-        workspaceDir: report.workspaceDir,
-        managedSkillsDir: report.managedSkillsDir,
-        summary: {
-          total: report.skills.length,
-          eligible: eligible.length,
-          modelVisible: modelVisible.length,
-          commandVisible: commandVisible.length,
-          disabled: disabled.length,
-          blocked: blocked.length,
-          agentFiltered: agentFiltered.length,
-          notInjected: promptHidden.length,
-          missingRequirements: missingReqs.length,
-        },
-        eligible: eligible.map((s) => s.name),
-        modelVisible: modelVisible.map((s) => s.name),
-        commandVisible: commandVisible.map((s) => s.name),
-        disabled: disabled.map((s) => s.name),
-        blocked: blocked.map((s) => s.name),
-        agentFiltered: agentFiltered.map((s) => s.name),
-        notInjected: promptHidden.map((s) => ({
-          name: s.name,
-          reason: "disable-model-invocation",
-        })),
-        missingRequirements: missingReqs.map((s) => ({
-          name: s.name,
-          missing: s.missing,
-          install: s.install,
-        })),
+    return formatSkillsJson({
+      agentId,
+      agentSkillFilter: report.agentSkillFilter,
+      workspaceDir: report.workspaceDir,
+      managedSkillsDir: report.managedSkillsDir,
+      summary: {
+        total: report.skills.length,
+        eligible: eligible.length,
+        modelVisible: modelVisible.length,
+        commandVisible: commandVisible.length,
+        disabled: disabled.length,
+        blocked: blocked.length,
+        agentFiltered: agentFiltered.length,
+        notInjected: promptHidden.length,
+        missingRequirements: missingReqs.length,
       },
-      sanitizeJsonValue,
-      2,
-    );
+      eligible: eligible.map((s) => s.name),
+      modelVisible: modelVisible.map((s) => s.name),
+      commandVisible: commandVisible.map((s) => s.name),
+      disabled: disabled.map((s) => s.name),
+      blocked: blocked.map((s) => s.name),
+      agentFiltered: agentFiltered.map((s) => s.name),
+      notInjected: promptHidden.map((s) => ({
+        name: s.name,
+        reason: "disable-model-invocation",
+      })),
+      missingRequirements: missingReqs.map((s) => ({
+        name: s.name,
+        missing: s.missing,
+        install: s.install,
+      })),
+    });
   }
 
   const lines: string[] = [];

--- a/src/cli/skills-cli.formatting.test.ts
+++ b/src/cli/skills-cli.formatting.test.ts
@@ -143,6 +143,28 @@ describe("skills-cli (e2e)", () => {
     },
   );
 
+  it("preserves description and path whitespace in skills JSON output", async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(tempWorkspaceDir, "json-whitespace-"));
+    const managedSkillsDir = path.join(workspaceDir, "managed\tlocal");
+    const description = "First paragraph.\nSecond\tcolumn.\r\nThird paragraph.";
+    await writeWorkspaceSkills(workspaceDir, [
+      { name: "json-whitespace", description: JSON.stringify(description) },
+    ]);
+    const report = buildWorkspaceSkillStatus(workspaceDir, {
+      managedSkillsDir,
+      config: { plugins: { enabled: false } },
+    });
+    expect(report.skills[0]?.description).toBe(description);
+
+    const list = JSON.parse(formatSkillsList(report, { json: true }));
+    const info = JSON.parse(formatSkillInfo(report, "json-whitespace", { json: true }));
+    const check = JSON.parse(formatSkillsCheck(report, { json: true }));
+    expect(list.skills[0].description).toBe(description);
+    expect(info.description).toBe(description);
+    expect(list.managedSkillsDir).toBe(managedSkillsDir);
+    expect(check.managedSkillsDir).toBe(managedSkillsDir);
+  });
+
   it("reports missing prerequisites for discovered agent-excluded skills", async () => {
     const missingBin = "qa35-fixture-absent-binary";
     await writeWorkspaceSkills(tempWorkspaceDir, [


### PR DESCRIPTION
Related: #140581

## What Problem This Solves

Fixes an issue where users reading `skills list`, `skills info`, or `skills check` JSON would lose tabs and line endings in descriptions and paths. For example, a valid loaded description containing `First paragraph.\nSecond\tcolumn.` became `First paragraph.Secondcolumn.`.

## Why This Change Was Made

Preserve tabs, LF, and CR for JSON's normal escaping while retaining the existing ANSI/C1 cleanup. Build on the native JSON replacer already merged in #140581 by sharing serialization across list, info, check, and missing-skill errors. Main's lazy formatting of human-only error text remains intact. The earlier recursion removal belongs to #140581; this change has a net production delta of -1 line.

## User Impact

Scripts can read descriptions and paths without silently losing meaningful whitespace. Human-readable table spacing and existing terminal escape cleanup remain unchanged.

## Evidence

- A regression loads a real workspace `SKILL.md`, confirms the loader preserves LF/CR/tab, and fails on the original formatter's collapsed JSON. It covers list/info descriptions and list/check paths.
- All 38 tests in `src/cli/skills-cli.formatting.test.ts` and `src/cli/skills-cli.test.ts` passed, including existing ANSI/C1 cleanup, missing-skill JSON, and table spacing.
- The owning CLI test type graph, full-file typed lint, formatting, docs index, and diff checks passed. Independent P2 review found no actionable findings.
- These checks preceded the mechanical integration onto main containing #140581. The integration preserves the reviewed fix, test, and docs plus main's existing lazy human-error formatting; final CI runs against the pushed head.

No Gateway or provider is needed for this formatting boundary. Production net -1 line; tests +22, docs +2.
