### PR TITLE
perf(media): bound playback input staging buffers

### DIFF
--- a/src/media/playback-input.test.ts
+++ b/src/media/playback-input.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import { copyPlaybackInputBounded } from "./playback-input.js";
+
+function reader(contents: Buffer, maxRead = Number.POSITIVE_INFINITY) {
+  return {
+    read: vi.fn(async (buffer: Buffer, offset: number, length: number, position: number) => ({
+      bytesRead: contents.copy(buffer, offset, position, position + Math.min(length, maxRead)),
+    })),
+  };
+}
+
+describe("bounded playback input copy", () => {
+  it("preserves every byte across short reads and partial positioned writes", async () => {
+    const contents = Buffer.from(
+      "A short read must finish all its writes before reusing the scratch buffer. 🦞",
+    );
+    const source = reader(contents, 7);
+    const actual = Buffer.alloc(contents.length);
+    const target = {
+      write: vi.fn(async (buffer: Buffer, offset: number, length: number, position: number) => ({
+        bytesWritten: buffer.copy(actual, position, offset, offset + Math.min(length, 3)),
+      })),
+    };
+    await copyPlaybackInputBounded(source, target, contents.length, contents.length);
+    expect(actual).toEqual(contents);
+    expect(source.read.mock.calls.at(-1)?.[3]).toBe(contents.length);
+    expect(target.write.mock.calls.length).toBeGreaterThan(source.read.mock.calls.length);
+  });
+
+  it("copies a file larger than the scratch buffer without dropping a tail", async () => {
+    const contents = Buffer.from("0123456789".repeat(20_000) + "tail");
+    const source = reader(contents);
+    const actual = Buffer.alloc(contents.length);
+    await copyPlaybackInputBounded(
+      source,
+      {
+        write: async (buffer, offset, length, position) => ({
+          bytesWritten: buffer.copy(actual, position, offset, offset + length),
+        }),
+      },
+      contents.length,
+      contents.length,
+    );
+    expect(actual).toEqual(contents);
+    expect(source.read.mock.calls.length).toBeGreaterThan(2);
+  });
+
+  it.each([
+    { name: "growth", contents: "123456789", expected: 5, cap: 5, readBytes: 6 },
+    { name: "truncation", contents: "1234", expected: 5, cap: 5, readBytes: 4 },
+    { name: "byte cap", contents: "123456789", expected: 8, cap: 5, readBytes: 6 },
+  ])(
+    "rejects $name with only the bounded overflow probe",
+    async ({ contents, expected, cap, readBytes }) => {
+      const source = reader(Buffer.from(contents));
+      const target = {
+        write: async (_buffer: Buffer, _offset: number, length: number) => ({
+          bytesWritten: length,
+        }),
+      };
+      await expect(copyPlaybackInputBounded(source, target, expected, cap)).rejects.toThrow(
+        "Playback source changed during bounded read",
+      );
+      expect(
+        (await Promise.all(source.read.mock.results.map((result) => result.value))).reduce(
+          (sum, result) => sum + result.bytesRead,
+          0,
+        ),
+      ).toBe(readBytes);
+    },
+  );
+
+  it("rejects a write that cannot make progress", async () => {
+    const write = vi.fn(async () => ({ bytesWritten: 0 }));
+    await expect(
+      copyPlaybackInputBounded(reader(Buffer.from("bytes")), { write }, 5, 5),
+    ).rejects.toThrow("made no progress");
+    expect(write).toHaveBeenCalledOnce();
+  });
+
+  it.each(["read", "write"] as const)("preserves the original %s failure", async (operation) => {
+    const error = new Error("synthetic filesystem failure");
+    const source =
+      operation === "read"
+        ? {
+            read: async () => {
+              throw error;
+            },
+          }
+        : reader(Buffer.from("bytes"));
+    const target = {
+      write: vi.fn(async () => {
+        throw error;
+      }),
+    };
+    await expect(copyPlaybackInputBounded(source, target, 5, 5)).rejects.toBe(error);
+    if (operation === "read") {
+      expect(target.write).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/src/media/playback-input.ts
+++ b/src/media/playback-input.ts
@@ -1,0 +1,60 @@
+type PositionedReader = {
+  read(
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: number,
+  ): Promise<{ bytesRead: number }>;
+};
+
+type PositionedWriter = {
+  write(
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: number,
+  ): Promise<{ bytesWritten: number }>;
+};
+
+/** Copies only the admitted source length, probing one extra byte for growth. */
+export async function copyPlaybackInputBounded(
+  source: PositionedReader,
+  target: PositionedWriter,
+  expectedSize: number,
+  maxBytes: number,
+): Promise<void> {
+  const maxReadBytes = Math.min(maxBytes + 1, expectedSize + 1);
+  const buffer = Buffer.allocUnsafe(Math.min(64 * 1024, maxReadBytes));
+  let totalBytes = 0;
+  while (totalBytes < maxReadBytes) {
+    const { bytesRead } = await source.read(
+      buffer,
+      0,
+      Math.min(buffer.length, maxReadBytes - totalBytes),
+      totalBytes,
+    );
+    if (bytesRead === 0) {
+      break;
+    }
+    if (totalBytes + bytesRead > maxBytes || totalBytes + bytesRead > expectedSize) {
+      throw new Error("Playback source changed during bounded read");
+    }
+    let written = 0;
+    while (written < bytesRead) {
+      const { bytesWritten } = await target.write(
+        buffer,
+        written,
+        bytesRead - written,
+        totalBytes + written,
+      );
+      if (bytesWritten === 0) {
+        throw new Error("Playback input staging write made no progress");
+      }
+      written += bytesWritten;
+    }
+    totalBytes += bytesRead;
+  }
+  if (totalBytes !== expectedSize) {
+    throw new Error("Playback source changed during bounded read");
+  }
+}

--- a/src/media/playback-transcode.staging.test.ts
+++ b/src/media/playback-transcode.staging.test.ts
@@ -1,0 +1,200 @@
+import { constants as fsConstants } from "node:fs";
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+import {
+  settlePlaybackTranscodeJobsForTest,
+  waitForPlaybackTranscodeJobsForTest,
+} from "./playback-transcode.test-support.js";
+
+const { runFfmpeg } = vi.hoisted(() => ({ runFfmpeg: vi.fn() }));
+vi.mock("./ffmpeg-exec.js", () => ({ runFfmpeg }));
+vi.mock("./media-probe.js", () => ({
+  probePlaybackMediaFileDescriptor: vi.fn(async () => ({
+    durationMs: 1000,
+    audioCodec: "pcm_s16le",
+    audioStreamIndex: 0,
+  })),
+}));
+
+let playback: typeof import("./playback-transcode.js");
+let tempHome: TempHomeEnv;
+
+beforeAll(async () => {
+  vi.resetModules();
+  tempHome = await createTempHomeEnv("openclaw-playback-staging-");
+  playback = await import("./playback-transcode.js");
+});
+
+afterAll(async () => {
+  try {
+    await tempHome.restore();
+  } finally {
+    vi.doUnmock("./ffmpeg-exec.js");
+    vi.doUnmock("./media-probe.js");
+    vi.resetModules();
+  }
+});
+
+beforeEach(() => {
+  runFfmpeg.mockReset();
+});
+
+async function createSource(fileName: string, contents: string) {
+  const fixturePath = path.join(tempHome.home, fileName);
+  await fs.writeFile(fixturePath, contents);
+  const sourcePath = await fs.realpath(fixturePath);
+  return { sourcePath, sourceStat: await fs.stat(sourcePath) };
+}
+
+describe("playback input staging", () => {
+  it.each(["grow", "truncate", "rewrite", "replace"] as const)(
+    "rejects a source that changes after open via %s before starting ffmpeg",
+    async (change) => {
+      const source = await createSource(`changed-${change}.caf`, "stable-source");
+      let changed = false;
+      __setFsSafeTestHooksForTest({
+        afterOpenedPathIdentityCheck: async (filePath) => {
+          if (filePath !== source.sourcePath || changed) {
+            return;
+          }
+          changed = true;
+          if (change === "grow") {
+            await fs.appendFile(filePath, "growth");
+          } else if (change === "truncate") {
+            await fs.truncate(filePath, 1);
+          } else if (change === "rewrite") {
+            await fs.writeFile(filePath, "edited-source");
+            await fs.utimes(
+              filePath,
+              source.sourceStat.atime,
+              new Date(source.sourceStat.mtimeMs + 2000),
+            );
+            expect((await fs.stat(filePath)).mtimeMs).not.toBe(source.sourceStat.mtimeMs);
+          } else {
+            await fs.rename(filePath, `${filePath}.old`);
+            await fs.writeFile(filePath, "stable-source");
+          }
+        },
+      });
+      try {
+        const params = {
+          ...source,
+          mimeType: "audio/x-caf",
+          kind: "audio" as const,
+          probe: { durationMs: 1000, audioStreamIndex: 0 },
+        };
+        expect(await playback.resolvePlaybackTranscode(params)).toEqual({ kind: "preparing" });
+        await expect(waitForPlaybackTranscodeJobsForTest("all")).rejects.toThrow(
+          /changed|mismatch/,
+        );
+        expect(changed).toBe(true);
+        expect(runFfmpeg).not.toHaveBeenCalled();
+        expect(await playback.resolvePlaybackTranscode(params)).toEqual({ kind: "fallback" });
+      } finally {
+        __setFsSafeTestHooksForTest(undefined);
+        await settlePlaybackTranscodeJobsForTest();
+      }
+    },
+  );
+
+  it("rejects a moved input that no longer names its staging descriptor", async () => {
+    const source = await createSource("replaced-staging.caf", "stable-source");
+    const open = fs.open.bind(fs);
+    const rename = fs.rename.bind(fs);
+    let writer: FileHandle | undefined;
+    let writerWasOpenAtMove = false;
+    let replaced = false;
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await open(...args);
+      if (
+        path.basename(String(args[0])) === ".input.caf.stage" &&
+        typeof args[1] === "number" &&
+        (args[1] & fsConstants.O_WRONLY) !== 0
+      ) {
+        writer = handle;
+      }
+      return handle;
+    });
+    const spy = vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
+      if (
+        path.basename(String(from)) === ".input.caf.stage" &&
+        path.basename(String(to)) === "input.caf"
+      ) {
+        // Observe the producer's handle without opening another one that would pin the inode.
+        writerWasOpenAtMove = writer !== undefined && writer.fd >= 0;
+        await rename(from, to);
+        await fs.unlink(to);
+        await fs.writeFile(to, "stable-source", { mode: 0o600 });
+        replaced = true;
+      } else {
+        await rename(from, to);
+      }
+    });
+    try {
+      expect(
+        await playback.resolvePlaybackTranscode({
+          ...source,
+          mimeType: "audio/x-caf",
+          kind: "audio",
+          probe: { durationMs: 1000, audioStreamIndex: 0 },
+        }),
+      ).toEqual({ kind: "preparing" });
+      const outcome = await waitForPlaybackTranscodeJobsForTest("all").then(
+        () => ({ ok: true }),
+        (error: unknown) => ({ ok: false, error }),
+      );
+      expect(writerWasOpenAtMove).toBe(true);
+      expect(outcome).toEqual({
+        ok: false,
+        error: expect.objectContaining({ message: expect.stringMatching(/changed|mismatch/) }),
+      });
+      expect(replaced).toBe(true);
+      expect(runFfmpeg).not.toHaveBeenCalled();
+      expect(writer?.fd).toBe(-1);
+    } finally {
+      spy.mockRestore();
+      openSpy.mockRestore();
+      await settlePlaybackTranscodeJobsForTest();
+    }
+  });
+
+  it("does not publish a cache entry when workspace cleanup fails", async () => {
+    const source = await createSource("cleanup-failed.caf", "stable-source");
+    const cleanupError = new Error("synthetic workspace cleanup failure");
+    const remove = fs.rm.bind(fs);
+    let quarantine: string | undefined;
+    const spy = vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+      if (path.basename(String(target)).startsWith(".fs-safe-workspace-cleanup-")) {
+        quarantine = String(target);
+        throw cleanupError;
+      }
+      return remove(target, options);
+    });
+    runFfmpeg.mockImplementationOnce(async (args: string[]) => {
+      await fs.writeFile(args.at(-1) ?? "", "normalized-audio");
+      return "";
+    });
+    try {
+      const params = {
+        ...source,
+        mimeType: "audio/x-caf",
+        kind: "audio" as const,
+        probe: { durationMs: 1000, audioStreamIndex: 0 },
+      };
+      expect(await playback.resolvePlaybackTranscode(params)).toEqual({ kind: "preparing" });
+      await expect(waitForPlaybackTranscodeJobsForTest("all")).rejects.toBe(cleanupError);
+      expect(runFfmpeg).toHaveBeenCalledOnce();
+      expect(quarantine).toBeDefined();
+      expect(await playback.resolvePlaybackTranscode(params)).toEqual({ kind: "fallback" });
+    } finally {
+      spy.mockRestore();
+      await settlePlaybackTranscodeJobsForTest();
+      if (quarantine) {
+        await remove(quarantine, { recursive: true, force: true });
+      }
+    }
+  });
+});

--- a/src/media/playback-transcode.test.ts
+++ b/src/media/playback-transcode.test.ts
@@ -95,35 +95,6 @@ function createCacheKey(source: {
   return testApi.createPlaybackTranscodeCacheKey(source);
 }
 
-async function readSourceBoundedForTest(
-  handle: {
-    read: (
-      buffer: Buffer,
-      offset: number,
-      length: number,
-      position: number,
-    ) => Promise<{ bytesRead: number; buffer: Buffer }>;
-  },
-  expectedSize: number,
-  maxBytes: number,
-): Promise<Buffer> {
-  const testApi = (globalThis as Record<PropertyKey, unknown>)[
-    Symbol.for("openclaw.playbackTranscodeTestApi")
-  ] as
-    | {
-        readPlaybackSourceBounded?: (
-          value: typeof handle,
-          expected: number,
-          max: number,
-        ) => Promise<Buffer>;
-      }
-    | undefined;
-  if (!testApi?.readPlaybackSourceBounded) {
-    throw new Error("playback bounded-read test API unavailable");
-  }
-  return await testApi.readPlaybackSourceBounded(handle, expectedSize, maxBytes);
-}
-
 describe("playback transcode policy", () => {
   it.each([
     ["audio/m4a", "audio", "native", "aac"],
@@ -271,20 +242,6 @@ describe("playback transcode policy", () => {
 });
 
 describe("resolvePlaybackTranscode", () => {
-  it("rejects descriptor growth after reading only the bounded overflow byte", async () => {
-    const contents = Buffer.from("123456");
-    const read = vi.fn(async (buffer: Buffer, offset: number, length: number, position: number) => {
-      expect(buffer.byteLength).toBe(6);
-      const bytesRead = contents.copy(buffer, offset, position, position + length);
-      return { bytesRead, buffer };
-    });
-
-    await expect(readSourceBoundedForTest({ read }, 5, 5)).rejects.toThrow(
-      "Playback source changed during bounded read",
-    );
-    expect(read).toHaveBeenCalledOnce();
-  });
-
   it("falls back before ffmpeg when source duration exceeds the transcode limit", async () => {
     const source = await createSource("long-video.mkv");
     probePlaybackMediaFileDescriptor.mockResolvedValueOnce({

--- a/src/media/playback-transcode.ts
+++ b/src/media/playback-transcode.ts
@@ -1,11 +1,13 @@
 // Playback transcode policy and lazy media-store cache ownership.
 import { createHash } from "node:crypto";
-import fs, { type FileHandle } from "node:fs/promises";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { maxBytesForKind, type MediaKind } from "@openclaw/media-core/constants";
 import { extensionForMime, normalizeMimeType } from "@openclaw/media-core/mime";
+import { hasErrnoCode } from "../infra/errno.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { fileStore } from "../infra/file-store.js";
+import { sameFileIdentity } from "../infra/fs-safe-advanced.js";
 import { openLocalFileSafely } from "../infra/fs-safe.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { withTempWorkspace } from "../infra/private-temp-workspace.js";
@@ -15,6 +17,7 @@ import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import { runFfmpeg } from "./ffmpeg-exec.js";
 import { probePlaybackMediaFileDescriptor, type PlaybackMediaProbeResult } from "./media-probe.js";
 import { resolveNativePlaybackCodecCompatibility } from "./playback-codec-policy.js";
+import { copyPlaybackInputBounded } from "./playback-input.js";
 import { getMediaDir, PLAYBACK_TRANSCODE_SUBDIR, writePlaybackTranscodeCache } from "./store.js";
 
 type PlaybackMediaKind = Extract<MediaKind, "audio" | "video">;
@@ -160,32 +163,6 @@ function createPlaybackTranscodeCacheKey(source: PlaybackSourceIdentity): string
     .digest("hex");
 }
 
-async function readPlaybackSourceBounded(
-  handle: Pick<FileHandle, "read">,
-  expectedSize: number,
-  maxBytes: number,
-): Promise<Buffer> {
-  const maxReadBytes = Math.min(maxBytes + 1, expectedSize + 1);
-  const buffer = Buffer.allocUnsafe(maxReadBytes);
-  let totalBytes = 0;
-  while (totalBytes < maxReadBytes) {
-    const { bytesRead } = await handle.read(
-      buffer,
-      totalBytes,
-      maxReadBytes - totalBytes,
-      totalBytes,
-    );
-    if (bytesRead === 0) {
-      break;
-    }
-    totalBytes += bytesRead;
-  }
-  if (totalBytes > maxBytes || totalBytes !== expectedSize) {
-    throw new Error("Playback source changed during bounded read");
-  }
-  return buffer.subarray(0, totalBytes);
-}
-
 /** Returns whether a sniffed audio/video type needs the cross-client playback target. */
 function resolvePlaybackMode(
   mimeType: string,
@@ -204,7 +181,6 @@ function resolvePlaybackMode(
 if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.playbackTranscodeTestApi")] = {
     createPlaybackTranscodeCacheKey,
-    readPlaybackSourceBounded,
     getPlaybackTranscodeJobs: (): Promise<void>[] => [...playbackJobs.values()],
   };
 }
@@ -517,31 +493,64 @@ async function transcodePlaybackSource(params: {
     if (!playbackSourceIdentityMatches(params.source, opened)) {
       throw new Error("Playback source changed before transcode");
     }
-    const sourceBuffer = await readPlaybackSourceBounded(
-      opened.handle,
-      params.source.size,
-      params.maxBytes,
-    );
-    const postReadStat = await opened.handle.stat();
-    if (
-      !playbackSourceIdentityMatches(params.source, {
-        realPath: opened.realPath,
-        stat: postReadStat,
-      })
-    ) {
-      throw new Error("Playback source changed during transcode read");
-    }
-
     const outputBuffer = await withTempWorkspace(
       {
         rootDir: resolvePreferredOpenClawTmpDir(),
         prefix: "playback-transcode-",
       },
       async (workspace) => {
-        const inputPath = await workspace.write(
-          makePlaybackInputFileName(params.source.path, params.mimeType),
-          sourceBuffer,
-        );
+        const inputName = makePlaybackInputFileName(params.source.path, params.mimeType);
+        const stagingName = `.${inputName}.stage`;
+        // Keep private-store admission without its full-payload buffering path.
+        await workspace.write(stagingName, "");
+        const inputRoot = await workspace.store.root();
+        const staged = await inputRoot.openWritable(stagingName, {
+          writeMode: "update",
+          mode: 0o600,
+          mkdir: false,
+        });
+        let inputPath: string;
+        try {
+          const inputIdentity = await staged.handle.stat({ bigint: true });
+          await copyPlaybackInputBounded(
+            opened.handle,
+            staged.handle,
+            params.source.size,
+            params.maxBytes,
+          );
+          if (
+            !playbackSourceIdentityMatches(params.source, {
+              realPath: opened.realPath,
+              stat: await opened.handle.stat(),
+            })
+          ) {
+            throw new Error("Playback source changed during transcode read");
+          }
+          await staged.handle.sync().catch((error: unknown) => {
+            if (!hasErrnoCode(error, "EPERM")) {
+              throw error;
+            }
+          });
+          // Keep the writer live so replacement cannot reuse its inode before verification.
+          await inputRoot.move(stagingName, inputName);
+          const input = await inputRoot.open(inputName);
+          try {
+            const stat = await input.handle.stat({ bigint: true });
+            // The move owns its path checks; bind its result to our completed writer.
+            if (
+              !sameFileIdentity(inputIdentity, stat) ||
+              stat.size !== BigInt(params.source.size) ||
+              (process.platform !== "win32" && (stat.mode & 0o7777n) !== 0o600n)
+            ) {
+              throw new Error("Playback staged input changed before transcode");
+            }
+            inputPath = input.realPath;
+          } finally {
+            await input.handle.close().catch(() => {});
+          }
+        } finally {
+          await staged.handle.close().catch(() => {});
+        }
         const outputPath = workspace.path(`output${policy.target.extension}`);
         const inputFormat = resolvePlaybackInputFormat(policy, params.mimeType);
         if (!inputFormat) {


### PR DESCRIPTION
Closes #140838

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Playback input staging holds a complete source Buffer and an additional private-write payload copy before conversion. The resolver only needs a private input file for ffmpeg.

## Why This Change Was Made

Create an empty private staging leaf through the existing store, then copy between admitted descriptors with at most 64 KiB scratch and explicit positions. Preserve overflow/short-read handling, partial writes, source revalidation, sync, guarded rename and writer-identity/size/mode checks while the writer stays open. Both staging handles close before ffmpeg. Output buffering and cleanup-before-cache-publication stay unchanged.

## User Impact

Eight matched actual resolver runs with deterministic CAF input and real ffmpeg/ffprobe preserve source/output/duration/readiness hashes and private staging permissions. Near a 15.36 MB source, input scratch changes from 15,360,130 to 65,536 bytes and the full private-write payload copy is removed.

With tested fs-safe 0.8.1, observed Node ArrayBuffer rise changes 31.847→2.621 MiB; sampled ffmpeg RSS stays about 15.6 MiB. These sampled maxima are not exhaustive peaks or process-memory ceilings. The output Buffer remains required. Near-cap elapsed time increases 851.7→864.0 ms (+1.4%), and small/medium medians rise 2.6–5.6%; no speedup is claimed.

## Evidence

- On Node 26.8.1 and installed fs-safe 0.8.3, 104 focused tests, the full changed-file gate and independent P2 review pass. Cases cover positioned partial I/O, overflow/truncation/cap rejection, zero-progress/original failures, changed source identity, substituted staging input and cleanup failure blocking publication.
- Actual resolver conversion includes source inspection, staging, conversion, output probing, cleanup and cache publication. HTTP ticket/Range/HEAD flows and real video encoding were not replayed.
- A fresh fs-safe 0.8.3 resolver/ffprobe/ffmpeg smoke converts a synthetic 15,360,129-byte CAF to valid 160-second AAC/M4A. It verifies exact staged bytes, private modes, writer lifetime through the final identity check, closure before ffmpeg, unchanged source and cleanup before cache readiness. Original comparative measurements above remain labeled 0.8.1; this smoke is current-dependency integration proof.
- Production net+69 lines handles the explicit I/O/descriptor ownership formerly delegated to a whole-buffer write; tests net+258, including extracted staging cases. The old test-only reader export is removed. No dependency, configuration, cache-key/quota/TTL, concurrency or persistent-state semantics change.

The private input file and OS page-cache work remain. Full output ownership is preserved; no leak, fixed RSS or whole-Gateway claim.

## CI Follow-up

The original Linux run exposed two assumptions in the new staging tests. The same-length rewrite fixture now explicitly changes and verifies its modification timestamp. The staging writer now remains open through the guarded rename and reopened-file identity check, preventing inode reuse from defeating that comparison. The moved-substitution regression observes the actual production writer; it fails on the former close-before-move implementation and passes with the repair. The existing changed/mismatch rejection and cleanup assertions remain intact.

The production repair changes 19 lines each way and adds no payload buffers or filesystem calls. Fresh Linux CI on the repaired head is required before landing. Windows delete-sharing compatibility was checked against [Node 26.8.1 source](https://github.com/nodejs/node/blob/7be6d3af31a65adea57c94c41e50c2b071ed0b3a/deps/uv/src/win/fs.c#L480-L513); no live Windows execution is claimed.
