### PR TITLE
fix: restore local password auth for trusted-proxy gateway status

### DIFF
--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -1622,29 +1622,113 @@ describe("gatherDaemonStatus", () => {
     );
   });
 
-  it("resolves daemon gateway auth password SecretRef values before probing", async () => {
-    daemonLoadedConfig = {
-      gateway: {
-        bind: "lan",
-        tls: { enabled: true },
-        auth: {
-          password: { source: "env", provider: "default", id: "DAEMON_GATEWAY_PASSWORD" },
+  it.each([undefined, "password", "trusted-proxy"] as const)(
+    "resolves daemon gateway auth password SecretRef values before probing in %s mode",
+    async (mode) => {
+      daemonLoadedConfig = {
+        gateway: {
+          bind: "lan",
+          tls: { enabled: true },
+          auth: {
+            mode,
+            password: { source: "env", provider: "default", id: "DAEMON_GATEWAY_PASSWORD" },
+          },
         },
-      },
-      secrets: {
-        providers: {
-          default: { source: "env" },
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
         },
-      },
-    };
-    setTestEnvValue("DAEMON_GATEWAY_PASSWORD", "daemon-secretref-password"); // pragma: allowlist secret
+      };
+      setTestEnvValue("DAEMON_GATEWAY_PASSWORD", "daemon-secretref-password"); // pragma: allowlist secret
 
-    await gatherStatus();
+      await gatherStatus();
 
-    expect((callArg(callGatewayStatusProbe) as { password?: string }).password).toBe(
-      "daemon-secretref-password",
-    ); // pragma: allowlist secret
-  });
+      expect((callArg(callGatewayStatusProbe) as { password?: string }).password).toBe(
+        "daemon-secretref-password",
+      ); // pragma: allowlist secret
+    },
+  );
+
+  it.each([false, true])(
+    "authenticates a trusted-proxy status probe with its file password (requireRpc=%s)",
+    async (requireRpc) => {
+      const actualProbe = await vi.importActual<typeof import("./probe.js")>("./probe.js");
+      const originalProbe = callGatewayStatusProbe.getMockImplementation();
+      assert(originalProbe);
+      const password = "synthetic-local-status-password";
+      const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+      const authenticated: boolean[] = [];
+      const methods: string[] = [];
+      wss.on("connection", (ws) => {
+        sendMinimalGatewayConnectChallenge(ws);
+        ws.on("message", (raw) => {
+          const frame = parseMinimalGatewayRequestFrame(raw);
+          if (!frame.id) {
+            return;
+          }
+          if (frame.method === "connect") {
+            const accepted = Reflect.get(frame.params?.auth ?? {}, "password") === password;
+            authenticated.push(accepted);
+            if (!accepted) {
+              ws.close(1008, "password required");
+              return;
+            }
+            sendMinimalGatewayResponse(
+              ws,
+              frame.id,
+              buildMinimalGatewayHelloOkPayload({
+                auth: { role: "operator", scopes: ["operator.read"] },
+              }),
+            );
+          } else if (frame.method === "status") {
+            methods.push(frame.method);
+            sendMinimalGatewayResponse(ws, frame.id, {});
+          }
+        });
+      });
+      callGatewayStatusProbe.mockImplementation(actualProbe.probeGatewayStatus);
+      try {
+        await new Promise<void>((resolve) => wss.once("listening", resolve));
+        const address = wss.address();
+        assert(address && typeof address !== "string");
+        await withStatusConfig(undefined, async (configPath) => {
+          const passwordPath = path.join(path.dirname(configPath), "gateway-password");
+          await fs.writeFile(passwordPath, password, { mode: 0o600 });
+          await fs.writeFile(
+            configPath,
+            JSON.stringify({
+              gateway: {
+                mode: "local",
+                bind: "loopback",
+                port: address.port,
+                auth: {
+                  mode: "trusted-proxy",
+                  password: { source: "file", provider: "local", id: "value" },
+                },
+                remote: { url: "wss://unrelated.example", password: "unrelated-password" },
+              },
+              secrets: {
+                providers: { local: { source: "file", path: passwordPath, mode: "singleValue" } },
+              },
+            }),
+          );
+          const result = await gatherStatus({
+            rpc: { port: String(address.port), json: true, timeout: "2000" },
+            requireRpc,
+          });
+          expect(result.rpc?.ok, result.rpc?.error).toBe(true);
+          expect(authenticated).toEqual([true]);
+          expect(methods).toEqual(requireRpc ? ["status"] : []);
+          expect(JSON.stringify(result)).not.toContain(password);
+        });
+      } finally {
+        callGatewayStatusProbe.mockImplementation(originalProbe);
+        await closeMinimalGatewayServer(wss);
+        resetSecretRedactionRegistryForTest();
+      }
+    },
+  );
 
   it("resolves daemon gateway auth token SecretRef values before probing", async () => {
     daemonLoadedConfig = {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -494,10 +494,7 @@ export async function gatherDaemonStatus(
       });
     if (probeUrlOverride || explicitAuth.token || explicitAuth.password) {
       daemonProbeAuth = explicitAuth;
-    } else if (
-      daemonCfg.gateway?.auth?.mode === "none" ||
-      daemonCfg.gateway?.auth?.mode === "trusted-proxy"
-    ) {
+    } else if (daemonCfg.gateway?.auth?.mode === "none") {
       daemonProbeAuth = {};
     } else if (canResolveProbeAuth) {
       const probeAuthResolution = await loadGatewayProbeAuthModule().then(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw gateway status` reports an authentication failure for a healthy local Gateway using trusted-proxy authentication with an existing local password. Managed update verification can consequently time out and roll back even while normal Gateway RPC calls succeed.

## Why This Change Was Made

Status now lets the existing credential resolver load the service's local password, including file and environment SecretRefs. The status-specific shortcut introduced in #135862 incorrectly grouped trusted-proxy with auth mode `none`, discarding the documented password path for same-host clients.

The change removes that shortcut for trusted-proxy. Service-derived target isolation, explicit-URL credential rules, read-only diagnostics, and Gateway authorization policies remain intact.

## User Impact

Operators can verify their trusted-proxy Gateway through its existing local password without copying credentials into command arguments or changing authentication policy.

## Evidence

- Before the production fix, the trusted-proxy environment SecretRef regression failed with an undefined password; both real WebSocket probes using a synthetic file SecretRef failed with close code 1008 (`password required`). The neighboring password/unspecified-mode cases passed.
- After the fix, 136 tests passed across `status.gather.test.ts`, `probe.test.ts`, and `probe.reachability.test.ts`. These include default connectivity and `--require-rpc` wire behavior, existing TLS/explicit-target isolation, no pairing writes, and an isolated real Gateway authentication-rejection/recovery test.
- The synthetic file credential is stored with mode 0600, delivered to the selected loopback peer, and absent from serialized status output. The fixture exercises actual status gathering, SecretRef resolution, client connection, and read RPC; it does not simulate a proxy identity.
- The existing local-direct password contract is documented in `docs/gateway/trusted-proxy-auth.md` and enforced by `src/gateway/auth.ts`. No configuration or server-policy change is included.
