### PR TITLE
refactor(ui): share companion error detail reader

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3877,7 +3877,7 @@ ui/src/pages/chat/chat-send-ack.ts	2
 ui/src/pages/chat/chat-send-composer.ts	1
 ui/src/pages/chat/chat-send-request.ts	1
 ui/src/pages/chat/chat-send-timing.ts	6
-ui/src/pages/chat/chat-session-companion.ts	5
+ui/src/pages/chat/chat-session-companion.ts	3
 ui/src/pages/chat/chat-state-events.ts	6
 ui/src/pages/chat/chat-state-page.ts	5
 ui/src/pages/chat/chat-state-route.ts	1

--- a/ui/src/pages/chat/chat-session-companion.ts
+++ b/ui/src/pages/chat/chat-session-companion.ts
@@ -36,7 +36,7 @@ function exchangeKey(exchange: SessionCompanionExchange): string {
   return JSON.stringify([exchange.question, exchange.answer, exchange.ts]);
 }
 
-function errorDetailCode(error: unknown): string | null {
+function errorDetailString(error: unknown, field: "code" | "reason"): string | null {
   if (!error || typeof error !== "object") {
     return null;
   }
@@ -44,20 +44,8 @@ function errorDetailCode(error: unknown): string | null {
   if (!details || typeof details !== "object") {
     return null;
   }
-  const code = (details as { code?: unknown }).code;
-  return typeof code === "string" ? code : null;
-}
-
-function errorDetailReason(error: unknown): string | null {
-  if (!error || typeof error !== "object") {
-    return null;
-  }
-  const details = (error as { details?: unknown }).details;
-  if (!details || typeof details !== "object") {
-    return null;
-  }
-  const reason = (details as { reason?: unknown }).reason;
-  return typeof reason === "string" ? reason : null;
+  const value = (details as { code?: unknown; reason?: unknown })[field];
+  return typeof value === "string" ? value : null;
 }
 
 function errorIsRetryable(error: unknown): boolean {
@@ -202,9 +190,9 @@ export class ChatSessionCompanionThreads {
       }
       thread.failedQuestion = normalized;
       thread.failedQuestionKnownExchanges = knownExchanges;
-      const reason = errorDetailReason(error);
+      const reason = errorDetailString(error, "reason");
       thread.hint =
-        errorDetailCode(error) === COMPANION_BUSY_DETAIL_CODE
+        errorDetailString(error, "code") === COMPANION_BUSY_DETAIL_CODE
           ? "busy"
           : reason === "context-unavailable"
             ? "history-unavailable"


### PR DESCRIPTION
## What Problem This Solves

The Control UI companion error path maintained two private readers with identical object and detail validation. Keeping the readers separate made small behavior-preserving changes easier to drift.

## Why This Change Was Made

This consolidates both readers into one private field-selecting helper while preserving reason-before-code evaluation, direct property access, getter and inherited-property behavior, busy precedence, and retry handling. The assertion-safety ratchet is reduced from 5 to 3 to match the removed assertion sites.

## User Impact

No user-visible behavior changes. Companion busy and failure hints continue to map exactly as before, with less duplicated production code.

## Evidence

- Local focused Control UI tests: 45 passed.
- Local Control UI production build: passed.
- Blacksmith Testbox `tbx_01m1xdsykj82x71qx3n3grn9cx`: focused tests 45 passed, Control UI build passed, full changed gate passed.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/34097849659
- Independent autoreview through P2: scoped clean.
- `git diff --check`: passed.
