### PR TITLE
refactor(gateway): simplify provider usage cache keys

### DIFF
--- a/src/gateway/server-methods/models-auth-status-usage-cache.ts
+++ b/src/gateway/server-methods/models-auth-status-usage-cache.ts
@@ -53,37 +53,24 @@ export function clearModelAuthStatusUsageCache(): void {
   clearProviderUsageRuntimeSnapshot();
 }
 
-function providerUsageCacheKey(providerIds: readonly UsageProviderId[]): string {
-  return providerIds.toSorted().join("\0");
-}
-
 function scopeProviderUsageCredentialKey(
   credentialKey: string,
   providerIds: readonly UsageProviderId[],
 ): string {
   // models.authStatus fingerprints every direct provider. Scope that evidence to
   // this fetch set so usage.status can share the same credential-bound snapshot.
-  try {
-    // Produced only by fingerprintProviderUsageCredentials below, which always
-    // stringifies an object with a `direct` array; a parse failure returns the input.
-    // SAFETY: in-module producer guarantees this shape, and `direct` is re-checked.
-    const parsed = JSON.parse(credentialKey) as {
-      direct?: Array<[string, string | null]>;
-      [key: string]: unknown;
-    };
-    if (!Array.isArray(parsed.direct)) {
-      return credentialKey;
-    }
-    const providers = new Set(providerIds);
-    return JSON.stringify({
-      ...parsed,
-      direct: parsed.direct.filter(
-        ([provider, fingerprint]) => providers.has(provider) && fingerprint !== null,
-      ),
-    });
-  } catch {
-    return credentialKey;
-  }
+  // SAFETY: fingerprintProviderUsageCredentials always serializes this shape.
+  const parsed = JSON.parse(credentialKey) as {
+    direct: Array<[string, string | null]>;
+    [key: string]: unknown;
+  };
+  const providers = new Set(providerIds);
+  return JSON.stringify({
+    ...parsed,
+    direct: parsed.direct.filter(
+      ([provider, fingerprint]) => providers.has(provider) && fingerprint !== null,
+    ),
+  });
 }
 
 function mapProviderUsage(usage: Awaited<ReturnType<typeof loadProviderUsageSummary>>) {
@@ -213,7 +200,7 @@ type ProviderUsageCacheParams = {
 
 function resolveProviderUsageCacheRead(params: ProviderUsageCacheParams) {
   const providerIds = params.providerIds.toSorted();
-  const providerKey = providerUsageCacheKey(providerIds);
+  const providerKey = providerIds.join("\0");
   const credentialKey = scopeProviderUsageCredentialKey(params.credentialKey, providerIds);
   const cached = usageCacheByAgentId.get(params.agentId);
   const matching =


### PR DESCRIPTION
## What Problem This Solves

Provider usage caching repeats provider-key sorting and retains an internal serialized-key fallback that its runtime producer cannot reach. This is a production-deletion follow-up to #140869 and the #135868 split campaign.

## Why This Change Was Made

Build the provider key from the already-sorted provider list and consume the runtime owner's guaranteed JSON shape directly. Provider filtering, all fingerprint fields, refresh ownership, last-good retention, and the distinct immediate/blocking cold-read paths remain unchanged.

Deletion evidence:

- `resolveProviderUsageCacheRead` sorts the provider list before its sole call to `providerUsageCacheKey`, which sorted the same string array again. Joining the existing sorted array produces identical key bytes and keeps refresh order unchanged.
- Both production entry paths obtain `credentialKey` from `getProviderUsageRuntimeSnapshot`. Its sole producer, `fingerprintProviderUsageCredentials` in `provider-usage-runtime.ts`, always serializes an object containing a `direct` array. The key lives only in process memory; it is not a persisted format, public RPC input, or SDK input. The parser's catch/absent-array branches have no current runtime source. `git log -S` traces the helper to #115369 and the prepared producer to #125520; there is no compatibility reader to retain.
- The old comment incorrectly described the producer as in-module. The retained assertion comment names the actual producer invariant.

## User Impact

No supported behavior changes. `models.authStatus` remains immediate, and `usage.status` preserves its documented capability-dependent cold-read behavior.

## Evidence

The complete `models-auth-status.test.ts` and `usage.status-cache.test.ts` suites passed before and after: 2 files, 117 cases each, 32.63s → 30.99s. They retain credential-rotation invalidation, shared snapshots, config/plugin generations, timeout retention, and cold-read behavior. No tests or assertions were removed.

| Judged class | Added | Deleted | Net |
| --- | ---: | ---: | ---: |
| Production | 13 | 26 | −13 |
| Tests | 0 | 0 | 0 |
| Tooling | 0 | 0 | 0 |
| Docs | 0 | 0 | 0 |

The full `node scripts/check-changed.mjs` plan passed with exit 0, including core/test types, lint, dead exports, and all selected guards. Independent local and final branch autoreviews: scoped-clean, no actionable findings. The final rebase preserved the cache, its producer/callers, and the lockfile. No build boundary changed.
