### PR TITLE
docs(ios): correct Watch Rust build prerequisites

### DIFF
--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -52,7 +52,27 @@ build compiles the native Watch WebRTC library. Install the official
 and standard-library sources:
 
 ```bash
-rustup toolchain install nightly-2026-08-31 --profile minimal --component rust-src
+rustup toolchain install nightly-2026-09-05 --profile minimal --component rust-src
+```
+
+Both `rustup` and the rustup-managed `cargo` shim must be on the build's `PATH`.
+If you installed rustup through Homebrew, add its shim directory before running
+a command-line build such as `pnpm ios:build`:
+
+```bash
+export PATH="$(brew --prefix rustup)/bin:$PATH"
+```
+
+On Apple Silicon with the default Homebrew prefix, this directory is
+`/opt/homebrew/opt/rustup/bin`. Having `rustup` in `/opt/homebrew/bin` does not
+mean `cargo` is available. The Watch build phase adds `$HOME/.cargo/bin`,
+`/opt/homebrew/bin`, and `/usr/local/bin`, but not Homebrew's rustup shim directory.
+For GUI-launched Xcode builds, ensure that directory is also in the build
+phase's `PATH`; exporting it in a terminal alone does not configure Xcode.
+Verify the pinned Cargo is reachable from the build environment:
+
+```bash
+cargo +nightly-2026-09-05 --version
 ```
 
 `apps/shared/OpenClawWatchRTC/build.sh` uses that exact toolchain with


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers building the iOS app from source would install an outdated Rust nightly by following the README, then fail while building the embedded Watch companion. Homebrew installations could also expose `rustup` without exposing the `cargo` shim required by the Watch build.

## Why This Change Was Made

The iOS prerequisite instructions now install `nightly-2026-09-05`, matching `apps/shared/OpenClawWatchRTC/build.sh` and the native Watch module README. They document adding `$(brew --prefix rustup)/bin` to the build's `PATH`, explain why finding `rustup` alone is insufficient, and distinguish command-line environment setup from GUI-launched Xcode builds.

This is a prerequisite-documentation correction only. It does not change the pinned compiler, build scripts, Xcode project, release instructions, or runtime behavior.

## User Impact

Developers can install the compiler actually required by the embedded Watch build and make the Homebrew-managed Cargo shim available before building. The README includes a pinned Cargo version probe to check the build environment.

## Evidence

- Verified the compiler pin, required commands, and locked `build-std` invocation against the current Watch build script; the native Watch README already uses the same nightly.
- Verified the Watch prebuild PATH in `apps/ios/project.yml` and the installed Homebrew rustup formula's shim installation and caveats.
- Reproduced `rustup` resolving while `cargo` was absent from PATH. With `$(brew --prefix rustup)/bin` prepended, both `rustup run nightly-2026-09-05 rustc --version` and `cargo +nightly-2026-09-05 --version` succeeded.
- Passed `node scripts/check-changed.mjs -- apps/ios/README.md`, `node scripts/check-docs-mdx.mjs apps/ios/README.md`, and `git diff --check`.
- Verified prerequisite pin consistency, Bash syntax for the changed section's command fences, and the native module README link target.
- Oxfmt intentionally excludes `apps/`, so the scoped check did not format-check this README. No new iOS/Watch build, hardware validation, or release was run for this documentation-only change.
