### PR TITLE
refactor: simplify desktop cleanup plumbing

### DIFF
--- a/src/gateway/desktop/session-registry.ts
+++ b/src/gateway/desktop/session-registry.ts
@@ -142,13 +142,12 @@ export function createDesktopSessionRegistry(
     })()
       .then(() => {
         owners.delete(entry);
-        // Concurrent Stop and replacement acquisition must join the full teardown.
         if (entries.get(entry.sourceKey) === entry) {
           entries.delete(entry.sourceKey);
         }
       })
       .then(stopped.resolve, (error: unknown) => {
-        // Retain cleanup custody even after a replacement leaves the active index.
+        // Keep the failed owner available for a cleanup retry.
         entry.stopPromise = undefined;
         stopped.reject(error);
       });
@@ -190,10 +189,8 @@ export function createDesktopSessionRegistry(
   ): Promise<DesktopSessionStartResult> {
     claimOwnerEpoch(request.sourceKey, request.ownerEpoch);
     const current = entries.get(request.sourceKey);
-    if (current) {
-      if (request.ownerEpoch === current.ownerEpoch && !current.stopped) {
-        return await waitForReady(current);
-      }
+    if (current && request.ownerEpoch === current.ownerEpoch && !current.stopped) {
+      return await waitForReady(current);
     }
 
     const previous = [...owners].filter((entry) => entry.sourceKey === request.sourceKey);

--- a/src/gateway/worker-environments/desktop-tunnel.test.ts
+++ b/src/gateway/worker-environments/desktop-tunnel.test.ts
@@ -90,6 +90,17 @@ function fakeRunner(
   return { runner, runs, starts };
 }
 
+function readyRunner() {
+  const fake = fakeRunner();
+  const start = fake.runner.start.bind(fake.runner);
+  fake.runner.start = (argv, options) => {
+    const child = start(argv, options);
+    fake.starts.at(-1)!.process.becomeReady();
+    return child;
+  };
+  return fake;
+}
+
 function launchApp(
   manager: ReturnType<typeof createWorkerDesktopTunnels>,
   app: "browser" | "terminal" = "browser",
@@ -364,13 +375,7 @@ describe("worker desktop tunnels", () => {
   });
 
   it("does not cancel a same-epoch retry when its retained predecessor exits", async () => {
-    const fake = fakeRunner();
-    const start = fake.runner.start.bind(fake.runner);
-    fake.runner.start = (argv, options) => {
-      const child = start(argv, options);
-      fake.starts.at(-1)!.process.becomeReady();
-      return child;
-    };
+    const fake = readyRunner();
     const manager = createWorkerDesktopTunnels({ runner: fake.runner });
     await acquire(manager, 1, { protocol: "rfb", port: 5900 });
     const failure = new Error("transport still running");
@@ -449,13 +454,7 @@ describe("worker desktop tunnels", () => {
   });
 
   it("cancels a replacement while the previous desktop is stopping", async () => {
-    const fake = fakeRunner();
-    const start = fake.runner.start.bind(fake.runner);
-    fake.runner.start = (argv, options) => {
-      const child = start(argv, options);
-      fake.starts.at(-1)!.process.becomeReady();
-      return child;
-    };
+    const fake = readyRunner();
     const manager = createWorkerDesktopTunnels({ runner: fake.runner });
     await acquire(manager, 1, { protocol: "rfb", port: 5900 });
     const child = fake.starts[0]!.process;

--- a/src/gateway/worker-environments/desktop-tunnel.ts
+++ b/src/gateway/worker-environments/desktop-tunnel.ts
@@ -80,51 +80,22 @@ export function createWorkerDesktopTunnels(deps: {
   const sessions = deps.registry ?? createDesktopSessionRegistry({ lingerMs: deps.lingerMs });
   const appLaunches = new Map<string, DesktopAppLaunchEntry>();
 
-  const appLaunchKey = (environmentId: string, appId: WorkerDesktopApp["id"]) =>
-    `${environmentId}\0${appId}`;
-
-  const stopAppLaunches = async (environmentId: string, ownerEpoch?: number): Promise<void> => {
-    const matching = [...appLaunches.values()].filter(
-      (entry) =>
-        entry.environmentId === environmentId &&
-        (ownerEpoch === undefined || entry.ownerEpoch === ownerEpoch),
-    );
+  const stopAppLaunches = async (
+    matches: (entry: DesktopAppLaunchEntry) => boolean,
+    reason: "stopped" | "replaced",
+  ): Promise<void> => {
+    const matching = [...appLaunches.values()].filter(matches);
     for (const entry of matching) {
-      entry.abortController.abort(new Error("Worker desktop app launch owner stopped"));
+      entry.abortController.abort(new Error(`Worker desktop app launch owner ${reason}`));
     }
     await Promise.allSettled(matching.map((entry) => entry.operation));
   };
 
-  const claimOwnerEpoch = (environmentId: string, ownerEpoch: number): boolean => {
-    try {
-      return sessions.claimOwnerEpoch(environmentId, ownerEpoch);
-    } catch (error) {
-      if (error instanceof DesktopSessionStaleOwnerError) {
-        throw new Error("Worker desktop owner epoch is stale", { cause: error });
-      }
-      throw error;
-    }
-  };
-
-  const stopReplacedAppLaunches = async (
-    environmentId: string,
-    ownerEpoch: number,
-  ): Promise<void> => {
-    const staleLaunches = [...appLaunches.values()].filter(
+  const stopReplacedAppLaunches = (environmentId: string, ownerEpoch: number) =>
+    stopAppLaunches(
       (entry) => entry.environmentId === environmentId && entry.ownerEpoch < ownerEpoch,
+      "replaced",
     );
-    for (const entry of staleLaunches) {
-      entry.abortController.abort(new Error("Worker desktop app launch owner replaced"));
-    }
-    await Promise.allSettled(staleLaunches.map((entry) => entry.operation));
-  };
-
-  const fenceReplacedOwners = async (environmentId: string, ownerEpoch: number): Promise<void> => {
-    await joinWorkerTunnelStops([
-      sessions.stopSuperseded(environmentId, ownerEpoch),
-      stopReplacedAppLaunches(environmentId, ownerEpoch),
-    ]);
-  };
 
   const createSessionHooks = (request: DesktopAcquireRequest) => {
     let prepared: PreparedWorkerSsh | undefined;
@@ -174,11 +145,10 @@ export function createWorkerDesktopTunnels(deps: {
           timeoutMs: Number.MAX_SAFE_INTEGER,
         }),
       );
-      const startedChild = child;
-      void startedChild.exited.then(() => {
+      void child.exited.then(() => {
         void stopOwner();
       });
-      await startedChild.ready;
+      await child.ready;
       if (!isCurrent()) {
         throw new Error("Worker desktop tunnel stopped before connecting");
       }
@@ -231,7 +201,7 @@ export function createWorkerDesktopTunnels(deps: {
     }
     const hooks = createSessionHooks(request);
     try {
-      claimOwnerEpoch(request.environmentId, request.ownerEpoch);
+      sessions.claimOwnerEpoch(request.environmentId, request.ownerEpoch);
       // Register before abort callbacks can reenter Stop; the registry defers source startup.
       const acquiring = sessions.acquire({
         sourceKey: request.environmentId,
@@ -268,15 +238,18 @@ export function createWorkerDesktopTunnels(deps: {
     }
     let ownerAdvanced: boolean;
     try {
-      ownerAdvanced = claimOwnerEpoch(request.environmentId, request.ownerEpoch);
+      ownerAdvanced = sessions.claimOwnerEpoch(request.environmentId, request.ownerEpoch);
     } catch (error) {
+      if (error instanceof DesktopSessionStaleOwnerError) {
+        return Promise.reject(new Error("Worker desktop owner epoch is stale", { cause: error }));
+      }
       return Promise.reject(
         error instanceof Error
           ? error
           : new Error("Worker desktop owner epoch is invalid", { cause: error }),
       );
     }
-    const key = appLaunchKey(request.environmentId, request.app.id);
+    const key = `${request.environmentId}\0${request.app.id}`;
     const current = appLaunches.get(key);
     if (current?.ownerEpoch === request.ownerEpoch) {
       return current.operation;
@@ -298,7 +271,10 @@ export function createWorkerDesktopTunnels(deps: {
         await current.operation.catch(() => undefined);
       }
       if (ownerAdvanced) {
-        await fenceReplacedOwners(request.environmentId, request.ownerEpoch);
+        await joinWorkerTunnelStops([
+          sessions.stopSuperseded(request.environmentId, request.ownerEpoch),
+          stopReplacedAppLaunches(request.environmentId, request.ownerEpoch),
+        ]);
       }
       abortController.signal.throwIfAborted();
       const prepared = await prepareWorkerSsh({
@@ -369,7 +345,12 @@ export function createWorkerDesktopTunnels(deps: {
   async function stop(environmentId: string, ownerEpoch?: number): Promise<void> {
     await joinWorkerTunnelStops([
       sessions.stop(environmentId, ownerEpoch),
-      stopAppLaunches(environmentId, ownerEpoch),
+      stopAppLaunches(
+        (entry) =>
+          entry.environmentId === environmentId &&
+          (ownerEpoch === undefined || entry.ownerEpoch === ownerEpoch),
+        "stopped",
+      ),
     ]);
   }
 


### PR DESCRIPTION
Related: #140658

## What Problem This Solves

Removes duplicated app-launch shutdown code and helper indirection left around the desktop cleanup repair.

## Why This Change Was Made

Matching and superseded app launches now share their existing snapshot-abort-join implementation while keeping their separate epoch predicates and exact abort messages. Single-use key and fencing helpers are inlined, redundant error forwarding and nesting are removed, and the repeated ready-process test fixture is shared.

## User Impact

No intended behavior change. Cleanup retention, exact-owner exit handling, reentrant cancellation, deferred startup, and shutdown deadlines are preserved.

## Evidence

- All 57 focused registry, desktop-tunnel, and enclosing tunnel-manager tests pass before and after the cleanup. No tests or assertions were removed.
- Real synthetic subprocess failure/retry and real loopback OpenSSH forwarding/exit/disposal probes pass.
- Isolated independent review through P2 is scoped-clean.
- Production: +30 / -52, net -22 lines. Test fixture: +13 / -14, net -1. No dependency, configuration, protocol, persistence, or generated-file changes.
- Full changed-code gate passed on Blacksmith Testbox (`tbx_01m1xecckypwtvbj6kvz5jy9pc`, wrapper exit 0; lease stopped). [Run](https://github.com/openclaw/openclaw/actions/runs/34098698748). The delegated run can show cancellation after successful lease cleanup.
- [Required exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34099212205). Completed ClawSweeper review found no actionable correctness or security issues.
