### PR TITLE
refactor(gateway): use resolved session owners directly

### DIFF
--- a/src/gateway/server-methods/sessions-delete.ts
+++ b/src/gateway/server-methods/sessions-delete.ts
@@ -29,7 +29,6 @@ import { handleSessionStateSessionDeleted } from "../../sessions/session-state-e
 import { removeSessionWorktree } from "../../sessions/session-worktree-lifecycle.js";
 import { resolvePluginSessionOwnershipError } from "../session-plugin-ownership.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-request-agent.js";
-import { resolveSessionStoreAgentId } from "../session-store-key.js";
 import { loadGatewaySessionEntryReadOnly, loadSessionEntry } from "../session-utils.js";
 import { prepareSessionWorkerPlacementRetirement } from "../worker-environments/session-placement-lifecycle.js";
 import { emitSessionsChanged } from "./session-change-event.js";
@@ -260,7 +259,7 @@ export const sessionDeleteHandlers: GatewayRequestHandlers = {
             const postCleanupTarget = loadAccessorSessionEntryForGatewayTarget({
               key,
               cfg,
-              ...(requestedAgentId ? { agentId: requestedAgentId } : {}),
+              agentId: requestedAgentId,
             });
             const postCleanupEntry = postCleanupTarget.entry;
             deletedWorktreeId = normalizeOptionalString(postCleanupEntry?.worktree?.id);
@@ -320,10 +319,7 @@ export const sessionDeleteHandlers: GatewayRequestHandlers = {
               // generation-scoped purge and checkout cleanup still finish before
               // this fence opens, so a same-key successor cannot be mistaken for it.
               const deletedSessionKey = target.canonicalKey ?? key;
-              handleSessionStateSessionDeleted(
-                deletedSessionKey,
-                requestedAgentId ?? resolveSessionStoreAgentId(cfg, deletedSessionKey),
-              );
+              handleSessionStateSessionDeleted(deletedSessionKey, requestedAgentId);
               worktreePreserved = await removeSessionWorktree({
                 id: deletedWorktreeId,
                 sessionKey: deletedSessionKey,

--- a/src/gateway/server-methods/sessions-subscriptions.ts
+++ b/src/gateway/server-methods/sessions-subscriptions.ts
@@ -12,7 +12,6 @@ import { canReviewOperatorApproval } from "../operator-approval-authorization.js
 import { APPROVALS_SCOPE } from "../operator-scopes.js";
 import { sessionObserverScopeKey } from "../session-observer-model.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
-import { resolveSessionStoreAgentId } from "../session-store-key.js";
 import { resolveSessionSubscriptionKey } from "../session-subscription-keys.js";
 import { resolveSessionStoreKey } from "../session-utils.js";
 import { sessionsListHandler } from "./sessions-read.js";
@@ -134,12 +133,9 @@ export const sessionSubscriptionHandlers: GatewayRequestHandlers = {
     const canonicalKey = resolveSessionStoreKey({
       cfg,
       sessionKey: key,
-      ...(requestedAgentId ? { storeAgentId: requestedAgentId } : {}),
+      storeAgentId: requestedAgentId,
     });
-    const subscriptionKey = resolveSessionSubscriptionKey(
-      canonicalKey,
-      requestedAgentId ?? resolveSessionStoreAgentId(cfg, canonicalKey),
-    );
+    const subscriptionKey = resolveSessionSubscriptionKey(canonicalKey, requestedAgentId);
     if (connId) {
       let approvalReplay;
       if (p.includeApprovals === true) {
@@ -219,12 +215,9 @@ export const sessionSubscriptionHandlers: GatewayRequestHandlers = {
     const canonicalKey = resolveSessionStoreKey({
       cfg,
       sessionKey: key,
-      ...(requestedAgentId ? { storeAgentId: requestedAgentId } : {}),
+      storeAgentId: requestedAgentId,
     });
-    const subscriptionKey = resolveSessionSubscriptionKey(
-      canonicalKey,
-      requestedAgentId ?? resolveSessionStoreAgentId(cfg, canonicalKey),
-    );
+    const subscriptionKey = resolveSessionSubscriptionKey(canonicalKey, requestedAgentId);
     if (connId) {
       context.unsubscribeSessionMessageEvents(connId, subscriptionKey);
     }


### PR DESCRIPTION
## What Problem This Solves

Session subscription and deletion handlers retain fallback owner lookups after the canonical resolver has already returned a nonempty owner. This is a maintainer-requested production simplification in the #135868 deletion pass.

## Why This Change Was Made

Pass the captured owner directly to subscription-key resolution, post-cleanup lookup and deletion notification. All three handlers call `resolveRequestedSessionAgentId` (imported as `resolveRequestedGlobalAgentId` in deletion), return on failure, and bind its successful `agentId` to a constant.

Deletion evidence: every successful resolver path returns either a normalized key owner or a truthy explicit/inferred owner. `normalizeAgentId` also always returns a nonempty string. The three nullish fallback calls, their unused imports, and conditional omission of these owner fields are therefore redundant. Error handling, authorization, hooks, cleanup fencing and callback order are unchanged.

## User Impact

Session subscription scope, approval replay, deletion events and cleanup continue using the same resolved owner. No supported behavior changes.

## Evidence

- Before/after: 6 resolver/subscription/deletion lifecycle files, 109 cases passed in each run (557.04s / 295.32s).
- After the lockfile update to `@openclaw/fs-safe` 0.8.3, ran the required frozen offline install and repeated proof. A concurrent local test/typecheck run had one 120-second archive-restore timeout (108 passed); the same six-suite command, run alone without code, fixture, or timeout changes, passed all 109 cases (498.89s). The previously timed-out case passed in 59.7s.
- No tests changed or removed; real worktree and lifecycle cases remain intact.
- Fresh independent autoreview: scoped-clean, no accepted/actionable findings.
- Production +6/−17 = **−11**; tests/tooling/docs zero.

- Full `node scripts/check-changed.mjs`: exit 0, including core and core-test typechecks, lint, export scans and every selected guard; repeated successfully after the lockfile update. The final rebase preserved both changed files, their resolver/normalizer, and the lockfile.
- No build required: internal argument forwarding only; no packaging, lazy boundary or public API change.
