### PR TITLE
refactor(chat): share transcript tool type vocabulary

### DIFF
--- a/src/gateway/chat-display-projection.canvas.ts
+++ b/src/gateway/chat-display-projection.canvas.ts
@@ -1,6 +1,7 @@
 import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { extractCanvasFromDetails, extractCanvasFromText } from "../chat/canvas-render.js";
+import { isToolCallContentType, isToolResultContentType } from "../chat/tool-content.js";
 import { truncateChatHistoryText } from "./chat-display-projection.helpers.js";
 
 const MAX_TOOL_APPROVAL_REVIEWS = 16;
@@ -52,23 +53,12 @@ export function isToolHistoryBlockType(type: unknown): boolean {
   if (typeof type !== "string") {
     return false;
   }
-  const normalized = type.trim().toLowerCase();
-  return (
-    normalized === "toolcall" ||
-    normalized === "tool_call" ||
-    normalized === "tooluse" ||
-    normalized === "tool_use" ||
-    normalized === "toolresult" ||
-    normalized === "tool_result"
-  );
+  const normalized = type.trim();
+  return isToolCallContentType(normalized) || isToolResultContentType(normalized);
 }
 
 export function isToolResultHistoryBlockType(type: unknown): boolean {
-  if (typeof type !== "string") {
-    return false;
-  }
-  const normalized = type.trim().toLowerCase();
-  return normalized === "toolresult" || normalized === "tool_result";
+  return typeof type === "string" && isToolResultContentType(type.trim());
 }
 
 export function projectToolResultDetails(


### PR DESCRIPTION
## What Problem This Solves

Gateway chat-history projection repeats the tool-call and tool-result spelling lists already maintained by the shared chat owner. A vocabulary update could otherwise reach rendering and history projection inconsistently.

## Why This Change Was Made

Reuse `isToolCallContentType` and `isToolResultContentType` from `src/chat/tool-content.ts`. Keep Gateway's existing trim at its boundary, and preserve the shared predicates' no-trim behavior. This is the final vocabulary consolidation in the maintainer-requested channel de-duplication campaign.

## User Impact

No intended user-visible or appearance change. Existing transcript spellings, case handling, whitespace handling, and non-string rejection remain unchanged. No public export is removed or added.

## Evidence

- Before: `node scripts/run-vitest.mjs src/gateway/chat-display-projection.canvas src/gateway/chat-display-projection.tool-result`: 34 tests passed, Vitest duration 56.92s.
- After, same command: 34 tests passed, Vitest duration 32.38s. Timings are affected by cache and host load; no performance claim is made.
- Isolated autoreview: zero actionable P0–P2 findings.
- Initial changed-file validation found seven unrelated type errors from stale installed `@openclaw/fs-safe` 0.8.1; current main's lockfile requires 0.8.3. `pnpm install --frozen-lockfile` synchronized this worktree without manifest changes. The full changed-file rerun passed, including core/test types, lint, architecture guards and zero unused exports.
- `pnpm build`: passed in 10m 16s, including all 152 public SDK subpaths, 90 external plugins, and native loads of 53 built control-plane modules.
- Exact-head CI [34083419184](https://github.com/openclaw/openclaw/actions/runs/34083419184): passed on `93c18fcb450309568bc44e8cdc33b12e65a8c5de`.
- Native review/prepare completed using `OPENCLAW_TESTBOX=1` hosted-evidence mode. No standalone Testbox lease was allocated.
- ClawSweeper review: no correctness or security findings.

Known gap: synthetic history-projection tests cover this boundary; no live channel account or browser rendering proof was run. The change does not alter display layout.
