### PR TITLE
refactor(diagnostics): share presentation action rewriting

### DIFF
--- a/src/auto-reply/reply/commands-diagnostics.test.ts
+++ b/src/auto-reply/reply/commands-diagnostics.test.ts
@@ -4,6 +4,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import * as sessionAccessor from "../../config/sessions/session-accessor.js";
+import type {
+  LegacyInteractiveReply,
+  MessagePresentationAction,
+} from "../../interactive/payload.js";
 import { clearPluginCommands, registerPluginCommand } from "../../plugins/commands.js";
 import { createPluginRegistry } from "../../plugins/registry.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
@@ -745,28 +749,71 @@ describe("diagnostics command", () => {
     expect(execCalls).toHaveLength(1);
   });
 
-  it("routes confirmations back to the Codex diagnostics handler without repeating the preamble", async () => {
-    const { handleDiagnosticsCommand } = createDiagnosticsHandlerForTest();
-    const commandHandler = vi.fn(async (ctx: PluginCommandContext) => ({
-      text: `confirmed ${ctx.args}`,
-    }));
-    registerHostTrustedReservedCommandForTest({
-      name: "codex",
-      description: "Codex command",
-      acceptsArgs: true,
-      handler: commandHandler,
-      ownership: "reserved",
-    });
+  it.each([
+    {
+      action: { type: "command", command: "/codex diagnostics confirm abc123def456" },
+      expectedAction: { type: "command", command: "/diagnostics confirm abc123def456" },
+    },
+    {
+      action: { type: "callback", value: "/codex diagnostics cancel abc123def456" },
+      expectedAction: { type: "callback", value: "/diagnostics cancel abc123def456" },
+    },
+    {
+      action: { type: "model-picker", version: 1, snapshotToken: "picker-1", intent: "cancel" },
+      expectedAction: {
+        type: "model-picker",
+        version: 1,
+        snapshotToken: "picker-1",
+        intent: "cancel",
+      },
+    },
+    {
+      action: { type: "url", url: "https://example.com/diagnostics" },
+      expectedAction: { type: "url", url: "https://example.com/diagnostics" },
+    },
+  ] satisfies Array<{
+    action: MessagePresentationAction;
+    expectedAction: MessagePresentationAction;
+  }>)(
+    "routes confirmations with $action.type actions without repeating the preamble",
+    async ({ action, expectedAction }) => {
+      const { handleDiagnosticsCommand } = createDiagnosticsHandlerForTest();
+      const interactive: LegacyInteractiveReply = {
+        blocks: [{ type: "buttons", buttons: [{ label: "Continue", action }] }],
+      };
+      const expectedInteractive: LegacyInteractiveReply = {
+        blocks: [{ type: "buttons", buttons: [{ label: "Continue", action: expectedAction }] }],
+      };
+      if (action.type !== "url" && expectedAction.type !== "url") {
+        interactive.blocks.push({ type: "select", options: [{ label: "Continue", action }] });
+        expectedInteractive.blocks.push({
+          type: "select",
+          options: [{ label: "Continue", action: expectedAction }],
+        });
+      }
+      const commandHandler = vi.fn(async (ctx: PluginCommandContext) => ({
+        text: `confirmed ${ctx.args}`,
+        interactive,
+      }));
+      registerHostTrustedReservedCommandForTest({
+        name: "codex",
+        description: "Codex command",
+        acceptsArgs: true,
+        handler: commandHandler,
+        ownership: "reserved",
+      });
 
-    const result = await handleDiagnosticsCommand(
-      buildDiagnosticsParams("/diagnostics confirm abc123def456"),
-      true,
-    );
+      const result = await handleDiagnosticsCommand(
+        buildDiagnosticsParams("/diagnostics confirm abc123def456"),
+        true,
+      );
 
-    expect(result?.shouldContinue).toBe(false);
-    expect(commandHandler).toHaveBeenCalledTimes(1);
-    expect(result?.reply?.text).toBe("confirmed diagnostics confirm abc123def456");
-  });
+      expect(result?.shouldContinue).toBe(false);
+      expect(commandHandler).toHaveBeenCalledTimes(1);
+      expect(result?.reply?.text).toBe("confirmed diagnostics confirm abc123def456");
+      expect(result?.reply?.interactive).toEqual(expectedInteractive);
+    },
+  );
 
   it("does not delegate diagnostics to a non-Codex plugin command", async () => {
     const { handleDiagnosticsCommand } = createDiagnosticsHandlerForTest();

--- a/src/auto-reply/reply/commands-diagnostics.ts
+++ b/src/auto-reply/reply/commands-diagnostics.ts
@@ -523,7 +523,7 @@ function rewriteInteractive(interactive: LegacyInteractiveReply): LegacyInteract
           ...block,
           options: block.options.map((option) => ({
             ...option,
-            ...(option.action ? { action: rewriteSelectPresentationAction(option.action) } : {}),
+            ...(option.action ? { action: rewritePresentationAction(option.action) } : {}),
             ...(option.value ? { value: rewriteCodexDiagnosticsCommandPrefix(option.value) } : {}),
           })),
         };
@@ -533,6 +533,10 @@ function rewriteInteractive(interactive: LegacyInteractiveReply): LegacyInteract
   };
 }
 
+function rewritePresentationAction(
+  action: Extract<MessagePresentationAction, { type: "command" | "callback" | "model-picker" }>,
+): Extract<MessagePresentationAction, { type: "command" | "callback" | "model-picker" }>;
+function rewritePresentationAction(action: MessagePresentationAction): MessagePresentationAction;
 function rewritePresentationAction(action: MessagePresentationAction): MessagePresentationAction {
   if (action.type === "command") {
     return {
@@ -545,18 +549,6 @@ function rewritePresentationAction(action: MessagePresentationAction): MessagePr
       type: "callback",
       value: rewriteCodexDiagnosticsCommandPrefix(action.value),
     };
-  }
-  return action;
-}
-
-function rewriteSelectPresentationAction(
-  action: Extract<MessagePresentationAction, { type: "command" | "callback" | "model-picker" }>,
-): Extract<MessagePresentationAction, { type: "command" | "callback" | "model-picker" }> {
-  if (action.type === "command") {
-    return { type: "command", command: rewriteCodexDiagnosticsCommandPrefix(action.command) };
-  }
-  if (action.type === "callback") {
-    return { type: "callback", value: rewriteCodexDiagnosticsCommandPrefix(action.value) };
   }
   return action;
 }


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested diagnostics action-rewriter dedupe: diagnostics buttons and select options currently maintain separate private implementations of the same command-prefix rewrite. Keeping them together prevents those paths from drifting.

## Why This Change Was Made

Use one private `rewritePresentationAction` implementation with a narrow-first overload for the existing `command | callback | model-picker` select subset. Preserve the broader button contract and identity fallback for other actions, without casts, exports, or payload changes.

Extend the existing confirmation test into a table covering command and callback rewrites in both buttons and selects, unchanged model-picker actions, and unchanged URL buttons.

## User Impact

No user-visible behavior change. Command prefixes, action construction, ordering, and fallback actions remain unchanged. No SDK, configuration, schema, storage, protocol, dependency, or security changes.

## Evidence

- Local focused diagnostics suite: 20 tests passed.
- Local changed-lane classification: `core`, `coreTests`.
- Local targeted lint, formatting, and `git diff --check`: passed.
- Independent autoreview through P2: scoped-clean.
- ClawSweeper reviewed the exact head with no actionable findings.
- Blacksmith Testbox focused suite: 20 tests passed on Node 24.19.0. Verified source tree `13c5566636b38b70669c12756cd0d2e6d561f394` matches commit `d230b7ddb353a32a99220c208f398789d76dad57`. Lease `tbx_01m1x84mrha9s3qt1jz8cc6knq` stopped after success; run https://github.com/openclaw/openclaw/actions/runs/34090059907.
- Exact-head Blacksmith Testbox `node scripts/check-changed.mjs --base origin/main`: passed, including production and core-test typechecks, targeted lint, formatting, dead-export scans, and all selected guards. This proves select callers retain the narrow return type. Wrapper exit code 0; lease `tbx_01m1x8b48b5a9p3artmf9s5ye1` stopped after success: https://github.com/openclaw/openclaw/actions/runs/34090316667.
- Exact-head required CI: passed for `d230b7ddb353a32a99220c208f398789d76dad57`: https://github.com/openclaw/openclaw/actions/runs/34090957551.
- Local `check:changed` passed its preliminary guards, then stopped because the declaration-input guard rejects the required shared dependency symlink. No guard was bypassed; the clean Testbox run provides the typecheck environment.

No live Gateway or provider API proof is needed for this private, behavior-preserving refactor.
