### PR TITLE
fix(webchat): preserve saved reply paragraph and caption order

### DIFF
--- a/src/cron/isolated-agent/current-session-completion.ts
+++ b/src/cron/isolated-agent/current-session-completion.ts
@@ -5,7 +5,7 @@ import {
   removeManagedOutgoingMediaBlocks,
 } from "../../gateway/managed-image-attachments.js";
 import {
-  buildAssistantDisplayContentFromReplyPayloads,
+  buildAssistantReplyContent,
   hasAssistantDisplayMediaContent,
   hasManagedOutgoingAssistantContent,
 } from "../../gateway/server-methods/chat-assistant-content.js";
@@ -58,7 +58,7 @@ export async function commitCurrentSessionCronCompletion(
       expectedGeneration: params.sourceSessionGeneration,
       text: completionText,
       prepareDisplayContent: async () => {
-        preparedContent = await buildAssistantDisplayContentFromReplyPayloads({
+        const { assistantContent } = await buildAssistantReplyContent({
           sessionKey: sourceSessionKey,
           agentId: params.agentId,
           // Enrich each payload before rendering so rich text, media order, and
@@ -81,6 +81,7 @@ export async function commitCurrentSessionCronCompletion(
             );
           },
         });
+        preparedContent = assistantContent;
         return hasAssistantDisplayMediaContent(preparedContent) ? preparedContent : undefined;
       },
       idempotencyKey: `cron-current-completion:${runId}`,

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -141,7 +141,7 @@ vi.mock("../../sessions/background-session-result.js", () => ({
 }));
 
 vi.mock("../../gateway/server-methods/chat-assistant-content.js", () => ({
-  buildAssistantDisplayContentFromReplyPayloads: vi.fn(),
+  buildAssistantReplyContent: vi.fn(),
   hasAssistantDisplayMediaContent: vi.fn(),
   hasManagedOutgoingAssistantContent: vi.fn(),
 }));

--- a/src/gateway/server-methods/chat-assistant-content.ts
+++ b/src/gateway/server-methods/chat-assistant-content.ts
@@ -1,4 +1,3 @@
-import { expectDefined } from "@openclaw/normalization-core";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   getReplyPayloadMetadata,
@@ -18,6 +17,7 @@ import {
   prepareOutgoingMediaFromReplyPayload,
 } from "../managed-image-attachments.js";
 import { formatForLog } from "../ws-log.js";
+import type { buildWebchatAssistantMessageFromReplyPayloads } from "./chat-webchat-media.js";
 
 const MANAGED_OUTGOING_MEDIA_PATH_PREFIX = "/api/chat/media/outgoing/";
 
@@ -57,7 +57,7 @@ export function isMediaBearingPayload(payload: ReplyPayload): boolean {
   return Boolean(payload.mediaUrls?.some((url) => url.trim()));
 }
 
-export function hasSensitiveMediaPayload(payloads: ReplyPayload[]): boolean {
+function hasSensitiveMediaPayload(payloads: ReplyPayload[]): boolean {
   return payloads.some(
     (payload) =>
       payload.sensitiveMedia === true &&
@@ -122,7 +122,7 @@ export function extractAssistantDisplayTextFromContent(
   return text || undefined;
 }
 
-export async function buildAssistantDisplayContentFromReplyPayloads(params: {
+export async function buildAssistantReplyContent(params: {
   sessionKey: string;
   agentId?: string;
   payloads: ReplyPayload[];
@@ -131,7 +131,13 @@ export async function buildAssistantDisplayContentFromReplyPayloads(params: {
   includeSensitiveDisplay?: boolean;
   onManagedMediaPrepareError?: (message: string) => void;
   onSensitiveDisplayPrepareError?: (message: string) => void;
-}): Promise<AssistantDisplayContentBlock[] | undefined> {
+  transcriptMediaMessage?: Awaited<
+    ReturnType<typeof buildWebchatAssistantMessageFromReplyPayloads>
+  >;
+}): Promise<{
+  assistantContent: AssistantDisplayContentBlock[] | undefined;
+  persistedAssistantContent: AssistantDisplayContentBlock[] | undefined;
+}> {
   const rawTextPayloadCount = params.payloads.filter(
     (payload) =>
       payload.isReasoning !== true &&
@@ -145,16 +151,21 @@ export async function buildAssistantDisplayContentFromReplyPayloads(params: {
         buildManagedMediaFailureBlock,
       ),
     );
-    if (failureBlocks.length > 0) {
-      return failureBlocks;
-    }
-    return rawTextPayloadCount > 0 ? [{ type: "text", text: "" }] : undefined;
+    const assistantContent =
+      failureBlocks.length > 0
+        ? failureBlocks
+        : rawTextPayloadCount > 0
+          ? [{ type: "text", text: "" }]
+          : undefined;
+    return { assistantContent, persistedAssistantContent: assistantContent };
   }
 
   const preserveTextBoundaries =
     plan.filter(({ payload }) => typeof payload.text === "string" && payload.text.trim()).length >
     1;
   const content: AssistantDisplayContentBlock[] = [];
+  const persistedContent: AssistantDisplayContentBlock[] = [];
+  const persistSensitiveDisplay = !hasSensitiveMediaPayload(params.payloads);
   let strippedTextPayloadCount = 0;
   for (const entry of plan) {
     const payload = entry.payload;
@@ -176,11 +187,20 @@ export async function buildAssistantDisplayContentFromReplyPayloads(params: {
     } else if (typeof payload.text === "string" && payload.text.trim().length > 0) {
       strippedTextPayloadCount += 1;
     }
+    // Display text may merge across payloads. Transcript captions and directives
+    // stay attached to their source payload instead of matching display slots.
+    const transcriptText = params.transcriptMediaMessage?.payloadTexts[entry.sourceIndex] ?? text;
+    if (transcriptText && !isSuppressedControlReplyText(transcriptText)) {
+      persistedContent.push({ type: "text", text: transcriptText });
+    }
     if (params.includeSensitiveDisplay === true) {
       try {
         const pairingQrBlock = await buildPairingQrAssistantContentBlock(payload);
         if (pairingQrBlock) {
           content.push(pairingQrBlock);
+          if (persistSensitiveDisplay) {
+            persistedContent.push(pairingQrBlock);
+          }
         }
       } catch (err) {
         params.onSensitiveDisplayPrepareError?.(formatForLog(err));
@@ -206,54 +226,26 @@ export async function buildAssistantDisplayContentFromReplyPayloads(params: {
         }
       }
     }
-    content.push(...mediaBlocks);
-    content.push(...mediaFailures.map(buildManagedMediaFailureBlock));
+    const mediaContent = [...mediaBlocks, ...mediaFailures.map(buildManagedMediaFailureBlock)];
+    content.push(...mediaContent);
+    persistedContent.push(...mediaContent);
   }
 
-  if (content.length > 0) {
-    return content;
-  }
-  return strippedTextPayloadCount > 0 ? [{ type: "text", text: "" }] : undefined;
-}
-
-export function replaceAssistantContentTextBlocks(
-  content: readonly AssistantDisplayContentBlock[] | undefined,
-  transcriptMediaMessage: { content: Array<Record<string, unknown>> } | null,
-): AssistantDisplayContentBlock[] | undefined {
-  const transcriptTextBlocks = (transcriptMediaMessage?.content ?? []).filter(
-    (block): block is AssistantDisplayContentBlock =>
-      Boolean(block) &&
-      typeof block === "object" &&
-      block.type === "text" &&
-      typeof block.text === "string",
-  );
-  if (transcriptTextBlocks.length === 0) {
-    return content ? [...content] : undefined;
-  }
-  if (!content || content.length === 0) {
-    return [...transcriptTextBlocks];
-  }
-  const merged: AssistantDisplayContentBlock[] = [];
-  let transcriptTextIndex = 0;
-  for (const block of content) {
-    if (
-      block?.type === "text" &&
-      typeof block.text === "string" &&
-      transcriptTextIndex < transcriptTextBlocks.length
-    ) {
-      const replacement = expectDefined(
-        transcriptTextBlocks[transcriptTextIndex++],
-        "transcript text blocks entry at transcript text index++",
-      );
-      merged.push(replacement);
-      continue;
-    }
-    merged.push(block);
-  }
-  if (transcriptTextIndex < transcriptTextBlocks.length) {
-    merged.unshift(...transcriptTextBlocks.slice(transcriptTextIndex));
-  }
-  return merged;
+  const assistantContent =
+    content.length > 0
+      ? content
+      : strippedTextPayloadCount > 0
+        ? [{ type: "text", text: "" }]
+        : undefined;
+  return {
+    assistantContent,
+    persistedAssistantContent:
+      persistedContent.length > 0
+        ? persistedContent
+        : strippedTextPayloadCount > 0
+          ? [{ type: "text", text: "" }]
+          : undefined,
+  };
 }
 
 function isManagedOutgoingMediaUrl(value: unknown): boolean {

--- a/src/gateway/server-methods/chat-reply-media.test.ts
+++ b/src/gateway/server-methods/chat-reply-media.test.ts
@@ -16,11 +16,9 @@ import {
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
 import { createManagedOutgoingMediaBlocks as createManagedOutgoingImageBlocks } from "../managed-image-attachments.js";
-import {
-  buildAssistantDisplayContentFromReplyPayloads,
-  replaceAssistantContentTextBlocks,
-} from "./chat-assistant-content.js";
+import { buildAssistantReplyContent } from "./chat-assistant-content.js";
 import { normalizeWebchatReplyMediaPathsForDisplay } from "./chat-reply-media.js";
+import { buildWebchatAssistantMessageFromReplyPayloads } from "./chat-webchat-media.js";
 
 const PNG_BYTES = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
@@ -235,7 +233,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
         ],
       });
       expect(payload?.mediaUrls).toHaveLength(3);
-      const content = await buildAssistantDisplayContentFromReplyPayloads({
+      const { assistantContent: content } = await buildAssistantReplyContent({
         sessionKey: TEST_SESSION_KEY,
         agentId: "main",
         payloads: payload ? [payload] : [],
@@ -338,7 +336,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     const source = "data:audio/mpeg;base64,not-valid!";
     const errors: string[] = [];
 
-    const content = await buildAssistantDisplayContentFromReplyPayloads({
+    const { assistantContent: content } = await buildAssistantReplyContent({
       sessionKey: TEST_SESSION_KEY,
       agentId: "main",
       payloads: [{ mediaUrls: [source] }],
@@ -366,18 +364,19 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     await fs.mkdir(workspaceDir, { recursive: true });
     await fs.writeFile(sourcePath, Buffer.from([0, 1, 2, 3]));
 
-    const content = await buildAssistantDisplayContentFromReplyPayloads({
-      sessionKey: TEST_SESSION_KEY,
-      agentId: "main",
-      payloads: [
-        {
-          text: "Artifact result",
-          mediaUrls: [sourcePath],
-          attachments: [{ name: "mystery.blob", trustedLocalMedia: true }],
-        },
-      ],
-      managedMediaLocalRoots: [workspaceDir],
-    });
+    const { assistantContent: content, persistedAssistantContent } =
+      await buildAssistantReplyContent({
+        sessionKey: TEST_SESSION_KEY,
+        agentId: "main",
+        payloads: [
+          {
+            text: "Artifact result",
+            mediaUrls: [sourcePath],
+            attachments: [{ name: "mystery.blob", trustedLocalMedia: true }],
+          },
+        ],
+        managedMediaLocalRoots: [workspaceDir],
+      });
 
     expect(content).toEqual([
       { type: "text", text: "Artifact result" },
@@ -390,36 +389,58 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
         },
       },
     ]);
+    expect(persistedAssistantContent).toEqual(content);
   });
 
-  it("preserves a structured media failure beside replaced transcript text", () => {
-    expect(
-      replaceAssistantContentTextBlocks(
-        [
-          { type: "text", text: "Artifact result" },
-          {
-            type: "attachment_error",
-            attachment: {
-              code: "delivery-failed",
-              kind: "document",
-              label: "report.7z",
-            },
-          },
-        ],
-        { content: [{ type: "text", text: "Canonical transcript text" }] },
-      ),
-    ).toEqual([
-      { type: "text", text: "Canonical transcript text" },
+  it("preserves paragraph order when media follows adjacent reply text payloads", async () => {
+    const payloads = [
+      { text: "First paragraph" },
       {
-        type: "attachment_error",
-        attachment: {
-          code: "delivery-failed",
-          kind: "document",
-          label: "report.7z",
-        },
+        text: "Second paragraph",
+        mediaUrl: `data:image/png;base64,${PNG_BYTES.toString("base64")}`,
       },
-    ]);
+    ];
+    const { assistantContent: displayContent, persistedAssistantContent: persistedContent } =
+      await buildAssistantReplyContent({
+        sessionKey: TEST_SESSION_KEY,
+        agentId: "main",
+        payloads,
+        transcriptMediaMessage: await buildWebchatAssistantMessageFromReplyPayloads(payloads),
+      });
+
+    expect(displayContent?.some((block) => block.type === "image")).toBe(true);
+    expect(
+      persistedContent?.filter((block) => block.type === "text").map((block) => block.text),
+    ).toEqual(["First paragraph", "Second paragraph"]);
+    expect(persistedContent?.at(-1)?.type).toBe("image");
   });
+
+  it.each([false, true])(
+    "keeps an image-only caption beside its image (reply directive=%s)",
+    async (replyToCurrent) => {
+      const payloads = [
+        { mediaUrl: `data:image/png;base64,${PNG_BYTES.toString("base64")}`, replyToCurrent },
+        { text: "Following paragraph" },
+      ];
+      const { assistantContent, persistedAssistantContent } = await buildAssistantReplyContent({
+        sessionKey: TEST_SESSION_KEY,
+        agentId: "main",
+        payloads,
+        transcriptMediaMessage: await buildWebchatAssistantMessageFromReplyPayloads(payloads),
+      });
+
+      expect(assistantContent?.map((block) => block.type)).toEqual(["image", "text"]);
+      expect(persistedAssistantContent?.map((block) => block.type)).toEqual([
+        "text",
+        "image",
+        "text",
+      ]);
+      expect(persistedAssistantContent?.[0]?.text).toBe(
+        `${replyToCurrent ? "[[reply_to_current]]" : ""}Image reply`,
+      );
+      expect(persistedAssistantContent?.[2]?.text).toBe("Following paragraph");
+    },
+  );
 
   it("preserves local audio paths for WebChat audio embedding", async () => {
     const { stateDir, workspaceDir, cfg } = createMediaTestContext({ allowRead: false });
@@ -459,7 +480,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
       await fs.mkdir(path.dirname(sourcePath), { recursive: true });
       await fs.writeFile(sourcePath, bytes);
 
-      const content = await buildAssistantDisplayContentFromReplyPayloads({
+      const { assistantContent: content } = await buildAssistantReplyContent({
         sessionKey: TEST_SESSION_KEY,
         agentId: "main",
         payloads: [
@@ -495,7 +516,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     await fs.writeFile(firstPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
     await fs.writeFile(secondPath, Buffer.from([0xff, 0xfb, 0x90, 0x01]));
 
-    const content = await buildAssistantDisplayContentFromReplyPayloads({
+    const { assistantContent: content } = await buildAssistantReplyContent({
       sessionKey: TEST_SESSION_KEY,
       agentId: "main",
       payloads: [
@@ -525,7 +546,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     await fs.mkdir(workspaceDir, { recursive: true });
     await fs.writeFile(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
 
-    const content = await buildAssistantDisplayContentFromReplyPayloads({
+    const { assistantContent: content } = await buildAssistantReplyContent({
       sessionKey: TEST_SESSION_KEY,
       agentId: "main",
       payloads: [{ text: `MEDIA:${audioPath}`, trustedLocalMedia: true }],
@@ -554,7 +575,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
       {},
     );
 
-    const content = await buildAssistantDisplayContentFromReplyPayloads({
+    const { assistantContent: content } = await buildAssistantReplyContent({
       sessionKey: TEST_SESSION_KEY,
       agentId: "main",
       payloads: [payload],
@@ -583,7 +604,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     await fs.writeFile(firstPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
     await fs.writeFile(thirdPath, Buffer.from([0xff, 0xfb, 0x90, 0x01]));
 
-    const content = await buildAssistantDisplayContentFromReplyPayloads({
+    const { assistantContent: content } = await buildAssistantReplyContent({
       sessionKey: TEST_SESSION_KEY,
       agentId: "main",
       payloads: [

--- a/src/gateway/server-methods/chat-send-reply-dispatch.test.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.test.ts
@@ -4,7 +4,7 @@ import { buildAssistantMessage, buildUsageWithNoCost } from "../../agents/stream
 import { setReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { projectChatDisplayMessage } from "../chat-display-projection.js";
-import { buildAssistantDisplayContentFromReplyPayloads } from "./chat-assistant-content.js";
+import { buildAssistantReplyContent } from "./chat-assistant-content.js";
 import {
   buildTranscriptReplyText,
   createChatSendReplyDispatch,
@@ -17,11 +17,13 @@ describe("buildTranscriptReplyText", () => {
       const payloads = [{ text: "First instruction" }, { text: controlText }, { text: "Done" }];
       expect(buildTranscriptReplyText(payloads)).toBe("First instruction\n\nDone");
       expect(
-        await buildAssistantDisplayContentFromReplyPayloads({
-          sessionKey: "agent:main:main",
-          agentId: "main",
-          payloads,
-        }),
+        (
+          await buildAssistantReplyContent({
+            sessionKey: "agent:main:main",
+            agentId: "main",
+            payloads,
+          })
+        ).assistantContent,
       ).toEqual([{ type: "text", text: "First instruction\n\nDone" }]);
     },
   );

--- a/src/gateway/server-methods/chat-send-reply-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.ts
@@ -30,12 +30,11 @@ import { attachManagedOutgoingMediaToMessage } from "../managed-image-attachment
 import { loadSessionEntry } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
 import {
-  buildAssistantDisplayContentFromReplyPayloads,
+  buildAssistantReplyContent,
   combineNonStreamingReplyParts,
   extractAssistantDisplayTextFromContent,
   hasAssistantDisplayMediaContent,
   isMediaBearingPayload,
-  replaceAssistantContentTextBlocks,
   sanitizeAssistantDisplayText,
 } from "./chat-assistant-content.js";
 import { isBtwReplyPayload, isSourceReplyTranscriptMirrorPayload } from "./chat-broadcast.js";
@@ -228,26 +227,23 @@ export function createChatSendReplyDispatch(params: {
       getAgentScopedMediaLocalRoots(cfg, agentId),
       latestStorePath ? [latestStorePath] : undefined,
     );
-    const assistantContent = await buildAssistantDisplayContentFromReplyPayloads({
-      sessionKey,
-      agentId,
-      payloads: [transcriptPayload],
-      managedMediaLocalRoots: mediaLocalRoots,
-      includeSensitiveMedia: transcriptPayload.sensitiveMedia !== true,
-      onManagedMediaPrepareError: (message) => {
-        logGateway.warn(`webchat media embedding skipped attachment: ${message}`);
-      },
-    });
     const mediaMessage = await buildWebchatAssistantMessageFromReplyPayloads([transcriptPayload], {
       localRoots: mediaLocalRoots,
       onLocalAudioAccessDenied: (err) => {
         logGateway.warn(`webchat audio embedding denied local path: ${formatForLog(err)}`);
       },
     });
-    const persistedAssistantContent = replaceAssistantContentTextBlocks(
-      assistantContent,
-      mediaMessage,
-    );
+    const { assistantContent, persistedAssistantContent } = await buildAssistantReplyContent({
+      sessionKey,
+      agentId,
+      payloads: [transcriptPayload],
+      transcriptMediaMessage: mediaMessage,
+      managedMediaLocalRoots: mediaLocalRoots,
+      includeSensitiveMedia: transcriptPayload.sensitiveMedia !== true,
+      onManagedMediaPrepareError: (message) => {
+        logGateway.warn(`webchat media embedding skipped attachment: ${message}`);
+      },
+    });
     const transcriptPayloadMetadata = getReplyPayloadMetadata(transcriptPayload);
     const mediaFailures = transcriptPayloadMetadata?.assistantMediaFailures ?? [];
     const mediaNormalizationFailed = mediaFailures.length > 0;

--- a/src/gateway/server-methods/chat-send-reply-finalization.ts
+++ b/src/gateway/server-methods/chat-send-reply-finalization.ts
@@ -10,14 +10,12 @@ import { attachManagedOutgoingMediaToMessage } from "../managed-image-attachment
 import { loadSessionEntry } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
 import {
-  buildAssistantDisplayContentFromReplyPayloads,
+  buildAssistantReplyContent,
   combineNonStreamingReplyParts,
   extractAssistantDisplayText,
   extractAssistantDisplayTextFromContent,
   hasAssistantDisplayMediaContent,
-  hasSensitiveMediaPayload,
   hasVisibleAssistantFinalMessage,
-  replaceAssistantContentTextBlocks,
   stripManagedOutgoingAssistantContentBlocks,
 } from "./chat-assistant-content.js";
 import {
@@ -265,10 +263,17 @@ export async function finalizeChatSendDispatchedReplies(params: {
     latestStorePath ? [latestStorePath] : undefined,
   );
   let managedMediaPrepareFailed = false;
-  const assistantContent = await buildAssistantDisplayContentFromReplyPayloads({
+  const mediaMessage = await buildWebchatAssistantMessageFromReplyPayloads(finalPayloads, {
+    localRoots: mediaLocalRoots,
+    onLocalAudioAccessDenied: (err) => {
+      context.logGateway.warn(`webchat audio embedding denied local path: ${formatForLog(err)}`);
+    },
+  });
+  const { assistantContent, persistedAssistantContent } = await buildAssistantReplyContent({
     sessionKey: transcriptSessionKey,
     agentId: transcriptAgentId,
     payloads: finalPayloads,
+    transcriptMediaMessage: mediaMessage,
     managedMediaLocalRoots: mediaLocalRoots,
     includeSensitiveMedia: false,
     includeSensitiveDisplay: true,
@@ -280,32 +285,9 @@ export async function finalizeChatSendDispatchedReplies(params: {
       context.logGateway.warn(`webchat sensitive display skipped attachment: ${message}`);
     },
   });
-  const mediaMessage = await buildWebchatAssistantMessageFromReplyPayloads(finalPayloads, {
-    localRoots: mediaLocalRoots,
-    onLocalAudioAccessDenied: (err) => {
-      context.logGateway.warn(`webchat audio embedding denied local path: ${formatForLog(err)}`);
-    },
-  });
-  const hasSensitiveMedia = hasSensitiveMediaPayload(finalPayloads);
   const ttsSupplementMarker = finalPayloads
     .map((payload) => buildMediaOnlyTtsSupplementTranscriptMarker(payload))
     .find((marker): marker is GatewayInjectedTtsSupplementMarker => Boolean(marker));
-  const persistedAssistantContent = replaceAssistantContentTextBlocks(
-    hasSensitiveMedia
-      ? await buildAssistantDisplayContentFromReplyPayloads({
-          sessionKey: transcriptSessionKey,
-          agentId: transcriptAgentId,
-          payloads: finalPayloads,
-          managedMediaLocalRoots: mediaLocalRoots,
-          includeSensitiveMedia: false,
-          onManagedMediaPrepareError: (message) => {
-            managedMediaPrepareFailed = true;
-            context.logGateway.warn(`webchat media embedding skipped attachment: ${message}`);
-          },
-        })
-      : assistantContent,
-    mediaMessage,
-  );
   const persistedContentForAppend = hasAssistantDisplayMediaContent(persistedAssistantContent)
     ? persistedAssistantContent
     : undefined;

--- a/src/gateway/server-methods/chat-send-source-finalization.ts
+++ b/src/gateway/server-methods/chat-send-source-finalization.ts
@@ -11,12 +11,11 @@ import { attachManagedOutgoingMediaToMessage } from "../managed-image-attachment
 import { loadSessionEntry } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
 import {
-  buildAssistantDisplayContentFromReplyPayloads,
+  buildAssistantReplyContent,
   extractAssistantDisplayTextFromContent,
   hasAssistantDisplayMediaContent,
   hasManagedOutgoingAssistantContent,
   hasVisibleAssistantFinalMessage,
-  replaceAssistantContentTextBlocks,
   stripManagedOutgoingAssistantContentBlocks,
   type AssistantDisplayContentBlock,
 } from "./chat-assistant-content.js";
@@ -123,32 +122,26 @@ async function finalizeChatSendAgentReplyPayloads(
     getAgentScopedMediaLocalRoots(cfg, agentId),
     latestStorePath ? [latestStorePath] : undefined,
   );
-  const buildReplyAssistantContent = async (
-    payloads: typeof finalPayloads,
-  ): Promise<AssistantDisplayContentBlock[] | undefined> =>
-    await buildAssistantDisplayContentFromReplyPayloads({
+  const buildReplyContent = async (payloads: typeof finalPayloads) => {
+    const mediaMessage = await buildWebchatAssistantMessageFromReplyPayloads(payloads, {
+      localRoots: mediaLocalRoots,
+      onLocalAudioAccessDenied: (err) => {
+        context.logGateway.warn(`webchat audio embedding denied local path: ${formatForLog(err)}`);
+      },
+    });
+    const content = await buildAssistantReplyContent({
       sessionKey,
       agentId,
       payloads,
+      transcriptMediaMessage: mediaMessage,
       managedMediaLocalRoots: mediaLocalRoots,
       includeSensitiveMedia: false,
       onManagedMediaPrepareError: (message) => {
         context.logGateway.warn(`webchat media embedding skipped attachment: ${message}`);
       },
     });
-  const buildReplyMediaMessage = async (payloads: typeof finalPayloads) =>
-    await buildWebchatAssistantMessageFromReplyPayloads(payloads, {
-      localRoots: mediaLocalRoots,
-      onLocalAudioAccessDenied: (err) => {
-        context.logGateway.warn(`webchat audio embedding denied local path: ${formatForLog(err)}`);
-      },
-    });
-  const combinedAssistantContent =
-    agentRunReplyPayloads.length === 1
-      ? await buildReplyAssistantContent(finalPayloads)
-      : undefined;
-  const combinedMediaMessage =
-    agentRunReplyPayloads.length === 1 ? await buildReplyMediaMessage(finalPayloads) : undefined;
+    return { ...content, mediaMessage };
+  };
   const sourceReplyContentStates: SourceReplyContentState[] = [];
   const sourceReplyBroadcastContent: AssistantDisplayContentBlock[] = [];
   for (const [replyIndex] of agentRunReplyPayloads.entries()) {
@@ -156,23 +149,16 @@ async function finalizeChatSendAgentReplyPayloads(
     if (!finalPayload) {
       continue;
     }
-    const replyAssistantContent =
-      agentRunReplyPayloads.length === 1
-        ? combinedAssistantContent
-        : await buildReplyAssistantContent([finalPayload]);
-    const replyMediaMessage =
-      agentRunReplyPayloads.length === 1
-        ? combinedMediaMessage
-        : await buildReplyMediaMessage([finalPayload]);
+    const {
+      assistantContent: replyAssistantContent,
+      persistedAssistantContent: persistedContent,
+      mediaMessage: replyMediaMessage,
+    } = await buildReplyContent([finalPayload]);
     const replyBroadcastContent = hasAssistantDisplayMediaContent(replyAssistantContent)
       ? replyAssistantContent
       : hasAssistantDisplayMediaContent(replyMediaMessage?.content)
         ? replyMediaMessage?.content
         : replyAssistantContent;
-    const persistedContent = replaceAssistantContentTextBlocks(
-      replyAssistantContent,
-      replyMediaMessage ?? null,
-    );
     const state: SourceReplyContentState = {
       broadcastContent: replyBroadcastContent ? [...replyBroadcastContent] : [],
       persistedContent: persistedContent ? [...persistedContent] : [],

--- a/src/gateway/server-methods/chat-webchat-media.test.ts
+++ b/src/gateway/server-methods/chat-webchat-media.test.ts
@@ -270,7 +270,7 @@ describe("buildWebchatAssistantMessageFromReplyPayloads", () => {
       },
     ]);
 
-    expect(message).toEqual({
+    expect(message).toMatchObject({
       transcriptText: "Scan this QR code with the OpenClaw iOS app:",
       content: [
         { type: "text", text: "Scan this QR code with the OpenClaw iOS app:" },
@@ -299,7 +299,7 @@ describe("buildWebchatAssistantMessageFromReplyPayloads", () => {
       },
     ]);
 
-    expect(message).toEqual({
+    expect(message).toMatchObject({
       transcriptText: "Image reply",
       content: [
         { type: "text", text: "Image reply" },
@@ -316,7 +316,7 @@ describe("buildWebchatAssistantMessageFromReplyPayloads", () => {
       },
     ]);
 
-    expect(message).toEqual({
+    expect(message).toMatchObject({
       transcriptText: "[[reply_to_current]]Image reply",
       content: [
         { type: "text", text: "[[reply_to_current]]Image reply" },
@@ -390,7 +390,7 @@ describe("buildWebchatAssistantMessageFromReplyPayloads", () => {
       },
     ]);
 
-    expect(message).toEqual({
+    expect(message).toMatchObject({
       transcriptText: "[[reply_to:abcaudio_as_voice]]Image reply",
       content: [
         { type: "text", text: "[[reply_to:abcaudio_as_voice]]Image reply" },

--- a/src/gateway/server-methods/chat-webchat-media.ts
+++ b/src/gateway/server-methods/chat-webchat-media.ts
@@ -214,15 +214,20 @@ function resolveReplyDirectivePrefix(payload: ReplyPayload): string {
 export async function buildWebchatAssistantMessageFromReplyPayloads(
   payloads: ReplyPayload[],
   options?: WebchatAudioEmbeddingOptions,
-): Promise<{ content: Array<Record<string, unknown>>; transcriptText: string } | null> {
+): Promise<{
+  content: Array<Record<string, unknown>>;
+  transcriptText: string;
+  payloadTexts: Array<string | undefined>;
+} | null> {
   const content: Array<Record<string, unknown>> = [];
   const transcriptTextParts: string[] = [];
+  const payloadTexts: Array<string | undefined> = [];
   const seenAudio = new Set<string>();
   const seenImages = new Set<string>();
   let hasAudio = false;
   let hasImage = false;
 
-  for (const payload of payloads) {
+  for (const [payloadIndex, payload] of payloads.entries()) {
     if (payload.isReasoning === true) {
       continue;
     }
@@ -270,9 +275,11 @@ export async function buildWebchatAssistantMessageFromReplyPayloads(
     if (blockText) {
       const fullText = replyDirectivePrefix ? `${replyDirectivePrefix}${blockText}` : blockText;
       transcriptTextParts.push(fullText);
+      payloadTexts[payloadIndex] = fullText;
       content.push({ type: "text", text: fullText });
     } else if (replyDirectivePrefix) {
       transcriptTextParts.push(replyDirectivePrefix);
+      payloadTexts[payloadIndex] = replyDirectivePrefix;
       content.push({ type: "text", text: replyDirectivePrefix });
     }
     content.push(...payloadMediaBlocks);
@@ -287,5 +294,5 @@ export async function buildWebchatAssistantMessageFromReplyPayloads(
   if (transcriptTextParts.length === 0) {
     content.unshift({ type: "text", text: transcriptText });
   }
-  return { content, transcriptText };
+  return { content, transcriptText, payloadTexts };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reloading a WebChat command reply could see its paragraphs reordered when the reply contained multiple text payloads and media. For example, a reply displayed as “First paragraph”, “Second paragraph”, then an image could be saved with the second paragraph first.

## Why This Change Was Made

Preserve each caption and transcript text block's association with its original reply payload while assembling display and saved content. This removes the positional replacement heuristic, which matched merged display text against a different number of transcript blocks. Source replies use the normalizer's existing one-input/one-output contract; current-session cron completion continues to consume display content only.

The repair uses the existing transcript APIs and storage format. Production changes remove 36 lines net; tests add 23 lines net.

## User Impact

Saved WebChat command and media replies retain their original paragraph and caption order. Synthetic image descriptions, reply directives, and media failure messages remain associated with the correct payload.

## Evidence

- A regression using the real display/media builders, two paragraphs, and a valid tiny PNG failed before the fix with reversed saved text and passed afterward.
- The final grouped run passed 201 tests across reply/media formatting, reply dispatch, and cron delivery. An additional 31 tests passed for the unchanged media transcript builder. Coverage includes image-only captions, reply directives, audio/video, attachment failures, command formatting, and cancellation cleanup.
- Canonical Gateway and services test type graphs, full-file type-aware lint, formatting, and diff checks passed.
- Independent review is clean through P2. The complete media normalizer was supplied to verify its one-input/one-output contract.
- Publication qualification against `86a3c7267be4a6a49cc3de5b00ec87588421783d` found unchanged production owners and a clean merge of the disjoint test-fixture updates. Hosted checks will validate the PR merge result.
