### PR TITLE
refactor(ui): share request subscription cancellation

### DIFF
--- a/ui/src/lib/model-catalog-store.ts
+++ b/ui/src/lib/model-catalog-store.ts
@@ -2,6 +2,7 @@
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { ModelCatalogResult } from "../api/types.ts";
 import { invalidateChatMetadataStore } from "./chat/chat-metadata-store.ts";
+import { subscribeToSharedRequest } from "./shared-request-subscription.ts";
 
 const MODEL_CATALOG_CACHE_TTL_MS = 60_000;
 // A picker open is an operator signal to revalidate, but full provider discovery can be slow.
@@ -71,13 +72,13 @@ export async function loadModelCatalog(
     !pendingRequestAborted &&
     cached.inFlightRefresh === true
   ) {
-    return await subscribeToModelCatalogRequest(cached.inFlight, opts.signal);
+    return await subscribeToSharedRequest(cached.inFlight, {}, opts.signal);
   }
   if (!refresh && cached?.result && (cached.expiresAt > now || refreshCooldownActive)) {
     return cached.result;
   }
   if (cached?.inFlight && !pendingRequestAborted && (!refresh || cached.inFlightRefresh === true)) {
-    return await subscribeToModelCatalogRequest(cached.inFlight, opts.signal);
+    return await subscribeToSharedRequest(cached.inFlight, {}, opts.signal);
   }
 
   // The cache write happens here, gated on inFlight identity: a refresh call
@@ -140,44 +141,5 @@ export async function loadModelCatalog(
     inFlight,
     ...(refresh ? { inFlightRefresh: true } : {}),
   });
-  return await subscribeToModelCatalogRequest(inFlight, opts.signal);
-}
-
-async function subscribeToModelCatalogRequest(
-  pending: ModelCatalogPendingRequest,
-  signal: AbortSignal | undefined,
-): Promise<ModelCatalogResult> {
-  const subscriber = {};
-  pending.subscribers.add(subscriber);
-  if (!signal) {
-    try {
-      return await pending.promise;
-    } finally {
-      pending.subscribers.delete(subscriber);
-    }
-  }
-
-  let rejectAbort: (reason: unknown) => void = () => undefined;
-  const aborted = new Promise<never>((_resolve, reject) => {
-    rejectAbort = reject;
-  });
-  const onAbort = () => {
-    pending.subscribers.delete(subscriber);
-    // The request is shared: one retired page must not cancel another active
-    // consumer, while the final subscriber should stop the Gateway request.
-    if (pending.subscribers.size === 0) {
-      pending.controller?.abort(signal.reason);
-    }
-    rejectAbort(signal.reason);
-  };
-  signal.addEventListener("abort", onAbort, { once: true });
-  if (signal.aborted) {
-    onAbort();
-  }
-  try {
-    return await Promise.race([pending.promise, aborted]);
-  } finally {
-    signal.removeEventListener("abort", onAbort);
-    pending.subscribers.delete(subscriber);
-  }
+  return await subscribeToSharedRequest(inFlight, {}, opts.signal);
 }

--- a/ui/src/lib/shared-request-subscription.ts
+++ b/ui/src/lib/shared-request-subscription.ts
@@ -1,0 +1,41 @@
+/** Subscriber identity and producer cancellation remain owned by the caller. */
+export async function subscribeToSharedRequest<T, Subscriber extends object>(
+  pending: {
+    controller?: AbortController;
+    promise: Promise<T>;
+    subscribers: Set<Subscriber>;
+  },
+  subscriber: Subscriber,
+  signal?: AbortSignal,
+  onRelease?: () => void,
+): Promise<T> {
+  pending.subscribers.add(subscriber);
+  let onAbort: (() => void) | undefined;
+  try {
+    if (!signal) {
+      return await pending.promise;
+    }
+    let rejectAbort: (reason: unknown) => void = () => undefined;
+    const aborted = new Promise<never>((_resolve, reject) => {
+      rejectAbort = reject;
+    });
+    onAbort = () => {
+      pending.subscribers.delete(subscriber);
+      if (pending.subscribers.size === 0) {
+        pending.controller?.abort(signal.reason);
+      }
+      rejectAbort(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+    }
+    return await Promise.race([pending.promise, aborted]);
+  } finally {
+    if (onAbort) {
+      signal?.removeEventListener("abort", onAbort);
+    }
+    pending.subscribers.delete(subscriber);
+    onRelease?.();
+  }
+}

--- a/ui/src/pages/chat/route-loader-session-reference.ts
+++ b/ui/src/pages/chat/route-loader-session-reference.ts
@@ -10,6 +10,7 @@ import {
   normalizeAgentId,
   resolveUiConfiguredMainKey,
 } from "../../lib/sessions/session-key.ts";
+import { subscribeToSharedRequest } from "../../lib/shared-request-subscription.ts";
 import type { SessionRouteContext as ApplicationContext } from "./route-loader-context.ts";
 import {
   sessionReferenceResolution,
@@ -126,32 +127,10 @@ export async function querySessionReference(
     };
     cache.set(cacheKey, pending);
   }
-  pending.subscribers.add(signal);
   const shared = pending;
-  let rejectAbort: (reason: unknown) => void = () => undefined;
-  const aborted = new Promise<never>((_resolve, reject) => {
-    rejectAbort = reject;
-  });
-  const onAbort = () => {
-    shared.subscribers.delete(signal);
-    // A cancelled route cannot cancel another consumer's lookup; only the last
-    // subscriber abandons the producer and prevents a not-yet-started request.
-    if (shared.subscribers.size === 0) {
-      shared.controller.abort(signal.reason);
-    }
-    rejectAbort(signal.reason);
-  };
-  signal.addEventListener("abort", onAbort, { once: true });
-  if (signal.aborted) {
-    onAbort();
-  }
-  try {
-    return await Promise.race([shared.promise, aborted]);
-  } finally {
-    signal.removeEventListener("abort", onAbort);
-    shared.subscribers.delete(signal);
+  return await subscribeToSharedRequest(shared, signal, signal, () => {
     if (shared.subscribers.size === 0 && cache.get(cacheKey) === shared) {
       cache.delete(cacheKey);
     }
-  }
+  });
 }


### PR DESCRIPTION
## What Problem This Solves

Model catalog requests and session-reference lookups separately implement subscriber registration, per-consumer abort racing, last-member producer cancellation, and listener/member cleanup. Maintaining that cancellation boundary in two places makes it easier for one cancelled consumer to retire another consumer's work.

## Why This Change Was Made

`lib/shared-request-subscription.ts` now owns consumer subscription and cleanup. Callers choose their existing membership identity: a fresh object for each model catalog call, and the AbortSignal itself for route lookup. Route cache cleanup stays in the same synchronous final-cleanup step and retains its shared-request identity check. Production delta: +48/-66, net -18; tests unchanged.

## User Impact

No intended behavior change. Catalog callers without a signal remain members until completion. Catalog requests still forward their existing producer signal to `models.list`; route lookup still only prevents deferred startup and abandons cancelled consumers, without adding a signal to `sessions.resolve`. Abort reasons, cache TTL/cooldown, refresh fencing, and connection ownership are unchanged.

## Evidence

All 55 existing model-catalog, route-resolution, and route-handoff cases passed. UI build and explicit performance passed at 346474 B startup JavaScript gzip and 8 requests, with the baseline unchanged. Independent Codex review was clean through P2; `node scripts/check-changed.mjs` passed.

```sh
node scripts/run-vitest.mjs ui/src/lib/model-catalog-store.test.ts ui/src/pages/chat/route-resolution.test.ts ui/src/pages/chat/route-resolution-handoff.test.ts
```
 Source inspection found no current runtime caller intentionally starting concurrent reference lookups under one signal: the four `loadChatRoute` call sites are mutually exclusive or sequential, and the installed router coalesces same-match loads and creates a controller per navigation. The extraction nevertheless preserves signal-keyed membership exactly, including concurrent shared-signal calls. It does not change either owner's cancellation semantics.

This is the shared-request item in the maintainer-requested UI consolidation campaign. No configuration, wire, public SDK, or persistent-state changes.

Rebased onto freshly fetched main `61d957a9cb64bd8c70cc125e644778b3fb034c49`; full pre/post-rebase patches compare byte-identically. Current head: `a0f1a72319a268a25f9f14fc2642c269a5f873fe`. Focused local proof applies to that unchanged patch. Full `pnpm build` on this rebased head passed in 14m 20.4s, followed by the explicit performance check. [Hosted CI run 34086799540](https://github.com/openclaw/openclaw/actions/runs/34086799540) passed for the exact head. Native review artifacts are validated; prepare/merge use hosted-proof mode, without a separate Testbox lease.
