### PR TITLE
fix(sessions): shorten stalls during cold session updates

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3587,7 +3587,7 @@ src/state/openclaw-agent-db-readonly.ts	1
 src/state/openclaw-agent-db-registry-listing.ts	3
 src/state/openclaw-agent-db-registry.ts	7
 src/state/openclaw-agent-db-schema-helpers.ts	1
-src/state/openclaw-agent-db-schema.ts	3
+src/state/openclaw-agent-db-schema.ts	2
 src/state/openclaw-agent-db-session-migrations.ts	4
 src/state/openclaw-agent-db-session-provenance.ts	2
 src/state/openclaw-agent-standing-intents-schema.ts	1

--- a/src/config/sessions/session-accessor.sqlite-entry-admission.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-admission.test.ts
@@ -162,7 +162,7 @@ it.each(["sessions.json", "custom.json"])(
       entries.map(({ sessionKey }) => loadSessionEntry({ env, storePath, sessionKey })?.sessionId),
     ).toEqual(entries.map(({ entry }) => entry.sessionId));
     expect(
-      fs.readdirSync(path.dirname(storePath)).filter((filename) => filename.endsWith(".sqlite")),
+      fs.readdirSync(path.dirname(storePath)).filter((entryName) => entryName.endsWith(".sqlite")),
     ).toHaveLength(1);
   },
 );

--- a/src/config/sessions/session-accessor.sqlite-entry-admission.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-admission.test.ts
@@ -24,6 +24,7 @@ import {
 } from "./session-accessor.js";
 import {
   patchSessionEntryTarget,
+  replaceSessionEntry,
   replaceSessionEntrySync,
 } from "./session-accessor.sqlite-entry.js";
 import {
@@ -137,6 +138,34 @@ async function expectAdmission(gate: ReturnType<typeof holdNative>, operation: P
     true,
   );
 }
+
+it.each(["sessions.json", "custom.json"])(
+  "keeps concurrent first writes in one custom store (%s)",
+  async (filename) => {
+    const root = roots.make("session-patch-first-writes-");
+    const env = { OPENCLAW_STATE_DIR: root };
+    vi.stubEnv("OPENCLAW_STATE_DIR", root);
+    const storePath = path.join(root, "custom-store", filename);
+    const entries = ["first", "second", "third"].map((name) => ({
+      sessionKey: `agent:main:${name}`,
+      entry: {
+        sessionId: `session-${name}`,
+        updatedAt: Date.now(),
+      },
+    }));
+    await Promise.all(
+      entries.map(({ sessionKey, entry }) =>
+        own(replaceSessionEntry({ env, storePath, sessionKey }, entry)),
+      ),
+    );
+    expect(
+      entries.map(({ sessionKey }) => loadSessionEntry({ env, storePath, sessionKey })?.sessionId),
+    ).toEqual(entries.map(({ entry }) => entry.sessionId));
+    expect(
+      fs.readdirSync(path.dirname(storePath)).filter((filename) => filename.endsWith(".sqlite")),
+    ).toHaveLength(1);
+  },
+);
 
 it.each([
   ["entry", "preparation"],

--- a/src/config/sessions/session-accessor.sqlite-entry-admission.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-admission.test.ts
@@ -1,0 +1,501 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import * as sqlite from "../../infra/node-sqlite.js";
+import * as integrity from "../../infra/sqlite-integrity-worker.js";
+import * as writerQueue from "../../shared/store-writer-queue.js";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  closeOpenClawAgentDatabasesAsync,
+  closeOpenClawAgentDatabasesForTest,
+  getOpenClawAgentDatabaseIfOpen,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config.js";
+import { resolveStateDir } from "../paths.js";
+import {
+  loadSessionEntry,
+  onSessionIdentityMutation,
+  patchSessionEntryCore,
+} from "./session-accessor.js";
+import {
+  patchSessionEntryTarget,
+  replaceSessionEntrySync,
+} from "./session-accessor.sqlite-entry.js";
+import {
+  resolveSqliteScope,
+  runExclusiveSqliteSessionWrite,
+  toDatabaseOptions,
+} from "./session-accessor.sqlite-scope.js";
+
+const roots = createTempDirTracker();
+const pending: Promise<unknown>[] = [];
+const releases: Array<() => void> = [];
+const realOpen = sqlite.openNodeSqliteDatabase;
+const realIntegrity = integrity.assertSqliteIntegrityInWorker;
+let queued = vi.spyOn(writerQueue, "runQueuedStoreWrite");
+
+beforeEach(() => {
+  resetConfigRuntimeState();
+  setRuntimeConfigSnapshot({}, {});
+  queued = vi.spyOn(writerQueue, "runQueuedStoreWrite");
+});
+
+afterEach(async () => {
+  for (const release of releases.splice(0)) {
+    release();
+  }
+  await Promise.allSettled(pending.splice(0));
+  // Join the actual default-budget kicks too; this suite does not disable retention.
+  let joined = -1;
+  while (joined !== queued.mock.results.length) {
+    joined = queued.mock.results.length;
+    await Promise.allSettled(
+      queued.mock.results.flatMap((result) => (result.type === "return" ? [result.value] : [])),
+    );
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+  }
+  await closeOpenClawAgentDatabasesAsync();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  resetConfigRuntimeState();
+  roots.cleanup();
+});
+
+function own<T>(promise: Promise<T>): Promise<T> {
+  pending.push(promise);
+  void promise.catch(() => {});
+  return promise;
+}
+
+function fixture(sessionKey = "agent:main:admission") {
+  const root = roots.make("session-patch-admission-");
+  const env = { OPENCLAW_STATE_DIR: root };
+  vi.stubEnv("OPENCLAW_STATE_DIR", root);
+  const scope = { agentId: "main", env, sessionKey };
+  replaceSessionEntrySync(scope, { sessionId: "original", updatedAt: 1 });
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolveSqliteScope(scope)));
+  return { root, env, scope, database, databasePath: database.path };
+}
+
+function nativeChecks(databasePath: string) {
+  let parentChecks = 0;
+  vi.spyOn(sqlite, "openNodeSqliteDatabase").mockImplementation((pathname, options) => {
+    const database = realOpen(pathname, options);
+    if (pathname !== databasePath || options?.readOnly) {
+      return database;
+    }
+    const prepare = database.prepare.bind(database);
+    database.prepare = (sql) => {
+      const statement = prepare(sql);
+      if (sql === "PRAGMA integrity_check;") {
+        const all = statement.all.bind(statement);
+        statement.all = () => {
+          parentChecks += 1;
+          return all();
+        };
+      }
+      return statement;
+    };
+    return database;
+  });
+  return () => parentChecks;
+}
+
+function holdNative(databasePath: string) {
+  const entered = createDeferred();
+  const release = createDeferred();
+  releases.push(() => release.resolve());
+  vi.spyOn(integrity, "assertSqliteIntegrityInWorker").mockImplementation((...args) => {
+    const work = realIntegrity(...args);
+    if (args[0] !== databasePath) {
+      return work;
+    }
+    entered.resolve();
+    return Promise.all([work, release.promise]).then(() => undefined);
+  });
+  return { entered, release };
+}
+
+async function expectAdmission(gate: ReturnType<typeof holdNative>, operation: Promise<unknown>) {
+  const entered = await Promise.race([
+    gate.entered.promise.then(() => true),
+    operation.then(
+      () => false,
+      () => false,
+    ),
+  ]);
+  expect(entered, "cold patch settled before a pending native admission could be observed").toBe(
+    true,
+  );
+}
+
+it.each([
+  ["entry", "preparation"],
+  ["target", "preparation"],
+  ["entry", "commit"],
+  ["target", "commit"],
+] as const)("keeps %s %s integrity checks off the caller thread", async (kind, phase) => {
+  const f = fixture();
+  if (phase === "preparation") {
+    closeOpenClawAgentDatabaseByPath(f.databasePath);
+  }
+  const parentChecks = nativeChecks(f.databasePath);
+  const update = () => {
+    if (phase === "commit") {
+      closeOpenClawAgentDatabaseByPath(f.databasePath);
+    }
+    return { label: "updated" };
+  };
+  const operation = own(
+    kind === "entry"
+      ? patchSessionEntryCore(f.scope, update, { skipMaintenance: true })
+      : patchSessionEntryTarget(
+          {
+            agentId: "main",
+            storePath: f.databasePath,
+            target: { canonicalKey: f.scope.sessionKey, storeKeys: [f.scope.sessionKey] },
+          },
+          update,
+          { skipMaintenance: true },
+        ),
+  );
+  await expect(operation).resolves.toMatchObject({ sessionId: "original", label: "updated" });
+  expect(loadSessionEntry(f.scope)).toMatchObject({ sessionId: "original", label: "updated" });
+  expect(parentChecks()).toBe(0);
+});
+
+it.each(["warm", "incognito"] as const)("keeps %s updater invocation direct", async (mode) => {
+  const f = fixture(mode === "incognito" ? "agent:main:dashboard:incognito-admission" : undefined);
+  const native = vi.spyOn(integrity, "assertSqliteIntegrityInWorker");
+  let called = false;
+  const operation = own(
+    patchSessionEntryCore(
+      f.scope,
+      () => {
+        called = true;
+        return { label: mode };
+      },
+      { skipMaintenance: true },
+    ),
+  );
+  expect(called).toBe(true);
+  await expect(operation).resolves.toMatchObject({ label: mode });
+  expect(native).not.toHaveBeenCalled();
+  if (mode === "incognito") {
+    expect(fs.readdirSync(f.root)).toEqual([]);
+  }
+});
+
+it.each([false, true])(
+  "captures the queued state owner before admission (ambient=%s)",
+  async (ambient) => {
+    const f = fixture();
+    const original = { ...f.scope, env: { ...f.env } };
+    const successor = roots.make("session-patch-successor-");
+    const release = createDeferred();
+    releases.push(() => release.resolve());
+    const blocker = own(
+      runExclusiveSqliteSessionWrite(resolveSqliteScope(original), async () => {
+        await release.promise;
+      }),
+    );
+    const scope = ambient ? { agentId: "main", sessionKey: original.sessionKey } : f.scope;
+    const operation = own(
+      patchSessionEntryCore(
+        scope,
+        () => {
+          closeOpenClawAgentDatabaseByPath(f.databasePath);
+          return { label: "original owner" };
+        },
+        { skipMaintenance: true },
+      ),
+    );
+    if (ambient) {
+      vi.stubEnv("OPENCLAW_STATE_DIR", successor);
+    } else {
+      f.env.OPENCLAW_STATE_DIR = successor;
+    }
+    closeOpenClawAgentDatabaseByPath(f.databasePath);
+    release.resolve();
+    await blocker;
+    await expect(operation).resolves.toMatchObject({
+      sessionId: "original",
+      label: "original owner",
+    });
+    expect(loadSessionEntry(original)).toMatchObject({ label: "original owner" });
+    expect(fs.readdirSync(successor)).toEqual([]);
+  },
+);
+
+it("keeps the physical database owner for logical rows in a shared store", async () => {
+  const f = fixture();
+  const storePath = path.join(f.root, "shared.sqlite");
+  openOpenClawAgentDatabase({ agentId: "main", env: f.env, path: storePath });
+  const main = { ...f.scope, storePath, sessionKey: "agent:main:kept" };
+  const secondary = { ...main, agentId: "secondary", sessionKey: "agent:secondary:shared" };
+  replaceSessionEntrySync(main, { sessionId: "kept", updatedAt: 1 });
+  replaceSessionEntrySync(secondary, { sessionId: "secondary", updatedAt: 1 });
+  closeOpenClawAgentDatabaseByPath(storePath);
+  await expect(
+    own(
+      patchSessionEntryCore(
+        secondary,
+        () => {
+          closeOpenClawAgentDatabaseByPath(storePath);
+          return { label: "shared owner" };
+        },
+        { skipMaintenance: true },
+      ),
+    ),
+  ).resolves.toMatchObject({ sessionId: "secondary", label: "shared owner" });
+  expect(loadSessionEntry(main)).toMatchObject({ sessionId: "kept" });
+  expect(
+    openOpenClawAgentDatabase({ agentId: "main", env: f.env, path: storePath })
+      .db.prepare("SELECT agent_id FROM schema_meta")
+      .get(),
+  ).toMatchObject({ agent_id: "main" });
+  expect(
+    fs.existsSync(path.join(f.root, "agents", "secondary", "agent", "openclaw-agent.sqlite")),
+  ).toBe(false);
+});
+
+it("retains FIFO, caller context and publication across cold admission", async () => {
+  const f = fixture();
+  closeOpenClawAgentDatabaseByPath(f.databasePath);
+  const gate = holdNative(f.databasePath);
+  const contexts = new AsyncLocalStorage<string>();
+  const order: string[] = [];
+  const updateRelease = createDeferred();
+  releases.push(() => updateRelease.resolve());
+  const enteredUpdater = createDeferred();
+  let holdUpdater = false;
+  const unsubscribe = onSessionIdentityMutation((mutation) => {
+    if (mutation.kind !== "delete" && mutation.current.sessionKeys.includes(f.scope.sessionKey)) {
+      order.push(`published:${mutation.current.sessionId}`);
+    }
+  });
+  try {
+    const first = own(
+      contexts.run("first", () =>
+        patchSessionEntryCore(
+          f.scope,
+          async () => {
+            order.push(`update:${contexts.getStore()}`);
+            enteredUpdater.resolve();
+            if (holdUpdater) {
+              await updateRelease.promise;
+            }
+            return { sessionId: "first" };
+          },
+          { skipMaintenance: true, onCommitted: () => order.push(`commit:${contexts.getStore()}`) },
+        ),
+      ),
+    );
+    await expectAdmission(gate, first);
+    holdUpdater = true;
+    const second = own(
+      contexts.run("second", () =>
+        patchSessionEntryCore(
+          f.scope,
+          (entry) => {
+            order.push(`update:${contexts.getStore()}:${entry.sessionId}`);
+            return { sessionId: "second" };
+          },
+          { skipMaintenance: true, onCommitted: () => order.push(`commit:${contexts.getStore()}`) },
+        ),
+      ),
+    );
+    expect(order).toEqual([]);
+    gate.release.resolve();
+    await enteredUpdater.promise;
+    expect(order).toEqual(["update:first"]);
+    updateRelease.resolve();
+    await Promise.all([first, second]);
+    expect(order).toEqual([
+      "update:first",
+      "commit:first",
+      "published:first",
+      "update:second:first",
+      "commit:second",
+      "published:second",
+    ]);
+    expect(loadSessionEntry(f.scope)?.sessionId).toBe("second");
+  } finally {
+    unsubscribe();
+    gate.release.resolve();
+    updateRelease.resolve();
+  }
+});
+
+it.each(["dispose", "sync replacement"] as const)(
+  "rejects %s before updater admission and recovers the lane",
+  async (mode) => {
+    const f = fixture();
+    closeOpenClawAgentDatabaseByPath(f.databasePath);
+    const gate = holdNative(f.databasePath);
+    const update = vi.fn(() => ({ label: "must not commit" }));
+    const committed = vi.fn();
+    const operation = own(
+      patchSessionEntryCore(f.scope, update, { skipMaintenance: true, onCommitted: committed }),
+    );
+    try {
+      await expectAdmission(gate, operation);
+      expect(update).not.toHaveBeenCalled();
+      if (mode === "dispose") {
+        closeOpenClawAgentDatabaseByPath(f.databasePath);
+      } else {
+        openOpenClawAgentDatabase({ agentId: "main", env: f.env });
+      }
+      gate.release.resolve();
+      await expect(operation).rejects.toThrow(/closed|revoked|replaced/);
+      expect(update).not.toHaveBeenCalled();
+      expect(committed).not.toHaveBeenCalled();
+      expect(loadSessionEntry(f.scope)).not.toHaveProperty("label");
+      await expect(
+        own(
+          patchSessionEntryCore(f.scope, () => ({ label: "successor" }), { skipMaintenance: true }),
+        ),
+      ).resolves.toMatchObject({ label: "successor" });
+    } finally {
+      gate.release.resolve();
+    }
+  },
+);
+
+it.each(["cancel", "revoke"] as const)(
+  "rechecks %s authority after cold commit admission",
+  async (mode) => {
+    const f = fixture();
+    const gate = holdNative(f.databasePath);
+    let allowed = true;
+    const revoked = new Error("authority revoked during commit admission");
+    const committed = vi.fn();
+    const operation = own(
+      patchSessionEntryCore(
+        f.scope,
+        () => {
+          closeOpenClawAgentDatabaseByPath(f.databasePath);
+          return { sessionId: "uncommitted" };
+        },
+        {
+          skipMaintenance: true,
+          shouldCommit: () => mode !== "cancel" || allowed,
+          assertCommitAllowed: () => {
+            if (!allowed && mode === "revoke") {
+              throw revoked;
+            }
+          },
+          onCommitted: committed,
+        },
+      ),
+    );
+    try {
+      await expectAdmission(gate, operation);
+      allowed = false;
+      gate.release.resolve();
+      if (mode === "cancel") {
+        await expect(operation).resolves.toBeNull();
+      } else {
+        await expect(operation).rejects.toBe(revoked);
+      }
+      expect(committed).not.toHaveBeenCalled();
+      expect(loadSessionEntry(f.scope)?.sessionId).toBe("original");
+      expect(
+        getOpenClawAgentDatabaseIfOpen({ agentId: "main", env: f.env })?.db.isTransaction,
+      ).toBe(false);
+    } finally {
+      gate.release.resolve();
+    }
+  },
+);
+
+it.each(["relative queued", "relative reopen", "implicit queued"] as const)(
+  "pins the selected root for %s patch work",
+  async (mode) => {
+    const home = roots.make("session-patch-root-selection-");
+    const implicit = mode === "implicit queued";
+    const ownerRoot = path.join(home, implicit ? ".clawdbot" : "state");
+    const successor = path.join(home, implicit ? ".openclaw" : "next-cwd");
+    fs.mkdirSync(ownerRoot);
+    if (!implicit) {
+      fs.mkdirSync(successor);
+    }
+    const cwd = vi.spyOn(process, "cwd").mockReturnValue(home);
+    const env: NodeJS.ProcessEnv = {
+      HOME: home,
+      OPENCLAW_HOME: home,
+      OPENCLAW_CONFIG_PATH: path.join(ownerRoot, "openclaw.json"),
+      ...(implicit
+        ? // Deliberately select normal legacy discovery, not the fast-test new-root shortcut.
+          { OPENCLAW_TEST_FAST: "0" }
+        : { OPENCLAW_STATE_DIR: "state" }),
+    };
+    vi.stubEnv("OPENCLAW_STATE_DIR", ownerRoot);
+    const scope = { agentId: "main", env, sessionKey: "agent:main:root-selection" };
+    const original = { ...scope, env: { ...env, OPENCLAW_STATE_DIR: ownerRoot } };
+    expect(resolveStateDir(env)).toBe(ownerRoot);
+    replaceSessionEntrySync(original, { sessionId: "original", updatedAt: 1 });
+    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolveSqliteScope(original)));
+    const selectedPath = database.path;
+    const shiftOwner = () => {
+      if (implicit) {
+        fs.mkdirSync(successor);
+      } else {
+        cwd.mockReturnValue(successor);
+      }
+    };
+    const release = createDeferred();
+    releases.push(() => release.resolve());
+    const blocker =
+      mode === "relative reopen"
+        ? undefined
+        : own(
+            runExclusiveSqliteSessionWrite(resolveSqliteScope(original), async () => {
+              await release.promise;
+            }),
+          );
+    const operation = own(
+      patchSessionEntryCore(
+        scope,
+        () => {
+          if (mode === "relative reopen") {
+            // The first read happened warm in A; commit must reopen A after the updater.
+            expect(closeOpenClawAgentDatabaseByPath(selectedPath)).toBe(true);
+            shiftOwner();
+          }
+          return { label: "retained selected root" };
+        },
+        { skipMaintenance: true },
+      ),
+    );
+    if (blocker) {
+      // Admission was queued with A selected; its first physical open must retain A.
+      closeOpenClawAgentDatabaseByPath(selectedPath);
+      shiftOwner();
+      release.resolve();
+      await blocker;
+    }
+    // Control: unchanged caller inputs now resolve elsewhere; the operation must use
+    // its private resolved root, not repeat ambient/legacy selection after its await.
+    expect(resolveStateDir(env)).toBe(implicit ? successor : path.join(successor, "state"));
+    await expect(operation).resolves.toMatchObject({
+      sessionId: "original",
+      label: "retained selected root",
+    });
+    expect(loadSessionEntry(original)).toMatchObject({
+      sessionId: "original",
+      label: "retained selected root",
+    });
+    expect(env.OPENCLAW_STATE_DIR).toBe(implicit ? undefined : "state");
+    expect(fs.readdirSync(successor, { recursive: true })).toEqual([]);
+  },
+);

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -8,12 +8,16 @@ import { coerceRequiredSqliteNumber as sqliteNumber } from "../../infra/sqlite-n
 import type { ChannelRouteRef } from "../../plugin-sdk/channel-route.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import {
+  getOpenClawAgentDatabaseIfOpen,
   isIncognitoOpenClawAgentSqlitePath,
   openOpenClawAgentDatabase,
+  resolveOpenClawAgentSqlitePath,
   runOpenClawAgentWriteTransaction,
+  withOpenClawAgentDatabaseAsync,
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
+import { resolveStateDir } from "../paths.js";
 import { isInternalSessionEffectsKey } from "./internal-session-key.js";
 import { deriveLastRoutePatch, deriveSessionMetaPatch } from "./metadata.js";
 import type {
@@ -482,73 +486,90 @@ type SqliteSessionEntrySnapshotPatchParams = {
 async function patchSqliteSessionEntrySnapshot(
   params: SqliteSessionEntrySnapshotPatchParams,
 ): Promise<SessionEntry | null> {
-  const { options, resolved, sessionKey } = params;
+  const { options, sessionKey } = params;
+  // Queueing and either cold open must retain the same registration and lease owner.
+  const resolved = { ...params.resolved, env: { ...(params.resolved.env ?? process.env) } };
+  resolved.env.OPENCLAW_STATE_DIR = resolveStateDir(resolved.env);
+  const databaseOptions = toDatabaseOptions(resolved);
+  const databasePath = resolveOpenClawAgentSqlitePath(databaseOptions);
+  resolved.path = databasePath;
+  databaseOptions.path = databasePath;
+  const incognito = isIncognitoOpenClawAgentSqlitePath(databasePath, databaseOptions);
+  const withDatabase = <T>(operation: () => T | Promise<T>) =>
+    !incognito && !getOpenClawAgentDatabaseIfOpen(databaseOptions)
+      ? withOpenClawAgentDatabaseAsync(databaseOptions, operation)
+      : operation();
   let wrote = false;
-  const committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
-    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-    const prepared = params.readSnapshot(database);
-    const existing = prepared[0]?.entry;
-    const writeBase = existing ?? options.fallbackEntry;
-    if (!writeBase) {
-      return null;
-    }
-    const patch = await params.update(cloneSessionEntry(writeBase), {
-      existingEntry: existing ? cloneSessionEntry(existing) : undefined,
-    });
-    // A fallback supplies identity, not an existing node's immutable creation policy.
-    const mergeBase = existing ? writeBase : undefined;
-    const creationPatch = !existing && patch ? { ...writeBase, ...patch } : patch;
-    const merged = !creationPatch
-      ? undefined
-      : options.replaceEntry
-        ? cloneSessionEntry(patch as SessionEntry)
-        : options.preserveActivity
-          ? mergeSessionEntryPreserveActivity(mergeBase, creationPatch)
-          : mergeSessionEntry(mergeBase, creationPatch);
-    const next = !merged
-      ? undefined
-      : options.replaceEntry
-        ? merged
-        : preserveSqliteSameKeySessionRolloverLineage({
-            next: merged,
-            previous: writeBase,
-            sessionKey,
-          });
-    let result: SessionEntry | null = null;
-    let previousIdentity = new Map<string, SessionEntry>();
-    let currentIdentity = new Map<string, SessionEntry>();
-    runOpenClawAgentWriteTransaction((writeDatabase) => {
-      if (options.shouldCommit?.() === false) {
-        return;
+  const committed = await runExclusiveSqliteSessionWrite(resolved, async () =>
+    withDatabase(async () => {
+      const database = openOpenClawAgentDatabase(databaseOptions);
+      const prepared = params.readSnapshot(database);
+      const existing = prepared[0]?.entry;
+      const writeBase = existing ?? options.fallbackEntry;
+      if (!writeBase) {
+        return null;
       }
-      const fresh = params.readSnapshot(writeDatabase);
-      assertLifecycleTargetSnapshotUnchanged(prepared, fresh, params.operationLabel);
-      options.assertCommitAllowed?.();
-      if (!next) {
-        result = cloneSessionEntry(writeBase);
-        return;
-      }
-      // Commit reads own these entries; update callbacks only receive detached copies.
-      previousIdentity = new Map(fresh.map((row) => [row.sessionKey, row.entry]));
-      const selectedPreviousEntry = fresh[0]?.entry ?? writeBase;
-      const persisted = writeSessionEntry(writeDatabase, sessionKey, next, {
-        ...(options.consumePendingReset ? { consumePendingReset: true } : {}),
-        previousEntry: selectedPreviousEntry,
+      const patch = await params.update(cloneSessionEntry(writeBase), {
+        existingEntry: existing ? cloneSessionEntry(existing) : undefined,
       });
-      wrote = true;
-      // Identity observers only consume sessionId, already owned by this canonical write.
-      currentIdentity = new Map([[sessionKey, persisted]]);
-      result = cloneSessionEntry(persisted);
-    }, toDatabaseOptions(resolved));
-    try {
-      if (next && result) {
-        options.onCommitted?.(cloneSessionEntry(result));
-      }
-    } finally {
-      emitCommittedSessionIdentityDiff(resolved.agentId, previousIdentity, currentIdentity);
-    }
-    return result;
-  });
+      // A fallback supplies identity, not an existing node's immutable creation policy.
+      const mergeBase = existing ? writeBase : undefined;
+      const creationPatch = !existing && patch ? { ...writeBase, ...patch } : patch;
+      const merged = !creationPatch
+        ? undefined
+        : options.replaceEntry
+          ? cloneSessionEntry(patch as SessionEntry)
+          : options.preserveActivity
+            ? mergeSessionEntryPreserveActivity(mergeBase, creationPatch)
+            : mergeSessionEntry(mergeBase, creationPatch);
+      const next = !merged
+        ? undefined
+        : options.replaceEntry
+          ? merged
+          : preserveSqliteSameKeySessionRolloverLineage({
+              next: merged,
+              previous: writeBase,
+              sessionKey,
+            });
+      // The updater may dispose the prepared handle; re-admit before the synchronous commit.
+      return withDatabase(() => {
+        let result: SessionEntry | null = null;
+        let previousIdentity = new Map<string, SessionEntry>();
+        let currentIdentity = new Map<string, SessionEntry>();
+        runOpenClawAgentWriteTransaction((writeDatabase) => {
+          if (options.shouldCommit?.() === false) {
+            return;
+          }
+          const fresh = params.readSnapshot(writeDatabase);
+          assertLifecycleTargetSnapshotUnchanged(prepared, fresh, params.operationLabel);
+          options.assertCommitAllowed?.();
+          if (!next) {
+            result = cloneSessionEntry(writeBase);
+            return;
+          }
+          // Commit reads own these entries; update callbacks only receive detached copies.
+          previousIdentity = new Map(fresh.map((row) => [row.sessionKey, row.entry]));
+          const selectedPreviousEntry = fresh[0]?.entry ?? writeBase;
+          const persisted = writeSessionEntry(writeDatabase, sessionKey, next, {
+            ...(options.consumePendingReset ? { consumePendingReset: true } : {}),
+            previousEntry: selectedPreviousEntry,
+          });
+          wrote = true;
+          // Identity observers only consume sessionId, already owned by this canonical write.
+          currentIdentity = new Map([[sessionKey, persisted]]);
+          result = cloneSessionEntry(persisted);
+        }, databaseOptions);
+        try {
+          if (next && result) {
+            options.onCommitted?.(cloneSessionEntry(result));
+          }
+        } finally {
+          emitCommittedSessionIdentityDiff(resolved.agentId, previousIdentity, currentIdentity);
+        }
+        return result;
+      });
+    }),
+  );
   if (wrote) {
     kickSessionEntryMaintenanceAfterWrite({
       activeSessionKey: sessionKey,
@@ -561,6 +582,7 @@ async function patchSqliteSessionEntrySnapshot(
   }
   kickSessionHistoryDiskBudgetMaintenance({
     ...(resolved.agentId ? { agentId: resolved.agentId } : {}),
+    env: resolved.env,
     storePath: params.storePath,
     ...(options.maintenanceConfig ? { maintenanceConfig: options.maintenanceConfig } : {}),
   });

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -61,11 +61,13 @@ import {
 } from "./session-accessor.sqlite-reclamation.js";
 import {
   cloneSessionEntry,
+  resolveSqliteAgentId,
   resolveSqliteReadScope,
   resolveSqliteStoreScope,
   resolveSqliteTranscriptArchiveDirectory,
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
+  type ResolvedSqliteScope,
 } from "./session-accessor.sqlite-scope.js";
 import {
   appendTranscriptEventsInTransaction,
@@ -608,14 +610,23 @@ export async function deleteSessionEntryLifecycle(
 /** Disk-budget owner: delete one exact archived row without recursively scheduling another pass. */
 export async function deleteDiskBudgetSessionEntryLifecycle(
   params: DeleteSessionEntryLifecycleParams,
+  resolved: ResolvedSqliteScope,
 ): Promise<DeleteSessionEntryLifecycleResult> {
-  const agentId = params.agentId ?? parseAgentSessionKey(params.target.canonicalKey)?.agentId;
-  const resolved = resolveSqliteStoreScope(params.storePath, { agentId });
+  // A shared store lends its physical owner, not the victim's logical identity.
+  // Validate against captured ownership so a custom selector cannot retarget cleanup.
+  const targetScope = {
+    ...resolved,
+    agentId: resolveSqliteAgentId({
+      scopedAgentId: params.agentId ?? parseAgentSessionKey(params.target.canonicalKey)?.agentId,
+      storeAgentId: resolved.databaseAgentId ?? resolved.agentId,
+      storeShared: resolved.databaseAgentId !== undefined,
+    }),
+  };
   return await withCommittedHistoryMaintenance(
     params,
     async (recordCommit, markCommitted) =>
       await deleteSqliteSessionEntryLifecycleLocked(
-        resolved,
+        targetScope,
         params,
         false,
         undefined,

--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -284,12 +284,18 @@ export function resolveSqliteStoreScope(
   });
 }
 
-function resolveSqliteAgentId(params: {
+type ResolveSqliteAgentIdParams = {
   scopedAgentId?: string;
   sessionKey?: string;
   storeAgentId?: string;
   storeShared?: boolean;
-}): string | undefined {
+};
+
+export function resolveSqliteAgentId(
+  params: ResolveSqliteAgentIdParams & { storeAgentId: string },
+): string;
+export function resolveSqliteAgentId(params: ResolveSqliteAgentIdParams): string | undefined;
+export function resolveSqliteAgentId(params: ResolveSqliteAgentIdParams): string | undefined {
   const scopedAgentId = params.scopedAgentId ? normalizeAgentId(params.scopedAgentId) : undefined;
   if (
     scopedAgentId &&

--- a/src/config/sessions/session-history-budget-owner-parity.test.ts
+++ b/src/config/sessions/session-history-budget-owner-parity.test.ts
@@ -1,0 +1,473 @@
+// Budget deletion retains the logical owner while reusing the captured physical store.
+import { randomUUID } from "node:crypto";
+import { channel } from "node:diagnostics_channel";
+import fs from "node:fs";
+import path from "node:path";
+import type { SQLInputValue } from "node:sqlite";
+import type { Worker } from "node:worker_threads";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  insertRepositoryGitHubPublication,
+  readRepositoryGitHubPublication,
+  repositoryGitHubPublicationDigest,
+  type RepositoryGitHubPublicationRow,
+} from "../../gateway/github-repository-publication-store.js";
+import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
+import {
+  onSessionIdentityMutation,
+  type SessionIdentityMutation,
+} from "../../sessions/session-lifecycle-events.js";
+import {
+  closeOpenClawAgentDatabasesAsync,
+  closeOpenClawAgentDatabasesForTest,
+  listOpenClawRegisteredAgentDatabases,
+  openOpenClawAgentDatabase,
+  resolveOpenClawAgentSqlitePath,
+  runOpenClawAgentWriteTransaction,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { appendTranscriptMessage } from "./session-accessor.js";
+import { writeSessionEntry } from "./session-accessor.sqlite-entry-store.js";
+import { replaceSessionEntrySync } from "./session-accessor.sqlite-entry.js";
+import {
+  resolveSqliteScope,
+  runExclusiveSqliteSessionWrite,
+} from "./session-accessor.sqlite-scope.js";
+import {
+  appendTranscriptEventsInTransaction,
+  ensureTranscriptHeader,
+} from "./session-accessor.sqlite-transcript-store.js";
+import { enforceSqliteSessionHistoryDiskBudget } from "./session-history-eviction.js";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+import { resolveMaintenanceConfigFromInput } from "./store-maintenance.js";
+
+const states: OpenClawTestState[] = [];
+const pending: Promise<unknown>[] = [];
+const listeners: Array<() => void> = [];
+const workers: Worker[] = [];
+const workerChannel = channel("worker_threads");
+const recordWorker = (message: unknown) => workers.push((message as { worker: Worker }).worker);
+beforeEach(() => workerChannel.subscribe(recordWorker));
+afterEach(async () => {
+  for (const unsubscribe of listeners.splice(0)) {
+    unsubscribe();
+  }
+  await Promise.allSettled(pending.splice(0));
+  try {
+    for (const state of states) {
+      await closeOpenClawAgentDatabasesAsync(state.root);
+    }
+    for (const state of states) {
+      closeOpenClawAgentDatabasesForTest(state.root);
+    }
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    workerChannel.unsubscribe(recordWorker);
+    // Real archive/reclamation calls settle their workers. Only this test's idle
+    // measurement pool remains; join termination before removing the fixture.
+    await Promise.all(workers.splice(0).map((worker) => worker.terminate()));
+    for (const state of states.splice(0).toReversed()) {
+      await state.cleanup();
+    }
+  }
+});
+
+function row(databasePath: string, sql: string, ...values: SQLInputValue[]) {
+  const database = openNodeSqliteDatabase(databasePath, { readOnly: true });
+  try {
+    return database.prepare(sql).get(...values);
+  } finally {
+    database.close();
+  }
+}
+
+function retain<T>(promise: Promise<T>): Promise<T> {
+  pending.push(promise);
+  return promise;
+}
+
+function seedReceipt(agentId: string, sessionKey: string, sessionId: string): string {
+  // This is the real persistence/digest owner, with a synthetic system identity.
+  // No coordinator, OAuth account, repository checkout, push, or external API runs.
+  const requestId = randomUUID();
+  const now = Date.now();
+  const receipt: RepositoryGitHubPublicationRow = {
+    request_id: requestId,
+    idempotency_key: `owner-parity-${requestId}`,
+    request_digest: "",
+    session_id: sessionId,
+    session_lifecycle_revision: null,
+    session_key: sessionKey,
+    agent_id: agentId,
+    workspace_id: `workspace-${requestId}`,
+    owner_profile_id: null,
+    connection_generation: null,
+    identity_source: "system-detected",
+    identity_profile_id: null,
+    identity_account_id: 12345,
+    identity_login: "synthetic-owner",
+    title: null,
+    body: null,
+    push_repository: "example/synthetic-owner-proof",
+    repository: "example/synthetic-owner-proof",
+    base_branch: "main",
+    branch: "proof/owner-parity",
+    previous_head_commit: null,
+    claim_id: null,
+    run_id: null,
+    environment_id: null,
+    owner_epoch: null,
+    placement_generation: null,
+    checkpoint_ref: null,
+    checkpoint_digest: null,
+    source_head_commit: null,
+    source_index_tree: null,
+    workspace_tree: null,
+    status: "requested",
+    execution_id: null,
+    gateway_instance_id: null,
+    head_commit: null,
+    pushed_head_commit: null,
+    pull_request_url: null,
+    last_effect: null,
+    effect_state: null,
+    error_code: null,
+    next_action: null,
+    created_at_ms: now,
+    updated_at_ms: now,
+    reported_at_ms: null,
+  };
+  receipt.request_digest = repositoryGitHubPublicationDigest(receipt);
+  insertRepositoryGitHubPublication(receipt, () => {});
+  expect(readRepositoryGitHubPublication(requestId)).toMatchObject({
+    agent_id: agentId,
+    session_key: sessionKey,
+    session_id: sessionId,
+  });
+  return requestId;
+}
+
+type Fixture = Awaited<ReturnType<typeof fixture>>;
+async function fixture(kind: "shared" | "canonical-nonshared" | "custom-nonshared", bare = false) {
+  const state = await createOpenClawTestState({
+    prefix: "omitted-budget-owner-",
+    layout: "state-only",
+    scenario: "minimal",
+  });
+  states.push(state);
+  const storePath =
+    kind === "canonical-nonshared"
+      ? path.join(state.sessionsDir("main"), "sessions.json")
+      : state.path("custom", kind === "shared" ? "shared.sqlite" : "sessions.json");
+  fs.mkdirSync(path.dirname(storePath), { recursive: true });
+  const databasePath =
+    kind === "shared"
+      ? storePath
+      : resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main", env: state.env })
+          .path;
+  openOpenClawAgentDatabase({ agentId: "main", env: state.env, path: databasePath });
+  const victimKey = bare ? "unknown" : "agent:secondary:explicit:owner-parity";
+  const victimAgent = bare ? "main" : "secondary";
+  const victimId = "owner-parity-victim";
+  const survivorKey = "agent:main:main";
+  const survivorId = "owner-parity-survivor";
+  const marker = "retained owner parity transcript";
+  const archived = {
+    sessionId: victimId,
+    updatedAt: 1,
+    archivedAt: 1,
+    archiveReason: "active-session-cap" as const,
+  };
+  if (kind === "shared") {
+    const victimScope = { agentId: victimAgent, env: state.env, storePath, sessionKey: victimKey };
+    replaceSessionEntrySync(victimScope, { sessionId: victimId, updatedAt: 1 });
+    await retain(
+      appendTranscriptMessage(
+        { ...victimScope, sessionId: victimId },
+        {
+          message: { role: "user", content: marker + "x".repeat(64 * 1024) },
+        },
+      ),
+    );
+    replaceSessionEntrySync(victimScope, archived);
+  } else {
+    // Deliberately model a foreign qualified row in a nonshared physical store.
+    // Public scope resolution refuses this mismatch. Existing low-level canonical
+    // writers construct the fixture without weakening or mocking that validator.
+    runOpenClawAgentWriteTransaction(
+      (database) => {
+        writeSessionEntry(database, victimKey, archived);
+        const transcript = {
+          agentId: "main",
+          env: state.env,
+          path: databasePath,
+          sessionKey: victimKey,
+          sessionId: victimId,
+        };
+        ensureTranscriptHeader(database, transcript, state.root);
+        expect(
+          appendTranscriptEventsInTransaction(database, transcript, [
+            {
+              type: "message",
+              id: "owner-parity-message",
+              message: { role: "user", content: marker + "x".repeat(64 * 1024) },
+            },
+          ]),
+        ).toBe(1);
+      },
+      { agentId: "main", env: state.env, path: databasePath },
+    );
+  }
+  replaceSessionEntrySync(
+    { agentId: "main", env: state.env, storePath, sessionKey: survivorKey },
+    {
+      sessionId: survivorId,
+      updatedAt: Date.now(),
+    },
+  );
+  // Join real seed maintenance with unchanged defaults, rather than disabling it.
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+  await retain(
+    runExclusiveSqliteSessionWrite(
+      resolveSqliteScope({
+        agentId: "main",
+        env: state.env,
+        storePath,
+        sessionKey: "",
+      }),
+      async () => {},
+    ),
+  );
+  await retain(
+    enforceSqliteSessionHistoryDiskBudget({
+      agentId: "main",
+      storePath,
+      mode: "enforce",
+      maintenance: resolveMaintenanceConfigFromInput(),
+    }),
+  );
+  const victimReceipt = seedReceipt(victimAgent, victimKey, victimId);
+  const survivorReceipt = seedReceipt("main", survivorKey, survivorId);
+  expect(row(databasePath, "SELECT agent_id FROM schema_meta")).toEqual({ agent_id: "main" });
+  expect(
+    row(
+      databasePath,
+      "SELECT current_session_id FROM session_nodes WHERE session_key = ?",
+      victimKey,
+    ),
+  ).toEqual({ current_session_id: victimId });
+  expect(
+    Number(
+      row(
+        databasePath,
+        "SELECT count(*) AS count FROM transcript_events WHERE session_id = ?",
+        victimId,
+      )?.count,
+    ),
+  ).toBeGreaterThan(0);
+  const secondaryCanonicalPath = resolveOpenClawAgentSqlitePath({
+    agentId: "secondary",
+    env: state.env,
+  });
+  expect(fs.existsSync(secondaryCanonicalPath)).toBe(false);
+  const registryBefore = listOpenClawRegisteredAgentDatabases({ env: state.env }).map(
+    ({ agentId, path: registeredPath }) => ({ agentId, path: registeredPath }),
+  );
+  expect(registryBefore).toContainEqual({ agentId: "main", path: databasePath });
+  await closeOpenClawAgentDatabasesAsync(state.root);
+  closeOpenClawAgentDatabasesForTest(state.root);
+  expect(
+    row(
+      resolveOpenClawStateSqlitePath(state.env),
+      "SELECT count(*) AS count FROM agent_database_leases",
+    ),
+  ).toEqual({ count: 0 });
+  return {
+    state,
+    storePath,
+    databasePath,
+    victimKey,
+    victimAgent,
+    victimId,
+    survivorKey,
+    survivorId,
+    victimReceipt,
+    survivorReceipt,
+    secondaryCanonicalPath,
+    registryBefore,
+  };
+}
+
+function observeVictim(f: Fixture) {
+  const facts: Array<{
+    mutation: SessionIdentityMutation;
+    rowExists: boolean;
+    receiptExists: boolean;
+  }> = [];
+  listeners.push(
+    onSessionIdentityMutation((mutation) => {
+      if (mutation.kind === "delete" && mutation.previous.sessionKeys.includes(f.victimKey)) {
+        facts.push({
+          mutation,
+          rowExists:
+            row(
+              f.databasePath,
+              "SELECT session_key FROM session_nodes WHERE session_key = ?",
+              f.victimKey,
+            ) !== undefined,
+          receiptExists: readRepositoryGitHubPublication(f.victimReceipt) !== undefined,
+        });
+      }
+    }),
+  );
+  return facts;
+}
+
+function enforce(f: Fixture, agentId?: string) {
+  expect(process.env.OPENCLAW_STATE_DIR).toBe(f.state.stateDir);
+  return retain(
+    enforceSqliteSessionHistoryDiskBudget({
+      ...(agentId !== undefined ? { agentId } : {}),
+      storePath: f.storePath,
+      mode: "enforce",
+      maintenance: resolveMaintenanceConfigFromInput({
+        mode: "enforce",
+        maxDiskBytes: 1,
+        highWaterBytes: 1,
+      }),
+    }),
+  );
+}
+
+async function assertCustody(f: Fixture) {
+  expect(process.env.OPENCLAW_STATE_DIR).toBe(f.state.stateDir);
+  expect(row(f.databasePath, "SELECT agent_id FROM schema_meta")).toEqual({ agent_id: "main" });
+  expect(
+    row(
+      f.databasePath,
+      "SELECT current_session_id FROM session_nodes WHERE session_key = ?",
+      f.survivorKey,
+    ),
+  ).toEqual({ current_session_id: f.survivorId });
+  expect(readRepositoryGitHubPublication(f.survivorReceipt)).toMatchObject({
+    agent_id: "main",
+    session_key: f.survivorKey,
+  });
+  expect(fs.existsSync(f.secondaryCanonicalPath)).toBe(false);
+  const registry = listOpenClawRegisteredAgentDatabases({ env: f.state.env }).map(
+    ({ agentId, path: registeredPath }) => ({ agentId, path: registeredPath }),
+  );
+  const sorted = (rows: Array<{ agentId: string; path: string }>) =>
+    rows.toSorted((a, b) => a.path.localeCompare(b.path));
+  expect(sorted(registry)).toEqual(sorted(f.registryBefore));
+  await closeOpenClawAgentDatabasesAsync(f.state.root);
+  closeOpenClawAgentDatabasesForTest(f.state.root);
+  expect(
+    row(
+      resolveOpenClawStateSqlitePath(f.state.env),
+      "SELECT count(*) AS count FROM agent_database_leases",
+    ),
+  ).toEqual({ count: 0 });
+}
+
+describe("budget cap-entry logical ownership", () => {
+  it.each([
+    { name: "omitted qualified owner", explicit: false, bare: false, expectedAgent: "secondary" },
+    { name: "explicit secondary owner", explicit: true, bare: false, expectedAgent: "secondary" },
+    { name: "omitted canonical bare unknown", explicit: false, bare: true, expectedAgent: "main" },
+  ] as const)(
+    "deletes the matching receipt for $name in a shared physical main store",
+    async (scenario) => {
+      const f = await fixture("shared", scenario.bare);
+      const facts = observeVictim(f);
+      await expect(enforce(f, scenario.explicit ? "secondary" : undefined)).resolves.toMatchObject({
+        removedEntries: 1,
+      });
+      expect(
+        row(
+          f.databasePath,
+          "SELECT session_key FROM session_nodes WHERE session_key = ?",
+          f.victimKey,
+        ),
+      ).toBeUndefined();
+      expect(
+        row(
+          f.databasePath,
+          "SELECT session_id FROM session_windows WHERE session_id = ?",
+          f.victimId,
+        ),
+      ).toBeUndefined();
+      expect(
+        readRepositoryGitHubPublication(f.victimReceipt),
+        "deleted logical owner must lose its retained publication receipt",
+      ).toBeUndefined();
+      // agentId is fallback metadata for qualified keys, not authorization evidence.
+      expect(facts).toEqual([
+        {
+          mutation: {
+            agentId: scenario.expectedAgent,
+            kind: "delete",
+            previous: { sessionId: f.victimId, sessionKeys: [f.victimKey] },
+          },
+          rowExists: false,
+          receiptExists: true,
+        },
+      ]);
+      await assertCustody(f);
+    },
+  );
+
+  it.each(["canonical-nonshared", "custom-nonshared"] as const)(
+    "rejects a foreign candidate in a %s store without retargeting cleanup",
+    async (kind) => {
+      const f = await fixture(kind);
+      const facts = observeVictim(f);
+      const suffixPath =
+        kind === "custom-nonshared"
+          ? resolveSqliteTargetFromSessionStorePath(f.storePath, {
+              agentId: "secondary",
+              env: f.state.env,
+            }).path
+          : undefined;
+      if (suffixPath) {
+        expect(suffixPath).not.toBe(f.databasePath);
+        expect(fs.existsSync(suffixPath)).toBe(false);
+      }
+      await expect(enforce(f)).rejects.toThrow(
+        "SQLite session store path belongs to agent main; requested agent secondary.",
+      );
+      expect(
+        row(
+          f.databasePath,
+          "SELECT current_session_id FROM session_nodes WHERE session_key = ?",
+          f.victimKey,
+        ),
+      ).toEqual({ current_session_id: f.victimId });
+      expect(
+        Number(
+          row(
+            f.databasePath,
+            "SELECT count(*) AS count FROM transcript_events WHERE session_id = ?",
+            f.victimId,
+          )?.count,
+        ),
+      ).toBeGreaterThan(0);
+      expect(readRepositoryGitHubPublication(f.victimReceipt)).toMatchObject({
+        agent_id: "secondary",
+        session_key: f.victimKey,
+      });
+      expect(facts).toEqual([]);
+      if (suffixPath) {
+        expect(fs.existsSync(suffixPath)).toBe(false);
+      }
+      await assertCustody(f);
+    },
+  );
+});

--- a/src/config/sessions/session-history-budget-owner.test.ts
+++ b/src/config/sessions/session-history-budget-owner.test.ts
@@ -1,0 +1,503 @@
+import { channel } from "node:diagnostics_channel";
+import fs from "node:fs";
+import path from "node:path";
+import type { SQLInputValue } from "node:sqlite";
+import type { Worker } from "node:worker_threads";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
+import * as queue from "../../shared/store-writer-queue.js";
+import {
+  closeOpenClawAgentDatabasesAsync,
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+  resolveIncognitoOpenClawAgentSqlitePath,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { readSessionArchiveContentSync } from "./archive-compression.js";
+import * as diskBudget from "./disk-budget.js";
+import { appendTranscriptMessage, resetSessionEntryLifecycle } from "./session-accessor.js";
+import * as archiveStore from "./session-accessor.sqlite-archive-store.js";
+import * as archives from "./session-accessor.sqlite-archive.js";
+import { patchSessionEntryCore, replaceSessionEntrySync } from "./session-accessor.sqlite-entry.js";
+import * as reclamation from "./session-accessor.sqlite-reclamation.js";
+import * as entryEviction from "./session-history-entry-eviction.runtime.js";
+import {
+  enforceSqliteSessionHistoryDiskBudget,
+  inspectSqliteSessionHistoryDiskBudget,
+  kickSessionHistoryDiskBudgetMaintenance,
+} from "./session-history-eviction.js";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+import { resolveMaintenanceConfigFromInput } from "./store-maintenance.js";
+
+const states: OpenClawTestState[] = [];
+const work: Promise<unknown>[] = [];
+const releaseGates: Array<() => void> = [];
+const workers: Worker[] = [];
+const workerChannel = channel("worker_threads");
+const trackWorker = (message: unknown) => workers.push((message as { worker: Worker }).worker);
+beforeEach(() => workerChannel.subscribe(trackWorker));
+afterEach(async () => {
+  for (const release of releaseGates.splice(0)) {
+    release();
+  }
+  await Promise.allSettled(work.splice(0));
+  vi.restoreAllMocks();
+  await closeOpenClawAgentDatabasesAsync();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  workerChannel.unsubscribe(trackWorker);
+  // Archive/reclamation promises above already joined their Workers; the measurement pool is idle.
+  await Promise.all(workers.splice(0).map((worker) => worker.terminate()));
+  vi.unstubAllEnvs();
+  for (const state of states.splice(0).toReversed()) {
+    await state.cleanup();
+  }
+});
+
+function readRow(databasePath: string, sql: string, ...values: SQLInputValue[]) {
+  // Independent read-only evidence must not register, lease, or warm an agent owner.
+  const database = openNodeSqliteDatabase(databasePath, { readOnly: true });
+  try {
+    return database.prepare(sql).get(...values);
+  } finally {
+    database.close();
+  }
+}
+
+type QueueObservation = {
+  mock: {
+    calls: Array<Parameters<typeof queue.runQueuedStoreWrite>>;
+    results: Array<{ type: string; value: unknown }>;
+  };
+};
+
+function observeFirstSweep(spy: QueueObservation) {
+  const index = spy.mock.calls.findIndex(
+    ([params]) => params.label === "enforceSqliteSessionHistoryDiskBudget",
+  );
+  const outcome = spy.mock.results[index];
+  if (!outcome || outcome.type !== "return" || !(outcome.value instanceof Promise)) {
+    throw new Error("Real budget sweep was not queued");
+  }
+  const pending: Promise<unknown> = outcome.value;
+  work.push(pending);
+  return pending;
+}
+
+async function joinSeedSweeps(spy: QueueObservation): Promise<void> {
+  let joined = 0;
+  for (;;) {
+    const pending = spy.mock.calls.flatMap(([params], index) => {
+      const outcome = spy.mock.results[index];
+      return params.label === "enforceSqliteSessionHistoryDiskBudget" &&
+        outcome?.type === "return" &&
+        outcome.value instanceof Promise
+        ? [outcome.value as Promise<unknown>]
+        : [];
+    });
+    if (joined === pending.length) {
+      return;
+    }
+    const next = pending.slice(joined);
+    joined = pending.length;
+    work.push(...next);
+    await Promise.all(next);
+    // A settled seed sweep may enqueue its existing pending-force continuation.
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+  }
+}
+
+it.each([
+  { layout: "canonical", trigger: "kick", victim: "history" },
+  { layout: "canonical", trigger: "relative-kick", victim: "history" },
+  { layout: "custom", trigger: "kick", victim: "history" },
+  { layout: "shared", trigger: "kick", victim: "history" },
+  { layout: "canonical", trigger: "patch", victim: "history" },
+  { layout: "shared", trigger: "kick", victim: "cap-entry" },
+  { layout: "canonical", trigger: "enforce", victim: "history" },
+  { layout: "canonical", trigger: "inspect", victim: "history" },
+] as const)(
+  "retains $layout ownership for actual $trigger budget work on $victim",
+  async ({ layout, trigger, victim }) => {
+    const state = await createOpenClawTestState({
+      prefix: "budget-owner-",
+      layout: "state-only",
+      scenario: "minimal",
+    });
+    states.push(state);
+    const successor = state.path("successor-state");
+    fs.mkdirSync(successor);
+    const agentId = layout === "shared" ? "secondary" : "main";
+    const storePath =
+      layout === "canonical"
+        ? path.join(state.sessionsDir(), "sessions.json")
+        : state.path("custom", layout === "shared" ? "shared.sqlite" : "sessions.json");
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    // The exact shared locator has a main schema owner but secondary logical rows.
+    if (layout === "shared") {
+      openOpenClawAgentDatabase({ agentId: "main", path: storePath, env: state.env });
+    }
+    const sessionKey =
+      victim === "cap-entry"
+        ? `agent:${agentId}:explicit:budget-owner`
+        : `agent:${agentId}:budget-owner`;
+    const protectedKey = victim === "cap-entry" ? `agent:${agentId}:main` : sessionKey;
+    const scope = { agentId, env: state.env, storePath, sessionKey };
+    const originalId = "budget-owner-old";
+    const currentId = "budget-owner-current";
+    const marker = "synthetic retained history under original state";
+    const queueSpy = vi.spyOn(queue, "runQueuedStoreWrite");
+    replaceSessionEntrySync(scope, { sessionId: originalId, updatedAt: 1 });
+    await appendTranscriptMessage(
+      { ...scope, sessionId: originalId },
+      { message: { role: "user", content: marker + "x".repeat(64 * 1024) } },
+    );
+    if (victim === "history") {
+      await resetSessionEntryLifecycle({
+        agentId,
+        storePath,
+        target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+        buildNextEntry: () => ({ sessionId: currentId, updatedAt: 2 }),
+      });
+    } else {
+      // Keep the old generation referenced by a cap-archived node: only the entry
+      // eviction stage can reclaim it, not the unreferenced-history stage.
+      replaceSessionEntrySync(scope, {
+        sessionId: originalId,
+        updatedAt: 1,
+        archivedAt: 1,
+        archiveReason: "active-session-cap",
+      });
+      replaceSessionEntrySync(
+        { ...scope, sessionKey: protectedKey },
+        {
+          sessionId: currentId,
+          updatedAt: 2,
+        },
+      );
+    }
+    // Join seed-triggered real default-budget work; do not use a warn/no-retention drain.
+    await joinSeedSweeps(queueSpy);
+    queueSpy.mockClear();
+    const target = resolveSqliteTargetFromSessionStorePath(storePath, { agentId, env: state.env });
+    const databasePath = target.path;
+    expect(
+      readRow(
+        databasePath,
+        "SELECT session_id FROM session_windows WHERE session_id = ?",
+        originalId,
+      ),
+    ).toEqual({ session_id: originalId });
+    expect(
+      readRow(
+        databasePath,
+        "SELECT current_session_id FROM session_nodes WHERE session_key = ?",
+        protectedKey,
+      ),
+    ).toEqual({ current_session_id: currentId });
+    // Forget both the handle and process validation, exposing registration as well as lease drift.
+    closeOpenClawAgentDatabasesForTest(state.root);
+
+    let capEntryCalls = 0;
+    const deleteEntry = entryEviction.deleteDiskBudgetArchivedSessionEntry;
+    vi.spyOn(entryEviction, "deleteDiskBudgetArchivedSessionEntry").mockImplementation(
+      async (...args) => {
+        if (victim === "cap-entry" && args[0].target.canonicalKey === sessionKey) {
+          capEntryCalls += 1;
+          expect(
+            readRow(
+              databasePath,
+              "SELECT current_session_id FROM session_nodes WHERE session_key = ?",
+              sessionKey,
+            ),
+          ).toEqual({ current_session_id: originalId });
+          // The pass has warmed A while pruning. Clear it before the REAL lazy
+          // loader so a missing scope handoff cannot hide behind its cached handle.
+          closeOpenClawAgentDatabasesForTest(state.root);
+        }
+        return await deleteEntry(...args);
+      },
+    );
+    const order: string[] = [];
+    const materialize = archives.materializeSessionStateDeletePlans;
+    vi.spyOn(archives, "materializeSessionStateDeletePlans").mockImplementation(async (plans) => {
+      const result = await materialize(plans);
+      if (victim === "history" && plans.some((plan) => plan.sessionId === originalId)) {
+        expect(
+          result.find((plan) => plan.sessionId === originalId)?.archive?.bytes.byteLength,
+        ).toBeGreaterThan(0);
+        expect(
+          readRow(
+            databasePath,
+            "SELECT session_id FROM session_windows WHERE session_id = ?",
+            originalId,
+          ),
+        ).toEqual({ session_id: originalId });
+        order.push("materialized while source exists");
+      }
+      return result;
+    });
+    const reclaim = reclamation.runSqliteSessionReclamation;
+    vi.spyOn(reclamation, "runSqliteSessionReclamation").mockImplementation(async (params) => {
+      const result = await reclaim(params);
+      if (params.plan.kind === "history-eviction" && params.plan.sessionId === originalId) {
+        expect(
+          readRow(
+            databasePath,
+            "SELECT session_id FROM session_windows WHERE session_id = ?",
+            originalId,
+          ),
+        ).toBeUndefined();
+        expect(
+          readRow(
+            databasePath,
+            "SELECT length(archive_blob) AS bytes FROM session_transcript_archives WHERE session_id = ?",
+            originalId,
+          )?.bytes,
+        ).toBeGreaterThan(0);
+        order.push("canonical archive durable after deletion");
+      }
+      if (victim === "cap-entry" && params.plan.kind === "entry") {
+        expect(result).toMatchObject({ kind: "entry", value: { deleted: true } });
+        expect(
+          readRow(
+            databasePath,
+            "SELECT session_key FROM session_nodes WHERE session_key = ?",
+            sessionKey,
+          ),
+        ).toBeUndefined();
+        expect(
+          readRow(
+            databasePath,
+            "SELECT session_id FROM session_windows WHERE session_id = ?",
+            originalId,
+          ),
+        ).toBeUndefined();
+        order.push("cap-archived entry durably deleted");
+      }
+      return result;
+    });
+    const publish = archiveStore.publishSessionStateArchives;
+    vi.spyOn(archiveStore, "publishSessionStateArchives").mockImplementation(async (...args) => {
+      const result = await publish(...args);
+      const saved = result.find((archive) => archive.sessionId === originalId);
+      if (saved) {
+        expect(readSessionArchiveContentSync(saved.archivedPath)).toContain(marker);
+        order.push("archive file published");
+      }
+      return result;
+    });
+    const measured = createDeferred();
+    const release = createDeferred();
+    releaseGates.push(() => release.resolve());
+    let first = true;
+    const measure = diskBudget.measureSessionPhysicalDiskUsage;
+    vi.spyOn(diskBudget, "measureSessionPhysicalDiskUsage").mockImplementation(async (pathname) => {
+      const usage = await measure(pathname);
+      if (first && pathname === storePath) {
+        first = false;
+        expect(usage.totalBytes).toBeGreaterThan(1);
+        measured.resolve();
+        await release.promise;
+      }
+      return usage;
+    });
+    // Pure observation: preserve runQueuedStoreWrite and its callback/promise exactly.
+    const maintenanceConfig = resolveMaintenanceConfigFromInput({
+      mode: "enforce",
+      maxDiskBytes: 1,
+      highWaterBytes: 1,
+    });
+    let moveRelativeCwd: (() => void) | undefined;
+    let sweep: Promise<unknown>;
+    if (trigger === "patch") {
+      // Seed writes used the normal 30-minute throttle. Advance wall-clock time
+      // past it so the ordinary patch kick (which has no force flag) is eligible.
+      const afterThrottle = Date.now() + 31 * 60 * 1000;
+      vi.spyOn(Date, "now").mockReturnValue(afterThrottle);
+      const updaterStarted = createDeferred();
+      const finishUpdater = createDeferred();
+      releaseGates.push(() => finishUpdater.resolve());
+      const patch = patchSessionEntryCore(
+        scope,
+        async () => {
+          updaterStarted.resolve();
+          await finishUpdater.promise;
+          return { label: "patch committed under original owner" };
+        },
+        { skipMaintenance: true, maintenanceConfig },
+      );
+      work.push(patch);
+      await Promise.race([
+        updaterStarted.promise,
+        patch.then(() => {
+          throw new Error("Patch ended without entering updater");
+        }),
+      ]);
+      // The patch began in A, but its late budget kick occurs while ambient is B.
+      // Capturing B inside kick alone is insufficient: the patch must forward A.
+      vi.stubEnv("OPENCLAW_STATE_DIR", successor);
+      finishUpdater.resolve();
+      await expect(patch).resolves.toMatchObject({
+        sessionId: currentId,
+        label: "patch committed under original owner",
+      });
+      sweep = observeFirstSweep(queueSpy);
+    } else if (trigger === "kick" || trigger === "relative-kick") {
+      let suppliedEnv: NodeJS.ProcessEnv | undefined;
+      if (trigger === "relative-kick") {
+        const cwd = vi.spyOn(process, "cwd").mockReturnValue(state.root);
+        suppliedEnv = { ...state.env, OPENCLAW_STATE_DIR: "state" };
+        // state-only layout is <root>/state; the physical store locator stays absolute.
+        expect(path.join(state.root, "state")).toBe(state.stateDir);
+        expect(path.isAbsolute(storePath)).toBe(true);
+        moveRelativeCwd = () => {
+          cwd.mockReturnValue(successor);
+        };
+      }
+      kickSessionHistoryDiskBudgetMaintenance({
+        agentId,
+        storePath,
+        maintenanceConfig,
+        force: true,
+        ...(suppliedEnv ? { env: suppliedEnv } : {}),
+      });
+      sweep = observeFirstSweep(queueSpy);
+    } else {
+      const input = {
+        agentId,
+        storePath,
+        mode: "enforce" as const,
+        maintenance: maintenanceConfig,
+      };
+      sweep =
+        trigger === "inspect"
+          ? inspectSqliteSessionHistoryDiskBudget(input)
+          : enforceSqliteSessionHistoryDiskBudget(input);
+      work.push(sweep);
+    }
+    await Promise.race([
+      measured.promise,
+      sweep.then(() => {
+        throw new Error("Sweep ended without entering real measurement");
+      }),
+    ]);
+    vi.stubEnv("OPENCLAW_STATE_DIR", successor);
+    moveRelativeCwd?.();
+    // Patch commit reopened A. Remove its handle and validation before allowing
+    // the REAL first measurement to return to enforcement/preview.
+    closeOpenClawAgentDatabasesForTest(state.root);
+    release.resolve();
+    if (trigger === "inspect") {
+      await expect(sweep).resolves.toMatchObject({
+        diskBudget: { overBudget: true, removedEntries: 0, removedFiles: 0 },
+        wouldMutate: true,
+      });
+      expect(order).toEqual([]);
+    } else {
+      await expect(sweep).resolves.toMatchObject({ overBudget: true, removedEntries: 1 });
+      expect(order).toEqual(
+        victim === "history"
+          ? [
+              "materialized while source exists",
+              "canonical archive durable after deletion",
+              "archive file published",
+            ]
+          : ["cap-archived entry durably deleted"],
+      );
+    }
+    expect(capEntryCalls).toBe(victim === "cap-entry" ? 1 : 0);
+    // A one-byte high water can legitimately prune the new derived archive afterward.
+    const oldWindow = readRow(
+      databasePath,
+      "SELECT session_id FROM session_windows WHERE session_id = ?",
+      originalId,
+    );
+    if (trigger === "inspect") {
+      expect(oldWindow).toEqual({ session_id: originalId });
+    } else {
+      expect(oldWindow).toBeUndefined();
+    }
+    if (victim === "cap-entry") {
+      expect(
+        readRow(
+          databasePath,
+          "SELECT session_id FROM session_transcript_archives WHERE session_id = ?",
+          originalId,
+        ),
+      ).toBeUndefined();
+    }
+    expect(
+      readRow(
+        databasePath,
+        "SELECT current_session_id FROM session_nodes WHERE session_key = ?",
+        protectedKey,
+      ),
+    ).toEqual({ current_session_id: currentId });
+    expect(readRow(databasePath, "SELECT agent_id FROM schema_meta")).toEqual({ agent_id: "main" });
+
+    // Do not open B to inspect it: that would create the failure under test.
+    const successorFiles = fs.readdirSync(successor, { recursive: true }).map(String).toSorted();
+    const successorStatePath = resolveOpenClawStateSqlitePath({
+      OPENCLAW_STATE_DIR: trigger === "relative-kick" ? path.join(successor, "state") : successor,
+    });
+    const successorLeases = fs.existsSync(successorStatePath)
+      ? readRow(successorStatePath, "SELECT count(*) AS count FROM agent_database_leases")
+      : undefined;
+    const successorRegistration = fs.existsSync(successorStatePath)
+      ? readRow(successorStatePath, "SELECT agent_id, path FROM agent_databases LIMIT 1")
+      : undefined;
+    expect
+      .soft(successorRegistration, "budget admission must not register A's file in B")
+      .toBeUndefined();
+    expect
+      .soft(successorLeases, "budget admission must not claim a runtime lease in B")
+      .toBeUndefined();
+    expect(
+      successorFiles,
+      "absolute file ownership must retain the originating shared-state owner",
+    ).toEqual([]);
+  },
+);
+
+it("skips an originating incognito budget kick without disk or background work", async () => {
+  const state = await createOpenClawTestState({ layout: "state-only", scenario: "empty" });
+  states.push(state);
+  const successor = state.path("successor-state");
+  fs.mkdirSync(successor);
+  const sentinel = resolveIncognitoOpenClawAgentSqlitePath({ agentId: "main", env: state.env });
+  const memory = openOpenClawAgentDatabase({ agentId: "main", env: state.env, path: sentinel });
+  const queueSpy = vi.spyOn(queue, "runQueuedStoreWrite");
+  const measureSpy = vi.spyOn(diskBudget, "measureSessionPhysicalDiskUsage");
+  kickSessionHistoryDiskBudgetMaintenance({
+    agentId: "main",
+    storePath: sentinel,
+    force: true,
+    maintenanceConfig: resolveMaintenanceConfigFromInput({
+      mode: "enforce",
+      maxDiskBytes: 1,
+      highWaterBytes: 1,
+    }),
+  });
+  vi.stubEnv("OPENCLAW_STATE_DIR", successor);
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+  expect(
+    queueSpy.mock.calls.filter(
+      ([params]) => params.label === "enforceSqliteSessionHistoryDiskBudget",
+    ),
+  ).toEqual([]);
+  expect(measureSpy).not.toHaveBeenCalled();
+  expect(memory.db.isOpen).toBe(true);
+  expect(fs.existsSync(path.dirname(sentinel))).toBe(false);
+  expect(fs.readdirSync(successor)).toEqual([]);
+});

--- a/src/config/sessions/session-history-entry-eviction.runtime.ts
+++ b/src/config/sessions/session-history-entry-eviction.runtime.ts
@@ -2,11 +2,13 @@ import type {
   DeleteSessionEntryLifecycleParams,
   DeleteSessionEntryLifecycleResult,
 } from "./session-accessor.lifecycle-types.js";
+import type { ResolvedSqliteScope } from "./session-accessor.sqlite-scope.js";
 
 export async function deleteDiskBudgetArchivedSessionEntry(
   params: DeleteSessionEntryLifecycleParams,
+  resolved: ResolvedSqliteScope,
 ): Promise<DeleteSessionEntryLifecycleResult> {
   const { deleteDiskBudgetSessionEntryLifecycle } =
     await import("./session-accessor.sqlite-lifecycle.js");
-  return await deleteDiskBudgetSessionEntryLifecycle(params);
+  return await deleteDiskBudgetSessionEntryLifecycle(params, resolved);
 }

--- a/src/config/sessions/session-history-eviction.ts
+++ b/src/config/sessions/session-history-eviction.ts
@@ -11,6 +11,7 @@ import {
   type OpenClawAgentDatabase,
   type OpenClawAgentDatabaseOptions,
 } from "../../state/openclaw-agent-db.js";
+import { resolveStateDir } from "../paths.js";
 import {
   hasRetainedSessionTranscriptArchives,
   measureSessionPhysicalDiskUsage,
@@ -56,6 +57,7 @@ import type { SessionEntry } from "./types.js";
 
 type SessionHistoryDiskBudgetParams = {
   agentId?: string;
+  env?: NodeJS.ProcessEnv;
   mode: ResolvedSessionMaintenanceConfig["mode"];
   storePath: string;
   maintenance: Pick<ResolvedSessionMaintenanceConfig, "highWaterBytes" | "maxDiskBytes"> &
@@ -85,8 +87,10 @@ function createPhysicalBudgetResult(params: {
 
 /** Reports the same physical total enforce mode compares, without projecting logical row bytes. */
 export async function inspectSqliteSessionHistoryDiskBudget(
-  params: SessionHistoryDiskBudgetParams,
+  input: SessionHistoryDiskBudgetParams,
 ): Promise<{ diskBudget: SessionDiskBudgetSweepResult | null; wouldMutate: boolean }> {
+  const params = { ...input, env: { ...(input.env ?? process.env) } };
+  params.env.OPENCLAW_STATE_DIR = resolveStateDir(params.env);
   const { highWaterBytes, maxDiskBytes } = params.maintenance;
   if (maxDiskBytes == null || highWaterBytes == null) {
     return { diskBudget: null, wouldMutate: false };
@@ -105,6 +109,7 @@ export async function inspectSqliteSessionHistoryDiskBudget(
   // preview; applied summaries report it via their byte-decrease predicate.
   const resolved = resolveSqliteScope({
     ...(params.agentId ? { agentId: params.agentId } : {}),
+    env: params.env,
     sessionKey: "",
     storePath: params.storePath,
   });
@@ -360,8 +365,9 @@ const budgetKickStateByStore = new Map<
 >();
 
 /** Fire-and-forget budget pass from the ordinary entry-write maintenance seam. */
-export function kickSessionHistoryDiskBudgetMaintenance(params: {
+export function kickSessionHistoryDiskBudgetMaintenance(input: {
   agentId?: string;
+  env?: NodeJS.ProcessEnv;
   storePath: string;
   maintenanceConfig?: ResolvedSessionMaintenanceConfig;
   now?: number;
@@ -370,12 +376,15 @@ export function kickSessionHistoryDiskBudgetMaintenance(params: {
   force?: boolean;
 }): void {
   if (
-    params.agentId &&
-    isIncognitoOpenClawAgentSqlitePath(params.storePath, { agentId: params.agentId })
+    input.agentId &&
+    isIncognitoOpenClawAgentSqlitePath(input.storePath, {
+      agentId: input.agentId,
+      env: input.env,
+    })
   ) {
     return;
   }
-  const maintenance = params.maintenanceConfig ?? resolveMaintenanceConfig();
+  const maintenance = input.maintenanceConfig ?? resolveMaintenanceConfig();
   if (
     maintenance.mode !== "enforce" ||
     maintenance.maxDiskBytes == null ||
@@ -383,8 +392,8 @@ export function kickSessionHistoryDiskBudgetMaintenance(params: {
   ) {
     return;
   }
-  const now = params.now ?? Date.now();
-  const state = budgetKickStateByStore.get(params.storePath) ?? {
+  const now = input.now ?? Date.now();
+  const state = budgetKickStateByStore.get(input.storePath) ?? {
     lastCheckAt: 0,
     running: false,
     pendingForce: false,
@@ -393,21 +402,24 @@ export function kickSessionHistoryDiskBudgetMaintenance(params: {
     // A running pass may already have taken its last measurement; a forced
     // kick (post-delete spike) must not be dropped or the store could stay
     // over budget until the next unrelated write.
-    state.pendingForce = state.pendingForce || params.force === true;
-    budgetKickStateByStore.set(params.storePath, state);
+    state.pendingForce = state.pendingForce || input.force === true;
+    budgetKickStateByStore.set(input.storePath, state);
     return;
   }
-  if (!params.force && now - state.lastCheckAt < PHYSICAL_BUDGET_CHECK_INTERVAL_MS) {
+  if (!input.force && now - state.lastCheckAt < PHYSICAL_BUDGET_CHECK_INTERVAL_MS) {
     // Dropped, not deferred: every entry write (including heartbeats) re-kicks,
     // so a store that goes over budget is rechecked on the next activity.
     // Reset/delete use force and bypass this window entirely.
     return;
   }
+  const params = { ...input, env: { ...(input.env ?? process.env) } };
+  params.env.OPENCLAW_STATE_DIR = resolveStateDir(params.env);
   state.lastCheckAt = now;
   state.running = true;
   budgetKickStateByStore.set(params.storePath, state);
   void enforceSqliteSessionHistoryDiskBudget({
     ...(params.agentId ? { agentId: params.agentId } : {}),
+    env: params.env,
     storePath: params.storePath,
     mode: maintenance.mode,
     maintenance,
@@ -437,8 +449,11 @@ const SESSION_HISTORY_MAINTENANCE_QUEUES = new Map<string, StoreWriterQueue>();
 
 /** Extracts historical sessions durably before reclaiming their SQLite rows. */
 export async function enforceSqliteSessionHistoryDiskBudget(
-  params: SessionHistoryDiskBudgetParams,
+  input: SessionHistoryDiskBudgetParams,
 ): Promise<SessionDiskBudgetSweepResult | null> {
+  // Measurement and queued cleanup must keep the invoking shared-state owner.
+  const params = { ...input, env: { ...(input.env ?? process.env) } };
+  params.env.OPENCLAW_STATE_DIR = resolveStateDir(params.env);
   return await runQueuedStoreWrite({
     queues: SESSION_HISTORY_MAINTENANCE_QUEUES,
     storePath: params.storePath,
@@ -469,6 +484,7 @@ async function enforceSessionHistoryMaintenanceSerialized(
 
   const resolved = resolveSqliteScope({
     ...(params.agentId ? { agentId: params.agentId } : {}),
+    env: params.env,
     sessionKey: "",
     storePath: params.storePath,
   });
@@ -635,16 +651,19 @@ async function enforceSessionHistoryMaintenanceSerialized(
           scope: params.storePath,
           identities: [candidate.sessionKey, candidate.entry.sessionId],
           run: async () =>
-            await deleteDiskBudgetArchivedSessionEntry({
-              ...(params.agentId ? { agentId: params.agentId } : {}),
-              archiveTranscript: false,
-              deleteDeliveryArtifacts: true,
-              deleteTranscriptWithoutArchive: true,
-              expectedEntry: candidate.entry,
-              expectedSessionId: candidate.entry.sessionId,
-              storePath: params.storePath,
-              target: { canonicalKey: candidate.sessionKey, storeKeys: [candidate.sessionKey] },
-            }),
+            await deleteDiskBudgetArchivedSessionEntry(
+              {
+                ...(params.agentId ? { agentId: params.agentId } : {}),
+                archiveTranscript: false,
+                deleteDeliveryArtifacts: true,
+                deleteTranscriptWithoutArchive: true,
+                expectedEntry: candidate.entry,
+                expectedSessionId: candidate.entry.sessionId,
+                storePath: params.storePath,
+                target: { canonicalKey: candidate.sessionKey, storeKeys: [candidate.sessionKey] },
+              },
+              resolved,
+            ),
         });
         if (!deletion.deleted) {
           continue;

--- a/src/state/openclaw-agent-admission-order.diagnostic.test.ts
+++ b/src/state/openclaw-agent-admission-order.diagnostic.test.ts
@@ -19,11 +19,13 @@ import {
   closeOpenClawAgentDatabasesForTest,
   closeOpenClawAgentDatabasesAsync,
   disposeOpenClawAgentDatabaseByPath,
+  inspectOpenClawAgentDatabaseOwner,
   listOpenClawRegisteredAgentDatabases,
   openOpenClawAgentDatabase,
   withOpenClawAgentDatabaseAsync,
   runOpenClawAgentWriteTransaction,
   resolveIncognitoOpenClawAgentSqlitePath,
+  resolveOpenClawAgentSqlitePath,
 } from "./openclaw-agent-db.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -83,7 +85,11 @@ function corruptForeignKey(writer: DatabaseSync) {
   expect(writer.prepare("PRAGMA foreign_key_check").all()).toHaveLength(1);
 }
 
-function commitAfterCheck(pathname: string, gate: "integrity" | "foreign-key", commit: () => void) {
+function tracePhysicalChecks(
+  pathname: string,
+  gate?: "integrity" | "foreign-key",
+  commit?: () => void,
+) {
   let completed = false;
   const events: string[] = [];
   vi.spyOn(sqlite, "openNodeSqliteDatabase").mockImplementation((location, options) => {
@@ -99,7 +105,7 @@ function commitAfterCheck(pathname: string, gate: "integrity" | "foreign-key", c
         statement.all = () => {
           const rows = all();
           events.push("integrity-completed");
-          if (!completed && gate === "integrity") {
+          if (commit && !completed && gate === "integrity") {
             completed = true;
             commit();
             events.push("external-commit");
@@ -112,7 +118,7 @@ function commitAfterCheck(pathname: string, gate: "integrity" | "foreign-key", c
         statement.iterate = function* () {
           yield* iterate();
           events.push("foreign-key-completed");
-          if (!completed && gate === "foreign-key") {
+          if (commit && !completed && gate === "foreign-key") {
             completed = true;
             commit();
             events.push("external-commit");
@@ -143,7 +149,7 @@ function ordinaryWrite(options: Parameters<typeof openOpenClawAgentDatabase>[0])
 describe("physical-open admission ordering", () => {
   it("rejects an external FK violation committed between full integrity and FK checks", () => {
     const { options, pathname, writer } = seed();
-    const trace = commitAfterCheck(pathname, "integrity", () => corruptForeignKey(writer));
+    const trace = tracePhysicalChecks(pathname, "integrity", () => corruptForeignKey(writer));
     expect(() => openOpenClawAgentDatabase(options)).toThrow(/foreign_key_check failed/);
     expect(trace.events).toEqual([
       "integrity-completed",
@@ -154,7 +160,7 @@ describe("physical-open admission ordering", () => {
 
   it("exposes and writes after an external FK violation committed after the FK check", () => {
     const { options, pathname, writer } = seed();
-    const trace = commitAfterCheck(pathname, "foreign-key", () => corruptForeignKey(writer));
+    const trace = tracePhysicalChecks(pathname, "foreign-key", () => corruptForeignKey(writer));
     const database = openOpenClawAgentDatabase(options);
     expect(trace.events).toEqual([
       "integrity-completed",
@@ -179,7 +185,7 @@ describe("physical-open admission ordering", () => {
     "rejects concurrent %s replacement after the physical checks before exposure",
     (replacement) => {
       const { options, pathname, writer } = seed();
-      const trace = commitAfterCheck(pathname, "foreign-key", () => {
+      const trace = tracePhysicalChecks(pathname, "foreign-key", () => {
         if (replacement === "agent-id") {
           writer.exec("UPDATE schema_meta SET agent_id='replacement' WHERE meta_key='primary'");
         } else if (replacement === "role") {
@@ -438,7 +444,7 @@ describe("asynchronous canonical admission", () => {
   });
 
   it.each(["new", "registered replacement", "disposed replacement"] as const)(
-    "initializes a %s database after read-only physical admission",
+    "publishes a %s database after full checks and before yielding",
     async (mode) => {
       const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-open-empty-"));
       roots.push(root);
@@ -454,9 +460,18 @@ describe("asynchronous canonical admission", () => {
         }
         fs.renameSync(path.dirname(original.path), `${path.dirname(original.path)}-retired`);
       }
-      const check = vi.spyOn(integrityWorker, "assertSqliteIntegrityInWorker");
-      const database = await openOpenClawAgentDatabaseAsync(options);
-      expect(check).toHaveBeenCalledOnce();
+      const pathname = resolveOpenClawAgentSqlitePath(options);
+      const trace = tracePhysicalChecks(pathname);
+      const opening = openOpenClawAgentDatabaseAsync(options);
+      const beforeYield = {
+        checks: [...trace.events],
+        owner: inspectOpenClawAgentDatabaseOwner(pathname),
+      };
+      const database = await opening;
+      expect(beforeYield).toEqual({
+        checks: ["integrity-completed", "foreign-key-completed"],
+        owner: { status: "owned", agentId: options.agentId },
+      });
       expect(database.db.prepare("SELECT agent_id FROM schema_meta").get()).toEqual({
         agent_id: options.agentId,
       });
@@ -466,6 +481,32 @@ describe("asynchronous canonical admission", () => {
       ]);
     },
   );
+
+  it("keeps a nonempty unversioned database with no application tables on async admission", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-open-retained-pages-"));
+    roots.push(root);
+    const options = { agentId: "synthetic-retained", env: { OPENCLAW_STATE_DIR: root } };
+    const pathname = resolveOpenClawAgentSqlitePath(options);
+    fs.mkdirSync(path.dirname(pathname), { recursive: true });
+    const writer = realOpen(pathname);
+    independent.push(writer);
+    writer.exec(`
+      CREATE TABLE retired (value BLOB);
+      INSERT INTO retired VALUES (zeroblob(16384));
+      DROP TABLE retired;
+    `);
+    expect(writer.prepare("PRAGMA user_version").get()).toEqual({ user_version: 0 });
+    expect(writer.prepare("PRAGMA page_count").get()?.page_count).toBeGreaterThan(0);
+    expect(
+      writer.prepare("SELECT name FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%'").all(),
+    ).toEqual([]);
+    writer.close();
+    const check = vi.spyOn(integrityWorker, "assertSqliteIntegrityInWorker");
+    const database = await openOpenClawAgentDatabaseAsync(options);
+    expect(check).toHaveBeenCalledOnce();
+    expect(database.agentId).toBe(options.agentId);
+    expect(ordinaryWrite(options)).toEqual({ n: 1 });
+  });
 
   it("keeps the incognito handle in memory without starting a disk checker", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-open-incognito-"));

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -16,6 +16,7 @@ import {
   verifyAndRepairCanonicalSqliteIndexSteps,
 } from "../infra/sqlite-index-schema.js";
 import {
+  assertSqliteIntegrity,
   runSqliteIntegrityOperationSync,
   type SqliteIntegrityOperation,
 } from "../infra/sqlite-integrity.js";
@@ -528,6 +529,14 @@ export function* agentDatabaseIntegrityBeforeMutationSteps(
         assertOpenClawAgentCurrentRuntimeSchema(database, { agentId, pathname }),
     });
     assertOpenClawAgentCurrentRuntimeSchema(database, { agentId, pathname });
+  } else if (
+    userVersion === 0 &&
+    !hasApplicationSchema &&
+    database.prepare("PRAGMA page_count").get()?.page_count === 0
+  ) {
+    // Publish a fresh empty database's owner before another local caller resolves its store.
+    // Yielding first leaves an occupied, unowned file that custom selectors must avoid.
+    assertSqliteIntegrity(database, pathname);
   } else {
     // Every physical open proves the full file before schema mutation or exposure.
     yield { database, databaseLabel: pathname };

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -51,6 +51,7 @@ import {
 } from "./openclaw-agent-db-schema-helpers.js";
 import {
   backfillSessionConversations,
+  dropLegacySessionTranscriptSearchSchema,
   ensureSessionAdditiveColumns,
   ensureSessionEntryValidityProjection,
   hasPendingSessionConversationRouteContextColumn,
@@ -80,22 +81,6 @@ type OpenClawAgentMetadataDatabase = Pick<OpenClawAgentKyselyDatabase, "schema_m
 type MigratedSessionEntry = Record<string, unknown>;
 
 const agentDbLog = createSubsystemLogger("state/agent-db");
-
-function dropLegacySessionTranscriptSearchSchema(db: DatabaseSync): void {
-  // The pre-landing sessions_search branch tracked JSONL file watermarks and
-  // stored session_key inside the FTS table. Both are derived caches; drop
-  // them so reconcile rebuilds the row-native index shape.
-  db.exec("DROP TABLE IF EXISTS session_transcript_files;");
-  const columns = db.prepare("PRAGMA table_info(session_transcript_fts)").all() as Array<{
-    name?: unknown;
-  }>;
-  if (columns.some((row) => row.name === "session_key")) {
-    db.exec(`
-      DROP TABLE IF EXISTS session_transcript_fts;
-      DROP TABLE IF EXISTS session_transcript_index_state;
-    `);
-  }
-}
 
 function dropLegacyMemoryIndexSchema(db: DatabaseSync): void {
   const columns = db.prepare("PRAGMA table_info(memory_index_sources)").all() as Array<{

--- a/src/state/openclaw-agent-db-session-migrations.ts
+++ b/src/state/openclaw-agent-db-session-migrations.ts
@@ -14,6 +14,20 @@ import { tableExists } from "./openclaw-state-db-schema-helpers.js";
 
 type MigratedConversationEntry = Record<string, unknown>;
 
+export function dropLegacySessionTranscriptSearchSchema(db: DatabaseSync): void {
+  // The pre-landing sessions_search branch tracked JSONL file watermarks and
+  // stored session_key inside the FTS table. Both are derived caches; drop
+  // them so reconcile rebuilds the row-native index shape.
+  db.exec("DROP TABLE IF EXISTS session_transcript_files;");
+  const columns = db.prepare("PRAGMA table_info(session_transcript_fts)").all();
+  if (columns.some((row) => row.name === "session_key")) {
+    db.exec(`
+      DROP TABLE IF EXISTS session_transcript_fts;
+      DROP TABLE IF EXISTS session_transcript_index_state;
+    `);
+  }
+}
+
 function parseConversationEntry(value: unknown): MigratedConversationEntry | undefined {
   return typeof value === "string" ? safeParseJsonRecord(value) : undefined;
 }


### PR DESCRIPTION
Related: #139674

<details>
<summary>Additional instructions</summary>

This branch is in the main repository and is editable by maintainers with repository write access.

</details>

## What Problem This Solves

Resolves a problem where cold session updates and legacy worktree startup migration pause unrelated Gateway work during database initialization. A queued update also needs to keep its original store and maintenance owner when its environment changes while awaiting work.

## Why This Change Was Made

Cold durable preparation and commit reopening use the existing asynchronous database admission owner inside the existing writer queue. The patch captures its environment, selected state root and physical database path before waiting. Commit transactions, snapshot checks and authority validation retain their existing synchronous ordering.

The same captured owner continues through physical-budget maintenance and its private deletion loader. Cleanup reuses the canonical logical-agent validator instead of resolving the store again. This preserves omitted-agent receipt cleanup in shared stores and rejects a foreign logical owner in a nonshared store before opening another database. For a custom nonshared selector, that rejection intentionally replaces the previous internal retarget-and-no-op behavior.

First-time creation retains one physical owner for concurrent callers on the same event loop: an opened connection with version zero, no application schema and zero pages completes the same full integrity and foreign-key checks synchronously before schema ownership is published. This prevents parallel first writes through a custom store selector from splitting into suffixed databases. Existing, nonempty databases keep asynchronous validation.

Production grows by 68 lines to carry these ownership facts through both admission boundaries and maintenance; the logical-agent policy remains in its existing resolver. Database schemas, retention settings and public RPC shapes are unchanged.

## User Impact

The intended benefit is shorter event-loop stalls during cold updates, with warm and incognito operations retaining direct admission. Cold completion latency is a tradeoff, not a claimed general speedup.

Synthetic Node 26.7 measurements of the existing-file admission change at `53c6acb413cc` show the tradeoff clearly:

| Cold operation | Completion, before → after | Longest timer gap, before → after |
| --- | ---: | ---: |
| Preparation reopen | 94.1 → 157.8 ms | 95.4 → 60.3 ms |
| Commit reopen | 42.2 → 105.2 ms | 43.4 → 25.2 ms |
| Single-row worktree migration | 124.6 → 177.3 ms | 124.9 → 64.5 ms |

These are medians from six alternating pairs per patch case and two per startup case, using byte-identical restored fixtures within each pair (about 17 MB). Cold owner completion costs about 53–64 ms more while allowing the event loop to run earlier. Warm 100-update batches averaged about 0.51–0.61 ms per update; small before/after differences were within the A/A variation. Background maintenance joining is measured separately from the patch interval.

The accepted path scope covers normal absolute/configured store selectors, worktree startup targets and captured relative state roots. A named follow-up remains for an explicitly relative SDK store selector combined with host-global working-directory mutation; no ordinary producer of that combination was found, and this change does not claim to fix it.

## Evidence

- Original failing admission and owner-routing cases were preserved before implementation. The separate shared-store receipt and nonshared-owner controls passed on the original owner, failed on the intermediate scope handoff, and pass with the canonical validator reused.
- At `53c6acb413cc`, 272 focused tests passed on Node 26.7.0; all 31 then-changed boundary cases passed again after mechanical test-style fixes. Coverage includes cold preparation/commit, disposal and cancellation, FIFO/context behavior, state-root capture, actual over-budget cleanup, shared physical ownership, receipt outcomes and nonshared rejection.
- At `53c6acb413cc`, all 29 selected changed-code checks passed, including production/test typechecks, lint, formatting and dependency/import/schema boundaries. Independent P2 review of the corrected implementation and final cleanup is also clean.
- The original test and compiled-runtime proof verified managed closure, source, compiled outputs, installed dependencies and link ownership. Tool-generated metadata and source-bound test transforms were qualified separately. Corrected targeted runs verified source and runtime identities and managed closure. The final exact-head gate verified all 38,847 source files and 107,267 original dependency entries/links unchanged. Its 166 new Jiti transforms were independently bound to their exact source and output bytes.
- The existing-file runtime comparison used normal `sourcePerformance` builds of baseline `5c756bdbae55` and `53c6acb413cc` under Node 26.7.0. The later fresh-empty creation correction is qualified separately; these measurements are retained as observations of that earlier revision. Actual compiled parent/Worker loads were checked separately with coverage; timing runs had coverage disabled. The fixture measures the storage/startup owners, not whole-Gateway or production request latency.

The first hosted CI run exposed two concurrent-creation regressions: WhatsApp activation backfill and restart recovery. Unchanged WhatsApp ABBA passed 4/4 on the baseline twice and failed the same test on the admission candidate twice. The restart case also passed on the baseline and failed on the candidate. Physical inspection confirmed two main-owned databases and an invisible scoped entry in the candidate, versus one database with both entries on the baseline.

The correction passes both new concurrency cases on Node 24.19 and Node 26.7, all four unchanged WhatsApp activation cases, and the unchanged restart ID-only case. Both new tests first failed on the unfixed candidate and passed on the original baseline. All assertions, operation order and deadlines are preserved. The remaining seven owner/sibling test files also pass (88 tests); earlier unaffected component passes and six platform-specific skips are retained. The final cleanup moves an unchanged migration helper into its existing owner module, removes an unnecessary type assertion, and lowers the corresponding assertion allowance.

An earlier twelve-file `check-changed` attempt returned no completion result after its backing Testbox step was cancelled; it remains unqualified, with no inferred cancellation trigger. A fresh gate on published head `599b2cbd3eea` passed all 31 selected checks, with managed closure and source/dependency custody verified.

The final hosted CI initially timed out in the unchanged profiling-wrapper help test after 120 seconds. Its precise child stage and cause remain unknown. The relevant wrapper, helper and test source matches the actual CI merge checkout. The single exact-job retry completed successfully on the same published head (CI run 34095619920, attempt 2). The first timeout is retained; the retry does not establish its cause or claim to fix a flake.

The schema-file warning is a file-level classification: this PR changes no schema definition, version, table, index or stored representation. The legacy transcript-search cleanup helper moved into its existing migration owner with the same SQL and transaction call position; only an unnecessary TypeScript assertion was removed. Retained existing-database tests cover v1/v8/v10/v11/v12/v13/v16 upgrades, migration rollback, current-schema validation and integrity-before-mutation. The three session-conversation migration tests passed again after the helper move.
