### PR TITLE
refactor: simplify group reply guidance

### DIFF
--- a/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
+++ b/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
@@ -51,9 +51,7 @@ export function registerGroupIntroPromptCases(): void {
     const telegramGroupParticipationNote =
       "Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \\n sequences; use real line breaks sparingly.";
     const groupSilentNote =
-      'If no response is needed, reply with exactly "NO_REPLY" (and nothing else) so OpenClaw stays silent.';
-    const groupSilentProseGuard =
-      'Any prose describing silence is wrong; the whole final answer must be only "NO_REPLY".';
+      'If no text reply is needed, including after a reaction or other action, reply with exactly "NO_REPLY" as the entire final answer, without commentary, punctuation, or formatting.';
     const automaticGroupDeliveryGuidance = [
       "Your text replies are automatically sent to this group chat unless the current-turn context says final replies stay private.",
       "For ordinary text, do not use the message tool to send to this same destination unless the current-turn context asks for visible output via message(action=send).",
@@ -80,7 +78,6 @@ export function registerGroupIntroPromptCases(): void {
           "You are in a Discord group chat.",
           groupParticipationNote,
           groupSilentNote,
-          groupSilentProseGuard,
           "Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included). Address the specific sender noted in the message context.",
         ],
       },
@@ -99,7 +96,6 @@ export function registerGroupIntroPromptCases(): void {
           ...automaticGroupDeliveryGuidance,
           groupParticipationNote,
           groupSilentNote,
-          groupSilentProseGuard,
           "Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included). Address the specific sender noted in the message context.",
         ],
       },
@@ -117,7 +113,6 @@ export function registerGroupIntroPromptCases(): void {
           "You are in a Telegram group chat.",
           telegramGroupParticipationNote,
           groupSilentNote,
-          groupSilentProseGuard,
           "Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included). Address the specific sender noted in the message context.",
         ],
         forbidden: ["Avoid Markdown tables"],
@@ -137,7 +132,6 @@ export function registerGroupIntroPromptCases(): void {
           ...automaticChannelDeliveryGuidance,
           groupParticipationNote,
           groupSilentNote,
-          groupSilentProseGuard,
           "Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included). Address the specific sender noted in the message context.",
         ],
         forbidden: ["Mattermost group chat"],
@@ -169,9 +163,7 @@ export function registerGroupIntroPromptCases(): void {
         expected: [
           "You are in a WhatsApp group chat.",
           "Activation: always-on (you receive every group message). You see every message; most need no response. When you do reply, address the specific sender noted in the message context.",
-          'If you only react or otherwise handle the message without a text reply, your final answer must still be exactly "NO_REPLY".',
-          "Never say that you are staying quiet, keeping channel noise low, making a context-only note, or sending no channel reply.",
-          groupSilentProseGuard,
+          groupSilentNote,
         ],
         defaultActivation: "always",
       },

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -78,7 +78,7 @@ describe("group runtime loading", () => {
     expect(toolOnlyContext).toContain("<https://example.com>");
     expect(toolOnlyContext).toContain("do not call message(action=send)");
     expect(toolOnlyContext).toContain(
-      "Be extremely selective: reply only when directly addressed or clearly helpful.",
+      "reply only when directly addressed or you can add clear value",
     );
     expect(toolOnlyContext).not.toContain('reply with exactly "NO_REPLY"');
     const channelToolOnlyContext = isolatedGroups.buildGroupChatContext({
@@ -88,7 +88,7 @@ describe("group runtime loading", () => {
       silentToken: "NO_REPLY",
     });
     expect(channelToolOnlyContext).toContain("visible channel response");
-    expect(channelToolOnlyContext).toContain("posted to this channel");
+    expect(channelToolOnlyContext).toContain("not automatically sent to this channel");
     expect(channelToolOnlyContext).not.toContain("visible group response");
     expect(channelToolOnlyContext).not.toContain("posted to the group");
     expect(
@@ -176,11 +176,11 @@ describe("group runtime loading", () => {
       silentReplyPolicy: "allow",
     });
     expect(allowed).toContain('reply with exactly "NO_REPLY"');
-    expect(allowed).toContain('your final answer must still be exactly "NO_REPLY"');
-    expect(allowed).toContain("Never say that you are staying quiet");
+    expect(allowed).toContain("including after a reaction or other action");
     expect(allowed).toContain(
-      "Be extremely selective: reply only when directly addressed or clearly helpful.",
+      "as the entire final answer, without commentary, punctuation, or formatting",
     );
+    expect(allowed).toContain("reply only when directly addressed or you can add clear value");
     expect(allowed).not.toContain("Otherwise stay silent.");
 
     const disallowed = groups.buildGroupChatContext({
@@ -189,7 +189,7 @@ describe("group runtime loading", () => {
       silentReplyPolicy: "disallow",
     });
     expect(disallowed).not.toContain("NO_REPLY");
-    expect(disallowed).not.toContain("Never say that you are staying quiet");
+    expect(disallowed).not.toContain("as the entire final answer");
   });
 
   it("keeps per-message mention state out of stable group context", () => {

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -149,23 +149,12 @@ export function buildGroupChatContext(params: {
     !messageToolOnly && params.silentToken && params.silentReplyPolicy !== "disallow";
   if (messageToolOnly) {
     lines.push(
-      `If no visible ${sharedChatNoun === "channel" ? "channel" : "group"} response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to ${destinationLabel}.`,
+      `If no visible ${sharedChatNoun === "channel" ? "channel" : "group"} response is needed, do not call message(action=send).`,
     );
-    lines.push("Be extremely selective: reply only when directly addressed or clearly helpful.");
   }
   if (canUseSilentReply) {
     lines.push(
-      `If no response is needed, reply with exactly "${params.silentToken}" (and nothing else) so OpenClaw stays silent.`,
-    );
-    lines.push("Be extremely selective: reply only when directly addressed or clearly helpful.");
-    lines.push(
-      "Do not add any other words, punctuation, tags, markdown/code blocks, or explanations.",
-    );
-    lines.push(
-      `If you only react or otherwise handle the message without a text reply, your final answer must still be exactly "${params.silentToken}". Never say that you are staying quiet, keeping channel noise low, making a context-only note, or sending no channel reply.`,
-    );
-    lines.push(
-      `Any prose describing silence is wrong; the whole final answer must be only "${params.silentToken}".`,
+      `If no text reply is needed, including after a reaction or other action, reply with exactly "${params.silentToken}" as the entire final answer, without commentary, punctuation, or formatting.`,
     );
   }
   return lines.join(" ");

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
 --- telegram-direct-codex-message-tool.md	sha256=1f0e5aa6d2bd912cd45d8e604558bb4f4d82124496c23526c62d00e7e3cf8237
-+++ discord-group-codex-message-tool.md	sha256=3e483c9beea3569b68e0f9a79991aa1acae9f6e10ee333e18758871a6317a6e9
++++ discord-group-codex-message-tool.md	sha256=63d926a4f2a0f55a67faace9939eb9e283a550c794b3da6f9bf60f9b375da41f
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -39,18 +39,18 @@
 @@ -258,2 +258,2 @@
 -    "chars": 3672,
 -    "roughTokens": 918
-+    "chars": 4781,
-+    "roughTokens": 1196
++    "chars": 4620,
++    "roughTokens": 1155
 @@ -262,2 +262,2 @@
 -    "chars": 28502,
 -    "roughTokens": 7126
-+    "chars": 29981,
-+    "roughTokens": 7496
++    "chars": 29820,
++    "roughTokens": 7455
 @@ -266,2 +266,2 @@
 -    "chars": 86325,
 -    "roughTokens": 21582
-+    "chars": 88360,
-+    "roughTokens": 22090
++    "chars": 88199,
++    "roughTokens": 22050
 @@ -270,2 +270,2 @@
 -    "chars": 863,
 -    "roughTokens": 216
@@ -67,7 +67,7 @@
 +  "chat_type": "group"
 @@ -486,1 +486,3 @@
 -You are in a Telegram direct conversation. Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation. If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.
-+You are in a Discord group chat. Normal final replies are private and are not automatically sent to this group chat. To post visible output here, use the message tool with action=send; the target defaults to this group chat. Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \n sequences; use real line breaks sparingly. If addressed to someone else, stay silent unless invited or correcting key facts. Discord: wrap bare URLs like <https://example.com> to suppress embeds. When subagent or session-spawn tools are available and a directly requested group-chat task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise group-visible updates when they add value. If no visible group response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to this group chat. Be extremely selective: reply only when directly addressed or clearly helpful.
++You are in a Discord group chat. Normal final replies are private and are not automatically sent to this group chat. To post visible output here, use the message tool with action=send; the target defaults to this group chat. Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \n sequences; use real line breaks sparingly. If addressed to someone else, stay silent unless invited or correcting key facts. Discord: wrap bare URLs like <https://example.com> to suppress embeds. When subagent or session-spawn tools are available and a directly requested group-chat task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise group-visible updates when they add value. If no visible group response is needed, do not call message(action=send).
 +
 +Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included). Address the specific sender noted in the message context.
 @@ -524,1 +526,1 @@


### PR DESCRIPTION
## What Problem This Solves

Group prompts repeated when-to-reply and silence instructions on every turn.

## Why This Change Was Made

The prompt keeps one participation rule and one complete automatic-silence instruction, including reaction-only outcomes. Message-tool-only guidance states private final delivery once and keeps the rule to skip sending when no visible response is needed. Runtime conditions, the exact silence token, routing exceptions, formatting, activation, and direct-chat wording remain unchanged.

## User Impact

Group prompts carry less repeated text with the same reply and silence rules. The two measured automatic-group prompts shrink by 23% and 22%. Direct-chat and ineligible-silence variants remain byte-identical.

## Evidence

All 20 targeted group, composition, and channel-prompt tests passed. Seven generated snapshots passed, with only the group snapshot changed. Semantic review compared nine complete before/after variants and found no lost instruction. Formatting, syntax lint, and whitespace checks passed. No live-channel behavior improvement is claimed.
