### PR TITLE
refactor(cli): reuse Claws option declarations

### DIFF
--- a/src/cli/claws-cli.ts
+++ b/src/cli/claws-cli.ts
@@ -7,40 +7,28 @@ export type ClawsInspectOptions = {
   json?: boolean;
 };
 
-export type ClawsCreateOptions = {
+export type ClawsCreateOptions = ClawsInspectOptions & {
   name?: string;
   agentId?: string;
-  json?: boolean;
 };
 export type ClawsValidateOptions = { json?: boolean };
 export type ClawsBuildOptions = { out: string; json?: boolean };
 export type ClawsDevOptions = { agentId?: string; workspace?: string; json?: boolean };
 
-export type ClawsAddOptions = {
+export type ClawsAddOptions = ClawsDevOptions & {
   dryRun?: boolean;
   yes?: boolean;
   planIntegrity?: string;
-  json?: boolean;
-  agentId?: string;
-  workspace?: string;
 };
 
 export type ClawsStatusOptions = { json?: boolean };
-export type ClawsUpdateOptions = {
+export type ClawsUpdateOptions = Omit<ClawsAddOptions, "agentId" | "workspace"> & {
   from?: string;
-  dryRun?: boolean;
-  yes?: boolean;
-  planIntegrity?: string;
-  json?: boolean;
 };
-export type ClawsRemoveOptions = {
-  dryRun?: boolean;
-  yes?: boolean;
-  planIntegrity?: string;
+export type ClawsRemoveOptions = Omit<ClawsAddOptions, "agentId" | "workspace"> & {
   removeUnused?: boolean;
   removeReferenced?: string[];
   forceReferenced?: boolean;
-  json?: boolean;
 };
 export type ClawsExportOptions = { out: string; bootstrap?: string; json?: boolean };
 


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Claws repeats the same option fields across its create, add, update, and remove declarations. This maintainer-requested cleanup removes that duplication as part of the #135868 deletion campaign.

## Why This Change Was Made

Reuse existing declarations in the same owner while retaining all ten exported type names. Update and remove explicitly omit add/dev-only `agentId` and `workspace`; consent fields, optionality, mutable cleanup arrays, and required build/export output paths remain intact.

Only type declarations change. Runtime registration, flags, consent checks, callbacks, imports, and dynamic imports are unchanged. No configuration, schema, dependency, or persistence changes.

## User Impact

No user-visible behavior change. Claws commands retain the same options, previews, consent requirements, and outputs.

## Evidence

- Both complete owner suites pass before and after: 36 tests in `claws-cli.test.ts` and `claws-cli.project.test.ts` (38.20s before, 34.36s after). They cover exact plan consent, referenced cleanup selection, and project create/validate/build/offline-preview flows.
- Actual AST-extracted declarations pass 55 structural assertions in each optionality mode, covering all ten exported types. Missing consent integrity, losing the workspace exclusion, and changing the cleanup list to readonly each fail contract assertions in both modes. No permanent tests or copied field inventory were added.
- The complete before/after files emit byte-identical JavaScript with the same TypeScript 6.0.3 filename/options. The applied source matches the proven candidate hash. This preserves executable registration and lazy imports; it is source-emission evidence, not a package-build result.
- The full selected `check:changed` plan passed in 556.42s, including core/test types, all three zero-entry Knip scans, lint, zero runtime import cycles, and architecture/storage guards. All 14 recorded owner/consumer/test/dependency inputs stayed unchanged against source base `93a7f6de63622905c99091f8ca4a6d889a41fec6`.
- Refresh onto `a9676bd2b95db391b3ad6ae36b7e7d6a88770f5d` retained all 14 input hashes, including the lockfile. Exact-head CI supplies integration proof for current main.
- Independent Codex review is scoped-clean through P2.

- Initial exact-head CI passed. Final refresh onto `c69965b2cffab20f80914eb80939969897499357` is patch-identical (`git range-diff`), and all 14 source/test/consumer/dependency inputs—including the installed lockfile—remain byte-identical.

- Final branch Codex review is scoped-clean through P2. [ClawSweeper review](https://github.com/openclaw/openclaw/pull/140947#issuecomment-5566476938) found no correctness/security findings or before-merge/rank-up actions and confirmed the preserved option and consent contracts.

| Class | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 4 | 16 | -12 |
| Tests | 0 | 0 | 0 |
| Tooling | 0 | 0 | 0 |
| Docs | 0 | 0 | 0 |

`src/cli/claws-cli.ts` shrinks from 193 to 181 lines. Existing tests and baselines remain intact.
