### PR TITLE
refactor(gateway): inline the usage status loader

### DIFF
--- a/src/gateway/server-methods/models-auth-status-usage-cache.ts
+++ b/src/gateway/server-methods/models-auth-status-usage-cache.ts
@@ -243,10 +243,23 @@ export function readProviderUsageStaleWhileRevalidate(
   return matching?.usageByProvider ?? new Map();
 }
 
-/** Returns cached provider usage while network refreshes run in the background for capable clients. */
-async function loadProviderUsageSummaryStaleWhileRevalidate(
-  params: ProviderUsageCacheParams,
-): Promise<UsageSummary> {
+/** Shares the models.authStatus cache contract with the unscoped usage.status RPC. */
+export async function loadUsageStatusStaleWhileRevalidate(options: {
+  config: OpenClawConfig;
+  coldRead?: "refresh-marker";
+  now?: number;
+}): Promise<UsageSummary> {
+  const snapshot = getProviderUsageRuntimeSnapshot({ config: options.config });
+  const params: ProviderUsageCacheParams = {
+    agentId: snapshot.agentId,
+    agentDir: snapshot.agentDir,
+    authStore: snapshot.store,
+    configRef: snapshot.configRef,
+    credentialKey: snapshot.credentialKey,
+    providerIds: snapshot.providerIds,
+    coldRead: options.coldRead,
+    now: options.now ?? Date.now(),
+  };
   if (params.providerIds.length === 0) {
     usageCacheByAgentId.delete(params.agentId);
     return { updatedAt: params.now, providers: [] };
@@ -275,23 +288,4 @@ async function loadProviderUsageSummaryStaleWhileRevalidate(
   }
   void refresh.catch(() => {});
   return { updatedAt: params.now, providers: [], refreshing: true };
-}
-
-/** Shares the models.authStatus cache contract with the unscoped usage.status RPC. */
-export async function loadUsageStatusStaleWhileRevalidate(params: {
-  config: OpenClawConfig;
-  coldRead?: "refresh-marker";
-  now?: number;
-}): Promise<UsageSummary> {
-  const snapshot = getProviderUsageRuntimeSnapshot({ config: params.config });
-  return await loadProviderUsageSummaryStaleWhileRevalidate({
-    agentId: snapshot.agentId,
-    agentDir: snapshot.agentDir,
-    authStore: snapshot.store,
-    configRef: snapshot.configRef,
-    credentialKey: snapshot.credentialKey,
-    providerIds: snapshot.providerIds,
-    coldRead: params.coldRead,
-    now: params.now ?? Date.now(),
-  });
 }


### PR DESCRIPTION
## What Problem This Solves

The public usage-status loader only prepares a snapshot and forwards it to a private async helper with one caller. This follow-up to #140910 removes that extra layer from the #135868 production-deletion campaign.

## Why This Change Was Made

Inline the helper body into its public entrypoint. The same snapshot values and options are captured into a typed local object before the unchanged cache-read and refresh branches. The separate synchronous auth-status reader retains its existing policy.

Deletion evidence: `loadProviderUsageSummaryStaleWhileRevalidate` had exactly one caller and no public export. Its argument object is now a local object with the same property values, evaluation order, and defaults. Refresh registration still precedes cached/marker responses, and ordinary cold reads still await the same tracked refresh.

## User Impact

No supported behavior changes. Public options, results, errors, cache sharing, and refresh ownership remain unchanged.

## Evidence

The complete `models-auth-status.test.ts` and `usage.status-cache.test.ts` suites passed before and after: 2 files, 117 cases each, 51.64s → 37.43s. The baseline ran on refreshed main with its updated frozen lockfile installed. No tests or assertions changed.

| Judged class | Added | Deleted | Net |
| --- | ---: | ---: | ---: |
| Production | 17 | 23 | −6 |
| Tests | 0 | 0 | 0 |
| Tooling | 0 | 0 | 0 |
| Docs | 0 | 0 | 0 |

Independent local and final branch autoreviews: scoped-clean, no actionable findings. The full `node scripts/check-changed.mjs` plan passed with exit 0, including core/test types, lint, dead exports, and every selected guard. The final rebase preserved the cache module, producer/callers, and lockfile. No build boundary changed.
