### PR TITLE
fix(matrix): include alternative aliases in room info

### DIFF
--- a/extensions/matrix/src/matrix/actions/room.test.ts
+++ b/extensions/matrix/src/matrix/actions/room.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { MatrixClient } from "../sdk.js";
 import { getMatrixMemberInfo, getMatrixRoomInfo } from "./room.js";
 
-function createRoomClient() {
+function createRoomClient(altAliases?: string[]) {
   const getRoomStateEvent = vi.fn(async (_roomId: string, eventType: string) => {
     switch (eventType) {
       case "m.room.name":
@@ -11,7 +11,7 @@ function createRoomClient() {
       case "m.room.topic":
         return { topic: "Incidents" };
       case "m.room.canonical_alias":
-        return { alias: "#ops:example.org" };
+        return { alias: "#ops:example.org", alt_aliases: altAliases };
       default:
         throw new Error(`unexpected state event ${eventType}`);
     }
@@ -36,8 +36,14 @@ function createRoomClient() {
 }
 
 describe("matrix room actions", () => {
-  it("returns room details from the resolved Matrix room id", async () => {
-    const { client, getJoinedRoomMembers, getRoomStateEvent } = createRoomClient();
+  it.each([
+    { name: "without alternative aliases", altAliases: undefined },
+    {
+      name: "with alternative aliases",
+      altAliases: ["#incidents:example.org", "#team:example.org"],
+    },
+  ])("returns room details $name", async ({ altAliases }) => {
+    const { client, getJoinedRoomMembers, getRoomStateEvent } = createRoomClient(altAliases);
 
     const result = await getMatrixRoomInfo("room:!ops:example.org", { client });
 
@@ -48,7 +54,7 @@ describe("matrix room actions", () => {
       name: "Ops Room",
       topic: "Incidents",
       canonicalAlias: "#ops:example.org",
-      altAliases: [],
+      altAliases: altAliases ?? [],
       memberCount: 2,
     });
   });

--- a/extensions/matrix/src/matrix/actions/room.ts
+++ b/extensions/matrix/src/matrix/actions/room.ts
@@ -1,4 +1,5 @@
 // Matrix plugin module implements room behavior.
+import { filterStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveMatrixRoomId } from "../send.js";
 import { withResolvedActionClient, withResolvedRoomAction } from "./client.js";
 import { EventType, type MatrixActionClientOpts } from "./types.js";
@@ -34,6 +35,7 @@ export async function getMatrixRoomInfo(roomId: string, opts: MatrixActionClient
     let name: string | null = null;
     let topic: string | null = null;
     let canonicalAlias: string | null = null;
+    let altAliases: string[] = [];
     let memberCount: number | null = null;
 
     try {
@@ -53,6 +55,7 @@ export async function getMatrixRoomInfo(roomId: string, opts: MatrixActionClient
     try {
       const aliasState = await client.getRoomStateEvent(resolvedRoom, "m.room.canonical_alias", "");
       canonicalAlias = typeof aliasState?.alias === "string" ? aliasState.alias : null;
+      altAliases = filterStringEntries(aliasState?.alt_aliases);
     } catch {
       // ignore
     }
@@ -69,7 +72,7 @@ export async function getMatrixRoomInfo(roomId: string, opts: MatrixActionClient
       name,
       topic,
       canonicalAlias,
-      altAliases: [], // Would need separate query
+      altAliases,
       memberCount,
     };
   });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This PR uses a branch in the same repository, so maintainers can update it directly.

</details>

## What Problem This Solves

Fixes an issue where users requesting Matrix channel information would receive an empty alternative-alias list even when the room advertised additional addresses.

## Why This Change Was Made

Return `alt_aliases` from the existing `m.room.canonical_alias` state response using the shared string-entry helper. This removes the hardcoded empty result and the stale assumption that a separate request was required.

## User Impact

Channel information includes the room's advertised alternative addresses alongside its canonical alias. Other room metadata remains available as before, with no additional network request.

## Evidence

- The regression failed before the repair when the server response contained two alternative aliases; the other three room-action tests passed. All four tests pass after the repair, covering both absent and populated aliases and the existing room/member fields.
- A synthetic loopback HTTP homeserver exercised the real Matrix SDK, OpenClaw adapter, and `getMatrixRoomInfo`. Before: `altAliases` was `[]`. After: it contained `#incidents:example.org` and `#team:example.org`, with exactly one canonical-alias state request. The fixture did not start sync or use saved accounts; final cleanup awaited `stopWithoutPersist()`. This is local adapter/protocol evidence, not a live public homeserver test.
- Full extension production and test typechecks, full-file lint, formatting, and `check:changed` passed. Independent review found no actionable P0–P2 issues.
- Production delta: +4/-1 lines for projecting the already-fetched state through a shared helper; test delta: +11/-5 lines. No new settings or persistence behavior.
