### PR TITLE
refactor(sessions): share agent-turn reuse decisions

### DIFF
--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -219,7 +219,7 @@ export function resolveSessionLifecycleTimestamps(params: {
   };
 }
 
-export function resolveTerminalMainSessionTranscriptRegistryCheck(
+function resolveTerminalMainSessionTranscriptRegistryCheck(
   params: TerminalMainSessionTranscriptRegistryParams,
 ): TerminalMainSessionTranscriptRegistryCheck | undefined {
   if (!params.entry || !params.sessionKey) {

--- a/src/gateway/agent-turn/agent-session-reuse.test.ts
+++ b/src/gateway/agent-turn/agent-session-reuse.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import {
+  mergeSessionEntry,
+  resolveSessionResetPolicy,
+  type InternalSessionEntry as SessionEntry,
+} from "../../config/sessions.js";
+import {
+  loadSessionEntry,
+  upsertSessionEntryCore,
+} from "../../config/sessions/session-accessor.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { buildAgentSessionPatch } from "../server-methods/agent-session-patch.js";
+import { prepareAgentSession } from "../server-methods/agent-session-prepare.js";
+
+type PatchParams = Parameters<typeof buildAgentSessionPatch>[0];
+const now = 120_001;
+const expiredEntry: SessionEntry = {
+  sessionId: "original",
+  updatedAt: 1,
+  sessionStartedAt: 1,
+  lastInteractionAt: 1,
+};
+const freshEntry: SessionEntry = { ...expiredEntry, lastInteractionAt: now - 1 };
+const resetPolicy = resolveSessionResetPolicy({
+  sessionCfg: { reset: { mode: "idle", idleMinutes: 1 } },
+  resetType: "direct",
+});
+
+function buildReusePatch(input: Partial<PatchParams>) {
+  return buildAgentSessionPatch({
+    freshEntry: expiredEntry,
+    initialEntry: expiredEntry,
+    cfg: {},
+    sessionAgentId: "main",
+    canonicalSessionKey: "agent:main:reuse-proof",
+    storePath: "/synthetic/session-reuse.sqlite",
+    normalizedSpawned: {},
+    requestDeliveryHint: undefined,
+    hasRestoredCronContinuation: false,
+    resetPolicy,
+    now,
+    isSystemGatewayRun: false,
+    visibleRequest: true,
+    fallbackSessionId: "replacement",
+    touchInteraction: true,
+    failedSessionTranscriptMissing: () => false,
+    ...input,
+  });
+}
+
+describe("agent session reuse at mutation", () => {
+  it.each([
+    { name: "expired ordinary turn", input: {}, sessionId: "replacement", isNew: true },
+    { name: "fresh ordinary turn", input: { freshEntry }, sessionId: "original", isNew: false },
+    {
+      name: "expected existing identity",
+      input: { expectedExistingSessionId: "original" },
+      sessionId: "original",
+      isNew: false,
+    },
+    {
+      name: "restored cron continuation",
+      input: { hasRestoredCronContinuation: true },
+      sessionId: "original",
+      isNew: false,
+    },
+    {
+      name: "model-locked identity",
+      input: { freshEntry: { ...expiredEntry, modelSelectionLocked: true } },
+      sessionId: "original",
+      isNew: false,
+    },
+    {
+      name: "visible terminal recovery",
+      input: { freshEntry: { ...expiredEntry, status: "failed" } },
+      sessionId: "original",
+      isNew: false,
+    },
+    {
+      name: "background terminal expiry",
+      input: { freshEntry: { ...expiredEntry, status: "failed" }, visibleRequest: false },
+      sessionId: "replacement",
+      isNew: true,
+    },
+    {
+      name: "missing failed transcript",
+      input: {
+        freshEntry: { ...freshEntry, status: "failed" },
+        failedSessionTranscriptMissing: () => true,
+      },
+      sessionId: "replacement",
+      isNew: true,
+    },
+    {
+      name: "requested identity for an expired row",
+      input: { requestedSessionId: "requested" },
+      sessionId: "replacement",
+      isNew: true,
+    },
+    {
+      name: "requested identity for a fresh row",
+      input: { freshEntry, requestedSessionId: "requested" },
+      sessionId: "requested",
+      isNew: true,
+    },
+    {
+      name: "requested identity for a missing row",
+      input: { freshEntry: undefined, initialEntry: undefined, requestedSessionId: "requested" },
+      sessionId: "requested",
+      isNew: true,
+    },
+  ] satisfies Array<{
+    name: string;
+    input: Partial<PatchParams>;
+    sessionId: string;
+    isNew: boolean;
+  }>)("preserves $name", ({ input, sessionId, isNew }) => {
+    const result = buildReusePatch(input);
+    expect(result.patch.sessionId).toBe(sessionId);
+    expect(result.isNewSession).toBe(isNew);
+  });
+
+  it("keeps a concurrent replacement after preparing a rotation from the stored row", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const cfg = { session: { reset: { mode: "idle" as const, idleMinutes: 1 } } };
+      await state.writeConfig(cfg);
+      const sessionKey = "agent:main:reuse-proof";
+      const scope = {
+        agentId: "main",
+        sessionKey,
+        storePath: state.statePath("agents", "main", "sessions", "sessions.json"),
+      };
+      await upsertSessionEntryCore(scope, expiredEntry);
+      const prepared = prepareAgentSession({
+        cfg,
+        requestedSessionKey: sessionKey,
+        request: { message: "continue", idempotencyKey: "reuse-proof" },
+        canUseCronRunContinuation: false,
+        lifecycleGeneration: "reuse-proof",
+        respond: () => {
+          throw new Error("Unexpected preparation rejection");
+        },
+      });
+      if (!prepared) {
+        throw new Error("Session preparation did not return a candidate");
+      }
+      expect(prepared.isNewSession).toBe(true);
+      expect(prepared.sessionId).not.toBe("original");
+      const concurrent: SessionEntry = {
+        ...freshEntry,
+        sessionId: "concurrent",
+        sessionStartedAt: prepared.now,
+        lastInteractionAt: prepared.now,
+        status: "done",
+        lifecycleRunId: "concurrent-run",
+        cliSessionIds: { "claude-cli": "native-concurrent" },
+      };
+      await upsertSessionEntryCore(scope, concurrent);
+      const latest = loadSessionEntry(scope);
+      const updated = buildReusePatch({
+        initialEntry: prepared.entry,
+        freshEntry: latest,
+        cfg: prepared.cfg,
+        canonicalSessionKey: prepared.canonicalKey,
+        storePath: prepared.storePath,
+        resetPolicy: prepared.resetPolicy,
+        now: prepared.now,
+        requestedSessionId: "original",
+        fallbackSessionId: prepared.sessionId,
+      });
+      expect(mergeSessionEntry(latest, updated.patch)).toMatchObject({
+        sessionId: "concurrent",
+        sessionStartedAt: prepared.now,
+        status: "done",
+        lifecycleRunId: "concurrent-run",
+        cliSessionIds: { "claude-cli": "native-concurrent" },
+      });
+    });
+  });
+});

--- a/src/gateway/server-methods/agent-session-patch.ts
+++ b/src/gateway/server-methods/agent-session-patch.ts
@@ -48,18 +48,12 @@ export type AgentSessionPatchBuild = {
   freshness: SessionFreshness | undefined;
 };
 
-export function buildAgentSessionPatch(params: {
+type AgentSessionReuseInput = {
   freshEntry: SessionEntry | undefined;
-  initialEntry: SessionEntry | undefined;
   cfg: OpenClawConfig;
   sessionAgentId: string;
   canonicalSessionKey: string;
   storePath: string;
-  normalizedSpawned: { groupId?: string; groupChannel?: string; groupSpace?: string };
-  requestDeliveryHint: DeliveryContext | undefined;
-  requestLabel?: string;
-  explicitSessionKey?: string;
-  pluginOwnerId?: string;
   expectedExistingSessionId?: string;
   hasRestoredCronContinuation: boolean;
   resetPolicy: ReturnType<typeof import("../../config/sessions.js").resolveSessionResetPolicy>;
@@ -67,10 +61,89 @@ export function buildAgentSessionPatch(params: {
   requestedSessionId?: string;
   isSystemGatewayRun: boolean;
   visibleRequest: boolean;
-  fallbackSessionId: string;
-  touchInteraction: boolean;
   failedSessionTranscriptMissing: (entry: SessionEntry | undefined) => boolean;
-}): AgentSessionPatchBuild {
+};
+
+/** Re-evaluate the entry from each read; callers retain admission and concurrent-rotation fencing. */
+export function evaluateAgentSessionReuse(params: AgentSessionReuseInput) {
+  const lifecycleTimestamps = params.freshEntry
+    ? resolveSessionLifecycleTimestamps({
+        entry: params.freshEntry,
+        storePath: params.storePath,
+        agentId: params.sessionAgentId,
+        sessionKey: params.canonicalSessionKey,
+      })
+    : undefined;
+  const skipImplicitExpiry =
+    params.expectedExistingSessionId !== undefined ||
+    params.hasRestoredCronContinuation ||
+    params.freshEntry?.modelSelectionLocked === true ||
+    (params.resetPolicy.configured !== true && hasProviderOwnedSession(params.freshEntry));
+  const freshness = params.freshEntry
+    ? skipImplicitExpiry
+      ? ({ fresh: true } satisfies SessionFreshness)
+      : evaluateSessionFreshness({
+          updatedAt: params.freshEntry.updatedAt,
+          ...lifecycleTimestamps,
+          now: params.now,
+          policy: params.resetPolicy,
+        })
+    : undefined;
+  const requestedSessionMatchesEntry = Boolean(
+    params.requestedSessionId && params.freshEntry?.sessionId?.trim() === params.requestedSessionId,
+  );
+  const terminalMainTranscriptNewerThanRegistry =
+    params.isSystemGatewayRun || requestedSessionMatchesEntry
+      ? false
+      : hasTerminalMainSessionTranscriptNewerThanRegistrySync({
+          entry: params.freshEntry,
+          sessionScope: params.cfg.session?.scope,
+          sessionKey: params.canonicalSessionKey,
+          agentId: params.sessionAgentId,
+          mainKey: params.cfg.session?.mainKey,
+          storePath: params.storePath,
+        });
+  const recoverableTerminalSession =
+    Boolean(params.freshEntry?.sessionId) &&
+    params.visibleRequest &&
+    isRecoverableTerminalSessionStatus(params.freshEntry?.status);
+  const canReuseSession =
+    Boolean(params.freshEntry?.sessionId) &&
+    ((freshness?.fresh ?? false) || recoverableTerminalSession) &&
+    !params.failedSessionTranscriptMissing(params.freshEntry) &&
+    !terminalMainTranscriptNewerThanRegistry;
+  const usableRequestedSessionId =
+    params.requestedSessionId && (!params.freshEntry?.sessionId || canReuseSession)
+      ? params.requestedSessionId
+      : undefined;
+  const sessionId =
+    usableRequestedSessionId ?? (canReuseSession ? params.freshEntry?.sessionId : undefined);
+  const isNewSession =
+    !params.freshEntry ||
+    (!canReuseSession && !usableRequestedSessionId) ||
+    Boolean(usableRequestedSessionId && params.freshEntry?.sessionId !== usableRequestedSessionId);
+  return {
+    freshness,
+    recoverableTerminalSession,
+    canReuseSession,
+    usableRequestedSessionId,
+    sessionId,
+    isNewSession,
+  };
+}
+
+export function buildAgentSessionPatch(
+  params: AgentSessionReuseInput & {
+    initialEntry: SessionEntry | undefined;
+    normalizedSpawned: { groupId?: string; groupChannel?: string; groupSpace?: string };
+    requestDeliveryHint: DeliveryContext | undefined;
+    requestLabel?: string;
+    explicitSessionKey?: string;
+    pluginOwnerId?: string;
+    fallbackSessionId: string;
+    touchInteraction: boolean;
+  },
+): AgentSessionPatchBuild {
   const storedSpawnedBy = normalizeOptionalString(params.freshEntry?.spawnedBy);
   const freshSpawnedBy = storedSpawnedBy
     ? resolveSessionStoreKey({
@@ -158,67 +231,8 @@ export function buildAgentSessionPatch(params: {
     params.freshEntry?.sessionId &&
     params.freshEntry.sessionId !== params.initialEntry.sessionId,
   );
-  const freshLifecycleTimestamps = params.freshEntry
-    ? resolveSessionLifecycleTimestamps({
-        entry: params.freshEntry,
-        storePath: params.storePath,
-        agentId: params.sessionAgentId,
-        sessionKey: params.canonicalSessionKey,
-      })
-    : undefined;
-  const freshSkipImplicitExpiry =
-    params.expectedExistingSessionId !== undefined ||
-    params.hasRestoredCronContinuation ||
-    params.freshEntry?.modelSelectionLocked === true ||
-    (params.resetPolicy.configured !== true && hasProviderOwnedSession(params.freshEntry));
-  const freshFreshness = params.freshEntry
-    ? freshSkipImplicitExpiry
-      ? ({ fresh: true } satisfies SessionFreshness)
-      : evaluateSessionFreshness({
-          updatedAt: params.freshEntry.updatedAt,
-          ...freshLifecycleTimestamps,
-          now: params.now,
-          policy: params.resetPolicy,
-        })
-    : undefined;
-  const freshRequestedSessionMatchesEntry = Boolean(
-    params.requestedSessionId && params.freshEntry?.sessionId?.trim() === params.requestedSessionId,
-  );
-  const freshTerminalMainTranscriptNewerThanRegistry =
-    params.isSystemGatewayRun || freshRequestedSessionMatchesEntry
-      ? false
-      : hasTerminalMainSessionTranscriptNewerThanRegistrySync({
-          entry: params.freshEntry,
-          sessionScope: params.cfg.session?.scope,
-          sessionKey: params.canonicalSessionKey,
-          agentId: params.sessionAgentId,
-          mainKey: params.cfg.session?.mainKey,
-          storePath: params.storePath,
-        });
-  const freshRecoverableTerminalSession =
-    Boolean(params.freshEntry?.sessionId) &&
-    params.visibleRequest &&
-    isRecoverableTerminalSessionStatus(params.freshEntry?.status);
-  const freshCanReuseSession =
-    Boolean(params.freshEntry?.sessionId) &&
-    ((freshFreshness?.fresh ?? false) || freshRecoverableTerminalSession) &&
-    !params.failedSessionTranscriptMissing(params.freshEntry) &&
-    !freshTerminalMainTranscriptNewerThanRegistry;
-  const freshUsableRequestedSessionId =
-    params.requestedSessionId && (!params.freshEntry?.sessionId || freshCanReuseSession)
-      ? params.requestedSessionId
-      : undefined;
-  const freshSessionId =
-    freshUsableRequestedSessionId ??
-    (freshCanReuseSession ? params.freshEntry?.sessionId : undefined) ??
-    params.fallbackSessionId;
-  const freshIsNewSession =
-    !params.freshEntry ||
-    (!freshCanReuseSession && !freshUsableRequestedSessionId) ||
-    Boolean(
-      freshUsableRequestedSessionId &&
-      params.freshEntry?.sessionId !== freshUsableRequestedSessionId,
-    );
+  const reuse = evaluateAgentSessionReuse(params);
+  const freshSessionId = reuse.sessionId ?? params.fallbackSessionId;
   const freshRotatedSessionId = Boolean(
     params.freshEntry?.sessionId && params.freshEntry.sessionId !== freshSessionId,
   );
@@ -227,8 +241,8 @@ export function buildAgentSessionPatch(params: {
     : freshSessionId;
   const shouldClearRotatedState = freshRotatedSessionId && !freshSessionRotatedSinceLoad;
   const shouldClearTerminalState =
-    freshCanReuseSession &&
-    freshRecoverableTerminalSession &&
+    reuse.canReuseSession &&
+    reuse.recoverableTerminalSession &&
     !freshSessionRotatedSinceLoad &&
     patchSessionId === params.freshEntry?.sessionId;
   const automaticRecoveryClearPatch = shouldClearRotatedState
@@ -237,7 +251,9 @@ export function buildAgentSessionPatch(params: {
   const patch: Partial<SessionEntry> = {
     sessionId: patchSessionId,
     updatedAt: params.now,
-    ...(freshIsNewSession && !freshSessionRotatedSinceLoad ? { sessionStartedAt: params.now } : {}),
+    ...(reuse.isNewSession && !freshSessionRotatedSinceLoad
+      ? { sessionStartedAt: params.now }
+      : {}),
     ...(params.touchInteraction
       ? {
           lastInteractionAt: params.now,
@@ -282,9 +298,9 @@ export function buildAgentSessionPatch(params: {
     groupChannel: nextGroup.groupChannel,
     groupSpace: nextGroup.groupSpace,
     freshSessionRotatedSinceLoad,
-    isNewSession: freshIsNewSession,
+    isNewSession: reuse.isNewSession,
     rotatedSessionId: freshRotatedSessionId,
-    usableRequestedSessionId: freshUsableRequestedSessionId,
-    freshness: freshFreshness,
+    usableRequestedSessionId: reuse.usableRequestedSessionId,
+    freshness: reuse.freshness,
   };
 }

--- a/src/gateway/server-methods/agent-session-prepare.ts
+++ b/src/gateway/server-methods/agent-session-prepare.ts
@@ -3,22 +3,16 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
 import { hasGeneratedMediaCompletionEvent } from "../../agents/internal-event-contract.js";
 import {
-  evaluateSessionFreshness,
-  hasTerminalMainSessionTranscriptNewerThanRegistrySync,
   resolveAgentMainSessionKey,
   resolveChannelResetConfig,
-  resolveSessionLifecycleTimestamps,
   resolveSessionResetPolicy,
   resolveSessionResetType,
   resolveSessionWorkStartError,
-  resolveTerminalMainSessionTranscriptRegistryCheck,
   type SessionEntry,
   type SessionFreshness,
 } from "../../config/sessions.js";
-import { hasProviderOwnedSession } from "../../config/sessions/entry-freshness.js";
 import { readTranscriptStatsSync } from "../../config/sessions/session-accessor.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
-import { isRecoverableTerminalSessionStatus } from "../../config/sessions/terminal-status.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { parseCronRunScopeSuffix } from "../../sessions/session-key-utils.js";
@@ -30,6 +24,7 @@ import {
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { loadSessionEntry } from "../session-utils.js";
 import type { AgentRunRequest } from "./agent-request-types.js";
+import { evaluateAgentSessionReuse } from "./agent-session-patch.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
 type PreparedAgentSession = {
@@ -214,29 +209,6 @@ export function prepareAgentSession(params: {
       channel: sessionDeliveryChannel(entry) ?? params.recipientChannel,
     }),
   });
-  const lifecycleTimestamps = entry
-    ? resolveSessionLifecycleTimestamps({
-        entry,
-        storePath,
-        agentId: canonicalSessionAgentId,
-        sessionKey: canonicalKey,
-      })
-    : undefined;
-  const skipImplicitExpiry =
-    params.expectedExistingSessionId !== undefined ||
-    restoredCronContinuationIdentity !== undefined ||
-    entry?.modelSelectionLocked === true ||
-    (resetPolicy.configured !== true && hasProviderOwnedSession(entry));
-  const freshness = entry
-    ? skipImplicitExpiry
-      ? ({ fresh: true } satisfies SessionFreshness)
-      : evaluateSessionFreshness({
-          updatedAt: entry.updatedAt,
-          ...lifecycleTimestamps,
-          now,
-          policy: resetPolicy,
-        })
-    : undefined;
   const visibleRequest =
     effectiveBootstrapContextRunKind !== "cron" &&
     effectiveBootstrapContextRunKind !== "heartbeat" &&
@@ -262,49 +234,22 @@ export function prepareAgentSession(params: {
   const mainSessionKey = resolveAgentMainSessionKey({ cfg, agentId: canonicalSessionAgentId });
   const isSystemGatewayRun =
     effectiveBootstrapContextRunKind === "cron" || effectiveBootstrapContextRunKind === "heartbeat";
-  const requestedSessionMatchesEntry = Boolean(
-    params.requestedSessionId && entry?.sessionId?.trim() === params.requestedSessionId,
-  );
-  const terminalMainTranscriptCheck =
-    isSystemGatewayRun || requestedSessionMatchesEntry
-      ? undefined
-      : resolveTerminalMainSessionTranscriptRegistryCheck({
-          entry,
-          sessionScope: cfg.session?.scope,
-          sessionKey: canonicalKey,
-          agentId: canonicalSessionAgentId,
-          mainKey: cfg.session?.mainKey,
-          storePath,
-        });
-  const terminalMainTranscriptNewerThanRegistry = terminalMainTranscriptCheck
-    ? hasTerminalMainSessionTranscriptNewerThanRegistrySync({
-        entry,
-        sessionScope: cfg.session?.scope,
-        sessionKey: canonicalKey,
-        agentId: canonicalSessionAgentId,
-        mainKey: cfg.session?.mainKey,
-        storePath,
-      })
-    : false;
-  const recoverableTerminalSession =
-    Boolean(entry?.sessionId) &&
-    visibleRequest &&
-    isRecoverableTerminalSessionStatus(entry?.status);
-  const canReuseSession =
-    Boolean(entry?.sessionId) &&
-    ((freshness?.fresh ?? false) || recoverableTerminalSession) &&
-    !failedSessionTranscriptMissing(entry) &&
-    !terminalMainTranscriptNewerThanRegistry;
-  const usableRequestedSessionId =
-    params.requestedSessionId && (!entry?.sessionId || canReuseSession)
-      ? params.requestedSessionId
-      : undefined;
-  const sessionId =
-    usableRequestedSessionId ?? (canReuseSession ? entry?.sessionId : undefined) ?? randomUUID();
-  const isNewSession =
-    !entry ||
-    (!canReuseSession && !usableRequestedSessionId) ||
-    Boolean(usableRequestedSessionId && entry?.sessionId !== usableRequestedSessionId);
+  const reuse = evaluateAgentSessionReuse({
+    freshEntry: entry,
+    cfg,
+    sessionAgentId: canonicalSessionAgentId,
+    canonicalSessionKey: canonicalKey,
+    storePath,
+    expectedExistingSessionId: params.expectedExistingSessionId,
+    hasRestoredCronContinuation: restoredCronContinuationIdentity !== undefined,
+    resetPolicy,
+    now,
+    requestedSessionId: params.requestedSessionId,
+    isSystemGatewayRun,
+    visibleRequest,
+    failedSessionTranscriptMissing,
+  });
+  const sessionId = reuse.sessionId ?? randomUUID();
   return {
     cfg,
     storePath,
@@ -315,13 +260,13 @@ export function prepareAgentSession(params: {
     canonicalSessionAgentId,
     resetPolicy,
     now,
-    freshness,
+    freshness: reuse.freshness,
     visibleRequest,
     mainSessionKey,
     isSystemGatewayRun,
-    usableRequestedSessionId,
+    usableRequestedSessionId: reuse.usableRequestedSessionId,
     sessionId,
-    isNewSession,
+    isNewSession: reuse.isNewSession,
     rotatedSessionId: Boolean(entry?.sessionId && entry.sessionId !== sessionId),
     touchInteraction: visibleRequest,
     sessionPersistedBeforeGatewayAdmission: entry !== undefined,

--- a/src/gateway/server-methods/agent.base.test-utils.ts
+++ b/src/gateway/server-methods/agent.base.test-utils.ts
@@ -1522,7 +1522,12 @@ describe("gateway agent handler", () => {
       vi.useFakeTimers({ toFake: ["Date"] });
       setDateOnlyFakeClockActive(true);
       vi.setSystemTime(now);
-      mocks.hasTerminalMainSessionTranscriptNewerThanRegistrySync.mockReturnValue(true);
+      mocks.readTranscriptStatsSync.mockReturnValue({
+        eventCount: 1,
+        maxSeq: 1,
+        sizeBytes: 32,
+        lastMutationAtMs: now - 1_000,
+      });
 
       await withTestDir({ prefix: "openclaw-gateway-terminal-main-newer-" }, async (root) => {
         const sessionsDir = `${root}/sessions`;
@@ -1562,6 +1567,7 @@ describe("gateway agent handler", () => {
         if (scenario.expectReuse) {
           expect(call.sessionId).toBe("terminal-main-session");
           expect(capturedEntry?.sessionId).toBe("terminal-main-session");
+          expect(mocks.readTranscriptStatsSync).not.toHaveBeenCalled();
           return;
         }
         expect(call.sessionId).not.toBe("terminal-main-session");

--- a/src/gateway/server-methods/agent.test-harness.ts
+++ b/src/gateway/server-methods/agent.test-harness.ts
@@ -81,7 +81,6 @@ const mocks = vi.hoisted(() => ({
       lastInteractionAt: entry?.lastInteractionAt,
     }),
   ),
-  hasTerminalMainSessionTranscriptNewerThanRegistrySync: vi.fn(() => false),
   lifecycleGeneration: "test-generation",
 }));
 
@@ -135,8 +134,6 @@ vi.mock("../../config/sessions.js", async () => {
       return m?.[1] ?? "main";
     },
     resolveExplicitAgentSessionKey: mocks.resolveExplicitAgentSessionKey,
-    hasTerminalMainSessionTranscriptNewerThanRegistrySync:
-      mocks.hasTerminalMainSessionTranscriptNewerThanRegistrySync,
     resolveAgentMainSessionKey: ({
       cfg,
       agentId,
@@ -1168,7 +1165,6 @@ export const describe0AfterEach0 = () => {
         lastInteractionAt: entry?.lastInteractionAt,
       }),
     );
-  mocks.hasTerminalMainSessionTranscriptNewerThanRegistrySync.mockReset().mockReturnValue(false);
   mocks.lifecycleGeneration = "test-generation";
   dateOnlyFakeClockActive = false;
   vi.useRealTimers();


### PR DESCRIPTION
## What Problem This Solves

Agent-turn preparation and session mutation independently decide whether to reuse or rotate the same session. Keeping two copies risks divergent expiry, recovery, and requested-ID behavior when the authoritative row changes between reads. Peter Steinberger requested this consolidation and the accompanying fixture correction.

## Why This Change Was Made

The internal `evaluateAgentSessionReuse` helper in `agent-session-patch.ts` evaluates the entry at both boundaries. It owns freshness bypasses, terminal recovery and transcript checks, requested-ID eligibility, and the new-session decision. Preparation retains request errors, cron-continuation admission, and lazy UUID generation. Mutation retains the authoritative reread, concurrent-rotation fencing, and metadata projection/clearing.

The handler fixture now runs the real lifecycle predicate over transcript statistics. Its former whole-predicate mock forced `true` for a `done` row, which the real owner rejects before reading statistics. The existing done/killed/endedAt table now supplies a newer mutation watermark: done retains its identity without a statistics read; killed and endedAt-only rows rotate. The redundant production guard remains removed.

The now file-local registry-check helper has no public SDK/package export. No public API, config, protocol, schema, or persistence semantics change. Production delta: **-39 lines**; tests and test support: **+182 lines**.

## User Impact

None. Existing reuse/rotation behavior and concurrent-session protection are preserved. Test support follows the real lifecycle contract.

## Evidence

- The original contract table passed against the original implementation. The ordered SQLite test prepares a rotation, writes a concurrent replacement, rereads it, and verifies mutation retains its identity, lifecycle state, and native binding.
- Before the fixture correction, the full handler suite reproduced 323 passes / 1 failure at the done-row identity assertion. The corrected fixture retains the behavioral assertions and exercises the real lifecycle owner.
- Fresh verification after rebasing onto `0015b209956c8c121222eaad906677f7581728cb`: **577 tests across 13 files passed** (545 Gateway/reuse/persistence tests and 32 lifecycle/freshness/reset tests), including all seven handler suites.
- Command: `node scripts/run-vitest.mjs src/gateway/server-methods/agent*.test.ts src/gateway/agent-turn/agent-session-reuse.test.ts src/gateway/agent-turn/agent-session-persist.test.ts src/config/sessions/lifecycle.test.ts src/config/sessions/entry-freshness.test.ts src/config/sessions/reset-policy.test.ts src/config/sessions/reset.test.ts`.
- Fresh `node scripts/check-changed.mjs` and `git diff --check` passed completely, without baseline changes.
- The inherited patch had an independent Codex review clean through P2. Fresh requested Codex branch review is scoped-clean at its configured P0 threshold, with zero findings. `git range-diff` confirms both inherited patches are unchanged by the rebase.
- The original production candidate passed `pnpm build`, including package/SDK declarations, runtime/CLI checks, and Dashboard boot budgets. This rebase has no changes to the affected production files or import boundaries.

No assertions, timeouts, mocks, or baselines were weakened. No live Gateway or real session state was used.

## Landing evidence

Exact-head [CI run 34114390075, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34114390075/attempts/2) passed, including `openclaw/ci-gate`. The new base includes the Telegram line-cap fix from #141148, and `check-lint` passed on the first attempt.

Attempt 1 repeated the two known failures outside this PR: compact-small-22 hit the 1,000 ms `targetConfigValidation` timeout in CLI finalization process tests, and compact-small-29 hit the 120,000 ms hosted-tooling inventory-growth timeout. Exactly one failed-job rerun was used. Both [compact-small-22](https://github.com/openclaw/openclaw/actions/runs/34114390075/job/101722940664) and [compact-small-29](https://github.com/openclaw/openclaw/actions/runs/34114390075/job/101722942589) passed on retry without code, timeout, mock, or baseline changes.

Native review artifacts validated with zero findings for `cb20645345086e94875dbdb030db04b7efce983c`. Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 140960` verified hosted CI/Testbox evidence, and `scripts/pr merge-run 140960 --auto-merge` landed `40ad90a012eb6a3a738963347fe4cdc02cef2921`. The merge is verified as an ancestor of freshly fetched `origin/main`; all six landed files match the reviewed head. No manual Testbox lease or live provider run was needed. The native workflow noted intervening mainline CI/tooling drift and proceeded under its normal policy without an override or admin merge.
