### PR TITLE
fix(gateway): retain heartbeat timeout write diagnostics

### DIFF
--- a/docs/gateway/diagnostics.md
+++ b/docs/gateway/diagnostics.md
@@ -105,6 +105,16 @@ it is omitted. `heartbeat-timeout` records the Gateway's missed-pong decision.
 It does not prove that a ping reached the remote peer or that the peer caused
 the transport failure.
 
+Heartbeat-timeout records also capture these facts before termination:
+
+- `pingWriteState`: `pending` when no write callback has been observed,
+  `completed` after local write completion, or `failed` after a write error.
+  Pending does not prove the ping was unsent; completed does not prove peer receipt.
+- `lastPongAgeMs`: monotonic elapsed milliseconds since the last observed pong,
+  omitted when no pong has been observed.
+- `bufferedBytes`: aggregate local WebSocket buffering at the timeout decision,
+  not the delivery status of an individual ping.
+
 ## Stability recorder
 
 The Gateway records a bounded, payload-free stability stream by default when

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -825,45 +825,88 @@ describe("attachGatewayWsConnectionHandler", () => {
   });
 
   it.each([
-    { reason: "normal peer close", durationMs: 1_000, cause: undefined, code: 1000 },
-    { reason: "missed protocol pong", durationMs: 50_000, cause: "heartbeat-timeout", code: 1006 },
-  ])("records connected close ownership after $reason", async ({ durationMs, cause, code }) => {
-    vi.useFakeTimers();
-    const socket = createGatewayWsTestSocket({ ping: true });
-    socket.terminate.mockImplementation(() => socket.emit("close", 1006, Buffer.alloc(0)));
-    const { logWsControl, passed } = await connectTestWs({ socket });
-    const handlerParams = passed as {
-      setClient: (client: never) => boolean;
-    };
+    { write: "normal", durationMs: 1_000, cause: undefined, code: 1000 },
+    { write: "pending", durationMs: 75_000, cause: "heartbeat-timeout", code: 1006 },
+    { write: "completed", durationMs: 50_000, cause: "heartbeat-timeout", code: 1006 },
+    { write: "failed", durationMs: 50_000, cause: "heartbeat-timeout", code: 1006 },
+    { write: "threw", durationMs: 50_000, cause: "heartbeat-timeout", code: 1006 },
+  ])(
+    "records connected close ownership with a $write ping write",
+    async ({ write, durationMs, cause, code }) => {
+      vi.useFakeTimers();
+      const socket = createGatewayWsTestSocket({ ping: true });
+      const callbacks: Array<((error?: Error) => void) | undefined> = [];
+      socket.ping?.mockImplementation((_data, _mask, callback?: (error?: Error) => void) => {
+        callbacks.push(callback);
+        if (write === "threw") {
+          throw new Error("private write error");
+        }
+        if (write === "completed" || write === "failed") {
+          callback?.(write === "failed" ? new Error("private write error") : undefined);
+        }
+      });
+      socket.bufferedAmount = 41;
+      socket.terminate.mockImplementation(() => {
+        // Destroy can settle a pending write before close; retain the decision snapshot.
+        callbacks.at(-1)?.(new Error("private teardown error"));
+        socket.bufferedAmount = 0;
+        socket.emit("close", 1006, Buffer.alloc(0));
+      });
+      const { logWsControl, passed } = await connectTestWs({ socket });
+      const handlerParams = passed as {
+        setClient: (client: never) => boolean;
+      };
 
-    expect(
-      handlerParams.setClient({
-        socket,
-        connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
-        connId: "conn-authenticated-user",
-        authenticatedUserId: "alice@example.com",
-        usesSharedGatewayAuth: false,
-      } as never),
-    ).toBe(true);
+      expect(
+        handlerParams.setClient({
+          socket,
+          connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+          connId: "conn-authenticated-user",
+          authenticatedUserId: "alice@example.com",
+          usesSharedGatewayAuth: false,
+        } as never),
+      ).toBe(true);
 
-    vi.advanceTimersByTime(durationMs);
-    if (!cause) {
-      socket.emit("close", code, Buffer.from("done"));
-    }
-    const closeReason = cause ? "n/a" : "done";
-    expect(logWsControl.info).toHaveBeenCalledWith(
-      expect.stringContaining(`webchat disconnected code=${code} reason=${closeReason} conn=`),
-      { cause, durationMs },
-    );
-    expect(logWsControl.info).toHaveBeenCalledWith(
-      expect.stringMatching(
-        new RegExp(
-          `^authenticated user disconnected code=${code} reason=${closeReason} conn=.+ user=alice@example\\.com$`,
+      if (write === "pending") {
+        vi.advanceTimersByTime(25_000);
+        socket.emit("pong");
+        vi.advanceTimersByTime(25_000);
+        callbacks[0]?.(); // An old completion must not mark the new attempt completed.
+        vi.advanceTimersByTime(25_000);
+      } else {
+        vi.advanceTimersByTime(durationMs);
+      }
+      if (!cause) {
+        socket.emit("close", code, Buffer.from("done"));
+      }
+      const closeReason = cause ? "n/a" : "done";
+      const context = {
+        cause,
+        durationMs,
+        ...(cause
+          ? {
+              pingWriteState: write === "threw" ? "failed" : write,
+              lastPongAgeMs: write === "pending" ? 50_000 : undefined,
+              bufferedBytes: 41,
+            }
+          : {}),
+      };
+      expect(logWsControl.info).toHaveBeenCalledWith(
+        expect.stringContaining(`webchat disconnected code=${code} reason=${closeReason} conn=`),
+        context,
+      );
+      expect(logWsControl.info).toHaveBeenCalledWith(
+        expect.stringMatching(
+          new RegExp(
+            `^authenticated user disconnected code=${code} reason=${closeReason} conn=.+ user=alice@example\\.com$`,
+          ),
         ),
-      ),
-      { cause, durationMs },
-    );
-  });
+        context,
+      );
+      expect(socket.terminate).toHaveBeenCalledTimes(cause ? 1 : 0);
+      expect(JSON.stringify(logWsControl.info.mock.calls)).not.toContain("private");
+    },
+  );
 
   it("records disconnect history for the current node connection", async () => {
     const unregister = vi.fn(() => "node-1");

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -36,7 +36,10 @@ import {
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
 import { formatError } from "../server-utils.js";
 import { cleanupTalkConnection } from "../talk-session-registry.js";
-import { startWebSocketKeepalive } from "../websocket-keepalive.js";
+import {
+  startWebSocketKeepalive,
+  type WebSocketHeartbeatDiagnostics,
+} from "../websocket-keepalive.js";
 import { formatForLog, logWs } from "../ws-log.js";
 import { refreshClientPresence } from "./client-presence.js";
 import { getHealthVersion, incrementPresenceVersion } from "./health-state.js";
@@ -205,6 +208,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     let lastHandshakePhase: WsHandshakePhase = "tcp_accepted";
     let holdsPreauthBudget = true;
     let closeCause: string | undefined;
+    let heartbeatDiagnostics: WebSocketHeartbeatDiagnostics | undefined;
     let closeMeta: Record<string, unknown> = {};
     let lastFrameType: string | undefined;
     let lastFrameMethod: string | undefined;
@@ -396,6 +400,8 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
 
     const handleSocketClose = async (code: number, reason: Buffer) => {
       const durationMs = Date.now() - openedAt;
+      // Only the typed heartbeat snapshot is safe for default connected-close logs.
+      const disconnectContext = { cause: closeCause, durationMs, ...heartbeatDiagnostics };
       const logForwardedFor = sanitizeWsLogValue(forwardedFor);
       const logOrigin = sanitizeWsLogValue(requestOrigin);
       const logHost = sanitizeWsLogValue(requestHost);
@@ -403,10 +409,9 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       const logReason = sanitizeWsLogValue(reason?.toString());
       const handshakeIncomplete = lastHandshakePhase !== "ready";
       const closeContext = {
-        cause: closeCause,
+        ...disconnectContext,
         handshake: handshakeState,
         ...(handshakeIncomplete ? { phase: lastHandshakePhase } : {}),
-        durationMs,
         lastFrameType,
         lastFrameMethod,
         lastFrameId,
@@ -463,13 +468,13 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       if (client && isWebchatClient(client.connect.client)) {
         logWsControl.info(
           `webchat disconnected code=${code} reason=${logReason || "n/a"} conn=${connId}`,
-          { cause: closeCause, durationMs },
+          disconnectContext,
         );
       }
       if (client?.authenticatedUserId) {
         logWsControl.info(
           `authenticated user disconnected code=${code} reason=${logReason || "n/a"} conn=${connId} user=${formatForLog(client.authenticatedUserId)}`,
-          { cause: closeCause, durationMs },
+          disconnectContext,
         );
       }
       if (connectionKind === "gateway") {
@@ -547,8 +552,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         connId,
         code,
         reason: logReason,
-        durationMs,
-        cause: closeCause,
+        ...disconnectContext,
         handshake: handshakeState,
         ...(handshakeIncomplete ? { phase: lastHandshakePhase } : {}),
         lastFrameType,
@@ -613,8 +617,9 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         next.personPresence = { onlineSince: Date.now() };
         refreshClientPresence(clients, next);
       }
-      stopKeepalive = startWebSocketKeepalive(socket, () => {
+      stopKeepalive = startWebSocketKeepalive(socket, (diagnostics) => {
         // A half-open control connection must release its node and worker owners.
+        heartbeatDiagnostics = diagnostics;
         setCloseCause("heartbeat-timeout");
         try {
           socket.terminate();

--- a/src/gateway/websocket-keepalive.ts
+++ b/src/gateway/websocket-keepalive.ts
@@ -1,10 +1,23 @@
 import { WebSocket } from "ws";
 
+type PingWrite = { pingWriteState: "pending" | "completed" | "failed" };
+export type WebSocketHeartbeatDiagnostics = PingWrite & {
+  lastPongAgeMs: number | undefined;
+  bufferedBytes: number;
+};
+
 /** Keep idle transports active; only the connection owner may impose a pong deadline. */
-export function startWebSocketKeepalive(socket: WebSocket, onMissedPong?: () => void): () => void {
-  let awaitingPong = false;
+export function startWebSocketKeepalive(
+  socket: WebSocket,
+  onMissedPong?: (diagnostics: WebSocketHeartbeatDiagnostics) => void,
+): () => void {
+  let awaitingPong: PingWrite | undefined;
+  let lastPongAt: number | undefined;
   const onPong = () => {
-    awaitingPong = false;
+    awaitingPong = undefined;
+    if (onMissedPong) {
+      lastPongAt = performance.now();
+    }
   };
   const stop = () => {
     clearInterval(timer);
@@ -21,13 +34,30 @@ export function startWebSocketKeepalive(socket: WebSocket, onMissedPong?: () => 
     // Stream peers can pause reads for backpressure, delaying automatic pongs.
     // Their existing control connection and stream owner still govern revocation.
     if (awaitingPong && onMissedPong) {
-      onMissedPong();
+      // Copy before termination can settle writes. Callback completion proves
+      // local writing, not peer receipt; a pending callback does not prove unsent bytes.
+      onMissedPong({
+        ...awaitingPong,
+        lastPongAgeMs: lastPongAt === undefined ? undefined : performance.now() - lastPongAt,
+        bufferedBytes: socket.bufferedAmount,
+      });
       return;
     }
-    awaitingPong = true;
+    const attempt: PingWrite = { pingWriteState: "pending" };
+    awaitingPong = attempt;
     try {
-      socket.ping();
+      socket.ping(
+        undefined,
+        undefined,
+        onMissedPong
+          ? (error) => {
+              // A late completion belongs to this attempt, never a later ping.
+              attempt.pingWriteState = error ? "failed" : "completed";
+            }
+          : undefined,
+      );
     } catch {
+      attempt.pingWriteState = "failed";
       // The socket owner handles transport failure and closes the connection.
     }
   }, 25_000);


### PR DESCRIPTION
Related: #140640

## What Problem This Solves

Resolves a problem where operators investigating heartbeat-timeout disconnects could see the Gateway's timeout decision but not whether its ping write callback had completed or how recently it had observed a pong.

## Why This Change Was Made

Capture the current ping's local write state, monotonic last-pong age, and aggregate buffered bytes at the existing timeout decision. Each attempt owns its callback state, and the close path receives a copied, typed snapshot before termination can settle writes. Normal close logs and arbitrary close metadata stay separate.

## User Impact

Existing disconnect logs now distinguish pending, completed, and failed local writes. Pending does not prove a ping was unsent, and completed does not prove remote receipt. The existing intervals, missed-pong deadline, termination, and desktop/portal stream behavior are preserved. The shared helper allocates one small attempt record per 25-second stream tick; stream callers do not add write callbacks or pong timing.

## Evidence

- Four new owner assertions fail on the baseline; the candidate passes all 63 focused connection, native WebSocket, desktop observer, and node stream tests.
- A small native WebSocket/default-file-log fixture fails on the baseline and passes on the candidate: normal close omits heartbeat fields; missed pong records a completed local write, zero buffered bytes, and unknown last-pong age. Only interval advancement is faked; socket, write, pong, close, and file logging are real. Registration uses the existing fixture, not a full authentication/browser/proxy flow. Both variants close their sockets/listener and remove temporary state.
- Deferred-callback coverage protects old-attempt isolation and snapshot stability when termination settles writes before close. Error text never enters the diagnostic fields.
- Tests use Node 24.20.0 on macOS. The exact ws 8.21.3 and Node 26.7.0 callback/teardown contracts were inspected separately.
- Full changed-file gate passed, including core/test types, lint, formatting, and ownership guards. Independent P2 autoreview found no actionable issues.
- Exact-head CI passed after one targeted rerun of a memory-maintenance test timeout. The original failure is retained; a separate capability-fixture regression is being repaired independently. No timeout, assertion, or diagnostics source changed for the rerun.
