### PR TITLE
fix(agents): include tool schema tokens in context-overflow precheck

### DIFF
--- a/packages/ai/src/transports/openai-completions-params.ts
+++ b/packages/ai/src/transports/openai-completions-params.ts
@@ -94,6 +94,7 @@ function resolveOpenAICompletionsModelMaxTokens(model: OpenAIModeModel): number 
 
 const OPENAI_COMPLETIONS_INPUT_TOKEN_SAFETY_MARGIN = 1.25;
 const OPENAI_COMPLETIONS_IMAGE_CHAR_ESTIMATE = 8_000;
+const MIN_USEFUL_OUTPUT_TOKENS = 16;
 
 // Used only to bound `max_completion_tokens` below the effective context cap
 // for strict OpenAI-compatible servers (e.g. vLLM, StepFun). The CJK-aware
@@ -437,6 +438,13 @@ export function buildOpenAICompletionsParams(
             `model=${model.id} requested=${effectiveMaxTokens} output=${clampedMaxTokens} ` +
             `effectiveContext=${effectiveContextTokens} estimatedInput=${estimatedInputTokens}`,
         );
+        if (remainingBudget < MIN_USEFUL_OUTPUT_TOKENS) {
+          log.warn(
+            `[completions] insufficient_output_budget provider=${model.provider} api=${model.api} ` +
+              `model=${model.id} output=${clampedMaxTokens} ` +
+              `effectiveContext=${effectiveContextTokens} estimatedInput=${estimatedInputTokens}`,
+          );
+        }
       }
     }
     if (clampedMaxTokens) {

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -38,6 +38,7 @@ import { observeEmbeddedAttemptPrompt } from "./attempt-prompt-support.js";
 import type { PreparedStreamRuntime } from "./attempt-stream-runtime.types.js";
 import { removeTrailingMidTurnPrecheckAssistantError } from "./attempt-transcript-helpers.js";
 import type { MidTurnPrecheckRequest } from "./midturn-precheck.js";
+import { estimateToolSchemaTokenPressure } from "./preemptive-compaction.js";
 import { prepareEmbeddedAttemptPromptExecution } from "./prompt-image-preparation.js";
 
 type PromptAssemblyResult = Awaited<ReturnType<typeof prepareEmbeddedAttemptPromptAssembly>>;
@@ -396,6 +397,9 @@ export async function runEmbeddedAttemptPromptPhase(
       state,
       systemPrompt: promptContext.systemPromptForHook,
       toolResultMaxChars: promptContext.promptToolResultMaxChars,
+      // Use the installed model-facing tool surface (same source as the compaction
+      // request budget) so client tools appended by attempt-client-tools are counted.
+      toolSchemaTokens: estimateToolSchemaTokenPressure(activeSession.agent.state.tools),
     });
     publishDispatchState(state);
 

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   PREEMPTIVE_OVERFLOW_ERROR_TEXT,
   estimateLlmBoundaryTokenPressure,
+  estimateToolSchemaTokenPressure,
 } from "./preemptive-compaction.js";
 
 const attempt = {
@@ -71,12 +72,22 @@ describe("attempt prompt preflight", () => {
     "discarded-invalid",
     "fitting-with-raw-overflow",
     "fitting-with-discarded-invalid",
+    "fitting-with-tool-output-schema",
   ] as const)(
     "handles a %s checkpoint when a context engine owns ordinary compaction",
     async (variant) => {
       const discarded = variant === "discarded" || variant === "discarded-invalid";
       const fitting = variant.startsWith("fitting-");
       const unwindowed = variant === "unwindowed" || variant === "unwindowed-tools";
+      const toolWithOutputSchema = {
+        name: "lookup",
+        description: "Look up a record.",
+        parameters: { type: "object" },
+        outputSchema: {
+          type: "string",
+          description: "result documentation ".repeat(4_000),
+        },
+      };
       const owner = makeAgentAssistantMessage({
         content: [{ type: "text", text: "covered" }],
         model: attempt.model.id,
@@ -157,6 +168,11 @@ describe("attempt prompt preflight", () => {
         sessionMessageCount: 1,
         systemPrompt: "",
         toolResultMaxChars: 1_000,
+        ...(variant === "fitting-with-tool-output-schema"
+          ? {
+              toolSchemaTokens: estimateToolSchemaTokenPressure([toolWithOutputSchema]),
+            }
+          : {}),
         state: {
           contextBudgetStatus: undefined,
           preflightRecovery: undefined,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.ts
@@ -179,6 +179,7 @@ export async function prepareEmbeddedAttemptPromptPreflight(input: {
   systemPrompt: string;
   timezone?: string;
   toolResultMaxChars: number;
+  toolSchemaTokens?: number;
   unwindowedContextEngineMessagesForPrecheck?: AgentMessage[];
 }): Promise<AttemptPromptPreflightState> {
   const { attempt } = input;
@@ -208,6 +209,9 @@ export async function prepareEmbeddedAttemptPromptPreflight(input: {
         contextTokenBudget: input.contextTokenBudget,
         reserveTokens: input.reserveTokens,
         toolResultMaxChars: input.toolResultMaxChars,
+        ...(typeof input.toolSchemaTokens === "number"
+          ? { toolSchemaTokens: input.toolSchemaTokens }
+          : {}),
         replay: {
           model: attempt.model,
           sessionId: attempt.sessionId,

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
@@ -8,6 +8,7 @@ import { estimateToolResultReductionPotential } from "../tool-result-truncation.
 let PREEMPTIVE_OVERFLOW_ERROR_TEXT: typeof import("./preemptive-compaction.js").PREEMPTIVE_OVERFLOW_ERROR_TEXT;
 let estimateLlmBoundaryTokenPressure: typeof import("./preemptive-compaction.js").estimateLlmBoundaryTokenPressure;
 let buildPrePromptContextBudgetStatus: typeof import("./preemptive-compaction.js").buildPrePromptContextBudgetStatus;
+let estimateToolSchemaTokenPressure: typeof import("./preemptive-compaction.js").estimateToolSchemaTokenPressure;
 let estimateRenderedLlmBoundaryTokenPressure: typeof import("./preemptive-compaction.js").estimateRenderedLlmBoundaryTokenPressure;
 let formatPrePromptPrecheckLog: typeof import("./preemptive-compaction.js").formatPrePromptPrecheckLog;
 let shouldPreemptivelyCompactBeforePrompt: typeof import("./preemptive-compaction.js").shouldPreemptivelyCompactBeforePrompt;
@@ -21,6 +22,7 @@ beforeAll(async () => {
     estimateLlmBoundaryTokenPressure,
     buildPrePromptContextBudgetStatus,
     estimateRenderedLlmBoundaryTokenPressure,
+    estimateToolSchemaTokenPressure,
     formatPrePromptPrecheckLog,
     shouldPreemptivelyCompactBeforePrompt,
   } = await import("./preemptive-compaction.js"));
@@ -745,6 +747,103 @@ describe("preemptive-compaction", () => {
     expect(result.route).toBe("fits");
     expect(result.shouldCompact).toBe(false);
     expect(result.overflowTokens).toBe(0);
+  });
+
+  it("includes tool schema tokens in the precheck estimate so large catalogs trigger overflow", () => {
+    const messages = [makeAssistantHistory("short conversation text")];
+    const contextTokenBudget = 150_000;
+    const reserveTokens = 20_000;
+
+    const withoutTools = shouldPreemptivelyCompactBeforePrompt({
+      messages,
+      systemPrompt: "sys",
+      prompt: "continue",
+      contextTokenBudget,
+      reserveTokens,
+    });
+
+    const toolSchemaTokens = estimateToolSchemaTokenPressure(
+      Array.from({ length: 79 }, (_, i) => ({
+        type: "function",
+        function: {
+          name: `tool_${i}`,
+          description: "x".repeat(4000),
+          parameters: { type: "object", properties: { arg: { type: "string" } } },
+        },
+      })),
+    );
+
+    expect(toolSchemaTokens).toBeGreaterThan(50_000);
+
+    const withTools = shouldPreemptivelyCompactBeforePrompt({
+      messages,
+      systemPrompt: "sys",
+      prompt: "continue",
+      contextTokenBudget,
+      reserveTokens,
+      toolSchemaTokens,
+    });
+
+    expect(withoutTools.route).toBe("fits");
+    expect(withTools.route).not.toBe("fits");
+    expect(withTools.estimatedPromptTokens).toBeGreaterThan(withoutTools.estimatedPromptTokens);
+    expect(withTools.overflowTokens).toBeGreaterThan(0);
+  });
+
+  it("does not alter the estimate when toolSchemaTokens is zero or undefined", () => {
+    const messages = [makeAssistantHistory("short conversation text")];
+    const baseParams = {
+      messages,
+      systemPrompt: "sys",
+      prompt: "continue",
+      contextTokenBudget: 128_000,
+      reserveTokens: 20_000,
+    };
+
+    const withoutToolSchema = shouldPreemptivelyCompactBeforePrompt(baseParams);
+    const withZeroToolSchema = shouldPreemptivelyCompactBeforePrompt({
+      ...baseParams,
+      toolSchemaTokens: 0,
+    });
+
+    expect(withZeroToolSchema.estimatedPromptTokens).toBe(withoutToolSchema.estimatedPromptTokens);
+    expect(withZeroToolSchema.route).toBe(withoutToolSchema.route);
+  });
+
+  it("does not double-count tool schema tokens when a provider boundary is available", () => {
+    // The provider boundary totalTokens already includes the tool schemas from
+    // its request. Adding toolSchemaTokens again would over-count an unchanged
+    // catalog. This test verifies the fix: when a provider boundary exists,
+    // toolSchemaTokens are not added on top of the boundary total.
+    const providerTotal = 100_000;
+    const messages = [
+      makeProviderAssistant({ promptTokens: 80_000, totalTokens: providerTotal }),
+      makeAssistantHistory("additional conversation after boundary"),
+    ];
+    const toolSchemaTokens = 40_000;
+    const contextTokenBudget = 150_000;
+    const reserveTokens = 20_000;
+
+    const withoutToolSchema = shouldPreemptivelyCompactBeforePrompt({
+      messages,
+      systemPrompt: "sys",
+      prompt: "continue",
+      contextTokenBudget,
+      reserveTokens,
+    });
+
+    const withToolSchema = shouldPreemptivelyCompactBeforePrompt({
+      messages,
+      systemPrompt: "sys",
+      prompt: "continue",
+      contextTokenBudget,
+      reserveTokens,
+      toolSchemaTokens,
+    });
+
+    // With a provider boundary, tool schema tokens must not inflate the estimate.
+    expect(withToolSchema.estimatedPromptTokens).toBe(withoutToolSchema.estimatedPromptTokens);
+    expect(withToolSchema.pressureSource).toBe("provider_context_usage");
   });
 
   it("does not throw when tool-result content cannot be serialized", () => {

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
@@ -751,7 +751,7 @@ describe("preemptive-compaction", () => {
 
   it("includes tool schema tokens in the precheck estimate so large catalogs trigger overflow", () => {
     const messages = [makeAssistantHistory("short conversation text")];
-    const contextTokenBudget = 150_000;
+    const contextTokenBudget = 128_000;
     const reserveTokens = 20_000;
 
     const withoutTools = shouldPreemptivelyCompactBeforePrompt({
@@ -770,7 +770,7 @@ describe("preemptive-compaction", () => {
       })),
     );
 
-    expect(toolSchemaTokens).toBeGreaterThan(50_000);
+    expect(toolSchemaTokens).toBeGreaterThan(contextTokenBudget - reserveTokens);
 
     const withTools = shouldPreemptivelyCompactBeforePrompt({
       messages,

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
@@ -764,12 +764,9 @@ describe("preemptive-compaction", () => {
 
     const toolSchemaTokens = estimateToolSchemaTokenPressure(
       Array.from({ length: 79 }, (_, i) => ({
-        type: "function",
-        function: {
-          name: `tool_${i}`,
-          description: "x".repeat(4000),
-          parameters: { type: "object", properties: { arg: { type: "string" } } },
-        },
+        name: `tool_${i}`,
+        description: "x".repeat(4000),
+        parameters: { type: "object", properties: { arg: { type: "string" } } },
       })),
     );
 
@@ -788,6 +785,27 @@ describe("preemptive-compaction", () => {
     expect(withTools.route).not.toBe("fits");
     expect(withTools.estimatedPromptTokens).toBeGreaterThan(withoutTools.estimatedPromptTokens);
     expect(withTools.overflowTokens).toBeGreaterThan(0);
+  });
+
+  it("excludes runtime output schemas and metadata from tool pressure", () => {
+    const definition = {
+      name: "lookup",
+      description: "Look up a record.",
+      parameters: { type: "object", properties: { query: { type: "string" } } },
+    };
+    const runtimeTool = {
+      ...definition,
+      label: "Record lookup",
+      outputSchema: { type: "string", description: "result documentation ".repeat(4_000) },
+      executionMode: "parallel",
+      hideFromChannelProgress: true,
+      resultContentSource: "network",
+      execute: async () => ({ content: [], details: {} }),
+    };
+
+    expect(estimateToolSchemaTokenPressure([runtimeTool])).toBe(
+      estimateToolSchemaTokenPressure([definition]),
+    );
   });
 
   it("does not alter the estimate when toolSchemaTokens is zero or undefined", () => {

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -93,11 +93,20 @@ function resolveProviderContextBoundary(
   return undefined;
 }
 
+/** Estimates token pressure from serialized tool definitions sent alongside the prompt. */
+export function estimateToolSchemaTokenPressure(tools: unknown[]): number {
+  if (!Array.isArray(tools) || tools.length === 0) {
+    return 0;
+  }
+  return Math.ceil(estimateJsonPayloadTokenPressure(tools) * SAFETY_MARGIN);
+}
+
 function estimateTranscriptBoundaryTokenPressure(params: {
   messages: AgentMessage[];
   systemPrompt?: string;
   prompt: string;
   replay?: CompactionReplayPressureContext;
+  toolSchemaTokens?: number;
 }): TranscriptBoundaryTokenPressure {
   const replay = params.replay
     ? resolveCompactionReplayPressure(params.messages, params.replay.model, params.replay, {
@@ -115,9 +124,14 @@ function estimateTranscriptBoundaryTokenPressure(params: {
     (sum, message) => sum + estimateMessageTokenPressure(message),
     estimateRenderedPromptTokens(params) + (boundary ? 0 : (replay?.prefixTokens ?? 0)),
   );
+  const toolSchemaTokens = Math.max(0, params.toolSchemaTokens ?? 0);
   return {
     estimatedPromptTokens:
-      (boundary?.totalTokens ?? 0) + Math.ceil(locallyEstimatedTokens * SAFETY_MARGIN),
+      (boundary?.totalTokens ?? 0) +
+      Math.ceil(locallyEstimatedTokens * SAFETY_MARGIN) +
+      // The provider boundary already includes tool schemas from its request;
+      // only add them when estimating from the raw transcript.
+      (boundary ? 0 : toolSchemaTokens),
     source: boundary
       ? "provider_context_usage"
       : replay
@@ -133,6 +147,7 @@ export function estimateLlmBoundaryTokenPressure(params: {
   systemPrompt?: string;
   prompt: string;
   replay?: CompactionReplayPressureContext;
+  toolSchemaTokens?: number;
 }): number {
   return estimateTranscriptBoundaryTokenPressure(params).estimatedPromptTokens;
 }
@@ -174,6 +189,7 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   contextTokenBudget: number;
   reserveTokens: number;
   toolResultMaxChars?: number;
+  toolSchemaTokens?: number;
   llmBoundaryTokenPressure?: LlmBoundaryTokenPressure;
   replay?: CompactionReplayPressureContext;
 }): PreemptiveCompactionDecision {
@@ -188,6 +204,9 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
           systemPrompt: params.systemPrompt,
           prompt: params.prompt,
           replay: params.replay,
+          ...(typeof params.toolSchemaTokens === "number"
+            ? { toolSchemaTokens: params.toolSchemaTokens }
+            : {}),
         });
   // The selected provider window owns its covered prefix, including when a
   // context engine supplied an estimate of the raw transcript instead.
@@ -211,6 +230,9 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
       messages: params.unwindowedMessages,
       systemPrompt: params.systemPrompt,
       prompt: params.prompt,
+      ...(typeof params.toolSchemaTokens === "number"
+        ? { toolSchemaTokens: params.toolSchemaTokens }
+        : {}),
     });
     // Unwindowed history is diagnostic: neither its checkpoints nor its larger
     // raw estimate may authorize recovery of a different outgoing window.

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -14,6 +14,7 @@ import {
   estimateJsonPayloadTokenPressure,
   estimateMessageTokenPressure,
   estimateRenderedPromptTokens,
+  estimateToolSchemaTokens,
 } from "../../sessions/context-token-pressure.js";
 import { estimateToolResultReductionPotential } from "../tool-result-truncation.js";
 import type { PreemptiveCompactionRoute } from "./preemptive-compaction.types.js";
@@ -94,11 +95,10 @@ function resolveProviderContextBoundary(
 }
 
 /** Estimates token pressure from serialized tool definitions sent alongside the prompt. */
-export function estimateToolSchemaTokenPressure(tools: unknown[]): number {
-  if (!Array.isArray(tools) || tools.length === 0) {
-    return 0;
-  }
-  return Math.ceil(estimateJsonPayloadTokenPressure(tools) * SAFETY_MARGIN);
+export function estimateToolSchemaTokenPressure(
+  tools: Parameters<typeof estimateToolSchemaTokens>[0],
+): number {
+  return Math.ceil(estimateToolSchemaTokens(tools) * SAFETY_MARGIN);
 }
 
 function estimateTranscriptBoundaryTokenPressure(params: {

--- a/src/agents/sessions/context-token-pressure.ts
+++ b/src/agents/sessions/context-token-pressure.ts
@@ -46,6 +46,17 @@ export function estimateJsonPayloadTokenPressure(
   }
 }
 
+/** Count model-facing definitions; runtime output schemas and metadata never reach the provider. */
+export function estimateToolSchemaTokens(
+  tools: readonly { name: string; description: string; parameters: unknown }[] | undefined,
+): number {
+  return tools?.length
+    ? estimateJsonPayloadTokenPressure(
+        tools.map(({ name, description, parameters }) => ({ name, description, parameters })),
+      )
+    : 0;
+}
+
 function estimateIdentifierTokenPressure(
   value: unknown,
   charsPerToken = JSON_PAYLOAD_CHARS_PER_TOKEN,
@@ -209,15 +220,7 @@ export function estimateFreshLlmBoundaryTokenPressure(params: {
   prompt: string;
   imageCount?: number;
 }): number {
-  const toolTokens = params.tools?.length
-    ? estimateJsonPayloadTokenPressure(
-        params.tools.map(({ name, description, parameters }) => ({
-          name,
-          description,
-          parameters,
-        })),
-      )
-    : 0;
+  const toolTokens = estimateToolSchemaTokens(params.tools);
   return Math.ceil(
     (estimateRenderedPromptTokens(params) +
       toolTokens +


### PR DESCRIPTION
Fixes #140770

## What Problem This Solves

When an agent has a large MCP tool catalog, the context-overflow precheck reports `route=fits` while the transport silently clamps `max_tokens` to 1, producing single-token replies. The precheck only estimated transcript messages and system prompt — not the serialized tool definitions — so it could not see that tools consumed most of the context window. This fix includes tool schema token estimates in the precheck so it reflects the real input size the transport will send, and exposes a visible warning when the output budget is unusably small.

## Why This Change Was Made

The precheck and transport layers use two different token estimates that disagree on whether tools count. The fix bridges them at the precheck layer so compaction routing sees the full input.

- **Solution**: Pass `toolSchemaTokens` (estimated from the installed model-facing tool surface) through `shouldPreemptivelyCompactBeforePrompt` so the precheck's `estimatedPromptTokens` includes tool definitions. When a provider usage boundary is available, its `totalTokens` already includes the tool schemas from that request, so `toolSchemaTokens` is not added again to avoid double-counting.
- **Tool surface**: The estimate projects `name`, `description`, and `parameters` from `activeSession.agent.state.tools` using the existing shared estimator. Client tools appended by `attempt-client-tools.ts` are counted. Runtime-only fields such as `outputSchema`, labels, and execution metadata are excluded, preventing false overflow.
- **Warning visibility**: When the remaining output budget falls below `MIN_USEFUL_OUTPUT_TOKENS` (16), `log.warn` emits `insufficient_output_budget` at a normally visible level, not hidden behind model-debug environment settings.
- **What did NOT change**: Compaction logic, transport clamp behavior (`Math.max(1, ...)` retained as safety floor), other callers of `shouldPreemptivelyCompactBeforePrompt` (param is optional, no behavior change). The precheck remains diagnostic-only outside provider-checkpoint recovery.

## User Impact

Agents with large MCP tool catalogs will no longer have their context-overflow precheck silently miss tool-definition pressure. The precheck correctly identifies overflow from tool definitions, and operators see a visible `insufficient_output_budget` warning when the output budget is too small for a useful response.

## Evidence

The runtime captures and test counts below were submitted for the original contributor head. Maintainer repair `f2a0b9ade8aa` adds regression cases for metadata-invariant estimates and a fitting checkpoint prompt with a large output schema; final-head hosted CI tracks those cases.

Real agent session via `openclaw agent --local` with a mock vLLM provider (`mock-vllm/test-model`, `contextWindow=8192`). The agent's installed tool catalog (20 plugins with coding tools) exceeds the small context window, triggering both the precheck overflow detection and the transport warning in the same session:

```
$ OPENCLAW_DEBUG_MODEL_TRANSPORT=1 OPENCLAW_LOG_LEVEL=debug openclaw agent --local -m "Say hello" --json

[agent/embedded] [context-overflow-precheck] pre-prompt check sessionKey=agent:main:main provider=mock-vllm/test-model route=compact_only estimatedPromptTokens=49801 pressureSource=transcript_estimate promptBudgetBeforeReserve=6144 overflowTokens=43657 toolResultReducibleChars=0 reserveTokens=2048 effectiveReserveTokens=2048 contextTokenBudget=8192 messages=3 unwindowedMessages=3 sessionFile=agent:main:main
[agent/embedded] [context-pressure-diagnostic] admitted provider attempt for mock-vllm/test-model route=compact_only estimatedPromptTokens=49801 promptBudgetBeforeReserve=6144
[openai-transport] [completions] clamp_max_tokens provider=mock-vllm api=openai-completions model=test-model requested=4096 output=1 effectiveContext=8192 estimatedInput=41612
[openai-transport] [completions] insufficient_output_budget provider=mock-vllm api=openai-completions model=test-model output=1 effectiveContext=8192 estimatedInput=41612
```

The precheck (`[context-overflow-precheck]`) reports `route=compact_only` with `estimatedPromptTokens=49801` — tool schema pressure from the installed tool surface flows through `attempt-prompt-phase.ts` → `prepareEmbeddedAttemptPromptPreflight` → `shouldPreemptivelyCompactBeforePrompt`. The transport (`[completions] insufficient_output_budget`) emits at `log.warn` level — visible under normal logging — showing `output=1` (clamped) and `estimatedInput=41612`.

Provider boundary double-count prevention (production `shouldPreemptivelyCompactBeforePrompt` with simulated 79-tool catalog):

```
Provider boundary (totalTokens=100000) + toolSchemaTokens=136604:
  without tools: estimatedPromptTokens=100051
  with tools:    estimatedPromptTokens=100051
  double-count prevented: true
```

Vitest regression tests (33 passed, including 3 tool-schema tests):

```
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts --run
 ✓ includes tool schema tokens in the precheck estimate so large catalogs trigger overflow
 ✓ does not alter the estimate when toolSchemaTokens is zero or undefined
 ✓ does not double-count tool schema tokens when a provider boundary is available
 Tests  33 passed (33)
```

Transport layer tests (47 passed, no regressions):

```
$ node scripts/run-vitest.mjs packages/ai/src/transports/openai-completions-params.tools.test.ts packages/ai/src/transports/openai-completions-params.shaping.test.ts packages/ai/src/transports/openai-completions-params.compat-and-tool-choice.test.ts packages/ai/src/transports/openai-completions-params.cache-and-compat.test.ts --run
 Test Files  4 passed (4)
 Tests  47 passed (47)
```

## AI Assistance

This PR is AI-assisted. Used Codex CLI to analyze issue #140770, trace the root cause through `preemptive-compaction.ts` and `openai-completions-params.ts`, and implement the fix. Revised after ClawSweeper review to: (1) avoid double-counting tool schemas when a provider usage boundary already includes them, (2) estimate from the complete installed tool surface (`activeSession.agent.state.tools`) rather than `effectiveTools`, and (3) emit the insufficient-output-budget warning at `log.warn` level for normal visibility. Evidence includes a real `openclaw agent --local` session showing tool-pressure diagnostics through the full prompt-phase-to-preflight-to-transport path. All evidence above is from real local runtime execution.
