### PR TITLE
feat(android): use both fold planes for tabletop chat

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -32,11 +32,24 @@ page on the other plane. Both use the reported bounds, including off-center
 hinges. The sidebar remains visible after selecting a page or session.
 
 Book panes require at least 280 dp for the sidebar, 320 dp for the active page,
-and 320 dp of height. Otherwise, onboarding and the main app use the largest
-rectangular region clear of separating folds and fully occluding hinges. Equal
-regions prefer the top, then the reading-direction start side. Opening the
-keyboard does not select a different fallback region. Without an intersecting
-separator, the app keeps its full-window layout and modal sidebar.
+and 320 dp of height. Onboarding and layouts without a supported split use the
+largest rectangular region clear of separating folds and fully occluding hinges.
+Equal regions prefer the top, then the reading-direction start side. Opening
+the keyboard does not select a different fallback region for this outer host.
+Without an intersecting separator, the app keeps its full-window layout and
+modal sidebar.
+
+In Chat, a full-width horizontal separator can place the conversation header,
+transcript, and status above the hinge and the same composer below it. Each
+usable pane must be at least 320 dp wide. The measured space must fit the complete
+header, a transcript band with a complete text line, and status above, with a
+complete input line and controls below, accounting for the current font size
+and padding.
+
+Layout changes retain the draft, cursor, reader position, and existing local
+capture state owners. If keyboard insets or larger text leave too little space,
+Chat uses the existing one-region fallback based on the space remaining after
+insets, then restores the split when it fits.
 
 Command search and gateway trust prompts retain the single-region host.
 
@@ -46,8 +59,7 @@ space is limited; opening the keyboard does not move them to another region.
 If the keyboard covers that region entirely, dismiss the keyboard to reach the
 prompt again.
 
-A tabletop transcript/composer split, other dialogs, sheets, and menus are not
-adapted yet.
+Other dialogs, sheets, and menus are not adapted yet.
 
 ## Wear OS companion
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareContent.kt
@@ -20,7 +20,8 @@ internal fun FoldAwareContent(
   features: List<DisplayFeature>,
   modifier: Modifier = Modifier,
   bookPanesEnabled: Boolean = false,
-  content: @Composable (BookPaneBounds?) -> Unit,
+  tabletopEnabled: Boolean = false,
+  content: @Composable (FoldContentBounds) -> Unit,
 ) {
   SubcomposeLayout(
     modifier = modifier.fillMaxSize(),
@@ -34,11 +35,14 @@ internal fun FoldAwareContent(
       val origin = coordinates?.positionInWindow()?.round() ?: IntOffset.Zero
       val host = IntRect(origin, IntSize(width, height))
       val book = if (bookPanesEnabled) bookPaneBounds(host, features, layoutDirection, density) else null
-      val pane = if (book != null) host else foldSafeRegion(host, features, layoutDirection)
+      val tabletop = if (tabletopEnabled) tabletopPaneBounds(host, features, layoutDirection) else null
+      val fallback = foldSafeRegion(host, features, layoutDirection)
+      val pane = if (book != null || tabletop != null) host else fallback
       val localBook = book?.let { BookPaneBounds(it.start.translate(-origin), it.end.translate(-origin)) }
+      val bounds = FoldContentBounds(localBook, tabletop, fallback.translate(-origin).takeIf { tabletop != null })
       // One subcomposition keeps the screen alive while deciding its mode from current host bounds.
       subcompose(Unit) {
-        Box(Modifier.recalculateWindowInsets().clipToBounds()) { content(localBook) }
+        Box(Modifier.recalculateWindowInsets().clipToBounds()) { content(bounds) }
       }.single()
         .measure(Constraints.fixed(pane.width, pane.height))
         .place(pane.left - origin.x, pane.top - origin.y)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -152,7 +152,9 @@ fun ShellScreen(
       features = features,
       modifier = modifier.background(ClawTheme.colors.canvas),
       bookPanesEnabled = !commandOpen && pendingTrust == null,
-    ) { bookPanes ->
+      tabletopEnabled = nav.activeTab == Tab.Chat && !commandOpen && pendingTrust == null,
+    ) { foldBounds ->
+      val bookPanes = foldBounds.book
       val permanentSidebar = bookPanes != null
       // Mode changes discard modal operations and their drag state, not the two content slots.
       val sidebarDrawerState = key(permanentSidebar) { rememberDrawerState(initialValue = DrawerValue.Closed) }
@@ -248,10 +250,12 @@ fun ShellScreen(
         SidebarNavigationShell(
           drawerState = sidebarDrawerState,
           bookPanes = bookPanes,
+          sidebarBand = foldBounds.sidebarBand,
           gesturesEnabled = !sidebarRowDragging,
           drawerContent = {
             OpenClawSidebar(
               viewModel = viewModel,
+              rowHostBand = foldBounds.sidebarBand,
               agents = gatewayAgents,
               selectedAgentId = chatSessionOwnerAgentId ?: gatewayDefaultAgentId,
               sessions = chatSessions,
@@ -311,6 +315,8 @@ fun ShellScreen(
             Tab.Chat -> {
               UnifiedChatShellScreen(
                 viewModel = viewModel,
+                tabletopPanes = foldBounds.tabletop,
+                features = features,
                 showSidebarButton = !permanentSidebar,
                 onOpenSidebar = openSidebar,
                 onOpenDashboard = nav::openSessionDashboard,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarComponents.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarComponents.kt
@@ -8,7 +8,10 @@ import ai.openclaw.app.ui.design.sessionColor
 import ai.openclaw.app.ui.design.sessionColorStripe
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
+import androidx.compose.foundation.gestures.drag
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -43,6 +46,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -50,12 +54,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
@@ -70,6 +79,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
+import kotlinx.coroutines.CancellationException
 import kotlin.math.abs
 
 @Composable
@@ -225,6 +235,7 @@ internal fun SidebarActionRow(
 @Composable
 internal fun SidebarNavigationRow(
   destination: SidebarDestination,
+  rowHost: SidebarRowHost,
   selected: Boolean,
   pinned: Boolean? = null,
   palette: SidebarPalette,
@@ -240,22 +251,26 @@ internal fun SidebarNavigationRow(
     pinned?.let { nativeString(if (it) "Pinned" else "Not pinned") }
   var dragOffset by remember(destination) { mutableFloatStateOf(0f) }
   var dragging by remember(destination) { mutableStateOf(false) }
+  var dragGeneration by remember(destination) { mutableLongStateOf(0L) }
+  val visualDragging = dragging && dragGeneration == rowHost.generation
   val finishDrag = {
     dragOffset = 0f
-    dragging = false
-    currentOnDragActiveChange(false)
+    if (dragging) {
+      dragging = false
+      currentOnDragActiveChange(false)
+    }
   }
 
   Box(
     modifier =
       Modifier
         .fillMaxWidth()
-        .zIndex(if (dragging) 1f else 0f)
+        .zIndex(if (visualDragging) 1f else 0f)
         .graphicsLayer {
-          translationY = dragOffset
-          scaleX = if (dragging) 1.015f else 1f
-          scaleY = if (dragging) 1.015f else 1f
-          shadowElevation = if (dragging) 10.dp.toPx() else 0f
+          translationY = if (visualDragging) dragOffset else 0f
+          scaleX = if (visualDragging) 1.015f else 1f
+          scaleY = if (visualDragging) 1.015f else 1f
+          shadowElevation = if (visualDragging) 10.dp.toPx() else 0f
         },
   ) {
     NavigationDrawerItem(
@@ -296,9 +311,11 @@ internal fun SidebarNavigationRow(
           .semantics {
             if (pinStateDescription != null) stateDescription = pinStateDescription
           }.pointerInput(destination, thresholdPx) {
-            detectDragGesturesAfterLongPress(
-              onDragStart = {
+            detectSidebarRowDrag(
+              rowHost = rowHost,
+              onDragStart = { generation ->
                 dragOffset = 0f
+                dragGeneration = generation
                 dragging = true
                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                 currentOnDragActiveChange(true)
@@ -319,14 +336,14 @@ internal fun SidebarNavigationRow(
       colors =
         NavigationDrawerItemDefaults.colors(
           selectedContainerColor = palette.selection,
-          unselectedContainerColor = if (dragging) palette.elevated else Color.Transparent,
+          unselectedContainerColor = if (visualDragging) palette.elevated else Color.Transparent,
           selectedIconColor = palette.text,
           unselectedIconColor = palette.text,
           selectedTextColor = palette.text,
           unselectedTextColor = palette.text,
         ),
     )
-    if (dragging) {
+    if (visualDragging) {
       HorizontalDivider(
         color = ClawTheme.colors.primary,
         thickness = 2.dp,
@@ -415,6 +432,7 @@ internal fun SidebarSessionActivityIndicator(
 @Composable
 internal fun SidebarSessionRow(
   session: ChatSessionEntry,
+  rowHost: SidebarRowHost,
   selected: Boolean,
   palette: SidebarPalette,
   onClick: () -> Unit,
@@ -438,6 +456,7 @@ internal fun SidebarSessionRow(
     }
   SidebarRowSurface(
     selected = selected,
+    rowHost = rowHost,
     stateDescription = sessionStateDescription,
     palette = palette,
     stripeColor = ClawTheme.colors.sessionColor(session.color),
@@ -487,6 +506,7 @@ internal fun SidebarRowSurface(
   dragKey: Any? = null,
   onDragCommit: ((Int) -> Unit)? = null,
   onDragActiveChange: (Boolean) -> Unit = {},
+  rowHost: SidebarRowHost? = null,
   contentPadding: PaddingValues = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
   content: @Composable RowScope.() -> Unit,
 ) {
@@ -496,33 +516,38 @@ internal fun SidebarRowSurface(
   val currentOnDragActiveChange by rememberUpdatedState(onDragActiveChange)
   var dragOffset by remember(dragKey) { mutableFloatStateOf(0f) }
   var dragging by remember(dragKey) { mutableStateOf(false) }
+  var dragGeneration by remember(dragKey) { mutableLongStateOf(0L) }
+  val visualDragging = dragging && dragGeneration == (rowHost?.generation ?: 0L)
+  val cancelDrag = {
+    dragOffset = 0f
+    if (dragging) {
+      dragging = false
+      currentOnDragActiveChange(false)
+    }
+  }
   val finishDrag = {
     val commit = currentOnDragCommit
     if (commit != null && abs(dragOffset) >= dragThresholdPx) {
       commit(if (dragOffset < 0f) -1 else 1)
     }
-    dragOffset = 0f
-    dragging = false
-    currentOnDragActiveChange(false)
+    cancelDrag()
   }
   val dragModifier =
     if (!enabled || onDragCommit == null) {
       Modifier
     } else {
       Modifier.pointerInput(dragKey, dragThresholdPx) {
-        detectDragGesturesAfterLongPress(
-          onDragStart = {
+        detectSidebarRowDrag(
+          rowHost = rowHost,
+          onDragStart = { generation ->
             dragOffset = 0f
+            dragGeneration = generation
             dragging = true
             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
             currentOnDragActiveChange(true)
           },
           onDragEnd = finishDrag,
-          onDragCancel = {
-            dragOffset = 0f
-            dragging = false
-            currentOnDragActiveChange(false)
-          },
+          onDragCancel = cancelDrag,
         ) { change, dragAmount ->
           change.consume()
           dragOffset += dragAmount.y
@@ -534,12 +559,12 @@ internal fun SidebarRowSurface(
     modifier =
       Modifier
         .fillMaxWidth()
-        .zIndex(if (dragging) 1f else 0f)
+        .zIndex(if (visualDragging) 1f else 0f)
         .graphicsLayer {
-          translationY = dragOffset
-          scaleX = if (dragging) 1.015f else 1f
-          scaleY = if (dragging) 1.015f else 1f
-          shadowElevation = if (dragging) 10.dp.toPx() else 0f
+          translationY = if (visualDragging) dragOffset else 0f
+          scaleX = if (visualDragging) 1.015f else 1f
+          scaleY = if (visualDragging) 1.015f else 1f
+          shadowElevation = if (visualDragging) 10.dp.toPx() else 0f
         },
   ) {
     Row(
@@ -551,7 +576,7 @@ internal fun SidebarRowSurface(
           .background(
             if (selected == true) {
               palette.selection
-            } else if (dragging) {
+            } else if (visualDragging) {
               palette.elevated
             } else {
               Color.Transparent
@@ -575,12 +600,49 @@ internal fun SidebarRowSurface(
       horizontalArrangement = Arrangement.spacedBy(10.dp),
       content = content,
     )
-    if (dragging) {
+    if (visualDragging) {
       HorizontalDivider(
         color = ClawTheme.colors.primary,
         thickness = 2.dp,
         modifier = Modifier.align(if (dragOffset < 0f) Alignment.TopCenter else Alignment.BottomCenter),
       )
+    }
+  }
+}
+
+private suspend fun PointerInputScope.detectSidebarRowDrag(
+  rowHost: SidebarRowHost?,
+  onDragStart: (Long) -> Unit,
+  onDragEnd: () -> Unit,
+  onDragCancel: () -> Unit,
+  onDrag: (PointerInputChange, Offset) -> Unit,
+) {
+  awaitEachGesture {
+    var claimed = false
+    try {
+      val down = awaitFirstDown(requireUnconsumed = false)
+      val generation = rowHost?.generation ?: 0L
+      val longPress = awaitLongPressOrCancellation(down.id)
+      if (longPress != null) {
+        claimed = generation == (rowHost?.generation ?: 0L)
+        if (claimed) onDragStart(generation)
+        // Retain consumption through release, even after the row loses mutation authority.
+        val ended =
+          drag(longPress.id) { change ->
+            if (claimed && generation == (rowHost?.generation ?: 0L)) {
+              onDrag(change, change.positionChange())
+            }
+            change.consume()
+          }
+        if (ended) currentEvent.changes.forEach { if (it.changedToUp()) it.consume() }
+        if (claimed) {
+          claimed = false
+          if (ended && generation == (rowHost?.generation ?: 0L)) onDragEnd() else onDragCancel()
+        }
+      }
+    } catch (cancel: CancellationException) {
+      if (claimed) onDragCancel()
+      throw cancel
     }
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarContent.kt
@@ -63,6 +63,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -76,6 +77,8 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
@@ -84,7 +87,9 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.round
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -373,6 +378,28 @@ internal data class SidebarPalette(
   val hairline: Color,
 )
 
+internal class SidebarRowHost {
+  private data class Placement(
+    val band: IntRect?,
+    val viewport: IntRect,
+  )
+
+  private var placement: Placement? = null
+  var generation by mutableLongStateOf(0L)
+    private set
+
+  fun recordPlacement(
+    band: IntRect?,
+    viewport: IntRect,
+  ) {
+    val next = Placement(band, viewport)
+    if (next != placement) {
+      placement = next
+      generation++
+    }
+  }
+}
+
 internal fun sidebarPalette(colors: ClawColors): SidebarPalette =
   SidebarPalette(
     background = colors.canvas,
@@ -405,11 +432,13 @@ internal fun OpenClawSidebar(
   onSelectCatalogSession: (SessionCatalogEntry) -> Unit,
   onCreateCatalogSession: (String) -> Unit,
   onSelectDestination: (SidebarDestination) -> Unit,
+  rowHostBand: IntRect? = null,
 ) {
   val palette = sidebarPalette()
   val scope = rememberCoroutineScope()
   val lifecycle = LocalLifecycleOwner.current.lifecycle
   val scrollState = rememberScrollState()
+  val rowHost = remember { SidebarRowHost() }
   val agentPicker = agentPickerState(agents, selectedAgentId)
   val storedGroups by viewModel.sessionCustomGroups.collectAsState()
   val catalogState by viewModel.sessionCatalogState.collectAsState()
@@ -604,7 +633,10 @@ internal fun OpenClawSidebar(
           Modifier
             .weight(1f)
             .fillMaxWidth()
-            .verticalScroll(scrollState),
+            .onPlaced {
+              // Observe the viewport, never row reorder/drag offsets or the scrolling content.
+              rowHost.recordPlacement(rowHostBand, IntRect(it.positionInParent().round(), it.size))
+            }.verticalScroll(scrollState),
       ) {
         if (searchState.query.isNotEmpty()) {
           SidebarSectionTitle(nativeString("Threads"), palette)
@@ -631,6 +663,7 @@ internal fun OpenClawSidebar(
                   searchResults.forEach { session ->
                     SidebarSessionRow(
                       session = session,
+                      rowHost = rowHost,
                       selected = session.key == activeSessionKey,
                       palette = palette,
                       onClick = { onSelectSession(session) },
@@ -642,6 +675,7 @@ internal fun OpenClawSidebar(
           }
         } else {
           SidebarPagesHeader(
+            rowHost = rowHost,
             expanded = pagesExpanded,
             menuMode = pagesMenuMode,
             destinations = orderedPages,
@@ -680,6 +714,7 @@ internal fun OpenClawSidebar(
               key(destination.stableId) {
                 SidebarNavigationRow(
                   destination = destination,
+                  rowHost = rowHost,
                   selected = destination == activeDestination,
                   palette = palette,
                   onClick = { onSelectDestination(destination) },
@@ -718,6 +753,7 @@ internal fun OpenClawSidebar(
                 pinnedSessions.forEach { session ->
                   SidebarSessionRow(
                     session = session,
+                    rowHost = rowHost,
                     selected = session.key == activeSessionKey,
                     palette = palette,
                     onClick = { onSelectSession(session) },
@@ -794,6 +830,7 @@ internal fun OpenClawSidebar(
                     )
                     if (section.expanded) {
                       SidebarSessionCatalog(
+                        rowHost = rowHost,
                         state = catalogState,
                         catalog = catalog,
                         activeSessionKey = activeSessionKey,
@@ -852,6 +889,7 @@ internal fun OpenClawSidebar(
                   section.entries.forEach { session ->
                     SidebarSessionRow(
                       session = session,
+                      rowHost = rowHost,
                       selected = session.key == activeSessionKey,
                       palette = palette,
                       onClick = { onSelectSession(session) },
@@ -920,6 +958,7 @@ internal fun OpenClawSidebar(
 
 @Composable
 private fun SidebarPagesHeader(
+  rowHost: SidebarRowHost,
   expanded: Boolean,
   menuMode: SidebarPagesMenuMode,
   destinations: List<SidebarDestination>,
@@ -1049,6 +1088,7 @@ private fun SidebarPagesHeader(
                 val visible = destination.stableId in visiblePageIds
                 SidebarNavigationRow(
                   destination = destination,
+                  rowHost = rowHost,
                   selected = false,
                   pinned = visible,
                   palette = palette,
@@ -1080,6 +1120,7 @@ private fun SidebarPagesHeader(
 
 @Composable
 private fun SidebarSessionCatalog(
+  rowHost: SidebarRowHost,
   state: SessionCatalogState,
   catalog: SessionCatalog,
   activeSessionKey: String,
@@ -1229,6 +1270,7 @@ private fun SidebarSessionCatalog(
               workspace.sessions.forEach { session ->
                 SidebarCatalogSessionRow(
                   session = session,
+                  rowHost = rowHost,
                   liveSession = session.sessionKey?.let(liveSessionsByKey::get),
                   selected = session.sessionKey == activeSessionKey,
                   continuing = state.continuingEntryId == session.locatorId,
@@ -1272,6 +1314,7 @@ internal fun sidebarCatalogSessionSelectionEnabled(
 @Composable
 private fun SidebarCatalogSessionRow(
   session: SessionCatalogEntry,
+  rowHost: SidebarRowHost,
   liveSession: ChatSessionEntry?,
   selected: Boolean,
   continuing: Boolean,
@@ -1295,6 +1338,7 @@ private fun SidebarCatalogSessionRow(
     )
   SidebarRowSurface(
     selected = selected,
+    rowHost = rowHost,
     palette = palette,
     enabled = enabled && selectionEnabled,
     onClick = onClick,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarShell.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarShell.kt
@@ -2,6 +2,7 @@ package ai.openclaw.app.ui
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.recalculateWindowInsets
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.DrawerState
@@ -16,6 +17,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
@@ -63,6 +65,7 @@ internal fun bookPaneBounds(
 internal fun SidebarNavigationShell(
   drawerState: DrawerState,
   bookPanes: BookPaneBounds? = null,
+  sidebarBand: IntRect? = null,
   gesturesEnabled: Boolean = true,
   drawerContent: @Composable () -> Unit,
   content: @Composable () -> Unit,
@@ -78,7 +81,20 @@ internal fun SidebarNavigationShell(
       key(drawerState) {
         ModalDrawerSheet(
           drawerState = drawerState,
-          modifier = Modifier.widthIn(max = 360.dp).testTag("sidebar-drawer"),
+          modifier =
+            Modifier
+              .widthIn(max = 360.dp)
+              .fillMaxWidth()
+              .layout { measurable, constraints ->
+                // Keep Material's real width anchors; only the stationary vertical band changes.
+                val height = sidebarBand?.height ?: constraints.maxHeight
+                val sheet = measurable.measure(Constraints.fixed(constraints.maxWidth, height))
+                layout(sheet.width, constraints.maxHeight) {
+                  sheet.place(0, sidebarBand?.top ?: 0)
+                }
+              }.recalculateWindowInsets()
+              .clipToBounds()
+              .testTag("sidebar-drawer"),
         ) {
           // The closed empty sheet retains real measured anchors in permanent mode.
           if (bookPanes == null) sidebar()

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/TabletopLayout.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/TabletopLayout.kt
@@ -1,0 +1,36 @@
+package ai.openclaw.app.ui
+
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.window.layout.DisplayFeature
+import androidx.window.layout.FoldingFeature
+
+internal data class TabletopPaneBounds(
+  val upper: IntRect,
+  val lower: IntRect,
+)
+
+internal data class FoldContentBounds(
+  val book: BookPaneBounds?,
+  val tabletop: TabletopPaneBounds?,
+  val sidebarBand: IntRect?,
+)
+
+/** Physical window rectangles; certify both planes against the complete feature set. */
+internal fun tabletopPaneBounds(
+  host: IntRect,
+  features: List<DisplayFeature>,
+  direction: LayoutDirection,
+): TabletopPaneBounds? {
+  val separator =
+    features.filterIsInstance<FoldingFeature>().singleOrNull {
+      (it.isSeparating || it.occlusionType == FoldingFeature.OcclusionType.FULL) &&
+        it.orientation == FoldingFeature.Orientation.HORIZONTAL &&
+        it.bounds.top > host.top && it.bounds.bottom < host.bottom &&
+        it.bounds.left <= host.left && it.bounds.right >= host.right
+    } ?: return null
+  val upper = host.copy(bottom = separator.bounds.top)
+  val lower = host.copy(top = separator.bounds.bottom)
+  if (foldSafeRegion(upper, features, direction) != upper || foldSafeRegion(lower, features, direction) != lower) return null
+  return TabletopPaneBounds(upper, lower)
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/UnifiedChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/UnifiedChatScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.unit.dp
+import androidx.window.layout.DisplayFeature
 
 @Composable
 internal fun UnifiedChatShellScreen(
@@ -21,6 +22,8 @@ internal fun UnifiedChatShellScreen(
   onOpenDashboard: (String) -> Unit,
   onOpenGatewaySettings: () -> Unit,
   onOpenProvidersModels: () -> Unit,
+  tabletopPanes: TabletopPaneBounds? = null,
+  features: List<DisplayFeature> = emptyList(),
 ) {
   val talkModeEnabled by viewModel.talkModeEnabled.collectAsState()
   val startTalk = rememberChatRealtimeTalkLauncher(viewModel)
@@ -45,6 +48,8 @@ internal fun UnifiedChatShellScreen(
       onOpenDashboard = onOpenDashboard,
       onOpenGatewaySettings = onOpenGatewaySettings,
       onOpenProvidersModels = onOpenProvidersModels,
+      tabletopPanes = tabletopPanes,
+      features = features,
     )
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatPaneLayout.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatPaneLayout.kt
@@ -1,0 +1,111 @@
+package ai.openclaw.app.ui.chat
+
+import ai.openclaw.app.ui.TabletopPaneBounds
+import ai.openclaw.app.ui.foldSafeRegion
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.recalculateWindowInsets
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.round
+import androidx.window.layout.DisplayFeature
+
+@Composable
+internal fun ChatPaneLayout(
+  tabletopPanes: TabletopPaneBounds?,
+  features: List<DisplayFeature>,
+  minimumInputHeight: Dp,
+  minimumHeaderHeight: Dp,
+  minimumReaderHeight: Dp,
+  touchTarget: Dp,
+  modifier: Modifier = Modifier,
+  header: @Composable (compact: Boolean, tabletop: Boolean) -> Unit,
+  transcript: @Composable () -> Unit,
+  status: @Composable () -> Unit,
+  composer: @Composable (compact: Boolean, tabletop: Boolean) -> Unit,
+) {
+  SubcomposeLayout(modifier.fillMaxSize()) { constraints ->
+    val width = constraints.maxWidth
+    val height = constraints.maxHeight
+    val padding = 10.dp.roundToPx()
+    val gap = 8.dp.roundToPx()
+    val inputFloor = minimumInputHeight.roundToPx()
+    val headerFloor = minimumHeaderHeight.roundToPx()
+    val readerFloor = minimumReaderHeight.roundToPx()
+    val statusFloor = touchTarget.roundToPx()
+    val widthFloor = 320.dp.roundToPx()
+    layout(width, height) {
+      // This host is already inside scaffold/IME padding. Translate window facts only here.
+      val origin = coordinates?.positionInWindow()?.round() ?: IntOffset.Zero
+      val host = IntRect(origin, IntSize(width, height))
+      val upper = tabletopPanes?.upper?.intersect(host)
+      val lower = tabletopPanes?.lower?.intersect(host)
+      val tabletop =
+        upper != null && lower != null &&
+          upper.width >= widthFloor && lower.width >= widthFloor &&
+          upper.height >= headerFloor + readerFloor + statusFloor + padding * 2 + gap * 2 &&
+          lower.height >= inputFloor + padding * 2
+      val fallback = if (tabletop) host else foldSafeRegion(host, features, layoutDirection)
+      val upperBounds = (if (tabletop) checkNotNull(upper) else fallback).translate(-origin)
+      val lowerBounds = (if (tabletop) checkNotNull(lower) else fallback).translate(-origin)
+      val lowerHeight = lowerBounds.height - if (tabletop) padding * 2 else 0
+      val compact = lowerHeight < inputFloor + statusFloor * 2 + padding * 2 + gap * 2
+      val inset = if (tabletop || !compact) padding else 0
+      val spacing = if (tabletop || !compact) gap else 0
+      subcompose(Unit) {
+        Layout(
+          content = {
+            Box { header(compact, tabletop) }
+            Box(Modifier.recalculateWindowInsets().clipToBounds()) { transcript() }
+            Box(Modifier.clipToBounds().verticalScroll(rememberScrollState())) {
+              if (tabletop) Column { status() }
+            }
+            Box(Modifier.clipToBounds()) { composer(compact, tabletop) }
+          },
+        ) { measurables, _ ->
+          val upperHeight = (upperBounds.height - inset * 2).coerceAtLeast(0)
+          val lowerAvailable = (lowerBounds.height - inset * 2).coerceAtLeast(0)
+          val headerLimit = if (tabletop) headerFloor else (upperHeight - inputFloor).coerceAtLeast(0)
+          val headerPlaceable =
+            measurables[0].measure(Constraints(minWidth = upperBounds.width, maxWidth = upperBounds.width, maxHeight = headerLimit))
+          val headerGap = if (headerPlaceable.height > 0) spacing else 0
+          // The input gets its real remaining height before transcript or auxiliary content.
+          val composerLimit =
+            if (tabletop) lowerAvailable else (lowerAvailable - headerPlaceable.height - headerGap - spacing).coerceAtLeast(0)
+          val composerPlaceable =
+            measurables[3].measure(Constraints(minWidth = lowerBounds.width, maxWidth = lowerBounds.width, maxHeight = composerLimit))
+          val statusLimit =
+            if (tabletop) (upperHeight - headerPlaceable.height - headerGap - readerFloor - spacing).coerceAtLeast(0) else 0
+          val statusPlaceable =
+            measurables[2].measure(Constraints(minWidth = upperBounds.width, maxWidth = upperBounds.width, maxHeight = statusLimit))
+          val statusGap = if (statusPlaceable.height > 0) spacing else 0
+          val readerHeight =
+            (
+              upperHeight - headerPlaceable.height - headerGap - statusPlaceable.height - statusGap -
+                if (tabletop) 0 else composerPlaceable.height + spacing
+            ).coerceAtLeast(0)
+          val readerPlaceable = measurables[1].measure(Constraints.fixed(upperBounds.width, readerHeight))
+          layout(width, height) {
+            headerPlaceable.place(upperBounds.left, upperBounds.top + inset)
+            readerPlaceable.place(upperBounds.left, upperBounds.top + inset + headerPlaceable.height + headerGap)
+            statusPlaceable.place(upperBounds.left, upperBounds.bottom - inset - statusPlaceable.height)
+            composerPlaceable.place(lowerBounds.left, lowerBounds.bottom - inset - composerPlaceable.height)
+          }
+        }
+      }.single().measure(Constraints.fixed(width, height)).place(0, 0)
+    }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -56,6 +56,7 @@ import ai.openclaw.app.i18n.verbatimText
 import ai.openclaw.app.operatorScopesAllowAdmin
 import ai.openclaw.app.operatorScopesAllowWrite
 import ai.openclaw.app.resolveAgentIdFromMainSessionKey
+import ai.openclaw.app.ui.TabletopPaneBounds
 import ai.openclaw.app.ui.copyGatewayDiagnosticsReport
 import ai.openclaw.app.ui.design.ClawAgentAvatar
 import ai.openclaw.app.ui.design.ClawListItem
@@ -206,7 +207,9 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -215,6 +218,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.window.layout.DisplayFeature
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -225,6 +229,7 @@ import java.util.Date
 import java.util.Locale
 import java.util.UUID
 import kotlin.math.abs
+import kotlin.math.ceil
 import kotlin.math.roundToInt
 import kotlin.math.sin
 
@@ -295,7 +300,7 @@ internal fun shouldUseUserMessageDisclosure(
 
 /** Full chat surface that wires MainViewModel state to messages, attachments, voice, and composer actions. */
 @Composable
-fun ChatScreen(
+internal fun ChatScreen(
   viewModel: MainViewModel,
   talkActive: Boolean,
   showSidebarButton: Boolean,
@@ -304,6 +309,8 @@ fun ChatScreen(
   onOpenDashboard: (String) -> Unit,
   onOpenGatewaySettings: () -> Unit,
   onOpenProvidersModels: () -> Unit = onOpenGatewaySettings,
+  tabletopPanes: TabletopPaneBounds? = null,
+  features: List<DisplayFeature> = emptyList(),
 ) {
   val messages by viewModel.chatMessages.collectAsState()
   val transcriptAnchor by viewModel.chatTranscriptAnchor.collectAsState()
@@ -776,282 +783,273 @@ fun ChatScreen(
       },
     )
   }
-  BoxWithConstraints(Modifier.fillMaxSize().imePadding()) {
-    val contentPadding = 10.dp
-    val contentSpacing = 8.dp
-    // Keep a header target and a scrollable auxiliary target only when the complete input fits.
-    val compactHeight =
-      maxHeight < minimumChatInputHeight() + ClawTheme.spacing.touchTarget * 2 + contentPadding * 2 + contentSpacing * 2
-    Column(
-      modifier =
-        Modifier
-          .fillMaxSize()
-          .padding(vertical = if (compactHeight) 0.dp else contentPadding),
-      verticalArrangement = Arrangement.spacedBy(if (compactHeight) 0.dp else contentSpacing),
-    ) {
-      ChatMessageList(
-        sessionKey = sessionKey,
-        fullMessageOwner = composerOwner,
-        selectionGeneration = selectionGeneration,
-        gatewayCatalogRevision = gatewayCatalogRevision,
-        prepareFullMessageRead = { message -> viewModel.prepareFullMessageRead(composerOwner, selectionGeneration, gatewayCatalogRevision, message) },
-        session = activeSession,
-        messages = messages,
-        transcriptAnchor = transcriptAnchor,
-        historyLoading = historyLoading,
-        activeRunCount = selectedActiveRun.count,
-        activeRunId = selectedActiveRun.runId,
-        activeRunClockKey = selectedActiveRun.clockKey,
-        activeRunOutputTokens = selectedActiveRun.outputTokens,
-        pendingToolCalls = pendingToolCalls,
-        subagentActivities = subagentActivities,
-        questions = questionsForSession(questions, sessionKey, mainSessionKey, activeAgentId),
-        streamingAssistantText = streamingAssistantText,
-        healthOk = healthOk,
-        gatewayOffline = gatewayOffline,
-        outboxItems = currentSessionOutboxItems,
-        recoveryOutboxItems =
-          outboxItemsForRecovery(
-            items = outboxItems,
+  val conversationStatus: @Composable () -> Unit = {
+    errorText?.takeIf { it.isNotBlank() }?.let { error ->
+      ChatNotice(
+        title = nativeString("Chat needs attention"),
+        body = userFacingChatError(error = error, gatewayConnected = gatewayConnectionDisplay.isConnected),
+      )
+    }
+    ChatSwarmProgress(groups = swarmGroups)
+  }
+  ChatMessageList(
+    sessionKey = sessionKey,
+    fullMessageOwner = composerOwner,
+    selectionGeneration = selectionGeneration,
+    gatewayCatalogRevision = gatewayCatalogRevision,
+    prepareFullMessageRead = { message -> viewModel.prepareFullMessageRead(composerOwner, selectionGeneration, gatewayCatalogRevision, message) },
+    session = activeSession,
+    messages = messages,
+    transcriptAnchor = transcriptAnchor,
+    historyLoading = historyLoading,
+    activeRunCount = selectedActiveRun.count,
+    activeRunId = selectedActiveRun.runId,
+    activeRunClockKey = selectedActiveRun.clockKey,
+    activeRunOutputTokens = selectedActiveRun.outputTokens,
+    pendingToolCalls = pendingToolCalls,
+    subagentActivities = subagentActivities,
+    questions = questionsForSession(questions, sessionKey, mainSessionKey, activeAgentId),
+    streamingAssistantText = streamingAssistantText,
+    healthOk = healthOk,
+    gatewayOffline = gatewayOffline,
+    outboxItems = currentSessionOutboxItems,
+    recoveryOutboxItems =
+      outboxItemsForRecovery(
+        items = outboxItems,
+      ),
+    onRetryOutbox = viewModel::retryChatOutboxCommand,
+    onDeleteOutbox = viewModel::deleteChatOutboxCommand,
+    onResolveQuestion = viewModel::resolveChatQuestion,
+    onQuestionDraftChanged = viewModel::updateChatQuestionDraft,
+    onSkipQuestion = viewModel::skipChatQuestion,
+    onStarterPrompt = { prompt -> inputDrafts[composerOwner] = prompt },
+    onReplyMessage = { value -> viewModel.setChatReplyDraft(value, composerOwner) },
+    sessionActionsEnabled =
+      pendingRunCount == 0 &&
+        !sessionBranchSwitching &&
+        outboxPresentationRestored &&
+        currentSessionOutboxItems.none { it.status != ChatOutboxStatus.Failed },
+    onRewindMessage = { entryId ->
+      val expectedInput = inputDrafts[composerOwner].orEmpty()
+      scope.launch {
+        val result = viewModel.rewindChatAtEntry(entryId) ?: return@launch
+        viewModel.setChatDraft(
+          ChatDraft(
+            text = result.editorText.orEmpty(),
+            placement = ChatDraftPlacement.Replace,
+            owner = composerOwner,
+            expectedExistingText = expectedInput,
+            acceptsEmptyText = true,
+            attachments = result.editorAttachments.toPendingAttachments(),
           ),
-        onRetryOutbox = viewModel::retryChatOutboxCommand,
-        onDeleteOutbox = viewModel::deleteChatOutboxCommand,
-        onResolveQuestion = viewModel::resolveChatQuestion,
-        onQuestionDraftChanged = viewModel::updateChatQuestionDraft,
-        onSkipQuestion = viewModel::skipChatQuestion,
-        onStarterPrompt = { prompt -> inputDrafts[composerOwner] = prompt },
-        onReplyMessage = { value -> viewModel.setChatReplyDraft(value, composerOwner) },
-        sessionActionsEnabled =
-          pendingRunCount == 0 &&
-            !sessionBranchSwitching &&
-            outboxPresentationRestored &&
-            currentSessionOutboxItems.none { it.status != ChatOutboxStatus.Failed },
-        onRewindMessage = { entryId ->
-          val expectedInput = inputDrafts[composerOwner].orEmpty()
-          scope.launch {
-            val result = viewModel.rewindChatAtEntry(entryId) ?: return@launch
-            viewModel.setChatDraft(
-              ChatDraft(
-                text = result.editorText.orEmpty(),
-                placement = ChatDraftPlacement.Replace,
-                owner = composerOwner,
-                expectedExistingText = expectedInput,
-                acceptsEmptyText = true,
-                attachments = result.editorAttachments.toPendingAttachments(),
-              ),
-            )
-          }
-        },
-        onForkMessage = { entryId ->
-          scope.launch {
-            val result = viewModel.forkChatAtEntry(entryId) ?: return@launch
-            val newOwner = composerOwner.copy(sessionKey = result.sessionKey)
-            val expectedInput = inputDrafts[newOwner].orEmpty()
-            viewModel.switchChatSession(result.sessionKey, composerOwner.agentId)
-            viewModel.setChatDraft(
-              ChatDraft(
-                text = result.editorText.orEmpty(),
-                placement = ChatDraftPlacement.Replace,
-                owner = newOwner,
-                expectedExistingText = expectedInput,
-                acceptsEmptyText = true,
-                attachments = result.editorAttachments.toPendingAttachments(),
-              ),
-            )
-          }
-        },
-        speechState = messageSpeechState,
-        onToggleListen = viewModel::toggleChatMessageSpeech,
-        inlineMediaPlaybackBlocked = inlineMediaPlaybackBlocked,
-        resolveInlineWidgetResource = viewModel::resolveInlineWidgetResource,
-        loadImageArtifact = viewModel::loadChatImageArtifact,
-        loadMediaArtifact = viewModel::loadChatMediaArtifact,
-        modifier = Modifier.weight(1f),
-        header = { onJumpToLatest ->
-          if (!compactHeight && !detailsExpanded) headerContent(onJumpToLatest) { detailsExpanded = false }
-        },
-      ) { onJumpToLatest ->
-        ChatComposer(
-          compactHeight = compactHeight,
-          detailsExpanded = detailsExpanded,
-          onDetailsExpandedChange = { detailsExpanded = it },
-          conversationHeader = { dismissDetails -> headerContent(onJumpToLatest, dismissDetails) },
-          conversationStatus = {
-            errorText?.takeIf { it.isNotBlank() }?.let { error ->
-              ChatNotice(
-                title = nativeString("Chat needs attention"),
-                body = userFacingChatError(error = error, gatewayConnected = gatewayConnectionDisplay.isConnected),
-              )
-            }
-            ChatSwarmProgress(groups = swarmGroups)
-          },
-          progressCard = progressCard,
-          value = input,
-          onValueChange = {
-            sendMessageTooLong = false
-            sendCheckpointFull = false
-            inputDrafts[composerOwner] = it
-          },
-          attachments = attachments,
-          thinkingLevel = thinkingLevel,
-          thinkingOptions = thinkingLevelSelection.options,
-          thinkingSupported = thinkingSupported,
-          thinkingLevelEnabled = canAdminSessionSettings,
-          fastMode = fastMode,
-          fastModeEnabled =
-            chatFastModeControlEnabled(
-              supported = fastModeSupported,
-              adminAuthorized = canAdminSessionSettings,
-              connected = gatewayConnectionDisplay.isConnected,
-              gatewayAvailable = healthOk,
-              loading = historyLoading || sessionCreating,
-              sending = sendInFlight,
-              activeRun = pendingRunCount > 0,
-              streaming = streamingAssistantText != null,
-              settingsMutationPending = sessionSettingsPending,
-            ),
-          contextUsage = contextUsage,
-          selectedModelLabel = selectedModelLabel,
-          modelPickerEnabled = gatewayConnectionDisplay.isConnected && canWriteSessionSettings,
-          healthOk = healthOk,
-          gatewayOffline = gatewayOffline,
-          offlineStatus = offlineStatus,
-          pendingRunCount = pendingRunCount,
-          shareStaging = shareStaging,
-          sendInFlight = sendInFlight,
-          shareImportNotice = shareImportNotice,
-          modelUnavailableMessage = modelUnavailableMessage,
-          onDismissShareImportNotice = {
-            sendMessageTooLong = false
-            sendCheckpointFull = false
-            composerState.clearAttachmentOmission(composerOwner)
-          },
-          commands = chatCommands,
-          onThinkingLevelChange = viewModel::setChatThinkingLevel,
-          onFastModeChange = { enabled ->
-            viewModel.setChatSessionFastMode(
-              sessionKey = sessionKey,
-              enabled = enabled,
-              clearOverride = !fastModeProviderSupported,
-            )
-          },
-          onOpenModelPicker = { showModelPicker = true },
-          onPickImages = {
-            if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
-            val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
-            imagePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
-            pickImages.launch("image/*")
-          },
-          onPickAudioOrDocument = {
-            if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
-            val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
-            filePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
-            pickMediaOrDocument.launch(SHARED_AUDIO_DOCUMENT_MIME_TYPES)
-          },
-          onPickVideo = {
-            if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
-            val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
-            filePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
-            pickMediaOrDocument.launch(SHARED_VIDEO_MIME_TYPES)
-          },
-          onRemoveAttachment = { id -> composerState.removeAttachments(composerOwner, setOf(id)) },
-          voiceNoteState = voiceNoteState,
-          voiceNoteElapsedMs = voiceNoteElapsedMs,
-          voiceNoteLevel = voiceNoteLevel,
-          recordVoiceNoteEnabled =
-            !talkActive &&
-              !composerOwner.gatewayStableId.isNullOrBlank() &&
-              pendingRunCount == 0 &&
-              !micCaptureActive &&
-              !dictationActive &&
-              !sendInFlight,
-          onStartVoiceNote = {
-            scope.launch {
-              val ownerSnapshot = composerOwner
-              val mediaAuthorizationId = composerState.beginMediaAcquisition(ownerSnapshot) ?: return@launch
-              val recordingId = UUID.randomUUID().toString()
-              if (!viewModel.isCurrentChatComposerOwner(ownerSnapshot)) {
-                composerState.cancelMediaAcquisition(mediaAuthorizationId)
-                return@launch
-              }
-              dictationController.cancel()
-              if (voiceNoteRecorder.start(recordingId)) {
-                if (
-                  viewModel.isCurrentChatComposerOwner(ownerSnapshot) &&
-                  composerState.isMediaAcquisitionActive(mediaAuthorizationId)
-                ) {
-                  voiceNoteCommitCheckpoint.begin(ownerSnapshot, mediaAuthorizationId, recordingId)
-                } else {
-                  voiceNoteRecorder.cancel()
-                  composerState.cancelMediaAcquisition(mediaAuthorizationId)
-                }
-              } else {
-                composerState.cancelMediaAcquisition(mediaAuthorizationId)
-              }
-            }
-          },
-          onCancelVoiceNote = {
-            voiceNoteCommitCheckpoint.clear()?.let { lease ->
-              composerState.cancelMediaAcquisition(lease.authorizationId)
-            }
-            voiceNoteRecorder.cancel()
-          },
-          onFinishVoiceNote = voiceNoteRecorder::finish,
-          dictationState = dictationState,
-          dictationEnabled =
-            !talkActive &&
-              pendingRunCount == 0 &&
-              !micCaptureActive &&
-              !sendInFlight &&
-              (voiceNoteState is VoiceNoteRecorderState.Idle || voiceNoteState is VoiceNoteRecorderState.Failure),
-          onToggleDictation = {
-            if (dictationActive) {
-              dictationController.finish()
-            } else {
-              scope.launch {
-                val ownerSnapshot = composerOwner
-                val transcript = dictationController.start()
-                // Recognition can finish after navigation. Only the composer that started
-                // dictation may receive its transcript; otherwise a late result crosses drafts.
-                if (transcript != null && viewModel.isCurrentChatComposerOwner(ownerSnapshot)) {
-                  inputDrafts[ownerSnapshot] =
-                    appendChatDictationTranscript(inputDrafts[ownerSnapshot], transcript)
-                }
-              }
-            }
-          },
-          talkActive = talkActive,
-          onToggleTalk = onToggleTalk,
-          onFixConnection = onOpenGatewaySettings,
-          onOpenProvidersModels = onOpenProvidersModels,
-          onCopyDiagnostics = {
-            copyGatewayDiagnosticsReport(
-              context = context,
-              screen = "chat composer",
-              gatewayAddress = gatewayAddress,
-              statusText = offlineStatus,
-            )
-          },
-          onAbort = viewModel::abortChat,
-          onSend = {
-            // Re-read the ViewModel so a stale click callback cannot beat StateFlow recomposition.
-            val currentShare = viewModel.chatShareDraftForOwner(composerOwner, mainSessionKey)
-            if (currentShare != null || composerOwner in sendStates) {
-              return@ChatComposer
-            }
-            val ownerSnapshot = composerOwner
-            if (!viewModel.isCurrentChatComposerOwner(ownerSnapshot)) return@ChatComposer
-            val result =
-              viewModel.beginChatComposerSend(
-                owner = ownerSnapshot,
-                thinking = thinkingLevel,
-              )
-            sendMessageTooLong = result == ChatComposerSendStartResult.MessageTooLong
-            sendCheckpointFull = result == ChatComposerSendStartResult.CheckpointFull
-          },
         )
       }
-    }
+    },
+    onForkMessage = { entryId ->
+      scope.launch {
+        val result = viewModel.forkChatAtEntry(entryId) ?: return@launch
+        val newOwner = composerOwner.copy(sessionKey = result.sessionKey)
+        val expectedInput = inputDrafts[newOwner].orEmpty()
+        viewModel.switchChatSession(result.sessionKey, composerOwner.agentId)
+        viewModel.setChatDraft(
+          ChatDraft(
+            text = result.editorText.orEmpty(),
+            placement = ChatDraftPlacement.Replace,
+            owner = newOwner,
+            expectedExistingText = expectedInput,
+            acceptsEmptyText = true,
+            attachments = result.editorAttachments.toPendingAttachments(),
+          ),
+        )
+      }
+    },
+    speechState = messageSpeechState,
+    onToggleListen = viewModel::toggleChatMessageSpeech,
+    inlineMediaPlaybackBlocked = inlineMediaPlaybackBlocked,
+    resolveInlineWidgetResource = viewModel::resolveInlineWidgetResource,
+    loadImageArtifact = viewModel::loadChatImageArtifact,
+    loadMediaArtifact = viewModel::loadChatMediaArtifact,
+    modifier = Modifier.fillMaxSize().imePadding(),
+    tabletopPanes = tabletopPanes,
+    features = features,
+    conversationStatus = conversationStatus,
+    header = { onJumpToLatest, compactHeight, tabletop ->
+      if ((!compactHeight || tabletop) && !detailsExpanded) headerContent(onJumpToLatest) { detailsExpanded = false }
+    },
+  ) { onJumpToLatest, compactHeight, tabletop ->
+    ChatComposer(
+      compactHeight = compactHeight,
+      detailsExpanded = detailsExpanded,
+      onDetailsExpandedChange = { detailsExpanded = it },
+      conversationHeader = { dismissDetails -> headerContent(onJumpToLatest, dismissDetails) },
+      conversationStatus = {
+        if (!tabletop) conversationStatus()
+      },
+      progressCard = progressCard,
+      value = input,
+      onValueChange = {
+        sendMessageTooLong = false
+        sendCheckpointFull = false
+        inputDrafts[composerOwner] = it
+      },
+      attachments = attachments,
+      thinkingLevel = thinkingLevel,
+      thinkingOptions = thinkingLevelSelection.options,
+      thinkingSupported = thinkingSupported,
+      thinkingLevelEnabled = canAdminSessionSettings,
+      fastMode = fastMode,
+      fastModeEnabled =
+        chatFastModeControlEnabled(
+          supported = fastModeSupported,
+          adminAuthorized = canAdminSessionSettings,
+          connected = gatewayConnectionDisplay.isConnected,
+          gatewayAvailable = healthOk,
+          loading = historyLoading || sessionCreating,
+          sending = sendInFlight,
+          activeRun = pendingRunCount > 0,
+          streaming = streamingAssistantText != null,
+          settingsMutationPending = sessionSettingsPending,
+        ),
+      contextUsage = contextUsage,
+      selectedModelLabel = selectedModelLabel,
+      modelPickerEnabled = gatewayConnectionDisplay.isConnected && canWriteSessionSettings,
+      healthOk = healthOk,
+      gatewayOffline = gatewayOffline,
+      offlineStatus = offlineStatus,
+      pendingRunCount = pendingRunCount,
+      shareStaging = shareStaging,
+      sendInFlight = sendInFlight,
+      shareImportNotice = shareImportNotice,
+      modelUnavailableMessage = modelUnavailableMessage,
+      onDismissShareImportNotice = {
+        sendMessageTooLong = false
+        sendCheckpointFull = false
+        composerState.clearAttachmentOmission(composerOwner)
+      },
+      commands = chatCommands,
+      onThinkingLevelChange = viewModel::setChatThinkingLevel,
+      onFastModeChange = { enabled ->
+        viewModel.setChatSessionFastMode(
+          sessionKey = sessionKey,
+          enabled = enabled,
+          clearOverride = !fastModeProviderSupported,
+        )
+      },
+      onOpenModelPicker = { showModelPicker = true },
+      onPickImages = {
+        if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
+        val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
+        imagePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
+        pickImages.launch("image/*")
+      },
+      onPickAudioOrDocument = {
+        if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
+        val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
+        filePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
+        pickMediaOrDocument.launch(SHARED_AUDIO_DOCUMENT_MIME_TYPES)
+      },
+      onPickVideo = {
+        if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
+        val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
+        filePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
+        pickMediaOrDocument.launch(SHARED_VIDEO_MIME_TYPES)
+      },
+      onRemoveAttachment = { id -> composerState.removeAttachments(composerOwner, setOf(id)) },
+      voiceNoteState = voiceNoteState,
+      voiceNoteElapsedMs = voiceNoteElapsedMs,
+      voiceNoteLevel = voiceNoteLevel,
+      recordVoiceNoteEnabled =
+        !talkActive &&
+          !composerOwner.gatewayStableId.isNullOrBlank() &&
+          pendingRunCount == 0 &&
+          !micCaptureActive &&
+          !dictationActive &&
+          !sendInFlight,
+      onStartVoiceNote = {
+        scope.launch {
+          val ownerSnapshot = composerOwner
+          val mediaAuthorizationId = composerState.beginMediaAcquisition(ownerSnapshot) ?: return@launch
+          val recordingId = UUID.randomUUID().toString()
+          if (!viewModel.isCurrentChatComposerOwner(ownerSnapshot)) {
+            composerState.cancelMediaAcquisition(mediaAuthorizationId)
+            return@launch
+          }
+          dictationController.cancel()
+          if (voiceNoteRecorder.start(recordingId)) {
+            if (
+              viewModel.isCurrentChatComposerOwner(ownerSnapshot) &&
+              composerState.isMediaAcquisitionActive(mediaAuthorizationId)
+            ) {
+              voiceNoteCommitCheckpoint.begin(ownerSnapshot, mediaAuthorizationId, recordingId)
+            } else {
+              voiceNoteRecorder.cancel()
+              composerState.cancelMediaAcquisition(mediaAuthorizationId)
+            }
+          } else {
+            composerState.cancelMediaAcquisition(mediaAuthorizationId)
+          }
+        }
+      },
+      onCancelVoiceNote = {
+        voiceNoteCommitCheckpoint.clear()?.let { lease ->
+          composerState.cancelMediaAcquisition(lease.authorizationId)
+        }
+        voiceNoteRecorder.cancel()
+      },
+      onFinishVoiceNote = voiceNoteRecorder::finish,
+      dictationState = dictationState,
+      dictationEnabled =
+        !talkActive &&
+          pendingRunCount == 0 &&
+          !micCaptureActive &&
+          !sendInFlight &&
+          (voiceNoteState is VoiceNoteRecorderState.Idle || voiceNoteState is VoiceNoteRecorderState.Failure),
+      onToggleDictation = {
+        if (dictationActive) {
+          dictationController.finish()
+        } else {
+          scope.launch {
+            val ownerSnapshot = composerOwner
+            val transcript = dictationController.start()
+            // Recognition can finish after navigation. Only the composer that started
+            // dictation may receive its transcript; otherwise a late result crosses drafts.
+            if (transcript != null && viewModel.isCurrentChatComposerOwner(ownerSnapshot)) {
+              inputDrafts[ownerSnapshot] =
+                appendChatDictationTranscript(inputDrafts[ownerSnapshot], transcript)
+            }
+          }
+        }
+      },
+      talkActive = talkActive,
+      onToggleTalk = onToggleTalk,
+      onFixConnection = onOpenGatewaySettings,
+      onOpenProvidersModels = onOpenProvidersModels,
+      onCopyDiagnostics = {
+        copyGatewayDiagnosticsReport(
+          context = context,
+          screen = "chat composer",
+          gatewayAddress = gatewayAddress,
+          statusText = offlineStatus,
+        )
+      },
+      onAbort = viewModel::abortChat,
+      onSend = {
+        // Re-read the ViewModel so a stale click callback cannot beat StateFlow recomposition.
+        val currentShare = viewModel.chatShareDraftForOwner(composerOwner, mainSessionKey)
+        if (currentShare != null || composerOwner in sendStates) {
+          return@ChatComposer
+        }
+        val ownerSnapshot = composerOwner
+        if (!viewModel.isCurrentChatComposerOwner(ownerSnapshot)) return@ChatComposer
+        val result =
+          viewModel.beginChatComposerSend(
+            owner = ownerSnapshot,
+            thinking = thinkingLevel,
+          )
+        sendMessageTooLong = result == ChatComposerSendStartResult.MessageTooLong
+        sendCheckpointFull = result == ChatComposerSendStartResult.CheckpointFull
+      },
+    )
   }
 
   if (showModelPicker) {
@@ -1244,7 +1242,7 @@ private fun ChatHeader(
         projectLabel?.let { project ->
           Text(
             text = project,
-            style = ClawTheme.type.caption.copy(fontSize = 11.sp, lineHeight = 13.sp, fontWeight = FontWeight.Normal),
+            style = chatProjectStyle(),
             color = ClawTheme.colors.textMuted,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
@@ -1256,7 +1254,7 @@ private fun ChatHeader(
         ) {
           Text(
             text = sessionTitle,
-            style = ClawTheme.type.title.copy(fontSize = 14.sp, lineHeight = 18.sp, fontWeight = FontWeight.Medium),
+            style = chatTitleStyle(),
             color = ClawTheme.colors.text,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
@@ -1398,8 +1396,11 @@ private fun ChatMessageList(
   loadImageArtifact: suspend (String) -> GatewayLoadedImage?,
   loadMediaArtifact: suspend (String, GatewayMediaKind, Boolean) -> GatewayLoadedMedia?,
   modifier: Modifier = Modifier,
-  header: @Composable ((() -> Unit)?) -> Unit,
-  composer: @Composable ((() -> Unit)?) -> Unit,
+  tabletopPanes: TabletopPaneBounds?,
+  features: List<DisplayFeature>,
+  conversationStatus: @Composable () -> Unit,
+  header: @Composable ((() -> Unit)?, Boolean, Boolean) -> Unit,
+  composer: @Composable ((() -> Unit)?, Boolean, Boolean) -> Unit,
 ) {
   val baseTimeline =
     remember(messages, activeRunCount, pendingToolCalls, subagentActivities, questions, streamingAssistantText, outboxItems, recoveryOutboxItems) {
@@ -1449,158 +1450,180 @@ private fun ChatMessageList(
     onDispose { turnRecapResolver.abandonActiveWatch(sessionKey) }
   }
 
-  // The header stays outside the weighted transcript so composer panels cannot collapse it.
   val onJumpToLatest = readerScroll.jumpToLatest.takeIf { readerScroll.showJumpToLatest }
-  header(onJumpToLatest)
-  CompositionLocalProvider(LocalChatReaderNavigation provides readerScroll.onManualNavigation) {
-    ChatMessageDisclosure(
-      messages = messages,
-      owner = fullMessageOwner,
-      selectionGeneration = selectionGeneration,
-      catalogRevision = gatewayCatalogRevision,
-      prepareRead = prepareFullMessageRead,
-    ) { visibleContent, disclosure ->
-      Box(modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
-        LazyColumn(
-          modifier = Modifier.fillMaxSize().nestedScroll(readerScroll.nestedScrollConnection),
-          state = readerScroll.listState,
-          reverseLayout = true,
-          verticalArrangement = Arrangement.spacedBy(12.dp),
-          contentPadding = PaddingValues(top = 6.dp, bottom = 3.dp),
-        ) {
-          itemsIndexed(items = timeline.items, key = { _, item -> chatTimelineItemKey(item) }) { _, item ->
-            when (item) {
-              is ChatTimelineItem.Message -> {
-                ChatBubble(
-                  messageId = item.message.id,
-                  entryId = item.message.entryId,
-                  role = item.message.role,
-                  live = false,
-                  content = visibleContent(item.message),
-                  timestampMs = item.message.timestampMs,
-                  onReplyMessage = onReplyMessage,
-                  sessionActionsEnabled = sessionActionsEnabled,
-                  onRewindMessage = onRewindMessage,
-                  onForkMessage = onForkMessage,
-                  speechState = speechState,
-                  onToggleListen = onToggleListen,
-                  inlineMediaPlaybackBlocked = inlineMediaPlaybackBlocked,
-                  inlineWidgetResolverReady = healthOk,
-                  resolveInlineWidgetResource = resolveInlineWidgetResource,
-                  loadImageArtifact = loadImageArtifact,
-                  loadMediaArtifact = loadMediaArtifact,
-                  senderLabel = item.message.senderLabel,
-                  disclosure = { disclosure(item.message) },
-                )
-              }
+  val density = LocalDensity.current
+  val headerTextHeight = minimumChatLineHeight(chatProjectStyle()) + minimumChatLineHeight(chatTitleStyle())
+  val readerLineHeight = minimumChatLineHeight(ClawTheme.type.body)
+  val minimumHeaderHeight =
+    with(density) {
+      maxOf(ClawTheme.spacing.touchTarget.roundToPx(), headerTextHeight).toDp()
+    }
+  val minimumReaderHeight =
+    with(density) {
+      maxOf(ClawTheme.spacing.touchTarget.roundToPx(), readerLineHeight).toDp()
+    }
+  ChatPaneLayout(
+    tabletopPanes = tabletopPanes,
+    features = features,
+    minimumInputHeight = minimumChatInputHeight(),
+    minimumHeaderHeight = minimumHeaderHeight,
+    minimumReaderHeight = minimumReaderHeight,
+    touchTarget = ClawTheme.spacing.touchTarget,
+    modifier = modifier,
+    header = { compact, tabletop -> header(onJumpToLatest, compact, tabletop) },
+    status = conversationStatus,
+    composer = { compact, tabletop -> composer(onJumpToLatest, compact, tabletop) },
+    transcript = {
+      CompositionLocalProvider(LocalChatReaderNavigation provides readerScroll.onManualNavigation) {
+        ChatMessageDisclosure(
+          messages = messages,
+          owner = fullMessageOwner,
+          selectionGeneration = selectionGeneration,
+          catalogRevision = gatewayCatalogRevision,
+          prepareRead = prepareFullMessageRead,
+        ) { visibleContent, disclosure ->
+          Box(modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp)) {
+            LazyColumn(
+              modifier = Modifier.fillMaxSize().nestedScroll(readerScroll.nestedScrollConnection),
+              state = readerScroll.listState,
+              reverseLayout = true,
+              verticalArrangement = Arrangement.spacedBy(12.dp),
+              contentPadding = PaddingValues(top = 6.dp, bottom = 3.dp),
+            ) {
+              itemsIndexed(items = timeline.items, key = { _, item -> chatTimelineItemKey(item) }) { _, item ->
+                when (item) {
+                  is ChatTimelineItem.Message -> {
+                    ChatBubble(
+                      messageId = item.message.id,
+                      entryId = item.message.entryId,
+                      role = item.message.role,
+                      live = false,
+                      content = visibleContent(item.message),
+                      timestampMs = item.message.timestampMs,
+                      onReplyMessage = onReplyMessage,
+                      sessionActionsEnabled = sessionActionsEnabled,
+                      onRewindMessage = onRewindMessage,
+                      onForkMessage = onForkMessage,
+                      speechState = speechState,
+                      onToggleListen = onToggleListen,
+                      inlineMediaPlaybackBlocked = inlineMediaPlaybackBlocked,
+                      inlineWidgetResolverReady = healthOk,
+                      resolveInlineWidgetResource = resolveInlineWidgetResource,
+                      loadImageArtifact = loadImageArtifact,
+                      loadMediaArtifact = loadMediaArtifact,
+                      senderLabel = item.message.senderLabel,
+                      disclosure = { disclosure(item.message) },
+                    )
+                  }
 
-              is ChatTimelineItem.OutboxCommand -> {
-                ChatOutboxBubble(
-                  item = item.item,
-                  onRetry = { onRetryOutbox(item.item.id) },
-                  onDelete = { onDeleteOutbox(item.item.id) },
-                )
-              }
+                  is ChatTimelineItem.OutboxCommand -> {
+                    ChatOutboxBubble(
+                      item = item.item,
+                      onRetry = { onRetryOutbox(item.item.id) },
+                      onDelete = { onDeleteOutbox(item.item.id) },
+                    )
+                  }
 
-              is ChatTimelineItem.RecoveryOutboxCommand -> {
-                ChatOutboxBubble(
-                  item = item.item,
-                  retryEnabled = false,
-                  onRetry = { onRetryOutbox(item.item.id) },
-                  onDelete = { onDeleteOutbox(item.item.id) },
-                )
-              }
+                  is ChatTimelineItem.RecoveryOutboxCommand -> {
+                    ChatOutboxBubble(
+                      item = item.item,
+                      retryEnabled = false,
+                      onRetry = { onRetryOutbox(item.item.id) },
+                      onDelete = { onDeleteOutbox(item.item.id) },
+                    )
+                  }
 
-              is ChatTimelineItem.OutboxRecoveryHeader -> {
-                ChatNotice(
-                  title = nativeString("Messages to recover"),
-                  body =
-                    nativeString(
-                      "\${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows.",
-                      item.count,
-                    ),
-                )
-              }
+                  is ChatTimelineItem.OutboxRecoveryHeader -> {
+                    ChatNotice(
+                      title = nativeString("Messages to recover"),
+                      body =
+                        nativeString(
+                          "\${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows.",
+                          item.count,
+                        ),
+                    )
+                  }
 
-              is ChatTimelineItem.PendingTools -> {
-                ToolBubble(toolCalls = item.toolCalls)
-              }
+                  is ChatTimelineItem.PendingTools -> {
+                    ToolBubble(toolCalls = item.toolCalls)
+                  }
 
-              is ChatTimelineItem.SubagentActivity -> {
-                SubagentActivityRows(
-                  activities = item.activities,
-                  moreWorkingCount = item.moreWorkingCount,
-                )
-              }
+                  is ChatTimelineItem.SubagentActivity -> {
+                    SubagentActivityRows(
+                      activities = item.activities,
+                      moreWorkingCount = item.moreWorkingCount,
+                    )
+                  }
 
-              is ChatTimelineItem.QuestionPrompt -> {
-                ChatQuestionCard(prompt = item.prompt, onDraftChanged = onQuestionDraftChanged, onSubmit = onResolveQuestion, onSkip = onSkipQuestion)
-              }
+                  is ChatTimelineItem.QuestionPrompt -> {
+                    ChatQuestionCard(prompt = item.prompt, onDraftChanged = onQuestionDraftChanged, onSubmit = onResolveQuestion, onSkip = onSkipQuestion)
+                  }
 
-              is ChatTimelineItem.TurnRecapSummary -> {
-                ChatTurnRecapRow(item.recap)
-              }
+                  is ChatTimelineItem.TurnRecapSummary -> {
+                    ChatTurnRecapRow(item.recap)
+                  }
 
-              is ChatTimelineItem.SystemNotice -> {
-                ChatSystemNoticeRow(item)
-              }
+                  is ChatTimelineItem.SystemNotice -> {
+                    ChatSystemNoticeRow(item)
+                  }
 
-              is ChatTimelineItem.SystemDivider -> {
-                ChatSystemDividerRow(item)
-              }
+                  is ChatTimelineItem.SystemDivider -> {
+                    ChatSystemDividerRow(item)
+                  }
 
-              is ChatTimelineItem.StreamingAssistant -> {
-                ChatBubble(
-                  messageId = null,
-                  entryId = null,
-                  role = "assistant",
-                  live = true,
-                  content = listOf(ChatMessageContent(text = item.text)),
-                  timestampMs = null,
-                  onReplyMessage = onReplyMessage,
-                  sessionActionsEnabled = false,
-                  onRewindMessage = onRewindMessage,
-                  onForkMessage = onForkMessage,
-                  speechState = null,
-                  onToggleListen = onToggleListen,
-                  inlineMediaPlaybackBlocked = inlineMediaPlaybackBlocked,
-                  inlineWidgetResolverReady = healthOk,
-                  resolveInlineWidgetResource = resolveInlineWidgetResource,
-                  loadImageArtifact = loadImageArtifact,
-                  loadMediaArtifact = loadMediaArtifact,
-                )
-              }
+                  is ChatTimelineItem.StreamingAssistant -> {
+                    ChatBubble(
+                      messageId = null,
+                      entryId = null,
+                      role = "assistant",
+                      live = true,
+                      content = listOf(ChatMessageContent(text = item.text)),
+                      timestampMs = null,
+                      onReplyMessage = onReplyMessage,
+                      sessionActionsEnabled = false,
+                      onRewindMessage = onRewindMessage,
+                      onForkMessage = onForkMessage,
+                      speechState = null,
+                      onToggleListen = onToggleListen,
+                      inlineMediaPlaybackBlocked = inlineMediaPlaybackBlocked,
+                      inlineWidgetResolverReady = healthOk,
+                      resolveInlineWidgetResource = resolveInlineWidgetResource,
+                      loadImageArtifact = loadImageArtifact,
+                      loadMediaArtifact = loadMediaArtifact,
+                    )
+                  }
 
-              ChatTimelineItem.Thinking -> {
-                val run = workingRun
-                if (run != null) {
-                  ChatTypingIndicatorBubble(
-                    runKey = run.clockKey,
-                    observedAtElapsedMs = run.observedAtElapsedMs,
-                    outputTokens = run.outputTokens,
-                  )
+                  ChatTimelineItem.Thinking -> {
+                    val run = workingRun
+                    if (run != null) {
+                      ChatTypingIndicatorBubble(
+                        runKey = run.clockKey,
+                        observedAtElapsedMs = run.observedAtElapsedMs,
+                        outputTokens = run.outputTokens,
+                      )
+                    }
+                  }
                 }
+              }
+            }
+
+            if (timeline.items.isEmpty()) {
+              if (showChatLoadingPlaceholder(historyLoading = historyLoading, healthOk = healthOk, gatewayOffline = gatewayOffline)) {
+                ClawLoadingState(title = nativeString("Loading thread"), modifier = Modifier.align(Alignment.Center))
+              } else {
+                EmptyChatHint(
+                  healthOk = healthOk,
+                  gatewayOffline = gatewayOffline,
+                  onStarterPrompt = onStarterPrompt,
+                  modifier = Modifier.align(Alignment.Center),
+                )
               }
             }
           }
         }
-
-        if (timeline.items.isEmpty()) {
-          if (showChatLoadingPlaceholder(historyLoading = historyLoading, healthOk = healthOk, gatewayOffline = gatewayOffline)) {
-            ClawLoadingState(title = nativeString("Loading thread"), modifier = Modifier.align(Alignment.Center))
-          } else {
-            EmptyChatHint(
-              healthOk = healthOk,
-              gatewayOffline = gatewayOffline,
-              onStarterPrompt = onStarterPrompt,
-              modifier = Modifier.align(Alignment.Center),
-            )
-          }
-        }
       }
-    }
-  }
-  composer(onJumpToLatest)
+    },
+  )
 }
 
 internal data class ChatWorkingRun(
@@ -2436,12 +2459,33 @@ private fun PlanStepMarker(status: ChatPlanStepStatus) {
   }
 }
 
-private val chatDraftLineHeight = 22.sp
+@Composable
+private fun chatDraftStyle(): TextStyle = ClawTheme.type.body.copy(fontSize = 16.sp, lineHeight = 22.sp)
 
 @Composable
-private fun minimumChatInputHeight(): Dp =
-  maxOf(ClawTheme.spacing.touchTarget, with(LocalDensity.current) { chatDraftLineHeight.toDp() } + 12.dp) +
-    ClawTheme.spacing.touchTarget + 8.dp
+private fun chatProjectStyle(): TextStyle = ClawTheme.type.caption.copy(fontSize = 11.sp, lineHeight = 13.sp, fontWeight = FontWeight.Normal)
+
+@Composable
+private fun chatTitleStyle(): TextStyle = ClawTheme.type.title.copy(fontSize = 14.sp, lineHeight = 18.sp, fontWeight = FontWeight.Medium)
+
+@Composable
+private fun minimumChatLineHeight(style: TextStyle): Int {
+  // Android's nonlinear scaling resolves line height relative to the rendered font size.
+  val measured = rememberTextMeasurer().measure("H", style = style, maxLines = 1, softWrap = false).size.height
+  return maxOf(measured, with(LocalDensity.current) { ceil(style.lineHeight.toPx()).toInt() })
+}
+
+@Composable
+private fun minimumChatInputHeight(): Dp {
+  val lineHeight = minimumChatLineHeight(chatDraftStyle())
+  return with(LocalDensity.current) {
+    // Match each separately rounded editor/action padding and the text's full pixel line.
+    (
+      maxOf(ClawTheme.spacing.touchTarget.roundToPx(), lineHeight + 8.dp.roundToPx() + 4.dp.roundToPx()) +
+        ClawTheme.spacing.touchTarget.roundToPx() + 4.dp.roundToPx() * 2
+    ).toDp()
+  }
+}
 
 @Composable
 private fun ChatComposer(
@@ -3542,7 +3586,7 @@ private fun ChatInputPill(
 ) {
   val hardwareEnterHandler = remember { PhysicalChatSendKeyHandler() }
   var attachmentMenuExpanded by rememberSaveable { mutableStateOf(false) }
-  val draftStyle = ClawTheme.type.body.copy(fontSize = 16.sp, lineHeight = chatDraftLineHeight)
+  val draftStyle = chatDraftStyle()
 
   Surface(
     modifier = modifier.testTag("chat-composer-surface"),

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareContentTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareContentTest.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.window.layout.DisplayFeature
+import androidx.window.layout.FoldingFeature
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -79,6 +80,52 @@ class FoldAwareContentTest {
     composeRule.runOnIdle {
       assertEquals("Fold changes must not recreate the editor composition", 1, starts)
       assertEquals(0, disposals)
+    }
+  }
+
+  @Test
+  fun tabletopExposesBothPlanesOnlyWhenEverySeparatorAllowsThem() {
+    var folds by mutableStateOf(emptyList<DisplayFeature>())
+    composeRule.setContent {
+      Box(Modifier.fillMaxSize(), contentAlignment = AbsoluteAlignment.TopLeft) {
+        FoldAwareContent(
+          folds,
+          Modifier.absoluteOffset { IntOffset(100, 50) }.size(800.dp, 800.dp),
+          tabletopEnabled = true,
+        ) {
+          var draft by remember { mutableStateOf("") }
+          Box(Modifier.fillMaxSize().testTag("pane")) {
+            BasicTextField(draft, { draft = it }, Modifier.testTag("editor"))
+          }
+        }
+      }
+    }
+    val pane = composeRule.onNodeWithTag("pane")
+    val editor = composeRule.onNodeWithTag("editor")
+    editor.performTextReplacement("all-feature draft")
+    val editorId = editor.fetchSemanticsNode().id
+    val full = DpRect(100.dp, 50.dp, 900.dp, 850.dp)
+    val horizontal = testFold(Rect(100, 350, 900, 370))
+    val cases =
+      listOf(
+        listOf(horizontal) to full,
+        listOf(testFold(Rect(100, 350, 900, 370), state = FoldingFeature.State.FLAT)) to full,
+        listOf(testFold(Rect(100, 350, 900, 350))) to full,
+        listOf(testFold(Rect(100, 350, 900, 370), separating = false, occlusion = FoldingFeature.OcclusionType.FULL)) to full,
+        listOf(horizontal, testFold(Rect(-40, -40, -20, -20))) to full,
+        listOf(testFold(Rect(100, 850, 900, 870))) to full,
+        listOf(testFold(Rect(100, 350, 900, 370), separating = false, state = FoldingFeature.State.FLAT)) to full,
+        listOf(testFold(Rect(200, 350, 700, 370))) to DpRect(100.dp, 370.dp, 900.dp, 850.dp),
+        listOf(testFold(Rect(100, 300, 900, 320)), testFold(Rect(100, 600, 900, 620))) to DpRect(100.dp, 320.dp, 900.dp, 600.dp),
+        listOf(horizontal, testFold(Rect(500, 50, 520, 850))) to DpRect(100.dp, 370.dp, 500.dp, 850.dp),
+        listOf(horizontal, testFold(Rect(100, 360, 900, 380))) to DpRect(100.dp, 380.dp, 900.dp, 850.dp),
+        emptyList<DisplayFeature>() to full,
+      )
+    for ((features, expected) in cases) {
+      composeRule.runOnIdle { folds = features }
+      assertEquals("Actual host allocation for $features", expected, pane.getUnclippedBoundsInRoot())
+      editor.assertTextEquals("all-feature draft")
+      assertEquals(editorId, editor.fetchSemanticsNode().id)
     }
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/RootScreenFoldTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/RootScreenFoldTest.kt
@@ -6,6 +6,7 @@ import ai.openclaw.app.NodeApp
 import ai.openclaw.app.NodeRuntime
 import ai.openclaw.app.NodeRuntimeMode
 import ai.openclaw.app.SecurePrefs
+import ai.openclaw.app.chat.ChatController
 import ai.openclaw.app.closeNodeRuntimeTestFixture
 import android.annotation.SuppressLint
 import android.app.Activity
@@ -78,6 +79,11 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -92,6 +98,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.util.ReflectionHelpers
+import java.util.Collections
 import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
@@ -180,6 +187,334 @@ class RootScreenFoldTest {
       composeRule.onNodeWithContentDescription("Close search").performClick()
       composeRule.onNodeWithTag("sidebar-search-toggle").assertIsDisplayed()
       composeRule.onNodeWithText("Theme family").assertDoesNotExist()
+    }
+  }
+
+  @Test
+  fun tabletopUsesTheLowerPlaneWithoutReplacingTheFocusedDraft() {
+    withRoot(completed = true, destination = HomeDestination.Chat) {
+      val editor = composeRule.onNode(hasSetTextAction() and hasAnyAncestor(hasTestTag("chat-composer-surface")))
+      editor.performClick().performTextReplacement("Tabletop retained draft")
+      editor.performTextInputSelection(TextRange(9, 17))
+      val editorId = editor.fetchSemanticsNode().id
+      val hinge = Rect(0, 600, view.width, 620)
+      emit(listOf(testFold(hinge)))
+      val bounds = windowBounds(editor)
+      assertTrue("Tabletop must use the lower plane: editor=$bounds hinge=$hinge", bounds.top >= hinge.bottom)
+      assertTrue(windowBounds(composeRule.onNodeWithContentDescription("Show Sidebar")).bottom <= hinge.top)
+      val transcript = composeRule.onNode(SemanticsMatcher.keyIsDefined(SemanticsActions.ScrollToIndex))
+      assertTrue("The actual transcript stays above the fold", windowBounds(transcript).bottom <= hinge.top)
+      for (label in listOf("Send", "Add attachment")) {
+        val action = windowBounds(composeRule.onNodeWithContentDescription(label))
+        assertTrue("The complete $label action stays below the fold: $action", action.top >= hinge.bottom && action.height() >= 48 && action.bottom <= view.height)
+      }
+      val voiceAction =
+        windowBounds(
+          composeRule.onNode(
+            SemanticsMatcher("Voice input action") {
+              it.config.contains(SemanticsActions.OnClick) && it.config[SemanticsActions.OnClick].label == "Dictation"
+            },
+          ),
+        )
+      assertTrue("The complete Voice input target stays below the fold", voiceAction.top >= hinge.bottom && voiceAction.height() >= 48)
+      editor.assertIsFocused().assertTextEquals("Tabletop retained draft")
+      assertEquals(editorId, editor.fetchSemanticsNode().id)
+      assertEquals(TextRange(9, 17), editor.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange])
+      composeRule.onRoot().performKeyInput { pressKey(Key.B) }
+      editor.assertTextEquals("Tabletop b draft")
+      emit(emptyList())
+      editor.assertIsFocused().assertTextEquals("Tabletop b draft")
+      assertEquals(editorId, editor.fetchSemanticsNode().id)
+    }
+  }
+
+  @Test
+  fun tabletopRelocationRetiresHeldRowMovementWithoutUndoingAnAcceptedMove() {
+    withRoot(completed = true, destination = HomeDestination.Chat) { model ->
+      composeRule.onNodeWithContentDescription("Show Sidebar").performClick()
+      val row = composeRule.onNode(hasText("Settings") and hasAnyAncestor(hasTestTag("sidebar-drawer")))
+      val initialOrder = model.sidebarPageOrder.value
+      val sessionKey = model.chatSessionKey.value
+      row.performTouchInput {
+        down(center)
+        advanceEventTime(viewConfiguration.longPressTimeoutMillis + 1L)
+        moveBy(Offset(0f, 1f))
+        moveBy(Offset(0f, 60f))
+      }
+      val firstOrder = composeRule.runOnIdle { model.sidebarPageOrder.value }
+      assertTrue("Accept the first held move", firstOrder.indexOf("settings") > initialOrder.indexOf("settings"))
+      val initialSheet = windowBounds(composeRule.onNodeWithTag("sidebar-drawer"))
+      emit(listOf(testFold(Rect(-40, -40, -20, -20))))
+      composeRule.runOnIdle { view.requestLayout() }
+      composeRule.waitForIdle()
+      assertEquals("An outside feature and equal placement leave the sheet unchanged", initialSheet, windowBounds(composeRule.onNodeWithTag("sidebar-drawer")))
+      composeRule.onRoot().performTouchInput { moveBy(Offset(0f, 60f)) }
+      val acceptedOrder = composeRule.runOnIdle { model.sidebarPageOrder.value }
+      assertTrue("The same held gesture must accept another move after idle/equal placement", acceptedOrder.indexOf("settings") > firstOrder.indexOf("settings"))
+      assertTrue("Leave room for a stale move to be observable", acceptedOrder.indexOf("settings") < acceptedOrder.lastIndex)
+      emit(listOf(testFold(Rect(0, 300, view.width, 320))))
+      val relocatedSheet = windowBounds(composeRule.onNodeWithTag("sidebar-drawer"))
+      assertEquals(initialSheet.width(), relocatedSheet.width())
+      assertTrue("Relocate the same open modal sheet to the lower safe band", relocatedSheet.top >= 320)
+      composeRule.onNodeWithTag("sidebar-close").assertIsDisplayed()
+      emit(listOf(testFold(Rect(0, 200, view.width, 220))))
+      assertTrue(windowBounds(composeRule.onNodeWithTag("sidebar-drawer")).top >= 220)
+      emit(emptyList())
+      assertEquals("Return to the original placement without reviving its gesture", initialSheet, windowBounds(composeRule.onNodeWithTag("sidebar-drawer")))
+      composeRule.onRoot().performTouchInput {
+        moveBy(Offset(0f, 130f))
+        up()
+      }
+      composeRule.runOnIdle {
+        assertEquals("Old-pointer movement must not reorder after positive-band relocation", acceptedOrder, model.sidebarPageOrder.value)
+      }
+      composeRule.onNodeWithTag("sidebar-close").assertIsDisplayed()
+      composeRule.onNodeWithTag("chat-composer-surface").assertIsDisplayed()
+      assertEquals(sessionKey, model.chatSessionKey.value)
+      row.performScrollTo().performTouchInput {
+        down(center)
+        advanceEventTime(viewConfiguration.longPressTimeoutMillis + 1L)
+        moveBy(Offset(0f, 1f))
+        moveBy(Offset(0f, 60f))
+        up()
+      }
+      composeRule.runOnIdle {
+        assertTrue("A new deliberate gesture must still reorder", model.sidebarPageOrder.value.indexOf("settings") > acceptedOrder.indexOf("settings"))
+      }
+    }
+  }
+
+  @Test
+  fun tabletopRelocationBeforeLongPressRejectsOldDownAndAcceptsFreshGesture() {
+    withRoot(completed = true, destination = HomeDestination.Chat) { model ->
+      composeRule.onNodeWithContentDescription("Show Sidebar").performClick()
+      val row = composeRule.onNode(hasText("Settings") and hasAnyAncestor(hasTestTag("sidebar-drawer")))
+      val order = model.sidebarPageOrder.value
+      val sessionKey = model.chatSessionKey.value
+      val originalBounds = windowBounds(row)
+      row.performTouchInput { down(center) }
+      emit(listOf(testFold(Rect(0, 900, view.width, 920))))
+      emit(emptyList())
+      assertEquals("The pointer stays over its row; out-of-bounds cancellation is not the witness", originalBounds, windowBounds(row))
+      composeRule.onRoot().performTouchInput {
+        advanceEventTime(viewConfiguration.longPressTimeoutMillis + 1L)
+        moveBy(Offset(0f, 1f))
+        moveBy(Offset(0f, 130f))
+        up()
+      }
+      composeRule.runOnIdle {
+        assertEquals("Relocation after DOWN must invalidate the later recognized long press", order, model.sidebarPageOrder.value)
+        assertEquals(sessionKey, model.chatSessionKey.value)
+      }
+      composeRule.onNodeWithTag("sidebar-close").assertIsDisplayed()
+      composeRule.onNodeWithTag("chat-composer-surface").assertIsDisplayed()
+      row.performTouchInput {
+        down(center)
+        advanceEventTime(viewConfiguration.longPressTimeoutMillis + 1L)
+        moveBy(Offset(0f, 1f))
+        moveBy(Offset(0f, 60f))
+        up()
+      }
+      composeRule.runOnIdle { assertNotEquals("A fresh DOWN must get current authority", order, model.sidebarPageOrder.value) }
+    }
+  }
+
+  @Test
+  fun tabletopRelocationRetiresAccumulatedSessionPinBeforeRelease() {
+    val pinRequests = Collections.synchronizedList(mutableListOf<JsonObject>())
+    var restoreRequest: () -> Unit = {}
+    try {
+      withRoot(
+        completed = true,
+        destination = HomeDestination.Chat,
+        configureRuntime = { runtime ->
+          val controller = ReflectionHelpers.getField<ChatController>(runtime, "chat")
+          val requestField = ChatController::class.java.getDeclaredField("requestGateway").apply { isAccessible = true }
+
+          @Suppress("UNCHECKED_CAST")
+          val original = requestField.get(controller) as suspend (String, String?) -> String
+          val request: suspend (String, String?) -> String = { method, params ->
+            if (method == "sessions.patch") {
+              val patch = Json.parseToJsonElement(requireNotNull(params)).jsonObject
+              if ("pinned" in patch) pinRequests.add(patch)
+            }
+            original(method, params)
+          }
+          restoreRequest = { requestField.set(controller, original) }
+          requestField.set(controller, request)
+        },
+      ) { model ->
+        val sessionKey = model.chatSessionKey.value
+        composeRule.onNodeWithContentDescription("Show Sidebar").performClick()
+        composeRule.onNodeWithText("Recent").performScrollTo().performClick()
+        val row = composeRule.onNodeWithText("Android QA").performScrollTo()
+        val session = model.chatSessions.value.single { it.key == "discord:android" }
+        val expectedPatch =
+          buildJsonObject {
+            put("key", session.key)
+            session.ownerAgentId?.let { put("agentId", it) }
+            put("pinned", true)
+          }
+        row.performTouchInput {
+          down(center)
+          advanceEventTime(viewConfiguration.longPressTimeoutMillis + 1L)
+          moveBy(Offset(0f, -1f))
+          moveBy(Offset(0f, -60f))
+          up()
+        }
+        composeRule.runOnIdle {
+          assertEquals("Fresh gesture must request the exact pin; fixture throws, so this is not persistence", listOf(expectedPatch), pinRequests.toList())
+        }
+        val originalBounds = windowBounds(row)
+        row.performTouchInput {
+          down(center)
+          advanceEventTime(viewConfiguration.longPressTimeoutMillis + 1L)
+          moveBy(Offset(0f, -1f))
+          moveBy(Offset(0f, -60f))
+        }
+        assertTrue("Accumulate a real upward session drag before relocation", windowBounds(row).top < originalBounds.top - 40)
+        composeRule.runOnIdle { assertEquals("The next pin must wait for release", listOf(expectedPatch), pinRequests.toList()) }
+        emit(listOf(testFold(Rect(0, 300, view.width, 320))))
+        assertTrue(windowBounds(composeRule.onNodeWithTag("sidebar-drawer")).top >= 320)
+        composeRule.onRoot().performTouchInput { up() }
+        composeRule.runOnIdle {
+          assertEquals("Old accumulated displacement must not request a pin after relocation", listOf(expectedPatch), pinRequests.toList())
+          assertEquals("The held session row must not navigate on release", sessionKey, model.chatSessionKey.value)
+        }
+        composeRule.onNodeWithTag("sidebar-close").assertIsDisplayed()
+        row.performScrollTo().performTouchInput {
+          down(center)
+          advanceEventTime(viewConfiguration.longPressTimeoutMillis + 1L)
+          moveBy(Offset(0f, -1f))
+          moveBy(Offset(0f, -60f))
+          up()
+        }
+        composeRule.waitForIdle()
+        composeRule.runOnIdle {
+          assertEquals("Fresh post-relocation gesture must request the same pin", listOf(expectedPatch, expectedPatch), pinRequests.toList())
+        }
+      }
+    } finally {
+      restoreRequest()
+    }
+  }
+
+  @Test
+  fun tabletopKeepsNativeDrawerDragsAndPredictiveBackAcrossPositiveRelocation() {
+    withRoot(completed = true, destination = HomeDestination.Chat) {
+      composeRule.onNodeWithContentDescription("Show Sidebar").performClick()
+      val sheet = composeRule.onNodeWithTag("sidebar-drawer")
+      val original = windowBounds(sheet)
+      Settings.Global.putFloat(view.context.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f)
+      // The fixture's active Chat run has a perpetual frame animation; advance native settling explicitly.
+      composeRule.mainClock.autoAdvance = false
+      composeRule.onNode(hasText("Settings") and hasAnyAncestor(hasTestTag("sidebar-drawer"))).performTouchInput {
+        down(center)
+        moveBy(Offset(-80f, 0f), delayMillis = 32)
+        moveBy(Offset(-40f, 0f), delayMillis = 32)
+      }
+      composeRule.mainClock.advanceTimeBy(32)
+      val closing = windowBounds(sheet)
+      assertTrue("A real native closing drag begins over a row before long press", closing.left < original.left && closing.right > 0)
+      emit(listOf(testFold(Rect(0, 300, view.width, 320))))
+      composeRule.mainClock.advanceTimeBy(160)
+      val relocatedClosing = windowBounds(sheet)
+      assertEquals("Y-only relocation keeps the real width", closing.width(), relocatedClosing.width())
+      assertEquals("Relocation must not settle or reset the held native closing drag", closing.left, relocatedClosing.left)
+      assertTrue(relocatedClosing.top >= 320)
+      composeRule.onRoot().performTouchInput {
+        moveBy(Offset(-260f, 0f), delayMillis = 32)
+        up()
+      }
+      composeRule.mainClock.advanceTimeBy(1_000)
+      composeRule.onNodeWithTag("sidebar-close").assertIsNotDisplayed()
+
+      composeRule.onRoot().performTouchInput {
+        down(Offset(2f, 400f))
+        moveBy(Offset(80f, 0f), delayMillis = 32)
+        moveBy(Offset(60f, 0f), delayMillis = 32)
+      }
+      composeRule.mainClock.advanceTimeBy(32)
+      val opening = windowBounds(sheet)
+      assertTrue("A real held opening drag must be between native anchors", opening.left < 0 && opening.right > 0)
+      emit(listOf(testFold(Rect(0, 200, view.width, 220))))
+      composeRule.mainClock.advanceTimeBy(160)
+      val relocatedOpening = windowBounds(sheet)
+      assertEquals(opening.width(), relocatedOpening.width())
+      assertEquals("Relocation must not settle or reset the held native opening drag", opening.left, relocatedOpening.left)
+      assertTrue(relocatedOpening.top >= 220)
+      composeRule.onRoot().performTouchInput {
+        moveBy(Offset(260f, 0f), delayMillis = 32)
+        up()
+      }
+      composeRule.mainClock.advanceTimeBy(1_000)
+      composeRule.onNodeWithTag("sidebar-close").assertIsDisplayed()
+      composeRule.onNodeWithContentDescription("Close navigation menu").assertIsDisplayed()
+
+      val closeButton = composeRule.onNodeWithTag("sidebar-close")
+      val idleCloseHeight = closeButton.fetchSemanticsNode().boundsInRoot.height
+      composeRule.runOnIdle {
+        backDispatcher.dispatchOnBackStarted(BackEventCompat(0f, 400f, 0f, BackEventCompat.EDGE_LEFT))
+        backDispatcher.dispatchOnBackProgressed(BackEventCompat(80f, 400f, 0.4f, BackEventCompat.EDGE_LEFT))
+      }
+      composeRule.mainClock.advanceTimeBy(32)
+      val predictive = windowBounds(sheet)
+      assertTrue("Predictive Back must visibly scale the real drawer content", closeButton.fetchSemanticsNode().boundsInRoot.height < idleCloseHeight)
+      emit(listOf(testFold(Rect(0, 300, view.width, 320))))
+      composeRule.mainClock.advanceTimeBy(160)
+      val relocatedPredictive = windowBounds(sheet)
+      assertEquals("Y-only relocation keeps the native sheet width", predictive.width(), relocatedPredictive.width())
+      val relocatedCloseHeight = closeButton.fetchSemanticsNode().boundsInRoot.height
+      assertTrue("Relocation must not clear active predictive scaling", relocatedCloseHeight < idleCloseHeight)
+      composeRule.onNodeWithTag("sidebar-close").assertIsDisplayed()
+      composeRule.onNodeWithContentDescription("Close navigation menu").assertIsDisplayed()
+      composeRule.runOnIdle {
+        backDispatcher.dispatchOnBackProgressed(BackEventCompat(160f, 400f, 0.7f, BackEventCompat.EDGE_LEFT))
+      }
+      composeRule.mainClock.advanceTimeBy(32)
+      assertTrue("The same predictive gesture must accept further progress", closeButton.fetchSemanticsNode().boundsInRoot.height < relocatedCloseHeight)
+      composeRule.runOnIdle { backDispatcher.onBackPressed() }
+      composeRule.mainClock.advanceTimeBy(1_000)
+      composeRule.onNodeWithTag("sidebar-close").assertIsNotDisplayed()
+      composeRule.onNodeWithContentDescription("Show Sidebar").performClick()
+      composeRule.mainClock.advanceTimeBy(1_000)
+      composeRule.onNodeWithTag("sidebar-close").assertIsDisplayed()
+      composeRule.runOnIdle { backDispatcher.onBackPressed() }
+      composeRule.mainClock.advanceTimeBy(1_000)
+      composeRule.onNodeWithTag("sidebar-close").assertIsNotDisplayed()
+      Settings.Global.putFloat(view.context.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 0f)
+      composeRule.mainClock.advanceTimeBy(32)
+      composeRule.mainClock.autoAdvance = true
+    }
+  }
+
+  @Test
+  fun tabletopKeepsSidebarSearchOwnerAndScrolledExpansion() {
+    withRoot(completed = true, destination = HomeDestination.Chat) {
+      emit(listOf(testFold(Rect(0, 400, view.width, 420))))
+      composeRule.onNodeWithContentDescription("Show Sidebar").performClick()
+      composeRule.onNodeWithText("Recent").performScrollTo().performClick()
+      composeRule.onNodeWithText("Android QA").performScrollTo().assertIsDisplayed()
+      val scroll = composeRule.onNode(hasScrollAction() and hasAnyAncestor(hasTestTag("sidebar-drawer")))
+      val position = scroll.fetchSemanticsNode().config[SemanticsProperties.VerticalScrollAxisRange].value()
+      assertTrue("Exercise a truly scrolled expanded sidebar", position > 0f)
+      emit(listOf(testFold(Rect(0, 420, view.width, 440))))
+      assertEquals(position, scroll.fetchSemanticsNode().config[SemanticsProperties.VerticalScrollAxisRange].value())
+      composeRule.onNodeWithText("Android QA").assertIsDisplayed()
+      composeRule.onNodeWithTag("sidebar-search-toggle").performClick()
+      val search = composeRule.onNodeWithTag("sidebar-search")
+      search.performClick().performTextReplacement("retained search")
+      search.performTextInputSelection(TextRange(9, 15))
+      val editorId = search.fetchSemanticsNode().id
+      for (folds in listOf(listOf(testFold(Rect(0, 300, view.width, 320))), emptyList())) {
+        emit(folds)
+        search.assertIsFocused().assertTextContains("retained search")
+        assertEquals(editorId, search.fetchSemanticsNode().id)
+        assertEquals(TextRange(9, 15), search.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange])
+      }
+      composeRule.onRoot().performKeyInput { pressKey(Key.B) }
+      search.assertIsFocused().assertTextContains("retained b")
+      assertEquals(editorId, search.fetchSemanticsNode().id)
     }
   }
 
@@ -543,6 +878,7 @@ class RootScreenFoldTest {
   private fun withRoot(
     completed: Boolean,
     destination: HomeDestination = HomeDestination.Settings,
+    configureRuntime: (NodeRuntime) -> Unit = {},
     verify: (MainViewModel) -> Unit,
   ) {
     val app = RuntimeEnvironment.getApplication() as NodeApp
@@ -551,6 +887,7 @@ class RootScreenFoldTest {
     val runtime = NodeRuntime(app, prefs, NodeRuntimeMode.ScreenshotFixture)
     val models = ViewModelStore()
     try {
+      configureRuntime(runtime)
       if (!completed) Robolectric.buildContentProvider(MlKitInitProvider::class.java).create()
       val model = MainViewModel(app, prefs, SavedStateHandle())
       models.put("root-fold", model)

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
@@ -19,12 +19,16 @@ import ai.openclaw.app.gateway.GatewayRegistryEntryKind
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.i18n.NativeStringResources
 import ai.openclaw.app.i18n.nativeString
+import ai.openclaw.app.ui.FoldAwareContent
+import ai.openclaw.app.ui.TabletopPaneBounds
 import ai.openclaw.app.ui.UnifiedChatShellScreen
 import ai.openclaw.app.ui.design.ClawDesignTheme
 import ai.openclaw.app.ui.design.ClawTheme
+import ai.openclaw.app.ui.testFold
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.graphics.Rect
 import android.provider.Settings
 import android.speech.SpeechRecognizer
 import android.view.KeyEvent
@@ -36,18 +40,24 @@ import androidx.activity.findViewTreeOnBackPressedDispatcherOwner
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.absoluteOffset
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.AbsoluteAlignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
@@ -72,6 +82,7 @@ import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
@@ -95,10 +106,17 @@ import androidx.compose.ui.test.swipeUp
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.core.graphics.Insets
 import androidx.core.os.LocaleListCompat
 import androidx.core.view.ViewCompat
@@ -109,6 +127,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelStore
+import androidx.window.layout.DisplayFeature
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -134,6 +153,8 @@ import org.robolectric.annotation.GraphicsMode
 import org.robolectric.shadows.ShadowSpeechRecognizer
 import java.util.UUID
 import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.math.ceil
+import kotlin.math.roundToInt
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34], qualifiers = "w360dp-h800dp-420dpi")
@@ -152,6 +173,7 @@ class ChatComposerLayoutTest {
   private var renderedCanvasColor = Color.Unspecified
   private lateinit var insetView: View
   private var observedBottomInsets: Pair<Int, Int>? = null
+  private lateinit var renderedDensity: Density
 
   @Before
   fun setUp() {
@@ -178,6 +200,241 @@ class ChatComposerLayoutTest {
     AndroidScreenshotFixture.configure(AndroidScreenshotScene.Home)
     Settings.Global.putString(app.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, originalAnimatorScale)
     NativeStringResources.install(app)
+  }
+
+  @Test
+  @Config(qualifiers = "w1000dp-h1000dp-hdpi")
+  fun tabletopEnforcesPixelFloorsAndUsesTranslatedPostInsetBoundsOnce() {
+    val width = mutableStateOf(320.dp)
+    val height = mutableStateOf(720.dp)
+    val scale = mutableStateOf(1f)
+    val offset = mutableStateOf(IntOffset(40, 60))
+    val direction = mutableStateOf(LayoutDirection.Ltr)
+    val folds = mutableStateOf(emptyList<DisplayFeature>())
+    showChat(
+      viewportHeight = { height.value },
+      fontScale = { scale.value },
+      useChatShell = true,
+      currentViewportWidth = { width.value },
+      displayFeatures = { folds.value },
+      viewportOffset = { offset.value },
+      layoutDirection = { direction.value },
+    )
+    val editor = composeRule.onNode(hasSetTextAction())
+    editor.performClick().performTextReplacement("Pixel floor draft")
+    val editorId = editor.fetchSemanticsNode().id
+
+    fun insets(
+      top: Int,
+      visibleBottom: Int,
+    ) {
+      composeRule.runOnIdle {
+        ViewCompat.dispatchApplyWindowInsets(
+          insetView,
+          WindowInsetsCompat
+            .Builder()
+            .setInsets(WindowInsetsCompat.Type.statusBars(), Insets.of(0, top, 0, 0))
+            .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, insetView.height - visibleBottom))
+            .setVisible(WindowInsetsCompat.Type.ime(), visibleBottom < insetView.height)
+            .build(),
+        )
+      }
+      composeRule.waitForIdle()
+    }
+    insets(0, insetView.height)
+    val initialViewport = chatWindowBounds(composeRule.onNodeWithTag("chat-viewport"))
+    assertTrue("The translated fixture must fit inside a stationary full window: $initialViewport, ${insetView.width}x${insetView.height}", initialViewport.right <= insetView.width && initialViewport.bottom <= insetView.height)
+    for (font in listOf(1f, 2f)) {
+      composeRule.runOnIdle {
+        scale.value = font
+        folds.value = emptyList()
+        height.value = 720.dp
+      }
+      composeRule.waitForIdle()
+      val density = renderedDensity
+      val touch = with(density) { 48.dp.roundToPx() }
+      val pad = with(density) { 10.dp.roundToPx() }
+      val gap = with(density) { 8.dp.roundToPx() }
+      val fullLayouts = mutableListOf<TextLayoutResult>()
+      editor.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { assertTrue(it(fullLayouts)) }
+      val fullLineHeight = ceil(fullLayouts.single().getLineBottom(0) - fullLayouts.single().getLineTop(0)).toInt()
+      val textInput = fullLayouts.single().layoutInput
+      val measurer = TextMeasurer(textInput.fontFamilyResolver, density, textInput.layoutDirection)
+      // Use the real font metrics, including nonlinear scaling and the font's minimum line box.
+      val projectLine = measurer.measure("Project", style = textInput.style.copy(fontSize = 11.sp, lineHeight = 13.sp, fontWeight = FontWeight.Normal)).size.height
+      val titleLine = measurer.measure("Chat", style = textInput.style.copy(fontSize = 14.sp, lineHeight = 18.sp, fontWeight = FontWeight.Medium)).size.height
+      val readerLine = measurer.measure("Reader", style = textInput.style.copy(fontSize = 14.sp, lineHeight = 19.sp)).size.height
+      val readerFloor = maxOf(touch, readerLine)
+      val upperFloor = maxOf(touch, projectLine + titleLine) + readerFloor + touch + pad * 2 + gap * 2
+      val lowerFloor =
+        maxOf(touch, with(density) { maxOf(fullLineHeight, ceil(22.sp.toPx()).toInt()) + 8.dp.roundToPx() + 4.dp.roundToPx() }) +
+          touch + with(density) { 4.dp.roundToPx() * 2 } + pad * 2
+      val widthFloor = with(density) { 320.dp.roundToPx() }
+      for ((upper, lower, paneWidth) in listOf(
+        Triple(upperFloor, lowerFloor, widthFloor),
+        Triple(upperFloor - 1, lowerFloor, widthFloor),
+        Triple(upperFloor, lowerFloor - 1, widthFloor),
+        Triple(upperFloor, lowerFloor, widthFloor - 1),
+        Triple(upperFloor, lowerFloor, widthFloor),
+      )) {
+        val top = offset.value.y + with(density) { 8.dp.roundToPx() }
+        val hinge = Rect(offset.value.x, top + upper, offset.value.x + paneWidth, top + upper + 20)
+        composeRule.runOnIdle {
+          width.value = with(density) { paneWidth.toDp() }
+          height.value = with(density) { (8.dp.roundToPx() + upper + 20 + lower).toDp() }
+          folds.value = listOf(testFold(hinge))
+        }
+        editor.assertIsFocused().assertTextEquals("Pixel floor draft")
+        assertEquals(editorId, editor.fetchSemanticsNode().id)
+        val bounds = chatWindowBounds(editor)
+        val fits = upper >= upperFloor && lower >= lowerFloor && paneWidth >= widthFloor
+        if (fits) {
+          assertTrue("Equality must allocate the lower plane: font=$font editor=$bounds hinge=$hinge floors=$upperFloor,$lowerFloor", bounds.top >= hinge.bottom)
+          assertTrue(chatWindowBounds(readerHeaderControl("Show Sidebar")).bottom <= hinge.top)
+          assertTrue("Reserve a real reader band", chatWindowBounds(readerTranscript()).height >= readerFloor)
+          assertComposerControlsVisible(primaryAction = "Send")
+          val layouts = mutableListOf<TextLayoutResult>()
+          editor.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { assertTrue(it(layouts)) }
+          val line = layouts.single()
+          assertTrue(
+            "The complete real text line fits at the exact floor: font=$font density=$density editor=$bounds textSize=${line.size} line=${line.getLineTop(0)}..${line.getLineBottom(0)} lower=$lowerFloor touch=$touch",
+            bounds.height >= ceil(line.getLineBottom(0) - line.getLineTop(0)).toInt(),
+          )
+          val caret = line.getCursorRect(editor.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange].end)
+          assertTrue("The complete caret fits at equality: $caret in $bounds", caret.top >= 0 && caret.bottom <= bounds.height && caret.left >= 0 && caret.right <= bounds.width)
+          val send = chatWindowBounds(composeRule.onNodeWithContentDescription(nativeString("Send")))
+          assertTrue("The full target fits at equality", send.height >= touch && send.top >= hinge.bottom && send.bottom <= offset.value.y + with(density) { height.value.roundToPx() })
+        } else {
+          assertTrue("One physical pixel below a floor must use the larger safe upper pane", bounds.bottom <= hinge.top)
+        }
+      }
+    }
+
+    // Independent window-coordinate receipt: the content host moves, while bars/IME stay fixed.
+    composeRule.runOnIdle {
+      scale.value = 1f
+      width.value = with(renderedDensity) { 900.toDp() }
+      height.value = with(renderedDensity) { 800.toDp() }
+      folds.value = listOf(testFold(Rect(0, 430, insetView.width, 450)))
+    }
+    insets(100, 700)
+    var bounds = chatWindowBounds(editor)
+    assertTrue("Do not subtract the IME twice: $bounds", bounds.top >= 450 && bounds.bottom <= 700)
+    for (rtl in listOf(LayoutDirection.Rtl, LayoutDirection.Ltr)) {
+      composeRule.runOnIdle {
+        offset.value = IntOffset(60, 80)
+        direction.value = rtl
+      }
+      bounds = chatWindowBounds(editor)
+      assertTrue("Ancestor movement must use this frame's physical origin: $bounds", bounds.left >= 60 && bounds.right <= 960 && bounds.top >= 450 && bounds.bottom <= 700)
+      editor.assertIsFocused()
+      assertEquals(editorId, editor.fetchSemanticsNode().id)
+    }
+    insets(100, 470)
+    assertTrue("A keyboard leaving no useful lower plane uses the safe upper pane", chatWindowBounds(editor).bottom <= 430)
+    editor.assertIsFocused().assertTextEquals("Pixel floor draft")
+    insets(100, 700)
+    assertTrue(chatWindowBounds(editor).top >= 450)
+    composeRule.runOnIdle {
+      controller.handleGatewayEvent(
+        "chat",
+        buildJsonObject {
+          put("sessionKey", JsonPrimitive(controller.sessionKey.value))
+          put("runId", JsonPrimitive("android-screenshot-active-run"))
+          put("state", JsonPrimitive("error"))
+          put("errorMessage", JsonPrimitive(List(40) { "Recoverable tabletop status line ${it + 1}" }.joinToString("\n")))
+        }.toString(),
+      )
+    }
+    composeRule.onAllNodesWithText(nativeString("Chat needs attention")).assertCountEquals(1)
+    val status = composeRule.onNode(hasScrollAction() and hasAnyDescendant(hasText(nativeString("Chat needs attention"))))
+    val statusBounds = chatWindowBounds(status)
+    assertTrue("Long status must stay in its bounded upper remainder", statusBounds.bottom <= 430 && statusBounds.height > 0)
+    assertTrue("Status cannot consume the reader floor", chatWindowBounds(readerTranscript()).height >= with(renderedDensity) { 48.dp.roundToPx() })
+    status.performTouchInput { swipeUp() }
+    assertTrue(chatWindowBounds(editor).top >= 450)
+  }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun tabletopKeepsReadingCompositionAndDetailsThroughImeFallback() {
+    val folds = mutableStateOf(emptyList<DisplayFeature>())
+    withReaderHistory(
+      assistantCount = 24,
+      viewportWidth = 720.dp,
+      viewportHeight = { 720.dp },
+      useChatShell = true,
+      displayFeatures = { folds.value },
+    ) { model ->
+      val editor = composeRule.onNode(hasSetTextAction())
+      editor.performClick().performTextReplacement("original tail")
+      editor.performSemanticsAction(SemanticsActions.SetSelection) { assertTrue(it(0, 8, false)) }
+      val editorId = editor.fetchSemanticsNode().id
+      val connection = composeRule.runOnIdle { checkNotNull(insetView.onCreateInputConnection(EditorInfo())) }
+      composeRule.runOnIdle { connection.setComposingText("fold", 1) }
+      editor.assertTextEquals("fold tail")
+      val transcript = readerTranscript()
+      val readerId = transcript.fetchSemanticsNode().id
+      transcript.performTouchInput { swipeDown() }
+      assertTrue(transcript.fetchSemanticsNode().config[SemanticsProperties.VerticalScrollAxisRange].value() > 0f)
+      composeRule.runOnIdle { folds.value = listOf(testFold(Rect(0, 540, insetView.width, 560))) }
+      editor.assertIsFocused()
+      composeRule.runOnIdle { connection.setComposingText("kept", 1) }
+      editor.assertTextEquals("kept tail")
+      assertEquals("The live composing range must survive placement, not append a new word", TextRange(4), editor.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange])
+      composeRule.runOnIdle { connection.finishComposingText() }
+      assertEquals(editorId, editor.fetchSemanticsNode().id)
+      assertEquals(readerId, transcript.fetchSemanticsNode().id)
+      assertTrue("Posture must not jump the reading viewport to latest", transcript.fetchSemanticsNode().config[SemanticsProperties.VerticalScrollAxisRange].value() > 0f)
+      readerHeaderControl("Jump to latest").assertIsDisplayed()
+      assertTrue(chatWindowBounds(readerHeaderControl("Show Sidebar")).bottom <= 540)
+      composeRule.onNodeWithContentDescription(nativeString("Details")).performClick()
+      val details = composeRule.onNode(SemanticsMatcher.expectValue(SemanticsProperties.PaneTitle, nativeString("Details")))
+      assertTrue(chatWindowBounds(details).top >= 560)
+      composeRule.runOnIdle { folds.value = listOf(testFold(Rect(0, 300, insetView.width, 320))) }
+      details.assertIsDisplayed()
+      composeRule.onAllNodesWithContentDescription(nativeString("Jump to latest")).assertCountEquals(1)
+      val owner = model.captureChatShareOwner()
+      composeRule.runOnIdle {
+        connection.commitText("hidden", 1)
+        dispatchHardwareKey(insetView, KeyEvent.KEYCODE_ENTER)
+      }
+      composeRule.runOnIdle {
+        assertEquals("Details keeps the same hidden-input guard after relocation", "kept tail", model.chatComposerState.textDrafts[owner])
+        assertFalse(owner in model.chatComposerState.sendStates.value)
+      }
+      composeRule.runOnIdle { folds.value = listOf(testFold(Rect(0, 540, insetView.width, 560))) }
+      applyChatImeInsets()
+      assertTrue("Open Details must move into the truthful safe fallback", chatWindowBounds(details).bottom <= 540)
+      composeRule.onNodeWithContentDescription(nativeString("Close")).performClick()
+      editor.assertIsEnabled().assertTextEquals("kept tail")
+      assertEquals(editorId, editor.fetchSemanticsNode().id)
+      composeRule.runOnIdle {
+        ViewCompat.dispatchApplyWindowInsets(insetView, WindowInsetsCompat.Builder().build())
+        folds.value = emptyList()
+      }
+      editor.performClick()
+      composeRule.runOnIdle { dispatchHardwareKey(insetView, KeyEvent.KEYCODE_X) }
+      editor.assertTextEquals("kept tailx")
+      assertEquals(editorId, editor.fetchSemanticsNode().id)
+      assertEquals(readerId, transcript.fetchSemanticsNode().id)
+      readerHeaderControl("Jump to latest").assertIsDisplayed().performClick()
+      assertEquals(0f, transcript.fetchSemanticsNode().config[SemanticsProperties.VerticalScrollAxisRange].value(), 0f)
+      assertReaderMessageVisible("OpenClaw", "Reader answer 24")
+    }
+  }
+
+  private fun chatWindowBounds(node: SemanticsNodeInteraction): IntRect {
+    val bounds = node.getUnclippedBoundsInRoot()
+    val origin = IntArray(2).also(insetView::getLocationInWindow)
+    return with(composeRule.density) {
+      IntRect(
+        bounds.left.roundToPx() + origin[0],
+        bounds.top.roundToPx() + origin[1],
+        bounds.right.roundToPx() + origin[0],
+        bounds.bottom.roundToPx() + origin[1],
+      )
+    }
   }
 
   @Test
@@ -1991,6 +2248,7 @@ class ChatComposerLayoutTest {
     fontScale: () -> Float = { 1f },
     onOpenSidebar: () -> Unit = {},
     useChatShell: Boolean = false,
+    displayFeatures: (() -> List<DisplayFeature>)? = null,
     additionalAssistantMessages: () -> List<String> = { emptyList() },
     onRequest: (String) -> Unit = {},
     assertions: (MainViewModel) -> Unit,
@@ -2040,6 +2298,7 @@ class ChatComposerLayoutTest {
           expectedMessageCount = texts.size,
           onOpenSidebar = onOpenSidebar,
           useChatShell = useChatShell,
+          displayFeatures = displayFeatures,
         )
       composeRule.waitUntil(timeoutMillis = 5_000) {
         composeRule.runOnIdle {
@@ -2150,6 +2409,9 @@ class ChatComposerLayoutTest {
     onOpenSidebar: () -> Unit = {},
     useChatShell: Boolean = false,
     currentViewportWidth: () -> Dp = { viewportWidth },
+    displayFeatures: (() -> List<DisplayFeature>)? = null,
+    viewportOffset: () -> IntOffset = { IntOffset.Zero },
+    layoutDirection: () -> LayoutDirection = { LayoutDirection.Ltr },
   ): MainViewModel {
     val viewModel = MainViewModel(app, prefs, SavedStateHandle())
     viewModelStore.put("chat", viewModel)
@@ -2168,35 +2430,51 @@ class ChatComposerLayoutTest {
         }
       }
       DeviceConfigurationOverride(DeviceConfigurationOverride.FontScale(fontScale())) {
-        ClawDesignTheme {
-          renderedCanvasColor = ClawTheme.colors.canvas
-          // The default viewport models a portrait phone after its IME opens.
-          Box(
-            Modifier
-              .size(width = currentViewportWidth(), height = viewportHeight())
-              .background(ClawTheme.colors.canvas)
-              .clipToBounds()
-              .testTag("chat-viewport"),
-          ) {
-            if (useChatShell) {
-              UnifiedChatShellScreen(
-                viewModel = viewModel,
-                showSidebarButton = true,
-                onOpenSidebar = onOpenSidebar,
-                onOpenDashboard = {},
-                onOpenGatewaySettings = {},
-                onOpenProvidersModels = {},
-              )
-            } else {
-              ChatScreen(
-                viewModel = viewModel,
-                talkActive = talkActive,
-                showSidebarButton = true,
-                onOpenSidebar = onOpenSidebar,
-                onToggleTalk = {},
-                onOpenDashboard = {},
-                onOpenGatewaySettings = {},
-              )
+        CompositionLocalProvider(LocalLayoutDirection provides layoutDirection()) {
+          ClawDesignTheme {
+            renderedCanvasColor = ClawTheme.colors.canvas
+            renderedDensity = LocalDensity.current
+            Box(if (displayFeatures != null) Modifier.fillMaxSize() else Modifier, contentAlignment = AbsoluteAlignment.TopLeft) {
+              // The default viewport models a portrait phone after its IME opens.
+              Box(
+                Modifier
+                  .absoluteOffset { viewportOffset() }
+                  .size(width = currentViewportWidth(), height = viewportHeight())
+                  .background(ClawTheme.colors.canvas)
+                  .clipToBounds()
+                  .testTag("chat-viewport"),
+              ) {
+                if (useChatShell) {
+                  val features = displayFeatures?.invoke().orEmpty()
+                  val shell: @Composable (TabletopPaneBounds?) -> Unit = { panes ->
+                    UnifiedChatShellScreen(
+                      viewModel = viewModel,
+                      showSidebarButton = true,
+                      onOpenSidebar = onOpenSidebar,
+                      onOpenDashboard = {},
+                      onOpenGatewaySettings = {},
+                      onOpenProvidersModels = {},
+                      tabletopPanes = panes,
+                      features = features,
+                    )
+                  }
+                  if (displayFeatures != null) {
+                    FoldAwareContent(features = features, tabletopEnabled = true) { shell(it.tabletop) }
+                  } else {
+                    shell(null)
+                  }
+                } else {
+                  ChatScreen(
+                    viewModel = viewModel,
+                    talkActive = talkActive,
+                    showSidebarButton = true,
+                    onOpenSidebar = onOpenSidebar,
+                    onToggleTalk = {},
+                    onOpenDashboard = {},
+                    onOpenGatewaySettings = {},
+                  )
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/140708

## What Problem This Solves

Chat currently puts both the conversation and composer on one side of a horizontal fold, leaving the other plane unused. Opening the keyboard further constrains that shared space.

## Why This Change Was Made

Use a certified pair of horizontal fold panes: conversation header, transcript, and status above; the existing composer below. The same reader, editor, disclosure, and capture-state owners survive layout changes. Both panes must fit their actual text and controls; insufficient space uses the existing safe-region fallback.

The containing drawer remains in a safe region. Row gestures that started before its viewport moved cannot reorder or pin an item after relocation. Remaining separate-window menus and sheets are tracked separately.

## User Impact

- Read on the upper plane and compose on the lower plane in tabletop posture.
- Keep the draft, cursor, and reading state when folding, rotating, or opening the keyboard.
- Use larger text without clipping the complete input line or losing the action row.
- Return to the split when both planes have enough usable space again.

## Evidence

- 132 focused and sibling tests passed, including real RootScreen placement, pixel-boundary fit, larger text, native inset delivery, composing range, Details/Jump behavior, and stale drawer gestures. Original lower-plane and stale-action failures were reproduced before repair.
- Ordinary Android lint, actual changed-file checks, and independent P2 review passed. README sanity and `git diff --check` passed; the repository formatter excludes `apps/`.
- Genuine debug APK built from `82bea9481e839e50a84a4e0cd2326291558d2265`, with signature and installed hash verified. The final follow-up commit changes only README text.
- API 36 fold emulator: tabletop, flat, book, and cover-screen transitions retained the draft. Real Gboard triggered the safe fallback; dismissing it restored the split. Input continued without retapping the editor. Manual reading remained off-tail across rotation, and the modal drawer stayed in the upper safe plane.
- Synthetic Chat fixture only. No live Gateway, send/abort, camera, active recording, or physical-device certification. JVM gesture and owner checks are not presented as native active-capture proof.

Before: conversation and composer share the upper plane.

![Before: Chat and its composer share the upper plane](https://github.com/user-attachments/assets/3ad53c42-394a-405b-a42c-8483790f5c6d)

After: conversation above, retained draft and composer below.

![After: tabletop conversation and composer use separate planes](https://github.com/user-attachments/assets/7b64938a-f008-4bea-a1bb-f108c4384189)

Real Gboard: the lower plane is too short, so Chat uses the safe upper fallback.

![Keyboard-open fallback keeps the complete composer reachable](https://github.com/user-attachments/assets/8c6f20b8-52e5-42ad-bcc2-48694cebf961)
