### PR TITLE
refactor(web): reuse credential input normalization

### DIFF
--- a/src/web/provider-runtime-shared.ts
+++ b/src/web/provider-runtime-shared.ts
@@ -4,6 +4,7 @@ import {
   isLegacySecretRefEnvMarker,
   normalizeSecretInputString,
 } from "../config/types.secrets.js";
+import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
 
 type WebProviderConfigSource = {
   tools?: {
@@ -21,26 +22,6 @@ type ProviderWithCredential = {
 };
 
 type WebContentProcessEnv = Record<string, string | undefined>;
-
-function normalizeSecretInput(value: unknown): string {
-  if (typeof value !== "string") {
-    return "";
-  }
-  const collapsed = value.replace(/[\r\n\u2028\u2029]+/g, "");
-  let latin1Only = "";
-  for (const char of collapsed) {
-    const codePoint = char.codePointAt(0);
-    const isControl =
-      typeof codePoint === "number" &&
-      ((codePoint >= 0x00 && codePoint <= 0x1f) ||
-        codePoint === 0x7f ||
-        (codePoint >= 0x80 && codePoint <= 0x9f));
-    if (typeof codePoint === "number" && codePoint <= 0xff && !isControl) {
-      latin1Only += char;
-    }
-  }
-  return latin1Only.trim();
-}
 
 export function resolveWebProviderConfig(
   cfg: WebProviderConfigSource | undefined,


### PR DESCRIPTION
## What Problem This Solves

Web provider credential resolution repeats the normalization already used by setup and other credential paths, leaving two implementations of the same byte-cleanup rules.

## Why This Change Was Made

The web provider resolver imports `normalizeSecretInput` from its existing utility owner and deletes the private copy. Credential-source ordering, SecretRef handling, provider auth, and fallback behavior remain unchanged.

## User Impact

None intended. Normalized values remain byte-identical: line breaks, controls and non-Latin-1 code points are removed, ordinary internal spaces remain, and surrounding whitespace is trimmed. No public export, runtime configuration, dependency, persistence, or API contract changes.

## Evidence

- `node scripts/run-vitest.mjs src/utils/normalize-secret-input.test.ts src/web/provider-runtime-shared.test.ts`: 18 tests passed.
- Fresh old/new comparison of the actual functions: 1,114,121 cases passed, covering every Unicode code point plus invalid/surrogate cases.
- Independent review: P0–P2 scoped-clean, zero findings. Unchanged-owner context was a verified behavioral summary because the context-file guard refused its filename; the reviewer states that source-context limitation. The lead inspected both complete implementations and compared the actual functions.
- Production +1/-20, net -19 lines; tests unchanged. `node scripts/check-changed.mjs --base 3f69289f16f7f8814470109e4aaf1509f41feabf` passed.
- Required rebase onto `ce174871076b4a5db8524ef8eb8ea17a3abe97fa` is patch-identical; unchanged helper/config dependencies have no diff. Current head `6cc84a94880ffd9d7c54339fc2cc49ee65324f12` passed [CI 34091390523](https://github.com/openclaw/openclaw/actions/runs/34091390523).

ClawSweeper also inspected both complete normalization implementations at the reviewed head and found no actionable correctness or security issue.
