### PR TITLE
refactor(google-meet): share browser open and recovery setup

### DIFF
--- a/extensions/google-meet/src/transports/chrome.ts
+++ b/extensions/google-meet/src/transports/chrome.ts
@@ -210,43 +210,14 @@ export async function launchChromeMeet(params: {
 
   await checkRealtimeAudioPrerequisites();
 
-  if (!params.config.chrome.launch) {
-    const recovered = await recoverMeetingBrowserTab({
-      adapter: GOOGLE_MEET_PLATFORM_ADAPTER,
-      allowSessionAdoption: true,
-      autoJoin: params.config.chrome.autoJoin,
-      callBrowser: await resolveLocalMeetingBrowserRequest(params.runtime),
-      captureCaptions: shouldCaptureCaptions(params.mode, params.fullConfig),
-      config: params.config.chrome,
-      locationLabel: "in local Chrome",
-      meetingSessionId: params.meetingSessionId,
-      mode: params.mode,
-      requestedMeetingUrl: params.url,
-      trackedMeetingUrl: params.url,
-      trackedTargetId: undefined,
-    });
-    const audioBridge = MeetingPlatformAdapter.isRealtimeRouteReady(params.mode, recovered.browser)
-      ? await startRealtimeAudioBridge()
-      : undefined;
-    return {
-      launched: false,
-      audioBackend: audio?.backend,
-      audioBridge,
-      browser: recovered.browser,
-      tab: recovered.targetId ? { targetId: recovered.targetId, openedByPlugin: false } : undefined,
-    };
-  }
-
-  const result = await openMeetingWithBrowser({
-    adapter: GOOGLE_MEET_PLATFORM_ADAPTER,
+  const result = await openOrRecoverMeetWithBrowser({
     callBrowser: await resolveLocalMeetingBrowserRequest(params.runtime),
-    config: params.config.chrome,
-    session: {
-      captureCaptions: shouldCaptureCaptions(params.mode, params.fullConfig),
-      meetingSessionId: params.meetingSessionId,
-      mode: params.mode,
-      url: params.url,
-    },
+    config: params.config,
+    captureCaptions: shouldCaptureCaptions(params.mode, params.fullConfig),
+    locationLabel: "in local Chrome",
+    meetingSessionId: params.meetingSessionId,
+    mode: params.mode,
+    url: params.url,
   });
   const shouldStartRealtimeBridge = MeetingPlatformAdapter.isRealtimeRouteReady(
     params.mode,
@@ -366,33 +337,24 @@ export async function readChromeMeetTranscript(
   });
 }
 
-async function openMeetWithBrowserProxy(params: {
-  runtime: PluginRuntime;
-  nodeId: string;
+async function openOrRecoverMeetWithBrowser(params: {
+  callBrowser: MeetingBrowserRequestCaller;
+  locationLabel: string;
   config: GoogleMeetConfig;
   captureCaptions: boolean;
   mode: GoogleMeetMode;
   meetingSessionId: string;
   url: string;
 }): Promise<{ launched: boolean; browser?: GoogleMeetChromeHealth; tab?: GoogleMeetBrowserTab }> {
-  const callBrowser: MeetingBrowserRequestCaller = async (request) =>
-    await callBrowserProxyOnNode({
-      runtime: params.runtime,
-      nodeId: params.nodeId,
-      method: request.method,
-      path: request.path,
-      body: request.body,
-      timeoutMs: request.timeoutMs,
-    });
   if (!params.config.chrome.launch) {
     const recovered = await recoverMeetingBrowserTab({
       adapter: GOOGLE_MEET_PLATFORM_ADAPTER,
       allowSessionAdoption: true,
       autoJoin: params.config.chrome.autoJoin,
-      callBrowser,
+      callBrowser: params.callBrowser,
       captureCaptions: params.captureCaptions,
       config: params.config.chrome,
-      locationLabel: "on the selected Chrome node",
+      locationLabel: params.locationLabel,
       meetingSessionId: params.meetingSessionId,
       mode: params.mode,
       requestedMeetingUrl: params.url,
@@ -407,7 +369,7 @@ async function openMeetWithBrowserProxy(params: {
   }
   return await openMeetingWithBrowser({
     adapter: GOOGLE_MEET_PLATFORM_ADAPTER,
-    callBrowser,
+    callBrowser: params.callBrowser,
     config: params.config.chrome,
     session: {
       captureCaptions: params.captureCaptions,
@@ -533,9 +495,9 @@ export async function launchChromeMeetOnNode(params: {
         }),
       )
     : undefined;
-  const browserControl = await openMeetWithBrowserProxy({
-    runtime: params.runtime,
-    nodeId,
+  const browserControl = await openOrRecoverMeetWithBrowser({
+    callBrowser: chromeNodeBrowserRequest(params.runtime, nodeId),
+    locationLabel: "on the selected Chrome node",
     config: params.config,
     captureCaptions: shouldCaptureCaptions(params.mode, params.fullConfig),
     mode: params.mode,


### PR DESCRIPTION
## What Problem This Solves

Google Meet carries parallel browser/audio orchestration beside the shared meeting-bot owner. This maintainer-requested consolidation precursor removes the duplicated local/node browser open-or-recover sequence while the full SDK composition contract is decided.

## Why This Change Was Made

Both Google Meet routes now use one private helper around the existing `meeting-runtime` browser APIs. Audio prerequisites and external health checks still finish before local browser routing, and bridge startup still waits for the same readiness check. Production delta: 16 added, 54 removed (net -38); tests unchanged.

The eventual canonical transport/facade/setup owners remain `src/meeting-bot`. This bounded PR does not claim that migration is complete. The caption-serialization work in #140682 is separate and untouched; #140792's platform-guard coverage is already on main.

## User Impact

No intentional user-visible behavior, configuration, SDK signature, transcript storage, or endpoint-permission change.

## Deferred API choice (maintainer)

The maintainer approved landing this bounded precursor independently; the broader API design below remains deferred.

Full consolidation needs public composition parameters that the campaign decision gate reserves for maintainer approval:

- **Node recovery:** manual recovery deliberately re-resolves the configured node; leave/transcript reads preserve the session pin, including empty-string identity. Decide whether automatic health refresh should retain Google's configured-node behavior or use core's session pin.
- **Tracked-tab ownership:** preserve create→join ownership and inherited shared-tab ownership. Google bridge restart omits the tracked target and requester session key that core carries; repairing that drift needs a multi-tab/requester regression case.
- **External bridge health:** retain the documented bidi-only external daemon/start/health path. Core's node host supports it, but the Chrome transport and browser facade do not expose its bridge result or forward its command fields.
- **Rollback:** core disposes failed engine transports, stops node bridges and rolls back browser joins; Google lacks that outer cleanup. This is source-supported cleanup drift, not yet an execution-proven fix. Decide and prove the intended policy before replacing the transport.
- **`launch:false`:** Google recovers existing tabs on launch but skips browser leave; core permits leave for reused tabs. Preserve Google's current behavior until explicitly decided.

The facade also needs typed composition for Twilio, browser creation, mode normalization and `keepBrowserTab`; setup needs Google's OAuth/Twilio seed and diagnostic policy. Google transcribe currently invokes node `start`, while core skips it. Do not erase these differences in a factory swap.

## Evidence

- Refreshed onto main with the shared Telegram lint fixes; `git range-diff` confirmed this private helper extraction is unchanged.
- `node scripts/run-vitest.mjs extensions/google-meet src/meeting-bot`: 49 files, 536 tests passed on the refreshed head.
- `node scripts/check-changed.mjs`: 19 checks passed. Extension lint preparation hit the approved nested-worktree `Declaration input escapes checkout` limitation; exact-head hosted CI supplies that boundary proof.
- Fresh independent Codex autoreview: scoped-clean through P2, zero actionable findings. `git diff --check` passed.
- Exact-head [CI run 34119393388](https://github.com/openclaw/openclaw/actions/runs/34119393388) and the required `openclaw/ci-gate` passed on `3772deefc85b60ccde9d6c22766db791d1845380`. Fresh check reads showed no failures; no manual CI rerun was required.
- Native review artifacts validated, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 140972` passed without changing the green CI head.
- No live Chrome/audio meeting claim. Live multi-tab/lifecycle proof remains part of the deferred broader migration.
