### PR TITLE
fix(agents): preserve Claude ask_user deadlines

### DIFF
--- a/src/agents/cli-runner/execute-ask-user-deadline.ts
+++ b/src/agents/cli-runner/execute-ask-user-deadline.ts
@@ -1,0 +1,74 @@
+import type * as Loopback from "../../gateway/mcp-http.loopback-runtime.js";
+import { resolveQuestionTimeoutMs } from "../tools/ask-user-tool-normalization.js";
+
+type McpTerminalOutcome = Loopback.McpLoopbackToolCallTerminalOutcome;
+export type CliToolTerminalOutcome = McpTerminalOutcome | { outcome: "completed" };
+export type CliLoopbackCall = {
+  admitted: Loopback.McpLoopbackToolCallStart;
+  current: Loopback.McpLoopbackToolCallStart;
+  boundToolCallId?: string;
+  outcome?: CliToolTerminalOutcome;
+  ambiguous: boolean;
+  ambiguityGroup?: CliLoopbackAmbiguityGroup;
+};
+export type CliLoopbackAmbiguityGroup = {
+  calls: Set<CliLoopbackCall>;
+  activeToolCallIds: Set<string>;
+};
+export type ActiveCliTool = Loopback.McpLoopbackToolCallStart & {
+  loopbackCall?: CliLoopbackCall;
+  loopbackAmbiguous: boolean;
+  ambiguityGroup?: CliLoopbackAmbiguityGroup;
+};
+
+export function createAskUserDeadlineTracking(
+  activeTools: ReadonlyMap<string, ActiveCliTool>,
+  isOverflowed: () => boolean,
+) {
+  const deadlines = new WeakMap<CliLoopbackCall, number>();
+  const state: { listeners: Set<() => void>; selected: number | undefined } = {
+    listeners: new Set(),
+    selected: undefined,
+  };
+  const selectDeadline = () => {
+    if (isOverflowed()) {
+      return undefined;
+    }
+    let earliest = Number.POSITIVE_INFINITY;
+    for (const { loopbackCall: call, loopbackAmbiguous } of activeTools.values()) {
+      if (!call || loopbackAmbiguous || call.ambiguous) {
+        continue;
+      }
+      earliest = Math.min(earliest, deadlines.get(call) ?? Number.POSITIVE_INFINITY);
+    }
+    return Number.isFinite(earliest) ? earliest : undefined;
+  };
+  const refresh = () => {
+    const nextDeadline = selectDeadline();
+    if (nextDeadline === state.selected) {
+      return;
+    }
+    state.selected = nextDeadline;
+    state.listeners.forEach((listener) => listener());
+  };
+  const clear = (call: CliLoopbackCall) => {
+    deadlines.delete(call);
+    refresh();
+  };
+  const update = (call: CliLoopbackCall, toolName: string, args: Record<string, unknown>) => {
+    deadlines.delete(call);
+    if (toolName === "ask_user") {
+      try {
+        deadlines.set(call, Date.now() + resolveQuestionTimeoutMs(args.timeoutSeconds));
+      } catch {
+        // Invalid timeout input must not arm a watchdog deadline.
+      }
+    }
+    refresh();
+  };
+  const onChange = (listener: () => void) => {
+    state.listeners.add(listener);
+    return () => void state.listeners.delete(listener);
+  };
+  return { clear, update, refresh, get: () => state.selected, onChange };
+}

--- a/src/agents/cli-runner/execute-plugin.ask-user-timeout.test.ts
+++ b/src/agents/cli-runner/execute-plugin.ask-user-timeout.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import {
+  closePluginTestAdmissions,
+  createExecution,
+  runPlugin,
+  SUCCESS_RESULT,
+} from "./execute-plugin.test-support.js";
+
+async function startBlockedRun(options: {
+  timeoutMs: number;
+  getDeadline: () => number | undefined;
+  onChange?: (listener: () => void) => () => void;
+}) {
+  const { context } = await createExecution({ timeoutMs: options.timeoutMs });
+  const started = createDeferred();
+  const run = runPlugin(
+    context,
+    async function* ({ abortSignal }) {
+      if (!abortSignal) {
+        throw new Error("Host execution did not expose its abort signal.");
+      }
+      started.resolve();
+      await new Promise<never>((_, reject) => {
+        abortSignal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+      });
+      yield SUCCESS_RESULT;
+    },
+    {
+      noOutputTimeoutMs: 100,
+      activeToolCount: () => 1,
+      getActiveLoopbackAskUserDeadline: options.getDeadline,
+      onActiveLoopbackAskUserDeadlineChange: options.onChange ?? (() => () => {}),
+    },
+  );
+  await started.promise;
+  return { run };
+}
+
+afterEach(() => {
+  closePluginTestAdmissions();
+  vi.useRealTimers();
+});
+
+describe("plugin-owned CLI ask_user timeout", () => {
+  it.each([
+    ["uses the exact question deadline", 4_000_000, 3_610_000, "no-output-timeout"],
+    ["keeps the earlier overall deadline authoritative", 150, 150, "overall-timeout"],
+  ] as const)("%s", async (_name, timeoutMs, advanceMs, reason) => {
+    vi.useFakeTimers();
+    const deadline = Date.now() + 3_610_000;
+    const { run } = await startBlockedRun({ timeoutMs, getDeadline: () => deadline });
+    let completed = false;
+    void run.then(() => {
+      completed = true;
+    });
+    if (reason === "no-output-timeout") {
+      await vi.advanceTimersByTimeAsync(900_000);
+      expect(completed).toBe(false);
+      await vi.advanceTimersByTimeAsync(advanceMs - 900_000);
+    } else {
+      await vi.advanceTimersByTimeAsync(advanceMs);
+    }
+    await expect(run).resolves.toMatchObject({
+      reason,
+      timedOut: true,
+      noOutputTimedOut: reason === "no-output-timeout",
+    });
+  });
+
+  it("does not let a short question shrink the blocked-tool watchdog floor", async () => {
+    vi.useFakeTimers();
+    const deadline = Date.now() + 40_000;
+    const { run } = await startBlockedRun({
+      timeoutMs: 2_000_000,
+      getDeadline: () => deadline,
+    });
+    let completed = false;
+    void run.then(() => {
+      completed = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(899_999);
+    expect(completed).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(run).resolves.toMatchObject({
+      reason: "no-output-timeout",
+      noOutputTimedOut: true,
+    });
+  });
+
+  it("restores the remaining ordinary watchdog when ask_user clears early", async () => {
+    vi.useFakeTimers();
+    let deadline: number | undefined = Date.now() + 3_610_000;
+    const listeners = new Set<() => void>();
+    const { run } = await startBlockedRun({
+      timeoutMs: 2_000_000,
+      getDeadline: () => deadline,
+      onChange: (listener) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(200);
+    deadline = undefined;
+    listeners.forEach((listener) => listener());
+    await vi.advanceTimersByTimeAsync(899_799);
+    let completed = false;
+    void run.then(() => {
+      completed = true;
+    });
+    expect(completed).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(run).resolves.toMatchObject({
+      reason: "no-output-timeout",
+      noOutputTimedOut: true,
+    });
+  });
+});

--- a/src/agents/cli-runner/execute-plugin.test-support.ts
+++ b/src/agents/cli-runner/execute-plugin.test-support.ts
@@ -79,6 +79,9 @@ export function runPlugin(
       Parameters<typeof executePluginOwnedProcess>[0]["onNoOutputTimeout"]
     >;
     onOutstandingWorkChange?: (active: boolean) => void;
+    activeToolCount?: () => number;
+    getActiveLoopbackAskUserDeadline?: () => number | undefined;
+    onActiveLoopbackAskUserDeadlineChange?: (listener: () => void) => () => void;
     onInterrupted?: (reason: "aborted" | "timeout") => boolean;
   } = {},
 ) {
@@ -105,6 +108,9 @@ export function runPlugin(
       : {}),
     ...(options.onNoOutputTimeout ? { onNoOutputTimeout: options.onNoOutputTimeout } : {}),
     onOutstandingWorkChange: options.onOutstandingWorkChange,
+    activeToolCount: options.activeToolCount,
+    getActiveLoopbackAskUserDeadline: options.getActiveLoopbackAskUserDeadline,
+    onActiveLoopbackAskUserDeadlineChange: options.onActiveLoopbackAskUserDeadlineChange,
     ...(options.onInterrupted ? { onInterrupted: options.onInterrupted } : {}),
     noOutputTimeoutMs: options.noOutputTimeoutMs ?? 2_000,
     consumeStdout: options.consumeStdout ?? (() => {}),

--- a/src/agents/cli-runner/execute-plugin.ts
+++ b/src/agents/cli-runner/execute-plugin.ts
@@ -409,6 +409,8 @@ export async function executePluginOwnedProcess(params: {
   consumeStdout: (chunk: string) => void;
   onOutstandingWorkChange?: (active: boolean) => void;
   activeToolCount?: () => number;
+  getActiveLoopbackAskUserDeadline?: () => number | undefined;
+  onActiveLoopbackAskUserDeadlineChange?: (listener: () => void) => () => void;
   onNoOutputTimeout?: (error: FailoverError) => void;
   onInterrupted?: (reason: CliTerminalInterruption["reason"]) => boolean;
   liveSession?: {
@@ -454,13 +456,25 @@ export async function executePluginOwnedProcess(params: {
           termination.reason = "overall-timeout";
           controller.abort(new Error("CLI plugin runtime exceeded its execution timeout."));
         }, overallTimeoutMs);
-  const resetNoOutputTimer = (delayMs = noOutputTimeoutMs) => {
+  const activeToolCount = () => Math.max(params.activeToolCount?.() ?? 0, outstanding.approvals);
+  const resetNoOutputTimer = (delayMs?: number) => {
     clearTimeout(noOutputTimer);
-    if (delayMs === undefined || noOutputTimeoutMs === undefined) {
+    if (noOutputTimeoutMs === undefined) {
       return;
     }
+    const activeAskUserDeadline = params.getActiveLoopbackAskUserDeadline?.();
+    const baselineDeadline = outstanding.lastOutputAt + noOutputTimeoutMs;
+    const effectiveDelayMs =
+      delayMs ??
+      Math.max(
+        0,
+        (activeAskUserDeadline === undefined
+          ? baselineDeadline
+          : Math.max(baselineDeadline, activeAskUserDeadline)) - Date.now(),
+      );
     noOutputTimer = setTimeout(() => {
       const quietDurationMs = Date.now() - outstanding.lastOutputAt;
+      const askUserDeadline = params.getActiveLoopbackAskUserDeadline?.();
       const decision = noOutputPolicy.resolveCliNoOutputTimeoutDecision({
         context: {
           provider: run.provider,
@@ -474,14 +488,20 @@ export async function executePluginOwnedProcess(params: {
           mode: "no-output",
           timeoutSeconds: Math.round(quietDurationMs / 1000),
           observedActivity: outstanding.observed,
-          activeToolCount: Math.max(params.activeToolCount?.() ?? 0, outstanding.approvals),
+          activeToolCount: activeToolCount(),
           backgroundTaskCount: outstanding.background,
         },
         hasOutputText: false,
         useResume: params.useResume,
         hasReplayUnsafeActivity: outstanding.replayUnsafe,
         allowResumeControlOnlyRetry: true,
-        outstandingWorkGraceMs: BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
+        outstandingWorkGraceMs:
+          askUserDeadline === undefined
+            ? BLOCKED_TOOL_CALL_ABORT_FLOOR_MS
+            : Math.max(
+                BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
+                askUserDeadline - outstanding.lastOutputAt,
+              ),
       });
       if (decision.deferMs !== undefined) {
         resetNoOutputTimer(decision.deferMs);
@@ -490,8 +510,11 @@ export async function executePluginOwnedProcess(params: {
       termination.reason = "no-output-timeout";
       params.onNoOutputTimeout?.(decision.error);
       controller.abort(decision.error);
-    }, delayMs);
+    }, effectiveDelayMs);
   };
+  const stopAskUserDeadlineListener = params.onActiveLoopbackAskUserDeadlineChange?.(() =>
+    resetNoOutputTimer(),
+  );
 
   const replyBackendHandle = run.replyOperation
     ? {
@@ -639,6 +662,7 @@ export async function executePluginOwnedProcess(params: {
   } finally {
     clearTimeout(overallTimer);
     clearTimeout(noOutputTimer);
+    stopAskUserDeadlineListener?.();
     params.onOutstandingWorkChange?.(false);
     // Permission callbacks can be retained by the plugin or its subprocess.
     // Closing the turn fences those capabilities before any outer cleanup runs.

--- a/src/agents/cli-runner/execute-process.ts
+++ b/src/agents/cli-runner/execute-process.ts
@@ -250,6 +250,9 @@ export async function executeCliProcess(params: {
         consumeStdout,
         onOutstandingWorkChange: backendActivity?.setOutstandingWork,
         activeToolCount: params.events.activeParsedToolCount,
+        getActiveLoopbackAskUserDeadline: params.toolTracking.getActiveLoopbackAskUserDeadline,
+        onActiveLoopbackAskUserDeadlineChange:
+          params.toolTracking.onActiveLoopbackAskUserDeadlineChange,
         onNoOutputTimeout: (error) => {
           pluginTimeout.error = error;
         },

--- a/src/agents/cli-runner/execute-tool-tracking.test.ts
+++ b/src/agents/cli-runner/execute-tool-tracking.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  markMcpLoopbackToolCallStarted,
+  recordMcpLoopbackToolCallResult,
+  updateMcpLoopbackToolCallCapture,
+} from "../../gateway/mcp-http.loopback-runtime.js";
+import { buildPreparedCliRunContext } from "../cli-runner.test-helpers.js";
+import { createCliToolTracking } from "./execute-tool-tracking.js";
+
+type Tracking = ReturnType<typeof createCliToolTracking>;
+
+function createTracking() {
+  const context = buildPreparedCliRunContext();
+  context.preparedBackend.mcpClientGrantCapture = {
+    transportToken: "test-token",
+    adoptProcessToken: vi.fn(),
+    revokeProcessToken: vi.fn(),
+    activate: vi.fn(),
+    deactivate: vi.fn(),
+  };
+  const tracking = createCliToolTracking(context);
+  tracking.beginGatewayCapture("deadline-test");
+  return tracking;
+}
+
+function startParsed(tracking: Tracking, toolCallId: string, args: Record<string, unknown>) {
+  tracking.handleCliToolUseStart({
+    toolCallId,
+    name: "mcp__openclaw__ask_user",
+    kind: "mcp_tool_use",
+    args,
+  });
+}
+
+function startQuestion(tracking: Tracking, toolCallId: string, timeoutSeconds?: unknown) {
+  const args = { questions: [], timeoutSeconds };
+  startParsed(tracking, toolCallId, args);
+  const capture = markMcpLoopbackToolCallStarted({
+    captureKey: "deadline-test",
+    toolName: "ask_user",
+    args,
+  });
+  if (!capture) {
+    throw new Error("expected captured ask_user call");
+  }
+  updateMcpLoopbackToolCallCapture(capture, { toolName: "ask_user", args });
+  return capture;
+}
+
+describe("CLI loopback ask_user deadline tracking", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-07T00:00:00Z"));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("keeps the deadline until Claude emits the correlated tool result", () => {
+    const tracking = createTracking();
+    const listener = vi.fn();
+    tracking.onActiveLoopbackAskUserDeadlineChange(listener);
+    const capture = startQuestion(tracking, "tool-1");
+    expect(tracking.getActiveLoopbackAskUserDeadline()).toBe(Date.now() + 910_000);
+    expect(listener).toHaveBeenCalledOnce();
+
+    vi.advanceTimersByTime(900_000);
+    recordMcpLoopbackToolCallResult({
+      captureHandle: capture,
+      toolName: "ask_user",
+      args: capture.call.args,
+      outcome: "completed",
+    });
+    startQuestion(tracking, "tool-2", 60);
+    expect(tracking.getActiveLoopbackAskUserDeadline()).toBe(Date.now() + 10_000);
+    expect(listener).toHaveBeenCalledOnce();
+
+    tracking.handleCliToolResult({
+      toolCallId: "tool-1",
+      name: "mcp__openclaw__ask_user",
+      isError: false,
+    });
+    expect(tracking.getActiveLoopbackAskUserDeadline()).toBe(Date.now() + 70_000);
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    tracking.handleCliToolResult({
+      toolCallId: "tool-2",
+      name: "mcp__openclaw__ask_user",
+      isError: false,
+    });
+    expect(tracking.getActiveLoopbackAskUserDeadline()).toBeUndefined();
+    expect(listener).toHaveBeenCalledTimes(3);
+    tracking.finalizeCapture(() => {});
+  });
+
+  it("reports the earliest concurrent uniquely correlated question", () => {
+    const tracking = createTracking();
+    startQuestion(tracking, "later", 600);
+    vi.advanceTimersByTime(100);
+    startQuestion(tracking, "earlier", 30);
+    expect(tracking.getActiveLoopbackAskUserDeadline()).toBe(Date.now() + 40_000);
+    tracking.finalizeCapture(() => {});
+  });
+
+  it("fails closed for invalid and ambiguous correlation", () => {
+    const tracking = createTracking();
+    startQuestion(tracking, "invalid", "bad");
+    expect(tracking.getActiveLoopbackAskUserDeadline()).toBeUndefined();
+    tracking.handleCliToolResult({
+      toolCallId: "invalid",
+      name: "mcp__openclaw__ask_user",
+      isError: true,
+    });
+
+    const args = { questions: [], timeoutSeconds: 3_600 };
+    startParsed(tracking, "duplicate-1", args);
+    startParsed(tracking, "duplicate-2", args);
+    const capture = markMcpLoopbackToolCallStarted({
+      captureKey: "deadline-test",
+      toolName: "ask_user",
+      args,
+    });
+    updateMcpLoopbackToolCallCapture(capture, { toolName: "ask_user", args });
+    expect(tracking.getActiveLoopbackAskUserDeadline()).toBeUndefined();
+    tracking.finalizeCapture(() => {});
+  });
+
+  it("fails closed after correlation overflow", () => {
+    const tracking = createTracking();
+    for (let index = 0; index < 65; index += 1) {
+      startQuestion(tracking, `overflow-${index}`, 30 + index);
+      if (index === 0) {
+        expect(tracking.getActiveLoopbackAskUserDeadline()).toBeDefined();
+      }
+    }
+    expect(tracking.getActiveLoopbackAskUserDeadline()).toBeUndefined();
+    tracking.finalizeCapture(() => {});
+  });
+});

--- a/src/agents/cli-runner/execute-tool-tracking.ts
+++ b/src/agents/cli-runner/execute-tool-tracking.ts
@@ -3,7 +3,6 @@ import {
   beginMcpLoopbackToolCallCapture,
   clearMcpLoopbackToolCallCapture,
   type McpLoopbackToolCallStart,
-  type McpLoopbackToolCallTerminalOutcome,
   waitForMcpLoopbackToolCallCaptureIdle,
 } from "../../gateway/mcp-http.loopback-runtime.js";
 import { shouldUseInternalSourceReplySink } from "../../infra/outbound/internal-source-reply.js";
@@ -40,6 +39,7 @@ import {
 import { readToolResultDetails } from "../tool-result-error.js";
 import { closeCliLiveSession } from "./cli-live-session-registry.js";
 import { attachCliMessagingDeliveryEvidence } from "./delivery-evidence.js";
+import * as Deadline from "./execute-ask-user-deadline.js";
 import {
   appendUniqueCliMessagingEvidence,
   buildMessagingToolSendEvidenceKey,
@@ -53,27 +53,8 @@ import type { PreparedCliRunContext } from "./types.js";
 const CLI_LOOPBACK_CORRELATION_MAX_CALLS = 64;
 const CLI_MCP_DELIVERY_DRAIN_GRACE_MS = 5_000;
 const CLI_MCP_REQUEST_ADMISSION_GRACE_MS = 250;
-
-type CliToolTerminalOutcome = McpLoopbackToolCallTerminalOutcome | { outcome: "completed" };
-type CliLoopbackCall = {
-  admitted: McpLoopbackToolCallStart;
-  current: McpLoopbackToolCallStart;
-  boundToolCallId?: string;
-  outcome?: CliToolTerminalOutcome;
-  ambiguous: boolean;
-  ambiguityGroup?: CliLoopbackAmbiguityGroup;
-};
-type CliLoopbackAmbiguityGroup = {
-  calls: Set<CliLoopbackCall>;
-  activeToolCallIds: Set<string>;
-};
-type ActiveCliTool = {
-  toolName: string;
-  args: Record<string, unknown>;
-  loopbackCall?: CliLoopbackCall;
-  loopbackAmbiguous: boolean;
-  ambiguityGroup?: CliLoopbackAmbiguityGroup;
-};
+type ActiveCliTool = Deadline.ActiveCliTool;
+type CliLoopbackCall = Deadline.CliLoopbackCall;
 
 export function createCliToolTracking(context: PreparedCliRunContext) {
   let gatewayCaptureKey: string | undefined;
@@ -92,6 +73,10 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
   const cliLoopbackCalls: CliLoopbackCall[] = [];
   const activeCliTools = new Map<string, ActiveCliTool>();
   let cliLoopbackCorrelationOverflowed = false;
+  const askUserDeadlines = Deadline.createAskUserDeadlineTracking(
+    activeCliTools,
+    () => cliLoopbackCorrelationOverflowed,
+  );
   const messagingToolSentTexts: string[] = [];
   const messagingToolSentTextKeys = new Set<string>();
   const messagingToolSentMediaUrls: string[] = [];
@@ -118,7 +103,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
         activeTool.loopbackCall !== undefined && calls.includes(activeTool.loopbackCall),
     ),
   ) => {
-    const groups = new Set<CliLoopbackAmbiguityGroup>();
+    const groups = new Set<Deadline.CliLoopbackAmbiguityGroup>();
     for (const call of calls) {
       if (call.ambiguityGroup) {
         groups.add(call.ambiguityGroup);
@@ -161,6 +146,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
       activeTool.ambiguityGroup = group;
       group.activeToolCallIds.add(toolCallId);
     }
+    askUserDeadlines.refresh();
   };
   const matchingActiveCliTools = (call: McpLoopbackToolCallStart): Array<[string, ActiveCliTool]> =>
     Array.from(activeCliTools.entries()).filter(([, activeTool]) =>
@@ -181,6 +167,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
         }
       }
       cliLoopbackCalls.length = 0;
+      askUserDeadlines.refresh();
       return undefined;
     }
     const retained: CliLoopbackCall = { admitted: call, current: call, ambiguous: false };
@@ -199,6 +186,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
       activeTool.ambiguityGroup = call.ambiguityGroup;
       call.ambiguityGroup.activeToolCallIds.add(toolCallId);
     }
+    askUserDeadlines.refresh();
   };
   const removeCliLoopbackCall = (call: CliLoopbackCall | undefined) => {
     if (!call) {
@@ -413,6 +401,8 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
         const candidate = candidates.at(0);
         if (candidates.length === 1 && candidate && !candidate.ambiguous) {
           candidate.current = current;
+          const toolName = normalizeCliMessagingToolName(current.toolName);
+          askUserDeadlines.update(candidate, toolName, current.args);
         } else if (candidates.length > 0) {
           markCliLoopbackCallsAmbiguous(candidates);
         }
@@ -439,7 +429,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
         inFlightPreparedMessagingCalls.delete(call);
       },
       onToolCallResult: (call) => {
-        const terminalOutcome: CliToolTerminalOutcome =
+        const terminalOutcome: Deadline.CliToolTerminalOutcome =
           call.outcome === "blocked"
             ? { outcome: call.outcome, deniedReason: call.deniedReason }
             : { outcome: call.outcome };
@@ -552,6 +542,9 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
     result?: unknown;
   }) => {
     const activeTool = activeCliTools.get(event.toolCallId);
+    if (activeTool?.loopbackCall) {
+      askUserDeadlines.clear(activeTool.loopbackCall);
+    }
     activeCliTools.delete(event.toolCallId);
     retireCliLoopbackCorrelation(event.toolCallId, activeTool);
     const pending = pendingMessagingCalls.get(event.toolCallId);
@@ -664,6 +657,8 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
   });
   return {
     beginGatewayCapture,
+    getActiveLoopbackAskUserDeadline: askUserDeadlines.get,
+    onActiveLoopbackAskUserDeadlineChange: askUserDeadlines.onChange,
     handleCliToolUseStart,
     handleCliToolResult,
     resolveCliLoopbackTerminalOutcome,

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -113,6 +113,7 @@ import {
 } from "../test-helpers/model-routing-decision-e2e-fixtures.js";
 import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import type { SystemAgentToolOptions } from "../tools/system-agent-tool.js";
+import { prepareCliBundleMcpCaptureAttempt, prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 import { prepareClaudeCliSkillsPlugin } from "./claude-skills-plugin.js";
 import { executePluginOwnedProcess } from "./execute-plugin.js";
 import { prepareCliHistoryBoundary } from "./history-boundary.js";
@@ -4893,10 +4894,119 @@ describe("prepareCliRunContext", () => {
       const args = context.preparedBackend.backend.args ?? [];
       const mcpConfigPath = args[args.indexOf("--mcp-config") + 1];
       const rawBundle = JSON.parse(fs.readFileSync(mcpConfigPath ?? "", "utf-8")) as {
-        mcpServers?: Record<string, unknown>;
+        mcpServers?: Record<string, { timeout?: number }>;
       };
       expect(Object.keys(rawBundle.mcpServers ?? {})).toEqual(["openclaw"]);
+      expect(rawBundle.mcpServers?.openclaw?.timeout).toBe(3_610_000);
     } finally {
+      await cleanup?.();
+    }
+  });
+
+  it("preserves an existing user MCP timeout beside the generated Claude loopback", async () => {
+    const userMcpConfigPath = path.join(fixture.session.dir, "user-mcp.json");
+    fs.writeFileSync(
+      userMcpConfigPath,
+      JSON.stringify({
+        mcpServers: {
+          localUser: {
+            type: "http",
+            url: "http://127.0.0.1:43119/mcp",
+            timeout: 12_345,
+          },
+        },
+      }),
+    );
+    setRawCliBackendForPrepareTest({
+      id: "claude-cli",
+      pluginId: "anthropic",
+      bundleMcp: true,
+      bundleMcpMode: "claude-config-file",
+      config: {
+        command: "claude",
+        args: ["--print"],
+        resumeArgs: ["--resume", "{sessionId}"],
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        input: "stdin",
+        sessionMode: "existing",
+      },
+    });
+    setCliRunnerPrepareTestDeps({
+      getActiveMcpLoopbackRuntime: vi.fn(() => ({
+        port: 31783,
+        ownerToken: "loopback-owner-token",
+        nonOwnerToken: "loopback-non-owner-token",
+      })),
+      ensureMcpLoopbackServer: vi.fn(createTestMcpLoopbackServer),
+      createMcpLoopbackServerConfig: vi.fn(createTestMcpLoopbackServerConfig),
+      mintMcpLoopbackClientGrant: vi.fn(createTestMcpLoopbackClientGrant),
+      resolveMcpLoopbackScopedTools: vi.fn(() => ({ agentId: "main", tools: [] })),
+    });
+
+    let cleanup: (() => Promise<void>) | undefined;
+    let mergedCleanup: (() => Promise<void>) | undefined;
+    try {
+      const context = await fixture.prepare({
+        sessionKey: "agent:main:main",
+        provider: "claude-cli",
+        config: createCliBackendConfig(),
+      });
+      cleanup = context.preparedBackend.cleanup;
+      expect(context.params.cliToolAvailability).toBeUndefined();
+      const args = context.preparedBackend.backend.args ?? [];
+      const generatedConfigPath = expectDefined(
+        args[args.indexOf("--mcp-config") + 1],
+        "generated Claude MCP config path",
+      );
+      const generatedConfig = JSON.parse(
+        fs.readFileSync(generatedConfigPath, "utf-8"),
+      ) as NonNullable<Parameters<typeof prepareCliBundleMcpConfig>[0]["additionalConfig"]>;
+      expect(generatedConfig.mcpServers.openclaw?.timeout).toBe(3_610_000);
+
+      const merged = await prepareCliBundleMcpConfig({
+        enabled: true,
+        mode: "claude-config-file",
+        backend: {
+          command: "claude",
+          args: ["--print", "--mcp-config", userMcpConfigPath],
+          resumeArgs: ["--resume", "{sessionId}", "--mcp-config", userMcpConfigPath],
+        },
+        workspaceDir: fixture.session.dir,
+        additionalConfig: generatedConfig,
+      });
+      mergedCleanup = merged.cleanup;
+      const mergedArgs = merged.backend.args ?? [];
+      const mcpConfigPath = expectDefined(
+        mergedArgs[mergedArgs.indexOf("--mcp-config") + 1],
+        "merged Claude MCP config path",
+      );
+      const readConfig = () =>
+        JSON.parse(fs.readFileSync(mcpConfigPath, "utf-8")) as {
+          mcpServers?: Record<string, { headers?: Record<string, string>; timeout?: number }>;
+        };
+
+      expect(readConfig().mcpServers).toMatchObject({
+        openclaw: { timeout: 3_610_000 },
+        localUser: { timeout: 12_345 },
+      });
+
+      await prepareCliBundleMcpCaptureAttempt({
+        mode: "claude-config-file",
+        backend: merged.backend,
+        env: merged.env,
+        captureKey: "attempt-timeout-proof",
+      });
+
+      expect(readConfig().mcpServers).toMatchObject({
+        openclaw: {
+          timeout: 3_610_000,
+          headers: { "x-openclaw-cli-capture-key": "attempt-timeout-proof" },
+        },
+        localUser: { timeout: 12_345 },
+      });
+    } finally {
+      await mergedCleanup?.();
       await cleanup?.();
     }
   });

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -128,6 +128,7 @@ import { resolveSandboxRuntimeStatus } from "../sandbox/runtime-status.js";
 import { buildSystemPromptReport } from "../system-prompt-report.js";
 import { appendModelIdentitySystemPrompt, buildModelIdentityPromptLine } from "../system-prompt.js";
 import { expandToolGroups, normalizeToolPolicyName } from "../tool-policy.js";
+import { resolveQuestionTimeoutMs } from "../tools/ask-user-tool-normalization.js";
 import { assertNativeCronCreatorCapabilities } from "../tools/cron-tool-creator-cap.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
 import {
@@ -168,6 +169,8 @@ type PrivateCliBackendPreparedExecution = CliBackendPreparedExecution & {
   isolatedCompletionEnforced?: true;
   secretInput?: CliSecretInput;
 };
+
+const CLAUDE_MANAGED_MCP_TIMEOUT_MS = resolveQuestionTimeoutMs(3_600);
 
 function unsupportedIsolatedCompletionError(backendId: string): Error & { code: "unsupported" } {
   const error = new Error(
@@ -1461,9 +1464,22 @@ async function prepareCliRunContextWithinReadFence(
         }
       : undefined;
     cleanupPreparedResources = cleanupMcpClientGrant;
-    const loopbackServerConfig = mcpLoopbackRuntime
+    const rawLoopbackServerConfig = mcpLoopbackRuntime
       ? prepareDeps.createMcpLoopbackServerConfig(mcpLoopbackRuntime.port)
       : undefined;
+    const loopbackServerConfig =
+      rawLoopbackServerConfig && backendResolved.bundleMcpMode === "claude-config-file"
+        ? {
+            ...rawLoopbackServerConfig,
+            mcpServers: {
+              ...rawLoopbackServerConfig.mcpServers,
+              openclaw: {
+                ...rawLoopbackServerConfig.mcpServers.openclaw,
+                timeout: CLAUDE_MANAGED_MCP_TIMEOUT_MS,
+              },
+            },
+          }
+        : rawLoopbackServerConfig;
     const sandboxStatus = resolveSandboxRuntimeStatus({
       cfg: runConfig,
       sessionKey: policySessionKey,

--- a/src/agents/tools/ask-user-tool-normalization.ts
+++ b/src/agents/tools/ask-user-tool-normalization.ts
@@ -4,6 +4,7 @@ import type { QuestionRequestQuestion } from "../../../packages/gateway-protocol
 import { ToolInputError } from "./common.js";
 
 export const DEFAULT_ASK_USER_TIMEOUT_SECONDS = 900;
+export const QUESTION_RPC_GRACE_MS = 10_000;
 const MIN_ASK_USER_TIMEOUT_SECONDS = 30;
 const MAX_ASK_USER_TIMEOUT_SECONDS = 3600;
 const QUESTION_ID_PATTERN = /^[a-z][a-z0-9_]*$/;
@@ -109,6 +110,10 @@ export function normalizeQuestionTimeoutSeconds(rawTimeoutSeconds: unknown): num
     MAX_ASK_USER_TIMEOUT_SECONDS,
     Math.max(MIN_ASK_USER_TIMEOUT_SECONDS, rawTimeoutSeconds ?? DEFAULT_ASK_USER_TIMEOUT_SECONDS),
   );
+}
+
+export function resolveQuestionTimeoutMs(rawTimeoutSeconds: unknown): number {
+  return normalizeQuestionTimeoutSeconds(rawTimeoutSeconds) * 1_000 + QUESTION_RPC_GRACE_MS;
 }
 
 export const AskUserToolSchema = Type.Object(

--- a/src/agents/tools/ask-user-tool.ts
+++ b/src/agents/tools/ask-user-tool.ts
@@ -21,6 +21,7 @@ import { ASK_USER_TOOL_DISPLAY_SUMMARY, describeAskUserTool } from "../tool-desc
 import {
   AskUserToolSchema,
   DEFAULT_ASK_USER_TIMEOUT_SECONDS,
+  QUESTION_RPC_GRACE_MS,
   type NormalizedAskUserParams,
   normalizeAskUserParams,
 } from "./ask-user-tool-normalization.js";
@@ -33,7 +34,6 @@ import {
 } from "./gateway-question-lifecycle.js";
 import { type QuestionPromptDelivery, sendQuestionToolPrompt } from "./question-prompt-send.js";
 
-const ASK_USER_RPC_GRACE_MS = 10_000;
 const ASK_USER_PROMPT_RECHECK_MS = 50;
 
 type AskUserQuestionPhase =
@@ -216,7 +216,7 @@ async function readAskUserQuestionStatus(
   questionId: string,
   gatewayCall: GatewayQuestionCall,
 ): Promise<string | undefined> {
-  const result = await gatewayCall("question.list", { timeoutMs: ASK_USER_RPC_GRACE_MS }, {});
+  const result = await gatewayCall("question.list", { timeoutMs: QUESTION_RPC_GRACE_MS }, {});
   const questions =
     result && typeof result === "object" && !Array.isArray(result)
       ? (result as { questions?: unknown }).questions
@@ -629,7 +629,7 @@ export function createAskUserTool(params: {
         }
         const answerPromise = gatewayCall(
           "question.waitAnswer",
-          { timeoutMs: timeoutMs + ASK_USER_RPC_GRACE_MS },
+          { timeoutMs: timeoutMs + QUESTION_RPC_GRACE_MS },
           { id: questionId, timeoutMs, includeResolutionId: true },
           signal ? { signal } : undefined,
         ).finally(prompt.close) as Promise<QuestionWaitAnswerResult>;


### PR DESCRIPTION
Related: #116554

## What Problem This Solves

Fixes the remaining timeout boundary where Claude CLI-backed agents could create and deliver an `ask_user` question, but a long wait could still be terminated by Claude's MCP tool timeout or OpenClaw's ordinary blocked-tool watchdog before the supported question lifetime ended.

Question delivery itself is already on `main` through #138831. This PR is the narrower timeout-only follow-up and credits the original report from @josh-cornelius.

## Why This Change Was Made

The generated OpenClaw MCP server entry for Claude now receives a `3,610,000 ms` timeout, matching the maximum 3,600-second question lifetime plus the existing 10-second RPC grace. Existing user MCP server timeout values are preserved, and non-Claude bundle modes are unchanged.

OpenClaw now carries the normalized deadline for a uniquely correlated loopback `ask_user` call into the CLI no-output watchdog. Long questions can extend the watchdog, short questions cannot shrink the existing no-output schedule or 15-minute blocked-tool floor, and the deadline remains active until Claude emits the correlated parsed tool result. Invalid, ambiguous, or overflowed correlation fails closed.

No public API, operator configuration, protocol, persistence, schema, channel delivery, Codex, or Gemini behavior changes.

## User Impact

Claude CLI-backed agents can wait for long `ask_user` answers without being cut off around 60 seconds by Claude or around 15 minutes by OpenClaw. Existing short-question and unrelated MCP timeout behavior is preserved.

## Evidence

- Pre-fix regression: unchanged production at `3f22e84d4e5` failed the generated Claude MCP config assertion with `expected undefined to be 3610000`.
- Exact validated head: `e6c770cca31`, based on `61d957a9cb6`.
- Focused Vitest: 167 tests passed across preparation, deadline tracking, watchdog behavior, and question timeout normalization.
- Regression coverage proves:
  - the generated Claude OpenClaw MCP server receives `3,610,000 ms`;
  - an existing user MCP timeout remains unchanged through config merge and capture-key rewrite;
  - long questions extend the watchdog to their absolute deadline;
  - an earlier overall timeout still wins;
  - short questions never shrink the existing 15-minute blocked-tool floor;
  - clearing a question restores the ordinary watchdog;
  - the deadline persists until Claude emits the correlated parsed result;
  - an unrelated loopback refresh after Gateway completion cannot retire that deadline;
  - invalid, ambiguous, and overflowed correlation fails closed.
- Installed Claude Code `2.1.228` live proof:
  - baseline: a silent 70-second MCP call timed out at 60 seconds and never recorded completion;
  - candidate per-server timeout: the same call recorded start and finish 70 seconds apart and returned successfully.
- Direct Codex contract check:
  - `codex-rs/config/src/mcp_types.rs:185-230` owns `tool_timeout_sec` in seconds;
  - `codex-rs/codex-mcp/src/connection_manager.rs:309-315` applies that Codex-owned timeout;
  - this patch changes only the `claude-config-file` projection.
- `oxlint --type-aware --type-check`: passed on changed production files.
- `oxfmt --check`: passed on all 11 changed files.
- Max-lines ratchet and `git diff --check`: passed.
- Independent review found and the patch resolved two lifecycle regressions before submission:
  - deadline release now waits for Claude's parsed tool result;
  - question deadlines can extend but never shorten existing watchdog floors.
- ClawSweeper's exact-head review found and the patch resolved an interleaving where an unrelated refresh could retire a Gateway-completed deadline before Claude parsed the result.
- Production delta: `+150/-33`; test and test-support delta: `+375/-1`. The production growth is the deadline owner, fail-closed correlation state, and explicit timer plumbing needed to preserve the supported question lifetime without adding a fallback path.

Channel delivery was not retested by this timeout-only PR; #138831 owns that repair and its delivery proof.
