### PR TITLE
improve(computer): reduce work while image input is blocked

### DIFF
--- a/src/agents/tools/computer-tool-result.ts
+++ b/src/agents/tools/computer-tool-result.ts
@@ -86,7 +86,7 @@ export function invalidateComputerFrameIfMissing(params: {
   imagesBlocked?: boolean;
 }): boolean {
   const frameToolCallId = params.contextEpoch.frameToolCallId;
-  if (frameToolCallId === undefined) {
+  if (frameToolCallId === undefined || params.imagesBlocked) {
     return invalidateComputerFrame(params.contextEpoch);
   }
 
@@ -105,7 +105,6 @@ export function invalidateComputerFrameIfMissing(params: {
   }
 
   if (
-    !params.imagesBlocked &&
     frameImageIdentity !== undefined &&
     frameImageIdentity === params.contextEpoch.frameImageIdentity
   ) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Please keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Computer-frame context checks still inspect retained screenshots after the operator has blocked image input, even though those frames must be invalidated. This removes that unnecessary work in the blocked-image case.

## Why This Change Was Made

Route `imagesBlocked` through the existing early invalidator before searching history or hashing screenshot content. Preserve the same epoch increment and removal of both tracking fields; unblocked image matching and all tool/action permissions remain unchanged. The patch removes one production line and adds no configuration, dependency, or tests.

## User Impact

This is a targeted blocked-frame optimization with an explicit opposing cost: the measured unblocked payload cases and omitted-setting controls regress in both orders. The benefit is limited to avoided blocked-frame work; this is not a general or default-path speedup. No Gateway/model-turn, desktop, memory, or traffic-weighted net benefit is claimed, and the regressions are not attributed to unproven noise.

## Evidence

All 20 tests across the complete computer context, screenshot-result, and attempt-context-guard suites passed. The full 28-check changed gate passed in 329.112s. Canonical independent P2 review was clean, confidence 0.99. This proof is on base `2413c5e3`; the newer `33ca4b1` cache-TTL caller changes were read and found not to change the blocked-frame decision, but their new tests and current-main stream composition were not run here.

One fixed six-phase cohort covered 40 rows, 10,240 timed calls, and 10,800 complete boolean/epoch results, with a fresh epoch before every operation. All in-process assertions and retained output comparisons passed, including matching/missing/replaced images, duplicate images, orphan identities, clear epochs, and omitted block settings. Independent audit verified all raw vectors and arithmetic. Medians below summarize eight sample means of eight individually timed calls; they are not percentiles.

| Case | Forward median, µs | Change | Reverse median, µs | Change |
| --- | ---: | ---: | ---: | ---: |
| Blocked, 1 MiB | 687.612 → 0.174 | -99.97% | 707.773 → 0.153 | -99.98% |
| Unblocked, 64 B | 0.914 → 1.516 | +65.80% | 0.839 → 1.417 | +68.92% |
| Unblocked, 4 KiB | 3.242 → 3.958 | +22.09% | 3.245 → 4.549 | +40.20% |
| Unblocked, 256 KiB | 150.836 → 177.888 | +17.93% | 153.693 → 179.487 | +16.78% |
| Unblocked, 1 MiB | 673.693 → 690.961 | +2.56% | 665.336 → 685.107 | +2.97% |
| Setting omitted, 64 B | 0.828 → 0.865 | +4.39% | 0.760 → 0.899 | +18.15% |
| Setting omitted, 1 MiB | 671.609 → 688.742 | +2.55% | 667.279 → 695.263 | +4.19% |

The unblocked 256 KiB regressions cost about 27/26µs per operation; unblocked 1 MiB costs about 17/20µs, and 64 B about 0.6µs. Across the complete corpus, **35/80 primary medians and 104/240 primary statistics are adverse** (35 medians, 36 means, 33 maxima); **105/240 individual-call statistics and 4/10 resource comparisons are adverse**. All are retained. Even the blocked controls include three adverse medians; this is not a universal blocked-case win.

The operation stopwatch excludes epoch creation, copying, serialization, and assertions. Frozen synthetic histories and image strings do not establish live workload frequencies or repeatability. Kernel peak RSS rose 0.23%/1.69%, so no memory reduction is inferred.

All six native children exited successfully with joined monitors and verified closure before source restoration. The root joined the outer parent successfully after 8.648s; this is separately reported outer completion, not an exhaustive process census. Source and selected dependency pins remained stable, the candidate was restored, and the fixed 120s/4GiB child and 32MiB-member/160MiB-family limits were respected. Exact-head CI and native landing remain pending.

## Review disposition

The latest ClawSweeper review identifies no correctness finding and offers explicit acceptance of the performance exchange as an alternative to more representative caller measurements. Under the requested autonomous performance/cleanup scope, I am choosing that bounded optimization: eliminating a history scan and image hash that the blocked path necessarily discards, with unchanged frame invalidation and one fewer production line. The reported 17–27 µs costs on unblocked large-frame calls remain accepted costs in this synthetic cohort, not dismissed as noise. Production workload frequencies and aggregate benefit remain unknown.

The optional Rank-up move to establish representative caller-level performance is deferred; this PR does not claim that proof, a default-path gain, or an overall runtime speedup. The campaign's separate live Gateway run does not exercise computer-use frames and will not be presented as resolving this limitation. This disposition addresses the review's performance decision without changing source or its measurements.
