### PR TITLE
refactor(tests): import benchmark helpers from their owners

### DIFF
--- a/scripts/bench-gateway-restart.ts
+++ b/scripts/bench-gateway-restart.ts
@@ -10,7 +10,6 @@ import { writeGatewayRestartIntentSync } from "../src/infra/restart-intent.js";
 import { delay, stopChild, type StopChildResult } from "./lib/gateway-bench-child.ts";
 import {
   getFreePort,
-  parseProcessRssKb,
   readProcessRssMb,
   readProcessTreeCpuMs,
   requestProbeStatus,
@@ -1294,28 +1293,21 @@ async function main() {
 }
 
 export const testing = {
-  collectOutputLines,
-  collectTraceLine,
   countLsofFileDescriptors,
   createRestartIteration,
   ensureSupportedRestartPlatform,
   finalizeRestartIteration,
-  flushOutputLineBuffers,
   collectBenchmarkEvidenceFailures,
   hasInitialReadyLogs,
   hasBenchmarkFailures,
   hasInvalidBenchmarkEvidence,
-  parseNonNegativeInt,
   parseOptions,
-  parsePositiveInt,
-  parseProcessRssKb,
   resolveRestartDeadlineFailure,
   resolveEntry,
   resolvePhaseDeadlineAt,
   resolveSampleExitFailure,
   sanitizedEnv,
   shouldFailBenchmark,
-  stopChild,
   summarizeCase,
   waitForRestartProbe,
   writeConfig,

--- a/scripts/bench-gateway-startup.ts
+++ b/scripts/bench-gateway-startup.ts
@@ -1129,16 +1129,12 @@ async function main() {
 }
 
 export const testing = {
-  classifyGatewayReadyLog,
-  collectOutputLines,
   collectResultFailures,
   collectStartupTrace,
   listIncidentPackagedPluginArtifacts,
   parseOptions,
   sanitizedEnv,
-  stopChild,
   summarizeCase,
-  waitForProbe,
   waitForStartupTracePhase,
   withGatewayBenchRoot,
   writeIncidentFixture,

--- a/test/scripts/bench-gateway-restart.test.ts
+++ b/test/scripts/bench-gateway-restart.test.ts
@@ -8,7 +8,15 @@ import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { beforeAll, describe, expect, it } from "vitest";
 import { testing } from "../../scripts/bench-gateway-restart.ts";
-import { requestProbeStatus } from "../../scripts/lib/gateway-bench-probes.ts";
+import { stopChild } from "../../scripts/lib/gateway-bench-child.ts";
+import { parseProcessRssKb, requestProbeStatus } from "../../scripts/lib/gateway-bench-probes.ts";
+import {
+  collectOutputLines,
+  collectTraceLine,
+  flushOutputLineBuffers,
+  parseNonNegativeInt,
+  parsePositiveInt,
+} from "../../scripts/lib/gateway-bench-runtime.ts";
 import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
@@ -113,8 +121,8 @@ describe("gateway restart benchmark script", () => {
 
   it("rejects ambiguous benchmark CLI values before spawning Node", () => {
     expect(() => testing.parseOptions(["--wat"])).toThrow("Unknown argument: --wat");
-    expect(testing.parsePositiveInt("5", 1, "--restarts")).toBe(5);
-    expect(testing.parseNonNegativeInt("0", 1, "--warmup")).toBe(0);
+    expect(parsePositiveInt("5", 1, "--restarts")).toBe(5);
+    expect(parseNonNegativeInt("0", 1, "--warmup")).toBe(0);
     expect(
       testing.parseOptions([
         "--case",
@@ -131,7 +139,7 @@ describe("gateway restart benchmark script", () => {
       output: "restart.json",
       restarts: 2,
     });
-    expect(() => testing.parsePositiveInt("2abc", 1, "--restarts")).toThrow(
+    expect(() => parsePositiveInt("2abc", 1, "--restarts")).toThrow(
       /--restarts must be an integer/u,
     );
     expect(() => testing.parseOptions(["--output", "--case", "skipChannels"])).toThrow(
@@ -166,13 +174,13 @@ describe("gateway restart benchmark script", () => {
   });
 
   it("buffers child output lines split across chunks", () => {
-    const first = testing.collectOutputLines("", "[gateway] restart trace: restart.ready 12");
+    const first = collectOutputLines("", "[gateway] restart trace: restart.ready 12");
     expect(first.lines).toEqual([]);
 
-    const second = testing.collectOutputLines(first.carry, ".5ms total=45.0ms\r");
+    const second = collectOutputLines(first.carry, ".5ms total=45.0ms\r");
     expect(second.lines).toEqual([]);
 
-    const third = testing.collectOutputLines(second.carry, "\n[gateway] ready\npartial");
+    const third = collectOutputLines(second.carry, "\n[gateway] ready\npartial");
     expect(third.lines).toEqual([
       "[gateway] restart trace: restart.ready 12.5ms total=45.0ms",
       "[gateway] ready",
@@ -217,7 +225,7 @@ describe("gateway restart benchmark script", () => {
     };
     const lines: string[] = [];
 
-    testing.flushOutputLineBuffers(buffers, (line) => lines.push(line), 1);
+    flushOutputLineBuffers(buffers, (line) => lines.push(line), 1);
 
     expect(lines).toEqual([]);
     expect(buffers).toEqual({
@@ -233,7 +241,7 @@ describe("gateway restart benchmark script", () => {
     };
     const lines: string[] = [];
 
-    testing.flushOutputLineBuffers(buffers, (line) => lines.push(line), 1, {
+    flushOutputLineBuffers(buffers, (line) => lines.push(line), 1, {
       flushPartial: true,
     });
 
@@ -258,11 +266,11 @@ node    1234 user   12u  IPv4    0t0      TCP localhost:1234
   });
 
   it("rejects malformed ps RSS samples", () => {
-    expect(testing.parseProcessRssKb("4096\n")).toBe(4096);
-    expect(testing.parseProcessRssKb("4096kb\n")).toBeNull();
-    expect(testing.parseProcessRssKb("4096 8192\n")).toBeNull();
-    expect(testing.parseProcessRssKb("0\n")).toBeNull();
-    expect(testing.parseProcessRssKb("")).toBeNull();
+    expect(parseProcessRssKb("4096\n")).toBe(4096);
+    expect(parseProcessRssKb("4096kb\n")).toBeNull();
+    expect(parseProcessRssKb("4096 8192\n")).toBeNull();
+    expect(parseProcessRssKb("0\n")).toBeNull();
+    expect(parseProcessRssKb("")).toBeNull();
   });
 
   it("accepts healthy probe headers without waiting for the response body", async () => {
@@ -374,7 +382,7 @@ node    1234 user   12u  IPv4    0t0      TCP localhost:1234
   it("parses restart trace metrics including resource Count fields", () => {
     const restartTrace: Record<string, number> = {};
 
-    testing.collectTraceLine(
+    collectTraceLine(
       "[gateway] restart trace: restart.ready 12.5ms total=45.0ms rssMb=200.5 heapUsedMb=80.1 activeHandlesCount=12 activeTimersCount=2 indexPlugins=50",
       "restart trace",
       restartTrace,
@@ -410,7 +418,7 @@ node    1234 user   12u  IPv4    0t0      TCP localhost:1234
   });
 
   registerStopChildBehaviorTests({
-    stopChild: testing.stopChild,
+    stopChild,
     queuedExitCode: 0,
   });
 

--- a/test/scripts/bench-gateway-startup.test.ts
+++ b/test/scripts/bench-gateway-startup.test.ts
@@ -8,6 +8,12 @@ import { performance } from "node:perf_hooks";
 import { collectConfiguredModelRefs } from "@openclaw/model-catalog-core/configured-model-refs";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { testing } from "../../scripts/bench-gateway-startup.ts";
+import { stopChild } from "../../scripts/lib/gateway-bench-child.ts";
+import {
+  classifyGatewayReadyLog,
+  collectOutputLines,
+  waitForInitialProbe,
+} from "../../scripts/lib/gateway-bench-runtime.ts";
 import { isStartupTraceDuration } from "../../scripts/lib/gateway-startup-trace-ranking.js";
 import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
 import { validateConfigObject } from "../../src/config/validation.js";
@@ -182,14 +188,12 @@ describe("gateway startup benchmark script", () => {
   });
 
   it("classifies HTTP listen and gateway ready logs separately", () => {
-    expect(
-      testing.classifyGatewayReadyLog("[gateway] http server listening (0 plugins, 0.8s)"),
-    ).toBe("http-listen");
-    expect(testing.classifyGatewayReadyLog("[gateway] ready (0 plugins, 0.8s)")).toBe(
-      "gateway-ready",
+    expect(classifyGatewayReadyLog("[gateway] http server listening (0 plugins, 0.8s)")).toBe(
+      "http-listen",
     );
-    expect(testing.classifyGatewayReadyLog("[gateway] ready")).toBe("gateway-ready");
-    expect(testing.classifyGatewayReadyLog("[gateway] starting HTTP server...")).toBeNull();
+    expect(classifyGatewayReadyLog("[gateway] ready (0 plugins, 0.8s)")).toBe("gateway-ready");
+    expect(classifyGatewayReadyLog("[gateway] ready")).toBe("gateway-ready");
+    expect(classifyGatewayReadyLog("[gateway] starting HTTP server...")).toBeNull();
   });
 
   it("preserves ready and trace records split across output chunks", () => {
@@ -201,7 +205,7 @@ describe("gateway startup benchmark script", () => {
     let carry = "";
     const lines: string[] = [];
     for (const chunk of chunks) {
-      const parsed = testing.collectOutputLines(carry, chunk);
+      const parsed = collectOutputLines(carry, chunk);
       carry = parsed.carry;
       lines.push(...parsed.lines);
     }
@@ -211,7 +215,7 @@ describe("gateway startup benchmark script", () => {
     }
 
     expect(carry).toBe("");
-    expect(lines.map(testing.classifyGatewayReadyLog)).toContain("gateway-ready");
+    expect(lines.map(classifyGatewayReadyLog)).toContain("gateway-ready");
     expect(trace).toMatchObject({
       "sidecars.ready": 2,
       "sidecars.ready.heapUsedMb": 12,
@@ -471,7 +475,7 @@ describe("gateway startup benchmark script", () => {
   });
 
   registerStopChildBehaviorTests({
-    stopChild: testing.stopChild,
+    stopChild,
     queuedExitCode: 7,
   });
 
@@ -534,7 +538,7 @@ describe("gateway startup benchmark script", () => {
     });
     try {
       const startAt = performance.now();
-      const result = await testing.waitForProbe({
+      const result = await waitForInitialProbe({
         deadlineAt: startAt + 1_000,
         path: "/readyz",
         port,


### PR DESCRIPTION
## What Problem This Solves

Gateway benchmark tests still reach shared helpers through test-only forwarding members on the startup and restart CLI modules. This leaves duplicate ownership seams after the shared benchmark runtime extraction.

## Why This Change Was Made

Remove eleven forwarded members and one unused import. The same tests import the existing runtime, probe, and child-process helpers directly. CLI-local helpers stay on their existing testing surfaces, and both CLI modules remain imported and exercised through their real help/error paths.

## User Impact

No benchmark or Gateway behavior changes. Tooling loses 12 lines; test imports replace the forwarded access without removing cases or assertions. The child-stop suites retain their distinct exit-code scenarios and lifecycle checks.

## Evidence

- The startup, restart, and discovery-isolation suites pass all 67 cases before and after, with identical case names and outcomes.
- Trace buffering, probe transitions, malformed RSS, restart persistence, and bounded child cleanup assertions remain unchanged.
- Targeted formatting and `git diff --check` pass.
- Independent Codex review is clean through P2.
- All 19 normal changed-file checks passed on the configured Testbox (typechecks, lint, formatting, and structural guards); the one-shot lease and source capsule are closed.

No live Gateway benchmark or performance result is claimed: helper implementations and benchmark behavior are unchanged. A separate formatting follow-up tracks counts displayed with an ms suffix.
