### PR TITLE
fix(discord): restore persona formatting and mentions after multiline code

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -308,6 +308,7 @@ Now create channels and start chatting. The agent sees the channel name, and eac
 
 - Gateway owns the Discord connection.
 - Reply routing is deterministic: Discord inbound replies back to Discord.
+- Bot replies and thread-bound persona replies share Markdown formatting, including CommonMark bold and configured table conversion.
 - Forwarded message snapshots reach the agent together with any accompanying caption. Forwarded text is not treated as a typed command; command classification uses only the sender’s own message text.
 - Discord guild/channel metadata is added to the model prompt as untrusted context, not as a user-visible reply prefix. If a model copies that envelope back, OpenClaw strips the copied metadata from outbound replies and from future replay context.
 - By default (`session.dmScope=main`), direct chats share the agent main session (`agent:main:main`).

--- a/extensions/discord/src/mentions.test.ts
+++ b/extensions/discord/src/mentions.test.ts
@@ -92,6 +92,21 @@ describe("rewriteDiscordKnownMentions", () => {
       expected: "inline `@alice` fence ```\n@alice\n``` text <@123456789>",
     },
     {
+      name: "closed multiline single-backtick code",
+      input: "Example: `first\nsecond`\nPlease review @alice",
+      expected: "Example: `first\nsecond`\nPlease review <@123456789>",
+    },
+    {
+      name: "closed multiline double-backtick code with CRLF",
+      input: "Example: ``first ` line\r\nsecond``\r\nPlease review @alice",
+      expected: "Example: ``first ` line\r\nsecond``\r\nPlease review <@123456789>",
+    },
+    {
+      name: "closed multiline code containing a longer backtick run",
+      input: "Example: ``first ``` literal\nsecond``\nPlease review @alice",
+      expected: "Example: ``first ``` literal\nsecond``\nPlease review <@123456789>",
+    },
+    {
       name: "unterminated single-backtick code",
       input: "outside @alice then `inside @alice",
       expected: "outside <@123456789> then `inside @alice",

--- a/extensions/discord/src/mentions.ts
+++ b/extensions/discord/src/mentions.ts
@@ -119,16 +119,13 @@ function countBacktickRun(text: string, index: number): number {
   return cursor - index;
 }
 
-function findSameLineBacktickRun(
-  text: string,
-  startIndex: number,
-  runLength: number,
-): number | null {
-  const delimiter = "`".repeat(runLength);
-  const newlineIndex = text.indexOf("\n", startIndex);
+function findInlineBacktickRun(text: string, startIndex: number, runLength: number): number | null {
+  // Inline spans can cross soft line breaks; fence-sized runs use the block scanner below.
+  const newlineIndex = runLength >= 3 ? text.indexOf("\n", startIndex) : -1;
   const lineEnd = newlineIndex === -1 ? text.length : newlineIndex;
-  const closeIndex = text.indexOf(delimiter, startIndex);
-  return closeIndex !== -1 && closeIndex < lineEnd ? closeIndex + runLength : null;
+  // A longer backtick run is literal code, not a matching inline delimiter.
+  const close = new RegExp("(?<!`)`{" + runLength + "}(?!`)").exec(text.slice(startIndex, lineEnd));
+  return close ? startIndex + close.index + runLength : null;
 }
 
 function findFenceEnd(text: string, startIndex: number, runLength: number): number {
@@ -164,7 +161,7 @@ function findNextMarkdownCodeSegment(
   return {
     startIndex: segmentStart,
     endIndex:
-      findSameLineBacktickRun(text, segmentStart + runLength, runLength) ??
+      findInlineBacktickRun(text, segmentStart + runLength, runLength) ??
       (runLength >= 3 ? findFenceEnd(text, segmentStart, runLength) : text.length),
   };
 }

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -93,6 +93,7 @@ async function maybeSendDiscordWebhookText(params: DiscordOutboundMessageContext
     replyTo: params.replyToId ?? undefined,
     username: truncateUtf16Safe(username, 80) || undefined,
     avatarUrl: normalizeOptionalString(params.identity?.avatarUrl),
+    tableMode: params.formatting?.tableMode,
     ...resolveDiscordDeliveryOptions(params),
   });
 }

--- a/extensions/discord/src/outbound-text.ts
+++ b/extensions/discord/src/outbound-text.ts
@@ -1,0 +1,28 @@
+import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
+import type { ResolvedDiscordAccount } from "./accounts.js";
+import { renderDiscordMarkdown } from "./markdown.js";
+import { rewriteDiscordKnownMentions } from "./mentions.js";
+
+export function prepareDiscordOutboundText(
+  text: string,
+  params: {
+    cfg: OpenClawConfig;
+    account: Pick<ResolvedDiscordAccount, "accountId" | "config">;
+    tableMode?: MarkdownTableMode;
+  },
+) {
+  const { account } = params;
+  const tableMode =
+    params.tableMode ??
+    resolveMarkdownTableMode({ cfg: params.cfg, channel: "discord", accountId: account.accountId });
+  const renderedText = renderDiscordMarkdown(text, tableMode);
+  // Both transports measure chunks after rendering and alias expansion; titles retain display names.
+  return {
+    renderedText,
+    textWithMentions: rewriteDiscordKnownMentions(renderedText, {
+      accountId: account.accountId,
+      mentionAliases: account.config.mentionAliases,
+    }),
+  };
+}

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -2,7 +2,6 @@ import type { APIChannel, APIGuildForumChannel, APIGuildMediaChannel } from "dis
 import { ChannelType } from "discord-api-types/v10";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import type { OutboundMediaAccess, PollInput } from "openclaw/plugin-sdk/media-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { resolveChunkMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
@@ -10,8 +9,8 @@ import type { RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { createChannelMessage, createThread, type RequestClient } from "./internal/discord.js";
-import { renderDiscordMarkdown } from "./markdown.js";
 import { rewriteDiscordKnownMentions } from "./mentions.js";
+import { prepareDiscordOutboundText } from "./outbound-text.js";
 import { parseAndResolveChannelRecipient } from "./recipient-resolution.js";
 import {
   createReusableDiscordReplyReference,
@@ -181,12 +180,6 @@ export async function sendMessageDiscord(
 ): Promise<DiscordSendResult> {
   const cfg = requireRuntimeConfig(opts.cfg, "Discord send");
   const { token, rest, request, account: accountInfo } = createDiscordClient({ ...opts, cfg });
-  const tableMode = resolveMarkdownTableMode({
-    cfg,
-    channel: "discord",
-    accountId: accountInfo.accountId,
-  });
-  const effectiveTableMode = opts.tableMode ?? tableMode;
   const chunkMode = opts.chunkMode ?? resolveChunkMode(cfg, "discord", accountInfo.accountId);
   const maxLinesPerMessage = opts.maxLinesPerMessage ?? accountInfo.config.maxLinesPerMessage;
   const suppressEmbeds = resolveDiscordSuppressEmbeds({
@@ -201,10 +194,10 @@ export async function sendMessageDiscord(
     typeof accountInfo.config.mediaMaxMb === "number"
       ? accountInfo.config.mediaMaxMb * 1024 * 1024
       : DEFAULT_DISCORD_MEDIA_MAX_MB * 1024 * 1024;
-  const renderedText = renderDiscordMarkdown(text ?? "", effectiveTableMode);
-  const textWithMentions = rewriteDiscordKnownMentions(renderedText, {
-    accountId: accountInfo.accountId,
-    mentionAliases: accountInfo.config.mentionAliases,
+  const { renderedText, textWithMentions } = prepareDiscordOutboundText(text ?? "", {
+    cfg,
+    account: accountInfo,
+    tableMode: opts.tableMode,
   });
   const recipient = await parseAndResolveChannelRecipient(to, cfg, accountInfo.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);

--- a/extensions/discord/src/send.webhook.chunk-limit.test.ts
+++ b/extensions/discord/src/send.webhook.chunk-limit.test.ts
@@ -67,6 +67,60 @@ describe("Discord webhook delivery", () => {
   });
 
   it.each([
+    {
+      label: "CommonMark bold",
+      text: "`__literal__` __Important__",
+      expected: "`__literal__` **Important**",
+      tableMode: undefined,
+    },
+    {
+      label: "configured table formatting",
+      text: "| A | B |\n| - | - |\n| x | y |",
+      expected: "```\n| A | B |\n| --- | --- |\n| x | y |\n```",
+      tableMode: undefined,
+    },
+    {
+      label: "explicit table formatting override",
+      text: "| A | B |\n| - | - |\n| x | y |",
+      expected: "| A | B |\n| - | - |\n| x | y |",
+      tableMode: "off" as const,
+    },
+    {
+      label: "prose mention after closed multiline code",
+      text: "Example: `first\nsecond`\nPlease review @alice",
+      expected: "Example: `first\nsecond`\nPlease review <@123456789>",
+      tableMode: undefined,
+    },
+  ])(
+    "preserves $label through bound-thread persona delivery",
+    async ({ text, expected, tableMode }) => {
+      mockDiscordBoundThreadManager(hoisted);
+      await withWebhookServer(
+        (_content, index) => ({ body: { id: String(index), channel_id: "thread-1" } }),
+        async (contents) => {
+          await discordOutbound.sendText?.({
+            cfg: {
+              channels: {
+                discord: {
+                  token: "Bot test-token",
+                  markdown: { tables: "code" },
+                  mentionAliases: { alice: "123456789" },
+                },
+              },
+            },
+            to: "channel:parent-1",
+            threadId: "thread-1",
+            text,
+            formatting: { tableMode },
+          });
+          expect(contents).toEqual([expected]);
+          expect(hoisted.sendMessageDiscordMock).not.toHaveBeenCalled();
+        },
+      );
+    },
+  );
+
+  it.each([
     { label: "reasoning", text: `Reasoning:\n_${"a".repeat(4000)}_`, aliases: undefined },
     {
       label: "expanded mention",

--- a/extensions/discord/src/send.webhook.ts
+++ b/extensions/discord/src/send.webhook.ts
@@ -1,7 +1,7 @@
 // Discord plugin module implements send.webhook behavior.
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
 import { recordOutboundMessageIdentity } from "openclaw/plugin-sdk/channel-outbound";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { buildTimeoutAbortSignal } from "openclaw/plugin-sdk/extension-shared";
 import {
@@ -19,7 +19,7 @@ import {
   readDiscordMessage,
   readRetryAfter,
 } from "./internal/rest-errors.js";
-import { rewriteDiscordKnownMentions } from "./mentions.js";
+import { prepareDiscordOutboundText } from "./outbound-text.js";
 import { DISCORD_REST_TIMEOUT_MS } from "./proxy-request-client.js";
 import { createDiscordRetryRunner, recordDiscordMessageCreateAmbiguity } from "./retry.js";
 import {
@@ -41,6 +41,7 @@ type DiscordWebhookSendOpts = {
   replyTo?: string;
   username?: string;
   avatarUrl?: string;
+  tableMode?: MarkdownTableMode;
   wait?: boolean;
   onPlatformSendDispatch?: () => Promise<void>;
   assertPlatformSendAuthorized?: () => void;
@@ -110,9 +111,10 @@ export async function sendWebhookMessageDiscord(
     cfg: opts.cfg,
     accountId: opts.accountId,
   });
-  const rewrittenText = rewriteDiscordKnownMentions(text, {
-    accountId: account.accountId,
-    mentionAliases: account.config.mentionAliases,
+  const { textWithMentions } = prepareDiscordOutboundText(text, {
+    cfg: opts.cfg,
+    account,
+    tableMode: opts.tableMode,
   });
   const flags = resolveDiscordMessageFlags({
     suppressEmbeds: resolveDiscordSuppressEmbeds({ configured: account.config.suppressEmbeds }),
@@ -143,7 +145,7 @@ export async function sendWebhookMessageDiscord(
   const request = createDiscordRetryRunner({ signal: deadline.signal });
   // Alias expansion happens after the outer delivery planner. Bound the actual
   // wire text here, retaining each accepted part before another can fail.
-  const chunks = chunkDiscordTextWithMode(rewrittenText, { maxLines: Number.MAX_SAFE_INTEGER });
+  const chunks = chunkDiscordTextWithMode(textWithMentions, { maxLines: Number.MAX_SAFE_INTEGER });
   const results: DiscordSendResult[] = [];
   try {
     for (const content of chunks.length ? chunks : [""]) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users receive different Markdown formatting when a Discord reply is sent through a thread-bound persona instead of the bot. CommonMark underscore-bold stays as Discord underline, and configured Markdown table conversion is skipped. It also fixes ordinary prose mentions remaining unresolved after a closed multiline inline-code span.

## Why This Change Was Made

Bot and webhook sends now share one text-preparation owner for account-specific table settings, Markdown rendering, and mention expansion before their existing transport chunking. Inline-code matching recognizes a complete matching backtick run across line breaks, including spans containing longer literal runs; existing unfinished-code handling and raw message-edit/thread-create contracts remain intact.

## User Impact

Replies use consistent formatting across bot and persona delivery, including explicit table-mode overrides. A known alias after a closed multiline code example becomes a Discord mention as expected, while aliases inside code remain literal.

## Evidence

- Before production edits, five new assertions failed on the original source: closed LF/CRLF code suppressed later aliases, and the real localhost webhook HTTP adapter emitted raw underscore-bold/table text and an unresolved prose alias. Existing controls passed.
- The captured webhook body changed from `__Important__` to `**Important**`; configured tables now use the same code-block conversion as bot sends. Explicit table-mode `off` and literal code remain covered.
- Final focused owner and real HTTP adapter suites: 124 tests passed. Adapter, raw-message, and explicit-thread sibling suites: 120 passed, with overlapping webhook coverage. The longer-literal-backtick case also has an immutable-source reproduction.
- Full `check:changed`, final production and extension-test TypeScript graphs, full-file lint/format, and `git diff --check` passed. Independent review was scoped-clean through P2.
- Integration onto current main preserved the exact reviewed production/test bytes and stable patch ID while retaining upstream documentation additions. Hosted checks will validate the published head.

The HTTP proof exercises the real outbound adapter and webhook sender against a localhost receiver with a synthetic thread binding; no live Discord account was used. Production changes are +21 lines for the shared preparation owner, with +69 test lines and one documentation line. No configuration, schema, or dependency was added.
