### PR TITLE
fix(cron): release queued reservations when activation fails

### DIFF
--- a/src/cron/service/run-admission.lost-queued.test.ts
+++ b/src/cron/service/run-admission.lost-queued.test.ts
@@ -1,0 +1,106 @@
+// A queued run whose activation fails before the run starts must release its
+// own reservation. #139215: a transient store failure in that window left the
+// durable queuedAtMs marker, the open receipt, and the process-local
+// reservation in place, and every later tick skipped the job behind its own
+// marker until restart.
+import { expect, it, vi } from "vitest";
+import {
+  createCronRegressionState,
+  createDueIsolatedJob,
+  setupCronRegressionFixtures,
+} from "../../../test/helpers/cron/service-regression-fixtures.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../../state/openclaw-state-db.js";
+import { loadCronStore, saveCronStore } from "../store.js";
+import { cronStoreKey } from "../store/key.js";
+import { stop } from "./ops-lifecycle.js";
+import { list } from "./ops-read.js";
+import {
+  executeQueuedCronRun,
+  persistQueuedCronRunReservations,
+  reserveQueuedCronRun,
+} from "./run-admission.js";
+import { onTimer } from "./timer.test-support.js";
+
+const fixtures = setupCronRegressionFixtures({ prefix: "cron-admission-lost-queued-" });
+
+it("releases a reservation whose activation failed, so later ticks still run the job (#139215)", async () => {
+  const store = fixtures.makeStorePath();
+  const now = Date.parse("2026-08-13T18:15:00.000Z");
+  const job = createDueIsolatedJob({
+    id: "activation-write-failure",
+    nowMs: now,
+    nextRunAtMs: now,
+  });
+  await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+  const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+  const state = createCronRegressionState({
+    storePath: store.storePath,
+    nowMs: () => now,
+    runIsolatedAgentJob,
+  });
+  await list(state);
+
+  const [reserved] = await persistQueuedCronRunReservations({
+    state,
+    candidates: [job],
+    reservedAtMs: now,
+  });
+  if (!reserved) {
+    throw new Error("expected durable reservation");
+  }
+  const reservationIdentity = reserveQueuedCronRun(state, job.id, now, {
+    runReceipt: reserved.runReceipt,
+  });
+
+  // Inject the queued-phase fault: the activation UPDATE that moves the queued
+  // marker to runningAtMs aborts, while cleanup writes still go through. The
+  // trigger is scoped to this job's rows so parallel tests stay unaffected.
+  const storeKey = cronStoreKey(store.storePath);
+  const database = openOpenClawStateDatabase().db;
+  database.exec(`
+    CREATE TEMP TRIGGER fail_cron_activation_before_start
+    AFTER UPDATE OF state_json ON cron_jobs
+    WHEN NEW.store_key = '${storeKey}'
+      AND NEW.job_id = '${job.id}'
+      AND json_extract(OLD.state_json, '$.queuedAtMs') IS NOT NULL
+      AND json_extract(NEW.state_json, '$.runningAtMs') IS NOT NULL
+    BEGIN
+      SELECT RAISE(ABORT, 'injected activation write failure');
+    END;
+  `);
+
+  await expect(
+    executeQueuedCronRun({
+      state,
+      jobId: job.id,
+      reservedAtMs: now,
+      reservationIdentity,
+      onNotRunnable: vi.fn(),
+    }),
+  ).rejects.toThrow();
+
+  // The producer owns its reservation: with the run never activated, the
+  // marker, receipt, and local claim must be released instead of wedging the
+  // job behind its own queued marker.
+  const persisted = (await loadCronStore(store.storePath)).jobs[0];
+  expect(persisted?.state.queuedAtMs).toBeUndefined();
+  const receipt = runOpenClawStateWriteTransaction(({ db }) =>
+    db
+      .prepare("SELECT status FROM cron_run_receipts WHERE receipt_id = ?")
+      .get(reserved.runReceipt.receiptId),
+  ) as { status: string } | undefined;
+  expect(receipt?.status).toBe("skipped");
+  database.exec("DROP TRIGGER IF EXISTS fail_cron_activation_before_start");
+
+  // User-visible boundary: the next timer tick re-queues and runs the job
+  // instead of silently swallowing every slot until restart.
+  await onTimer(state);
+  expect(runIsolatedAgentJob).toHaveBeenCalledOnce();
+  const afterTick = (await loadCronStore(store.storePath)).jobs[0];
+  expect(afterTick?.state).toMatchObject({ lastRunStatus: "ok" });
+  expect(afterTick?.state.queuedAtMs).toBeUndefined();
+  stop(state);
+});

--- a/src/cron/service/run-admission.ts
+++ b/src/cron/service/run-admission.ts
@@ -492,7 +492,6 @@ export async function executeQueuedCronRun(params: {
   | { kind: "completed"; outcome: TimedCronRunOutcome; handled: boolean }
 > {
   const { state } = params;
-  let activated = false;
   const executeAdmitted = async () => {
     const started = await locked(state, async () => {
       await ensureLoaded(state, { forceReload: true, skipRecompute: true });
@@ -558,7 +557,6 @@ export async function executeQueuedCronRun(params: {
       if (activation.kind !== "activated") {
         return undefined;
       }
-      activated = true;
       params.onActivated?.();
       return {
         job: activation.job,
@@ -647,13 +645,16 @@ export async function executeQueuedCronRun(params: {
     executeAdmitted,
     params.admissionRelease,
   ).catch(async (error: unknown) => {
-    if (activated) {
-      await cleanupQueuedCronRunReservations({
-        state,
-        reservations: [{ jobId: params.jobId, reservationIdentity: params.reservationIdentity }],
-        recompute: "maintenance",
-      });
-    }
+    // Admission or queued-phase setup failures never activated this run, so
+    // the durable marker, open receipt, and local reservation all still
+    // belong to it. Batch callers release unclaimed rows as a safety net, but
+    // this reservation is the producer's own lifecycle: leaving it behind
+    // wedges the job behind its own queuedAtMs marker until restart (#139215).
+    await cleanupQueuedCronRunReservations({
+      state,
+      reservations: [{ jobId: params.jobId, reservationIdentity: params.reservationIdentity }],
+      recompute: "maintenance",
+    });
     throw error;
   });
   if (admission.kind === "stopped") {

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -4296,6 +4296,39 @@ describe("buildGatewayCronService", () => {
       state.cron.stop();
     }
   });
+
+  it("does not silently skip unclaimed due cron-expression siblings when a batch sibling fails (#139215)", async () => {
+    vi.useFakeTimers();
+    const cfg = {
+      ...createCronConfig("server-cron-cron-expression-batch-sibling-failure"),
+      agents: { defaults: { model: { primary: "openai/gpt-5.6-sol" } } },
+    } as OpenClawConfig;
+    const state = loadCronService(cfg);
+    try {
+      await state.cron.start();
+      const names = ["batch-job-a", "batch-job-b", "batch-job-c"];
+      for (const name of names) {
+        await addAgentTurnJob(state, name, `run ${name}`, {
+          schedule: { kind: "cron", expr: "* * * * *" },
+        });
+      }
+      // The first activated run fails hard; its unclaimed siblings must still run.
+      runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => {
+        throw new Error("boom: first sibling execution failure");
+      });
+
+      // Cross the minute boundary so all three cron-expression jobs come due
+      // in the same timer tick.
+      await vi.advanceTimersByTimeAsync(61_000);
+
+      // All three isolated runs must have been attempted: the failed sibling
+      // must not silently swallow its unclaimed peers (#139215).
+      expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(3);
+    } finally {
+      state.cron.stop();
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("fireOnExitJob (on-exit fire routing)", () => {


### PR DESCRIPTION
Refs #139215 — kept open. After a closer pass through the timer-scheduler callers, the producer-side cleanup alone does not demonstrate the reported missing-tick fix, so this PR should not auto-close the issue.

## What Problem This Solves

When the write that moves a cron run from queued to running fails, the job can be left holding a durable `queuedAtMs` marker, an open run receipt, and a process-local reservation. Three facts from the current code:

- `executeQueuedCronRun` only released its own reservation when the failure happened after activation (`if (activated)` in the `.catch`).
- `persistQueuedCronRunReservations` skips jobs whose `queuedAtMs` is already set, so a surviving marker blocks later re-queuing.
- Recovery treats an own-process receipt as live (never stale), so it won't reclaim it.

The timer scheduler does have a batch-level safety net: a mapper-level catch stops admitting further due jobs, and the batch tail calls `releaseUnclaimedDueJobReservationsWithRetry` → `cleanupQueuedCronRunReservations`, which settles the receipt as `skipped`, deletes `queuedAtMs`, and recomputes `nextRunAtMs`. So on the normal timer path a queued-phase failure self-heals at the end of that batch. The marker survives only where that batch-tail cleanup itself fails (store still erroring through the tail) or on callers without the net.

That residual window does not, by itself, demonstrate the reporter's observed shape (missed occurrences with no receipt at all, manual force-runs succeeding), so this PR is a producer-side hardening, not a proven fix for every reported occurrence.

## Why This Change Was Made

The queued producer owns the reservation it receives, so its failure path should release that exact reservation rather than defer to the caller's net. Any admission or queued-phase failure now runs the same `cleanupQueuedCronRunReservations` the post-activation path already used: the receipt settles as `skipped`, the marker clears, and the next tick re-queues and runs the job. The cleanup is identity-matched, so it stays a no-op once another claimant has taken over. The batch-level nets in the timer scheduler and startup catch-up are unchanged.

The earlier approach on this branch (proving own-process liveness inside `repairInDatabase`) is fully reverted — recovery semantics are unchanged.

## User Impact

Jobs that fail during admission or the queued phase settle immediately instead of waiting on the batch tail; the residual wedge window shrinks to store failures that also defeat the batch-tail cleanup. No schema, config, or API changes.

## Evidence

Current qualification, 2026-09-15.

Original production repair by @holny; maintainer qualification preserves its ancestry and identity-matched cleanup. No unrelated timing blocks or recovery changes were imported.

### Five focused regression designs

- Baseline producer from the PR merge-base, using the same final fixtures: **2 expected failures** (durable marker survives; local reservation survives). This is a fault-injected before/after comparison, not an untouched-main run.
- Fixed direct producer: **3/3 passed** — activation-write rejection, pre-activation callback rejection, and replacement-identity preservation. The activation test also preserves the same-time sibling's marker, receipt and local ownership.
- Fixed Gateway scheduler controls: **2/2 passed**, 135 unrelated cases skipped — activation failure followed by a later cron-expression tick; an execution failure does not swallow due siblings.
- These five tests use real SQLite and scheduler code, but mock isolated-agent execution. Earlier contributor-reported full-suite numbers are historical, not current-head qualification.

### Real local runtime trace

A separate isolated process used the candidate source, Node 24.20.0 on macOS, real SQLite, the production wall-clock timer and `runCronCommandJob`. No Vitest, fake timers, product monkeypatching, model call or operator Gateway was involved. A temporary SQLite trigger injected only the selected queued-to-running write failure; it was removed before the timer was armed.

```text
02:32:49.141Z durable reservation: receipt running, localOwned=true
02:32:49.145Z activation rejected: injected real activation write failure
02:32:49.146Z BEFORE arming scheduler: queuedAtMs=null, runningAtMs=null,
                  localOwned=false, admissionActive=0, original receipt=skipped
02:32:49.147Z real wall-clock timer armed
02:32:51.159Z cron event: started
02:32:51.193Z native child: scheduled-command-executed
02:32:51.217Z cron event: finished, status=ok
02:32:51.244Z original receipt=skipped; new receipt=ok;
                  localReservations=0, admissionActive=0, activeTimerTicks=0
02:32:51.274Z disposed: timer=null, admissionActive=0, activeTimerTicks=0
```

The child wrote its completion artifact and exited successfully through the production command runner. This demonstrates immediate producer cleanup followed by real scheduled command execution. It does **not** claim real model/provider execution, full-Gateway startup or reproduction of the receipt-free missing ticks in #139215.

### Maintained checks and review

- Published candidate: `1d1e62d098c1795057a274465e1d09aefa0c9ff7`, with unchanged tested/reviewed source bytes.
- Fresh independent final-source review: **scoped-clean P0–P2**, including test design and real runtime evidence.
- `oxfmt`, targeted `oxlint`, core production and test type checks, native schema, dependency pins/patches, boundary/coercion/deprecation/import checks, and maintained dead-export scans passed.
- Local `check:changed` stopped at the pre-existing dated `sdk-untrusted-context-identifier-aliases` removal guard (`removeAfter: 2026-09-08`). Current main marks that unrelated SDK item `removal-pending`. All 18 subsequent checks from the maintained plan were run separately and passed; no guard was disabled and no unrelated SDK policy was copied into this PR.
- Exact-head hosted CI and native prepare/merge remain pending. Earlier CI and earlier source-only reviews are not final-head proof.

### CI repair continuation — 2026-09-15

- Published head: `c016b10d3754a2c0caba421b199593ce37094250`. Integrated main `7bf5deb308ed73fd3b327752eb6cc1b2907128b1` by ordinary merge; holny’s original commit and all three cron patch payloads are preserved.
- Previous exact-head CI run34922026897 failed one newly merged model-policy integration test (job104232305427); 3051 other tests in that lane passed. The test read model state after a chat admission ACK instead of waiting for command completion.
- Replaced `expect.poll` with the existing `agent.wait` terminal result, requiring success before asserting the same history model. No production behavior, timeout, or test count changed.
- The unchanged test passed locally; the recorded CI failure is the observed timing-sensitive reproduction, not a claimed deterministic local failure. Both repaired model-policy cases and21 existing terminal-wait controls passed (23/23).
- Fresh independent final-candidate review is clean at P0–P2. The earlier five cron designs and isolated native-command proof remain historical qualified evidence, not newly rerun tests.
- Maintained `check:changed` passed in full, including the Gateway test-type graph, dead-export scans and targeted lint. New exact-head hosted CI is pending. Native preparation/merge remain gated on required CI and the independently owned trusted non-force cleanup route.
