### PR TITLE
refactor: simplify background task text preparation

### DIFF
--- a/src/gateway/server-methods/task-summary.ts
+++ b/src/gateway/server-methods/task-summary.ts
@@ -8,6 +8,7 @@ import {
   formatTaskStatusTitle,
   sanitizeTaskPromptText,
   sanitizeTaskStatusText,
+  truncateTaskStatusText,
 } from "../../tasks/task-status.js";
 
 type TaskLedgerStatus = TaskSummary["status"];
@@ -48,26 +49,22 @@ function sanitizeOptionalTaskText(
 export function mapTaskSummary(task: TaskRecord, opts?: { includePrompt?: boolean }): TaskSummary {
   const activity = getTaskActivitySnapshot(task.taskId);
   const lastActivity = sanitizeOptionalTaskText(activity?.lastActivity);
-  const progressSummary = sanitizeOptionalTaskText(task.progressSummary);
-  const terminalSummary = sanitizeOptionalTaskText(task.terminalSummary, { errorContext: true });
+  const progressResult = sanitizeTaskStatusText(task.progressSummary);
+  const terminalResult = sanitizeTaskStatusText(task.terminalSummary, { errorContext: true });
+  const progressSummary =
+    truncateTaskStatusText(progressResult, TASK_STATUS_DETAIL_MAX_CHARS) || undefined;
+  const terminalSummary =
+    truncateTaskStatusText(terminalResult, TASK_STATUS_DETAIL_MAX_CHARS) || undefined;
   const error = sanitizeOptionalTaskText(task.error, { errorContext: true });
   const lastToolName = sanitizeOptionalTaskText(task.lastToolName);
   const prompt = opts?.includePrompt
     ? sanitizeTaskPromptText(task.task, TASK_PROMPT_MAX_CHARS) || undefined
     : undefined;
-  const progressResult = opts?.includePrompt
-    ? sanitizeTaskStatusText(task.progressSummary, { maxChars: TASK_RESULT_MAX_CHARS })
-    : "";
-  const terminalResult = opts?.includePrompt
-    ? sanitizeTaskStatusText(task.terminalSummary, {
-        errorContext: true,
-        maxChars: TASK_RESULT_MAX_CHARS,
-      })
-    : "";
-  const result =
-    (task.runtime === "subagent" || task.runtime === "acp"
-      ? progressResult
-      : terminalResult || progressResult) || undefined;
+  const result = opts?.includePrompt
+    ? (task.runtime === "subagent" || task.runtime === "acp"
+        ? progressResult
+        : terminalResult || progressResult) || undefined
+    : undefined;
   const toolUseCount =
     typeof task.toolUseCount === "number" && Number.isInteger(task.toolUseCount)
       ? Math.max(0, task.toolUseCount)
@@ -100,7 +97,7 @@ export function mapTaskSummary(task: TaskRecord, opts?: { includePrompt?: boolea
     ...(error ? { error } : {}),
     deliveryStatus: task.deliveryStatus,
     ...(task.terminalOutcome ? { terminalOutcome: task.terminalOutcome } : {}),
-    ...(result ? { result } : {}),
+    ...(result ? { result: truncateTaskStatusText(result, TASK_RESULT_MAX_CHARS) } : {}),
     ...(prompt ? { prompt } : {}),
   };
 }

--- a/src/tasks/task-executor-policy.ts
+++ b/src/tasks/task-executor-policy.ts
@@ -35,10 +35,10 @@ export function formatTaskTerminalMessage(
 ): string {
   const title = resolveTaskDisplayTitle(task);
   const runLabel = resolveTaskRunLabel(task);
-  const summary = sanitizeTaskStatusText(task.terminalSummary, {
-    errorContext: task.status !== "succeeded" || task.terminalOutcome === "blocked",
-  });
   if (task.status === "succeeded") {
+    const summary = sanitizeTaskStatusText(task.terminalSummary, {
+      errorContext: task.terminalOutcome === "blocked",
+    });
     if (task.terminalOutcome === "blocked") {
       return summary
         ? `Background task blocked: ${title}${runLabel}. ${summary}`
@@ -57,11 +57,6 @@ export function formatTaskTerminalMessage(
   if (task.status === "timed_out") {
     return `Background task timed out: ${title}${runLabel}.`;
   }
-  if (task.status === "lost") {
-    const error = sanitizeTaskStatusText(task.error, { errorContext: true });
-    const fallbackSummary = sanitizeTaskStatusText(task.terminalSummary, { errorContext: true });
-    return `Background task lost: ${title}${runLabel}. ${error || fallbackSummary || "Backing session disappeared."}`;
-  }
   if (task.status === "cancelled") {
     if (task.runtime === "subagent") {
       // A final reply can win the kill race and reconcile this row to success.
@@ -70,13 +65,15 @@ export function formatTaskTerminalMessage(
     }
     return `Background task cancelled: ${title}${runLabel}.`;
   }
-  const error = sanitizeTaskStatusText(task.error, { errorContext: true });
-  const fallbackSummary = sanitizeTaskStatusText(task.terminalSummary, { errorContext: true });
-  return error
-    ? `Background task failed: ${title}${runLabel}. ${error}`
-    : fallbackSummary
-      ? `Background task failed: ${title}${runLabel}. ${fallbackSummary}`
-      : `Background task failed: ${title}${runLabel}.`;
+  const detail =
+    sanitizeTaskStatusText(task.error, { errorContext: true }) ||
+    sanitizeTaskStatusText(task.terminalSummary, { errorContext: true });
+  if (task.status === "lost") {
+    return `Background task lost: ${title}${runLabel}. ${detail || "Backing session disappeared."}`;
+  }
+  return detail
+    ? `Background task failed: ${title}${runLabel}. ${detail}`
+    : `Background task failed: ${title}${runLabel}.`;
 }
 
 export function shouldUseParentReviewTaskTerminalMessage(task: TaskRecord): boolean {

--- a/src/tasks/task-status.ts
+++ b/src/tasks/task-status.ts
@@ -45,7 +45,8 @@ function isRecentTerminalTask(task: TaskRecord, now: number): boolean {
   return now - resolveTaskReferenceAt(task) <= TASK_STATUS_RECENT_WINDOW_MS;
 }
 
-function truncateTaskStatusText(value: string, maxChars: number): string {
+/** Applies a task display limit to text that its caller has already sanitized. */
+export function truncateTaskStatusText(value: string, maxChars: number): string {
   const trimmed = value.trim();
   if (trimmed.length <= maxChars) {
     return trimmed;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Background-task detail responses and completion notifications perform repeated text preparation, especially for long progress and terminal summaries. Timeout and cancellation notifications can process large summaries they never display.

## Why This Change Was Made

Sanitize progress and terminal text once per projection, derive compact fields directly, and bound only the selected detail result. Terminal notifications skip unused summaries and lazily prefer a sanitized error before falling back to terminal text. The existing internal truncator is reused unchanged. The production diff is **+27/−32 lines, net −5**.

This removes duplicated preparation without introducing a cache, configuration, storage change, or public SDK surface. Full sanitized strings can remain in local variables longer during the synchronous mapper call; the memory tradeoff is discussed below.

## User Impact

Messages, DTO fields, status wording, result precedence, sanitization, prompt layout, and display bounds remain unchanged. Measured long-detail preparation improves roughly **47–50%**; discarded-summary terminal cases improve **98.8–99.8%** on the declared synthetic inputs.

**R2 does not establish a fix for list performance.** Its 3,999–4,001-character list-boundary cases still regress **20.60–30.58% in both orders**, about **31–43 μs per mapping**. The simpler preparation flow has gains and costs; no general list, mapper, Gateway, or provider-latency improvement is claimed.

## Evidence

- Fresh **46 tests** passed across the three complete existing task-status, executor-policy, and Gateway task-handler files; all **28 normal changed checks** passed. Formatting changed no bytes, and no failed validation stage needed a retry or cap increase. Only the unchanged owned dependency installation was reused.
- Fresh independent **P2 review was scoped-clean at 0.97**, with no findings. The independent numerical audit also passed.
- Fixed **75-case B0/C0/C1/B1** study on Node 26.8.1: **11,100 complete V8-serialized outputs**, **9,600 timed calls**, and **2,400 four-call batch means**. All outputs match independently reconstructed string/DTO expectations and the other R2 phases. Every timed duration and adverse comparison is retained.

These are medians of batch means for complete owner calls, in microseconds. Forward compares R2's B0→C0; reverse compares its B1→C1. Negative changes are faster.

| Complete operation | Forward baseline → R2 (μs) | Change | Reverse baseline → R2 (μs) | Change |
|---|---:|---:|---:|---:|
| CLI long detail | 1005.453 → 528.177 | -47.47% | 1016.338 → 511.974 | -49.63% |
| Subagent long detail | 999.323 → 530.442 | -46.92% | 1059.677 → 543.901 | -48.67% |
| Timeout; unused 32 KiB summary | 741.005 → 1.677 | -99.77% | 728.885 → 1.708 | -99.77% |
| Lost; error wins over 32 KiB summary | 1475.015 → 17.859 | -98.79% | 1461.047 → 16.979 | -98.84% |
| List: 3,999-character boundary | 152.031 → 186.886 | +22.93% | 146.349 → 185.464 | +26.73% |
| List: 4,000-character boundary | 149.266 → 186.469 | +24.92% | 144.458 → 182.203 | +26.13% |
| List: 4,001-character boundary | 152.401 → 183.792 | +20.60% | 141.656 → 184.979 | +30.58% |

There are **47/150 adverse medians, 49/150 adverse means, and 51/150 adverse maximum batch means**: **147/450 correlated scalar summaries**, not independent observations. Adverse medians split into 6/46 terminal and 41/104 mapping comparisons. Controls remain mixed: long CLI list mapping is +1.42%/−2.50%, and parent-session plain notification preparation is +34.62%/−1.10%. The largest maximum-batch regression is the forward cron detail/hidden-fallback case: **15.031→40.146 μs, +167.08%**. Maxima are not individual-call latency percentiles.

Native child wall time decreases **4.692→3.463 s / 4.043→3.795 s**, including startup, verification, and artifact writing. Kernel peak RSS increases **3.84% / 4.56%**, and sampled tree peak RSS increases **3.66% / 5.42%**. Forward ending heapUsed increases 4.01%; reverse ending arrayBuffers increases 6.90%. These observations do not establish a memory improvement. Longer-lived sanitized locals are a real source-level lifetime consideration, but whole-child RSS cannot attribute the increase to a particular local. Visible output bounds do not bound transient allocation, string backing storage, or GC behavior.

R1 is retained as a separate historical candidate and cohort. R2 changes the preparation shape and uses its own fresh baseline phases; no R1 timings are pooled here, and cross-cohort differences are not treated as causal evidence that R2 repaired the list slowdown.

The numerical lane uses the actual activity getter with an empty overlay; existing Gateway tests cover populated activity. Input immutability was checked in-process, while complete before/after input snapshots were not retained. All native phases closed and the exact R2 source was restored. No live Gateway, provider request, retention study, or production-wide latency result is claimed.
