### PR TITLE
refactor(google-meet): test platform guards through the tool

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -1467,41 +1467,63 @@ describe("google-meet plugin", () => {
     });
   });
 
-  it("keeps local Chrome talk-back available on Linux and blocks unsupported hosts", () => {
+  it("keeps local Chrome talk-back available on Linux and blocks unsupported hosts", async () => {
     const { cliRegistrations, methods, tools } = setup(undefined, { registerPlatform: "linux" });
+    const tool = getMeetTool({ tools });
+    const callGatewayFromCli = vi.fn(async () => ({ ok: true }));
+    googleMeetPluginTesting.setCallGatewayFromCliForTests(callGatewayFromCli);
 
     expect(tools).toHaveLength(1);
     expect(cliRegistrations).toHaveLength(1);
     expect(methods.has("googlemeet.setup")).toBe(true);
-    expect(
-      googleMeetPluginTesting.isGoogleMeetAgentToolActionUnsupportedOnHost({
-        config: resolveGoogleMeetConfig({}),
-        raw: { action: "join" },
-        platform: "linux",
-      }),
-    ).toBe(false);
 
-    expect(
-      googleMeetPluginTesting.isGoogleMeetAgentToolActionUnsupportedOnHost({
-        config: resolveGoogleMeetConfig({}),
-        raw: { action: "join", mode: "transcribe" },
-        platform: "linux",
-      }),
-    ).toBe(false);
-    expect(
-      googleMeetPluginTesting.isGoogleMeetAgentToolActionUnsupportedOnHost({
-        config: resolveGoogleMeetConfig({}),
-        raw: { action: "join" },
-        platform: "win32",
-      }),
-    ).toBe(true);
-    expect(
-      googleMeetPluginTesting.isGoogleMeetAgentToolActionUnsupportedOnHost({
-        config: resolveGoogleMeetConfig({}),
-        raw: { action: "join", transport: "chrome-node" },
-        platform: "linux",
-      }),
-    ).toBe(false);
+    const joined = await tool.execute("linux-agent", { action: "join" });
+    expect(joined.details).toEqual({ ok: true });
+    expect(callGatewayFromCli).toHaveBeenCalledOnce();
+    expect(callGatewayFromCli).toHaveBeenNthCalledWith(
+      1,
+      "googlemeet.join",
+      expect.any(Object),
+      { action: "join" },
+      { progress: false, scopes: ["operator.admin"] },
+    );
+
+    const transcribed = await tool.execute("linux-transcribe", {
+      action: "join",
+      mode: "transcribe",
+    });
+    expect(transcribed.details).toEqual({ ok: true });
+    expect(callGatewayFromCli).toHaveBeenCalledTimes(2);
+    expect(callGatewayFromCli).toHaveBeenNthCalledWith(
+      2,
+      "googlemeet.join",
+      expect.any(Object),
+      { action: "join", mode: "transcribe" },
+      { progress: false, scopes: ["operator.admin"] },
+    );
+
+    googleMeetPluginTesting.setPlatformForTests(() => "win32");
+    const blocked = await tool.execute("windows-agent", { action: "join" });
+    expect(blocked.details).toEqual({
+      error:
+        "Google Meet local Chrome talk-back audio requires macOS with BlackHole 2ch or Linux with PipeWire-Pulse. On this host, use mode: transcribe, transport: twilio, or a supported chrome-node.",
+    });
+    expect(callGatewayFromCli).toHaveBeenCalledTimes(2);
+
+    googleMeetPluginTesting.setPlatformForTests(() => "linux");
+    const remote = await tool.execute("linux-chrome-node", {
+      action: "join",
+      transport: "chrome-node",
+    });
+    expect(remote.details).toEqual({ ok: true });
+    expect(callGatewayFromCli).toHaveBeenCalledTimes(3);
+    expect(callGatewayFromCli).toHaveBeenNthCalledWith(
+      3,
+      "googlemeet.join",
+      expect.any(Object),
+      { action: "join", transport: "chrome-node" },
+      { progress: false, scopes: ["operator.admin"] },
+    );
   });
 
   it("returns structured gateway errors for missing session ids", async () => {

--- a/extensions/google-meet/src/plugin-registration.ts
+++ b/extensions/google-meet/src/plugin-registration.ts
@@ -112,9 +112,8 @@ function googleMeetGatewayMethodForToolAction(action: GoogleMeetGatewayToolActio
 function isGoogleMeetAgentToolActionUnsupportedOnHost(params: {
   config: GoogleMeetConfig;
   raw: Record<string, unknown>;
-  platform?: NodeJS.Platform;
 }): boolean {
-  const platform = params.platform ?? googleMeetToolDeps.platform();
+  const platform = googleMeetToolDeps.platform();
   if (platform === "darwin" || platform === "linux") {
     return false;
   }
@@ -281,5 +280,4 @@ export const testing = {
   setPlatformForTests(next?: () => NodeJS.Platform): void {
     googleMeetToolDeps.platform = next ?? (() => process.platform);
   },
-  isGoogleMeetAgentToolActionUnsupportedOnHost,
 };


### PR DESCRIPTION
## What Problem This Solves

Google Meet's platform test called a private predicate directly. It stayed green when the registered tool stopped invoking the platform guard, leaving the unsupported-host error path unprotected.

## Why This Change Was Made

Exercise the same four platform/mode/transport cases through the registered tool. Allowed cases assert their result and Gateway dispatch; the Windows case asserts the existing actionable error and no additional dispatch. Remove the private predicate's testing export and its test-only platform argument, using the existing platform producer and fixture setters.

## User Impact

No runtime behavior, supported platform, configuration, or API changes. The production diff removes two lines; the test grows by 22 lines to preserve all four cases at the tool boundary. Existing routing, authorization, browser ownership, lifecycle, transcript, and audio coverage stays intact.

## Evidence

- Both owning suites passed before and after: 178/178 tests, with every test name retained.
- Caller regression control: removing the tool's guard call leaves all 178 old cases green; the revised suite fails exactly the Windows case because it returns success instead of the existing platform error. The fault was removed and candidate bytes restored exactly.
- Read the original platform-guard history and Linux support change (#118451), the complete owning suites, registration/dispatch/config owners, and existing fixture lifecycle. Tests use the existing synthetic Gateway stub; no real meeting, provider call, microphone, or browser is involved.
- Independent applied review is clean through P2. All 25 required changed-file checks passed through the configured Blacksmith Testbox route ([run 34082784920](https://github.com/openclaw/openclaw/actions/runs/34082784920)); command exit 0 in 10m49s. The lease completed and its temporary checkout was removed. PR-head CI is tracked separately.
