### PR TITLE
fix(process): preserve output and cleanup after command exit

### DIFF
--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -43,23 +43,22 @@ export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): voi
     return;
   }
 
-  const useGroupKill =
-    opts?.detached === true || (opts?.detached !== false && isProcessGroupLeader(pid));
+  // A selected group remains the only target after its leader exits; its positive
+  // PID may already identify an unrelated process when signaling or grace expires.
+  const target =
+    opts?.detached === true || (opts?.detached !== false && isProcessGroupLeader(pid)) ? -pid : pid;
   if (opts?.force === true) {
-    signalProcessTreeUnix(pid, "SIGKILL", useGroupKill);
+    signalUnixTarget(target, "SIGKILL");
     return;
   }
 
   const graceMs = normalizeGraceMs(opts?.graceMs);
-  signalProcessTreeUnix(pid, "SIGTERM", useGroupKill);
+  signalUnixTarget(target, "SIGTERM");
   setTimeout(() => {
-    const stillAlive = useGroupKill
-      ? isProcessAlive(-pid) || isProcessAlive(pid)
-      : isProcessAlive(pid);
-    if (!stillAlive) {
+    if (!isProcessAlive(target)) {
       return;
     }
-    signalProcessTreeUnix(pid, "SIGKILL", useGroupKill);
+    signalUnixTarget(target, "SIGKILL");
   }, graceMs).unref();
 }
 
@@ -78,9 +77,9 @@ export function signalProcessTree(
     return;
   }
 
-  const useGroupKill =
-    opts?.detached === true || (opts?.detached !== false && isProcessGroupLeader(pid));
-  signalProcessTreeUnix(pid, signal, useGroupKill);
+  const target =
+    opts?.detached === true || (opts?.detached !== false && isProcessGroupLeader(pid)) ? -pid : pid;
+  signalUnixTarget(target, signal);
   opts?.onComplete?.();
 }
 
@@ -95,12 +94,12 @@ export function signalPtySessionTree(pid: number, signal: "SIGTERM" | "SIGKILL")
   }
   const darwinTty = process.platform === "darwin" ? readDarwinPtyTty(pid) : undefined;
   if (process.platform === "darwin" && !darwinTty) {
-    signalProcessTreeUnix(pid, signal, true);
+    signalUnixTarget(-pid, signal);
     return;
   }
   const members = readProcessSessionMembers(pid, darwinTty);
   if (!members) {
-    signalProcessTreeUnix(pid, signal, true);
+    signalUnixTarget(-pid, signal);
     return;
   }
   const signalMembers = (snapshot: Array<{ pid: number; pgid: number }>) => {
@@ -236,27 +235,6 @@ function isProcessGroupLeader(pid: number): boolean {
   const procPgid = process.platform === "linux" ? readProcessGroupIdFromProc(pid) : undefined;
   const pgid = procPgid ?? readProcessGroupIdFromPs(pid);
   return pgid === pid;
-}
-
-function signalProcessTreeUnix(
-  pid: number,
-  signal: "SIGTERM" | "SIGKILL",
-  useGroupKill: boolean,
-): void {
-  if (useGroupKill) {
-    try {
-      process.kill(-pid, signal);
-      return;
-    } catch {
-      // Process group does not exist or we lack permission; try direct pid.
-    }
-  }
-
-  try {
-    process.kill(pid, signal);
-  } catch {
-    // Already gone.
-  }
 }
 
 function signalUnixTarget(pid: number, signal: "SIGTERM" | "SIGKILL"): void {

--- a/src/process/child-process-tree.ts
+++ b/src/process/child-process-tree.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess } from "node:child_process";
+import { hasErrnoCode } from "../infra/errno.js";
 import { signalProcessTree } from "./kill-tree.js";
 
 export function shouldDetachChildForProcessTree(): boolean {
@@ -13,8 +14,9 @@ export function isChildProcessTreeAlive(child: Pick<ChildProcess, "pid">): boole
   try {
     process.kill(target, 0);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    // Only ESRCH proves absence. Permission or probe failures must retain cleanup.
+    return !hasErrnoCode(error, "ESRCH");
   }
 }
 

--- a/src/process/child-process.test.ts
+++ b/src/process/child-process.test.ts
@@ -67,32 +67,39 @@ describe.skipIf(process.platform === "win32")("releaseChildProcessOutputAfterExi
     expect(Date.now() - startedAt).toBeLessThan(2_000);
   });
 
-  it("bounds draining from a continuously writing descendant", async () => {
-    vi.useFakeTimers();
-    const stdout = new PassThrough();
-    const stderr = new PassThrough();
-    const fakeChild = Object.assign(new EventEmitter(), {
-      stdout,
-      stderr,
-    }) as unknown as ChildProcess;
-    const cleanup = releaseChildProcessOutputAfterExit(fakeChild);
-    fakeChild.emit("exit", 0);
-    const writer = setInterval(() => stdout.write("TICK\n"), 30);
+  it.each([false, true])(
+    "bounds continuously writing descendants when drain starts after exit=%s",
+    async (alreadyExited) => {
+      vi.useFakeTimers();
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const fakeChild = Object.assign(new EventEmitter(), {
+        stdout,
+        stderr,
+        exitCode: alreadyExited ? 0 : null,
+        signalCode: null,
+      }) as unknown as ChildProcess;
+      const cleanup = releaseChildProcessOutputAfterExit(fakeChild);
+      if (!alreadyExited) {
+        fakeChild.emit("exit", 0);
+      }
+      const writer = setInterval(() => stdout.write("TICK\n"), 30);
 
-    try {
-      await vi.advanceTimersByTimeAsync(999);
-      expect(stdout.destroyed).toBe(false);
-      await vi.advanceTimersByTimeAsync(1);
-      expect(stdout.destroyed).toBe(false);
-      stdout.write("AFTER DEADLINE\n");
-      await vi.advanceTimersByTimeAsync(1);
-      expect(stdout.destroyed).toBe(true);
-      expect(stderr.destroyed).toBe(true);
-    } finally {
-      clearInterval(writer);
-      cleanup();
-    }
-  });
+      try {
+        await vi.advanceTimersByTimeAsync(999);
+        expect(stdout.destroyed).toBe(false);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(stdout.destroyed).toBe(false);
+        stdout.write("AFTER DEADLINE\n");
+        await vi.advanceTimersByTimeAsync(1);
+        expect(stdout.destroyed).toBe(true);
+        expect(stderr.destroyed).toBe(true);
+      } finally {
+        clearInterval(writer);
+        cleanup();
+      }
+    },
+  );
 
   it.each(["idle", "hard"])("cancels pending %s release when cleaned up", async (deadline) => {
     vi.useFakeTimers();

--- a/src/process/child-process.ts
+++ b/src/process/child-process.ts
@@ -59,6 +59,11 @@ export function releaseChildProcessOutputAfterExit(child: ChildProcess): () => v
 
   child.stdout?.on("data", onData);
   child.stderr?.on("data", onData);
-  child.once("exit", onExit);
+  // A command deadline can transfer output here after the root has already exited.
+  if (child.exitCode != null || child.signalCode != null) {
+    onExit();
+  } else {
+    child.once("exit", onExit);
+  }
   return cleanup;
 }

--- a/src/process/exec-runner.ts
+++ b/src/process/exec-runner.ts
@@ -154,7 +154,6 @@ async function runCommandWithOutputEncoding(
   const cancelController = new AbortController();
   let termination: CommandTerminationReason | undefined;
   let childExitState: { code: number | null; signal: NodeJS.Signals | null } | undefined;
-  let childExited = false;
   let commandSettled = false;
   let combinedOutputBytes = 0;
   let combinedCapturedBytes = 0;
@@ -183,21 +182,41 @@ async function runCommandWithOutputEncoding(
     windowsVerbatimArguments: options.windowsVerbatimArguments,
   });
   const nodeChild = child.nodeChildProcess;
-  const releaseOutput = releaseChildProcessOutputAfterExit(nodeChild);
-  nodeChild.once("exit", (code, signalValue) => {
-    childExited = true;
-    childExitState = { code, signal: signalValue };
-  });
+  const ownsExitedProcessTree = Boolean(killProcessTree && process.platform !== "win32");
+  const shouldTrackOutputTimeout =
+    typeof noOutputTimeoutMs === "number" &&
+    Number.isFinite(noOutputTimeoutMs) &&
+    noOutputTimeoutMs > 0;
+  const resolvedNoOutputTimeoutMs = shouldTrackOutputTimeout
+    ? resolveTimerTimeoutMs(noOutputTimeoutMs, 1)
+    : undefined;
+  const ownsOutputDeadline =
+    ownsExitedProcessTree &&
+    (resolvedTimeoutMs !== undefined || resolvedNoOutputTimeoutMs !== undefined);
+  let releaseOutput: (() => void) | undefined;
   const terminationController = createCommandTerminationController({
     child: nodeChild,
     cancelController,
     baseEnv,
     env,
     processTree: killProcessTree ? { mode: "graceful" } : undefined,
-    isChildExited: () => childExited,
+    isChildExited: () => childExitState !== undefined,
     isCommandSettled: () => commandSettled,
     killGraceMs: resolvedKillGraceMs,
     killSignal,
+  });
+  nodeChild.once("exit", (code, signalValue) => {
+    childExitState = { code, signal: signalValue };
+    // Successful tree output belongs to its command deadline, not the diagnostic
+    // idle cutoff. Failed, terminated, and unowned output still gets a bounded drain.
+    if (!ownsOutputDeadline || code !== 0 || termination) {
+      releaseOutput = releaseChildProcessOutputAfterExit(nodeChild);
+    }
+    // An inner timeout can become an ordinary failed exit while its descendants survive.
+    // Retain the existing tree owner through its drain without changing that exit result.
+    if (killProcessTree && !termination && code !== 0) {
+      terminationController.terminate();
+    }
   });
 
   const clearNoOutputTimer = () => {
@@ -206,37 +225,35 @@ async function runCommandWithOutputEncoding(
       noOutputTimer = undefined;
     }
   };
-  const ownsExitedProcessTree = Boolean(killProcessTree && process.platform !== "win32");
   const cancel = (reason: Exclude<CommandTerminationReason, "exit">) => {
-    // Direct exit ends ordinary timer/abort ownership; releaseChildProcessOutputAfterExit
-    // still bounds inherited pipes. POSIX tree mode must reap descendants, while
-    // output caps remain meaningful for bytes drained after exit.
+    // Failed roots already own a drain; later deadlines must preserve their exit result.
+    // Successful POSIX roots retain deadline ownership of inherited descendants.
+    // Output caps remain meaningful for bytes drained after either exit.
     if (
       termination ||
       commandSettled ||
-      (childExited && reason !== "output-limit" && !ownsExitedProcessTree)
+      (childExitState &&
+        reason !== "output-limit" &&
+        (!ownsExitedProcessTree || childExitState.code !== 0))
     ) {
       return;
     }
     termination = reason;
+    if (childExitState) {
+      // An escaped pipe holder can survive group termination; bound its final drain.
+      releaseOutput ??= releaseChildProcessOutputAfterExit(nodeChild);
+    }
     const abortDeferred = terminationController.terminate();
     if (!abortDeferred) {
       cancelController.abort();
     }
   };
-  const shouldTrackOutputTimeout =
-    typeof noOutputTimeoutMs === "number" &&
-    Number.isFinite(noOutputTimeoutMs) &&
-    noOutputTimeoutMs > 0;
-  const resolvedNoOutputTimeoutMs = shouldTrackOutputTimeout
-    ? resolveTimerTimeoutMs(noOutputTimeoutMs, 1)
-    : undefined;
   const armNoOutputTimer = () => {
     if (
       resolvedNoOutputTimeoutMs === undefined ||
       commandSettled ||
       termination ||
-      (childExited && !ownsExitedProcessTree)
+      (childExitState && !ownsExitedProcessTree)
     ) {
       return;
     }
@@ -385,7 +402,7 @@ async function runCommandWithOutputEncoding(
     }
     clearNoOutputTimer();
     signal?.removeEventListener("abort", onAbort);
-    releaseOutput();
+    releaseOutput?.();
   });
   let cleanup = await terminationController.settle();
   const resolvedSignal = result.signal ?? childExitState?.signal ?? nodeChild.signalCode ?? null;

--- a/src/process/exec-termination.test.ts
+++ b/src/process/exec-termination.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferredCore } from "../shared/deferred.js";
 import * as processIdentity from "../shared/pid-alive.js";
 import { killPidIfAlive, waitForPidToExit } from "../test-utils/process-tree.js";
+import { COMMAND_PROCESS_TREE_KILL_GRACE_MS } from "./exec-spawn.js";
 import { createCommandTerminationController } from "./exec-termination.js";
 
 afterEach(() => vi.restoreAllMocks());
@@ -44,6 +45,72 @@ async function withOwnedTree(
 }
 
 describe.skipIf(process.platform === "win32")("command process-group settlement", () => {
+  it.each([
+    { name: "an absent group", probeError: "ESRCH", needsGrace: false },
+    { name: "surviving descendants", probeError: undefined, needsGrace: true },
+    { name: "a permission-denied group", probeError: "EPERM", needsGrace: true },
+  ])(
+    "settles $name after a failed root without losing cleanup ownership",
+    async ({ probeError, needsGrace }) => {
+      vi.useFakeTimers();
+      vi.spyOn(processIdentity, "getFileLockProcessStartTime").mockReturnValue(123);
+      const kill = vi.spyOn(process, "kill").mockImplementation(() => {
+        if (probeError) {
+          throw Object.assign(new Error(probeError), { code: probeError });
+        }
+        return true;
+      });
+      const child = { pid: 4242, exitCode: 7, signalCode: null, kill: vi.fn(() => true) };
+      const cancelController = new AbortController();
+      const controller = createCommandTerminationController({
+        child,
+        cancelController,
+        processTree: { mode: "graceful" },
+        killGraceMs: 300,
+        isChildExited: () => true,
+        isCommandSettled: () => true,
+      });
+      try {
+        expect(controller.terminate()).toBe(needsGrace);
+        let settled = false;
+        const completion = controller.settle().then((cleanup) => {
+          settled = true;
+          return cleanup;
+        });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(settled).toBe(!needsGrace);
+        expect(controller.terminate()).toBe(needsGrace);
+        if (needsGrace) {
+          expect(kill).toHaveBeenCalledWith(-4242, "SIGTERM");
+        } else {
+          expect(kill).not.toHaveBeenCalledWith(-4242, "SIGTERM");
+        }
+        expect(kill).not.toHaveBeenCalledWith(-4242, "SIGKILL");
+        await vi.advanceTimersByTimeAsync(299);
+        expect(settled).toBe(!needsGrace);
+        expect(kill).not.toHaveBeenCalledWith(-4242, "SIGKILL");
+        await vi.advanceTimersByTimeAsync(1);
+        expect(settled).toBe(!needsGrace);
+        if (needsGrace) {
+          expect(kill).toHaveBeenCalledWith(-4242, "SIGKILL");
+        } else {
+          expect(kill).not.toHaveBeenCalledWith(-4242, "SIGKILL");
+        }
+        // Neither live nor EPERM probes prove extinction after the force-send receipt.
+        await vi.advanceTimersByTimeAsync(COMMAND_PROCESS_TREE_KILL_GRACE_MS - 1);
+        expect(settled).toBe(!needsGrace);
+        await vi.advanceTimersByTimeAsync(1);
+        await expect(completion).resolves.toBe(needsGrace ? "uncertain" : "normal");
+        expect(kill.mock.calls.every(([pid]) => pid === -4242)).toBe(true);
+        expect(child.kill).not.toHaveBeenCalled();
+        expect(cancelController.signal.aborted).toBe(false);
+      } finally {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it.each(["graceful", "force"] as const)(
     "joins observed group exit after a %s force-send receipt",
     async (mode) => {

--- a/src/process/exec-termination.ts
+++ b/src/process/exec-termination.ts
@@ -2,6 +2,7 @@ import { constants as osConstants } from "node:os";
 import process from "node:process";
 import { getWindowsSystem32ExePath } from "../infra/windows-install-roots.js";
 import { getFileLockProcessStartTime } from "../shared/pid-alive.js";
+import { isChildProcessTreeAlive } from "./child-process-tree.js";
 import { COMMAND_PROCESS_TREE_KILL_GRACE_MS, spawnCommand } from "./exec-spawn.js";
 import { killProcessTree as terminateProcessTree } from "./kill-tree.js";
 
@@ -95,16 +96,7 @@ export function createCommandTerminationController(params: {
       if (processTreeSettlement) {
         return !force;
       }
-      cleanup = "cooperative";
-      const groupAlive = () => {
-        try {
-          process.kill(-childPid, 0);
-          return true;
-        } catch (error) {
-          // SAFETY: Node's kill error carries errno; only ESRCH certifies absence.
-          return (error as NodeJS.ErrnoException).code !== "ESRCH";
-        }
-      };
+      const groupAlive = () => isChildProcessTreeAlive({ pid: childPid });
       const forceAndObserve = async () => {
         const start = getFileLockProcessStartTime(childPid);
         if (start !== null && start !== originalStart) {
@@ -134,6 +126,12 @@ export function createCommandTerminationController(params: {
         processTreeSettlement = forceAndObserve();
         return false;
       }
+      // Failed roots can finish without descendants. Record graceful cleanup only
+      // when this invocation still owns a live or unproven tree to terminate.
+      if (!directChildAlive && !groupAlive()) {
+        return false;
+      }
+      cleanup = "cooperative";
       try {
         process.kill(-childPid, params.killSignal ?? "SIGTERM");
       } catch (error) {

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -591,10 +591,14 @@ describe("runCommandBuffered", () => {
     ).resolves.toMatchObject({ code: null, termination: "signal", error: new Error("stop") });
   });
 
-  it.runIf(process.platform !== "win32")(
-    "force-kills inherited-pipe descendants after the direct child exits",
+  it.runIf(process.platform !== "win32").each([
+    { exitCode: 0, escaped: false, timeoutMs: 50 },
+    { exitCode: 7, escaped: false, timeoutMs: 50 },
+    { exitCode: 0, escaped: true, timeoutMs: 250 },
+  ])(
+    "drains descendants on failure or the post-success timeout (exit $exitCode, escaped=$escaped)",
     { timeout: 5_000 },
-    async () =>
+    async ({ exitCode, escaped, timeoutMs }) =>
       withTempDir("openclaw-exec-descendant-", async (dir) => {
         const pidPath = path.join(dir, "descendant.pid");
         const termPath = path.join(dir, "sigterm");
@@ -609,12 +613,14 @@ describe("runCommandBuffered", () => {
         const parentSource = [
           "const { spawn } = require('node:child_process')",
           "const { writeFileSync } = require('node:fs')",
-          `const child = spawn(process.execPath, ['-e', ${JSON.stringify(descendantSource)}], { stdio: ['ignore', 'inherit', 'inherit', 'ipc'] })`,
-          `child.once('message', () => { writeFileSync(${JSON.stringify(pidPath)}, String(child.pid)); process.exit(0) })`,
+          `const child = spawn(process.execPath, ['-e', ${JSON.stringify(descendantSource)}], { detached: ${escaped}, stdio: ['ignore', 'inherit', 'inherit', 'ipc'] })`,
+          `writeFileSync(${JSON.stringify(pidPath)}, String(child.pid))`,
+          `child.once('message', () => process.exit(${exitCode}))`,
         ].join(";");
         const realSetTimeout = setTimeout;
         const spawnSpy = vi.spyOn(execSpawn, "spawnCommandWithInvocation");
         let parent: ChildProcess | undefined;
+        let descendantPid: number | undefined;
         let command: ReturnType<typeof runCommandBuffered> | undefined;
         // Freeze deadlines, not subprocess I/O: Node startup must not consume the
         // timeout or the 100ms inherited-pipe idle grace. Polling must stay real.
@@ -622,7 +628,7 @@ describe("runCommandBuffered", () => {
         try {
           let settled = false;
           command = runCommandBuffered([process.execPath, "-e", parentSource], {
-            timeoutMs: 50,
+            timeoutMs,
           }).then((result) => {
             settled = true;
             return result;
@@ -636,14 +642,42 @@ describe("runCommandBuffered", () => {
             throw new Error("command did not expose a child process");
           }
           expect(await once(parent, "exit", { signal: AbortSignal.timeout(2_000) })).toEqual([
-            0,
+            exitCode,
             null,
           ]);
-          const descendantPid = await readPidFile(pidPath);
+          descendantPid = await readPidFile(pidPath);
           expect(isPidAlive(descendantPid)).toBe(true);
           expect(settled).toBe(false);
 
-          await vi.advanceTimersByTimeAsync(50);
+          if (escaped) {
+            // This pipe holder has its own group: root-group termination cannot
+            // close its pipes. Quiet successful output still belongs to the deadline.
+            await vi.advanceTimersByTimeAsync(101);
+            await new Promise<void>((resolve) => {
+              setImmediate(resolve);
+            });
+            expect(parent.stdout?.destroyed).toBe(false);
+            expect(parent.stderr?.destroyed).toBe(false);
+            expect(settled).toBe(false);
+            expect(isPidAlive(descendantPid)).toBe(true);
+            expect(existsSync(termPath)).toBe(false);
+
+            // Bound the real close observation separately from the frozen policy
+            // clock so missing post-termination release still reaches test cleanup.
+            const closed = once(parent, "close", { signal: AbortSignal.timeout(1_000) });
+            await vi.advanceTimersByTimeAsync(timeoutMs - 101);
+            await vi.advanceTimersByTimeAsync(100);
+            await closed;
+            expect(await command).toMatchObject({ code: null, termination: "timeout" });
+            expect(isPidAlive(descendantPid)).toBe(true);
+            expect(existsSync(termPath)).toBe(false);
+            return;
+          }
+
+          if (exitCode === 0) {
+            expect(existsSync(termPath)).toBe(false);
+            await vi.advanceTimersByTimeAsync(50);
+          }
           for (let attempt = 0; attempt < 40 && !existsSync(termPath); attempt += 1) {
             await new Promise<void>((resolve) => {
               realSetTimeout(resolve, 25);
@@ -656,14 +690,26 @@ describe("runCommandBuffered", () => {
           await vi.advanceTimersByTimeAsync(execSpawn.COMMAND_PROCESS_TREE_KILL_GRACE_MS);
           // Force delivery now has a separate bounded exit-observation phase.
           await vi.advanceTimersByTimeAsync(execSpawn.COMMAND_PROCESS_TREE_KILL_GRACE_MS);
-          expect(await command).toMatchObject({ code: null, termination: "timeout" });
+          expect(await command).toMatchObject(
+            exitCode === 0
+              ? { code: null, termination: "timeout" }
+              : { code: exitCode, termination: "exit" },
+          );
           vi.useRealTimers();
           expect(await waitForPidToExit(descendantPid)).toBe(true);
         } finally {
           try {
-            if (parent?.pid) {
+            // Record the spawned descendant before its readiness acknowledgement,
+            // so even an early root/IPC failure can reap the explicitly owned group.
+            if (descendantPid === undefined && existsSync(pidPath)) {
+              descendantPid = await readPidFile(pidPath);
+            }
+            for (const groupPid of [parent?.pid, escaped ? descendantPid : undefined]) {
+              if (groupPid === undefined || !Number.isInteger(groupPid) || groupPid <= 0) {
+                continue;
+              }
               try {
-                process.kill(-parent.pid, "SIGKILL");
+                process.kill(-groupPid, "SIGKILL");
               } catch {
                 // Already gone.
               }
@@ -676,6 +722,12 @@ describe("runCommandBuffered", () => {
             spawnSpy.mockRestore();
           }
           await command;
+          if (parent?.pid) {
+            expect(await waitForPidToExit(parent.pid)).toBe(true);
+          }
+          if (descendantPid !== undefined) {
+            expect(await waitForPidToExit(descendantPid)).toBe(true);
+          }
         }
       }),
   );

--- a/src/process/exec.windows.integration.test.ts
+++ b/src/process/exec.windows.integration.test.ts
@@ -1,11 +1,91 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { once } from "node:events";
 import process from "node:process";
 import { describe, expect, it, vi } from "vitest";
+import {
+  inspectNodeWorkerProcessIdentity,
+  requireNodeWorkerProcessIdentity,
+  type NodeWorkerProcessIdentity,
+} from "../node-host/node-worker-process-identity.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { runUtf8CommandWithTimeout } from "./exec.js";
 import { killProcessTree } from "./kill-tree.js";
 
 describe("runUtf8CommandWithTimeout Windows integration", () => {
+  it.runIf(process.platform === "win32")(
+    "closes a nested Node descendant after an inner spawnSync timeout and outer failure",
+    async () => {
+      const descendantSource = 'setInterval(() => {}, 1000); process.send("ready");';
+      const innerSource = [
+        'const { spawn } = require("node:child_process");',
+        `const child = spawn(process.execPath, ["-e", ${JSON.stringify(descendantSource)}], { stdio: ["ignore", "ignore", "ignore", "ipc"], windowsHide: true });`,
+        'child.once("message", () => process.stdout.write(String(child.pid) + "\\n"));',
+      ].join("\n");
+      // Match the finalization fence's real child deadline. Each non-detached Node
+      // child has libuv job ownership; this does not cover arbitrary grandchildren
+      // or hosts that deny job assignment.
+      const outerSource = [
+        'const { spawnSync } = require("node:child_process");',
+        `const result = spawnSync(process.execPath, ["-"], { input: ${JSON.stringify(innerSource)}, stdio: ["pipe", "inherit", "pipe"], timeout: 60_000, killSignal: "SIGKILL", encoding: "utf8", windowsHide: true });`,
+        "if (result.error) process.stderr.write(result.error.message);",
+        "process.exitCode = result.error || result.status !== 0 ? 1 : 0;",
+      ].join("\n");
+      const ready = createDeferredCore<NodeWorkerProcessIdentity>();
+      const controller = new AbortController();
+      let child: NodeWorkerProcessIdentity | undefined;
+      let output = "";
+      const pending = runUtf8CommandWithTimeout([process.execPath, "-e", outerSource], {
+        timeoutMs: 75_000,
+        killProcessTree: true,
+        signal: controller.signal,
+        onOutputChunk: (chunk, stream) => {
+          if (stream !== "stdout" || child) {
+            return;
+          }
+          output += chunk.toString("utf8");
+          if (output.includes("\n")) {
+            child = requireNodeWorkerProcessIdentity(Number(output.trim()));
+            ready.resolve(child);
+          }
+        },
+      });
+      try {
+        const descendant = await Promise.race([
+          ready.promise,
+          pending.then(() => {
+            throw new Error("inner command ended without descendant readiness");
+          }),
+        ]);
+        expect(inspectNodeWorkerProcessIdentity(descendant)).toBe("live");
+        await expect(pending).resolves.toMatchObject({
+          code: 1,
+          termination: "exit",
+          stderr: expect.stringContaining("ETIMEDOUT"),
+        });
+        await vi.waitFor(
+          () => {
+            expect(inspectNodeWorkerProcessIdentity(descendant)).toBe("dead");
+          },
+          { timeout: 5_000, interval: 50 },
+        );
+      } finally {
+        controller.abort();
+        await pending.catch(() => undefined);
+        // Failed assertions still clean only the exact observed fixture process.
+        if (child && inspectNodeWorkerProcessIdentity(child) === "live") {
+          process.kill(child.pid, "SIGKILL");
+          await vi.waitFor(
+            () => {
+              expect(inspectNodeWorkerProcessIdentity(child!)).toBe("dead");
+            },
+            { timeout: 5_000, interval: 50 },
+          );
+        }
+      }
+    },
+    90_000,
+  );
+
   it.runIf(process.platform === "win32")(
     "keeps truncated UTF-8 head output on a code point boundary",
     async () => {
@@ -66,11 +146,9 @@ describe("runUtf8CommandWithTimeout Windows integration", () => {
           { timeout: 5_000, interval: 50 },
         );
       } finally {
-        spawnSync("taskkill", ["/F", "/T", "/PID", String(parentPid)], {
-          stdio: "ignore",
-          timeout: 5_000,
-          windowsHide: true,
-        });
+        // The retained child handle is safe after exit; taskkill of its reusable
+        // PID is not. This fixture's non-detached Node child is in its libuv job.
+        parent.kill("SIGKILL");
         parentStdout.destroy();
       }
     },

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -383,29 +383,40 @@ describe("Windows command execution", () => {
     });
   });
 
-  it("does not time out after the direct child exits while output settles", async () => {
-    vi.useFakeTimers();
-    const command = createMockSubprocess({ autoFinish: false });
-    execaMock.mockReturnValueOnce(command);
+  it.each([
+    { exitCode: 0, killProcessTree: undefined },
+    { exitCode: 7, killProcessTree: undefined },
+    { exitCode: 0, killProcessTree: true },
+    { exitCode: 7, killProcessTree: true },
+  ])(
+    "does not target an exited Windows root (code $exitCode, tree=$killProcessTree) while output settles",
+    async ({ exitCode, killProcessTree }) => {
+      vi.useFakeTimers();
+      const command = createMockSubprocess({ autoFinish: false });
+      execaMock.mockReturnValueOnce(command);
 
-    await withMockedWindowsPlatform(async () => {
-      const resultPromise = runCommandWithTimeout(["node", "quick.js"], { timeoutMs: 80 });
-      command.exitCode = 0;
-      command.emit("exit", 0, null);
+      await withMockedWindowsPlatform(async () => {
+        const resultPromise = runCommandWithTimeout(["node", "quick.js"], {
+          timeoutMs: 80,
+          killProcessTree,
+        });
+        command.exitCode = exitCode;
+        command.emit("exit", exitCode, null);
 
-      await vi.advanceTimersByTimeAsync(81);
-      expect(execaMock).toHaveBeenCalledTimes(1);
-      expect(command.stdout.destroyed).toBe(false);
-      await vi.advanceTimersByTimeAsync(19);
-      expect(command.stdout.destroyed).toBe(false);
-      await vi.advanceTimersToNextTimerAsync();
-      expect(command.stdout.destroyed).toBe(true);
-      expect(command.stderr.destroyed).toBe(true);
+        await vi.advanceTimersByTimeAsync(81);
+        expect(execaMock).toHaveBeenCalledTimes(1);
+        expect(command.stdout.destroyed).toBe(false);
+        await vi.advanceTimersByTimeAsync(19);
+        expect(command.stdout.destroyed).toBe(false);
+        await vi.advanceTimersToNextTimerAsync();
+        expect(command.stdout.destroyed).toBe(true);
+        expect(command.stderr.destroyed).toBe(true);
 
-      command.finish();
-      await expect(resultPromise).resolves.toMatchObject({ code: 0, termination: "exit" });
-    });
-  });
+        command.finish({ exitCode });
+        await expect(resultPromise).resolves.toMatchObject({ code: exitCode, termination: "exit" });
+      });
+    },
+  );
 
   it("gracefully then force-kills a Windows process tree", async () => {
     vi.useFakeTimers();

--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -200,12 +200,9 @@ describe("killProcessTree", () => {
     });
   });
 
-  it("on Unix sends SIGTERM first and skips SIGKILL when process exits", async () => {
+  it("on Unix never probes a reused positive PID after its selected group disappears", async () => {
     killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
       if (pid === -3333 && signal === 0) {
-        throw new Error("ESRCH");
-      }
-      if (pid === 3333 && signal === 0) {
         throw new Error("ESRCH");
       }
       return true;
@@ -220,41 +217,54 @@ describe("killProcessTree", () => {
       expect(killSpy).toHaveBeenCalledWith(-3333, "SIGTERM");
       expect(killSpy).not.toHaveBeenCalledWith(-3333, "SIGKILL");
       expect(killSpy).not.toHaveBeenCalledWith(3333, "SIGKILL");
+      expect(killSpy.mock.calls.every((call: unknown[]) => call[0] === -3333)).toBe(true);
     });
   });
 
-  it("on Unix sends SIGKILL after grace period when process is still alive", async () => {
-    killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
-      if (pid === -4444 && signal === 0) {
+  it.each([false, true])(
+    "on Unix keeps grace escalation group-only (group vanishes: %s)",
+    async (vanishes) => {
+      killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+        if (pid === -4444 && signal === "SIGKILL" && vanishes) {
+          throw new Error("ESRCH");
+        }
         return true;
-      }
-      return true;
-    }) as typeof process.kill);
+      }) as typeof process.kill);
 
-    await withMockedPlatform("linux", async () => {
-      mockIsProcessGroupLeader(4444);
-      killProcessTree(4444, { graceMs: 5 });
+      await withMockedPlatform("linux", async () => {
+        mockIsProcessGroupLeader(4444);
+        killProcessTree(4444, { graceMs: 5 });
 
-      await vi.advanceTimersByTimeAsync(5);
+        await vi.advanceTimersByTimeAsync(5);
 
-      expect(killSpy).toHaveBeenCalledWith(-4444, "SIGTERM");
-      expect(killSpy).toHaveBeenCalledWith(-4444, "SIGKILL");
-    });
-  });
+        expect(killSpy).toHaveBeenCalledWith(-4444, "SIGTERM");
+        expect(killSpy).toHaveBeenCalledWith(-4444, "SIGKILL");
+        expect(killSpy.mock.calls.every((call: unknown[]) => call[0] === -4444)).toBe(true);
+      });
+    },
+  );
 
-  it("on Unix force-kills synchronously without SIGTERM or delayed escalation", async () => {
-    killSpy.mockImplementation(() => true);
+  it.each([false, true])(
+    "on Unix keeps immediate force-kill group-only (group missing: %s)",
+    async (missing) => {
+      killSpy.mockImplementation((pid: number) => {
+        if (pid === -4949 && missing) {
+          throw new Error("ESRCH");
+        }
+        return true;
+      });
 
-    await withMockedPlatform("linux", async () => {
-      mockIsProcessGroupLeader(4949);
-      killProcessTree(4949, { force: true });
-      await vi.advanceTimersByTimeAsync(60_000);
+      await withMockedPlatform("linux", async () => {
+        mockIsProcessGroupLeader(4949);
+        killProcessTree(4949, { force: true });
+        await vi.advanceTimersByTimeAsync(60_000);
 
-      expect(killSpy).toHaveBeenCalledTimes(1);
-      expect(killSpy).toHaveBeenCalledWith(-4949, "SIGKILL");
-      expect(killSpy).not.toHaveBeenCalledWith(-4949, "SIGTERM");
-    });
-  });
+        expect(killSpy).toHaveBeenCalledTimes(1);
+        expect(killSpy).toHaveBeenCalledWith(-4949, "SIGKILL");
+        expect(killSpy).not.toHaveBeenCalledWith(-4949, "SIGTERM");
+      });
+    },
+  );
 
   it("on Unix force-kills a live detached group even after the parent pid exits", async () => {
     killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
@@ -268,14 +278,14 @@ describe("killProcessTree", () => {
     }) as typeof process.kill);
 
     await withMockedPlatform("linux", async () => {
-      mockIsProcessGroupLeader(4545);
-      killProcessTree(4545, { graceMs: 5 });
+      killProcessTree(4545, { graceMs: 5, detached: true });
 
       await vi.advanceTimersByTimeAsync(5);
 
       expect(killSpy).toHaveBeenCalledWith(-4545, "SIGTERM");
       expect(killSpy).toHaveBeenCalledWith(-4545, "SIGKILL");
       expect(killSpy).not.toHaveBeenCalledWith(4545, "SIGKILL");
+      expect(spawnSyncMock).not.toHaveBeenCalled();
     });
   });
 
@@ -361,6 +371,7 @@ describe("killProcessTree", () => {
       await vi.advanceTimersByTimeAsync(10);
 
       expect(killSpy).toHaveBeenCalledWith(9999, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(9999, "SIGKILL");
       expect(killSpy).not.toHaveBeenCalledWith(-9999, "SIGTERM");
       expect(killSpy).not.toHaveBeenCalledWith(-9999, "SIGKILL");
     });
@@ -378,20 +389,28 @@ describe("killProcessTree", () => {
     });
   });
 
-  it("on Unix sends a single requested tree signal without scheduling escalation", async () => {
-    killSpy.mockImplementation(() => true);
+  it.each([false, true])(
+    "on Unix keeps a requested signal group-only (group missing: %s)",
+    async (missing) => {
+      killSpy.mockImplementation((pid: number) => {
+        if (pid === -7777 && missing) {
+          throw new Error("ESRCH");
+        }
+        return true;
+      });
 
-    await withMockedPlatform("linux", async () => {
-      mockIsProcessGroupLeader(7777);
-      signalProcessTree(7777, "SIGTERM");
+      await withMockedPlatform("linux", async () => {
+        mockIsProcessGroupLeader(7777);
+        signalProcessTree(7777, "SIGTERM");
 
-      await vi.advanceTimersByTimeAsync(60_000);
+        await vi.advanceTimersByTimeAsync(60_000);
 
-      expect(killSpy).toHaveBeenCalledTimes(1);
-      expect(killSpy).toHaveBeenCalledWith(-7777, "SIGTERM");
-      expect(killSpy).not.toHaveBeenCalledWith(-7777, "SIGKILL");
-    });
-  });
+        expect(killSpy).toHaveBeenCalledTimes(1);
+        expect(killSpy).toHaveBeenCalledWith(-7777, "SIGTERM");
+        expect(killSpy).not.toHaveBeenCalledWith(-7777, "SIGKILL");
+      });
+    },
+  );
 
   it("rescans a PTY session for job-control groups created after the first snapshot", async () => {
     killSpy.mockImplementation(() => true);


### PR DESCRIPTION
Related: #132180 (node-session completion delays and execution outcomes). This replaces only its process-output lifetime slice; the original remains open while the other slices are handled.

## What Problem This Solves

Fixes an issue where command users could lose quiet descendant output before the configured command deadline, or keep waiting on descendants after the command had already failed. A later deadline could also replace the command's original failure with a timeout result.

## Why This Change Was Made

Make the command owner retain successful, tree-owned POSIX output until its existing deadline, while failed or terminated commands enter bounded diagnostic drainage and owned descendant cleanup immediately. Keep a selected process group as the signal target throughout cleanup rather than falling back to its reusable positive PID, preserving current main's force-and-observe and PID-incarnation checks.

## User Impact

Commands retain expected output and report their original failure while cleaning up owned descendants. Existing deadlines, output limits, explicit restrictions, and Windows retired-root behavior remain unchanged. Cleanup still reports uncertainty when termination cannot be proved; this does not promise containment of escaped descendants.

No configuration, schema, dependency, or public API change. Production is **+69/-69 (net zero)**; tests are **+341/-107 (net +234)**. The obsolete group-to-PID fallback and duplicate child-exited flag are removed.

## Evidence

Tests-only reproduction on unchanged production at `3de516d21fc4bb05e4c9166c3be9a985b53f5a92`: **9 intended failures, 6 passes, 90 unselected**. The failing cases cover late drain attachment, failed-root cleanup, quiet inherited pipes, and selected-group targeting.

Post-fix proof: **161 tests passed, four platform skips**, including real POSIX child/descendant/escaped-pipe cases, no-output deadlines, and local-provider lifecycle coverage. Readiness handshakes precede policy-clock advancement; no timeout or grace budget was increased.

```bash
node scripts/run-vitest.mjs src/process/child-process.test.ts src/process/exec-termination.test.ts src/process/exec.test.ts src/process/kill-tree.test.ts src/process/exec.windows.test.ts src/process/exec.windows.integration.test.ts src/process/exec.no-output-timer.test.ts src/agents/provider-local-service.test.ts
```

```bash
pnpm build
```

```bash
node scripts/check-changed.mjs --staged
```

The packaged build passed in 257.647 seconds; all changed checks passed in 517.334 seconds. Both receipts bind the same unchanged candidate tree, `4e92d18397babbae8ca1e483e6e60275a11f186c`. Two earlier build attempts were stopped by CPU admission before executing, not build failures.

Independent isolated Codex review returned **scoped-clean at P0**, with no accepted/actionable findings. [Exact-head CI 34091063703](https://github.com/openclaw/openclaw/actions/runs/34091063703) and the required gate passed. The [native Windows job](https://github.com/openclaw/openclaw/actions/runs/34091063703/job/101644558087) passed both default and explicit tree modes for success/failure, plus the real nested Node timeout integration case in 60.502 seconds. [ClawSweeper's review](https://github.com/openclaw/openclaw/pull/140927#issuecomment-5566136859) reports no findings or before-merge requirements.

Current main added a separate command-cleanup scope after this branch's base. An additional **37 tests passed** on GitHub's merge tree `cab1a08cca3ab402d3ddc852be6e9614fdadaa67` (main parent `d8af304112659dda862df8bde111cae2ba1b1dc6` plus exact PR head `2aa7aa7f0922c263919a5ec1cdb5d1e8592ede7b`). The inspected new scope and caller match main `ce174871076b4a5db8524ef8eb8ea17a3abe97fa` byte-for-byte; all eleven PR files match the reviewed candidate. This proof used its own checkout and dependencies, without rebasing or modifying the PR.

```bash
node scripts/run-vitest.mjs src/process/exec-spawn.test.ts src/process/kill-tree.test.ts
```

Dependency inspection covered Execa's separate exit/stream settlement and [Codex's exact-group signaling contract](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/utils/pty/src/process_group.rs#L120-L133). The Windows fixture's Node/libuv job behavior does not establish general descendant containment or Bun equivalence.
