### PR TITLE
refactor(onboarding): share preset primary preservation

### DIFF
--- a/src/plugin-sdk/provider-onboard.ts
+++ b/src/plugin-sdk/provider-onboard.ts
@@ -60,8 +60,14 @@ function extractAgentDefaultModelFallbacks(model: unknown): string[] | undefined
   return Array.isArray(fallbacks) ? fallbacks.map((value) => String(value)) : undefined;
 }
 
-function hasAgentDefaultModelPrimary(cfg: OpenClawConfig): boolean {
-  return resolvePrimaryStringValue(cfg.agents?.defaults?.model) !== undefined;
+function completeProviderPreset(
+  cfg: OpenClawConfig,
+  next: OpenClawConfig,
+  primaryModelRef: string | undefined,
+): OpenClawConfig {
+  return primaryModelRef && resolvePrimaryStringValue(cfg.agents?.defaults?.model) === undefined
+    ? applyAgentDefaultModelPrimary(next, primaryModelRef)
+    : next;
 }
 
 function normalizeAgentModelAliasEntry(entry: AgentModelAliasEntry): {
@@ -555,11 +561,7 @@ export function applyProviderConfigWithDefaultModelsPreset(
     defaultModels: params.defaultModels,
     defaultModelId: params.defaultModelId,
   });
-  return params.primaryModelRef
-    ? hasAgentDefaultModelPrimary(cfg)
-      ? next
-      : applyAgentDefaultModelPrimary(next, params.primaryModelRef)
-    : next;
+  return completeProviderPreset(cfg, next, params.primaryModelRef);
 }
 
 /** Build setup appliers for presets that resolve to multiple default provider models. */
@@ -631,11 +633,7 @@ export function applyProviderConfigWithModelCatalogPreset(
     baseUrl: params.baseUrl,
     catalogModels: params.catalogModels,
   });
-  return params.primaryModelRef
-    ? hasAgentDefaultModelPrimary(cfg)
-      ? next
-      : applyAgentDefaultModelPrimary(next, params.primaryModelRef)
-    : next;
+  return completeProviderPreset(cfg, next, params.primaryModelRef);
 }
 
 /** Build setup appliers for presets that resolve to a provider model catalog. */


### PR DESCRIPTION
## What Problem This Solves

Provider onboarding presets independently repeated the rule that a suggested primary model must preserve an operator's existing primary selection. Single-model presets already delegate to the multi-model path, and alias registration already has a shared owner.

## Why This Change Was Made

A private completion helper in `provider-onboard.ts` now applies that remaining rule for both default-model and catalog presets. It checks the original config after each caller performs its existing merge. Default-set seeding and per-ID catalog merging retain their distinct policies.

## User Impact

No user-visible change. All public signatures, alias precedence, primary selection, fallbacks, and model merge ordering remain unchanged. Production delta: -2 lines; tests unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/plugin-sdk/provider-onboard.test.ts src/commands/onboard-auth.config-shared.test.ts`: 2 files / 26 tests passed.
- Independent Codex autoreview: no actionable P0–P2 findings.
- `pnpm build` and the complete `node scripts/check-changed.mjs` passed, including all 152 public SDK subpaths, on Blacksmith Testbox `tbx_01m1x3c9g65g9nwjnm3n007v78`: https://github.com/openclaw/openclaw/actions/runs/34084723214.
- Command: `node scripts/crabbox-wrapper.mjs run --timing-json -- bash -lc 'git hash-object src/plugin-sdk/provider-onboard.ts && pnpm build && OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs'`. Expected source blob: `9ca71f52322885f075cbdef82a694d8a166890e4`.
- Exact-head CI passed for `678496432c568c3e650d2912f2ae45040216c753`: https://github.com/openclaw/openclaw/actions/runs/34084881964. Native prepare completed without changing the head.
- Testbox command elapsed 24m44s, exit 0; lease stopped automatically. A portal-sync timeout was reported after the successful command and cleanup; the wrapper reports `runStatus: succeeded`.
- A clean Testbox supplies package/declaration proof because this nested local worktree previously hit the documented ancestor declaration-boundary error. No live-provider contract changes.
