### PR TITLE
refactor(imessage): share LF framing for RPC streams

### DIFF
--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -80,8 +80,8 @@ describe("IMessageRpcClient LF framing", () => {
     stderr: PassThrough;
   };
   let client: InstanceType<typeof IMessageRpcClient>;
-  let runtimeError: ReturnType<typeof vi.fn>;
-  let onNotification: ReturnType<typeof vi.fn>;
+  const runtimeError = vi.fn();
+  const onNotification = vi.fn();
 
   beforeEach(async () => {
     vi.stubEnv("NODE_ENV", "development");
@@ -92,8 +92,8 @@ describe("IMessageRpcClient LF framing", () => {
       stderr: new PassThrough(),
     });
     spawnMock.mockReset().mockReturnValue(child);
-    runtimeError = vi.fn();
-    onNotification = vi.fn();
+    runtimeError.mockReset();
+    onNotification.mockReset();
     client = new IMessageRpcClient({
       runtime: { error: runtimeError, exit: vi.fn(), log: vi.fn() },
       onNotification,
@@ -200,7 +200,7 @@ describe("IMessageRpcClient LF framing", () => {
 
   it("flushes incomplete UTF-8 and preserves internal CRs in unterminated stderr", async () => {
     const bytes = Buffer.from("first\rsecond \u20ac");
-    child.stderr.write(bytes.subarray(0, bytes.length - 1));
+    child.stderr.write(bytes.subarray(0, -1));
     expect(runtimeError).not.toHaveBeenCalled();
 
     child.emit("close", 1, null);

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { IMessagePrivateApiStatus } from "./private-api-status.js";
 
@@ -70,6 +71,153 @@ afterAll(() => {
   vi.doUnmock("node:child_process");
   vi.doUnmock("./cli-output.js");
   vi.resetModules();
+});
+
+describe("IMessageRpcClient LF framing", () => {
+  let child: ReturnType<typeof createMockChild> & {
+    stdin: PassThrough;
+    stdout: PassThrough;
+    stderr: PassThrough;
+  };
+  let client: InstanceType<typeof IMessageRpcClient>;
+  let runtimeError: ReturnType<typeof vi.fn>;
+  let onNotification: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("VITEST", "");
+    child = Object.assign(createMockChild(), {
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+    });
+    spawnMock.mockReset().mockReturnValue(child);
+    runtimeError = vi.fn();
+    onNotification = vi.fn();
+    client = new IMessageRpcClient({
+      runtime: { error: runtimeError, exit: vi.fn(), log: vi.fn() },
+      onNotification,
+    });
+    await client.start();
+  });
+
+  afterEach(async () => {
+    child.emit("close", 0, null);
+    await client.stop();
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    ["U+2028", "\u2028"],
+    ["U+2029", "\u2029"],
+    ["four-byte UTF-8", "\u{1f680}"],
+  ])("preserves split %s inside an LF-delimited response", async (_, separator) => {
+    const pending = client.request("chats.list");
+    const text = `line one${separator}line two`;
+    const bytes = Buffer.from(`${JSON.stringify({ id: 1, result: { messages: [{ text }] } })}\n`);
+    const split = bytes.indexOf(Buffer.from(separator)) + 1;
+
+    child.stdout.write(bytes.subarray(0, split));
+    child.stdout.write(bytes.subarray(split));
+
+    await expect(pending).resolves.toEqual({ messages: [{ text }] });
+    expect(runtimeError).not.toHaveBeenCalled();
+  });
+
+  it("delivers multiple LF responses and notifications in order, trimming CRLF and blanks", async () => {
+    const responses: unknown[] = [];
+    const first = client.request("first").then((value) => responses.push(value));
+    const second = client.request("second").then((value) => responses.push(value));
+    child.stdout.setEncoding("utf8");
+    child.stdout.write(
+      ' \r\n{"id":2,"result":"second"}\r\n{"method":"first"}\n{"id":1,"result":"first"}\n{"method":"second"}\r',
+    );
+    expect(onNotification.mock.calls).toEqual([[{ method: "first", params: undefined }]]);
+
+    child.stdout.write("\n");
+
+    expect(onNotification.mock.calls).toEqual([
+      [{ method: "first", params: undefined }],
+      [{ method: "second", params: undefined }],
+    ]);
+    await Promise.all([first, second]);
+    expect(responses).toEqual(["second", "first"]);
+    expect(runtimeError).not.toHaveBeenCalled();
+  });
+
+  it("keeps interleaved stdout/stderr decoder state independent and bypasses decoding strings", async () => {
+    const pending = client.request("ping");
+    const stdout = Buffer.from('{"id":1,"result":"\u20ac"}\n');
+    const stderr = Buffer.from("notice \u732b\r\n");
+    const stdoutSplit = stdout.indexOf(Buffer.from("\u20ac")) + 1;
+    const stderrSplit = stderr.indexOf(Buffer.from("\u732b")) + 1;
+
+    child.stdout.write(stdout.subarray(0, stdoutSplit));
+    child.stderr.write(stderr.subarray(0, stderrSplit));
+    // A string data event must not consume a buffered partial UTF-8 sequence.
+    child.stdout.emit("data", "prefix ");
+    child.stderr.emit("data", "prefix ");
+    child.stderr.write(stderr.subarray(stderrSplit));
+    child.stdout.write(stdout.subarray(stdoutSplit));
+
+    await expect(pending).resolves.toBe("prefix \u20ac");
+    expect(runtimeError.mock.calls).toEqual([["imsg rpc: notice prefix \u732b"]]);
+  });
+
+  it("resolves an unterminated stdout response before rejecting remaining requests on child close", async () => {
+    const response = client.request("first");
+    const remaining = expect(client.request("second")).rejects.toThrow("imsg rpc exited (code 1)");
+    child.stdout.write('{"id":1,"result":"final"}');
+    child.stdout.emit("close");
+    child.emit("close", 1, null);
+
+    await expect(response).resolves.toBe("final");
+    await remaining;
+    await expect(client.waitForClose()).rejects.toThrow("imsg rpc exited (code 1)");
+  });
+
+  it("flushes stdout then stderr only on child close, before choosing the terminal diagnostic", async () => {
+    const order: string[] = [];
+    onNotification.mockImplementation(() => order.push("stdout"));
+    runtimeError.mockImplementation(() => order.push("stderr"));
+    const pending = expect(client.request("ping")).rejects.toThrow(
+      "imsg cannot access ~/Library/Messages/chat.db. Grant Full Disk Access to the Gateway/launcher process and restart Gateway.",
+    );
+    child.stdout.write('{"method":"final"}');
+    child.stderr.write("notice Full Disk Access denied for chat.db");
+
+    child.stdout.emit("close");
+    child.stderr.emit("close");
+    expect(order).toEqual([]);
+    child.emit("close", 1, null);
+
+    expect(order).toEqual(["stdout", "stderr"]);
+    expect(runtimeError).toHaveBeenCalledExactlyOnceWith(
+      "imsg rpc: notice Full Disk Access denied for chat.db",
+    );
+    await pending;
+  });
+
+  it("flushes incomplete UTF-8 and preserves internal CRs in unterminated stderr", async () => {
+    const bytes = Buffer.from("first\rsecond \u20ac");
+    child.stderr.write(bytes.subarray(0, bytes.length - 1));
+    expect(runtimeError).not.toHaveBeenCalled();
+
+    child.emit("close", 1, null);
+
+    expect(runtimeError).toHaveBeenCalledExactlyOnceWith("imsg rpc: first\rsecond \ufffd");
+  });
+
+  it("ignores both streams from a stale child after stop", async () => {
+    child.stdin.once("finish", () => child.emit("close", 0, null));
+    await client.stop();
+
+    child.stdout.write('{"method":"messages.changed","params":{}}\n');
+    child.stderr.write("late diagnostic\n");
+
+    expect(onNotification).not.toHaveBeenCalled();
+    expect(runtimeError).not.toHaveBeenCalled();
+  });
 });
 
 describe("IMessageRpcClient child stream error handling", () => {

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -126,6 +126,35 @@ function normalizeIMessageFullDiskAccessError(message: string): string | undefin
   return PUBLIC_IMESSAGE_FULL_DISK_ACCESS_ERROR;
 }
 
+function createLfLineFramer(onLine: (line: string) => void): {
+  write(chunk: Buffer | string): void;
+  flush(): void;
+} {
+  const decoder = new StringDecoder("utf8");
+  let buffer = "";
+  return {
+    write(chunk) {
+      buffer += typeof chunk === "string" ? chunk : decoder.write(chunk);
+      let newlineIndex = buffer.indexOf("\n");
+      while (newlineIndex !== -1) {
+        const line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        onLine(line);
+        newlineIndex = buffer.indexOf("\n");
+      }
+    },
+    flush() {
+      buffer += decoder.end();
+      if (!buffer) {
+        return;
+      }
+      const line = buffer;
+      buffer = "";
+      onLine(line);
+    },
+  };
+}
+
 export class IMessageRpcClient {
   private readonly cliPath: string;
   // The private-API cache is keyed by the *configured* cliPath (see
@@ -144,10 +173,8 @@ export class IMessageRpcClient {
   private isReaped = false;
   private child: ChildProcessWithoutNullStreams | null = null;
   private stopPromise: Promise<void> | null = null;
-  private stdoutBuffer = "";
-  private readonly stdoutDecoder = new StringDecoder("utf8");
-  private stderrBuffer = "";
-  private readonly stderrDecoder = new StringDecoder("utf8");
+  private readonly stdoutFramer = createLfLineFramer((line) => this.handleStdoutLine(line));
+  private readonly stderrFramer = createLfLineFramer((line) => this.handleStderrLine(line));
   private nextId = 1;
   private publicProcessError: string | null = null;
 
@@ -188,14 +215,14 @@ export class IMessageRpcClient {
       if (this.child !== child) {
         return;
       }
-      this.handleStdoutChunk(chunk);
+      this.stdoutFramer.write(chunk);
     });
 
     child.stderr?.on("data", (chunk) => {
       if (this.child !== child) {
         return;
       }
-      this.handleStderrChunk(chunk);
+      this.stderrFramer.write(chunk);
     });
 
     // Every process/stdio error is terminal for this RPC transport. Settle the
@@ -218,8 +245,8 @@ export class IMessageRpcClient {
       if (this.child === child) {
         // Complete both byte streams before selecting the terminal error so a
         // final split diagnostic can still provide its public recovery guidance.
-        this.flushStdoutBuffer();
-        this.flushStderrBuffer();
+        this.stdoutFramer.flush();
+        this.stderrFramer.flush();
         this.child = null;
       }
       this.finish(this.buildCloseError(code, signal));
@@ -368,61 +395,12 @@ export class IMessageRpcClient {
     }
   }
 
-  private handleStdoutChunk(chunk: Buffer | string) {
-    const text = typeof chunk === "string" ? chunk : this.stdoutDecoder.write(chunk);
-    this.stdoutBuffer += text;
-
-    let newlineIndex = this.stdoutBuffer.indexOf("\n");
-    while (newlineIndex !== -1) {
-      const line = this.stdoutBuffer.slice(0, newlineIndex);
-      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
-      this.handleStdoutLine(line);
-      newlineIndex = this.stdoutBuffer.indexOf("\n");
-    }
-  }
-
-  private flushStdoutBuffer() {
-    const tail = this.stdoutDecoder.end();
-    if (tail) {
-      this.stdoutBuffer += tail;
-    }
-    if (!this.stdoutBuffer) {
-      return;
-    }
-    const line = this.stdoutBuffer;
-    this.stdoutBuffer = "";
-    this.handleStdoutLine(line);
-  }
-
   private handleStdoutLine(line: string) {
     const trimmed = line.trim();
     if (!trimmed) {
       return;
     }
     this.handleLine(trimmed);
-  }
-
-  private handleStderrChunk(chunk: Buffer | string) {
-    const text = typeof chunk === "string" ? chunk : this.stderrDecoder.write(chunk);
-    this.stderrBuffer += text;
-
-    let newlineIndex = this.stderrBuffer.indexOf("\n");
-    while (newlineIndex !== -1) {
-      const line = this.stderrBuffer.slice(0, newlineIndex);
-      this.stderrBuffer = this.stderrBuffer.slice(newlineIndex + 1);
-      this.handleStderrLine(line);
-      newlineIndex = this.stderrBuffer.indexOf("\n");
-    }
-  }
-
-  private flushStderrBuffer() {
-    this.stderrBuffer += this.stderrDecoder.end();
-    if (!this.stderrBuffer) {
-      return;
-    }
-    const line = this.stderrBuffer;
-    this.stderrBuffer = "";
-    this.handleStderrLine(line);
   }
 
   private handleStderrLine(line: string) {

--- a/extensions/imessage/src/status.test.ts
+++ b/extensions/imessage/src/status.test.ts
@@ -1,6 +1,4 @@
 // Imessage tests cover status plugin behavior.
-import { EventEmitter } from "node:events";
-import { PassThrough } from "node:stream";
 import {
   createPluginSetupWizardStatus,
   createTestWizardPrompter,
@@ -34,14 +32,6 @@ const installIMessageCliMock = vi.hoisted(() => vi.fn());
 
 type CommandResult = Awaited<ReturnType<typeof processRuntime.runCommandWithTimeout>>;
 type RpcClient = Awaited<ReturnType<typeof clientModule.createIMessageRpcClient>>;
-type RpcPendingRequest = {
-  resolve: (value: unknown) => void;
-  reject: (error: Error) => void;
-};
-type RpcClientInternals = {
-  handleStdoutChunk: (chunk: Buffer | string) => void;
-  pending: Map<string, RpcPendingRequest>;
-};
 type TestPrompterOverrides = NonNullable<Parameters<typeof createTestWizardPrompter>[0]>;
 
 function commandResult(overrides: Partial<CommandResult> = {}): CommandResult {
@@ -92,10 +82,6 @@ function mockRpcClient(requestResult: unknown = { chats: [] }) {
   return { create, request, stop };
 }
 
-function rpcClientInternals(client: RpcClient): RpcClientInternals {
-  return client as unknown as RpcClientInternals;
-}
-
 function mockSuccessfulInstall(detected: boolean, version: string): void {
   setupToolsMocks.detectBinary.mockResolvedValueOnce(detected);
   installIMessageCliMock.mockResolvedValueOnce({
@@ -144,26 +130,6 @@ vi.mock("openclaw/plugin-sdk/setup-tools", async (importOriginal) => ({
 vi.mock("./install-imsg.js", () => ({
   installIMessageCli: installIMessageCliMock,
 }));
-
-function createMockChildProcess() {
-  const child = new EventEmitter() as EventEmitter & {
-    stdin: PassThrough;
-    stdout: PassThrough;
-    stderr: PassThrough;
-    killed: boolean;
-    kill: (signal?: string) => boolean;
-  };
-  child.stdin = new PassThrough();
-  child.stdout = new PassThrough();
-  child.stderr = new PassThrough();
-  child.killed = false;
-  child.kill = (signal?: string) => {
-    child.killed = true;
-    child.emit("close", 0, signal ?? null);
-    return true;
-  };
-  return child;
-}
 
 async function withPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
   const originalPlatform = process.platform;
@@ -222,78 +188,6 @@ describe("createIMessageRpcClient", () => {
     expect(internals.buildCloseError(1, null).message).toBe(
       "imsg cannot access ~/Library/Messages/chat.db. Grant Full Disk Access to the Gateway/launcher process and restart Gateway.",
     );
-  });
-
-  it.each([
-    ["U+2028", "\u2028"],
-    ["U+2029", "\u2029"],
-  ])(
-    "frames stdout on LF only so raw %s inside JSON strings stays intact",
-    async (_, separator) => {
-      const { IMessageRpcClient } = await import("./client.js");
-      const client = new IMessageRpcClient();
-      const internals = rpcClientInternals(client);
-      const result = new Promise((resolve, reject) => {
-        internals.pending.set("1", { resolve, reject });
-      });
-      const text = `line one${separator}line two`;
-      const payload = `${JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        result: { messages: [{ text }] },
-      })}\n`;
-      const bytes = Buffer.from(payload, "utf8");
-      const separatorIndex = bytes.indexOf(Buffer.from(separator, "utf8"));
-
-      internals.handleStdoutChunk(bytes.subarray(0, separatorIndex + 1));
-      internals.handleStdoutChunk(bytes.subarray(separatorIndex + 1));
-
-      await expect(result).resolves.toEqual({
-        messages: [{ text }],
-      });
-    },
-  );
-
-  it("handles multiple LF-delimited stdout responses in one chunk", async () => {
-    const { IMessageRpcClient } = await import("./client.js");
-    const client = new IMessageRpcClient();
-    const internals = rpcClientInternals(client);
-    const first = new Promise((resolve, reject) => {
-      internals.pending.set("1", { resolve, reject });
-    });
-    const second = new Promise((resolve, reject) => {
-      internals.pending.set("2", { resolve, reject });
-    });
-
-    internals.handleStdoutChunk(
-      `${JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: "first" } })}\n${JSON.stringify({
-        jsonrpc: "2.0",
-        id: 2,
-        result: { ok: "second" },
-      })}\n`,
-    );
-
-    await expect(first).resolves.toEqual({ ok: "first" });
-    await expect(second).resolves.toEqual({ ok: "second" });
-  });
-
-  it("ignores stdout from a stale child after stop so late notifications cannot leak (#89830)", async () => {
-    vi.stubEnv("VITEST", "");
-    vi.stubEnv("NODE_ENV", "");
-    const child = createMockChildProcess();
-    spawnMock.mockReturnValue(child);
-    const onNotification = vi.fn();
-    const { IMessageRpcClient } = await import("./client.js");
-    const client = new IMessageRpcClient({ onNotification });
-
-    await client.start();
-    await client.stop();
-
-    // A not-yet-exited imsg child emits a complete notification after stop().
-    // The `this.child !== child` guard must drop it before handleStdoutChunk.
-    child.stdout.write('{"jsonrpc":"2.0","method":"messages.changed","params":{}}\n');
-
-    expect(onNotification).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/89830

## What Problem This Solves

This maintainer-requested refactor keeps the iMessage RPC stdout and stderr LF-framing implementations from drifting apart. It preserves the framing contract that fixed JSON responses containing U+2028/U+2029, while replacing tests coupled to private framing methods and pending-request state.

## Why This Change Was Made

Use one private plugin-local factory with independent UTF-8 decoders and buffers for stdout and stderr. Keep LF-only splitting, string-chunk bypass, synchronous callbacks, whitespace trimming, diagnostics, stale-child guards, and stdout-before-stderr child-close flushing unchanged. The errored-stdio closure handling from https://github.com/openclaw/openclaw/pull/140221 remains separate.

Move only the superseded framing and stale-child cases from `status.test.ts` to public `start()`/`request()` coverage in `client.test.ts`, using mocked child streams. No SDK, dependency, configuration, or protocol changes.

## User Impact

No intentional user-visible behavior change. Existing responses, notifications, diagnostics, and shutdown semantics remain intact.

## Evidence

- The nine new public-boundary framing cases passed against the original production implementation before extraction.
- Focused local run: 61 tests passed across `client.test.ts` and `status.test.ts`.
- Coverage includes split UTF-8, U+2028/U+2029, LF response and synchronous notification order, interleaved independent decoders, string chunks, CRLF, unterminated close-time output, and stale-child output.
- Targeted formatting and `git diff --check` passed.
- Fresh independent autoreview through P2 completed. The follow-up review identified only the old index versions of the two test-check failures below; the reviewed working-tree corrections were staged and verified.
- The changed-file dry run selected extension production/tests. The actual gate passed its preliminary guards and six doctor-contract tests, then stopped because declaration generation rejects the mandated shared-install symlink. Targeted lint encounters the same environment guard; neither is claimed green.
- Final isolated Blacksmith Testbox on Linux/Node 24: all 61 focused tests and the full three-file `check:changed` gate passed, including production/test typechecking and targeted lint. Both source receipts match committed tree `91e8ed103b1cfb875f59e5423c978afd401b89e7`. Provider `blacksmith-testbox`, lease `tbx_01m1xc0mhnr5br72p67d3aw7nh`, both wrapper exits 0, lease stopped/completed. Run: https://github.com/openclaw/openclaw/actions/runs/34095246767 (the backing workflow may show cancellation because the delegated lease owns cleanup).
- Initial CI caught a negative-index lint expression and overly broad mock annotations in the new tests. Both were corrected without changing production code and verified by the final Testbox gate.
- Exact-head CI and the required `openclaw/ci-gate` passed for `e6f80a57fc746d2ab7de506cbc30c74dad743c67`: https://github.com/openclaw/openclaw/actions/runs/34096143192. The native exact-head watcher reported `GREEN` and exited 0.
- No live Messages.app or real iMessage account was exercised; proof covers the transport boundary, including existing real-child process tests.
- Overlap checked against https://github.com/openclaw/openclaw/pull/126852: its `status.test.ts` additions only pin locale; this change does not modify those sections.

Production LOC: +35/-57. Tests and test support: +148/-106.
