### PR TITLE
fix(browser): reject unsupported buttons in click commands

### DIFF
--- a/extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts
@@ -32,6 +32,7 @@ const { registerBrowserElementCommands } = await import("./register.element.js")
 
 function createElementProgram(): Command {
   const { program, browser, parentOpts } = createBrowserProgram();
+  browser.exitOverride().configureOutput({ writeErr: () => {}, writeOut: () => {} });
   registerBrowserElementCommands(browser, parentOpts);
   return program;
 }
@@ -164,6 +165,37 @@ describe("browser element commands", () => {
     const capture = getBrowserCliRuntimeCapture();
     expect(capture.runtimeErrors.join("\n")).toContain("ref is required");
     expect(mocks.callBrowserRequest).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "click",
+      argv: ["browser", "click", "ref-1", "--button", "auxiliary"],
+    },
+    {
+      name: "click-coords",
+      argv: ["browser", "click-coords", "10", "20", "--button", "Left"],
+    },
+  ])("rejects an invalid --button for $name before dispatch", async ({ argv }) => {
+    const program = createElementProgram();
+
+    await expect(program.parseAsync(argv, { from: "user" })).rejects.toMatchObject({
+      code: "commander.invalidArgument",
+      exitCode: 1,
+    });
+
+    expect(mocks.callBrowserRequest).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "click", argv: ["browser", "click", "ref-1"] },
+    { name: "click-coords", argv: ["browser", "click-coords", "10", "20"] },
+  ])("leaves button undefined for $name when omitted", async ({ argv }) => {
+    const program = createElementProgram();
+
+    await program.parseAsync(argv, { from: "user" });
+
+    expect(getLastActionBody()?.button).toBeUndefined();
   });
 
   it("rejects non-decimal coordinate values before dispatch", async () => {

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.element.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.element.ts
@@ -19,6 +19,17 @@ import {
   resolveBrowserActionContext,
 } from "./shared.js";
 
+function parseBrowserMouseButtonOption(value: string): "left" | "right" | "middle" {
+  if (value === "left" || value === "right" || value === "middle") {
+    return value;
+  }
+  throw Object.assign(new Error("--button must be left, right, or middle."), {
+    name: "InvalidArgumentError",
+    code: "commander.invalidArgument",
+    exitCode: 1,
+  });
+}
+
 /** Registers element-centric Browser action commands. */
 export function registerBrowserElementCommands(
   browser: Command,
@@ -72,7 +83,7 @@ export function registerBrowserElementCommands(
     .argument("<ref>", "Ref id from snapshot")
     .option("--target-id <id>", BROWSER_TAB_REFERENCE_HELP)
     .option("--double", "Double click", false)
-    .option("--button <left|right|middle>", "Mouse button to use")
+    .option("--button <left|right|middle>", "Mouse button to use", parseBrowserMouseButtonOption)
     .option("--modifiers <list>", "Comma-separated modifiers (Shift,Alt,Meta)")
     .action(async (ref: string | undefined, opts, cmd) => {
       const refValue = requireRef(ref);
@@ -110,7 +121,7 @@ export function registerBrowserElementCommands(
     .argument("<y>", "Viewport y coordinate")
     .option("--target-id <id>", BROWSER_TAB_REFERENCE_HELP)
     .option("--double", "Double click", false)
-    .option("--button <left|right|middle>", "Mouse button to use")
+    .option("--button <left|right|middle>", "Mouse button to use", parseBrowserMouseButtonOption)
     .option("--delay-ms <ms>", "Delay between mouse down/up", (v: string) =>
       parseBrowserNonNegativeIntegerOption(v, "--delay-ms"),
     )


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw browser click` and `click-coords` send unsupported `--button` values to the Browser service instead of reporting an argument error immediately.

## Why This Change Was Made

Both commands validate the existing option during Commander parsing. Valid values and omitted options keep their existing request bodies. Server validation remains in place for other clients.

## User Impact

Unsupported buttons produce an immediate error that names `left`, `right`, and `middle`, with exit code 1 and no Browser request. Supported clicks continue to work.

## Evidence

Tested the compiled CLI in an isolated Linux environment with a request recorder and a real Gateway, Chrome, and synthetic page.

| Case | Before | After |
| --- | --- | --- |
| Invalid button, both commands | Browser request sent; server rejects it | Exit 1 during option parsing; zero Browser requests |
| Empty, whitespace, mixed-case, near-match values | Forwarded or normalized | Rejected without dispatch |
| `left`, `right`, `middle`, omitted | Existing request body and page events | Same request body and page events |
| Target, ref, coordinates, double click, modifiers, delay, profile, timeout, output | Existing behavior | Preserved |
| Direct API request with invalid button | Server rejects it | Server still rejects it |

Example after-fix output:

```text
openclaw browser click e1 --button auxiliary
OpenClaw could not parse this command: option '--button <left|right|middle>' argument 'auxiliary' is invalid. --button must be left, right, or middle.
Try: openclaw browser click --help
exit: 1
Browser requests: 0

openclaw browser click-coords 30 40 --button auxiliary
OpenClaw could not parse this command: option '--button <left|right|middle>' argument 'auxiliary' is invalid. --button must be left, right, or middle.
Try: openclaw browser click-coords --help
exit: 1
Browser requests: 0
```

Baseline: `252158295ee487c4145404367fa15e3db588989b`. Candidate: `c3fb332dff1cd0b3ebf721b1bcc3971dd3ce8d91`, using its CI test-merge artifact from `19e6a765d94182b6e2e8e7746523f1d1c841464a`.

- Focused tests: 16 passed, including both invalid-button cases and omitted-value controls.
- Formatting and lint: passed for both changed files.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34096496194): passed.
- Regression check on current main: the two new invalid-button tests fail for the intended missing rejection; 14 controls pass.
- Independent behavior validation: all 11 observable acceptance clauses pass, including varied inputs and real page events. Source-only absence claims remain covered by code review; fixture cleanup follows landing.
