### PR TITLE
refactor(clawhub): reuse plugin compatibility contract

### DIFF
--- a/src/infra/clawhub-packages.ts
+++ b/src/infra/clawhub-packages.ts
@@ -1,6 +1,7 @@
 // ClawHub package metadata, security, search, and telemetry operations.
 import { isRecord as isJsonObject } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { ExternalPluginCompatibility } from "../../packages/plugin-package-contract/src/index.js";
 import {
   createClawHubError,
   fetchClawHubJson,
@@ -16,13 +17,7 @@ import {
 
 export type ClawHubPackageFamily = "skill" | "code-plugin" | "bundle-plugin";
 export type ClawHubPackageChannel = "official" | "community" | "private";
-// Keep aligned with @openclaw/plugin-package-contract ExternalPluginCompatibility.
-export type ClawHubPackageCompatibility = {
-  pluginApiRange?: string;
-  builtWithOpenClawVersion?: string;
-  pluginSdkVersion?: string;
-  minGatewayVersion?: string;
-};
+export type ClawHubPackageCompatibility = ExternalPluginCompatibility;
 type ClawHubPackageHostTarget = {
   os?: string | null;
   arch?: string | null;


### PR DESCRIPTION
## What Problem This Solves

ClawHub package metadata repeats the plugin package contract's compatibility shape and relies on a comment to keep the two definitions aligned.

## Why This Change Was Made

The exported `ClawHubPackageCompatibility` name remains as a type alias to `ExternalPluginCompatibility`, owned by `packages/plugin-package-contract`. The import is type-only; the four optional string fields and all runtime logic remain unchanged.

## User Impact

None. Existing type names, metadata payloads, fetch behavior, and compatibility fields remain unchanged. No public export removal, new dependency, configuration, schema, or protocol change.

## Evidence

- `node scripts/run-vitest.mjs src/infra/clawhub-packages.test.ts packages/plugin-package-contract/src/index.test.ts`: nine tests passed across two files.
- Source comparison confirms all four optional string properties are identical. TypeScript emits byte-identical JavaScript with comments removed.
- Production +2/-7, net -5 lines; tests unchanged.
- Independent review with the full contract owner supplied: P0–P2 scoped-clean, zero findings.
- `node scripts/check-changed.mjs --base 18e99a15f8b022614abb0d4ed5135a9c3607f011`: passed.
- Clean Linux `pnpm build` passed in 3m 34.2s, including package and SDK declarations. `pnpm ui:check-performance` passed: startup JS 348,060 / 350,953 B gzip, 8 / 18 requests; CSS 43,989 / 51,200 B. Provider `blacksmith-testbox`, lease `tbx_01m1xa6n38c2g6abpw4fbxncdk`, [run 34092730510](https://github.com/openclaw/openclaw/actions/runs/34092730510). Command: `node scripts/crabbox-wrapper.mjs run --timing-json --shell -- 'pnpm build && pnpm ui:check-performance'`. Wrapper exit 0 and lease completion/stoppage verified. Build source is original commit `af9d2bd65724c5d3ca8e38b4d1d0042cb1806246`.
- Required fresh-main rebase onto `149e97d4dbcadfaf2eda0c463aa7c7815da393d3` is patch-identical; touched type owners have no diff. Current head `cc97e34f47b4feea5c9fb3815aff437f1724b95e` passed [CI 34093051662](https://github.com/openclaw/openclaw/actions/runs/34093051662).
