### PR TITLE
test(ci): avoid compact plan topology coupling

### DIFF
--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -2232,12 +2232,6 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     }
     expect(crossRunnerHostedJobs).toHaveLength(1);
     expect(crossRunnerHostedJobs[0]?.runner).toBe(DEFAULT_NODE_TEST_RUNNER);
-    expect(crossRunnerHostedJobs[0]?.groups.map((group) => group.shard_name)).toEqual([
-      "core-tooling-15-hosted-3",
-      "core-tooling-6-hosted-2",
-      "core-tooling-10-hosted-3",
-      "core-tooling-8-hosted-3",
-    ]);
 
     for (const extraFiles of extraInventories) {
       const extraBaseline = await createPlanWithInventory(false, extraFiles);


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI plan test failure when legal changes to the tooling-test inventory cause the compact planner to choose different shard names.

## Why This Change Was Made

The planner contract is its cap, coverage, selection, runner, and scheduling policy—not one incidental packing arrangement. The test retains those behavioral assertions and removes only the literal list of packed shard names.

## User Impact

No product behavior changes. Maintainers can add correctly classified tooling tests without unrelated compact-plan CI failing solely because bins are repacked.

## Evidence

- Reproduced on #136761 exact CI: [checks-node-compact-small-29](https://github.com/openclaw/openclaw/actions/runs/34091242555/job/101645116729) expected a fixed set of four shard names after the valid tooling inventory changed.
- Focused owner test in CI mode passed: 1 test, 51 skipped.
- Changed-file dry run and whitespace validation passed.
- Autoreview on 60f61c2ad71d1c0fd1e5d373d551d4e47c92edd5 was scoped-clean.

Production/tooling delta: 0. Test delta: -6 lines. No release, package, or workflow behavior changed.