### PR TITLE
fix(ui): keep reopened select menus visible

### DIFF
--- a/patches/@awesome.me__webawesome@3.12.0.patch
+++ b/patches/@awesome.me__webawesome@3.12.0.patch
@@ -1,3 +1,179 @@
+diff --git a/dist/chunks/chunk.CWBSN34U.js b/dist/chunks/chunk.CWBSN34U.js
+index 5b1df53a771e31410852af7ea483db52edbc0140..dbb7dc5db6d83acaf9261846451ce86b9eb4cab6 100644
+--- a/dist/chunks/chunk.CWBSN34U.js
++++ b/dist/chunks/chunk.CWBSN34U.js
+@@ -43,9 +43,6 @@ import {
+ import {
+   size_styles_default
+ } from "./chunk.G5ZZIGWB.js";
+-import {
+-  waitForEvent
+-} from "./chunk.F25QOBDY.js";
+ import {
+   animateWithClass
+ } from "./chunk.L6CIKOFQ.js";
+@@ -74,6 +71,7 @@ var WaSelect = class extends WebAwesomeFormAssociatedElement {
+     this.selectionOrder = /* @__PURE__ */ new Map();
+     this.typeToSelectString = "";
+     this.slotChangePending = false;
++    this.openTransition = { open: false };
+     this.displayLabel = "";
+     this.selectedOptions = [];
+     this.name = "";
+@@ -294,7 +292,12 @@ var WaSelect = class extends WebAwesomeFormAssociatedElement {
+   }
+   disconnectedCallback() {
+     super.disconnectedCallback();
+-    this.removeOpenListeners();
++    this.openTransition.controller?.abort();
++    this.openTransition = { open: false };
++    this.popup?.popup?.classList.remove("show", "hide");
++    if (this.listbox) this.listbox.hidden = true;
++    if (this.popup) this.popup.active = false;
++    unregisterDismissible(this);
+     this.cachedOptions = null;
+   }
+   updateDefaultValue() {
+@@ -308,24 +311,6 @@ var WaSelect = class extends WebAwesomeFormAssociatedElement {
+       this._defaultValue = this.getAttribute("value") || null;
+     }
+   }
+-  addOpenListeners() {
+-    document.addEventListener("focusin", this.handleDocumentFocusIn);
+-    document.addEventListener("keydown", this.handleDocumentKeyDown);
+-    document.addEventListener("mousedown", this.handleDocumentMouseDown);
+-    registerDismissible(this);
+-    if (this.getRootNode() !== document) {
+-      this.getRootNode().addEventListener("focusin", this.handleDocumentFocusIn);
+-    }
+-  }
+-  removeOpenListeners() {
+-    document.removeEventListener("focusin", this.handleDocumentFocusIn);
+-    document.removeEventListener("keydown", this.handleDocumentKeyDown);
+-    document.removeEventListener("mousedown", this.handleDocumentMouseDown);
+-    unregisterDismissible(this);
+-    if (this.getRootNode() !== document) {
+-      this.getRootNode().removeEventListener("focusin", this.handleDocumentFocusIn);
+-    }
+-  }
+   handleFocus() {
+     this.displayInput.setSelectionRange(0, 0);
+   }
+@@ -588,6 +573,8 @@ var WaSelect = class extends WebAwesomeFormAssociatedElement {
+   handleDisabledChange() {
+     if (this.disabled && this.open) {
+       this.open = false;
++      // The open watcher has already run for this update.
++      this.handleOpenChange();
+     }
+   }
+   handleValueChange() {
+@@ -598,56 +585,72 @@ var WaSelect = class extends WebAwesomeFormAssociatedElement {
+     this.updateValidity();
+   }
+   async handleOpenChange() {
+-    if (this.open && !this.disabled) {
+-      this.setCurrentOption(this.selectedOptions[0] || this.getFirstOption());
+-      const waShowEvent = new WaShowEvent();
+-      this.dispatchEvent(waShowEvent);
+-      if (waShowEvent.defaultPrevented) {
+-        this.open = false;
+-        return;
+-      }
+-      this.addOpenListeners();
++    const open = this.open && !this.disabled;
++    if (!this.isConnected || this.openTransition.open === open) return this.openAnimation;
++    if (open) this.setCurrentOption(this.selectedOptions[0] || this.getFirstOption());
++    const event = open ? new WaShowEvent() : new WaHideEvent();
++    this.dispatchEvent(event);
++    if (event.defaultPrevented && !this.disabled) {
++      this.open = this.openTransition.open;
++      return this.openAnimation;
++    }
++    if (!this.isConnected || (this.open && !this.disabled) !== open) return this.openAnimation;
++    this.openTransition.controller?.abort();
++    this.openTransition = { open, controller: new AbortController() };
++    const { signal } = this.openTransition.controller;
++    const isCurrent = () => !signal.aborted && this.isConnected && (this.open && !this.disabled) === open;
++    if (open) {
++      document.addEventListener("focusin", this.handleDocumentFocusIn, { signal });
++      document.addEventListener("keydown", this.handleDocumentKeyDown, { signal });
++      document.addEventListener("mousedown", this.handleDocumentMouseDown, { signal });
++      registerDismissible(this);
++      const root = this.getRootNode();
++      if (root !== document) root.addEventListener("focusin", this.handleDocumentFocusIn, { signal });
+       this.listbox.hidden = false;
+       this.popup.active = true;
+       requestAnimationFrame(() => {
+-        this.setCurrentOption(this.currentOption);
++        if (isCurrent()) this.setCurrentOption(this.currentOption);
+       });
+-      await animateWithClass(this.popup.popup, "show");
+-      if (this.currentOption) {
++    } else {
++      unregisterDismissible(this);
++    }
++    // Retire the old animation before joining its cleanup; only the accepted
++    // transition may publish visibility, focus, or completion after an await.
++    this.popup.popup.classList.remove("show", "hide");
++    const previousAnimation = this.openAnimation;
++    this.openAnimation = (async () => {
++      await previousAnimation;
++      if (!isCurrent()) return;
++      await animateWithClass(this.popup.popup, open ? "show" : "hide");
++      if (!isCurrent()) return;
++      if (open && this.currentOption) {
+         scrollIntoView(this.currentOption, this.listbox, "vertical", "auto");
+       }
+-      this.dispatchEvent(new WaAfterShowEvent());
+-    } else {
+-      const waHideEvent = new WaHideEvent();
+-      this.dispatchEvent(waHideEvent);
+-      if (waHideEvent.defaultPrevented) {
+-        this.open = false;
+-        return;
++      if (!open) {
++        this.listbox.hidden = true;
++        this.popup.active = false;
+       }
+-      this.removeOpenListeners();
+-      await animateWithClass(this.popup.popup, "hide");
+-      this.listbox.hidden = true;
+-      this.popup.active = false;
+-      this.dispatchEvent(new WaAfterHideEvent());
+-    }
++      this.dispatchEvent(open ? new WaAfterShowEvent() : new WaAfterHideEvent());
++    })();
++    return this.openAnimation;
+   }
+   /** Shows the listbox. */
+   async show() {
+-    if (this.open || this.disabled) {
++    if (this.disabled) {
+       this.open = false;
+-      return void 0;
++      return;
+     }
++    if (!this.isConnected) return;
+     this.open = true;
+-    return waitForEvent(this, "wa-after-show");
++    await this.updateComplete;
++    return this.handleOpenChange();
+   }
+   /** Hides the listbox. */
+   async hide() {
+-    if (!this.open || this.disabled) {
+-      this.open = false;
+-      return void 0;
+-    }
+     this.open = false;
+-    return waitForEvent(this, "wa-after-hide");
++    if (!this.isConnected) return;
++    await this.updateComplete;
++    return this.openAnimation;
+   }
+   /** Sets focus on the control. */
+   focus(options) {
 diff --git a/dist/chunks/chunk.JZGJWX35.js b/dist/chunks/chunk.JZGJWX35.js
 index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..66e09365025b0e593e38d8410c8019d660081e16 100644
 --- a/dist/chunks/chunk.JZGJWX35.js
@@ -785,6 +961,50 @@ index 1e458bc4c742d94cd58d688acde8a45f9c681763..477eac752d3d2c0a81ee3a59a80c09b8
      /** Notifies the parent dropdown that this item is opening its submenu */
      private notifyParentOfOpening;
      /** Closes the submenu. */
+diff --git a/dist/components/select/select.d.ts b/dist/components/select/select.d.ts
+index 9b4c748a83e5e990fd6eeb6367b37713b56773b2..f801fce20728a10630b6e47099a1054b464fb37c 100644
+--- a/dist/components/select/select.d.ts
++++ b/dist/components/select/select.d.ts
+@@ -66,6 +66,8 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
+     static get validators(): import("../../internal/webawesome-form-associated-element.js").Validator<WebAwesomeFormAssociatedElement>[];
+     assumeInteractionOn: string[];
+     private cachedOptions;
++    private openTransition;
++    private openAnimation;
+     private readonly hasSlotController;
+     private readonly localize;
+     private selectionOrder;
+@@ -154,8 +156,6 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
+     connectedCallback(): void;
+     disconnectedCallback(): void;
+     private updateDefaultValue;
+-    private addOpenListeners;
+-    private removeOpenListeners;
+     private handleFocus;
+     private handleDocumentFocusIn;
+     private handleDocumentKeyDown;
+diff --git a/dist/custom-elements.json b/dist/custom-elements.json
+index 4128d582ee76895db1e7a8b55349680d84bfa40f..51fa14f3ad1234ce8fc7991fd83b002b30238d92 100644
+--- a/dist/custom-elements.json
++++ b/dist/custom-elements.json
+@@ -27842,13 +27842,13 @@
+               "privacy": "private"
+             },
+             {
+-              "kind": "method",
+-              "name": "addOpenListeners",
++              "kind": "field",
++              "name": "openTransition",
+               "privacy": "private"
+             },
+             {
+-              "kind": "method",
+-              "name": "removeOpenListeners",
++              "kind": "field",
++              "name": "openAnimation",
+               "privacy": "private"
+             },
+             {
 diff --git a/dist/internal/animate.d.ts b/dist/internal/animate.d.ts
 index bedb1923179f2a73be2eaf24e8c1a3c35718683d..04dc1c15097ad58de31a8670e2c870d3a475b96f 100644
 --- a/dist/internal/animate.d.ts
@@ -1314,6 +1534,182 @@ index 20d309f89017ef7d1857f3b1c88216a88354fefd..ea0b8ee34255009d9d9e86605dbdc059
  }
  function parseDuration(duration) {
    duration = duration.toString().toLowerCase();
+diff --git a/dist-cdn/chunks/chunk.VVUBGO75.js b/dist-cdn/chunks/chunk.VVUBGO75.js
+index 79243983dd4273713e7d1cc5d7e9a7b103cb787c..b7007d1129565982cac88ea9878d78e47072e340 100644
+--- a/dist-cdn/chunks/chunk.VVUBGO75.js
++++ b/dist-cdn/chunks/chunk.VVUBGO75.js
+@@ -46,9 +46,6 @@ import {
+ import {
+   size_styles_default
+ } from "./chunk.JB5Y2AN3.js";
+-import {
+-  waitForEvent
+-} from "./chunk.F25QOBDY.js";
+ import {
+   animateWithClass
+ } from "./chunk.L6CIKOFQ.js";
+@@ -88,6 +85,7 @@ var WaSelect = class extends WebAwesomeFormAssociatedElement {
+     this.selectionOrder = /* @__PURE__ */ new Map();
+     this.typeToSelectString = "";
+     this.slotChangePending = false;
++    this.openTransition = { open: false };
+     this.displayLabel = "";
+     this.selectedOptions = [];
+     this.name = "";
+@@ -308,7 +306,12 @@ var WaSelect = class extends WebAwesomeFormAssociatedElement {
+   }
+   disconnectedCallback() {
+     super.disconnectedCallback();
+-    this.removeOpenListeners();
++    this.openTransition.controller?.abort();
++    this.openTransition = { open: false };
++    this.popup?.popup?.classList.remove("show", "hide");
++    if (this.listbox) this.listbox.hidden = true;
++    if (this.popup) this.popup.active = false;
++    unregisterDismissible(this);
+     this.cachedOptions = null;
+   }
+   updateDefaultValue() {
+@@ -322,24 +325,6 @@ var WaSelect = class extends WebAwesomeFormAssociatedElement {
+       this._defaultValue = this.getAttribute("value") || null;
+     }
+   }
+-  addOpenListeners() {
+-    document.addEventListener("focusin", this.handleDocumentFocusIn);
+-    document.addEventListener("keydown", this.handleDocumentKeyDown);
+-    document.addEventListener("mousedown", this.handleDocumentMouseDown);
+-    registerDismissible(this);
+-    if (this.getRootNode() !== document) {
+-      this.getRootNode().addEventListener("focusin", this.handleDocumentFocusIn);
+-    }
+-  }
+-  removeOpenListeners() {
+-    document.removeEventListener("focusin", this.handleDocumentFocusIn);
+-    document.removeEventListener("keydown", this.handleDocumentKeyDown);
+-    document.removeEventListener("mousedown", this.handleDocumentMouseDown);
+-    unregisterDismissible(this);
+-    if (this.getRootNode() !== document) {
+-      this.getRootNode().removeEventListener("focusin", this.handleDocumentFocusIn);
+-    }
+-  }
+   handleFocus() {
+     this.displayInput.setSelectionRange(0, 0);
+   }
+@@ -602,6 +587,8 @@ var WaSelect = class extends WebAwesomeFormAssociatedElement {
+   handleDisabledChange() {
+     if (this.disabled && this.open) {
+       this.open = false;
++      // The open watcher has already run for this update.
++      this.handleOpenChange();
+     }
+   }
+   handleValueChange() {
+@@ -612,56 +599,72 @@ var WaSelect = class extends WebAwesomeFormAssociatedElement {
+     this.updateValidity();
+   }
+   async handleOpenChange() {
+-    if (this.open && !this.disabled) {
+-      this.setCurrentOption(this.selectedOptions[0] || this.getFirstOption());
+-      const waShowEvent = new WaShowEvent();
+-      this.dispatchEvent(waShowEvent);
+-      if (waShowEvent.defaultPrevented) {
+-        this.open = false;
+-        return;
+-      }
+-      this.addOpenListeners();
++    const open = this.open && !this.disabled;
++    if (!this.isConnected || this.openTransition.open === open) return this.openAnimation;
++    if (open) this.setCurrentOption(this.selectedOptions[0] || this.getFirstOption());
++    const event = open ? new WaShowEvent() : new WaHideEvent();
++    this.dispatchEvent(event);
++    if (event.defaultPrevented && !this.disabled) {
++      this.open = this.openTransition.open;
++      return this.openAnimation;
++    }
++    if (!this.isConnected || (this.open && !this.disabled) !== open) return this.openAnimation;
++    this.openTransition.controller?.abort();
++    this.openTransition = { open, controller: new AbortController() };
++    const { signal } = this.openTransition.controller;
++    const isCurrent = () => !signal.aborted && this.isConnected && (this.open && !this.disabled) === open;
++    if (open) {
++      document.addEventListener("focusin", this.handleDocumentFocusIn, { signal });
++      document.addEventListener("keydown", this.handleDocumentKeyDown, { signal });
++      document.addEventListener("mousedown", this.handleDocumentMouseDown, { signal });
++      registerDismissible(this);
++      const root = this.getRootNode();
++      if (root !== document) root.addEventListener("focusin", this.handleDocumentFocusIn, { signal });
+       this.listbox.hidden = false;
+       this.popup.active = true;
+       requestAnimationFrame(() => {
+-        this.setCurrentOption(this.currentOption);
++        if (isCurrent()) this.setCurrentOption(this.currentOption);
+       });
+-      await animateWithClass(this.popup.popup, "show");
+-      if (this.currentOption) {
++    } else {
++      unregisterDismissible(this);
++    }
++    // Retire the old animation before joining its cleanup; only the accepted
++    // transition may publish visibility, focus, or completion after an await.
++    this.popup.popup.classList.remove("show", "hide");
++    const previousAnimation = this.openAnimation;
++    this.openAnimation = (async () => {
++      await previousAnimation;
++      if (!isCurrent()) return;
++      await animateWithClass(this.popup.popup, open ? "show" : "hide");
++      if (!isCurrent()) return;
++      if (open && this.currentOption) {
+         scrollIntoView(this.currentOption, this.listbox, "vertical", "auto");
+       }
+-      this.dispatchEvent(new WaAfterShowEvent());
+-    } else {
+-      const waHideEvent = new WaHideEvent();
+-      this.dispatchEvent(waHideEvent);
+-      if (waHideEvent.defaultPrevented) {
+-        this.open = false;
+-        return;
++      if (!open) {
++        this.listbox.hidden = true;
++        this.popup.active = false;
+       }
+-      this.removeOpenListeners();
+-      await animateWithClass(this.popup.popup, "hide");
+-      this.listbox.hidden = true;
+-      this.popup.active = false;
+-      this.dispatchEvent(new WaAfterHideEvent());
+-    }
++      this.dispatchEvent(open ? new WaAfterShowEvent() : new WaAfterHideEvent());
++    })();
++    return this.openAnimation;
+   }
+   /** Shows the listbox. */
+   async show() {
+-    if (this.open || this.disabled) {
++    if (this.disabled) {
+       this.open = false;
+-      return void 0;
++      return;
+     }
++    if (!this.isConnected) return;
+     this.open = true;
+-    return waitForEvent(this, "wa-after-show");
++    await this.updateComplete;
++    return this.handleOpenChange();
+   }
+   /** Hides the listbox. */
+   async hide() {
+-    if (!this.open || this.disabled) {
+-      this.open = false;
+-      return void 0;
+-    }
+     this.open = false;
+-    return waitForEvent(this, "wa-after-hide");
++    if (!this.isConnected) return;
++    await this.updateComplete;
++    return this.openAnimation;
+   }
+   /** Sets focus on the control. */
+   focus(options) {
 diff --git a/dist-cdn/chunks/chunk.W2C46OQX.js b/dist-cdn/chunks/chunk.W2C46OQX.js
 index da164574ce537b386894e751d6e9727cc9249d08..4625393889d6d1b92bddc212b8ba407843f70136 100644
 --- a/dist-cdn/chunks/chunk.W2C46OQX.js
@@ -1587,6 +1983,50 @@ index 1e458bc4c742d94cd58d688acde8a45f9c681763..477eac752d3d2c0a81ee3a59a80c09b8
      /** Notifies the parent dropdown that this item is opening its submenu */
      private notifyParentOfOpening;
      /** Closes the submenu. */
+diff --git a/dist-cdn/components/select/select.d.ts b/dist-cdn/components/select/select.d.ts
+index 9b4c748a83e5e990fd6eeb6367b37713b56773b2..f801fce20728a10630b6e47099a1054b464fb37c 100644
+--- a/dist-cdn/components/select/select.d.ts
++++ b/dist-cdn/components/select/select.d.ts
+@@ -66,6 +66,8 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
+     static get validators(): import("../../internal/webawesome-form-associated-element.js").Validator<WebAwesomeFormAssociatedElement>[];
+     assumeInteractionOn: string[];
+     private cachedOptions;
++    private openTransition;
++    private openAnimation;
+     private readonly hasSlotController;
+     private readonly localize;
+     private selectionOrder;
+@@ -154,8 +156,6 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
+     connectedCallback(): void;
+     disconnectedCallback(): void;
+     private updateDefaultValue;
+-    private addOpenListeners;
+-    private removeOpenListeners;
+     private handleFocus;
+     private handleDocumentFocusIn;
+     private handleDocumentKeyDown;
+diff --git a/dist-cdn/custom-elements.json b/dist-cdn/custom-elements.json
+index 4128d582ee76895db1e7a8b55349680d84bfa40f..51fa14f3ad1234ce8fc7991fd83b002b30238d92 100644
+--- a/dist-cdn/custom-elements.json
++++ b/dist-cdn/custom-elements.json
+@@ -27842,13 +27842,13 @@
+               "privacy": "private"
+             },
+             {
+-              "kind": "method",
+-              "name": "addOpenListeners",
++              "kind": "field",
++              "name": "openTransition",
+               "privacy": "private"
+             },
+             {
+-              "kind": "method",
+-              "name": "removeOpenListeners",
++              "kind": "field",
++              "name": "openAnimation",
+               "privacy": "private"
+             },
+             {
 diff --git a/dist-cdn/internal/animate.d.ts b/dist-cdn/internal/animate.d.ts
 index bedb1923179f2a73be2eaf24e8c1a3c35718683d..04dc1c15097ad58de31a8670e2c870d3a475b96f 100644
 --- a/dist-cdn/internal/animate.d.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,7 +150,7 @@ overrides:
 packageExtensionsChecksum: sha256-zZ8fyodhMTumshonC7kktCqTPsiHL3UAyS9vltFAlMo=
 
 patchedDependencies:
-  '@awesome.me/webawesome@3.12.0': 56965f5288ab449b79b5cf0920c37325444105bfc76f146d339c954804671fee
+  '@awesome.me/webawesome@3.12.0': a366a1422e3d8f0b9699205e969a73294877cbff761550bb360380e3ab9428f1
   '@novnc/novnc@1.7.0': bfde0e1bda172da3525f9f5014d85ad28073325b74f09609084598a65d2f412d
   matrix-js-sdk@42.2.0: 9e97147d99b86977d6665a676cdf853434ef61eee7cfb176bb66c9c48da599b4
   vitest@5.0.0: 76a69c6de8bc85bb68eebebddf7e1e798a4ebf46d36ad60e6447ebc62c49f702
@@ -2594,7 +2594,7 @@ importers:
     dependencies:
       '@awesome.me/webawesome':
         specifier: 3.12.0
-        version: 3.12.0(patch_hash=56965f5288ab449b79b5cf0920c37325444105bfc76f146d339c954804671fee)(@floating-ui/utils@0.2.12)(@types/node@26.4.0)(@types/react@19.2.18)
+        version: 3.12.0(patch_hash=a366a1422e3d8f0b9699205e969a73294877cbff761550bb360380e3ab9428f1)(@floating-ui/utils@0.2.12)(@types/node@26.4.0)(@types/react@19.2.18)
       '@codemirror/commands':
         specifier: 6.11.0
         version: 6.11.0
@@ -9816,7 +9816,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@awesome.me/webawesome@3.12.0(patch_hash=56965f5288ab449b79b5cf0920c37325444105bfc76f146d339c954804671fee)(@floating-ui/utils@0.2.12)(@types/node@26.4.0)(@types/react@19.2.18)':
+  '@awesome.me/webawesome@3.12.0(patch_hash=a366a1422e3d8f0b9699205e969a73294877cbff761550bb360380e3ab9428f1)(@floating-ui/utils@0.2.12)(@types/node@26.4.0)(@types/react@19.2.18)':
     dependencies:
       '@ctrl/tinycolor': 4.1.0
       '@floating-ui/dom': 1.8.0

--- a/ui/src/components/web-awesome-select-controls.browser.test.ts
+++ b/ui/src/components/web-awesome-select-controls.browser.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { duringElementAnimation } from "../test-helpers/web-awesome-animation.ts";
+import "@awesome.me/webawesome/dist/styles/themes/default.css";
+import "./web-awesome-select.ts";
+
+type Operation = "show" | "hide";
+
+async function fixture(multiple = false, shadow = false) {
+  const host = document.createElement("div");
+  host.style.cssText = "width: 20rem; padding: 2rem";
+  const root = shadow ? host.attachShadow({ mode: "open" }) : host;
+  const select = document.createElement("wa-select");
+  select.label = "Choice";
+  select.multiple = multiple;
+  select.withClear = true;
+  select.innerHTML = `<wa-option value="a">Alpha</wa-option>
+    <wa-option value="unavailable" disabled>Unavailable</wa-option>
+    <wa-option value="b">Beta</wa-option>`;
+  select.value = multiple ? ["a"] : "a";
+  const outside = document.createElement("button");
+  outside.textContent = "Outside";
+  root.append(select, outside);
+  document.body.append(host);
+  await select.updateComplete;
+  await Promise.all(
+    [...select.querySelectorAll("wa-option")].map((option) => option.updateComplete),
+  );
+  const events: string[] = [];
+  for (const type of ["wa-show", "wa-hide", "wa-after-show", "wa-after-hide"]) {
+    select.addEventListener(type, (event) => {
+      if (event.target === select) {
+        events.push(type);
+      }
+    });
+  }
+  return { host, root, select, outside, events };
+}
+
+type Fixture = Awaited<ReturnType<typeof fixture>>;
+
+async function visible(f: Fixture, open: boolean) {
+  const { page } = await import("vitest/browser");
+  const option = page.elementLocator(f.select.querySelector('wa-option[value="b"]')!);
+  await expect.poll(() => f.select.open).toBe(open);
+  if (open) {
+    await expect.element(option).toBeVisible();
+  } else {
+    await expect
+      .element(f.select.querySelector<HTMLElement>('wa-option[value="b"]')!)
+      .not.toBeVisible();
+  }
+}
+
+function focused(): Element | null {
+  let active = document.activeElement;
+  while (active?.shadowRoot?.activeElement) {
+    active = active.shadowRoot.activeElement;
+  }
+  return active;
+}
+
+async function prepare(f: Fixture, operation: Operation) {
+  if (operation === "hide") {
+    await f.select.show();
+  }
+  f.events.length = 0;
+}
+
+afterEach(() => document.body.replaceChildren());
+
+describe.runIf("__vitest_browser__" in globalThis)(
+  "Web Awesome select public lifecycle controls",
+  () => {
+    it.each(["show", "hide"] as const)(
+      "joins repeated pending and completed %s calls",
+      async (operation) => {
+        const f = await fixture();
+        await prepare(f, operation);
+        const settled: string[] = [];
+        let first: Promise<void> | undefined;
+        let second: Promise<void> | undefined;
+        await duringElementAnimation(
+          f.select.popup.popup,
+          operation,
+          () => {
+            first = f.select[operation]().then(() => {
+              settled.push("first");
+            });
+          },
+          async () => {
+            second = f.select[operation]().then(() => {
+              settled.push("second");
+            });
+            await f.select.updateComplete;
+            expect(f.select.open).toBe(operation === "show");
+            expect(settled).toEqual([]);
+          },
+        );
+        await Promise.all([first, second]);
+        expect(settled.toSorted()).toEqual(["first", "second"]);
+        await visible(f, operation === "show");
+        expect(f.events).toEqual([`wa-${operation}`, `wa-after-${operation}`]);
+        await f.select[operation]();
+        await visible(f, operation === "show");
+        expect(f.events).toEqual([`wa-${operation}`, `wa-after-${operation}`]);
+      },
+    );
+
+    it.each(["show", "hide"] as const)(
+      "settles a same-turn %s reversal at the final requested state",
+      async (operation) => {
+        const f = await fixture();
+        await prepare(f, operation);
+        const opposite = operation === "show" ? "hide" : "show";
+        const first = f.select[operation]();
+        const second = f.select[opposite]();
+        await Promise.all([first, second]);
+        await visible(f, opposite === "show");
+        expect(f.events).toEqual([]);
+      },
+    );
+
+    it.each(["show", "hide"] as const)(
+      "settles an interrupted %s without a stale completion event",
+      async (operation) => {
+        const f = await fixture();
+        await prepare(f, operation);
+        const opposite = operation === "show" ? "hide" : "show";
+        let first: Promise<void> | undefined;
+        let replacement: Promise<void> | undefined;
+        await duringElementAnimation(
+          f.select.popup.popup,
+          operation,
+          () => {
+            first = f.select[operation]();
+          },
+          async () => {
+            replacement = f.select[opposite]();
+            await f.select.updateComplete;
+          },
+        );
+        await Promise.all([first, replacement]);
+        await visible(f, opposite === "show");
+        expect(f.events).toEqual([`wa-${operation}`, `wa-${opposite}`, `wa-after-${opposite}`]);
+      },
+    );
+
+    it("settles a vetoed show and permits the next accepted opening", async () => {
+      const f = await fixture();
+      f.select.addEventListener("wa-show", (event) => event.preventDefault(), { once: true });
+      await f.select.show();
+      await visible(f, false);
+      expect(f.events).toEqual(["wa-show"]);
+      await f.select.show();
+      await visible(f, true);
+      expect(f.events).toEqual(["wa-show", "wa-show", "wa-after-show"]);
+    });
+
+    it("keeps an accepted opening when hide is vetoed during its animation", async () => {
+      const { userEvent } = await import("vitest/browser");
+      const f = await fixture();
+      let opening: Promise<void> | undefined;
+      let vetoed: Promise<void> | undefined;
+      await duringElementAnimation(
+        f.select.popup.popup,
+        "show",
+        () => {
+          opening = f.select.show();
+        },
+        async () => {
+          f.select.addEventListener("wa-hide", (event) => event.preventDefault(), { once: true });
+          vetoed = f.select.hide();
+          await f.select.updateComplete;
+          expect(f.select.open).toBe(true);
+        },
+      );
+      await Promise.all([opening, vetoed]);
+      await visible(f, true);
+      expect(f.events).toEqual(["wa-show", "wa-hide", "wa-after-show"]);
+      await userEvent.keyboard("{Escape}");
+      await visible(f, false);
+      await expect.poll(() => f.events.at(-1)).toBe("wa-after-hide");
+      expect(focused()).toBe(f.select.displayInput);
+    });
+
+    it.each(["show", "hide"] as const)(
+      "settles a disconnected %s and opens normally after shadow-root remount",
+      async (operation) => {
+        const { userEvent } = await import("vitest/browser");
+        const f = await fixture(false, true);
+        await prepare(f, operation);
+        let pending: Promise<void> | undefined;
+        await duringElementAnimation(
+          f.select.popup.popup,
+          operation,
+          () => {
+            pending = f.select[operation]();
+          },
+          () => {
+            f.select.remove();
+            f.outside.focus();
+          },
+        );
+        await pending;
+        expect(f.events).toEqual([`wa-${operation}`]);
+        expect(focused()).toBe(f.outside);
+        const nextHost = document.createElement("div");
+        const nextRoot = nextHost.attachShadow({ mode: "open" });
+        document.body.append(nextHost);
+        nextRoot.append(f.select);
+        await f.select.updateComplete;
+        await visible(f, false);
+        await f.select.show();
+        await visible(f, true);
+        await userEvent.keyboard("{Escape}");
+        await visible(f, false);
+        await expect.poll(() => f.events.at(-1)).toBe("wa-after-hide");
+        expect(f.events).toEqual([
+          `wa-${operation}`,
+          "wa-show",
+          "wa-after-show",
+          "wa-hide",
+          "wa-after-hide",
+        ]);
+        expect(focused()).toBe(f.select.displayInput);
+      },
+    );
+
+    it("preserves keyboard selection, disabled options, and focus return", async () => {
+      const { userEvent } = await import("vitest/browser");
+      const f = await fixture();
+      const changes: unknown[] = [];
+      f.select.addEventListener("change", () => changes.push(f.select.value));
+      f.select.focus();
+      await userEvent.keyboard("{ArrowDown}");
+      await visible(f, true);
+      await expect.poll(() => f.events.at(-1)).toBe("wa-after-show");
+      await userEvent.keyboard("{ArrowDown}{Enter}");
+      expect(f.select.value).toBe("a");
+      expect(changes).toEqual([]);
+      await visible(f, true);
+      await userEvent.keyboard("{End}{Enter}");
+      await expect.poll(() => changes).toEqual(["b"]);
+      await visible(f, false);
+      expect(focused()).toBe(f.select.displayInput);
+    });
+
+    it.each([false, true])("closes a disabled select (hide veto: %s)", async (veto) => {
+      const { userEvent } = await import("vitest/browser");
+      const f = await fixture();
+      await f.select.show();
+      const changes: unknown[] = [];
+      f.select.addEventListener("change", () => changes.push(f.select.value));
+      if (veto) {
+        f.select.addEventListener("wa-hide", (event) => event.preventDefault());
+      }
+
+      f.select.disabled = true;
+      await f.select.updateComplete;
+      await userEvent.keyboard("{End}{Enter}");
+      expect(f.select.value).toBe("a");
+      expect(changes).toEqual([]);
+      await visible(f, false);
+    });
+
+    it("preserves multiple selection, clearing, outside dismissal, and ordinary disabled behavior", async () => {
+      const { page } = await import("vitest/browser");
+      const f = await fixture(true);
+      await f.select.show();
+      await page.elementLocator(f.select.querySelector('wa-option[value="b"]')!).click();
+      expect(f.select.value).toEqual(["a", "b"]);
+      await visible(f, true);
+      f.outside.focus();
+      await visible(f, false);
+      await expect.poll(() => f.events.at(-1)).toBe("wa-after-hide");
+      const cleared: unknown[] = [];
+      f.select.addEventListener("wa-clear", () => cleared.push(f.select.value));
+      await page
+        .elementLocator(f.select.shadowRoot!.querySelector<HTMLElement>('[part="clear-button"]')!)
+        .click();
+      expect(f.select.value).toEqual([]);
+      await expect.poll(() => cleared).toEqual([[]]);
+      f.select.disabled = true;
+      await f.select.updateComplete;
+      await f.select.show();
+      await visible(f, false);
+      f.select.disabled = false;
+      await f.select.updateComplete;
+      await f.select.show();
+      await visible(f, true);
+    });
+  },
+);

--- a/ui/src/components/web-awesome-select.browser.test.ts
+++ b/ui/src/components/web-awesome-select.browser.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { duringElementAnimation } from "../test-helpers/web-awesome-animation.ts";
+import "@awesome.me/webawesome/dist/styles/themes/default.css";
+import "./web-awesome-select.ts";
+
+afterEach(() => document.body.replaceChildren());
+
+describe.runIf("__vitest_browser__" in globalThis)("Web Awesome select lifecycle", () => {
+  it("keeps a reopened option visible and selectable after an interrupted hide", async () => {
+    const { page, userEvent } = await import("vitest/browser");
+    const host = document.createElement("div");
+    host.style.cssText = "width: 20rem; padding: 2rem";
+    host.innerHTML = `<wa-select label="Model" value="default">
+      <wa-option value="default">Default</wa-option>
+      <wa-option value="selected">Reopened option</wa-option>
+    </wa-select>`;
+    const select = host.querySelector("wa-select")!;
+    document.body.append(host);
+    await select.updateComplete;
+    await Promise.all(
+      [...select.querySelectorAll("wa-option")].map((option) => option.updateComplete),
+    );
+    const events: string[] = [];
+    const changes: unknown[] = [];
+    select.addEventListener("wa-after-show", () => events.push("shown"));
+    select.addEventListener("change", () => changes.push(select.value));
+
+    await page.getByRole("combobox", { name: "Model", exact: true }).click();
+    await expect.element(page.getByRole("option", { name: "Default", exact: true })).toBeVisible();
+    await expect.poll(() => events).toEqual(["shown"]);
+    await duringElementAnimation(
+      select.popup.popup,
+      "hide",
+      () => userEvent.keyboard("{Escape}"),
+      async () => {
+        await page.getByRole("combobox", { name: "Model", exact: true }).click();
+        await select.updateComplete;
+      },
+    );
+    await expect.poll(() => select.popup.popup.getAnimations().length).toBe(0);
+    await select.updateComplete;
+    await select.popup.updateComplete;
+
+    const option = select.querySelector<HTMLElement>('wa-option[value="selected"]')!;
+    await expect.element(option).toBeVisible();
+    await page.elementLocator(option).click();
+    await expect.poll(() => changes).toEqual(["selected"]);
+    await expect.element(option).not.toBeVisible();
+  });
+
+  it("shows a selectable option when called immediately after connection", async () => {
+    const { page } = await import("vitest/browser");
+    const select = document.createElement("wa-select");
+    select.label = "Model";
+    select.innerHTML = '<wa-option value="chosen">Available option</wa-option>';
+    document.body.append(select);
+
+    await select.show();
+    const option = select.querySelector("wa-option")!;
+    await expect.element(option).toBeVisible();
+    await page.elementLocator(option).click();
+    expect(select.value).toBe("chosen");
+    await expect.element(option).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reopening a Control UI select during its closing animation would see an expanded control with no visible options. This can affect the Automations model picker when its catalog refreshes between closing and reopening. An already-open select could also leave its menu visible after being disabled.

## Why This Change Was Made

Give each accepted transition ownership of its listeners, animation, focus updates, and completion. A replacement retires and joins the previous animation, so an old close cannot hide a reopened menu. Public `show()` and `hide()` calls join that work, including interrupted calls, vetoes, repeated requests, and first-render initialization.

Disabling invokes the same transition owner directly: its callback runs after the open watcher, so merely setting `open = false` during that update never closed the popup. Disabled teardown proceeds even when ordinary closing is vetoed; enabled cancellation still works.

This extends the existing, approved Web Awesome 3.12.0 patch. Both distributions receive the same repair, and the public declarations and metadata remain unchanged. The distributed runtime grows by six lines overall while replacing the paired listener-registration helpers.

## User Impact

Reopened options remain visible and selectable, and disabled menus close. Keyboard selection, focus return, multiple selection, clearing, and dismissal retain their existing behavior.

## Evidence

- Before/after component proof reproduces hidden reopening, unsettled method calls, stale completion, and disabled-menu visibility. Twelve lifecycle cases fail against the original package while its two ordinary behavior controls pass; the additional disabled-owner failure was reproduced separately before its repair.
- All 65 select and existing dropdown browser cases pass, plus four picker rendering tests and three mocked production-bundle Automations E2E cases. The original catalog-refresh/draft-preservation test is unchanged.
- The final visibility assertions inspect retained DOM elements. This fixes Vitest's inability to re-resolve a hidden option through a role locator while preserving the actual visibility check. No timeout or retry was increased.
- Existing patch hunks, both distributed implementations, public type/metadata parity, and the lockfile's patch-hash-only change are verified.

The captures show the same synthetic interrupted-close scenario in Chromium. The original CI interleaving is not independently established. Real-profile Chrome control was unavailable; the browser evidence is component and mocked application proof.

The full changed gate and independent P0–P2 review pass. [CI run 34102406448](https://github.com/openclaw/openclaw/actions/runs/34102406448) exposed a separate clipboard-test mock contaminating native Mermaid tests. That failure reproduced on clean main and the mock removal independently landed in #141092. This branch now includes that repair. Its reviewed patch is identical after rebase; 16 select lifecycle cases, seven picker/Agents catalog cases, and three current mocked Automations E2E cases pass on the refreshed base `7f06602a11d`. Current main's normal-dismissal waits are preserved; the dedicated component regression still interrupts the hide animation. The later [CI run 34112443896](https://github.com/openclaw/openclaw/actions/runs/34112443896) finished with 118 successful jobs and 13 workflow skips; its only failed test job contained the CI-planner inventory-growth timeout. That failure was independently repaired in the combined #141137. The final rebase includes #141092, #141139, #141085, and #141137; all four changed files remain byte-identical to the reviewed source. Final [CI run 34117558444](https://github.com/openclaw/openclaw/actions/runs/34117558444) passed on `760c6c79a16d897a8461f6ce3a9e22b49a7b7dc7` after the normal failed-job retry: 120 successful and 13 skipped workflow results, with the required gate green. The first attempt included two jobs that never acquired runners and a separate service-worker fixture setup failure. A controlled reproduction supports an independent fixture fix; the select source stayed unchanged.

<details>
<summary>Maintainer disposition of review limitations</summary>

The complete installed Web Awesome select, its lifecycle dependencies, and both distributions were inspected, and the fresh independent review received the full baseline/current sources. Both synthetic captures were inspected locally; ordinary downloads of the published URLs reproduce their original hashes. ClawSweeper reports no concrete correctness or security finding. Its access limitations are covered by this source and visual verification.

The exact original Automations CI schedule remains unproved. The controlled real-component animation reproduces the violated visibility invariant, and the unchanged Automations catalog-refresh flow passes against the repair. The controlled regression and application flow support this transition-ownership repair. The current review’s two merge-risk bullets repeat these inspection and historical-timing limitations. Both have been considered in the maintainer decision above; no introduced code or security defect was identified.

</details>

![Before: reopened select has no visible options](https://github.com/user-attachments/assets/2b9c381e-f98f-4bd5-bbaf-6333d0f2803c)

![After: reopened options remain visible and selectable](https://github.com/user-attachments/assets/e198bed0-ecf5-4163-86a4-15725cc266db)
