### PR TITLE
fix(anthropic): correct inflated Sonnet 5 cost estimates

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -453,8 +453,9 @@ publishes its 1,000,000-token context window, 128,000-token output limit, image
 input, and `$5/$25` input/output pricing.
 
 `anthropic/claude-sonnet-5` uses the same adaptive-thinking defaults and request
-restrictions. The catalog uses Anthropic's introductory `$2/$10` input/output
-pricing through August 31, 2026; standard `$3/$15` pricing begins September 1, 2026.
+restrictions. The catalog uses Anthropic's standard `$2/$10` input/output pricing
+per million tokens. Anthropic canceled the previously scheduled September 2026
+increase; see [current model pricing](https://platform.claude.com/docs/en/about-claude/pricing#model-pricing).
 
 `anthropic/claude-fable-5-1` and `anthropic/claude-fable-5` always use adaptive
 thinking and default to `high` effort. Anthropic does not allow thinking to be

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -691,6 +691,7 @@ describe("anthropic provider replay hooks", () => {
       modelId: "claude-sonnet-5",
       cost: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
       thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+      restoresMissingCost: true,
     },
   ];
 
@@ -704,9 +705,6 @@ describe("anthropic provider replay hooks", () => {
       restoresMissingCost,
       checksCliPolicy,
     }) => {
-      // This table describes the promotional contract before the September pricing cutover.
-      const clock = vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 7, 31));
-      onTestFinished(() => clock.mockRestore());
       const provider = await registerSingleProviderPlugin(anthropicPlugin);
       const resolved = provider.resolveDynamicModel?.({
         provider: "anthropic",
@@ -783,34 +781,13 @@ describe("anthropic provider replay hooks", () => {
     },
   );
 
-  it("normalizes a Sonnet 5 model without cost metadata instead of crashing", async () => {
-    const provider = await registerSingleProviderPlugin(anthropicPlugin);
-    const resolved = provider.resolveDynamicModel?.({
-      provider: "anthropic",
-      modelId: "claude-sonnet-5",
-      modelRegistry: createModelRegistry([]),
-    } as ProviderResolveDynamicModelContext);
-
-    const costlessModel = {
-      ...(resolved as ProviderRuntimeModel),
-      cost: undefined,
-    } as unknown as ProviderRuntimeModel;
-    const normalized = provider.normalizeResolvedModel?.({
-      provider: "anthropic",
-      modelId: "claude-sonnet-5",
-      model: costlessModel,
-    } as never);
-    // Compare against the resolver's own cost so the assertion survives the
-    // promotional -> standard pricing cutover.
-    expect(normalized?.cost).toEqual((resolved as ProviderRuntimeModel).cost);
-  });
-
   it.each([
     { modelId: "claude-sonnet-5", pricingSource: "configured" },
     { modelId: "claude-opus-5", pricingSource: "configured" },
     { modelId: "claude-fable-5", pricingSource: "configured" },
     { modelId: "claude-fable-5-1", pricingSource: "configured" },
     { modelId: "claude-fable-5-custom", pricingSource: "discovered" },
+    { modelId: "claude-opus-4-8", pricingSource: "discovered" },
   ])(
     "uses $pricingSource $modelId pricing for assistant usage",
     async ({ modelId, pricingSource }) => {
@@ -926,11 +903,13 @@ describe("anthropic provider replay hooks", () => {
     });
   });
 
-  it("rolls Claude Sonnet 5 to standard pricing on September 1, 2026", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(Date.UTC(2026, 8, 1));
-    try {
+  it.each(["2026-08-31T23:59:59Z", "2026-09-01T00:00:00Z", "2027-01-01T00:00:00Z"])(
+    "keeps published Sonnet 5 pricing on %s",
+    async (timestamp) => {
+      const clock = vi.spyOn(Date, "now").mockReturnValue(Date.parse(timestamp));
+      onTestFinished(() => clock.mockRestore());
       const provider = await registerSingleProviderPlugin(anthropicPlugin);
+      const expectedCost = { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 };
       const model = {
         id: "claude-sonnet-5",
         name: "Claude Sonnet 5",
@@ -938,31 +917,34 @@ describe("anthropic provider replay hooks", () => {
         api: "anthropic-messages",
         reasoning: true,
         input: ["text", "image"],
-        cost: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
+        cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
         contextWindow: 1_000_000,
         contextTokens: 1_000_000,
         maxTokens: 128_000,
         thinkingLevelMap: { xhigh: "xhigh", max: "max" },
       } as ProviderRuntimeModel;
 
-      expect(
-        provider.normalizeResolvedModel?.({
-          provider: "anthropic",
-          modelId: model.id,
-          model,
-        } as never)?.cost,
-      ).toEqual({ input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 });
+      for (const candidate of [
+        model,
+        { ...model, id: "deployment-sonnet", params: { canonicalModelId: model.id } },
+      ]) {
+        expect(
+          provider.normalizeResolvedModel?.({
+            provider: "anthropic",
+            modelId: candidate.id,
+            model: candidate,
+          } as never)?.cost,
+        ).toEqual(expectedCost);
+      }
       expect(
         provider.resolveDynamicModel?.({
           provider: "anthropic",
           modelId: "claude-sonnet-5-20260901",
           modelRegistry: createModelRegistry([]),
         } as ProviderResolveDynamicModelContext)?.cost,
-      ).toEqual({ input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 });
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+      ).toEqual(expectedCost);
+    },
+  );
 
   it("does not apply direct API pricing to Claude CLI Sonnet 5", async () => {
     const provider = await registerSingleProviderPlugin(anthropicPlugin);

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -88,20 +88,6 @@ const ANTHROPIC_OPUS_47_MODEL_ID = "claude-opus-4-7";
 const ANTHROPIC_OPUS_47_DOT_MODEL_ID = "claude-opus-4.7";
 const ANTHROPIC_1M_CONTEXT_TOKENS = 1_000_000;
 const ANTHROPIC_MODERN_MAX_OUTPUT_TOKENS = 128_000;
-// Anthropic's introductory rate expires at the documented UTC month boundary.
-const ANTHROPIC_SONNET_5_STANDARD_PRICING_START_MS = Date.UTC(2026, 8, 1);
-const ANTHROPIC_SONNET_5_PROMOTIONAL_COST = {
-  input: 2,
-  output: 10,
-  cacheRead: 0.2,
-  cacheWrite: 2.5,
-};
-const ANTHROPIC_SONNET_5_STANDARD_COST = {
-  input: 3,
-  output: 15,
-  cacheRead: 0.3,
-  cacheWrite: 3.75,
-};
 const ANTHROPIC_OPUS_46_MODEL_ID = "claude-opus-4-6";
 const ANTHROPIC_OPUS_46_DOT_MODEL_ID = "claude-opus-4.6";
 const ANTHROPIC_OPUS_47_TEMPLATE_MODEL_IDS = [
@@ -162,20 +148,12 @@ function restoreUnpublishedAnthropicModels(result: ProviderCatalogResult): Provi
   };
 }
 
-function resolveAnthropicSonnet5Cost(nowMs: number = Date.now()) {
-  return nowMs >= ANTHROPIC_SONNET_5_STANDARD_PRICING_START_MS
-    ? ANTHROPIC_SONNET_5_STANDARD_COST
-    : ANTHROPIC_SONNET_5_PROMOTIONAL_COST;
-}
-
 function resolveAnthropicModelCost(modelId: string) {
   // Snapshots share their dateless model's price; unlisted deployments retain
   // their discovered cost instead of inheriting a different version's pricing.
   const normalized = resolveClaudeModelIdentity({ id: modelId }).replace(/-\d{8}$/, "");
   const id = CLAUDE_MODEL_ID_ALIASES.get(normalized) ?? normalized;
-  return isAnthropicSonnet5Model(id)
-    ? resolveAnthropicSonnet5Cost()
-    : manifest.modelCatalog.providers.anthropic.models.find((model) => model.id === id)?.cost;
+  return manifest.modelCatalog.providers.anthropic.models.find((model) => model.id === id)?.cost;
 }
 
 const CLAUDE_CLI_CANONICAL_ALLOWLIST_REFS = CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS.map((ref) =>


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/132180

## What Problem This Solves

Fixes an issue where users running Claude Sonnet 5 through the direct Anthropic API would see inflated usage-cost estimates after September 1, 2026. OpenClaw applied a scheduled increase from $2/$10 to $3/$15 per million input/output tokens even though Anthropic canceled that increase.

## Why This Change Was Made

The Anthropic plugin manifest already contains the correct standard rates. Remove the obsolete date switch and duplicate price constants so Sonnet 5 uses the same manifest-backed pricing path as other listed models. Update the provider documentation and consolidate missing-cost coverage into the existing model-contract table.

Canonical deployment identities and dated model references retain their normalization. Explicit operator prices, unlisted discovered prices, and Claude CLI costs remain authoritative. No authentication, model selection, request shaping, configuration, or storage changes are introduced. Amazon Bedrock Mantle pricing is a separate split and is not inferred from Anthropic's direct tariff.

## User Impact

Newly resolved direct-API Sonnet 5 usage estimates use the published standard rates: input **$2**, output **$10**, cache reads **$0.20**, and five-minute cache writes **$2.50** per million tokens. This corrects OpenClaw's estimates, not Anthropic's actual billing, and does not rewrite historical usage records.

## Evidence

Anthropic's [current model pricing](https://platform.claude.com/docs/en/about-claude/pricing#model-pricing), fetched during this work, explicitly states:

> The $2/$10 per million input/output token pricing for Claude Sonnet 5, announced at launch as introductory pricing through August 31, 2026, is now the standard price. The previously scheduled increase to $3/$15 per million input/output tokens on September 1, 2026 will not occur.

The same page lists the cache rates above. The owning `extensions/anthropic/openclaw.plugin.json` already matches; no manifest price edit is needed. Current main and stable tag `v2026.9.2` both contain the obsolete runtime cutover.

- **Before:** tests-only main produced two intended post-boundary failures and one passing pre-boundary case; actual costs were 3/15/0.3/3.75 instead of 2/10/0.2/2.5.
- **After:** all **60 tests** in the Anthropic index suite pass. Coverage includes dates on both sides of the canceled boundary and in 2027, canonical deployment aliases, synthetic dated references, missing-cost restoration, explicit/discovered cost preservation, usage calculation, and Claude CLI exclusion.
- Changed formatting/type/lint/guard checks pass in **286 seconds**, with the candidate source unchanged.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34084891934) is green at `4a0d7c9698070ca206f85df618d9f803448d801a`. Native review artifacts and preparation passed without changing that head. A canceled zero-step ClawSweeper dispatch initially stopped the broad watcher; the actual CI run and required gate passed without a CI rerun.
- Fresh isolated Codex P0 review returned **scoped-clean** on tree `52ec16cc7ca08db84ef2a75bb2bcf5a31269a42e`. The public pricing contract was checked live; no billable model request or provider API behavior change is involved.

Reproduction:
```bash
node scripts/run-vitest.mjs extensions/anthropic/index.test.ts -t 'published Sonnet 5 pricing'
```

Post-fix proof:
```bash
node scripts/run-vitest.mjs extensions/anthropic/index.test.ts
```

Changed checks:
```bash
node scripts/check-changed.mjs -- extensions/anthropic/register.runtime.ts extensions/anthropic/index.test.ts docs/providers/anthropic.md
```

Production **+1/-23 (net -22)**; tests **+24/-42 (net -18)**; docs **+3/-2 (net +1)**. No new pricing helper, clock-dependent path, compatibility branch, or dependency is added. The original PR remains open for its other replacements.
