### PR TITLE
refactor(perplexity): share search result envelope

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -911,7 +911,6 @@ extensions/openshell/src/fs-bridge.ts	2
 extensions/parallel/src/parallel-free-web-search-provider.runtime.ts	1
 extensions/parallel/src/parallel-search-normalize.ts	1
 extensions/parallel/src/parallel-web-search-provider.runtime.ts	2
-extensions/perplexity/src/perplexity-web-search-provider.runtime.ts	5
 extensions/perplexity/src/perplexity-web-search-provider.shared.ts	1
 extensions/pixverse/video-generation-provider.ts	2
 extensions/policy/src/cli.ts	1

--- a/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
@@ -390,69 +390,51 @@ export async function executePerplexitySearch(
 
   const start = Date.now();
   const timeoutSeconds = resolveSearchTimeoutSeconds(searchConfig);
-  const payload =
+  const result =
     runtime.transport === "chat_completions"
-      ? {
+      ? await runPerplexitySearch({
           query,
-          provider: "perplexity",
+          apiKey: runtime.apiKey,
+          baseUrl: runtime.baseUrl,
           model: runtime.model,
-          tookMs: Date.now() - start,
-          externalContent: {
-            untrusted: true,
-            source: "web_search",
-            provider: "perplexity",
-            wrapped: true,
-          },
-          ...(await (async () => {
-            const result = await runPerplexitySearch({
-              query,
-              apiKey: runtime.apiKey!,
-              baseUrl: runtime.baseUrl,
-              model: runtime.model,
-              timeoutSeconds,
-              signal,
-              freshness,
-            });
-            return {
-              content: wrapWebContent(result.content, "web_search"),
-              citations: result.citations,
-            };
-          })()),
-        }
-      : {
+          timeoutSeconds,
+          signal,
+          freshness,
+        })
+      : await runPerplexitySearchApi({
           query,
-          provider: "perplexity",
-          count: 0,
-          tookMs: Date.now() - start,
-          externalContent: {
-            untrusted: true,
-            source: "web_search",
-            provider: "perplexity",
-            wrapped: true,
-          },
-          results: await runPerplexitySearchApi({
-            query,
-            apiKey: runtime.apiKey,
-            count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
-            timeoutSeconds,
-            signal,
-            country: country ?? undefined,
-            searchDomainFilter: domainFilter,
-            searchRecencyFilter: freshness,
-            searchLanguageFilter: language ? [language] : undefined,
-            searchAfterDate: dateAfter ? isoToPerplexityDate(dateAfter) : undefined,
-            searchBeforeDate: dateBefore ? isoToPerplexityDate(dateBefore) : undefined,
-            maxTokens: maxTokens ?? undefined,
-            maxTokensPerPage: maxTokensPerPage ?? undefined,
-          }),
-        };
-
-  if (Array.isArray((payload as { results?: unknown[] }).results)) {
-    (payload as { count: number }).count = (payload as { results: unknown[] }).results.length;
-    (payload as { tookMs: number }).tookMs = Date.now() - start;
-  } else {
-    (payload as { tookMs: number }).tookMs = Date.now() - start;
-  }
+          apiKey: runtime.apiKey,
+          count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
+          timeoutSeconds,
+          signal,
+          country: country ?? undefined,
+          searchDomainFilter: domainFilter,
+          searchRecencyFilter: freshness,
+          searchLanguageFilter: language ? [language] : undefined,
+          searchAfterDate: dateAfter ? isoToPerplexityDate(dateAfter) : undefined,
+          searchBeforeDate: dateBefore ? isoToPerplexityDate(dateBefore) : undefined,
+          maxTokens: maxTokens ?? undefined,
+          maxTokensPerPage: maxTokensPerPage ?? undefined,
+        });
+  const resultFields = Array.isArray(result)
+    ? { results: result }
+    : {
+        content: wrapWebContent(result.content, "web_search"),
+        citations: result.citations,
+      };
+  const payload = {
+    query,
+    provider: "perplexity",
+    ...(Array.isArray(result) ? { count: result.length } : { model: runtime.model }),
+    tookMs: Date.now() - start,
+    externalContent: {
+      untrusted: true,
+      source: "web_search",
+      provider: "perplexity",
+      wrapped: true,
+    },
+    ...resultFields,
+  };
 
   signal?.throwIfAborted();
   writeCachedSearchPayload(cacheKey, payload, cacheTtlMs);


### PR DESCRIPTION
## What Problem This Solves

Perplexity's native search and chat-completion paths build the same result envelope separately, then patch count and timing through type assertions. This is a safe precursor to the maintainer-requested cached-search consolidation.

## Why This Change Was Made

Each transport now produces its own typed result, followed by one common envelope. Count comes directly from native results; answer wrapping, citation fields, final timing, cache keys/TTL and cancellation-before-publication remain unchanged. Production +41/-59 (net -18); tests unchanged. The private-test-export cleanup in #140541 is already on main and remains intact.

## User Impact

No intentional result, configuration, cache lifetime/capacity, transport, or SDK change.

## Deferred API choice (maintainer)

The maintainer approved landing this bounded precursor independently. The full eleven-provider cached runner needs a new public `provider-web-search` helper contract, which the campaign gates. Preserve the existing core or provider-local maps rather than merging their capacity; retain each provider's timing boundary and envelope projection. Brave's diagnostics and deadline ordering, Kimi's returned-but-not-cached failures, and Parallel's original-returned/transformed-cached session fields must remain explicit adapter policy. Gemini is owned by a sibling lane and must migrate under coordinated ownership. #139868's Tavily endpoint routing is separate; this precursor does not touch it.

The intended canonical owner is the existing web-search common owner through the Plugin SDK. This bounded PR completes only Perplexity's private envelope simplification, not the cross-provider runner.

## Evidence

- Refreshed onto main containing #141139 and #141148; `git range-diff` confirmed the bounded Perplexity patch was unchanged.
- `node scripts/run-vitest.mjs extensions/perplexity src/agents/tools/web-search-provider-common.test.ts src/agents/tools/web-shared.test.ts`: 3 files, 89 tests passed on the refreshed head.
- `node scripts/check-changed.mjs`: 20 checks passed. Extension lint preparation hit the approved nested-worktree `Declaration input escapes checkout` limitation; hosted CI supplies that boundary proof. The exact 5-to-0 assertion-baseline shrink remains intact; no baseline grew.
- Fresh independent Codex autoreview: scoped-clean through P2, zero actionable findings. `git diff --check` passed.
- Exact-head [CI run 34116436116](https://github.com/openclaw/openclaw/actions/runs/34116436116) and `openclaw/ci-gate` passed on `50d98347183b366d63257723ce3fd35abdb8a8e5`. The first attempt timed out in the unrelated CI planner inventory-growth test at 120s; its isolated normal-settings probe passed in 31s, and the single permitted failed-job rerun passed with no source or test-setting changes.
- Native review artifacts validated, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 140982` passed without changing the green CI head.
- No live search claim. The broader cached-runner API and its provider validation remain deferred.
