### PR TITLE
fix: restore local password auth in gateway status

### DIFF
--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -105,7 +105,7 @@ The `deviceAutoApprove` examples below target beta/current-main builds. Stable `
 
 `allowLoopback` trusts local processes on the Gateway host to the same degree as the reverse proxy. Enable it only when the Gateway is still firewalled from direct remote access and the local proxy strips or overwrites client-supplied identity headers.
 
-Internal Gateway clients that do not travel through the reverse proxy should use `gateway.auth.password` / `OPENCLAW_GATEWAY_PASSWORD`, not trusted-proxy identity headers. Non-loopback Control UI deployments still need explicit `gateway.controlUi.allowedOrigins`.
+Internal Gateway clients that do not travel through the reverse proxy should use `gateway.auth.password` / `OPENCLAW_GATEWAY_PASSWORD`, not trusted-proxy identity headers. `openclaw gateway status` selects this local password automatically when no `--url` override is supplied, including with `--json`. Non-loopback Control UI deployments still need explicit `gateway.controlUi.allowedOrigins`.
 </Warning>
 
 ### Configuration reference

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -738,7 +738,7 @@ describe("gatherDaemonStatus", () => {
     const originalProbe = callGatewayStatusProbe.getMockImplementation();
     assert(originalProbe);
     const server = createServer({ key: TEST_TLS_KEY_PEM, cert: TEST_TLS_CERT_PEM });
-    const wss = new WebSocketServer({ noServer: true });
+    const wss = new WebSocketServer({ noServer: true, maxPayload: 1_000_000 });
     const sockets = new Set<Socket>();
     const closedSockets: Promise<void>[] = [];
     const edgeAuthHeaders: unknown[] = [];

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -1622,29 +1622,69 @@ describe("gatherDaemonStatus", () => {
     );
   });
 
-  it("resolves daemon gateway auth password SecretRef values before probing", async () => {
-    daemonLoadedConfig = {
-      gateway: {
-        bind: "lan",
-        tls: { enabled: true },
-        auth: {
-          password: { source: "env", provider: "default", id: "DAEMON_GATEWAY_PASSWORD" },
+  it.each(["configured", "environment"] as const)(
+    "uses the trusted-proxy local-direct password from %s",
+    async (source) => {
+      daemonLoadedConfig = {
+        gateway: {
+          bind: "loopback",
+          auth: {
+            mode: "trusted-proxy",
+            ...(source === "configured" ? { password: "local-config-password" } : {}),
+          },
+          remote: { url: "wss://peer.example", password: "peer-password" },
         },
-      },
-      secrets: {
-        providers: {
-          default: { source: "env" },
+      };
+      serviceReadCommand.mockResolvedValueOnce({
+        programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],
+        environment: {
+          OPENCLAW_STATE_DIR: "/tmp/openclaw-daemon",
+          OPENCLAW_CONFIG_PATH: "/tmp/openclaw-daemon/openclaw.json",
+          OPENCLAW_GATEWAY_PASSWORD: "local-service-password",
         },
-      },
-    };
-    setTestEnvValue("DAEMON_GATEWAY_PASSWORD", "daemon-secretref-password"); // pragma: allowlist secret
+      });
+      setTestEnvValue("OPENCLAW_GATEWAY_PASSWORD", "ambient-password");
 
-    await gatherStatus();
+      await gatherStatus();
 
-    expect((callArg(callGatewayStatusProbe) as { password?: string }).password).toBe(
-      "daemon-secretref-password",
-    ); // pragma: allowlist secret
-  });
+      const input = callArg(callGatewayStatusProbe) as GatewayStatusProbeOptions;
+      expect(input.password).toBe(
+        source === "configured" ? "local-config-password" : "local-service-password",
+      );
+      expect(input.token).toBeUndefined();
+      expect(input.urlOverride).toBeUndefined();
+      expect(input.config?.gateway?.auth).toEqual({ mode: "trusted-proxy" });
+      expect(input.config?.gateway?.remote?.password).toBeUndefined();
+    },
+  );
+
+  it.each([undefined, "password", "trusted-proxy"] as const)(
+    "resolves daemon %s auth password SecretRef values before probing",
+    async (mode) => {
+      daemonLoadedConfig = {
+        gateway: {
+          bind: "lan",
+          tls: { enabled: true },
+          auth: {
+            mode,
+            password: { source: "env", provider: "default", id: "DAEMON_GATEWAY_PASSWORD" },
+          },
+        },
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+      };
+      setTestEnvValue("DAEMON_GATEWAY_PASSWORD", "daemon-secretref-password"); // pragma: allowlist secret
+
+      await gatherStatus();
+
+      expect((callArg(callGatewayStatusProbe) as { password?: string }).password).toBe(
+        "daemon-secretref-password",
+      ); // pragma: allowlist secret
+    },
+  );
 
   it("resolves daemon gateway auth token SecretRef values before probing", async () => {
     daemonLoadedConfig = {
@@ -1671,38 +1711,45 @@ describe("gatherDaemonStatus", () => {
     );
   });
 
-  it("skips daemon exec SecretRef probe auth when exec refs are disabled", async () => {
-    daemonLoadedConfig = {
-      gateway: {
-        bind: "lan",
-        tls: { enabled: true },
-        auth: {
-          mode: "token",
-          token: { source: "exec", provider: "vault", id: "gateway/token" },
+  it.each(["token", "trusted-proxy"] as const)(
+    "skips daemon %s exec SecretRef probe auth when exec refs are disabled",
+    async (mode) => {
+      daemonLoadedConfig = {
+        gateway: {
+          bind: "lan",
+          tls: { enabled: true },
+          auth: {
+            mode,
+            [mode === "token" ? "token" : "password"]: {
+              source: "exec",
+              provider: "vault",
+              id: "gateway/credential",
+            },
+          },
         },
-      },
-      secrets: {
-        providers: {
-          vault: { source: "exec", command: "/bin/false" },
+        secrets: {
+          providers: {
+            vault: { source: "exec", command: "/bin/false" },
+          },
         },
-      },
-    };
+      };
 
-    const status = await gatherStatus({ allowExecSecretRefs: false });
+      const status = await gatherStatus({ allowExecSecretRefs: false });
 
-    expect(resolveGatewayProbeAuthSafeWithSecretInputsCalls).not.toHaveBeenCalled();
-    const probeInput = callArg(callGatewayStatusProbe) as {
-      token?: string;
-      password?: string;
-      allowRpcConfigCredentials?: boolean;
-    };
-    expect(probeInput.token).toBeUndefined();
-    expect(probeInput.password).toBeUndefined();
-    expect(probeInput.allowRpcConfigCredentials).toBe(false);
-    expect(status.rpc?.authWarning).toContain(
-      "gateway credentials use an exec SecretRef and exec SecretRefs are disabled",
-    );
-  });
+      expect(resolveGatewayProbeAuthSafeWithSecretInputsCalls).not.toHaveBeenCalled();
+      const probeInput = callArg(callGatewayStatusProbe) as {
+        token?: string;
+        password?: string;
+        allowRpcConfigCredentials?: boolean;
+      };
+      expect(probeInput.token).toBeUndefined();
+      expect(probeInput.password).toBeUndefined();
+      expect(probeInput.allowRpcConfigCredentials).toBe(false);
+      expect(status.rpc?.authWarning).toContain(
+        "gateway credentials use an exec SecretRef and exec SecretRefs are disabled",
+      );
+    },
+  );
 
   it("keeps service password auth independent of unused remote exec SecretRefs", async () => {
     daemonLoadedConfig = {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -494,12 +494,10 @@ export async function gatherDaemonStatus(
       });
     if (probeUrlOverride || explicitAuth.token || explicitAuth.password) {
       daemonProbeAuth = explicitAuth;
-    } else if (
-      daemonCfg.gateway?.auth?.mode === "none" ||
-      daemonCfg.gateway?.auth?.mode === "trusted-proxy"
-    ) {
+    } else if (daemonCfg.gateway?.auth?.mode === "none") {
       daemonProbeAuth = {};
     } else if (canResolveProbeAuth) {
+      // Trusted-proxy probes still use the local-direct password owned by this resolver.
       const probeAuthResolution = await loadGatewayProbeAuthModule().then(
         ({ resolveGatewayProbeAuthSafeWithSecretInputs }) =>
           resolveGatewayProbeAuthSafeWithSecretInputs({


### PR DESCRIPTION
Related: #135862

## What Problem This Solves

Resolves a problem where `openclaw gateway status` reported an authentication failure for a local Gateway in trusted-proxy mode even though its local-direct password was configured. The JSON command could exit successfully with `rpc.ok: false`, causing callers that inspect that field to reject an otherwise reachable Gateway.

## Why This Change Was Made

Status credential selection grouped trusted-proxy with credential-free `none` mode. Trusted-proxy already supports password authentication for local-direct clients, so it must use the existing probe credential resolver. This restores configured, environment and SecretRef password selection while preserving explicit URL/auth precedence, remote credential isolation and disabled-exec restrictions. Server authorization is unchanged.

## User Impact

Local status checks can authenticate with the existing password configuration, including under an external supervisor. Explicit URL targets still require their own credentials. The documentation clarifies the default local-target behavior.

## Evidence

- Baseline: four intended credential-contract failures, with 16 existing controls passing.
- Candidate: 199 focused/sibling tests passed; two existing Windows/macOS-only cases skipped. This includes all four regressions, status JSON projection, target/probe behavior, and canonical probe auth.
- Independent P2 review found no actionable findings; unchanged credential owners and the server's local-direct contract were also directly audited.
- On `b6fe8d2454d2`, full changed-scope checks passed on Linux/Node 26.7. An ordinary source-entry `gateway status --json` call against a real isolated Gateway returned `rpc.ok: true` with external-supervisor context, fresh client state and normal password configuration. No credential/URL overrides or model turns were used; the client process, Gateway and temporary state closed cleanly. This is actual Vitest minimal Gateway startup plus the source-entry CLI, not compiled packaging or full startup validation.
- OpenGrep reported an existing TLS test server missing an explicit payload bound. The follow-up changes only that fixture to its existing advertised 1,000,000-byte limit; the two matching/mismatched TLS cases and independent incremental review cover that line. Production source and documentation remain identical to the completed b6 proof.
- A preliminary proof preflight refused an incorrectly assumed source-carrier parent before any workload ran. The successful run verifies the canonical carrier base and exact published source tree, retaining the original commit and managed closure receipts. No source-trust check was bypassed.
