### PR TITLE
fix(android): keep chat menus within fold-safe panes

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -59,7 +59,15 @@ space is limited; opening the keyboard does not move them to another region.
 If the keyboard covers that region entirely, dismiss the keyboard to reach the
 prompt again.
 
-Other dialogs, sheets, and menus are not adapted yet.
+Chat actions and Add attachment (Photos, Videos, Files) menus stay in the safe
+region containing their trigger. These popups remain focusable without becoming
+keyboard (IME) targets. If folds, insets, or layout changes invalidate an open
+menu, it closes without choosing an action. Reopen it explicitly when space
+permits; it does not reopen automatically when the layout recovers. Dismissing
+the menu does not reset Chat's draft, editor, or reader state.
+
+The Thinking control opens an effort sheet, not an adapted dropdown. Other
+dialogs, sheets, and popup menus are not fold-adapted yet.
 
 ## Wear OS companion
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareDropdownMenu.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareDropdownMenu.kt
@@ -1,0 +1,468 @@
+package ai.openclaw.app.ui
+
+import android.app.Activity
+import android.graphics.Rect
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.view.View
+import android.view.ViewTreeObserver
+import androidx.activity.compose.LocalActivity
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MenuDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.window.layout.WindowMetricsCalculator
+import kotlin.math.roundToInt
+
+internal data class FoldAwareMenuItem(
+  val id: String,
+  val label: String,
+  val onClick: () -> Unit,
+  val icon: ImageVector? = null,
+  val enabled: Boolean = true,
+  val interactionSource: MutableInteractionSource? = null,
+)
+
+/** Activity-hosted, non-nested menu. The surrounding Box is its stationary anchor. */
+@Composable
+internal fun FoldAwareDropdownMenu(
+  expanded: Boolean,
+  onDismissRequest: () -> Unit,
+  items: List<FoldAwareMenuItem>,
+) {
+  val activity = LocalActivity.current
+  val host = LocalView.current
+  val lifecycle = LocalLifecycleOwner.current.lifecycle
+  val density = LocalDensity.current
+  val direction = LocalLayoutDirection.current
+  val owner = remember { AnchoredMenuOwner() }
+  rememberWindowDisplayFeatureState(owner::publishFeatures)
+
+  DisposableEffect(activity, host, lifecycle) {
+    owner.attach(activity, host, lifecycle)
+    val roots = listOfNotNull(activity?.window?.decorView, host).distinct()
+    val listener =
+      ViewTreeObserver.OnPreDrawListener {
+        owner.refresh()
+        true
+      }
+    roots.forEach { it.viewTreeObserver.addOnPreDrawListener(listener) }
+    onDispose {
+      roots.forEach { if (it.viewTreeObserver.isAlive) it.viewTreeObserver.removeOnPreDrawListener(listener) }
+      owner.detach()
+    }
+  }
+  SideEffect { owner.update(expanded, items, onDismissRequest, density, direction) }
+  Layout(
+    content = {},
+    modifier = Modifier.onGloballyPositioned { owner.publishAnchor(it.parentLayoutCoordinates) },
+  ) { _, _ -> layout(0, 0) {} }
+
+  val opening = owner.opening
+  if (opening != null) {
+    Popup(
+      popupPositionProvider = opening,
+      onDismissRequest = opening.dismiss,
+      properties = PopupProperties(focusable = true),
+    ) {
+      val popupView = LocalView.current
+      SideEffect { opening.popupRoot = popupView.rootView }
+      // Popup's native layout direction is updated after its first composition.
+      CompositionLocalProvider(LocalDensity provides density, LocalLayoutDirection provides direction) {
+        MenuBody(owner, opening, items)
+      }
+    }
+  }
+}
+
+@Composable
+private fun MenuBody(
+  owner: AnchoredMenuOwner,
+  opening: MenuOpening,
+  items: List<FoldAwareMenuItem>,
+) {
+  val density = LocalDensity.current
+  val scroll = rememberScrollState()
+  val maxHeight = opening.bounds?.height ?: opening.geometry.available.height
+  Surface(
+    shape = MenuDefaults.shape,
+    color = MenuDefaults.containerColor,
+    tonalElevation = MenuDefaults.TonalElevation,
+    shadowElevation = MenuDefaults.ShadowElevation,
+  ) {
+    Layout(
+      modifier =
+        Modifier
+          .heightIn(max = with(density) { maxHeight.toDp() })
+          .padding(vertical = 8.dp)
+          .verticalScroll(scroll),
+      content = {
+        items.forEach { item ->
+          DropdownMenuItem(
+            text = {
+              Text(item.label, onTextLayout = { opening.textLayouts[item.id] = it })
+            },
+            leadingIcon = item.icon?.let { icon -> { Icon(icon, contentDescription = null) } },
+            enabled = item.enabled,
+            interactionSource = item.interactionSource,
+            onClick = { owner.accept(opening, item.id) },
+          )
+        }
+      },
+    ) { measurables, constraints ->
+      val padding = 16.dp.roundToPx()
+      val limit = minOf(constraints.maxWidth, opening.geometry.available.width, 280.dp.roundToPx())
+      if (opening.terminal || measurables.isEmpty() || limit < 112.dp.roundToPx()) {
+        owner.cancel(opening)
+        layout(0, 0) {}
+      } else {
+        val width =
+          opening.bounds?.width
+            ?: measurables.maxOf { it.maxIntrinsicWidth(Constraints.Infinity) }.coerceIn(112.dp.roundToPx(), limit)
+        val rows = measurables.map { it.measure(Constraints.fixedWidth(width)) }
+        val bodyHeight = rows.sumOf { it.height }
+        val height = opening.bounds?.height ?: minOf(bodyHeight + padding, maxHeight)
+        val textLayouts = items.mapNotNull { opening.textLayouts[it.id] }
+        val fits =
+          width <= limit && height >= rows.maxOf { it.height } + padding &&
+            textLayouts.size == items.size && textLayouts.none { it.hasVisualOverflow }
+        val rowLayout = MenuRows(rows.map { it.height }, textLayouts.map(::menuTextLayout))
+        if (!fits || !owner.admit(opening, IntSize(width, height), rowLayout)) {
+          owner.cancel(opening)
+          layout(0, 0) {}
+        } else {
+          layout(width, bodyHeight) {
+            var y = 0
+            rows.forEach {
+              it.place(0, y)
+              y += it.height
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+private data class MenuTextLine(
+  val start: Int,
+  val end: Int,
+  val left: Float,
+  val right: Float,
+  val bottom: Float,
+)
+
+private data class MenuTextLayout(
+  val style: TextStyle,
+  val size: IntSize,
+  val lines: List<MenuTextLine>,
+)
+
+private data class MenuRows(
+  val heights: List<Int>,
+  val text: List<MenuTextLayout>,
+) {
+  fun hasSameLayout(other: MenuRows): Boolean =
+    heights == other.heights && text.size == other.text.size &&
+      text.zip(other.text).all { (before, after) ->
+        before.size == after.size && before.lines == after.lines &&
+          before.style.hasSameLayoutAffectingAttributes(after.style)
+      }
+}
+
+private fun menuTextLayout(result: TextLayoutResult): MenuTextLayout =
+  MenuTextLayout(
+    result.layoutInput.style,
+    result.size,
+    (0 until result.lineCount).map { line ->
+      MenuTextLine(result.getLineStart(line), result.getLineEnd(line), result.getLineLeft(line), result.getLineRight(line), result.getLineBottom(line))
+    },
+  )
+
+private data class MenuGeometry(
+  val anchor: IntRect,
+  val available: IntRect,
+  val origin: IntOffset,
+  val token: IBinder,
+  val display: Int,
+)
+
+private class MenuOpening(
+  val owner: AnchoredMenuOwner,
+  val geometry: MenuGeometry,
+  val items: List<Triple<String, String, ImageVector?>>,
+) : PopupPositionProvider {
+  var terminal = false
+  var notified = false
+  var bounds: IntRect? = null
+  var rowLayout: MenuRows? = null
+  val textLayouts = mutableMapOf<String, TextLayoutResult>()
+  var popupRoot: View? = null
+  val dismiss: () -> Unit = { owner.cancel(this) }
+
+  override fun calculatePosition(
+    anchorBounds: IntRect,
+    windowSize: IntSize,
+    layoutDirection: LayoutDirection,
+    popupContentSize: IntSize,
+  ): IntOffset {
+    owner.refresh()
+    val admitted = bounds
+    if (anchorBounds != geometry.anchor || admitted?.size != popupContentSize) owner.cancel(this)
+    return admitted?.topLeft ?: geometry.available.topLeft
+  }
+}
+
+private class AnchoredMenuOwner {
+  var opening by mutableStateOf<MenuOpening?>(null)
+    private set
+  private val handler = Handler(Looper.getMainLooper())
+  private var activity: Activity? = null
+  private var host: View? = null
+  private var lifecycle: Lifecycle? = null
+  private var anchor: LayoutCoordinates? = null
+  private var features = WindowDisplayFeatureSnapshot()
+  private var expanded = false
+  private var items = emptyList<FoldAwareMenuItem>()
+  private var dismiss: () -> Unit = {}
+  private var density: Density = Density(1f)
+  private var direction = LayoutDirection.Ltr
+
+  fun attach(
+    activity: Activity?,
+    host: View,
+    lifecycle: Lifecycle,
+  ) {
+    this.activity = activity
+    this.host = host
+    this.lifecycle = lifecycle
+  }
+
+  fun detach() {
+    opening?.let(::cancel)
+    activity = null
+    host = null
+    anchor = null
+    features = WindowDisplayFeatureSnapshot()
+  }
+
+  fun publishFeatures(publication: WindowDisplayFeatureSnapshot) {
+    features = publication
+    refresh()
+  }
+
+  fun publishAnchor(coordinates: LayoutCoordinates?) {
+    anchor = coordinates
+    refresh()
+  }
+
+  fun update(
+    expanded: Boolean,
+    items: List<FoldAwareMenuItem>,
+    dismiss: () -> Unit,
+    density: Density,
+    direction: LayoutDirection,
+  ) {
+    val rising = expanded && !this.expanded
+    this.dismiss = dismiss
+    this.items = items
+    if (!expanded || this.density != density || this.direction != direction) opening?.let(::cancel)
+    this.expanded = expanded
+    this.density = density
+    this.direction = direction
+    refresh()
+    if (rising && opening == null) {
+      val geometry = geometry()
+      if (geometry == null || geometry.available.width < with(density) { 112.dp.roundToPx() } ||
+        geometry.available.height < with(density) { 64.dp.roundToPx() } || items.isEmpty()
+      ) {
+        handler.post { if (this.expanded && opening == null) this.dismiss() }
+      } else {
+        opening = MenuOpening(this, geometry, itemLayout())
+      }
+    }
+  }
+
+  fun refresh() {
+    val current = opening ?: return
+    if (!valid(current, geometry())) cancel(current)
+  }
+
+  private fun itemLayout() = items.map { Triple(it.id, it.label, it.icon) }
+
+  private fun valid(
+    current: MenuOpening,
+    next: MenuGeometry?,
+  ): Boolean =
+    opening === current && !current.terminal && expanded && next != null &&
+      next.anchor == current.geometry.anchor && next.origin == current.geometry.origin &&
+      next.token == current.geometry.token && next.display == current.geometry.display &&
+      next.available.contains(current.bounds ?: current.geometry.available) && itemLayout() == current.items
+
+  fun admit(
+    current: MenuOpening,
+    size: IntSize,
+    rows: MenuRows,
+  ): Boolean {
+    if (!valid(current, geometry())) return false
+    if (current.bounds == null) {
+      val available = current.geometry.available
+      val anchor = current.geometry.anchor
+      val start = if (direction == LayoutDirection.Ltr) anchor.left else anchor.right - size.width
+      val end = if (direction == LayoutDirection.Ltr) anchor.right - size.width else anchor.left
+      val x =
+        listOf(start, end).firstOrNull { it >= available.left && it + size.width <= available.right }
+          ?: start.coerceIn(available.left, available.right - size.width)
+      val y =
+        listOf(anchor.bottom, anchor.top - size.height).firstOrNull { it >= available.top && it + size.height <= available.bottom }
+          ?: anchor.bottom.coerceIn(available.top, available.bottom - size.height)
+      current.bounds = IntRect(IntOffset(x, y), size)
+      current.rowLayout = rows
+    }
+    return current.bounds?.size == size && current.rowLayout?.hasSameLayout(rows) == true
+  }
+
+  fun cancel(current: MenuOpening) {
+    if (current.terminal) return
+    // A publication latches immediately; neither a later safe fact nor deferred removal can rearm it.
+    current.terminal = true
+    handler.post { close(current) }
+  }
+
+  private fun close(current: MenuOpening) {
+    if (opening !== current || current.notified) return
+    current.notified = true
+    opening = null
+    if (expanded) dismiss()
+  }
+
+  fun accept(
+    current: MenuOpening,
+    id: String,
+  ) {
+    val geometry = geometry()
+    val item = items.singleOrNull { it.id == id }
+    val root = current.popupRoot
+    val expected = current.bounds?.translate(current.geometry.origin)
+    if (!valid(current, geometry) || item?.enabled != true || root?.isAttachedToWindow != true ||
+      expected == null || root.screenBounds() != expected
+    ) {
+      cancel(current)
+      return
+    }
+    current.terminal = true
+    close(current)
+    item.onClick()
+  }
+
+  private fun geometry(): MenuGeometry? {
+    val activity = activity ?: return null
+    val host = host ?: return null
+    val decor = activity.window.decorView
+    val anchor = anchor?.takeIf { it.isAttached } ?: return null
+    if (!features.ready || lifecycle?.currentState?.isAtLeast(Lifecycle.State.STARTED) != true ||
+      !decor.isAttachedToWindow || !host.isAttachedToWindow || decor.display?.displayId != host.display?.displayId
+    ) {
+      return null
+    }
+    val token = host.windowToken ?: return null
+    val display = host.display?.displayId ?: return null
+    val origin = host.windowOrigin()
+    val activityOffset = decor.windowOrigin() - origin
+    val metrics = WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(activity).bounds
+    val full = IntRect(0, 0, metrics.width(), metrics.height())
+    val position = anchor.positionInWindow()
+    val actualAnchor = IntRect(IntOffset(position.x.roundToInt(), position.y.roundToInt()), anchor.size)
+    val visible = anchor.boundsInWindow()
+    if (visible.isEmpty) return null
+    val pane =
+      foldSafeRegions(full, features.features)
+        .map { it.translate(activityOffset) }
+        .filter { it.contains(actualAnchor) }
+        .minWithOrNull(
+          compareByDescending<IntRect> { it.width.toLong() * it.height }
+            .thenBy { it.top }
+            .thenBy { if (direction == LayoutDirection.Ltr) it.left else -it.right },
+        ) ?: return null
+    val frame = Rect().also(host::getWindowVisibleDisplayFrame)
+    val hostPosition = IntArray(2).also(host::getLocationInWindow)
+    val hostBounds = IntRect(hostPosition[0], hostPosition[1], hostPosition[0] + host.width, hostPosition[1] + host.height)
+    val window = full.translate(activityOffset)
+    val insets =
+      ViewCompat.getRootWindowInsets(host)?.getInsets(
+        WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout() or WindowInsetsCompat.Type.ime(),
+      )
+    val safe =
+      IntRect(
+        window.left + (insets?.left ?: 0),
+        window.top + (insets?.top ?: 0),
+        window.right - (insets?.right ?: 0),
+        window.bottom - (insets?.bottom ?: 0),
+      )
+    val available =
+      pane
+        .intersect(hostBounds)
+        .intersect(safe)
+        .intersect(IntRect(frame.left - origin.x, frame.top - origin.y, frame.right - origin.x, frame.bottom - origin.y))
+    if (available.width <= 0 || available.height <= 0 ||
+      visible.right <= available.left || visible.left >= available.right || visible.bottom <= available.top || visible.top >= available.bottom
+    ) {
+      return null
+    }
+    return MenuGeometry(actualAnchor, available, origin, token, display)
+  }
+}
+
+private fun IntRect.contains(other: IntRect): Boolean = other.width > 0 && other.height > 0 && other.left >= left && other.top >= top && other.right <= right && other.bottom <= bottom
+
+private fun View.windowOrigin(): IntOffset {
+  val screen = IntArray(2).also(::getLocationOnScreen)
+  val window = IntArray(2).also(::getLocationInWindow)
+  return IntOffset(screen[0] - window[0], screen[1] - window[1])
+}
+
+private fun View.screenBounds(): IntRect {
+  val screen = IntArray(2).also(::getLocationOnScreen)
+  return IntRect(screen[0], screen[1], screen[0] + width, screen[1] + height)
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareDropdownMenu.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareDropdownMenu.kt
@@ -7,6 +7,7 @@ import android.os.IBinder
 import android.os.Looper
 import android.view.View
 import android.view.ViewTreeObserver
+import android.view.WindowManager
 import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.heightIn
@@ -104,7 +105,12 @@ internal fun FoldAwareDropdownMenu(
     Popup(
       popupPositionProvider = opening,
       onDismissRequest = opening.dismiss,
-      properties = PopupProperties(focusable = true),
+      // Non-editing menus own native focus without becoming IME targets.
+      properties =
+        PopupProperties(
+          flags = WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH or WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM,
+          inheritSecurePolicy = true,
+        ),
     ) {
       val popupView = LocalView.current
       SideEffect { opening.popupRoot = popupView.rootView }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/WindowLayout.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/WindowLayout.kt
@@ -3,10 +3,11 @@ package ai.openclaw.app.ui
 import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.lifecycle.Lifecycle
@@ -17,21 +18,42 @@ import androidx.window.layout.FoldingFeature
 import androidx.window.layout.WindowInfoTracker
 
 @Composable
-internal fun rememberWindowDisplayFeatures(): List<DisplayFeature> {
+internal fun rememberWindowDisplayFeatures(): List<DisplayFeature> = rememberWindowDisplayFeatureState().value.features
+
+internal data class WindowDisplayFeatureSnapshot(
+  val features: List<DisplayFeature> = emptyList(),
+  val ready: Boolean = false,
+)
+
+@Composable
+internal fun rememberWindowDisplayFeatureState(
+  onPublication: (WindowDisplayFeatureSnapshot) -> Unit = {},
+): State<WindowDisplayFeatureSnapshot> {
   val activity = LocalActivity.current
   val lifecycle = LocalLifecycleOwner.current.lifecycle
-  var features by remember(activity) { mutableStateOf(emptyList<DisplayFeature>()) }
+  val snapshot = remember(activity) { mutableStateOf(WindowDisplayFeatureSnapshot()) }
+  val deliver by rememberUpdatedState(onPublication)
   LaunchedEffect(activity, lifecycle) {
     if (activity != null) {
       // The flow belongs to this Activity, never to a retained ViewModel or application.
       lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-        WindowInfoTracker.getOrCreate(activity).windowLayoutInfo(activity).collect {
-          features = it.displayFeatures
+        try {
+          WindowInfoTracker.getOrCreate(activity).windowLayoutInfo(activity).collect {
+            val publication = WindowDisplayFeatureSnapshot(it.displayFeatures, ready = true)
+            // Delivery precedes conflatable Compose state so transient invalidation is not lost.
+            deliver(publication)
+            snapshot.value = publication
+          }
+        } finally {
+          val unavailable = snapshot.value.copy(ready = false)
+          deliver(unavailable)
+          // Existing List consumers retain their last features while stopped.
+          snapshot.value = unavailable
         }
       }
     }
   }
-  return features
+  return snapshot
 }
 
 /** The largest hinge-free rectangle, in physical window coordinates. */
@@ -39,7 +61,17 @@ internal fun foldSafeRegion(
   host: IntRect,
   features: List<DisplayFeature>,
   direction: LayoutDirection,
-): IntRect {
+): IntRect =
+  foldSafeRegions(host, features).minWithOrNull(
+    compareByDescending<IntRect> { it.width.toLong() * it.height }
+      .thenBy { it.top }
+      .thenBy { if (direction == LayoutDirection.Ltr) it.left else -it.right },
+  ) ?: IntRect(host.left, host.top, host.left, host.top)
+
+internal fun foldSafeRegions(
+  host: IntRect,
+  features: List<DisplayFeature>,
+): List<IntRect> {
   var regions = listOf(host)
   for (feature in features.filterIsInstance<FoldingFeature>()) {
     if (!feature.isSeparating && feature.occlusionType != FoldingFeature.OcclusionType.FULL) continue
@@ -64,9 +96,5 @@ internal fun foldSafeRegion(
           }
         }.distinct()
   }
-  return regions.minWithOrNull(
-    compareByDescending<IntRect> { it.width.toLong() * it.height }
-      .thenBy { it.top }
-      .thenBy { if (direction == LayoutDirection.Ltr) it.left else -it.right },
-  ) ?: IntRect(host.left, host.top, host.left, host.top)
+  return regions
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -56,6 +56,8 @@ import ai.openclaw.app.i18n.verbatimText
 import ai.openclaw.app.operatorScopesAllowAdmin
 import ai.openclaw.app.operatorScopesAllowWrite
 import ai.openclaw.app.resolveAgentIdFromMainSessionKey
+import ai.openclaw.app.ui.FoldAwareDropdownMenu
+import ai.openclaw.app.ui.FoldAwareMenuItem
 import ai.openclaw.app.ui.TabletopPaneBounds
 import ai.openclaw.app.ui.copyGatewayDiagnosticsReport
 import ai.openclaw.app.ui.design.ClawAgentAvatar
@@ -150,8 +152,6 @@ import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -1282,53 +1282,30 @@ private fun ChatHeader(
           contentDescription = nativeString("Chat actions"),
           onClick = { actionsMenuExpanded = true },
         )
-        DropdownMenu(expanded = actionsMenuExpanded, onDismissRequest = { actionsMenuExpanded = false }) {
-          DropdownMenuItem(
-            text = { Text(nativeString("Refresh chat")) },
-            leadingIcon = { Icon(Icons.Default.Refresh, contentDescription = null) },
-            onClick = {
-              actionsMenuExpanded = false
-              onRefresh()
+        FoldAwareDropdownMenu(
+          expanded = actionsMenuExpanded,
+          onDismissRequest = { actionsMenuExpanded = false },
+          items =
+            buildList {
+              add(FoldAwareMenuItem("refresh", nativeString("Refresh chat"), onRefresh, Icons.Default.Refresh))
+              if (branches.size > 1) {
+                add(
+                  FoldAwareMenuItem(
+                    "branches",
+                    nativeString("Switch branch"),
+                    onOpenBranchSwitcher,
+                    Icons.Default.ArrowDropDown,
+                    enabled = branchSwitchEnabled && !branchesLoading,
+                  ),
+                )
+              }
+              add(FoldAwareMenuItem("dashboard", nativeString("Dashboard"), onOpenDashboard, Icons.Default.Dashboard))
+              add(FoldAwareMenuItem("background", nativeString("Background tasks"), onOpenBackgroundTasks, Icons.Default.HourglassEmpty))
+              if (workspaceGit) {
+                add(FoldAwareMenuItem("worktree", newChatInWorktreeLabel, onNewChatInWorktree, enabled = newChatEnabled))
+              }
             },
-          )
-          if (branches.size > 1) {
-            DropdownMenuItem(
-              text = { Text(nativeString("Switch branch")) },
-              leadingIcon = { Icon(Icons.Default.ArrowDropDown, contentDescription = null) },
-              enabled = branchSwitchEnabled && !branchesLoading,
-              onClick = {
-                actionsMenuExpanded = false
-                onOpenBranchSwitcher()
-              },
-            )
-          }
-          DropdownMenuItem(
-            text = { Text(nativeString("Dashboard")) },
-            leadingIcon = { Icon(Icons.Default.Dashboard, contentDescription = null) },
-            onClick = {
-              actionsMenuExpanded = false
-              onOpenDashboard()
-            },
-          )
-          DropdownMenuItem(
-            text = { Text(nativeString("Background tasks")) },
-            leadingIcon = { Icon(Icons.Default.HourglassEmpty, contentDescription = null) },
-            onClick = {
-              actionsMenuExpanded = false
-              onOpenBackgroundTasks()
-            },
-          )
-          if (workspaceGit) {
-            DropdownMenuItem(
-              text = { Text(newChatInWorktreeLabel) },
-              enabled = newChatEnabled,
-              onClick = {
-                actionsMenuExpanded = false
-                onNewChatInWorktree()
-              },
-            )
-          }
-        }
+        )
       }
     }
   }
@@ -3585,7 +3562,7 @@ private fun ChatInputPill(
   modifier: Modifier = Modifier,
 ) {
   val hardwareEnterHandler = remember { PhysicalChatSendKeyHandler() }
-  var attachmentMenuExpanded by rememberSaveable { mutableStateOf(false) }
+  var attachmentMenuExpanded by remember { mutableStateOf(false) }
   val draftStyle = chatDraftStyle()
 
   Surface(
@@ -3654,20 +3631,16 @@ private fun ChatInputPill(
               Icon(imageVector = Icons.Default.Add, contentDescription = nativeString("Add attachment"), modifier = Modifier.size(20.dp))
             }
           }
-          DropdownMenu(expanded = attachmentMenuExpanded, onDismissRequest = { attachmentMenuExpanded = false }) {
-            DropdownMenuItem(text = { Text(nativeString("Photos")) }, leadingIcon = { Icon(Icons.Default.Photo, contentDescription = null) }, onClick = {
-              attachmentMenuExpanded = false
-              onPickImages()
-            })
-            DropdownMenuItem(text = { Text(nativeString("Videos")) }, leadingIcon = { Icon(Icons.Default.Videocam, contentDescription = null) }, onClick = {
-              attachmentMenuExpanded = false
-              onPickVideo()
-            })
-            DropdownMenuItem(text = { Text(nativeString("Files")) }, leadingIcon = { Icon(Icons.Default.AttachFile, contentDescription = null) }, onClick = {
-              attachmentMenuExpanded = false
-              onPickAudioOrDocument()
-            })
-          }
+          FoldAwareDropdownMenu(
+            expanded = attachmentMenuExpanded,
+            onDismissRequest = { attachmentMenuExpanded = false },
+            items =
+              listOf(
+                FoldAwareMenuItem("photos", nativeString("Photos"), onPickImages, Icons.Default.Photo),
+                FoldAwareMenuItem("videos", nativeString("Videos"), onPickVideo, Icons.Default.Videocam),
+                FoldAwareMenuItem("files", nativeString("Files"), onPickAudioOrDocument, Icons.Default.AttachFile),
+              ),
+          )
         }
         Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
           ChatComposerModelPicker(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareDropdownMenuTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareDropdownMenuTest.kt
@@ -367,6 +367,7 @@ class FoldAwareDropdownMenuTest {
     val params = root.layoutParams as WindowManager.LayoutParams
     assertEquals(0, params.flags and (WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL))
     assertTrue(params.flags and WindowManager.LayoutParams.FLAG_SECURE != 0)
+    assertFalse("Non-editing menu must not become an IME target", WindowManager.LayoutParams.mayUseInputMethod(params.flags))
     composeRule.runOnIdle {
       assertTrue(root.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ESCAPE)))
       assertTrue(root.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ESCAPE)))

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareDropdownMenuTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareDropdownMenuTest.kt
@@ -1,0 +1,696 @@
+package ai.openclaw.app.ui
+
+import ai.openclaw.app.ui.design.ClawDesignTheme
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.graphics.Rect
+import android.os.SystemClock
+import android.provider.Settings
+import android.view.KeyEvent
+import android.view.MotionEvent
+import android.view.View
+import android.view.WindowManager
+import android.view.inspector.WindowInspector
+import androidx.activity.compose.LocalActivity
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.absoluteOffset
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.AbsoluteAlignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.window.layout.DisplayFeature
+import androidx.window.layout.FoldingFeature
+import androidx.window.layout.WindowInfoTracker
+import androidx.window.layout.WindowInfoTrackerDecorator
+import androidx.window.layout.WindowLayoutInfo
+import androidx.window.layout.WindowMetrics
+import androidx.window.layout.WindowMetricsCalculator
+import androidx.window.layout.WindowMetricsCalculatorDecorator
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import org.robolectric.shadow.api.Shadow
+import org.robolectric.shadows.ShadowViewRootImpl
+import org.robolectric.util.ReflectionHelpers
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w1000dp-h800dp-mdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class FoldAwareDropdownMenuTest {
+  @get:Rule val composeRule = createComposeRule()
+  private val publisher = FeaturePublisher()
+  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+  private val interactionSource = MutableInteractionSource()
+  private val interactions = mutableListOf<Interaction>()
+  private val actions = mutableListOf<String>()
+  private var dismissals = 0
+  private var expanded by mutableStateOf(false)
+  private var mounted by mutableStateOf(true)
+  private var enabled by mutableStateOf(true)
+  private var x by mutableStateOf(350.dp)
+  private var y by mutableStateOf(80.dp)
+  private var direction by mutableStateOf(LayoutDirection.Ltr)
+  private var fontScale by mutableStateOf(1f)
+  private var labels by mutableStateOf(listOf("Refresh", "Last action"))
+  private lateinit var activity: Activity
+  private lateinit var host: View
+  private lateinit var lifecycle: LifecycleRegistry
+  private var animatorScale: String? = null
+  private var touchDownTime = 0L
+
+  @Before
+  @SuppressLint("RestrictedApi")
+  fun setUp() {
+    WindowInfoTracker.overrideDecorator(
+      object : WindowInfoTrackerDecorator {
+        override fun decorate(tracker: WindowInfoTracker): WindowInfoTracker =
+          object : WindowInfoTracker by tracker {
+            override fun windowLayoutInfo(activity: Activity) = publisher.observe()
+          }
+      },
+    )
+    val resolver = RuntimeEnvironment.getApplication().contentResolver
+    animatorScale = Settings.Global.getString(resolver, Settings.Global.ANIMATOR_DURATION_SCALE)
+    Settings.Global.putFloat(resolver, Settings.Global.ANIMATOR_DURATION_SCALE, 0f)
+  }
+
+  @After
+  @SuppressLint("RestrictedApi")
+  fun tearDown() {
+    scope.cancel()
+    WindowInfoTracker.reset()
+    WindowMetricsCalculator.reset()
+    Settings.Global.putString(RuntimeEnvironment.getApplication().contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, animatorScale)
+  }
+
+  @Test
+  fun unsafeThenSafeBeforeDisposalRetiresHeldEnterButBenignGrowthAndFreshOpeningWork() {
+    publisher.latest = WindowLayoutInfo(listOf(testFold(Rect(490, 0, 510, 800))))
+    showMenu()
+    open()
+    val first = nativePopup()
+    val before = screenBounds(first)
+    holdKey(first, KeyEvent.KEYCODE_ENTER)
+    val press = interactions.filterIsInstance<PressInteraction.Press>().single()
+    val deliveries = publisher.deliveries
+    onMain {
+      publisher.publish(listOf(testFold(Rect(360, 0, 380, 800))))
+      publisher.publish(listOf(testFold(Rect(490, 0, 510, 800))))
+      assertEquals("Both publications reached the owner before UP", deliveries + 2, publisher.deliveries)
+      assertTrue("The original popup must still be attached before UP", first.isAttachedToWindow)
+      assertTrue("The original focused row must survive until UP", first.hasFocus())
+      assertTrue("The original native window must retain focus before UP", first.hasWindowFocus())
+      assertEquals(before, screenBounds(first))
+      assertTrue(first.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER)))
+      assertTrue("The owner must reject the stale action before deferred removal", actions.isEmpty())
+      println("unsafe/safe pre-disposal UP: deliveries=${publisher.deliveries} attached=${first.isAttachedToWindow} focused=${first.hasFocus()} windowFocused=${first.hasWindowFocus()} actions=$actions")
+    }
+    composeRule.waitForIdle()
+    assertEquals(1, dismissals)
+    assertFalse(first.isAttachedToWindow)
+    assertTrue("UP reached the still-live clickable, not an orphan key path", interactions.any { it is PressInteraction.Release && it.press === press })
+
+    interactions.clear()
+    open()
+    val second = nativePopup()
+    val admitted = screenBounds(second)
+    holdKey(second, KeyEvent.KEYCODE_SPACE)
+    onMain {
+      publisher.publish(emptyList())
+      assertTrue(second.isAttachedToWindow && second.hasFocus())
+      assertTrue(second.hasWindowFocus())
+      assertEquals("Growth must not resize or relocate the admitted menu", admitted, screenBounds(second))
+      assertTrue(second.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_SPACE)))
+      assertEquals(listOf("0"), actions)
+    }
+    composeRule.waitForIdle()
+    open()
+    composeRule.onNodeWithText("Refresh").performClick()
+    assertEquals(listOf("0", "0"), actions)
+    assertEquals("Open/close must not create collectors", 1, publisher.registrations)
+  }
+
+  @Test
+  fun actualNativeRectanglesFollowTheAnchorPaneForAllFeaturesAndRtl() {
+    showMenu()
+
+    data class Case(
+      val x: Int,
+      val y: Int,
+      val rtl: Boolean,
+      val features: List<DisplayFeature>,
+      val pane: Rect,
+    )
+    val cases =
+      listOf(
+        Case(350, 80, false, emptyList(), Rect(0, 0, 1000, 800)),
+        Case(350, 80, false, listOf(testFold(Rect(490, 0, 510, 800))), Rect(0, 0, 490, 800)),
+        Case(80, 80, false, listOf(testFold(Rect(200, 0, 220, 800))), Rect(0, 0, 200, 800)),
+        Case(850, 80, true, listOf(testFold(Rect(700, 0, 700, 800))), Rect(700, 0, 1000, 800)),
+        Case(350, 80, false, listOf(testFold(Rect(0, 300, 1000, 320))), Rect(0, 0, 1000, 300)),
+        Case(350, 450, true, listOf(testFold(Rect(490, 0, 510, 800)), testFold(Rect(0, 300, 1000, 320))), Rect(0, 320, 490, 800)),
+        Case(350, 450, false, listOf(testFold(Rect(0, 300, 1000, 320)), testFold(Rect(490, 0, 510, 800))), Rect(0, 320, 490, 800)),
+        Case(350, 400, false, listOf(testFold(Rect(490, 0, 510, 200))), Rect(0, 200, 1000, 800)),
+        Case(350, 80, false, listOf(testFold(Rect(490, 0, 510, 800), separating = false, occlusion = FoldingFeature.OcclusionType.FULL)), Rect(0, 0, 490, 800)),
+        Case(350, 80, false, listOf(testFold(Rect(490, 0, 490, 800), separating = false)), Rect(0, 0, 1000, 800)),
+      )
+    for (case in cases) {
+      println("Native geometry case: $case")
+      composeRule.runOnIdle {
+        x = case.x.dp
+        y = case.y.dp
+        direction = if (case.rtl) LayoutDirection.Rtl else LayoutDirection.Ltr
+      }
+      onMain { publisher.publish(case.features) }
+      open()
+      val popup = nativePopup()
+      val bounds = screenBounds(popup)
+      assertTrue("Native menu $bounds must fit ${case.pane}", case.pane.contains(bounds))
+      assertTrue(popup.layoutParams is WindowManager.LayoutParams)
+      composeRule.onNodeWithText("Refresh").performClick()
+      composeRule.waitForIdle()
+      assertFalse(popup.isAttachedToWindow)
+    }
+    assertEquals(cases.size, actions.size)
+  }
+
+  @Test
+  fun coldReadinessAndZeroViewportDeclineWithoutReopeningAndDisposalReleasesCollector() {
+    publisher.latest = null
+    showMenu()
+    composeRule.onNodeWithTag("anchor").performClick()
+    composeRule.waitForIdle()
+    assertTrue(nativePopups().isEmpty())
+    assertEquals(1, dismissals)
+    onMain { publisher.publish(emptyList()) }
+    composeRule.waitForIdle()
+    assertTrue("First publication must not reopen a declined request", nativePopups().isEmpty())
+    open()
+    onMain { publisher.publish(listOf(testFold(Rect(0, 0, 1000, 800)))) }
+    composeRule.waitForIdle()
+    assertTrue(nativePopups().isEmpty())
+    assertEquals(2, dismissals)
+    onMain { publisher.publish(emptyList()) }
+    composeRule.waitForIdle()
+    assertTrue(nativePopups().isEmpty())
+    open()
+    val popup = nativePopup()
+    composeRule.runOnIdle { mounted = false }
+    composeRule.waitForIdle()
+    assertFalse(popup.isAttachedToWindow)
+    assertEquals(0, publisher.active)
+    assertTrue(actions.isEmpty())
+  }
+
+  @Test
+  fun wrappedRowsFitAndScrollWithoutGrowingOnBenignPublication() {
+    labels = List(6) { "Wrapped action $it with a complete descriptive label" }
+    fontScale = 2f
+    x = 80.dp
+    publisher.latest = WindowLayoutInfo(listOf(testFold(Rect(230, 0, 250, 800)), testFold(Rect(0, 390, 1000, 410))))
+    showMenu()
+    open()
+    val popup = nativePopup()
+    val before = screenBounds(popup)
+    assertTrue(before.right <= 230 && before.bottom <= 390)
+    labels.forEach { label ->
+      val row = composeRule.onNodeWithText(label).performScrollTo().assertIsDisplayed()
+      row.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { action ->
+        val results = mutableListOf<androidx.compose.ui.text.TextLayoutResult>()
+        assertTrue(action(results))
+        assertTrue(results.all { !it.hasVisualOverflow && it.lineCount > 1 })
+      }
+    }
+    onMain { publisher.publish(emptyList()) }
+    composeRule.waitForIdle()
+    assertSame(popup, nativePopup())
+    assertEquals(before, screenBounds(popup))
+    composeRule.onNodeWithText(labels.last()).performClick()
+    assertEquals(listOf("5"), actions)
+  }
+
+  @Test
+  fun touchReleaseAfterInvalidationIsRejectedWhileCancelDragBlankAndDisabledNeverAct() {
+    publisher.latest = WindowLayoutInfo(listOf(testFold(Rect(490, 0, 510, 800))))
+    showMenu()
+    open()
+    var root = nativePopup()
+    var point = firstRowPoint()
+    composeRule.runOnIdle { touch(root, MotionEvent.ACTION_DOWN, point) }
+    composeRule.mainClock.advanceTimeBy(200)
+    composeRule.waitForIdle()
+    val press = interactions.filterIsInstance<PressInteraction.Press>().single()
+    onMain {
+      publisher.publish(listOf(testFold(Rect(360, 0, 380, 800))))
+      publisher.publish(listOf(testFold(Rect(490, 0, 510, 800))))
+      assertTrue(root.isAttachedToWindow)
+      touch(root, MotionEvent.ACTION_UP, point)
+      assertTrue(actions.isEmpty())
+    }
+    composeRule.waitForIdle()
+    assertTrue(interactions.any { it is PressInteraction.Release && it.press === press })
+    assertEquals(1, dismissals)
+
+    open()
+    root = nativePopup()
+    point = firstRowPoint()
+    for (cancel in listOf(true, false)) {
+      interactions.clear()
+      composeRule.runOnIdle { touch(root, MotionEvent.ACTION_DOWN, point) }
+      composeRule.mainClock.advanceTimeBy(200)
+      composeRule.waitForIdle()
+      val held = interactions.filterIsInstance<PressInteraction.Press>().single()
+      composeRule.runOnIdle {
+        if (cancel) {
+          touch(root, MotionEvent.ACTION_CANCEL, point)
+        } else {
+          val moved = Offset(point.x, root.height - 10f)
+          touch(root, MotionEvent.ACTION_MOVE, moved)
+          touch(root, MotionEvent.ACTION_UP, moved)
+        }
+      }
+      composeRule.waitForIdle()
+      assertTrue(interactions.any { it is PressInteraction.Cancel && it.press === held })
+      assertTrue(actions.isEmpty())
+      assertSame(root, nativePopup())
+    }
+    composeRule.runOnIdle {
+      touch(root, MotionEvent.ACTION_DOWN, Offset(2f, 2f))
+      touch(root, MotionEvent.ACTION_UP, Offset(2f, 2f))
+    }
+    composeRule.waitForIdle()
+    assertEquals(1, dismissals)
+    assertTrue(actions.isEmpty())
+    composeRule.runOnIdle {
+      touch(root, MotionEvent.ACTION_DOWN, point)
+      touch(root, MotionEvent.ACTION_UP, point)
+    }
+    composeRule.waitForIdle()
+    assertEquals(listOf("0"), actions)
+    composeRule.runOnIdle { enabled = false }
+    open()
+    root = nativePopup()
+    point = firstRowPoint()
+    composeRule.runOnIdle {
+      touch(root, MotionEvent.ACTION_DOWN, point)
+      touch(root, MotionEvent.ACTION_UP, point)
+    }
+    composeRule.waitForIdle()
+    assertEquals(listOf("0"), actions)
+    assertSame(root, nativePopup())
+  }
+
+  @Test
+  fun nativeWindowKeepsSecureFocusBackAndOutsideDownPolicy() {
+    showMenu()
+    composeRule.runOnIdle { activity.window.addFlags(WindowManager.LayoutParams.FLAG_SECURE) }
+    open()
+    var root = nativePopup()
+    val params = root.layoutParams as WindowManager.LayoutParams
+    assertEquals(0, params.flags and (WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL))
+    assertTrue(params.flags and WindowManager.LayoutParams.FLAG_SECURE != 0)
+    composeRule.runOnIdle {
+      assertTrue(root.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ESCAPE)))
+      assertTrue(root.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ESCAPE)))
+    }
+    composeRule.waitForIdle()
+    assertFalse(root.isAttachedToWindow)
+    assertEquals(1, dismissals)
+    open()
+    root = nativePopup()
+    composeRule.runOnIdle { touch(root, MotionEvent.ACTION_DOWN, Offset(-1f, -1f)) }
+    composeRule.waitForIdle()
+    assertFalse("Popup outside policy dismisses on DOWN without needing UP", root.isAttachedToWindow)
+    assertEquals(2, dismissals)
+    assertTrue(actions.isEmpty())
+  }
+
+  @Test
+  fun actualWrappedRowFitAndClippedAnchorDeclineAndLayoutChangesTerminate() {
+    labels = listOf("A long action that wraps into several measured lines", "Last action")
+    fontScale = 2f
+    x = 20.dp
+    y = 10.dp
+    publisher.latest = WindowLayoutInfo(listOf(testFold(Rect(180, 0, 200, 800)), testFold(Rect(0, 90, 1000, 110))))
+    showMenu()
+    composeRule.onNodeWithTag("anchor").performClick()
+    composeRule.waitForIdle()
+    assertTrue("Nominal 64dp is not enough for the actual wrapped row", nativePopups().isEmpty())
+    assertEquals(1, dismissals)
+    onMain { publisher.publish(emptyList()) }
+    composeRule.waitForIdle()
+    assertTrue(nativePopups().isEmpty())
+    open()
+    val first = nativePopup()
+    composeRule.runOnIdle { labels = labels + "New action" }
+    composeRule.waitForIdle()
+    assertFalse(first.isAttachedToWindow)
+    open()
+    val second = nativePopup()
+    composeRule.runOnIdle { fontScale = 1.5f }
+    composeRule.waitForIdle()
+    assertFalse(second.isAttachedToWindow)
+    assertTrue(nativePopups().isEmpty())
+    composeRule.runOnIdle {
+      x = 1100.dp
+      expanded = true
+    }
+    composeRule.waitForIdle()
+    assertTrue("A wholly clipped anchor cannot authorize a native menu", nativePopups().isEmpty())
+    assertFalse(expanded)
+    assertTrue(actions.isEmpty())
+  }
+
+  @Test
+  fun stoppedLifecycleReleasesWindowAndObserverAndRestartNeedsExplicitOpening() {
+    showMenu()
+    open()
+    val old = nativePopup()
+    composeRule.runOnIdle { lifecycle.currentState = Lifecycle.State.CREATED }
+    composeRule.waitForIdle()
+    assertFalse(old.isAttachedToWindow)
+    assertEquals(0, publisher.active)
+    composeRule.runOnIdle { lifecycle.currentState = Lifecycle.State.RESUMED }
+    composeRule.waitForIdle()
+    assertEquals(1, publisher.active)
+    assertEquals(2, publisher.registrations)
+    assertTrue(nativePopups().isEmpty())
+    open()
+    composeRule.onNodeWithText("Refresh").performClick()
+    assertEquals(listOf("0"), actions)
+  }
+
+  @Test
+  @SuppressLint("RestrictedApi")
+  fun translatedStationaryHostUsesFullActivityExtentAndMovementRetiresHeldInput() {
+    WindowMetricsCalculator.overrideDecorator(
+      object : WindowMetricsCalculatorDecorator {
+        override fun decorate(calculator: WindowMetricsCalculator): WindowMetricsCalculator =
+          object : WindowMetricsCalculator by calculator {
+            override fun computeCurrentWindowMetrics(activity: Activity): WindowMetrics {
+              val metrics = calculator.computeCurrentWindowMetrics(activity)
+              return WindowMetrics(Rect(metrics.bounds).apply { offset(300, 180) }, metrics.density)
+            }
+          }
+      },
+    )
+    publisher.latest = WindowLayoutInfo(listOf(testFold(Rect(490, 0, 510, 800))))
+    showMenu()
+    composeRule.runOnIdle {
+      host.translationX = 17f
+      host.translationY = 11f
+    }
+    open()
+    val popup = nativePopup()
+    val bounds = screenBounds(popup)
+    assertEquals(Rect(271, 131, 407, 243), bounds)
+    holdKey(popup, KeyEvent.KEYCODE_ENTER)
+    composeRule.runOnIdle {
+      // No pre-draw/recomposition: the action gate must read the attached host again.
+      host.translationX = 30f
+      assertTrue(popup.isAttachedToWindow && popup.hasFocus())
+      popup.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER))
+      assertTrue(actions.isEmpty())
+    }
+    composeRule.waitForIdle()
+    assertFalse(popup.isAttachedToWindow)
+  }
+
+  @Test
+  fun deliveredNativeNavigationAndImeFactsBoundAdmissionAndRejectLateInput() {
+    x = 80.dp
+    y = 580.dp
+    showMenu()
+    composeRule.runOnIdle { deliverInsets(ime = 100) }
+    open()
+    val popup = nativePopup()
+    val bounds = screenBounds(popup)
+    assertTrue("The native popup must fit above the delivered IME", bounds.bottom <= 700)
+    holdKey(popup, KeyEvent.KEYCODE_ENTER)
+    composeRule.runOnIdle {
+      deliverInsets(ime = 0)
+      host.viewTreeObserver.dispatchOnPreDraw()
+      assertTrue(popup.isAttachedToWindow && popup.hasFocus())
+      assertEquals("IME disappearance must preserve the admitted rectangle", bounds, screenBounds(popup))
+      popup.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER))
+      assertEquals(listOf("0"), actions)
+    }
+    composeRule.waitForIdle()
+    open()
+    val next = nativePopup()
+    interactions.clear()
+    holdKey(next, KeyEvent.KEYCODE_SPACE)
+    composeRule.runOnIdle {
+      deliverInsets(ime = 400)
+      // An action can arrive before the next pre-draw publication.
+      assertTrue(next.isAttachedToWindow && next.hasFocus())
+      next.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_SPACE))
+      assertEquals(listOf("0"), actions)
+    }
+    composeRule.waitForIdle()
+    assertFalse(next.isAttachedToWindow)
+  }
+
+  private fun showMenu() {
+    composeRule.setContent {
+      val currentActivity = requireNotNull(LocalActivity.current)
+      val currentHost = LocalView.current
+      val currentDensity = LocalDensity.current
+      val currentLifecycle = LocalLifecycleOwner.current.lifecycle
+      SideEffect {
+        activity = currentActivity
+        host = currentHost
+        lifecycle = currentLifecycle as LifecycleRegistry
+      }
+      LaunchedEffect(interactionSource) {
+        interactionSource.interactions.collect { interactions.add(it) }
+      }
+      CompositionLocalProvider(
+        LocalLayoutDirection provides direction,
+        LocalDensity provides Density(currentDensity.density, fontScale),
+      ) {
+        ClawDesignTheme {
+          Box(Modifier.fillMaxSize(), contentAlignment = AbsoluteAlignment.TopLeft) {
+            if (mounted) {
+              Box(Modifier.absoluteOffset(x, y).size(40.dp)) {
+                TextButton(onClick = { expanded = true }, modifier = Modifier.testTag("anchor")) { Text("Open") }
+                FoldAwareDropdownMenu(
+                  expanded = expanded,
+                  onDismissRequest = {
+                    dismissals++
+                    expanded = false
+                  },
+                  items =
+                    labels.mapIndexed { index, label ->
+                      FoldAwareMenuItem(
+                        id = index.toString(),
+                        label = label,
+                        icon = Icons.Default.Refresh,
+                        enabled = enabled,
+                        interactionSource = if (index == 0) interactionSource else null,
+                        onClick = { actions.add(index.toString()) },
+                      )
+                    },
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+    composeRule.waitForIdle()
+    assertEquals(1, publisher.active)
+  }
+
+  private fun open() {
+    composeRule.onNodeWithTag("anchor").performClick()
+    composeRule.waitForIdle()
+    println("Opening: expanded=$expanded dismissals=$dismissals anchor=${composeRule.onNodeWithTag("anchor").getUnclippedBoundsInRoot()} native=${nativePopups().map(::screenBounds)}")
+    composeRule.onNodeWithText(labels.first()).assertIsDisplayed()
+    assertEquals(1, nativePopups().size)
+  }
+
+  private fun holdKey(
+    root: View,
+    key: Int,
+  ) {
+    composeRule.runOnIdle {
+      // Robolectric does not automatically transfer native focus to an added Popup.
+      deliverWindowFocus(activity.window.decorView, false)
+      deliverWindowFocus(root, true)
+      root.requestFocusFromTouch()
+      assertFalse("The native keyboard fixture must leave touch mode", root.isInTouchMode)
+    }
+    composeRule.waitForIdle()
+    composeRule.onNodeWithText(labels.first()).performSemanticsAction(SemanticsActions.RequestFocus) { assertTrue(it()) }
+    composeRule.onNodeWithText(labels.first()).assertIsFocused()
+    composeRule.runOnIdle {
+      assertTrue(root.hasFocus())
+      assertTrue("Native focus must be delivered before DOWN", root.hasWindowFocus())
+      assertTrue(root.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, key)))
+    }
+    composeRule.waitForIdle()
+    assertEquals(1, interactions.filterIsInstance<PressInteraction.Press>().size)
+  }
+
+  private fun deliverWindowFocus(
+    view: View,
+    focused: Boolean,
+  ) {
+    val attachInfo = ReflectionHelpers.getField<Any>(view, "mAttachInfo")
+    val root = ReflectionHelpers.getField<Any>(attachInfo, "mViewRootImpl")
+    Shadow.extract<ShadowViewRootImpl>(root).callWindowFocusChanged(focused)
+  }
+
+  private fun firstRowPoint(): Offset =
+    composeRule
+      .onNodeWithText(labels.first())
+      .fetchSemanticsNode()
+      .boundsInRoot.center
+
+  private fun touch(
+    root: View,
+    action: Int,
+    point: Offset,
+  ) {
+    if (action == MotionEvent.ACTION_DOWN) touchDownTime = SystemClock.uptimeMillis()
+    val event = MotionEvent.obtain(touchDownTime, SystemClock.uptimeMillis(), action, point.x, point.y, 0)
+    try {
+      root.dispatchTouchEvent(event)
+    } finally {
+      event.recycle()
+    }
+  }
+
+  private fun deliverInsets(ime: Int) {
+    val insets =
+      WindowInsetsCompat
+        .Builder()
+        .setInsets(WindowInsetsCompat.Type.navigationBars(), Insets.of(0, 0, 0, 24))
+        .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, ime))
+        .setVisible(WindowInsetsCompat.Type.ime(), ime > 0)
+        .build()
+    // Robolectric dispatch does not populate ViewRootImpl's native last-delivered cache.
+    val attachInfo = ReflectionHelpers.getField<Any>(host, "mAttachInfo")
+    val root = ReflectionHelpers.getField<Any>(attachInfo, "mViewRootImpl")
+    ReflectionHelpers.setField(root, "mLastWindowInsets", insets.toWindowInsets())
+    ViewCompat.dispatchApplyWindowInsets(activity.window.decorView, insets)
+    assertEquals(ime, ViewCompat.getRootWindowInsets(host)?.getInsets(WindowInsetsCompat.Type.ime())?.bottom)
+    assertEquals(24, ViewCompat.getRootWindowInsets(host)?.getInsets(WindowInsetsCompat.Type.navigationBars())?.bottom)
+  }
+
+  private fun onMain(block: suspend () -> Unit) {
+    lateinit var result: Deferred<Unit>
+    composeRule.runOnUiThread { result = scope.async { block() } }
+    composeRule.waitUntil { result.isCompleted }
+    runBlocking { result.await() }
+  }
+
+  private fun nativePopups(): List<View> =
+    WindowInspector.getGlobalWindowViews().filter {
+      it.isAttachedToWindow && (it.layoutParams as? WindowManager.LayoutParams)?.type == WindowManager.LayoutParams.TYPE_APPLICATION_SUB_PANEL
+    }
+
+  private fun nativePopup(): View = nativePopups().single()
+
+  private fun screenBounds(view: View): Rect {
+    val position = IntArray(2).also(view::getLocationOnScreen)
+    return Rect(position[0], position[1], position[0] + view.width, position[1] + view.height)
+  }
+
+  private class FeaturePublisher {
+    private data class Publication(
+      val layout: WindowLayoutInfo,
+      val delivered: CompletableDeferred<Unit> = CompletableDeferred(),
+    )
+
+    private val subscribers = mutableSetOf<Channel<Publication>>()
+    var latest: WindowLayoutInfo? = WindowLayoutInfo(emptyList())
+    var registrations = 0
+    var deliveries = 0
+    val active get() = subscribers.size
+
+    fun observe(): Flow<WindowLayoutInfo> =
+      flow {
+        val channel = Channel<Publication>(Channel.UNLIMITED)
+        subscribers.add(channel)
+        registrations++
+        try {
+          latest?.let { emit(it) }
+          for (publication in channel) {
+            emit(publication.layout)
+            deliveries++
+            publication.delivered.complete(Unit)
+          }
+        } finally {
+          subscribers.remove(channel)
+          channel.close()
+        }
+      }
+
+    suspend fun publish(features: List<DisplayFeature>) {
+      val layout = WindowLayoutInfo(features)
+      latest = layout
+      val publications = subscribers.map { channel -> Publication(layout).also { channel.send(it) } }
+      publications.forEach { it.delivered.await() }
+    }
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/RootScreenFoldTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/RootScreenFoldTest.kt
@@ -107,7 +107,7 @@ class RootScreenFoldTest {
   @get:Rule val composeRule = createComposeRule()
 
   private val layouts = MutableSharedFlow<WindowLayoutInfo>(replay = 1)
-  private val activeActivities = mutableSetOf<Activity>()
+  private val activeCollections = mutableMapOf<Activity, Int>()
   private lateinit var view: View
   private lateinit var backDispatcher: OnBackPressedDispatcher
   private lateinit var focusManager: FocusManager
@@ -122,11 +122,17 @@ class RootScreenFoldTest {
           object : WindowInfoTracker by tracker {
             override fun windowLayoutInfo(activity: Activity): Flow<WindowLayoutInfo> =
               flow {
-                check(activeActivities.add(activity))
+                activeCollections[activity] = (activeCollections[activity] ?: 0) + 1
                 try {
                   emitAll(layouts)
                 } finally {
-                  activeActivities.remove(activity)
+                  val count = checkNotNull(activeCollections[activity])
+                  check(count > 0)
+                  if (count == 1) {
+                    activeCollections.remove(activity)
+                  } else {
+                    activeCollections[activity] = count - 1
+                  }
                 }
               }
           }
@@ -831,38 +837,61 @@ class RootScreenFoldTest {
     val first = Robolectric.buildActivity(ComponentActivity::class.java).setup()
     val second = Robolectric.buildActivity(ComponentActivity::class.java).create()
     var activity by mutableStateOf(first.get())
+    var siblingEnabled by mutableStateOf(false)
     var observed = emptyList<DisplayFeature>()
+    var siblingObserved = emptyList<DisplayFeature>()
     try {
       composeRule.setContent {
         CompositionLocalProvider(LocalActivity provides activity, LocalLifecycleOwner provides activity) {
           val features = rememberWindowDisplayFeatures()
           SideEffect { observed = features }
+          if (siblingEnabled) {
+            val siblingFeatures = rememberWindowDisplayFeatures()
+            SideEffect { siblingObserved = siblingFeatures }
+          }
         }
       }
-      composeRule.runOnIdle { assertEquals(setOf(first.get()), activeActivities) }
+      composeRule.runOnIdle { assertEquals(mapOf(first.get() to 1), activeCollections) }
       val fold = testFold(Rect(490, 0, 510, 1000))
       emit(listOf(fold))
       composeRule.runOnIdle { assertEquals(listOf(fold), observed) }
+      composeRule.runOnIdle { siblingEnabled = true }
+      composeRule.runOnIdle {
+        assertEquals(mapOf(first.get() to 2), activeCollections)
+        assertEquals(listOf(fold), observed)
+        assertEquals(listOf(fold), siblingObserved)
+      }
+      composeRule.runOnIdle { siblingEnabled = false }
+      composeRule.runOnIdle { assertEquals(mapOf(first.get() to 1), activeCollections) }
+      val updatedFold = testFold(Rect(590, 0, 610, 1000))
+      emit(listOf(updatedFold))
+      composeRule.runOnIdle {
+        assertEquals(listOf(updatedFold), observed)
+        assertEquals(listOf(fold), siblingObserved)
+      }
       composeRule.runOnIdle {
         first.pause().stop()
       }
-      composeRule.runOnIdle { assertTrue(activeActivities.isEmpty()) }
+      composeRule.runOnIdle { assertTrue(activeCollections.isEmpty()) }
       composeRule.runOnIdle { first.start().resume() }
-      composeRule.runOnIdle { assertEquals(setOf(first.get()), activeActivities) }
+      composeRule.runOnIdle {
+        assertEquals(mapOf(first.get() to 1), activeCollections)
+        assertEquals(listOf(updatedFold), observed)
+      }
       composeRule.runOnIdle { activity = second.get() }
       composeRule.runOnIdle {
-        assertTrue("The stopped replacement must not collect", activeActivities.isEmpty())
+        assertTrue("The stopped replacement must not collect", activeCollections.isEmpty())
         assertTrue("Do not retain old-Activity features while awaiting an emission", observed.isEmpty())
         first.pause().stop().destroy()
         second.start().resume()
       }
-      composeRule.runOnIdle { assertEquals(setOf(second.get()), activeActivities) }
+      composeRule.runOnIdle { assertEquals(mapOf(second.get() to 1), activeCollections) }
       emit(emptyList())
       composeRule.runOnIdle {
         assertTrue(observed.isEmpty())
         second.pause().stop().destroy()
       }
-      composeRule.runOnIdle { assertTrue(activeActivities.isEmpty()) }
+      composeRule.runOnIdle { assertTrue(activeCollections.isEmpty()) }
     } finally {
       if (!first.get().isDestroyed) first.pause().stop().destroy()
       if (!second.get().isDestroyed) second.pause().stop().destroy()

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
@@ -26,6 +26,8 @@ import ai.openclaw.app.ui.design.ClawDesignTheme
 import ai.openclaw.app.ui.design.ClawTheme
 import ai.openclaw.app.ui.testFold
 import android.Manifest
+import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.Rect
@@ -33,6 +35,7 @@ import android.provider.Settings
 import android.speech.SpeechRecognizer
 import android.view.KeyEvent
 import android.view.View
+import android.view.WindowManager
 import android.view.inputmethod.EditorInfo
 import android.view.inspector.WindowInspector
 import androidx.activity.compose.LocalActivity
@@ -88,6 +91,7 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDialog
 import androidx.compose.ui.test.isPopup
+import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
@@ -128,7 +132,15 @@ import androidx.lifecycle.LifecycleRegistry
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelStore
 import androidx.window.layout.DisplayFeature
+import androidx.window.layout.WindowInfoTracker
+import androidx.window.layout.WindowInfoTrackerDecorator
+import androidx.window.layout.WindowLayoutInfo
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -171,6 +183,7 @@ class ChatComposerLayoutTest {
   private val viewModelStore = ViewModelStore()
   private var originalAnimatorScale: String? = null
   private var renderedCanvasColor = Color.Unspecified
+  private lateinit var chatActivity: Activity
   private lateinit var insetView: View
   private var observedBottomInsets: Pair<Int, Int>? = null
   private lateinit var renderedDensity: Density
@@ -655,6 +668,56 @@ class ChatComposerLayoutTest {
       assertEquals("The resized transcript reaches its latest edge", 0f, range.value(), 0f)
       assertEquals("The same complete history fits after resizing", 0f, range.maxValue(), 0f)
       composeRule.onNodeWithContentDescription(nativeString("Jump to latest")).assertDoesNotExist()
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "w1000dp-h800dp-mdpi")
+  @SuppressLint("RestrictedApi")
+  fun chatActionsNativeWindowStaysInTheAnchorFoldPane() {
+    val fold = testFold(Rect(490, 0, 510, 800))
+    WindowInfoTracker.overrideDecorator(
+      object : WindowInfoTrackerDecorator {
+        override fun decorate(tracker: WindowInfoTracker): WindowInfoTracker =
+          object : WindowInfoTracker by tracker {
+            override fun windowLayoutInfo(activity: Activity): Flow<WindowLayoutInfo> =
+              flow {
+                emit(WindowLayoutInfo(listOf(fold)))
+                awaitCancellation()
+              }
+          }
+      },
+    )
+    try {
+      showChat(viewportWidth = 490.dp, viewportHeight = { 640.dp })
+      composeRule.runOnIdle {
+        val published = runBlocking { WindowInfoTracker.getOrCreate(chatActivity).windowLayoutInfo(chatActivity).first() }
+        assertEquals(listOf(fold), published.displayFeatures)
+      }
+      readerHeaderControl("Chat actions").performClick()
+      composeRule.onNode(hasText(nativeString("Refresh chat")) and hasClickAction()).assertIsDisplayed()
+      composeRule.runOnIdle {
+        val roots = WindowInspector.getGlobalWindowViews().filter { it.isAttachedToWindow }
+        val popup =
+          roots.single { (it.layoutParams as? WindowManager.LayoutParams)?.type == WindowManager.LayoutParams.TYPE_APPLICATION_SUB_PANEL }
+        val activityRoot = chatActivity.window.decorView
+        assertTrue("The menu must have a separate native owner", popup !== activityRoot)
+        assertTrue("Native popup geometry must be nonzero", popup.width > 0 && popup.height > 0)
+        val activityScreen = IntArray(2).also(activityRoot::getLocationOnScreen)
+        val activityWindow = IntArray(2).also(activityRoot::getLocationInWindow)
+        val popupScreen = IntArray(2).also(popup::getLocationOnScreen)
+        val bounds = Rect(popupScreen[0], popupScreen[1], popupScreen[0] + popup.width, popupScreen[1] + popup.height)
+        val params = popup.layoutParams as WindowManager.LayoutParams
+        val originX = activityScreen[0] - activityWindow[0]
+        println("Native menu bounds=$bounds requested=(${params.x},${params.y},${params.width},${params.height}) activityOriginX=$originX fold=${fold.bounds}")
+        assertEquals("The fixture must model the native sub-panel's horizontal placement", originX + params.x, bounds.left)
+        assertTrue(
+          "Actual Chat actions native window $bounds must stay left of the Activity fold at ${originX + fold.bounds.left}",
+          bounds.left >= originX && bounds.right <= originX + fold.bounds.left,
+        )
+      }
+    } finally {
+      WindowInfoTracker.reset()
     }
   }
 
@@ -1754,6 +1817,28 @@ class ChatComposerLayoutTest {
   }
 
   @Test
+  fun attachmentMenuDoesNotRestoreWhileDraftAndExplicitReopeningRemainUsable() {
+    val restoration = StateRestorationTester(composeRule)
+    showChat(viewportHeight = { 640.dp }, restorationTester = restoration)
+    composeRule.onNode(hasSetTextAction()).performTextInput("retained menu draft")
+    composeRule.onNodeWithContentDescription(nativeString("Add attachment")).performClick()
+    composeRule.onNodeWithText(nativeString("Photos")).assertIsDisplayed()
+    val old =
+      WindowInspector.getGlobalWindowViews().single {
+        it.isAttachedToWindow && (it.layoutParams as? WindowManager.LayoutParams)?.type == WindowManager.LayoutParams.TYPE_APPLICATION_SUB_PANEL
+      }
+    restoration.emulateSavedInstanceStateRestore()
+    composeRule.waitForIdle()
+    assertFalse(old.isAttachedToWindow)
+    composeRule.onNode(isPopup()).assertDoesNotExist()
+    composeRule.onNode(hasSetTextAction()).assertTextEquals("retained menu draft")
+    composeRule.onNodeWithContentDescription(nativeString("Add attachment")).performClick()
+    for (label in listOf("Photos", "Videos", "Files")) {
+      composeRule.onNodeWithText(nativeString(label)).assertIsDisplayed()
+    }
+  }
+
+  @Test
   fun narrowComposerKeepsModelNamesOnOneLineWithLargeTextAndContextUsage() {
     NativeStringResources.setApplicationLocales(LocaleListCompat.forLanguageTags("fr"))
     val fontScale = mutableStateOf(1f)
@@ -2412,11 +2497,15 @@ class ChatComposerLayoutTest {
     displayFeatures: (() -> List<DisplayFeature>)? = null,
     viewportOffset: () -> IntOffset = { IntOffset.Zero },
     layoutDirection: () -> LayoutDirection = { LayoutDirection.Ltr },
+    restorationTester: StateRestorationTester? = null,
   ): MainViewModel {
     val viewModel = MainViewModel(app, prefs, SavedStateHandle())
     viewModelStore.put("chat", viewModel)
     viewModel.enterScreenshotFixtureMode(AndroidScreenshotScene.Chat)
-    composeRule.setContent {
+    val setContent = restorationTester?.let { it::setContent } ?: composeRule::setContent
+    setContent {
+      val currentActivity = requireNotNull(LocalActivity.current)
+      SideEffect { chatActivity = currentActivity }
       if (useChatShell) {
         val activity = requireNotNull(LocalActivity.current)
         val view = LocalView.current


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/140708

## What Problem This Solves

Fixes an issue where users opening Chat actions or Add attachment on a foldable
could get a popup across the hinge, even though the underlying Chat was in a
safe pane. A popup also must not choose an action from an opening invalidated by
a fold or window change.

Native testing found a second problem during this repair: opening the attachment
menu over Gboard briefly dismissed the keyboard and canceled the menu.

## Why This Change Was Made

These two menus now use the safe region containing their actual trigger,
respecting current window origins, fold features and system/keyboard insets.
An invalidated opening is retired; recovering space does not silently reopen
it or authorize an old input event. A new deliberate tap creates a new opening.

The popup stays focusable for native Back and input interception without
becoming an IME target. The editor, reader, attachment acquisition and business
actions keep their existing owners. This is scoped to Chat actions and Add
attachment, not message long-press menus, the Thinking sheet or every popup.

## User Impact

Chat menus remain usable in their fold-safe pane, including while typing.
Dismissing a menu or canceling the system Files picker does not discard the
draft. Invalid layout transitions close the menu without selecting an action.

## Evidence

- Original control reproduces a Chat actions popup crossing the vertical fold.
- **94 focused JVM/Robolectric tests pass**, including geometry, native-window,
  Chat, Root, content and hardware-key coverage. Ordinary Android lint, actual
  changed-file checks and the debug APK build pass.
- Original-red checks cover invalidated actions and popup IME eligibility.
  Integration corrects the Root test tracker to model independent WindowManager
  subscribers, retaining exact lifecycle cleanup and partial-removal checks.
- Independent source reviews completed without unresolved actionable findings.
- **Combined API 36 emulator proof:** book-mode menus stay in the right plane;
  Photos/Videos/Files stays visible over real Gboard with the Activity remaining
  the IME target. Canceling the real Files picker retains the draft and typing
  focus. Tabletop attachment and Chat actions menus stay in the lower and upper
  planes respectively. Rotation cancels the old opening; returning does not
  reopen it; a deliberate fresh tap works.
- Separate matched-base proof also covers hardware-key and outside-key
  interception, including a positive typing control after dismissal.

The before capture predates the merged book/tabletop slices; the original-red
tests isolate the menu defects. Captures use synthetic data, with no live Gateway,
selected file, send or recording. No physical-device, native held-pointer,
predictive-Back animation or active-capture certification is claimed.

### Before

![Original popup crossing the vertical fold](https://github.com/user-attachments/assets/a8321cd4-45e5-4e91-a914-92eb4c5b1bed)

### Book And Keyboard

![Chat actions inside the right plane](https://github.com/user-attachments/assets/e719d911-21aa-411f-a27d-c3415b95bea5)

![Attachment menu above Gboard inside the right plane](https://github.com/user-attachments/assets/a5a7cadd-bc94-4663-8383-e72e9333deb0)

### Tabletop

![Attachment menu inside the lower plane](https://github.com/user-attachments/assets/fee83d0b-8605-4dee-aef3-4c97e5968627)

![Chat actions inside the upper plane](https://github.com/user-attachments/assets/0ec36472-23c7-4c6a-82ac-2362855efb9a)
