### PR TITLE
refactor: speed up cold Google policy checks

### DIFF
--- a/extensions/google/provider-policy-api.test.ts
+++ b/extensions/google/provider-policy-api.test.ts
@@ -1,6 +1,11 @@
 // Google tests cover provider policy api plugin behavior.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { normalizeConfig, resolveThinkingProfile } from "./provider-policy-api.js";
+
+// Config and model policy must remain usable without initializing streaming transports.
+vi.mock("openclaw/plugin-sdk/provider-stream-shared", () => {
+  throw new Error("Google provider policy must not load the streaming SDK");
+});
 
 describe("google provider policy public artifact", () => {
   it("normalizes Google provider config without loading the full provider plugin", () => {

--- a/extensions/google/provider-policy.ts
+++ b/extensions/google/provider-policy.ts
@@ -4,6 +4,10 @@ import type {
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/core";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
+import {
+  isGoogleGemini3ProModel,
+  isGoogleGemini3ThinkingLevelModel,
+} from "openclaw/plugin-sdk/provider-thinking-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeAntigravityModelId, normalizeGoogleModelId } from "./model-id.js";
 import {
@@ -12,7 +16,6 @@ import {
   normalizeGoogleApiBaseUrl,
   normalizeGoogleGenerativeAiBaseUrl,
 } from "./src/google-api-base-url.js";
-import { isGoogleGemini3ProModel, isGoogleGemini3ThinkingLevelModel } from "./thinking-api.js";
 
 export {
   DEFAULT_GOOGLE_API_BASE_URL,

--- a/extensions/google/thinking-api.ts
+++ b/extensions/google/thinking-api.ts
@@ -1,11 +1,13 @@
+export {
+  isGoogleGemini3FlashModel,
+  isGoogleGemini3ProModel,
+  isGoogleGemini3ThinkingLevelModel,
+} from "openclaw/plugin-sdk/provider-thinking-runtime";
 // Google API module exposes the plugin public contract.
 export {
   createGoogleThinkingPayloadWrapper,
   createGoogleThinkingStreamWrapper,
   isGoogleGemini25ThinkingBudgetModel,
-  isGoogleGemini3FlashModel,
-  isGoogleGemini3ProModel,
-  isGoogleGemini3ThinkingLevelModel,
   isGoogleThinkingRequiredModel,
   resolveGoogleGemini3ThinkingLevel,
   sanitizeGoogleThinkingPayload,

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -23,7 +23,7 @@ Host policy (request fetch guarding, secret redaction, strict-tool defaults,
 provider plugin hooks, and diagnostics logging) can be injected with
 `configureAiTransportHost`; the defaults are inert.
 
-The explicit `@openclaw/ai/internal/anthropic`, `openai`,
+The explicit `@openclaw/ai/internal/anthropic`, `google-model-family`, `openai`,
 `openai-responses-payload-policy`, `retry-after`, `runtime`, `shared`, and
 `tool-schema` subpaths exist for the OpenClaw application itself.
 They carry no semver guarantee and can change or disappear in any release; do

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -76,6 +76,11 @@
       "import": "./dist/internal/anthropic.mjs",
       "default": "./dist/internal/anthropic.mjs"
     },
+    "./internal/google-model-family": {
+      "types": "./dist/internal/google-model-family.d.mts",
+      "import": "./dist/internal/google-model-family.mjs",
+      "default": "./dist/internal/google-model-family.mjs"
+    },
     "./internal/openai": {
       "types": "./dist/internal/openai.d.mts",
       "import": "./dist/internal/openai.mjs",

--- a/packages/ai/src/internal/google-model-family.ts
+++ b/packages/ai/src/internal/google-model-family.ts
@@ -1,0 +1,15 @@
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+
+export function isGoogleGemini3ProModel(modelId: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(modelId);
+  return /(?:^|\/)gemini-(?:3(?:\.\d+)?-pro|pro-latest)(?:-|$)/.test(normalized);
+}
+
+export function isGoogleGemini3FlashModel(modelId: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(modelId);
+  return /(?:^|\/)gemini-(?:3(?:\.\d+)?-flash|flash(?:-lite)?-latest)(?:-|$)/.test(normalized);
+}
+
+export function isGoogleGemini3ThinkingLevelModel(modelId: string): boolean {
+  return isGoogleGemini3ProModel(modelId) || isGoogleGemini3FlashModel(modelId);
+}

--- a/packages/ai/src/transports/openai-completions-replay.ts
+++ b/packages/ai/src/transports/openai-completions-replay.ts
@@ -1,11 +1,14 @@
 import type { Context, Model } from "@openclaw/llm-core";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import {
+  isGoogleGemini3FlashModel,
+  isGoogleGemini3ProModel,
+} from "../internal/google-model-family.js";
 import { detectOpenAICompletionsCompat } from "./openai-completions-compat.js";
 import {
   GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP,
   type OpenAIModeModel,
 } from "./openai-transport-shared.js";
-import { isGoogleGemini3FlashModel, isGoogleGemini3ProModel } from "./transport-utils.js";
 
 function isGoogleOpenAICompatModel(model: OpenAIModeModel): boolean {
   const endpointClass = detectOpenAICompletionsCompat(model as Model<"openai-completions">)

--- a/packages/ai/src/transports/transport-utils.ts
+++ b/packages/ai/src/transports/transport-utils.ts
@@ -89,22 +89,6 @@ export function isCodeModeModelVisibleToolName(
   return visibleToolNames.has(name);
 }
 
-function isGoogleGemini3Model(modelId: string, family: "flash" | "pro"): boolean {
-  const normalized = modelId.trim().toLowerCase();
-  const suffix = family === "pro" ? "pro" : "flash";
-  return new RegExp(
-    `(?:^|/)gemini-(?:3(?:\\.\\d+)?-${suffix}|${suffix}${family === "flash" ? "(?:-lite)?" : ""}-latest)(?:-|$)`,
-  ).test(normalized);
-}
-
-export function isGoogleGemini3ProModel(modelId: string): boolean {
-  return isGoogleGemini3Model(modelId, "pro");
-}
-
-export function isGoogleGemini3FlashModel(modelId: string): boolean {
-  return isGoogleGemini3Model(modelId, "flash");
-}
-
 async function readChunkWithIdleTimeout(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   timeoutMs: number,

--- a/src/llm/providers/stream-wrappers/google-thinking-payload.ts
+++ b/src/llm/providers/stream-wrappers/google-thinking-payload.ts
@@ -1,3 +1,8 @@
+import {
+  isGoogleGemini3FlashModel,
+  isGoogleGemini3ProModel,
+  isGoogleGemini3ThinkingLevelModel,
+} from "@openclaw/ai/internal/google-model-family";
 import { googleFlashSupportsMinimalThinking } from "@openclaw/ai/transports";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
@@ -24,23 +29,6 @@ export function isGoogleThinkingRequiredModel(modelId: string): boolean {
 /** @deprecated Google provider-owned stream helper; do not use from third-party plugins. */
 export function isGoogleGemini25ThinkingBudgetModel(modelId: string): boolean {
   return /(?:^|\/)gemini-2\.5-/.test(normalizeLowercaseStringOrEmpty(modelId));
-}
-
-/** @deprecated Google provider-owned stream helper; do not use from third-party plugins. */
-export function isGoogleGemini3ProModel(modelId: string): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(modelId);
-  return /(?:^|\/)gemini-(?:3(?:\.\d+)?-pro|pro-latest)(?:-|$)/.test(normalized);
-}
-
-/** @deprecated Google provider-owned stream helper; do not use from third-party plugins. */
-export function isGoogleGemini3FlashModel(modelId: string): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(modelId);
-  return /(?:^|\/)gemini-(?:3(?:\.\d+)?-flash|flash(?:-lite)?-latest)(?:-|$)/.test(normalized);
-}
-
-/** @deprecated Google provider-owned stream helper; do not use from third-party plugins. */
-export function isGoogleGemini3ThinkingLevelModel(modelId: string): boolean {
-  return isGoogleGemini3ProModel(modelId) || isGoogleGemini3FlashModel(modelId);
 }
 
 /**

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -29,6 +29,11 @@ import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js"
 import { findCodeRegions } from "../shared/text/code-regions.js";
 import { assertProviderStreamEvent } from "./provider-stream-event-normalization.js";
 export {
+  isGoogleGemini3FlashModel,
+  isGoogleGemini3ProModel,
+  isGoogleGemini3ThinkingLevelModel,
+} from "@openclaw/ai/internal/google-model-family";
+export {
   applyAnthropicRefusal,
   isAnthropicOAuthApiKey,
   resolveAnthropicServerCompactionPlan,
@@ -675,9 +680,6 @@ export function createThinkingOnlyFinalTextWrapper(params: {
 
 export {
   isGoogleGemini25ThinkingBudgetModel,
-  isGoogleGemini3FlashModel,
-  isGoogleGemini3ProModel,
-  isGoogleGemini3ThinkingLevelModel,
   isGoogleThinkingRequiredModel,
   resolveGoogleGemini3ThinkingLevel,
   sanitizeGoogleThinkingPayload,

--- a/src/plugin-sdk/provider-thinking-runtime.ts
+++ b/src/plugin-sdk/provider-thinking-runtime.ts
@@ -1,8 +1,13 @@
 import type { ProviderThinkingProfile } from "../plugins/provider-thinking.types.js";
+export {
+  isGoogleGemini3FlashModel,
+  isGoogleGemini3ProModel,
+  isGoogleGemini3ThinkingLevelModel,
+} from "@openclaw/ai/internal/google-model-family";
 
 const THINKING_LEVEL_IDS = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
 
-// Provider policies load eagerly; keep this module free of runtime imports.
+// Provider policies load eagerly; keep this module free of streaming runtime imports.
 export function resolveEffortThinkingProfile(
   efforts: readonly string[] | null | undefined,
 ): ProviderThinkingProfile | undefined {

--- a/src/plugins/plugin-sdk-native-resolver.test.ts
+++ b/src/plugins/plugin-sdk-native-resolver.test.ts
@@ -642,6 +642,11 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
       "ai",
       path.join("internal", "openai-responses-payload-policy.ts"),
     );
+    const aiGoogleModelFamilySource = writeInternalCorePackageSource(
+      root,
+      "ai",
+      path.join("internal", "google-model-family.ts"),
+    );
     const aiRetryAfterSource = writeInternalCorePackageSource(
       root,
       "ai",
@@ -699,6 +704,9 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
       ),
     ).toBe(fs.realpathSync(aiResponsesPayloadPolicySource));
     expect(
+      fs.realpathSync(requireFromCoreSource.resolve("@openclaw/ai/internal/google-model-family")),
+    ).toBe(fs.realpathSync(aiGoogleModelFamilySource));
+    expect(
       fs.realpathSync(requireFromCoreSource.resolve("@openclaw/ai/internal/retry-after")),
     ).toBe(fs.realpathSync(aiRetryAfterSource));
     expect(fs.realpathSync(requireFromCoreSource.resolve("@openclaw/ai/internal/runtime"))).toBe(
@@ -725,6 +733,7 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
     expect(() =>
       requireFromPlugin.resolve("@openclaw/ai/internal/openai-responses-payload-policy"),
     ).toThrow();
+    expect(() => requireFromPlugin.resolve("@openclaw/ai/internal/google-model-family")).toThrow();
     expect(() => requireFromPlugin.resolve("@openclaw/ai/internal/retry-after")).toThrow();
     expect(() => requireFromPlugin.resolve("@openclaw/ai/internal/runtime")).toThrow();
     expect(() => requireFromPlugin.resolve("@openclaw/ai/internal/tool-schema")).toThrow();

--- a/src/plugins/plugin-sdk-native-resolver.ts
+++ b/src/plugins/plugin-sdk-native-resolver.ts
@@ -82,6 +82,7 @@ const INTERNAL_CORE_PACKAGE_ALIASES = [
       ["types", "types.ts"],
       ["validation", "validation.ts"],
       ["internal/anthropic", path.join("internal", "anthropic.ts")],
+      ["internal/google-model-family", path.join("internal", "google-model-family.ts")],
       ["internal/openai", path.join("internal", "openai.ts")],
       [
         "internal/openai-responses-payload-policy",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,9 @@
       "@openclaw/ai/types": ["./packages/ai/src/types.ts"],
       "@openclaw/ai/validation": ["./packages/ai/src/validation.ts"],
       "@openclaw/ai/internal/anthropic": ["./packages/ai/src/internal/anthropic.ts"],
+      "@openclaw/ai/internal/google-model-family": [
+        "./packages/ai/src/internal/google-model-family.ts"
+      ],
       "@openclaw/ai/internal/openai": ["./packages/ai/src/internal/openai.ts"],
       "@openclaw/ai/internal/openai-responses-payload-policy": [
         "./packages/ai/src/internal/openai-responses-payload-policy.ts"

--- a/tsdown.ai.config.ts
+++ b/tsdown.ai.config.ts
@@ -25,6 +25,7 @@ const config = {
     "provider-types": "packages/ai/src/provider-types.ts",
     validation: "packages/ai/src/validation.ts",
     "internal/anthropic": "packages/ai/src/internal/anthropic.ts",
+    "internal/google-model-family": "packages/ai/src/internal/google-model-family.ts",
     "internal/openai": "packages/ai/src/internal/openai.ts",
     "internal/openai-responses-payload-policy":
       "packages/ai/src/internal/openai-responses-payload-policy.ts",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where cold Google model-policy checks load unrelated streaming machinery. In a matched source-layout PDF run, the policy lookup alone took 12.65 seconds.

## Why This Change Was Made

Move the existing boundary-aware Gemini 3 classifiers into one lightweight AI internal entry shared by policy, thinking-payload normalization, and OpenAI-compatible replay. Delete the equivalent transport helper definitions. Google policy uses the existing narrow thinking SDK entry; historical streaming-SDK exports retain their names and behavior.

The package export, TypeScript path, dedicated AI build entry, and native source-loader alias are wired together. The native alias retains the existing host-parent boundary. No dependency, configuration option, model-policy change, or public SDK subpath is added. Runtime TypeScript grows by three lines; package/build wiring adds nine. The native Google adapter's separate unanchored predicates retain their semantics.

## User Impact

Cold policy checks avoid unnecessary streaming imports. Provider selection, thinking mappings, replay signatures, and PDF runtime-generation ownership remain unchanged. Source development and packaged runtimes both resolve the classifier entry. Shard configuration and existing test coverage are preserved.

## Evidence

- Matched source-layout PDF runs: all six original cases passed in order. Direct policy lookup **12,648.85ms → 205.33ms**; committed-generation case **12,862ms → 797ms**. Whole commands were 51.57s and 57.77s because worker preparation varied; this is a case improvement, not a whole-command speedup claim.
- Existing policy, thinking-payload, replay-signature, and unchanged PDF tests: **60 passed** across four files. The policy test now rejects an import of the broad streaming SDK; restoring the old import produces that exact failure.
- With generated root and AI build outputs absent: **24/24 passed** across PDF, OpenCode context, and native resolver tests. The final PDF case took 199ms. The source alias fixture resolves for host parents and remains unavailable to unrelated plugin parents. Removing the alias reproduces the missing module and OpenCode's incorrect 200,000-token fallback; the repair restores the expected 1,000,000 without changing its assertion.
- Full `pnpm build` passed after the source-alias repair, including declarations, SDK exports, and native built control-plane checks. Cold built-policy import passed in 22ms, loading ten files with no streaming/transport/host regions. Built historical SDK exports and isolated Google entrypoint loading also passed.
- Full changed-code checks passed through typechecking and all three dead-export scans. Import-order lint errors were corrected and focused canonical lint plus the remaining import-cycle check passed. The added source-alias repair passed focused typecheck/lint. Final independent P0–P2 review: no actionable findings.

The first CI head exposed the omitted native source alias, which a local full build had hidden by supplying the compiled file. The source-only controls above specifically reproduce and repair that gap. That run also reported one invalid UI transition frame; the UI assertion is preserved and its cause remains unproven. Exact-head CI must pass before landing. Temporary timing instrumentation is not included. No authenticated provider API call was used as proof; no provider API behavior changed.
