### PR TITLE
fix(ui): measure mobile picker geometry after animation

### DIFF
--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -5,6 +5,7 @@ import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-ar
 import {
   takeControlUiElementScreenshot,
   takeControlUiViewportScreenshot,
+  waitForControlUiProofSurface,
 } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -214,17 +215,22 @@ suite.define(() => {
       for (const picker of [
         {
           menu: ".chat-controls__model-menu",
+          popup: '.chat-controls__model-picker wa-popup [part="popup"]',
           trigger: '[data-chat-model-select="true"]',
         },
         {
           menu: ".chat-controls__effort-menu",
+          popup: '.chat-controls__effort-picker wa-popup [part="popup"]',
           trigger: '[data-chat-thinking-select="true"]',
         },
       ]) {
         const visibleTrigger = composer.locator(picker.trigger);
         await expect.poll(() => visibleTrigger.isVisible()).toBe(true);
         await visibleTrigger.click();
-        await page.waitForTimeout(100);
+        // The popup scales while opening; measure its settled viewport bounds.
+        await waitForControlUiProofSurface(composer.locator(picker.popup), [
+          page.locator(picker.menu),
+        ]);
         const [composerBox, footerBox, menuBox, triggerBox] = await Promise.all([
           composer.boundingBox(),
           composer.locator(".agent-chat__composer-footer").boundingBox(),


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent Control UI e2e failure in the mobile model and effort picker geometry test. It can block unrelated PRs even though the fully opened panels retain the correct width and placement above an expanded composer.

Related: #140633, #140699, #140974.

## Why This Change Was Made

The test waited a fixed 100 ms after opening each picker and then measured its bounding box. The popup animates from a scale of 0.9, so its correct 369 px layout width can temporarily measure 332.10 px. This animation was introduced in #133650 and predates #140633; the relevant test, picker renderers, overlays, and composer CSS have no changes between the parent of #140633 and the tested main revision.

The scenario now reuses `waitForControlUiProofSurface` on the actual animated Web Awesome shadow popup, with the menu as required visible content. This joins the existing presentation owner before measuring. It removes the fixed delay and preserves every numeric geometry assertion, including the 368 px minimum. No production, CSS, dependency, timeout, retry, skip, mock, or baseline changes.

## User Impact

No product behavior change. The browser test continues to enforce full-width mobile panels, viewport containment, placement above the composer, and keyboard focus behavior, after the opening animation has completed.

## Evidence

Five serial headless runs of the exact case, with `CI=1`:

| Revision | Result |
| --- | --- |
| Main `86a3c7267be` | 2/5 passed; widths 342.93, 342.06, and 339.56 failed the unchanged minimum |
| Parent of #140633, `6cf361dc08f` | 2/5 passed; widths 345.98, 365.51, and 346.99 failed the same assertion |
| Repaired case | 5/5 passed |

The complete `chat-composer-redesign.e2e.test.ts` file passes 9/9. Production delta: 0; test delta: +7/-1, net +6.

#140699 is an open draft whose actual fork parent is `b0667d59bcb`; it only moves compact context-option styling, with no change to these popup widths or animations. That branch is not a causal candidate. No CSS value was adjusted to accommodate a test result.

```sh
CI=1 OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-composer-redesign.e2e.test.ts --testNamePattern 'keeps mobile picker panels above an attachment-expanded composer'
CI=1 OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-composer-redesign.e2e.test.ts
```

Each run used a task-owned filesystem module cache, separate from the cron repair worktree. Changed checks pass, and independent Codex review is clean through P2. The tested e2e, readiness helper and composer CSS are unchanged across the rebase onto main `15e5cf111d5`. Production delta remains zero.

### Completed landing validation

- `node scripts/check-changed.mjs`: passed.
- `pnpm build`: passed in **8m 57.4s** on head `35fac1ff650af376953065fb5ea4818130813825`.
- `pnpm ui:check-performance`: passed; startup JavaScript **347,949 B gzip / 8 requests**, below **350,953 B / 18 requests**. Startup CSS is **43,989 B gzip**. The baseline is unchanged.
- Required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/34098023563/job/101679306137): **SUCCESS** for the exact head.
- Native review artifacts: validated.

ClawSweeper found no actionable patch defect and flagged missing CI/build/performance evidence. The completed checks above resolve that validation gap.

### CI history

The [original attempt](https://github.com/openclaw/openclaw/actions/runs/34098023563/attempts/1) failed an unrelated image-handoff case (278 passed / 1 failed); one local replay passed. The first retry request encountered GitHub `startup_failure` before a second attempt was created. A subsequent authorized infrastructure retry started [attempt 2](https://github.com/openclaw/openclaw/actions/runs/34098023563/attempts/2), which executed the UI e2e step and **passed**. This was one executed test rerun on the unchanged head; no test assertion was weakened.

Browser/Gateway data is synthetic. No external-provider live claim or separately allocated Testbox lease.
