### PR TITLE
fix(update): refuse schema bumps under unfenced updaters

### DIFF
--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -111,7 +111,10 @@ unable to finish or safely restore the previous release.
 
 The refusal reports the on-disk and target schema versions and, when readable,
 the driving updater version. Let the failed update finish restoring the previous
-package, then run the manual update from a shell outside the Gateway. Replace
+package. OpenClaw 2026.9.2 treats any failed post-install verification as unsafe
+for an automatic restart and leaves the Gateway service stopped; run
+`openclaw gateway start` to bring the previous release back on its untouched
+database, then run the manual update from a shell outside the Gateway. Replace
 `<target>` with the exact target version from the refusal:
 
 ```bash

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -101,6 +101,40 @@ another restart.
 
 See [Release channels](/install/development-channels) for channel semantics.
 
+### Updating from 2026.9.2 across a schema bump
+
+When the target release needs a newer shared-state or registered agent database
+schema, its Doctor refuses an update driven by OpenClaw 2026.9.2 before applying
+repairs. That release introduced the update ledger but still accesses it with old
+code after running the target's Doctor. Migrating first would leave the updater
+unable to finish or safely restore the previous release.
+
+The refusal reports the on-disk and target schema versions and, when readable,
+the driving updater version. Let the failed update finish restoring the previous
+package, then run the manual update from a shell outside the Gateway. Replace
+`<target>` with the exact target version from the refusal:
+
+```bash
+openclaw gateway stop
+npm install -g openclaw@<target> --allow-scripts=openclaw
+openclaw doctor --fix
+openclaw gateway start
+```
+
+Run each command only after the previous one succeeds. On npm 11.15 and earlier,
+omit `--allow-scripts=openclaw`. For a pnpm-owned install, replace the install
+command with `pnpm add -g --allow-build=openclaw openclaw@<target>`; for Bun, use
+`bun add -g --trust openclaw@<target>`.
+
+Same-schema updates continue normally. Earlier updaters, including 2026.9.1,
+do not reopen shared state after Doctor and can cross schema bumps without this
+refusal. Later transactional updaters fence old ledger access and hand completion
+to the candidate, including 2026.9.3 prereleases. The guard requires an active update ledger run from an affected
+updater; a missing table or no running row preserves the earlier update behavior.
+The guard does not undo an earlier migration; if the database is already newer
+than the restored package, install a compatible target and finish Doctor before
+starting the Gateway. See [Database schemas](/reference/database-schemas).
+
 ### From chat
 
 The OpenClaw owner can say "update" (the agent uses the `gateway` action

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -236,6 +236,31 @@ original result and a keyed request fingerprint, not a second raw request.
 There is no backfill or configuration switch. Downgrading preserves the table
 but disables the new structured controls; upgrading can read retained receipts.
 
+### Schema bumps and older updaters
+
+Update-time Doctor checks the shared database and registered agent databases
+before CLI debug capture, maintenance, config rewrites, or migration ledger writes.
+If a database would advance `user_version` and a running `update_runs` row identifies
+the driving updater as the 2026.9.2 release line, Doctor reports
+`update-schema-bump-unfenced` and a nonzero exit. The
+refusal includes on-disk and target schema versions, the active update run's
+`before.version`, and manual update commands. Doctor leaves the databases and
+config unchanged.
+
+OpenClaw 2026.9.2 introduced the update ledger and reopens it with the previous
+build after the target's Doctor. That release cannot safely drive a schema bump.
+Earlier updaters, including 2026.9.1, never reopen shared state after Doctor and
+continue to work. A missing ledger table or no running row does not trigger this
+guard, including when a database schema is indeterminate. Builds from 2026.9.3
+onward, including prereleases, use transactional updates that suspend old-process
+ledger access and let candidate code finish after migration. The version check
+includes 2026.9.2 rebuilds and requires a valid semantic version; it adds no
+environment override. Same-schema repairs and ordinary Doctor runs remain available.
+
+Use the [manual update sequence](/install/updating#updating-from-2026.9.2-across-a-schema-bump)
+after the old updater restores the previous package. Package rollback cannot
+reverse a migration that already happened.
+
 ### Profile-owned skill library
 
 [Personal and team skills](/tools/skills#personal-skills-on-a-shared-gateway) use four first-use tables in the shared state database without changing its schema version: `skill_library_entries`, `skill_library_revisions`, `skill_library_events`, and `skill_library_uploads`. Ordinary workspace skills and unused-library discovery do not create these tables. Ownership, sharing, the current revision pointer, portable file manifests, and publication events are canonical SQLite data. Session selections remain in the existing per-agent session store; inherited cron selections remain in the existing private job record.

--- a/src/cli/doctor-output.process.test.ts
+++ b/src/cli/doctor-output.process.test.ts
@@ -12,12 +12,17 @@ import {
   runSourceRuntime,
 } from "../commands/doctor-config-preflight.process.test-support.js";
 import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import { createUpdateRun } from "../infra/update-run-ledger.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   listOpenClawRegisteredAgentDatabases,
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { spawnNodeEvalSync } from "../test-utils/node-process.js";
 import { cliRecoveryEntrypoints } from "./cli-entrypoint.test-support.js";
 
@@ -49,7 +54,12 @@ function createDoctorRuntime(root: string) {
       : runBuiltRuntime(runtimeRoot, env, args, 60_000, 4 * 1024 * 1024);
 }
 
-function runDoctor(params: { root: string; configPath: string; repair?: boolean }) {
+function runDoctor(params: {
+  root: string;
+  configPath: string;
+  repair?: boolean;
+  env?: NodeJS.ProcessEnv;
+}) {
   // Only the immutable package is shared across cases; scenario state stays separate.
   doctorRuntime ??= createDoctorRuntime(runtimeDirs.make("openclaw-doctor-runtime-"));
   return doctorRuntime(
@@ -70,6 +80,7 @@ function runDoctor(params: { root: string; configPath: string; repair?: boolean 
       VITEST: undefined,
       VITEST_POOL_ID: undefined,
       VITEST_WORKER_ID: undefined,
+      ...params.env,
     },
     [
       "doctor",
@@ -82,6 +93,54 @@ function runDoctor(params: { root: string; configPath: string; repair?: boolean 
 }
 
 describe("Doctor report process output", () => {
+  it("refuses an unfenced schema bump before CLI debug capture can write state", () => {
+    const root = tempDirs.make("openclaw-doctor-update-schema-");
+    const configPath = path.join(root, "openclaw.json");
+    const env = { OPENCLAW_STATE_DIR: path.join(root, "state"), OPENCLAW_CONFIG_PATH: configPath };
+    fs.writeFileSync(configPath, "{}\n");
+    const shared = openOpenClawStateDatabase({ env }).path;
+    createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } }, { env });
+    closeOpenClawStateDatabaseForTest();
+    const legacy = new DatabaseSync(shared);
+    legacy.exec(
+      `PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION - 1}; UPDATE schema_meta SET schema_version = ${OPENCLAW_STATE_SCHEMA_VERSION - 1};`,
+    );
+    legacy.close();
+    const databaseBefore = fs.readFileSync(shared);
+    const sidecarsBefore = ["-wal", "-shm"].map((suffix) => fs.existsSync(`${shared}${suffix}`));
+    const configBefore = fs.readFileSync(configPath);
+
+    const result = runDoctor({
+      root,
+      configPath,
+      repair: true,
+      env: {
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_DEBUG_PROXY_ENABLED: "1",
+        OPENCLAW_SERVICE_REPAIR_POLICY: "external",
+      },
+    });
+    expect(result.error).toBeUndefined();
+    expect(
+      ["-wal", "-shm"].map((suffix) => fs.existsSync(`${shared}${suffix}`)),
+      result.stderr,
+    ).toEqual(sidecarsBefore);
+    expect(fs.readFileSync(shared).equals(databaseBefore), result.stderr).toBe(true);
+    const after = new DatabaseSync(shared, { readOnly: true });
+    try {
+      expect(after.prepare("PRAGMA user_version").get()?.user_version).toBe(
+        OPENCLAW_STATE_SCHEMA_VERSION - 1,
+      );
+    } finally {
+      after.close();
+    }
+    expect(fs.readFileSync(configPath)).toEqual(configBefore);
+    expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(1);
+    expect(`${result.stderr}\n${result.stdout}`).toContain(
+      "Doctor refused update-time schema repair driven by OpenClaw 2026.9.2",
+    );
+  });
+
   it("reports deferred Doctor-only state after config refusal, then converges", () => {
     const root = tempDirs.make("openclaw-doctor-deferred-state-");
     const stateDir = path.join(root, "state");

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -1144,6 +1144,22 @@ async function runCliWithPreparedOutputMode(
       }
     });
   }
+  if (
+    !isHelpOrVersionInvocation &&
+    normalizedInvocation.primary === "doctor" &&
+    process.env.OPENCLAW_UPDATE_IN_PROGRESS === "1"
+  ) {
+    // Debug capture can migrate shared state before Commander reaches Doctor.
+    // Resolve the update guard after selectors settle, before any bootstrap writer.
+    const [{ guardUpdateDoctorSchemaUpgrade }, { defaultRuntime }] = await Promise.all([
+      import("../commands/doctor-update-schema-guard.js"),
+      import("../runtime.js"),
+    ]);
+    await guardUpdateDoctorSchemaUpgrade({
+      runtime: defaultRuntime,
+      json: options.builtInMachineOutput,
+    });
+  }
   await configureStartupTraces();
   if (!isHelpOrVersionInvocation && isGatewayRunInvocation) {
     await startupTrace.measure("gateway-run-select-environment", async () => {

--- a/src/commands/doctor-config-preflight.process.test-support.ts
+++ b/src/commands/doctor-config-preflight.process.test-support.ts
@@ -116,7 +116,11 @@ export function createSourceRuntime(root: string): string {
   return runtimeRoot;
 }
 
-export function createBuiltRuntime(root: string, sourceDist = path.resolve("dist")): string {
+export function createBuiltRuntime(
+  root: string,
+  sourceDist = path.resolve("dist"),
+  options: { copyDirectories?: boolean } = {},
+): string {
   const runtimeRoot = createSourceRuntime(root);
   // The pretest owner supplies immutable built modules once; mutable package
   // metadata and Control UI assets remain private to each fixture.
@@ -126,7 +130,10 @@ export function createBuiltRuntime(root: string, sourceDist = path.resolve("dist
     }
     const source = path.join(sourceDist, entry.name);
     const target = path.join(runtimeRoot, "dist", entry.name);
-    if (entry.isDirectory()) {
+    if (entry.isDirectory() && options.copyDirectories) {
+      // Direct package entry invocations do not pass --preserve-symlinks.
+      fs.cpSync(source, target, { recursive: true, mode: fs.constants.COPYFILE_FICLONE });
+    } else if (entry.isDirectory()) {
       fs.symlinkSync(source, target, process.platform === "win32" ? "junction" : "dir");
     } else {
       fs.copyFileSync(source, target, fs.constants.COPYFILE_FICLONE);

--- a/src/commands/doctor-config-preflight.refusal.process.test.ts
+++ b/src/commands/doctor-config-preflight.refusal.process.test.ts
@@ -1,8 +1,15 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterAll, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createUpdateRun } from "../infra/update-run-ledger.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import {
   createBuiltRuntime,
   runBuiltRuntime,
@@ -11,6 +18,88 @@ import {
 const tempDirs = useAutoCleanupTempDirTracker(afterAll);
 
 describe("Doctor CLI migration refusal", () => {
+  it.each(["index.js", "entry.js"])(
+    "refuses the 2026.9.2 updater through %s with its running ledger row only in WAL",
+    (entry) => {
+      const root = fs.realpathSync(tempDirs.make("openclaw-doctor-update-wal-"));
+      const stateDir = path.join(root, "state");
+      const configPath = path.join(root, "openclaw.json");
+      const env = { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_CONFIG_PATH: configPath };
+      fs.writeFileSync(configPath, "{}\n");
+      const shared = openOpenClawStateDatabase({ env }).path;
+      createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } }, { env });
+      closeOpenClawStateDatabaseForTest();
+      const runtimeRoot = createBuiltRuntime(root, undefined, { copyDirectories: true });
+      const packagePath = path.join(runtimeRoot, "package.json");
+      const manifest = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+      fs.writeFileSync(packagePath, JSON.stringify({ ...manifest, version: "2026.9.3" }));
+      const writer = new DatabaseSync(shared);
+      try {
+        const row = writer.prepare("SELECT * FROM update_runs").get();
+        if (!row) {
+          throw new Error("Expected the fixture's update ledger row");
+        }
+        row.phase = "activating";
+        writer.exec(`
+          PRAGMA journal_mode = WAL;
+          PRAGMA wal_autocheckpoint = 0;
+          PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION - 1};
+          UPDATE schema_meta SET schema_version = ${OPENCLAW_STATE_SCHEMA_VERSION - 1};
+          DELETE FROM update_runs;
+          PRAGMA wal_checkpoint(TRUNCATE);
+        `);
+        const checkpoint = fs.readFileSync(shared);
+        writer
+          .prepare(
+            `INSERT INTO update_runs (${Object.keys(row).join(",")}) VALUES (${Object.keys(row)
+              .map(() => "?")
+              .join(",")})`,
+          )
+          .run(...Object.values(row));
+        expect(fs.readFileSync(shared)).toEqual(checkpoint);
+        expect(fs.statSync(`${shared}-wal`).size).toBeGreaterThan(32);
+        const files = [shared, `${shared}-wal`, `${shared}-shm`, configPath];
+        const before = files.map((file) => fs.readFileSync(file));
+
+        // 2026.9.2 invokes the installed index directly and keeps its ledger open.
+        const result = spawnSync(
+          process.execPath,
+          [path.join(runtimeRoot, "dist", entry), "doctor", "--non-interactive", "--fix"],
+          {
+            cwd: runtimeRoot,
+            encoding: "utf8",
+            timeout: 60_000,
+            env: {
+              PATH: process.env.PATH,
+              HOME: root,
+              USERPROFILE: root,
+              ...env,
+              OPENCLAW_UPDATE_IN_PROGRESS: "1",
+              OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.9.3",
+              OPENCLAW_SERVICE_REPAIR_POLICY: "external",
+              NO_COLOR: "1",
+              CI: "1",
+            },
+          },
+        );
+        const output = `${result.stdout}\n${result.stderr}`;
+        expect(result.error, output).toBeUndefined();
+        expect(result.status, output).toBe(1);
+        expect(output).toContain(
+          "Doctor refused update-time schema repair driven by OpenClaw 2026.9.2",
+        );
+        expect(files.map((file) => fs.readFileSync(file))).toEqual(before);
+        expect(writer.prepare("PRAGMA user_version").get()?.user_version).toBe(
+          OPENCLAW_STATE_SCHEMA_VERSION - 1,
+        );
+        expect(writer.prepare("SELECT * FROM update_runs").get()).toEqual(row);
+      } finally {
+        writer.close();
+      }
+    },
+    60_000,
+  );
+
   it.each([false, true])(
     "honors the ordered graph with valid TUI=%s",
     async (validTui) => {

--- a/src/commands/doctor-update-schema-guard.ts
+++ b/src/commands/doctor-update-schema-guard.ts
@@ -1,0 +1,149 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { parse as parseSemver } from "semver";
+import { exitCliAfterOutput } from "../cli/one-shot-exit.js";
+import {
+  clearNodeSqliteKyselyCacheForDatabase,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db-contract.js";
+import {
+  preflightOpenClawDatabaseSchemas,
+  type OpenClawDatabaseSchemaPreflight,
+} from "../state/openclaw-database-preflight.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
+import type { DB } from "../state/openclaw-state-db.generated.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { VERSION } from "../version.js";
+
+// 2026.9.2 introduced the ledger without fencing post-Doctor access. Earlier
+// updaters never reopen state; #138839 fenced every 2026.9.3-and-later build.
+// Compare the parsed release line so 2026.9.2 rebuilds are included and
+// 2026.9.3 prereleases are excluded, independently of this checkout's VERSION.
+const UNFENCED_LEDGER_UPDATER_RELEASE = "2026.9.2";
+
+/** A pre-transaction updater would reopen the migrated ledger with its old code. */
+class DoctorUpdateSchemaRefusalError extends Error {
+  readonly code = "update-schema-bump-unfenced";
+  readonly targetVersion = VERSION;
+  readonly commands: string[];
+
+  constructor(
+    readonly databases: NonNullable<OpenClawDatabaseSchemaPreflight["pendingMigrations"]>,
+    readonly updaterVersion: string,
+  ) {
+    const commands = [
+      "openclaw gateway stop",
+      `npm install -g openclaw@${VERSION} --allow-scripts=openclaw`,
+      "openclaw doctor --fix",
+      "openclaw gateway start",
+    ];
+    super(
+      `Doctor refused update-time schema repair driven by OpenClaw ${updaterVersion}: this updater reopens the ledger with old code after migration. ` +
+        databases
+          .map(
+            (database) =>
+              `${database.kind} database ${database.path}: on-disk schema ${database.foundVersion}, this build's schema ${database.supportedVersion}.`,
+          )
+          .join(" ") +
+        " No doctor repairs were applied. Let the updater restore the previous package, then update manually: " +
+        `${commands.join(" && ")}. ` +
+        `Use the package manager that owns this install (pnpm: pnpm add -g --allow-build=openclaw openclaw@${VERSION}; Bun: bun add -g --trust openclaw@${VERSION}). On npm 11.15 and earlier, omit --allow-scripts=openclaw.`,
+    );
+    this.name = "DoctorUpdateSchemaRefusalError";
+    this.commands = commands;
+  }
+}
+
+async function readDrivingUpdaterVersion(): Promise<string | undefined> {
+  // The runtime ledger reader consults quarantine state. This diagnostic must
+  // not open any live database, including a quarantine store needing recovery.
+  const snapshot = await prepareSqliteReadOnlyLocation(resolveOpenClawStateSqlitePath(), {
+    preserveSourceArtifacts: true,
+  });
+  try {
+    const database = openNodeSqliteDatabase(snapshot.location, { readOnly: true });
+    try {
+      if (!tableExists(database, "update_runs")) {
+        return undefined;
+      }
+      const row = executeSqliteQueryTakeFirstSync(
+        database,
+        getNodeSqliteKysely<Pick<DB, "update_runs">>(database)
+          .selectFrom("update_runs")
+          .select("before_json")
+          .where("status", "=", "running")
+          .orderBy("created_at_ms", "desc")
+          .orderBy("run_id", "desc")
+          .limit(1),
+      );
+      const before: unknown = row ? JSON.parse(row.before_json) : undefined;
+      return isRecord(before) && typeof before.version === "string" ? before.version : undefined;
+    } finally {
+      clearNodeSqliteKyselyCacheForDatabase(database);
+      database.close();
+    }
+  } finally {
+    snapshot.cleanup();
+  }
+}
+
+/** Refuse before CLI capture or Doctor maintenance can open writable state. */
+export async function guardUpdateDoctorSchemaUpgrade(options: {
+  schemas?: OpenClawDatabaseSchemaPreflight;
+  runtime: RuntimeEnv;
+  json?: boolean;
+}): Promise<void> {
+  if (process.env.OPENCLAW_UPDATE_IN_PROGRESS !== "1") {
+    return;
+  }
+  const schemas =
+    options.schemas ??
+    (await preflightOpenClawDatabaseSchemas({
+      env: process.env,
+      supportedVersions: {
+        state: OPENCLAW_STATE_SCHEMA_VERSION,
+        agent: OPENCLAW_AGENT_SCHEMA_VERSION,
+      },
+    }));
+  if (!schemas.pendingMigrations?.length) {
+    return;
+  }
+  let updaterVersion: string | undefined;
+  try {
+    updaterVersion = await readDrivingUpdaterVersion();
+  } catch {
+    // A missing or unreadable run cannot prove that the driver writes the ledger.
+  }
+  if (!updaterVersion) {
+    return;
+  }
+  const driver = parseSemver(updaterVersion);
+  if (
+    !driver ||
+    `${driver.major}.${driver.minor}.${driver.patch}` !== UNFENCED_LEDGER_UPDATER_RELEASE
+  ) {
+    return;
+  }
+  const error = new DoctorUpdateSchemaRefusalError(schemas.pendingMigrations, updaterVersion);
+  if (options.json) {
+    writeRuntimeJson(options.runtime, {
+      ok: false,
+      error: {
+        type: "cli_error",
+        code: error.code,
+        message: error.message,
+        databases: error.databases,
+        updaterVersion: error.updaterVersion,
+        targetVersion: error.targetVersion,
+        commands: error.commands,
+      },
+    });
+    exitCliAfterOutput(options.runtime, 1);
+  }
+  throw error;
+}

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -4,6 +4,7 @@ import { intro as clackIntro, outro as clackOutro } from "@clack/prompts";
 import { stylePromptTitle } from "../../packages/terminal-core/src/prompt-style.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { DoctorOptions } from "../commands/doctor-prompter.js";
+import { guardUpdateDoctorSchemaUpgrade } from "../commands/doctor-update-schema-guard.js";
 import { resolveStateDir } from "../config/paths.js";
 import { DoctorStateMigrationRefusalError } from "../infra/state-migrations.messages.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -16,7 +17,7 @@ const outro = (message: string) => clackOutro(stylePromptTitle(message) ?? messa
 
 const loadConfigModule = createLazyRuntimeModule(() => import("../config/config.js"));
 
-async function assertDoctorDatabaseSchemasCompatible(): Promise<void> {
+async function assertDoctorDatabaseSchemasCompatible() {
   const [databasePreflight, agentDatabase, stateDatabase] = await Promise.all([
     import("../state/openclaw-database-preflight.js"),
     import("../state/openclaw-agent-db-contract.js"),
@@ -42,6 +43,7 @@ async function assertDoctorDatabaseSchemasCompatible(): Promise<void> {
       `Doctor cannot continue because the shared state database is unreadable: ${unreadableStateDatabase.path}: ${unreadableStateDatabase.reason}. The database was left unchanged; doctor will not recreate it because that could discard persistent operator data. Stop the Gateway and other OpenClaw processes, then restore this file from a verified backup or repair it manually. After recovery, run ${formatCliCommand("openclaw doctor --fix")} again. See ${stateDatabase.OPENCLAW_DATABASE_SCHEMA_DOCS_URL}.`,
     );
   }
+  return databaseSchemas;
 }
 
 function stateDirectoryExistsAtDoctorStart(): boolean {
@@ -84,7 +86,8 @@ export async function runDoctorHealthFlow(runtime?: RuntimeEnv, options: DoctorO
 
   // A stale source checkout may update itself, but no diagnostic or repair may
   // touch state until the surviving build proves it understands every database.
-  await assertDoctorDatabaseSchemasCompatible();
+  const schemas = await assertDoctorDatabaseSchemasCompatible();
+  await guardUpdateDoctorSchemaUpgrade({ schemas, runtime: effectiveRuntime, json: options.json });
   if (options.repair === true || options.yes === true || options.generateGatewayToken === true) {
     const { assertConfigWriteAllowedInCurrentMode } = await loadConfigModule();
     assertConfigWriteAllowedInCurrentMode();

--- a/src/flows/doctor-health.update-schema.test.ts
+++ b/src/flows/doctor-health.update-schema.test.ts
@@ -1,0 +1,189 @@
+// Install fixture mocks before importing the real maintenance owners.
+import "./doctor-health.test-support.js";
+import fs from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createUpdateRun, finishUpdateRun } from "../infra/update-run-ledger.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+  OPENCLAW_AGENT_SCHEMA_VERSION,
+} from "../state/openclaw-agent-db.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+  repairOpenClawStateDatabaseSchema,
+} from "../state/openclaw-state-db.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { VERSION } from "../version.js";
+import { runDoctorHealthFlow } from "./doctor-health.js";
+
+const { mocks } = await import("./doctor-health.test-support.js");
+
+function setSchemaVersion(databasePath: string, version: number): void {
+  const db = new DatabaseSync(databasePath);
+  try {
+    db.exec(`PRAGMA user_version = ${version};`);
+    db.prepare("UPDATE schema_meta SET schema_version = ? WHERE meta_key = 'primary'").run(version);
+  } finally {
+    db.close();
+  }
+}
+
+function readDatabase(databasePath: string) {
+  const db = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    return {
+      version: db.prepare("PRAGMA user_version").get()?.user_version,
+      ledger: tableExists(db, "update_runs")
+        ? db.prepare("SELECT * FROM update_runs ORDER BY run_id").all()
+        : [],
+    };
+  } finally {
+    db.close();
+  }
+}
+
+describe("Doctor schema bumps under an updating parent", () => {
+  afterEach(() => vi.unstubAllEnvs());
+  beforeEach(() => {
+    mocks.config.mockReturnValue({});
+    mocks.packageRoot.mockReturnValue(undefined);
+    mocks.runContributions.mockReset();
+    mocks.outro.mockClear();
+    vi.stubEnv("OPENCLAW_UPDATE_IN_PROGRESS", "1");
+  });
+
+  it.each([
+    { kind: "state", updaterVersion: "2026.9.2" },
+    { kind: "agent", updaterVersion: "2026.9.2" },
+    { kind: "state", updaterVersion: "2026.9.2-rebuild.1" },
+  ])(
+    "refuses a $kind bump driven by $updaterVersion before changing database bytes, ledger, or config",
+    async ({ kind, updaterVersion }) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+        const shared = openOpenClawStateDatabase({ env: state.env }).path;
+        const agent = openOpenClawAgentDatabase({ agentId: "main", env: state.env }).path;
+        createUpdateRun({ trigger: "cli", before: { version: updaterVersion } });
+        closeOpenClawAgentDatabasesForTest();
+        closeOpenClawStateDatabaseForTest();
+        const target = kind === "state" ? shared : agent;
+        const supported =
+          kind === "state" ? OPENCLAW_STATE_SCHEMA_VERSION : OPENCLAW_AGENT_SCHEMA_VERSION;
+        setSchemaVersion(target, supported - 1);
+        const before = readDatabase(shared);
+        const quarantine = state.statePath("state", "openclaw-quarantine.sqlite");
+        fs.writeFileSync(quarantine, "unreadable quarantine fixture");
+        const files = [shared, agent, state.configPath, quarantine];
+        const bytes = files.map((file) => fs.readFileSync(file));
+        const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+        const failure = await runDoctorHealthFlow(runtime, {
+          repair: true,
+          nonInteractive: true,
+        }).catch((error: unknown) => error);
+        expect(failure).toMatchObject({
+          code: "update-schema-bump-unfenced",
+          updaterVersion,
+          databases: [
+            { kind, path: target, foundVersion: supported - 1, supportedVersion: supported },
+          ],
+          commands: [
+            "openclaw gateway stop",
+            `npm install -g openclaw@${VERSION} --allow-scripts=openclaw`,
+            "openclaw doctor --fix",
+            "openclaw gateway start",
+          ],
+        });
+        expect(files.map((file) => fs.readFileSync(file))).toEqual(bytes);
+        expect(readDatabase(shared)).toEqual(before);
+        expect(mocks.runContributions).not.toHaveBeenCalled();
+      });
+    },
+  );
+
+  it.each([
+    { ledger: "missing", update: "1", driver: "2026.9.1", bump: true },
+    { ledger: "finished", update: "1", driver: "2026.9.2", bump: true },
+    { ledger: "running", update: "1", driver: "2026.9.3", bump: true },
+    { ledger: "running", update: "1", driver: "2026.9.3-beta.1", bump: true },
+    { ledger: "running", update: "1", driver: "2026.10.0", bump: true },
+    { ledger: "running", update: "1", driver: "2026.9.1", bump: true },
+    { ledger: "running", update: "1", driver: "unknown", bump: true },
+    { ledger: "running", update: "1", driver: "2026.9.2", bump: false },
+    { ledger: "running", update: undefined, driver: "2026.9.2", bump: true },
+  ])("completes real migration when permitted: %j", async ({ ledger, update, driver, bump }) => {
+    vi.stubEnv("OPENCLAW_UPDATE_IN_PROGRESS", update);
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const shared = openOpenClawStateDatabase({ env: state.env }).path;
+      const run = createUpdateRun({ trigger: "cli", before: { version: driver } });
+      if (ledger === "finished") {
+        finishUpdateRun(run.runId, { status: "succeeded" });
+      }
+      closeOpenClawStateDatabaseForTest();
+      if (ledger === "missing") {
+        const db = new DatabaseSync(shared);
+        try {
+          db.exec("DROP TABLE update_runs");
+        } finally {
+          db.close();
+        }
+      }
+      if (bump) {
+        setSchemaVersion(shared, OPENCLAW_STATE_SCHEMA_VERSION - 1);
+      }
+      mocks.runContributions.mockImplementation(async () => {
+        const result = repairOpenClawStateDatabaseSchema({ env: state.env });
+        expect(result.warnings).toEqual([]);
+      });
+      await runDoctorHealthFlow(
+        { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        {
+          repair: true,
+          nonInteractive: true,
+        },
+      );
+      expect(readDatabase(shared).version).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
+      expect(mocks.outro).toHaveBeenCalledWith("Doctor complete.");
+    });
+  });
+
+  it("emits a structured refusal with a failure exit for the affected ledger writer", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const shared = openOpenClawStateDatabase({ env: state.env }).path;
+      createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } });
+      closeOpenClawStateDatabaseForTest();
+      setSchemaVersion(shared, OPENCLAW_STATE_SCHEMA_VERSION - 1);
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+        writeStdout: vi.fn(),
+        writeJson: vi.fn(),
+      };
+      await expect(
+        runDoctorHealthFlow(runtime, { repair: true, nonInteractive: true, json: true }),
+      ).rejects.toMatchObject({ code: 1 });
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(runtime.writeJson).toHaveBeenCalledWith(
+        {
+          ok: false,
+          error: expect.objectContaining({
+            code: "update-schema-bump-unfenced",
+            targetVersion: VERSION,
+            updaterVersion: "2026.9.2",
+            databases: [
+              expect.objectContaining({
+                kind: "state",
+                foundVersion: OPENCLAW_STATE_SCHEMA_VERSION - 1,
+              }),
+            ],
+          }),
+        },
+        2,
+      );
+    });
+  });
+});

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -72,6 +72,7 @@ export type IndeterminateOpenClawDatabase = {
 export type OpenClawDatabaseSchemaPreflight = {
   incompatible: IncompatibleOpenClawDatabase[];
   indeterminate: IndeterminateOpenClawDatabase[];
+  pendingMigrations?: Omit<IncompatibleOpenClawDatabase, "writerAppVersion">[];
 };
 
 type OpenClawStateSchemaPreflightResult = {
@@ -375,6 +376,14 @@ export async function preflightOpenClawDatabaseSchemas(options: {
       });
       stateDatabase.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
       const stateVersion = readSqliteUserVersion(stateDatabase);
+      if (stateVersion < options.supportedVersions.state) {
+        (result.pendingMigrations ??= []).push({
+          kind: "state",
+          path: statePath,
+          foundVersion: stateVersion,
+          supportedVersion: options.supportedVersions.state,
+        });
+      }
       if (stateVersion > options.supportedVersions.state) {
         const writerAppVersion = readWriterAppVersion(stateDatabase);
         result.incompatible.push({
@@ -502,6 +511,15 @@ export async function preflightOpenClawDatabaseSchemas(options: {
       });
       agentDatabase.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
       const agentVersion = readSqliteUserVersion(agentDatabase);
+      if (agentVersion < options.supportedVersions.agent) {
+        (result.pendingMigrations ??= []).push({
+          kind: "agent",
+          path: agentPath,
+          ...(row.agentId !== undefined ? { agentId: row.agentId } : {}),
+          foundVersion: agentVersion,
+          supportedVersion: options.supportedVersions.agent,
+        });
+      }
       if (agentVersion <= options.supportedVersions.agent) {
         if (options.verifyCurrentSchemaShape === true && row.agentId !== undefined) {
           // Existing agent databases require Doctor-owned migration before


### PR DESCRIPTION
## What Problem This Solves

Fixes updates driven by OpenClaw 2026.9.2 that migrate state with the target Doctor, then roll back to a package that cannot read the migrated database, leaving the Gateway stopped.

Related: #138839, #139495.

## Why This Change Was Made

The shipped [2026.9.2 global updater](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/infra/update-runner-global.ts#L113) runs the target's `doctor --non-interactive --fix` as post-install verification. Its [package swap](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/infra/package-update-steps.ts#L880-L965) restores the previous package on verification failure. However, the old [progress reader](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/progress.ts#L54) and ledger writer still reopen shared state after Doctor. Advancing the state schema from 15 to 16 makes those accesses fail.

The target now refuses before writes when update mode is active, an existing database needs a numeric schema upgrade, and a running ledger row identifies the driving updater as the parsed 2026.9.2 release line. This includes 2026.9.2 rebuilds and excludes 2026.9.3 prereleases and later releases, whose transactional updater was introduced in #138839 and hardened in #139495. Earlier updaters do not reopen the ledger; missing tables, no running row, and unparseable driver versions do not trigger this guard.

The CLI checks immediately after profile/dotenv selection, before debug capture can open SQLite, and direct Doctor callers check before maintenance. Schema inspection and the driver-version diagnostic use private read-only snapshots; the diagnostic avoids runtime quarantine admission. The typed refusal carries schema versions, the driver version, and the stop/install/doctor/start recovery sequence. Most of the added production code owns that diagnostic and refusal; existing preflight gains only pending-migration facts.

The transactional flow already suspends progress reads and buffers ledger writes before activation. It inspects migrated state and finalizes through candidate workers, while retaining package rollback ownership. No updater changes are needed.

## User Impact

Affected updates stop cleanly before migration, ledger writes, or config rewrites. The operator receives a manual installation path. Same-schema updates, standalone Doctor, earlier updaters without an active ledger, and drivers from 2026.9.3 onward retain their existing behavior. No environment variables, config keys, schema versions, or migration contents change.

## Evidence

The supplied AWS Crabbox baseline reproduced the 2026.9.2 failure: state 15 → 16, newer-schema errors in the old updater, package rollback, and an inactive Gateway. The coordinator separately verified successful 2026.9.1 → main and 2026.8.1-beta.3 → main updates; the compatibility tests preserve those no-ledger paths. This patch was validated with isolated SQLite fixtures and CLI processes; the full AWS update lane was not rerun for this patch.

The direct Doctor regression first failed because the affected updater was allowed to complete. The subprocess regression first failed because debug capture created WAL/SHM files before the late guard. Both now pass. Coverage includes unchanged database/config bytes and ledger rows, registered agent upgrades, 2026.9.2 rebuilds, missing/finished ledgers, later releases including prereleases, same-schema updates, and standalone Doctor.

On Linux/Node 24.19.0 using `blacksmith-testbox`, lease `tbx_01m1x0nq52fegfwyevb0d2r00k` ([runner workflow](https://github.com/openclaw/openclaw/actions/runs/34081832035)), the following commands passed with exit 0:

```sh
pnpm install --frozen-lockfile
pnpm check:changed
pnpm test src/flows/doctor-health.update-schema.test.ts src/flows/doctor-health.test.ts src/state/openclaw-database-preflight.test.ts src/state/openclaw-database-preflight.artifacts.test.ts src/cli/doctor-output.process.test.ts src/cli/run-main.profile-env.test.ts src/cli/run-main.test.ts
```

All **256 tests passed**: 142 unit, 8 CLI process, and 106 CLI startup tests. SHA-256 checks matched all eight changed files before and after validation. Existing CLI process tests hit subprocess/maintenance-heartbeat deadlines on the loaded local Mac; they all passed on Testbox without changing deadlines or assertions. The remote runner emitted a post-command portal-sync warning and a trailing heredoc-format warning after all eight final hashes matched; the validation command reported success.

Additional passing local checks:

```sh
node scripts/check-docs-mdx.mjs docs/install/updating.md docs/reference/database-schemas.md
pnpm docs:check-links:anchors
git diff --check
```

The anchor audit used the local ClawHub docs checkout via `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO` and checked 8,826 links with zero broken links. Independent autoreview was P0/P1 scoped-clean.


### Follow-up: exact legacy entry and WAL proof

Follow-up package proof found a fixture-builder defect: re-versioning the c9a639fb35e tarball changed every quoted `2026.9.2` literal, including `UNFENCED_LEDGER_UPDATER_RELEASE`, to `2026.9.3`. The altered constant was reachable from `dist/cli/run-main.js`. The intact pre-reversion artifact has the correct cutoff. The lane's re-versioning script now stamps explicit package/build/plugin/catalog identity fields and preserves historical compatibility constants; no production guard change was needed.

The new process regression failed against that exact altered tarball because Doctor completed with exit 0. The same regression passed for both `dist/index.js` and `dist/entry.js` against the corrected 2026.9.3 package: exit 1, refusal naming the 2026.9.2 driver, schema 15 unchanged, and identical DB/WAL/SHM/config bytes and ledger row. The row is committed only to WAL and its writer stays open throughout the exact `doctor --non-interactive --fix` invocation. The test fixture copies built directories so the process uses ordinary Node resolution, without symlink-preservation flags.

The committed tests use the normal built dist. Corrected B/B2 artifacts preserve the original guard implementation byte-for-byte while reporting 2026.9.3/2026.9.4 in their identity metadata. The full AWS service-update lane has not been rerun with these corrected artifacts.

Latest validation passed with exit 0:

```sh
pnpm build
pnpm check:changed
pnpm test src/commands/doctor-config-preflight.refusal.process.test.ts src/flows/doctor-health.update-schema.test.ts
```

All 17 focused tests passed (4 process cases and 13 guard cases), including the existing ordered-migration cases. Fresh P0/P1 autoreview was scoped-clean. The follow-up commit changes only the process regression and its fixture helper; the production version rule, environment surface, and migrations remain unchanged.
