### PR TITLE
fix(android): adopt fresh-bootstrap credential handoff

### DIFF
--- a/apps/android/GATEWAY_AUTH_POLICY.md
+++ b/apps/android/GATEWAY_AUTH_POLICY.md
@@ -1,0 +1,131 @@
+# Fresh-bootstrap authentication policy
+
+Draft implementation reference for adopting the shared Swift policy on Android.
+The precedence change requires a durable bootstrap handoff before it can ship.
+This document describes the existing implementations and the remaining decision;
+it does not claim Android already implements the Swift policy.
+
+## Swift decision table
+
+The canonical selector is `selectConnectAuth` in
+[`GatewayChannel.swift`](../shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift).
+Explicit credentials are trimmed; empty values count as absent. Evaluate these
+rows in order:
+
+| Credentials available | Authentication sent |
+| --- | --- |
+| Explicit Gateway token | `auth.token` with the explicit token |
+| No Gateway token; explicit password | `auth.password` |
+| Neither above; bootstrap token | `auth.bootstrapToken`, even when a stored device token exists |
+| No explicit credential; eligible stored device token | `auth.token` with the stored device token |
+| None of the above | No `auth` field |
+
+Stored lookup requires device identity, permission to use stored device auth,
+and a matching device, role, Gateway owner, and identity profile. Suppressing
+lookup or reuse does not delete the old token. Signature binding uses the
+selected token or bootstrap token; password auth has no signature token.
+
+The retry overlay applies only to explicit Gateway-token authentication. After
+one eligible rejection, a trusted endpoint may receive both `auth.token` and
+`auth.deviceToken`. When stored scope metadata is nonempty, Swift requires that
+grant to cover the requested scopes before attaching the retry token. Empty
+scope metadata does not suppress an otherwise eligible retry. It schedules at most one retry for
+`canRetryWithDeviceToken` or `AUTH_TOKEN_MISMATCH`; a retry rejected with
+`AUTH_DEVICE_TOKEN_MISMATCH` clears only the matching stored role token. Success
+resets the retry budget.
+
+### Freshness, expiry, and pairing
+
+“Fresh” in the selector means a supplied nonempty bootstrap token. The selector
+does not compare timestamps or infer pairing completion from a stored token.
+Neither platform's device-token entry has an expiry field: `updatedAtMs` records
+a write time, and neither loader treats age as expiration. The Gateway owns
+bootstrap validity and consumption. The iOS manual-connect owner also rejects a
+setup override whose `expiresAtMs` is at or before the current time.
+
+| State | Swift behavior |
+| --- | --- |
+| Fresh setup token, with or without an old device token | Submit bootstrap auth unless explicit Gateway token or password wins |
+| Bootstrap rejected as invalid or pairing required | Surface the rejection; the channel pauses automatic reconnect rather than silently using the old token |
+| Successful bootstrap hello | Record received roles separately from successfully persisted roles |
+| Node and operator replacement tokens durably persisted | iOS completes the handoff, removes bootstrap from saved credentials and active reconnect configuration, and enables stored auth |
+| Subsequent reconnect or relaunch after that handoff | Use the stored role token when no explicit Gateway token or password exists |
+| Explicit Gateway token rotated while a stored token remains | Try explicit auth first; only the bounded trusted retry can attach the stored token |
+
+Bootstrap handoff persistence permits WSS and local-network WS. It accepts node
+tokens with empty scopes and operator tokens filtered to `operator.admin`,
+`operator.approvals`, `operator.questions`, `operator.read`,
+`operator.talk.secrets`, and `operator.write`. A missing issued role or failed
+durable write must not be mistaken for completed handoff.
+
+The lifecycle owners are `completeSuccessfulGatewayAuthHandoff` in
+[`NodeAppModel.swift`](../ios/Sources/Model/NodeAppModel.swift) and
+`completeGatewayCredentialHandoff` in
+[`GatewaySettingsStore.swift`](../ios/Sources/Gateway/GatewaySettingsStore.swift).
+
+## Android handoff decision
+
+Android's [`GatewaySession.kt`](app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt)
+currently reuses a stored device token even when a bootstrap token is supplied.
+The existing `connect_prefersStoredDeviceTokenOverBootstrapToken` test in
+[`GatewaySessionInvokeTest.kt`](app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt)
+explicitly protects that behavior.
+
+That precedence also compensates for a lifecycle difference:
+[`MainViewModel.kt`](app/src/main/java/ai/openclaw/app/MainViewModel.kt) saves the
+bootstrap credential, [`NodeRuntime.kt`](app/src/main/java/ai/openclaw/app/NodeRuntime.kt)
+reloads it for later connection intents, and the session retains it in
+`DesiredConnection`. Successful hello handling saves issued device tokens but
+does not retire bootstrap auth. Replacing the selector condition alone would
+therefore make later connections submit the spent bootstrap token.
+
+The proposed repair needs an explicit decision to change persisted credential
+handoff and recovery: retire only the consumed bootstrap credential after both
+replacement role tokens are durably stored, update the current connection
+intent, and fence completion against a newer setup/reset intent. Android's
+[`DeviceAuthStore.kt`](app/src/main/java/ai/openclaw/app/gateway/DeviceAuthStore.kt)
+currently exposes `saveToken` without a durable-success result. A successful
+hello or a preexisting token is insufficient proof of that handoff.
+
+Existing installations can already contain a spent bootstrap alongside usable
+device tokens. The repair must define their upgrade behavior without treating
+an unrelated old device token as evidence that a freshly supplied setup token
+has been consumed. The fresh-bootstrap preference is decided; this durable
+handoff and upgrade behavior remains the implementation decision.
+
+## Other differences retained
+
+These are separate from fresh-bootstrap stored-token precedence. Unifying them
+would change other Android authentication paths, outside this fix's scope:
+
+- Android's session chooses bootstrap over password when both are supplied;
+  Swift chooses password. Android's operator-auth helper already prefers the
+  explicit password.
+- Android substitutes stored scopes whenever it selects device-token auth.
+  Swift preserves explicitly requested scopes and suppresses stored-token retry
+  for scope upgrades beyond a nonempty stored grant.
+- Android's retry trust includes local cleartext hosts and existing TLS pins,
+  and accepts the legacy `retry_with_device_token` advice. Swift uses strict
+  loopback or a trusted WSS session, plus the boolean hint or mismatch code.
+- Android keeps retrying a bootstrap node request with no scopes when the
+  Gateway reports `not-paired` and explicitly advises waiting. Swift's channel
+  classifies pairing-required as nonrecoverable.
+- Android may start an operator session using an old stored operator token
+  while bootstrap is present. iOS waits for the bootstrap handoff before
+  starting stored-only operator access.
+
+## Required implementation proof
+
+Extend the existing wire-level auth tests without adding a selector-only test
+seam. Demonstrate fresh bootstrap winning over an old device token, continued
+bootstrap use while pairing is pending, durable role-token handoff, reconnect
+and process relaunch, and unchanged explicit-token/password/retry behavior.
+The regression must fail on the old implementation for the credential actually
+sent. Include interruption and failed-persistence cases before marking handoff
+complete.
+
+Run the Android gateway unit tests and `pnpm android:i18n:check`. Then use a
+Blacksmith Testbox with an Android emulator and an isolated Gateway state
+directory and free port. Record an explicit `adb -s <serial>` sequence covering
+fresh install, pairing, kill/relaunch, and Gateway-token rotation. Unit tests or
+source inspection alone do not satisfy that live proof.

--- a/apps/android/GATEWAY_AUTH_POLICY.md
+++ b/apps/android/GATEWAY_AUTH_POLICY.md
@@ -1,9 +1,9 @@
 # Fresh-bootstrap authentication policy
 
-Draft implementation reference for adopting the shared Swift policy on Android.
-The precedence change requires a durable bootstrap handoff before it can ship.
-This document describes the existing implementations and the remaining decision;
-it does not claim Android already implements the Swift policy.
+Android honors newly supplied bootstrap credentials before stored device tokens.
+A durable handoff retires the consumed bootstrap only after both replacement role
+tokens are saved. The shared Swift selector remains the precedence reference;
+the platform differences listed below are retained.
 
 ## Swift decision table
 
@@ -63,35 +63,54 @@ The lifecycle owners are `completeSuccessfulGatewayAuthHandoff` in
 `completeGatewayCredentialHandoff` in
 [`GatewaySettingsStore.swift`](../ios/Sources/Gateway/GatewaySettingsStore.swift).
 
-## Android handoff decision
+## Android durable handoff
 
-Android's [`GatewaySession.kt`](app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt)
-currently reuses a stored device token even when a bootstrap token is supplied.
-The existing `connect_prefersStoredDeviceTokenOverBootstrapToken` test in
-[`GatewaySessionInvokeTest.kt`](app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt)
-explicitly protects that behavior.
+[`GatewaySession.kt`](app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt)
+selects fresh bootstrap before a stored device token. The wire regression is
+`connect_prefersFreshBootstrapTokenOverStoredDeviceToken` in
+[`GatewaySessionInvokeTest.kt`](app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt).
 
-That precedence also compensates for a lifecycle difference:
-[`MainViewModel.kt`](app/src/main/java/ai/openclaw/app/MainViewModel.kt) saves the
-bootstrap credential, [`NodeRuntime.kt`](app/src/main/java/ai/openclaw/app/NodeRuntime.kt)
-reloads it for later connection intents, and the session retains it in
-`DesiredConnection`. Successful hello handling saves issued device tokens but
-does not retire bootstrap auth. Replacing the selector condition alone would
-therefore make later connections submit the spent bootstrap token.
-
-The proposed repair needs an explicit decision to change persisted credential
-handoff and recovery: retire only the consumed bootstrap credential after both
-replacement role tokens are durably stored, update the current connection
-intent, and fence completion against a newer setup/reset intent. Android's
 [`DeviceAuthStore.kt`](app/src/main/java/ai/openclaw/app/gateway/DeviceAuthStore.kt)
-currently exposes `saveToken` without a durable-success result. A successful
-hello or a preexisting token is insufficient proof of that handoff.
+commits each role token and its metadata together and returns the actual durable
+write result. The session records the final write result for each role in this
+hello; receipt alone and preexisting tokens do not establish fresh handoff.
+Both node and operator writes must succeed before bootstrap retirement.
 
-Existing installations can already contain a spent bootstrap alongside usable
-device tokens. The repair must define their upgrade behavior without treating
-an unrelated old device token as evidence that a freshly supplied setup token
-has been consumed. The fresh-bootstrap preference is decided; this durable
-handoff and upgrade behavior remains the implementation decision.
+[`SecurePrefs.kt`](app/src/main/java/ai/openclaw/app/SecurePrefs.kt) then commits
+the existing credential bundle with only the consumed bootstrap removed. Token
+and password fields are preserved. A failed commit restores the previous
+in-memory values, because Android can publish a failed disk write in memory.
+Missing roles or failed writes retain bootstrap in saved credentials and in the
+session intent; the current socket can remain connected, but a later rejected
+bootstrap requires setup repair.
+
+[`GatewayBootstrapHandoff.kt`](app/src/main/java/ai/openclaw/app/gateway/GatewayBootstrapHandoff.kt)
+owns retirement authority for one connection intent. Every new runtime intent
+invalidates that authority before socket cleanup. A preference revision also
+fences every setup save/reset, including replacement with identical token bytes.
+Successful retirement clears the session's reconnect bootstrap and the active
+[`NodeRuntime.kt`](app/src/main/java/ai/openclaw/app/NodeRuntime.kt) auth view.
+Reconnect and relaunch then select the stored role tokens. Revision and handoff
+state are in memory only; encrypted preference keys and serialized formats do
+not change.
+
+### Existing-install recovery
+
+An implicitly loaded saved bootstrap is submitted first. After the Gateway
+returns `AUTH_BOOTSTRAP_TOKEN_INVALID`, a trusted endpoint may get one recovery
+attempt using stored device auth, provided both node and operator token slots
+are nonempty for the same Gateway and device. A successful stored-node hello
+and durable writes of both role entries permit retirement of the rejected saved
+bootstrap. The existing operator connection authenticates its own stored token.
+The Gateway does not distinguish spent, expired, and invalid bootstrap tokens,
+so this recovery applies to that saved-credential rejection, not an inferred age.
+
+Explicit setup input never receives this recovery permission, even if its bytes
+match a saved token. It follows bootstrap auth and surfaces rejection instead of
+falling back to old device access. The normal setup owner,
+[`MainViewModel.kt`](app/src/main/java/ai/openclaw/app/MainViewModel.kt), drains and
+resets old role credentials before saving replacement setup input; this also
+preserves the distinction across process death during setup.
 
 ## Other differences retained
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1059,6 +1059,7 @@ class NodeRuntime private constructor(
     val token: String?,
     val bootstrapToken: String?,
     val password: String?,
+    val bootstrapHandoff: ai.openclaw.app.gateway.GatewayBootstrapHandoff? = null,
   )
 
   /**
@@ -1122,11 +1123,15 @@ class NodeRuntime private constructor(
   // Identity owns an established connection until disconnect/replacement, independently
   // of the UI request or lifecycle sequence that originally admitted it.
   private class GatewayConnectionContext(
-    val auth: GatewayConnectAuth,
+    private val initialAuth: GatewayConnectAuth,
     // A started session owns retries and auth pauses before readiness is published.
     // Only bootstrap without operator auth may admit this role after the node connects.
     var operatorConnectAdmitted: Boolean = false,
-  )
+  ) {
+    val bootstrapHandoff = initialAuth.bootstrapHandoff
+    val auth: GatewayConnectAuth
+      get() = if (bootstrapHandoff?.completed == true) initialAuth.copy(bootstrapToken = null) else initialAuth
+  }
 
   private var activeGatewayConnection: GatewayConnectionContext? = null
 
@@ -4556,8 +4561,11 @@ class NodeRuntime private constructor(
 
   // Queued callers can exit before cleanup, so generation changes must request reconciliation.
   private fun advanceGatewayLifecycleIntent(): Long =
-    gatewayLifecycleIntentSeq.incrementAndGet().also {
-      requestBackgroundGatewayReconciliation()
+    synchronized(gatewayLifecycleIntentLock) {
+      activeGatewayConnection?.bootstrapHandoff?.invalidate()
+      gatewayLifecycleIntentSeq.incrementAndGet().also {
+        requestBackgroundGatewayReconciliation()
+      }
     }
 
   private fun gatewayLifecycleIntent(
@@ -4598,6 +4606,7 @@ class NodeRuntime private constructor(
   ): Boolean =
     runGatewayConnectOperation {
       beforeConnect()
+      activeGatewayConnection?.bootstrapHandoff?.invalidate()
       val connection = GatewayConnectionContext(auth)
       activeGatewayConnection = connection
       val tls = connectionManager.resolveTlsParams(endpoint)
@@ -4643,6 +4652,7 @@ class NodeRuntime private constructor(
         auth.password,
         nodeConnectOptions,
         tls,
+        bootstrapHandoff = connection.bootstrapHandoff,
       )
     }
 
@@ -4820,15 +4830,21 @@ class NodeRuntime private constructor(
   internal fun resolveGatewayConnectAuth(
     endpoint: GatewayEndpoint,
     explicitAuth: GatewayConnectAuth? = null,
-  ): GatewayConnectAuth =
-    explicitAuth
-      ?: prefs.loadGatewayCredentials(endpoint.stableId).let { credentials ->
-        GatewayConnectAuth(
-          token = credentials.token,
-          bootstrapToken = credentials.bootstrapToken,
-          password = credentials.password,
-        )
-      }
+  ): GatewayConnectAuth {
+    val auth =
+      explicitAuth
+        ?: prefs.loadGatewayCredentials(endpoint.stableId).let { credentials ->
+          GatewayConnectAuth(
+            token = credentials.token,
+            bootstrapToken = credentials.bootstrapToken,
+            password = credentials.password,
+          )
+        }
+    val bootstrap = auth.bootstrapToken?.trim()?.takeIf { it.isNotEmpty() } ?: return auth
+    return auth.copy(
+      bootstrapHandoff = prefs.prepareGatewayBootstrapHandoff(endpoint.stableId, bootstrap, allowStoredTokenRecovery = explicitAuth == null),
+    )
+  }
 
   fun acceptGatewayTrustPrompt(manualFingerprint: String? = null) {
     val prompt = _pendingGatewayTrust.value ?: return
@@ -5139,6 +5155,7 @@ class NodeRuntime private constructor(
     connectedEndpoint = null
     connectingEndpointStableId = null
     _gatewayControlPage.value = null
+    activeGatewayConnection?.bootstrapHandoff?.invalidate()
     activeGatewayConnection = null
     updateStatus {
       operatorConnected = false

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -2,6 +2,7 @@
 
 package ai.openclaw.app
 
+import ai.openclaw.app.gateway.GatewayBootstrapHandoff
 import ai.openclaw.app.gateway.GatewayCustomHeaders
 import ai.openclaw.app.gateway.GatewayRegistryStore
 import ai.openclaw.app.gateway.GatewayStoreMigration
@@ -80,6 +81,9 @@ class SecurePrefs(
   context: Context,
   private val securePrefsOverride: SharedPreferences? = null,
 ) {
+  private val gatewayCredentialLock = Any()
+  private val gatewayCredentialRevisions = mutableMapOf<String, Long>()
+
   companion object {
     private const val displayNameKey = "node.displayName"
     private const val locationModeKey = "location.enabledMode"
@@ -509,19 +513,23 @@ class SecurePrefs(
   }
 
   fun loadGatewayCredentials(stableId: String): GatewayCredentials {
-    // Credential reads are gateway state; force the lazy registry so the one-time
-    // legacy migration has run before the first per-gateway bundle is resolved.
+    // The lazy migration can write credentials; initialize it before taking the
+    // credential lock so concurrent first access cannot invert those locks.
     gatewayRegistry
-    val raw = securePrefs.getString(gatewayCredentialsKey(stableId), null) ?: return GatewayCredentials()
-    return runCatching { json.decodeFromString<GatewayCredentials>(raw).normalized() }.getOrDefault(GatewayCredentials())
+    return synchronized(gatewayCredentialLock) {
+      val raw = securePrefs.getString(gatewayCredentialsKey(stableId), null) ?: return GatewayCredentials()
+      return runCatching { json.decodeFromString<GatewayCredentials>(raw).normalized() }.getOrDefault(GatewayCredentials())
+    }
   }
 
   fun saveGatewayCredentials(
     stableId: String,
     credentials: GatewayCredentials,
   ) {
-    securePrefs.edit {
-      putString(gatewayCredentialsKey(stableId), json.encodeToString(credentials.normalized()))
+    synchronized(gatewayCredentialLock) {
+      val key = gatewayCredentialsKey(stableId)
+      gatewayCredentialRevisions[key] = (gatewayCredentialRevisions[key] ?: 0L) + 1L
+      securePrefs.edit { putString(key, json.encodeToString(credentials.normalized())) }
     }
   }
 
@@ -535,7 +543,34 @@ class SecurePrefs(
   }
 
   fun clearGatewayCredentials(stableId: String) {
-    securePrefs.edit { remove(gatewayCredentialsKey(stableId)) }
+    synchronized(gatewayCredentialLock) {
+      val key = gatewayCredentialsKey(stableId)
+      gatewayCredentialRevisions[key] = (gatewayCredentialRevisions[key] ?: 0L) + 1L
+      securePrefs.edit { remove(key) }
+    }
+  }
+
+  internal fun prepareGatewayBootstrapHandoff(
+    stableId: String,
+    bootstrapToken: String,
+    allowStoredTokenRecovery: Boolean,
+  ): GatewayBootstrapHandoff {
+    gatewayRegistry
+    return synchronized(gatewayCredentialLock) {
+      val key = gatewayCredentialsKey(stableId)
+      val revision = gatewayCredentialRevisions[key]
+      val credentials = loadGatewayCredentials(stableId)
+      GatewayBootstrapHandoff(allowStoredTokenRecovery) {
+        synchronized(gatewayCredentialLock) {
+          when {
+            gatewayCredentialRevisions[key] != revision -> false
+            credentials.bootstrapToken == null -> true
+            credentials.bootstrapToken != bootstrapToken.trim() -> false
+            else -> commitSecureStrings(mapOf(key to json.encodeToString(credentials.copy(bootstrapToken = null))))
+          }
+        }
+      }
+    }
   }
 
   /**
@@ -611,6 +646,22 @@ class SecurePrefs(
     key: String,
     value: String,
   ): Boolean = securePrefs.edit().putString(key, value).commit()
+
+  internal fun commitSecureStrings(values: Map<String, String>): Boolean =
+    synchronized(securePrefs) {
+      val previous = values.keys.associateWith { securePrefs.getString(it, null) }
+      val editor = securePrefs.edit()
+      values.forEach { (key, value) -> editor.putString(key, value) }
+      val committed = runCatching { editor.commit() }.getOrDefault(false)
+      if (!committed) {
+        // commit(false) can still publish its changes in memory. Keep failed handoffs
+        // from looking complete to a later reconnect in this process.
+        securePrefs.edit {
+          previous.forEach { (key, value) -> if (value == null) remove(key) else putString(key, value) }
+        }
+      }
+      return committed
+    }
 
   fun remove(key: String) {
     securePrefs.edit { remove(key) }

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/DeviceAuthStore.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/DeviceAuthStore.kt
@@ -35,14 +35,14 @@ interface DeviceAuthTokenStore {
     role: String,
   ): String? = loadEntry(gatewayId, deviceId, role)?.token
 
-  /** Persists a role token and deterministic scope metadata under normalized keys. */
+  /** Returns true only after the token and its scope metadata are durably committed. */
   fun saveToken(
     gatewayId: String,
     deviceId: String,
     role: String,
     token: String,
     scopes: List<String> = emptyList(),
-  )
+  ): Boolean
 
   /** Removes both token and metadata for the normalized device/role pair. */
   fun clearToken(
@@ -86,17 +86,19 @@ class DeviceAuthStore(
     role: String,
     token: String,
     scopes: List<String>,
-  ) {
+  ): Boolean {
     val normalizedScopes = normalizeScopes(scopes)
     val key = tokenKey(gatewayId, deviceId, role)
-    prefs.putString(key, token.trim())
-    prefs.putString(
-      metadataKey(gatewayId, deviceId, role),
-      json.encodeToString(
-        PersistedDeviceAuthMetadata(
-          scopes = normalizedScopes,
-          updatedAtMs = System.currentTimeMillis(),
-        ),
+    return prefs.commitSecureStrings(
+      mapOf(
+        key to token.trim(),
+        metadataKey(gatewayId, deviceId, role) to
+          json.encodeToString(
+            PersistedDeviceAuthMetadata(
+              scopes = normalizedScopes,
+              updatedAtMs = System.currentTimeMillis(),
+            ),
+          ),
       ),
     )
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayBootstrapHandoff.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayBootstrapHandoff.kt
@@ -1,0 +1,26 @@
+package ai.openclaw.app.gateway
+
+/** One connection intent's authority to retire its saved bootstrap after durable role writes. */
+class GatewayBootstrapHandoff(
+  val allowStoredTokenRecovery: Boolean = false,
+  private val retireCredential: () -> Boolean,
+) {
+  private val lock = Any()
+  private var active = true
+
+  @Volatile var completed = false
+    private set
+
+  fun complete(): Boolean =
+    synchronized(lock) {
+      if (!active) return@synchronized false
+      if (!completed) completed = retireCredential()
+      completed
+    }
+
+  // Intent admission invalidates this owner before waiting for sockets or other cleanup.
+  // This lock never calls back into runtime/session locks, preserving their lock order.
+  fun invalidate() {
+    synchronized(lock) { active = false }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -417,11 +417,14 @@ class GatewaySession(
   private class DesiredConnection(
     val endpoint: GatewayEndpoint,
     val token: String?,
-    val bootstrapToken: String?,
+    @Volatile var bootstrapToken: String?,
     val password: String?,
     val options: GatewayConnectOptions,
     val tls: GatewayTlsParams?,
+    val bootstrapHandoff: GatewayBootstrapHandoff?,
   ) {
+    var recoveringStoredBootstrap = false
+
     // Retry state belongs to this connect intent, not a later target whose socket may already be ready.
     @Volatile var pendingDeviceTokenRetry = false
 
@@ -460,11 +463,12 @@ class GatewaySession(
     password: String?,
     options: GatewayConnectOptions,
     tls: GatewayTlsParams? = null,
+    bootstrapHandoff: GatewayBootstrapHandoff? = null,
   ) {
     synchronized(notificationLock) {
       val connectionToClose: Connection?
       synchronized(lifecycleLock) {
-        desired = DesiredConnection(endpoint, token, bootstrapToken, password, options, tls)
+        desired = DesiredConnection(endpoint, token, bootstrapToken, password, options, tls, bootstrapHandoff)
         connectionToClose = currentConnection
         if (job?.isActive != true) {
           job = scope.launch(Dispatchers.IO) { runLoop() }
@@ -1380,7 +1384,7 @@ class GatewaySession(
         selectConnectAuth(
           target = target,
           explicitGatewayToken = target.token?.trim()?.takeIf { it.isNotEmpty() },
-          explicitBootstrapToken = target.bootstrapToken?.trim()?.takeIf { it.isNotEmpty() },
+          explicitBootstrapToken = target.bootstrapToken?.trim()?.takeIf { it.isNotEmpty() && !target.recoveringStoredBootstrap },
           explicitPassword = target.password?.trim()?.takeIf { it.isNotEmpty() },
           storedToken = storedToken?.takeIf { it.isNotEmpty() },
           storedScopes = storedEntry?.scopes.orEmpty(),
@@ -1397,6 +1401,20 @@ class GatewaySession(
       val res = request(GatewayMethod.Connect.rawValue, payload, timeoutMs = CONNECT_RPC_TIMEOUT_MS)
       if (!res.ok) {
         val error = res.error ?: ErrorShape("UNAVAILABLE", "connect failed")
+        // Only implicitly loaded credentials may recover an old install's spent setup code.
+        // Never turn a rejection of newly supplied setup auth into access under an older grant.
+        if (
+          selectedAuth.authSource == GatewayConnectAuthSource.BOOTSTRAP_TOKEN &&
+          target.bootstrapHandoff?.allowStoredTokenRecovery == true &&
+          !target.recoveringStoredBootstrap &&
+          error.details?.code == "AUTH_BOOTSTRAP_TOKEN_INVALID" &&
+          shouldPersistBootstrapHandoffTokens(selectedAuth.authSource) &&
+          listOf("node", "operator").all { role ->
+            !deviceAuthStore.loadToken(target.endpoint.stableId, identity.deviceId, role).isNullOrBlank()
+          }
+        ) {
+          target.recoveringStoredBootstrap = true
+        }
         val shouldRetryWithDeviceToken =
           shouldRetryWithStoredDeviceToken(
             target = target,
@@ -1455,29 +1473,21 @@ class GatewaySession(
         }
       }
 
-    private fun persistBootstrapHandoffToken(
-      deviceId: String,
-      role: String,
-      token: String,
-      scopes: List<String>,
-    ) {
-      val filteredScopes = filteredBootstrapHandoffScopes(role, scopes) ?: return
-      deviceAuthStore.saveToken(target.endpoint.stableId, deviceId, role, token, filteredScopes)
-    }
-
     private fun persistIssuedDeviceToken(
       authSource: GatewayConnectAuthSource,
       deviceId: String,
       role: String,
       token: String,
       scopes: List<String>,
-    ) {
-      if (authSource == GatewayConnectAuthSource.BOOTSTRAP_TOKEN) {
-        if (!shouldPersistBootstrapHandoffTokens(authSource)) return
-        persistBootstrapHandoffToken(deviceId, role, token, scopes)
-        return
-      }
-      deviceAuthStore.saveToken(target.endpoint.stableId, deviceId, role, token, scopes)
+    ): Boolean {
+      val persistedScopes =
+        if (authSource == GatewayConnectAuthSource.BOOTSTRAP_TOKEN) {
+          if (!shouldPersistBootstrapHandoffTokens(authSource)) return false
+          filteredBootstrapHandoffScopes(role, scopes) ?: return false
+        } else {
+          scopes
+        }
+      return deviceAuthStore.saveToken(target.endpoint.stableId, deviceId, role, token, persistedScopes)
     }
 
     private fun parseConnectSuccess(
@@ -1516,14 +1526,17 @@ class GatewaySession(
           .asArrayOrNull()
           ?.mapNotNull { it.asStringOrNull() }
           ?: emptyList()
+      val persistedRoles = mutableMapOf<String, Boolean>()
       if (!deviceToken.isNullOrBlank()) {
         // Hello scopes describe this socket. Reissuing the same stored token must not narrow its
         // reusable grant metadata, while a rotated token starts with the live approved scopes.
         val sameStoredTokenRecord =
-          deviceToken.trim() == selectedAuth.storedToken &&
+          selectedAuth.authSource != GatewayConnectAuthSource.BOOTSTRAP_TOKEN &&
+            deviceToken.trim() == selectedAuth.storedToken &&
             authRole.trim().equals(target.options.role.trim(), ignoreCase = true)
         val persistedScopes = if (sameStoredTokenRecord) selectedAuth.storedScopes else authScopes
-        persistIssuedDeviceToken(selectedAuth.authSource, deviceId, authRole, deviceToken, persistedScopes)
+        persistedRoles[authRole.trim()] =
+          persistIssuedDeviceToken(selectedAuth.authSource, deviceId, authRole, deviceToken, persistedScopes)
       }
       if (shouldPersistBootstrapHandoffTokens(selectedAuth.authSource)) {
         // Bootstrap connects can mint role-specific device tokens; store only locally trusted handoffs.
@@ -1540,9 +1553,26 @@ class GatewaySession(
                 ?.mapNotNull { it.asStringOrNull() }
                 ?: emptyList()
             if (!handoffToken.isNullOrBlank() && !handoffRole.isNullOrBlank()) {
-              persistBootstrapHandoffToken(deviceId, handoffRole, handoffToken, handoffScopes)
+              persistedRoles[handoffRole.trim()] =
+                persistIssuedDeviceToken(selectedAuth.authSource, deviceId, handoffRole, handoffToken, handoffScopes)
             }
           }
+      }
+      if (target.recoveringStoredBootstrap && selectedAuth.authSource == GatewayConnectAuthSource.DEVICE_TOKEN) {
+        // A successful stored-node hello validates legacy recovery. Recommit both saved
+        // roles before retiring its rejected bootstrap; this is never a fresh-setup path.
+        for (role in listOf("node", "operator")) {
+          if (role in persistedRoles) continue
+          val entry = deviceAuthStore.loadEntry(target.endpoint.stableId, deviceId, role) ?: continue
+          persistedRoles[role] = deviceAuthStore.saveToken(target.endpoint.stableId, deviceId, role, entry.token, entry.scopes)
+        }
+      }
+      if (persistedRoles["node"] == true && persistedRoles["operator"] == true) {
+        synchronized(lifecycleLock) {
+          if (desired === target && currentConnection === this && target.bootstrapHandoff?.complete() == true) {
+            target.bootstrapToken = null
+          }
+        }
       }
       val rawPluginSurfaceUrls = obj["pluginSurfaceUrls"].asObjectOrNull()
       val normalizedPluginSurfaceUrls =
@@ -2088,7 +2118,7 @@ class GatewaySession(
       explicitGatewayToken
         ?: if (
           explicitPassword == null &&
-          (explicitBootstrapToken == null || storedToken != null)
+          explicitBootstrapToken == null
         ) {
           storedToken
         } else {
@@ -2154,13 +2184,14 @@ class GatewaySession(
     target: DesiredConnection,
     error: ErrorShape,
   ): Boolean =
-    shouldPauseGatewayReconnectAfterAuthFailure(
-      error = error,
-      hasBootstrapToken = target.bootstrapToken?.trim()?.isNotEmpty() == true,
-      role = target.options.role,
-      scopes = target.options.scopes,
-      pendingDeviceTokenRetry = target.pendingDeviceTokenRetry,
-    )
+    !(target.recoveringStoredBootstrap && error.details?.code == "AUTH_BOOTSTRAP_TOKEN_INVALID") &&
+      shouldPauseGatewayReconnectAfterAuthFailure(
+        error = error,
+        hasBootstrapToken = target.bootstrapToken?.trim()?.isNotEmpty() == true,
+        role = target.options.role,
+        scopes = target.options.scopes,
+        pendingDeviceTokenRetry = target.pendingDeviceTokenRetry,
+      )
 
   private fun shouldClearStoredDeviceTokenAfterRetry(error: ErrorShape): Boolean = error.details?.code == "AUTH_DEVICE_TOKEN_MISMATCH"
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -28,6 +28,7 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -588,6 +589,9 @@ class GatewayBootstrapAuthTest {
     assertNull(auth.token)
     assertEquals("setup-bootstrap-token", auth.bootstrapToken)
     assertNull(auth.password)
+    assertFalse(auth.bootstrapHandoff!!.allowStoredTokenRecovery)
+    prefs.saveGatewayCredentials(endpoint.stableId, bootstrapToken = "setup-bootstrap-token")
+    assertTrue(runtime.resolveGatewayConnectAuth(endpoint).bootstrapHandoff!!.allowStoredTokenRecovery)
   }
 
   @Test
@@ -914,6 +918,30 @@ class GatewayBootstrapAuthTest {
     assertNull(prompt.fingerprintSha256)
     assertEquals(GatewayTlsProbeFailure.TLS_HANDSHAKE_TIMEOUT, prompt.probeFailure)
   }
+
+  @Test
+  fun authResetInvalidatesHandoffBeforeWaitingForConnectionCleanup() =
+    runBlocking {
+      val (_, prefs, runtime) = gatewayFixture()
+      val endpoint = gatewayEndpoint()
+      prefs.setManualTls(false)
+      prefs.saveGatewayCredentials(endpoint.stableId, bootstrapToken = "setup")
+      assertTrue(runtime.connectSwitchingGateway(endpoint, auth(bootstrapToken = "setup")))
+      val desired = waitForDesiredConnection(runtime, "nodeSession")
+      val handoff = readField<ai.openclaw.app.gateway.GatewayBootstrapHandoff>(desired, "bootstrapHandoff")
+      val switchMutex = readField<Mutex>(runtime, "gatewaySwitchMutex")
+      switchMutex.lock()
+      val reset = async(start = CoroutineStart.UNDISPATCHED) { runtime.resetGatewaySetupAuth(endpoint.stableId) }
+      try {
+        assertFalse(reset.isCompleted)
+        assertFalse(handoff.complete())
+        assertEquals("setup", prefs.loadGatewayCredentials(endpoint.stableId).bootstrapToken)
+      } finally {
+        switchMutex.unlock()
+      }
+      assertTrue(reset.await())
+      assertNull(prefs.loadGatewayCredentials(endpoint.stableId).bootstrapToken)
+    }
 
   @Test
   fun resetGatewaySetupAuth_clearsOnlyTargetGatewayCredentialsAndDeviceTokens() =

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
@@ -2,6 +2,7 @@ package ai.openclaw.app
 
 import ai.openclaw.app.gateway.DeviceAuthStore
 import ai.openclaw.app.gateway.DeviceIdentityStore
+import ai.openclaw.app.gateway.GatewayBootstrapHandoff
 import ai.openclaw.app.gateway.GatewayConnectOptions
 import ai.openclaw.app.gateway.GatewayEndpoint
 import ai.openclaw.app.gateway.GatewayRegistryEntryKind
@@ -1110,7 +1111,7 @@ class NodeForegroundServiceTest {
                   return this
                 }
 
-                override fun apply() {
+                override fun commit(): Boolean {
                   if (savesOperatorToken) {
                     operatorTokenWriteGate?.let { gate ->
                       if (gate.claimed.compareAndSet(false, true)) {
@@ -1119,8 +1120,9 @@ class NodeForegroundServiceTest {
                       }
                     }
                   }
-                  editor.apply()
-                  operatorToken?.let { operatorTokenWrites.trySend(it) }
+                  val committed = editor.commit()
+                  if (committed) operatorToken?.let { operatorTokenWrites.trySend(it) }
+                  return committed
                 }
               }
             }
@@ -1250,6 +1252,7 @@ class NodeForegroundServiceTest {
       password: String?,
       options: GatewayConnectOptions,
       tls: GatewayTlsParams?,
+      bootstrapHandoff: GatewayBootstrapHandoff?,
     ) {
       connectStarted?.complete(Unit)
       Shadow
@@ -1266,6 +1269,7 @@ class NodeForegroundServiceTest {
         ReflectionHelpers.ClassParameter.from(String::class.java, password),
         ReflectionHelpers.ClassParameter.from(GatewayConnectOptions::class.java, options),
         ReflectionHelpers.ClassParameter.from(GatewayTlsParams::class.java, tls),
+        ReflectionHelpers.ClassParameter.from(GatewayBootstrapHandoff::class.java, bootstrapHandoff),
       )
     }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/DeviceAuthStoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/DeviceAuthStoreTest.kt
@@ -1,8 +1,11 @@
 package ai.openclaw.app.gateway
 
+import ai.openclaw.app.GatewayCredentials
 import ai.openclaw.app.SecurePrefs
 import android.content.Context
+import android.content.SharedPreferences
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -17,21 +20,17 @@ import java.util.UUID
 class DeviceAuthStoreTest {
   @Test
   fun saveTokenPersistsNormalizedScopesMetadata() {
-    val app = RuntimeEnvironment.getApplication()
-    val securePrefs =
-      app.getSharedPreferences(
-        "openclaw.node.secure.test.${UUID.randomUUID()}",
-        Context.MODE_PRIVATE,
-      )
-    val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+    val (prefs) = createPrefs()
     val store = DeviceAuthStore(prefs)
 
-    store.saveToken(
-      gatewayId = "gateway-a",
-      deviceId = " Device-1 ",
-      role = " Operator ",
-      token = " operator-token ",
-      scopes = listOf("operator.write", "operator.read", "operator.write", " "),
+    assertTrue(
+      store.saveToken(
+        gatewayId = "gateway-a",
+        deviceId = " Device-1 ",
+        role = " Operator ",
+        token = " operator-token ",
+        scopes = listOf("operator.write", "operator.read", "operator.write", " "),
+      ),
     )
 
     val entry = store.loadEntry("gateway-a", "device-1", "operator")
@@ -44,13 +43,7 @@ class DeviceAuthStoreTest {
 
   @Test
   fun gatewayIdsIsolateSameDeviceAndRole() {
-    val app = RuntimeEnvironment.getApplication()
-    val securePrefs =
-      app.getSharedPreferences(
-        "openclaw.node.secure.test.${UUID.randomUUID()}",
-        Context.MODE_PRIVATE,
-      )
-    val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+    val (prefs) = createPrefs()
     val store = DeviceAuthStore(prefs)
     store.saveToken("gateway-a", "device-1", "operator", "token-a")
     store.saveToken("gateway-b", "device-1", "operator", "token-b")
@@ -62,5 +55,124 @@ class DeviceAuthStoreTest {
 
     assertEquals(null, store.loadToken("gateway-a", "device-1", "operator"))
     assertEquals("token-b", store.loadToken("gateway-b", "device-1", "operator"))
+  }
+
+  @Test
+  fun failedTokenCommitRestoresBothTokenAndMetadata() {
+    for (hasPreviousToken in listOf(false, true)) {
+      val (prefs, securePrefs) = createPrefs()
+      val store = DeviceAuthStore(prefs)
+      if (hasPreviousToken) {
+        assertTrue(store.saveToken("gateway-a", "device-1", "operator", "old-token", listOf("operator.read")))
+      }
+      val previousEntry = store.loadEntry("gateway-a", "device-1", "operator")
+      val previousValues = securePrefs.all.toMap()
+
+      securePrefs.failNextCommit = true
+      assertFalse(store.saveToken("gateway-a", "device-1", "operator", "replacement-token", listOf("operator.write")))
+
+      assertEquals(previousEntry, store.loadEntry("gateway-a", "device-1", "operator"))
+      assertEquals(previousValues, securePrefs.all)
+      assertEquals(
+        previousEntry,
+        DeviceAuthStore(SecurePrefs(RuntimeEnvironment.getApplication(), securePrefs)).loadEntry("gateway-a", "device-1", "operator"),
+      )
+    }
+  }
+
+  @Test
+  fun failedBootstrapRetirementRetainsCredentialsUntilDurableRetry() {
+    val (prefs, securePrefs) = createPrefs()
+    val credentials = GatewayCredentials(token = "shared-token", bootstrapToken = "bootstrap-token", password = "password")
+    prefs.saveGatewayCredentials("gateway-a", credentials)
+    val handoff = prefs.prepareGatewayBootstrapHandoff("gateway-a", "bootstrap-token", allowStoredTokenRecovery = false)
+
+    securePrefs.failNextCommit = true
+    assertFalse(handoff.complete())
+    assertFalse(handoff.completed)
+    assertEquals(credentials, prefs.loadGatewayCredentials("gateway-a"))
+    assertEquals(
+      credentials,
+      SecurePrefs(RuntimeEnvironment.getApplication(), securePrefs).loadGatewayCredentials("gateway-a"),
+    )
+
+    assertTrue(handoff.complete())
+    assertTrue(handoff.completed)
+    assertEquals(credentials.copy(bootstrapToken = null), prefs.loadGatewayCredentials("gateway-a"))
+  }
+
+  @Test
+  fun newerCredentialIntentFencesBootstrapRetirement() {
+    val credentials = GatewayCredentials(token = "shared-token", bootstrapToken = "bootstrap-token", password = "password")
+    for (replacement in listOf("same-value save", "reset", "reset and same-value save", "intent invalidation")) {
+      val (prefs) = createPrefs()
+      prefs.saveGatewayCredentials("gateway-a", credentials)
+      val handoff = prefs.prepareGatewayBootstrapHandoff("gateway-a", "bootstrap-token", allowStoredTokenRecovery = false)
+      when (replacement) {
+        "same-value save" -> {
+          prefs.saveGatewayCredentials("gateway-a", credentials)
+        }
+
+        "reset" -> {
+          prefs.clearGatewayCredentials("gateway-a")
+        }
+
+        "reset and same-value save" -> {
+          prefs.clearGatewayCredentials("gateway-a")
+          prefs.saveGatewayCredentials("gateway-a", credentials)
+        }
+
+        "intent invalidation" -> {
+          handoff.invalidate()
+        }
+      }
+
+      assertFalse(replacement, handoff.complete())
+      assertFalse(replacement, handoff.completed)
+      assertEquals(
+        replacement,
+        if (replacement == "reset") GatewayCredentials() else credentials,
+        prefs.loadGatewayCredentials("gateway-a"),
+      )
+    }
+  }
+
+  @Test
+  fun handoffCannotRetireDifferentSavedBootstrap() {
+    val (prefs) = createPrefs()
+    val credentials = GatewayCredentials(bootstrapToken = "saved-bootstrap")
+    prefs.saveGatewayCredentials("gateway-a", credentials)
+    val handoff = prefs.prepareGatewayBootstrapHandoff("gateway-a", "different-bootstrap", allowStoredTokenRecovery = false)
+
+    assertFalse(handoff.complete())
+    assertEquals(credentials, prefs.loadGatewayCredentials("gateway-a"))
+  }
+
+  private fun createPrefs(): Pair<SecurePrefs, CommitControlledSharedPreferences> {
+    val app = RuntimeEnvironment.getApplication()
+    val securePrefs =
+      CommitControlledSharedPreferences(
+        app.getSharedPreferences("openclaw.node.secure.test.${UUID.randomUUID()}", Context.MODE_PRIVATE),
+      )
+    return SecurePrefs(app, securePrefsOverride = securePrefs) to securePrefs
+  }
+
+  private class CommitControlledSharedPreferences(
+    private val delegate: SharedPreferences,
+  ) : SharedPreferences by delegate {
+    var failNextCommit = false
+
+    override fun edit(): SharedPreferences.Editor {
+      val editor = delegate.edit()
+      return object : SharedPreferences.Editor by editor {
+        override fun commit(): Boolean {
+          if (!failNextCommit) return editor.commit()
+          failNextCommit = false
+          // Android publishes memory before attempting the disk write, even when commit fails.
+          editor.apply()
+          return false
+        }
+      }
+    }
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionCustomHeadersTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionCustomHeadersTest.kt
@@ -55,7 +55,7 @@ private class NoopDeviceAuthStore : DeviceAuthTokenStore {
     role: String,
     token: String,
     scopes: List<String>,
-  ) = Unit
+  ) = true
 
   override fun clearToken(
     gatewayId: String,

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -1,7 +1,9 @@
 package ai.openclaw.app.gateway
 
+import ai.openclaw.app.SecurePrefs
 import ai.openclaw.app.chat.ChatWidgetUrlResolver
 import ai.openclaw.app.node.NodeHostStatsReporter
+import android.content.Context
 import android.util.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
@@ -13,6 +15,7 @@ import kotlinx.coroutines.ThreadContextElement
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -43,6 +46,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLog
+import java.util.UUID
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -60,6 +64,7 @@ private const val CONNECT_CHALLENGE_FRAME =
 
 private class InMemoryDeviceAuthStore : DeviceAuthTokenStore {
   private val tokens = mutableMapOf<String, DeviceAuthEntry>()
+  var saveResult: (String, String) -> Boolean = { _, _ -> true }
 
   override fun loadEntry(
     gatewayId: String,
@@ -73,7 +78,8 @@ private class InMemoryDeviceAuthStore : DeviceAuthTokenStore {
     role: String,
     token: String,
     scopes: List<String>,
-  ) {
+  ): Boolean {
+    if (!saveResult(role, token)) return false
     tokens["${gatewayId.trim()}|${deviceId.trim()}|${role.trim()}"] =
       DeviceAuthEntry(
         token = token.trim(),
@@ -81,6 +87,7 @@ private class InMemoryDeviceAuthStore : DeviceAuthTokenStore {
         scopes = scopes,
         updatedAtMs = System.currentTimeMillis(),
       )
+    return true
   }
 
   override fun clearToken(
@@ -133,7 +140,7 @@ private class RpcCallbackEntryGate :
 private data class NodeHarness(
   val session: GatewaySession,
   val sessionJob: Job,
-  val deviceAuthStore: InMemoryDeviceAuthStore,
+  val deviceAuthStore: DeviceAuthTokenStore,
 )
 
 private data class InvokeScenarioResult(
@@ -773,7 +780,7 @@ class GatewaySessionInvokeTest {
     }
 
   @Test
-  fun connect_prefersStoredDeviceTokenOverBootstrapToken() =
+  fun connect_prefersFreshBootstrapTokenOverStoredDeviceToken() =
     runBlocking {
       val json = testJson()
       val connected = CompletableDeferred<Unit>()
@@ -811,8 +818,8 @@ class GatewaySessionInvokeTest {
         awaitConnectedOrThrow(connected, lastDisconnect, server)
 
         val auth = withTimeout(TEST_TIMEOUT_MS) { connectAuth.await() }
-        assertEquals("device-token", auth?.get("token")?.jsonPrimitive?.content)
-        assertNull(auth?.get("bootstrapToken"))
+        assertEquals("bootstrap-token", auth?.get("bootstrapToken")?.jsonPrimitive?.content)
+        assertNull(auth?.get("token"))
       } finally {
         shutdownHarness(harness, server)
       }
@@ -1125,6 +1132,226 @@ class GatewaySessionInvokeTest {
         )
       } finally {
         shutdownHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun bootstrapHandoff_reconnectsAndRelaunchesOnlyAfterDurableRoles() =
+    runBlocking {
+      val prefs = testPrefs(RuntimeEnvironment.getApplication())
+      val store = DeviceAuthStore(prefs)
+      val authFrames = Channel<JsonObject>(Channel.UNLIMITED)
+      val server =
+        startGatewayServer(testJson()) { socket, id, method, frame ->
+          if (method == "connect") {
+            authFrames.trySend(frame["params"]!!.jsonObject["auth"]!!.jsonObject)
+            socket.send(
+              connectResponseFrame(
+                id,
+                authJson =
+                  """{"deviceToken":"new-node","role":"node","scopes":[],"deviceTokens":[{"deviceToken":"new-operator","role":"operator","scopes":["operator.read"]}]}""",
+              ),
+            )
+          }
+        }
+      val gatewayId = gatewayIdForPort(server.port)
+      prefs.saveGatewayCredentials(gatewayId, bootstrapToken = "setup")
+      var harness: NodeHarness? = null
+      try {
+        repeat(2) { launch ->
+          val connected = CompletableDeferred<Unit>()
+          val disconnected = AtomicReference("")
+          val current = createNodeHarness(connected, disconnected, deviceAuthStore = store) { GatewaySession.InvokeResult.ok(null) }
+          harness = current
+          val bootstrap = prefs.loadGatewayCredentials(gatewayId).bootstrapToken
+          connectNodeSession(
+            current.session,
+            server.port,
+            token = null,
+            bootstrapToken = bootstrap,
+            bootstrapHandoff = bootstrap?.let { prefs.prepareGatewayBootstrapHandoff(gatewayId, it, false) },
+          )
+          val auth = withTimeout(TEST_TIMEOUT_MS) { authFrames.receive() }
+          assertEquals(if (launch == 0) "setup" else "new-node", auth[if (launch == 0) "bootstrapToken" else "token"]?.jsonPrimitive?.content)
+          awaitConnectedOrThrow(connected, disconnected, server)
+          assertNull(prefs.loadGatewayCredentials(gatewayId).bootstrapToken)
+          current.session.reconnect()
+          val reconnectAuth = withTimeout(TEST_TIMEOUT_MS) { authFrames.receive() }
+          assertEquals("new-node", reconnectAuth["token"]?.jsonPrimitive?.content)
+          assertNull(reconnectAuth["bootstrapToken"])
+          current.session.disconnectAndJoin()
+          current.sessionJob.cancelAndJoin()
+          harness = null
+        }
+      } finally {
+        harness?.let {
+          it.session.disconnectAndJoin()
+          it.sessionJob.cancelAndJoin()
+        }
+        server.shutdown()
+      }
+    }
+
+  @Test
+  fun bootstrapHandoff_retainsBootstrapForMissingOrFailedFinalRoleWrites() =
+    runBlocking {
+      for (failure in listOf("node", "operator", "missing-operator", "duplicate-operator")) {
+        val prefs = testPrefs(RuntimeEnvironment.getApplication())
+        val store = InMemoryDeviceAuthStore()
+        val connected = CompletableDeferred<Unit>()
+        val disconnected = AtomicReference("")
+        val authFrames = Channel<JsonObject>(Channel.UNLIMITED)
+        val operatorTokens =
+          when (failure) {
+            "missing-operator" -> "[]"
+            "duplicate-operator" -> """[{"deviceToken":"new-operator","role":"operator","scopes":[]},{"deviceToken":"failed-operator","role":"operator","scopes":[]}]"""
+            else -> """[{"deviceToken":"new-operator","role":"operator","scopes":[]}]"""
+          }
+        val server =
+          startGatewayServer(testJson()) { socket, id, method, frame ->
+            if (method == "connect") {
+              authFrames.trySend(frame["params"]!!.jsonObject["auth"]!!.jsonObject)
+              socket.send(
+                connectResponseFrame(
+                  id,
+                  authJson =
+                    """{"deviceToken":"new-node","role":"node","scopes":[],"deviceTokens":$operatorTokens}""",
+                ),
+              )
+            }
+          }
+        val gatewayId = gatewayIdForPort(server.port)
+        val deviceId = testDeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
+        for (role in listOf("node", "operator")) store.saveToken(gatewayId, deviceId, role, "old-$role")
+        store.saveResult = { role, token -> role != failure && token != "failed-operator" }
+        prefs.saveGatewayCredentials(gatewayId, bootstrapToken = "setup")
+        val handoff = prefs.prepareGatewayBootstrapHandoff(gatewayId, "setup", false)
+        val harness = createNodeHarness(connected, disconnected, deviceAuthStore = store) { GatewaySession.InvokeResult.ok(null) }
+        try {
+          connectNodeSession(harness.session, server.port, token = null, bootstrapToken = "setup", bootstrapHandoff = handoff)
+          withTimeout(TEST_TIMEOUT_MS) { authFrames.receive() }
+          awaitConnectedOrThrow(connected, disconnected, server)
+          assertFalse(failure, handoff.completed)
+          assertEquals(failure, "setup", prefs.loadGatewayCredentials(gatewayId).bootstrapToken)
+          harness.session.reconnect()
+          val retry = withTimeout(TEST_TIMEOUT_MS) { authFrames.receive() }
+          assertEquals(failure, "setup", retry["bootstrapToken"]?.jsonPrimitive?.content)
+          assertNull(retry["token"])
+        } finally {
+          shutdownHarness(harness, server)
+        }
+      }
+    }
+
+  @Test
+  fun bootstrapHandoff_cannotRetireAfterNewSetupOrDisconnectDuringRoleWrite() =
+    runBlocking {
+      for (replacement in listOf(true, false)) {
+        val prefs = testPrefs(RuntimeEnvironment.getApplication())
+        val store = InMemoryDeviceAuthStore()
+        val connected = CompletableDeferred<Unit>()
+        val disconnected = AtomicReference("")
+        val authFrames = Channel<JsonObject>(Channel.UNLIMITED)
+        val retired = CompletableDeferred<Unit>()
+        val attempts = AtomicInteger()
+        val server =
+          startGatewayServer(testJson()) { socket, id, method, frame ->
+            if (method == "connect") {
+              authFrames.trySend(frame["params"]!!.jsonObject["auth"]!!.jsonObject)
+              val auth =
+                if (attempts.incrementAndGet() == 1) {
+                  """{"deviceToken":"new-node","role":"node","scopes":[],"deviceTokens":[{"deviceToken":"new-operator","role":"operator","scopes":[]}]}"""
+                } else {
+                  null
+                }
+              socket.send(connectResponseFrame(id, authJson = auth))
+            }
+          }
+        val gatewayId = gatewayIdForPort(server.port)
+        prefs.saveGatewayCredentials(gatewayId, bootstrapToken = "setup")
+        val oldHandoff = prefs.prepareGatewayBootstrapHandoff(gatewayId, "setup", false)
+        val harness = createNodeHarness(connected, disconnected, deviceAuthStore = store) { GatewaySession.InvokeResult.ok(null) }
+        store.saveResult = { role, _ ->
+          if (role == "operator") {
+            if (replacement) {
+              prefs.saveGatewayCredentials(gatewayId, bootstrapToken = "new-setup")
+              connectNodeSession(
+                harness.session,
+                server.port,
+                token = null,
+                bootstrapToken = "new-setup",
+                bootstrapHandoff = prefs.prepareGatewayBootstrapHandoff(gatewayId, "new-setup", false),
+              )
+            } else {
+              harness.session.disconnect()
+            }
+            retired.complete(Unit)
+          }
+          true
+        }
+        try {
+          connectNodeSession(harness.session, server.port, token = null, bootstrapToken = "setup", bootstrapHandoff = oldHandoff)
+          withTimeout(TEST_TIMEOUT_MS) {
+            authFrames.receive()
+            retired.await()
+          }
+          if (replacement) {
+            val next = withTimeout(TEST_TIMEOUT_MS) { authFrames.receive() }
+            assertEquals("new-setup", next["bootstrapToken"]?.jsonPrimitive?.content)
+            awaitConnectedOrThrow(connected, disconnected, server)
+          }
+          harness.session.disconnectAndJoin()
+          assertFalse(oldHandoff.completed)
+          assertEquals(if (replacement) "new-setup" else "setup", prefs.loadGatewayCredentials(gatewayId).bootstrapToken)
+        } finally {
+          shutdownHarness(harness, server)
+        }
+      }
+    }
+
+  @Test
+  fun savedBootstrapRecovery_neverOverridesExplicitSetupOrMissingRole() =
+    runBlocking {
+      for ((explicit, hasOperator) in listOf(false to true, true to true, false to false)) {
+        val prefs = testPrefs(RuntimeEnvironment.getApplication())
+        val store = InMemoryDeviceAuthStore()
+        val connected = CompletableDeferred<Unit>()
+        val disconnected = AtomicReference("")
+        val authFrames = Channel<JsonObject>(Channel.UNLIMITED)
+        val attempts = AtomicInteger()
+        val server =
+          startGatewayServer(testJson()) { socket, id, method, frame ->
+            if (method == "connect") {
+              authFrames.trySend(frame["params"]!!.jsonObject["auth"]!!.jsonObject)
+              if (attempts.incrementAndGet() == 1) {
+                socket.send("""{"type":"res","id":"$id","ok":false,"error":{"code":"UNAUTHORIZED","message":"bootstrap token invalid or expired","details":{"code":"AUTH_BOOTSTRAP_TOKEN_INVALID"}}}""")
+              } else {
+                socket.send(connectResponseFrame(id, authJson = """{"deviceToken":"old-node","role":"node","scopes":[]}"""))
+              }
+            }
+          }
+        val gatewayId = gatewayIdForPort(server.port)
+        val deviceId = testDeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
+        store.saveToken(gatewayId, deviceId, "node", "old-node")
+        if (hasOperator) store.saveToken(gatewayId, deviceId, "operator", "old-operator")
+        prefs.saveGatewayCredentials(gatewayId, bootstrapToken = "setup")
+        val handoff = prefs.prepareGatewayBootstrapHandoff(gatewayId, "setup", !explicit)
+        val harness = createNodeHarness(connected, disconnected, deviceAuthStore = store) { GatewaySession.InvokeResult.ok(null) }
+        try {
+          connectNodeSession(harness.session, server.port, token = null, bootstrapToken = "setup", bootstrapHandoff = handoff)
+          assertEquals("setup", withTimeout(TEST_TIMEOUT_MS) { authFrames.receive() }["bootstrapToken"]?.jsonPrimitive?.content)
+          withTimeout(TEST_TIMEOUT_MS) { while (!disconnected.get().contains("bootstrap token invalid")) yield() }
+          harness.session.reconnect()
+          val retry = withTimeout(TEST_TIMEOUT_MS) { authFrames.receive() }
+          val recovered = !explicit && hasOperator
+          assertEquals(if (recovered) "old-node" else null, retry["token"]?.jsonPrimitive?.content)
+          assertEquals(if (recovered) null else "setup", retry["bootstrapToken"]?.jsonPrimitive?.content)
+          awaitConnectedOrThrow(connected, disconnected, server)
+          assertEquals(recovered, handoff.completed)
+          assertEquals(if (recovered) null else "setup", prefs.loadGatewayCredentials(gatewayId).bootstrapToken)
+        } finally {
+          shutdownHarness(harness, server)
+        }
       }
     }
 
@@ -1744,6 +1971,8 @@ class GatewaySessionInvokeTest {
 
   private fun testJson(): Json = Json { ignoreUnknownKeys = true }
 
+  private fun testPrefs(context: Context): SecurePrefs = SecurePrefs(context, context.getSharedPreferences("handoff-test-${UUID.randomUUID()}", Context.MODE_PRIVATE))
+
   private fun JsonObject.scopes(): List<String> =
     (this["scopes"] as? JsonArray)
       ?.map { it.jsonPrimitive.content }
@@ -1754,11 +1983,11 @@ class GatewaySessionInvokeTest {
     lastDisconnect: AtomicReference<String>,
     onEvent: (event: String, payloadJson: String?) -> Unit = { _, _ -> },
     extraContext: CoroutineContext = EmptyCoroutineContext,
+    deviceAuthStore: DeviceAuthTokenStore = InMemoryDeviceAuthStore(),
     onInvoke: suspend (GatewaySession.InvokeRequest) -> GatewaySession.InvokeResult,
   ): NodeHarness {
     val app = RuntimeEnvironment.getApplication()
     val sessionJob = SupervisorJob()
-    val deviceAuthStore = InMemoryDeviceAuthStore()
     val session =
       GatewaySession(
         scope = CoroutineScope(sessionJob + Dispatchers.Default + extraContext),
@@ -1777,7 +2006,7 @@ class GatewaySessionInvokeTest {
     return NodeHarness(session = session, sessionJob = sessionJob, deviceAuthStore = deviceAuthStore)
   }
 
-  private suspend fun connectNodeSession(
+  private fun connectNodeSession(
     session: GatewaySession,
     port: Int,
     token: String? = "test-token",
@@ -1785,6 +2014,7 @@ class GatewaySessionInvokeTest {
     role: String = "node",
     scopes: List<String> = listOf("node:invoke"),
     contextPath: String = "",
+    bootstrapHandoff: GatewayBootstrapHandoff? = null,
   ) {
     session.connect(
       endpoint =
@@ -1819,6 +2049,7 @@ class GatewaySessionInvokeTest {
             ),
         ),
       tls = null,
+      bootstrapHandoff = bootstrapHandoff,
     )
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -68,7 +68,7 @@ private class ReconnectDeviceAuthStore(
     role: String,
     token: String,
     scopes: List<String>,
-  ) = Unit
+  ) = true
 
   override fun clearToken(
     gatewayId: String,
@@ -94,10 +94,11 @@ private class BlockingSaveDeviceAuthStore : DeviceAuthTokenStore {
     role: String,
     token: String,
     scopes: List<String>,
-  ) {
+  ): Boolean {
     saveStarted.countDown()
     allowSave.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
     savedToken.complete(token)
+    return true
   }
 
   override fun clearToken(
@@ -122,8 +123,9 @@ private class RecordingDeviceAuthStore : DeviceAuthTokenStore {
     role: String,
     token: String,
     scopes: List<String>,
-  ) {
+  ): Boolean {
     savedToken.complete(token)
+    return true
   }
 
   override fun clearToken(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users supplied a new Gateway setup code but the app silently reused an older stored device token instead. Adopting fresh-bootstrap precedence also requires retiring the consumed setup credential, so reconnect and process relaunch do not submit a spent bootstrap token.

## Why This Change Was Made

Android now follows the shared Swift fresh-bootstrap selection contract. `GatewaySession` records actual durable write results for the node and operator tokens; only successful writes for both roles permit retirement. `SecurePrefs` atomically commits each token with its metadata, removes only the consumed bootstrap from the existing credential bundle, and restores the previous in-memory values when a disk commit fails. Connection-intent invalidation, preference revisions, and session identity fence completion against newer setup/reset requests, including identical replacement token bytes.

Existing installs first submit implicitly loaded saved bootstrap credentials. After `AUTH_BOOTSTRAP_TOKEN_INVALID`, local-network WS or WSS can make a bounded stored-token recovery attempt if both role tokens are present. A successful stored-node hello and durable writes of both entries allow retirement. Explicitly supplied setup credentials never receive that fallback.

## User Impact

New setup codes take the intended pairing path. Successful handoff preserves access through reconnect, process relaunch, and Gateway shared-token rotation. Failed writes retain bootstrap instead of incorrectly reporting a durable handoff.

## Contract Notes

This implements the approved durable-handoff contract in `apps/android/GATEWAY_AUTH_POLICY.md`. Encrypted preference keys and serialized formats, protocol, dependencies, configuration options, and UI appearance are unchanged. Intent revisions are in memory only. Existing password/bootstrap ordering, stored-scope behavior, shared-token retry rules, and operator-startup policy remain documented platform differences.

The Gateway does not distinguish consumed, expired, and invalid bootstrap tokens; recovery is therefore explicitly restricted to saved-credential rejection. Normal setup replacement drains and clears old role tokens before saving new credentials. No compatibility alias, schema bump, release, or Google Play upload is included.

## Evidence

- The updated existing wire regression failed on unchanged Android production code (`expected bootstrap-token but was null`) and passes with the repair.
- Wire/store/runtime coverage includes both-role handoff, failed durable writes, duplicate role issuance, reconnect/relaunch, newer setup/disconnect/reset intents, same-value setup saves, and saved-bootstrap recovery with and without explicit setup input or both stored roles.
- Full app unit suites: Play 2,933 tests and third-party 3,064 tests; zero failures, errors, or skips. Command: `ANDROID_HOME=/opt/homebrew/share/android-commandlinetools node --import ./scripts/tsx.mjs scripts/run-android-gradle.mts :app:testPlayDebugUnitTest :app:testThirdPartyDebugUnitTest`.
- `pnpm android:i18n:check`: passed (1,687 app keys, 4 third-party keys, 122 Wear keys).
- `ANDROID_HOME=/opt/homebrew/share/android-commandlinetools node scripts/check-changed.mjs`: passed, including Android ktlint and unchanged native schema version v16.
- Independent Codex review through P2: clean. The full-suite run found lifecycle fixtures tied to asynchronous `apply()` and the previous connect signature; those adapters now follow the real synchronous commit boundary and exact signature, retaining their assertions. The affected lifecycle suite passes.

Live emulator proof passed on Blacksmith Testbox `tbx_01m1ygm1rtsz5b4808gx5x2v98`, [run](https://github.com/openclaw/openclaw/actions/runs/34150088435). The source-built Play debug APK was installed on Android 16/API 36, serial `emulator-5580`. The Gateway used `OPENCLAW_STATE_DIR=/home/runner/openclaw-L21-android-proof/gateway-state`, free port `57867`, and `gateway.nodes.pairing.autoApproveCidrs` restricted to loopback. The lease, emulator, and Gateway were stopped after collecting the evidence.

| Real flow | Gateway-observed node auth | Gateway-observed operator auth |
| --- | --- | --- |
| Fresh install; enter setup code through onboarding | `bootstrap-token` | `device-token` |
| Force-stop and relaunch the app | `device-token` | `device-token` |
| Rotate the Gateway shared token and restart the isolated Gateway | `device-token` | `device-token` |

The complete Gateway log contained **zero bootstrap rejections**. Relaunch therefore used the completed stored-token handoff directly. Explicit shared-token retry behavior remains covered by the gateway wire suite. These screenshots show the synthetic test Gateway; its Overview reports Gateway **Online** and node **1/1**. The broader test Gateway still displays “Needs attention”; no model conversation was part of this auth proof.

Commands included:

```sh
# Inside the task-owned Testbox through scripts/crabbox-wrapper.mjs:
node --import ./scripts/tsx.mjs scripts/run-android-gradle.mts :app:assemblePlayDebug
adb -s emulator-5580 install -r apps/android/app/build/outputs/apk/play/debug/openclaw-2026.8.2-debug-play-debug.apk
adb -s emulator-5580 reverse tcp:57867 tcp:57867
OPENCLAW_STATE_DIR=/home/runner/openclaw-L21-android-proof/gateway-state pnpm openclaw gateway run --port 57867 --bind loopback --ws-log compact --verbose
adb -s emulator-5580 shell am start -n ai.openclaw.app.debug/ai.openclaw.app.MainActivity
# Entered the generated setup code through the real onboarding UI.
adb -s emulator-5580 shell am force-stop ai.openclaw.app.debug
adb -s emulator-5580 shell am start -n ai.openclaw.app.debug/ai.openclaw.app.MainActivity
adb -s emulator-5580 exec-out screencap -p
```

The wrapper reported portal-sync warnings after successful remote commands; those warnings did not change the observed build or live result. The initial install attempt used the wrong default APK filename, then the versioned output was installed and verified successfully. No Google Play upload occurred.

**Fresh pairing**

![Fresh pairing](https://github.com/user-attachments/assets/feb32a35-f7d5-468f-92c0-7fad81b8e544)

**After process relaunch**

![After process relaunch](https://github.com/user-attachments/assets/8fe2683d-f286-4e96-bde5-8ad8811b1833)

**After Gateway-token rotation**

![After Gateway-token rotation](https://github.com/user-attachments/assets/29a7fb35-b283-43a9-9008-0f6d6e833282)

<details>
<summary>Live proof invocation</summary>

The SDK and emulator were provisioned on the task lease before this invocation. This reproduces the exact remote shell argument used for install, Gateway startup, UI pairing, relaunch, and token rotation. Tokens and setup codes stay inside the isolated task state.

```sh
node scripts/crabbox-wrapper.mjs run --id tbx_01m1ygm1rtsz5b4808gx5x2v98 --timing-json -- bash -lc "$(cat <<'L21_REMOTE'
source /home/runner/openclaw-L21-android-proof/env.sh
python3 -u - <<'L21_PROOF'
import pathlib, subprocess
apks=list(pathlib.Path('apps/android/app/build/outputs/apk/play/debug').glob('*.apk'))
assert len(apks)==1, 'expected one Play debug APK'
subprocess.run(['adb','-s','emulator-5580','install','-r',str(apks[0])],check=True)
print('installed '+apks[0].name, flush=True)
import json, os, pathlib, secrets, socket, subprocess, time, urllib.request, xml.etree.ElementTree as ET
root=pathlib.Path('/home/runner/openclaw-L21-android-proof')
state=root/'gateway-state'
state.mkdir(exist_ok=True)
(root/'artifacts').mkdir(exist_ok=True)
s=socket.socket(); s.bind(('127.0.0.1',0)); port=s.getsockname()[1]; s.close()
config={'gateway':{'mode':'local','bind':'loopback','port':port,'auth':{'mode':'token','token':secrets.token_urlsafe(32)},'nodes':{'pairing':{'autoApproveCidrs':['127.0.0.1/32','::1/128']}}}}
config_path=state/'openclaw.json'; config_path.write_text(json.dumps(config)); config_path.chmod(0o600)
env=os.environ.copy(); env.update(OPENCLAW_STATE_DIR=str(state), OPENCLAW_CONFIG_PATH=str(config_path), NO_COLOR='1')
log=open(root/'logs/gateway.log','w')
gateway=subprocess.Popen(['pnpm','openclaw','gateway','run','--port',str(port),'--bind','loopback','--ws-log','compact','--verbose'],env=env,stdout=log,stderr=subprocess.STDOUT,start_new_session=True)
(root/'gateway.pid').write_text(str(gateway.pid)); (root/'port').write_text(str(port))
for _ in range(600):
    if gateway.poll() is not None: raise RuntimeError('isolated Gateway exited; inspect task log locally')
    try:
        if urllib.request.urlopen(f'http://127.0.0.1:{port}/health',timeout=1).status==200: break
    except Exception: pass
    time.sleep(1)
else: raise RuntimeError('isolated Gateway readiness timeout')
with open(root/'setup.json','w') as output:
    subprocess.run(['pnpm','openclaw','qr','--url',f'ws://127.0.0.1:{port}','--json'],env=env,stdout=output,stderr=open(root/'logs/qr.log','w'),check=True)
(root/'setup.json').chmod(0o600)
adb=['adb','-s','emulator-5580']
subprocess.run(adb+['reverse',f'tcp:{port}',f'tcp:{port}'],check=True)
subprocess.run(adb+['shell','pm','path','ai.openclaw.app.debug'],check=True)
subprocess.run(adb+['shell','am','start','-n','ai.openclaw.app.debug/ai.openclaw.app.MainActivity'],check=True)
time.sleep(4)
subprocess.run(adb+['shell','uiautomator','dump','/sdcard/l21-ui.xml'],check=True,stdout=subprocess.DEVNULL)
xml=subprocess.check_output(adb+['shell','cat','/sdcard/l21-ui.xml'])
(root/'artifacts/initial.xml').write_bytes(xml)
with open(root/'artifacts/initial.png','wb') as output: subprocess.run(adb+['exec-out','screencap','-p'],stdout=output,check=True)
print(json.dumps({'gateway_ready':True,'port':port,'serial':'emulator-5580','ui':[{'text':n.get('text'),'description':n.get('content-desc'),'bounds':n.get('bounds'),'class':n.get('class')} for n in ET.fromstring(xml).iter('node') if n.get('password')!='true' and (n.get('text') or n.get('content-desc'))]}))

import json, os, pathlib, re, signal, subprocess, time, urllib.request, xml.etree.ElementTree as ET
root=pathlib.Path('/home/runner/openclaw-L21-android-proof')
adb=['adb','-s','emulator-5580']
port=int((root/'port').read_text())
logpath=root/'logs/gateway.log'
ansi=re.compile(r'\x1b\[[0-9;]*[A-Za-z]')
def run(*args): return subprocess.check_output(adb+list(args),stderr=subprocess.STDOUT)
def ui():
    run('shell','uiautomator','dump','/sdcard/l21-ui.xml')
    return ET.fromstring(run('shell','cat','/sdcard/l21-ui.xml'))
def tap_node(node):
    x1,y1,x2,y2=map(int,re.findall(r'\d+',node.get('bounds')))
    run('shell','input','tap',str((x1+x2)//2),str((y1+y2)//2))
def click(text,timeout=20):
    end=time.monotonic()+timeout
    while time.monotonic()<end:
        tree=ui()
        for n in tree.iter('node'):
            if (n.get('text')==text or n.get('content-desc')==text) and n.get('enabled')=='true':
                tap_node(n); time.sleep(0.7); return
        time.sleep(0.5)
    labels=[n.get('text') for n in tree.iter('node') if n.get('text') and n.get('password')!='true']
    raise RuntimeError('control unavailable '+text+'; labels='+repr(labels))
def capture(name):
    with open(root/'artifacts'/f'{name}.png','wb') as output: subprocess.run(adb+['exec-out','screencap','-p'],stdout=output,check=True)
def auth_entries(offset=0):
    lines=ansi.sub('',logpath.read_text(errors='replace')[offset:]).splitlines()
    entries=[]
    for line in lines:
        if 'connect' not in line or 'client=openclaw-android' not in line: continue
        mode=re.search(r'\bmode=([^\s]+)',line); auth=re.search(r'\bauth=([^\s]+)',line)
        if mode and auth: entries.append({'mode':mode.group(1),'auth':auth.group(1)})
    return entries

def wait_roles(offset,expected_node,timeout=90):
    end=time.monotonic()+timeout
    while time.monotonic()<end:
        entries=auth_entries(offset)
        if any(e['mode']=='node' and e['auth']==expected_node for e in entries) and any(e['mode']=='ui' and e['auth']=='device-token' for e in entries): return entries
        time.sleep(1)
    raise RuntimeError('auth sequence not observed: '+repr(auth_entries(offset)))

raw=(root/'setup.json').read_text(); setup=json.loads(raw[raw.index('{'):])['setupCode']
click('Continue'); click('Scan QR or setup code'); click('Enter setup code')
field=next(n for n in ui().iter('node') if n.get('class')=='android.widget.EditText')
tap_node(field); run('shell','input','text',setup); run('shell','input','keyevent','4')
offset=len(logpath.read_text(errors='replace')); click('Use setup code')
sequence={'fresh':wait_roles(offset,'bootstrap-token')}
capture('fresh-paired')
click('Continue')
click('Continue')
time.sleep(3)
capture('onboarding-complete')
offset=len(logpath.read_text(errors='replace'))
run('shell','am','force-stop','ai.openclaw.app.debug')
run('shell','am','start','-n','ai.openclaw.app.debug/ai.openclaw.app.MainActivity')
sequence['relaunch']=wait_roles(offset,'device-token')
time.sleep(2); capture('after-relaunch')
config_path=root/'gateway-state/openclaw.json'; config=json.loads(config_path.read_text())
old_token=config['gateway']['auth']['token']
import secrets
config['gateway']['auth']['token']=secrets.token_urlsafe(32)
old_pid=int((root/'gateway.pid').read_text()); os.killpg(old_pid,signal.SIGTERM)
for _ in range(30):
    try: os.kill(old_pid,0)
    except ProcessLookupError: break
    time.sleep(1)
config_path.write_text(json.dumps(config))
env=os.environ.copy(); env.update(OPENCLAW_STATE_DIR=str(root/'gateway-state'),OPENCLAW_CONFIG_PATH=str(config_path),NO_COLOR='1')
offset=len(logpath.read_text(errors='replace'))
with open(logpath,'a') as log:
    gateway=subprocess.Popen(['pnpm','openclaw','gateway','run','--port',str(port),'--bind','loopback','--ws-log','compact','--verbose'],env=env,stdout=log,stderr=subprocess.STDOUT,start_new_session=True)
(root/'gateway.pid').write_text(str(gateway.pid))
sequence['rotated_gateway_token']=wait_roles(offset,'device-token',120)
time.sleep(2); capture('after-gateway-token-rotation')
(root/'artifacts/auth-sequence.json').write_text(json.dumps(sequence,indent=2))
print(json.dumps({'serial':'emulator-5580','sequence':sequence,'screenshots':['fresh-paired.png','onboarding-complete.png','after-relaunch.png','after-gateway-token-rotation.png']}))

L21_PROOF
L21_REMOTE
)"
```

</details>
