### PR TITLE
fix(tasks): return expired-page errors promptly during updates

### DIFF
--- a/src/tasks/task-registry-query.test.ts
+++ b/src/tasks/task-registry-query.test.ts
@@ -134,6 +134,94 @@ describe("listTaskRecordPage", () => {
     },
   );
 
+  it.each([
+    { name: "stale cursor", continuation: true, mutate: true, failLater: false },
+    { name: "cursorless retry", continuation: false, mutate: true, failLater: false },
+    {
+      name: "stale cursor before a later failure",
+      continuation: true,
+      mutate: true,
+      failLater: true,
+    },
+    {
+      name: "valid cursor with a later failure",
+      continuation: true,
+      mutate: false,
+      failLater: true,
+    },
+  ])("handles yielded task pages with $name", async ({ continuation, mutate, failLater }) => {
+    const tasks = Array.from({ length: 1_024 }, (_, index): TaskRecord => ({
+      taskId: `task-${String(index).padStart(5, "0")}`,
+      runtime: "cli",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      task: "Task page interrupted by one completion",
+      status: "running",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "done_only",
+      createdAt: 1,
+      lastEventAt: 1_024 - index,
+    }));
+    configureTaskSnapshot(tasks);
+    const first = await readTaskPage({ offset: 0, limit: 25 });
+    const unchanged = await readTaskPage({
+      offset: 25,
+      limit: 25,
+      expectedRevision: first.revision,
+    });
+    expect(unchanged.tasks.map((task) => task.taskId)).toEqual(
+      tasks.slice(25, 50).map((task) => task.taskId),
+    );
+
+    let examined = 0;
+    let scheduled = false;
+    let mutation: TaskRecord | null | undefined;
+    const accessFailure = new Error("canonical-store collision in a later slice");
+    const pendingPage = listTaskRecordPage({
+      offset: continuation ? 25 : 0,
+      limit: 25,
+      ...(continuation ? { expectedRevision: first.revision } : {}),
+      prepareFilter: (batch) => {
+        examined += batch.length;
+        if (failLater && examined > 32) {
+          throw accessFailure;
+        }
+        if (mutate && !scheduled) {
+          scheduled = true;
+          // The ordinary completion runs only when this scan reaches its existing yield.
+          queueMicrotask(() => {
+            mutation = markTaskTerminalById({
+              taskId: "task-01023",
+              status: "succeeded",
+              endedAt: 2_000,
+            });
+          });
+        }
+        return () => true;
+      },
+    });
+    if (!mutate) {
+      await expect(pendingPage).rejects.toBe(accessFailure);
+      return;
+    }
+    const page = await pendingPage;
+    expect(mutation).toMatchObject({ taskId: "task-01023", status: "succeeded" });
+    if (continuation) {
+      expect(page).toEqual({ ok: false, error: "cursor_stale" });
+      expect(examined).toBe(32);
+    } else {
+      expect(page.ok).toBe(true);
+      if (page.ok) {
+        expect(page.value.tasks.map((task) => task.taskId)).toEqual([
+          "task-01023",
+          ...tasks.slice(0, 24).map((task) => task.taskId),
+        ]);
+        expect(page.value.revision).toBeGreaterThan(first.revision);
+      }
+    }
+  });
+
   it("keeps large page scans responsive and sorts only the selected window", async () => {
     const total = 10_000;
     const offset = 13;

--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -197,6 +197,11 @@ export async function listTaskRecordPage(params: {
       // Yield only when another batch exists; completed pages keep their revision.
       if (scannedCount > 0) {
         await yieldToEventLoop();
+        // A carried revision cannot recover; skip unrelated reads once it is stale.
+        // Cursorless scans still finish their attempt before retrying.
+        if (params.expectedRevision !== undefined && revision !== readTaskRegistryRevision()) {
+          return err("cursor_stale");
+        }
       }
       const batch: TaskRecord[] = [];
       while (!current.done && batch.length < 32 && scannedCount < scanLimit) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users paging through Tasks could wait for a full obsolete scan after concurrent task activity had already invalidated their pagination cursor.

## Why This Change Was Made

Check the carried registry revision immediately after each existing event-loop yield, before reading another batch. Cursorless scans retain their complete-attempt retry behavior, and the final revision and authorization checks remain in place.

An already-invalid cursor deliberately returns the existing restart-pagination error before an unrelated later batch can fail, matching stale-at-entry behavior. Valid cursors still surface those later errors.

## User Impact

Expired task pages return restart-pagination guidance sooner during concurrent task activity.

## Evidence

- Regression: the stale continuation examines 32 records instead of 1,024 and returns the same cursor error.
- All 14 query tests pass, including cursorless convergence, valid-cursor error propagation, combined invalidation/error priority, and existing 32/33/64/65-record yield boundaries. The original implementation fails the two new stale-cursor cases.
- Exact-head compiled Gateway proof passed in an isolated Linux environment: 23 ordinary request operations and 11 observed operations cover UI request pairs, valid pagination, cursorless convergence, and access-only cursor invalidation. The instrumented continuation examined 32 rows and skipped 992, returning the existing restart error. Both Gateway processes shut down normally with closed streams; source, build, runtime, and dependency seals remained stable.
- The full changed-file gate and exact-head CI pass. Independent review found no actionable issues.
- This proves reduced discarded scan work, not a whole-Gateway latency improvement or a cure for historical stalls. No provider workload was exercised.
