### PR TITLE
fix(media): correct anamorphic video attachment proportions

### DIFF
--- a/docs/nodes/media-playback.md
+++ b/docs/nodes/media-playback.md
@@ -105,9 +105,9 @@ ticket from the authenticated Gateway when needed.
 Chat attachments may include `sizeBytes`, `durationMs`, `width`, and `height`.
 OpenClaw also uses `ffprobe`, when available, to fill audio duration and video
 duration/dimensions for media facts and the Control UI `?meta=1` availability
-probe. Video dimensions account for quarter-turn display rotation; image
-dimensions account for EXIF orientation. Probing is best-effort: a missing or
-failed probe leaves fields absent instead of rejecting the attachment.
+probe. Video dimensions account for non-square pixels and quarter-turn display
+rotation; image dimensions account for EXIF orientation. Probing is best-effort:
+a missing or failed probe leaves fields absent instead of rejecting the attachment.
 
 Gateway-managed assistant attachments use these per-file caps:
 

--- a/src/media/media-probe.test.ts
+++ b/src/media/media-probe.test.ts
@@ -72,7 +72,7 @@ describe("probeMediaFile", () => {
         "-protocol_whitelist",
         "fd",
         "-show_entries",
-        "format=duration:stream=index,codec_type,codec_name,profile,pix_fmt,duration,width,height:stream_disposition=default,attached_pic:stream_side_data=rotation",
+        "format=duration:stream=index,codec_type,codec_name,profile,pix_fmt,duration,width,height,sample_aspect_ratio:stream_disposition=default,attached_pic:stream_side_data=rotation",
         "-of",
         "json",
         "-fd",
@@ -120,6 +120,39 @@ describe("probeMediaFile", () => {
       height: 1280,
     });
   });
+
+  it.each([
+    { sampleAspectRatio: "64:45", rotation: 0, width: 1024, height: 576 },
+    { sampleAspectRatio: "64:45", rotation: -90, width: 576, height: 1024 },
+    { sampleAspectRatio: "8:9", rotation: 0, width: 640, height: 576 },
+    { sampleAspectRatio: "1:1", rotation: 0, width: 720, height: 576 },
+    { sampleAspectRatio: "0:1", rotation: 0, width: 720, height: 576 },
+    { sampleAspectRatio: "N/A", rotation: 0, width: 720, height: 576 },
+  ])(
+    "returns display dimensions for SAR $sampleAspectRatio at rotation $rotation",
+    async (testCase) => {
+      runFfprobe.mockResolvedValue(
+        JSON.stringify({
+          streams: [
+            {
+              codec_type: "video",
+              width: 720,
+              height: 576,
+              sample_aspect_ratio: testCase.sampleAspectRatio,
+              side_data_list: [{ rotation: testCase.rotation }],
+            },
+          ],
+        }),
+      );
+      const display = { width: testCase.width, height: testCase.height };
+      await expect(probeMediaFile(clipPath, "video")).resolves.toEqual(display);
+      await expect(probeVideoDimensions(Buffer.from("video"))).resolves.toEqual(display);
+      await expect(probePlaybackMediaFileDescriptor(17, "video")).resolves.toMatchObject({
+        width: 720,
+        height: 576,
+      });
+    },
+  );
 
   it("probes an inherited descriptor through stdin", async () => {
     runFfprobe.mockResolvedValueOnce(JSON.stringify({ format: { duration: "2" } }));
@@ -340,7 +373,7 @@ describe("probeVideoDimensions", () => {
         "-protocol_whitelist",
         "pipe",
         "-show_entries",
-        "format=duration:stream=index,codec_type,codec_name,profile,pix_fmt,duration,width,height:stream_disposition=default,attached_pic:stream_side_data=rotation",
+        "format=duration:stream=index,codec_type,codec_name,profile,pix_fmt,duration,width,height,sample_aspect_ratio:stream_disposition=default,attached_pic:stream_side_data=rotation",
         "-of",
         "json",
         "pipe:0",

--- a/src/media/media-probe.ts
+++ b/src/media/media-probe.ts
@@ -24,6 +24,7 @@ export type PlaybackMediaProbeResult = MediaProbeResult & {
   videoPixelFormat?: string;
   videoProfile?: string;
   videoRotation?: number;
+  videoSampleAspectRatio?: number;
   videoStreamIndex?: number;
 };
 
@@ -111,6 +112,13 @@ function parseFfprobeMediaMetadata(
     parseDurationMs(format?.duration);
   const width = parsePositiveInteger(videoStream?.width);
   const height = parsePositiveInteger(videoStream?.height);
+  const [sarWidth, sarHeight] =
+    typeof videoStream?.sample_aspect_ratio === "string"
+      ? videoStream.sample_aspect_ratio
+          .split(":")
+          .map((value) => parsePositiveInteger(Number(value)))
+      : [];
+  const videoSampleAspectRatio = sarWidth && sarHeight ? sarWidth / sarHeight : undefined;
   const videoRotation = (
     Array.isArray(videoStream?.side_data_list) ? videoStream.side_data_list : []
   )
@@ -126,6 +134,7 @@ function parseFfprobeMediaMetadata(
     ...(durationMs ? { durationMs } : {}),
     ...(kind === "video" && width && height ? { width, height } : {}),
     ...(videoRotation !== undefined ? { videoRotation } : {}),
+    ...(videoSampleAspectRatio !== undefined ? { videoSampleAspectRatio } : {}),
     ...(audioCodec ? { audioCodec } : {}),
     ...(audioStreamIndex !== undefined ? { audioStreamIndex } : {}),
     ...(videoCodec ? { videoCodec } : {}),
@@ -143,7 +152,7 @@ function buildFfprobeMetadataArgs(protocol: "fd" | "pipe"): string[] {
     "-protocol_whitelist",
     protocol,
     "-show_entries",
-    "format=duration:stream=index,codec_type,codec_name,profile,pix_fmt,duration,width,height:stream_disposition=default,attached_pic:stream_side_data=rotation",
+    "format=duration:stream=index,codec_type,codec_name,profile,pix_fmt,duration,width,height,sample_aspect_ratio:stream_disposition=default,attached_pic:stream_side_data=rotation",
     "-of",
     "json",
     ...(isFileDescriptor ? ["-fd", "0"] : []),
@@ -194,12 +203,17 @@ export function toMediaProbeResult(result: PlaybackMediaProbeResult | null): Med
     return {};
   }
   const swapsAxes = Math.abs(result.videoRotation ?? 0) % 180 === 90;
+  // Non-square pixels change display width before rotation; playback keeps encoded axes.
+  const width =
+    result.width &&
+    (parsePositiveInteger(Math.round(result.width * (result.videoSampleAspectRatio ?? 1))) ??
+      result.width);
   return {
     ...(result.durationMs ? { durationMs: result.durationMs } : {}),
-    ...(result.width && result.height
+    ...(width && result.height
       ? {
-          width: swapsAxes ? result.height : result.width,
-          height: swapsAxes ? result.width : result.height,
+          width: swapsAxes ? result.height : width,
+          height: swapsAxes ? width : result.height,
         }
       : {}),
   };


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a same-repository branch; maintainers can update it directly.

</details>

## What Problem This Solves

Fixes an issue where users viewing anamorphic video attachments see unnecessary letterboxing and incorrect proportions in the attachment frame. A normal 720×576 clip intended for 16:9 playback was displayed inside a 5:4 box.

## Why This Change Was Made

Preserve ffprobe's sample aspect ratio and apply it in the existing display-dimension projection before rotation. Encoded width and height remain unchanged for playback inspection, and missing or unspecified pixel aspect ratios retain their existing behavior. The media playback documentation now describes non-square-pixel handling.

## User Impact

Anamorphic attachments use the intended display proportions in the Control UI and in consumers of the shared video-dimension helper. Ordinary square-pixel videos and the existing rotation behavior are preserved.

## Evidence

A generated, unrotated H.264 MP4 was verified with real FFmpeg/ffprobe 6.1.1 on Testbox: coded dimensions 720×576, sample aspect ratio 64:45, display aspect ratio 16:9. The actual buffer and file-batch metadata helpers returned 720×576 before this change and 1024×576 afterward.

The existing video component in Chromium confirmed native video dimensions of 1024×576. With the old metadata its rendered box measured approximately 638×510; with the corrected metadata it measured 638×359. These captures contain only a synthetic fixture:

**Before**

![Anamorphic attachment with an incorrect 5:4 frame and excess letterboxing](https://github.com/user-attachments/assets/72fc2c66-3950-46d7-b327-9285abf4f3b1)

**After**

![Anamorphic attachment with the correct 16:9 frame](https://github.com/user-attachments/assets/d5fba39b-20bf-4563-964a-e0e9f00c35c5)

The regression failed on the original implementation. All 198 focused tests pass across media probing, playback transcoding, inbound media facts, and the video component, including narrower/wider pixels, unspecified ratios, rotation, and preserved encoded dimensions. Production and core-test type graphs, typed lint, formatting, docs indexing, and independent P2 review pass.

The native and component proofs ran on the reviewed candidate; hosted PR checks provide current-main integration coverage. This does not claim a live Telegram send or a full authenticated Gateway session. The task-owned Testbox lease was stopped after proof.

Maintainer review follow-through: the exact before/after PNGs embedded above were directly inspected before upload and clearly show the incorrect 5:4 frame versus the corrected 16:9 frame. This resolves ClawSweeper's stated inability to retrieve the images in its reviewer environment. Its exact-head review found no patch defect. The Telegram proof label identifies a downstream consumer; this repair changes the shared metadata projection and preserves the Telegram adapter and API contract. Native helper and actual Chromium behavior are verified; a live Telegram send is not claimed.
