### PR TITLE
refactor(sessions): share ownership parsing and main-key construction

### DIFF
--- a/packages/session-url-contract/src/grammar.ts
+++ b/packages/session-url-contract/src/grammar.ts
@@ -1,6 +1,7 @@
 import { normalizeNullableString } from "@openclaw/normalization-core/string-coerce";
+import { DEFAULT_MAIN_KEY } from "./session-key.js";
 
-export const DEFAULT_MAIN_KEY = "main";
+export { DEFAULT_MAIN_KEY };
 
 const SHORT_SESSION_REF_RE = /^(?:.*-)?([0-9a-f]{8,32})$/iu;
 const FIXED_RESERVED_SESSION_RESTS = new Set(["main", "global", "boot", "sessions"]);

--- a/packages/session-url-contract/src/index.test.ts
+++ b/packages/session-url-contract/src/index.test.ts
@@ -163,6 +163,16 @@ describe("buildControlUiCatalogSharePath", () => {
 
 describe("buildControlUiSessionPath", () => {
   it.each([
+    [
+      "case-sensitive literal",
+      { sessionKey: "Agent:Ops:Matrix:Channel:!Room:Org:Thread:$Event", exactKey: true },
+      "/chat/ops/Matrix/Channel/!Room/Org/Thread/%24Event",
+    ],
+    [
+      "opaque catalog",
+      { sessionKey: "agent:ops:catalog:fixture:Host:Thread" },
+      "/chat/ops/catalog/fixture/Host/Thread",
+    ],
     ["scoped main", { sessionKey: "agent:main:main" }, "/chat/main"],
     ["unscoped main", { sessionKey: "main", fallbackAgentId: "research" }, "/chat/research"],
     [
@@ -282,6 +292,9 @@ describe("buildControlUiSessionPath", () => {
     { sessionKey: "agent::control-link" },
     { sessionKey: "agent:main:" },
     { sessionKey: "agent:main:telegram::12345" },
+    { sessionKey: "agent:ops:room::part" },
+    { sessionKey: "agent:ops::main" },
+    { sessionKey: "agent:ops:cron:" },
   ] satisfies readonly ChatParams[])("rejects invalid input %#", (params) => {
     expect(buildChatPath(params)).toBeNull();
   });

--- a/packages/session-url-contract/src/index.ts
+++ b/packages/session-url-contract/src/index.ts
@@ -7,8 +7,16 @@ import {
   normalizeControlUiBasePath,
   parseShortSessionRef,
 } from "./grammar.js";
+import { parseAgentSessionKeyParts } from "./session-key.js";
 
 export { controlUiSessionSlug, normalizeControlUiBasePath };
+export {
+  buildAgentMainSessionKey,
+  DEFAULT_MAIN_KEY,
+  normalizeMainKey,
+  parseAgentSessionKeyParts,
+  type ParsedAgentSessionKey,
+} from "./session-key.js";
 export * from "./focus.js";
 export {
   CONTROL_UI_RESERVED_ROUTE_SEGMENTS,
@@ -46,16 +54,11 @@ export const SESSION_UUID_SUFFIX_RE =
 export const SHORT_SESSION_ID_RE = /^[0-9a-f]{8,32}$/iu;
 
 function agentSessionKeyParts(sessionKey: string): { agentId: string; rest: string } | null {
-  const parts = sessionKey.split(":");
-  if (parts.length < 3 || parts[0]?.toLowerCase() !== "agent") {
+  const parsed = parseAgentSessionKeyParts(sessionKey);
+  if (!parsed || parsed.rest.split(":").some((segment) => !segment)) {
     return null;
   }
-  const agentId = normalizeNullableString(parts[1]);
-  const restSegments = parts.slice(2);
-  if (!agentId || restSegments.some((segment) => !segment)) {
-    return null;
-  }
-  return { agentId: normalizeAgentId(agentId), rest: restSegments.join(":") };
+  return { agentId: normalizeAgentId(parsed.agentId), rest: parsed.rest };
 }
 
 function encodePathSegment(segment: string): string {

--- a/packages/session-url-contract/src/session-key.ts
+++ b/packages/session-url-contract/src/session-key.ts
@@ -1,0 +1,34 @@
+import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+
+export const DEFAULT_MAIN_KEY = "main";
+
+export type ParsedAgentSessionKey = {
+  agentId: string;
+  rest: string;
+};
+
+/** Split the ownership head without changing opaque tail bytes or empty tail segments. */
+export function parseAgentSessionKeyParts(sessionKey: string): ParsedAgentSessionKey | null {
+  if (sessionKey.slice(0, 6).toLowerCase() !== "agent:") {
+    return null;
+  }
+  const agentIdEnd = sessionKey.indexOf(":", 6);
+  if (agentIdEnd === -1) {
+    return null;
+  }
+  const agentId = sessionKey.slice(6, agentIdEnd).trim();
+  const rest = sessionKey.slice(agentIdEnd + 1);
+  return agentId && rest && !rest.startsWith(":") ? { agentId, rest } : null;
+}
+
+export function normalizeMainKey(value: string | undefined | null): string {
+  return normalizeLowercaseStringOrEmpty(value) || DEFAULT_MAIN_KEY;
+}
+
+export function buildAgentMainSessionKey(params: {
+  agentId: string;
+  mainKey?: string | undefined;
+}): string {
+  return `agent:${normalizeAgentId(params.agentId)}:${normalizeMainKey(params.mainKey)}`;
+}

--- a/src/config/sessions/main-session.ts
+++ b/src/config/sessions/main-session.ts
@@ -5,6 +5,7 @@ import {
 } from "../../agents/agent-scope-config.js";
 // Main-session keys normalize configured agents and legacy aliases into store keys.
 import {
+  buildAgentMainSessionKey,
   normalizeAgentId,
   normalizeMainKey,
   resolveAgentIdFromSessionKey,
@@ -16,11 +17,6 @@ import type { SessionScope } from "./types.js";
 
 const FALLBACK_DEFAULT_AGENT_ID = "main";
 export const SESSION_ROUTING_CHANGED_ERROR_REASON = "session-routing-changed";
-
-/** Builds the canonical main session key for an agent. */
-function buildMainSessionKey(agentId: string, mainKey?: string): string {
-  return `agent:${normalizeAgentId(agentId)}:${normalizeMainKey(mainKey)}`;
-}
 
 /** Resolves the configured main session key, honoring global session scope. */
 export function resolveMainSessionKey(cfg: OpenClawConfig): string {
@@ -81,7 +77,10 @@ export function resolveAgentMainSessionKey(params: {
   cfg?: { session?: { mainKey?: string } };
   agentId: string;
 }): string {
-  return buildMainSessionKey(params.agentId, params.cfg?.session?.mainKey);
+  return buildAgentMainSessionKey({
+    agentId: params.agentId,
+    mainKey: params.cfg?.session?.mainKey,
+  });
 }
 
 /** Resolves an explicit agent id to its canonical main session key. */
@@ -109,15 +108,18 @@ export function canonicalizeMainSessionAlias(params: {
 
   const agentId = normalizeAgentId(params.agentId);
   const mainKey = normalizeMainKey(params.cfg?.session?.mainKey);
-  const agentMainSessionKey = buildMainSessionKey(agentId, mainKey);
-  const agentMainAliasKey = buildMainSessionKey(agentId, "main");
+  const agentMainSessionKey = buildAgentMainSessionKey({ agentId, mainKey });
+  const agentMainAliasKey = buildAgentMainSessionKey({ agentId, mainKey: "main" });
 
   // Also recognize legacy keys built with the hardcoded DEFAULT_AGENT_ID ("main")
   // when the configured agent differs. resolveSessionKey() historically used
   // DEFAULT_AGENT_ID="main" for all write paths, producing "agent:main:<mainKey>"
   // even when the configured agent is e.g. "ops". See #29683.
-  const legacyMainKey = buildMainSessionKey(FALLBACK_DEFAULT_AGENT_ID, mainKey);
-  const legacyMainAliasKey = buildMainSessionKey(FALLBACK_DEFAULT_AGENT_ID, "main");
+  const legacyMainKey = buildAgentMainSessionKey({ agentId: FALLBACK_DEFAULT_AGENT_ID, mainKey });
+  const legacyMainAliasKey = buildAgentMainSessionKey({
+    agentId: FALLBACK_DEFAULT_AGENT_ID,
+    mainKey: "main",
+  });
 
   const isMainAlias =
     raw === "main" ||

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -283,6 +283,30 @@ describe("cron run scope suffix parsing", () => {
   });
 });
 
+describe("stored session grammar boundaries", () => {
+  it.each([
+    ["agent:ops:room::part", { agentId: "ops", rest: "room::part" }],
+    ["agent:ops::main", null],
+    ["agent::ops:main", null],
+    [":agent:ops:main", null],
+    ["agent:ops:cron:", { agentId: "ops", rest: "cron:" }],
+    [
+      "Agent:Ops:Matrix:Channel:!Room:Org:Thread:$Event",
+      { agentId: "ops", rest: "matrix:channel:!Room:Org:thread:$Event" },
+    ],
+    [
+      "Agent:Ops:Signal:Group:AbC:Thread:XyZ",
+      { agentId: "ops", rest: "signal:group:AbC:thread:xyz" },
+    ],
+    [
+      "agent:ops:catalog:fixture:Host:Thread",
+      { agentId: "ops", rest: "catalog:fixture:host:thread" },
+    ],
+  ] as const)("preserves stored identity for %s", (key, expected) => {
+    expect(parseAgentSessionKey(key)).toEqual(expected);
+  });
+});
+
 describe("session key canonicalization", () => {
   function expectSessionKeyCanonicalizationCase(params: { run: () => void }) {
     params.run();

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -8,6 +8,11 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import {
+  buildAgentMainSessionKey,
+  DEFAULT_MAIN_KEY,
+  normalizeMainKey,
+} from "@openclaw/session-url-contract";
 import type { ChatType } from "../channels/chat-type.js";
 import {
   isCronRunSessionKey,
@@ -39,7 +44,7 @@ export { isValidAgentId, normalizeAgentId, normalizeAgentIdStrict };
 export const LEGACY_IMPLICIT_AGENT_ID = "main";
 /** @deprecated legacy implicit agent id; use roster default resolution. Removal: next major SDK cut. */
 export const DEFAULT_AGENT_ID = LEGACY_IMPLICIT_AGENT_ID;
-export const DEFAULT_MAIN_KEY = "main";
+export { buildAgentMainSessionKey, DEFAULT_MAIN_KEY, normalizeMainKey };
 type SessionKeyShape = "missing" | "agent" | "legacy_or_alias" | "malformed_agent";
 
 function normalizeToken(value: string | undefined | null): string {
@@ -87,10 +92,6 @@ export function resolveEventSessionKey(
     return "global";
   }
   return buildAgentMainSessionKey({ agentId: parsed.agentId, mainKey });
-}
-
-export function normalizeMainKey(value: string | undefined | null): string {
-  return normalizeLowercaseStringOrEmpty(value) || DEFAULT_MAIN_KEY;
 }
 
 export function toAgentRequestSessionKey(storeKey: string | undefined | null): string | undefined {
@@ -201,15 +202,6 @@ export function normalizeOptionalAgentId(value: unknown): string | undefined {
 
 export function sanitizeAgentId(value: string | undefined | null): string {
   return normalizeAgentId(value);
-}
-
-export function buildAgentMainSessionKey(params: {
-  agentId: string;
-  mainKey?: string | undefined;
-}): string {
-  const agentId = normalizeAgentId(params.agentId);
-  const mainKey = normalizeMainKey(params.mainKey);
-  return `agent:${agentId}:${mainKey}`;
 }
 
 export function buildAgentPeerSessionKey(params: {

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -4,13 +4,14 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import {
+  parseAgentSessionKeyParts,
+  type ParsedAgentSessionKey,
+} from "@openclaw/session-url-contract";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { escapeRegExp } from "../shared/regexp.js";
 
-export type ParsedAgentSessionKey = {
-  agentId: string;
-  rest: string;
-};
+export type { ParsedAgentSessionKey };
 
 export type ParsedThreadSessionSuffix = {
   baseSessionKey: string | undefined;
@@ -246,23 +247,7 @@ export function normalizeSessionKeyPreservingOpaquePeerIds(
 export function parseAgentSessionKey(
   sessionKey: string | undefined | null,
 ): ParsedAgentSessionKey | null {
-  const raw = normalizeSessionKeyPreservingOpaquePeerIds(sessionKey);
-  if (!raw) {
-    return null;
-  }
-  if (!raw.startsWith("agent:")) {
-    return null;
-  }
-  const agentIdEnd = raw.indexOf(":", "agent:".length);
-  if (agentIdEnd === -1) {
-    return null;
-  }
-  const agentId = normalizeOptionalString(raw.slice("agent:".length, agentIdEnd));
-  const rest = raw.slice(agentIdEnd + 1);
-  if (!agentId || !rest || rest.startsWith(":")) {
-    return null;
-  }
-  return { agentId, rest };
+  return parseAgentSessionKeyParts(normalizeSessionKeyPreservingOpaquePeerIds(sessionKey));
 }
 
 export function isCronRunSessionKey(sessionKey: string | undefined | null): boolean {

--- a/ui/src/lib/session-display.test.ts
+++ b/ui/src/lib/session-display.test.ts
@@ -1,11 +1,32 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
+  isCronSessionKey,
   resolveChannelSessionInfo,
   resolveSessionDisplayName,
   resolveSessionWorkContext,
   resolveSessionWorkSubtitle,
 } from "./session-display.ts";
+
+describe("isCronSessionKey", () => {
+  it.each([
+    ["cron:job", true],
+    [" CRON:JOB ", true],
+    ["agent:ops:cron:job", true],
+    ["agent:ops:cron:job:run:one", true],
+    ["agent:ops::cron:job", true],
+    ["agent: :cron:job", true],
+    ["agent:ops:cron:", false],
+    ["agent:ops:cron::", false],
+    ["agent::cron:job", false],
+    [":agent:ops:cron:job", false],
+    ["agent:ops:custom:cron:job", false],
+    ["agent:ops:main", false],
+    ["", false],
+  ] as const)("retains automation classification for %j", (key, expected) => {
+    expect(isCronSessionKey(key)).toBe(expected);
+  });
+});
 
 describe("resolveSessionDisplayName", () => {
   it("uses the same friendly main-thread name for every agent", () => {

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -334,19 +334,10 @@ export function resolveSessionDisplayName(
 
 export function isCronSessionKey(key: string): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(key);
-  if (!normalized) {
-    return false;
-  }
-  if (normalized.startsWith("cron:")) {
-    return true;
-  }
-  if (!normalized.startsWith("agent:")) {
-    return false;
-  }
   const parts = normalized.split(":").filter(Boolean);
-  if (parts.length < 3) {
-    return false;
-  }
-  const rest = parts.slice(2).join(":");
-  return rest.startsWith("cron:");
+  // Display classification also accepts whitespace-only owners; routing rejects them.
+  return (
+    normalized.startsWith("cron:") ||
+    (normalized.startsWith("agent:") && parts.length >= 4 && parts[2] === "cron")
+  );
 }

--- a/ui/src/lib/sessions/session-key.test.ts
+++ b/ui/src/lib/sessions/session-key.test.ts
@@ -1,16 +1,110 @@
 // @vitest-environment node
+import { parseAgentSessionKeyParts } from "@openclaw/session-url-contract";
 import { describe, expect, it } from "vitest";
 import {
   canArchiveSessionRow,
   canDeleteSessionRows,
   canonicalUiSessionKeyForPersistence,
   isUiSelectedGlobalSessionKey,
+  normalizeSessionKeyForUiComparison,
+  parseAgentSessionKey,
   parseSessionKeyParts,
+  resolveAgentIdFromSessionKey,
   resolveUiSessionNavigationParentKey,
   resolveUiConversationIdentity,
   uiSessionEventMatches,
   uiSessionRowMatchesSelectedChat,
 } from "./session-key.ts";
+
+describe("Dashboard fixture session keys", () => {
+  it.each([
+    ["agent:main:main", "main", "main"],
+    ["agent:ops:home", "ops", "home"],
+    ["agent:ops:current", "ops", "current"],
+    ["agent:research:main:thread", "research", "main:thread"],
+    ["agent:main:dashboard:uuid", "main", "dashboard:uuid"],
+    [
+      "agent:main:dashboard:0f9d5c1e-6d0f-4c9a-9d84-1c2f3a4b5c6d",
+      "main",
+      "dashboard:0f9d5c1e-6d0f-4c9a-9d84-1c2f3a4b5c6d",
+    ],
+    ["agent:main:node-proof-claude", "main", "node-proof-claude"],
+    ["agent:main:explicit:node-mcp-debug", "main", "explicit:node-mcp-debug"],
+    ["agent:main:telegram:direct:42", "main", "telegram:direct:42"],
+    ["agent:main:telegram:cards:dm:42", "main", "telegram:cards:dm:42"],
+    ["agent:main:telegram:cards:direct:42", "main", "telegram:cards:direct:42"],
+    ["agent:main:telegram:default:direct:42", "main", "telegram:default:direct:42"],
+    ["agent:main:telegram:direct:12345😀67890", "main", "telegram:direct:12345😀67890"],
+    ["agent:main:telegram:group:-1001234567890", "main", "telegram:group:-1001234567890"],
+    ["agent:main:slack:channel:C1", "main", "slack:channel:C1", "slack:channel:c1"],
+    ["agent:main:dm:+123", "main", "dm:+123"],
+    ["agent:main:direct:+123", "main", "direct:+123"],
+    ["agent:main:dm:account:group:room", "main", "dm:account:group:room"],
+    [
+      "agent:main:slack:acct-1:channel:C1",
+      "main",
+      "slack:acct-1:channel:C1",
+      "slack:acct-1:channel:c1",
+    ],
+    [
+      "agent:data-expert:dingtalk:cidzg6sF43NZMy52Rnk8EN",
+      "data-expert",
+      "dingtalk:cidzg6sF43NZMy52Rnk8EN",
+      "dingtalk:cidzg6sf43nzmy52rnk8en",
+    ],
+    ["agent:main:telegram:user:12345:extra", "main", "telegram:user:12345:extra"],
+    ["agent:main:subagent:worker", "main", "subagent:worker"],
+    ["agent:main:cron:daily", "main", "cron:daily"],
+    [
+      "agent:ops:catalog:fixture:node%3ADevBox:Thread%3AA",
+      "ops",
+      "catalog:fixture:node%3ADevBox:Thread%3AA",
+      "catalog:fixture:node%3adevbox:thread%3aa",
+    ],
+    [
+      "agent:ops:matrix:channel:!Room:Example.Org:thread:$Event",
+      "ops",
+      "matrix:channel:!Room:Example.Org:thread:$Event",
+      "matrix:channel:!room:example.org:thread:$event",
+    ],
+    [
+      "agent:ops:signal:group:AbC123=:thread:xyz",
+      "ops",
+      "signal:group:AbC123=:thread:xyz",
+      "signal:group:abc123=:thread:xyz",
+    ],
+  ] as const)("retains ownership and tail for %s", (key, agentId, rest, uiRest?: string) => {
+    expect(parseAgentSessionKeyParts(key)).toEqual({ agentId, rest });
+    expect(parseAgentSessionKey(key)).toEqual({ agentId, rest: uiRest ?? rest });
+  });
+
+  it.each(["main", "global", "unknown", "catalog:claude:gateway%3Alocal:thread-1"])(
+    "keeps %s unscoped while retaining the UI owner fallback",
+    (key) => {
+      expect(parseAgentSessionKeyParts(key)).toBeNull();
+      expect(parseAgentSessionKey(key)).toBeNull();
+      expect(resolveAgentIdFromSessionKey(key)).toBe("main");
+    },
+  );
+
+  it.each([
+    ["agent:ops:room::part", { agentId: "ops", rest: "room::part" }, "ops", "room:part"],
+    ["agent:ops:main:", { agentId: "ops", rest: "main:" }, "ops", "main"],
+    ["agent:ops::cron:job", null, "ops", "cron:job"],
+    ["agent::cron:job", null, "cron", "job"],
+    [":agent:ops:main", null, "ops", "main"],
+    ["agent:ops: :", { agentId: "ops", rest: " :" }, "ops", " "],
+  ] as const)("preserves the display adapter's accepted shape %s", (key, raw, agentId, rest) => {
+    expect(parseAgentSessionKeyParts(key)).toEqual(raw);
+    expect(parseAgentSessionKey(key)).toEqual({ agentId, rest });
+    expect(resolveAgentIdFromSessionKey(key)).toBe(agentId);
+  });
+
+  it("retains the UI fallback for a malformed owner", () => {
+    expect(parseAgentSessionKey("agent::secret")).toBeNull();
+    expect(resolveAgentIdFromSessionKey("agent::secret")).toBe("main");
+  });
+});
 
 describe("session archive eligibility", () => {
   it.each([
@@ -74,6 +168,23 @@ describe("parseSessionKeyParts", () => {
 });
 
 describe("UI session identity", () => {
+  it.each([
+    [
+      "Agent:Ops:Catalog:Fixture:Node%3ADevBox:Thread%3AA",
+      "agent:ops:Catalog:Fixture:Node%3ADevBox:Thread%3AA",
+    ],
+    ["agent:ops:other:signal:group:AbC", "agent:ops:other:signal:group:abc"],
+    ["agent:ops:signal:group:AbC:signal:group:DeF", "agent:ops:signal:group:AbC:signal:group:def"],
+    [":Matrix:Channel:!Room:Org", ":matrix:channel:!Room:Org"],
+    ["agent:ops: :Matrix:Channel:!Room:Org", "agent:ops: :matrix:channel:!Room:Org"],
+    [
+      "agent:ops:matrix:channel: !Room:Org :thread:$Event",
+      "agent:ops:matrix:channel: !Room:Org :thread:$Event",
+    ],
+  ])("retains UI comparison normalization for %s", (key, expected) => {
+    expect(normalizeSessionKeyForUiComparison(key)).toBe(expected);
+  });
+
   it.each([
     {
       name: "native catalog source IDs",

--- a/ui/src/lib/sessions/session-key.ts
+++ b/ui/src/lib/sessions/session-key.ts
@@ -5,14 +5,16 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import {
+  buildAgentMainSessionKey,
+  DEFAULT_MAIN_KEY,
+  normalizeMainKey,
+  parseAgentSessionKeyParts,
+  type ParsedAgentSessionKey,
+} from "@openclaw/session-url-contract";
 
-type ParsedAgentSessionKey = {
-  agentId: string;
-  rest: string;
-};
-
+export { buildAgentMainSessionKey, DEFAULT_MAIN_KEY };
 export const DEFAULT_AGENT_ID = "main";
-export const DEFAULT_MAIN_KEY = "main";
 
 export type UiSessionDefaultsHost = {
   assistantAgentId?: string | null;
@@ -32,12 +34,11 @@ export { normalizeAgentId };
 export function parseAgentSessionKey(
   sessionKey: string | undefined | null,
 ): ParsedAgentSessionKey | null {
-  const parts = normalizeLowercaseStringOrEmpty(sessionKey).split(":").filter(Boolean);
-  if (parts.length < 3 || parts[0] !== "agent") {
-    return null;
-  }
-  const agentId = normalizeOptionalString(parts[1]);
-  return agentId ? { agentId, rest: parts.slice(2).join(":") } : null;
+  // Display ownership historically tolerates empty segments and folds the tail.
+  // Store identities and URL literals apply their own stricter policies.
+  return parseAgentSessionKeyParts(
+    normalizeLowercaseStringOrEmpty(sessionKey).split(":").filter(Boolean).join(":"),
+  );
 }
 
 export function parseSessionKeyParts(
@@ -62,10 +63,6 @@ export function isPinnableUiSessionRow(row: {
   spawnedBy?: string | null;
 }): boolean {
   return resolveUiSessionNavigationParentKey(row) == null && !isSubagentSessionKey(row.key);
-}
-
-function normalizeMainKey(value: string | undefined | null): string {
-  return normalizeOptionalLowercaseString(value) ?? DEFAULT_MAIN_KEY;
 }
 
 export function normalizeSessionKeyForUiComparison(sessionKey: string | undefined | null): string {
@@ -320,15 +317,6 @@ export function uiSessionRowMatchesSelectedChat(
     rowKey,
     rowAgentId ?? (isUiGlobalSessionKey(rowKey) ? selected?.agentId : undefined),
   );
-}
-
-export function buildAgentMainSessionKey(params: {
-  agentId: string;
-  mainKey?: string | undefined;
-}): string {
-  const agentId = normalizeAgentId(params.agentId);
-  const mainKey = normalizeMainKey(params.mainKey);
-  return `agent:${agentId}:${mainKey}`;
 }
 
 export function normalizeDefaultMainSessionAliasForUi(


### PR DESCRIPTION
Related: #138329, #124467.

## What Problem This Solves

Session ownership and main-key construction are repeated in Gateway routing, configuration, Dashboard helpers, and session URL construction. This maintainer-requested consolidation removes their shared structural recipe while preserving each caller's accepted identity domain.

## Why This Change Was Made

`packages/session-url-contract/src/session-key.ts` owns the browser-safe ownership split and main-key construction. Backend, Dashboard, and URL adapters retain their existing normalization and admission policies. Existing SDK exports and call signatures remain intact; no compatibility export is removed or renamed. The package's existing entry point exports the leaf helpers so current browser/test aliases continue to resolve them without tooling changes or new dependencies.

The inspected sibling PRs remain independent: #138329 consumes the strict backend parser for HTTP owner selection; #124467 keeps QA provider/thread identity structured. Neither is superseded or modified here.

## User Impact

None. Stored session keys, Dashboard resolution and appearance, catalog identity, URL literals, and owner fallback/error behavior are preserved.

## Known differences kept

Peter Steinberger explicitly approved landing the safe structural/main-key extraction independently. Broader opaque normalization remains a separate maintainer follow-up. The following contractual differences remain explicit and unchanged:

| Input or policy | Backend | Dashboard | URL |
| --- | --- | --- | --- |
| Interior/trailing empty tail (`agent:ops:room::part`, `agent:ops:main:`) | Preserve bytes | Collapse empties for owner parsing | Reject empty path segments |
| Empty owner/body (`agent::cron:job`, `agent:ops::cron:job`) | Reject | Parse after collapsing empty segments | Reject |
| Leading colon (`:agent:ops:main`) | Reject | Owner parser accepts | Unscoped literal only with fallback owner |
| Opaque Matrix/Signal tail | Preserve enrolled provider ID case | Owner parser folds; comparison preserves normal opaque IDs | Preserve raw tail spelling |
| Catalog source (`catalog:fixture:node%3ADevBox:Thread%3AA`) | Fold | Owner parser folds; comparison preserves source bytes | Preserve source bytes |
| Signal marker inside another channel or repeated in a tail | Preserve each matched group segment | Preserve only the first body Signal group | Preserve literal bytes |
| Blank prefix/body before Matrix | Fold if outside backend opaque grammar | Comparison skips blank segments and preserves opaque tail | Keep current literal validation |
| Matrix whitespace before thread marker | Keep existing trimmed-index behavior | Preserve whitespace | Preserve literal bytes |
| Unscoped `cron:job` | Not cron | Cron | Literal route with fallback owner |
| `agent:ops:cron:` | Cron | Not cron after empty collapse | Reject |
| `agent: :cron:job` | Invalid owner | Cron display accepts whitespace owner; owner parser rejects | Reject |
| `:agent:ops:cron:job` | Not cron | Not cron; display retains its leading-agent guard | Existing unscoped rules |
| `agent:ops::acp:w` / `agent:ops::subagent:w` | Not classified | Classified by permissive parser | Reject |
| Missing/malformed owner | Error without suitable configured default; malformed scoped keys always error | Existing implicit `main` fallback | Existing explicit fallback and malformed-head rejection |

Persisted-key/SDK semantics win at the backend boundary, including interior empty segments and opaque provider IDs. Dashboard compatibility is required for this campaign, including catalog comparisons and permissive ownership parsing. Bookmark paths retain stricter empty-segment rejection and exact raw tail case. Unifying the two opaque normalizers would change these domains; neither normalizer is replaced by this extraction.

## Evidence

The original candidate validation is listed below. The approved patch was rebased unchanged onto `0d30dcbbf4d7a15936f3d71a0fda888d77df01ea`; `git range-diff` confirms identical changes, and the affected production paths had no intervening upstream edits.

- `node scripts/run-vitest.mjs src/sessions src/routing/session-key src/config/sessions packages/session-url-contract ui/src/lib/sessions ui/src/lib/session-display`: 2,855 tests in 195 files passed. Final focused UI rerun after the whitespace-owner case: 127 tests / 2 files passed.
- Direct comparison against the original cron classifier: 299,593 generated inputs, zero differences.
- Independent Codex review of the pinned candidate: clean through P2.
- `node scripts/check-changed.mjs`: passed (including production/test/UI types, lint, export scans, and storage/import guards).
- `pnpm build`: passed, including package/SDK declarations, plugin runtime checks, CLI import checks, and Dashboard boot budgets.

Boundary tables cover stored-key differences, URL literal/rejection behavior, current Dashboard fixture families, permissive display ownership, opaque comparison cases, and scoped/unscoped cron classification. Production delta: net -4 lines; tests: +169. No live Gateway or real state was used.

### Refreshed validation

Fresh Codex review is clean through P2. Current changed-file checks passed. Exact-head [CI run 34104336941](https://github.com/openclaw/openclaw/actions/runs/34104336941) passed on `c0af89b77e7f6feb9a4a358d7657561312245ecd`.

The local refresh passed 512 unit/routing/package tests. Its broad runtime-config attempt had 1,658 passes and two failures in unchanged setup/worker code: a SQLite open lock in legacy migration and a pre-action writer-fence timeout in transcript reconciliation. Both complete affected files passed all 36 tests on rerun with unchanged assertions and timeouts; all 724 UI tests also passed. The original competing handle/worker outcome was not established, so the broad attempt is not claimed clean. No semantic connection to the structural extraction was found.
