### PR TITLE
improve: reduce work when summarizing long transcripts

### DIFF
--- a/src/transcripts/summary.ts
+++ b/src/transcripts/summary.ts
@@ -36,16 +36,29 @@ const RISK_PATTERNS =
 
 function firstSentences(utterances: TranscriptUtterance[], limit: number): string {
   const text = normalizeStringEntries(utterances.map((utterance) => utterance.text)).join(" ");
-  const sentences = text.match(/[^.!?]+[.!?]?/g) ?? [];
-  return normalizeStringEntries(sentences.slice(0, limit)).join(" ");
+  const sentences: string[] = [];
+  for (const match of text.matchAll(/[^.!?]+[.!?]?/g)) {
+    sentences.push(match[0]);
+    // Whitespace-only matches count toward the limit before normalization.
+    if (sentences.length >= limit) {
+      break;
+    }
+  }
+  return normalizeStringEntries(sentences).join(" ");
 }
 
 function collectMatches(utterances: TranscriptUtterance[], pattern: RegExp): string[] {
-  return utterances
-    .filter((utterance) => pattern.test(utterance.text))
-    .map(formatSpeakerLine)
-    .filter(Boolean)
-    .slice(0, 12);
+  const matches: string[] = [];
+  utterances.some((utterance) => {
+    if (pattern.test(utterance.text)) {
+      const line = formatSpeakerLine(utterance);
+      if (line) {
+        matches.push(line);
+      }
+    }
+    return matches.length >= 12;
+  });
+  return matches;
 }
 
 function sanitizeUtterance(utterance: TranscriptUtterance): TranscriptUtterance {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled where applicable.

</details>

## What Problem This Solves

Heuristic meeting summaries did unnecessary work on long transcripts: they collected every sentence and every matching decision, action, and risk before keeping only a small prefix. This affects captured/imported transcripts and the heuristic base used by model-backed summaries.

## Why This Change Was Made

Stop each classification scan after its existing 12 nonempty output lines, and collect only the first four raw sentence matches before normalizing them. Native array iteration preserves sparse-array behavior; regex punctuation semantics, duplicates, speaker prefixes, ordering, terminal sanitization, timestamps, full transcript content, and participants remain unchanged.

The two explicit bounded collections add 13 production lines while removing whole-input result arrays. This growth makes the existing limits bound collection work; it introduces no configuration, persistent cache, dependency, or public API. Full transcript sanitization and rendering still process the entire transcript.

## User Impact

Long, dense inputs become cheaper to summarize without changing their notes. In the fixed two-order comparison, 2,000 matching utterances improved 41.68%/42.04% at the complete summary-plus-Markdown boundary, saving about 501/519 µs per invocation. A 2,000-sentence utterance improved 35.59%/25.07%, saving about 42/27 µs.

This trades some small-input performance for bounded collection work. Twelve-match controls regressed 16.08%/8.74%, empty inputs 6.89%/3.37%, and punctuation inputs 7.01%/7.25%. No uniform speedup, model latency improvement, or whole-Gateway gain is claimed.

## Evidence

- Two complete existing suites passed **19/19 tests**; all **28 normal changed checks** passed without bypasses. Install, formatter, plan, tests, and checks closed successfully; formatting left the owner bytes unchanged.
- Canonical managed **P2 review: scoped clean**, no actionable findings, confidence 0.98.
- Fixed **B0, C0, C1, B1** execution: 13 cases, 533 calls per process, **2,132 complete invocations**. Full normalized summary and Markdown returns matched across variants. Only the generated timestamp and its Markdown line were normalized. Targeted independent fixture assertions cover selected caps, duplicate/sparse behavior, transcript/participant retention, and sanitation; these are differential full-output comparisons plus partial independent oracles, **not 13 literal full-output goldens**.
- Every first observation, warmup and sample remains retained. Of 26 median comparisons, **11 regressed**; across first/median/mean/p95/max, **57 of 130 comparisons regressed**. In the reverse escape case, the maximum increased **16.042 → 378.166 µs** and the mean increased **155.00%**, despite its improved median. The outlier and adverse controls remain in the evidence; no rerun or selective deletion was used. A row's first observation follows imports and earlier rows, so it is not cold startup; sample p95/max are not population-tail guarantees.

Median µs per complete summary-plus-Markdown invocation; lower is better:

| Case | B0 baseline | C0 candidate | B1 baseline | C1 candidate |
| --- | ---: | ---: | ---: | ---: |
| empty | 2.729 | 2.917 | 3.729 | 3.855 |
| short | 4.876 | 4.625 | 5.937 | 6.104 |
| matches-12 | 11.917 | 13.833 | 13.354 | 14.521 |
| matches-13 | 13.833 | 13.480 | 14.229 | 13.250 |
| late-matches | 586.605 | 579.208 | 608.979 | 541.875 |
| no-matches | 968.208 | 985.500 | 998.083 | 954.896 |
| matches-2000 | 1200.979 | 700.416 | 1235.375 | 716.042 |
| sentences-2000 | 117.708 | 75.812 | 107.521 | 80.562 |
| whitespace | 5.416 | 5.313 | 4.292 | 4.687 |
| punctuation | 3.583 | 3.834 | 3.730 | 4.000 |
| escapes | 6.666 | 6.771 | 8.000 | 7.708 |
| duplicates | 10.666 | 10.500 | 10.166 | 10.520 |
| sparse | 6.604 | 6.042 | 6.916 | 6.875 |

| Phase | Process wall seconds | Kernel child peak RSS bytes | Sampled tree peak RSS bytes |
| --- | ---: | ---: | ---: |
| B0 | 0.506833291 | 184,287,232 | 183,566,336 |
| C0 | 0.444267125 | 167,641,088 | 185,581,568 |
| C1 | 0.447762666 | 167,280,640 | 184,958,976 |
| B1 | 0.476284375 | 176,472,064 | 186,335,232 |

Process wall and kernel RSS decreased in both orders, while sampled tree RSS increased 1.10% forward and decreased 0.74% reverse. These include imports, fixture preparation, capture retention and assertions; they do not isolate per-call allocations or establish a general memory reduction. All four numeric processes closed and the exact candidate source was restored.

Proof binds base `2413c5e3dcde376a208ed866d87909a2f4b5a71d` and candidate owner SHA-256 `17de9d4412ba2969adb82852c5181448fc714351bb15122ca276caf4e8aea330`. No newer-head numeric proof or live Gateway improvement is claimed.

An independent retained-data audit verified all 2,132 captures, 8,528 journal records, original timestamps, all 130 timing comparisons, resource arithmetic, source pins and closure. It did not rerun the target or supplied reducer.
