### PR TITLE
refactor(media): share generation candidate lifecycle

### DIFF
--- a/src/image-generation/runtime.ts
+++ b/src/image-generation/runtime.ts
@@ -1,9 +1,6 @@
 /** Runtime entrypoint for image generation with provider fallback and override normalization. */
-import { describeFailoverError, isFailoverError } from "../agents/failover-error.js";
-import type { FallbackAttempt } from "../agents/model-fallback.types.js";
 import { resolveAgentModelTimeoutMsValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { parseImageGenerationModelRef } from "../media-generation/model-ref.js";
 import {
@@ -13,11 +10,10 @@ import {
 import {
   buildMediaGenerationNormalizationMetadata,
   buildNoCapabilityModelConfiguredMessage,
-  recordCapabilityCandidateFailure,
   resolveCapabilityModelCandidates,
-  resolveReferenceImageCapabilityError,
   resolveMediaProviderRequestTimeoutMs,
-  throwCapabilityGenerationFailure,
+  resolveReferenceImageCapabilityError,
+  runMediaGenerationCandidates,
 } from "../media-generation/runtime-shared.js";
 import { getProviderEnvVars } from "../secrets/provider-env-vars.js";
 import { resolveImageGenerationMaxInputImages } from "./capabilities.js";
@@ -83,145 +79,112 @@ export async function generateImage(
     throw new Error(buildNoImageGenerationModelConfiguredMessage(params.cfg, deps));
   }
 
-  const attempts: FallbackAttempt[] = [];
-  let lastError: unknown;
-
-  // Try configured/fallback models in order and return the first provider whose
-  // entire image batch is present and non-empty; preserve failed attempts for diagnostics.
-  for (const candidate of candidates) {
-    const provider = getProvider(candidate.provider, params.cfg);
-    if (!provider) {
-      const error = `No image-generation provider registered for ${candidate.provider}`;
-      attempts.push({
-        provider: candidate.provider,
-        model: candidate.model,
-        error,
-      });
-      lastError = new Error(error);
+  return runMediaGenerationCandidates({
+    candidates,
+    capability: "image",
+    getProvider: (providerId) => getProvider(providerId, params.cfg),
+    includeSkipFailureDetails: true,
+    onMissingProvider: (attempt) => {
       logger.warn(
-        `image-generation candidate failed: ${candidate.provider}/${candidate.model}: ${error}`,
+        `image-generation candidate failed: ${attempt.provider}/${attempt.model}: ${attempt.error}`,
       );
-      continue;
-    }
-
-    const inputImageCount = params.inputImages?.length ?? 0;
-    const maxInputImages = resolveImageGenerationMaxInputImages({
-      provider,
-      model: candidate.model,
-    });
-    const referenceImageError = resolveReferenceImageCapabilityError({
-      candidateRef: `${candidate.provider}/${candidate.model}`,
-      inputImageCount,
-      edit: {
-        enabled: provider.capabilities.edit.enabled,
-        ...(maxInputImages !== undefined ? { maxInputImages } : {}),
-      },
-    });
-    if (referenceImageError) {
-      recordCapabilityCandidateFailure({
-        attempts,
-        provider: candidate.provider,
-        model: candidate.model,
-        error: referenceImageError,
-      });
-      lastError = new Error(referenceImageError);
-      logger.warn(`image-generation candidate skipped: ${referenceImageError}`);
-      continue;
-    }
-
-    try {
-      const timeoutMs = resolveMediaProviderRequestTimeoutMs({
-        timeoutMs: requestedTimeoutMs,
-        providerDefaultTimeoutMs: provider.defaultTimeoutMs,
-      });
-      const modelResolutions =
-        provider.capabilities.geometry?.resolutionsByModel?.[candidate.model];
-      const modeCapabilities = params.inputImages?.length
-        ? provider.capabilities.edit
-        : provider.capabilities.generate;
-      const inferredResolution =
-        modeCapabilities.supportsResolution === false || modelResolutions?.length === 0
-          ? undefined
-          : params.inferredResolution;
-      const sanitized = resolveImageGenerationOverrides({
+    },
+    onFailure: (attempt) => {
+      logger.warn(
+        `image-generation candidate failed: ${attempt.provider}/${attempt.model}: ${attempt.error}`,
+      );
+    },
+    prepareCandidate(candidate, provider) {
+      const inputImageCount = params.inputImages?.length ?? 0;
+      const maxInputImages = resolveImageGenerationMaxInputImages({
         provider,
         model: candidate.model,
-        size: params.size,
-        aspectRatio: params.aspectRatio,
-        resolution: params.resolution ?? inferredResolution,
-        quality: params.quality,
-        outputFormat: params.outputFormat,
-        background: params.background,
-        inputImages: params.inputImages,
       });
-      // Providers receive only supported overrides. Ignored/normalized values
-      // are returned to callers so user-facing replies can explain adjustments.
-      const result: ImageGenerationResult = await provider.generateImage({
-        provider: candidate.provider,
-        model: candidate.model,
-        prompt: params.prompt,
-        cfg: params.cfg,
-        agentDir: params.agentDir,
-        authStore: params.authStore,
-        count: params.count,
-        size: sanitized.size,
-        aspectRatio: sanitized.aspectRatio,
-        resolution: sanitized.resolution,
-        quality: sanitized.quality,
-        outputFormat: sanitized.outputFormat,
-        background: sanitized.background,
-        inputImages: params.inputImages,
-        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-        providerOptions: params.providerOptions,
-        ssrfPolicy: params.ssrfPolicy,
-      });
-      if (!Array.isArray(result.images) || result.images.length === 0) {
-        throw new Error("Image generation provider returned no images.");
-      }
-      const emptyImageIndex = result.images.findIndex((image) => image.buffer.byteLength === 0);
-      if (emptyImageIndex >= 0) {
-        throw new Error(
-          `Image generation provider returned an empty image buffer at index ${emptyImageIndex}.`,
-        );
-      }
-      return {
-        images: result.images,
-        provider: candidate.provider,
-        model: result.model ?? candidate.model,
-        attempts,
-        ...(sanitized.resolution ? { appliedResolution: sanitized.resolution } : {}),
-        normalization: sanitized.normalization,
-        metadata: {
-          ...result.metadata,
-          ...buildMediaGenerationNormalizationMetadata({
-            normalization: sanitized.normalization,
-            requestedSizeForDerivedAspectRatio: params.size,
-          }),
+      const referenceImageError = resolveReferenceImageCapabilityError({
+        candidateRef: `${candidate.provider}/${candidate.model}`,
+        inputImageCount,
+        edit: {
+          enabled: provider.capabilities.edit.enabled,
+          ...(maxInputImages !== undefined ? { maxInputImages } : {}),
         },
-        ignoredOverrides: sanitized.ignoredOverrides,
-      };
-    } catch (err) {
-      lastError = err;
-      const described = isFailoverError(err) ? describeFailoverError(err) : undefined;
-      attempts.push({
-        provider: candidate.provider,
-        model: candidate.model,
-        error: described?.message ?? formatErrorMessage(err),
-        reason: described?.reason,
-        status: described?.status,
-        code: described?.code,
       });
-      logger.warn(
-        `image-generation candidate failed: ${candidate.provider}/${candidate.model}: ${
-          described?.message ?? formatErrorMessage(err)
-        }`,
-      );
-    }
-  }
+      if (referenceImageError) {
+        logger.warn(`image-generation candidate skipped: ${referenceImageError}`);
+        return referenceImageError;
+      }
 
-  return throwCapabilityGenerationFailure({
-    capabilityLabel: "image generation",
-    attempts,
-    lastError,
+      return async (attempts): Promise<GenerateImageRuntimeResult> => {
+        const timeoutMs = resolveMediaProviderRequestTimeoutMs({
+          timeoutMs: requestedTimeoutMs,
+          providerDefaultTimeoutMs: provider.defaultTimeoutMs,
+        });
+        const modelResolutions =
+          provider.capabilities.geometry?.resolutionsByModel?.[candidate.model];
+        const modeCapabilities = params.inputImages?.length
+          ? provider.capabilities.edit
+          : provider.capabilities.generate;
+        const inferredResolution =
+          modeCapabilities.supportsResolution === false || modelResolutions?.length === 0
+            ? undefined
+            : params.inferredResolution;
+        const sanitized = resolveImageGenerationOverrides({
+          provider,
+          model: candidate.model,
+          size: params.size,
+          aspectRatio: params.aspectRatio,
+          resolution: params.resolution ?? inferredResolution,
+          quality: params.quality,
+          outputFormat: params.outputFormat,
+          background: params.background,
+          inputImages: params.inputImages,
+        });
+        // Providers receive only supported overrides. Ignored/normalized values
+        // are returned to callers so user-facing replies can explain adjustments.
+        const result: ImageGenerationResult = await provider.generateImage({
+          provider: candidate.provider,
+          model: candidate.model,
+          prompt: params.prompt,
+          cfg: params.cfg,
+          agentDir: params.agentDir,
+          authStore: params.authStore,
+          count: params.count,
+          size: sanitized.size,
+          aspectRatio: sanitized.aspectRatio,
+          resolution: sanitized.resolution,
+          quality: sanitized.quality,
+          outputFormat: sanitized.outputFormat,
+          background: sanitized.background,
+          inputImages: params.inputImages,
+          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+          providerOptions: params.providerOptions,
+          ssrfPolicy: params.ssrfPolicy,
+        });
+        if (!Array.isArray(result.images) || result.images.length === 0) {
+          throw new Error("Image generation provider returned no images.");
+        }
+        const emptyImageIndex = result.images.findIndex((image) => image.buffer.byteLength === 0);
+        if (emptyImageIndex >= 0) {
+          throw new Error(
+            `Image generation provider returned an empty image buffer at index ${emptyImageIndex}.`,
+          );
+        }
+        return {
+          images: result.images,
+          provider: candidate.provider,
+          model: result.model ?? candidate.model,
+          attempts,
+          ...(sanitized.resolution ? { appliedResolution: sanitized.resolution } : {}),
+          normalization: sanitized.normalization,
+          metadata: {
+            ...result.metadata,
+            ...buildMediaGenerationNormalizationMetadata({
+              normalization: sanitized.normalization,
+              requestedSizeForDerivedAspectRatio: params.size,
+            }),
+          },
+          ignoredOverrides: sanitized.ignoredOverrides,
+        };
+      };
+    },
   });
 }

--- a/src/media-generation/runtime-shared.test.ts
+++ b/src/media-generation/runtime-shared.test.ts
@@ -10,6 +10,7 @@ import {
   resolveClosestSize,
   resolveMediaProviderRequestTimeoutMs,
   resolveReferenceImageCapabilityError,
+  runMediaGenerationCandidates,
   throwCapabilityGenerationFailure,
 } from "./runtime-shared.js";
 
@@ -314,6 +315,108 @@ describe("media-generation runtime shared candidates", () => {
 
     expect(candidates[0]).toEqual({ provider: "google", model: "lyria-3-pro-preview" });
   });
+});
+
+describe("media-generation candidate lifecycle", () => {
+  it("preserves missing, skipped, and failed attempts before the first usable result", async () => {
+    const calls: string[] = [];
+    const result = await runMediaGenerationCandidates({
+      candidates: ["missing", "skipped", "failed", "success", "unused"].map((provider) => ({
+        provider,
+        model: "model",
+      })),
+      capability: "image",
+      includeSkipFailureDetails: true,
+      getProvider(id) {
+        calls.push(`lookup:${id}`);
+        return id === "missing" ? undefined : { id };
+      },
+      prepareCandidate(candidate) {
+        if (candidate.provider === "skipped") {
+          return "reference inputs unsupported";
+        }
+        return async (attempts) => {
+          calls.push(`generate:${candidate.provider}`);
+          if (candidate.provider === "failed") {
+            throw new Error("generation failed");
+          }
+          return { model: "selected-model", attempts };
+        };
+      },
+    });
+
+    expect(result.model).toBe("selected-model");
+    expect(result.attempts).toStrictEqual([
+      {
+        provider: "missing",
+        model: "model",
+        error: "No image-generation provider registered for missing",
+      },
+      {
+        provider: "skipped",
+        model: "model",
+        error: "reference inputs unsupported",
+        reason: undefined,
+        status: undefined,
+        code: undefined,
+      },
+      {
+        provider: "failed",
+        model: "model",
+        error: "generation failed",
+        reason: undefined,
+        status: undefined,
+        code: undefined,
+      },
+    ]);
+    expect(calls).toEqual([
+      "lookup:missing",
+      "lookup:skipped",
+      "lookup:failed",
+      "generate:failed",
+      "lookup:success",
+      "generate:success",
+    ]);
+  });
+
+  it.each(["lookup", "prepare", "async prepare"])(
+    "propagates %s failures without submitting a fallback",
+    async (stage) => {
+      const error = new Error("provider registry unavailable");
+      const lookedUp: string[] = [];
+      let executions = 0;
+      const result = runMediaGenerationCandidates({
+        candidates: [
+          { provider: "primary", model: "model" },
+          { provider: "fallback", model: "model" },
+        ],
+        capability: "video",
+        getProvider(id) {
+          lookedUp.push(id);
+          if (stage === "lookup") {
+            throw error;
+          }
+          return { id };
+        },
+        prepareCandidate() {
+          if (stage === "prepare") {
+            throw error;
+          }
+          if (stage === "async prepare") {
+            return Promise.reject(error);
+          }
+          return async () => {
+            executions += 1;
+            return "unexpected generation";
+          };
+        },
+      });
+
+      await expect(result).rejects.toBe(error);
+      expect(lookedUp).toEqual(["primary"]);
+      expect(executions).toBe(0);
+    },
+  );
 });
 
 describe("media-generation runtime shared normalization", () => {

--- a/src/media-generation/runtime-shared.ts
+++ b/src/media-generation/runtime-shared.ts
@@ -25,21 +25,75 @@ type ParsedProviderModelRef = {
   model: string;
 };
 
-/** Records one provider/model failure in the common fallback-attempt shape. */
-export function recordCapabilityCandidateFailure(params: {
-  attempts: FallbackAttempt[];
-  provider: string;
-  model: string;
-  error: unknown;
-}): void {
-  const described = isFailoverError(params.error) ? describeFailoverError(params.error) : undefined;
-  params.attempts.push({
-    provider: params.provider,
-    model: params.model,
-    error: described?.message ?? formatErrorMessage(params.error),
+function buildCapabilityCandidateFailure(
+  candidate: ParsedProviderModelRef,
+  error: unknown,
+): FallbackAttempt {
+  const described = isFailoverError(error) ? describeFailoverError(error) : undefined;
+  return {
+    provider: candidate.provider,
+    model: candidate.model,
+    error: described?.message ?? formatErrorMessage(error),
     reason: described?.reason,
     status: described?.status,
     code: described?.code,
+  };
+}
+
+type PreparedMediaGenerationCandidate<TResult> =
+  | string
+  | ((attempts: FallbackAttempt[]) => Promise<TResult>);
+
+/** Keeps provider lookup and capability preflight outside the generation fallback catch. */
+export async function runMediaGenerationCandidates<TProvider extends object, TResult>(params: {
+  candidates: readonly ParsedProviderModelRef[];
+  capability: "image" | "music" | "video";
+  getProvider: (providerId: string) => TProvider | undefined;
+  prepareCandidate: (
+    candidate: ParsedProviderModelRef,
+    provider: TProvider,
+  ) =>
+    | PreparedMediaGenerationCandidate<TResult>
+    | Promise<PreparedMediaGenerationCandidate<TResult>>;
+  /** Image/music skip records retain optional failure fields; video skip records do not. */
+  includeSkipFailureDetails?: boolean;
+  onMissingProvider?: (attempt: FallbackAttempt) => void;
+  onFailure?: (attempt: FallbackAttempt) => void;
+}): Promise<TResult> {
+  const attempts: FallbackAttempt[] = [];
+  let lastError: unknown;
+  for (const candidate of params.candidates) {
+    const provider = params.getProvider(candidate.provider);
+    const preparation = provider
+      ? params.prepareCandidate(candidate, provider)
+      : `No ${params.capability}-generation provider registered for ${candidate.provider}`;
+    // Image/music preflight is synchronous; only video's capability overlay yields.
+    const prepared = preparation instanceof Promise ? await preparation : preparation;
+    if (typeof prepared === "string") {
+      const attempt =
+        provider && params.includeSkipFailureDetails
+          ? buildCapabilityCandidateFailure(candidate, prepared)
+          : { provider: candidate.provider, model: candidate.model, error: prepared };
+      attempts.push(attempt);
+      lastError = new Error(prepared);
+      if (!provider) {
+        params.onMissingProvider?.(attempt);
+      }
+      continue;
+    }
+    try {
+      return await prepared(attempts);
+    } catch (error) {
+      lastError = error;
+      const attempt = buildCapabilityCandidateFailure(candidate, error);
+      attempts.push(attempt);
+      params.onFailure?.(attempt);
+    }
+  }
+  return throwCapabilityGenerationFailure({
+    capabilityLabel: `${params.capability} generation`,
+    attempts,
+    lastError,
   });
 }
 

--- a/src/music-generation/runtime.ts
+++ b/src/music-generation/runtime.ts
@@ -1,5 +1,4 @@
 // Runs music generation requests through provider runtimes and fallbacks.
-import type { FallbackAttempt } from "../agents/model-fallback.types.js";
 import { resolveAgentModelTimeoutMsValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -11,10 +10,9 @@ import {
 import {
   buildMediaGenerationNormalizationMetadata,
   buildNoCapabilityModelConfiguredMessage,
-  recordCapabilityCandidateFailure,
   resolveCapabilityModelCandidates,
   resolveReferenceImageCapabilityError,
-  throwCapabilityGenerationFailure,
+  runMediaGenerationCandidates,
 } from "../media-generation/runtime-shared.js";
 import { getProviderEnvVars } from "../secrets/provider-env-vars.js";
 import { resolveMusicGenerationOverrides } from "./normalization.js";
@@ -78,104 +76,74 @@ export async function generateMusic(
     );
   }
 
-  const attempts: FallbackAttempt[] = [];
-  let lastError: unknown;
-
-  for (const candidate of candidates) {
-    const provider = getProvider(candidate.provider, params.cfg);
-    if (!provider) {
-      // Candidate resolution can include stale config refs; keep them in attempts for diagnostics.
-      const error = `No music-generation provider registered for ${candidate.provider}`;
-      attempts.push({
-        provider: candidate.provider,
-        model: candidate.model,
-        error,
+  return runMediaGenerationCandidates({
+    candidates,
+    capability: "music",
+    getProvider: (providerId) => getProvider(providerId, params.cfg),
+    includeSkipFailureDetails: true,
+    onFailure: (attempt) => {
+      logger.debug(`music-generation candidate failed: ${attempt.provider}/${attempt.model}`);
+    },
+    prepareCandidate(candidate, provider) {
+      const referenceImageError = resolveReferenceImageCapabilityError({
+        candidateRef: `${candidate.provider}/${candidate.model}`,
+        inputImageCount: params.inputImages?.length ?? 0,
+        edit: provider.capabilities.edit,
       });
-      lastError = new Error(error);
-      continue;
-    }
-
-    const referenceImageError = resolveReferenceImageCapabilityError({
-      candidateRef: `${candidate.provider}/${candidate.model}`,
-      inputImageCount: params.inputImages?.length ?? 0,
-      edit: provider.capabilities.edit,
-    });
-    if (referenceImageError) {
-      recordCapabilityCandidateFailure({
-        attempts,
-        provider: candidate.provider,
-        model: candidate.model,
-        error: referenceImageError,
-      });
-      lastError = new Error(referenceImageError);
-      logger.debug(`music-generation candidate skipped: ${referenceImageError}`);
-      continue;
-    }
-
-    try {
-      const sanitized = resolveMusicGenerationOverrides({
-        provider,
-        model: candidate.model,
-        lyrics: params.lyrics,
-        instrumental: params.instrumental,
-        durationSeconds: params.durationSeconds,
-        format: params.format,
-        inputImages: params.inputImages,
-      });
-      const result: MusicGenerationResult = await provider.generateMusic({
-        provider: candidate.provider,
-        model: candidate.model,
-        prompt: params.prompt,
-        cfg: params.cfg,
-        agentDir: params.agentDir,
-        authStore: params.authStore,
-        lyrics: sanitized.lyrics,
-        instrumental: sanitized.instrumental,
-        durationSeconds: sanitized.durationSeconds,
-        format: sanitized.format,
-        inputImages: params.inputImages,
-        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-      });
-      if (!Array.isArray(result.tracks) || result.tracks.length === 0) {
-        throw new Error("Music generation provider returned no tracks.");
+      if (referenceImageError) {
+        logger.debug(`music-generation candidate skipped: ${referenceImageError}`);
+        return referenceImageError;
       }
-      const emptyTrackIndex = result.tracks.findIndex((track) => track.buffer.byteLength === 0);
-      if (emptyTrackIndex >= 0) {
-        throw new Error(
-          `Music generation provider returned an empty track buffer at index ${emptyTrackIndex}.`,
-        );
-      }
-      return {
-        tracks: result.tracks,
-        provider: candidate.provider,
-        model: result.model ?? candidate.model,
-        attempts,
-        lyrics: result.lyrics,
-        normalization: sanitized.normalization,
-        metadata: {
-          ...result.metadata,
-          ...buildMediaGenerationNormalizationMetadata({
-            normalization: sanitized.normalization,
-          }),
-        },
-        ignoredOverrides: sanitized.ignoredOverrides,
+
+      return async (attempts): Promise<GenerateMusicRuntimeResult> => {
+        const sanitized = resolveMusicGenerationOverrides({
+          provider,
+          model: candidate.model,
+          lyrics: params.lyrics,
+          instrumental: params.instrumental,
+          durationSeconds: params.durationSeconds,
+          format: params.format,
+          inputImages: params.inputImages,
+        });
+        const result: MusicGenerationResult = await provider.generateMusic({
+          provider: candidate.provider,
+          model: candidate.model,
+          prompt: params.prompt,
+          cfg: params.cfg,
+          agentDir: params.agentDir,
+          authStore: params.authStore,
+          lyrics: sanitized.lyrics,
+          instrumental: sanitized.instrumental,
+          durationSeconds: sanitized.durationSeconds,
+          format: sanitized.format,
+          inputImages: params.inputImages,
+          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+        });
+        if (!Array.isArray(result.tracks) || result.tracks.length === 0) {
+          throw new Error("Music generation provider returned no tracks.");
+        }
+        const emptyTrackIndex = result.tracks.findIndex((track) => track.buffer.byteLength === 0);
+        if (emptyTrackIndex >= 0) {
+          throw new Error(
+            `Music generation provider returned an empty track buffer at index ${emptyTrackIndex}.`,
+          );
+        }
+        return {
+          tracks: result.tracks,
+          provider: candidate.provider,
+          model: result.model ?? candidate.model,
+          attempts,
+          lyrics: result.lyrics,
+          normalization: sanitized.normalization,
+          metadata: {
+            ...result.metadata,
+            ...buildMediaGenerationNormalizationMetadata({
+              normalization: sanitized.normalization,
+            }),
+          },
+          ignoredOverrides: sanitized.ignoredOverrides,
+        };
       };
-    } catch (err) {
-      lastError = err;
-      // Preserve failed candidates so callers can see which provider/model refs were tried.
-      recordCapabilityCandidateFailure({
-        attempts,
-        provider: candidate.provider,
-        model: candidate.model,
-        error: err,
-      });
-      logger.debug(`music-generation candidate failed: ${candidate.provider}/${candidate.model}`);
-    }
-  }
-
-  return throwCapabilityGenerationFailure({
-    capabilityLabel: "music generation",
-    attempts,
-    lastError,
+    },
   });
 }

--- a/src/video-generation/runtime.ts
+++ b/src/video-generation/runtime.ts
@@ -1,5 +1,4 @@
 // Video generation runtime coordinates provider auth, fallbacks, and job polling.
-import type { FallbackAttempt } from "../agents/model-fallback.types.js";
 import { resolveAgentModelTimeoutMsValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -11,10 +10,9 @@ import {
 import {
   buildMediaGenerationNormalizationMetadata,
   buildNoCapabilityModelConfiguredMessage,
-  recordCapabilityCandidateFailure,
   resolveCapabilityModelCandidates,
   resolveMediaProviderRequestTimeoutMs,
-  throwCapabilityGenerationFailure,
+  runMediaGenerationCandidates,
 } from "../media-generation/runtime-shared.js";
 import { getProviderEnvVars } from "../secrets/provider-env-vars.js";
 import { resolveVideoGenerationModeCapabilities } from "./capabilities.js";
@@ -138,8 +136,6 @@ export async function generateVideo(
     throw new Error(buildNoVideoGenerationModelConfiguredMessage(params.cfg, deps));
   }
 
-  const attempts: FallbackAttempt[] = [];
-  let lastError: unknown;
   let skipWarnEmitted = false;
   const warnOnFirstSkip = (reason: string) => {
     // Skip events are common in normal fallback flow, so log the *first* one in
@@ -152,227 +148,199 @@ export async function generateVideo(
     }
   };
 
-  for (const candidate of candidates) {
-    const provider = getProvider(candidate.provider, params.cfg);
-    if (!provider) {
-      const error = `No video-generation provider registered for ${candidate.provider}`;
-      attempts.push({
-        provider: candidate.provider,
-        model: candidate.model,
-        error,
+  return runMediaGenerationCandidates({
+    candidates,
+    capability: "video",
+    getProvider: (providerId) => getProvider(providerId, params.cfg),
+    onFailure: (attempt) => {
+      logger.debug(`video-generation candidate failed: ${attempt.provider}/${attempt.model}`);
+    },
+    async prepareCandidate(candidate, provider) {
+      const timeoutMs = resolveMediaProviderRequestTimeoutMs({
+        timeoutMs: requestedTimeoutMs,
+        providerDefaultTimeoutMs: provider.defaultTimeoutMs,
       });
-      lastError = new Error(error);
-      continue;
-    }
-    const timeoutMs = resolveMediaProviderRequestTimeoutMs({
-      timeoutMs: requestedTimeoutMs,
-      providerDefaultTimeoutMs: provider.defaultTimeoutMs,
-    });
-    const activeProvider = await resolveProviderWithModelCapabilities({
-      provider,
-      providerId: candidate.provider,
-      model: candidate.model,
-      cfg: params.cfg,
-      agentDir: params.agentDir,
-      authStore: params.authStore,
-      timeoutMs: MODEL_CAPABILITY_LOOKUP_TIMEOUT_MS,
-      log: logger,
-    });
-
-    // Guard: catalog modes and reference counts are authoritative before I/O,
-    // so fallback cannot select a model that will reject or drop the request.
-    const inputImageCount = params.inputImages?.length ?? 0;
-    const inputVideoCount = params.inputVideos?.length ?? 0;
-    const inputAudioCount = params.inputAudios?.length ?? 0;
-    const capabilityMismatch = buildVideoGenerationCapabilityFailure({
-      providerId: candidate.provider,
-      model: candidate.model,
-      provider: activeProvider,
-      inputImageCount,
-      inputVideoCount,
-      inputAudioCount,
-    });
-    if (capabilityMismatch) {
-      attempts.push({
-        provider: candidate.provider,
-        model: candidate.model,
-        error: capabilityMismatch,
-      });
-      lastError = new Error(capabilityMismatch);
-      warnOnFirstSkip(capabilityMismatch);
-      logger.debug(
-        `video-generation candidate skipped (mode or reference capability): ${candidate.provider}/${candidate.model}`,
-      );
-      continue;
-    }
-
-    // Guard: skip candidates that do not accept the requested providerOptions keys,
-    // or whose declared providerOptions schema does not match the supplied value
-    // types. Same skip-in-fallback rationale as the audio guard above — we never
-    // want to silently forward provider-specific options to the wrong provider,
-    // but we also do not want to block valid fallback candidates that *do* accept
-    // them. Providers opt in by declaring `capabilities.providerOptions` on the
-    // active mode or on the flat provider capabilities.
-    if (
-      params.providerOptions &&
-      typeof params.providerOptions === "object" &&
-      Object.keys(params.providerOptions).length > 0
-    ) {
-      const { capabilities: optCaps } = resolveVideoGenerationModeCapabilities({
-        provider: activeProvider,
-        model: candidate.model,
-        inputImageCount,
-        inputVideoCount,
-      });
-      const declaredOptions =
-        optCaps?.providerOptions ?? activeProvider.capabilities.providerOptions ?? undefined;
-      const mismatch = validateProviderOptionsAgainstDeclaration({
+      const activeProvider = await resolveProviderWithModelCapabilities({
+        provider,
         providerId: candidate.provider,
         model: candidate.model,
-        providerOptions: params.providerOptions,
-        declaration: declaredOptions,
-      });
-      if (mismatch) {
-        attempts.push({ provider: candidate.provider, model: candidate.model, error: mismatch });
-        lastError = new Error(mismatch);
-        warnOnFirstSkip(mismatch);
-        logger.debug(
-          `video-generation candidate skipped (providerOptions): ${candidate.provider}/${candidate.model}`,
-        );
-        continue;
-      }
-    }
-
-    // Guard: skip candidates whose maxDurationSeconds hard cap is below the requested
-    // duration. Only applies when the provider uses a simple max with no explicit
-    // supported-durations list — when a list exists, runtime normalization snaps to the
-    // nearest valid value so skipping is not appropriate.
-    const supportedDurations = resolveVideoGenerationSupportedDurations({
-      provider: activeProvider,
-      model: candidate.model,
-      inputImageCount,
-      inputVideoCount,
-    });
-    const requestedDuration = params.durationSeconds;
-    if (typeof requestedDuration === "number" && Number.isFinite(requestedDuration)) {
-      const { capabilities: durCaps } = resolveVideoGenerationModeCapabilities({
-        provider: activeProvider,
-        model: candidate.model,
-        inputImageCount,
-        inputVideoCount,
-      });
-      const maxDuration =
-        durCaps?.maxDurationSeconds ?? activeProvider.capabilities.maxDurationSeconds;
-      if (
-        !supportedDurations &&
-        typeof maxDuration === "number" &&
-        // Compare the normalized (rounded) duration, not the raw float, since
-        // resolveVideoGenerationOverrides applies Math.round before sending to the provider.
-        // A request for 4.4s against maxDurationSeconds=4 rounds to 4 and is valid.
-        Math.round(requestedDuration) > maxDuration
-      ) {
-        const error = `${candidate.provider}/${candidate.model} supports at most ${maxDuration}s per video, ${requestedDuration}s requested; skipping`;
-        attempts.push({ provider: candidate.provider, model: candidate.model, error });
-        lastError = new Error(error);
-        warnOnFirstSkip(error);
-        logger.debug(
-          `video-generation candidate skipped (duration capability): ${candidate.provider}/${candidate.model}`,
-        );
-        continue;
-      }
-    }
-
-    try {
-      const sanitized = resolveVideoGenerationOverrides({
-        provider: activeProvider,
-        model: candidate.model,
-        size: params.size,
-        aspectRatio: params.aspectRatio,
-        resolution: params.resolution,
-        durationSeconds: params.durationSeconds,
-        audio: params.audio,
-        watermark: params.watermark,
-        inputImageCount,
-        inputVideoCount,
-      });
-      const generationRequest: Parameters<typeof provider.generateVideo>[0] & {
-        [SUPPORTED_DURATIONS_HINT]?: readonly number[];
-      } = {
-        provider: candidate.provider,
-        model: candidate.model,
-        prompt: params.prompt,
         cfg: params.cfg,
         agentDir: params.agentDir,
         authStore: params.authStore,
-        size: sanitized.size,
-        aspectRatio: sanitized.aspectRatio,
-        resolution: sanitized.resolution,
-        durationSeconds: sanitized.durationSeconds,
-        audio: sanitized.audio,
-        watermark: sanitized.watermark,
-        inputImages: params.inputImages,
-        inputVideos: params.inputVideos,
-        inputAudios: params.inputAudios,
-        providerOptions: params.providerOptions,
-        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-      };
-      if (supportedDurations) {
-        generationRequest[SUPPORTED_DURATIONS_HINT] = supportedDurations;
-      }
-      const result: VideoGenerationResult = await provider.generateVideo(generationRequest);
-      if (!Array.isArray(result.videos) || result.videos.length === 0) {
-        throw new Error("Video generation provider returned no videos.");
-      }
-      const videos = result.videos.map((video, index) => {
-        if (video.buffer?.byteLength === 0) {
-          if (video.url) {
-            // URL-only video is valid; remove the unusable buffer so callers do not
-            // prefer it and persist zero bytes instead of delivering the URL.
-            const { buffer: _emptyBuffer, ...urlOnlyVideo } = video;
-            return urlOnlyVideo;
-          }
-          throw new Error(
-            `Video generation provider returned an empty video buffer at index ${index}.`,
-          );
-        }
-        if (!video.buffer && !video.url) {
-          throw new Error(
-            `Video generation provider returned an undeliverable asset at index ${index}: neither buffer nor url is set.`,
-          );
-        }
-        return video;
+        timeoutMs: MODEL_CAPABILITY_LOOKUP_TIMEOUT_MS,
+        log: logger,
       });
-      return {
-        videos,
-        provider: candidate.provider,
-        model: result.model ?? candidate.model,
-        attempts,
-        normalization: sanitized.normalization,
-        ignoredOverrides: sanitized.ignoredOverrides,
-        metadata: {
-          ...result.metadata,
-          ...buildMediaGenerationNormalizationMetadata({
-            normalization: sanitized.normalization,
-            requestedSizeForDerivedAspectRatio: params.size,
-            includeSupportedDurationSeconds: true,
-          }),
-        },
-      };
-    } catch (err) {
-      lastError = err;
-      recordCapabilityCandidateFailure({
-        attempts,
-        provider: candidate.provider,
-        model: candidate.model,
-        error: err,
-      });
-      logger.debug(`video-generation candidate failed: ${candidate.provider}/${candidate.model}`);
-    }
-  }
 
-  return throwCapabilityGenerationFailure({
-    capabilityLabel: "video generation",
-    attempts,
-    lastError,
+      // Guard: catalog modes and reference counts are authoritative before I/O,
+      // so fallback cannot select a model that will reject or drop the request.
+      const inputImageCount = params.inputImages?.length ?? 0;
+      const inputVideoCount = params.inputVideos?.length ?? 0;
+      const inputAudioCount = params.inputAudios?.length ?? 0;
+      const capabilityMismatch = buildVideoGenerationCapabilityFailure({
+        providerId: candidate.provider,
+        model: candidate.model,
+        provider: activeProvider,
+        inputImageCount,
+        inputVideoCount,
+        inputAudioCount,
+      });
+      if (capabilityMismatch) {
+        warnOnFirstSkip(capabilityMismatch);
+        logger.debug(
+          `video-generation candidate skipped (mode or reference capability): ${candidate.provider}/${candidate.model}`,
+        );
+        return capabilityMismatch;
+      }
+
+      // Guard: skip candidates that do not accept the requested providerOptions keys,
+      // or whose declared providerOptions schema does not match the supplied value
+      // types. Same skip-in-fallback rationale as the audio guard above — we never
+      // want to silently forward provider-specific options to the wrong provider,
+      // but we also do not want to block valid fallback candidates that *do* accept
+      // them. Providers opt in by declaring `capabilities.providerOptions` on the
+      // active mode or on the flat provider capabilities.
+      if (
+        params.providerOptions &&
+        typeof params.providerOptions === "object" &&
+        Object.keys(params.providerOptions).length > 0
+      ) {
+        const { capabilities: optCaps } = resolveVideoGenerationModeCapabilities({
+          provider: activeProvider,
+          model: candidate.model,
+          inputImageCount,
+          inputVideoCount,
+        });
+        const declaredOptions =
+          optCaps?.providerOptions ?? activeProvider.capabilities.providerOptions ?? undefined;
+        const mismatch = validateProviderOptionsAgainstDeclaration({
+          providerId: candidate.provider,
+          model: candidate.model,
+          providerOptions: params.providerOptions,
+          declaration: declaredOptions,
+        });
+        if (mismatch) {
+          warnOnFirstSkip(mismatch);
+          logger.debug(
+            `video-generation candidate skipped (providerOptions): ${candidate.provider}/${candidate.model}`,
+          );
+          return mismatch;
+        }
+      }
+
+      // Guard: skip candidates whose maxDurationSeconds hard cap is below the requested
+      // duration. Only applies when the provider uses a simple max with no explicit
+      // supported-durations list — when a list exists, runtime normalization snaps to the
+      // nearest valid value so skipping is not appropriate.
+      const supportedDurations = resolveVideoGenerationSupportedDurations({
+        provider: activeProvider,
+        model: candidate.model,
+        inputImageCount,
+        inputVideoCount,
+      });
+      const requestedDuration = params.durationSeconds;
+      if (typeof requestedDuration === "number" && Number.isFinite(requestedDuration)) {
+        const { capabilities: durCaps } = resolveVideoGenerationModeCapabilities({
+          provider: activeProvider,
+          model: candidate.model,
+          inputImageCount,
+          inputVideoCount,
+        });
+        const maxDuration =
+          durCaps?.maxDurationSeconds ?? activeProvider.capabilities.maxDurationSeconds;
+        if (
+          !supportedDurations &&
+          typeof maxDuration === "number" &&
+          // Compare the normalized (rounded) duration, not the raw float, since
+          // resolveVideoGenerationOverrides applies Math.round before sending to the provider.
+          // A request for 4.4s against maxDurationSeconds=4 rounds to 4 and is valid.
+          Math.round(requestedDuration) > maxDuration
+        ) {
+          const error = `${candidate.provider}/${candidate.model} supports at most ${maxDuration}s per video, ${requestedDuration}s requested; skipping`;
+          warnOnFirstSkip(error);
+          logger.debug(
+            `video-generation candidate skipped (duration capability): ${candidate.provider}/${candidate.model}`,
+          );
+          return error;
+        }
+      }
+
+      return async (attempts): Promise<GenerateVideoRuntimeResult> => {
+        const sanitized = resolveVideoGenerationOverrides({
+          provider: activeProvider,
+          model: candidate.model,
+          size: params.size,
+          aspectRatio: params.aspectRatio,
+          resolution: params.resolution,
+          durationSeconds: params.durationSeconds,
+          audio: params.audio,
+          watermark: params.watermark,
+          inputImageCount,
+          inputVideoCount,
+        });
+        const generationRequest: Parameters<typeof provider.generateVideo>[0] & {
+          [SUPPORTED_DURATIONS_HINT]?: readonly number[];
+        } = {
+          provider: candidate.provider,
+          model: candidate.model,
+          prompt: params.prompt,
+          cfg: params.cfg,
+          agentDir: params.agentDir,
+          authStore: params.authStore,
+          size: sanitized.size,
+          aspectRatio: sanitized.aspectRatio,
+          resolution: sanitized.resolution,
+          durationSeconds: sanitized.durationSeconds,
+          audio: sanitized.audio,
+          watermark: sanitized.watermark,
+          inputImages: params.inputImages,
+          inputVideos: params.inputVideos,
+          inputAudios: params.inputAudios,
+          providerOptions: params.providerOptions,
+          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+        };
+        if (supportedDurations) {
+          generationRequest[SUPPORTED_DURATIONS_HINT] = supportedDurations;
+        }
+        const result: VideoGenerationResult = await provider.generateVideo(generationRequest);
+        if (!Array.isArray(result.videos) || result.videos.length === 0) {
+          throw new Error("Video generation provider returned no videos.");
+        }
+        const videos = result.videos.map((video, index) => {
+          if (video.buffer?.byteLength === 0) {
+            if (video.url) {
+              // URL-only video is valid; remove the unusable buffer so callers do not
+              // prefer it and persist zero bytes instead of delivering the URL.
+              const { buffer: _emptyBuffer, ...urlOnlyVideo } = video;
+              return urlOnlyVideo;
+            }
+            throw new Error(
+              `Video generation provider returned an empty video buffer at index ${index}.`,
+            );
+          }
+          if (!video.buffer && !video.url) {
+            throw new Error(
+              `Video generation provider returned an undeliverable asset at index ${index}: neither buffer nor url is set.`,
+            );
+          }
+          return video;
+        });
+        return {
+          videos,
+          provider: candidate.provider,
+          model: result.model ?? candidate.model,
+          attempts,
+          normalization: sanitized.normalization,
+          ignoredOverrides: sanitized.ignoredOverrides,
+          metadata: {
+            ...result.metadata,
+            ...buildMediaGenerationNormalizationMetadata({
+              normalization: sanitized.normalization,
+              requestedSizeForDerivedAspectRatio: params.size,
+              includeSupportedDurationSeconds: true,
+            }),
+          },
+        };
+      };
+    },
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Image, music and video generation each maintained their own candidate iteration and failure bookkeeping. Changes to fallback behavior had to be repeated across all three paths, despite already sharing candidate selection and diagnostics.

## Why This Change Was Made

Peter Steinberger explicitly sponsored this bounded consolidation as item 3 of the media de-duplication campaign, including implementation and native landing subject to proof.

One internal lifecycle in `src/media-generation/runtime-shared.ts` now owns provider lookup, ordered attempts, skipped/missing candidates, caught generation failures and final exhaustion. Each media owner retains capability preparation, provider calls, normalization, asset validation and result projection. Lookup and preparation errors still propagate outside the generation fallback catch; synchronous image/music preparation remains synchronous.

The obsolete internal failure-recorder was deleted after all of its callers migrated; it was not exposed through a public SDK or package barrel. No SDK export, public parameter, model-selection configuration or result shape changes. Image/music detailed skip records, video first-skip logging, provider-default timeouts, reference limits and URL-only video delivery retain their existing policies.

Production net -47 lines; tests +103 lines. Much of the raw diff is indentation of unchanged execution bodies. This is one atomic migration of the three callers, and the earlier survey overestimated the savings because supporting primitives were already shared.

## User Impact

No intentional user-visible behavior or API change. Configured fallback order and diagnostic details remain the same.

## Evidence

- `node scripts/run-vitest.mjs src/image-generation src/music-generation src/video-generation src/media-generation`: 17 files, 196 tests passed. New cases cover missing→skip→failure→success order and lookup/synchronous/asynchronous preflight failures without fallback submission.
- The final shared-owner suite passed all 27 tests after removing the obsolete internal export.
- Independent Codex autoreview of the final diff against its pinned merge base: clean through P2, zero actionable findings.
- `git diff --check`: passed.
- Changed-file checks advanced through formatting, typechecking, lint and the remaining source guards. The orchestration was interrupted at the final pairing-account guard; `node --import ./scripts/tsx.mjs scripts/check-pairing-account-scope.mts` then exited 0. Exact-head hosted CI also passed: [run 34100173558](https://github.com/openclaw/openclaw/actions/runs/34100173558).
- Final `pnpm build` passed on Blacksmith Testbox `tbx_01m1xfap8tr3n7rqpr749p4wmh`, [run 34100174246](https://github.com/openclaw/openclaw/actions/runs/34100174246), wrapper exit 0; build phases took 6m37s. The earlier local publication guard rejected a Testbox lease record created during compilation; no guard or baseline was weakened. The final serial isolated build resolved this proof gap.
- Live image proof passed on Blacksmith Testbox `tbx_01m1xd79tsgfvvejwyz6w49e3y`, [run 34096984911](https://github.com/openclaw/openclaw/actions/runs/34096984911): 12 real generation/edit round trips across DeepInfra, Google, MiniMax, OpenAI, OpenRouter and xAI; zero selected variants skipped or failed. Wrapper command exit 0. Verified live source tree `15c869168e7e9a6df3a17423f263f8d4363146d5` from base `86a3c7267be4a6a49cc3de5b00ec87588421783d` plus the candidate patch. Live proof preceded the deletion of the unreferenced internal recorder and a patch-identical rebase onto main. The request and projection code stayed unchanged. These provider-level suites call the plugins directly and do not exercise the shared candidate coordinator. The reviewed commit was rebased as `2e90068b182ef7561c0bfc93791443df19716afe` onto `240b8b1589886ecbf58ca40634172fad46775fdc`; all five changed files are byte-identical across that rebase. An external runner portal sync timed out after the successful command; provider proof and wrapper exit were successful.
- Live video proof passed on the same lease and verified source tree: six real generation round trips across DeepInfra, Google, MiniMax, OpenAI, OpenRouter and xAI, each returning one video. All six provider cases passed; the suite also passed four decoder/filter coverage cases. Wrapper command exit 0. The same post-success external portal-sync warning occurred; no selected real provider was skipped or failed.

Commands (all ran with `GITHUB_TOKEN`, `GH_TOKEN`, and `HOMEBREW_GITHUB_API_TOKEN` unset; the shell expands the helper path on the Testbox):

```sh
node scripts/crabbox-wrapper.mjs run --id tbx_01m1xd79tsgfvvejwyz6w49e3y --timing-json -- bash -lc 'exec "$HOME/.local/bin/openclaw-testbox-env" env OPENCLAW_LIVE_TEST=1 pnpm test:live:media:image'
node scripts/crabbox-wrapper.mjs run --id tbx_01m1xd79tsgfvvejwyz6w49e3y --timing-json -- bash -lc 'exec "$HOME/.local/bin/openclaw-testbox-env" env OPENCLAW_LIVE_TEST=1 pnpm test:live:media:video'
# This older-snapshot build attempt was canceled for the unused-export cleanup, not counted as proof:
node scripts/crabbox-wrapper.mjs run --id tbx_01m1xd79tsgfvvejwyz6w49e3y --timing-json -- pnpm build
# Final rebased-head build, on a fresh automatically cleaned-up lease:
node scripts/crabbox-wrapper.mjs run --timing-json -- pnpm build
```

All three proof leases were stopped and verified completed. The no-mock real-runtime probe also passed on the exact PR head `2e90068b182ef7561c0bfc93791443df19716afe`, verified tree `eac8247efc545f5f2b3e16bd7efd130a8d0fbaec`: Blacksmith Testbox `tbx_01m1xhgywd6m4sxh5dthyfpph3`, [run 34103563351](https://github.com/openclaw/openclaw/actions/runs/34103563351), command 7m37s, wrapper exit 0. It invokes actual `generateImage`, `generateVideo`, and `generateMusic` without dependency mocks, using isolated temporary state and the hydrated helper. Each configured missing primary is recorded once before real fallback success. Returned assets: OpenAI PNG 1,248,161 bytes; MiniMax MP4 467,767 bytes; MiniMax MP3 5,588,994 bytes. All ignored-override lists were empty. The post-success portal-sync warning did not affect the provider results or exit code.

<details>
<summary>Reproducible coordinator proof command and script</summary>

Save this script as `/tmp/L14-runtime-proof.mjs` on the caller. It prints only provider/model, diagnostic, byte-count and MIME evidence and removes its isolated state.

```js
import assert from 'node:assert/strict';
import { mkdtemp, mkdir, rm } from 'node:fs/promises';
import { tmpdir } from 'node:os';
import path from 'node:path';
const state = await mkdtemp(path.join(tmpdir(), 'l14-runtime-proof-'));
process.env.OPENCLAW_STATE_DIR = state;
const agentDir = path.join(state, 'agent');
await mkdir(agentDir);
try {
  assert.ok(process.env.OPENAI_API_KEY && process.env.MINIMAX_API_KEY, 'Required hydrated credentials are absent');
  const [{ generateImage }, { generateVideo }, { generateMusic }] = await Promise.all([
    import('./src/image-generation/runtime.ts'),
    import('./src/video-generation/runtime.ts'),
    import('./src/music-generation/runtime.ts'),
  ]);
  const cfg = {
    plugins: { allow: ['openai', 'minimax'], entries: { openai: { enabled: true }, minimax: { enabled: true } } },
    agents: { defaults: { mediaModels: {
      image: { primary: 'l14-missing/probe', fallbacks: ['openai/gpt-image-2'] },
      video: { primary: 'l14-missing/probe', fallbacks: ['minimax/MiniMax-Hailuo-2.3'] },
      music: { primary: 'l14-missing/probe', fallbacks: ['minimax/music-2.6'] },
    } } },
  };
  const common = { cfg, agentDir, authStore: { version: 1, profiles: {} }, autoProviderFallback: false };
  for (const kind of ['image', 'video', 'music']) {
    console.log(`L14_RUNTIME_START ${kind}`);
    const result = kind === 'image'
      ? await generateImage({ ...common, prompt: 'A red paper boat on calm blue water, simple studio lighting.', count: 1, quality: 'low' })
      : kind === 'video'
        ? await generateVideo({ ...common, prompt: 'A red paper boat drifting slowly on calm blue water.', durationSeconds: 6, resolution: '768P' })
        : await generateMusic({ ...common, prompt: 'A short calm instrumental piano phrase.', instrumental: true, format: 'mp3' });
    assert.equal(result.provider, kind === 'image' ? 'openai' : 'minimax');
    assert.deepEqual(result.attempts, [{ provider: 'l14-missing', model: 'probe', error: `No ${kind}-generation provider registered for l14-missing` }]);
    const assets = result.images ?? result.videos ?? result.tracks;
    assert.ok(assets.length > 0);
    for (const asset of assets) assert.ok((asset.buffer?.byteLength ?? 0) > 512 || asset.url);
    console.log('L14_RUNTIME_OK ' + JSON.stringify({ kind, provider: result.provider, model: result.model, attempts: result.attempts, assets: assets.map(asset => ({ bytes: asset.buffer?.byteLength ?? 0, mimeType: asset.mimeType, hasUrl: Boolean(asset.url) })), ignoredOverrides: result.ignoredOverrides }));
  }
} finally {
  await rm(state, { recursive: true, force: true });
}
```

The exact command is the following wrapper invocation with the script above shell-quoted as the Node `-e` argument (the helper path expands remotely):

```python
import pathlib, shlex, subprocess
script = pathlib.Path('/tmp/L14-runtime-proof.mjs').read_text()
remote = 'exec "$HOME/.local/bin/openclaw-testbox-env" env OPENCLAW_LIVE_TEST=1 node --import ./scripts/tsx.mjs --input-type=module -e ' + shlex.quote(script)
subprocess.run(['env', '-u', 'GITHUB_TOKEN', '-u', 'GH_TOKEN', '-u', 'HOMEBREW_GITHUB_API_TOKEN', 'node', 'scripts/crabbox-wrapper.mjs', 'run', '--timing-json', '--', 'bash', '-lc', remote], check=True)
```

</details>
