### PR TITLE
refactor(runtime): share version manager path classification

### DIFF
--- a/src/bootstrap/node-extra-ca-certs.test.ts
+++ b/src/bootstrap/node-extra-ca-certs.test.ts
@@ -17,6 +17,7 @@ const VERSION_MANAGER_EXEC_PATHS = [
   ["nodenv", "/home/test/.nodenv/versions/22.14.0/bin/node"],
   ["nodebrew", "/home/test/.nodebrew/node/v22.14.0/bin/node"],
   ["nvs", "/home/test/nvs/node/22.14.0/x64/bin/node"],
+  ["raw path before normalization", "/home/test/.nvm/../system/bin/node"],
 ] as const;
 
 function allowOnly(path: string) {
@@ -73,12 +74,20 @@ describe("resolveAutoNodeExtraCaCerts", () => {
     ).toBeUndefined();
   });
 
-  it("returns undefined when node is not nvm-managed", () => {
+  it.each([
+    ["/usr/bin/node", undefined],
+    ["/usr/bin/node", ""],
+    ["/usr/bin/node", " \t "],
+    ["/home/test/.NVM/versions/node/v22/bin/node", undefined],
+    ["/home/test/library/application support/fnm/bin/node", undefined],
+    ["/home/test/.local/share/pnpm/node", undefined],
+    ["/home/test/.nvm\\versions\\node\\v22\\bin\\node", undefined],
+  ] as const)("does not infer Linux CA settings for %s with NVM_DIR=%j", (execPath, NVM_DIR) => {
     expect(
       resolveAutoNodeExtraCaCerts({
-        env: {},
+        env: { NVM_DIR },
         platform: "linux",
-        execPath: "/usr/bin/node",
+        execPath,
         accessSync: allowOnly(DEBIAN_CA_BUNDLE_PATH),
       }),
     ).toBeUndefined();

--- a/src/bootstrap/node-extra-ca-certs.ts
+++ b/src/bootstrap/node-extra-ca-certs.ts
@@ -1,5 +1,6 @@
 // Resolves additional CA certificate settings for Node child processes.
 import fs from "node:fs";
+import { matchesVersionManagerPath } from "../shared/version-manager-path.js";
 
 const LINUX_CA_BUNDLE_PATHS = [
   "/etc/ssl/certs/ca-certificates.crt",
@@ -9,27 +10,6 @@ const LINUX_CA_BUNDLE_PATHS = [
 
 export type EnvMap = Record<string, string | undefined>;
 type AccessSyncFn = (path: string, mode?: number) => void;
-
-/**
- * Version manager path markers (Linux subset), mirroring VERSION_MANAGER_MARKERS
- * in src/daemon/runtime-paths.ts. Not imported directly because bootstrap code
- * must avoid daemon-layer dependencies at startup.
- * Version-manager-installed Node does not inherit system CA certificates,
- * so we detect this to auto-inject NODE_EXTRA_CA_CERTS.
- */
-const VERSION_MANAGER_PATH_MARKERS: readonly string[] = [
-  "/.nvm/",
-  "/.fnm/",
-  "/.local/share/fnm/",
-  "/.volta/",
-  "/.asdf/",
-  "/.local/share/mise/",
-  "/.n/",
-  "/.nodenv/",
-  "/.nodebrew/",
-  "/nvs/",
-  "/.nvs/",
-];
 
 export function resolveAutoNodeExtraCaCerts(
   params: {
@@ -50,9 +30,9 @@ export function resolveAutoNodeExtraCaCerts(
     return undefined;
   }
 
+  // Version-manager Node may not inherit system CAs; supply NODE_EXTRA_CA_CERTS.
   const isVersionManagerRuntime =
-    Boolean(env.NVM_DIR?.trim()) ||
-    VERSION_MANAGER_PATH_MARKERS.some((marker) => execPath.includes(marker));
+    Boolean(env.NVM_DIR?.trim()) || matchesVersionManagerPath(execPath, "linux-ca");
   if (!isVersionManagerRuntime) {
     return undefined;
   }

--- a/src/daemon/runtime-paths.test.ts
+++ b/src/daemon/runtime-paths.test.ts
@@ -184,46 +184,35 @@ describe("resolvePreferredNodePath", () => {
     expect(execFile).toHaveBeenCalledTimes(2);
   });
 
-  it("uses system node for Linux service installs instead of nvm execPath", async () => {
-    mockNodePathPresent(linuxSystemNode);
+  it.each([
+    [nvmNode, true],
+    ["/home/test/.local/share/fnm/aliases/default/bin/node", true],
+    ["/home/test/.local/share/mise/installs/node/24/bin/node", true],
+    ["/home/test/.NVM/versions/node/v24/bin/node", true],
+    ["/home/test/.nvs/node/24/bin/node", false],
+    ["/home/test/.local/share/pnpm/node", false],
+    ["/home/test/.nvm/../system/bin/node", false],
+  ] as const)(
+    "preserves Linux runtime preference for %s (managed=%s)",
+    async (execPath, managed) => {
+      mockNodePathPresent(linuxSystemNode);
+      const execFile = vi
+        .fn()
+        .mockResolvedValueOnce(nodeRuntime("24.15.0"))
+        .mockResolvedValueOnce(nodeRuntime("24.15.0"));
 
-    const execFile = vi
-      .fn()
-      .mockResolvedValueOnce(nodeRuntime("24.15.0"))
-      .mockResolvedValueOnce(nodeRuntime("24.15.0"));
+      const result = await resolvePreferredNodePath({
+        env: {},
+        runtime: "node",
+        platform: "linux",
+        execFile,
+        execPath,
+      });
 
-    const result = await resolvePreferredNodePath({
-      env: {},
-      runtime: "node",
-      platform: "linux",
-      execFile,
-      execPath: nvmNode,
-    });
-
-    expect(result).toBe(linuxSystemNode);
-    expect(execFile).toHaveBeenCalledTimes(2);
-  });
-
-  it("uses system node for Linux service installs instead of default fnm execPath", async () => {
-    const linuxFnmNode = "/home/test/.local/share/fnm/aliases/default/bin/node";
-    mockNodePathPresent(linuxSystemNode);
-
-    const execFile = vi
-      .fn()
-      .mockResolvedValueOnce(nodeRuntime("24.15.0"))
-      .mockResolvedValueOnce(nodeRuntime("24.15.0"));
-
-    const result = await resolvePreferredNodePath({
-      env: {},
-      runtime: "node",
-      platform: "linux",
-      execFile,
-      execPath: linuxFnmNode,
-    });
-
-    expect(result).toBe(linuxSystemNode);
-    expect(execFile).toHaveBeenCalledTimes(2);
-  });
+      expect(result).toBe(managed ? linuxSystemNode : execPath);
+      expect(execFile).toHaveBeenCalledTimes(managed ? 2 : 1);
+    },
+  );
 
   it("uses system node for macOS service installs instead of default fnm execPath", async () => {
     const darwinFnmNode = "/Users/test/Library/Application Support/fnm/aliases/default/bin/node";

--- a/src/daemon/runtime-paths.ts
+++ b/src/daemon/runtime-paths.ts
@@ -10,21 +10,9 @@ import { isSqliteWalResetSafeVersion } from "../infra/sqlite-runtime-version.js"
 import { resolveStableNodePath } from "../infra/stable-node-path.js";
 import { getWindowsProgramFilesRoots } from "../infra/windows-install-roots.js";
 import { runExec } from "../process/exec.js";
+import { matchesVersionManagerPath } from "../shared/version-manager-path.js";
 import { isBunRuntime } from "./runtime-binary.js";
-
-const VERSION_MANAGER_MARKERS = [
-  "/.nvm/",
-  "/.fnm/",
-  "/.local/share/fnm/",
-  "/library/application support/fnm/",
-  "/.volta/",
-  "/.asdf/",
-  "/.local/share/mise/",
-  "/.n/",
-  "/.nodenv/",
-  "/.nodebrew/",
-  "/nvs/",
-];
+import { normalizeServicePathEntry } from "./service-path-policy.js";
 
 function getPathModule(platform: NodeJS.Platform) {
   return platform === "win32" ? path.win32 : path.posix;
@@ -34,15 +22,6 @@ function isNodeExecPath(execPath: string, platform: NodeJS.Platform): boolean {
   const pathModule = getPathModule(platform);
   const base = normalizeLowercaseStringOrEmpty(pathModule.basename(execPath));
   return base === "node" || base === "node.exe";
-}
-
-function normalizeForCompare(input: string, platform: NodeJS.Platform): string {
-  const pathModule = getPathModule(platform);
-  const normalized = pathModule.normalize(input).replaceAll("\\", "/");
-  if (platform === "win32") {
-    return normalizeLowercaseStringOrEmpty(normalized);
-  }
-  return normalized;
 }
 
 function buildSystemNodeCandidates(
@@ -89,7 +68,7 @@ function buildBunCandidates(
     if (!candidate || !pathModule.isAbsolute(candidate)) {
       return;
     }
-    const normalized = normalizeForCompare(candidate, platform);
+    const normalized = normalizeServicePathEntry(candidate, platform);
     if (seen.has(normalized)) {
       return;
     }
@@ -236,8 +215,8 @@ export function isVersionManagedNodePath(
   nodePath: string,
   platform: NodeJS.Platform = process.platform,
 ): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(normalizeForCompare(nodePath, platform));
-  return VERSION_MANAGER_MARKERS.some((marker) => normalized.includes(marker));
+  const normalized = normalizeLowercaseStringOrEmpty(normalizeServicePathEntry(nodePath, platform));
+  return matchesVersionManagerPath(normalized, "daemon-runtime");
 }
 
 /** True when a Node path matches known system install candidates for the platform. */
@@ -246,9 +225,9 @@ export function isSystemNodePath(
   env: Record<string, string | undefined> = process.env,
   platform: NodeJS.Platform = process.platform,
 ): boolean {
-  const normalized = normalizeForCompare(nodePath, platform);
+  const normalized = normalizeServicePathEntry(nodePath, platform);
   return buildSystemNodeCandidates(env, platform).some((candidate) => {
-    const normalizedCandidate = normalizeForCompare(candidate, platform);
+    const normalizedCandidate = normalizeServicePathEntry(candidate, platform);
     return normalized === normalizedCandidate;
   });
 }

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -200,28 +200,28 @@ describe("auditGatewayServiceConfig", () => {
     expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayRuntimeBun)).toBe(false);
   });
 
-  it("flags version-managed node paths", async () => {
+  it.each([
+    [".nvm/versions/node/v22.0.0/bin", true, true],
+    [".NVM/versions/node/v22.0.0/bin", true, false],
+    [".local/share/mise/installs/node/22/bin", true, false],
+    ["Library/Application Support/fnm/aliases/default/bin", true, false],
+    [".nvs/node/22/bin", false, false],
+    [".local/share/pnpm", false, true],
+    [".nvm/../system/bin", false, false],
+    [".local/share/mise/.nvm/bin", true, true],
+  ] as const)("audits runtime and PATH for %s", async (directory, runtime, nonMinimal) => {
+    const bin = `/Users/test/${directory}`;
     const audit = await auditGatewayServiceConfig({
       env: { HOME: "/tmp" },
       platform: "darwin",
       command: {
-        programArguments: ["/Users/test/.nvm/versions/node/v22.0.0/bin/node", "gateway"],
-        environment: {
-          PATH: "/usr/bin:/bin:/Users/test/.nvm/versions/node/v22.0.0/bin",
-        },
+        programArguments: [`${bin}/node`, "gateway"],
+        environment: { PATH: `/usr/bin:/bin:${bin}` },
       },
     });
-    expect(
-      audit.issues.some(
-        (issue) => issue.code === SERVICE_AUDIT_CODES.gatewayRuntimeNodeVersionManager,
-      ),
-    ).toBe(true);
-    expect(
-      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayPathNonMinimal),
-    ).toBe(true);
-    expect(
-      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayPathMissingDirs),
-    ).toBe(true);
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayRuntimeNodeVersionManager)).toBe(runtime);
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayPathNonMinimal)).toBe(nonMinimal);
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayPathMissingDirs)).toBe(true);
   });
 
   it("accepts Linux minimal PATH with user directories", async () => {

--- a/src/daemon/service-path-policy.ts
+++ b/src/daemon/service-path-policy.ts
@@ -1,6 +1,7 @@
 /** Classifies service PATH entries that should not be frozen into daemons. */
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { matchesVersionManagerPath } from "../shared/version-manager-path.js";
 
 // Service PATH policy keeps managed services away from user shell package-manager paths.
 export function normalizeServicePathEntry(entry: string, platform: NodeJS.Platform): string {
@@ -20,15 +21,7 @@ export function isNonMinimalServicePathEntry(entry: string, platform: NodeJS.Pla
   // User shell package-manager paths are fragile in non-interactive services and
   // should be replaced by stable system/runtime paths.
   return (
-    normalized.includes("/.nvm/") ||
-    normalized.includes("/.fnm/") ||
-    normalized.includes("/.local/share/fnm/") ||
-    normalized.includes("/.volta/") ||
-    normalized.includes("/.asdf/") ||
-    normalized.includes("/.n/") ||
-    normalized.includes("/.nodenv/") ||
-    normalized.includes("/.nodebrew/") ||
-    normalized.includes("/nvs/") ||
+    matchesVersionManagerPath(normalized, "service-path") ||
     normalized.includes("/.local/share/pnpm/") ||
     normalized.includes("/pnpm/") ||
     normalized.endsWith("/pnpm")

--- a/src/shared/version-manager-path.ts
+++ b/src/shared/version-manager-path.ts
@@ -1,0 +1,25 @@
+const COMMON_VERSION_MANAGER_MARKERS = [
+  "/.nvm/",
+  "/.fnm/",
+  "/.local/share/fnm/",
+  "/.volta/",
+  "/.asdf/",
+  "/.n/",
+  "/.nodenv/",
+  "/.nodebrew/",
+  "/nvs/",
+];
+
+// Callers own normalization and case handling; the profiles preserve their
+// distinct CA-discovery, executable-selection, and service PATH policies.
+export function matchesVersionManagerPath(
+  path: string,
+  profile: "linux-ca" | "daemon-runtime" | "service-path",
+): boolean {
+  return (
+    COMMON_VERSION_MANAGER_MARKERS.some((marker) => path.includes(marker)) ||
+    (profile !== "service-path" && path.includes("/.local/share/mise/")) ||
+    (profile === "linux-ca" && path.includes("/.nvs/")) ||
+    (profile === "daemon-runtime" && path.includes("/library/application support/fnm/"))
+  );
+}


### PR DESCRIPTION
## What Problem This Solves

Bootstrap TLS defaults, daemon runtime selection, and service PATH filtering independently list overlapping version-manager path markers. Their differences affect existing behavior, so copying one list into another would silently change certificate defaults or service diagnostics.

## Why This Change Was Made

Use the dependency-free `src/shared/version-manager-path.ts` leaf for the shared marker inventory and explicit caller profiles. Callers retain normalization, case handling, platform gates, and environment inspection. Daemon runtime selection also reuses the existing service-path normalizer instead of keeping an identical private implementation.

| Policy | Linux CA bootstrap | Daemon runtime | Service PATH |
| --- | --- | --- | --- |
| Common manager markers | Retained | Retained | Retained |
| mise | Retained | Retained | Excluded |
| Dotted `.nvs` | Retained | Excluded | Excluded |
| macOS fnm path | Excluded | Retained | Excluded |
| Matching | Raw, case-sensitive; Linux only | Normalized and lowercased | Normalized, case-sensitive POSIX; disabled on Windows |

`NVM_DIR` still independently enables bootstrap detection when nonblank, and an existing `NODE_EXTRA_CA_CERTS` still takes precedence. pnpm filtering remains local to service PATH policy. Matching preserves OR behavior when a path contains multiple manager markers.

## User Impact

No runtime, TLS, PATH, CLI, configuration, or persisted-state behavior change. Production code shrinks by 23 lines. Existing caller tests gain negative policy cases while consolidating identical Linux runtime setup, for a net reduction of two test lines.

## Evidence

- Expanded characterization tests passed against the original production code: 156 tests across bootstrap CA, runtime selection and service audit, 11.01 seconds.
- After extraction, `node scripts/run-vitest.mjs src/bootstrap/node-extra-ca-certs.test.ts src/bootstrap/node-startup-env.test.ts src/daemon/runtime-paths.test.ts src/daemon/service-audit.test.ts src/daemon/service-env.test.ts`: 254 passed across 5 files, 11.25 seconds.
- `node scripts/run-vitest.mjs src/commands/daemon-install-helpers.test.ts -t 'drops stale non-minimal PATH entries'`: selected install-plan PATH case passed (74 other cases filtered), 24.63 seconds.
- Cases retain uppercase/raw-path distinctions, blank `NVM_DIR`, dotted NVS, mise, macOS fnm, mixed markers, system runtime choice, service diagnostics, and existing cross-platform behavior.
- Independent Codex autoreview: no actionable P0–P2 findings. Lead directly compared the reused normalization implementation and its existing caller coverage.
- Formatting, `git diff --check`, and the full `node scripts/check-changed.mjs`: passed.
- `pnpm build`: passed in 9m6.8s, including the CLI bootstrap import guard. `dist/build-info.json` identifies `12d51f915f9ab0ed2f549ca11cca275938c58a5a`.

## Known Gaps

None. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34088681005) passed. The latest review has no actionable findings.
