### PR TITLE
fix(plugins): restore source startup for Gateway error imports

### DIFF
--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -1370,6 +1370,39 @@ describe("plugin sdk alias helpers", () => {
     expectWorkspaceAliasTargets(aliases, workspaceAliases, "expectedDistFile");
   });
 
+  it.each(["src", "dist"] as const)(
+    "loads gateway error details through Jiti from %s workspace artifacts",
+    async (resolution) => {
+      const fixture = createPluginSdkAliasFixture();
+      const workspaceAliases = writeWorkspaceAliasFixtures(fixture.root, [
+        ["@openclaw/gateway-protocol", "gateway-protocol", "index"],
+        [
+          "@openclaw/gateway-protocol/gateway-error-details",
+          "gateway-protocol",
+          "gateway-error-details",
+        ],
+      ]);
+      const details = expectDefined(workspaceAliases[1], "gateway error details fixture");
+      fs.writeFileSync(details.srcFile, 'export const fallback = "source fallback";\n');
+      fs.writeFileSync(details.distFile, 'export const fallback = "built fallback";\n');
+      const entry = writePluginEntry(fixture.root, bundledPluginFile("demo", "index.ts"));
+      fs.writeFileSync(
+        entry,
+        'export { fallback } from "@openclaw/gateway-protocol/gateway-error-details";\n',
+      );
+      const aliases = buildPluginLoaderAliasMap(entry, undefined, undefined, resolution);
+      const createJiti = await getCreateJiti();
+      const loader = createJiti(entry, {
+        ...buildPluginLoaderJitiOptions(aliases),
+        tryNative: false,
+      });
+
+      expect(loader(entry)).toMatchObject({
+        fallback: resolution === "src" ? "source fallback" : "built fallback",
+      });
+    },
+  );
+
   it("derives workspace aliases from packaged root dist when package metadata is absent", () => {
     const fixture = createPluginSdkAliasFixture();
     const sourcePluginEntry = writePluginEntry(

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -522,6 +522,7 @@ const WORKSPACE_PACKAGE_ALIAS_SUBPATHS = [
       "client-info",
       "connect-error-details",
       "frame-guards",
+      "gateway-error-details",
       "schema",
       "startup-unavailable",
       "version",


### PR DESCRIPTION
## What Problem This Solves

Fixes source-backed plugin startup when its SDK runtime imports Gateway error details. An isolated Telegram Gateway hit a module-not-found path ending in `gateway-protocol/src/index.ts/gateway-error-details` before its channel could start.

Related: #139976. This is a separate startup repair; it does not contain that PR's rich-message changes.

## Why This Change Was Made

The public protocol subpath and TypeScript mapping already exist, but the plugin loader's curated workspace map omitted the subpath. Jiti consequently applied the package-root alias and appended the subpath to `index.ts` or `index.mjs`.

Add that existing export to the same canonical map. Package manifests can be absent in installed layouts, so this preserves the established resolution contract without adding another manifest reader, resolver, or fallback. Protocol schemas, dependencies, configuration, and private SDK permissions are unchanged.

## User Impact

Source-backed plugins can load the existing Gateway error-details module. The same exact alias works for source and built workspace artifacts.

The production change is one necessary alias line; regression coverage adds 33 lines in the existing test file.

## Evidence

- Both new real-Jiti cases fail on the main baseline with the malformed `index.ts`/`index.mjs` paths and pass with the repair.
- The full alias and loader sibling run passed 80 tests, with one existing Windows-only skip.
- Full build, required changed-code gate, and fresh independent P0-P2 review passed.
- The built Telegram entrypoint import profile passed (161.09 MiB peak RSS); this is import profiling, not a live Telegram message test.
- Literal SDK/runtime import-graph inspection found the same missing specifier at two value imports; computed dynamic imports remain outside that static evidence.

An earlier cold source-only legacy SDK bridge test timed out on both the original code and the candidate at its unchanged 120-second limit. The fresh built-layout sibling run passes; this PR does not claim to repair or erase that earlier limitation.

The separate native custom-emoji failure in #139976 remains unresolved and is not counted as proof for this fix.

### Remaining runtime proof

A bounded actual source-Gateway run using the existing QA Lab/Crabline owners did not reach healthy channel readiness. The Gateway logged its HTTP listener, but the existing HEAD health check timed out after 120 seconds; zero Telegram API calls were recorded. Owned cleanup completed. The cause is not established, and this failed attempt is not replaced by the passing import tests or built-entry profile. This PR remains a draft pending that readiness investigation and exact-head CI.
