### PR TITLE
fix: preserve Markdown formatting in HTML export lists

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -202,6 +202,9 @@ plugins.
     Explicit `/export-session` paths replace existing files inside the
     workspace. Omit the path to generate a collision-safe filename.
 
+    HTML exports preserve inline Markdown formatting in list items, including
+    bold text, links, and inline code.
+
     HTML conversation cards omit messages marked hidden. The sidebar's **All**
     filter includes these records with a **[hidden]** label for debugging.
     Message counts describe the raw archive. The HTML file and its JSONL download

--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -1886,9 +1886,9 @@
         }
         return `<pre><code class="hljs">${highlighted}</code></pre>`;
       },
-      // Text content: escape HTML tags
+      // Delegate nested inline tokens; leaf text keeps the existing escaping.
       text(token) {
-        return escapeHtmlTags(escapeHtml(token.text));
+        return token.tokens ? false : escapeHtmlTags(escapeHtml(token.text));
       },
       // Inline code: escape HTML
       codespan(token) {

--- a/src/auto-reply/reply/export-html/template.security.test.ts
+++ b/src/auto-reply/reply/export-html/template.security.test.ts
@@ -407,6 +407,66 @@ describe("export html security hardening", () => {
     expect(code.textContent).toContain("answer = true");
   });
 
+  it.each(["user", "assistant"] as const)(
+    "renders tight-list inline formatting in %s transcript exports",
+    async (role) => {
+      const inline =
+        "**Important**: read [the guide](https://example.test/guide) and use `config.json`.";
+      const literal = "**literal** [not a link](https://example.test/literal)";
+      const session: SessionData = {
+        header: { id: "session-tight-list", timestamp: now() },
+        entries: [
+          {
+            id: "tight-list",
+            parentId: null,
+            timestamp: now(),
+            type: "message",
+            message: {
+              role,
+              content: [
+                `Paragraph control: ${inline}`,
+                "",
+                `- ${inline}`,
+                "- Plain item.",
+                "",
+                "`" + literal + "`",
+              ].join("\n"),
+            },
+          },
+        ],
+        leafId: "tight-list",
+        systemPrompt: "",
+        tools: [],
+      };
+
+      const { document } = await renderTemplate(session);
+      const entry = requireElement(document.getElementById("entry-tight-list"), "entry missing");
+      const paragraph = requireElement(entry.querySelector("p"), "paragraph control missing");
+      expect(paragraph.querySelector("strong")?.textContent).toBe("Important");
+      expect(paragraph.querySelector("a")?.getAttribute("href")).toBe("https://example.test/guide");
+      expect(paragraph.querySelector("code")?.textContent).toBe("config.json");
+
+      const list = requireElement(entry.querySelector("ul"), "tight list missing");
+      expect(list.querySelectorAll("li")).toHaveLength(2);
+      const item = requireElement(list.querySelector("li"), "list item missing");
+      expect(item.querySelector("strong")?.textContent).toBe("Important");
+      const link = requireElement(item.querySelector("a"), "list link missing");
+      expect(link.getAttribute("href")).toBe("https://example.test/guide");
+      expect(link.textContent).toBe("the guide");
+      expect(item.querySelector("code")?.textContent).toBe("config.json");
+      expect(item.textContent?.trim()).toBe("Important: read the guide and use config.json.");
+
+      const literalParagraph = requireElement(
+        Array.from(entry.querySelectorAll("p")).find(
+          (candidate) => candidate.querySelector("code")?.textContent === literal,
+        ) ?? null,
+        "literal code control missing",
+      );
+      expect(literalParagraph.textContent).toBe(literal);
+      expect(literalParagraph.querySelector("a, strong")).toBeNull();
+    },
+  );
+
   it("escapes tree and header metadata fields", async () => {
     const attack = "<img src=x onerror=alert(9)>";
     const baseEntries: SessionEntry[] = [


### PR DESCRIPTION
Closes #140785.

## What Problem This Solves

Fixes an issue where users exporting a session to HTML would see literal Markdown inside tight lists, even though the same bold text, link, and inline code rendered correctly in a paragraph.

## Why This Change Was Made

The shared export renderer treated composite Marked text tokens as leaves. It now delegates tokens with inline children through Marked 18.0.11's existing renderer contract. Leaf escaping and the code, raw-HTML, image, link, and URL-validation hooks keep their existing implementations. This restores the canonical traversal without adding a parser, dependency, configuration option, or stored state.

Production: **+2/-2, net zero**. Tests: **+60**. Docs: **+3**.

## User Impact

`/export-session` and `/export` preserve bold text, authored links, and inline code in list items for both user and assistant messages. Markdown inside literal inline code stays literal.

## Evidence

- The same composed template corpus produced two intended failures and 20 passing controls before the repair, then **22/22 passing tests** afterward. It uses the real template and generated pinned vendor assets; existing escaping, link, image, and hidden-message controls pass.
- The complete three-file changed check passed in **1107.3 seconds**, including typechecking, lint, and repository guards. Independent managed review completed one full pass with **zero P0–P2 findings**.
- Normal `pnpm build` passed in **624.6 seconds**. Full source inventories matched before/after; the generated export template equals the repaired source.
- Real isolated Gateway → canonical synthetic assistant injection → normal gateway-mode TUI `/export tight-list-proof.html` → actual HTML in Chromium passed before and after. Both runs received the persisted export acknowledgement, exported one entry, preserved paragraph/plain-list/literal-code controls, and completed TUI/browser/session/Gateway cleanup without forced termination. Source, dependencies, and complete build inventories verified before and after each run. Screenshots and recordings were inspected.

Validation ran against the final working diff, which matches committed `d3ff01fd12d446b63c57a0cd30ca6eda1bb7dd1d` byte-for-byte. The live case is an injected assistant export, not a model inference run; both roles are covered by the source regression. The leaf-only hook is also present in `v2026.9.2` source; its introducing commit is not attributed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34085309057) passed: 77 jobs succeeded and 16 inapplicable jobs were skipped.

Before — list syntax remains literal:

![Before: actual HTML export leaves list Markdown literal](https://github.com/user-attachments/assets/d87267fb-6253-4b03-b0d0-4d8256108382)

After — list formatting matches the paragraph:

![After: actual HTML export preserves list bold, link, and code](https://github.com/user-attachments/assets/065b6e21-e09c-4436-81b8-3dc223986916)

<details>
<summary>Proof harness recovery</summary>

Earlier attempts are retained as failed evidence: one stopped at a Git preflight timeout; another completed the export but exceeded teardown while its observer repeatedly spawned per-PID process queries. The accepted runs use a single-inventory observer with fresh identity checks before signals and unchanged product assertions and shutdown limits. Both accepted runs exited normally with no survivors or open listener.

</details>
