### PR TITLE
fix(cron): persist platform-appropriate shell wrapper for command jobs

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -1024,6 +1024,62 @@ describe("cron cli", () => {
     expect(params?.delivery?.mode).toBe("none");
   });
 
+  it("wraps shell-string commands for the gateway platform reported by system.info", async () => {
+    resetGatewayMock();
+    callGatewayFromCli.mockImplementation(
+      async (method: string, _opts: unknown, params?: unknown) => {
+        if (method === "system.info") {
+          return { platform: "linux" };
+        }
+        return { ok: true, params };
+      },
+    );
+    const program = buildProgram();
+    await program.parseAsync(
+      ["cron", "add", "--name", "Remote posix gateway", "--every", "10m", "--command", "echo ok"],
+      { from: "user" },
+    );
+
+    const params = getGatewayCallParams<CronAddParams>("cron.add");
+    expect(params?.payload?.kind).toBe("command");
+    expect(params?.payload?.argv).toEqual(["sh", "-lc", "echo ok"]);
+  });
+
+  it("wraps shell-string commands with cmd.exe for a win32 gateway", async () => {
+    resetGatewayMock();
+    callGatewayFromCli.mockImplementation(
+      async (method: string, _opts: unknown, params?: unknown) => {
+        if (method === "system.info") {
+          return { platform: "win32" };
+        }
+        return { ok: true, params };
+      },
+    );
+    const program = buildProgram();
+    await program.parseAsync(
+      ["cron", "add", "--name", "Remote windows gateway", "--every", "10m", "--command", "echo ok"],
+      { from: "user" },
+    );
+
+    const params = getGatewayCallParams<CronAddParams>("cron.add");
+    expect(params?.payload?.argv).toEqual(["cmd.exe", "/d", "/s", "/c", "echo ok"]);
+  });
+
+  it("falls back to the local platform when system.info is unavailable", async () => {
+    // defaultGatewayMock answers non-cron methods with { ok: true, params } (no platform).
+
+    const params = await runCronAddAndGetParams([
+      "--name",
+      "Legacy gateway",
+      "--every",
+      "10m",
+      "--command",
+      "echo ok",
+    ]);
+
+    expect(params?.payload?.argv).toEqual(buildCronCommandShellArgv("echo ok"));
+  });
+
   it("creates stream schedules from exact argv flags", async () => {
     await runCronCommand([
       "cron",

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -1,6 +1,7 @@
 // Cron CLI tests cover cron command registration and schedule output.
 import { Command } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildCronCommandShellArgv } from "../cron/command-shell-argv.js";
 import type { CronJob } from "../cron/types.js";
 import { ExitError } from "../runtime.js";
 import { registerCronCli } from "./cron-cli.js";
@@ -1013,7 +1014,7 @@ describe("cron cli", () => {
     expect(params?.sessionTarget).toBe("isolated");
     expect(params?.payload).toMatchObject({
       kind: "command",
-      argv: ["sh", "-lc", "echo ok"],
+      argv: buildCronCommandShellArgv("echo ok"),
       cwd: "/srv/app",
       env: { FOO: "bar" },
       timeoutSeconds: 30,

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -6,6 +6,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { buildCronCommandShellArgv } from "../../cron/command-shell-argv.js";
 import type { CronJob } from "../../cron/types.js";
 import { normalizeHttpWebhookUrl } from "../../cron/webhook-url.js";
 import { sanitizeAgentId } from "../../routing/session-key.js";
@@ -219,7 +220,7 @@ export function registerCronAddCommand(cron: Command) {
                 }
                 return {
                   kind: "command" as const,
-                  argv: commandArgv ?? ["sh", "-lc", commandShell ?? ""],
+                  argv: commandArgv ?? buildCronCommandShellArgv(commandShell ?? ""),
                   cwd: normalizeOptionalString(opts.commandCwd),
                   env: parseCronCommandEnv(opts.commandEnv),
                   input: typeof opts.commandInput === "string" ? opts.commandInput : undefined,

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -27,6 +27,7 @@ import {
   parseCronToolsAllow,
   printCronJson,
   printCronList,
+  resolveGatewayPlatform,
   warnIfCronSchedulerDisabled,
 } from "./shared.js";
 import { normalizeCronSessionTargetOption, parseCronThreadIdOption } from "./thread-id-shared.js";
@@ -133,6 +134,10 @@ export function registerCronAddCommand(cron: Command) {
               throw new Error("Choose at most one of --announce, --no-deliver, or --webhook");
             }
 
+            // Shell-string payloads execute on the Gateway host, which may differ
+            // from this CLI machine; resolve the wrapper for that platform.
+            const gatewayPlatform =
+              opts.command === undefined ? undefined : await resolveGatewayPlatform(opts);
             const payload = (() => {
               // Main-session jobs use system events; isolated/current/session jobs use messages.
               const systemEvent = normalizeOptionalString(opts.systemEvent) ?? "";
@@ -220,7 +225,8 @@ export function registerCronAddCommand(cron: Command) {
                 }
                 return {
                   kind: "command" as const,
-                  argv: commandArgv ?? buildCronCommandShellArgv(commandShell ?? ""),
+                  argv:
+                    commandArgv ?? buildCronCommandShellArgv(commandShell ?? "", gatewayPlatform),
                   cwd: normalizeOptionalString(opts.commandCwd),
                   env: parseCronCommandEnv(opts.commandEnv),
                   input: typeof opts.commandInput === "string" ? opts.commandInput : undefined,

--- a/src/cli/cron-cli/register.cron-edit-options.ts
+++ b/src/cli/cron-cli/register.cron-edit-options.ts
@@ -4,11 +4,13 @@ import { buildCronCommandShellArgv } from "../../cron/command-shell-argv.js";
 import { isSystemMonitorDeclaration } from "../../cron/system-owned-declaration.js";
 import type { CronJob } from "../../cron/types.js";
 import { isSystemOwnedCronPayloadKind } from "../../cron/types.js";
+import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import {
   parseCronCommandArgv,
   parseCronCommandEnv,
   parseCronFallbacks,
   parseCronToolsAllow,
+  resolveGatewayPlatform,
 } from "./shared.js";
 import { parseCronThreadIdOption } from "./thread-id-shared.js";
 import { readCronPayloadScript } from "./trigger-options.js";
@@ -25,7 +27,7 @@ const assignIf = (
 };
 
 export async function resolveCronEditPayloadDeliveryPatch(
-  opts: Record<string, unknown>,
+  opts: GatewayRpcOpts & Record<string, unknown>,
   loadExistingJob: () => Promise<CronJob>,
   webhookUrl: string | undefined,
   commandCwd: string | undefined,
@@ -35,6 +37,9 @@ export async function resolveCronEditPayloadDeliveryPatch(
   const scriptPath = normalizeOptionalString(opts.script);
   const commandShell = normalizeOptionalString(opts.command);
   const commandArgv = parseCronCommandArgv(opts.commandArgv);
+  // Shell-string payloads execute on the Gateway host, which may differ from
+  // this CLI machine; resolve the wrapper for that platform.
+  const gatewayPlatform = commandShell ? await resolveGatewayPlatform(opts) : undefined;
   if (commandShell && commandArgv) {
     throw new Error("Pass command payload either with --command or --command-argv, not both.");
   }
@@ -242,7 +247,12 @@ export async function resolveCronEditPayloadDeliveryPatch(
   } else if (hasCommandPatch) {
     const payload: Record<string, unknown> = { kind: "command" };
     assignIf(payload, "argv", commandArgv, Boolean(commandArgv));
-    assignIf(payload, "argv", buildCronCommandShellArgv(commandShell ?? ""), Boolean(commandShell));
+    assignIf(
+      payload,
+      "argv",
+      buildCronCommandShellArgv(commandShell ?? "", gatewayPlatform),
+      Boolean(commandShell),
+    );
     assignIf(payload, "cwd", commandCwd, Boolean(commandCwd));
     assignIf(payload, "env", parseCronCommandEnv(opts.commandEnv), opts.commandEnv !== undefined);
     assignIf(payload, "input", opts.commandInput, hasCommandInput);

--- a/src/cli/cron-cli/register.cron-edit-options.ts
+++ b/src/cli/cron-cli/register.cron-edit-options.ts
@@ -1,5 +1,6 @@
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { buildCronCommandShellArgv } from "../../cron/command-shell-argv.js";
 import { isSystemMonitorDeclaration } from "../../cron/system-owned-declaration.js";
 import type { CronJob } from "../../cron/types.js";
 import { isSystemOwnedCronPayloadKind } from "../../cron/types.js";
@@ -241,7 +242,7 @@ export async function resolveCronEditPayloadDeliveryPatch(
   } else if (hasCommandPatch) {
     const payload: Record<string, unknown> = { kind: "command" };
     assignIf(payload, "argv", commandArgv, Boolean(commandArgv));
-    assignIf(payload, "argv", ["sh", "-lc", commandShell], Boolean(commandShell));
+    assignIf(payload, "argv", buildCronCommandShellArgv(commandShell ?? ""), Boolean(commandShell));
     assignIf(payload, "cwd", commandCwd, Boolean(commandCwd));
     assignIf(payload, "env", parseCronCommandEnv(opts.commandEnv), opts.commandEnv !== undefined);
     assignIf(payload, "input", opts.commandInput, hasCommandInput);

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -251,6 +251,21 @@ export const formatCronLookupMiss = (jobId: string) =>
     valueLabel: "automation id",
   });
 
+/**
+ * Resolve the execution Gateway's platform so shell-string payloads are wrapped
+ * for the host that will run them. Returns undefined when the Gateway does not
+ * expose it (older gateway, offline); callers then fall back to the local platform.
+ */
+export async function resolveGatewayPlatform(opts: GatewayRpcOpts): Promise<string | undefined> {
+  try {
+    // SAFETY: system.info responds with a gateway-info record; only platform is consumed.
+    const res = (await callGatewayFromCli("system.info", opts, {})) as { platform?: unknown };
+    return typeof res?.platform === "string" && res.platform.length > 0 ? res.platform : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function warnIfCronSchedulerDisabled(opts: GatewayRpcOpts) {
   // Old/offline gateways should not make successful cron mutations fail after the fact.
   try {

--- a/src/commands/doctor/cron/payload-migration.ts
+++ b/src/commands/doctor/cron/payload-migration.ts
@@ -10,6 +10,7 @@ import {
   parseCronAgentTurnCommandPrompt,
   type CronAgentTurnShellPromptKind,
 } from "../../../cron/agent-turn-command-prompt.js";
+import { buildCronCommandShellArgv } from "../../../cron/command-shell-argv.js";
 import { toCanonicalOpenAIModelRef } from "../shared/codex-route-model-ref.js";
 import {
   IMAGE_INSPECTION_TOOL_NAME_MIGRATION,
@@ -352,7 +353,7 @@ export function migrateLegacyAgentTurnCommandPayload(payload: UnknownRecord): bo
   }
 
   payload.kind = "command";
-  payload.argv = ["sh", "-lc", parsed.command];
+  payload.argv = buildCronCommandShellArgv(parsed.command);
   if (parsed.cwd) {
     payload.cwd = parsed.cwd;
   }

--- a/src/commands/doctor/cron/store-migration.test.ts
+++ b/src/commands/doctor/cron/store-migration.test.ts
@@ -3,6 +3,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import { resolveAgentHarnessPolicy } from "../../../agents/harness/policy.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { buildCronCommandShellArgv } from "../../../cron/command-shell-argv.js";
 import { legacyCodexProviderIdentityKey } from "../shared/codex-route-model-ref.js";
 import {
   IMAGE_INSPECTION_TOOL_NAME_MIGRATION,
@@ -617,7 +618,7 @@ describe("normalizeStoredCronJobs", () => {
     const payload = expectDefined(job, "job test invariant").payload as Record<string, unknown>;
     expect(payload).toEqual({
       kind: "command",
-      argv: ["sh", "-lc", command],
+      argv: buildCronCommandShellArgv(command),
       cwd: "/home/openclaw/.razor/quant",
       timeoutSeconds: 900,
     });

--- a/src/cron/command-shell-argv.test.ts
+++ b/src/cron/command-shell-argv.test.ts
@@ -1,0 +1,21 @@
+// Cron command payloads must persist a shell wrapper that can actually run on
+// the gateway host platform; see register.cron-add and doctor payload migration.
+import { describe, expect, it } from "vitest";
+import { buildCronCommandShellArgv } from "./command-shell-argv.js";
+
+describe("buildCronCommandShellArgv", () => {
+  it("wraps commands in cmd.exe for win32 targets", () => {
+    expect(buildCronCommandShellArgv("echo hi", "win32")).toEqual([
+      "cmd.exe",
+      "/d",
+      "/s",
+      "/c",
+      "echo hi",
+    ]);
+  });
+
+  it("keeps the POSIX sh wrapper for non-win32 targets", () => {
+    expect(buildCronCommandShellArgv("echo hi", "linux")).toEqual(["sh", "-lc", "echo hi"]);
+    expect(buildCronCommandShellArgv("echo hi", "darwin")).toEqual(["sh", "-lc", "echo hi"]);
+  });
+});

--- a/src/cron/command-shell-argv.ts
+++ b/src/cron/command-shell-argv.ts
@@ -1,0 +1,12 @@
+// Builds the platform shell wrapper persisted for cron command payloads. Jobs
+// execute through the platform default shell on the gateway host, mirroring
+// buildNodeShellCommand for Node-driven command execution.
+export function buildCronCommandShellArgv(
+  command: string,
+  platform: string = process.platform,
+): string[] {
+  if (platform === "win32") {
+    return ["cmd.exe", "/d", "/s", "/c", command];
+  }
+  return ["sh", "-lc", command];
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who create cron command jobs on a Windows gateway would see every run fail permanently with `spawn sh ENOENT` when `sh.exe` is not on PATH (the default for Git for Windows installs), and silently inconsistent shell semantics when it is. Affected surfaces: `openclaw cron add`, `openclaw cron edit`, and doctor's legacy payload migration.

## Why This Change Was Made

Command job payloads persisted a hardcoded POSIX wrapper (`["sh", "-lc", ...]`) on every platform. The persisted wrapper now follows the platform of the **execution Gateway**, not the CLI machine:

- `cron add` / `cron edit` resolve the Gateway platform via the existing `system.info` RPC (`resolveGatewayPlatform` in `shared.ts`), falling back to the local platform when the Gateway does not expose it (older gateway / offline). The extra RPC only happens when `--command` is passed.
- Doctor's legacy payload migration runs on the Gateway host itself, so `process.platform` there is already the execution platform.
- Explicit `--command-argv` payloads are preserved verbatim; only shell-string commands get a wrapper.

## User Impact

- Windows gateways: cron command jobs persist `["cmd.exe", "/d", "/s", "/c", <command>]` and run successfully.
- Windows clients managing a POSIX gateway (and POSIX clients managing a Windows gateway): the wrapper matches the remote host again.
- Existing jobs persisted with the old hardcoded argv are not rewritten automatically (persisted `argv` is indistinguishable from explicit `--command-argv`); they already fail closed with ENOENT, so nothing regresses. Recovery is one command per affected job: `openclaw cron edit <id> --command "<command>"`, which re-persists the correct wrapper.

## Evidence

Fixes #141038.

After-fix real execution on Windows 11 (local gateway, isolated state dir — stored argv, then a manual run through the Gateway command runner):

```
$ openclaw cron add --name proof-clean --every 1h --command "echo cron-proof-ok" --no-deliver
  "id": "5b3ef720-…",
  "argv": [ "cmd.exe", "/d", "/s", "/c", "echo cron-proof-ok" ]

$ openclaw cron runs 5b3ef720-…
  "message": "command ok: \"cmd.exe\" \"/d\" \"/s\" \"/c\" \"echo cron-proof-ok\"",
  "exitCode": 0,
  "durationMs": 68
```

Cross-platform behavior is covered by new CLI tests (Gateway platform mocked via `system.info`): a Gateway reporting `linux` persists `["sh", "-lc", …]`, one reporting `win32` persists the `cmd.exe` wrapper, and an unresponsive `system.info` falls back to the local platform. `vitest`: 356 tests green on Windows across `cron-cli`, `register.cron-edit`, `command-shell-argv`, `store-migration`; `node scripts/check-changed.mjs` lanes green except the pre-existing `scripts/` dead-export findings on `main`.
