### PR TITLE
refactor(bench): require process metrics directly

### DIFF
--- a/scripts/bench-gateway-startup.ts
+++ b/scripts/bench-gateway-startup.ts
@@ -473,11 +473,7 @@ function summarizeCase(benchCase: GatewayBenchCase, samples: GatewaySample[]): C
   };
 }
 
-function collectResultFailures(
-  results: CaseResult[],
-  options: { processMetricsRequired?: boolean } = {},
-): BenchmarkFailure[] {
-  const processMetricsRequired = options.processMetricsRequired ?? true;
+function collectResultFailures(results: CaseResult[]): BenchmarkFailure[] {
   const failures: BenchmarkFailure[] = [];
   for (const result of results) {
     result.samples.forEach((sample, index) => {
@@ -491,13 +487,11 @@ function collectResultFailures(
       if (sample.completionMs == null) {
         missing.push("completion");
       }
-      if (processMetricsRequired) {
-        if (sample.cpuMs == null || sample.cpuCoreRatio == null) {
-          missing.push("cpu");
-        }
-        if (sample.maxRssMb == null) {
-          missing.push("rss");
-        }
+      if (sample.cpuMs == null || sample.cpuCoreRatio == null) {
+        missing.push("cpu");
+      }
+      if (sample.maxRssMb == null) {
+        missing.push("rss");
       }
       if (missing.length > 0) {
         failures.push({

--- a/test/scripts/bench-gateway-startup.test.ts
+++ b/test/scripts/bench-gateway-startup.test.ts
@@ -440,7 +440,7 @@ server.listen(port, "127.0.0.1", () => {
       },
     ]);
 
-    expect(testing.collectResultFailures([result], { processMetricsRequired: true })).toEqual([
+    expect(testing.collectResultFailures([result])).toEqual([
       {
         id: "demo",
         reason: "missing /healthz, /readyz, completion, cpu, rss",
@@ -483,7 +483,7 @@ server.listen(port, "127.0.0.1", () => {
       },
     ]);
 
-    expect(testing.collectResultFailures([result], { processMetricsRequired: true })).toEqual([
+    expect(testing.collectResultFailures([result])).toEqual([
       {
         id: "demo",
         reason: "child exited 1",
@@ -526,7 +526,7 @@ server.listen(port, "127.0.0.1", () => {
       },
     ]);
 
-    expect(testing.collectResultFailures([result], { processMetricsRequired: true })).toEqual([]);
+    expect(testing.collectResultFailures([result])).toEqual([]);
   });
 
   it("enforces the combined incident readiness budgets", () => {
@@ -562,7 +562,7 @@ server.listen(port, "127.0.0.1", () => {
       },
     ]);
 
-    expect(testing.collectResultFailures([result], { processMetricsRequired: true })).toEqual([
+    expect(testing.collectResultFailures([result])).toEqual([
       {
         id: "incidentCombined",
         reason: "/healthz p95 30000.0ms must be under 30000.0ms",
@@ -610,7 +610,7 @@ server.listen(port, "127.0.0.1", () => {
       },
     ]);
 
-    expect(testing.collectResultFailures([result], { processMetricsRequired: true })).toEqual([
+    expect(testing.collectResultFailures([result])).toEqual([
       {
         id: "demo",
         reason: "child exited by SIGSEGV",


### PR DESCRIPTION
## What Problem This Solves

Gateway startup benchmark validation retains an unused switch for allowing missing CPU/RSS samples. The benchmark already requires these metrics on every platform, while five tests redundantly override the switch to the same value.

## Why This Change Was Made

Remove the unused optional argument and make the existing CPU/RSS checks direct. The tests now exercise the same one-argument path as the benchmark entry point. No cases, fixtures, or assertions are removed.

## User Impact

No behavior change: missing process metrics still fail the benchmark, zero values remain valid, and failure ordering, child-exit handling, incident budgets, and report formatting are preserved. This removes six tooling lines without adding a replacement seam.

## Evidence

All 74 startup, restart, and shared-runtime cases pass before and after with identical case/status inventories. Independent Codex review found no actionable findings. History confirms the all-platform requirement predates this cleanup; no false caller remains. No new platform execution or performance result is claimed.

All 19 normal changed-file checks passed on the final source in Linux Testbox. The one-shot lease and source capsule are closed.
