### PR TITLE
refactor(ui): share gateway set synchronization lifecycle

### DIFF
--- a/ui/src/lib/gateway-set-sync-lifecycle.ts
+++ b/ui/src/lib/gateway-set-sync-lifecycle.ts
@@ -1,0 +1,87 @@
+import type { ApplicationGateway } from "../app/gateway.ts";
+import { createGatewayRetryOwner } from "./gateway-retry.ts";
+
+/** Active consumers own registrations and fence queued work when their set detaches. */
+export function createGatewaySetSyncLifecycle(
+  gateway: ApplicationGateway,
+  options: {
+    sync: () => void;
+    onAttach: () => void;
+    onDetach: () => void;
+    onSnapshot?: Parameters<ApplicationGateway["subscribe"]>[0];
+    onEvent?: Parameters<ApplicationGateway["subscribeEvents"]>[0];
+  },
+) {
+  const retry = createGatewayRetryOwner();
+  let attached = false;
+  let scheduled = false;
+  let scheduleGeneration = 0;
+  let stopSnapshots: (() => void) | null = null;
+  let stopEvents: (() => void) | null = null;
+  let visibilityDocument: Document | null = null;
+
+  function sync() {
+    scheduled = false;
+    if (attached) {
+      options.sync();
+    }
+  }
+
+  function schedule() {
+    if (!attached || scheduled) {
+      return;
+    }
+    scheduled = true;
+    const generation = scheduleGeneration;
+    globalThis.queueMicrotask(() => {
+      if (generation === scheduleGeneration) {
+        sync();
+      }
+    });
+  }
+
+  const handleVisibilityChange = () => {
+    retry.reset();
+    schedule();
+  };
+
+  return {
+    get attached() {
+      return attached;
+    },
+    get retry() {
+      return retry;
+    },
+    sync,
+    schedule,
+    attach() {
+      if (attached) {
+        return;
+      }
+      attached = true;
+      options.onAttach();
+      stopSnapshots = gateway.subscribe(options.onSnapshot ?? schedule);
+      stopEvents = options.onEvent ? gateway.subscribeEvents(options.onEvent) : null;
+      if (typeof document !== "undefined") {
+        document.addEventListener("visibilitychange", handleVisibilityChange);
+        visibilityDocument = document;
+      }
+    },
+    detach() {
+      if (!attached) {
+        return;
+      }
+      attached = false;
+      stopSnapshots?.();
+      stopSnapshots = null;
+      stopEvents?.();
+      stopEvents = null;
+      visibilityDocument?.removeEventListener("visibilitychange", handleVisibilityChange);
+      visibilityDocument = null;
+      retry.reset();
+      scheduleGeneration += 1;
+      scheduled = false;
+      options.onDetach();
+    },
+  };
+}

--- a/ui/src/lib/session-pull-requests.ts
+++ b/ui/src/lib/session-pull-requests.ts
@@ -12,7 +12,7 @@ import {
 import type { ApplicationGateway } from "../app/gateway.ts";
 import { createGatewayConnectionLifecycle } from "./gateway-connection-lifecycle.ts";
 import { isGatewayMethodAdvertised } from "./gateway-methods.ts";
-import { createGatewayRetryOwner } from "./gateway-retry.ts";
+import { createGatewaySetSyncLifecycle } from "./gateway-set-sync-lifecycle.ts";
 import { readSessionChangedEvent } from "./sessions/reconcile.ts";
 import { uiSessionEventMatches } from "./sessions/session-key.ts";
 
@@ -85,17 +85,10 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
     Set<(snapshot: ControlUiSessionPullRequestSnapshot | undefined) => void>
   >();
   const pendingRefreshKeys = new Set<string>();
-  const retry = createGatewayRetryOwner();
   const connection = createGatewayConnectionLifecycle(gateway.snapshot);
   let lastHello: object | null = null;
   let lastSignature: string | null = null;
   let syncRequestGeneration = 0;
-  let syncScheduled = false;
-  let syncScheduleGeneration = 0;
-  let attached = false;
-  let stopGatewaySnapshots: (() => void) | null = null;
-  let stopGatewayEvents: (() => void) | null = null;
-  let visibilityDocument: Document | null = null;
 
   const notify = () => {
     for (const listener of Array.from(listeners)) {
@@ -172,7 +165,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
     }
     if (changed || snapshot.hello !== lastHello) {
       retry.reset();
-      scheduleSync();
+      lifecycle.schedule();
     }
   };
 
@@ -206,7 +199,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
       if (removed) {
         notify();
       }
-      scheduleSync();
+      lifecycle.schedule();
       return;
     }
     if (event.event !== CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT) {
@@ -242,56 +235,27 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
     notify();
   };
 
-  const handleVisibilityChange = () => {
-    retry.reset();
-    scheduleSync();
-  };
-
-  const attachExternalRegistrations = () => {
-    if (attached) {
-      return;
-    }
-    attached = true;
-    if (connection.transition(gateway.snapshot)) {
-      retireConnection();
-    }
-    lastHello = null;
-    lastSignature = null;
-    // Active consumers own these registrations: isolate:false workers share document, so an
-    // always-on visibility listener would root every per-gateway store and fake gateway.
-    stopGatewaySnapshots = gateway.subscribe(handleGatewaySnapshot);
-    stopGatewayEvents = gateway.subscribeEvents(handleGatewayEvent);
-    if (typeof document !== "undefined") {
-      document.addEventListener("visibilitychange", handleVisibilityChange);
-      visibilityDocument = document;
-    }
-  };
-
-  const detachExternalRegistrations = () => {
-    if (!attached) {
-      return;
-    }
-    attached = false;
-    stopGatewaySnapshots?.();
-    stopGatewaySnapshots = null;
-    stopGatewayEvents?.();
-    stopGatewayEvents = null;
-    visibilityDocument?.removeEventListener("visibilitychange", handleVisibilityChange);
-    visibilityDocument = null;
-    retry.reset();
-    syncRequestGeneration += 1;
-    syncScheduleGeneration += 1;
-    syncScheduled = false;
-    lastHello = null;
-    lastSignature = null;
-    snapshots.clear();
-  };
+  const lifecycle = createGatewaySetSyncLifecycle(gateway, {
+    sync,
+    onSnapshot: handleGatewaySnapshot,
+    onEvent: handleGatewayEvent,
+    onAttach: () => {
+      if (connection.transition(gateway.snapshot)) {
+        retireConnection();
+      }
+      lastHello = null;
+      lastSignature = null;
+    },
+    onDetach: () => {
+      syncRequestGeneration += 1;
+      lastHello = null;
+      lastSignature = null;
+      snapshots.clear();
+    },
+  });
+  const { retry } = lifecycle;
 
   function sync() {
-    syncScheduled = false;
-    if (!attached) {
-      return;
-    }
     const snapshot = gateway.snapshot;
     const client = snapshot.client;
     const available =
@@ -306,7 +270,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
         settle(key);
       }
       if (!isActive()) {
-        detachExternalRegistrations();
+        lifecycle.detach();
       }
       return;
     }
@@ -321,7 +285,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
       refreshSessionKeys.length === 0
     ) {
       if (!isActive()) {
-        detachExternalRegistrations();
+        lifecycle.detach();
       }
       return;
     }
@@ -329,7 +293,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
     lastSignature = signature;
     const requestGeneration = ++syncRequestGeneration;
     const isCurrentRequest = () =>
-      attached &&
+      lifecycle.attached &&
       isActive() &&
       requestGeneration === syncRequestGeneration &&
       snapshot.hello === lastHello &&
@@ -340,7 +304,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
       ...(refreshSessionKeys.length > 0 ? { refreshSessionKeys } : {}),
     });
     if (!isActive()) {
-      detachExternalRegistrations();
+      lifecycle.detach();
     }
     void request
       .then(() => {
@@ -355,8 +319,8 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
         if (isCurrentRequest()) {
           lastSignature = null;
           retry.schedule(() => {
-            if (attached && isActive()) {
-              scheduleSync();
+            if (lifecycle.attached && isActive()) {
+              lifecycle.schedule();
             }
           });
           for (const key of sessionKeys) {
@@ -364,19 +328,6 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
           }
         }
       });
-  }
-
-  function scheduleSync() {
-    if (!attached || syncScheduled) {
-      return;
-    }
-    syncScheduled = true;
-    const generation = syncScheduleGeneration;
-    globalThis.queueMicrotask(() => {
-      if (generation === syncScheduleGeneration) {
-        sync();
-      }
-    });
   }
 
   const watch = (
@@ -408,10 +359,10 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
         lastHello = null;
         lastSignature = null;
       }
-      attachExternalRegistrations();
-      scheduleSync();
-    } else if (attached) {
-      sync();
+      lifecycle.attach();
+      lifecycle.schedule();
+    } else if (lifecycle.attached) {
+      lifecycle.sync();
     }
   };
 
@@ -447,7 +398,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
           const pending = waiters.get(key) ?? new Set();
           pending.add(resolve);
           waiters.set(key, pending);
-          scheduleSync();
+          lifecycle.schedule();
         });
       } finally {
         const currentWatch = watchedByOwner.get(owner);
@@ -468,7 +419,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
       }
       pendingRefreshKeys.add(key);
       retry.reset();
-      scheduleSync();
+      lifecycle.schedule();
       return true;
     },
     get: (sessionKey) => snapshots.get(sessionKey),
@@ -479,13 +430,13 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
         lastHello = null;
         lastSignature = null;
       }
-      attachExternalRegistrations();
+      lifecycle.attach();
       return () => {
         if (listeners.delete(listener)) {
           if (isActive()) {
-            scheduleSync();
-          } else if (attached) {
-            sync();
+            lifecycle.schedule();
+          } else if (lifecycle.attached) {
+            lifecycle.sync();
           }
         }
       };

--- a/ui/src/lib/session-viewer-presence.ts
+++ b/ui/src/lib/session-viewer-presence.ts
@@ -1,7 +1,7 @@
 import { SESSION_VIEWER_PRESENCE_MAX_KEYS } from "../../../packages/gateway-protocol/src/schema/sessions-viewer-presence.js";
 import type { ApplicationGateway } from "../app/gateway.ts";
 import { isGatewayMethodAdvertised } from "./gateway-methods.ts";
-import { createGatewayRetryOwner } from "./gateway-retry.ts";
+import { createGatewaySetSyncLifecycle } from "./gateway-set-sync-lifecycle.ts";
 import { resolveSessionKey } from "./sessions/index.ts";
 
 const SESSION_VIEWERS_SET_METHOD = "sessions.viewers.set";
@@ -15,18 +15,12 @@ const stores = new WeakMap<ApplicationGateway, SessionViewerPresenceStore>();
 
 function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
   const watchedByOwner = new Map<object, Set<string>>();
-  const retry = createGatewayRetryOwner();
   let knownClient = gateway.snapshot.client;
   let lastHello: object | null = null;
   let lastSignature: string | null = null;
   let acknowledgedSignature: string | null = null;
   let acknowledgedGeneration = 0;
   let requestGeneration = 0;
-  let syncScheduled = false;
-  let scheduleGeneration = 0;
-  let attached = false;
-  let stopGatewaySnapshots: (() => void) | null = null;
-  let visibilityDocument: Document | null = null;
 
   const isActive = () => watchedByOwner.size > 0;
 
@@ -44,53 +38,26 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
     return [...keys].toSorted().slice(0, SESSION_VIEWER_PRESENCE_MAX_KEYS);
   };
 
-  const handleGatewaySnapshot = () => scheduleSync();
-  const handleVisibilityChange = () => {
-    retry.reset();
-    scheduleSync();
-  };
-
-  const attach = () => {
-    if (attached) {
-      return;
-    }
-    attached = true;
-    knownClient = gateway.snapshot.client;
-    lastHello = null;
-    lastSignature = null;
-    acknowledgedSignature = null;
-    acknowledgedGeneration = 0;
-    stopGatewaySnapshots = gateway.subscribe(handleGatewaySnapshot);
-    if (typeof document !== "undefined") {
-      document.addEventListener("visibilitychange", handleVisibilityChange);
-      visibilityDocument = document;
-    }
-  };
-
-  const detach = () => {
-    if (!attached) {
-      return;
-    }
-    attached = false;
-    stopGatewaySnapshots?.();
-    stopGatewaySnapshots = null;
-    visibilityDocument?.removeEventListener("visibilitychange", handleVisibilityChange);
-    visibilityDocument = null;
-    retry.reset();
-    requestGeneration += 1;
-    scheduleGeneration += 1;
-    syncScheduled = false;
-    lastHello = null;
-    lastSignature = null;
-    acknowledgedSignature = null;
-    acknowledgedGeneration = 0;
-  };
+  const lifecycle = createGatewaySetSyncLifecycle(gateway, {
+    sync,
+    onAttach: () => {
+      knownClient = gateway.snapshot.client;
+      lastHello = null;
+      lastSignature = null;
+      acknowledgedSignature = null;
+      acknowledgedGeneration = 0;
+    },
+    onDetach: () => {
+      requestGeneration += 1;
+      lastHello = null;
+      lastSignature = null;
+      acknowledgedSignature = null;
+      acknowledgedGeneration = 0;
+    },
+  });
+  const { retry } = lifecycle;
 
   function sync() {
-    syncScheduled = false;
-    if (!attached) {
-      return;
-    }
     const snapshot = gateway.snapshot;
     const client = snapshot.client;
     if (client !== knownClient) {
@@ -112,7 +79,7 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
       acknowledgedSignature = null;
       acknowledgedGeneration = 0;
       if (!isActive()) {
-        detach();
+        lifecycle.detach();
       }
       return;
     }
@@ -130,7 +97,7 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
         acknowledgedSignature === signature &&
         acknowledgedGeneration === requestGeneration
       ) {
-        detach();
+        lifecycle.detach();
       }
       return;
     }
@@ -138,7 +105,7 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
     lastSignature = signature;
     const currentGeneration = ++requestGeneration;
     const isCurrentRequest = () =>
-      attached &&
+      lifecycle.attached &&
       currentGeneration === requestGeneration &&
       snapshot.hello === lastHello &&
       signature === lastSignature;
@@ -154,7 +121,7 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
           acknowledgedGeneration = currentGeneration;
           retry.reset();
           if (!isActive()) {
-            detach();
+            lifecycle.detach();
           }
         }
       })
@@ -163,25 +130,8 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
           return;
         }
         lastSignature = null;
-        retry.schedule(() => {
-          if (attached) {
-            scheduleSync();
-          }
-        });
+        retry.schedule(lifecycle.schedule);
       });
-  }
-
-  function scheduleSync() {
-    if (!attached || syncScheduled) {
-      return;
-    }
-    syncScheduled = true;
-    const generation = scheduleGeneration;
-    globalThis.queueMicrotask(() => {
-      if (generation === scheduleGeneration) {
-        sync();
-      }
-    });
   }
 
   const watch = (owner: object, sessionKeys: readonly string[]) => {
@@ -201,10 +151,10 @@ function createStore(gateway: ApplicationGateway): SessionViewerPresenceStore {
     }
     retry.reset();
     if (isActive()) {
-      attach();
-      scheduleSync();
-    } else if (attached) {
-      sync();
+      lifecycle.attach();
+      lifecycle.schedule();
+    } else if (lifecycle.attached) {
+      lifecycle.sync();
     }
   };
 


### PR DESCRIPTION
## What Problem This Solves

Session pull-request tracking and viewer presence each implement the same visibility listener, Gateway registrations, retry ownership, and queued synchronization lifecycle. That duplicates the cleanup boundary responsible for releasing idle stores and retiring queued work.

## Why This Change Was Made

`lib/gateway-set-sync-lifecycle.ts`, beside the existing Gateway connection and retry helpers, owns those registrations and the immediate/coalesced synchronization schedule. It captures the Document used for registration and fences queued work across detach/reattach. The two stores retain their wire payloads, key projections, request generations, signatures, and release policies. Production delta: +153/-165, net -12; tests unchanged.

## User Impact

No intended user-visible change. Presence still retries a failed final clear and waits for its current acknowledgment before detaching. PR tracking still dispatches its final empty set and detaches immediately, never retrying while idle. Foreground key limits, alias/agent handling, refresh tokens, reconnect retirement, and degraded snapshot retention are preserved.

## Evidence

All 66 existing focused cases passed across the two stores, chat PR handling, and sidebar indicators. They cover final-clear acknowledgment/retry, idle PR release, stale requests, synchronous reconnect retirement, refresh supersession, foreground limits, and mounted consumer cleanup.

`pnpm ui:build` and `pnpm ui:check-performance` passed: startup JavaScript 346310 B gzip, 8 requests, no baseline edit. Independent Codex review was clean through P2. `node scripts/check-changed.mjs` passed after a frozen install corrected a stale local `@openclaw/fs-safe` 0.8.1 installation to main's locked 0.8.3. Its initial seven unrelated core type errors came from that mismatch. All 66 focused cases and UI build/performance passed again after installation; no dependency manifest or source workaround changed.

```sh
node scripts/run-vitest.mjs ui/src/lib/session-pull-requests.test.ts ui/src/lib/session-viewer-presence.test.ts ui/src/pages/chat/chat-pane-pull-requests.test.ts ui/src/components/app-sidebar-session-pr-indicators.test.ts
```

No test-only seams or helper-only tests were added; existing behavioral suites protect both policies. This is the owner-set lifecycle item in the maintainer-requested UI consolidation campaign; no protocol, configuration, public SDK, or persistent-state changes.

Rebased onto freshly fetched main `e3c0531a27bce27cb6feaa52892f66e7d39beb8d`; the complete patch compares byte-identically. Local proof applies to that unchanged patch. Current head: `3a45dd7f963db1216a05945adf30991c2d2bf015`. Hosted [CI run 34084832027](https://github.com/openclaw/openclaw/actions/runs/34084832027), native review validation, and native prepare passed for this exact head. ClawSweeper review has no actionable findings. Prepare used hosted-proof mode (`OPENCLAW_TESTBOX=1`); no separate Testbox lease was allocated.
