### PR TITLE
refactor(models): share model metadata primitives

### DIFF
--- a/packages/llm-core/src/model-data.ts
+++ b/packages/llm-core/src/model-data.ts
@@ -1,0 +1,97 @@
+// Data-only primitives shared by runtime models, catalogs, and configuration.
+export const MODEL_DATA_APIS = [
+  "openai-completions",
+  "openai-responses",
+  "openai-chatgpt-responses",
+  "anthropic-messages",
+  "google-generative-ai",
+  "google-vertex",
+  "github-copilot",
+  "bedrock-converse-stream",
+  "ollama",
+  "azure-openai-responses",
+] as const;
+
+export const MODEL_DATA_THINKING_FORMATS = [
+  "openai",
+  "openrouter",
+  "deepseek",
+  "together",
+  "qwen",
+  "qwen-chat-template",
+  "zai",
+] as const;
+
+export type ModelDataThinkingFormat = (typeof MODEL_DATA_THINKING_FORMATS)[number];
+
+export const MODEL_DATA_THINKING_LEVELS = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+
+export type ModelDataThinkingLevel = (typeof MODEL_DATA_THINKING_LEVELS)[number];
+export type ModelDataThinkingLevelMap = Partial<Record<ModelDataThinkingLevel, string | null>>;
+
+export type ModelDataImageInputConfig = {
+  /** Provider-documented maximum encoded image payload size. */
+  maxBytes?: number;
+  /** Provider-documented maximum accepted input pixels. */
+  maxPixels?: number;
+  /** Provider-documented maximum accepted width/height in pixels. */
+  maxSidePx?: number;
+  /** Preferred resize side for the default balanced compression policy. */
+  preferredSidePx?: number;
+  /** Token accounting style, used as documentation for provider-owned policy. */
+  tokenMode?: "tile" | "detail" | "provider";
+};
+
+export type ModelDataMediaInputConfig = {
+  /** Image input limits and accounting hints for this model. */
+  image?: ModelDataImageInputConfig;
+};
+
+/** Per-million-token rates for separately billed token buckets. */
+export type ModelDataCostRates = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+};
+
+export type ModelDataRawPricingTier = ModelDataCostRates & {
+  /** Half-open prompt-token interval; `[start]` is an open-ended upper tier. */
+  range: [number, number] | [number];
+};
+
+export type ModelRoutingSortConfig = {
+  /** The sorting metric: "price", "throughput", "latency". */
+  by?: string;
+  /** Partitioning strategy: "model" (default) or "none". */
+  partition?: string | null;
+};
+
+export type ModelRoutingMaxPrice = {
+  /** Price per million prompt tokens. */
+  prompt?: number | string;
+  /** Price per million completion tokens. */
+  completion?: number | string;
+  /** Price per image. */
+  image?: number | string;
+  /** Price per audio unit. */
+  audio?: number | string;
+  /** Price per request. */
+  request?: number | string;
+};
+
+/** Percentile targets in the owning field's throughput or latency units. */
+export type ModelRoutingPercentiles = {
+  p50?: number;
+  p75?: number;
+  p90?: number;
+  p99?: number;
+};

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -1,4 +1,15 @@
 import type { TSchema } from "typebox";
+import type {
+  ModelDataCostRates,
+  ModelDataMediaInputConfig,
+  ModelDataRawPricingTier,
+  ModelDataThinkingFormat,
+  ModelDataThinkingLevel,
+  ModelDataThinkingLevelMap,
+  ModelRoutingMaxPrice,
+  ModelRoutingPercentiles,
+  ModelRoutingSortConfig,
+} from "./model-data.js";
 import type { AssistantMessageDiagnostic } from "./utils/diagnostics.js";
 export type { AssistantMessageDiagnostic, DiagnosticErrorInfo } from "./utils/diagnostics.js";
 
@@ -33,11 +44,11 @@ export type KnownImagesProvider = "openrouter";
 export type ImagesProvider = string;
 
 /** Normalized reasoning-effort levels shared across provider-specific knobs. */
-export type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+export type ThinkingLevel = Exclude<ModelDataThinkingLevel, "off">;
 /** Model thinking setting including explicit disabled state. */
-export type ModelThinkingLevel = "off" | ThinkingLevel;
+export type ModelThinkingLevel = ModelDataThinkingLevel;
 /** Provider-specific values for normalized thinking levels. */
-export type ThinkingLevelMap = Partial<Record<ModelThinkingLevel, string | null>>;
+export type ThinkingLevelMap = ModelDataThinkingLevelMap;
 
 /** Token budgets for each thinking level (token-based providers only) */
 export interface ThinkingBudgets {
@@ -325,7 +336,7 @@ export interface Usage {
 }
 
 /** Per-million-token rates for separately billed token buckets. */
-export type ModelCostRates = Pick<Usage["cost"], "input" | "output" | "cacheRead" | "cacheWrite">;
+export type ModelCostRates = ModelDataCostRates;
 
 /** One whole-request tier on the cache-inclusive prompt-token axis. */
 export type PricingTier = ModelCostRates & {
@@ -333,10 +344,7 @@ export type PricingTier = ModelCostRates & {
   range: [number, number];
 };
 
-export type RawPricingTier = ModelCostRates & {
-  /** `[start]` is an open-ended upper tier. */
-  range: [number, number] | [number];
-};
+export type RawPricingTier = ModelDataRawPricingTier;
 
 /** Normalized pricing used by token accounting and usage summaries. */
 export type ModelCostConfig = ModelCostRates & { tieredPricing?: PricingTier[] };
@@ -528,14 +536,7 @@ export interface OpenAICompletionsCompat {
   /** Whether all replayed assistant messages must include an empty reasoning_content field when reasoning is enabled. Default: auto-detected from URL. */
   requiresReasoningContentOnAssistantMessages?: boolean;
   /** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "deepseek" uses thinking: { type } plus reasoning_effort, "together" uses reasoning: { enabled } plus reasoning_effort when supported, "zai" uses top-level enable_thinking: boolean, "qwen" uses top-level enable_thinking: boolean, and "qwen-chat-template" uses chat_template_kwargs.enable_thinking. Default: "openai". */
-  thinkingFormat?:
-    | "openai"
-    | "openrouter"
-    | "deepseek"
-    | "together"
-    | "zai"
-    | "qwen"
-    | "qwen-chat-template";
+  thinkingFormat?: ModelDataThinkingFormat;
   /** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */
   openRouterRouting?: OpenRouterRouting;
   /** Vercel AI Gateway routing preferences. Only used when baseUrl points to Vercel AI Gateway. */
@@ -610,6 +611,7 @@ export interface AnthropicMessagesCompat {
  * OpenRouter provider routing preferences.
  * Controls which upstream providers OpenRouter routes requests to.
  * Sent as the `provider` field in the OpenRouter API request body.
+ * Own member declarations preserve existing module-augmentation semantics.
  * @see https://openrouter.ai/docs/guides/routing/provider-selection
  */
 export interface OpenRouterRouting {
@@ -632,53 +634,13 @@ export interface OpenRouterRouting {
   /** A list of quantization levels to filter providers by (e.g., ["fp16", "bf16", "fp8", "fp6", "int8", "int4", "fp4", "fp32"]). */
   quantizations?: string[];
   /** Sorting strategy. Can be a string (e.g., "price", "throughput", "latency") or an object with `by` and `partition`. */
-  sort?:
-    | string
-    | {
-        /** The sorting metric: "price", "throughput", "latency". */
-        by?: string;
-        /** Partitioning strategy: "model" (default) or "none". */
-        partition?: string | null;
-      };
+  sort?: string | ModelRoutingSortConfig;
   /** Maximum price per million tokens (USD). */
-  max_price?: {
-    /** Price per million prompt tokens. */
-    prompt?: number | string;
-    /** Price per million completion tokens. */
-    completion?: number | string;
-    /** Price per image. */
-    image?: number | string;
-    /** Price per audio unit. */
-    audio?: number | string;
-    /** Price per request. */
-    request?: number | string;
-  };
+  max_price?: ModelRoutingMaxPrice;
   /** Preferred minimum throughput (tokens/second). Can be a number (applies to p50) or an object with percentile-specific cutoffs. */
-  preferred_min_throughput?:
-    | number
-    | {
-        /** Minimum tokens/second at the 50th percentile. */
-        p50?: number;
-        /** Minimum tokens/second at the 75th percentile. */
-        p75?: number;
-        /** Minimum tokens/second at the 90th percentile. */
-        p90?: number;
-        /** Minimum tokens/second at the 99th percentile. */
-        p99?: number;
-      };
+  preferred_min_throughput?: number | ModelRoutingPercentiles;
   /** Preferred maximum latency (seconds). Can be a number (applies to p50) or an object with percentile-specific cutoffs. */
-  preferred_max_latency?:
-    | number
-    | {
-        /** Maximum latency in seconds at the 50th percentile. */
-        p50?: number;
-        /** Maximum latency in seconds at the 75th percentile. */
-        p75?: number;
-        /** Maximum latency in seconds at the 90th percentile. */
-        p90?: number;
-        /** Maximum latency in seconds at the 99th percentile. */
-        p99?: number;
-      };
+  preferred_max_latency?: number | ModelRoutingPercentiles;
 }
 
 /**
@@ -729,15 +691,7 @@ export interface Model<TApi extends Api = Api> {
         ? AnthropicMessagesCompat
         : never;
   /** Provider-documented media input limits used by attachment preprocessing. */
-  mediaInput?: {
-    image?: {
-      maxBytes?: number;
-      maxPixels?: number;
-      maxSidePx?: number;
-      preferredSidePx?: number;
-      tokenMode?: "tile" | "detail" | "provider";
-    };
-  };
+  mediaInput?: ModelDataMediaInputConfig;
 }
 
 export interface ImagesModel<TApi extends ImagesApi = ImagesApi> extends Omit<

--- a/packages/model-catalog-core/src/model-catalog-types.ts
+++ b/packages/model-catalog-core/src/model-catalog-types.ts
@@ -1,32 +1,26 @@
 // Shared model catalog data contracts for provider manifests and normalized rows.
+import {
+  MODEL_DATA_APIS,
+  MODEL_DATA_THINKING_FORMATS,
+  MODEL_DATA_THINKING_LEVELS,
+  type ModelDataCostRates,
+  type ModelDataImageInputConfig,
+  type ModelDataMediaInputConfig,
+  type ModelDataRawPricingTier,
+  type ModelDataThinkingLevelMap,
+  type ModelRoutingMaxPrice,
+  type ModelRoutingPercentiles,
+  type ModelRoutingSortConfig,
+} from "../../llm-core/src/model-data.js";
 
 /** Supported API protocols for model catalog entries. */
-export const MODEL_CATALOG_APIS = [
-  "openai-completions",
-  "openai-responses",
-  "openai-chatgpt-responses",
-  "anthropic-messages",
-  "google-generative-ai",
-  "google-vertex",
-  "github-copilot",
-  "bedrock-converse-stream",
-  "ollama",
-  "azure-openai-responses",
-] as const;
+export const MODEL_CATALOG_APIS = [...MODEL_DATA_APIS] as const;
 
 /** API protocol for a model catalog entry. */
 export type ModelCatalogApi = (typeof MODEL_CATALOG_APIS)[number];
 
 /** Supported model thinking/reasoning wire formats. */
-export const MODEL_CATALOG_THINKING_FORMATS = [
-  "openai",
-  "openrouter",
-  "deepseek",
-  "together",
-  "qwen",
-  "qwen-chat-template",
-  "zai",
-] as const;
+export const MODEL_CATALOG_THINKING_FORMATS = [...MODEL_DATA_THINKING_FORMATS] as const;
 
 /** Thinking/reasoning wire format for model compatibility. */
 export type ModelCatalogThinkingFormat = (typeof MODEL_CATALOG_THINKING_FORMATS)[number];
@@ -88,35 +82,10 @@ export type ModelCatalogOpenRouterRouting = {
   only?: string[];
   ignore?: string[];
   quantizations?: string[];
-  sort?:
-    | string
-    | {
-        by?: string;
-        partition?: string | null;
-      };
-  max_price?: {
-    prompt?: number | string;
-    completion?: number | string;
-    image?: number | string;
-    audio?: number | string;
-    request?: number | string;
-  };
-  preferred_min_throughput?:
-    | number
-    | {
-        p50?: number;
-        p75?: number;
-        p90?: number;
-        p99?: number;
-      };
-  preferred_max_latency?:
-    | number
-    | {
-        p50?: number;
-        p75?: number;
-        p90?: number;
-        p99?: number;
-      };
+  sort?: string | ModelRoutingSortConfig;
+  max_price?: ModelRoutingMaxPrice;
+  preferred_min_throughput?: number | ModelRoutingPercentiles;
+  preferred_max_latency?: number | ModelRoutingPercentiles;
 };
 
 /** Vercel AI Gateway routing preferences. */
@@ -126,35 +95,17 @@ export type ModelCatalogVercelGatewayRouting = {
 };
 
 /** Image input limits for a model. */
-export type ModelCatalogImageInputConfig = {
-  maxBytes?: number;
-  maxPixels?: number;
-  maxSidePx?: number;
-  preferredSidePx?: number;
-  tokenMode?: "tile" | "detail" | "provider";
-};
+export type ModelCatalogImageInputConfig = ModelDataImageInputConfig;
 
 /** Media input limits for a model. */
-export type ModelCatalogMediaInputConfig = {
-  image?: ModelCatalogImageInputConfig;
-};
+export type ModelCatalogMediaInputConfig = ModelDataMediaInputConfig;
 
 /** Supported input modality for a model. */
 export type ModelCatalogInput = "text" | "image" | "document";
 /** Model-level thinking settings carried by provider catalog metadata. */
-export const MODEL_CATALOG_THINKING_LEVELS = [
-  "off",
-  "minimal",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-  "max",
-] as const;
+export const MODEL_CATALOG_THINKING_LEVELS = [...MODEL_DATA_THINKING_LEVELS] as const;
 export type ModelCatalogThinkingLevel = (typeof MODEL_CATALOG_THINKING_LEVELS)[number];
-export type ModelCatalogThinkingLevelMap = Partial<
-  Record<ModelCatalogThinkingLevel, string | null>
->;
+export type ModelCatalogThinkingLevelMap = ModelDataThinkingLevelMap;
 /** Discovery lifecycle for a provider catalog. */
 export type ModelCatalogDiscovery = "static" | "refreshable" | "runtime";
 /** Availability state for a model. */
@@ -204,20 +155,10 @@ export type UnifiedModelCatalogEntry<TCapabilities = unknown> = {
 };
 
 /** Tiered token cost row. */
-export type ModelCatalogTieredCost = {
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
-  range: [number, number] | [number];
-};
+export type ModelCatalogTieredCost = ModelDataRawPricingTier;
 
 /** Token cost metadata for one model. */
-export type ModelCatalogCost = {
-  input?: number;
-  output?: number;
-  cacheRead?: number;
-  cacheWrite?: number;
+export type ModelCatalogCost = Partial<ModelDataCostRates> & {
   tieredPricing?: ModelCatalogTieredCost[];
 };
 

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -1,4 +1,10 @@
 // Defines model selection and provider configuration types.
+import {
+  MODEL_DATA_APIS,
+  MODEL_DATA_THINKING_FORMATS,
+  type ModelDataImageInputConfig,
+  type ModelDataMediaInputConfig,
+} from "../../packages/llm-core/src/model-data.js";
 import type {
   AnthropicMessagesCompat,
   OpenAICompletionsCompat,
@@ -12,18 +18,7 @@ import type { ConfiguredModelProviderRequest } from "./types.provider-request.js
 import type { SecretInput } from "./types.secrets.js";
 
 /** Provider API adapter ids accepted by model/provider config and schema generation. */
-export const MODEL_APIS = [
-  "openai-completions",
-  "openai-responses",
-  "openai-chatgpt-responses",
-  "anthropic-messages",
-  "google-generative-ai",
-  "google-vertex",
-  "github-copilot",
-  "bedrock-converse-stream",
-  "ollama",
-  "azure-openai-responses",
-] as const;
+export const MODEL_APIS = [...MODEL_DATA_APIS] as const;
 
 export type ModelApi = (typeof MODEL_APIS)[number];
 
@@ -70,13 +65,7 @@ export type SupportedThinkingFormat =
 
 /** Thinking/reasoning payload dialects emitted by OpenAI-compatible providers. */
 export const MODEL_THINKING_FORMATS = [
-  "openai",
-  "openrouter",
-  "deepseek",
-  "together",
-  "qwen",
-  "qwen-chat-template",
-  "zai",
+  ...MODEL_DATA_THINKING_FORMATS,
 ] as const satisfies readonly SupportedThinkingFormat[];
 
 /** Runtime guard for config-provided thinking format strings. */
@@ -114,23 +103,9 @@ export type ModelCompatConfig = SupportedOpenAICompatFields &
     requiresOpenAiAnthropicToolPayload?: boolean;
   };
 
-export type ModelImageInputConfig = {
-  /** Provider-documented maximum encoded image payload size. */
-  maxBytes?: number;
-  /** Provider-documented maximum accepted input pixels. */
-  maxPixels?: number;
-  /** Provider-documented maximum accepted width/height in pixels. */
-  maxSidePx?: number;
-  /** Preferred resize side for the default balanced compression policy. */
-  preferredSidePx?: number;
-  /** Token accounting style, used as documentation for provider-owned policy. */
-  tokenMode?: "tile" | "detail" | "provider";
-};
+export type ModelImageInputConfig = ModelDataImageInputConfig;
 
-export type ModelMediaInputConfig = {
-  /** Image input limits and accounting hints for this model. */
-  image?: ModelImageInputConfig;
-};
+export type ModelMediaInputConfig = ModelDataMediaInputConfig;
 
 /** Authentication mode expected by a configured model provider. */
 export type ModelProviderAuthMode = "api-key" | "aws-sdk" | "oauth" | "token";


### PR DESCRIPTION
## What Problem This Solves

Runtime models, catalog metadata, and model configuration independently declared the same reasoning values, media limits, pricing buckets, and nested routing shapes. Maintaining these copies makes metadata contracts easier to drift apart.

## Why This Change Was Made

One dependency-free data leaf in `packages/llm-core/src/model-data.ts` now owns those shared primitives. Existing public names stay in their original modules. The leaf is bundled from source by the existing package builds; no package dependency or public subpath was added.

Routing interfaces keep their own top-level members. Replacing those members with inheritance rejects a previously valid `only?: string[] | undefined` augmentation under exact optional properties. Sharing only nested routing objects preserves that contract. The two-field Vercel shapes and API-specific compatibility bags remain local.

## User Impact

No user-visible change. Existing public type contracts are preserved. Runtime API/modality differences, optional catalog rates, normalized pricing, and complete model shapes remain intact. Exported arrays retain their order, readonly tuple types, mutability, and separate identities. Production delta: -33 lines; tests unchanged.

Config compatibility and upgrade review is complete: accepted schema values and defaults are unchanged, confirmed by the unchanged config documentation baseline and old/new type/value probes. No normalizer or config writer changed, no existing config is invalidated, and no migration is required.

## Evidence

- `node scripts/run-vitest.mjs packages/model-catalog-core/src/model-catalog-normalize.test.ts packages/model-catalog-core/src/model-catalog-pricing.test.ts src/config/zod-schema.models.test.ts`: 3 files / 124 tests passed.
- `pnpm config:docs:check` passed without generated-file changes.
- Actual-source type probes preserve all 113 existing exports and 53 type pairs with exact optional properties enabled and disabled. All 37 valid augmentation cases remain valid; 11 invalid cases keep the same diagnostics. Five tuple values and their owner identities/guards also pass. The inherited-interface negative control produces the expected two TS2430 errors.
- Independent Codex autoreview: no actionable P0–P2 findings. Rebase verified patch-identical, with all four source hashes unchanged.
- Clean build, built catalog smoke, declaration scan, and the complete changed-file gate passed on Blacksmith Testbox `tbx_01m1x5wna4xtejtdrd52hr0pjv`: https://github.com/openclaw/openclaw/actions/runs/34087460914. Command elapsed 20m18.7s, exit 0; the lease stopped automatically. All four source hashes matched, and 454 declarations contained zero private LLM package specifiers. No live-provider contract changed.

- Exact-head CI passed for `d77aaf1e341543dc3d773186ceb030ce073dd7fd`: https://github.com/openclaw/openclaw/actions/runs/34087729644. Native prepare completed without changing the head.

<details>
<summary>Exact Testbox command</summary>

```sh
'node' 'scripts/crabbox-wrapper.mjs' 'run' '--timing-json' '--' 'bash' '-lc' 'pnpm build && node --input-type=module -e '\''import assert from "node:assert/strict";
import fs from "node:fs";
import path from "node:path";
import { execFileSync } from "node:child_process";

const sources = [
  "packages/llm-core/src/model-data.ts",
  "packages/llm-core/src/types.ts",
  "packages/model-catalog-core/src/model-catalog-types.ts",
  "src/config/types.models.ts",
];
const expected = [
  "dce338cd34e280221a513e01ba945ab1c6b4bab7",
  "4c685d66f58914dc1b891a859fce1b2de9165b8f",
  "bdd6fe31ff2fe77adbe592ddb51396e2f18bf661",
  "0debf71c3a0339c644d20a6faa05fe279f803564",
];
assert.deepEqual(execFileSync("git", ["hash-object", ...sources], { encoding: "utf8" }).trim().split("\n"), expected);
const walk = (root) => fs.readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
  const file = path.join(root, entry.name);
  return entry.isDirectory() ? walk(file) : [file];
});
const declarations = walk("dist").filter((file) => /\.d\.[cm]?ts$/.test(file));
assert(declarations.some((file) => file.startsWith("dist/plugin-sdk/")));
assert.deepEqual(declarations.filter((file) => fs.readFileSync(file, "utf8").includes("@openclaw/llm-core")), []);
const catalog = await import("./packages/model-catalog-core/dist/model-catalog-types.mjs");
assert.equal(catalog.MODEL_CATALOG_APIS.length, 10);
assert.equal(catalog.isModelCatalogThinkingFormat("qwen-chat-template"), true);
assert.equal(catalog.isModelCatalogThinkingFormat("unknown"), false);
assert.equal(Object.keys(catalog).some((key) => key.startsWith("MODEL_DATA_")), false);
console.log(JSON.stringify({ sourceFiles: sources.length, declarations: declarations.length, privateLlmSpecifiers: 0, builtCatalog: "passed" }));
'\'' && OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs'
```

</details>
