### PR TITLE
fix: identify embedded stage timing log emitters

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -327,6 +327,11 @@ logs each completed slow stage immediately, including failures, and emits a
 `native-turn-handoff` summary before submitting the native turn. Timing records
 contain stage names and identifiers, not prompts or tool arguments.
 
+Embedded-run startup, prep, core-plugin-tool and auth stage summaries include
+`pid`, `threadId` and `isMainThread` in the message to distinguish emitters sharing
+a log file. These identify the summary emitter, not where every timed operation
+ran. Elapsed stage time can include asynchronous waits and is not CPU time.
+
 Use the first `turn_accepted`, `model_call_started`, `tool_execution_started`, and
 `assistant_output_started` milestones to separate startup from later activity.
 Delayed first assistant/tool activity is logged once at `info` by default,

--- a/src/agents/embedded-agent-runner/run/attempt-stage-timing.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stage-timing.test.ts
@@ -1,4 +1,5 @@
 // Coverage for embedded attempt startup stage timing diagnostics.
+import { isMainThread, threadId } from "node:worker_threads";
 import { describe, expect, it } from "vitest";
 import {
   createEmbeddedRunStageTracker,
@@ -67,7 +68,7 @@ describe("embedded run stage timing", () => {
         ],
       }),
     ).toBe(
-      "embedded run startup stages: runId=r1 totalMs=80 stages=workspace:25ms@25ms,tools:55ms@80ms",
+      `embedded run startup stages: runId=r1 pid=${process.pid} threadId=${threadId} isMainThread=${isMainThread} totalMs=80 stages=workspace:25ms@25ms,tools:55ms@80ms`,
     );
   });
 
@@ -86,7 +87,7 @@ describe("embedded run stage timing", () => {
     tracker.mark("runtime-plugins");
 
     expect(formatEmbeddedRunStageSummary("startup", tracker.snapshot())).toBe(
-      "startup totalMs=21 stages=workspace:2ms@2ms,harness-selection:5ms@7ms,prepared-runtime:11ms@18ms,runtime-context:3ms@21ms,runtime-plugins:0ms@21ms",
+      `startup pid=${process.pid} threadId=${threadId} isMainThread=${isMainThread} totalMs=21 stages=workspace:2ms@2ms,harness-selection:5ms@7ms,prepared-runtime:11ms@18ms,runtime-context:3ms@21ms,runtime-plugins:0ms@21ms`,
     );
   });
 
@@ -106,7 +107,7 @@ describe("embedded run stage timing", () => {
     tracker.mark(EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE.dispatch);
 
     expect(formatEmbeddedRunStageSummary("startup", tracker.snapshot())).toBe(
-      "startup totalMs=91 stages=attempt-workspace:10ms@10ms,attempt-prompt:30ms@40ms,attempt-runtime-plan:50ms@90ms,attempt-dispatch:1ms@91ms",
+      `startup pid=${process.pid} threadId=${threadId} isMainThread=${isMainThread} totalMs=91 stages=attempt-workspace:10ms@10ms,attempt-prompt:30ms@40ms,attempt-runtime-plan:50ms@90ms,attempt-dispatch:1ms@91ms`,
     );
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-stage-timing.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stage-timing.ts
@@ -1,3 +1,4 @@
+import { isMainThread, threadId } from "node:worker_threads";
 import {
   createStageTimingTracker,
   formatStageTimings,
@@ -91,5 +92,5 @@ export function formatEmbeddedRunStageSummary(
   summary: EmbeddedRunStageSummary,
 ): string {
   const stages = formatStageTimings(summary.stages);
-  return `${prefix} totalMs=${summary.totalMs} stages=${stages}`;
+  return `${prefix} pid=${process.pid} threadId=${threadId} isMainThread=${isMainThread} totalMs=${summary.totalMs} stages=${stages}`;
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators reading shared logs could not identify the process and thread that emitted an embedded-run stage timing summary.

## Why This Change Was Made

The existing embedded summary formatter now records the emitter's `pid`, `threadId` and `isMainThread`. This covers startup, prep, core-plugin-tool and auth summaries without changing their timing, warning thresholds or event count. The generic SDK timing helper stays unchanged.

## User Impact

Operators can distinguish emitters sharing a log file. The logging guide explains that these fields identify the summary emitter: elapsed stages can include asynchronous waits and do not establish where every operation ran or how much CPU it used.

## Evidence

- Before the change, the three updated formatter expectations failed while the three existing duration/threshold controls passed.
- A native Node 26.7 baseline used the actual subsystem logger and one shared JSONL file from a true main thread and a joined Worker. All six trace/warning records lacked the emitter tuple; their levels, stage text and quiet control matched the contract.
- Candidate: all six native main/Worker log records include the correct tuple; all 16 focused/sibling tests and the full changed-scope gate pass. Every managed child/group/output is joined. The committed tree exactly matches the tested source carrier.
- Independent Codex review through P2 found no actionable findings. Production delta: +1 line.

The proof uses synthetic identifiers and a controlled clock; it makes no startup-speed or CPU-blocking claim.
