### PR TITLE
fix(agents): report prompt-cache misses per request

### DIFF
--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -332,6 +332,8 @@ diagnostics:
 
 ### What to inspect
 
+Prompt-cache observations record `input`, `cacheRead`, and `cacheWrite` per completed foreground model request alongside its stable system-prefix/tools fingerprint, and flag cache-read drops from the previous request, including reported zero reads; billing totals remain separate. Observations and warnings require cache tracing (`diagnostics.cacheTrace.enabled` or `OPENCLAW_CACHE_TRACE=1`) or debug logging, and trace results identify each request within its attempt.
+
 - Cache trace events are JSONL with staged snapshots like `session:loaded`, `prompt:before`, `stream:context`, and `session:after`.
 - Per-turn cache token impact is visible in normal usage surfaces: `cacheRead` and `cacheWrite` show up in `/usage tokens`, `/status`, session usage summaries, and custom `messages.usageTemplate` layouts.
 - For Anthropic, expect both `cacheRead` and `cacheWrite` when caching is active.

--- a/src/agents/embedded-agent-runner/prompt-cache-observability.test.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-observability.test.ts
@@ -1,11 +1,14 @@
 // Coverage for prompt-cache diagnostic tracking across turns.
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
+import { Type } from "typebox";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   beginPromptCacheObservation,
   collectPromptCacheTools,
   completePromptCacheObservation,
+  recordAggregateTruncation,
 } from "./prompt-cache-observability.js";
+import { createPromptCacheRequestObserver } from "./prompt-cache-request-observer.js";
 
 let testScope = 0;
 let currentTestScope = "";
@@ -18,6 +21,83 @@ describe("prompt cache observability", () => {
   beforeEach(() => {
     currentTestScope = String(++testScope);
   });
+
+  it.each([
+    {
+      name: "three healthy calls then one",
+      turns: [[10_000, 10_000, 10_000], [10_000]],
+      misses: [],
+    },
+    {
+      name: "one call then a miss and two hits",
+      turns: [[10_000], [0, 10_000, 10_000]],
+      misses: ["2:1"],
+    },
+    { name: "a complete miss below the drop threshold", turns: [[500], [0]], misses: ["2:1"] },
+  ])("observes each request: $name", ({ turns, misses }) => {
+    const sessionId = scopedKey("request-usage");
+    const observed: Array<{ request: string; cacheRead: number | undefined; broke: boolean }> = [];
+    for (const [turnIndex, reads] of turns.entries()) {
+      const observer = createPromptCacheRequestObserver(
+        { sessionId, streamStrategy: "test" },
+        (observation) =>
+          observed.push({
+            request: `${turnIndex + 1}:${observation.requestIndex}`,
+            cacheRead: observation.cacheRead,
+            broke: observation.broke,
+          }),
+      );
+      for (const cacheRead of reads) {
+        observer.onModelRequest(
+          { provider: "anthropic", id: "claude-sonnet-4-6", api: "anthropic-messages" },
+          {
+            systemPrompt: "stable prefix",
+            tools: [{ name: "read", description: "Read text", parameters: Type.Object({}) }],
+          },
+        );
+        observer.onModelUsage({ input: 10_000 - cacheRead, cacheRead, cacheWrite: 0 });
+      }
+    }
+    expect(observed.map((entry) => entry.cacheRead)).toEqual(turns.flat());
+    expect(observed.filter((entry) => entry.broke).map((entry) => entry.request)).toEqual(misses);
+  });
+
+  it.each([false, true])(
+    "keeps small complete misses tied to the last reported fingerprint (changed=%s)",
+    (changed) => {
+      const sessionId = scopedKey("small-cache-miss");
+      const begin = (systemPrompt: string) =>
+        beginPromptCacheObservation({
+          sessionId,
+          provider: "anthropic",
+          modelId: "claude-sonnet-4-6",
+          streamStrategy: "test",
+          systemPrompt,
+          tools: [],
+        });
+      begin("prefix A");
+      completePromptCacheObservation({ sessionId, usage: { cacheRead: 500 } });
+      if (changed) {
+        begin("prefix B");
+        completePromptCacheObservation({ sessionId });
+      }
+      recordAggregateTruncation({ sessionId });
+      begin(changed ? "prefix B" : "prefix A");
+      const result = completePromptCacheObservation({
+        sessionId,
+        usage: { input: 500, cacheRead: 0 },
+      });
+      if (changed) {
+        expect(result).toBeNull();
+      } else {
+        expect(result).toMatchObject({
+          previousCacheRead: 500,
+          cacheRead: 0,
+          changes: [{ code: "aggregateToolResultTruncation" }],
+        });
+      }
+    },
+  );
 
   it("collects canonical trimmed tool snapshots", () => {
     expect(

--- a/src/agents/embedded-agent-runner/prompt-cache-observability.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-observability.ts
@@ -25,7 +25,7 @@ export type PromptCacheChange = {
   detail: string;
 };
 
-export type PromptCacheToolSnapshot = {
+type PromptCacheToolSnapshot = {
   name: string;
   descriptionDigest?: string;
   schemaDigest?: string;
@@ -56,7 +56,7 @@ type PromptCacheObservationStart = {
   previousCacheRead: number | null;
 };
 
-export type PromptCacheBreak = {
+type PromptCacheBreak = {
   previousCacheRead: number;
   cacheRead: number;
   changes: PromptCacheChange[] | null;
@@ -65,6 +65,8 @@ export type PromptCacheBreak = {
 type PromptCacheTracker = {
   snapshot: PromptCacheSnapshot;
   lastCacheRead: number | null;
+  /** Missing usage must not bind an older hit to a new request fingerprint. */
+  lastCacheReadSnapshot?: PromptCacheSnapshot;
   pendingChanges: PromptCacheChange[] | null;
 };
 
@@ -298,15 +300,23 @@ export function beginPromptCacheObservation(params: {
     toolNames: tools.map((tool) => tool.name),
   };
   const previous = trackers.get(key);
-  const changes = previous ? diffSnapshots(previous.snapshot, snapshot) : null;
+  const changes = previous
+    ? [
+        ...(previous.pendingChanges?.filter(
+          (change) => change.code === "aggregateToolResultTruncation",
+        ) ?? []),
+        ...(diffSnapshots(previous.snapshot, snapshot) ?? []),
+      ]
+    : [];
   setTracker(key, {
     snapshot,
     lastCacheRead: previous?.lastCacheRead ?? null,
-    pendingChanges: changes,
+    lastCacheReadSnapshot: previous?.lastCacheReadSnapshot,
+    pendingChanges: changes.length > 0 ? changes : null,
   });
   return {
     snapshot,
-    changes,
+    changes: changes.length > 0 ? changes : null,
     previousCacheRead: previous?.lastCacheRead ?? null,
   };
 }
@@ -348,7 +358,9 @@ export function completePromptCacheObservation(params: {
     return null;
   }
   const previousCacheRead = tracker.lastCacheRead;
+  const previousSnapshot = tracker.lastCacheReadSnapshot;
   tracker.lastCacheRead = cacheRead;
+  tracker.lastCacheReadSnapshot = tracker.snapshot;
 
   if (previousCacheRead == null || previousCacheRead <= 0) {
     tracker.pendingChanges = null;
@@ -359,13 +371,19 @@ export function completePromptCacheObservation(params: {
   const hasMeaningfulDrop =
     cacheRead < previousCacheRead * MAX_STABLE_CACHE_READ_RATIO &&
     tokenDrop >= MIN_CACHE_BREAK_TOKEN_DROP;
-  const result = hasMeaningfulDrop
-    ? {
-        previousCacheRead,
-        cacheRead,
-        changes: tracker.pendingChanges,
-      }
-    : null;
+  const completeMiss =
+    cacheRead === 0 &&
+    (params.usage?.input ?? 0) > 0 &&
+    previousSnapshot !== undefined &&
+    diffSnapshots(previousSnapshot, tracker.snapshot) === null;
+  const result =
+    hasMeaningfulDrop || completeMiss
+      ? {
+          previousCacheRead,
+          cacheRead,
+          changes: tracker.pendingChanges,
+        }
+      : null;
   tracker.pendingChanges = null;
   return result;
 }

--- a/src/agents/embedded-agent-runner/prompt-cache-request-observer.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-request-observer.ts
@@ -1,0 +1,74 @@
+import type { StreamFn } from "../runtime/index.js";
+import type { NormalizedUsage } from "../usage.js";
+import {
+  beginPromptCacheObservation,
+  collectPromptCacheTools,
+  completePromptCacheObservation,
+  type PromptCacheChange,
+} from "./prompt-cache-observability.js";
+
+type PromptCacheObservationStart = ReturnType<typeof beginPromptCacheObservation>;
+type PromptCacheSnapshot = PromptCacheObservationStart["snapshot"];
+
+export type PromptCacheRequestObservation = {
+  requestIndex: number;
+  broke: boolean;
+  input?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  previousCacheRead?: number;
+  changes: PromptCacheChange[] | null;
+};
+
+/** Pairs foreground request inputs with completion usage before billing aggregation. */
+export function createPromptCacheRequestObserver(
+  params: Omit<
+    Parameters<typeof beginPromptCacheObservation>[0],
+    "provider" | "modelId" | "modelApi" | "systemPrompt" | "tools"
+  >,
+  onObservation: (
+    observation: PromptCacheRequestObservation,
+    snapshot: PromptCacheSnapshot,
+  ) => void,
+  onRequest?: (request: PromptCacheObservationStart & { requestIndex: number }) => void,
+) {
+  let requestIndex = 0;
+  let request: PromptCacheObservationStart | undefined;
+  let observation: PromptCacheRequestObservation | undefined;
+  return {
+    onModelRequest: (
+      model: Pick<Parameters<StreamFn>[0], "provider" | "id" | "api">,
+      context: Pick<Parameters<StreamFn>[1], "systemPrompt" | "tools">,
+    ) => {
+      requestIndex += 1;
+      request = beginPromptCacheObservation({
+        ...params,
+        provider: model.provider,
+        modelId: model.id,
+        modelApi: model.api,
+        systemPrompt: context.systemPrompt ?? "",
+        tools: collectPromptCacheTools(context.tools ?? []),
+      });
+      onRequest?.({ ...request, requestIndex });
+    },
+    onModelUsage: (usage: NormalizedUsage | undefined) => {
+      if (!request) {
+        return;
+      }
+      const cacheBreak = completePromptCacheObservation({ ...params, usage });
+      observation = {
+        requestIndex,
+        broke: Boolean(cacheBreak),
+        previousCacheRead: request.previousCacheRead ?? undefined,
+        input: usage?.input,
+        cacheRead: usage?.cacheRead,
+        cacheWrite: usage?.cacheWrite,
+        changes: cacheBreak?.changes ?? request.changes,
+      };
+      const { snapshot } = request;
+      request = undefined;
+      onObservation(observation, snapshot);
+    },
+    getObservation: () => observation,
+  };
+}

--- a/src/agents/embedded-agent-runner/run/attempt-execution-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-phase.test.ts
@@ -219,8 +219,9 @@ async function createFixture(
   mocks.installStreamGuards.mockImplementation(() => {
     order.push("guards");
     return {
-      cacheObservabilityEnabled: true,
-      promptCacheTools: [{ name: "read" }],
+      onModelRequest: vi.fn(),
+      onModelUsage: vi.fn(),
+      getPromptCacheObservation: vi.fn(),
     };
   });
   mocks.prepareHistory.mockImplementation(async () => {
@@ -501,8 +502,8 @@ describe("runEmbeddedAttemptExecutionPhase", () => {
       expect.objectContaining({
         preparedStreamRuntime: expect.objectContaining({
           cache: {
-            observabilityEnabled: true,
-            promptTools: [{ name: "read" }],
+            onModelRequest: expect.any(Function),
+            getObservation: expect.any(Function),
           },
           history: expect.objectContaining({ contextEngineAssemblySucceeded: true }),
           isProbeSession: false,
@@ -518,6 +519,9 @@ describe("runEmbeddedAttemptExecutionPhase", () => {
     expect(abortInput.abortActiveSession).toBe(fixture.abortActiveSession);
     const streamInput = mocks.prepareStream.mock.calls[0]?.[0];
     expect(streamInput.activeSession).toBe(fixture.activeSession);
+    expect(streamInput.onModelUsage).toBe(
+      mocks.installStreamGuards.mock.results[0]?.value.onModelUsage,
+    );
     expect(streamInput.getRunState()).toEqual({
       aborted: true,
       promptError: null,

--- a/src/agents/embedded-agent-runner/run/attempt-execution-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-phase.test.ts
@@ -1,10 +1,15 @@
+import { createAssistantMessageEventStream, type Message } from "openclaw/plugin-sdk/llm";
+import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
+import { createDiagnosticEmbeddedRunOwner } from "../../../logging/diagnostic-run-activity.js";
+import { runAgentLoop } from "../../../plugin-sdk/agent-core.js";
 import { prepareSystemAgentRunAdmission } from "../../admitted-run-context.js";
 import {
   applyAgentAutoCompactionGuard,
   applyAgentCompactionSettingsFromConfig,
 } from "../../agent-settings.js";
+import { createEmbeddedModelState } from "../../embedded-agent-subscribe.model-state.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import {
   createAssistant,
@@ -17,6 +22,7 @@ import {
 } from "../../sessions/agent-session-loop-correctness.test-support.js";
 import type { AgentSessionEvent } from "../../sessions/agent-session-types.js";
 import { SessionManager } from "../../sessions/session-manager.js";
+import { makeZeroUsageSnapshot } from "../../usage.js";
 import { resolveEmbeddedAgentStream } from "../stream-resolution.js";
 
 const mocks = vi.hoisted(() => ({
@@ -290,6 +296,144 @@ beforeEach(() => {
 });
 
 describe("runEmbeddedAttemptExecutionPhase", () => {
+  it.each([
+    { stopReason: "stop", cacheRead: 10_000 },
+    { stopReason: "stop", cacheRead: 0 },
+    { stopReason: "toolUse", cacheRead: 10_000 },
+    { stopReason: "error", cacheRead: 10_000 },
+    { stopReason: "aborted", cacheRead: 10_000 },
+  ] as const)(
+    "observes terminal $stopReason usage once across async-tool fragments (cacheRead=$cacheRead)",
+    async ({ stopReason, cacheRead }) => {
+      const fixture = await createFixture();
+      const recordStage = vi.fn();
+      const runtime = fixture.input.prepared.sessionRuntime;
+      Object.assign(fixture.input.attempt, {
+        model: testModel,
+        modelId: testModel.id,
+        provider: testModel.provider,
+        sessionId: `async-fragment-${stopReason}-${cacheRead}`,
+      });
+      Object.assign(runtime, {
+        anthropicPayloadLogger: undefined,
+        isOpenAIResponsesApi: false,
+        cacheTrace: { recordStage, wrapStreamFn: (streamFn: unknown) => streamFn },
+      });
+      const toolCall = {
+        type: "toolCall",
+        name: "read",
+        id: "read-1",
+        arguments: {},
+        async: true,
+      } as const;
+      const message = createAssistant(
+        testModel,
+        [toolCall, { type: "text", text: "Done." }],
+        stopReason,
+      );
+      message.usage = {
+        ...makeZeroUsageSnapshot(),
+        input: 100,
+        output: 5,
+        cacheRead,
+        totalTokens: cacheRead + 105,
+      };
+      const response = createAssistantMessageEventStream();
+      response.push({
+        type: "start",
+        partial: { ...message, content: [], usage: makeZeroUsageSnapshot() },
+      });
+      response.push({
+        type: "toolcall_end",
+        contentIndex: 0,
+        toolCall,
+        partial: { ...message, content: [toolCall], usage: makeZeroUsageSnapshot() },
+      });
+      if (stopReason === "error" || stopReason === "aborted") {
+        response.push({ type: "error", reason: stopReason, error: message });
+      } else {
+        response.push({ type: "done", reason: stopReason, message });
+      }
+      response.end();
+      const providerStream = vi.fn(() => response);
+      runtime.agentSession.activeSession.agent.streamFn = providerStream;
+      const { installEmbeddedAttemptStreamGuards } =
+        await vi.importActual<typeof import("./attempt-stream.js")>("./attempt-stream.js");
+      const guards = installEmbeddedAttemptStreamGuards(fixture.input, {
+        onRejectedProviderReplayRepaired: vi.fn(),
+        onIdleTimeout: vi.fn(),
+        diagnosticOwner: createDiagnosticEmbeddedRunOwner({
+          runId: "async-fragment",
+          sessionId: fixture.input.attempt.sessionId,
+        }),
+      });
+      const modelState = createEmbeddedModelState(
+        {
+          session: runtime.agentSession.activeSession,
+          runId: "async-fragment",
+          onModelUsage: guards.onModelUsage,
+        },
+        { warn: vi.fn() },
+      );
+      const fragments: number[] = [];
+      const observed = () => recordStage.mock.calls.filter(([stage]) => stage === "cache:result");
+      const context = {
+        systemPrompt: "stable prefix",
+        messages: [],
+        tools: [
+          {
+            name: "read",
+            label: "Read",
+            description: "Read",
+            parameters: Type.Object({}),
+            execute: async () => ({ content: [], details: {}, terminate: true }),
+          },
+        ],
+      };
+      guards.onModelRequest?.(testModel, context);
+      await runAgentLoop(
+        [{ role: "user", content: "Read once", timestamp: 0 }],
+        context,
+        { model: testModel, convertToLlm: (messages) => messages as Message[] },
+        (event) => {
+          if (
+            event.type === "message_start" ||
+            event.type === "message_update" ||
+            event.type === "message_end"
+          ) {
+            modelState.captureModelEvent(event);
+          }
+          if (event.type === "message_end" && event.message.role === "assistant") {
+            fragments.push(event.message.usage.cacheRead);
+            if (fragments.length === 1) {
+              expect(observed()).toEqual([]);
+            }
+          }
+        },
+        undefined,
+        runtime.agentSession.activeSession.agent.streamFn,
+      );
+      expect(providerStream).toHaveBeenCalledOnce();
+      expect(fragments).toEqual([0, cacheRead]);
+      expect(observed()).toEqual([
+        [
+          "cache:result",
+          {
+            options: {
+              requestIndex: 1,
+              broke: false,
+              previousCacheRead: undefined,
+              input: 100,
+              cacheRead,
+              cacheWrite: 0,
+              changes: null,
+            },
+          },
+        ],
+      ]);
+    },
+  );
+
   it.each([
     { owner: "active", phase: "during summarization" },
     { owner: "replaced", phase: "during summarization" },

--- a/src/agents/embedded-agent-runner/run/attempt-execution-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-phase.test.ts
@@ -297,14 +297,17 @@ beforeEach(() => {
 
 describe("runEmbeddedAttemptExecutionPhase", () => {
   it.each([
-    { stopReason: "stop", cacheRead: 10_000 },
-    { stopReason: "stop", cacheRead: 0 },
-    { stopReason: "toolUse", cacheRead: 10_000 },
-    { stopReason: "error", cacheRead: 10_000 },
-    { stopReason: "aborted", cacheRead: 10_000 },
+    { stopReason: "stop", cacheRead: 10_000, completion: "event" },
+    { stopReason: "stop", cacheRead: 0, completion: "event" },
+    { stopReason: "toolUse", cacheRead: 10_000, completion: "event" },
+    { stopReason: "error", cacheRead: 10_000, completion: "event" },
+    { stopReason: "aborted", cacheRead: 10_000, completion: "event" },
+    { stopReason: "stop", cacheRead: 10_000, completion: "result" },
+    { stopReason: "stop", cacheRead: 0, completion: "result" },
+    { stopReason: "error", cacheRead: 10_000, completion: "result" },
   ] as const)(
-    "observes terminal $stopReason usage once across async-tool fragments (cacheRead=$cacheRead)",
-    async ({ stopReason, cacheRead }) => {
+    "observes terminal $stopReason usage once across async-tool fragments (cacheRead=$cacheRead, completion=$completion)",
+    async ({ stopReason, cacheRead, completion }) => {
       const fixture = await createFixture();
       const recordStage = vi.fn();
       const runtime = fixture.input.prepared.sessionRuntime;
@@ -312,7 +315,7 @@ describe("runEmbeddedAttemptExecutionPhase", () => {
         model: testModel,
         modelId: testModel.id,
         provider: testModel.provider,
-        sessionId: `async-fragment-${stopReason}-${cacheRead}`,
+        sessionId: `async-fragment-${stopReason}-${cacheRead}-${completion}`,
       });
       Object.assign(runtime, {
         anthropicPayloadLogger: undefined,
@@ -349,7 +352,9 @@ describe("runEmbeddedAttemptExecutionPhase", () => {
         toolCall,
         partial: { ...message, content: [toolCall], usage: makeZeroUsageSnapshot() },
       });
-      if (stopReason === "error" || stopReason === "aborted") {
+      if (completion === "result") {
+        response.end(message);
+      } else if (stopReason === "error" || stopReason === "aborted") {
         response.push({ type: "error", reason: stopReason, error: message });
       } else {
         response.push({ type: "done", reason: stopReason, message });
@@ -431,6 +436,9 @@ describe("runEmbeddedAttemptExecutionPhase", () => {
           },
         ],
       ]);
+      expect(runtime.contextGuards.recordCacheTouch).toHaveBeenCalledTimes(
+        stopReason === "error" || stopReason === "aborted" ? 0 : 1,
+      );
     },
   );
 

--- a/src/agents/embedded-agent-runner/run/attempt-execution-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-phase.ts
@@ -57,16 +57,14 @@ export async function runEmbeddedAttemptExecutionPhase(
   };
 
   const idleTimeoutTriggerRef: { current?: (error: Error) => void } = {};
-  const { cacheObservabilityEnabled, promptCacheTools } = installEmbeddedAttemptStreamGuards(
-    input,
-    {
+  const { onModelRequest, onModelUsage, getPromptCacheObservation } =
+    installEmbeddedAttemptStreamGuards(input, {
       onRejectedProviderReplayRepaired: () => {
         repairedRejectedProviderReplay = true;
       },
       onIdleTimeout: (error) => idleTimeoutTriggerRef.current?.(error),
       diagnosticOwner,
-    },
-  );
+    });
   input.setup.prepStages.mark("stream-setup");
   input.setup.emitPrepStageSummary("stream-ready");
 
@@ -137,6 +135,7 @@ export async function runEmbeddedAttemptExecutionPhase(
     : undefined;
   const preparedStream = prepareEmbeddedAttemptStream({
     attempt,
+    onModelUsage,
     applyPermissionMode: input.lifecycle.applyPermissionMode,
     activeSession,
     runAbortController: input.runAbortController,
@@ -196,8 +195,8 @@ export async function runEmbeddedAttemptExecutionPhase(
   const preparedStreamRuntime = {
     abortable,
     cache: {
-      observabilityEnabled: cacheObservabilityEnabled,
-      promptTools: promptCacheTools,
+      onModelRequest,
+      getObservation: getPromptCacheObservation,
     },
     history: preparedHistory,
     isProbeSession,

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
@@ -149,10 +149,7 @@ function createFixture() {
   const result = { messages: [{ role: "assistant", content: "done" }] };
   const preparedStreamRuntime = {
     abortable: (promise: Promise<unknown>) => promise,
-    cache: {
-      observabilityEnabled: true,
-      promptTools: [{ name: "read" }],
-    },
+    cache: {},
     history: {
       contextEnginePromptAuthority: "assembled",
       contextEngineAssemblySucceeded: true,
@@ -282,7 +279,6 @@ function createFixture() {
     Object.assign(promptState, {
       contextBudgetStatus: { status: "ok" },
       preflightRecovery: { attempted: false },
-      promptCacheChangesForTurn: [{ type: "cache" }],
       finalPromptText: "final prompt",
     });
     promptInput.prepared.sessionRuntime.state.prePromptMessageCount = 4;
@@ -301,7 +297,6 @@ function createFixture() {
       currentAttemptAssistant: { role: "assistant", content: "done" },
       currentAttemptCompletedAssistant: undefined,
       attemptUsage: { input: 1, output: 2, total: 3 },
-      cacheBreak: null,
       promptCache: { cacheRead: 1 },
       lastCallUsage: undefined,
       compactionOccurredThisAttempt: false,
@@ -616,7 +611,6 @@ describe("runEmbeddedAttemptSettledPhase", () => {
         lastAssistant: undefined,
         currentAttemptAssistant: undefined,
         attemptUsage: undefined,
-        cacheBreak: null,
         promptCache: undefined,
         lastCallUsage: undefined,
         compactionOccurredThisAttempt: false,

--- a/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
@@ -115,8 +115,6 @@ describe("embedded attempt phase lifecycle state", () => {
       prePromptMessageCount: 0,
       nestedToolActivities: [],
       cache: {
-        observabilityEnabled: false,
-        changesForTurn: null,
         retention: undefined,
       },
       shouldFlushForContextEngine: false,
@@ -192,8 +190,6 @@ describe("embedded attempt phase lifecycle state", () => {
       prePromptMessageCount: 0,
       nestedToolActivities: [],
       cache: {
-        observabilityEnabled: false,
-        changesForTurn: null,
         retention: undefined,
       },
       shouldFlushForContextEngine: false,
@@ -300,8 +296,6 @@ describe("embedded attempt phase lifecycle state", () => {
         }),
       ],
       cache: {
-        observabilityEnabled: false,
-        changesForTurn: null,
         retention: undefined,
       },
       shouldFlushForContextEngine: false,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-build.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-build.ts
@@ -22,7 +22,6 @@ import {
 import type { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import { annotateInterSessionPromptText } from "../../../sessions/input-provenance.js";
 import { resolveAdmittedRunActiveAssertion } from "../../admitted-run-context.js";
-import type { createCacheTrace } from "../../cache-trace.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { describeProviderRequestRoutingSummary } from "../../provider-attribution.js";
 import { buildRuntimeFactsPrompt } from "../../runtime-facts-prompt.js";
@@ -36,13 +35,7 @@ import {
   appendModelIdentitySystemPrompt,
   buildModelIdentityPromptLine,
 } from "../../system-prompt.js";
-import { normalizeToolPolicyName } from "../../tool-policy.js";
 import { log } from "../logger.js";
-import {
-  beginPromptCacheObservation,
-  type PromptCacheChange,
-  type PromptCacheToolSnapshot,
-} from "../prompt-cache-observability.js";
 import {
   cloneToolResultPromptProjectionState,
   type ToolResultPromptProjectionState,
@@ -78,9 +71,7 @@ import type { EmbeddedRunAttemptParams } from "./types.js";
  * Assembles hook, orphan-repair, steering, and cache inputs for one prompt.
  */
 type HookRunner = ReturnType<typeof getGlobalHookRunner>;
-type CacheTrace = ReturnType<typeof createCacheTrace>;
 type OrphanRepairPlan = ReturnType<typeof resolveOrphanRepairPlan>;
-type CacheRetention = Parameters<typeof beginPromptCacheObservation>[0]["cacheRetention"];
 type PromptBuildHookContext = Parameters<typeof resolvePromptBuildHookResult>[0]["hookCtx"];
 
 type EmbeddedAttemptSteeringLease = {
@@ -102,7 +93,6 @@ type EmbeddedAttemptPromptAssembly = {
   promptForRuntimeContextBeforeAnnotation: string;
   transcriptLeafId: string | null;
   heartbeatSummary?: ReturnType<typeof resolveHeartbeatSummaryForAgent>;
-  promptCacheChangesForTurn: PromptCacheChange[] | null;
   leasedSteering?: EmbeddedAttemptSteeringLease;
 };
 
@@ -121,14 +111,6 @@ export async function prepareEmbeddedAttemptPromptAssembly(input: {
   applyPromptBuildToolsAllow: (toolsAllow: string[] | undefined) => string[];
   setActiveSessionSystemPrompt: (systemPrompt: string) => void;
   setLeasedSteering: (lease: EmbeddedAttemptSteeringLease) => void;
-  cache: {
-    observabilityEnabled: boolean;
-    retention: CacheRetention;
-    streamStrategy: string;
-    transport: AgentSession["agent"]["transport"];
-    tools: readonly PromptCacheToolSnapshot[];
-    trace: CacheTrace;
-  };
 }): Promise<EmbeddedAttemptPromptAssembly> {
   const { attempt } = input;
   const isSettledTurnFinalization = attempt.operation === "settled-tool-finalization";
@@ -185,7 +167,6 @@ export async function prepareEmbeddedAttemptPromptAssembly(input: {
           activeToolNames: promptCacheToolNames,
           assertHostActive,
         });
-  const promptCacheToolNameSet = new Set(promptCacheToolNames.map(normalizeToolPolicyName));
   const promptBeforeResolvedToolFinalization = effectivePrompt;
   effectivePrompt = applyResolvedToolPromptFinalizer({
     prompt: effectivePrompt,
@@ -196,9 +177,6 @@ export async function prepareEmbeddedAttemptPromptAssembly(input: {
     attempt.finalizePromptForResolvedTools && attempt.transcriptPrompt === undefined
       ? promptBeforeResolvedToolFinalization
       : attempt.transcriptPrompt;
-  const promptCacheTools = input.cache.tools.filter((tool) =>
-    promptCacheToolNameSet.has(normalizeToolPolicyName(tool.name)),
-  );
   const promptBeforePromptBuildHooks = effectivePrompt;
   const joinHookContext = (...values: Array<string | undefined>) =>
     values.filter((value): value is string => Boolean(value?.trim())).join("\n\n") || undefined;
@@ -250,34 +228,6 @@ export async function prepareEmbeddedAttemptPromptAssembly(input: {
       });
   if (modelAwareSystemPrompt !== systemPromptText) {
     setSystemPrompt(modelAwareSystemPrompt);
-  }
-
-  let promptCacheChangesForTurn: PromptCacheChange[] | null = null;
-  if (input.cache.observabilityEnabled) {
-    const cacheObservation = beginPromptCacheObservation({
-      sessionId: attempt.sessionId,
-      promptCacheKey: attempt.promptCacheKey,
-      sessionKey: attempt.sessionKey,
-      provider: attempt.provider,
-      modelId: attempt.modelId,
-      modelApi: attempt.model.api,
-      cacheRetention: input.cache.retention,
-      streamStrategy: input.cache.streamStrategy,
-      transport: input.cache.transport,
-      systemPrompt: systemPromptText,
-      tools: promptCacheTools,
-    });
-    promptCacheChangesForTurn = cacheObservation.changes;
-    input.cache.trace?.recordStage("cache:state", {
-      options: {
-        snapshot: cacheObservation.snapshot,
-        previousCacheRead: cacheObservation.previousCacheRead ?? undefined,
-        changes: cacheObservation.changes?.map((change) => ({
-          code: change.code,
-          detail: change.detail,
-        })),
-      },
-    });
   }
 
   const routingSummary = describeProviderRequestRoutingSummary({
@@ -404,7 +354,6 @@ export async function prepareEmbeddedAttemptPromptAssembly(input: {
     promptForRuntimeContextBeforeAnnotation,
     transcriptLeafId,
     heartbeatSummary,
-    promptCacheChangesForTurn,
     leasedSteering,
   };
 }

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
@@ -355,11 +355,9 @@ describe("runEmbeddedAttemptPromptPhase", () => {
     const fixture = createFixture();
     const session = fixture.input.prepared.sessionRuntime.agentSession.activeSession;
     const observations = vi.fn<(observation: PromptCacheRequestObservation) => void>();
-    const requests: number[] = [];
     const observer = createPromptCacheRequestObserver(
       { sessionId: "prompt-phase-cache-observer", streamStrategy: "test" },
       observations,
-      ({ requestIndex }) => requests.push(requestIndex),
     );
     fixture.input.preparedStreamRuntime.cache.onModelRequest = observer.onModelRequest;
     let compacting = false;
@@ -401,7 +399,6 @@ describe("runEmbeddedAttemptPromptPhase", () => {
         changes: [{ code: "tools", detail: "tool set changed with same count" }],
       },
     ]);
-    expect(requests).toEqual([1, 2, 3]);
   });
 
   it.each([

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { upsertSessionEntryCore } from "../../../config/sessions/session-accessor.js";
@@ -11,6 +12,7 @@ import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
 } from "../../../state/openclaw-agent-db.js";
+import type { StreamFn } from "../../runtime/index.js";
 import {
   createAssistant,
   createAssistantResultStream,
@@ -25,6 +27,10 @@ import {
 } from "../../sessions/compaction/request-budget.js";
 import { SessionManager } from "../../sessions/session-manager.js";
 import { SettingsManager } from "../../sessions/settings-manager.js";
+import {
+  createPromptCacheRequestObserver,
+  type PromptCacheRequestObservation,
+} from "../prompt-cache-request-observer.js";
 import {
   getEmbeddedSessionPromptState,
   clearEmbeddedSessionPromptStates,
@@ -127,7 +133,6 @@ function createFixture({ pendingPrompt = "hello", pendingImageCount = 1 } = {}) 
   const promptState: EmbeddedAttemptPromptState = {
     contextBudgetStatus: undefined,
     preflightRecovery: undefined,
-    promptCacheChangesForTurn: null,
     yieldAborted: false,
   };
   const executionState: PromptPhaseInput["state"] = {
@@ -163,7 +168,6 @@ function createFixture({ pendingPrompt = "hello", pendingImageCount = 1 } = {}) 
     input.setLeasedSteering(lease);
     return {
       hookCtx: {},
-      promptCacheChangesForTurn: [],
       leasedSteering: lease,
       transcriptLeafId: "leaf-1",
     };
@@ -347,6 +351,59 @@ afterEach(() => {
 });
 
 describe("runEmbeddedAttemptPromptPhase", () => {
+  it("observes canonical request prefixes before managed cache consumption and skips compaction", async () => {
+    const fixture = createFixture();
+    const session = fixture.input.prepared.sessionRuntime.agentSession.activeSession;
+    const observations = vi.fn<(observation: PromptCacheRequestObservation) => void>();
+    const requests: number[] = [];
+    const observer = createPromptCacheRequestObserver(
+      { sessionId: "prompt-phase-cache-observer", streamStrategy: "test" },
+      observations,
+      ({ requestIndex }) => requests.push(requestIndex),
+    );
+    fixture.input.preparedStreamRuntime.cache.onModelRequest = observer.onModelRequest;
+    let compacting = false;
+    Object.defineProperty(session, "isCompacting", { get: () => compacting });
+    mocks.prepareGooglePromptCache.mockImplementation(
+      async ({ streamFn }: { streamFn: StreamFn }): Promise<StreamFn> =>
+        (model, context, options) =>
+          streamFn(model, { ...context, systemPrompt: undefined, tools: undefined }, options),
+    );
+    mocks.submitPrompt.mockImplementation(async () => {
+      const tool = { name: "read", description: "Read text", parameters: Type.Object({}) };
+      for (const [index, cacheRead] of [10_000, 0, 10_000].entries()) {
+        await session.agent.streamFn(testModel, {
+          systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}turn ${index}`,
+          messages: [],
+          tools: [{ ...tool, description: index === 2 ? "Read workspace text" : tool.description }],
+        });
+        observer.onModelUsage({ input: 10_000 - cacheRead, cacheRead, cacheWrite: 0 });
+        if (index === 0) {
+          compacting = true;
+          await session.agent.streamFn(testModel, {
+            systemPrompt: "Summarize",
+            messages: [],
+            tools: [],
+          });
+          compacting = false;
+        }
+      }
+    });
+    await runEmbeddedAttemptPromptPhase(fixture.input, fixture.promptState);
+    expect(fixture.readState().promptError).toBeNull();
+    expect(observations.mock.calls.map(([observation]) => observation)).toMatchObject([
+      { requestIndex: 1, broke: false, cacheRead: 10_000, changes: null },
+      { requestIndex: 2, broke: true, cacheRead: 0, changes: null },
+      {
+        requestIndex: 3,
+        broke: false,
+        cacheRead: 10_000,
+        changes: [{ code: "tools", detail: "tool set changed with same count" }],
+      },
+    ]);
+    expect(requests).toEqual([1, 2, 3]);
+  });
+
   it.each([
     { appendOnlyRuntimeContext: true, queued: false },
     { appendOnlyRuntimeContext: false, queued: false },
@@ -728,7 +785,6 @@ describe("runEmbeddedAttemptPromptPhase", () => {
       "stop-steering",
     ]);
     expect(fixture.sessionRuntimeState.prePromptMessageCount).toBe(2);
-    expect(fixture.promptState.promptCacheChangesForTurn).toEqual([]);
     expect(fixture.promptState.finalPromptText).toBe("hello");
     expect(mocks.preparePromptContext).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -47,7 +47,6 @@ export type EmbeddedAttemptPromptState = Pick<
   PromptPreflightState,
   "contextBudgetStatus" | "preflightRecovery"
 > & {
-  promptCacheChangesForTurn: PromptAssemblyResult["promptCacheChangesForTurn"];
   finalPromptText?: string;
   yieldAborted: boolean;
 };
@@ -85,7 +84,6 @@ export async function runEmbeddedAttemptPromptPhase(
     transport: {
       effectiveAgentTransport,
       effectiveExtraParams,
-      effectivePromptCacheRetention,
       streamStrategy,
       compactionReplayEnabled,
     },
@@ -165,14 +163,6 @@ export async function runEmbeddedAttemptPromptPhase(
     runtimeModel: runtimeInfo.model,
     systemPromptText,
     setActiveSessionSystemPrompt,
-    cache: {
-      observabilityEnabled: preparedStreamRuntime.cache.observabilityEnabled,
-      retention: effectivePromptCacheRetention,
-      streamStrategy,
-      transport: effectiveAgentTransport,
-      tools: preparedStreamRuntime.cache.promptTools,
-      trace: cacheTrace,
-    },
     applyPromptBuildToolsAllow: (toolsAllow) => {
       return promptToolPolicy.apply(toolsAllow).activeToolNames;
     },
@@ -188,7 +178,6 @@ export async function runEmbeddedAttemptPromptPhase(
   const { hookCtx, promptBuildPrependContext, promptBuildAppendContext, transcriptLeafId } =
     promptAssembly;
   leasedSteering = promptAssembly.leasedSteering ?? leasedSteering;
-  promptState.promptCacheChangesForTurn = promptAssembly.promptCacheChangesForTurn;
 
   try {
     const canClaimHeartbeatOutcome =
@@ -272,6 +261,17 @@ export async function runEmbeddedAttemptPromptPhase(
       });
       if (googlePromptCacheStreamFn) {
         activeSession.agent.streamFn = googlePromptCacheStreamFn;
+      }
+      const { onModelRequest } = preparedStreamRuntime.cache;
+      if (onModelRequest) {
+        const streamFn = activeSession.agent.streamFn;
+        activeSession.agent.streamFn = (model, context, options) => {
+          // Observe canonical inputs before managed caches consume system/tools.
+          if (!activeSession.isCompacting) {
+            onModelRequest(model, context);
+          }
+          return streamFn(model, context, options);
+        };
       }
     }
 

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
@@ -706,14 +706,6 @@ describe("submitEmbeddedAttemptPrompt", () => {
             applyPromptBuildToolsAllow: () => [],
             setActiveSessionSystemPrompt: vi.fn(),
             setLeasedSteering: vi.fn(),
-            cache: {
-              observabilityEnabled: false,
-              retention: "none",
-              streamStrategy: "default",
-              transport: "sse",
-              tools: [],
-              trace: null,
-            },
           });
           await submitEmbeddedAttemptPrompt({
             ...input,

--- a/src/agents/embedded-agent-runner/run/attempt-result.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.test.ts
@@ -58,14 +58,12 @@ function createResultFixture(params?: {
     currentAttemptCompletedAssistant: params?.currentAttemptCompletedAssistant,
     successfulNestedToolNames: params?.successfulNestedToolNames ?? [],
     attemptUsage: undefined,
-    cacheBreak: null,
     lastCallUsage: undefined,
     promptCache: undefined,
   };
   const prompt: Parameters<typeof completeEmbeddedAttemptResult>[2] = {
     preflightRecovery: undefined,
     contextBudgetStatus: undefined,
-    promptCacheChangesForTurn: null,
     yieldAborted: false,
     sessionIdUsed: settled.sessionIdUsed,
     sessionFileUsed: undefined,
@@ -138,7 +136,7 @@ function createResultFixture(params?: {
     },
     preparedStreamRuntime: {
       stream: { subscription },
-      cache: { observabilityEnabled: false },
+      cache: {},
     },
   };
   return { input, state, settled, prompt, hookRunner };

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -190,13 +190,10 @@ export function completeEmbeddedAttemptResult(
   const { sessionRuntime, bootstrap, systemPrompt } = input.prepared;
   const {
     agentSession: { clientToolCallSlots, hasDeliveredSourceReply, hookRunner },
-    cacheTrace,
     trajectoryRecorder,
-    transport: { streamStrategy },
   } = sessionRuntime;
   const { subscription, deferredLifecycleOwner } = input.preparedStreamRuntime.stream;
   const { bootstrapPromptWarning } = bootstrap;
-  const promptCacheChangesForTurn = prompt.promptCacheChangesForTurn;
   const hookAgentId = input.setup.sessionAgentId;
   // Output hooks can reenter the runtime; project only the state settled before they run.
   const state = {
@@ -251,45 +248,6 @@ export function completeEmbeddedAttemptResult(
     toolMetas,
   } = subscription;
   const toolMetasNormalized = normalizeEmbeddedAttemptToolMetas(toolMetas);
-
-  if (input.preparedStreamRuntime.cache.observabilityEnabled) {
-    const cacheBreak = settled.cacheBreak;
-    if (cacheBreak) {
-      const changeSummary =
-        cacheBreak.changes?.map((change) => `${change.code}(${change.detail})`).join(", ") ??
-        "no tracked cache input change";
-      log.warn(
-        `[prompt-cache] cache read dropped ${cacheBreak.previousCacheRead} -> ${cacheBreak.cacheRead} ` +
-          `for ${attempt.provider}/${attempt.modelId} via ${streamStrategy}; ${changeSummary}`,
-      );
-      cacheTrace?.recordStage("cache:result", {
-        options: {
-          previousCacheRead: cacheBreak.previousCacheRead,
-          cacheRead: cacheBreak.cacheRead,
-          changes: cacheBreak.changes?.map((change) => ({
-            code: change.code,
-            detail: change.detail,
-          })),
-        },
-      });
-    } else if (cacheTrace && promptCacheChangesForTurn) {
-      cacheTrace.recordStage("cache:result", {
-        note: "state changed without a cache-read break",
-        options: {
-          cacheRead: state.attemptUsage?.cacheRead ?? 0,
-          changes: promptCacheChangesForTurn.map((change) => ({
-            code: change.code,
-            detail: change.detail,
-          })),
-        },
-      });
-    } else if (cacheTrace) {
-      cacheTrace.recordStage("cache:result", {
-        note: "stable cache inputs",
-        options: { cacheRead: state.attemptUsage?.cacheRead ?? 0 },
-      });
-    }
-  }
 
   if (
     attempt.operation !== "settled-tool-finalization" &&

--- a/src/agents/embedded-agent-runner/run/attempt-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-settle.ts
@@ -115,13 +115,11 @@ export async function runEmbeddedAttemptSettledPhase(
   const promptState: EmbeddedAttemptPromptState = {
     contextBudgetStatus: undefined,
     preflightRecovery: undefined,
-    promptCacheChangesForTurn: null,
     yieldAborted: false,
   };
   const preparedStreamRuntime = input.preparedStreamRuntime;
   const {
     abortable,
-    cache: { observabilityEnabled: cacheObservabilityEnabled },
     isProbeSession,
     onBlockReplyFlush,
     stream: preparedStream,
@@ -262,8 +260,7 @@ export async function runEmbeddedAttemptSettledPhase(
           prePromptMessageCount: sessionRuntimeState.prePromptMessageCount,
           nestedToolActivities,
           cache: {
-            observabilityEnabled: cacheObservabilityEnabled,
-            changesForTurn: promptState.promptCacheChangesForTurn,
+            getObservation: preparedStreamRuntime.cache.getObservation,
             retention: effectivePromptCacheRetention,
           },
         });

--- a/src/agents/embedded-agent-runner/run/attempt-stream-finalize.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-finalize.test.ts
@@ -185,7 +185,7 @@ function createFixture(overrides: FixtureOverrides = {}) {
     getRepairedRejectedProviderReplay: () => overrides.repairedRejectedProviderReplay ?? true,
     preparedStreamRuntime: {
       abortable: async <T>(promise: Promise<T>) => await promise,
-      cache: { observabilityEnabled: false, promptTools: [] },
+      cache: {},
       history: {
         contextEnginePromptAuthority: "assembled",
         contextEngineAssemblySucceeded: true,
@@ -224,7 +224,6 @@ function createFixture(overrides: FixtureOverrides = {}) {
     currentAttemptAssistant: undefined,
     currentAttemptCompletedAssistant: undefined,
     attemptUsage: undefined,
-    cacheBreak: null,
     lastCallUsage: undefined,
     promptCache: undefined,
   });
@@ -299,7 +298,6 @@ describe("runEmbeddedAttemptSettledPhase stream finalization", () => {
       currentAttemptAssistant: failedAssistant,
       currentAttemptCompletedAssistant: failedAssistant,
       attemptUsage: undefined,
-      cacheBreak: null,
       lastCallUsage: undefined,
       promptCache: undefined,
     });
@@ -353,7 +351,6 @@ describe("runEmbeddedAttemptSettledPhase stream finalization", () => {
       currentAttemptAssistant: undefined,
       currentAttemptCompletedAssistant: undefined,
       attemptUsage: undefined,
-      cacheBreak: null,
       lastCallUsage: undefined,
       promptCache: undefined,
     };
@@ -416,7 +413,6 @@ describe("runEmbeddedAttemptSettledPhase stream finalization", () => {
       currentAttemptAssistant: undefined,
       currentAttemptCompletedAssistant: undefined,
       attemptUsage: undefined,
-      cacheBreak: null,
       lastCallUsage: undefined,
       promptCache: { published: true },
     };
@@ -473,7 +469,6 @@ describe("runEmbeddedAttemptSettledPhase stream finalization", () => {
         currentAttemptAssistant: undefined,
         currentAttemptCompletedAssistant: undefined,
         attemptUsage: undefined,
-        cacheBreak: null,
         lastCallUsage: undefined,
         promptCache: undefined,
       });
@@ -512,7 +507,6 @@ describe("runEmbeddedAttemptSettledPhase stream finalization", () => {
       currentAttemptAssistant: undefined,
       currentAttemptCompletedAssistant: undefined,
       attemptUsage: undefined,
-      cacheBreak: null,
       lastCallUsage: undefined,
       promptCache: undefined,
     });
@@ -544,7 +538,6 @@ describe("runEmbeddedAttemptSettledPhase stream finalization", () => {
         currentAttemptAssistant: undefined,
         currentAttemptCompletedAssistant: undefined,
         attemptUsage: undefined,
-        cacheBreak: null,
         lastCallUsage: undefined,
         promptCache: undefined,
       };
@@ -760,7 +753,6 @@ describe("runEmbeddedAttemptSettledPhase stream finalization", () => {
       currentAttemptAssistant: undefined,
       currentAttemptCompletedAssistant: undefined,
       attemptUsage: undefined,
-      cacheBreak: null,
       lastCallUsage: undefined,
       promptCache: undefined,
     });

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -103,6 +103,7 @@ export function prepareEmbeddedAttemptStream(input: {
     revokeApprovals: () => void,
   ) => void;
   activeSession: AgentSession;
+  onModelUsage?: Parameters<typeof subscribeEmbeddedAgentSession>[0]["onModelUsage"];
   runtimeChannel?: string;
   hookRunner: HookRunner;
   hookAgentId: string;
@@ -288,6 +289,7 @@ export function prepareEmbeddedAttemptStream(input: {
   let deferredLifecycleOwner: EmbeddedAttemptDeferredLifecycleOwner | undefined;
   const subscription = subscribeEmbeddedAgentSession({
     session: input.activeSession,
+    onModelUsage: input.onModelUsage,
     runId: attempt.runId,
     lifecycleGeneration: attempt.lifecycleGeneration,
     messageChannel: input.runtimeChannel,

--- a/src/agents/embedded-agent-runner/run/attempt-stream-runtime.types.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-runtime.types.ts
@@ -6,8 +6,10 @@ import type { prepareEmbeddedAttemptTimeout } from "./attempt-timeout-prepare.js
 export type PreparedStreamRuntime = {
   abortable: <T>(promise: Promise<T>) => Promise<T>;
   cache: {
-    observabilityEnabled: boolean;
-    promptTools: ReturnType<typeof installEmbeddedAttemptStreamGuards>["promptCacheTools"];
+    onModelRequest?: ReturnType<typeof installEmbeddedAttemptStreamGuards>["onModelRequest"];
+    getObservation?: ReturnType<
+      typeof installEmbeddedAttemptStreamGuards
+    >["getPromptCacheObservation"];
   };
   history: Awaited<ReturnType<typeof prepareEmbeddedAttemptHistory>>;
   isProbeSession: boolean;

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts
@@ -91,8 +91,6 @@ function createSettleFixture(overrides?: Partial<SettleInput>): SettleInput {
     prePromptMessageCount: 0,
     nestedToolActivities: [],
     cache: {
-      observabilityEnabled: false,
-      changesForTurn: null,
       retention: undefined,
     },
     shouldFlushForContextEngine: false,
@@ -123,6 +121,31 @@ describe("settleEmbeddedAttemptStream liveness", () => {
     await vi.advanceTimersByTimeAsync(1);
     const result = await settle;
     expect(result.sessionIdUsed).toBe("sess-settle-1");
+  });
+
+  it("keeps the last request observation separate from billing totals", async () => {
+    const input = createSettleFixture();
+    input.subscription.getUsageTotals = () => ({ input: 300, cacheRead: 30_000 });
+    input.subscription.getLastAssistantUsage = () => ({ input: 100, cacheRead: 10_000 });
+    input.cache = {
+      ...input.cache,
+      getObservation: () => ({
+        requestIndex: 3,
+        broke: false,
+        input: 100,
+        cacheRead: 10_000,
+        cacheWrite: 0,
+        previousCacheRead: 10_000,
+        changes: null,
+      }),
+    };
+    const result = await settleEmbeddedAttemptStream(input);
+    expect(result.attemptUsage?.cacheRead).toBe(30_000);
+    expect(result.promptCache?.observation).toMatchObject({
+      broke: false,
+      cacheRead: 10_000,
+      previousCacheRead: 10_000,
+    });
   });
 
   it("settles normally when the flush resolves", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -31,11 +31,7 @@ import {
   resolvePreparedExtraParams,
 } from "../extra-params.js";
 import { log } from "../logger.js";
-import {
-  completePromptCacheObservation,
-  type PromptCacheBreak,
-  type PromptCacheChange,
-} from "../prompt-cache-observability.js";
+import type { PromptCacheRequestObservation } from "../prompt-cache-request-observer.js";
 import { resolveCacheRetention } from "../prompt-cache-retention.js";
 import {
   type ProviderPromptState,
@@ -97,7 +93,6 @@ type StreamSettleResult = {
   currentAttemptCompletedAssistant: EmbeddedRunAttemptResult["currentAttemptCompletedAssistant"];
   successfulNestedToolNames: string[];
   attemptUsage: EmbeddedRunAttemptResult["attemptUsage"];
-  cacheBreak: PromptCacheBreak | null;
   lastCallUsage: NormalizedUsage | undefined;
   promptCache: EmbeddedRunAttemptResult["promptCache"];
 };
@@ -132,8 +127,7 @@ export async function settleEmbeddedAttemptStream(input: {
   prePromptMessageCount: number;
   nestedToolActivities: readonly NestedToolActivity[];
   cache: {
-    observabilityEnabled: boolean;
-    changesForTurn: PromptCacheChange[] | null;
+    getObservation?: () => PromptCacheRequestObservation | undefined;
     retention: PromptCacheRetention;
   };
   shouldFlushForContextEngine: boolean;
@@ -283,7 +277,6 @@ export async function settleEmbeddedAttemptStream(input: {
   let currentAttemptAssistant: AssistantMessage | undefined;
   let currentAttemptCompletedAssistant: AssistantMessage | undefined;
   let attemptUsage: EmbeddedRunAttemptResult["attemptUsage"];
-  let cacheBreak: PromptCacheBreak | null = null;
   let lastCallUsage: NormalizedUsage | undefined;
   let promptCache: EmbeddedRunAttemptResult["promptCache"];
 
@@ -337,14 +330,6 @@ export async function settleEmbeddedAttemptStream(input: {
     });
     currentAttemptCompletedAssistant = subscription.getCurrentAttemptAssistant();
     attemptUsage = subscription.getUsageTotals();
-    cacheBreak = input.cache.observabilityEnabled
-      ? completePromptCacheObservation({
-          sessionId: attempt.sessionId,
-          promptCacheKey: attempt.promptCacheKey,
-          sessionKey: attempt.sessionKey,
-          usage: attemptUsage,
-        })
-      : null;
     const transcriptUsageSnapshot = findLatestUncompactedAttemptUsageSnapshot({
       messagesSnapshot,
       prePromptMessageCount: input.prePromptMessageCount,
@@ -361,22 +346,6 @@ export async function settleEmbeddedAttemptStream(input: {
     const usageAssistant = hasNonzeroUsage(completedAssistantUsage)
       ? currentAttemptCompletedAssistant
       : transcriptUsageSnapshot?.assistant;
-    const promptCacheObservation =
-      input.cache.observabilityEnabled &&
-      (cacheBreak || input.cache.changesForTurn || typeof attemptUsage?.cacheRead === "number")
-        ? {
-            broke: Boolean(cacheBreak),
-            ...(typeof cacheBreak?.previousCacheRead === "number"
-              ? { previousCacheRead: cacheBreak.previousCacheRead }
-              : {}),
-            ...(typeof cacheBreak?.cacheRead === "number"
-              ? { cacheRead: cacheBreak.cacheRead }
-              : typeof attemptUsage?.cacheRead === "number"
-                ? { cacheRead: attemptUsage.cacheRead }
-                : {}),
-            changes: cacheBreak?.changes ?? input.cache.changesForTurn,
-          }
-        : undefined;
     const fallbackLastCacheTouchAt = readLastCacheTtlTimestamp(sessionManager, {
       provider: attempt.provider,
       modelId: attempt.modelId,
@@ -384,7 +353,7 @@ export async function settleEmbeddedAttemptStream(input: {
     promptCache = buildContextEnginePromptCacheInfo({
       retention: input.cache.retention,
       lastCallUsage,
-      observation: promptCacheObservation,
+      observation: input.cache.getObservation?.(),
       lastCacheTouchAt: resolvePromptCacheTouchTimestamp({
         lastCallUsage,
         assistantTimestamp: usageAssistant?.timestamp,
@@ -431,7 +400,6 @@ export async function settleEmbeddedAttemptStream(input: {
       ),
     ],
     attemptUsage,
-    cacheBreak,
     lastCallUsage,
     promptCache,
   };

--- a/src/agents/embedded-agent-runner/run/attempt-stream.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream.ts
@@ -13,7 +13,7 @@ import { UNKNOWN_TOOL_THRESHOLD } from "../../tool-loop-detection.js";
 import { wrapStreamFnCodeModeSource } from "../../transcript-code-mode-source.js";
 import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
 import { log } from "../logger.js";
-import { collectPromptCacheTools } from "../prompt-cache-observability.js";
+import { createPromptCacheRequestObserver } from "../prompt-cache-request-observer.js";
 import {
   repairRejectedCompactionReplayInSessionManager,
   repairRejectedThinkingReplayInSessionManager,
@@ -83,7 +83,7 @@ export function installEmbeddedAttemptStreamGuards(
 ) {
   const { attempt } = input;
   const {
-    agentSession: { activeSession: session, allCustomTools, codeModeExecToolNames },
+    agentSession: { activeSession: session, codeModeExecToolNames },
     anthropicPayloadLogger,
     cacheTrace,
     contextGuards,
@@ -91,7 +91,12 @@ export function installEmbeddedAttemptStreamGuards(
     sessionManager,
     state: { systemPromptText },
     transcriptPolicy,
-    transport: { effectiveAgentTransport, providerTextTransforms },
+    transport: {
+      effectiveAgentTransport,
+      effectivePromptCacheRetention,
+      streamStrategy,
+      providerTextTransforms,
+    },
   } = input.prepared.sessionRuntime;
   const { liveAllowedToolNames, replayAllowedToolNames } =
     input.prepared.toolCatalog.toolSearchRunPlan;
@@ -138,7 +143,35 @@ export function installEmbeddedAttemptStreamGuards(
     }
   };
   const cacheObservabilityEnabled = Boolean(cacheTrace) || log.isEnabled("debug");
-  const promptCacheTools = cacheObservabilityEnabled ? collectPromptCacheTools(allCustomTools) : [];
+  const cacheObserver = cacheObservabilityEnabled
+    ? createPromptCacheRequestObserver(
+        {
+          sessionId: attempt.sessionId,
+          sessionKey: attempt.sessionKey,
+          promptCacheKey: attempt.promptCacheKey,
+          cacheRetention: effectivePromptCacheRetention,
+          streamStrategy,
+          transport: effectiveAgentTransport,
+        },
+        (observation, snapshot) => {
+          if (observation.broke) {
+            const changes =
+              observation.changes?.map((change) => `${change.code}(${change.detail})`).join(", ") ??
+              "no tracked cache input change";
+            log.warn(
+              `[prompt-cache] cache read dropped ${observation.previousCacheRead} -> ${observation.cacheRead} ` +
+                `runId=${attempt.runId} request=${observation.requestIndex} for ${snapshot.provider}/${snapshot.modelId} via ${streamStrategy}; ${changes}`,
+            );
+          }
+          cacheTrace?.recordStage("cache:result", { options: { ...observation } });
+        },
+        (request) => {
+          cacheTrace?.recordStage("cache:state", {
+            options: { ...request, previousCacheRead: request.previousCacheRead ?? undefined },
+          });
+        },
+      )
+    : undefined;
   if (cacheTrace) {
     cacheTrace.recordStage("session:loaded", {
       messages: session.messages,
@@ -379,7 +412,8 @@ export function installEmbeddedAttemptStreamGuards(
     );
   }
   return {
-    cacheObservabilityEnabled,
-    promptCacheTools,
+    onModelRequest: cacheObserver?.onModelRequest,
+    onModelUsage: cacheObserver?.onModelUsage,
+    getPromptCacheObservation: cacheObserver?.getObservation,
   };
 }

--- a/src/agents/embedded-agent-runner/run/attempt-stream.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream.ts
@@ -12,6 +12,7 @@ import { resolveAgentTimeoutMs } from "../../timeout.js";
 import { UNKNOWN_TOOL_THRESHOLD } from "../../tool-loop-detection.js";
 import { wrapStreamFnCodeModeSource } from "../../transcript-code-mode-source.js";
 import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
+import type { NormalizedUsage } from "../../usage.js";
 import { log } from "../logger.js";
 import { createPromptCacheRequestObserver } from "../prompt-cache-request-observer.js";
 import {
@@ -370,6 +371,7 @@ export function installEmbeddedAttemptStreamGuards(
     };
   }
   let diagnosticModelCallSeq = 0;
+  let modelResponseTerminal = false;
   session.agent.streamFn = wrapStreamFnWithDiagnosticModelCallEvents(session.agent.streamFn, {
     runId: attempt.runId,
     ...(attempt.sessionKey && { sessionKey: attempt.sessionKey }),
@@ -395,7 +397,11 @@ export function installEmbeddedAttemptStreamGuards(
     nextCallId: () => `${attempt.runId}:model:${(diagnosticModelCallSeq += 1)}`,
     ownerGeneration: callbacks.diagnosticOwner.generation,
     onSucceeded: contextGuards.recordCacheTouch,
+    onTerminal: () => {
+      modelResponseTerminal = true;
+    },
     onStarted: () => {
+      modelResponseTerminal = false;
       attempt.onExecutionPhase?.({
         phase: "model_call_started",
         provider: attempt.provider,
@@ -413,7 +419,16 @@ export function installEmbeddedAttemptStreamGuards(
   }
   return {
     onModelRequest: cacheObserver?.onModelRequest,
-    onModelUsage: cacheObserver?.onModelUsage,
+    onModelUsage: cacheObserver
+      ? (usage: NormalizedUsage | undefined) => {
+          // Async-tool fragments also end messages. result() marks the terminal
+          // response before core commits its final fragment with normalized usage.
+          if (modelResponseTerminal) {
+            modelResponseTerminal = false;
+            cacheObserver.onModelUsage(usage);
+          }
+        }
+      : undefined,
     getPromptCacheObservation: cacheObserver?.getObservation,
   };
 }

--- a/src/agents/embedded-agent-runner/run/attempt.media-hint-cache-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.media-hint-cache-boundary.test.ts
@@ -116,14 +116,6 @@ async function createTurnFixture(systemPromptOverride?: string) {
       applyPromptBuildToolsAllow: () => ["image_generate"],
       setActiveSessionSystemPrompt,
       setLeasedSteering: vi.fn(),
-      cache: {
-        observabilityEnabled: false,
-        retention: "none",
-        streamStrategy: "default",
-        transport: "sse",
-        tools: [],
-        trace: null,
-      },
     });
     return prepareEmbeddedAttemptPromptContext({
       attempt,

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { notifyProviderStreamOpened } from "@openclaw/ai/transports";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../../../test/helpers/temp-dir.js";
@@ -25,6 +26,7 @@ import {
 } from "../../../plugins/hook-runner-global.js";
 import { createHookRunnerWithRegistry } from "../../../plugins/hooks.test-fixtures.js";
 import { withEnvAsync } from "../../../test-utils/env.js";
+import { makeZeroUsageSnapshot } from "../../usage.js";
 import { wrapStreamFnWithDiagnosticModelCallEvents } from "./attempt.model-diagnostic-events.js";
 
 const tempDirs = createTempDirTracker();
@@ -120,6 +122,46 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents lifecycle", () => {
     vi.restoreAllMocks();
     vi.useRealTimers();
   });
+
+  it.each(["stop", "error"] as const)(
+    "notifies terminal %s once when an explicit result follows iterator exhaustion",
+    async (stopReason) => {
+      const onTerminal = vi.fn();
+      const onSucceeded = vi.fn();
+      const originalStream = createAssistantMessageEventStream();
+      originalStream.end({
+        role: "assistant",
+        content: [{ type: "text", text: "Done." }],
+        api: "openai-responses",
+        provider: "openai",
+        model: "gpt-5.4",
+        stopReason,
+        usage: makeZeroUsageSnapshot(),
+        timestamp: 0,
+      });
+      const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(() => originalStream, {
+        runId: "run-explicit-result",
+        provider: "openai",
+        model: "gpt-5.4",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => "call-explicit-result",
+        onTerminal,
+        onSucceeded,
+      });
+      const events = await collectModelCallEvents(async () => {
+        const response = await wrapped({} as never, { messages: [] });
+        await drain(response);
+        expect(onTerminal).not.toHaveBeenCalled();
+        expect(onSucceeded).not.toHaveBeenCalled();
+        await response.result();
+        await response.result();
+        await drain(response);
+      });
+      expect(onTerminal).toHaveBeenCalledOnce();
+      expect(onSucceeded).toHaveBeenCalledTimes(stopReason === "stop" ? 1 : 0);
+      expect(events.filter((event) => event.type === "model.call.completed")).toHaveLength(1);
+    },
+  );
 
   it.each(["stop", "error"])(
     "emits one %s provider timeline event for result and iterator completion",

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
@@ -52,6 +52,7 @@ export type ModelCallDiagnosticContext = {
   nextCallId: () => string;
   ownerGeneration?: CoreModelRequestOwnerGeneration;
   onStarted?: () => void;
+  onTerminal?: () => void;
   onSucceeded?: (startedAt: number) => void;
   suppressPluginHooks?: boolean;
   requestTimeoutMs?: number;
@@ -414,13 +415,15 @@ export function createModelLifecycle(params: {
     propagatedOptions,
     startedAt,
     emitCompleted() {
-      // Iterator cleanup alone is not a successful request; require its terminal result.
+      // Iterator cleanup alone is not a completed response; require its terminal result.
       if (
         !observer.state.terminalEventEmitted &&
-        observer.state.terminalSucceeded &&
-        !observer.state.terminalError
+        (observer.state.terminalSucceeded || observer.state.terminalError)
       ) {
-        params.ctx.onSucceeded?.(startedAt);
+        params.ctx.onTerminal?.();
+        if (observer.state.terminalSucceeded && !observer.state.terminalError) {
+          params.ctx.onSucceeded?.(startedAt);
+        }
       }
       emitModelCallEnded(
         eventBase,

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
@@ -409,17 +409,16 @@ export function createModelLifecycle(params: {
   params.ctx.onStarted?.();
   const startedAt = Date.now();
   const propagatedOptions = withDiagnosticRequestContext(params.options, trace, observer, callId);
+  let terminalNotified = false;
   return {
     eventBase,
     observer,
     propagatedOptions,
     startedAt,
     emitCompleted() {
-      // Iterator cleanup alone is not a completed response; require its terminal result.
-      if (
-        !observer.state.terminalEventEmitted &&
-        (observer.state.terminalSucceeded || observer.state.terminalError)
-      ) {
+      // Iterator exhaustion can emit diagnostics before result() supplies the terminal response.
+      if (!terminalNotified && (observer.state.terminalSucceeded || observer.state.terminalError)) {
+        terminalNotified = true;
         params.ctx.onTerminal?.();
         if (observer.state.terminalSucceeded && !observer.state.terminalError) {
           params.ctx.onSucceeded?.(startedAt);

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test-support.ts
@@ -161,14 +161,12 @@ export function projectSettledProviderFailureAttempt(
     currentAttemptCompletedAssistant: assistant,
     successfulNestedToolNames: [],
     attemptUsage: undefined,
-    cacheBreak: null,
     lastCallUsage: undefined,
     promptCache: undefined,
   };
   const prompt: Parameters<typeof completeEmbeddedAttemptResult>[2] = {
     preflightRecovery: undefined,
     contextBudgetStatus: undefined,
-    promptCacheChangesForTurn: null,
     yieldAborted: false,
     sessionIdUsed: base.sessionIdUsed,
     sessionFileUsed: undefined,

--- a/src/agents/embedded-agent-runner/usage-accumulator.test.ts
+++ b/src/agents/embedded-agent-runner/usage-accumulator.test.ts
@@ -148,6 +148,22 @@ describe("usage-accumulator", () => {
       expect(toNormalizedUsage(createUsageAccumulator())).toBeUndefined();
     });
 
+    it("preserves reported zero cache counters across attempt and run totals", () => {
+      const attempt = createAccumulatorWithUsage({ input: 100, cacheRead: 0, cacheWrite: 0 });
+      const run = createUsageAccumulator();
+      mergeUsageIntoAccumulator(run, toNormalizedUsage(attempt));
+      expect(toNormalizedUsage(run)).toMatchObject({
+        input: 100,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 100,
+      });
+      expect(toNormalizedUsage(createAccumulatorWithUsage({ input: 100 }))).toMatchObject({
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      });
+    });
+
     it("returns accumulated totals for billing", () => {
       const acc = createUsageAccumulator();
 

--- a/src/agents/embedded-agent-runner/usage-accumulator.ts
+++ b/src/agents/embedded-agent-runner/usage-accumulator.ts
@@ -9,6 +9,8 @@ export type UsageAccumulator = {
   output: number;
   cacheRead: number;
   cacheWrite: number;
+  cacheReadReported?: true;
+  cacheWriteReported?: true;
   cacheWrite1h: number;
   reasoningTokens: number;
   total: number;
@@ -53,6 +55,12 @@ export const mergeUsageIntoAccumulator = (
   const callTotal =
     usage.total ??
     (usage.input ?? 0) + (usage.output ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
+  if (usage.cacheRead !== undefined) {
+    target.cacheReadReported = true;
+  }
+  if (usage.cacheWrite !== undefined) {
+    target.cacheWriteReported = true;
+  }
   target.input += usage.input ?? 0;
   target.output += usage.output ?? 0;
   target.cacheRead += usage.cacheRead ?? 0;
@@ -105,8 +113,8 @@ export const toNormalizedUsage = (usage: UsageAccumulator): NormalizedUsage | un
   return {
     input: usage.input || undefined,
     output: usage.output || undefined,
-    cacheRead: usage.cacheRead || undefined,
-    cacheWrite: usage.cacheWrite || undefined,
+    cacheRead: usage.cacheReadReported ? usage.cacheRead : usage.cacheRead || undefined,
+    cacheWrite: usage.cacheWriteReported ? usage.cacheWrite : usage.cacheWrite || undefined,
     ...(usage.cacheWrite1h > 0 ? { cacheWrite1h: usage.cacheWrite1h } : {}),
     ...(usage.reasoningTokens > 0 ? { reasoningTokens: usage.reasoningTokens } : {}),
     total: usage.total || derivedTotal || undefined,

--- a/src/agents/embedded-agent-subscribe.model-state.ts
+++ b/src/agents/embedded-agent-subscribe.model-state.ts
@@ -148,6 +148,11 @@ export function createEmbeddedModelState(
             lastUsage = { ...pending };
           }
           recordModelUsage(pending);
+          runBestEffortCallback({
+            label: "model usage observation",
+            log,
+            callback: () => params.onModelUsage?.(pending),
+          });
           pending = undefined;
           // Context-engine projection can later mutate transcript objects; retain this run's result.
           completed = structuredClone(message);

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -414,6 +414,7 @@ describe("subscribeEmbeddedAgentSession", () => {
       const secondCompleted = createDeferred();
       const admittedUsage: StreamUsage[] = [];
       const onAgentEvent = vi.fn();
+      const onModelUsage = vi.fn();
       const onBlockReplyFlush = vi.fn();
       const onBlockReply = vi.fn().mockImplementationOnce(() => {
         deliveryStarted.resolve();
@@ -427,6 +428,7 @@ describe("subscribeEmbeddedAgentSession", () => {
         onBlockReply,
         onBlockReplyFlush,
         onAgentEvent,
+        onModelUsage,
       });
       const { emit, subscription } = harness;
       const running = runUsageCalls(
@@ -464,6 +466,10 @@ describe("subscribeEmbeddedAgentSession", () => {
         expect(admittedUsage).toMatchObject([
           { input: 100, output: 12, totalTokens: 112, cost: { total: 0.125 } },
           { input: 200, output: 8, totalTokens: 208, cost: { total: 0.5 } },
+        ]);
+        expect(onModelUsage.mock.calls).toMatchObject([
+          [{ input: 100, output: 12, cacheRead: 0, cacheWrite: 0 }],
+          [{ input: 200, output: 8, cacheRead: 0, cacheWrite: 0 }],
         ]);
         expect(subscription.getUsageTotals()).toMatchObject({
           input: 300,

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -72,7 +72,7 @@ export type SubscribeEmbeddedAgentSessionParams = {
   blockReplyChunking?: BlockReplyChunking;
   onPartialReply?: (payload: PartialReplyPayload) => boolean | void | Promise<boolean | void>;
   onAssistantMessageStart?: () => void | Promise<void>;
-  /** Exact completed model request usage, before aggregation or queued delivery. */
+  /** Assistant fragment usage before queued delivery; fragments may be intermediate. */
   onModelUsage?: (usage: NormalizedUsage | undefined) => void;
   onExecutionPhase?: (info: {
     phase: "tool_execution_started";

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -26,6 +26,7 @@ import type { PreparedProviderFailoverOwner } from "./failover/provider-patterns
 import type { AgentInternalEvent } from "./internal-events.js";
 import type { AgentMessage } from "./runtime/index.js";
 import type { AgentSession } from "./sessions/index.js";
+import type { NormalizedUsage } from "./usage.js";
 export type { BlockReplyChunking } from "./embedded-agent-subscribe.shared-types.js";
 
 type ReasoningStreamPayload = Pick<
@@ -71,6 +72,8 @@ export type SubscribeEmbeddedAgentSessionParams = {
   blockReplyChunking?: BlockReplyChunking;
   onPartialReply?: (payload: PartialReplyPayload) => boolean | void | Promise<boolean | void>;
   onAssistantMessageStart?: () => void | Promise<void>;
+  /** Exact completed model request usage, before aggregation or queued delivery. */
+  onModelUsage?: (usage: NormalizedUsage | undefined) => void;
   onExecutionPhase?: (info: {
     phase: "tool_execution_started";
     tool?: string;

--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
 import { SESSION_TOTAL_TOKENS_VERSION } from "../config/sessions/types.js";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
+import * as transcriptReaders from "../gateway/session-transcript-readers.js";
 
 vi.mock("../version.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../version.js")>();
@@ -247,6 +248,52 @@ describe("buildStatusMessage cost snapshot", () => {
     }
   });
 });
+
+describe.each(["session", "transcript", "session with unreported transcript"] as const)(
+  "buildStatusMessage %s cache usage",
+  (source) => {
+    it.each([
+      { name: "reported zero reads and writes", cacheRead: 0, cacheWrite: 0, reported: true },
+      { name: "reported zero reads", cacheRead: 0, cacheWrite: undefined, reported: true },
+      { name: "unreported usage", cacheRead: undefined, cacheWrite: undefined, reported: false },
+    ])("distinguishes $name", ({ cacheRead, cacheWrite, reported }) => {
+      const usage = { inputTokens: 10_000, outputTokens: 50, cacheRead, cacheWrite };
+      const reader = vi.spyOn(transcriptReaders, "readRecentSessionUsageFromTranscript");
+      reader.mockReturnValue(
+        source === "transcript"
+          ? usage
+          : source === "session with unreported transcript"
+            ? { inputTokens: usage.inputTokens, outputTokens: usage.outputTokens }
+            : null,
+      );
+      try {
+        const parts = buildStatusMessageParts({
+          agent: { model: "anthropic/claude-haiku-4-5" },
+          sessionEntry: {
+            sessionId: "status-cache",
+            updatedAt: 0,
+            ...(source !== "transcript" ? usage : {}),
+          },
+          includeTranscriptUsage: source !== "session",
+        });
+        const table = parts.presentation.blocks.find((block) => block.type === "table");
+        if (table?.type !== "table") {
+          throw new Error("expected table block");
+        }
+        const rows = new Map(table.rows.map((row) => [row[0], row[1]]));
+        if (reported) {
+          expect(parts.text).toContain("Cache: 0% hit · 0 cached, 0 new");
+          expect(rows.get("🗄️ Cache")).toBe("0% hit · 0 cached, 0 new");
+        } else {
+          expect(parts.text).not.toContain("Cache:");
+          expect(rows.has("🗄️ Cache")).toBe(false);
+        }
+      } finally {
+        reader.mockRestore();
+      }
+    });
+  },
+);
 
 describe("buildStatusMessage context window", () => {
   it("rejects a stale runtime window after a same-model harness change", () => {

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -313,8 +313,8 @@ const readUsageFromSessionLog = (
   | {
       input: number;
       output: number;
-      cacheRead: number;
-      cacheWrite: number;
+      cacheRead?: number;
+      cacheWrite?: number;
       promptTokens: number;
       total: number;
       totalTokensFresh: boolean;
@@ -344,9 +344,9 @@ const readUsageFromSessionLog = (
 
     const input = snapshot.inputTokens ?? 0;
     const output = snapshot.outputTokens ?? 0;
-    const cacheRead = snapshot.cacheRead ?? 0;
-    const cacheWrite = snapshot.cacheWrite ?? 0;
-    const promptTokens = snapshot.totalTokens ?? input + cacheRead + cacheWrite;
+    const cacheRead = snapshot.cacheRead;
+    const cacheWrite = snapshot.cacheWrite;
+    const promptTokens = snapshot.totalTokens ?? input + (cacheRead ?? 0) + (cacheWrite ?? 0);
     const total = promptTokens + output;
     if (promptTokens === 0 && total === 0) {
       return undefined;
@@ -386,12 +386,9 @@ const formatCacheHitValue = (
   cacheRead?: number | null,
   cacheWrite?: number | null,
 ) => {
-  if (!cacheRead && !cacheWrite) {
-    return null;
-  }
   if (
-    (typeof cacheRead !== "number" || cacheRead <= 0) &&
-    (typeof cacheWrite !== "number" || cacheWrite <= 0)
+    (typeof cacheRead !== "number" || cacheRead < 0) &&
+    (typeof cacheWrite !== "number" || cacheWrite < 0)
   ) {
     return null;
   }
@@ -725,10 +722,10 @@ export function buildStatusMessageParts(args: StatusArgs): StatusMessageParts {
         outputTokens = logUsage.output;
       }
       if (typeof cacheRead !== "number" || cacheRead <= 0) {
-        cacheRead = logUsage.cacheRead;
+        cacheRead = logUsage.cacheRead ?? cacheRead;
       }
       if (typeof cacheWrite !== "number" || cacheWrite <= 0) {
-        cacheWrite = logUsage.cacheWrite;
+        cacheWrite = logUsage.cacheWrite ?? cacheWrite;
       }
     }
   }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators diagnosing prompt caching saw false regressions when tool-loop lengths changed, while a first-request miss could disappear behind later cache hits. `/status` also hid provider-reported zero cache reads.

## Why This Change Was Made

Observe canonical system-prefix/tool fingerprints at each foreground request and pair them with usage at assistant completion, before usage is aggregated for billing. Request-indexed observations preserve zero reads, retain the fingerprint belonging to the last reported usage, capture inputs before managed Google caches consume them, and exclude compaction's separate requests; obsolete turn-level observation paths are removed.

## User Impact

Operators get warnings for real request-level drops without tool-loop-length false alarms, and `/status` displays an explicit zero-cache line when cache counters were reported as zero. The existing cache-trace/debug enablement gate is unchanged and documented; billing arithmetic is unchanged.

## Evidence

Before the core fix, synthetic request tests received no per-request usage events, zero cache counters normalized to undefined, and settlement reported 30,000 aggregate cache reads instead of the final request's 10,000. The status baseline had four expected failures because the zero-cache line was absent.

Focused owner validation: **456 distinct tests passed across 15 files**, using `node scripts/run-vitest.mjs` for observability, usage accumulation, stream settlement, status, subscriber accounting, and adjacent attempt phases. Changed owners were rerun after cleanup; the final prompt-phase suite passed all 21 tests, and the observer's 19 unit cases run without importing the full subscriber runtime.

Synthetic request proof covers three cached calls followed by one (no false warning), a first-call miss followed by two hits (the first request is identified), explicit zero reads, missing-usage fingerprint pairing, canonical inputs before managed-cache consumption, and compaction exclusion. Status proof distinguishes reported zero from absent counters in text and table output, including transcript fallback.

`node scripts/check-changed.mjs`: **passed (exit 0)**, including core/test typechecks, lint, dead-export scans, import cycles, and state/storage guards.

**Codex autoreview (high reasoning, P1 threshold): scoped-clean; 0 accepted/actionable P0/P1 findings.** No exemptions or test baselines were changed. No live provider requests were made; this change observes request inputs and usage without changing provider payloads or billing arithmetic.

Terminal-response follow-up (`3407a8c3eec712d6e27ed77edeb6a40e1eff3296`): the diagnostic lifecycle now identifies the provider's terminal result before the final assistant fragment reaches model-state accounting. Intermediate async-tool `message_end` fragments leave the request observation pending; only the terminal fragment completes it, retaining existing normalized usage recovery. Success, tool-use, error, and aborted terminal results are covered without testing whether usage is present.

The real-agent-loop regression failed on the previous head in all five cases because the intermediate fragment prematurely emitted `cache:result`. After the fix, each request commits both fragments and emits exactly one observation with terminal usage, including explicit zero cache reads. **358 tests passed across 11 files** covering observability, stream preparation/settlement/finalization, attempt execution, usage accumulation, subscriber/model-state accounting, model diagnostics, and both status suites. The final edited test file was rerun: **17/17 passed**.

Final `node scripts/check-changed.mjs`: **passed (exit 0)** after correcting two test-fixture typing errors. Fresh **Codex autoreview, high reasoning, P1 threshold: scoped-clean; no accepted/actionable P0/P1 findings**. Follow-up diff: **4 files, +168/-6** (production +24/-6; regression tests +144). No live provider requests were made.

Explicit-result follow-up (`bdca1624fc575e7b0cc85a2c3c4cb1a747ad7646`): terminal callbacks now have their own once-only flag, independent of diagnostic-event emission. Iterator exhaustion can finish diagnostics before `result()` supplies the assistant; the late terminal result now notifies the cache observer and records a successful cache touch exactly once. Error results notify terminal completion without recording success.

The three added real-agent-loop cases (successful cached result, successful zero-cache result, and error result) failed before the fix because `cache:result` was absent. After the fix, each emits exactly one observation with terminal usage while intermediate async-tool fragments remain unobserved. Existing normal `done`/`error` cases continue recording once. Two lifecycle regressions also failed before the fix and now verify that iterator exhaustion followed by repeated `result()` calls notifies terminal completion once, invokes success only for a successful result, and leaves diagnostic emission deduplicated.

Validation: **245 tests passed across 13 files**, covering prompt-cache and prompt observability, attempt execution, stream preparation/settlement/finalization, model-diagnostic lifecycle/observation/events, context guards, usage accumulation, and both status suites. **Codex autoreview (high reasoning, P1 threshold): scoped-clean; no accepted/actionable P0/P1 findings.** Follow-up diff: **3 files, +63/-14** (production +4/-5; tests +59/-9). No live provider requests were made.

`node scripts/check-changed.mjs`: **passed (exit 0)**, including core/test typechecks, lint, dead-export scans, import cycles, and state/storage guards.

CI integration recovery (`a7ab1714f2ba322a7d7b76e4b6fe0c5eae9172a2`): the first follow-up run found two interactions with newer `main`: a media-cache fixture still supplied the prompt-assembly `cache` argument removed by this PR, and added prompt-phase fixture fields pushed that test above the line limit. Rebased onto `2d58961f33fd48b94b48bf569b65fb1c6ad2d954`, removed the stale argument, and removed duplicate request-index tracking already asserted by the observation results. No assertions or limits were weakened. The terminal-result fix is unchanged (rebased commit `8f0e0106191`).

Final refreshed validation: **268 tests passed across 15 files**, including the full owner suite above plus prompt-phase and media-cache-boundary tests. **`node scripts/check-changed.mjs` passed (exit 0)**, including test types and file-length lint. Fresh **Codex autoreview (high reasoning, P1 threshold): scoped-clean; no accepted/actionable P0/P1 findings.** Combined follow-up changes after the previous terminal-response commit: **5 files, +63/-25** (production +4/-5; tests +59/-20).

Final CI: [run 34096165183](https://github.com/openclaw/openclaw/actions/runs/34096165183) **passed** on `a7ab1714f2ba322a7d7b76e4b6fe0c5eae9172a2`, including the previously failing core test-type and lint jobs. The exact-head watcher returned **GREEN** in `ci-run` mode. The full-rollup watcher had stopped on a separately canceled [ClawSweeper Dispatch run](https://github.com/openclaw/openclaw/actions/runs/34096207957); this cancellation is not reported as a successful check. No prepare or merge operation was run.
