### PR TITLE
refactor(devices): share redacted pairing list types

### DIFF
--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -14,6 +14,12 @@ import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import { buildGatewayConnectionDetails, formatGatewayTransportErrorJson } from "../gateway/call.js";
+import type {
+  DevicePairingList as GatewayDevicePairingList,
+  DeviceTokenSummary,
+  PairedDevice,
+  PendingDevice,
+} from "../gateway/device-pairing-list.types.js";
 import { ADMIN_SCOPE, PAIRING_SCOPE, type OperatorScope } from "../gateway/method-scopes.js";
 import { isLoopbackHost } from "../gateway/net.js";
 import { isOperatorScope } from "../gateway/operator-scopes.js";
@@ -55,48 +61,7 @@ type DevicesRpcOpts = {
   name?: string;
 };
 
-type DeviceTokenSummary = {
-  role: string;
-  scopes?: string[];
-  revokedAtMs?: number;
-};
-
-type PendingDevice = {
-  requestId: string;
-  deviceId: string;
-  publicKey?: string;
-  displayName?: string;
-  clientId?: string;
-  clientMode?: string;
-  role?: string;
-  roles?: string[];
-  scopes?: string[];
-  remoteIp?: string;
-  isRepair?: boolean;
-  ts?: number;
-};
-
-type PairedDevice = {
-  deviceId: string;
-  publicKey?: string;
-  displayName?: string;
-  operatorLabel?: string;
-  clientId?: string;
-  role?: string;
-  roles?: string[];
-  scopes?: string[];
-  remoteIp?: string;
-  tokens?: DeviceTokenSummary[];
-  nodeSurface?: InfraPairedDevice["nodeSurface"];
-  pendingNodeSurface?: InfraPairedDevice["pendingNodeSurface"];
-  createdAtMs?: number;
-  approvedAtMs?: number;
-};
-
-type DevicePairingList = {
-  pending?: PendingDevice[];
-  paired?: PairedDevice[];
-};
+type DevicePairingList = Partial<GatewayDevicePairingList>;
 
 type ApprovePairingGatewayContext = {
   originalRequest: PendingDevice | null;

--- a/src/gateway/device-pairing-list.types.ts
+++ b/src/gateway/device-pairing-list.types.ts
@@ -1,0 +1,33 @@
+import type { Static } from "typebox";
+import type { DevicePairRequestedEventSchema } from "../../packages/gateway-protocol/src/schema/devices.js";
+import type { DeviceAuthTokenSummary } from "../infra/device-pairing-tokens.js";
+import type { PairedDeviceApprovalKind } from "../infra/device-pairing.types.js";
+
+type DevicePairRequestedEvent = Static<typeof DevicePairRequestedEventSchema>;
+
+export type DeviceTokenSummary = Pick<DeviceAuthTokenSummary, "role"> &
+  Partial<Omit<DeviceAuthTokenSummary, "role">>;
+
+export type PendingDevice = Pick<DevicePairRequestedEvent, "requestId" | "deviceId"> &
+  Partial<Omit<DevicePairRequestedEvent, "requestId" | "deviceId">>;
+
+/** Redacted list metadata, independent of the persisted pairing record and bearer tokens. */
+export type PairedDevice = Omit<PendingDevice, "requestId" | "silent" | "isRepair" | "ts"> & {
+  /** Operator-assigned label; preferred over client displayName when rendering. */
+  operatorLabel?: string;
+  tokens?: DeviceTokenSummary[];
+  approvedVia?: PairedDeviceApprovalKind;
+  /** Server-computed: the device currently holds a live gateway connection. */
+  connected?: boolean;
+  createdAtMs?: number;
+  approvedAtMs?: number;
+  lastSeenAtMs?: number;
+  // Clients need only these node-approval hints, not the persisted capability surface.
+  nodeSurface?: { displayName?: string };
+  pendingNodeSurface?: { requestId: string; displayName?: string; remoteIp?: string };
+};
+
+export type DevicePairingList = {
+  pending: PendingDevice[];
+  paired: PairedDevice[];
+};

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -26,11 +26,15 @@ import {
   getPendingDevicePairing,
   listDevicePairing,
   removePairedDevice,
-  type DeviceAuthToken,
+  type PairedDevice,
   rejectDevicePairing,
   updatePairedDeviceMetadata,
 } from "../../infra/device-pairing.js";
 import type { DiagnosticSecurityEventInput } from "../../infra/diagnostic-events.js";
+import type {
+  DevicePairingList,
+  PairedDevice as RedactedPairedDevice,
+} from "../device-pairing-list.types.js";
 import { reconcileRevokedDeviceWorker } from "../device-worker-revocation.js";
 import { GATEWAY_EVENT_DEVICE_PAIR_CHANGED } from "../events.js";
 import { clearRemovedNodeRuntimeState } from "../node-runtime-state.js";
@@ -59,9 +63,9 @@ const DEVICE_PAIR_APPROVAL_DENIED_MESSAGE = "device pairing approval denied";
 const DEVICE_PAIR_REJECTION_DENIED_MESSAGE = "device pairing rejection denied";
 
 function redactPairedDevice(
-  device: { tokens?: Record<string, DeviceAuthToken> } & Record<string, unknown>,
+  device: PairedDevice,
   opts?: { connected?: boolean },
-) {
+): RedactedPairedDevice {
   // Pairing lists are visible to operators; expose token lifecycle metadata
   // without returning raw token material or the internal approved-scope set.
   const { tokens, approvedScopes: _approvedScopes, ...rest } = device;
@@ -245,7 +249,7 @@ export const deviceHandlers: GatewayRequestHandlers = {
             connected: context.hasConnectedClientsForDevice?.(device.deviceId.trim()) ?? false,
           }),
         ),
-      },
+      } satisfies DevicePairingList,
       undefined,
     );
   },

--- a/ui/src/lib/nodes/index.ts
+++ b/ui/src/lib/nodes/index.ts
@@ -4,6 +4,7 @@
 import { getPublicKeyAsync, hashes, signAsync, utils } from "@noble/ed25519";
 import { gatewayCredentialScope } from "@openclaw/gateway-client/browser";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { DevicePairingList } from "../../../../src/gateway/device-pairing-list.types.js";
 import {
   type DeviceAuthEntry,
   type DeviceAuthStore,
@@ -14,6 +15,13 @@ import { getSafeLocalStorage } from "../../local-storage.ts";
 import { cloneConfigObject, removePathValue, setPathValue } from "../config-form-utils.ts";
 // Shared Nodes operations used by the Control UI page and Gateway event hooks.
 import { formatUiError } from "../format-error.ts";
+
+export type {
+  DevicePairingList,
+  DeviceTokenSummary,
+  PairedDevice,
+  PendingDevice,
+} from "../../../../src/gateway/device-pairing-list.types.js";
 
 // @noble/ed25519 defaults its SHA-512 to crypto.subtle, which browsers gate to
 // secure contexts. On plain-HTTP origins the pure-JS digests load lazily so
@@ -35,55 +43,6 @@ type GatewayRequestClient = {
 type NodesGatewaySnapshot = {
   client: GatewayRequestClient | null;
   connected: boolean;
-};
-
-export type DeviceTokenSummary = {
-  role: string;
-  scopes?: string[];
-  createdAtMs?: number;
-  rotatedAtMs?: number;
-  revokedAtMs?: number;
-  lastUsedAtMs?: number;
-};
-
-export type PendingDevice = {
-  requestId: string;
-  deviceId: string;
-  publicKey?: string;
-  displayName?: string;
-  role?: string;
-  roles?: string[];
-  scopes?: string[];
-  remoteIp?: string;
-  isRepair?: boolean;
-  ts?: number;
-};
-
-export type PairedDevice = {
-  deviceId: string;
-  publicKey?: string;
-  displayName?: string;
-  /** Operator-assigned label; preferred over client displayName when rendering. */
-  operatorLabel?: string;
-  platform?: string;
-  clientId?: string;
-  clientMode?: string;
-  role?: string;
-  roles?: string[];
-  scopes?: string[];
-  remoteIp?: string;
-  tokens?: DeviceTokenSummary[];
-  approvedVia?: "owner" | "silent" | "trusted-cidr" | "ssh-verified" | "bootstrap";
-  /** Server-computed: the device currently holds a live gateway connection. */
-  connected?: boolean;
-  createdAtMs?: number;
-  approvedAtMs?: number;
-  lastSeenAtMs?: number;
-};
-
-export type DevicePairingList = {
-  pending: PendingDevice[];
-  paired: PairedDevice[];
 };
 
 export type ExecSecurity = "deny" | "allowlist" | "full";
@@ -293,10 +252,7 @@ export async function loadDevices(state: DevicesState, opts?: { quiet?: boolean 
   }
   const generation = state.requestGeneration;
   try {
-    const res = await client.request<{
-      pending?: Array<PendingDevice>;
-      paired?: Array<PairedDevice>;
-    }>("device.pair.list", {});
+    const res = await client.request<Partial<DevicePairingList>>("device.pair.list", {});
     if (isCurrentNodesRequest(state, client, generation)) {
       state.devicesList = {
         pending: Array.isArray(res?.pending) ? res.pending : [],


### PR DESCRIPTION
## What Problem This Solves

The Dashboard and `openclaw devices` independently describe the same device-pairing list, so their metadata declarations can drift from the Gateway response.

## Why This Change Was Made

`src/gateway/device-pairing-list.types.ts` now owns the redacted list contract. The Gateway checks its list against that contract, and both clients derive their response and normalized-state types from it. Existing UI type exports remain available. Pending metadata derives from the event schema; token metadata derives from the existing redacted summary. No schema or runtime validation machinery is added.

The Gateway continues stripping bearer tokens and internal approved scopes and adding live connection state. The privileged CLI fallback continues using its existing local redactor and loopback/request-match checks. Its additional local metadata is preserved. The shared browser shape never aliases the persisted paired-device row.

## User Impact

No behavior, CLI output, UI appearance, signing, authorization, or persistence changes. Missing/non-array list normalization is unchanged. The contract includes the already-produced trusted-proxy approval kind.

## Evidence

- Focused Gateway, CLI, UI inventory and token tests passed: `node scripts/run-vitest.mjs src/cli/devices-cli.test.ts src/gateway/server-methods/devices.test.ts ui/src/lib/nodes/inventory.test.ts ui/src/lib/nodes/device-token.test.ts` (144 tests, 4 files, 3 routed shards on the rebased candidate).
- TypeScript erasure produces byte-identical JavaScript for all three existing modules; the new leaf emits no runtime JavaScript.
- Full `node scripts/check-changed.mjs`, `pnpm build` (15m55.1s), and `pnpm protocol:check` passed before the clean rebase. All four edited files and immediate type dependencies are unchanged after rebasing onto fresh main; the 144 focused tests passed again. Registry and generated Swift/Kotlin outputs are unchanged. Final rebased Codex review found no actionable P0–P2 issues.
- Final-head [CI run 34088125665](https://github.com/openclaw/openclaw/actions/runs/34088125665) passed for `420de7389f58dfc53bcd8d225768e888ee14983c`. Native review, hosted preparation, and merge passed; squash `99b5d76f9e29dd540c231f4897a7d761fb6fd384` is verified on main.

Production net -42 lines; tests unchanged. Existing public exports remain available; the protocol registry and generated Swift/Kotlin models are unchanged.
