### PR TITLE
perf(copilot): reuse the private replay projection

### DIFF
--- a/extensions/copilot/src/attempt-transcript-journal.ts
+++ b/extensions/copilot/src/attempt-transcript-journal.ts
@@ -188,7 +188,7 @@ export function createAttemptTranscriptJournal(params: {
     options: { singleton?: boolean } = {},
   ): TranscriptMessage | undefined => {
     const message = structuredClone(write.message) as TranscriptMessage;
-    const originalReplayPayload = structuredClone(projectReplayPayload(message));
+    const originalReplayPayload = projectReplayPayload(message);
     const hooked = runAgentHarnessBeforeMessageWriteHook({
       message: structuredClone(message) as TranscriptMessage,
       agentId: target.agentId,


### PR DESCRIPTION
Closes #140867

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Copilot transcript preparation deep-clones a replay projection that already references the journal's private message snapshot. The hook receives its own separate full-message clone, so the middle clone adds allocation without protecting another borrower.

## Why This Change Was Made

Reuse the private replay projection directly. Keep both full-message clones and capture projection before the synchronous hook. Replay validity, tool identity, taint/provenance, hidden display, operational metadata and persistence remain unchanged.

## User Impact

Eleven actual event-bridge → journal → SQLite scenarios preserve complete normalized durable outcomes, snapshots, recorder results, hook counts, replay flags and raw event_json byte totals. Large and stress cases reduce sampled transient JavaScript allocation by 1.875 and 12.587 MiB respectively.

Those cases scale user/assistant content and tool arguments. Tool results retain their 8,000-character cap and excluded details. Small timing controls became slower while larger medians improved; no universal CPU, native allocation, retained-leak, peak/RSS or whole-Gateway claim is made.

## Evidence

- 79 existing journal, event-bridge and session integration tests, full changed checks and fresh P2 review pass on pinned base 28a4d417 with the matching frozen lock and SDK 1.0.11.
- The before/after matrix covers nested hook mutation, metadata-only rewrites, replacement/reordered keys, suppression and capped tool results. Only documented generated IDs, timestamps and cwd are normalized; whole SQLite file-byte equality is not claimed.
- One production expression changes, with no new test/helper/import, SDK, configuration, schema or persistence semantics. No full build is required or claimed.

Active #135969 contains broader durability/authority/group validation work and still retains this clone. Preserve that work and requalify attribution if it lands, especially paths that bypass preparation.
