### PR TITLE
fix(cli): describe telemetry show as a local preview

### DIFF
--- a/src/cli/telemetry-cli.ts
+++ b/src/cli/telemetry-cli.ts
@@ -86,7 +86,7 @@ export function registerTelemetryCli(program: Command): void {
 
   telemetry
     .command("show")
-    .description("Show exactly what the daily update request sends")
+    .description("Preview the daily update request from this CLI process")
     .option("--json", "Print the request and payload as JSON")
     .action(async (options: { json?: boolean }) =>
       runCommandWithRuntime(defaultRuntime, () => showTelemetry(options)),


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/140768

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where operators reading `openclaw telemetry show --help` could mistake the CLI-process preview for the exact next Gateway request. The help text still said "Show exactly what the daily update request sends" after the documentation clarified that distinction.

## Why This Change Was Made

Change only the command description to "Preview the daily update request from this CLI process." The command already builds its preview locally; payloads, status, configuration, cadence, options, and JSON output remain unchanged.

## User Impact

Telemetry help accurately describes a local preview without promising an exact running-Gateway payload. No behavior or consent setting changes.

## Evidence

- Real Commander help using the production `registerTelemetryCli` entry point was checked before and after, without a full build or Gateway:

```text
Before: Show exactly what the daily update request sends
After:  Preview the daily update request from this CLI process
```

- The visible help still lists the same `--json` and `--help` options. The probes invoked only `--help` with isolated state, `CI=1`, `OPENCLAW_NO_AUTO_UPDATE=1`, and `DO_NOT_TRACK=1`; no telemetry action or ingestion request was made.
- Existing `src/cli/telemetry-cli.test.ts`: all 9 tests passed, including JSON/status parity and preference writes. No brittle wording test or test-only export was added.
- Targeted formatting and `git diff --check` passed. Changed-check planning was inspected; broad local core typechecks and repository-wide validation are intentionally left to required exact-head CI for this one-string correction.
- Targeted oxlint passed; fresh independent review is scoped-clean through P2 with no actionable findings.
