### PR TITLE
fix(meeting): cancel consults and seal speech on shutdown

### DIFF
--- a/docs/plugins/meeting-plugins.md
+++ b/docs/plugins/meeting-plugins.md
@@ -36,6 +36,8 @@ Use `transcribe` when the agent only needs meeting text. Use `agent` for normal 
 
 In `bidi` mode, recoverable provider diagnostics are logged without stopping the audio bridge. Providers that support reconnecting own that recovery. Terminal provider closure, exhausted recovery, failed initial setup, and local audio-transport failures still stop the bridge; leaving the meeting also stops it.
 
+Stopping a meeting requests cancellation of any active agent consult. In `agent` mode, OpenClaw finishes active output and turn events before closing the session, then ignores late speech synthesis and audio delivery results.
+
 The bounded live transcript remains available only in `transcribe` mode. In all
 three modes, browser joins also persist completed caption rows and a derived
 summary to the shared state database. Leaving the meeting finalizes visible

--- a/src/meeting-bot/realtime-agent-engine.ts
+++ b/src/meeting-bot/realtime-agent-engine.ts
@@ -77,6 +77,8 @@ export async function startMeetingAgentRealtimeEngine(params: {
           `${params.platform.logScope} ${agentLogScope} transcription bridge close ignored: ${formatErrorMessage(error)}`,
         );
       }
+      harness.finishOutputAudio("stopped");
+      harness.endTurn("stopped");
       harness.emit({
         type: "session.closed",
         final: true,
@@ -135,6 +137,9 @@ export async function startMeetingAgentRealtimeEngine(params: {
           text: normalized,
           cfg: params.fullConfig,
         });
+        if (stopped) {
+          return;
+        }
         if (!result.success || !result.audioBuffer || !result.sampleRate) {
           throw new Error(result.error ?? "TTS conversion failed");
         }
@@ -150,10 +155,16 @@ export async function startMeetingAgentRealtimeEngine(params: {
             params.platform.displayName,
           ),
         );
+        if (stopped) {
+          return;
+        }
         harness.finishOutputAudio("completed");
         harness.endTurn();
       })
       .catch((error: unknown) => {
+        if (stopped) {
+          return;
+        }
         // TTS and sink failures happen after a turn, and sometimes output, has started.
         // Close both spans so later input cannot inherit stale playback suppression.
         harness.finishOutputAudio("failed");
@@ -200,12 +211,13 @@ export async function startMeetingAgentRealtimeEngine(params: {
       logPrefix: `${params.platform.logScope} ${agentLogScope}`,
       responseStyle: "Brief, natural spoken answer for a live meeting.",
       fallbackText: "I hit an error while checking that. Please try again.",
-      consult: ({ question, responseStyle }) =>
+      consult: ({ question, responseStyle, signal }) =>
         params.consultAgent({
           meetingSessionId: params.meetingSessionId,
           requesterSessionKey: params.requesterSessionKey,
           args: { question, responseStyle },
           transcript: harness.transcript,
+          abortSignal: signal,
         }),
       deliver: enqueueSpeakText,
     },

--- a/src/meeting-bot/realtime-engine.ts
+++ b/src/meeting-bot/realtime-engine.ts
@@ -64,6 +64,8 @@ export type MeetingAgentConsultParams = {
   requesterSessionKey?: string;
   args: unknown;
   transcript: Array<{ role: "user" | "assistant"; text: string }>;
+  /** Meeting-owned cancellation for the active consult. */
+  abortSignal?: AbortSignal;
 };
 
 export type MeetingRealtimeToolCallParams = {
@@ -439,12 +441,13 @@ export async function startMeetingRealtimeEngine(params: {
       logPrefix: `${params.platform.logScope} ${realtimeLogScope} agent`,
       responseStyle: "Brief, natural spoken answer for a live meeting.",
       fallbackText: "I hit an error while checking that. Please try again.",
-      consult: ({ question, responseStyle }) =>
+      consult: ({ question, responseStyle, signal }) =>
         params.consultAgent({
           meetingSessionId: params.meetingSessionId,
           requesterSessionKey: params.requesterSessionKey,
           args: { question, responseStyle },
           transcript: harness.transcript,
+          abortSignal: signal,
         }),
       deliver: (text) => {
         bridge?.sendUserMessage(buildMeetingSpeakExactUserMessage(text));

--- a/src/meeting-bot/realtime-shutdown.test.ts
+++ b/src/meeting-bot/realtime-shutdown.test.ts
@@ -1,0 +1,373 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { setImmediate } from "node:timers/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RunEmbeddedAgentParams } from "../agents/embedded-agent-runner/run/params.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { PluginRuntime } from "../plugins/runtime/types.js";
+import type {
+  RealtimeTranscriptionProviderPlugin,
+  RealtimeVoiceProviderPlugin,
+} from "../plugins/types.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { createMeetingRealtimeEngineBindings } from "./agent-consult.js";
+import { startMeetingAgentRealtimeEngine } from "./realtime-agent-engine.js";
+import * as audioFormat from "./realtime-audio-format.js";
+import type { MeetingRealtimeAudioTransport } from "./realtime-audio-transport.js";
+import {
+  MEETING_AGENT_TRANSCRIPT_DEBOUNCE_MS,
+  startMeetingRealtimeEngine,
+} from "./realtime-engine.js";
+
+const environment = captureEnv(["OPENCLAW_STATE_DIR", "OPENCLAW_CONFIG_PATH"]);
+let stateDir: string;
+const spokenResult = {
+  success: true,
+  audioBuffer: Buffer.from([1, 0, 2, 0]),
+  sampleRate: 24_000,
+  outputFormat: "pcm16",
+};
+
+async function createFixture(engine: "transcription" | "voice" = "transcription") {
+  const sessionKey = "agent:main:subagent:test-meeting:meeting-1";
+  let entry: SessionEntry = { sessionId: "synthetic-consult", updatedAt: 1 };
+  const runEmbeddedAgent = vi.fn(async (_params: RunEmbeddedAgentParams) => ({
+    payloads: [{ text: "The synthetic answer." }],
+    meta: {},
+  }));
+  const textToSpeechTelephony = vi.fn(async () => spokenResult);
+  const runtime = {
+    agent: {
+      resolveAgentDir: () => path.join(stateDir, "agent"),
+      resolveAgentWorkspaceDir: () => path.join(stateDir, "workspace"),
+      ensureAgentWorkspace: async () => {},
+      resolveAgentTimeoutMs: () => 30_000,
+      session: {
+        resolveStorePath: () => path.join(stateDir, "sessions.json"),
+        getSessionEntry: ({ sessionKey: key }: { sessionKey: string }) =>
+          key === sessionKey ? entry : undefined,
+        patchSessionEntry: async ({
+          update,
+        }: {
+          update: (current: SessionEntry) => Promise<Partial<SessionEntry>>;
+        }) => {
+          entry = { ...entry, ...(await update(entry)) };
+          return entry;
+        },
+      },
+      runEmbeddedAgent,
+    },
+    tts: { textToSpeechTelephony },
+  } as unknown as PluginRuntime;
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  const config = {
+    chrome: { audioFormat: "pcm16-24khz" as const },
+    realtime: { strategy: "agent", provider: "test", providers: { test: {} } },
+  };
+  const bindings = createMeetingRealtimeEngineBindings({
+    platform: {
+      id: "test-meeting",
+      displayName: "Test Meeting",
+      logScope: "[test-meeting]",
+      agentConsult: {
+        surface: "a synthetic meeting",
+        userLabel: "Participant",
+        assistantLabel: "Agent",
+        questionSourceLabel: "participant",
+        workingResponseLabel: "participant",
+        extraSystemPrompt: "Answer briefly.",
+      },
+      session: { idPrefix: "test_meeting", participantIdentity: () => "Test participant" },
+    },
+    config: { realtime: { toolPolicy: "safe-read-only" } },
+    fullConfig: {},
+    runtime,
+    logger,
+  });
+  let fatal = () => {};
+  let transcript = (_text: string) => {};
+  const disposed = createDeferredCore();
+  const writeOutput = vi.fn(async (_audio: Buffer) => {});
+  const sendUserMessage = vi.fn();
+  const transport: MeetingRealtimeAudioTransport = {
+    onFatal: (handler) => {
+      fatal = handler;
+    },
+    startInput: vi.fn(),
+    beginOutput: vi.fn(),
+    stop: vi.fn(async () => {}),
+    dispose: vi.fn(async () => {
+      disposed.resolve();
+    }),
+    clearOutput: vi.fn(async () => {}),
+    writeOutput,
+  };
+  const common = {
+    config,
+    fullConfig: {},
+    runtime,
+    ...bindings,
+    meetingSessionId: "meeting-1",
+    // A different requester agent naturally uses the existing isolated consult branch.
+    requesterSessionKey: "agent:requester:main",
+    logger,
+    transport,
+  };
+  let handle;
+  if (engine === "transcription") {
+    const provider: RealtimeTranscriptionProviderPlugin = {
+      id: "test",
+      label: "Test",
+      isConfigured: () => true,
+      createSession: (request) => {
+        transcript = (text) => request.onTranscript?.(text);
+        return { connect: async () => {}, sendAudio() {}, close() {}, isConnected: () => true };
+      },
+    };
+    handle = await startMeetingAgentRealtimeEngine({ ...common, providers: [provider] });
+  } else {
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "test",
+      label: "Test",
+      isConfigured: () => true,
+      createBridge: (request) => {
+        transcript = (text) => request.onTranscript?.("user", text, true);
+        return {
+          connect: async () => {
+            request.onReady?.();
+          },
+          sendAudio() {},
+          setMediaTimestamp() {},
+          submitToolResult() {},
+          acknowledgeMark() {},
+          close() {},
+          isConnected: () => true,
+          sendUserMessage,
+        };
+      },
+    };
+    handle = await startMeetingRealtimeEngine({ ...common, providers: [provider] });
+  }
+  return {
+    handle,
+    runtime,
+    runEmbeddedAgent,
+    textToSpeechTelephony,
+    writeOutput,
+    sendUserMessage,
+    logger,
+    transcript: (text: string) => transcript(text),
+    stop: async (kind: "stop" | "fatal") => {
+      if (kind === "fatal") {
+        fatal();
+        await disposed.promise;
+        await setImmediate();
+      } else {
+        await handle.stop();
+      }
+    },
+    eventTypes: () => handle.getHealth().recentTalkEvents.map((event) => event.type),
+  };
+}
+
+describe("meeting shutdown", () => {
+  beforeEach(async () => {
+    stateDir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "meeting-shutdown-")));
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    const configPath = path.join(stateDir, "openclaw.json");
+    await fs.writeFile(configPath, "{}\n");
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+    vi.useFakeTimers();
+  });
+  afterEach(async () => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    environment.restore();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it.each(["transcription", "voice"] as const)(
+    "delivers a completed %s consult once",
+    async (engine) => {
+      const fixture = await createFixture(engine);
+      const delivered = createDeferredCore();
+      fixture.textToSpeechTelephony.mockImplementation(async () => {
+        delivered.resolve();
+        return spokenResult;
+      });
+      fixture.sendUserMessage.mockImplementation(() => {
+        delivered.resolve();
+      });
+      try {
+        fixture.transcript("Please answer this meeting question.");
+        await vi.advanceTimersByTimeAsync(MEETING_AGENT_TRANSCRIPT_DEBOUNCE_MS);
+        await delivered.promise;
+        await setImmediate();
+        expect(fixture.runEmbeddedAgent).toHaveBeenCalledOnce();
+        const run = fixture.runEmbeddedAgent.mock.calls[0]?.[0];
+        expect(run?.abortSignal?.aborted).toBe(false);
+        expect(
+          engine === "transcription" ? fixture.textToSpeechTelephony : fixture.sendUserMessage,
+        ).toHaveBeenCalledOnce();
+        await fixture.handle.stop();
+        expect(run?.abortSignal?.aborted).toBe(false);
+      } finally {
+        await fixture.handle.stop();
+      }
+    },
+  );
+
+  it("closes an idle engine once without opening a turn", async () => {
+    const fixture = await createFixture();
+    await fixture.handle.stop();
+    await fixture.handle.stop();
+    expect(fixture.eventTypes()).toEqual(["session.started", "session.ready", "session.closed"]);
+  });
+
+  it.each([
+    ["transcription", "stop"],
+    ["transcription", "fatal"],
+    ["voice", "stop"],
+    ["voice", "fatal"],
+  ] as const)("cancels the generic agent run from %s %s", async (engine, shutdown) => {
+    const fixture = await createFixture(engine);
+    const started = createDeferredCore<RunEmbeddedAgentParams>();
+    const settled = createDeferredCore();
+    const result = createDeferredCore<Awaited<ReturnType<typeof fixture.runEmbeddedAgent>>>();
+    fixture.runEmbeddedAgent.mockImplementationOnce((params) => {
+      const abort = () => {
+        result.reject(params.abortSignal?.reason);
+      };
+      params.abortSignal?.addEventListener("abort", abort, { once: true });
+      started.resolve(params);
+      return result.promise.finally(() => {
+        params.abortSignal?.removeEventListener("abort", abort);
+        settled.resolve();
+      });
+    });
+    try {
+      fixture.transcript("Please check this for the meeting.");
+      await vi.advanceTimersByTimeAsync(MEETING_AGENT_TRANSCRIPT_DEBOUNCE_MS);
+      const run = await started.promise;
+      const aborted = vi.fn();
+      run.abortSignal?.addEventListener("abort", aborted, { once: true });
+      expect(run.abortSignal?.aborted).toBe(false);
+      await fixture.stop(shutdown);
+      expect(run.abortSignal?.aborted).toBe(true);
+      expect(aborted).toHaveBeenCalledOnce();
+      await settled.promise;
+      await setImmediate();
+      expect(fixture.textToSpeechTelephony).not.toHaveBeenCalled();
+      expect(fixture.sendUserMessage).not.toHaveBeenCalled();
+    } finally {
+      result.resolve({ payloads: [], meta: {} });
+      await fixture.handle.stop();
+      await setImmediate();
+    }
+  });
+
+  it.each([
+    ["tts", "resolve", "stop"],
+    ["tts", "reject", "stop"],
+    ["tts", "resolve", "fatal"],
+    ["tts", "reject", "fatal"],
+    ["tts", "failed result", "stop"],
+    ["tts", "failed result", "fatal"],
+    ["sink", "resolve", "stop"],
+    ["sink", "reject", "stop"],
+    ["sink", "resolve", "fatal"],
+    ["sink", "reject", "fatal"],
+  ] as const)("seals %s spans before %s settles after %s", async (stage, settlement, shutdown) => {
+    const fixture = await createFixture();
+    const synthesis = createDeferredCore<typeof spokenResult>();
+    const sink = createDeferredCore();
+    const conversion = vi.spyOn(audioFormat, "convertMeetingTtsAudioForBridge");
+    fixture.textToSpeechTelephony.mockReturnValueOnce(synthesis.promise);
+    fixture.writeOutput.mockReturnValueOnce(sink.promise);
+    try {
+      fixture.handle.speak("A synthetic spoken answer.");
+      await setImmediate();
+      if (stage === "sink") {
+        synthesis.resolve(spokenResult);
+        await setImmediate();
+        expect(fixture.writeOutput).toHaveBeenCalledOnce();
+      }
+      await fixture.stop(shutdown);
+      const ended = fixture.eventTypes();
+      expect
+        .soft(ended.slice(stage === "sink" ? -3 : -2))
+        .toEqual([
+          ...(stage === "sink" ? ["output.audio.done"] : []),
+          "turn.ended",
+          "session.closed",
+        ]);
+      const conversions = conversion.mock.calls.length;
+      const writes = fixture.writeOutput.mock.calls.length;
+      const warnings = fixture.logger.warn.mock.calls.length;
+      const pending = stage === "tts" ? synthesis : sink;
+      if (settlement === "reject") {
+        pending.reject(new Error("late failure"));
+      } else if (settlement === "failed result") {
+        synthesis.resolve({ ...spokenResult, success: false });
+      } else if (stage === "tts") {
+        synthesis.resolve(spokenResult);
+      } else {
+        sink.resolve();
+      }
+      await setImmediate();
+      expect.soft(fixture.eventTypes()).toEqual(ended);
+      expect.soft(conversion).toHaveBeenCalledTimes(conversions);
+      expect.soft(fixture.writeOutput).toHaveBeenCalledTimes(writes);
+      expect.soft(fixture.logger.warn).toHaveBeenCalledTimes(warnings);
+    } finally {
+      synthesis.resolve(spokenResult);
+      sink.resolve();
+      await fixture.handle.stop();
+      await setImmediate();
+    }
+  });
+
+  it.each(["success", "tts failure", "sink failure"] as const)(
+    "preserves active speech completion for %s",
+    async (outcome) => {
+      const fixture = await createFixture();
+      let eventsAtWarning: string[] | undefined;
+      fixture.logger.warn.mockImplementation(() => {
+        eventsAtWarning = fixture.eventTypes();
+      });
+      if (outcome === "tts failure") {
+        fixture.textToSpeechTelephony.mockRejectedValueOnce(new Error("active synthesis failed"));
+      } else if (outcome === "sink failure") {
+        fixture.writeOutput.mockRejectedValueOnce(new Error("active sink failed"));
+      }
+      try {
+        fixture.handle.speak("A synthetic answer.");
+        await setImmediate();
+        expect(fixture.eventTypes()).toEqual([
+          "session.started",
+          "session.ready",
+          "turn.started",
+          "output.text.done",
+          ...(outcome === "tts failure"
+            ? []
+            : ["output.audio.started", "output.audio.delta", "output.audio.done"]),
+          "turn.ended",
+        ]);
+        expect(fixture.logger.warn).toHaveBeenCalledTimes(outcome === "success" ? 0 : 1);
+        if (outcome !== "success") {
+          expect(eventsAtWarning).toEqual(fixture.eventTypes());
+        }
+        await fixture.handle.stop();
+        expect(fixture.eventTypes().slice(-2)).toEqual(["turn.ended", "session.closed"]);
+      } finally {
+        await fixture.handle.stop();
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes #140800

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Meeting shutdown aborts its talkback queue but both engine adapters drop the consult signal. Agent-mode output and turn spans also stay open when the session closes, allowing late speech synthesis or audio-sink settlement to append work, events or warnings afterward.

## Why This Change Was Made

Pass the existing meeting-owned signal through optional MeetingAgentConsultParams.abortSignal into the unchanged binding and linked generic runtime. Finish existing agent-mode output/turn spans before session.closed, then ignore late synthesis and sink settlement. The existing controller is idempotent and cannot open an idle turn during shutdown.

## User Impact

Stopping or fatally closing a meeting requests cancellation of active consults and keeps agent speech output final after closure. Active speech success/failure ordering, completed consults, repeated idle stop and transport stop/dispose behavior remain intact. The meeting documentation now states this contract.

This proves signal propagation and settlement at a synthetic generic runner boundary. It does not claim cancellation inside a specific remote model backend, nor token, CPU, RSS or whole-Gateway savings.

## Evidence

- The final new suite fails fourteen shutdown cases on original source and preserves six controls; all twenty pass on the repair. It composes actual engines, consult bindings, generic runtime and lifecycle/controller code with synthetic endpoint and audio boundaries.
- Both engines propagate cancellation through explicit stop and fatal disposal. Pending TTS success/rejection/failed results and pending sink resolve/reject cannot add conversion, writes, terminal events or warnings after closure.
- Active success/failure controls preserve output-finish → turn-end → warning ordering. Completed consult signals are detached and remain un-aborted when the meeting later stops.
- 110 focused tests across eight relevant files, full changed-file checks and fresh isolated P2 review passed. Fresh SDK declarations contain the optional signal field; this is declaration proof, not a claim that an older runtime build is current.
- Production net +15 lines, documentation +2 and one shared 373-line boundary suite. No changes to admission, model locks, provider recovery, configuration, protocol, persistence or cleanup ownership.

Related #116201 remains open for its broader resource-lifetime scope. Existing #140750 loopback and #140563 transcript ownership repairs are preserved.
