### PR TITLE
refactor: consolidate Twitch markdown parser coverage

### DIFF
--- a/extensions/twitch/src/utils/markdown.test.ts
+++ b/extensions/twitch/src/utils/markdown.test.ts
@@ -2,26 +2,10 @@ import { describe, expect, it } from "vitest";
 import { stripMarkdownForTwitch } from "./markdown.js";
 
 describe("stripMarkdownForTwitch", () => {
-  it.each([
-    [
-      "keeps labeled link destinations",
-      "Read **the [docs](https://example.com/docs)**",
+  it("keeps labeled link destinations", () => {
+    expect(stripMarkdownForTwitch("Read **the [docs](https://example.com/docs)**")).toBe(
       "Read the docs (https://example.com/docs)",
-    ],
-  ])("%s", (_name, input, expected) => {
-    expect(stripMarkdownForTwitch(input)).toBe(expected);
-  });
-});
-
-describe("Twitch plain text", () => {
-  it.each([
-    ["foo_bar_baz", "foo_bar_baz"],
-    ["https://cdn.example/my_file_name.png", "https://cdn.example/my_file_name.png"],
-    ["привет_мир_тест", "привет_мир_тест"],
-    ["東京_駅_前", "東京_駅_前"],
-    ["e\u0301_mail_.txt", "e\u0301_mail_.txt"],
-  ])("preserves intraword underscores in %s", (input, expected) => {
-    expect(stripMarkdownForTwitch(input)).toBe(expected);
+    );
   });
 
   it("strips standalone underscore emphasis across lines", () => {

--- a/src/tts/prepare-text.test.ts
+++ b/src/tts/prepare-text.test.ts
@@ -53,6 +53,9 @@ describe("TTS text preparation – stripMarkdown", () => {
   it("preserves underscores inside words while still stripping italic markers", () => {
     const cases = [
       ["here_is_a_message", "here_is_a_message"],
+      ["foo_bar_baz", "foo_bar_baz"],
+      ["https://cdn.example/my_file_name.png", "https://cdn.example/my_file_name.png"],
+      ["e\u0301_mail_.txt", "e\u0301_mail_.txt"],
       ["snake_case_var", "snake_case_var"],
       ["use foo_bar_baz in code", "use foo_bar_baz in code"],
       ["This is _italic_ text", "This is italic text"],


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Twitch's Markdown tests repeat five generic underscore-preservation cases already partly covered by the shared parser suite. Those cases add maintenance without exercising Twitch's own link and whitespace behavior.

## Why This Change Was Made

Keep the three local link, multiline-emphasis, and mixed-formatting cases with their exact inputs and expected outputs. Remove the five generic local cases and add the three missing exact inputs to the existing shared table, including the decomposed combining-mark fixture. The Cyrillic and Japanese inputs were already covered there.

## User Impact

No production behavior changes. This maintainer-requested cleanup removes 13 net test lines and five duplicate cases. No runtime improvement is claimed.

## Evidence

- Four focused suites: 40 cases before consolidation and 35 afterward; all retained cases pass.
- Exact input/output inventory preserves all three local pairs, all five generic pairs, and every original shared assertion.
- Controlled Unicode normalization, missing newline flattening, and label-only output changes each fail the intended retained assertion; original production bytes restored afterward.
- Initial typecheck found stale installed dependencies. A private frozen-lock install restored the pinned versions without tracked dependency changes, and all 35 final cases passed again.
- Formatting, deslop, and fresh P2 review passed. Corrected full changed-file gate passed.
