### PR TITLE
refactor: share Git acquisition for plugin and skill installs

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3377,7 +3377,7 @@ src/plugins/manifest-install-owner.ts	1
 src/plugins/manifest-registry.ts	2
 src/plugins/manifest-setup-normalizers.ts	5
 src/plugins/manifest.ts	2
-src/plugins/marketplace.ts	7
+src/plugins/marketplace.ts	6
 src/plugins/memory-runtime.ts	1
 src/plugins/module-export.ts	2
 src/plugins/native-module-require.ts	3

--- a/src/infra/git-source.test.ts
+++ b/src/infra/git-source.test.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+import { runCommandWithTimeout } from "../process/exec.js";
+import { withTestDir } from "../test-helpers/temp-dir.js";
+import { acquireGitSource } from "./git-source.js";
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const result = await runCommandWithTimeout(["git", ...args], { cwd, timeoutMs: 30_000 });
+  if (result.code !== 0) {
+    throw new Error(result.stderr || result.stdout);
+  }
+  return result.stdout.trim();
+}
+
+describe("Git source acquisition", () => {
+  it("preserves each caller's ref selection against a local repository", async () => {
+    await withTestDir({ prefix: "openclaw-git-source-" }, async (root) => {
+      const sourceDir = path.join(root, "source");
+      await fs.mkdir(sourceDir);
+      await git(sourceDir, "init", "--initial-branch=main");
+      const commit = async (contents: string) => {
+        await fs.writeFile(path.join(sourceDir, "payload.txt"), contents);
+        await git(sourceDir, "add", "payload.txt");
+        await git(
+          sourceDir,
+          "-c",
+          "user.name=OpenClaw Test",
+          "-c",
+          "user.email=test@openclaw.invalid",
+          "-c",
+          "commit.gpgsign=false",
+          "commit",
+          "-m",
+          contents,
+        );
+        return await git(sourceDir, "rev-parse", "HEAD");
+      };
+      const mainCommit = await commit("main");
+      await git(sourceDir, "switch", "-c", "feature/skill");
+      const featureCommit = await commit("feature");
+      await git(sourceDir, "tag", "v1");
+      await git(sourceDir, "switch", "main");
+
+      const cases = [
+        { ref: undefined, refMode: "detached", expected: mainCommit, payload: "main" },
+        {
+          ref: "feature/skill",
+          refMode: "resolve-remote",
+          expected: featureCommit,
+          payload: "feature",
+        },
+        {
+          ref: "origin/feature/skill",
+          refMode: "resolve-remote",
+          expected: featureCommit,
+          payload: "feature",
+        },
+        {
+          ref: "feature/skill",
+          refMode: "shallow-branch",
+          expected: featureCommit,
+          payload: "feature",
+        },
+        { ref: "v1", refMode: "shallow-branch", expected: featureCommit, payload: "feature" },
+        { ref: featureCommit, refMode: "detached", expected: featureCommit, payload: "feature" },
+      ] as const;
+      for (const [index, entry] of cases.entries()) {
+        const repoDir = path.join(root, `checkout-${index}`);
+        const result = await acquireGitSource({
+          url: pathToFileURL(sourceDir).href,
+          label: "fixture",
+          repoDir,
+          ref: entry.ref,
+          refMode: entry.refMode,
+        });
+        expect(result).toEqual({ ok: true, commit: entry.expected });
+        expect(await fs.readFile(path.join(repoDir, "payload.txt"), "utf8")).toBe(entry.payload);
+      }
+
+      const repoDir = path.join(root, "missing-ref");
+      const failed = await acquireGitSource({
+        url: pathToFileURL(sourceDir).href,
+        label: "fixture",
+        repoDir,
+        ref: "missing",
+        refMode: "resolve-remote",
+        cleanupOnFailure: () => fs.rm(repoDir, { recursive: true, force: true }),
+      });
+      expect(failed).toEqual({ ok: false, error: "failed to resolve ref missing in fixture" });
+      await expect(fs.access(repoDir)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(await fs.readFile(path.join(sourceDir, "payload.txt"), "utf8")).toBe("main");
+    });
+  });
+});

--- a/src/infra/git-source.ts
+++ b/src/infra/git-source.ts
@@ -1,0 +1,103 @@
+import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
+import { runCommandWithTimeout } from "../process/exec.js";
+
+type GitSourceFailure = {
+  action: "clone" | "checkout" | "resolve ref" | "resolve commit for";
+  stdout: string;
+  stderr: string;
+};
+
+/** Acquires a tree; callers retain source policy and ownership of its staging directory. */
+export async function acquireGitSource(params: {
+  url: string;
+  label: string;
+  repoDir: string;
+  ref?: string;
+  refMode: "detached" | "resolve-remote" | "shallow-branch";
+  timeoutMs?: number;
+  commandEnv?: () => { baseEnv?: NodeJS.ProcessEnv; env?: NodeJS.ProcessEnv };
+  cloneSeparator?: boolean;
+  recordCommit?: boolean;
+  formatFailure?: (failure: GitSourceFailure) => string;
+  cleanupOnFailure?: () => Promise<void>;
+}): Promise<{ ok: true; commit?: string } | { ok: false; error: string }> {
+  const run = (argv: string[], cwd?: string) =>
+    runCommandWithTimeout(argv, {
+      ...params.commandEnv?.(),
+      ...(cwd ? { cwd } : {}),
+      timeoutMs: params.timeoutMs ?? 120_000,
+    });
+  const failure = async (details: GitSourceFailure) => {
+    await params.cleanupOnFailure?.();
+    if (params.formatFailure) {
+      return { ok: false as const, error: params.formatFailure(details) };
+    }
+    const safe = (value: string) => sanitizeForLog(redactSensitiveUrlLikeString(value));
+    const label = safe(params.label);
+    const ref = safe(params.ref ?? "");
+    const detail = safe(details.stderr.trim() || details.stdout.trim() || "git failed");
+    return {
+      ok: false as const,
+      error:
+        details.action === "resolve ref"
+          ? `failed to resolve ref ${ref} in ${label}`
+          : `failed to ${details.action}${details.action === "checkout" ? ` ${params.ref}` : ""} ${label}: ${detail}`,
+    };
+  };
+
+  const argv = ["git", "clone"];
+  if (!params.ref || params.refMode === "shallow-branch") {
+    argv.push("--depth", "1");
+  }
+  if (params.ref && params.refMode === "shallow-branch") {
+    argv.push("--branch", params.ref);
+  }
+  if (params.cloneSeparator !== false) {
+    argv.push("--");
+  }
+  argv.push(params.url, params.repoDir);
+  const clone = await run(argv);
+  if (clone.code !== 0) {
+    return await failure({ action: "clone", ...clone });
+  }
+
+  if (params.ref && params.refMode !== "shallow-branch") {
+    let checkoutRef = params.ref;
+    if (params.refMode === "resolve-remote") {
+      const candidates = params.ref.startsWith("origin/")
+        ? [params.ref]
+        : [params.ref, `origin/${params.ref}`];
+      let commitish: string | undefined;
+      for (const candidate of candidates) {
+        const resolved = await run(
+          ["git", "rev-parse", "--verify", "--quiet", `${candidate}^{commit}`],
+          params.repoDir,
+        );
+        const commit = normalizeOptionalString(resolved.stdout);
+        if (resolved.code === 0 && commit) {
+          commitish = commit;
+          break;
+        }
+      }
+      if (!commitish) {
+        return await failure({ action: "resolve ref", stdout: "", stderr: "" });
+      }
+      checkoutRef = commitish;
+    }
+    const checkout = await run(["git", "switch", "--detach", "--", checkoutRef], params.repoDir);
+    if (checkout.code !== 0) {
+      return await failure({ action: "checkout", ...checkout });
+    }
+  }
+
+  if (params.recordCommit === false) {
+    return { ok: true };
+  }
+  const rev = await run(["git", "rev-parse", "HEAD"], params.repoDir);
+  if (rev.code !== 0) {
+    return await failure({ action: "resolve commit for", ...rev });
+  }
+  return { ok: true, commit: normalizeOptionalString(rev.stdout) };
+}

--- a/src/plugins/git-install.ts
+++ b/src/plugins/git-install.ts
@@ -8,6 +8,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { sha256HexPrefixCore } from "../infra/crypto-digest.js";
 import { pathExists } from "../infra/fs-safe.js";
+import { acquireGitSource } from "../infra/git-source.js";
 import {
   installPackageDir,
   requestDeferredPackageDirInstall,
@@ -344,18 +345,6 @@ async function replaceManagedGitRepo(params: {
   }
 }
 
-function formatGitCommandFailure(params: {
-  action: string;
-  source: ParsedGitPluginSpec;
-  stdout: string;
-  stderr: string;
-}): string {
-  const detail = sanitizeForLog(
-    redactSensitiveUrlLikeString(params.stderr.trim() || params.stdout.trim() || "git failed"),
-  );
-  return `failed to ${params.action} ${sanitizeForLog(redactSensitiveUrlLikeString(params.source.label))}: ${detail}`;
-}
-
 function buildBlockedGitInstallResult(params: {
   blocked: NonNullable<NonNullable<InstallSecurityScanResult>["blocked"]>;
 }): Extract<InstallPluginResult, { ok: false }> {
@@ -368,32 +357,6 @@ function buildBlockedGitInstallResult(params: {
         ? { code: PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED }
         : {}),
   };
-}
-
-async function runGitCommand(params: {
-  argv: string[];
-  action: string;
-  source: ParsedGitPluginSpec;
-  cwd?: string;
-  timeoutMs?: number;
-}): Promise<{ ok: true; stdout: string } | { ok: false; error: string }> {
-  const result = await runCommandWithTimeout(params.argv, {
-    cwd: params.cwd,
-    timeoutMs: params.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS,
-    env: createGitCommandEnv(),
-  });
-  if (result.code !== 0) {
-    return {
-      ok: false,
-      error: formatGitCommandFailure({
-        action: params.action,
-        source: params.source,
-        stdout: result.stdout,
-        stderr: result.stderr,
-      }),
-    };
-  }
-  return { ok: true, stdout: result.stdout };
 }
 
 export async function installPluginFromGitSpec(
@@ -435,41 +398,15 @@ export async function installPluginFromGitSpec(
     params.logger?.info?.(
       `Cloning ${sanitizeForLog(redactSensitiveUrlLikeString(parsed.label))}...`,
     );
-    const cloneArgs = parsed.ref
-      ? ["git", "clone", "--", parsed.url, repoDir]
-      : ["git", "clone", "--depth", "1", "--", parsed.url, repoDir];
-    const clone = await runGitCommand({
-      argv: cloneArgs,
-      action: "clone",
-      source: parsed,
+    const acquired = await acquireGitSource({
+      ...parsed,
+      repoDir,
+      refMode: "detached",
       timeoutMs: params.timeoutMs,
+      commandEnv: () => ({ env: createGitCommandEnv() }),
     });
-    if (!clone.ok) {
-      return clone;
-    }
-
-    if (parsed.ref) {
-      const checkout = await runGitCommand({
-        argv: ["git", "switch", "--detach", "--", parsed.ref],
-        action: `checkout ${parsed.ref}`,
-        source: parsed,
-        cwd: repoDir,
-        timeoutMs: params.timeoutMs,
-      });
-      if (!checkout.ok) {
-        return checkout;
-      }
-    }
-
-    const rev = await runGitCommand({
-      argv: ["git", "rev-parse", "HEAD"],
-      action: "resolve commit for",
-      source: parsed,
-      cwd: repoDir,
-      timeoutMs: params.timeoutMs,
-    });
-    if (!rev.ok) {
-      return rev;
+    if (!acquired.ok) {
+      return acquired;
     }
 
     const installPolicyRequest = {
@@ -591,7 +528,7 @@ export async function installPluginFromGitSpec(
       git: {
         url: parsed.url,
         ref: parsed.ref,
-        commit: normalizeOptionalString(rev.stdout),
+        commit: acquired.commit,
         resolvedAt: new Date().toISOString(),
       },
     };

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -7,14 +7,15 @@ import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { resolveArchiveKind } from "../infra/archive.js";
-import { formatErrorMessage, toErrorObject } from "../infra/errors.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { pathExists } from "../infra/fs-safe.js";
+import { acquireGitSource } from "../infra/git-source.js";
 import { resolveOsHomeRelativePath } from "../infra/home-dir.js";
+import { readChunkWithIdleTimeout } from "../infra/http-response-body-timeout.js";
 import { tryReadJson } from "../infra/json-files.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { readRegularFile } from "../infra/regular-file.js";
-import { runCommandWithTimeout } from "../process/exec.js";
 import type { InstallPolicySource } from "../security/install-policy.js";
 import { resolveUserPath } from "../utils.js";
 import { isImmutableGitCommitRef } from "./git-install.js";
@@ -23,7 +24,6 @@ import { copyPluginInstallTransactionRequest } from "./install-transaction.js";
 import type { PluginInstallArtifactConsentHandler } from "./install-types.js";
 import { installPluginFromPath, type InstallPluginResult } from "./install.js";
 
-const DEFAULT_GIT_TIMEOUT_MS = 120_000;
 const DEFAULT_MARKETPLACE_DOWNLOAD_TIMEOUT_MS = 120_000;
 const MAX_MARKETPLACE_ARCHIVE_BYTES = 256 * 1024 * 1024;
 const MAX_MARKETPLACE_MANIFEST_BYTES = 16 * 1024 * 1024;
@@ -538,43 +538,25 @@ async function cloneMarketplaceRepo(params: {
 
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-marketplace-"));
   const repoDir = path.join(tmpDir, "repo");
-  const refIsCommit = isImmutableGitCommitRef(normalized.ref);
-  const argv = ["git", "clone"];
-  if (!normalized.ref) {
-    argv.push("--depth", "1");
-  } else if (!refIsCommit) {
-    argv.push("--depth", "1");
-    argv.push("--branch", normalized.ref);
-  }
-  argv.push(normalized.url, repoDir);
-  params.logger?.info?.(`Cloning marketplace source ${normalized.label}...`);
-  const res = await runCommandWithTimeout(argv, {
-    timeoutMs: params.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS,
-  });
-  if (res.code !== 0) {
+  const cleanup = async () => {
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
-    const detail = res.stderr.trim() || res.stdout.trim() || "git clone failed";
-    return {
-      ok: false,
-      error: `failed to clone marketplace source ${normalized.label}: ${detail}`,
-    };
-  }
-  if (refIsCommit) {
-    const checkout = await runCommandWithTimeout(
-      ["git", "switch", "--detach", "--", normalized.ref as string],
-      {
-        cwd: repoDir,
-        timeoutMs: params.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS,
-      },
-    );
-    if (checkout.code !== 0) {
-      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
-      const detail = checkout.stderr.trim() || checkout.stdout.trim() || "git checkout failed";
-      return {
-        ok: false,
-        error: `failed to checkout marketplace source ${normalized.label}: ${detail}`,
-      };
-    }
+  };
+  params.logger?.info?.(`Cloning marketplace source ${normalized.label}...`);
+  const acquired = await acquireGitSource({
+    ...normalized,
+    repoDir,
+    refMode: isImmutableGitCommitRef(normalized.ref) ? "detached" : "shallow-branch",
+    timeoutMs: params.timeoutMs,
+    cloneSeparator: false,
+    recordCommit: false,
+    cleanupOnFailure: cleanup,
+    formatFailure: ({ action, stdout, stderr }) => {
+      const detail = stderr.trim() || stdout.trim() || `git ${action} failed`;
+      return `failed to ${action} marketplace source ${normalized.label}: ${detail}`;
+    },
+  });
+  if (!acquired.ok) {
+    return acquired;
   }
 
   return {
@@ -582,9 +564,7 @@ async function cloneMarketplaceRepo(params: {
     rootDir: repoDir,
     label: normalized.label,
     ...(normalized.ref ? { ref: normalized.ref } : {}),
-    cleanup: async () => {
-      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
-    },
+    cleanup,
   };
 }
 
@@ -795,45 +775,6 @@ function parseMarketplaceContentLength(raw: string): number {
   return size;
 }
 
-async function readMarketplaceChunkWithTimeout(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-  chunkTimeoutMs: number,
-): Promise<Awaited<ReturnType<typeof reader.read>>> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  let timedOut = false;
-
-  return await new Promise((resolve, reject) => {
-    const clear = () => {
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId);
-        timeoutId = undefined;
-      }
-    };
-
-    timeoutId = setTimeout(() => {
-      timedOut = true;
-      clear();
-      void reader.cancel().catch(() => undefined);
-      reject(new Error(`download timed out after ${chunkTimeoutMs}ms`));
-    }, chunkTimeoutMs);
-
-    void reader.read().then(
-      (result) => {
-        clear();
-        if (!timedOut) {
-          resolve(result);
-        }
-      },
-      (err: unknown) => {
-        clear();
-        if (!timedOut) {
-          reject(toErrorObject(err, "Non-Error rejection"));
-        }
-      },
-    );
-  });
-}
-
 async function writeMarketplaceChunk(
   fileHandle: Awaited<ReturnType<typeof fs.open>>,
   chunk: Uint8Array,
@@ -860,7 +801,11 @@ async function streamMarketplaceResponseToFile(params: {
 
   try {
     while (true) {
-      const { done, value } = await readMarketplaceChunkWithTimeout(reader, params.chunkTimeoutMs);
+      const { done, value } = await readChunkWithIdleTimeout(
+        reader,
+        params.chunkTimeoutMs,
+        ({ chunkTimeoutMs }) => new Error(`download timed out after ${chunkTimeoutMs}ms`),
+      );
       if (done) {
         return;
       }

--- a/src/skills/lifecycle/source-install.ts
+++ b/src/skills/lifecycle/source-install.ts
@@ -5,12 +5,12 @@ import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensit
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { acquireGitSource } from "../../infra/git-source.js";
 import { sanitizeHostExecEnv } from "../../infra/host-env-security.js";
 import { withInstallWorkspace } from "../../infra/install-source-utils.js";
 import { writeJson } from "../../infra/json-files.js";
 import { isImmutableGitCommitRef, parseGitPluginSpec } from "../../plugins/git-install.js";
 import type { InstallSafetyOverrides } from "../../plugins/install-security-scan.types.js";
-import { runCommandWithTimeout } from "../../process/exec.js";
 import { resolveUserPath } from "../../utils.js";
 import { parseSkillFrontmatter } from "../loading/frontmatter.js";
 import { installExtractedSkillRoot, validateRequestedSkillSlug } from "./archive-install.js";
@@ -46,7 +46,6 @@ type SkillSourceInstallResult =
   | { ok: false; error: string };
 
 const SKILL_SOURCE_ORIGIN_RELATIVE_PATH = path.join(".openclaw", "source-origin.json");
-const DEFAULT_GIT_TIMEOUT_MS = 120_000;
 
 function createGitCommandEnv(): NodeJS.ProcessEnv {
   return sanitizeHostExecEnv({
@@ -57,76 +56,6 @@ function createGitCommandEnv(): NodeJS.ProcessEnv {
     },
     blockPathOverrides: false,
   });
-}
-
-function formatGitCommandFailure(params: {
-  action: string;
-  label: string;
-  stdout: string;
-  stderr: string;
-}): string {
-  const detail = sanitizeForLog(
-    redactSensitiveUrlLikeString(params.stderr.trim() || params.stdout.trim() || "git failed"),
-  );
-  return `failed to ${params.action} ${sanitizeForLog(redactSensitiveUrlLikeString(params.label))}: ${detail}`;
-}
-
-async function runGitCommand(params: {
-  argv: string[];
-  action: string;
-  label: string;
-  cwd?: string;
-  timeoutMs?: number;
-}): Promise<{ ok: true; stdout: string } | { ok: false; error: string }> {
-  const result = await runCommandWithTimeout(params.argv, {
-    baseEnv: {},
-    cwd: params.cwd,
-    timeoutMs: params.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS,
-    env: createGitCommandEnv(),
-  });
-  if (result.code !== 0) {
-    return {
-      ok: false,
-      error: formatGitCommandFailure({
-        action: params.action,
-        label: params.label,
-        stdout: result.stdout,
-        stderr: result.stderr,
-      }),
-    };
-  }
-  return { ok: true, stdout: result.stdout };
-}
-
-async function resolveGitCommitish(params: {
-  repoDir: string;
-  ref: string;
-  label: string;
-  timeoutMs?: number;
-}): Promise<{ ok: true; commitish: string } | { ok: false; error: string }> {
-  const candidates = params.ref.startsWith("origin/")
-    ? [params.ref]
-    : [params.ref, `origin/${params.ref}`];
-  for (const candidate of candidates) {
-    const resolved = await runCommandWithTimeout(
-      ["git", "rev-parse", "--verify", "--quiet", `${candidate}^{commit}`],
-      {
-        baseEnv: {},
-        cwd: params.repoDir,
-        timeoutMs: params.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS,
-        env: createGitCommandEnv(),
-      },
-    );
-    const commit = normalizeOptionalString(resolved.stdout);
-    if (resolved.code === 0 && commit) {
-      return { ok: true, commitish: commit };
-    }
-  }
-
-  return {
-    ok: false,
-    error: `failed to resolve ref ${sanitizeForLog(redactSensitiveUrlLikeString(params.ref))} in ${sanitizeForLog(redactSensitiveUrlLikeString(params.label))}`,
-  };
 }
 
 async function readSkillNameFromFrontmatter(skillDir: string): Promise<string | null> {
@@ -286,56 +215,21 @@ async function installGitSkill(params: {
     params.logger?.info?.(
       `Cloning ${sanitizeForLog(redactSensitiveUrlLikeString(parsed.label))}...`,
     );
-    const cloneArgs = parsed.ref
-      ? ["git", "clone", "--", parsed.url, repoDir]
-      : ["git", "clone", "--depth", "1", "--", parsed.url, repoDir];
-    const clone = await runGitCommand({
-      argv: cloneArgs,
-      action: "clone",
-      label: parsed.label,
+    const acquired = await acquireGitSource({
+      ...parsed,
+      repoDir,
+      refMode: "resolve-remote",
       timeoutMs: params.timeoutMs,
+      commandEnv: () => ({ baseEnv: {}, env: createGitCommandEnv() }),
     });
-    if (!clone.ok) {
-      return clone;
-    }
-
-    if (parsed.ref) {
-      const commitish = await resolveGitCommitish({
-        repoDir,
-        ref: parsed.ref,
-        label: parsed.label,
-        timeoutMs: params.timeoutMs,
-      });
-      if (!commitish.ok) {
-        return commitish;
-      }
-      const checkout = await runGitCommand({
-        argv: ["git", "switch", "--detach", "--", commitish.commitish],
-        action: `checkout ${parsed.ref}`,
-        label: parsed.label,
-        cwd: repoDir,
-        timeoutMs: params.timeoutMs,
-      });
-      if (!checkout.ok) {
-        return checkout;
-      }
-    }
-
-    const rev = await runGitCommand({
-      argv: ["git", "rev-parse", "HEAD"],
-      action: "resolve commit for",
-      label: parsed.label,
-      cwd: repoDir,
-      timeoutMs: params.timeoutMs,
-    });
-    if (!rev.ok) {
-      return rev;
+    if (!acquired.ok) {
+      return acquired;
     }
 
     const git = {
       url: redactSensitiveUrlLikeString(parsed.url),
       ...(parsed.ref ? { ref: parsed.ref } : {}),
-      commit: normalizeOptionalString(rev.stdout),
+      commit: acquired.commit,
       resolvedAt: new Date().toISOString(),
     };
     const exported = await copyGitWorktreeExport({ repoDir, exportDir });


### PR DESCRIPTION
## What Problem This Solves

Skill installs, direct Git plugin installs, and marketplace installs independently implemented Git acquisition. Keeping the same command sequence in three places made ref handling, failure reporting, and cleanup harder to maintain consistently.

## Why This Change Was Made

`src/infra/git-source.ts` now owns cloning, optional remote-ref resolution, detached checkout, and commit reads. Callers retain their exact ref policy, inherited/sanitized command environment, credential handling, installation policy, provenance publication, and staging ownership. Marketplace downloads also use the existing response-body idle-timeout helper, retaining their download error text and bounds.

This stays separate from #117416 (marketplace duplicate identities), #125414 (install publication transactions), and #131584 (skill repair receipts), whose metadata and diffs were inspected first. None of those PRs was modified.

## User Impact

Normal installation behavior is unchanged. Skills still resolve local refs before `origin/<ref>`, direct plugin installs retain detached-ref semantics, and marketplaces retain shallow branch/tag clones and full-commit checkout. No public exports, configuration, stored records, or package dependencies change.

## Evidence

- 85 focused tests passed across skill source installation, direct Git plugin installation/target ownership, marketplace installation/downloads, and the new acquisition-owner suite.
- Real local fixture repositories prove branch, tag, full-commit, `origin/` resolution, recorded commit, and cleanup after a missing ref. No external repository was cloned by tests.
- Independent Codex review at P0–P3: no accepted/actionable findings.
- `git diff --check` passed.
- Required exact assertion baseline shrink: `src/plugins/marketplace.ts` 7 → 6 after deleting its ref cast.
- Net production change: −121 lines; tests: +96 lines.

`node scripts/check-changed.mjs` and `pnpm build` passed, including core/test typechecks, lint, zero runtime import cycles, database guards, and Plugin SDK declarations/exports. Exact-head hosted CI passed for `563d3d71d5afae4eef9041cf98e05b742d5a5612`: https://github.com/openclaw/openclaw/actions/runs/34093479760.

Refreshed onto main `00fd5d6a404939da829ceae80e01d941a729cf06`; current head is `c77aedbab6a7e8241cb4857c8738e78a43dc452d`. The stable patch ID is unchanged. Main includes a shared command-runner update, so all 85 focused tests were rerun against the refreshed dependencies and passed (59.55 seconds). Exact-head CI and the required `openclaw/ci-gate` also passed: https://github.com/openclaw/openclaw/actions/runs/34094565664.
