### PR TITLE
fix(update): finalize plugins from the activated package after handoff

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -620,6 +620,10 @@ openclaw gateway restart
 openclaw gateway uninstall
 ```
 
+`gateway stop` remains available when plugin configuration needs Doctor migration.
+It still validates core configuration and refuses configuration written by a newer
+OpenClaw binary. Start and restart continue to validate plugin configuration.
+
 ### Recover an unreadable native service definition
 
 If installation or a managed update reports `SERVICE_DEFINITION_UNKNOWN`, first

--- a/src/cli/daemon-cli/lifecycle-action-preflight.test.ts
+++ b/src/cli/daemon-cli/lifecycle-action-preflight.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { resetConfigRuntimeState } from "../../config/config.js";
+import { readConfigFileSnapshot, resetConfigRuntimeState } from "../../config/config.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import { getServiceActionPreflightFailure } from "./lifecycle-action-preflight.js";
 
@@ -45,6 +45,60 @@ describe("getServiceActionPreflightFailure", () => {
     },
   );
 
+  it("allows stopping before plugin config migration while retaining the newer-writer guard", async () => {
+    await withIsolatedLifecycleState(async ({ configPath }) => {
+      const pluginRoot = path.join(path.dirname(configPath), "migration-fixture");
+      await fs.mkdir(pluginRoot);
+      await fs.writeFile(path.join(pluginRoot, "index.js"), "export default {};\n");
+      await fs.writeFile(
+        path.join(pluginRoot, "package.json"),
+        JSON.stringify({
+          name: "migration-fixture",
+          version: "2.0.0",
+          openclaw: { extensions: ["./index.js"] },
+        }),
+      );
+      await fs.writeFile(
+        path.join(pluginRoot, "openclaw.plugin.json"),
+        JSON.stringify({
+          id: "migration-fixture",
+          configSchema: {
+            type: "object",
+            required: ["current"],
+            properties: { current: { type: "boolean" } },
+            additionalProperties: false,
+          },
+        }),
+      );
+      const config = {
+        plugins: {
+          allow: ["migration-fixture"],
+          load: { paths: [pluginRoot] },
+          entries: { "migration-fixture": { enabled: true, config: { legacy: true } } },
+        },
+      };
+      await fs.writeFile(configPath, JSON.stringify(config));
+      resetConfigRuntimeState();
+      const snapshot = await readConfigFileSnapshot({ observe: false });
+      expect(snapshot.valid).toBe(false);
+      expect(
+        snapshot.issues.some((issue) => issue.path.startsWith("plugins.entries.migration-fixture")),
+      ).toBe(true);
+      expect(await getServiceActionPreflightFailure("start")).not.toBeNull();
+      expect(await getServiceActionPreflightFailure("restart")).not.toBeNull();
+      expect(await getServiceActionPreflightFailure("stop")).toBeNull();
+
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ ...config, meta: { lastTouchedVersion: "9999.1.1" } }),
+      );
+      resetConfigRuntimeState();
+      expect((await getServiceActionPreflightFailure("stop"))?.message).toContain(
+        "older than the config",
+      );
+    });
+  });
+
   it.each(["start", "restart"] as const)(
     "allows %s when no legacy credential files exist",
     async (action) => {
@@ -54,7 +108,7 @@ describe("getServiceActionPreflightFailure", () => {
     },
   );
 
-  it.each(["start", "restart"] as const)(
+  it.each(["start", "restart", "stop"] as const)(
     "renders actionable invalid-config diagnostics before %s",
     async (action) => {
       await withIsolatedLifecycleState(async ({ configPath }) => {

--- a/src/cli/daemon-cli/lifecycle-action-preflight.ts
+++ b/src/cli/daemon-cli/lifecycle-action-preflight.ts
@@ -30,7 +30,12 @@ export async function getServiceActionPreflightFailure(
 ): Promise<ServiceActionPreflightFailure | null> {
   let snapshot: ConfigFileSnapshot;
   try {
-    snapshot = await readConfigFileSnapshot({ observe: false });
+    // Stop must remain available before Doctor migrates newly installed plugins.
+    // Core validation and the newer-writer guard still protect service selection.
+    snapshot = await readConfigFileSnapshot({
+      observe: false,
+      pluginValidation: action === "stop" ? "core-only" : undefined,
+    });
     if (snapshot.exists && !snapshot.valid) {
       const message =
         snapshot.issues.length > 0

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2016,6 +2016,11 @@ describe("update-cli", () => {
       if (argv[1] === "--version") {
         return commandResult({ stdout: "12.0.0\n" });
       }
+      if (argv[2] === "gateway" && argv[3] === "stop") {
+        return commandResult({
+          stdout: JSON.stringify({ action: "stop", ok: true, result: "stopped" }),
+        });
+      }
       if (argv[0] === "npm" && argv[1] === "pack") {
         const destination = argv[argv.indexOf("--pack-destination") + 1];
         if (destination) {
@@ -3853,6 +3858,7 @@ describe("update-cli", () => {
   );
 
   it("post-core resume returns package work without running core update or Doctor completion", async () => {
+    readPackageVersion.mockResolvedValue("2026.9.4");
     await runPostCoreCommand({ restart: false }, { OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1" });
 
     expect(runGatewayUpdate).not.toHaveBeenCalled();
@@ -3872,6 +3878,10 @@ describe("update-cli", () => {
     expect(vi.mocked(runExec).mock.calls.filter(([, args]) => args[1] === "doctor")).toEqual([]);
     expect(syncPluginsForUpdateChannel).toHaveBeenCalledTimes(1);
     expect(updateNpmInstalledPlugins).toHaveBeenCalledTimes(1);
+    expect(lastNpmPluginUpdateCall()).toMatchObject({
+      coreVersion: "2026.9.4",
+      versionBoundPluginIds: new Set(["codex"]),
+    });
     expect(spawn).not.toHaveBeenCalled();
   });
 
@@ -9686,7 +9696,14 @@ describe("update-cli", () => {
     });
     await expect(updateCommand({ yes: true })).rejects.toEqual(new ExitError(1));
 
-    expect(serviceStop).toHaveBeenCalledTimes(2);
+    expect(serviceStop).toHaveBeenCalledOnce();
+    const stopCallIndex = vi
+      .mocked(runCommandWithTimeout)
+      .mock.calls.findIndex(([args]) => args[2] === "gateway" && args[3] === "stop");
+    expect(vi.mocked(runCommandWithTimeout).mock.calls[stopCallIndex]).toEqual([
+      [expect.any(String), serviceEntrypoint, "gateway", "stop", "--force", "--json"],
+      expect.objectContaining({ cwd: process.cwd() }),
+    ]);
     expect(runRestartScript).toHaveBeenCalledOnce();
     const firstRestartOrder = requireValue(
       runRestartScript.mock.invocationCallOrder[0],
@@ -9697,7 +9714,7 @@ describe("update-cli", () => {
       "plugin packages",
     );
     const secondStopOrder = requireValue(
-      serviceStop.mock.invocationCallOrder[1],
+      vi.mocked(runCommandWithTimeout).mock.invocationCallOrder[stopCallIndex],
       "plugin maintenance stop",
     );
     const doctorCallIndex = vi

--- a/src/cli/update-cli/update-command-plugins.ts
+++ b/src/cli/update-cli/update-command-plugins.ts
@@ -2,6 +2,7 @@
 import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../../packages/gateway-protocol/src/capability-consent-error-details.js";
 import { stripAnsi } from "../../../packages/terminal-core/src/ansi.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { VERSION_BOUND_RUNTIME_PLUGIN_IDS } from "../../commands/doctor/shared/configured-runtime-plugin-installs.js";
 import { runPostCorePluginConvergence } from "../../commands/doctor/shared/post-core-plugin-convergence.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -233,6 +234,7 @@ export async function updatePluginsAfterCoreUpdate(params: {
     config: withPluginInstallRecords(params.configSnapshot.sourceConfig, pluginInstallRecords),
     channel: pluginUpdateChannel,
     coreVersion: coreVersion ?? undefined,
+    versionBoundPluginIds: VERSION_BOUND_RUNTIME_PLUGIN_IDS,
     timeoutMs: params.timeoutMs,
     workspaceDir: params.root,
     externalizedBundledPluginBridges: await listPersistedBundledPluginLocationBridges({

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -617,6 +617,7 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
           shouldRestart: true,
           jsonMode: Boolean(params.opts.json),
           expectedService: { serviceEnv: gatewayServiceEnv, serviceUpdateVerdict },
+          activatedInstall: params,
           timeoutMs: params.updateStepTimeoutMs,
         });
         before.windowsTaskAutoStartRecovery = stopped.windowsTaskAutoStartRecovery;

--- a/src/cli/update-cli/update-command-service-command.process.test.ts
+++ b/src/cli/update-cli/update-command-service-command.process.test.ts
@@ -2,7 +2,7 @@ import { expect, it } from "vitest";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { formatCliProcessFailure, runCliProcessChild } from "../cli-process-child.test-helpers.js";
 
-it.each(["restart", "install", "missing candidate"] as const)(
+it.each(["restart", "install", "stop", "missing candidate"] as const)(
   "handles %s after replacing the updater's module files",
   async (scenario) => {
     await withOpenClawTestState(
@@ -71,7 +71,7 @@ it.each(["restart", "install", "missing candidate"] as const)(
             assert.equal(await runUpdatedInstallGatewayCommand(params, scenario, true), "unverified");
             const observed = JSON.parse(await fs.readFile(receipt, "utf8"));
             assert.deepEqual(observed, {
-              args: ["gateway", scenario, scenario === "install" ? "--force" : "--preserve-definition", "--json"],
+              args: ["gateway", scenario, scenario === "restart" ? "--preserve-definition" : "--force", "--json"],
               node: process.execPath,
               config: process.env.OPENCLAW_CONFIG_PATH,
               compileCacheDisabled: "1",

--- a/src/cli/update-cli/update-command-service-command.ts
+++ b/src/cli/update-cli/update-command-service-command.ts
@@ -44,7 +44,7 @@ export async function runUpdatedInstallGatewayCommand(
     signal?: AbortSignal;
     assertCurrent?: () => void;
   },
-  action: "install" | "restart",
+  action: "install" | "restart" | "stop",
   preserveDefinition = false,
 ): Promise<"accepted" | "unverified"> {
   params.signal?.throwIfAborted();
@@ -62,7 +62,7 @@ export async function runUpdatedInstallGatewayCommand(
     );
   }
   const args = ["gateway", action];
-  if (installing) {
+  if (installing || action === "stop") {
     args.push("--force");
   } else if (preserveDefinition) {
     args.push("--preserve-definition");
@@ -98,14 +98,15 @@ export async function runUpdatedInstallGatewayCommand(
   const complete = !res.stdoutTruncatedBytes && !res.outputLimitExceeded && !res.outputErrorStream;
   const response = complete ? safeParseJsonRecord(res.stdout) : undefined;
   if (exited && res.code === 0) {
-    return action === "restart" &&
-      response?.action === "restart" &&
+    return response?.action === action &&
       response.ok === true &&
-      (response.result === "restarted" || response.result === "scheduled")
+      ((action === "restart" &&
+        (response.result === "restarted" || response.result === "scheduled")) ||
+        (action === "stop" && (response.result === "stopped" || response.result === "not-loaded")))
       ? "accepted"
       : "unverified";
   }
-  const operation = installing ? "refresh" : "restart";
+  const operation = installing ? "refresh" : action;
   const message = `updated install ${operation} failed (${entrypoint}): ${formatCommandFailure(res.stdout, res.stderr)}`;
   if (
     exited &&

--- a/src/cli/update-cli/update-command-service-maintenance.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.ts
@@ -24,6 +24,7 @@ import { getUpdateRun, recordUpdateRunPhase } from "../../infra/update-run-ledge
 import { defaultRuntime } from "../../runtime.js";
 import { UpdatePreMutationError, type UpdateCommandOptions } from "./shared.js";
 import { gatewayMaintenanceBlockMessage } from "./update-command-handoff.js";
+import { runUpdatedInstallGatewayCommand } from "./update-command-service-command.js";
 import {
   assertGatewayServiceAdmissionUnchanged,
   assertGatewayServiceManagementAllowedForUpdate,
@@ -315,6 +316,7 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
   phase?: "inspect" | "prepare";
   handoffFromGateway?: (state: GatewayServiceState) => Promise<boolean>;
   expectedService?: Pick<PreManagedServiceStop, "serviceEnv" | "serviceUpdateVerdict">;
+  activatedInstall?: { packageUpdateNodeRunner?: string; invocationCwd?: string };
   timeoutMs?: number;
 }): Promise<PreManagedServiceStop> {
   const uninspected = { stopped: false, inspected: false, runtimeInspected: false, running: false };
@@ -510,10 +512,32 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
         env: params.updateRun.env,
       });
     }
-    await service.stop({
-      env: currentState.env,
-      stdout: params.jsonMode ? JSON_MODE_SERVICE_STDOUT : process.stdout,
-    });
+    if (params.activatedInstall) {
+      // Activation Doctor may have stamped newer config. Keep its service stop
+      // in that runtime too; the old parent's destructive-action guard is valid.
+      const stopped = await runUpdatedInstallGatewayCommand(
+        {
+          result: { root: params.root },
+          opts: { json: params.jsonMode },
+          invocationEnv: process.env,
+          serviceEnv: currentState.env,
+          timeoutMs: params.timeoutMs,
+          nodeRunner: params.activatedInstall.packageUpdateNodeRunner,
+          invocationCwd: params.activatedInstall.invocationCwd,
+        },
+        "stop",
+      );
+      if (stopped !== "accepted") {
+        throw new Error(
+          "Updated Gateway CLI did not confirm the service stopped for plugin maintenance.",
+        );
+      }
+    } else {
+      await service.stop({
+        env: currentState.env,
+        stdout: params.jsonMode ? JSON_MODE_SERVICE_STDOUT : process.stdout,
+      });
+    }
     if (windowsTaskAutoStartRecovery) {
       await abortWindowsTaskUpdateIfInterrupted(windowsTaskAutoStartRecovery);
     }

--- a/src/cli/update-cli/update-command-service-transition.test-support.ts
+++ b/src/cli/update-cli/update-command-service-transition.test-support.ts
@@ -2,11 +2,13 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, it, vi, type Mock } from "vitest";
 import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
+import { runExec } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
 import { VERSION } from "../../version.js";
 import { runDaemonRestart } from "../daemon-cli/lifecycle.js";
 import * as startRepair from "../daemon-cli/start-repair.js";
 import type { UpdateCommandOptions } from "./shared.js";
+import { runUpdateFinalizationDoctorInFreshProcess } from "./update-command-fresh-doctor.js";
 import { runUpdatedInstallGatewayCommand } from "./update-command-service-command.js";
 import {
   maybeRestartService,
@@ -393,6 +395,164 @@ export function registerRestartOutcomeTests(
         name: scenario === "health" ? "GatewayRestartHealthError" : "Error",
       });
       expect(mocks.child.mock.lastCall?.[0]).toContain("--json");
+    },
+  );
+}
+
+type PluginMaintenanceFixture = InstallRootTransitionFixture & {
+  writeConfig: (version: string) => Promise<void>;
+  mocks: { log: Mock; start: Mock; restart: Mock; doctor: Mock };
+};
+
+export function registerPluginMaintenanceTests(getFixture: () => PluginMaintenanceFixture) {
+  it.each(
+    (["git", "npm"] as const).flatMap((mode) =>
+      (["stopped", "not-loaded", "unverified", "failed"] as const).map((stopResult) => ({
+        mode,
+        stopResult,
+      })),
+    ),
+  )(
+    "delegates $mode activation and post-handoff plugin maintenance after candidate doctor stamps newer config ($stopResult)",
+    async ({ mode, stopResult }) => {
+      const { root, run, mocks, writeConfig } = getFixture();
+      const before = await maybeStopManagedServiceBeforeMutableUpdate({
+        updateInstallKind: mode === "git" ? "git" : "package",
+        root,
+        shouldRestart: true,
+        jsonMode: true,
+      });
+      expect(before.stopped).toBe(true);
+      mocks.events.push("core updated");
+      await writeConfig("9999.1.1");
+      mocks.events.push("candidate doctor stamped config");
+      const service = resolveGatewayService();
+      const state = await readGatewayServiceState(service, { requireEffective: true });
+      const verdict = await revalidateManagedGatewayServiceAfterUpdate({
+        state,
+        root,
+        preManagedServiceStop: before,
+      });
+
+      const activated = await maybeRestartService({
+        shouldRestart: true,
+        result: {
+          status: "ok",
+          mode,
+          root,
+          steps: [],
+          durationMs: 0,
+          before: { version: VERSION },
+          after: { version: "9999.1.1" },
+        },
+        opts: { run },
+        refreshServiceEnv: false,
+        serviceUpdateVerdict: verdict,
+        serviceEnv: state.env,
+        gatewayPort: 19305,
+        requireRunningServiceAfterRestart: true,
+        timeoutMs: 1000,
+      });
+
+      expect(activated, mocks.log.mock.calls.flat().join("\n")).toBe("ok");
+      expect(mocks.events).toEqual([
+        "native stop",
+        "core updated",
+        "candidate doctor stamped config",
+        "fresh CLI restart",
+      ]);
+      const child = mocks.child.mock.calls[0];
+      expect(child?.[0].slice(1)).toEqual([
+        path.join(root, "dist", "index.js"),
+        "gateway",
+        "restart",
+        "--preserve-definition",
+        "--json",
+      ]);
+      expect(mocks.health.mock.calls[0]?.[0]).toMatchObject({
+        port: 19305,
+        expectedVersion: "9999.1.1",
+        requireRunningService: true,
+      });
+      expect(mocks.start).not.toHaveBeenCalled();
+      expect(mocks.restart).not.toHaveBeenCalled();
+      expect(mocks.doctor).not.toHaveBeenCalled();
+      // The old adapter still refuses the same config: delegation must not weaken its guard.
+      await expect(service.restart({ env: state.env, stdout: process.stdout })).rejects.toThrow(
+        "older than the config",
+      );
+
+      process.env.OPENCLAW_UPDATE_RUN_HANDOFF = "1";
+      mocks.child.mockImplementation(async () => {
+        mocks.events.push("fresh CLI stop");
+        mocks.running = false;
+        return {
+          code: stopResult === "failed" ? 1 : 0,
+          stdout:
+            stopResult === "unverified"
+              ? ""
+              : JSON.stringify({
+                  action: "stop",
+                  ok: stopResult !== "failed",
+                  result: stopResult,
+                }),
+          stderr: "",
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      });
+      const maintenance = maybeStopManagedServiceBeforeMutableUpdate({
+        root,
+        updateInstallKind: mode === "git" ? "git" : "package",
+        shouldRestart: true,
+        jsonMode: true,
+        expectedService: { serviceEnv: state.env, serviceUpdateVerdict: verdict },
+        activatedInstall: { packageUpdateNodeRunner: process.execPath },
+        timeoutMs: 1000,
+      });
+      if (stopResult === "unverified" || stopResult === "failed") {
+        await expect(maintenance).rejects.toThrow(
+          stopResult === "unverified"
+            ? "did not confirm the service stopped"
+            : "updated install stop failed",
+        );
+        return;
+      }
+      expect((await maintenance).stopped).toBe(true);
+      expect(mocks.child.mock.lastCall?.[0]).toEqual([
+        process.execPath,
+        path.join(root, "dist", "index.js"),
+        "gateway",
+        "stop",
+        "--force",
+        "--json",
+      ]);
+      expect(mocks.child.mock.lastCall?.[1]).toMatchObject({ cwd: root });
+      vi.mocked(runExec).mockResolvedValueOnce({ stdout: "", stderr: "" });
+      await runUpdateFinalizationDoctorInFreshProcess({
+        root,
+        phase: "post-plugin",
+        yes: true,
+        json: true,
+        timeoutMs: 1000,
+      });
+      expect(runExec).toHaveBeenLastCalledWith(
+        process.execPath,
+        [
+          path.join(root, "dist", "index.js"),
+          "doctor",
+          "--repair",
+          "--non-interactive",
+          "--no-workspace-suggestions",
+          "--yes",
+        ],
+        expect.objectContaining({ cwd: root }),
+      );
+      // Delegation must leave the stale parent's destructive-action guard intact.
+      await expect(service.stop({ env: state.env, stdout: process.stdout })).rejects.toThrow(
+        "older than the config",
+      );
     },
   );
 }

--- a/src/cli/update-cli/update-command-service.integration.test.ts
+++ b/src/cli/update-cli/update-command-service.integration.test.ts
@@ -33,6 +33,7 @@ import {
 } from "./update-command-service-recovery.test-support.js";
 import {
   registerInstallRootTransitionTests,
+  registerPluginMaintenanceTests,
   registerRestartOutcomeTests,
 } from "./update-command-service-transition.test-support.js";
 import {
@@ -635,76 +636,7 @@ describe("preserved update activation with real version guards", () => {
     },
   );
 
-  it.each(["git", "npm"] as const)(
-    "delegates %s activation after candidate doctor stamps newer config",
-    async (mode) => {
-      const before = await maybeStopManagedServiceBeforeMutableUpdate({
-        updateInstallKind: mode === "git" ? "git" : "package",
-        root,
-        shouldRestart: true,
-        jsonMode: true,
-      });
-      expect(before.stopped).toBe(true);
-      mocks.events.push("core updated");
-      await writeConfig("9999.1.1");
-      mocks.events.push("candidate doctor stamped config");
-      const service = resolveGatewayService();
-      const state = await readGatewayServiceState(service, { requireEffective: true });
-      const verdict = await revalidateManagedGatewayServiceAfterUpdate({
-        state,
-        root,
-        preManagedServiceStop: before,
-      });
-
-      const activated = await maybeRestartService({
-        shouldRestart: true,
-        result: {
-          status: "ok",
-          mode,
-          root,
-          steps: [],
-          durationMs: 0,
-          before: { version: VERSION },
-          after: { version: "9999.1.1" },
-        },
-        opts: { run },
-        refreshServiceEnv: false,
-        serviceUpdateVerdict: verdict,
-        serviceEnv: state.env,
-        gatewayPort: 19305,
-        requireRunningServiceAfterRestart: true,
-        timeoutMs: 1000,
-      });
-
-      expect(activated, mocks.log.mock.calls.flat().join("\n")).toBe("ok");
-      expect(mocks.events).toEqual([
-        "native stop",
-        "core updated",
-        "candidate doctor stamped config",
-        "fresh CLI restart",
-      ]);
-      const child = mocks.child.mock.calls[0];
-      expect(child?.[0].slice(1)).toEqual([
-        path.join(root, "dist", "index.js"),
-        "gateway",
-        "restart",
-        "--preserve-definition",
-        "--json",
-      ]);
-      expect(mocks.health.mock.calls[0]?.[0]).toMatchObject({
-        port: 19305,
-        expectedVersion: "9999.1.1",
-        requireRunningService: true,
-      });
-      expect(mocks.start).not.toHaveBeenCalled();
-      expect(mocks.restart).not.toHaveBeenCalled();
-      expect(mocks.doctor).not.toHaveBeenCalled();
-      // The old adapter still refuses the same config: delegation must not weaken its guard.
-      await expect(service.restart({ env: state.env, stdout: process.stdout })).rejects.toThrow(
-        "older than the config",
-      );
-    },
-  );
+  registerPluginMaintenanceTests(() => ({ root, run, mocks, writeConfig }));
 
   it.each(["sealed", "writable"] as const)(
     "fresh restart keeps the preserved launcher even when authority is %s",

--- a/src/commands/doctor/shared/missing-configured-plugin-install.targets.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.targets.ts
@@ -217,6 +217,7 @@ export async function collectConfiguredNpmPluginTargets(params: {
         syncOfficialPluginInstalls: true,
         updateChannel: params.channel,
         coreVersion: params.targetVersion,
+        versionBoundToCore: candidate?.versionBoundToOpenClaw,
       });
       if (target && parseRegistryNpmSpec(target.spec)) {
         targets.push({ pluginId, ...target });

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -3125,23 +3125,29 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     },
     { availability: "registry outage", channel: "stable", error: "registry connection timed out" },
     { availability: "published version", channel: "stable" },
+    { availability: "already-current floating package", channel: "stable" },
     { availability: "beta-only package", channel: "beta" },
     { availability: "unknown core version", channel: "stable" },
   ] as const)(
-    "preflights a stale exact Codex pin with $availability before any plugin mutation",
+    "preflights Codex with $availability before any plugin mutation",
     async ({ availability, channel, ...outcome }) => {
+      const alreadyCurrent = availability === "already-current floating package";
+      const installedVersion = alreadyCurrent ? "2026.9.3" : "2026.9.1";
+      if (alreadyCurrent) {
+        useManifestCatalogResolvers();
+      }
       const installDir = tempDirs.make("openclaw-plugin-availability-");
       createColdPluginFixture({
         rootDir: installDir,
         pluginId: "codex",
         packageName: "@openclaw/codex",
-        packageVersion: "2026.9.1",
+        packageVersion: installedVersion,
       });
       const packageFile = path.join(installDir, "package.json");
       const originalPackage = fs.readFileSync(packageFile, "utf8");
       const records = installedRecords("codex", {
-        spec: "@openclaw/codex@2026.9.1",
-        resolvedVersion: "2026.9.1",
+        spec: alreadyCurrent ? "@openclaw/codex" : "@openclaw/codex@2026.9.1",
+        resolvedVersion: installedVersion,
         installPath: installDir,
       });
       const config: OpenClawConfig = { plugins: { entries: { codex: { enabled: true } } } };
@@ -3149,7 +3155,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       const originalRecords = structuredClone(records);
       mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
       mocks.loadPluginMetadataSnapshot.mockReturnValue({
-        plugins: [{ id: "codex", packageVersion: "2026.9.1", channels: [] }],
+        plugins: [{ id: "codex", packageVersion: installedVersion, channels: [] }],
         diagnostics: [],
       });
       mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
@@ -3162,7 +3168,12 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         if (availability === "beta-only package" && spec === "@openclaw/codex@latest") {
           return { ok: false, error: "No latest release for @openclaw/codex." };
         }
-        const version = spec.endsWith("@beta") ? "2026.9.3-beta.1" : spec.split("@").at(-1);
+        const version =
+          spec === "@openclaw/codex"
+            ? "2026.9.2"
+            : spec.endsWith("@beta")
+              ? "2026.9.3-beta.1"
+              : spec.split("@").at(-1);
         return {
           ok: true,
           metadata: {

--- a/src/plugins/update-cohort.ts
+++ b/src/plugins/update-cohort.ts
@@ -38,6 +38,7 @@ export async function convergePluginReleaseCohort(params: {
   config: OpenClawConfig;
   channel: UpdateChannel;
   coreVersion?: string;
+  versionBoundPluginIds?: ReadonlySet<string>;
   timeoutMs: number;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
@@ -93,6 +94,7 @@ export async function convergePluginReleaseCohort(params: {
       timeoutMs: params.timeoutMs,
       updateChannel: params.channel,
       coreVersion: params.coreVersion,
+      versionBoundPluginIds: params.versionBoundPluginIds,
       skipDisabledPlugins: true,
       syncOfficialPluginInstalls: true,
       disableOnFailure: true,
@@ -117,6 +119,7 @@ export async function convergePluginReleaseCohort(params: {
       ...sync.summary.switchedToNpm,
       ...repairedMissingPayloadIds,
     ]),
+    versionBoundPluginIds: params.versionBoundPluginIds,
     skipDisabledPlugins: true,
     syncOfficialPluginInstalls: true,
     disableOnFailure: true,

--- a/src/plugins/update-installed.ts
+++ b/src/plugins/update-installed.ts
@@ -100,6 +100,7 @@ export async function updateNpmInstalledPlugins(params: {
   updateChannel?: UpdateChannel;
   officialPluginUpdateChannel?: UpdateChannel;
   coreVersion?: string;
+  versionBoundPluginIds?: ReadonlySet<string>;
   dangerouslyForceUnsafeInstall?: boolean;
   onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
   specOverrides?: Record<string, string>;
@@ -201,6 +202,7 @@ export async function updateNpmInstalledPlugins(params: {
       syncOfficialPluginInstalls: params.syncOfficialPluginInstalls,
       updateChannel,
       coreVersion: params.coreVersion,
+      versionBoundToCore: params.versionBoundPluginIds?.has(pluginId),
       timeoutMs: params.timeoutMs,
     });
     if (normalizedPluginConfig) {
@@ -246,6 +248,7 @@ export async function updateNpmInstalledPlugins(params: {
             updateChannel,
             officialPackageName: trustedOfficialClawHubInstall ? recordClawHubPackage : undefined,
             coreVersion: params.coreVersion,
+            versionBoundToCore: params.versionBoundPluginIds?.has(pluginId),
           })
         : undefined;
     const effectiveSpec =

--- a/src/plugins/update-source.ts
+++ b/src/plugins/update-source.ts
@@ -454,6 +454,7 @@ export function resolveNpmUpdateTarget(params: {
   syncOfficialPluginInstalls?: boolean;
   updateChannel?: UpdateChannel;
   coreVersion?: string;
+  versionBoundToCore?: boolean;
   timeoutMs?: number;
 }) {
   const official = params.trustedOfficialInstall;
@@ -472,6 +473,7 @@ export function resolveNpmUpdateTarget(params: {
           updateChannel: params.updateChannel,
           officialPackageName: resolveNpmSpecPackageName(official?.npmSpec),
           coreVersion: params.coreVersion,
+          versionBoundToCore: params.versionBoundToCore,
           timeoutMs: params.timeoutMs,
         }
       : undefined,
@@ -484,6 +486,7 @@ export function resolveClawHubUpdateSpecs(params: {
   updateChannel?: UpdateChannel;
   officialPackageName?: string;
   coreVersion?: string;
+  versionBoundToCore?: boolean;
 }): {
   installSpec?: string;
   recordSpec?: string;
@@ -507,6 +510,7 @@ export function resolveClawHubUpdateSpecs(params: {
     updateChannel: params.updateChannel,
     officialPackageName: params.officialPackageName,
     coreVersion: params.coreVersion,
+    versionBoundToCore: params.versionBoundToCore,
   });
 }
 

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1536,6 +1536,36 @@ describe("updateNpmInstalledPlugins", () => {
     },
   );
 
+  it.each(["@openclaw/codex", "@openclaw/codex@latest", "@openclaw/codex@2026.9.3"])(
+    "targets the activated core for version-bound post-update plugins while preserving %s",
+    async (spec) => {
+      const targetVersion = spec.endsWith("@2026.9.3") ? "2026.9.3" : "2026.9.4";
+      const { config } = createNpmUpdateFixture({
+        pluginId: "codex",
+        packageName: "@openclaw/codex",
+        installedVersion: "2026.9.2",
+        spec,
+        installerVersion: targetVersion,
+        installerResolvedSpec: `@openclaw/codex@${targetVersion}`,
+      });
+      runCommandWithTimeoutMock.mockImplementation(async (argv) => ({
+        code: 0,
+        stdout: JSON.stringify({
+          name: "@openclaw/codex",
+          version: argv.includes(`@openclaw/codex@${targetVersion}`) ? targetVersion : "2026.9.2",
+        }),
+        stderr: "",
+      }));
+      await updatePlugin(config, "codex", {
+        updateChannel: "stable",
+        coreVersion: "2026.9.4",
+        versionBoundPluginIds: new Set(["codex"]),
+        syncOfficialPluginInstalls: true,
+      });
+      expect(npmInstallCall()?.spec).toBe(`@openclaw/codex@${targetVersion}`);
+    },
+  );
+
   it("preserves floating official npm records during official sync", async () => {
     const { config } = createNpmUpdateFixture({
       pluginId: "acpx",


### PR DESCRIPTION
Related: #140778

## What Problem This Solves

Fixes an issue where a managed Gateway update that had already activated and verified the new core could roll back when npm plugin changes required a final Doctor pass. The old updater attempted another service stop after activation Doctor had stamped configuration with the new version, triggering the older-binary destructive-action guard before fresh Doctor started.

## Why This Change Was Made

The activated core root was already correct: `package-update-swap.ts` publishes `activePackageRoot`, and `update-command-package.ts` returns it as `result.root`. The stale operation was `update-command-post-update.ts`'s `beforeDoctor` callback calling the old process's guarded `service.stop()`. Delegate this post-activation stop through `runUpdatedInstallGatewayCommand`, using the activated package entrypoint and the owned service environment. Require a complete successful `stopped` or `not-loaded` response before Doctor proceeds; command failures and unverified responses abort maintenance. Keep service ownership revalidation, Windows task suspension, and the retained rollback transaction with the parent.

The plugin-version discrepancy had a separate cause. `update-command-plugins.ts` supplied the activated core version, but the npm update path did not carry the existing runtime plugin version-binding policy into `install-channel-specs.ts`. Forward that policy through post-core cohort convergence so version-bound plugins select the core cohort immediately. This avoids an unnecessary downgrade to an older registry `latest` followed by Doctor repair back to the core version. Explicit package pins, non-bound plugins, and the documented beta newest-of-beta/latest policy retain their selectors; ordinary standalone plugin updates retain their behavior.

The npm admission helper receives the same binding policy for already-current floating runtime packages, so availability preflight and post-core execution select the same artifact.

The ordinary stop preflight also used full plugin validation, which could deny the maintenance stop before Doctor migrated a newly installed plugin. Stop now validates core configuration while leaving plugin validation to start/restart and Doctor. The newer-writer and service ownership guards remain enforced. A real synthetic plugin fixture reproduces the old circular refusal and protects the repaired shutdown boundary.

## User Impact

Healthy updates can finish plugin maintenance using the activated CLI without disabling the older-binary guard. Genuine post-update failures still use the existing failure and rollback paths. No changes to schemas, configuration options, protocol, serving verification, or startup readiness.

## Evidence

Regression coverage reproduces the old-parent refusal after candidate configuration stamping, verifies the activated stop/Doctor entrypoint and working directory, and checks version-bound npm selection with core 2026.9.4 while registry latest remains 2026.9.2. Explicit pins remain covered, as do existing rollback and lifecycle failure tests.

Reported AWS reproduction (2026-09-07): a 2026.9.3 to 2026.9.4 managed RPC update became healthy, then rolled back with `post-update-plugins` and 58 seconds of reported downtime. The warning lacked the fresh Doctor subprocess failure wrapper because it came from the parent's pre-Doctor stop. Plugin generation paths were plugin payload roots, not core roots. The synthetic registry retained an older latest tag; Codex's later runtime repair returned it to 2026.9.4, while non-bound Brave legitimately remained on latest. This patched branch has not been rerun in that live lane.

Validation (all passed):

```text
pnpm check:changed
pnpm check:changed --base 5a4f24e73e9ed79de8481e47ab27b0ddcf58f6cb
pnpm check:changed --base 5a4f24e73e9ed79de8481e47ab27b0ddcf58f6cb -- src/commands/doctor/shared/missing-configured-plugin-install.targets.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts

pnpm test src/plugins/update.test.ts src/cli/update-cli.test.ts src/cli/update-cli/update-command-execution.test.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts
# 748 passed after rebasing onto the main target-helper refactor

pnpm test src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/plugins/update.test.ts
# 328 passed after the final admission alignment
```

Before the rebase, 818 focused tests passed across the update CLI, native service/rollback, fresh Doctor, shutdown preflight, and plugin suites. The test harness also rebuilt the runtime successfully. The new stale-parent, version-target, invalid-plugin-config shutdown, and already-current admission regressions each failed before their corresponding fix. Existing fixture stop responses were updated to reflect the delegated CLI's structured result.

Final independent autoreview: no actionable P0–P2 findings. Runtime and protocol guards remain enforced; the documented beta selector was preserved after source/test review.
