### PR TITLE
fix(anthropic): preserve tool cache when system prompts change

### DIFF
--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -91,6 +91,7 @@ agents:
 
 ### Anthropic (direct API and Vertex AI)
 
+- When caching is enabled and the route supports tool cache control, the tool prefix is checkpointed separately from the system prompt.
 - `cacheRetention` is supported for `anthropic` and `anthropic-vertex` providers, and for Claude models on `amazon-bedrock` and custom `anthropic-messages`-compatible endpoints when `cacheRetention` is set explicitly.
 - When unset, OpenClaw seeds `cacheRetention: "short"` for direct Anthropic (`anthropic` and `anthropic-vertex` providers only; other Anthropic-family routes require an explicit value).
 - Native Anthropic Messages responses expose `cache_read_input_tokens` and `cache_creation_input_tokens`, mapped to `cacheRead` and `cacheWrite`.

--- a/packages/ai/src/anthropic-cache-transport-parity.test.ts
+++ b/packages/ai/src/anthropic-cache-transport-parity.test.ts
@@ -1,0 +1,200 @@
+import type { Context, Model } from "@openclaw/llm-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { describe, expect, it, vi } from "vitest";
+import {
+  anthropicModel,
+  captureAnthropicRequest,
+  context,
+  registerParityHostLifecycle,
+} from "./provider-transport-parity.test-support.js";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./utils/system-prompt-cache-boundary.js";
+
+function markers(value: unknown, path = ""): Array<{ path: string; control: unknown }> {
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) => markers(item, `${path}[${index}]`));
+  }
+  if (!isRecord(value)) {
+    return [];
+  }
+  return Object.entries(value).flatMap(([key, item]) =>
+    key === "cache_control"
+      ? [{ path, control: item }]
+      : markers(item, path ? `${path}.${key}` : key),
+  );
+}
+
+function appendToolTurn(messages: Context["messages"], turn: number): Context["messages"] {
+  return [
+    ...messages,
+    {
+      role: "assistant",
+      api: anthropicModel.api,
+      provider: anthropicModel.provider,
+      model: anthropicModel.id,
+      timestamp: turn * 2,
+      stopReason: "toolUse",
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      content: [
+        { type: "toolCall", id: `call_${turn}`, name: "lookup", arguments: { query: "value" } },
+      ],
+    },
+    {
+      role: "toolResult",
+      toolCallId: `call_${turn}`,
+      toolName: "lookup",
+      timestamp: turn * 2 + 1,
+      content: [{ type: "text", text: `Result ${turn}` }],
+      isError: false,
+    },
+  ];
+}
+
+const routes: Array<{
+  name: string;
+  apiKey?: string;
+  model?: Partial<Model<"anthropic-messages">>;
+  toolCache: boolean;
+  longCache?: boolean;
+}> = [
+  { name: "direct API key", toolCache: true },
+  { name: "OAuth", apiKey: "sk-ant-oat01-synthetic", toolCache: true },
+  { name: "Foundry", model: { provider: "microsoft-foundry" }, toolCache: true },
+  { name: "proxy", model: { baseUrl: "https://proxy.example/v1" }, toolCache: true },
+  { name: "Fireworks", model: { provider: "fireworks" }, toolCache: false, longCache: false },
+  {
+    name: "incompatible proxy",
+    model: { baseUrl: "https://proxy.example/v1", compat: { supportsCacheControlOnTools: false } },
+    toolCache: false,
+  },
+];
+
+describe("Anthropic cache checkpoint transport parity", () => {
+  registerParityHostLifecycle();
+
+  it.each([
+    { name: "absent", systemPrompt: undefined },
+    { name: "empty", systemPrompt: "" },
+    { name: "only dynamic", systemPrompt: `${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic` },
+    { name: "empty boundary", systemPrompt: SYSTEM_PROMPT_CACHE_BOUNDARY },
+  ])(
+    "keeps the OAuth identity fallback checkpoint with $name system text",
+    async ({ systemPrompt }) => {
+      for (const implementation of ["provider", "transport"] as const) {
+        const { payload } = await captureAnthropicRequest(implementation, {
+          apiKey: "sk-ant-oat01-synthetic",
+          cacheRetention: "short",
+          context: { ...context, systemPrompt },
+        });
+        expect(
+          markers(payload)
+            .map((marker) => marker.path)
+            .toSorted(),
+        ).toEqual(["messages[0].content[0]", "system[1]", "tools[0]"]);
+        expect(payload.system).toEqual(
+          expect.arrayContaining([
+            {
+              type: "text",
+              text: "x-anthropic-billing-header: cc_version=2.1.75; cc_entrypoint=sdk-cli;",
+            },
+            {
+              type: "text",
+              text: "You are Claude Code, Anthropic's official CLI for Claude.",
+              cache_control: { type: "ephemeral" },
+            },
+          ]),
+        );
+      }
+    },
+  );
+
+  it.each([
+    { name: "direct", baseUrl: "https://api.anthropic.com", long: true },
+    { name: "default", baseUrl: undefined, long: true },
+    { name: "proxy", baseUrl: "https://proxy.example/v1", long: false },
+    {
+      name: "environment proxy",
+      baseUrl: undefined,
+      envBaseUrl: "https://proxy.example/v1",
+      long: false,
+    },
+  ])(
+    "keeps implicit long TTL host gating identical for $name",
+    async ({ baseUrl, envBaseUrl, long }) => {
+      vi.stubEnv("OPENCLAW_CACHE_RETENTION", "long");
+      vi.stubEnv("ANTHROPIC_BASE_URL", envBaseUrl);
+      for (const implementation of ["provider", "transport"] as const) {
+        const { payload } = await captureAnthropicRequest(implementation, { model: { baseUrl } });
+        const actual = markers(payload);
+        expect(actual).toHaveLength(3);
+        for (const marker of actual) {
+          expect(marker.control).toEqual({ type: "ephemeral", ...(long ? { ttl: "1h" } : {}) });
+        }
+      }
+    },
+  );
+
+  for (const route of routes) {
+    for (const withTools of [true, false]) {
+      it.each(["short", "long", "none"] as const)(
+        `${route.name}, tools=${withTools}, retention=%s: checkpoints stay within budget and advance`,
+        async (cacheRetention) => {
+          let messages: Context["messages"] = context.messages;
+          const previousTools = new Map<string, unknown>();
+          for (let turn = 0; turn < 3; turn++) {
+            if (turn > 0) {
+              messages = appendToolTurn(messages, turn);
+            }
+            const captured = [];
+            for (const implementation of ["provider", "transport"] as const) {
+              const { payload } = await captureAnthropicRequest(implementation, {
+                ...route,
+                cacheRetention,
+                context: {
+                  ...context,
+                  tools: withTools
+                    ? context.tools.flatMap((tool) => [tool, { ...tool, name: "read" }])
+                    : [],
+                  systemPrompt: `Stable instructions version ${turn === 2 ? 2 : 1}${SYSTEM_PROMPT_CACHE_BOUNDARY}Turn ${turn}`,
+                  messages,
+                },
+              });
+              const actual = markers(payload);
+              const expectedPaths =
+                cacheRetention === "none"
+                  ? []
+                  : [
+                      ...(withTools && route.toolCache ? ["tools[1]"] : []),
+                      `system[${route.apiKey ? 2 : 0}]`,
+                      "messages[0].content[0]",
+                      ...(turn > 0 ? [`messages[${turn * 2}].content[0]`] : []),
+                    ];
+              expect(actual.map((marker) => marker.path).toSorted()).toEqual(
+                expectedPaths.toSorted(),
+              );
+              expect(actual.length).toBeLessThanOrEqual(4);
+              for (const marker of actual) {
+                expect(marker.control).toEqual({
+                  type: "ephemeral",
+                  ...(cacheRetention === "long" && route.longCache !== false ? { ttl: "1h" } : {}),
+                });
+              }
+              if (turn > 0) {
+                expect(payload.tools).toEqual(previousTools.get(implementation));
+              }
+              previousTools.set(implementation, payload.tools);
+              captured.push({ markers: actual, system: payload.system });
+            }
+            expect(captured[1]).toEqual(captured[0]);
+          }
+        },
+      );
+    }
+  }
+});

--- a/packages/ai/src/provider-transport-parity.test-support.ts
+++ b/packages/ai/src/provider-transport-parity.test-support.ts
@@ -110,6 +110,7 @@ export async function captureAnthropicRequest(
     apiKey?: string;
     transportApi?: Model["api"];
     reasoning?: "low" | "off";
+    cacheRetention?: "short" | "long" | "none";
     events?: readonly Record<string, unknown>[];
     context?: Context;
     thinkingOverride?: { type: "disabled" } | { type: "enabled"; budget_tokens: number };
@@ -155,6 +156,7 @@ export async function captureAnthropicRequest(
   const streamOptions = {
     apiKey: options.apiKey ?? "sk-test",
     reasoning: options.reasoning ?? "low",
+    cacheRetention: options.cacheRetention,
     headers: options.headers,
     cacheTtlPruning: options.cacheTtlPruning,
     anthropicServerCompaction: options.anthropicServerCompaction,

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1,11 +1,9 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { Stream } from "@anthropic-ai/sdk/core/streaming.js";
 import type {
-  CacheControlEphemeral,
   MessageCreateParamsStreaming,
   MessageParam,
   RawMessageStreamEvent,
-  TextBlockParam,
 } from "@anthropic-ai/sdk/resources/messages.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { getAiTransportHost, resolveAiTransportHeaderSentinels } from "../host.js";
@@ -22,7 +20,9 @@ import {
   buildAnthropicGenerationParams,
 } from "../transports/anthropic-messages.js";
 import {
-  applyAnthropicCacheControlToMessages,
+  applyAnthropicRequestCacheControl,
+  buildAnthropicSystemBlocks,
+  resolveAnthropicCacheOptions,
   applyAnthropicContextManagementToRequest,
   isDirectAnthropicModel,
   resolveAnthropicContextManagementBetaHeader,
@@ -38,9 +38,7 @@ import {
 } from "../transports/transport-stream-shared.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transports/transport-utils.js";
 import type {
-  AnthropicMessagesCompat,
   AssistantMessageEvent,
-  CacheRetention,
   Context,
   Model,
   SimpleStreamOptions,
@@ -50,11 +48,6 @@ import { createDeferredEventBuffer } from "../utils/deferred-event-buffer.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseJsonWithRepair } from "../utils/json-parse.js";
 import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
-import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
-import {
-  splitSystemPromptCacheBoundary,
-  stripSystemPromptCacheBoundary,
-} from "../utils/system-prompt-cache-boundary.js";
 import {
   isAnthropicOAuthApiKey,
   omitFoundryBearerCredentialHeaders,
@@ -62,7 +55,6 @@ import {
 } from "./anthropic-auth-headers.js";
 import {
   applyClaudeRequestContract,
-  ANTHROPIC_CLAUDE_CODE_BILLING_SYSTEM_BLOCK,
   ANTHROPIC_CLAUDE_CODE_VERSION,
   prepareClaudeNoPrefillRequestContext,
   resolveAnthropicThinkingEffort,
@@ -91,27 +83,9 @@ import {
   clampMaxTokensToModel,
 } from "./simple-options.js";
 
-const ANTHROPIC_CACHE_CONTROL_LIMIT = 4;
-
 type AnthropicCompactionOptions = AnthropicOptions & {
   authProfileId?: string;
 };
-
-function getCacheControl(
-  model: Model<"anthropic-messages">,
-  cacheRetention?: CacheRetention,
-): { retention: CacheRetention; cacheControl?: CacheControlEphemeral } {
-  const retention = resolveCacheRetention(cacheRetention);
-  if (retention === "none") {
-    return { retention };
-  }
-  const ttl =
-    retention === "long" && getAnthropicCompat(model).supportsLongCacheRetention ? "1h" : undefined;
-  return {
-    retention,
-    cacheControl: { type: "ephemeral", ...(ttl && { ttl }) },
-  };
-}
 
 export type {
   AnthropicEffort,
@@ -123,17 +97,15 @@ const FINE_GRAINED_TOOL_STREAMING_BETA = "fine-grained-tool-streaming-2025-05-14
 const INTERLEAVED_THINKING_BETA = "interleaved-thinking-2025-05-14";
 const ANTHROPIC_MIN_THINKING_BUDGET_TOKENS = 1024;
 
-function getAnthropicCompat(model: Model<"anthropic-messages">): Required<AnthropicMessagesCompat> {
-  // Auto-detect session affinity and cache control support from provider
+function getAnthropicCompat(model: Model<"anthropic-messages">) {
+  // Auto-detect session affinity and tool streaming support from provider.
   const isFireworks = model.provider === "fireworks";
   const isCloudflareAiGatewayAnthropic =
     model.provider === "cloudflare-ai-gateway" && model.baseUrl.includes("anthropic");
   return {
     supportsEagerToolInputStreaming: model.compat?.supportsEagerToolInputStreaming ?? !isFireworks,
-    supportsLongCacheRetention: model.compat?.supportsLongCacheRetention ?? !isFireworks,
     sendSessionAffinityHeaders:
       model.compat?.sendSessionAffinityHeaders ?? (isFireworks || isCloudflareAiGatewayAnthropic),
-    supportsCacheControlOnTools: model.compat?.supportsCacheControlOnTools ?? !isFireworks,
     allowEmptySignature: model.compat?.allowEmptySignature ?? false,
   };
 }
@@ -637,7 +609,10 @@ async function buildParams(
 }> {
   const mandatoryAdaptiveThinking = requiresClaudeAdaptiveThinking(model);
   const replayThinkingEnabled = mandatoryAdaptiveThinking || options?.thinkingEnabled === true;
-  const { cacheControl } = getCacheControl(model, options?.cacheRetention);
+  const { cacheControl, supportsCacheControlOnTools } = resolveAnthropicCacheOptions(
+    model,
+    options?.cacheRetention,
+  );
   const system = buildAnthropicSystemBlocks(context.systemPrompt, isOAuthTokenResult, cacheControl);
   const compat = getAnthropicCompat(model);
   const convertedTools = context.tools
@@ -645,17 +620,10 @@ async function buildParams(
         context.tools,
         isOAuthTokenResult,
         compat.supportsEagerToolInputStreaming,
-        compat.supportsCacheControlOnTools ? cacheControl : undefined,
       )
     : undefined;
   const tools = convertedTools?.tools;
   const toolProjection = convertedTools?.projection;
-  const systemCacheControlCount = countNativeCacheControlMarkers(system);
-  const toolCacheControlCount = countNativeCacheControlMarkers(tools);
-  const messageCacheControlLimit = Math.max(
-    0,
-    ANTHROPIC_CACHE_CONTROL_LIMIT - systemCacheControlCount - toolCacheControlCount,
-  );
   const replayPlan = buildAnthropicReplayPlan(context.messages, model, {
     enabled: !isOAuthTokenResult && options?.anthropicServerCompaction === true,
     authProfileId: options?.authProfileId,
@@ -679,16 +647,6 @@ async function buildParams(
     stream: true,
   };
 
-  if (cacheControl) {
-    // Anthropic-family carriers are append-only, so they are stable cache anchors too.
-    applyAnthropicCacheControlToMessages(
-      params.messages,
-      cacheControl,
-      messageCacheControlLimit,
-      new Set(),
-    );
-  }
-
   if (system) {
     params.system = system;
   }
@@ -705,80 +663,9 @@ async function buildParams(
     buildAnthropicGenerationParams({ model, options, tools, toolProjection, profile: "provider" }),
   );
 
+  applyAnthropicRequestCacheControl(params, cacheControl, supportsCacheControlOnTools);
+
   return { params, toolProjection, usedCompactionReplay: replayPlan.compaction !== undefined };
-}
-
-function buildAnthropicSystemBlocks(
-  systemPrompt: string | undefined,
-  isOAuthTokenResult: boolean,
-  cacheControl: CacheControlEphemeral | undefined,
-): TextBlockParam[] | undefined {
-  const blocks: TextBlockParam[] = [];
-  if (isOAuthTokenResult) {
-    // Anthropic uses this first system block to route Claude subscription OAuth billing.
-    blocks.push({
-      type: "text",
-      text: ANTHROPIC_CLAUDE_CODE_BILLING_SYSTEM_BLOCK,
-    });
-    blocks.push({
-      type: "text",
-      text: "You are Claude Code, Anthropic's official CLI for Claude.",
-      ...(cacheControl ? { cache_control: cacheControl } : {}),
-    });
-  }
-  if (systemPrompt) {
-    blocks.push(...buildSystemPromptBlocks(systemPrompt, cacheControl));
-  }
-  return blocks.length > 0 ? blocks : undefined;
-}
-
-function buildSystemPromptBlocks(
-  systemPrompt: string,
-  cacheControl: CacheControlEphemeral | undefined,
-): TextBlockParam[] {
-  if (!cacheControl) {
-    return [
-      { type: "text", text: sanitizeSurrogates(stripSystemPromptCacheBoundary(systemPrompt)) },
-    ];
-  }
-
-  const split = splitSystemPromptCacheBoundary(systemPrompt);
-  if (!split) {
-    return [
-      {
-        type: "text",
-        text: sanitizeSurrogates(systemPrompt),
-        cache_control: cacheControl,
-      },
-    ];
-  }
-
-  const blocks: TextBlockParam[] = [];
-  if (split.stablePrefix) {
-    blocks.push({
-      type: "text",
-      text: sanitizeSurrogates(split.stablePrefix),
-      cache_control: cacheControl,
-    });
-  }
-  if (split.dynamicSuffix) {
-    blocks.push({ type: "text", text: sanitizeSurrogates(split.dynamicSuffix) });
-  }
-  return blocks.length > 0 ? blocks : [{ type: "text", text: "" }];
-}
-
-function countNativeCacheControlMarkers(blocks: unknown): number {
-  if (!Array.isArray(blocks)) {
-    return 0;
-  }
-
-  let count = 0;
-  for (const block of blocks) {
-    if (block && typeof block === "object" && "cache_control" in block) {
-      count += 1;
-    }
-  }
-  return count;
 }
 
 function shouldUseFineGrainedToolStreamingBeta(

--- a/packages/ai/src/transports/anthropic-messages.ts
+++ b/packages/ai/src/transports/anthropic-messages.ts
@@ -1,5 +1,4 @@
 import type {
-  CacheControlEphemeral,
   ContentBlockParam,
   MessageCreateParamsStreaming,
   Tool as AnthropicTool,
@@ -444,7 +443,6 @@ export function convertAnthropicTools(
   tools: Tool[],
   isOAuthTokenLocal: boolean,
   supportsEagerToolInputStreaming = false,
-  cacheControl?: CacheControlEphemeral,
 ): {
   projection: AnthropicToolProjection;
   tools: AnthropicTool[];
@@ -453,7 +451,7 @@ export function convertAnthropicTools(
     isOAuthTokenLocal ? toClaudeCodeToolName(name) : name,
   );
   const convertedTools: AnthropicTool[] = [];
-  for (const [index, tool] of projection.tools.entries()) {
+  for (const tool of projection.tools) {
     const convertedTool: AnthropicTool = {
       name: tool.wireName,
       description: tool.description,
@@ -461,9 +459,6 @@ export function convertAnthropicTools(
     };
     if (supportsEagerToolInputStreaming) {
       convertedTool.eager_input_streaming = true;
-    }
-    if (cacheControl && index === projection.tools.length - 1) {
-      convertedTool.cache_control = cacheControl;
     }
     convertedTools.push(convertedTool);
   }

--- a/packages/ai/src/transports/anthropic-payload-policy.ts
+++ b/packages/ai/src/transports/anthropic-payload-policy.ts
@@ -1,11 +1,14 @@
 import type { BetaContextManagementConfig } from "@anthropic-ai/sdk/resources/beta/messages/messages.js";
+import type { TextBlockParam } from "@anthropic-ai/sdk/resources/messages.js";
 import type { Model } from "@openclaw/llm-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { getAiTransportHost } from "../host.js";
 import type { AnthropicContextManagementOptions } from "../provider-options.js";
 import { isAnthropicOAuthApiKey } from "../providers/anthropic-auth-headers.js";
+import { ANTHROPIC_CLAUDE_CODE_BILLING_SYSTEM_BLOCK } from "../providers/anthropic-model-contract.js";
 import { resolveCacheRetention } from "../providers/cache-retention.js";
+import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
   splitSystemPromptCacheBoundary,
   stripSystemPromptCacheBoundary,
@@ -170,6 +173,84 @@ export function resolveAnthropicEphemeralCacheControl(
   return { type: "ephemeral", ...(ttl ? { ttl } : {}) };
 }
 
+/** Resolve the same cache capabilities and TTL for both Messages entry points. */
+export function resolveAnthropicCacheOptions(
+  model: Model<"anthropic-messages">,
+  cacheRetention?: "short" | "long" | "none",
+) {
+  const supportsLongCacheRetention =
+    model.compat?.supportsLongCacheRetention ?? model.provider !== "fireworks";
+  const baseUrl =
+    model.baseUrl?.trim() || process.env.ANTHROPIC_BASE_URL?.trim() || "https://api.anthropic.com";
+  const cacheControl = resolveAnthropicEphemeralCacheControl(baseUrl, cacheRetention);
+  return {
+    cacheControl:
+      cacheControl && !supportsLongCacheRetention ? { type: "ephemeral" as const } : cacheControl,
+    supportsCacheControlOnTools:
+      model.compat?.supportsCacheControlOnTools ?? model.provider !== "fireworks",
+  };
+}
+
+export function buildAnthropicSystemBlocks(
+  systemPrompt: string | undefined,
+  isOAuthToken: boolean,
+  cacheControl: AnthropicEphemeralCacheControl | undefined,
+): TextBlockParam[] | undefined {
+  const blocks: TextBlockParam[] = systemPrompt
+    ? [{ type: "text", text: sanitizeSurrogates(systemPrompt) }]
+    : [];
+  if (cacheControl) {
+    applyAnthropicCacheControlToSystem(blocks, cacheControl);
+  } else {
+    stripAnthropicSystemPromptBoundary(blocks);
+  }
+  if (systemPrompt && blocks.length === 0) {
+    blocks.push({ type: "text", text: "" });
+  }
+  if (isOAuthToken) {
+    // The stable application prompt covers the OAuth preamble too; keep slots for history.
+    const identityCacheControl = blocks.some((block) => block.cache_control)
+      ? undefined
+      : cacheControl;
+    blocks.unshift(
+      { type: "text", text: ANTHROPIC_CLAUDE_CODE_BILLING_SYSTEM_BLOCK },
+      {
+        type: "text",
+        text: "You are Claude Code, Anthropic's official CLI for Claude.",
+        ...(identityCacheControl ? { cache_control: identityCacheControl } : {}),
+      },
+    );
+  }
+  return blocks.length > 0 ? blocks : undefined;
+}
+
+/** Allocate tool and history checkpoints around the prepared stable system blocks. */
+export function applyAnthropicRequestCacheControl(
+  payload: { system?: unknown; tools?: unknown; messages?: unknown },
+  cacheControl: AnthropicEphemeralCacheControl | undefined,
+  supportsCacheControlOnTools: boolean,
+  cacheBreakpointOptOutMessageIndexes: ReadonlySet<number> = new Set(),
+): void {
+  if (!cacheControl) {
+    return;
+  }
+  if (supportsCacheControlOnTools && Array.isArray(payload.tools)) {
+    const lastTool = payload.tools.at(-1);
+    if (isRecord(lastTool)) {
+      lastTool.cache_control = cacheControl;
+    }
+  }
+  const usedMarkers =
+    countAnthropicCacheControlMarkers(payload.system) +
+    countAnthropicCacheControlMarkers(payload.tools);
+  applyAnthropicCacheControlToMessages(
+    payload.messages,
+    cacheControl,
+    ANTHROPIC_CACHE_CONTROL_LIMIT - usedMarkers,
+    cacheBreakpointOptOutMessageIndexes,
+  );
+}
+
 function applyAnthropicCacheControlToSystem(
   system: unknown,
   cacheControl: AnthropicEphemeralCacheControl,
@@ -234,7 +315,7 @@ function stripAnthropicSystemPromptBoundary(system: unknown): void {
 }
 
 /** Apply one shared deepest-stable-message cache breakpoint policy. */
-export function applyAnthropicCacheControlToMessages(
+function applyAnthropicCacheControlToMessages(
   messages: unknown,
   cacheControl: AnthropicEphemeralCacheControl,
   markerLimit: number,
@@ -564,17 +645,10 @@ export function applyAnthropicPayloadPolicyToParams(
 
   applyAnthropicContextManagementEdits(payloadObj, policy);
 
-  if (!policy.cacheControl) {
-    return;
-  }
-
-  const usedMarkers =
-    countAnthropicCacheControlMarkers(payloadObj.system) +
-    countAnthropicCacheControlMarkers(payloadObj.tools);
-  applyAnthropicCacheControlToMessages(
-    payloadObj.messages,
+  applyAnthropicRequestCacheControl(
+    payloadObj,
     policy.cacheControl,
-    ANTHROPIC_CACHE_CONTROL_LIMIT - usedMarkers,
+    false,
     cacheBreakpointOptOutMessageIndexes,
   );
 }

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -22,7 +22,6 @@ import {
 } from "../providers/anthropic-auth-headers.js";
 import {
   applyClaudeRequestContract,
-  ANTHROPIC_CLAUDE_CODE_BILLING_SYSTEM_BLOCK,
   ANTHROPIC_CLAUDE_CODE_VERSION,
   defaultsClaudeAdaptiveThinking,
   prepareClaudeNoPrefillRequestContext,
@@ -56,11 +55,12 @@ import {
   buildAnthropicGenerationParams,
 } from "./anthropic-messages.js";
 import {
-  applyAnthropicPayloadPolicyToParams,
+  applyAnthropicRequestCacheControl,
+  buildAnthropicSystemBlocks,
   applyAnthropicContextManagementToRequest,
   isDirectAnthropicModel,
   resolveAnthropicContextManagementBetaHeader,
-  resolveAnthropicPayloadPolicy,
+  resolveAnthropicCacheOptions,
 } from "./anthropic-payload-policy.js";
 import { consumeAnthropicStream, type AnthropicStreamBlock } from "./anthropic-stream-reducer.js";
 import { createAssistantOutput } from "./assistant-output.js";
@@ -77,7 +77,6 @@ import {
   finalizeTransportStream,
   mergeTransportHeaders,
   notifyProviderHttpResponse,
-  sanitizeTransportPayloadText,
 } from "./transport-stream-shared.js";
 import {
   createAbortError as createNamedAbortError,
@@ -569,15 +568,9 @@ async function buildAnthropicParams(
       `Anthropic Messages transport requires a positive maxTokens value for ${model.provider}/${model.id}`,
     );
   }
-  const payloadPolicy = resolveAnthropicPayloadPolicy(
-    {
-      provider: model.provider,
-      api: model.api,
-      baseUrl: model.baseUrl,
-      cacheRetention: options?.cacheRetention,
-      enableCacheControl: true,
-    },
+  const { cacheControl, supportsCacheControlOnTools } = resolveAnthropicCacheOptions(
     model,
+    options?.cacheRetention,
   );
   const replayPlan = buildAnthropicReplayPlan(context.messages, model, {
     enabled: !isOAuthToken && options?.anthropicServerCompaction === true,
@@ -607,33 +600,9 @@ async function buildAnthropicParams(
   if (!isOAuthToken && useAnthropicServerSideFallback(model)) {
     params.fallbacks = ANTHROPIC_SERVER_SIDE_FALLBACKS;
   }
-  if (isOAuthToken) {
-    params.system = [
-      // Anthropic requires this first block to route Claude subscription OAuth billing.
-      {
-        type: "text",
-        text: ANTHROPIC_CLAUDE_CODE_BILLING_SYSTEM_BLOCK,
-      },
-      {
-        type: "text",
-        text: "You are Claude Code, Anthropic's official CLI for Claude.",
-      },
-      ...(context.systemPrompt
-        ? [
-            {
-              type: "text",
-              text: sanitizeTransportPayloadText(context.systemPrompt),
-            },
-          ]
-        : []),
-    ];
-  } else if (context.systemPrompt) {
-    params.system = [
-      {
-        type: "text",
-        text: sanitizeTransportPayloadText(context.systemPrompt),
-      },
-    ];
+  const system = buildAnthropicSystemBlocks(context.systemPrompt, isOAuthToken, cacheControl);
+  if (system) {
+    params.system = system;
   }
   const convertedTools = context.tools
     ? convertAnthropicTools(context.tools, isOAuthToken)
@@ -650,7 +619,7 @@ async function buildAnthropicParams(
     }),
   );
   // Anthropic-family carriers are append-only, so they are stable cache anchors too.
-  applyAnthropicPayloadPolicyToParams(params, payloadPolicy, new Set());
+  applyAnthropicRequestCacheControl(params, cacheControl, supportsCacheControlOnTools);
   return { params, toolProjection, usedCompactionReplay: replayPlan.compaction !== undefined };
 }
 

--- a/packages/ai/test/fixtures/provider-transport-parity/anthropic-success.snap.txt
+++ b/packages/ai/test/fixtures/provider-transport-parity/anthropic-success.snap.txt
@@ -176,6 +176,9 @@
             "required": [
               "query"
             ]
+          },
+          "cache_control": {
+            "type": "ephemeral"
           }
         }
       ],


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can update this repository branch.

</details>

## What Problem This Solves

Fixes an issue where users running managed Anthropic Messages requests would lose reuse of unchanged tool definitions when their system prompt changed, such as after a workspace edit or skills refresh. OAuth requests also spent a cache checkpoint on the billing preamble, leaving less room to cache conversation history.

## Why This Change Was Made

Both Messages builders now share system shaping, cache capability and TTL resolution, and checkpoint allocation. Supported routes checkpoint the last projected tool separately from the stable system prompt, then use the remaining slots for the latest user and tool-result anchors, within Anthropic's four-marker limit. OAuth billing and identity text is preserved; the identity checkpoint is retained only when there is no stable application-system checkpoint.

The existing Fireworks defaults and explicit compatibility overrides gate tool markers and long TTLs. Implicit long retention follows the documented endpoint-host restriction in both paths. The generic plugin-SDK payload-policy helper retains its existing behavior. Production code is reduced by 75 lines.

## User Impact

Stable tool definitions remain independently cacheable when the system prompt changes. OAuth tool loops retain both conversation anchors without marking the billing block. No configuration, storage, dependency, or changelog changes are introduced.

## Evidence

- Before the fix, the new HTTP-payload parity matrix failed 12 of 36 cases for missing tool checkpoints, OAuth allocation, and managed Fireworks TTL handling.
- After the fix: 13 Anthropic package test files passed, 375 tests passed, including 44 payload-parity cases covering API keys, OAuth, Foundry, proxies, incompatible tool caching, tools/no tools, short/long/none retention, tool-loop advancement, stable-system edits, empty-system fallback, and implicit TTL host gating.
- Command: `node scripts/run-vitest.mjs` with the Anthropic provider, transport, policy, replay, usage, inline-image, and parity test paths.
- The Anthropic section of `docs/reference/prompt-caching.md` now documents the independent tool-prefix checkpoint.
- Proof uses synthetic HTTP capture and existing loopback tests; no live provider cache-hit or billing measurements were taken.
- Legacy exported policy: `node scripts/run-vitest.mjs src/agents/anthropic-payload-policy.test.ts` — 1 file passed, 17 tests passed. Together with the shared snapshot suite below, total focused proof is 15 files and 407 passing tests.
- Final Codex autoreview: `scoped-clean`; zero accepted/actionable P0/P1 findings; overall verdict: patch is correct. No findings required disposition.

Focused output summaries:

```text
Test Files  13 passed (13)
     Tests  375 passed (375)

Test Files  1 passed (1)
     Tests  17 passed (17)

Final policy/parity rerun after lint and export cleanup:
Test Files  2 passed (2)
     Tests  58 passed (58)
```

`node scripts/check-changed.mjs` completed successfully (exit 0), including production/test typechecking, lint, dead-export scans, and the final architecture guards. All three dead-export scans reported zero entries; runtime import-cycle checking reported zero cycles.

Validation follow-through: strict test-array typing and three test `sort()` calls were corrected, and the newly unused message-helper export was made module-private. One later gate run hit the existing managed-process cleanup error `EPROCESSGROUP_CLEANUP_FAILED` without a TypeScript diagnostic; the process group was verified terminated, the diagnostic typecheck passed, and the complete gate then passed without weakening guards or changing timeouts.

Final autoreview output:

```text
autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority
overall: patch is correct
```


CI follow-up: the first exact-head run failed only `checks-node-compact-small-7` (and its aggregate gate) because the shared transport snapshot lacked the intended tool checkpoint. Vitest regenerated exactly three lines in `anthropic-success.snap.txt`, adding the last tool's ephemeral `cache_control`; no assertion was weakened.

`node scripts/run-vitest.mjs packages/ai/src/provider-transport-parity.test.ts --update` regenerated the snapshot, then the same command without `--update` passed:

```text
Test Files  1 passed (1)
     Tests  15 passed (15)
```

The follow-up `node scripts/check-changed.mjs` passed (exit 0), including full core lint. Fresh Codex autoreview remains scoped-clean with zero accepted/actionable P0/P1 findings.


Final CI: [run 34085820808](https://github.com/openclaw/openclaw/actions/runs/34085820808) completed successfully on `f1479f54cdff533478b82028e9c7ba949949c98e`: 77 successful jobs, 16 intentionally skipped jobs, zero failed or pending jobs. The exact-head watcher returned `GREEN` (exit 0), including the corrected snapshot shard and `openclaw/ci-gate`.
