### PR TITLE
perf(node): serialize duplex frames at the transport boundary

### DIFF
--- a/src/gateway/node-claude-skill-runtime.test.ts
+++ b/src/gateway/node-claude-skill-runtime.test.ts
@@ -194,7 +194,8 @@ async function fixture(
         const request = await decodeClaudeCliNodeRunParams(frame.paramsJSON);
         let seq = 0;
         endpoint = createNodeDuplexEndpoint({
-          sendFrame: (text) => {
+          sendFrame: (payload) => {
+            const text = JSON.stringify(payload);
             expect(Buffer.byteLength(text)).toBeLessThanOrEqual(16 * 1024);
             progress(text, seq++);
           },

--- a/src/gateway/node-claude-skill-runtime.ts
+++ b/src/gateway/node-claude-skill-runtime.ts
@@ -238,7 +238,7 @@ export async function invokeNodeClaudeSkillRuntime(params: {
     maxMessageBytes: NODE_CLAUDE_SKILLS_MESSAGE_BYTES,
     sendFrame(frame) {
       assertCurrent();
-      registry.sendInvokeInput(invokeId!, JSON.parse(frame));
+      registry.sendInvokeInput(invokeId!, frame);
     },
     onReady() {
       assertCurrent();

--- a/src/gateway/server-plugins-node-runtime.ts
+++ b/src/gateway/server-plugins-node-runtime.ts
@@ -82,7 +82,7 @@ export async function openGatewayNodeDuplex(options: {
       if (!invokeId || !framedReady) {
         throw new Error("Node duplex command is not ready for binary messages.");
       }
-      context.nodeRegistry.sendInvokeInput(invokeId, JSON.parse(frame));
+      context.nodeRegistry.sendInvokeInput(invokeId, frame);
     },
     onReady() {
       if (!invokeId) {

--- a/src/infra/node-duplex-framing.test.ts
+++ b/src/infra/node-duplex-framing.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { createNodeDuplexEndpoint } from "./node-duplex-framing.js";
 
 const FRAGMENT_BYTES = 8 * 1024;
@@ -27,14 +28,16 @@ describe("node duplex message framing", () => {
     const rightMessages: Uint8Array[] = [];
     const left = createNodeDuplexEndpoint({
       sendFrame(frame) {
-        outboundFrames.push(frame);
-        right.receive(frame);
+        const serialized = JSON.stringify(frame);
+        outboundFrames.push(serialized);
+        right.receive(serialized);
       },
     });
     const right = createNodeDuplexEndpoint({
       sendFrame(frame) {
-        inboundFrames.push(frame);
-        left.receive(frame);
+        const serialized = JSON.stringify(frame);
+        inboundFrames.push(serialized);
+        left.receive(serialized);
       },
     });
     left.onMessage((message) => {
@@ -73,13 +76,36 @@ describe("node duplex message framing", () => {
     const sender = createNodeDuplexEndpoint({
       async sendFrame(frame) {
         await Promise.resolve();
-        receiver.receive(frame);
+        receiver.receive(JSON.stringify(frame));
       },
     });
 
     await Promise.all([sender.send(first), sender.send(second)]);
 
     expect(received).toEqual([first, second]);
+  });
+
+  it("snapshots each fragment before its transport serializes it", async () => {
+    const entered = createDeferred();
+    const released = createDeferred();
+    const received = vi.fn();
+    const receiver = createNodeDuplexEndpoint({ sendFrame: () => {} });
+    receiver.onMessage(received);
+    const sender = createNodeDuplexEndpoint({
+      async sendFrame(frame) {
+        entered.resolve();
+        await released.promise;
+        receiver.receive(JSON.stringify(frame));
+      },
+    });
+    const input = Uint8Array.of(1, 2, 3);
+    const pending = sender.send(input);
+    await entered.promise;
+    input.fill(9);
+    released.resolve();
+    await pending;
+
+    expect(received).toHaveBeenCalledExactlyOnceWith(Uint8Array.of(1, 2, 3));
   });
 
   it("serializes framed readiness ahead of a concurrent message", async () => {
@@ -94,7 +120,7 @@ describe("node duplex message framing", () => {
     const sender = createNodeDuplexEndpoint({
       async sendFrame(frame) {
         await Promise.resolve();
-        receiver.receive(frame);
+        receiver.receive(JSON.stringify(frame));
       },
     });
 
@@ -127,7 +153,9 @@ describe("node duplex message framing", () => {
     receiver.onMessage((message) => {
       received.push(message);
     });
-    const sender = createNodeDuplexEndpoint({ sendFrame: (frame) => receiver.receive(frame) });
+    const sender = createNodeDuplexEndpoint({
+      sendFrame: (frame) => receiver.receive(JSON.stringify(frame)),
+    });
 
     await sender.send(new Uint8Array());
     await sender.send(Uint8Array.of(7));
@@ -227,7 +255,7 @@ describe("node duplex message framing", () => {
     const bytesError = vi.fn();
     const bytesBounded = createNodeDuplexEndpoint({ sendFrame: () => {}, onError: bytesError });
     const sender = createNodeDuplexEndpoint({
-      sendFrame: (frame) => bytesBounded.receive(frame),
+      sendFrame: (frame) => bytesBounded.receive(JSON.stringify(frame)),
     });
     await sender.send(new Uint8Array(600_000));
     await expect(sender.send(new Uint8Array(600_000))).rejects.toThrow(/pending/i);
@@ -254,7 +282,9 @@ describe("node duplex message framing", () => {
     const received = vi.fn();
     const receiver = createNodeDuplexEndpoint({ sendFrame: () => {} });
     receiver.onMessage(received);
-    const sender = createNodeDuplexEndpoint({ sendFrame: (frame) => receiver.receive(frame) });
+    const sender = createNodeDuplexEndpoint({
+      sendFrame: (frame) => receiver.receive(JSON.stringify(frame)),
+    });
     const message = new Uint8Array(1024 * 1024 + 1);
 
     await sender.send(message);
@@ -461,7 +491,7 @@ describe("node duplex message framing", () => {
       return deliveriesFinished;
     });
     const sender = createNodeDuplexEndpoint({
-      sendFrame: (frame) => receiver.receive(frame),
+      sendFrame: (frame) => receiver.receive(JSON.stringify(frame)),
       maxMessageBytes,
       maxOutstandingDeliveryBytes,
     });

--- a/src/infra/node-duplex-framing.ts
+++ b/src/infra/node-duplex-framing.ts
@@ -7,9 +7,14 @@ const NODE_DUPLEX_MAX_MESSAGE_BYTES = 100 * 1024 * 1024;
 const MAX_PENDING_MESSAGES = 8;
 const MAX_PENDING_BYTES = 1024 * 1024;
 
+type NodeDuplexFrame = Readonly<
+  | { v: 1; kind: "ready" }
+  | { v: 1; kind: "data"; message: number; index: number; last: boolean; data: string }
+>;
+
 /** Owns ordered, bounded binary messages carried by existing node-invoke string frames. */
 export function createNodeDuplexEndpoint(options: {
-  sendFrame: (frame: string) => Promise<void> | void;
+  sendFrame: (frame: NodeDuplexFrame) => Promise<void> | void;
   onReady?: () => void;
   onError?: (error: Error) => void;
   requireReady?: boolean;
@@ -160,18 +165,16 @@ export function createNodeDuplexEndpoint(options: {
           assertOpen();
           const start = index * NODE_DUPLEX_FRAGMENT_BYTES;
           const fragment = message.subarray(start, start + NODE_DUPLEX_FRAGMENT_BYTES);
-          await options.sendFrame(
-            JSON.stringify({
-              v: 1,
-              kind: "data",
-              message: messageId,
-              index,
-              last: index === fragments - 1,
-              data: Buffer.from(fragment.buffer, fragment.byteOffset, fragment.byteLength).toString(
-                "base64",
-              ),
-            }),
-          );
+          await options.sendFrame({
+            v: 1,
+            kind: "data",
+            message: messageId,
+            index,
+            last: index === fragments - 1,
+            data: Buffer.from(fragment.buffer, fragment.byteOffset, fragment.byteLength).toString(
+              "base64",
+            ),
+          });
           assertOpen();
         }
       });
@@ -184,7 +187,7 @@ export function createNodeDuplexEndpoint(options: {
           throw new Error("node duplex framed readiness is duplicate or out of order");
         }
         ready.sent = true;
-        await options.sendFrame(JSON.stringify({ v: 1, kind: "ready" }));
+        await options.sendFrame({ v: 1, kind: "ready" });
         assertOpen();
       });
     },

--- a/src/node-host/runtime.test.ts
+++ b/src/node-host/runtime.test.ts
@@ -549,14 +549,9 @@ describe("node-host invoke input dispatch", () => {
 
       await vi.waitFor(() => expect(mocks.progressWrite).toHaveBeenCalledTimes(2));
       expect(received).toHaveBeenCalledWith(Uint8Array.from([0, 255, 1]));
-      expect(JSON.parse(mocks.progressWrite.mock.calls[1]?.[0] ?? "null")).toMatchObject({
-        v: 1,
-        kind: "data",
-        message: 0,
-        index: 0,
-        last: true,
-        data: "AP8B",
-      });
+      expect(mocks.progressWrite.mock.calls[1]?.[0]).toBe(
+        '{"v":1,"kind":"data","message":0,"index":0,"last":true,"data":"AP8B"}',
+      );
     } finally {
       held.release();
       await invoking;

--- a/src/node-host/runtime.ts
+++ b/src/node-host/runtime.ts
@@ -590,7 +590,7 @@ export async function prepareNodeHostRuntime(params?: {
             input && progress
               ? createNodeDuplexEndpoint({
                   ...(claudeSkills ? { maxMessageBytes: NODE_CLAUDE_SKILLS_MESSAGE_BYTES } : {}),
-                  sendFrame: async (payloadJSON) => await progress.write(payloadJSON),
+                  sendFrame: async (payload) => await progress.write(JSON.stringify(payload)),
                   onError: (error) => {
                     active.framedFailure = error;
                     controller.abort(error);


### PR DESCRIPTION
Closes #140826

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Each Gateway-to-node duplex fragment is serialized by the private endpoint, immediately parsed by its adapter, and serialized again by the registry. The intermediate text and object provide no value.

## Why This Change Was Made

Pass a fresh typed ready/data frame to the three private callbacks. Gateway adapters pass it to the unchanged registry owner; node-host serializes at its progress writer. Base64 is still encoded before the transport await, and receiving validation is unchanged.

## User Impact

Twelve actual adapter/registry wire/error cases remain identical, including both directions, exact property order, sliced inputs, authority loss and socket closure. For an 8 MiB outbound message, frame calls fall from 2,048 stringify plus 1,024 parse to 1,024 stringify and zero parse; the return direction is unchanged.

In the local synthetic-node adapter/registry fixture, median processing changes from 8.327 to 3.531 ms and sampled cumulative JavaScript allocation falls by about 22.2 MB per send. This is cumulative temporary allocation, not another retained 8 MiB message, native memory, RSS or remote execution/download speed. Large-message incidence is unknown and small samples fluctuate.

## Evidence

- 353 focused tests, complete changed-file checks and fresh P2 review passed on all seven files.
- The new delayed-serialization test preserves per-fragment byte snapshots; the real node-host runtime test asserts exact wire JSON. Readiness, ordering, queue bounds and cancellation controls remain.
- Actual openGatewayNodeDuplex and NodeRegistry use normal invocation/progress APIs with a synthetic socket. No private pending-state seeding or mocked registry send method is used.
- Production net +3 lines and tests net +26. No import, public API, protocol, configuration or persistent-state change; no extra full build required or claimed.

Related #135475 and #126961 remain credited for distinct prior work. Active #135599 adds independent plugin lifecycle authority and cancellation checks that must be preserved if it lands first.
