### PR TITLE
refactor(gateway): share workspace conflict projection type

### DIFF
--- a/src/gateway/worker-environments/placement-record.ts
+++ b/src/gateway/worker-environments/placement-record.ts
@@ -1,4 +1,5 @@
 import type { WorkerSessionPlacementState } from "./placement-state.js";
+import type { WorkerWorkspaceResultConflict } from "./workspace-conflicts.js";
 
 export const FORCED_WORKER_ABANDONMENT_ERROR =
   "Worker result abandoned by forced operator teardown";
@@ -92,12 +93,6 @@ export type PersistedTurnClaim =
       generation: number;
       ownerEpoch: number;
     };
-
-export type WorkerWorkspaceResultConflict = {
-  paths: string[];
-  stagedResultRef: string;
-  totalCount?: number;
-};
 
 type PersistedLocalTurnClaim = Extract<PersistedTurnClaim, { owner: "local" }>;
 

--- a/src/gateway/worker-environments/placement-store.ts
+++ b/src/gateway/worker-environments/placement-store.ts
@@ -23,7 +23,6 @@ import {
   type WorkerSessionPlacementRecord,
   type WorkerSessionPlacementTransitionPatch,
   type WorkerSessionTurnClaim,
-  type WorkerWorkspaceResultConflict,
 } from "./placement-record.js";
 import {
   ensureLocal,
@@ -59,7 +58,10 @@ import {
   hasWorkerWorkspacePendingResult,
 } from "./placement-workspace-result.js";
 import { boundedWorkerError } from "./worker-error.js";
-import { projectWorkspaceResultConflict } from "./workspace-conflicts.js";
+import {
+  projectWorkspaceResultConflict,
+  type WorkerWorkspaceResultConflict,
+} from "./workspace-conflicts.js";
 
 const RETIRABLE_PLACEMENT_STATES = ["local", "requested", "reclaimed", "failed"] as const;
 


### PR DESCRIPTION
## What Problem This Solves

The worker placement record and workspace-conflict projector independently declare the same process-local conflict projection, allowing those types to drift.

## Why This Change Was Made

`workspace-conflicts.ts`, beside `projectWorkspaceResultConflict`, is now the single type owner. The placement record and store import that type instead of repeating it. The sole importer of the duplicate declaration is migrated; no public package or plugin-SDK export is removed.

## User Impact

None. This is a type-only consolidation. The projection remains process-local and absent from SQLite; sorting, deduplication, bounds, clearing, and store lifecycle behavior do not change.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/worker-environments/placement-store.test.ts src/gateway/worker-environments/workspace-conflicts.test.ts`: 21 tests passed across two files.
- Both edited modules emit byte-identical JavaScript. Formatting and diff checks passed.
- Independent Codex review found no actionable P0–P2 issues.
- Full `node scripts/check-changed.mjs`, `pnpm build` (12m58.4s), and `pnpm protocol:check` passed before the clean rebase. Both edited files and the canonical type owner are unchanged; the 21 focused tests passed again on the rebased head. Registry and generated Swift/Kotlin models are unchanged.
- Final rebased Codex review found no actionable P0–P2 issues. Final-head [CI run 34088602360](https://github.com/openclaw/openclaw/actions/runs/34088602360) passed for `8b38b854c51ca4b327c8b8b890f624f60ec5d6c7`. Native review, hosted preparation, and merge passed; squash `096d345e5bd6d7651a8c1e98ce96e6868a253ba2` is verified on main.

Two source files, production net -3 lines; tests unchanged. No schema, persistent-store semantics, protocol, dependency, or ratchet changes.
