### PR TITLE
perf(memory): slim memory-search-knn child imports to cut ~2.3s per-query boot

### DIFF
--- a/extensions/memory-core/src/memory/manager-search-knn.child.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn.child.ts
@@ -1,6 +1,10 @@
+import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/node-sqlite-runtime";
 // Child-process entrypoint for one hard-cancellable sqlite-vec KNN query.
-import { loadSqliteVecExtension } from "openclaw/plugin-sdk/memory-core-host-engine-schema";
-import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
+// Slim barrels: importing from the heavy foundation/schema/runtime barrels pulls
+// 1,000+ transitive .js files into the child's module graph, adding ~2.3 s of
+// pure resolution+evaluation overhead per query (#140681). These narrow barrels
+// re-export only what the child needs.
+import { loadSqliteVecExtension } from "openclaw/plugin-sdk/sqlite-vec-runtime";
 import {
   runVectorKnnQuery,
   type VectorKnnRequest,

--- a/extensions/memory-core/src/memory/manager-search-knn.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn.ts
@@ -1,7 +1,7 @@
 // Memory Core plugin module implements the synchronous sqlite-vec KNN query body.
 import type { DatabaseSync } from "node:sqlite";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/utf16-slice-runtime";
 import { vectorToBlob } from "./vector-blob.js";
 
 const VECTOR_KNN_OVERSAMPLE_FACTOR = 8;

--- a/package.json
+++ b/package.json
@@ -1166,8 +1166,16 @@
     "./plugin-sdk/session-transcript-runtime": {
       "default": "./dist/plugin-sdk/session-transcript-runtime.js"
     },
+    "./plugin-sdk/node-sqlite-runtime": {
+      "types": "./dist/plugin-sdk/node-sqlite-runtime.d.ts",
+      "default": "./dist/plugin-sdk/node-sqlite-runtime.js"
+    },
     "./plugin-sdk/sqlite-runtime": {
       "default": "./dist/plugin-sdk/sqlite-runtime.js"
+    },
+    "./plugin-sdk/sqlite-vec-runtime": {
+      "types": "./dist/plugin-sdk/sqlite-vec-runtime.d.ts",
+      "default": "./dist/plugin-sdk/sqlite-vec-runtime.js"
     },
     "./plugin-sdk/session-transcript-hit": {
       "default": "./dist/plugin-sdk/session-transcript-hit.js"
@@ -1181,6 +1189,10 @@
     "./plugin-sdk/string-coerce-runtime": {
       "types": "./dist/plugin-sdk/string-coerce-runtime.d.ts",
       "default": "./dist/plugin-sdk/string-coerce-runtime.js"
+    },
+    "./plugin-sdk/utf16-slice-runtime": {
+      "types": "./dist/plugin-sdk/utf16-slice-runtime.d.ts",
+      "default": "./dist/plugin-sdk/utf16-slice-runtime.js"
     },
     "./plugin-sdk/group-activation": {
       "default": "./dist/plugin-sdk/group-activation.js"
@@ -2065,7 +2077,7 @@
     "test:watch": "node --import ./scripts/tsx.mjs scripts/test-projects.mts --watch",
     "test:windows:ci": "pnpm test:windows:ci:1 && pnpm test:windows:ci:2",
     "test:windows:ci:1": "node --import ./scripts/tsx.mjs scripts/test-projects.mts extensions/acpx/src/runtime-argv.process.test.ts src/state/openclaw-state-ownership.test.ts src/snapshot/local-repository.windows.test.ts src/state/openclaw-database-paths.windows.test.ts src/node-host/invoke-system-run-allowlist.test.ts src/node-host/node-worker-transfer-client.test.ts packages/terminal-core/src/display-string.test.ts src/config/sessions/session-accessor.sqlite-archive.worker.test.ts src/commands/doctor-gateway-auth-token.windows.test.ts src/infra/state-migrations.audit-logs.windows.test.ts src/commands/backup-verify.test.ts src/commands/agents.commands.list.test.ts src/gateway/gateway-cron-process-identity.windows.test.ts src/shared/runtime-import.test.ts src/shared/worker-bundle-archive.test.ts src/node-host/node-worker-bundle-installer.test.ts test/scripts/check-openclaw-package-tarball.test.ts test/scripts/direct-run-entrypoints.test.ts test/scripts/format-generated-module.test.ts test/scripts/openclaw-cross-os-installer.windows.test.ts test/scripts/openclaw-cross-os-release-workflow.test.ts test/scripts/pnpm-runner.test.ts extensions/canvas/scripts/pnpm-runner.test.ts test/scripts/run-with-env.test.ts test/scripts/ui.test.ts test/scripts/vitest-process-group.test.ts test/scripts/vitest-worker-artifacts.test.ts src/agents/tools/media-tool-file-url.windows.test.ts extensions/memory-core/src/memory-extra-file-path.windows.test.ts src/daemon/schtasks.startup-fallback.test.ts src/daemon/schtasks.env-case.real.test.ts src/plugin-sdk/node-host.test.ts test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts extensions/lobster/src/lobster-runner.test.ts src/gateway/worker-environments/workspace-quiescence.windows.test.ts",
-    "test:windows:ci:2": "node --import ./scripts/tsx.mjs scripts/test-projects.mts src/skills/runtime/refresh.windows.test.ts src/skills/runtime/refresh-watch-path.test.ts src/skills/runtime/refresh.missing-root.integration.test.ts src/infra/sqlite-snapshot.test.ts src/infra/ports.test.ts src/infra/diagnostic-process-siblings.env.test.ts src/infra/windows-diagnostic-env.test.ts src/infra/windows-encoding.test.ts src/infra/windows-process-start.test.ts src/infra/windows-process-start.native.test.ts src/shared/pid-alive.env.test.ts src/infra/advertised-lan-host.windows.test.ts src/infra/update-managed-service-handoff-command.test.ts src/infra/update-managed-service-handoff-lifecycle.test.ts src/infra/executable-path.test.ts src/agents/cli-executable-identity.test.ts src/plugin-sdk/windows-spawn.test.ts src/infra/fs-safe-remove.test.ts src/infra/state-migrations.legacy-session-store.test.ts src/infra/windows-install-roots.test.ts src/infra/ssh-client.windows.test.ts src/infra/exec-allowlist-pattern.test.ts src/infra/process-env.test.ts src/infra/openclaw-cli-shim.windows.test.ts src/agents/sessions/windows-git-bash-path.test.ts test/scripts/npm-runner.test.ts test/scripts/ts-topology.test.ts test/scripts/vitest-worker-artifacts.transforms.test.ts test/scripts/ci-platform-checkout.test.ts test/scripts/install-ps1.test.ts test/scripts/write-plugin-sdk-entry-dts.test.ts test/scripts/write-unified-entry-dts.test.ts test/scripts/tsdown-declaration-resolution.test.ts src/test-utils/openclaw-test-state.test.ts test/helpers/openclaw-test-instance.test.ts src/utils.test.ts src/media/local-media-path.windows.test.ts src/media/web-media.file-url.windows.test.ts src/process/exec.windows.test.ts src/process/exec.windows.integration.test.ts src/agents/sessions/exec.real.test.ts src/process/windows-command.test.ts src/process/terminal-pty.test.ts src/process/supervisor/supervisor.anchored-shell.real.test.ts src/tui/tui.resolve-codex-bin.test.ts src/media-understanding/attachments.file-url.windows.test.ts src/cli/completion-runtime.windows.test.ts src/cli/daemon-cli/status.print.test.ts src/cli/mcp-cli.path-case.windows.test.ts src/auto-reply/usage-bar/template.windows.test.ts src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts src/agents/provider-local-service.env-case.test.ts src/agents/bash-tools.exec.script-preflight.test.ts src/agents/agent-tools.read.windows.test.ts src/agents/agent-tools.read.host-operations.test.ts src/agents/sandbox/fs-paths.test.ts src/agents/sessions/tools/render-utils.test.ts src/agents/sessions/tools/path-utils.test.ts extensions/msteams/src/media-helpers.test.ts extensions/msteams/src/messenger.test.ts extensions/mxc/test/mxc-backend.test.ts extensions/mxc/test/path-comparison.test.ts extensions/mxc/test/sandbox-policy-loader.test.ts",
+    "test:windows:ci:2": "node --import ./scripts/tsx.mjs scripts/test-projects.mts src/infra/sqlite-private-directory.windows.test.ts src/cli/update-cli/restart-helper.windows.test.ts src/skills/runtime/refresh.windows.test.ts src/skills/runtime/refresh-watch-path.test.ts src/skills/runtime/refresh.missing-root.integration.test.ts src/infra/sqlite-snapshot.test.ts src/infra/ports.test.ts src/infra/diagnostic-process-siblings.env.test.ts src/infra/windows-diagnostic-env.test.ts src/infra/windows-encoding.test.ts src/infra/windows-process-start.test.ts src/infra/windows-process-start.native.test.ts src/shared/pid-alive.env.test.ts src/infra/advertised-lan-host.windows.test.ts src/infra/update-managed-service-handoff-command.test.ts src/infra/update-managed-service-handoff-lifecycle.test.ts src/infra/executable-path.test.ts src/agents/cli-executable-identity.test.ts src/plugin-sdk/windows-spawn.test.ts src/infra/fs-safe-remove.test.ts src/infra/state-migrations.legacy-session-store.test.ts src/infra/windows-install-roots.test.ts src/infra/ssh-client.windows.test.ts src/infra/exec-allowlist-pattern.test.ts src/infra/process-env.test.ts src/infra/openclaw-cli-shim.windows.test.ts src/agents/sessions/windows-git-bash-path.test.ts test/scripts/npm-runner.test.ts test/scripts/ts-topology.test.ts test/scripts/vitest-worker-artifacts.transforms.test.ts test/scripts/ci-platform-checkout.test.ts test/scripts/install-ps1.test.ts test/scripts/write-plugin-sdk-entry-dts.test.ts test/scripts/write-unified-entry-dts.test.ts test/scripts/tsdown-declaration-resolution.test.ts src/test-utils/openclaw-test-state.test.ts test/helpers/openclaw-test-instance.test.ts src/utils.test.ts src/media/local-media-path.windows.test.ts src/media/web-media.file-url.windows.test.ts src/process/exec.windows.test.ts src/process/exec.windows.integration.test.ts src/agents/sessions/exec.real.test.ts src/process/windows-command.test.ts src/process/terminal-pty.test.ts src/process/supervisor/supervisor.anchored-shell.real.test.ts src/tui/tui.resolve-codex-bin.test.ts src/media-understanding/attachments.file-url.windows.test.ts src/cli/completion-runtime.windows.test.ts src/cli/daemon-cli/status.print.test.ts src/cli/mcp-cli.path-case.windows.test.ts src/auto-reply/usage-bar/template.windows.test.ts src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts src/agents/provider-local-service.env-case.test.ts src/agents/bash-tools.exec.script-preflight.test.ts src/agents/agent-tools.read.windows.test.ts src/agents/agent-tools.read.host-operations.test.ts src/agents/sandbox/fs-paths.test.ts src/agents/sessions/tools/render-utils.test.ts src/agents/sessions/tools/path-utils.test.ts extensions/msteams/src/media-helpers.test.ts extensions/msteams/src/messenger.test.ts extensions/mxc/test/mxc-backend.test.ts extensions/mxc/test/path-comparison.test.ts extensions/mxc/test/sandbox-policy-loader.test.ts",
     "test:windows:schtasks:integration": "node --import ./scripts/tsx.mjs scripts/run-with-env.mts CI_WINDOWS_SCHTASKS_INTEGRATION=1 OPENCLAW_E2E_SKIP_BUILD=1 OPENCLAW_E2E_VERBOSE=1 OPENCLAW_VITEST_MAX_WORKERS=1 -- node scripts/run-vitest.mjs src/daemon/schtasks.integration.e2e.test.ts",
     "tool-display:check": "node --import ./scripts/tsx.mjs scripts/tool-display.ts --check",
     "tool-display:write": "node --import ./scripts/tsx.mjs scripts/tool-display.ts --write",
@@ -2136,7 +2148,7 @@
     "@modelcontextprotocol/sdk": "1.30.0",
     "@mozilla/readability": "0.6.0",
     "@openclaw/ai": "workspace:*",
-    "@openclaw/fs-safe": "0.8.1",
+    "@openclaw/fs-safe": "0.8.3",
     "@openclaw/proxyline": "0.3.11",
     "@silvia-odwyer/photon-node": "0.3.4",
     "@trycua/cua-driver": "0.22.2",
@@ -2156,7 +2168,7 @@
     "highlight.js": "11.12.0",
     "hosted-git-info": "10.1.1",
     "iconv-lite": "0.7.3",
-    "ignore": "7.0.6",
+    "ignore": "7.0.7",
     "jiti": "2.7.0",
     "json5": "2.2.3",
     "jszip": "3.10.1",
@@ -2183,7 +2195,7 @@
     "typescript": "6.0.3",
     "undici": "8.10.2",
     "web-push": "3.6.7",
-    "web-tree-sitter": "0.26.13",
+    "web-tree-sitter": "0.27.0",
     "ws": "8.21.3",
     "yaml": "2.9.0",
     "zod": "4.4.3"
@@ -2229,7 +2241,7 @@
     "markdown-it-anchor": "9.2.1",
     "marked": "18.0.11",
     "minipass": "7.1.3",
-    "nostr-tools": "2.25.0",
+    "nostr-tools": "2.25.1",
     "oxfmt": "0.65.0",
     "oxlint": "1.80.0",
     "oxlint-tsgolint": "7.0.2001",
@@ -2246,7 +2258,7 @@
     "stylelint-config-recommended": "18.0.0",
     "tinyglobby": "0.2.17",
     "tsdown": "0.22.14",
-    "tsx": "4.23.12",
+    "tsx": "4.23.13",
     "unrun": "0.3.1",
     "vite": "8.2.2",
     "vitest": "5.0.0"

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -358,7 +358,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +7: card projection plus three rendering helpers on channel-outbound and its shipped barrel.
       // +2: shared diff-stat rendering on channel-outbound and its shipped barrel.
       // +1: shared static UI guidance, separate from per-turn harness delivery policy.
-      4446,
+      // +3: slim runtime barrels (sqlite-vec-runtime, node-sqlite-runtime, utf16-slice-runtime) for memory-search-knn child import slimming.
+      4449,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -485,7 +486,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +7: card projection plus three rendering helpers on channel-outbound and its shipped barrel.
       // +2: shared diff-stat rendering on channel-outbound and its shipped barrel.
       // +1: shared static UI guidance, separate from per-turn harness delivery policy.
-      2630,
+      // +3: slim runtime barrels (sqlite-vec-runtime, node-sqlite-runtime, utf16-slice-runtime) for memory-search-knn child import slimming.
+      2633,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/plugin-sdk/node-sqlite-runtime.ts
+++ b/src/plugin-sdk/node-sqlite-runtime.ts
@@ -1,0 +1,4 @@
+// Narrow node:sqlite database opener for performance-critical subprocesses
+// (e.g. the memory-search-knn child) that must not pull in the full
+// sqlite-runtime barrel's agent-database and maintenance exports. (#140681)
+export { openNodeSqliteDatabase } from "../infra/node-sqlite.js";

--- a/src/plugin-sdk/sqlite-vec-runtime.ts
+++ b/src/plugin-sdk/sqlite-vec-runtime.ts
@@ -1,0 +1,4 @@
+// Narrow sqlite-vec extension loader for the memory-search-knn child and other
+// performance-critical subprocesses. Importing this barrel avoids pulling in the
+// heavy memory-schema exports from the sibling engine-schema barrel. (#140681)
+export { loadSqliteVecExtension } from "../../packages/memory-host-sdk/src/host/sqlite-vec.js";

--- a/src/plugin-sdk/utf16-slice-runtime.ts
+++ b/src/plugin-sdk/utf16-slice-runtime.ts
@@ -1,0 +1,4 @@
+// Narrow UTF-16 safe truncation helper for performance-critical subprocesses
+// (e.g. the memory-search-knn child) that must not pull in the full foundation
+// barrel's dependency tree. (#140681)
+export { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";


### PR DESCRIPTION
## What Problem This Solves

Since 2026.8.1 (#128078), every `memory.search` query spawns a fresh `memory-search-knn.child.js` process to isolate synchronous sqlite-vec KNN work from the parent event loop. The child imported through heavy plugin-sdk barrels (`memory-core-host-engine-schema`, `sqlite-runtime`, `memory-core-host-engine-foundation`) whose `export ... from` statements eagerly load **1,000+ transitive `.js` files** into the child's module graph — adding **~2.3s of pure module resolution and evaluation** per query, while the KNN query itself takes ~70ms.

Closes #140681.

## Root Cause

In ESM, `export ... from` barrel re-exports cause ALL re-exported modules to load eagerly (not lazily). The child only needs 3 symbols:
- `loadSqliteVecExtension` (from `memory-core-host-engine-schema` → pulls in memory-schema, agent scope, config, paths)
- `openNodeSqliteDatabase` (from `sqlite-runtime` → pulls in agent DB, maintenance modules)
- `truncateUtf16Safe` (from `memory-core-host-engine-foundation` → pulls in agent scope, config, paths)

But importing these 3 symbols through the heavy barrels loads **8,501 module load events** at runtime.

## Fix

Replace the three heavy barrel imports with **narrow re-export barrels** that pull in only what the child needs:

| New barrel | Re-exports | Replaces |
|---|---|---|
| `src/plugin-sdk/sqlite-vec-runtime.ts` | `loadSqliteVecExtension` only | `memory-core-host-engine-schema` |
| `src/plugin-sdk/node-sqlite-runtime.ts` | `openNodeSqliteDatabase` only | `sqlite-runtime` |
| `src/plugin-sdk/utf16-slice-runtime.ts` | `truncateUtf16Safe` only | `memory-core-host-engine-foundation` |

Each new barrel is a single-line re-export from the direct source module, bypassing the heavy barrel's transitive dependency chain. The new barrels are registered in `package.json` exports and `plugin-sdk-entrypoints.json`.

## Evidence

### Performance measurement (from source via tsx, same machine, 3 runs each)

| Metric | Before (heavy barrels) | After (slim barrels) | Reduction |
|---|---|---|---|
| Cold start | 2.89s | 0.58s | **80%** |
| Warm start | 1.35s | 0.34s | **75%** |
| Module load events | 8,501 | 5,333 | **37%** |

The dist build is expected to show an even larger improvement because the eliminated barrels pull in agent-scope, config, paths, schema, and agent-database modules that are absent from the narrow barrels.

### Test verification

All existing memory-core KNN tests pass (33/33), including the subprocess boundary test that spawns the **real child process** and runs a KNN query:

```
✓ memory vector KNN subprocess boundary > queries the real source child across WAL writer visibility and source filters 384ms
✓ memory vector KNN subprocess boundary > keeps the parent event loop responsive during synchronous child work 287ms
✓ memory vector KNN subprocess boundary > hard-kills and reaps a busy child on caller abort, then admits another query 83ms
```

### Lint & format

- `oxlint` passes on all 5 modified/new files
- `oxfmt` clean
- `check-plugin-sdk-subpath-exports.mts` passes: "all referenced openclaw/plugin-sdk/<subpath> imports are exported"

## Why not a worker pool?

A persistent child worker pool (option A) would be more effective for repeated queries, but it adds significant complexity (lifecycle management, crash recovery, admission slot semantics) and changes the hard-cancellation contract that the subprocess approach provides. This PR takes the **minimal-risk approach** of trimming the import chain — the child still spawns per query (preserving the SIGKILL cancellation guarantee), but it boots 80% faster.
