### PR TITLE
perf(slack): prepare structured replies once per delivery attempt

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1134,7 +1134,7 @@ extensions/slack/src/monitor/ingress.ts	8
 extensions/slack/src/monitor/media.ts	1
 extensions/slack/src/monitor/message-handler.ts	2
 extensions/slack/src/monitor/message-handler/dispatch-helpers.ts	2
-extensions/slack/src/monitor/message-handler/dispatch-streaming.ts	6
+extensions/slack/src/monitor/message-handler/dispatch-streaming.ts	5
 extensions/slack/src/monitor/message-handler/dispatch.ts	1
 extensions/slack/src/monitor/message-handler/prepare-dm-history.ts	1
 extensions/slack/src/monitor/message-handler/prepare-thread-context.ts	1

--- a/extensions/slack/src/monitor/message-handler/dispatch-helpers.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-helpers.ts
@@ -6,7 +6,7 @@ import { mergePairLoopGuardConfig } from "openclaw/plugin-sdk/pair-loop-guard-ru
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { resolveSlackReplyRenderPlan } from "../../reply-blocks.js";
+import { prepareSlackReply, type PreparedSlackReply } from "../../reply-blocks.js";
 import type { SlackMessageEvent } from "../../types.js";
 import { readSlackReplyBlocks, resolveSlackThreadTs } from "../replies.js";
 import { resolveSlackTimestampMs } from "./timestamp.js";
@@ -147,14 +147,14 @@ function getSlackStreamRecipientTeamCache(client: object): Map<string, string> {
   return cache;
 }
 
-function buildSlackEventDeliveryKey(params: SlackEventDeliveryAttempt): string | null {
+export function buildSlackEventDeliveryKey(
+  params: SlackEventDeliveryAttempt,
+  preparedReply: PreparedSlackReply = prepareSlackReply(params.payload),
+): string | null {
   const reply = resolveSendableOutboundReplyParts(params.payload, {
     text: params.textOverride,
   });
-  const renderPlan = resolveSlackReplyRenderPlan(
-    params.payload,
-    params.textOverride ?? params.payload.text,
-  );
+  const renderPlan = preparedReply.resolvePreview(params.textOverride);
   const plannedBlocks =
     renderPlan.mode === "single" ? renderPlan.blocks : renderPlan.blockPart?.blocks;
   const slackBlocks = readSlackReplyBlocks(params.payload) ?? plannedBlocks;
@@ -217,12 +217,10 @@ function rememberSlackStreamRecipientTeam(params: {
 export function createSlackEventDeliveryTracker() {
   const deliveredKeys = new Set<string>();
   return {
-    hasDelivered(params: SlackEventDeliveryAttempt) {
-      const key = buildSlackEventDeliveryKey(params);
+    hasDelivered(key: string | null) {
       return key ? deliveredKeys.has(key) : false;
     },
-    markDelivered(params: SlackEventDeliveryAttempt) {
-      const key = buildSlackEventDeliveryKey(params);
+    markDelivered(key: string | null) {
       if (key) {
         deliveredKeys.add(key);
       }

--- a/extensions/slack/src/monitor/message-handler/dispatch-streaming.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-streaming.ts
@@ -5,7 +5,7 @@ import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatSlackError } from "../../errors.js";
 import { emitSlackMessageSentHooks } from "../../message-sent-hook.js";
-import { resolveSlackReplyRenderPlan } from "../../reply-blocks.js";
+import { prepareSlackReply, resolveSlackReplyRenderPlan } from "../../reply-blocks.js";
 import {
   appendSlackStream,
   markSlackStreamFallbackDelivered,
@@ -19,6 +19,7 @@ import { countSlackTextUtf8Bytes } from "../../truncate.js";
 import { deliverReplies, readSlackReplyBlocks } from "../replies.js";
 import {
   createSlackEventDeliveryTracker,
+  buildSlackEventDeliveryKey,
   resolveSlackStreamRecipientTeamId,
   type SlackEventDeliveryAttempt,
 } from "./dispatch-helpers.js";
@@ -72,12 +73,15 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     payload: ReplyPayload;
     threadTs: string | undefined;
   }) => {
-    deliveryTracker.markDelivered(params);
+    const preparedReply = prepareSlackReply(params.payload);
+    deliveryTracker.markDelivered(buildSlackEventDeliveryKey(params, preparedReply));
     // Single-use reply modes move later same-turn payloads off the preview
     // thread, so protect both delivery keys from duplicates.
     const nextThreadTs = replyPlan.peekThreadTs();
     if (nextThreadTs !== params.threadTs) {
-      deliveryTracker.markDelivered({ ...params, threadTs: nextThreadTs });
+      deliveryTracker.markDelivered(
+        buildSlackEventDeliveryKey({ ...params, threadTs: nextThreadTs }, preparedReply),
+      );
     }
   };
   const resolveDeliveryThreadTs = (params: {
@@ -139,7 +143,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     }
     await deliverReplies({
       cfg: ctx.cfg,
-      replies: [{ text: fallbackText } as ReplyPayload],
+      replies: [prepareSlackReply({ text: fallbackText })],
       target: prepared.replyTarget,
       token: ctx.botToken,
       accountId: account.accountId,
@@ -215,19 +219,22 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
       replyDeliveryMode === "off" && !forcedReplyThreadTs && !isThreadReply
         ? undefined
         : replyThreadTs;
-    if (
-      deliveryTracker.hasDelivered({
+    const preparedReply = prepareSlackReply(params.payload);
+    const deliveryKey = buildSlackEventDeliveryKey(
+      {
         kind: params.kind,
         payload: params.payload,
         threadTs: deliveryReplyThreadTs,
-      })
-    ) {
+      },
+      preparedReply,
+    );
+    if (deliveryTracker.hasDelivered(deliveryKey)) {
       logVerbose("slack: suppressed duplicate normal delivery within the same turn");
       return deliveryReplyThreadTs;
     }
     await deliverReplies({
       cfg: ctx.cfg,
-      replies: [params.payload],
+      replies: [preparedReply],
       target: prepared.replyTarget,
       token: ctx.botToken,
       accountId: account.accountId,
@@ -254,11 +261,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     // Record the thread ts only after confirmed delivery success.
     rememberDeliveredThreadTs(params.kind, deliveredThreadTs);
     replyPlan.markSent();
-    deliveryTracker.markDelivered({
-      kind: params.kind,
-      payload: params.payload,
-      threadTs: deliveryReplyThreadTs,
-    });
+    deliveryTracker.markDelivered(deliveryKey);
     return deliveryReplyThreadTs;
   };
 
@@ -315,7 +318,8 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     }
     const hookContent = resolveSendableOutboundReplyParts(params.payload).trimmedText;
     const text = params.streamText ?? hookContent;
-    if (deliveryTracker.hasDelivered({ ...params, threadTs, textOverride: text })) {
+    const deliveryKey = buildSlackEventDeliveryKey({ ...params, threadTs, textOverride: text });
+    if (deliveryTracker.hasDelivered(deliveryKey)) {
       logVerbose("slack-stream: suppressed duplicate reply payload");
       return;
     }
@@ -389,7 +393,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     }
     rememberDeliveredThreadTs(params.kind, threadTs);
     replyPlan.markSent();
-    deliveryTracker.markDelivered({ ...params, threadTs, textOverride: text });
+    deliveryTracker.markDelivered(deliveryKey);
     emitStreamedDelivery(hookContent, { success: true, ...(messageId ? { messageId } : {}) });
   };
 
@@ -397,7 +401,8 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     deliverNormally,
     deliverWithStreaming,
     finishStream,
-    hasDelivered: (params: SlackEventDeliveryAttempt) => deliveryTracker.hasDelivered(params),
+    hasDelivered: (params: SlackEventDeliveryAttempt) =>
+      deliveryTracker.hasDelivered(buildSlackEventDeliveryKey(params)),
     isStreamingEligible,
     markPreviewPayloadDelivered,
     rememberDeliveredThreadTs,

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -22,7 +22,8 @@ const SAME_TEXT = "same reply";
 const getGlobalHookRunnerMock = vi.hoisted(() => vi.fn());
 const createSlackDraftStreamMock = vi.fn();
 const deliverRepliesMock = vi.fn(
-  async () => undefined as { messageId?: string; channelId?: string } | undefined,
+  async (_params: { replies: ReplyPayload[] }) =>
+    undefined as { messageId?: string; channelId?: string } | undefined,
 );
 const finalizeSlackPreviewEditMock = vi.fn(async (_input: { blocks?: unknown }) => {});
 const normalizeSlackOutboundTextMock = vi.fn((value: string) => value.trim());
@@ -998,7 +999,8 @@ vi.mock("../replies.js", async (importOriginal) => ({
       mockedReplyThreadTsSequence ? mockedReplyThreadTsSequence.shift() : mockedReplyThreadTs,
     markSent: () => {},
   }),
-  deliverReplies: deliverRepliesMock,
+  deliverReplies: (params: Parameters<typeof import("../replies.js").deliverReplies>[0]) =>
+    deliverRepliesMock({ ...params, replies: params.replies.map((prepared) => prepared.payload) }),
   readSlackReplyBlocks: () => mockedSlackReplyBlocks,
   resolveSlackThreadTs: () => mockedReplyThreadTs,
 }));

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -34,6 +34,7 @@ vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => {
 let deliverReplies: typeof import("./replies.js").deliverReplies;
 let createSlackReplyDeliveryPlan: typeof import("./replies.js").createSlackReplyDeliveryPlan;
 let resolveSlackThreadTs: typeof import("./replies.js").resolveSlackThreadTs;
+import { prepareSlackReply } from "../reply-blocks.js";
 import { deliverSlackSlashReplies, sanitizeSlackMonitorReplyPayload } from "./replies.js";
 
 const SLACK_TEST_CFG = { channels: { slack: { botToken: "xoxb-test" } } };
@@ -69,7 +70,7 @@ describe("sanitizeSlackMonitorReplyPayload", () => {
 });
 
 function baseParams(overrides?: Record<string, unknown>) {
-  return {
+  const params = {
     cfg: SLACK_TEST_CFG,
     replies: [{ text: "hello" }],
     target: "C123",
@@ -79,6 +80,7 @@ function baseParams(overrides?: Record<string, unknown>) {
     replyToMode: "off" as const,
     ...overrides,
   };
+  return { ...params, replies: params.replies.map(prepareSlackReply) };
 }
 
 function largePortableTablePresentation() {
@@ -258,36 +260,37 @@ describe("deliverReplies identity passthrough", () => {
     };
     const enterpriseCfg = { channels: { slack: {} } };
 
-    const result = await deliverReplies(
-      baseParams({
-        cfg: enterpriseCfg,
-        accountId: "work",
-        identity,
-        metadata,
-        eventScope,
-        mediaMaxBytes: 1024,
-        replyThreadTs: "thread-ts",
-        replies: [
-          {
-            text: "Revenue summary",
-            mediaUrl: "https://example.com/report.png",
-            presentation: {
-              blocks: [
-                {
-                  type: "chart",
-                  chartType: "pie",
-                  title: "Revenue mix",
-                  segments: [
-                    { label: "Product", value: 60 },
-                    { label: "Services", value: 40 },
-                  ],
-                },
-              ],
-            },
+    const params = baseParams({
+      cfg: enterpriseCfg,
+      accountId: "work",
+      identity,
+      metadata,
+      eventScope,
+      mediaMaxBytes: 1024,
+      replyThreadTs: "thread-ts",
+      replies: [
+        {
+          text: "Revenue summary",
+          mediaUrl: "https://example.com/report.png",
+          presentation: {
+            blocks: [
+              {
+                type: "chart",
+                chartType: "pie",
+                title: "Revenue mix",
+                segments: [
+                  { label: "Product", value: 60 },
+                  { label: "Services", value: 40 },
+                ],
+              },
+            ],
           },
-        ],
-      }),
-    );
+        },
+      ],
+    });
+    // Preview materialization must not consume the media caption or add it to the chart message.
+    params.replies[0]?.resolvePreview();
+    const result = await deliverReplies(params);
 
     expect(sendMock).toHaveBeenCalledTimes(2);
     expect(sendMock).toHaveBeenNthCalledWith(1, "C123", "Revenue summary", {

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -40,6 +40,7 @@ import {
   hasSlackReplyStructuredContent,
   resolveSlackReplyBlockResolution,
   resolveSlackReplyBlocks,
+  type PreparedSlackReply,
 } from "../reply-blocks.js";
 import { resolveSlackReplyThreadTs } from "../thread-ts.js";
 import type { SlackEventScope } from "./event-scope.js";
@@ -121,7 +122,7 @@ function resolveSlackMediaHookSpokenText(payload: ReplyPayload): string | undefi
 
 export async function deliverReplies(params: {
   cfg: OpenClawConfig;
-  replies: ReplyPayload[];
+  replies: PreparedSlackReply[];
   target: string;
   token: string;
   accountId?: string;
@@ -153,7 +154,8 @@ export async function deliverReplies(params: {
   eventScope?: SlackEventScope;
 }) {
   let latestResult: SlackSendResult | undefined;
-  for (const payload of params.replies) {
+  for (const prepared of params.replies) {
+    const { payload } = prepared;
     if (payload.isReasoning === true) {
       continue;
     }
@@ -168,10 +170,7 @@ export async function deliverReplies(params: {
       reply.hasText && !isSilentReplyText(reply.trimmedText, SILENT_REPLY_TOKEN)
         ? reply.trimmedText
         : undefined;
-    const materializeAuthoredText = !reply.hasMedia && hasSlackReplyStructuredContent(payload);
-    const { authoredTextPlacement, segments } = resolveSlackReplyBlockResolution(payload, {
-      materializeAuthoredText,
-    });
+    const { authoredTextPlacement, segments } = prepared.resolveDelivery();
     if (!textRaw && !reply.hasMedia && segments.length === 0) {
       continue;
     }

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -6,6 +6,7 @@ import {
 // Slack plugin module implements reply blocks behavior.
 import {
   resolveAskUserQuestionOptionIndices,
+  resolveSendableOutboundReplyParts,
   type AskUserQuestionOptionIndices,
   type ReplyPayload,
 } from "openclaw/plugin-sdk/reply-payload";
@@ -150,14 +151,58 @@ export function resolveSlackReplyRenderPlan(
   payload: ReplyPayload,
   text = payload.text,
 ): SlackReplyRenderPlan {
-  const hasStructuredContent = hasSlackReplyStructuredContent(payload);
-  // Live preview/streaming still consumes this compact plan shape. Derive it
-  // from canonical ordered segments so preview/streaming stays conservative
-  // without a second renderer.
-  const resolution = resolveSlackReplyBlockResolution(
-    { ...payload, text },
-    { materializeAuthoredText: hasStructuredContent },
-  );
+  return prepareSlackReply(payload).resolvePreview(text);
+}
+
+export type PreparedSlackReply = {
+  readonly payload: ReplyPayload;
+  resolveDelivery: () => SlackReplyBlockResolution;
+  resolvePreview: (text?: string) => SlackReplyRenderPlan;
+};
+
+/** One attempt owns its authored compilation; media captions retain a separate delivery policy. */
+export function prepareSlackReply(payload: ReplyPayload): PreparedSlackReply {
+  const text = payload.text;
+  const source = { ...payload, text };
+  let authoredChunks: readonly string[] | undefined;
+  let structuredContent: boolean | undefined;
+  let materialized: SlackReplyBlockResolution | undefined;
+  let unmaterialized: SlackReplyBlockResolution | undefined;
+  let preview: SlackReplyRenderPlan | undefined;
+  const resolveAuthoredTextChunks = () =>
+    (authoredChunks ??= markdownToSlackMrkdwnChunks(text?.trim() ?? "", SLACK_SECTION_TEXT_MAX));
+  const hasStructuredContent = () => (structuredContent ??= hasSlackReplyStructuredContent(source));
+  const resolve = (materializeAuthoredText: boolean) =>
+    materializeAuthoredText
+      ? (materialized ??= resolveSlackReplyBlockResolution(source, {
+          materializeAuthoredText: true,
+          resolveAuthoredTextChunks,
+        }))
+      : (unmaterialized ??= resolveSlackReplyBlockResolution(source));
+  return {
+    payload,
+    resolveDelivery: () =>
+      resolve(!resolveSendableOutboundReplyParts(source).hasMedia && hasStructuredContent()),
+    resolvePreview: (override = text) => {
+      if (override !== text) {
+        return prepareSlackReply({ ...source, text: override }).resolvePreview();
+      }
+      return (preview ??= projectSlackReplyRenderPlan(
+        source,
+        text,
+        resolve(hasStructuredContent()),
+        resolveAuthoredTextChunks,
+      ));
+    },
+  };
+}
+
+function projectSlackReplyRenderPlan(
+  payload: ReplyPayload,
+  text: string | undefined,
+  resolution: SlackReplyBlockResolution,
+  resolveAuthoredTextChunks: () => readonly string[],
+): SlackReplyRenderPlan {
   const messages = resolveSlackReplyDeliveryMessages({
     authoredTextPlacement: resolution.authoredTextPlacement,
     segments: resolution.segments,
@@ -168,7 +213,10 @@ export function resolveSlackReplyRenderPlan(
     const sourceText = text?.trim() ?? "";
     const blocks =
       message?.authoredTextPlacement === "blocks"
-        ? addPreviewVerbatimToAuthoredTextBlocks(message.blocks, sourceText)
+        ? addPreviewVerbatimToAuthoredTextBlocks(
+            message.blocks,
+            sourceText ? resolveAuthoredTextChunks() : [],
+          )
         : message?.blocks;
     let renderedText = message?.text ?? resolveSlackReplyText(payload, text);
     let textIsSlackMrkdwn = Boolean(
@@ -229,8 +277,8 @@ function renderSlackAuthoredTextFragments(blocks: readonly SlackBlock[]): string
   });
 }
 
-function buildSlackAuthoredTextBlocks(text: string): SlackBlock[] {
-  return markdownToSlackMrkdwnChunks(text, SLACK_SECTION_TEXT_MAX).map((chunk) => ({
+function buildSlackAuthoredTextBlocks(chunks: readonly string[]): SlackBlock[] {
+  return chunks.map((chunk) => ({
     type: "section",
     text: { type: "mrkdwn", text: chunk, verbatim: true },
   }));
@@ -238,12 +286,12 @@ function buildSlackAuthoredTextBlocks(text: string): SlackBlock[] {
 
 function addPreviewVerbatimToAuthoredTextBlocks(
   blocks: SlackBlock[] | undefined,
-  sourceText: string,
+  authoredTextChunks: readonly string[],
 ): SlackBlock[] | undefined {
-  if (!blocks?.length || !sourceText) {
+  if (!blocks?.length || authoredTextChunks.length === 0) {
     return blocks;
   }
-  const authoredChunks = new Set(markdownToSlackMrkdwnChunks(sourceText, SLACK_SECTION_TEXT_MAX));
+  const authoredChunks = new Set(authoredTextChunks);
   return blocks.map((block) => {
     const text = (block as { text?: { text?: unknown; type?: unknown; verbatim?: unknown } }).text;
     if (
@@ -433,7 +481,10 @@ function subtractMirroredSlackControlRows(params: {
  */
 export function resolveSlackReplyBlockResolution(
   payload: ReplyPayload,
-  options: { materializeAuthoredText?: boolean } = {},
+  options: {
+    materializeAuthoredText?: boolean;
+    resolveAuthoredTextChunks?: () => readonly string[];
+  } = {},
 ): SlackReplyBlockResolution {
   const segments: SlackReplyBlockSegment[] = [];
   const channelBlocks = readSlackChannelBlocks(payload);
@@ -449,7 +500,10 @@ export function resolveSlackReplyBlockResolution(
     authoredTextKnownInBlocks = initialPlacement === "blocks";
     const text = normalizeOptionalString(payload.text);
     if (text && initialPlacement === "outside-blocks") {
-      const textBlocks = buildSlackAuthoredTextBlocks(text);
+      const textBlocks = buildSlackAuthoredTextBlocks(
+        options.resolveAuthoredTextChunks?.() ??
+          markdownToSlackMrkdwnChunks(text, SLACK_SECTION_TEXT_MAX),
+      );
       const compiledText = renderSlackAuthoredTextFragments(textBlocks).join(" ");
       const compiledPlacement = resolveSlackAuthoredTextPlacement({
         text: compiledText,


### PR DESCRIPTION
Closes #140836

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

One Slack structured delivery repeatedly compiles the same authored Markdown during duplicate checks, actual send and success marking. Preview projection repeats that work again to identify matching authored sections.

## Why This Change Was Made

Prepare authored chunks and projections once per attempt, and pass that preparation through the private delivery flow. Record the exact key computed before the send await after confirmed success. Preview/media delivery retain separate policies; overrides create their own preparation and no global/payload-identity cache is added.

## User Impact

Twelve actual dispatch-to-send synthetic wire/error cases are identical, preserving media captions, raw blocks, text overrides, thread keys, split/native-table output, failed-send retry and duplicate suppression. A roughly 6 KiB structured send plus duplicate attempt drops from 11 to 4 formatter calls and 70,213 to 25,532 formatter input bytes.

Three allocation-instrumented samples measured median 2,317→870 ms and 6.665→2.437 GB cumulative JavaScript allocation. These include collected objects under instrumentation and synthetic I/O; they are not production latency, retained heap or RSS claims. The remaining render-aware prefix search is unchanged.

## Evidence

- 272 focused tests, complete changed-file checks and fresh isolated P 2 review passed on all seven final files; existing wire goldens and the original trace fixture are unchanged.
- Actual dispatchPreparedSlackMessage through real projections/delivery/send reaches a recording WebClient. Only core turn/network boundaries and the media receipt control are synthetic; no live Slack messages were sent.
- Preview-before-media-delivery preserves the caption and chart/post order. Raw matching sections keep cloned verbatim text objects; retries mark only successful keys, and resets remain intact.
- Production grows 56 lines for the attempt owner and two policy-specific resolutions; tests net+5. The only ratchet change shrinks dispatch-streaming.ts from 6 to 5. No SDK/configuration/persistence change or full build requirement.

Related #133135/#133136 cover distinct visible output behavior and remain separate. Preserve raw-upload #140787's independent Blob path/ratchet row. Active #133136 rendering-policy changes and #119737 confirmed upload receipts require fresh integration proof if they land first.
