### PR TITLE
fix(tests): avoid model discovery in memory budget fixtures

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -609,6 +609,27 @@ describe("runMemoryFlushIfNeeded", () => {
         : undefined,
     });
     const overrides = {
+      cfg: {
+        agents: { defaults: { compaction: { memoryFlush: {} } } },
+        models: {
+          providers: {
+            [provider]: {
+              baseUrl: "https://catalog-fixture.invalid/v1",
+              // Keep input preparation local while each case owns its catalog budget facts.
+              models: [
+                {
+                  id: model,
+                  name: model,
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  maxTokens: 4_096,
+                },
+              ],
+            },
+          },
+        },
+      } satisfies MemoryFlushTestParams["cfg"],
       followupRun,
       storePath,
       modelContextTokens: testCase.cap,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where memory-maintenance budget tests entered unrelated model-capability discovery, coupling otherwise synthetic CI cases to discovery startup.

## Why This Change Was Made

Declare the fixture model's text input in config while leaving context-window metadata under each table case's control. Prepared-window, authored-cap, provider-mismatch, and missing-catalog cases retain their original budget and flush assertions. This follows the capability-fixture boundary established in #133532 for the table added in #137440.

## User Impact

Test reliability only. Production behavior, assertions, and timeouts are unchanged.

## Evidence

- Observation-only `vi.spyOn` preserving the real discovery implementation: all original budget assertions passed on the baseline, but the three runnable cases each made one unrelated vision-catalog call. With configured text input, all five cases passed with zero discovery calls. The temporary observer was removed from this patch.
- Final uninstrumented memory and vision coverage: 172 tests passed across six files on Blacksmith Testbox, Node 24.19.0.
- Standard changed-file gate passed, including core test types, formatting, lint, and repository guards.
- Independent P2 review: no actionable findings.

The original 120-second CI timeout did not capture stage timing. The observation proves the unintended discovery path and its removal; it does not attribute that timeout to a specific discovery stage or constitute a cold-import benchmark.
