### PR TITLE
refactor(tests): simplify the serial UI source inventory

### DIFF
--- a/ui/src/components/web-awesome-migration.node.test.ts
+++ b/ui/src/components/web-awesome-migration.node.test.ts
@@ -1,31 +1,27 @@
 // @vitest-environment node
-import { readdir, readFile } from "node:fs/promises";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const sourceRoot = path.resolve(import.meta.dirname, "..");
 
-async function productionTypeScriptFiles(dir = sourceRoot): Promise<string[]> {
-  const entries = await readdir(dir, { withFileTypes: true });
-  const files = await Promise.all(
-    entries.map(async (entry) => {
-      const filePath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        return productionTypeScriptFiles(filePath);
-      }
-      if (!entry.name.endsWith(".ts") || entry.name.includes(".test.")) {
-        return [];
-      }
-      return [filePath];
-    }),
-  );
-  return files.flat();
+function productionTypeScriptFiles(dir = sourceRoot): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const filePath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return productionTypeScriptFiles(filePath);
+    }
+    if (!entry.name.endsWith(".ts") || entry.name.includes(".test.")) {
+      return [];
+    }
+    return [filePath];
+  });
 }
 
-async function matchingFiles(pattern: RegExp): Promise<string[]> {
+function matchingFiles(pattern: RegExp): string[] {
   const matches: string[] = [];
-  for (const filePath of await productionTypeScriptFiles()) {
-    if (pattern.test(await readFile(filePath, "utf8"))) {
+  for (const filePath of productionTypeScriptFiles()) {
+    if (pattern.test(readFileSync(filePath, "utf8"))) {
       matches.push(path.relative(sourceRoot, filePath));
     }
   }
@@ -33,23 +29,23 @@ async function matchingFiles(pattern: RegExp): Promise<string[]> {
 }
 
 describe("Web Awesome control ownership", () => {
-  it("keeps dialogs, menus, and tabs on shared primitives", async () => {
-    expect(await matchingFiles(/<dialog\b/u)).toEqual([]);
+  it("keeps dialogs, menus, and tabs on shared primitives", () => {
+    expect(matchingFiles(/<dialog\b/u)).toEqual([]);
     expect(
-      await matchingFiles(/<[a-z][^>]*\srole=["'](?:menu|menubar|menuitem|tab|tablist)["']/u),
+      matchingFiles(/<[a-z][^>]*\srole=["'](?:menu|menubar|menuitem|tab|tablist)["']/u),
     ).toEqual([]);
     expect(
-      await matchingFiles(/<details\b[^>]*class=["'][^"']*(?:menu|select|popover|dropdown)/u),
+      matchingFiles(/<details\b[^>]*class=["'][^"']*(?:menu|select|popover|dropdown)/u),
     ).toEqual([
       "pages/chat/components/chat-effort-picker.ts",
       "pages/chat/components/chat-model-picker.ts",
     ]);
   });
 
-  it("limits custom comboboxes to dynamic suggestion surfaces", async () => {
+  it("limits custom comboboxes to dynamic suggestion surfaces", () => {
     // Web Awesome Core has no combobox; its combobox is a paid Pro component.
     // This inventory tracks literal ARIA roles, not Web Awesome elements that own roles internally.
-    expect(await matchingFiles(/<[a-z][^>]*\srole=["'](?:combobox|listbox|option)["']/u)).toEqual([
+    expect(matchingFiles(/<[a-z][^>]*\srole=["'](?:combobox|listbox|option)["']/u)).toEqual([
       "components/command-palette.ts",
       "pages/chat/components/chat-composer-mention-menu.ts",
       "pages/chat/components/chat-composer-skill-menu.ts",
@@ -60,10 +56,10 @@ describe("Web Awesome control ownership", () => {
     ]);
   });
 
-  it("limits custom dividers to docked multi-pane layouts", async () => {
+  it("limits custom dividers to docked multi-pane layouts", () => {
     // Web Awesome split panel owns exactly two panes; these layouts coordinate
     // sidebar, inspector, and responsive dock state across more than two panes.
-    expect(await matchingFiles(/<resizable-divider\b/u)).toEqual([
+    expect(matchingFiles(/<resizable-divider\b/u)).toEqual([
       "app/app-shell-view.ts",
       "components/dock-layout-controller.ts",
       "pages/chat/chat-page.ts",


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The Web Awesome ownership guard repeatedly scans local source files to enforce UI architecture contracts. Its serial checks pay asynchronous filesystem and Promise overhead without needing concurrent execution.

## Why This Change Was Made

Uses synchronous filesystem reads and a recursive flatMap walk, removing unnecessary async/await machinery. All three tests, five scans, regular expressions, file filters, sorted paths, and independent expected inventories remain unchanged. There is no cache or retained source snapshot.

## User Impact

No product behavior change. This maintainer-requested cleanup removes four net test lines and reduces local source-scan overhead; it does not claim a full-suite runtime improvement.

## Evidence

- All three actual Vitest cases passed before and after with identical names and results. Single local shard runs took 1.58 seconds before and 1.06 seconds after; these are observations, not a controlled full-suite benchmark.
- An alternating source-only diagnostic using the actual case bodies and assertions measured median scan work of 222 ms versus 133 ms. Both variants performed all 7,940 file reads and returned identical match arrays. This excludes Vitest startup and does not measure global test performance.
- File and directory failure probes preserved filesystem errors at all three case boundaries.
- Full mapped changed gate, deslop, and independent P2 review passed.
