### PR TITLE
fix(android): constrain model sheets to fold-safe panes

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -66,8 +66,14 @@ menu, it closes without choosing an action. Reopen it explicitly when space
 permits; it does not reopen automatically when the layout recovers. Dismissing
 the menu does not reset Chat's draft, editor, or reader state.
 
-The Thinking control opens an effort sheet, not an adapted dropdown. Other
-dialogs, sheets, and popup menus are not fold-adapted yet.
+Chat's Model picker and its Permissions page initially use the largest safe
+region with usable sheet space, not the trigger's region. They keep that region
+while it remains usable. Valid geometry changes retain the same sheet and local
+state. An invalid opening closes without selecting an option and stays closed
+until explicitly reopened.
+
+The Thinking effort sheet, background-task and branch-switching sheets, and
+other dialogs, sheets, and popup menus are not fold-adapted yet.
 
 ## Wear OS companion
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareDialog.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareDialog.kt
@@ -1,9 +1,6 @@
 package ai.openclaw.app.ui
 
 import ai.openclaw.app.ui.design.ClawTheme
-import android.app.Activity
-import android.view.View
-import android.view.ViewTreeObserver
 import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
@@ -25,7 +22,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -54,7 +50,6 @@ import androidx.compose.ui.unit.round
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.SecureFlagPolicy
-import androidx.window.layout.WindowMetricsCalculator
 
 @Composable
 internal fun FoldAwareDialog(
@@ -84,7 +79,7 @@ internal fun FoldAwareDialog(
         decorFitsSystemWindows = false,
       ),
   ) {
-    val geometry = rememberDialogWindowGeometry(activity, activityView, LocalView.current)
+    val geometry = rememberOverlayWindowGeometry(activity, activityView, LocalView.current)
     Layout(
       modifier =
         Modifier.fillMaxSize().pointerInput(Unit) {
@@ -143,7 +138,7 @@ internal fun FoldAwareDialog(
         val origin = coordinates?.positionInWindow()?.round() ?: IntOffset.Zero
         val pane =
           geometry?.let {
-            foldSafeRegion(it.activityExtent, features, layoutDirection).translate(it.activityToDialog - origin)
+            foldSafeRegion(it.activityExtent, features, layoutDirection).translate(it.activityToOverlay - origin)
           } ?: IntRect.Zero
         val left = pane.left.coerceIn(0, width)
         val top = pane.top.coerceIn(0, height)
@@ -153,62 +148,6 @@ internal fun FoldAwareDialog(
       }
     }
   }
-}
-
-private data class DialogWindowGeometry(
-  val activityExtent: IntRect,
-  val activityToDialog: IntOffset,
-)
-
-@Composable
-private fun rememberDialogWindowGeometry(
-  activity: Activity?,
-  activityView: View,
-  dialogView: View,
-): DialogWindowGeometry? {
-  var geometry by remember(activity, activityView, dialogView) { mutableStateOf<DialogWindowGeometry?>(null) }
-  DisposableEffect(activity, activityView, dialogView) {
-    val calculator = WindowMetricsCalculator.getOrCreate()
-
-    fun sample() {
-      val displayId = activityView.display?.displayId
-      geometry =
-        if (activity != null && activityView.isAttachedToWindow && dialogView.isAttachedToWindow &&
-          displayId != null && displayId == dialogView.display?.displayId
-        ) {
-          val extent = calculator.computeCurrentWindowMetrics(activity).bounds
-          DialogWindowGeometry(
-            IntRect(0, 0, extent.width(), extent.height()),
-            activityView.windowScreenOrigin() - dialogView.windowScreenOrigin(),
-          )
-        } else {
-          null
-        }
-    }
-    // A window can move without changing Compose constraints. Both references must be current
-    // and attached to the same display; never retain an offset from a previous Activity.
-    val observer =
-      ViewTreeObserver.OnPreDrawListener {
-        sample()
-        true
-      }
-    val activityObserver = activityView.viewTreeObserver
-    val dialogObserver = dialogView.viewTreeObserver
-    activityObserver.addOnPreDrawListener(observer)
-    dialogObserver.addOnPreDrawListener(observer)
-    sample()
-    onDispose {
-      if (activityObserver.isAlive) activityObserver.removeOnPreDrawListener(observer)
-      if (dialogObserver.isAlive) dialogObserver.removeOnPreDrawListener(observer)
-    }
-  }
-  return geometry
-}
-
-private fun View.windowScreenOrigin(): IntOffset {
-  val screen = IntArray(2).also(::getLocationOnScreen)
-  val window = IntArray(2).also(::getLocationInWindow)
-  return IntOffset(screen[0] - window[0], screen[1] - window[1])
 }
 
 @Composable

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareSheet.kt
@@ -1,0 +1,253 @@
+package ai.openclaw.app.ui
+
+import android.app.Activity
+import android.os.IBinder
+import android.view.View
+import androidx.compose.foundation.layout.recalculateWindowInsets
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.LayoutModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.node.invalidatePlacement
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.round
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.Lifecycle
+
+/** Geometry for one terminal opening, never reused by a replacement native sheet. */
+internal class FoldAwareSheetState(
+  val activity: Activity?,
+  val activityView: View,
+  private val lifecycle: Lifecycle,
+  private val onUnsafe: () -> Unit,
+) {
+  var revoked = false
+    private set
+  private var features = WindowDisplayFeatureSnapshot()
+  private var destination: View? = null
+  private var token: IBinder? = null
+  private var display: Int? = null
+  private var nativeEstablished = false
+  private var host: LayoutCoordinates? = null
+  private var hostSize = IntSize.Zero
+  private var direction = LayoutDirection.Ltr
+  private var selectedPane: IntRect? = null
+  private var resolvedPane: IntRect? = null
+  private var placedPane: IntRect? = null
+  private var publishedMapping: OverlayWindowGeometry? = null
+  var invalidate: () -> Unit = {}
+
+  fun revoke() {
+    if (revoked) return
+    revoked = true
+    invalidate()
+  }
+
+  private fun reject() {
+    if (revoked) return
+    revoke()
+    onUnsafe()
+  }
+
+  fun publishFeatures(next: WindowDisplayFeatureSnapshot) {
+    features = next
+    refresh()
+    invalidate()
+  }
+
+  fun canOpen(): Boolean {
+    val mapping = sampleOverlayWindowGeometry(activity, activityView, activityView) ?: return false
+    return features.ready && lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED) &&
+      foldSafeRegions(mapping.activityExtent, features.features).any { it.width > 0 && it.height > 0 }
+  }
+
+  fun bind(view: View) {
+    if (destination != null && destination !== view) reject()
+    if (!revoked) destination = view
+  }
+
+  fun publishMapping(mapping: OverlayWindowGeometry?) {
+    if (mapping == null && nativeEstablished) reject()
+    refresh()
+    if (publishedMapping != mapping || resolvedPane != placedPane) invalidate()
+    publishedMapping = mapping
+  }
+
+  fun detach() = reject()
+
+  fun refresh(): Boolean {
+    if (revoked) return false
+    if (!canOpen()) {
+      reject()
+      return false
+    }
+    val view = destination ?: return false
+    val mapping = sampleOverlayWindowGeometry(activity, activityView, view)
+    if (mapping == null) {
+      if (nativeEstablished) reject()
+      return false
+    }
+    if (!nativeEstablished) {
+      token = view.windowToken ?: return false
+      display = view.display?.displayId ?: return false
+      nativeEstablished = true
+    } else if (view.windowToken != token || view.display?.displayId != display) {
+      reject()
+      return false
+    }
+    val coordinates = host ?: return false
+    if (!coordinates.isAttached) {
+      reject()
+      return false
+    }
+    val origin = coordinates.positionInWindow().round()
+    var available = IntRect(origin, hostSize)
+    // The Material host is already IME-adjusted. Intersect with current native facts so an
+    // input arriving before its next measure cannot borrow the previous keyboard viewport.
+    val ime = ViewCompat.getRootWindowInsets(view)?.getInsets(WindowInsetsCompat.Type.ime())
+    if (ime != null) {
+      available =
+        available.intersect(
+          IntRect(ime.left, ime.top, view.rootView.width - ime.right, view.rootView.height - ime.bottom),
+        )
+    }
+    val candidates =
+      foldSafeRegions(mapping.activityExtent, features.features)
+        .filter { pane ->
+          val intersection = pane.translate(mapping.activityToOverlay).intersect(available)
+          intersection.width > 0 && intersection.height > 0
+        }
+    val pane =
+      selectedPane?.takeIf { it in candidates }
+        ?: candidates.minWithOrNull(
+          compareByDescending<IntRect> { it.width.toLong() * it.height }
+            .thenBy { it.top }
+            .thenBy { if (direction == LayoutDirection.Ltr) it.left else -it.right },
+        )
+    if (pane == null) {
+      reject()
+      return false
+    }
+    selectedPane = pane
+    resolvedPane = pane.translate(mapping.activityToOverlay).intersect(available).translate(-origin)
+    return placedPane == resolvedPane
+  }
+
+  fun place(
+    coordinates: LayoutCoordinates?,
+    size: IntSize,
+    direction: LayoutDirection,
+  ): IntRect? {
+    if (revoked) return null
+    if (coordinates == null) {
+      if (host != null) reject()
+      return null
+    }
+    host = coordinates
+    hostSize = size
+    this.direction = direction
+    refresh()
+    if (revoked || !nativeEstablished) return null
+    placedPane = resolvedPane
+    return placedPane?.takeIf { it.width > 0 && it.height > 0 }
+  }
+}
+
+/** Material materializes this modifier inside its native window, not at the Activity call site. */
+@Composable
+internal fun Modifier.foldAwareSheet(state: FoldAwareSheetState): Modifier {
+  // Capture the caller's direction. A newly created native dialog initially reports LTR.
+  val direction = LocalLayoutDirection.current
+  return composed {
+    val destination = LocalView.current
+    DisposableEffect(state, destination) {
+      state.bind(destination)
+      onDispose { state.detach() }
+    }
+    rememberOverlayWindowGeometry(state.activity, state.activityView, destination, state::publishMapping)
+    this
+      .then(SheetHostElement(state, direction))
+      .clipToBounds()
+      .recalculateWindowInsets()
+      .layout { measurable, constraints ->
+        val surface = measurable.measure(constraints.copy(minWidth = 0, minHeight = 0))
+        layout(constraints.maxWidth, constraints.maxHeight) {
+          surface.place((constraints.maxWidth - surface.width) / 2, 0)
+        }
+      }
+  }
+}
+
+private data class SheetHostElement(
+  val state: FoldAwareSheetState,
+  val direction: LayoutDirection,
+) : ModifierNodeElement<SheetHostNode>() {
+  override fun create() = SheetHostNode(state, direction)
+
+  override fun update(node: SheetHostNode) {
+    check(node.state === state)
+    node.direction = direction
+  }
+
+  override fun InspectorInfo.inspectableProperties() {
+    name = "foldAwareSheet"
+  }
+}
+
+private class SheetHostNode(
+  val state: FoldAwareSheetState,
+  var direction: LayoutDirection,
+) : Modifier.Node(),
+  LayoutModifierNode,
+  DrawModifierNode {
+  override fun onAttach() {
+    state.invalidate = {
+      if (isAttached) {
+        invalidatePlacement()
+        invalidateDraw()
+      }
+    }
+  }
+
+  override fun onDetach() {
+    state.invalidate = {}
+    state.detach()
+  }
+
+  override fun MeasureScope.measure(
+    measurable: Measurable,
+    constraints: Constraints,
+  ): MeasureResult {
+    val size = IntSize(constraints.maxWidth, constraints.maxHeight)
+    return layout(size.width, size.height) {
+      val pane = state.place(coordinates, size, direction)
+      if (pane != null && !state.revoked) {
+        measurable.measure(Constraints.fixed(pane.width, pane.height)).place(pane.left, pane.top)
+      }
+    }
+  }
+
+  override fun ContentDrawScope.draw() {
+    if (state.refresh()) drawContent()
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OverlayWindowGeometry.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OverlayWindowGeometry.kt
@@ -1,0 +1,96 @@
+package ai.openclaw.app.ui
+
+import android.app.Activity
+import android.view.View
+import android.view.ViewTreeObserver
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.window.layout.WindowMetricsCalculator
+
+internal data class OverlayWindowGeometry(
+  val activityExtent: IntRect,
+  val activityToOverlay: IntOffset,
+)
+
+internal fun sampleOverlayWindowGeometry(
+  activity: Activity?,
+  activityView: View,
+  overlayView: View,
+): OverlayWindowGeometry? {
+  val displayId = activityView.display?.displayId
+  return if (activity != null && activityView.isAttachedToWindow && overlayView.isAttachedToWindow &&
+    displayId != null && displayId == overlayView.display?.displayId
+  ) {
+    val extent = WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(activity).bounds
+    OverlayWindowGeometry(
+      IntRect(0, 0, extent.width(), extent.height()),
+      activityView.windowScreenOrigin() - overlayView.windowScreenOrigin(),
+    )
+  } else {
+    null
+  }
+}
+
+@Composable
+internal fun rememberOverlayWindowGeometry(
+  activity: Activity?,
+  activityView: View,
+  overlayView: View,
+  onPublication: ((OverlayWindowGeometry?) -> Unit)? = null,
+): OverlayWindowGeometry? {
+  var geometry by remember(activity, activityView, overlayView) { mutableStateOf<OverlayWindowGeometry?>(null) }
+  val deliver by rememberUpdatedState(onPublication)
+  DisposableEffect(activity, activityView, overlayView) {
+    fun sample() {
+      val next = sampleOverlayWindowGeometry(activity, activityView, overlayView)
+      deliver?.invoke(next)
+      geometry = next
+    }
+    // Both windows can move independently without changing Compose constraints.
+    val observer =
+      ViewTreeObserver.OnPreDrawListener {
+        sample()
+        true
+      }
+    val activityObserver = activityView.viewTreeObserver
+    val overlayObserver = overlayView.viewTreeObserver
+    activityObserver.addOnPreDrawListener(observer)
+    overlayObserver.addOnPreDrawListener(observer)
+    val attachment =
+      object : View.OnAttachStateChangeListener {
+        override fun onViewAttachedToWindow(view: View) = sample()
+
+        override fun onViewDetachedFromWindow(view: View) {
+          deliver?.invoke(null)
+        }
+      }
+    // The dialog retains its original initial/pre-draw behavior. Terminal sheets additionally
+    // need direct detach delivery, before disposal or conflatable composition can run.
+    if (onPublication != null) {
+      activityView.addOnAttachStateChangeListener(attachment)
+      overlayView.addOnAttachStateChangeListener(attachment)
+    }
+    sample()
+    onDispose {
+      if (activityObserver.isAlive) activityObserver.removeOnPreDrawListener(observer)
+      if (overlayObserver.isAlive) overlayObserver.removeOnPreDrawListener(observer)
+      activityView.removeOnAttachStateChangeListener(attachment)
+      overlayView.removeOnAttachStateChangeListener(attachment)
+      deliver?.invoke(null)
+    }
+  }
+  return geometry
+}
+
+internal fun View.windowScreenOrigin(): IntOffset {
+  val screen = IntArray(2).also(::getLocationOnScreen)
+  val window = IntArray(2).also(::getLocationInWindow)
+  return IntOffset(screen[0] - window[0], screen[1] - window[1])
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatModelPickerSession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatModelPickerSession.kt
@@ -1,0 +1,83 @@
+package ai.openclaw.app.ui.chat
+
+import ai.openclaw.app.chat.ChatComposerOwner
+import ai.openclaw.app.ui.FoldAwareSheetState
+import ai.openclaw.app.ui.WindowDisplayFeatureSnapshot
+import android.app.Activity
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+
+internal class ChatModelPickerSession(
+  val composerOwner: ChatComposerOwner,
+  val sessionKey: String,
+  val geometry: FoldAwareSheetState,
+)
+
+/** Main-thread admission is separate from deferred Compose removal. */
+internal class ChatModelPickerSessionOwner(
+  private val activity: Activity?,
+  private val activityView: View,
+  private val lifecycle: Lifecycle,
+  private val targetIsCurrent: (ChatComposerOwner) -> Boolean,
+) {
+  var visible by mutableStateOf<ChatModelPickerSession?>(null)
+    private set
+  private var active: ChatModelPickerSession? = null
+  private var features = WindowDisplayFeatureSnapshot()
+  private val handler = Handler(Looper.getMainLooper())
+
+  fun publishFeatures(next: WindowDisplayFeatureSnapshot) {
+    features = next
+    active?.geometry?.publishFeatures(next)
+  }
+
+  fun open(
+    composerOwner: ChatComposerOwner,
+    sessionKey: String,
+  ) {
+    if (active != null || !targetIsCurrent(composerOwner)) return
+    var captured: ChatModelPickerSession? = null
+    val geometry =
+      FoldAwareSheetState(activity, activityView, lifecycle) {
+        captured?.let(::retire)
+      }
+    // Preflight must not treat a missing first publication as a flat window.
+    geometry.publishFeatures(features)
+    if (!geometry.canOpen()) return
+    val session = ChatModelPickerSession(composerOwner, sessionKey, geometry)
+    captured = session
+    active = session
+    visible = session
+  }
+
+  fun retire(session: ChatModelPickerSession) {
+    session.geometry.revoke()
+    if (active === session) active = null
+    handler.post {
+      if (visible === session) visible = null
+    }
+  }
+
+  fun refreshTarget() {
+    active?.let { if (!targetIsCurrent(it.composerOwner)) retire(it) }
+  }
+
+  fun dispose() {
+    active?.let(::retire)
+  }
+
+  fun admit(session: ChatModelPickerSession): Boolean {
+    if (active !== session || session.geometry.revoked) return false
+    // A declined late dismiss may already have hidden its native sheet. Never leave it active.
+    if (!targetIsCurrent(session.composerOwner) || !session.geometry.refresh()) {
+      retire(session)
+      return false
+    }
+    return true
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -72,15 +72,18 @@ import ai.openclaw.app.ui.design.ClawTheme
 import ai.openclaw.app.ui.design.ProviderBrandIcon
 import ai.openclaw.app.ui.design.agentAvatarSource
 import ai.openclaw.app.ui.design.sessionColor
+import ai.openclaw.app.ui.foldAwareSheet
 import ai.openclaw.app.ui.gatewayDiagnosticsEndpoint
 import ai.openclaw.app.ui.gatewayStatusForDisplay
 import ai.openclaw.app.ui.localizedUppercase
 import ai.openclaw.app.ui.relativeSessionTime
 import ai.openclaw.app.ui.rememberSystemAnimationsEnabled
+import ai.openclaw.app.ui.rememberWindowDisplayFeatureState
 import ai.openclaw.app.ui.sessionPresentationTitle
 import ai.openclaw.app.ui.sidebarCatalogHosts
 import android.os.SystemClock
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
@@ -171,8 +174,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -197,6 +202,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -457,7 +463,19 @@ internal fun ChatScreen(
   val currentPickerOwner by rememberUpdatedState(composerOwner)
   val currentPickerMainSessionKey by rememberUpdatedState(mainSessionKey)
   val sendInFlight = composerOwner in sendStates
-  var showModelPicker by rememberSaveable { mutableStateOf(false) }
+  val pickerActivity = LocalActivity.current
+  val pickerView = LocalView.current
+  val modelPicker =
+    remember(viewModel, pickerActivity, pickerView, lifecycleOwner) {
+      ChatModelPickerSessionOwner(pickerActivity, pickerView, lifecycleOwner.lifecycle) { expected ->
+        viewModel.isCurrentChatComposerOwner(expected) &&
+          viewModel.gatewayConnectionDisplay.value.isConnected &&
+          operatorScopesAllowWrite(viewModel.operatorScopes.value)
+      }
+    }
+  rememberWindowDisplayFeatureState(modelPicker::publishFeatures)
+  SideEffect { modelPicker.refreshTarget() }
+  DisposableEffect(modelPicker) { onDispose { modelPicker.dispose() } }
   var showBackgroundTasks by rememberSaveable { mutableStateOf(false) }
   var showBranchSwitcher by rememberSaveable { mutableStateOf(false) }
   var detailsExpanded by rememberSaveable { mutableStateOf(false) }
@@ -711,12 +729,6 @@ internal fun ChatScreen(
     }
   }
 
-  LaunchedEffect(gatewayConnectionDisplay.isConnected) {
-    if (!gatewayConnectionDisplay.isConnected) {
-      showModelPicker = false
-    }
-  }
-
   val newChatEnabled =
     !sessionCreating && !modelSelectionLocked &&
       canStartNewChat(
@@ -935,7 +947,7 @@ internal fun ChatScreen(
           clearOverride = !fastModeProviderSupported,
         )
       },
-      onOpenModelPicker = { showModelPicker = true },
+      onOpenModelPicker = { modelPicker.open(composerOwner, sessionKey) },
       onPickImages = {
         if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
         val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
@@ -1052,42 +1064,83 @@ internal fun ChatScreen(
     )
   }
 
-  if (showModelPicker) {
-    ChatModelPickerSheet(
-      sections = modelSections,
-      favorites = modelFavorites.toSet(),
-      selectedModelLabel = selectedModelLabel,
-      modelSelectionLocked = modelSelectionLocked,
-      contextUsage = contextUsage,
-      messages = messages,
-      permissionMode = activeSession?.permissionMode,
-      permissionModePending = permissionModePending,
-      permissionPickerEnabled =
-        permissionSettingsAvailable &&
-          !activeSession?.sessionId.isNullOrBlank() &&
-          gatewayConnectionDisplay.isConnected &&
-          canWriteSessionSettings &&
-          !permissionModePending &&
-          !sessionSettingsPending,
-      permissionUnavailableReason =
-        when {
-          !permissionSettingsAvailable -> nativeString("Update the Gateway to change session permissions.")
-          activeSession?.sessionId.isNullOrBlank() -> nativeString("Refresh this chat before changing permissions.")
-          else -> null
+  modelPicker.visible?.let { opening ->
+    // The original callback target never becomes the newest opening after a coalesced close/open.
+    fun currentSession() =
+      viewModel.chatSessions.value.firstOrNull {
+        isActiveSessionChoice(it.key, opening.sessionKey, viewModel.mainSessionKey.value)
+      }
+
+    fun admitPermissions(): Boolean =
+      modelPicker.admit(opening) &&
+        viewModel.chatPermissionSettingsAvailable.value &&
+        currentSession()?.let { !it.sessionId.isNullOrBlank() && it.permissionModePending != true } == true &&
+        opening.sessionKey !in viewModel.chatPendingSessionSettingsKeys.value
+
+    key(opening) {
+      ChatModelPickerSheet(
+        opening = opening,
+        admit = { modelPicker.admit(opening) },
+        admitPermissions = ::admitPermissions,
+        sections = modelSections,
+        favorites = modelFavorites.toSet(),
+        selectedModelLabel = selectedModelLabel,
+        modelSelectionLocked = modelSelectionLocked,
+        contextUsage = contextUsage,
+        messages = messages,
+        permissionMode = activeSession?.permissionMode,
+        permissionModePending = permissionModePending,
+        permissionPickerEnabled =
+          permissionSettingsAvailable &&
+            !activeSession?.sessionId.isNullOrBlank() &&
+            gatewayConnectionDisplay.isConnected &&
+            canWriteSessionSettings &&
+            !permissionModePending &&
+            !sessionSettingsPending,
+        permissionUnavailableReason =
+          when {
+            !permissionSettingsAvailable -> nativeString("Update the Gateway to change session permissions.")
+            activeSession?.sessionId.isNullOrBlank() -> nativeString("Refresh this chat before changing permissions.")
+            else -> null
+          },
+        canSelectFullPermission = canAdminSessionSettings,
+        onPermissionModeChange = { mode ->
+          if (admitPermissions() && canSelectChatPermissionMode(mode, operatorScopesAllowAdmin(viewModel.operatorScopes.value))) {
+            viewModel.setChatSessionPermissionMode(opening.sessionKey, mode)
+            true
+          } else {
+            false
+          }
         },
-      canSelectFullPermission = canAdminSessionSettings,
-      onPermissionModeChange = { mode -> viewModel.setChatSessionPermissionMode(sessionKey, mode) },
-      onDismiss = { showModelPicker = false },
-      onSelect = { modelRef ->
-        viewModel.setChatSessionModel(sessionKey = sessionKey, modelRef = modelRef)
-        showModelPicker = false
-      },
-      onOpenProviders = {
-        showModelPicker = false
-        onOpenProvidersModels()
-      },
-      onToggleFavorite = viewModel::toggleModelFavorite,
-    )
+        onDismiss = { if (modelPicker.admit(opening)) modelPicker.retire(opening) },
+        onSelect = { modelRef ->
+          val model = viewModel.chatModelCatalog.value.firstOrNull { it.providerQualifiedRef() == modelRef }
+          if (modelPicker.admit(opening) && currentSession()?.modelSelectionLocked != true &&
+            (modelRef == null || model?.let(::chatModelPickerAction) == ChatModelPickerAction.Select)
+          ) {
+            modelPicker.retire(opening)
+            viewModel.setChatSessionModel(sessionKey = opening.sessionKey, modelRef = modelRef)
+          }
+        },
+        onOpenProviders = { ref ->
+          val model = viewModel.chatModelCatalog.value.firstOrNull { it.providerQualifiedRef() == ref }
+          if (modelPicker.admit(opening) && currentSession()?.modelSelectionLocked != true &&
+            model?.let(::chatModelPickerAction) == ChatModelPickerAction.OpenProviders
+          ) {
+            modelPicker.retire(opening)
+            onOpenProvidersModels()
+          }
+        },
+        onToggleFavorite = { ref ->
+          val model = viewModel.chatModelCatalog.value.firstOrNull { it.providerQualifiedRef() == ref }
+          if (modelPicker.admit(opening) && currentSession()?.modelSelectionLocked != true &&
+            model != null && model.available != false
+          ) {
+            viewModel.toggleModelFavorite(ref)
+          }
+        },
+      )
+    }
   }
 
   if (showBranchSwitcher) {
@@ -3118,6 +3171,9 @@ internal fun branchMetadataText(branch: SessionBranch): String {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ChatModelPickerSheet(
+  opening: ChatModelPickerSession,
+  admit: () -> Boolean,
+  admitPermissions: () -> Boolean,
   sections: ChatModelPickerSections,
   favorites: Set<String>,
   selectedModelLabel: String,
@@ -3129,18 +3185,19 @@ private fun ChatModelPickerSheet(
   permissionPickerEnabled: Boolean,
   permissionUnavailableReason: String?,
   canSelectFullPermission: Boolean,
-  onPermissionModeChange: (ChatPermissionMode?) -> Unit,
+  onPermissionModeChange: (ChatPermissionMode?) -> Boolean,
   onDismiss: () -> Unit,
   onSelect: (String?) -> Unit,
-  onOpenProviders: () -> Unit,
+  onOpenProviders: (String) -> Unit,
   onToggleFavorite: (String) -> Unit,
 ) {
   var showPermissionPicker by rememberSaveable { mutableStateOf(false) }
   var showUsageDetails by rememberSaveable { mutableStateOf(false) }
   LaunchedEffect(permissionPickerEnabled) {
-    if (!permissionPickerEnabled) showPermissionPicker = false
+    if (showPermissionPicker && !permissionPickerEnabled && admit()) showPermissionPicker = false
   }
   ModalBottomSheet(
+    modifier = Modifier.foldAwareSheet(opening.geometry),
     onDismissRequest = onDismiss,
     // IME dismissal can remove a partial-height anchor while the selector opens.
     sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
@@ -3155,7 +3212,9 @@ private fun ChatModelPickerSheet(
     // Material captures its Back callback's enabled state when the dialog is created.
     // Own both pages here so recreation cannot leave the model page without Back.
     BackHandler {
-      if (showPermissionPicker) showPermissionPicker = false else onDismiss()
+      if (admit()) {
+        if (showPermissionPicker) showPermissionPicker = false else onDismiss()
+      }
     }
     // Keep the outer sheet unconstrained: Material anchors use the full window height.
     // Cap only its scrollable content against the actual inset-adjusted available bounds.
@@ -3165,10 +3224,9 @@ private fun ChatModelPickerSheet(
           ChatPermissionPicker(
             selectedMode = permissionMode,
             canSelectFull = canSelectFullPermission,
-            onBack = { showPermissionPicker = false },
+            onBack = { if (admit()) showPermissionPicker = false },
             onSelect = { mode ->
-              showPermissionPicker = false
-              onPermissionModeChange(mode)
+              if (onPermissionModeChange(mode)) showPermissionPicker = false
             },
           )
         } else {
@@ -3208,7 +3266,7 @@ private fun ChatModelPickerSheet(
                 Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
                   Text(text = nativeString("Latest run"), style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted)
                   TextButton(
-                    onClick = { showUsageDetails = !showUsageDetails },
+                    onClick = { if (admit()) showUsageDetails = !showUsageDetails },
                     modifier = Modifier.semantics { stateDescription = if (showUsageDetails) nativeString("Expanded") else nativeString("Collapsed") },
                   ) {
                     Text(nativeString("Details"))
@@ -3251,7 +3309,7 @@ private fun ChatModelPickerSheet(
                 verticalAlignment = Alignment.CenterVertically,
               ) {
                 Surface(
-                  onClick = { showPermissionPicker = true },
+                  onClick = { if (admitPermissions()) showPermissionPicker = true },
                   enabled = permissionPickerEnabled,
                   modifier = Modifier.weight(1f).heightIn(min = ClawTheme.spacing.touchTarget),
                   color = Color.Transparent,
@@ -3317,7 +3375,7 @@ private fun ChatModelPickerSheet(
                     model = model,
                     pinned = ref in favorites,
                     onSelect = { onSelect(ref) },
-                    onOpenProviders = onOpenProviders,
+                    onOpenProviders = { onOpenProviders(ref) },
                     onToggleFavorite = { onToggleFavorite(ref) },
                   )
                 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareSheetTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareSheetTest.kt
@@ -1,0 +1,275 @@
+package ai.openclaw.app.ui
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Rect
+import android.provider.Settings
+import android.view.View
+import androidx.activity.ComponentDialog
+import androidx.activity.compose.LocalActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.window.layout.DisplayFeature
+import androidx.window.layout.WindowInfoTracker
+import androidx.window.layout.WindowInfoTrackerDecorator
+import androidx.window.layout.WindowLayoutInfo
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import org.robolectric.shadows.ShadowDialog
+import org.robolectric.util.ReflectionHelpers
+
+@OptIn(ExperimentalMaterial3Api::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w1000dp-h1000dp-mdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class FoldAwareSheetTest {
+  @get:Rule val composeRule = createComposeRule()
+  private val features = MutableStateFlow(WindowLayoutInfo(emptyList()))
+  private lateinit var state: FoldAwareSheetState
+  private lateinit var sheetState: SheetState
+  private lateinit var activity: Activity
+  private lateinit var activityView: View
+  private var unsafe = 0
+  private var actions = 0
+  private var contentHeight by mutableStateOf(144.dp)
+  private var direction = LayoutDirection.Ltr
+
+  @Before
+  @SuppressLint("RestrictedApi")
+  fun installTracker() {
+    WindowInfoTracker.overrideDecorator(
+      object : WindowInfoTrackerDecorator {
+        override fun decorate(tracker: WindowInfoTracker): WindowInfoTracker =
+          object : WindowInfoTracker by tracker {
+            override fun windowLayoutInfo(activity: Activity): Flow<WindowLayoutInfo> = features
+          }
+      },
+    )
+    Settings.Global.putFloat(RuntimeEnvironment.getApplication().contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 0f)
+  }
+
+  @After
+  @SuppressLint("RestrictedApi")
+  fun resetTracker() = WindowInfoTracker.reset()
+
+  @Test
+  fun realSurfaceUsesPhysicalPanesAndImeAlternativeWithoutChangingNativeOwner() {
+    show()
+    val dialog = dialog()
+    val nativeState = sheetState
+    val cases =
+      listOf(
+        emptyList<DisplayFeature>() to Rect(0, 0, 1000, 1000),
+        listOf(testFold(Rect(490, 0, 510, 1000))) to Rect(0, 0, 490, 1000),
+        listOf(testFold(Rect(200, 0, 220, 1000))) to Rect(220, 0, 1000, 1000),
+        listOf(testFold(Rect(0, 200, 1000, 220))) to Rect(0, 220, 1000, 1000),
+      )
+    for ((next, expected) in cases) {
+      emit(next)
+      assertSurfaceInside(expected)
+      composeRule.onNodeWithText("Select").assertIsDisplayed().performClick()
+      assertSame(dialog, dialog())
+      assertSame(nativeState, sheetState)
+    }
+    keyboard(800)
+    assertSurfaceInside(Rect(0, 0, 1000, 200))
+    keyboard(0)
+    // A still-usable top plane stays selected when the IME goes away.
+    assertSurfaceInside(Rect(0, 0, 1000, 200))
+    assertEquals(4, actions)
+    assertEquals(0, unsafe)
+  }
+
+  @Test
+  fun terminalOmissionCannotRedrawOnRecoveryOrChildRemeasure() {
+    show()
+    val dialog = dialog()
+    val nativeState = sheetState
+    assertSurfaceInside(Rect(0, 0, 1000, 1000))
+    emit(listOf(testFold(Rect(0, 0, 1000, 1000))))
+    assertTrue(state.revoked)
+    assertEquals(1, unsafe)
+    assertEquals(null, surfacePixels())
+    emit(emptyList())
+    composeRule.runOnIdle { contentHeight = 200.dp }
+    composeRule.waitForIdle()
+    assertEquals(null, surfacePixels())
+    assertSame(dialog, dialog())
+    assertSame(nativeState, sheetState)
+    assertTrue(dialog.isShowing)
+    assertEquals(0, actions)
+  }
+
+  @Test
+  fun actionTimeSamplingRejectsDetachedActivityWithoutWaitingForPredraw() {
+    show()
+    assertTrue(composeRule.runOnIdle { state.refresh() })
+    composeRule.runOnUiThread {
+      // Native attachment loss is a raw owner fact, not a supplied geometry answer.
+      val info = ReflectionHelpers.getField<Any>(activityView, "mAttachInfo")
+      try {
+        ReflectionHelpers.setField(activityView, "mAttachInfo", null)
+        assertFalse(state.refresh())
+      } finally {
+        ReflectionHelpers.setField(activityView, "mAttachInfo", info)
+      }
+      assertTrue(state.revoked)
+      assertFalse(state.refresh())
+    }
+    assertEquals(1, unsafe)
+  }
+
+  @Test
+  fun independentWindowOriginsTranslateExactlyOnce() {
+    show()
+    emit(listOf(testFold(Rect(200, 0, 220, 1000))))
+    composeRule.runOnIdle {
+      val info = ReflectionHelpers.getField<Any>(activityView, "mAttachInfo")
+      ReflectionHelpers.setField(info, "mWindowLeft", 100)
+      activityView.viewTreeObserver.dispatchOnPreDraw()
+    }
+    composeRule.waitForIdle()
+    assertSurfaceInside(Rect(320, 0, 1000, 1000))
+    assertEquals(0, unsafe)
+  }
+
+  @Test
+  fun rtlOpeningChoosesTheLogicalStartPlaneForAnEqualBookSplit() {
+    direction = LayoutDirection.Rtl
+    features.value = WindowLayoutInfo(listOf(testFold(Rect(490, 0, 510, 1000))))
+    show()
+    assertSurfaceInside(Rect(510, 0, 1000, 1000))
+    composeRule.onNodeWithText("Select").assertIsDisplayed().performClick()
+    assertEquals(1, actions)
+  }
+
+  private fun show() {
+    composeRule.setContent {
+      activity = requireNotNull(LocalActivity.current)
+      activityView = LocalView.current
+      val lifecycle = LocalLifecycleOwner.current.lifecycle
+      val geometry = remember { FoldAwareSheetState(activity, activityView, lifecycle) { unsafe++ } }
+      val publication = rememberWindowDisplayFeatureState(geometry::publishFeatures)
+      val native = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+      SideEffect {
+        state = geometry
+        sheetState = native
+      }
+      if (publication.value.ready) {
+        CompositionLocalProvider(LocalLayoutDirection provides direction) {
+          ModalBottomSheet(
+            modifier = Modifier.foldAwareSheet(geometry),
+            sheetState = native,
+            containerColor = Color(SURFACE),
+            onDismissRequest = { if (geometry.refresh()) actions++ },
+          ) {
+            Column(Modifier.fillMaxWidth().height(contentHeight)) {
+              TextButton(onClick = { if (geometry.refresh()) actions++ }) { Text("Select") }
+            }
+          }
+        }
+      }
+    }
+    composeRule.waitForIdle()
+  }
+
+  private fun emit(next: List<DisplayFeature>) {
+    composeRule.runOnIdle { features.value = WindowLayoutInfo(next) }
+    composeRule.waitForIdle()
+  }
+
+  private fun keyboard(bottom: Int) {
+    composeRule.runOnIdle {
+      ViewCompat.dispatchApplyWindowInsets(
+        checkNotNull(dialog().window).decorView,
+        WindowInsetsCompat
+          .Builder()
+          .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, bottom))
+          .setVisible(WindowInsetsCompat.Type.ime(), bottom > 0)
+          .build(),
+      )
+    }
+    composeRule.waitForIdle()
+  }
+
+  private fun dialog() = checkNotNull(ShadowDialog.getLatestDialog()) as ComponentDialog
+
+  private fun surfacePixels(): Rect? =
+    composeRule.runOnIdle {
+      val root = checkNotNull(dialog().window).decorView
+      val bitmap = Bitmap.createBitmap(root.width, root.height, Bitmap.Config.ARGB_8888)
+      try {
+        root.draw(Canvas(bitmap))
+        var left = bitmap.width
+        var top = bitmap.height
+        var right = 0
+        var bottom = 0
+        for (y in 0 until bitmap.height) {
+          for (x in 0 until bitmap.width) {
+            if (bitmap.getPixel(x, y) == SURFACE) {
+              left = minOf(left, x)
+              top = minOf(top, y)
+              right = maxOf(right, x + 1)
+              bottom = maxOf(bottom, y + 1)
+            }
+          }
+        }
+        if (right > left && bottom > top) Rect(left, top, right, bottom) else null
+      } finally {
+        bitmap.recycle()
+      }
+    }
+
+  private fun assertSurfaceInside(expected: Rect) {
+    val actual = checkNotNull(surfacePixels()) { "The actual Material Surface must render" }
+    assertTrue("Surface $actual must fit physical pane $expected", expected.contains(actual))
+    assertTrue("Material's natural Surface must not stretch to fill the host", actual.height() < 300)
+    assertTrue("Material's width cap must remain in effect", actual.width() <= 640)
+  }
+
+  private companion object {
+    const val SURFACE = 0xFFFF00AA.toInt()
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
@@ -22,6 +22,7 @@ import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.ui.FoldAwareContent
 import ai.openclaw.app.ui.TabletopPaneBounds
 import ai.openclaw.app.ui.UnifiedChatShellScreen
+import ai.openclaw.app.ui.WindowDisplayFeatureSnapshot
 import ai.openclaw.app.ui.design.ClawDesignTheme
 import ai.openclaw.app.ui.design.ClawTheme
 import ai.openclaw.app.ui.testFold
@@ -31,13 +32,17 @@ import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.Rect
+import android.os.SystemClock
 import android.provider.Settings
 import android.speech.SpeechRecognizer
 import android.view.KeyEvent
+import android.view.MotionEvent
 import android.view.View
+import android.view.ViewGroup
 import android.view.WindowManager
 import android.view.inputmethod.EditorInfo
 import android.view.inspector.WindowInspector
+import androidx.activity.ComponentDialog
 import androidx.activity.compose.LocalActivity
 import androidx.activity.findViewTreeOnBackPressedDispatcherOwner
 import androidx.compose.foundation.background
@@ -121,6 +126,7 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.DialogWindowProvider
 import androidx.core.graphics.Insets
 import androidx.core.os.LocaleListCompat
 import androidx.core.view.ViewCompat
@@ -135,8 +141,10 @@ import androidx.window.layout.DisplayFeature
 import androidx.window.layout.WindowInfoTracker
 import androidx.window.layout.WindowInfoTrackerDecorator
 import androidx.window.layout.WindowLayoutInfo
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
@@ -152,6 +160,7 @@ import kotlinx.serialization.json.jsonObject
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -162,6 +171,7 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
+import org.robolectric.shadows.ShadowDialog
 import org.robolectric.shadows.ShadowSpeechRecognizer
 import java.util.UUID
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -187,9 +197,19 @@ class ChatComposerLayoutTest {
   private lateinit var insetView: View
   private var observedBottomInsets: Pair<Int, Int>? = null
   private lateinit var renderedDensity: Density
+  private val sheetFeatures = SheetFeatures()
 
   @Before
+  @SuppressLint("RestrictedApi")
   fun setUp() {
+    WindowInfoTracker.overrideDecorator(
+      object : WindowInfoTrackerDecorator {
+        override fun decorate(tracker: WindowInfoTracker): WindowInfoTracker =
+          object : WindowInfoTracker by tracker {
+            override fun windowLayoutInfo(activity: Activity): Flow<WindowLayoutInfo> = sheetFeatures
+          }
+      },
+    )
     app = RuntimeEnvironment.getApplication() as NodeApp
     prefs = SecurePrefs(app, app.getSharedPreferences("chat-composer-${UUID.randomUUID()}", Context.MODE_PRIVATE))
     AndroidScreenshotFixture.configure(AndroidScreenshotScene.Chat)
@@ -206,6 +226,7 @@ class ChatComposerLayoutTest {
   }
 
   @After
+  @SuppressLint("RestrictedApi")
   fun tearDown() {
     viewModelStore.clear()
     setApplicationRuntime(originalRuntime)
@@ -213,6 +234,7 @@ class ChatComposerLayoutTest {
     AndroidScreenshotFixture.configure(AndroidScreenshotScene.Home)
     Settings.Global.putString(app.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, originalAnimatorScale)
     NativeStringResources.install(app)
+    WindowInfoTracker.reset()
   }
 
   @Test
@@ -1725,6 +1747,9 @@ class ChatComposerLayoutTest {
     val initialOwner = composeRule.runOnIdle { sheetBackOwner() }
     composeRule.runOnIdle { fontScale.value = 1.2f }
     composeRule.waitForIdle()
+    composeRule.onNode(isDialog()).assertDoesNotExist()
+    composeRule.onNodeWithContentDescription(nativeString("Model")).performClick()
+    composeRule.onNode(hasText(nativeString("Permissions")) and hasClickAction()).performClick()
     composeRule.runOnIdle {
       val recreatedOwner = sheetBackOwner()
       assertTrue("The dialog must actually be recreated", initialOwner !== recreatedOwner)
@@ -1741,6 +1766,356 @@ class ChatComposerLayoutTest {
 
     composeRule.onNodeWithText(nativeString("Default model")).assertIsDisplayed().performClick()
     composeRule.onNode(isDialog()).assertDoesNotExist()
+  }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun modelOpeningRevokesHeldTouchBeforeCoalescedRecoveryAndPreservesDraft() = assertTerminalModelInput(keyboard = false)
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun modelOpeningRevokesHeldEnterBeforeCoalescedRecoveryAndPreservesDraft() = assertTerminalModelInput(keyboard = true)
+
+  private fun assertTerminalModelInput(keyboard: Boolean) {
+    showChat(viewportWidth = 720.dp, viewportHeight = { 720.dp })
+    val editor = composeRule.onNode(hasSetTextAction())
+    editor.performTextReplacement("retained selector draft")
+    editor.performSemanticsAction(SemanticsActions.SetSelection) { assertTrue(it(4, 9, false)) }
+    val editorId = editor.fetchSemanticsNode().id
+    val before = prefs.modelFavorites.value
+    composeRule.onNodeWithContentDescription(nativeString("Model")).performClick()
+    val pin = composeRule.onAllNodesWithContentDescription(nativeString("Pin model"))[0].performScrollTo()
+    val bounds = pin.getUnclippedBoundsInRoot()
+    val x = (bounds.left.value + bounds.right.value) / 2f
+    val y = (bounds.top.value + bounds.bottom.value) / 2f
+    val old = checkNotNull(ShadowDialog.getLatestDialog()) as ComponentDialog
+    if (keyboard) {
+      composeRule.runOnIdle { assertTrue(sheetComposeView(old).requestFocusFromTouch()) }
+      pin.performSemanticsAction(SemanticsActions.RequestFocus) { assertTrue(it()) }
+      pin.assertIsFocused()
+    }
+    val time = SystemClock.uptimeMillis()
+    composeRule.mainClock.autoAdvance = false
+    composeRule.runOnUiThread {
+      if (keyboard) {
+        assertTrue(checkNotNull(old.window).decorView.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER)))
+      } else {
+        assertTrue("The real row must consume the original DOWN", sheetTouch(old, MotionEvent.ACTION_DOWN, x, y, time, time))
+      }
+      val deliveries = sheetFeatures.deliveries
+      runBlocking {
+        sheetFeatures.publish(listOf(testFold(Rect(0, 0, 800, 800))))
+        sheetFeatures.publish(emptyList())
+      }
+      assertEquals("Both direct producer deliveries precede UP", deliveries + 2, sheetFeatures.deliveries)
+      assertTrue("Original UP must reach the still-attached A window", old.isShowing)
+      if (keyboard) {
+        checkNotNull(old.window).decorView.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER))
+      } else {
+        sheetTouch(old, MotionEvent.ACTION_UP, x, y, time, time + 40)
+      }
+      assertEquals("A's held touch cannot borrow recovered geometry", before, prefs.modelFavorites.value)
+    }
+    composeRule.mainClock.autoAdvance = true
+    composeRule.waitForIdle()
+    composeRule.onNode(isDialog()).assertDoesNotExist()
+    editor.assertTextEquals("retained selector draft")
+    assertEquals(editorId, editor.fetchSemanticsNode().id)
+    assertEquals(TextRange(4, 9), editor.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange])
+
+    composeRule.onNodeWithContentDescription(nativeString("Model")).performClick()
+    composeRule.waitForIdle()
+    val fresh = checkNotNull(ShadowDialog.getLatestDialog()) as ComponentDialog
+    assertNotSame(old.window, fresh.window)
+    val freshPin = composeRule.onAllNodesWithContentDescription(nativeString("Pin model"))[0].performScrollTo()
+    freshPin.performTouchInput {
+      down(center)
+      up()
+    }
+    composeRule.waitForIdle()
+    val after = prefs.modelFavorites.value.toSet()
+    assertEquals("A fresh complete touch still toggles exactly one favorite", 1, ((before.toSet() - after) + (after - before.toSet())).size)
+  }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun modelOpeningBCannotBeChangedBySavedACommandsOrQueuedRemoval() {
+    showChat(viewportWidth = 720.dp, viewportHeight = { 720.dp })
+    updatePermissions(null, pending = false)
+    val open =
+      checkNotNull(
+        composeRule
+          .onNodeWithContentDescription(nativeString("Model"))
+          .fetchSemanticsNode()
+          .config[SemanticsActions.OnClick]
+          .action,
+      )
+    composeRule.onNodeWithContentDescription(nativeString("Model")).performClick()
+    composeRule.waitForIdle()
+    val old = checkNotNull(ShadowDialog.getLatestDialog()) as ComponentDialog
+    val details =
+      checkNotNull(
+        composeRule
+          .onNodeWithText(nativeString("Details"))
+          .fetchSemanticsNode()
+          .config[SemanticsActions.OnClick]
+          .action,
+      )
+    val permissions =
+      checkNotNull(
+        composeRule
+          .onNode(hasText(nativeString("Permissions")) and hasClickAction())
+          .fetchSemanticsNode()
+          .config[SemanticsActions.OnClick]
+          .action,
+      )
+    val select =
+      checkNotNull(
+        composeRule
+          .onNodeWithText(nativeString("Default model"))
+          .fetchSemanticsNode()
+          .config[SemanticsActions.OnClick]
+          .action,
+      )
+    val before = controller.selectedModelRef.value
+    composeRule.mainClock.autoAdvance = false
+    composeRule.runOnUiThread {
+      runBlocking {
+        sheetFeatures.publish(listOf(testFold(Rect(0, 0, 800, 800))))
+        sheetFeatures.publish(emptyList())
+      }
+      // Saved callbacks deliberately test origin identity, not pointer routing through an old window.
+      assertTrue(open())
+      details()
+      permissions()
+      select()
+      old.onBackPressedDispatcher.onBackPressed()
+      assertEquals(before, controller.selectedModelRef.value)
+    }
+    composeRule.mainClock.autoAdvance = true
+    composeRule.waitForIdle()
+    val fresh = checkNotNull(ShadowDialog.getLatestDialog()) as ComponentDialog
+    assertNotSame(old.window, fresh.window)
+    assertTrue(fresh.isShowing)
+    assertFalse(old.isShowing)
+    composeRule.onNodeWithText(nativeString("Default model")).assertIsDisplayed()
+    composeRule.onNodeWithText(nativeString("Non-cached input excludes cache reads.")).assertDoesNotExist()
+    composeRule.onNodeWithText(nativeString("Back")).assertDoesNotExist()
+    composeRule.onNode(hasText(nativeString("Permissions")) and hasClickAction()).performClick()
+    composeRule.onNodeWithText(nativeString("Back")).assertIsDisplayed().performClick()
+    composeRule.runOnIdle { fresh.onBackPressedDispatcher.onBackPressed() }
+    composeRule.onNode(isDialog()).assertDoesNotExist()
+  }
+
+  @Test
+  fun modelSessionLateRetirementCannotRemoveItsReplacement() {
+    val model = showChat()
+    val owner =
+      ChatModelPickerSessionOwner(chatActivity, chatActivity.window.decorView, (chatActivity as LifecycleOwner).lifecycle) {
+        model.isCurrentChatComposerOwner(it)
+      }
+    lateinit var old: ChatModelPickerSession
+    lateinit var fresh: ChatModelPickerSession
+    composeRule.runOnUiThread {
+      owner.publishFeatures(WindowDisplayFeatureSnapshot(ready = true))
+      owner.open(model.captureChatShareOwner(), controller.sessionKey.value)
+      old = checkNotNull(owner.visible)
+      owner.retire(old)
+      owner.open(model.captureChatShareOwner(), controller.sessionKey.value)
+      fresh = checkNotNull(owner.visible)
+      assertNotSame(old, fresh)
+      assertFalse(owner.admit(old))
+    }
+    composeRule.runOnIdle {
+      assertTrue(owner.visible === fresh)
+      // Invoke the real production owner, not Material semantics on a detached node.
+      owner.retire(old)
+      assertFalse(owner.admit(old))
+    }
+    composeRule.runOnIdle {
+      assertTrue(owner.visible === fresh)
+      owner.dispose()
+    }
+  }
+
+  private fun sheetComposeView(dialog: ComponentDialog): View {
+    fun find(view: View): View? {
+      if (view.parent is DialogWindowProvider) return view
+      if (view is ViewGroup) {
+        for (index in 0 until view.childCount) find(view.getChildAt(index))?.let { return it }
+      }
+      return null
+    }
+    return checkNotNull(find(checkNotNull(dialog.window).decorView))
+  }
+
+  private fun sheetTouch(
+    dialog: ComponentDialog,
+    action: Int,
+    x: Float,
+    y: Float,
+    downTime: Long,
+    eventTime: Long,
+  ): Boolean {
+    val event = MotionEvent.obtain(downTime, eventTime, action, x, y, 0)
+    try {
+      return dialog.dispatchTouchEvent(event)
+    } finally {
+      event.recycle()
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun modelOpeningDoesNotCancelOrRetargetAnAlreadyAdmittedModelEffect() {
+    prefs.gatewayRegistry.upsert(
+      GatewayRegistryEntry(stableId = AndroidScreenshotFixture.gatewayId, kind = GatewayRegistryEntryKind.MANUAL, name = "Test gateway"),
+    )
+    prefs.gatewayRegistry.setActive(AndroidScreenshotFixture.gatewayId)
+    val model = showChat(viewportWidth = 720.dp, viewportHeight = { 720.dp })
+    val originalOwner = model.captureChatShareOwner()
+    val originalSession = controller.sessionKey.value
+    val release = CompletableDeferred<Unit>()
+    val admitted = ConcurrentLinkedQueue<Pair<String, JsonObject>>()
+    val requestField = ChatController::class.java.getDeclaredField("captureRequestLease").apply { isAccessible = true }
+
+    @Suppress("UNCHECKED_CAST")
+    val originalRequest = requestField.get(controller) as (ChatCacheScope?) -> GatewaySession.RequestLease?
+    val request: (ChatCacheScope?) -> GatewaySession.RequestLease? = { scope ->
+      originalRequest(scope)?.let { lease ->
+        GatewaySession.RequestLease(
+          endpointStableId = lease.endpointStableId,
+          isCurrentImpl = lease::isCurrent,
+          commitIfCurrentImpl = lease::commitIfCurrent,
+        ) { method, params, timeout, withEnqueue ->
+          if (method == "sessions.patch") {
+            val payload = Json.parseToJsonElement(checkNotNull(params)).jsonObject
+            withEnqueue { admitted.add(lease.endpointStableId to payload) }
+            release.await()
+            """{"entry":{"key":"$originalSession","modelOverride":null},"resolved":{"modelProvider":"openai","model":"gpt-5.2"}}"""
+          } else {
+            lease.request(method, params, timeout, withEnqueue)
+          }
+        }
+      }
+    }
+    try {
+      requestField.set(controller, request)
+      composeRule.onNodeWithContentDescription(nativeString("Model")).performClick()
+      composeRule.onNodeWithText(nativeString("Default model")).performClick()
+      composeRule.waitUntil { admitted.size == 1 }
+      composeRule.onNode(isDialog()).assertDoesNotExist()
+      assertFalse(release.isCompleted)
+      composeRule.onNodeWithContentDescription(nativeString("Model")).performClick()
+      composeRule.onNodeWithText(nativeString("Default model")).assertIsDisplayed()
+      composeRule.runOnUiThread {
+        runBlocking {
+          sheetFeatures.publish(listOf(testFold(Rect(0, 0, 800, 800))))
+          sheetFeatures.publish(emptyList())
+        }
+      }
+      composeRule.waitForIdle()
+      composeRule.onNode(isDialog()).assertDoesNotExist()
+      composeRule.onNodeWithContentDescription(nativeString("Model")).performClick()
+      composeRule.onNodeWithText(nativeString("Default model")).assertIsDisplayed()
+      val fresh = checkNotNull(ShadowDialog.getLatestDialog())
+      composeRule.runOnIdle { release.complete(Unit) }
+      composeRule.waitUntil { composeRule.runOnIdle { originalSession !in model.chatPendingSessionSettingsKeys.value } }
+      assertTrue("Business completion must not close the new selector", fresh.isShowing)
+      assertEquals(1, admitted.size)
+      val (gateway, payload) = admitted.single()
+      assertEquals(originalOwner.gatewayStableId, gateway)
+      assertEquals(JsonPrimitive(originalSession), payload["key"])
+      assertEquals(JsonPrimitive(originalOwner.agentId), payload["agentId"])
+    } finally {
+      release.complete(Unit)
+      requestField.set(controller, originalRequest)
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun modelBackDuringUnplacedPaneChangeRetiresOpeningAndAllowsReopen() {
+    showChat(viewportWidth = 720.dp, viewportHeight = { 720.dp })
+    composeRule.onNodeWithContentDescription(nativeString("Model")).performClick()
+    composeRule.onNodeWithText(nativeString("Default model")).assertIsDisplayed()
+    val old = checkNotNull(ShadowDialog.getLatestDialog()) as ComponentDialog
+    composeRule.mainClock.autoAdvance = false
+    composeRule.runOnUiThread {
+      runBlocking { sheetFeatures.publish(listOf(testFold(Rect(390, 0, 410, 800)))) }
+      // Both panes are usable, but A's previous placement is no longer authoritative.
+      old.onBackPressedDispatcher.onBackPressed()
+    }
+    composeRule.mainClock.autoAdvance = true
+    composeRule.waitForIdle()
+    composeRule.onNode(isDialog()).assertDoesNotExist()
+    composeRule.onNodeWithContentDescription(nativeString("Model")).performClick()
+    composeRule.onNodeWithText(nativeString("Default model")).assertIsDisplayed()
+    val fresh = checkNotNull(ShadowDialog.getLatestDialog()) as ComponentDialog
+    assertNotSame(old.window, fresh.window)
+    composeRule.runOnIdle { fresh.onBackPressedDispatcher.onBackPressed() }
+    composeRule.onNode(isDialog()).assertDoesNotExist()
+  }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun modelOpeningWithExistingImeKeepsDraftSelectionAndNativeKeyboardCommands() {
+    showChat(viewportWidth = 720.dp, viewportHeight = { 720.dp }, useChatShell = true)
+    val editor = composeRule.onNode(hasSetTextAction())
+    editor.performClick().performTextReplacement("IME before selector")
+    editor.performSemanticsAction(SemanticsActions.SetSelection) { assertTrue(it(3, 6, false)) }
+    val editorId = editor.fetchSemanticsNode().id
+    applyChatImeInsets()
+    composeRule.onNodeWithContentDescription(nativeString("Model")).performClick()
+    composeRule.onNodeWithText(nativeString("Default model")).performScrollTo().assertIsDisplayed()
+    val dialog = checkNotNull(ShadowDialog.getLatestDialog()) as ComponentDialog
+    composeRule.runOnIdle {
+      ViewCompat.dispatchApplyWindowInsets(
+        checkNotNull(dialog.window).decorView,
+        WindowInsetsCompat
+          .Builder()
+          .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, 220))
+          .setVisible(WindowInsetsCompat.Type.ime(), true)
+          .build(),
+      )
+    }
+    val details = composeRule.onNode(hasText(nativeString("Details")) and hasClickAction()).performScrollTo()
+    composeRule.runOnIdle { assertTrue(sheetComposeView(dialog).requestFocusFromTouch()) }
+    details.performSemanticsAction(SemanticsActions.RequestFocus) { assertTrue(it()) }
+    details.assertIsFocused()
+    composeRule.runOnIdle { dispatchHardwareKey(checkNotNull(dialog.window).decorView, KeyEvent.KEYCODE_SPACE) }
+    details.assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, nativeString("Expanded")))
+    details.performClick()
+    details.assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, nativeString("Collapsed")))
+    composeRule.runOnIdle { dialog.onBackPressedDispatcher.onBackPressed() }
+    composeRule.onNode(isDialog()).assertDoesNotExist()
+    editor.assertTextEquals("IME before selector")
+    assertEquals(editorId, editor.fetchSemanticsNode().id)
+    assertEquals(TextRange(3, 6), editor.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange])
+  }
+
+  private class SheetFeatures : Flow<WindowLayoutInfo> {
+    private val collectors = mutableSetOf<FlowCollector<WindowLayoutInfo>>()
+    var deliveries = 0
+      private set
+    private var latest = WindowLayoutInfo(emptyList())
+
+    override suspend fun collect(collector: FlowCollector<WindowLayoutInfo>) {
+      collectors.add(collector)
+      try {
+        collector.emit(latest)
+        awaitCancellation()
+      } finally {
+        collectors.remove(collector)
+      }
+    }
+
+    suspend fun publish(features: List<DisplayFeature>) {
+      latest = WindowLayoutInfo(features)
+      check(collectors.isNotEmpty())
+      collectors.toList().forEach { it.emit(latest) }
+      deliveries++
+    }
   }
 
   @Test


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/140708
Builds on merged https://github.com/openclaw/openclaw/pull/140884; this PR is now based on `main`.

## What Problem This Solves

Fixes an issue where users opening Android Chat's Model picker or its Permissions
page could encounter content crossing a separating fold, or stale input acting
after the opening's geometry or Chat owner became invalid.

## Why This Change Was Made

Keep the existing Material sheet within the initially largest eligible safe
region, not the trigger's region, and bind its actions to the original opening
and Chat owner. Valid geometry changes retain sheet state; invalid openings
terminate before stale actions can run, while already-admitted work remains
with its original effect owner rather than being cancelled or retargeted.

## User Impact

The Model picker and its internal Permissions page retain their selected region
while it remains eligible. Invalid openings close and stay closed until
explicitly reopened; valid openings retain their local state.

Thinking, background-task, and branch-switching sheets are not adapted by this
change. Existing permission eligibility and model-lock policies are unchanged.

## Evidence

- **114 JVM/Robolectric tests passed in one integrated-head invocation**, with
  zero failures, errors, or skips: 60 Chat, 5 sheet, 8 dialog, 10 menu, 18 root,
  2 content, 5 geometry, and 6 hardware-key tests. Coverage includes real
  Material windows in the harness, held-input invalidation, Back before
  replacement placement, and original effect ownership. Genuine-red
  regressions and the earlier review evidence are retained.
- Ordinary `lintPlayDebug` and the actual seven-file `check:changed` passed
  on integrated head `1ad0fef5785d8c8f493c977cceeefbb691c36ee6`.
  The subsequent `main` rebase is patch-identical; all eight changed files,
  including the approved README, retain their exact hashes.
- Final independent P2 review returned one finding, rejected with coordinator
  acceptance: locked sessions already omitted the model/pin rows in the base,
  so the stale-action guard removes no previously usable pin control. This
  was **not** a scoped-clean review; there are no unresolved actionable
  findings. The subsequent integration was mechanically reviewed.
- **API 36 emulator:** Model opens from real Gboard into the left book pane;
  Material dismisses the keyboard. Expanded Details and the same native modal
  survive rotation into the upper tabletop pane. An in-sheet swipe reaches the
  complete model row. Back restores Gboard, and typing continues in the same
  draft without tapping the editor again. The APK's v2 signature and installed
  SHA-256 match:
  `3dcb896159e1823399fa70a81bc166ba0ac13bbd5a359a63053ca03bf5e26aaa`.
- The existing fixture's Permissions row remains disabled with "Refresh this
  chat before changing permissions." Its internal page has JVM coverage, not
  native-device proof. No fixture identity or capability was fabricated.
- No physical-device, native held-pointer, predictive-Back animation,
  active-recording, arbitrary Activity-recreation, or all-popup claim is made.
  Android README documents the scoped behavior; release-owned CHANGELOG is
  unchanged.

### Simulator Examples

All six synthetic-fixture captures were personally and independently inspected.
Anonymous public downloads returned HTTP 200 and matched the originals by
SHA-256.

Before: the earlier foundation's Model sheet crosses the book separator. This
is an integrated layout comparison, not a matched-draft experiment.

![Before: Model sheet crosses the book separator](https://github.com/user-attachments/assets/d688ac9d-7b4f-4f0d-914b-cac069e994bc)

After: opening from Gboard yields a usable sheet in the left book pane.
Material dismisses the keyboard.

![After: Model sheet stays in the left book pane](https://github.com/user-attachments/assets/14ee27df-f5ad-4803-ac44-6204def55cf1)

Expanded Details before and after a valid book-to-tabletop rotation. Native
window receipts confirm the same modal; the stills alone do not prove identity.

![Expanded Details in book posture](https://github.com/user-attachments/assets/eb3d394c-8e6a-4d94-8271-699a34034e90)

![Expanded Details retained in the upper tabletop pane](https://github.com/user-attachments/assets/74376a70-8126-4fb1-9299-ebb65cc517d0)

After a deliberate reopening, an in-sheet swipe reaches the full model row.

![Model row reached within the upper tabletop pane](https://github.com/user-attachments/assets/25fa7ee2-b5ac-4e2d-905b-bdfa5bf5540b)

Back restores Gboard; typing continues without tapping the editor again.

![Retained draft with continued typing after Back](https://github.com/user-attachments/assets/2e59a65c-5a56-4caf-94f9-f30ee5af0450)
