### PR TITLE
fix(android): keep open model settings current

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -5507,6 +5507,10 @@ class NodeRuntime private constructor(
     if (event == GatewayEvent.VoicewakeChanged.rawValue) {
       applyVoiceWakeWords(payloadJson)
     }
+    if (operatorConnected && (event == "config.changed" || event == "chat.metadata.changed")) {
+      refreshModelCatalog()
+      refreshProviderModels()
+    }
     if (event == "config.changed" || event == GatewayEvent.UsersPrefsChanged.rawValue) {
       // Config changes invalidate the snapshot; profile changes are targeted by
       // the gateway to connections bound to our own profile.

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeRuntimeAgentSelectionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeRuntimeAgentSelectionTest.kt
@@ -43,6 +43,92 @@ import java.util.concurrent.atomic.AtomicReference
 @Config(sdk = [34])
 class NodeRuntimeAgentSelectionTest {
   @Test
+  fun publicationsRereadSelectedAgentModelsWithoutDiscovery() =
+    runBlocking {
+      for (event in listOf("config.changed", "chat.metadata.changed")) {
+        val runtime = createConnectedRuntime()
+        val catalogRequests = Channel<Pair<JsonObject, Job>>(Channel.UNLIMITED)
+        val revision = AtomicInteger(0)
+        try {
+          runtime.gatewayDataRequestOverrideForTests = { _, method, paramsJson ->
+            when (method) {
+              "models.list" -> {
+                catalogRequests.send(Json.parseToJsonElement(paramsJson.orEmpty()).jsonObject to currentCoroutineContext().job)
+                """{"models":[{"id":"model-${revision.get()}","provider":"fixture","name":"Published"}]}"""
+              }
+
+              "models.authStatus" -> {
+                assertEquals(
+                  "beta",
+                  Json
+                    .parseToJsonElement(paramsJson.orEmpty())
+                    .jsonObject["agentId"]
+                    ?.jsonPrimitive
+                    ?.content,
+                )
+                """{"providers":[{"provider":"credential-${revision.get()}","status":"ok","profiles":[]}]}"""
+              }
+
+              "config.get" -> {
+                """{"config":{}}"""
+              }
+
+              else -> {
+                error("Unexpected publication request: $method")
+              }
+            }
+          }
+          runtime.selectChatAgent("beta")
+          runtime.refreshModelCatalog()
+          runtime.refreshProviderModels()
+          withTimeout(2_000) {
+            repeat(2) { catalogRequests.receive().second.join() }
+          }
+          assertEquals(
+            "model-0",
+            runtime.modelCatalog.value
+              .single()
+              .id,
+          )
+          assertEquals(
+            "model-0",
+            runtime.providerModelCatalog.value
+              .single()
+              .id,
+          )
+          assertEquals(
+            "credential-0",
+            runtime.modelAuthProviders.value
+              .single()
+              .id,
+          )
+          revision.set(1)
+          ReflectionHelpers.callInstanceMethod<Unit>(
+            runtime,
+            "handleGatewayEvent",
+            ReflectionHelpers.ClassParameter.from(String::class.java, event),
+            ReflectionHelpers.ClassParameter.from(String::class.java, "{}"),
+          )
+
+          withTimeout(2_000) {
+            runtime.modelCatalog.first { it.singleOrNull()?.id == "model-1" }
+            runtime.providerModelCatalog.first { it.singleOrNull()?.id == "model-1" }
+            runtime.modelAuthProviders.first { it.singleOrNull()?.id == "credential-1" }
+            repeat(2) {
+              val (params, job) = catalogRequests.receive()
+              job.join()
+              assertEquals("beta", params["agentId"]?.jsonPrimitive?.content)
+              assertFalse(params.containsKey("refresh"))
+            }
+          }
+        } finally {
+          closeNodeRuntimeTestFixture(runtime)
+          catalogRequests.close()
+        }
+      }
+    }
+
+  @Test
   fun defaultModelReadsKeepTheLegacyGatewayContract() =
     runBlocking {
       val runtime = createConnectedRuntime()

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -19,7 +19,7 @@ The official Android app is available on [Google Play](https://play.google.com/s
 - Install: [Google Play](https://play.google.com/store/apps/details?id=ai.openclaw.app&hl=en_IN) or `OpenClaw-Android.apk` from a supported [GitHub Release](https://github.com/openclaw/openclaw/releases), [Getting Started](/start/getting-started) for the Gateway, then [Pairing](/channels/pairing).
 - Gateway: [Runbook](/gateway) + [Configuration](/gateway/configuration).
   - Protocols: [Gateway protocol](/gateway/protocol) (nodes + control plane).
-- Select an agent in the sidebar to view its credential status in **Settings → Providers & Models**. Use **Refresh** to recheck model availability.
+- Select an agent in the sidebar to view its credential status in **Settings → Providers & Models**. The page updates when the Gateway publishes model, credential, or config changes. Use **Refresh** to recheck model availability.
 - **Settings → OpenClaw** opens a dedicated Gateway settings assistant when the operator connection has `operator.admin` and the Gateway supports `openclaw.chat`. Its setup conversation stays separate from ordinary Chat, redacts secret replies locally, and moves to Chat only after you tap **Open Chat**.
 
 Its reply field switches to masked input for secret prompts. Tap it again if a prompt change closes the keyboard. Android sends sensitive replies without trimming them and clears unsent drafts when you leave this page or background the app.


### PR DESCRIPTION
Related: #136257, #140130.

## What Problem This Solves

Android Providers & Models stayed stale after the Gateway accepted model-name or credential changes. Manual Refresh worked, but the open page ignored publication events.

## Why This Change Was Made

The current connection's configuration and metadata events refresh existing model and provider readers through their selected-agent and connection guards. Event-driven reads remain passive; explicit Refresh retains discovery behavior.

## User Impact

The open page follows accepted configuration changes and provider sign-out without navigation or reconnecting. Agent switching, visible errors, and reconnect-to-Gateway-default behavior remain intact. No configuration, protocol, or authentication-policy change is added.

Consumers: Android model and provider settings now reread published state on current-connection events.

## Evidence

The original client remained stale until manual refresh. A real emulator showed sign-out and two model-name changes on the open page within 15 seconds. Native checks covered passive versus explicit requests, selected-agent reads, event bursts, stale responses, rejection recovery, and reconnect behavior. All 36 focused owner/request tests passed; the event regression failed before the fix. Provider data was synthetic, with no inference. Sampled captures do not prove every frame or replacement-socket callback race.
