### PR TITLE
fix(matrix): show disclosed poll results across event namespaces

### DIFF
--- a/extensions/matrix/src/matrix/actions/messages.test.ts
+++ b/extensions/matrix/src/matrix/actions/messages.test.ts
@@ -1,4 +1,7 @@
 // Matrix tests cover messages plugin behavior.
+import { M_POLL_KIND_DISCLOSED, M_POLL_KIND_UNDISCLOSED } from "matrix-js-sdk/lib/@types/polls.js";
+import { PollResponseEvent } from "matrix-js-sdk/lib/extensible_events_v1/PollResponseEvent.js";
+import { PollStartEvent } from "matrix-js-sdk/lib/extensible_events_v1/PollStartEvent.js";
 import { describe, expect, it, vi } from "vitest";
 import { setMatrixRuntime } from "../../runtime.js";
 import type { MatrixClient } from "../sdk.js";
@@ -365,6 +368,46 @@ describe("matrix message actions", () => {
       eventId: "$msg",
       body: "hello",
     });
+  });
+
+  it.each([
+    { kind: M_POLL_KIND_DISCLOSED.name, disclosed: true },
+    { kind: M_POLL_KIND_DISCLOSED.altName, disclosed: true },
+    { kind: M_POLL_KIND_UNDISCLOSED.name, disclosed: false },
+    { kind: M_POLL_KIND_UNDISCLOSED.altName, disclosed: false },
+  ])("preserves $kind results in room and thread history", async ({ kind, disclosed }) => {
+    const poll = PollStartEvent.from("Favorite fruit?", ["Apple", "Strawberry"], kind);
+    const pollRoot = {
+      ...poll.serialize(),
+      event_id: "$poll",
+      sender: "@alice:example.org",
+      origin_server_ts: 1,
+    };
+    const vote = {
+      ...PollResponseEvent.from(
+        poll.answers.slice(0, 1).map((answer) => answer.id),
+        "$poll",
+      ).serialize(),
+      event_id: "$vote",
+      sender: "@bob:example.org",
+      origin_server_ts: 20,
+    };
+    const { client } = createMessagesClient({
+      chunk: [vote],
+      pollRoot,
+      pollRelations: [vote],
+      threadRelations: [],
+    });
+
+    for (const threadId of [undefined, "$poll"]) {
+      const result = await readMatrixMessages("room:!room:example.org", { client, threadId });
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0]?.body).toBe(
+        disclosed
+          ? "[Poll]\nFavorite fruit?\n\n1. Apple (1 vote)\n2. Strawberry (0 votes)\n\nTotal voters: 1"
+          : "[Poll]\nFavorite fruit?\n\n1. Apple\n2. Strawberry\n\nResponses are hidden until the poll closes.",
+      );
+    }
   });
 
   it.each([

--- a/extensions/matrix/src/matrix/poll-types.ts
+++ b/extensions/matrix/src/matrix/poll-types.ts
@@ -7,6 +7,10 @@
  * - m.poll.end - Closes a poll
  */
 
+import {
+  M_POLL_KIND_DISCLOSED,
+  type PollKind as MatrixPollKind,
+} from "matrix-js-sdk/lib/@types/polls.js";
 import { normalizePollInput, type PollInput } from "openclaw/plugin-sdk/poll-runtime";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 
@@ -50,7 +54,7 @@ type PollParsedAnswer = {
 
 type PollStartSubtype = {
   question: TextContent;
-  kind?: PollKind;
+  kind?: MatrixPollKind;
   max_selections?: number;
   answers: PollAnswer[];
 };
@@ -164,7 +168,9 @@ export function parsePollStart(content: PollStartContent): ParsedPollStart | nul
   return {
     question,
     answers,
-    kind: poll.kind ?? "m.poll.disclosed",
+    kind: M_POLL_KIND_DISCLOSED.matches(poll.kind ?? "m.poll.disclosed")
+      ? "m.poll.disclosed"
+      : "m.poll.undisclosed",
     maxSelections: Math.min(Math.max(maxSelections, 1), answers.length),
   };
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This PR uses a branch in the same repository, so maintainers can update it directly.

</details>

## What Problem This Solves

Fixes an issue where users reading a disclosed Matrix poll would see “Responses are hidden until the poll closes” when the poll was created with the MSC3381 event namespace, even though votes were available.

## Why This Change Was Made

Normalize the incoming poll kind with the Matrix SDK's existing namespace matcher before building summaries. The parser now accepts the SDK's wire kind type and produces the canonical kind used by the renderer, while preserving the existing omitted-kind default.

## User Impact

Room and thread history show current vote counts for disclosed polls from both supported Matrix namespaces. Undisclosed polls continue to hide results until closed.

## Evidence

- The regression failed before the repair specifically for `org.matrix.msc3381.poll.disclosed`; the other 33 message-action tests passed.
- Real Matrix SDK poll/vote serialization now passes through the room and thread history readers for both disclosed and undisclosed namespace spellings. The focused poll, snapshot, message-action and voting suites passed all 49 tests; the final message-action rerun passed all 34 tests.
- A synthetic loopback HTTP homeserver exercised the actual Matrix SDK and OpenClaw adapter. Before: the disclosed poll returned hidden-results text. After: both room and thread reads returned `Apple (1 vote)` and `Total voters: 1`. The fixture did not start sync or use saved accounts, and final cleanup awaited `stopWithoutPersist()`. This is local adapter/protocol evidence, not a live public homeserver test.
- Full extension production and test typechecks, full-file lint, formatting, and `check:changed` passed. Independent review found no actionable P0–P2 issues.
- Production delta: +8/-2 lines for the SDK type/constant import and canonical normalization; test delta: +43 lines. No new settings, network requests, or persistence behavior.
