### PR TITLE
fix(memory): honor profile and home paths in host lookups

### DIFF
--- a/packages/memory-host-sdk/src/host/config-utils.test.ts
+++ b/packages/memory-host-sdk/src/host/config-utils.test.ts
@@ -1,20 +1,26 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   normalizeConfiguredMemoryExtraPaths,
   resolveMemoryHostAgentWorkspaceDir,
   resolveRememberAcrossConversations,
+  type OpenClawConfig,
 } from "./config-utils.js";
 
 describe("resolveMemoryHostAgentWorkspaceDir", () => {
-  it("uses the active profile state root for the default agent workspace", () => {
+  it.each([
+    { name: "profile alone", stateDir: undefined },
+    { name: "explicit profile state directory", stateDir: "/home/fixture/.openclaw-work" },
+  ])("uses the active profile workspace with $name", ({ stateDir }) => {
     expect(
       resolveMemoryHostAgentWorkspaceDir({}, "main", {
-        HOME: "/home/peter",
+        HOME: "/home/fixture",
         OPENCLAW_PROFILE: "work",
-        OPENCLAW_STATE_DIR: "/home/peter/.openclaw-work",
+        OPENCLAW_STATE_DIR: stateDir,
       }),
-    ).toBe("/home/peter/.openclaw-work/workspace");
+    ).toBe(path.resolve("/home/fixture/.openclaw-work/workspace"));
   });
 
   it("keeps the default agent workspace inside an overridden state directory", () => {
@@ -44,6 +50,211 @@ describe("resolveMemoryHostAgentWorkspaceDir", () => {
         { HOME: "/home/peter$&mall", OPENCLAW_HOME: "~/oc" },
       ),
     ).toBe(path.resolve("/home/peter$&mall/oc/ws"));
+  });
+
+  it.each([
+    {
+      name: "tilde state root",
+      stateDir: "~/state",
+      workspaceDir: undefined,
+      expected: "state/workspace",
+    },
+    {
+      name: "tilde workspace override",
+      stateDir: "~/state",
+      workspaceDir: "~/workspace",
+      expected: "workspace",
+    },
+  ])("expands the $name against OPENCLAW_HOME", ({ stateDir, workspaceDir, expected }) => {
+    expect(
+      resolveMemoryHostAgentWorkspaceDir({}, "main", {
+        HOME: "/home/fixture",
+        OPENCLAW_HOME: "~/openclaw-home",
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_WORKSPACE_DIR: workspaceDir,
+      }),
+    ).toBe(path.resolve("/home/fixture/openclaw-home", expected));
+  });
+
+  it.each([
+    { name: "default workspace", workspace: undefined, expected: ".openclaw/workspace" },
+    { name: "configured workspace", workspace: "~/notes", expected: "notes" },
+  ])("uses the Termux home for the $name when HOME is unavailable", ({ workspace, expected }) => {
+    const homedir = vi.spyOn(os, "homedir").mockReturnValue("/unexpected/os/home");
+    try {
+      expect(
+        resolveMemoryHostAgentWorkspaceDir(
+          { agents: { entries: { main: { workspace } } } },
+          "main",
+          {
+            HOME: "undefined",
+            USERPROFILE: "null",
+            PREFIX: "/data/data/com.termux/files/usr",
+            ANDROID_DATA: "/data",
+          },
+        ),
+      ).toBe(path.resolve("/data/data/com.termux/files/home", expected));
+    } finally {
+      homedir.mockRestore();
+    }
+  });
+
+  it.each([
+    { agentId: "main", stateDir: undefined, expected: ".openclaw/workspace" },
+    { agentId: "support", stateDir: undefined, expected: ".openclaw/workspace-support" },
+    { agentId: "main", stateDir: "~/state", expected: "state/workspace" },
+    { agentId: "support", stateDir: "~/state", expected: "state/workspace-support" },
+  ])(
+    "expands the OS fallback home once for $agentId with state override $stateDir",
+    ({ agentId, stateDir, expected }) => {
+      const homedir = vi.spyOn(os, "homedir").mockReturnValue("/home/fixture");
+      try {
+        expect(
+          resolveMemoryHostAgentWorkspaceDir(
+            { agents: { entries: { main: {}, support: {} } } },
+            agentId,
+            {
+              OPENCLAW_HOME: "~/oc",
+              OPENCLAW_STATE_DIR: stateDir,
+              VITEST: "1",
+              OPENCLAW_TEST_FAST: "1",
+            },
+          ),
+        ).toBe(path.resolve("/home/fixture/oc", expected));
+      } finally {
+        homedir.mockRestore();
+      }
+    },
+  );
+
+  it.each([
+    { agentId: "main", override: "state", leaf: "workspace" },
+    { agentId: "support", override: "state", leaf: "workspace-support" },
+    { agentId: "main", override: "workspace", leaf: "" },
+  ])(
+    "resolves the absolute $override override for $agentId without home or cwd",
+    ({ agentId, override, leaf }) => {
+      const absolute = path.resolve("/srv/fixture-override");
+      const expected = path.join(absolute, leaf);
+      const homedir = vi.spyOn(os, "homedir").mockImplementation(() => {
+        throw new Error("fixture home unavailable");
+      });
+      const cwd = vi.spyOn(process, "cwd").mockImplementation(() => {
+        throw new Error("ENOENT: fixture cwd unavailable");
+      });
+      try {
+        expect(
+          resolveMemoryHostAgentWorkspaceDir(
+            { agents: { entries: { main: {}, support: {} } } },
+            agentId,
+            {
+              OPENCLAW_HOME: "~/oc",
+              OPENCLAW_STATE_DIR: override === "state" ? absolute : "~/state",
+              OPENCLAW_WORKSPACE_DIR: override === "workspace" ? absolute : undefined,
+            },
+          ),
+        ).toBe(expected);
+      } finally {
+        cwd.mockRestore();
+        homedir.mockRestore();
+      }
+    },
+  );
+
+  it("falls back to cwd when no home source is available", () => {
+    const expected = path.join(process.cwd(), ".openclaw", "workspace");
+    const homedir = vi.spyOn(os, "homedir").mockImplementation(() => {
+      throw new Error("fixture home unavailable");
+    });
+    try {
+      expect(resolveMemoryHostAgentWorkspaceDir({}, "main", {})).toBe(expected);
+    } finally {
+      homedir.mockRestore();
+    }
+  });
+
+  it("explains how to recover when both home and cwd are unavailable", () => {
+    const homedir = vi.spyOn(os, "homedir").mockImplementation(() => {
+      throw new Error("fixture home unavailable");
+    });
+    const cwd = vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw new Error("ENOENT: fixture cwd unavailable");
+    });
+    try {
+      expect(() => resolveMemoryHostAgentWorkspaceDir({}, "main", {})).toThrow(
+        "Unable to resolve an OpenClaw home: set OPENCLAW_HOME, HOME, or USERPROFILE",
+      );
+    } finally {
+      cwd.mockRestore();
+      homedir.mockRestore();
+    }
+  });
+
+  it("preserves legacy state precedence for secondary agents without moving the default workspace", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-state-"));
+    const cfg: OpenClawConfig = { agents: { entries: { main: {}, support: {} } } };
+    const env = { HOME: home };
+    const legacy = path.join(home, ".clawdbot");
+    const current = path.join(home, ".openclaw");
+    try {
+      await fs.mkdir(legacy);
+      expect(resolveMemoryHostAgentWorkspaceDir(cfg, "support", env)).toBe(
+        path.join(legacy, "workspace-support"),
+      );
+      expect(resolveMemoryHostAgentWorkspaceDir(cfg, "main", env)).toBe(
+        path.join(current, "workspace"),
+      );
+      expect(
+        resolveMemoryHostAgentWorkspaceDir(cfg, "support", {
+          ...env,
+          VITEST: "1",
+          OPENCLAW_TEST_FAST: "1",
+        }),
+      ).toBe(path.join(current, "workspace-support"));
+      await fs.mkdir(current);
+      expect(resolveMemoryHostAgentWorkspaceDir(cfg, "support", env)).toBe(
+        path.join(current, "workspace-support"),
+      );
+      expect(
+        resolveMemoryHostAgentWorkspaceDir(cfg, "support", {
+          ...env,
+          OPENCLAW_STATE_DIR: path.join(home, "override"),
+        }),
+      ).toBe(path.join(home, "override", "workspace-support"));
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it.each<{
+    name: string;
+    agents: NonNullable<OpenClawConfig["agents"]>;
+    expected: Record<string, string>;
+  }>([
+    {
+      name: "keyed first-agent inheritance",
+      agents: { entries: { main: {}, support: {} } },
+      expected: { main: "shared", support: "shared/support" },
+    },
+    {
+      name: "marked legacy default",
+      agents: { list: [{ id: "first" }, { id: "support", default: true }] },
+      expected: { first: "shared/first", support: "shared" },
+    },
+    {
+      name: "optional legacy list id and explicit workspace",
+      agents: { list: [{ workspace: "~/anonymous" }, { id: "support" }] },
+      expected: { main: "anonymous", support: "shared/support" },
+    },
+  ])("preserves $name", ({ agents, expected }) => {
+    const cfg: OpenClawConfig = {
+      agents: { ...agents, defaults: { workspace: "~/shared" } },
+    };
+    for (const [agentId, relativePath] of Object.entries(expected)) {
+      expect(resolveMemoryHostAgentWorkspaceDir(cfg, agentId, { HOME: "/home/fixture" })).toBe(
+        path.resolve("/home/fixture", relativePath),
+      );
+    }
   });
 });
 

--- a/packages/memory-host-sdk/src/host/config-utils.ts
+++ b/packages/memory-host-sdk/src/host/config-utils.ts
@@ -1,12 +1,11 @@
 // Memory Host SDK helper module supports config utils behavior.
-import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
 import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+  resolveDefaultAgentWorkspaceDir,
+  resolveStateDir,
+  resolveUserPath,
+} from "./openclaw-runtime-paths.js";
 import type { MemoryExtraPath } from "./types.js";
 export { normalizeAgentId };
 
@@ -128,118 +127,6 @@ export function resolveRememberAcrossConversations(cfg: OpenClawConfig, agentId:
 export const MEMORY_HOST_ROOT_FILENAME = "MEMORY.md";
 
 const DEFAULT_AGENT_ID = "main";
-const LEGACY_STATE_DIRNAMES = [".clawdbot"] as const;
-const NEW_STATE_DIRNAME = ".openclaw";
-/** Treat shell-placeholder home values as absent. */
-function normalizeHomeValue(value: string | undefined): string | undefined {
-  const trimmed = normalizeOptionalString(value);
-  if (!trimmed || trimmed === "undefined" || trimmed === "null") {
-    return undefined;
-  }
-  return trimmed;
-}
-
-/** Resolve the underlying OS home before applying OpenClaw-specific overrides. */
-function resolveRawOsHomeDir(env: NodeJS.ProcessEnv, homedir: () => string): string | undefined {
-  return (
-    normalizeHomeValue(env.HOME) ??
-    normalizeHomeValue(env.USERPROFILE) ??
-    normalizeHomeValue(homedir())
-  );
-}
-
-/** Resolve OPENCLAW_HOME or the OS home, falling back to cwd for hermetic tests. */
-function resolveRequiredHomeDir(
-  env: NodeJS.ProcessEnv = process.env,
-  homedir: () => string = os.homedir,
-): string {
-  const explicitHome = normalizeHomeValue(env.OPENCLAW_HOME);
-  const rawHome = explicitHome
-    ? explicitHome.replace(/^~(?=$|[\\/])/, () => resolveRawOsHomeDir(env, homedir) ?? "")
-    : resolveRawOsHomeDir(env, homedir);
-  return rawHome ? path.resolve(rawHome) : path.resolve(process.cwd());
-}
-
-/** Resolve standalone memory-host paths without importing core home-directory policy. */
-function resolveMemoryHostUserPath(
-  input: string,
-  env: NodeJS.ProcessEnv = process.env,
-  homedir: () => string = os.homedir,
-): string {
-  const trimmed = input.trim();
-  if (!trimmed) {
-    return trimmed;
-  }
-  if (trimmed.startsWith("~")) {
-    return path.resolve(
-      trimmed.replace(/^~(?=$|[\\/])/, () => resolveRequiredHomeDir(env, homedir)),
-    );
-  }
-  return path.resolve(trimmed);
-}
-
-/** Return legacy state roots in priority order. */
-function legacyStateDirs(homedir: () => string): string[] {
-  return LEGACY_STATE_DIRNAMES.map((dir) => path.join(homedir(), dir));
-}
-
-function isFastTestRuntimeEnv(env: NodeJS.ProcessEnv): boolean {
-  const isTestRuntime =
-    env.VITEST === "true" ||
-    env.VITEST === "1" ||
-    env.VITEST_POOL_ID !== undefined ||
-    env.VITEST_WORKER_ID !== undefined ||
-    env.NODE_ENV === "test" ||
-    (env !== process.env &&
-      (process.env.VITEST === "true" ||
-        process.env.VITEST === "1" ||
-        process.env.VITEST_POOL_ID !== undefined ||
-        process.env.VITEST_WORKER_ID !== undefined ||
-        process.env.NODE_ENV === "test"));
-  return isTestRuntime && env.OPENCLAW_TEST_FAST === "1";
-}
-
-/** Resolve the current state root while preserving shipped legacy installs when present. */
-function resolveStateDir(
-  env: NodeJS.ProcessEnv = process.env,
-  homedir: () => string = os.homedir,
-): string {
-  const override = env.OPENCLAW_STATE_DIR?.trim();
-  if (override) {
-    return resolveMemoryHostUserPath(override, env, homedir);
-  }
-  const effectiveHome = () => resolveRequiredHomeDir(env, homedir);
-  const nextDir = path.join(effectiveHome(), NEW_STATE_DIRNAME);
-  if (isFastTestRuntimeEnv(env) || fs.existsSync(nextDir)) {
-    return nextDir;
-  }
-  // Remove after 2026-10-01: drop legacy state-dir precedence once an explicit migration creates .openclaw.
-  const existingLegacy = legacyStateDirs(effectiveHome).find((dir) => {
-    try {
-      return fs.existsSync(dir);
-    } catch {
-      return false;
-    }
-  });
-  return existingLegacy ?? nextDir;
-}
-
-/** Resolve the default agent workspace, partitioned by OPENCLAW_PROFILE when set. */
-function resolveDefaultAgentWorkspaceDir(env: NodeJS.ProcessEnv = process.env): string {
-  const workspaceDir = env.OPENCLAW_WORKSPACE_DIR?.trim();
-  if (workspaceDir) {
-    return resolveMemoryHostUserPath(workspaceDir, env);
-  }
-  if (env.OPENCLAW_STATE_DIR?.trim()) {
-    return path.join(resolveStateDir(env), "workspace");
-  }
-  const home = resolveRequiredHomeDir(env, os.homedir);
-  const profile = env.OPENCLAW_PROFILE?.trim();
-  if (profile && normalizeLowercaseStringOrEmpty(profile) !== "default") {
-    return path.join(resolveStateDir(env), "workspace");
-  }
-  return path.join(home, ".openclaw", "workspace");
-}
 
 /** Return configured agent entries after dropping nullish placeholders. */
 function listAgentEntries(cfg: OpenClawConfig): AgentConfig[] {
@@ -281,16 +168,16 @@ export function resolveMemoryHostAgentWorkspaceDir(
   const id = normalizeAgentId(agentId);
   const configured = resolveAgentConfig(cfg, id)?.workspace?.trim();
   if (configured) {
-    return stripNullBytes(resolveMemoryHostUserPath(configured, env));
+    return stripNullBytes(resolveUserPath(configured, env));
   }
   const fallback = cfg.agents?.defaults?.workspace?.trim();
   if (id === resolveDefaultAgentId(cfg)) {
     return stripNullBytes(
-      fallback ? resolveMemoryHostUserPath(fallback, env) : resolveDefaultAgentWorkspaceDir(env),
+      fallback ? resolveUserPath(fallback, env) : resolveDefaultAgentWorkspaceDir(env),
     );
   }
   if (fallback) {
-    return stripNullBytes(path.join(resolveMemoryHostUserPath(fallback, env), id));
+    return stripNullBytes(path.join(resolveUserPath(fallback, env), id));
   }
   return stripNullBytes(path.join(resolveStateDir(env), `workspace-${id}`));
 }

--- a/packages/memory-host-sdk/src/host/openclaw-runtime-paths.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime-paths.ts
@@ -1,0 +1,28 @@
+// Pure path owners; importing memory helpers must not initialize core runtime paths.
+import path from "node:path";
+import { resolveDefaultAgentWorkspaceDir as resolveCoreDefaultAgentWorkspaceDir } from "../../../../src/agents/workspace-default-path.js";
+import { resolveStateDirFromHome } from "../../../../src/config/state-dir.js";
+import { resolveRequiredHomeDir, resolveUserPath } from "../../../../src/infra/home-dir.js";
+export { resolveUserPath };
+
+/** Keep effective-home expansion at the memory-host boundary, before state selection. */
+export function resolveStateDir(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.OPENCLAW_STATE_DIR?.trim();
+  if (override) {
+    return resolveUserPath(override, env);
+  }
+  const home = resolveRequiredHomeDir(env);
+  return resolveStateDirFromHome(env, () => home);
+}
+
+/** Preserve memory-host override expansion without re-expanding an effective home. */
+export function resolveDefaultAgentWorkspaceDir(env: NodeJS.ProcessEnv): string {
+  const workspaceDir = env.OPENCLAW_WORKSPACE_DIR?.trim();
+  if (workspaceDir) {
+    return resolveUserPath(workspaceDir, env);
+  }
+  if (env.OPENCLAW_STATE_DIR?.trim()) {
+    return path.join(resolveStateDir(env), "workspace");
+  }
+  return resolveCoreDefaultAgentWorkspaceDir(env);
+}

--- a/src/agents/workspace-default-path.ts
+++ b/src/agents/workspace-default-path.ts
@@ -1,0 +1,31 @@
+/**
+ * Default agent workspace resolver.
+ *
+ * Derives the process workspace directory from env, profile, and home-directory state.
+ */
+import os from "node:os";
+import path from "node:path";
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { resolveProfileStateDir } from "../cli/profile-utils.js";
+import { resolveStateDir } from "../config/state-dir.js";
+import { resolveRequiredHomeDir } from "../infra/home-dir.js";
+
+/** Resolve the default agent workspace directory from env/profile/home state. */
+export function resolveDefaultAgentWorkspaceDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = os.homedir,
+): string {
+  const workspaceDir = env.OPENCLAW_WORKSPACE_DIR?.trim();
+  if (workspaceDir) {
+    return path.resolve(workspaceDir);
+  }
+  if (env.OPENCLAW_STATE_DIR?.trim()) {
+    return path.join(resolveStateDir(env, homedir), "workspace");
+  }
+  const home = resolveRequiredHomeDir(env, homedir);
+  const profile = env.OPENCLAW_PROFILE?.trim();
+  if (profile && normalizeOptionalLowercaseString(profile) !== "default") {
+    return path.join(resolveProfileStateDir(profile, env, homedir), "workspace");
+  }
+  return path.join(home, ".openclaw", "workspace");
+}

--- a/src/agents/workspace-default.ts
+++ b/src/agents/workspace-default.ts
@@ -1,34 +1,5 @@
-/**
- * Default agent workspace resolver.
- *
- * Derives the process workspace directory from env, profile, and home-directory state.
- */
-import os from "node:os";
-import path from "node:path";
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
-import { resolveProfileStateDir } from "../cli/profile-utils.js";
-import { resolveStateDir } from "../config/paths.js";
-import { resolveRequiredHomeDir } from "../infra/home-dir.js";
-
-/** Resolve the default agent workspace directory from env/profile/home state. */
-export function resolveDefaultAgentWorkspaceDir(
-  env: NodeJS.ProcessEnv = process.env,
-  homedir: () => string = os.homedir,
-): string {
-  const workspaceDir = env.OPENCLAW_WORKSPACE_DIR?.trim();
-  if (workspaceDir) {
-    return path.resolve(workspaceDir);
-  }
-  if (env.OPENCLAW_STATE_DIR?.trim()) {
-    return path.join(resolveStateDir(env, homedir), "workspace");
-  }
-  const home = resolveRequiredHomeDir(env, homedir);
-  const profile = env.OPENCLAW_PROFILE?.trim();
-  if (profile && normalizeOptionalLowercaseString(profile) !== "default") {
-    return path.join(resolveProfileStateDir(profile, env, homedir), "workspace");
-  }
-  return path.join(home, ".openclaw", "workspace");
-}
+import { resolveDefaultAgentWorkspaceDir } from "./workspace-default-path.js";
+export { resolveDefaultAgentWorkspaceDir } from "./workspace-default-path.js";
 
 /** Default agent workspace directory for the current process environment. */
 export const DEFAULT_AGENT_WORKSPACE_DIR = resolveDefaultAgentWorkspaceDir();

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -7,7 +7,9 @@ import { resolveGatewayNativeServiceIdentityConflict } from "../daemon/constants
 import { resolveHomeRelativePath, resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { parseTcpPort } from "../infra/tcp-port.js";
 import { isFastTestRuntimeEnv } from "../infra/test-runtime-env.js";
+import { resolveLegacyStateDirs, resolveNewStateDir, resolveStateDir } from "./state-dir.js";
 import type { OpenClawConfig } from "./types.js";
+export { resolveLegacyStateDirs, resolveNewStateDir, resolveStateDir } from "./state-dir.js";
 
 /**
  * Nix mode detection: When OPENCLAW_NIX_MODE=1, the gateway is running under Nix.
@@ -22,9 +24,6 @@ export function resolveIsNixMode(env: NodeJS.ProcessEnv = process.env): boolean 
 
 export let isNixMode = resolveIsNixMode();
 
-// Support the remaining legacy pre-rebrand state dir.
-const LEGACY_STATE_DIRNAMES = [".clawdbot"] as const;
-const NEW_STATE_DIRNAME = ".openclaw";
 const CONFIG_FILENAME = "openclaw.json";
 const LEGACY_CONFIG_FILENAMES = ["clawdbot.json"] as const;
 
@@ -34,10 +33,6 @@ export function isNamedProfile(env: NodeJS.ProcessEnv = process.env): boolean {
   return Boolean(profile && profile.toLowerCase() !== "default");
 }
 
-function resolveDefaultHomeDir(): string {
-  return resolveRequiredHomeDir(process.env, os.homedir);
-}
-
 function resolveSystemAccountHomeDir(): string {
   return os.userInfo().homedir;
 }
@@ -45,58 +40,6 @@ function resolveSystemAccountHomeDir(): string {
 /** Build a homedir thunk that respects OPENCLAW_HOME for the given env. */
 function envHomedir(env: NodeJS.ProcessEnv): () => string {
   return () => resolveRequiredHomeDir(env, os.homedir);
-}
-
-function legacyStateDirs(homedir: () => string = resolveDefaultHomeDir): string[] {
-  return LEGACY_STATE_DIRNAMES.map((dir) => path.join(homedir(), dir));
-}
-
-function newStateDir(homedir: () => string = resolveDefaultHomeDir): string {
-  return path.join(homedir(), NEW_STATE_DIRNAME);
-}
-
-export function resolveLegacyStateDirs(homedir: () => string = resolveDefaultHomeDir): string[] {
-  return legacyStateDirs(homedir);
-}
-
-export function resolveNewStateDir(homedir: () => string = resolveDefaultHomeDir): string {
-  return newStateDir(homedir);
-}
-
-/**
- * State directory for mutable data (sessions, logs, caches).
- * Can be overridden via OPENCLAW_STATE_DIR.
- * Default: ~/.openclaw
- */
-export function resolveStateDir(
-  env: NodeJS.ProcessEnv = process.env,
-  homedir: () => string = envHomedir(env),
-): string {
-  const effectiveHomedir = () => resolveRequiredHomeDir(env, homedir);
-  const override = env.OPENCLAW_STATE_DIR?.trim();
-  if (override) {
-    return resolveUserPath(override, env, effectiveHomedir);
-  }
-  const newDir = newStateDir(effectiveHomedir);
-  if (isFastTestRuntimeEnv(env)) {
-    return newDir;
-  }
-  const legacyDirs = legacyStateDirs(effectiveHomedir);
-  const hasNew = fs.existsSync(newDir);
-  if (hasNew) {
-    return newDir;
-  }
-  const existingLegacy = legacyDirs.find((dir) => {
-    try {
-      return fs.existsSync(dir);
-    } catch {
-      return false;
-    }
-  });
-  if (existingLegacy) {
-    return existingLegacy;
-  }
-  return newDir;
 }
 
 function normalizePathForComparison(candidate: string): string {
@@ -122,7 +65,7 @@ export function isDefaultStateDir(
   const effectiveHomedir = () => resolveRequiredHomeDir(env, homedir);
   return (
     normalizePathForComparison(resolveStateDir(env, effectiveHomedir)) ===
-    normalizePathForComparison(newStateDir(effectiveHomedir))
+    normalizePathForComparison(resolveNewStateDir(effectiveHomedir))
   );
 }
 
@@ -395,7 +338,10 @@ export function resolveDefaultConfigCandidates(
     candidates.push(...LEGACY_CONFIG_FILENAMES.map((name) => path.join(resolved, name)));
   }
 
-  const defaultDirs = [newStateDir(effectiveHomedir), ...legacyStateDirs(effectiveHomedir)];
+  const defaultDirs = [
+    resolveNewStateDir(effectiveHomedir),
+    ...resolveLegacyStateDirs(effectiveHomedir),
+  ];
   for (const dir of defaultDirs) {
     candidates.push(path.join(dir, CONFIG_FILENAME));
     candidates.push(...LEGACY_CONFIG_FILENAMES.map((name) => path.join(dir, name)));

--- a/src/config/state-dir.ts
+++ b/src/config/state-dir.ts
@@ -1,0 +1,65 @@
+// State-directory lookup without initializing process-wide config paths.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveHomeRelativePath, resolveRequiredHomeDir } from "../infra/home-dir.js";
+import { isFastTestRuntimeEnv } from "../infra/test-runtime-env.js";
+
+const LEGACY_STATE_DIRNAMES = [".clawdbot"] as const;
+const NEW_STATE_DIRNAME = ".openclaw";
+
+function resolveDefaultHomeDir(): string {
+  return resolveRequiredHomeDir(process.env, os.homedir);
+}
+
+export function resolveLegacyStateDirs(homedir: () => string = resolveDefaultHomeDir): string[] {
+  return LEGACY_STATE_DIRNAMES.map((dir) => path.join(homedir(), dir));
+}
+
+export function resolveNewStateDir(homedir: () => string = resolveDefaultHomeDir): string {
+  return path.join(homedir(), NEW_STATE_DIRNAME);
+}
+
+/**
+ * State directory for mutable data (sessions, logs, caches).
+ * Can be overridden via OPENCLAW_STATE_DIR.
+ * Default: ~/.openclaw
+ */
+export function resolveStateDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = () => resolveRequiredHomeDir(env, os.homedir),
+): string {
+  const effectiveHomedir = () => resolveRequiredHomeDir(env, homedir);
+  const override = env.OPENCLAW_STATE_DIR?.trim();
+  if (override) {
+    return resolveHomeRelativePath(override, { env, homedir: effectiveHomedir });
+  }
+  return resolveStateDirFromHome(env, effectiveHomedir);
+}
+
+/** Select a default state directory from the caller's already resolved home. */
+export function resolveStateDirFromHome(
+  env: NodeJS.ProcessEnv,
+  effectiveHomedir: () => string,
+): string {
+  const newDir = resolveNewStateDir(effectiveHomedir);
+  if (isFastTestRuntimeEnv(env)) {
+    return newDir;
+  }
+  const legacyDirs = resolveLegacyStateDirs(effectiveHomedir);
+  const hasNew = fs.existsSync(newDir);
+  if (hasNew) {
+    return newDir;
+  }
+  const existingLegacy = legacyDirs.find((dir) => {
+    try {
+      return fs.existsSync(dir);
+    } catch {
+      return false;
+    }
+  });
+  if (existingLegacy) {
+    return existingLegacy;
+  }
+  return newDir;
+}

--- a/src/plugins/contracts/extension-package-project-boundaries.test.ts
+++ b/src/plugins/contracts/extension-package-project-boundaries.test.ts
@@ -81,6 +81,7 @@ const MEMORY_HOST_SDK_ALLOWED_CORE_BRIDGE_FILES = [
   "packages/memory-host-sdk/src/host/openclaw-runtime-kysely.ts",
   "packages/memory-host-sdk/src/host/openclaw-runtime-memory.ts",
   "packages/memory-host-sdk/src/host/openclaw-runtime-network.ts",
+  "packages/memory-host-sdk/src/host/openclaw-runtime-paths.ts",
   "packages/memory-host-sdk/src/host/openclaw-runtime-session.ts",
   "packages/memory-host-sdk/src/host/openclaw-runtime-sqlite.ts",
 ] as const;


### PR DESCRIPTION
## What Problem This Solves

Memory-host file lookups could use the default profile workspace when only `OPENCLAW_PROFILE` selected another profile. Termux and unavailable-home environments could also choose the wrong home or fail without an actionable diagnostic.

## Why This Change Was Made

The memory host now uses the core home policy, one current/legacy state-directory selector, and the core default-profile workspace resolver through a private host binding. Callable path owners are separate from eager runtime-path constants, so importing memory helpers does not initialize unrelated core state.

The state selector receives the caller's resolved home. This preserves core's existing callback semantics and the memory host's single home expansion, including tilde state overrides and absolute overrides that do not need a usable home or cwd. Existing exports and the public memory-reader config input remain available.

## User Impact

Memory-host default workspaces follow the selected profile. Termux home lookup and unavailable-home diagnostics follow core behavior. Existing agent selection, inherited workspaces, legacy state-root precedence, explicit overrides, and memory context-limit behavior are preserved.

## Evidence

- Tests-first baseline: five of 17 cases failed on the original implementation for profile-only routing, two Termux cases, and unavailable home/cwd handling.
- Final focused proof: 191 tests passed across memory-host path and file readers, core home/state paths, workspace defaults, legacy state, and workspace behavior. The new cases cover single home expansion with tilde state overrides and absolute overrides without a usable home/cwd.
- Fresh Codex P0–P3 review on refreshed main: scoped-clean, zero accepted/actionable findings.
- Rebased head `d8b4b20477902bd44d34a32aad750736d9da88ec` has an unchanged stable patch ID; all 191 focused tests passed again in 190.60s.
- `git diff --check` passed.
- The package-boundary contract caught a missing inventory entry for the approved private path bridge (1 failed / 744 passed in CI). The exact inventory now includes that bridge; all 10 focused package-boundary tests pass, and a fresh Codex review is clean. No SDK budget or ratchet baseline changed.
- Net production change: −72 lines; tests: +212 lines.

The final `node scripts/check-changed.mjs` passed, including core/test types, lint, dead-export scans and runtime import-cycle checks. `pnpm build` passed in 17m46.5s. The bounded extraction is approved for landing; the package behaviors below remain unchanged.

Exact-head CI passed for `d584d6973a8db73c03a8c6840e3fba82cbbcbd66`: https://github.com/openclaw/openclaw/actions/runs/34103815092. The final private bridge inventory check, types, lint and dead-export scans also passed.

## Known differences kept

This PR is limited to home, state-directory, and default-profile path policy. It preserves three existing memory-reader behaviors:

- The public reader accepts missing legacy agent-roster IDs; core agent readers require IDs. The original config object's retained legacy-owner fact remains intact.
- The package grants the first configured agent the shared workspace; core uses different explicit-roster ownership rules.
- The package replaces a partial context-limit object; core merges context limits differently.

No SQLite schema, stored row, vector metadata, retention, or persisted projection changes in this PR. The path selection repair uses existing state/workspace locations, and the focused suites cover legacy `.clawdbot` precedence and existing file-read containment; no migration is required.

Agent-workspace roster and context-limit unification are outside this PR. These differences are preserved deliberately under maintainer direction.
