### PR TITLE
refactor(native): share chat RPC application operations

### DIFF
--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -4,7 +4,15 @@ import OpenClawKit
 import OpenClawProtocol
 import OSLog
 
-struct IOSGatewayChatTransport: OpenClawChatTransport {
+struct IOSGatewayChatTransport: OpenClawChatGatewayTransport {
+    var chatGatewayAgentID: String? {
+        self.globalAgentId
+    }
+
+    func requestChatGateway(_ request: OpenClawChatGatewayRequest) async throws -> Data {
+        try await self.gateway.request(request)
+    }
+
     static let logger = Logger(subsystem: "ai.openclawfoundation.app", category: "ios.chat.transport")
     let gateway: GatewayNodeSession
     private let widgetGateway: GatewayNodeSession?
@@ -190,21 +198,6 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
     func createSession(
         key: String,
         label: String?,
-        parentSessionKey: String?,
-        worktree: Bool?) async throws -> OpenClawChatCreateSessionResponse
-    {
-        try await self.createSession(
-            key: key,
-            label: label,
-            agentID: nil,
-            parentSessionKey: parentSessionKey,
-            worktree: worktree,
-            worktreeBaseRef: nil)
-    }
-
-    func createSession(
-        key: String,
-        label: String?,
         agentID: String?,
         parentSessionKey: String?,
         worktree: Bool?,
@@ -243,15 +236,6 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             parentSessionKey: parentTarget?.sessionKey,
             worktree: worktree,
             worktreeBaseRef: worktreeBaseRef)
-    }
-
-    func abortRun(sessionKey: String, runId: String) async throws {
-        let target = self.sessionTarget(for: sessionKey)
-        let request = OpenClawChatGatewayRequests.abortRun(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID,
-            runID: runId)
-        _ = try await self.gateway.request(request)
     }
 
     func listSessions(
@@ -341,17 +325,6 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         _ = try await self.patchSessionModel(sessionKey: sessionKey, agentID: nil, model: model)
     }
 
-    func patchSessionModel(
-        sessionKey: String,
-        agentID: String?,
-        model: String?) async throws -> OpenClawChatModelPatchResult?
-    {
-        try await self.patchSessionSettings(
-            sessionKey: sessionKey,
-            agentID: agentID,
-            patch: OpenClawChatSessionSettingsPatch(model: .some(model)))
-    }
-
     func patchSessionSettings(
         sessionKey: String,
         agentID: String?,
@@ -421,14 +394,6 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         try JSONDecoder().decode(OpenClawChatModelPatchResult.self, from: data)
     }
 
-    func setSessionThinking(sessionKey: String, thinkingLevel: String) async throws {
-        let target = self.sessionTarget(for: sessionKey)
-        _ = try await self.patchSessionSettings(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID,
-            patch: OpenClawChatSessionSettingsPatch(thinkingLevel: .some(thinkingLevel)))
-    }
-
     func patchSession(
         key: String,
         expectedSessionID: String? = nil,
@@ -453,14 +418,6 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             unread: unread)
     }
 
-    func deleteSession(key: String) async throws {
-        let target = self.sessionTarget(for: key)
-        let request = OpenClawChatGatewayRequests.deleteSession(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID)
-        _ = try await self.gateway.request(request)
-    }
-
     func forkSession(parentKey: String) async throws -> String {
         try await self.forkSession(parentKey: parentKey, fromLastCompleted: false)
     }
@@ -474,69 +431,6 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             fromLastCompleted: fromLastCompleted)
         let response = try await gateway.request(request)
         return try JSONDecoder().decode(OpenClawChatCreateSessionResponse.self, from: response).key
-    }
-
-    func rewindSession(
-        sessionKey: String,
-        entryId: String) async throws -> OpenClawChatRewindResponse
-    {
-        let target = self.sessionTarget(for: sessionKey)
-        let request = OpenClawChatGatewayRequests.rewindSession(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID,
-            entryId: entryId)
-        let response = try await gateway.request(request)
-        return try JSONDecoder().decode(OpenClawChatRewindResponse.self, from: response)
-    }
-
-    func forkSessionAtMessage(
-        sessionKey: String,
-        entryId: String) async throws -> OpenClawChatForkAtMessageResponse
-    {
-        let target = self.sessionTarget(for: sessionKey)
-        let request = OpenClawChatGatewayRequests.forkAtMessage(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID,
-            entryId: entryId)
-        let response = try await gateway.request(request)
-        return try JSONDecoder().decode(OpenClawChatForkAtMessageResponse.self, from: response)
-    }
-
-    func listSessionBranches(
-        sessionKey: String,
-        agentID: String?) async throws -> OpenClawChatSessionBranchesResponse
-    {
-        let target = self.sessionTarget(for: sessionKey, overrideAgentID: agentID)
-        let request = OpenClawChatGatewayRequests.listSessionBranches(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID)
-        let response = try await gateway.request(request)
-        return try JSONDecoder().decode(OpenClawChatSessionBranchesResponse.self, from: response)
-    }
-
-    func switchSessionBranch(sessionKey: String, agentID: String?, leafEntryId: String) async throws {
-        let target = self.sessionTarget(for: sessionKey)
-        let request = OpenClawChatGatewayRequests.switchSessionBranch(
-            sessionKey: target.sessionKey,
-            agentID: agentID ?? target.agentID,
-            leafEntryId: leafEntryId)
-        _ = try await self.gateway.request(request)
-    }
-
-    func setActiveSessionKey(_ sessionKey: String) async throws {
-        let target = self.sessionTarget(for: sessionKey)
-        let request = OpenClawChatGatewayRequests.subscribeSessionMessages(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID)
-        _ = try await self.gateway.request(request)
-    }
-
-    func resetSession(sessionKey: String) async throws {
-        let target = self.sessionTarget(for: sessionKey)
-        let request = OpenClawChatGatewayRequests.resetSession(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID)
-        _ = try await self.gateway.request(request)
     }
 
     func compactSession(sessionKey: String) async throws {
@@ -667,15 +561,6 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         true
     }
 
-    func listCommands(sessionKey: String) async throws -> [OpenClawChatCommandChoice] {
-        let request = OpenClawChatGatewayRequests.commandsList(
-            sessionKey: sessionKey,
-            fallbackAgentID: self.globalAgentId)
-        let res = try await gateway.request(request)
-        let decoded = try JSONDecoder().decode(CommandsListResult.self, from: res)
-        return decoded.commands.map(OpenClawChatGatewayPayloadCodec.commandChoice)
-    }
-
     func waitForRunCompletion(
         runId rawRunId: String,
         timeoutMs: Int) async -> OpenClawChatRunObservation
@@ -714,39 +599,6 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
     func requestHealth(timeoutMs: Int) async throws -> Bool {
         let res = try await gateway.request(OpenClawChatGatewayRequests.health(timeoutMs: timeoutMs))
         return (try? JSONDecoder().decode(OpenClawGatewayHealthOK.self, from: res))?.ok ?? true
-    }
-
-    func listQuestions() async throws -> [QuestionRecord] {
-        let data = try await gateway.request(OpenClawChatGatewayRequests.questionList())
-        return try JSONDecoder().decode(QuestionListResult.self, from: data).questions
-    }
-
-    func listTasks(sessionKey: String, agentID: String?) async throws -> [TaskSummary] {
-        let data = try await gateway.request(OpenClawChatGatewayRequests.tasksList(
-            sessionKey: sessionKey,
-            agentID: agentID))
-        return try JSONDecoder().decode(TasksListResult.self, from: data).tasks
-    }
-
-    func getQuestion(id: String) async throws -> QuestionRecord {
-        let data = try await gateway.request(OpenClawChatGatewayRequests.questionGet(id: id))
-        return try JSONDecoder().decode(QuestionGetResult.self, from: data).question
-    }
-
-    func resolveQuestion(
-        id: String,
-        answers: [String: [String]],
-        secretStoreAllowedHosts: [String]?) async throws -> QuestionAnswers
-    {
-        let data = try await self.gateway.request(OpenClawChatGatewayRequests.resolveQuestion(
-            id: id,
-            answers: answers,
-            secretStoreAllowedHosts: secretStoreAllowedHosts))
-        return try OpenClawChatGatewayPayloadCodec.decodeQuestionAnswer(data)
-    }
-
-    func cancelQuestion(id: String) async throws {
-        _ = try await self.gateway.request(OpenClawChatGatewayRequests.cancelQuestion(id: id))
     }
 
     func events() -> AsyncStream<OpenClawChatTransportEvent> {

--- a/apps/macos/Sources/OpenClaw/MacGatewayChatTransport+SessionActions.swift
+++ b/apps/macos/Sources/OpenClaw/MacGatewayChatTransport+SessionActions.swift
@@ -81,7 +81,7 @@ extension MacGatewayChatTransport {
             })
     }
 
-    private func requestSessionAction(_ request: OpenClawChatGatewayRequest) async throws -> Data {
+    func requestChatSessionAction(_ request: OpenClawChatGatewayRequest) async throws -> Data {
         guard let serverLease = await self.connection.captureServerLease() else {
             throw OpenClawChatTransportSendError.notDispatched
         }
@@ -103,54 +103,7 @@ extension MacGatewayChatTransport {
             parentSessionKey: target.sessionKey,
             agentID: target.agentID,
             fromLastCompleted: fromLastCompleted)
-        let data = try await self.requestSessionAction(request)
+        let data = try await self.requestChatSessionAction(request)
         return try JSONDecoder().decode(OpenClawChatCreateSessionResponse.self, from: data).key
-    }
-
-    func rewindSession(
-        sessionKey: String,
-        entryId: String) async throws -> OpenClawChatRewindResponse
-    {
-        let target = self.sessionTarget(for: sessionKey)
-        let request = OpenClawChatGatewayRequests.rewindSession(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID,
-            entryId: entryId)
-        let data = try await self.requestSessionAction(request)
-        return try JSONDecoder().decode(OpenClawChatRewindResponse.self, from: data)
-    }
-
-    func forkSessionAtMessage(
-        sessionKey: String,
-        entryId: String) async throws -> OpenClawChatForkAtMessageResponse
-    {
-        let target = self.sessionTarget(for: sessionKey)
-        let request = OpenClawChatGatewayRequests.forkAtMessage(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID,
-            entryId: entryId)
-        let data = try await self.requestSessionAction(request)
-        return try JSONDecoder().decode(OpenClawChatForkAtMessageResponse.self, from: data)
-    }
-
-    func listSessionBranches(
-        sessionKey: String,
-        agentID: String?) async throws -> OpenClawChatSessionBranchesResponse
-    {
-        let target = self.sessionTarget(for: sessionKey, overrideAgentID: agentID)
-        let request = OpenClawChatGatewayRequests.listSessionBranches(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID)
-        let data = try await self.requestSessionAction(request)
-        return try JSONDecoder().decode(OpenClawChatSessionBranchesResponse.self, from: data)
-    }
-
-    func switchSessionBranch(sessionKey: String, agentID: String?, leafEntryId: String) async throws {
-        let target = self.sessionTarget(for: sessionKey)
-        let request = OpenClawChatGatewayRequests.switchSessionBranch(
-            sessionKey: target.sessionKey,
-            agentID: agentID ?? target.agentID,
-            leafEntryId: leafEntryId)
-        _ = try await self.requestSessionAction(request)
     }
 }

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -64,7 +64,15 @@ private final class WebChatWindow: NSWindow {
     }
 }
 
-struct MacGatewayChatTransport: OpenClawChatTransport {
+struct MacGatewayChatTransport: OpenClawChatGatewayTransport {
+    var chatGatewayAgentID: String? {
+        self.routingIdentity.currentAgentID()
+    }
+
+    func requestChatGateway(_ request: OpenClawChatGatewayRequest) async throws -> Data {
+        try await self.connection.request(request)
+    }
+
     /// Shared across transport value copies so the live view model and its
     /// snapshot observer cannot diverge on the owner of the bare global alias.
     private final class RoutingIdentity: @unchecked Sendable {
@@ -273,15 +281,6 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         return try JSONDecoder().decode(OpenClawChatMetadataCapabilities.self, from: data).swarmEnabled
     }
 
-    func abortRun(sessionKey: String, runId: String) async throws {
-        let target = self.sessionTarget(for: sessionKey)
-        let request = OpenClawChatGatewayRequests.abortRun(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID,
-            runID: runId)
-        _ = try await self.connection.request(request)
-    }
-
     func listSessions(
         limit: Int?,
         search: String?,
@@ -400,17 +399,6 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             model: model)
     }
 
-    func patchSessionModel(
-        sessionKey: String,
-        agentID: String?,
-        model: String?) async throws -> OpenClawChatModelPatchResult?
-    {
-        try await self.patchSessionSettings(
-            sessionKey: sessionKey,
-            agentID: agentID,
-            patch: OpenClawChatSessionSettingsPatch(model: .some(model)))
-    }
-
     func patchSessionSettings(
         sessionKey: String,
         agentID: String?,
@@ -476,14 +464,6 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
                 patch: patch,
                 serverLease: serverLease)
         }
-    }
-
-    func setSessionThinking(sessionKey: String, thinkingLevel: String) async throws {
-        let target = self.sessionTarget(for: sessionKey)
-        _ = try await self.patchSessionSettings(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID,
-            patch: OpenClawChatSessionSettingsPatch(thinkingLevel: .some(thinkingLevel)))
     }
 
     func sendMessage(
@@ -621,30 +601,6 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         true
     }
 
-    func listCommands(sessionKey: String) async throws -> [OpenClawChatCommandChoice] {
-        let request = OpenClawChatGatewayRequests.commandsList(
-            sessionKey: sessionKey,
-            fallbackAgentID: self.routingIdentity.currentAgentID())
-        let data = try await connection.request(request)
-        let decoded = try JSONDecoder().decode(CommandsListResult.self, from: data)
-        return decoded.commands.map(OpenClawChatGatewayPayloadCodec.commandChoice)
-    }
-
-    func createSession(
-        key: String,
-        label: String?,
-        parentSessionKey: String?,
-        worktree: Bool?) async throws -> OpenClawChatCreateSessionResponse
-    {
-        try await self.createSession(
-            key: key,
-            label: label,
-            agentID: nil,
-            parentSessionKey: parentSessionKey,
-            worktree: worktree,
-            worktreeBaseRef: nil)
-    }
-
     func createSession(
         key: String,
         label: String?,
@@ -693,50 +649,8 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         throw OpenClawChatTransportSendError.notDispatched
     }
 
-    func deleteSession(key: String) async throws {
-        let target = self.sessionTarget(for: key)
-        let request = OpenClawChatGatewayRequests.deleteSession(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID)
-        _ = try await self.connection.request(request)
-    }
-
     func requestHealth(timeoutMs: Int) async throws -> Bool {
         try await self.connection.healthOK(timeoutMs: timeoutMs)
-    }
-
-    func listQuestions() async throws -> [QuestionRecord] {
-        let data = try await connection.request(OpenClawChatGatewayRequests.questionList())
-        return try JSONDecoder().decode(QuestionListResult.self, from: data).questions
-    }
-
-    func listTasks(sessionKey: String, agentID: String?) async throws -> [TaskSummary] {
-        let data = try await connection.request(OpenClawChatGatewayRequests.tasksList(
-            sessionKey: sessionKey,
-            agentID: agentID))
-        return try JSONDecoder().decode(TasksListResult.self, from: data).tasks
-    }
-
-    func getQuestion(id: String) async throws -> QuestionRecord {
-        let data = try await connection.request(OpenClawChatGatewayRequests.questionGet(id: id))
-        return try JSONDecoder().decode(QuestionGetResult.self, from: data).question
-    }
-
-    func resolveQuestion(
-        id: String,
-        answers: [String: [String]],
-        secretStoreAllowedHosts: [String]?) async throws -> QuestionAnswers
-    {
-        let data = try await self.connection.request(OpenClawChatGatewayRequests.resolveQuestion(
-            id: id,
-            answers: answers,
-            secretStoreAllowedHosts: secretStoreAllowedHosts))
-        return try OpenClawChatGatewayPayloadCodec.decodeQuestionAnswer(data)
-    }
-
-    func cancelQuestion(id: String) async throws {
-        _ = try await self.connection.request(
-            OpenClawChatGatewayRequests.cancelQuestion(id: id))
     }
 
     func waitForRunCompletion(
@@ -761,14 +675,6 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         }
     }
 
-    func resetSession(sessionKey: String) async throws {
-        let target = self.sessionTarget(for: sessionKey)
-        let request = OpenClawChatGatewayRequests.resetSession(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID)
-        _ = try await self.connection.request(request)
-    }
-
     func compactSession(sessionKey: String) async throws {
         let target = self.sessionTarget(for: sessionKey)
         let request = OpenClawChatGatewayRequests.compactSession(
@@ -776,14 +682,6 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             agentID: target.agentID)
         let response = try await connection.request(request, retryTransportFailures: false)
         try OpenClawSessionsCompactResponse.requireSuccess(from: response)
-    }
-
-    func setActiveSessionKey(_ sessionKey: String) async throws {
-        let target = self.sessionTarget(for: sessionKey)
-        let request = OpenClawChatGatewayRequests.subscribeSessionMessages(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID)
-        _ = try await self.connection.request(request)
     }
 
     func events() -> AsyncStream<OpenClawChatTransportEvent> {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatGatewayTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatGatewayTransport.swift
@@ -1,0 +1,175 @@
+import Foundation
+import OpenClawKit
+import OpenClawProtocol
+
+/// Shared RPC application layer. Platform adapters retain route acquisition,
+/// dispatch fencing, event subscriptions, and their session-target policy.
+public protocol OpenClawChatGatewayTransport: OpenClawChatTransport {
+    var chatGatewayAgentID: String? { get }
+    func sessionTarget(for sessionKey: String, overrideAgentID: String?) -> OpenClawChatSessionTarget
+    func requestChatGateway(_ request: OpenClawChatGatewayRequest) async throws -> Data
+    func requestChatSessionAction(_ request: OpenClawChatGatewayRequest) async throws -> Data
+}
+
+extension OpenClawChatGatewayTransport {
+    public func requestChatSessionAction(_ request: OpenClawChatGatewayRequest) async throws -> Data {
+        try await self.requestChatGateway(request)
+    }
+
+    public func abortRun(sessionKey: String, runId: String) async throws {
+        let target = self.sessionTarget(for: sessionKey, overrideAgentID: nil)
+        let request = OpenClawChatGatewayRequests.abortRun(
+            sessionKey: target.sessionKey,
+            agentID: target.agentID,
+            runID: runId)
+        _ = try await self.requestChatGateway(request)
+    }
+
+    public func deleteSession(key: String) async throws {
+        let target = self.sessionTarget(for: key, overrideAgentID: nil)
+        let request = OpenClawChatGatewayRequests.deleteSession(
+            sessionKey: target.sessionKey,
+            agentID: target.agentID)
+        _ = try await self.requestChatGateway(request)
+    }
+
+    public func setActiveSessionKey(_ sessionKey: String) async throws {
+        let target = self.sessionTarget(for: sessionKey, overrideAgentID: nil)
+        let request = OpenClawChatGatewayRequests.subscribeSessionMessages(
+            sessionKey: target.sessionKey,
+            agentID: target.agentID)
+        _ = try await self.requestChatGateway(request)
+    }
+
+    public func resetSession(sessionKey: String) async throws {
+        let target = self.sessionTarget(for: sessionKey, overrideAgentID: nil)
+        let request = OpenClawChatGatewayRequests.resetSession(
+            sessionKey: target.sessionKey,
+            agentID: target.agentID)
+        _ = try await self.requestChatGateway(request)
+    }
+
+    public func listCommands(sessionKey: String) async throws -> [OpenClawChatCommandChoice] {
+        let request = OpenClawChatGatewayRequests.commandsList(
+            sessionKey: sessionKey,
+            fallbackAgentID: self.chatGatewayAgentID)
+        let data = try await self.requestChatGateway(request)
+        let decoded = try JSONDecoder().decode(CommandsListResult.self, from: data)
+        return decoded.commands.map(OpenClawChatGatewayPayloadCodec.commandChoice)
+    }
+
+    public func listQuestions() async throws -> [QuestionRecord] {
+        let data = try await self.requestChatGateway(OpenClawChatGatewayRequests.questionList())
+        return try JSONDecoder().decode(QuestionListResult.self, from: data).questions
+    }
+
+    public func listTasks(sessionKey: String, agentID: String?) async throws -> [TaskSummary] {
+        let data = try await self.requestChatGateway(OpenClawChatGatewayRequests.tasksList(
+            sessionKey: sessionKey,
+            agentID: agentID))
+        return try JSONDecoder().decode(TasksListResult.self, from: data).tasks
+    }
+
+    public func getQuestion(id: String) async throws -> QuestionRecord {
+        let data = try await self.requestChatGateway(OpenClawChatGatewayRequests.questionGet(id: id))
+        return try JSONDecoder().decode(QuestionGetResult.self, from: data).question
+    }
+
+    public func resolveQuestion(
+        id: String,
+        answers: [String: [String]],
+        secretStoreAllowedHosts: [String]?) async throws -> QuestionAnswers
+    {
+        let data = try await self.requestChatGateway(OpenClawChatGatewayRequests.resolveQuestion(
+            id: id,
+            answers: answers,
+            secretStoreAllowedHosts: secretStoreAllowedHosts))
+        return try OpenClawChatGatewayPayloadCodec.decodeQuestionAnswer(data)
+    }
+
+    public func cancelQuestion(id: String) async throws {
+        _ = try await self.requestChatGateway(
+            OpenClawChatGatewayRequests.cancelQuestion(id: id))
+    }
+
+    public func setSessionThinking(sessionKey: String, thinkingLevel: String) async throws {
+        let target = self.sessionTarget(for: sessionKey, overrideAgentID: nil)
+        _ = try await self.patchSessionSettings(
+            sessionKey: target.sessionKey,
+            agentID: target.agentID,
+            patch: OpenClawChatSessionSettingsPatch(thinkingLevel: .some(thinkingLevel)))
+    }
+
+    public func patchSessionModel(
+        sessionKey: String,
+        agentID: String?,
+        model: String?) async throws -> OpenClawChatModelPatchResult?
+    {
+        try await self.patchSessionSettings(
+            sessionKey: sessionKey,
+            agentID: agentID,
+            patch: OpenClawChatSessionSettingsPatch(model: .some(model)))
+    }
+
+    public func createSession(
+        key: String,
+        label: String?,
+        parentSessionKey: String?,
+        worktree: Bool?) async throws -> OpenClawChatCreateSessionResponse
+    {
+        try await self.createSession(
+            key: key,
+            label: label,
+            agentID: nil,
+            parentSessionKey: parentSessionKey,
+            worktree: worktree,
+            worktreeBaseRef: nil)
+    }
+
+    public func rewindSession(
+        sessionKey: String,
+        entryId: String) async throws -> OpenClawChatRewindResponse
+    {
+        let target = self.sessionTarget(for: sessionKey, overrideAgentID: nil)
+        let request = OpenClawChatGatewayRequests.rewindSession(
+            sessionKey: target.sessionKey,
+            agentID: target.agentID,
+            entryId: entryId)
+        let data = try await self.requestChatSessionAction(request)
+        return try JSONDecoder().decode(OpenClawChatRewindResponse.self, from: data)
+    }
+
+    public func forkSessionAtMessage(
+        sessionKey: String,
+        entryId: String) async throws -> OpenClawChatForkAtMessageResponse
+    {
+        let target = self.sessionTarget(for: sessionKey, overrideAgentID: nil)
+        let request = OpenClawChatGatewayRequests.forkAtMessage(
+            sessionKey: target.sessionKey,
+            agentID: target.agentID,
+            entryId: entryId)
+        let data = try await self.requestChatSessionAction(request)
+        return try JSONDecoder().decode(OpenClawChatForkAtMessageResponse.self, from: data)
+    }
+
+    public func listSessionBranches(
+        sessionKey: String,
+        agentID: String?) async throws -> OpenClawChatSessionBranchesResponse
+    {
+        let target = self.sessionTarget(for: sessionKey, overrideAgentID: agentID)
+        let request = OpenClawChatGatewayRequests.listSessionBranches(
+            sessionKey: target.sessionKey,
+            agentID: target.agentID)
+        let data = try await self.requestChatSessionAction(request)
+        return try JSONDecoder().decode(OpenClawChatSessionBranchesResponse.self, from: data)
+    }
+
+    public func switchSessionBranch(sessionKey: String, agentID: String?, leafEntryId: String) async throws {
+        let target = self.sessionTarget(for: sessionKey, overrideAgentID: nil)
+        let request = OpenClawChatGatewayRequests.switchSessionBranch(
+            sessionKey: target.sessionKey,
+            agentID: agentID ?? target.agentID,
+            leafEntryId: leafEntryId)
+        _ = try await self.requestChatSessionAction(request)
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatGatewayTransportTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatGatewayTransportTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import OpenClawKit
+import Testing
+@testable import OpenClawChatUI
+
+struct ChatGatewayTransportTests {
+    @Test(arguments: [OpenClawChatSessionTargetPolicy.preserveBareKeys, .scopeBareKeysToSelectedAgent])
+    func `shared operations preserve platform targeting through the transport protocol`(
+        policy: OpenClawChatSessionTargetPolicy) async throws
+    {
+        let recorder = RequestRecorder()
+        let transport: any OpenClawChatTransport = Transport(policy: policy, request: { request in
+            await recorder.append(request)
+            return Data(#"{"ok":true}"#.utf8)
+        })
+        try await transport.deleteSession(key: " main ")
+        try await transport.resetSession(sessionKey: "global")
+        try await transport.abortRun(sessionKey: "agent:other:main", runId: "run-1")
+
+        let requests = await recorder.requests
+        #expect(requests.map(\.method) == ["sessions.delete", "sessions.reset", "chat.abort"])
+        let bareKey = switch policy {
+        case .preserveBareKeys: "main"
+        case .scopeBareKeysToSelectedAgent: "agent:reviewer:main"
+        }
+        #expect(requests[0].params["key"]?.value as? String == bareKey)
+        #expect(requests[0].params["deleteTranscript"]?.value as? Bool == true)
+        #expect(requests[1].params["key"]?.value as? String == "global")
+        #expect(requests[1].params["agentId"]?.value as? String == "reviewer")
+        #expect(requests[2].params["sessionKey"]?.value as? String == "agent:other:main")
+        #expect(requests[2].params["agentId"] == nil)
+        #expect(requests[2].params["runId"]?.value as? String == "run-1")
+    }
+
+    @Test func `branch operations use the platform authority hook and propagate its rejection`() async throws {
+        let recorder = RequestRecorder()
+        let transport: any OpenClawChatTransport = Transport(
+            request: { _ in throw Failure.unexpectedRequest },
+            actionRequest: { request in
+                await recorder.append(request)
+                if request.method == "sessions.rewind" {
+                    return Data(#"{"editorText":"restored draft"}"#.utf8)
+                }
+                throw Failure.retiredRoute
+            })
+
+        let response = try await transport.rewindSession(sessionKey: "global", entryId: "message-1")
+        #expect(response.editorText == "restored draft")
+        await #expect(throws: Failure.retiredRoute) {
+            try await transport.switchSessionBranch(sessionKey: "global", agentID: "other", leafEntryId: "leaf-1")
+        }
+        let requests = await recorder.requests
+        #expect(requests.map(\.method) == ["sessions.rewind", "sessions.branches.switch"])
+        #expect(requests[0].params["agentId"]?.value as? String == "reviewer")
+        #expect(requests[1].params["agentId"]?.value as? String == "other")
+    }
+
+    private enum Failure: Error { case unexpectedRequest, retiredRoute }
+
+    private actor RequestRecorder {
+        var requests: [OpenClawChatGatewayRequest] = []
+
+        func append(_ request: OpenClawChatGatewayRequest) {
+            self.requests.append(request)
+        }
+    }
+
+    private struct Transport: OpenClawChatGatewayTransport {
+        var policy: OpenClawChatSessionTargetPolicy = .preserveBareKeys
+        var request: @Sendable (OpenClawChatGatewayRequest) async throws -> Data
+        var actionRequest: (@Sendable (OpenClawChatGatewayRequest) async throws -> Data)?
+        let chatGatewayAgentID: String? = "reviewer"
+
+        func sessionTarget(for sessionKey: String, overrideAgentID: String?) -> OpenClawChatSessionTarget {
+            OpenClawChatSessionTarget.resolve(
+                sessionKey, selectedAgentID: self.chatGatewayAgentID, overrideAgentID: overrideAgentID,
+                policy: self.policy)
+        }
+
+        func requestChatGateway(_ request: OpenClawChatGatewayRequest) async throws -> Data {
+            try await self.request(request)
+        }
+
+        func requestChatSessionAction(_ request: OpenClawChatGatewayRequest) async throws -> Data {
+            try await (self.actionRequest ?? self.request)(request)
+        }
+
+        func requestHistory(sessionKey: String) async throws -> OpenClawChatHistoryPayload {
+            throw Failure.unexpectedRequest
+        }
+
+        func sendMessage(
+            sessionKey: String, message: String, thinking: String, idempotencyKey: String,
+            attachments: [OpenClawChatAttachmentPayload]) async throws -> OpenClawChatSendResponse
+        {
+            throw Failure.unexpectedRequest
+        }
+
+        func requestHealth(timeoutMs: Int) async throws -> Bool {
+            throw Failure.unexpectedRequest
+        }
+
+        func events() -> AsyncStream<OpenClawChatTransportEvent> {
+            AsyncStream { $0.finish() }
+        }
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

The macOS and iOS chat adapters separately implement the same task, question, command, and session RPC operations. Keeping those bodies synchronized makes request and response changes easy to apply to only one Apple client.

## Why This Change Was Made

OpenClawChatUI now owns seventeen common operations through `OpenClawChatGatewayTransport`. The platform adapters provide their current agent identity, session-target policy, and request hooks. macOS retains its captured server-lease handling for branch actions; iOS retains its existing request path. Send/receive lifecycle, composer and CAS policy, media handling, and the differing session-creation and compaction behavior remain with their existing owners.

This removes 122 production lines and adds 107 lines of shared boundary tests. Existing public transport contracts remain available; no compatibility export was removed. The adjacent iOS Settings work in #139514 was inspected and is outside this change.

## User Impact

No intended user-visible behavior change. Both Apple clients use the same implementation for these common RPC operations while preserving their routing and authority rules.

## Evidence

- Shared Swift package: 1,665 tests in 127 suites passed after rebasing onto current main (55.185 seconds). The new tests exercise operations through the public transport protocol, both session-target policies, and the separate authority hook for branch operations.
- An earlier full run hit two assertions in the unchanged model-catalog test `failed newest catalog refresh retains the last accepted auth gate`. Its focused rerun and the subsequent full run passed. No assertion, timeout, or mock was changed.
- macOS app build and test compilation passed.
- Strict macOS Periphery scan passed with no unused code.
- iOS simulator build passed after adding the installed Homebrew Rustup directory to PATH for the pinned Watch toolchain.
- `pnpm protocol:check:swift` and `pnpm native:i18n:check` passed.
- `node scripts/check-changed.mjs` passed, including 1,130 tooling tests.
- iPhone 17 simulator: 30 chat transport/discovery tests passed.
- Development macOS packaging passed with the OpenClaw Foundation Developer ID and verified private worker; the optional MLX helper was excluded.
- Independent Codex review through P2: no accepted or actionable findings.

Prior patch-identical head [CI 34097083994](https://github.com/openclaw/openclaw/actions/runs/34097083994) passed, including the native app checks. Rebased-head [CI 34105142206](https://github.com/openclaw/openclaw/actions/runs/34105142206) passed, including macOS Swift tests and the iOS build. Two real provider turns completed through the native macOS chat window on an isolated loopback Gateway using `openai/gpt-5.6-luna`. A read-only observer recorded 67 text-bearing deltas (3 to 3,118 characters), followed by a final event, for the second turn. The inspected capture shows the first completed turn.

iOS live chat proof was not completed on this host (no usable Simulator GUI); unit tests and CI native proof cover iOS. An earlier isolated pairing attempt stopped at “Could not save paired gateway,” before connection or chat dispatch; the unchanged Gateway registry persistence path remains a follow-up. Local sandboxed macOS test startup aborted before producing test results; test compilation alone is not runtime proof.

### Proof

![Native macOS chat on the isolated Gateway, with a real provider reply](https://github.com/user-attachments/assets/dd565bce-d70d-4698-ae97-5a2d4f0ced14)


Known unrelated check failure: the separate [iOS Periphery report](https://github.com/openclaw/openclaw/actions/runs/34105142111) reports one unused symbol, `StartLiveVoiceIntent.description` at `apps/ios/Sources/StartLiveVoiceIntent.swift:5`, introduced on main by #141003. That file is unchanged by this PR; no suppression or unrelated repair is included.
