### PR TITLE
refactor(runtime): share probe permit queues

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -367,7 +367,7 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
     | `plugin-sdk/agent-harness` | Experimental trusted-plugin surface for low-level agent harnesses: harness types, active-run steer/abort helpers, OpenClaw tool bridge helpers, runtime-plan tool policy helpers, terminal outcome classification, tool progress formatting/detail helpers, and attempt result utilities |
     | `plugin-sdk/async-lock-runtime` | Private-local after July 2026; Process-local async lock helper for small runtime state files |
     | `plugin-sdk/channel-activity-runtime` | Private-local after July 2026; Channel activity telemetry helper |
-    | `plugin-sdk/concurrency-runtime` | Private-local after July 2026; Bounded async task concurrency helper |
+    | `plugin-sdk/concurrency-runtime` | Private-local after July 2026; Bounded async task concurrency (`runTasksWithConcurrency`) and cancellable permit admission (`createPermitPool`) with caller-owned release |
     | `plugin-sdk/dedupe-runtime` | In-memory and persistent-backed dedupe cache helpers |
     | `plugin-sdk/delivery-queue-runtime` | Private-local after July 2026; Outbound pending-delivery drain helper |
     | `plugin-sdk/file-access-runtime` | Private-local after July 2026; Safe local-file, path-containment, temp-root, media-source path, and directory-durability helpers |

--- a/extensions/telegram/src/startup-probe-limiter.ts
+++ b/extensions/telegram/src/startup-probe-limiter.ts
@@ -1,88 +1,20 @@
-// Telegram plugin module implements startup probe limiter behavior.
+import { createPermitPool } from "openclaw/plugin-sdk/concurrency-runtime";
+
 const TELEGRAM_STARTUP_PROBE_CONCURRENCY = 2;
-
-type StartupProbeSlot = () => void;
-
-type StartupProbeWaiter = {
-  resolve: (release: StartupProbeSlot) => void;
-  reject: (error: Error) => void;
-  abortSignal?: AbortSignal;
-  onAbort?: () => void;
-};
-
-let activeStartupProbes = 0;
-const pendingStartupProbeWaiters: StartupProbeWaiter[] = [];
+const startupProbePermits = createPermitPool(TELEGRAM_STARTUP_PROBE_CONCURRENCY);
 
 function buildStartupProbeAbortError(): Error {
   return new Error("telegram startup probe wait aborted");
-}
-
-function detachAbortHandler(waiter: StartupProbeWaiter) {
-  if (!waiter.abortSignal || !waiter.onAbort) {
-    return;
-  }
-  waiter.abortSignal.removeEventListener("abort", waiter.onAbort);
-}
-
-function removePendingWaiter(waiter: StartupProbeWaiter) {
-  const index = pendingStartupProbeWaiters.indexOf(waiter);
-  if (index >= 0) {
-    pendingStartupProbeWaiters.splice(index, 1);
-  }
-}
-
-function releaseStartupProbeSlot() {
-  activeStartupProbes = Math.max(0, activeStartupProbes - 1);
-  drainStartupProbeWaiters();
-}
-
-function drainStartupProbeWaiters() {
-  while (
-    activeStartupProbes < TELEGRAM_STARTUP_PROBE_CONCURRENCY &&
-    pendingStartupProbeWaiters.length > 0
-  ) {
-    const waiter = pendingStartupProbeWaiters.shift();
-    if (!waiter) {
-      return;
-    }
-    detachAbortHandler(waiter);
-    if (waiter.abortSignal?.aborted) {
-      waiter.reject(buildStartupProbeAbortError());
-      continue;
-    }
-    activeStartupProbes += 1;
-    waiter.resolve(releaseStartupProbeSlot);
-  }
-}
-
-async function acquireStartupProbeSlot(abortSignal?: AbortSignal): Promise<StartupProbeSlot> {
-  if (abortSignal?.aborted) {
-    throw buildStartupProbeAbortError();
-  }
-  if (activeStartupProbes < TELEGRAM_STARTUP_PROBE_CONCURRENCY) {
-    activeStartupProbes += 1;
-    return releaseStartupProbeSlot;
-  }
-  return await new Promise<StartupProbeSlot>((resolve, reject) => {
-    const waiter: StartupProbeWaiter = {
-      resolve,
-      reject,
-      ...(abortSignal ? { abortSignal } : {}),
-    };
-    waiter.onAbort = () => {
-      removePendingWaiter(waiter);
-      reject(buildStartupProbeAbortError());
-    };
-    abortSignal?.addEventListener("abort", waiter.onAbort, { once: true });
-    pendingStartupProbeWaiters.push(waiter);
-  });
 }
 
 export async function withTelegramStartupProbeSlot<T>(
   abortSignal: AbortSignal | undefined,
   run: () => Promise<T>,
 ): Promise<T> {
-  const release = await acquireStartupProbeSlot(abortSignal);
+  const release = await startupProbePermits.acquire({ signal: abortSignal });
+  if (!release) {
+    throw buildStartupProbeAbortError();
+  }
   try {
     if (abortSignal?.aborted) {
       throw buildStartupProbeAbortError();

--- a/src/gateway/health/collector.ts
+++ b/src/gateway/health/collector.ts
@@ -30,6 +30,7 @@ import { listPluginServiceHealthFailures } from "../../plugins/service-health.js
 import { buildChannelAccountBindings, resolvePreferredAccountId } from "../../routing/bindings.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { trackAsyncWork } from "../../shared/async-work-scope.js";
+import { createPermitPool } from "../../shared/permit-pool.js";
 import { ABSOLUTE_DEADLINE_EXPIRED, awaitWithinDeadline } from "../../utils/absolute-deadline.js";
 import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
 import {
@@ -242,91 +243,9 @@ type HealthChannelPlan = {
   accountSummaries: Record<string, ChannelAccountHealthSummary>;
 };
 
-type HealthOperationRelease = () => void;
-type HealthOperationWaiter = {
-  deadlineAtMs: number;
-  resolve: (release: HealthOperationRelease | null) => void;
-  timer: ReturnType<typeof setTimeout>;
-  settled: boolean;
-};
-
 // Permits outlive response deadlines so an unfinished plugin hook cannot be
 // replaced by later health refreshes and amplify process-wide probe work.
-let activeHealthOperations = 0;
-const healthOperationWaiters: HealthOperationWaiter[] = [];
-
-function settleHealthOperationWaiter(
-  waiter: HealthOperationWaiter,
-  release: HealthOperationRelease | null,
-): void {
-  if (waiter.settled) {
-    return;
-  }
-  waiter.settled = true;
-  clearTimeout(waiter.timer);
-  waiter.resolve(release);
-}
-
-function releaseNextHealthOperationWaiter(): void {
-  while (healthOperationWaiters.length > 0) {
-    const waiter = healthOperationWaiters.shift();
-    if (!waiter || waiter.settled) {
-      continue;
-    }
-    if (Date.now() >= waiter.deadlineAtMs) {
-      settleHealthOperationWaiter(waiter, null);
-      continue;
-    }
-    settleHealthOperationWaiter(waiter, createHealthOperationRelease());
-    return;
-  }
-}
-
-function createHealthOperationRelease(): HealthOperationRelease {
-  activeHealthOperations += 1;
-  let released = false;
-  return () => {
-    if (released) {
-      return;
-    }
-    released = true;
-    activeHealthOperations -= 1;
-    releaseNextHealthOperationWaiter();
-  };
-}
-
-async function acquireHealthOperationPermit(
-  deadlineAtMs: number,
-): Promise<HealthOperationRelease | null> {
-  if (Date.now() >= deadlineAtMs) {
-    return null;
-  }
-  if (activeHealthOperations < HEALTH_PROBE_CONCURRENCY) {
-    return createHealthOperationRelease();
-  }
-
-  return await new Promise<HealthOperationRelease | null>((resolve) => {
-    const waiter: HealthOperationWaiter = {
-      deadlineAtMs,
-      resolve,
-      timer: setTimeout(
-        () => {
-          const index = healthOperationWaiters.indexOf(waiter);
-          if (index >= 0) {
-            healthOperationWaiters.splice(index, 1);
-          }
-          settleHealthOperationWaiter(waiter, null);
-        },
-        Math.max(1, deadlineAtMs - Date.now()),
-      ),
-      settled: false,
-    };
-    if (typeof waiter.timer === "object" && "unref" in waiter.timer) {
-      waiter.timer.unref();
-    }
-    healthOperationWaiters.push(waiter);
-  });
-}
+const healthOperationPermits = createPermitPool(HEALTH_PROBE_CONCURRENCY);
 
 function buildHealthTimeoutRecord(
   accountId: string,
@@ -509,7 +428,7 @@ async function runHealthAccountWithinDeadline(
 ): Promise<ChannelAccountHealthSummary> {
   // Own permit admission and release too: neither a deadline nor shutdown may orphan a hook.
   const operation = trackAsyncWork(async () => {
-    const release = await acquireHealthOperationPermit(params.deadlineAtMs);
+    const release = await healthOperationPermits.acquire({ deadlineAtMs: params.deadlineAtMs });
     if (!release) {
       return buildHealthTimeoutRecord(params.accountId, params.timeoutMs);
     }

--- a/src/plugin-sdk/concurrency-runtime.ts
+++ b/src/plugin-sdk/concurrency-runtime.ts
@@ -1,3 +1,4 @@
 // Small concurrency helpers for plugin runtime work.
 
+export { createPermitPool } from "../shared/permit-pool.js";
 export { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";

--- a/src/shared/permit-pool.test.ts
+++ b/src/shared/permit-pool.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPermitPool } from "./permit-pool.js";
+
+describe("permit pool", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("admits FIFO without releasing another holder on a duplicate release", async () => {
+    const pool = createPermitPool(2);
+    const first = await pool.acquire();
+    const second = await pool.acquire();
+    const admitted: string[] = [];
+    const queued = ["a", "b", "c"].map((name) =>
+      pool.acquire().then((release) => {
+        admitted.push(name);
+        return release;
+      }),
+    );
+
+    expect(first).toBeTypeOf("function");
+    expect(second).toBeTypeOf("function");
+    first?.();
+    first?.();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(admitted).toEqual(["a"]);
+    second?.();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(admitted).toEqual(["a", "b"]);
+    (await queued[0])?.();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(admitted).toEqual(["a", "b", "c"]);
+    (await queued[1])?.();
+    (await queued[2])?.();
+  });
+
+  it("removes cancelled and expired waiters without revoking acquired permits", async () => {
+    const pool = createPermitPool(1);
+    const owner = new AbortController();
+    const release = await pool.acquire({ signal: owner.signal, deadlineAtMs: Date.now() + 10 });
+    const cancel = new AbortController();
+    const cancelled = pool.acquire({ signal: cancel.signal });
+    const expired = pool.acquire({ deadlineAtMs: Date.now() + 10 });
+    let admitted = false;
+    const next = pool.acquire().then((nextRelease) => {
+      admitted = true;
+      return nextRelease;
+    });
+
+    cancel.abort();
+    owner.abort();
+    await vi.advanceTimersByTimeAsync(10);
+    await expect(cancelled).resolves.toBeNull();
+    await expect(expired).resolves.toBeNull();
+    expect(admitted).toBe(false);
+    release?.();
+    const nextRelease = await next;
+    expect(nextRelease).toBeTypeOf("function");
+    nextRelease?.();
+  });
+
+  it("rechecks deadlines on release even before an expiry timer runs", async () => {
+    const pool = createPermitPool(1);
+    const release = await pool.acquire();
+    const expired = pool.acquire({ deadlineAtMs: Date.now() + 10 });
+    const next = pool.acquire();
+    vi.setSystemTime(Date.now() + 10);
+    release?.();
+    await expect(expired).resolves.toBeNull();
+    const nextRelease = await next;
+    expect(nextRelease).toBeTypeOf("function");
+    nextRelease?.();
+
+    const aborted = new AbortController();
+    aborted.abort();
+    await expect(pool.acquire({ signal: aborted.signal })).resolves.toBeNull();
+    await expect(pool.acquire({ deadlineAtMs: Date.now() })).resolves.toBeNull();
+  });
+});

--- a/src/shared/permit-pool.ts
+++ b/src/shared/permit-pool.ts
@@ -1,0 +1,82 @@
+type PermitRelease = () => void;
+type PermitWaiter = {
+  expired: () => boolean;
+  settle: (release: PermitRelease | null) => void;
+};
+
+/**
+ * FIFO admission with caller-owned lifetime. Cancellation/deadlines only stop
+ * waiting: an acquired permit stays held until its idempotent release is called.
+ * A null result means admission was aborted or its deadline elapsed.
+ */
+export function createPermitPool(limit: number) {
+  let active = 0;
+  const waiters: PermitWaiter[] = [];
+
+  const createRelease = (): PermitRelease => {
+    active += 1;
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      active -= 1;
+      while (waiters.length > 0) {
+        const waiter = waiters.shift();
+        if (!waiter) {
+          break;
+        }
+        if (waiter.expired()) {
+          waiter.settle(null);
+          continue;
+        }
+        waiter.settle(createRelease());
+        break;
+      }
+    };
+  };
+
+  return {
+    async acquire({
+      signal,
+      deadlineAtMs,
+    }: { signal?: AbortSignal; deadlineAtMs?: number } = {}): Promise<PermitRelease | null> {
+      const expired = () =>
+        signal?.aborted === true || (deadlineAtMs !== undefined && Date.now() >= deadlineAtMs);
+      if (expired()) {
+        return null;
+      }
+      if (active < limit) {
+        return createRelease();
+      }
+      return await new Promise<PermitRelease | null>((resolve) => {
+        let settled = false;
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const cancel = () => waiter.settle(null);
+        const waiter: PermitWaiter = {
+          expired,
+          settle: (release) => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            clearTimeout(timer);
+            signal?.removeEventListener("abort", cancel);
+            const index = waiters.indexOf(waiter);
+            if (index >= 0) {
+              waiters.splice(index, 1);
+            }
+            resolve(release);
+          },
+        };
+        if (deadlineAtMs !== undefined) {
+          timer = setTimeout(cancel, Math.max(1, deadlineAtMs - Date.now()));
+          timer.unref();
+        }
+        signal?.addEventListener("abort", cancel, { once: true });
+        waiters.push(waiter);
+      });
+    },
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Health collection and Telegram account startup independently implement process-wide queues for bounded probe work. Both must cancel waiting work without letting unfinished hooks exceed their concurrency limits.

## Why This Change Was Made

Use one small `createPermitPool` owner in `src/shared/permit-pool.ts`, reached by Telegram through the existing private-local `concurrency-runtime` SDK seam. Separate module-lifetime instances retain five health permits and two Telegram permits. The pool owns FIFO admission, queued cancellation/deadline expiry, and idempotent release; callers retain hook execution, error mapping, and the lifetime of acquired work.

Health's tracked account operation still holds its permit after a response deadline until the hook settles. Telegram still rejects cancelled admission with its existing message, checks abort again after acquisition, and releases only in the callback's finally block. No manifest, API baseline, export budget, dependency, configuration, or persistent-state change.

## User Impact

No user-visible behavior change. Production code shrinks by 66 lines. The existing private-local SDK catalog row now describes both concurrency helpers.

## Evidence

- `node scripts/run-vitest.mjs src/shared/permit-pool.test.ts src/gateway/health/collector.deadline.test.ts extensions/telegram/src/channel.gateway.test.ts`: 28 tests passed across 3 files, 64.90 seconds.
- Existing caller suites retain health unfinished-hook/deadline and Telegram concurrency/cancellation proof. Three shared-owner tests cover FIFO/idempotent release, cancelled/expired waiters, permits surviving abort/deadline after acquisition, and expiry rechecks at handoff.
- Before extraction, the two caller suites passed 25 tests in 69.05 seconds. Health's focused suite measured 25.53 seconds before and 17.51 seconds after; these single runs are validation timings, not a performance claim.
- Independent Codex autoreview: no actionable P0–P2 findings.
- Formatting and `git diff --check`: passed.
- SDK export registration and surface budget checks: passed without baseline changes.
- `pnpm build`: passed in 18m57.8s, including all 90 plugin builds and 53 native control-plane module load checks. `dist/build-info.json` identifies candidate `eb32bfe41eb2f417c2080327636cb283df1f292d`.
- `OPENCLAW_LOCAL_CHECK=0 node --import tsx scripts/profile-extension-memory.mts --extension telegram --skip-combined --concurrency 1`: passed against the completed candidate build; 1 entry ok, 0 failures/timeouts, peak RSS 155.46875 MiB. This proves the built private-local SDK import resolves and Telegram loads.

## Known Gaps

The local changed-file check passed all four typecheck lanes, SDK export/surface checks, dead-export scans, and core lint, then stopped at extension declaration preparation: `Declaration input escapes checkout` for an ancestor `node_modules/punycode/package.json`. This is the documented nested-worktree limitation; no guard or dependency was changed. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/34086246374) passed, covering the clean-environment declaration/lint gates. Candidate build and entrypoint profile both passed. The earlier review request to record those results is resolved. No live Telegram transport change is included; the retained plugin startup suite exercises the changed boundary.
