### PR TITLE
refactor(config): reuse channel migration traversal

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2551,7 +2551,6 @@ src/config/io.write-prepare.ts	12
 src/config/io.write-safety.ts	4
 src/config/io.write.ts	6
 src/config/issue-location.ts	2
-src/config/legacy-private-network-migration.ts	1
 src/config/legacy.default-agent-roles.ts	1
 src/config/legacy.roster.ts	13
 src/config/legacy.ts	3

--- a/src/config/legacy-private-network-migration.test.ts
+++ b/src/config/legacy-private-network-migration.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { createLegacyPrivateNetworkDoctorContract } from "./legacy-private-network-migration.js";
+
+const { normalizeCompatibilityConfig } = createLegacyPrivateNetworkDoctorContract({
+  channelKey: "example",
+});
+
+describe("legacy private-network channel traversal", () => {
+  it("preserves root-first diagnostics, canonical precedence, and untouched scopes", () => {
+    const kept = { enabled: false };
+    const other = { enabled: true };
+    const cfg = {
+      channels: {
+        example: {
+          allowPrivateNetwork: true,
+          network: { dangerouslyAllowPrivateNetwork: false },
+          accounts: {
+            first: { allowPrivateNetwork: false },
+            kept,
+            invalid: null,
+            last: { allowPrivateNetwork: true },
+          },
+        },
+        other,
+      },
+    };
+
+    const result = normalizeCompatibilityConfig({ cfg });
+
+    expect(result.config).toEqual({
+      channels: {
+        example: {
+          network: { dangerouslyAllowPrivateNetwork: false },
+          accounts: {
+            first: { network: { dangerouslyAllowPrivateNetwork: false } },
+            kept,
+            invalid: null,
+            last: { network: { dangerouslyAllowPrivateNetwork: true } },
+          },
+        },
+        other,
+      },
+    });
+    expect(result.changes).toEqual([
+      "Moved channels.example.allowPrivateNetwork → channels.example.network.dangerouslyAllowPrivateNetwork (false).",
+      "Moved channels.example.accounts.first.allowPrivateNetwork → channels.example.accounts.first.network.dangerouslyAllowPrivateNetwork (false).",
+      "Moved channels.example.accounts.last.allowPrivateNetwork → channels.example.accounts.last.network.dangerouslyAllowPrivateNetwork (true).",
+    ]);
+    expect(cfg.channels.example.allowPrivateNetwork).toBe(true);
+    expect(cfg.channels.example.accounts.first.allowPrivateNetwork).toBe(false);
+    expect(result.config.channels?.other).toBe(other);
+
+    const repeated = normalizeCompatibilityConfig({ cfg: result.config });
+    expect(repeated.config).toBe(result.config);
+    expect(repeated.changes).toEqual([]);
+  });
+
+  it("does not migrate an array-shaped channel map through a numeric channel key", () => {
+    const cfg = { channels: [{ allowPrivateNetwork: true }] };
+    const contract = createLegacyPrivateNetworkDoctorContract({ channelKey: "0" });
+
+    const result = contract.normalizeCompatibilityConfig({ cfg });
+
+    expect(result.config).toBe(cfg);
+    expect(result.changes).toEqual([]);
+  });
+
+  it("keeps an array account map intact while migrating the channel root", () => {
+    const accounts = [{ allowPrivateNetwork: true }];
+    const cfg = { channels: { example: { allowPrivateNetwork: false, accounts } } };
+
+    const result = normalizeCompatibilityConfig({ cfg });
+
+    expect(result.config).toEqual({
+      channels: {
+        example: { accounts, network: { dangerouslyAllowPrivateNetwork: false } },
+      },
+    });
+    expect(result.changes).toEqual([
+      "Moved channels.example.allowPrivateNetwork → channels.example.network.dangerouslyAllowPrivateNetwork (false).",
+    ]);
+  });
+});

--- a/src/config/legacy-private-network-migration.ts
+++ b/src/config/legacy-private-network-migration.ts
@@ -11,6 +11,7 @@ import type {
   ChannelDoctorConfigMutation,
   ChannelDoctorLegacyConfigRule,
 } from "../plugin-sdk/channel-contract.js";
+import { normalizeChannelConfigEntries } from "./channel-doctor-helpers.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
 /** Detects the retired flat `allowPrivateNetwork` key before doctor migration. */
@@ -93,63 +94,15 @@ export function createLegacyPrivateNetworkDoctorContract(params: { channelKey: s
       },
     ],
     normalizeCompatibilityConfig: ({ cfg }) => {
-      const channels = asNullableRecord(cfg.channels);
-      const channelEntry = asNullableRecord(channels?.[params.channelKey]);
-      if (!channelEntry) {
+      // A channel array can expose numeric keys but must remain invalid config.
+      if (!asNullableRecord(cfg.channels)) {
         return { config: cfg, changes: [] };
       }
-
-      const changes: string[] = [];
-      let updatedChannel = channelEntry;
-      let changed = false;
-
-      const topLevel = migrateLegacyFlatAllowPrivateNetworkAlias({
-        entry: updatedChannel,
-        pathPrefix,
-        changes,
+      return normalizeChannelConfigEntries({
+        cfg,
+        channelId: params.channelKey,
+        normalizeEntry: migrateLegacyFlatAllowPrivateNetworkAlias,
       });
-      updatedChannel = topLevel.entry;
-      changed = changed || topLevel.changed;
-
-      const accounts = asNullableRecord(updatedChannel.accounts);
-      if (accounts) {
-        let accountsChanged = false;
-        const nextAccounts: Record<string, unknown> = { ...accounts };
-        for (const [accountId, accountValue] of Object.entries(accounts)) {
-          const account = asNullableRecord(accountValue);
-          if (!account) {
-            continue;
-          }
-          const migrated = migrateLegacyFlatAllowPrivateNetworkAlias({
-            entry: account,
-            pathPrefix: `${pathPrefix}.accounts.${accountId}`,
-            changes,
-          });
-          if (!migrated.changed) {
-            continue;
-          }
-          nextAccounts[accountId] = migrated.entry;
-          accountsChanged = true;
-        }
-        if (accountsChanged) {
-          updatedChannel = { ...updatedChannel, accounts: nextAccounts };
-          changed = true;
-        }
-      }
-
-      if (!changed) {
-        return { config: cfg, changes: [] };
-      }
-      return {
-        config: {
-          ...cfg,
-          channels: {
-            ...cfg.channels,
-            [params.channelKey]: updatedChannel,
-          } as OpenClawConfig["channels"],
-        },
-        changes,
-      };
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested de-duplication of private-network Doctor repair. The factory manually repeats the root/account traversal and immutable config reconstruction already owned by the shared channel Doctor helpers.

## Why This Change Was Made

Route the existing flat-key migration through `normalizeChannelConfigEntries`, retaining the factory's outer record guard so an array-shaped channel map remains invalid config. The shared owner preserves canonical-value precedence, root-first diagnostics, account iteration order, immutable updates, and unchanged-config identity on reruns.

Remove the obsolete assertion-safety baseline entry (1 → 0) in the same commit. This is the exact shrink-only maintenance requested by the maintainer and resolves the review finding.

## User Impact

No user-visible behavior, CLI-output, public API, config, or persisted-data change. Existing legacy private-network settings remain supported by Doctor. Production code decreases by 47 lines; boundary tests add 83 lines; the baseline shrinks by one line.

## Evidence

- `node scripts/run-vitest.mjs src/config/legacy-private-network-migration.test.ts extensions/mattermost/src/doctor.test.ts extensions/nextcloud-talk/src/doctor-contract.test.ts src/plugins/doctor-contract-closure-guard.test.ts`: all 11 tests passed again after the baseline change and rebase.
- Deliberate negative control without the outer guard: one of three owner tests failed because an array channel map became an object keyed by `"0"`. The guard is retained.
- `node --import ./scripts/tsx.mjs scripts/check-assertion-safety-ratchet.mts --base HEAD`: passed, 3,985 files and 11,909 grandfathered assertions.
- Fresh independent Codex review through P3, with shared-helper and record-predicate source supplied: zero actionable findings.
- Full `pnpm build` previously passed on Blacksmith Testbox `tbx_01m1x0s7bxykh7sqqkzbzgbd5c`, [workflow run](https://github.com/openclaw/openclaw/actions/runs/34081936577), through the repository Crabbox wrapper (3m41s). The lease is stopped. Migration, tests, and shared-helper source are unchanged from that build.
- Local `node scripts/check-changed.mjs` passed both ratchets, formatting, and plugin boundaries, then stopped at seven unrelated type errors: the worktree has `@openclaw/fs-safe` 0.8.1 installed while the lockfile requires 0.8.3. The complete changed-file check passed on clean Blacksmith Testbox `tbx_01m1x367vz26k6tty889t3zywv`, [run 34084528446](https://github.com/openclaw/openclaw/actions/runs/34084528446), in 16m16s with exit 0. The wrapper verified the exact candidate source/tree and stopped the lease. Command: `node scripts/crabbox-wrapper.mjs run --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 node scripts/check-changed.mjs`.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/34084352085) is green for `56883fd7978d6d0f35cdc19cf4c263ee69e90af9`, verified with `node scripts/watch-pr-ci.mjs 140790 56883fd7978d6d0f35cdc19cf4c263ee69e90af9`. ClawSweeper reviewed this head with no actionable findings. No live-service proof is claimed.

Native review artifacts validated with zero findings. `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 140790` completed with `OPENCLAW_PR_GATES_REMOTE` unset; the prepared head remains `56883fd7978d6d0f35cdc19cf4c263ee69e90af9`. Exact-head CI was rechecked green after prepare.
