### PR TITLE
fix(ai): prevent truncated Anthropic streamed replies

### DIFF
--- a/packages/ai/src/provider-transport-parity.test.ts
+++ b/packages/ai/src/provider-transport-parity.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import Anthropic from "@anthropic-ai/sdk";
 import { APIError as AnthropicAPIError } from "@anthropic-ai/sdk/core/error.js";
 import type { AssistantMessageEventStreamLike, Model } from "@openclaw/llm-core";
 import { describe, expect, it, vi } from "vitest";
@@ -416,6 +417,75 @@ const fixtures: ParityFixture[] = [
 
 describe("provider and transport observable parity fixtures", () => {
   registerParityHostLifecycle();
+
+  it.each([
+    { name: "seeded starts followed by deltas", seeded: true, deltas: true },
+    { name: "seed-only blocks", seeded: true, deltas: false },
+    { name: "empty starts followed by deltas", seeded: false, deltas: true },
+  ])("preserves Anthropic $name like the native SDK", async ({ seeded, deltas }) => {
+    const events = anthropicEvents
+      .filter((event) => deltas || event.type !== "content_block_delta")
+      .map((event) => {
+        if (event.type === "message_start") {
+          return Object.assign({}, event, {
+            message: Object.assign({}, event.message, {
+              type: "message",
+              role: "assistant",
+              content: [],
+              stop_reason: null,
+              stop_sequence: null,
+            }),
+          });
+        }
+        if (!seeded && event.type === "content_block_start" && event.content_block) {
+          return Object.assign({}, event, {
+            content_block:
+              event.content_block.type === "text"
+                ? { type: "text", text: "" }
+                : { type: "thinking", thinking: "", signature: "" },
+          });
+        }
+        return event;
+      });
+    const sdk = new Anthropic({
+      apiKey: "synthetic-key",
+      fetch: async () => createAnthropicResponse(events),
+    });
+    const sdkResult = await sdk.messages
+      .stream({
+        model: anthropicModel.id,
+        max_tokens: 4096,
+        messages: [{ role: "user", content: "Find the answer." }],
+      })
+      .finalMessage();
+    const thinking = `${seeded ? "seed" : ""}${deltas ? " + thought" : ""}`;
+    const text = `${seeded ? "Hello" : ""}${deltas ? " world" : ""}`;
+    const signature = deltas ? "final-signature" : "seed-signature";
+    expect(sdkResult.content).toEqual([
+      { type: "thinking", thinking, signature },
+      { type: "text", text },
+    ]);
+    for (const implementation of ["provider", "transport"] as const) {
+      const result = await runAnthropic(implementation, "success", events);
+      expect(result.terminal).toMatchObject({
+        stopReason: "stop",
+        content: [
+          { type: "thinking", thinking, thinkingSignature: signature },
+          { type: "text", text },
+        ],
+      });
+      expect(result.eventTrace).toContainEqual({
+        type: "thinking_end",
+        contentIndex: 0,
+        content: thinking,
+      });
+      expect(result.eventTrace).toContainEqual({
+        type: "text_end",
+        contentIndex: 1,
+        content: text,
+      });
+    }
+  });
 
   it.each(fixtures)("$name", async ({ provider, outcome, snapshot }) => {
     const run = provider === "anthropic" ? runAnthropic : runOpenAi;

--- a/packages/ai/src/transports/anthropic-stream-reducer.ts
+++ b/packages/ai/src/transports/anthropic-stream-reducer.ts
@@ -309,7 +309,7 @@ export async function consumeAnthropicStream(params: {
         pendingThinkingSignatures.delete(index);
         if (contentBlock?.type === "text") {
           const text =
-            managed && typeof contentBlock.text === "string"
+            typeof contentBlock.text === "string"
               ? sanitizeTransportPayloadText(contentBlock.text)
               : "";
           const block: AnthropicStreamBlock = { type: "text", text, index };
@@ -332,13 +332,12 @@ export async function consumeAnthropicStream(params: {
           continue;
         }
         if (contentBlock?.type === "thinking") {
-          const thinking =
-            managed && typeof contentBlock.thinking === "string" ? contentBlock.thinking : "";
+          const thinking = typeof contentBlock.thinking === "string" ? contentBlock.thinking : "";
           const block: AnthropicStreamBlock = {
             type: "thinking",
             thinking,
             thinkingSignature:
-              managed && typeof contentBlock.signature === "string" ? contentBlock.signature : "",
+              typeof contentBlock.signature === "string" ? contentBlock.signature : "",
             index,
           };
           output.content.push(block);
@@ -526,13 +525,10 @@ export async function consumeAnthropicStream(params: {
           delta?.type === "signature_delta" &&
           typeof delta.signature === "string"
         ) {
-          if (!managed) {
-            block.thinkingSignature = (block.thinkingSignature || "") + delta.signature;
-            continue;
-          }
           const signatureIndex = eventIndexKey(event.index);
           const pendingSignature = pendingThinkingSignatures.get(signatureIndex);
           if (pendingSignature === undefined) {
+            // The streamed signature replaces any seed from content_block_start.
             block.thinkingSignature = "";
             pendingThinkingSignatures.set(signatureIndex, delta.signature);
           } else {

--- a/packages/ai/test/fixtures/provider-transport-parity/anthropic-success.snap.txt
+++ b/packages/ai/test/fixtures/provider-transport-parity/anthropic-success.snap.txt
@@ -67,16 +67,26 @@
       {
         "type": "thinking_delta",
         "contentIndex": 0,
+        "delta": "seed"
+      },
+      {
+        "type": "thinking_delta",
+        "contentIndex": 0,
         "delta": " + thought"
       },
       {
         "type": "thinking_end",
         "contentIndex": 0,
-        "content": " + thought"
+        "content": "seed + thought"
       },
       {
         "type": "text_start",
         "contentIndex": 1
+      },
+      {
+        "type": "text_delta",
+        "contentIndex": 1,
+        "delta": "Hello"
       },
       {
         "type": "text_delta",
@@ -86,7 +96,7 @@
       {
         "type": "text_end",
         "contentIndex": 1,
-        "content": " world"
+        "content": "Hello world"
       },
       {
         "type": "done",
@@ -98,12 +108,12 @@
       "content": [
         {
           "type": "thinking",
-          "thinking": " + thought",
+          "thinking": "seed + thought",
           "thinkingSignature": "final-signature"
         },
         {
           "type": "text",
-          "text": " world"
+          "text": "Hello world"
         }
       ],
       "api": "anthropic-messages",


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can help update the branch.

</details>

## What Problem This Solves

Fixes an issue where developers consuming Anthropic streams through the standalone adapter received truncated or empty replies when the response included text or thinking in its initial stream events. A response starting with `Hello` and continuing with ` world` returned only ` world`.

## Why This Change Was Made

Both Anthropic adapters now preserve initial content through their shared stream reducer. They also share the completed-signature accumulation path: an initial signature survives when no replacement arrives, and streamed signature data replaces that initial value. Production code shrinks by four lines.

## User Impact

Standalone Anthropic consumers retain the complete streamed reply and thinking content, matching the managed adapter and native SDK. The usual empty-start sequence continues to work.

## Evidence

The two seeded regression cases failed before production changes; the empty-start control passed. After repair, both adapters matched the pinned Anthropic SDK 0.120.0 across three event sequences and nine real local HTTP requests. All 278 related tests passed, followed by a final 18-test parity run. The full package test typecheck, full-file lint, formatting, max-lines ratchet, and independent P2 review passed. Regression tests add 70 lines, and the corrected snapshot adds 10 net lines.

The HTTP proof uses synthetic local SSE responses. Current first-party frequency of nonempty block starts was not measured: request parameters cannot force whether Anthropic places content in a start event or a later delta, so a live smoke would not reliably exercise this case. The regression compares the actual native SDK parser and both adapters against seeded, seed-only, and empty-start sequences.
