### PR TITLE
feat(cron): report slow list page timings

### DIFF
--- a/docs/gateway/logging.md
+++ b/docs/gateway/logging.md
@@ -51,6 +51,23 @@ openclaw logs --follow
 - Embedded-run `continue_normal` decisions log at `debug`; retry, profile-rotation, model-fallback, and error decisions remain warnings.
 - Trace logging also includes diagnostic timing summaries for selected hot paths, such as plugin tool factory preparation. See [/tools/plugin#slow-plugin-tool-setup](/tools/plugin#slow-plugin-tool-setup).
 
+### Slow cron list pages
+
+A cron list page taking at least one second emits `cron: slow list page` through
+its existing logger, subject to the file log level. The structured record names
+`operation: "cron.listPage"` and reports `elapsedMs`, `waitToCallbackMs`,
+`callbackMs`, and `completionDelayMs`, plus available source, matched, and returned
+row counts, the outcome, and emitter `pid`, `threadId`, and `isMainThread`. Fast
+pages emit no such record.
+
+These are wall times, not CPU time: waiting includes scheduling delays, callback
+time includes awaited work, and completion delay covers settlement after the
+callback finishes. Each source page is measured separately; caller visibility
+filtering and delivery previews outside that page are not included. Existing
+trace context is retained when present. Emitter identity identifies the logging process/isolate, not the owner of work
+awaited by the callback. The diagnostic adds no job identifiers,
+job contents, or request parameters.
+
 ## Console capture
 
 The CLI captures `console.log/info/warn/error/debug/trace`, writes them to file logs, and still prints to stdout/stderr.

--- a/src/cron/service.list-page-sort-guards.test.ts
+++ b/src/cron/service.list-page-sort-guards.test.ts
@@ -2,8 +2,12 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { isMainThread, threadId } from "node:worker_threads";
 import { describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../shared/deferred.js";
 import { createMockCronStateForJobs } from "./service.test-harness.js";
+import { locked } from "./service/locked.js";
 import { list, listPage } from "./service/ops-read.js";
 import type { CronJob } from "./types.js";
 
@@ -326,6 +330,183 @@ describe("cron listPage sort guards", () => {
       expect(page.hasMore).toBe(false);
     } finally {
       await fs.rm(storeDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("cron listPage slow diagnostics", () => {
+  it.each([999, 1_000])(
+    "warns only once elapsed reaches the threshold (%i ms)",
+    async (duration) => {
+      let now = 0;
+      const clock = vi.spyOn(performance, "now").mockImplementation(() => now);
+      const state = createMockCronStateForJobs({ jobs: [createBaseJob()] });
+      const warn = vi.fn();
+      state.deps.log.warn = warn;
+      state.deps.resolveDefaultAgentId = () => {
+        now = duration;
+        return "main";
+      };
+      try {
+        const page = await listPage(state, { agentId: "main" });
+        expect(page.jobs).toHaveLength(1);
+        expect(warn).toHaveBeenCalledTimes(duration < 1_000 ? 0 : 1);
+        if (duration >= 1_000) {
+          expect(warn).toHaveBeenCalledWith(
+            {
+              operation: "cron.listPage",
+              pid: process.pid,
+              threadId,
+              isMainThread,
+              elapsedMs: 1_000,
+              waitToCallbackMs: 0,
+              callbackMs: 1_000,
+              completionDelayMs: 0,
+              sourceCount: 1,
+              matchedCount: 1,
+              returnedCount: 1,
+              outcome: "ok",
+              thresholdMs: 1_000,
+            },
+            "cron: slow list page",
+          );
+        }
+      } finally {
+        await state.op;
+        clock.mockRestore();
+      }
+    },
+  );
+
+  it("separates a held predecessor from callback work without delaying another partition", async () => {
+    let now = 0;
+    const clock = vi.spyOn(performance, "now").mockImplementation(() => now);
+    const state = createMockCronStateForJobs({
+      jobs: [createBaseJob(), createBaseJob({ id: "disabled", enabled: false })],
+    });
+    const other = createMockCronStateForJobs({ jobs: [] });
+    other.deps.storePath = "/mock/other-partition";
+    const warn = vi.fn();
+    state.deps.log.warn = warn;
+    const entered = createDeferredCore();
+    const release = createDeferredCore();
+    const order: string[] = [];
+    const predecessor = locked(state, async () => {
+      order.push("predecessor");
+      entered.resolve();
+      await release.promise;
+    });
+    await entered.promise;
+    state.deps.resolveDefaultAgentId = () => {
+      order.push("list");
+      now = 1_750;
+      return "main";
+    };
+    const pagePromise = listPage(state, { agentId: "main", limit: 1 });
+    const successor = locked(state, async () => {
+      order.push("successor");
+    });
+    try {
+      expect((await listPage(other)).jobs).toEqual([]);
+      expect(order).toEqual(["predecessor"]);
+      expect(warn).not.toHaveBeenCalled();
+      now = 1_400;
+      release.resolve();
+      const page = await pagePromise;
+      await successor;
+      expect(order).toEqual(["predecessor", "list", "successor"]);
+      expect(page.jobs.map((job) => job.id)).toEqual(["job-1"]);
+      expect(warn).toHaveBeenCalledExactlyOnceWith(
+        {
+          operation: "cron.listPage",
+          pid: process.pid,
+          threadId,
+          isMainThread,
+          elapsedMs: 1_750,
+          waitToCallbackMs: 1_400,
+          callbackMs: 350,
+          completionDelayMs: 0,
+          sourceCount: 2,
+          matchedCount: 1,
+          returnedCount: 1,
+          outcome: "ok",
+          thresholdMs: 1_000,
+        },
+        "cron: slow list page",
+      );
+    } finally {
+      release.resolve();
+      await Promise.allSettled([predecessor, pagePromise, successor, other.op]);
+      clock.mockRestore();
+    }
+  });
+
+  it.each([false, true])(
+    "preserves callback failure and subsequent reads when logger throws=%s",
+    async (loggerThrows) => {
+      let now = 0;
+      const clock = vi.spyOn(performance, "now").mockImplementation(() => now);
+      const state = createMockCronStateForJobs({ jobs: [createBaseJob()] });
+      const failure = new Error("synthetic selected-row failure");
+      const warn = vi.fn(() => {
+        if (loggerThrows) {
+          throw new Error("synthetic logger failure");
+        }
+      });
+      state.deps.log.warn = warn;
+      state.deps.resolveDefaultAgentId = () => {
+        now = 1_200;
+        throw failure;
+      };
+      try {
+        await expect(listPage(state, { agentId: "main" })).rejects.toBe(failure);
+        expect(warn).toHaveBeenCalledExactlyOnceWith(
+          {
+            operation: "cron.listPage",
+            pid: process.pid,
+            threadId,
+            isMainThread,
+            elapsedMs: 1_200,
+            waitToCallbackMs: 0,
+            callbackMs: 1_200,
+            completionDelayMs: 0,
+            sourceCount: 1,
+            matchedCount: undefined,
+            returnedCount: undefined,
+            outcome: "error",
+            thresholdMs: 1_000,
+          },
+          "cron: slow list page",
+        );
+        expect((await listPage(state)).jobs.map((job) => job.id)).toEqual(["job-1"]);
+        expect(warn).toHaveBeenCalledTimes(1);
+      } finally {
+        await state.op;
+        clock.mockRestore();
+      }
+    },
+  );
+
+  it("preserves the detached page when the slow warning logger throws", async () => {
+    let now = 0;
+    const clock = vi.spyOn(performance, "now").mockImplementation(() => now);
+    const job = createBaseJob();
+    const state = createMockCronStateForJobs({ jobs: [job] });
+    state.deps.log.warn = () => {
+      throw new Error("synthetic logger failure");
+    };
+    state.deps.resolveDefaultAgentId = () => {
+      now = 1_100;
+      return "main";
+    };
+    try {
+      const page = await listPage(state, { agentId: "main" });
+      expect(page.jobs).toEqual([job]);
+      expect(page.jobs[0]).not.toBe(job);
+      expect((await listPage(state)).snapshotRevision).toBe(page.snapshotRevision);
+    } finally {
+      await state.op;
+      clock.mockRestore();
     }
   });
 });

--- a/src/cron/service/ops-read.ts
+++ b/src/cron/service/ops-read.ts
@@ -1,3 +1,5 @@
+import { performance } from "node:perf_hooks";
+import { isMainThread, threadId } from "node:worker_threads";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import { tryResolveCronJobEffectiveAgentId } from "../agent-id.js";
@@ -319,80 +321,129 @@ function resolveTriggerFilter(opts?: CronListPageOptions): CronJobsTriggerFilter
   return "all";
 }
 
+const SLOW_LIST_PAGE_MS = 1_000;
+
 /** Lists a filtered, sorted, bounded page of cron jobs for CLI/RPC callers. */
 export async function listPage(state: CronServiceState, opts?: CronListPageOptions) {
-  return await locked(state, async () => {
-    await ensureLoadedForRead(state);
-    const query = normalizeLowercaseStringOrEmpty(opts?.query);
-    const enabledFilter = resolveEnabledFilter(opts);
-    const scheduleKindFilter = resolveScheduleKindFilter(opts);
-    const lastRunStatusFilter = resolveLastRunStatusFilter(opts);
-    const triggerFilter = resolveTriggerFilter(opts);
-    const sortBy = opts?.sortBy ?? "nextRunAtMs";
-    const sortDir = opts?.sortDir ?? "asc";
-    const requestedAgentId = normalizeOptionalAgentId(opts?.agentId);
-    const source = state.store?.jobs ?? [];
-    const filtered = source.filter((job) => {
-      if (enabledFilter === "enabled" && !isJobEnabled(job)) {
-        return false;
+  const startedAt = performance.now();
+  let enteredAt: number | undefined;
+  let finishedAt: number | undefined;
+  let sourceCount: number | undefined;
+  let result: CronListPageResult | undefined;
+  try {
+    return await locked(state, async () => {
+      enteredAt = performance.now();
+      try {
+        await ensureLoadedForRead(state);
+        const query = normalizeLowercaseStringOrEmpty(opts?.query);
+        const enabledFilter = resolveEnabledFilter(opts);
+        const scheduleKindFilter = resolveScheduleKindFilter(opts);
+        const lastRunStatusFilter = resolveLastRunStatusFilter(opts);
+        const triggerFilter = resolveTriggerFilter(opts);
+        const sortBy = opts?.sortBy ?? "nextRunAtMs";
+        const sortDir = opts?.sortDir ?? "asc";
+        const requestedAgentId = normalizeOptionalAgentId(opts?.agentId);
+        const source = state.store?.jobs ?? [];
+        sourceCount = source.length;
+        const filtered = source.filter((job) => {
+          if (enabledFilter === "enabled" && !isJobEnabled(job)) {
+            return false;
+          }
+          if (enabledFilter === "disabled" && isJobEnabled(job)) {
+            return false;
+          }
+          if (
+            requestedAgentId &&
+            tryResolveCronJobEffectiveAgentId(job, resolveCurrentDefaultAgentId(state)) !==
+              requestedAgentId
+          ) {
+            return false;
+          }
+          if (scheduleKindFilter !== "all" && job.schedule.kind !== scheduleKindFilter) {
+            return false;
+          }
+          if (
+            lastRunStatusFilter !== "all" &&
+            (resolveJobLastRunStatus(job) ?? "unknown") !== lastRunStatusFilter
+          ) {
+            return false;
+          }
+          if (triggerFilter === "conditional" && !job.trigger) {
+            return false;
+          }
+          if (triggerFilter === "unconditional" && job.trigger) {
+            return false;
+          }
+          if (!query) {
+            return true;
+          }
+          const haystack = normalizeLowercaseStringOrEmpty(
+            [
+              job.id,
+              job.name,
+              job.description ?? "",
+              job.agentId ?? "",
+              ...(job.displayName ? [job.displayName] : []),
+            ].join(" "),
+          );
+          return haystack.includes(query);
+        });
+        // Hash the complete sorted result under the lock, but detach only the page
+        // that can outlive later in-place execution state changes.
+        const sortedJobs = sortCronJobs(filtered, sortBy, sortDir);
+        const snapshotRevision = resolveCronListSnapshotRevision(sortedJobs);
+        const total = sortedJobs.length;
+        const offset = Math.max(0, Math.min(total, Math.floor(opts?.offset ?? 0)));
+        const defaultLimit = total === 0 ? 50 : total;
+        const limit = Math.max(1, Math.min(200, Math.floor(opts?.limit ?? defaultLimit)));
+        const jobs = structuredClone(sortedJobs.slice(offset, offset + limit));
+        const nextOffset = offset + jobs.length;
+        return (result = {
+          jobs,
+          snapshotRevision,
+          total,
+          offset,
+          limit,
+          hasMore: nextOffset < total,
+          nextOffset: nextOffset < total ? nextOffset : null,
+        } satisfies CronListPageResult);
+      } finally {
+        finishedAt = performance.now();
       }
-      if (enabledFilter === "disabled" && isJobEnabled(job)) {
-        return false;
-      }
-      if (
-        requestedAgentId &&
-        tryResolveCronJobEffectiveAgentId(job, resolveCurrentDefaultAgentId(state)) !==
-          requestedAgentId
-      ) {
-        return false;
-      }
-      if (scheduleKindFilter !== "all" && job.schedule.kind !== scheduleKindFilter) {
-        return false;
-      }
-      if (
-        lastRunStatusFilter !== "all" &&
-        (resolveJobLastRunStatus(job) ?? "unknown") !== lastRunStatusFilter
-      ) {
-        return false;
-      }
-      if (triggerFilter === "conditional" && !job.trigger) {
-        return false;
-      }
-      if (triggerFilter === "unconditional" && job.trigger) {
-        return false;
-      }
-      if (!query) {
-        return true;
-      }
-      const haystack = normalizeLowercaseStringOrEmpty(
-        [
-          job.id,
-          job.name,
-          job.description ?? "",
-          job.agentId ?? "",
-          ...(job.displayName ? [job.displayName] : []),
-        ].join(" "),
-      );
-      return haystack.includes(query);
     });
-    // Hash the complete sorted result under the lock, but detach only the page
-    // that can outlive later in-place execution state changes.
-    const sortedJobs = sortCronJobs(filtered, sortBy, sortDir);
-    const snapshotRevision = resolveCronListSnapshotRevision(sortedJobs);
-    const total = sortedJobs.length;
-    const offset = Math.max(0, Math.min(total, Math.floor(opts?.offset ?? 0)));
-    const defaultLimit = total === 0 ? 50 : total;
-    const limit = Math.max(1, Math.min(200, Math.floor(opts?.limit ?? defaultLimit)));
-    const jobs = structuredClone(sortedJobs.slice(offset, offset + limit));
-    const nextOffset = offset + jobs.length;
-    return {
-      jobs,
-      snapshotRevision,
-      total,
-      offset,
-      limit,
-      hasMore: nextOffset < total,
-      nextOffset: nextOffset < total ? nextOffset : null,
-    } satisfies CronListPageResult;
-  });
+  } finally {
+    const completedAt = performance.now();
+    const elapsedMs = completedAt - startedAt;
+    if (elapsedMs >= SLOW_LIST_PAGE_MS) {
+      // These are wall times: waiting includes scheduling, and callback awaits
+      // include unrelated work. Keep queue completion delay separate from both.
+      try {
+        state.deps.log.warn(
+          {
+            operation: "cron.listPage",
+            pid: process.pid,
+            threadId,
+            isMainThread,
+            elapsedMs: Math.round(elapsedMs),
+            waitToCallbackMs:
+              enteredAt === undefined ? undefined : Math.round(enteredAt - startedAt),
+            callbackMs:
+              enteredAt === undefined || finishedAt === undefined
+                ? undefined
+                : Math.round(finishedAt - enteredAt),
+            completionDelayMs:
+              finishedAt === undefined ? undefined : Math.round(completedAt - finishedAt),
+            sourceCount,
+            matchedCount: result?.total,
+            returnedCount: result?.jobs.length,
+            outcome: result ? "ok" : "error",
+            thresholdMs: SLOW_LIST_PAGE_MS,
+          },
+          "cron: slow list page",
+        );
+      } catch {
+        // Diagnostics must not replace the operation result or original error.
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators investigating a slow cron list cannot tell whether a source page waited before entering cron's serialized callback or spent that time inside it. Gateway RPC timing includes both and does not expose the internal cron queue boundary.

## Why This Change Was Made

The existing list-page owner records four monotonic timestamps and emits one warning only when total elapsed time reaches one second. The record separates wait-to-callback, callback and subsequent settlement time, retains existing trace context, and includes aggregate row counts, outcome and emitter process/thread identity. Queue ordering, filtering, returned pages and original exceptions remain unchanged; logging failures cannot replace an operation outcome.

## User Impact

Operators can read `cron: slow list page` records in the existing file log to narrow a slow page's next investigation. These are wall times, not CPU time or pure lock contention. Caller visibility filtering and delivery previews outside the service page are not measured. No new configuration, RPC, dependency or database change, and no claimed latency improvement.

## Evidence

- Focused regression and read sibling suites: 41 tests passed across four files after refreshing onto the current cron owner-resolution fix. Baseline failed four missing-warning assertions; existing page and queue behavior passed.
- Real source-runtime queue/file-logger proof on Node 26.8.1 on macOS: baseline produced no slow records; candidate main thread and Worker each produced exactly three, with caller trace, actual emitter identity, and no job/error text. Held-queue and callback-only work were distinguished; original callback errors and later reads were preserved.
- A separate real microtask-delay control reported 0ms before entry, 1ms callback and 1100ms subsequent settlement, avoiding false attribution of that delay to callback work.
- Independent review found no actionable findings. Initial head `0876b965` passed all 28 blocking changed checks (plus the warning-only report), including all 16 core-test type graphs. The required refresh preserves main’s new unresolved-owner behavior; its 41 focused tests and main/Worker/settlement source-runtime proofs passed again. [Final CI](https://github.com/openclaw/openclaw/actions/runs/34098571394) passed on `e695605b`; native prepare and merge completed with that head unchanged.

The native proof exercises the real source owners and file logger with synthetic already-loaded scheduler state; it is not a compiled Gateway or hydration benchmark. Production adds 51 lines for this bounded diagnostic capability; no generic timing framework or queue change.
