### PR TITLE
fix(plugins): avoid runtime loading during bundled enablement

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -328,7 +328,7 @@ See [Configuration reference](/gateway/configuration) for the full `plugins.*` s
 - `channels`, `providers`, `cliBackends`, and `skills` can all be omitted when a plugin does not need them.
 - `providerCatalogEntry` must stay lightweight and should not import broad runtime code; use it for static provider catalog metadata or narrow discovery descriptors, not request-time execution.
 - Exclusive plugin kinds are selected through `plugins.slots.*`: `kind: "memory"` via `plugins.slots.memory` (default `memory-core`), `kind: "context-engine"` via `plugins.slots.contextEngine` (default `legacy`).
-- Declare exclusive plugin kind in this manifest. Runtime-entry `OpenClawPluginDefinition.kind` is deprecated and remains only as a compatibility fallback for older plugins.
+- Declare exclusive plugin kind in this manifest. Bundled plugins use manifest kinds without loading their runtime during enablement. Runtime-entry `OpenClawPluginDefinition.kind` is deprecated and remains only as a compatibility fallback for older external plugins.
 - Env-var metadata in `setup.providers[].envVars` is declarative only. Status, audit, cron delivery validation, and other read-only surfaces still apply plugin trust and effective activation policy before treating an env var as configured.
 - For runtime wizard metadata that requires provider code, see [Provider runtime hooks](/plugins/architecture-internals#provider-runtime-hooks).
 - If your plugin depends on native modules, document the build steps and any package-manager allowlist requirements (for example, pnpm `allow-build-scripts` + `pnpm rebuild <package>`).

--- a/src/plugins/management-mutations.ts
+++ b/src/plugins/management-mutations.ts
@@ -37,6 +37,7 @@ import {
   refreshManagedPluginMetadata,
   listManagedPlugins,
 } from "./management-service.js";
+import { isBundledManifestOwner } from "./manifest-owner-policy.js";
 import {
   getOfficialExternalPluginCatalogManifest,
   listOfficialExternalPluginCatalogEntries,
@@ -381,8 +382,10 @@ export async function mutateManagedPluginEnabled(
       }
       next = enableResult.config;
       policyPluginId = enableResult.pluginId;
-      // CLI slot inspection uses the enabled config, including legacy runtime-only kinds.
-      const slotResult = applySlotSelectionForPlugin(next, pluginId, cli ? undefined : metadata);
+      // Bundled kinds are already prepared under this lease. External CLI inspection
+      // still needs the enabled config to resolve legacy runtime-only kinds.
+      const slotMetadata = cli && !isBundledManifestOwner(installedPlugin) ? undefined : metadata;
+      const slotResult = applySlotSelectionForPlugin(next, pluginId, slotMetadata);
       next = slotResult.config;
       slotWarnings.push(...slotResult.warnings);
     } else {

--- a/src/plugins/slot-selection.ts
+++ b/src/plugins/slot-selection.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isBundledManifestOwner } from "./manifest-owner-policy.js";
 import type { PluginKind } from "./plugin-kind.types.js";
 import {
   loadPluginMetadataSnapshot,
@@ -49,17 +50,14 @@ export function applySlotSelectionForPlugin(
       config,
       env: process.env,
     });
-  const report: SlotSelectionRegistry = {
-    plugins: metadataSnapshot.plugins
-      .filter((plugin) => plugin.id === pluginId)
-      .map((plugin) => ({ id: plugin.id, kind: plugin.kind })),
-  };
-  const plugin = report.plugins.find((entry) => entry.id === pluginId);
+  const plugin = metadataSnapshot.plugins.find((entry) => entry.id === pluginId);
   if (!plugin) {
     return { config, warnings: [] };
   }
-  if (!plugin.kind) {
-    // Older manifests need runtime kind inspection against the same prepared candidate.
+  const report: SlotSelectionRegistry = { plugins: [plugin] };
+  if (!plugin.kind && !isBundledManifestOwner(plugin)) {
+    // Bundled manifests own slot declarations. Only legacy external plugins need
+    // runtime kind inspection; enabling a bundled non-slot plugin must not execute its module.
     const runtimeReport = buildPluginDiagnosticsReport({
       config,
       onlyPluginIds: [plugin.id],

--- a/src/plugins/status.runtime-inspection.test.ts
+++ b/src/plugins/status.runtime-inspection.test.ts
@@ -16,6 +16,7 @@ import {
   useNoBundledPlugins,
   writePlugin,
 } from "./loader.test-fixtures.js";
+import { mutateManagedPluginEnabled } from "./management-mutations.js";
 import { withPluginLifecycleLease } from "./plugin-lifecycle-lease.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
@@ -33,6 +34,57 @@ describe("plugin runtime inspection", () => {
   afterAll(() => {
     cleanupPluginLoaderFixturesForTest();
   });
+
+  it.each([
+    { source: "bundled", kind: undefined, runtimeKind: undefined },
+    { source: "bundled", kind: "memory", runtimeKind: undefined },
+    { source: "config", kind: undefined, runtimeKind: "memory" },
+  ] as const)(
+    "enables a $source plugin with manifest kind $kind and runtime kind $runtimeKind",
+    async ({ source, kind, runtimeKind }) => {
+      const stateDir = makePluginLoaderTempDir();
+      const bundledDir = makePluginLoaderTempDir();
+      const pluginId = "policy-candidate";
+      const imported = path.join(stateDir, "runtime-imported");
+      const plugin = writePlugin({
+        id: pluginId,
+        dir: path.join(bundledDir, pluginId),
+        filename: "index.cjs",
+        body: `require("node:fs").writeFileSync(${JSON.stringify(imported)}, "imported"); module.exports = { id: ${JSON.stringify(pluginId)}, kind: ${JSON.stringify(runtimeKind)}, register() {} };`,
+      });
+      const manifestPath = path.join(plugin.dir, "openclaw.plugin.json");
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+      fs.writeFileSync(manifestPath, JSON.stringify({ ...manifest, ...(kind ? { kind } : {}) }));
+      await withEnvAsync(
+        {
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+          OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: source === "bundled" ? undefined : "1",
+        },
+        async () => {
+          await writeConfigFile({
+            plugins: {
+              ...(source === "config" ? { load: { paths: [plugin.file] }, allow: [pluginId] } : {}),
+              entries: { [pluginId]: { enabled: false } },
+            },
+          });
+          const result = await mutateManagedPluginEnabled({
+            pluginId,
+            enabled: true,
+            caller: "cli",
+          });
+          expect(result.status).toBe("committed");
+          const { snapshot } = await readConfigFileSnapshotForWrite();
+          expect(snapshot.sourceConfig.plugins?.entries?.[pluginId]?.enabled).toBe(true);
+          expect(snapshot.sourceConfig.plugins?.slots?.memory).toBe(
+            kind || runtimeKind ? pluginId : undefined,
+          );
+          expect(fs.existsSync(imported)).toBe(source !== "bundled");
+        },
+      );
+    },
+  );
 
   it("selects a newly installed legacy runtime kind without changing the running inventory", () => {
     const plugin = writePlugin({


### PR DESCRIPTION
## What Problem This Solves

Enabling a bundled plugin without an exclusive kind can execute its runtime solely to discover that it owns no slot. The CLI also reconstructs metadata after it has already prepared the same bundled manifest. Cloud-node bootstrap calls this path during activation; an earlier warm-start observation spent 41.201 seconds in that phase.

## Why This Change Was Made

Bundled manifests are authoritative for exclusive slot kinds. Reuse their prepared metadata under the existing lifecycle lease and avoid runtime inspection when no kind is declared. External CLI plugins retain fresh inspection against the enabled config and the documented legacy runtime-kind fallback. The discarded selected-plugin projection is removed instead of adding a cache or another activation path.

## User Impact

Bundled enablement persists activation policy without executing the plugin just to resolve its slot. Slot selection, capability consent, restrictive allowlists, missing-plugin results, config-write ownership, and registry refresh keep their existing behavior. There are no added, removed, or changed config keys/defaults, CLI flags, schemas, or stored representations. Existing external plugins with runtime-only kinds retain their compatibility path; bundled memory owners already declare their kinds in their manifests.

## Evidence

- The real config-mutation regression failed before the fix because a bundled plugin's module executed. With the fix it verifies persisted enablement, declared memory-slot selection, and no bundled runtime import. External legacy CLI enablement still imports the required runtime and selects its memory slot. All 58 focused tests pass across `src/plugins/slots.test.ts`, `src/plugins/status.runtime-inspection.test.ts`, and `src/cli/plugins-cli.policy.test.ts`.
- Changed-surface gates and independent managed review passed. [Exact-head CI run 34085636778](https://github.com/openclaw/openclaw/actions/runs/34085636778) is successful for `4f2b533c468c0d6d8021fcc02d481558f636bba5`.
- `pnpm build` passed in 245.7 seconds on the frozen combined validation source: captured main `28a4d41744af04bc68c6877fdc19753f7ef96b77` plus this plugin patch, the separate warm-readiness patch, and private diagnostic instrumentation. This is an instrumented combined candidate, not unmodified main or an isolated timing experiment for this PR.
- The required affected-entrypoint profile passed on both existing builds with `OPENCLAW_LOCAL_CHECK=0 node --import tsx scripts/profile-extension-memory.mts --extension codex --skip-combined --concurrency 1`. The build-readiness owner returned `built: false`; neither build was changed. Baseline `b39b6276cac298ce4562182f1b42335e03042397`: 151.484 MB peak RSS, +108.094 MB over its empty-Node baseline. Combined candidate: 150.656 MB, +107.156 MB. These are one-sample import/RSS measurements, not plugin-enable timing or an asserted memory improvement.

Live phase and complete dispatch observations:

| Run | Plugin activation | Complete repository-session dispatch |
| --- | ---: | ---: |
| Earlier baseline, cold | 2.976 s | 174.813 s |
| Earlier baseline, warm | 41.201 s | 211.093 s |
| Combined candidate, fresh cold | 4.449 s | 266.398 s |
| Combined candidate, warm | 4.659 s | 263.936 s |

These measurements establish that the changed plugin-activation phase completed in both candidate runs; they do **not** establish a complete-bootstrap speedup. The candidate cold run completed a real model turn and normal checkpoint/Stop flow. The candidate warm run dispatched and restored its files, then its real model turn failed in the execution transport (`execution socket closed`). That later execution-deadline failure remains a separate follow-up and is not counted as successful end-to-end proof. Both runs completed canonical provider cleanup with no attached session or owned process left running.

ClawSweeper's build/profile/timing rank-up move is addressed by the explicit build, entrypoint profile, and complete-dispatch comparison above. The compatibility check confirms no new operator action or configuration migration: the changed decision is limited to using bundled manifest kinds, with external legacy discovery preserved. The separate warm execution failure and remaining end-to-end latency are recorded rather than attributed to this plugin repair.

Production delta: +1 line; tests +52; manifest documentation clarified with zero net lines. This follows the metadata-ownership work in https://github.com/openclaw/openclaw/pull/131442 and keeps the canonical plugin policy mutation path.
