### PR TITLE
fix(plugins): install Git plugins from non-default branches

### DIFF
--- a/src/plugins/git-install-target.test.ts
+++ b/src/plugins/git-install-target.test.ts
@@ -61,6 +61,59 @@ describe("git install target ownership", () => {
     await state.cleanup();
   });
 
+  it.each(["branch", "tag", "annotated-tag", "commit", "short-commit", "default"] as const)(
+    "installs the requested %s revision from a real Git repository",
+    async (kind) => {
+      const defaultCommit = await git(sourceDir, "rev-parse", "HEAD");
+      await git(sourceDir, "switch", "-c", "feature/demo");
+      const featureCommit = await commitPlugin("demo", "2.0.0");
+      await git(sourceDir, "tag", "v2.0.0");
+      await git(sourceDir, "-c", "tag.gpgsign=false", "tag", "-a", "release", "-m", "release");
+      await git(sourceDir, "switch", "main");
+      const refs = {
+        branch: "feature/demo",
+        tag: "v2.0.0",
+        "annotated-tag": "release",
+        commit: featureCommit,
+        "short-commit": featureCommit.slice(0, 12),
+        default: undefined,
+      };
+      const ref = refs[kind];
+      const result = await installPluginFromGitSpec({
+        spec: `${spec}${ref ? `#${ref}` : ""}`,
+        expectedPluginId: "demo",
+      });
+      if (!result.ok) {
+        throw new Error(result.error);
+      }
+      const expectedCommit = kind === "default" ? defaultCommit : featureCommit;
+      const expectedVersion = kind === "default" ? "1.0.0" : "2.0.0";
+      expect(result.version).toBe(expectedVersion);
+      expect(result.git).toMatchObject({ ref, commit: expectedCommit });
+      expect(await git(result.targetDir, "rev-parse", "HEAD")).toBe(expectedCommit);
+      await expect(fs.readFile(path.join(result.targetDir, "index.js"), "utf8")).resolves.toBe(
+        `export default ${JSON.stringify(expectedVersion)};\n`,
+      );
+      if (kind === "branch") {
+        await git(sourceDir, "switch", "feature/demo");
+        const nextCommit = await commitPlugin("demo", "3.0.0");
+        await git(sourceDir, "switch", "main");
+        const updated = await installPluginFromGitSpec({
+          spec: `${spec}#${ref}`,
+          mode: "update",
+          expectedPluginId: "demo",
+        });
+        expect(updated).toMatchObject({
+          ok: true,
+          version: "3.0.0",
+          targetDir: result.targetDir,
+          git: { ref, commit: nextCommit },
+        });
+        expect(await git(result.targetDir, "rev-parse", "HEAD")).toBe(nextCommit);
+      }
+    },
+  );
+
   it.each([
     { pluginId: "demo", deferred: false },
     { pluginId: "renamed-demo", deferred: false },

--- a/src/plugins/git-install.test.ts
+++ b/src/plugins/git-install.test.ts
@@ -195,6 +195,7 @@ describe("installPluginFromGitSpec", () => {
   it("clones, checks out refs, installs from the clone, and returns commit metadata", async () => {
     runCommandWithTimeoutMock
       .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
+      .mockResolvedValueOnce({ code: 0, stdout: "abc123\n", stderr: "" })
       .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
       .mockResolvedValueOnce({ code: 0, stdout: "abc123\n", stderr: "" })
       .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" });
@@ -238,8 +239,8 @@ describe("installPluginFromGitSpec", () => {
       "https://github.com/acme/demo.git",
     ]);
     expect(cloneArgv[4]).toContain("/repo");
-    expect(commandArgvAt(1)).toEqual(["git", "switch", "--detach", "--", "v1.2.3"]);
-    expect(commandArgvAt(3)).toEqual([
+    expect(commandArgvAt(2)).toEqual(["git", "switch", "--detach", "--", "abc123"]);
+    expect(commandArgvAt(4)).toEqual([
       "npm",
       "install",
       "--omit=dev",
@@ -451,6 +452,7 @@ describe("installPluginFromGitSpec", () => {
     const commit = "0123456789abcdef0123456789abcdef01234567";
     runCommandWithTimeoutMock
       .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
+      .mockResolvedValueOnce({ code: 0, stdout: `${commit}\n`, stderr: "" })
       .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
       .mockResolvedValueOnce({ code: 0, stdout: `${commit}\n`, stderr: "" })
       .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" });
@@ -818,11 +820,8 @@ describe("installPluginFromGitSpec", () => {
   it("separates requested refs from git options", async () => {
     runCommandWithTimeoutMock
       .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
-      .mockResolvedValueOnce({
-        code: 128,
-        stdout: "",
-        stderr: "fatal: invalid reference: --ignore-skip-worktree-bits",
-      });
+      .mockResolvedValueOnce({ code: 1, stdout: "", stderr: "" })
+      .mockResolvedValueOnce({ code: 1, stdout: "", stderr: "" });
 
     const result = await installPluginFromGitSpec({
       spec: "git:github.com/acme/demo@--ignore-skip-worktree-bits",
@@ -831,10 +830,17 @@ describe("installPluginFromGitSpec", () => {
     expect(result.ok).toBe(false);
     expect(commandArgvAt(1)).toEqual([
       "git",
-      "switch",
-      "--detach",
-      "--",
-      "--ignore-skip-worktree-bits",
+      "rev-parse",
+      "--verify",
+      "--quiet",
+      "--ignore-skip-worktree-bits^{commit}",
+    ]);
+    expect(commandArgvAt(2)).toEqual([
+      "git",
+      "rev-parse",
+      "--verify",
+      "--quiet",
+      "origin/--ignore-skip-worktree-bits^{commit}",
     ]);
     expect(installPluginFromInstalledPackageDirMock).not.toHaveBeenCalled();
   });

--- a/src/plugins/git-install.ts
+++ b/src/plugins/git-install.ts
@@ -401,7 +401,7 @@ export async function installPluginFromGitSpec(
     const acquired = await acquireGitSource({
       ...parsed,
       repoDir,
-      refMode: "detached",
+      refMode: "resolve-remote",
       timeoutMs: params.timeoutMs,
       commandEnv: () => ({ env: createGitCommandEnv() }),
     });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users installing a Git plugin from a non-default branch, such as `git:owner/plugin#feature/demo`, would receive a Git checkout error even though the requested branch existed.

## Why This Change Was Made

Select the existing remote-ref resolution mode in the shared Git acquisition helper. It resolves the requested revision to a commit before detached checkout, including branches that the clone knows only through `origin`. The plugin installer continues to own package validation, installation, and recorded commit metadata.

## User Impact

Users can install and update plugins from non-default Git branches. Lightweight and annotated tags, full and abbreviated commit IDs, and default-branch installs retain their existing behavior.

## Evidence

The real installer regression failed on current main before the repair with `fatal: '--detach' cannot be used with '-b/-B/--orphan'`. After the one-line mode change, all 40 focused tests passed: both plugin Git suites and the shared Git-source suite. Actual installations use controlled local repositories containing a minimal plugin with no external dependencies. Coverage includes a non-default branch during both installation and update, lightweight and annotated tags, full and abbreviated commit IDs, default HEAD, installed file contents, and recorded commit identity.

Validation: `node scripts/run-vitest.mjs src/plugins/git-install-target.test.ts src/plugins/git-install.test.ts src/infra/git-source.test.ts --maxWorkers=1`; the owning `test/tsconfig/tsconfig.core.test.plugins-platform.json` type graph; full-file typed lint; formatting; and `git diff --check`.

The production diff replaces one line and adds no net lines. Tests add 59 net lines. The existing Git install documentation already describes the repaired behavior.
