### PR TITLE
perf(browser): count encoded envelopes without a second serialization

### DIFF
--- a/extensions/browser/src/node-host/invoke-browser.test.ts
+++ b/extensions/browser/src/node-host/invoke-browser.test.ts
@@ -665,10 +665,7 @@ describe("runBrowserProxyCommand", () => {
 
       const error = await runBrowserProxyCommand(
         JSON.stringify({ method: "POST", path: "/act" }),
-      ).then(
-        () => null,
-        (err: unknown) => err,
-      );
+      ).catch((err: unknown) => err);
       expect(error).toBeInstanceOf(Error);
       expect((error as Error).message).toBe(
         `browser proxy file read failed for ${secondPath}: Error: browser proxy files exceed 16 MiB aggregate limit`,
@@ -702,6 +699,25 @@ describe("runBrowserProxyCommand", () => {
     await expect(
       runBrowserProxyCommand(JSON.stringify({ method: "POST", path: "/act" })),
     ).rejects.toThrow("browser proxy payload exceeds 24 MiB encoded limit");
+  });
+
+  it.each([-1, 0, 1])("enforces the exact quoted payload limit at offset %i", async (delta) => {
+    const prefix = '\0\u0001\b\t\n\f\r"\\/Ω漢🦞\u2028\u2029\ud800a\udc00';
+    const maxBytes = 24 * 1024 * 1024;
+    const overhead = Buffer.byteLength(
+      JSON.stringify(JSON.stringify({ result: { result: prefix } })),
+    );
+    const body = { result: prefix + "a".repeat(maxBytes + delta - overhead) };
+    const expected = JSON.stringify({ result: body });
+    expect(Buffer.byteLength(JSON.stringify(expected))).toBe(maxBytes + delta);
+    dispatcherMocks.dispatch.mockResolvedValueOnce({ status: 200, body });
+
+    const result = runBrowserProxyCommand(JSON.stringify({ method: "POST", path: "/act" }));
+    if (delta > 0) {
+      await expect(result).rejects.toThrow("browser proxy payload exceeds 24 MiB encoded limit");
+    } else {
+      await expect(result).resolves.toBe(expected);
+    }
   });
 
   it("adds profile and browser status details on ws-backed timeouts", async () => {
@@ -993,39 +1009,23 @@ describe("runBrowserProxyCommand", () => {
     expect(dispatcherMocks.dispatch).not.toHaveBeenCalled();
   });
 
-  it("rejects persistent profile deletion when allowProfiles is configured", async () => {
+  it.each([
+    { name: "deletion", request: { method: "DELETE", path: "/profiles/poc" } },
+    {
+      name: "reset",
+      request: {
+        method: "POST",
+        path: "/reset-profile",
+        body: { profile: "openclaw", name: "openclaw" },
+      },
+    },
+  ])("rejects persistent profile $name when allowProfiles is configured", async ({ request }) => {
     configMocks.loadConfig.mockReturnValue({
       browser: {},
       nodeHost: { browserProxy: { enabled: true, allowProfiles: ["openclaw"] } },
     });
-
     await expect(
-      runBrowserProxyCommand(
-        JSON.stringify({
-          method: "DELETE",
-          path: "/profiles/poc",
-          timeoutMs: 50,
-        }),
-      ),
-    ).rejects.toThrow("INVALID_REQUEST: browser.proxy cannot mutate persistent browser profiles");
-    expect(dispatcherMocks.dispatch).not.toHaveBeenCalled();
-  });
-
-  it("rejects persistent profile reset when allowProfiles is configured", async () => {
-    configMocks.loadConfig.mockReturnValue({
-      browser: {},
-      nodeHost: { browserProxy: { enabled: true, allowProfiles: ["openclaw"] } },
-    });
-
-    await expect(
-      runBrowserProxyCommand(
-        JSON.stringify({
-          method: "POST",
-          path: "/reset-profile",
-          body: { profile: "openclaw", name: "openclaw" },
-          timeoutMs: 50,
-        }),
-      ),
+      runBrowserProxyCommand(JSON.stringify({ ...request, timeoutMs: 50 })),
     ).rejects.toThrow("INVALID_REQUEST: browser.proxy cannot mutate persistent browser profiles");
     expect(dispatcherMocks.dispatch).not.toHaveBeenCalled();
   });

--- a/extensions/browser/src/node-host/invoke-browser.ts
+++ b/extensions/browser/src/node-host/invoke-browser.ts
@@ -3,6 +3,7 @@
  * requests.
  */
 import fsPromises from "node:fs/promises";
+import { toUSVString } from "node:util";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
   asNullableRecord,
@@ -84,6 +85,39 @@ const DEFAULT_BROWSER_PROXY_TIMEOUT_MS = 20_000;
 const BROWSER_PROXY_STATUS_TIMEOUT_MS = 750;
 // Leave one MiB for the fixed node.invoke.result frame around payloadJSON.
 const BROWSER_PROXY_MAX_ENCODED_PAYLOAD_BYTES = 24 * 1024 * 1024;
+
+function countBrowserProxyEncodedPayloadBytes(serialized: string): number {
+  // Native JSON serialization has already escaped C0 units; raw JSON cannot contain them.
+  let bytes = Buffer.byteLength(serialized, "utf8") + 2;
+  for (const character of '"\\') {
+    const code = character.charCodeAt(0);
+    let index = serialized.indexOf(character);
+    while (index !== -1) {
+      // Skip sparse escapes natively and count dense escapes in bounded runs.
+      const end = Math.min(index + 128, serialized.length);
+      for (; index < end; index++) {
+        if (serialized.charCodeAt(index) === code) {
+          bytes++;
+        }
+      }
+      index = serialized.indexOf(character, index);
+    }
+  }
+  const wellFormed = toUSVString(serialized);
+  if (wellFormed !== serialized) {
+    // Raw JSON may preserve lone surrogates. Replacement keeps UTF-16 positions intact.
+    for (
+      let index = wellFormed.indexOf("\ufffd");
+      index !== -1;
+      index = wellFormed.indexOf("\ufffd", index + 1)
+    ) {
+      if (serialized.charCodeAt(index) !== 0xfffd) {
+        bytes += 3;
+      }
+    }
+  }
+  return bytes;
+}
 
 function normalizeProfileAllowlist(raw?: string[]): string[] {
   return Array.isArray(raw) ? normalizeStringEntries(raw) : [];
@@ -509,7 +543,7 @@ export async function runBrowserProxyCommand(
     : { result, ...(includeRoute ? { route } : {}) };
   const serialized = JSON.stringify(payload);
   // Node results carry this JSON as a string inside a second JSON frame.
-  if (Buffer.byteLength(JSON.stringify(serialized)) > BROWSER_PROXY_MAX_ENCODED_PAYLOAD_BYTES) {
+  if (countBrowserProxyEncodedPayloadBytes(serialized) > BROWSER_PROXY_MAX_ENCODED_PAYLOAD_BYTES) {
     throw new Error("browser proxy payload exceeds 24 MiB encoded limit");
   }
   return serialized;


### PR DESCRIPTION
Closes #140881

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Browser node responses build a second full JSON string solely to measure the serialized payload inside the outer node frame. That allocation is discarded after budget admission.

## Why This Change Was Made

Keep native serialization once, then count its exact quoted byte length with UTF-8 byteLength, statics-free quote/backslash scans and typed toUSVString handling for raw lone surrogates. The private helper accepts native compact JSON output; actual final framing and receiver validation stay unchanged.

## User Impact

Twenty actual delegated-command/framing/receiver flows preserve returned and wire hashes, native errors, file handling and exact 24 MiB admission. Sampled allocation falls by about 22.55 MB per owner operation for an 8 MiB PDF and 44.79 MB for 16 MiB aggregate files; corresponding framing/receiver observations are consistent.

Owner retention matches baseline. Malformed raw JSON can still require a replacement string, with no demonstrated allocation saving in that control. No small-output throughput, strict non-regression, peak/RSS or whole-Gateway claim is made.

## Evidence

- 63 focused tests, full changed-file checks and final P2 review pass. Three exact-limit cases cover minus one/equal/plus one with controls, Unicode, escapes and lone surrogates.
- 27 private counter oracle cases and 134 native serialization-domain checks preserve native JSON/rawJSON behavior. Native serialization still owns unknown-object traversal and its errors.
- Actual control service, routes, file read/MIME/base64, Gateway request framing and receiver validation/persistence are exercised. Playwright/CDP and RPC transport/ack boundaries are synthetic.
- The rejected sticky-RegExp prototype is excluded; no gain against that prototype is credited. A longer small-output control failed fixture validation and is excluded entirely, so it supplies no throughput or parity claim.
- Production net +34 lines; tests net zero. Per-file/aggregate/encoded limits, routes and authorization remain unchanged. No new public serializer, SDK/configuration or full build requirement.

Related #103328 established the budget. Active #128289 and #126870 change independent invocation authority/lifecycle behavior; preserve those guards if they land first.
