### PR TITLE
refactor(ui): derive exec approval editor wire types

### DIFF
--- a/ui/src/lib/nodes/index.ts
+++ b/ui/src/lib/nodes/index.ts
@@ -4,6 +4,10 @@
 import { getPublicKeyAsync, hashes, signAsync, utils } from "@noble/ed25519";
 import { gatewayCredentialScope } from "@openclaw/gateway-client/browser";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type {
+  ExecApprovalsNodeSnapshot as GatewayExecApprovalsNodeSnapshot,
+  ExecApprovalsSnapshot as GatewayExecApprovalsSnapshot,
+} from "../../../../packages/gateway-protocol/src/schema/exec-approvals.js";
 import type { DevicePairingList } from "../../../../src/gateway/device-pairing-list.types.js";
 import {
   type DeviceAuthEntry,
@@ -45,61 +49,40 @@ type NodesGatewaySnapshot = {
   connected: boolean;
 };
 
-export type ExecSecurity = "deny" | "allowlist" | "full";
-export type ExecAsk = "off" | "on-miss" | "always";
-type ExecApprovalsDefaults = {
-  security?: ExecSecurity;
-  ask?: ExecAsk;
-  askFallback?: ExecSecurity;
-  autoAllowSkills?: boolean;
-};
+type WireExecApprovalsFile = GatewayExecApprovalsSnapshot["file"];
+type WireExecApprovalsAgent = NonNullable<WireExecApprovalsFile["agents"]>[string];
 
-export type ExecApprovalsResolvedDefaults = Required<ExecApprovalsDefaults>;
+export type ExecApprovalsResolvedDefaults = NonNullable<
+  GatewayExecApprovalsSnapshot["resolvedDefaults"]
+>;
+export type ExecSecurity = ExecApprovalsResolvedDefaults["security"];
+export type ExecAsk = ExecApprovalsResolvedDefaults["ask"];
+// Editor choices stay closed even though the wire accepts policy strings for host normalization.
+type ExecApprovalsDefaults = Partial<ExecApprovalsResolvedDefaults>;
 
-export type ExecApprovalsAllowlistEntry = {
-  id?: string;
-  pattern: string;
-  source?: "allow-always";
-  commandText?: string;
-  argPattern?: string;
-  lastUsedAt?: number;
-  lastUsedCommand?: string;
-  lastResolvedPath?: string;
-};
+export type ExecApprovalsAllowlistEntry = NonNullable<WireExecApprovalsAgent["allowlist"]>[number];
 
-type ExecApprovalsAgent = ExecApprovalsDefaults & {
-  allowlist?: ExecApprovalsAllowlistEntry[];
-};
+type ExecApprovalsAgent = ExecApprovalsDefaults & Pick<WireExecApprovalsAgent, "allowlist">;
 
 export type ExecApprovalsFile = {
   version?: number;
-  socket?: { path?: string };
+  socket?: Pick<NonNullable<WireExecApprovalsFile["socket"]>, "path">;
   defaults?: ExecApprovalsDefaults;
   agents?: Record<string, ExecApprovalsAgent>;
 };
 
-type FileExecApprovalsSnapshot = {
-  path: string;
-  exists: boolean;
-  hash: string;
+type FileExecApprovalsSnapshot = Omit<GatewayExecApprovalsSnapshot, "file"> & {
   file: ExecApprovalsFile;
-  resolvedDefaults?: ExecApprovalsResolvedDefaults;
 };
 
-type NativeExecApprovalRule = {
-  pattern: string;
-  action: "allow" | "deny" | "prompt";
-  shells?: string[];
-  description?: string;
-  enabled?: boolean;
-};
+type NativeExecApprovalRule = NonNullable<GatewayExecApprovalsNodeSnapshot["rules"]>[number];
 
 export type NativeExecApprovalsSnapshot =
   | {
       enabled: true;
       hash: string;
       baseHash?: string;
-      defaultAction: "allow" | "deny" | "prompt";
+      defaultAction: NativeExecApprovalRule["action"];
       rules: NativeExecApprovalRule[];
       constraints?: Record<string, boolean>;
     }


### PR DESCRIPTION
## What Problem This Solves

The Dashboard independently repeats exec-approval fields already declared by the Gateway protocol, allowing its editor contract to drift from the response it consumes.

## Why This Change Was Made

The editor now derives resolved defaults, closed policy choices, allowlist entries, file snapshot metadata, and native rules from the existing schema-derived snapshot types. Imports are type-only.

The editable form remains a separate projection: its version is an optional number, its socket exposes only the path, policy choices remain closed, and it does not add typed MCP-tool editing. The native enabled/disabled discriminated union and its existing constraint representation remain explicit because the schema's runtime oneOf does not provide that static discrimination.

## User Impact

No behavior, UI appearance, policy, protocol, or persistence change. Existing exported UI type names remain available.

## Evidence

- `node scripts/run-vitest.mjs ui/src/lib/nodes/exec-approvals.test.ts ui/src/pages/devices/view.execution.test.ts`: 17 tests passed across two files. One existing Lit scheduling warning; no failures.
- TypeScript erasure produces byte-identical JavaScript (18,174 bytes). Formatting, focused lint, and diff checks passed.
- Independent Codex review found no actionable P0–P2 issues.
- Full `node scripts/check-changed.mjs`, `pnpm build` (15m16.1s), and `pnpm protocol:check` passed. Registry and generated Swift/Kotlin models are unchanged.
- Original-head [CI run 34086932162](https://github.com/openclaw/openclaw/actions/runs/34086932162) passed. Rebased onto fresh main including #140857, preserving both canonical type owners through the adjacent declaration/import conflict. The combined JavaScript remains byte-identical and all 17 focused tests passed again; final review found no actionable P0–P2 issues. The maintainer-authorized single failed-job rerun passed on the unchanged final head. Native preparation and merge completed; squash `a325c39220f1c114c61b1ce15d85dec603ba2d2d` is verified on main.
- After rebase, the typed-lint wrapper encountered the documented nested-checkout limitation: `Declaration input escapes checkout` through the ancestor installation. The earlier full changed check passed; final declaration-boundary proof remains with the required hosted gates. No ancestor install, check, timeout, or baseline was changed.

Production net -17 lines; tests unchanged. No public export removal or compatibility shim. The existing file-length exemption remains necessary under the 700-line production limit (excluding blanks/comments); the combined file has 996 physical lines and the unused-directive diagnostic passes. No ratchet was changed.


## CI recovery

Final-head [job checks-node-compact-small-16](https://github.com/openclaw/openclaw/actions/runs/34089292541/job/101639717649) failed `src/cli/update-dry-run-state.process.test.ts:186`: `keeps cleanup preview/refusal byte-identical (dryRun=false)`. The subprocess running `openclaw.mjs update cleanup --json` hit its existing 60,000 ms `spawnSync` timeout (`ETIMEDOUT`). That shard had 234 passing tests and one failure across seven files.

The required single local reproduction, `node scripts/run-vitest.mjs src/cli/update-dry-run-state.process.test.ts`, passed all 18 tests in the file. The wrapper first refreshed stale runtime artifacts in 1m11.2s; the test run took 53.86s (131.40s overall), so this is not a claim that the CI worker's environment was reproduced. All state/home/cache/temp paths were isolated synthetic fixtures.

The final PR diff changes only UI type declarations, with identical emitted runtime JavaScript. No timeout, assertion, mock, updater code, CI check, or baseline was changed. The initial campaign stop was followed by an explicit maintainer decision to rerun failed jobs exactly once. That single rerun passed on the unchanged head; no source or test repair was needed.


The only requested rerun was `gh run rerun 34089292541 --failed` with token environments unset. [Attempt 1](https://github.com/openclaw/openclaw/actions/runs/34089292541/attempts/1) failed; [attempt 2](https://github.com/openclaw/openclaw/actions/runs/34089292541/attempts/2) succeeded on `6d5a7daedc639502d11d857473b30a6745b3c446`. Required hosted checks are green, including the declaration-boundary proof unavailable in the nested local checkout.


Native merge admission initially stopped before intent on a PR/main observation race. After verifying no dispatch, recovering only the task-owned lock, and waiting for readiness, the bounded same-head retry succeeded. No additional CI retry or source change was made. [Native completion receipt](https://github.com/openclaw/openclaw/pull/140861#issuecomment-5566368053).
