### PR TITLE
feat(browser): stream the Control UI browser panel live instead of polling screenshots

### DIFF
--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -23,7 +23,7 @@ agent tools, but nothing listens on the loopback control port.
 - Status/start/stop: `GET /`, `GET /doctor`, `POST /start`, `POST /stop`, `POST /reset-profile`
 - Profiles: `GET /profiles`, `POST /profiles/create`, `DELETE /profiles/:name`
 - Tabs: `GET /tabs`, `POST /tabs/open`, `POST /tabs/focus`, `DELETE /tabs/:targetId`, `POST /tabs/action`
-- Snapshot/screenshot: `GET /snapshot`, `POST /screenshot`
+- Snapshot/screenshot/stream: `GET /snapshot`, `POST /screenshot`, `POST /screencast`
 - Actions: `POST /navigate`, `POST /act`
 - Hooks: `POST /hooks/file-chooser`, `POST /hooks/dialog`
 - Downloads: `POST /download`, `POST /wait/download`
@@ -84,6 +84,53 @@ Notes:
   Tailscale Serve identity headers.
 - If `gateway.auth.mode` is `none` or `trusted-proxy`, these loopback browser
   routes do not inherit those identity-bearing modes; keep them loopback-only.
+
+### Screencast stream
+
+`POST /screencast` mints a single-use token for a live view of the selected tab.
+Pass an optional `targetId`, `maxWidth`, `maxHeight`, and `quality` in the JSON
+body. Dimensions default to 1280 and are clamped to integers from 320 to 2000;
+JPEG quality defaults to 70 and is clamped from 30 to 90.
+
+The response contains `token`, `wsPath`, `expiresAtMs`, `targetId`, and `url`.
+Resolve `wsPath` against the Gateway URL and open a WebSocket there:
+`/browser/screencast?token=<token>`. The 48-character hexadecimal token expires
+after 60 seconds and can be consumed once. Invalid, expired, and reused tokens
+are rejected with HTTP 401 before upgrade. Viewers send no application messages;
+binary viewer messages close the connection.
+
+The plugin shares one CDP screencast per profile and tab. Chrome sends JPEG
+frames on repaint, paced to approximately 20 frames per second. Slow viewers
+skip frames instead of building a queue. Navigation immediately retires the
+capture session. A new CDP session starts only after the address is allowed,
+so delayed frames from the previous document cannot enter the new stream.
+A rejected navigation stops the stream.
+
+Text messages are JSON with `type` in `ready`, `meta`, or `error`. A `ready`
+message includes `targetId`, `url`, and `title`; `meta` updates `url` and `title`
+after allowed navigation and page load. Binary messages contain:
+
+1. A four-byte unsigned big-endian JSON header length.
+2. That many bytes of UTF-8 JSON: `{ "url", "cssWidth", "cssHeight", "scrollX", "scrollY", "ts" }`.
+3. The JPEG bytes.
+
+`cssWidth` and `cssHeight` come from CDP's `deviceWidth` and `deviceHeight`
+metadata and describe the layout viewport in CSS pixels. `scrollX` and `scrollY`
+come from `scrollOffsetX` and `scrollOffsetY`; `ts` is the CDP frame timestamp.
+
+| Close code | Meaning                                                                   |
+| ---------- | ------------------------------------------------------------------------- |
+| 4001       | Token invalid or expired (normally rejected before upgrade with HTTP 401) |
+| 4003       | `navigation_blocked`                                                      |
+| 4004       | `target_closed`, including a profile lifecycle change                     |
+| 4005       | Unsupported streaming                                                     |
+| 1012       | Gateway shutting down                                                     |
+
+Chrome MCP existing-session profiles and missing Playwright return HTTP 501 with
+`code: "SCREENCAST_UNSUPPORTED"` and `reason: "existing-session"` or `"playwright"`.
+Node-routed requests fail before proxying with `INVALID_REQUEST` and details
+`{ "code": "SCREENCAST_UNSUPPORTED", "reason": "node" }`. The Control UI falls
+back to the existing screenshot route when streaming is unavailable.
 
 ### `/act` error contract
 

--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -101,8 +101,10 @@ binary viewer messages close the connection.
 
 Tickets and viewers minted through the Gateway are bound to the requesting
 Gateway connection; ending that connection revokes unused tickets and closes
-its viewers. The loopback HTTP control API has no Gateway connection to bind,
-so its tickets remain TTL-only.
+its viewers. Revoked (invalidated) connections are fenced immediately, before
+the Gateway socket finishes closing: their tickets cannot upgrade, and their
+viewers receive no further frames or metadata. The loopback HTTP control API
+has no Gateway connection to bind, so its tickets remain TTL-only.
 
 The plugin shares one CDP screencast per profile and tab. Chrome sends JPEG
 frames on repaint, paced to approximately 20 frames per second. Slow viewers
@@ -123,22 +125,24 @@ after allowed navigation and page load. Binary messages contain:
 metadata and describe the layout viewport in CSS pixels. `scrollX` and `scrollY`
 come from `scrollOffsetX` and `scrollOffsetY`; `ts` is the CDP frame timestamp.
 
-| Close code | Meaning                                                                                             |
-| ---------- | --------------------------------------------------------------------------------------------------- |
-| 4001       | Token invalid or expired (normally rejected before upgrade with HTTP 401)                           |
-| 4003       | `navigation_blocked`                                                                                |
-| 4004       | `target_closed`, including a profile lifecycle change                                               |
-| 4005       | Unsupported streaming                                                                               |
-| 4006       | `authority_revoked` (the Gateway connection that minted the token ended, e.g. device token revoked) |
-| 1012       | Gateway shutting down                                                                               |
+| Close code | Meaning                                                                                                     |
+| ---------- | ----------------------------------------------------------------------------------------------------------- |
+| 4001       | Token invalid or expired (normally rejected before upgrade with HTTP 401)                                   |
+| 4003       | `navigation_blocked`                                                                                        |
+| 4004       | `target_closed`, including a profile lifecycle change                                                       |
+| 4005       | Unsupported streaming                                                                                       |
+| 4006       | `authority_revoked` (the requesting Gateway connection ended or was invalidated, e.g. device token revoked) |
+| 1012       | Gateway shutting down                                                                                       |
 
 Chrome MCP existing-session profiles and missing Playwright return HTTP 501 with
 `code: "SCREENCAST_UNSUPPORTED"` and `reason: "existing-session"` or `"playwright"`.
 Node-routed requests fail before proxying with `INVALID_REQUEST` and details
 `{ "code": "SCREENCAST_UNSUPPORTED", "reason": "node" }`. The Control UI falls
 back to the existing screenshot route when streaming is unavailable.
-While Annotate or Inspect is active, the Control UI pins the captured image and
-its URL, then displays the latest held frame when capture mode ends.
+Navigation metadata updates the tab and address bar; the displayed image keeps
+its own URL and metrics until a replacement frame arrives. While Annotate or
+Inspect is active, the Control UI pins the captured image and its URL, then
+displays the latest held frame when capture mode ends.
 
 ### `/act` error contract
 

--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -99,6 +99,11 @@ after 60 seconds and can be consumed once. Invalid, expired, and reused tokens
 are rejected with HTTP 401 before upgrade. Viewers send no application messages;
 binary viewer messages close the connection.
 
+Tickets and viewers minted through the Gateway are bound to the requesting
+Gateway connection; ending that connection revokes unused tickets and closes
+its viewers. The loopback HTTP control API has no Gateway connection to bind,
+so its tickets remain TTL-only.
+
 The plugin shares one CDP screencast per profile and tab. Chrome sends JPEG
 frames on repaint, paced to approximately 20 frames per second. Slow viewers
 skip frames instead of building a queue. Navigation immediately retires the
@@ -118,19 +123,22 @@ after allowed navigation and page load. Binary messages contain:
 metadata and describe the layout viewport in CSS pixels. `scrollX` and `scrollY`
 come from `scrollOffsetX` and `scrollOffsetY`; `ts` is the CDP frame timestamp.
 
-| Close code | Meaning                                                                   |
-| ---------- | ------------------------------------------------------------------------- |
-| 4001       | Token invalid or expired (normally rejected before upgrade with HTTP 401) |
-| 4003       | `navigation_blocked`                                                      |
-| 4004       | `target_closed`, including a profile lifecycle change                     |
-| 4005       | Unsupported streaming                                                     |
-| 1012       | Gateway shutting down                                                     |
+| Close code | Meaning                                                                                             |
+| ---------- | --------------------------------------------------------------------------------------------------- |
+| 4001       | Token invalid or expired (normally rejected before upgrade with HTTP 401)                           |
+| 4003       | `navigation_blocked`                                                                                |
+| 4004       | `target_closed`, including a profile lifecycle change                                               |
+| 4005       | Unsupported streaming                                                                               |
+| 4006       | `authority_revoked` (the Gateway connection that minted the token ended, e.g. device token revoked) |
+| 1012       | Gateway shutting down                                                                               |
 
 Chrome MCP existing-session profiles and missing Playwright return HTTP 501 with
 `code: "SCREENCAST_UNSUPPORTED"` and `reason: "existing-session"` or `"playwright"`.
 Node-routed requests fail before proxying with `INVALID_REQUEST` and details
 `{ "code": "SCREENCAST_UNSUPPORTED", "reason": "node" }`. The Control UI falls
 back to the existing screenshot route when streaming is unavailable.
+While Annotate or Inspect is active, the Control UI pins the captured image and
+its URL, then displays the latest held frame when capture mode ends.
 
 ### `/act` error contract
 

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -160,6 +160,11 @@ that card's browser and tab. This does not change `browser.defaultProfile` or
 another session's selection. Without a session browser target, the panel uses
 the configured default routing.
 
+The panel streams the active tab live as the page repaints. It falls back to
+screenshots for node-routed browsers, Chrome MCP existing-session profiles,
+missing Playwright, or stream connection failures. Navigation rules apply to
+the stream: navigating to a blocked address stops it and clears the view.
+
 Preview cards are interactive only when OpenClaw can identify the browser's
 route. Sandbox browser results remain available to the agent but do not open a
 host-browser preview.

--- a/extensions/browser/plugin-registration.shutdown.test.ts
+++ b/extensions/browser/plugin-registration.shutdown.test.ts
@@ -7,6 +7,7 @@ import { registerBrowserPlugin } from "./plugin-registration.js";
 
 const runtimeMocks = vi.hoisted(() => ({
   handleGatewayExtensionUpgrade: vi.fn(async () => true),
+  handleBrowserScreencastUpgrade: vi.fn(async () => true),
   stopBrowserControlService: vi.fn(async () => undefined),
 }));
 
@@ -18,6 +19,10 @@ vi.mock("./src/browser/extension-relay/gateway-relay-route.js", () => ({
   handleGatewayExtensionUpgrade: runtimeMocks.handleGatewayExtensionUpgrade,
 }));
 
+vi.mock("./src/browser/screencast/upgrade.js", () => ({
+  handleBrowserScreencastUpgrade: runtimeMocks.handleBrowserScreencastUpgrade,
+}));
+
 vi.mock("./src/browser/session-tab-store.js", () => ({
   initializeBrowserSessionTabStore: vi.fn(),
 }));
@@ -26,7 +31,7 @@ vi.mock("./src/browser/system-profile-import-state.js", () => ({
   configureSystemProfileImportStateStore: vi.fn(),
 }));
 
-function registerLifecycleCallbacks() {
+function registerLifecycleCallbacks(path: string) {
   let route: Parameters<OpenClawPluginApi["registerHttpRoute"]>[0] | undefined;
   let service: OpenClawPluginService | undefined;
   registerBrowserPlugin(
@@ -35,7 +40,9 @@ function registerLifecycleCallbacks() {
         state: { openKeyedStore: vi.fn() },
       } as never,
       registerHttpRoute(value) {
-        route = value;
+        if (value.path === path) {
+          route = value;
+        }
       },
       registerService(value) {
         service = value;
@@ -48,27 +55,30 @@ function registerLifecycleCallbacks() {
   return { handleUpgrade: route.handleUpgrade, stop: service.stop };
 }
 
-describe("browser relay shutdown registration", () => {
+describe("browser websocket shutdown registration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("keeps shutdown lazy until direct relay activity prepares teardown", async () => {
-    const coldLifecycle = registerLifecycleCallbacks();
+  it("keeps shutdown lazy until direct websocket activity prepares teardown", async () => {
+    const coldLifecycle = registerLifecycleCallbacks("/browser/screencast");
 
     await coldLifecycle.stop({} as never);
 
     expect(runtimeMocks.stopBrowserControlService).not.toHaveBeenCalled();
 
-    const { handleUpgrade, stop } = registerLifecycleCallbacks();
     const req = {} as IncomingMessage;
     const socket = {} as Duplex;
     const head = Buffer.alloc(0);
 
-    await expect(handleUpgrade(req, socket, head)).resolves.toBe(true);
-    await stop({} as never);
+    for (const path of ["/browser/screencast", "/browser/extension"]) {
+      const { handleUpgrade, stop } = registerLifecycleCallbacks(path);
+      await expect(handleUpgrade(req, socket, head)).resolves.toBe(true);
+      await stop({} as never);
+    }
 
+    expect(runtimeMocks.handleBrowserScreencastUpgrade).toHaveBeenCalledWith(req, socket, head);
     expect(runtimeMocks.handleGatewayExtensionUpgrade).toHaveBeenCalledWith(req, socket, head);
-    expect(runtimeMocks.stopBrowserControlService).toHaveBeenCalledOnce();
+    expect(runtimeMocks.stopBrowserControlService).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -328,5 +328,20 @@ export function registerBrowserPlugin(api: OpenClawPluginApi) {
       return await handleGatewayExtensionUpgrade(req, socket, head);
     },
   });
+  api.registerHttpRoute({
+    path: "/browser/screencast",
+    auth: "plugin",
+    match: "exact",
+    handler: (_req: IncomingMessage, res: ServerResponse) => {
+      res.writeHead(426, { "Content-Type": "text/plain" });
+      res.end("Upgrade Required: connect the browser screencast over WebSocket.");
+    },
+    handleUpgrade: async (req: IncomingMessage, socket: Duplex, head: Buffer) => {
+      await loadBrowserRegistrationRuntimeModule();
+      const { handleBrowserScreencastUpgrade } =
+        await import("./src/browser/screencast/upgrade.js");
+      return await handleBrowserScreencastUpgrade(req, socket, head);
+    },
+  });
   api.registerService(createLazyBrowserPluginService());
 }

--- a/extensions/browser/src/browser/routes/agent.screencast.test.ts
+++ b/extensions/browser/src/browser/routes/agent.screencast.test.ts
@@ -13,6 +13,7 @@ import {
 import { makeBrowserProfile, makeBrowserServerState } from "../server-context.test-harness.js";
 import { registerBrowserAgentScreencastRoutes } from "./agent.screencast.js";
 import { createBrowserRouteApp, createBrowserRouteResponse } from "./test-helpers.js";
+import type { BrowserRequest } from "./types.js";
 
 const pw = vi.hoisted(() => ({ available: true }));
 
@@ -52,9 +53,12 @@ function setup(options: { existingSession?: boolean; url?: string; listedUrl?: s
     state,
     runtime,
     ensureTabAvailable,
-    request: async (body: Record<string, unknown> = {}) => {
+    request: async (
+      body: Record<string, unknown> = {},
+      requester?: BrowserRequest["requester"],
+    ) => {
       const response = createBrowserRouteResponse();
-      await route({ params: {}, query: {}, body }, response.res);
+      await route({ params: {}, query: {}, body, requester }, response.res);
       return response;
     },
   };
@@ -67,6 +71,37 @@ describe("browser screencast mint route", () => {
 
   afterEach(() => {
     clearBrowserScreencastTokens();
+  });
+
+  it.each(["before request", "during tab resolution"])(
+    "rejects a requester revoked %s",
+    async (when) => {
+      const requester = new AbortController();
+      const { request, ensureTabAvailable } = setup();
+      if (when === "before request") {
+        requester.abort();
+      } else {
+        const resolveTab = ensureTabAvailable.getMockImplementation()!;
+        ensureTabAvailable.mockImplementationOnce(async () => {
+          requester.abort();
+          return await resolveTab();
+        });
+      }
+      const response = await request({}, { signal: requester.signal });
+      expect(response.statusCode).toBe(401);
+      expect(response.body).toMatchObject({ code: "SCREENCAST_REQUESTER_GONE" });
+      expect(response.body).not.toHaveProperty("token");
+    },
+  );
+
+  it("binds a minted token to the requester lifetime", async () => {
+    const requester = new AbortController();
+    const { request } = setup();
+    const response = await request({}, { signal: requester.signal });
+    const token = (response.body as { token: string }).token;
+    expect(response.statusCode).toBe(200);
+    requester.abort();
+    expect(consumeBrowserScreencastToken(token)).toBeUndefined();
   });
 
   it.each([

--- a/extensions/browser/src/browser/routes/agent.screencast.test.ts
+++ b/extensions/browser/src/browser/routes/agent.screencast.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "../../test-support/browser-security.mock.js";
+import {
+  clearBrowserScreencastTokens,
+  consumeBrowserScreencastToken,
+} from "../screencast/tokens.js";
+import type { BrowserRouteContext, ProfileContext } from "../server-context.js";
+import {
+  getOrCreateProfileRuntime,
+  getProfileLifecycle,
+  markBrowserRuntimeStopping,
+} from "../server-context.lifecycle.js";
+import { makeBrowserProfile, makeBrowserServerState } from "../server-context.test-harness.js";
+import { registerBrowserAgentScreencastRoutes } from "./agent.screencast.js";
+import { createBrowserRouteApp, createBrowserRouteResponse } from "./test-helpers.js";
+
+const pw = vi.hoisted(() => ({ available: true }));
+
+vi.mock("../pw-ai-module.js", () => ({
+  getPwAiModule: async () => (pw.available ? {} : null),
+  getLoadedPwAiModule: () => null,
+}));
+
+function setup(options: { existingSession?: boolean; url?: string; listedUrl?: string } = {}) {
+  const profile = makeBrowserProfile(options.existingSession ? { driver: "existing-session" } : {});
+  const state = makeBrowserServerState({
+    profile,
+    resolvedOverrides: { ssrfPolicy: { allowPrivateNetwork: false } },
+  });
+  const runtime = getOrCreateProfileRuntime(state, profile);
+  const tab = {
+    targetId: "resolved-tab",
+    title: "Example",
+    url: options.url ?? "https://example.com/",
+    type: "page",
+  };
+  const ensureTabAvailable = vi.fn(async () => tab);
+  const profileCtx = {
+    profile,
+    ensureTabAvailable,
+    listTabs: async () => [{ ...tab, url: options.listedUrl ?? tab.url }],
+  } as unknown as ProfileContext;
+  const ctx = {
+    state: () => state,
+    forProfile: () => profileCtx,
+    mapTabError: () => null,
+  } as unknown as BrowserRouteContext;
+  const { app, postHandlers } = createBrowserRouteApp();
+  registerBrowserAgentScreencastRoutes(app, ctx);
+  const route = postHandlers.get("/screencast")!;
+  return {
+    state,
+    runtime,
+    ensureTabAvailable,
+    request: async (body: Record<string, unknown> = {}) => {
+      const response = createBrowserRouteResponse();
+      await route({ params: {}, query: {}, body }, response.res);
+      return response;
+    },
+  };
+}
+
+describe("browser screencast mint route", () => {
+  beforeEach(() => {
+    pw.available = true;
+  });
+
+  afterEach(() => {
+    clearBrowserScreencastTokens();
+  });
+
+  it.each([
+    { existingSession: true, playwright: true, reason: "existing-session" },
+    { existingSession: false, playwright: false, reason: "playwright" },
+  ])("reports $reason as unsupported", async ({ existingSession, playwright, reason }) => {
+    pw.available = playwright;
+    const { request } = setup({ existingSession });
+    const response = await request();
+
+    expect(response.statusCode).toBe(501);
+    expect(response.body).toMatchObject({
+      error: expect.any(String),
+      code: "SCREENCAST_UNSUPPORTED",
+      reason,
+    });
+  });
+
+  it("mints an expiring token scoped to the resolved target with bounded capture options", async () => {
+    const { request, ensureTabAvailable } = setup();
+    const startedAt = Date.now();
+    const response = await request({ targetId: "t1", maxWidth: 17, maxHeight: 9000, quality: 99 });
+    const body = response.body as { token: string; wsPath: string; expiresAtMs: number };
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toMatchObject({
+      token: expect.stringMatching(/^[a-f0-9]{48}$/),
+      wsPath: `/browser/screencast?token=${body.token}`,
+      targetId: "resolved-tab",
+      url: "https://example.com/",
+    });
+    expect(body.expiresAtMs).toBeGreaterThanOrEqual(startedAt + 60_000);
+    expect(ensureTabAvailable).toHaveBeenCalledWith("t1", expect.any(Object));
+    expect(consumeBrowserScreencastToken(body.token)).toMatchObject({
+      profileName: "openclaw",
+      targetId: "resolved-tab",
+      cdpUrl: "http://127.0.0.1:18800",
+      maxWidth: 320,
+      maxHeight: 2000,
+      quality: 90,
+    });
+  });
+
+  it("keeps default bounds and checks current navigation policy after config changes", async () => {
+    const { request, state, runtime } = setup();
+    state.resolved.ssrfPolicy = { allowPrivateNetwork: true };
+    const response = await request();
+    const token = consumeBrowserScreencastToken((response.body as { token: string }).token)!;
+
+    expect(token).toMatchObject({ maxWidth: 1280, maxHeight: 1280, quality: 70 });
+    await expect(token.checkNavigationAllowed("http://127.0.0.1/")).resolves.toBeUndefined();
+    state.resolved.ssrfPolicy = { allowPrivateNetwork: false };
+    await expect(token.checkNavigationAllowed("http://127.0.0.1/")).rejects.toThrow();
+    getProfileLifecycle(runtime).generation += 1;
+    expect(() => token.assertCurrent()).toThrow("superseded");
+  });
+
+  it("blocks minting for a disallowed current tab through the shared route guard", async () => {
+    const { request } = setup({ url: "http://127.0.0.1/private" });
+    const response = await request();
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toMatchObject({ reason: "navigation_blocked" });
+    expect(response.body).not.toHaveProperty("token");
+  });
+
+  it.each(["runtime retirement", "profile removal"] as const)(
+    "rejects a minted token after %s",
+    async (transition) => {
+      const { request, state } = setup();
+      const response = await request();
+      const token = consumeBrowserScreencastToken((response.body as { token: string }).token)!;
+
+      if (transition === "runtime retirement") {
+        markBrowserRuntimeStopping(state);
+      } else {
+        state.profiles.delete("openclaw");
+      }
+
+      expect(() => token.assertCurrent()).toThrow("superseded");
+    },
+  );
+
+  it("redacts a newly blocked listed URL in the mint response", async () => {
+    const { request } = setup({ listedUrl: "http://127.0.0.1/private" });
+    const response = await request();
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toMatchObject({ token: expect.any(String), url: undefined });
+  });
+});

--- a/extensions/browser/src/browser/routes/agent.screencast.test.ts
+++ b/extensions/browser/src/browser/routes/agent.screencast.test.ts
@@ -73,34 +73,59 @@ describe("browser screencast mint route", () => {
     clearBrowserScreencastTokens();
   });
 
-  it.each(["before request", "during tab resolution"])(
-    "rejects a requester revoked %s",
-    async (when) => {
-      const requester = new AbortController();
-      const { request, ensureTabAvailable } = setup();
-      if (when === "before request") {
-        requester.abort();
+  it.each([
+    { when: "before request", abort: true },
+    { when: "during tab resolution", abort: true },
+    { when: "before request", abort: false },
+    { when: "during tab resolution", abort: false },
+  ])("rejects a requester invalidated $when (socket closed: $abort)", async ({ when, abort }) => {
+    const connection = new AbortController();
+    const requester = {
+      invalidated: false,
+      signal: connection.signal,
+      isCurrent: () => !requester.invalidated && !connection.signal.aborted,
+    };
+    const revoke = () => {
+      if (abort) {
+        connection.abort();
       } else {
-        const resolveTab = ensureTabAvailable.getMockImplementation()!;
-        ensureTabAvailable.mockImplementationOnce(async () => {
-          requester.abort();
-          return await resolveTab();
-        });
+        requester.invalidated = true;
       }
-      const response = await request({}, { signal: requester.signal });
-      expect(response.statusCode).toBe(401);
-      expect(response.body).toMatchObject({ code: "SCREENCAST_REQUESTER_GONE" });
-      expect(response.body).not.toHaveProperty("token");
-    },
-  );
+    };
+    const { request, ensureTabAvailable } = setup();
+    if (when === "before request") {
+      revoke();
+    } else {
+      const resolveTab = ensureTabAvailable.getMockImplementation()!;
+      ensureTabAvailable.mockImplementationOnce(async () => {
+        revoke();
+        return await resolveTab();
+      });
+    }
+    const response = await request({}, requester);
+    expect(connection.signal.aborted).toBe(abort);
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toMatchObject({ code: "SCREENCAST_REQUESTER_GONE" });
+    expect(response.body).not.toHaveProperty("token");
+  });
 
-  it("binds a minted token to the requester lifetime", async () => {
-    const requester = new AbortController();
+  it.each(["socket close", "invalidation"])("binds a minted token to requester %s", async (end) => {
+    const connection = new AbortController();
+    const requester = {
+      invalidated: false,
+      signal: connection.signal,
+      isCurrent: () => !requester.invalidated && !connection.signal.aborted,
+    };
     const { request } = setup();
-    const response = await request({}, { signal: requester.signal });
+    const response = await request({}, requester);
     const token = (response.body as { token: string }).token;
     expect(response.statusCode).toBe(200);
-    requester.abort();
+    if (end === "socket close") {
+      connection.abort();
+    } else {
+      requester.invalidated = true;
+    }
+    expect(connection.signal.aborted).toBe(end === "socket close");
     expect(consumeBrowserScreencastToken(token)).toBeUndefined();
   });
 

--- a/extensions/browser/src/browser/routes/agent.screencast.ts
+++ b/extensions/browser/src/browser/routes/agent.screencast.ts
@@ -25,7 +25,7 @@ export function registerBrowserAgentScreencastRoutes(
 ) {
   app.post("/screencast", async (req, res) => {
     const requesterGone = () => {
-      if (!req.requester?.signal.aborted) {
+      if (!req.requester || req.requester.isCurrent()) {
         return false;
       }
       res.status(401).json({
@@ -95,6 +95,7 @@ export function registerBrowserAgentScreencastRoutes(
           lifecycleGeneration: generation,
           lifecycleSignal: lifecycle.controller.signal,
           requesterSignal: req.requester?.signal,
+          isRequesterCurrent: req.requester?.isCurrent,
           assertCurrent,
           checkNavigationAllowed: async (nextUrl) => {
             await assertBrowserNavigationResultAllowed({

--- a/extensions/browser/src/browser/routes/agent.screencast.ts
+++ b/extensions/browser/src/browser/routes/agent.screencast.ts
@@ -24,6 +24,19 @@ export function registerBrowserAgentScreencastRoutes(
   ctx: BrowserRouteContext,
 ) {
   app.post("/screencast", async (req, res) => {
+    const requesterGone = () => {
+      if (!req.requester?.signal.aborted) {
+        return false;
+      }
+      res.status(401).json({
+        error: "The Gateway connection that requested the screencast has ended.",
+        code: "SCREENCAST_REQUESTER_GONE",
+      });
+      return true;
+    };
+    if (requesterGone()) {
+      return;
+    }
     const body = readBody(req);
     await withRouteTabContext({
       req,
@@ -68,6 +81,9 @@ export function registerBrowserAgentScreencastRoutes(
         const url = await resolveTabUrl(tab.url);
         signal.throwIfAborted();
         assertCurrent();
+        if (requesterGone()) {
+          return;
+        }
         const { token, expiresAtMs } = mintBrowserScreencastToken({
           profileName,
           targetId: tab.targetId,
@@ -78,6 +94,7 @@ export function registerBrowserAgentScreencastRoutes(
           quality: clampScreencastOption(body.quality, 30, 90, 70),
           lifecycleGeneration: generation,
           lifecycleSignal: lifecycle.controller.signal,
+          requesterSignal: req.requester?.signal,
           assertCurrent,
           checkNavigationAllowed: async (nextUrl) => {
             await assertBrowserNavigationResultAllowed({

--- a/extensions/browser/src/browser/routes/agent.screencast.ts
+++ b/extensions/browser/src/browser/routes/agent.screencast.ts
@@ -1,0 +1,99 @@
+import { BrowserProfileUnavailableError } from "../errors.js";
+import { assertBrowserNavigationResultAllowed } from "../navigation-guard.js";
+import { getBrowserProfileCapabilities } from "../profile-capabilities.js";
+import { mintBrowserScreencastToken } from "../screencast/tokens.js";
+import type { BrowserRouteContext } from "../server-context.js";
+import { getProfileLifecycle, isProfileGenerationCurrent } from "../server-context.lifecycle.js";
+import {
+  browserNavigationPolicyForProfile,
+  getPwAiModule,
+  readBody,
+  resolveTargetIdFromBody,
+  withRouteTabContext,
+} from "./agent.shared.js";
+import type { BrowserRouteRegistrar } from "./types.js";
+
+function clampScreencastOption(value: unknown, min: number, max: number, fallback: number) {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(min, Math.min(max, Math.floor(value)))
+    : fallback;
+}
+
+export function registerBrowserAgentScreencastRoutes(
+  app: BrowserRouteRegistrar,
+  ctx: BrowserRouteContext,
+) {
+  app.post("/screencast", async (req, res) => {
+    const body = readBody(req);
+    await withRouteTabContext({
+      req,
+      res,
+      ctx,
+      targetId: resolveTargetIdFromBody(body),
+      enforceCurrentUrlAllowed: true,
+      run: async ({ profileCtx, tab, cdpUrl, signal, resolveTabUrl }) => {
+        if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
+          res.status(501).json({
+            error: "Browser screencast is not available for existing-session profiles.",
+            code: "SCREENCAST_UNSUPPORTED",
+            reason: "existing-session",
+          });
+          return;
+        }
+        if (!(await getPwAiModule())) {
+          res.status(501).json({
+            error: "Browser screencast requires Playwright in this gateway build.",
+            code: "SCREENCAST_UNSUPPORTED",
+            reason: "playwright",
+          });
+          return;
+        }
+        const state = ctx.state();
+        const profileName = profileCtx.profile.name;
+        const runtime = state.profiles.get(profileName);
+        if (!runtime) {
+          throw new BrowserProfileUnavailableError("Browser profile is no longer available.");
+        }
+        const lifecycle = getProfileLifecycle(runtime);
+        const generation = lifecycle.generation;
+        const configRevision = lifecycle.configRevision;
+        const assertCurrent = () => {
+          if (
+            state.profiles.get(profileName) !== runtime ||
+            !isProfileGenerationCurrent({ state, runtime, generation, configRevision })
+          ) {
+            throw new BrowserProfileUnavailableError("Browser screencast target was superseded.");
+          }
+        };
+        const url = await resolveTabUrl(tab.url);
+        signal.throwIfAborted();
+        assertCurrent();
+        const { token, expiresAtMs } = mintBrowserScreencastToken({
+          profileName,
+          targetId: tab.targetId,
+          cdpUrl,
+          ssrfPolicy: state.resolved.ssrfPolicy,
+          maxWidth: clampScreencastOption(body.maxWidth, 320, 2000, 1280),
+          maxHeight: clampScreencastOption(body.maxHeight, 320, 2000, 1280),
+          quality: clampScreencastOption(body.quality, 30, 90, 70),
+          lifecycleGeneration: generation,
+          lifecycleSignal: lifecycle.controller.signal,
+          assertCurrent,
+          checkNavigationAllowed: async (nextUrl) => {
+            await assertBrowserNavigationResultAllowed({
+              url: nextUrl,
+              ...browserNavigationPolicyForProfile(ctx, profileCtx),
+            });
+          },
+        });
+        res.json({
+          token,
+          wsPath: `/browser/screencast?token=${token}`,
+          expiresAtMs,
+          targetId: tab.targetId,
+          url,
+        });
+      },
+    });
+  });
+}

--- a/extensions/browser/src/browser/routes/agent.ts
+++ b/extensions/browser/src/browser/routes/agent.ts
@@ -7,6 +7,7 @@
 import type { BrowserRouteContext } from "../server-context.js";
 import { registerBrowserAgentActRoutes } from "./agent.act.js";
 import { registerBrowserAgentDebugRoutes } from "./agent.debug.js";
+import { registerBrowserAgentScreencastRoutes } from "./agent.screencast.js";
 import { registerBrowserAgentSnapshotRoutes } from "./agent.snapshot.js";
 import { registerBrowserAgentStorageRoutes } from "./agent.storage.js";
 import type { BrowserRouteRegistrar } from "./types.js";
@@ -14,6 +15,7 @@ import type { BrowserRouteRegistrar } from "./types.js";
 /** Register all agent-facing browser route groups. */
 export function registerBrowserAgentRoutes(app: BrowserRouteRegistrar, ctx: BrowserRouteContext) {
   registerBrowserAgentSnapshotRoutes(app, ctx);
+  registerBrowserAgentScreencastRoutes(app, ctx);
   registerBrowserAgentActRoutes(app, ctx);
   registerBrowserAgentDebugRoutes(app, ctx);
   registerBrowserAgentStorageRoutes(app, ctx);

--- a/extensions/browser/src/browser/routes/dispatcher.ts
+++ b/extensions/browser/src/browser/routes/dispatcher.ts
@@ -16,6 +16,7 @@ type BrowserDispatchRequest = {
   query?: Record<string, unknown>;
   body?: unknown;
   signal?: AbortSignal;
+  requester?: BrowserRequest["requester"];
 };
 
 type BrowserDispatchResponse = {
@@ -119,6 +120,7 @@ export function createBrowserRouteDispatcher(ctx: BrowserRouteContext) {
             query,
             body,
             signal,
+            requester: req.requester,
           },
           res,
         );

--- a/extensions/browser/src/browser/routes/types.ts
+++ b/extensions/browser/src/browser/routes/types.ts
@@ -14,8 +14,8 @@ export type BrowserRequest = {
    * timeouts and (where supported) cancel long-running operations.
    */
   signal?: AbortSignal;
-  /** Gateway connection lifetime, independent of the request timeout. */
-  requester?: { connId?: string; signal: AbortSignal };
+  /** Gateway authority, including invalidation before transport retirement; independent of request timeout. */
+  requester?: { connId?: string; signal: AbortSignal; isCurrent: () => boolean };
 };
 
 /** Response shape used by browser route handlers. */

--- a/extensions/browser/src/browser/routes/types.ts
+++ b/extensions/browser/src/browser/routes/types.ts
@@ -14,6 +14,8 @@ export type BrowserRequest = {
    * timeouts and (where supported) cancel long-running operations.
    */
   signal?: AbortSignal;
+  /** Gateway connection lifetime, independent of the request timeout. */
+  requester?: { connId?: string; signal: AbortSignal };
 };
 
 /** Response shape used by browser route handlers. */

--- a/extensions/browser/src/browser/runtime-lifecycle.ts
+++ b/extensions/browser/src/browser/runtime-lifecycle.ts
@@ -3,6 +3,7 @@
  */
 import type { Server } from "node:http";
 import { getExtensionRelayModule } from "./extension-relay.runtime.js";
+import { stopBrowserScreencasts } from "./screencast/session.js";
 import type { BrowserServerState } from "./server-context.js";
 import { markBrowserRuntimeStopping } from "./server-context.lifecycle.js";
 import { stopKnownBrowserProfiles } from "./server-lifecycle.js";
@@ -61,6 +62,8 @@ async function stopBrowserRuntimeInternal(
   markBrowserRuntimeStopping(current);
   let firstError: Error | undefined;
 
+  // Viewers receive the shutdown code before profile invalidation closes their targets.
+  const screencastDrain = finalizeGlobalAdapters ? stopBrowserScreencasts() : Promise.resolve();
   // stopKnownBrowserProfiles invalidates every actor synchronously before its
   // first await; only then do we wait for tab cleanup and profile drains.
   const profileDrain = stopKnownBrowserProfiles({
@@ -76,7 +79,7 @@ async function stopBrowserRuntimeInternal(
       current.stopTrackedTabCleanup?.();
     }
   });
-  for (const result of await Promise.allSettled([profileDrain, tabCleanup])) {
+  for (const result of await Promise.allSettled([screencastDrain, profileDrain, tabCleanup])) {
     if (result.status === "rejected") {
       firstError ??= toRuntimeLifecycleError(result.reason, "Browser profile cleanup failed.");
     }

--- a/extensions/browser/src/browser/screencast/session.chromium.test.ts
+++ b/extensions/browser/src/browser/screencast/session.chromium.test.ts
@@ -1,0 +1,69 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import type { Browser, Page } from "playwright-core";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { WebSocket } from "ws";
+import { getPlaywrightCore } from "../playwright-core.runtime.js";
+import { attachBrowserScreencastViewer, stopBrowserScreencasts } from "./session.js";
+import { parseScreencastFrame, screencastParams, ScreencastViewer } from "./test-support.js";
+
+const state = vi.hoisted(() => ({ page: undefined as Page | undefined }));
+vi.mock("../pw-ai-module.js", () => ({
+  getPwAiModule: async () => ({
+    getPageForTargetId: async () => {
+      if (!state.page) {
+        throw new Error("Chromium page is not initialized");
+      }
+      return state.page;
+    },
+  }),
+}));
+
+describe.runIf(process.env.OPENCLAW_BROWSER_SCREENCAST_E2E === "1")(
+  "browser screencast in Chromium",
+  () => {
+    let browser: Browser;
+    let page: Page;
+
+    beforeAll(async () => {
+      browser = await getPlaywrightCore().chromium.launch({
+        headless: true,
+        executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+      });
+      page = await browser.newPage({ viewport: { width: 800, height: 600 } });
+      await page.setContent(
+        "<title>Screencast proof</title><style>body{height:2000px;background:#ffc}</style><h1>Live browser</h1>",
+      );
+      state.page = page;
+    });
+
+    afterAll(async () => {
+      await stopBrowserScreencasts();
+      state.page = undefined;
+      await browser?.close();
+    });
+
+    it("streams JPEG with CSS viewport dimensions and closes when the page closes", async () => {
+      const viewer = new ScreencastViewer();
+      attachBrowserScreencastViewer(screencastParams(), viewer as unknown as WebSocket);
+      await expect.poll(() => viewer.frames().length, { timeout: 5_000 }).toBeGreaterThan(0);
+      const frame = parseScreencastFrame(
+        expectDefined(viewer.frames()[0], "Chromium screencast frame"),
+      );
+      const viewport = await page.evaluate(() => ({
+        width: window.innerWidth,
+        height: window.innerHeight,
+        scrollbarWidth: window.innerWidth - document.documentElement.clientWidth,
+        scrollbarHeight: window.innerHeight - document.documentElement.clientHeight,
+      }));
+      expect(frame.jpeg.subarray(0, 2)).toEqual(Buffer.from([0xff, 0xd8]));
+      expect(frame.header.cssWidth).toBe(viewport.width);
+      expect(frame.header.cssHeight).toBe(viewport.height);
+      console.log(
+        `Chromium screencast: JPEG FF D8; CSS ${frame.header.cssWidth}x${frame.header.cssHeight}; inner ${viewport.width}x${viewport.height}; scrollbar delta ${viewport.scrollbarWidth}x${viewport.scrollbarHeight}`,
+      );
+      await page.close();
+      await expect.poll(() => viewer.close.mock.calls).toContainEqual([4004, "target_closed"]);
+      console.log("Chromium screencast: page close -> 4004 target_closed");
+    });
+  },
+);

--- a/extensions/browser/src/browser/screencast/session.test.ts
+++ b/extensions/browser/src/browser/screencast/session.test.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "node:events";
+import { EventEmitter, getEventListeners } from "node:events";
 import { expectDefined } from "@openclaw/normalization-core";
 import type { Page } from "playwright-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -91,6 +91,42 @@ describe("browser screencast sessions", () => {
     await flush();
     return viewer;
   }
+
+  it("revokes only the requesting viewer and stops capture after the last requester leaves", async () => {
+    const firstRequester = new AbortController();
+    const secondRequester = new AbortController();
+    const first = await attach(screencastParams({ requesterSignal: firstRequester.signal }));
+    const second = await attach(screencastParams({ requesterSignal: secondRequester.signal }));
+    page.paint(1);
+    firstRequester.abort();
+    expect(first.close).toHaveBeenCalledWith(4006, "authority_revoked");
+    expect(second.close).not.toHaveBeenCalled();
+    expect(getEventListeners(firstRequester.signal, "abort")).toHaveLength(0);
+    page.paint(2);
+    expect(first.frames()).toHaveLength(1);
+    expect(second.frames()).toHaveLength(2);
+    expect(page.cdp.detach).not.toHaveBeenCalled();
+    secondRequester.abort();
+    expect(second.close).toHaveBeenCalledWith(4006, "authority_revoked");
+    await flush();
+    expect(page.cdp.detach).toHaveBeenCalledOnce();
+  });
+
+  it("releases requester subscriptions when a viewer closes normally", async () => {
+    const requester = new AbortController();
+    const viewer = await attach(screencastParams({ requesterSignal: requester.signal }));
+    expect(getEventListeners(requester.signal, "abort")).toHaveLength(1);
+    viewer.close();
+    expect(getEventListeners(requester.signal, "abort")).toHaveLength(0);
+    requester.abort();
+    expect(viewer.close).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a requester revoked before viewer attachment without starting capture", async () => {
+    const viewer = await attach(screencastParams({ requesterSignal: AbortSignal.abort() }));
+    expect(viewer.close).toHaveBeenCalledWith(4006, "authority_revoked");
+    expect(page.newCDPSession).not.toHaveBeenCalled();
+  });
 
   it("shares one JPEG message across viewers, skips congestion, and ack-paces every frame", async () => {
     const first = await attach();

--- a/extensions/browser/src/browser/screencast/session.test.ts
+++ b/extensions/browser/src/browser/screencast/session.test.ts
@@ -1,0 +1,390 @@
+import { EventEmitter } from "node:events";
+import { expectDefined } from "@openclaw/normalization-core";
+import type { Page } from "playwright-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WebSocket } from "ws";
+import { attachBrowserScreencastViewer, stopBrowserScreencasts } from "./session.js";
+import { parseScreencastFrame, screencastParams, ScreencastViewer } from "./test-support.js";
+
+const mocks = vi.hoisted(() => ({ getPage: vi.fn<() => Promise<Page>>() }));
+vi.mock("../pw-ai-module.js", () => ({
+  getPwAiModule: async () => ({ getPageForTargetId: mocks.getPage }),
+}));
+
+class FakeCdp extends EventEmitter {
+  send = vi.fn(async (_method: string, _params?: unknown) => ({}));
+  detach = vi.fn(async () => {
+    this.emit("close", this);
+  });
+
+  paint(sessionId = 1, jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xd9])): void {
+    this.emit("Page.screencastFrame", {
+      sessionId,
+      data: jpeg.toString("base64"),
+      metadata: {
+        deviceWidth: 800,
+        deviceHeight: 600,
+        scrollOffsetX: 12,
+        scrollOffsetY: 34,
+        timestamp: 123,
+      },
+    });
+  }
+}
+
+class FakePage extends EventEmitter {
+  cdps: FakeCdp[] = [];
+  newCDPSession = vi.fn(async () => {
+    const cdp = new FakeCdp();
+    this.cdps.push(cdp);
+    return cdp;
+  });
+
+  get cdp(): FakeCdp {
+    const cdp = this.cdps.at(-1);
+    if (!cdp) {
+      throw new Error("No capture session attached");
+    }
+    return cdp;
+  }
+
+  currentUrl = "https://example.test/";
+  currentTitle = "Example";
+  frame = {};
+  title = vi.fn(async () => this.currentTitle);
+  url = () => this.currentUrl;
+  mainFrame = () => this.frame;
+  isClosed = () => false;
+  context = () => ({ newCDPSession: this.newCDPSession });
+
+  navigate(url: string): void {
+    this.currentUrl = url;
+    this.emit("framenavigated", this.frame);
+  }
+
+  paint(sessionId = 1): void {
+    this.cdps.at(-1)?.paint(sessionId);
+  }
+}
+
+async function flush(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+describe("browser screencast sessions", () => {
+  let page: FakePage;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    page = new FakePage();
+    mocks.getPage.mockReset().mockResolvedValue(page as unknown as Page);
+  });
+
+  afterEach(async () => {
+    await stopBrowserScreencasts();
+    vi.useRealTimers();
+  });
+
+  async function attach(params = screencastParams()): Promise<ScreencastViewer> {
+    const viewer = new ScreencastViewer();
+    attachBrowserScreencastViewer(params, viewer as unknown as WebSocket);
+    await flush();
+    return viewer;
+  }
+
+  it("shares one JPEG message across viewers, skips congestion, and ack-paces every frame", async () => {
+    const first = await attach();
+    const second = await attach();
+    expect(mocks.getPage).toHaveBeenCalledTimes(1);
+    expect(first.messages()).toEqual([
+      { type: "ready", targetId: "target-1", url: "https://example.test/", title: "Example" },
+    ]);
+    expect(page.cdp.send).toHaveBeenCalledWith("Page.startScreencast", {
+      format: "jpeg",
+      quality: 70,
+      maxWidth: 1280,
+      maxHeight: 1280,
+      everyNthFrame: 1,
+    });
+    page.paint(1);
+    expect(first.frames()).toHaveLength(1);
+    expect(first.frames()[0]).toBe(second.frames()[0]);
+    expect(
+      parseScreencastFrame(expectDefined(first.frames()[0], "first screencast frame")),
+    ).toEqual({
+      header: {
+        url: "https://example.test/",
+        cssWidth: 800,
+        cssHeight: 600,
+        scrollX: 12,
+        scrollY: 34,
+        ts: 123,
+      },
+      jpeg: Buffer.from([0xff, 0xd8, 0xff, 0xd9]),
+    });
+    await vi.advanceTimersByTimeAsync(49);
+    expect(
+      page.cdp.send.mock.calls.filter(([method]) => method === "Page.screencastFrameAck"),
+    ).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(1);
+    second.bufferedAmount = 2 * 1024 * 1024;
+    page.paint(2);
+    await vi.advanceTimersByTimeAsync(50);
+    first.bufferedAmount = 2 * 1024 * 1024;
+    page.paint(3);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(first.frames()).toHaveLength(2);
+    expect(second.frames()).toHaveLength(1);
+    expect(
+      page.cdp.send.mock.calls.filter(([method]) => method === "Page.screencastFrameAck"),
+    ).toEqual([
+      ["Page.screencastFrameAck", { sessionId: 1 }],
+      ["Page.screencastFrameAck", { sessionId: 2 }],
+      ["Page.screencastFrameAck", { sessionId: 3 }],
+    ]);
+  });
+
+  it("detaches without capturing or acking while policy is pending, and closes on rejection", async () => {
+    let reject!: (error: Error) => void;
+    const check = vi.fn(async (_url: string) => {});
+    const viewer = await attach(screencastParams({ checkNavigationAllowed: check }));
+    const retired = page.cdp;
+    page.paint(9);
+    viewer.send.mockClear();
+    check.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, fail) => {
+          reject = fail;
+        }),
+    );
+    page.navigate("https://blocked.test/");
+    expect(retired.detach).toHaveBeenCalledOnce();
+    expect(page.newCDPSession).toHaveBeenCalledTimes(1);
+    page.paint(10);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(viewer.frames()).toHaveLength(0);
+    expect(retired.send.mock.calls.map(([method]) => method)).toEqual(["Page.startScreencast"]);
+    reject(new Error("blocked"));
+    await flush();
+    page.paint(11);
+    expect(viewer.frames()).toHaveLength(0);
+    expect(viewer.close).toHaveBeenCalledWith(4003, "navigation_blocked");
+    expect(retired.detach).toHaveBeenCalledOnce();
+  });
+
+  it("never forwards delayed blocked-document pixels after a later allowed navigation", async () => {
+    let rejectBlocked!: (error: Error) => void;
+    let allowNext!: () => void;
+    const check = vi.fn(async (_url: string) => {});
+    const viewer = await attach(screencastParams({ checkNavigationAllowed: check }));
+    const retired = page.cdp;
+    page.paint(1);
+    await vi.advanceTimersByTimeAsync(50);
+    viewer.send.mockClear();
+    retired.send.mockClear();
+    check.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectBlocked = reject;
+        }),
+    );
+    page.navigate("https://blocked.test/");
+    expect.soft(retired.detach).toHaveBeenCalledOnce();
+    expect(page.newCDPSession).toHaveBeenCalledTimes(1);
+    retired.paint(10);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(viewer.frames()).toEqual([]);
+    expect.soft(retired.send).not.toHaveBeenCalled();
+
+    check.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          allowNext = resolve;
+        }),
+    );
+    page.navigate("https://example.test/next");
+    rejectBlocked(new Error("blocked"));
+    await flush();
+    expect(viewer.close).not.toHaveBeenCalled();
+    expect(page.newCDPSession).toHaveBeenCalledTimes(1);
+    allowNext();
+    await flush();
+    expect.soft(page.newCDPSession).toHaveBeenCalledTimes(2);
+
+    retired.paint(99, Buffer.from([0xff, 0xd8, 0x42, 0xff, 0xd9]));
+    expect(viewer.frames().map(parseScreencastFrame)).toEqual([]);
+    page.paint(100);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(viewer.frames().map(parseScreencastFrame)).toEqual([
+      {
+        header: {
+          url: "https://example.test/next",
+          cssWidth: 800,
+          cssHeight: 600,
+          scrollX: 12,
+          scrollY: 34,
+          ts: 123,
+        },
+        jpeg: Buffer.from([0xff, 0xd8, 0xff, 0xd9]),
+      },
+    ]);
+    expect(
+      page.cdp.send.mock.calls.filter(([method]) => method === "Page.screencastFrameAck"),
+    ).toEqual([["Page.screencastFrameAck", { sessionId: 100 }]]);
+    expect(viewer.close).not.toHaveBeenCalled();
+  });
+
+  it("checks the initial URL before ready or frames, and ignores stale navigation completions", async () => {
+    let initial!: () => void;
+    const check = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            initial = resolve;
+          }),
+      )
+      .mockResolvedValue(undefined);
+    const viewer = await attach(screencastParams({ checkNavigationAllowed: check }));
+    expect(page.newCDPSession).not.toHaveBeenCalled();
+    page.paint();
+    expect(viewer.send).not.toHaveBeenCalled();
+    page.currentTitle = "Next";
+    page.navigate("https://example.test/next");
+    await flush();
+    initial();
+    await flush();
+    page.paint(2);
+    expect(viewer.messages()).toEqual([
+      { type: "ready", targetId: "target-1", url: "https://example.test/next", title: "Next" },
+    ]);
+    expect(
+      parseScreencastFrame(expectDefined(viewer.frames()[0], "approved document frame")).header.url,
+    ).toBe("https://example.test/next");
+    page.currentTitle = "Loaded";
+    page.emit("load");
+    await flush();
+    expect(viewer.messages().at(-1)).toEqual({
+      type: "meta",
+      url: "https://example.test/next",
+      title: "Loaded",
+    });
+  });
+
+  it("does not leak a changed URL before Playwright's navigation event", async () => {
+    let allowed!: () => void;
+    const check = vi.fn(async (_url: string) => {});
+    const viewer = await attach(screencastParams({ checkNavigationAllowed: check }));
+    const retired = page.cdp;
+    check.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          allowed = resolve;
+        }),
+    );
+    page.currentUrl = "https://example.test/next";
+    page.paint();
+    expect(viewer.frames()).toHaveLength(0);
+    expect(retired.detach).toHaveBeenCalledOnce();
+    expect(page.newCDPSession).toHaveBeenCalledTimes(1);
+    allowed();
+    await flush();
+    page.paint(2);
+    expect(viewer.frames()).toHaveLength(1);
+  });
+
+  it.each(["page", "cdp", "lifecycle"])(
+    "closes viewers with target_closed when %s closes",
+    async (owner) => {
+      const lifecycle = new AbortController();
+      const viewer = await attach(screencastParams({ lifecycleSignal: lifecycle.signal }));
+      if (owner === "lifecycle") {
+        lifecycle.abort();
+      } else if (owner === "page") {
+        page.emit("close");
+      } else {
+        page.cdp.emit("close", page.cdp);
+      }
+      expect(viewer.close).toHaveBeenCalledWith(4004, "target_closed");
+      await flush();
+      expect(page.cdp.detach).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("stops only after the last viewer leaves and closes all viewers with 1012 on shutdown", async () => {
+    const first = await attach();
+    const second = await attach();
+    first.close();
+    await flush();
+    expect(page.cdp.detach).not.toHaveBeenCalled();
+    second.close();
+    await flush();
+    expect(page.cdp.detach).toHaveBeenCalledTimes(1);
+    const next = await attach();
+    const stopped = stopBrowserScreencasts();
+    expect(next.close).toHaveBeenCalledWith(1012, "gateway shutting down");
+    await stopped;
+  });
+
+  it("revalidates lifecycle after page acquisition and never attaches a stale token to a successor", async () => {
+    let resolvePage!: (page: Page) => void;
+    mocks.getPage.mockImplementationOnce(
+      () =>
+        new Promise<Page>((resolve) => {
+          resolvePage = resolve;
+        }),
+    );
+    const lifecycle = new AbortController();
+    const params = screencastParams({ lifecycleSignal: lifecycle.signal });
+    const pending = await attach(params);
+    lifecycle.abort();
+    resolvePage(page as unknown as Page);
+    await flush();
+    expect(pending.close).toHaveBeenCalledWith(4004, "target_closed");
+    expect(page.newCDPSession).not.toHaveBeenCalled();
+    const successor = await attach(screencastParams({ lifecycleGeneration: 1 }));
+    const stale = await attach(params);
+    expect(stale.close).toHaveBeenCalledWith(4004, "target_closed");
+    expect(successor.close).not.toHaveBeenCalled();
+  });
+
+  it("waits for predecessor teardown before starting a replacement on the same target", async () => {
+    const first = await attach();
+    let finishDetach!: () => void;
+    page.cdp.detach.mockImplementation(async () => {
+      await new Promise<void>((resolve) => {
+        finishDetach = resolve;
+      });
+    });
+    first.close();
+    await flush();
+    const successor = await attach();
+    expect(mocks.getPage).toHaveBeenCalledTimes(1);
+    expect(successor.send).not.toHaveBeenCalled();
+    finishDetach();
+    await flush();
+    expect(mocks.getPage).toHaveBeenCalledTimes(2);
+    expect(successor.messages()).toHaveLength(1);
+  });
+
+  it("does not send stale metadata after a title read crosses a navigation", async () => {
+    const viewer = await attach();
+    let finishTitle!: (title: string) => void;
+    page.title.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          finishTitle = resolve;
+        }),
+    );
+    page.emit("load");
+    page.currentTitle = "Next";
+    page.navigate("https://example.test/next");
+    await flush();
+    finishTitle("Old title");
+    await flush();
+    expect(viewer.messages()).toEqual([
+      { type: "ready", targetId: "target-1", url: "https://example.test/", title: "Example" },
+      { type: "meta", url: "https://example.test/next", title: "Next" },
+    ]);
+  });
+});

--- a/extensions/browser/src/browser/screencast/session.test.ts
+++ b/extensions/browser/src/browser/screencast/session.test.ts
@@ -122,6 +122,66 @@ describe("browser screencast sessions", () => {
     expect(viewer.close).toHaveBeenCalledOnce();
   });
 
+  it("fences frames immediately on requester invalidation before its close handshake finishes, preserving live viewers", async () => {
+    const requester = { invalidated: false, signal: new AbortController().signal };
+    const first = await attach(
+      screencastParams({
+        requesterSignal: requester.signal,
+        isRequesterCurrent: () => !requester.invalidated,
+      }),
+    );
+    const second = await attach(
+      screencastParams({
+        requesterSignal: new AbortController().signal,
+        isRequesterCurrent: () => true,
+      }),
+    );
+    page.paint(1);
+    expect(first.frames()).toHaveLength(1);
+    expect(second.frames()[0]).toBe(first.frames()[0]);
+    requester.invalidated = true;
+    page.paint(2);
+    page.paint(3);
+    expect(requester.signal.aborted).toBe(false);
+    expect(first.frames()).toHaveLength(1);
+    expect(first.close.mock.calls).toEqual([[4006, "authority_revoked"]]);
+    expect(getEventListeners(requester.signal, "abort")).toHaveLength(0);
+    expect(second.frames()).toHaveLength(3);
+    expect(second.close).not.toHaveBeenCalled();
+    expect(page.cdp.detach).not.toHaveBeenCalled();
+  });
+
+  it.each(["ready", "meta"])(
+    "fences %s after requester invalidation during the awaited title read without a socket close",
+    async (message) => {
+      const requester = { invalidated: false, signal: new AbortController().signal };
+      const params = screencastParams({
+        requesterSignal: requester.signal,
+        isRequesterCurrent: () => !requester.invalidated,
+      });
+      const viewer = new ScreencastViewer();
+      if (message === "meta") {
+        attachBrowserScreencastViewer(params, viewer as unknown as WebSocket);
+        await flush();
+        expect(viewer.messages()).toHaveLength(1);
+        viewer.send.mockClear();
+      }
+      page.title.mockImplementationOnce(async () => {
+        requester.invalidated = true;
+        return "Revoked title";
+      });
+      if (message === "ready") {
+        attachBrowserScreencastViewer(params, viewer as unknown as WebSocket);
+      } else {
+        page.emit("load");
+      }
+      await flush();
+      expect(requester.signal.aborted).toBe(false);
+      expect(viewer.send).not.toHaveBeenCalled();
+      expect(viewer.close.mock.calls).toEqual([[4006, "authority_revoked"]]);
+    },
+  );
+
   it("rejects a requester revoked before viewer attachment without starting capture", async () => {
     const viewer = await attach(screencastParams({ requesterSignal: AbortSignal.abort() }));
     expect(viewer.close).toHaveBeenCalledWith(4006, "authority_revoked");

--- a/extensions/browser/src/browser/screencast/session.ts
+++ b/extensions/browser/src/browser/screencast/session.ts
@@ -31,15 +31,22 @@ class BrowserScreencastSession {
     params.lifecycleSignal.addEventListener("abort", this.onTargetClosed, { once: true });
   }
 
-  addViewer(ws: WebSocket): void {
+  addViewer(ws: WebSocket, requesterSignal?: AbortSignal): void {
+    const onRequesterGone = () => ws.close(4006, "authority_revoked");
     this.viewers.add(ws);
     ws.once("close", () => {
+      requesterSignal?.removeEventListener("abort", onRequesterGone);
       this.viewers.delete(ws);
       this.readyViewers.delete(ws);
       if (this.viewers.size === 0) {
         void this.close();
       }
     });
+    requesterSignal?.addEventListener("abort", onRequesterGone, { once: true });
+    if (requesterSignal?.aborted) {
+      onRequesterGone();
+      return;
+    }
     this.sendReady();
   }
 
@@ -298,6 +305,10 @@ export function attachBrowserScreencastViewer(
   params: BrowserScreencastTokenParams,
   ws: WebSocket,
 ): void {
+  if (params.requesterSignal?.aborted) {
+    ws.close(4006, "authority_revoked");
+    return;
+  }
   try {
     params.lifecycleSignal.throwIfAborted();
     params.assertCurrent();
@@ -316,12 +327,12 @@ export function attachBrowserScreencastViewer(
     session = undefined;
   }
   if (session) {
-    session.addViewer(ws);
+    session.addViewer(ws, params.requesterSignal);
     return;
   }
   session = new BrowserScreencastSession(key, params);
   sessions.set(key, session);
-  session.addViewer(ws);
+  session.addViewer(ws, params.requesterSignal);
   const next = session;
   // Finish retiring the predecessor before attaching a replacement to the same page.
   void Promise.resolve(previousDrain).then(() => next.start());

--- a/extensions/browser/src/browser/screencast/session.ts
+++ b/extensions/browser/src/browser/screencast/session.ts
@@ -1,0 +1,336 @@
+import type { CDPSession, Frame, Page } from "playwright-core";
+import type { WebSocket } from "ws";
+import { getPwAiModule } from "../pw-ai-module.js";
+import { clearBrowserScreencastTokens, type BrowserScreencastTokenParams } from "./tokens.js";
+import { encodeBrowserScreencastFrame } from "./wire.js";
+
+const MAX_BUFFERED_BYTES = 2 * 1024 * 1024;
+const FRAME_INTERVAL_MS = 50;
+const sessions = new Map<string, BrowserScreencastSession>();
+
+type ScreencastFrame = Parameters<typeof encodeBrowserScreencastFrame>[1] & { sessionId: number };
+
+class BrowserScreencastSession {
+  readonly viewers = new Set<WebSocket>();
+  private readonly readyViewers = new Set<WebSocket>();
+  private readonly acknowledgements = new Set<ReturnType<typeof setTimeout>>();
+  private page?: Page;
+  private cdp?: CDPSession;
+  private frameListener?: (frame: ScreencastFrame) => void;
+  private captureDrain: Promise<void> = Promise.resolve();
+  closed = false;
+  private navigationEpoch = 0;
+  private checkedUrl?: string;
+  private metadata?: { url: string; title: string };
+  private stopPromise?: Promise<void>;
+
+  constructor(
+    readonly key: string,
+    readonly params: BrowserScreencastTokenParams,
+  ) {
+    params.lifecycleSignal.addEventListener("abort", this.onTargetClosed, { once: true });
+  }
+
+  addViewer(ws: WebSocket): void {
+    this.viewers.add(ws);
+    ws.once("close", () => {
+      this.viewers.delete(ws);
+      this.readyViewers.delete(ws);
+      if (this.viewers.size === 0) {
+        void this.close();
+      }
+    });
+    this.sendReady();
+  }
+
+  private isCurrent(): boolean {
+    if (this.closed) {
+      return false;
+    }
+    try {
+      this.params.lifecycleSignal.throwIfAborted();
+      this.params.assertCurrent();
+      return true;
+    } catch {
+      this.onTargetClosed();
+      return false;
+    }
+  }
+
+  async start(): Promise<void> {
+    try {
+      if (!this.isCurrent()) {
+        return;
+      }
+      const pw = await getPwAiModule();
+      if (!this.isCurrent()) {
+        return;
+      }
+      if (!pw) {
+        await this.close(4005, "unsupported");
+        return;
+      }
+      const page = await pw.getPageForTargetId({
+        cdpUrl: this.params.cdpUrl,
+        targetId: this.params.targetId,
+        ssrfPolicy: this.params.ssrfPolicy,
+      });
+      if (!this.isCurrent() || page.isClosed()) {
+        this.onTargetClosed();
+        return;
+      }
+      this.page = page;
+      page.on("close", this.onTargetClosed);
+      page.on("framenavigated", this.onNavigation);
+      page.on("load", this.onLoad);
+      await this.checkNavigation(page.url());
+    } catch {
+      await this.close(4004, "target_closed");
+    }
+  }
+
+  private readonly onTargetClosed = (): void => {
+    void this.close(4004, "target_closed");
+  };
+
+  private readonly onCdpClosed = (cdp: CDPSession): void => {
+    if (this.cdp === cdp) {
+      this.onTargetClosed();
+    }
+  };
+
+  private readonly onNavigation = (frame: Frame): void => {
+    if (frame === this.page?.mainFrame()) {
+      void this.checkNavigation(this.page.url());
+    }
+  };
+
+  private readonly onLoad = (): void => {
+    void this.updateMetadata(this.navigationEpoch);
+  };
+
+  private async checkNavigation(url: string): Promise<void> {
+    const retired = this.retireCapture();
+    const epoch = this.navigationEpoch;
+    try {
+      await this.params.checkNavigationAllowed(url);
+    } catch {
+      if (epoch === this.navigationEpoch) {
+        void this.close(4003, "navigation_blocked");
+      }
+      return;
+    }
+    const page = this.page;
+    const current = () => this.isCurrent() && epoch === this.navigationEpoch && page?.url() === url;
+    if (!page || !current()) {
+      return;
+    }
+    try {
+      await retired;
+      if (!current()) {
+        return;
+      }
+      const cdp = await page.context().newCDPSession(page);
+      if (!current()) {
+        await cdp.detach().catch(() => {});
+        return;
+      }
+      this.cdp = cdp;
+      this.frameListener = (frame) => this.onFrame(cdp, frame);
+      cdp.on("close", this.onCdpClosed);
+      cdp.on("Page.screencastFrame", this.frameListener);
+      this.checkedUrl = url;
+      await this.updateMetadata(epoch);
+      if (!current() || this.cdp !== cdp) {
+        return;
+      }
+      await cdp.send("Page.startScreencast", {
+        format: "jpeg",
+        quality: this.params.quality,
+        maxWidth: this.params.maxWidth,
+        maxHeight: this.params.maxHeight,
+        everyNthFrame: 1,
+      });
+    } catch {
+      if (current()) {
+        this.onTargetClosed();
+      }
+    }
+  }
+
+  private async updateMetadata(epoch: number): Promise<void> {
+    const page = this.page;
+    const url = this.checkedUrl;
+    if (!page || url === undefined || page.url() !== url) {
+      return;
+    }
+    const title = await page.title().catch(() => "");
+    if (!this.isCurrent() || epoch !== this.navigationEpoch || this.checkedUrl !== page.url()) {
+      return;
+    }
+    this.metadata = { url, title };
+    for (const ws of this.readyViewers) {
+      this.send(ws, JSON.stringify({ type: "meta", ...this.metadata }));
+    }
+    this.sendReady();
+  }
+
+  private sendReady(): void {
+    if (
+      !this.isCurrent() ||
+      !this.metadata ||
+      this.metadata.url !== this.checkedUrl ||
+      this.page?.url() !== this.checkedUrl
+    ) {
+      return;
+    }
+    for (const ws of this.viewers) {
+      if (!this.readyViewers.has(ws) && ws.readyState === 1) {
+        this.send(
+          ws,
+          JSON.stringify({ type: "ready", targetId: this.params.targetId, ...this.metadata }),
+        );
+        this.readyViewers.add(ws);
+      }
+    }
+  }
+
+  private send(ws: WebSocket, data: string | Buffer): void {
+    if (ws.readyState !== 1) {
+      return;
+    }
+    try {
+      ws.send(data, (error) => {
+        if (error) {
+          ws.terminate();
+        }
+      });
+    } catch {
+      ws.terminate();
+    }
+  }
+
+  private onFrame(cdp: CDPSession, frame: ScreencastFrame): void {
+    const page = this.page;
+    if (this.cdp !== cdp || !page || !this.isCurrent()) {
+      return;
+    }
+    const url = this.checkedUrl;
+    const pageUrl = page.url();
+    if (pageUrl !== url) {
+      void this.checkNavigation(pageUrl);
+      return;
+    }
+    if (url === undefined) {
+      return;
+    }
+    // Chrome retains one unacked frame; delayed acks bound work without a frame queue.
+    const timer = setTimeout(() => {
+      this.acknowledgements.delete(timer);
+      if (this.cdp !== cdp || !this.isCurrent()) {
+        return;
+      }
+      void cdp.send("Page.screencastFrameAck", { sessionId: frame.sessionId }).catch(() => {
+        if (this.cdp === cdp) {
+          this.onTargetClosed();
+        }
+      });
+    }, FRAME_INTERVAL_MS);
+    timer.unref();
+    this.acknowledgements.add(timer);
+    const wire = encodeBrowserScreencastFrame(url, frame);
+    for (const ws of this.readyViewers) {
+      if (ws.bufferedAmount < MAX_BUFFERED_BYTES) {
+        this.send(ws, wire);
+      }
+    }
+  }
+
+  close(code?: number, reason?: string): Promise<void> {
+    if (this.stopPromise) {
+      return this.stopPromise;
+    }
+    this.closed = true;
+    this.params.lifecycleSignal.removeEventListener("abort", this.onTargetClosed);
+    this.page?.off("close", this.onTargetClosed);
+    this.page?.off("framenavigated", this.onNavigation);
+    this.page?.off("load", this.onLoad);
+    const viewers = [...this.viewers];
+    this.viewers.clear();
+    this.readyViewers.clear();
+    // Publish the drain before closing sockets; their close callbacks may reenter.
+    this.stopPromise = this.retireCapture().finally(() => {
+      if (sessions.get(this.key) === this) {
+        sessions.delete(this.key);
+      }
+    });
+    for (const ws of viewers) {
+      ws.close(code, reason);
+    }
+    return this.stopPromise;
+  }
+
+  private retireCapture(): Promise<void> {
+    // Encoded frames belong to a CDP session, so revoke it before navigation checks yield.
+    this.checkedUrl = undefined;
+    this.navigationEpoch += 1;
+    const cdp = this.cdp;
+    this.cdp = undefined;
+    for (const timer of this.acknowledgements) {
+      clearTimeout(timer);
+    }
+    this.acknowledgements.clear();
+    if (cdp) {
+      cdp.off("close", this.onCdpClosed);
+      if (this.frameListener) {
+        cdp.off("Page.screencastFrame", this.frameListener);
+      }
+      this.captureDrain = Promise.all([this.captureDrain, cdp.detach().catch(() => {})]).then(
+        () => {},
+      );
+    }
+    this.frameListener = undefined;
+    return this.captureDrain;
+  }
+}
+
+export function attachBrowserScreencastViewer(
+  params: BrowserScreencastTokenParams,
+  ws: WebSocket,
+): void {
+  try {
+    params.lifecycleSignal.throwIfAborted();
+    params.assertCurrent();
+  } catch {
+    ws.close(4004, "target_closed");
+    return;
+  }
+  const key = `${params.profileName}:${params.targetId}`;
+  let session = sessions.get(key);
+  let previousDrain: Promise<void> | undefined;
+  if (
+    session &&
+    (session.closed || session.params.lifecycleGeneration !== params.lifecycleGeneration)
+  ) {
+    previousDrain = session.close(4004, "target_closed");
+    session = undefined;
+  }
+  if (session) {
+    session.addViewer(ws);
+    return;
+  }
+  session = new BrowserScreencastSession(key, params);
+  sessions.set(key, session);
+  session.addViewer(ws);
+  const next = session;
+  // Finish retiring the predecessor before attaching a replacement to the same page.
+  void Promise.resolve(previousDrain).then(() => next.start());
+}
+
+export function stopBrowserScreencasts(): Promise<void> {
+  clearBrowserScreencastTokens();
+  const drains = [...sessions.values()].map((session) =>
+    session.close(1012, "gateway shutting down"),
+  );
+  return Promise.allSettled(drains).then(() => {});
+}

--- a/extensions/browser/src/browser/screencast/session.ts
+++ b/extensions/browser/src/browser/screencast/session.ts
@@ -9,9 +9,10 @@ const FRAME_INTERVAL_MS = 50;
 const sessions = new Map<string, BrowserScreencastSession>();
 
 type ScreencastFrame = Parameters<typeof encodeBrowserScreencastFrame>[1] & { sessionId: number };
+type ViewerRequester = { signal?: AbortSignal; isCurrent?: () => boolean };
 
 class BrowserScreencastSession {
-  readonly viewers = new Set<WebSocket>();
+  readonly viewers = new Map<WebSocket, ViewerRequester>();
   private readonly readyViewers = new Set<WebSocket>();
   private readonly acknowledgements = new Set<ReturnType<typeof setTimeout>>();
   private page?: Page;
@@ -31,23 +32,34 @@ class BrowserScreencastSession {
     params.lifecycleSignal.addEventListener("abort", this.onTargetClosed, { once: true });
   }
 
-  addViewer(ws: WebSocket, requesterSignal?: AbortSignal): void {
+  addViewer(ws: WebSocket, requester: ViewerRequester): void {
     const onRequesterGone = () => ws.close(4006, "authority_revoked");
-    this.viewers.add(ws);
+    this.viewers.set(ws, requester);
     ws.once("close", () => {
-      requesterSignal?.removeEventListener("abort", onRequesterGone);
+      requester.signal?.removeEventListener("abort", onRequesterGone);
       this.viewers.delete(ws);
       this.readyViewers.delete(ws);
       if (this.viewers.size === 0) {
         void this.close();
       }
     });
-    requesterSignal?.addEventListener("abort", onRequesterGone, { once: true });
-    if (requesterSignal?.aborted) {
-      onRequesterGone();
+    requester.signal?.addEventListener("abort", onRequesterGone, { once: true });
+    if (!this.isViewerCurrent(ws)) {
       return;
     }
     this.sendReady();
+  }
+
+  private isViewerCurrent(ws: WebSocket): boolean {
+    const requester = this.viewers.get(ws);
+    if (!requester) {
+      return false;
+    }
+    if (requester.signal?.aborted || requester.isCurrent?.() === false) {
+      ws.close(4006, "authority_revoked");
+      return false;
+    }
+    return true;
   }
 
   private isCurrent(): boolean {
@@ -191,20 +203,25 @@ class BrowserScreencastSession {
     ) {
       return;
     }
-    for (const ws of this.viewers) {
-      if (!this.readyViewers.has(ws) && ws.readyState === 1) {
+    for (const ws of this.viewers.keys()) {
+      if (
+        !this.readyViewers.has(ws) &&
         this.send(
           ws,
           JSON.stringify({ type: "ready", targetId: this.params.targetId, ...this.metadata }),
-        );
+        )
+      ) {
         this.readyViewers.add(ws);
       }
     }
   }
 
-  private send(ws: WebSocket, data: string | Buffer): void {
-    if (ws.readyState !== 1) {
-      return;
+  private send(ws: WebSocket, data: string | Buffer): boolean {
+    if (!this.isViewerCurrent(ws) || ws.readyState !== 1) {
+      return false;
+    }
+    if (typeof data !== "string" && ws.bufferedAmount >= MAX_BUFFERED_BYTES) {
+      return false;
     }
     try {
       ws.send(data, (error) => {
@@ -212,8 +229,10 @@ class BrowserScreencastSession {
           ws.terminate();
         }
       });
+      return true;
     } catch {
       ws.terminate();
+      return false;
     }
   }
 
@@ -247,9 +266,7 @@ class BrowserScreencastSession {
     this.acknowledgements.add(timer);
     const wire = encodeBrowserScreencastFrame(url, frame);
     for (const ws of this.readyViewers) {
-      if (ws.bufferedAmount < MAX_BUFFERED_BYTES) {
-        this.send(ws, wire);
-      }
+      this.send(ws, wire);
     }
   }
 
@@ -262,7 +279,7 @@ class BrowserScreencastSession {
     this.page?.off("close", this.onTargetClosed);
     this.page?.off("framenavigated", this.onNavigation);
     this.page?.off("load", this.onLoad);
-    const viewers = [...this.viewers];
+    const viewers = [...this.viewers.keys()];
     this.viewers.clear();
     this.readyViewers.clear();
     // Publish the drain before closing sockets; their close callbacks may reenter.
@@ -305,7 +322,7 @@ export function attachBrowserScreencastViewer(
   params: BrowserScreencastTokenParams,
   ws: WebSocket,
 ): void {
-  if (params.requesterSignal?.aborted) {
+  if (params.requesterSignal?.aborted || params.isRequesterCurrent?.() === false) {
     ws.close(4006, "authority_revoked");
     return;
   }
@@ -317,6 +334,7 @@ export function attachBrowserScreencastViewer(
     return;
   }
   const key = `${params.profileName}:${params.targetId}`;
+  const requester = { signal: params.requesterSignal, isCurrent: params.isRequesterCurrent };
   let session = sessions.get(key);
   let previousDrain: Promise<void> | undefined;
   if (
@@ -327,12 +345,12 @@ export function attachBrowserScreencastViewer(
     session = undefined;
   }
   if (session) {
-    session.addViewer(ws, params.requesterSignal);
+    session.addViewer(ws, requester);
     return;
   }
   session = new BrowserScreencastSession(key, params);
   sessions.set(key, session);
-  session.addViewer(ws, params.requesterSignal);
+  session.addViewer(ws, requester);
   const next = session;
   // Finish retiring the predecessor before attaching a replacement to the same page.
   void Promise.resolve(previousDrain).then(() => next.start());

--- a/extensions/browser/src/browser/screencast/test-support.ts
+++ b/extensions/browser/src/browser/screencast/test-support.ts
@@ -1,0 +1,81 @@
+import { EventEmitter } from "node:events";
+import { vi } from "vitest";
+import type { BrowserScreencastTokenParams } from "./tokens.js";
+
+export function screencastParams(
+  overrides: Partial<BrowserScreencastTokenParams> = {},
+): BrowserScreencastTokenParams {
+  return {
+    profileName: "openclaw",
+    targetId: "target-1",
+    cdpUrl: "http://127.0.0.1:9222",
+    maxWidth: 1280,
+    maxHeight: 1280,
+    quality: 70,
+    lifecycleGeneration: 0,
+    lifecycleSignal: new AbortController().signal,
+    assertCurrent: () => {},
+    checkNavigationAllowed: async () => {},
+    ...overrides,
+  };
+}
+
+export class ScreencastViewer extends EventEmitter {
+  readyState = 1;
+  bufferedAmount = 0;
+  send = vi.fn<(data: string | Buffer, callback?: (error?: Error) => void) => void>(
+    (_data, callback) => callback?.(),
+  );
+  close = vi.fn((code?: number, reason?: string) => {
+    this.readyState = 3;
+    this.emit("close", code, reason);
+  });
+  terminate = vi.fn(() => this.close());
+
+  frames(): Buffer[] {
+    return this.send.mock.calls.flatMap(([data]) => (Buffer.isBuffer(data) ? [data] : []));
+  }
+
+  messages(): unknown[] {
+    return this.send.mock.calls.flatMap(([data]) =>
+      typeof data === "string" ? [JSON.parse(data)] : [],
+    );
+  }
+}
+
+export type ScreencastFrameHeader = {
+  url: string;
+  cssWidth: number;
+  cssHeight: number;
+  scrollX: number;
+  scrollY: number;
+  ts: number | undefined;
+};
+
+function readHeaderNumber(record: Record<string, unknown>, key: string): number {
+  const value = record[key];
+  if (typeof value !== "number") {
+    throw new Error(`screencast header ${key} is not a number`);
+  }
+  return value;
+}
+
+export function parseScreencastFrame(wire: Buffer): {
+  header: ScreencastFrameHeader;
+  jpeg: Buffer;
+} {
+  const length = wire.readUInt32BE(0);
+  const record: Record<string, unknown> = JSON.parse(wire.toString("utf8", 4, 4 + length));
+  const ts = record.ts;
+  return {
+    header: {
+      url: typeof record.url === "string" ? record.url : "",
+      cssWidth: readHeaderNumber(record, "cssWidth"),
+      cssHeight: readHeaderNumber(record, "cssHeight"),
+      scrollX: readHeaderNumber(record, "scrollX"),
+      scrollY: readHeaderNumber(record, "scrollY"),
+      ts: typeof ts === "number" ? ts : undefined,
+    },
+    jpeg: wire.subarray(4 + length),
+  };
+}

--- a/extensions/browser/src/browser/screencast/tokens.test.ts
+++ b/extensions/browser/src/browser/screencast/tokens.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { screencastParams } from "./test-support.js";
+import {
+  clearBrowserScreencastTokens,
+  consumeBrowserScreencastToken,
+  mintBrowserScreencastToken,
+} from "./tokens.js";
+
+afterEach(() => {
+  clearBrowserScreencastTokens();
+  vi.useRealTimers();
+});
+
+describe("browser screencast tokens", () => {
+  it("mints a 48-hex token that can only be consumed once", () => {
+    const params = screencastParams();
+    const token = mintBrowserScreencastToken(params);
+    expect(token.token).toMatch(/^[a-f0-9]{48}$/u);
+    expect(consumeBrowserScreencastToken(token.token)).toBe(params);
+    expect(consumeBrowserScreencastToken(token.token)).toBeUndefined();
+  });
+
+  it("expires at 60 seconds, including before the expiry timer runs", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const token = mintBrowserScreencastToken(screencastParams());
+    expect(token.expiresAtMs).toBe(61_000);
+    vi.setSystemTime(token.expiresAtMs);
+    expect(consumeBrowserScreencastToken(token.token)).toBeUndefined();
+    const timed = mintBrowserScreencastToken(screencastParams());
+    vi.advanceTimersByTime(60_000);
+    expect(consumeBrowserScreencastToken(timed.token)).toBeUndefined();
+  });
+
+  it.each(["", "a".repeat(47), "g".repeat(48), "A".repeat(48), "a".repeat(49)])(
+    "rejects malformed token %j",
+    (token) => {
+      expect(consumeBrowserScreencastToken(token)).toBeUndefined();
+    },
+  );
+});

--- a/extensions/browser/src/browser/screencast/tokens.test.ts
+++ b/extensions/browser/src/browser/screencast/tokens.test.ts
@@ -1,3 +1,4 @@
+import { getEventListeners } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { screencastParams } from "./test-support.js";
 import {
@@ -12,6 +13,34 @@ afterEach(() => {
 });
 
 describe("browser screencast tokens", () => {
+  it("revokes unconsumed tokens when their requester leaves", () => {
+    const requester = new AbortController();
+    const token = mintBrowserScreencastToken(
+      screencastParams({ requesterSignal: requester.signal }),
+    );
+    requester.abort();
+    expect(consumeBrowserScreencastToken(token.token)).toBeUndefined();
+    expect(getEventListeners(requester.signal, "abort")).toHaveLength(0);
+  });
+
+  it.each(["consume", "expire", "shutdown"])("releases the requester listener on %s", (end) => {
+    vi.useFakeTimers();
+    const requester = new AbortController();
+    const params = screencastParams({ requesterSignal: requester.signal });
+    const token = mintBrowserScreencastToken(params);
+    expect(getEventListeners(requester.signal, "abort")).toHaveLength(1);
+    if (end === "consume") {
+      expect(consumeBrowserScreencastToken(token.token)).toBe(params);
+    } else if (end === "expire") {
+      vi.advanceTimersByTime(60_000);
+    } else {
+      clearBrowserScreencastTokens();
+    }
+    expect(getEventListeners(requester.signal, "abort")).toHaveLength(0);
+    requester.abort();
+    expect(consumeBrowserScreencastToken(token.token)).toBeUndefined();
+  });
+
   it("mints a 48-hex token that can only be consumed once", () => {
     const params = screencastParams();
     const token = mintBrowserScreencastToken(params);

--- a/extensions/browser/src/browser/screencast/tokens.ts
+++ b/extensions/browser/src/browser/screencast/tokens.ts
@@ -11,6 +11,7 @@ export type BrowserScreencastTokenParams = {
   quality: number;
   lifecycleGeneration: number;
   lifecycleSignal: AbortSignal;
+  requesterSignal?: AbortSignal;
   assertCurrent: () => void;
   checkNavigationAllowed: (url: string) => Promise<void>;
 };
@@ -19,13 +20,19 @@ type TokenEntry = {
   params: BrowserScreencastTokenParams;
   expiresAtMs: number;
   expiryTimer: ReturnType<typeof setTimeout>;
+  onRequesterGone: () => void;
 };
 
 const TOKEN_TTL_MS = 60_000;
 const tokens = new Map<string, TokenEntry>();
 
 function deleteToken(token: string): void {
-  clearTimeout(tokens.get(token)?.expiryTimer);
+  const entry = tokens.get(token);
+  if (!entry) {
+    return;
+  }
+  clearTimeout(entry.expiryTimer);
+  entry.params.requesterSignal?.removeEventListener("abort", entry.onRequesterGone);
   tokens.delete(token);
 }
 
@@ -37,7 +44,12 @@ export function mintBrowserScreencastToken(params: BrowserScreencastTokenParams)
   const expiresAtMs = Date.now() + TOKEN_TTL_MS;
   const expiryTimer = setTimeout(() => deleteToken(token), TOKEN_TTL_MS);
   expiryTimer.unref();
-  tokens.set(token, { params, expiresAtMs, expiryTimer });
+  const onRequesterGone = () => deleteToken(token);
+  tokens.set(token, { params, expiresAtMs, expiryTimer, onRequesterGone });
+  params.requesterSignal?.addEventListener("abort", onRequesterGone, { once: true });
+  if (params.requesterSignal?.aborted) {
+    deleteToken(token);
+  }
   return { token, expiresAtMs };
 }
 

--- a/extensions/browser/src/browser/screencast/tokens.ts
+++ b/extensions/browser/src/browser/screencast/tokens.ts
@@ -1,0 +1,59 @@
+import crypto from "node:crypto";
+import type { SsrFPolicy } from "../../infra/net/ssrf.js";
+
+export type BrowserScreencastTokenParams = {
+  profileName: string;
+  targetId: string;
+  cdpUrl: string;
+  ssrfPolicy?: SsrFPolicy;
+  maxWidth: number;
+  maxHeight: number;
+  quality: number;
+  lifecycleGeneration: number;
+  lifecycleSignal: AbortSignal;
+  assertCurrent: () => void;
+  checkNavigationAllowed: (url: string) => Promise<void>;
+};
+
+type TokenEntry = {
+  params: BrowserScreencastTokenParams;
+  expiresAtMs: number;
+  expiryTimer: ReturnType<typeof setTimeout>;
+};
+
+const TOKEN_TTL_MS = 60_000;
+const tokens = new Map<string, TokenEntry>();
+
+function deleteToken(token: string): void {
+  clearTimeout(tokens.get(token)?.expiryTimer);
+  tokens.delete(token);
+}
+
+export function mintBrowserScreencastToken(params: BrowserScreencastTokenParams): {
+  token: string;
+  expiresAtMs: number;
+} {
+  const token = crypto.randomBytes(24).toString("hex");
+  const expiresAtMs = Date.now() + TOKEN_TTL_MS;
+  const expiryTimer = setTimeout(() => deleteToken(token), TOKEN_TTL_MS);
+  expiryTimer.unref();
+  tokens.set(token, { params, expiresAtMs, expiryTimer });
+  return { token, expiresAtMs };
+}
+
+export function consumeBrowserScreencastToken(
+  token: string,
+): BrowserScreencastTokenParams | undefined {
+  if (!/^[a-f0-9]{48}$/u.test(token)) {
+    return undefined;
+  }
+  const entry = tokens.get(token);
+  deleteToken(token);
+  return entry && entry.expiresAtMs > Date.now() ? entry.params : undefined;
+}
+
+export function clearBrowserScreencastTokens(): void {
+  for (const token of tokens.keys()) {
+    deleteToken(token);
+  }
+}

--- a/extensions/browser/src/browser/screencast/tokens.ts
+++ b/extensions/browser/src/browser/screencast/tokens.ts
@@ -12,6 +12,7 @@ export type BrowserScreencastTokenParams = {
   lifecycleGeneration: number;
   lifecycleSignal: AbortSignal;
   requesterSignal?: AbortSignal;
+  isRequesterCurrent?: () => boolean;
   assertCurrent: () => void;
   checkNavigationAllowed: (url: string) => Promise<void>;
 };
@@ -61,7 +62,12 @@ export function consumeBrowserScreencastToken(
   }
   const entry = tokens.get(token);
   deleteToken(token);
-  return entry && entry.expiresAtMs > Date.now() ? entry.params : undefined;
+  return entry &&
+    entry.expiresAtMs > Date.now() &&
+    !entry.params.requesterSignal?.aborted &&
+    entry.params.isRequesterCurrent?.() !== false
+    ? entry.params
+    : undefined;
 }
 
 export function clearBrowserScreencastTokens(): void {

--- a/extensions/browser/src/browser/screencast/upgrade.test.ts
+++ b/extensions/browser/src/browser/screencast/upgrade.test.ts
@@ -1,0 +1,91 @@
+import { once } from "node:events";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
+import { screencastParams } from "./test-support.js";
+import { clearBrowserScreencastTokens, mintBrowserScreencastToken } from "./tokens.js";
+import { handleBrowserScreencastUpgrade } from "./upgrade.js";
+
+const mocks = vi.hoisted(() => ({ attach: vi.fn() }));
+vi.mock("./session.js", () => ({ attachBrowserScreencastViewer: mocks.attach }));
+
+describe("browser screencast WebSocket upgrade", () => {
+  let server: Server;
+  let url: string;
+  let clients: WebSocket[];
+
+  beforeEach(async () => {
+    mocks.attach.mockReset();
+    clients = [];
+    server = createServer();
+    server.on("upgrade", (req, socket, head) => {
+      void handleBrowserScreencastUpgrade(req, socket, head);
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    url = `ws://127.0.0.1:${(server.address() as AddressInfo).port}/browser/screencast`;
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    for (const client of clients) {
+      client.terminate();
+    }
+    for (const [, viewer] of mocks.attach.mock.calls) {
+      (viewer as WebSocket).terminate();
+    }
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+    clearBrowserScreencastTokens();
+  });
+
+  function connect(token: string, autoPong = true): WebSocket {
+    const ws = new WebSocket(`${url}?token=${token}`, { autoPong });
+    clients.push(ws);
+    return ws;
+  }
+
+  async function rejected(token: string): Promise<number | undefined> {
+    const ws = connect(token);
+    return await new Promise((resolve) => {
+      ws.once("unexpected-response", (_request, response) => {
+        response.resume();
+        ws.on("error", () => {});
+        ws.terminate();
+        resolve(response.statusCode);
+      });
+    });
+  }
+
+  it("accepts a minted token once and rejects invalid or reused tokens with HTTP 401", async () => {
+    expect(await rejected("invalid")).toBe(401);
+    const params = screencastParams();
+    const token = mintBrowserScreencastToken(params).token;
+    const ws = connect(token);
+    await once(ws, "open");
+    expect(mocks.attach).toHaveBeenCalledWith(params, expect.any(WebSocket));
+    expect(await rejected(token)).toBe(401);
+  });
+
+  it("rejects binary input on the view-only socket", async () => {
+    const ws = connect(mintBrowserScreencastToken(screencastParams()).token);
+    await once(ws, "open");
+    const closed = once(ws, "close");
+    ws.send(Buffer.from([1]));
+    expect(await closed).toEqual([1003, Buffer.from("view_only")]);
+  });
+
+  it("pings viewers and terminates a missed pong", async () => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    const ws = connect(mintBrowserScreencastToken(screencastParams()).token, false);
+    await once(ws, "open");
+    const ping = once(ws, "ping");
+    await vi.advanceTimersByTimeAsync(25_000);
+    await ping;
+    const closed = once(ws, "close");
+    await vi.advanceTimersByTimeAsync(25_000);
+    expect(await closed).toEqual([1006, Buffer.alloc(0)]);
+  });
+});

--- a/extensions/browser/src/browser/screencast/upgrade.test.ts
+++ b/extensions/browser/src/browser/screencast/upgrade.test.ts
@@ -87,6 +87,22 @@ describe("browser screencast WebSocket upgrade", () => {
     expect(mocks.attach).not.toHaveBeenCalled();
   });
 
+  it("rejects and consumes a minted ticket after requester invalidation before its close handshake finishes", async () => {
+    const requester = { invalidated: false, signal: new AbortController().signal };
+    const token = mintBrowserScreencastToken(
+      screencastParams({
+        requesterSignal: requester.signal,
+        isRequesterCurrent: () => !requester.invalidated,
+      }),
+    );
+    requester.invalidated = true;
+    expect(requester.signal.aborted).toBe(false);
+    expect(await rejected(token.token)).toBe(401);
+    requester.invalidated = false;
+    expect(await rejected(token.token)).toBe(401);
+    expect(mocks.attach).not.toHaveBeenCalled();
+  });
+
   it("rejects binary input on the view-only socket", async () => {
     const ws = connect(mintBrowserScreencastToken(screencastParams()).token);
     await once(ws, "open");

--- a/extensions/browser/src/browser/screencast/upgrade.test.ts
+++ b/extensions/browser/src/browser/screencast/upgrade.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
 import { screencastParams } from "./test-support.js";
 import { clearBrowserScreencastTokens, mintBrowserScreencastToken } from "./tokens.js";
+import * as tokens from "./tokens.js";
 import { handleBrowserScreencastUpgrade } from "./upgrade.js";
 
 const mocks = vi.hoisted(() => ({ attach: vi.fn() }));
@@ -28,6 +29,7 @@ describe("browser screencast WebSocket upgrade", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
     for (const client of clients) {
       client.terminate();
@@ -50,6 +52,7 @@ describe("browser screencast WebSocket upgrade", () => {
   async function rejected(token: string): Promise<number | undefined> {
     const ws = connect(token);
     return await new Promise((resolve) => {
+      ws.once("open", () => resolve(undefined));
       ws.once("unexpected-response", (_request, response) => {
         response.resume();
         ws.on("error", () => {});
@@ -67,6 +70,21 @@ describe("browser screencast WebSocket upgrade", () => {
     await once(ws, "open");
     expect(mocks.attach).toHaveBeenCalledWith(params, expect.any(WebSocket));
     expect(await rejected(token)).toBe(401);
+  });
+
+  it("rejects a fresh token whose requester aborts during consumption", async () => {
+    const requester = new AbortController();
+    const token = mintBrowserScreencastToken(
+      screencastParams({ requesterSignal: requester.signal }),
+    );
+    const consume = tokens.consumeBrowserScreencastToken;
+    vi.spyOn(tokens, "consumeBrowserScreencastToken").mockImplementationOnce((value) => {
+      const params = consume(value);
+      requester.abort();
+      return params;
+    });
+    expect(await rejected(token.token)).toBe(401);
+    expect(mocks.attach).not.toHaveBeenCalled();
   });
 
   it("rejects binary input on the view-only socket", async () => {

--- a/extensions/browser/src/browser/screencast/upgrade.ts
+++ b/extensions/browser/src/browser/screencast/upgrade.ts
@@ -1,0 +1,51 @@
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import { WebSocketServer } from "ws";
+import { attachBrowserScreencastViewer } from "./session.js";
+import { consumeBrowserScreencastToken } from "./tokens.js";
+
+const wss = new WebSocketServer({ noServer: true, maxPayload: 16 * 1024 });
+
+export async function handleBrowserScreencastUpgrade(
+  req: IncomingMessage,
+  socket: Duplex,
+  head: Buffer,
+): Promise<boolean> {
+  const url = new URL(req.url ?? "/", "http://127.0.0.1");
+  if (url.pathname !== "/browser/screencast") {
+    return false;
+  }
+  const params = consumeBrowserScreencastToken(url.searchParams.get("token") ?? "");
+  if (!params) {
+    try {
+      socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+    } finally {
+      socket.destroy();
+    }
+    return true;
+  }
+  wss.handleUpgrade(req, socket, head, (ws) => {
+    let alive = true;
+    ws.on("pong", () => {
+      alive = true;
+    });
+    const pingTimer = setInterval(() => {
+      if (!alive) {
+        ws.terminate();
+        return;
+      }
+      alive = false;
+      ws.ping();
+    }, 25_000);
+    pingTimer.unref();
+    ws.once("close", () => clearInterval(pingTimer));
+    ws.on("error", () => ws.terminate());
+    ws.on("message", (_data, binary) => {
+      if (binary) {
+        ws.close(1003, "view_only");
+      }
+    });
+    attachBrowserScreencastViewer(params, ws);
+  });
+  return true;
+}

--- a/extensions/browser/src/browser/screencast/upgrade.ts
+++ b/extensions/browser/src/browser/screencast/upgrade.ts
@@ -16,7 +16,7 @@ export async function handleBrowserScreencastUpgrade(
     return false;
   }
   const params = consumeBrowserScreencastToken(url.searchParams.get("token") ?? "");
-  if (!params || params.requesterSignal?.aborted) {
+  if (!params || params.requesterSignal?.aborted || params.isRequesterCurrent?.() === false) {
     try {
       socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
     } finally {

--- a/extensions/browser/src/browser/screencast/upgrade.ts
+++ b/extensions/browser/src/browser/screencast/upgrade.ts
@@ -16,7 +16,7 @@ export async function handleBrowserScreencastUpgrade(
     return false;
   }
   const params = consumeBrowserScreencastToken(url.searchParams.get("token") ?? "");
-  if (!params) {
+  if (!params || params.requesterSignal?.aborted) {
     try {
       socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
     } finally {

--- a/extensions/browser/src/browser/screencast/wire.ts
+++ b/extensions/browser/src/browser/screencast/wire.ts
@@ -1,0 +1,30 @@
+type ScreencastFrame = {
+  data: string;
+  metadata: {
+    deviceWidth: number;
+    deviceHeight: number;
+    scrollOffsetX: number;
+    scrollOffsetY: number;
+    timestamp?: number;
+  };
+};
+
+export function encodeBrowserScreencastFrame(url: string, frame: ScreencastFrame): Buffer {
+  const header = Buffer.from(
+    JSON.stringify({
+      url,
+      cssWidth: frame.metadata.deviceWidth,
+      cssHeight: frame.metadata.deviceHeight,
+      scrollX: frame.metadata.scrollOffsetX,
+      scrollY: frame.metadata.scrollOffsetY,
+      ts: frame.metadata.timestamp,
+    }),
+    "utf8",
+  );
+  const jpeg = Buffer.from(frame.data, "base64");
+  const wire = Buffer.allocUnsafe(4 + header.length + jpeg.length);
+  wire.writeUInt32BE(header.length, 0);
+  header.copy(wire, 4);
+  jpeg.copy(wire, 4 + header.length);
+  return wire;
+}

--- a/extensions/browser/src/control-service.ts
+++ b/extensions/browser/src/control-service.ts
@@ -97,6 +97,8 @@ export async function stopBrowserControlService(): Promise<void> {
     const { disposeGatewayExtensionRelay } =
       await import("./browser/extension-relay/gateway-relay-route.js");
     disposeGatewayExtensionRelay();
+    const { stopBrowserScreencasts } = await import("./browser/screencast/session.js");
+    await stopBrowserScreencasts();
   }
 }
 

--- a/extensions/browser/src/gateway/browser-request.profile-from-body.test.ts
+++ b/extensions/browser/src/gateway/browser-request.profile-from-body.test.ts
@@ -176,8 +176,9 @@ describe("browser.request profile selection", () => {
     };
   }
 
-  it("keeps dispatched requester authority bound to the Gateway connection after the request", async () => {
+  it("invalidates dispatched requester authority immediately before the Gateway close handshake finishes", async () => {
     const connection = new AbortController();
+    const client = requesterClient(connection.signal);
     startBrowserControlServiceFromConfigMock.mockResolvedValueOnce(true);
     dispatchBrowserRouteMock.mockResolvedValueOnce({ status: 200, body: {} });
     await runBrowserRequest(
@@ -185,18 +186,25 @@ describe("browser.request profile selection", () => {
       undefined,
       [],
       {
-        client: requesterClient(connection.signal),
+        client,
       },
     );
     const dispatched = dispatchBrowserRouteMock.mock.calls[0]?.[0];
-    expect(dispatched.requester).toEqual({ connId: "requester-1", signal: connection.signal });
+    expect(dispatched.requester).toMatchObject({
+      connId: "requester-1",
+      signal: connection.signal,
+    });
+    expect(dispatched.requester.signal.aborted).toBe(false);
+    expect(dispatched.requester.isCurrent()).toBe(true);
+    client.invalidated = true;
+    expect(dispatched.requester.isCurrent()).toBe(false);
     expect(dispatched.requester.signal.aborted).toBe(false);
     connection.abort();
     expect(dispatched.requester.signal.aborted).toBe(true);
   });
 
   it.each(["connection closed", "authority revoked"])(
-    "dispatches an aborted requester when %s",
+    "dispatches a requester without current authority when %s",
     async (reason) => {
       const connection = new AbortController();
       if (reason === "connection closed") {
@@ -213,7 +221,9 @@ describe("browser.request profile selection", () => {
           hasCurrentClientAuthority: () => reason !== "authority revoked",
         },
       );
-      expect(dispatchBrowserRouteMock.mock.calls[0]?.[0].requester.signal.aborted).toBe(true);
+      const requester = dispatchBrowserRouteMock.mock.calls[0]?.[0].requester;
+      expect(requester.signal).toBe(connection.signal);
+      expect(requester.isCurrent()).toBe(false);
     },
   );
 

--- a/extensions/browser/src/gateway/browser-request.profile-from-body.test.ts
+++ b/extensions/browser/src/gateway/browser-request.profile-from-body.test.ts
@@ -1,6 +1,7 @@
 // Browser tests cover browser request.profile from body plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayRequestHandlers } from "../core-api.js";
 
 const {
   loadConfigMock,
@@ -107,6 +108,9 @@ async function runBrowserRequest(
   params: Record<string, unknown>,
   invokeResult?: unknown,
   connectedNodes?: TestNode[],
+  requester: Partial<
+    Pick<Parameters<GatewayRequestHandlers[string]>[0], "client" | "hasCurrentClientAuthority">
+  > = {},
 ) {
   const respond = vi.fn();
   const nodeRegistry = createContext(invokeResult, connectedNodes);
@@ -120,6 +124,7 @@ async function runBrowserRequest(
     client: null,
     req: { type: "req", id: "req-1", method: "browser.request" },
     isWebchatConnect: () => false,
+    ...requester,
   });
   return { respond, nodeRegistry };
 }
@@ -156,6 +161,61 @@ describe("browser.request profile selection", () => {
       .mockReset()
       .mockImplementation(async ({ body }: { body: unknown }) => ({ body }));
   });
+
+  function requesterClient(
+    connectionSignal: AbortSignal,
+  ): NonNullable<Parameters<GatewayRequestHandlers[string]>[0]["client"]> {
+    return {
+      connId: "requester-1",
+      connectionSignal,
+      connect: {
+        minProtocol: 3,
+        maxProtocol: 3,
+        client: { id: "test", version: "1", platform: "test", mode: "test" },
+      },
+    };
+  }
+
+  it("keeps dispatched requester authority bound to the Gateway connection after the request", async () => {
+    const connection = new AbortController();
+    startBrowserControlServiceFromConfigMock.mockResolvedValueOnce(true);
+    dispatchBrowserRouteMock.mockResolvedValueOnce({ status: 200, body: {} });
+    await runBrowserRequest(
+      { method: "POST", path: "/screencast", target: "host" },
+      undefined,
+      [],
+      {
+        client: requesterClient(connection.signal),
+      },
+    );
+    const dispatched = dispatchBrowserRouteMock.mock.calls[0]?.[0];
+    expect(dispatched.requester).toEqual({ connId: "requester-1", signal: connection.signal });
+    expect(dispatched.requester.signal.aborted).toBe(false);
+    connection.abort();
+    expect(dispatched.requester.signal.aborted).toBe(true);
+  });
+
+  it.each(["connection closed", "authority revoked"])(
+    "dispatches an aborted requester when %s",
+    async (reason) => {
+      const connection = new AbortController();
+      if (reason === "connection closed") {
+        connection.abort();
+      }
+      startBrowserControlServiceFromConfigMock.mockResolvedValueOnce(true);
+      dispatchBrowserRouteMock.mockResolvedValueOnce({ status: 200, body: {} });
+      await runBrowserRequest(
+        { method: "POST", path: "/screencast", target: "host", timeoutMs: 1000 },
+        undefined,
+        [],
+        {
+          client: requesterClient(connection.signal),
+          hasCurrentClientAuthority: () => reason !== "authority revoked",
+        },
+      );
+      expect(dispatchBrowserRouteMock.mock.calls[0]?.[0].requester.signal.aborted).toBe(true);
+    },
+  );
 
   it.each([undefined, "node"] as const)(
     "rejects screencast on the %s node route before invoking the node",

--- a/extensions/browser/src/gateway/browser-request.profile-from-body.test.ts
+++ b/extensions/browser/src/gateway/browser-request.profile-from-body.test.ts
@@ -157,6 +157,31 @@ describe("browser.request profile selection", () => {
       .mockImplementation(async ({ body }: { body: unknown }) => ({ body }));
   });
 
+  it.each([undefined, "node"] as const)(
+    "rejects screencast on the %s node route before invoking the node",
+    async (target) => {
+      const { respond, nodeRegistry } = await runBrowserRequest({
+        method: "POST",
+        path: "/screencast",
+        target,
+        ...(target === "node" ? { node: "node-1" } : {}),
+      });
+
+      expect(firstRespondCall(respond)).toEqual([
+        false,
+        undefined,
+        {
+          code: "INVALID_REQUEST",
+          message: "browser screencast is not available over a node proxy",
+          details: { code: "SCREENCAST_UNSUPPORTED", reason: "node" },
+        },
+      ]);
+      expect(nodeRegistry.invoke).not.toHaveBeenCalled();
+      expect(uploadMocks.prepareBrowserProxyUploadRequest).not.toHaveBeenCalled();
+      expect(startBrowserControlServiceFromConfigMock).not.toHaveBeenCalled();
+    },
+  );
+
   it.each([undefined, "host", "node"] as const)(
     "dispatches the requested %s execution host while preserving the profile",
     async (target) => {

--- a/extensions/browser/src/gateway/browser-request.ts
+++ b/extensions/browser/src/gateway/browser-request.ts
@@ -134,6 +134,19 @@ export async function handleBrowserGatewayRequest({
     }
   }
 
+  if (nodeTarget && path === "/screencast") {
+    respond(
+      false,
+      undefined,
+      errorShape(
+        ErrorCodes.INVALID_REQUEST,
+        "browser screencast is not available over a node proxy",
+        { details: { code: "SCREENCAST_UNSUPPORTED", reason: "node" } },
+      ),
+    );
+    return;
+  }
+
   if (nodeTarget && isPersistentBrowserProfileMutation(methodRaw, path)) {
     respond(
       false,

--- a/extensions/browser/src/gateway/browser-request.ts
+++ b/extensions/browser/src/gateway/browser-request.ts
@@ -60,6 +60,8 @@ export async function handleBrowserGatewayRequest({
   params,
   respond,
   context,
+  client,
+  hasCurrentClientAuthority,
 }: Parameters<GatewayRequestHandlers["browser.request"]>[0]) {
   const typed = params as BrowserRequestParams;
   const methodRaw = (normalizeOptionalString(typed.method) ?? "").toUpperCase();
@@ -289,6 +291,11 @@ export async function handleBrowserGatewayRequest({
     return;
   }
 
+  const requesterSignal =
+    hasCurrentClientAuthority?.() === false ? AbortSignal.abort() : client?.connectionSignal;
+  const requester = requesterSignal
+    ? { connId: client?.connId, signal: requesterSignal }
+    : undefined;
   let result;
   try {
     result = timeoutMs
@@ -300,6 +307,7 @@ export async function handleBrowserGatewayRequest({
               query,
               body,
               signal,
+              ...(requester ? { requester } : {}),
             }),
           timeoutMs,
           "browser request",
@@ -309,6 +317,7 @@ export async function handleBrowserGatewayRequest({
           path,
           query,
           body,
+          ...(requester ? { requester } : {}),
         });
   } catch (err) {
     respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));

--- a/extensions/browser/src/gateway/browser-request.ts
+++ b/extensions/browser/src/gateway/browser-request.ts
@@ -291,11 +291,19 @@ export async function handleBrowserGatewayRequest({
     return;
   }
 
-  const requesterSignal =
-    hasCurrentClientAuthority?.() === false ? AbortSignal.abort() : client?.connectionSignal;
-  const requester = requesterSignal
-    ? { connId: client?.connId, signal: requesterSignal }
-    : undefined;
+  // Invalidation precedes the socket's close event; retain live authority separately.
+  const requesterSignal = client?.connectionSignal;
+  const requester =
+    client && requesterSignal
+      ? {
+          connId: client.connId,
+          signal: requesterSignal,
+          isCurrent: () =>
+            client.invalidated !== true &&
+            !requesterSignal.aborted &&
+            hasCurrentClientAuthority?.() !== false,
+        }
+      : undefined;
   let result;
   try {
     result = timeoutMs

--- a/ui/src/components/browser/browser-client.test.ts
+++ b/ui/src/components/browser/browser-client.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { GatewayRequestError } from "../../api/gateway.ts";
 import { i18n } from "../../i18n/index.ts";
-import { fetchBrowserScreenshotDataUrl } from "./browser-client.ts";
+import {
+  fetchBrowserScreenshotDataUrl,
+  requestBrowserScreencast,
+  isBrowserScreencastUnsupportedError,
+} from "./browser-client.ts";
 
 afterEach(async () => {
   vi.useRealTimers();
@@ -196,5 +201,42 @@ describe("fetchBrowserScreenshotDataUrl", () => {
         path: "/tmp/missing.png",
       }),
     ).rejects.toThrow("Falha ao buscar captura de tela (503).");
+  });
+});
+
+describe("browser screencast requests", () => {
+  it("mints an HTTP-shaped request with the requested target and size", async () => {
+    const response = {
+      token: "token",
+      wsPath: "/browser/screencast?token=token",
+      targetId: "raw-a",
+      url: "https://example.test",
+    };
+    const request = vi.fn().mockResolvedValue(response);
+    await expect(
+      requestBrowserScreencast({ request }, { targetId: "tab-a", maxWidth: 1280, maxHeight: 1600 }),
+    ).resolves.toEqual(response);
+    expect(request).toHaveBeenCalledWith("browser.request", {
+      method: "POST",
+      path: "/screencast",
+      body: { targetId: "tab-a", maxWidth: 1280, maxHeight: 1600 },
+    });
+  });
+
+  it.each([
+    [
+      new GatewayRequestError({
+        code: "INVALID_REQUEST",
+        message: "Unsupported",
+        details: { code: "SCREENCAST_UNSUPPORTED", reason: "node" },
+      }),
+      true,
+    ],
+    [{ body: { code: "SCREENCAST_UNSUPPORTED" } }, true],
+    [{ details: { body: { code: "SCREENCAST_UNSUPPORTED" } } }, true],
+    [new Error("SCREENCAST_UNSUPPORTED"), false],
+    [{ details: { code: "OTHER" } }, false],
+  ])("recognizes structured unsupported failures (%s)", (error, expected) => {
+    expect(isBrowserScreencastUnsupportedError(error)).toBe(expected);
   });
 });

--- a/ui/src/components/browser/browser-client.test.ts
+++ b/ui/src/components/browser/browser-client.test.ts
@@ -205,6 +205,33 @@ describe("fetchBrowserScreenshotDataUrl", () => {
 });
 
 describe("browser screencast requests", () => {
+  it.each([
+    null,
+    {},
+    { token: "", wsPath: "/browser/screencast" },
+    { token: 123, wsPath: "/browser/screencast" },
+    { token: "token" },
+    { token: "token", wsPath: "" },
+    { token: "token", wsPath: 123 },
+  ])("rejects a malformed mint response (%j)", async (response) => {
+    await expect(
+      requestBrowserScreencast(
+        { request: vi.fn().mockResolvedValue(response) },
+        { targetId: "tab-a", maxWidth: 1280, maxHeight: 1600 },
+      ),
+    ).rejects.toThrow("browser screencast response is malformed");
+  });
+
+  it("normalizes absent or invalid optional metadata to empty strings", async () => {
+    const response = { token: "token", wsPath: "/browser/screencast?token=token", url: 123 };
+    await expect(
+      requestBrowserScreencast(
+        { request: vi.fn().mockResolvedValue(response) },
+        { targetId: "tab-a", maxWidth: 1280, maxHeight: 1600 },
+      ),
+    ).resolves.toEqual({ ...response, targetId: "", url: "" });
+  });
+
   it("mints an HTTP-shaped request with the requested target and size", async () => {
     const response = {
       token: "token",

--- a/ui/src/components/browser/browser-client.ts
+++ b/ui/src/components/browser/browser-client.ts
@@ -168,6 +168,24 @@ export async function navigateBrowser(
   };
 }
 
+export async function requestBrowserScreencast(
+  client: BrowserRequestClient,
+  params: { targetId: string; maxWidth: number; maxHeight: number },
+): Promise<{ token: string; wsPath: string; targetId: string; url: string }> {
+  return await browserRequest(client, { method: "POST", path: "/screencast", body: params });
+}
+
+export function isBrowserScreencastUnsupportedError(error: unknown): boolean {
+  const record = asRecord(error);
+  const details =
+    error instanceof GatewayRequestError ? asRecord(error.details) : asRecord(record?.details);
+  return (
+    details?.code === "SCREENCAST_UNSUPPORTED" ||
+    asRecord(details?.body)?.code === "SCREENCAST_UNSUPPORTED" ||
+    asRecord(record?.body)?.code === "SCREENCAST_UNSUPPORTED"
+  );
+}
+
 export async function captureBrowserScreenshot(
   client: BrowserRequestClient,
   targetId: string,

--- a/ui/src/components/browser/browser-client.ts
+++ b/ui/src/components/browser/browser-client.ts
@@ -172,7 +172,20 @@ export async function requestBrowserScreencast(
   client: BrowserRequestClient,
   params: { targetId: string; maxWidth: number; maxHeight: number },
 ): Promise<{ token: string; wsPath: string; targetId: string; url: string }> {
-  return await browserRequest(client, { method: "POST", path: "/screencast", body: params });
+  const result = asRecord(
+    await browserRequest(client, { method: "POST", path: "/screencast", body: params }),
+  );
+  const token = stringOrEmpty(result?.token);
+  const wsPath = stringOrEmpty(result?.wsPath);
+  if (!token || !wsPath) {
+    throw new Error("browser screencast response is malformed");
+  }
+  return {
+    token,
+    wsPath,
+    targetId: stringOrEmpty(result?.targetId),
+    url: stringOrEmpty(result?.url),
+  };
 }
 
 export function isBrowserScreencastUnsupportedError(error: unknown): boolean {

--- a/ui/src/components/browser/browser-panel-controller-input.test.ts
+++ b/ui/src/components/browser/browser-panel-controller-input.test.ts
@@ -891,6 +891,8 @@ describe("BrowserPanelController capture and input ownership", () => {
     const oldCapture = createDeferred<unknown>();
     const freshCapture = createDeferred<unknown>();
     const captures = [oldCapture, freshCapture];
+    const oldStarted = createDeferred();
+    const freshStarted = createDeferred();
     const url = "https://example.test/page";
     const { client, request } = createBrowserClient(async (envelope) => {
       if (envelope.path === "/tabs") {
@@ -904,6 +906,7 @@ describe("BrowserPanelController capture and input ownership", () => {
         if (!capture) {
           throw new Error("Unexpected screenshot capture");
         }
+        (capture === oldCapture ? oldStarted : freshStarted).resolve();
         return await capture.promise;
       }
       if (envelope.path === "/act") {
@@ -916,8 +919,9 @@ describe("BrowserPanelController capture and input ownership", () => {
     controller.activeTargetId = "tab-a";
 
     const oldRefresh = controller.refreshAll();
+    await oldStarted.promise;
     const freshRefresh = controller.refreshAll();
-    await flushBrowserResponses();
+    await freshStarted.promise;
     expect(
       request.mock.calls.filter(([, envelope]) => {
         return (envelope as BrowserRequestEnvelope).path === "/screenshot";

--- a/ui/src/components/browser/browser-panel-controller-test-support.ts
+++ b/ui/src/components/browser/browser-panel-controller-test-support.ts
@@ -1,6 +1,6 @@
 import type { ReactiveController } from "lit";
 import { afterEach, vi } from "vitest";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { BrowserInspectedNode } from "./browser-client.ts";
 import {
   BrowserPanelController,
@@ -29,14 +29,29 @@ export function setupBrowserPanelTestCleanup(): void {
 
 export function createBrowserClient(
   handleRequest: (envelope: BrowserRequestEnvelope) => Promise<unknown>,
+  options: { screencast?: boolean } = {},
 ) {
   const request = vi.fn(async (method: string, params?: unknown) => {
     if (method !== "browser.request") {
       throw new Error(`Unexpected Gateway method: ${method}`);
     }
-    return await handleRequest(params as BrowserRequestEnvelope);
+    const envelope = params as BrowserRequestEnvelope;
+    if (envelope.path === "/screencast" && !options.screencast) {
+      throw new GatewayRequestError({
+        code: "INVALID_REQUEST",
+        message: "Screencast unavailable",
+        details: { code: "SCREENCAST_UNSUPPORTED", reason: "playwright" },
+      });
+    }
+    return await handleRequest(envelope);
   });
-  return { client: { request } as unknown as GatewayBrowserClient, request };
+  return {
+    client: {
+      request,
+      gatewayUrl: "https://gateway.example.test",
+    } as unknown as GatewayBrowserClient,
+    request,
+  };
 }
 
 export function createBrowserPanelTestTab(id: string, url: string, title: string) {

--- a/ui/src/components/browser/browser-panel-controller.test.ts
+++ b/ui/src/components/browser/browser-panel-controller.test.ts
@@ -60,6 +60,7 @@ describe("BrowserPanelController tab and lifecycle ownership", () => {
     async (completion) => {
       stubScreenshotMedia();
       const previousCapture = createDeferred<unknown>();
+      const captureStarted = createDeferred();
       const openedTab = createDeferred<ReturnType<typeof createBrowserPanelTestTab>>();
       const activeUrl = "https://example.test/active";
       const newUrl = "https://example.test/new";
@@ -75,6 +76,7 @@ describe("BrowserPanelController tab and lifecycle ownership", () => {
         }
         if (envelope.path === "/screenshot") {
           if (envelope.body?.targetId === "active-tab") {
+            captureStarted.resolve();
             return await previousCapture.promise;
           }
           return { path: "/fresh.png", targetId: "raw-new", url: newUrl };
@@ -88,7 +90,7 @@ describe("BrowserPanelController tab and lifecycle ownership", () => {
       const previousView = controller.view;
 
       const capture = controller.refreshAll();
-      await flushBrowserResponses();
+      await captureStarted.promise;
       const opening = controller.openUrl(newUrl, { newTab: true });
       expect(controller.loading).toBe(true);
       expect(controller.view).toBe(previousView);

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -710,6 +710,7 @@ export class BrowserPanelController implements ReactiveController {
     this.setState("strokes", []);
     this.setState("inspected", null);
     this.setState("inspectPointer", null);
+    this.stream.flushPendingFrame();
   }
 
   setMode(mode: BrowserPanelMode): void {

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -9,9 +9,7 @@ import type {
   BrowserPanelTab,
 } from "./browser-client.ts";
 import {
-  captureBrowserScreenshot,
   closeBrowserTab,
-  fetchBrowserScreenshotDataUrl,
   focusBrowserTab,
   goBrowserHistory,
   isBrowserEvaluateDisabledError,
@@ -25,12 +23,13 @@ import {
 import { BrowserPanelInputController } from "./browser-panel-controller-input.ts";
 import {
   BrowserPanelOperationOwnership,
-  readBrowserPanelOwnedMetrics,
+  captureBrowserPanelOwnedView,
   type BrowserPanelControllerHost,
   type BrowserPanelSnapshotOutcome,
 } from "./browser-panel-operation-ownership.ts";
 import { BrowserPanelPendingInput } from "./browser-panel-pending-input.ts";
-import { loadBrowserPanelImage, type BrowserPanelView } from "./browser-panel-surface.ts";
+import { BrowserPanelStream } from "./browser-panel-stream.ts";
+import type { BrowserPanelView } from "./browser-panel-surface.ts";
 import { browserRouteKey, type BrowserRoute } from "./browser-target.ts";
 import { normalizeBrowserUrlDraft } from "./browser-url.ts";
 
@@ -64,26 +63,34 @@ export class BrowserPanelController implements ReactiveController {
   readonly operations: BrowserPanelOperationOwnership;
   readonly pendingInput = new BrowserPanelPendingInput();
   private readonly input: BrowserPanelInputController;
+  private readonly stream: BrowserPanelStream;
   private activeClient: GatewayBrowserClient | null = null;
-  private urlDraftEditing = false;
-  private observedViewportSize: { width: number; height: number } | null = null;
+  urlDraftEditing = false;
+  observedViewportSize: { width: number; height: number } | null = null;
   private lastRequestedViewport: { targetId: string; width: number; height: number } | null = null;
 
   constructor(readonly host: BrowserPanelControllerHost) {
     this.operations = new BrowserPanelOperationOwnership(host);
     this.input = new BrowserPanelInputController(this);
+    this.stream = new BrowserPanelStream(this);
     host.addController(this);
   }
 
   hostDisconnected(): void {
     this.input.cancelOverlayPointerGesture();
     this.invalidateViewOperations();
+    if (this.view?.dataUrl.startsWith("blob:")) {
+      this.setState("view", null);
+    }
     this.setState("loading", false);
   }
 
   setState<Key extends keyof this>(key: Key, value: this[Key]): void {
     if (Object.is(this[key], value)) {
       return;
+    }
+    if ((key === "view" && value === null) || key === "activeTargetId") {
+      this.stream.close();
     }
     Object.assign(this, { [key]: value });
     this.host.requestUpdate();
@@ -110,7 +117,7 @@ export class BrowserPanelController implements ReactiveController {
       : null;
   }
 
-  private clearUnavailableView(): boolean {
+  clearUnavailableView(): boolean {
     if (!this.unavailableTabText) {
       return false;
     }
@@ -124,6 +131,7 @@ export class BrowserPanelController implements ReactiveController {
   }
 
   private invalidateViewOperations(): void {
+    this.stream.close();
     this.operations.invalidate();
     this.pendingInput.clear();
     // The resize guard is per-document: after a tab or document change the
@@ -167,7 +175,9 @@ export class BrowserPanelController implements ReactiveController {
     }
     const invocation = this.operations.beginSnapshot(client);
     this.setState("errorText", null);
-    this.setState("loading", true);
+    if (!this.stream.ownsView(this.activeTargetId)) {
+      this.setState("loading", true);
+    }
     try {
       const snapshot = await listBrowserTabs(client);
       // Tool results carry raw targets; preserve that selection when the list supplies its alias.
@@ -215,12 +225,12 @@ export class BrowserPanelController implements ReactiveController {
     }
   }
 
-  private async refreshView(targetId: string, epoch = this.operations.epoch): Promise<void> {
+  async refreshView(targetId: string, epoch = this.operations.epoch): Promise<void> {
     const client = this.operations.captureClient();
     if (!client || !this.operations.isLive(epoch, client) || this.activeTargetId !== targetId) {
       return;
     }
-    if (this.clearUnavailableView()) {
+    if (this.clearUnavailableView() || this.stream.ownsView(targetId)) {
       return;
     }
     const current = this.operations.beginCapture(
@@ -233,46 +243,36 @@ export class BrowserPanelController implements ReactiveController {
       return;
     }
     this.setState("loading", true);
+    let captureRevision = this.stream.frameRevision;
+    const captureCurrent = () =>
+      current() && captureRevision === this.stream.frameRevision && !this.stream.ownsView(targetId);
     try {
-      const shot = await captureBrowserScreenshot(client, targetId);
-      if (!current()) {
+      if (
+        (await this.stream.ensure(targetId, client, epoch)) ||
+        !current() ||
+        this.stream.ownsView(targetId)
+      ) {
         return;
       }
-      const dataUrl = await fetchBrowserScreenshotDataUrl({
-        resourceBasePath: this.host.resourceBasePath,
-        authToken: this.host.authToken,
-        path: shot.path,
-      });
-      if (!current()) {
-        return;
-      }
-      const image = await loadBrowserPanelImage(dataUrl);
-      const observedMetrics = await readBrowserPanelOwnedMetrics(
+      captureRevision = this.stream.frameRevision;
+      const view = await captureBrowserPanelOwnedView({
         client,
         targetId,
-        this.evaluateUnavailable,
-        current,
-        () => this.setState("evaluateUnavailable", true),
-      );
-      if (!current()) {
+        route: this.operations.route,
+        host: this.host,
+        isEvaluateUnavailable: () => this.evaluateUnavailable,
+        current: captureCurrent,
+        markEvaluateUnavailable: () => this.setState("evaluateUnavailable", true),
+      });
+      if (!view || !captureCurrent()) {
         return;
       }
-      // A navigation between screenshot and evaluation changes the coordinate document.
-      const metrics =
-        shot.url && observedMetrics?.url && shot.url !== observedMetrics.url
-          ? null
-          : observedMetrics;
+      const { metrics } = view;
       // Tab snapshots can lag history and in-page navigation. Keep the stable
       // identity aligned with the document this capture owns.
-      this.setState("tabs", this.operations.capturedTabs(this.tabs, targetId, metrics, shot.url));
-      this.setState("view", {
-        targetId,
-        dataUrl,
-        image,
-        url: shot.url,
-        metrics,
-        ...(this.operations.route ? { browserTab: { ...this.operations.route, targetId } } : {}),
-      });
+      this.setState("tabs", this.operations.capturedTabs(this.tabs, targetId, metrics, view.url));
+      this.setState("view", view);
+      this.stream.releaseReplacedView();
       if (
         metrics &&
         this.observedViewportSize &&
@@ -281,11 +281,11 @@ export class BrowserPanelController implements ReactiveController {
       ) {
         this.scheduleViewportSync();
       }
-      if (!this.urlDraftEditing && shot.url) {
-        this.setState("urlDraft", shot.url);
+      if (!this.urlDraftEditing && view.url) {
+        this.setState("urlDraft", view.url);
       }
     } catch (error) {
-      if (current()) {
+      if (captureCurrent()) {
         // A capture denial describes the selected tab; a denied navigation
         // describes the destination and must keep the valid source screenshot.
         if (isBrowserNavigationBlockedError(error)) {
@@ -353,7 +353,7 @@ export class BrowserPanelController implements ReactiveController {
     this.scheduleViewportSync();
   }
 
-  private scheduleViewportSync(): void {
+  scheduleViewportSync(): void {
     this.pendingInput.scheduleViewportResize(VIEWPORT_RESIZE_DELAY_MS, () => this.syncViewport());
   }
 
@@ -368,6 +368,7 @@ export class BrowserPanelController implements ReactiveController {
     if (!targetId || !observed) {
       return;
     }
+    this.stream.resize();
     const width = Math.min(
       MAX_VIEWPORT_DIMENSION,
       Math.max(MIN_VIEWPORT_DIMENSION, Math.round(observed.width)),
@@ -594,7 +595,10 @@ export class BrowserPanelController implements ReactiveController {
         return;
       }
       this.setState("activeTargetId", previous.targetId);
-      this.setState("view", previous.view);
+      this.setState("view", previous.view?.dataUrl.startsWith("blob:") ? null : previous.view);
+      if (previous.targetId && previous.view?.dataUrl.startsWith("blob:")) {
+        await this.refreshView(previous.targetId);
+      }
     }
   }
 

--- a/ui/src/components/browser/browser-panel-operation-ownership.ts
+++ b/ui/src/components/browser/browser-panel-operation-ownership.ts
@@ -2,6 +2,8 @@ import type { ReactiveControllerHost } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import {
   bindBrowserRequestClient,
+  captureBrowserScreenshot,
+  fetchBrowserScreenshotDataUrl,
   type BrowserRequestClient,
   isBrowserEvaluateDisabledError,
   isBrowserNavigationBlockedError,
@@ -9,6 +11,7 @@ import {
   type BrowserPageMetrics,
   type BrowserPanelTab,
 } from "./browser-client.ts";
+import { loadBrowserPanelImage, type BrowserPanelView } from "./browser-panel-surface.ts";
 import type { BrowserRoute } from "./browser-target.ts";
 
 export interface BrowserPanelControllerHost extends ReactiveControllerHost {
@@ -316,7 +319,7 @@ export class BrowserPanelOperationOwnership {
 }
 
 /** A stale gateway must not disable evaluation on the replacement browser. */
-export async function readBrowserPanelOwnedMetrics(
+async function readBrowserPanelOwnedMetrics(
   client: BrowserRequestClient,
   targetId: string,
   evaluateUnavailable: boolean,
@@ -337,4 +340,52 @@ export async function readBrowserPanelOwnedMetrics(
     }
     return null;
   }
+}
+
+export async function captureBrowserPanelOwnedView(params: {
+  client: BrowserRequestClient;
+  targetId: string;
+  route?: BrowserRoute;
+  host: Pick<BrowserPanelControllerHost, "resourceBasePath" | "authToken">;
+  isEvaluateUnavailable: () => boolean;
+  current: () => boolean;
+  markEvaluateUnavailable: () => void;
+}): Promise<BrowserPanelView | null> {
+  const shot = await captureBrowserScreenshot(params.client, params.targetId);
+  if (!params.current()) {
+    return null;
+  }
+  const dataUrl = await fetchBrowserScreenshotDataUrl({
+    resourceBasePath: params.host.resourceBasePath,
+    authToken: params.host.authToken,
+    path: shot.path,
+  });
+  if (!params.current()) {
+    return null;
+  }
+  const image = await loadBrowserPanelImage(dataUrl);
+  if (!params.current()) {
+    return null;
+  }
+  const observedMetrics = await readBrowserPanelOwnedMetrics(
+    params.client,
+    params.targetId,
+    params.isEvaluateUnavailable(),
+    params.current,
+    params.markEvaluateUnavailable,
+  );
+  if (!params.current()) {
+    return null;
+  }
+  // A navigation between screenshot and evaluation changes the coordinate document.
+  const metrics =
+    shot.url && observedMetrics?.url && shot.url !== observedMetrics.url ? null : observedMetrics;
+  return {
+    targetId: params.targetId,
+    dataUrl,
+    image,
+    url: shot.url,
+    metrics,
+    ...(params.route ? { browserTab: { ...params.route, targetId: params.targetId } } : {}),
+  };
 }

--- a/ui/src/components/browser/browser-panel-stream.test.ts
+++ b/ui/src/components/browser/browser-panel-stream.test.ts
@@ -5,6 +5,7 @@ import {
   createBrowserClient,
   createBrowserPanelTestMetrics,
   createBrowserPanelTestTab,
+  createInspectedNode,
   flushBrowserResponses,
   setupBrowserPanelTestCleanup,
   stubScreenshotMedia,
@@ -110,6 +111,67 @@ async function start(controller: BrowserPanelController) {
 }
 
 describe("Browser panel stream ownership", () => {
+  it.each(["annotate", "inspect"] as const)(
+    "pins the captured image and URL during %s and presents the latest frame on exit",
+    async (mode) => {
+      const { controller } = setup();
+      const socket = await start(controller);
+      controller.setMode(mode);
+      controller.setState("strokes", [{ points: [{ x: 0.1, y: 0.2 }] }]);
+      controller.setState("inspected", createInspectedNode("Original button"));
+      const pinnedView = controller.view;
+      socket.receive(screencastFrame(NEXT_URL, 200, 100));
+      socket.receive(screencastFrame(NEXT_URL, 300, 100));
+      socket.receive(JSON.stringify({ type: "meta", url: NEXT_URL, title: "Next" }));
+      await flush();
+      expect(controller.view).toBe(pinnedView);
+      expect(controller.view).toMatchObject({ dataUrl: "blob:frame-0", url: PAGE_URL });
+      expect(controller.tabs[0]).toMatchObject({ url: NEXT_URL, title: "Next" });
+      expect(controller.urlDraft).toBe(NEXT_URL);
+      expect(controller.strokes).toHaveLength(1);
+      expect(controller.inspected?.name).toBe("Original button");
+
+      controller.exitCaptureModes();
+      await flush();
+      expect(controller.view).toMatchObject({
+        dataUrl: "blob:frame-1",
+        url: NEXT_URL,
+        metrics: { cssWidth: 300, title: "Next", url: NEXT_URL },
+      });
+      expect(controller.strokes).toEqual([]);
+      expect(controller.inspected).toBeNull();
+      expect(revokedUrls).toEqual(["blob:frame-0"]);
+    },
+  );
+
+  it("holds a frame whose decode finishes after capture mode begins", async () => {
+    const { controller } = setup();
+    const socket = await start(controller);
+    const images: EventTarget[] = [];
+    vi.stubGlobal(
+      "Image",
+      class extends EventTarget {
+        constructor() {
+          super();
+          images.push(this);
+        }
+        src = "";
+      },
+    );
+    socket.receive(screencastFrame(NEXT_URL));
+    controller.setMode("annotate");
+    socket.receive(JSON.stringify({ type: "meta", url: NEXT_URL, title: "Next" }));
+    images[0]!.dispatchEvent(new Event("load"));
+    await flush();
+    expect(controller.view).toMatchObject({ dataUrl: "blob:frame-0", url: PAGE_URL });
+    expect(revokedUrls).toEqual(["blob:frame-1"]);
+
+    controller.exitCaptureModes();
+    images[1]!.dispatchEvent(new Event("load"));
+    await flush();
+    expect(controller.view).toMatchObject({ dataUrl: "blob:frame-2", url: NEXT_URL });
+  });
+
   it("lets frames own the view and skips screenshot refreshes while live", async () => {
     const { controller, calls } = setup();
     const socket = await start(controller);
@@ -236,6 +298,24 @@ describe("Browser panel stream ownership", () => {
     expect(calls("/screencast")).toHaveLength(2);
     sockets[1]!.disconnect(1006);
     await retry;
+  });
+
+  it("falls back and backs off malformed mint responses without opening a socket", async () => {
+    const { controller, calls } = setup(async (envelope) =>
+      envelope.path === "/screencast" ? {} : undefined,
+    );
+    const pending = controller.refreshAll();
+    await flush();
+    expect(sockets).toHaveLength(0);
+    await pending;
+    expect(controller.view?.dataUrl).toMatch(/^data:/);
+    await controller.refreshAll();
+    expect(calls("/screencast")).toHaveLength(1);
+    expect(calls("/screenshot")).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(10_000);
+    await controller.refreshAll();
+    expect(calls("/screencast")).toHaveLength(2);
+    expect(sockets).toHaveLength(0);
   });
 
   it("restarts streaming immediately after a URL-bar navigation on the same tab", async () => {

--- a/ui/src/components/browser/browser-panel-stream.test.ts
+++ b/ui/src/components/browser/browser-panel-stream.test.ts
@@ -1,0 +1,367 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import { GatewayRequestError } from "../../api/gateway.ts";
+import {
+  createBrowserClient,
+  createBrowserPanelTestMetrics,
+  createBrowserPanelTestTab,
+  flushBrowserResponses,
+  setupBrowserPanelTestCleanup,
+  stubScreenshotMedia,
+  TestBrowserPanelHost,
+  type BrowserRequestEnvelope,
+} from "./browser-panel-controller-test-support.ts";
+import { BrowserPanelController } from "./browser-panel-controller.ts";
+import { screencastFrame, TestScreencastSocket } from "./browser-screencast-test-support.ts";
+
+const PAGE_URL = "https://example.test/page";
+const NEXT_URL = "https://example.test/next";
+const controllers: BrowserPanelController[] = [];
+let sockets: TestScreencastSocket[];
+let createdUrls: string[];
+let revokedUrls: string[];
+
+setupBrowserPanelTestCleanup();
+beforeEach(() => {
+  vi.useFakeTimers();
+  stubScreenshotMedia();
+  sockets = [];
+  createdUrls = [];
+  revokedUrls = [];
+  vi.stubGlobal(
+    "WebSocket",
+    class extends TestScreencastSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    },
+  );
+  vi.spyOn(URL, "createObjectURL").mockImplementation(() => {
+    const url = `blob:frame-${createdUrls.length}`;
+    createdUrls.push(url);
+    return url;
+  });
+  vi.spyOn(URL, "revokeObjectURL").mockImplementation((url) => revokedUrls.push(url));
+});
+afterEach(() => {
+  for (const controller of controllers.splice(0)) {
+    controller.hostDisconnected();
+  }
+});
+
+async function flush(): Promise<void> {
+  await flushBrowserResponses();
+  await flushBrowserResponses();
+  await flushBrowserResponses();
+}
+
+function setup(handle?: (envelope: BrowserRequestEnvelope) => Promise<unknown>) {
+  const gateway = createBrowserClient(
+    async (envelope) => {
+      if (handle) {
+        const result = await handle(envelope);
+        if (result !== undefined) {
+          return result;
+        }
+      }
+      switch (envelope.path) {
+        case "/tabs":
+          return { running: true, tabs: [createBrowserPanelTestTab("tab-a", PAGE_URL, "Page")] };
+        case "/screencast":
+          return {
+            token: "token",
+            wsPath: "/browser/screencast?token=token",
+            targetId: "raw-a",
+            url: PAGE_URL,
+          };
+        case "/screenshot":
+          return { path: "/fresh.png", targetId: "raw-a", url: PAGE_URL };
+        case "/act":
+          return createBrowserPanelTestMetrics(PAGE_URL);
+        default:
+          return { ok: true };
+      }
+    },
+    { screencast: true },
+  );
+  const host = new TestBrowserPanelHost(gateway.client);
+  const controller = new BrowserPanelController(host);
+  controller.synchronizeClient();
+  controllers.push(controller);
+  const calls = (path: string) =>
+    gateway.request.mock.calls.filter(
+      ([, params]) => (params as BrowserRequestEnvelope).path === path,
+    );
+  return { ...gateway, host, controller, calls };
+}
+
+async function start(controller: BrowserPanelController) {
+  const pending = controller.refreshAll();
+  await flush();
+  const socket = sockets.at(-1)!;
+  socket.receive(
+    JSON.stringify({ type: "ready", targetId: "raw-a", url: PAGE_URL, title: "Page" }),
+  );
+  socket.receive(screencastFrame());
+  await pending;
+  await flush();
+  return socket;
+}
+
+describe("Browser panel stream ownership", () => {
+  it("lets frames own the view and skips screenshot refreshes while live", async () => {
+    const { controller, calls } = setup();
+    const socket = await start(controller);
+    expect(controller.view).toMatchObject({
+      targetId: "tab-a",
+      dataUrl: "blob:frame-0",
+      metrics: { cssWidth: 100, cssHeight: 100 },
+    });
+    await controller.refreshAll();
+    expect(calls("/screenshot")).toHaveLength(0);
+    expect(calls("/screencast")).toHaveLength(1);
+    expect(controller.loading).toBe(false);
+    socket.receive(JSON.stringify({ type: "meta", url: NEXT_URL, title: "Next" }));
+    expect(controller.view?.metrics).toMatchObject({ title: "Next", url: NEXT_URL });
+    expect(controller.tabs[0]).toMatchObject({ title: "Next", url: NEXT_URL });
+    expect(controller.urlDraft).toBe(NEXT_URL);
+    controller.setUrlDraftEditing(true);
+    controller.setUrlDraft("editing");
+    socket.receive(JSON.stringify({ type: "meta", url: PAGE_URL, title: "Page again" }));
+    expect(controller.urlDraft).toBe("editing");
+  });
+
+  it.each([false, true])(
+    "discards a fallback screenshot overtaken by a frame (socket then closes: %s)",
+    async (closes) => {
+      const screenshot = createDeferred<unknown>();
+      const { controller, calls } = setup(async (envelope) =>
+        envelope.path === "/screenshot" ? screenshot.promise : undefined,
+      );
+      const pending = controller.refreshAll();
+      await flush();
+      await vi.advanceTimersByTimeAsync(1499);
+      expect(calls("/screenshot")).toHaveLength(0);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(calls("/screenshot")).toHaveLength(1);
+      sockets[0]!.receive(screencastFrame());
+      await flush();
+      const streamedView = controller.view;
+      expect(streamedView?.dataUrl).toBe("blob:frame-0");
+      expect(controller.loading).toBe(false);
+      if (closes) {
+        sockets[0]!.disconnect(1006);
+      }
+      screenshot.resolve({ path: "/old.png", targetId: "raw-a", url: PAGE_URL });
+      await pending;
+      expect(controller.view).toBe(streamedView);
+      expect(fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it("marks navigation-blocked tabs unavailable and releases the visible frame", async () => {
+    const { controller } = setup();
+    const socket = await start(controller);
+    socket.disconnect(4003, "navigation_blocked");
+    expect(controller.tabs[0]).toMatchObject({
+      url: "",
+      urlUnavailableReason: "navigation_blocked",
+    });
+    expect(controller.view).toBeNull();
+    expect(controller.urlDraft).toBe("");
+    expect(revokedUrls).toEqual(["blob:frame-0"]);
+  });
+
+  it("reconciles the tab list when the streamed page closes", async () => {
+    let closed = false;
+    const { controller, calls } = setup(async (envelope) =>
+      envelope.path === "/tabs" && closed ? { running: true, tabs: [] } : undefined,
+    );
+    const socket = await start(controller);
+    closed = true;
+    socket.disconnect(4004, "target_closed");
+    await flush();
+    expect(calls("/tabs")).toHaveLength(2);
+    expect(controller.activeTargetId).toBeNull();
+    expect(controller.view).toBeNull();
+  });
+
+  it("remembers unsupported streaming until the route or client changes", async () => {
+    const { controller, calls, host } = setup(async (envelope) => {
+      if (envelope.path === "/screencast") {
+        throw new GatewayRequestError({
+          code: "INVALID_REQUEST",
+          message: "Unsupported",
+          details: { code: "SCREENCAST_UNSUPPORTED", reason: "node" },
+        });
+      }
+    });
+    await controller.refreshAll();
+    await vi.advanceTimersByTimeAsync(20_000);
+    await controller.refreshAll();
+    expect(calls("/screencast")).toHaveLength(1);
+    expect(calls("/screenshot")).toHaveLength(2);
+    controller.operations.resetRoute({ target: "host", profile: "another" });
+    controller.resetBrowserState();
+    await controller.refreshAll();
+    expect(calls("/screencast")).toHaveLength(2);
+    const replacement = createBrowserClient(async () => ({
+      running: true,
+      tabs: [createBrowserPanelTestTab("tab-a", PAGE_URL, "Page")],
+    }));
+    host.client = replacement.client;
+    controller.synchronizeClient();
+    await controller.refreshAll();
+    expect(
+      replacement.request.mock.calls.some(
+        ([, params]) => (params as BrowserRequestEnvelope).path === "/screencast",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps the displayed frame on socket failure, falls back, and rate-limits retries", async () => {
+    const { controller, calls } = setup();
+    const socket = await start(controller);
+    socket.disconnect(1006);
+    expect(controller.view?.dataUrl).toBe("blob:frame-0");
+    expect(revokedUrls).toEqual([]);
+    await controller.refreshAll();
+    expect(controller.view?.dataUrl).toMatch(/^data:/);
+    expect(revokedUrls).toEqual(["blob:frame-0"]);
+    expect(calls("/screencast")).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(10_000);
+    const retry = controller.refreshAll();
+    await flush();
+    expect(calls("/screencast")).toHaveLength(2);
+    sockets[1]!.disconnect(1006);
+    await retry;
+  });
+
+  it("restarts streaming immediately after a URL-bar navigation on the same tab", async () => {
+    const { controller, calls } = setup(async (envelope) =>
+      envelope.path === "/navigate" ? { targetId: "raw-a", url: NEXT_URL } : undefined,
+    );
+    await start(controller);
+    expect(calls("/screencast")).toHaveLength(1);
+    const navigation = controller.openUrl(NEXT_URL, { newTab: false });
+    await flush();
+    expect(calls("/screencast")).toHaveLength(2);
+    const socket = sockets.at(-1)!;
+    socket.receive(
+      JSON.stringify({ type: "ready", targetId: "raw-a", url: NEXT_URL, title: "Next" }),
+    );
+    socket.receive(screencastFrame(NEXT_URL));
+    await navigation;
+    await flush();
+    expect(controller.view?.dataUrl).toBe("blob:frame-1");
+    expect(controller.view?.url).toBe(NEXT_URL);
+    expect(calls("/screenshot")).toHaveLength(0);
+  });
+
+  it.each(["disconnect", "reset", "tab"])("closes and revokes on %s teardown", async (kind) => {
+    const { controller } = setup();
+    const socket = await start(controller);
+    if (kind === "disconnect") {
+      controller.hostDisconnected();
+    } else if (kind === "reset") {
+      controller.resetBrowserState();
+    } else {
+      controller.setState("activeTargetId", "tab-b");
+    }
+    expect(socket.close).toHaveBeenCalledOnce();
+    expect(revokedUrls).toEqual(["blob:frame-0"]);
+  });
+
+  it("coalesces decoding frames and never publishes a frame overtaken by navigation metadata", async () => {
+    const { controller } = setup();
+    const socket = await start(controller);
+    const images: EventTarget[] = [];
+    vi.stubGlobal(
+      "Image",
+      class extends EventTarget {
+        constructor() {
+          super();
+          images.push(this);
+        }
+        src = "";
+      },
+    );
+    socket.receive(screencastFrame());
+    socket.receive(JSON.stringify({ type: "meta", url: NEXT_URL, title: "Next" }));
+    socket.receive(screencastFrame(NEXT_URL, 200, 100));
+    socket.receive(screencastFrame(NEXT_URL, 300, 100));
+    expect(images).toHaveLength(1);
+    images[0]!.dispatchEvent(new Event("load"));
+    await flush();
+    expect(controller.view?.url).toBe(NEXT_URL);
+    expect(images).toHaveLength(2);
+    expect(revokedUrls).toContain("blob:frame-1");
+    images[1]!.dispatchEvent(new Event("load"));
+    await flush();
+    expect(controller.view).toMatchObject({
+      dataUrl: "blob:frame-2",
+      metrics: { cssWidth: 300, title: "Next", url: NEXT_URL },
+    });
+    expect(revokedUrls).toContain("blob:frame-0");
+    expect(createdUrls.filter((url) => !revokedUrls.includes(url))).toEqual(["blob:frame-2"]);
+  });
+
+  it("negotiates pixel density and restarts only after a large debounced width change", async () => {
+    const { controller, host, calls } = setup();
+    vi.stubGlobal("devicePixelRatio", 2);
+    let width = 500;
+    const stage = host.renderRoot.querySelector<HTMLElement>(".bp-stage")!;
+    Object.defineProperty(stage, "clientWidth", { get: () => width });
+    controller.handleViewportResize(width, 300);
+    await start(controller);
+    expect(calls("/screencast")[0]?.[1]).toMatchObject({
+      body: { maxWidth: 1000, maxHeight: 1000 },
+    });
+    width = 640;
+    controller.handleViewportResize(width, 300);
+    await vi.advanceTimersByTimeAsync(300);
+    expect(calls("/screencast")).toHaveLength(1);
+    width = 800;
+    controller.handleViewportResize(width, 1200);
+    await vi.advanceTimersByTimeAsync(300);
+    expect(calls("/screencast")).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(9400);
+    expect(calls("/screencast")).toHaveLength(2);
+    expect(calls("/screencast")[1]?.[1]).toMatchObject({
+      body: { maxWidth: 1600, maxHeight: 2000 },
+    });
+    sockets[1]!.receive(screencastFrame(PAGE_URL, 800, 1200));
+    await flush();
+  });
+
+  it("does not let a retired decoder replace or revoke the new stream's frame", async () => {
+    const { controller } = setup();
+    await start(controller);
+    const images: EventTarget[] = [];
+    vi.stubGlobal(
+      "Image",
+      class extends EventTarget {
+        constructor() {
+          super();
+          images.push(this);
+        }
+        src = "";
+      },
+    );
+    sockets[0]!.receive(screencastFrame());
+    controller.resetBrowserState();
+    await vi.advanceTimersByTimeAsync(10_000);
+    const restarted = controller.refreshAll();
+    await flush();
+    sockets[1]!.receive(screencastFrame(NEXT_URL));
+    images[1]!.dispatchEvent(new Event("load"));
+    await restarted;
+    images[0]!.dispatchEvent(new Event("load"));
+    await flush();
+    expect(controller.view?.dataUrl).toBe("blob:frame-2");
+    expect(revokedUrls).toEqual(["blob:frame-0", "blob:frame-1"]);
+    sockets[1]!.receive(screencastFrame(NEXT_URL));
+    expect(images).toHaveLength(3);
+  });
+});

--- a/ui/src/components/browser/browser-panel-stream.test.ts
+++ b/ui/src/components/browser/browser-panel-stream.test.ts
@@ -419,6 +419,30 @@ describe("Browser panel stream ownership", () => {
     expect(createdUrls.filter((url) => !revokedUrls.includes(url))).toEqual(["blob:frame-2"]);
   });
 
+  it("does not let continuous mismatched frames postpone the debounced viewport sync", async () => {
+    const { controller, calls } = setup();
+    controller.handleViewportResize(500, 300);
+    const schedule = vi.spyOn(controller, "scheduleViewportSync");
+    const socket = await start(controller);
+    expect(schedule).toHaveBeenCalledTimes(1);
+    for (let elapsed = 100; elapsed <= 600; elapsed += 100) {
+      socket.receive(screencastFrame(PAGE_URL, 100, 100));
+      await vi.advanceTimersByTimeAsync(100);
+    }
+    const resizes = () =>
+      calls("/act").filter(
+        ([, params]) => (params as BrowserRequestEnvelope).body?.kind === "resize",
+      );
+    // The sync fired at 300 ms and 600 ms despite a frame every 100 ms; frames
+    // arriving while a sync was pending joined it instead of postponing it.
+    expect(resizes()).toHaveLength(1);
+    expect(resizes()[0]?.[1]).toMatchObject({ body: { width: 500, height: 300 } });
+    expect(schedule).toHaveBeenCalledTimes(2);
+    socket.receive(screencastFrame(PAGE_URL, 100, 100));
+    await flush();
+    expect(schedule).toHaveBeenCalledTimes(3);
+  });
+
   it("negotiates pixel density and restarts only after a large debounced width change", async () => {
     const { controller, host, calls } = setup();
     vi.stubGlobal("devicePixelRatio", 2);

--- a/ui/src/components/browser/browser-panel-stream.test.ts
+++ b/ui/src/components/browser/browser-panel-stream.test.ts
@@ -144,6 +144,22 @@ describe("Browser panel stream ownership", () => {
     },
   );
 
+  it("keeps annotation context on the displayed frame when navigation metadata arrives first", async () => {
+    const { controller } = setup();
+    const socket = await start(controller);
+    socket.receive(JSON.stringify({ type: "meta", url: NEXT_URL, title: "Next" }));
+    controller.setMode("annotate");
+
+    expect(controller.mode).toBe("annotate");
+    expect(controller.view).toMatchObject({
+      dataUrl: "blob:frame-0",
+      url: PAGE_URL,
+      metrics: { title: "Page", url: PAGE_URL },
+    });
+    expect(controller.tabs[0]).toMatchObject({ title: "Next", url: NEXT_URL });
+    expect(controller.urlDraft).toBe(NEXT_URL);
+  });
+
   it("holds a frame whose decode finishes after capture mode begins", async () => {
     const { controller } = setup();
     const socket = await start(controller);
@@ -185,9 +201,20 @@ describe("Browser panel stream ownership", () => {
     expect(calls("/screencast")).toHaveLength(1);
     expect(controller.loading).toBe(false);
     socket.receive(JSON.stringify({ type: "meta", url: NEXT_URL, title: "Next" }));
-    expect(controller.view?.metrics).toMatchObject({ title: "Next", url: NEXT_URL });
+    expect(controller.view).toMatchObject({
+      dataUrl: "blob:frame-0",
+      url: PAGE_URL,
+      metrics: { title: "Page", url: PAGE_URL },
+    });
     expect(controller.tabs[0]).toMatchObject({ title: "Next", url: NEXT_URL });
     expect(controller.urlDraft).toBe(NEXT_URL);
+    socket.receive(screencastFrame(NEXT_URL));
+    await flush();
+    expect(controller.view).toMatchObject({
+      dataUrl: "blob:frame-1",
+      url: NEXT_URL,
+      metrics: { title: "Next", url: NEXT_URL },
+    });
     controller.setUrlDraftEditing(true);
     controller.setUrlDraft("editing");
     socket.receive(JSON.stringify({ type: "meta", url: PAGE_URL, title: "Page again" }));
@@ -374,13 +401,18 @@ describe("Browser panel stream ownership", () => {
     expect(images).toHaveLength(1);
     images[0]!.dispatchEvent(new Event("load"));
     await flush();
-    expect(controller.view?.url).toBe(NEXT_URL);
+    expect(controller.view).toMatchObject({
+      dataUrl: "blob:frame-0",
+      url: PAGE_URL,
+      metrics: { title: "Page", url: PAGE_URL },
+    });
     expect(images).toHaveLength(2);
     expect(revokedUrls).toContain("blob:frame-1");
     images[1]!.dispatchEvent(new Event("load"));
     await flush();
     expect(controller.view).toMatchObject({
       dataUrl: "blob:frame-2",
+      url: NEXT_URL,
       metrics: { cssWidth: 300, title: "Next", url: NEXT_URL },
     });
     expect(revokedUrls).toContain("blob:frame-0");

--- a/ui/src/components/browser/browser-panel-stream.ts
+++ b/ui/src/components/browser/browser-panel-stream.ts
@@ -1,0 +1,367 @@
+import type { BrowserPanelTab, BrowserRequestClient } from "./browser-client.ts";
+import { isBrowserScreencastUnsupportedError, requestBrowserScreencast } from "./browser-client.ts";
+import type {
+  BrowserPanelControllerHost,
+  BrowserPanelOperationOwnership,
+} from "./browser-panel-operation-ownership.ts";
+import { loadBrowserPanelImage, type BrowserPanelView } from "./browser-panel-surface.ts";
+import {
+  BrowserScreencastClient,
+  type BrowserScreencastFrame,
+  type BrowserScreencastMeta,
+} from "./browser-screencast-client.ts";
+import { browserRouteKey } from "./browser-target.ts";
+
+const FIRST_FRAME_TIMEOUT_MS = 1500;
+const RETRY_DELAY_MS = 10_000;
+const RESIZE_RESTART_DEBOUNCE_MS = 500;
+
+type StreamState = {
+  activeTargetId: string | null;
+  view: BrowserPanelView | null;
+  tabs: BrowserPanelTab[];
+  urlDraft: string;
+  loading: boolean;
+};
+
+interface BrowserPanelStreamHost extends StreamState {
+  readonly host: BrowserPanelControllerHost;
+  readonly operations: Pick<
+    BrowserPanelOperationOwnership,
+    "epoch" | "route" | "isLive" | "capturedTabs" | "markNavigationReconciled"
+  >;
+  readonly urlDraftEditing: boolean;
+  readonly observedViewportSize: { width: number; height: number } | null;
+  setState<Key extends keyof StreamState>(key: Key, value: StreamState[Key]): void;
+  clearUnavailableView(): boolean;
+  scheduleViewportSync(): void;
+  refreshView(targetId: string): Promise<void>;
+  refreshAll(): Promise<void>;
+}
+
+type Attempt = {
+  targetId: string;
+  epoch: number;
+  client: BrowserRequestClient;
+  width: number;
+  live: boolean;
+  connection?: BrowserScreencastClient;
+  firstFrame: Promise<boolean>;
+  settle: (received: boolean) => void;
+  metadata?: BrowserScreencastMeta;
+  pendingFrame?: BrowserScreencastFrame;
+  decoding: boolean;
+  presented: boolean;
+};
+
+/** Owns stream attachment and the object URLs of the active browser surface. */
+export class BrowserPanelStream {
+  private attempt?: Attempt;
+  frameRevision = 0;
+  private scope?: { client: BrowserPanelControllerHost["client"]; route: string };
+  private unsupported = false;
+  private readonly lastFailures = new Map<string, number>();
+  private objectUrl?: string;
+  private decodingUrl?: string;
+  private resizeTimer?: ReturnType<typeof setTimeout>;
+  private readonly retiringUrls = new Set<string>();
+
+  constructor(private readonly host: BrowserPanelStreamHost) {}
+
+  ownsView(targetId: string | null): boolean {
+    return Boolean(
+      this.attempt?.live && this.attempt.targetId === targetId && this.current(this.attempt),
+    );
+  }
+
+  private current(attempt: Attempt): boolean {
+    return (
+      this.attempt === attempt &&
+      this.host.activeTargetId === attempt.targetId &&
+      this.host.operations.isLive(attempt.epoch, attempt.client)
+    );
+  }
+
+  private dimensions() {
+    const stage = this.host.host.renderRoot.querySelector<HTMLElement>(".bp-stage");
+    const viewport = this.host.host.renderRoot.querySelector<HTMLElement>(".bp-viewport");
+    const width =
+      stage?.clientWidth || viewport?.clientWidth || this.host.observedViewportSize?.width || 1280;
+    const height = viewport?.clientHeight || this.host.observedViewportSize?.height || width;
+    const ratio = globalThis.devicePixelRatio || 1;
+    return {
+      width,
+      maxWidth: Math.min(2000, Math.ceil(width * ratio)),
+      maxHeight: Math.min(2000, Math.ceil(Math.max(width, height) * ratio)),
+    };
+  }
+
+  async ensure(targetId: string, client: BrowserRequestClient, epoch: number): Promise<boolean> {
+    const route = browserRouteKey(this.host.operations.route);
+    if (!this.scope || this.scope.client !== this.host.host.client || this.scope.route !== route) {
+      this.close();
+      this.scope = { client: this.host.host.client, route };
+      this.unsupported = false;
+      this.lastFailures.clear();
+    }
+    if (this.attempt && this.current(this.attempt) && this.attempt.targetId === targetId) {
+      return this.attempt.live || (await this.attempt.firstFrame);
+    }
+    this.close(false);
+    // Only failed attempts back off; navigation and resize close streams on purpose and restart at once.
+    if (
+      this.unsupported ||
+      Date.now() - (this.lastFailures.get(targetId) ?? -Infinity) < RETRY_DELAY_MS
+    ) {
+      return false;
+    }
+    const dimensions = this.dimensions();
+    let settle!: Attempt["settle"];
+    const firstFrame = new Promise<boolean>((resolve) => {
+      const timeout = setTimeout(() => resolve(false), FIRST_FRAME_TIMEOUT_MS);
+      settle = (received) => {
+        clearTimeout(timeout);
+        resolve(received);
+      };
+    });
+    const attempt: Attempt = {
+      targetId,
+      client,
+      epoch,
+      width: dimensions.width,
+      live: false,
+      firstFrame,
+      settle,
+      decoding: false,
+      presented: false,
+    };
+    this.attempt = attempt;
+    void this.connect(attempt, { maxWidth: dimensions.maxWidth, maxHeight: dimensions.maxHeight });
+    return await firstFrame;
+  }
+
+  private async connect(
+    attempt: Attempt,
+    dimensions: { maxWidth: number; maxHeight: number },
+  ): Promise<void> {
+    try {
+      const response = await requestBrowserScreencast(attempt.client, {
+        targetId: attempt.targetId,
+        ...dimensions,
+      });
+      if (!this.current(attempt)) {
+        return;
+      }
+      attempt.connection = new BrowserScreencastClient({
+        gatewayUrl: this.host.host.client!.gatewayUrl,
+        wsPath: response.wsPath,
+        onReady: ({ url, title }) => this.updateMetadata(attempt, { url, title }),
+        onMeta: (meta) => this.updateMetadata(attempt, meta),
+        onFrame: (frame) => {
+          if (!this.current(attempt)) {
+            return;
+          }
+          // A received frame owns the view even while its image is decoding.
+          this.frameRevision += 1;
+          attempt.live = true;
+          attempt.pendingFrame = frame;
+          if (!attempt.decoding) {
+            void this.decodeFrames(attempt);
+          }
+        },
+        onClose: ({ code }) => {
+          if (!this.current(attempt)) {
+            return;
+          }
+          if (code !== 4003 && code !== 4004) {
+            this.lastFailures.set(attempt.targetId, Date.now());
+          }
+          this.close(code === 4003 || code === 4004);
+          if (code === 4003) {
+            this.host.setState(
+              "tabs",
+              this.host.tabs.map((tab) =>
+                tab.id === attempt.targetId
+                  ? { ...tab, url: "", urlUnavailableReason: "navigation_blocked" }
+                  : tab,
+              ),
+            );
+            this.host.clearUnavailableView();
+          } else if (code === 4004) {
+            void this.host.refreshAll();
+          }
+        },
+      });
+    } catch (error) {
+      if (this.current(attempt)) {
+        this.unsupported = isBrowserScreencastUnsupportedError(error);
+        if (!this.unsupported) {
+          this.lastFailures.set(attempt.targetId, Date.now());
+        }
+        this.close(false);
+      }
+    }
+  }
+
+  private updateMetadata(attempt: Attempt, metadata: BrowserScreencastMeta): void {
+    if (!this.current(attempt)) {
+      return;
+    }
+    attempt.metadata = metadata;
+    const view = this.host.view;
+    if (attempt.live && view?.targetId === attempt.targetId && view.metrics) {
+      this.host.setState("view", {
+        ...view,
+        url: metadata.url,
+        metrics: { ...view.metrics, ...metadata },
+      });
+    }
+    this.host.setState(
+      "tabs",
+      this.host.tabs.map((tab) =>
+        tab.id === attempt.targetId
+          ? { ...tab, ...metadata, urlUnavailableReason: undefined }
+          : tab,
+      ),
+    );
+    if (!this.host.urlDraftEditing) {
+      this.host.setState("urlDraft", metadata.url);
+    }
+  }
+
+  private async decodeFrames(attempt: Attempt): Promise<void> {
+    attempt.decoding = true;
+    try {
+      while (this.current(attempt) && attempt.pendingFrame) {
+        const frame = attempt.pendingFrame;
+        const metadata = attempt.metadata;
+        attempt.pendingFrame = undefined;
+        const objectUrl = URL.createObjectURL(frame.blob);
+        this.decodingUrl = objectUrl;
+        const image = await loadBrowserPanelImage(objectUrl);
+        if (!this.current(attempt)) {
+          return;
+        }
+        if (metadata !== attempt.metadata && attempt.metadata?.url !== frame.url) {
+          URL.revokeObjectURL(objectUrl);
+          this.decodingUrl = undefined;
+          continue;
+        }
+        const previousUrl = this.objectUrl;
+        this.decodingUrl = undefined;
+        this.objectUrl = objectUrl;
+        const title =
+          attempt.metadata?.url === frame.url
+            ? attempt.metadata.title
+            : (this.host.tabs.find((tab) => tab.id === attempt.targetId)?.title ?? "");
+        const metrics = {
+          cssWidth: frame.cssWidth,
+          cssHeight: frame.cssHeight,
+          title,
+          url: frame.url,
+        };
+        this.host.setState(
+          "tabs",
+          this.host.operations.capturedTabs(this.host.tabs, attempt.targetId, metrics, frame.url),
+        );
+        this.host.setState("view", {
+          targetId: attempt.targetId,
+          dataUrl: objectUrl,
+          image,
+          url: frame.url,
+          metrics,
+          ...(this.host.operations.route
+            ? { browserTab: { ...this.host.operations.route, targetId: attempt.targetId } }
+            : {}),
+        });
+        this.host.operations.markNavigationReconciled(attempt.client, attempt.targetId);
+        if (!this.host.urlDraftEditing) {
+          this.host.setState("urlDraft", frame.url);
+        }
+        if (
+          this.host.observedViewportSize &&
+          (Math.abs(frame.cssWidth - this.host.observedViewportSize.width) > 1 ||
+            Math.abs(frame.cssHeight - this.host.observedViewportSize.height) > 1)
+        ) {
+          this.host.scheduleViewportSync();
+        }
+        if (!attempt.presented) {
+          attempt.presented = true;
+          this.host.setState("loading", false);
+        }
+        attempt.settle(true);
+        await this.retireAfterUpdate(previousUrl);
+      }
+    } catch {
+      if (this.current(attempt)) {
+        this.close(false);
+      }
+    } finally {
+      attempt.decoding = false;
+    }
+  }
+
+  resize(): void {
+    const attempt = this.attempt;
+    if (
+      !attempt ||
+      !this.current(attempt) ||
+      Math.abs(this.dimensions().width - attempt.width) / attempt.width <= 0.3
+    ) {
+      return;
+    }
+    // Coalesce a burst of layout changes into one restart.
+    this.resizeTimer ??= setTimeout(() => {
+      this.resizeTimer = undefined;
+      if (
+        this.attempt !== attempt ||
+        !this.current(attempt) ||
+        Math.abs(this.dimensions().width - attempt.width) / attempt.width <= 0.3
+      ) {
+        return;
+      }
+      this.close(false);
+      void this.host.refreshView(attempt.targetId);
+    }, RESIZE_RESTART_DEBOUNCE_MS);
+  }
+
+  releaseReplacedView(): void {
+    const previousUrl = this.objectUrl;
+    this.objectUrl = undefined;
+    void this.retireAfterUpdate(previousUrl);
+  }
+
+  private async retireAfterUpdate(url?: string): Promise<void> {
+    if (url) {
+      this.retiringUrls.add(url);
+    }
+    // The previous image must survive until Lit has committed its replacement.
+    await this.host.host.updateComplete;
+    if (url && this.retiringUrls.delete(url)) {
+      URL.revokeObjectURL(url);
+    }
+  }
+
+  close(releaseView = true): void {
+    clearTimeout(this.resizeTimer);
+    this.resizeTimer = undefined;
+    const attempt = this.attempt;
+    this.attempt = undefined;
+    attempt?.settle(false);
+    attempt?.connection?.close();
+    for (const url of [
+      releaseView ? this.objectUrl : undefined,
+      this.decodingUrl,
+      ...(releaseView ? this.retiringUrls : []),
+    ]) {
+      if (url) {
+        URL.revokeObjectURL(url);
+      }
+    }
+    if (releaseView) {
+      this.objectUrl = undefined;
+      this.retiringUrls.clear();
+    }
+    this.decodingUrl = undefined;
+  }
+}

--- a/ui/src/components/browser/browser-panel-stream.ts
+++ b/ui/src/components/browser/browser-panel-stream.ts
@@ -65,6 +65,7 @@ export class BrowserPanelStream {
   private objectUrl?: string;
   private decodingUrl?: string;
   private resizeTimer?: ReturnType<typeof setTimeout>;
+  private viewportSyncPending = false;
   private readonly retiringUrls = new Set<string>();
 
   constructor(private readonly host: BrowserPanelStreamHost) {}
@@ -292,8 +293,11 @@ export class BrowserPanelStream {
         if (
           this.host.observedViewportSize &&
           (Math.abs(frame.cssWidth - this.host.observedViewportSize.width) > 1 ||
-            Math.abs(frame.cssHeight - this.host.observedViewportSize.height) > 1)
+            Math.abs(frame.cssHeight - this.host.observedViewportSize.height) > 1) &&
+          !this.viewportSyncPending
         ) {
+          // The sync is debounced; a repainting page must not keep postponing it.
+          this.viewportSyncPending = true;
           this.host.scheduleViewportSync();
         }
         if (!attempt.presented) {
@@ -313,6 +317,8 @@ export class BrowserPanelStream {
   }
 
   resize(): void {
+    // The debounced viewport sync just ran; later mismatched frames may schedule again.
+    this.viewportSyncPending = false;
     const attempt = this.attempt;
     if (
       !attempt ||
@@ -356,6 +362,8 @@ export class BrowserPanelStream {
   close(releaseView = true): void {
     clearTimeout(this.resizeTimer);
     this.resizeTimer = undefined;
+    // Invalidation cancels the pending sync timer; the next stream must be able to schedule one.
+    this.viewportSyncPending = false;
     const attempt = this.attempt;
     this.attempt = undefined;
     attempt?.settle(false);

--- a/ui/src/components/browser/browser-panel-stream.ts
+++ b/ui/src/components/browser/browser-panel-stream.ts
@@ -26,6 +26,7 @@ type StreamState = {
 
 interface BrowserPanelStreamHost extends StreamState {
   readonly host: BrowserPanelControllerHost;
+  readonly mode: "interact" | "annotate" | "inspect";
   readonly operations: Pick<
     BrowserPanelOperationOwnership,
     "epoch" | "route" | "isLive" | "capturedTabs" | "markNavigationReconciled"
@@ -209,7 +210,12 @@ export class BrowserPanelStream {
     }
     attempt.metadata = metadata;
     const view = this.host.view;
-    if (attempt.live && view?.targetId === attempt.targetId && view.metrics) {
+    if (
+      this.host.mode === "interact" &&
+      attempt.live &&
+      view?.targetId === attempt.targetId &&
+      view.metrics
+    ) {
       this.host.setState("view", {
         ...view,
         url: metadata.url,
@@ -229,10 +235,21 @@ export class BrowserPanelStream {
     }
   }
 
+  flushPendingFrame(): void {
+    const attempt = this.attempt;
+    if (attempt && this.current(attempt) && !attempt.decoding) {
+      void this.decodeFrames(attempt);
+    }
+  }
+
   private async decodeFrames(attempt: Attempt): Promise<void> {
     attempt.decoding = true;
     try {
       while (this.current(attempt) && attempt.pendingFrame) {
+        const mode = this.host.mode;
+        if (mode !== "interact") {
+          return;
+        }
         const frame = attempt.pendingFrame;
         const metadata = attempt.metadata;
         attempt.pendingFrame = undefined;
@@ -240,6 +257,13 @@ export class BrowserPanelStream {
         this.decodingUrl = objectUrl;
         const image = await loadBrowserPanelImage(objectUrl);
         if (!this.current(attempt)) {
+          return;
+        }
+        // Capture mode can begin while an image is decoding; keep the newest frame for exit.
+        if (this.host.mode !== "interact") {
+          attempt.pendingFrame ??= frame;
+          URL.revokeObjectURL(objectUrl);
+          this.decodingUrl = undefined;
           return;
         }
         if (metadata !== attempt.metadata && attempt.metadata?.url !== frame.url) {

--- a/ui/src/components/browser/browser-panel-stream.ts
+++ b/ui/src/components/browser/browser-panel-stream.ts
@@ -209,19 +209,6 @@ export class BrowserPanelStream {
       return;
     }
     attempt.metadata = metadata;
-    const view = this.host.view;
-    if (
-      this.host.mode === "interact" &&
-      attempt.live &&
-      view?.targetId === attempt.targetId &&
-      view.metrics
-    ) {
-      this.host.setState("view", {
-        ...view,
-        url: metadata.url,
-        metrics: { ...view.metrics, ...metadata },
-      });
-    }
     this.host.setState(
       "tabs",
       this.host.tabs.map((tab) =>

--- a/ui/src/components/browser/browser-panel.ts
+++ b/ui/src/components/browser/browser-panel.ts
@@ -101,7 +101,7 @@ class OpenClawBrowserPanel extends OpenClawLitElement implements BrowserPanelCon
     if (changed.has("suppressed")) {
       const restored = this.dockLayout.setSuppressed(this.suppressed);
       if (this.suppressed) {
-        this.browserPanelController.cancelOverlayPointerGesture();
+        this.browserPanelController.hostDisconnected();
       } else if (restored && this.browserPanelIsOpen()) {
         void this.browserPanelController.refreshAll();
       }
@@ -281,7 +281,7 @@ class OpenClawBrowserPanel extends OpenClawLitElement implements BrowserPanelCon
   }
 
   private closePanel(): void {
-    this.browserPanelController.cancelOverlayPointerGesture();
+    this.browserPanelController.hostDisconnected();
     this.dockLayout.setOpen(false);
   }
 

--- a/ui/src/components/browser/browser-screencast-client.test.ts
+++ b/ui/src/components/browser/browser-screencast-client.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { BrowserScreencastClient } from "./browser-screencast-client.ts";
+import { screencastFrame, TestScreencastSocket } from "./browser-screencast-test-support.ts";
+
+function connect() {
+  const socket = new TestScreencastSocket("");
+  const createSocket = vi.fn(() => socket as unknown as WebSocket);
+  const callbacks = { onReady: vi.fn(), onMeta: vi.fn(), onFrame: vi.fn(), onClose: vi.fn() };
+  const client = new BrowserScreencastClient(
+    {
+      gatewayUrl: "https://gateway.example.test/chat",
+      wsPath: "/browser/screencast?token=abc",
+      ...callbacks,
+    },
+    createSocket,
+  );
+  return { socket, createSocket, callbacks, client };
+}
+
+describe("BrowserScreencastClient", () => {
+  it("resolves the gateway socket and decodes metadata and JPEG bytes", async () => {
+    const { socket, createSocket, callbacks, client } = connect();
+    expect(createSocket).toHaveBeenCalledWith(
+      "wss://gateway.example.test/browser/screencast?token=abc",
+    );
+    expect(socket.binaryType).toBe("arraybuffer");
+    socket.receive(
+      JSON.stringify({
+        type: "ready",
+        targetId: "raw-tab",
+        url: "https://example.test/page",
+        title: "Page",
+      }),
+    );
+    socket.receive(
+      JSON.stringify({ type: "meta", url: "https://example.test/next", title: "Next" }),
+    );
+    socket.receive(screencastFrame());
+    expect(callbacks.onReady).toHaveBeenCalledWith({
+      targetId: "raw-tab",
+      url: "https://example.test/page",
+      title: "Page",
+    });
+    expect(callbacks.onMeta).toHaveBeenCalledWith({
+      url: "https://example.test/next",
+      title: "Next",
+    });
+    const [frame] = callbacks.onFrame.mock.calls[0]!;
+    expect(frame).toMatchObject({
+      url: "https://example.test/page",
+      cssWidth: 100,
+      cssHeight: 100,
+    });
+    expect(frame.blob.type).toBe("image/jpeg");
+    expect(new Uint8Array(await frame.blob.arrayBuffer())).toEqual(
+      new Uint8Array([0xff, 0xd8, 0xff, 0xd9]),
+    );
+    client.close();
+    expect(socket.close).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    [4003, "navigation_blocked"],
+    [4004, "target_closed"],
+    [1012, "gateway shutting down"],
+  ])("preserves close code %i and reason", (code, reason) => {
+    const { socket, callbacks } = connect();
+    socket.disconnect(code, reason);
+    socket.receive(screencastFrame());
+    expect(callbacks.onClose).toHaveBeenCalledExactlyOnceWith({ code, reason });
+    expect(callbacks.onFrame).not.toHaveBeenCalled();
+  });
+
+  it.each(["{", new ArrayBuffer(2), new Uint8Array([0, 0, 1, 0, 0]).buffer])(
+    "closes malformed input without forwarding a frame",
+    (wire) => {
+      const { socket, callbacks } = connect();
+      socket.receive(wire);
+      expect(callbacks.onClose).toHaveBeenCalledExactlyOnceWith({ code: 1002, reason: "" });
+      expect(socket.close).toHaveBeenCalledOnce();
+      expect(callbacks.onFrame).not.toHaveBeenCalled();
+    },
+  );
+
+  it("maps errors to a terminal failure and suppresses intentional-close callbacks", () => {
+    const failed = connect();
+    failed.socket.receive(JSON.stringify({ type: "error", error: "Unavailable" }));
+    failed.socket.disconnect(1011);
+    expect(failed.callbacks.onClose).toHaveBeenCalledExactlyOnceWith({ code: 1011, reason: "" });
+    const closed = connect();
+    closed.client.close();
+    closed.socket.disconnect(1000);
+    expect(closed.callbacks.onClose).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/browser/browser-screencast-client.ts
+++ b/ui/src/components/browser/browser-screencast-client.ts
@@ -1,0 +1,112 @@
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
+import { resolveGatewayWebSocketUrl } from "../../lib/gateway-websocket-url.ts";
+
+export type BrowserScreencastMeta = { url: string; title: string };
+export type BrowserScreencastFrame = {
+  blob: Blob;
+  url: string;
+  cssWidth: number;
+  cssHeight: number;
+};
+
+type BrowserScreencastOptions = {
+  gatewayUrl: string;
+  wsPath: string;
+  onReady: (meta: BrowserScreencastMeta & { targetId: string }) => void;
+  onMeta: (meta: BrowserScreencastMeta) => void;
+  onFrame: (frame: BrowserScreencastFrame) => void;
+  onClose: (detail: { code: number; reason: string }) => void;
+};
+
+export class BrowserScreencastClient {
+  private readonly socket: WebSocket;
+  private closed = false;
+
+  constructor(
+    private readonly options: BrowserScreencastOptions,
+    createWebSocket: (url: string) => WebSocket = (url) => new WebSocket(url),
+  ) {
+    this.socket = createWebSocket(resolveGatewayWebSocketUrl(options.wsPath, options.gatewayUrl));
+    this.socket.binaryType = "arraybuffer";
+    this.socket.addEventListener("message", (event) => this.receive(event.data));
+    this.socket.addEventListener("close", ({ code, reason }) => this.finish(code, reason));
+    this.socket.addEventListener("error", () => {
+      this.finish(1006, "");
+      this.socket.close();
+    });
+  }
+
+  close(): void {
+    this.closed = true;
+    this.socket.close();
+  }
+
+  private finish(code: number, reason: string): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.options.onClose({ code, reason });
+  }
+
+  private receive(data: unknown): void {
+    if (this.closed) {
+      return;
+    }
+    try {
+      if (typeof data === "string") {
+        const message = asRecord(JSON.parse(data));
+        if (message?.type === "error") {
+          this.finish(1011, "");
+          this.socket.close();
+          return;
+        }
+        if (typeof message?.url !== "string" || typeof message.title !== "string") {
+          throw new Error("Invalid screencast metadata");
+        }
+        if (message.type === "ready" && typeof message.targetId === "string") {
+          this.options.onReady({
+            targetId: message.targetId,
+            url: message.url,
+            title: message.title,
+          });
+        } else if (message.type === "meta") {
+          this.options.onMeta({ url: message.url, title: message.title });
+        } else {
+          throw new Error("Invalid screencast message");
+        }
+        return;
+      }
+      if (!(data instanceof ArrayBuffer) || data.byteLength < 5) {
+        throw new Error("Invalid screencast frame");
+      }
+      const headerLength = new DataView(data).getUint32(0);
+      if (headerLength === 0 || headerLength >= data.byteLength - 4) {
+        throw new Error("Invalid screencast header length");
+      }
+      const header = asRecord(
+        JSON.parse(new TextDecoder().decode(new Uint8Array(data, 4, headerLength))),
+      );
+      if (
+        typeof header?.url !== "string" ||
+        typeof header.cssWidth !== "number" ||
+        !Number.isFinite(header.cssWidth) ||
+        header.cssWidth <= 0 ||
+        typeof header.cssHeight !== "number" ||
+        !Number.isFinite(header.cssHeight) ||
+        header.cssHeight <= 0
+      ) {
+        throw new Error("Invalid screencast dimensions");
+      }
+      this.options.onFrame({
+        blob: new Blob([new Uint8Array(data, 4 + headerLength)], { type: "image/jpeg" }),
+        url: header.url,
+        cssWidth: header.cssWidth,
+        cssHeight: header.cssHeight,
+      });
+    } catch {
+      this.finish(1002, "");
+      this.socket.close();
+    }
+  }
+}

--- a/ui/src/components/browser/browser-screencast-test-support.ts
+++ b/ui/src/components/browser/browser-screencast-test-support.ts
@@ -1,0 +1,33 @@
+import { vi } from "vitest";
+
+export class TestScreencastSocket extends EventTarget {
+  binaryType = "blob";
+  readonly close = vi.fn();
+
+  constructor(readonly url: string) {
+    super();
+  }
+
+  receive(data: string | ArrayBuffer): void {
+    this.dispatchEvent(new MessageEvent("message", { data }));
+  }
+
+  disconnect(code: number, reason = ""): void {
+    this.dispatchEvent(new CloseEvent("close", { code, reason }));
+  }
+}
+
+export function screencastFrame(
+  url = "https://example.test/page",
+  width = 100,
+  height = 100,
+): ArrayBuffer {
+  const header = new TextEncoder().encode(
+    JSON.stringify({ url, cssWidth: width, cssHeight: height, scrollX: 0, scrollY: 0, ts: 1 }),
+  );
+  const bytes = new Uint8Array(4 + header.length + 4);
+  new DataView(bytes.buffer).setUint32(0, header.length);
+  bytes.set(header, 4);
+  bytes.set([0xff, 0xd8, 0xff, 0xd9], 4 + header.length);
+  return bytes.buffer;
+}

--- a/ui/src/components/desktop/desktop-client.ts
+++ b/ui/src/components/desktop/desktop-client.ts
@@ -1,3 +1,5 @@
+import { resolveGatewayWebSocketUrl } from "../../lib/gateway-websocket-url.ts";
+
 export type DesktopDisconnectDetail = {
   clean: boolean;
   code?: number;
@@ -56,25 +58,6 @@ const loadDefaultRfb: RfbLoader = async () => {
   return module.default;
 };
 
-function resolveDesktopWebSocketUrl(wsUrl: string, gatewayUrl = globalThis.location?.href): string {
-  const base = new URL(gatewayUrl ?? globalThis.location.href, globalThis.location?.href);
-  if (base.protocol === "http:") {
-    base.protocol = "ws:";
-  } else if (base.protocol === "https:") {
-    base.protocol = "wss:";
-  }
-  const resolved = new URL(wsUrl, base);
-  if (resolved.protocol === "http:") {
-    resolved.protocol = "ws:";
-  } else if (resolved.protocol === "https:") {
-    resolved.protocol = "wss:";
-  }
-  if (resolved.protocol !== "ws:" && resolved.protocol !== "wss:") {
-    throw new Error("Desktop observer URL must use WebSocket transport");
-  }
-  return resolved.toString();
-}
-
 /** Thin owner for one noVNC RFB lifecycle. */
 export class DesktopClient {
   constructor(
@@ -85,7 +68,7 @@ export class DesktopClient {
 
   async connect(options: DesktopConnectOptions): Promise<DesktopConnectionHandle> {
     const Rfb = this.rfbConstructor ?? (await this.loadRfb());
-    const wsUrl = resolveDesktopWebSocketUrl(options.wsUrl, options.gatewayUrl);
+    const wsUrl = resolveGatewayWebSocketUrl(options.wsUrl, options.gatewayUrl);
     // The socket claims control before RFB authentication; canceled lazy loads must not open it.
     if (!options.isCurrent()) {
       throw new DOMException("Desktop connection is no longer current", "AbortError");

--- a/ui/src/e2e/browser-route-handoff.e2e.test.ts
+++ b/ui/src/e2e/browser-route-handoff.e2e.test.ts
@@ -97,6 +97,16 @@ suite.define(() => {
                     },
                   },
                   {
+                    match: { path: "/screencast" },
+                    response: {
+                      __mockError: {
+                        code: "UNAVAILABLE",
+                        message: "Browser screencast requires Playwright in this gateway build.",
+                        details: { code: "SCREENCAST_UNSUPPORTED", reason: "playwright" },
+                      },
+                    },
+                  },
+                  {
                     match: { path: "/screenshot" },
                     response: { path: "/proof/default.png", targetId: "default-tab" },
                   },

--- a/ui/src/lib/gateway-websocket-url.ts
+++ b/ui/src/lib/gateway-websocket-url.ts
@@ -1,0 +1,21 @@
+export function resolveGatewayWebSocketUrl(
+  wsUrl: string,
+  gatewayUrl = globalThis.location?.href,
+): string {
+  const base = new URL(gatewayUrl ?? globalThis.location.href, globalThis.location?.href);
+  if (base.protocol === "http:") {
+    base.protocol = "ws:";
+  } else if (base.protocol === "https:") {
+    base.protocol = "wss:";
+  }
+  const resolved = new URL(wsUrl, base);
+  if (resolved.protocol === "http:") {
+    resolved.protocol = "ws:";
+  } else if (resolved.protocol === "https:") {
+    resolved.protocol = "wss:";
+  }
+  if (resolved.protocol !== "ws:" && resolved.protocol !== "wss:") {
+    throw new Error("Gateway stream URL must use WebSocket transport");
+  }
+  return resolved.toString();
+}


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Control UI Browser panel felt slow and stale: it showed the agent's browser as one-off screenshots, each refresh costing three gateway round trips (a screenshot written to the media store, an HTTP fetch of that PNG, and an evaluate call for viewport metrics), and it only refreshed after a user action, so page loads that finished a moment later never appeared.

An iframe is not a viable alternative: most sites block embedding with `X-Frame-Options` / `frame-ancestors`, and an iframe would be a separate browser with its own cookies rather than the agent's browser.

## Why This Change Was Made

The browser plugin now streams the active tab with Chrome's own `Page.startScreencast`. `POST /screencast` (via `browser.request`) validates the tab exactly like `/screenshot` and mints a one-time 60 s token; the panel opens a plugin-owned binary WebSocket at `/browser/screencast?token=…` and receives JPEG frames only when the page repaints, ack-paced to about 20 fps, with slow viewers skipping frames instead of queueing.

Navigation policy keeps parity with screenshots: each approved document gets its own CDP session. A main-frame navigation retires the capture synchronously and a new session starts only after the address passes the navigation policy, so frames of a rejected document can never reach a viewer (Chromium encodes frames asynchronously, so a plain stop/restart would not close that race). A rejected navigation closes the stream with `4003 navigation_blocked`; the panel shows the existing blocked-tab state. Sessions end when the page closes, the last viewer leaves, the profile lifecycle changes, or the gateway shuts down. Gateway-minted tickets and individual viewers also follow the requesting Gateway connection: disconnect or revocation deletes pending tickets and closes that requester’s viewers with `4006 authority_revoked`, without interrupting other live viewers sharing capture. Minting for an ended requester returns HTTP 401 / `SCREENCAST_REQUESTER_GONE`. Loopback HTTP control-API tickets retain the documented TTL-only boundary.

The screenshot path stays as an automatic fallback for node-routed browsers, Chrome MCP existing-session profiles, missing Playwright, and stream failures. Stream frames own the view while live, a late screenshot never overwrites a newer frame, and only failed attempts back off, so URL-bar navigation and resizes restart the stream immediately. Malformed mint replies also fall back to screenshots. Annotate and Inspect pin the capture image and URL while holding the latest incoming frame, which is published when capture mode ends. Node-side streaming for paired-node browsers is a follow-up.

## User Impact

The Browser panel now shows the agent's browser live: page loads, scrolling, and clicks render as they happen instead of after the next action, and idle pages cost no bandwidth. Existing interactions (click, type, scroll, annotate, inspect) work unchanged on top of the live frames. Docs: `docs/tools/browser.md` (panel behavior) and `docs/tools/browser-control.md` (route, wire format, close codes).

## Evidence

Live proof on an isolated gateway with the managed headless profile (Playwright-driven Control UI):

- Stream live on example.com over `ws://…/browser/screencast`; URL-bar navigation to iana.org followed via frames with **zero** `assistant-media` (screenshot) fetches for the whole session.
- A page-initiated navigation to a private loopback address closed the stream with `4003` and the tab showed the blocked state.

![Browser panel streaming iana.org live after a URL-bar navigation](https://github.com/user-attachments/assets/a0456fb5-d956-4439-87dc-a0537ccfacfc)

![Blocked-tab state after a policy-rejected in-page navigation closed the stream](https://github.com/user-attachments/assets/d7ea8796-634e-4201-954c-7e6fd35eead5)

Tests and checks:

- Plugin: `node scripts/run-vitest.mjs extensions/browser/src/browser/screencast extensions/browser/src/browser/routes/agent.screencast.test.ts extensions/browser/src/gateway/browser-request.profile-from-body.test.ts extensions/browser/plugin-registration.shutdown.test.ts` → 77 passed, 1 skipped (chromium-gated).
- Chromium e2e (`OPENCLAW_BROWSER_SCREENCAST_E2E=1`, Google Chrome): JPEG `FF D8`, header CSS size equals `window.innerWidth/innerHeight`, page close → `4004 target_closed`.
- Regression `never forwards delayed blocked-document pixels after a later allowed navigation` fails on the pre-fix session module and passes after.
- UI: `node scripts/run-vitest.mjs ui/src/components/browser` → 139 passed.
- `node scripts/check-changed.mjs`: 28 lanes ok; the extension-lint lane cannot run inside a nested worktree (its declaration-boundary preflight resolves the parent checkout's `node_modules`), so it ran from a neutral checkout with the same diff → clean.
- Codex autoreview (P0/P1): scoped-clean after the session-rotation fix.


Review-fix validation for `1a46746cad7`:

- Focused browser/plugin, browser UI, and route-handoff e2e suites: 246 passed, with the Chromium-gated test run separately and passing. The standalone route-handoff rerun also passed all 4 tests.
- Regression coverage reproduced the missing requester revocation, capture pinning, and malformed-response behavior before the fixes. Requester tests cover pending-token deletion, ended-requester mint refusal, and independent viewer revocation while another viewer continues receiving frames. Live proof reported in the landing handoff covers the `4003 navigation_blocked` and `4006 authority_revoked` paths.
- The route-handoff mock now explicitly returns `SCREENCAST_UNSUPPORTED`; the client rejects malformed mint replies before opening a WebSocket.
- Changed-file checks passed except for the known nested-worktree declaration-boundary environment error. The affected extension lint passed in a separate byte-verified neutral checkout, and the remaining guards passed separately.
- Final Codex autoreview through P2: scoped-clean, with no actionable findings and no subsequent product edits.

These changes use in-memory session, token, and viewer state; they introduce no persistent schema or stored-data migration.
