### PR TITLE
fix(subagents): stop terminal requester wake retry loops

### DIFF
--- a/src/agents/subagents/completion/subagent-completion-admission.store.ts
+++ b/src/agents/subagents/completion/subagent-completion-admission.store.ts
@@ -416,13 +416,39 @@ export function settleRejectedRequesterSettleWakeBatch(params: {
   try {
     runOpenClawStateWriteTransaction(
       (database) => {
-        const batchRunIds = params.entries.map((entry) => entry.subagent.runId).toSorted();
+        const submittedRunIds = params.entries.map((entry) => entry.subagent.runId).toSorted();
+        const submittedRunIdSet = new Set(submittedRunIds);
+        const firstWake = params.entries[0]?.expectedWake;
+        const frozenBatchRunIds = firstWake?.batchRunIds?.length
+          ? firstWake.batchRunIds.toSorted()
+          : undefined;
+        for (const expected of params.entries) {
+          const declaredBatchRunIds = expected.expectedWake.batchRunIds?.length
+            ? expected.expectedWake.batchRunIds.toSorted()
+            : undefined;
+          if (
+            !isDeepStrictEqual(declaredBatchRunIds, frozenBatchRunIds) ||
+            (frozenBatchRunIds && !frozenBatchRunIds.includes(expected.subagent.runId))
+          ) {
+            rejectedRunId = expected.subagent.runId;
+            throw ownershipChanged;
+          }
+        }
+        // Frozen cohorts can retain IDs after a row retires. A still-present
+        // same-generation wake remains an owner and may not be omitted.
+        for (const declaredRunId of frozenBatchRunIds ?? []) {
+          if (submittedRunIdSet.has(declaredRunId)) {
+            continue;
+          }
+          const declaredMember = readSubagentRun(database, declaredRunId);
+          if (declaredMember?.requesterSettleWake?.rearmGeneration === firstWake?.rearmGeneration) {
+            rejectedRunId = declaredRunId;
+            throw ownershipChanged;
+          }
+        }
         for (const expected of params.entries) {
           const generation = expected.subagent.delivery?.generation ?? 1;
           let subagent = readSubagentRun(database, expected.subagent.runId);
-          const expectedBatchRunIds = (
-            expected.expectedWake.batchRunIds ?? [expected.subagent.runId]
-          ).toSorted();
           const deliveryNeedsSettlement =
             subagent?.expectsCompletionMessage === true &&
             ["pending", "in_progress", "failed"].includes(subagent.delivery?.status ?? "pending");
@@ -432,7 +458,6 @@ export function settleRejectedRequesterSettleWakeBatch(params: {
             (expected.settleDelivery && subagent.expectsCompletionMessage !== true) ||
             (subagent.delivery?.generation ?? 1) !== generation ||
             deliveryNeedsSettlement !== expected.settleDelivery ||
-            !isDeepStrictEqual(expectedBatchRunIds, batchRunIds) ||
             !isDeepStrictEqual(subagent.requesterSettleWake, expected.expectedWake)
           ) {
             rejectedRunId = expected.subagent.runId;

--- a/src/agents/subagents/completion/subagent-completion-admission.store.ts
+++ b/src/agents/subagents/completion/subagent-completion-admission.store.ts
@@ -1,8 +1,16 @@
+import { isDeepStrictEqual } from "node:util";
 import {
   bindDeliveryQueueEntry,
   loadDeliveryQueueEntryInDatabase,
+  loadDeliveryQueueEntryStateInDatabase,
+  loadUnfinishedDeliveryQueueEntryStatesInDatabase,
+  terminalizeBoundDeliveryQueueEntry,
   upsertBoundDeliveryQueueEntryInDatabase,
 } from "../../../infra/delivery-queue-sqlite-bound.js";
+import {
+  inferDeliveryQueueFailureRetention,
+  projectDeliveryQueueTerminalEntry,
+} from "../../../infra/delivery-queue-sqlite.types.js";
 import { scheduleSessionDelivery } from "../../../infra/session-delivery-queue-runtime.js";
 import {
   prepareClaimedSessionDelivery,
@@ -34,10 +42,14 @@ import {
 import { subagentRuns } from "../registry/subagent-registry-memory.js";
 import {
   bindSubagentRunRecord,
+  deleteSubagentRunRowInDatabase,
   readSubagentRun,
   upsertSubagentRunRowInDatabase,
 } from "../registry/subagent-registry.store.sqlite.js";
-import type { SubagentRunRecord } from "../registry/subagent-registry.types.js";
+import type {
+  RequesterSettleWakeState,
+  SubagentRunRecord,
+} from "../registry/subagent-registry.types.js";
 
 export const SUSPENDED_RETENTION_MS = 7 * 24 * 60 * 60_000;
 
@@ -56,7 +68,7 @@ function invokeSynchronousHook(hook: (() => unknown) | undefined): void {
   }
 }
 
-export function publishCommittedRecords(subagent: SubagentRunRecord, task: TaskRecord): void {
+function publishCommittedSubagentRecord(subagent: SubagentRunRecord): void {
   const live = subagentRuns.get(subagent.runId);
   if (live) {
     for (const key of Object.keys(live)) {
@@ -66,6 +78,10 @@ export function publishCommittedRecords(subagent: SubagentRunRecord, task: TaskR
   } else {
     subagentRuns.set(subagent.runId, subagent);
   }
+}
+
+export function publishCommittedRecords(subagent: SubagentRunRecord, task: TaskRecord): void {
+  publishCommittedSubagentRecord(subagent);
   publishTaskRecordAfterAtomicStore(task);
 }
 
@@ -88,6 +104,82 @@ function assertCorrelatedEntry(params: {
   ) {
     throw new Error("subagent completion admission records do not share one owner generation");
   }
+}
+
+function terminalizeOwnedCompletionQueue(params: {
+  database: OpenClawStateDatabase;
+  subagent: SubagentRunRecord;
+  task: TaskRecord;
+  generation: number;
+  now: number;
+}): boolean {
+  const queueId = params.subagent.delivery?.queueId;
+  const loadedEntries = queueId
+    ? [
+        loadDeliveryQueueEntryStateInDatabase(
+          params.database,
+          SESSION_DELIVERY_QUEUE_NAME,
+          queueId,
+        ),
+      ].filter((entry) => entry !== null)
+    : loadUnfinishedDeliveryQueueEntryStatesInDatabase(
+        params.database,
+        SESSION_DELIVERY_QUEUE_NAME,
+      );
+  // A missing physical row cannot replay. Historical logical owners can still
+  // be closed using their exact task, run, generation, and wake fences.
+  if (loadedEntries.length === 0) {
+    return true;
+  }
+  for (const loaded of loadedEntries) {
+    // SAFETY: The session queue stores QueuedSessionDelivery; kind and owner are checked below.
+    const queued = loaded.entry as QueuedSessionDelivery;
+    const owner = queued.kind === "agentTurn" ? queued.owner : undefined;
+    const ownsQueue =
+      owner?.kind === "subagent_completion" &&
+      owner.runId === params.subagent.runId &&
+      owner.taskId === params.task.taskId &&
+      owner.generation === params.generation &&
+      owner.deadlineAt === params.subagent.delivery?.deadlineAt;
+    if (!ownsQueue) {
+      if (queueId) {
+        return false;
+      }
+      continue;
+    }
+    if (
+      loaded.status === "completed" ||
+      (loaded.status === "failed" && loaded.entry.recoveryState !== "settlement_pending")
+    ) {
+      continue;
+    }
+    const retention = inferDeliveryQueueFailureRetention(
+      queued,
+      loaded.id,
+      SESSION_DELIVERY_QUEUE_NAME,
+    );
+    const terminalEntry = retention
+      ? {
+          ...projectDeliveryQueueTerminalEntry(queued, params.now, "failed", retention),
+          kind: "agentTurn" as const,
+          owner,
+        }
+      : undefined;
+    if (
+      !terminalizeBoundDeliveryQueueEntry(
+        params.database.db,
+        SESSION_DELIVERY_QUEUE_NAME,
+        loaded.id,
+        loaded.entryJson,
+        terminalEntry,
+        params.now,
+        loaded.status,
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**
@@ -173,6 +265,8 @@ export function blockSubagentCompletionDelivery(params: {
   reason: string;
   suspendedReason?: "expiry" | "permanent_failure";
   disposition?: NonNullable<SubagentRunRecord["delivery"]>["disposition"];
+  allowMissingHistoricalOutcome?: boolean;
+  terminalizeQueueOwner?: boolean;
   databaseOptions?: OpenClawStateDatabaseOptions;
 }): boolean {
   const generation = params.subagent.delivery?.generation ?? 1;
@@ -191,15 +285,32 @@ export function blockSubagentCompletionDelivery(params: {
     ) {
       return false;
     }
-    const successful = task.status === "succeeded" && subagent.execution.outcome?.status === "ok";
+    // Historical rows written before terminal capture was atomic can have a
+    // canonical terminal task but no producer outcome. The exact run and
+    // delivery generation still fence that task as this completion's owner.
+    const missingHistoricalOutcome =
+      params.allowMissingHistoricalOutcome === true &&
+      subagent.execution.outcome === undefined &&
+      typeof subagent.execution.endedAt === "number";
+    const successful =
+      task.status === "succeeded" &&
+      (subagent.execution.outcome?.status === "ok" || missingHistoricalOutcome);
+    const deliveryAlreadyObserved = task.deliveryStatus === "delivered";
     // A terminal non-success still owns its failed requester wake. Classify the
     // persisted pair; a missing or superseded owner is not permission to settle.
     if (
       !successful &&
       (params.suspendedReason !== undefined ||
         !["cancelled", "failed", "timed_out"].includes(task.status) ||
-        resolveFinalizedSubagentTaskState(subagent)?.status !== task.status ||
+        (!missingHistoricalOutcome &&
+          resolveFinalizedSubagentTaskState(subagent)?.status !== task.status) ||
         !["pending", "in_progress", "failed"].includes(subagent.delivery?.status ?? "pending"))
+    ) {
+      return false;
+    }
+    if (
+      params.terminalizeQueueOwner === true &&
+      !terminalizeOwnedCompletionQueue({ database, subagent, task, generation, now })
     ) {
       return false;
     }
@@ -224,7 +335,7 @@ export function blockSubagentCompletionDelivery(params: {
     } else {
       subagent.suppressCompletionDelivery = true;
     }
-    if (successful) {
+    if (successful && !deliveryAlreadyObserved) {
       const terminal = resolveRequiredCompletionDeliveryFailureTerminalResult(params.reason);
       Object.assign(task, {
         ...terminal,
@@ -233,11 +344,15 @@ export function blockSubagentCompletionDelivery(params: {
       });
     }
     Object.assign(task, {
-      deliveryStatus: "failed" as const,
+      // A stale logical completion must not revoke delivery already observed
+      // by the canonical task owner.
+      deliveryStatus: deliveryAlreadyObserved ? ("delivered" as const) : ("failed" as const),
       lastEventAt: now,
     });
     const text =
-      successful && task.notifyPolicy !== "silent" ? formatTaskBlockedFollowupMessage(task) : null;
+      successful && !deliveryAlreadyObserved && task.notifyPolicy !== "silent"
+        ? formatTaskBlockedFollowupMessage(task)
+        : null;
     const queued = text
       ? prepareClaimedSessionDelivery(
           {
@@ -275,4 +390,98 @@ export function blockSubagentCompletionDelivery(params: {
     });
     return true;
   }, params.databaseOptions);
+}
+
+export type RejectedRequesterSettleWakeBatchEntry = {
+  subagent: SubagentRunRecord;
+  taskId?: string;
+  expectedWake: RequesterSettleWakeState;
+  settleDelivery: boolean;
+  retireAfterSettle: boolean;
+  retireAfterRequesterTurn: boolean;
+};
+
+/** Settles a rejected requester wake without exposing a half-cleared durable batch. */
+export function settleRejectedRequesterSettleWakeBatch(params: {
+  entries: readonly RejectedRequesterSettleWakeBatchEntry[];
+  reason: string;
+  disposition?: NonNullable<SubagentRunRecord["delivery"]>["disposition"];
+  databaseOptions?: OpenClawStateDatabaseOptions;
+}): { settled: true } | { settled: false; runId: string } {
+  let rejectedRunId: string | undefined;
+  const ownershipChanged = new Error("requester settle batch ownership changed");
+  try {
+    runOpenClawStateWriteTransaction(
+      (database) => {
+        const batchRunIds = params.entries.map((entry) => entry.subagent.runId).toSorted();
+        for (const expected of params.entries) {
+          const generation = expected.subagent.delivery?.generation ?? 1;
+          let subagent = readSubagentRun(database, expected.subagent.runId);
+          const expectedBatchRunIds = (
+            expected.expectedWake.batchRunIds ?? [expected.subagent.runId]
+          ).toSorted();
+          const deliveryNeedsSettlement =
+            subagent?.expectsCompletionMessage === true &&
+            ["pending", "in_progress", "failed"].includes(subagent.delivery?.status ?? "pending");
+          if (
+            !subagent ||
+            subagent.execution.status !== "terminal" ||
+            (expected.settleDelivery && subagent.expectsCompletionMessage !== true) ||
+            (subagent.delivery?.generation ?? 1) !== generation ||
+            deliveryNeedsSettlement !== expected.settleDelivery ||
+            !isDeepStrictEqual(expectedBatchRunIds, batchRunIds) ||
+            !isDeepStrictEqual(subagent.requesterSettleWake, expected.expectedWake)
+          ) {
+            rejectedRunId = expected.subagent.runId;
+            throw ownershipChanged;
+          }
+          if (expected.settleDelivery) {
+            if (
+              !expected.taskId ||
+              !blockSubagentCompletionDelivery({
+                subagent,
+                taskId: expected.taskId,
+                reason: params.reason,
+                disposition: params.disposition,
+                allowMissingHistoricalOutcome: true,
+                terminalizeQueueOwner: true,
+                databaseOptions: { ...params.databaseOptions, database },
+              })
+            ) {
+              rejectedRunId = expected.subagent.runId;
+              throw ownershipChanged;
+            }
+            subagent = readSubagentRun(database, expected.subagent.runId);
+            if (
+              !subagent ||
+              !isDeepStrictEqual(subagent.requesterSettleWake, expected.expectedWake)
+            ) {
+              rejectedRunId = expected.subagent.runId;
+              throw ownershipChanged;
+            }
+          }
+          if (expected.retireAfterSettle) {
+            deleteSubagentRunRowInDatabase(database, subagent.runId);
+            continue;
+          }
+          subagent.requesterSettleWake = undefined;
+          subagent.retireAfterRequesterTurn = expected.retireAfterRequesterTurn
+            ? true
+            : subagent.retireAfterRequesterTurn;
+          upsertSubagentRunRowInDatabase(database, bindSubagentRunRecord(subagent));
+          deferSqlitePostCommitPublication(database.db, () =>
+            publishCommittedSubagentRecord(subagent),
+          );
+        }
+      },
+      params.databaseOptions,
+      { operationLabel: "requester settle wake rejection" },
+    );
+  } catch (error) {
+    if (error === ownershipChanged && rejectedRunId) {
+      return { settled: false, runId: rejectedRunId };
+    }
+    throw error;
+  }
+  return { settled: true };
 }

--- a/src/agents/subagents/completion/subagent-completion-admission.store.ts
+++ b/src/agents/subagents/completion/subagent-completion-admission.store.ts
@@ -296,6 +296,9 @@ export function blockSubagentCompletionDelivery(params: {
       task.status === "succeeded" &&
       (subagent.execution.outcome?.status === "ok" || missingHistoricalOutcome);
     const deliveryAlreadyObserved = task.deliveryStatus === "delivered";
+    const deliveryProjectionAlreadySettled =
+      deliveryAlreadyObserved ||
+      (task.deliveryStatus === "failed" && task.terminalOutcome === "blocked");
     // A terminal non-success still owns its failed requester wake. Classify the
     // persisted pair; a missing or superseded owner is not permission to settle.
     if (
@@ -335,7 +338,7 @@ export function blockSubagentCompletionDelivery(params: {
     } else {
       subagent.suppressCompletionDelivery = true;
     }
-    if (successful && !deliveryAlreadyObserved) {
+    if (successful && !deliveryProjectionAlreadySettled) {
       const terminal = resolveRequiredCompletionDeliveryFailureTerminalResult(params.reason);
       Object.assign(task, {
         ...terminal,
@@ -350,7 +353,7 @@ export function blockSubagentCompletionDelivery(params: {
       lastEventAt: now,
     });
     const text =
-      successful && !deliveryAlreadyObserved && task.notifyPolicy !== "silent"
+      successful && !deliveryProjectionAlreadySettled && task.notifyPolicy !== "silent"
         ? formatTaskBlockedFollowupMessage(task)
         : null;
     const queued = text

--- a/src/agents/subagents/completion/subagent-completion-admission.store.ts
+++ b/src/agents/subagents/completion/subagent-completion-admission.store.ts
@@ -441,7 +441,8 @@ export function settleRejectedRequesterSettleWakeBatch(params: {
             continue;
           }
           const declaredMember = readSubagentRun(database, declaredRunId);
-          if (declaredMember?.requesterSettleWake?.rearmGeneration === firstWake?.rearmGeneration) {
+          const declaredWake = declaredMember?.requesterSettleWake;
+          if (declaredWake && declaredWake.rearmGeneration === firstWake?.rearmGeneration) {
             rejectedRunId = declaredRunId;
             throw ownershipChanged;
           }

--- a/src/agents/subagents/completion/subagent-completion-requester-settle.store.test.ts
+++ b/src/agents/subagents/completion/subagent-completion-requester-settle.store.test.ts
@@ -293,6 +293,49 @@ describe("atomic rejected requester-settle storage", () => {
     }
   });
 
+  it("does not enqueue a second blocked alert for a legacy successful settlement", async () => {
+    useDefaultDatabase();
+    const input = armRequesterWake(records());
+    admitSubagentCompletionDelivery({
+      ...input,
+      databaseOptions: { database },
+    });
+    subagentRuns.set(input.subagent.runId, input.subagent);
+    ensureTaskRegistryReady();
+    publishTaskRecordAfterAtomicStore(input.task);
+    expect(
+      blockSubagentCompletionDelivery({
+        subagent: input.subagent,
+        taskId: input.task.taskId,
+        reason: "legacy partial settlement",
+        databaseOptions: { database },
+      }),
+    ).toBe(true);
+    const blockedAlertCount = () =>
+      database.db
+        .prepare(
+          "SELECT COUNT(*) AS count FROM delivery_queue_entries WHERE queue_name = 'session' AND entry_kind = 'systemEvent'",
+        )
+        .get();
+    expect(blockedAlertCount()).toEqual({ count: 1 });
+
+    const driver = requesterWakeDriver([input]);
+    try {
+      await driver.run();
+      expect(blockedAlertCount()).toEqual({ count: 1 });
+      reopenOwners();
+      expect(subagentRuns.get(input.subagent.runId)?.requesterSettleWake).toBeUndefined();
+      expect(getTaskById(input.task.taskId)).toMatchObject({
+        status: "succeeded",
+        deliveryStatus: "failed",
+        terminalOutcome: "blocked",
+        error: "legacy partial settlement",
+      });
+    } finally {
+      driver.controller.clearScheduledResumeTimers();
+    }
+  });
+
   it("rolls the whole rejected batch back when a later generation changed", async () => {
     useDefaultDatabase();
     const first = failedRecords("failed", { status: "error" });

--- a/src/agents/subagents/completion/subagent-completion-requester-settle.store.test.ts
+++ b/src/agents/subagents/completion/subagent-completion-requester-settle.store.test.ts
@@ -1,0 +1,338 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { recoverPendingSessionDeliveries } from "../../../infra/session-delivery-queue-recovery.js";
+import { resolvePreferredOpenClawTmpDir } from "../../../infra/tmp-openclaw-dir.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+  type OpenClawStateDatabase,
+} from "../../../state/openclaw-state-db.js";
+import { ensureTaskRegistryReady, getTaskById } from "../../../tasks/runtime-internal.js";
+import { publishTaskRecordAfterAtomicStore } from "../../../tasks/task-registry.js";
+import { resetTaskRegistryForTests } from "../../../tasks/task-runtime.test-helpers.js";
+import { subagentRuns } from "../registry/subagent-registry-memory.js";
+import { loadSubagentRegistryFromSqlite } from "../registry/subagent-registry.store.sqlite.js";
+import {
+  admitSubagentCompletionDelivery,
+  blockSubagentCompletionDelivery,
+  settleSubagentCompletionDelivery,
+} from "./subagent-completion-admission.store.js";
+import {
+  armRequesterWake,
+  failedRecords,
+  records,
+  requesterWakeDriver,
+} from "./subagent-completion-admission.test-helpers.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("atomic rejected requester-settle storage", () => {
+  let tempDir: string;
+  let database: OpenClawStateDatabase;
+
+  beforeEach(() => {
+    tempDir = tempDirs.make("openclaw-requester-settle-", resolvePreferredOpenClawTmpDir());
+    database = openOpenClawStateDatabase({ path: path.join(tempDir, "state.sqlite") });
+  });
+
+  afterEach(() => {
+    subagentRuns.clear();
+    resetTaskRegistryForTests({ persist: false });
+    closeOpenClawStateDatabaseForTest();
+    vi.unstubAllEnvs();
+  });
+
+  function persistOwner(input = records()) {
+    settleSubagentCompletionDelivery({
+      subagent: input.subagent,
+      task: input.task,
+      databaseOptions: { database },
+    });
+    subagentRuns.set(input.subagent.runId, input.subagent);
+    ensureTaskRegistryReady();
+    publishTaskRecordAfterAtomicStore(input.task);
+    return input;
+  }
+
+  function useDefaultDatabase(): void {
+    closeOpenClawStateDatabaseForTest();
+    vi.stubEnv("OPENCLAW_STATE_DIR", tempDir);
+    database = openOpenClawStateDatabase();
+  }
+
+  function reopenOwners(): void {
+    closeOpenClawStateDatabaseForTest();
+    subagentRuns.clear();
+    resetTaskRegistryForTests({ persist: false });
+    database = openOpenClawStateDatabase();
+    for (const [runId, entry] of loadSubagentRegistryFromSqlite()) {
+      subagentRuns.set(runId, entry);
+    }
+    ensureTaskRegistryReady();
+  }
+
+  it("preserves an already-delivered cancelled task while closing its stale wake", async () => {
+    useDefaultDatabase();
+    const input = failedRecords("cancelled", { status: "error" });
+    input.task.deliveryStatus = "delivered";
+    persistOwner(input);
+    const driver = requesterWakeDriver([input]);
+    try {
+      await driver.run();
+      expect(driver.warn).not.toHaveBeenCalledWith(
+        "failed to persist requester settle wake rejection",
+        expect.any(Object),
+      );
+
+      reopenOwners();
+      expect(subagentRuns.get(input.subagent.runId)).toMatchObject({
+        delivery: { status: "failed", lastError: "requester unavailable" },
+        suppressCompletionDelivery: true,
+      });
+      expect(subagentRuns.get(input.subagent.runId)?.requesterSettleWake).toBeUndefined();
+      expect(getTaskById(input.task.taskId)).toMatchObject({
+        status: "cancelled",
+        deliveryStatus: "delivered",
+        error: "original child failure",
+      });
+    } finally {
+      driver.controller.clearScheduledResumeTimers();
+    }
+  });
+
+  it("preserves an already-delivered succeeded task without a blocked alert", async () => {
+    useDefaultDatabase();
+    const input = armRequesterWake(records());
+    input.task.deliveryStatus = "delivered";
+    persistOwner(input);
+    const driver = requesterWakeDriver([input]);
+    try {
+      await driver.run();
+
+      reopenOwners();
+      expect(subagentRuns.get(input.subagent.runId)?.requesterSettleWake).toBeUndefined();
+      expect(getTaskById(input.task.taskId)).toMatchObject({
+        status: "succeeded",
+        deliveryStatus: "delivered",
+        terminalOutcome: "succeeded",
+      });
+      expect(getTaskById(input.task.taskId)?.error).toBeUndefined();
+      expect(
+        database.db.prepare("SELECT COUNT(*) AS count FROM delivery_queue_entries").get(),
+      ).toEqual({ count: 0 });
+    } finally {
+      driver.controller.clearScheduledResumeTimers();
+    }
+  });
+
+  it("settles a historical succeeded task whose subagent outcome is missing", async () => {
+    useDefaultDatabase();
+    const input = armRequesterWake(records());
+    delete input.subagent.execution.outcome;
+    input.subagent.pauseReason = "sessions_yield";
+    const originalExecution = structuredClone(input.subagent.execution);
+    persistOwner(input);
+    const driver = requesterWakeDriver([input]);
+    try {
+      await driver.run();
+      expect(driver.warn).not.toHaveBeenCalledWith(
+        "failed to persist requester settle wake rejection",
+        expect.any(Object),
+      );
+
+      reopenOwners();
+      expect(subagentRuns.get(input.subagent.runId)?.requesterSettleWake).toBeUndefined();
+      expect(subagentRuns.get(input.subagent.runId)?.execution).toEqual(originalExecution);
+      expect(getTaskById(input.task.taskId)).toMatchObject({
+        status: "succeeded",
+        deliveryStatus: "failed",
+        terminalOutcome: "blocked",
+        error: "requester unavailable",
+      });
+    } finally {
+      driver.controller.clearScheduledResumeTimers();
+    }
+  });
+
+  it("clears a rejected wake without a completion-message delivery owner", async () => {
+    useDefaultDatabase();
+    const input = armRequesterWake(records());
+    input.subagent.expectsCompletionMessage = false;
+    input.subagent.delivery = { status: "not_required" };
+    persistOwner(input);
+    const driver = requesterWakeDriver([input]);
+    try {
+      await driver.run();
+      expect(driver.warn).not.toHaveBeenCalledWith(
+        "failed to persist requester settle wake rejection",
+        expect.any(Object),
+      );
+
+      reopenOwners();
+      expect(subagentRuns.get(input.subagent.runId)?.requesterSettleWake).toBeUndefined();
+      expect(getTaskById(input.task.taskId)).toMatchObject({
+        status: "succeeded",
+        deliveryStatus: "session_queued",
+        terminalOutcome: "succeeded",
+      });
+    } finally {
+      driver.controller.clearScheduledResumeTimers();
+    }
+  });
+
+  it("rolls delivery settlement back when clearing the durable wake fails", async () => {
+    useDefaultDatabase();
+    const input = persistOwner(failedRecords("cancelled", { status: "error" }));
+    const before = structuredClone(input);
+    database.db.exec(`
+      CREATE TEMP TRIGGER reject_requester_wake_clear
+      BEFORE UPDATE ON subagent_runs
+      WHEN json_extract(OLD.payload_json, '$.requesterSettleWake.status') IS NOT NULL
+        AND json_extract(NEW.payload_json, '$.requesterSettleWake') IS NULL
+      BEGIN
+        SELECT RAISE(ABORT, 'cut:requester-wake-clear');
+      END;
+    `);
+    const driver = requesterWakeDriver([input]);
+    try {
+      await driver.run();
+      expect(driver.warn).toHaveBeenCalledWith(
+        "failed to persist requester settle wake rejection",
+        expect.objectContaining({
+          error: expect.objectContaining({
+            message: expect.stringContaining("cut:requester-wake-clear"),
+          }),
+        }),
+      );
+
+      database.db.exec("DROP TRIGGER reject_requester_wake_clear");
+      reopenOwners();
+      expect(subagentRuns.get(input.subagent.runId)).toEqual(before.subagent);
+      expect(getTaskById(input.task.taskId)).toMatchObject(before.task);
+    } finally {
+      driver.controller.clearScheduledResumeTimers();
+    }
+  });
+
+  it("terminalizes the owned physical queue with the rejected wake", async () => {
+    useDefaultDatabase();
+    const input = failedRecords("failed", { status: "error" });
+    admitSubagentCompletionDelivery({
+      ...input,
+      databaseOptions: { database },
+    });
+    subagentRuns.set(input.subagent.runId, input.subagent);
+    ensureTaskRegistryReady();
+    publishTaskRecordAfterAtomicStore(input.task);
+    const driver = requesterWakeDriver([input]);
+    try {
+      await driver.run();
+      expect(driver.warn).not.toHaveBeenCalledWith(
+        "failed to persist requester settle wake rejection",
+        expect.any(Object),
+      );
+      expect(
+        database.db
+          .prepare(
+            "SELECT status, recovery_state FROM delivery_queue_entries WHERE queue_name = 'session' AND id = ?",
+          )
+          .get(input.queueEntry.id),
+      ).toEqual({ status: "failed", recovery_state: "completed_permanent" });
+
+      const deliver = vi.fn(async () => {});
+      await expect(
+        recoverPendingSessionDeliveries({
+          deliver,
+          log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        }),
+      ).resolves.toMatchObject({ recovered: 0, failed: 0 });
+      expect(deliver).not.toHaveBeenCalled();
+    } finally {
+      driver.controller.clearScheduledResumeTimers();
+    }
+  });
+
+  it("reconciles a legacy failed delivery whose physical queue is still pending", async () => {
+    useDefaultDatabase();
+    const input = failedRecords("failed", { status: "error" });
+    admitSubagentCompletionDelivery({
+      ...input,
+      databaseOptions: { database },
+    });
+    subagentRuns.set(input.subagent.runId, input.subagent);
+    ensureTaskRegistryReady();
+    publishTaskRecordAfterAtomicStore(input.task);
+    expect(
+      blockSubagentCompletionDelivery({
+        subagent: input.subagent,
+        taskId: input.task.taskId,
+        reason: "legacy partial settlement",
+        databaseOptions: { database },
+      }),
+    ).toBe(true);
+    expect(input.subagent).toMatchObject({
+      delivery: { status: "failed" },
+      requesterSettleWake: { status: "pending" },
+    });
+
+    const driver = requesterWakeDriver([input]);
+    try {
+      await driver.run();
+      expect(
+        database.db
+          .prepare(
+            "SELECT status, recovery_state FROM delivery_queue_entries WHERE queue_name = 'session' AND id = ?",
+          )
+          .get(input.queueEntry.id),
+      ).toEqual({ status: "failed", recovery_state: "completed_permanent" });
+      reopenOwners();
+      expect(subagentRuns.get(input.subagent.runId)?.requesterSettleWake).toBeUndefined();
+    } finally {
+      driver.controller.clearScheduledResumeTimers();
+    }
+  });
+
+  it("rolls the whole rejected batch back when a later generation changed", async () => {
+    useDefaultDatabase();
+    const first = failedRecords("failed", { status: "error" });
+    const second = failedRecords("timed_out", { status: "timeout" });
+    second.task.taskId = "task-completion-second";
+    second.task.runId = "task-run-second";
+    second.subagent.runId = "completion-run-second";
+    second.subagent.taskRunId = second.task.runId;
+    const batchRunIds = [first.subagent.runId, second.subagent.runId];
+    armRequesterWake(first, batchRunIds);
+    armRequesterWake(second, batchRunIds);
+    persistOwner(first);
+    persistOwner(second);
+    const firstBefore = structuredClone(first);
+    const durableSecond = structuredClone(second);
+    durableSecond.subagent.delivery!.generation = 2;
+    settleSubagentCompletionDelivery({
+      subagent: durableSecond.subagent,
+      task: durableSecond.task,
+      databaseOptions: { database },
+    });
+
+    const driver = requesterWakeDriver([first, second]);
+    try {
+      await driver.run();
+      expect(driver.warn).toHaveBeenCalledWith(
+        "failed to persist requester settle wake rejection",
+        expect.objectContaining({
+          error: expect.objectContaining({
+            message: expect.stringContaining(second.subagent.runId),
+          }),
+        }),
+      );
+
+      reopenOwners();
+      expect(subagentRuns.get(first.subagent.runId)).toEqual(firstBefore.subagent);
+      expect(getTaskById(first.task.taskId)).toMatchObject(firstBefore.task);
+      expect(subagentRuns.get(second.subagent.runId)).toEqual(durableSecond.subagent);
+    } finally {
+      driver.controller.clearScheduledResumeTimers();
+    }
+  });
+});

--- a/src/agents/subagents/completion/subagent-completion-requester-settle.store.test.ts
+++ b/src/agents/subagents/completion/subagent-completion-requester-settle.store.test.ts
@@ -340,6 +340,7 @@ describe("atomic rejected requester-settle storage", () => {
     useDefaultDatabase();
     const input = failedRecords("failed", { status: "error" });
     armRequesterWake(input, [input.subagent.runId, "retired-run"]);
+    delete input.subagent.requesterSettleWake!.rearmGeneration;
     persistOwner(input);
     const driver = requesterWakeDriver([input]);
     try {
@@ -360,6 +361,42 @@ describe("atomic rejected requester-settle storage", () => {
     }
   });
 
+  it("settles an unnumbered frozen owner after another member cleared its wake", async () => {
+    useDefaultDatabase();
+    const first = failedRecords("failed", { status: "error" });
+    const second = failedRecords("timed_out", { status: "timeout" });
+    second.task.taskId = "task-completion-cleared";
+    second.task.runId = "task-run-cleared";
+    second.subagent.runId = "completion-run-cleared";
+    second.subagent.taskRunId = second.task.runId;
+    const batchRunIds = [first.subagent.runId, second.subagent.runId];
+    armRequesterWake(first, batchRunIds);
+    delete first.subagent.requesterSettleWake!.rearmGeneration;
+    second.subagent.requesterSettleWake = undefined;
+    persistOwner(first);
+    persistOwner(second);
+    subagentRuns.delete(second.subagent.runId);
+
+    const driver = requesterWakeDriver([first]);
+    try {
+      await driver.run();
+      expect(driver.warn).not.toHaveBeenCalledWith(
+        "failed to persist requester settle wake rejection",
+        expect.any(Object),
+      );
+      reopenOwners();
+      expect(subagentRuns.get(first.subagent.runId)?.requesterSettleWake).toBeUndefined();
+      expect(subagentRuns.get(second.subagent.runId)?.requesterSettleWake).toBeUndefined();
+      expect(getTaskById(first.task.taskId)).toMatchObject({
+        status: "failed",
+        deliveryStatus: "failed",
+        error: "original child failure",
+      });
+    } finally {
+      driver.controller.clearScheduledResumeTimers();
+    }
+  });
+
   it("rejects a frozen batch while an omitted member still owns its wake", async () => {
     useDefaultDatabase();
     const first = failedRecords("failed", { status: "error" });
@@ -371,6 +408,8 @@ describe("atomic rejected requester-settle storage", () => {
     const batchRunIds = [first.subagent.runId, second.subagent.runId];
     armRequesterWake(first, batchRunIds);
     armRequesterWake(second, batchRunIds);
+    delete first.subagent.requesterSettleWake!.rearmGeneration;
+    delete second.subagent.requesterSettleWake!.rearmGeneration;
     persistOwner(first);
     persistOwner(second);
     const firstBefore = structuredClone(first);

--- a/src/agents/subagents/completion/subagent-completion-requester-settle.store.test.ts
+++ b/src/agents/subagents/completion/subagent-completion-requester-settle.store.test.ts
@@ -336,6 +336,69 @@ describe("atomic rejected requester-settle storage", () => {
     }
   });
 
+  it("settles a surviving frozen owner after another batch member retired", async () => {
+    useDefaultDatabase();
+    const input = failedRecords("failed", { status: "error" });
+    armRequesterWake(input, [input.subagent.runId, "retired-run"]);
+    persistOwner(input);
+    const driver = requesterWakeDriver([input]);
+    try {
+      await driver.run();
+      expect(driver.warn).not.toHaveBeenCalledWith(
+        "failed to persist requester settle wake rejection",
+        expect.any(Object),
+      );
+      reopenOwners();
+      expect(subagentRuns.get(input.subagent.runId)?.requesterSettleWake).toBeUndefined();
+      expect(getTaskById(input.task.taskId)).toMatchObject({
+        status: "failed",
+        deliveryStatus: "failed",
+        error: "original child failure",
+      });
+    } finally {
+      driver.controller.clearScheduledResumeTimers();
+    }
+  });
+
+  it("rejects a frozen batch while an omitted member still owns its wake", async () => {
+    useDefaultDatabase();
+    const first = failedRecords("failed", { status: "error" });
+    const second = failedRecords("timed_out", { status: "timeout" });
+    second.task.taskId = "task-completion-omitted";
+    second.task.runId = "task-run-omitted";
+    second.subagent.runId = "completion-run-omitted";
+    second.subagent.taskRunId = second.task.runId;
+    const batchRunIds = [first.subagent.runId, second.subagent.runId];
+    armRequesterWake(first, batchRunIds);
+    armRequesterWake(second, batchRunIds);
+    persistOwner(first);
+    persistOwner(second);
+    const firstBefore = structuredClone(first);
+    const secondBefore = structuredClone(second);
+    subagentRuns.delete(second.subagent.runId);
+
+    const driver = requesterWakeDriver([first]);
+    try {
+      await driver.run();
+      expect(driver.warn).toHaveBeenCalledWith(
+        "failed to persist requester settle wake rejection",
+        expect.objectContaining({
+          error: expect.objectContaining({
+            message: expect.stringContaining(second.subagent.runId),
+          }),
+        }),
+      );
+
+      reopenOwners();
+      expect(subagentRuns.get(first.subagent.runId)).toEqual(firstBefore.subagent);
+      expect(getTaskById(first.task.taskId)).toMatchObject(firstBefore.task);
+      expect(subagentRuns.get(second.subagent.runId)).toEqual(secondBefore.subagent);
+      expect(getTaskById(second.task.taskId)).toMatchObject(secondBefore.task);
+    } finally {
+      driver.controller.clearScheduledResumeTimers();
+    }
+  });
+
   it("rolls the whole rejected batch back when a later generation changed", async () => {
     useDefaultDatabase();
     const first = failedRecords("failed", { status: "error" });

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
@@ -11,7 +11,10 @@ import { defaultRuntime } from "../../../runtime.js";
 import { retireSessionMcpRuntimeForSessionKey } from "../../agent-bundle-mcp-tools.js";
 import { removeInternalSessionEffectsSession } from "../../internal-session-effects.js";
 import type { SubagentAnnounceDeliveryResult } from "../announce/subagent-announce-dispatch.js";
-import { blockSubagentCompletionDelivery } from "../completion/subagent-completion-admission.store.js";
+import {
+  blockSubagentCompletionDelivery,
+  settleRejectedRequesterSettleWakeBatch,
+} from "../completion/subagent-completion-admission.store.js";
 import { ensureDeliveryState } from "./subagent-delivery-state.js";
 import { SUBAGENT_ENDED_REASON_KILLED } from "./subagent-lifecycle-events.js";
 import { shouldSuppressSubagentRecoverySessionEffects } from "./subagent-recovery-state.js";
@@ -106,6 +109,66 @@ const completeRequesterSettleWakeBatch = (
     return;
   }
   const requesterSessionKeys = new Set(entries.map((entry) => entry.requesterSessionKey));
+  if (outcome?.delivered === false) {
+    const error = outcome.error ?? outcome.reason ?? "requester settle wake failed";
+    const batchEntries = entries.flatMap((entry) => {
+      const expectedWake = entry.requesterSettleWake;
+      if (!expectedWake) {
+        return [];
+      }
+      const settleDelivery =
+        entry.expectsCompletionMessage === true &&
+        ["pending", "in_progress", "failed"].includes(entry.delivery?.status ?? "pending");
+      const retainForRequesterTurn =
+        Boolean(entry.requesterTurnRunId) && entry.expectsCompletionMessage === true;
+      return [
+        {
+          subagent: entry,
+          ...(settleDelivery ? { taskId: params.resolveSubagentTask(entry).task?.taskId } : {}),
+          expectedWake: structuredClone(expectedWake),
+          settleDelivery,
+          retireAfterSettle: !retainForRequesterTurn && expectedWake.retireAfterSettle === true,
+          retireAfterRequesterTurn:
+            retainForRequesterTurn &&
+            (entry.retireAfterRequesterTurn === true || expectedWake.retireAfterSettle === true),
+        },
+      ];
+    });
+    if (batchEntries.length !== entries.length) {
+      throw new Error("requester settle wake owner changed before batch settlement");
+    }
+    const settled = settleRejectedRequesterSettleWakeBatch({
+      entries: batchEntries,
+      reason: error,
+      disposition: outcome.disposition,
+    });
+    if (!settled.settled) {
+      throw new Error(`subagent completion owner changed before settlement: ${settled.runId}`);
+    }
+    for (const batchEntry of batchEntries) {
+      const { runId } = batchEntry.subagent;
+      if (batchEntry.retireAfterSettle) {
+        params.runs.delete(runId);
+        subagentRuns.confirmRetirement(batchEntry.subagent);
+      }
+      const retryTimer = context.getRequesterSettleWakeTimer(runId);
+      if (retryTimer) {
+        clearTimeout(retryTimer.timer);
+        context.deleteRequesterSettleWakeTimer(runId);
+      }
+      if (batchEntry.subagent.requesterSettleWake === undefined || !params.runs.has(runId)) {
+        clearGatewayContextResolver(batchEntry.subagent);
+        params.resumedRuns.delete(runId);
+        params.clearPendingLifecycleError(runId);
+      }
+    }
+    for (const [nextRunId, entry] of params.runs) {
+      if (entry.requesterSettleWake && requesterSessionKeys.has(entry.requesterSessionKey)) {
+        scheduleRequesterSettleWake(context, nextRunId, entry);
+      }
+    }
+    return;
+  }
   const previousStates = entries.map((entry) => ({
     delivery: outcome?.delivered ? entry.delivery : structuredClone(entry.delivery),
     requesterSettleWake: structuredClone(entry.requesterSettleWake),

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -102,6 +102,7 @@ const taskExecutorMocks = vi.hoisted(() => ({
 
 const completionDeliveryMocks = vi.hoisted(() => ({
   blockSubagentCompletionDelivery: vi.fn(),
+  settleRejectedRequesterSettleWakeBatch: vi.fn(),
 }));
 
 function mockBlockedCompletionDeliveryOwner(): void {
@@ -133,6 +134,33 @@ function mockBlockedCompletionDeliveryOwner(): void {
         subagent.suppressCompletionDelivery = true;
       }
       return true;
+    },
+  );
+}
+
+function mockRejectedRequesterSettleWakeBatch(): void {
+  completionDeliveryMocks.settleRejectedRequesterSettleWakeBatch.mockImplementation(
+    ({ entries, reason, disposition }) => {
+      for (const entry of entries) {
+        if (
+          entry.settleDelivery &&
+          !completionDeliveryMocks.blockSubagentCompletionDelivery({
+            subagent: entry.subagent,
+            taskId: entry.taskId ?? "",
+            reason,
+            disposition,
+          })
+        ) {
+          return { settled: false, runId: entry.subagent.runId } as const;
+        }
+      }
+      for (const entry of entries) {
+        entry.subagent.requesterSettleWake = undefined;
+        entry.subagent.retireAfterRequesterTurn = entry.retireAfterRequesterTurn
+          ? true
+          : entry.subagent.retireAfterRequesterTurn;
+      }
+      return { settled: true } as const;
     },
   );
 }
@@ -182,6 +210,8 @@ vi.mock("../completion/subagent-completion-admission.store.js", async (importOri
     typeof import("../completion/subagent-completion-admission.store.js")
   >()),
   blockSubagentCompletionDelivery: completionDeliveryMocks.blockSubagentCompletionDelivery,
+  settleRejectedRequesterSettleWakeBatch:
+    completionDeliveryMocks.settleRejectedRequesterSettleWakeBatch,
 }));
 
 vi.mock("../../../sessions/session-lifecycle-events.js", () => ({
@@ -560,6 +590,7 @@ describe("subagent registry lifecycle hardening", () => {
     taskExecutorMocks.failTaskRunByRunId.mockReset();
     taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId.mockReset();
     mockBlockedCompletionDeliveryOwner();
+    mockRejectedRequesterSettleWakeBatch();
     gatewayMocks.callGateway.mockReset();
     gatewayMocks.callGateway.mockResolvedValue({});
     browserLifecycleCleanupMocks.cleanupBrowserSessionsForLifecycleEnd.mockClear();
@@ -4747,6 +4778,7 @@ describe("subagent registry lifecycle hardening", () => {
 describe("requester settle wake trigger", () => {
   beforeEach(() => {
     mockBlockedCompletionDeliveryOwner();
+    mockRejectedRequesterSettleWakeBatch();
     helperMocks.safeRemoveAttachmentsDir.mockClear();
     helperMocks.logAnnounceGiveUp.mockClear();
     taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId.mockClear();
@@ -5347,7 +5379,7 @@ describe("requester settle wake trigger", () => {
     expect(hasDeliveredTaskStatusUpdate(entry.runId)).toBe(false);
   });
 
-  it("keeps committed blocked state when requester-settle bookkeeping persistence fails", async () => {
+  it("keeps the batch unchanged when atomic requester-settle persistence fails", async () => {
     const entry = createRunEntry({
       endedAt: 4_000,
       expectsCompletionMessage: true,
@@ -5356,10 +5388,8 @@ describe("requester settle wake trigger", () => {
     let settleParams:
       | Parameters<LifecycleControllerParams["maybeWakeRequesterAfterAllChildrenSettled"]>[0]
       | undefined;
-    const persistOrThrow = vi.fn();
     const controller = createLifecycleController({
       entry,
-      persistOrThrow,
       maybeWakeRequesterAfterAllChildrenSettled: vi.fn(async (params) => {
         settleParams = params;
         return false;
@@ -5371,7 +5401,7 @@ describe("requester settle wake trigger", () => {
       terminalReply: { disposition: "empty" },
     });
     await waitForLifecycleState(() => expect(settleParams).toBeDefined());
-    persistOrThrow.mockImplementationOnce(() => {
+    completionDeliveryMocks.settleRejectedRequesterSettleWakeBatch.mockImplementationOnce(() => {
       throw new Error("bookkeeping write failed");
     });
 
@@ -5383,10 +5413,10 @@ describe("requester settle wake trigger", () => {
       }),
     ).toThrow("bookkeeping write failed");
     expect(entry).toMatchObject({
-      delivery: { status: "failed", lastError: "requester settle wake failed" },
-      suppressCompletionDelivery: true,
+      delivery: { status: "pending" },
       requesterSettleWake: { status: "pending", attemptCount: 0, rearmGeneration: 1 },
     });
+    expect(entry.suppressCompletionDelivery).toBeUndefined();
   });
 
   it("retains a delete-mode child after no-wake until its requester turn settles", async () => {

--- a/src/agents/subagents/registry/subagent-registry.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.test.ts
@@ -2353,32 +2353,42 @@ describe("subagent registry seam flow", () => {
 
   it("settles a requester-settle wake rejected before attempt admission", async () => {
     const endedAt = Date.now() - 1_000;
+    const runId = "run-settle-retry";
     mod.addSubagentRunForTests({
-      runId: "run-settle-retry",
+      runId,
       childSessionKey: "agent:main:subagent:settle-retry",
       task: "retry requester settle wake",
       expectsCompletionMessage: true,
       createdAt: endedAt - 1_000,
       endedAt,
       cleanupCompletedAt: endedAt,
+      completion: { required: true },
       delivery: { status: "delivered" },
       requesterSettleWake: { status: "pending", attemptCount: 0 },
     });
-    mocks.maybeWakeRequesterAfterAllChildrenSettled.mockRejectedValueOnce(new Error("sqlite busy"));
+    const entry = expectDefined(mod.getSubagentRunByRunId(runId), "requester settle run");
+    saveSubagentRegistryChangesToSqlite(new Map([[runId, entry]]), [runId]);
+    try {
+      mocks.maybeWakeRequesterAfterAllChildrenSettled.mockRejectedValueOnce(
+        new Error("sqlite busy"),
+      );
 
-    await mod.testing.sweepOnceForTests();
-    await waitForFast(() =>
-      expect(mocks.maybeWakeRequesterAfterAllChildrenSettled).toHaveBeenCalledTimes(1),
-    );
-    await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+      await mod.testing.sweepOnceForTests();
+      await waitForFast(() =>
+        expect(mocks.maybeWakeRequesterAfterAllChildrenSettled).toHaveBeenCalledTimes(1),
+      );
+      await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
 
-    expect(mod.getSubagentRunByRunId("run-settle-retry")).toMatchObject({
-      delivery: { status: "delivered" },
-      requesterSettleWake: undefined,
-    });
+      expect(mod.getSubagentRunByRunId(runId)).toMatchObject({
+        delivery: { status: "delivered" },
+        requesterSettleWake: undefined,
+      });
 
-    await mod.testing.sweepOnceForTests();
-    expect(mocks.maybeWakeRequesterAfterAllChildrenSettled).toHaveBeenCalledTimes(1);
+      await mod.testing.sweepOnceForTests();
+      expect(mocks.maybeWakeRequesterAfterAllChildrenSettled).toHaveBeenCalledTimes(1);
+    } finally {
+      saveSubagentRegistryChangesToSqlite(new Map(), [runId]);
+    }
   });
 
   it("keeps runs active instead of terminally failing on recoverable wait transport errors", async () => {

--- a/src/infra/delivery-queue-sqlite-bound.ts
+++ b/src/infra/delivery-queue-sqlite-bound.ts
@@ -12,6 +12,8 @@ import {
 import { coerceRequiredSqliteNumber as sqliteNumber } from "./sqlite-number.js";
 
 type QueueStatus = "pending" | "failed" | "completed";
+const isQueueStatus = (value: string): value is QueueStatus =>
+  value === "pending" || value === "failed" || value === "completed";
 export type DeliveryQueueReadMode = "pending" | "unfinished" | "all";
 type DeliveryQueueTable = OpenClawStateKyselyDatabase["delivery_queue_entries"];
 const COMPLETED_TOMBSTONE_RETENTION_MS = 30 * 24 * 60 * 60_000;
@@ -46,6 +48,13 @@ type DeliveryQueueSqliteRow = Pick<
   Selectable<DeliveryQueueTable>,
   (typeof deliveryQueueRowColumns)[number]
 >;
+
+export type LoadedDeliveryQueueEntryState = {
+  id: string;
+  entry: DeliveryQueueEntryState;
+  entryJson: string;
+  status: QueueStatus;
+};
 
 type DeliveryQueueRowMetadata = {
   entryKind?: string;
@@ -311,4 +320,43 @@ export function loadDeliveryQueueEntryInDatabase(
   const query = deliveryQueueEntriesQuery(database, [queueName], mode).where("id", "=", id);
   const row = executeSqliteQueryTakeFirstSync(database.db, query);
   return row ? inflateDeliveryQueueRow(row) : null;
+}
+
+/** Reads payload and row status together for owner-fenced cross-table settlement. */
+export function loadDeliveryQueueEntryStateInDatabase(
+  database: OpenClawStateDatabase,
+  queueName: string,
+  id: string,
+): LoadedDeliveryQueueEntryState | null {
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    getNodeSqliteKysely<DeliveryQueueDatabase>(database.db)
+      .selectFrom("delivery_queue_entries")
+      .select([...deliveryQueueRowColumns, "status"])
+      .where("queue_name", "=", queueName)
+      .where("id", "=", id),
+  );
+  if (!row || !isQueueStatus(row.status)) {
+    return null;
+  }
+  const entry = inflateDeliveryQueueRow(row);
+  return entry ? { id: row.id, entry, entryJson: row.entry_json, status: row.status } : null;
+}
+
+/** Lists replayable rows from one queue for owner-fenced cross-table recovery. */
+export function loadUnfinishedDeliveryQueueEntryStatesInDatabase(
+  database: OpenClawStateDatabase,
+  queueName: string,
+): LoadedDeliveryQueueEntryState[] {
+  const rows = executeSqliteQuerySync(
+    database.db,
+    deliveryQueueEntriesQuery(database, [queueName], "unfinished").select("status"),
+  ).rows;
+  return rows.flatMap((row) => {
+    if (!isQueueStatus(row.status)) {
+      return [];
+    }
+    const entry = inflateDeliveryQueueRow(row);
+    return entry ? [{ id: row.id, entry, entryJson: row.entry_json, status: row.status }] : [];
+  });
 }

--- a/test/gateway-restored-requester-settle.e2e.test.ts
+++ b/test/gateway-restored-requester-settle.e2e.test.ts
@@ -2,6 +2,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { admitSubagentCompletionDelivery } from "../src/agents/subagents/completion/subagent-completion-admission.store.js";
 import { writeSubagentSessionEntry } from "../src/agents/subagents/registry/subagent-registry.persistence.test-support.js";
 import {
   loadSubagentRegistryFromSqlite,
@@ -11,8 +12,15 @@ import type { SubagentRunRecord } from "../src/agents/subagents/registry/subagen
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
 import type { SessionsListResult } from "../src/gateway/session-utils.types.js";
 import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
+import { getDeliveryQueueEntryStatus } from "../src/infra/delivery-queue-sqlite.js";
+import {
+  prepareClaimedSessionDelivery,
+  SESSION_DELIVERY_QUEUE_NAME,
+} from "../src/infra/session-delivery-queue-storage.js";
 import type { Deferred } from "../src/shared/deferred.js";
 import { closeOpenClawStateDatabaseForTest } from "../src/state/openclaw-state-db.js";
+import { loadTaskRegistryStateFromSqlite } from "../src/tasks/task-registry.store.sqlite.js";
+import type { TaskRecord } from "../src/tasks/task-registry.types.js";
 import { writeOpenAiResponsesSse } from "./helpers/openai-responses-sse.js";
 import {
   createOpenClawTestInstance,
@@ -213,7 +221,7 @@ describe("Gateway restored requester settlement", () => {
         },
       });
       instances.push(instance);
-      await seedRestoredRequesters(instance, 1, 2);
+      const seeded = await seedPendingRestoredRequester(instance);
 
       await instance.startGateway();
       const client = await connectGatewayClient({
@@ -238,19 +246,16 @@ describe("Gateway restored requester settlement", () => {
           },
           { interval: 50, timeout: 20_000 },
         );
+        await vi.waitFor(() => expectPendingRestoredRequesterSettled(seeded), {
+          interval: 50,
+          timeout: 20_000,
+        });
       } finally {
         await disconnectGatewayClient(client);
         await instance.stopGateway();
       }
 
-      try {
-        expect(
-          loadSubagentRegistryFromSqlite().get("run-gateway-restored-settle-0")
-            ?.requesterSettleWake,
-        ).toBeUndefined();
-      } finally {
-        closeOpenClawStateDatabaseForTest();
-      }
+      expectPendingRestoredRequesterSettled(seeded);
 
       await instance.startGateway();
       await new Promise<void>((resolve) => {
@@ -261,6 +266,122 @@ describe("Gateway restored requester settlement", () => {
     },
   );
 });
+
+function expectPendingRestoredRequesterSettled(seeded: {
+  queueId: string;
+  runId: string;
+  taskId: string;
+}): void {
+  try {
+    const subagent = loadSubagentRegistryFromSqlite().get(seeded.runId);
+    const task = loadTaskRegistryStateFromSqlite().tasks.get(seeded.taskId);
+    const queueStatus = getDeliveryQueueEntryStatus(SESSION_DELIVERY_QUEUE_NAME, seeded.queueId);
+    expect(subagent?.delivery).toMatchObject({ status: "failed" });
+    expect(subagent?.delivery?.queueId).toBeUndefined();
+    expect(subagent?.requesterSettleWake).toBeUndefined();
+    expect(task).toMatchObject({
+      status: "succeeded",
+      deliveryStatus: "failed",
+      terminalOutcome: "blocked",
+    });
+    expect(queueStatus).toBe("failed");
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+  }
+}
+
+async function seedPendingRestoredRequester(instance: OpenClawTestInstance) {
+  instance.state.applyEnv();
+  try {
+    const endedAt = Date.now();
+    const runId = "run-gateway-restored-settle-pending";
+    const taskId = "task-gateway-restored-settle-pending";
+    const taskRunId = "task-run-gateway-restored-settle-pending";
+    const requesterSessionKey = "agent:main:gateway-restored-requester-0";
+    const childSessionKey = "agent:main:subagent:gateway-restored-settle-pending";
+    const deadlineAt = endedAt + 30 * 60_000;
+    const task: TaskRecord = {
+      taskId,
+      runtime: "subagent",
+      requesterSessionKey,
+      ownerKey: requesterSessionKey,
+      scopeKind: "session",
+      childSessionKey,
+      runId: taskRunId,
+      requesterAgentId: "main",
+      task: "settle a restored pending completion",
+      status: "succeeded",
+      deliveryStatus: "session_queued",
+      terminalOutcome: "succeeded",
+      notifyPolicy: "silent",
+      createdAt: endedAt - 1_000,
+      endedAt,
+      lastEventAt: endedAt,
+    };
+    const subagent: SubagentRunRecord = {
+      runId,
+      taskRunId,
+      childSessionKey,
+      requesterSessionKey,
+      requesterDisplayKey: "gateway-restored-requester-0",
+      requesterAgentId: "main",
+      task: task.task,
+      cleanup: "keep",
+      createdAt: task.createdAt,
+      endedReason: "subagent-complete",
+      execution: {
+        status: "terminal",
+        startedAt: endedAt - 500,
+        endedAt,
+        outcome: { status: "ok" },
+      },
+      expectsCompletionMessage: true,
+      completion: { required: true, resultText: "done", capturedAt: endedAt },
+      delivery: {
+        status: "in_progress",
+        disposition: "session_queued",
+        generation: 1,
+        windowStartedAt: endedAt,
+        deadlineAt,
+      },
+      cleanupHandled: true,
+      cleanupCompletedAt: endedAt,
+      requesterSettleWake: {
+        status: "pending",
+        attemptCount: 2,
+        batchRunIds: [runId],
+        requesterYieldBatch: true,
+        afterRequesterYield: true,
+        rearmGeneration: 1,
+      },
+    };
+    const queueEntry = prepareClaimedSessionDelivery(
+      {
+        kind: "agentTurn",
+        sessionKey: requesterSessionKey,
+        message: "load the canonical completion at delivery time",
+        messageId: "gateway-restored-settle-pending:agent-loop",
+        idempotencyKey: "gateway-restored-settle-pending:agent-loop",
+        maxRetries: Number.MAX_SAFE_INTEGER,
+        owner: { kind: "subagent_completion", runId, taskId, generation: 1, deadlineAt },
+      },
+      125_000,
+      endedAt,
+    );
+    subagent.delivery!.queueId = queueEntry.id;
+    admitSubagentCompletionDelivery({ queueEntry, subagent, task });
+    await writeSubagentSessionEntry({
+      stateDir: instance.stateDir,
+      agentId: "main",
+      sessionKey: requesterSessionKey,
+      sessionId: "gateway-restored-requester-0",
+      defaultSessionId: "gateway-restored-requester-0",
+    });
+    return { queueId: queueEntry.id, runId, taskId };
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+  }
+}
 
 async function seedRestoredRequesters(
   instance: OpenClawTestInstance,

--- a/test/gateway-restored-requester-settle.e2e.test.ts
+++ b/test/gateway-restored-requester-settle.e2e.test.ts
@@ -33,6 +33,7 @@ type HeldModelServer = {
   countRequestsContaining: (marker: string) => number;
   peakRestored: () => number;
   release: (index: number) => void;
+  releaseWithText: (index: number, text: string) => void;
   releaseAll: () => void;
   requestCount: () => number;
   url: string;
@@ -196,9 +197,76 @@ describe("Gateway restored requester settlement", () => {
       await expect(probe).resolves.toMatchObject({ code: 0 });
     },
   );
+
+  it(
+    "does not replay a restored wake after a hidden final settles",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const modelServer = await startHeldModelServer();
+      modelServers.push(modelServer);
+      const instance = await createOpenClawTestInstance({
+        name: "gateway-restored-requester-rejection",
+        config: createTestConfig(modelServer.url),
+        env: {
+          OPENCLAW_SKIP_PROVIDERS: undefined,
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+        },
+      });
+      instances.push(instance);
+      await seedRestoredRequesters(instance, 1, 2);
+
+      await instance.startGateway();
+      const client = await connectGatewayClient({
+        url: instance.url,
+        token: instance.gatewayToken,
+      });
+      try {
+        await vi.waitFor(
+          () => expect(modelServer.countRequestsContaining(RESTORED_WAKE_MARKER)).toBe(1),
+          { interval: 20, timeout: 30_000 },
+        );
+        modelServer.releaseWithText(0, "NO_REPLY");
+        await vi.waitFor(
+          async () => {
+            const sessions = await client.request<SessionsListResult>("sessions.list", {
+              agentId: "main",
+            });
+            expect(sessions.sessions.find((row) => row.key.endsWith("requester-0"))).toMatchObject({
+              status: "done",
+              hasActiveRun: false,
+            });
+          },
+          { interval: 50, timeout: 20_000 },
+        );
+      } finally {
+        await disconnectGatewayClient(client);
+        await instance.stopGateway();
+      }
+
+      try {
+        expect(
+          loadSubagentRegistryFromSqlite().get("run-gateway-restored-settle-0")
+            ?.requesterSettleWake,
+        ).toBeUndefined();
+      } finally {
+        closeOpenClawStateDatabaseForTest();
+      }
+
+      await instance.startGateway();
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 1_000);
+      });
+      expect(modelServer.countRequestsContaining(RESTORED_WAKE_MARKER), instance.logs()).toBe(1);
+      await instance.stopGateway();
+    },
+  );
 });
 
-async function seedRestoredRequesters(instance: OpenClawTestInstance, count: number) {
+async function seedRestoredRequesters(
+  instance: OpenClawTestInstance,
+  count: number,
+  attemptCount = 0,
+) {
   instance.state.applyEnv();
   try {
     const endedAt = Date.now();
@@ -226,7 +294,7 @@ async function seedRestoredRequesters(instance: OpenClawTestInstance, count: num
         cleanupCompletedAt: endedAt,
         requesterSettleWake: {
           status: "pending",
-          attemptCount: 0,
+          attemptCount,
           batchRunIds: [runId],
           requesterYieldBatch: true,
           afterRequesterYield: true,
@@ -298,6 +366,7 @@ async function startHeldModelServer(): Promise<HeldModelServer> {
   const requestBodies: string[] = [];
   const responses: ServerResponse[] = [];
   const requestStartedAt: number[] = [];
+  const responseTexts: Array<string | undefined> = [];
   let active = 0;
   let activeRestored = 0;
   let peakRestored = 0;
@@ -344,7 +413,7 @@ async function startHeldModelServer(): Promise<HeldModelServer> {
     try {
       await release.promise;
       if (!response.destroyed) {
-        writeModelResponse(response, index);
+        writeModelResponse(response, index, responseTexts[index]);
       }
     } finally {
       active -= 1;
@@ -372,6 +441,10 @@ async function startHeldModelServer(): Promise<HeldModelServer> {
       requestBodies.filter((body) => body.includes(marker)).length,
     peakRestored: () => peakRestored,
     release: (index) => releases[index]?.resolve(undefined),
+    releaseWithText: (index, text) => {
+      responseTexts[index] = text;
+      releases[index]?.resolve(undefined);
+    },
     releaseAll,
     requestCount: () => requestCount,
     url: `http://127.0.0.1:${address.port}`,
@@ -385,8 +458,12 @@ async function startHeldModelServer(): Promise<HeldModelServer> {
   };
 }
 
-function writeModelResponse(response: ServerResponse, sequence: number): void {
-  const text = `restored requester response ${sequence}`;
+function writeModelResponse(
+  response: ServerResponse,
+  sequence: number,
+  responseText?: string,
+): void {
+  const text = responseText ?? `restored requester response ${sequence}`;
   const message = {
     type: "message",
     id: `restored-requester-message-${sequence}`,


### PR DESCRIPTION
Related: #137332

## What Problem This Solves

Fixes an issue where terminal subagent completions could retain a durable requester-settle wake after the final handoff was rejected, causing the same failed reconciliation to run repeatedly across Gateway restarts. This includes non-success child outcomes, already-delivered task projections, historical rows without a captured outcome, and legacy partial settlements whose physical delivery queue entry remained replayable.

## Why This Change Was Made

Rejected requester-settle batches now validate their exact wake, frozen cohort, task/run owner, and delivery generation before settling all affected state in one SQLite transaction. Retired or already-cleared frozen members may disappear without trapping the surviving owner, including legacy wakes without a rearm generation, while an omitted member that still holds the same wake generation in SQLite rejects the whole transaction. The transaction terminalizes any matching replayable session-queue owner, preserves task delivery already observed by the requester, and clears or retires the durable wake atomically; legacy rows that already lost their logical queue ID are reconciled by the full physical owner tuple.

This is an incremental repair on top of #137344. It intentionally does not clear rows whose task owner is entirely absent, because that state still needs an explicit owner-safe reconciliation policy.

## User Impact

Operators no longer see represented terminal subagent completions retry the same rejected requester wake indefinitely after restart, and stale physical queue work cannot replay after the wake is closed. Existing successful or already-delivered task outcomes remain intact.

## Evidence

- `node scripts/run-vitest.mjs src/agents/subagents/completion/subagent-completion-requester-settle.store.test.ts src/agents/subagents/registry/subagent-registry-lifecycle.test.ts src/agents/subagents/registry/subagent-registry.test.ts`: 365 passed.
- Real Gateway restart E2E with a pending task, in-progress completion delivery, leased physical queue entry, and HTTP/SSE `NO_REPLY`: 1 passed; task, logical delivery, queue, and wake reached their durable terminal projections, and a second Gateway start made no additional model request.
- Changed-gate format, core production types, core test types, root E2E types, core/root Oxlint, database-first storage guard, import-cycle check, and native state schema guard passed.
- All three Knip dead-export scans passed on an isolated rerun after one concurrent changed-gate subprocess exited transiently despite reporting zero findings.
- Latest `pnpm tsgo:core`, changed-file Oxlint, and changed-file Oxfmt checks passed.
- Fresh local autoreview after the unnumbered frozen-wake follow-up: scoped clean at P0-P2.
