### PR TITLE
refactor(tests): reuse background maintenance engine fixtures

### DIFF
--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -8,7 +8,7 @@ import {
   registerContextEngineForOwner,
   resolveLogicalTurnContextEngines,
 } from "../../context-engine/registry.js";
-import type { ContextEngineRuntimeContext } from "../../context-engine/types.js";
+import type { ContextEngine, ContextEngineRuntimeContext } from "../../context-engine/types.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
 import {
   enqueueCommandInLane,
@@ -63,6 +63,18 @@ let runContextEngineMaintenance: typeof import("./context-engine-maintenance.js"
 // Keep this literal aligned with the production module; tests use dynamic
 // import reloading, so they cannot safely import the constant directly.
 const TURN_MAINTENANCE_TASK_KIND = "context_engine_turn_maintenance";
+
+function createBackgroundMaintenanceEngine(
+  maintain: NonNullable<ContextEngine["maintain"]>,
+): ContextEngine {
+  return {
+    info: { id: "test", name: "Test Engine", turnMaintenanceMode: "background" },
+    ingest: async () => ({ ingested: true }),
+    assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+    compact: async () => ({ ok: true, compacted: false }),
+    maintain,
+  };
+}
 
 async function flushAsyncWork(times = 4): Promise<void> {
   for (let index = 0; index < times; index += 1) {
@@ -486,20 +498,7 @@ describe("runContextEngineMaintenance", () => {
           };
         });
 
-        const backgroundEngine = {
-          info: {
-            id: "test",
-            name: "Test Engine",
-            turnMaintenanceMode: "background" as const,
-          },
-          ingest: async () => ({ ingested: true }),
-          assemble: async ({ messages }: { messages: unknown[] }) => ({
-            messages,
-            estimatedTokens: 0,
-          }),
-          compact: async () => ({ ok: true, compacted: false }),
-          maintain,
-        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const backgroundEngine = createBackgroundMaintenanceEngine(maintain);
 
         const result = await runContextEngineMaintenance({
           contextEngine: backgroundEngine,
@@ -612,20 +611,7 @@ describe("runContextEngineMaintenance", () => {
           };
         });
 
-        const backgroundEngine = {
-          info: {
-            id: "test",
-            name: "Test Engine",
-            turnMaintenanceMode: "background" as const,
-          },
-          ingest: async () => ({ ingested: true }),
-          assemble: async ({ messages }: { messages: unknown[] }) => ({
-            messages,
-            estimatedTokens: 0,
-          }),
-          compact: async () => ({ ok: true, compacted: false }),
-          maintain,
-        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const backgroundEngine = createBackgroundMaintenanceEngine(maintain);
 
         await runContextEngineMaintenance({
           contextEngine: backgroundEngine,
@@ -697,20 +683,7 @@ describe("runContextEngineMaintenance", () => {
           };
         });
 
-        const backgroundEngine = {
-          info: {
-            id: "test",
-            name: "Test Engine",
-            turnMaintenanceMode: "background" as const,
-          },
-          ingest: async () => ({ ingested: true }),
-          assemble: async ({ messages }: { messages: unknown[] }) => ({
-            messages,
-            estimatedTokens: 0,
-          }),
-          compact: async () => ({ ok: true, compacted: false }),
-          maintain,
-        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const backgroundEngine = createBackgroundMaintenanceEngine(maintain);
         const deferredPromises: Promise<void>[] = [];
 
         await runContextEngineMaintenance({
@@ -1171,20 +1144,7 @@ describe("runContextEngineMaintenance", () => {
       }));
       const onDeferredMaintenance = vi.fn();
       const onDeferredMaintenanceFailure = vi.fn();
-      const backgroundEngine = {
-        info: {
-          id: "test",
-          name: "Test Engine",
-          turnMaintenanceMode: "background" as const,
-        },
-        ingest: async () => ({ ingested: true }),
-        assemble: async ({ messages }: { messages: unknown[] }) => ({
-          messages,
-          estimatedTokens: 0,
-        }),
-        compact: async () => ({ ok: true, compacted: false }),
-        maintain,
-      } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+      const backgroundEngine = createBackgroundMaintenanceEngine(maintain);
 
       markGatewayDraining();
       const result = await runContextEngineMaintenance({
@@ -1232,20 +1192,7 @@ describe("runContextEngineMaintenance", () => {
             rewrittenEntries: 0,
           };
         });
-        const backgroundEngine = {
-          info: {
-            id: "test",
-            name: "Test Engine",
-            turnMaintenanceMode: "background" as const,
-          },
-          ingest: async () => ({ ingested: true }),
-          assemble: async ({ messages }: { messages: unknown[] }) => ({
-            messages,
-            estimatedTokens: 0,
-          }),
-          compact: async () => ({ ok: true, compacted: false }),
-          maintain,
-        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const backgroundEngine = createBackgroundMaintenanceEngine(maintain);
         const firstDeferred: Promise<void>[] = [];
 
         await runContextEngineMaintenance({
@@ -1322,20 +1269,7 @@ describe("runContextEngineMaintenance", () => {
           bytesFreed: 0,
           rewrittenEntries: 0,
         }));
-        const backgroundEngine = {
-          info: {
-            id: "test",
-            name: "Test Engine",
-            turnMaintenanceMode: "background" as const,
-          },
-          ingest: async () => ({ ingested: true }),
-          assemble: async ({ messages }: { messages: unknown[] }) => ({
-            messages,
-            estimatedTokens: 0,
-          }),
-          compact: async () => ({ ok: true, compacted: false }),
-          maintain,
-        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const backgroundEngine = createBackgroundMaintenanceEngine(maintain);
 
         await runContextEngineMaintenance({
           contextEngine: backgroundEngine,
@@ -1385,20 +1319,7 @@ describe("runContextEngineMaintenance", () => {
           bytesFreed: 0,
           rewrittenEntries: 0,
         }));
-        const backgroundEngine = {
-          info: {
-            id: "test",
-            name: "Test Engine",
-            turnMaintenanceMode: "background" as const,
-          },
-          ingest: async () => ({ ingested: true }),
-          assemble: async ({ messages }: { messages: unknown[] }) => ({
-            messages,
-            estimatedTokens: 0,
-          }),
-          compact: async () => ({ ok: true, compacted: false }),
-          maintain,
-        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const backgroundEngine = createBackgroundMaintenanceEngine(maintain);
 
         await runContextEngineMaintenance({
           contextEngine: backgroundEngine,
@@ -1454,20 +1375,7 @@ describe("runContextEngineMaintenance", () => {
           };
         });
 
-        const backgroundEngine = {
-          info: {
-            id: "test",
-            name: "Test Engine",
-            turnMaintenanceMode: "background" as const,
-          },
-          ingest: async () => ({ ingested: true }),
-          assemble: async ({ messages }: { messages: unknown[] }) => ({
-            messages,
-            estimatedTokens: 0,
-          }),
-          compact: async () => ({ ok: true, compacted: false }),
-          maintain,
-        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const backgroundEngine = createBackgroundMaintenanceEngine(maintain);
 
         await runContextEngineMaintenance({
           contextEngine: backgroundEngine,
@@ -1564,20 +1472,7 @@ describe("runContextEngineMaintenance", () => {
           };
         });
 
-        const backgroundEngine = {
-          info: {
-            id: "test",
-            name: "Test Engine",
-            turnMaintenanceMode: "background" as const,
-          },
-          ingest: async () => ({ ingested: true }),
-          assemble: async ({ messages }: { messages: unknown[] }) => ({
-            messages,
-            estimatedTokens: 0,
-          }),
-          compact: async () => ({ ok: true, compacted: false }),
-          maintain,
-        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const backgroundEngine = createBackgroundMaintenanceEngine(maintain);
 
         await runContextEngineMaintenance({
           contextEngine: backgroundEngine,
@@ -1638,20 +1533,7 @@ describe("runContextEngineMaintenance", () => {
           bytesFreed: 0,
           rewrittenEntries: 0,
         }));
-        const backgroundEngine = {
-          info: {
-            id: "test",
-            name: "Test Engine",
-            turnMaintenanceMode: "background" as const,
-          },
-          ingest: async () => ({ ingested: true }),
-          assemble: async ({ messages }: { messages: unknown[] }) => ({
-            messages,
-            estimatedTokens: 0,
-          }),
-          compact: async () => ({ ok: true, compacted: false }),
-          maintain,
-        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const backgroundEngine = createBackgroundMaintenanceEngine(maintain);
 
         await runContextEngineMaintenance({
           contextEngine: backgroundEngine,
@@ -1710,20 +1592,7 @@ describe("runContextEngineMaintenance", () => {
             rewrittenEntries: 0,
           };
         });
-        const backgroundEngine = {
-          info: {
-            id: "test",
-            name: "Test Engine",
-            turnMaintenanceMode: "background" as const,
-          },
-          ingest: async () => ({ ingested: true }),
-          assemble: async ({ messages }: { messages: unknown[] }) => ({
-            messages,
-            estimatedTokens: 0,
-          }),
-          compact: async () => ({ ok: true, compacted: false }),
-          maintain,
-        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const backgroundEngine = createBackgroundMaintenanceEngine(maintain);
 
         await runContextEngineMaintenance({
           contextEngine: backgroundEngine,


### PR DESCRIPTION
## What Problem This Solves

The context-engine maintenance suite repeats the same background-engine input fixture in eleven scenarios, obscuring the scheduling behavior each case protects.

## Why This Change Was Made

Use one local, typed constructor for those exact fixtures. It preserves the original maintain spies, fresh engine and method identities, property order and absent optional methods. Custom engines, disposal matrices, allocation points, and every assertion remain unchanged. Removes 131 net test lines without production changes.

## User Impact

No user-visible behavior change. The existing maintenance regressions remain explicit and easier to maintain. No runtime improvement is claimed.

## Evidence

- All three maintenance suites passed before and after: 33 tests, including lifecycle and real-transcript ownership cases. The final 33-test run also passed after reconciling the checkout's dependencies.
- External proof verifies all eleven original initializer emissions match, surrounding emitted JavaScript is identical after allocation normalization, and the constructor preserves ordered keys, optional-field absence, fresh identities, method results/arity and assemble message identity.
- Full changed gate and fresh P2 review passed; diff-scoped deslop found no further edits.
- The initial gate failed because the local installation still contained fs-safe 0.8.1 while the existing lockfile required 0.8.3. A normal frozen install corrected it; no dependency files changed.
