### PR TITLE
fix: avoid retry delays for absent ClawHub tracking

### DIFF
--- a/src/skills/lifecycle/clawhub-store.ts
+++ b/src/skills/lifecycle/clawhub-store.ts
@@ -1,5 +1,6 @@
 import fsSync from "node:fs";
 import path from "node:path";
+import { statRegularFile } from "@openclaw/fs-safe/advanced";
 import { normalizeOptionalString as normalizeOptionalStringValue } from "@openclaw/normalization-core/string-coerce";
 import type { ClawHubDownloadResult } from "../../infra/clawhub-artifacts.js";
 import {
@@ -286,6 +287,11 @@ export async function readClawHubSkillsLockfile(
 ): Promise<ClawHubSkillsLockfile> {
   for (const candidate of metadataPaths(workspaceDir, "lock.json")) {
     try {
+      // Missing metadata is normal before installation. Leave present-file races
+      // and uncertain paths to the strict reader, including its error diagnostics.
+      if ((await statRegularFile(candidate).catch(() => undefined))?.missing) {
+        continue;
+      }
       return parseClawHubSkillsLockfile(await readJson<Partial<ClawHubSkillsLockfile>>(candidate));
     } catch (err) {
       if (err instanceof JsonFileReadError && hasErrnoCode(err.cause, "ENOENT")) {

--- a/src/skills/lifecycle/clawhub-store.ts
+++ b/src/skills/lifecycle/clawhub-store.ts
@@ -1,6 +1,5 @@
 import fsSync from "node:fs";
 import path from "node:path";
-import { statRegularFile } from "@openclaw/fs-safe/advanced";
 import { normalizeOptionalString as normalizeOptionalStringValue } from "@openclaw/normalization-core/string-coerce";
 import type { ClawHubDownloadResult } from "../../infra/clawhub-artifacts.js";
 import {
@@ -10,6 +9,7 @@ import {
   type ClawHubSkillsShTrustState,
 } from "../../infra/clawhub-skills.js";
 import { formatErrorMessage, hasErrnoCode } from "../../infra/errors.js";
+import { statRegularFile } from "../../infra/fs-safe.js";
 import {
   JsonFileReadError,
   readJson,

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -9,6 +9,7 @@ import type {
   ClawHubSkillSecurityVerdictItem,
   ClawHubSkillVerificationResponse,
 } from "../../infra/clawhub-skills.js";
+import { hasErrnoCode } from "../../infra/errno.js";
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
 
 const fetchClawHubSkillDetailMock = vi.fn();
@@ -1436,6 +1437,60 @@ describe("skills-clawhub", () => {
     expect(installed.skills.weather).toEqual(existing.skills.weather);
     expect(installed.skills.calendar).toEqual(added);
     expect(installed.skills.agentreceipt).toMatchObject({ version: "1.0.0" });
+  });
+
+  it.for([".clawhub", ".clawdhub"])(
+    "rejects symlinked %s tracking without changing the link or its target",
+    async (directory, context) => {
+      const workspaceDir = await tempDirs.make("openclaw-skills-linked-tracking-");
+      const target = path.join(workspaceDir, "original.json");
+      const content = JSON.stringify({ version: 1, skills: {} });
+      const lockPath = path.join(workspaceDir, directory, "lock.json");
+      await fs.writeFile(target, content);
+      await fs.mkdir(path.dirname(lockPath));
+      try {
+        await fs.symlink(target, lockPath);
+      } catch (error) {
+        if (process.platform === "win32" && hasErrnoCode(error, "EPERM")) {
+          // Windows file symlinks require a host-granted capability.
+          context.skip();
+          return;
+        }
+        throw error;
+      }
+
+      await expect(readTrackedClawHubSkillSlugs(workspaceDir)).rejects.toThrow(
+        "Malformed workspace ClawHub lockfile",
+      );
+      expect((await fs.lstat(lockPath)).isSymbolicLink()).toBe(true);
+      expect(await fs.readFile(target, "utf8")).toBe(content);
+    },
+  );
+
+  it("reads the replacement tracking when an existing lock changes before open", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skills-replaced-tracking-");
+    await writeTrackedSkill(workspaceDir, "weather");
+    const lockPath = path.join(workspaceDir, ".clawhub", "lock.json");
+    const replacement = path.join(workspaceDir, "replacement.json");
+    await fs.writeFile(
+      replacement,
+      JSON.stringify({ version: 1, skills: { calendar: { version: "2.0.0", installedAt: 123 } } }),
+    );
+    const open = fs.open.bind(fs);
+    let replaced = false;
+    const spy = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      if (!replaced && args[0] === lockPath) {
+        replaced = true;
+        await fs.rename(replacement, lockPath);
+      }
+      return await open(...args);
+    });
+    try {
+      await expect(readTrackedClawHubSkillSlugs(workspaceDir)).resolves.toEqual(["calendar"]);
+      expect(replaced).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("persists install artifact and verification provenance in the ClawHub lockfile", async () => {

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -71,7 +71,8 @@ vi.mock("../../plugins/install-security-scan.js", async (importOriginal) => {
   };
 });
 
-vi.mock("../../infra/fs-safe.js", () => ({
+vi.mock("../../infra/fs-safe.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../infra/fs-safe.js")>()),
   pathExists: pathExistsMock,
 }));
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where first-time ClawHub skill installs pause for about three seconds while checking tracking files that do not exist yet. The same waits made the ClawHub test file take 145 seconds locally.

## Why This Change Was Made

Recognize confirmed initial absence through the existing OpenClaw filesystem facade before invoking the strict JSON reader for optional workspace tracking. Present files and uncertain probe results retain strict parsing, errors, and replacement-race retries. This preserves rejection of malformed JSON, JSON null, and symlinks; a nullable JSON helper would conflate actual JSON null with absence.

Both the initial read and the publication-time reread remain. The tracking file is metadata; existing workspace mutation leases still own writer coordination. No metadata format, dependency, schema, lease, or trust-policy changes. The six added production lines use the existing filesystem primitive rather than introducing another reader or cache.

## User Impact

Fresh installs and operations on untracked workspaces respond promptly. Existing damaged tracking is still rejected and preserved. An optional read reports initial absence immediately rather than waiting for a future file; present-file replacement handling remains intact.

## Evidence

- Whole ClawHub file: **145.27s → 18.33s** with the same pinned Node/pnpm dependency install. All **117 original cases** remain, plus three filesystem preservation cases; candidate **120/120** passed. Case-time sum: **119.467s → 3.077s**.
- Representative fresh install: **3,559ms → 246ms**; early missing-resolution error: **1,733ms → 6ms**. These are local measurements, not workflow-time claims.
- Canonical and legacy metadata symlink rejection, plus real atomic replacement between inspection and open, passed against both the old reader and candidate. New symlink cases skip only when Windows actually denies the required file-symlink capability with EPERM.
- Uninstall rollback and workspace lease siblings: **15/15 passed**. Changed-code gate passed; the final capability-only test refinement passed focused tests, typecheck, formatting, and lint.
- Final wrapper repair: **122/122** ClawHub and filesystem-boundary cases passed, with focused typecheck/lint and independent P0–P2 review clean. The test mock now preserves real filesystem exports.
- Exact fs-safe **0.8.3** runtime and upstream source were inspected; [dependency evidence](https://github.com/openclaw/openclaw/pull/140958#issuecomment-5566765968) resolves both review inspection requests.
- The initial CI head passed all **120 ClawHub cases** (117 originals retained), totaling **687ms**, but failed the repository import-boundary guard. The follow-up routes the same primitive through the required policy facade; the guard is preserved.

No live registry write was performed; the change is local filesystem handling.
