### PR TITLE
fix(ui): wait for cron model picker dismissal in e2e

### DIFF
--- a/ui/src/e2e/cron-agent-ownership.e2e.test.ts
+++ b/ui/src/e2e/cron-agent-ownership.e2e.test.ts
@@ -58,6 +58,8 @@ suite.define(() => {
         await page.getByRole("option", { name: "fixture/old", exact: true }).waitFor();
         await page.screenshot({ path: path.join(suite.artifactDir, "initial.png") });
         await page.keyboard.press("Escape");
+        // Finish the hide animation before a later click reopens the picker.
+        await picker.getByRole("listbox").waitFor({ state: "hidden" });
 
         await gateway.setMethodResponse("models.list", models("fixture/new"));
         await gateway.emitGatewayEvent("chat.metadata.changed", {});
@@ -67,6 +69,7 @@ suite.define(() => {
         await page.getByRole("option", { name: "fixture/new", exact: true }).waitFor();
         await page.screenshot({ path: path.join(suite.artifactDir, "refreshed.png") });
         await page.keyboard.press("Escape");
+        await picker.getByRole("listbox").waitFor({ state: "hidden" });
 
         await gateway.setMethodResponse("models.list", {
           __mockError: { code: "UNAVAILABLE", message: "Model suggestions unavailable" },


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent Control UI e2e failure that blocks unrelated PRs in `checks-ui-e2e`: the automation catalog-refresh case times out waiting for the refreshed model option after reopening its picker.

Related: #139876, #140860. Observed on #140677, #140654, #140742, #140887, and #140645.

## Why This Change Was Made

The catalog refresh already succeeds: the test confirms that `fixture/new` exists and `fixture/old` is gone before the failure. Cron reads `models.list` directly and does not use the shared subscription helper extracted in #140860.

Escape starts Web Awesome's asynchronous close animation. Reopening before it finishes lets the previous close hide the newly opened listbox. The scenario now waits for the listbox to become hidden after each Escape. This is the owning test's missing interaction boundary; every existing catalog, visibility, error-recovery, draft-preservation, and no-write assertion remains intact. No production code, dependency patch, mock, timeout, retry, skip, or baseline changes.

## User Impact

No product behavior change. The browser regression test still proves live catalog suggestions and draft preservation, with a completed dismissal before reopening the picker.

## Evidence

Original [failing CI job](https://github.com/openclaw/openclaw/actions/runs/34089289090/job/101639481386), head `50f77ae9c17a2e49f0cce91622fdf71a85188045`: `TimeoutError: locator.waitFor: Timeout 30000ms exceeded`, waiting for `getByRole('option', { name: 'fixture/new', exact: true })` at line 67. The retained screenshot shows an expanded picker chevron and hidden popup; both prepared-only catalog requests completed and no page errors were recorded.

Unmodified revision checks, running the exact cron e2e file headlessly with `CI=1 OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY=1`:

| Revision | Result |
| --- | --- |
| Main `2d58961f33f` | 4/5; run 4 reproduces the same line-67 visibility timeout |
| Parent of #140860, `7bf42984a27` | 5/5 |
| #140860, `afed2b5c956` | 1/1 |
| #140883, `7e8cffd9a38` | 1/1 |
| #140633, `caec9c81e73` | 1/1 |

This is intermittent on main, not a deterministic failure introduced at one of those suspect commits. The local harness uses its unchanged 10-second visibility timeout for `CI=1`; GitHub Actions uses its unchanged 30-second timeout. The original test was introduced in #139876; the select transition implementation predates all suspect consolidations.

The unmodified CI-equivalent shard (`--shard 4/12`) passed 129/129 tests across 33 files, including this case. The repaired exact file passes 5/5 runs on refreshed base `aa3ee347b8a` (both cases pass each time). Independent Codex review is clean through P2. Production delta: 0; test delta: +3 lines.

Commands:

```sh
CI=1 OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/cron-agent-ownership.e2e.test.ts
CI=1 OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner --shard 4/12
```

### Separate composer validation finding

The required full `ui/src/e2e` run hit an unrelated failure in `chat-composer-redesign.e2e.test.ts:243`: "keeps mobile picker panels above an attachment-expanded composer" measured a picker width of `332.09999084472656`, below the required `368`. The full run was interrupted after this failure to honor the campaign stop rule.

One focused reproduction of the unchanged composer file failed again: **8 passed, 1 failed**, picker width `361.73216247558594 < 368`. The cron change only adds waits in its own isolated test file; it changes neither the composer nor the shared harness.

```sh
CI=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e
CI=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-composer-redesign.e2e.test.ts
```

The composer failure is being repaired separately in #140997. The earlier local full-suite failure remains recorded and is not claimed green. No budget or baseline was edited.

This uses synthetic local browser/Gateway fixtures; no external-provider live claim or Testbox lease.


### Completed landing proof

The unchanged patch is on head `d2e6d8f1869920dfbb31bddc56cb6f678d1c9913`, rebased onto main `86a3c7267be`. Pre/post-rebase patches compare byte-identically. `node scripts/check-changed.mjs` passed, followed by `pnpm build` (21m 50.2s) and `pnpm ui:check-performance`. Startup JavaScript is **347,973 B gzip in 8 requests**, below the **350,953 B / 18-request** limits; startup CSS is **43,989 B gzip**. Baselines are unchanged.

[Exact-head CI run 34096502837](https://github.com/openclaw/openclaw/actions/runs/34096502837) is green. Native review artifacts validate; `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 140974` passed without a head change, using hosted evidence and no separately allocated Testbox. ClawSweeper reported no actionable findings.
