### PR TITLE
fix(ui): keep pre-final assistant text visible after a completed turn

### DIFF
--- a/ui/src/pages/chat/chat-thread-grouping.test.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.test.ts
@@ -188,7 +188,7 @@ describe("cached group content classification", () => {
     },
   );
 
-  it("keeps media visible and folds commentary after the same message changes in place", () => {
+  it("keeps media visible and folds text-less activity after the same message changes in place", () => {
     const content: Record<string, unknown>[] = [
       { type: "image", url: "https://example.com/diagram.png" },
     ];
@@ -222,7 +222,7 @@ describe("cached group content classification", () => {
       { kind: "group", role: "assistant" },
     ]);
 
-    preview.content.splice(0, 1, { type: "text", text: "Preparing a diagram" });
+    preview.content.splice(0, 1, { type: "thinking", thinking: "Preparing a diagram" });
 
     expect(project()).toMatchObject([
       { kind: "group", role: "user" },
@@ -231,6 +231,42 @@ describe("cached group content classification", () => {
         groups: [{ role: "assistant", messages: [{ message: preview }] }, { role: "tool" }],
       },
       { kind: "group", role: "assistant" },
+    ]);
+  });
+
+  it("keeps assistant text before the final reply visible and folds only tool work", () => {
+    const messages = [
+      { role: "user", content: "Explain the plan", timestamp: 1 },
+      {
+        role: "assistant",
+        content: "Here is the full answer the user watched stream.",
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "lookup",
+        toolName: "read",
+        content: "ok",
+        timestamp: 3,
+      },
+      { role: "assistant", content: "That covers it.", timestamp: 4 },
+    ];
+
+    expect(
+      collapseCompletedTurnWork(cachedGroups(messages), {
+        sessionKey: "agent:target:dashboard:history",
+        runWorking: false,
+      }),
+    ).toMatchObject([
+      { kind: "group", role: "user" },
+      {
+        kind: "group",
+        role: "assistant",
+        visibleContent: "text",
+        messages: [{ message: messages[1] }],
+      },
+      { kind: "work-group", groups: [{ role: "tool" }] },
+      { kind: "group", role: "assistant", messages: [{ message: messages[3] }] },
     ]);
   });
 });

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -210,7 +210,17 @@ function isCollapsibleWorkGroup(item: TurnRenderItem): item is MessageGroup {
     return false;
   }
   const role = item.role.toLowerCase();
-  return role === "tool" || (role === "assistant" && !assistantGroupIsForwardedBoundary(item));
+  if (role === "tool") {
+    return true;
+  }
+  // Assistant text that precedes the final reply is still part of the answer
+  // the user watched stream (completions transports retag pre-tool text as
+  // commentary after the fact). Fold only text-less activity, never visible text.
+  return (
+    role === "assistant" &&
+    !assistantGroupIsForwardedBoundary(item) &&
+    item.visibleContent !== "text"
+  );
 }
 
 function groupHasVisibleReplyContent(group: MessageGroup, includeText = true): boolean {

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -879,11 +879,13 @@ describe("collapseCompletedTurnWork", () => {
       ],
     });
 
-    expect(items.map((item) => item.kind)).toEqual(["group", "work-group", "group"]);
-    const work = requireWorkGroup(items[1]);
-    expect(work.groups).toHaveLength(2);
+    // Pre-final assistant text stays visible; only the tool work folds.
+    expect(items.map((item) => item.kind)).toEqual(["group", "group", "work-group", "group"]);
+    expect(messageRecord(requireGroup(items[1])).content).toBe("Checking…");
+    const work = requireWorkGroup(items[2]);
+    expect(work.groups.map((group) => group.role)).toEqual(["tool"]);
     expect(work.durationMs).toBe(9_000);
-    expect(requireGroup(items[2]).role).toBe("assistant");
+    expect(requireGroup(items[3]).role).toBe("assistant");
   });
 
   it.each([
@@ -983,7 +985,7 @@ describe("collapseCompletedTurnWork", () => {
         2_000,
       ),
       commentary: [],
-      workRoles: ["tool"],
+      visibleBeforeWork: 2,
     },
     {
       role: "tool",
@@ -994,11 +996,11 @@ describe("collapseCompletedTurnWork", () => {
         2_000,
       ),
       commentary: [assistantMessage("Checking the details.", 2_500)],
-      workRoles: ["assistant", "tool"],
+      visibleBeforeWork: 3,
     },
   ])(
     "keeps an earlier visualization visible while collapsing only tool work ($role)",
-    ({ visualization, commentary, workRoles }) => {
+    ({ visualization, commentary, visibleBeforeWork }) => {
       const items = collapsedItems({
         messages: [
           userMessage("show the result", 1_000),
@@ -1009,10 +1011,21 @@ describe("collapseCompletedTurnWork", () => {
         ],
       });
 
-      expect(items.map((item) => item.kind)).toEqual(["group", "group", "work-group", "group"]);
+      // Assistant commentary text stays visible alongside the visualization;
+      // only the tool work folds behind the rollup.
+      expect(items.map((item) => item.kind)).toEqual([
+        ...Array.from({ length: visibleBeforeWork }, () => "group"),
+        "work-group",
+        "group",
+      ]);
       expect(canvasBlocksIn(requireGroup(items[1]))).toHaveLength(1);
-      expect(requireWorkGroup(items[2]).groups.map((group) => group.role)).toEqual(workRoles);
-      expect(messageRecord(requireGroup(items[3])).content).toBe("All done.");
+      for (const message of commentary) {
+        expect(messageRecord(requireGroup(items[2])).content).toBe(message.content);
+      }
+      expect(requireWorkGroup(items[visibleBeforeWork]).groups.map((group) => group.role)).toEqual([
+        "tool",
+      ]);
+      expect(messageRecord(requireGroup(items[visibleBeforeWork + 1])).content).toBe("All done.");
     },
   );
 
@@ -1084,12 +1097,16 @@ describe("collapseCompletedTurnWork", () => {
       const completed = collapsedItems({ messages });
       expect(completed.map((item) => item.kind)).toEqual([
         "group",
+        "group",
         "work-group",
         "group",
         "group",
         "group",
       ]);
-      expect(requireWorkGroup(completed[1]).durationMs).toBe(4_000);
+      expect(messageRecord(requireGroup(completed[1])).content).toBe("Checking…");
+      const work = requireWorkGroup(completed[2]);
+      expect(work.groups.map((group) => group.role)).toEqual(["tool"]);
+      expect(work.durationMs).toBe(4_000);
     },
   );
 
@@ -1284,9 +1301,10 @@ describe("collapseCompletedTurnWork", () => {
 
     const prepended = collapsedItems({
       messages: [
-        assistantMessage("Checking.", 1_000, {
-          __openclaw: { id: "older-commentary", seq: 1 },
-        }),
+        {
+          ...toolResult("call-0", 1_000),
+          __openclaw: { id: "older-work", seq: 1 },
+        },
         toolResult("call-1", 2_000),
         finalReply,
       ],
@@ -1294,7 +1312,35 @@ describe("collapseCompletedTurnWork", () => {
     const prependedWork = requireWorkGroup(prepended[0]);
 
     expect(prependedWork.key).toBe(initialWork.key);
+    expect(groupAt(prependedWork.groups, 0).messages).toHaveLength(2);
     expect(prependedWork.durationMs).toBeGreaterThan(initialWork.durationMs ?? 0);
+  });
+
+  it("keeps prepended assistant text visible ahead of the completed-work row", () => {
+    resetChatThreadState();
+    const finalReply = assistantMessage("Done.", 3_000, {
+      __openclaw: { id: "final-reply", seq: 3 },
+    });
+    const initial = collapsedItems({
+      messages: [toolResult("call-1", 2_000), finalReply],
+    });
+    const initialWork = requireWorkGroup(initial[0]);
+
+    const prepended = collapsedItems({
+      messages: [
+        assistantMessage("Checking.", 1_000, {
+          __openclaw: { id: "older-commentary", seq: 1 },
+        }),
+        toolResult("call-1", 2_000),
+        finalReply,
+      ],
+    });
+
+    expect(prepended.map((item) => item.kind)).toEqual(["group", "work-group", "group"]);
+    expect(messageRecord(requireGroup(prepended[0])).content).toBe("Checking.");
+    const prependedWork = requireWorkGroup(prepended[1]);
+    expect(prependedWork.key).toBe(initialWork.key);
+    expect(prependedWork.groups.map((group) => group.role)).toEqual(["tool"]);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users chatting in the Control UI WebChat would watch a long assistant reply disappear once the turn completed, leaving only a short closing message visible, when the agent ran on an `openai-completions` transport and a tool call followed the reply text.

## Why This Change Was Made

`openai-completions` transports retag already-streamed answer text as commentary once a tool call follows it. The WebChat's completed-turn grouping then folded that text behind the "worked for" row together with the tool activity, so the substantive reply vanished from view.

The fix changes `chat-thread-grouping` to fold only tool groups and text-less assistant groups when a turn completes. Assistant groups that carry text stay visible regardless of how the transport phased them.

## User Impact

Long replies that precede a tool call remain visible after the turn completes. Tool activity still collapses as before.

## Evidence

New cases in `chat-thread-grouping.test.ts` and `chat-thread.test.ts` cover a text-bearing commentary group before a tool call, a text-less group, and the existing tool-only collapse.

Focused runs on this branch (rebased on current `main`):

```
node scripts/run-vitest.mjs ui/src/pages/chat/chat-thread-grouping.test.ts ui/src/pages/chat/chat-thread.test.ts
  Test Files  2 passed (2)   Tests  277 passed (277)
node scripts/run-oxlint.mjs <changed files>   # clean
```

Observed originally on the 2026.9.2 release with an `openai-completions` transport in the WebChat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
