### PR TITLE
feat(cli): add --follow to channel logs

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -66,7 +66,8 @@ such as `discord-archive` do not match `discord`.
 
 Pass `--follow` to print the initial tail and poll for newly appended matching records.
 The cursor follows the configured log file and re-anchors after truncation or rolling-file
-rotation, so records already printed are not replayed. `--interval <ms>` controls the
+rotation, validating the current file generation before continuing; a reset may re-read the
+current tail. `--interval <ms>` controls the
 positive polling interval. Press Ctrl-C to stop cleanly. Follow-mode `--json` emits one
 compact JSON record per line (`meta`, `log`, or `notice`); without `--follow`, JSON output
 retains the one-shot object shape.

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -58,11 +58,18 @@ did not name.
 - `channels status`: `--channel <name>`, `--probe`, `--timeout <ms>` (default `10000`), `--json`
 - `channels capabilities`: `--channel <name>`, `--agent <id>`, `--account <id>` (requires `--channel`), `--target <dest>` (requires `--channel`), `--timeout <ms>` (default `10000`, capped at `30000`), `--json`
 - `channels resolve <entries...>`: `--channel <name>`, `--account <id>`, `--agent <id>`, `--kind <auto|user|group|channel>` (default `auto`), `--json`
-- `channels logs`: `--channel <name|all>` (default `all`), `--lines <n>` (default `200`), `--json`
+- `channels logs`: `--channel <name|all>` (default `all`), `--lines <n>` (default `200`), `--follow`, `--interval <ms>` (default `1000`), `--json`
 
 `channels logs --channel <name>` matches subsystem or module names rooted at `<name>`
 or `gateway/channels/<name>`, including slash-separated descendants. Similar names
 such as `discord-archive` do not match `discord`.
+
+Pass `--follow` to print the initial tail and poll for newly appended matching records.
+The cursor follows the configured log file and re-anchors after truncation or rolling-file
+rotation, so records already printed are not replayed. `--interval <ms>` controls the
+positive polling interval. Press Ctrl-C to stop cleanly. Follow-mode `--json` emits one
+compact JSON record per line (`meta`, `log`, or `notice`); without `--follow`, JSON output
+retains the one-shot object shape.
 
 `channels status --probe` is the live path: on a reachable gateway it runs per-account
 `probeAccount` and optional `auditAccount` checks, so output can include transport

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -131,8 +131,12 @@ To filter channel activity (WhatsApp/Telegram/etc), use:
 openclaw channels logs --channel whatsapp
 ```
 
-`--channel` defaults to `all`; `--lines <n>` (default 200) and `--json` are also
-available.
+`--channel` defaults to `all`; `--lines <n>` (default 200), `--follow`,
+`--interval <ms>` (default 1000), and `--json` are also available. `--follow` prints
+the initial tail, then polls the configured file for newly appended matching records.
+It preserves the channel filter across truncation and rolling-file rotation, and Ctrl-C
+stops the poll cleanly. Follow-mode `--json` emits compact line-delimited `meta`, `log`,
+and `notice` records; one-shot JSON keeps the existing object shape.
 
 ## Log formats
 

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -260,6 +260,8 @@ export async function registerChannelsCli(
     .description("Show recent channel logs from the gateway log file")
     .option("--channel <name>", `Channel (${formatCliChannelOptions(["all"])}; default: all)`)
     .option("--lines <n>", "Number of lines (default: 200)", "200")
+    .option("--follow", "Follow newly appended channel log lines", false)
+    .option("--interval <ms>", "Polling interval in ms (default: 1000)", "1000")
     .option("--json", "Output JSON", false)
     .action(async (opts) => {
       await runChannelsCommand(async () => {

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -1043,12 +1043,13 @@ export async function runPluginMarketplaceListCommand(
   }
 
   if (opts.json) {
-    return defaultRuntime.writeJson({
+    defaultRuntime.writeJson({
       source: result.sourceLabel,
       name: result.manifest.name,
       version: result.manifest.version,
       plugins: result.manifest.plugins,
     });
+    return;
   }
 
   if (result.manifest.plugins.length === 0) {

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -750,6 +750,53 @@ describe("channelsLogsCommand", () => {
     }
   });
 
+  it("keeps committed records anchored when an incomplete suffix shrinks", async () => {
+    vi.useFakeTimers();
+    try {
+      const complete = logLine({
+        module: "gateway/channels/slack/send",
+        message: "complete-before-suffix-repair",
+      });
+      const pending = logLine({
+        module: "gateway/channels/slack/send",
+        message: "pending-record-with-a-longer-suffix",
+      }).trimEnd();
+      const repaired = logLine({
+        module: "gateway/channels/slack/send",
+        message: "repaired",
+      });
+      await fs.writeFile(logPath, `${complete}${pending}`);
+
+      const follow = channelsLogsCommand(
+        { channel: "slack", follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
+      await vi.advanceTimersByTimeAsync(10);
+
+      await fs.writeFile(logPath, `${complete}${repaired}`);
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => {
+        expect(
+          runtime.log.mock.calls.some(([value]) => {
+            const record = JSON.parse(String(value));
+            return record.type === "log" && record.message === "repaired";
+          }),
+        ).toBe(true);
+      });
+      process.emit("SIGINT");
+      await follow;
+
+      const records = runtime.log.mock.calls.map(([value]) => JSON.parse(String(value)));
+      expect(
+        records.filter((record) => record.type === "log").map((record) => record.message),
+      ).toEqual(["complete-before-suffix-repair", "repaired"]);
+      expect(records.filter((record) => record.type === "notice")).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("waits quietly while the configured log file is absent", async () => {
     vi.useFakeTimers();
     try {

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -652,6 +652,36 @@ describe("channelsLogsCommand", () => {
     }
   });
 
+  it("does not replay after a metadata-only log update", async () => {
+    vi.useFakeTimers();
+    try {
+      await fs.writeFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: "before" }),
+      );
+      const follow = channelsLogsCommand(
+        { channel: "slack", follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
+
+      const timestamp = new Date("2026-01-01T00:00:00.000Z");
+      await fs.utimes(logPath, timestamp, timestamp);
+      await vi.advanceTimersByTimeAsync(10);
+
+      const records = runtime.log.mock.calls.map(([value]) => JSON.parse(String(value)));
+      expect(
+        records.filter((record) => record.type === "log").map((record) => record.message),
+      ).toEqual(["before"]);
+      expect(records.filter((record) => record.type === "notice")).toHaveLength(0);
+
+      process.emit("SIGINT");
+      await follow;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not replay a complete record while a trailing record is incomplete", async () => {
     vi.useFakeTimers();
     try {

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -750,53 +750,6 @@ describe("channelsLogsCommand", () => {
     }
   });
 
-  it("keeps committed records anchored when an incomplete suffix shrinks", async () => {
-    vi.useFakeTimers();
-    try {
-      const complete = logLine({
-        module: "gateway/channels/slack/send",
-        message: "complete-before-suffix-repair",
-      });
-      const pending = logLine({
-        module: "gateway/channels/slack/send",
-        message: "pending-record-with-a-longer-suffix",
-      }).trimEnd();
-      const repaired = logLine({
-        module: "gateway/channels/slack/send",
-        message: "repaired",
-      });
-      await fs.writeFile(logPath, `${complete}${pending}`);
-
-      const follow = channelsLogsCommand(
-        { channel: "slack", follow: true, interval: 10, json: true },
-        runtime,
-      );
-      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
-      await vi.advanceTimersByTimeAsync(10);
-
-      await fs.writeFile(logPath, `${complete}${repaired}`);
-      await vi.advanceTimersByTimeAsync(10);
-      await vi.waitFor(() => {
-        expect(
-          runtime.log.mock.calls.some(([value]) => {
-            const record = JSON.parse(String(value));
-            return record.type === "log" && record.message === "repaired";
-          }),
-        ).toBe(true);
-      });
-      process.emit("SIGINT");
-      await follow;
-
-      const records = runtime.log.mock.calls.map(([value]) => JSON.parse(String(value)));
-      expect(
-        records.filter((record) => record.type === "log").map((record) => record.message),
-      ).toEqual(["complete-before-suffix-repair", "repaired"]);
-      expect(records.filter((record) => record.type === "notice")).toHaveLength(0);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
   it("waits quietly while the configured log file is absent", async () => {
     vi.useFakeTimers();
     try {

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -788,11 +788,11 @@ describe("channelsLogsCommand", () => {
       );
       await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
 
-      armRace = true;
       await fs.appendFile(
         logPath,
         logLine({ module: "gateway/channels/slack/send", message: "pending" }),
       );
+      armRace = true;
       await vi.advanceTimersByTimeAsync(10);
       await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(5));
       expect(armedOpenCount).toBeGreaterThanOrEqual(4);
@@ -842,11 +842,11 @@ describe("channelsLogsCommand", () => {
       );
       await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
 
-      armRace = true;
       await fs.appendFile(
         logPath,
         logLine({ module: "gateway/channels/slack/send", message: "pending" }),
       );
+      armRace = true;
       await vi.advanceTimersByTimeAsync(10);
       await vi.waitFor(() => expect(runtime.log.mock.calls.length).toBeGreaterThanOrEqual(4));
       expect(armedOpenCount).toBeGreaterThanOrEqual(4);

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -381,6 +381,39 @@ describe("channelsLogsCommand", () => {
     }
   });
 
+  it("writes text follow output to stdout without re-entering the logger", async () => {
+    vi.useFakeTimers();
+    try {
+      await fs.writeFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: "text follow" }),
+      );
+      const writeStdout = vi.fn();
+      const followRuntime = {
+        ...runtime,
+        writeStdout,
+        writeJson: vi.fn(),
+      };
+      const follow = channelsLogsCommand(
+        { channel: "slack", follow: true, interval: 10 },
+        followRuntime,
+      );
+
+      await vi.waitFor(() => expect(writeStdout).toHaveBeenCalledTimes(3));
+      expect(writeStdout.mock.calls.map(([value]) => String(value))).toEqual([
+        expect.stringContaining("Log file:"),
+        expect.stringContaining("Channel: slack"),
+        "2026-04-25T12:00:00.000Z info text follow",
+      ]);
+      expect(runtime.log).not.toHaveBeenCalled();
+
+      process.emit("SIGINT");
+      await follow;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not replay a short file when an append grows its prefix", async () => {
     vi.useFakeTimers();
     try {
@@ -556,7 +589,7 @@ describe("channelsLogsCommand", () => {
         if (armRace && armedOpenCount === 4) {
           await fs.writeFile(
             logPath,
-            logLine({ module: "gateway/channels/slack/receive", message: newMessage }),
+            logLine({ module: "gateway/channels/slack/send", message: newMessage }),
           );
         }
         return realOpen(...args);
@@ -602,6 +635,38 @@ describe("channelsLogsCommand", () => {
       vi.spyOn(fs, "open").mockImplementation(async (...args) => {
         openCount += 1;
         if (openCount === 2) {
+          throw Object.assign(new Error("rotated away"), { code: "ENOENT" });
+        }
+        return realOpen(...args);
+      });
+
+      const follow = channelsLogsCommand(
+        { channel: "slack", follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log.mock.calls.length).toBeGreaterThanOrEqual(2));
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => expect(openCount).toBeGreaterThanOrEqual(4));
+
+      process.emit("SIGINT");
+      await expect(follow).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("continues following when the tail open races a file rotation", async () => {
+    vi.useFakeTimers();
+    try {
+      await fs.writeFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: "before" }),
+      );
+      const realOpen = fs.open.bind(fs);
+      let openCount = 0;
+      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        openCount += 1;
+        if (openCount === 4) {
           throw Object.assign(new Error("rotated away"), { code: "ENOENT" });
         }
         return realOpen(...args);

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -408,6 +408,39 @@ describe("channelsLogsCommand", () => {
     }
   });
 
+  it("grows the prefix fingerprint after starting with an empty file", async () => {
+    vi.useFakeTimers();
+    try {
+      await fs.writeFile(logPath, "");
+      const follow = channelsLogsCommand(
+        { lines: 1, follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(1));
+
+      const firstMessage = `aaaaa${"x".repeat(200)}`;
+      await fs.appendFile(logPath, logLine({ message: firstMessage }));
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
+
+      const replacementMessage = `bbbbb${"x".repeat(200)}`;
+      await fs.writeFile(logPath, logLine({ message: replacementMessage }));
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(4));
+
+      process.emit("SIGINT");
+      await follow;
+
+      const records = runtime.log.mock.calls.map(([value]) => JSON.parse(String(value)));
+      expect(
+        records.filter((record) => record.type === "log").map((record) => record.message),
+      ).toEqual([firstMessage, replacementMessage]);
+      expect(records.filter((record) => record.type === "notice")).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("re-anchors after a same-path replacement without replaying the old cursor", async () => {
     vi.useFakeTimers();
     try {
@@ -482,8 +515,13 @@ describe("channelsLogsCommand", () => {
       await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
 
       armRace = true;
+      await fs.appendFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: "pending" }),
+      );
       await vi.advanceTimersByTimeAsync(10);
       await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(5));
+      expect(armedOpenCount).toBeGreaterThanOrEqual(3);
 
       process.emit("SIGINT");
       await follow;
@@ -525,6 +563,71 @@ describe("channelsLogsCommand", () => {
 
       process.emit("SIGINT");
       await expect(follow).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("announces a newly resolved rolling file after a checkpoint disappears", async () => {
+    vi.useFakeTimers();
+    try {
+      const configuredFile = path.join(tempDir, "openclaw-2026-04-26.log");
+      const fallbackFile = path.join(tempDir, "openclaw-2026-04-25.log");
+      setLoggerOverride({ file: configuredFile });
+      await fs.writeFile(
+        fallbackFile,
+        logLine({ module: "gateway/channels/slack/send", message: "before" }),
+      );
+
+      const realOpen = fs.open.bind(fs);
+      let openCount = 0;
+      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        openCount += 1;
+        if (openCount === 2) {
+          throw Object.assign(new Error("rotated away"), { code: "ENOENT" });
+        }
+        return realOpen(...args);
+      });
+
+      const follow = channelsLogsCommand(
+        { channel: "slack", follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => {
+        expect(openCount).toBeGreaterThanOrEqual(2);
+        expect(
+          runtime.log.mock.calls.some(([value]) => {
+            const record = JSON.parse(String(value));
+            return record.type === "log" && record.message === "before";
+          }),
+        ).toBe(true);
+      });
+      expect(
+        runtime.log.mock.calls.some(([value]) => {
+          const record = JSON.parse(String(value));
+          return record.type === "meta" && record.file === fallbackFile;
+        }),
+      ).toBe(true);
+      runtime.log.mockClear();
+
+      await fs.rm(fallbackFile);
+      await fs.writeFile(
+        configuredFile,
+        logLine({ module: "gateway/channels/slack/send", message: "after" }),
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(3));
+
+      process.emit("SIGINT");
+      await follow;
+
+      const records = runtime.log.mock.calls.map(([value]) => JSON.parse(String(value)));
+      expect(
+        records.filter((record) => record.type === "meta").map((record) => record.file),
+      ).toEqual([configuredFile]);
+      expect(
+        records.filter((record) => record.type === "log").map((record) => record.message),
+      ).toEqual(["after"]);
     } finally {
       vi.useRealTimers();
     }

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -339,4 +339,87 @@ describe("channelsLogsCommand", () => {
       "--lines must be a positive integer.",
     );
   });
+
+  it("follows appended matching records without replaying the initial tail", async () => {
+    vi.useFakeTimers();
+    try {
+      await fs.writeFile(
+        logPath,
+        [
+          logLine({ module: "gateway/channels/slack/send", message: "existing" }),
+          logLine({ module: "gateway/health", message: "unrelated" }),
+        ].join(""),
+      );
+
+      const follow = channelsLogsCommand(
+        { channel: "slack", lines: 1, follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
+
+      await fs.appendFile(
+        logPath,
+        [
+          logLine({ module: "gateway/health", message: "ignored" }),
+          logLine({ module: "gateway/channels/slack/receive", message: "appended" }),
+          logLine({ module: "gateway/channels/slack/receive", message: "appended-second" }),
+        ].join(""),
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(4));
+
+      process.emit("SIGINT");
+      await follow;
+
+      const records = runtime.log.mock.calls.map(([value]) => JSON.parse(String(value)));
+      expect(
+        records.filter((record) => record.type === "log").map((record) => record.message),
+      ).toEqual(["existing", "appended", "appended-second"]);
+      expect(records.some((record) => record.message === "ignored")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-anchors after a same-path replacement without replaying the old cursor", async () => {
+    vi.useFakeTimers();
+    try {
+      await fs.writeFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: "before" }),
+      );
+      const follow = channelsLogsCommand(
+        { channel: "slack", follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
+
+      await fs.writeFile(
+        logPath,
+        [
+          logLine({ module: "gateway/channels/slack/send", message: "new-first" }),
+          logLine({ module: "gateway/channels/slack/send", message: "new-second" }),
+        ].join(""),
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(5));
+
+      process.emit("SIGINT");
+      await follow;
+
+      const records = runtime.log.mock.calls.map(([value]) => JSON.parse(String(value)));
+      expect(
+        records.filter((record) => record.type === "log").map((record) => record.message),
+      ).toEqual(["before", "new-first", "new-second"]);
+      expect(records.filter((record) => record.type === "notice")).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects invalid follow intervals", async () => {
+    await expect(
+      channelsLogsCommand({ follow: true, interval: "0", json: true }, runtime),
+    ).rejects.toThrow("--interval must be a positive integer.");
+  });
 });

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -381,6 +381,52 @@ describe("channelsLogsCommand", () => {
     }
   });
 
+  it("advances past an oversized record and keeps filtered follow progress", async () => {
+    vi.useFakeTimers();
+    try {
+      await fs.writeFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: "existing" }),
+      );
+
+      const follow = channelsLogsCommand(
+        { channel: "slack", lines: 1, follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
+
+      await fs.appendFile(
+        logPath,
+        [
+          logLine({
+            module: "gateway/channels/slack/send",
+            message: "x".repeat(1_000_100),
+          }),
+          logLine({ module: "gateway/health", message: "ignored-after-oversized" }),
+          logLine({ module: "gateway/channels/slack/receive", message: "after-oversized" }),
+        ].join(""),
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(3));
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(4));
+
+      process.emit("SIGINT");
+      await follow;
+
+      const records = runtime.log.mock.calls.map(([value]) => JSON.parse(String(value)));
+      expect(
+        records.filter((record) => record.type === "log").map((record) => record.message),
+      ).toEqual(["existing", "after-oversized"]);
+      expect(records.filter((record) => record.type === "notice")).toEqual([
+        { type: "notice", message: "Log tail truncated; earlier entries were omitted." },
+      ]);
+      expect(JSON.stringify(records)).not.toContain("ignored-after-oversized");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("writes text follow output to stdout without re-entering the logger", async () => {
     vi.useFakeTimers();
     try {

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -536,6 +536,60 @@ describe("channelsLogsCommand", () => {
     }
   });
 
+  it("re-anchors after a same-path rewrite preserves the file prefix during checkpointing", async () => {
+    vi.useFakeTimers();
+    try {
+      const oldMessage = `${"x".repeat(200)}-old`;
+      const newMessage = `${"x".repeat(200)}-new`;
+      await fs.writeFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: oldMessage }),
+      );
+
+      const realOpen = fs.open.bind(fs);
+      let armRace = false;
+      let armedOpenCount = 0;
+      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        if (armRace) {
+          armedOpenCount += 1;
+        }
+        if (armRace && armedOpenCount === 4) {
+          await fs.writeFile(
+            logPath,
+            logLine({ module: "gateway/channels/slack/receive", message: newMessage }),
+          );
+        }
+        return realOpen(...args);
+      });
+
+      const follow = channelsLogsCommand(
+        { channel: "slack", follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
+
+      armRace = true;
+      await fs.appendFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: "pending" }),
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => expect(runtime.log.mock.calls.length).toBeGreaterThanOrEqual(4));
+      expect(armedOpenCount).toBeGreaterThanOrEqual(4);
+
+      process.emit("SIGINT");
+      await follow;
+
+      const records = runtime.log.mock.calls.map(([value]) => JSON.parse(String(value)));
+      expect(
+        records.filter((record) => record.type === "log").map((record) => record.message),
+      ).toEqual([oldMessage, newMessage]);
+      expect(records.filter((record) => record.type === "notice")).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("continues following when a file disappears during checkpointing", async () => {
     vi.useFakeTimers();
     try {

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -581,6 +581,44 @@ describe("channelsLogsCommand", () => {
     }
   });
 
+  it("re-anchors after same-path truncate/regrow with matching edge samples", async () => {
+    vi.useFakeTimers();
+    try {
+      const oldMessage = `${"x".repeat(200)}-old`;
+      const newMessage = `${"x".repeat(200)}-new`;
+      await fs.writeFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: oldMessage }),
+      );
+      const follow = channelsLogsCommand(
+        { channel: "slack", follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
+
+      await fs.writeFile(
+        logPath,
+        [
+          logLine({ module: "gateway/channels/slack/send", message: newMessage }),
+          logLine({ module: "gateway/channels/slack/send", message: "new-second" }),
+        ].join(""),
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(5));
+
+      process.emit("SIGINT");
+      await follow;
+
+      const records = runtime.log.mock.calls.map(([value]) => JSON.parse(String(value)));
+      expect(
+        records.filter((record) => record.type === "log").map((record) => record.message),
+      ).toEqual([oldMessage, newMessage, "new-second"]);
+      expect(records.filter((record) => record.type === "notice")).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps the cursor stable while a poll observes an append", async () => {
     vi.useFakeTimers();
     try {

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -510,6 +510,143 @@ describe("channelsLogsCommand", () => {
     }
   });
 
+  it("re-anchors after a same-size rewrite between polls", async () => {
+    vi.useFakeTimers();
+    try {
+      const oldMessage = `${"x".repeat(200)}-old`;
+      const newMessage = `${"x".repeat(200)}-new`;
+      await fs.writeFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: oldMessage }),
+      );
+      const follow = channelsLogsCommand(
+        { channel: "slack", follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
+
+      await fs.writeFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: newMessage }),
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(4));
+
+      process.emit("SIGINT");
+      await follow;
+
+      const records = runtime.log.mock.calls.map(([value]) => JSON.parse(String(value)));
+      expect(
+        records.filter((record) => record.type === "log").map((record) => record.message),
+      ).toEqual([oldMessage, newMessage]);
+      expect(records.filter((record) => record.type === "notice")).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the cursor stable while a poll observes an append", async () => {
+    vi.useFakeTimers();
+    try {
+      await fs.writeFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: "before" }),
+      );
+      const follow = channelsLogsCommand(
+        { channel: "slack", follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
+
+      await fs.appendFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: "appended" }),
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(3));
+
+      process.emit("SIGINT");
+      await follow;
+
+      const records = runtime.log.mock.calls.map(([value]) => JSON.parse(String(value)));
+      expect(
+        records.filter((record) => record.type === "log").map((record) => record.message),
+      ).toEqual(["before", "appended"]);
+      expect(records.filter((record) => record.type === "notice")).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not replay a complete record while a trailing record is incomplete", async () => {
+    vi.useFakeTimers();
+    try {
+      const complete = logLine({ module: "gateway/channels/slack/send", message: "complete" });
+      const partial = logLine({
+        module: "gateway/channels/slack/send",
+        message: "pending",
+      }).trimEnd();
+      await fs.writeFile(logPath, `${complete}${partial}`);
+
+      const follow = channelsLogsCommand(
+        { channel: "slack", follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
+      await vi.advanceTimersByTimeAsync(30);
+
+      const records = runtime.log.mock.calls.map(([value]) => JSON.parse(String(value)));
+      expect(
+        records.filter((record) => record.type === "log").map((record) => record.message),
+      ).toEqual(["complete"]);
+      expect(records.filter((record) => record.type === "notice")).toHaveLength(0);
+
+      process.emit("SIGINT");
+      await follow;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits quietly while the configured log file is absent", async () => {
+    vi.useFakeTimers();
+    try {
+      const missingPath = path.join(tempDir, "missing.log");
+      setLoggerOverride({ file: missingPath });
+      const follow = channelsLogsCommand(
+        { channel: "slack", follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(1));
+      await vi.advanceTimersByTimeAsync(30);
+
+      expect(
+        runtime.log.mock.calls
+          .map(([value]) => JSON.parse(String(value)))
+          .filter((record) => record.type === "notice"),
+      ).toHaveLength(0);
+
+      await fs.writeFile(
+        missingPath,
+        logLine({ module: "gateway/channels/slack/send", message: "appeared" }),
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => {
+        expect(
+          runtime.log.mock.calls.some(([value]) => {
+            const record = JSON.parse(String(value));
+            return record.type === "log" && record.message === "appeared";
+          }),
+        ).toBe(true);
+      });
+
+      process.emit("SIGINT");
+      await follow;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("re-anchors when a file changes between reading and checkpointing", async () => {
     vi.useFakeTimers();
     try {

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -501,7 +501,7 @@ describe("channelsLogsCommand", () => {
         if (armRace) {
           armedOpenCount += 1;
         }
-        if (armRace && armedOpenCount === 3) {
+        if (armRace && armedOpenCount === 4) {
           await fs.rename(logPath, oldPath);
           await fs.rename(replacementPath, logPath);
         }
@@ -521,7 +521,7 @@ describe("channelsLogsCommand", () => {
       );
       await vi.advanceTimersByTimeAsync(10);
       await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(5));
-      expect(armedOpenCount).toBeGreaterThanOrEqual(3);
+      expect(armedOpenCount).toBeGreaterThanOrEqual(4);
 
       process.emit("SIGINT");
       await follow;

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -414,6 +414,44 @@ describe("channelsLogsCommand", () => {
     }
   });
 
+  it("waits for stdout drain before emitting the next follow record", async () => {
+    vi.useFakeTimers();
+    try {
+      await fs.writeFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: "backpressure" }),
+      );
+      let blocked = true;
+      const writeJson = vi.fn(() => {
+        if (blocked) {
+          blocked = false;
+          return false;
+        }
+        return true;
+      });
+      const followRuntime = {
+        ...runtime,
+        writeStdout: vi.fn(),
+        writeJson,
+      };
+      const follow = channelsLogsCommand(
+        { channel: "slack", follow: true, interval: 10, json: true },
+        followRuntime,
+      );
+
+      await vi.waitFor(() => expect(writeJson).toHaveBeenCalledTimes(1));
+      expect(writeJson.mock.calls).toHaveLength(1);
+
+      process.stdout.emit("drain");
+      await vi.waitFor(() => expect(writeJson).toHaveBeenCalledTimes(2));
+
+      process.emit("SIGINT");
+      await follow;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not replay a short file when an append grows its prefix", async () => {
     vi.useFakeTimers();
     try {

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -510,6 +510,42 @@ describe("channelsLogsCommand", () => {
     }
   });
 
+  it("keeps a partial replacement anchored to one generation", async () => {
+    vi.useFakeTimers();
+    try {
+      await fs.writeFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: "before" }),
+      );
+      const follow = channelsLogsCommand(
+        { channel: "slack", follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
+
+      await fs.writeFile(
+        logPath,
+        `${logLine({ module: "gateway/channels/slack/send", message: "new-first" })}${logLine({
+          module: "gateway/channels/slack/send",
+          message: "new-partial",
+        }).trimEnd()}`,
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(4));
+      await vi.advanceTimersByTimeAsync(10);
+
+      const records = runtime.log.mock.calls.map(([value]) => JSON.parse(String(value)));
+      expect(
+        records.filter((record) => record.type === "log").map((record) => record.message),
+      ).toEqual(["before", "new-first"]);
+
+      process.emit("SIGINT");
+      await follow;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("re-anchors after a same-size rewrite between polls", async () => {
     vi.useFakeTimers();
     try {

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -381,6 +381,33 @@ describe("channelsLogsCommand", () => {
     }
   });
 
+  it("does not replay a short file when an append grows its prefix", async () => {
+    vi.useFakeTimers();
+    try {
+      await fs.writeFile(logPath, '{"0":"first"}\n');
+      const follow = channelsLogsCommand(
+        { lines: 1, follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
+
+      await fs.appendFile(logPath, '{"0":"second"}\n');
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(3));
+
+      process.emit("SIGINT");
+      await follow;
+
+      const records = runtime.log.mock.calls.map(([value]) => JSON.parse(String(value)));
+      expect(
+        records.filter((record) => record.type === "log").map((record) => record.message),
+      ).toEqual(["first", "second"]);
+      expect(records.some((record) => record.type === "notice")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("re-anchors after a same-path replacement without replaying the old cursor", async () => {
     vi.useFakeTimers();
     try {
@@ -417,9 +444,101 @@ describe("channelsLogsCommand", () => {
     }
   });
 
+  it("re-anchors when a file changes between reading and checkpointing", async () => {
+    vi.useFakeTimers();
+    try {
+      const replacementPath = path.join(tempDir, "replacement.log");
+      const oldPath = path.join(tempDir, "old.log");
+      await fs.writeFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: "before" }),
+      );
+      await fs.writeFile(
+        replacementPath,
+        [
+          logLine({ module: "gateway/channels/slack/send", message: "new-first" }),
+          logLine({ module: "gateway/channels/slack/send", message: "new-second" }),
+        ].join(""),
+      );
+
+      const realOpen = fs.open.bind(fs);
+      let armRace = false;
+      let armedOpenCount = 0;
+      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        if (armRace) {
+          armedOpenCount += 1;
+        }
+        if (armRace && armedOpenCount === 3) {
+          await fs.rename(logPath, oldPath);
+          await fs.rename(replacementPath, logPath);
+        }
+        return realOpen(...args);
+      });
+
+      const follow = channelsLogsCommand(
+        { channel: "slack", follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(2));
+
+      armRace = true;
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => expect(runtime.log).toHaveBeenCalledTimes(5));
+
+      process.emit("SIGINT");
+      await follow;
+
+      const records = runtime.log.mock.calls.map(([value]) => JSON.parse(String(value)));
+      expect(
+        records.filter((record) => record.type === "log").map((record) => record.message),
+      ).toEqual(["before", "new-first", "new-second"]);
+      expect(records.filter((record) => record.type === "notice")).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("continues following when a file disappears during checkpointing", async () => {
+    vi.useFakeTimers();
+    try {
+      await fs.writeFile(
+        logPath,
+        logLine({ module: "gateway/channels/slack/send", message: "before" }),
+      );
+      const realOpen = fs.open.bind(fs);
+      let openCount = 0;
+      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        openCount += 1;
+        if (openCount === 2) {
+          throw Object.assign(new Error("rotated away"), { code: "ENOENT" });
+        }
+        return realOpen(...args);
+      });
+
+      const follow = channelsLogsCommand(
+        { channel: "slack", follow: true, interval: 10, json: true },
+        runtime,
+      );
+      await vi.waitFor(() => expect(runtime.log.mock.calls.length).toBeGreaterThanOrEqual(2));
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.waitFor(() => expect(openCount).toBeGreaterThanOrEqual(4));
+
+      process.emit("SIGINT");
+      await expect(follow).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("rejects invalid follow intervals", async () => {
     await expect(
       channelsLogsCommand({ follow: true, interval: "0", json: true }, runtime),
     ).rejects.toThrow("--interval must be a positive integer.");
+  });
+
+  it("rejects follow intervals beyond the timer limit", async () => {
+    await expect(
+      channelsLogsCommand({ follow: true, interval: "2147483648", json: true }, runtime),
+    ).rejects.toThrow("--interval must be no greater than 2147483647 milliseconds.");
   });
 });

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -383,6 +383,18 @@ async function followChannelLogs(
         reanchored = true;
       }
 
+      if (tail.generationStable === false) {
+        try {
+          await delay(interval, undefined, { signal: controller.signal });
+        } catch (error) {
+          if (controller.signal.aborted) {
+            return;
+          }
+          throw error;
+        }
+        continue;
+      }
+
       if (!reanchored && previousGeneration !== undefined && previousCheckpoint !== undefined) {
         const postReadGeneration = await readFileCheckpoint(
           tail.file,

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -149,24 +149,98 @@ function parseIntervalOption(value: unknown): number {
   return parsed;
 }
 
+function waitForFollowOutputDrain(
+  writeResult: boolean | void,
+  signal: AbortSignal,
+): Promise<void> | undefined {
+  // A pipe can accept less than one follow batch at a time; wait for drain so polling
+  // cannot enqueue unbounded output, while abort/close still lets SIGINT unwind promptly.
+  if (writeResult !== false || signal.aborted) {
+    return undefined;
+  }
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => {
+      process.stdout.off("drain", onDrain);
+      process.stdout.off("close", onClose);
+      process.stdout.off("error", onError);
+      signal.removeEventListener("abort", onAbort);
+    };
+    const settle = (error?: unknown) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      if (error === undefined) {
+        resolve();
+      } else {
+        reject(error);
+      }
+    };
+    const onDrain = () => settle();
+    const onClose = () => settle();
+    const onError = (error: Error) => {
+      if (isOutputClosedError(error)) {
+        settle();
+      } else {
+        settle(error);
+      }
+    };
+    const onAbort = () => settle();
+
+    process.stdout.once("drain", onDrain);
+    process.stdout.once("close", onClose);
+    process.stdout.once("error", onError);
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      settle();
+    }
+  });
+}
+
+function writeFollowStdout(
+  runtime: RuntimeEnv,
+  value: string,
+  signal: AbortSignal,
+): Promise<void> | undefined {
+  return waitForFollowOutputDrain(writeRuntimeStdout(runtime, value), signal);
+}
+
+function writeFollowJson(
+  runtime: RuntimeEnv,
+  value: unknown,
+  signal: AbortSignal,
+): Promise<void> | undefined {
+  return waitForFollowOutputDrain(writeRuntimeJson(runtime, value, 0), signal);
+}
+
 function writeChannelLogLine(
   runtime: RuntimeEnv,
   line: ParsedLogLine,
   json: boolean,
   follow = false,
-): void {
+  signal?: AbortSignal,
+): Promise<void> | undefined {
   if (json) {
-    writeRuntimeJson(runtime, { type: "log", ...line }, 0);
+    const writeResult = writeRuntimeJson(runtime, { type: "log", ...line }, 0);
+    if (follow && signal) {
+      return waitForFollowOutputDrain(writeResult, signal);
+    }
     return;
   }
   const ts = line.time ? `${line.time} ` : "";
   const level = line.level ? `${normalizeLowercaseStringOrEmpty(line.level)} ` : "";
   const output = `${ts}${level}${line.message}`.trim();
   if (follow) {
-    writeRuntimeStdout(runtime, output);
+    const writeResult = writeRuntimeStdout(runtime, output);
+    if (signal) {
+      return waitForFollowOutputDrain(writeResult, signal);
+    }
     return;
   }
   runtime.log(output);
+  return undefined;
 }
 
 function installFollowSignalHandlers(controller: AbortController): () => void {
@@ -466,42 +540,110 @@ async function followChannelLogs(
       const fileChanged = previousFile !== undefined && tail.file !== previousFile;
       if (json) {
         if (firstRead || fileChanged) {
-          writeRuntimeJson(runtime, { type: "meta", file: tail.file, channel }, 0);
-        }
-        if (tail.truncated) {
-          writeRuntimeJson(
+          const outputWait = writeFollowJson(
             runtime,
-            { type: "notice", message: "Log tail truncated; earlier entries were omitted." },
-            0,
+            { type: "meta", file: tail.file, channel },
+            controller.signal,
           );
-        }
-        if (tail.reset || reanchored) {
-          writeRuntimeJson(
-            runtime,
-            { type: "notice", message: "Log file reset; re-reading the current tail." },
-            0,
-          );
-        }
-      } else {
-        if (firstRead || fileChanged) {
-          writeRuntimeStdout(runtime, theme.info(`Log file: ${tail.file}`));
-          if (channel !== "all") {
-            writeRuntimeStdout(runtime, theme.info(`Channel: ${channel}`));
+          if (outputWait) {
+            await outputWait;
+            if (controller.signal.aborted) {
+              return;
+            }
           }
         }
         if (tail.truncated) {
-          writeRuntimeStdout(
+          const outputWait = writeFollowJson(
             runtime,
-            theme.warn("Log tail truncated; earlier entries were omitted."),
+            { type: "notice", message: "Log tail truncated; earlier entries were omitted." },
+            controller.signal,
           );
+          if (outputWait) {
+            await outputWait;
+            if (controller.signal.aborted) {
+              return;
+            }
+          }
         }
         if (tail.reset || reanchored) {
-          writeRuntimeStdout(runtime, theme.warn("Log file reset; re-reading the current tail."));
+          const outputWait = writeFollowJson(
+            runtime,
+            { type: "notice", message: "Log file reset; re-reading the current tail." },
+            controller.signal,
+          );
+          if (outputWait) {
+            await outputWait;
+            if (controller.signal.aborted) {
+              return;
+            }
+          }
+        }
+      } else {
+        if (firstRead || fileChanged) {
+          const outputWait = writeFollowStdout(
+            runtime,
+            theme.info(`Log file: ${tail.file}`),
+            controller.signal,
+          );
+          if (outputWait) {
+            await outputWait;
+            if (controller.signal.aborted) {
+              return;
+            }
+          }
+          if (channel !== "all") {
+            const channelOutputWait = writeFollowStdout(
+              runtime,
+              theme.info(`Channel: ${channel}`),
+              controller.signal,
+            );
+            if (channelOutputWait) {
+              await channelOutputWait;
+              if (controller.signal.aborted) {
+                return;
+              }
+            }
+          }
+        }
+        if (tail.truncated) {
+          const outputWait = writeFollowStdout(
+            runtime,
+            theme.warn("Log tail truncated; earlier entries were omitted."),
+            controller.signal,
+          );
+          if (outputWait) {
+            await outputWait;
+            if (controller.signal.aborted) {
+              return;
+            }
+          }
+        }
+        if (tail.reset || reanchored) {
+          const outputWait = writeFollowStdout(
+            runtime,
+            theme.warn("Log file reset; re-reading the current tail."),
+            controller.signal,
+          );
+          if (outputWait) {
+            await outputWait;
+            if (controller.signal.aborted) {
+              return;
+            }
+          }
         }
       }
 
       for (const line of tail.lines) {
-        writeChannelLogLine(runtime, line, json, true);
+        if (controller.signal.aborted) {
+          return;
+        }
+        const outputWait = writeChannelLogLine(runtime, line, json, true, controller.signal);
+        if (outputWait) {
+          await outputWait;
+          if (controller.signal.aborted) {
+            return;
+          }
+        }
       }
       cursor = checkpoint ? tail.cursor : undefined;
       previousFile = tail.file;

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -191,18 +191,6 @@ function isSameFileCheckpoint(
   );
 }
 
-function isSameFileGeneration(
-  previous: FileCheckpoint,
-  current: FileCheckpoint | undefined,
-): boolean {
-  return (
-    current?.file === previous.file &&
-    current.identity === previous.identity &&
-    current.prefixLength === previous.prefixLength &&
-    current.prefix === previous.prefix
-  );
-}
-
 async function followChannelLogs(
   filter: ChannelLogFilter,
   channel: string,
@@ -250,24 +238,26 @@ async function followChannelLogs(
         reanchored = true;
       }
 
-      let checkpoint = await readFileCheckpoint(
-        tail.file,
-        tail.cursor,
-        reanchored ? undefined : previousCheckpoint?.prefixLength,
-      );
-      if (
-        !reanchored &&
-        previousGeneration !== undefined &&
-        !isSameFileGeneration(previousGeneration, checkpoint)
-      ) {
-        tail = await readConfiguredParsedLogTail({
-          limit: readLimit,
-          maxBytes: MAX_BYTES,
-          filter: (line) => matchesChannel(line, filter),
-        });
-        reanchored = true;
-        checkpoint = await readFileCheckpoint(tail.file, tail.cursor);
+      if (!reanchored && previousGeneration !== undefined && previousCheckpoint !== undefined) {
+        const postReadGeneration = await readFileCheckpoint(
+          tail.file,
+          previousCheckpoint.cursor,
+          previousCheckpoint.prefixLength,
+        );
+        if (!isSameFileCheckpoint(previousGeneration, postReadGeneration)) {
+          tail = await readConfiguredParsedLogTail({
+            limit: readLimit,
+            maxBytes: MAX_BYTES,
+            filter: (line) => matchesChannel(line, filter),
+          });
+          reanchored = true;
+        }
       }
+
+      const checkpointPrefixLength = reanchored
+        ? undefined
+        : Math.max(previousCheckpoint?.prefixLength ?? 0, Math.min(64, tail.cursor));
+      const checkpoint = await readFileCheckpoint(tail.file, tail.cursor, checkpointPrefixLength);
 
       const fileChanged = previousFile !== undefined && tail.file !== previousFile;
       if (json) {
@@ -307,7 +297,7 @@ async function followChannelLogs(
         writeChannelLogLine(runtime, line, json);
       }
       cursor = checkpoint ? tail.cursor : undefined;
-      previousFile = checkpoint ? tail.file : undefined;
+      previousFile = tail.file;
       previousCheckpoint = checkpoint;
       firstRead = false;
 

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -360,9 +360,7 @@ function isSameFileGeneration(
   return (
     current?.file === previous.file &&
     current.identity === previous.identity &&
-    // A pending unterminated record may shrink while the committed prefix stays intact.
-    // Compare against the consumed cursor so that suffix repair does not replay the tail.
-    current.size >= previous.cursor &&
+    current.size >= previous.size &&
     current.prefixLength >= previous.prefixLength &&
     currentPrefix?.subarray(0, previous.prefixLength).equals(previousPrefix) === true &&
     current.validationContentHash === previous.contentHash &&

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -378,14 +378,18 @@ function isSameTailGeneration(
     return current === undefined;
   }
   const currentPrefix = current ? Buffer.from(current.prefix, "base64") : undefined;
-  const generationPrefix = Buffer.from(generation.prefix, "base64");
+  const generationBoundary = current ? Buffer.from(current.boundary, "base64") : undefined;
   return (
     current?.file === file &&
     current.identity === generation.identity &&
     current.size >= generation.size &&
     current.prefixLength >= generation.prefixLength &&
-    currentPrefix?.subarray(0, generation.prefixLength).equals(generationPrefix) === true &&
-    current.boundary === generation.boundary &&
+    currentPrefix !== undefined &&
+    createHash("sha256")
+      .update(currentPrefix.subarray(0, generation.prefixLength))
+      .digest("hex") === generation.prefixHash &&
+    generationBoundary !== undefined &&
+    createHash("sha256").update(generationBoundary).digest("hex") === generation.boundaryHash &&
     current.contentHash === generation.contentHash &&
     current.contentWindowStart === generation.contentWindowStart &&
     current.contentWindowLength === generation.contentWindowLength

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -56,8 +56,6 @@ type FileCheckpoint = {
   validationContentWindowStart: number;
   validationContentWindowLength: number;
   validationBoundary: string;
-  mtimeNs: string;
-  ctimeNs: string;
 };
 
 function checkpointPrefixLength(size: number): number {
@@ -266,8 +264,6 @@ async function readFileCheckpoint(
               validationBoundaryStart,
               boundedValidationCursor - validationBoundaryStart,
             ),
-      mtimeNs: stat.mtimeNs.toString(),
-      ctimeNs: stat.ctimeNs.toString(),
     };
   } finally {
     await handle.close();
@@ -295,9 +291,7 @@ function isSameFileGeneration(
     currentPrefix?.subarray(0, previous.prefixLength).equals(previousPrefix) === true &&
     current.validationContentHash === previous.contentHash &&
     current.validationContentWindowStart === previous.contentWindowStart &&
-    current.validationContentWindowLength === previous.contentWindowLength &&
-    (current.size > previous.size ||
-      (current.mtimeNs === previous.mtimeNs && current.ctimeNs === previous.ctimeNs))
+    current.validationContentWindowLength === previous.contentWindowLength
   );
 }
 
@@ -320,9 +314,7 @@ function isSameTailGeneration(
     current.boundary === generation.boundary &&
     current.contentHash === generation.contentHash &&
     current.contentWindowStart === generation.contentWindowStart &&
-    current.contentWindowLength === generation.contentWindowLength &&
-    (current.size > generation.size ||
-      (current.mtimeNs === generation.mtimeNs && current.ctimeNs === generation.ctimeNs))
+    current.contentWindowLength === generation.contentWindowLength
   );
 }
 

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -1,4 +1,6 @@
 // Implements channel-scoped tailing of the OpenClaw log file.
+import fs from "node:fs/promises";
+import { setTimeout as delay } from "node:timers/promises";
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
@@ -6,6 +8,7 @@ import {
   CHAT_CHANNEL_ORDER,
   normalizeChatChannelId as normalizeBundledChannelId,
 } from "../../channels/registry.js";
+import { readFileWindowFully } from "../../infra/file-read.js";
 import { readConfiguredParsedLogTail } from "../../logging/log-tail.js";
 import type { ParsedLogLine } from "../../logging/parse-log-line.js";
 import { loadPluginManifestRegistryForPluginRegistry } from "../../plugins/plugin-registry.js";
@@ -15,13 +18,23 @@ export type ChannelsLogsOptions = {
   channel?: string;
   lines?: string | number;
   json?: boolean;
+  follow?: boolean;
+  interval?: string | number;
 };
 
 const DEFAULT_LIMIT = 200;
+const DEFAULT_INTERVAL = 1000;
 const MAX_BYTES = 1_000_000;
 
 type ChannelLogFilter = { channel: string; pluginIds: ReadonlySet<string> };
 type ManifestChannel = { id: string; pluginId: string };
+type FileCheckpoint = {
+  file: string;
+  identity: string;
+  cursor: number;
+  prefix: string;
+  boundary: string;
+};
 
 function listManifestChannels(): ManifestChannel[] {
   return loadPluginManifestRegistryForPluginRegistry({
@@ -90,6 +103,184 @@ function parseLinesOption(value: unknown): number {
   return parsed;
 }
 
+function parseIntervalOption(value: unknown): number {
+  if (value === undefined || value === null || value === "") {
+    return DEFAULT_INTERVAL;
+  }
+  const parsed = parseStrictPositiveInteger(value);
+  if (parsed === undefined) {
+    throw new Error("--interval must be a positive integer.");
+  }
+  return parsed;
+}
+
+function writeChannelLogLine(runtime: RuntimeEnv, line: ParsedLogLine, json: boolean): void {
+  if (json) {
+    writeRuntimeJson(runtime, { type: "log", ...line }, 0);
+    return;
+  }
+  const ts = line.time ? `${line.time} ` : "";
+  const level = line.level ? `${normalizeLowercaseStringOrEmpty(line.level)} ` : "";
+  runtime.log(`${ts}${level}${line.message}`.trim());
+}
+
+function installFollowSignalHandlers(controller: AbortController): () => void {
+  const stop = () => controller.abort();
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+  return () => {
+    process.off("SIGINT", stop);
+    process.off("SIGTERM", stop);
+  };
+}
+
+async function readFileCheckpoint(
+  file: string,
+  cursor: number,
+): Promise<FileCheckpoint | undefined> {
+  const stat = await fs.stat(file).catch(() => undefined);
+  if (!stat) {
+    return undefined;
+  }
+  const handle = await fs.open(file, "r");
+  try {
+    const readWindow = async (start: number, length: number) => {
+      const buffer = Buffer.alloc(Math.max(0, Math.min(length, stat.size - start)));
+      const bytesRead = await readFileWindowFully(handle, buffer, start);
+      return buffer.toString("base64", 0, bytesRead);
+    };
+    const boundedCursor = Math.min(Math.max(0, cursor), stat.size);
+    const boundaryStart = Math.max(0, boundedCursor - 64);
+    return {
+      file,
+      identity: `${stat.dev}:${stat.ino}`,
+      cursor: boundedCursor,
+      prefix: await readWindow(0, 64),
+      boundary: await readWindow(boundaryStart, boundedCursor - boundaryStart),
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+function isSameFileCheckpoint(
+  previous: FileCheckpoint,
+  current: FileCheckpoint | undefined,
+): boolean {
+  return (
+    current?.file === previous.file &&
+    current.identity === previous.identity &&
+    current.prefix === previous.prefix &&
+    current.boundary === previous.boundary
+  );
+}
+
+async function followChannelLogs(
+  filter: ChannelLogFilter,
+  channel: string,
+  limit: number,
+  interval: number,
+  json: boolean,
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const controller = new AbortController();
+  const removeSignalHandlers = installFollowSignalHandlers(controller);
+  let cursor: number | undefined;
+  let previousFile: string | undefined;
+  let previousCheckpoint: FileCheckpoint | undefined;
+  let firstRead = true;
+
+  try {
+    while (!controller.signal.aborted) {
+      const readLimit = firstRead ? limit : "all";
+      let tail = await readConfiguredParsedLogTail({
+        cursor,
+        limit: readLimit,
+        maxBytes: MAX_BYTES,
+        filter: (line) => matchesChannel(line, filter),
+      });
+      let reanchored = false;
+
+      // A rolling file can change between polls. Re-anchor to the new file so a
+      // coincidentally valid byte offset cannot skip its initial records.
+      if (previousFile !== undefined && tail.file !== previousFile) {
+        tail = await readConfiguredParsedLogTail({
+          limit: readLimit,
+          maxBytes: MAX_BYTES,
+          filter: (line) => matchesChannel(line, filter),
+        });
+        reanchored = true;
+      } else if (
+        previousCheckpoint !== undefined &&
+        !isSameFileCheckpoint(
+          previousCheckpoint,
+          await readFileCheckpoint(tail.file, previousCheckpoint.cursor),
+        )
+      ) {
+        tail = await readConfiguredParsedLogTail({
+          limit: readLimit,
+          maxBytes: MAX_BYTES,
+          filter: (line) => matchesChannel(line, filter),
+        });
+        reanchored = true;
+      }
+
+      const fileChanged = previousFile !== undefined && tail.file !== previousFile;
+      if (json) {
+        if (firstRead || fileChanged) {
+          writeRuntimeJson(runtime, { type: "meta", file: tail.file, channel }, 0);
+        }
+        if (tail.truncated) {
+          writeRuntimeJson(
+            runtime,
+            { type: "notice", message: "Log tail truncated; earlier entries were omitted." },
+            0,
+          );
+        }
+        if (tail.reset || reanchored) {
+          writeRuntimeJson(
+            runtime,
+            { type: "notice", message: "Log file reset; re-reading the current tail." },
+            0,
+          );
+        }
+      } else {
+        if (firstRead || fileChanged) {
+          runtime.log(theme.info(`Log file: ${tail.file}`));
+          if (channel !== "all") {
+            runtime.log(theme.info(`Channel: ${channel}`));
+          }
+        }
+        if (tail.truncated) {
+          runtime.log(theme.warn("Log tail truncated; earlier entries were omitted."));
+        }
+        if (tail.reset || reanchored) {
+          runtime.log(theme.warn("Log file reset; re-reading the current tail."));
+        }
+      }
+
+      for (const line of tail.lines) {
+        writeChannelLogLine(runtime, line, json);
+      }
+      cursor = tail.cursor;
+      previousFile = tail.file;
+      previousCheckpoint = await readFileCheckpoint(tail.file, tail.cursor);
+      firstRead = false;
+
+      try {
+        await delay(interval, undefined, { signal: controller.signal });
+      } catch (error) {
+        if (controller.signal.aborted) {
+          return;
+        }
+        throw error;
+      }
+    }
+  } finally {
+    removeSignalHandlers();
+  }
+}
+
 /** Print or serialize recent log lines matching one channel subsystem/module. */
 export async function channelsLogsCommand(
   opts: ChannelsLogsOptions,
@@ -98,6 +289,18 @@ export async function channelsLogsCommand(
   const filter = parseChannelFilter(opts.channel);
   const { channel } = filter;
   const limit = parseLinesOption(opts.lines);
+
+  if (opts.follow) {
+    await followChannelLogs(
+      filter,
+      channel,
+      limit,
+      parseIntervalOption(opts.interval),
+      Boolean(opts.json),
+      runtime,
+    );
+    return;
+  }
 
   const tail = await readConfiguredParsedLogTail({
     limit,
@@ -123,8 +326,6 @@ export async function channelsLogsCommand(
     return;
   }
   for (const line of lines) {
-    const ts = line.time ? `${line.time} ` : "";
-    const level = line.level ? `${normalizeLowercaseStringOrEmpty(line.level)} ` : "";
-    runtime.log(`${ts}${level}${line.message}`.trim());
+    writeChannelLogLine(runtime, line, false);
   }
 }

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -8,6 +8,7 @@ import {
   CHAT_CHANNEL_ORDER,
   normalizeChatChannelId as normalizeBundledChannelId,
 } from "../../channels/registry.js";
+import { isMissingPathError } from "../../infra/errno.js";
 import { readFileWindowFully } from "../../infra/file-read.js";
 import { readConfiguredParsedLogTail } from "../../logging/log-tail.js";
 import type { ParsedLogLine } from "../../logging/parse-log-line.js";
@@ -24,6 +25,8 @@ export type ChannelsLogsOptions = {
 
 const DEFAULT_LIMIT = 200;
 const DEFAULT_INTERVAL = 1000;
+// Node clamps setTimeout delays outside the signed 32-bit range to 1 ms.
+const MAX_TIMER_DELAY = 2_147_483_647;
 const MAX_BYTES = 1_000_000;
 
 type ChannelLogFilter = { channel: string; pluginIds: ReadonlySet<string> };
@@ -32,6 +35,7 @@ type FileCheckpoint = {
   file: string;
   identity: string;
   cursor: number;
+  prefixLength: number;
   prefix: string;
   boundary: string;
 };
@@ -111,6 +115,9 @@ function parseIntervalOption(value: unknown): number {
   if (parsed === undefined) {
     throw new Error("--interval must be a positive integer.");
   }
+  if (parsed > MAX_TIMER_DELAY) {
+    throw new Error(`--interval must be no greater than ${MAX_TIMER_DELAY} milliseconds.`);
+  }
   return parsed;
 }
 
@@ -137,25 +144,33 @@ function installFollowSignalHandlers(controller: AbortController): () => void {
 async function readFileCheckpoint(
   file: string,
   cursor: number,
+  prefixLength?: number,
 ): Promise<FileCheckpoint | undefined> {
-  const stat = await fs.stat(file).catch(() => undefined);
-  if (!stat) {
+  const handle = await fs.open(file, "r").catch((error) => {
+    if (isMissingPathError(error)) {
+      return undefined;
+    }
+    throw error;
+  });
+  if (!handle) {
     return undefined;
   }
-  const handle = await fs.open(file, "r");
   try {
+    const stat = await handle.stat();
     const readWindow = async (start: number, length: number) => {
       const buffer = Buffer.alloc(Math.max(0, Math.min(length, stat.size - start)));
       const bytesRead = await readFileWindowFully(handle, buffer, start);
       return buffer.toString("base64", 0, bytesRead);
     };
     const boundedCursor = Math.min(Math.max(0, cursor), stat.size);
+    const boundedPrefixLength = Math.min(64, Math.max(0, prefixLength ?? boundedCursor), stat.size);
     const boundaryStart = Math.max(0, boundedCursor - 64);
     return {
       file,
       identity: `${stat.dev}:${stat.ino}`,
       cursor: boundedCursor,
-      prefix: await readWindow(0, 64),
+      prefixLength: boundedPrefixLength,
+      prefix: await readWindow(0, boundedPrefixLength),
       boundary: await readWindow(boundaryStart, boundedCursor - boundaryStart),
     };
   } finally {
@@ -170,8 +185,21 @@ function isSameFileCheckpoint(
   return (
     current?.file === previous.file &&
     current.identity === previous.identity &&
+    current.prefixLength === previous.prefixLength &&
     current.prefix === previous.prefix &&
     current.boundary === previous.boundary
+  );
+}
+
+function isSameFileGeneration(
+  previous: FileCheckpoint,
+  current: FileCheckpoint | undefined,
+): boolean {
+  return (
+    current?.file === previous.file &&
+    current.identity === previous.identity &&
+    current.prefixLength === previous.prefixLength &&
+    current.prefix === previous.prefix
   );
 }
 
@@ -193,13 +221,23 @@ async function followChannelLogs(
   try {
     while (!controller.signal.aborted) {
       const readLimit = firstRead ? limit : "all";
+      const previousGeneration = previousCheckpoint
+        ? await readFileCheckpoint(
+            previousCheckpoint.file,
+            previousCheckpoint.cursor,
+            previousCheckpoint.prefixLength,
+          )
+        : undefined;
+      let reanchored =
+        previousCheckpoint !== undefined &&
+        !isSameFileCheckpoint(previousCheckpoint, previousGeneration);
+      const readCursor = reanchored ? undefined : cursor;
       let tail = await readConfiguredParsedLogTail({
-        cursor,
+        cursor: readCursor,
         limit: readLimit,
         maxBytes: MAX_BYTES,
         filter: (line) => matchesChannel(line, filter),
       });
-      let reanchored = false;
 
       // A rolling file can change between polls. Re-anchor to the new file so a
       // coincidentally valid byte offset cannot skip its initial records.
@@ -210,12 +248,17 @@ async function followChannelLogs(
           filter: (line) => matchesChannel(line, filter),
         });
         reanchored = true;
-      } else if (
-        previousCheckpoint !== undefined &&
-        !isSameFileCheckpoint(
-          previousCheckpoint,
-          await readFileCheckpoint(tail.file, previousCheckpoint.cursor),
-        )
+      }
+
+      let checkpoint = await readFileCheckpoint(
+        tail.file,
+        tail.cursor,
+        reanchored ? undefined : previousCheckpoint?.prefixLength,
+      );
+      if (
+        !reanchored &&
+        previousGeneration !== undefined &&
+        !isSameFileGeneration(previousGeneration, checkpoint)
       ) {
         tail = await readConfiguredParsedLogTail({
           limit: readLimit,
@@ -223,6 +266,7 @@ async function followChannelLogs(
           filter: (line) => matchesChannel(line, filter),
         });
         reanchored = true;
+        checkpoint = await readFileCheckpoint(tail.file, tail.cursor);
       }
 
       const fileChanged = previousFile !== undefined && tail.file !== previousFile;
@@ -262,9 +306,9 @@ async function followChannelLogs(
       for (const line of tail.lines) {
         writeChannelLogLine(runtime, line, json);
       }
-      cursor = tail.cursor;
-      previousFile = tail.file;
-      previousCheckpoint = await readFileCheckpoint(tail.file, tail.cursor);
+      cursor = checkpoint ? tail.cursor : undefined;
+      previousFile = checkpoint ? tail.file : undefined;
+      previousCheckpoint = checkpoint;
       firstRead = false;
 
       try {

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -191,6 +191,20 @@ function isSameFileCheckpoint(
   );
 }
 
+function isSameFileGeneration(
+  previous: FileCheckpoint,
+  current: FileCheckpoint | undefined,
+): boolean {
+  const currentPrefix = current ? Buffer.from(current.prefix, "base64") : undefined;
+  const previousPrefix = Buffer.from(previous.prefix, "base64");
+  return (
+    current?.file === previous.file &&
+    current.identity === previous.identity &&
+    current.prefixLength >= previous.prefixLength &&
+    currentPrefix?.subarray(0, previous.prefixLength).equals(previousPrefix) === true
+  );
+}
+
 async function followChannelLogs(
   filter: ChannelLogFilter,
   channel: string,
@@ -257,7 +271,20 @@ async function followChannelLogs(
       const checkpointPrefixLength = reanchored
         ? undefined
         : Math.max(previousCheckpoint?.prefixLength ?? 0, Math.min(64, tail.cursor));
-      const checkpoint = await readFileCheckpoint(tail.file, tail.cursor, checkpointPrefixLength);
+      let checkpoint = await readFileCheckpoint(tail.file, tail.cursor, checkpointPrefixLength);
+      if (
+        !reanchored &&
+        previousGeneration !== undefined &&
+        !isSameFileGeneration(previousGeneration, checkpoint)
+      ) {
+        tail = await readConfiguredParsedLogTail({
+          limit: readLimit,
+          maxBytes: MAX_BYTES,
+          filter: (line) => matchesChannel(line, filter),
+        });
+        reanchored = true;
+        checkpoint = await readFileCheckpoint(tail.file, tail.cursor);
+      }
 
       const fileChanged = previousFile !== undefined && tail.file !== previousFile;
       if (json) {

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -360,7 +360,9 @@ function isSameFileGeneration(
   return (
     current?.file === previous.file &&
     current.identity === previous.identity &&
-    current.size >= previous.size &&
+    // A pending unterminated record may shrink while the committed prefix stays intact.
+    // Compare against the consumed cursor so that suffix repair does not replay the tail.
+    current.size >= previous.cursor &&
     current.prefixLength >= previous.prefixLength &&
     currentPrefix?.subarray(0, previous.prefixLength).equals(previousPrefix) === true &&
     current.validationContentHash === previous.contentHash &&

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -49,6 +49,10 @@ type FileCheckpoint = {
   ctimeNs: string;
 };
 
+function checkpointPrefixLength(size: number): number {
+  return Math.min(64, Math.max(0, size));
+}
+
 function listManifestChannels(): ManifestChannel[] {
   return loadPluginManifestRegistryForPluginRegistry({
     includeDisabled: true,
@@ -186,7 +190,7 @@ async function readFileCheckpoint(
   prefixLength?: number,
   validationCursor = cursor,
 ): Promise<FileCheckpoint | undefined> {
-  const handle = await fs.open(file, "r").catch((error) => {
+  const handle = await fs.open(file, "r").catch((error: unknown) => {
     if (isMissingPathError(error)) {
       return undefined;
     }
@@ -205,7 +209,7 @@ async function readFileCheckpoint(
     };
     const boundedCursor = Math.min(Math.max(0, cursor), size);
     const boundedValidationCursor = Math.min(Math.max(0, validationCursor), size);
-    const boundedPrefixLength = Math.min(64, Math.max(0, prefixLength ?? boundedCursor), size);
+    const boundedPrefixLength = Math.min(64, Math.max(0, prefixLength ?? size), size);
     const boundaryStart = Math.max(0, boundedCursor - 64);
     const validationBoundaryStart = Math.max(0, boundedValidationCursor - 64);
     const boundary = await readWindow(boundaryStart, boundedCursor - boundaryStart);
@@ -351,28 +355,30 @@ async function followChannelLogs(
         }
       }
 
-      const checkpointPrefixLength = reanchored
-        ? undefined
-        : Math.max(previousCheckpoint?.prefixLength ?? 0, Math.min(64, tail.size));
+      const checkpointPrefix = reanchored ? undefined : checkpointPrefixLength(tail.size);
       let checkpoint = await readFileCheckpoint(
         tail.file,
         tail.cursor,
-        checkpointPrefixLength,
+        checkpointPrefix,
         previousCheckpoint?.cursor,
       );
-      if (!isSameTailGeneration(tail.file, tail.generation, checkpoint)) {
+      let checkpointValid = isSameTailGeneration(tail.file, tail.generation, checkpoint);
+      if (!checkpointValid) {
         tail = await readConfiguredParsedLogTail({
           limit: readLimit,
           maxBytes: MAX_BYTES,
           filter: (line) => matchesChannel(line, filter),
         });
         reanchored = true;
-        checkpoint = await readFileCheckpoint(tail.file, tail.cursor);
-        if (!isSameTailGeneration(tail.file, tail.generation, checkpoint)) {
-          checkpoint = undefined;
-        }
+        checkpoint = await readFileCheckpoint(
+          tail.file,
+          tail.cursor,
+          checkpointPrefixLength(tail.size),
+        );
+        checkpointValid = isSameTailGeneration(tail.file, tail.generation, checkpoint);
       }
       if (
+        checkpointValid &&
         !reanchored &&
         previousGeneration !== undefined &&
         previousCheckpoint !== undefined &&
@@ -384,10 +390,23 @@ async function followChannelLogs(
           filter: (line) => matchesChannel(line, filter),
         });
         reanchored = true;
-        checkpoint = await readFileCheckpoint(tail.file, tail.cursor);
-        if (!isSameTailGeneration(tail.file, tail.generation, checkpoint)) {
-          checkpoint = undefined;
+        checkpoint = await readFileCheckpoint(
+          tail.file,
+          tail.cursor,
+          checkpointPrefixLength(tail.size),
+        );
+        checkpointValid = isSameTailGeneration(tail.file, tail.generation, checkpoint);
+      }
+      if (!checkpointValid) {
+        try {
+          await delay(interval, undefined, { signal: controller.signal });
+        } catch (error) {
+          if (controller.signal.aborted) {
+            return;
+          }
+          throw error;
         }
+        continue;
       }
 
       const fileChanged = previousFile !== undefined && tail.file !== previousFile;

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -39,6 +39,7 @@ type ManifestChannel = { id: string; pluginId: string };
 type FileCheckpoint = {
   file: string;
   identity: string;
+  size: number;
   cursor: number;
   prefixLength: number;
   prefix: string;
@@ -159,6 +160,26 @@ function installFollowSignalHandlers(controller: AbortController): () => void {
   };
 }
 
+function isOutputClosedError(error: unknown): boolean {
+  const code = (error as { code?: unknown })?.code;
+  return code === "EPIPE" || code === "EIO";
+}
+
+function installFollowOutputHandlers(controller: AbortController): () => void {
+  const stop = () => controller.abort();
+  const handleError = (error: Error) => {
+    if (isOutputClosedError(error)) {
+      stop();
+    }
+  };
+  process.stdout.once("close", stop);
+  process.stdout.once("error", handleError);
+  return () => {
+    process.stdout.off("close", stop);
+    process.stdout.off("error", handleError);
+  };
+}
+
 async function readFileCheckpoint(
   file: string,
   cursor: number,
@@ -191,6 +212,7 @@ async function readFileCheckpoint(
     return {
       file,
       identity: `${stat.dev}:${stat.ino}`,
+      size,
       cursor: boundedCursor,
       prefixLength: boundedPrefixLength,
       prefix: await readWindow(0, boundedPrefixLength),
@@ -214,13 +236,7 @@ function isSameFileCheckpoint(
   previous: FileCheckpoint,
   current: FileCheckpoint | undefined,
 ): boolean {
-  return (
-    current?.file === previous.file &&
-    current.identity === previous.identity &&
-    current.prefixLength === previous.prefixLength &&
-    current.prefix === previous.prefix &&
-    current.boundary === previous.boundary
-  );
+  return isSameFileGeneration(previous, current) && current?.boundary === previous.boundary;
 }
 
 function isSameFileGeneration(
@@ -232,8 +248,11 @@ function isSameFileGeneration(
   return (
     current?.file === previous.file &&
     current.identity === previous.identity &&
+    current.size >= previous.size &&
     current.prefixLength >= previous.prefixLength &&
-    currentPrefix?.subarray(0, previous.prefixLength).equals(previousPrefix) === true
+    currentPrefix?.subarray(0, previous.prefixLength).equals(previousPrefix) === true &&
+    (current.size > previous.size ||
+      (current.mtimeNs === previous.mtimeNs && current.ctimeNs === previous.ctimeNs))
   );
 }
 
@@ -242,15 +261,20 @@ function isSameTailGeneration(
   generation: LogFileGeneration | undefined,
   current: FileCheckpoint | undefined,
 ): boolean {
+  if (generation === undefined) {
+    return current === undefined;
+  }
+  const currentPrefix = current ? Buffer.from(current.prefix, "base64") : undefined;
+  const generationPrefix = Buffer.from(generation.prefix, "base64");
   return (
-    generation !== undefined &&
     current?.file === file &&
     current.identity === generation.identity &&
-    current.prefixLength === generation.prefixLength &&
-    current.prefix === generation.prefix &&
+    current.size >= generation.size &&
+    current.prefixLength >= generation.prefixLength &&
+    currentPrefix?.subarray(0, generation.prefixLength).equals(generationPrefix) === true &&
     current.boundary === generation.boundary &&
-    current.mtimeNs === generation.mtimeNs &&
-    current.ctimeNs === generation.ctimeNs
+    (current.size > generation.size ||
+      (current.mtimeNs === generation.mtimeNs && current.ctimeNs === generation.ctimeNs))
   );
 }
 
@@ -258,14 +282,8 @@ function isSameFileGenerationAtValidationCursor(
   previous: FileCheckpoint,
   current: FileCheckpoint | undefined,
 ): boolean {
-  const changedWithoutCursorAdvance =
-    current !== undefined &&
-    current.cursor <= previous.cursor &&
-    (current.mtimeNs !== previous.mtimeNs || current.ctimeNs !== previous.ctimeNs);
   return (
-    isSameFileGeneration(previous, current) &&
-    current?.validationBoundary === previous.boundary &&
-    !changedWithoutCursorAdvance
+    isSameFileGeneration(previous, current) && current?.validationBoundary === previous.boundary
   );
 }
 
@@ -279,6 +297,7 @@ async function followChannelLogs(
 ): Promise<void> {
   const controller = new AbortController();
   const removeSignalHandlers = installFollowSignalHandlers(controller);
+  const removeOutputHandlers = installFollowOutputHandlers(controller);
   let cursor: number | undefined;
   let previousFile: string | undefined;
   let previousCheckpoint: FileCheckpoint | undefined;
@@ -334,7 +353,7 @@ async function followChannelLogs(
 
       const checkpointPrefixLength = reanchored
         ? undefined
-        : Math.max(previousCheckpoint?.prefixLength ?? 0, Math.min(64, tail.cursor));
+        : Math.max(previousCheckpoint?.prefixLength ?? 0, Math.min(64, tail.size));
       let checkpoint = await readFileCheckpoint(
         tail.file,
         tail.cursor,
@@ -427,6 +446,7 @@ async function followChannelLogs(
     }
   } finally {
     removeSignalHandlers();
+    removeOutputHandlers();
   }
 }
 

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -38,6 +38,7 @@ type FileCheckpoint = {
   prefixLength: number;
   prefix: string;
   boundary: string;
+  validationBoundary: string;
 };
 
 function listManifestChannels(): ManifestChannel[] {
@@ -145,6 +146,7 @@ async function readFileCheckpoint(
   file: string,
   cursor: number,
   prefixLength?: number,
+  validationCursor = cursor,
 ): Promise<FileCheckpoint | undefined> {
   const handle = await fs.open(file, "r").catch((error) => {
     if (isMissingPathError(error)) {
@@ -163,15 +165,25 @@ async function readFileCheckpoint(
       return buffer.toString("base64", 0, bytesRead);
     };
     const boundedCursor = Math.min(Math.max(0, cursor), stat.size);
+    const boundedValidationCursor = Math.min(Math.max(0, validationCursor), stat.size);
     const boundedPrefixLength = Math.min(64, Math.max(0, prefixLength ?? boundedCursor), stat.size);
     const boundaryStart = Math.max(0, boundedCursor - 64);
+    const validationBoundaryStart = Math.max(0, boundedValidationCursor - 64);
+    const boundary = await readWindow(boundaryStart, boundedCursor - boundaryStart);
     return {
       file,
       identity: `${stat.dev}:${stat.ino}`,
       cursor: boundedCursor,
       prefixLength: boundedPrefixLength,
       prefix: await readWindow(0, boundedPrefixLength),
-      boundary: await readWindow(boundaryStart, boundedCursor - boundaryStart),
+      boundary,
+      validationBoundary:
+        validationBoundaryStart === boundaryStart && boundedValidationCursor === boundedCursor
+          ? boundary
+          : await readWindow(
+              validationBoundaryStart,
+              boundedValidationCursor - validationBoundaryStart,
+            ),
     };
   } finally {
     await handle.close();
@@ -202,6 +214,15 @@ function isSameFileGeneration(
     current.identity === previous.identity &&
     current.prefixLength >= previous.prefixLength &&
     currentPrefix?.subarray(0, previous.prefixLength).equals(previousPrefix) === true
+  );
+}
+
+function isSameFileGenerationAtValidationCursor(
+  previous: FileCheckpoint,
+  current: FileCheckpoint | undefined,
+): boolean {
+  return (
+    isSameFileGeneration(previous, current) && current?.validationBoundary === previous.boundary
   );
 }
 
@@ -271,11 +292,17 @@ async function followChannelLogs(
       const checkpointPrefixLength = reanchored
         ? undefined
         : Math.max(previousCheckpoint?.prefixLength ?? 0, Math.min(64, tail.cursor));
-      let checkpoint = await readFileCheckpoint(tail.file, tail.cursor, checkpointPrefixLength);
+      let checkpoint = await readFileCheckpoint(
+        tail.file,
+        tail.cursor,
+        checkpointPrefixLength,
+        previousCheckpoint?.cursor,
+      );
       if (
         !reanchored &&
         previousGeneration !== undefined &&
-        !isSameFileGeneration(previousGeneration, checkpoint)
+        previousCheckpoint !== undefined &&
+        !isSameFileGenerationAtValidationCursor(previousGeneration, checkpoint)
       ) {
         tail = await readConfiguredParsedLogTail({
           limit: readLimit,

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -1,4 +1,5 @@
 // Implements channel-scoped tailing of the OpenClaw log file.
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import { setTimeout as delay } from "node:timers/promises";
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
@@ -10,7 +11,11 @@ import {
 } from "../../channels/registry.js";
 import { isMissingPathError } from "../../infra/errno.js";
 import { readFileWindowFully } from "../../infra/file-read.js";
-import { readConfiguredParsedLogTail, type LogFileGeneration } from "../../logging/log-tail.js";
+import {
+  LOG_GENERATION_WINDOW_BYTES,
+  readConfiguredParsedLogTail,
+  type LogFileGeneration,
+} from "../../logging/log-tail.js";
 import type { ParsedLogLine } from "../../logging/parse-log-line.js";
 import { loadPluginManifestRegistryForPluginRegistry } from "../../plugins/plugin-registry.js";
 import {
@@ -44,6 +49,12 @@ type FileCheckpoint = {
   prefixLength: number;
   prefix: string;
   boundary: string;
+  contentHash: string;
+  contentWindowStart: number;
+  contentWindowLength: number;
+  validationContentHash: string;
+  validationContentWindowStart: number;
+  validationContentWindowLength: number;
   validationBoundary: string;
   mtimeNs: string;
   ctimeNs: string;
@@ -51,6 +62,12 @@ type FileCheckpoint = {
 
 function checkpointPrefixLength(size: number): number {
   return Math.min(64, Math.max(0, size));
+}
+
+function contentWindowBounds(cursor: number, size: number) {
+  const end = Math.min(Math.max(0, cursor), size);
+  const start = Math.max(0, end - LOG_GENERATION_WINDOW_BYTES);
+  return { start, length: end - start };
 }
 
 function listManifestChannels(): ManifestChannel[] {
@@ -207,12 +224,27 @@ async function readFileCheckpoint(
       const bytesRead = await readFileWindowFully(handle, buffer, start);
       return buffer.toString("base64", 0, bytesRead);
     };
+    const readContentHash = async (contentCursor: number) => {
+      const window = contentWindowBounds(contentCursor, size);
+      const buffer = Buffer.alloc(window.length);
+      const bytesRead = await readFileWindowFully(handle, buffer, window.start);
+      return {
+        hash: createHash("sha256").update(buffer.subarray(0, bytesRead)).digest("hex"),
+        start: window.start,
+        length: bytesRead,
+      };
+    };
     const boundedCursor = Math.min(Math.max(0, cursor), size);
     const boundedValidationCursor = Math.min(Math.max(0, validationCursor), size);
     const boundedPrefixLength = Math.min(64, Math.max(0, prefixLength ?? size), size);
     const boundaryStart = Math.max(0, boundedCursor - 64);
     const validationBoundaryStart = Math.max(0, boundedValidationCursor - 64);
     const boundary = await readWindow(boundaryStart, boundedCursor - boundaryStart);
+    const content = await readContentHash(boundedCursor);
+    const validationContent =
+      boundedValidationCursor === boundedCursor
+        ? content
+        : await readContentHash(boundedValidationCursor);
     return {
       file,
       identity: `${stat.dev}:${stat.ino}`,
@@ -221,6 +253,12 @@ async function readFileCheckpoint(
       prefixLength: boundedPrefixLength,
       prefix: await readWindow(0, boundedPrefixLength),
       boundary,
+      contentHash: content.hash,
+      contentWindowStart: content.start,
+      contentWindowLength: content.length,
+      validationContentHash: validationContent.hash,
+      validationContentWindowStart: validationContent.start,
+      validationContentWindowLength: validationContent.length,
       validationBoundary:
         validationBoundaryStart === boundaryStart && boundedValidationCursor === boundedCursor
           ? boundary
@@ -255,6 +293,9 @@ function isSameFileGeneration(
     current.size >= previous.size &&
     current.prefixLength >= previous.prefixLength &&
     currentPrefix?.subarray(0, previous.prefixLength).equals(previousPrefix) === true &&
+    current.validationContentHash === previous.contentHash &&
+    current.validationContentWindowStart === previous.contentWindowStart &&
+    current.validationContentWindowLength === previous.contentWindowLength &&
     (current.size > previous.size ||
       (current.mtimeNs === previous.mtimeNs && current.ctimeNs === previous.ctimeNs))
   );
@@ -277,6 +318,9 @@ function isSameTailGeneration(
     current.prefixLength >= generation.prefixLength &&
     currentPrefix?.subarray(0, generation.prefixLength).equals(generationPrefix) === true &&
     current.boundary === generation.boundary &&
+    current.contentHash === generation.contentHash &&
+    current.contentWindowStart === generation.contentWindowStart &&
+    current.contentWindowLength === generation.contentWindowLength &&
     (current.size > generation.size ||
       (current.mtimeNs === generation.mtimeNs && current.ctimeNs === generation.ctimeNs))
   );

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -10,10 +10,15 @@ import {
 } from "../../channels/registry.js";
 import { isMissingPathError } from "../../infra/errno.js";
 import { readFileWindowFully } from "../../infra/file-read.js";
-import { readConfiguredParsedLogTail } from "../../logging/log-tail.js";
+import { readConfiguredParsedLogTail, type LogFileGeneration } from "../../logging/log-tail.js";
 import type { ParsedLogLine } from "../../logging/parse-log-line.js";
 import { loadPluginManifestRegistryForPluginRegistry } from "../../plugins/plugin-registry.js";
-import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
+import {
+  defaultRuntime,
+  type RuntimeEnv,
+  writeRuntimeJson,
+  writeRuntimeStdout,
+} from "../../runtime.js";
 
 export type ChannelsLogsOptions = {
   channel?: string;
@@ -39,6 +44,8 @@ type FileCheckpoint = {
   prefix: string;
   boundary: string;
   validationBoundary: string;
+  mtimeNs: string;
+  ctimeNs: string;
 };
 
 function listManifestChannels(): ManifestChannel[] {
@@ -122,14 +129,24 @@ function parseIntervalOption(value: unknown): number {
   return parsed;
 }
 
-function writeChannelLogLine(runtime: RuntimeEnv, line: ParsedLogLine, json: boolean): void {
+function writeChannelLogLine(
+  runtime: RuntimeEnv,
+  line: ParsedLogLine,
+  json: boolean,
+  follow = false,
+): void {
   if (json) {
     writeRuntimeJson(runtime, { type: "log", ...line }, 0);
     return;
   }
   const ts = line.time ? `${line.time} ` : "";
   const level = line.level ? `${normalizeLowercaseStringOrEmpty(line.level)} ` : "";
-  runtime.log(`${ts}${level}${line.message}`.trim());
+  const output = `${ts}${level}${line.message}`.trim();
+  if (follow) {
+    writeRuntimeStdout(runtime, output);
+    return;
+  }
+  runtime.log(output);
 }
 
 function installFollowSignalHandlers(controller: AbortController): () => void {
@@ -158,15 +175,16 @@ async function readFileCheckpoint(
     return undefined;
   }
   try {
-    const stat = await handle.stat();
+    const stat = await handle.stat({ bigint: true });
+    const size = Number(stat.size);
     const readWindow = async (start: number, length: number) => {
-      const buffer = Buffer.alloc(Math.max(0, Math.min(length, stat.size - start)));
+      const buffer = Buffer.alloc(Math.max(0, Math.min(length, size - start)));
       const bytesRead = await readFileWindowFully(handle, buffer, start);
       return buffer.toString("base64", 0, bytesRead);
     };
-    const boundedCursor = Math.min(Math.max(0, cursor), stat.size);
-    const boundedValidationCursor = Math.min(Math.max(0, validationCursor), stat.size);
-    const boundedPrefixLength = Math.min(64, Math.max(0, prefixLength ?? boundedCursor), stat.size);
+    const boundedCursor = Math.min(Math.max(0, cursor), size);
+    const boundedValidationCursor = Math.min(Math.max(0, validationCursor), size);
+    const boundedPrefixLength = Math.min(64, Math.max(0, prefixLength ?? boundedCursor), size);
     const boundaryStart = Math.max(0, boundedCursor - 64);
     const validationBoundaryStart = Math.max(0, boundedValidationCursor - 64);
     const boundary = await readWindow(boundaryStart, boundedCursor - boundaryStart);
@@ -184,6 +202,8 @@ async function readFileCheckpoint(
               validationBoundaryStart,
               boundedValidationCursor - validationBoundaryStart,
             ),
+      mtimeNs: stat.mtimeNs.toString(),
+      ctimeNs: stat.ctimeNs.toString(),
     };
   } finally {
     await handle.close();
@@ -217,12 +237,35 @@ function isSameFileGeneration(
   );
 }
 
+function isSameTailGeneration(
+  file: string,
+  generation: LogFileGeneration | undefined,
+  current: FileCheckpoint | undefined,
+): boolean {
+  return (
+    generation !== undefined &&
+    current?.file === file &&
+    current.identity === generation.identity &&
+    current.prefixLength === generation.prefixLength &&
+    current.prefix === generation.prefix &&
+    current.boundary === generation.boundary &&
+    current.mtimeNs === generation.mtimeNs &&
+    current.ctimeNs === generation.ctimeNs
+  );
+}
+
 function isSameFileGenerationAtValidationCursor(
   previous: FileCheckpoint,
   current: FileCheckpoint | undefined,
 ): boolean {
+  const changedWithoutCursorAdvance =
+    current !== undefined &&
+    current.cursor <= previous.cursor &&
+    (current.mtimeNs !== previous.mtimeNs || current.ctimeNs !== previous.ctimeNs);
   return (
-    isSameFileGeneration(previous, current) && current?.validationBoundary === previous.boundary
+    isSameFileGeneration(previous, current) &&
+    current?.validationBoundary === previous.boundary &&
+    !changedWithoutCursorAdvance
   );
 }
 
@@ -298,6 +341,18 @@ async function followChannelLogs(
         checkpointPrefixLength,
         previousCheckpoint?.cursor,
       );
+      if (!isSameTailGeneration(tail.file, tail.generation, checkpoint)) {
+        tail = await readConfiguredParsedLogTail({
+          limit: readLimit,
+          maxBytes: MAX_BYTES,
+          filter: (line) => matchesChannel(line, filter),
+        });
+        reanchored = true;
+        checkpoint = await readFileCheckpoint(tail.file, tail.cursor);
+        if (!isSameTailGeneration(tail.file, tail.generation, checkpoint)) {
+          checkpoint = undefined;
+        }
+      }
       if (
         !reanchored &&
         previousGeneration !== undefined &&
@@ -311,6 +366,9 @@ async function followChannelLogs(
         });
         reanchored = true;
         checkpoint = await readFileCheckpoint(tail.file, tail.cursor);
+        if (!isSameTailGeneration(tail.file, tail.generation, checkpoint)) {
+          checkpoint = undefined;
+        }
       }
 
       const fileChanged = previousFile !== undefined && tail.file !== previousFile;
@@ -334,21 +392,24 @@ async function followChannelLogs(
         }
       } else {
         if (firstRead || fileChanged) {
-          runtime.log(theme.info(`Log file: ${tail.file}`));
+          writeRuntimeStdout(runtime, theme.info(`Log file: ${tail.file}`));
           if (channel !== "all") {
-            runtime.log(theme.info(`Channel: ${channel}`));
+            writeRuntimeStdout(runtime, theme.info(`Channel: ${channel}`));
           }
         }
         if (tail.truncated) {
-          runtime.log(theme.warn("Log tail truncated; earlier entries were omitted."));
+          writeRuntimeStdout(
+            runtime,
+            theme.warn("Log tail truncated; earlier entries were omitted."),
+          );
         }
         if (tail.reset || reanchored) {
-          runtime.log(theme.warn("Log file reset; re-reading the current tail."));
+          writeRuntimeStdout(runtime, theme.warn("Log file reset; re-reading the current tail."));
         }
       }
 
       for (const line of tail.lines) {
-        writeChannelLogLine(runtime, line, json);
+        writeChannelLogLine(runtime, line, json, true);
       }
       cursor = checkpoint ? tail.cursor : undefined;
       previousFile = tail.file;

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -406,7 +406,9 @@ async function followChannelLogs(
         checkpointPrefix,
         previousCheckpoint?.cursor,
       );
-      let checkpointValid = isSameTailGeneration(tail.file, tail.generation, checkpoint);
+      let checkpointValid =
+        tail.generationStable !== false &&
+        isSameTailGeneration(tail.file, tail.generation, checkpoint);
       if (!checkpointValid) {
         tail = await readConfiguredParsedLogTail({
           limit: readLimit,
@@ -419,7 +421,9 @@ async function followChannelLogs(
           tail.cursor,
           checkpointPrefixLength(tail.size),
         );
-        checkpointValid = isSameTailGeneration(tail.file, tail.generation, checkpoint);
+        checkpointValid =
+          tail.generationStable !== false &&
+          isSameTailGeneration(tail.file, tail.generation, checkpoint);
       }
       if (
         checkpointValid &&
@@ -439,7 +443,9 @@ async function followChannelLogs(
           tail.cursor,
           checkpointPrefixLength(tail.size),
         );
-        checkpointValid = isSameTailGeneration(tail.file, tail.generation, checkpoint);
+        checkpointValid =
+          tail.generationStable !== false &&
+          isSameTailGeneration(tail.file, tail.generation, checkpoint);
       }
       if (!checkpointValid) {
         try {

--- a/src/logging/log-tail-redaction.test.ts
+++ b/src/logging/log-tail-redaction.test.ts
@@ -54,5 +54,6 @@ describe("readConfiguredLogTail redaction", () => {
     expect(text).not.toContain(basicSecret);
     expect(text).not.toContain(openClawToken);
     expect(text).not.toContain(pomeriumJwt);
+    expect(payload).not.toHaveProperty("generation");
   });
 });

--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -256,6 +256,46 @@ describe("readConfiguredLogTail", () => {
     expect(result.lines.map((line) => line.message)).toEqual(["before"]);
   });
 
+  it("retries when a same-size rewrite races the returned buffer", async () => {
+    const { readConfiguredParsedLogTail } = await import("./log-tail.js");
+    const tempDir = tempDirs.make("openclaw-log-tail-");
+    const file = path.join(tempDir, "openclaw-2026-01-22.log");
+    const makeLine = (message: string) =>
+      `${JSON.stringify({
+        0: message,
+        time: "2026-01-22T00:00:00.000Z",
+        _meta: { logLevelName: "INFO", name: JSON.stringify({ module: "test" }) },
+      })}\n`;
+    const oldLine = makeLine("old");
+    const newLine = makeLine("new");
+    expect(Buffer.byteLength(newLine)).toBe(Buffer.byteLength(oldLine));
+    await fs.writeFile(file, oldLine);
+    setLoggerOverride({ file });
+
+    const realOpen = fs.open.bind(fs);
+    let readCalls = 0;
+    let rewritten = false;
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      const realRead = handle.read.bind(handle);
+      vi.spyOn(handle, "read").mockImplementation(async (...readArgs) => {
+        const result = await realRead(...readArgs);
+        readCalls += 1;
+        if (!rewritten && readCalls === 3) {
+          rewritten = true;
+          await fs.writeFile(file, newLine);
+        }
+        return result;
+      });
+      return handle;
+    });
+
+    const result = await readConfiguredParsedLogTail({ limit: "all" });
+
+    expect(rewritten).toBe(true);
+    expect(result.lines.map((line) => line.message)).toEqual(["new"]);
+  });
+
   it("keeps the first line when the byte window starts exactly after a newline", async () => {
     const { readConfiguredLogTail } = await import("./log-tail.js");
     const tempDir = tempDirs.make("openclaw-log-tail-");

--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -165,7 +165,7 @@ describe("readConfiguredLogTail", () => {
     });
   });
 
-  it("distinguishes a byte-budget re-anchor from file shrink", async () => {
+  it("bounds cursor continuation without confusing it with file shrink", async () => {
     const { readConfiguredLogTail } = await import("./log-tail.js");
     const tempDir = tempDirs.make("openclaw-log-tail-");
     const file = path.join(tempDir, "openclaw-2026-01-22.log");
@@ -177,8 +177,10 @@ describe("readConfiguredLogTail", () => {
     await fs.appendFile(file, `${"x".repeat(40)}\n`.repeat(200));
     const byteBudget = await readConfiguredLogTail({ cursor: initial.cursor, maxBytes: 500 });
 
-    expect(byteBudget).toMatchObject({ truncated: true, reset: true });
-    expect(byteBudget.skippedBytes).toBeGreaterThan(0);
+    expect(byteBudget).toMatchObject({ truncated: false, reset: false });
+    expect(byteBudget.skippedBytes).toBeUndefined();
+    expect(byteBudget.cursor).toBeGreaterThan(initial.cursor);
+    expect(byteBudget.cursor).toBeLessThan(byteBudget.size);
 
     await fs.writeFile(file, "fresh\n");
     const fileShrink = await readConfiguredLogTail({ cursor: byteBudget.cursor, maxBytes: 500 });

--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -296,6 +296,24 @@ describe("readConfiguredLogTail", () => {
     expect(result.lines.map((line) => line.message)).toEqual(["new"]);
   });
 
+  it("keeps generation coverage for a partial record beyond the byte window", async () => {
+    const { readConfiguredParsedLogTail } = await import("./log-tail.js");
+    const tempDir = tempDirs.make("openclaw-log-tail-");
+    const file = path.join(tempDir, "openclaw-2026-01-22.log");
+    const complete = `${JSON.stringify({
+      0: "complete",
+      time: "2026-01-22T00:00:00.000Z",
+      _meta: { logLevelName: "INFO", name: JSON.stringify({ module: "test" }) },
+    })}\n`;
+    await fs.writeFile(file, `${"x".repeat(1_000_000)}\n${complete}partial`);
+    setLoggerOverride({ file });
+
+    const result = await readConfiguredParsedLogTail({ limit: "all" });
+
+    expect(result.generation).toBeDefined();
+    expect(result.lines.map((entry) => entry.message)).toEqual(["complete"]);
+  });
+
   it("keeps the first line when the byte window starts exactly after a newline", async () => {
     const { readConfiguredLogTail } = await import("./log-tail.js");
     const tempDir = tempDirs.make("openclaw-log-tail-");

--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -235,6 +235,13 @@ describe("readConfiguredLogTail", () => {
           }
           return realStat(...args);
         });
+      } else if (boundary === "final stat") {
+        const realOpen = fs.open.bind(fs);
+        vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+          const handle = await realOpen(...args);
+          vi.spyOn(handle, "stat").mockRejectedValueOnce(error);
+          return handle;
+        });
       } else {
         vi.spyOn(fs, "stat")
           .mockImplementationOnce((...args: Parameters<typeof fs.stat>) => realStat(...args))

--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -98,6 +98,33 @@ describe("readConfiguredLogTail", () => {
     expect(result.lines).toEqual(["custom…wxyz", "second line"]);
   });
 
+  it("does not expose raw generation samples with parsed tails", async () => {
+    const { readConfiguredParsedLogTail } = await import("./log-tail.js");
+    const tempDir = tempDirs.make("openclaw-log-tail-");
+    const file = path.join(tempDir, "openclaw-2026-01-22.log");
+    const rawLine = `${JSON.stringify({
+      0: "custom-secret-abcdefghijklmnopqrstuvwxyz",
+      time: "2026-01-22T00:00:00.000Z",
+      _meta: { logLevelName: "INFO", name: JSON.stringify({ module: "test" }) },
+    })}\n`;
+
+    await fs.writeFile(file, rawLine);
+    setLoggerOverride({ file });
+
+    const result = await readConfiguredParsedLogTail({ limit: "all" });
+
+    expect(result.lines).toHaveLength(1);
+    expect(JSON.stringify(result)).not.toContain(Buffer.from(rawLine).toString("base64"));
+    expect(result.generation).toEqual(
+      expect.objectContaining({
+        prefixHash: expect.any(String),
+        boundaryHash: expect.any(String),
+      }),
+    );
+    expect(result.generation).not.toHaveProperty("prefix");
+    expect(result.generation).not.toHaveProperty("boundary");
+  });
+
   it("fills short positional reads before splitting log lines", async () => {
     const { readConfiguredLogTail } = await import("./log-tail.js");
     const tempDir = tempDirs.make("openclaw-log-tail-");
@@ -143,6 +170,69 @@ describe("readConfiguredLogTail", () => {
       lines: ["partial-completed"],
       cursor: Buffer.byteLength(`${completePrefix}partial-completed\n`),
     });
+  });
+
+  it("skips an oversized record at the byte boundary and advances to later records", async () => {
+    const { readConfiguredLogTail } = await import("./log-tail.js");
+    const tempDir = tempDirs.make("openclaw-log-tail-");
+    const file = path.join(tempDir, "openclaw-2026-01-22.log");
+    const maxBytes = 64;
+    const prefix = "before\n";
+    const oversized = "x".repeat(maxBytes * 3 + 17);
+    const suffix = "after\n";
+
+    await fs.writeFile(file, `${prefix}${oversized}\n${suffix}`);
+    setLoggerOverride({ file });
+
+    const firstSkip = await readConfiguredLogTail({
+      cursor: Buffer.byteLength(prefix),
+      maxBytes,
+      filter: (line) => line === oversized || line === suffix.trimEnd(),
+    });
+
+    expect(firstSkip).toMatchObject({
+      lines: [],
+      truncated: true,
+      reset: false,
+      skippedBytes: maxBytes,
+      cursor: Buffer.byteLength(prefix) + maxBytes,
+    });
+
+    const secondSkip = await readConfiguredLogTail({
+      cursor: firstSkip.cursor,
+      maxBytes,
+      filter: (line) => line === oversized || line === suffix.trimEnd(),
+    });
+
+    expect(secondSkip).toMatchObject({
+      lines: [],
+      truncated: true,
+      reset: false,
+      skippedBytes: maxBytes,
+      cursor: Buffer.byteLength(prefix) + maxBytes * 2,
+    });
+
+    const thirdSkip = await readConfiguredLogTail({
+      cursor: secondSkip.cursor,
+      maxBytes,
+      filter: (line) => line === oversized || line === suffix.trimEnd(),
+    });
+
+    expect(thirdSkip).toMatchObject({
+      lines: [],
+      truncated: true,
+      reset: false,
+      skippedBytes: maxBytes,
+      cursor: Buffer.byteLength(prefix) + maxBytes * 3,
+    });
+
+    const continuation = await readConfiguredLogTail({
+      cursor: thirdSkip.cursor,
+      maxBytes,
+      filter: (line) => line === suffix.trimEnd(),
+    });
+    expect(continuation.lines).toEqual([suffix.trimEnd()]);
+    expect(continuation.cursor).toBe(Buffer.byteLength(`${prefix}${oversized}\n${suffix}`));
   });
 
   it("reports truncation when the line limit omits complete records", async () => {

--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -221,6 +221,41 @@ describe("readConfiguredLogTail", () => {
     expect(result.lines).toEqual(["new-first", "new-second", appended.trimEnd()]);
   });
 
+  it("accepts append-only growth while validating a tail snapshot", async () => {
+    const { readConfiguredParsedLogTail } = await import("./log-tail.js");
+    const tempDir = tempDirs.make("openclaw-log-tail-");
+    const file = path.join(tempDir, "openclaw-2026-01-22.log");
+    await fs.writeFile(
+      file,
+      `${JSON.stringify({
+        0: "before",
+        time: "2026-01-22T00:00:00.000Z",
+        _meta: { logLevelName: "INFO", name: JSON.stringify({ module: "test" }) },
+      })}\n`,
+    );
+    setLoggerOverride({ file });
+
+    const realOpen = fs.open.bind(fs);
+    let statCalls = 0;
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      const realStat = handle.stat.bind(handle);
+      vi.spyOn(handle, "stat").mockImplementation(async (...statArgs) => {
+        statCalls += 1;
+        if (statCalls % 2 === 0 && statCalls <= 6) {
+          await fs.appendFile(file, `append-${statCalls / 2}\n`);
+        }
+        return realStat(...statArgs);
+      });
+      return handle;
+    });
+
+    const result = await readConfiguredParsedLogTail({ limit: "all" });
+
+    expect(result.generationStable).not.toBe(false);
+    expect(result.lines.map((line) => line.message)).toEqual(["before"]);
+  });
+
   it("keeps the first line when the byte window starts exactly after a newline", async () => {
     const { readConfiguredLogTail } = await import("./log-tail.js");
     const tempDir = tempDirs.make("openclaw-log-tail-");

--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -187,6 +187,40 @@ describe("readConfiguredLogTail", () => {
     expect(fileShrink.skippedBytes).toBeUndefined();
   });
 
+  it("keeps a shrink re-anchored when a replacement grows during the retry", async () => {
+    const { readConfiguredLogTail } = await import("./log-tail.js");
+    const tempDir = tempDirs.make("openclaw-log-tail-");
+    const file = path.join(tempDir, "openclaw-2026-01-22.log");
+    const oldContent = `${"old".repeat(333)}\n`;
+    await fs.writeFile(file, oldContent);
+    setLoggerOverride({ file });
+    const initial = await readConfiguredLogTail();
+
+    const replacement = "new-first\nnew-second\n";
+    const appended = `${"new-third".repeat(120)}\n`;
+    await fs.writeFile(file, replacement);
+    const realOpen = fs.open.bind(fs);
+    let mutated = false;
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      const realRead = handle.read.bind(handle);
+      vi.spyOn(handle, "read").mockImplementation(async (...readArgs) => {
+        const result = await realRead(...readArgs);
+        if (!mutated) {
+          mutated = true;
+          await fs.appendFile(file, appended);
+        }
+        return result;
+      });
+      return handle;
+    });
+
+    const result = await readConfiguredLogTail({ cursor: initial.cursor });
+
+    expect(result.reset).toBe(true);
+    expect(result.lines).toEqual(["new-first", "new-second", appended.trimEnd()]);
+  });
+
   it("keeps the first line when the byte window starts exactly after a newline", async () => {
     const { readConfiguredLogTail } = await import("./log-tail.js");
     const tempDir = tempDirs.make("openclaw-log-tail-");

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -33,6 +33,17 @@ export type LogTailPayload = {
   truncated: boolean;
   reset: boolean;
   skippedBytes?: number;
+  generation?: LogFileGeneration;
+};
+
+/** File identity and content samples captured by the handle used for a tail read. */
+export type LogFileGeneration = {
+  identity: string;
+  prefix: string;
+  prefixLength: number;
+  boundary: string;
+  mtimeNs: string;
+  ctimeNs: string;
 };
 
 /** Redacted configured log tail with only parseable structured records. */
@@ -78,8 +89,8 @@ async function readLogSlice(params: {
   maxBytes: number;
   filter?: (line: string) => boolean;
 }): Promise<Omit<LogTailPayload, "file">> {
-  const stat = await fs.stat(params.file).catch(missingPathToNull);
-  if (!stat) {
+  const handle = await fs.open(params.file, "r").catch(missingPathToNull);
+  if (!handle) {
     return {
       cursor: 0,
       size: 0,
@@ -88,55 +99,74 @@ async function readLogSlice(params: {
       reset: false,
     };
   }
+  try {
+    const stat = await handle.stat({ bigint: true });
+    const size = Number(stat.size);
+    const maxBytes = clamp(params.maxBytes, 1, MAX_BYTES);
+    const limit = params.limit === "all" ? undefined : clamp(params.limit, 1, MAX_LIMIT);
+    let cursor =
+      typeof params.cursor === "number" && Number.isFinite(params.cursor)
+        ? Math.max(0, Math.floor(params.cursor))
+        : undefined;
+    let reset = false;
+    let skippedBytes: number | undefined;
+    let truncated = false;
+    let start;
 
-  const size = stat.size;
-  const maxBytes = clamp(params.maxBytes, 1, MAX_BYTES);
-  const limit = params.limit === "all" ? undefined : clamp(params.limit, 1, MAX_LIMIT);
-  let cursor =
-    typeof params.cursor === "number" && Number.isFinite(params.cursor)
-      ? Math.max(0, Math.floor(params.cursor))
-      : undefined;
-  let reset = false;
-  let skippedBytes: number | undefined;
-  let truncated = false;
-  let start;
-
-  if (cursor != null) {
-    if (cursor > size) {
-      // File rotated or shrank since the previous cursor; restart near the end.
-      reset = true;
+    if (cursor != null) {
+      if (cursor > size) {
+        // File rotated or shrank since the previous cursor; restart near the end.
+        reset = true;
+        start = Math.max(0, size - maxBytes);
+        truncated = start > 0;
+      } else {
+        start = cursor;
+        if (size - start > maxBytes) {
+          // Keep reset as the re-anchor signal for existing clients. The skipped byte count
+          // lets current clients distinguish this valid-cursor fast-forward from file shrink.
+          reset = true;
+          truncated = true;
+          const boundedStart = Math.max(0, size - maxBytes);
+          skippedBytes = boundedStart - start;
+          start = boundedStart;
+        }
+      }
+    } else {
       start = Math.max(0, size - maxBytes);
       truncated = start > 0;
-    } else {
-      start = cursor;
-      if (size - start > maxBytes) {
-        // Keep reset as the re-anchor signal for existing clients. The skipped byte count
-        // lets current clients distinguish this valid-cursor fast-forward from file shrink.
-        reset = true;
-        truncated = true;
-        const boundedStart = Math.max(0, size - maxBytes);
-        skippedBytes = boundedStart - start;
-        start = boundedStart;
-      }
     }
-  } else {
-    start = Math.max(0, size - maxBytes);
-    truncated = start > 0;
-  }
 
-  if (size === 0 || size <= start) {
-    return {
-      cursor: size,
-      size,
-      lines: [],
-      truncated,
-      reset,
-      skippedBytes,
+    const readWindow = async (windowStart: number, length: number) => {
+      const buffer = Buffer.alloc(Math.max(0, Math.min(length, size - windowStart)));
+      const bytesRead = await readFileWindowFully(handle, buffer, windowStart);
+      return buffer.toString("base64", 0, bytesRead);
     };
-  }
+    const buildGeneration = async (generationCursor: number): Promise<LogFileGeneration> => {
+      const boundedCursor = Math.min(Math.max(0, generationCursor), size);
+      const prefixLength = Math.min(64, size);
+      const boundaryStart = Math.max(0, boundedCursor - 64);
+      return {
+        identity: `${stat.dev}:${stat.ino}`,
+        prefix: await readWindow(0, prefixLength),
+        prefixLength,
+        boundary: await readWindow(boundaryStart, boundedCursor - boundaryStart),
+        mtimeNs: stat.mtimeNs.toString(),
+        ctimeNs: stat.ctimeNs.toString(),
+      };
+    };
 
-  const handle = await fs.open(params.file, "r");
-  try {
+    if (size === 0 || size <= start) {
+      return {
+        cursor: size,
+        size,
+        lines: [],
+        truncated,
+        reset,
+        skippedBytes,
+        generation: await buildGeneration(size),
+      };
+    }
+
     let prefix = "";
     if (start > 0) {
       const prefixBuf = Buffer.alloc(1);
@@ -174,6 +204,7 @@ async function readLogSlice(params: {
       truncated,
       reset,
       skippedBytes,
+      generation: await buildGeneration(cursor),
     };
   } finally {
     await handle.close();

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -16,6 +16,13 @@ const DEFAULT_MAX_BYTES = 250_000;
 const MAX_LIMIT = 5000;
 const MAX_BYTES = 1_000_000;
 type LogTailLimit = number | "all";
+type LogFileStat = {
+  dev: bigint;
+  ino: bigint;
+  size: bigint;
+  mtimeNs: bigint;
+  ctimeNs: bigint;
+};
 
 function missingPathToNull(error: unknown): null {
   if (!isMissingPathError(error)) {
@@ -102,116 +109,149 @@ async function readLogSlice(params: {
     };
   }
   try {
-    const stat = await handle.stat({ bigint: true });
-    const size = Number(stat.size);
-    const maxBytes = clamp(params.maxBytes, 1, MAX_BYTES);
-    const limit = params.limit === "all" ? undefined : clamp(params.limit, 1, MAX_LIMIT);
-    let cursor =
-      typeof params.cursor === "number" && Number.isFinite(params.cursor)
-        ? Math.max(0, Math.floor(params.cursor))
-        : undefined;
-    let reset = false;
-    let skippedBytes: number | undefined;
-    let truncated = false;
-    let start;
-
-    if (cursor != null) {
-      if (cursor > size) {
-        // File rotated or shrank since the previous cursor; restart near the end.
-        reset = true;
-        start = Math.max(0, size - maxBytes);
-        truncated = start > 0;
-      } else {
-        start = cursor;
-        if (size - start > maxBytes) {
-          // Keep reset as the re-anchor signal for existing clients. The skipped byte count
-          // lets current clients distinguish this valid-cursor fast-forward from file shrink.
-          reset = true;
-          truncated = true;
-          const boundedStart = Math.max(0, size - maxBytes);
-          skippedBytes = boundedStart - start;
-          start = boundedStart;
-        }
+    let lastResult: Omit<LogTailReadPayload, "file"> | undefined;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const stat = (await handle.stat({ bigint: true })) as LogFileStat;
+      const result = await readLogSliceAttempt(params, handle, stat);
+      lastResult = result;
+      const finalStat = (await handle.stat({ bigint: true })) as LogFileStat;
+      if (isSameLogFileStat(stat, finalStat)) {
+        return result;
       }
-    } else {
-      start = Math.max(0, size - maxBytes);
-      truncated = start > 0;
     }
-
-    const readWindow = async (windowStart: number, length: number) => {
-      const buffer = Buffer.alloc(Math.max(0, Math.min(length, size - windowStart)));
-      const bytesRead = await readFileWindowFully(handle, buffer, windowStart);
-      return buffer.toString("base64", 0, bytesRead);
-    };
-    const buildGeneration = async (generationCursor: number): Promise<LogFileGeneration> => {
-      const boundedCursor = Math.min(Math.max(0, generationCursor), size);
-      const prefixLength = Math.min(64, size);
-      const boundaryStart = Math.max(0, boundedCursor - 64);
-      return {
-        identity: `${stat.dev}:${stat.ino}`,
-        size,
-        prefix: await readWindow(0, prefixLength),
-        prefixLength,
-        boundary: await readWindow(boundaryStart, boundedCursor - boundaryStart),
-        mtimeNs: stat.mtimeNs.toString(),
-        ctimeNs: stat.ctimeNs.toString(),
-      };
-    };
-
-    if (size === 0 || size <= start) {
-      return {
-        cursor: size,
-        size,
-        lines: [],
-        truncated,
-        reset,
-        skippedBytes,
-        generation: await buildGeneration(size),
-      };
-    }
-
-    let prefix = "";
-    if (start > 0) {
-      const prefixBuf = Buffer.alloc(1);
-      const prefixRead = await handle.read(prefixBuf, 0, 1, start - 1);
-      prefix = prefixBuf.toString("utf8", 0, prefixRead.bytesRead);
-    }
-
-    const length = Math.max(0, size - start);
-    const buffer = Buffer.alloc(length);
-    const bytesRead = await readFileWindowFully(handle, buffer, start);
-    const text = buffer.toString("utf8", 0, bytesRead);
-    let lines = text.split("\n");
-    lines.pop();
-    if (start > 0 && prefix !== "\n") {
-      // Drop the first partial line when starting in the middle of a file.
-      lines.shift();
-    }
-    if (params.filter) {
-      // Sparse consumers inspect the full byte-bounded window before the shared line cap.
-      lines = lines.filter(params.filter);
-    }
-    if (limit !== undefined && lines.length > limit) {
-      truncated = true;
-      lines = lines.slice(lines.length - limit);
-    }
-
-    // Keep an unterminated record pending so a later read can emit it whole.
-    const lastNewline = buffer.subarray(0, bytesRead).lastIndexOf(0x0a);
-    cursor = text.endsWith("\n") ? size : start + lastNewline + 1;
-
-    return {
-      cursor,
-      size,
-      lines,
-      truncated,
-      reset,
-      skippedBytes,
-      generation: await buildGeneration(cursor),
-    };
+    return lastResult as Omit<LogTailReadPayload, "file">;
   } finally {
     await handle.close();
   }
+}
+
+function isSameLogFileStat(left: LogFileStat, right: LogFileStat): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+async function readLogSliceAttempt(
+  params: {
+    file: string;
+    cursor?: number;
+    limit: LogTailLimit;
+    maxBytes: number;
+    filter?: (line: string) => boolean;
+  },
+  handle: Awaited<ReturnType<typeof fs.open>>,
+  stat: LogFileStat,
+): Promise<Omit<LogTailReadPayload, "file">> {
+  const size = Number(stat.size);
+  const maxBytes = clamp(params.maxBytes, 1, MAX_BYTES);
+  const limit = params.limit === "all" ? undefined : clamp(params.limit, 1, MAX_LIMIT);
+  let cursor =
+    typeof params.cursor === "number" && Number.isFinite(params.cursor)
+      ? Math.max(0, Math.floor(params.cursor))
+      : undefined;
+  let reset = false;
+  let skippedBytes: number | undefined;
+  let truncated = false;
+  let start;
+
+  if (cursor != null) {
+    if (cursor > size) {
+      // File rotated or shrank since the previous cursor; restart near the end.
+      reset = true;
+      start = Math.max(0, size - maxBytes);
+      truncated = start > 0;
+    } else {
+      start = cursor;
+      if (size - start > maxBytes) {
+        // Keep reset as the re-anchor signal for existing clients. The skipped byte count
+        // lets current clients distinguish this valid-cursor fast-forward from file shrink.
+        reset = true;
+        truncated = true;
+        const boundedStart = Math.max(0, size - maxBytes);
+        skippedBytes = boundedStart - start;
+        start = boundedStart;
+      }
+    }
+  } else {
+    start = Math.max(0, size - maxBytes);
+    truncated = start > 0;
+  }
+
+  const readWindow = async (windowStart: number, length: number) => {
+    const buffer = Buffer.alloc(Math.max(0, Math.min(length, size - windowStart)));
+    const bytesRead = await readFileWindowFully(handle, buffer, windowStart);
+    return buffer.toString("base64", 0, bytesRead);
+  };
+  const buildGeneration = async (generationCursor: number): Promise<LogFileGeneration> => {
+    const boundedCursor = Math.min(Math.max(0, generationCursor), size);
+    const prefixLength = Math.min(64, size);
+    const boundaryStart = Math.max(0, boundedCursor - 64);
+    return {
+      identity: `${stat.dev}:${stat.ino}`,
+      size,
+      prefix: await readWindow(0, prefixLength),
+      prefixLength,
+      boundary: await readWindow(boundaryStart, boundedCursor - boundaryStart),
+      mtimeNs: stat.mtimeNs.toString(),
+      ctimeNs: stat.ctimeNs.toString(),
+    };
+  };
+
+  if (size === 0 || size <= start) {
+    return {
+      cursor: size,
+      size,
+      lines: [],
+      truncated,
+      reset,
+      skippedBytes,
+      generation: await buildGeneration(size),
+    };
+  }
+
+  let prefix = "";
+  if (start > 0) {
+    const prefixBuf = Buffer.alloc(1);
+    const prefixRead = await handle.read(prefixBuf, 0, 1, start - 1);
+    prefix = prefixBuf.toString("utf8", 0, prefixRead.bytesRead);
+  }
+
+  const length = Math.max(0, size - start);
+  const buffer = Buffer.alloc(length);
+  const bytesRead = await readFileWindowFully(handle, buffer, start);
+  const text = buffer.toString("utf8", 0, bytesRead);
+  let lines = text.split("\n");
+  lines.pop();
+  if (start > 0 && prefix !== "\n") {
+    // Drop the first partial line when starting in the middle of a file.
+    lines.shift();
+  }
+  if (params.filter) {
+    // Sparse consumers inspect the full byte-bounded window before the shared line cap.
+    lines = lines.filter(params.filter);
+  }
+  if (limit !== undefined && lines.length > limit) {
+    truncated = true;
+    lines = lines.slice(lines.length - limit);
+  }
+
+  // Keep an unterminated record pending so a later read can emit it whole.
+  const lastNewline = buffer.subarray(0, bytesRead).lastIndexOf(0x0a);
+  cursor = text.endsWith("\n") ? size : start + lastNewline + 1;
+
+  return {
+    cursor,
+    size,
+    lines,
+    truncated,
+    reset,
+    skippedBytes,
+    generation: await buildGeneration(cursor),
+  };
 }
 
 async function readConfiguredLogTailInternal(

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -1,4 +1,5 @@
 // Log tail helpers read recent log lines with optional parsing and redaction.
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { isMissingPathError } from "../infra/errno.js";
@@ -15,6 +16,7 @@ const DEFAULT_LIMIT = 500;
 const DEFAULT_MAX_BYTES = 250_000;
 const MAX_LIMIT = 5000;
 const MAX_BYTES = 1_000_000;
+export const LOG_GENERATION_WINDOW_BYTES = 64 * 1024;
 type LogTailLimit = number | "all";
 type LogFileStat = {
   dev: bigint;
@@ -39,6 +41,12 @@ function missingPathToNull(error: unknown): null {
   return null;
 }
 
+function getContentWindowBounds(cursor: number, size: number) {
+  const end = Math.min(Math.max(0, cursor), size);
+  const start = Math.max(0, end - LOG_GENERATION_WINDOW_BYTES);
+  return { start, length: end - start };
+}
+
 /** Payload returned to log-tail callers with cursor and truncation metadata. */
 export type LogTailPayload = {
   file: string;
@@ -57,6 +65,9 @@ export type LogFileGeneration = {
   prefix: string;
   prefixLength: number;
   boundary: string;
+  contentHash: string;
+  contentWindowStart: number;
+  contentWindowLength: number;
   mtimeNs: string;
   ctimeNs: string;
 };
@@ -191,12 +202,20 @@ async function readLogSliceAttempt(
     const boundedCursor = Math.min(Math.max(0, generationCursor), size);
     const prefixLength = Math.min(64, size);
     const boundaryStart = Math.max(0, boundedCursor - 64);
+    const contentWindow = getContentWindowBounds(boundedCursor, size);
+    const contentBuffer = Buffer.alloc(contentWindow.length);
+    const contentBytesRead = await readFileWindowFully(handle, contentBuffer, contentWindow.start);
     return {
       identity: `${stat.dev}:${stat.ino}`,
       size,
       prefix: await readWindow(0, prefixLength),
       prefixLength,
       boundary: await readWindow(boundaryStart, boundedCursor - boundaryStart),
+      contentHash: createHash("sha256")
+        .update(contentBuffer.subarray(0, contentBytesRead))
+        .digest("hex"),
+      contentWindowStart: contentWindow.start,
+      contentWindowLength: contentBytesRead,
       mtimeNs: stat.mtimeNs.toString(),
       ctimeNs: stat.ctimeNs.toString(),
     };

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -233,15 +233,6 @@ async function readLogSliceAttempt(
       truncated = start > 0;
     } else {
       start = cursor;
-      if (size - start > maxBytes) {
-        // Keep reset as the re-anchor signal for existing clients. The skipped byte count
-        // lets current clients distinguish this valid-cursor fast-forward from file shrink.
-        reset = true;
-        truncated = true;
-        const boundedStart = Math.max(0, size - maxBytes);
-        skippedBytes = boundedStart - start;
-        start = boundedStart;
-      }
     }
   } else {
     start = Math.max(0, size - maxBytes);
@@ -258,14 +249,16 @@ async function readLogSliceAttempt(
   const prefixLength = Math.min(64, size);
   const prefixSnapshot = await readBytes(0, prefixLength);
   const generationSnapshotStart = Math.max(0, start - LOG_GENERATION_WINDOW_BYTES);
+  // Cursor-follow reads drain a burst in bounded chunks; later polls continue at the returned cursor.
+  const generationSnapshotEnd = Math.min(size, start + maxBytes);
   const generationSnapshot = await readBytes(
     generationSnapshotStart,
-    size - generationSnapshotStart,
+    generationSnapshotEnd - generationSnapshotStart,
   );
   const buildGeneration = (generationCursor: number): LogFileGeneration | undefined => {
     if (
       prefixSnapshot.length !== prefixLength ||
-      generationSnapshot.length !== size - generationSnapshotStart
+      generationSnapshot.length !== generationSnapshotEnd - generationSnapshotStart
     ) {
       return undefined;
     }
@@ -317,7 +310,8 @@ async function readLogSliceAttempt(
     prefix = prefixBuf.toString("utf8", 0, prefixRead.bytesRead);
   }
 
-  const length = Math.max(0, size - start);
+  // Keep cursor continuation bounded instead of re-anchoring and skipping a burst.
+  const length = Math.max(0, Math.min(size - start, maxBytes));
   const buffer = Buffer.alloc(length);
   const bytesRead = await readFileWindowFully(handle, buffer, start);
   const text = buffer.toString("utf8", 0, bytesRead);
@@ -338,7 +332,8 @@ async function readLogSliceAttempt(
 
   // Keep an unterminated record pending so a later read can emit it whole.
   const lastNewline = buffer.subarray(0, bytesRead).lastIndexOf(0x0a);
-  cursor = text.endsWith("\n") ? size : start + lastNewline + 1;
+  const reachedEnd = start + bytesRead >= size;
+  cursor = reachedEnd && text.endsWith("\n") ? size : start + lastNewline + 1;
 
   return {
     cursor,

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -110,13 +110,18 @@ async function readLogSlice(params: {
   }
   try {
     let lastResult: Omit<LogTailReadPayload, "file"> | undefined;
+    let retryParams = params;
     for (let attempt = 0; attempt < 3; attempt += 1) {
       const stat = (await handle.stat({ bigint: true })) as LogFileStat;
-      const result = await readLogSliceAttempt(params, handle, stat);
+      const result = await readLogSliceAttempt(retryParams, handle, stat);
       lastResult = result;
       const finalStat = (await handle.stat({ bigint: true })) as LogFileStat;
       if (isSameLogFileStat(stat, finalStat)) {
         return result;
+      }
+      if (result.reset && result.skippedBytes === undefined) {
+        // Preserve a shrink/rotation re-anchor if the file grows again before the retry.
+        retryParams = { ...params, cursor: undefined, forceReset: true };
       }
     }
     return lastResult as Omit<LogTailReadPayload, "file">;
@@ -142,6 +147,7 @@ async function readLogSliceAttempt(
     limit: LogTailLimit;
     maxBytes: number;
     filter?: (line: string) => boolean;
+    forceReset?: boolean;
   },
   handle: Awaited<ReturnType<typeof fs.open>>,
   stat: LogFileStat,
@@ -153,7 +159,7 @@ async function readLogSliceAttempt(
     typeof params.cursor === "number" && Number.isFinite(params.cursor)
       ? Math.max(0, Math.floor(params.cursor))
       : undefined;
-  let reset = false;
+  let reset = params.forceReset === true;
   let skippedBytes: number | undefined;
   let truncated = false;
   let start;

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -23,6 +23,14 @@ type LogFileStat = {
   mtimeNs: bigint;
   ctimeNs: bigint;
 };
+type LogSliceParams = {
+  file: string;
+  cursor?: number;
+  limit: LogTailLimit;
+  maxBytes: number;
+  filter?: (line: string) => boolean;
+  forceReset?: boolean;
+};
 
 function missingPathToNull(error: unknown): null {
   if (!isMissingPathError(error)) {
@@ -91,13 +99,7 @@ async function resolveLogFile(file: string, options?: { rolling?: boolean }): Pr
   return sorted[0]?.path ?? file;
 }
 
-async function readLogSlice(params: {
-  file: string;
-  cursor?: number;
-  limit: LogTailLimit;
-  maxBytes: number;
-  filter?: (line: string) => boolean;
-}): Promise<Omit<LogTailReadPayload, "file">> {
+async function readLogSlice(params: LogSliceParams): Promise<Omit<LogTailReadPayload, "file">> {
   const handle = await fs.open(params.file, "r").catch(missingPathToNull);
   if (!handle) {
     return {
@@ -141,14 +143,7 @@ function isSameLogFileStat(left: LogFileStat, right: LogFileStat): boolean {
 }
 
 async function readLogSliceAttempt(
-  params: {
-    file: string;
-    cursor?: number;
-    limit: LogTailLimit;
-    maxBytes: number;
-    filter?: (line: string) => boolean;
-    forceReset?: boolean;
-  },
+  params: LogSliceParams,
   handle: Awaited<ReturnType<typeof fs.open>>,
   stat: LogFileStat,
 ): Promise<Omit<LogTailReadPayload, "file">> {

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -33,12 +33,12 @@ export type LogTailPayload = {
   truncated: boolean;
   reset: boolean;
   skippedBytes?: number;
-  generation?: LogFileGeneration;
 };
 
 /** File identity and content samples captured by the handle used for a tail read. */
 export type LogFileGeneration = {
   identity: string;
+  size: number;
   prefix: string;
   prefixLength: number;
   boundary: string;
@@ -47,8 +47,10 @@ export type LogFileGeneration = {
 };
 
 /** Redacted configured log tail with only parseable structured records. */
+type LogTailReadPayload = LogTailPayload & { generation?: LogFileGeneration };
 type ParsedLogTailPayload = Omit<LogTailPayload, "lines"> & {
   lines: ParsedLogLine[];
+  generation?: LogFileGeneration;
 };
 
 /** Resolves a rolling daily log path to the newest existing rolling log when needed. */
@@ -88,7 +90,7 @@ async function readLogSlice(params: {
   limit: LogTailLimit;
   maxBytes: number;
   filter?: (line: string) => boolean;
-}): Promise<Omit<LogTailPayload, "file">> {
+}): Promise<Omit<LogTailReadPayload, "file">> {
   const handle = await fs.open(params.file, "r").catch(missingPathToNull);
   if (!handle) {
     return {
@@ -147,6 +149,7 @@ async function readLogSlice(params: {
       const boundaryStart = Math.max(0, boundedCursor - 64);
       return {
         identity: `${stat.dev}:${stat.ino}`,
+        size,
         prefix: await readWindow(0, prefixLength),
         prefixLength,
         boundary: await readWindow(boundaryStart, boundedCursor - boundaryStart),
@@ -211,11 +214,10 @@ async function readLogSlice(params: {
   }
 }
 
-/** Reads and redacts the configured log tail with bounded bytes and line count. */
-export async function readConfiguredLogTail(
+async function readConfiguredLogTailInternal(
   params?: { cursor?: number; limit?: LogTailLimit; maxBytes?: number },
   filter?: (line: string) => boolean,
-): Promise<LogTailPayload> {
+): Promise<LogTailReadPayload> {
   const target = getResolvedLoggerFileTarget();
   const file = await resolveLogFile(target.file, { rolling: target.rolling });
   const result = await readLogSlice({
@@ -233,6 +235,16 @@ export async function readConfiguredLogTail(
   };
 }
 
+/** Reads and redacts the configured log tail with bounded bytes and line count. */
+export async function readConfiguredLogTail(
+  params?: { cursor?: number; limit?: LogTailLimit; maxBytes?: number },
+  filter?: (line: string) => boolean,
+): Promise<LogTailPayload> {
+  const tail = await readConfiguredLogTailInternal(params, filter);
+  const { generation: _generation, ...publicTail } = tail;
+  return publicTail;
+}
+
 /** Reads the canonical configured tail and parses its already-redacted lines. */
 export async function readConfiguredParsedLogTail(params?: {
   cursor?: number;
@@ -240,7 +252,7 @@ export async function readConfiguredParsedLogTail(params?: {
   maxBytes?: number;
   filter?: (line: Pick<ParsedLogLine, "subsystem" | "module" | "plugin">) => boolean;
 }): Promise<ParsedLogTailPayload> {
-  const tail = await readConfiguredLogTail(params, (raw) => {
+  const tail = await readConfiguredLogTailInternal(params, (raw) => {
     const parsed = parseLogLine(raw);
     return parsed !== null && (params?.filter?.(parsed) ?? true);
   });

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -15,6 +15,7 @@ const DEFAULT_LIMIT = 500;
 const DEFAULT_MAX_BYTES = 250_000;
 const MAX_LIMIT = 5000;
 const MAX_BYTES = 1_000_000;
+type LogTailLimit = number | "all";
 
 function missingPathToNull(error: unknown): null {
   if (!isMissingPathError(error)) {
@@ -73,7 +74,7 @@ async function resolveLogFile(file: string, options?: { rolling?: boolean }): Pr
 async function readLogSlice(params: {
   file: string;
   cursor?: number;
-  limit: number;
+  limit: LogTailLimit;
   maxBytes: number;
   filter?: (line: string) => boolean;
 }): Promise<Omit<LogTailPayload, "file">> {
@@ -90,7 +91,7 @@ async function readLogSlice(params: {
 
   const size = stat.size;
   const maxBytes = clamp(params.maxBytes, 1, MAX_BYTES);
-  const limit = clamp(params.limit, 1, MAX_LIMIT);
+  const limit = params.limit === "all" ? undefined : clamp(params.limit, 1, MAX_LIMIT);
   let cursor =
     typeof params.cursor === "number" && Number.isFinite(params.cursor)
       ? Math.max(0, Math.floor(params.cursor))
@@ -157,7 +158,7 @@ async function readLogSlice(params: {
       // Sparse consumers inspect the full byte-bounded window before the shared line cap.
       lines = lines.filter(params.filter);
     }
-    if (lines.length > limit) {
+    if (limit !== undefined && lines.length > limit) {
       truncated = true;
       lines = lines.slice(lines.length - limit);
     }
@@ -181,7 +182,7 @@ async function readLogSlice(params: {
 
 /** Reads and redacts the configured log tail with bounded bytes and line count. */
 export async function readConfiguredLogTail(
-  params?: { cursor?: number; limit?: number; maxBytes?: number },
+  params?: { cursor?: number; limit?: LogTailLimit; maxBytes?: number },
   filter?: (line: string) => boolean,
 ): Promise<LogTailPayload> {
   const target = getResolvedLoggerFileTarget();
@@ -204,7 +205,7 @@ export async function readConfiguredLogTail(
 /** Reads the canonical configured tail and parses its already-redacted lines. */
 export async function readConfiguredParsedLogTail(params?: {
   cursor?: number;
-  limit?: number;
+  limit?: LogTailLimit;
   maxBytes?: number;
   filter?: (line: Pick<ParsedLogLine, "subsystem" | "module" | "plugin">) => boolean;
 }): Promise<ParsedLogTailPayload> {

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -248,29 +248,51 @@ async function readLogSliceAttempt(
     truncated = start > 0;
   }
 
-  const readWindow = async (windowStart: number, length: number) => {
+  const readBytes = async (windowStart: number, length: number) => {
     const buffer = Buffer.alloc(Math.max(0, Math.min(length, size - windowStart)));
     const bytesRead = await readFileWindowFully(handle, buffer, windowStart);
-    return buffer.toString("base64", 0, bytesRead);
+    return buffer.subarray(0, bytesRead);
   };
-  const buildGeneration = async (generationCursor: number): Promise<LogFileGeneration> => {
+  // Capture the generation before reading returned records so a rewrite cannot replace its
+  // fingerprint after the output buffer was produced.
+  const prefixLength = Math.min(64, size);
+  const prefixSnapshot = await readBytes(0, prefixLength);
+  const generationSnapshotStart = Math.max(0, size - LOG_GENERATION_WINDOW_BYTES);
+  const generationSnapshot = await readBytes(
+    generationSnapshotStart,
+    size - generationSnapshotStart,
+  );
+  const buildGeneration = (generationCursor: number): LogFileGeneration | undefined => {
+    if (
+      prefixSnapshot.length !== prefixLength ||
+      generationSnapshot.length !== size - generationSnapshotStart
+    ) {
+      return undefined;
+    }
     const boundedCursor = Math.min(Math.max(0, generationCursor), size);
-    const prefixLength = Math.min(64, size);
     const boundaryStart = Math.max(0, boundedCursor - 64);
     const contentWindow = getContentWindowBounds(boundedCursor, size);
-    const contentBuffer = Buffer.alloc(contentWindow.length);
-    const contentBytesRead = await readFileWindowFully(handle, contentBuffer, contentWindow.start);
+    const sliceSnapshot = (windowStart: number, length: number) => {
+      const offset = windowStart - generationSnapshotStart;
+      if (offset < 0 || offset + length > generationSnapshot.length) {
+        return undefined;
+      }
+      return generationSnapshot.subarray(offset, offset + length);
+    };
+    const contentBuffer = sliceSnapshot(contentWindow.start, contentWindow.length);
+    const boundary = sliceSnapshot(boundaryStart, boundedCursor - boundaryStart);
+    if (contentBuffer === undefined || boundary === undefined) {
+      return undefined;
+    }
     return {
       identity: `${stat.dev}:${stat.ino}`,
       size,
-      prefix: await readWindow(0, prefixLength),
+      prefix: prefixSnapshot.toString("base64"),
       prefixLength,
-      boundary: await readWindow(boundaryStart, boundedCursor - boundaryStart),
-      contentHash: createHash("sha256")
-        .update(contentBuffer.subarray(0, contentBytesRead))
-        .digest("hex"),
+      boundary: boundary.toString("base64"),
+      contentHash: createHash("sha256").update(contentBuffer).digest("hex"),
       contentWindowStart: contentWindow.start,
-      contentWindowLength: contentBytesRead,
+      contentWindowLength: contentBuffer.length,
       mtimeNs: stat.mtimeNs.toString(),
       ctimeNs: stat.ctimeNs.toString(),
     };
@@ -284,7 +306,7 @@ async function readLogSliceAttempt(
       truncated,
       reset,
       skippedBytes,
-      generation: await buildGeneration(size),
+      generation: buildGeneration(size),
     };
   }
 
@@ -325,7 +347,7 @@ async function readLogSliceAttempt(
     truncated,
     reset,
     skippedBytes,
-    generation: await buildGeneration(cursor),
+    generation: buildGeneration(cursor),
   };
 }
 

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -134,7 +134,10 @@ async function readLogSlice(params: LogSliceParams): Promise<Omit<LogTailReadPay
       const result = await readLogSliceAttempt(retryParams, handle, stat);
       lastResult = result;
       const finalStat = (await handle.stat({ bigint: true })) as LogFileStat;
-      if (isSameLogFileStat(stat, finalStat)) {
+      if (
+        isSameLogFileStat(stat, finalStat) ||
+        (await isStableLogSlice(handle, stat, finalStat, result, retryParams.forceReset === true))
+      ) {
         return result;
       }
       if (result.reset && result.skippedBytes === undefined) {
@@ -159,6 +162,50 @@ function isSameLogFileStat(left: LogFileStat, right: LogFileStat): boolean {
     left.mtimeNs === right.mtimeNs &&
     left.ctimeNs === right.ctimeNs
   );
+}
+
+// An append can race the read without changing consumed bytes; validate that bounded snapshot
+// instead of requiring an idle file, while preserving shrink re-anchors for callers.
+async function isStableLogSlice(
+  handle: Awaited<ReturnType<typeof fs.open>>,
+  initialStat: LogFileStat,
+  finalStat: LogFileStat,
+  result: Omit<LogTailReadPayload, "file">,
+  forcedReset: boolean,
+): Promise<boolean> {
+  if (
+    initialStat.dev !== finalStat.dev ||
+    initialStat.ino !== finalStat.ino ||
+    finalStat.size < initialStat.size ||
+    (!forcedReset && result.reset && result.skippedBytes === undefined) ||
+    result.generation === undefined
+  ) {
+    return false;
+  }
+
+  const generation = result.generation;
+  const readWindow = async (start: number, length: number) => {
+    const buffer = Buffer.alloc(Math.max(0, length));
+    const bytesRead = await readFileWindowFully(handle, buffer, start);
+    return buffer.subarray(0, bytesRead);
+  };
+  const prefix = await readWindow(0, generation.prefixLength);
+  if (!prefix.equals(Buffer.from(generation.prefix, "base64"))) {
+    return false;
+  }
+
+  const content = await readWindow(generation.contentWindowStart, generation.contentWindowLength);
+  if (
+    content.length !== generation.contentWindowLength ||
+    createHash("sha256").update(content).digest("hex") !== generation.contentHash
+  ) {
+    return false;
+  }
+
+  const cursor = generation.contentWindowStart + generation.contentWindowLength;
+  const boundaryStart = Math.max(0, cursor - 64);
+  const boundary = await readWindow(boundaryStart, cursor - boundaryStart);
+  return boundary.equals(Buffer.from(generation.boundary, "base64"));
 }
 
 async function readLogSliceAttempt(

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -257,7 +257,7 @@ async function readLogSliceAttempt(
   // fingerprint after the output buffer was produced.
   const prefixLength = Math.min(64, size);
   const prefixSnapshot = await readBytes(0, prefixLength);
-  const generationSnapshotStart = Math.max(0, size - LOG_GENERATION_WINDOW_BYTES);
+  const generationSnapshotStart = Math.max(0, start - LOG_GENERATION_WINDOW_BYTES);
   const generationSnapshot = await readBytes(
     generationSnapshotStart,
     size - generationSnapshotStart,

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -63,9 +63,9 @@ export type LogTailPayload = {
 export type LogFileGeneration = {
   identity: string;
   size: number;
-  prefix: string;
+  prefixHash: string;
   prefixLength: number;
-  boundary: string;
+  boundaryHash: string;
   contentHash: string;
   contentWindowStart: number;
   contentWindowLength: number;
@@ -190,7 +190,7 @@ async function isStableLogSlice(
     return buffer.subarray(0, bytesRead);
   };
   const prefix = await readWindow(0, generation.prefixLength);
-  if (!prefix.equals(Buffer.from(generation.prefix, "base64"))) {
+  if (createHash("sha256").update(prefix).digest("hex") !== generation.prefixHash) {
     return false;
   }
 
@@ -205,7 +205,7 @@ async function isStableLogSlice(
   const cursor = generation.contentWindowStart + generation.contentWindowLength;
   const boundaryStart = Math.max(0, cursor - 64);
   const boundary = await readWindow(boundaryStart, cursor - boundaryStart);
-  return boundary.equals(Buffer.from(generation.boundary, "base64"));
+  return createHash("sha256").update(boundary).digest("hex") === generation.boundaryHash;
 }
 
 async function readLogSliceAttempt(
@@ -244,14 +244,14 @@ async function readLogSliceAttempt(
     const bytesRead = await readFileWindowFully(handle, buffer, windowStart);
     return buffer.subarray(0, bytesRead);
   };
+
   // Capture the generation before reading returned records so a rewrite cannot replace its
   // fingerprint after the output buffer was produced.
   const prefixLength = Math.min(64, size);
   const prefixSnapshot = await readBytes(0, prefixLength);
-  const generationSnapshotStart = Math.max(0, start - LOG_GENERATION_WINDOW_BYTES);
-  // Cursor-follow reads drain a burst in bounded chunks; later polls continue at the returned cursor.
-  const generationSnapshotEnd = Math.min(size, start + maxBytes);
-  const generationSnapshot = await readBytes(
+  let generationSnapshotStart = Math.max(0, start - LOG_GENERATION_WINDOW_BYTES);
+  let generationSnapshotEnd = Math.min(size, start + maxBytes);
+  let generationSnapshot = await readBytes(
     generationSnapshotStart,
     generationSnapshotEnd - generationSnapshotStart,
   );
@@ -280,15 +280,24 @@ async function readLogSliceAttempt(
     return {
       identity: `${stat.dev}:${stat.ino}`,
       size,
-      prefix: prefixSnapshot.toString("base64"),
+      prefixHash: createHash("sha256").update(prefixSnapshot).digest("hex"),
       prefixLength,
-      boundary: boundary.toString("base64"),
+      boundaryHash: createHash("sha256").update(boundary).digest("hex"),
       contentHash: createHash("sha256").update(contentBuffer).digest("hex"),
       contentWindowStart: contentWindow.start,
       contentWindowLength: contentBuffer.length,
       mtimeNs: stat.mtimeNs.toString(),
       ctimeNs: stat.ctimeNs.toString(),
     };
+  };
+
+  const captureGeneration = async (generationCursor: number) => {
+    generationSnapshotStart = Math.max(0, generationCursor - LOG_GENERATION_WINDOW_BYTES);
+    generationSnapshotEnd = generationCursor;
+    generationSnapshot = await readBytes(
+      generationSnapshotStart,
+      generationSnapshotEnd - generationSnapshotStart,
+    );
   };
 
   if (size === 0 || size <= start) {
@@ -330,10 +339,32 @@ async function readLogSliceAttempt(
     lines = lines.slice(lines.length - limit);
   }
 
-  // Keep an unterminated record pending so a later read can emit it whole.
   const lastNewline = buffer.subarray(0, bytesRead).lastIndexOf(0x0a);
   const reachedEnd = start + bytesRead >= size;
-  cursor = reachedEnd && text.endsWith("\n") ? size : start + lastNewline + 1;
+  let skippedOversizedRecord = false;
+  if (lastNewline < 0) {
+    // Keep an unterminated record pending so a later read can emit it whole. If more bytes
+    // exist, discard only this bounded chunk and advance toward its newline without buffering it.
+    lines = [];
+    if (!reachedEnd) {
+      const nextCursor = start + bytesRead;
+      if (nextCursor > start) {
+        truncated = true;
+        skippedBytes = nextCursor - start;
+        cursor = nextCursor;
+        skippedOversizedRecord = true;
+      }
+    }
+    cursor ??= start;
+  } else {
+    cursor = reachedEnd && text.endsWith("\n") ? size : start + lastNewline + 1;
+  }
+
+  if (skippedOversizedRecord) {
+    // The skipped newline can be beyond the initial read window; refresh only this bounded
+    // cursor snapshot so follow checkpoint validation can continue from the new position.
+    await captureGeneration(cursor);
+  }
 
   return {
     cursor,

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -16,7 +16,8 @@ const DEFAULT_LIMIT = 500;
 const DEFAULT_MAX_BYTES = 250_000;
 const MAX_LIMIT = 5000;
 const MAX_BYTES = 1_000_000;
-export const LOG_GENERATION_WINDOW_BYTES = 64 * 1024;
+// Follow validation fingerprints the entire bounded tail window, not just its edge samples.
+export const LOG_GENERATION_WINDOW_BYTES = MAX_BYTES;
 type LogTailLimit = number | "all";
 type LogFileStat = {
   dev: bigint;

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -73,10 +73,14 @@ export type LogFileGeneration = {
 };
 
 /** Redacted configured log tail with only parseable structured records. */
-type LogTailReadPayload = LogTailPayload & { generation?: LogFileGeneration };
+type LogTailReadPayload = LogTailPayload & {
+  generation?: LogFileGeneration;
+  generationStable?: boolean;
+};
 type ParsedLogTailPayload = Omit<LogTailPayload, "lines"> & {
   lines: ParsedLogLine[];
   generation?: LogFileGeneration;
+  generationStable?: boolean;
 };
 
 /** Resolves a rolling daily log path to the newest existing rolling log when needed. */
@@ -137,7 +141,10 @@ async function readLogSlice(params: LogSliceParams): Promise<Omit<LogTailReadPay
         retryParams = { ...params, cursor: undefined, forceReset: true };
       }
     }
-    return lastResult as Omit<LogTailReadPayload, "file">;
+    return {
+      ...(lastResult as Omit<LogTailReadPayload, "file">),
+      generationStable: false,
+    };
   } finally {
     await handle.close();
   }
@@ -301,7 +308,7 @@ export async function readConfiguredLogTail(
   filter?: (line: string) => boolean,
 ): Promise<LogTailPayload> {
   const tail = await readConfiguredLogTailInternal(params, filter);
-  const { generation: _generation, ...publicTail } = tail;
+  const { generation: _generation, generationStable: _generationStable, ...publicTail } = tail;
   return publicTail;
 }
 

--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -54,6 +54,18 @@ describe("writeRuntimeJson", () => {
     expect(runtime.writeJson).toHaveBeenCalledWith({ key: "value" }, 2);
   });
 
+  it("returns the JSON writer backpressure result", () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+      writeStdout: vi.fn(),
+      writeJson: vi.fn(() => false),
+    };
+
+    expect(writeRuntimeJson(runtime, { key: "value" })).toBe(false);
+  });
+
   it("writes JSON using log when writeJson not available", () => {
     const runtime = {
       log: vi.fn(),
@@ -101,6 +113,18 @@ describe("writeRuntimeStdout", () => {
 
     expect(runtime.writeStdout).toHaveBeenCalledWith("plain output");
     expect(runtime.log).not.toHaveBeenCalled();
+  });
+
+  it("returns the stdout writer backpressure result", () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+      writeStdout: vi.fn(() => false),
+      writeJson: vi.fn(),
+    };
+
+    expect(writeRuntimeStdout(runtime, "plain output")).toBe(false);
   });
 
   it("falls back to the runtime logger when no stdout writer is available", () => {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -20,8 +20,8 @@ export type RuntimeEnv = {
 };
 
 export type OutputRuntimeEnv = RuntimeEnv & {
-  writeStdout: (value: string) => void;
-  writeJson: (value: unknown, space?: number) => void;
+  writeStdout: (value: string) => boolean | void;
+  writeJson: (value: unknown, space?: number) => boolean | void;
 };
 
 function shouldEmitRuntimeLog(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -61,14 +61,14 @@ function hasRuntimeOutputWriter(
   return typeof (runtime as Partial<OutputRuntimeEnv>).writeStdout === "function";
 }
 
-function writeStdout(value: string): void {
+function writeStdout(value: string): boolean | void {
   if (!shouldEmitRuntimeStdout()) {
     return;
   }
   clearActiveProgressLine();
   const line = value.endsWith("\n") ? value : `${value}\n`;
   try {
-    process.stdout.write(line);
+    return process.stdout.write(line);
   } catch (err) {
     if (isPipeClosedError(err)) {
       return;
@@ -92,7 +92,7 @@ function createRuntimeIo(): Pick<OutputRuntimeEnv, "log" | "error" | "writeStdou
     },
     writeStdout,
     writeJson: (value: unknown, space = 2) => {
-      writeStdout(JSON.stringify(value, null, space > 0 ? space : undefined));
+      return writeStdout(JSON.stringify(value, null, space > 0 ? space : undefined));
     },
   };
 }
@@ -146,18 +146,19 @@ export function writeRuntimeJson(
   runtime: RuntimeEnv | OutputRuntimeEnv,
   value: unknown,
   space = 2,
-): void {
+): boolean | void {
   if (hasRuntimeOutputWriter(runtime)) {
-    runtime.writeJson(value, space);
-    return;
+    return runtime.writeJson(value, space);
   }
   runtime.log(JSON.stringify(value, null, space > 0 ? space : undefined));
 }
 
-export function writeRuntimeStdout(runtime: RuntimeEnv | OutputRuntimeEnv, value: string): void {
+export function writeRuntimeStdout(
+  runtime: RuntimeEnv | OutputRuntimeEnv,
+  value: string,
+): boolean | void {
   if (hasRuntimeOutputWriter(runtime)) {
-    runtime.writeStdout(value);
-    return;
+    return runtime.writeStdout(value);
   }
   runtime.log(value);
 }


### PR DESCRIPTION
## What Problem This Solves

`openclaw channels logs` was one-shot only. Operators could not keep a channel-scoped log view open while new gateway records arrived, so live diagnosis required repeated manual invocations.

Closes #130198

## Why This Change Was Made

This adds additive `--follow` behavior to the existing channel log command. The first read honors `--lines`; later polls read all newly available records, preserve channel filtering, emit newline-delimited JSON records in `--json` mode, and re-anchor when the configured file is rotated or reset. SIGINT/SIGTERM and closed stdout stop the follow loop cleanly.

The existing OpenClaw log-tail/parser path is the right owner boundary, so the implementation reuses it rather than adding a watcher dependency or a second log source. A lightweight existing-solutions preflight found no maintained library in the current dependency surface that supplies this channel-filtered, rotation-aware follow contract without duplicating the command's ownership and output rules.

`--interval` is an additive CLI-only polling control. It accepts a positive integer in milliseconds, defaults to 1000, and is capped at Node's maximum timer delay; it is not persisted in config or environment state and does not change log sources, permissions, remote behavior, or channel ownership. One-shot behavior is unchanged.

Across the complete parent-to-HEAD branch, the diff is 11 files with 1,901 insertions and 89 deletions: 883 production insertions/83 deletions, 1,003 test insertions/3 deletions, and 15 documentation insertions/3 deletions. The final branch includes the original feature, generation/checkpoint hardening, suffix repair, bounded cursor reads, and oversized-record progress fix; no parallel logging system or new dependency was introduced.

## User Impact

Users can run `openclaw channels logs --channel slack --follow` or add `--json` to observe newly appended matching records. Follow JSON is newline-delimited `meta`, `notice`, and `log` records; the one-shot JSON object shape remains unchanged. The follow loop waits for stdout drain before emitting more records, and Ctrl-C exits with status 0.

Reset detection covers pathname rotation and detectable same-path truncate/regrow or rewrite changes using bounded file identity/content checkpoints. This is a bounded detection contract, not an archival no-loss guarantee for arbitrary rewrites that are indistinguishable from append-only growth.

## Evidence

### Acceptance-red on the parent

The parent source commit `c12305c799058d2bd3176073697a62aa1df0eb30` registers `channels logs` in `src/cli/channels-cli.ts:259-264` with `--channel`, `--lines`, and `--json`, but no `--follow`. I checked the original argv against that parent parser in an isolated Commander harness: `channels logs --channel slack --json --lines 1 --follow --interval 100` exited 1 with the exact stderr `error: unknown option '--follow'` and no stdout. This is the acceptance-red for the requested feature; historical harness outputs are not used as proof.

### Focused tests, static checks, and build

- `node scripts/run-vitest.mjs src/commands/channels.logs.test.ts src/logging/log-tail.test.ts` on final source commit `fd59082197ba5c263f8d867dc0ed5c88d4430226` — 65/65 passed (38 channels, 27 log-tail).
- The preceding four-file focused suite on `6f94d2c55cda508570f5da5a0adfd9daf940bdd7` was 76/76 passed (37 channels, 25 log-tail, 1 redaction, 13 runtime).
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental` — passed.
- Scoped `oxlint --deny-warnings`, `oxfmt --check`, and `git diff --check` — passed.
- `OPENCLAW_BUILD_ALL_NO_PNPM=1 node --import ./scripts/tsx.mjs scripts/build-all.mts gatewayWatch` — exit 0 on the current HEAD; all 11/11 tsdown invocations, the CLI bootstrap import guard, runtime-postbuild, plugin control-plane load checks, plugin SDK export checks, asset copy, Control UI production build, and startup metadata completed. This uses the repository's built-in Node fallback for the three asset/UI package steps while preserving the same build phases.

Final source commit: `fd59082197ba5c263f8d867dc0ed5c88d4430226`; tree: `2759655cbec38da26703a1b0b361b302d73dcf11`.

### Real CLI proof

- Follow command: `node dist/entry.js channels logs --channel slack --json --lines 1 --follow --interval 100`.
- The current-head production CLI waited for its startup `meta` marker, then exercised an append burst, channel filtering, pathname rotation, same-path rewrite, newline-delimited JSON, and SIGINT. Follow exited `{code: 0, signal: null}` with empty stderr.
- Observed matching messages, in order: `before-two`, `burst-a`, `burst-b`, `burst-c`, `new-first`, `new-second`, `new-third`, `new-fourth`.
- The `gateway/health` and Discord fixture records were absent. Notices covered truncation, pathname rotation, and same-path reset.
- One-shot control: `node dist/entry.js channels logs --channel slack --json --lines 1` — exit 0, existing object shape preserved, and only `new-fourth` returned.
- Oversized-record progress proof appended a 1,100,000-byte non-matching record followed by `after-oversized`; the matching record arrived, the oversized payload was not emitted, the truncation notice was present, and the process exited 0 with empty stderr.
- The repair-owned final P0–P3 review artifact reports no accepted/actionable finding for the final source state. Its disposition covers bounded cursor advancement for oversized records, generation validation, redacted/bounded output, reset/rotation behavior, JSON-lines, interval validation, and backpressure.

Representative redacted NDJSON from the behavior run:

```text
{"type":"meta","file":"[redacted fixture path]","channel":"slack"}
{"type":"notice","message":"Log tail truncated; earlier entries were omitted."}
{"type":"log","module":"gateway/channels/slack/send","message":"before-two","raw":"[redacted]"}
{"type":"log","module":"gateway/channels/slack/send","message":"burst-a","raw":"[redacted]"}
{"type":"log","module":"gateway/channels/slack/send","message":"burst-b","raw":"[redacted]"}
{"type":"log","module":"gateway/channels/slack/send","message":"burst-c","raw":"[redacted]"}
{"type":"notice","message":"Log file reset; re-reading the current tail."}
{"type":"log","module":"gateway/channels/slack/send","message":"new-first","raw":"[redacted]"}
{"type":"log","module":"gateway/channels/slack/send","message":"new-second","raw":"[redacted]"}
{"type":"notice","message":"Log file reset; re-reading the current tail."}
{"type":"log","module":"gateway/channels/slack/send","message":"new-third","raw":"[redacted]"}
{"type":"log","module":"gateway/channels/slack/send","message":"new-fourth","raw":"[redacted]"}
```

### Reproducible fixture steps

1. Configure `logging.file` to a temporary newline-delimited structured log and seed matching Slack records plus one `gateway/health` and one Discord record.
2. Run `node dist/entry.js channels logs --channel slack --json --lines 1 --follow --interval 100`.
3. Append `burst-a`, the health record, `burst-b`, and `burst-c` in one write; verify all three Slack messages arrive and non-Slack records do not.
4. Rename the active file and create a new file at the configured pathname containing `new-first` and `new-second`; verify a reset notice and both records.
5. Truncate/regrow that same pathname with `new-third` and `new-fourth`; verify a second reset notice and both records.
6. Append a non-matching structured record larger than 1 MiB followed by a matching Slack record; verify the later Slack record arrives and the oversized payload is not emitted.
7. Send Ctrl-C; verify exit 0. Run the one-shot command with `--lines 1` and verify only `new-fourth` is returned in the existing object shape.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Condensed activity summary (not a verbatim transcript)</summary>

```text
- Read the contribution, testing, and review contracts before changing the follow owner.
- Fixed the large-file partial-record generation window, propagated stdout writer backpressure, serialized follow output around drain/abort, preserved committed records across incomplete-suffix repair, and kept one-shot output unchanged.
- Added focused regressions for the large partial tail, writer return values, stdout drain ordering, rotation/rewrite races, filtering, JSON/text output, and signal cleanup.
- Ran the focused suites, tsgo, scoped lint/format checks, and the production build successfully.
- Ran the current-head built CLI for append/filter/burst/rotation/same-path rewrite/JSON/Ctrl-C/one-shot and oversized-record progress; all bounded proofs passed.
- The repair-owned final P0-P3 review reports no accepted/actionable finding after the oversized-record progress repair. No GitHub writes or push were performed before this PR.
```

</details>
<!-- agent-transcript:end -->
