### PR TITLE
fix(docker): preserve workspace project ownership during setup

### DIFF
--- a/scripts/docker/setup.sh
+++ b/scripts/docker/setup.sh
@@ -803,9 +803,9 @@ fi
 # it works regardless of the host uid and doesn't require host-side root.
 echo ""
 echo "==> Fixing data-directory permissions"
-# Use -xdev to restrict chown to the config-dir mount only — without it,
-# the recursive chown would cross into the workspace bind mount and rewrite
-# ownership of all user project files on Linux hosts.
+# Prune workspace descendants explicitly: -xdev still crosses bind mounts on
+# the same filesystem. Repair the mount point itself so node can write there,
+# but leave user project file ownership unchanged.
 # Run a no-dereference chown from each entry's directory. This keeps ownership
 # repair for sockets/FIFOs while preventing a swapped symlink leaf from
 # redirecting the root operation outside the mounted tree.
@@ -813,7 +813,7 @@ echo "==> Fixing data-directory permissions"
 # (.openclaw/) inside the workspace gets chowned, not the user's project files.
 run_prestart_gateway --user root --entrypoint sh openclaw-gateway -c \
   'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin; export PATH; \
-   /usr/bin/find -P /home/node/.openclaw -xdev -execdir /usr/bin/chown -h node:node {} +; \
+   /usr/bin/find -P /home/node/.openclaw -xdev \( ! -path /home/node/.openclaw/workspace -o -prune \) -execdir /usr/bin/chown -h node:node {} +; \
    /usr/bin/chown -h node:node /home/node/.config; \
    /usr/bin/find -P /home/node/.config/openclaw -xdev -execdir /usr/bin/chown -h node:node {} +; \
    if [ -d /home/node/.openclaw/workspace/.openclaw ] && [ ! -L /home/node/.openclaw/workspace/.openclaw ]; then \

--- a/src/docker-setup.e2e.test.ts
+++ b/src/docker-setup.e2e.test.ts
@@ -602,7 +602,19 @@ describe("scripts/docker/setup.sh", () => {
   it("precreates agent data dirs to avoid EACCES in container", async () => {
     const activeSandbox = requireSandbox(sandbox);
     const configDir = join(activeSandbox.rootDir, "config-agent-dirs");
-    const workspaceDir = join(activeSandbox.rootDir, "workspace-agent-dirs");
+    const workspaceDir = join(configDir, "workspace");
+    const stateFiles = [
+      "identity/owned.txt",
+      "agents/workspace/owned.txt",
+      "workspace-archive/owned.txt",
+    ];
+    const workspaceFile = "workspace/project/user.txt";
+    for (const relative of [...stateFiles, workspaceFile]) {
+      const path = join(configDir, relative);
+      await mkdir(join(path, ".."), { recursive: true });
+      await writeFile(path, "fixture");
+    }
+    expect((await stat(workspaceDir)).dev).toBe((await stat(configDir)).dev);
 
     const result = runDockerSetup(activeSandbox, {
       OPENCLAW_CONFIG_DIR: configDir,
@@ -619,7 +631,11 @@ describe("scripts/docker/setup.sh", () => {
     const log = await readDockerLog(activeSandbox);
     const chownIdx = log.indexOf("--user root");
     const safePathIdx = log.indexOf(`${prestartSafePath}; export PATH`);
-    const stateRepairIdx = log.indexOf(noFollowOwnershipRepair("/home/node/.openclaw"));
+    const stateRepair = log.match(/\/usr\/bin\/find -P \/home\/node\/\.openclaw [^;]+/u)?.[0];
+    if (!stateRepair) {
+      throw new Error("Missing generated state ownership repair");
+    }
+    const stateRepairIdx = log.indexOf(stateRepair);
     const onboardIdx = log.indexOf("onboard");
     expect(chownIdx).toBeGreaterThanOrEqual(0);
     expect(safePathIdx).toBeGreaterThan(chownIdx);
@@ -627,7 +643,7 @@ describe("scripts/docker/setup.sh", () => {
     expect(onboardIdx).toBeGreaterThan(chownIdx);
     expect(log).toContain("run --rm --no-deps --user root --entrypoint sh openclaw-gateway -c");
     expect(log).toContain("/usr/bin/chown -h node:node /home/node/.config");
-    expect(log).toContain(noFollowOwnershipRepair("/home/node/.openclaw"));
+    expect(stateRepair).toContain("-execdir /usr/bin/chown -h node:node {} +");
     expect(log).toContain(noFollowOwnershipRepair("/home/node/.config/openclaw"));
     expect(log).toContain("[ ! -L /home/node/.openclaw/workspace/.openclaw ]");
     expect(log).toContain(noFollowOwnershipRepair("/home/node/.openclaw/workspace/.openclaw"));
@@ -636,6 +652,27 @@ describe("scripts/docker/setup.sh", () => {
     expect(log).not.toContain("-exec chown");
     expect(log).not.toContain(" chown node:node");
     expect(log).not.toContain("chown -R node:node /home/node/.openclaw/workspace/.openclaw");
+
+    // Execute the generated traversal, replacing only the ownership side effect.
+    // Same-device workspace mounts are not excluded by find's -xdev option.
+    const selection = stateRepair
+      .replaceAll("/home/node/.openclaw", '"$repair_root"')
+      .replace(/-execdir \/usr\/bin\/chown -h node:node \{\} \+$/u, "-print");
+    expect(selection).not.toContain("chown");
+    const traversal = spawnSync(
+      "bash",
+      ["-c", 'repair_root="$(cd "$1" && pwd)"; ' + selection, "ownership-repair", configDir],
+      { encoding: "utf8" },
+    );
+    expect(traversal.status, traversal.stderr).toBe(0);
+    const selected = traversal.stdout.trim().split(/\r?\n/u);
+    const selectedRoot = selected[0];
+    expect(selectedRoot).toMatch(/\/config-agent-dirs$/u);
+    for (const relative of stateFiles) {
+      expect(selected).toContain(`${selectedRoot}/${relative}`);
+    }
+    expect(selected).toContain(`${selectedRoot}/workspace`);
+    expect(selected).not.toContain(`${selectedRoot}/${workspaceFile}`);
   });
 
   it("precreates auth profile secret key dir outside the mounted state dir", async () => {


### PR DESCRIPTION
Closes #140968

## What Problem This Solves

Docker setup can rewrite ownership of project files when the config and workspace bind mounts share a filesystem. `find -xdev` crosses that workspace mount because its device ID is unchanged.

## Why This Change Was Made

Prune the exact workspace path during config-state traversal. Still repair the workspace root, config state, auth-profile state, and normal `workspace/.openclaw` metadata. Keep the existing no-follow symlink protections.

## User Impact

Project contents, modes, user IDs, and group IDs stay unchanged. OpenClaw state and the workspace root remain writable by the container user. This changes no user-ID default, config schema, migration, or image-selection policy.

## Evidence

Real Linux Docker proof used the complete setup script with `--offline`, one pinned preloaded runtime, and synthetic bind mounts. The ownership operation was real; Docker and `chown` were not stubbed.

| Case | Observed result |
| --- | --- |
| Main `5b2b7173023dd5cb841364b2048f08d62e9101c5` | All five project descendants changed from distinct owners/groups to `1000:1000`; contents and modes stayed unchanged. |
| Candidate `e6183c025cd3c442c38e99bd9d26e8465990797a`, fresh setup | All project contents, modes, owners, and groups stayed unchanged; state and metadata were repaired. |
| Candidate, existing-workspace rerun | Same ownership boundary, successful Gateway health, and writable state/workspace root. |
| Similarly named state directories | `agents/workspace` and `workspace-archive` were repaired normally. |
| State symlinks and symlinked workspace metadata | Link targets and project ownership stayed unchanged. |
| Workspace on a separate filesystem | Same preservation and writability results; distinct device IDs were verified. |
| Explicit numeric container user | Main and candidate both preserved project ownership on a separate filesystem with user `1000:1000`. |
| Missing preloaded image | Setup exited with a visible error before ownership repair. |
| Read-only config | Real ownership errors were visible; setup exited 1 before starting the Gateway. |

The successful fresh, rerun, symlink, separate-filesystem, and numeric-user cases passed Gateway health and applicable container-user writability checks. The initial main run was stopped by a resource gate after demonstrating the ownership failure; the full main setup then completed on the retained fixture after the accounting input was corrected. That interrupted attempt is retained separately from successful proof.

The existing GNU find regression remains, including ordinary-state positive controls. Exact-head CI run [34097541862](https://github.com/openclaw/openclaw/actions/runs/34097541862) passed. No runtime build or dependency change was needed for the Docker ownership proof.

An independent source-blind check added new project and state files, then requested another full setup rerun. The project retained its exact bytes, `24101:24102` ownership, and mode `0640`; the state control was repaired from `24103:24104` to `1000:1000` and remained writable. Live Gateway health passed.

The independent check and supplement pass the observed behavior. Source-only claims—exact traversal, absence of additional passes or migrations, and unchanged defaults—are documented by the pinned source comparison for final code review. The read-only case demonstrates visible final failure, not immediate termination or rollback at the first ownership error.

Full command output, original failure history, before/after observations, and both independent reports are retained for the exact-head review.
