### PR TITLE
fix(ui): restore authenticated agent picker avatars

### DIFF
--- a/ui/src/components/agent-select.test.ts
+++ b/ui/src/components/agent-select.test.ts
@@ -153,6 +153,37 @@ it("preserves complete grapheme clusters in emoji avatar fallback", async () => 
   }
 });
 
+it("keeps a failed avatar on its fallback until the image changes", async () => {
+  const invalidAvatar = "data:image/gif;base64,bm90LWFuLWltYWdl";
+  const replacementAvatar = "data:image/png;base64,cmVwbGFjZW1lbnQ=";
+  const element = await createAgentSelect({
+    identityById: { alpha: createIdentity("alpha", { avatar: invalidAvatar }) },
+  });
+  const failedImage = element.querySelector<HTMLImageElement>("img.agent-select__avatar");
+  expect(failedImage).not.toBeNull();
+  failedImage?.dispatchEvent(new Event("error"));
+  await element.updateComplete;
+  expect(element.querySelector("img.agent-select__avatar")).toBeNull();
+  expect(element.querySelector(".agent-select__avatar--text")?.getAttribute("data-avatar")).toBe(
+    "A",
+  );
+
+  element.accessibleLabel = "Choose another agent";
+  await element.updateComplete;
+  expect(element.querySelector("img.agent-select__avatar")).toBeNull();
+
+  element.identityById = { alpha: createIdentity("alpha", { avatar: replacementAvatar }) };
+  await element.updateComplete;
+  expect(element.querySelector("img.agent-select__avatar")?.getAttribute("src")).toBe(
+    replacementAvatar,
+  );
+  failedImage?.dispatchEvent(new Event("error"));
+  await element.updateComplete;
+  expect(element.querySelector("img.agent-select__avatar")?.getAttribute("src")).toBe(
+    replacementAvatar,
+  );
+});
+
 it("fetches local avatars with the bearer credential when token auth is active", async () => {
   const createObjectURL = vi.fn(() => "blob:agent-avatar");
   const revokeObjectURL = vi.fn();

--- a/ui/src/components/agent-select.ts
+++ b/ui/src/components/agent-select.ts
@@ -2,6 +2,7 @@ import "@awesome.me/webawesome/dist/components/dropdown/dropdown.js";
 import "@awesome.me/webawesome/dist/components/dropdown-item/dropdown-item.js";
 import { type PropertyValues, html, nothing, type TemplateResult } from "lit";
 import { property } from "lit/decorators.js";
+import { keyed } from "lit/directives/keyed.js";
 import { ref } from "lit/directives/ref.js";
 import type { AgentIdentityResult, GatewayAgentRow } from "../api/types.ts";
 import { t } from "../i18n/index.ts";
@@ -27,13 +28,23 @@ export function renderAgentSelectAvatar(
   option: AgentSelectOption,
   identity: AgentIdentityResult | null = null,
   imageUrl?: string | null,
+  onImageError?: () => void,
 ) {
   const resolvedImageUrl =
     imageUrl === undefined && option.agent
       ? resolveAgentAvatarUrl(option.agent, identity)
       : (imageUrl ?? null);
   if (resolvedImageUrl) {
-    return html`<img class="agent-select__avatar" src=${resolvedImageUrl} alt="" loading="lazy" />`;
+    return keyed(
+      resolvedImageUrl,
+      html`<img
+        class="agent-select__avatar"
+        src=${resolvedImageUrl}
+        alt=""
+        loading="lazy"
+        @error=${onImageError}
+      />`,
+    );
   }
   if (option.icon) {
     return html`<span class="agent-select__avatar agent-select__avatar--icon" aria-hidden="true"
@@ -91,7 +102,12 @@ export class AgentSelect extends OpenClawLightDomElement {
     const identity = agentId ? (this.identityById[agentId] ?? null) : null;
     const url = option.agent ? resolveAgentAvatarUrl(option.agent, identity) : null;
     const imageUrl = url ? this.avatarLoader.resolve(url) : null;
-    return renderAgentSelectAvatar(option, identity, imageUrl);
+    return renderAgentSelectAvatar(
+      option,
+      identity,
+      imageUrl,
+      url ? this.avatarLoader.imageErrorHandler(url) : undefined,
+    );
   }
 
   private readonly handleSelect = (event: WebAwesomeSelectEvent) => {

--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -9,6 +9,7 @@ import type { ApplicationNavigationOptions } from "../app/context.ts";
 import type { ThemeMode } from "../app/theme.ts";
 import { t } from "../i18n/index.ts";
 import { normalizeAgentLabel } from "../lib/agents/display.ts";
+import { resolveAgentAvatarUrl } from "../lib/avatar.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../lib/external-link.ts";
 import {
   formatKeyboardShortcutCombo,
@@ -181,6 +182,8 @@ type SidebarAgentMenuParams = {
   identities: ReadonlyMap<string, AgentIdentityResult>;
   pinnedAgentIds: readonly string[];
   connected: boolean;
+  /** Resolves roster avatar routes through the authenticated identity loader. */
+  resolveAvatarUrl: (url: string) => string | null;
   openMode: "hover" | "click";
   agentUnreadCount: (agentId: string) => number;
   onPointerEnter: () => void;
@@ -235,6 +238,10 @@ function renderAgentRow(agent: AgentMenuAgent, params: SidebarAgentMenuParams) {
   const active = agentId === params.activeId;
   const unread = active ? 0 : params.agentUnreadCount(agentId);
   const option = { value: agentId, label, agent };
+  // Tiles are <img> elements: the authenticated /avatar route must go through
+  // the loader, never straight into img.src where it cannot carry credentials.
+  const avatarUrl = resolveAgentAvatarUrl(agent, identity);
+  const resolvedAvatarUrl = avatarUrl ? params.resolveAvatarUrl(avatarUrl) : null;
   return html`
     <wa-dropdown-item
       class="sidebar-customize-menu__item sidebar-agent-menu__agent-switch agent-select__option ${
@@ -248,7 +255,7 @@ function renderAgentRow(agent: AgentMenuAgent, params: SidebarAgentMenuParams) {
     >
       <span class="sidebar-agent-menu__agent-tile">
         <span class="sidebar-agent-menu__agent-avatar">
-          ${renderAgentSelectAvatar(option, identity)}
+          ${renderAgentSelectAvatar(option, identity, resolvedAvatarUrl)}
         </span>
         ${renderAgentSelectCopy(option)}
         <span class="sidebar-agent-menu__agent-status">

--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -182,8 +182,8 @@ type SidebarAgentMenuParams = {
   identities: ReadonlyMap<string, AgentIdentityResult>;
   pinnedAgentIds: readonly string[];
   connected: boolean;
-  /** Resolves roster avatar routes through the authenticated identity loader. */
   resolveAvatarUrl: (url: string) => string | null;
+  avatarErrorHandler: (url: string) => () => void;
   openMode: "hover" | "click";
   agentUnreadCount: (agentId: string) => number;
   onPointerEnter: () => void;
@@ -238,8 +238,6 @@ function renderAgentRow(agent: AgentMenuAgent, params: SidebarAgentMenuParams) {
   const active = agentId === params.activeId;
   const unread = active ? 0 : params.agentUnreadCount(agentId);
   const option = { value: agentId, label, agent };
-  // Tiles are <img> elements: the authenticated /avatar route must go through
-  // the loader, never straight into img.src where it cannot carry credentials.
   const avatarUrl = resolveAgentAvatarUrl(agent, identity);
   const resolvedAvatarUrl = avatarUrl ? params.resolveAvatarUrl(avatarUrl) : null;
   return html`
@@ -255,7 +253,12 @@ function renderAgentRow(agent: AgentMenuAgent, params: SidebarAgentMenuParams) {
     >
       <span class="sidebar-agent-menu__agent-tile">
         <span class="sidebar-agent-menu__agent-avatar">
-          ${renderAgentSelectAvatar(option, identity, resolvedAvatarUrl)}
+          ${renderAgentSelectAvatar(
+            option,
+            identity,
+            resolvedAvatarUrl,
+            avatarUrl ? params.avatarErrorHandler(avatarUrl) : undefined,
+          )}
         </span>
         ${renderAgentSelectCopy(option)}
         <span class="sidebar-agent-menu__agent-status">

--- a/ui/src/components/sidebar-agent-card.ts
+++ b/ui/src/components/sidebar-agent-card.ts
@@ -1,5 +1,6 @@
 import { html, nothing } from "lit";
 import { property } from "lit/decorators.js";
+import { keyed } from "lit/directives/keyed.js";
 import type { ControlUiEnvironment } from "../../../src/gateway/control-ui-bootstrap-contract.js";
 import { t } from "../i18n/index.ts";
 import { IdentityAvatarController } from "../lib/identity-avatar-loader.ts";
@@ -32,11 +33,11 @@ class SidebarAgentCard extends OpenClawLightDomContentsElement {
   }
 
   private renderContent() {
-    const avatarUrl = this.avatarUrl?.startsWith("/")
-      ? this.avatarAuthReady
-        ? this.avatarLoader.resolve(this.avatarUrl)
-        : null
-      : this.avatarUrl;
+    const sourceUrl = this.avatarUrl;
+    const avatarUrl =
+      sourceUrl && (!sourceUrl.startsWith("/") || this.avatarAuthReady)
+        ? this.avatarLoader.resolve(sourceUrl)
+        : null;
     const menuLabel = this.switcherAvailable
       ? t("agentChip.switchAgent")
       : t("agentChip.menuLabel");
@@ -72,14 +73,18 @@ class SidebarAgentCard extends OpenClawLightDomContentsElement {
             }"
           >
             ${
-              avatarUrl
-                ? html`<img
-                    src=${avatarUrl}
-                    alt=""
-                    aria-hidden="true"
-                    loading="lazy"
-                    decoding="async"
-                  />`
+              avatarUrl && sourceUrl
+                ? keyed(
+                    avatarUrl,
+                    html`<img
+                      src=${avatarUrl}
+                      alt=""
+                      aria-hidden="true"
+                      loading="lazy"
+                      decoding="async"
+                      @error=${this.avatarLoader.imageErrorHandler(sourceUrl)}
+                    />`,
+                  )
                 : html`<span class="sidebar-agent-card__avatar-text" aria-hidden="true"
                     >${this.avatarText}</span
                   >`

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -11,6 +11,7 @@ import { isSessionRouteId, pathForRoute, type RouteId } from "../app-route-paths
 import type { ApplicationContext, ApplicationNavigationOptions } from "../app/context.ts";
 import type { ThemeMode } from "../app/theme.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
+import { IdentityAvatarController } from "../lib/identity-avatar-loader.ts";
 import { createIdleImport } from "../lib/idle-import.ts";
 import {
   SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD,
@@ -197,10 +198,14 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
     },
   );
   readonly catalogMenu: SidebarCatalogMenuController;
+  // Switcher tiles are plain <img> elements on the authenticated /avatar
+  // route, which only the shared identity avatar loader can fetch.
+  readonly agentMenuAvatars: IdentityAvatarController;
   pluginActionLifetime = new AbortController();
 
   constructor(readonly host: SidebarMenusControllerHost) {
     host.addController(this);
+    this.agentMenuAvatars = new IdentityAvatarController(host);
     this.catalogMenu = new SidebarCatalogMenuController({
       // Closing every transient menu keeps one popover at a time.
       beforeOpen: () => void this.dismissTransientMenus(),
@@ -696,7 +701,9 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
   }
 
   renderAgentMenu() {
-    return this.menuRenderer?.renderSidebarAgentMenuForController(this) ?? nothing;
+    return this.agentMenuAvatars.withActiveRoutes(
+      () => this.menuRenderer?.renderSidebarAgentMenuForController(this) ?? nothing,
+    );
   }
 
   renderIdentityMenu() {

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -70,16 +70,7 @@ interface SidebarMenusControllerState {
 
 export type SidebarFilterMenuView = "root" | "specific-owner";
 
-type SidebarMenusRenderer = {
-  renderSidebarAgentMenuForController(controller: SidebarMenusController): unknown;
-  renderSidebarCatalogViewMenuForController(controller: SidebarMenusController): unknown;
-  renderSidebarCustomizeMenuForController(controller: SidebarMenusController): unknown;
-  renderSidebarIdentityMenuForController(controller: SidebarMenusController): unknown;
-  renderSidebarMoreMenuForController(controller: SidebarMenusController): unknown;
-  renderSidebarSessionGroupMenuForController(controller: SidebarMenusController): unknown;
-  renderSidebarSessionMenuForController(controller: SidebarMenusController): unknown;
-  renderSidebarSessionSortMenuForController(controller: SidebarMenusController): unknown;
-};
+type SidebarMenusRenderer = typeof import("./sidebar-menus-render.ts");
 
 interface SidebarMenusControllerHost
   extends ReactiveControllerHost, SessionOrganizerControllerHost {

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -198,8 +198,6 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
     },
   );
   readonly catalogMenu: SidebarCatalogMenuController;
-  // Switcher tiles are plain <img> elements on the authenticated /avatar
-  // route, which only the shared identity avatar loader can fetch.
   readonly agentMenuAvatars: IdentityAvatarController;
   pluginActionLifetime = new AbortController();
 

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -110,6 +110,7 @@ export function renderSidebarAgentMenuForController(controller: SidebarMenusCont
     identities,
     pinnedAgentIds: host.pinnedAgentIds,
     connected: host.connected,
+    resolveAvatarUrl: (url) => controller.agentMenuAvatars.resolve(url),
     openMode: controller.agentMenuInteractionState === "open-hover" ? "hover" : "click",
     agentUnreadCount: (agentId) => host.agentUnreadCount(agentId),
     onPointerEnter: () => controller.handleAgentMenuPointerEnter(),

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -111,6 +111,7 @@ export function renderSidebarAgentMenuForController(controller: SidebarMenusCont
     pinnedAgentIds: host.pinnedAgentIds,
     connected: host.connected,
     resolveAvatarUrl: (url) => controller.agentMenuAvatars.resolve(url),
+    avatarErrorHandler: (url) => controller.agentMenuAvatars.imageErrorHandler(url),
     openMode: controller.agentMenuInteractionState === "open-hover" ? "hover" : "click",
     agentUnreadCount: (agentId) => host.agentUnreadCount(agentId),
     onPointerEnter: () => controller.handleAgentMenuPointerEnter(),

--- a/ui/src/lib/identity-avatar-loader.ts
+++ b/ui/src/lib/identity-avatar-loader.ts
@@ -187,12 +187,26 @@ export class IdentityAvatarController implements ReactiveController {
     }
   }
 
+  imageErrorHandler(value: string): () => void {
+    const route = this.routes.get(value);
+    return () => {
+      // An old image may fail after its view or Gateway context was replaced.
+      if (
+        !route?.url ||
+        !this.connected ||
+        this.generation !== identityAvatarGeneration ||
+        this.routes.get(value) !== route
+      ) {
+        return;
+      }
+      route.url = null;
+      this.host.requestUpdate();
+    };
+  }
+
   resolve(value: string): string | null {
     if (!this.connected) {
       return null;
-    }
-    if (!value.startsWith("/")) {
-      return value;
     }
     if (this.generation !== identityAvatarGeneration) {
       for (const route of this.routes.values()) {
@@ -202,7 +216,7 @@ export class IdentityAvatarController implements ReactiveController {
       this.generation = identityAvatarGeneration;
     }
     this.activeRoutes?.add(value);
-    const result = resolveAvatarImageUrl(value);
+    const result = value.startsWith("/") ? resolveAvatarImageUrl(value) : value;
     const cached = this.routes.get(value);
     if (cached && cached.result === result) {
       return cached.url;

--- a/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentsListResult } from "../../api/types.ts";
 import { createAgentIdentityCapability } from "../../lib/agents/identity.ts";
+import { setAvatarGatewayOrigin } from "../../lib/identity-avatar-context.ts";
 import {
   SESSION_COMPOSER_FOCUS_PARAM,
   SESSION_FACE_PREFERENCE_PARAM,
@@ -618,5 +619,70 @@ describe("AppSidebar agent chip", () => {
         ".sidebar-agent-menu wa-dropdown-item.sidebar-agent-menu__agent-switch",
       ),
     ).toHaveLength(12);
+  });
+
+  it("loads switcher avatar tiles through the authenticated avatar loader", async () => {
+    // The roster advertises the authenticated /avatar/<id> route for
+    // workspace-relative avatars. An <img> element cannot send the
+    // Authorization header, so menu tiles must resolve through the shared
+    // identity avatar loader instead of binding that route to img.src.
+    const avatarRoute = "/avatar/research?v=140879";
+    const createObjectURL = vi.fn(() => "blob:agent-avatar");
+    vi.stubGlobal(
+      "URL",
+      class extends URL {
+        static override createObjectURL = createObjectURL;
+        static override revokeObjectURL = vi.fn();
+      },
+    );
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(["avatar"], { type: "image/png" }),
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    setAvatarGatewayOrigin(globalThis.location.origin, ["secret-token"]);
+    try {
+      const { sidebar } = await mountSidebar(
+        createGateway({} as GatewayBrowserClient),
+        createSessions("main", ["agent:main:main"]),
+        "panel",
+        {
+          ...TWO_AGENTS,
+          agents: [
+            { id: "main", identity: { name: "Molty", emoji: "🦞" } },
+            { id: "research", identity: { avatarUrl: avatarRoute } },
+          ],
+        },
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+
+      sidebar.querySelector<HTMLButtonElement>(".sidebar-agent-card__main")?.click();
+      await sidebar.updateComplete;
+      const menu = sidebar.querySelector(".sidebar-agent-menu");
+      expect(menu).not.toBeNull();
+      const researchRow = [
+        ...(menu?.querySelectorAll<HTMLElement>(".sidebar-agent-menu__agent-switch") ?? []),
+      ].find((row) => row.textContent?.includes("research"));
+      expect(researchRow).toBeDefined();
+
+      await vi.waitFor(() => {
+        expect(
+          researchRow
+            ?.querySelector<HTMLImageElement>("img.agent-select__avatar")
+            ?.getAttribute("src"),
+        ).toBe("blob:agent-avatar");
+      });
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${globalThis.location.origin}/avatar/research?v=140879`,
+        expect.objectContaining({
+          headers: { Authorization: "Bearer secret-token" },
+        }),
+      );
+    } finally {
+      setAvatarGatewayOrigin(null);
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
@@ -622,10 +622,6 @@ describe("AppSidebar agent chip", () => {
   });
 
   it("loads switcher avatar tiles through the authenticated avatar loader", async () => {
-    // The roster advertises the authenticated /avatar/<id> route for
-    // workspace-relative avatars. An <img> element cannot send the
-    // Authorization header, so menu tiles must resolve through the shared
-    // identity avatar loader instead of binding that route to img.src.
     const avatarRoute = "/avatar/research?v=140879";
     const createObjectURL = vi.fn(() => "blob:agent-avatar");
     vi.stubGlobal(
@@ -639,7 +635,7 @@ describe("AppSidebar agent chip", () => {
       ok: true,
       blob: async () => new Blob(["avatar"], { type: "image/png" }),
     });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.stubGlobal("fetch", fetchMock);
     setAvatarGatewayOrigin(globalThis.location.origin, ["secret-token"]);
     try {
       const { sidebar } = await mountSidebar(


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #140879

## What Problem This Solves

Fixes broken avatar images when users open the Control UI agent picker on a token-authenticated Gateway with workspace-relative or inline avatars.

## Why This Change Was Made

The picker now uses the existing authenticated avatar loader, matching the selected-agent header and standalone selector. These views also retain their text or emoji fallback when an image cannot decode, and retry presentation when its source changes. Gateway authorization and shared image caching stay intact.

## User Impact

Configured agent images render in the picker. Missing or malformed images show a fallback. Switching agents and replacing images preserve each agent's identity without putting credentials in image URLs.

## Evidence

- A real token-authenticated Gateway and Chromium reproduced the bug on main at `ade9cce816fabe84c268933da2cd8e2bba2db6a4`: both picker images failed while the selected-agent header decoded correctly.
- Matching Gateway and Control UI builds at `a4aacc5b6fa96ec19bcaca29d7a11114c4f15c06` render the expected red, blue, and inline green pixels. Missing, unreadable, malformed GIF, and unsupported files settle to their text or emoji fallback.
- Independent browser acceptance covered all 16 original clauses, including agent switching, version changes after the documented 60-second freshness window, credential/origin invalidation, cache eviction, stable rerenders, and page teardown. A 132-avatar fixture exercised image-lease release; all temporary fixtures were restored or removed.
- Unauthenticated, invalid-token, and query-token avatar requests remain `401`; valid bearer requests return `200`. Images contain no credential-bearing URLs.
- Pin order and read/unread session behavior match baseline. The aggregate picker unread dot did not appear on either build in these fixtures, so its positive display remains unverified. Arbitrary external image hosts remain blocked by the existing image policy.
- Both regression tests failed for their intended reasons before the corresponding repair. All 414 focused sidebar, selector, identity-view, and image-loader tests pass. Changed-file formatting, lint, line-limit, and assertion-safety checks pass. Full CI runs on GitHub and is required before landing.

The final follow-up replaces a duplicated TypeScript renderer declaration with the existing module type. Its emitted JavaScript is byte-identical to the browser-tested build, and lint passes against the exact CI merge that exposed the line-limit failure. The retained browser evidence therefore keeps its original build identity.
