### PR TITLE
perf(plugins): speed up tool preparation with installed plugins

### DIFF
--- a/src/plugins/installed-plugin-index.compat.test.ts
+++ b/src/plugins/installed-plugin-index.compat.test.ts
@@ -6,7 +6,11 @@ import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js
 import { clearBundledDiscoveryModeMemo } from "./bundled-discovery-state.js";
 import type { PluginCandidate } from "./discovery.js";
 import { refreshPersistedInstalledPluginIndex } from "./installed-plugin-index-store-write.js";
-import { isInstalledPluginEnabled, loadInstalledPluginIndex } from "./installed-plugin-index.js";
+import {
+  createInstalledPluginEnabledPredicate,
+  isInstalledPluginEnabled,
+  loadInstalledPluginIndex,
+} from "./installed-plugin-index.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
@@ -101,6 +105,36 @@ describe("bundled provider compatibility in installed plugin indexes", () => {
         env,
       ),
     ).toBe(false);
+  });
+
+  it("keeps bundled compatibility separate from external policy in each batch", () => {
+    const { candidate, env } = createFixture();
+    const config = { plugins: { allow: ["listed"] } };
+    setMode(env, "compat");
+    const index = loadInstalledPluginIndex({ candidates: [candidate], config, env });
+    const plugins = [
+      ...index.plugins,
+      ...index.plugins.map((record) =>
+        Object.assign({}, record, {
+          pluginId: "external-tool",
+          origin: "global" as const,
+        }),
+      ),
+    ];
+    const compatible = createInstalledPluginEnabledPredicate(plugins, config, env);
+    expect(compatible("external-tool")).toBe(false);
+    expect(compatible(PLUGIN_ID)).toBe(true);
+    expect(compatible("external-tool")).toBe(false);
+
+    config.plugins.allow.push("external-tool");
+    const reconfigured = createInstalledPluginEnabledPredicate(plugins, config, env);
+    expect(reconfigured("external-tool")).toBe(true);
+    expect(reconfigured(PLUGIN_ID)).toBe(true);
+
+    setMode(env, "allowlist");
+    const strict = createInstalledPluginEnabledPredicate(plugins, config, env);
+    expect(strict(PLUGIN_ID)).toBe(false);
+    expect(strict("external-tool")).toBe(true);
   });
 
   it("refreshes persisted contract-only provider policy without rebuilding source records", async () => {

--- a/src/plugins/manifest-contract-eligibility.test.ts
+++ b/src/plugins/manifest-contract-eligibility.test.ts
@@ -38,6 +38,8 @@ let isManifestPluginAvailableForControlPlane: typeof import("./manifest-contract
 let listAvailableManifestContractValues: typeof import("./manifest-contract-eligibility.js").listAvailableManifestContractValues;
 let loadManifestContractSnapshot: typeof import("./manifest-contract-eligibility.js").loadManifestContractSnapshot;
 let clearPluginMetadataLifecycleCaches: typeof import("./plugin-metadata-lifecycle.js").clearPluginMetadataLifecycleCaches;
+let makePluginMetadataIndex: typeof import("./current-plugin-metadata.test-support.js").makePluginMetadataIndex;
+let createInstalledPluginEnabledPredicate: typeof import("./installed-plugin-index.js").createInstalledPluginEnabledPredicate;
 
 beforeAll(async () => {
   // The plugins project shares module state across files. Rebind this module graph
@@ -49,6 +51,8 @@ beforeAll(async () => {
     loadManifestContractSnapshot,
   } = await import("./manifest-contract-eligibility.js"));
   ({ clearPluginMetadataLifecycleCaches } = await import("./plugin-metadata-lifecycle.js"));
+  ({ makePluginMetadataIndex } = await import("./current-plugin-metadata.test-support.js"));
+  ({ createInstalledPluginEnabledPredicate } = await import("./installed-plugin-index.js"));
 });
 
 describe("bundled manifest contract availability", () => {
@@ -276,6 +280,118 @@ describe("bundled manifest contract availability", () => {
         config: { plugins: { allow: ["another-plugin"] } },
       }),
     ).toEqual([]);
+  });
+});
+
+describe("prepared installed-plugin eligibility", () => {
+  it("normalizes installed policy once for a batch of manifest checks", () => {
+    const ids = Array.from({ length: 8 }, (_, index) => `external-${index}`);
+    const index = makePluginMetadataIndex();
+    index.plugins = ids.flatMap((id) => makePluginMetadataIndex(id).plugins);
+    let enumerations = 0;
+    const entries = new Proxy(Object.fromEntries(ids.map((id) => [id, { enabled: true }])), {
+      ownKeys(target) {
+        enumerations += 1;
+        return Reflect.ownKeys(target);
+      },
+    });
+    const config = { plugins: { entries } };
+    const normalizedConfig = normalizePluginsConfig(config.plugins);
+    enumerations = 0;
+    const isInstalledPluginEnabled = createInstalledPluginEnabledPredicate(index.plugins, config);
+    expect(
+      ids.map((id) =>
+        isManifestPluginAvailableForControlPlane({
+          snapshot: { index },
+          plugin: { id, origin: "global" },
+          config,
+          normalizedConfig,
+          isInstalledPluginEnabled,
+        }),
+      ),
+    ).toEqual(ids.map(() => true));
+    expect(enumerations).toBe(1);
+  });
+
+  it.each([
+    { config: undefined, expected: [true, true, true, false, false, false] },
+    { config: {}, expected: [true, true, false, true, false, false] },
+    {
+      config: { plugins: { enabled: false } },
+      expected: [true, false, false, false, false, false],
+    },
+    {
+      config: { plugins: { allow: ["global", "workspace", "duplicate"] } },
+      expected: [false, true, true, false, true, false],
+    },
+    {
+      config: {
+        plugins: {
+          allow: ["global", "workspace", "duplicate"],
+          deny: ["workspace"],
+          entries: { global: { enabled: false } },
+        },
+      },
+      expected: [false, false, false, false, true, false],
+    },
+  ])("preserves policy and first-record selection for $config", ({ config, expected }) => {
+    const index = makePluginMetadataIndex();
+    index.plugins = [
+      ...makePluginMetadataIndex("provider").plugins.map((record) =>
+        Object.assign({}, record, {
+          origin: "bundled" as const,
+          enabledByDefault: true,
+          contributions: {
+            channels: [],
+            channelConfigs: [],
+            providers: ["provider"],
+            modelCatalogProviders: [],
+            modelSupportPrefixes: [],
+            modelSupportPatterns: [],
+            autoEnableProviderIds: [],
+            commandAliases: [],
+            contracts: {},
+          },
+        }),
+      ),
+      ...makePluginMetadataIndex("global").plugins,
+      ...makePluginMetadataIndex("workspace").plugins.map((record) =>
+        Object.assign({}, record, {
+          origin: "workspace" as const,
+        }),
+      ),
+      ...makePluginMetadataIndex("disabled").plugins.map((record) =>
+        Object.assign({}, record, {
+          enabled: false,
+        }),
+      ),
+      ...makePluginMetadataIndex("duplicate").plugins.map((record) =>
+        Object.assign({}, record, {
+          origin: "workspace" as const,
+          enabled: false,
+        }),
+      ),
+      ...makePluginMetadataIndex("duplicate").plugins,
+    ];
+    const plugins = index.plugins.slice(0, 5).map((record) => ({
+      id: record.pluginId,
+      origin: record.origin,
+    }));
+    plugins.push({ id: "missing", origin: "global" });
+    const isInstalledPluginEnabled = createInstalledPluginEnabledPredicate(index.plugins, config);
+    const params = {
+      snapshot: { index },
+      config,
+      normalizedConfig: normalizePluginsConfig(config?.plugins),
+    };
+    expect(
+      plugins.map((plugin) => isManifestPluginAvailableForControlPlane({ ...params, plugin })),
+    ).toEqual(expected);
+    expect(
+      plugins.map((plugin) =>
+        isManifestPluginAvailableForControlPlane({ ...params, plugin, isInstalledPluginEnabled }),
+      ),
+    ).toEqual(expected);
   });
 });
 

--- a/src/plugins/manifest-contract-eligibility.ts
+++ b/src/plugins/manifest-contract-eligibility.ts
@@ -76,12 +76,17 @@ export function isManifestPluginAvailableForControlPlane(params: {
   allowRestrictiveAllowlistBypass?: boolean;
   allowBundledProviderCompat?: boolean;
   env?: NodeJS.ProcessEnv;
+  /** Batch callers prepare installed enablement for this same config and operation. */
+  isInstalledPluginEnabled?: (pluginId: string) => boolean;
 }): boolean {
   if (!isManifestPluginOwnerAllowedByControlPlanePolicy(params)) {
     return false;
   }
   if (params.plugin.origin === "bundled") {
     return true;
+  }
+  if (params.isInstalledPluginEnabled) {
+    return params.isInstalledPluginEnabled(params.plugin.id);
   }
   return isInstalledPluginEnabled(
     params.snapshot.index,

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -18,6 +18,7 @@ import {
   registrationIncludesHostRestrictedConversationReadTool,
 } from "./compat/conversation-read-tools.js";
 import { applyTestPluginDefaults, normalizePluginsConfig } from "./config-state.js";
+import { createInstalledPluginEnabledPredicate } from "./installed-plugin-index.js";
 import { loadPluginRegistryHandle, type PluginLoadOptions } from "./loader.js";
 import {
   isManifestPluginAvailableForControlPlane,
@@ -548,6 +549,10 @@ function resolvePluginToolRuntimePluginIds(params: {
       workspaceDir: params.workspaceDir,
       env: params.env,
     });
+  const isInstalledPluginEnabled = createInstalledPluginEnabledPredicate(
+    snapshot.index.plugins,
+    params.config,
+  );
   for (const plugin of snapshot.plugins) {
     if (
       !isManifestPluginAvailableForControlPlane({
@@ -555,6 +560,7 @@ function resolvePluginToolRuntimePluginIds(params: {
         plugin,
         config: params.config,
         normalizedConfig: normalizedPlugins,
+        isInstalledPluginEnabled,
       })
     ) {
       continue;
@@ -666,7 +672,6 @@ function resolvePluginToolLoadState(params: {
       loadOptions: PluginLoadOptions;
       onlyPluginIds: string[];
       allowlist: PluginToolAllowlist;
-      runtimeOptions: PluginLoadOptions["runtimeOptions"];
       snapshot: PluginMetadataManifestView;
     }
   | undefined {
@@ -715,7 +720,7 @@ function resolvePluginToolLoadState(params: {
     onlyPluginIds,
     runtimeOptions,
   });
-  return { context, env, loadOptions, onlyPluginIds, allowlist, runtimeOptions, snapshot };
+  return { context, env, loadOptions, onlyPluginIds, allowlist, snapshot };
 }
 
 export function ensureStandalonePluginToolRegistryLoaded(params: {
@@ -759,7 +764,7 @@ export function resolvePluginTools(params: {
   if (!loadState) {
     return [];
   }
-  const { context, env, onlyPluginIds, allowlist, runtimeOptions, snapshot } = loadState;
+  const { context, env, onlyPluginIds, allowlist, loadOptions, snapshot } = loadState;
   const tools: AnyAgentTool[] = [];
   const existing = params.existingToolNames ?? new Set<string>();
   const existingNormalized = new Set(Array.from(existing, (tool) => normalizeToolPolicyName(tool)));
@@ -776,12 +781,6 @@ export function resolvePluginTools(params: {
   if (onlyPluginIds.length === 0) {
     return tools;
   }
-  const loadOptions = buildPluginRuntimeLoadOptions(context, {
-    activate: false,
-    toolDiscovery: true,
-    onlyPluginIds,
-    runtimeOptions,
-  });
   const registry = resolvePluginToolRegistry({
     loadOptions,
     onlyPluginIds,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where preparing agent tools repeats a full plugin configuration scan for every installed plugin. With many installed tool plugins, this adds avoidable work to each turn even when their runtime registry is already prepared.

## Why This Change Was Made

Reuse the existing installed-plugin eligibility predicate for one synchronous tool selection, carrying it through the existing manifest eligibility check. Owner policy and bundled-plugin behavior still take precedence, and each new selection prepares fresh policy. Also carry forward the already-built loader options instead of constructing them twice.

This extends the operation-owned preparation introduced in #137128 to tool selection. No cross-turn cache, configuration, database, dependency or public plugin API change. Production net +4 lines.

## User Impact

Lower tool-preparation overhead when multiple installed plugins contribute tools. Plugin enablement, trust, tool availability, factory context and execution remain unchanged.

## Evidence

- The new regression fails on the original source: eight configuration scans instead of one. Existing behavior controls pass.
- Focused eligibility, tool-resolution and real SQLite compatibility tests pass. The full four-file changed gate and independent P2 review passed.
- Actual native CommonJS plugin loader and tool execution on Linux Node 24.19.0, using 100 generated no-op plugins and A/B/B/A order: 40 warm observations per variant measured baseline medians 2.39/2.30 ms versus 0.84/0.77 ms. Configuration scans fell from 101 to 2. Both variants selected all 100 tools, and disabling/re-enabling one plugin produced 99 then 100 tools.
- Independent macOS Node 26.8.1 comparison also improved. These synthetic measurements establish the removed repeated work, not a claim to resolve unrelated production stalls.

The first full local gate caught an incomplete contribution type in the new test fixture. The fixture now supplies the required fields and uses the required nonmutating clone style; no type or lint checks were weakened. The Linux proof used identical production bytes before that test-only correction and additional compatibility coverage.
