### PR TITLE
fix(bench): report startup counts without time units

### DIFF
--- a/scripts/bench-gateway-startup.ts
+++ b/scripts/bench-gateway-startup.ts
@@ -569,20 +569,6 @@ function formatRatio(value: number | null): string {
   return value.toFixed(3);
 }
 
-function formatMemoryStats(stats: SummaryStats | null | undefined): string {
-  if (!stats) {
-    return "n/a";
-  }
-  return `p50=${formatMb(stats.p50)} avg=${formatMb(stats.avg)} min=${formatMb(stats.min)} max=${formatMb(stats.max)}`;
-}
-
-function formatRatioStats(stats: SummaryStats | null): string {
-  if (!stats) {
-    return "n/a";
-  }
-  return `p50=${formatRatio(stats.p50)} avg=${formatRatio(stats.avg)} min=${formatRatio(stats.min)} max=${formatRatio(stats.max)}`;
-}
-
 async function waitForStartupTracePhase(params: {
   deadlineAt: number;
   isDone: () => boolean;
@@ -1051,20 +1037,20 @@ function printResult(result: CaseResult): void {
   console.log(`  completion:   ${formatStats(result.summary.completionMs)}`);
   console.log(`  first output: ${formatStats(result.summary.firstOutputMs)}`);
   console.log(`  CPU:          ${formatStats(result.summary.cpuMs)}`);
-  console.log(`  CPU core:     ${formatRatioStats(result.summary.cpuCoreRatio)}`);
+  console.log(`  CPU core:     ${formatStats(result.summary.cpuCoreRatio, formatRatio)}`);
   console.log(`  /healthz:     ${formatStats(result.summary.healthzMs)}`);
   console.log(`  http listen:  ${formatStats(result.summary.httpListenLogMs)}`);
   console.log(`  gateway ready: ${formatStats(result.summary.gatewayReadyLogMs)}`);
   console.log(`  /readyz:      ${formatStats(result.summary.readyzMs)}`);
-  console.log(`  max RSS:      ${formatMemoryStats(result.summary.maxRssMb)}`);
+  console.log(`  max RSS:      ${formatStats(result.summary.maxRssMb, formatMb)}`);
   console.log(
-    `  ready memory: rss=${formatMemoryStats(result.summary.startupTrace["memory.ready.rssMb"])} heap=${formatMemoryStats(result.summary.startupTrace["memory.ready.heapUsedMb"])} external=${formatMemoryStats(result.summary.startupTrace["memory.ready.externalMb"])}`,
+    `  ready memory: rss=${formatStats(result.summary.startupTrace["memory.ready.rssMb"], formatMb)} heap=${formatStats(result.summary.startupTrace["memory.ready.heapUsedMb"], formatMb)} external=${formatStats(result.summary.startupTrace["memory.ready.externalMb"], formatMb)}`,
   );
   console.log(
-    `  post-ready memory: rss=${formatMemoryStats(result.summary.startupTrace["memory.post-ready.rssMb"])} heap=${formatMemoryStats(result.summary.startupTrace["memory.post-ready.heapUsedMb"])} external=${formatMemoryStats(result.summary.startupTrace["memory.post-ready.externalMb"])}`,
+    `  post-ready memory: rss=${formatStats(result.summary.startupTrace["memory.post-ready.rssMb"], formatMb)} heap=${formatStats(result.summary.startupTrace["memory.post-ready.heapUsedMb"], formatMb)} external=${formatStats(result.summary.startupTrace["memory.post-ready.externalMb"], formatMb)}`,
   );
   console.log(
-    `  prepared runtime: agents=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.agentCount"])} workspaces=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.workspaceGroupCount"])} configuredGroups=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.configuredFactsGroupCount"])} configuredModels=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.configuredRuntimeModelCount"])} generatedPlugins=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.generatedCatalogPluginCount"])} generatedReads=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.generatedCatalogReadCount"])} sources=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.catalogSourceCount"])} credentials=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.credentialGroupCount"])} catalogs=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.catalogGroupCount"])} registries=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.runtimeRegistryCount"])} workspaceFacts=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.workspaceFactsMs"])} runtimePlugins=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.runtimePluginMs"])} metadata=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.pluginMetadataMs"])} staticProviders=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.staticProviderCatalogMs"])} ambientAuth=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.ambientCredentialsMs"])} agentFacts=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.agentFactsMs"])} configuredProjection=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.configuredProjectionMs"])} sourceMs=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.catalogSourceMs"])} registryMs=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.registryMs"])} sourceLimit=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.sourceConcurrencyLimitCount"])} fullCatalogLimit=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.fullCatalogConcurrencyLimitCount"])} staticCatalog=${formatStats(result.summary.startupTrace["benchmark.preparedRuntimeStaticCatalogCallCount"])} pluginLoader=${formatStats(result.summary.startupTrace["sidecars.plugin-loader.callsCount"])} eventLoopMax=${formatStats(result.summary.startupTrace["sidecars.model-runtime.eventLoopMax"])}`,
+    `  prepared runtime: agents=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.agentCount"], String)} workspaces=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.workspaceGroupCount"], String)} configuredGroups=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.configuredFactsGroupCount"], String)} configuredModels=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.configuredRuntimeModelCount"], String)} generatedPlugins=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.generatedCatalogPluginCount"], String)} generatedReads=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.generatedCatalogReadCount"], String)} sources=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.catalogSourceCount"], String)} credentials=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.credentialGroupCount"], String)} catalogs=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.catalogGroupCount"], String)} registries=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.runtimeRegistryCount"], String)} workspaceFacts=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.workspaceFactsMs"])} runtimePlugins=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.runtimePluginMs"])} metadata=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.pluginMetadataMs"])} staticProviders=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.staticProviderCatalogMs"])} ambientAuth=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.ambientCredentialsMs"])} agentFacts=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.agentFactsMs"])} configuredProjection=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.configuredProjectionMs"])} sourceMs=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.catalogSourceMs"])} registryMs=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.registryMs"])} sourceLimit=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.sourceConcurrencyLimitCount"], String)} fullCatalogLimit=${formatStats(result.summary.startupTrace["sidecars.model-runtime-build.fullCatalogConcurrencyLimitCount"], String)} staticCatalog=${formatStats(result.summary.startupTrace["benchmark.preparedRuntimeStaticCatalogCallCount"], String)} pluginLoader=${formatStats(result.summary.startupTrace["sidecars.plugin-loader.callsCount"], String)} eventLoopMax=${formatStats(result.summary.startupTrace["sidecars.model-runtime.eventLoopMax"])}`,
   );
   const trace = selectSlowStartupTraceDurations(result.summary.startupTrace, 8);
   if (trace.length > 0) {

--- a/scripts/lib/gateway-bench-runtime.ts
+++ b/scripts/lib/gateway-bench-runtime.ts
@@ -229,11 +229,14 @@ export function formatMb(value: number | null): string {
   return value == null ? "n/a" : `${value.toFixed(1)}MB`;
 }
 
-export function formatStats(stats: SummaryStats | null | undefined): string {
+export function formatStats(
+  stats: SummaryStats | null | undefined,
+  formatValue: (value: number) => string = formatMs,
+): string {
   if (!stats) {
     return "n/a";
   }
-  return `p50=${formatMs(stats.p50)} avg=${formatMs(stats.avg)} min=${formatMs(stats.min)} max=${formatMs(stats.max)}`;
+  return `p50=${formatValue(stats.p50)} avg=${formatValue(stats.avg)} min=${formatValue(stats.min)} max=${formatValue(stats.max)}`;
 }
 
 export function createGatewayBenchEnv(

--- a/test/scripts/bench-gateway-startup.test.ts
+++ b/test/scripts/bench-gateway-startup.test.ts
@@ -11,7 +11,10 @@ import { testing } from "../../scripts/bench-gateway-startup.ts";
 import { isStartupTraceDuration } from "../../scripts/lib/gateway-startup-trace-ranking.js";
 import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
 import { validateConfigObject } from "../../src/config/validation.js";
-import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+import { isPidAlive } from "../../src/shared/pid-alive.js";
+import { waitForPidToExit } from "../../src/test-utils/process-tree.js";
+import { runNodeScript } from "../helpers/run-node-script.js";
+import { createTempDirTracker, useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 import { registerStopChildBehaviorTests } from "./bench-gateway-child-test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -58,6 +61,148 @@ describe("gateway startup benchmark script", () => {
     expect(helpResult.stdout).not.toContain("[gateway-startup-bench]");
     expect(helpResult.stderr).toBe("");
   });
+
+  // Strict managed process-group verification is not supported on Windows.
+  it.skipIf(process.platform === "win32")(
+    "reports fractional counts without time units through the benchmark CLI",
+    async ({ signal }) => {
+      const fixtures = createTempDirTracker();
+      const root = fixtures.make("openclaw-bench-count-report-");
+      const entry = path.join(root, "entry.mjs");
+      const counter = path.join(root, "counter.json");
+      const eventsPath = path.join(root, "events.jsonl");
+      const reportPath = path.join(root, "report.json");
+      type FixtureEvent = {
+        phase: string;
+        pid: number;
+        home?: string;
+        method?: string;
+        status?: number;
+        path?: string;
+      };
+      const readEvents = (): FixtureEvent[] =>
+        fs.existsSync(eventsPath)
+          ? fs
+              .readFileSync(eventsPath, "utf8")
+              .trim()
+              .split("\n")
+              .map((line) => JSON.parse(line))
+          : [];
+      try {
+        fs.writeFileSync(
+          entry,
+          `import { createServer } from "node:http";
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+const counter = ${JSON.stringify(counter)};
+const record = (phase, extra = {}) => appendFileSync(${JSON.stringify(eventsPath)}, JSON.stringify({ phase, pid: process.pid, ...extra }) + "\\n");
+const sample = (existsSync(counter) ? JSON.parse(readFileSync(counter, "utf8")) : 0) + 1;
+writeFileSync(counter, JSON.stringify(sample));
+record("started", { home: process.env.OPENCLAW_HOME });
+const port = Number(process.argv[process.argv.indexOf("--port") + 1]);
+const server = createServer((req, res) => {
+  const status = req.method === "HEAD" && ["/healthz", "/readyz"].includes(req.url) ? 200 : 404;
+  record("probe", { method: req.method, status, path: req.url });
+  res.writeHead(status, { connection: "close" });
+  res.end();
+});
+let stopping = false;
+const stop = (reason) => {
+  if (stopping) return;
+  stopping = true;
+  server.close(() => { record("closed", { reason }); process.exit(0); });
+};
+process.on("SIGTERM", () => stop("signal"));
+// The CLI owns stdin; EOF retires this detached fixture when the CLI is cancelled.
+process.stdin.on("end", () => stop("stdin-eof"));
+process.stdin.resume();
+server.listen(port, "127.0.0.1", () => {
+  console.log("[gateway] http server listening (0 plugins, 0.0s)");
+  console.log("[gateway] ready (0 plugins, 0.0s)");
+  console.log("startup trace: sidecars.model-runtime-build agentCount=" + (10 + sample) + " workspaceGroupCount=" + sample + " workspaceFactsMs=2.5");
+  console.log("startup trace: memory.ready rssMb=32.5 heapUsedMb=16.25 externalMb=2");
+});
+`,
+        );
+        const result = await runNodeScript(
+          [
+            "--import",
+            "tsx",
+            "scripts/bench-gateway-startup.ts",
+            "--entry",
+            entry,
+            "--case",
+            "default",
+            "--runs",
+            "2",
+            "--warmup",
+            "0",
+            "--output",
+            reportPath,
+          ],
+          { ...process.env, TMPDIR: root },
+          undefined,
+          { cwd: process.cwd(), signal, maxBuffer: 1024 * 1024, requireProcessTreeExit: true },
+        );
+        expect(result.error).toBeUndefined();
+        expect(result.status, result.stderr).toBe(0);
+        const events = readEvents();
+        const started = events.filter((event) => event.phase === "started");
+        expect(started).toHaveLength(2);
+        expect(events.filter((event) => event.phase === "closed")).toHaveLength(2);
+        const probes = events.filter((event) => event.phase === "probe");
+        for (const probe of probes) {
+          expect(probe).toMatchObject({ method: "HEAD", status: 200 });
+        }
+        for (const event of started) {
+          expect(
+            probes.filter((probe) => probe.pid === event.pid).map((probe) => probe.path),
+          ).toEqual(expect.arrayContaining(["/healthz", "/readyz"]));
+          expect(isPidAlive(event.pid)).toBe(false);
+          expect(event.home).toBeDefined();
+          expect(fs.existsSync(event.home!)).toBe(false);
+        }
+        const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+        expect(report.results).toHaveLength(1);
+        expect(report.results[0].samples).toHaveLength(2);
+        expect(report.results[0].summary.startupTrace).toMatchObject({
+          "sidecars.model-runtime-build.agentCount": { p50: 11.5, avg: 11.5, min: 11, max: 12 },
+          "sidecars.model-runtime-build.workspaceGroupCount": {
+            p50: 1.5,
+            avg: 1.5,
+            min: 1,
+            max: 2,
+          },
+          "sidecars.model-runtime-build.workspaceFactsMs": { p50: 2.5, avg: 2.5 },
+        });
+        expect(result.stdout).toContain("workspaceFacts=p50=2.5ms");
+        expect(result.stdout).toContain("ready memory: rss=p50=32.5MB");
+        expect(result.stdout).toContain("runtimePlugins=n/a");
+        expect(result.stdout).toMatch(
+          / {2}CPU core:\s+p50=\d+\.\d{3} avg=\d+\.\d{3} min=\d+\.\d{3} max=\d+\.\d{3}/u,
+        );
+        const counts = result.stdout
+          .split("\n")
+          .find((line) => line.startsWith("  prepared runtime:"));
+        expect(counts).toContain("agents=p50=11.5 avg=11.5 min=11 max=12");
+        expect(counts).toContain("workspaces=p50=1.5 avg=1.5 min=1 max=2");
+      } finally {
+        // Never signal retired PIDs; retain fixture evidence if an unclosed child remains alive.
+        const events = readEvents();
+        const closed = new Set(
+          events.filter((event) => event.phase === "closed").map((event) => event.pid),
+        );
+        for (const startedEvent of events.filter((event) => event.phase === "started")) {
+          if (!closed.has(startedEvent.pid)) {
+            expect(
+              await waitForPidToExit(startedEvent.pid),
+              `Unclosed fixture retained at ${root}`,
+            ).toBe(true);
+          }
+        }
+        fixtures.cleanup();
+      }
+    },
+  );
 
   it("rejects ambiguous benchmark CLI values before spawning Node", () => {
     expect(() => testing.parseOptions(["--wat"])).toThrow("Unknown argument: --wat");

--- a/test/scripts/gateway-bench-runtime.test.ts
+++ b/test/scripts/gateway-bench-runtime.test.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   BASE_GATEWAY_BENCH_CONFIG,
   createGatewayBenchEnv,
+  formatMb,
+  formatStats,
   writeGatewayBenchConfig,
 } from "../../scripts/lib/gateway-bench-runtime.js";
 import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
@@ -25,6 +27,32 @@ vi.mock("../../src/infra/widearea-dns.js", async (importOriginal) => {
 });
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("benchmark statistic units", () => {
+  const stats = { p50: 1.5, avg: 1.5, min: 1, max: 2, p95: 2 };
+  it.each([
+    {
+      name: "default duration",
+      format: undefined,
+      expected: "p50=1.5ms avg=1.5ms min=1.0ms max=2.0ms",
+    },
+    { name: "fractional counts", format: String, expected: "p50=1.5 avg=1.5 min=1 max=2" },
+    { name: "memory", format: formatMb, expected: "p50=1.5MB avg=1.5MB min=1.0MB max=2.0MB" },
+    {
+      name: "ratios",
+      format: (value: number) => value.toFixed(3),
+      expected: "p50=1.500 avg=1.500 min=1.000 max=2.000",
+    },
+  ])("formats $name", ({ format, expected }) => {
+    expect(format === undefined ? formatStats(stats) : formatStats(stats, format)).toBe(expected);
+  });
+
+  it.each([null, undefined])("keeps missing statistics %s unavailable", (missingStats) => {
+    const format = vi.fn(() => "unexpected");
+    expect(formatStats(missingStats, format)).toBe("n/a");
+    expect(format).not.toHaveBeenCalled();
+  });
+});
 
 afterEach(() => {
   vi.unstubAllEnvs();


### PR DESCRIPTION
Related: #140870

## What Problem This Solves

Gateway startup benchmark reports label agent, workspace, and catalog counts as milliseconds. For example, a median of 11.5 agents appears as `11.5ms`, even though the numeric JSON is correct.

## Why This Change Was Made

Let the existing statistics formatter accept a value formatter while keeping milliseconds as its default. Count fields use unitless numbers, preserving fractional medians and averages. Memory and ratio summaries reuse that same owner, removing two duplicated formatting wrappers (net 11 fewer tooling lines).

## User Impact

All fourteen count fields display unitless values. Duration, memory, ratio, unavailable-value formatting, and numeric JSON retain their existing meaning.

## Evidence

- Four new regression cases fail on the original formatters; the repaired candidate passes 74 startup, restart, and shared-runtime cases.
- Actual CLI runs with synthetic HEAD-probe children verify all fourteen count fields and the same numeric trace summaries. Noncount fields in the prepared-runtime row and fixed memory rows match the baseline.
- Cancelling the test-owned CLI proves its detached fixture closes on stdin EOF without signalling retired PIDs; normal and cancellation paths release owned processes, ports, and temporary roots.
- Independent Codex review is clean through P2. The CLI fixture is POSIX-only because the managed helper does not support strict process-tree verification on Windows; no Windows execution or performance result is claimed.

All 19 normal changed-file checks passed on the final source. The first run stopped on three mechanical test-lint findings after 18 passing checks; those were corrected, checked locally, and the full gate rerun passed. Both one-shot Testboxes and source capsules are closed.
