### PR TITLE
refactor(scripts): use canonical bounded response readers

### DIFF
--- a/scripts/debug-claude-usage.ts
+++ b/scripts/debug-claude-usage.ts
@@ -8,7 +8,7 @@ import { pathToFileURL } from "node:url";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { normalizeOptionalString } from "../packages/normalization-core/src/string-coerce.js";
 import { requireOptionArgument } from "./lib/arg-utils.mts";
-import { readBoundedResponseText as readBoundedResponseTextWithLimit } from "./lib/bounded-response.mjs";
+import { readBoundedResponseText } from "./lib/bounded-response.mjs";
 import {
   maskIdentifier,
   parseStrictIntegerOption,
@@ -177,17 +177,6 @@ const withFetchTimeout = async <T>(
   }
 };
 
-const readBoundedResponseText = (
-  response: Response,
-  label: string,
-  signal: AbortSignal,
-  maxBytes = FETCH_RESPONSE_MAX_BYTES,
-): Promise<string> =>
-  readBoundedResponseTextWithLimit(response, label, maxBytes, {
-    createTooLargeError: (message: string) => new Error(message),
-    signal,
-  });
-
 const fetchText = async (
   label: string,
   url: string,
@@ -198,7 +187,7 @@ const fetchText = async (
   const timeoutMs = options.timeoutMs ?? resolveFetchTimeoutMs();
   return await withFetchTimeout(label, timeoutMs, async (signal) => {
     const res = await fetchImpl(url, { ...init, signal });
-    const text = await readBoundedResponseText(res, label, signal);
+    const text = await readBoundedResponseText(res, label, FETCH_RESPONSE_MAX_BYTES, { signal });
     return { res, text };
   });
 };
@@ -535,10 +524,8 @@ const main = async (argv = process.argv.slice(2)) => {
 
 export const testing = {
   CLAUDE_COOKIE_HOST_SQL,
-  FETCH_RESPONSE_MAX_BYTES,
   fetchAnthropicOAuthUsage,
   parseArgs,
-  readBoundedResponseText,
   resolveFetchTimeoutMs,
 };
 

--- a/scripts/firecrawl-compare.ts
+++ b/scripts/firecrawl-compare.ts
@@ -4,7 +4,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { fetchFirecrawlContent } from "../extensions/firecrawl/api.ts";
 import { formatErrorMessage } from "../src/infra/errors.ts";
 import { extractReadableContent } from "../src/web-fetch/content-extractors.runtime.js";
-import { readBoundedResponseText as readBoundedResponseTextWithLimit } from "./lib/bounded-response.mjs";
+import { readBoundedResponseText } from "./lib/bounded-response.mjs";
 
 const DEFAULT_URLS = [
   "https://en.wikipedia.org/wiki/Web_scraping",
@@ -36,18 +36,6 @@ function truncate(value: string, max = 180): string {
   return value.length > max ? `${truncateUtf16Safe(value, max)}…` : value;
 }
 
-function readBoundedResponseText(
-  response: Response,
-  label: string,
-  signal: AbortSignal,
-  maxBytes = FETCH_HTML_MAX_BYTES,
-): Promise<string> {
-  return readBoundedResponseTextWithLimit(response, label, maxBytes, {
-    createTooLargeError: (message: string) => new Error(message),
-    signal,
-  });
-}
-
 async function fetchHtml(
   url: string,
   options: FetchHtmlOptions = {},
@@ -71,8 +59,8 @@ async function fetchHtml(
     const body = await readBoundedResponseText(
       res,
       "local HTML fetch",
-      controller.signal,
       options.maxBytes ?? FETCH_HTML_MAX_BYTES,
+      { signal: controller.signal },
     );
     return {
       ok: res.ok,

--- a/test/scripts/dev-tooling-safety.test.ts
+++ b/test/scripts/dev-tooling-safety.test.ts
@@ -1136,24 +1136,21 @@ describe("script-specific dev tooling hardening", () => {
   });
 
   it("bounds Claude usage response body reads by content-length", async () => {
-    const maxBytes = claudeUsageTesting.FETCH_RESPONSE_MAX_BYTES;
+    const maxBytes = 256 * 1024;
     const response = new Response("{}", {
       headers: { "content-length": String(maxBytes + 1) },
     });
-    const controller = new AbortController();
 
     await expect(
-      claudeUsageTesting.readBoundedResponseText(
-        response,
-        "Claude usage test",
-        controller.signal,
-        maxBytes,
-      ),
-    ).rejects.toThrow(`Claude usage test response body exceeded ${maxBytes} bytes`);
+      claudeUsageTesting.fetchAnthropicOAuthUsage("test-token", {
+        fetchImpl: async () => response,
+        timeoutMs: 1_000,
+      }),
+    ).rejects.toThrow(`Anthropic OAuth usage request response body exceeded ${maxBytes} bytes`);
   });
 
   it("bounds Claude usage response body reads by streamed bytes", async () => {
-    const maxBytes = claudeUsageTesting.FETCH_RESPONSE_MAX_BYTES;
+    const maxBytes = 256 * 1024;
     const response = new Response(
       new ReadableStream({
         start(controller) {
@@ -1162,16 +1159,13 @@ describe("script-specific dev tooling hardening", () => {
         },
       }),
     );
-    const controller = new AbortController();
 
     await expect(
-      claudeUsageTesting.readBoundedResponseText(
-        response,
-        "Claude usage test",
-        controller.signal,
-        maxBytes,
-      ),
-    ).rejects.toThrow(`Claude usage test response body exceeded ${maxBytes} bytes`);
+      claudeUsageTesting.fetchAnthropicOAuthUsage("test-token", {
+        fetchImpl: async () => response,
+        timeoutMs: 1_000,
+      }),
+    ).rejects.toThrow(`Anthropic OAuth usage request response body exceeded ${maxBytes} bytes`);
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Two diagnostic scripts retain private wrappers around the canonical bounded response reader. Claude's overflow tests call that adapter directly, so they can miss a request caller that accidentally skips bounded reading.

## Why This Change Was Made

Firecrawl comparison and Claude usage now call the shared reader with the same limits and signals. The two Claude overflow cases exercise the existing usage-request function with synthetic responses and an independent 256 KiB expectation; the test-only reader and constant exports disappear.

The former planner follow-up is already covered by merged #141137 and has been removed from this PR. The refreshed branch preserves main's planner fixture, discovery caches, and later assertions unchanged.

## User Impact

Response limits, timeouts, cancellation, returned fields, and displayed errors are unchanged. Raw overflow-error stacks now originate in the shared helper. Authentication, credential discovery, CLI behavior, and production planning policy are untouched. Tooling shrinks by 25 lines and tests by six; no test case is removed.

## Evidence

- Fresh recovery runs pass all 23 selected reader/usage cases before and after. All 52 other safety cases remain unchanged and unselected.
- A deliberate caller bypass still passes both original cap tests and fails both migrated tests because their promises resolve instead of rejecting. The control changes are removed and source hashes verified.
- The current complete planner file passes all 53 tests in original order. Both canonical cron browser cases also pass. These validate the main integration; the planner/UI repairs are not claimed as this PR's contribution.
- Fresh independent residual review is clean through P2, and the exact resulting tree preserves every other main entry.

The refreshed three-file configured changed gate passed all 19 checks on Linux, including both TypeScript graphs and scoped lint. Its one-shot runner stopped normally and the temporary source capsule was removed. The reported remote tree matches the signed candidate tree; a post-success portal synchronization warning is retained separately.
