### PR TITLE
fix(release): accept reviewed cleanup fixtures during validation

### DIFF
--- a/.agents/skills/release-openclaw-maintainer/SKILL.md
+++ b/.agents/skills/release-openclaw-maintainer/SKILL.md
@@ -32,6 +32,18 @@ validated publication and verification; do not ask again unless identity,
 channel, scope, or material risk changes. Ship authority for ordinary code is
 not release authority.
 
+An operator's explicit approval to do whatever is needed to prepare a named
+release is standing authority for the necessary preparation decisions and
+repairs. Carry it through candidate and tooling fixes, upgrade/migration design,
+reviewed test or security-inventory alignments, isolated proof, commits, pushes,
+and validation recovery. Record the decision, its evidence, and the selected
+support contract; do not ask again merely because an already-approved class of
+work reaches an implementation or verification step. Continue independent work
+while resolving a blocker. This authority does not permit hiding defects,
+lowering a gate to manufacture success, destructive changes to operator state,
+unrelated work, or publication. A prepare-only request still requires a separate
+publication instruction before releasing artifacts or a bridge version.
+
 Keep one compact state record using
 [the handoff template](references/release-handoff-template.md): effective goal,
 version/tag/branch, cut/Code/Tooling/Release SHAs, active parent run and attempt,

--- a/scripts/lib/plugin-npm-security-scan.mts
+++ b/scripts/lib/plugin-npm-security-scan.mts
@@ -143,6 +143,7 @@ const CURRENT_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS = new Map<string, number>(
   ["@openclaw/codex:dangerous-exec:dist/session-catalog-<hash>.js", 1],
   ["@openclaw/codex:dangerous-exec:dist/transport-stdio-<hash>.js", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/attempt-startup-retry.test.ts", 6],
+  ["@openclaw/codex:dangerous-exec:src/app-server/run-attempt-one-shot-cleanup.test.ts", 3],
   ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server.http.test.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-orphan.test-helper.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-orphan.test.ts", 3],

--- a/test/scripts/plugin-npm-security-scan.test.ts
+++ b/test/scripts/plugin-npm-security-scan.test.ts
@@ -261,6 +261,51 @@ describe("scripts/lib/plugin-npm-security-scan.mts", () => {
     ).toMatchObject({ layout: null, status: "fail" });
   });
 
+  it.each([null, 0, 2, 3, 4])(
+    "requires exactly three reviewed one-shot fixture spawns when packed: %s",
+    async (count) => {
+      const packageName = "@openclaw/codex";
+      const fixturePath = "src/app-server/run-attempt-one-shot-cleanup.test.ts";
+      const fixtureKey = `${packageName}:dangerous-exec:${fixturePath}`;
+      const spawnProbe =
+        'import { spawn } from "node:child_process";\nspawn(process.execPath, []);\n';
+      const artifact = writePluginArtifact({
+        extensionId: "codex",
+        packageName,
+        files: {
+          "src/app-server/transport-stdio.ts": spawnProbe,
+          "src/doctor.ts": spawnProbe,
+          "src/app-server/sandbox-exec-server/sandbox-child.ts": spawnProbe,
+          "src/app-server/transport-process-snapshot.ts": spawnProbe,
+          ...(count === null
+            ? {}
+            : {
+                [fixturePath]:
+                  'import { spawn } from "node:child_process";\n' +
+                  "spawn(process.execPath, []);\n".repeat(count),
+              }),
+        },
+      });
+      const scanned = await scanPublishablePluginPackages([artifact.artifact], "release/2026.9.3");
+      expect(scanned.scanErrors).toEqual([]);
+      expect(scanned.packageResults[0]?.unexpectedCriticalFindings).toEqual([]);
+      expect(scanned.packageResults[0]?.expectedReviewedCriticalFindings).toEqual(
+        count === null ? [] : Array.from({ length: 3 }, () => fixtureKey),
+      );
+      const report = buildPluginNpmSecurityScanReport({
+        candidateSha: CANDIDATE_SHA,
+        packageResults: scanned.packageResults,
+        targetContextRef: "release/2026.9.3",
+        toolingSha: TOOLING_SHA,
+      });
+      expect(report.errors.filter((error) => error.startsWith(`${packageName}:`))).toEqual(
+        count === null || count === 3
+          ? []
+          : [expect.stringContaining("reviewed critical inventory mismatch")],
+      );
+    },
+  );
+
   it.each([1, 2])(
     "reviews exactly one current hardware probe, preserving frozen policy: %s",
     async (count) => {


### PR DESCRIPTION
## What Problem This Solves

Full release validation rejects three reviewed process-spawn fixtures in the Codex plugin package as unexpected scanner findings. This blocked the 2026.9.3 candidate in [Full Release Validation 34071816366](https://github.com/openclaw/openclaw/actions/runs/34071816366).

## Why This Change Was Made

Record exactly three optional findings for the existing one-shot cleanup test file. These calls create isolated synthetic Node process trees and clean up their owned processes; the scanner itself and all other findings remain unchanged. Executable package tests require the exact count when the file is present and reject missing or additional findings.

The release-maintainer skill also records the operator-requested standing preparation authority, preserving separate publication authorization and all evidence and safety requirements.

## User Impact

Maintainers can validate the reviewed package without suppressing new scanner findings or repeating already-granted preparation approvals. This does not publish the release or make its other failing checks pass.

## Evidence

- Exact candidate source reviewed; the three scanner sites are the generated fixture launchers and their task-owned Node launcher.
- Absent/exact/under/over-count package scan regressions exercised; the original inventory failed the intended new cases.
- Scanner and runner suite: 30 tests passed on frozen tooling with full changed checks and independent review.
- Skill validation and independent review passed.
- Current-main integration checks and exact-head CI are required before landing.
