### PR TITLE
refactor(macos): consolidate onboarding model setup entry

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -205,13 +205,6 @@ extension OnboardingView {
                 case .none:
                     break
                 }
-                // A configured label is a display fact, not permission for a live
-                // completion. Existing routes appear in the same explicit picker.
-                if intent != .inspectOnly,
-                   knownAISetupPage || self.activePageIndex == self.aiPageIndex
-                {
-                    self.aiSetup.startIfNeeded()
-                }
             case .missing:
                 // A route-bound activation/verification can complete while the
                 // earlier agents.list request is suspended. Never let that
@@ -239,15 +232,18 @@ extension OnboardingView {
                 case .none:
                     break
                 }
-                if intent != .inspectOnly,
-                   knownAISetupPage || self.activePageIndex == self.aiPageIndex
-                {
-                    self.aiSetup.startIfNeeded()
-                }
             case .unavailable, .authIssue:
                 self.showConfiguredGatewayProbeBlocker(outcome)
+                return
             case .superseded:
-                break
+                return
+            }
+            // Both configured and empty Gateways enter the picker only after
+            // native receipt recovery. A configured label never authorizes a live test.
+            if intent != .inspectOnly,
+               knownAISetupPage || self.activePageIndex == self.aiPageIndex
+            {
+                self.aiSetup.startIfNeeded()
             }
         }
     }


### PR DESCRIPTION
## What Problem This Solves

macOS onboarding duplicates the same model-picker entry block for configured and empty Gateways. Keeping these entry checks together reduces the chance that the two paths drift while preserving native activation recovery.

Landed by maintainer decision: the wizard migration is deferred; this PR only removes the duplicated entry blocks. Related: #138092, #137971, and the existing embed-mode work in #139492.

## Why This Change Was Made

Consolidates the identical setup-entry branches for configured and empty Gateways in `OnboardingView+Layout.swift`. Both reach one entry point after the selected route is persisted, its probe remains current, and native activation receipts have been reconciled. Authentication failures, unavailable Gateways, and superseded probes return before that entry point.

The Dashboard remains the intended owner of Gateway-side setup. The native wizard is retained until the lifecycle contract below is agreed. This patch removes four net production Swift lines (+9/-13), with no test deletions; it does not claim the anticipated 2,200–2,800-line consolidation.

## User Impact

No user-visible change. Provider choice remains explicit, native pending receipts retain their current ownership/deadline behavior, and onboarding completion and close-window confirmation remain unchanged. `OnboardingAISetupTests.swift` and the Dashboard handoff tests are retained.

## Deferred design: native/web lifecycle bridge

Future wizard replacement requires a separate decision on the native/web lifecycle contract and bridge-owner scope. #139492 supplies a presentation-only `__OPENCLAW_NATIVE_EMBED__` flag; its inspected head does not change model setup. The existing `openclawDeviceSettings` contract has no setup progress, cancellation, verified completion, or recovery handoff messages.

The existing route `/settings/model-setup?firstRun=1` preserves explicit provider choice, but opening it is insufficient:

- Native completion writes onboarding seen/version, closes its window, and informs DashboardManager. Busy state drives the native close-window confirmation.
- Dashboard completion clears its browser receipt and navigates internally to the custodian; Continue without a pending activation can navigate to Chat. Neither URL proves successful activation to native code.
- Native version-4 receipts and browser receipts have different authority bindings. Web receipts include Gateway URL, agent, model, kind, deadline, credentials, and browser device identity. Copying native receipt fields into browser storage would change recovery semantics.

**Recommended direction:** retain outstanding native receipts with their existing native recovery owner until resolved. Reuse #139492's embed presentation. Add an explicitly reviewed bridge for admission/progress, cancellation and document retirement, and verified completion, bound to the current route/document. Specify how new web-owned activations preserve native relaunch readiness and process-loss recovery. Do not infer completion from navigation or a configured model label.

Also decide the behavior when a connected Gateway serves a Dashboard without the new lifecycle capability. The native wizard currently has method-gated activation fallback, while the Dashboard ships with its Gateway. Supported older-Gateway compatibility has not been proven for the replacement; silently requiring an upgrade or retaining a second wizard is not part of this PR.

That requires coordinated changes to the canonical web bridge, Swift mirror/host, and model-setup owner, beyond an embed affordance in this lane. No new bridge messages, persistence migration, configuration, or protocol change is implemented here. The maintainer approved this entry-block cleanup independently; the wizard migration remains deferred.

## Evidence

Validated the unchanged +9/-13 patch rebased onto current main at `e61e1354782db6b26faee5db26ce44611f9ca99e`:

- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34149945136): passed. The [disposable macOS native job](https://github.com/openclaw/openclaw/actions/runs/34149945136/job/101830071048) executed full OpenClawKit `swift test` and the macOS app test suite, including `OnboardingAISetupTests.swift`; OpenClawKit passed 1,668 tests and the app suite passed 2,080 default-profile plus 2 isolated-profile tests. `OnboardingAISetupTests` explicitly passed. All three macOS Node jobs passed.
- `swift build --package-path apps/macos --build-system native --product OpenClaw`: passed (145.14s).
- `pnpm native:i18n:check`: passed; source inventory unchanged, zero translation contradictions. No localization artifact changed.
- `pnpm protocol:check:swift`: passed.
- `periphery scan --config .periphery.yml --strict -- --build-system native` from `apps/macos`: passed; no unused code detected.
- `node scripts/check-changed.mjs`: passed; 1,132 selected tests, zero Swift lint violations, native state schema guard v16.
- `git diff --check`: passed.
- Fresh Codex branch autoreview: scoped-clean at the requested command's default P0 threshold, zero actionable findings. The original worker also reported a clean P2 review.

The canonical `node scripts/prepare-apple-mermaid.mjs` prerequisite generated the missing local Mermaid resources before the build. No source or dependency changes were needed.

**Scope and remaining design proof:** This PR changes no UI appearance. The deferred wizard migration still needs its lifecycle contract, signed-app embedded onboarding/first-chat proof, and sanitized before/after captures when implemented. No live provider round-trip or Testbox lease is claimed for this cleanup; native execution used the disposable GitHub macOS runner.
