### PR TITLE
fix(ui): keep model picker search current across refresh and Escape

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3901,7 +3901,7 @@ ui/src/pages/chat/components/chat-message-markdown.ts	1
 ui/src/pages/chat/components/chat-message-media.ts	3
 ui/src/pages/chat/components/chat-message-timestamp.ts	4
 ui/src/pages/chat/components/chat-model-picker-options.ts	2
-ui/src/pages/chat/components/chat-model-picker.ts	7
+ui/src/pages/chat/components/chat-model-picker.ts	5
 ui/src/pages/chat/components/chat-pane-header.ts	2
 ui/src/pages/chat/components/chat-selection-popup.ts	1
 ui/src/pages/chat/components/chat-session-rail.ts	4
@@ -3966,7 +3966,6 @@ ui/src/pages/model-setup/provider-picker.ts	3
 ui/src/pages/model-setup/view.ts	2
 ui/src/pages/new-session/discovery.ts	3
 ui/src/pages/new-session/draft-place-browser.ts	4
-ui/src/pages/new-session/new-session-runtime.ts	1
 ui/src/pages/new-session/place-browser.ts	1
 ui/src/pages/new-session/place-facts.ts	1
 ui/src/pages/new-session/preferences.ts	1

--- a/docs/web/control-ui/sessions-and-sidebar.md
+++ b/docs/web/control-ui/sessions-and-sidebar.md
@@ -152,6 +152,8 @@ For a remote target, the Control UI creates the repository or managed-worktree s
 
 Model and **Effort** are separate adjacent composer controls in chat and New session, on desktop and mobile. The model picker never contains Effort or Fast-mode controls. Long model labels ellipsize to leave room for the other controls; the full name remains in the picker, accessible label, and tooltip. Mobile Effort uses a gauge whose needle reflects the current level, with a lightning badge when Fast mode is active. In chat, Fast mode stays in the Effort menu, or appears as the adjacent control when reasoning is unavailable. Models with neither available control omit it.
 
+Search the model picker by model name or provider. Your search stays applied as the model catalog refreshes. Press **Escape** to clear a nonempty search while keeping the picker open; press it again to close the picker and return focus to its trigger.
+
 When you switch sessions, the composer keeps the session's known model name visible while refreshing the model options available for that session. If the model is not yet known, the control shows a loading placeholder. Locked chats also show the selected model, or **Session model** when it is not known. The lock prevents model selection changes; it does not indicate that a native runtime owns the model.
 
 Once the session is created, chat opens immediately. Remote startup uses the same transcript progress indicator and elapsed timer as GitHub workspace preparation, showing provisioning, workspace preparation, startup, and first-message delivery as they happen. The composer stays disabled until the first message is accepted; normal startup is not an error. Startup failures remain visible in the session, with **Retry** when recovery is available.

--- a/ui/src/e2e/chat-flow.model-picker-refresh.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.model-picker-refresh.e2e.test.ts
@@ -2,6 +2,7 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   createChatFlowE2eSuite,
   installMockGateway,
@@ -301,6 +302,95 @@ suite.define(() => {
         .waitFor({ state: "visible" });
       expect(await picker.locator("[data-chat-model-catalog-state]").count()).toBe(0);
       await screenshot(page, "02-picker-after-background-apply.png");
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("reconciles the current model search when an open catalog replaces its results", async () => {
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
+    const page = await context.newPage();
+    const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("model-search-refresh", artifactRoot)
+      : undefined;
+    const gateway = await installMockGateway(page, {
+      models: [
+        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
+        { id: "claude-haiku-4-5", name: "Claude Haiku 4.5", provider: "anthropic" },
+      ],
+      sessionKey: "agent:main:main",
+    });
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const picker = page.locator(
+        'openclaw-chat-pane[aria-hidden="false"] .chat-controls__model-picker',
+      );
+      const previous = picker.locator('[data-chat-model-option="anthropic/claude-haiku-4-5"]');
+      await previous.waitFor({ state: "attached" });
+      const discoveryCount = (await gateway.getRequests("models.list")).length;
+      await gateway.deferNext("models.list", { refresh: true });
+      await picker.locator('[data-chat-model-select="true"]').click();
+      await gateway.waitForRequest("models.list", { after: discoveryCount });
+      const search = picker.locator("[data-chat-model-search]");
+      await search.fill("anthropic");
+      await expect.poll(() => picker.locator("[data-chat-model-option]:visible").count()).toBe(1);
+      expect(await previous.isVisible()).toBe(true);
+      if (artifactDir) {
+        await page.screenshot({
+          animations: "disabled",
+          path: `${artifactDir}/01-search-warm.png`,
+        });
+      }
+
+      const metadataCount = (await gateway.getRequests("chat.metadata")).length;
+      await gateway.deferNext("chat.metadata");
+      const refreshedModels = [
+        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
+        { id: "gpt-5.4-mini", name: "GPT-5.4 mini", provider: "openai" },
+        { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", provider: "anthropic" },
+      ];
+      await gateway.resolveDeferred("models.list", { models: refreshedModels });
+      await gateway.waitForRequest("chat.metadata", { after: metadataCount });
+      expect(await previous.isVisible()).toBe(true);
+      await gateway.resolveDeferred("chat.metadata", { commands: [], models: refreshedModels });
+      const replacement = picker.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]');
+      await replacement.waitFor({ state: "attached" });
+      await previous.waitFor({ state: "detached" });
+      if (artifactDir) {
+        await page.screenshot({
+          animations: "disabled",
+          path: `${artifactDir}/02-search-refreshed.png`,
+        });
+      }
+
+      expect(await search.inputValue()).toBe("anthropic");
+      await expect
+        .poll(() =>
+          picker
+            .locator("[data-chat-model-option]:visible")
+            .evaluateAll((rows) => rows.map((row) => row.getAttribute("data-chat-model-option"))),
+        )
+        .toEqual(["anthropic/claude-sonnet-4-6"]);
+      expect(await picker.locator("[data-chat-model-search-empty]").isVisible()).toBe(false);
+      await expect
+        .poll(() =>
+          search.evaluate((input) => {
+            const activeId = input.getAttribute("aria-activedescendant");
+            return activeId
+              ? document.getElementById(activeId)?.getAttribute("data-chat-model-option")
+              : null;
+          }),
+        )
+        .toBe("anthropic/claude-sonnet-4-6");
+      const patchCount = (await gateway.getRequests("sessions.patch")).length;
+      await search.press("Enter");
+      const patch = await gateway.waitForRequest("sessions.patch", { after: patchCount });
+      expect(patch.params).toMatchObject({
+        key: "agent:main:main",
+        model: "anthropic/claude-sonnet-4-6",
+      });
+      await expect.poll(() => picker.getAttribute("open")).toBe(null);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/chat-model-controls.e2e.test.ts
+++ b/ui/src/e2e/chat-model-controls.e2e.test.ts
@@ -537,4 +537,61 @@ suite.define(() => {
       });
     },
   );
+
+  it.each(["chat", "new"])(
+    "clears %s model search before Escape dismisses the picker",
+    async (route) => {
+      await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+        const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+        const artifactDir = artifactRoot
+          ? createControlUiE2eArtifactDir(`model-search-escape-${route}`, artifactRoot)
+          : undefined;
+        const gateway = await installMockGateway(page, {
+          agentModel: "openai/gpt-5.5",
+          models: [
+            { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
+            { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", provider: "anthropic" },
+          ],
+        });
+        await page.goto(`${suite.server.baseUrl}${route}`);
+        const composer = page.locator(".agent-chat__input").first();
+        const picker = composer.locator(".chat-controls__model-picker");
+        const trigger = picker.locator('[data-chat-model-select="true"]');
+        await expect.poll(() => picker.locator("[data-chat-model-option]").count()).toBe(2);
+        await expect.poll(() => trigger.getAttribute("aria-disabled")).toBe("false");
+        await trigger.click();
+        const search = picker.locator("[data-chat-model-search]");
+        await search.fill("anthropic");
+        await expect.poll(() => picker.locator("[data-chat-model-option]:visible").count()).toBe(1);
+        if (artifactDir) {
+          await page.screenshot({
+            animations: "disabled",
+            path: `${artifactDir}/01-filtered.png`,
+          });
+        }
+        await search.press("Escape");
+        if (artifactDir) {
+          await page.screenshot({
+            animations: "disabled",
+            path: `${artifactDir}/02-first-escape.png`,
+          });
+        }
+        await expect.poll(() => picker.getAttribute("open")).toBe("");
+        expect(await search.inputValue()).toBe("");
+        expect(await search.evaluate((input) => input === document.activeElement)).toBe(true);
+        await expect.poll(() => picker.locator("[data-chat-model-option]:visible").count()).toBe(2);
+        expect(await gateway.getRequests("sessions.patch")).toEqual([]);
+
+        await search.press("Escape");
+        await expect.poll(() => picker.getAttribute("open")).toBe(null);
+        expect(await trigger.evaluate((summary) => summary === document.activeElement)).toBe(true);
+        if (artifactDir) {
+          await page.screenshot({
+            animations: "disabled",
+            path: `${artifactDir}/03-second-escape.png`,
+          });
+        }
+      });
+    },
+  );
 });

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -65,7 +65,6 @@ import {
 import { resetChatViewState } from "./chat-view-state.ts";
 import { publishChatWorkContext } from "./chat-work-context.ts";
 import { dismissConfirmedActionPopovers } from "./components/chat-message.ts";
-import { clearChatModelSearchOnEscape } from "./components/chat-model-picker.ts";
 import { dismissThreadPortals } from "./components/chat-thread-interactions.ts";
 import { WIDGET_PROMPT_EVENT, type WidgetPromptEventDetail } from "./components/chat-tool-cards.ts";
 import { CHAT_COMPOSER_DRAFT_STORAGE_ERROR } from "./composer-persistence.ts";
@@ -231,7 +230,6 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
 
     focusChatComposerFromPrintableKeydown(this, event);
 
-    clearChatModelSearchOnEscape(event);
     if (event.defaultPrevented || event.key !== "Escape") {
       return;
     }

--- a/ui/src/pages/chat/components/chat-model-picker-search.ts
+++ b/ui/src/pages/chat/components/chat-model-picker-search.ts
@@ -1,0 +1,224 @@
+import { generateUUID } from "../../../lib/uuid.ts";
+
+export function pickerMenu(target: EventTarget | null): HTMLElement | null {
+  return target instanceof Element
+    ? target.closest<HTMLElement>(".chat-controls__model-menu")
+    : null;
+}
+
+function visibleModelRows(root: HTMLElement): HTMLButtonElement[] {
+  return [...root.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]")]
+    .filter((row) => !row.hidden)
+    .toSorted(
+      (left, right) =>
+        Number(left.dataset.chatModelRank ?? left.dataset.chatModelIndex ?? 0) -
+        Number(right.dataset.chatModelRank ?? right.dataset.chatModelIndex ?? 0),
+    );
+}
+
+function selectableModelRows(root: HTMLElement): HTMLButtonElement[] {
+  return visibleModelRows(root).filter((row) => !row.disabled);
+}
+
+function ensureModelPickerIds(menu: HTMLElement): void {
+  const details = menu.closest<HTMLDetailsElement>(".chat-controls__model-picker");
+  const input = menu.querySelector<HTMLInputElement>("[data-chat-model-search]");
+  const listboxes = [...menu.querySelectorAll<HTMLElement>("[data-chat-model-list]")];
+  if (!details || !input || listboxes.length === 0) {
+    return;
+  }
+  const prefix = details.dataset.chatModelPickerId ?? `chat-model-picker-${generateUUID()}`;
+  details.dataset.chatModelPickerId = prefix;
+  listboxes.forEach((listbox, index) => {
+    listbox.id = `${prefix}-listbox-${index}`;
+  });
+  menu.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]").forEach((row, index) => {
+    row.id = `${prefix}-option-${index}`;
+  });
+  input.setAttribute("aria-controls", listboxes.map((listbox) => listbox.id).join(" "));
+  input.setAttribute("aria-expanded", details.open ? "true" : "false");
+}
+
+export function highlightModelRow(menu: HTMLElement, row: HTMLButtonElement | undefined): void {
+  menu.querySelectorAll<HTMLElement>("[data-chat-model-option]").forEach((candidate) => {
+    candidate.toggleAttribute("data-chat-model-highlighted", candidate === row);
+  });
+  const input = menu.querySelector<HTMLInputElement>("[data-chat-model-search]");
+  if (row?.id) {
+    input?.setAttribute("aria-activedescendant", row.id);
+  } else {
+    input?.removeAttribute("aria-activedescendant");
+  }
+}
+
+// Numbers follow the filtered order because digit selection reads that same row list.
+// Search inputs and nested dropdowns own digits instead. The :focus-within rule
+// in styles/chat/composer.css hides these keycaps while the search input has focus.
+function updateModelShortcuts(menu: HTMLElement, rows: readonly HTMLButtonElement[]): void {
+  menu.querySelectorAll<HTMLElement>("[data-chat-model-shortcut]").forEach((shortcut) => {
+    shortcut.hidden = true;
+    shortcut.removeAttribute("data-shortcut");
+    shortcut.removeAttribute("data-chat-model-shortcut-number");
+  });
+  rows.slice(0, 9).forEach((row, index) => {
+    const shortcut = row.querySelector<HTMLElement>("[data-chat-model-shortcut]");
+    if (!shortcut) {
+      return;
+    }
+    shortcut.hidden = false;
+    shortcut.setAttribute("data-shortcut", String(index + 1));
+    shortcut.setAttribute("data-chat-model-shortcut-number", String(index + 1));
+  });
+}
+
+function modelMatchRank(row: HTMLButtonElement, query: string): number | null {
+  const model = row.dataset.chatModelName ?? "";
+  const keywords = row.dataset.chatModelKeywords ?? "";
+  const provider = row.dataset.chatModelProviderLabel ?? "";
+  if (model.startsWith(query)) {
+    return 0;
+  }
+  if (model.includes(query)) {
+    return 1;
+  }
+  if (keywords.includes(query)) {
+    return 2;
+  }
+  if (provider.startsWith(query)) {
+    return 3;
+  }
+  return provider.includes(query) ? 4 : null;
+}
+
+export function updateModelSearch(input: HTMLInputElement, preserveHighlight = false): void {
+  const menu = pickerMenu(input);
+  if (!menu) {
+    return;
+  }
+  ensureModelPickerIds(menu);
+  const query = input.value.trim().toLocaleLowerCase();
+  menu.toggleAttribute("data-chat-model-filtering", Boolean(query));
+  const rows = [...menu.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]")];
+  const matches: Array<{ row: HTMLButtonElement; score: number; index: number }> = [];
+  rows.forEach((row, index) => {
+    const score = query ? modelMatchRank(row, query) : 0;
+    row.hidden = score === null;
+    row.style.removeProperty("--chat-model-rank");
+    delete row.dataset.chatModelRank;
+    if (score !== null) {
+      matches.push({ row, score, index });
+    }
+  });
+  matches
+    .toSorted((left, right) => left.score - right.score || left.index - right.index)
+    .forEach(({ row }, rank) => {
+      row.dataset.chatModelRank = String(rank);
+      row.style.setProperty("--chat-model-rank", String(rank));
+    });
+  const visibleRows = visibleModelRows(menu);
+  const selectableRows = selectableModelRows(menu);
+  updateModelShortcuts(menu, selectableRows);
+  const selected = selectableRows.find((row) => row.getAttribute("aria-selected") === "true");
+  const highlighted = preserveHighlight
+    ? selectableRows.find((row) => row.hasAttribute("data-chat-model-highlighted"))
+    : undefined;
+  highlightModelRow(
+    menu,
+    highlighted ?? (query ? selectableRows[0] : (selected ?? selectableRows[0])),
+  );
+  const empty = menu.querySelector<HTMLElement>("[data-chat-model-search-empty]");
+  if (empty) {
+    empty.hidden = !query || visibleRows.length > 0;
+  }
+}
+
+export function resetModelSearch(details: HTMLDetailsElement): void {
+  const input = details.querySelector<HTMLInputElement>("[data-chat-model-search]");
+  if (!input) {
+    return;
+  }
+  input.value = "";
+  updateModelSearch(input);
+}
+
+export function clearChatModelSearchOnEscape(event: KeyboardEvent): boolean {
+  if (event.key !== "Escape") {
+    return false;
+  }
+  const input = event
+    .composedPath()
+    .find(
+      (target): target is HTMLInputElement =>
+        target instanceof HTMLInputElement && target.matches("[data-chat-model-search]"),
+    );
+  if (!input?.value) {
+    return false;
+  }
+  input.value = "";
+  updateModelSearch(input);
+  event.preventDefault();
+  event.stopPropagation();
+  return true;
+}
+
+export function handleModelSearchKeydown(event: KeyboardEvent): void {
+  // SAFETY: Bound only to the model-search input’s keydown event.
+  const input = event.currentTarget as HTMLInputElement;
+  const menu = pickerMenu(input);
+  if (!menu) {
+    return;
+  }
+  const rows = selectableModelRows(menu);
+  if (rows.length === 0) {
+    return;
+  }
+  if (event.key === "Enter") {
+    const highlighted = rows.find((row) => row.hasAttribute("data-chat-model-highlighted"));
+    if (highlighted) {
+      event.preventDefault();
+      highlighted.click();
+    }
+    return;
+  }
+  if (event.key !== "ArrowDown" && event.key !== "ArrowUp") {
+    return;
+  }
+  event.preventDefault();
+  const currentIndex = rows.findIndex((row) => row.hasAttribute("data-chat-model-highlighted"));
+  const offset = event.key === "ArrowDown" ? 1 : rows.length - 1;
+  const nextIndex = currentIndex < 0 ? 0 : (currentIndex + offset) % rows.length;
+  highlightModelRow(menu, rows[nextIndex]);
+  rows[nextIndex]?.scrollIntoView?.({ block: "nearest" });
+}
+
+export function handleModelPickerKeydown(event: KeyboardEvent): void {
+  // SAFETY: Bound only to the model picker’s details element.
+  const details = event.currentTarget as HTMLDetailsElement;
+  if (
+    !details.open ||
+    event.target instanceof HTMLInputElement ||
+    event
+      .composedPath()
+      .some((target) => target instanceof HTMLElement && target.localName === "wa-dropdown") ||
+    !/^[1-9]$/u.test(event.key)
+  ) {
+    return;
+  }
+  const row = selectableModelRows(details)[Number(event.key) - 1];
+  event.preventDefault();
+  row?.click();
+}
+
+export function syncChatModelSearch(details: Element | undefined): void {
+  if (!(details instanceof HTMLDetailsElement) || !details.open) {
+    return;
+  }
+  // Keyed catalog rows commit after the details binding; project the retained
+  // query onto the new DOM without resetting a still-valid keyboard selection.
+  queueMicrotask(() => {
+    const input = details.querySelector<HTMLInputElement>("[data-chat-model-search]");
+    if (input) {
+      updateModelSearch(input, true);
+    }
+  });
+}

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -177,10 +177,10 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
   };
   return html`
     <details
-      ${ref((details) => syncChatModelSearch(details))}
       class="chat-controls__inline-select chat-controls__model-picker"
       data-chat-autotype-shortcuts
       ?open=${params.open === true}
+      ${ref((details) => syncChatModelSearch(details))}
       @keydown=${handleModelPickerKeydown}
       @toggle=${(event: Event) => {
         const details = event.currentTarget as HTMLDetailsElement;

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
 import { icons } from "../../../components/icons.ts";
 import "../../../components/tooltip.ts";
@@ -8,7 +9,6 @@ import {
   renderProviderBrandIcon,
 } from "../../../components/provider-icon.ts";
 import { t } from "../../../i18n/index.ts";
-import { generateUUID } from "../../../lib/uuid.ts";
 import {
   type ChatContextWindowControlParams,
   renderContextWindowControl,
@@ -24,6 +24,15 @@ import {
   type ChatModelPickerOption,
   type ChatModelPickerTargetGroup,
 } from "./chat-model-picker-options.ts";
+import {
+  handleModelPickerKeydown,
+  handleModelSearchKeydown,
+  highlightModelRow,
+  pickerMenu,
+  resetModelSearch,
+  syncChatModelSearch,
+  updateModelSearch,
+} from "./chat-model-picker-search.ts";
 import { handleChatComposerDetailsToggle, syncChatPickerOverlay } from "./chat-picker-overlay.ts";
 
 export type { ChatModelCatalogState } from "./chat-model-catalog-state.ts";
@@ -56,207 +65,6 @@ type ChatModelPickerParams = {
   onTargetSelect?: (groupId: string, value: string) => unknown;
   onRequestUpdate?: () => void;
 };
-
-function pickerMenu(target: EventTarget | null): HTMLElement | null {
-  return target instanceof Element
-    ? target.closest<HTMLElement>(".chat-controls__model-menu")
-    : null;
-}
-
-function visibleModelRows(root: HTMLElement): HTMLButtonElement[] {
-  return [...root.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]")]
-    .filter((row) => !row.hidden)
-    .toSorted(
-      (left, right) =>
-        Number(left.dataset.chatModelRank ?? left.dataset.chatModelIndex ?? 0) -
-        Number(right.dataset.chatModelRank ?? right.dataset.chatModelIndex ?? 0),
-    );
-}
-
-function selectableModelRows(root: HTMLElement): HTMLButtonElement[] {
-  return visibleModelRows(root).filter((row) => !row.disabled);
-}
-
-function ensureModelPickerIds(menu: HTMLElement): void {
-  const details = menu.closest<HTMLDetailsElement>(".chat-controls__model-picker");
-  const input = menu.querySelector<HTMLInputElement>("[data-chat-model-search]");
-  const listboxes = [...menu.querySelectorAll<HTMLElement>("[data-chat-model-list]")];
-  if (!details || !input || listboxes.length === 0) {
-    return;
-  }
-  const prefix = details.dataset.chatModelPickerId ?? `chat-model-picker-${generateUUID()}`;
-  details.dataset.chatModelPickerId = prefix;
-  listboxes.forEach((listbox, index) => {
-    listbox.id = `${prefix}-listbox-${index}`;
-  });
-  menu.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]").forEach((row, index) => {
-    row.id = `${prefix}-option-${index}`;
-  });
-  input.setAttribute("aria-controls", listboxes.map((listbox) => listbox.id).join(" "));
-  input.setAttribute("aria-expanded", details.open ? "true" : "false");
-}
-
-function highlightModelRow(menu: HTMLElement, row: HTMLButtonElement | undefined): void {
-  menu.querySelectorAll<HTMLElement>("[data-chat-model-option]").forEach((candidate) => {
-    candidate.toggleAttribute("data-chat-model-highlighted", candidate === row);
-  });
-  const input = menu.querySelector<HTMLInputElement>("[data-chat-model-search]");
-  if (row?.id) {
-    input?.setAttribute("aria-activedescendant", row.id);
-  } else {
-    input?.removeAttribute("aria-activedescendant");
-  }
-}
-
-// Numbers follow the filtered order because digit selection reads that same row list.
-// Search inputs and nested dropdowns own digits instead. The :focus-within rule
-// in styles/chat/composer.css hides these keycaps while the search input has focus.
-function updateModelShortcuts(menu: HTMLElement, rows: readonly HTMLButtonElement[]): void {
-  menu.querySelectorAll<HTMLElement>("[data-chat-model-shortcut]").forEach((shortcut) => {
-    shortcut.hidden = true;
-    shortcut.removeAttribute("data-shortcut");
-    shortcut.removeAttribute("data-chat-model-shortcut-number");
-  });
-  rows.slice(0, 9).forEach((row, index) => {
-    const shortcut = row.querySelector<HTMLElement>("[data-chat-model-shortcut]");
-    if (!shortcut) {
-      return;
-    }
-    shortcut.hidden = false;
-    shortcut.setAttribute("data-shortcut", String(index + 1));
-    shortcut.setAttribute("data-chat-model-shortcut-number", String(index + 1));
-  });
-}
-
-function modelMatchRank(row: HTMLButtonElement, query: string): number | null {
-  const model = row.dataset.chatModelName ?? "";
-  const keywords = row.dataset.chatModelKeywords ?? "";
-  const provider = row.dataset.chatModelProviderLabel ?? "";
-  if (model.startsWith(query)) {
-    return 0;
-  }
-  if (model.includes(query)) {
-    return 1;
-  }
-  if (keywords.includes(query)) {
-    return 2;
-  }
-  if (provider.startsWith(query)) {
-    return 3;
-  }
-  return provider.includes(query) ? 4 : null;
-}
-
-function updateModelSearch(input: HTMLInputElement): void {
-  const menu = pickerMenu(input);
-  if (!menu) {
-    return;
-  }
-  ensureModelPickerIds(menu);
-  const query = input.value.trim().toLocaleLowerCase();
-  menu.toggleAttribute("data-chat-model-filtering", Boolean(query));
-  const rows = [...menu.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]")];
-  const matches: Array<{ row: HTMLButtonElement; score: number; index: number }> = [];
-  rows.forEach((row, index) => {
-    const score = query ? modelMatchRank(row, query) : 0;
-    row.hidden = score === null;
-    row.style.removeProperty("--chat-model-rank");
-    delete row.dataset.chatModelRank;
-    if (score !== null) {
-      matches.push({ row, score, index });
-    }
-  });
-  matches
-    .toSorted((left, right) => left.score - right.score || left.index - right.index)
-    .forEach(({ row }, rank) => {
-      row.dataset.chatModelRank = String(rank);
-      row.style.setProperty("--chat-model-rank", String(rank));
-    });
-  const visibleRows = visibleModelRows(menu);
-  const selectableRows = selectableModelRows(menu);
-  updateModelShortcuts(menu, selectableRows);
-  const selected = selectableRows.find((row) => row.getAttribute("aria-selected") === "true");
-  highlightModelRow(menu, query ? selectableRows[0] : (selected ?? selectableRows[0]));
-  const empty = menu.querySelector<HTMLElement>("[data-chat-model-search-empty]");
-  if (empty) {
-    empty.hidden = !query || visibleRows.length > 0;
-  }
-}
-
-function resetModelSearch(details: HTMLDetailsElement): void {
-  const input = details.querySelector<HTMLInputElement>("[data-chat-model-search]");
-  if (!input) {
-    return;
-  }
-  input.value = "";
-  updateModelSearch(input);
-}
-
-export function clearChatModelSearchOnEscape(event: KeyboardEvent): boolean {
-  if (event.key !== "Escape") {
-    return false;
-  }
-  const input = event
-    .composedPath()
-    .find(
-      (target): target is HTMLInputElement =>
-        target instanceof HTMLInputElement && target.matches("[data-chat-model-search]"),
-    );
-  if (!input?.value) {
-    return false;
-  }
-  input.value = "";
-  updateModelSearch(input);
-  event.preventDefault();
-  event.stopPropagation();
-  return true;
-}
-
-function handleModelSearchKeydown(event: KeyboardEvent): void {
-  const input = event.currentTarget as HTMLInputElement;
-  const menu = pickerMenu(input);
-  if (!menu) {
-    return;
-  }
-  const rows = selectableModelRows(menu);
-  if (rows.length === 0) {
-    return;
-  }
-  if (event.key === "Enter") {
-    const highlighted = rows.find((row) => row.hasAttribute("data-chat-model-highlighted"));
-    if (highlighted) {
-      event.preventDefault();
-      highlighted.click();
-    }
-    return;
-  }
-  if (event.key !== "ArrowDown" && event.key !== "ArrowUp") {
-    return;
-  }
-  event.preventDefault();
-  const currentIndex = rows.findIndex((row) => row.hasAttribute("data-chat-model-highlighted"));
-  const offset = event.key === "ArrowDown" ? 1 : rows.length - 1;
-  const nextIndex = currentIndex < 0 ? 0 : (currentIndex + offset) % rows.length;
-  highlightModelRow(menu, rows[nextIndex]);
-  rows[nextIndex]?.scrollIntoView?.({ block: "nearest" });
-}
-
-function handleModelPickerKeydown(event: KeyboardEvent): void {
-  const details = event.currentTarget as HTMLDetailsElement;
-  if (
-    !details.open ||
-    event.target instanceof HTMLInputElement ||
-    event
-      .composedPath()
-      .some((target) => target instanceof HTMLElement && target.localName === "wa-dropdown") ||
-    !/^[1-9]$/u.test(event.key)
-  ) {
-    return;
-  }
-  const row = selectableModelRows(details)[Number(event.key) - 1];
-  event.preventDefault();
-  row?.click();
-}
 
 export function renderChatModelPicker(params: ChatModelPickerParams) {
   const defaultModelOption = params.modelOptions.find((option) => option.isDefault);
@@ -369,6 +177,7 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
   };
   return html`
     <details
+      ${ref((details) => syncChatModelSearch(details))}
       class="chat-controls__inline-select chat-controls__model-picker"
       data-chat-autotype-shortcuts
       ?open=${params.open === true}
@@ -383,12 +192,7 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
           return;
         }
         void params.onOpen?.();
-        queueMicrotask(() => {
-          const input = details.querySelector<HTMLInputElement>("[data-chat-model-search]");
-          if (input) {
-            updateModelSearch(input);
-          }
-        });
+        syncChatModelSearch(details);
       }}
     >
       <summary

--- a/ui/src/pages/chat/components/chat-picker-overlay.ts
+++ b/ui/src/pages/chat/components/chat-picker-overlay.ts
@@ -1,5 +1,6 @@
 import { syncAnchoredOverlay } from "../../../components/anchored-overlay.ts";
 import { consumeTooltipEscape } from "../../../components/tooltip.ts";
+import { clearChatModelSearchOnEscape } from "./chat-model-picker-search.ts";
 
 const MOBILE_COMPOSER_OVERLAY_QUERY =
   "(max-width: 640px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape)";
@@ -70,6 +71,9 @@ function dismissChatComposerPickersOnEscape(event: KeyboardEvent): void {
     event.key !== "Escape" ||
     document.querySelector(".shell-nav[aria-modal='true']")
   ) {
+    return;
+  }
+  if (clearChatModelSearchOnEscape(event)) {
     return;
   }
   const pickers = openChatComposerPickers();

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -35,7 +35,6 @@ import {
   closeAgentPicker,
   closeSessionMenus,
   createControllerHost,
-  handleSessionPickerEvent,
   isPlaceTopologyEvent,
   presenceStateSignature,
 } from "./new-session-runtime.ts";
@@ -235,19 +234,16 @@ export class NewSessionPage extends OpenClawLightDomElement {
     if (event instanceof KeyboardEvent) {
       focusChatComposerFromPrintableKeydown(this, event);
     }
-    handleSessionPickerEvent(this, event);
   }
 
   override connectedCallback() {
     super.connectedCallback();
     document.addEventListener("keydown", this, true);
-    document.addEventListener("pointerdown", this, true);
     window.addEventListener("beforeunload", this.flushDraft);
   }
 
   override disconnectedCallback() {
     document.removeEventListener("keydown", this, true);
-    document.removeEventListener("pointerdown", this, true);
     window.removeEventListener("beforeunload", this.flushDraft);
     retainDraft(this.context, this.submission, this.openedFor, this.messageOwnerKey);
     this.subscriptions.clear();

--- a/ui/src/pages/new-session/new-session-runtime.ts
+++ b/ui/src/pages/new-session/new-session-runtime.ts
@@ -1,7 +1,6 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import type { PresenceEntry } from "../../api/types.ts";
 import type { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
-import { clearChatModelSearchOnEscape } from "../chat/components/chat-model-picker.ts";
 
 const PLACE_TOPOLOGY_EVENTS = new Set([
   "config.changed",
@@ -52,40 +51,6 @@ export function closeSessionMenus(root: ParentNode) {
   for (const selector of ["wa-dropdown[open]", "wa-popover.new-session-page__picker-popover"]) {
     for (const menu of root.querySelectorAll<HTMLElement & { open: boolean }>(selector)) {
       menu.open = false;
-    }
-  }
-}
-
-export function handleSessionPickerEvent(root: ParentNode, event: Event) {
-  if (document.querySelector(".shell-nav[aria-modal='true']")) {
-    return;
-  }
-  const pickers = root.querySelectorAll<HTMLDetailsElement>(".chat-controls__inline-select[open]");
-  if (pickers.length === 0) {
-    return;
-  }
-  if (event.type === "keydown") {
-    const keyEvent = event as KeyboardEvent;
-    clearChatModelSearchOnEscape(keyEvent);
-    if (keyEvent.defaultPrevented || keyEvent.key !== "Escape") {
-      return;
-    }
-    const picker =
-      [...pickers].find((candidate) => event.composedPath().includes(candidate)) ?? pickers[0];
-    if (!picker) {
-      return;
-    }
-    const restoreFocus = event.composedPath().includes(picker);
-    keyEvent.preventDefault();
-    picker.open = false;
-    if (restoreFocus) {
-      picker.querySelector<HTMLElement>("summary")?.focus();
-    }
-    return;
-  }
-  for (const picker of pickers) {
-    if (!event.composedPath().includes(picker)) {
-      picker.open = false;
     }
   }
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users searching the model picker would see unrelated models when the catalog refreshed in the background. Escape also closed the entire picker before clearing the search in both Chat and New Session.

## Why This Change Was Made

The shared picker interaction owner now reapplies the current query after model rows render and preserves an eligible highlighted choice. Shared Escape handling clears the search before dismissing the picker, replacing the duplicate New Session dismissal path while retaining tooltip and nested-menu precedence.

## User Impact

Users can keep searching while model discovery finishes, then select the matching result with Enter. With the search field focused, the first Escape clears its query and keeps the picker open; the next Escape closes it and returns focus to the trigger. The behavior is documented alongside the composer controls.

## Evidence

Both failures were reproduced independently against the original code. The repair passed all 19 tests in the affected model-refresh, model-controls, and New Session catalog browser suites, plus 377 focused unit tests, the owning E2E test type graph, production UI types, full-file lint, and the full changed-file gate. Independent P0–P2 review was scoped-clean. The verified change was rebased patch-identically onto current main; published-head CI is tracked below. Production code is nine lines smaller overall, with exact shrink-only assertion-baseline updates.

The [initial CI run](https://github.com/openclaw/openclaw/actions/runs/34086008188) found the same control-ownership inventory mismatch in two jobs. [The follow-up correction](https://github.com/openclaw/openclaw/commit/257ca7156935073a39f98d6e61ccc636c95a17b6) moves the existing ref binding after the class and open bindings while preserving the inventory guard. All three inventory cases and the three focused browser regressions pass, with a fresh scoped-clean P0–P2 review. CI now tracks corrected head `257ca7156935073a39f98d6e61ccc636c95a17b6`.

All five linked captures were visually inspected. They contain only synthetic test UI and show the retained catalog filter and clear-search-before-dismiss behavior, covering the image-inspection gap in the earlier automated review.

Synthetic screenshots show the actual browser flow before and after the repair:

| Catalog refresh before | Catalog refresh after |
| --- | --- |
| ![An Anthropic search incorrectly shows a newly discovered GPT model](https://github.com/user-attachments/assets/4a222aec-864f-42fd-8113-816e073d70dc) | ![The same search stays filtered after discovery](https://github.com/user-attachments/assets/cda88b18-87ec-4461-be95-54783823a880) |

| First Escape before | First Escape after |
| --- | --- |
| ![New Session closes the picker on the first Escape](https://github.com/user-attachments/assets/d033e03b-f8ee-4eb0-9a8d-7ea57eacbace) | ![New Session clears the query while retaining its picker](https://github.com/user-attachments/assets/6cacbdc8-dfdc-4d47-8f15-408507205251) |

<details>
<summary>Chat uses the same clear-search behavior</summary>

![Chat keeps its model picker open after clearing the query with Escape](https://github.com/user-attachments/assets/afcd5602-8225-4ddb-8cbc-831bd09d320c)

</details>
