### PR TITLE
fix(cli): reject blank numeric options in status and logs

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -60,6 +60,8 @@ did not name.
 - `channels resolve <entries...>`: `--channel <name>`, `--account <id>`, `--agent <id>`, `--kind <auto|user|group|channel>` (default `auto`), `--json`
 - `channels logs`: `--channel <name|all>` (default `all`), `--lines <n>` (default `200`), `--json`
 
+`channels logs --lines` requires a positive integer. Omit `--lines` to use the default of `200`; explicitly empty values are rejected.
+
 `channels logs --channel <name>` matches subsystem or module names rooted at `<name>`
 or `gateway/channels/<name>`, including slash-separated descendants. Similar names
 such as `discord-archive` do not match `discord`.

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -61,6 +61,8 @@ Options:
 | `--probe-max-tokens <n>`  | Probe max tokens (best effort).                                                                                                          |
 | `--agent <id>`            | Configured agent id; overrides `OPENCLAW_AGENT_DIR`.                                                                                     |
 
+`--probe-timeout` requires a positive number; `--probe-concurrency` and `--probe-max-tokens` require positive integers. Omit these options to use their defaults (`8000`, `2`, and `8`, respectively); explicitly empty values are rejected.
+
 Probe rows can come from auth profiles, env credentials, or `models.json`. Probe status buckets: `ok`, `auth`, `rate_limit`, `billing`, `timeout`, `format`, `unknown`, `no_model`.
 
 Direct `models status --probe` runs create temporary internal sessions in the selected agent's canonical database, so the command requires exclusive ownership of the configured state directory. Stop a running Gateway with `openclaw gateway stop` before probing; the command removes its internal sessions and releases the state lock when it finishes or is interrupted.

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -197,43 +197,28 @@ describe("channelsLogsCommand", () => {
     expect(JSON.stringify(payload)).not.toContain(fixtureCredential);
   });
 
-  it("preserves ordering and line limits for an explicit all filter", async () => {
+  it.each([
+    { lines: undefined, count: 200 },
+    { lines: 2, count: 2 },
+  ])("preserves ordering with line limit $lines", async ({ lines, count }) => {
+    const messages = Array.from({ length: 205 }, (_, index) => `message-${index}`);
     await fs.writeFile(
       logPath,
-      [
-        logLine({ module: "gateway/channels/slack/send", message: "first" }),
-        logLine({ module: "gateway/channels/external-chat/send", message: "second" }),
-        logLine({ module: "gateway/channels/slack/send", message: "third" }),
-      ].join(""),
+      messages
+        .map((message, index) =>
+          logLine({
+            module: `gateway/channels/${index % 2 ? "external-chat" : "slack"}/send`,
+            message,
+          }),
+        )
+        .join(""),
     );
 
-    await channelsLogsCommand({ channel: "all", lines: 2, json: true }, runtime);
+    await channelsLogsCommand({ channel: "all", lines, json: true }, runtime);
 
     const payload = readJsonPayload();
     expect(payload.channel).toBe("all");
-    expect(payload.lines.map((line) => line.message)).toEqual(["second", "third"]);
-  });
-
-  it("preserves the omitted default and a legal explicit line limit", async () => {
-    await fs.writeFile(
-      logPath,
-      [
-        logLine({ module: "gateway/channels/slack/send", message: "first" }),
-        logLine({ module: "gateway/channels/external-chat/send", message: "second" }),
-        logLine({ module: "gateway/channels/slack/send", message: "third" }),
-      ].join(""),
-    );
-
-    await channelsLogsCommand({ channel: "all", json: true }, runtime);
-    expect(readJsonPayload().lines.map((line) => line.message)).toEqual([
-      "first",
-      "second",
-      "third",
-    ]);
-
-    runtime.log.mockClear();
-    await channelsLogsCommand({ channel: "all", lines: 1, json: true }, runtime);
-    expect(readJsonPayload().lines.map((line) => line.message)).toEqual(["third"]);
+    expect(payload.lines.map((line) => line.message)).toEqual(messages.slice(-count));
   });
 
   it("finds sparse channel records beyond the shared 5000-line cap", async () => {
@@ -356,13 +341,7 @@ describe("channelsLogsCommand", () => {
     expect(payload.lines).toStrictEqual([]);
   });
 
-  it("rejects partial line limits", async () => {
-    await expect(channelsLogsCommand({ lines: "2x", json: true }, runtime)).rejects.toThrow(
-      "--lines must be a positive integer.",
-    );
-  });
-
-  it.each(["", "   "])("rejects an explicit blank line limit (%j)", async (lines) => {
+  it.each(["2x", "", "   "])("rejects invalid line limit %j", async (lines) => {
     await expect(channelsLogsCommand({ lines, json: true }, runtime)).rejects.toThrow(
       "--lines must be a positive integer.",
     );

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -214,6 +214,28 @@ describe("channelsLogsCommand", () => {
     expect(payload.lines.map((line) => line.message)).toEqual(["second", "third"]);
   });
 
+  it("preserves the omitted default and a legal explicit line limit", async () => {
+    await fs.writeFile(
+      logPath,
+      [
+        logLine({ module: "gateway/channels/slack/send", message: "first" }),
+        logLine({ module: "gateway/channels/external-chat/send", message: "second" }),
+        logLine({ module: "gateway/channels/slack/send", message: "third" }),
+      ].join(""),
+    );
+
+    await channelsLogsCommand({ channel: "all", json: true }, runtime);
+    expect(readJsonPayload().lines.map((line) => line.message)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+
+    runtime.log.mockClear();
+    await channelsLogsCommand({ channel: "all", lines: 1, json: true }, runtime);
+    expect(readJsonPayload().lines.map((line) => line.message)).toEqual(["third"]);
+  });
+
   it("finds sparse channel records beyond the shared 5000-line cap", async () => {
     const filler = logLine({ module: "gateway/health", message: "ok" });
     const lines = [
@@ -338,5 +360,12 @@ describe("channelsLogsCommand", () => {
     await expect(channelsLogsCommand({ lines: "2x", json: true }, runtime)).rejects.toThrow(
       "--lines must be a positive integer.",
     );
+  });
+
+  it.each(["", "   "])("rejects an explicit blank line limit (%j)", async (lines) => {
+    await expect(channelsLogsCommand({ lines, json: true }, runtime)).rejects.toThrow(
+      "--lines must be a positive integer.",
+    );
+    expect(runtime.log).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -80,7 +80,7 @@ function matchesChannel(
 }
 
 function parseLinesOption(value: unknown): number {
-  if (value === undefined || value === null || value === "") {
+  if (value === undefined || value === null) {
     return DEFAULT_LIMIT;
   }
   const parsed = parseStrictPositiveInteger(value);

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -197,7 +197,7 @@ type StatusModelRouteIssue =
     };
 
 function parseOptionalPositiveFiniteOption(raw: unknown, label: string, fallback: number): number {
-  if (raw === undefined || raw === null || raw === "") {
+  if (raw === undefined || raw === null) {
     return fallback;
   }
   const parsed = parseStrictFiniteNumber(raw);
@@ -208,7 +208,7 @@ function parseOptionalPositiveFiniteOption(raw: unknown, label: string, fallback
 }
 
 function parseOptionalPositiveIntegerOption(raw: unknown, label: string, fallback: number): number {
-  if (raw === undefined || raw === null || raw === "") {
+  if (raw === undefined || raw === null) {
     return fallback;
   }
   const parsed = parseStrictPositiveInteger(raw);

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -175,6 +175,25 @@ const mocks = vi.hoisted(() => {
   };
 });
 
+const probeMocks = vi.hoisted(() => ({
+  runAuthProbes: vi.fn().mockResolvedValue({
+    startedAt: 0,
+    finishedAt: 1,
+    durationMs: 1,
+    totalTargets: 0,
+    options: {
+      timeoutMs: 8000,
+      concurrency: 2,
+      maxTokens: 8,
+    },
+    results: [],
+  }),
+}));
+
+vi.mock("./list.probe.js", () => ({
+  runAuthProbes: probeMocks.runAuthProbes,
+}));
+
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentDir: mocks.resolveAgentDir,
   resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
@@ -735,9 +754,60 @@ describe("modelsStatusCommand auth overview", () => {
     [{ probeConcurrency: "2.5" }, "--probe-concurrency"],
     [{ probeMaxTokens: "64x" }, "--probe-max-tokens"],
   ])("rejects partial probe numeric option %s", async (opts, label) => {
+    probeMocks.runAuthProbes.mockClear();
     await expect(
-      modelsStatusCommand({ json: true, ...opts }, createRuntime() as never),
+      modelsStatusCommand({ json: true, probe: true, ...opts }, createRuntime() as never),
     ).rejects.toThrow(label);
+    expect(probeMocks.runAuthProbes).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [{ probeTimeout: "" }, "--probe-timeout"],
+    [{ probeTimeout: "   " }, "--probe-timeout"],
+    [{ probeConcurrency: "" }, "--probe-concurrency"],
+    [{ probeConcurrency: "   " }, "--probe-concurrency"],
+    [{ probeMaxTokens: "" }, "--probe-max-tokens"],
+    [{ probeMaxTokens: "   " }, "--probe-max-tokens"],
+  ])("rejects blank probe numeric option %s before starting auth probes", async (opts, label) => {
+    probeMocks.runAuthProbes.mockClear();
+    await expect(
+      modelsStatusCommand({ json: true, probe: true, ...opts }, createRuntime() as never),
+    ).rejects.toThrow(label);
+    expect(probeMocks.runAuthProbes).not.toHaveBeenCalled();
+  });
+
+  it("preserves omitted defaults and forwards legal probe numeric values", async () => {
+    probeMocks.runAuthProbes.mockClear();
+    await modelsStatusCommand(
+      {
+        json: true,
+        probe: true,
+        probeTimeout: "1.5",
+        probeConcurrency: "1",
+        probeMaxTokens: "1",
+      },
+      createRuntime() as never,
+    );
+    expect(probeMocks.runAuthProbes).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          timeoutMs: 1.5,
+          concurrency: 1,
+          maxTokens: 1,
+        }),
+      }),
+    );
+
+    await modelsStatusCommand({ json: true, probe: true }, createRuntime() as never);
+    expect(probeMocks.runAuthProbes).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          timeoutMs: 8000,
+          concurrency: 2,
+          maxTokens: 8,
+        }),
+      }),
+    );
   });
 
   it("includes masked auth sources in JSON output", async () => {

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -159,6 +159,16 @@ const mocks = vi.hoisted(() => {
     }),
     loadModelsConfigArgs: vi.fn(),
     loadProviderUsageSummary: vi.fn().mockResolvedValue(undefined),
+    runAuthProbes: vi
+      .fn<typeof import("./list.probe.js").runAuthProbes>()
+      .mockImplementation(async ({ options }) => ({
+        startedAt: 0,
+        finishedAt: 0,
+        durationMs: 0,
+        totalTargets: 0,
+        options,
+        results: [],
+      })),
     resolveRuntimeSyntheticAuthProviderRefs: vi.fn().mockReturnValue([]),
     resolveProviderSyntheticAuthWithPlugin: vi.fn().mockReturnValue(undefined),
     resolveAgentHarnessOwnerPluginIds: vi.fn().mockReturnValue(["codex"]),
@@ -174,25 +184,6 @@ const mocks = vi.hoisted(() => {
     openAIModelRouteOverride: undefined as ((params: unknown) => unknown) | undefined,
   };
 });
-
-const probeMocks = vi.hoisted(() => ({
-  runAuthProbes: vi.fn().mockResolvedValue({
-    startedAt: 0,
-    finishedAt: 1,
-    durationMs: 1,
-    totalTargets: 0,
-    options: {
-      timeoutMs: 8000,
-      concurrency: 2,
-      maxTokens: 8,
-    },
-    results: [],
-  }),
-}));
-
-vi.mock("./list.probe.js", () => ({
-  runAuthProbes: probeMocks.runAuthProbes,
-}));
 
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentDir: mocks.resolveAgentDir,
@@ -296,6 +287,7 @@ vi.mock("../../config/config.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../config/config.js")>()),
   createConfigIO: mocks.createConfigIO,
 }));
+vi.mock("./list.probe.js", () => ({ runAuthProbes: mocks.runAuthProbes }));
 vi.mock("./load-config.js", () => ({
   loadModelsConfig: vi.fn(async (...args: unknown[]) => {
     mocks.loadModelsConfigArgs(...args);
@@ -753,60 +745,33 @@ describe("modelsStatusCommand auth overview", () => {
     [{ probeTimeout: "5000ms" }, "--probe-timeout"],
     [{ probeConcurrency: "2.5" }, "--probe-concurrency"],
     [{ probeMaxTokens: "64x" }, "--probe-max-tokens"],
-  ])("rejects partial probe numeric option %s", async (opts, label) => {
-    probeMocks.runAuthProbes.mockClear();
-    await expect(
-      modelsStatusCommand({ json: true, probe: true, ...opts }, createRuntime() as never),
-    ).rejects.toThrow(label);
-    expect(probeMocks.runAuthProbes).not.toHaveBeenCalled();
-  });
-
-  it.each([
     [{ probeTimeout: "" }, "--probe-timeout"],
     [{ probeTimeout: "   " }, "--probe-timeout"],
     [{ probeConcurrency: "" }, "--probe-concurrency"],
     [{ probeConcurrency: "   " }, "--probe-concurrency"],
     [{ probeMaxTokens: "" }, "--probe-max-tokens"],
     [{ probeMaxTokens: "   " }, "--probe-max-tokens"],
-  ])("rejects blank probe numeric option %s before starting auth probes", async (opts, label) => {
-    probeMocks.runAuthProbes.mockClear();
+  ])("rejects invalid probe numeric option %j", async (opts, label) => {
+    const localRuntime = createRuntime();
+    mocks.runAuthProbes.mockClear();
     await expect(
-      modelsStatusCommand({ json: true, probe: true, ...opts }, createRuntime() as never),
+      modelsStatusCommand({ json: true, probe: true, ...opts }, localRuntime),
     ).rejects.toThrow(label);
-    expect(probeMocks.runAuthProbes).not.toHaveBeenCalled();
+    expect(mocks.runAuthProbes).not.toHaveBeenCalled();
+    expect(localRuntime.log).not.toHaveBeenCalled();
   });
 
-  it("preserves omitted defaults and forwards legal probe numeric values", async () => {
-    probeMocks.runAuthProbes.mockClear();
-    await modelsStatusCommand(
-      {
-        json: true,
-        probe: true,
-        probeTimeout: "1.5",
-        probeConcurrency: "1",
-        probeMaxTokens: "1",
-      },
-      createRuntime() as never,
-    );
-    expect(probeMocks.runAuthProbes).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        options: expect.objectContaining({
-          timeoutMs: 1.5,
-          concurrency: 1,
-          maxTokens: 1,
-        }),
-      }),
-    );
-
-    await modelsStatusCommand({ json: true, probe: true }, createRuntime() as never);
-    expect(probeMocks.runAuthProbes).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        options: expect.objectContaining({
-          timeoutMs: 8000,
-          concurrency: 2,
-          maxTokens: 8,
-        }),
-      }),
+  it.each([
+    [{}, { timeoutMs: 8000, concurrency: 2, maxTokens: 8 }],
+    [
+      { probeTimeout: "1.5", probeConcurrency: "1", probeMaxTokens: "1" },
+      { timeoutMs: 1.5, concurrency: 1, maxTokens: 1 },
+    ],
+  ])("forwards probe numeric options %j", async (opts, expected) => {
+    mocks.runAuthProbes.mockClear();
+    await modelsStatusCommand({ json: true, probe: true, ...opts }, createRuntime());
+    expect(mocks.runAuthProbes).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ options: expect.objectContaining(expected) }),
     );
   });
 


### PR DESCRIPTION
## What Problem This Solves

`channels logs --lines` and the three numeric `models status` probe options silently used their defaults when explicitly given an empty string. Whitespace-only values already failed validation.

Remove the three empty-string exemptions so the existing strict numeric parsers handle supplied values consistently. Omitted options keep their defaults. Consolidated regressions cover the log limit, rejection before probe dispatch, and numeric forwarding; the CLI references clarify accepted values. Production LOC is unchanged.

## Evidence

- Original production: four intended regression failures and twelve passing controls. Candidate owner and sibling suites: 257 passing tests. The retained reports were revalidated after correcting a proof-reader assumption about duplicate parameterized test titles; no tests were dropped or rerun. [Unit evidence](https://github.com/steipete/openclaw/actions/runs/34153109025).
- Changed checks, normal build, and all 18 real CLI cases passed, including exact errors for four empty and four whitespace inputs, unchanged defaults/valid values, fixture integrity, and process cleanup. [Completed proof](https://github.com/steipete/openclaw/actions/runs/34157120000).

Model status CLI checks used no provider probe. Numeric defaults and forwarding were tested separately at the mocked probe boundary. Required CI passed on head `484d205d8b6f5dc2f8e341af186af27080d7111e`. Its hosted checkout was synthetic merge `7ecdda9379b58f12f96579be74cbadf0217ad621`, combining that head with main `9c962dab44a3aac2c18095ed199517ddc680a9ca`. [CI](https://github.com/openclaw/openclaw/actions/runs/34162658761).

Maintainer review retains the documented input tightening: scripts requesting defaults must omit the numeric flag. The raw hosted reports, source hashes, CLI outputs and cleanup receipts were independently inspected by the repair owner and a separate verifier, addressing the bot reviewer’s artifact-access limitation.

Thanks @Alix-007 for the original fix.
