### PR TITLE
refactor(gateway): share unavailable method responses

### DIFF
--- a/src/gateway/server-methods/channel-pairing.ts
+++ b/src/gateway/server-methods/channel-pairing.ts
@@ -30,6 +30,7 @@ import {
 } from "../../pairing/pairing-store.js";
 import { resolveGatewayPluginConfig } from "../runtime-plugin-config.js";
 import { formatForLog } from "../ws-log.js";
+import { respondUnavailable, respondUnavailableOnThrow } from "./response.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -341,7 +342,7 @@ export const channelPairingHandlers: GatewayRequestHandlers = {
         undefined,
       );
     } catch (error) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(error)));
+      respondUnavailable(respond, error);
     }
   },
 
@@ -373,7 +374,7 @@ export const channelPairingHandlers: GatewayRequestHandlers = {
       invalidPairingAccount(respond, parsed.channel, parsed.accountId);
       return;
     }
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       const dismissed = await dismissChannelPairingRequest({
         channel: account.plugin.id,
         accountId: account.accountId,
@@ -395,8 +396,6 @@ export const channelPairingHandlers: GatewayRequestHandlers = {
         },
         undefined,
       );
-    } catch (error) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(error)));
-    }
+    });
   },
 };

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -46,6 +46,7 @@ import {
   collectGatewayChannelStatusIssues,
   resolveDeferredChannelReloadIssue,
 } from "./channels-status-issues.js";
+import { respondUnavailableOnThrow } from "./response.js";
 import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams, type Validator } from "./validation.js";
 
@@ -102,11 +103,9 @@ async function respondWithChannelOperationPayload<TPayload>(params: {
   respond: RespondFn;
   run: () => Promise<TPayload>;
 }): Promise<void> {
-  try {
+  await respondUnavailableOnThrow(params.respond, async () => {
     params.respond(true, await params.run(), undefined);
-  } catch (error) {
-    params.respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(error)));
-  }
+  });
 }
 
 const CHANNEL_STATUS_MAX_TIMEOUT_MS = 30_000;

--- a/src/gateway/server-methods/device-pair-setup.ts
+++ b/src/gateway/server-methods/device-pair-setup.ts
@@ -25,7 +25,7 @@ import {
   VOICE_NODE_PAIRING_SETUP_BOOTSTRAP_PROFILE,
 } from "../../shared/device-bootstrap-profile.js";
 import { isLoopbackHost } from "../net.js";
-import { formatForLog } from "../ws-log.js";
+import { respondUnavailableOnThrow } from "./response.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -66,7 +66,7 @@ export const devicePairSetupHandlers: GatewayRequestHandlers = {
     ) {
       return;
     }
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       if (
         params.joinUrl === true &&
         params.bootstrapProfile !== undefined &&
@@ -147,9 +147,7 @@ export const devicePairSetupHandlers: GatewayRequestHandlers = {
         },
         undefined,
       );
-    } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-    }
+    });
   },
   // Recovery path for the best-effort device.pair.setup.completed broadcast: a
   // client that missed the frame must not present a redeemed setup as expired.
@@ -164,7 +162,7 @@ export const devicePairSetupHandlers: GatewayRequestHandlers = {
     ) {
       return;
     }
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       const completion = await readDevicePairSetupCompletion({ setupId: params.setupId });
       // Retention bookkeeping stays server-side; the wire shape matches the
       // corresponding success or delivery-uncertain broadcast.
@@ -183,8 +181,6 @@ export const devicePairSetupHandlers: GatewayRequestHandlers = {
           })()
         : {};
       respond(true, result, undefined);
-    } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-    }
+    });
   },
 };

--- a/src/gateway/server-methods/environments.ts
+++ b/src/gateway/server-methods/environments.ts
@@ -33,7 +33,7 @@ import { resolveWorkerPlacementCapabilities } from "../worker-environments/place
 import type { WorkerEnvironmentServiceRecord } from "../worker-environments/service-contract.js";
 import type { WorkerEnvironmentState } from "../worker-environments/state.js";
 import { formatForLog } from "../ws-log.js";
-import { respondUnavailableOnThrow } from "./nodes.helpers.js";
+import { respondUnavailableOnThrow } from "./response.js";
 import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 

--- a/src/gateway/server-methods/exec-approvals.ts
+++ b/src/gateway/server-methods/exec-approvals.ts
@@ -29,9 +29,9 @@ import type { NodeSession } from "../node-registry.js";
 import { resolveBaseHashParam } from "./base-hash.js";
 import {
   respondUnavailableOnNodeInvokeErrorWithProvenance,
-  respondUnavailableOnThrow,
   parseGatewayPayload,
 } from "./nodes.helpers.js";
+import { respondUnavailableOnThrow } from "./response.js";
 import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams, type Validator } from "./validation.js";
 

--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -1,7 +1,6 @@
 // Health gateway methods return cached or refreshed status summaries while
 // detecting stale channel runtime state against live gateway snapshots.
 import { isFutureDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
-import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
 import type { ChannelAccountSnapshot } from "../../channels/plugins/types.public.js";
 import { getStatusSummary } from "../../status/summary.js";
 import type { GatewayHotReloadStatus } from "../config-reload-status.types.js";
@@ -11,7 +10,7 @@ import type { ChannelHealthSummary, HealthSummary } from "../health/types.js";
 import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
 import { HEALTH_REFRESH_INTERVAL_MS } from "../server-constants.js";
 import { formatError } from "../server-utils.js";
-import { formatForLog } from "../ws-log.js";
+import { respondUnavailableOnThrow } from "./response.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 
 const ADMIN_SCOPE = "operator.admin";
@@ -177,12 +176,10 @@ export const healthHandlers: GatewayRequestHandlers = {
       }
       return;
     }
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       const snap = await refreshHealthSnapshot({ probe: wantsProbe, includeSensitive });
       respond(true, snap, undefined);
-    } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-    }
+    });
   },
   status: async ({ respond, client, params, context }) => {
     const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];

--- a/src/gateway/server-methods/models-auth-order.ts
+++ b/src/gateway/server-methods/models-auth-order.ts
@@ -21,6 +21,7 @@ import { modelAuthAgentScopeError, resolveModelAuthAgentScope } from "./model-au
 import { resolveConfigBoundProfileIds } from "./models-auth-status-config.js";
 import { clearModelAuthStatusUsageCache } from "./models-auth-status-usage-cache.js";
 import type { ModelAuthOrderSetResult } from "./models-auth-status.types.js";
+import { respondUnavailableOnThrow } from "./response.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -37,7 +38,7 @@ export const modelsAuthOrderHandlers: GatewayRequestHandlers = {
     const profileIds = params.profileIds ?? null;
     const rejectInvalidOrder = (message: string) =>
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, message));
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       const cfg = context.getRuntimeConfig();
       const scope = resolveModelAuthAgentScope(cfg, params.agentId);
       if (!scope.ok) {
@@ -134,8 +135,6 @@ export const modelsAuthOrderHandlers: GatewayRequestHandlers = {
       ]).catch((err: unknown) => {
         log.warn(`provider auth state refresh after reorder failed: ${formatForLog(err)}`);
       });
-    } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-    }
+    });
   },
 };

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -64,6 +64,7 @@ import type {
   ModelProviderCapability,
 } from "./models-auth-status.types.js";
 import { getProviderUsageRuntimeSnapshot } from "./provider-usage-runtime.js";
+import { respondUnavailableOnThrow } from "./response.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 
 export type {
@@ -472,7 +473,7 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, selection.message));
       return;
     }
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       const cfg = context.getRuntimeConfig();
       const scope = resolveModelAuthAgentScope(cfg, params.agentId);
       if (!scope.ok) {
@@ -558,9 +559,7 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
         abortedRunIds,
       };
       respond(true, result, undefined);
-    } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-    }
+    });
   },
   "models.authStatus": async ({ params, respond, context, client }) => {
     const now = Date.now();
@@ -574,7 +573,7 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
           ? tryResolveAmbientOwnerAgentId(cfg)
           : params.agentId,
       );
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       let cfg = context.getRuntimeConfig();
       let scope = resolveScope(cfg);
       if (!scope.ok) {
@@ -714,8 +713,6 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
       });
       const result: ModelAuthStatusResult = { ts: now, providers, providerCapabilities };
       respond(true, result, undefined);
-    } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-    }
+    });
   },
 };

--- a/src/gateway/server-methods/nodes.event.ts
+++ b/src/gateway/server-methods/nodes.event.ts
@@ -6,8 +6,8 @@ import {
 import { recordPairedNodeHostStats } from "../../infra/device-pairing-node.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { NodeEventContext } from "../server-node-events-types.js";
-import { respondUnavailableOnThrow } from "./nodes.helpers.js";
 import { resolveDispatchableNodeSession, respondPairingChanged } from "./nodes.shared.js";
+import { respondUnavailableOnThrow } from "./response.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 

--- a/src/gateway/server-methods/nodes.helpers.ts
+++ b/src/gateway/server-methods/nodes.helpers.ts
@@ -1,22 +1,11 @@
-// Node method helpers centralize unavailable responses, safe JSON parsing,
-// and node-invoke error mapping.
+// Node method helpers centralize JSON parsing and node-invoke error mapping.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
   errorShape,
 } from "../../../packages/gateway-protocol/src/schema/error-codes.js";
-import { formatForLog } from "../ws-log.js";
 import type { RespondFn } from "./types.js";
 export { parseGatewayPayload } from "../server-json.js";
-
-/** Converts thrown node-handler failures into `UNAVAILABLE` protocol errors. */
-export async function respondUnavailableOnThrow(respond: RespondFn, fn: () => Promise<void>) {
-  try {
-    await fn();
-  } catch (err) {
-    respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-  }
-}
 
 /** Narrows successful node invoke results or responds with the node error details. */
 export function respondUnavailableOnNodeInvokeError<T extends { ok: boolean; error?: unknown }>(

--- a/src/gateway/server-methods/nodes.invoke.ts
+++ b/src/gateway/server-methods/nodes.invoke.ts
@@ -31,7 +31,6 @@ import { handleNodeInvokeProgress } from "./nodes.handlers.invoke-progress.js";
 import { handleNodeInvokeResult } from "./nodes.handlers.invoke-result.js";
 import {
   respondUnavailableOnNodeInvokeErrorWithProvenance,
-  respondUnavailableOnThrow,
   parseGatewayPayload,
 } from "./nodes.helpers.js";
 import {
@@ -51,6 +50,7 @@ import {
   maybeWakeNodeWithApns,
   waitForNodeReconnect,
 } from "./nodes.wake.js";
+import { respondUnavailableOnThrow } from "./response.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 

--- a/src/gateway/server-methods/nodes.pairing.ts
+++ b/src/gateway/server-methods/nodes.pairing.ts
@@ -33,8 +33,8 @@ import {
   type DeviceManagementAuthz,
 } from "./device-management-authz.js";
 import { emitDeviceManagementSecurityEvent } from "./device-management-security.js";
-import { respondUnavailableOnThrow } from "./nodes.helpers.js";
 import { refreshConnectedNodeSurfaceCaches } from "./nodes.read.js";
+import { respondUnavailableOnThrow } from "./response.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./shared-types.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";

--- a/src/gateway/server-methods/nodes.pending-work.ts
+++ b/src/gateway/server-methods/nodes.pending-work.ts
@@ -23,13 +23,13 @@ import {
   NODE_WAKE_RECONNECT_WAIT_MS,
   releaseNodeWakeLifecycle,
 } from "../node-wake-state.js";
-import { respondUnavailableOnThrow } from "./nodes.helpers.js";
 import { isNodePairingWorkCurrent } from "./nodes.shared.js";
 import {
   maybeSendNodeWakeNudge,
   maybeWakeNodeWithApns,
   waitForNodeReconnect,
 } from "./nodes.wake.js";
+import { respondUnavailableOnThrow } from "./response.js";
 import type { RespondFn } from "./shared-types.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";

--- a/src/gateway/server-methods/nodes.pending.ts
+++ b/src/gateway/server-methods/nodes.pending.ts
@@ -20,8 +20,8 @@ import {
   type PendingNodeAction,
 } from "../node-runtime-state.js";
 import { nodeInvokePolicy } from "./nodes-policy.js";
-import { respondUnavailableOnThrow } from "./nodes.helpers.js";
 import { respondPairingChanged } from "./nodes.shared.js";
+import { respondUnavailableOnThrow } from "./response.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 

--- a/src/gateway/server-methods/nodes.read.ts
+++ b/src/gateway/server-methods/nodes.read.ts
@@ -34,7 +34,7 @@ import {
   refreshClientPluginNodeCapability,
 } from "../plugin-node-capability.js";
 import { nodeInvokePolicy } from "./nodes-policy.js";
-import { respondUnavailableOnThrow } from "./nodes.helpers.js";
+import { respondUnavailableOnThrow } from "./response.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./shared-types.js";
 import type { GatewayRequestHandler, GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";

--- a/src/gateway/server-methods/push.ts
+++ b/src/gateway/server-methods/push.ts
@@ -41,7 +41,7 @@ import {
 } from "../../infra/push-web.js";
 import { getUserPreferences, setUserPreferences } from "../../state/user-preferences.js";
 import { resolveUserProfileId } from "../../state/user-profiles.js";
-import { respondUnavailableOnThrow } from "./nodes.helpers.js";
+import { respondUnavailableOnThrow } from "./response.js";
 import type { GatewayRequestHandlers, GatewayRequestHandlerOptions } from "./types.js";
 import { assertValidParams } from "./validation.js";
 

--- a/src/gateway/server-methods/response.ts
+++ b/src/gateway/server-methods/response.ts
@@ -1,0 +1,18 @@
+import {
+  ErrorCodes,
+  errorShape,
+} from "../../../packages/gateway-protocol/src/schema/error-codes.js";
+import { formatForLog } from "../ws-log.js";
+import type { RespondFn } from "./types.js";
+
+export function respondUnavailable(respond: RespondFn, err: unknown): void {
+  respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
+}
+
+export async function respondUnavailableOnThrow(respond: RespondFn, fn: () => Promise<void>) {
+  try {
+    await fn();
+  } catch (err) {
+    respondUnavailable(respond, err);
+  }
+}

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -73,6 +73,7 @@ import {
 import { getVoiceProviderConfig, providerMatchesId } from "../../tts/voice-models.js";
 import { ADMIN_SCOPE, READ_SCOPE, TALK_SECRETS_SCOPE } from "../operator-scopes.js";
 import { formatForLog } from "../ws-log.js";
+import { respondUnavailable } from "./response.js";
 import { inferSpeechMimeType } from "./speech-mime.js";
 import { talkClientHandlers } from "./talk-client.js";
 import { talkSessionHandlers } from "./talk-session.js";
@@ -880,7 +881,7 @@ export const talkHandlers: GatewayRequestHandlers = {
       talk = resolved?.talk;
       realtimeClientHints = resolved?.realtimeClientHints;
     } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
+      respondUnavailable(respond, err);
       return;
     }
     if (talk) {

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -32,6 +32,7 @@ import {
   textToSpeech,
 } from "../../tts/tts.js";
 import { formatForLog } from "../ws-log.js";
+import { respondUnavailableOnThrow } from "./response.js";
 import { inferSpeechMimeType } from "./speech-mime.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
@@ -62,7 +63,7 @@ function resolveTtsGatewayStatusFacts(cfg: OpenClawConfig) {
 /** Gateway request handlers for TTS status, preference mutation, and synthesis. */
 export const ttsHandlers: GatewayRequestHandlers = {
   "tts.status": async ({ respond, context }) => {
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       await yieldBeforeTtsStatusSetup();
       const cfg = context.getRuntimeConfig();
       const { configuredByProvider, provider, settings, speechProviders } =
@@ -98,31 +99,25 @@ export const ttsHandlers: GatewayRequestHandlers = {
         prefsPath: settings.prefsPath,
         providerStates,
       });
-    } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-    }
+    });
   },
   "tts.enable": async ({ respond, context }) => {
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       const cfg = context.getRuntimeConfig();
       const config = resolveTtsConfig(cfg);
       const prefsPath = resolveTtsPrefsPath(config);
       setTtsEnabled(prefsPath, true);
       respond(true, { enabled: true });
-    } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-    }
+    });
   },
   "tts.disable": async ({ respond, context }) => {
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       const cfg = context.getRuntimeConfig();
       const config = resolveTtsConfig(cfg);
       const prefsPath = resolveTtsPrefsPath(config);
       setTtsEnabled(prefsPath, false);
       respond(true, { enabled: false });
-    } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-    }
+    });
   },
   "tts.convert": async ({ params, respond, context }) => {
     const text = normalizeOptionalString(params.text) ?? "";
@@ -134,7 +129,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       const cfg = context.getRuntimeConfig();
       const channel = normalizeOptionalString(params.channel);
       const providerRaw = normalizeOptionalString(params.provider);
@@ -175,9 +170,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
         undefined,
         errorShape(ErrorCodes.UNAVAILABLE, result.error ?? "TTS conversion failed"),
       );
-    } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-    }
+    });
   },
   // Unlike tts.convert (gateway-local audioPath) this returns the clip inline,
   // so remote clients (mobile apps) can play it without filesystem access.
@@ -261,17 +254,15 @@ export const ttsHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       const config = resolveTtsConfig(cfg);
       const prefsPath = resolveTtsPrefsPath(config);
       setTtsProvider(prefsPath, provider);
       respond(true, { provider });
-    } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-    }
+    });
   },
   "tts.personas": async ({ respond, context }) => {
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       const cfg = context.getRuntimeConfig();
       const config = resolveTtsConfig(cfg);
       const prefsPath = resolveTtsPrefsPath(config);
@@ -287,14 +278,12 @@ export const ttsHandlers: GatewayRequestHandlers = {
           providers: Object.keys(persona.providers ?? {}),
         })),
       });
-    } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-    }
+    });
   },
   "tts.setPersona": async ({ params, respond, context }) => {
     const cfg = context.getRuntimeConfig();
     const rawPersona = normalizeOptionalString(params.persona);
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       const config = resolveTtsConfig(cfg);
       const prefsPath = resolveTtsPrefsPath(config);
       if (!rawPersona || ["off", "none", "default"].includes(rawPersona.toLowerCase())) {
@@ -320,12 +309,10 @@ export const ttsHandlers: GatewayRequestHandlers = {
       // so preference files remain stable across copy changes.
       setTtsPersona(prefsPath, persona.id);
       respond(true, { persona: persona.id });
-    } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-    }
+    });
   },
   "tts.providers": async ({ respond, context }) => {
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       const cfg = context.getRuntimeConfig();
       const { configuredByProvider, provider, speechProviders } = resolveTtsGatewayStatusFacts(cfg);
       respond(true, {
@@ -338,8 +325,6 @@ export const ttsHandlers: GatewayRequestHandlers = {
         })),
         active: provider,
       });
-    } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-    }
+    });
   },
 };

--- a/src/gateway/server-methods/voicewake.ts
+++ b/src/gateway/server-methods/voicewake.ts
@@ -2,18 +2,16 @@
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
 import { loadVoiceWakeConfig, setVoiceWakeTriggers } from "../../infra/voicewake.js";
 import { normalizeVoiceWakeTriggers } from "../server-utils.js";
-import { formatForLog } from "../ws-log.js";
+import { respondUnavailableOnThrow } from "./response.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
 /** Gateway request handlers for reading and updating voice wake triggers. */
 export const voicewakeHandlers: GatewayRequestHandlers = {
   "voicewake.get": async ({ respond }) => {
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       const cfg = await loadVoiceWakeConfig();
       respond(true, { triggers: cfg.triggers });
-    } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-    }
+    });
   },
   "voicewake.set": async ({ params, respond, context }) => {
     if (!Array.isArray(params.triggers)) {
@@ -24,15 +22,13 @@ export const voicewakeHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    try {
+    await respondUnavailableOnThrow(respond, async () => {
       const triggers = normalizeVoiceWakeTriggers(params.triggers);
       // Persist the normalized trigger list before broadcasting so connected
       // nodes and future gateway starts observe the same wake phrases.
       const cfg = await setVoiceWakeTriggers(triggers);
       context.broadcastVoiceWakeChanged(cfg.triggers);
       respond(true, { triggers: cfg.triggers });
-    } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
-    }
+    });
   },
 };

--- a/src/gateway/server-methods/web.ts
+++ b/src/gateway/server-methods/web.ts
@@ -13,7 +13,7 @@ import { listLoadedChannelPluginsForRegistry } from "../../channels/plugins/regi
 import type { ChannelId } from "../../channels/plugins/types.public.js";
 import { resolveMissingOfficialExternalChannelPluginRepairHints } from "../../plugins/official-external-plugin-repair-hints.js";
 import { getPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
-import { formatForLog } from "../ws-log.js";
+import { respondUnavailable } from "./response.js";
 import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -107,10 +107,6 @@ function respondProviderUnsupported(respond: RespondFn, providerId: string) {
     undefined,
     errorShape(ErrorCodes.INVALID_REQUEST, `web login is not supported by provider ${providerId}`),
   );
-}
-
-function respondWebLoginUnavailable(respond: RespondFn, err: unknown) {
-  respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
 }
 
 /** Resolves a concrete provider gateway login method or sends the public error. */
@@ -211,7 +207,7 @@ export const webHandlers: GatewayRequestHandlers = {
       }
       respond(true, result, undefined);
     } catch (err) {
-      respondWebLoginUnavailable(respond, err);
+      respondUnavailable(respond, err);
     }
   },
   "web.login.wait": async ({ params, respond, context }) => {
@@ -241,7 +237,7 @@ export const webHandlers: GatewayRequestHandlers = {
       }
       respond(true, result, undefined);
     } catch (err) {
-      respondWebLoginUnavailable(respond, err);
+      respondUnavailable(respond, err);
     }
   },
 };


### PR DESCRIPTION
## What Problem This Solves

Gateway method families maintained separate copies of the same unavailable-error response, including its sensitive-text formatter. Keeping those copies aligned made a shared wire contract harder to maintain.

## Why This Change Was Made

`server-methods/response.ts` now owns the exact `UNAVAILABLE` response and the existing async exception wrapper. Seventeen method-local catch blocks reuse the wrapper; channel operations retain their success-payload adapter. DM approval, Web login, and the mid-handler Talk catch call the synchronous mapper, preserving their existing control flow.

Validation and authorization remain at their original boundaries. Domain-specific TTS/Talk errors, node-invoke details/provenance, background warning catches, and public SDK helper exports remain intact. All 22 exact default mapping sites now route to the shared owner. Production changes are +78/-106, a net reduction of 28 lines; tests are unchanged.

Rebased on the merged channel-status diagnostics in #140635, preserving both sets of imports. Its diagnostics remain separate from the response adapter changed here.

## User Impact

No user-visible change. Successful results, error codes, complete error messages, secret redaction, and node error details retain their existing behavior. No protocol schema, configuration, dependency, or persistent-state changes.

## Evidence

- 1,921 selected tests passed across 133 files with the locked dependencies installed. After rebase, all 29 channel tests passed; the other 20 edited files remained byte-identical to that tested candidate. Coverage includes affected methods, exact error messages, secret redaction, protocol/client behavior, and UI/CLI consumers.
- Independent Codex review against the pinned branch merge base: scoped-clean through P2, with no accepted/actionable findings.
- `git diff --check` passed.
- The first typecheck exposed a callback narrowing issue; DM approval now keeps its original catch and mutable adapter reads. A frozen-lockfile install aligned the stale worktree dependency with the already-declared filesystem package version; no manifest or lockfile changes. Final tests and core typechecking passed. `node scripts/check-changed.mjs` passed in full, including core/test types, all dead-export scans, lint, and guards. `pnpm build` and `pnpm protocol:check` passed. The protocol registry and generated Swift/Kotlin models are unchanged. Exact-head [CI run 34085417709](https://github.com/openclaw/openclaw/actions/runs/34085417709) passed for `0ac90aaf3ff882f36cdebd4ea965d37e7db756d0`; native review validation and hosted preparation passed.

<details>
<summary>Focused test command (shell brace expansion shown for the explicit method files)</summary>

```bash
node scripts/run-vitest.mjs \
  src/gateway/ws-log.test.ts \
  src/gateway/server-methods/{channels.start,channels.status,health.owner-routing,tts,talk,device-pair-setup,channel-pairing,models-auth-status,nodes,nodes.read,nodes.validation,nodes.event,nodes.pending-work,nodes.invoke-wake,nodes.invoke-abort,nodes.helpers,push,exec-approvals,environments,environments.node-ownership,environments.desktop,environments.node-command-authority,web.start,web.gateway}.test.ts \
  packages/gateway-protocol packages/gateway-client ui/src/api ui/src/lib/nodes src/cli/devices-cli
```

</details>

The earlier broad campaign baseline passed 5,443 Gateway tests but failed the unrelated session-cache retention subprocess's existing 15-second deadline, also on isolated retry. That test and its timeout were not changed; the final focused proof and native hosted gate above passed.


## Landing Status

Merged through the native workflow after the maintainer-directed readiness check reported MERGEABLE/CLEAN and no retained intent or dispatch. The single resumed merge attempt landed `ce174871076b4a5db8524ef8eb8ea17a3abe97fa` from the unchanged prepared head `0ac90aaf3ff882f36cdebd4ea965d37e7db756d0`. Native hosted gates and the completed review were revalidated; no gate was bypassed.
