### PR TITLE
fix(doctor): give manual recovery for unsupported state

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -97,8 +97,19 @@ service through its owner. Once the native manager confirms it is offline,
 Doctor can repair its selected state without changing or starting that service.
 
 If migration or config repair cannot finish, Doctor leaves the stopped service
-stopped and reports an incomplete repair. Resolve the reported blocker, rerun
-`openclaw doctor --fix`, then start the service through its owner.
+stopped and reports an incomplete repair with exit code 1. When state requires
+manual recovery, the diagnosis names its path and the next action:
+
+- **Unsupported canonical workspace version:** use an OpenClaw build that supports
+  that version. Preserve the shared database unchanged.
+- **Unreadable or conflicting exec policy:** stop the Gateway and node hosts,
+  then reconcile the named legacy file or interrupted claim with a verified copy
+  of the intended policy. Preserve the existing SQLite policy.
+
+Doctor does not quarantine unsupported workspace state, discard future-version
+rows, or infer execution policy. Repeating the same repair invocation cannot
+resolve these conditions. After manual recovery, verify readiness before starting
+the service through its owner.
 
 ## Gateway service recovery
 

--- a/src/agents/workspace-legacy-state.test.ts
+++ b/src/agents/workspace-legacy-state.test.ts
@@ -144,7 +144,7 @@ describe("legacy workspace reset cleanup", () => {
     );
 
     expect(() => assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir })).toThrow(
-      /run openclaw doctor --fix/u,
+      /doctor --fix/u,
     );
   });
 
@@ -162,7 +162,9 @@ describe("legacy workspace reset cleanup", () => {
         env: context.env,
         homedir: context.homedir,
       }),
-    ).toThrow(`${workspaceDirs.join(", ")}; run openclaw doctor --fix`);
+    ).toThrow(
+      workspaceDirs.map((dir) => path.join(dir, "openclaw-workspace-state.json")).join(", "),
+    );
     for (const workspaceDir of workspaceDirs) {
       await fs.unlink(path.join(workspaceDir, "openclaw-workspace-state.json"));
     }
@@ -201,7 +203,7 @@ describe("legacy workspace reset cleanup", () => {
       path.join(context.stateDir, "workspace-attestations", `${identity.workspaceKey}.attested`),
     );
     expect(() => assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir })).toThrow(
-      /run openclaw doctor --fix/u,
+      /doctor --fix/u,
     );
     const cleanup = await removeLegacyWorkspaceStateForReset(prepare(context));
     expect(cleanup.removedPaths).toContain(canonicalSiblingPath);

--- a/src/agents/workspace-legacy-state.test.ts
+++ b/src/agents/workspace-legacy-state.test.ts
@@ -144,7 +144,7 @@ describe("legacy workspace reset cleanup", () => {
     );
 
     expect(() => assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir })).toThrow(
-      /doctor --fix/u,
+      /run openclaw doctor --fix/u,
     );
   });
 
@@ -162,9 +162,7 @@ describe("legacy workspace reset cleanup", () => {
         env: context.env,
         homedir: context.homedir,
       }),
-    ).toThrow(
-      workspaceDirs.map((dir) => path.join(dir, "openclaw-workspace-state.json")).join(", "),
-    );
+    ).toThrow(`${workspaceDirs.join(", ")}; run openclaw doctor --fix`);
     for (const workspaceDir of workspaceDirs) {
       await fs.unlink(path.join(workspaceDir, "openclaw-workspace-state.json"));
     }
@@ -203,7 +201,7 @@ describe("legacy workspace reset cleanup", () => {
       path.join(context.stateDir, "workspace-attestations", `${identity.workspaceKey}.attested`),
     );
     expect(() => assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir })).toThrow(
-      /doctor --fix/u,
+      /run openclaw doctor --fix/u,
     );
     const cleanup = await removeLegacyWorkspaceStateForReset(prepare(context));
     expect(cleanup.removedPaths).toContain(canonicalSiblingPath);

--- a/src/agents/workspace-legacy-state.ts
+++ b/src/agents/workspace-legacy-state.ts
@@ -3,10 +3,10 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { formatCliCommand } from "../cli/command-format.js";
 import { resolveLegacyStateDirs, resolveStateDir } from "../config/paths.js";
 import { root } from "../infra/fs-safe.js";
 import { pathMayExistSync } from "../infra/path-existence.js";
+import { formatStateRepairRequired } from "../infra/state-repair-message.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveWorkspaceStateIdentity } from "./workspace-state-identity.js";
 
@@ -108,12 +108,6 @@ export function resolveLegacyWorkspaceSourcePaths(
   };
 }
 
-function pathOrClaimExists(filePath: string): boolean {
-  return (
-    pathMayExistSync(filePath) || pathMayExistSync(`${filePath}${WORKSPACE_DOCTOR_CLAIM_SUFFIX}`)
-  );
-}
-
 /** Share presence-only sibling ownership checks between runtime and Doctor. */
 export function legacyWorkspaceSiblingAttestationMayExist(filePath: string): boolean {
   try {
@@ -148,22 +142,28 @@ export function legacyWorkspaceSiblingAttestationMayExist(filePath: string): boo
   }
 }
 
-function hasUnmigratedWorkspaceSources(sources: LegacyWorkspaceSourcePaths): boolean {
+function findUnmigratedWorkspaceSource(sources: LegacyWorkspaceSourcePaths): string | undefined {
+  const withClaims = (paths: string[]) =>
+    paths.flatMap((filePath) => [filePath, `${filePath}${WORKSPACE_DOCTOR_CLAIM_SUFFIX}`]);
   return (
-    sources.setupStatePaths.some(pathOrClaimExists) ||
-    sources.stateDirAttestationPaths.some(pathOrClaimExists) ||
-    sources.siblingAttestationPaths.some(
-      (sourcePath) =>
-        legacyWorkspaceSiblingAttestationMayExist(
-          `${sourcePath}${WORKSPACE_DOCTOR_CLAIM_SUFFIX}`,
-        ) || legacyWorkspaceSiblingAttestationMayExist(sourcePath),
-    )
+    withClaims([...sources.setupStatePaths, ...sources.stateDirAttestationPaths]).find(
+      pathMayExistSync,
+    ) ?? withClaims(sources.siblingAttestationPaths).find(legacyWorkspaceSiblingAttestationMayExist)
   );
 }
 
-function workspaceMigrationError(workspaceDirs: string[], env?: NodeJS.ProcessEnv): Error {
+function workspaceMigrationError(
+  sourcePaths: string[],
+  env?: NodeJS.ProcessEnv,
+  operation?: "doctor",
+): Error {
   return new Error(
-    `Legacy workspace setup state requires migration for ${workspaceDirs.join(", ")}; run ${formatCliCommand("openclaw doctor --fix", env)}.`,
+    formatStateRepairRequired(
+      `Legacy workspace setup state requires migration at ${sourcePaths.join(", ")}`,
+      "Stop the Gateway, then restore the retained setup file or claim from a verified backup.",
+      operation,
+      env,
+    ),
   );
 }
 
@@ -172,12 +172,16 @@ export function assertWorkspaceStateMigrationReady(params: {
   workspaceDirs: readonly string[];
   env?: NodeJS.ProcessEnv;
   homedir?: () => string;
+  operation?: "doctor";
 }): void {
-  const blocked = params.workspaceDirs.filter((workspaceDir) =>
-    hasUnmigratedWorkspaceSources(resolveLegacyWorkspaceSourcePaths(workspaceDir, params)),
-  );
+  const blocked = params.workspaceDirs.flatMap((workspaceDir) => {
+    const sourcePath = findUnmigratedWorkspaceSource(
+      resolveLegacyWorkspaceSourcePaths(workspaceDir, params),
+    );
+    return sourcePath ? [sourcePath] : [];
+  });
   if (blocked.length > 0) {
-    throw workspaceMigrationError(blocked, params.env);
+    throw workspaceMigrationError(blocked, params.env, params.operation);
   }
 }
 
@@ -194,8 +198,9 @@ export function assertNoUnmigratedWorkspaceState(params: { workspaceDir: string 
   if (checkedWorkspaceSourceSets.has(sourceSetKey)) {
     return;
   }
-  if (hasUnmigratedWorkspaceSources(sources)) {
-    throw workspaceMigrationError([identity.workspacePath]);
+  const sourcePath = findUnmigratedWorkspaceSource(sources);
+  if (sourcePath) {
+    throw workspaceMigrationError([sourcePath]);
   }
   checkedWorkspaceSourceSets.add(sourceSetKey);
 }

--- a/src/agents/workspace-legacy-state.ts
+++ b/src/agents/workspace-legacy-state.ts
@@ -3,10 +3,11 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { formatCliCommand } from "../cli/command-format.js";
 import { resolveLegacyStateDirs, resolveStateDir } from "../config/paths.js";
 import { root } from "../infra/fs-safe.js";
 import { pathMayExistSync } from "../infra/path-existence.js";
-import { formatStateRepairRequired } from "../infra/state-repair-message.js";
+import { formatDoctorStateRepairFailure } from "../infra/state-repair-message.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveWorkspaceStateIdentity } from "./workspace-state-identity.js";
 
@@ -153,17 +154,17 @@ function findUnmigratedWorkspaceSource(sources: LegacyWorkspaceSourcePaths): str
 }
 
 function workspaceMigrationError(
-  sourcePaths: string[],
+  blockedPaths: string[],
   env?: NodeJS.ProcessEnv,
   operation?: "doctor",
 ): Error {
   return new Error(
-    formatStateRepairRequired(
-      `Legacy workspace setup state requires migration at ${sourcePaths.join(", ")}`,
-      "Stop the Gateway, then restore the retained setup file or claim from a verified backup.",
-      operation,
-      env,
-    ),
+    operation === "doctor"
+      ? formatDoctorStateRepairFailure(
+          `Legacy workspace setup state requires migration at ${blockedPaths.join(", ")}`,
+          "Stop the Gateway, then restore the retained setup file or claim from a verified backup.",
+        )
+      : `Legacy workspace setup state requires migration for ${blockedPaths.join(", ")}; run ${formatCliCommand("openclaw doctor --fix", env)}.`,
   );
 }
 
@@ -178,7 +179,7 @@ export function assertWorkspaceStateMigrationReady(params: {
     const sourcePath = findUnmigratedWorkspaceSource(
       resolveLegacyWorkspaceSourcePaths(workspaceDir, params),
     );
-    return sourcePath ? [sourcePath] : [];
+    return sourcePath ? [params.operation === "doctor" ? sourcePath : workspaceDir] : [];
   });
   if (blocked.length > 0) {
     throw workspaceMigrationError(blocked, params.env, params.operation);
@@ -200,7 +201,7 @@ export function assertNoUnmigratedWorkspaceState(params: { workspaceDir: string 
   }
   const sourcePath = findUnmigratedWorkspaceSource(sources);
   if (sourcePath) {
-    throw workspaceMigrationError([sourcePath]);
+    throw workspaceMigrationError([identity.workspacePath]);
   }
   checkedWorkspaceSourceSets.add(sourceSetKey);
 }

--- a/src/agents/workspace-state-dirs.ts
+++ b/src/agents/workspace-state-dirs.ts
@@ -12,6 +12,7 @@ import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
 import { resolveSandboxWorkspaceLayoutPaths } from "./sandbox/shared.js";
 import { listAgentWorkspaceDirs } from "./workspace-dirs.js";
 import { assertWorkspaceStateMigrationReady } from "./workspace-legacy-state.js";
+import { readWorkspaceStateSnapshot } from "./workspace-state-store.js";
 
 /** Select configured workspaces and active sandbox copies for migration and readiness. */
 export function listWorkspaceStateDirs(params: {
@@ -86,6 +87,7 @@ export function listWorkspaceStateDirs(params: {
 export function assertConfiguredWorkspaceStateReady(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
+  operation?: "doctor";
 }): void {
   const env = params.env ?? process.env;
   const homedir = os.homedir;
@@ -95,5 +97,10 @@ export function assertConfiguredWorkspaceStateReady(params: {
     homedir,
     stateDir: resolveStateDir(env, homedir),
   });
-  assertWorkspaceStateMigrationReady({ workspaceDirs, env, homedir });
+  if (params.operation === "doctor") {
+    for (const workspaceDir of workspaceDirs) {
+      readWorkspaceStateSnapshot(workspaceDir, { env, readOnly: true });
+    }
+  }
+  assertWorkspaceStateMigrationReady({ ...params, workspaceDirs, env, homedir });
 }

--- a/src/agents/workspace-state-store.test.ts
+++ b/src/agents/workspace-state-store.test.ts
@@ -527,7 +527,9 @@ describe("workspace state store", () => {
       ) VALUES (?, ?, 99, NULL, NULL, 1)`,
     ).run(identity.workspaceKey, identity.workspacePath);
 
-    expect(() => readWorkspaceStateSnapshot(dir)).toThrow(/version requires openclaw doctor/u);
+    expect(() => readWorkspaceStateSnapshot(dir)).toThrow(
+      /unsupported workspace setup version 99/u,
+    );
     expect(() => deleteState(dir)).not.toThrow();
     const row = db
       .prepare("SELECT workspace_key FROM workspace_setup_state WHERE workspace_key = ?")

--- a/src/agents/workspace-state-store.ts
+++ b/src/agents/workspace-state-store.ts
@@ -7,6 +7,7 @@ import {
 } from "../infra/kysely-sync.js";
 import { deferSqlitePostCommitPublication } from "../infra/sqlite-post-commit.js";
 import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
+import { formatStateRepairRequired } from "../infra/state-repair-message.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
@@ -101,7 +102,10 @@ type WorkspaceStateDatabase = Pick<
   | "migration_sources"
 >;
 
-type WorkspaceStateDatabaseHandle = Pick<ReturnType<typeof openOpenClawStateDatabase>, "db">;
+type WorkspaceStateDatabaseHandle = Pick<
+  ReturnType<typeof openOpenClawStateDatabase>,
+  "db" | "path"
+>;
 
 function workspacePathEntryExists(workspaceDir: string): boolean {
   try {
@@ -247,7 +251,13 @@ function readSnapshotFromDatabase(params: {
     throw new Error("workspace state key collision");
   }
   if (setupRow?.version != null && setupRow.version !== WORKSPACE_SETUP_STATE_VERSION) {
-    throw new Error("workspace setup state version requires openclaw doctor --fix");
+    throw new Error(
+      formatStateRepairRequired(
+        `unsupported workspace setup version ${setupRow.version} in ${params.database.path} for ${identity.workspacePath}`,
+        "Use a compatible OpenClaw build that supports this workspace version; preserve the database unchanged.",
+        "doctor",
+      ),
+    );
   }
   if (setupRow?.version != null) {
     assertCanonicalTimestamp(setupRow.bootstrap_seeded_at, "bootstrap seeded");

--- a/src/agents/workspace-state-store.ts
+++ b/src/agents/workspace-state-store.ts
@@ -7,7 +7,7 @@ import {
 } from "../infra/kysely-sync.js";
 import { deferSqlitePostCommitPublication } from "../infra/sqlite-post-commit.js";
 import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
-import { formatStateRepairRequired } from "../infra/state-repair-message.js";
+import { formatDoctorStateRepairFailure } from "../infra/state-repair-message.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
@@ -252,10 +252,9 @@ function readSnapshotFromDatabase(params: {
   }
   if (setupRow?.version != null && setupRow.version !== WORKSPACE_SETUP_STATE_VERSION) {
     throw new Error(
-      formatStateRepairRequired(
+      formatDoctorStateRepairFailure(
         `unsupported workspace setup version ${setupRow.version} in ${params.database.path} for ${identity.workspacePath}`,
         "Use a compatible OpenClaw build that supports this workspace version; preserve the database unchanged.",
-        "doctor",
       ),
     );
   }

--- a/src/commands/doctor-config-preflight-startup.ts
+++ b/src/commands/doctor-config-preflight-startup.ts
@@ -8,10 +8,15 @@ import type {
   StartupMigrationLease,
 } from "../infra/startup-migration-checkpoint.js";
 import {
+  DoctorStateMigrationRefusalError,
   formatStartupMigrationFailure,
   recordStartupMigrationWarnings,
+  throwIfDoctorStateMigrationRefused,
 } from "../infra/state-migrations.messages.js";
-import type { MigrationMessages } from "../infra/state-migrations.types.js";
+import type {
+  LegacyStateMigrationStepReceipt,
+  MigrationMessages,
+} from "../infra/state-migrations.types.js";
 import { setActiveDegradedPlugins } from "../plugins/runtime-degraded-state.js";
 import {
   migrationCheckpointIdentitiesMatch,
@@ -179,6 +184,29 @@ export async function completeStartupMigrationPreflight(params: {
     });
   }
   return snapshotRead;
+}
+
+export async function assertDoctorPreflightMigrationsComplete(params: {
+  cfg: OpenClawConfig;
+  stepReceipts: readonly LegacyStateMigrationStepReceipt[];
+  report: (result: MigrationMessages) => void;
+}): Promise<void> {
+  try {
+    throwIfDoctorStateMigrationRefused(params.stepReceipts);
+  } catch (error) {
+    if (error instanceof DoctorStateMigrationRefusalError) {
+      // A refused owner stops all later repairs. Still diagnose canonical
+      // workspace state read-only before final completion becomes unreachable.
+      const { assertConfiguredWorkspaceStateReady } =
+        await import("../agents/workspace-state-dirs.js");
+      try {
+        assertConfiguredWorkspaceStateReady({ cfg: params.cfg, operation: "doctor" });
+      } catch (workspaceError) {
+        params.report({ changes: [], warnings: [String(workspaceError)] });
+      }
+    }
+    throw error;
+  }
 }
 
 export function noteStateMigrationResult(result: MigrationMessages): void {

--- a/src/commands/doctor-config-preflight.refusal.process.test.ts
+++ b/src/commands/doctor-config-preflight.refusal.process.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   createBuiltRuntime,
   runBuiltRuntime,
+  runIsolatedModuleScript,
 } from "./doctor-config-preflight.process.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterAll);
@@ -99,6 +100,84 @@ describe("Doctor CLI migration refusal", () => {
     },
     60_000,
   );
+
+  it("fails closed with manual recovery for an unsupported workspace and conflicting exec policy", async () => {
+    const root = fs.realpathSync(tempDirs.make("openclaw-doctor-unsupported-state-"));
+    const stateDir = path.join(root, "state");
+    const workspaceDir = path.join(root, "workspace");
+    const configPath = path.join(root, "openclaw.json");
+    const sourcePath = path.join(stateDir, "exec-approvals.json");
+    const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.mkdirSync(workspaceDir);
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        agents: { ownership: "explicit", entries: { main: { workspace: workspaceDir } } },
+        plugins: { enabled: false },
+      }),
+    );
+    const legacy = JSON.stringify({ version: 1, defaults: { security: "full" }, agents: {} });
+    fs.writeFileSync(sourcePath, legacy);
+    const env = {
+      PATH: process.env.PATH,
+      HOME: root,
+      USERPROFILE: root,
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_SERVICE_REPAIR_POLICY: "external",
+      NO_COLOR: "1",
+      CI: "1",
+    };
+    const runtimeRoot = createBuiltRuntime(root);
+    await runIsolatedModuleScript(
+      env,
+      `
+      import { openOpenClawStateDatabase, closeOpenClawStateDatabaseForTest } from "./src/state/openclaw-state-db.ts";
+      import { resolveWorkspaceStateIdentity } from "./src/agents/workspace-state-identity.ts";
+      import { writeExecApprovalsConfigRow } from "./src/infra/exec-approvals-sqlite.ts";
+      const { db } = openOpenClawStateDatabase();
+      const identity = resolveWorkspaceStateIdentity(${JSON.stringify(workspaceDir)});
+      db.prepare("INSERT INTO workspace_setup_state (workspace_key, workspace_path, version, updated_at) VALUES (?, ?, 99, 1)").run(identity.workspaceKey, identity.workspacePath);
+      writeExecApprovalsConfigRow({ db, file: { version: 1, defaults: { security: "deny" }, agents: {} } });
+      closeOpenClawStateDatabaseForTest();
+    `,
+      { runtimeRoot, timeoutMs: 60_000 },
+    );
+    const result = runBuiltRuntime(
+      runtimeRoot,
+      env,
+      ["doctor", "--fix", "--non-interactive", "--no-workspace-suggestions"],
+      60_000,
+    );
+    const output = `${result.stdout}\n${result.stderr}`;
+    const text = output.replaceAll("│", " ").replace(/\s+/g, " ");
+    expect(result.error, output).toBeUndefined();
+    expect(result.status, output).toBe(1);
+    expect(output).toContain(databasePath);
+    expect(output).toContain(workspaceDir);
+    expect(text).toContain("unsupported workspace setup version 99");
+    expect(text).toContain("compatible OpenClaw build");
+    expect(output).toContain(sourcePath);
+    expect(text).toContain("reconcile this file");
+    expect(text).not.toMatch(/(?:openclaw\s+)?doctor\s+--(?:fix|repair)/i);
+    expect(output).not.toContain("Doctor complete.");
+    expect(fs.readFileSync(sourcePath, "utf8")).toBe(legacy);
+    const db = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(db.prepare("SELECT version FROM workspace_setup_state").all()).toEqual([
+        { version: 99 },
+      ]);
+      const policy = db
+        .prepare("SELECT raw_json FROM exec_approvals_config WHERE config_key = 'current'")
+        .get();
+      expect(JSON.parse(String(policy?.raw_json))).toMatchObject({
+        defaults: { security: "deny" },
+      });
+    } finally {
+      db.close();
+    }
+  }, 120_000);
 
   it.each([false, true])(
     "honors the ordered graph with valid TUI=%s",

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -20,7 +20,6 @@ import type {
   MigrationCheckpointIdentity,
   StartupMigrationLease,
 } from "../infra/startup-migration-checkpoint.js";
-import { throwIfDoctorStateMigrationRefused } from "../infra/state-migrations.messages.js";
 import type {
   LegacyStateMigrationStepReceipt,
   MigrationMessages,
@@ -43,6 +42,7 @@ import {
   type DoctorConfigPreflightPluginSnapshotRead,
 } from "./doctor-config-preflight-plugin-index.js";
 import {
+  assertDoctorPreflightMigrationsComplete,
   completeStartupMigrationPreflight,
   noteStateMigrationResult,
   prepareStartupMigrationPlugins,
@@ -583,7 +583,11 @@ export async function runDoctorConfigPreflight(
           doctorMediaPersistenceAttempted = options.doctorOnlyStateMigrations === true;
           noteStartupStateMigrationResult(legacyStateResult);
           if (options.doctorOnlyStateMigrations === true) {
-            throwIfDoctorStateMigrationRefused(stateMigrationStepReceipts);
+            await assertDoctorPreflightMigrationsComplete({
+              cfg: migrationConfig,
+              stepReceipts: stateMigrationStepReceipts,
+              report: noteStartupStateMigrationResult,
+            });
           }
         } else if (stateMigrationInput.pluginDoctorConfig) {
           const pluginDoctorConfig = stateMigrationInput.pluginDoctorConfig;

--- a/src/commands/doctor-skill-workshop-collection-backups.ts
+++ b/src/commands/doctor-skill-workshop-collection-backups.ts
@@ -62,7 +62,11 @@ export async function listPendingLegacyCollectionBackupRoots(
       if (!ownerAgentId) {
         throw new Error("workspace does not map to exactly one configured agent");
       }
-      assertWorkspaceStateMigrationReady({ workspaceDirs: [...workspaceDirs], env });
+      assertWorkspaceStateMigrationReady({
+        workspaceDirs: [...workspaceDirs],
+        env,
+        operation: "doctor",
+      });
       const destinationRoot = resolveSkillCollectionBackupRoot(config, ownerAgentId, env);
       const alreadyArchived = await Promise.all(
         backups.map((backup) =>

--- a/src/commands/doctor-skill-workshop-relocation.reservations.test.ts
+++ b/src/commands/doctor-skill-workshop-relocation.reservations.test.ts
@@ -355,8 +355,10 @@ describe("doctor Workshop relocation reservations", () => {
     expect(result.warnings.join("\n")).toContain(child.record.id);
     if (legacyState) {
       expect(result.warnings.join("\n")).toContain(
-        `Legacy workspace setup state requires migration for ${formerWorkspace}`,
+        `Legacy workspace setup state requires migration at ${attestationPath}`,
       );
+      expect(result.warnings.join("\n")).toContain("restore the retained setup file or claim");
+      expect(result.warnings.join("\n")).not.toContain("doctor --fix");
       await expect(fs.readFile(attestationPath, "utf8")).resolves.toBe(attestationContent);
     }
     await expect(

--- a/src/commands/doctor-skill-workshop-relocation.ts
+++ b/src/commands/doctor-skill-workshop-relocation.ts
@@ -291,7 +291,11 @@ export async function planWorkshopRelocation(
       continue;
     }
     try {
-      assertWorkspaceStateMigrationReady({ workspaceDirs: [workspaceDir], env });
+      assertWorkspaceStateMigrationReady({
+        workspaceDirs: [workspaceDir],
+        env,
+        operation: "doctor",
+      });
     } catch (error) {
       // Doctor owns legacy-file import. Leave every proposal for this workspace
       // unchanged until that import and its source cleanup have both finished.

--- a/src/commands/doctor-skill-workshop-sqlite.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.ts
@@ -188,7 +188,11 @@ async function relocateLegacyWorkshopTargets(
       continue;
     }
     try {
-      assertWorkspaceStateMigrationReady({ workspaceDirs: [workspaceDir], env });
+      assertWorkspaceStateMigrationReady({
+        workspaceDirs: [workspaceDir],
+        env,
+        operation: "doctor",
+      });
       const sourceStat = await readLegacyWorkshopSourceStat(workspaceDir, record.target.skillDir);
       if (sourceStat?.isSymbolicLink()) {
         continue;

--- a/src/commands/doctor-skill-workshop-workspaces.ts
+++ b/src/commands/doctor-skill-workshop-workspaces.ts
@@ -230,7 +230,8 @@ export async function finishWorkshopWorkspaceRelocations(env: NodeJS.ProcessEnv)
       complete = (await directoryIdentity(captured.workspaceDir)) === captured.directoryIdentity;
     }
     runOpenClawStateWriteTransaction(
-      ({ db }) => {
+      (writeDatabase) => {
+        const { db } = writeDatabase;
         const current = executeSqliteQueryTakeFirstSync(
           db,
           kysely
@@ -244,7 +245,7 @@ export async function finishWorkshopWorkspaceRelocations(env: NodeJS.ProcessEnv)
         const retired =
           complete &&
           retireWorkspaceRelocationAttestation({
-            database: { db },
+            database: writeDatabase,
             identity: captured,
             attestedAtMs: captured.attestedAtMs,
           });

--- a/src/config/sessions/startup-migration.ts
+++ b/src/config/sessions/startup-migration.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { formatCliCommand } from "../../cli/command-format.js";
+import { formatStateRepairRequired } from "../../infra/state-repair-message.js";
 import { listOpenClawRegisteredAgentDatabases } from "../../state/openclaw-agent-db-registry.js";
 import {
   closeOpenClawAgentDatabaseByPath,
@@ -27,6 +27,7 @@ export function assertSessionStoreMigrationComplete(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   targets?: readonly { storePath: string }[];
+  operation?: "doctor";
 }): void {
   const env = params.env ?? process.env;
   const targets = params.targets ?? resolveAllAgentSessionStoreTargetsSync(params.cfg, { env });
@@ -36,7 +37,12 @@ export function assertSessionStoreMigrationComplete(params: {
   ].find((storePath) => !storePath.endsWith(".sqlite") && fs.existsSync(storePath));
   if (legacyStore) {
     throw new SessionStoreMigrationRequiredError(
-      `Legacy session store requires migration: ${legacyStore}. Run "${formatCliCommand("openclaw doctor --fix", env)}" against the same state/config before starting OpenClaw.`,
+      formatStateRepairRequired(
+        `Legacy session store requires migration at ${legacyStore}`,
+        "Repair the retained source using the migration report's named file and validation error, preserving the original history.",
+        params.operation,
+        env,
+      ),
     );
   }
 }

--- a/src/config/sessions/startup-migration.ts
+++ b/src/config/sessions/startup-migration.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import { formatStateRepairRequired } from "../../infra/state-repair-message.js";
+import { formatCliCommand } from "../../cli/command-format.js";
+import { formatDoctorStateRepairFailure } from "../../infra/state-repair-message.js";
 import { listOpenClawRegisteredAgentDatabases } from "../../state/openclaw-agent-db-registry.js";
 import {
   closeOpenClawAgentDatabaseByPath,
@@ -37,12 +38,12 @@ export function assertSessionStoreMigrationComplete(params: {
   ].find((storePath) => !storePath.endsWith(".sqlite") && fs.existsSync(storePath));
   if (legacyStore) {
     throw new SessionStoreMigrationRequiredError(
-      formatStateRepairRequired(
-        `Legacy session store requires migration at ${legacyStore}`,
-        "Repair the retained source using the migration report's named file and validation error, preserving the original history.",
-        params.operation,
-        env,
-      ),
+      params.operation === "doctor"
+        ? formatDoctorStateRepairFailure(
+            `Legacy session store requires migration at ${legacyStore}`,
+            "Repair the retained source using the migration report's named file and validation error, preserving the original history.",
+          )
+        : `Legacy session store requires migration: ${legacyStore}. Run "${formatCliCommand("openclaw doctor --fix", env)}" against the same state/config before starting OpenClaw.`,
     );
   }
 }

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1226,7 +1226,8 @@ describe("doctor health contributions", () => {
     expect(deferredPanels[0]?.[0]).toContain(pendingWarnings[1]);
     expect(deferredPanels[0]?.[0]).toContain("2 additional pending entries were omitted");
     expect(deferredPanels[0]?.[0]).toContain("No listed legacy source was removed.");
-    expect(deferredPanels[0]?.[0]).toContain('rerun "openclaw doctor --fix"');
+    expect(deferredPanels[0]?.[0]).toContain("Fix the config errors above.");
+    expect(deferredPanels[0]?.[0]).not.toContain("doctor --fix");
     expect(mocks.runLegacyStateMigrations).not.toHaveBeenCalled();
 
     // A later write pass must not retry the identical candidate or duplicate the warning.

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -63,10 +63,10 @@ async function reportDeferredLegacyState(ctx: DoctorHealthFlowContext): Promise<
   const omittedDetailCount = pendingDetails.length - displayedDetails.length;
   const remediation =
     ctx.configWriteRefusal === "validation"
-      ? 'Fix the config errors above, then rerun "openclaw doctor --fix".'
+      ? "Fix the config errors above."
       : ctx.configWriteRefusal === "include-ownership"
-        ? 'Repair the include boundary named above by hand, then rerun "openclaw doctor --fix".'
-        : 'Resolve the Gateway or cron-store condition above, then rerun "openclaw doctor --fix".';
+        ? "Repair the include boundary named above by hand."
+        : "Resolve the Gateway or cron-store condition above.";
   note(
     [
       "Pending owners and blockers:",

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -2,11 +2,11 @@
 import fs from "node:fs";
 import { intro as clackIntro, outro as clackOutro } from "@clack/prompts";
 import { stylePromptTitle } from "../../packages/terminal-core/src/prompt-style.js";
-import { formatCliCommand } from "../cli/command-format.js";
 import type { DoctorOptions } from "../commands/doctor-prompter.js";
 import { guardUpdateDoctorSchemaUpgrade } from "../commands/doctor-update-schema-guard.js";
 import { resolveStateDir } from "../config/paths.js";
 import { DoctorStateMigrationRefusalError } from "../infra/state-migrations.messages.js";
+import { formatStateRepairRequired } from "../infra/state-repair-message.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import type { DoctorHealthFlowContext } from "./doctor-health-contributions.js";
@@ -40,7 +40,11 @@ async function assertDoctorDatabaseSchemasCompatible() {
   );
   if (unreadableStateDatabase) {
     throw new Error(
-      `Doctor cannot continue because the shared state database is unreadable: ${unreadableStateDatabase.path}: ${unreadableStateDatabase.reason}. The database was left unchanged; doctor will not recreate it because that could discard persistent operator data. Stop the Gateway and other OpenClaw processes, then restore this file from a verified backup or repair it manually. After recovery, run ${formatCliCommand("openclaw doctor --fix")} again. See ${stateDatabase.OPENCLAW_DATABASE_SCHEMA_DOCS_URL}.`,
+      formatStateRepairRequired(
+        `shared state database is unreadable at ${unreadableStateDatabase.path}: ${unreadableStateDatabase.reason}`,
+        "Stop OpenClaw processes, then restore this file from a verified backup; the unreadable database was left unchanged.",
+        "doctor",
+      ),
     );
   }
   return databaseSchemas;
@@ -149,7 +153,7 @@ export async function runDoctorHealthFlow(runtime?: RuntimeEnv, options: DoctorO
       // complete while required state still blocks runtime access.
       const { assertSessionStoreMigrationComplete } =
         await import("../config/sessions/startup-migration.js");
-      assertSessionStoreMigrationComplete({ cfg: ctx.cfg, env: process.env });
+      assertSessionStoreMigrationComplete({ cfg: ctx.cfg, env: process.env, operation: "doctor" });
       const { assertOpenClawDatabasesReady } =
         await import("../state/openclaw-database-preflight.js");
       const { resolveConfiguredAgentDatabaseTargets } =
@@ -163,10 +167,10 @@ export async function runDoctorHealthFlow(runtime?: RuntimeEnv, options: DoctorO
       });
       const { assertConfiguredWorkspaceStateReady } =
         await import("../agents/workspace-state-dirs.js");
-      assertConfiguredWorkspaceStateReady({ cfg: ctx.cfg });
+      assertConfiguredWorkspaceStateReady({ cfg: ctx.cfg, operation: "doctor" });
       const { assertNoPendingLegacyExecApprovals } =
         await import("../infra/exec-approvals-migration-gate.js");
-      assertNoPendingLegacyExecApprovals();
+      assertNoPendingLegacyExecApprovals({ operation: "doctor" });
     }
     await maintenance?.finish(ctx.cfg);
     if (ctx.postInstallDoctorResult) {
@@ -188,7 +192,7 @@ export async function runDoctorHealthFlow(runtime?: RuntimeEnv, options: DoctorO
   } catch (error) {
     if (maintenance && !(error instanceof DoctorStateMigrationRefusalError)) {
       effectiveRuntime.error(
-        "Doctor could not complete maintenance. Check the reported service state, resolve the failure, and rerun doctor --fix.",
+        "Doctor could not complete maintenance. Check the reported service state and resolve the failure.",
       );
     }
     throw error;

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -6,7 +6,7 @@ import type { DoctorOptions } from "../commands/doctor-prompter.js";
 import { guardUpdateDoctorSchemaUpgrade } from "../commands/doctor-update-schema-guard.js";
 import { resolveStateDir } from "../config/paths.js";
 import { DoctorStateMigrationRefusalError } from "../infra/state-migrations.messages.js";
-import { formatStateRepairRequired } from "../infra/state-repair-message.js";
+import { formatDoctorStateRepairFailure } from "../infra/state-repair-message.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import type { DoctorHealthFlowContext } from "./doctor-health-contributions.js";
@@ -40,10 +40,9 @@ async function assertDoctorDatabaseSchemasCompatible() {
   );
   if (unreadableStateDatabase) {
     throw new Error(
-      formatStateRepairRequired(
+      formatDoctorStateRepairFailure(
         `shared state database is unreadable at ${unreadableStateDatabase.path}: ${unreadableStateDatabase.reason}`,
         "Stop OpenClaw processes, then restore this file from a verified backup; the unreadable database was left unchanged.",
-        "doctor",
       ),
     );
   }

--- a/src/flows/doctor-health.unsupported-state.test.ts
+++ b/src/flows/doctor-health.unsupported-state.test.ts
@@ -1,0 +1,82 @@
+// Install fixture mocks before importing the real maintenance owners.
+import "./doctor-health.test-support.js";
+import fs from "node:fs";
+import { expect, it, vi } from "vitest";
+import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
+import { runCommandWithRuntime } from "../cli/cli-utils.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  readExecApprovalsConfigRow,
+  serializeExecApprovals,
+  writeExecApprovalsConfigRow,
+} from "../infra/exec-approvals-sqlite.js";
+import {
+  detectLegacyExecApprovals,
+  migrateLegacyExecApprovals,
+} from "../infra/state-migrations.exec-approvals.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { runDoctorHealthFlow } from "./doctor-health.js";
+
+const { mocks } = await import("./doctor-health.test-support.js");
+
+it("reports unsupported workspace and conflicting exec policy without recommending itself", async () => {
+  mocks.packageRoot.mockReturnValue(undefined);
+  mocks.outro.mockClear();
+  await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+    const cfg: OpenClawConfig = {
+      agents: { entries: { main: { default: true, workspace: state.workspaceDir } } },
+    };
+    mocks.config.mockReturnValue(cfg);
+    const identity = resolveWorkspaceStateIdentity(state.workspaceDir);
+    const { db, path: databasePath } = openOpenClawStateDatabase({ env: state.env });
+    db.prepare(
+      "INSERT INTO workspace_setup_state (workspace_key, workspace_path, version, updated_at) VALUES (?, ?, 99, 1)",
+    ).run(identity.workspaceKey, identity.workspacePath);
+    writeExecApprovalsConfigRow({
+      db,
+      file: { version: 1, defaults: { security: "deny" }, agents: {} },
+    });
+    const canonical = readExecApprovalsConfigRow(db);
+    const legacy = serializeExecApprovals({
+      version: 1,
+      defaults: { security: "full" },
+      agents: {},
+    });
+    const sourcePath = state.statePath("exec-approvals.json");
+    fs.writeFileSync(sourcePath, legacy);
+    mocks.runContributions.mockImplementation(async (ctx) => {
+      const result = await migrateLegacyExecApprovals({
+        stateDir: state.stateDir,
+        env: state.env,
+        detected: detectLegacyExecApprovals({
+          stateDir: state.stateDir,
+          doctorOnlyStateMigrations: true,
+        }),
+      });
+      ctx.runtime.log(result.warnings.join("\n"));
+    });
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    await runCommandWithRuntime(runtime, () =>
+      runDoctorHealthFlow(runtime, { repair: true, nonInteractive: true }),
+    );
+    const output = [...runtime.log.mock.calls, ...runtime.error.mock.calls].flat().join("\n");
+    expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(1);
+    expect(output).toContain(databasePath);
+    expect(output).toContain(state.workspaceDir);
+    expect(output).toContain("99");
+    expect(output).toContain("compatible OpenClaw build");
+    expect(output).toContain(sourcePath);
+    expect(output).toContain("reconcile this file");
+    expect(output).not.toMatch(/(?:openclaw\s+)?doctor\s+--(?:fix|repair)/i);
+    expect(fs.readFileSync(sourcePath, "utf8")).toBe(legacy);
+    const reopened = openOpenClawStateDatabase({ env: state.env }).db;
+    expect(readExecApprovalsConfigRow(reopened)).toEqual(canonical);
+    expect(
+      reopened
+        .prepare("SELECT version FROM workspace_setup_state WHERE workspace_key = ?")
+        .get(identity.workspaceKey),
+    ).toEqual({ version: 99 });
+    expect(mocks.outro).not.toHaveBeenCalledWith("Doctor complete.");
+  });
+});

--- a/src/infra/exec-approvals-migration-gate.ts
+++ b/src/infra/exec-approvals-migration-gate.ts
@@ -2,7 +2,7 @@
 import path from "node:path";
 import { resolveExecApprovalsPath } from "./exec-approvals-config.js";
 import { pathMayExistSync } from "./path-existence.js";
-import { formatStateRepairRequired } from "./state-repair-message.js";
+import { formatDoctorStateRepairFailure } from "./state-repair-message.js";
 
 const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
 // Doctor usually runs in another process, so cache only the steady-state absence;
@@ -26,10 +26,9 @@ export class ExecApprovalsMigrationRequiredError extends Error {
   constructor(filePath: string, operation?: "doctor", problem = "Legacy exec approvals exist") {
     super(
       operation === "doctor"
-        ? formatStateRepairRequired(
+        ? formatDoctorStateRepairFailure(
             `${problem} at ${filePath}`,
             "Stop the Gateway and node hosts, then reconcile this file with a verified copy of the intended exec policy; preserve existing SQLite policy.",
-            operation,
           )
         : `${problem} at ${filePath}. ${doctorFixInstruction(filePath)} before using exec approvals.`,
     );
@@ -52,7 +51,9 @@ export function assertNoPendingLegacyExecApprovals(
   const sourceAfter = probe(sourcePath);
   if (sourceBefore || claim || sourceAfter) {
     throw new ExecApprovalsMigrationRequiredError(
-      sourceBefore || sourceAfter ? sourcePath : `${sourcePath}${DOCTOR_CLAIM_SUFFIX}`,
+      options.operation === "doctor" && !sourceBefore && !sourceAfter
+        ? `${sourcePath}${DOCTOR_CLAIM_SUFFIX}`
+        : sourcePath,
       options.operation,
     );
   }

--- a/src/infra/exec-approvals-migration-gate.ts
+++ b/src/infra/exec-approvals-migration-gate.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { resolveExecApprovalsPath } from "./exec-approvals-config.js";
 import { pathMayExistSync } from "./path-existence.js";
+import { formatStateRepairRequired } from "./state-repair-message.js";
 
 const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
 // Doctor usually runs in another process, so cache only the steady-state absence;
@@ -22,9 +23,15 @@ function doctorFixInstruction(filePath: string): string {
 }
 
 export class ExecApprovalsMigrationRequiredError extends Error {
-  constructor(filePath: string) {
+  constructor(filePath: string, operation?: "doctor", problem = "Legacy exec approvals exist") {
     super(
-      `Legacy exec approvals exist at ${filePath}. ${doctorFixInstruction(filePath)} before using exec approvals.`,
+      operation === "doctor"
+        ? formatStateRepairRequired(
+            `${problem} at ${filePath}`,
+            "Stop the Gateway and node hosts, then reconcile this file with a verified copy of the intended exec policy; preserve existing SQLite policy.",
+            operation,
+          )
+        : `${problem} at ${filePath}. ${doctorFixInstruction(filePath)} before using exec approvals.`,
     );
     this.name = "ExecApprovalsMigrationRequiredError";
   }
@@ -32,7 +39,7 @@ export class ExecApprovalsMigrationRequiredError extends Error {
 
 /** Refuse runtime access until Doctor owns the one-time legacy import. */
 export function assertNoPendingLegacyExecApprovals(
-  options: { pathMayExist?: (filePath: string) => boolean } = {},
+  options: { pathMayExist?: (filePath: string) => boolean; operation?: "doctor" } = {},
 ): void {
   const sourcePath = resolveExecApprovalsPath();
   if (legacyAbsenceCache.has(sourcePath)) {
@@ -44,7 +51,10 @@ export function assertNoPendingLegacyExecApprovals(
   const claim = probe(`${sourcePath}${DOCTOR_CLAIM_SUFFIX}`);
   const sourceAfter = probe(sourcePath);
   if (sourceBefore || claim || sourceAfter) {
-    throw new ExecApprovalsMigrationRequiredError(sourcePath);
+    throw new ExecApprovalsMigrationRequiredError(
+      sourceBefore || sourceAfter ? sourcePath : `${sourcePath}${DOCTOR_CLAIM_SUFFIX}`,
+      options.operation,
+    );
   }
   legacyAbsenceCache.add(sourcePath);
 }

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -465,7 +465,7 @@ describe("exec approvals SQLite store", () => {
       }
       expect(caught).toBeInstanceOf(ExecApprovalsMigrationRequiredError);
       expect(caught).toMatchObject({
-        message: `Legacy exec approvals exist at ${sourcePath}. Run \`openclaw doctor --fix\` with OPENCLAW_STATE_DIR set to ${stateDir} before using exec approvals.`,
+        message: `Legacy exec approvals exist at ${legacyPath}. Run \`openclaw doctor --fix\` with OPENCLAW_STATE_DIR set to ${stateDir} before using exec approvals.`,
       });
 
       fs.rmSync(legacyPath);

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -465,7 +465,7 @@ describe("exec approvals SQLite store", () => {
       }
       expect(caught).toBeInstanceOf(ExecApprovalsMigrationRequiredError);
       expect(caught).toMatchObject({
-        message: `Legacy exec approvals exist at ${legacyPath}. Run \`openclaw doctor --fix\` with OPENCLAW_STATE_DIR set to ${stateDir} before using exec approvals.`,
+        message: `Legacy exec approvals exist at ${sourcePath}. Run \`openclaw doctor --fix\` with OPENCLAW_STATE_DIR set to ${stateDir} before using exec approvals.`,
       });
 
       fs.rmSync(legacyPath);

--- a/src/infra/state-migrations.exec-approvals.test.ts
+++ b/src/infra/state-migrations.exec-approvals.test.ts
@@ -457,10 +457,12 @@ describe("legacy exec approvals migration", () => {
       const result = await migrate({ env, stateDir });
 
       expect(result.changes).toEqual([]);
-      expect(result.warnings).toEqual([
-        `Preserved malformed legacy exec approvals for operator recovery. First problem: ${problem}. Repair exec-approvals.json locally, then rerun \`openclaw doctor --fix\` with the same OPENCLAW_STATE_DIR.`,
-      ]);
-      expect(result.warnings[0]?.length).toBeLessThan(400);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain(problem);
+      expect(result.warnings[0]).toContain(sourcePath);
+      expect(result.warnings[0]).toContain("reconcile this file");
+      expect(result.warnings[0]).not.toContain("doctor --fix");
+      expect(result.warnings[0]!.length - sourcePath.length).toBeLessThan(400);
       expect(JSON.stringify(result)).not.toContain("private-marker");
       expect(fs.readFileSync(sourcePath)).toEqual(original);
       expect(fs.existsSync(`${sourcePath}.doctor-importing`)).toBe(false);
@@ -524,7 +526,9 @@ describe("legacy exec approvals migration", () => {
     const result = await migrate({ env, stateDir });
 
     expect(result.changes).toEqual([]);
-    expect(result.warnings[0]).toContain("retained conflicting legacy JSON");
+    expect(result.warnings[0]).toContain("Conflicting legacy exec approvals remain");
+    expect(result.warnings[0]).toContain(sourcePath);
+    expect(result.warnings[0]).toContain("reconcile this file");
     expect(fs.existsSync(sourcePath)).toBe(true);
     expect(readExecApprovalsConfigRow(database(env))?.raw_json).toBe(
       serializeExecApprovals(canonical),

--- a/src/infra/state-migrations.exec-approvals.ts
+++ b/src/infra/state-migrations.exec-approvals.ts
@@ -14,11 +14,13 @@ import {
   tryParsePersistedExecApprovals,
 } from "./exec-approvals-config.js";
 import type { ExecApprovalsFile } from "./exec-approvals-core.js";
+import { ExecApprovalsMigrationRequiredError } from "./exec-approvals-migration-gate.js";
 import {
   readExecApprovalsConfigRow,
   serializeExecApprovals,
   writeExecApprovalsConfigRow,
 } from "./exec-approvals-sqlite.js";
+import { pathMayExistSync } from "./path-existence.js";
 import type { LegacyExecApprovalsDetection } from "./state-migrations.exec-approvals.types.js";
 import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import {
@@ -249,11 +251,11 @@ function decideAndRecordMigration(params: {
         reportJson,
         upsert: true,
       });
-      const message =
-        decisionMessage(decision, removeSource) +
-        (legacy.ok
-          ? ""
-          : ` First problem: ${legacy.error}. Repair exec-approvals.json locally, then rerun \`openclaw doctor --fix\` with the same OPENCLAW_STATE_DIR.`);
+      const message = removeSource
+        ? decisionMessages[decision]
+        : legacy.ok
+          ? "Conflicting legacy exec approvals remain"
+          : `Invalid legacy exec approvals (${legacy.error})`;
       return { message, removeSource, sourceKey };
     },
     { env: params.env },
@@ -261,26 +263,15 @@ function decideAndRecordMigration(params: {
   );
 }
 
-function decisionMessage(decision: MigrationDecision, removeSource: boolean): string {
-  switch (decision) {
-    case "empty-legacy-retired":
-      return "Archived empty legacy exec approvals without changing SQLite policy.";
-    case "legacy-imported":
-      return "Imported legacy exec approvals into shared SQLite state.";
-    case "invalid-canonical-repaired":
-      return "Replaced an invalid SQLite exec approvals row with validated legacy state.";
-    case "canonical-preserved":
-      return removeSource
-        ? "Preserved byte-identical canonical SQLite exec approvals."
-        : "Preserved canonical SQLite exec approvals and retained conflicting legacy JSON.";
-    case "malformed-legacy-preserved":
-      return "Preserved malformed legacy exec approvals for operator recovery.";
-    case "receipt-authoritative":
-      return "Completed cleanup for previously imported legacy exec approvals.";
-  }
-  const unreachable: never = decision;
-  return unreachable;
-}
+const decisionMessages: Record<MigrationDecision, string> = {
+  "empty-legacy-retired": "Archived empty legacy exec approvals without changing SQLite policy.",
+  "legacy-imported": "Imported legacy exec approvals into shared SQLite state.",
+  "invalid-canonical-repaired":
+    "Replaced an invalid SQLite exec approvals row with validated legacy state.",
+  "canonical-preserved": "Preserved byte-identical canonical SQLite exec approvals.",
+  "malformed-legacy-preserved": "Preserved malformed legacy exec approvals for operator recovery.",
+  "receipt-authoritative": "Completed cleanup for previously imported legacy exec approvals.",
+};
 
 async function migrateWithExclusiveStateOwnership(params: {
   detected: LegacyExecApprovalsDetection;
@@ -445,13 +436,13 @@ export async function migrateLegacyExecApprovals(params: {
   if (!detected?.hasLegacy) {
     return { changes: [], warnings: [] };
   }
-  return await withLegacyMigrationStateLock({
+  const result = await withLegacyMigrationStateLock({
     stateDir: params.stateDir,
     env: params.env,
     label: "legacy exec approvals",
     releaseLabel: "Exec approvals",
     errorLabel: "Failed reading legacy exec approvals",
-    retryGuidance: "Stop the Gateway, then run `openclaw doctor --fix` again.",
+    retryGuidance: `Stop the Gateway and node hosts holding ${params.stateDir}.`,
     run: async (env) => {
       const stateRoot = await root(params.stateDir, {
         hardlinks: "reject",
@@ -466,4 +457,22 @@ export async function migrateLegacyExecApprovals(params: {
       });
     },
   });
+  if (result.changes.length > 0) {
+    return result;
+  }
+  const retainedPaths = [
+    detected.sourcePath,
+    `${detected.sourcePath}${DOCTOR_CLAIM_SUFFIX}`,
+  ].filter(pathMayExistSync);
+  return {
+    ...result,
+    warnings: result.warnings.map(
+      (problem) =>
+        new ExecApprovalsMigrationRequiredError(
+          retainedPaths.join(", ") || detected.sourcePath,
+          "doctor",
+          problem,
+        ).message,
+    ),
+  };
 }

--- a/src/infra/state-repair-message.ts
+++ b/src/infra/state-repair-message.ts
@@ -1,13 +1,3 @@
-import { formatCliCommand } from "../cli/command-format.js";
-
-/** Runtime callers request migration; Doctor reports the manual recovery that remains. */
-export function formatStateRepairRequired(
-  problem: string,
-  recovery: string,
-  operation?: "doctor",
-  env: NodeJS.ProcessEnv = process.env,
-): string {
-  return operation === "doctor"
-    ? `Doctor cannot repair this state: ${problem}. ${recovery}`
-    : `${problem}. Run "${formatCliCommand("openclaw doctor --fix", env)}" against the same state/config before using OpenClaw.`;
+export function formatDoctorStateRepairFailure(problem: string, recovery: string): string {
+  return `Doctor cannot repair this state: ${problem}. ${recovery}`;
 }

--- a/src/infra/state-repair-message.ts
+++ b/src/infra/state-repair-message.ts
@@ -1,0 +1,13 @@
+import { formatCliCommand } from "../cli/command-format.js";
+
+/** Runtime callers request migration; Doctor reports the manual recovery that remains. */
+export function formatStateRepairRequired(
+  problem: string,
+  recovery: string,
+  operation?: "doctor",
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return operation === "doctor"
+    ? `Doctor cannot repair this state: ${problem}. ${recovery}`
+    : `${problem}. Run "${formatCliCommand("openclaw doctor --fix", env)}" against the same state/config before using OpenClaw.`;
+}

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -160,7 +160,7 @@ export async function assertOpenClawDatabasesReady(
   const action =
     options.operation === "doctor" ? "Doctor could not complete repair" : "Gateway refused restart";
   throw new Error(
-    `${action} because persisted database readiness could not be verified: ${shown.join("; ")}${omitted > 0 ? `; +${omitted} more` : ""}. Stop the Gateway and other OpenClaw processes, run openclaw doctor --fix, then retry.`,
+    `${action} because persisted database readiness could not be verified: ${shown.join("; ")}${omitted > 0 ? `; +${omitted} more` : ""}. ${options.operation === "doctor" ? "Stop OpenClaw processes, then restore the affected database from a verified backup." : "Stop the Gateway and other OpenClaw processes, run openclaw doctor --fix, then retry."}`,
   );
 }
 


### PR DESCRIPTION
Related: #139395

## What Problem This Solves

Fixes an issue where users running Doctor repair were told to run Doctor repair again when unsupported canonical workspace state or preserved exec policy still blocked runtime access. This completes the separate recovery work identified during the upgrade-recovery fixes in #139395, following community reports.

## Why This Change Was Made

`src/agents/workspace-state-store.ts` rejected unknown versions with a repair command that cannot support those versions, and `src/flows/doctor-health.ts` checked legacy workspace sources without reading canonical setup state. Exec migration deliberately preserves unreadable or conflicting policy, but its warnings and the final runtime gate did not provide consistent manual recovery. One Doctor-specific message producer formats manual recovery. Runtime migration guidance stays with its existing owners and retains its exact wording.

Doctor checks canonical workspace state read-only before declaring completion. When an earlier migration refuses, config preflight reports the workspace diagnosis read-only and rethrows the original refusal, preserving the stopped repair graph. Exec warnings name retained source/claim paths, and successful source removal retains its distinct receipt-finalization warning. Automatic quarantine, discarding future-version state, and choosing policy on the operator's behalf are deliberately excluded.

## User Impact

Unsupported workspace state and preserved exec policy produce exit code 1, exact offending paths, and concrete manual recovery actions without recommending another identical Doctor repair invocation. Supported migrations and runtime state-directory guidance remain intact. Documentation explains the recovery choices and preservation guarantees.

## Evidence

Head: `44a026d0469a2c882ef709738b0f89fe968ec0a6`.

- The completion regression failed on the original implementation: the workspace diagnosis was absent and output recommended Doctor repair again. The repaired completion flow and real CLI now report both offending paths, manual recovery, exit code 1, and unchanged workspace version / policy bytes, with no repair invocation in the output.
- `node scripts/run-vitest.mjs src/commands/doctor-config-preflight.refusal.process.test.ts src/commands/doctor-config-preflight.refusal-receipts.process.test.ts`: 4 passed, including the real CLI combined fixture and unchanged blocked-tail receipts.
- `node scripts/run-vitest.mjs src/flows/doctor-health.unsupported-state.test.ts src/commands/doctor-skill-workshop-workspace.test.ts`: 13 passed.
- Additional focused owner runs passed: Doctor maintenance/readiness, database preflight, exec store/migration, session startup migration, and workspace state. Together these cover 280 distinct tests.
- `node scripts/check-changed.mjs`: passed, including core/test typechecks, all lint batches, storage guards, and zero runtime import cycles.
- `git diff --check`: clean.
- `pnpm build`: passed. Subsequent caller propagation and helper extraction were verified by successful runtime prerequisite builds, typechecks, and the focused tests above.
- Independent Codex review of the final diff: scoped-clean through P2, no actionable findings.

The first source-CLI fixture timed out during cold startup on the loaded host; the retained regression uses the existing built-CLI fixture and its unchanged timeout. Iteration also corrected a downstream database-path argument, terminal-wrap-sensitive assertion, file-size limits, and variable shadowing. Those local failures were resolved before publication.

Maintainer-approved separate recovery scope permits production growth. Production: +175/-75 (net +100); tests: +178/-8 (net +170); docs: +13/-2. Compared with the earlier candidate, the current source also requires preserving the newer fail-stop preflight path and its receipt behavior. Existing preflight helpers keep the main file within its line limit without suppressions.

A real merge conflict with main added an include-ownership recovery case. The rebase preserves that manual action and removes its repeated repair invocation. `node scripts/run-vitest.mjs src/flows/doctor-health-contributions.test.ts -t 'defers every config write after an include-ownership refusal'`: 3 passed on the rebased source; fresh independent review is scoped-clean through P2. The core workspace, exec-policy, and completion code merged unchanged.

CI history: [run 34086671684](https://github.com/openclaw/openclaw/actions/runs/34086671684) exposed a runtime-message compatibility regression and two Doctor assertions that still required the obsolete retry guidance. Runtime session/workspace/exec messages are now preserved exactly, and the Doctor assertions require the manual action and reject another repair invocation. All 23 targeted cases passed, including the built-Gateway SQLite lifecycle proof and the previously failing gateway refusal, workspace, deferred-config, and Workshop reservation cases. Two Discord voice backlog cases also timed out in that run; Discord code is unchanged.

The existing lockfile dependencies were refreshed after rebase; changed-file validation now passes with the pinned fs-safe version. Fresh independent review of the correction is scoped-clean through P2.

The final rebase retained both independent CLI tests added at the same insertion point. Range comparison confirms the task patch is unchanged apart from main context, including its newer updater guard.

CI: [run 34091133675](https://github.com/openclaw/openclaw/actions/runs/34091133675) passed on `44a026d0469a2c882ef709738b0f89fe968ec0a6`. ClawSweeper reviewed that exact head with no actionable findings. Native preparation and merge completed; landed commit: [a1457127d365](https://github.com/openclaw/openclaw/commit/a1457127d3652585c8e0a124ebad59987f862ed7). Remote main ancestry and the landed source were verified.

Credit: follow-up to the maintainer work in #139395 by @steipete. The already-landed workspace ordering and health lastError fixes are excluded.
