### PR TITLE
fix: yield after costly session list preparation

### DIFF
--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -1,4 +1,5 @@
 // Read-only session queries.
+import { performance } from "node:perf_hooks";
 import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -247,6 +248,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
             rowRepairAttempted?: boolean;
           } = {},
         ): Promise<Awaited<ReturnType<typeof listSessionsFromStoreAsync>>> {
+          const workStartedAt = performance.now();
           let loaded = options.loaded;
           if (!loaded) {
             const loadedStore = measureDiagnosticsTimelineSpanSync(
@@ -278,6 +280,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
             () =>
               listSessionsFromStoreAsync({
                 cfg,
+                workStartedAt,
                 durableStorePath,
                 ...(entryFilter ? { entryFilter } : {}),
                 storePath,

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -1,4 +1,5 @@
 import { performance } from "node:perf_hooks";
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import { expectDefined } from "@openclaw/normalization-core";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -571,7 +572,7 @@ export function filterAndSortSessionEntries(
 
 /** Projects lightweight list rows while sharing the event loop with other requests. */
 export async function listSessionsFromStoreAsync(
-  params: ListSessionsFromStoreParams,
+  params: ListSessionsFromStoreParams & { workStartedAt?: number },
 ): Promise<SessionsListResult> {
   // Pin the active plugin-registry workspace dir for the duration of this
   // call so per-row metadata lookups use a stable memo key. Without this pin,
@@ -579,7 +580,7 @@ export async function listSessionsFromStoreAsync(
   // between rows, the memo never hits, and each row triggers a full
   // loadPluginMetadataSnapshot scan (~100 ms).
   return withPinnedActivePluginRegistryWorkspaceDir(async () => {
-    let workStartedAt = performance.now();
+    let workStartedAt = params.workStartedAt ?? performance.now();
     const { cfg, store, targetsBySessionKey } = params;
     const list = prepareSessionList(params);
     const sessions: GatewaySessionRow[] = [];
@@ -599,6 +600,12 @@ export async function listSessionsFromStoreAsync(
         ];
       });
     const transcriptFields = readScopedSessionTitleFieldsFromTranscriptBatch(transcriptScopes);
+    // Consume synchronous sharing facts and capture transcripts before yielding.
+    // Loading and preparation can spend the budget even for zero or one row.
+    if (performance.now() - workStartedAt >= SESSIONS_LIST_YIELD_INTERVAL_MS) {
+      await yieldToEventLoop();
+      workStartedAt = performance.now();
+    }
     let transcriptFieldIndex = 0;
     for (let i = 0; i < list.entries.length; i++) {
       const [key, entry] = expectDefined(list.entries[i], "entries entry at i");
@@ -642,9 +649,7 @@ export async function listSessionsFromStoreAsync(
         i + 1 < list.entries.length &&
         performance.now() - workStartedAt >= SESSIONS_LIST_YIELD_INTERVAL_MS
       ) {
-        await new Promise<void>((resolve) => {
-          setImmediate(resolve);
-        });
+        await yieldToEventLoop();
         // Waiting behind other work is not projection work; start the next budget on resume.
         workStartedAt = performance.now();
       }

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -85,6 +85,15 @@ describe("session list resolver cache", () => {
       limit: 1,
       shouldYield: true,
     },
+    {
+      name: "one row after expensive store loading",
+      rowWorkMs: 0,
+      storeWorkMs: 20,
+      preparationWorkMs: 0,
+      keepRows: true,
+      limit: 1,
+      shouldYield: true,
+    },
   ])(
     "shares the event loop for $name",
     async ({ rowWorkMs, storeWorkMs, preparationWorkMs, keepRows, limit, shouldYield }) => {

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -40,11 +40,54 @@ import * as rowProjection from "./session-utils-row.js";
  */
 describe("session list resolver cache", () => {
   test.each([
-    { rowWorkMs: 0, shouldYield: false },
-    { rowWorkMs: 20, shouldYield: true },
+    {
+      name: "cheap rows",
+      rowWorkMs: 0,
+      storeWorkMs: 0,
+      preparationWorkMs: 0,
+      keepRows: true,
+      limit: 100,
+      shouldYield: false,
+    },
+    {
+      name: "expensive rows",
+      rowWorkMs: 20,
+      storeWorkMs: 0,
+      preparationWorkMs: 0,
+      keepRows: true,
+      limit: 100,
+      shouldYield: true,
+    },
+    {
+      name: "one row after expensive preparation",
+      rowWorkMs: 0,
+      storeWorkMs: 0,
+      preparationWorkMs: 1,
+      keepRows: true,
+      limit: 1,
+      shouldYield: true,
+    },
+    {
+      name: "an empty page after expensive preparation",
+      rowWorkMs: 0,
+      storeWorkMs: 0,
+      preparationWorkMs: 1,
+      keepRows: false,
+      limit: 1,
+      shouldYield: true,
+    },
+    {
+      name: "one row after combined loading and preparation",
+      rowWorkMs: 0,
+      storeWorkMs: 8,
+      preparationWorkMs: 0.25,
+      keepRows: true,
+      limit: 1,
+      shouldYield: true,
+    },
   ])(
-    "yields for row work rather than row count ($rowWorkMs ms)",
-    async ({ rowWorkMs, shouldYield }) => {
+    "shares the event loop for $name",
+    async ({ rowWorkMs, storeWorkMs, preparationWorkMs, keepRows, limit, shouldYield }) => {
       await withStateDirEnv("openclaw-list-work-budget-", async ({ stateDir }) => {
         resetPluginRuntimeStateForTest();
         setActivePluginRegistry(createEmptyPluginRegistry());
@@ -57,7 +100,8 @@ describe("session list resolver cache", () => {
             { sessionId: `budget-${index}`, updatedAt: index + 1 },
           ]),
         );
-        let workMs = 0;
+        let workMs = storeWorkMs;
+        let controlBeforePreparation: boolean | undefined;
         const buildRow = rowProjection.buildGatewaySessionRow;
         const clock = vi.spyOn(performance, "now").mockImplementation(() => workMs);
         const rows = vi
@@ -77,12 +121,21 @@ describe("session list resolver cache", () => {
         try {
           const result = await listSessionFixture({
             cfg,
+            workStartedAt: 0,
             storePath: path.join(stateDir, "sessions.json"),
             store,
-            opts: {},
+            entryFilter: () => {
+              controlBeforePreparation ??= controlRan;
+              workMs += preparationWorkMs;
+              return keepRows;
+            },
+            opts: { limit },
           });
-          expect(result.sessions.map((row) => row.key)).toEqual(Object.keys(store).toReversed());
+          expect(result.sessions.map((row) => row.key)).toEqual(
+            keepRows ? Object.keys(store).toReversed().slice(0, limit) : [],
+          );
           expect(controlRan).toBe(shouldYield);
+          expect(controlBeforePreparation).toBe(false);
         } finally {
           rows.mockRestore();
           clock.mockRestore();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where loading a filtered Activity session list could keep other Gateway work waiting after expensive preparation, even when the resulting page contained only one row or no rows.

## Why This Change Was Made

Carry the existing 12 ms work budget from store loading through list preparation, then yield after synchronous selection and transcript capture when that budget is spent. This preserves the sharing facts' synchronous lifetime, workspace pin, transcript read order, and fresh selected-row authorization checks. The underlying store load and preparation remain atomic synchronous phases.

## User Impact

Other Gateway work gets an event-loop opportunity before row projection after costly preparation. Cheap lists retain their existing behavior. This is a cooperative fairness improvement; it does not promise a 12 ms maximum stall or reduce the underlying SQLite work.

## Evidence

- Final regression table: four expected failures on unchanged production code, two existing row cases passing, then all six cases passing with the repair. The loading-only case also proves that visibility filtering starts before the queued callback.
- Linux Node 26.7: the unchanged production diff passed 103 tests across eight focused suites covering the work budget, visibility refresh, response-cache invalidation, catalog scope, transcript ownership, plugin runtime, and single-row projections.
- Native canonical-writer proof kept retained shallow-copied session metadata stable across entry replacement and participant/owner updates. A separate real lifecycle listener/event-bus/index projection proof preserved late-bound run start timestamps.
- Ordinary production build and loopback Gateway RPC flow passed with synthetic sessions, ordinary metadata mutations before measured calls, four list shapes, 12 measured list requests, 80 concurrent successful health requests, and clean Gateway/seeder shutdown. Request latency remained similar to baseline; no overall speedup claim is made.
- Independent autoreview through P2: no actionable findings, including the final test-only extension. All 29 changed-file checks passed before that extension; [final exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34088725588) passed.

Production delta: +8 lines for carrying the existing work clock and the additional checkpoint; tests: +62 net lines extending the existing behavioral table.
