### PR TITLE
refactor(e2e): share home path expansion

### DIFF
--- a/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
+++ b/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { readPositiveIntEnvWithEmptyFallback } from "../env-limits.mjs";
+import { resolveHomePath } from "../openclaw-state-paths.mjs";
 import { readPluginInstallRecords } from "../plugin-index-sqlite.mjs";
 import { isExplicitPluginDisableMarker } from "../plugin-uninstall-assertions.mjs";
 
@@ -27,16 +28,6 @@ const EXPECT_FAILURE_OUTPUT_MAX_BYTES = readPositiveIntEnvWithEmptyFallback(
 const readJson = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
 const scratchFile = (name) => path.join(scratchRoot, name);
 const normalizedPath = (filePath) => filePath.replaceAll("\\", "/");
-
-function resolveHomePath(value) {
-  if (value === "~") {
-    return process.env.HOME;
-  }
-  if (value?.startsWith("~/") || value?.startsWith("~\\")) {
-    return path.join(process.env.HOME, value.slice(2));
-  }
-  return value;
-}
 
 function readTextFileBounded(file, maxBytes, label) {
   const stats = fs.statSync(file);

--- a/scripts/e2e/lib/openclaw-state-paths.mjs
+++ b/scripts/e2e/lib/openclaw-state-paths.mjs
@@ -1,5 +1,15 @@
 import path from "node:path";
 
+export function resolveHomePath(value) {
+  if (value === "~") {
+    return process.env.HOME;
+  }
+  if (value?.startsWith("~/") || value?.startsWith("~\\")) {
+    return path.join(process.env.HOME, value.slice(2));
+  }
+  return value;
+}
+
 export function resolveOpenClawStateDir() {
   return process.env.OPENCLAW_STATE_DIR || path.join(process.env.HOME, ".openclaw");
 }

--- a/scripts/e2e/lib/plugins/assertions.mjs
+++ b/scripts/e2e/lib/plugins/assertions.mjs
@@ -8,6 +8,7 @@ import {
 } from "../../../lib/bounded-response.mjs";
 import { createTimeoutError } from "../../../lib/timeout-error.mjs";
 import { readPositiveIntEnv } from "../env-limits.mjs";
+import { resolveHomePath } from "../openclaw-state-paths.mjs";
 import {
   readPluginInstallIndex,
   readPluginInstallRecords,
@@ -51,16 +52,6 @@ async function withTimeout(label, timeoutMs, run) {
       clearTimeout(timeout);
     }
   }
-}
-
-function resolveHomePath(value) {
-  if (value === "~") {
-    return process.env.HOME;
-  }
-  if (value?.startsWith("~/") || value?.startsWith("~\\")) {
-    return path.join(process.env.HOME, value.slice(2));
-  }
-  return value;
 }
 
 function comparablePath(value) {


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested deduplication of E2E plugin-install assertions. The plugins and kitchen-sink assertion programs independently maintain the same home-relative path expansion, creating an avoidable drift point in their shared validation behavior.

## Why This Change Was Made

Move the identical `resolveHomePath` body into the existing internal `openclaw-state-paths.mjs` module and import it from both consumers. All seven calls remain unchanged. Both programs already load this module through their install-record reader.

Preserve bare tilde, both tilde separator spellings, host-native `path.join`, per-call `HOME` lookup, raw non-tilde values, and missing/empty `HOME` results and errors. State/config resolution, install records, realpath/containment checks, diagnostics, and release helpers are unchanged. No new module, package export, configuration, dependency, or SDK API.

## User Impact

No user-visible behavior change. E2E maintainers have one implementation of this shared path contract. Exactly three production files change, with a net reduction of eight lines; no test files change.

## Evidence

- Private before/after characterization: 48 input/environment cases compared against each original implementation, including changing `HOME` between calls. Return values and error type/code/message match.
- 86 focused tests passed through the repository wrapper across `openclaw-state-paths`, `plugins-assertions`, and `kitchen-sink-plugin-assertions`.
- Existing Docker test `mounts root helper modules imported by bare Docker E2E scripts` passed.
- All three `node --check` invocations, targeted formatting, `git diff --check`, and the complete selected `check:changed` gates passed locally.
- Fresh independent review found no actionable P0-P2 findings.
- Exact-head Linux Testbox passed the same 86 focused tests, Docker mount check, and syntax checks on Node 24.19.0 / pnpm 12.3.4. The source receiver and proof command verified the complete candidate tree. Lease `tbx_01m1x32ehw966e9ef29vhe4ct9` completed with exit 0 and is confirmed stopped: https://github.com/openclaw/openclaw/actions/runs/34084406957.
- Exact-head CI is green: 97 passed, 37 intentionally skipped, zero failed/pending. Head `a360926f4d70cd151e06a8299ced4540424aa69b`: https://github.com/openclaw/openclaw/actions/runs/34084403015.
- Completed exact-head ClawSweeper review found no actionable findings or before-merge items.
- Live source and the actual overlapping diffs were rechecked for https://github.com/openclaw/openclaw/pull/136761, https://github.com/openclaw/openclaw/pull/137663, and https://github.com/openclaw/openclaw/pull/120887. None changes home expansion or provides an equivalent extraction.

Backslash fixtures on macOS/Linux are not native Windows proof. No provider credentials or live Gateway are required for these synthetic boundaries.
