### PR TITLE
refactor(plugins): remove the redundant config policy relay

### DIFF
--- a/src/plugins/config-normalization-shared.ts
+++ b/src/plugins/config-normalization-shared.ts
@@ -49,7 +49,7 @@ export type NormalizedPluginsConfig = {
 export type NormalizePluginId = (id: string) => string;
 
 /** Default plugin id normalizer for already-canonical ids. */
-export const identityNormalizePluginId: NormalizePluginId = (id) => id.trim();
+const identityNormalizePluginId: NormalizePluginId = (id) => id.trim();
 
 function normalizeList(value: unknown, normalizePluginId: NormalizePluginId): string[] {
   if (!Array.isArray(value)) {

--- a/src/plugins/config-policy.ts
+++ b/src/plugins/config-policy.ts
@@ -3,27 +3,15 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   resolvePluginActivationDecisionShared,
   toPluginActivationState,
-  type PluginActivationStateLike,
+  type PluginActivationStateLike as PluginActivationState,
 } from "./config-activation-shared.js";
 import {
-  identityNormalizePluginId,
-  normalizePluginsConfigWithResolverCore as normalizePluginsConfigWithResolverShared,
   resolveChannelConfigEnablement,
-  type NormalizePluginId,
-  type NormalizedPluginsConfig as SharedNormalizedPluginsConfig,
+  type NormalizedPluginsConfig,
 } from "./config-normalization-shared.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 
-type PluginActivationState = PluginActivationStateLike;
-
-type NormalizedPluginsConfig = SharedNormalizedPluginsConfig;
-
-export function normalizePluginsConfigWithResolver(
-  config?: OpenClawConfig["plugins"],
-  normalizePluginId: NormalizePluginId = identityNormalizePluginId,
-): NormalizedPluginsConfig {
-  return normalizePluginsConfigWithResolverShared(config, normalizePluginId);
-}
+export { normalizePluginsConfigWithResolverCore as normalizePluginsConfigWithResolver } from "./config-normalization-shared.js";
 
 type PolicyEffectiveActivationParams = {
   id: string;


### PR DESCRIPTION
Related: #135868, #140815

## What Problem This Solves

The private plugin-policy facade repeats a normalizer signature and forwards every call directly to the shared implementation. Two additional aliases repeat imported types. This is the requested owner follow-up to #140815 in the maintainer's deletion campaign.

## Why This Change Was Made

Replace the forwarding function with a named re-export of the same canonical normalizer and import the existing types directly. Make the shared default resolver private after the facade, its only external consumer, disappears. Both exported names, the normalizer's call signature/default resolver/results, and the activation-policy implementation stay intact. The four direct consumer families—manifest discovery, hook discovery, skill discovery, and agent settings—continue using the same facade.

The existing wrapper-shadowing guidance explicitly permits a pure re-export when the wrapper adds no behavior. Its earlier rename in `e74be5d41db` only distinguished the core import; it introduced no policy requiring an additional wrapper. The separate registry timeout helper remains because it floors positive values and has a different accepted domain.

## User Impact

No user-visible behavior change. Plugin configuration, activation policy, and discovery retain their existing semantics with less duplicate code. No configuration option, schema, storage behavior, dependency, or authorization change.

## Evidence

- All 245 existing tests across eight suites passed before (65.64s) and after the complete two-file cleanup (39.25s), covering config policy/state, manifest registry, hooks, skills, agent settings, bundle settings, and cached MCP settings.
- The first full check passed core and test types, then both Knip scans correctly flagged the now-unused `identityNormalizePluginId` export. The completed patch makes that existing helper private; it keeps all internal uses and retains the separately consumed `NormalizePluginId` type.
- The complete selected `check:changed` plan passed in 603.94s, including core/test types, all three zero-entry Knip scans, lint, zero runtime import cycles, and architecture/storage guards. All 17 recorded source/test/dependency input hashes remained unchanged.
- Full `pnpm build` passed in 544.62s, including public SDK declarations/exports, 53 native control-plane module loads, CLI bootstrap imports, and UI checks. Both full checks and build ran on pinned base `038acb2695d298ac671c3b886647025abdbfd22c`, verifying all 17 recorded input hashes and the complete changed-path set before and after each command.
- Independent review of the complete patch is scoped-clean through P2.
- Refresh onto `64887802d73bb7f2d0ce499aef979a71807ac5fd` was clean; all 17 source/test/dependency input hashes remained byte-identical, including the lockfile. Exact-head CI supplies integration proof for refreshed main.
- Fresh author-open PR discovery and complete net diffs for all 16 truncated/missing file inventories found no competing change in this owner.

- Initial exact-head CI passed. Final refresh onto `7ab1c97cb7fee1a5bc72da1cf913ea25873c3497` is patch-identical. Main added the Team Reports workspace; the offline install lacked cached package metadata, then the normal frozen install passed its supply-chain check. All 15 source/test hashes stayed identical, all 245 tests passed again (83.45s), and final branch review is scoped-clean through P2.
- [ClawSweeper review](https://github.com/openclaw/openclaw/pull/140904#issuecomment-5565892517): no findings, security issues, or before-merge/rank-up actions. Its source/caller review confirms the preserved callable contract and absence of external/default-resolver SDK consumers.

| Class | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 4 | 16 | -12 |
| Tests | 0 | 0 | 0 |
| Tooling | 0 | 0 | 0 |
| Docs | 0 | 0 | 0 |

The policy owner shrinks from 53 to 41 lines; the shared normalizer keeps the same line count. Existing behavior tests and all baselines remain intact.
