### PR TITLE
fix(xai): preserve image history prefixes on compatibility routes

### DIFF
--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -687,6 +687,12 @@ stale context metadata on active 4.20 rows. It does not pin active 4.20
   <Accordion title="Advanced notes">
     - OpenClaw applies xAI-specific tool-schema and tool-call compatibility
       fixes automatically on the shared runner path.
+    - Native `https://api.x.ai/v1` Responses requests keep tool images attached
+      to their tool results. On compatibility routes (including Grok OAuth),
+      image-capable models receive a labeled user image message immediately
+      after each consecutive tool-result group. Parallel results stay together,
+      and later turns preserve the historical image position for prompt caching.
+      Compaction establishes a new history prefix and result numbering.
     - Native xAI requests default `tool_stream: true`. Set
       `agents.defaults.models["xai/<model>"].params.tool_stream` to `false`
       to disable it.

--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -668,6 +668,82 @@ describe("xai stream wrappers", () => {
     ]);
   });
 
+  it.each([false, true])(
+    "keeps compatibility image history as a prefix across turns (parallel: %s)",
+    (parallel) => {
+      const image = { type: "input_image", image_url: "data:image/png;base64,QUJDRA==" };
+      const result = {
+        type: "function_call_output",
+        call_id: "call_image",
+        output: [{ type: "input_text", text: "Read image" }, image],
+      };
+      const group = [
+        result,
+        ...(parallel
+          ? [{ type: "function_call_output", call_id: "call_text", output: "No image" }]
+          : []),
+      ];
+      const history = [
+        { type: "message", role: "user", content: "Read the files" },
+        { type: "function_call", call_id: "call_image", name: "read", arguments: "{}" },
+        ...(parallel
+          ? [{ type: "function_call", call_id: "call_text", name: "read", arguments: "{}" }]
+          : []),
+        ...group,
+      ];
+      const project = (input: Array<Record<string, unknown>>) => {
+        const payload = { input: structuredClone(input) };
+        runXaiToolPayloadWrapper({ payload, input: ["text", "image"] });
+        return payload.input;
+      };
+      const first = project(history);
+      const nextTurns = [
+        { type: "message", role: "assistant", content: "I read the files." },
+        { type: "message", role: "user", content: "Read another image" },
+        { type: "function_call", call_id: "call_next", name: "read", arguments: "{}" },
+        { ...result, call_id: "call_next" },
+      ];
+      const next = project([...history, ...nextTurns]);
+
+      // Compare the actual serialized message prefix, including the image bytes.
+      expect(JSON.stringify(next.slice(0, first.length))).toBe(JSON.stringify(first));
+      expect(first.slice(-group.length - 1)).toEqual([
+        { ...result, output: "Read image" },
+        ...(parallel ? [group[1]] : []),
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Image(s) from tool result #1:" }, image],
+        },
+      ]);
+      expect(next.at(-1)).toEqual({
+        type: "message",
+        role: "user",
+        content: [
+          { type: "input_text", text: `Image(s) from tool result #${group.length + 1}:` },
+          image,
+        ],
+      });
+      expect(project(next)).toEqual(next);
+
+      // Compaction replaces old history; the retained tail establishes a fresh prefix.
+      const compactedHistory = [
+        { type: "message", role: "user", content: "Summary: the first files were read." },
+        ...nextTurns,
+      ];
+      const compacted = project(compactedHistory);
+      expect(compacted.at(-1)).toEqual(first.at(-1));
+      expect(compacted).toHaveLength(compactedHistory.length + 1);
+      expect(
+        project([
+          ...compactedHistory,
+          { type: "message", role: "assistant", content: "The next image is blue." },
+          { type: "message", role: "user", content: "Thanks" },
+        ]).slice(0, compacted.length),
+      ).toEqual(compacted);
+    },
+  );
+
   it("replays source-based input_image parts from tool results", () => {
     const payload: Record<string, unknown> = {
       input: [

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -173,50 +173,51 @@ function normalizeXaiResponsesToolResultPayload(
   }
 
   const includeImages = Array.isArray(model.input) && model.input.includes("image");
-  const imageContentParts: Array<Record<string, unknown>> = [];
+  let imageContentParts: Array<Record<string, unknown>> = [];
   let toolResultIndex = 0;
-  const normalizedInput = payloadObj.input.map((item: unknown) => {
+  const normalizedInput = payloadObj.input.flatMap((item: unknown, index, input) => {
     const itemObj = asOptionalRecord(item);
     if (itemObj?.type !== "function_call_output") {
-      return item;
+      return [item];
     }
     // String outputs also occupy a result position, even though they carry no images.
     toolResultIndex += 1;
-    if (!Array.isArray(itemObj.output)) {
-      return item;
-    }
-
-    const outputParts = itemObj.output as Array<Record<string, unknown>>;
-    let textOutput = "";
-    const imageStart = imageContentParts.length;
-    for (const part of outputParts) {
-      if (part.type === "input_text" && typeof part.text === "string") {
-        textOutput += part.text;
-      }
-      if (includeImages && isReplayableInputImagePart(part)) {
-        // Emit one ownership label before this result's first replayable image.
-        if (imageContentParts.length === imageStart) {
-          imageContentParts.push({
-            type: "input_text",
-            text: `Image(s) from tool result #${toolResultIndex}:`,
-          });
+    let normalizedItem = item;
+    if (Array.isArray(itemObj.output)) {
+      const outputParts = itemObj.output as Array<Record<string, unknown>>;
+      let textOutput = "";
+      const imageStart = imageContentParts.length;
+      for (const part of outputParts) {
+        if (part.type === "input_text" && typeof part.text === "string") {
+          textOutput += part.text;
         }
-        imageContentParts.push(part);
+        if (includeImages && isReplayableInputImagePart(part)) {
+          // Emit one ownership label before this result's first replayable image.
+          if (imageContentParts.length === imageStart) {
+            imageContentParts.push({
+              type: "input_text",
+              text: `Image(s) from tool result #${toolResultIndex}:`,
+            });
+          }
+          imageContentParts.push(part);
+        }
       }
+      normalizedItem = {
+        ...itemObj,
+        output: textOutput || describeXaiFunctionOutputMediaPlaceholder(outputParts) || "",
+      };
     }
-    return {
-      ...itemObj,
-      output: textOutput || describeXaiFunctionOutputMediaPlaceholder(outputParts) || "",
-    };
+    // Keep parallel outputs together, then anchor their images before later history.
+    if (
+      imageContentParts.length === 0 ||
+      asOptionalRecord(input[index + 1])?.type === "function_call_output"
+    ) {
+      return [normalizedItem];
+    }
+    const carrier = { type: "message", role: "user", content: imageContentParts };
+    imageContentParts = [];
+    return [normalizedItem, carrier];
   });
-
-  if (imageContentParts.length > 0) {
-    normalizedInput.push({
-      type: "message",
-      role: "user",
-      content: imageContentParts,
-    });
-  }
 
   payloadObj.input = normalizedInput;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users continuing image-bearing tool conversations through xAI Responses compatibility routes would lose prompt-prefix reuse as historical tool images moved to the end of every request.

## Why This Change Was Made

Emit the existing labeled user image carrier immediately after each consecutive tool-result group. Parallel outputs remain adjacent, text/media fallback behavior and deterministic ordinal labels are preserved, and the native `https://api.x.ai/v1` route still keeps images attached to their original tool outputs. Compaction establishes a new history prefix without retained image state.

## User Impact

Later turns preserve earlier compatibility image positions, avoiding this source of prompt-cache prefix churn without configuration changes. The xAI provider docs describe the behavior. Production code is +35/-34 lines (net +1); there are no new configuration options, stores, schemas, or dependencies.

## Evidence

- Before the fix, `node scripts/run-vitest.mjs extensions/xai/stream.test.ts` reported **2 failed / 41 passed**. Both new regressions failed because appending assistant/user turns displaced the earlier image carrier.
- After the fix, `node scripts/run-vitest.mjs extensions/xai` reported **34 test files passed; 589 tests passed**. Coverage includes single and parallel results, mixed text/media, source-based images, numbering, compaction, idempotent replay, and native-route preservation.
- Codex autoreview: **scoped-clean; 0 accepted/actionable P0/P1 findings; patch is correct**. No findings required remediation.
- `node scripts/check-changed.mjs` passed every preceding gate, including production/test typechecks and dead-export scans, then stopped at the documented nested-checkout declaration-boundary error: `Declaration input escapes checkout ... qrcode/package.json`. CI owns that blocked declaration/lint lane. The remaining database-store, media-download, runtime-sidecar, and import-cycle guards were run directly and all passed.
- `git diff --check` passed.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34102179777) passed for `e3766744e741a63633b1f7ed0ed708595b40dc30`; the bounded watcher finished with `SUCCESS`, `pending=0`, and `GREEN` (exit 0). This includes the [extension package-boundary](https://github.com/openclaw/openclaw/actions/runs/34102179777/job/101679127544) and [lint](https://github.com/openclaw/openclaw/actions/runs/34102179777/job/101679127750) jobs blocked by the local checkout layout.

Provider ordering evidence: xAI's [Responses continuation example](https://docs.x.ai/developers/advanced-api-usage/websocket-mode#continuing-a-run) places a tool output before a user message, and its [parallel function-calling guidance](https://docs.x.ai/developers/tools/function-calling#parallel-function-calling) processes all parallel calls before continuing. [Image understanding](https://docs.x.ai/developers/model-capabilities/images/understanding) documents mixed text/image user content. Combining these contracts supports placing the image carrier after the complete result group; the docs do not explicitly require grouping synthetic image carriers.

Live endpoint acceptance and cache billing were not measured. These official xAI contracts do not guarantee arbitrary third-party compatibility endpoints; the payload regression is boundary proof, not a live-provider result.
