### PR TITLE
fix(export-html): render inline markdown inside tight list items

### DIFF
--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -1886,8 +1886,15 @@
         }
         return `<pre><code class="hljs">${highlighted}</code></pre>`;
       },
-      // Text content: escape HTML tags
+      // Text content: escape HTML tags.
+      // Composite text tokens (tight list items without blank lines) carry
+      // their parsed inline children in token.tokens; render those through the
+      // renderer set so **bold**, [links](…) and `code` are not shown literally.
+      // Leaf text keeps the existing HTML escaping.
       text(token) {
+        if (token.tokens && token.tokens.length > 0) {
+          return this.parser.parseInline(token.tokens);
+        }
         return escapeHtmlTags(escapeHtml(token.text));
       },
       // Inline code: escape HTML

--- a/src/auto-reply/reply/export-html/template.security.test.ts
+++ b/src/auto-reply/reply/export-html/template.security.test.ts
@@ -407,6 +407,80 @@ describe("export html security hardening", () => {
     expect(code.textContent).toContain("answer = true");
   });
 
+  it("renders inline markup inside tight list items instead of showing it literally", async () => {
+    // #140785: tight list items (no blank line between them) previously rendered
+    // **bold**, [links] and `code` as literal markdown because the text renderer
+    // escaped the composite text token instead of traversing its inline children.
+    const session: SessionData = {
+      header: { id: "session-tight-list", timestamp: now() },
+      entries: [
+        {
+          id: "1",
+          parentId: null,
+          timestamp: now(),
+          type: "message",
+          message: {
+            role: "assistant",
+            content:
+              "- **Important**: read [the guide](https://example.test/guide) and use `config.json`.\n" +
+              "- Plain item.",
+          },
+        },
+      ],
+      leafId: "1",
+      systemPrompt: "",
+      tools: [],
+    };
+
+    const { document } = await renderTemplate(session);
+    const messages = requireElement(document.getElementById("messages"), "messages root missing");
+
+    // The first tight list item must render real inline elements, not literal markdown.
+    expect(messages.querySelector("strong")?.textContent).toBe("Important");
+    const link = requireElement(messages.querySelector("a"), "link missing");
+    expect(link.textContent).toBe("the guide");
+    expect(link.getAttribute("href")).toBe("https://example.test/guide");
+    expect(messages.querySelector("code")?.textContent).toBe("config.json");
+
+    // No literal markdown delimiters remain as visible text.
+    expect(messages.textContent).not.toContain("**");
+    expect(messages.textContent).not.toContain("[the guide](");
+    expect(messages.textContent).not.toContain("`config.json`");
+    // The second, plain item is still present.
+    expect(messages.textContent).toContain("Plain item");
+  });
+
+  it("escapes raw HTML inside tight list items via the inline-delegate path", async () => {
+    // The composite-text delegation must still route inline HTML tokens through
+    // the hardened html renderer — walking child tokens must not weaken escaping.
+    const session: SessionData = {
+      header: { id: "session-tight-list-xss", timestamp: now() },
+      entries: [
+        {
+          id: "1",
+          parentId: null,
+          timestamp: now(),
+          type: "message",
+          message: {
+            role: "assistant",
+            content:
+              "- item with <img src=x onerror=alert(1)> inline\n" +
+              "- **safe** markup",
+          },
+        },
+      ],
+      leafId: "1",
+      systemPrompt: "",
+      tools: [],
+    };
+
+    const { document } = await renderTemplate(session);
+    const messages = requireElement(document.getElementById("messages"), "messages root missing");
+    expect(messages.querySelector("img[onerror]")).toBeNull();
+    expect(messages.querySelector("strong")?.textContent).toBe("safe");
+    expect(messages.innerHTML).toContain("&lt;img src=x onerror=alert(1)&gt;");
+  });
+
   it("escapes tree and header metadata fields", async () => {
     const attack = "<img src=x onerror=alert(9)>";
     const baseEntries: SessionEntry[] = [


### PR DESCRIPTION
## Problem

When a chat session is exported to HTML, **tight list items** (list items with no blank line between them) rendered their inline Markdown *literally*. That is, `- **Important**: read [the guide](...)` inside a tight list showed the raw `**bold**`, `[link](...)` and backtick `code` syntax instead of bold text, a link, and inline code.

**Reproduction** (export a session containing):
```
- **Important**: read [the guide](https://example.test/guide) and use `config.json`.
- Plain item.
```
The first item's inline markup appears unrendered (literal `**`, `[]` and backticks).

## Root cause

`src/auto-reply/reply/export-html/template.js` overrides the Marked `text` renderer:

```js
text(token) {
  return escapeHtmlTags(escapeHtml(token.text));
}
```

It treats every text token as a leaf and escapes the raw `token.text`. But for tight list items, Marked v18 produces a **composite** text token carrying its already-parsed inline children in `token.tokens` (`Tokens.Text.tokens?: Token[]`). Escaping the raw `token.text` bypasses those children, so `**bold**`, `[link](…)` and `` `code` `` never reach their own renderers and show up literally. (Paragraph text works only because its inline children are passed to the renderer individually, not grouped into a composite text token.)

## Fix

Delegate composite text tokens through `parseInline` so their inline children are rendered by the normal renderer set, while leaf text keeps the existing HTML escaping:

```js
text(token) {
  if (token.tokens && token.tokens.length > 0) {
    return this.parser.parseInline(token.tokens);
  }
  return escapeHtmlTags(escapeHtml(token.text));
}
```

Security is preserved: delegation routes any inline HTML children through the already-hardened `html`/`link` renderers, so raw HTML inside tight list items is still escaped (covered by a regression test asserting no `img[onerror]` and escaped innerHTML).

## Tests

Two regression tests were added to `src/auto-reply/reply/export-html/template.security.test.ts`:
- inline Markdown inside tight list items renders as `<strong>` / `<a>` / `<code>` (no literal `**`/`[]`/backticks),
- raw HTML inside tight list items stays escaped through the inline-delegate path.

Both pass with the fix and the inline-markdown test fails on the pre-fix code. Related `commands-export-session` tests pass.

Fixes #140785
