### PR TITLE
fix(bedrock): keep prompt cache checkpoints on conversation history

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -806,6 +806,14 @@ catalog, API-key auth, and dynamic model resolution.
       </Tab>
     </Tabs>
 
+    Set `supportsSystemPromptCacheBoundary: true` on a provider registration
+    only when its `createStreamFn` transport understands the stable/dynamic
+    system-prompt boundary. Use `splitSystemPromptCacheBoundary` from
+    `openclaw/plugin-sdk/provider-transport-runtime` to checkpoint the stable
+    prefix separately, and consume the marker before sending any payload.
+    Use `stripSystemPromptCacheBoundary` when caching is disabled. By default,
+    OpenClaw strips the marker before invoking a custom transport.
+
     For custom `createStreamFn` transports that accumulate JSON tool arguments,
     use `createToolArgumentPreviewSchedule()` from `openclaw/plugin-sdk/llm`.
     Create one schedule per tool call and pass the accumulated raw string's

--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -136,6 +136,7 @@ cache billing are described in [Model Studio context caching](https://www.alibab
 ### Amazon Bedrock
 
 - Anthropic Claude model refs (`amazon-bedrock/*anthropic.claude*`, plus AWS system inference profile prefixes `us.`/`eu.`/`global.anthropic.claude*`) support explicit `cacheRetention` pass-through.
+- The stable system prefix is checkpointed separately from dynamic runtime additions. Conversation checkpoints advance through retained history, including tool results; transient runtime-context carriers remain outside the cached prefix. Bedrock Mantle's Anthropic Messages transport also preserves the separate stable system boundary.
 - Non-Anthropic Bedrock models (for example `amazon.nova-*`) resolve to no cache retention at runtime, regardless of any configured `cacheRetention` value.
 - Opaque Bedrock application inference profile ARNs (profile IDs that do not contain `claude`) also resolve to no cache retention unless `cacheRetention` is set explicitly, since the model family cannot be inferred from the ARN alone.
 

--- a/extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.test.ts
+++ b/extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.test.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
 import type { Model } from "openclaw/plugin-sdk/llm";
 // Amazon Bedrock Mantle tests cover mantle anthropic plugin behavior.
 import {
@@ -58,6 +59,57 @@ function firstStreamOptions(deps: ReturnType<typeof createTestDeps>): Record<str
 }
 
 describe("createMantleAnthropicStreamFn", () => {
+  it.each(["short", "long", "none"] as const)(
+    "keeps the stable system prefix independently cacheable across suffix changes (%s)",
+    async (cacheRetention) => {
+      const systems: unknown[] = [];
+      for (const suffix of ["Today: Monday", "Today: Tuesday"]) {
+        let payload: unknown;
+        const events = await createMantleAnthropicStreamFn()(
+          createTestModel(),
+          {
+            systemPrompt: `Stable workspace${SYSTEM_PROMPT_CACHE_BOUNDARY}${suffix}`,
+            messages: [{ role: "user", content: "Hello", timestamp: 0 }],
+          },
+          {
+            apiKey: "synthetic-test-key",
+            cacheRetention,
+            onPayload: (request) => {
+              payload = request;
+              throw new Error("payload captured before network");
+            },
+          },
+        );
+        await events.result();
+        const request = requireRecord(payload, "Mantle payload");
+        systems.push(request.system);
+        expect(JSON.stringify(request)).not.toContain("OPENCLAW_CACHE_BOUNDARY");
+        if (cacheRetention === "none") {
+          expect(request.system).toEqual([{ type: "text", text: `Stable workspace\n${suffix}` }]);
+          expect(JSON.stringify(request)).not.toContain("cache_control");
+        } else {
+          expect(request.system).toEqual([
+            {
+              type: "text",
+              text: "Stable workspace",
+              cache_control: {
+                type: "ephemeral",
+                ...(cacheRetention === "long" ? { ttl: "1h" } : {}),
+              },
+            },
+            { type: "text", text: suffix },
+          ]);
+          expect(JSON.stringify(request).match(/"cache_control"/g)?.length).toBeLessThanOrEqual(4);
+        }
+      }
+      if (cacheRetention !== "none") {
+        expect(Array.isArray(systems[0]) && systems[0][0]).toEqual(
+          Array.isArray(systems[1]) && systems[1][0],
+        );
+      }
+    },
+  );
+
   it("uses authToken bearer auth for Mantle Anthropic requests", async () => {
     const stream = { kind: "anthropic-stream" };
     const model = createTestModel();

--- a/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
@@ -91,6 +91,7 @@ export function registerBedrockMantlePlugin(api: OpenClawPluginApi): void {
       }),
     normalizeResolvedModel: ({ modelId, model }) =>
       normalizeMantleResolvedModel({ modelId, model }),
+    supportsSystemPromptCacheBoundary: true,
     createStreamFn: ({ model }) =>
       model.api === "anthropic-messages" ? createMantleAnthropicStreamFn() : undefined,
     matchesContextOverflowError: ({ errorMessage }) =>

--- a/extensions/amazon-bedrock/bedrock-options.ts
+++ b/extensions/amazon-bedrock/bedrock-options.ts
@@ -2,7 +2,23 @@
  * Stream option extensions and prompt-cache policy for Amazon Bedrock models.
  * Provider registration and runtime streaming share these contracts.
  */
-import type { ModelThinkingLevel, StreamOptions, ThinkingBudgets } from "openclaw/plugin-sdk/llm";
+import type {
+  Model,
+  ModelThinkingLevel,
+  StreamOptions,
+  ThinkingBudgets,
+} from "openclaw/plugin-sdk/llm";
+import { resolveClaudeModelIdentity } from "openclaw/plugin-sdk/provider-model-shared";
+
+/** Share resolved model eligibility between the runtime and profile fallback. */
+export function supportsBedrockModelPromptCaching(
+  model: Pick<Model, "id" | "params"> & { name?: string },
+): boolean {
+  return (
+    supportsBedrockPromptCaching(model.id, model.name) ||
+    supportsBedrockPromptCaching(resolveClaudeModelIdentity(model), model.name)
+  );
+}
 
 /** How Bedrock thinking output should be displayed to users. */
 type BedrockThinkingDisplay = "summarized" | "omitted";

--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
 import { expectDefined } from "@openclaw/normalization-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type { Context, Model } from "openclaw/plugin-sdk/llm";
 import {
   buildPluginApi,
   registerSingleProviderPlugin,
@@ -1036,21 +1038,22 @@ describe("amazon-bedrock provider plugin", () => {
     async function callWrappedStreamWithPayload(
       provider: RegisteredProviderPlugin,
       modelId: string,
-      modelDescriptor: never,
+      modelDescriptor: Model,
       options: Record<string, unknown>,
       payload: Record<string, unknown>,
+      context: Context = { messages: [] },
     ): Promise<Record<string, unknown>> {
       const wrapped = provider.wrapStreamFn?.({
         provider: "amazon-bedrock",
         modelId,
+        model: modelDescriptor,
         streamFn: spyStreamFn,
       } as never);
 
-      const result = wrapped?.(
-        modelDescriptor,
-        { messages: [] } as never,
-        options,
-      ) as unknown as Record<string, unknown>;
+      const result = wrapped?.(modelDescriptor, context, options) as unknown as Record<
+        string,
+        unknown
+      >;
 
       if (typeof result?.onPayload === "function") {
         await (
@@ -1104,6 +1107,88 @@ describe("amazon-bedrock provider plugin", () => {
         expect(content).toHaveLength(2);
         expect(content[1]).toEqual({ cachePoint: { type: "default" } });
       }
+    });
+
+    it("keeps opaque-profile fallback checkpoints before dynamic system context and out of transient history", async () => {
+      const provider = await registerWithConfig(undefined);
+      const payload = {
+        system: [{ text: "Stable workspace" }, { text: "Dynamic suffix" }],
+        messages: [{ role: "user", content: [{ text: "Request with transient context" }] }],
+      };
+      await callWrappedStreamWithPayload(
+        provider,
+        APP_INFERENCE_PROFILE_ARN,
+        APP_INFERENCE_PROFILE_DESCRIPTOR,
+        { cacheRetention: "long" },
+        payload,
+        {
+          systemPrompt: `Stable workspace${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
+          messages: [
+            {
+              role: "user",
+              content: "Request with transient context",
+              runtimeContextCarrier: true,
+              timestamp: 0,
+            },
+          ],
+        },
+      );
+      expect(payload.system).toEqual([
+        { text: "Stable workspace" },
+        { cachePoint: { type: "default", ttl: "1h" } },
+        { text: "Dynamic suffix" },
+      ]);
+      expect(payload.messages[0]?.content).toEqual([{ text: "Request with transient context" }]);
+    });
+
+    it("leaves canonical-profile runtime checkpoints unchanged", async () => {
+      const provider = await registerWithConfig(undefined);
+      const payload = {
+        system: [
+          { text: "Stable workspace" },
+          { cachePoint: { type: "default" } },
+          { text: "Dynamic suffix" },
+        ],
+        messages: [
+          {
+            role: "user",
+            content: [{ text: "Stable request" }, { cachePoint: { type: "default" } }],
+          },
+          { role: "user", content: [{ text: "Transient context" }] },
+        ],
+      };
+      const expected = structuredClone(payload);
+      await callWrappedStreamWithPayload(
+        provider,
+        APP_INFERENCE_PROFILE_ARN,
+        {
+          id: APP_INFERENCE_PROFILE_ARN,
+          provider: "amazon-bedrock",
+          api: "bedrock-converse-stream",
+          name: "Test profile",
+          params: { canonicalModelId: "claude-haiku-4-5" },
+          baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+          reasoning: false,
+          input: ["text"],
+          contextWindow: 200000,
+          maxTokens: 1024,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        },
+        { cacheRetention: "short" },
+        payload,
+        {
+          messages: [
+            { role: "user", content: "Stable request", timestamp: 0 },
+            {
+              role: "user",
+              content: "Transient context",
+              runtimeContextCarrier: true,
+              timestamp: 1,
+            },
+          ],
+        },
+      );
+      expect(payload).toEqual(expected);
     });
 
     it("does not double-inject cache points if already present", async () => {

--- a/extensions/amazon-bedrock/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock/register.sync.runtime.ts
@@ -5,6 +5,7 @@
 import type { BedrockClient } from "@aws-sdk/client-bedrock";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { Context, Model } from "openclaw/plugin-sdk/llm";
 import { resolvePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
 import type {
   OpenClawPluginApi,
@@ -21,8 +22,12 @@ import {
   resolveClaudeSonnet5ModelIdentity,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { createPayloadPatchStreamWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
+import { splitSystemPromptCacheBoundary } from "openclaw/plugin-sdk/provider-transport-runtime";
 import { refreshAwsSharedConfigCacheForBedrock } from "./aws-credential-refresh.js";
-import { supportsBedrockPromptCaching } from "./bedrock-options.js";
+import {
+  supportsBedrockModelPromptCaching,
+  supportsBedrockPromptCaching,
+} from "./bedrock-options.js";
 import { loadBedrockControlPlaneSdk, runBedrockControlPlaneRequest } from "./control-plane.js";
 import { resolveBedrockConfigApiKey } from "./discovery-shared.js";
 import { bedrockMemoryEmbeddingProviderAdapter } from "./memory-embedding-adapter.js";
@@ -180,10 +185,6 @@ function createGuardrailWrapStreamFn(
   };
 }
 
-function sharedRuntimeWouldInjectCachePoints(modelId: string): boolean {
-  return supportsBedrockPromptCaching(modelId);
-}
-
 /**
  * Detect Bedrock application inference profile ARNs — these are the only IDs
  * where model-name-based checks fail because the ARN is opaque.
@@ -195,31 +196,6 @@ const BEDROCK_APP_INFERENCE_PROFILE_RE =
 
 function isBedrockAppInferenceProfile(modelId: string): boolean {
   return BEDROCK_APP_INFERENCE_PROFILE_RE.test(modelId);
-}
-
-/**
- * The shared runtime's `supportsPromptCaching` checks `model.id` for specific Claude
- * model name patterns, which fails for application inference profile ARNs (opaque
- * IDs that may not contain the model name). When OpenClaw's `isAnthropicBedrockModel`
- * identifies the model but the shared runtime won't inject cache points, we do it via onPayload.
- *
- * Gated to application inference profile ARNs only — regular Claude model IDs and
- * system-defined inference profiles (us.anthropic.claude-*) are left to the shared runtime.
- */
-function needsCachePointInjection(modelId: string): boolean {
-  // Only target application inference profile ARNs.
-  if (!isBedrockAppInferenceProfile(modelId)) {
-    return false;
-  }
-  // If the shared runtime would already inject cache points, skip.
-  if (sharedRuntimeWouldInjectCachePoints(modelId)) {
-    return false;
-  }
-  // Check if OpenClaw identifies this as an Anthropic model via the ARN heuristic.
-  if (isAnthropicBedrockModel(modelId)) {
-    return true;
-  }
-  return false;
 }
 
 /**
@@ -326,8 +302,10 @@ function makeCachePoint(cacheRetention: string | undefined): BedrockCachePoint {
 function injectBedrockCachePoints(
   payload: Record<string, unknown>,
   cacheRetention: string | undefined,
+  context: Context,
+  model: Model,
 ): void {
-  if (!cacheRetention || cacheRetention === "none") {
+  if (!cacheRetention || cacheRetention === "none" || supportsBedrockModelPromptCaching(model)) {
     return;
   }
   const point = makeCachePoint(cacheRetention);
@@ -335,7 +313,18 @@ function injectBedrockCachePoints(
   // Inject into system prompt if missing.
   const system = payload.system as BedrockContentBlock[] | undefined;
   if (Array.isArray(system) && system.length > 0 && !hasCachePoint(system)) {
-    system.push(point);
+    const split = context.systemPrompt && splitSystemPromptCacheBoundary(context.systemPrompt);
+    if (!split || split.stablePrefix) {
+      system.splice(split ? 1 : system.length, 0, point);
+    }
+  }
+
+  // Unresolved profiles use transient carriers. Conversion has removed their
+  // flags, so fallback injection cannot safely select a conversation anchor.
+  if (
+    context.messages.some((message) => message.role === "user" && message.runtimeContextCarrier)
+  ) {
+    return;
   }
 
   // Inject into the last user message if missing.
@@ -538,6 +527,7 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
     },
     resolveConfigApiKey: ({ env }) => resolveBedrockConfigApiKey(env),
     normalizeResolvedModel: normalizeBedrockResolvedModel,
+    supportsSystemPromptCacheBoundary: true,
     createStreamFn: ({ model }) =>
       model.api === "bedrock-converse-stream" ? bedrockStreamFn : undefined,
     ...anthropicByModelReplayHooks,
@@ -583,7 +573,7 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
         extractRegionFromBaseUrl(model?.baseUrl) ??
         currentPluginConfig?.discovery?.region;
       const mayNeedCacheInjection =
-        isBedrockAppInferenceProfile(modelId) && !sharedRuntimeWouldInjectCachePoints(modelId);
+        isBedrockAppInferenceProfile(modelId) && !supportsBedrockPromptCaching(modelId);
       const shouldOmitTemperature =
         opus47OrNewer || fable5 || isLatestAdaptiveBedrockModelRef(modelId, model?.params);
       const shouldPatchMaxThinking = supportsNativeMax && thinkingLevel === "max";
@@ -591,7 +581,7 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
 
       // For known Anthropic models (heuristic match), enable injection immediately.
       // For opaque profile IDs, we'll resolve via GetInferenceProfile on first call.
-      const heuristicMatch = needsCachePointInjection(modelId);
+      const heuristicMatch = isAnthropicBedrockModel(modelId);
 
       if (!region && !mayNeedCacheInjection && !shouldOmitTemperature && !shouldPatchMaxThinking) {
         return createAwsCredentialRefreshStreamWrapper(wrapped);
@@ -659,7 +649,7 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
               onPayload: async (payload: unknown, payloadModel: unknown) => {
                 if (payload && typeof payload === "object") {
                   const payloadRecord = payload as Record<string, unknown>;
-                  injectBedrockCachePoints(payloadRecord, cacheRetention);
+                  injectBedrockCachePoints(payloadRecord, cacheRetention, context, streamModel);
                   if (shouldPatchMaxThinking) {
                     patchMaxThinkingEffort(payloadRecord);
                   }
@@ -690,7 +680,7 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
               if (payload && typeof payload === "object") {
                 const payloadRecord = payload as Record<string, unknown>;
                 if (traits.cacheEligible) {
-                  injectBedrockCachePoints(payloadRecord, cacheRetention);
+                  injectBedrockCachePoints(payloadRecord, cacheRetention, context, streamModel);
                 }
                 if (shouldPatchMaxThinking) {
                   patchMaxThinkingEffort(payloadRecord);

--- a/extensions/amazon-bedrock/stream.runtime.accounting-replay.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.accounting-replay.test.ts
@@ -3,8 +3,11 @@ import {
   BedrockRuntimeClient,
   CacheTTL,
   ConversationRole,
+  ConverseStreamCommand,
   StopReason as BedrockStopReason,
 } from "@aws-sdk/client-bedrock-runtime";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
+import type { Context, Model } from "openclaw/plugin-sdk/llm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BedrockOptions } from "./bedrock-options.js";
 import { streamSimpleBedrock } from "./stream.runtime.js";
@@ -60,11 +63,11 @@ function streamBedrockForTest(
   return streamSimpleBedrock(model, context, options as never);
 }
 
-async function captureMessages(
+async function capturePayload(
   model: Parameters<typeof streamSimpleBedrock>[0],
   context: Parameters<typeof streamSimpleBedrock>[1],
   options: BedrockOptions = {},
-): Promise<Array<{ content?: unknown; role?: unknown }>> {
+) {
   const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
     $metadata: { httpStatusCode: 200 },
     stream: streamEvents([
@@ -73,13 +76,19 @@ async function captureMessages(
     ]),
   } as never);
   await streamBedrockForTest(model, context, options).result();
-  const command = send.mock.calls.at(-1)?.[0] as {
-    input?: { messages?: Array<{ content?: unknown; role?: unknown }> };
-  };
-  if (!command.input || !Array.isArray(command.input.messages)) {
-    throw new Error("expected ConverseStreamCommand messages");
+  const command = send.mock.calls.at(-1)?.[0];
+  if (!(command instanceof ConverseStreamCommand)) {
+    throw new Error("expected ConverseStreamCommand");
   }
-  return command.input.messages;
+  return command.input;
+}
+
+async function captureMessages(
+  model: Parameters<typeof streamSimpleBedrock>[0],
+  context: Context,
+  options: BedrockOptions = {},
+) {
+  return (await capturePayload(model, context, options)).messages ?? [];
 }
 
 afterEach(() => {
@@ -295,6 +304,128 @@ describe("Bedrock reasoning replay", () => {
 });
 
 describe("Bedrock prompt cache ownership", () => {
+  it.each(["direct", "application-profile"])(
+    "advances the retained-carrier checkpoint through a tool loop (%s)",
+    async (route) => {
+      const canonicalModelId = "claude-fable-5-1";
+      const model: Model<"bedrock-converse-stream"> = bedrockModel({
+        id:
+          route === "direct"
+            ? `anthropic.${canonicalModelId}-v1:0`
+            : "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/cache-test",
+        name: "Test deployment",
+        ...(route === "application-profile" ? { params: { canonicalModelId } } : {}),
+      });
+      const context: Context = {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "First request" },
+              { type: "text", text: "Retained context one" },
+            ],
+            runtimeContextCarrier: true,
+            timestamp: 0,
+          },
+          {
+            role: "assistant",
+            api: model.api,
+            provider: model.provider,
+            model: model.id,
+            content: [{ type: "text", text: "First answer" }],
+            stopReason: "stop",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: 1,
+          },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Second request" },
+              { type: "text", text: "Retained context two" },
+            ],
+            runtimeContextCarrier: true,
+            timestamp: 2,
+          },
+        ],
+      };
+      const first = await captureMessages(model, context, { cacheRetention: "short" });
+      expect(first[2]?.content?.at(-1)).toEqual({ cachePoint: { type: "default" } });
+      const previousAssistant = context.messages[1];
+      if (previousAssistant?.role !== "assistant") throw new Error("missing assistant fixture");
+      context.messages.push(
+        {
+          ...previousAssistant,
+          content: [{ type: "toolCall", id: "read_1", name: "read", arguments: {} }],
+          stopReason: "toolUse",
+          timestamp: 3,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "read_1",
+          toolName: "read",
+          content: [{ type: "text", text: "Tool output" }],
+          isError: false,
+          timestamp: 4,
+        },
+      );
+      const second = await captureMessages(model, context, { cacheRetention: "short" });
+      expect(second[2]?.content).toEqual([
+        { text: "Second request" },
+        { text: "Retained context two" },
+      ]);
+      expect(second[4]?.content?.at(-1)).toEqual({ cachePoint: { type: "default" } });
+      expect(second.slice(0, 2)).toEqual(first.slice(0, 2));
+    },
+  );
+
+  it.each(["short", "long", "none"] as const)(
+    "keeps stable system bytes and checkpoint position across suffix changes (%s)",
+    async (cacheRetention) => {
+      const requests = [];
+      for (const suffix of ["Today: Monday", "Today: Tuesday"]) {
+        requests.push(
+          await capturePayload(
+            bedrockModel({
+              id: "anthropic.claude-haiku-4-5-20251001-v1:0",
+              name: "Claude Haiku 4.5",
+            }),
+            {
+              systemPrompt: `Stable workspace${SYSTEM_PROMPT_CACHE_BOUNDARY}${suffix}`,
+              messages: [{ role: "user", content: "Hello", timestamp: 0 }],
+            },
+            { cacheRetention },
+          ),
+        );
+      }
+      for (const [index, payload] of requests.entries()) {
+        const suffix = index === 0 ? "Today: Monday" : "Today: Tuesday";
+        expect(JSON.stringify(payload)).not.toContain("OPENCLAW_CACHE_BOUNDARY");
+        if (cacheRetention === "none") {
+          expect(JSON.stringify(payload)).not.toContain("cachePoint");
+          expect(payload.system).toEqual([{ text: `Stable workspace\n${suffix}` }]);
+        } else {
+          expect(payload.system).toEqual([
+            { text: "Stable workspace" },
+            {
+              cachePoint: { type: "default", ...(cacheRetention === "long" ? { ttl: "1h" } : {}) },
+            },
+            { text: suffix },
+          ]);
+          expect(JSON.stringify(payload).match(/"cachePoint"/g)).toHaveLength(2);
+        }
+      }
+      if (cacheRetention !== "none")
+        expect(requests[0]?.system?.slice(0, 2)).toEqual(requests[1]?.system?.slice(0, 2));
+    },
+  );
+
   const model = () =>
     bedrockModel({ id: "anthropic.claude-haiku-4-5-20251001-v1:0", name: "Claude Haiku 4.5" });
 

--- a/extensions/amazon-bedrock/stream.runtime.accounting-replay.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.accounting-replay.test.ts
@@ -358,7 +358,9 @@ describe("Bedrock prompt cache ownership", () => {
       const first = await captureMessages(model, context, { cacheRetention: "short" });
       expect(first[2]?.content?.at(-1)).toEqual({ cachePoint: { type: "default" } });
       const previousAssistant = context.messages[1];
-      if (previousAssistant?.role !== "assistant") throw new Error("missing assistant fixture");
+      if (previousAssistant?.role !== "assistant") {
+        throw new Error("missing assistant fixture");
+      }
       context.messages.push(
         {
           ...previousAssistant,
@@ -421,8 +423,9 @@ describe("Bedrock prompt cache ownership", () => {
           expect(JSON.stringify(payload).match(/"cachePoint"/g)).toHaveLength(2);
         }
       }
-      if (cacheRetention !== "none")
+      if (cacheRetention !== "none") {
         expect(requests[0]?.system?.slice(0, 2)).toEqual(requests[1]?.system?.slice(0, 2));
+      }
     },
   );
 

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -57,6 +57,7 @@ import {
 } from "openclaw/plugin-sdk/llm";
 import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import {
+  bindsClaudeThinkingPrefix,
   resolveClaudeFable5ModelIdentity,
   resolveClaudeModelIdentity,
   resolveClaudeMythos5ModelIdentity,
@@ -76,9 +77,11 @@ import {
   failTransportStream,
   finalizeTerminalToolCallArguments,
   notifyProviderHttpMetadata,
+  splitSystemPromptCacheBoundary,
+  stripSystemPromptCacheBoundary,
 } from "openclaw/plugin-sdk/provider-transport-runtime";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { supportsBedrockPromptCaching, type BedrockOptions } from "./bedrock-options.js";
+import { supportsBedrockModelPromptCaching, type BedrockOptions } from "./bedrock-options.js";
 import { supportsBedrockNativeMaxEffort } from "./thinking-policy.js";
 
 type Block = (TextContent | ThinkingContent | ToolCall) & {
@@ -907,14 +910,6 @@ function isAnthropicClaudeModel(model: Model<"bedrock-converse-stream">): boolea
   );
 }
 
-function supportsPromptCaching(model: Model<"bedrock-converse-stream">): boolean {
-  return (
-    usesClaudeFable5BedrockContract(model) ||
-    supportsBedrockPromptCaching(model.id, model.name) ||
-    supportsBedrockPromptCaching(resolveClaudeModelIdentity(model), model.name)
-  );
-}
-
 /**
  * Check if the model supports thinking signatures in reasoningContent.
  * Only Anthropic Claude models support the signature field.
@@ -936,10 +931,17 @@ function buildSystemPrompt(
     return undefined;
   }
 
-  const blocks: SystemContentBlock[] = [{ text: sanitizeSurrogates(systemPrompt) }];
+  if (cacheRetention === "none") {
+    return [{ text: sanitizeSurrogates(stripSystemPromptCacheBoundary(systemPrompt)) }];
+  }
+  const split = splitSystemPromptCacheBoundary(systemPrompt);
+  const stablePrefix = split?.stablePrefix ?? systemPrompt;
+  const blocks: SystemContentBlock[] = stablePrefix
+    ? [{ text: sanitizeSurrogates(stablePrefix) }]
+    : [];
 
   // Add cache point for supported Claude models when caching is enabled
-  if (cacheRetention !== "none" && supportsPromptCaching(model)) {
+  if (stablePrefix && supportsBedrockModelPromptCaching(model)) {
     blocks.push({
       cachePoint: {
         type: CachePointType.DEFAULT,
@@ -948,7 +950,10 @@ function buildSystemPrompt(
     });
   }
 
-  return blocks;
+  if (split?.dynamicSuffix) {
+    blocks.push({ text: sanitizeSurrogates(stripSystemPromptCacheBoundary(split.dynamicSuffix)) });
+  }
+  return blocks.length > 0 ? blocks : undefined;
 }
 
 function normalizeToolCallId(id: string): string {
@@ -1014,7 +1019,11 @@ function convertMessages(
         if (content.length === 0) {
           continue;
         }
-        if (m.runtimeContextCarrier === true && firstVolatileMessageIndex === undefined) {
+        if (
+          m.runtimeContextCarrier === true &&
+          !bindsClaudeThinkingPrefix(model) &&
+          firstVolatileMessageIndex === undefined
+        ) {
           firstVolatileMessageIndex = result.length;
         }
         result.push({
@@ -1154,7 +1163,7 @@ function convertMessages(
   // context would still cache volatile bytes even when those anchors are stable.
   if (
     cacheRetention !== "none" &&
-    supportsPromptCaching(model) &&
+    supportsBedrockModelPromptCaching(model) &&
     result.at(-1)?.role === ConversationRole.USER
   ) {
     const cacheAnchor = result.findLast(

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -7,7 +7,6 @@ vi.mock("../context-engine-capabilities.js", () => ({
 }));
 import type { LlmRuntime } from "@openclaw/ai";
 import { defaultLlmRuntime } from "@openclaw/ai/internal/runtime";
-import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { addSession } from "../../bash-process-registry.js";
 import { createProcessSessionFixture } from "../../bash-process-registry.test-helpers.js";
@@ -531,31 +530,6 @@ describe("resolveEmbeddedAgentStream", () => {
     expect(providerStreamFn).toHaveBeenCalledTimes(1);
   });
 
-  it("strips the internal cache boundary before provider-owned stream calls", async () => {
-    const providerStreamFn = vi.fn(async (_model, context) => context);
-    const { streamFn } = resolveEmbeddedAgentStream({
-      currentStreamFn: undefined,
-      providerStreamFn,
-      sessionId: "session-1",
-      model: {
-        api: "openai-completions",
-        provider: "demo-provider",
-        id: "demo-model",
-      } as never,
-    });
-
-    const context = await streamFn(
-      { provider: "demo-provider", id: "demo-model" } as never,
-      {
-        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
-      } as never,
-      {},
-    );
-    expect(requireRecord(context, "stream context").systemPrompt).toBe(
-      "Stable prefix\nDynamic suffix",
-    );
-    expect(providerStreamFn).toHaveBeenCalledTimes(1);
-  });
   it("routes supported default streamSimple fallbacks through boundary-aware transports", () => {
     const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: undefined,

--- a/src/agents/embedded-agent-runner/stream-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.test.ts
@@ -5,11 +5,15 @@ import * as providerTransportStream from "@openclaw/ai/transports";
 // Stream resolution tests cover how embedded runs choose provider, boundary,
 // native Codex, or custom stream functions and pass auth/cache/signal options.
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import type { OpenClawPluginDefinition } from "openclaw/plugin-sdk/plugin-entry";
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { bindStreamLlmRuntime } from "../../llm/model-runtime-binding.js";
 import { streamSimple } from "../../llm/stream.js";
 import type { Model } from "../../llm/types.js";
+import { loadBundledPluginPublicSurface } from "../../plugin-sdk/test-helpers/public-surface-loader.js";
+import { resolveProviderStreamFn } from "../../plugins/provider-runtime.js";
 import { mintSecretSentinel } from "../../secrets/sentinel.js";
 import { wrapStreamFnWithProviderPromptState } from "./provider-prompt-state.js";
 import {
@@ -194,6 +198,124 @@ describe("prepared embedded stream strategy", () => {
 });
 
 describe("resolveEmbeddedAgentStream", () => {
+  it.each(["amazon-bedrock", "amazon-bedrock-mantle"])(
+    "preserves the stable system cache boundary through the registered %s transport",
+    async (providerId) => {
+      const { default: plugin } = await loadBundledPluginPublicSurface<{
+        default: OpenClawPluginDefinition;
+      }>({
+        pluginId: providerId,
+        artifactBasename: "index.ts",
+      });
+      const register = plugin.register;
+      if (!register) {
+        throw new Error("expected provider plugin registration");
+      }
+      const provider = await registerSingleProviderPlugin({ ...plugin, register });
+      const model: Model = {
+        provider: providerId,
+        api: providerId === "amazon-bedrock" ? "bedrock-converse-stream" : "anthropic-messages",
+        id: "anthropic.claude-haiku-4-5-20251001-v1:0",
+        name: "Claude Haiku 4.5",
+        baseUrl:
+          providerId === "amazon-bedrock"
+            ? "https://bedrock-runtime.us-east-1.amazonaws.com"
+            : "https://bedrock-mantle.us-east-1.api.aws/v1",
+        reasoning: false,
+        input: ["text"],
+        contextWindow: 200000,
+        maxTokens: 1024,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      };
+      const providerStreamFn = resolveProviderStreamFn({
+        provider: providerId,
+        runtimeHandle: { provider: providerId, plugin: provider },
+        context: { provider: providerId, modelId: model.id, model },
+      });
+      const { streamFn } = resolveEmbeddedAgentStream({
+        model,
+        providerStreamFn,
+        currentStreamFn: undefined,
+        sessionId: "registered-cache-test",
+      });
+      let payload: unknown;
+      const events = await streamFn(
+        model,
+        {
+          systemPrompt: `Stable workspace${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
+          messages: [{ role: "user", content: "Hello", timestamp: 0 }],
+        },
+        {
+          apiKey: "synthetic-test-key",
+          cacheRetention: "short",
+          onPayload: (request) => {
+            payload = request;
+            throw new Error("payload captured before network");
+          },
+        },
+      );
+      await events.result();
+      const request = requireRecord(payload, "registered provider payload");
+      expect(request.system).toEqual(
+        providerId === "amazon-bedrock"
+          ? [
+              { text: "Stable workspace" },
+              { cachePoint: { type: "default" } },
+              { text: "Dynamic suffix" },
+            ]
+          : [
+              { type: "text", text: "Stable workspace", cache_control: { type: "ephemeral" } },
+              { type: "text", text: "Dynamic suffix" },
+            ],
+      );
+      expect(JSON.stringify(request)).not.toContain("OPENCLAW_CACHE_BOUNDARY");
+    },
+  );
+
+  it.each([undefined, false, true])(
+    "passes the system cache boundary only to opted-in plugin streams (%s)",
+    async (supportsSystemPromptCacheBoundary) => {
+      const providerStreamFn = vi.fn<StreamFn>();
+      const model: Model = {
+        api: "custom-api",
+        provider: "test-provider",
+        id: "test-model",
+        name: "Test model",
+        baseUrl: "https://example.test",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 4096,
+        maxTokens: 1024,
+      };
+      const registeredStream = resolveProviderStreamFn({
+        provider: model.provider,
+        runtimeHandle: {
+          provider: model.provider,
+          plugin: {
+            id: model.provider,
+            label: "Test provider",
+            auth: [],
+            supportsSystemPromptCacheBoundary,
+            createStreamFn: () => providerStreamFn,
+          },
+        },
+        context: { provider: model.provider, modelId: model.id, model },
+      });
+      const { streamFn } = resolveEmbeddedAgentStream({
+        model,
+        providerStreamFn: registeredStream,
+        currentStreamFn: undefined,
+        sessionId: "cache-boundary-test",
+      });
+      const systemPrompt = `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`;
+      await streamFn(model, { systemPrompt, messages: [] });
+      expect(providerStreamFn.mock.calls[0]?.[1].systemPrompt).toBe(
+        supportsSystemPromptCacheBoundary ? systemPrompt : "Stable prefix\nDynamic suffix",
+      );
+    },
+  );
+
   it("preserves sentinels for registered provider streams", async () => {
     const secret = "plugin-stream-secret";
     const sentinel = mintSecretSentinel(secret, { label: "model-auth:plugin" });

--- a/src/agents/embedded-agent-runner/stream-resolution.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.ts
@@ -134,10 +134,8 @@ export function resolveEmbeddedAgentStream(
       : context;
   if (params.providerStreamFn) {
     return {
-      streamFn: wrapEmbeddedAgentStreamFn(params.providerStreamFn, {
-        ...wrapOptions,
-        transformContext: stripCacheBoundary,
-      }),
+      // Provider stream creation owns the plugin's cache-boundary capability.
+      streamFn: wrapEmbeddedAgentStreamFn(params.providerStreamFn, wrapOptions),
       strategy: "provider",
     };
   }

--- a/src/plugin-sdk/provider-transport-runtime.ts
+++ b/src/plugin-sdk/provider-transport-runtime.ts
@@ -5,6 +5,7 @@ export { buildGuardedModelFetch } from "../agents/provider-transport-fetch.js";
 export { buildOpenAICompletionsParams } from "../agents/openai-transport-stream.js";
 export {
   sortPromptCacheToolsByName,
+  splitSystemPromptCacheBoundary,
   stripSystemPromptCacheBoundary,
 } from "@openclaw/ai/internal/shared";
 export { transformTransportMessages } from "../agents/transport-message-transform.js";

--- a/src/plugins/provider-plugin.types.ts
+++ b/src/plugins/provider-plugin.types.ts
@@ -308,6 +308,12 @@ export type ProviderPlugin = {
    */
   createStreamFn?: (ctx: ProviderCreateStreamFnContext) => StreamFn | null | undefined;
   /**
+   * Opt custom streams into the internal stable/dynamic system-prompt boundary.
+   * The transport must consume the boundary before sending its provider payload.
+   * Otherwise the host strips it before invoking the custom stream.
+   */
+  supportsSystemPromptCacheBoundary?: boolean;
+  /**
    * Provider-owned stream wrapper applied after generic OpenClaw wrappers.
    *
    * Typical uses: provider attribution headers, request-body rewrites, or

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -811,14 +811,15 @@ describe("provider-runtime", () => {
     });
     setActivePluginRegistry(registry, "startup-registry", "gateway-bindable", "/tmp/workspace");
 
-    expect(
-      getAiTransportHost().plugin.resolveProviderStream({
-        provider: DEMO_PROVIDER_ID,
-        workspaceDir: "/tmp/workspace",
-        allowRuntimePluginLoad: false,
-        context: createDemoResolvedModelContext({}),
-      }),
-    ).toBe(streamFn);
+    const registeredStream = getAiTransportHost().plugin.resolveProviderStream({
+      provider: DEMO_PROVIDER_ID,
+      workspaceDir: "/tmp/workspace",
+      allowRuntimePluginLoad: false,
+      context: createDemoResolvedModelContext({}),
+    });
+    const context = { messages: [] };
+    void registeredStream?.(MODEL, context);
+    expect(streamFn).toHaveBeenCalledWith(MODEL, context, undefined);
     expect(createStreamFn).toHaveBeenCalledOnce();
     expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
   });
@@ -924,13 +925,14 @@ describe("provider-runtime", () => {
       }),
     ).toEqual({ headers: { "x-demo-turn": "turn-1" } });
     expect(resolveTransportTurnState).toHaveBeenCalledOnce();
-    expect(
-      getAiTransportHost().plugin.resolveProviderStream({
-        provider: DEMO_PROVIDER_ID,
-        allowRuntimePluginLoad: true,
-        context: createDemoResolvedModelContext({ model }),
-      }),
-    ).toBe(streamFn);
+    const registeredStream = getAiTransportHost().plugin.resolveProviderStream({
+      provider: DEMO_PROVIDER_ID,
+      allowRuntimePluginLoad: true,
+      context: createDemoResolvedModelContext({ model }),
+    });
+    const context = { messages: [] };
+    void registeredStream?.(model, context);
+    expect(streamFn).toHaveBeenCalledWith(model, context, undefined);
     expect(
       getAiTransportHost().plugin.wrapSimpleCompletionStream({
         provider: DEMO_PROVIDER_ID,
@@ -953,13 +955,14 @@ describe("provider-runtime", () => {
       modelId: MODEL.id,
       plugin: { id: DEMO_PROVIDER_ID, label: "Demo", auth: [] },
     });
-    expect(
-      getAiTransportHost().plugin.resolveProviderStream({
-        provider: "fallback",
-        allowRuntimePluginLoad: false,
-        context: createDemoResolvedModelContext({ model }),
-      }),
-    ).toBe(streamFn);
+    const registeredStream = getAiTransportHost().plugin.resolveProviderStream({
+      provider: "fallback",
+      allowRuntimePluginLoad: false,
+      context: createDemoResolvedModelContext({ model }),
+    });
+    const context = { messages: [] };
+    void registeredStream?.(model, context);
+    expect(streamFn).toHaveBeenCalledWith(model, context, undefined);
     expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
   });
 

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -1,3 +1,4 @@
+import { stripSystemPromptCacheBoundary } from "@openclaw/ai/internal/shared";
 // Composes provider plugin runtime hooks with shared provider policy.
 import {
   findNormalizedProviderValue,
@@ -13,6 +14,7 @@ import {
   mergePluginTextTransforms,
 } from "../agents/plugin-text-transforms.js";
 import { unwrapSecretSentinelsForProviderEgress } from "../agents/provider-secret-egress.js";
+import type { StreamFn } from "../agents/runtime/index.js";
 import type { ProviderSystemPromptContribution } from "../agents/system-prompt-contribution.js";
 import type { ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -572,7 +574,7 @@ export function resolveProviderStreamFn(params: {
   runtimeHandle?: ProviderRuntimePluginHandle;
   allowRuntimePluginLoad?: boolean;
   context: ProviderCreateStreamFnContext;
-}) {
+}): StreamFn | undefined {
   // Transport families may explicitly ask for a different fallback owner.
   const plugin =
     params.runtimeHandle?.provider === params.provider
@@ -580,7 +582,18 @@ export function resolveProviderStreamFn(params: {
       : params.allowRuntimePluginLoad === false
         ? resolveLoadedProviderRuntimePlugin(params)
         : resolveProviderRuntimePlugin(params);
-  return plugin?.createStreamFn?.(params.context) ?? undefined;
+  const streamFn = plugin?.createStreamFn?.(params.context);
+  if (!streamFn || plugin?.supportsSystemPromptCacheBoundary) {
+    return streamFn ?? undefined;
+  }
+  return (model, context, options) =>
+    streamFn(
+      model,
+      context.systemPrompt
+        ? { ...context, systemPrompt: stripSystemPromptCacheBoundary(context.systemPrompt) }
+        : context,
+      options,
+    );
 }
 
 export function resolveProviderTransportTurnStateWithPlugin(params: {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can update this branch in the repository.

</details>

## What Problem This Solves

Fixes an issue where users running Claude through Amazon Bedrock Converse would lose conversation prompt caching after retained runtime context was merged into the first user message. Conversation history, including subsequent tool loops, received no cache checkpoint.

Bedrock and Bedrock Mantle also cached the entire system prompt as one block, so a date rollover or other dynamic runtime change invalidated the stable workspace prefix.

## Why This Change Was Made

Retained, append-only runtime-context carriers now remain stable conversation anchors; only transient carriers impose the checkpoint cutoff, and checkpoints advance through tool results. Provider registrations can opt into `supportsSystemPromptCacheBoundary`, allowing Bedrock and Mantle to consume the existing system boundary and checkpoint the stable prefix separately from dynamic additions. Other custom transports retain boundary stripping by default.

Application-profile fallback injection respects the split and preserves runtime-owned checkpoints. Opaque profiles with transient carriers conservatively retain only the system checkpoint. No operator configuration, schema, persistent-store, or dependency changes are introduced.

## User Impact

Bedrock Claude conversations can reuse retained history across turns and tool loops. Bedrock and Mantle can preserve the stable system prefix when dynamic runtime facts change. Disabled caching, transient-context exclusion, thinking signatures, and role merging retain their existing behavior.

The SDK opt-in is documented in `docs/plugins/sdk-provider-plugins.md`; provider behavior is documented in `docs/reference/prompt-caching.md`.

## Evidence

- Focused proof: `node scripts/run-vitest.mjs extensions/amazon-bedrock extensions/amazon-bedrock-mantle src/agents/embedded-agent-runner/stream-resolution.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts src/plugins/provider-runtime.test.ts` — 18 files, 590 tests passed across four shards in the implementation run. The fresh publication sanity run also passed all 590 tests in 18 files across four shards (148.22 seconds).
- After the final test-fixture type correction, `stream-resolution.test.ts` passed all 47 tests; all four typecheck lanes subsequently passed. Production code did not change after the successful build.
- `pnpm build` passed, including runtime, package/SDK declarations, export checks, and UI build.
- Codex autoreview of the exact staged patch: scoped-clean, 0 accepted/actionable P0/P1 findings. Publication verified byte-for-byte equality with the reviewed patch.
- Before the fix, payload/profile coverage produced seven expected regression failures; registered-stream coverage produced three expected failures. They exercised missing conversation checkpoints, stripped system boundaries, and profile injection.
- Local `check:changed` passed every gate through core lint: formatting, ratchets, imports and SDK guards, declaration checks, all four typecheck lanes, and three dead-export scans (zero findings). It stopped at extension-lint artifact preparation with `Declaration input escapes checkout ... qrcode`, caused by this nested worktree's ancestor installation. The declaration-boundary guard is unchanged. Fresh-checkout CI's extension lint lane is the authoritative remaining proof; later local gates were not reached.
- Payload coverage exercises the actual Converse and Anthropic Messages builders, both plugin registrations, retained/transient carriers, advancing tool-loop checkpoints, stable-prefix bytes, marker removal, disabled caching, and one-hour TTL. No authenticated live AWS requests or cache-hit billing measurements were made.
- `git diff --cached --check` passed.
- Diff: 16 files, +532/-119; production +91/-57, tests +432/-62, docs +9/-0.

CI follow-up: the [first ready-state run](https://github.com/openclaw/openclaw/actions/runs/34083863043) reached extension lint and found two missing-brace errors in the changed checkpoint test. A follow-up commit adds those braces; targeted lint, formatting, all 20 tests in that file, and fresh Codex autoreview (0 actionable P0/P1 findings) passed. The same run's `check-guards` failed independently during Matrix native dependency installation (`ECONNRESET`, followed by an installer `ReferenceError`), before guards executed. No dependency or guard changes were made. The follow-up exact-head CI result is recorded below.

Final CI: [run 34084194236](https://github.com/openclaw/openclaw/actions/runs/34084194236) completed successfully for `9f51c58878faf022d81cd497f62109240a52f924`: 108 successful jobs, 16 intentional skips, zero failed jobs. `check-lint` (including extension lint) and `check-guards` both passed. The bounded exact-head watcher terminated `GREEN` (exit 0), reconciling superseded checks, including the stale cancelled Labeler status. The earlier watcher terminated `FAILING checks=check-guards` (exit 15); its source-related lint findings were fixed as described above.
