### PR TITLE
perf(channels): snapshot raw Slack and Teams uploads as blobs

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1105,7 +1105,7 @@ extensions/slack/src/blocks-render.ts	1
 extensions/slack/src/channel-actions.ts	1
 extensions/slack/src/channel-type.ts	1
 extensions/slack/src/channel.ts	7
-extensions/slack/src/client-delivery.ts	5
+extensions/slack/src/client-delivery.ts	4
 extensions/slack/src/client-options.ts	5
 extensions/slack/src/directory-live.ts	2
 extensions/slack/src/doctor.ts	1

--- a/extensions/msteams/src/file-consent.test.ts
+++ b/extensions/msteams/src/file-consent.test.ts
@@ -325,7 +325,7 @@ describe("uploadToConsentUrl", () => {
       "Content-Type": "application/octet-stream",
       "User-Agent": buildUserAgent(),
     });
-    expect(opts?.body).toEqual(new Uint8Array(Buffer.from("hello")));
+    expect(Buffer.from(await new Response(opts?.body).arrayBuffer())).toEqual(Buffer.from("hello"));
   });
 
   it("aborts consent uploads that do not finish before the request timeout", async () => {
@@ -484,16 +484,35 @@ describe("uploadToConsentUrl", () => {
 
   it("allows upload to a valid SharePoint URL and performs PUT", async () => {
     const { response, cancel } = responseWithCancel(200);
-    const mockFetch = vi.fn<typeof fetch>(async () => response);
-    const buffer = Buffer.from("file content");
+    const backing = Buffer.from([0xfe, 0xfd, 1, 2, 3, 0xfc]);
+    const buffer = backing.subarray(2, 5);
+    const expectedBytes = Buffer.from([0, 0x80, 0xff]);
+    let finishResolution: () => void = () => {};
+    const resolutionReady = new Promise<void>((resolve) => {
+      finishResolution = resolve;
+    });
+    const resolveFn = vi.fn(async () => {
+      await resolutionReady;
+      return { address: "13.107.136.10" };
+    });
+    const mockFetch = vi.fn<typeof fetch>(async (_url, init) => {
+      backing.fill(0);
+      expect(Buffer.from(await new Response(init?.body).arrayBuffer())).toEqual(expectedBytes);
+      return response;
+    });
 
-    await uploadToConsentUrl({
+    const upload = uploadToConsentUrl({
       url: "https://contoso.sharepoint.com/sites/uploads/file.pdf",
       buffer,
       contentType: "application/pdf",
       fetchFn: mockFetch,
-      validationOpts: { resolveFn: publicResolve },
+      validationOpts: { resolveFn },
     });
+    await vi.waitFor(() => expect(resolveFn).toHaveBeenCalledOnce());
+    expect(mockFetch).not.toHaveBeenCalled();
+    expectedBytes.copy(buffer);
+    finishResolution();
+    await expect(upload).resolves.toBeUndefined();
 
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, opts] = firstFetchCall(mockFetch);
@@ -502,9 +521,8 @@ describe("uploadToConsentUrl", () => {
     expect(opts?.headers).toEqual({
       "User-Agent": buildUserAgent(),
       "Content-Type": "application/pdf",
-      "Content-Range": "bytes 0-11/12",
+      "Content-Range": "bytes 0-2/3",
     });
-    expect(opts?.body).toEqual(new Uint8Array(buffer));
     expect(opts?.signal).toBeInstanceOf(AbortSignal);
     expect(opts?.signal?.aborted).toBe(false);
     expect(cancel).toHaveBeenCalledOnce();

--- a/extensions/msteams/src/file-consent.ts
+++ b/extensions/msteams/src/file-consent.ts
@@ -9,6 +9,7 @@
  */
 
 import { lookup } from "node:dns/promises";
+import { bufferToBlobPart } from "openclaw/plugin-sdk/blob-runtime";
 import { isPrivateIpAddress } from "openclaw/plugin-sdk/ssrf-policy";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { fetchWithTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -219,7 +220,7 @@ export async function uploadToConsentUrl(params: {
         "Content-Type": params.contentType ?? "application/octet-stream",
         "Content-Range": `bytes 0-${params.buffer.length - 1}/${params.buffer.length}`,
       },
-      body: new Uint8Array(params.buffer),
+      body: new Blob([bufferToBlobPart(params.buffer)]),
     },
     params.timeoutMs ?? resolveMSTeamsSharePointUploadTimeoutMs(params.buffer.length),
     fetchFn,

--- a/extensions/msteams/src/graph-upload.test.ts
+++ b/extensions/msteams/src/graph-upload.test.ts
@@ -23,12 +23,16 @@ function requireFetchCall(fetchFn: ReturnType<typeof vi.fn>, index = 0): FetchCa
   return call;
 }
 
-function expectGraphUploadFetch(fetchFn: ReturnType<typeof vi.fn>, expectedUrl: string): void {
+function expectGraphUploadFetch(
+  fetchFn: ReturnType<typeof vi.fn>,
+  expectedUrl: string,
+  contentType = "application/octet-stream",
+): void {
   const [url, init] = requireFetchCall(fetchFn);
   expect(url).toBe(expectedUrl);
   expect(init?.method).toBe("PUT");
   expect(init?.headers?.Authorization).toBe("Bearer graph-token");
-  expect(init?.headers?.["Content-Type"]).toBe("application/octet-stream");
+  expect(init?.headers?.["Content-Type"]).toBe(contentType);
   expect(init?.headers?.["User-Agent"]).toMatch(/^teams\.ts\[apps\]\/.+ OpenClaw\/.+$/);
 }
 
@@ -224,26 +228,48 @@ describe("graph upload helpers", () => {
     expect(requireMSTeamsSharePointSiteId(" site-123 ")).toBe("site-123");
   });
 
-  it("uploads to SharePoint with the site drive path", async () => {
-    const fetchFn = vi.fn(async () =>
-      jsonResponse({ id: "item-2", webUrl: "https://example.com/2", name: "b.txt" }),
-    );
+  it.each([undefined, "application/pdf"])(
+    "uploads to SharePoint with the site drive path and MIME %s",
+    async (contentType) => {
+      const backing = Buffer.from([0xfe, 0xfd, 1, 2, 3, 0xfc]);
+      const buffer = backing.subarray(2, 5);
+      const expectedBytes = Buffer.from([0, 0x80, 0xff]);
+      let finishToken: (token: string) => void = () => {};
+      const tokenReady = new Promise<string>((resolve) => {
+        finishToken = resolve;
+      });
+      const delayedTokenProvider = { getAccessToken: vi.fn(async () => await tokenReady) };
+      const fetchFn = vi.fn<typeof fetch>(async (_url, init) => {
+        backing.fill(0);
+        expect(Buffer.from(await new Response(init?.body).arrayBuffer())).toEqual(expectedBytes);
+        return jsonResponse({ id: "item-2", webUrl: "https://example.com/2", name: "b.txt" });
+      });
 
-    const result = await uploadToSharePoint({
-      filename: "b.txt",
-      fetchFn: withFetchPreconnect(fetchFn),
-    });
+      const upload = uploadToSharePoint({
+        buffer,
+        contentType,
+        filename: "b.txt",
+        tokenProvider: delayedTokenProvider,
+        fetchFn: withFetchPreconnect(fetchFn),
+      });
+      await vi.waitFor(() => expect(delayedTokenProvider.getAccessToken).toHaveBeenCalledOnce());
+      expect(fetchFn).not.toHaveBeenCalled();
+      expectedBytes.copy(buffer);
+      finishToken("graph-token");
+      const result = await upload;
 
-    expectGraphUploadFetch(
-      fetchFn,
-      "https://graph.microsoft.com/v1.0/sites/site-123/drive/root:/OpenClawShared/b.txt:/content?@microsoft.graph.conflictBehavior=rename",
-    );
-    expect(result).toEqual({
-      id: "item-2",
-      webUrl: "https://example.com/2",
-      name: "b.txt",
-    });
-  });
+      expectGraphUploadFetch(
+        fetchFn,
+        "https://graph.microsoft.com/v1.0/sites/site-123/drive/root:/OpenClawShared/b.txt:/content?@microsoft.graph.conflictBehavior=rename",
+        contentType,
+      );
+      expect(result).toEqual({
+        id: "item-2",
+        webUrl: "https://example.com/2",
+        name: "b.txt",
+      });
+    },
+  );
 
   it("uploads with conflictBehavior=rename and surfaces the name SharePoint assigns", async () => {
     // Regression: openclaw-runtime image assets reuse names (image-1.png). Graph's default

--- a/extensions/msteams/src/graph-upload.ts
+++ b/extensions/msteams/src/graph-upload.ts
@@ -8,6 +8,7 @@
  * - Getting chat members for per-user sharing
  */
 
+import { bufferToBlobPart } from "openclaw/plugin-sdk/blob-runtime";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
 import { createMSTeamsHttpError } from "./http-error.js";
@@ -93,7 +94,7 @@ async function uploadToSharePoint(params: {
           Authorization: `Bearer ${token}`,
           "Content-Type": params.contentType ?? "application/octet-stream",
         },
-        body: new Uint8Array(params.buffer),
+        body: new Blob([bufferToBlobPart(params.buffer)]),
         signal,
       });
 

--- a/extensions/slack/src/client-delivery.ts
+++ b/extensions/slack/src/client-delivery.ts
@@ -1,6 +1,7 @@
 // Slack plugin module owns WebClient-scoped message and file delivery primitives.
 import type { MessageMetadata } from "@slack/types";
 import type { Block, ChatPostMessageResponse, KnownBlock, WebClient } from "@slack/web-api";
+import { bufferToBlobPart } from "openclaw/plugin-sdk/blob-runtime";
 import {
   extractErrorCode,
   PlatformMessageNotDispatchedError,
@@ -333,7 +334,7 @@ export async function uploadSlackFile(params: {
         init: {
           method: "POST",
           ...(contentType ? { headers: { "Content-Type": contentType } } : {}),
-          body: new Uint8Array(buffer) as BodyInit,
+          body: new Blob([bufferToBlobPart(buffer)]),
         },
         // The signal bounds the whole transfer; the guarded timeout also applies
         // the same budget to Undici's connect, header, and body phases.

--- a/extensions/slack/src/client-delivery.upload.test.ts
+++ b/extensions/slack/src/client-delivery.upload.test.ts
@@ -1,0 +1,64 @@
+import type { WebClient } from "@slack/web-api";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type { WebMediaResult } from "openclaw/plugin-sdk/web-media";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { loadMedia, guardedFetch } = vi.hoisted(() => ({
+  loadMedia: vi.fn<() => Promise<WebMediaResult>>(),
+  guardedFetch: vi.fn<typeof import("openclaw/plugin-sdk/ssrf-runtime").fetchWithSsrFGuard>(),
+}));
+
+vi.mock("openclaw/plugin-sdk/outbound-media", () => ({
+  loadOutboundMediaFromUrl: loadMedia,
+}));
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: guardedFetch,
+}));
+
+const { uploadSlackFile } = await import("./client-delivery.js");
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("uploadSlackFile snapshots", () => {
+  it.each(["image/png", undefined])("preserves upload bytes and MIME %s", async (contentType) => {
+    const backing = Buffer.from([0xfe, 0xfd, 1, 2, 3, 0xfc]);
+    const buffer = backing.subarray(2, 5);
+    const expectedBytes = Buffer.from([0, 0x80, 0xff]);
+    loadMedia.mockResolvedValue({ buffer, contentType, kind: "image", fileName: "image.png" });
+    const urlReady = createDeferred<void>();
+    const getUploadURLExternal = vi.fn(async () => {
+      await urlReady.promise;
+      return { ok: true, upload_url: "https://files.slack.com/upload", file_id: "F123" };
+    });
+    const completeUploadExternal = vi.fn(async () => ({ ok: true }));
+    const client = {
+      files: { getUploadURLExternal, completeUploadExternal },
+    } as unknown as WebClient;
+    let uploadedBytes: Buffer | undefined;
+    let uploadedMime: string | null | undefined;
+    guardedFetch.mockImplementation(async (params) => {
+      backing.fill(0);
+      const request = new Request(params.url, params.init);
+      uploadedBytes = Buffer.from(await request.arrayBuffer());
+      uploadedMime = request.headers.get("content-type");
+      return {
+        response: new Response("ok"),
+        finalUrl: params.url,
+        release: async () => {},
+      };
+    });
+
+    const upload = uploadSlackFile({ client, channelId: "C123", mediaUrl: "/tmp/image.png" });
+    await vi.waitFor(() => expect(getUploadURLExternal).toHaveBeenCalledOnce());
+    expect(guardedFetch).not.toHaveBeenCalled();
+    expectedBytes.copy(buffer);
+    urlReady.resolve();
+    await expect(upload).resolves.toBe("F123");
+
+    expect(uploadedBytes).toEqual(expectedBytes);
+    expect(uploadedMime).toBe(contentType ?? null);
+    expect(completeUploadExternal).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Closes #140786

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Slack and Teams raw file uploads pass Uint8Array snapshots to fetch, which copies those BufferSource bytes again. The queued transport can retain additional copied representations before connection admission.

## Why This Change Was Made

Use immediate Blob snapshots through the existing public bufferToBlobPart helper at the same three expressions: Slack after upload-URL acquisition, Graph after token acquisition, and file consent after URL/DNS validation. Exact Buffer slices and SharedArrayBuffer-backed inputs remain protected. Blob.type stays empty, leaving existing explicit MIME/range headers authoritative.

## User Impact

The actual 16 MiB Slack owner records 16,777,216 bytes copied by the real package BufferSource helper before, and zero afterward. Twenty real local HTTP upload scenarios plus two consent rejection controls preserve complete payloads, headers, result values, failures, completion order and deadline values across Slack, Graph and consent owners.

Separately, native/package transport probes at gated connection admission measured 32 MiB fewer retained ArrayBuffer bytes for a 16 MiB Blob request. Response-wait deltas differ and Blob native storage accounting is not the same as external-memory accounting; no fixed per-upload peak/RSS or whole-transfer saving is claimed. Blob still owns one immutable snapshot, and shared backing can need a temporary helper copy. Small transport timing controls showed no material regression, without establishing general throughput gains.

## Evidence

- Actual source owners run through real media loading/guards and a synthetic local HTTP server. Accepted responses traverse the real fetch transport; cases include ordinary/sliced/shared backing, mutation during prerequisite awaits and after snapshot, raw 503 failures, late completion errors, timeouts and rejected consent destinations.
- Long Slack/Graph deadlines use clock-controlled invocation of the already-armed owner timer after the real request reaches the server; this does not claim that full 120/301-second deadlines elapsed. Consent uses its real configurable short timeout.
- 169 focused tests across six files, the complete changed-file gate, normal build with SDK/bundled-plugin validation, and final isolated P2 review passed on the final seven-file candidate.
- Tests protect bytes, exact slice boundaries, snapshot timing, explicit/absent MIME, completion and cancellation. The old Slack send suite is unchanged; two focused cases live beside the upload owner.
- Production is net +3 lines, tests net +108. The assertion baseline shrinks only client-delivery.ts from five to four after removal of its BodyInit assertion. No dependency or configuration change.

Credit #135162 for the existing Blob helper. Active #119737, #123244 and #136274 address distinct receipt, response-validation and SharePoint-resolution behavior; their independent contracts must be preserved if they land first.
