### PR TITLE
fix(gateway): preserve paragraph boundaries in streamed replies

### DIFF
--- a/src/gateway/agent-event-assistant-text.ts
+++ b/src/gateway/agent-event-assistant-text.ts
@@ -78,6 +78,16 @@ export function resolveAssistantTextInput(data: unknown): AssistantTextInput | u
   };
 }
 
+/** Paragraph separator owed between a retained item prefix and the next item's text. */
+function missingItemBoundarySeparator(previousText: string, nextText: string): string {
+  if (!previousText || !nextText) {
+    return "";
+  }
+  const trailing = previousText.slice(-2).match(/\n*$/u)?.[0].length ?? 0;
+  const leading = nextText.slice(0, 2).match(/^\n*/u)?.[0].length ?? 0;
+  return "\n".repeat(Math.max(0, 2 - trailing - leading));
+}
+
 /** Merge item snapshots without imposing a transport's display or wire limit. */
 export function mergeAssistantText(
   previous: AssistantTextSnapshot,
@@ -93,11 +103,17 @@ export function mergeAssistantText(
           // Only provisional stream replacements discard earlier items.
           prefix: input.replace && input.replaceable ? "" : previous.text,
         };
+  // Distinct items are separate messages; keep their paragraph boundary.
+  const startsNewItem = scope !== undefined && scope !== previous.scope;
   let text: string;
   if (scope && input.text !== undefined) {
-    text = scope.prefix + input.text;
+    text = scope.prefix + missingItemBoundarySeparator(scope.prefix, input.text) + input.text;
   } else if (input.text === undefined) {
-    text = previous.text + (input.delta ?? "");
+    const delta = input.delta ?? "";
+    text =
+      previous.text +
+      (startsNewItem ? missingItemBoundarySeparator(previous.text, delta) : "") +
+      delta;
   } else if (unkeyed === "append-only") {
     // Legacy HTTP snapshots recover held prefixes; non-prefix input remains
     // incremental unless its producer explicitly marks a replacement.

--- a/src/gateway/agent-event-assistant-text.ts
+++ b/src/gateway/agent-event-assistant-text.ts
@@ -11,7 +11,12 @@ type AssistantTextInput = {
 
 export type AssistantTextSnapshot = {
   text: string;
-  scope?: { itemId: string; prefix: string };
+  scope?: {
+    itemId: string;
+    prefix: string;
+    boundaryNewlines: number;
+    separatorLength: number;
+  };
 };
 
 /** A text-bearing empty result clears output; a missing text payload does not. */
@@ -78,42 +83,47 @@ export function resolveAssistantTextInput(data: unknown): AssistantTextInput | u
   };
 }
 
-/** Paragraph separator owed between a retained item prefix and the next item's text. */
-function missingItemBoundarySeparator(previousText: string, nextText: string): string {
-  if (!previousText || !nextText) {
-    return "";
-  }
-  const trailing = previousText.slice(-2).match(/\n*$/u)?.[0].length ?? 0;
-  const leading = nextText.slice(0, 2).match(/^\n*/u)?.[0].length ?? 0;
-  return "\n".repeat(Math.max(0, 2 - trailing - leading));
-}
-
 /** Merge item snapshots without imposing a transport's display or wire limit. */
 export function mergeAssistantText(
   previous: AssistantTextSnapshot,
   input: AssistantTextInput,
   unkeyed: "live" | "append-only",
 ): AssistantTextSnapshot {
-  const scope = !input.itemId
-    ? undefined
-    : previous.scope?.itemId === input.itemId
-      ? previous.scope
-      : {
-          itemId: input.itemId,
-          // Only provisional stream replacements discard earlier items.
-          prefix: input.replace && input.replaceable ? "" : previous.text,
-        };
-  // Distinct items are separate messages; keep their paragraph boundary.
-  const startsNewItem = scope !== undefined && scope !== previous.scope;
+  let scope = previous.scope;
+  if (!input.itemId) {
+    scope = undefined;
+  } else if (scope?.itemId !== input.itemId) {
+    // Only provisional stream replacements discard earlier items.
+    const prefix = input.replace && input.replaceable ? "" : previous.text;
+    scope = {
+      itemId: input.itemId,
+      prefix,
+      boundaryNewlines: !prefix || prefix.endsWith("\n\n") ? 0 : prefix.endsWith("\n") ? 1 : 2,
+      separatorLength: 0,
+    };
+  }
   let text: string;
-  if (scope && input.text !== undefined) {
-    text = scope.prefix + missingItemBoundarySeparator(scope.prefix, input.text) + input.text;
+  if (scope) {
+    // Inserted padding is not provider text. Keep it out of later item deltas
+    // so a matching cumulative snapshot cannot retract a streamed newline.
+    const itemText =
+      input.text ??
+      (scope === previous.scope
+        ? previous.text.slice(scope.prefix.length + scope.separatorLength)
+        : "") + (input.delta ?? "");
+    const leadingNewlines = itemText.startsWith("\n\n") ? 2 : itemText.startsWith("\n") ? 1 : 0;
+    if (!scope.prefix) {
+      // Once the display cap retires the prior item, only surviving padding
+      // and the current snapshot's own newlines can retain its boundary.
+      scope.boundaryNewlines = Math.min(
+        scope.boundaryNewlines,
+        scope.separatorLength + leadingNewlines,
+      );
+    }
+    scope.separatorLength = itemText ? Math.max(0, scope.boundaryNewlines - leadingNewlines) : 0;
+    text = scope.prefix + "\n".repeat(scope.separatorLength) + itemText;
   } else if (input.text === undefined) {
-    const delta = input.delta ?? "";
-    text =
-      previous.text +
-      (startsNewItem ? missingItemBoundarySeparator(previous.text, delta) : "") +
-      delta;
+    text = previous.text + (input.delta ?? "");
   } else if (unkeyed === "append-only") {
     // Legacy HTTP snapshots recover held prefixes; non-prefix input remains
     // incremental unless its producer explicitly marks a replacement.

--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -56,7 +56,7 @@ function createOps(params: {
   Object.assign(chatRunState.getOrCreate(runId), {
     ...(buffer !== undefined ? { buffer, deltaLastBroadcastText: buffer } : {}),
     deltaSentAt: Date.now(),
-    assistantScope: { itemId: "assistant-1", prefix: "" },
+    assistantScope: { itemId: "assistant-1", prefix: "", boundaryNewlines: 0, separatorLength: 0 },
     agentText: {
       assistant: {
         lastSentAt: Date.now(),

--- a/src/gateway/live-chat-projector.ts
+++ b/src/gateway/live-chat-projector.ts
@@ -27,7 +27,16 @@ export function capLiveAssistantText(snapshot: AssistantTextSnapshot): string {
       ? sliceUtf16Safe(text, -MAX_LIVE_CHAT_BUFFER_CHARS)
       : text;
   if (scope) {
-    scope.prefix = sliceUtf16Safe(scope.prefix, text.length - capped.length);
+    const retired = text.length - capped.length;
+    const retiredAfterPrefix = Math.max(0, retired - scope.prefix.length);
+    // Retire padding with its prefix, including a cap that cuts through the
+    // separator. Later deltas must not recreate or consume those newlines.
+    scope.boundaryNewlines =
+      retiredAfterPrefix > scope.separatorLength
+        ? 0
+        : Math.max(0, scope.boundaryNewlines - retiredAfterPrefix);
+    scope.separatorLength = Math.max(0, scope.separatorLength - retiredAfterPrefix);
+    scope.prefix = sliceUtf16Safe(scope.prefix, retired);
   }
   return capped;
 }

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2513,7 +2513,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         { itemId: "answer-1", text: "Echo", delta: "Echo" },
         { itemId: "answer-2", text: "Echo", delta: "Echo" },
       ],
-      expected: "EchoEcho",
+      expected: "Echo\n\nEcho",
       resultTexts: ["Echo", "Echo"],
     },
     {
@@ -2525,7 +2525,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         { itemId: "answer-2", text: "Echo", delta: "Echo" },
         { itemId: "answer-2", text: "Echo!", delta: "!" },
       ],
-      expected: "EchoEcho!",
+      expected: "Echo\n\nEcho!",
     },
     {
       name: "repeated delta-only text within an assistant item",
@@ -2541,7 +2541,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         { itemId: "answer-1", text: "x".repeat(500_001), delta: "x".repeat(500_001) },
         { itemId: "answer-2", text: "tail", delta: "tail" },
       ],
-      expected: `${"x".repeat(500_001)}tail`,
+      expected: `${"x".repeat(500_001)}\n\ntail`,
     },
   ])(
     "preserves $name in official SDK assistant streams",

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2536,6 +2536,26 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       expected: "EchoEcho",
     },
     {
+      name: "split leading newlines followed by the matching item snapshot",
+      events: [
+        { itemId: "answer-1", text: "First." },
+        { itemId: "answer-2", delta: "\n" },
+        { itemId: "answer-2", delta: "\nSecond." },
+        { itemId: "answer-2", text: "\n\nSecond." },
+      ],
+      expected: "First.\n\nSecond.",
+    },
+    {
+      name: "an empty new item followed by deltas and a matching snapshot",
+      events: [
+        { itemId: "answer-1", text: "First." },
+        { itemId: "answer-2", delta: "" },
+        { itemId: "answer-2", delta: "Second." },
+        { itemId: "answer-2", text: "Second." },
+      ],
+      expected: "First.\n\nSecond.",
+    },
+    {
       name: "text beyond the live display cap",
       events: [
         { itemId: "answer-1", text: "x".repeat(500_001), delta: "x".repeat(500_001) },

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -457,7 +457,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
         { itemId: "answer-1", text: "Echo", delta: "Echo" },
         { itemId: "answer-2", text: "Echo", delta: "Echo" },
       ],
-      expected: "EchoEcho",
+      expected: "Echo\n\nEcho",
       resultTexts: ["Echo", "Echo"],
     },
     {
@@ -469,7 +469,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
         { itemId: "answer-2", text: "Echo", delta: "Echo" },
         { itemId: "answer-2", text: "Echo!", delta: "!" },
       ],
-      expected: "EchoEcho!",
+      expected: "Echo\n\nEcho!",
     },
     {
       name: "repeated delta-only text within an assistant item",
@@ -485,7 +485,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
         { itemId: "answer-1", text: "x".repeat(500_001), delta: "x".repeat(500_001) },
         { itemId: "answer-2", text: "tail", delta: "tail" },
       ],
-      expected: `${"x".repeat(500_001)}tail`,
+      expected: `${"x".repeat(500_001)}\n\ntail`,
     },
   ])(
     "preserves $name in official SDK assistant streams",

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -480,6 +480,26 @@ describe("OpenResponses HTTP API (e2e)", () => {
       expected: "EchoEcho",
     },
     {
+      name: "split leading newlines followed by the matching item snapshot",
+      events: [
+        { itemId: "answer-1", text: "First." },
+        { itemId: "answer-2", delta: "\n" },
+        { itemId: "answer-2", delta: "\nSecond." },
+        { itemId: "answer-2", text: "\n\nSecond." },
+      ],
+      expected: "First.\n\nSecond.",
+    },
+    {
+      name: "an empty new item followed by deltas and a matching snapshot",
+      events: [
+        { itemId: "answer-1", text: "First." },
+        { itemId: "answer-2", delta: "" },
+        { itemId: "answer-2", delta: "Second." },
+        { itemId: "answer-2", text: "Second." },
+      ],
+      expected: "First.\n\nSecond.",
+    },
+    {
       name: "text beyond the live display cap",
       events: [
         { itemId: "answer-1", text: "x".repeat(500_001), delta: "x".repeat(500_001) },
@@ -521,6 +541,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
         deltas: expected,
         outputText: expected,
       });
+      expect(response.status).toBe("completed");
     },
   );
 

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -2,6 +2,7 @@ import type { AgentPlanStep } from "../channels/streaming.js";
 // Gateway chat run state registries.
 // Tracks active runs, delta buffers, tool recipients, and session subscribers.
 import type { AgentEventPayload } from "../infra/agent-events.js";
+import type { AssistantTextSnapshot } from "./agent-event-assistant-text.js";
 import type { ChatCanvasBlock } from "./chat-display-projection.canvas.js";
 import {
   normalizeLiveAssistantBufferedText,
@@ -115,7 +116,7 @@ type ChatRunRecord = {
   /** Last time any buffered assistant text changed, including suppressed raw buffers. */
   bufferUpdatedAt?: number;
   deltaSentAt?: number;
-  assistantScope?: { itemId: string; prefix: string };
+  assistantScope?: AssistantTextSnapshot["scope"];
   managedMediaUrls?: Set<string>;
   deltaLastBroadcastText?: string;
   agentText?: Partial<

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2903,20 +2903,20 @@ describe("agent event handler", () => {
   });
 
   it.each([
-    { itemId: "message-2", text: "Hello", flags: {}, expected: "HelloHello" },
-    { itemId: "message-2", text: "Hi", flags: { replace: true }, expected: "HelloHi" },
-    { itemId: "message-2", text: "Hi", flags: { replaceable: true }, expected: "HelloHi" },
+    { itemId: "message-2", text: "Hello", flags: {}, expected: "Hello\n\nHello" },
+    { itemId: "message-2", text: "Hi", flags: { replace: true }, expected: "Hello\n\nHi" },
+    { itemId: "message-2", text: "Hi", flags: { replaceable: true }, expected: "Hello\n\nHi" },
     {
       itemId: "message-2",
       text: "Hi",
       flags: { replace: true, replaceable: true },
       expected: "Hi",
     },
-    { itemId: "message-1", text: "Hi", flags: { replace: true }, expected: "EarlierHi" },
+    { itemId: "message-1", text: "Hi", flags: { replace: true }, expected: "Earlier\n\nHi" },
     { itemId: "message-1", text: "", flags: { replace: true }, expected: "Earlier" },
     { itemId: "message-1", text: "", flags: {}, expected: "Earlier" },
-    { itemId: "message-1", flags: { delta: "Hello" }, expected: "EarlierHelloHello" },
-    { itemId: "message-2", flags: { delta: "Hello" }, expected: "HelloHello" },
+    { itemId: "message-1", flags: { delta: "Hello" }, expected: "Earlier\n\nHelloHello" },
+    { itemId: "message-2", flags: { delta: "Hello" }, expected: "Hello\n\nHello" },
   ])(
     "keeps item ownership across $itemId correction $text",
     ({ itemId, text, flags, expected }) => {

--- a/src/gateway/server-chat.stream-text-merge.test.ts
+++ b/src/gateway/server-chat.stream-text-merge.test.ts
@@ -86,14 +86,15 @@ describe("server chat stream text merge", () => {
   });
 
   it("does not resurrect a discarded scoped prefix after a shorter correction", () => {
-    const snapshot = "y".repeat(LIVE_CHAT_BUFFER_CHARS - 5);
+    // The item boundary owes a paragraph separator, so the snapshot leaves room for it.
+    const snapshot = "y".repeat(LIVE_CHAT_BUFFER_CHARS - 6);
     const merged = mergeAssistantText(
       { text: "x🚀keep" },
       { itemId: "answer", text: snapshot, delta: snapshot },
       "live",
     );
     const capped = capLiveAssistantText(merged);
-    expect(capped).toBe(`keep${snapshot}`);
+    expect(capped).toBe(`keep\n\n${snapshot}`);
     expect(
       capLiveAssistantText(
         mergeAssistantText(
@@ -102,7 +103,67 @@ describe("server chat stream text merge", () => {
           "live",
         ),
       ),
-    ).toBe("keep!");
+    ).toBe("keep\n\n!");
+  });
+
+  it.each([
+    {
+      name: "no trailing newline",
+      prefix: "First.",
+      next: "Second.",
+      expected: "First.\n\nSecond.",
+    },
+    {
+      name: "one trailing newline",
+      prefix: "First.\n",
+      next: "Second.",
+      expected: "First.\n\nSecond.",
+    },
+    {
+      name: "paragraph break already present",
+      prefix: "First.\n\n",
+      next: "Second.",
+      expected: "First.\n\nSecond.",
+    },
+    {
+      name: "leading newlines on the next item",
+      prefix: "First.",
+      next: "\n\nSecond.",
+      expected: "First.\n\nSecond.",
+    },
+    {
+      name: "table as the next item",
+      prefix: "Intro line",
+      next: "| a | b |\n| - | - |",
+      expected: "Intro line\n\n| a | b |\n| - | - |",
+    },
+    { name: "empty prefix", prefix: "", next: "Second.", expected: "Second." },
+    { name: "empty next item", prefix: "First.", next: "", expected: "First." },
+  ])(
+    "keeps a paragraph boundary between distinct assistant items ($name)",
+    ({ prefix, next, expected }) => {
+      expect(
+        mergeAssistantText(
+          { text: prefix },
+          { itemId: "next-item", text: next, delta: next },
+          "live",
+        ).text,
+      ).toBe(expected);
+    },
+  );
+
+  it("owes the paragraph boundary to a new item that starts with a delta, not to its later deltas", () => {
+    const first = mergeAssistantText(
+      { text: "First." },
+      { itemId: "next-item", delta: "Sec" },
+      "live",
+    );
+    expect(first.text).toBe("First.\n\nSec");
+    const grown = mergeAssistantText(first, { itemId: "next-item", delta: "ond." }, "live");
+    expect(grown.text).toBe("First.\n\nSecond.");
+    expect(
+      mergeAssistantText(grown, { itemId: "next-item", text: "Second!", delta: "!" }, "live").text,
+    ).toBe("First.\n\nSecond!");
   });
 
   it("does not start the capped tail with the low half of a surrogate pair", () => {

--- a/src/gateway/server-chat.stream-text-merge.test.ts
+++ b/src/gateway/server-chat.stream-text-merge.test.ts
@@ -86,7 +86,6 @@ describe("server chat stream text merge", () => {
   });
 
   it("does not resurrect a discarded scoped prefix after a shorter correction", () => {
-    // The item boundary owes a paragraph separator, so the snapshot leaves room for it.
     const snapshot = "y".repeat(LIVE_CHAT_BUFFER_CHARS - 6);
     const merged = mergeAssistantText(
       { text: "x🚀keep" },
@@ -173,5 +172,54 @@ describe("server chat stream text merge", () => {
     );
 
     expect(result).toBe(safeTail);
+  });
+
+  it.each([
+    { leading: "", itemLength: LIVE_CHAT_BUFFER_CHARS - 1, corrected: "\n!" },
+    { leading: "", itemLength: LIVE_CHAT_BUFFER_CHARS, corrected: "!" },
+    { leading: "", itemLength: LIVE_CHAT_BUFFER_CHARS + 1, corrected: "!" },
+    { leading: "\n", itemLength: LIVE_CHAT_BUFFER_CHARS - 1, corrected: "\n!" },
+    { leading: "\n", itemLength: LIVE_CHAT_BUFFER_CHARS, corrected: "!" },
+    { leading: "\n\n", itemLength: LIVE_CHAT_BUFFER_CHARS, corrected: "!" },
+  ])(
+    "retains only the uncapped boundary for leading $leading and length $itemLength",
+    ({ leading, itemLength, corrected }) => {
+      const merged = mergeAssistantText(
+        { text: "First." },
+        { itemId: "answer", text: leading + "y".repeat(itemLength - leading.length) },
+        "live",
+      );
+      const capped = capLiveAssistantText(merged);
+      expect(capped).toHaveLength(LIVE_CHAT_BUFFER_CHARS);
+      const grown = mergeAssistantText(
+        { text: capped, scope: merged.scope },
+        { itemId: "answer", delta: "?" },
+        "live",
+      );
+      expect(grown.text).toBe(`${capped}?`);
+      const replacement = mergeAssistantText(grown, { itemId: "answer", text: "!" }, "live");
+      expect(replacement.text).toBe(corrected);
+      expect(mergeAssistantText(replacement, { itemId: "answer", delta: "?" }, "live").text).toBe(
+        `${corrected}?`,
+      );
+    },
+  );
+
+  it("recalculates padding when a current-item snapshot gains a leading newline", () => {
+    const previous = mergeAssistantText(
+      { text: "First." },
+      { itemId: "answer", text: "\nSecond." },
+      "live",
+    );
+    expect(previous.text).toBe("First.\n\nSecond.");
+    const corrected = mergeAssistantText(
+      previous,
+      { itemId: "answer", text: "\n\nSecond." },
+      "live",
+    );
+    expect(corrected.text).toBe("First.\n\nSecond.");
+    expect(mergeAssistantText(corrected, { itemId: "answer", delta: "!" }, "live").text).toBe(
+      "First.\n\nSecond.!",
+    );
   });
 });

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -1253,7 +1253,12 @@ describe("createGatewayCloseHandler", () => {
     const run = chatRunState.getOrCreate("run-1");
     run.buffer = "partial reply";
     run.deltaSentAt = Date.now();
-    run.assistantScope = { itemId: "assistant-1", prefix: "" };
+    run.assistantScope = {
+      itemId: "assistant-1",
+      prefix: "",
+      boundaryNewlines: 0,
+      separatorLength: 0,
+    };
     run.deltaLastBroadcastText = "par";
     run.agentText = {
       assistant: {

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -100,7 +100,7 @@ function seedStaleRunBuffers(deps: MaintenanceTimerDeps, runId: string): void {
     rawBuffer: "raw buffer",
     bufferUpdatedAt: staleRunTimestamp(),
     deltaSentAt: staleRunTimestamp(),
-    assistantScope: { itemId: "assistant-1", prefix: "" },
+    assistantScope: { itemId: "assistant-1", prefix: "", boundaryNewlines: 0, separatorLength: 0 },
     deltaLastBroadcastText: "buffer",
   });
 }
@@ -111,7 +111,7 @@ function expectStaleRunBuffersPresent(deps: MaintenanceTimerDeps, runId: string)
     rawBuffer: "raw buffer",
     bufferUpdatedAt: expect.any(Number),
     deltaSentAt: expect.any(Number),
-    assistantScope: { itemId: "assistant-1", prefix: "" },
+    assistantScope: { itemId: "assistant-1", prefix: "", boundaryNewlines: 0, separatorLength: 0 },
     deltaLastBroadcastText: "buffer",
   });
 }

--- a/src/gateway/worker-environments/live-chat.test.ts
+++ b/src/gateway/worker-environments/live-chat.test.ts
@@ -76,11 +76,26 @@ describe("worker live Gateway chat projection", () => {
   };
 
   it.each([
-    { prefix: "Before tool\n", final: "Revised", name: "corrected final" },
-    { prefix: "Before tool\n", final: "Draft", name: "shortened final" },
-    { prefix: "Before tool\n", final: "", name: "empty final after pre-tool text" },
-    { prefix: "", final: "", name: "empty final clears rendered draft" },
-  ])("projects a scoped worker $name", async ({ prefix, final }) => {
+    {
+      prefix: "Before tool\n",
+      final: "Revised",
+      expectedFinal: "Before tool\n\nRevised",
+      name: "corrected final",
+    },
+    {
+      prefix: "Before tool\n",
+      final: "Draft",
+      expectedFinal: "Before tool\n\nDraft",
+      name: "shortened final",
+    },
+    {
+      prefix: "Before tool\n",
+      final: "",
+      expectedFinal: "Before tool\n",
+      name: "empty final after pre-tool text",
+    },
+    { prefix: "", final: "", expectedFinal: "", name: "empty final clears rendered draft" },
+  ])("projects a scoped worker $name", async ({ prefix, final, expectedFinal }) => {
     const live = await liveProjection();
     if (prefix) {
       live.start();
@@ -94,13 +109,15 @@ describe("worker live Gateway chat projection", () => {
     }
     live.start();
     live.preview(message("Draft with stale suffix"));
-    await expectChatText(prefix + "Draft with stale suffix");
+    await expectChatText(
+      prefix ? "Before tool\n\nDraft with stale suffix" : "Draft with stale suffix",
+    );
     live.end(message(final));
     await live.finish();
-    await expectChatText(prefix + final);
+    await expectChatText(expectedFinal);
     expect(harness.chat.events.at(-1)).toMatchObject({
       state: "delta",
-      deltaText: prefix + final,
+      deltaText: expectedFinal,
       replace: true,
     });
   });
@@ -115,7 +132,7 @@ describe("worker live Gateway chat projection", () => {
         live.end(message(text));
       }
       await live.finish();
-      await expectChatText("Same" + second);
+      await expectChatText("Same\n\n" + second);
     },
   );
 
@@ -138,7 +155,7 @@ describe("worker live Gateway chat projection", () => {
       };
       if (phaseAt !== "explicit") {
         live.preview(message(commentary.text));
-        await expectChatText("Prior answer\nChecking...");
+        await expectChatText("Prior answer\n\nChecking...");
       }
       const authoritative = makeAgentAssistantMessage({
         content: phaseAt === "mixed" ? [commentary, final] : [commentary],
@@ -161,7 +178,7 @@ describe("worker live Gateway chat projection", () => {
       live.end(authoritative);
       live.end(authoritative);
       await live.finish();
-      await expectChatText("Prior answer\n" + (phaseAt === "mixed" ? "Answer" : ""));
+      await expectChatText(phaseAt === "mixed" ? "Prior answer\n\nAnswer" : "Prior answer\n");
     },
   );
 
@@ -174,7 +191,7 @@ describe("worker live Gateway chat projection", () => {
       live.preview(message("🚀".repeat(9_000) + suffix), 0, suffix ? suffix.slice(-1) : undefined);
     }
     live.end(message("🚀".repeat(9_000) + "ABC"));
-    const expected = "Before tool\n" + "🚀".repeat(1_023) + "…";
+    const expected = "Before tool\n\n" + "🚀".repeat(1_023) + "…";
     await expectChatText(expected);
     const snapshots = harness.requestParams("worker.live-event").flatMap((params) => {
       const { event } = params as WorkerLiveEventParams;
@@ -185,7 +202,7 @@ describe("worker live Gateway chat projection", () => {
     );
     expect(snapshots.every((snapshot) => !snapshot.text.includes("\uFFFD"))).toBe(true);
     live.end(message("Short"));
-    await expectChatText("Before tool\nShort");
+    await expectChatText("Before tool\n\nShort");
     await live.finish();
   });
 
@@ -238,11 +255,13 @@ describe("worker live Gateway chat projection", () => {
       live.start();
       live.end(message("x".repeat(16_000)));
     }
-    await expectChatText("x".repeat(500_000));
+    // The 31 paragraph separators leave 3,938 characters of the first item after capping.
+    const retainedPrefix = "x".repeat(3_938) + ("\n\n" + "x".repeat(16_000)).repeat(30);
+    await expectChatText(retainedPrefix + "\n\n" + "x".repeat(16_000));
     live.end(message("Short"));
-    await expectChatText("x".repeat(484_000) + "Short");
+    await expectChatText(retainedPrefix + "\n\nShort");
     live.end(message(""));
-    await expectChatText("x".repeat(484_000));
+    await expectChatText(retainedPrefix);
     await live.finish();
   });
 

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -3461,9 +3461,9 @@ describe("EmbeddedTuiBackend", () => {
       ],
       expectedDeltas: [
         { deltaText: "Echo", replace: undefined },
-        { deltaText: "Echo", replace: undefined },
+        { deltaText: "\n\nEcho", replace: undefined },
       ],
-      expectedText: "EchoEcho",
+      expectedText: "Echo\n\nEcho",
     },
     {
       name: "a new assistant item extending an earlier item's text",
@@ -3473,9 +3473,9 @@ describe("EmbeddedTuiBackend", () => {
       ],
       expectedDeltas: [
         { deltaText: "Echo", replace: undefined },
-        { deltaText: "Echo!", replace: undefined },
+        { deltaText: "\n\nEcho!", replace: undefined },
       ],
-      expectedText: "EchoEcho!",
+      expectedText: "Echo\n\nEcho!",
     },
     {
       name: "replayed and growing snapshots of one assistant item",
@@ -3500,9 +3500,9 @@ describe("EmbeddedTuiBackend", () => {
       expectedDeltas: [
         { deltaText: "Echo", replace: undefined },
         { deltaText: "Echo", replace: undefined },
-        { deltaText: "!", replace: undefined },
+        { deltaText: "\n\n!", replace: undefined },
       ],
-      expectedText: "EchoEcho!",
+      expectedText: "EchoEcho\n\n!",
     },
     {
       name: "empty corrections that remove only the current assistant item",
@@ -3513,7 +3513,7 @@ describe("EmbeddedTuiBackend", () => {
       ],
       expectedDeltas: [
         { deltaText: "Hello", replace: undefined },
-        { deltaText: " world", replace: undefined },
+        { deltaText: "\n\n world", replace: undefined },
         { deltaText: "Hello", replace: true },
       ],
       expectedText: "Hello",


### PR DESCRIPTION
## What Problem This Solves

When a tool-calling turn produces distinct assistant messages, public Gateway chat events and OpenAI-compatible HTTP streams join their text without a paragraph boundary. A second message starting with a list or table becomes part of the preceding paragraph in the combined text.

## Why This Change Was Made

The shared text merger now keeps inserted separator bytes separate from each item's text. Snapshots and deltas use the same boundary calculation, including an initially empty item. This fixes the reviewed split-newline case without retracting output already sent over HTTP. Display truncation also retires separator state so a later correction cannot recreate discarded padding.

## User Impact

Distinct assistant items keep their paragraph boundaries in public chat text, the embedded terminal backend, Chat Completions, and OpenResponses. Existing blank lines do not gain extra padding. Same-item updates, provisional replacement, legacy unkeyed streams, media handling, and terminal fallback retain their contracts.

The tested current WebChat already displayed separate paragraph, tool, and list blocks. That layout and transcript order remain correct. Its public combined text was still affected, including the final event.

## Evidence

- Baseline: `18f452584417a122747415fefc3089e296dc22cf`. Runtime/public proof: `adb13ba9a810357878b3829d50808c954b3f887e`. Current head `053b12bae1a4d1be0fcbacc16e1de18a34c498f3` adds only two test-file corrections; all production and fixture inputs are unchanged.
- A real isolated Gateway and bundled WebChat used a controlled Responses provider and an actual read tool. The same normal prompt produced distinct assistant items on both builds.
- Baseline public chat and both HTTP streams returned `First paragraph.- Second item\n- Third item`. Candidate live and final text is `First paragraph.\n\n- Second item\n- Third item`.
- All 12 candidate HTTP runs passed: list, table, trailing newlines, leading newlines, both edges, and split leading-newline provider deltas, through both endpoints. Each stream completed normally with consistent terminal text.
- The real producer normalizes edge whitespace. Separate official-SDK endpoint regressions cover raw delta-only events: all four new cases failed on the contributor patch and passed after repair.
- A display-limit correction also has a verified failing control and passing regression coverage. The original 713 focused Gateway, abort, and terminal tests passed. CI then identified omitted worker expectations and a shutdown fixture; both were corrected, and all 82 tests in those affected files passed. Formatting, syntax/boundary lint, source-size and assertion checks passed.
- An optional fresh-session browser probe hit an auxiliary title-request limitation in the controlled provider and was stopped. It is excluded from the successful proof claims; its failure is retained with the full evidence.

Complete private traffic, provider requests, inspected screenshots, command logs, and review history are retained. No claim is made that the baseline browser layout was broken or that its final event repaired the missing boundary.
