### PR TITLE
fix(macos): align menu cost totals with local days

### DIFF
--- a/apps/macos/Sources/OpenClaw/CostUsageMenuView.swift
+++ b/apps/macos/Sources/OpenClaw/CostUsageMenuView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct CostUsageHistoryMenuView: View {
     let summary: GatewayCostUsageSummary
+    let dates: CostUsageMenuDateParser
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -10,13 +11,14 @@ struct CostUsageHistoryMenuView: View {
             self.chart
             self.footer
         }
+        .environment(\.timeZone, self.dates.timeZone)
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var header: some View {
-        let todayKey = CostUsageMenuDateParser.format(Date())
+        let todayKey = self.dates.format(Date())
         let todayEntry = self.summary.daily.first { $0.date == todayKey }
         let todayCost = CostUsageFormatting.formatUsd(todayEntry?.totalCost) ?? "n/a"
         let totalCost = CostUsageFormatting.formatUsd(self.summary.totals.totalCost) ?? "n/a"
@@ -42,7 +44,7 @@ struct CostUsageHistoryMenuView: View {
 
     private var chart: some View {
         let entries = self.summary.daily.compactMap { entry -> (Date, Double)? in
-            guard let date = CostUsageMenuDateParser.parse(entry.date) else { return nil }
+            guard let date = self.dates.parse(entry.date) else { return nil }
             return (date, entry.totalCost)
         }
 
@@ -78,23 +80,5 @@ struct CostUsageHistoryMenuView: View {
                 self.summary.totals.missingCostEntries))
                 .font(.caption2)
                 .foregroundStyle(.secondary))
-    }
-}
-
-private enum CostUsageMenuDateParser {
-    static let formatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone.current
-        return formatter
-    }()
-
-    static func parse(_ value: String) -> Date? {
-        self.formatter.date(from: value)
-    }
-
-    static func format(_ date: Date) -> String {
-        self.formatter.string(from: date)
     }
 }

--- a/apps/macos/Sources/OpenClaw/StatusMenuSummaries.swift
+++ b/apps/macos/Sources/OpenClaw/StatusMenuSummaries.swift
@@ -16,7 +16,7 @@ final class StatusMenuSummaries: NSObject {
         let revision: UInt64?
         var lease: GatewayConnection.ServerLease?
         var usage: GatewayUsageSummary?
-        var cost: GatewayCostUsageSummary?
+        var cost: (summary: GatewayCostUsageSummary, dates: CostUsageMenuDateParser)?
         var costError: String?
         var usageUpdatedAt: Date?
         var costUpdatedAt: Date?
@@ -56,7 +56,7 @@ final class StatusMenuSummaries: NSObject {
         self.currentUsageState?.usage
     }
 
-    private var cachedCost: GatewayCostUsageSummary? {
+    private var cachedCost: (summary: GatewayCostUsageSummary, dates: CostUsageMenuDateParser)? {
         self.currentUsageState?.cost
     }
 
@@ -214,14 +214,15 @@ final class StatusMenuSummaries: NSObject {
             entries.append(.info(id: "usage.loading", title: String(localized: "Loading usage…")))
         }
 
-        if let summary = self.cachedCost, !summary.daily.isEmpty {
+        if let cost = self.cachedCost, !cost.summary.daily.isEmpty {
             if !entries.isEmpty {
                 entries.append(.separator(id: "usage.cost.separator"))
             }
             entries.append(MenuEntry(id: "usage.cost.chart") { item in
                 item.title = String(localized: "Usage cost (30 days)")
                 item.isEnabled = false
-                StatusMenuRenderer.configureHostedView(item, rootView: CostUsageHistoryMenuView(summary: summary))
+                StatusMenuRenderer.configureHostedView(
+                    item, rootView: CostUsageHistoryMenuView(summary: cost.summary, dates: cost.dates))
             })
         } else if let error = self.costError {
             if !entries.isEmpty {
@@ -417,10 +418,12 @@ final class StatusMenuSummaries: NSObject {
     private func loadCost(_ refresh: Refresh, enabled: Bool) async {
         guard enabled, self.isCurrent(refresh), let lease = refresh.lease else { return }
         do {
+            let dates = CostUsageMenuDateParser(timeZone: .current)
             let data = try await self.control.request(
-                method: "usage.cost", timeoutMs: 7000, ifCurrentServerLease: lease)
+                method: "usage.cost", params: dates.requestParameters, timeoutMs: 7000, ifCurrentServerLease: lease)
             guard self.isCurrent(refresh) else { return }
-            self.usageState?.cost = try JSONDecoder().decode(GatewayCostUsageSummary.self, from: data)
+            // Cached buckets retain the request's day boundaries if the Mac changes time zones.
+            self.usageState?.cost = try (JSONDecoder().decode(GatewayCostUsageSummary.self, from: data), dates)
             self.usageState?.costError = nil
             self.usageState?.costUpdatedAt = Date()
         } catch {

--- a/apps/macos/Sources/OpenClaw/UsageCostData.swift
+++ b/apps/macos/Sources/OpenClaw/UsageCostData.swift
@@ -50,3 +50,32 @@ enum CostUsageFormatting {
         return String(format: "$%.4f", value)
     }
 }
+
+struct CostUsageMenuDateParser {
+    let timeZone: TimeZone
+    private let formatter: DateFormatter
+
+    init(timeZone: TimeZone) {
+        self.timeZone = timeZone
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = timeZone
+        self.formatter = formatter
+    }
+
+    var requestParameters: [String: AnyHashable] {
+        // Older Gateway tzdata can use the existing fixed-offset contract for an unknown zone.
+        let minutes = self.timeZone.secondsFromGMT() / 60
+        let offset = String(format: "UTC%@%d:%02d", minutes < 0 ? "-" : "+", abs(minutes) / 60, abs(minutes) % 60)
+        return ["mode": "specific", "timeZone": self.timeZone.identifier, "utcOffset": offset]
+    }
+
+    func parse(_ value: String) -> Date? {
+        self.formatter.date(from: value)
+    }
+
+    func format(_ date: Date) -> String {
+        self.formatter.string(from: date)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/StatusMenuSummariesTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/StatusMenuSummariesTests.swift
@@ -211,13 +211,12 @@ private final class UsageGatewayFixture {
                 guard let frame = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                       let method = frame["method"] as? String else { return }
                 let requestParams = frame["params"] as? [String: Any]
-                requests.withValue {
-                    $0.append(Request(
-                        owner: owner,
-                        method: method,
-                        dateMode: requestParams?["mode"] as? String,
-                        timeZone: requestParams?["timeZone"] as? String))
-                }
+                let request = Request(
+                    owner: owner,
+                    method: method,
+                    dateMode: requestParams?["mode"] as? String,
+                    timeZone: requestParams?["timeZone"] as? String)
+                requests.withValue { $0.append(request) }
                 let payload: String
                 switch method {
                 case "usage.status":

--- a/apps/macos/Tests/OpenClawIPCTests/StatusMenuSummariesTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/StatusMenuSummariesTests.swift
@@ -48,6 +48,15 @@ struct StatusMenuSummariesTests {
         }
     }
 
+    @Test func `cost requests use the Mac time zone`() async throws {
+        try await self.withFixture { fixture in
+            try await fixture.populate()
+            let request = try #require(fixture.requests.value.first { $0.method == "usage.cost" })
+            #expect(request.dateMode == "specific")
+            #expect(request.timeZone == TimeZone.current.identifier)
+        }
+    }
+
     @Test
     func `retiring a Gateway invalidates the observed usage cache`() async throws {
         try await self.withFixture { fixture in
@@ -171,6 +180,8 @@ private final class UsageGatewayFixture {
     struct Request: Sendable {
         let owner: String
         let method: String
+        let dateMode: String?
+        let timeZone: String?
     }
 
     let revision = LockIsolated<UInt64>(1)
@@ -199,7 +210,14 @@ private final class UsageGatewayFixture {
                 }
                 guard let frame = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                       let method = frame["method"] as? String else { return }
-                requests.withValue { $0.append(Request(owner: owner, method: method)) }
+                let requestParams = frame["params"] as? [String: Any]
+                requests.withValue {
+                    $0.append(Request(
+                        owner: owner,
+                        method: method,
+                        dateMode: requestParams?["mode"] as? String,
+                        timeZone: requestParams?["timeZone"] as? String))
+                }
                 let payload: String
                 switch method {
                 case "usage.status":

--- a/apps/macos/Tests/OpenClawIPCTests/UsageCostDataTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/UsageCostDataTests.swift
@@ -147,4 +147,34 @@ struct UsageCostDataTests {
     func `USD precision follows the one-cent boundary`(_ value: Double?, _ expected: String?) {
         #expect(CostUsageFormatting.formatUsd(value) == expected)
     }
+
+    @Test(arguments: [
+        ("America/Los_Angeles", "2026-09-07T01:00:00Z", "2026-09-06", "2026-09-06T07:00:00Z"),
+        ("Asia/Tokyo", "2026-09-07T23:00:00Z", "2026-09-08", "2026-09-07T15:00:00Z"),
+        ("Etc/UTC", "2026-09-07T01:00:00Z", "2026-09-07", "2026-09-07T00:00:00Z"),
+        ("America/Los_Angeles", "2026-03-08T23:00:00Z", "2026-03-08", "2026-03-08T08:00:00Z"),
+        ("America/Los_Angeles", "2026-11-01T23:00:00Z", "2026-11-01", "2026-11-01T07:00:00Z"),
+    ])
+    func `cost request and display use the same local day`(
+        zone: String, timestamp: String, day: String, midnight: String) throws
+    {
+        let dates = try CostUsageMenuDateParser(timeZone: #require(TimeZone(identifier: zone)))
+        let iso = ISO8601DateFormatter()
+        let now = try #require(iso.date(from: timestamp))
+        #expect(dates.requestParameters["mode"] == AnyHashable("specific"))
+        #expect(dates.requestParameters["timeZone"] == AnyHashable(zone))
+        #expect(dates.format(now) == day)
+        #expect(dates.parse(day) == iso.date(from: midnight))
+    }
+
+    @Test(arguments: [
+        (-720, "UTC-12:00"), (-210, "UTC-3:30"), (0, "UTC+0:00"),
+        (330, "UTC+5:30"), (345, "UTC+5:45"), (765, "UTC+12:45"), (840, "UTC+14:00"),
+    ])
+    func `cost requests include a fixed offset for older Gateway timezone data`(
+        minutes: Int, expected: String) throws
+    {
+        let dates = try CostUsageMenuDateParser(timeZone: #require(TimeZone(secondsFromGMT: minutes * 60)))
+        #expect(dates.requestParameters["utcOffset"] == AnyHashable(expected))
+    }
 }

--- a/docs/platforms/mac/menu-bar.md
+++ b/docs/platforms/mac/menu-bar.md
@@ -11,7 +11,7 @@ title: "Menu bar"
 - Health status is hidden while work is active; it returns once all sessions are idle.
 - A root "Context" item opens a submenu with recent sessions instead of expanding them in the root menu.
 - A "Devices" block in the root menu lists paired **devices** only (from `node.list`), not client/presence entries.
-- A root "Usage" section appears below Context when provider usage snapshots are available, followed by cost details when available.
+- A root "Usage" section appears below Context when provider usage snapshots are available, followed by cost details when available. Cost totals for **Today** and the daily chart use the Mac’s local time zone.
 - When two or more Gateways are available, the first status row includes the primary Gateway name and a root "Gateways" section lists every Gateway with its health and primary marker. Select a row to open or focus that Gateway's dashboard; hold Option to reveal "Set as Primary…" for eligible saved Gateways.
 - **Quick Chat** opens the floating main-session composer; its current global shortcut appears beside the item.
 - **Settings…** (Cmd-,) opens Dashboard settings. App and device preferences live under **This Mac**, voice controls under **Talk**, and app update preferences under **Updates**.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Mac users would see another day's spending or **n/a** in the menu's **Today** cost total when the local date differed from UTC. Daily cost ranges also used 24-hour UTC days across local daylight-saving transitions.

## Why This Change Was Made

Request cost buckets in the Mac's local time zone using the existing Gateway API, including its UTC-offset fallback for older Gateway timezone data. Keep the requested date formatter with the cached response so Today and chart labels use the same day boundaries. This replaces the process-global formatter without adding configuration or changing the wire schema.

## User Impact

The menu's Today total and daily chart use local calendar days, including 23- and 25-hour daylight-saving days. Gateways that do not recognize a newer client timezone can still return costs through the existing fixed-offset fallback.

## Evidence

- Compiled native request-method and wire-model proof failed before the change and passes afterward. At `2026-09-07T01:00Z`, the Los Angeles display and server now agree on September 6; the Tokyo midnight case also matches.
- Eight Foundation tests covering 65 cases pass, including five local/UTC/DST cases and seven whole-, half-, and quarter-hour offsets. The new offset cases failed before the compatibility correction.
- The actual server date resolver accepts the native serialized parameters, preserves IANA timezone precedence, and handles the synthetic unsupported-zone fallback. This is isolated boundary proof; no live pair of mismatched timezone databases was used.
- Swift 6 cost view/model typechecking, pinned SwiftFormat and SwiftLint checks on all five changed Swift files, and P0–P2 autoreview pass. The [initial native CI run](https://github.com/openclaw/openclaw/actions/runs/34086866482) caught a non-Sendable JSON dictionary captured in the new test fixture. The correction constructs the existing Sendable request record before the lock closure; an exact pinned-dependency Swift 6 reproduction now compiles and preserves the wire fields. The [corrected exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/34088766421) passed, including both changed suites, 2,082 default native tests, two isolation tests, and 1,674 shared-package tests.

The change affects date/data behavior without redesigning the menu's appearance. Production delta is +16 lines, with +47 test lines; the added ownership keeps cached data and its date interpretation together.
