### PR TITLE
refactor(canvas): share widget theme message vocabulary

### DIFF
--- a/src/canvas/wrap.ts
+++ b/src/canvas/wrap.ts
@@ -1,30 +1,5 @@
 import { escapeHtml } from "../shared/html-escape.js";
-
-const WIDGET_THEME_TOKENS = [
-  "surface",
-  "card",
-  "elevated",
-  "text",
-  "text-strong",
-  "muted",
-  "border",
-  "border-strong",
-  "accent",
-  "accent-fill",
-  "accent-fg",
-  "ok",
-  "warn",
-  "danger",
-  "info",
-  "radius",
-  "radius-full",
-  "scrollbar-size",
-  "scrollbar-thumb-inset",
-  "scrollbar-thumb",
-  "scrollbar-thumb-hover",
-  "font-body",
-  "font-mono",
-] as const;
+import { WIDGET_THEME_MESSAGE_TYPE, WIDGET_THEME_TOKENS } from "../shared/widget-theme.js";
 
 // Baked palettes mirror the host claw theme (ui/src/styles/base.css) so
 // fallback renders match Control UI renders, where the theme bridge pushes the
@@ -226,7 +201,7 @@ export function buildWidgetDocument(
     "const rm=root.style.removeProperty.bind(root.style);" +
     `const keys=${JSON.stringify(WIDGET_THEME_TOKENS)};` +
     'addEventListener("message",event=>{if(event.source!==window.parent)return;' +
-    'const data=event.data;if(!data||data.type!=="openclaw:widget-theme"||' +
+    `const data=event.data;if(!data||data.type!==${JSON.stringify(WIDGET_THEME_MESSAGE_TYPE)}||` +
     'typeof data.tokens!=="object"||data.tokens===null)return;' +
     "for(const key of keys){const raw=data.tokens[key];" +
     'const value=typeof raw==="string"?raw.trim():"";' +

--- a/src/shared/widget-theme.ts
+++ b/src/shared/widget-theme.ts
@@ -1,0 +1,35 @@
+export const WIDGET_THEME_TOKENS = [
+  "surface",
+  "card",
+  "elevated",
+  "text",
+  "text-strong",
+  "muted",
+  "border",
+  "border-strong",
+  "accent",
+  "accent-fill",
+  "accent-fg",
+  "ok",
+  "warn",
+  "danger",
+  "info",
+  "radius",
+  "radius-full",
+  "scrollbar-size",
+  "scrollbar-thumb-inset",
+  "scrollbar-thumb",
+  "scrollbar-thumb-hover",
+  "font-body",
+  "font-mono",
+] as const;
+
+export type WidgetThemeToken = (typeof WIDGET_THEME_TOKENS)[number];
+
+export const WIDGET_THEME_MESSAGE_TYPE = "openclaw:widget-theme";
+
+export type WidgetThemeMessage = {
+  type: typeof WIDGET_THEME_MESSAGE_TYPE;
+  mode: "light" | "dark";
+  tokens: Record<string, string>;
+};

--- a/ui/src/lib/widget-theme.ts
+++ b/ui/src/lib/widget-theme.ts
@@ -1,30 +1,9 @@
-const WIDGET_THEME_TOKENS = [
-  "surface",
-  "card",
-  "elevated",
-  "text",
-  "text-strong",
-  "muted",
-  "border",
-  "border-strong",
-  "accent",
-  "accent-fill",
-  "accent-fg",
-  "ok",
-  "warn",
-  "danger",
-  "info",
-  "radius",
-  "radius-full",
-  "scrollbar-size",
-  "scrollbar-thumb-inset",
-  "scrollbar-thumb",
-  "scrollbar-thumb-hover",
-  "font-body",
-  "font-mono",
-] as const;
-
-type WidgetThemeToken = (typeof WIDGET_THEME_TOKENS)[number];
+import {
+  WIDGET_THEME_MESSAGE_TYPE,
+  WIDGET_THEME_TOKENS,
+  type WidgetThemeMessage,
+  type WidgetThemeToken,
+} from "../../../src/shared/widget-theme.ts";
 
 const HOST_TOKEN_SOURCES: Record<WidgetThemeToken, string> = {
   surface: "--bg",
@@ -63,15 +42,11 @@ function collectWidgetThemeTokens(read: (hostVar: string) => string): Record<str
   return tokens;
 }
 
-export function buildWidgetThemeMessage(): {
-  type: "openclaw:widget-theme";
-  mode: "light" | "dark";
-  tokens: Record<string, string>;
-} {
+export function buildWidgetThemeMessage(): WidgetThemeMessage {
   const root = document.documentElement;
   const styles = getComputedStyle(root);
   return {
-    type: "openclaw:widget-theme",
+    type: WIDGET_THEME_MESSAGE_TYPE,
     mode: root.dataset.themeMode === "light" ? "light" : "dark",
     tokens: collectWidgetThemeTokens((hostVar) => styles.getPropertyValue(hostVar)),
   };


### PR DESCRIPTION
## What Problem This Solves

Canvas widget documents and the Control UI independently define the same theme-message vocabulary. A token added on only one side can leave embedded widgets with incomplete themes.

## Why This Change Was Made

`src/shared/widget-theme.ts` owns the ordered 23-token allowlist, exact message discriminator, and message type. The document builder and UI import that browser-safe contract. Host CSS mappings, palette values, full-snapshot token removal, origin checks, and bridge capabilities retain their current owners and behavior.

## User Impact

None intended. Generated widget document bytes, theme messages and appearance remain identical. No wire/protocol change, public-export removal, SDK surface increase, or new dependency.

## Evidence

- `node scripts/run-vitest.mjs src/canvas/wrap.test.ts ui/src/pages/chat/components/widget-theme.test.ts`: five tests passed across two files, including document bytes and theme/origin behavior. No page source or test edited.
- Fresh-source parity probe: 120 byte-identical documents, 23 token mappings, eight theme profiles, and 16 message-origin cases. The existing fixture remains 18,121 bytes with SHA-256 `c8f0ea0dea6648693a8972f602762716618563022f8248e8e7d99a8b1a723692`.
- Independent review: P0–P2 scoped-clean, zero findings.
- Production +45/-60 (net -15); tests unchanged.
- `node scripts/check-changed.mjs --base a17f8c2b5d19f5dd99fc33044f8e87fbf4fe0fc4`: passed.
- Clean Linux `pnpm build` passed in 3m 18.2s; `pnpm ui:check-performance` passed: startup JS 347,948 / 350,953 B gzip, 8 / 18 requests; CSS 43,989 / 51,200 B. Provider `blacksmith-testbox`, lease `tbx_01m1x7s8r2vf0sf30wwrcqpc3k`, [run 34089603239](https://github.com/openclaw/openclaw/actions/runs/34089603239). Command: `node scripts/crabbox-wrapper.mjs run --timing-json --shell -- 'pnpm build && pnpm ui:check-performance'`. Wrapper exit 0; lease completion/stoppage verified. Build source is original commit `8ca882c5d231b0b9dbd3200427bf70392bc24dc1`.
- Required fresh-main rebase onto `9230180f699e738d39bac1feecd0187b845026a0` is patch-identical; touched dependencies have no diff. Current head `4f06df15bb970cdeda79bf693e8ab7358e3e31f1` passed [CI 34089720295](https://github.com/openclaw/openclaw/actions/runs/34089720295).
