### PR TITLE
perf(tools): reuse values normalized by code-mode IPC

### DIFF
--- a/src/agents/tool-search-code-mode-child.ts
+++ b/src/agents/tool-search-code-mode-child.ts
@@ -63,7 +63,8 @@ function bridgeResultPayload(message) {
   if (!message.ok) {
     return typeof message.error === "string" ? message.error : "tool bridge failed";
   }
-  const json = JSON.stringify(toJsonSafe(message.value));
+  // IPC already normalized the value; keep the string boundary into the guest.
+  const json = JSON.stringify(message.value);
   return typeof json === "string" ? json : "null";
 }
 

--- a/src/agents/tool-search-code-mode.ts
+++ b/src/agents/tool-search-code-mode.ts
@@ -40,7 +40,8 @@ export async function runCodeMode(params: {
   });
   return {
     ok: true,
-    value: toToolSearchJsonSafe(value),
+    // JSON IPC already detached and normalized the child's result.
+    value: value ?? null,
     logs,
     telemetry: runtime.telemetry(),
   };


### PR DESCRIPTION
Closes #140865

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Tool Search code mode rebuilds complete values after Node JSON IPC has already normalized and detached them, both for bridge responses entering the child and final values returning to the parent.

## Why This Change Was Made

Reuse the received final value with a nullish fallback and remove only the child's intermediate JSON clone. Preserve raw-value normalization, the required string transfer and guest parse, error/abort behavior, child permission flags and empty environment.

## User Impact

In actual-child synthetic 4 MiB workloads, median parent sampled allocation changes from 24,544,880 to 16,221,472 bytes for a guest final value, and 54,237,008 to 45,782,320 bytes when returning a bridged result. Separate child counters show each redundant stringify/parse pair is gone.

Child heap observations and small controls are mixed: one instrumented child high-water observation increased. These are transient-copy observations, not retained-leak, fixed peak/RSS, universal latency or whole-Gateway claims. Required normalization and realm transfers remain.

## Evidence

- 84 paired actual-child records preserve complete values/content digests, errors, ordered calls/arguments, logs and normalized telemetry. All 168 measured children joined and eight private runtimes were removed.
- The 279 existing owner/runtime/lifecycle/MCP tests, complete changed gate and final P2 review pass on base faa9d1e with its matching lock. Exact Node 26.8.1 built-in JSON IPC source was inspected; no serializer override or extra child permissions were added.
- Two expressions and two ownership comments change; no tests, imports, configuration or package boundaries change. No full build required or claimed.
- Later main #140767 adds shared scheduling/cancellation and queued-target checks without changing either copy site. That runtime/test work is preserved; the recorded measurements and 279-test run remain bound to their stated base.

Related #137594 may add a diagnostic wrapper around the result. Preserve that wrapper if it lands first; the copy removal belongs inside its result envelope.
