### PR TITLE
fix(plugins): show enablement in metadata inspections

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -551,6 +551,11 @@ openclaw plugins inspect --all
 
 Inspect shows identity, load status, source, manifest capabilities, policy flags, diagnostics, install metadata, bundle capabilities, and any detected MCP or LSP server support without importing plugin runtime by default. JSON output includes the plugin manifest contracts, such as `contracts.agentToolResultMiddleware` and `contracts.trustedToolPolicies`, so operators can audit trusted-surface declarations before enabling or restarting a plugin. Add `--runtime` to load the plugin module and include registered hooks, tools, commands, services, gateway methods, and HTTP routes. Runtime inspection reports missing plugin dependencies directly; installs and repairs stay in `openclaw plugins install`, `openclaw plugins update`, and `openclaw doctor --fix`.
 
+Default human inspection uses `enabled`, `disabled`, or `error` status labels,
+matching `plugins list`. It describes the metadata snapshot; it does not claim
+that a plugin module was imported. With `--runtime`, successful runtime inspection
+uses `loaded`. JSON retains the underlying registry status and separate `imported` field.
+
 For multi-entry packages, inspecting any child shows the shared package install metadata. `inspect --all --json` includes that same record for each child. If package ownership is missing or ambiguous, inspection omits install metadata rather than attributing an unrelated install record.
 
 Plugin-owned CLI commands are usually installed as root `openclaw` command groups, but plugins may also register nested commands under a core parent such as `openclaw nodes`. After `inspect --runtime` shows a command under `cliCommands`, run it at the listed path; for example a plugin that registers `demo-git` can be verified with `openclaw demo-git ping`.

--- a/src/cli/plugins-cli.inspect.test.ts
+++ b/src/cli/plugins-cli.inspect.test.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters } from "node:util";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
@@ -11,6 +12,7 @@ import {
   buildAllPluginInspectReportsMock,
   buildPluginDiagnosticsReportMock,
   buildPluginInspectReportMock,
+  buildPluginRegistrySnapshotReportMock,
   buildPluginSnapshotReportMock,
   pluginCliConfigMock,
   pluginsCliRuntimeLogs,
@@ -76,12 +78,111 @@ function createInspectReport(
   };
 }
 
+type PluginHumanFormat = "detail" | "table" | "verbose";
+
+function readRenderedStatus(output: string, format: PluginHumanFormat): string | undefined {
+  const text = stripVTControlCharacters(output);
+  if (format === "detail") {
+    return /^Status: (.+)$/m.exec(text)?.[1];
+  }
+  if (format === "verbose") {
+    return /^Display \(display-probe\) (.+)$/m.exec(text)?.[1];
+  }
+  const lines = text.split("\n");
+  const cells = (line: string) =>
+    line
+      .split(/[│|]/u)
+      .slice(1, -1)
+      .map((cell) => cell.trim());
+  const header = lines.find((line) => line.includes("Name") && line.includes("Status"));
+  const row = lines.find((line) => line.includes("Display"));
+  return header && row ? cells(row)[cells(header).indexOf("Status")] : undefined;
+}
+
 describe("plugins cli inspect", () => {
   beforeEach(() => {
     resetPluginsCliTestState();
     workshopMocks.detectToolPolicyDiagnostic.mockReset();
     workshopMocks.loadMetadata.mockReset();
     workshopMocks.loadMetadata.mockReturnValue({ index: createInstalledPluginIndexSnapshot([]) });
+  });
+
+  it.each([
+    { enabled: true, status: "loaded", expected: "enabled" },
+    { enabled: false, status: "disabled", expected: "disabled" },
+    { enabled: true, status: "error", expected: "error" },
+  ] as const)(
+    "renders cold $status records consistently across human commands",
+    async (testCase) => {
+      const plugin = createPluginRecord({
+        id: "display-probe",
+        name: "Display",
+        enabled: testCase.enabled,
+        status: testCase.status,
+        imported: false,
+      });
+      const report = { plugins: [plugin], diagnostics: [] };
+      const inspect = createInspectReport({ plugin });
+      buildPluginSnapshotReportMock.mockReturnValue(report);
+      buildPluginInspectReportMock.mockReturnValue(inspect);
+      buildAllPluginInspectReportsMock.mockReturnValue([inspect]);
+      buildPluginRegistrySnapshotReportMock.mockReturnValue({
+        ...report,
+        workspaceDir: "/workspace",
+        registrySource: "persisted",
+        registryDiagnostics: [],
+      });
+
+      const commands: Array<{ args: string[]; format: PluginHumanFormat }> = [
+        { args: ["list"], format: "table" },
+        { args: ["list", "--verbose"], format: "verbose" },
+        { args: ["inspect", plugin.id], format: "detail" },
+        { args: ["info", plugin.id], format: "detail" },
+        { args: ["inspect", "--all"], format: "table" },
+      ];
+      const renderedStatuses: Array<[string, string | undefined]> = [];
+      for (const { args, format } of commands) {
+        pluginsCliRuntimeLogs.length = 0;
+        await runPluginsCommand(["plugins", ...args]);
+        renderedStatuses.push([
+          args.join(" "),
+          readRenderedStatus(pluginsCliRuntimeLogs.join("\n"), format),
+        ]);
+      }
+      expect(buildPluginDiagnosticsReportMock).not.toHaveBeenCalled();
+
+      for (const selection of [[plugin.id], ["--all"]]) {
+        pluginsCliRuntimeLogs.length = 0;
+        await runPluginsCommand(["plugins", "inspect", ...selection, "--json"]);
+        const json = JSON.parse(pluginsCliRuntimeLogs.at(-1) ?? "null");
+        const entry = Array.isArray(json) ? json[0] : json;
+        expect(entry.plugin).toMatchObject({
+          enabled: testCase.enabled,
+          status: testCase.status,
+          imported: false,
+        });
+      }
+      expect(renderedStatuses).toEqual(
+        commands.map(({ args }) => [args.join(" "), testCase.expected]),
+      );
+    },
+  );
+
+  it.each([
+    { args: ["inspect", "display-probe", "--runtime"], format: "detail" },
+    { args: ["inspect", "--all", "--runtime"], format: "table" },
+  ] as const)("retains actual runtime status for $format output", async ({ args, format }) => {
+    const plugin = createPluginRecord({ id: "display-probe", name: "Display", imported: true });
+    const report = { plugins: [plugin], diagnostics: [] };
+    const inspect = createInspectReport({ plugin });
+    buildPluginSnapshotReportMock.mockReturnValue(report);
+    buildPluginDiagnosticsReportMock.mockReturnValue(report);
+    buildPluginInspectReportMock.mockReturnValue(inspect);
+    buildAllPluginInspectReportsMock.mockReturnValue([inspect]);
+
+    await runPluginsCommand(["plugins", ...args]);
+
+    expect(readRenderedStatus(pluginsCliRuntimeLogs.join("\n"), format)).toBe("loaded");
   });
 
   it.each(

--- a/src/cli/plugins-inspect-command.ts
+++ b/src/cli/plugins-inspect-command.ts
@@ -15,7 +15,7 @@ import { shortenHomeInString, shortenHomePath } from "../utils.js";
 import { formatMissingPluginMessage } from "./error-format.js";
 import { formatCliJsonFailure } from "./failure-output.js";
 import { quietPluginJsonLogger } from "./plugins-json-logger.js";
-import { formatPluginBundleFormat } from "./plugins-list-format.js";
+import { formatPluginBundleFormat, formatPluginStatus } from "./plugins-list-format.js";
 
 /** Options accepted by `openclaw plugins inspect`. */
 export type PluginInspectOptions = {
@@ -203,12 +203,7 @@ export async function runPluginsInspectCommand(
     const rows = inspectAll.map((inspect) => ({
       Name: inspect.plugin.name || inspect.plugin.id,
       ID: inspect.plugin.name && inspect.plugin.name !== inspect.plugin.id ? inspect.plugin.id : "",
-      Status:
-        inspect.plugin.status === "loaded"
-          ? theme.success("loaded")
-          : inspect.plugin.status === "disabled"
-            ? theme.warn("disabled")
-            : theme.error("error"),
+      Status: formatPluginStatus(inspect.plugin, runtimeInspect),
       Shape: inspect.shape,
       Capabilities: formatCapabilityKinds(inspect.capabilities),
       Compatibility:
@@ -327,7 +322,7 @@ export async function runPluginsInspectCommand(
     lines.push(inspect.plugin.description);
   }
   lines.push("");
-  lines.push(`${theme.muted("Status:")} ${inspect.plugin.status}`);
+  lines.push(`${theme.muted("Status:")} ${formatPluginStatus(inspect.plugin, runtimeInspect)}`);
   if (inspect.plugin.failurePhase) {
     lines.push(`${theme.muted("Failure phase:")} ${inspect.plugin.failurePhase}`);
   }

--- a/src/cli/plugins-list-command.test.ts
+++ b/src/cli/plugins-list-command.test.ts
@@ -80,6 +80,7 @@ function mockHumanListModules(importedModules: string[] = []): void {
     importedModules.push("plugins-list-format");
     return {
       formatPluginLine: vi.fn(),
+      formatPluginStatus: vi.fn(),
     };
   });
 }

--- a/src/cli/plugins-list-command.ts
+++ b/src/cli/plugins-list-command.ts
@@ -29,6 +29,7 @@ async function loadHumanListModules() {
 
   return {
     formatPluginLine: listFormat.formatPluginLine,
+    formatPluginStatus: listFormat.formatPluginStatus,
     formatPluginSourceForTable: sourceDisplay.formatPluginSourceForTable,
     formatCliCommand: commandFormat.formatCliCommand,
     getTerminalTableWidth: table.getTerminalTableWidth,
@@ -70,6 +71,7 @@ export async function runPluginsListCommand(
   const {
     formatCliCommand,
     formatPluginLine,
+    formatPluginStatus,
     formatPluginSourceForTable,
     getTerminalTableWidth,
     renderTable,
@@ -124,12 +126,7 @@ export async function runPluginsListCommand(
         Name: plugin.name || plugin.id,
         ID: plugin.name && plugin.name !== plugin.id ? plugin.id : "",
         Format: plugin.format ?? "openclaw",
-        Status:
-          plugin.status === "error"
-            ? theme.error("error")
-            : plugin.enabled
-              ? theme.success("enabled")
-              : theme.warn("disabled"),
+        Status: formatPluginStatus(plugin),
         Source: desc ? `${formattedSource.value}\n${desc}` : formattedSource.value,
         Version: plugin.version ?? "",
       };

--- a/src/cli/plugins-list-format.ts
+++ b/src/cli/plugins-list-format.ts
@@ -9,19 +9,25 @@ export function formatPluginBundleFormat(bundleFormat: PluginBundleFormat): stri
   return bundleFormat === "agent" ? "agent (Agent Plugins)" : bundleFormat;
 }
 
+/** Snapshot status describes enablement; only explicit runtime inspection reports loading. */
+export function formatPluginStatus(
+  plugin: Pick<PluginRecord, "enabled" | "status">,
+  runtimeInspection = false,
+): string {
+  if (plugin.status === "error") {
+    return theme.error("error");
+  }
+  const enabled = runtimeInspection ? plugin.status === "loaded" : plugin.enabled;
+  return enabled ? theme.success(runtimeInspection ? "loaded" : "enabled") : theme.warn("disabled");
+}
+
 export function formatPluginLine(plugin: PluginRecord): string {
-  const status =
-    plugin.status === "error"
-      ? theme.error("error")
-      : plugin.enabled
-        ? theme.success("enabled")
-        : theme.warn("disabled");
   const name = theme.command(plugin.name || plugin.id);
   const idSuffix = plugin.name && plugin.name !== plugin.id ? theme.muted(` (${plugin.id})`) : "";
   const format = plugin.format ?? "openclaw";
 
   const parts = [
-    `${name}${idSuffix} ${status}`,
+    `${name}${idSuffix} ${formatPluginStatus(plugin)}`,
     `  format: ${format}`,
     `  source: ${theme.muted(shortenHomeInString(plugin.source))}`,
     `  origin: ${plugin.origin}`,


### PR DESCRIPTION
Closes #140950

## What Problem This Solves

Default `plugins inspect`, its `info` alias, and `inspect --all` described an enabled plugin as `loaded` even when the same metadata report recorded `imported: false`. This gave operators misleading confirmation that its module had run.

## Why This Change Was Made

One shared human status formatter now serves list, verbose list, and both inspection layouts. Metadata inspection uses `enabled`, `disabled`, or `error`; explicit `--runtime` inspection retains its runtime labels. Registry records, JSON, and loading behavior stay unchanged.

The repair removes duplicate status decisions and reduces production code by two lines. The regression and existing mock update add 102 test lines; the CLI reference adds five.

## User Impact

Operators see consistent enablement labels when inspecting metadata and can request runtime inspection with the existing `--runtime` option.

## Evidence

The normal built CLI was exercised before and after with an empty isolated config and actual bundled plugin records. ACPX reported `enabled: true`, raw `status: "loaded"`, and `imported: false` in both runs:

| Command | Before | After |
| --- | --- | --- |
| `plugins info acpx` | `loaded` | `enabled` |
| `plugins inspect acpx` | `loaded` | `enabled` |
| `plugins inspect --all` | `loaded` | `enabled` |
| `plugins list` | `enabled` | `enabled` |
| `plugins list --verbose` | `enabled` | `enabled` |

All 151 inspection records and the complete list JSON were byte-for-byte unchanged. Both list outputs and the disabled A2A detail outputs were also byte-for-byte unchanged. Each build completed 11 CLI commands with normal exits, no cleanup signals, and verified source/output/dependency identities; the isolated state was removed afterward.

- The regression failed on original production with one intended failure and 31 passing controls; the same 32 cases passed after the repair.
- All 95 final owner/sibling cases pass, including JSON laziness and disabled/error/runtime labels. The initial sibling run exposed an existing full-module mock missing the new export; its one-line update retained every assertion.
- The complete six-file changed check and both normal builds pass. Independent P0–P2 review of the final patch has no findings.

The CLI runs cover actual metadata inspection. Error and explicit-runtime labels are covered by command/rendering tests with supplied reports. Commit `591a48e94b4684535af51f1a42d805ecad2a7520` exactly matches the reviewed, tested, and built working-tree patch. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34095609647). ClawSweeper reviewed this head with no findings or before-merge actions.
