### PR TITLE
fix(gateway): prevent systemd restarts from hanging

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1572,9 +1572,9 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it("treats SIGTERM with a restart intent as a draining restart", async () => {
+  it("exits after draining a SIGTERM restart intent without starting a successor", async () => {
     vi.clearAllMocks();
-    consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({});
+    consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({ reason: "gateway.restart" });
     createGatewayActiveWorkSnapshot
       .mockReturnValueOnce(
         createActiveWorkSnapshot({ activeTasks: 1 }, [
@@ -1584,57 +1584,33 @@ describe("runGatewayLoop", () => {
       .mockReturnValue(idleActiveWorkSnapshot);
 
     await withIsolatedSignals(async ({ captureSignal }) => {
-      const closeFirst = createCloseMock();
-      const closeSecond = createCloseMock();
+      const close = createCloseMock();
+      const { start, started } = createSignaledStart(close);
       const { runtime, exited } = createRuntimeWithExitSignal();
-      let resolveSecond: (() => void) | null = null;
-      const startedSecond = new Promise<void>((resolve) => {
-        resolveSecond = resolve;
-      });
-      const start = vi
-        .fn()
-        .mockResolvedValueOnce(createGatewayServer(closeFirst))
-        .mockImplementationOnce(async () => {
-          resolveSecond?.();
-          return createGatewayServer(closeSecond);
-        });
-      const { runGatewayLoop } = await import("./run-loop.js");
-      void runGatewayLoop({
-        start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
-        runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
-      });
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
-      const sigterm = captureSignal("SIGTERM");
-      const sigint = captureSignal("SIGINT");
+      const completeBoot = vi.fn();
+      await runLoopWithStart({ start, runtime, completeBoot });
+      await waitForStart(started);
+      captureSignal("SIGTERM")();
+      await waitForLoopCondition(
+        () => runtime.exit.mock.calls.length > 0 || start.mock.calls.length > 1,
+        "SIGTERM restart did not finish",
+      );
 
-      sigterm();
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
-
+      expect(start).toHaveBeenCalledOnce();
+      await expect(exited).resolves.toBe(0);
       expect(consumeGatewayRestartIntentPayloadSync).toHaveBeenCalledOnce();
       expect(waitForGatewayActiveWork).toHaveBeenCalledOnce();
       expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(
         DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS,
       );
-      expectRestartCloseCall(closeFirst, DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
-      await startedSecond;
-      expect(start).toHaveBeenCalledTimes(2);
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
+      expectRestartCloseCall(close, DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
+      expect(completeBoot).toHaveBeenCalledWith({
+        outcome: "planned_restart",
+        reason: "gateway.restart",
       });
-
-      sigint();
-      await expect(exited).resolves.toBe(0);
-      expect(closeSecond).toHaveBeenCalledWith({
-        reason: "gateway stopping",
-        restartExpectedMs: null,
-      });
+      expect(restartGatewayProcessWithFreshPid).not.toHaveBeenCalled();
+      expect(respawnGatewayProcessForUpdate).not.toHaveBeenCalled();
+      expect(acquireGatewayLock).toHaveBeenCalledOnce();
     });
   });
 
@@ -1653,7 +1629,6 @@ describe("runGatewayLoop", () => {
     await withIsolatedSignals(async ({ captureSignal }) => {
       const { start, exited } = await createSignaledLoopHarness();
       const sigterm = captureSignal("SIGTERM");
-      const sigint = captureSignal("SIGINT");
 
       sigterm();
       await new Promise<void>((resolve) => {
@@ -1665,9 +1640,8 @@ describe("runGatewayLoop", () => {
 
       expect(waitForGatewayActiveWork).toHaveBeenCalledOnce();
       expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(2_500);
-      expect(start).toHaveBeenCalledTimes(2);
+      expect(start).toHaveBeenCalledOnce();
 
-      sigint();
       await expect(exited).resolves.toBe(0);
     });
   });
@@ -1679,7 +1653,6 @@ describe("runGatewayLoop", () => {
     await withIsolatedSignals(async ({ captureSignal }) => {
       const { close, start, exited } = await createSignaledLoopHarness();
       const sigterm = captureSignal("SIGTERM");
-      const sigint = captureSignal("SIGINT");
 
       sigterm();
       await new Promise<void>((resolve) => {
@@ -1690,9 +1663,8 @@ describe("runGatewayLoop", () => {
       });
 
       expectRestartCloseCall(close, 315_000);
-      expect(start).toHaveBeenCalledTimes(2);
+      expect(start).toHaveBeenCalledOnce();
 
-      sigint();
       await expect(exited).resolves.toBe(0);
     });
   });
@@ -1718,7 +1690,6 @@ describe("runGatewayLoop", () => {
     await withIsolatedSignals(async ({ captureSignal }) => {
       const { close, start, exited } = await createSignaledLoopHarness();
       const sigterm = captureSignal("SIGTERM");
-      const sigint = captureSignal("SIGINT");
 
       sigterm();
       await vi.waitFor(() => expect(waitForGatewayActiveWork).toHaveBeenCalledOnce());
@@ -1730,13 +1701,11 @@ describe("runGatewayLoop", () => {
       expect(close).not.toHaveBeenCalled();
 
       releaseDrain?.();
-      await vi.waitFor(() => expect(start).toHaveBeenCalledTimes(2));
+      await expect(exited).resolves.toBe(0);
 
       expect(waitForGatewayActiveWork).toHaveBeenCalledWith(undefined, expect.any(Object));
       expectRestartCloseCall(close, 315_000);
-
-      sigint();
-      await expect(exited).resolves.toBe(0);
+      expect(start).toHaveBeenCalledOnce();
     });
   });
 
@@ -1756,7 +1725,6 @@ describe("runGatewayLoop", () => {
     await withIsolatedSignals(async ({ captureSignal }) => {
       const { close, start, exited } = await createSignaledLoopHarness();
       const sigterm = captureSignal("SIGTERM");
-      const sigint = captureSignal("SIGINT");
 
       sigterm();
       await new Promise<void>((resolve) => {
@@ -1774,9 +1742,8 @@ describe("runGatewayLoop", () => {
         "active-work drain timeout reached; proceeding with restart: embeddedRuns=1 activeTasks=1",
       );
       expectRestartCloseCall(close, DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
-      expect(start).toHaveBeenCalledTimes(2);
+      expect(start).toHaveBeenCalledOnce();
 
-      sigint();
       await expect(exited).resolves.toBe(0);
     });
   });
@@ -1833,7 +1800,6 @@ describe("runGatewayLoop", () => {
     await withIsolatedSignals(async ({ captureSignal }) => {
       const { close, start, exited } = await createSignaledLoopHarness();
       const sigterm = captureSignal("SIGTERM");
-      const sigint = captureSignal("SIGINT");
 
       sigterm();
       await new Promise<void>((resolve) => {
@@ -1852,9 +1818,8 @@ describe("runGatewayLoop", () => {
         "forced restart requested; skipping active work drain",
       );
       expectRestartCloseCall(close, 0);
-      expect(start).toHaveBeenCalledTimes(2);
+      expect(start).toHaveBeenCalledOnce();
 
-      sigint();
       await expect(exited).resolves.toBe(0);
     });
   });
@@ -2919,39 +2884,24 @@ describe("runGatewayLoop", () => {
     }
   });
 
-  it("carries SIGTERM restart intent reason into launchd supervised handoff", async () => {
+  it("leaves the successor to launchd after a SIGTERM restart intent", async () => {
     vi.clearAllMocks();
     consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({ reason: "gateway.restart" });
-    try {
-      setPlatform("darwin");
-      process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
-      restartGatewayProcessWithFreshPid.mockReturnValueOnce({
-        mode: "supervised",
-        handoffSpawned: Promise.resolve(true),
-      });
+    setPlatform("darwin");
+    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+    restartGatewayProcessWithFreshPid.mockReturnValueOnce({
+      mode: "supervised",
+      handoffSpawned: Promise.resolve(true),
+    });
 
-      await withIsolatedSignals(async ({ captureSignal }) => {
-        const { exited } = await createSignaledLoopHarness();
-        const sigterm = captureSignal("SIGTERM");
-
-        vi.useFakeTimers();
-        sigterm();
-        await vi.advanceTimersByTimeAsync(1500);
-
-        await expect(exited).resolves.toBe(0);
-        expectRestartHandoffCall({
-          restartKind: "full-process",
-          reason: "gateway.restart",
-          supervisorMode: "launchd",
-        });
-      });
-    } finally {
-      vi.useRealTimers();
-      delete process.env.OPENCLAW_LAUNCHD_LABEL;
-      if (originalPlatformDescriptor) {
-        Object.defineProperty(process, "platform", originalPlatformDescriptor);
-      }
-    }
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { start, exited } = await createSignaledLoopHarness();
+      captureSignal("SIGTERM")();
+      await expect(exited).resolves.toBe(0);
+      expect(start).toHaveBeenCalledOnce();
+      expect(restartGatewayProcessWithFreshPid).not.toHaveBeenCalled();
+      expect(respawnGatewayProcessForUpdate).not.toHaveBeenCalled();
+    });
   });
 
   it("records external ownership even when native supervisor markers are inherited", async () => {
@@ -3226,6 +3176,49 @@ describe("runGatewayLoop", () => {
       delete process.env.OPENCLAW_SUPERVISOR_MODE;
     }
   });
+
+  it.each(["update.run", "update.auto"])(
+    "keeps SIGTERM restart ownership when %s arrives during shutdown",
+    async (reason) => {
+      vi.clearAllMocks();
+      consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({ reason: "gateway.restart" });
+      peekGatewaySigusr1RestartReason.mockReturnValueOnce(reason);
+      const closing = createDeferred();
+      const close = vi.fn<GatewayCloseFn>(() => closing.promise);
+
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { start, started } = createSignaledStart(close);
+        const { runtime, exited } = createRuntimeWithExitSignal();
+        const completeBoot = vi.fn();
+        await runLoopWithStart({ start, runtime, completeBoot });
+        await waitForStart(started);
+        try {
+          captureSignal("SIGTERM")();
+          await waitForLoopCondition(() => close.mock.calls.length === 1, "close did not start");
+          captureSignal("SIGUSR1")();
+          await waitForLoopCondition(
+            () => markGatewaySigusr1RestartHandled.mock.calls.length === 1,
+            "update signal was not handled",
+          );
+          closing.resolve();
+          await waitForLoopCondition(
+            () => runtime.exit.mock.calls.length > 0 || start.mock.calls.length > 1,
+            "SIGTERM restart did not finish",
+          );
+          expect(start).toHaveBeenCalledOnce();
+          await expect(exited).resolves.toBe(0);
+          expect(completeBoot).toHaveBeenCalledWith({
+            outcome: "planned_restart",
+            reason: "gateway.restart",
+          });
+          expect(restartGatewayProcessWithFreshPid).not.toHaveBeenCalled();
+          expect(respawnGatewayProcessForUpdate).not.toHaveBeenCalled();
+        } finally {
+          closing.resolve();
+        }
+      });
+    },
+  );
 
   it("upgrades an accepted restart when an update arrives during shutdown", async () => {
     vi.clearAllMocks();

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -931,7 +931,10 @@ export async function runGatewayLoop(params: {
           } else {
             params.completeBoot?.(
               isRestart
-                ? { outcome: "planned_restart", reason: "gateway.restart.external" }
+                ? {
+                    outcome: "planned_restart",
+                    reason: acceptedRequest.restartReason ?? "gateway.restart.external",
+                  }
                 : {
                     outcome: shutdownFailed ? "forced_stop" : "clean_stop",
                     reason: shutdownFailed ? "gateway.stop_close_failed" : "gateway.stop",
@@ -1082,8 +1085,10 @@ export async function runGatewayLoop(params: {
     void (async () => {
       const { consumeGatewayRestartIntentPayloadSync } = await loadGatewayLifecycleRuntimeModule();
       const restartIntent = consumeGatewayRestartIntentPayloadSync();
+      // SIGTERM hands replacement to the caller (e.g. systemctl restart).
+      // Drain as a restart, then exit even when in-process respawn is configured.
       request(
-        restartIntent ? "restart" : "stop",
+        restartIntent ? "external-restart" : "stop",
         "SIGTERM",
         restartIntent?.reason,
         restartIntent ?? undefined,


### PR DESCRIPTION
Closes #140821. Thanks to @rboy1 for the report and @NianJiuZst for the repair.

## What Problem This Solves

`openclaw gateway restart` can leave a systemd-managed Gateway serving under its original process while systemd waits in `deactivating (stop-sigterm)`. This occurs when the running service has `OPENCLAW_NO_RESPAWN` enabled.

## Why This Change Was Made

Route SIGTERM with a valid restart intent through the existing external-restart action. It keeps the normal drain, force/wait settings, shutdown, and recorded reason, then exits so the service manager can create the successor. SIGUSR1 retains its existing internal-restart and managed-update ownership.

## User Impact

A managed restart finishes without waiting for the service stop timeout. A later update signal cannot replace the already accepted service-manager owner. Unit definitions, timeout defaults, restart policy, configuration, and stored intent format remain unchanged.

## Evidence

- Real Linux user-systemd proof used the public service install/start/restart commands, public Gateway readiness, and a bounded command automation. The unchanged generated unit inherited the existing no-respawn setting from its isolated user manager; this is a configured-condition reproduction.
- Pinned main `b1db51436d8f` drained the work and reopened its listener under the original process while systemd remained deactivating and the restart command stayed pending.
- Exact candidate `abb90c173d9a` drained, closed, and exited; systemd created a different ready process and the restart command completed successfully in six seconds. Ordinary public stop/start also passed.
- Three selected regressions failed on the pinned main because the server started twice instead of exiting. All 384 focused run-loop, service lifecycle, respawn, and systemd controls passed on the candidate, as did formatting, targeted lint, and its native runtime build.
- Independent source-blind validation passed all seven runtime checks: five managed restart modes (default, bounded wait, unbounded wait, timeout, and force), ordinary stop/start, and unmanaged SIGUSR1. Managed cases completed in 5–8 seconds; the unmanaged case retained its process. All test services, processes, and listeners were removed.
- Fresh independent source and security review found no actionable defect. Managed-update and other-platform behavior is supported by exact source and owner tests; Linux proof is not presented as native proof for those other platforms.

The candidate keeps its original source identity. Later main changes to process-lifetime retention and startup-maintenance handling were inspected separately and are not claimed as executed in the older candidate build. Required CI passed on the unchanged candidate in run 34380015339. The earlier plugin-config mock failures did not recur in fresh CI; their original cause remains unknown. A later SQLite timing assertion passed on the existing hosted retry route with unchanged source and assertions. No CI exception was used.
