### PR TITLE
fix(codex): avoid first-turn failures on cold cloud workers

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -248,7 +248,10 @@ openclaw gateway call sessions.dispatch \
 ```
 
 The node starts the same managed, pinned Codex binary with
-`codex exec-server --listen stdio` in the placement workspace. The Gateway
+`codex exec-server --listen stdio` in the placement workspace. The node waits for
+the native process to start listening before announcing execution readiness, so
+cold disk startup does not consume Codex's initialize-handshake budget. Startup
+remains cancellable through the existing attempt lifecycle. The Gateway
 relays complete Codex JSON-RPC messages through the existing authenticated,
 approval-gated duplex node channel, with a 64 MiB limit per message. It does not
 start an OpenClaw worker child, open a reverse tunnel, or copy provider, cloud,
@@ -261,6 +264,10 @@ credential-free endpoint. The node process uses a fresh private
 environment and requested child-process environments are sanitized. Completed
 filesystem changes reconcile into the Gateway-owned managed worktree or, for
 repository-only sessions, an immutable checkpoint retained by the Gateway.
+
+Native task processes inherit the exec-server's startup `RUST_LOG` filter under
+Codex's default environment policy. Set `RUST_LOG` explicitly in a command when
+that program needs a different log level.
 
 Disconnecting the node, closing the app-server connection, cancelling the turn,
 or retiring the plugin ends that Codex attempt visibly and terminates its remote

--- a/extensions/codex/src/node-exec-server.readiness.test.ts
+++ b/extensions/codex/src/node-exec-server.readiness.test.ts
@@ -1,0 +1,176 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
+import { access } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import type { OpenClawPluginNodeHostCommandIo } from "openclaw/plugin-sdk/node-host";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setManagedCodexPluginRoot } from "./app-server/managed-binary.js";
+import * as transport from "./app-server/transport-stdio.js";
+import { runCodexNodeExecServer } from "./node-exec-server.runtime.js";
+
+// Pinned Codex 0.153.4 transport.rs emits this line before entering its stdio loop.
+const READY = " INFO codex_exec_server::server::transport: codex-exec-server listening on stdio\n";
+const fixture = `
+const readline = require('node:readline');
+readline.createInterface({ input: process.stdin }).on('line', line => {
+  const message = JSON.parse(line);
+  if (message.stderr !== undefined) process.stderr.write(Buffer.from(message.stderr, 'base64'));
+  else if (message.exit !== undefined) process.exit(message.exit);
+  else if (message.method === 'initialize') process.stdout.write(JSON.stringify({id: message.id, result: {sessionId: 'fixture'}}) + '\\n');
+});
+`;
+
+beforeEach(() => setManagedCodexPluginRoot(fileURLToPath(new URL("../", import.meta.url))));
+afterEach(() => {
+  setManagedCodexPluginRoot(undefined);
+  vi.restoreAllMocks();
+});
+
+async function startFixture(readyBeforeRegistrationReturns = false) {
+  const controller = new AbortController();
+  const receiver = vi.fn();
+  const send = vi.fn(async (_message: Uint8Array) => {});
+  const assertExecAuthorized = vi.fn();
+  const activeProcesses = new Set<() => Promise<void>>();
+  const io = {
+    signal: controller.signal,
+    emitChunk: async () => {},
+    onInput: () => {},
+    frames: { send, onMessage: () => () => {} },
+  } satisfies OpenClawPluginNodeHostCommandIo;
+  let resolveChild!: (child: ChildProcessWithoutNullStreams) => void;
+  const childCreated = new Promise<ChildProcessWithoutNullStreams>((resolve) => {
+    resolveChild = resolve;
+  });
+  let privateHome: string | undefined;
+  const create = transport.createStdioTransport;
+  vi.spyOn(transport, "createStdioTransport").mockImplementation(
+    async (options, env, current, onSpawn) => {
+      privateHome = options.env?.HOME;
+      let earlyMarker: Promise<unknown> | undefined;
+      const child = await create(
+        { ...options, command: process.execPath, args: ["-e", fixture] },
+        env,
+        current,
+        (spawned) => {
+          onSpawn?.(spawned);
+          if (readyBeforeRegistrationReturns) {
+            earlyMarker = once(spawned.stderr, "data");
+            spawned.once("spawn", () => {
+              spawned.stdin.write(
+                JSON.stringify({ stderr: Buffer.from(READY).toString("base64") }) + "\n",
+              );
+            });
+          }
+        },
+      );
+      await earlyMarker;
+      resolveChild(child);
+      return child;
+    },
+  );
+  const invocation = runCodexNodeExecServer({
+    workspaceDir: process.cwd(),
+    io,
+    activeProcesses,
+    assertExecAuthorized,
+    onFrameReceiver: receiver,
+  });
+  const outcome = invocation.catch((error: unknown) => error);
+  const child = await Promise.race([
+    childCreated,
+    invocation.then(() => {
+      throw new Error("fixture exited before spawn");
+    }),
+  ]);
+  const stderr = async (text: string) => {
+    const delivered = once(child.stderr, "data");
+    child.stdin.write(JSON.stringify({ stderr: Buffer.from(text).toString("base64") }) + "\n");
+    await delivered;
+  };
+  return {
+    child,
+    controller,
+    receiver,
+    send,
+    assertExecAuthorized,
+    activeProcesses,
+    outcome,
+    stderr,
+    async cleanup() {
+      controller.abort(new Error("fixture cleanup"));
+      await outcome;
+      expect(child.exitCode !== null || child.signalCode !== null).toBe(true);
+      expect(activeProcesses.size).toBe(0);
+      expect(privateHome).toBeDefined();
+      await expect(access(privateHome!)).rejects.toThrow();
+    },
+  };
+}
+
+describe("Codex node native readiness", () => {
+  it("retains native readiness emitted before process registration returns", async () => {
+    const harness = await startFixture(true);
+    try {
+      await vi.waitFor(() => expect(harness.receiver).toHaveBeenCalledOnce());
+    } finally {
+      await harness.cleanup();
+    }
+  });
+  it("withholds the carrier until the fragmented native-ready line and preserves the first initialize", async () => {
+    const harness = await startFixture();
+    try {
+      await harness.stderr("loading native runtime\n");
+      expect(harness.receiver).not.toHaveBeenCalled();
+      for (const fragment of [READY.slice(0, 18), READY.slice(18, -1)]) {
+        await harness.stderr(fragment);
+        expect(harness.receiver).not.toHaveBeenCalled();
+      }
+      await harness.stderr("\n");
+      await vi.waitFor(() => expect(harness.receiver).toHaveBeenCalledOnce());
+      const receive = harness.receiver.mock.calls[0]![0] as (
+        message: Buffer,
+      ) => Promise<void> | void;
+      await receive(Buffer.from(JSON.stringify({ id: 1, method: "initialize", params: {} })));
+      await vi.waitFor(() => expect(harness.send).toHaveBeenCalledOnce());
+      expect(JSON.parse(Buffer.from(harness.send.mock.calls[0]![0]).toString())).toEqual({
+        id: 1,
+        result: { sessionId: "fixture" },
+      });
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it.each(["abort", "authority revoked", "early exit", "oversized line"])(
+    "does not publish readiness after %s",
+    async (failure) => {
+      const harness = await startFixture();
+      try {
+        await harness.stderr("loading native runtime\n");
+        expect(harness.receiver).not.toHaveBeenCalled();
+        if (failure === "abort") {
+          harness.controller.abort(new Error("startup canceled"));
+        }
+        if (failure === "authority revoked") {
+          harness.assertExecAuthorized.mockImplementation(() => {
+            throw new Error("authority revoked");
+          });
+          await harness.stderr(READY);
+        }
+        if (failure === "early exit") {
+          harness.child.stdin.end(JSON.stringify({ exit: 7 }) + "\n");
+        }
+        if (failure === "oversized line") {
+          await harness.stderr("x".repeat(4097));
+        }
+        const error = await harness.outcome;
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toMatch(/canceled|revoked|exited|diagnostic/i);
+        expect(harness.receiver).not.toHaveBeenCalled();
+      } finally {
+        await harness.cleanup();
+      }
+    },
+  );
+});

--- a/extensions/codex/src/node-exec-server.runtime.ts
+++ b/extensions/codex/src/node-exec-server.runtime.ts
@@ -3,6 +3,9 @@ import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { once } from "node:events";
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
+import { stripVTControlCharacters } from "node:util";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { OpenClawPluginNodeHostCommandIo } from "openclaw/plugin-sdk/node-host";
 import { killProcessTree } from "openclaw/plugin-sdk/process-runtime";
 import { sanitizeEnvVars } from "openclaw/plugin-sdk/sandbox";
@@ -18,6 +21,10 @@ import { closeCodexAppServerTransportAndWait } from "./app-server/transport.js";
 
 const MAX_CODEX_EXEC_SERVER_MESSAGE_BYTES = 64 * 1024 * 1024;
 const MAX_CODEX_EXEC_SERVER_STDERR_BYTES = 4 * 1024;
+// Pinned Codex 0.153.4 transport.rs:149 emits this before reading the one-shot
+// initialize request. Its package integration test guards this internal contract.
+const CODEX_EXEC_SERVER_READY_LINE =
+  "codex_exec_server::server::transport: codex-exec-server listening on stdio";
 const CODEX_EXEC_SERVER_TERMINATION_GRACE_MS = 1_000;
 const CODEX_EXEC_SERVER_REAP_TIMEOUT_MS = 5_000;
 const NODE_EXEC_SERVER_PLATFORM_ENVIRONMENT =
@@ -209,6 +216,12 @@ export async function runCodexNodeExecServer(params: {
         }
         // Awaited setup is complete; policy and invocation closure win at spawn.
         params.assertExecAuthorized();
+        const nativeReady = createDeferred<void>();
+        const exit = createDeferred<{ code: number | null; signal: NodeJS.Signals | null }>();
+        let stderr = Buffer.alloc(0);
+        let startupSettled = false;
+        let pendingLine = "";
+        const decoder = new StringDecoder("utf8");
         const child = await createStdioTransport(
           {
             transport: "stdio",
@@ -220,6 +233,8 @@ export async function runCodexNodeExecServer(params: {
             env: {
               HOME: dir,
               CODEX_HOME: codexHome,
+              RUST_LOG:
+                "error,opentelemetry_sdk=off,opentelemetry_otlp=off,codex_exec_server::server::transport=info",
               ...(process.platform === "win32" ? { USERPROFILE: dir } : {}),
             },
             clearEnv: ["NODE_OPTIONS"],
@@ -231,23 +246,51 @@ export async function runCodexNodeExecServer(params: {
             }
             params.assertExecAuthorized();
           },
-        );
-        child.stdin.on("error", (error) => {
-          rejectDisconnected(error);
-        });
-        let stderr = Buffer.alloc(0);
-        child.stderr.on("data", (chunk: Buffer | string) => {
-          const next = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-          const bounded = next.subarray(-MAX_CODEX_EXEC_SERVER_STDERR_BYTES);
-          stderr = Buffer.concat([stderr, bounded]).subarray(-MAX_CODEX_EXEC_SERVER_STDERR_BYTES);
-        });
-        const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
-          (resolve) => {
-            child.once("close", (code, signal) => resolve({ code, signal }));
+          (spawned) => {
+            // Observe before process registration yields: a fast child can emit
+            // readiness or exit before createStdioTransport returns.
+            spawned.once("close", (code, signal) => exit.resolve({ code, signal }));
+            spawned.once("error", rejectDisconnected);
+            spawned.stdin.on("error", rejectDisconnected);
+            spawned.stderr.on("data", (chunk: Buffer | string) => {
+              const next = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+              stderr = Buffer.concat([
+                stderr,
+                next.subarray(-MAX_CODEX_EXEC_SERVER_STDERR_BYTES),
+              ]).subarray(-MAX_CODEX_EXEC_SERVER_STDERR_BYTES);
+              if (startupSettled) {
+                return;
+              }
+              const lines = (pendingLine + decoder.write(next)).split("\n");
+              pendingLine = lines.pop()!;
+              for (const line of [...lines, pendingLine]) {
+                if (Buffer.byteLength(line, "utf8") > MAX_CODEX_EXEC_SERVER_STDERR_BYTES) {
+                  startupSettled = true;
+                  pendingLine = "";
+                  rejectDisconnected(
+                    new Error("Codex node startup diagnostic line exceeded 4 KiB."),
+                  );
+                  return;
+                }
+              }
+              if (
+                lines.some((line) =>
+                  stripVTControlCharacters(line).trimEnd().endsWith(CODEX_EXEC_SERVER_READY_LINE),
+                )
+              ) {
+                startupSettled = true;
+                pendingLine = "";
+                nativeReady.resolve();
+              }
+            });
           },
         );
-        child.once("error", (error) => {
-          rejectDisconnected(error);
+        const closed = exit.promise;
+        const stopped = closed.then((outcome) => {
+          const diagnostic = stderr.toString("utf8").trim();
+          throw new Error(
+            `Codex node exec-server exited (code ${outcome.code ?? "none"}, signal ${outcome.signal ?? "none"})${diagnostic ? `: ${diagnostic}` : "."}`,
+          );
         });
         const owner = createNodeExecServerProcessOwner(child, closed);
         params.activeProcesses.add(owner.terminate);
@@ -256,11 +299,16 @@ export async function runCodexNodeExecServer(params: {
           rejectDisconnected(error instanceof Error ? error : new Error(String(error)));
         });
         try {
+          await Promise.race([nativeReady.promise, stopped, disconnected]);
           if (io.signal.aborted) {
             throw nodeExecServerAbortError(io.signal);
           }
-          // Registration publishes framed readiness; avoid promising it before
-          // the child and every cleanup/error owner can consume incoming frames.
+          if (child.exitCode !== null || child.signalCode !== null) {
+            await stopped;
+          }
+          params.assertExecAuthorized();
+          // Framed readiness starts Codex's initialize budget. Native startup
+          // belongs to this cancellable launch, before that handshake begins.
           params.onFrameReceiver((message) => {
             const encoded = validateNodeExecServerMessage(message);
             const operation = writes
@@ -278,11 +326,7 @@ export async function runCodexNodeExecServer(params: {
             });
             return operation;
           });
-          const outcome = await Promise.race([closed, disconnected]);
-          const diagnostic = stderr.toString("utf8").trim();
-          throw new Error(
-            `Codex node exec-server exited (code ${outcome.code ?? "none"}, signal ${outcome.signal ?? "none"})${diagnostic ? `: ${diagnostic}` : "."}`,
-          );
+          return await Promise.race([stopped, disconnected]);
         } finally {
           await owner.terminate();
           params.activeProcesses.delete(owner.terminate);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting a Codex cloud session could lose the first turn when the worker's native executable was cold. A live snapshot-backed worker accepted the initialize frame while its native process was still starting: native listening took 10.544 seconds after spawn, while the Gateway-side initialize connection closed after 10.002 seconds.

## Why This Change Was Made

The node command advertised its duplex receiver immediately after spawning the process. It now announces readiness after the managed native process starts listening, keeping native startup inside the existing cancellable launch lifetime and preserving the single Codex initialize exchange. Stderr and exit observers are installed before process registration yields, and execution authority is revalidated before receiver publication. Process cleanup, ordered framing, and the existing handshake timeout remain unchanged.

This deliberately uses an internal contract of the pinned `@openai/codex` 0.153.4 executable: its transport emits a listening line immediately before processing stdio. The launch owns the exact diagnostic filter, and the real pinned-binary integration guards the contract. This is not a new public Codex readiness API; package updates must continue to satisfy that integration. The node path already permits only the managed package's native executable, including in OpenClaw's v2026.9.2 release; custom Gateway app-server commands are unaffected.

The production delta is +44 lines: bounded, fragmented startup-line handling plus the readiness/exit race and post-wait authority check. Existing stderr and exit handling moved into the same owner rather than adding another process, protocol proxy, or preparation path.

## User Impact

The first turn can wait for a cold native process to become usable instead of spending the protocol handshake budget on process startup. Cancellation still terminates the owned process and removes its private home.

The fixed startup diagnostic `RUST_LOG` filter is inherited by native task processes under Codex's default `inherit=all` environment policy. This is an operational tradeoff: an explicit command-level `RUST_LOG` value can select the log level a program needs. The docs state this behavior; the change does not rewrite task environment policies or request payloads.

## Evidence

- Live pre-fix trace distinguished native startup delay from transport delivery: initialize reached node stdin before the native listening marker, and the Gateway closed at its existing 10-second deadline.
- A separate diagnostic on a fresh fork read and hashed the same 258,659,424-byte executable before launch. Reading took 39.943 seconds; the following native initialize took 91 ms, with a 12 ms repeat. This supports cold executable I/O as the startup delay; a full-file prefetch is not included in this fix.
- Controlled delayed-startup cases failed on the base because the receiver was published prematurely, then passed with the fix. Coverage includes fragmented readiness, a marker emitted during process registration, first-initialize preservation, cancellation, authority revocation, early exit, and oversized diagnostic lines.
- Existing real pinned-binary, relay, duplex-framing, and node-host suites passed. Production and test extension types and the full changed gate passed. Independent P2 review found no actionable findings.
- Exact dependency contracts inspected: [stdio listening](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/exec-server/src/server/transport.rs#L149), [initialize deadline](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/exec-server/src/client.rs#L697), and [default environment policy](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/protocol/src/config_types.rs#L261).

The full combined candidate build passed in 303.8 seconds with this exact repair patch included.

Exact-head [CI run 34097560695](https://github.com/openclaw/openclaw/actions/runs/34097560695) passed on the first attempt: 84 jobs succeeded and 16 were skipped.

### After-fix live verification

The real cold-capture → warm-clone pair passed with the same runtime archive (`0f76db37c27866f48dff208da9864b3390c6d7e015611a99a1dc0d0f8ffdd034`). The combined build used captured main `86a3c7267be4` plus this exact repair and the now-merged plugin-activation/preallocation repairs (#140842, #140945). All three files in this PR were byte-compared with head `15acedda2070`; the tested build contained no private diagnostic instrumentation.

| Flow | Real tool turn | Repository continuity | Runtime setup |
| --- | --- | --- | --- |
| Cold capture | Passed, 58.929s | Restored 8 retained files and created the ninth | Downloaded and installed the runtime, then captured an available native image |
| Warm clone | Passed, 65.872s | Restored all 9 files and created the tenth | Used that same image/archive; no runtime download or npm installation |

Both flows completed normal Stop. Authoritative provider state was released with cleanup complete, canonical environments were destroyed with no attachments, and all 34 cold / 32 warm recorded process birth identities were absent. Gateway ports were closed, controllers joined, preexisting owners were preserved, and no coordinator version drift was observed. Neither flow created an additional Gateway repository checkout.

This completes ClawSweeper's requested after-fix cold/warm proof. It establishes the first-turn correctness repair, not an overall startup-speed claim: warm dispatch still took 325.591s, including 36.649s in plugin activation. That variable startup latency remains a separate performance follow-up.
