### PR TITLE
refactor(memory): consolidate recall prompt guidance

### DIFF
--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -53,12 +53,6 @@ function hostRuntimeWithConfig(current: () => OpenClawConfig) {
   });
 }
 
-const promptSources = {
-  files: "MEMORY.md, USER.md, Markdown files recursively under memory/",
-  search:
-    "MEMORY.md, USER.md, Markdown files recursively under memory/, indexed session transcripts",
-};
-
 function registerMemoryCoreRuntime(): MemoryPluginRuntime {
   let runtime: MemoryPluginRuntime | undefined;
   plugin.register(
@@ -115,20 +109,16 @@ function captureMemoryModelContract(initialConfig: OpenClawConfig) {
 
 describe("buildPromptSection", () => {
   it("returns empty when no memory tools are available", () => {
-    expect(
-      buildMemoryPromptSection({ availableTools: new Set(), sources: promptSources }),
-    ).toStrictEqual([]);
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toStrictEqual([]);
   });
 
   it("describes the two-step flow when both memory tools are available", () => {
     const result = buildMemoryPromptSection({
       availableTools: new Set(["memory_search", "memory_get"]),
-      sources: promptSources,
     });
     expect(result[0]).toBe("## Memory Recall");
     expect(result[1]).toContain("run memory_search");
     expect(result[1]).toContain("then use memory_get");
-    expect(result[1]).toContain("indexed session transcripts");
     expect(result).toContain(
       "Citations: include Source: <path#line> when it helps the user verify memory snippets.",
     );
@@ -138,18 +128,15 @@ describe("buildPromptSection", () => {
   it("limits the guidance to memory_search when only search is available", () => {
     const result = buildMemoryPromptSection({
       availableTools: new Set(["memory_search"]),
-      sources: promptSources,
     });
     expect(result[0]).toBe("## Memory Recall");
     expect(result[1]).toContain("run memory_search");
-    expect(result[1]).toContain("indexed session transcripts");
     expect(result[1]).not.toContain("then use memory_get");
   });
 
   it("limits the guidance to memory_get when only get is available", () => {
     const result = buildMemoryPromptSection({
       availableTools: new Set(["memory_get"]),
-      sources: promptSources,
     });
     expect(result[0]).toBe("## Memory Recall");
     expect(result[1]).toContain("run memory_get");
@@ -160,7 +147,6 @@ describe("buildPromptSection", () => {
     const result = buildMemoryPromptSection({
       availableTools: new Set(["memory_search"]),
       citationsMode: "off",
-      sources: promptSources,
     });
     expect(result).toContain(
       "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks.",
@@ -208,7 +194,7 @@ describe("buildPromptSection", () => {
     expect(lazy.get.parameters).toStrictEqual(eagerGet.parameters);
     expect(lazy.search.description).toBe(eagerSearch.description);
     expect(lazy.get.description).toBe(eagerGet.description);
-    for (const text of [lazy.search.description, lazy.get.description, prompt]) {
+    for (const text of [lazy.search.description, lazy.get.description]) {
       expect(text).toContain("MEMORY.md, USER.md");
       expect(text).toContain("recursively under memory/");
       expect(text.includes("configured extra paths")).toBe(sourceCase.extraPaths.length > 0);
@@ -217,16 +203,14 @@ describe("buildPromptSection", () => {
     expect(lazy.search.description.includes("indexed session transcripts")).toBe(
       sourceCase.sessions,
     );
-    expect(prompt.includes("indexed session transcripts")).toBe(sourceCase.sessions);
     expect(lazy.get.description).not.toContain("indexed session transcripts");
     expect(lazy.search.description).toContain("Corpus outcomes cover each requested corpus");
     expect(lazy.search.description).toContain("results are partial");
     expect(lazy.get.description).toContain("status=ok");
     expect(lazy.get.description).toContain("status=not_found");
     expect(lazy.get.description).toContain("results are partial");
-    expect(prompt).toContain("status=ok");
-    expect(prompt).toContain("status=not_found");
-    expect(prompt).toContain("results are partial");
+    expect(prompt).toContain("Report partial, unavailable, or stale recall");
+    expect(prompt).toContain("warning and action guidance");
   });
 });
 

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -258,7 +258,7 @@ export default definePluginEntry({
           agentId: params.agentId,
           agentSessionKey: params.agentSessionKey,
         });
-        return context ? buildMemoryPromptSection({ ...params, sources: context.sources }) : [];
+        return context ? buildMemoryPromptSection(params) : [];
       },
       flushPlanResolver: buildMemoryFlushPlan,
       runtime: memoryRuntime,

--- a/extensions/memory-core/src/memory-tool-contract.ts
+++ b/extensions/memory-core/src/memory-tool-contract.ts
@@ -108,24 +108,24 @@ export type MemoryToolContract =
 export function buildMemoryPromptSection({
   availableTools,
   citationsMode,
-  sources,
-}: Parameters<MemoryPromptSectionBuilder>[0] & { sources: MemorySourceContract }): string[] {
+}: Parameters<MemoryPromptSectionBuilder>[0]): string[] {
   const hasMemorySearch = availableTools.has("memory_search");
   const hasMemoryGet = availableTools.has("memory_get");
   if (!hasMemorySearch && !hasMemoryGet) {
     return [];
   }
 
+  // Code mode may defer tool descriptions; recall and disclosure policy must stay here.
   const guidance = hasMemorySearch
-    ? `Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on ${sources.search}${
+    ? `Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search${
         hasMemoryGet ? "; then use memory_get to pull only the needed lines" : ""
-      }. ${SEARCH_CORPUS_OUTCOME_GUIDANCE}${
-        hasMemoryGet ? ` For memory_get, ${GET_READ_OUTCOME_GUIDANCE}` : ""
-      } If low confidence after search, say you checked.`
-    : `Before answering anything about prior work, decisions, dates, people, preferences, or todos that point to a specific source in ${sources.files}: run memory_get to pull only the needed lines. ${GET_READ_OUTCOME_GUIDANCE} ${SEARCH_CORPUS_OUTCOME_GUIDANCE} If low confidence after reading, say you checked.`;
+      }. If low confidence after search, say you checked.`
+    : "Before answering anything about prior work, decisions, dates, people, preferences, or todos that point to a specific memory file: run memory_get to pull only the needed lines. If low confidence after reading, say you checked.";
+  const outcomeGuidance =
+    "Report partial, unavailable, or stale recall to the user, including returned warning and action guidance.";
   const citationGuidance =
     citationsMode === "off"
       ? "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks."
       : "Citations: include Source: <path#line> when it helps the user verify memory snippets.";
-  return ["## Memory Recall", guidance, citationGuidance, ""];
+  return ["## Memory Recall", guidance, outcomeGuidance, citationGuidance, ""];
 }


### PR DESCRIPTION
## What Problem This Solves

Memory Recall repeated source inventories and result definitions already provided by memory tool descriptions, adding context and duplicate policy to maintain.

## Why This Change Was Made

The runtime section keeps recall triggers, tool choice, search-then-read order, confidence disclosure, citations, and concise warning/recovery rules. Existing tool contracts retain source selection and result definitions. Mandatory search guidance remains in the tool description for minimal prompts, and code mode retains warnings before full descriptions are loaded.

## User Impact

Active recall prompts are 80–261 characters shorter. Tool descriptions, schemas, enablement, memory storage, and execution remain unchanged. This consolidates instructions without claiming measured behavior improvement.

## Evidence

All 128 complete prompt/descriptor combinations were compared across tool, source, prompt, and citation settings. The 48 changed prompts differed only within Memory Recall; tool descriptions and omitted sections were identical. Semantic review found no lost instruction. All 222 registration, memory-tool, prompt, and Doctor-contract tests passed, along with formatting and structural checks. No live model test was run.
