### PR TITLE
refactor(capture): reuse credential header classification

### DIFF
--- a/src/proxy-capture/header-redaction.ts
+++ b/src/proxy-capture/header-redaction.ts
@@ -9,41 +9,18 @@
  */
 import { isHeadersLike, type HeadersLike } from "../infra/fetch-headers.js";
 import { redactRegisteredSecretValues } from "../logging/secret-redaction-registry.js";
+import { isLikelySensitiveModelProviderHeaderName } from "../secrets/model-provider-header-policy.js";
 
 export const REDACTED_CAPTURE_HEADER_VALUE = "[REDACTED]";
 
-const SENSITIVE_CAPTURE_HEADER_NAMES = new Set([
-  "authorization",
-  "proxy-authorization",
-  "cookie",
-  "set-cookie",
-  "x-api-key",
-  "api-key",
-  "apikey",
-  "x-auth-token",
-  "auth-token",
-  "x-access-token",
-  "access-token",
-]);
-const SENSITIVE_CAPTURE_HEADER_NAME_FRAGMENTS = [
-  "api-key",
-  "apikey",
-  "token",
-  "secret",
-  "password",
-  "credential",
-  "session",
-];
-
 function isSensitiveCaptureHeaderName(name: string): boolean {
   const normalized = name.trim().toLowerCase();
-  if (!normalized) {
-    return false;
-  }
-  if (SENSITIVE_CAPTURE_HEADER_NAMES.has(normalized)) {
-    return true;
-  }
-  return SENSITIVE_CAPTURE_HEADER_NAME_FRAGMENTS.some((fragment) => normalized.includes(fragment));
+  return (
+    isLikelySensitiveModelProviderHeaderName(normalized) ||
+    normalized === "cookie" ||
+    normalized === "set-cookie" ||
+    normalized.includes("session")
+  );
 }
 
 export function redactedCaptureHeaders(


### PR DESCRIPTION
## What Problem This Solves

Debug proxy capture independently repeats the credential-header names and fragments used by the secrets audit. Keeping both lists makes future credential-name updates prone to drift.

## Why This Change Was Made

Capture delegates credential-name classification to the secrets-owned `isLikelySensitiveModelProviderHeaderName` and retains its cookie, set-cookie, and session-name extension. Caller-declared sensitive names, array flattening, output keys, and registered-secret value masking stay unchanged.

The matched header-name set is identical: the secrets owner's extra exact `secret-key` names were already matched by capture's `secret` fragment.

## User Impact

None intended. Request and response captures retain the same redacted output. No configuration, dependency, schema, persistence, or public-export change.

## Evidence

- `node scripts/run-vitest.mjs src/proxy-capture`: 99 tests passed across nine files, covering header forms and runtime request/response persistence and streams.
- The supplied `src/secrets/model-provider-header-policy` filter has no standalone test file; the wrapper rejected that target before running tests. The existing capture suites exercise the shared classifier through the changed boundary.
- Independent review with unchanged classifier and normalization dependencies supplied: P0-P2 scoped-clean, zero findings.
- `node scripts/check-changed.mjs --base 5e550555920fe6ccc0c0e8924b6d11435ed971fc`: passed.
- Production +7/-30, net -23 lines; no test changes. Exact-head CI and native landing gates remain required.

Required fresh-main rebase onto `038acb2695d298ac671c3b886647025abdbfd22c` preserved the patch exactly. The unchanged policy and normalization dependencies also have no diff. Current head `b48208bd72f5c7012a793f65f04f6e15ef44a52d` passed [CI 34087090712](https://github.com/openclaw/openclaw/actions/runs/34087090712).
