### PR TITLE
fix(codex): re-send workspace references dropped by prompt fitting

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -1070,7 +1070,9 @@ Codex harness forwards the other bootstrap files as developer instructions:
   These references are introduced on the first turn of a new native thread,
   after a cold resume (including a Gateway restart), after native compaction,
   or when their rendered content changes. Unchanged references are omitted
-  on subsequent warm turns. Tracking is process-local; reference content
+  on subsequent warm turns once the complete reference block has been submitted.
+  If prompt fitting drops or truncates the block, a later turn introduces it again.
+  Tracking is process-local; reference content
   remains ordinary user input in native history.
 
 ## Environment overrides

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -60,7 +60,9 @@ instructions. Active `BOOTSTRAP.md` and, when memory tools are unavailable,
 bounded `MEMORY.md` content travel as plain turn input references. They are
 introduced on a new native thread, after a cold resume or native compaction,
 and when their rendered content changes. Consecutive warm turns omit unchanged
-references; process-local tracking resets when the Gateway restarts.
+references once the complete block has been submitted. References dropped or
+truncated by prompt fitting are introduced again on a later turn. Process-local
+tracking resets when the Gateway restarts.
 
 Delivery mode and the current message target requirement arrive as compact
 application context before each user turn. They explicitly supersede earlier

--- a/extensions/codex/src/app-server/run-attempt-turn-request.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-request.ts
@@ -127,6 +127,9 @@ export async function prepareCodexAttemptTurnRequest(
     );
     connection.mutable.pluginAppServer = turnAppServer;
     const references = prepareWorkspaceReferences();
+    const referencesRetained = turnState.codexTurnPromptText.includes(
+      workspaceBootstrapContext.promptContext ?? "",
+    );
     const turnStartParams = buildTurnStartParams(
       {
         ...runtimeParams,
@@ -194,7 +197,10 @@ export async function prepareCodexAttemptTurnRequest(
       );
       acceptedTurnId = startedTurn.turn.id;
       connection.assertCurrent();
-      references.accepted();
+      // Fitting may drop or truncate references; only acknowledge the complete block.
+      if (referencesRetained) {
+        references.accepted();
+      }
       throwIfTurnStartAcceptedAfterAbort();
       return startedTurn;
     } catch (error) {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -4729,6 +4729,7 @@ describe("runCodexAppServerAttempt", () => {
     "cold resume",
     "unsubscribed",
     "compacted during acceptance",
+    "dropped by fitting",
   ] as const)(
     "introduces bounded workspace references once per native thread need: %s",
     async (scenario) => {
@@ -4738,6 +4739,18 @@ describe("runCodexAppServerAttempt", () => {
       await fs.mkdir(workspaceDir, { recursive: true });
       await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
       await fs.writeFile(path.join(workspaceDir, "BOOTSTRAP.md"), bootstrap);
+      let oversizedPrefix = scenario === "dropped by fitting";
+      if (oversizedPrefix) {
+        openRunSession(sessionFile).appendMessage(userMessage("Earlier conversation", Date.now()));
+        initializeGlobalHookRunner(
+          createMockPluginRegistry([
+            {
+              hookName: "before_prompt_build",
+              handler: () => ({ prependContext: oversizedPrefix ? "p".repeat(1 << 20) : "" }),
+            },
+          ]),
+        );
+      }
       let compactDuringAcceptance = false;
       let harness = createStartedThreadHarness(
         async (method) => {
@@ -4792,29 +4805,43 @@ describe("runCodexAppServerAttempt", () => {
         return { input, result };
       };
       const first = await runTurn();
-      expect(first.input).toContain(memorySummary);
-      expect(first.input).toContain(bootstrap);
-      expect(first.input).not.toContain("memory_search");
-      expect(
-        first.result.systemPromptReport?.injectedWorkspaceFiles.find(
-          (file) => file.name === "MEMORY.md",
-        ),
-      ).toMatchObject({
-        rawChars: memorySummary.length,
-        injectedChars: memorySummary.length,
-        truncated: false,
-      });
-      compactDuringAcceptance = scenario === "compacted during acceptance";
-      const second = await runTurn();
-      expect.soft(second.input).not.toContain(memorySummary);
-      expect.soft(second.input).not.toContain(bootstrap);
-      expect
-        .soft(
-          second.result.systemPromptReport?.injectedWorkspaceFiles.find(
+      if (oversizedPrefix) {
+        expect(first.input.length).toBeLessThanOrEqual(1 << 20);
+        expect(first.input).toContain("Earlier conversation");
+        expect(first.input).toContain("Current user request:");
+        expect(first.input).not.toContain(memorySummary);
+        expect(first.input).not.toContain(bootstrap);
+      } else {
+        expect(first.input).toContain(memorySummary);
+        expect(first.input).toContain(bootstrap);
+        expect(
+          first.result.systemPromptReport?.injectedWorkspaceFiles.find(
             (file) => file.name === "MEMORY.md",
           ),
-        )
-        .toMatchObject({ injectedChars: 0, truncated: false });
+        ).toMatchObject({
+          rawChars: memorySummary.length,
+          injectedChars: memorySummary.length,
+          truncated: false,
+        });
+      }
+      expect(first.input).not.toContain("memory_search");
+      compactDuringAcceptance = scenario === "compacted during acceptance";
+      oversizedPrefix = false;
+      const second = await runTurn();
+      if (scenario === "dropped by fitting") {
+        expect(second.input).toContain(memorySummary);
+        expect(second.input).toContain(bootstrap);
+      } else {
+        expect.soft(second.input).not.toContain(memorySummary);
+        expect.soft(second.input).not.toContain(bootstrap);
+        expect
+          .soft(
+            second.result.systemPromptReport?.injectedWorkspaceFiles.find(
+              (file) => file.name === "MEMORY.md",
+            ),
+          )
+          .toMatchObject({ injectedChars: 0, truncated: false });
+      }
       expect(harness.requests.filter(({ method }) => method === "thread/start")).toHaveLength(1);
       expect(harness.requests.filter(({ method }) => method === "thread/resume")).toHaveLength(0);
 
@@ -4839,7 +4866,7 @@ describe("runCodexAppServerAttempt", () => {
         await releaseCodexAppServerLiveThread(harness.client, "thread-1");
       }
       const third = await runTurn();
-      if (scenario === "unchanged") {
+      if (scenario === "unchanged" || scenario === "dropped by fitting") {
         expect.soft(third.input).not.toContain(expectedMemory);
         expect.soft(third.input).not.toContain(bootstrap);
       } else {


### PR DESCRIPTION
Related: #140814

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users continuing a Codex conversation after an oversized projected turn would lose workspace references on subsequent warm turns. Prompt fitting could discard the reference block, yet OpenClaw treated it as delivered and omitted it from the next request.

## Why This Change Was Made

Only acknowledge the rendered reference digest when the complete block survives final prompt fitting and `turn/start` accepts the input. Capture that survival decision from the fitted prompt before submission; dropped or truncated references retain their previous digest/reintroduction state. Tracking remains process-local, with the existing subscription and compaction invalidation ownership.

The directly inspected Codex source contract is `codex-rs/app-server-protocol/src/protocol/v2/turn.rs` (`TurnStartParams.input`) and `codex-rs/protocol/src/user_input.rs` (`UserInput::Text`, `MAX_USER_INPUT_TEXT_CHARS = 1 << 20`). OpenClaw's `buildCodexUserInput` forwards the fitted text unchanged.

## User Impact

A later short warm turn reintroduces references discarded by fitting. Subsequent unchanged turns omit them again once the complete block has been submitted. No configuration, persistence, schema, dependency, or prompt-budget changes.

Updated `docs/plugins/codex-harness-reference.md` and `docs/plugins/codex-harness-runtime.md` to state when references count as introduced.

## Evidence

Before the production fix, the oversized projected-turn → short warm-turn regression failed for the intended reason: the second request contained only `hello`, without the expected workspace memory reference. Result: **1 failed, 197 skipped**. The first submitted prompt was bounded, retained the projected conversation/current request, and omitted both workspace references.

```sh
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t 'dropped by fitting'
```

After the fix, the full focused run passed:

```sh
node scripts/run-vitest.mjs extensions/codex/src/app-server/{run-attempt,client-runtime,thread-resume,attempt-context,turn-params,trajectory,context-engine-projection}.test.ts
```

```text
Test Files  7 passed (7)
     Tests  318 passed (318)
  Duration  239.87s
```

This includes all six existing reference lifecycle cases, the oversized-turn regression, and fitting tests. The regression also proves the recovered reference block is omitted on the next unchanged warm turn and that trajectory context matches submitted text. The three pre-existing plan-restoration failures documented in #140814 did not recur.

Fresh Codex autoreview at P0/P1: **scoped-clean, zero accepted/actionable findings; overall: patch is correct**. Targeted formatting and `git diff --check` passed.

Production diff: **+7/-1 lines** (net +6) for the fitted-input acknowledgement guard. Test diff: **+48/-21**; docs: **+6/-2**. No duplicated production path needed removal.

Fixture proof covers submitted requests and lifecycle behavior; live provider billing/cache measurements were not run.

`node scripts/check-changed.mjs` passed formatting, production/test TypeScript, doctor contracts, plugin boundaries, dependency guards, coercion/deprecation guards, and all three dead-export scans. It stopped at extension lint with the known nested-checkout `Declaration input escapes checkout` error for `qrcode@1.5.4/package.json`. No boundary was bypassed; exact-head CI is authoritative for that lane.

An initial typecheck failure came from stale local dependencies (`fs-safe` 0.8.1 installed versus 0.8.3 in the existing lockfile). `pnpm install --frozen-lockfile` corrected the worktree-local install without tracked changes, and both typechecks passed on the gate rerun.

The remaining database-first, media-download, runtime-sidecar, and import-cycle guards were run separately and all passed (zero runtime value cycles). After dependency reconciliation, all seven reference lifecycle cases passed again: **7 passed, 191 skipped**, 108.53 seconds.

Final exact-head CI: **GREEN** for `db7d11a87d04d3796ac6610d7044bf7b56d44cd7`. [CI run 34088021246](https://github.com/openclaw/openclaw/actions/runs/34088021246) completed successfully: **84 successful jobs, 16 skipped, zero failed/cancelled/timed-out jobs**. The [authoritative lint job](https://github.com/openclaw/openclaw/actions/runs/34088021246/job/101635835555) passed. The bounded `watch-pr-ci` command exited 0 with `GREEN`; no CI repair or rerun was needed.
