### PR TITLE
refactor(line): share reply presentation preparation

### DIFF
--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -201,7 +201,7 @@ describe("deliverLineAutoReply", () => {
   // fallback prose is the only thing carrying the question. Delivering bare
   // option labels would leave the user choosing between answers to nothing.
   it("delivers the question with the options when only quick replies render", async () => {
-    const prepared = prepareLineReplyPayload({
+    const prepared = await prepareLineReplyPayload({
       text: "Agent needs input:\n1. Alpha",
       presentationTextMode: "fallback",
       presentation: {

--- a/extensions/line/src/channel.rich-messages.test.ts
+++ b/extensions/line/src/channel.rich-messages.test.ts
@@ -33,6 +33,22 @@ function resolveChannelDataSchema() {
 }
 
 describe("LINE rich-message boundaries", () => {
+  it.each([undefined, { blocks: [] }])(
+    "preserves a payload without renderable presentation: %j",
+    async (presentation) => {
+      const payload = {
+        text: "",
+        presentationTextMode: "fallback" as const,
+        presentation,
+        replyToId: "original-message",
+        mediaUrl: "https://example.com/image.png",
+        channelData: { line: { quickReplies: ["Continue"] } },
+      };
+
+      expect(await prepareLineReplyPayload(payload)).toEqual(payload);
+    },
+  );
+
   it("leaves legacy marker text unchanged", () => {
     const payload = { text: "Choose: [[buttons: Menu | Pick one | A:a, B:b]]" };
 
@@ -83,8 +99,8 @@ describe("LINE rich-message boundaries", () => {
     });
   });
 
-  it("resolves a reply's presentation into LINE controls before delivery reads it", () => {
-    const prepared = prepareLineReplyPayload({
+  it("resolves a reply's presentation into LINE controls before delivery reads it", async () => {
+    const prepared = await prepareLineReplyPayload({
       text: "Approve this run?",
       presentation: {
         blocks: [
@@ -118,51 +134,54 @@ describe("LINE rich-message boundaries", () => {
     { name: "exact byte limit", character: "x", extraBytes: 0, fits: true },
     { name: "one byte over", character: "x", extraBytes: 1, fits: false },
     { name: "multibyte overflow", character: "界", extraBytes: 1, fits: false },
-  ])("preserves the answer and controls at the Flex $name", ({ character, extraBytes, fits }) => {
-    const title = "Size boundary";
-    const action = {
-      type: "postback",
-      label: "Continue",
-      data: "next",
-      displayText: "Continue",
-    } as const;
-    const overhead =
-      Buffer.byteLength(
-        JSON.stringify(createActionCard(title, "x", [{ label: "Continue", action }])),
-        "utf8",
-      ) - 1;
-    const text = character.repeat(
-      Math.ceil((30_000 - overhead + extraBytes) / Buffer.byteLength(character, "utf8")),
-    );
-    const prepared = prepareLineReplyPayload({
-      text: "Full answer:",
-      presentation: {
-        title,
-        blocks: [
-          { type: "text", text },
-          {
-            type: "buttons",
-            buttons: [{ label: "Continue", action: { type: "callback", value: "next" } }],
-          },
-        ],
-      },
-    });
+  ])(
+    "preserves the answer and controls at the Flex $name",
+    async ({ character, extraBytes, fits }) => {
+      const title = "Size boundary";
+      const action = {
+        type: "postback",
+        label: "Continue",
+        data: "next",
+        displayText: "Continue",
+      } as const;
+      const overhead =
+        Buffer.byteLength(
+          JSON.stringify(createActionCard(title, "x", [{ label: "Continue", action }])),
+          "utf8",
+        ) - 1;
+      const text = character.repeat(
+        Math.ceil((30_000 - overhead + extraBytes) / Buffer.byteLength(character, "utf8")),
+      );
+      const prepared = await prepareLineReplyPayload({
+        text: "Full answer:",
+        presentation: {
+          title,
+          blocks: [
+            { type: "text", text },
+            {
+              type: "buttons",
+              buttons: [{ label: "Continue", action: { type: "callback", value: "next" } }],
+            },
+          ],
+        },
+      });
 
-    expect(prepared.presentation).toBeUndefined();
-    if (fits) {
-      const line = prepared.channelData?.line as { flexMessage: { contents: unknown } };
-      expect(Buffer.byteLength(JSON.stringify(line.flexMessage.contents), "utf8")).toBe(30_000);
-      expect(prepared.text).toBe("Full answer:");
-    } else {
-      expect(prepared.channelData?.line).toBeUndefined();
-      expect(prepared.text).toContain("Full answer:");
-      expect(prepared.text).toContain(text);
-      expect(prepared.text).toContain("Continue");
-    }
-  });
+      expect(prepared.presentation).toBeUndefined();
+      if (fits) {
+        const line = prepared.channelData?.line as { flexMessage: { contents: unknown } };
+        expect(Buffer.byteLength(JSON.stringify(line.flexMessage.contents), "utf8")).toBe(30_000);
+        expect(prepared.text).toBe("Full answer:");
+      } else {
+        expect(prepared.channelData?.line).toBeUndefined();
+        expect(prepared.text).toContain("Full answer:");
+        expect(prepared.text).toContain(text);
+        expect(prepared.text).toContain("Continue");
+      }
+    },
+  );
 
-  it("keeps fallback text when only quick replies render", () => {
-    const prepared = prepareLineReplyPayload({
+  it("keeps fallback text when only quick replies render", async () => {
+    const prepared = await prepareLineReplyPayload({
       text: "Agent needs input:\n1. Alpha",
       presentationTextMode: "fallback",
       presentation: {
@@ -185,34 +204,37 @@ describe("LINE rich-message boundaries", () => {
     expect(line?.quickReplyItems).toHaveLength(1);
   });
 
-  it.each([undefined, "", "   "])("keeps the select prompt when fallback text is %j", (text) => {
-    const prepared = prepareLineReplyPayload({
-      text,
-      presentationTextMode: "fallback",
-      presentation: {
-        title: "Choose a deployment",
-        blocks: [
-          {
-            type: "select",
-            placeholder: "Which environment should receive this deployment?",
-            options: [{ label: "Staging", action: { type: "callback", value: "staging" } }],
-          },
-        ],
-      },
-    });
+  it.each([undefined, "", "   "])(
+    "keeps the select prompt when fallback text is %j",
+    async (text) => {
+      const prepared = await prepareLineReplyPayload({
+        text,
+        presentationTextMode: "fallback",
+        presentation: {
+          title: "Choose a deployment",
+          blocks: [
+            {
+              type: "select",
+              placeholder: "Which environment should receive this deployment?",
+              options: [{ label: "Staging", action: { type: "callback", value: "staging" } }],
+            },
+          ],
+        },
+      });
 
-    expect(prepared.text).toBe(
-      "Choose a deployment\n\nWhich environment should receive this deployment?",
-    );
-  });
+      expect(prepared.text).toBe(
+        "Choose a deployment\n\nWhich environment should receive this deployment?",
+      );
+    },
+  );
 
-  it("preserves full select prompts and overflow labels while bounding native labels", () => {
+  it("preserves full select prompts and overflow labels while bounding native labels", async () => {
     const placeholder = "Which region should receive this deployment?";
     const options = Array.from({ length: 8 }, (_, index) => ({
       label: `Deployment region number ${index + 1}`,
       action: { type: "command" as const, command: `/region ${index + 1}` },
     }));
-    const prepared = prepareLineReplyPayload({
+    const prepared = await prepareLineReplyPayload({
       presentation: {
         blocks: [
           { type: "select", placeholder: "Choose the first region", options },
@@ -237,8 +259,8 @@ describe("LINE rich-message boundaries", () => {
     expect(native.items?.at(-1)?.action).toMatchObject({ type: "message", text: "/region 5" });
   });
 
-  it("keeps the words around quick replies when no Flex body carries them", () => {
-    const prepared = prepareLineReplyPayload({
+  it("keeps the words around quick replies when no Flex body carries them", async () => {
+    const prepared = await prepareLineReplyPayload({
       text: "Here are the files.",
       presentation: {
         title: "Pick a file",
@@ -264,13 +286,13 @@ describe("LINE rich-message boundaries", () => {
     expect(prepared.text).not.toContain("notes.md");
   });
 
-  it("keeps the options that did not fit LINE's quick reply row", () => {
+  it("keeps the options that did not fit LINE's quick reply row", async () => {
     const options = Array.from({ length: 20 }, (_, index) => ({
       label: `Option ${index + 1}`,
       action: { type: "callback" as const, value: `opt-${index + 1}` },
     }));
 
-    const prepared = prepareLineReplyPayload({
+    const prepared = await prepareLineReplyPayload({
       text: "Here are the files.",
       presentation: { blocks: [{ type: "select", options }] },
     });
@@ -284,8 +306,8 @@ describe("LINE rich-message boundaries", () => {
     expect(prepared.text).not.toContain("Option 1\n");
   });
 
-  it("keeps a select prompt's title when the title is all it carries", () => {
-    const prepared = prepareLineReplyPayload({
+  it("keeps a select prompt's title when the title is all it carries", async () => {
+    const prepared = await prepareLineReplyPayload({
       text: "Here are the files.",
       presentation: {
         title: "Pick a file",
@@ -322,7 +344,7 @@ describe("LINE rich-message boundaries", () => {
     expect(line?.quickReplyItems).toHaveLength(1);
   });
 
-  it("keeps a select's placeholder when every option became a chip", () => {
+  it("keeps a select's placeholder when every option became a chip", async () => {
     const presentation = {
       blocks: [
         {
@@ -336,7 +358,7 @@ describe("LINE rich-message boundaries", () => {
       ],
     };
 
-    const prepared = prepareLineReplyPayload({ text: "Here you go.", presentation });
+    const prepared = await prepareLineReplyPayload({ text: "Here you go.", presentation });
 
     // The placeholder is the prompt for those chips; the fallback renderer drops
     // a select with no options, so it cannot ride along inside the block.
@@ -362,7 +384,7 @@ describe("LINE rich-message boundaries", () => {
     expect(rendered?.text).toBe("Pick a day");
   });
 
-  it("keeps each select's own heading over its own leftovers", () => {
+  it("keeps each select's own heading over its own leftovers", async () => {
     const block = (placeholder: string, prefix: string) => ({
       type: "select" as const,
       placeholder,
@@ -372,7 +394,7 @@ describe("LINE rich-message boundaries", () => {
       })),
     });
 
-    const prepared = prepareLineReplyPayload({
+    const prepared = await prepareLineReplyPayload({
       text: "Choose.",
       presentation: { blocks: [block("Environment", "env"), block("Region", "region")] },
     });
@@ -384,7 +406,7 @@ describe("LINE rich-message boundaries", () => {
     );
   });
 
-  it("keeps the options two select blocks push past LINE's one-message limit", () => {
+  it("keeps the options two select blocks push past LINE's one-message limit", async () => {
     const block = (prefix: string) => ({
       type: "select" as const,
       options: Array.from({ length: 8 }, (_, index) => ({
@@ -393,7 +415,7 @@ describe("LINE rich-message boundaries", () => {
       })),
     });
 
-    const prepared = prepareLineReplyPayload({
+    const prepared = await prepareLineReplyPayload({
       text: "Pick an environment and a region.",
       presentation: { blocks: [block("env"), block("region")] },
     });
@@ -409,7 +431,7 @@ describe("LINE rich-message boundaries", () => {
     expect(prepared.text).not.toContain("env-1");
   });
 
-  it("keeps the overflow options beside a Flex card without repeating the card", () => {
+  it("keeps the overflow options beside a Flex card without repeating the card", async () => {
     const block = (prefix: string) => ({
       type: "select" as const,
       options: Array.from({ length: 8 }, (_, index) => ({
@@ -418,7 +440,7 @@ describe("LINE rich-message boundaries", () => {
       })),
     });
 
-    const prepared = prepareLineReplyPayload({
+    const prepared = await prepareLineReplyPayload({
       text: "Choose a target.",
       presentation: {
         title: "Deploy",
@@ -446,8 +468,8 @@ describe("LINE rich-message boundaries", () => {
     expect(prepared.text).not.toContain("Deploy");
   });
 
-  it("keeps a table beside a select instead of dropping it", () => {
-    const prepared = prepareLineReplyPayload({
+  it("keeps a table beside a select instead of dropping it", async () => {
+    const prepared = await prepareLineReplyPayload({
       text: "Here is this week's usage.",
       presentation: {
         blocks: [
@@ -465,8 +487,8 @@ describe("LINE rich-message boundaries", () => {
     expect(prepared.text).toContain("12");
   });
 
-  it("replaces fallback text once a Flex body renders the same controls", () => {
-    const prepared = prepareLineReplyPayload({
+  it("replaces fallback text once a Flex body renders the same controls", async () => {
+    const prepared = await prepareLineReplyPayload({
       text: "Agent needs input:\n1. Approve",
       presentationTextMode: "fallback",
       presentation: {
@@ -484,8 +506,8 @@ describe("LINE rich-message boundaries", () => {
     expect(prepared.text).toBeUndefined();
   });
 
-  it("keeps a presentation LINE has no native controls for in the visible text", () => {
-    const prepared = prepareLineReplyPayload({
+  it("keeps a presentation LINE has no native controls for in the visible text", async () => {
+    const prepared = await prepareLineReplyPayload({
       text: "Here are today's runs",
       presentation: {
         blocks: [

--- a/extensions/line/src/monitor.lifecycle.test.ts
+++ b/extensions/line/src/monitor.lifecycle.test.ts
@@ -3,8 +3,8 @@ import crypto from "node:crypto";
 import { createServer, IncomingMessage, type ServerResponse } from "node:http";
 import { Socket } from "node:net";
 import type { webhook } from "@line/bot-sdk";
+import type { ChannelInboundTurnPlan } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
 import { WEBHOOK_IN_FLIGHT_DEFAULTS } from "openclaw/plugin-sdk/webhook-request-guards";
@@ -378,10 +378,8 @@ describe("monitorLineProvider lifecycle", () => {
   });
 
   it("resolves a reply's presentation into LINE controls before delivering it", async () => {
-    // The turn adapter owns this preparation: core renders presentations inside
-    // the outbound send pipeline, which replies delivered here never enter.
     const { setLineRuntime } = await import("./runtime.js");
-    type ResolvedTurn = { delivery: { preparePayload?: (payload: ReplyPayload) => ReplyPayload } };
+    type ResolvedTurn = Pick<ChannelInboundTurnPlan, "delivery">;
     let resolvedTurn: ResolvedTurn | undefined;
     const runTurn = async (params: {
       adapter: { resolveTurn: () => ResolvedTurn };
@@ -417,17 +415,20 @@ describe("monitorLineProvider lifecycle", () => {
         { cfg: {} } as Parameters<typeof onMessage>[1],
       );
 
-      const prepared = resolvedTurn?.delivery.preparePayload?.({
-        text: "Approve this run?",
-        presentation: {
-          blocks: [
-            {
-              type: "buttons",
-              buttons: [{ label: "Approve", action: { type: "callback", value: "approve" } }],
-            },
-          ],
+      const prepared = await resolvedTurn?.delivery.preparePayload?.(
+        {
+          text: "Approve this run?",
+          presentation: {
+            blocks: [
+              {
+                type: "buttons",
+                buttons: [{ label: "Approve", action: { type: "callback", value: "approve" } }],
+              },
+            ],
+          },
         },
-      });
+        { kind: "final" },
+      );
       const line = prepared?.channelData?.line as { flexMessage?: unknown } | undefined;
 
       expect(prepared?.presentation).toBeUndefined();

--- a/extensions/line/src/rich-messages.ts
+++ b/extensions/line/src/rich-messages.ts
@@ -3,9 +3,9 @@ import type { messagingApi } from "@line/bot-sdk";
 import type { ChannelMessageActionAdapter } from "openclaw/plugin-sdk/channel-contract";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-result";
 import {
-  adaptMessagePresentationForChannel,
   normalizeMessagePresentation,
   renderMessagePresentationFallbackText,
+  renderPresentationForDelivery,
   resolveMessagePresentationButtonAction,
   resolveMessagePresentationOptionAction,
   type MessagePresentation,
@@ -154,10 +154,7 @@ function toLineAction(button: MessagePresentationButton): Action | undefined {
   return undefined;
 }
 
-export function renderLinePresentation(
-  payload: ReplyPayload,
-  presentation: MessagePresentation,
-): ReplyPayload | null {
+export function renderLinePresentation(payload: ReplyPayload, presentation: MessagePresentation) {
   const hasCard = presentation.blocks.some(
     (block) => block.type === "buttons" && block.buttons.length > 0,
   );
@@ -240,37 +237,25 @@ export function renderLinePresentation(
  * replies the plugin delivers itself reach delivery with the controls still
  * portable. Preparing them here keeps both LINE delivery paths on one rendering.
  */
-export function prepareLineReplyPayload(payload: ReplyPayload): ReplyPayload {
-  const presentation = normalizeMessagePresentation(payload.presentation);
-  if (!presentation) {
+export async function prepareLineReplyPayload(payload: ReplyPayload): Promise<ReplyPayload> {
+  if (!normalizeMessagePresentation(payload.presentation)) {
     return payload;
   }
-  const { presentation: _presentation, presentationTextMode, ...rest } = payload;
-  // "fallback" text already renders these controls as prose; native ones replace it.
-  const usesFallbackText = presentationTextMode === "fallback" && Boolean(rest.text?.trim());
-  const rendered = renderLinePresentation(
-    usesFallbackText ? { ...rest, text: undefined } : rest,
-    adaptMessagePresentationForChannel({
-      presentation,
-      capabilities: LINE_PRESENTATION_CAPABILITIES,
-    }),
+  const usesFallbackText =
+    payload.presentationTextMode === "fallback" && Boolean(payload.text?.trim());
+  return renderPresentationForDelivery(
+    {
+      presentationCapabilities: LINE_PRESENTATION_CAPABILITIES,
+      renderPresentation: (adapted) => {
+        const rendered = renderLinePresentation(adapted, adapted.presentation);
+        // Quick replies have no Flex body to replace the author's fallback prose.
+        return rendered && usesFallbackText && rendered.channelData.line.flexMessage === undefined
+          ? { ...rendered, text: payload.text }
+          : rendered;
+      },
+    },
+    { ...payload, presentationTextMode: usesFallbackText ? "fallback" : undefined },
   );
-  if (rendered) {
-    // Only a Flex body replaces the fallback prose. Without a card the renderer
-    // rebuilds the words it could not draw, and the author's own fallback text
-    // is the better rendering of the same facts, so it wins.
-    const renderedLine = isRecord(rendered.channelData?.line) ? rendered.channelData.line : {};
-    return usesFallbackText && renderedLine.flexMessage === undefined
-      ? { ...rendered, text: rest.text }
-      : rendered;
-  }
-  // LINE renders these controls natively or not at all; keep their labels visible.
-  return {
-    ...rest,
-    text: usesFallbackText
-      ? (rest.text ?? renderMessagePresentationFallbackText({ presentation }))
-      : renderMessagePresentationFallbackText({ text: rest.text, presentation }),
-  };
 }
 
 const toSlug = (value: string): string =>

--- a/extensions/line/src/row-overflow-delivery.loopback.test.ts
+++ b/extensions/line/src/row-overflow-delivery.loopback.test.ts
@@ -290,7 +290,7 @@ describe("Row-overflow table delivery through production outbound adapter over l
     const payload = { text: "Deployment details. ".repeat(1_500), presentation };
     const prepared =
       delivery === "reply"
-        ? prepareLineReplyPayload(payload)
+        ? await prepareLineReplyPayload(payload)
         : await lineOutboundAdapter.renderPresentation!({
             payload,
             presentation: adaptMessagePresentationForChannel({


### PR DESCRIPTION
## What Problem This Solves

LINE's inbound reply path maintained its own presentation adaptation, consumption, and failed-render fallback alongside the shared outbound delivery implementation. Maintaining both copies makes shared presentation fixes harder to carry consistently into replies.

## Why This Change Was Made

Delegate LINE reply preparation to the existing `renderPresentationForDelivery` owner, already used by Matrix and Feishu. Retain LINE's explicit policies for authored prose beside select-only quick replies and blank text marked as fallback. The private preparation function becomes asynchronous; the production turn lifecycle already awaits this hook. Derive the monitor test's delivery type from the SDK instead of retaining a handwritten synchronous type.

Native rendering, action encodings, quick-reply budgets, Flex envelope validation, reply-token use, retry behavior, and delivery outcomes remain in their current owners. No public SDK contract or configuration changes.

## User Impact

No intended user-visible behavior change. Questions, overflow choices, native controls, and fallback text retain their existing delivery behavior. This is a maintainer-requested consolidation.

## Evidence

- Baseline: `065b9cfa43bc6cbb823bff7fbe910c1935e45538`.
- Before: 82 selected LINE presentation, auto-reply delivery, HTTP loopback, and shared presentation tests passed.
- After: those tests plus two no-op payload cases passed (84 tests); 22 monitor lifecycle, signed-webhook wire, and durable-routing tests also passed.
- Commands: `node scripts/run-vitest.mjs extensions/line/src/channel.rich-messages.test.ts extensions/line/src/auto-reply-delivery.test.ts extensions/line/src/row-overflow-delivery.loopback.test.ts src/channels/plugins/outbound/presentation-delivery.test.ts` and `node scripts/run-vitest.mjs extensions/line/src/monitor.lifecycle.test.ts extensions/line/src/monitor.webhook-wire.test.ts extensions/line/src/monitor-durable.test.ts`.
- The monitor-facing test initially failed because it consumed the new promise synchronously. It now awaits the actual SDK hook contract; its native Flex assertion remains unchanged.
- Deslop completed. Final isolated full-scope autoreview, including the monitor test correction, was clean through P2.
- Production: +18/-33, net -15 lines (-12 excluding signature reflow). Test changes are accounted separately.
- `pnpm build` passed, including plugin SDK export checks and the Control UI build.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34100942160) passed for `673a40bd640f5781bb03a84f3c3c7a457bb4b9eb`.
- `node scripts/check-changed.mjs` passed for the production patch in [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/34099728243) (wrapper exit 0; the one-shot lease was stopped). The snapshot preceded the monitor test adjustment; that final test-only change additionally passed full extension test typechecking, targeted lint, formatting, the max-lines ratchet, and the 22 monitor tests above.
- Authenticated LINE delivery was not run. The passing loopback tests are transport-emulated evidence, not live LINE proof. The maintainer accepted this limitation for landing.
