### PR TITLE
refactor(status): remove unreachable scan modes

### DIFF
--- a/src/commands/status.cold-imports.test.ts
+++ b/src/commands/status.cold-imports.test.ts
@@ -43,7 +43,7 @@ describe("status cold imports", () => {
     await expect(resolveStatusRuntimeSnapshot(params)).resolves.toEqual(snapshot);
   });
 
-  it("keeps broad plugin status code behind the detailed status boundary", async () => {
+  it("keeps broad plugin status code out of default status imports", async () => {
     vi.doMock("../plugins/status.js", () => {
       throw new Error("default status must not import broad plugin diagnostics");
     });

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -133,12 +133,7 @@ export async function statusCommand(
 
   const scan = await statusScanModuleLoader
     .load()
-    .then(({ scanStatus }) =>
-      scanStatus(
-        { json: false, timeoutMs: opts.timeoutMs, all: opts.all, deep: opts.deep },
-        runtime,
-      ),
-    );
+    .then(({ scanStatus }) => scanStatus({ timeoutMs: opts.timeoutMs, deep: opts.deep }));
 
   const {
     cfg,

--- a/src/commands/status.scan.fast-json.test.ts
+++ b/src/commands/status.scan.fast-json.test.ts
@@ -306,6 +306,46 @@ describe("scanStatusJsonFast", () => {
     expect(mocks.probeGateway).not.toHaveBeenCalled();
   });
 
+  it("keeps status --json on read-only channel metadata when channel config exists", async () => {
+    const resolvedConfig = {
+      marker: "resolved-preload",
+      plugins: { enabled: false },
+      channels: { telegram: { enabled: false } },
+    };
+    applyStatusScanDefaults(mocks, {
+      hasConfiguredChannels: true,
+      sourceConfig: {
+        marker: "source-preload",
+        plugins: { enabled: false },
+        channels: { telegram: { enabled: false } },
+      } as never,
+      resolvedConfig: resolvedConfig as never,
+      summary: createStatusSummary({ linkChannel: { linked: false } }),
+    });
+
+    await scanStatusJsonFast({}, {} as never);
+
+    expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
+    expect(loggingStateRef.forceConsoleToStderr).toBe(false);
+    expect(mocks.probeGateway).toHaveBeenCalledOnce();
+    const probeArgs = firstCallArg(mocks.probeGateway, "probeGateway args") as {
+      env?: NodeJS.ProcessEnv;
+    };
+    expect(probeArgs).toMatchObject({
+      url: "ws://127.0.0.1:18789",
+      config: resolvedConfig,
+      auth: {},
+      timeoutMs: 1000,
+      detailLevel: "presence",
+    });
+    expect(probeArgs.env).toBe(process.env);
+    expect(
+      mocks.callGateway.mock.calls.some(([call]) => {
+        return (call as { method?: unknown } | undefined)?.method === "channels.status";
+      }),
+    ).toBe(false);
+  });
+
   it("keeps cold-start gateway probes with local-only updates when a channel is configured from manifest env vars", async () => {
     await withTemporaryEnv(
       {

--- a/src/commands/status.scan.fast-json.ts
+++ b/src/commands/status.scan.fast-json.ts
@@ -27,20 +27,6 @@ const STATUS_JSON_CHANNEL_ENV_VARS = new Set(
   ),
 );
 
-type StatusJsonScanPolicy = {
-  commandName: string;
-  allowMissingConfigFastPath?: boolean;
-  fetchGitUpdate?: boolean;
-  includeRegistryUpdate?: boolean;
-  includeLocalStatusRpcFallback?: boolean;
-  gatewayProbeTimeoutMs?: number;
-  resolveHasConfiguredChannels: (
-    cfg: OpenClawConfig,
-    sourceConfig: OpenClawConfig,
-  ) => boolean | Promise<boolean>;
-  resolveMemory: Parameters<typeof executeStatusScanFromOverview>[0]["resolveMemory"];
-};
-
 function hasMeaningfulStatusJsonChannelConfig(value: unknown): boolean {
   if (!isRecord(value)) {
     return false;
@@ -83,28 +69,27 @@ function hasPotentialConfiguredChannelsForStatusJson(cfg: OpenClawConfig): boole
   return hasExplicitStatusJsonChannelConfig(cfg) || hasStatusJsonChannelEnvConfig();
 }
 
-/** Runs status JSON with an injectable policy for tests and specialized callers. */
-export async function scanStatusJsonWithPolicy(
+/** Runs the default fast status JSON scan. */
+export async function scanStatusJsonFast(
   opts: {
     timeoutMs?: number;
     all?: boolean;
   },
   runtime: RuntimeEnv,
-  policy: StatusJsonScanPolicy,
 ): Promise<StatusScanResult> {
   const overview = await collectStatusScanOverview({
     env: process.env,
-    commandName: policy.commandName,
+    commandName: "status --json",
     opts,
     showSecrets: false,
     runtime,
-    allowMissingConfigFastPath: policy.allowMissingConfigFastPath,
-    resolveHasConfiguredChannels: policy.resolveHasConfiguredChannels,
+    allowMissingConfigFastPath: true,
+    resolveHasConfiguredChannels: (cfg) => hasPotentialConfiguredChannelsForStatusJson(cfg),
     includeChannelsData: false,
-    fetchGitUpdate: policy.fetchGitUpdate,
-    includeRegistryUpdate: policy.includeRegistryUpdate,
-    includeLocalStatusRpcFallback: policy.includeLocalStatusRpcFallback,
-    gatewayProbeTimeoutMs: policy.gatewayProbeTimeoutMs,
+    fetchGitUpdate: opts.all === true,
+    includeRegistryUpdate: opts.all === true,
+    includeLocalStatusRpcFallback: opts.all === true,
+    gatewayProbeTimeoutMs: opts.all === true ? undefined : (opts.timeoutMs ?? 1000),
   });
   const pluginCompatibility = opts.all
     ? await statusScanPluginStatusModuleLoader
@@ -116,29 +101,6 @@ export async function scanStatusJsonWithPolicy(
   return await executeStatusScanFromOverview({
     overview,
     runtime,
-    resolveMemory: policy.resolveMemory,
-    channelIssues: [],
-    channels: { rows: [], details: [] },
-    pluginCompatibility,
-  });
-}
-
-/** Runs the default fast status JSON scan. */
-export async function scanStatusJsonFast(
-  opts: {
-    timeoutMs?: number;
-    all?: boolean;
-  },
-  runtime: RuntimeEnv,
-): Promise<StatusScanResult> {
-  return await scanStatusJsonWithPolicy(opts, runtime, {
-    commandName: "status --json",
-    allowMissingConfigFastPath: true,
-    fetchGitUpdate: opts.all === true,
-    includeRegistryUpdate: opts.all === true,
-    includeLocalStatusRpcFallback: opts.all === true,
-    gatewayProbeTimeoutMs: opts.all === true ? undefined : (opts.timeoutMs ?? 1000),
-    resolveHasConfiguredChannels: (cfg) => hasPotentialConfiguredChannelsForStatusJson(cfg),
     resolveMemory: async ({ cfg, agentStatus, memoryPlugin }) => {
       if (!opts.all) {
         return null;
@@ -152,5 +114,8 @@ export async function scanStatusJsonFast(
         requireDefaultDatabasePath: resolveDefaultMemoryDatabasePath,
       });
     },
+    channelIssues: overview.channelIssues,
+    channels: overview.channels,
+    pluginCompatibility,
   });
 }

--- a/src/commands/status.scan.test.ts
+++ b/src/commands/status.scan.test.ts
@@ -8,7 +8,6 @@ import {
   createStatusScanConfig,
   createStatusSummary,
   loadStatusScanModuleForTest,
-  withTemporaryEnv,
 } from "./status.scan.test-helpers.js";
 
 const mocks = {
@@ -76,14 +75,6 @@ function configureScanStatus(
   mocks.getStatusCommandSecretTargetIds.mockReturnValue(new Set<string>());
 }
 
-function firstCallArg(mock: { mock: { calls: unknown[][] } }, label: string): unknown {
-  const arg = mock.mock.calls[0]?.[0];
-  if (arg === undefined) {
-    throw new Error(`expected ${label}`);
-  }
-  return arg;
-}
-
 function firstBuildChannelsTableCall(): unknown[] {
   const call = mocks.buildChannelsTable.mock.calls[0];
   if (!call) {
@@ -109,7 +100,7 @@ describe("scanStatus", () => {
       summary: createStatusSummary({ linkChannel: { linked: false } }),
     });
 
-    await scanStatus({ json: false }, {} as never);
+    await scanStatus({});
 
     expect(mocks.getStatusSummary).toHaveBeenCalledWith({
       config: resolvedConfig,
@@ -147,7 +138,7 @@ describe("scanStatus", () => {
       configSnapshot: null,
     });
 
-    await scanStatus({ json: false }, {} as never);
+    await scanStatus({});
 
     expect(
       mocks.callGateway.mock.calls.some(([call]) => {
@@ -176,7 +167,7 @@ describe("scanStatus", () => {
   it("bounds gateway secret resolution by the fast status probe budget", async () => {
     configureScanStatus();
 
-    await scanStatus({ json: false }, {} as never);
+    await scanStatus({});
 
     expect(mocks.resolveCommandSecretRefsViaGateway).toHaveBeenCalledWith(
       expect.objectContaining({ gatewaySecretResolveTimeoutMs: 2500 }),
@@ -210,7 +201,7 @@ describe("scanStatus", () => {
       configSnapshot: null,
     });
 
-    await scanStatus({ json: false, deep: true, timeoutMs: 5000 }, {} as never);
+    await scanStatus({ deep: true, timeoutMs: 5000 });
 
     expect(mocks.callGateway).toHaveBeenCalledTimes(2);
     expect(
@@ -237,52 +228,6 @@ describe("scanStatus", () => {
     ]);
   });
 
-  it("skips channel plugin preload for status --json with no channel config", async () => {
-    configureScanStatus({
-      sourceConfig: createStatusScanConfig({
-        plugins: { enabled: false },
-      }),
-      resolvedConfig: createStatusScanConfig({
-        plugins: { enabled: false },
-      }),
-    });
-
-    await scanStatus({ json: true }, {} as never);
-
-    expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
-  });
-
-  it("skips plugin compatibility loading for status --json when the config file is missing", async () => {
-    configureScanStatus({
-      sourceConfig: createStatusScanConfig({
-        plugins: { enabled: true },
-      }),
-      resolvedConfig: createStatusScanConfig({
-        plugins: { enabled: true },
-      }),
-    });
-
-    await scanStatus({ json: true }, {} as never);
-
-    expect(mocks.buildPluginCompatibilityNotices).not.toHaveBeenCalled();
-  });
-
-  it("skips plugin compatibility loading for status --json even with configured channels", async () => {
-    configureScanStatus({
-      hasConfiguredChannels: true,
-      sourceConfig: createStatusScanConfig({
-        channels: { discord: {} },
-      }),
-      resolvedConfig: createStatusScanConfig({
-        channels: { discord: {} },
-      }),
-    });
-
-    await scanStatus({ json: true }, {} as never);
-
-    expect(mocks.buildPluginCompatibilityNotices).not.toHaveBeenCalled();
-  });
-
   it("skips gateway and update probes on cold-start status paths", async () => {
     configureScanStatus({
       sourceConfig: createStatusScanConfig({
@@ -295,103 +240,18 @@ describe("scanStatus", () => {
       gatewayProbe: false,
     });
 
-    await scanStatus({ json: true }, {} as never);
-    await scanStatus({ json: false }, {} as never);
+    await scanStatus({});
 
     expect(mocks.getUpdateCheckResult).not.toHaveBeenCalled();
     expect(mocks.probeGateway).not.toHaveBeenCalled();
   });
 
-  it("skips memory backend inspection for default memory-core with no existing store", async () => {
-    configureScanStatus();
-
-    await scanStatus({ json: true }, {} as never);
-
-    expect(mocks.getMemorySearchManager).not.toHaveBeenCalled();
-  });
-
   it("keeps default text status off plugin compatibility and memory scans", async () => {
     configureScanStatus({ memoryConfigured: true });
 
-    await scanStatus({ json: false }, {} as never);
+    await scanStatus({});
 
     expect(mocks.buildPluginCompatibilityNotices).not.toHaveBeenCalled();
     expect(mocks.getMemorySearchManager).not.toHaveBeenCalled();
-  });
-
-  it("inspects memory backend when memory search is explicitly configured", async () => {
-    configureScanStatus({ memoryConfigured: true });
-
-    await scanStatus({ json: true }, {} as never);
-
-    expect(mocks.getMemorySearchManager).toHaveBeenCalledOnce();
-    expect(firstCallArg(mocks.getMemorySearchManager, "memory search manager args")).toStrictEqual({
-      cfg: createStatusMemorySearchConfig(),
-      agentId: "main",
-      purpose: "status",
-      inspectSources: true,
-    });
-  });
-
-  it("keeps status --json on read-only channel metadata when channel config exists", async () => {
-    const resolvedConfig = createStatusScanConfig({
-      marker: "resolved-preload",
-      plugins: { enabled: false },
-      channels: { telegram: { enabled: false } },
-    });
-    configureScanStatus({
-      hasConfiguredChannels: true,
-      sourceConfig: createStatusScanConfig({
-        marker: "source-preload",
-        plugins: { enabled: false },
-        channels: { telegram: { enabled: false } },
-      }),
-      resolvedConfig,
-      summary: createStatusSummary({ linkChannel: { linked: false } }),
-    });
-
-    await scanStatus({ json: true }, {} as never);
-
-    expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
-    // Verify plugin logs were routed to stderr during loading and restored after
-    expect(loggingStateRef.forceConsoleToStderr).toBe(false);
-    expect(mocks.probeGateway).toHaveBeenCalledOnce();
-    const probeArgs = firstCallArg(mocks.probeGateway, "probeGateway args") as {
-      env?: NodeJS.ProcessEnv;
-    };
-    expect(probeArgs).toMatchObject({
-      url: "ws://127.0.0.1:18789",
-      config: resolvedConfig,
-      auth: {},
-      timeoutMs: 2500,
-      detailLevel: "presence",
-    });
-    expect(probeArgs.env).toBe(process.env);
-    expect(
-      mocks.callGateway.mock.calls.some(([call]) => {
-        return (call as { method?: unknown } | undefined)?.method === "channels.status";
-      }),
-    ).toBe(false);
-  });
-
-  it("keeps status --json on read-only channel metadata when channel auth is env-only", async () => {
-    configureScanStatus({
-      hasConfiguredChannels: true,
-      sourceConfig: createStatusScanConfig({
-        marker: "source-env-only",
-        plugins: { enabled: false },
-      }),
-      resolvedConfig: createStatusScanConfig({
-        marker: "resolved-env-only",
-        plugins: { enabled: false },
-      }),
-      summary: createStatusSummary({ linkChannel: { linked: false } }),
-    });
-
-    await withTemporaryEnv({ MATRIX_ACCESS_TOKEN: "token" }, async () => {
-      await scanStatus({ json: true }, {} as never);
-    });
-
-    expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -7,12 +7,10 @@ import { collectStatusScanOverview } from "./status.scan-overview.ts";
 import type { StatusScanResult } from "./status.scan-result.ts";
 
 /** Runs the text status scan. */
-export async function scanStatus(
-  opts: {
-    timeoutMs?: number;
-    deep?: boolean;
-  },
-): Promise<StatusScanResult> {
+export async function scanStatus(opts: {
+  timeoutMs?: number;
+  deep?: boolean;
+}): Promise<StatusScanResult> {
   return await withProgress(
     {
       label: "Scanning status…",

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -1,66 +1,35 @@
-// Top-level status scan entrypoint.
-// Chooses fast JSON policy or full human scan and returns one normalized scan result.
+// Top-level text status scan entrypoint.
+// Human `status --all` and JSON status use their dedicated command paths.
 
 import { withProgress } from "../cli/progress.js";
-import { hasConfiguredChannelsForReadOnlyScope } from "../plugins/channel-plugin-ids.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { executeStatusScanFromOverview } from "./status.scan-execute.ts";
-import { resolveStatusMemoryStatusSnapshot } from "./status.scan-memory.ts";
 import { collectStatusScanOverview } from "./status.scan-overview.ts";
 import type { StatusScanResult } from "./status.scan-result.ts";
-import { scanStatusJsonWithPolicy } from "./status.scan.fast-json.js";
 
-/** Runs the status scan for text or JSON command modes. */
+/** Runs the text status scan. */
 export async function scanStatus(
   opts: {
-    json?: boolean;
     timeoutMs?: number;
-    all?: boolean;
     deep?: boolean;
   },
-  _runtime: RuntimeEnv,
 ): Promise<StatusScanResult> {
-  if (opts.json) {
-    // JSON mode uses a policy wrapper so tests and `status-json` can tune fast-path behavior.
-    return await scanStatusJsonWithPolicy(
-      {
-        timeoutMs: opts.timeoutMs,
-        all: opts.all,
-      },
-      _runtime,
-      {
-        commandName: "status --json",
-        resolveHasConfiguredChannels: (cfg, sourceConfig) =>
-          hasConfiguredChannelsForReadOnlyScope({
-            config: cfg,
-            activationSourceConfig: sourceConfig,
-          }),
-        resolveMemory: async ({ cfg, agentStatus, memoryPlugin }) =>
-          await resolveStatusMemoryStatusSnapshot({
-            cfg,
-            agentStatus,
-            memoryPlugin,
-          }),
-      },
-    );
-  }
   return await withProgress(
     {
       label: "Scanning status…",
-      total: 10,
+      total: 9,
       enabled: true,
     },
     async (progress) => {
-      const isFullScan = opts.all === true || opts.deep === true;
+      const isDetailedScan = opts.deep === true;
       const overview = await collectStatusScanOverview({
         env: process.env,
         commandName: "status",
         opts,
         showSecrets: process.env.OPENCLAW_SHOW_SECRETS?.trim() !== "0",
-        includeLiveChannelStatus: isFullScan,
-        includeChannelSetupRuntimeFallback: isFullScan,
-        fetchGitUpdate: isFullScan,
-        includeRegistryUpdate: isFullScan,
+        includeLiveChannelStatus: isDetailedScan,
+        includeChannelSetupRuntimeFallback: isDetailedScan,
+        fetchGitUpdate: isDetailedScan,
+        includeRegistryUpdate: isDetailedScan,
         includeAdvertisedControlUiLinks: true,
         progress,
         labels: {
@@ -74,29 +43,13 @@ export async function scanStatus(
         },
       });
 
-      progress.setLabel("Checking plugins…");
-      const pluginCompatibility = opts.all
-        ? await import("../plugins/status.js").then(({ buildPluginCompatibilitySnapshotNotices }) =>
-            buildPluginCompatibilitySnapshotNotices({ config: overview.cfg }),
-          )
-        : [];
-      progress.tick();
-
       progress.setLabel("Checking memory and sessions…");
       const result = await executeStatusScanFromOverview({
         overview,
-        resolveMemory: async ({ cfg, agentStatus, memoryPlugin }) =>
-          // Memory plugin probing can touch disk/plugin state; reserve it for full scans.
-          opts.all
-            ? await resolveStatusMemoryStatusSnapshot({
-                cfg,
-                agentStatus,
-                memoryPlugin,
-              })
-            : null,
+        resolveMemory: async () => null,
         channelIssues: overview.channelIssues,
         channels: overview.channels,
-        pluginCompatibility,
+        pluginCompatibility: [],
       });
       progress.tick();
 

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1184,10 +1184,7 @@ describe("statusCommand", () => {
 
     await statusCommand({ deep: true, timeoutMs: 5000 }, runtime as never);
 
-    expect(scanStatus).toHaveBeenCalledWith(
-      { json: false, timeoutMs: 5000, all: undefined, deep: true },
-      runtime,
-    );
+    expect(scanStatus).toHaveBeenCalledWith({ timeoutMs: 5000, deep: true });
   });
 
   it("surfaces unknown usage when totalTokens is missing", async () => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Removes unreachable legacy scan modes from the text `openclaw status` scanner.
The dedicated fast JSON status path remains the owner for JSON output, so the
old scanner-side JSON and `--all` branches only preserved duplicate dead policy.

## Why This Change Was Made

The command now has one canonical Status scan path for text output and keeps the
fast JSON path separate. This reduces duplicated progress/accounting behavior
without changing the public status command contract.

## User Impact

No intentional user-visible behavior change. Operators keep the same status
command behavior, with less stale internal branching behind it.

## Evidence

- Source head: `b83ada0bf0e81d47a7daba44e5e9d3ce37e4a6f7`
- Fixed base: `96bf3652adabc25d86af15a950a72be63575acc5`
- Patch SHA-256: `991984bea57715b8e086dd31af676e1b3864b36b4d52a85a325698941040b8d0`
- Scope: 7 files under `src/commands/status*`
- Delta: production `+28/-117` (net `-89`), tests `+48/-151` (net `-103`)
- Local proof: `git diff --check` passed; `git verify-commit` passed.
- Pinned Oxfmt 0.65.0 on-disk `--check --threads=1` passed all seven changed files.
- Independent actual-source and prepush verification passed for this exact head.
- Fresh whole-candidate P3 review against the fixed base was clean: `scoped-clean`, findings `[]`, `patch is correct`, confidence `0.94`, process exit `0`. The reviewed candidate's patch hash matches this signed head.

The previous-head CI run, https://github.com/openclaw/openclaw/actions/runs/34100297799,
failed formatting and also reported an `ENOTEMPTY` cleanup failure whose cause
remains unattributed. This successor changes only the approved formatting hunk;
it does not claim to repair that separate failure.

Exact-head hosted CI passed:
https://github.com/openclaw/openclaw/actions/runs/34103341809 (attempt 1).
Actual job logs establish 192 passing cases across 11 required Status/CLI files.
Build job 101682870157 completed `build:ci-artifacts`, generated-assets,
packing and built-artifact checks, and packaged Node and Bun
`openclaw.mjs status --json --timeout 1` smoke. Lint, production/test types,
guards, dependencies, source contracts, boundaries, and aggregate CI passed.

Exact-head ClawSweeper review completed with no actionable findings or remaining
rank-up moves:
https://github.com/openclaw/openclaw/pull/141021#issuecomment-5567789853

No new authenticated Gateway/channel or manual text/deep/all operator session
was run. Those unchanged paths have source and executed test coverage;
packaged JSON smoke is real CLI proof, not live-service proof. Runtime tests
and build proof above ran in hosted CI, not locally.

AI-assisted implementation, independently reviewed.
