### PR TITLE
fix: live test suites pass green when provider credentials are missing

### DIFF
--- a/docs/help/testing-live.md
+++ b/docs/help/testing-live.md
@@ -666,6 +666,7 @@ Live tests discover credentials the same way the CLI does. Practical implication
 
 - If the CLI works, live tests should find the same keys.
 - If a live test says "no creds", debug the same way you'd debug `openclaw models list` / model selection.
+- An OpenClaw live suite that cannot resolve its credentials must skip visibly in the reporter with Vitest test-context `skip(reason)` or fail; it must never pass green without reaching the provider, because a green run that did not reach the provider is not live evidence.
 
 - Per-agent auth profiles: SQLite credential rows in `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite` (this is what "profile keys" means in the live tests)
 - Config: `~/.openclaw/openclaw.json` (or `OPENCLAW_CONFIG_PATH`)

--- a/extensions/github-copilot/connection-bound-ids.live.test.ts
+++ b/extensions/github-copilot/connection-bound-ids.live.test.ts
@@ -136,11 +136,13 @@ async function resolveGithubTokenCandidates(): Promise<Array<{ source: string; t
 }
 
 describeLive("github-copilot connection-bound Responses IDs live", () => {
-  it("rewrites replayed item IDs and preserves streamed tool arguments", async () => {
+  it("rewrites replayed item IDs and preserves streamed tool arguments", async ({ skip }) => {
     logProgress("start");
     const candidates = await resolveGithubTokenCandidates();
     if (candidates.length === 0) {
-      logProgress("skip (no GitHub Copilot token found in env or auth profile)");
+      skip(
+        "No GitHub Copilot token found in env vars OPENCLAW_LIVE_GITHUB_COPILOT_TOKEN / COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN or the github-copilot auth profile",
+      );
       return;
     }
 

--- a/extensions/music-generation-providers.live.test.ts
+++ b/extensions/music-generation-providers.live.test.ts
@@ -31,7 +31,7 @@ import {
   resolveConfiguredLiveMusicModels,
   resolveLiveMusicAuthStore,
 } from "openclaw/plugin-sdk/test-media-generation";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import falPlugin from "./fal/index.js";
 import googlePlugin from "./google/index.js";
 import minimaxPlugin from "./minimax/index.js";
@@ -137,6 +137,7 @@ function expectMusicLiveSweepPassed(params: {
   attempted: string[];
   failures: string[];
   providerFilter: Set<string> | null;
+  skip: (note: string) => void;
   skipped: string[];
 }): void {
   if (params.attempted.length === 0) {
@@ -146,7 +147,9 @@ function expectMusicLiveSweepPassed(params: {
         `[live:music-generation] requested provider filter produced no live attempts: ${formatProviderFilter(params.providerFilter)}; skipped=${params.skipped.join(", ") || "none"}`,
       );
     }
-    console.warn("[live:music-generation] no provider had usable auth; skipping assertions");
+    params.skip(
+      `[live:music-generation] no live music attempt completed; skipped=${params.skipped.join(", ") || "none"}`,
+    );
     return;
   }
   expect(params.failures).toStrictEqual([]);
@@ -195,7 +198,7 @@ function resolveLiveMusicSkipReason(providerId: string, error: unknown): string 
 describeLive("music generation provider live", () => {
   it(
     "covers generate plus declared edit paths with shell/profile auth",
-    async () => {
+    async ({ skip }) => {
       const cfg = withPluginsEnabled(await readLiveTestConfig());
       const configuredModels = resolveConfiguredLiveMusicModels(cfg);
       const agentDir = resolveDefaultAgentDir(cfg as never);
@@ -325,21 +328,40 @@ describeLive("music generation provider live", () => {
         `[live:music-generation] attempted=${attempted.join(", ") || "none"} skipped=${skipped.join(", ") || "none"} failures=${failures.join(" | ") || "none"} shellEnv=${getShellEnvAppliedKeys().join(", ") || "none"}`,
       );
 
-      expectMusicLiveSweepPassed({ attempted, failures, providerFilter, skipped });
+      expectMusicLiveSweepPassed({ attempted, failures, providerFilter, skip, skipped });
     },
     10 * 60_000,
   );
 });
 
 describe("music generation live provider filter coverage", () => {
+  it("skips unfiltered sweeps when no provider is attempted", () => {
+    const skip = vi.fn();
+    expect(() =>
+      expectMusicLiveSweepPassed({
+        attempted: [],
+        failures: [],
+        providerFilter: null,
+        skip,
+        skipped: ["minimax: no usable auth", "google: no model configured"],
+      }),
+    ).not.toThrow();
+    expect(skip).toHaveBeenCalledExactlyOnceWith(
+      expect.stringContaining("minimax: no usable auth, google: no model configured"),
+    );
+  });
+
   it("fails filtered sweeps when no requested provider is attempted", () => {
+    const skip = vi.fn();
     expect(() =>
       expectMusicLiveSweepPassed({
         attempted: [],
         failures: [],
         providerFilter: new Set(["minimax"]),
+        skip,
         skipped: ["minimax: no usable auth"],
       }),
     ).toThrow(/requested provider filter produced no live attempts: minimax/u);
+    expect(skip).not.toHaveBeenCalled();
   });
 });

--- a/extensions/video-generation-providers.live.test.ts
+++ b/extensions/video-generation-providers.live.test.ts
@@ -43,7 +43,7 @@ import type {
   VideoGenerationProvider,
   VideoGenerationRequest,
 } from "openclaw/plugin-sdk/test-media-generation";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import alibabaPlugin from "./alibaba/index.js";
 import byteplusPlugin from "./byteplus/index.js";
 import deepinfraPlugin from "./deepinfra/index.js";
@@ -365,6 +365,7 @@ function expectLiveVideoCasePassed(
     attempted: string[];
     failures: string[];
     providerId: string;
+    skip: (note: string) => void;
     skipped: string[];
   },
   activeProviderFilter = providerFilter,
@@ -377,7 +378,9 @@ function expectLiveVideoCasePassed(
         `[live:video-generation] requested provider produced no live attempts: ${params.providerId}; skipped=${params.skipped.join(", ") || "none"}`,
       );
     }
-    console.warn("[live:video-generation] no live video attempt completed; skipping assertions");
+    params.skip(
+      `[live:video-generation] no live video attempt completed for ${params.providerId}; skipped=${params.skipped.join(", ") || "none"}`,
+    );
     return;
   }
   expect(params.failures).toStrictEqual([]);
@@ -400,14 +403,17 @@ function resolveLiveSmokeDurationSeconds(params: {
   );
 }
 
-async function runLiveVideoProviderCase(testCase: LiveProviderCase): Promise<void> {
+async function runLiveVideoProviderCase(
+  testCase: LiveProviderCase,
+  skip: (note: string) => void,
+): Promise<void> {
   const cfg = withPluginsEnabled(await readLiveTestConfig());
   const configuredModels = resolveConfiguredLiveVideoModels(cfg);
   const agentDir = resolveDefaultAgentDir(cfg as never);
   const attempted: string[] = [];
   const skipped: string[] = [];
   const failures: string[] = [];
-  const summaryParams = { attempted, failures, providerId: testCase.providerId, skipped };
+  const summaryParams = { attempted, failures, providerId: testCase.providerId, skip, skipped };
 
   maybeLoadShellEnvForVideoProviders([testCase.providerId]);
 
@@ -627,8 +633,8 @@ describeLive("video generation provider live", () => {
     // One provider per test keeps cumulative suite runtime from tripping a single timeout cap.
     it(
       `covers declared video-generation modes with shell/profile auth (${testCase.providerId})`,
-      async () => {
-        await runLiveVideoProviderCase(testCase);
+      async ({ skip }) => {
+        await runLiveVideoProviderCase(testCase, skip);
       },
       LIVE_VIDEO_TEST_TIMEOUT_MS,
     );
@@ -642,26 +648,39 @@ describe("video generation live provider filter coverage", () => {
     );
   });
 
-  it("keeps unfiltered zero-attempt provider cases advisory", () => {
-    expectLiveVideoCasePassed({
-      attempted: [],
-      failures: [],
-      providerId: "local-only",
-      skipped: ["local-only: no usable auth"],
-    });
+  it("skips unfiltered zero-attempt provider cases", () => {
+    const skip = vi.fn();
+    expect(() =>
+      expectLiveVideoCasePassed(
+        {
+          attempted: [],
+          failures: [],
+          providerId: "local-only",
+          skip,
+          skipped: ["local-only: no usable auth"],
+        },
+        null,
+      ),
+    ).not.toThrow();
+    expect(skip).toHaveBeenCalledExactlyOnceWith(
+      expect.stringContaining("local-only: no usable auth"),
+    );
   });
 
   it("fails filtered provider cases when the requested provider is not attempted", () => {
+    const skip = vi.fn();
     expect(() =>
       expectLiveVideoCasePassed(
         {
           attempted: [],
           failures: [],
           providerId: "minimax",
+          skip,
           skipped: ["minimax: no usable auth"],
         },
         new Set(["minimax"]),
       ),
     ).toThrow(/requested provider produced no live attempts: minimax/u);
+    expect(skip).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where live test suites under `extensions/` would report a passing test when `OPENCLAW_LIVE_TEST=1` was set but no provider credential could be resolved. `extensions/github-copilot/connection-bound-ids.live.test.ts` logged a skip message to stderr and returned, so the reporter showed a green live test that never contacted GitHub Copilot. A Testbox run on 2026-09-07 took that green as live proof for another PR. The music and video generation live sweeps had the same shape: an unfiltered run with zero provider attempts warned and passed.

Per `docs/help/testing-live.md` and root `AGENTS.md`, a green run that did not reach the provider is not live evidence.

## Why This Change Was Made

The Copilot suite resolves its token asynchronously (env vars, then the `github-copilot` auth profile), so the usual static `describe.skip` gate on key presence cannot cover it; the runtime check needs the Vitest test-context `skip(reason)` already used by the OpenAI realtime live suites. The sweep helpers get an explicit `skip` callback threaded from the test context, which keeps them unit-testable with a stub. Filtered zero-attempt runs still throw, and a present-but-invalid Copilot token still fails; only the missing-credential path changes from green to a visible skip.

Every `extensions/**/*.live.test.ts` file (55) was audited. Suites that gate statically on key presence already show as skipped; provider-side drift tolerances after contact (xAI billing drift, Moonshot auth drift, OpenAI image-description skip reason) and ffmpeg-unavailable sub-steps are a different class and are untouched.

## User Impact

Developers and release/Testbox runs can no longer mistake a credential-less live run for provider proof: the reporter shows the test as skipped with the reason, or the run fails. No runtime or product behavior changes.

## Evidence

Isolated run (fresh empty `HOME`/state dir, no token env, `OPENCLAW_LIVE_TEST=1`) of the Copilot suite after the fix:

```text
[github-copilot-live] start
 ↓ extensions/github-copilot/connection-bound-ids.live.test.ts > github-copilot connection-bound Responses IDs live > rewrites replayed item IDs and preserves streamed tool arguments [No GitHub Copilot token found in env vars OPENCLAW_LIVE_GITHUB_COPILOT_TOKEN / COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN or the github-copilot auth profile]
 Test Files  1 passed (1)
      Tests  1 skipped (1)
```

Before the fix the same invocation printed `✓ ... rewrites replayed item IDs ...` and `Tests 1 passed (1)`.

Same isolated invocation with a synthetic invalid token in `OPENCLAW_LIVE_GITHUB_COPILOT_TOKEN`: the test fails with `Copilot authentication failed for all candidates: env: Copilot authentication failed: HTTP 401` (present-but-invalid credentials remain a failure, not a skip).

Music/video sweep files without live opt-in: 6 unit tests pass (including the new skip-callback assertions, which failed against the original helpers) and the 14 live cases are statically skipped. The sweeps were not run in live mode.

`node scripts/check-changed.mjs`: 18 checks ok including `typecheck extension tests`; the `lint extensions` lane cannot run in this nested worktree (declaration-boundary guard rejects the ancestor install), so the changed files were linted directly with `oxlint --tsconfig test/tsconfig/tsconfig.extensions.test.json` (clean) and formatting verified with `oxfmt --check`. CI covers the full lint lane.
