### PR TITLE
refactor(plugins): reuse canonical config record and timeout guards

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3323,7 +3323,7 @@ src/plugins/clawhub.ts	10
 src/plugins/cli-gateway-nodes-runtime.ts	2
 src/plugins/command-registration.ts	3
 src/plugins/computer-use-contract.ts	3
-src/plugins/config-normalization-shared.ts	19
+src/plugins/config-normalization-shared.ts	1
 src/plugins/config-schema.ts	6
 src/plugins/contracts/inventory/bundled-capability-metadata.ts	3
 src/plugins/contracts/registry.ts	1

--- a/src/plugins/config-normalization-shared.ts
+++ b/src/plugins/config-normalization-shared.ts
@@ -1,4 +1,5 @@
 // Shares plugin config normalization helpers across control-plane paths.
+import { asSafeIntegerInRange } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeArrayBackedTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import { normalizeChatChannelId } from "../channels/ids.js";
@@ -60,20 +61,11 @@ function normalizeList(value: unknown, normalizePluginId: NormalizePluginId): st
 }
 
 function normalizeHookTimeoutMs(value: unknown): number | undefined {
-  if (
-    typeof value !== "number" ||
-    !Number.isInteger(value) ||
-    !Number.isFinite(value) ||
-    value <= 0 ||
-    value > 600_000
-  ) {
-    return undefined;
-  }
-  return value;
+  return asSafeIntegerInRange(value, { min: 1, max: 600_000 });
 }
 
 function normalizeHookTimeouts(value: unknown): Record<string, number> | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
+  if (!isRecord(value)) {
     return undefined;
   }
   const normalized: Record<string, number> = {};
@@ -90,7 +82,7 @@ function normalizePluginEntries(
   entries: unknown,
   normalizePluginId: NormalizePluginId,
 ): NormalizedPluginsConfig["entries"] {
-  if (!entries || typeof entries !== "object" || Array.isArray(entries)) {
+  if (!isRecord(entries)) {
     return {};
   }
   const normalized: NormalizedPluginsConfig["entries"] = {};
@@ -99,23 +91,20 @@ function normalizePluginEntries(
     if (!normalizedKey) {
       continue;
     }
-    if (!value || typeof value !== "object" || Array.isArray(value)) {
+    if (!isRecord(value)) {
       normalized[normalizedKey] = {};
       continue;
     }
-    const entry = value as Record<string, unknown>;
+    const entry = value;
     const hooksRaw = entry.hooks;
-    const hooks =
-      hooksRaw && typeof hooksRaw === "object" && !Array.isArray(hooksRaw)
-        ? {
-            allowPromptInjection: (hooksRaw as { allowPromptInjection?: unknown })
-              .allowPromptInjection,
-            allowConversationAccess: (hooksRaw as { allowConversationAccess?: unknown })
-              .allowConversationAccess,
-            timeoutMs: normalizeHookTimeoutMs((hooksRaw as { timeoutMs?: unknown }).timeoutMs),
-            timeouts: normalizeHookTimeouts((hooksRaw as { timeouts?: unknown }).timeouts),
-          }
-        : undefined;
+    const hooks = isRecord(hooksRaw)
+      ? {
+          allowPromptInjection: hooksRaw.allowPromptInjection,
+          allowConversationAccess: hooksRaw.allowConversationAccess,
+          timeoutMs: normalizeHookTimeoutMs(hooksRaw.timeoutMs),
+          timeouts: normalizeHookTimeouts(hooksRaw.timeouts),
+        }
+      : undefined;
     const normalizedHooks =
       hooks &&
       (typeof hooks.allowPromptInjection === "boolean" ||
@@ -134,21 +123,15 @@ function normalizePluginEntries(
           }
         : undefined;
     const subagentRaw = entry.subagent;
-    const subagent =
-      subagentRaw && typeof subagentRaw === "object" && !Array.isArray(subagentRaw)
-        ? {
-            allowModelOverride: (subagentRaw as { allowModelOverride?: unknown })
-              .allowModelOverride,
-            hasAllowedModelsConfig: Array.isArray(
-              (subagentRaw as { allowedModels?: unknown }).allowedModels,
-            ),
-            allowedModels: Array.isArray((subagentRaw as { allowedModels?: unknown }).allowedModels)
-              ? normalizeArrayBackedTrimmedStringList(
-                  (subagentRaw as { allowedModels?: unknown }).allowedModels,
-                )
-              : undefined,
-          }
-        : undefined;
+    const subagent = isRecord(subagentRaw)
+      ? {
+          allowModelOverride: subagentRaw.allowModelOverride,
+          hasAllowedModelsConfig: Array.isArray(subagentRaw.allowedModels),
+          allowedModels: Array.isArray(subagentRaw.allowedModels)
+            ? normalizeArrayBackedTrimmedStringList(subagentRaw.allowedModels)
+            : undefined,
+        }
+      : undefined;
     const normalizedSubagent =
       subagent &&
       (typeof subagent.allowModelOverride === "boolean" ||
@@ -165,34 +148,21 @@ function normalizePluginEntries(
           }
         : undefined;
     const llmRaw = entry.llm;
-    const llm =
-      llmRaw && typeof llmRaw === "object" && !Array.isArray(llmRaw)
-        ? {
-            allowModelOverride: (llmRaw as { allowModelOverride?: unknown }).allowModelOverride,
-            hasAllowedModelsConfig: Array.isArray(
-              (llmRaw as { allowedModels?: unknown }).allowedModels,
-            ),
-            allowedModels: Array.isArray((llmRaw as { allowedModels?: unknown }).allowedModels)
-              ? normalizeArrayBackedTrimmedStringList(
-                  (llmRaw as { allowedModels?: unknown }).allowedModels,
-                )
-              : undefined,
-            hasAllowedCompletionModelsConfig: Array.isArray(
-              (llmRaw as { allowedCompletionModels?: unknown }).allowedCompletionModels,
-            ),
-            allowedCompletionModels: Array.isArray(
-              (llmRaw as { allowedCompletionModels?: unknown }).allowedCompletionModels,
-            )
-              ? normalizeArrayBackedTrimmedStringList(
-                  (llmRaw as { allowedCompletionModels?: unknown }).allowedCompletionModels,
-                )
-              : undefined,
-            allowAuthProfileOverride: (llmRaw as { allowAuthProfileOverride?: unknown })
-              .allowAuthProfileOverride,
-            allowAgentIdOverride: (llmRaw as { allowAgentIdOverride?: unknown })
-              .allowAgentIdOverride,
-          }
-        : undefined;
+    const llm = isRecord(llmRaw)
+      ? {
+          allowModelOverride: llmRaw.allowModelOverride,
+          hasAllowedModelsConfig: Array.isArray(llmRaw.allowedModels),
+          allowedModels: Array.isArray(llmRaw.allowedModels)
+            ? normalizeArrayBackedTrimmedStringList(llmRaw.allowedModels)
+            : undefined,
+          hasAllowedCompletionModelsConfig: Array.isArray(llmRaw.allowedCompletionModels),
+          allowedCompletionModels: Array.isArray(llmRaw.allowedCompletionModels)
+            ? normalizeArrayBackedTrimmedStringList(llmRaw.allowedCompletionModels)
+            : undefined,
+          allowAuthProfileOverride: llmRaw.allowAuthProfileOverride,
+          allowAgentIdOverride: llmRaw.allowAgentIdOverride,
+        }
+      : undefined;
     const normalizedLlm =
       llm &&
       (typeof llm.allowModelOverride === "boolean" ||


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Plugin configuration normalization repeats non-array record checks and then asserts the same fields again, obscuring the existing policy boundary. This is a maintainer-requested cleanup in the #135868 split campaign; it extracts no feature content from that PR.

## Why This Change Was Made

Reuse the existing canonical `isRecord` guard at six equivalent boundaries, removing 18 redundant assertions, and delegate the existing hook-timeout range to `asSafeIntegerInRange`. The private timeout helper still owns its fixed policy at both call sites. The old accepted domain is exactly primitive integers from 1 through 600,000, so safe-integer validation accepts the same values.

The assertion inventory shrinks only this owner's count from 19 to 1. No compatibility path or migration is removed: the deletion replaces duplicate validation with its canonical owner. Public types, strict booleans, empty-list intent markers, alias merges, raw config references, callback order, and repeated getter reads remain unchanged.

## User Impact

No user-visible behavior change. Plugin configuration retains its current validation and policy semantics, with less duplicate code to maintain. No configuration option, schema, storage behavior, dependency, or authority boundary changes.

## Evidence

- All 145 existing tests in eight suites passed before and after: plugin config state/policy, registry contributions, bundled startup discovery, canonical record/number coercion, and SDK config/facade runtime.
- A bounded comparison executed the complete before owner and actual edited owner with real dependencies: 276 cases matched (258 outputs/reference/key-order outcomes and 18 exact sentinel errors). It checked timeout endpoints and rejection, decorated arrays, false/missing fields, explicit empty/invalid lists, alias collisions, raw config identity, resolver effects, and changing getter sequences. Deliberately removing an empty-list intent marker or accepting 600,001 was detected.
- The normal assertion guard passed with the exact 19-to-1 shrink. No unrelated inventory additions are included.
- Full selected `check:changed` plan passed in 835.75s, including all core test-type shards, three zero-entry Knip scans, lint, and architecture/storage guards. Full `pnpm build` passed in 209.85s, including public SDK exports, 53 native control-plane module loads, and the UI build. Clean Linux proof: [Testbox run](https://github.com/openclaw/openclaw/actions/runs/34083166726), source base `5f3fb92bb534b24c2eea6e1c48bd1fcdd2e0ea34`; complete candidate tree and 21 source/input hashes matched before and after both commands. The owned lease was stopped after success.
- Independent local and rebased-branch Codex reviews: scoped-clean through P2. After rebasing onto `e3c0531a27bce27cb6feaa52892f66e7d39beb8d`, the required offline reinstall passed and all 145 focused tests passed again (73.75s). Only package metadata and the lockfile changed among the 21 recorded proof inputs; all 19 source/test/build-config inputs remained byte-identical. Exact-head CI validates integration with the refreshed main.

- Final refresh onto `fadee067e6cd34a62a810c0759b634d7fc442c15` is patch-identical (`git range-diff`); the installed lockfile and all 19 source/test/build-config pins still match. Final branch Codex review is scoped-clean through P2.
- [ClawSweeper review](https://github.com/openclaw/openclaw/pull/140815#issuecomment-5565309621): no findings, no security findings, and no before-merge or rank-up actions. Its review confirms the canonical guard domains and documented timeout contract; no changes were requested.

| Class | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 38 | 68 | -30 |
| Tests | 0 | 0 | 0 |
| Tooling | 1 | 1 | 0 |
| Docs | 0 | 0 | 0 |

The production owner shrinks from 284 to 254 lines. Existing behavior tests remain intact.
