### PR TITLE
fix(skills): preserve Workshop routing descriptions

### DIFF
--- a/src/agents/tools/skill-workshop-tool-helpers.ts
+++ b/src/agents/tools/skill-workshop-tool-helpers.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { autonomousSkillSizeError } from "../../skills/workshop/collection-contracts.js";
 import {
   readProposalFrontmatter,
+  resolveDraftedSkillDescription,
   resolveSkillProposalName,
   stripProposalFrontmatterForSkill,
 } from "../../skills/workshop/frontmatter.js";
@@ -28,9 +29,15 @@ export function assertAutonomousSkillSize(
   currentContent: string | undefined,
   maxSkillBytes: number,
 ): void {
+  const label = description ?? readProposalFrontmatter(currentContent ?? "")?.description ?? name;
   const draft = prepareSkillProposalDraft({
     name,
-    description: description ?? readProposalFrontmatter(currentContent ?? "")?.description ?? name,
+    description: label,
+    skillDescription: resolveDraftedSkillDescription({
+      content,
+      ...(currentContent ? { fallbackContent: currentContent } : {}),
+      label,
+    }),
     content,
     fallbackFrontmatterContent: currentContent,
     date: new Date().toISOString(),

--- a/src/skills/workshop/frontmatter.test.ts
+++ b/src/skills/workshop/frontmatter.test.ts
@@ -64,4 +64,27 @@ describe("workshop proposal frontmatter", () => {
       }),
     ).toBe("Short listing label");
   });
+
+  it("prefers an explicitly revised description over previously rendered content", () => {
+    const explicitDescription = "Explicitly revised description";
+    expect(
+      resolveDraftedSkillDescription({
+        content: "---\nname: rich-skill\ndescription: Stale rendered description\n---\n\n# Body\n",
+        fallbackContent:
+          "---\nname: rich-skill\ndescription: Older live description\n---\n\n# Old\n",
+        label: "Short listing label",
+        explicitDescription,
+      }),
+    ).toBe(explicitDescription);
+    // Without an explicit revision the previously rendered content still wins,
+    // so body-only revisions keep the prior description instead of the label.
+    expect(
+      resolveDraftedSkillDescription({
+        content: "# Body only\n",
+        fallbackContent:
+          "---\nname: rich-skill\ndescription: Prior rich description\n---\n\n# Old\n",
+        label: "Short listing label",
+      }),
+    ).toBe("Prior rich description");
+  });
 });

--- a/src/skills/workshop/frontmatter.test.ts
+++ b/src/skills/workshop/frontmatter.test.ts
@@ -1,6 +1,10 @@
 // Workshop frontmatter tests cover proposal markdown extraction and stripping.
 import { describe, expect, it } from "vitest";
-import { renderProposalMarkdown, stripProposalFrontmatterForSkill } from "./frontmatter.js";
+import {
+  renderProposalMarkdown,
+  resolveDraftedSkillDescription,
+  stripProposalFrontmatterForSkill,
+} from "./frontmatter.js";
 
 describe("workshop proposal frontmatter", () => {
   it("preserves dash-prefixed Markdown when rendering proposals", () => {
@@ -19,5 +23,45 @@ describe("workshop proposal frontmatter", () => {
     expect(stripProposalFrontmatterForSkill("---not\nname: nope\n---not\n# Body\n")).toBe(
       "---not\nname: nope\n---not\n# Body\n",
     );
+  });
+
+  it("renders the resolved skill description without duplicating kept frontmatter", () => {
+    const richDescription =
+      "Route requests through the vendor intake protocol: trigger phrases, keywords, and example calls that exceed the label budget";
+    const rendered = renderProposalMarkdown({
+      name: "rich-skill",
+      description: richDescription,
+      content: `---\nname: rich-skill\ndescription: ${richDescription}\n---\n\n# Body\n`,
+      date: "2026-07-07T00:00:00.000Z",
+    });
+
+    expect(rendered.match(/description:/g)).toHaveLength(1);
+    expect(rendered).toContain(richDescription);
+    expect(stripProposalFrontmatterForSkill(rendered)).toContain(richDescription);
+  });
+
+  it("resolves the drafted description from content before the live fallback and label", () => {
+    const contentDescription = "Description drafted in the proposal content";
+    const liveDescription = "Live skill description with trigger phrases and keywords";
+    expect(
+      resolveDraftedSkillDescription({
+        content: `---\nname: rich-skill\ndescription: ${contentDescription}\n---\n\n# Body\n`,
+        fallbackContent: `---\nname: rich-skill\ndescription: ${liveDescription}\n---\n\n# Old\n`,
+        label: "Short listing label",
+      }),
+    ).toBe(contentDescription);
+    expect(
+      resolveDraftedSkillDescription({
+        content: "# Body only\n",
+        fallbackContent: `---\nname: rich-skill\ndescription: ${liveDescription}\n---\n\n# Old\n`,
+        label: "Short listing label",
+      }),
+    ).toBe(liveDescription);
+    expect(
+      resolveDraftedSkillDescription({
+        content: "# Body only\n",
+        label: "Short listing label",
+      }),
+    ).toBe("Short listing label");
   });
 });

--- a/src/skills/workshop/frontmatter.ts
+++ b/src/skills/workshop/frontmatter.ts
@@ -139,8 +139,15 @@ export function resolveDraftedSkillDescription(params: {
   content: string;
   fallbackContent?: string;
   label: string;
+  /**
+   * A description the caller explicitly supplied for this revision. It wins over
+   * any description still carried by previously rendered content, so an explicit
+   * description-only revision reaches the applied skill file.
+   */
+  explicitDescription?: string;
 }): string {
   return (
+    params.explicitDescription ??
     extractFrontmatterDescription(params.content) ??
     extractFrontmatterDescription(params.fallbackContent) ??
     params.label

--- a/src/skills/workshop/frontmatter.ts
+++ b/src/skills/workshop/frontmatter.ts
@@ -25,6 +25,7 @@ function yamlScalar(value: string): string {
 /** Renders proposal markdown while preserving allowed original frontmatter fields. */
 export function renderProposalMarkdown(params: {
   name: string;
+  /** Description apply writes into SKILL.md frontmatter — not the listing label. */
   description: string;
   content: string;
   fallbackFrontmatterContent?: string;
@@ -112,6 +113,38 @@ function filterFrontmatterBlock(block: string, keysToDrop: readonly string[]): s
   }
 
   return kept.join("\n").trim();
+}
+
+function extractFrontmatterDescription(content: string | undefined): string | undefined {
+  if (!content) {
+    return undefined;
+  }
+  try {
+    const description = parseSkillFrontmatter(content).description;
+    const trimmed = description?.trim();
+    return trimmed ? trimmed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolves the description that apply writes into SKILL.md frontmatter.
+ *
+ * The proposal listing label never replaces the skill description: the drafted
+ * content (or the current live skill, when the draft is body-only) stays
+ * authoritative, and the label is only proposal listing metadata.
+ */
+export function resolveDraftedSkillDescription(params: {
+  content: string;
+  fallbackContent?: string;
+  label: string;
+}): string {
+  return (
+    extractFrontmatterDescription(params.content) ??
+    extractFrontmatterDescription(params.fallbackContent) ??
+    params.label
+  );
 }
 
 function normalizeNewlines(content: string): string {

--- a/src/skills/workshop/proposal-draft.test.ts
+++ b/src/skills/workshop/proposal-draft.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { stripProposalFrontmatterForSkill } from "./frontmatter.js";
 import {
   nextProposalVersion,
   prepareSkillProposalDraft,
@@ -10,6 +11,7 @@ describe("Skill Workshop proposal draft preparation", () => {
     const prepared = prepareSkillProposalDraft({
       name: "release-check",
       description: "Check a release",
+      skillDescription: "Check a release",
       content: "# Release Check\n",
       date: "2026-07-29T00:00:00.000Z",
       maxSkillBytes: 1024,
@@ -45,6 +47,7 @@ describe("Skill Workshop proposal draft preparation", () => {
     const oversized = prepareSkillProposalDraft({
       name: "release-check",
       description: "Check a release",
+      skillDescription: "Check a release",
       content: "x".repeat(5),
       date: "2026-07-29T00:00:00.000Z",
       maxSkillBytes: 4,
@@ -59,6 +62,7 @@ describe("Skill Workshop proposal draft preparation", () => {
     const secret = prepareSkillProposalDraft({
       name: "release-check",
       description: "Check a release",
+      skillDescription: "Check a release",
       content: "# Release Check\n",
       date: "2026-07-29T00:00:00.000Z",
       maxSkillBytes: 1024,
@@ -75,6 +79,30 @@ describe("Skill Workshop proposal draft preparation", () => {
         message: expect.stringContaining("recognized literal credential in skill-name"),
       },
     });
+  });
+
+  it("separates the bounded listing label from the rendered skill description", () => {
+    const richDescription =
+      "Full routing description with trigger phrases, keywords, and example invocations beyond the label budget";
+    const prepared = prepareSkillProposalDraft({
+      name: "rich-skill",
+      description: "Short listing label",
+      skillDescription: richDescription,
+      content: "# Rich Skill\n",
+      date: "2026-07-29T00:00:00.000Z",
+      maxSkillBytes: 4096,
+    });
+
+    expect(prepared).toMatchObject({
+      ok: true,
+      value: { description: "Short listing label" },
+    });
+    if (!prepared.ok) {
+      throw prepared.error.cause;
+    }
+    expect(prepared.value.content).toContain(richDescription);
+    expect(prepared.value.content).not.toContain("Short listing label");
+    expect(stripProposalFrontmatterForSkill(prepared.value.content)).toContain(richDescription);
   });
 
   it("preserves version and UTF-8 description behavior", () => {

--- a/src/skills/workshop/proposal-draft.ts
+++ b/src/skills/workshop/proposal-draft.ts
@@ -43,6 +43,7 @@ type PreparedSkillProposalDraft = {
 export function prepareSkillProposalDraft(input: {
   name: string;
   description: string;
+  skillDescription: string;
   content: string;
   fallbackFrontmatterContent?: string;
   version?: string;
@@ -59,7 +60,7 @@ export function prepareSkillProposalDraft(input: {
     const supportFiles = prepareSkillProposalSupportFiles(input.supportFiles);
     const content = renderProposalMarkdown({
       name: input.name,
-      description: input.description,
+      description: input.skillDescription,
       content: input.content,
       fallbackFrontmatterContent: input.fallbackFrontmatterContent,
       version: input.version,
@@ -70,6 +71,7 @@ export function prepareSkillProposalDraft(input: {
     const scan = scanProposalBundle(content, supportFiles, [
       ...(input.secretScanMetadata ?? []),
       { file: "description", content: input.description },
+      { file: "skill-description", content: input.skillDescription },
       { file: "goal", content: goal },
       { file: "evidence", content: evidence },
     ]);

--- a/src/skills/workshop/service-propose.ts
+++ b/src/skills/workshop/service-propose.ts
@@ -5,7 +5,7 @@ import {
   readWorkspaceSupportFile,
 } from "../lifecycle/workspace-skill-write.js";
 import { resolveSkillWorkshopConfig } from "./config.js";
-import { stripProposalFrontmatterForSkill } from "./frontmatter.js";
+import { resolveDraftedSkillDescription, stripProposalFrontmatterForSkill } from "./frontmatter.js";
 import { createSkillProposalEvent, dispatchSkillProposalChanged } from "./plugin-hooks.js";
 import { prepareSkillProposalDraft, resolveUpdateProposalDescription } from "./proposal-draft.js";
 import { createSkillProposalGenerationDraftFile } from "./proposal-generation.js";
@@ -100,6 +100,10 @@ export async function proposeCreateSkill(
     draft: {
       name: target.skillKey,
       description,
+      skillDescription: resolveDraftedSkillDescription({
+        content: input.content,
+        label: description,
+      }),
       content: input.content,
       secretScanMetadata: [{ file: "skill-name", content: name }],
     },
@@ -183,6 +187,11 @@ export async function proposeUpdateSkill(
     draft: {
       name: target.skillName,
       description,
+      skillDescription: resolveDraftedSkillDescription({
+        content: draftContent,
+        fallbackContent: currentContent,
+        label: description,
+      }),
       content: draftContent,
       fallbackFrontmatterContent: currentContent,
     },
@@ -206,7 +215,12 @@ async function createPendingSkillProposal(
     target: SkillProposalRecord["target"];
     draft: Pick<
       Parameters<typeof prepareSkillProposalDraft>[0],
-      "name" | "description" | "content" | "fallbackFrontmatterContent" | "secretScanMetadata"
+      | "name"
+      | "description"
+      | "skillDescription"
+      | "content"
+      | "fallbackFrontmatterContent"
+      | "secretScanMetadata"
     >;
   },
 ): Promise<SkillProposalReadResult> {

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -1484,6 +1484,58 @@ describe("skill workshop proposals", () => {
     ).rejects.toThrow("proposal description is too large");
   });
 
+  it("preserves the live skill description when update proposals are applied", async () => {
+    const workspaceDir = await makeWorkspace();
+    const richDescription = `${"y".repeat(200)} plus trigger phrases and keywords`;
+    const skillDir = await createOwnedSkill({
+      workspaceDir,
+      name: "rich-description-skill",
+      description: "Initial description",
+      body: "# Rich Description Skill\n\nExisting body.\n",
+    });
+    const skillFile = path.join(skillDir, "SKILL.md");
+    await fs.writeFile(
+      skillFile,
+      `---\nname: rich-description-skill\ndescription: ${richDescription}\n---\n\n# Rich Description Skill\n\nExisting body.\n`,
+      "utf8",
+    );
+
+    const updateWithDerivedLabel = await proposeUpdateSkill({
+      workspaceDir,
+      skillName: "rich-description-skill",
+      content: "# Rich Description Skill\n\nUpdated body.\n",
+    });
+    expect(
+      Buffer.byteLength(updateWithDerivedLabel.record.description, "utf8"),
+    ).toBeLessThanOrEqual(160);
+    expect(updateWithDerivedLabel.content).toContain(richDescription);
+    await applySkillProposal({
+      workspaceDir,
+      proposalId: updateWithDerivedLabel.record.id,
+    });
+
+    await expect(fs.readFile(skillFile, "utf8")).resolves.toContain(richDescription);
+    await expect(fs.readFile(skillFile, "utf8")).resolves.toContain("Updated body.");
+
+    const updateWithSuppliedLabel = await proposeUpdateSkill({
+      workspaceDir,
+      skillName: "rich-description-skill",
+      description: "Concise listing label",
+      content: "# Rich Description Skill\n\nSecond updated body.\n",
+    });
+    expect(updateWithSuppliedLabel.record.description).toBe("Concise listing label");
+    expect(updateWithSuppliedLabel.content).toContain(richDescription);
+    await applySkillProposal({
+      workspaceDir,
+      proposalId: updateWithSuppliedLabel.record.id,
+    });
+
+    const applied = await fs.readFile(skillFile, "utf8");
+    expect(applied).toContain(richDescription);
+    expect(applied).toContain("Second updated body.");
+    expect(applied).not.toContain("Concise listing label");
+  });
+
   it("quarantines unsafe proposals during apply", async () => {
     const workspaceDir = await makeWorkspace();
     const proposal = await proposeCreateSkill({

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -1536,6 +1536,63 @@ describe("skill workshop proposals", () => {
     expect(applied).not.toContain("Concise listing label");
   });
 
+  it("applies explicitly revised descriptions from description-only create revisions", async () => {
+    const workspaceDir = await makeWorkspace();
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Describable Skill",
+      description: "Original label",
+      content: "# Describable\n\nOriginal body.\n",
+    });
+
+    const revised = await reviseSkillProposal({
+      workspaceDir,
+      proposalId: proposal.record.id,
+      description: "Revised label",
+    });
+
+    expect(revised.record.description).toBe("Revised label");
+    expect(revised.content).toContain("Revised label");
+
+    await applySkillProposal({ workspaceDir, proposalId: proposal.record.id });
+    await expect(
+      fs.readFile(path.join(workshopSkillsDir(), "describable-skill", "SKILL.md"), "utf8"),
+    ).resolves.toBe(
+      '---\nname: "describable-skill"\ndescription: "Revised label"\n---\n\n# Describable\n\nOriginal body.\n',
+    );
+  });
+
+  it("preserves rich create frontmatter descriptions across body-only revisions", async () => {
+    const workspaceDir = await makeWorkspace();
+    const richDescription = `${"z".repeat(200)} plus trigger phrases and keywords`;
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Rich Create Skill",
+      description: "Short listing label",
+      content: `---\nname: rich-create-skill\ndescription: ${richDescription}\n---\n\n# Rich Create\n\nOriginal body.\n`,
+    });
+    expect(proposal.record.description).toBe("Short listing label");
+    expect(proposal.content).toContain(richDescription);
+
+    const revised = await reviseSkillProposal({
+      workspaceDir,
+      proposalId: proposal.record.id,
+      content: "# Rich Create\n\nRevised body.\n",
+    });
+
+    expect(revised.record.description).toBe("Short listing label");
+    expect(revised.content).toContain(richDescription);
+
+    await applySkillProposal({ workspaceDir, proposalId: proposal.record.id });
+    const applied = await fs.readFile(
+      path.join(workshopSkillsDir(), "rich-create-skill", "SKILL.md"),
+      "utf8",
+    );
+    expect(applied).toContain(richDescription);
+    expect(applied).toContain("Revised body.");
+    expect(applied).not.toContain("Short listing label");
+  });
+
   it("quarantines unsafe proposals during apply", async () => {
     const workspaceDir = await makeWorkspace();
     const proposal = await proposeCreateSkill({

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -143,18 +143,21 @@ export async function reviseSkillProposal(
       input.supportFiles === undefined ? (read.supportFiles ?? []) : input.supportFiles;
     const requestedContent = input.content ?? read.content;
     const nextVersion = nextProposalVersion(record.proposedVersion);
-    const description = normalizeOptionalString(input.description) ?? record.description;
+    const explicitDescription = normalizeOptionalString(input.description);
+    const description = explicitDescription ?? record.description;
     const now = new Date().toISOString();
     const prepared = prepareSkillProposalDraft({
       name: resolveSkillProposalName(record.kind, record.target),
       description,
-      // The listing label is the skill description only for create proposals whose
-      // content never carried one; updates keep the description from the drafted or
-      // previously rendered content instead of the label.
+      // The listing label is the skill description only for proposals whose
+      // content never carried one; otherwise the description comes from the drafted
+      // or previously rendered content. An explicitly revised description still wins
+      // for create proposals so description-only revisions reach the applied skill.
       skillDescription: resolveDraftedSkillDescription({
         content: requestedContent,
-        ...(record.kind === "update" ? { fallbackContent: read.content } : {}),
+        fallbackContent: read.content,
         label: description,
+        ...(record.kind === "create" && explicitDescription ? { explicitDescription } : {}),
       }),
       content: requestedContent,
       fallbackFrontmatterContent: read.content,

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -14,7 +14,7 @@ import {
   type SkillProposalTransitionInput,
 } from "./apply-transition.js";
 import { resolveSkillWorkshopConfig } from "./config.js";
-import { resolveSkillProposalName } from "./frontmatter.js";
+import { resolveDraftedSkillDescription, resolveSkillProposalName } from "./frontmatter.js";
 import { createSkillProposalEvent, dispatchSkillProposalChanged } from "./plugin-hooks.js";
 import { nextProposalVersion, prepareSkillProposalDraft } from "./proposal-draft.js";
 import { createSkillProposalGenerationDraftFile } from "./proposal-generation.js";
@@ -148,6 +148,14 @@ export async function reviseSkillProposal(
     const prepared = prepareSkillProposalDraft({
       name: resolveSkillProposalName(record.kind, record.target),
       description,
+      // The listing label is the skill description only for create proposals whose
+      // content never carried one; updates keep the description from the drafted or
+      // previously rendered content instead of the label.
+      skillDescription: resolveDraftedSkillDescription({
+        content: requestedContent,
+        ...(record.kind === "update" ? { fallbackContent: read.content } : {}),
+        label: description,
+      }),
       content: requestedContent,
       fallbackFrontmatterContent: read.content,
       version: nextVersion,


### PR DESCRIPTION
Related: #125570. Follow-up to #140757.

## What Problem This Solves

Fixes an issue where updating and applying a Workshop skill replaces its full routing description with the short proposal listing label. Omitting that label can truncate the description to 160 bytes while leaving the skill valid.

## Why This Change Was Made

Resolve the rendered skill description separately from the bounded listing text. Full replacement frontmatter supplies the new description; body-only updates and patches retain the live description. Create revisions honor an explicit revised description and otherwise retain the drafted or previous rich frontmatter.

## User Impact

Future proposals preserve the routing phrases that agents use to select a skill. The listing limit, hashes, scanning, stale-target checks, support-file ownership, and apply lifecycle remain intact.

Already-pending drafts from older builds are unchanged. The legacy-draft decision in #125570 remains open; this PR does not resolve that whole issue.

## Evidence

- Real isolated Gateway and model-facing `skill_workshop` update/inspect/apply: baseline `6ee316d04d7d` replaced a 282-byte description with a 29-byte label; candidate `9b83058c4708` preserved the full description while keeping that label separate.
- Two contributor regression tests fail on the baseline for description loss. All 89 focused tests pass on the candidate.
- Public baseline and candidate controls cover updates, patching, replacement frontmatter, create revisions, the 160/161-byte limit, literal-secret rejection, rejected proposals, stale targets/support, revision hashes, support-file updates, and rollback after a real filesystem write failure.
- Fresh independent acceptance exercised 17 phases with new 306-byte descriptions containing quoted cues, accents, and a newline. Description precedence and the measured lifecycle controls passed. Tool proof used automatic approval with explicit inspect/apply.

AI-assisted validation. Synthetic fixtures and raw execution evidence remain private.
