### PR TITLE
fix: Windows worker sessions fail during repository preparation

### DIFF
--- a/src/gateway/github-repository-publication-restore.ts
+++ b/src/gateway/github-repository-publication-restore.ts
@@ -9,21 +9,21 @@ import type { WorkerWorkspaceManifest } from "./worker-environments/workspace-ma
 
 const RESTORE_PUBLICATION_INDEX_JS = String.raw`
 const fs = require("node:fs");
-const os = require("node:os");
+const gitNullPath = process.platform === "win32" ? "NUL" : "/dev/null";
 const { spawnSync } = require("node:child_process");
 const paths = JSON.parse(fs.readFileSync(0, "utf8"));
 const cwd = process.cwd();
 const env = { ...process.env };
 for (const key of Object.keys(env)) if (/^GIT_/i.test(key)) delete env[key];
-Object.assign(env, { GIT_CONFIG_GLOBAL: os.devNull, GIT_CONFIG_SYSTEM: os.devNull,
+Object.assign(env, { GIT_CONFIG_GLOBAL: gitNullPath, GIT_CONFIG_SYSTEM: gitNullPath,
   GIT_CONFIG_COUNT: "0", GIT_ATTR_NOSYSTEM: "1", GIT_NO_REPLACE_OBJECTS: "1" });
 ${GITHUB_PUBLICATION_CONFIG_GUARD_JS}
 const action = process.argv[1];
 if (action !== "add" && action !== "remove") throw Error("Invalid publication restore operation");
 const operation = action === "remove" ? ["update-index", "--force-remove", "-z", "--stdin"] :
   ["add", "--intent-to-add", "--force", "--pathspec-from-file=-", "--pathspec-file-nul"];
-const result = spawnSync("git", ["--literal-pathspecs", "-c", "core.hooksPath=" + os.devNull,
-  "-c", "core.fsmonitor=false", "-c", "core.attributesFile=" + os.devNull,
+const result = spawnSync("git", ["--literal-pathspecs", "-c", "core.hooksPath=" + gitNullPath,
+  "-c", "core.fsmonitor=false", "-c", "core.attributesFile=" + gitNullPath,
   ...operation], {
   env,
   input: paths.join("\0") + "\0", timeout: 60000, maxBuffer: 128 * 1024,

--- a/src/gateway/github-repository-publication-snapshot.test.ts
+++ b/src/gateway/github-repository-publication-snapshot.test.ts
@@ -1,7 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -16,10 +15,8 @@ import {
 import { readActualWorkspaceManifest } from "./worker-environments/workspace-reconcile-core.js";
 
 const temporary = useAutoCleanupTempDirTracker(afterEach);
-const env = {
+const baseEnv = {
   ...process.env,
-  GIT_CONFIG_GLOBAL: os.devNull,
-  GIT_CONFIG_SYSTEM: os.devNull,
   GIT_AUTHOR_NAME: "Snapshot Fixture",
   GIT_AUTHOR_EMAIL: "snapshot@example.test",
   GIT_COMMITTER_NAME: "Snapshot Fixture",
@@ -30,6 +27,9 @@ async function fixture(linked: false | "linked" | "linked-config" = false) {
   const root = temporary.make("github-repository-snapshot-");
   let cwd = path.join(root, "worker");
   await fs.mkdir(cwd);
+  const gitConfig = path.join(root, "empty.gitconfig");
+  await fs.writeFile(gitConfig, "");
+  const env = { ...baseEnv, GIT_CONFIG_GLOBAL: gitConfig, GIT_CONFIG_SYSTEM: gitConfig };
   const git = (...args: string[]) =>
     execFileSync("git", args, { cwd, env, encoding: "utf8" }).trim();
   git("init", "--quiet");
@@ -57,7 +57,7 @@ async function fixture(linked: false | "linked" | "linked-config" = false) {
       ["-e", REMOTE_GITHUB_PUBLICATION_SNAPSHOT_JS, cwd, base, output],
       { env, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
     ).trim();
-  return { cwd, root, git, base, output, capture };
+  return { cwd, root, git, base, output, capture, env };
 }
 
 describe("repository publication checkpoint capture", () => {
@@ -182,12 +182,12 @@ describe("repository publication checkpoint capture", () => {
           "-C",
           restored,
           "-c",
-          `core.hooksPath=${os.devNull}`,
+          `core.hooksPath=${path.join(f.root, "unused-hooks")}`,
           "-c",
           "core.fsmonitor=false",
           ...args,
         ],
-        { env, encoding: "utf8" },
+        { env: f.env, encoding: "utf8" },
       ).trim();
     const hooks = path.join(restored, ".git", "test-hooks");
     const sentinel = path.join(f.root, "unexpected-hook-or-filter");
@@ -214,7 +214,7 @@ describe("repository publication checkpoint capture", () => {
       for (const command of commands) {
         execFileSync(process.execPath, command.argv.slice(1), {
           cwd: restored,
-          env,
+          env: f.env,
           input: command.input,
           stdio: "pipe",
         });

--- a/src/gateway/github-repository-publication-snapshot.ts
+++ b/src/gateway/github-repository-publication-snapshot.ts
@@ -35,12 +35,13 @@ const maxFile = ${MAX_RECONCILIATION_FILE_BYTES};
 const maxTotal = ${MAX_RECONCILIATION_TOTAL_BYTES};
 const maxEntries = ${MAX_RECONCILIATION_ENTRIES};
 const objectPattern = /^[a-f0-9]{40}$/;
+const gitNullPath = process.platform === "win32" ? "NUL" : "/dev/null";
 const env = { ...process.env, GIT_NO_REPLACE_OBJECTS: "1", GIT_ATTR_NOSYSTEM: "1",
-  GIT_CONFIG_GLOBAL: os.devNull, GIT_CONFIG_SYSTEM: os.devNull,
+  GIT_CONFIG_GLOBAL: gitNullPath, GIT_CONFIG_SYSTEM: gitNullPath,
   GIT_CONFIG_COUNT: "0" };
 function git(args, options = {}) {
-  const result = spawnSync("git", ["-c", "core.hooksPath=" + os.devNull, "-c",
-    "core.fsmonitor=false", "-c", "core.attributesFile=" + os.devNull, ...args], {
+  const result = spawnSync("git", ["-c", "core.hooksPath=" + gitNullPath, "-c",
+    "core.fsmonitor=false", "-c", "core.attributesFile=" + gitNullPath, ...args], {
     cwd, env, timeout: 60000, maxBuffer: maxFile + 1, ...options,
   });
   if (result.error || result.status !== 0) throw Error("Publication snapshot Git command failed");

--- a/src/gateway/worker-environments/node-worker-repository-preparation.test.ts
+++ b/src/gateway/worker-environments/node-worker-repository-preparation.test.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, expect, it } from "vitest";
@@ -14,14 +13,16 @@ it("prepares and reuses an exact repository commit without a Gateway workspace",
   const root = await fs.realpath(tempDirs.make("node-repository-preparation-"));
   const origin = path.join(root, "origin");
   const home = path.join(root, "node-home");
+  const gitConfig = path.join(root, "empty.gitconfig");
   await fs.mkdir(origin);
+  await fs.writeFile(gitConfig, "");
   const git = async (cwd: string, ...args: string[]) => {
     const result = await runCommandWithTimeout(["git", "-C", cwd, ...args], {
       timeoutMs: 10_000,
       baseEnv: {
         PATH: process.env.PATH,
         HOME: root,
-        GIT_CONFIG_GLOBAL: os.devNull,
+        GIT_CONFIG_GLOBAL: gitConfig,
         GIT_CONFIG_NOSYSTEM: "1",
       },
     });

--- a/src/gateway/worker-environments/node-worker-repository-preparation.ts
+++ b/src/gateway/worker-environments/node-worker-repository-preparation.ts
@@ -28,7 +28,7 @@ const { spawnSync } = require("node:child_process");
 const { origin, token } = JSON.parse(fs.readFileSync(0, "utf8"));
 const env = { ...process.env };
 for (const key of Object.keys(env)) if (/^(GIT_|GH_TOKEN$|GITHUB_TOKEN$)/i.test(key)) delete env[key];
-Object.assign(env, { GIT_CONFIG_NOSYSTEM: "1", GIT_CONFIG_GLOBAL: require("node:os").devNull, GIT_TERMINAL_PROMPT: "0", GIT_ASKPASS: "", SSH_ASKPASS: "" });
+Object.assign(env, { GIT_CONFIG_NOSYSTEM: "1", GIT_CONFIG_GLOBAL: process.platform === "win32" ? "NUL" : "/dev/null", GIT_TERMINAL_PROMPT: "0", GIT_ASKPASS: "", SSH_ASKPASS: "" });
 if (token) Object.assign(env, { GIT_CONFIG_COUNT: "1", GIT_CONFIG_KEY_0: "http." + origin + ".extraheader", GIT_CONFIG_VALUE_0: "Authorization: Basic " + Buffer.from("x-access-token:" + token).toString("base64") });
 const result = spawnSync("git", process.argv.slice(1), { env, stdio: ["ignore", "inherit", "inherit"] });
 process.exitCode = result.status ?? 1;`;


### PR DESCRIPTION
Closes #140795

## What Problem This Solves

Fixes native Windows worker sessions failing with `Cloud repository preparation failed: clone-failed` even when Git, Node, and a public repository are available. The same invalid Git configuration path also affects remote workspace snapshot and restore operations.

## Why This Change Was Made

The generated scripts used Node's `os.devNull`, which is a namespaced Windows device path. Git for Windows rejects that path as a configuration file. Use the existing native workspace convention: `NUL` on Windows and `/dev/null` elsewhere, evaluated on the guest inside each generated script.

Keep all existing global/system Git config isolation, credential handling, hook and attribute settings, and publication guards. Test fixture setup uses an independent empty regular configuration file so Windows tests reach the production code instead of failing during fixture creation. Existing assertions, including offline seed reuse, remain intact.

## User Impact

Windows nodes can prepare Git-backed worker repositories and use the same remote snapshot/restore lifecycle. No new configuration, schema, dependency, protocol, permission, or API change. Other Gateway-host Git operations and POSIX-only project-image preparation remain outside this focused repair.

## Evidence

- Fresh AWS Windows desktop, Node 24.20.0, Git 2.52.0.windows.1: both public and private repository dispatches failed before an agent turn. `system.which` through the actual connected node confirmed Git and Node were available.
- Network-free Windows control: the same sanitized Git invocation exits 128 with `Invalid argument` for `os.devNull`; literal `NUL` and an empty regular configuration file each exit 0 with no output. No credentials, global configuration, or installed files were changed by the diagnostic.
- Eleven existing real-Git tests pass for repository preparation/reuse and publication snapshot/restore. Formatting passes. Independent review is clean through P2.
- Full changed gate passed, including production/test types, lint, formatting, dead-code and architecture checks. The full candidate build and canonical package validation also passed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34084189714) passed 107 jobs with 17 scope skips on `fdf25babb2cf260eec320edc6d704da653563675`. The complete AWS Windows worker/desktop retest passed on the same machine after normal Gateway and node package updates.
- Data-model compatibility: no persisted schema, version, parser, snapshot field, serialization shape, or recovery identifier changes. The diff changes only transient Git command environment/options and test fixture setup. POSIX Git settings still resolve to `/dev/null`; Windows now resolves to Git-compatible `NUL`. Existing snapshot capture/restore and offline seed-reuse tests pass without removing assertions. No migration applies; the generated-command file names do not themselves imply a persisted-format change.

Live outcome: the same public repository that failed before the fix cloned and checked out successfully; the worker became active in 51.41 seconds. Three real Computer calls succeeded, including text input. WebVNC typed a marker into Notepad and CUA observed it and appended its own text in the same window. The session archived with zero active claims and pending workspace results. All three synthetic sessions were archived; the Windows lease, instance, pairing, viewer and task keys were cleaned up. This is functional Windows proof, not a cold-start SLO, stress campaign, exact emoji-fidelity measurement, or complete Windows restart/recovery campaign.

No UI appearance changes. Release-note context remains in this PR rather than CHANGELOG.md.
