### PR TITLE
fix(sqlite): prevent cleanup timeouts during periodic vacuum

### DIFF
--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -415,6 +415,10 @@ The original lock-admission deadline is retained. After granting approval,
 the parent synchronously joins transaction settlement before allowing owner retirement;
 that mandatory join cannot be abandoned at the append deadline.
 
+Periodic incremental vacuum uses the same write-admission boundary, so it can
+service reclamation approval before taking the writer lock. Its 512-page limit
+is unchanged; passive checkpoints remain outside the write transaction.
+
 Reclamation page maintenance uses a PASSIVE checkpoint and at most 512 pages of
 incremental vacuum per pass. PASSIVE does not wait for readers, but does not cap
 the number of WAL frames copied. Before pruning retained archives, disk-budget

--- a/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
@@ -7,6 +7,7 @@ import type { Worker } from "node:worker_threads";
 import { afterEach, expect, test, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { SqliteBoardStore } from "../../boards/sqlite-board-store.js";
+import { configureSqliteWalMaintenance } from "../../infra/sqlite-wal.js";
 import { flushLogger, setLoggerOverride } from "../../logging/logger.js";
 import {
   closeOpenClawAgentDatabaseByPath,
@@ -20,6 +21,7 @@ import { loadSessionEntry, replaceSessionEntrySync } from "./session-accessor.sq
 import { ensureSessionEntrySync } from "./session-accessor.sqlite-initial-entry.js";
 import {
   createHistoryEvictionReclamationPlan,
+  createLifecycleArtifactReclamationPlan,
   runSqliteSessionReclamation,
 } from "./session-accessor.sqlite-reclamation.js";
 import { runExclusiveSqliteSessionWrite } from "./session-accessor.sqlite-scope.js";
@@ -198,6 +200,70 @@ test.each([
       await expect(loadTranscriptEvents(scope)).resolves.toEqual([
         { type: "session", id: scope.sessionId },
       ]);
+    }
+  },
+  20_000,
+);
+
+test.each([false, true])(
+  "periodic vacuum services reclamation approval (rejected: %s)",
+  async (rejected) => {
+    const { database, databaseOptions } = createFixture();
+    // sqlite-allow-raw -- Disposable free pages exercise the real incremental vacuum.
+    database.db.exec(`CREATE TABLE reclamation_fixture (payload BLOB);
+      INSERT INTO reclamation_fixture VALUES (zeroblob(8388608));
+      DROP TABLE reclamation_fixture;`);
+    const freePages = () =>
+      Number(database.db.prepare("PRAGMA freelist_count").get()?.freelist_count);
+    const before = freePages();
+    expect(before).toBeGreaterThan(512);
+    const plan = createLifecycleArtifactReclamationPlan({
+      databaseOptions,
+      entries: [],
+      materializedPlans: [],
+    });
+    const maintenanceErrors: unknown[] = [];
+    let commitChecks = 0;
+    let checksDuringMaintenance = 0;
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    const maintenance = configureSqliteWalMaintenance(database.db, {
+      busyTimeoutMs: 1_000,
+      checkpointIntervalMs: 1,
+      onCheckpointError: (error) => maintenanceErrors.push(error),
+    });
+    hooks.beforeAuthorization = () => {
+      // The worker holds the writer lock and cannot commit until this thread approves it.
+      vi.advanceTimersByTime(1);
+      checksDuringMaintenance = commitChecks;
+    };
+    try {
+      const reclamation = runSqliteSessionReclamation({
+        forceInProcess: false,
+        plan,
+        assertCommitAllowed: () => {
+          commitChecks += 1;
+          if (rejected) {
+            throw new Error("reclamation owner retired");
+          }
+        },
+      });
+      if (rejected) {
+        await expect(reclamation).rejects.toThrow("reclamation owner retired");
+      } else {
+        await expect(reclamation).resolves.toMatchObject({
+          kind: "lifecycle-artifacts",
+          value: { removedEntries: 0 },
+        });
+      }
+      expect(maintenanceErrors).toEqual([]);
+      expect(checksDuringMaintenance).toBe(1);
+      expect(commitChecks).toBe(1);
+      const reclaimed = before - freePages();
+      expect(reclaimed).toBeGreaterThan(0);
+      expect(reclaimed).toBeLessThanOrEqual(512);
+    } finally {
+      maintenance.close({ checkpointMode: "PASSIVE" });
+      vi.useRealTimers();
     }
   },
   20_000,

--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -582,16 +582,17 @@ describe("sqlite WAL maintenance", () => {
 
           expect(await periodic.promise).toEqual([undefined, undefined]);
           expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA wal_checkpoint(PASSIVE);");
-          expect(db["exec"]).toHaveBeenNthCalledWith(4, "PRAGMA incremental_vacuum(512);");
+          expect(db["exec"]).toHaveBeenCalledWith("PRAGMA incremental_vacuum(512);");
           expect(maintenance.close()).toBe(true);
           expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA wal_checkpoint(TRUNCATE);");
           expect(requestScope.getStore()).toBe(request);
           expect(sessionScope.getStore()).toBe(session);
+          const statementsAfterClose = vi.mocked(db).exec.mock.calls.length;
 
           await new Promise<void>((resolve) => {
             setTimeout(resolve, 10);
           });
-          expect(db["exec"]).toHaveBeenCalledTimes(4);
+          expect(db["exec"]).toHaveBeenCalledTimes(statementsAfterClose);
         }),
       );
     } finally {
@@ -860,7 +861,7 @@ describe("sqlite WAL maintenance", () => {
 
     vi.advanceTimersByTime(100);
     expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA wal_checkpoint(FULL);");
-    expect(db["exec"]).toHaveBeenNthCalledWith(4, "PRAGMA incremental_vacuum(512);");
+    expect(db["exec"]).toHaveBeenCalledWith("PRAGMA incremental_vacuum(512);");
 
     expect(maintenance.close({ checkpointMode: "PASSIVE" })).toBe(true);
     expect(db["prepare"]).toHaveBeenLastCalledWith("PRAGMA wal_checkpoint(PASSIVE);");

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -10,7 +10,7 @@ import type { Result } from "@openclaw/normalization-core/result";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { hasErrnoCode } from "./errno.js";
 import { normalizeSqliteNonNegativeInteger } from "./sqlite-busy-timeout.js";
-import { isSqliteLockError } from "./sqlite-transaction.js";
+import { isSqliteLockError, runSqliteImmediateTransactionSync } from "./sqlite-transaction.js";
 
 // WAL maintenance configures SQLite write-ahead logging and schedules bounded
 // checkpoints so state databases do not accumulate unbounded WAL files.
@@ -640,7 +640,16 @@ export function configureSqliteWalMaintenance(
   // the event loop have starved channel sockets in production (#83712).
   const runIncrementalVacuum = (): void => {
     try {
-      db.exec(`PRAGMA incremental_vacuum(${INCREMENTAL_VACUUM_MAX_PAGES_PER_PASS});`);
+      // Page limits do not bound lock waits; service worker commit requests before taking the lock.
+      runSqliteImmediateTransactionSync(
+        db,
+        () => db.exec(`PRAGMA incremental_vacuum(${INCREMENTAL_VACUUM_MAX_PAGES_PER_PASS});`),
+        {
+          busyTimeoutMs: options.busyTimeoutMs,
+          databaseLabel: options.databaseLabel ?? options.databasePath,
+          operationLabel: "incremental-vacuum",
+        },
+      );
     } catch (error) {
       options.onCheckpointError?.(error);
     }


### PR DESCRIPTION
Related: #139689, #139469

## What Problem This Solves

Fixes an issue where session deletion or cleanup could fail when periodic database maintenance ran while cleanup was awaiting commit approval. The maintenance callback could block the Gateway thread for the SQLite busy timeout, preventing the cleanup worker from receiving approval.

## Why This Change Was Made

Periodic incremental vacuum now uses the existing shared SQLite write-admission helper, which services pending cleanup approval before acquiring the writer lock. Passive checkpoints remain outside the transaction. This extends the existing admission design from #139689 while preserving the timeout policy, 512-page maintenance bound, and cleanup authorization and commit-settlement guarantees. Vacuum transaction diagnostics also identify the operation and database.

## User Impact

Background space reclamation can run alongside session cleanup without causing this approval timeout. Session cleanup still rejects a retired owner, and maintenance retains its existing page limit.

## Evidence

- Added a regression using the real periodic maintenance callback and a real reclamation worker, covering both accepted and revoked cleanup authority. Both cases failed on the original code with native SQLite error 5 (`database is locked`) and pass with this fix.
- The regression verifies that approval is serviced exactly once during maintenance, the expected cleanup outcome is preserved, and vacuum releases at most 512 pages.
- Focused SQLite WAL, transaction, reclamation, and commit-settlement suites: 94 passed; 7 Linux-only checks skipped on macOS.
- Updated the database reference to document the maintenance admission boundary.
- `node scripts/check-changed.mjs` passed, including core/test typechecking, lint, schema, and import-cycle guards.
- Documentation MDX validation passed; independent autoreview was clean through P2.
