### PR TITLE
fix(codex): send workspace reference files only when the thread needs them

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -1065,9 +1065,13 @@ Codex harness forwards the other bootstrap files as developer instructions:
   should use `memory_search` or `memory_get` when durable memory is relevant.
   If tools are disabled, memory search is unavailable, or the active
   workspace differs from the agent memory workspace, `MEMORY.md` uses the
-  normal bounded turn-context path instead.
-- `BOOTSTRAP.md`, when present, is forwarded as OpenClaw turn input reference
-  context.
+  bounded turn input reference path instead.
+- `BOOTSTRAP.md`, when present, uses the same turn input reference path.
+  These references are introduced on the first turn of a new native thread,
+  after a cold resume (including a Gateway restart), after native compaction,
+  or when their rendered content changes. Unchanged references are omitted
+  on subsequent warm turns. Tracking is process-local; reference content
+  remains ordinary user input in native history.
 
 ## Environment overrides
 

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -56,8 +56,11 @@ OpenClaw developer instructions cover OpenClaw runtime concerns: source-channel
 delivery, OpenClaw dynamic tools, ACP delegation, adapter context, and the
 active agent workspace profile files. Skill catalogs and tool-routed
 `MEMORY.md` pointers are projected as turn-scoped collaboration developer
-instructions. When memory tools are unavailable, active `BOOTSTRAP.md` content
-and full `MEMORY.md` fall back to plain turn input context instead.
+instructions. Active `BOOTSTRAP.md` and, when memory tools are unavailable,
+bounded `MEMORY.md` content travel as plain turn input references. They are
+introduced on a new native thread, after a cold resume or native compaction,
+and when their rendered content changes. Consecutive warm turns omit unchanged
+references; process-local tracking resets when the Gateway restarts.
 
 Delivery mode and the current message target requirement arrive as compact
 application context before each user turn. They explicitly supersede earlier

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -339,6 +339,7 @@ export function buildCodexSystemPromptReport(params: {
   workspaceDir: string;
   developerInstructions: string;
   workspaceBootstrapContext: CodexWorkspaceBootstrapContext;
+  omitWorkspaceReferences?: boolean;
   skillsPrompt: string;
   tools: CodexDynamicToolSpec[];
 }): CodexSystemPromptReport {
@@ -370,6 +371,7 @@ export function buildCodexSystemPromptReport(params: {
     injectedWorkspaceFiles: buildCodexBootstrapInjectionStats({
       bootstrapFiles: params.workspaceBootstrapContext.bootstrapFiles,
       injectedFiles: params.workspaceBootstrapContext.promptContextFiles ?? [],
+      omitReferenceFiles: params.omitWorkspaceReferences,
       developerInstructionFiles: [
         ...(params.workspaceBootstrapContext.threadDeveloperInstructionFiles ?? []),
         ...(params.workspaceBootstrapContext.turnScopedDeveloperInstructionFiles ?? []),
@@ -471,6 +473,7 @@ function stableJsonHash(value: JsonValue): string {
 function buildCodexBootstrapInjectionStats(params: {
   bootstrapFiles: CodexBootstrapFile[];
   injectedFiles: EmbeddedContextFile[];
+  omitReferenceFiles?: boolean;
   developerInstructionFiles?: EmbeddedContextFile[];
   memoryToolRoutedBootstrapFiles?: CodexBootstrapFile[];
   memoryToolRouted?: boolean;
@@ -514,8 +517,12 @@ function buildCodexBootstrapInjectionStats(params: {
         truncated: null,
       };
     }
-    const injectedChars = memoryToolRoutedFile ? 0 : (injected?.length ?? 0);
-    const truncated = memoryToolRoutedFile ? false : !file.missing && injectedChars < rawChars;
+    const omitted =
+      memoryToolRoutedFile ||
+      (params.omitReferenceFiles &&
+        readCodexIndexedContextFileContent(injectedIndex, pathValue, fileName) !== undefined);
+    const injectedChars = omitted ? 0 : (injected?.length ?? 0);
+    const truncated = omitted ? false : !file.missing && injectedChars < rawChars;
     return {
       name: displayName,
       path: pathValue,

--- a/extensions/codex/src/app-server/client-runtime.ts
+++ b/extensions/codex/src/app-server/client-runtime.ts
@@ -1,4 +1,5 @@
 /** Client-scoped Codex auth and account observers. */
+import { createHash } from "node:crypto";
 import { embeddedAgentLog, formatErrorMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { readCodexSessionMeta } from "../session-catalog-provenance.js";
@@ -23,6 +24,7 @@ type ClientRuntime = {
   releasingThreads: Map<string, ThreadReleaseTransition>;
   protectedThreads: Map<string, number>;
   sessionMetadata: Map<string, { sessionsRoot: string; rolloutPath: string; metadata: JsonObject }>;
+  workspaceReferences: Map<string, { digest?: string; needsReintroduction: boolean }>;
   evictionTimer?: ReturnType<typeof setTimeout>;
 };
 
@@ -70,6 +72,39 @@ const claimedThreadReleaseTokens = new WeakMap<
 export function isCodexAppServerClientRuntimeLive(client: CodexAppServerClient): boolean {
   const runtime = configuredClients.get(client);
   return runtime !== undefined && !runtime.closed;
+}
+
+/** Reference history is only trusted while this native subscription stays warm. */
+export function forgetCodexWorkspaceReferences(
+  client: CodexAppServerClient,
+  threadId: string,
+): void {
+  configuredClients.get(client)?.workspaceReferences.delete(threadId);
+}
+
+/** Record accepted input without clearing a compaction observed during turn/start. */
+export function prepareCodexWorkspaceReferences(
+  client: CodexAppServerClient,
+  threadId: string,
+  reference: string | undefined,
+) {
+  const runtime = configuredClients.get(client);
+  const digest = createHash("sha256")
+    .update(reference ?? "")
+    .digest("hex");
+  const previous = runtime?.workspaceReferences.get(threadId) ?? { needsReintroduction: true };
+  if (runtime && !runtime.closed) {
+    runtime.workspaceReferences.set(threadId, previous);
+  }
+  return {
+    include: previous.needsReintroduction || previous.digest !== digest,
+    accepted: () => {
+      if (!runtime || runtime.closed || runtime.workspaceReferences.get(threadId) !== previous) {
+        return;
+      }
+      runtime.workspaceReferences.set(threadId, { digest, needsReintroduction: false });
+    },
+  };
 }
 
 /** Immutable declarations are data owned by this physical client, never retained executors. */
@@ -134,6 +169,7 @@ export function ensureCodexAppServerClientRuntime(
     releasingThreads: new Map(),
     protectedThreads: new Map(),
     sessionMetadata: new Map(),
+    workspaceReferences: new Map(),
   };
   configuredClients.set(client, runtime);
   client.addCloseHandler(() => {
@@ -148,6 +184,7 @@ export function ensureCodexAppServerClientRuntime(
     runtime.claimedThreads.clear();
     runtime.protectedThreads.clear();
     runtime.sessionMetadata.clear();
+    runtime.workspaceReferences.clear();
   });
   client.addRequestHandler(async (request) => {
     if (request.method !== "account/chatgptAuthTokens/refresh") {
@@ -188,6 +225,20 @@ export function ensureCodexAppServerClientRuntime(
     }
   });
   client.addNotificationHandler((notification) => {
+    if (
+      notification.method === "item/completed" &&
+      isJsonObject(notification.params) &&
+      isJsonObject(notification.params.item) &&
+      notification.params.item.type === "contextCompaction" &&
+      typeof notification.params.threadId === "string"
+    ) {
+      const threadId = notification.params.threadId;
+      // Observe manual and automatic compaction even without an active turn projector.
+      const previous = runtime.workspaceReferences.get(threadId);
+      if (previous) {
+        runtime.workspaceReferences.set(threadId, { ...previous, needsReintroduction: true });
+      }
+    }
     if (notification.method === "account/rateLimits/updated") {
       mergeCodexRateLimitsUpdate(client, notification.params);
       return;
@@ -208,6 +259,7 @@ export function ensureCodexAppServerClientRuntime(
         runtime.retainedThreads.delete(threadId);
         runtime.claimedThreads.delete(threadId);
         runtime.sessionMetadata.delete(threadId);
+        runtime.workspaceReferences.delete(threadId);
         scheduleRetainedThreadEviction(client, runtime);
       }
     }
@@ -286,6 +338,7 @@ async function releaseRetainedThread(
   runtime.releasingThreads.set(threadId, transition);
   try {
     await transition.completion;
+    runtime.workspaceReferences.delete(threadId);
     return true;
   } catch (error) {
     if (
@@ -525,6 +578,7 @@ function claimCodexAppServerThreadOwnership(
       await transition.completion;
       if (runtime.claimedThreads.get(threadId) === claimed) {
         runtime.claimedThreads.delete(threadId);
+        runtime.workspaceReferences.delete(threadId);
       }
     } finally {
       if (runtime.releasingThreads.get(threadId) === transition) {
@@ -596,6 +650,7 @@ export async function unsubscribeCodexAppServerLiveThread(
     await client.request("thread/unsubscribe", { threadId }, { timeoutMs, assertCurrent });
     // Revalidate before successful release removes its own claim below.
     assertCurrent?.();
+    runtime?.workspaceReferences.delete(threadId);
   });
   const ownsTransition = runtime !== undefined && transition === undefined;
   if (transition) {

--- a/extensions/codex/src/app-server/run-attempt-context.ts
+++ b/extensions/codex/src/app-server/run-attempt-context.ts
@@ -185,16 +185,20 @@ export async function prepareCodexAttemptContext(
     }),
     agentWorkspaceDeveloperInstructions,
   );
-  const openClawPromptContext = buildCodexOpenClawPromptContext({
-    params: runtimeParams,
-    workspacePromptContext: workspaceBootstrapContext.promptContext,
-    watchedSessionsContext: buildCodexWatchedSessionsContext({
-      attempt: runtimeParams,
-      dynamicTools: toolBridge.availableSpecs,
-      sessionKey: contextSessionKey,
-      sandboxed: sandbox?.enabled === true,
-    }),
+  const watchedSessionsContext = buildCodexWatchedSessionsContext({
+    attempt: runtimeParams,
+    dynamicTools: toolBridge.availableSpecs,
+    sessionKey: contextSessionKey,
+    sandboxed: sandbox?.enabled === true,
   });
+  const buildOpenClawPromptContext = (includeWorkspaceReferences: boolean) =>
+    buildCodexOpenClawPromptContext({
+      params: runtimeParams,
+      workspacePromptContext: includeWorkspaceReferences
+        ? workspaceBootstrapContext.promptContext
+        : undefined,
+      watchedSessionsContext,
+    });
   const skillsCollaborationInstructions = renderCodexSkillsCollaborationInstructions({
     attempt: runtimeParams,
     skillsPrompt: params.skillsSnapshot?.prompt,
@@ -234,7 +238,7 @@ export async function prepareCodexAttemptContext(
     workspaceBootstrapContext,
     agentWorkspaceDeveloperInstructions,
     baseDeveloperInstructions,
-    openClawPromptContext,
+    buildOpenClawPromptContext,
     skillsCollaborationInstructions,
     promptState,
     codexContextProjectionMaxChars,

--- a/extensions/codex/src/app-server/run-attempt-prompt.ts
+++ b/extensions/codex/src/app-server/run-attempt-prompt.ts
@@ -51,7 +51,7 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
     workspaceBootstrapContext,
     buildActiveContextEngineRuntimeContext,
     baseDeveloperInstructions,
-    openClawPromptContext,
+    buildOpenClawPromptContext,
     skillsCollaborationInstructions,
     promptState,
     codexContextProjectionMaxChars,
@@ -325,13 +325,16 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
       },
     };
   };
-  const decorateCodexTurnPromptText = (promptBuildResult: {
-    prompt: string;
-    promptInputRange?: { start: number; end: number };
-  }) => {
+  const decorateCodexTurnPromptText = (
+    promptBuildResult: {
+      prompt: string;
+      promptInputRange?: { start: number; end: number };
+    },
+    includeWorkspaceReferences = true,
+  ) => {
     const turnPromptText = prependCodexOpenClawPromptContext(
       promptBuildResult.prompt,
-      openClawPromptContext,
+      buildOpenClawPromptContext(includeWorkspaceReferences),
       {
         preservePromptWithoutContext:
           params.bootstrapContextMode === "lightweight" &&
@@ -549,15 +552,19 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
     });
   };
   await rotateStartupBindingForProjectedTurn();
-  const systemPromptReport = buildCodexSystemPromptReport({
-    attempt: params,
-    sessionKey: contextSessionKey,
-    workspaceDir: effectiveWorkspace,
-    developerInstructions: buildRenderedCodexDeveloperInstructions(),
-    workspaceBootstrapContext,
-    skillsPrompt: skillsCollaborationInstructions ? (params.skillsSnapshot?.prompt ?? "") : "",
-    tools: toolBridge.availableSpecs,
-  });
+  const buildSystemPromptReport = (omitWorkspaceReferences = false) =>
+    buildCodexSystemPromptReport({
+      attempt: params,
+      sessionKey: contextSessionKey,
+      workspaceDir: effectiveWorkspace,
+      developerInstructions: buildRenderedCodexDeveloperInstructions(),
+      workspaceBootstrapContext,
+      omitWorkspaceReferences,
+      skillsPrompt: skillsCollaborationInstructions ? (params.skillsSnapshot?.prompt ?? "") : "",
+      tools: toolBridge.availableSpecs,
+    });
+  const systemPromptReport = buildSystemPromptReport();
+  let workspaceReferencesIncluded = true;
   return {
     context,
     get contextImages() {
@@ -565,6 +572,13 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
     },
     codexModelInputHistoryMessages,
     turnState,
+    refreshWorkspaceReferences: (include: boolean) => {
+      turnState.codexTurnPromptText = decorateCodexTurnPromptText(turnState.promptBuild, include);
+      if (include !== workspaceReferencesIncluded) {
+        Object.assign(systemPromptReport, buildSystemPromptReport(!include));
+        workspaceReferencesIncluded = include;
+      }
+    },
     buildRenderedCodexDeveloperInstructions,
     rebuildCodexTurnPromptTextFromCurrentProjection,
     applyNoContextEngineContinuityProjection,

--- a/extensions/codex/src/app-server/run-attempt-start.ts
+++ b/extensions/codex/src/app-server/run-attempt-start.ts
@@ -14,7 +14,6 @@ import {
 import type { CodexAttemptResources } from "./run-attempt-resources.js";
 import { joinPresentSections } from "./run-attempt-state.js";
 import { CodexThreadPolicyHandoffError } from "./thread-policy.js";
-import { recordCodexTrajectoryContext } from "./trajectory.js";
 
 export async function startCodexAttemptRuntime(resources: CodexAttemptResources) {
   const {
@@ -32,7 +31,6 @@ export async function startCodexAttemptRuntime(resources: CodexAttemptResources)
   const {
     context,
     turnState,
-    buildRenderedCodexDeveloperInstructions,
     rebuildCodexTurnPromptTextFromCurrentProjection,
     applyNoContextEngineContinuityProjection,
   } = prompt;
@@ -232,16 +230,6 @@ export async function startCodexAttemptRuntime(resources: CodexAttemptResources)
       authProfileId: startupAuthProfileId,
       workspaceDir: effectiveWorkspace,
       toolCount: flattenCodexDynamicToolFunctions(toolBridge.specs).length,
-    });
-    recordCodexTrajectoryContext(trajectoryRecorder, {
-      attempt: params,
-      cwd: effectiveCwd,
-      developerInstructions: joinPresentSections(
-        buildRenderedCodexDeveloperInstructions(),
-        attemptTools.configuredMcp?.diagnosticNotice,
-      ),
-      prompt: turnState.codexTurnPromptText,
-      tools: toolBridge.availableSpecs,
     });
     connection.mutable.pluginAppServer = pluginAppServer;
   } catch (error) {

--- a/extensions/codex/src/app-server/run-attempt-turn-request.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-request.ts
@@ -8,6 +8,7 @@ import {
   utf8JsonByteLength,
 } from "./attempt-diagnostics.js";
 import { assertCodexSessionRuntimeOwnership } from "./binding-connection.js";
+import { prepareCodexWorkspaceReferences } from "./client-runtime.js";
 import { isCodexAppServerIndeterminateRequestCancellationError } from "./client.js";
 import { resolveCodexExplicitSkillInputs } from "./explicit-skill-input.js";
 import { assertCodexTurnStartResponse } from "./protocol-validators.js";
@@ -18,8 +19,10 @@ import {
   withCodexAppServerFastModeServiceTier,
 } from "./run-attempt-lifecycle.js";
 import type { CodexAttemptResources } from "./run-attempt-resources.js";
+import { joinPresentSections } from "./run-attempt-state.js";
 import type { CodexAttemptTurnState } from "./run-attempt-turn-state.js";
 import { buildTurnStartParams } from "./thread-lifecycle.js";
+import { recordCodexTrajectoryContext } from "./trajectory.js";
 import { buildCodexUserPromptMessage } from "./transcript-mirror.js";
 
 export async function prepareCodexAttemptTurnRequest(
@@ -98,6 +101,15 @@ export async function prepareCodexAttemptTurnRequest(
     error.name = "AbortError";
     throw error;
   };
+  const prepareWorkspaceReferences = () => {
+    const references = prepareCodexWorkspaceReferences(
+      resourceState.client,
+      resourceState.thread.threadId,
+      workspaceBootstrapContext.promptContext,
+    );
+    prompt.refreshWorkspaceReferences(references.include);
+    return references;
+  };
   const startCodexTurn = async (): Promise<CodexTurnStartResponse> => {
     const activeTurnRoute = (await ensureCurrentThreadRoute()) as {
       armTurn(): void;
@@ -114,6 +126,7 @@ export async function prepareCodexAttemptTurnRequest(
       runtimeParams,
     );
     connection.mutable.pluginAppServer = turnAppServer;
+    const references = prepareWorkspaceReferences();
     const turnStartParams = buildTurnStartParams(
       {
         ...runtimeParams,
@@ -146,6 +159,16 @@ export async function prepareCodexAttemptTurnRequest(
       },
     );
     codexModelCallDiagnostics.setRequestPayloadBytes(utf8JsonByteLength(turnStartParams));
+    recordCodexTrajectoryContext(resources.trajectoryRecorder, {
+      attempt: params,
+      cwd: connection.effectiveCwd,
+      developerInstructions: joinPresentSections(
+        buildRenderedCodexDeveloperInstructions(),
+        attemptTools.configuredMcp?.diagnosticNotice,
+      ),
+      prompt: turnState.codexTurnPromptText,
+      tools: toolBridge.availableSpecs,
+    });
     state.latestStartupErrorNotification = undefined;
     state.rateLimitsRevisionBeforeLastTurnStart = readCodexRateLimitsRevision(resourceState.client);
     activeTurnRoute.armTurn();
@@ -171,6 +194,7 @@ export async function prepareCodexAttemptTurnRequest(
       );
       acceptedTurnId = startedTurn.turn.id;
       connection.assertCurrent();
+      references.accepted();
       throwIfTurnStartAcceptedAfterAbort();
       return startedTurn;
     } catch (error) {
@@ -219,6 +243,7 @@ export async function prepareCodexAttemptTurnRequest(
       );
     }
   }
+  prepareWorkspaceReferences();
   const buildLlmInputEvent = () => ({
     runId: params.runId,
     sessionId: params.sessionId,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1,4 +1,5 @@
 // Codex tests cover run attempt plugin behavior.
+import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { createOpenClawCodingTools } from "openclaw/plugin-sdk/agent-harness";
@@ -4785,7 +4786,8 @@ describe("runCodexAppServerAttempt", () => {
         const request = harness.requests
           .slice(offset)
           .find(({ method }) => method === "turn/start");
-        const input = (request?.params as { input: Array<{ text?: string }> }).input[0]?.text ?? "";
+        assert(request, "Expected the reference turn/start request");
+        const input = (request.params as { input: Array<{ text?: string }> }).input[0]?.text ?? "";
         expect(compiledPrompts).toEqual([input]);
         return { input, result };
       };

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -46,6 +46,7 @@ import { prepareCodexAppServerAuthBinding } from "./auth-binding.js";
 import { resolveCodexAppServerFallbackApiKeyCacheKey } from "./auth-cache-key.js";
 import {
   consumeCodexAppServerLiveThread,
+  releaseCodexAppServerLiveThread,
   retainCodexAppServerLiveThread,
 } from "./client-runtime.js";
 import { CodexAppServerRpcError, CodexAppServerClient } from "./client.js";
@@ -4720,36 +4721,137 @@ describe("runCodexAppServerAttempt", () => {
     expect(resumedInstructions).not.toContain(updatedGuidance);
   });
 
-  it("injects bounded MEMORY.md when memory tools are unavailable", async () => {
-    const { sessionFile, workspaceDir } = createRunPaths();
-    const memorySummary = "Memory summary goes here.";
-    await fs.mkdir(workspaceDir, { recursive: true });
-    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
-    const harness = createStartedThreadHarness();
-    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
-    await harness.waitForMethod("turn/start");
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
-    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-    const result = await run;
-    const turnStart = harness.requests.find((request) => request.method === "turn/start");
-    const turnStartParams = turnStart?.params as {
-      input?: Array<{ text?: string }>;
-    };
-    const inputText = turnStartParams.input?.[0]?.text ?? "";
-    expect(inputText).not.toContain("OpenClaw Workspace Memory");
-    expect(inputText).not.toContain("memory_search");
-    expect(inputText).toContain(memorySummary);
-    const fileStats = new Map(
-      result.systemPromptReport?.injectedWorkspaceFiles.map((file) => [file.name, file]) ?? [],
-    );
-    expect(fileStats.get("MEMORY.md")).toMatchObject({
-      rawChars: memorySummary.length,
-      injectedChars: memorySummary.length,
-      truncated: false,
-    });
-  });
+  it.each([
+    "unchanged",
+    "edited",
+    "compacted",
+    "cold resume",
+    "unsubscribed",
+    "compacted during acceptance",
+  ] as const)(
+    "introduces bounded workspace references once per native thread need: %s",
+    async (scenario) => {
+      const { sessionFile, workspaceDir } = createRunPaths();
+      const memorySummary = "Memory summary goes here.";
+      const bootstrap = "Bootstrap reference goes here.";
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
+      await fs.writeFile(path.join(workspaceDir, "BOOTSTRAP.md"), bootstrap);
+      let compactDuringAcceptance = false;
+      let harness = createStartedThreadHarness(
+        async (method) => {
+          if (method === "turn/start" && compactDuringAcceptance) {
+            compactDuringAcceptance = false;
+            await harness.notify({
+              method: "item/completed",
+              params: {
+                threadId: "thread-1",
+                turnId: "turn-1",
+                item: { type: "contextCompaction", id: "compact-during-start" },
+              },
+            });
+          }
+        },
+        { persistedThreads: [] },
+      );
+      const runTurn = async () => {
+        const offset = harness.requests.length;
+        const params = createParams(sessionFile, workspaceDir);
+        const compiledPrompts: Array<string | undefined> = [];
+        params.hostCapabilities = Object.freeze({
+          ...params.hostCapabilities,
+          trajectory: Object.freeze({
+            recordEvent: (type: string, data?: { prompt?: string }) => {
+              if (type === "context.compiled") {
+                compiledPrompts.push(data?.prompt);
+              }
+            },
+            flush: async () => undefined,
+          }),
+        });
+        const run = runCodexAppServerAttempt(params);
+        await vi.waitFor(() => {
+          expect(harness.requests.slice(offset).some(({ method }) => method === "turn/start")).toBe(
+            true,
+          );
+        }, fastWait);
+        await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+        const result = await run;
+        expect(readAttemptTerminal(result)).toMatchObject({
+          aborted: false,
+          timedOut: false,
+          promptError: null,
+        });
+        const request = harness.requests
+          .slice(offset)
+          .find(({ method }) => method === "turn/start");
+        const input = (request?.params as { input: Array<{ text?: string }> }).input[0]?.text ?? "";
+        expect(compiledPrompts).toEqual([input]);
+        return { input, result };
+      };
+      const first = await runTurn();
+      expect(first.input).toContain(memorySummary);
+      expect(first.input).toContain(bootstrap);
+      expect(first.input).not.toContain("memory_search");
+      expect(
+        first.result.systemPromptReport?.injectedWorkspaceFiles.find(
+          (file) => file.name === "MEMORY.md",
+        ),
+      ).toMatchObject({
+        rawChars: memorySummary.length,
+        injectedChars: memorySummary.length,
+        truncated: false,
+      });
+      compactDuringAcceptance = scenario === "compacted during acceptance";
+      const second = await runTurn();
+      expect.soft(second.input).not.toContain(memorySummary);
+      expect.soft(second.input).not.toContain(bootstrap);
+      expect
+        .soft(
+          second.result.systemPromptReport?.injectedWorkspaceFiles.find(
+            (file) => file.name === "MEMORY.md",
+          ),
+        )
+        .toMatchObject({ injectedChars: 0, truncated: false });
+      expect(harness.requests.filter(({ method }) => method === "thread/start")).toHaveLength(1);
+      expect(harness.requests.filter(({ method }) => method === "thread/resume")).toHaveLength(0);
+
+      let expectedMemory = memorySummary;
+      if (scenario === "edited") {
+        expectedMemory = "Updated memory reference.";
+        await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), expectedMemory);
+      } else if (scenario === "compacted") {
+        // Manual compaction may complete while no attempt projector is attached.
+        await harness.notify({
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "compact-1",
+            item: { type: "contextCompaction", id: "compact-item" },
+          },
+        });
+      } else if (scenario === "cold resume") {
+        harness.close();
+        harness = createResumeHarness("thread-1");
+      } else if (scenario === "unsubscribed") {
+        await releaseCodexAppServerLiveThread(harness.client, "thread-1");
+      }
+      const third = await runTurn();
+      if (scenario === "unchanged") {
+        expect.soft(third.input).not.toContain(expectedMemory);
+        expect.soft(third.input).not.toContain(bootstrap);
+      } else {
+        expect(third.input).toContain(expectedMemory);
+        expect(third.input).toContain(bootstrap);
+      }
+      if (scenario === "cold resume" || scenario === "unsubscribed") {
+        expect(harness.requests.filter(({ method }) => method === "thread/resume")).toHaveLength(1);
+      }
+      const fourth = await runTurn();
+      expect.soft(fourth.input).not.toContain(expectedMemory);
+      expect.soft(fourth.input).not.toContain(bootstrap);
+    },
+  );
   it("routes MEMORY.md through memory_get when search is unavailable", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
     const memorySummary = "Memory summary goes here.";

--- a/extensions/codex/src/app-server/thread-resume.ts
+++ b/extensions/codex/src/app-server/thread-resume.ts
@@ -6,6 +6,7 @@ import {
   unsubscribeCodexThreadBestEffort,
 } from "./attempt-client-cleanup.js";
 import { isCodexAppServerStartupError } from "./attempt-timeouts.js";
+import { forgetCodexWorkspaceReferences } from "./client-runtime.js";
 import {
   CodexAppServerRpcError,
   isCodexAppServerOverloadError,
@@ -53,6 +54,7 @@ export async function resumeCodexAppServerThread(params: {
           })),
     );
     assertCodexThreadResumeSubscription(threadId, response.thread.id);
+    forgetCodexWorkspaceReferences(params.client, threadId);
   } catch (error) {
     if (
       ownershipRejected ||


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users having multi-turn conversations through the Codex harness would repeatedly submit the same workspace reference content when memory tools were unavailable. The rendered MEMORY/BOOTSTRAP reference block was prepended to every turn's user input, duplicating it in native thread history and adding avoidable input tokens on each turn.

## Why This Change Was Made

Send bounded workspace references when a native thread needs them: on thread start, cold resume (including Gateway restart or subscription release), rendered content change, and after native compaction. Omit unchanged references on warm turns. The existing client lifecycle owns the process-local digest and invalidation state; there is no persistence, configuration, schema, dependency, or reference-budget change.

Compaction is observed through the app-server `item/completed` notification carrying a `contextCompaction` item, including between attempts. The native source contract is in `codex-rs/app-server-protocol/src/protocol/common.rs` (`ItemCompleted`), `codex-rs/app-server-protocol/src/protocol/v2/item.rs` (`ContextCompaction` and `ItemCompletedNotification`), and `codex-rs/app-server/src/bespoke_event_handling.rs` (`EventMsg::ItemCompleted`). `codex-rs/core/src/compact.rs` replaces compacted history before emitting the completion. These paths were inspected directly in the sibling Codex source checkout.

Tracking advances only after accepted turn input, and an acceptance response cannot clear a newer compaction invalidation. Prompt reporting and trajectory capture reflect the references actually submitted. Reference content remains bounded ordinary user input in native history.

## User Impact

Consecutive warm turns avoid repeated workspace-reference blocks while new, resumed, compacted, or changed contexts receive the references again. Memory-tool routing and per-turn watched-session context retain their existing behavior.

Updated documentation: `docs/plugins/codex-harness-reference.md` and `docs/plugins/codex-harness-runtime.md`.

## Evidence

Full focused run on the production fix: **261 passed, 6 test files passed**, 379.62 seconds:

```sh
node scripts/run-vitest.mjs extensions/codex/src/app-server/{run-attempt,client-runtime,thread-resume,attempt-context,turn-params,trajectory}.test.ts
```

Candidate and control runs used separate Vitest filesystem caches. Both updated docs passed targeted formatting validation.

Six reference-introduction regression cases cover new-thread introduction and warm omission, changed references, compaction between attempts, cold resume, unsubscribe/resume, and compaction during turn acceptance. They also check injected-file reporting and trajectory alignment. The previous worker demonstrated these cases failing against pre-fix production for duplicate-reference assertions.

Fresh Codex autoreview: scoped-clean at P0/P1, zero accepted/actionable findings. `git diff --check` passed.

Pre-existing plan-restoration failures were independently reproduced in a clean sibling worktree at current `origin/main`, commit `6223cf8b74800e22b85f16c71cfd002965d426e0`. Control command:

```sh
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t 'replaces the native surface with a filtered catalog and canonical plan persistence|bounds restored plan state after compaction|continues the turn when restoring plan state after compaction fails'
```

Control result: **3 failed, 189 skipped**, 68.33 seconds. Exact failures in `runCodexAppServerAttempt`:

- `replaces the native surface with a filtered catalog and canonical plan persistence`: expected the plan-restoration injection request; received `undefined`.
- `bounds restored plan state after compaction`: expected restored plan text to be defined; received `undefined`.
- `continues the turn when restoring plan state after compaction fails`: expected a `thread/inject_items` request; it was absent.

The prior candidate run had 258 passing tests and these three failures; the fresh candidate rerun passed these three tests. This PR does not modify their test bodies or repair plan restoration. The clean-main failures remain recorded as pre-existing and outside this fix.

The earlier `node scripts/check-changed.mjs` run passed its completed formatting, production/test TypeScript, contract, boundary, dependency, and dead-export stages, then stopped at extension lint with `Declaration input escapes checkout` for the nested installation's `qrcode@1.5.4/package.json`. The coordinator classified this as the nested-checkout environment boundary; it was not bypassed. Remaining database, media, sidecar, and runtime-cycle guards passed. The CI extension lint lane is authoritative for that unresolved local check; CI results attach to this PR's exact head.

Fixture tests prove submitted prompts and lifecycle behavior. Live provider billing/cache measurements were not run, so no measured billing reduction is claimed.

The [initial exact-head CI lint job](https://github.com/openclaw/openclaw/actions/runs/34084907650/job/101627067450) reached the extension lint lane and found one `no-unsafe-optional-chaining` error in the new reference test helper. The follow-up commit asserts that the expected `turn/start` request exists before reading its input. Production code is unchanged. All six reference regression cases passed again (191 skipped); targeted lint and formatting passed, and fresh review of that correction was scoped-clean at P0/P1. The follow-up head was verified independently by CI.

Final exact-head CI: **GREEN** for `931580562d82427a226575249b18f205ce235a65`. [CI run 34085324683](https://github.com/openclaw/openclaw/actions/runs/34085324683) completed successfully with **84 successful jobs and 16 skipped jobs**, including the [authoritative extension lint job](https://github.com/openclaw/openclaw/actions/runs/34085324683/job/101628339053). The bounded `watch-pr-ci` run exited 0 with `GREEN`; the earlier head exited 15 with `FAILING checks=check-lint` and is superseded by the correction above.
