### PR TITLE
fix(slack): deliver valid sections above fallback chunk limits

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1705,6 +1705,8 @@ In a channel with `requireMention: true`, a captionless audio clip can satisfy t
     - long file captions use the first Slack-safe text chunk as the upload comment and send remaining chunks as follow-up messages
     - outbound media cap follows `channels.slack.mediaMaxMb` when configured; otherwise channel sends use MIME-kind defaults from media pipeline
 
+    Native Block Kit sections retain all fields even when their combined accessibility text exceeds the preferred text chunk size. Slack's block limits and the 40,000-character message text hard limit still apply.
+
   </Accordion>
 
   <Accordion title="Delivery targets">

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -598,6 +598,29 @@ describe("deliverSlackSlashReplies chunking", () => {
     });
   });
 
+  it("delivers a valid field-rich section in one slash response", async () => {
+    const respond = vi.fn(async () => undefined);
+    const fields = ["Alpha", "Beta", "Gamma"].map((label) => ({
+      type: "plain_text",
+      text: label.padEnd(1_500, "."),
+    }));
+    const blocks = [{ type: "section", fields }];
+
+    await deliverSlackSlashReplies({
+      replies: [{ channelData: { slack: { blocks } } }],
+      respond,
+      ephemeral: true,
+      textLimit: 8000,
+    });
+
+    expect(respond).toHaveBeenCalledExactlyOnceWith({
+      blocks,
+      text: fields.map((field) => field.text).join("\n"),
+      mrkdwn: false,
+      response_type: "ephemeral",
+    });
+  });
+
   it("splits non-native blocks before slash accessibility text exceeds 40k", async () => {
     const respond = vi.fn(async () => undefined);
     const blocks = Array.from({ length: 20 }, (_entry, index) => ({

--- a/extensions/slack/src/native-data-fallback.ts
+++ b/extensions/slack/src/native-data-fallback.ts
@@ -1,6 +1,5 @@
 import type { Block, KnownBlock } from "@slack/web-api";
 import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { renderSlackBlockFallbackText } from "./blocks-fallback.js";
 import { SLACK_MAX_BLOCKS } from "./blocks-input.js";
 import { SLACK_MESSAGE_TEXT_HARD_LIMIT, SLACK_MESSAGE_TEXT_RECOMMENDED_LIMIT } from "./limits.js";
@@ -43,13 +42,6 @@ export function chunkSlackTextAtHardLimit(
   }
   const effectiveLimit = Math.max(1, Math.floor(limit));
   return chunkTextForOutbound(text, effectiveLimit, { preserveWhitespace: true });
-}
-
-function fitsSlackTextLimit(text: string, limit: number): boolean {
-  if (text.length <= limit) {
-    return true;
-  }
-  return truncateUtf16Safe(text, limit).length === text.length;
 }
 
 function buildPlainTextBlocks(text: string, textLimit: number): OrderedFallbackBlock[] {
@@ -122,13 +114,15 @@ function buildOrderedBlockMessages(entries: readonly OrderedFallbackBlock[], tex
   for (const entry of entries) {
     const separator = text && entry.text && !entry.continuesText ? "\n\n" : "";
     const nextText = entry.text ? `${text}${separator}${entry.text}` : text;
-    if (blocks.length >= SLACK_MAX_BLOCKS || !fitsSlackTextLimit(nextText, textLimit)) {
+    if (blocks.length >= SLACK_MAX_BLOCKS || nextText.length > textLimit) {
       flush();
     }
     const freshSeparator = text && entry.text && !entry.continuesText ? "\n\n" : "";
     const freshText = entry.text ? `${text}${freshSeparator}${entry.text}` : text;
-    if (!fitsSlackTextLimit(freshText, textLimit)) {
-      throw new Error("One Slack fallback block exceeds the resolved message text limit.");
+    // A valid native section can have ten 2,000-character fields. Keep it intact
+    // even when its accessibility text exceeds the preferred batching limit.
+    if (freshText.length > SLACK_MESSAGE_TEXT_HARD_LIMIT) {
+      throw new Error("One Slack fallback block exceeds the message text hard limit.");
     }
     blocks.push(entry.block);
     text = freshText;

--- a/extensions/slack/src/outbound-delivery.test.ts
+++ b/extensions/slack/src/outbound-delivery.test.ts
@@ -126,6 +126,89 @@ describe("slack outbound shared hook wiring", () => {
     });
   });
 
+  it("delivers a valid field-rich section through the outbound adapter", async () => {
+    const client = createSlackSendTestClient();
+    sendMessageSlackMock.mockImplementation(
+      async (to: string, text: string, opts: Parameters<typeof sendMessageSlack>[2]) =>
+        await sendMessageSlack(to, text, { ...opts, client }),
+    );
+    const fields = ["Alpha", "Beta", "Gamma"].map((label) => ({
+      type: "plain_text",
+      text: label.padEnd(1_500, "."),
+    }));
+    const blocks = [{ type: "section", fields }];
+
+    const result = await sendDurableMessageBatch({
+      cfg,
+      channel: "slack",
+      to: "C123",
+      payloads: [{ channelData: { slack: { blocks } } }],
+      accountId: "default",
+    });
+
+    assert(result.status === "sent", "error" in result ? String(result.error) : result.status);
+    expect(client.chat.postMessage).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        blocks,
+        text: fields.map((field) => field.text).join("\n"),
+        mrkdwn: false,
+      }),
+    );
+    expect(result.results[0]?.receipt?.platformMessageIds).toEqual(["171234.567"]);
+  });
+
+  it("preserves a field-rich section and every receipt when native table delivery falls back", async () => {
+    const client = createSlackSendTestClient();
+    client.chat.postMessage
+      .mockRejectedValueOnce({ data: { error: "invalid_blocks" } })
+      .mockResolvedValueOnce({ ts: "171234.1" })
+      .mockResolvedValueOnce({ ts: "171234.2" });
+    sendMessageSlackMock.mockImplementation(
+      async (to: string, text: string, opts: Parameters<typeof sendMessageSlack>[2]) =>
+        await sendMessageSlack(to, text, { ...opts, client }),
+    );
+    const fields = ["Alpha", "Beta", "Gamma"].map((label) => ({
+      type: "plain_text",
+      text: label.padEnd(1_500, "."),
+    }));
+    const section = { type: "section", fields };
+    const footer = { type: "section", text: { type: "plain_text", text: "End of report" } };
+    const blocks = [
+      section,
+      {
+        type: "data_table",
+        caption: "Pipeline",
+        rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
+      },
+      footer,
+    ];
+
+    const result = await sendDurableMessageBatch({
+      cfg,
+      channel: "slack",
+      to: "C123",
+      payloads: [{ channelData: { slack: { blocks } } }],
+      accountId: "default",
+    });
+
+    assert(result.status === "sent", "error" in result ? String(result.error) : result.status);
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(3);
+    expect(client.chat.postMessage.mock.calls[1]?.[0]).toMatchObject({
+      blocks: [section],
+      text: fields.map((field) => field.text).join("\n"),
+      mrkdwn: false,
+    });
+    expect(client.chat.postMessage.mock.calls[2]?.[0]).toMatchObject({
+      blocks: [
+        { type: "section", text: { type: "plain_text", text: "Pipeline (table)\nAccount\nAcme" } },
+        footer,
+      ],
+      text: "Pipeline (table)\nAccount\nAcme\n\nEnd of report",
+      mrkdwn: false,
+    });
+    expect(result.results[0]?.receipt?.platformMessageIds).toEqual(["171234.1", "171234.2"]);
+  });
+
   it("fires message_sending once with shared routing fields", async () => {
     const hookRegistry = createEmptyPluginRegistry();
     const handler = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled for this repository-owned branch.

</details>

## What Problem This Solves

Fixes an issue where users receiving Slack Block Kit messages would get no message when a valid section's fields produced more than 4,000 characters of accessibility text. A section with three 1,500-character fields reproduces the failure in ordinary outbound delivery and slash responses, including native-table fallback beside the section.

## Why This Change Was Made

The fallback planner confused its preferred text batching size with a validity limit for an indivisible native block. Keep surviving blocks intact within the existing 40,000-character hard bound while retaining explicit fallback chunks and complete delivery receipts; remove the redundant truncation-based limit helper.

## User Impact

Valid sections retain all their fields and reach Slack instead of failing during local fallback planning. Rejected native tables still become complete fallback text, sibling blocks stay ordered, and edits retain their separate byte limit.

## Evidence

Three new regression cases failed on the original source at the fallback planner's limit check. After repair, 156 tests passed across six Slack suites covering outbound delivery, slash responses, native-data fallback, block sends, edits, and preview finalization. The final outbound file rerun passed all 11 tests after a test mock signature correction.

The delivery tests exercise the real durable outbound sender, Slack adapter, and Slack sender with synthetic API responses. Scoped test-graph typechecking, typed lint, formatting, Slack MDX validation, and independent P2 review passed. No live Slack request was made; current official [section-block limits](https://docs.slack.dev/reference/block-kit/blocks/section-block/) and [message text limits](https://docs.slack.dev/reference/methods/chat.postMessage/#truncating-content), plus installed Slack types, establish the field and hard-limit contracts. Exact-head CI remains required before landing.

Requalified against main `9d689fa1c21fc0dc9fc280cc6df95ae212c43f3d`: the Slack owner, callers, tests, and relevant shared contracts are unchanged from the tested base. The previously reviewed source bytes are preserved. Production changes: 5 lines added, 11 removed (net -6); tests: 106 added; docs: 2 added.
