### PR TITLE
refactor(build): share current Git commit reader

### DIFF
--- a/scripts/build-all.mts
+++ b/scripts/build-all.mts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Builds OpenClaw packages and plugin SDK artifacts with cache-aware orchestration.
 
-import { spawnSync, type SpawnSyncOptions } from "node:child_process";
+import type { SpawnSyncOptions } from "node:child_process";
 import { performance } from "node:perf_hooks";
 import prettyMilliseconds from "pretty-ms";
 import {
@@ -10,7 +10,7 @@ import {
   restoreBuildStepCacheOutputs,
   type BuildCacheStep,
 } from "./lib/build-artifact-cache.mts";
-import { resolveBuildIdentityEnvironment } from "./lib/build-identity.mts";
+import { readCurrentGitCommit, resolveBuildIdentityEnvironment } from "./lib/build-identity.mts";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import {
   distArtifactEntryArgs,
@@ -367,14 +367,6 @@ export function resolveBuildAllSteps(
       const merged: BuildAllStep = Object.assign({}, step, { env: mergedEnv });
       return merged;
     });
-}
-
-function readCurrentGitCommit() {
-  const result = spawnSync("git", ["rev-parse", "HEAD"], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-  });
-  return result.status === 0 ? result.stdout.trim() : null;
 }
 
 /** Pin one source identity for every child process that contributes to this build. */

--- a/scripts/lib/build-identity.mts
+++ b/scripts/lib/build-identity.mts
@@ -1,3 +1,5 @@
+import { spawnSync } from "node:child_process";
+
 const FULL_GIT_COMMIT_RE = /^[0-9a-f]{40}$/iu;
 
 type BuildIdentityOptions = {
@@ -6,6 +8,14 @@ type BuildIdentityOptions = {
   now?: () => Date;
   readGitCommit: () => string | null;
 };
+
+export function readCurrentGitCommit(): string | null {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
 
 /** Pins one timestamp and source commit across every child in a build lifecycle. */
 export function resolveBuildIdentityEnvironment({

--- a/scripts/ocm-npm-workspace-deps.mts
+++ b/scripts/ocm-npm-workspace-deps.mts
@@ -5,7 +5,7 @@ import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSyn
 import { tmpdir } from "node:os";
 import { delimiter, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { resolveBuildIdentityEnvironment } from "./lib/build-identity.mts";
+import { readCurrentGitCommit, resolveBuildIdentityEnvironment } from "./lib/build-identity.mts";
 
 const WORKSPACE_DIRS_ENV = "OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS";
 const REAL_NPM_ENV = "OPENCLAW_OCM_REAL_NPM_BIN";
@@ -110,13 +110,7 @@ export function resolveRuntimePackPlan(args: string[], env: NodeJS.ProcessEnv = 
 export function resolveRuntimePackEnvironment(
   env: NodeJS.ProcessEnv = process.env,
   now: () => Date = () => new Date(),
-  readGitCommit: () => string | null = () => {
-    const result = spawnSync("git", ["rev-parse", "HEAD"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    return result.status === 0 ? result.stdout.trim() : null;
-  },
+  readGitCommit: () => string | null = readCurrentGitCommit,
 ) {
   return resolveBuildIdentityEnvironment({
     commitLabel: "runtime pack commit",

--- a/scripts/openclaw-prepack.ts
+++ b/scripts/openclaw-prepack.ts
@@ -6,7 +6,7 @@ import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { basename, delimiter, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { formatErrorMessage } from "../src/infra/errors.ts";
-import { resolveBuildIdentityEnvironment } from "./lib/build-identity.mts";
+import { readCurrentGitCommit, resolveBuildIdentityEnvironment } from "./lib/build-identity.mts";
 import { readPositiveEnvInt } from "./lib/numeric-options.mjs";
 import { writePackageDistInventoryForPublish } from "./lib/package-dist-inventory.ts";
 import { restorePrepackArtifacts } from "./openclaw-postpack.mjs";
@@ -241,13 +241,7 @@ function run(command: string, args: string[], options: SpawnSyncOptions = {}): v
 export function resolvePrepackBuildEnvironment(
   env: NodeJS.ProcessEnv = process.env,
   now: () => Date = () => new Date(),
-  readGitCommit: () => string | null = () => {
-    const result = spawnSync("git", ["rev-parse", "HEAD"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    return result.status === 0 ? result.stdout.trim() : null;
-  },
+  readGitCommit: () => string | null = readCurrentGitCommit,
 ): NodeJS.ProcessEnv {
   return resolveBuildIdentityEnvironment({
     commitLabel: "build commit",

--- a/test/scripts/build-identity.test.ts
+++ b/test/scripts/build-identity.test.ts
@@ -1,5 +1,79 @@
-import { describe, expect, it, vi } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveBuildIdentityEnvironment } from "../../scripts/lib/build-identity.mts";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const buildIdentityUrl = new URL("../../scripts/lib/build-identity.mts", import.meta.url).href;
+const tsxPreloadUrl = new URL("../../scripts/tsx.mjs", import.meta.url).href;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function readGitCommitInChild(cwd: string, env: NodeJS.ProcessEnv = process.env) {
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--import",
+      tsxPreloadUrl,
+      "--input-type=module",
+      "--eval",
+      `const { readCurrentGitCommit } = await import(${JSON.stringify(buildIdentityUrl)}); process.stdout.write(JSON.stringify(readCurrentGitCommit()));`,
+    ],
+    {
+      cwd,
+      encoding: "utf8",
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 10_000,
+    },
+  );
+  expect(result.error).toBeUndefined();
+  expect(result.status, result.stderr).toBe(0);
+  return JSON.parse(result.stdout) as string | null;
+}
+
+describe("readCurrentGitCommit", () => {
+  it("reads HEAD from the inherited cwd and returns null when Git cannot resolve it", () => {
+    const root = tempDirs.make("openclaw-build-identity-");
+    const repo = join(root, "repo");
+    const outsideRepo = join(root, "outside");
+    mkdirSync(repo);
+    mkdirSync(outsideRepo);
+
+    execFileSync("git", ["init", "-q"], { cwd: repo, stdio: "ignore" });
+    writeFileSync(join(repo, "fixture.txt"), "fixture\n");
+    execFileSync("git", ["add", "fixture.txt"], { cwd: repo, stdio: "ignore" });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=OpenClaw Tests",
+        "-c",
+        "user.email=openclaw-tests@example.invalid",
+        "commit",
+        "-qm",
+        "fixture",
+      ],
+      { cwd: repo, stdio: "ignore" },
+    );
+    const expected = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: repo,
+      encoding: "utf8",
+    }).trim();
+
+    expect(readGitCommitInChild(repo)).toBe(expected);
+    expect(readGitCommitInChild(outsideRepo)).toBeNull();
+
+    const envWithoutGit = { ...process.env };
+    for (const key of Object.keys(envWithoutGit)) {
+      if (key.toLowerCase() === "path") {
+        delete envWithoutGit[key];
+      }
+    }
+    envWithoutGit.PATH = "";
+    expect(readGitCommitInChild(repo, envWithoutGit)).toBeNull();
+  });
+});
 
 describe("resolveBuildIdentityEnvironment", () => {
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested deduplication for the active function-similarity cleanup. Three build and packaging entrypoints separately maintained the same current-checkout Git commit reader, making their build-identity behavior easier to drift.

## Why This Change Was Made

Move the exact synchronous `git rev-parse HEAD` reader into the existing internal build-identity owner and use it as the default callback for build-all, OCM runtime packing, and package prepack. Each resolver retains its injectable callback and existing source-identity precedence. The Control UI reader remains separate because it intentionally pins the repository root as its working directory.

## User Impact

No user-visible behavior changes. Build and packaging tooling now share one implementation for inherited-cwd Git commit discovery while preserving existing failure and override behavior.

## Evidence

- Local owner suites: 146 tests passed across build identity, build-all, OCM workspace dependencies, and prepack.
- Local helper rerun after test-fixture cleanup: 6 tests passed.
- Local formatting, focused script/test lint, and `git diff --check` passed.
- Local `check:changed` passed all checks before `tsgo` rejected the worktree's external `node_modules` symlink, as designed.
- Blacksmith Testbox `tbx_01m1xa2w188bcvhrdah7qcfvs3`: all 174 focused tests passed, including the Control UI sibling.
- Blacksmith Testbox: full changed gate passed with script and test-root typechecks, lint, erasability, formatting, and repository guards.
- Fresh P2 autoreview: scoped clean, no actionable findings.
- Live main was 14 commits ahead of the branch base at publication preflight, with no changes in the scoped source or test paths.

Production tooling: `+16/-26` lines. Tests: `+75/-1` lines.
