### PR TITLE
refactor(sessions): share maintenance phase planning

### DIFF
--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -30,16 +30,12 @@ import {
   inspectSqliteSessionHistoryDiskBudget,
 } from "./session-history-eviction.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+import { planSessionEntryMaintenance } from "./store-maintenance-plan.js";
 import { collectSessionMaintenancePreserveKeysForStore } from "./store-maintenance-preserve.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import {
-  archiveStaleDashboardEntries,
-  capEntryCount,
   countUnarchivedSessionEntries,
-  pruneStaleModelRunEntries,
-  pruneStaleEntries,
   shouldPreserveMaintenanceEntry,
-  shouldRunModelRunPrune,
   type ResolvedSessionMaintenanceConfig,
 } from "./store-maintenance.js";
 import {
@@ -336,60 +332,38 @@ async function previewStoreCleanup(params: {
     store: previewStore,
     baseKeys: [params.activeKey],
   });
-  const modelRunPruned = shouldRunModelRunPrune({
+  const {
+    modelRunPruned,
+    archived: totalArchived,
+    capArchived,
+    pruned,
+    capped,
+  } = planSessionEntryMaintenance({
+    profile: "write",
     maintenance: params.maintenance,
-    entryCount: countUnarchivedSessionEntries(previewStore),
-    // `sessions cleanup` applies the cap immediately (apply path forces maintenance and the
-    // preview caps unconditionally below), so mirror that here: prune stale probes before the
-    // forced cap can evict real sessions in their place.
-    force: true,
-  })
-    ? pruneStaleModelRunEntries(previewStore, params.maintenance.modelRunPruneAfterMs, {
-        log: false,
-        preserveKeys: preserveSessionKeys,
-        preserveRecentMs: params.maintenance.preserveRecentMs,
-        onPruned: ({ key }) => {
-          modelRunPrunedKeys.add(key);
-        },
-      })
-    : 0;
-  let archived = archiveStaleDashboardEntries(
-    previewStore,
-    params.maintenance.archiveDashboardAfterMs,
-    {
-      log: false,
-      onArchived: ({ key }) => {
-        archivedKeys.add(key);
-      },
-      preserveKeys: preserveSessionKeys,
-      preserveRecentMs: params.maintenance.preserveRecentMs,
-    },
-  );
-  const pruned = pruneStaleEntries(previewStore, params.maintenance.pruneAfterMs, {
-    log: false,
+    initialUnarchivedCount: countUnarchivedSessionEntries(previewStore),
+    // Cleanup previews apply the same immediate cap as the apply path.
+    forceMaintenance: true,
     preserveKeys: preserveSessionKeys,
-    preserveRecentMs: params.maintenance.preserveRecentMs,
-    onPruned: ({ key }) => {
-      staleKeys.add(key);
+    log: false,
+    readAgeCandidates: () => previewStore,
+    readCapCandidates: () => ({ store: previewStore, maxEntries: params.maintenance.maxEntries }),
+    onRemoved: ({ key }, reason) => {
+      const keys =
+        reason === "model-run-pruned"
+          ? modelRunPrunedKeys
+          : reason === "pruned"
+            ? staleKeys
+            : cappedKeys;
+      keys.add(key);
     },
-    onArchived: ({ key }) => {
-      archived += 1;
-      ageArchivedKeys.add(key);
+    onArchived: ({ key }, phase) => {
+      const keys =
+        phase === "dashboard" ? archivedKeys : phase === "age" ? ageArchivedKeys : capArchivedKeys;
+      keys.add(key);
     },
   });
-  let capArchived = 0;
-  const capped = capEntryCount(previewStore, params.maintenance.maxEntries, {
-    log: false,
-    preserveKeys: preserveSessionKeys,
-    preserveRecentMs: params.maintenance.preserveRecentMs,
-    onArchived: ({ key }) => {
-      capArchived += 1;
-      capArchivedKeys.add(key);
-    },
-    onRemoved: ({ key }) => {
-      cappedKeys.add(key);
-    },
-  });
+  const archived = totalArchived - capArchived;
   const entryCleanupArtifactPaths = new Set<string>();
   addEntryArtifactPathsToSet({
     paths: entryCleanupArtifactPaths,

--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -52,16 +52,11 @@ import {
   toDatabaseOptions,
   type ResolvedSqliteReadScope,
 } from "./session-accessor.sqlite-scope.js";
+import { planSessionEntryMaintenance } from "./store-maintenance-plan.js";
 import { collectSessionMaintenancePreserveKeysForStore } from "./store-maintenance-preserve.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import {
-  archiveStaleDashboardEntries,
-  capEntryCount,
-  pruneStaleModelRunEntries,
-  pruneStaleEntries,
   normalizeResolvedMaintenanceConfigInput,
-  shouldRunModelRunPrune,
-  shouldRunSessionEntryMaintenance,
   type ResolvedSessionMaintenanceConfigInput,
 } from "./store-maintenance.js";
 
@@ -375,95 +370,35 @@ export function applySessionEntryMaintenance(
       store: keyProjection,
       baseKeys: collectSqliteSessionMaintenanceBaseKeys(keyProjection, activeSessionKeys),
     }) ?? new Set<string>();
-  const runModelRunPrune = shouldRunModelRunPrune({
-    maintenance,
-    entryCount,
-    force: params.forceMaintenance,
-  });
-  const candidateAges = [
-    maintenance.pruneAfterMs,
-    maintenance.archiveDashboardAfterMs,
-    runModelRunPrune ? maintenance.modelRunPruneAfterMs : null,
-  ].filter((age): age is number => age != null && age > 0);
-  const store = readSessionMaintenanceAgeCandidates({
-    database,
-    minimumAgeMs: candidateAges.length > 0 ? Math.min(...candidateAges) : null,
-  });
   const removalReasons = new Map<
     string,
     NonNullable<SessionEntryMaintenancePlan["entryRemovals"][number]["maintenanceReason"]>
   >();
-  const rememberRemoval =
-    (
-      maintenanceReason: NonNullable<
-        SessionEntryMaintenancePlan["entryRemovals"][number]["maintenanceReason"]
-      >,
-    ) =>
-    ({ key }: { key: string }) => {
-      removalReasons.set(key, maintenanceReason);
-    };
-  let remainingEntryCount = entryCount;
-  let modelRunPruned = 0;
-  if (runModelRunPrune) {
-    modelRunPruned = pruneStaleModelRunEntries(store, maintenance.modelRunPruneAfterMs, {
-      log: false,
-      onPruned: rememberRemoval("model-run-pruned"),
-      preserveKeys,
-      preserveRecentMs: maintenance.preserveRecentMs,
-    });
-    remainingEntryCount -= modelRunPruned;
-  }
   const archivedKeys = new Set<string>();
-  let archived = archiveStaleDashboardEntries(store, maintenance.archiveDashboardAfterMs, {
-    log: false,
-    onArchived: ({ key }) => {
-      archivedKeys.add(key);
-    },
-    preserveKeys,
-    preserveRecentMs: maintenance.preserveRecentMs,
-  });
-  remainingEntryCount -= archived;
-  const pruned = pruneStaleEntries(store, maintenance.pruneAfterMs, {
-    log: false,
-    onPruned: rememberRemoval("pruned"),
-    onArchived: ({ key }) => {
-      archivedKeys.add(key);
-      archived += 1;
-      remainingEntryCount -= 1;
-    },
-    preserveKeys,
-    preserveRecentMs: maintenance.preserveRecentMs,
-  });
-  remainingEntryCount -= pruned;
-  let capped = 0;
-  let capArchived = 0;
-  if (
-    shouldRunSessionEntryMaintenance({
-      entryCount: remainingEntryCount,
-      maxEntries: maintenance.maxEntries,
-      force: params.forceMaintenance,
-    })
-  ) {
-    const overflow = Math.max(0, remainingEntryCount - maintenance.maxEntries);
-    if (overflow > 0) {
-      const capStore = readSessionMaintenanceCapCandidates({
-        database,
-        excludedKeys: new Set([...removalReasons.keys(), ...archivedKeys]),
-      });
-      capped = capEntryCount(capStore, Object.keys(capStore).length - overflow, {
-        log: false,
-        onArchived: ({ key, entry }) => {
-          archivedKeys.add(key);
-          store[key] = entry;
-          archived += 1;
-          capArchived += 1;
-        },
-        onRemoved: rememberRemoval("capped"),
-        preserveKeys,
-        preserveRecentMs: maintenance.preserveRecentMs,
-      });
-    }
-  }
+  const { store, archived, capArchived, modelRunPruned, pruned, capped } =
+    planSessionEntryMaintenance({
+      profile: "write",
+      maintenance,
+      initialUnarchivedCount: entryCount,
+      forceMaintenance: params.forceMaintenance,
+      preserveKeys,
+      log: false,
+      readAgeCandidates: (minimumAgeMs) =>
+        readSessionMaintenanceAgeCandidates({ database, minimumAgeMs }),
+      readCapCandidates: (remainingEntryCount) => {
+        const overflow = Math.max(0, remainingEntryCount - maintenance.maxEntries);
+        if (overflow > 0) {
+          const capStore = readSessionMaintenanceCapCandidates({
+            database,
+            excludedKeys: new Set([...removalReasons.keys(), ...archivedKeys]),
+          });
+          return { store: capStore, maxEntries: Object.keys(capStore).length - overflow };
+        }
+        return undefined;
+      },
+      onRemoved: ({ key }, reason) => removalReasons.set(key, reason),
+      onArchived: ({ key }) => archivedKeys.add(key),
+    });
   const selectedKeys = uniqueStrings([...archivedKeys, ...removalReasons.keys()]);
   const selectedEntries = readSessionEntryStore(database, { sessionKeys: selectedKeys });
   const archivedWorktrees: NonNullable<SessionEntryMaintenancePlan["archivedWorktrees"]> = [];

--- a/src/config/sessions/store-maintenance-operations.ts
+++ b/src/config/sessions/store-maintenance-operations.ts
@@ -1,16 +1,12 @@
 // Storage-neutral session maintenance operations for the file-backed session store.
 import path from "node:path";
 import { enforceSessionDiskBudget, type SessionDiskBudgetSweepResult } from "./disk-budget.js";
+import { planSessionEntryMaintenance } from "./store-maintenance-plan.js";
 import { collectSessionMaintenancePreserveKeysForStore } from "./store-maintenance-preserve.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import {
-  archiveStaleDashboardEntries,
-  capEntryCount,
   countUnarchivedSessionEntries,
   getActiveSessionMaintenanceWarning,
-  pruneStaleModelRunEntries,
-  pruneStaleEntries,
-  shouldRunModelRunPrune,
   shouldRunSessionEntryMaintenance,
   normalizeResolvedMaintenanceConfigInput,
   type ResolvedSessionMaintenanceConfig,
@@ -219,58 +215,19 @@ async function applyEnforcedMaintenance(params: {
   preserveSessionKeys: ReadonlySet<string> | undefined;
 }): Promise<FileBackedSessionStoreMaintenanceResult> {
   const removedSessionFiles = new Map<string, string | undefined>();
-  const modelRunPruned = shouldRunModelRunPrune({
+  const { modelRunPruned, archived, capArchived, pruned, capped } = planSessionEntryMaintenance({
+    profile: "write",
     maintenance: params.maintenance,
-    entryCount: countUnarchivedSessionEntries(params.operation.store),
-    force: params.forceMaintenance,
-  })
-    ? pruneStaleModelRunEntries(params.operation.store, params.maintenance.modelRunPruneAfterMs, {
-        onPruned: ({ entry }) => {
-          rememberRemovedSessionFile(removedSessionFiles, entry);
-        },
-        preserveKeys: params.preserveSessionKeys,
-        preserveRecentMs: params.maintenance.preserveRecentMs,
-      })
-    : 0;
-  let archived = archiveStaleDashboardEntries(
-    params.operation.store,
-    params.maintenance.archiveDashboardAfterMs,
-    {
-      preserveKeys: params.preserveSessionKeys,
-      preserveRecentMs: params.maintenance.preserveRecentMs,
-    },
-  );
-  const pruned = pruneStaleEntries(params.operation.store, params.maintenance.pruneAfterMs, {
-    onArchived: () => {
-      archived += 1;
-    },
-    onPruned: ({ entry }) => {
-      rememberRemovedSessionFile(removedSessionFiles, entry);
-    },
+    initialUnarchivedCount: countUnarchivedSessionEntries(params.operation.store),
+    forceMaintenance: params.forceMaintenance,
     preserveKeys: params.preserveSessionKeys,
-    preserveRecentMs: params.maintenance.preserveRecentMs,
-  });
-  const countAfterPrune = countUnarchivedSessionEntries(params.operation.store);
-  const shouldRunCapMaintenance =
-    params.forceMaintenance ||
-    shouldRunSessionEntryMaintenance({
-      entryCount: countAfterPrune,
+    readAgeCandidates: () => params.operation.store,
+    readCapCandidates: () => ({
+      store: params.operation.store,
       maxEntries: params.maintenance.maxEntries,
-    });
-  let capArchived = 0;
-  const capped = shouldRunCapMaintenance
-    ? capEntryCount(params.operation.store, params.maintenance.maxEntries, {
-        onArchived: () => {
-          archived += 1;
-          capArchived += 1;
-        },
-        onRemoved: ({ entry }) => {
-          rememberRemovedSessionFile(removedSessionFiles, entry);
-        },
-        preserveKeys: params.preserveSessionKeys,
-        preserveRecentMs: params.maintenance.preserveRecentMs,
-      })
-    : 0;
+    }),
+    onRemoved: ({ entry }) => rememberRemovedSessionFile(removedSessionFiles, entry),
+  });
   const referencedSessionIds = collectReferencedSessionIds(params.operation.store);
   await cleanupRemovedSessionArtifacts({
     operation: params.operation,

--- a/src/config/sessions/store-maintenance-plan.test.ts
+++ b/src/config/sessions/store-maintenance-plan.test.ts
@@ -1,0 +1,66 @@
+import { expect, it } from "vitest";
+import {
+  loadLegacySessionStore,
+  saveLegacySessionStore,
+} from "../../infra/state-migrations.legacy-session-store.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import type { SessionMaintenanceApplyReport } from "./store-maintenance-operations.js";
+import type { ResolvedSessionMaintenanceConfig } from "./store-maintenance.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+it("preserves the legacy read pressure gates separately from write maintenance", async () => {
+  await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+    const now = Date.now();
+    const probeKey = "agent:main:explicit:model-run-123e4567-e89b-12d3-a456-426614174000";
+    const dashboardKey = "agent:main:dashboard:stale";
+    const ordinaryKey = "agent:main:old";
+    const source = {
+      [probeKey]: { sessionId: "probe", updatedAt: now - 2 * DAY_MS },
+      [dashboardKey]: { sessionId: "dashboard", updatedAt: now - 8 * DAY_MS },
+      [ordinaryKey]: { sessionId: "ordinary", updatedAt: now - 40 * DAY_MS },
+    };
+    const storePath = await state.writeJson("legacy/sessions.json", source);
+    const maintenance: ResolvedSessionMaintenanceConfig = {
+      mode: "enforce",
+      pruneAfterMs: 30 * DAY_MS,
+      archiveDashboardAfterMs: 7 * DAY_MS,
+      modelRunPruneAfterMs: DAY_MS,
+      maxEntries: 2,
+      preserveRecentMs: null,
+      resetArchiveRetentionMs: null,
+      maxDiskBytes: null,
+      highWaterBytes: null,
+    };
+
+    const read = loadLegacySessionStore(storePath, {
+      runMaintenance: true,
+      maintenanceConfig: maintenance,
+    });
+    expect(read[probeKey]).toBeUndefined();
+    expect(read[dashboardKey]?.archiveReason).toBe("stale-dashboard");
+    expect(read[ordinaryKey]?.archivedAt).toBeUndefined();
+    expect(Object.keys(read).toSorted()).toEqual([dashboardKey, ordinaryKey].toSorted());
+
+    let report: SessionMaintenanceApplyReport | undefined;
+    await saveLegacySessionStore(storePath, source, {
+      maintenanceConfig: maintenance,
+      onMaintenanceApplied: (result) => {
+        report = result;
+      },
+    });
+    const written = loadLegacySessionStore(storePath);
+    expect(written[probeKey]).toBeUndefined();
+    expect(written[dashboardKey]?.archiveReason).toBe("stale-dashboard");
+    expect(written[ordinaryKey]?.archiveReason).toBe("age-retention");
+    expect(report).toMatchObject({
+      beforeCount: 3,
+      afterCount: 2,
+      modelRunPruned: 1,
+      archived: 2,
+      capArchived: 0,
+      pruned: 0,
+      capped: 0,
+    });
+  });
+});

--- a/src/config/sessions/store-maintenance-plan.ts
+++ b/src/config/sessions/store-maintenance-plan.ts
@@ -1,0 +1,121 @@
+import {
+  archiveStaleDashboardEntries,
+  capEntryCount,
+  pruneStaleEntries,
+  pruneStaleModelRunEntries,
+  shouldRunModelRunPrune,
+  shouldRunSessionEntryMaintenance,
+  type ResolvedSessionMaintenanceConfig,
+} from "./store-maintenance.js";
+import type { SessionEntry } from "./types.js";
+
+type MaintenanceCandidate = { key: string; entry: SessionEntry };
+type ArchivePhase = "dashboard" | "age" | "cap";
+type RemovalReason = "model-run-pruned" | "pruned" | "capped";
+type EntryMaintenanceConfig = Pick<
+  ResolvedSessionMaintenanceConfig,
+  | "pruneAfterMs"
+  | "archiveDashboardAfterMs"
+  | "modelRunPruneAfterMs"
+  | "maxEntries"
+  | "preserveRecentMs"
+>;
+
+/** Mutate working images only; callers own warn mode, protected keys, reads, and persistence. */
+export function planSessionEntryMaintenance(params: {
+  profile: "write" | "legacy-read";
+  maintenance: EntryMaintenanceConfig;
+  initialUnarchivedCount: number;
+  forceMaintenance?: boolean;
+  preserveKeys?: ReadonlySet<string>;
+  log?: boolean;
+  readAgeCandidates: (minimumAgeMs: number | null) => Record<string, SessionEntry>;
+  readCapCandidates: (
+    remainingUnarchivedCount: number,
+  ) => { store: Record<string, SessionEntry>; maxEntries: number } | undefined;
+  onArchived?: (candidate: MaintenanceCandidate, phase: ArchivePhase) => void;
+  onRemoved?: (candidate: MaintenanceCandidate, reason: RemovalReason) => void;
+}) {
+  // Legacy reads archive dashboards first but freeze probe pressure before that archive.
+  const runModelRunPrune = shouldRunModelRunPrune({
+    maintenance: params.maintenance,
+    entryCount: params.initialUnarchivedCount,
+    force: params.forceMaintenance,
+  });
+  const candidateAges = [
+    params.maintenance.pruneAfterMs,
+    params.maintenance.archiveDashboardAfterMs,
+    runModelRunPrune ? params.maintenance.modelRunPruneAfterMs : null,
+  ].filter((age): age is number => age != null && age > 0);
+  const store = params.readAgeCandidates(
+    candidateAges.length > 0 ? Math.min(...candidateAges) : null,
+  );
+  let remainingUnarchivedCount = params.initialUnarchivedCount;
+  const counts = { archived: 0, capArchived: 0, modelRunPruned: 0, pruned: 0, capped: 0 };
+  const options = {
+    log: params.log,
+    preserveKeys: params.preserveKeys,
+    preserveRecentMs: params.maintenance.preserveRecentMs,
+  };
+  const recordRemoval = (candidate: MaintenanceCandidate, reason: RemovalReason) => {
+    remainingUnarchivedCount -= 1;
+    params.onRemoved?.(candidate, reason);
+  };
+  const recordArchive = (candidate: MaintenanceCandidate, phase: ArchivePhase) => {
+    remainingUnarchivedCount -= 1;
+    counts.archived += 1;
+    if (phase === "cap") {
+      counts.capArchived += 1;
+    }
+    params.onArchived?.(candidate, phase);
+  };
+  const archiveDashboards = () =>
+    archiveStaleDashboardEntries(store, params.maintenance.archiveDashboardAfterMs, {
+      ...options,
+      onArchived: (candidate) => recordArchive(candidate, "dashboard"),
+    });
+
+  if (params.profile === "legacy-read") {
+    archiveDashboards();
+  }
+  if (runModelRunPrune) {
+    counts.modelRunPruned = pruneStaleModelRunEntries(
+      store,
+      params.maintenance.modelRunPruneAfterMs,
+      { ...options, onPruned: (candidate) => recordRemoval(candidate, "model-run-pruned") },
+    );
+  }
+  if (params.profile === "write") {
+    archiveDashboards();
+  }
+  if (params.profile === "write" || remainingUnarchivedCount > params.maintenance.maxEntries) {
+    counts.pruned = pruneStaleEntries(store, params.maintenance.pruneAfterMs, {
+      ...options,
+      onPruned: (candidate) => recordRemoval(candidate, "pruned"),
+      onArchived: (candidate) => recordArchive(candidate, "age"),
+    });
+    if (
+      shouldRunSessionEntryMaintenance({
+        entryCount: remainingUnarchivedCount,
+        maxEntries: params.maintenance.maxEntries,
+        force: params.forceMaintenance,
+      })
+    ) {
+      const cap = params.readCapCandidates(remainingUnarchivedCount);
+      if (cap) {
+        counts.capped = capEntryCount(cap.store, cap.maxEntries, {
+          ...options,
+          onArchived: (candidate) => {
+            // Indexed cap candidates may be absent from the age-candidate working image.
+            if (cap.store !== store) {
+              store[candidate.key] = candidate.entry;
+            }
+            recordArchive(candidate, "cap");
+          },
+          onRemoved: (candidate) => recordRemoval(candidate, "capped"),
+        });
+      }
+    }
+  }
+  return { store, ...counts };
+}

--- a/src/infra/state-migrations.legacy-session-store.ts
+++ b/src/infra/state-migrations.legacy-session-store.ts
@@ -16,16 +16,11 @@ import {
   applyFileBackedSessionStoreMaintenance,
   type SessionMaintenanceApplyReport,
 } from "../config/sessions/store-maintenance-operations.js";
+import { planSessionEntryMaintenance } from "../config/sessions/store-maintenance-plan.js";
 import { collectSessionMaintenancePreserveKeysForStore } from "../config/sessions/store-maintenance-preserve.js";
 import { resolveMaintenanceConfig } from "../config/sessions/store-maintenance-runtime.js";
 import {
-  archiveStaleDashboardEntries,
-  capEntryCount,
   countUnarchivedSessionEntries,
-  pruneStaleEntries,
-  pruneStaleModelRunEntries,
-  shouldRunModelRunPrune,
-  shouldRunSessionEntryMaintenance,
   type ResolvedSessionMaintenanceConfig,
   type SessionMaintenanceWarning,
 } from "../config/sessions/store-maintenance.js";
@@ -273,37 +268,15 @@ export function loadLegacySessionStore(
         storePath,
         store: sessionStore,
       });
-      archiveStaleDashboardEntries(sessionStore, maintenance.archiveDashboardAfterMs, {
-        log: false,
+      planSessionEntryMaintenance({
+        profile: "legacy-read",
+        maintenance,
+        initialUnarchivedCount: beforeCount,
         preserveKeys: preserveSessionKeys,
-        preserveRecentMs: maintenance.preserveRecentMs,
+        log: false,
+        readAgeCandidates: () => sessionStore,
+        readCapCandidates: () => ({ store: sessionStore, maxEntries: maintenance.maxEntries }),
       });
-      if (shouldRunModelRunPrune({ maintenance, entryCount: beforeCount })) {
-        pruneStaleModelRunEntries(sessionStore, maintenance.modelRunPruneAfterMs, {
-          log: false,
-          preserveKeys: preserveSessionKeys,
-          preserveRecentMs: maintenance.preserveRecentMs,
-        });
-      }
-      if (countUnarchivedSessionEntries(sessionStore) > maintenance.maxEntries) {
-        pruneStaleEntries(sessionStore, maintenance.pruneAfterMs, {
-          log: false,
-          preserveKeys: preserveSessionKeys,
-          preserveRecentMs: maintenance.preserveRecentMs,
-        });
-        if (
-          shouldRunSessionEntryMaintenance({
-            entryCount: countUnarchivedSessionEntries(sessionStore),
-            maxEntries: maintenance.maxEntries,
-          })
-        ) {
-          capEntryCount(sessionStore, maintenance.maxEntries, {
-            log: false,
-            preserveKeys: preserveSessionKeys,
-            preserveRecentMs: maintenance.preserveRecentMs,
-          });
-        }
-      }
     }
   }
   return sessionStore;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled.

</details>

## What Problem This Solves

Session cleanup preview, SQLite maintenance, legacy writes, and legacy reads independently sequence the same retention phases and maintain their counts. Updating one recipe can make cleanup predictions or entry reclamation diverge from the other paths.

## Why This Change Was Made

`store-maintenance-plan.ts`, beside the existing storage-neutral operations owner, now sequences model-run pruning, dashboard archival, age retention, and count capping. The four callers retain warning admission, active-ancestor protection, candidate reads, artifact handling, and transaction/publication ownership. Production code shrinks by 40 lines.

The planner explicitly preserves the existing policies: writes prune probes before dashboard archival and always run age retention; legacy reads archive dashboards first, use the initial count for probe pressure, and run age retention only while still over the cap. Cleanup previews force the immediate-cap policy. SQLite retains its global count, indexed age candidates, separately ordered cap candidates, exclusions, positive-overflow guard, and committed-result bookkeeping.

Maintainer sponsorship: Peter Steinberger explicitly requested this extraction as an active session-maintenance consolidation deliverable, with unchanged retention and storage semantics.

## User Impact

No user-visible change. Retention, archived rows, force/warn behavior, protected ancestry, schema, and persistence semantics remain unchanged. No public export is removed or renamed.

## Evidence

- Existing focused suites plus one real legacy read/write boundary case: 42 tests across 9 files passed before and after extraction. The added case preserves the different read/write pressure behavior.
- Synthetic differential comparison of the original recipes and shared planner: 1,488 of 1,488 matched across 124 scenarios, six caller/force adapters, and frozen/advancing clocks. Compared working images, phase hooks, counts, candidate arguments, exclusions, ordering, and retention clock calls.
- The differential comparison simulates indexed images; it is not SQL execution or transaction proof. The existing SQLite maintenance-writer suite exercises the real storage boundary.
- Focused command: `node scripts/run-vitest.mjs src/config/sessions/store-maintenance-plan.test.ts src/config/sessions/store-maintenance.dashboard-archive.test.ts src/config/sessions/store-maintenance-recent-preservation.test.ts src/config/sessions/store-maintenance-warning-parity.test.ts src/config/sessions/cleanup-service.model-run-retention.test.ts src/config/sessions/cleanup-service.cap-archive.test.ts src/config/sessions/cleanup-service.applied-summary.test.ts src/config/sessions/session-accessor.sqlite-maintenance-writer.test.ts src/infra/state-migrations.legacy-session-store.test.ts`.
- Full `pnpm build` passed, including SDK declarations, plugin/runtime checks, and UI budgets. Independent Codex review through P2 is clean on the final candidate.
- The first changed-file check found two test-only `Array.sort()` lint violations. Both were corrected to `toSorted()`; the corrected boundary test passed. Final `node scripts/check-changed.mjs` passed completely. No suppression or baseline changes were needed.

The branch was rebased onto `2d0d99fe08d89dba3db3c42dc71658101b930a5e`; `git range-diff` confirms the patch is identical. Full checks/build above were completed before that rebase; all 42 focused maintenance tests passed again on the published head `fe90c74f0fe9b5d99e12928ac5d60b89e1247e12`.

Exact-head CI passed: [run 34100971478](https://github.com/openclaw/openclaw/actions/runs/34100971478), including both Windows test shards. Native preparation is in progress.

### Cleanup behavior proof and review response

The existing `cleanup-service.applied-summary.test.ts` case "archives durable conversations under %s pressure and agrees with its preview after reopening" runs the real cleanup service against isolated SQLite stores with config written to disk. It seeds an existing archive, a disposable hook, a durable conversation with transcript content, and a recent session. Both age and count variants passed on the published head:

| Pressure | Before rows | After rows | Age archived | Cap archived | Pruned | Capped | Active rows after |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Age | 4 | 3 | 1 | 0 | 1 | 0 | 1 |
| Count | 4 | 3 | 0 | 1 | 0 | 2 | 1 |

The test verifies equal preview/applied summaries, removal of the disposable hook, and preservation of the conversation and transcript after closing and reopening the database. The cap suite also executes explicit dry-run and enforce calls and checks the stored row. These are automated checks of the actual cleanup/storage boundary, alongside the separate synthetic planner comparison.

ClawSweeper reported no actionable correctness or security defect. Its sponsorship question is answered above. For this behavior-preserving extraction, the exercised cleanup/SQLite boundary supplies the behavior proof required by the maintainer's scoped proof route. A separate live Gateway/provider smoke is not claimed or required; no real Gateway was used.
