### PR TITLE
fix(doctor): selected context engine reported as "not registered" when its plugin registers in discovery mode

### DIFF
--- a/src/commands/doctor/shared/context-engine-host-compat.test.ts
+++ b/src/commands/doctor/shared/context-engine-host-compat.test.ts
@@ -6,6 +6,8 @@ import {
   registerContextEngineForOwner,
 } from "../../../context-engine/registry.js";
 import type { ContextEngine, ContextEngineHostCapability } from "../../../context-engine/types.js";
+import { loadPluginRegistryHandle } from "../../../plugins/loader.js";
+import { createEmptyPluginRegistry } from "../../../plugins/registry-empty.js";
 import {
   collectContextEngineHostCompatibilityWarnings,
   maybeRepairContextEngineHostCompatibility,
@@ -31,6 +33,10 @@ vi.mock("../../../agents/harness/registry.js", () => ({
 
 vi.mock("../../../context-engine/init.js", () => ({
   ensureContextEnginesInitialized: vi.fn(),
+}));
+
+vi.mock("../../../plugins/loader.js", () => ({
+  loadPluginRegistryHandle: vi.fn(),
 }));
 
 let engineCounter = 0;
@@ -93,6 +99,37 @@ function configWithEngine(engineId: string, cfg: OpenClawConfig = {}): OpenClawC
 }
 
 describe("doctor context-engine host compatibility", () => {
+  it.each([true, false])(
+    "reports offline inspection availability without activating or repairing an engine (discovered=%s)",
+    async (discovered) => {
+      const id = uniqueEngineId();
+      const factory = vi.fn(() => {
+        throw new Error("Doctor must not initialize an engine to inspect its metadata");
+      });
+      const registry = createEmptyPluginRegistry();
+      if (discovered) {
+        registry.contextEngines.set(id, {
+          factory,
+          owner: `plugin:${id}`,
+          lifecycle: "readOnlyDiscovery",
+        });
+      }
+      vi.mocked(loadPluginRegistryHandle).mockReturnValue(registry);
+      const cfg = configWithEngine(id);
+      const params = { cfg, doctorFixCommand: "openclaw doctor --fix" };
+      const warnings = await collectContextEngineHostCompatibilityWarnings(params);
+      expect(warnings.join("\n")).toContain(
+        discovered
+          ? "registered for read-only discovery; offline host compatibility inspection is unavailable"
+          : "because it is not registered",
+      );
+      const repair = await maybeRepairContextEngineHostCompatibility(params);
+      expect(repair).toEqual({ config: cfg, changes: [], warnings });
+      expect(repair.config).toBe(cfg);
+      expect(factory).not.toHaveBeenCalled();
+    },
+  );
+
   it("distinguishes read-only discovery registrations from runtime entries", () => {
     const id = uniqueEngineId();
     const factory = () => {

--- a/src/commands/doctor/shared/context-engine-host-compat.ts
+++ b/src/commands/doctor/shared/context-engine-host-compat.ts
@@ -269,7 +269,15 @@ async function resolveSelectedContextEngineInfo(params: {
         };
       }
     }
-    if (pluginRegistry?.contextEngines.get(engineId)?.lifecycle !== "runtime") {
+    const registration = pluginRegistry?.contextEngines.get(engineId);
+    if (registration?.lifecycle === "readOnlyDiscovery") {
+      return {
+        warnings: [
+          `- plugins.slots.contextEngine: context engine "${engineId}" is registered for read-only discovery; offline host compatibility inspection is unavailable. This does not indicate a missing runtime registration in the Gateway.`,
+        ],
+      };
+    }
+    if (registration?.lifecycle !== "runtime") {
       return {
         warnings: [
           `- plugins.slots.contextEngine: could not inspect context engine "${engineId}" host requirements because it is not registered.`,


### PR DESCRIPTION
Closes #140817

AI-assisted.

## What Problem This Solves

Doctor reported a selected external context engine as "not registered" after its plugin had successfully registered during read-only discovery. That sent operators toward a registration failure when Doctor could only establish a limit on offline inspection.

## Why This Change Was Made

The compatibility check now distinguishes discovery-only registration from missing registration. Discovery gets an explicit offline-inspection diagnostic. Every non-runtime registration still returns before engine resolution, so Doctor does not activate the plugin or call its engine factory. Runtime compatibility checks and configuration repair behavior remain intact.

## User Impact

Operators see what Doctor knows: the engine registered for read-only discovery, and offline host-compatibility inspection is unavailable. The message makes no claim that Gateway runtime registration succeeded or failed. Truly missing registrations keep the existing diagnostic.

## Evidence

Real compiled `node openclaw.mjs doctor --non-interactive` runs used the same isolated JavaScript plugin and configuration before and after the change.

| Case | Before | After |
| --- | --- | --- |
| Discovery registration | Incorrectly reported as not registered | Reports read-only registration and unavailable offline inspection |
| Missing registration | Existing not-registered diagnostic | Preserved |
| Plugin registration failure | Specific plugin-load error | Preserved |
| Default engine and `none` | No context-engine warning | Preserved |

- All seven candidate command variants exited successfully and preserved configuration bytes. Discovery and missing cases included `--fix` after normal first-run migration completed.
- Registration markers showed discovery callbacks and no factory calls. Each selected-engine case produced one applicable compatibility message.
- An independent source-blind check repeated the seven CLI variants and passed all 14 CLI acceptance clauses, including matching baseline/candidate arguments, plugin identities, configuration bytes, exits, and markers.
- [All nine compatibility tests passed](https://github.com/openclaw/openclaw/actions/runs/34085061180/job/101627545448), including runtime host requirements, compatible hosts, and mixed-host repair behavior. Type, lint, and boundary checks passed in that run.
- Baseline build: `f6494e3526388272f03e80741c55f68290d6556f`. Candidate build: GitHub test merge `2b4594f3d1d90d0850b35a1607d29d098ea4fe73`, containing PR head `29554a111f342fd0473cf09c9cc016a49261e279`. Artifact digests and matching source/dependency inputs were verified. The relevant compatibility, loader, registry, and dependency inputs differ only by this production fix.

The first CI attempt recorded a session-cleanup timing failure (554 ms against 500 ms) on Blacksmith. [Attempt 2](https://github.com/openclaw/openclaw/actions/runs/34085061180/attempts/2) uses the repository’s existing GitHub-hosted fork-retry route with the same source and assertion. The original cause remains unresolved; no CI exception is requested.
