### PR TITLE
fix(markdown): preserve block boundaries inside list items

### DIFF
--- a/docs/concepts/markdown-formatting.md
+++ b/docs/concepts/markdown-formatting.md
@@ -95,6 +95,8 @@ channels:
   channels render the closing fence correctly.
 - List and blockquote prefixes are part of the IR text, so chunking never
   splits mid-prefix.
+- Paragraphs, headings, and code blocks inside a list item stay separated in
+  the IR, including paragraphs nested inside a quoted list item.
 - Inline styles never split across chunks; the renderer reopens an open
   style at the start of the next chunk.
 

--- a/packages/markdown-core/src/ir.nested-lists.test.ts
+++ b/packages/markdown-core/src/ir.nested-lists.test.ts
@@ -300,6 +300,26 @@ describe("Nested Lists - Edge Cases", () => {
 describe("list paragraph spacing", () => {
   it.each([
     {
+      title: "separates prose from a fenced block in a tight item",
+      markdown: "- Run this:\n  ```sh\n  echo hello\n  ```\n- Done",
+      expected: "• Run this:\necho hello\n• Done",
+    },
+    {
+      title: "separates headings and paragraphs in a tight ordered item",
+      markdown: "1. Intro\n   # Heading\n   Details\n2. Done",
+      expected: "1. Intro\nHeading\n\nDetails\n2. Done",
+    },
+    {
+      title: "preserves paragraph breaks inside a list-owned quote",
+      markdown: "- > First paragraph\n  >\n  > Second paragraph\n- Next",
+      expected: "• First paragraph\n\nSecond paragraph\n• Next",
+    },
+    {
+      title: "separates a quote from its containing item's next paragraph",
+      markdown: "- > Quoted\n\n  Continue here\n- Next",
+      expected: "• Quoted\n\nContinue here\n\n• Next",
+    },
+    {
       title: "preserves paragraph breaks inside loose bullet list items",
       markdown: `- first paragraph
 

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -323,7 +323,7 @@ function appendHeadingSeparator(state: RenderState, nextBlockStart: number | und
     state.headingLineEnd,
   );
   if (newlineCount === undefined) {
-    appendParagraphSeparator(state);
+    appendParagraphSeparator(state, undefined, nextBlockStart);
     return;
   }
   if (newlineCount > 0) {
@@ -643,22 +643,32 @@ function closeStyle(
   }
 }
 
-function appendParagraphSeparator(state: RenderState, token?: MarkdownToken) {
+function appendParagraphSeparator(
+  state: RenderState,
+  token?: MarkdownToken,
+  nextBlockStart?: number,
+) {
   if (state.table) {
     return;
   } // Don't add paragraph separators inside tables
   if (state.env.listStack.length > 0) {
     const currentList = state.env.listStack[state.env.listStack.length - 1];
     const directListParagraphLevel = (currentList?.openLevel ?? 0) + 2;
+    const itemEnd = state.openListItems.at(-1)?.sourceEndLine;
+    // Tight wrappers still separate sibling blocks inside their owning item.
+    // Item transitions keep their existing spacing at list_item_close.
+    const hasFollowingBlock =
+      nextBlockStart !== undefined && itemEnd !== undefined && nextBlockStart < itemEnd;
     if (
-      token?.type !== "paragraph_close" ||
-      token.hidden ||
-      token.level !== directListParagraphLevel
+      !hasFollowingBlock &&
+      (token?.type !== "paragraph_close" ||
+        token.hidden ||
+        token.level !== directListParagraphLevel)
     ) {
       return;
     }
   }
-  state.text += "\n\n";
+  state.text += token?.hidden ? "\n" : "\n\n";
 }
 
 function appendTopLevelListSeparator(state: RenderState) {
@@ -999,9 +1009,7 @@ function renderTableAsCode(state: RenderState) {
 }
 
 function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
-  const nextMappedBlockStarts = state.preserveSourceBlockSpacing
-    ? computeNextMappedBlockStarts(tokens)
-    : [];
+  const nextMappedBlockStarts = computeNextMappedBlockStarts(tokens);
   for (const [tokenIndex, token] of tokens.entries()) {
     const inlineStyle = INLINE_STYLE_BY_TOKEN.get(token.type);
     if (inlineStyle) {
@@ -1068,7 +1076,7 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         appendText(state, "\n");
         break;
       case "paragraph_close":
-        appendParagraphSeparator(state, token);
+        appendParagraphSeparator(state, token, nextMappedBlockStarts[tokenIndex]);
         break;
       case "heading_open":
         state.headingLineEnd = token.map?.[1];


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reading formatted replies would see separate paragraphs, headings, or commands joined together when they appeared inside a list item. An instruction followed by a fenced command could become `Run this:echo hello`, and separate quoted paragraphs could lose their boundary.

## Why This Change Was Made

The shared Markdown parser suppressed separators for tight or indirectly nested list paragraphs before channel rendering. Use its existing next-block and item source boundaries to preserve separators between blocks in the same item, while retaining the established spacing between tight and loose list items.

## User Impact

Lists containing instructions, code blocks, headings, or quoted paragraphs remain readable in replies that use the shared Markdown formatter. The formatting documentation now states this behavior.

## Evidence

Three regression cases failed before the repair while the existing 27 list cases passed. Afterward, 200 focused IR and renderer/chunk tests pass, including existing list nesting, quote spacing, block metadata, links, and source-spacing cases.

Direct calls through the Markdown parser and both marker and attributed-range renderers confirm that `Run this:` and `echo hello` appear on separate lines, headings keep separate surrounding prose, and quoted paragraphs retain their paragraph break. Code, link, and bold ranges remain aligned. These are formatter API probes; no live channel delivery is claimed.

Scoped Markdown production and test types, full-file lint and formatting, the max-lines check, and diff checks pass. Independent review found no actionable findings through P2. The candidate adds 8 production lines, 20 test lines, and 2 documentation lines. Required CI must pass on the published head before landing.
