### PR TITLE
refactor(cli): reuse devices runtime option types

### DIFF
--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -1,23 +1,12 @@
 // Commander registration for device pairing and auth-token commands.
 import type { Command } from "commander";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+import type { runDevicesListCommand } from "./devices-cli.runtime.js";
 import { isDevicesMachineOutput } from "./devices-output-mode.js";
 import { setCommandJsonMode } from "./program/json-mode.js";
 import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
 
-type DevicesRpcOpts = {
-  url?: string;
-  token?: string;
-  password?: string;
-  timeout?: string;
-  json?: boolean;
-  latest?: boolean;
-  yes?: boolean;
-  pending?: boolean;
-  device?: string;
-  role?: string;
-  scope?: string[];
-};
+type DevicesRpcOpts = Omit<Parameters<typeof runDevicesListCommand>[0], "name">;
 
 const DEFAULT_DEVICES_TIMEOUT_MS = 10_000;
 


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Devices CLI registration repeats eleven fields already defined by its runtime receiver. This maintainer-requested cleanup removes that duplicate private declaration as part of the #135868 deletion campaign.

## Why This Change Was Made

Derive the registration type from the existing `runDevicesListCommand` parameter and retain the existing exclusion of `name`. This reuses the runtime-owned contract without adding an export. The import is explicitly type-only, preserving lazy runtime loading.

The exclusion affects only the private declaration: rename still requires `--name` and forwards the original Commander options object unchanged. Raw string timeouts, mutable `scope` arrays, all eleven optional fields, command flags, and authorization/fallback logic remain intact.

## User Impact

No user-visible behavior change. Device listing, approval, rename, token management, and onboarding keep their existing behavior and startup boundaries. No configuration, schema, dependency, or persistence changes.

## Evidence

- All 62 existing Devices CLI tests pass before (2.38s) and after (7.30s), including explicit-URL fallback rejection, rename-label forwarding, and admin-scoped onboarding.
- Actual AST-extracted registration and runtime declarations, plus the current exported function signature, pass ten exact contract assertions in both optionality modes. Missing the omission, changing timeout to a number, or making `scope` readonly each fail contract assertions in both modes.
- Complete emitted JavaScript is byte-identical with `verbatimModuleSyntax: true`: four static imports and the existing dynamic runtime import remain. A value-import control adds the forbidden eager runtime edge and is detected. The applied file matches the proven candidate hash.
- Full selected `check:changed` passed in 718.69s, including actual core/test type graphs, all three zero-entry Knip scans, lint, zero runtime import cycles, and architecture/storage guards. All 14 pinned owner/consumer/test/config/dependency inputs remained unchanged against base `96646c085bcd69cf977e9aa6709249b8547dd077`.
- Full `pnpm build` passed in 1,695.70s, including all six unified declaration stages, SDK declarations/export checks, 91 external plugins, 53 native control-plane/Doctor closure checks, CLI bootstrap import guard, and Control UI asset budgets. The same 14 pinned inputs and exact changed-path set remained unchanged.
- Targeted lint passes. Local and rebased-branch independent Codex reviews are scoped-clean through P2.
- Rebased onto current main before publication and again for final landing. The final refresh changes none of the 14 verified inputs or the lockfile; fresh independent review is scoped-clean through P2. All Devices source/consumer/test inputs and the lockfile remain unchanged. Main added an unrelated Google model-family path alias; the 62 Devices tests passed again (8.62s), and the actual core type lane passed (18.78s).

| Class | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 2 | 13 | -11 |
| Tests | 0 | 0 | 0 |
| Tooling | 0 | 0 | 0 |
| Docs | 0 | 0 | 0 |

`src/cli/devices-cli.ts` shrinks from 148 to 137 lines. Runtime implementation, tests, and baselines remain intact.
