### PR TITLE
refactor(models): share bounded edit-distance calculation

### DIFF
--- a/src/auto-reply/reply/model-selection-directive.ts
+++ b/src/auto-reply/reply/model-selection-directive.ts
@@ -1,6 +1,5 @@
 // Normalizes model selection directives into provider and model ids.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { modelKey } from "../../agents/model-ref-shared.js";
 import {
@@ -12,6 +11,7 @@ import {
   type ModelVisibilityPolicy,
 } from "../../agents/model-visibility-policy.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { levenshteinDistance } from "../../shared/levenshtein-distance.js";
 export { modelKey };
 export type { ModelAliasIndex };
 
@@ -54,61 +54,6 @@ const FUZZY_VARIANT_TOKENS = [
   "small",
   "nano",
 ];
-
-function boundedLevenshteinDistance(a: string, b: string, maxDistance: number): number | null {
-  if (a === b) {
-    return 0;
-  }
-  if (!a || !b) {
-    return null;
-  }
-  const aLen = a.length;
-  const bLen = b.length;
-  if (Math.abs(aLen - bLen) > maxDistance) {
-    return null;
-  }
-
-  // Standard DP with early exit. Reuse fixed-size numeric buffers so fuzzy
-  // matching large model catalogs does not allocate a row per candidate.
-  const prev = new Uint32Array(bLen + 1);
-  const curr = new Uint32Array(bLen + 1);
-  for (let index = 0; index <= bLen; index += 1) {
-    prev[index] = index;
-  }
-
-  for (let i = 1; i <= aLen; i++) {
-    curr[0] = i;
-    let rowMin = expectDefined(curr[0], "curr entry at 0");
-
-    const aChar = a.charCodeAt(i - 1);
-    for (let j = 1; j <= bLen; j++) {
-      const cost = aChar === b.charCodeAt(j - 1) ? 0 : 1;
-      const distance = Math.min(
-        expectDefined(prev[j], "prev entry at j") + 1,
-        expectDefined(curr[j - 1], "curr entry at j 1") + 1,
-        expectDefined(prev[j - 1], "prev entry at j 1") + cost,
-      );
-      curr[j] = distance;
-      if (distance < rowMin) {
-        rowMin = distance;
-      }
-    }
-
-    if (rowMin > maxDistance) {
-      return null;
-    }
-
-    for (let j = 0; j <= bLen; j++) {
-      prev[j] = expectDefined(curr[j], "model selection directive edit-distance row");
-    }
-  }
-
-  const dist = expectDefined(prev[bLen], "prev entry at b len");
-  if (dist > maxDistance) {
-    return null;
-  }
-  return dist;
-}
 
 function scoreFuzzyMatch(params: {
   provider: string;
@@ -168,7 +113,7 @@ function scoreFuzzyMatch(params: {
 
   // Best-effort typo tolerance for common near-misses like "claud" vs "claude".
   // Bounded to keep this cheap across large model sets.
-  const distModel = boundedLevenshteinDistance(fragment, modelLower, 3);
+  const distModel = levenshteinDistance(fragment, modelLower, 3);
   if (distModel != null) {
     score += (3 - distModel) * 70;
   }

--- a/src/shared/levenshtein-distance.test.ts
+++ b/src/shared/levenshtein-distance.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { levenshteinDistance } from "./levenshtein-distance.js";
+
+describe("levenshteinDistance", () => {
+  it.each([
+    ["", "", 0],
+    ["", "abc", 3],
+    ["abc", "", 3],
+    ["kitten", "sitting", 3],
+    ["ab", "ba", 2],
+    ["😀", "😃", 1],
+    ["😀", "a", 2],
+  ] as const)("keeps the full UTF-16 distance from %j to %j", (left, right, expected) => {
+    const distance: number = levenshteinDistance(left, right);
+    expect(distance).toBe(expected);
+  });
+
+  it.each([
+    ["", "", 0, 0],
+    ["same", "same", 0, 0],
+    ["", "abc", 3, null],
+    ["abc", "", 3, null],
+    ["a", "abcde", 3, null],
+    ["kitten", "sitting", 3, 3],
+    ["kitten", "sitting", 2, null],
+    ["ab", "ba", 1, null],
+    ["😀", "😃", 1, 1],
+    ["😀", "a", 1, null],
+  ] as const)("bounds the distance from %j to %j at %i", (left, right, bound, expected) => {
+    expect(levenshteinDistance(left, right, bound)).toBe(expected);
+  });
+});

--- a/src/shared/levenshtein-distance.ts
+++ b/src/shared/levenshtein-distance.ts
@@ -1,13 +1,24 @@
 import { expectDefined } from "@openclaw/normalization-core";
-export function levenshteinDistance(left: string, right: string): number {
+
+export function levenshteinDistance(left: string, right: string): number;
+export function levenshteinDistance(
+  left: string,
+  right: string,
+  maxDistance: number,
+): number | null;
+export function levenshteinDistance(
+  left: string,
+  right: string,
+  maxDistance?: number,
+): number | null {
   if (left === right) {
     return 0;
   }
-  if (!left) {
-    return right.length;
+  if (!left || !right) {
+    return maxDistance === undefined ? left.length + right.length : null;
   }
-  if (!right) {
-    return left.length;
+  if (maxDistance !== undefined && Math.abs(left.length - right.length) > maxDistance) {
+    return null;
   }
 
   let previous = new Uint32Array(right.length + 1);
@@ -17,17 +28,29 @@ export function levenshteinDistance(left: string, right: string): number {
   }
   for (let leftIndex = 0; leftIndex < left.length; leftIndex += 1) {
     current[0] = leftIndex + 1;
+    const leftCode = left.charCodeAt(leftIndex);
     for (let rightIndex = 0; rightIndex < right.length; rightIndex += 1) {
-      const cost = left[leftIndex] === right[rightIndex] ? 0 : 1;
+      const cost = leftCode === right.charCodeAt(rightIndex) ? 0 : 1;
       current[rightIndex + 1] = Math.min(
         expectDefined(current[rightIndex], "current entry at right index") + 1,
         expectDefined(previous[rightIndex + 1], "previous entry at right index + 1") + 1,
         expectDefined(previous[rightIndex], "previous entry at right index") + cost,
       );
     }
+    // Keep cutoff work outside the inner loop used by full-distance callers.
+    if (maxDistance !== undefined) {
+      let rowMin = Number.POSITIVE_INFINITY;
+      for (const distance of current) {
+        rowMin = Math.min(rowMin, distance);
+      }
+      if (rowMin > maxDistance) {
+        return null;
+      }
+    }
     const nextPrevious = current;
     current = previous;
     previous = nextPrevious;
   }
-  return expectDefined(previous[right.length], "previous entry at right.length");
+  const distance = expectDefined(previous[right.length], "previous entry at right.length");
+  return maxDistance !== undefined && distance > maxDistance ? null : distance;
 }


### PR DESCRIPTION
Closes #140828

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Model suggestions duplicate a bounded edit-distance algorithm already owned by the shared core utility. Keeping two kernels makes identical contracts harder to maintain.

## Why This Change Was Made

Delete the model-local implementation and add a bounded overload to the shared helper. Preserve its two-argument numeric API; bounded equality, empty inputs, cutoffs and UTF-16 semantics stay identical. Reuse row buffers by swapping them and keep cutoff work outside the full-distance inner loop.

## User Impact

Model ranking and complete selection results are unchanged. Production shrinks by 32 lines and independent shared contract tests add 32 lines. This is code consolidation with an explicit performance tradeoff.

Local full-distance controls were 11–16% faster. Prepared model selection at 1,024 candidates was 16% slower, about 0.27 ms per call; the 128-candidate case was 4.6% slower and the eight-candidate case 2.9% faster. These warm host observations do not establish a selector speedup, memory reduction or provider/Gateway throughput gain.

## Evidence

- 65,025 original/candidate kernel observations preserve omitted, negative, zero, fractional, infinite and NaN bounds plus isolated UTF-16 surrogates. Thirty-six complete actual-selector results match.
- 113 focused tests across nine files, full changed-file validation and final isolated P2 review passed on the exact R2 source. Broader unselected tests in three large sibling suites are not claimed as run.
- The shared test protects full numeric return and exact cutoff behavior independently of selector scoring, where distance three otherwise gives no bonus.
- No new module wrapper, configuration, dependency, persistence or security-policy change. No full build is selected for this existing core-helper boundary.

The separate security-owned implementation is unchanged. Active #133633 and #130706 concern independent model normalization/catalog behavior and must be preserved if they land first.
