### PR TITLE
refactor(theme): share palette index lookup

### DIFF
--- a/src/agents/modes/interactive/theme/theme.test.ts
+++ b/src/agents/modes/interactive/theme/theme.test.ts
@@ -1,0 +1,95 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../../test/helpers/temp-dir.js";
+import darkTheme from "./dark.json" with { type: "json" };
+import { loadThemeFromPath } from "./theme.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function loadColor(color: string | number, mode: "256color" | "truecolor") {
+  const themePath = join(tempDirs.make("openclaw-theme-"), "theme.json");
+  writeFileSync(
+    themePath,
+    JSON.stringify({
+      ...darkTheme,
+      colors: { ...darkTheme.colors, accent: color, selectedBg: color },
+    }),
+  );
+  return loadThemeFromPath(themePath, mode);
+}
+
+describe("loadThemeFromPath", () => {
+  it.each([
+    ["#0000ff", 21],
+    ["#2f00ff", 21],
+    ["#3000ff", 57],
+    ["#7200ff", 57],
+    ["#7300ff", 57],
+    ["#7400ff", 93],
+    ["#9a00ff", 93],
+    ["#9b00ff", 93],
+    ["#9c00ff", 129],
+    ["#c200ff", 129],
+    ["#c300ff", 129],
+    ["#c400ff", 165],
+    ["#ea00ff", 165],
+    ["#eb00ff", 165],
+    ["#ec00ff", 201],
+    ["#ff00ff", 201],
+    ["#ff7200", 202],
+    ["#ff7300", 202],
+    ["#ff7400", 208],
+    ["#00ff72", 47],
+    ["#00ff73", 47],
+    ["#00ff74", 48],
+    ["#5f87af", 67],
+    ["#000000", 16],
+    ["#040404", 16],
+    ["#050505", 232],
+    ["#080808", 232],
+    ["#0c0c0c", 232],
+    ["#0d0d0d", 232],
+    ["#0e0e0e", 233],
+    ["#707070", 242],
+    ["#717171", 242],
+    ["#727272", 243],
+    ["#e8e8e8", 254],
+    ["#e9e9e9", 254],
+    ["#eaeaea", 255],
+    ["#eeeeee", 255],
+    ["#ffffff", 231],
+    ["#606060", 59],
+    ["#616161", 241],
+    ["#0c0d0e", 232],
+    ["#0d0d16", 233],
+    ["#0d0d17", 16],
+  ])(
+    "renders %s as palette index %i with separate foreground/background resets",
+    (color, index) => {
+      const theme = loadColor(color, "256color");
+      expect(theme.fg("accent", "text")).toBe(`\x1b[38;5;${index}mtext\x1b[39m`);
+      expect(theme.bg("selectedBg", "text")).toBe(`\x1b[48;5;${index}mtext\x1b[49m`);
+    },
+  );
+
+  it("preserves RGB channels in truecolor output", () => {
+    const theme = loadColor("#5f87af", "truecolor");
+    expect(theme.fg("accent", "text")).toBe("\x1b[38;2;95;135;175mtext\x1b[39m");
+    expect(theme.bg("selectedBg", "text")).toBe("\x1b[48;2;95;135;175mtext\x1b[49m");
+  });
+
+  it.each(["256color", "truecolor"] as const)(
+    "preserves numeric and reset colors in %s",
+    (mode) => {
+      for (const index of [0, 123, 255]) {
+        const theme = loadColor(index, mode);
+        expect(theme.fg("accent", "text")).toBe(`\x1b[38;5;${index}mtext\x1b[39m`);
+        expect(theme.bg("selectedBg", "text")).toBe(`\x1b[48;5;${index}mtext\x1b[49m`);
+      }
+      const reset = loadColor("", mode);
+      expect(reset.fg("accent", "text")).toBe("\x1b[39mtext\x1b[39m");
+      expect(reset.bg("selectedBg", "text")).toBe("\x1b[49mtext\x1b[49m");
+    },
+  );
+});

--- a/src/agents/modes/interactive/theme/theme.ts
+++ b/src/agents/modes/interactive/theme/theme.ts
@@ -180,24 +180,11 @@ const CUBE_VALUES = [0, 95, 135, 175, 215, 255];
 // Grayscale ramp values (indices 232-255, 24 grays from 8 to 238)
 const GRAY_VALUES = Array.from({ length: 24 }, (_, i) => 8 + i * 10);
 
-function findClosestCubeIndex(value: number): number {
+function findClosestPaletteIndex(value: number, palette: readonly number[]): number {
   let minDist = Infinity;
   let minIdx = 0;
-  for (const [i, cubeValue] of CUBE_VALUES.entries()) {
-    const dist = Math.abs(value - cubeValue);
-    if (dist < minDist) {
-      minDist = dist;
-      minIdx = i;
-    }
-  }
-  return minIdx;
-}
-
-function findClosestGrayIndex(gray: number): number {
-  let minDist = Infinity;
-  let minIdx = 0;
-  for (const [i, grayValue] of GRAY_VALUES.entries()) {
-    const dist = Math.abs(gray - grayValue);
+  for (const [i, paletteValue] of palette.entries()) {
+    const dist = Math.abs(value - paletteValue);
     if (dist < minDist) {
       minDist = dist;
       minIdx = i;
@@ -223,9 +210,9 @@ function colorDistance(
 
 function rgbTo256(r: number, g: number, b: number): number {
   // Find closest color in the 6x6x6 cube
-  const rIdx = findClosestCubeIndex(r);
-  const gIdx = findClosestCubeIndex(g);
-  const bIdx = findClosestCubeIndex(b);
+  const rIdx = findClosestPaletteIndex(r, CUBE_VALUES);
+  const gIdx = findClosestPaletteIndex(g, CUBE_VALUES);
+  const bIdx = findClosestPaletteIndex(b, CUBE_VALUES);
   const cubeR = CUBE_VALUES[rIdx];
   const cubeG = CUBE_VALUES[gIdx];
   const cubeB = CUBE_VALUES[bIdx];
@@ -237,7 +224,7 @@ function rgbTo256(r: number, g: number, b: number): number {
 
   // Find closest grayscale
   const gray = Math.round(0.299 * r + 0.587 * g + 0.114 * b);
-  const grayIdx = findClosestGrayIndex(gray);
+  const grayIdx = findClosestPaletteIndex(gray, GRAY_VALUES);
   const grayValue = GRAY_VALUES[grayIdx];
   if (grayValue === undefined) {
     throw new Error("Invalid 256-color grayscale index");


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested work for the active duplication cleanup deliverable: the interactive terminal theme maintained two identical nearest-palette lookup loops. Keeping them separate made the cube and grayscale paths unnecessarily easy to change inconsistently.

## Why This Change Was Made

Replace the two private helpers with `findClosestPaletteIndex(value, palette)` and redirect their four callers. Preserve `.entries()` traversal, strict `<` comparison, first-index ties, `Infinity`/zero initialization, both palettes, weighted distance arithmetic, saturation decisions, errors, and exact ANSI bytes.

The change is limited to the theme owner and its sibling behavior tests. No new exports, configuration, dependencies, or lifecycle changes.

## User Impact

No user-visible behavior change. Terminal colors, truecolor output, numeric palette colors, and foreground/background resets remain byte-for-byte unchanged.

## Evidence

- 46 theme characterization tests pass against both the original implementation and the refactor, through `loadThemeFromPath` using isolated variants of the complete built-in theme.
- Exact-byte assertions cover cube and grayscale midpoint ties, adjacent values and endpoints, RGB channel selection, saturation/weighted gray decisions, foreground/background output, truecolor, numeric colors, and resets.
- Independent review through P2: scoped-clean, no findings. ClawSweeper also reviewed the exact head with no actionable correctness or security findings.
- Targeted `oxfmt`, targeted `oxlint`, and `git diff --check` pass.
- Changed-lane dry run selects core production and core tests. The local actual gate passes formatting and preliminary guards, then stops because the declaration compiler rejects the worktree's shared dependency symlink.
- The requested local resource-loader sibling suite cannot initialize because package-local dependency links are absent. No shared installation was changed.
- Blacksmith Testbox: both requested suites pass, 51 tests total, using `node scripts/run-vitest.mjs src/agents/modes/interactive/theme/theme.test.ts src/agents/sessions/resource-loader.test.ts`.
- The full remote `node scripts/check-changed.mjs -- src/agents/modes/interactive/theme/theme.ts src/agents/modes/interactive/theme/theme.test.ts` gate passes, including core and all selected test typechecks, lint, formatting, and repository guards.
- Testbox proof: https://github.com/openclaw/openclaw/actions/runs/34087493508, lease `tbx_01m1x5xkkv4e25jdn6d83897wv`. Both delegated commands exited 0 on verified tree `befc9ec13d6c6b7da43d1181ef3cb2012e49385a`. Lease cleanup may mark the hydration workflow cancelled; the delegated command results are the Testbox proof.
- Exact-head PR CI passes for `ea1e083c96867aaa90b31409eeeb98fb42f2df39`: https://github.com/openclaw/openclaw/actions/runs/34088707468. The required `openclaw/ci-gate` check is successful.

Production: `+7/-20` lines. Tests: `+95/-0` lines.
