### PR TITLE
refactor(worker): share bounded line framing

### DIFF
--- a/src/node-host/node-worker-launch-observation.test.ts
+++ b/src/node-host/node-worker-launch-observation.test.ts
@@ -1,0 +1,212 @@
+import { PassThrough } from "node:stream";
+import { finished } from "node:stream/promises";
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { onDecodedOutput } from "../process/decoded-output.js";
+import type { WorkerProcessResult } from "../worker/worker-process-protocol.js";
+import {
+  observeNodeWorkerChildOutput,
+  type NodeWorkerTerminalOutcome,
+} from "./node-worker-launch-observation.js";
+import type { NodeWorkerChildAdapter } from "./node-worker-launch-transport.js";
+import {
+  createNodeWorkerCredentialScrubber,
+  NODE_WORKER_STDOUT_MAX_BYTES,
+} from "./node-worker-output.js";
+
+function resultFrame(turnId: string, transcriptLeafId = "leaf") {
+  return {
+    type: "result",
+    turnId,
+    result: { status: "completed", transcriptLeafId, transcriptNextSeq: 2 },
+    retainWorker: false,
+  } satisfies WorkerProcessResult;
+}
+
+function encodeResult(turnId: string, transcriptLeafId = "leaf"): Buffer {
+  return Buffer.from(`${JSON.stringify(resultFrame(turnId, transcriptLeafId))}\n`);
+}
+
+function sizedResult(turnId: string, bytes: number): Buffer {
+  return encodeResult(turnId, "x".repeat(bytes - encodeResult(turnId, "").length));
+}
+
+function observationHarness() {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const journal = createDeferred();
+  const exit = createDeferred<{ code: number | null; signal: NodeJS.Signals | null }>();
+  const unsubscribe: Array<() => void> = [];
+  const kill = vi.fn();
+  const dispose = vi.fn(() => {
+    for (const stop of unsubscribe) {
+      stop();
+    }
+    stdout.destroy();
+    stderr.destroy();
+  });
+  const adapter = {
+    supportsRawOutput: true,
+    onStdout: (listener, onRaw) => {
+      unsubscribe.push(onDecodedOutput(stdout, listener, onRaw));
+    },
+    onStderr: (listener, onRaw) => {
+      unsubscribe.push(onDecodedOutput(stderr, listener, onRaw));
+    },
+    onExit: () => {},
+    onError: () => {},
+    wait: () => exit.promise,
+    kill,
+    dispose,
+  } satisfies NodeWorkerChildAdapter;
+  const frames: WorkerProcessResult[] = [];
+  const outcome = observeNodeWorkerChildOutput(
+    {
+      adapter,
+      journalReady: journal.promise,
+      scrubber: createNodeWorkerCredentialScrubber("framing-fixture-token"),
+      connectionFailure: {},
+    },
+    (frame) => frames.push(frame),
+    () => undefined,
+  );
+  let closing: Promise<NodeWorkerTerminalOutcome> | undefined;
+  const close = () =>
+    (closing ??= (async () => {
+      stdout.end();
+      stderr.end();
+      await Promise.all([finished(stdout), finished(stderr)]);
+      journal.resolve();
+      exit.resolve({ code: 0, signal: null });
+      return await outcome;
+    })());
+  return {
+    stdout,
+    frames,
+    kill,
+    dispose,
+    close,
+    releaseJournal: async () => {
+      journal.resolve();
+      await journal.promise;
+    },
+  };
+}
+
+describe("node worker output framing", () => {
+  it("preserves a UTF-8 character split across decoded output chunks", async () => {
+    const harness = observationHarness();
+    try {
+      await harness.releaseJournal();
+      const wire = encodeResult("first", "hello 漢😀");
+      const split = wire.indexOf(Buffer.from("😀"));
+      harness.stdout.write(wire.subarray(0, split + 1));
+      harness.stdout.write(wire.subarray(split + 1, split + 3));
+      expect(harness.frames).toEqual([]);
+      harness.stdout.write(wire.subarray(split + 3));
+
+      expect(await harness.close()).toEqual({
+        state: "completed",
+        resultJson: JSON.stringify(resultFrame("first", "hello 漢😀").result),
+      });
+      expect(harness.frames).toEqual([resultFrame("first", "hello 漢😀")]);
+      expect(harness.kill).not.toHaveBeenCalled();
+      expect(harness.dispose).toHaveBeenCalledOnce();
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("accepts multiple bounded frames whose combined chunk exceeds the cap after journaling", async () => {
+    const harness = observationHarness();
+    try {
+      await harness.releaseJournal();
+      harness.stdout.write(
+        Buffer.concat([
+          sizedResult("first", NODE_WORKER_STDOUT_MAX_BYTES / 2 + 1),
+          sizedResult("second", NODE_WORKER_STDOUT_MAX_BYTES / 2 + 1),
+        ]),
+      );
+
+      expect(await harness.close()).toMatchObject({ state: "completed" });
+      expect(harness.frames.map((frame) => frame.turnId)).toEqual(["first", "second"]);
+      expect(harness.kill).not.toHaveBeenCalled();
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("delivers an earlier frame before rejecting a later oversized frame in the same chunk", async () => {
+    const harness = observationHarness();
+    try {
+      await harness.releaseJournal();
+      harness.stdout.write(
+        Buffer.concat([encodeResult("first"), Buffer.alloc(NODE_WORKER_STDOUT_MAX_BYTES + 1, 120)]),
+      );
+
+      expect(harness.frames).toEqual([resultFrame("first")]);
+      expect(harness.kill).toHaveBeenCalledExactlyOnceWith("SIGKILL");
+      expect(await harness.close()).toMatchObject({
+        state: "failed",
+        errorText: `worker stdout exceeded ${NODE_WORKER_STDOUT_MAX_BYTES} bytes`,
+      });
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it.each([-1, 0, 1])(
+    "bounds aggregate output including delimiters at cap + %i before journal readiness",
+    async (delta) => {
+      const harness = observationHarness();
+      try {
+        harness.stdout.write(
+          Buffer.concat([
+            sizedResult("first", NODE_WORKER_STDOUT_MAX_BYTES / 2),
+            sizedResult("second", NODE_WORKER_STDOUT_MAX_BYTES / 2 + delta),
+          ]),
+        );
+
+        expect(harness.frames).toEqual([]);
+        expect(harness.kill).toHaveBeenCalledTimes(delta > 0 ? 1 : 0);
+        const outcome = await harness.close();
+        if (delta > 0) {
+          expect(outcome).toMatchObject({
+            state: "failed",
+            errorText: `worker stdout exceeded ${NODE_WORKER_STDOUT_MAX_BYTES} bytes`,
+          });
+          expect(harness.frames).toEqual([]);
+        } else {
+          expect(outcome).toMatchObject({ state: "completed" });
+          expect(harness.frames.map((frame) => frame.turnId)).toEqual(["first", "second"]);
+        }
+      } finally {
+        await harness.close();
+      }
+    },
+  );
+
+  it.each([
+    { name: "empty output", wire: Buffer.alloc(0), frames: 0 },
+    { name: "an unterminated result", wire: encodeResult("first").subarray(0, -1), frames: 0 },
+    {
+      name: "a complete result followed by incomplete UTF-8",
+      wire: Buffer.concat([encodeResult("first"), Buffer.from([0xf0, 0x9f])]),
+      frames: 1,
+    },
+  ])("rejects EOF with $name", async ({ wire, frames }) => {
+    const harness = observationHarness();
+    try {
+      await harness.releaseJournal();
+      harness.stdout.write(wire);
+
+      expect(await harness.close()).toMatchObject({
+        state: "failed",
+        errorText: "worker exited without a complete turn result",
+      });
+      expect(harness.frames).toHaveLength(frames);
+    } finally {
+      await harness.close();
+    }
+  });
+});

--- a/src/node-host/node-worker-launch-observation.ts
+++ b/src/node-host/node-worker-launch-observation.ts
@@ -1,3 +1,4 @@
+import { createBoundedLineFramer } from "../process/bounded-line-framer.js";
 import {
   appendCapturedOutput,
   createCapturedOutputBuffers,
@@ -38,6 +39,10 @@ export async function observeNodeWorkerChildOutput(
   currentTurnId: () => string | undefined,
 ): Promise<NodeWorkerTerminalOutcome> {
   let stdout = "";
+  const framer = createBoundedLineFramer(
+    NODE_WORKER_STDOUT_MAX_BYTES,
+    `worker stdout exceeded ${NODE_WORKER_STDOUT_MAX_BYTES} bytes`,
+  );
   let lastResult: string | undefined;
   let outputError: unknown;
   let journaled = false;
@@ -46,15 +51,11 @@ export async function observeNodeWorkerChildOutput(
       return;
     }
     try {
-      let newline: number;
-      while ((newline = stdout.indexOf("\n")) >= 0) {
-        const line = stdout.slice(0, newline);
-        stdout = stdout.slice(newline + 1);
-        if (Buffer.byteLength(line, "utf8") > NODE_WORKER_STDOUT_MAX_BYTES) {
-          throw new Error(`worker stdout exceeded ${NODE_WORKER_STDOUT_MAX_BYTES} bytes`);
-        }
+      const chunk = Buffer.from(stdout, "utf8");
+      stdout = "";
+      for (const line of framer.push(chunk)) {
         const frame = parseWorkerProcessResult(
-          JSON.parse(parseNodeWorkerOutputJson(line, active.scrubber.scrub)),
+          JSON.parse(parseNodeWorkerOutputJson(line.toString("utf8"), active.scrubber.scrub)),
         );
         if (!frame) {
           throw new Error("worker returned an invalid turn result");
@@ -62,12 +63,10 @@ export async function observeNodeWorkerChildOutput(
         onResult(frame);
         lastResult = JSON.stringify(frame.result);
       }
-      if (Buffer.byteLength(stdout, "utf8") > NODE_WORKER_STDOUT_MAX_BYTES) {
-        throw new Error(`worker stdout exceeded ${NODE_WORKER_STDOUT_MAX_BYTES} bytes`);
-      }
     } catch (error) {
       outputError = error;
       stdout = "";
+      framer.clear();
       active.adapter.kill("SIGKILL");
     }
   };
@@ -118,7 +117,7 @@ export async function observeNodeWorkerChildOutput(
             : "node worker launch interrupted during node-host shutdown"),
       });
     }
-    if (outputError || stdout.length > 0 || (exit.code === 0 && !lastResult)) {
+    if (outputError || framer.pendingByteLength > 0 || (exit.code === 0 && !lastResult)) {
       return Object.freeze({
         state: "failed",
         errorText: sanitizeNodeWorkerDiagnostic(

--- a/src/process/bounded-line-framer.test.ts
+++ b/src/process/bounded-line-framer.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { createBoundedLineFramer } from "./bounded-line-framer.js";
+
+describe("bounded line framing", () => {
+  it("preserves bytes, empty lines, and CR across arbitrary chunk boundaries", () => {
+    const lines = [Buffer.from("漢😀\r"), Buffer.alloc(0), Buffer.from([0xff])];
+    const wire = Buffer.concat(lines.flatMap((line) => [line, Buffer.from("\n")]));
+    const framer = createBoundedLineFramer(8, "line too long");
+    const received: Buffer[] = [];
+
+    for (const byte of wire) {
+      received.push(...framer.push(Buffer.from([byte])));
+    }
+
+    expect(received).toEqual(lines);
+  });
+
+  it("does not inspect a later oversized frame after its consumer retires", () => {
+    const framer = createBoundedLineFramer(4, "line too long");
+    const received: Buffer[] = [];
+
+    for (const line of framer.push(Buffer.from("done\noversized"))) {
+      received.push(line);
+      break;
+    }
+
+    expect(received).toEqual([Buffer.from("done")]);
+  });
+});

--- a/src/process/bounded-line-framer.ts
+++ b/src/process/bounded-line-framer.ts
@@ -1,0 +1,35 @@
+/** Frames LF-delimited bytes without decoding or consuming an incomplete final line. */
+export function createBoundedLineFramer(maxBytes: number, overflowMessage: string) {
+  let chunks: Buffer[] = [];
+  let byteLength = 0;
+  const clear = () => {
+    chunks = [];
+    byteLength = 0;
+  };
+  return {
+    get pendingByteLength() {
+      return byteLength;
+    },
+    clear,
+    *push(chunk: Buffer): Generator<Buffer> {
+      let offset = 0;
+      while (offset < chunk.length) {
+        const newline = chunk.indexOf(10, offset);
+        const end = newline === -1 ? chunk.length : newline;
+        byteLength += end - offset;
+        if (byteLength > maxBytes) {
+          throw new Error(overflowMessage);
+        }
+        chunks.push(chunk.subarray(offset, end));
+        if (newline === -1) {
+          break;
+        }
+        const line = Buffer.concat(chunks, byteLength);
+        clear();
+        offset = newline + 1;
+        // A caller may retire after this frame; do not inspect later bytes until it resumes.
+        yield line;
+      }
+    },
+  };
+}

--- a/src/worker/worker-command.runtime.test.ts
+++ b/src/worker/worker-command.runtime.test.ts
@@ -529,6 +529,73 @@ describe("worker command lifetime gate", () => {
     expect(createWorkerRuntimeEnvironment).not.toHaveBeenCalled();
   });
 
+  it("handles a turn and its cancellation in the same input chunk", async () => {
+    const harness = managedHarness();
+    const running = runWorkerCommand({ ...harness, managed: true });
+    harness.input.write(
+      serializeWorkerProcessInput(buildWorkerProcessTurn(harness.launch)) +
+        serializeWorkerProcessInput({ type: "cancel", turnId: harness.launch.assignment.turnId }),
+    );
+
+    await running;
+
+    expect(runWorkerDescriptor).toHaveBeenCalledOnce();
+    expect(vi.mocked(runWorkerDescriptor).mock.calls[0]?.[1]?.signal?.reason).toMatchObject({
+      message: "worker turn cancelled",
+    });
+  });
+
+  it("delivers cancellation before rejecting a later oversized frame in the same chunk", async () => {
+    const harness = managedHarness();
+    const started = createDeferred<AbortSignal>();
+    vi.mocked(runWorkerDescriptor).mockImplementationOnce(async (_launch, options) => {
+      const signal = options?.signal;
+      if (!signal) {
+        throw new Error("expected managed worker abort signal");
+      }
+      started.resolve(signal);
+      await new Promise<void>((resolve) => {
+        signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      return { status: "completed", transcriptLeafId: null, transcriptNextSeq: 1 };
+    });
+    const running = runWorkerCommand({ ...harness, managed: true });
+    harness.turn();
+    const signal = await started.promise;
+    const rejected = expect(running).rejects.toThrow("exceeds the protocol payload limit");
+    harness.input.write(
+      Buffer.concat([
+        Buffer.from(
+          serializeWorkerProcessInput({ type: "cancel", turnId: harness.launch.assignment.turnId }),
+        ),
+        Buffer.alloc(WORKER_PROTOCOL_MAX_INFERENCE_PAYLOAD_BYTES + 1, 120),
+      ]),
+    );
+
+    await rejected;
+
+    expect(signal.reason).toMatchObject({ message: "worker turn cancelled" });
+    expect(harness.results).toEqual([]);
+    expect(managedRuntime.close).toHaveBeenCalledOnce();
+  });
+
+  it.each(["empty", "unterminated"])(
+    "closes %s managed input at EOF without admitting a turn",
+    async (input) => {
+      const harness = managedHarness();
+      const running = runWorkerCommand({ ...harness, managed: true });
+      harness.input.end(
+        input === "empty" ? undefined : JSON.stringify(buildWorkerProcessTurn(harness.launch)),
+      );
+
+      await running;
+
+      expect(runWorkerDescriptor).not.toHaveBeenCalled();
+      expect(createWorkerRuntimeEnvironment).not.toHaveBeenCalled();
+      expect(harness.results).toEqual([]);
+    },
+  );
+
   it.each(["standalone", "managed"] as const)(
     "preserves ordinary two-image input through the %s parser",
     async (mode) => {
@@ -592,12 +659,20 @@ describe("worker command lifetime gate", () => {
       delta > 0 ? expect(running).rejects.toThrow("exceeds the protocol payload limit") : running;
     if (mode === "managed") {
       // Raw input independently verifies the receiver, including serializer-rejected bytes.
-      harness.input.write(encoded);
+      const bytes = Buffer.from(encoded);
+      const split = bytes.indexOf(Buffer.from("漢")) + 1;
+      harness.input.write(bytes.subarray(0, split));
+      harness.input.write(bytes.subarray(split));
     } else {
       harness.input.end(encoded);
     }
     await outcome;
     expect(runWorkerDescriptor).toHaveBeenCalledTimes(delta > 0 ? 0 : 1);
+    if (delta <= 0) {
+      expect(vi.mocked(runWorkerDescriptor).mock.calls[0]?.[0].assignment.systemPrompt).toBe(
+        harness.launch.assignment.systemPrompt,
+      );
+    }
     console.info(
       "worker-input-boundary",
       JSON.stringify({ mode, bytes: targetBytes, accepted: delta <= 0 }),

--- a/src/worker/worker-command.runtime.ts
+++ b/src/worker/worker-command.runtime.ts
@@ -3,6 +3,7 @@ import type { Readable, Writable } from "node:stream";
 import { WORKER_PROTOCOL_MAX_INFERENCE_PAYLOAD_BYTES } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
 import { getActiveBackgroundExecSessionCount } from "../agents/bash-process-registry.js";
 import { toErrorObject } from "../infra/errors.js";
+import { createBoundedLineFramer } from "../process/bounded-line-framer.js";
 import type { WorkerBrowserRuntime } from "./browser-runtime.js";
 import { parseWorkerLaunchDescriptor, type WorkerLaunchDescriptor } from "./launch-descriptor.js";
 import { parseWorkerProcessRequest, type WorkerProcessResult } from "./worker-process-protocol.js";
@@ -34,8 +35,10 @@ async function runManagedWorkerCommand(
   let active: { turnId: string; controller: AbortController } | undefined;
   let running: Promise<void> | undefined;
   let closed = false;
-  let chunks: Buffer[] = [];
-  let byteLength = 0;
+  const framer = createBoundedLineFramer(
+    WORKER_PROTOCOL_MAX_INFERENCE_PAYLOAD_BYTES,
+    "managed worker request exceeds the protocol payload limit",
+  );
   let removeListeners = () => {};
 
   try {
@@ -173,26 +176,11 @@ async function runManagedWorkerCommand(
           if (!chunk) {
             throw new Error("managed worker input must be bytes");
           }
-          let offset = 0;
-          while (offset < chunk.length) {
+          for (const line of framer.push(chunk)) {
+            onLine(line);
             if (closed) {
               break;
             }
-            const newline = chunk.indexOf(10, offset);
-            const end = newline === -1 ? chunk.length : newline;
-            byteLength += end - offset;
-            if (byteLength > WORKER_PROTOCOL_MAX_INFERENCE_PAYLOAD_BYTES) {
-              throw new Error("managed worker request exceeds the protocol payload limit");
-            }
-            chunks.push(chunk.subarray(offset, end));
-            if (newline === -1) {
-              break;
-            }
-            const line = Buffer.concat(chunks, byteLength);
-            chunks = [];
-            byteLength = 0;
-            onLine(line);
-            offset = newline + 1;
           }
         } catch (error) {
           finish(error);
@@ -221,7 +209,7 @@ async function runManagedWorkerCommand(
       }
     });
   } finally {
-    chunks = [];
+    framer.clear();
     try {
       await running;
       await environment?.close();


### PR DESCRIPTION
## What Problem This Solves

Managed worker input and node-supervisor output independently assemble bounded newline-delimited frames. Their callers depend on precise byte limits, incremental delivery, journal readiness, and different EOF behavior.

## Why This Change Was Made

Use a small byte framer in `src/process/bounded-line-framer.ts` for fragment accumulation, LF boundaries, and per-frame limits. It yields frames incrementally so an earlier valid result or cancellation is delivered before a later oversized frame in the same chunk is rejected. A retiring consumer can stop before inspecting later bytes.

The worker retains raw-input conversion, request parsing, cancellation, and its incomplete-input EOF policy. The observer retains the existing streaming Windows/UTF-8 decoder, credential scrubbing, journal readiness, LF-inclusive aggregate pre-journal limit, and incomplete-output EOF failure. Decoding and lifecycle policy stay at their existing owners.

Production grows by 22 lines overall: the shared framer is 35 lines, and the separate journal/EOF policies remain explicit. This removes two framing loops without introducing a stream framework. Existing supervisor tests and fixtures are unchanged; the new observer suite covers its previously untested boundary directly.

## User Impact

No protocol, payload-limit, output, cancellation, configuration, or persisted-state behavior change. Managed requests still exclude LF from their per-frame cap; standalone stdin still counts all bytes. Node output before journal readiness still has one aggregate cap including delimiters.

## Evidence

- Before production extraction, the expanded worker/observer characterization suites passed all 44 tests in 5.27 seconds.
- After extraction, `node scripts/run-vitest.mjs src/process/bounded-line-framer.test.ts src/worker/worker-command.runtime.test.ts src/node-host/node-worker-launch-observation.test.ts src/node-host/node-worker-supervisor.test.ts src/node-host/node-worker-supervisor.lifetime.test.ts src/infra/windows-encoding.test.ts`: 124 tests passed across six files, 27.12 seconds.
- Coverage includes split multibyte input/output, multiple frames per chunk, valid-prefix delivery before later overflow, cancellation ordering, pre-journal aggregate cap −1/0/+1 and no early callbacks, empty/unterminated EOF, decoder flush, and existing physical-owner/descendant cleanup.
- Independent Codex autoreview: no actionable P0–P2 findings.
- `pnpm build`: passed in 11m48.7s, including bootstrap/worker import checks; build metadata identifies `f789e47d838706bb700b12ac016e1be4bfb269ce`.
- Formatting, `git diff --check`, and the full `node scripts/check-changed.mjs`: passed. No new suppression, test-only production seam, widened mock, timeout increase, or test skip.

## Known Gaps

None. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34090911463) completed successfully on `f789e47d838706bb700b12ac016e1be4bfb269ce`. The latest review has no actionable findings.

CI observation note: A [canceled ClawSweeper dispatch](https://github.com/openclaw/openclaw/actions/runs/34090911783/job/101644020024) stopped the default aggregate watcher; its dispatch steps succeeded, and it is not the required `openclaw/ci-gate` check. The documented CI-run watcher mode monitors the same exact run; native gates remain unchanged.
