### PR TITLE
refactor(time): isolate browser-safe duration parts

### DIFF
--- a/src/infra/format-time/duration-parts.ts
+++ b/src/infra/format-time/duration-parts.ts
@@ -1,0 +1,52 @@
+// Browser-safe duration quantities; formatting remains with each presentation owner.
+export const durationUnitMs = {
+  year: 31_536_000_000,
+  week: 604_800_000,
+  day: 86_400_000,
+  hour: 3_600_000,
+  minute: 60_000,
+  second: 1_000,
+  millisecond: 1,
+} as const;
+
+export type DurationPart = { value: number | bigint; unit: keyof typeof durationUnitMs };
+
+function resolveDurationParts(ms: number, unitCount: number, showYears = false): DurationPart[] {
+  const days = BigInt(Math.trunc(ms / durationUnitMs.day));
+  const parts: DurationPart[] = [
+    { value: showYears ? days / 365n : 0n, unit: "year" },
+    { value: showYears ? days % 365n : days, unit: "day" },
+    { value: Math.trunc((ms / durationUnitMs.hour) % 24), unit: "hour" },
+    { value: Math.trunc((ms / durationUnitMs.minute) % 60), unit: "minute" },
+    { value: Math.trunc((ms / durationUnitMs.second) % 60), unit: "second" },
+    // Large floats can retain a remainder after second-rounding; only subsecond input uses ms.
+    { value: ms < 1_000 ? Math.trunc(ms) : 0, unit: "millisecond" },
+  ];
+  // pretty-ms counts nonzero units, so an empty middle bucket must not hide the next one.
+  const selected = parts.filter(({ value }) => value !== 0 && value !== 0n).slice(0, unitCount);
+  return selected.length ? selected : [{ value: 0, unit: "millisecond" }];
+}
+
+export function resolveCompactDurationParts(ms?: number | null, showYears = false) {
+  if (ms == null || !Number.isFinite(ms) || ms <= 0) {
+    return undefined;
+  }
+  const roundedMs = Math.round(ms);
+  return resolveDurationParts(
+    roundedMs < 1_000 ? roundedMs : Math.round(ms / 1_000) * 1_000,
+    2,
+    showYears,
+  );
+}
+
+export function resolveSingleUnitDurationParts(ms: number): DurationPart[] {
+  let scale: number = durationUnitMs.millisecond;
+  for (const unit of ["second", "minute", "hour", "day"] as const) {
+    const nextScale = durationUnitMs[unit];
+    if (Math.round(ms / scale) * scale < nextScale) {
+      break;
+    }
+    scale = nextScale;
+  }
+  return resolveDurationParts(Math.round(ms / scale) * scale, 1);
+}

--- a/src/infra/format-time/format-duration-exact.ts
+++ b/src/infra/format-time/format-duration-exact.ts
@@ -1,4 +1,4 @@
-import { durationUnitMs, type DurationPart } from "./format-duration-internal.js";
+import { durationUnitMs, type DurationPart } from "./duration-parts.js";
 
 // Exact display stays outside startup formatting; health uses weeks, cron uses days.
 export function resolveExactDurationParts(ms?: number | null, showWeeks = false) {

--- a/src/infra/format-time/format-duration-internal.ts
+++ b/src/infra/format-time/format-duration-internal.ts
@@ -1,32 +1,9 @@
 import prettyMilliseconds from "pretty-ms";
-
-export const durationUnitMs = {
-  year: 31_536_000_000,
-  week: 604_800_000,
-  day: 86_400_000,
-  hour: 3_600_000,
-  minute: 60_000,
-  second: 1_000,
-  millisecond: 1,
-} as const;
-
-export type DurationPart = { value: number | bigint; unit: keyof typeof durationUnitMs };
-
-function resolveDurationParts(ms: number, unitCount: number, showYears = false): DurationPart[] {
-  const days = BigInt(Math.trunc(ms / durationUnitMs.day));
-  const parts: DurationPart[] = [
-    { value: showYears ? days / 365n : 0n, unit: "year" },
-    { value: showYears ? days % 365n : days, unit: "day" },
-    { value: Math.trunc((ms / durationUnitMs.hour) % 24), unit: "hour" },
-    { value: Math.trunc((ms / durationUnitMs.minute) % 60), unit: "minute" },
-    { value: Math.trunc((ms / durationUnitMs.second) % 60), unit: "second" },
-    // Large floats can retain a remainder after second-rounding; only subsecond input uses ms.
-    { value: ms < 1_000 ? Math.trunc(ms) : 0, unit: "millisecond" },
-  ];
-  // pretty-ms counts nonzero units, so an empty middle bucket must not hide the next one.
-  const selected = parts.filter(({ value }) => value !== 0 && value !== 0n).slice(0, unitCount);
-  return selected.length ? selected : [{ value: 0, unit: "millisecond" }];
-}
+import {
+  durationUnitMs,
+  resolveSingleUnitDurationParts,
+  type DurationPart,
+} from "./duration-parts.js";
 
 export function formatDurationParts(parts: DurationPart[], verbose = false): string {
   return parts
@@ -38,30 +15,6 @@ export function formatDurationParts(parts: DurationPart[], verbose = false): str
       }),
     )
     .join(" ");
-}
-
-export function resolveCompactDurationParts(ms?: number | null, showYears = false) {
-  if (ms == null || !Number.isFinite(ms) || ms <= 0) {
-    return undefined;
-  }
-  const roundedMs = Math.round(ms);
-  return resolveDurationParts(
-    roundedMs < 1_000 ? roundedMs : Math.round(ms / 1_000) * 1_000,
-    2,
-    showYears,
-  );
-}
-
-export function resolveSingleUnitDurationParts(ms: number): DurationPart[] {
-  let scale: number = durationUnitMs.millisecond;
-  for (const unit of ["second", "minute", "hour", "day"] as const) {
-    const nextScale = durationUnitMs[unit];
-    if (Math.round(ms / scale) * scale < nextScale) {
-      break;
-    }
-    scale = nextScale;
-  }
-  return resolveDurationParts(Math.round(ms / scale) * scale, 1);
 }
 
 /** Keep single-unit rounding identical for compact and verbose core displays. */

--- a/src/infra/format-time/format-duration.ts
+++ b/src/infra/format-time/format-duration.ts
@@ -1,11 +1,8 @@
 // Duration formatting helpers produce compact, precise, and human display
 // strings from millisecond values.
 import prettyMilliseconds from "pretty-ms";
-import {
-  formatDurationParts,
-  formatSingleUnitDuration,
-  resolveCompactDurationParts,
-} from "./format-duration-internal.js";
+import { resolveCompactDurationParts } from "./duration-parts.js";
+import { formatDurationParts, formatSingleUnitDuration } from "./format-duration-internal.js";
 
 export type FormatDurationSecondsOptions = {
   decimals?: number;

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -10,7 +10,7 @@ import {
   resolveCompactDurationParts,
   resolveSingleUnitDurationParts,
   type DurationPart,
-} from "../../../src/infra/format-time/format-duration-internal.ts";
+} from "../../../src/infra/format-time/duration-parts.ts";
 import { i18n, t } from "../i18n/index.ts";
 import { formatUiError } from "./format-error.ts";
 


### PR DESCRIPTION
## What Problem This Solves

Pure duration quantities currently share a module with the `pretty-ms` presentation adapter. A browser-safe owner is needed before consolidating Workboard's separate duration decomposition through a supported plugin contract.

## Why This Change Was Made

The existing constants, types, and resolver bodies move unchanged into `src/infra/format-time/duration-parts.ts`. Core formatters and the Dashboard import that owner; `pretty-ms` remains in the formatting adapter. This is the bounded preparatory part of the duration consolidation.

## User Impact

None intended. Existing duration strings and arithmetic are unchanged. Workboard's adjacent-unit behavior and the chat recap formatter remain unchanged. No SDK export, configuration, dependency, schema or protocol change.

## Evidence

- `node scripts/run-vitest.mjs src/infra/format-time extensions/workboard/browser/lib ui/src/lib/format`: 433 tests passed across eight files and three shards in 26.20s.
- Moved arithmetic blocks are byte-identical to their original implementations.
- Autoreview: P0-P2 scoped-clean, zero findings.
- `node scripts/check-changed.mjs --base abc35e08c1a2efd29f356354b7fa0d8374429889`: passed.
- `pnpm ui:build` and `pnpm ui:check-performance`: passed; startup JS 346,454 / 350,953 B gzip with 8 / 18 requests; CSS 43,989 / 51,200 B. Baseline unchanged.
- Full root/package build and full Workboard/SDK integration were not run or implemented for this preparatory draft.
- Production +61/-59 (net +2); no test changes. The small growth is import wiring for the browser-safe owner.

## NEEDS-MAINTAINER-DECISION

Keep this PR as a draft. A focused supported duration SDK entrypoint would increase the verified public entrypoint count from 152 to 153 against the existing cap of 152 in `scripts/plugin-sdk-surface-report.mts`. This lane has no authority to raise that ratchet. The existing `time-runtime` and `number-runtime` seams are private-local; `time-runtime` also imports Node-dependent filesystem code. A maintainer must choose the supported browser-safe duration contract and allocate its API budget before Workboard integration can proceed.

Workboard must retain its adjacent-unit cutoff: 3,630,000 ms displays as `1h`, while core/UI display `1h 30s`; 86,460,000 ms stays `1d`, versus `1d 1m`. It also decomposes rounded seconds through nested division, whereas core uses direct millisecond division and BigInt days. Those arithmetic differences must remain explicit in any shared resolver.

The chat recap loop in `chat-working-indicator.ts` requires body changes owned by lane L10; L09 is permitted only one import-line edit there, which cannot remove that loop. No chat page was edited. Full Workboard/SDK integration is not implemented in this draft.
