### PR TITLE
fix(ui): stop sidebar resources restarting after removal

### DIFF
--- a/ui/src/components/app-sidebar.catalog-hidden-pages.test.ts
+++ b/ui/src/components/app-sidebar.catalog-hidden-pages.test.ts
@@ -195,6 +195,67 @@ describe("AppSidebar expanded catalog refresh visibility", () => {
     expect(request).toHaveBeenCalledTimes(4);
   });
 
+  it("keeps resources retired during a detached update and resumes on reconnect", async () => {
+    const observed = new Set<Element>();
+    const observe = vi.fn((target: Element) => observed.add(target));
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        private targets = new Set<Element>();
+        observe(target: Element) {
+          this.targets.add(target);
+          observe(target);
+        }
+        disconnect() {
+          for (const target of this.targets) {
+            observed.delete(target);
+          }
+          this.targets.clear();
+        }
+        unobserve(target: Element) {
+          this.targets.delete(target);
+          observed.delete(target);
+        }
+      },
+    );
+    let mounted: Awaited<ReturnType<typeof mountExpanded>> | undefined;
+    try {
+      const request = vi.fn((_method, params: { cursors?: Record<string, string> }) => {
+        const cursor = params.cursors?.["gateway:local"];
+        return Promise.resolve(page(cursor === "page-2" ? 2 : cursor === "page-3" ? 3 : 1));
+      });
+      mounted = await mountExpanded(request);
+      const { sidebar, provider } = mounted;
+      const scrollBody = sidebar.querySelector(".sidebar-shell__body");
+      expect(scrollBody).not.toBeNull();
+      expect(observed.has(scrollBody!)).toBe(true);
+
+      sidebar.requestUpdate();
+      provider.remove();
+      expect(observed.has(scrollBody!)).toBe(false);
+      const timersAfterDetach = vi.getTimerCount();
+      const observationsAfterDetach = observe.mock.calls.length;
+      await sidebar.updateComplete;
+      expect.soft(vi.getTimerCount()).toBe(timersAfterDetach);
+      expect.soft(observe).toHaveBeenCalledTimes(observationsAfterDetach);
+      expect.soft(observed.has(scrollBody!)).toBe(false);
+
+      document.body.append(provider);
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(50);
+      await settle(sidebar);
+      expect(observed.has(sidebar.querySelector(".sidebar-shell__body")!)).toBe(true);
+      expect(request).toHaveBeenCalledTimes(4);
+      expect(sidebar.textContent).toContain("Original 1");
+    } finally {
+      mounted?.provider.remove();
+      await mounted?.sidebar.updateComplete;
+      // A red lifecycle assertion must not leave its retired resources in the next test.
+      vi.clearAllTimers();
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("accepts a complete exhausted first page while hidden", async () => {
     const pending = deferred<SessionsCatalogListResult>();
     const request = vi

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -42,7 +42,7 @@ import {
   scheduleSessionCatalogRefresh,
   type SessionCatalogDataOwner,
   type SessionDataControllerHost,
-  updateSessionCatalogData as updateSessionCatalogDataForHost,
+  updateSessionCatalogData,
 } from "./session-data-controller-catalog.ts";
 import {
   hasSidebarListFilter,
@@ -191,9 +191,13 @@ export class SessionDataController implements ReactiveController, SessionCatalog
   }
 
   hostUpdated(): void {
-    this.synchronizeSessionScope();
-    this.scroll.synchronize(this.host);
-    this.updateSessionCatalogData(true);
+    // Lit can finish a queued update after disconnect. Keep retired timers and
+    // observers closed until the host reconnects.
+    if (this.host.isConnected) {
+      this.synchronizeSessionScope();
+      this.scroll.synchronize(this.host);
+      updateSessionCatalogData(this, true);
+    }
   }
 
   hostDisconnected(): void {
@@ -313,10 +317,6 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     ) {
       void this.refreshSidebarSessions();
     }
-  }
-
-  updateSessionCatalogData(defer = false): void {
-    updateSessionCatalogDataForHost(this, defer);
   }
 
   handleSessionCatalogHostEvent(payload: unknown): void {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled where applicable.

</details>

## What Problem This Solves

Resolves a problem where removing the Control UI sidebar could leave catalog refresh timers and scroll observers active. A queued update could recreate these resources after teardown, producing an unhandled `document is not defined` error when the test environment subsequently closed.

The failure surfaced in the [UI CI job for #140754](https://github.com/openclaw/openclaw/actions/runs/34081541654/job/101617687686). That media-only change did not cause this independently reproduced lifecycle defect.

## Why This Change Was Made

Lit can finish an already queued update after disconnect. The session-data controller now runs its post-update synchronization only while its host is attached to the DOM, so teardown remains effective until reconnect. It also calls the canonical catalog updater directly and removes its sole-use wrapper: production stays net zero lines, with 8 additions and 8 removals.

## User Impact

Detached sidebars no longer restart their background resources. Reconnecting resumes catalog loading and scroll observation. There is no appearance, protocol, configuration, or persistence change.

## Evidence

- Before the fix, the new mounted-Lit regression failed all three resource checks: timer count grew from 3 to 5, observer calls from 1 to 2, and the detached scroll body remained observed. The seven existing tests and reconnect assertions passed.
- With the fix and unchanged regression, all 8 tests pass. Seven complete sibling files pass all 381 tests.
- All 20 normal changed-gate stages pass, including UI/core-test typechecks, lint, formatting, and dead-export checks, after local disk recovery. Source bytes stayed unchanged; process cleanup was verified.

Independent P2 review found no actionable issues.

The regression adds 61 test lines and uses jsdom with an observer ownership fake. This is resource-lifecycle proof, not a real-browser run or a replay of the original Linux CI worker order. No visual appearance changed.
