### PR TITLE
fix(ui): scope permission refresh e2e child lists

### DIFF
--- a/ui/src/e2e/chat-permission-refresh.e2e.test.ts
+++ b/ui/src/e2e/chat-permission-refresh.e2e.test.ts
@@ -25,7 +25,12 @@ suite.define(() => {
       updatedAt: 1,
     };
     const gateway = await installMockGateway(page, {
-      methodResponses: { "sessions.list": chatSessionListResponse([session]) },
+      sessions: [session],
+      methodResponses: {
+        "sessions.list": {
+          cases: [{ match: { spawnedBy: session.key }, response: chatSessionListResponse([]) }],
+        },
+      },
       sessionKey: session.key,
     });
 
@@ -41,6 +46,17 @@ suite.define(() => {
       await pane.locator('[data-chat-permission-option="workspace"]').click();
       await gateway.waitForRequest("sessions.patch");
       await gateway.waitForRequest("sessions.list", { after: listRequests, match: rosterMatch });
+      // Swarm hydration can finish here; the parent must not appear in its own child query.
+      await page.evaluate(async (key) => {
+        const app = document.querySelector("openclaw-app") as PermissionTestApp;
+        await app.runtime?.context.sessions.list({
+          spawnedBy: key,
+          includeGlobal: false,
+          includeUnknown: false,
+          configuredAgentsOnly: true,
+          limit: 10_000,
+        });
+      }, session.key);
       await gateway.rejectDeferred("sessions.list", {
         code: "UNAVAILABLE",
         message: "Roster refresh unavailable",
@@ -73,7 +89,12 @@ suite.define(() => {
       updatedAt: 1,
     };
     const gateway = await installMockGateway(page, {
-      methodResponses: { "sessions.list": chatSessionListResponse([session]) },
+      sessions: [session],
+      methodResponses: {
+        "sessions.list": {
+          cases: [{ match: { spawnedBy: session.key }, response: chatSessionListResponse([]) }],
+        },
+      },
       sessionKey: session.key,
     });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent Control UI permission-refresh E2E failure that blocks unrelated changes. The test confirms that the permission was saved, then times out waiting for the refresh-failure warning.

Related: https://github.com/openclaw/openclaw/actions/runs/34096957599/job/101662836808

## Why This Change Was Made

The fixture returned the parent session for its own `spawnedBy` child query. Swarm hydration can issue that query while the post-patch roster refresh is pending. Its impossible parent result arrives at a newer list revision, supersedes the permission projection, and suppresses the warning. The real Gateway filters parent rows out of this child query.

Both scenarios now seed their canonical session explicitly and return an empty child list. Other list requests use the existing canonical mock owner. The saved-permission scenario deliberately completes that child query before rejecting the pending roster refresh, making the previously intermittent ordering reproducible. No production code changes.

## User Impact

No product behavior or appearance change. The test preserves saved-mode, enabled-control, warning-content, newer-event ordering, and request-count assertions without retries, timing delays, increased timeouts, or broader mocks.

## Evidence

Current proof head: `9aa55ed7e4b1254bc9d3199a29b11722fa2716b8`, refreshed onto main `e3e2953f4b9a`. The fixture repair is patch-identical by range-diff; both cases pass in a fresh **5/5** loop and `node scripts/check-changed.mjs` passes again after the refresh.

- Unchanged exact file under `CI=1`, two workers: **5/5** passed, confirming the natural failure is intermittent.
- Controlled child-query ordering with the original fixture: **0/1** passed; reproduced the exact missing “Permissions were saved” warning. The existing local 10-second locator timeout and CI 30-second timeout are unchanged.
- Repaired exact file, including the controlled ordering: **5/5** passed, 2/2 cases each run.
- Independent Codex review: clean through P2, zero actionable findings.
- `node scripts/check-changed.mjs`: passed, including UI E2E typecheck, lint, formatting, i18n, and all selected guards.

```sh
CI=1 OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY=1 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-permission-refresh.e2e.test.ts
node scripts/check-changed.mjs
```

The original CI uses the same UI E2E configuration, shard 5/6. Local runs select the exact file and use a task-owned filesystem module cache. Browser/Gateway data is synthetic; no external-provider live claim or Testbox lease. Production delta: 0; test delta: +23/-2 (net +21). Exact-head CI remains required before landing.

### Landing status

#141092 repaired the unrelated Mermaid module-mock leak and is verified on main. The previous refreshed head passed every UI, E2E, and real-Gateway UI job, but encountered an unrelated 1,012/1,000 Telegram test line-limit failure. Upstream #141139 fixed that lint failure by consolidating duplicate test cases; its squash `908e5441f456ae327f059601b87a8b78ac32a395` is verified on main.

This head is refreshed onto that repair, with a patch-identical range-diff, another **5/5** focused E2E loop (2/2 cases each), and passing changed checks. [Exact-head CI run34112418097](https://github.com/openclaw/openclaw/actions/runs/34112418097) passed; the native watcher reports SUCCESS with zero pending checks. Native preparation passed at the same exact head with `OPENCLAW_TESTBOX=1`; merge is next.
