### PR TITLE
fix(skills): retire missing Workshop drafts safely

### DIFF
--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -703,8 +703,9 @@ If a proposal's draft is missing, Suggestions marks it unavailable. You can
 reject it, but cannot apply, evaluate, or revise content that is no longer there.
 Run `openclaw doctor --fix` to mark these proposals stale and remove them from
 actionable Suggestions. Doctor preserves their metadata and remaining files.
-If a proposal has unfinished apply recovery, Doctor leaves it pending and asks
-you to restore the draft before retrying; it does not discard rollback evidence
+If a proposal has unfinished apply recovery, Reject and Quarantine refuse to
+dismiss it. Doctor leaves it pending and asks you to restore the draft before
+retrying; it does not discard rollback evidence
 or change the installed skill.
 
 ## Limits

--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -674,6 +674,7 @@ SQLite after verifying each proposal, then removes the migrated JSON files.
 It moves applied legacy Workshop creates into `workshop-skills`, retargets
 eligible pending creates, and marks outside updates stale before normal use.
 Pending updates follow their relocated skill in the same database commit.
+Ownership-only moves preserve the proposal's existing edit time.
 Interrupted moves resume without discarding those pending updates.
 If older workspace setup files remain, run `openclaw doctor --fix`.
 Startup defers the affected skill moves and backup conversion until Doctor
@@ -697,6 +698,14 @@ workspace-survival evidence only when saved pre-move facts prove that the same
 directory contained only those skills and every moved file is intact.
 Missing or replaced workspaces, ordinary project files, and newer workspace
 attestations keep their protection.
+
+If a proposal's draft is missing, Suggestions marks it unavailable. You can
+reject it, but cannot apply, evaluate, or revise content that is no longer there.
+Run `openclaw doctor --fix` to mark these proposals stale and remove them from
+actionable Suggestions. Doctor preserves their metadata and remaining files.
+If a proposal has unfinished apply recovery, Doctor leaves it pending and asks
+you to restore the draft before retrying; it does not discard rollback evidence
+or change the installed skill.
 
 ## Limits
 

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -810,6 +810,8 @@ const SkillProposalManifestEntrySchema = closedObject({
   createdAt: NonEmptyString,
   updatedAt: NonEmptyString,
   scanState: SkillProposalScanStateSchema,
+  revisionHash: Type.Optional(Sha256String),
+  degradedState: Type.Optional(Type.Literal("draft-missing")),
 });
 
 /** Lists skill-workshop proposals for the selected agent scope. */

--- a/src/agents/tools/skill-workshop-tool.list.test.ts
+++ b/src/agents/tools/skill-workshop-tool.list.test.ts
@@ -95,10 +95,14 @@ describe("skill_workshop list", () => {
     });
     await expect(
       tool.execute("call-inspect", { action: "inspect", proposal_id: proposalId }),
-    ).rejects.toThrow(`Skill proposal draft is missing: ${proposalId}. Reject and re-propose it.`);
+    ).rejects.toThrow(
+      `Skill proposal draft is missing: ${proposalId}. Run openclaw doctor --fix for recovery.`,
+    );
     await expect(
       tool.execute("call-apply", { action: "apply", proposal_id: proposalId }),
-    ).rejects.toThrow(`Skill proposal draft is missing: ${proposalId}. Reject and re-propose it.`);
+    ).rejects.toThrow(
+      `Skill proposal draft is missing: ${proposalId}. Run openclaw doctor --fix for recovery.`,
+    );
     await expect(
       tool.execute("call-reject", { action: "reject", proposal_id: proposalId }),
     ).resolves.toMatchObject({ details: { id: proposalId, status: "rejected" } });

--- a/src/commands/doctor-skill-workshop-relocation.ts
+++ b/src/commands/doctor-skill-workshop-relocation.ts
@@ -157,7 +157,6 @@ function retargetWorkshopProposal(
       skillFile: target.skillFile,
       source: "openclaw-workshop",
     },
-    updatedAt: new Date().toISOString(),
   };
 }
 

--- a/src/commands/doctor-skill-workshop-sqlite.relocation-conflicts.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.relocation-conflicts.test.ts
@@ -1,11 +1,25 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { applySkillProposal, proposeCreateSkill } from "../skills/workshop/service.js";
+import {
+  applySkillProposal,
+  listSkillProposals,
+  proposeCreateSkill,
+  proposeUpdateSkill,
+} from "../skills/workshop/service.js";
 import { resolveWorkshopSkillsDir } from "../skills/workshop/skills-root.js";
+import {
+  writeSkillProposalRollback,
+  readSkillProposalRollback,
+} from "../skills/workshop/store-sqlite-rollback.js";
 import { hashSkillProposalContent, importLegacySkillProposal } from "../skills/workshop/store.js";
 import * as workshopStore from "../skills/workshop/store.js";
-import { SKILL_WORKSHOP_SCHEMA, type SkillProposalRecord } from "../skills/workshop/types.js";
+import {
+  SKILL_WORKSHOP_ROLLBACK_SCHEMA,
+  SKILL_WORKSHOP_SCHEMA,
+  type SkillProposalRecord,
+  type SkillProposalRollback,
+} from "../skills/workshop/types.js";
 import { repairOpenClawStateDatabaseSchemaIfNeeded } from "../state/openclaw-state-db.js";
 import {
   createOpenClawTestState,
@@ -40,6 +54,131 @@ afterEach(async () => {
   await tempDirs.cleanup();
 });
 describe("doctor Skill Workshop SQLite relocation conflicts and recovery", () => {
+  it.each(["create", "update"] as const)(
+    "retires a missing %s draft without losing valid drafts or recovery files",
+    async (kind) => {
+      const options = {
+        config: {},
+        env: testState.env,
+        agentId: "main",
+        workspaceDir: testState.workspaceDir,
+      };
+      const targetDir = path.join(
+        resolveWorkshopSkillsDir({}, "main", testState.env),
+        "missing-draft",
+      );
+      const installed =
+        "---\nname: missing-draft\ndescription: Existing procedure\n---\n\nKeep the existing procedure.\n";
+      if (kind === "update") {
+        await fs.mkdir(targetDir, { recursive: true });
+        await fs.writeFile(path.join(targetDir, "SKILL.md"), installed);
+      }
+      const input = {
+        ...options,
+        description: "Missing draft fixture",
+        content: "# Proposed procedure\n",
+        supportFiles: [{ path: "references/proof.md", content: "Keep recovery evidence.\n" }],
+      };
+      const missing =
+        kind === "create"
+          ? await proposeCreateSkill({ ...input, name: "missing-draft" })
+          : await proposeUpdateSkill({ ...input, skillName: "missing-draft" });
+      const valid = await proposeCreateSkill({
+        ...options,
+        name: "valid-draft",
+        description: "Valid sibling",
+        content: "# Valid procedure\n\nKeep this draft.\n",
+      });
+      const draftFile = path.join(
+        testState.stateDir,
+        "skill-workshop",
+        "proposals",
+        missing.record.id,
+        missing.record.draftFile,
+      );
+      await fs.unlink(draftFile);
+
+      expect(
+        (await listSkillProposals(options)).proposals.find(
+          (record) => record.id === missing.record.id,
+        ),
+      ).toMatchObject({ status: "pending", degradedState: "draft-missing" });
+      await migrateLegacySkillWorkshopProposals(options);
+      expect((await readSkillProposalRecord(missing.record.id, options))?.status).toBe("pending");
+      const repaired = await migrateLegacySkillWorkshopProposals({
+        ...options,
+        retireMissingDrafts: true,
+      });
+      expect(repaired.warnings).toEqual([]);
+      expect(repaired.changes.join("\n")).toContain("marked 1 stale");
+      expect(await readSkillProposalRecord(missing.record.id, options)).toMatchObject({
+        status: "stale",
+        draftHash: missing.record.draftHash,
+        supportFiles: missing.record.supportFiles,
+        statusReason: expect.stringContaining("draft is missing"),
+      });
+      await expect(
+        fs.readFile(path.join(path.dirname(draftFile), "references/proof.md"), "utf8"),
+      ).resolves.toBe("Keep recovery evidence.\n");
+      const unchanged = await workshopStore.readSkillProposal(valid.record.id, options, options, {
+        config: {},
+      });
+      expect(unchanged?.record).toEqual(valid.record);
+      expect(unchanged?.content).toBe(valid.content);
+      if (kind === "update") {
+        await expect(fs.readFile(path.join(targetDir, "SKILL.md"), "utf8")).resolves.toBe(
+          installed,
+        );
+      } else {
+        await expect(fs.access(targetDir)).rejects.toThrow();
+      }
+      await expect(
+        migrateLegacySkillWorkshopProposals({ ...options, retireMissingDrafts: true }),
+      ).resolves.toEqual({ changes: [], warnings: [], detected: 2, migrated: 0 });
+    },
+  );
+
+  it("preserves unfinished apply recovery when its draft is missing", async () => {
+    const options = {
+      config: {},
+      env: testState.env,
+      agentId: "main",
+      workspaceDir: testState.workspaceDir,
+    };
+    const proposal = await proposeCreateSkill({
+      ...options,
+      name: "unfinished-draft",
+      description: "Unfinished apply",
+      content: "# Pending procedure\n",
+    });
+    const rollback: SkillProposalRollback = {
+      schema: SKILL_WORKSHOP_ROLLBACK_SCHEMA,
+      proposalId: proposal.record.id,
+      writtenAt: proposal.record.createdAt,
+      targetSkillFile: proposal.record.target.skillFile,
+      action: "create",
+    };
+    await writeSkillProposalRollback({ proposalId: proposal.record.id, rollback, store: options });
+    await fs.unlink(
+      path.join(
+        testState.stateDir,
+        "skill-workshop",
+        "proposals",
+        proposal.record.id,
+        proposal.record.draftFile,
+      ),
+    );
+
+    const result = await migrateLegacySkillWorkshopProposals({
+      ...options,
+      retireMissingDrafts: true,
+    });
+    expect(result.changes).toEqual([]);
+    expect(result.warnings.join("\n")).toContain("unfinished apply recovery");
+    expect((await readSkillProposalRecord(proposal.record.id, options))?.status).toBe("pending");
+    expect(await readSkillProposalRollback(proposal.record.id, options)).toEqual(rollback);
+  });
+
   it("stales an applied legacy directory without a loadable skill file", async () => {
     const workspaceDir = await fs.realpath(
       await tempDirs.make("openclaw-workshop-invalid-relocation-workspace-"),

--- a/src/commands/doctor-skill-workshop-sqlite.relocation.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.relocation.test.ts
@@ -163,6 +163,8 @@ describe("doctor Skill Workshop SQLite relocation and legacy migration", () => {
     await expect(readSkillProposalRecord(update.id, { env: testState.env })).resolves.toMatchObject(
       {
         status: "pending",
+        createdAt: update.createdAt,
+        updatedAt: update.updatedAt,
         target: {
           skillDir: path.dirname(workshopSkillFile),
           skillFile: workshopSkillFile,

--- a/src/commands/doctor-skill-workshop-sqlite.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.ts
@@ -16,6 +16,7 @@ import {
 import { isPathInside } from "../infra/path-guards.js";
 import { movePathWithCopyFallback } from "../infra/replace-file.js";
 import { acquireStateDatabaseCoordinator } from "../infra/state-database-coordinator.js";
+import { transitionPendingSkillProposalToStale } from "../skills/workshop/apply-transition.js";
 import { reconcileInterruptedSkillProposalApply } from "../skills/workshop/reconcile-transition.js";
 import { resolveWorkshopSkillsDir } from "../skills/workshop/skills-root.js";
 import {
@@ -24,6 +25,7 @@ import {
   updateProposal,
 } from "../skills/workshop/store-sqlite-record.js";
 import {
+  SkillProposalDraftMissingError,
   hashSkillProposalContent,
   importLegacySkillProposal,
   readSkillProposal,
@@ -148,11 +150,12 @@ export async function inspectLegacySkillWorkshopMigration(params: {
 async function relocateLegacyWorkshopTargets(
   config: OpenClawConfig,
   env: NodeJS.ProcessEnv,
+  retireMissingDrafts: boolean,
 ): Promise<WorkshopRelocationResult> {
   const database = openOpenClawStateDatabase({ env });
-  const kysely = getNodeSqliteKysely<Pick<OpenClawStateDatabase, "skill_workshop_proposals">>(
-    database.db,
-  );
+  const kysely = getNodeSqliteKysely<
+    Pick<OpenClawStateDatabase, "skill_workshop_proposals" | "skill_workshop_proposal_rollbacks">
+  >(database.db);
   // Planning must not initialize optional Workshop tables or indexes on a no-op
   // startup. Actual proposal writes retain their feature-owned schema ensure.
   const readRows = () =>
@@ -164,12 +167,50 @@ async function relocateLegacyWorkshopTargets(
       : [];
   const deferredSources = new Set<string>();
   const recoveryWarnings: string[] = [];
+  let missingDraftsRetired = 0;
   // Settle writes while their proposal and rollback still name the same files.
   // Recovery can establish a create's ownership or restore a partial update.
   for (const row of readRows()) {
     const record = parseSkillProposalRow(row);
     if (!record || record.status !== "pending") {
       continue;
+    }
+    if (retireMissingDrafts) {
+      try {
+        await readSkillProposalBundle(record, { config, env });
+      } catch (error) {
+        if (!(error instanceof SkillProposalDraftMissingError)) {
+          recoveryWarnings.push(
+            `Could not inspect Skill Workshop proposal ${record.id}: ${String(error)}`,
+          );
+          deferredSources.add(resolveCanonicalWorkspacePath(record.target.skillDir));
+          continue;
+        }
+        // Any rollback row can describe an interrupted write. Keep it pending
+        // for recovery rather than treating its missing draft as abandoned work.
+        const rollback = executeSqliteQueryTakeFirstSync(
+          database.db,
+          kysely
+            .selectFrom("skill_workshop_proposal_rollbacks")
+            .select("proposal_id")
+            .where("proposal_id", "=", record.id),
+        );
+        if (rollback) {
+          recoveryWarnings.push(
+            `Skill Workshop proposal ${record.id} has a missing draft and unfinished apply recovery; restore its draft before retrying Doctor.`,
+          );
+          deferredSources.add(resolveCanonicalWorkspacePath(record.target.skillDir));
+          continue;
+        }
+        transitionPendingSkillProposalToStale({
+          record,
+          reason:
+            "Proposal draft is missing. Metadata and remaining files were preserved for recovery.",
+          input: { config, env, eventActor: { type: "system" } },
+        });
+        missingDraftsRetired += 1;
+        continue;
+      }
     }
     const workspaceDir = resolveLegacyWorkshopWorkspaceDir(record.target.skillDir, config, env);
     const { ownerAgentId } = inferOwnerAgentId({
@@ -297,7 +338,7 @@ async function relocateLegacyWorkshopTargets(
   return {
     movedSkills: plan.moves.filter((move) => move.operation === "move").length,
     retargetedProposals: updates.length - staleProposals,
-    staleProposals,
+    staleProposals: staleProposals + missingDraftsRetired,
     migratedBackupRoots: backupMigration.migrated,
     warnings: [...recoveryWarnings, ...plan.warnings, ...backupMigration.warnings],
   };
@@ -536,6 +577,7 @@ async function importLegacySkillProposalSidecars(params: {
 export async function migrateLegacySkillWorkshopProposals(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
+  retireMissingDrafts?: boolean;
 }): Promise<MigrationResult> {
   const env = params.env ?? process.env;
   // Plain Doctor can reach automatic migration without its repair scope.
@@ -545,7 +587,11 @@ export async function migrateLegacySkillWorkshopProposals(params: {
   });
   try {
     const sidecars = await importLegacySkillProposalSidecars({ config: params.config, env });
-    const relocation = await relocateLegacyWorkshopTargets(params.config, env);
+    const relocation = await relocateLegacyWorkshopTargets(
+      params.config,
+      env,
+      params.retireMissingDrafts === true,
+    );
     if (
       relocation.movedSkills > 0 ||
       relocation.retargetedProposals > 0 ||

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -2000,6 +2000,7 @@ function buildLegacyStateMigrationSteps(
         migrateLegacySkillWorkshopProposals({
           config: params.sessionConfig ?? params.config,
           env: { ...env, OPENCLAW_STATE_DIR: stateDir },
+          retireMissingDrafts: isDoctor,
         }),
       ),
       runWithoutFileDetection: true,

--- a/src/skills/workshop/apply-transition.ts
+++ b/src/skills/workshop/apply-transition.ts
@@ -432,7 +432,7 @@ export async function assertSkillProposalSupportTargetUnchanged(params: {
 export function transitionPendingSkillProposalToStale(params: {
   record: SkillProposalRecord;
   reason: string;
-  input: SkillProposalTransitionInput;
+  input: Omit<SkillProposalTransitionInput, "workspaceDir">;
 }): { record: SkillProposalRecord; event: SkillProposalEvent } {
   const now = new Date().toISOString();
   const stale: SkillProposalRecord = {

--- a/src/skills/workshop/service-query.ts
+++ b/src/skills/workshop/service-query.ts
@@ -198,7 +198,6 @@ async function reconcilePendingCreateProposal(
         record: current.record,
         reason: "Target skill was created after proposal creation.",
         input: {
-          workspaceDir: workshopDir,
           agentId: options.agentId,
           config: options.config,
           eventActor: { type: "system" },

--- a/src/skills/workshop/service-query.ts
+++ b/src/skills/workshop/service-query.ts
@@ -40,7 +40,7 @@ export async function listSkillProposals(
   const missingDrafts = new Set<string>();
   // The agent collection lease bounds concurrent manifest reconciliation.
   for (const proposal of manifest.proposals) {
-    if (proposal.kind !== "create" || proposal.status !== "pending") {
+    if (proposal.status !== "pending") {
       continue;
     }
     let read: SkillProposalReadResult | null;

--- a/src/skills/workshop/service-query.ts
+++ b/src/skills/workshop/service-query.ts
@@ -10,17 +10,21 @@ import {
 import { transitionPendingSkillProposalToStale } from "./apply-transition.js";
 import { resolveSkillProposalName } from "./frontmatter.js";
 import { dispatchSkillProposalChanged } from "./plugin-hooks.js";
-import { hashSkillProposalRevision } from "./revision-hash.js";
 import { resolveWorkshopSkillsDir } from "./skills-root.js";
 import {
   SkillProposalDraftMissingError,
   readSkillProposal,
+  readSkillProposalDraft,
   readSkillProposalManifest,
   readSkillProposalRecord,
   readSkillProposalRollback,
 } from "./store.js";
 import { withSkillProposalCommitLock } from "./target-lock.js";
-import type { SkillProposalManifest, SkillProposalReadResult } from "./types.js";
+import type {
+  SkillProposalManifest,
+  SkillProposalReadResult,
+  SkillProposalRecord,
+} from "./types.js";
 
 type SkillProposalScopeOptions = {
   agentId: string;
@@ -43,18 +47,18 @@ export async function listSkillProposals(
     if (proposal.status !== "pending") {
       continue;
     }
-    let read: SkillProposalReadResult | null;
     try {
-      read = await readSkillProposal(proposal.id, options, options, { config: options.config });
+      const record = await readSkillProposalRecord(proposal.id, options, options, {
+        config: options.config,
+      });
+      if (record) {
+        await reconcilePendingSkillProposal(record, options);
+      }
     } catch (error) {
       if (!(error instanceof SkillProposalDraftMissingError)) {
         throw error;
       }
       missingDrafts.add(error.proposalId);
-      continue;
-    }
-    if (read) {
-      await reconcilePendingCreateProposal(read, options);
     }
   }
   const reconciled = await readSkillProposalManifest(options, options);
@@ -92,11 +96,14 @@ export async function inspectSkillProposal(
   proposalId: string,
   options: SkillProposalScopeOptions,
 ): Promise<SkillProposalReadResult | null> {
-  const read = await readSkillProposal(proposalId, options, options, { config: options.config });
-  if (!read) {
+  const record = await readSkillProposalRecord(proposalId, options, options, {
+    config: options.config,
+  });
+  if (!record) {
     return null;
   }
-  return await reconcilePendingCreateProposal(read, options);
+  await reconcilePendingSkillProposal(record, options);
+  return await readSkillProposal(proposalId, options, options, { config: options.config });
 }
 
 export async function resolvePendingSkillProposal(input: {
@@ -133,10 +140,10 @@ export async function resolvePendingSkillProposal(input: {
     }
     proposalId = expectDefined(matches[0], "matches capture group 0").id;
   }
-  const matched = await reconcilePendingCreateProposal(
-    await readRequiredProposal(proposalId, input.env, input.agentId, { config: input.config }),
-    { agentId: input.agentId, env: input.env, config: input.config },
-  );
+  const matched = await inspectSkillProposal(proposalId, input);
+  if (!matched) {
+    throw new Error(`Skill proposal not found: ${proposalId}`);
+  }
   if (matched.record.status !== "pending") {
     throw new Error(
       `Only pending proposals can be revised. Current status: ${matched.record.status}.`,
@@ -163,39 +170,43 @@ export async function readRequiredProposal(
   return read;
 }
 
-async function reconcilePendingCreateProposal(
-  read: SkillProposalReadResult,
+async function reconcilePendingSkillProposal(
+  record: SkillProposalRecord,
   options: SkillProposalScopeOptions,
-): Promise<SkillProposalReadResult> {
-  if (read.record.kind !== "create" || read.record.status !== "pending") {
-    return read;
+): Promise<void> {
+  if (record.status !== "pending") {
+    return;
   }
   const workshopDir = resolveWorkshopSkillsDir(options.config, options.agentId, options.env);
-  const reconciled = await withSkillProposalCommitLock(
-    read.record,
+  const transition = await withSkillProposalCommitLock(
+    record,
     async () => {
-      const current = await readSkillProposal(read.record.id, options, options, {
+      const current = await readSkillProposalRecord(record.id, options, options, {
         config: options.config,
         reconcile: false,
       });
-      if (!current || current.record.kind !== "create" || current.record.status !== "pending") {
-        return { read: current ?? read };
+      if (!current || current.status !== "pending") {
+        return;
       }
+      // List availability depends on the draft, not supporting-file integrity.
+      // Read under the lease so revision cleanup cannot remove this generation.
+      await readSkillProposalDraft(current, options);
       // Deferred proposals remain readable without access to their old targets.
       // Collision reconciliation only operates inside the owned Workshop root.
       if (
-        !isPathInside(workshopDir, current.record.target.skillFile) ||
-        (await readSkillProposalRollback(current.record.id, options))
+        current.kind !== "create" ||
+        !isPathInside(workshopDir, current.target.skillFile) ||
+        (await readSkillProposalRollback(current.id, options))
       ) {
-        return { read: current };
+        return;
       }
-      assertInsideSkillsRoot(workshopDir, current.record.target.skillFile, "skill file");
-      const targetContent = await readWorkspaceSkillFile(current.record.target.skillFile);
+      assertInsideSkillsRoot(workshopDir, current.target.skillFile, "skill file");
+      const targetContent = await readWorkspaceSkillFile(current.target.skillFile);
       if (targetContent === null) {
-        return { read: current };
+        return;
       }
-      const transition = transitionPendingSkillProposalToStale({
-        record: current.record,
+      return transitionPendingSkillProposalToStale({
+        record: current,
         reason: "Target skill was created after proposal creation.",
         input: {
           agentId: options.agentId,
@@ -204,26 +215,17 @@ async function reconcilePendingCreateProposal(
           ...(options.env ? { env: options.env } : {}),
         },
       });
-      return {
-        read: {
-          ...current,
-          record: transition.record,
-          revisionHash: hashSkillProposalRevision(transition.record),
-        },
-        transition,
-      };
     },
     options,
   );
-  if (reconciled.transition) {
+  if (transition) {
     await dispatchSkillProposalChanged({
-      event: reconciled.transition.event,
-      record: reconciled.transition.record,
+      event: transition.event,
+      record: transition.record,
       workspaceDir: workshopDir,
       agentId: options.agentId,
     });
   }
-  return reconciled.read;
 }
 
 function proposalMatchesName(

--- a/src/skills/workshop/service-query.ts
+++ b/src/skills/workshop/service-query.ts
@@ -186,7 +186,7 @@ async function reconcilePendingSkillProposal(
         reconcile: false,
       });
       if (!current || current.status !== "pending") {
-        return;
+        return undefined;
       }
       // List availability depends on the draft, not supporting-file integrity.
       // Read under the lease so revision cleanup cannot remove this generation.
@@ -198,12 +198,12 @@ async function reconcilePendingSkillProposal(
         !isPathInside(workshopDir, current.target.skillFile) ||
         (await readSkillProposalRollback(current.id, options))
       ) {
-        return;
+        return undefined;
       }
       assertInsideSkillsRoot(workshopDir, current.target.skillFile, "skill file");
       const targetContent = await readWorkspaceSkillFile(current.target.skillFile);
       if (targetContent === null) {
-        return;
+        return undefined;
       }
       return transitionPendingSkillProposalToStale({
         record: current,

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -1179,7 +1179,7 @@ describe("skill workshop proposals", () => {
         proposalId: proposal.record.id,
         reason: "external target retained",
       }),
-    ).resolves.toMatchObject({ status: "rejected" });
+    ).rejects.toThrow("unfinished apply recovery");
     expect(Date.now() - startedAt).toBeLessThan(2_000);
   });
 
@@ -1310,7 +1310,7 @@ describe("skill workshop proposals", () => {
     });
   });
 
-  it("keeps proposal management available when a reconciliation target cannot be read", async () => {
+  it("preserves recovery when a reconciliation target cannot be read", async () => {
     const workspaceDir = await makeWorkspace();
     const proposal = await proposeCreateSkill({
       workspaceDir,
@@ -1333,7 +1333,67 @@ describe("skill workshop proposals", () => {
     });
     await expect(
       rejectSkillProposal({ workspaceDir, proposalId: proposal.record.id }),
-    ).resolves.toMatchObject({ status: "rejected" });
+    ).rejects.toThrow("unfinished apply recovery");
+    await expect(readSkillProposalRollback(proposal.record.id)).resolves.not.toBeNull();
+  });
+
+  it.each([
+    ["reject", rejectSkillProposal],
+    ["quarantine", quarantineSkillProposal],
+  ] as const)("preserves missing-draft recovery before %s", async (_action, decide) => {
+    const workspaceDir = await makeWorkspace();
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Recoverable Draft",
+      description: "Retain an interrupted support write",
+      content: "# Recoverable Draft\n",
+      supportFiles: [{ path: "references/proof.md", content: "Partial support.\n" }],
+    });
+    const rollback = createSkillProposalRollback({
+      proposalId: proposal.record.id,
+      targetSkillFile: proposal.record.target.skillFile,
+      action: "create",
+      supportFiles: [{ path: "references/proof.md", existed: false }],
+    });
+    await writeSkillProposalRollback({ proposalId: proposal.record.id, rollback });
+    const supportFile = path.join(proposal.record.target.skillDir, "references", "proof.md");
+    await fs.mkdir(path.dirname(supportFile), { recursive: true });
+    await fs.writeFile(supportFile, "Partial support.\n");
+    const draftFile = path.join(
+      stateDir,
+      "skill-workshop",
+      "proposals",
+      proposal.record.id,
+      proposal.record.draftFile,
+    );
+    await fs.rm(draftFile);
+
+    await expect(
+      decide({
+        workspaceDir,
+        proposalId: proposal.record.id,
+        expectedRevisionHash: proposal.revisionHash,
+      }),
+    ).rejects.toThrow("unfinished apply recovery");
+    await expect(readSkillProposalRollback(proposal.record.id)).resolves.toEqual(rollback);
+    await expect(fs.readFile(supportFile, "utf8")).resolves.toBe("Partial support.\n");
+
+    await fs.writeFile(draftFile, proposal.content);
+    closeOpenClawStateDatabaseForTest();
+    await expect(inspectSkillProposal(proposal.record.id)).resolves.toMatchObject({
+      record: { status: "pending" },
+    });
+    await expect(readSkillProposalRollback(proposal.record.id)).resolves.toBeNull();
+    await expect(fs.access(supportFile)).rejects.toThrow();
+    await expect(
+      decide({
+        workspaceDir,
+        proposalId: proposal.record.id,
+        expectedRevisionHash: proposal.revisionHash,
+      }),
+    ).resolves.toMatchObject({
+      status: _action === "reject" ? "rejected" : "quarantined",
+    });
   });
 
   it("enforces configured proposal limits before writing proposal state", async () => {
@@ -1678,22 +1738,43 @@ describe("skill workshop proposals", () => {
     ).rejects.toThrow();
   });
 
-  it("rejects tampered support files during apply", async () => {
-    const workspaceDir = await makeWorkspace();
-    const proposal = await proposeCreateSkill({
-      workspaceDir,
-      name: "Tamper Guard",
-      description: "Detect changed proposal support files",
-      content: "# Tamper Guard\n",
-      supportFiles: [
-        {
-          path: "references/check.md",
-          content: "Original\n",
-        },
-      ],
-    });
-    await fs.writeFile(
-      path.join(
+  it.each([
+    ["create", "changed"],
+    ["create", "missing"],
+    ["update", "changed"],
+    ["update", "missing"],
+  ] as const)(
+    "lists a %s with %s support files but refuses to inspect or apply it",
+    async (kind, damage) => {
+      const workspaceDir = await makeWorkspace();
+      const name = `Support Guard ${kind} ${damage}`;
+      if (kind === "update") {
+        await createOwnedSkill({
+          workspaceDir,
+          name,
+          description: "Keep the installed procedure",
+          body: "# Original procedure\n",
+        });
+      }
+      const input = {
+        workspaceDir,
+        description: "Detect damaged proposal support files",
+        content: "# Proposed procedure\n",
+        supportFiles: [{ path: "references/check.md", content: "Original\n" }],
+      };
+      const proposal =
+        kind === "create"
+          ? await proposeCreateSkill({ ...input, name })
+          : await proposeUpdateSkill({ ...input, skillName: name });
+      const original =
+        kind === "update" ? await fs.readFile(proposal.record.target.skillFile, "utf8") : undefined;
+      const healthy = await proposeCreateSkill({
+        workspaceDir,
+        name: "Healthy sibling",
+        description: "Keep other suggestions readable",
+        content: "# Healthy procedure\n",
+      });
+      const supportFile = path.join(
         stateDir,
         "skill-workshop",
         "proposals",
@@ -1701,17 +1782,39 @@ describe("skill workshop proposals", () => {
         path.dirname(proposal.record.draftFile),
         "references",
         "check.md",
-      ),
-      "Changed\n",
-      "utf8",
-    );
+      );
+      if (damage === "missing") {
+        await fs.unlink(supportFile);
+      } else {
+        await fs.writeFile(supportFile, "Changed\n", "utf8");
+      }
 
-    await expect(
-      applySkillProposal({ workspaceDir, proposalId: proposal.record.id }),
-    ).rejects.toThrow("changed without updating metadata");
-    await expect(
-      fs.access(path.join(workshopSkillsDir(), "tamper-guard", "SKILL.md")),
-    ).rejects.toThrow();
-  });
+      await expect(listSkillProposals()).resolves.toMatchObject({
+        proposals: expect.arrayContaining([
+          expect.objectContaining({ id: proposal.record.id, status: "pending" }),
+          expect.objectContaining({ id: healthy.record.id, status: "pending" }),
+        ]),
+      });
+      await expect(inspectSkillProposal(healthy.record.id)).resolves.toMatchObject({
+        content: healthy.content,
+      });
+      const failure =
+        damage === "missing"
+          ? { code: "not-found" }
+          : {
+              message:
+                "Proposal support file changed without updating metadata: references/check.md",
+            };
+      await expect(inspectSkillProposal(proposal.record.id)).rejects.toMatchObject(failure);
+      await expect(
+        applySkillProposal({ workspaceDir, proposalId: proposal.record.id }),
+      ).rejects.toMatchObject(failure);
+      if (kind === "update") {
+        await expect(fs.readFile(proposal.record.target.skillFile, "utf8")).resolves.toBe(original);
+      } else {
+        await expect(fs.access(proposal.record.target.skillFile)).rejects.toThrow();
+      }
+    },
+  );
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/skills/workshop/store.ts
+++ b/src/skills/workshop/store.ts
@@ -607,5 +607,6 @@ function manifestEntryFromRecord(record: SkillProposalRecord): SkillProposalMani
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
     scanState: record.scan.state,
+    revisionHash: hashSkillProposalRevision(record),
   };
 }

--- a/src/skills/workshop/store.ts
+++ b/src/skills/workshop/store.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import path from "node:path";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { FsSafeError, root, type ReadResult, type Root } from "../../infra/fs-safe.js";
+import { FsSafeError, root, type Root } from "../../infra/fs-safe.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -174,7 +174,10 @@ export class SkillProposalDraftMissingError extends Error {
     readonly proposalId: string,
     options?: ErrorOptions,
   ) {
-    super(`Skill proposal draft is missing: ${proposalId}. Reject and re-propose it.`, options);
+    super(
+      `Skill proposal draft is missing: ${proposalId}. Run openclaw doctor --fix for recovery.`,
+      options,
+    );
   }
 }
 
@@ -387,6 +390,23 @@ export async function updateSkillProposalRecord(params: {
       if (!current || !parseSkillProposalRow(current)) {
         throw new Error(`Skill proposal not found: ${params.record.id}`);
       }
+      // Recovery only visits pending proposals. A dismissal must not strand
+      // a partial install, including when its rollback metadata is damaged.
+      if (
+        current.status === "pending" &&
+        (params.record.status === "rejected" || params.record.status === "quarantined") &&
+        executeSqliteQueryTakeFirstSync(
+          db,
+          kysely
+            .selectFrom("skill_workshop_proposal_rollbacks")
+            .select("proposal_id")
+            .where("proposal_id", "=", params.record.id),
+        )
+      ) {
+        throw new Error(
+          "Skill proposal has unfinished apply recovery. Run openclaw doctor --fix and restore the files it identifies before retrying.",
+        );
+      }
       if (params.invalidateRollback) {
         executeSqliteQuerySync(
           db,
@@ -467,12 +487,7 @@ async function reconcileInterruptedApply(
   }
   let draftContent: string;
   try {
-    const stateRoot = await root(resolveSkillWorkshopStateDir(options));
-    const draft = await stateRoot.read(
-      proposalBundleRelativePath(stored.record, PROPOSAL_DRAFT_FILE),
-      { hardlinks: "reject", maxBytes: MAX_PROPOSAL_BYTES, symlinks: "reject" },
-    );
-    draftContent = draft.buffer.toString("utf8");
+    draftContent = await readSkillProposalDraft(stored.record, options);
   } catch {
     return false;
   }
@@ -509,29 +524,39 @@ async function readProposalSupportFiles(
   return out;
 }
 
-export async function readSkillProposalBundle(
+export async function readSkillProposalDraft(
   record: SkillProposalRecord,
   options: SkillWorkshopStoreOptions,
-): Promise<SkillProposalReadResult> {
+): Promise<string> {
   const stateRoot = await root(resolveSkillWorkshopStateDir(options));
-  let draft: ReadResult;
   try {
-    draft = await stateRoot.read(proposalBundleRelativePath(record, PROPOSAL_DRAFT_FILE), {
+    const draft = await stateRoot.read(proposalBundleRelativePath(record, PROPOSAL_DRAFT_FILE), {
       hardlinks: "reject",
       maxBytes: MAX_PROPOSAL_BYTES,
       symlinks: "reject",
     });
+    return draft.buffer.toString("utf8");
   } catch (error) {
     if (error instanceof FsSafeError && error.code === "not-found") {
       throw new SkillProposalDraftMissingError(record.id, { cause: error });
     }
     throw error;
   }
-  const supportFiles = await readProposalSupportFiles(record, stateRoot);
+}
+
+export async function readSkillProposalBundle(
+  record: SkillProposalRecord,
+  options: SkillWorkshopStoreOptions,
+): Promise<SkillProposalReadResult> {
+  const content = await readSkillProposalDraft(record, options);
+  const supportFiles = await readProposalSupportFiles(
+    record,
+    await root(resolveSkillWorkshopStateDir(options)),
+  );
   return {
     record,
     revisionHash: hashSkillProposalRevision(record),
-    content: draft.buffer.toString("utf8"),
+    content,
     ...(supportFiles.length > 0 ? { supportFiles } : {}),
   };
 }

--- a/src/skills/workshop/types.ts
+++ b/src/skills/workshop/types.ts
@@ -191,6 +191,7 @@ export type SkillProposalManifestEntry = {
   createdAt: string;
   updatedAt: string;
   scanState: SkillProposalScannerState;
+  revisionHash: string;
   /** The durable proposal body is unavailable; metadata remains inspectable in list output. */
   degradedState?: "draft-missing";
 };

--- a/ui/src/e2e/skill-workshop-revision-integrity.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-revision-integrity.e2e.test.ts
@@ -53,6 +53,7 @@ const workshopFeatureMethods = [
   ...defaultControlUiFeatureMethods,
   "sessions.list",
   "skills.proposals.apply",
+  "skills.proposals.evaluate",
   "skills.proposals.inspect",
   "skills.proposals.list",
   "skills.proposals.reject",
@@ -247,13 +248,15 @@ suite.define(() => {
         await setProposalRevision(gateway, H2, status);
         await gateway.resolveDeferred(method, {});
         await gateway.waitForRequest("skills.proposals.list", { after: secondListCount });
-        await gateway.waitForRequest("skills.proposals.inspect", { after: secondInspectCount });
         await expect.poll(() => page.locator(".sw-row").count()).toBe(0);
         await expect
           .poll(() => page.locator(".sw-action-toast").textContent())
           .toContain(status === "applied" ? "Applied" : "Rejected");
         expect(await page.getByText(H2.body, { exact: true }).count()).toBe(0);
         expect(await gateway.getRequests(method)).toHaveLength(secondActionCount + 1);
+        expect(await gateway.getRequests("skills.proposals.inspect")).toHaveLength(
+          secondInspectCount,
+        );
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
@@ -264,6 +267,109 @@ suite.define(() => {
       }
     },
   );
+
+  it("disables missing-draft actions and safely rejects beside an inspectable suggestion", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport,
+      recordVideo: { dir: artifactDir, size: viewport },
+    });
+    const page = await context.newPage();
+    try {
+      const validManifest = proposalManifest(H1);
+      const missing = {
+        ...validManifest.proposals[0],
+        id: "missing-draft",
+        title: "Missing draft suggestion",
+        kind: "update",
+        degradedState: "draft-missing",
+        revisionHash: H2_HASH,
+      };
+      const gateway = await installMockGateway(page, {
+        featureMethods: workshopFeatureMethods,
+        methodResponses: {
+          "skills.proposals.list": {
+            ...validManifest,
+            proposals: [...validManifest.proposals, missing],
+          },
+          "skills.proposals.inspect": proposalInspect(H1),
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}skills/workshop`);
+      await page.locator("#skill-workshop-mode-tab-suggestions").click();
+      await page.getByText(H1.body, { exact: true }).waitFor();
+      await page.locator(".sw-row").filter({ hasText: missing.title }).click();
+      await page.getByText("This suggestion's draft is missing.", { exact: false }).waitFor();
+      for (const action of ["Apply", "Evaluate", "Revise"]) {
+        expect(
+          await page
+            .locator(".sw-action-bar")
+            .getByRole("button", { name: action, exact: true })
+            .isDisabled(),
+        ).toBe(true);
+      }
+      expect(
+        await page
+          .locator(".sw-action-bar")
+          .getByRole("button", { name: "Reject", exact: true })
+          .isEnabled(),
+      ).toBe(true);
+      await page.screenshot({
+        animations: "disabled",
+        fullPage: true,
+        path: path.join(artifactDir, "missing-draft-unavailable.png"),
+      });
+
+      await gateway.deferNext("skills.proposals.reject", { proposalId: missing.id });
+      await page
+        .locator(".sw-action-bar")
+        .getByRole("button", { name: "Reject", exact: true })
+        .click();
+      const rejected = await gateway.waitForRequest("skills.proposals.reject");
+      expect(requestParams(rejected)).toEqual({
+        agentId: "main",
+        proposalId: missing.id,
+        expectedRevisionHash: H2_HASH,
+      });
+      await gateway.setMethodResponse("skills.proposals.list", {
+        ...validManifest,
+        proposals: [...validManifest.proposals, { ...missing, status: "rejected" }],
+      });
+      await gateway.resolveDeferred("skills.proposals.reject", {});
+      await page.getByText(H1.body, { exact: true }).waitFor();
+      await expect.poll(() => page.locator(".sw-action-toast").textContent()).toContain("Rejected");
+      expect(await page.locator(".sw-error").count()).toBe(0);
+      expect(await page.locator(".sw-row").count()).toBe(1);
+      for (const action of ["Apply", "Evaluate", "Revise", "Reject"]) {
+        expect(
+          await page
+            .locator(".sw-action-bar")
+            .getByRole("button", { name: action, exact: true })
+            .isEnabled(),
+        ).toBe(true);
+      }
+      const inspections = await gateway.getRequests("skills.proposals.inspect");
+      expect(inspections.length).toBeGreaterThan(0);
+      expect(
+        inspections.every((request) => requestParams(request).proposalId === PROPOSAL_ID),
+      ).toBe(true);
+      for (const method of [
+        "skills.proposals.apply",
+        "skills.proposals.evaluate",
+        "skills.proposals.requestRevision",
+      ]) {
+        expect(await gateway.getRequests(method)).toHaveLength(0);
+      }
+      await page.screenshot({
+        animations: "disabled",
+        fullPage: true,
+        path: path.join(artifactDir, "missing-draft-rejected-valid-suggestion.png"),
+      });
+    } finally {
+      await closeProofContext({ context });
+    }
+  });
 
   it("returns a stale natural Revision to H2 without retrying H1", async () => {
     const caseDir = path.join(artifactDir, "revision");

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3670,6 +3670,8 @@ export const en: TranslationMap & {
       supportFiles: "{count} support files",
       noSupportFiles: "0 support files",
       loading: "Loading\u2026",
+      draftMissing:
+        "This suggestion's draft is missing. Reject it and ask your agent to create a new suggestion.",
       supportFilesTitle: "Support files",
       clickToPreview: "\u00b7 click to preview",
     },

--- a/ui/src/lib/skill-workshop/index.ts
+++ b/ui/src/lib/skill-workshop/index.ts
@@ -48,6 +48,7 @@ export type SkillWorkshopProposal = {
    */
   bodyLoaded: boolean;
   status: SkillWorkshopProposalStatus;
+  degradedState?: SkillsProposalsListResult["proposals"][number]["degradedState"];
   origin?: {
     agentId?: string;
     sessionKey?: string;

--- a/ui/src/pages/skill-workshop/proposal-records.ts
+++ b/ui/src/pages/skill-workshop/proposal-records.ts
@@ -137,7 +137,8 @@ export function proposalFromManifest(
 ): SkillWorkshopProposal {
   const updatedAt = parseDateMs(entry.updatedAt);
   const createdAt = parseDateMs(entry.createdAt);
-  const previousIsCurrent = previous?.updatedAt === updatedAt;
+  const previousIsCurrent =
+    previous?.updatedAt === updatedAt && !entry.degradedState && !previous.degradedState;
   return {
     key: entry.id,
     kind: entry.kind,
@@ -147,9 +148,16 @@ export function proposalFromManifest(
     body: previousIsCurrent ? previous.body : "",
     bodyLoaded: previousIsCurrent ? previous.bodyLoaded : false,
     status: entry.status,
+    degradedState: entry.degradedState,
     ...(previousIsCurrent && previous.origin ? { origin: previous.origin } : {}),
     version: previousIsCurrent ? previous.version : 1,
-    revisionHash: previousIsCurrent ? previous.revisionHash : null,
+    // A missing draft can still be rejected against its recorded revision.
+    // Usable drafts require inspection before a decision can capture their hash.
+    revisionHash: entry.degradedState
+      ? (entry.revisionHash ?? null)
+      : previousIsCurrent
+        ? previous.revisionHash
+        : null,
     ...(previousIsCurrent && previous.evaluation ? { evaluation: previous.evaluation } : {}),
     createdAt,
     updatedAt,

--- a/ui/src/pages/skill-workshop/proposals.test.ts
+++ b/ui/src/pages/skill-workshop/proposals.test.ts
@@ -439,38 +439,29 @@ describe("Skill Workshop proposal RPCs", () => {
         ...manifest().proposals[0],
         kind,
         degradedState: "draft-missing",
-        revisionHash: REVISION_HASH,
       };
       const valid = { ...manifest().proposals[0], id: "proposal-2" };
       let status: SkillWorkshopProposal["status"] = "pending";
       const { state, context, request } = createFixture(
         {
           skillWorkshopAgentId: "research",
-          skillWorkshopSelectedKey: "proposal-1",
           skillWorkshopProposals: [proposal({ body: "Previously available draft." })],
           skillWorkshopRevisionDraft: "Revise this suggestion.",
         },
         {},
-        [
-          "skills.proposals.list",
-          "skills.proposals.inspect",
-          "skills.proposals.apply",
-          "skills.proposals.evaluate",
-          "skills.proposals.requestRevision",
-          "skills.proposals.reject",
-        ],
+        ["list", "inspect", "apply", "evaluate", "requestRevision", "reject"].map(
+          (method) => `skills.proposals.${method}`,
+        ),
       );
       const validInspect = inspectResult();
+      validInspect.record.id = "proposal-2";
       request.mockImplementation(async (method, payload) => {
         if (method === "skills.proposals.list") {
           return { ...manifest(), proposals: [{ ...missing, status }, valid] };
         }
         if (method === "skills.proposals.inspect") {
           expect(payload).toEqual({ agentId: "research", proposalId: "proposal-2" });
-          return {
-            ...validInspect,
-            record: { ...validInspect.record, id: "proposal-2" },
-          };
+          return validInspect;
         }
         if (method === "skills.proposals.reject") {
           expect(payload).toEqual({
@@ -489,34 +480,17 @@ describe("Skill Workshop proposal RPCs", () => {
         degradedState: "draft-missing",
         revisionHash: REVISION_HASH,
         body: "",
-        bodyLoaded: false,
       });
-      expect(state.skillWorkshopError).toBeNull();
-
-      await selectSkillWorkshopProposal(state, context, "proposal-2");
-      expect(state.skillWorkshopSelectedKey).toBe("proposal-2");
-      expect(state.skillWorkshopProposals[1]?.body).toBe(validInspect.content);
-      await selectSkillWorkshopProposal(state, context, "proposal-1");
-      expect(state.skillWorkshopSelectedKey).toBe("proposal-1");
-
       await runSkillWorkshopLifecycleAction(state, context, "apply", proposalDecision());
       await expect(runSkillWorkshopEvaluation(state, context, "proposal-1")).resolves.toBe(false);
       const sendRevision = vi.fn();
-      await expect(
-        requestSkillWorkshopRevision(state, context, "proposal-1", sendRevision),
-      ).resolves.toBeNull();
+      await requestSkillWorkshopRevision(state, context, "proposal-1", sendRevision);
       expect(sendRevision).not.toHaveBeenCalled();
-      expect(request.mock.calls.map(([method]) => method)).toEqual([
-        "skills.proposals.list",
-        "skills.proposals.inspect",
-      ]);
+      expect(request).toHaveBeenCalledTimes(1);
 
       try {
         await runSkillWorkshopLifecycleAction(state, context, "reject", proposalDecision());
         expect(state.skillWorkshopError).toBeNull();
-        expect(state.skillWorkshopActionNotice?.label).toBe("Rejected");
-        expect(state.skillWorkshopProposals[0]?.status).toBe("rejected");
-        expect(state.skillWorkshopSelectedKey).toBe("proposal-2");
         expect(state.skillWorkshopProposals[1]?.body).toBe(validInspect.content);
       } finally {
         clearNoticeTimer(state);

--- a/ui/src/pages/skill-workshop/proposals.test.ts
+++ b/ui/src/pages/skill-workshop/proposals.test.ts
@@ -105,6 +105,7 @@ function manifest(status: SkillWorkshopProposal["status"] = "pending") {
         createdAt: ISO_NOW,
         updatedAt: ISO_NOW,
         scanState: "clean",
+        revisionHash: REVISION_HASH,
       },
     ],
   };
@@ -371,17 +372,22 @@ describe("Skill Workshop proposal RPCs", () => {
 
   it("lists proposals with the selected agent id and carries it into the initial inspect", async () => {
     const { state, context, request } = createFixture();
+    const inspected = createDeferred<ReturnType<typeof inspectResult>>();
     request.mockImplementation(async (method: string) => {
       if (method === "skills.proposals.list") {
         return manifest();
       }
       if (method === "skills.proposals.inspect") {
-        return inspectResult();
+        return inspected.promise;
       }
       return {};
     });
 
-    await loadSkillWorkshopProposals(state, context);
+    const loading = loadSkillWorkshopProposals(state, context);
+    await vi.waitFor(() => expect(state.skillWorkshopInspectingKey).toBe("proposal-1"));
+    expect(state.skillWorkshopProposals[0]?.revisionHash).toBeNull();
+    inspected.resolve(inspectResult());
+    await loading;
 
     expect(request).toHaveBeenNthCalledWith(1, "skills.proposals.list", {
       agentId: "research",
@@ -391,6 +397,7 @@ describe("Skill Workshop proposal RPCs", () => {
       proposalId: "proposal-1",
     });
     expect(state.skillWorkshopProposals[0]?.kind).toBe("create");
+    expect(state.skillWorkshopProposals[0]?.revisionHash).toBe(REVISION_HASH);
   });
 
   it("reports a failed inspect for a selection retained across refresh", async () => {
@@ -424,6 +431,98 @@ describe("Skill Workshop proposal RPCs", () => {
       ["skills.proposals.inspect", { agentId: "research", proposalId: "proposal-1" }],
     ]);
   });
+
+  it.each(["create", "update"] as const)(
+    "keeps a missing %s draft dismissible beside a usable suggestion",
+    async (kind) => {
+      const missing = {
+        ...manifest().proposals[0],
+        kind,
+        degradedState: "draft-missing",
+        revisionHash: REVISION_HASH,
+      };
+      const valid = { ...manifest().proposals[0], id: "proposal-2" };
+      let status: SkillWorkshopProposal["status"] = "pending";
+      const { state, context, request } = createFixture(
+        {
+          skillWorkshopAgentId: "research",
+          skillWorkshopSelectedKey: "proposal-1",
+          skillWorkshopProposals: [proposal({ body: "Previously available draft." })],
+          skillWorkshopRevisionDraft: "Revise this suggestion.",
+        },
+        {},
+        [
+          "skills.proposals.list",
+          "skills.proposals.inspect",
+          "skills.proposals.apply",
+          "skills.proposals.evaluate",
+          "skills.proposals.requestRevision",
+          "skills.proposals.reject",
+        ],
+      );
+      const validInspect = inspectResult();
+      request.mockImplementation(async (method, payload) => {
+        if (method === "skills.proposals.list") {
+          return { ...manifest(), proposals: [{ ...missing, status }, valid] };
+        }
+        if (method === "skills.proposals.inspect") {
+          expect(payload).toEqual({ agentId: "research", proposalId: "proposal-2" });
+          return {
+            ...validInspect,
+            record: { ...validInspect.record, id: "proposal-2" },
+          };
+        }
+        if (method === "skills.proposals.reject") {
+          expect(payload).toEqual({
+            agentId: "research",
+            proposalId: "proposal-1",
+            expectedRevisionHash: REVISION_HASH,
+          });
+          status = "rejected";
+          return {};
+        }
+        throw new Error(`Unexpected request: ${method}`);
+      });
+
+      await loadSkillWorkshopProposals(state, context);
+      expect(state.skillWorkshopProposals[0]).toMatchObject({
+        degradedState: "draft-missing",
+        revisionHash: REVISION_HASH,
+        body: "",
+        bodyLoaded: false,
+      });
+      expect(state.skillWorkshopError).toBeNull();
+
+      await selectSkillWorkshopProposal(state, context, "proposal-2");
+      expect(state.skillWorkshopSelectedKey).toBe("proposal-2");
+      expect(state.skillWorkshopProposals[1]?.body).toBe(validInspect.content);
+      await selectSkillWorkshopProposal(state, context, "proposal-1");
+      expect(state.skillWorkshopSelectedKey).toBe("proposal-1");
+
+      await runSkillWorkshopLifecycleAction(state, context, "apply", proposalDecision());
+      await expect(runSkillWorkshopEvaluation(state, context, "proposal-1")).resolves.toBe(false);
+      const sendRevision = vi.fn();
+      await expect(
+        requestSkillWorkshopRevision(state, context, "proposal-1", sendRevision),
+      ).resolves.toBeNull();
+      expect(sendRevision).not.toHaveBeenCalled();
+      expect(request.mock.calls.map(([method]) => method)).toEqual([
+        "skills.proposals.list",
+        "skills.proposals.inspect",
+      ]);
+
+      try {
+        await runSkillWorkshopLifecycleAction(state, context, "reject", proposalDecision());
+        expect(state.skillWorkshopError).toBeNull();
+        expect(state.skillWorkshopActionNotice?.label).toBe("Rejected");
+        expect(state.skillWorkshopProposals[0]?.status).toBe("rejected");
+        expect(state.skillWorkshopSelectedKey).toBe("proposal-2");
+        expect(state.skillWorkshopProposals[1]?.body).toBe(validInspect.content);
+      } finally {
+        clearNoticeTimer(state);
+      }
+    },
+  );
 
   it("preserves capped support-file size formatting through the shared helper", async () => {
     const { state, context, request } = createFixture();
@@ -509,10 +608,10 @@ describe("Skill Workshop proposal RPCs", () => {
       expect(request).toHaveBeenNthCalledWith(2, "skills.proposals.list", {
         agentId: "reviewer",
       });
-      expect(request).toHaveBeenNthCalledWith(3, "skills.proposals.inspect", {
-        agentId: "reviewer",
-        proposalId: "proposal-1",
-      });
+      expect(request.mock.calls.map(([calledMethod]) => calledMethod)).toEqual([
+        method,
+        "skills.proposals.list",
+      ]);
     },
   );
 

--- a/ui/src/pages/skill-workshop/proposals.ts
+++ b/ui/src/pages/skill-workshop/proposals.ts
@@ -429,7 +429,7 @@ function loadSkillWorkshopProposalDetail(
     return Promise.resolve(false);
   }
   const existing = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
-  if (existing?.bodyLoaded && !options?.force) {
+  if (existing?.degradedState || (existing?.bodyLoaded && !options?.force)) {
     return Promise.resolve(true);
   }
   const requests = inspectRequests(state);
@@ -475,7 +475,12 @@ async function refreshAfterMutation(
 ): Promise<void> {
   state.skillWorkshopLoaded = false;
   await loadSkillWorkshopProposals(state, context, { force: true });
-  await loadSkillWorkshopProposalDetail(state, context, proposalId, { force: true });
+  if (
+    state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId)?.status ===
+    "pending"
+  ) {
+    await loadSkillWorkshopProposalDetail(state, context, proposalId, { force: true });
+  }
 }
 
 function markSkillWorkshopRevisionChanged(
@@ -508,6 +513,10 @@ export async function runSkillWorkshopLifecycleAction(
     return;
   }
   const previous = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
+  if (action === "apply" && previous?.degradedState) {
+    state.skillWorkshopError = t("skillWorkshop.detail.draftMissing");
+    return;
+  }
   if (!expectedRevisionHash) {
     clearActionNoticeTimer(state);
     state.skillWorkshopActionNotice = null;
@@ -588,6 +597,9 @@ export async function runSkillWorkshopEvaluation(
       return false;
     }
     const current = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
+    if (current?.degradedState) {
+      throw new Error(t("skillWorkshop.detail.draftMissing"));
+    }
     if (!current || current.status !== "pending" || !current.revisionHash) {
       throw new Error(t("skillWorkshop.evaluation.errors.revisionHashUnavailable"));
     }
@@ -652,6 +664,10 @@ export async function requestSkillWorkshopRevision(
   const proposal = state.skillWorkshopProposals.find((item) => item.key === proposalId);
   const instructions = state.skillWorkshopRevisionDraft.trim();
   if (!proposal || !instructions) {
+    return null;
+  }
+  if (proposal.degradedState) {
+    state.skillWorkshopError = t("skillWorkshop.detail.draftMissing");
     return null;
   }
   const proposalAgentId = loadedSkillWorkshopAgentParams(state, context).agentId;

--- a/ui/src/pages/skill-workshop/view.ts
+++ b/ui/src/pages/skill-workshop/view.ts
@@ -289,9 +289,13 @@ function renderDetail(props: SkillWorkshopProps, proposal: SkillWorkshopProposal
             <h1>${proposal.slug}</h1>
           </div>
           ${
-            detailLoading
-              ? html`<p class="sw-muted">${t("skillWorkshop.detail.loading")}</p>`
-              : renderSkillDocument(proposal.body)
+            proposal.degradedState
+              ? html`<p class="sw-muted" role="status">
+                  ${t("skillWorkshop.detail.draftMissing")}
+                </p>`
+              : detailLoading
+                ? html`<p class="sw-muted">${t("skillWorkshop.detail.loading")}</p>`
+                : renderSkillDocument(proposal.body)
           }
         </div>
 
@@ -351,11 +355,12 @@ function proposalDecision(proposal: SkillWorkshopProposal): SkillWorkshopProposa
 function renderPendingActions(props: SkillWorkshopProps, proposal: SkillWorkshopProposal) {
   const busy = props.actionBusy?.key === proposal.key ? props.actionBusy.action : null;
   const disabled = Boolean(props.actionBusy);
+  const draftUnavailable = disabled || Boolean(proposal.degradedState);
   return html`
     <div class="sw-action-bar" aria-busy=${busy ? "true" : "false"}>
       <button
         class="sw-btn ${busy === "evaluate" ? "is-busy" : ""}"
-        ?disabled=${disabled || !props.access.canEvaluate}
+        ?disabled=${draftUnavailable || !props.access.canEvaluate}
         @click=${() => props.onEvaluate(proposal.key)}
       >
         ${
@@ -366,14 +371,14 @@ function renderPendingActions(props: SkillWorkshopProps, proposal: SkillWorkshop
       </button>
       <button
         class="sw-btn sw-btn--primary ${busy === "apply" ? "is-busy" : ""}"
-        ?disabled=${disabled || !props.access.canApply}
+        ?disabled=${draftUnavailable || !props.access.canApply}
         @click=${() => props.onApply(proposalDecision(proposal))}
       >
         ${busy === "apply" ? t("skillWorkshop.actions.applying") : t("skillWorkshop.actions.apply")}
       </button>
       <button
         class="sw-btn ${busy === "revise" ? "is-busy" : ""}"
-        ?disabled=${disabled || !props.access.canRevise}
+        ?disabled=${draftUnavailable || !props.access.canRevise}
         @click=${() => props.onRevise(proposal.key)}
       >
         ${


### PR DESCRIPTION
## What Problem This Solves

Skill Workshop could show usable-looking suggestions whose drafts no longer existed. Ownership migration could also make old proposals appear newly edited, and dismissal could strand unfinished apply recovery.

## Why This Change Was Made

Doctor marks missing drafts stale only when no rollback remains. Listing checks draft availability through the store owner, while Inspect and Apply still validate the full bundle. Reject and Quarantine check recovery within their state-change transaction. Ownership-only moves preserve edit time.

## User Impact

Missing drafts show as unavailable with content actions disabled. Safe rejection remains possible; unfinished recovery must complete first. Restore the draft and use Inspect to finish recovery. Doctor repair preserves remaining files and installed skills. No schema or configuration change is added.

Consumers: proposal lists, Workshop actions, Doctor repair, and recovery dismissal share draft availability and recovery state.

## Evidence

The original Doctor left missing drafts pending. Compiled UI/Gateway/Doctor checks verified retirement, rejection, valid siblings, preserved dates, and restart persistence. Follow-up checks preserved unfinished recovery and kept healthy suggestions visible despite damaged support files. Restored drafts completed recovery through Inspect. Doctor correctly refused during active Gateway maintenance ownership. Final mechanical test/lint fixes retain earlier proof.
