### PR TITLE
fix(doctor): explain preserved Workshop backups

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -268,6 +268,13 @@ Bare `openclaw doctor --json` exits `0` once it emits a findings payload, includ
 
 `core/doctor/local-audio-acceleration` reports the auto-selected local STT command, separate capable/requested/observed backend evidence, and fallback order without loading a speech model. It emits an informational finding, so include `--severity-min info` to display it.
 
+`core/doctor/skill-workshop-relocation` distinguishes pending legacy collection
+backup roots from roots preserved for review. Eligible proposals or backup roots
+receive `openclaw doctor --fix` guidance, not a guarantee that every backup will
+be retired. Preserved roots require manual review of workspace ownership, backup
+manifests, and workspace migration blockers. If both kinds remain, Doctor reports
+both next steps. Do not delete preserved backups to clear the warning.
+
 ## Structured health checks
 
 Modern doctor checks use a small split contract:

--- a/src/commands/doctor-skill-workshop-relocation.reservations.test.ts
+++ b/src/commands/doctor-skill-workshop-relocation.reservations.test.ts
@@ -241,6 +241,7 @@ describe("doctor Workshop relocation reservations", () => {
       externalProposalCount: 0,
       externalProposalCountsByAgent: {},
       legacyBackupRootCount: 0,
+      preservedLegacyBackupRootCount: 0,
     });
     await expectWorkshopMigrationConverged({ env: testState.env });
   });

--- a/src/commands/doctor-skill-workshop-sqlite.readonly.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.readonly.test.ts
@@ -2,6 +2,8 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { createCoreHealthChecks } from "../flows/doctor-core-checks.js";
+import { exitCodeFromFindings, runDoctorLintChecks } from "../flows/doctor-lint-flow.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { resolveWorkshopSkillsDir } from "../skills/workshop/skills-root.js";
 import { importLegacySkillProposal } from "../skills/workshop/store.js";
@@ -37,6 +39,105 @@ async function snapshotDatabase(databasePath: string) {
 }
 
 describe("read-only Skill Workshop migration inspection", () => {
+  it.each([
+    { roots: [], proposal: false, preserved: 0, automatic: false },
+    { roots: ["eligible"], proposal: false, preserved: 0, automatic: true },
+    { roots: ["ambiguous"], proposal: false, preserved: 1, automatic: false },
+    { roots: ["invalid"], proposal: false, preserved: 1, automatic: false },
+    { roots: ["eligible", "ambiguous", "invalid"], proposal: false, preserved: 2, automatic: true },
+    { roots: ["ambiguous"], proposal: true, preserved: 1, automatic: true },
+  ])(
+    "gives truthful read-only lint remediation for roots=$roots proposal=$proposal",
+    async ({ roots, proposal, preserved, automatic }) => {
+      await withOpenClawTestState({ layout: "split" }, async (state) => {
+        const config = {
+          agents: {
+            entries: {
+              main: { workspace: state.workspaceDir },
+              alpha: { workspace: path.join(state.root, "shared-workspace") },
+              beta: { workspace: path.join(state.root, "shared-workspace") },
+            },
+          },
+        };
+        await state.writeConfig(config);
+        const configBefore = await fs.readFile(state.configPath);
+        const manifests = await Promise.all(
+          roots.map(async (kind, index) => {
+            const contents = JSON.stringify({
+              schema: kind === "invalid" ? "invalid" : "openclaw.skill-collection-backup.v1",
+              id: "legacy-backup",
+              createdAt: "2026-09-01T00:00:00.000Z",
+              workspaceDir:
+                kind === "ambiguous" ? config.agents.entries.alpha.workspace : state.workspaceDir,
+              skillDirs: [],
+              resultSkillDirs: [],
+              resultSkillHashes: {},
+            });
+            const file = await state.writeText(
+              `skill-workshop/collection-backups/${index.toString(16).padStart(16, "0")}/legacy-backup/manifest.json`,
+              contents,
+            );
+            return { file, contents };
+          }),
+        );
+        if (proposal) {
+          importLegacySkillProposal({
+            record: createAppliedLegacyProposal({
+              id: "readonly-workshop-20260907-1234567890",
+              title: "Legacy Workshop",
+              description: "Pending relocation",
+              content: "# Preserved\n",
+              target: {
+                skillKey: "legacy",
+                skillDir: path.join(state.workspaceDir, "skills", "legacy"),
+              },
+            }),
+            ownerAgentId: "main",
+            store: { env: state.env },
+          });
+        }
+        closeOpenClawStateDatabaseForTest();
+        const databasePath = resolveOpenClawStateSqlitePath(state.env);
+        const databaseBefore = proposal ? await snapshotDatabase(databasePath) : undefined;
+        const filesBefore = await fs.readdir(state.stateDir, { recursive: true });
+
+        const result = await runDoctorLintChecks(
+          { mode: "lint", runtime: { log() {}, error() {}, exit() {} }, cfg: config },
+          {
+            checks: createCoreHealthChecks().filter((check) => "detect" in check),
+            onlyIds: ["core/doctor/skill-workshop-relocation"],
+          },
+        );
+
+        expect(result.checksRun).toBe(1);
+        expect(result.findings).toHaveLength(roots.length || proposal ? 1 : 0);
+        expect(exitCodeFromFindings(result.findings)).toBe(roots.length || proposal ? 1 : 0);
+        if (result.findings.length > 0) {
+          const finding = result.findings[0]!;
+          expect(finding.severity).toBe("warning");
+          expect(finding.fixHint?.includes("Run `openclaw doctor --fix`")).toBe(automatic);
+          expect(finding.fixHint).not.toContain("retire legacy backup roots");
+          if (preserved > 0) {
+            expect(finding.message).toContain(`${preserved} preserved`);
+            expect(finding.fixHint).toMatch(/manual/i);
+            expect(finding.fixHint).toContain("workspace ownership");
+            expect(finding.fixHint).toContain("manifests");
+          }
+        }
+        expect(await fs.readdir(state.stateDir, { recursive: true })).toEqual(filesBefore);
+        expect(await fs.readFile(state.configPath)).toEqual(configBefore);
+        for (const manifest of manifests) {
+          expect(await fs.readFile(manifest.file, "utf8")).toBe(manifest.contents);
+        }
+        if (proposal) {
+          expect(await snapshotDatabase(databasePath)).toEqual(databaseBefore);
+        } else {
+          await expect(fs.access(databasePath)).rejects.toMatchObject({ code: "ENOENT" });
+        }
+      });
+    },
+  );
+
   it.each([
     { version: 16, sourcePresent: true },
     { version: 16, sourcePresent: false },
@@ -94,6 +195,7 @@ describe("read-only Skill Workshop migration inspection", () => {
           externalProposalCount: 1,
           externalProposalCountsByAgent: { main: 1 },
           legacyBackupRootCount: 0,
+          preservedLegacyBackupRootCount: 0,
         });
 
         closeOpenClawStateDatabaseForTest();
@@ -188,6 +290,7 @@ describe("read-only Skill Workshop migration inspection", () => {
         externalProposalCount: 9,
         externalProposalCountsByAgent: { main: 5, other: 2, retired: 1, unknown: 1 },
         legacyBackupRootCount: 0,
+        preservedLegacyBackupRootCount: 0,
       });
     });
   });

--- a/src/commands/doctor-skill-workshop-sqlite.relocation-conflicts.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.relocation-conflicts.test.ts
@@ -225,6 +225,7 @@ describe("doctor Skill Workshop SQLite relocation conflicts and recovery", () =>
       externalProposalCount: 0,
       externalProposalCountsByAgent: {},
       legacyBackupRootCount: 0,
+      preservedLegacyBackupRootCount: 0,
     });
     await expectWorkshopMigrationConverged({ config, env: testState.env });
     await expect(

--- a/src/commands/doctor-skill-workshop-sqlite.relocation.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.relocation.test.ts
@@ -79,6 +79,7 @@ describe("doctor Skill Workshop SQLite relocation and legacy migration", () => {
       externalProposalCount: 1,
       externalProposalCountsByAgent: { main: 1 },
       legacyBackupRootCount: 0,
+      preservedLegacyBackupRootCount: 0,
     });
     await expect(fs.access(legacySkillFile)).resolves.toBeUndefined();
 
@@ -251,6 +252,7 @@ describe("doctor Skill Workshop SQLite relocation and legacy migration", () => {
       externalProposalCount: 1,
       externalProposalCountsByAgent: { retired: 1 },
       legacyBackupRootCount: 0,
+      preservedLegacyBackupRootCount: 0,
     });
     const result = await migrateLegacySkillWorkshopProposals({ config, env: testState.env });
 
@@ -416,6 +418,7 @@ describe("doctor Skill Workshop SQLite relocation and legacy migration", () => {
       externalProposalCount: 0,
       externalProposalCountsByAgent: {},
       legacyBackupRootCount: 0,
+      preservedLegacyBackupRootCount: 0,
     });
     await expectWorkshopMigrationConverged({ env: testState.env });
   });

--- a/src/commands/doctor-skill-workshop-sqlite.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.test.ts
@@ -101,6 +101,7 @@ describe("doctor Skill Workshop SQLite migration", () => {
       externalProposalCount: 1,
       externalProposalCountsByAgent: { main: 1 },
       legacyBackupRootCount: 0,
+      preservedLegacyBackupRootCount: 0,
     });
     const first = await migrateLegacySkillWorkshopProposals({
       config: {},
@@ -120,6 +121,7 @@ describe("doctor Skill Workshop SQLite migration", () => {
       externalProposalCount: 0,
       externalProposalCountsByAgent: {},
       legacyBackupRootCount: 0,
+      preservedLegacyBackupRootCount: 0,
     });
     await expect(
       migrateLegacySkillWorkshopProposals({ config: {}, env: testState.env }),

--- a/src/commands/doctor-skill-workshop-sqlite.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.ts
@@ -92,6 +92,7 @@ export type LegacyWorkshopMigrationInspection = {
   externalProposalCount: number;
   externalProposalCountsByAgent: Record<string, number>;
   legacyBackupRootCount: number;
+  preservedLegacyBackupRootCount: number;
 };
 
 async function readJson(rootDir: Root, relativePath: string, maxBytes: number): Promise<unknown> {
@@ -142,6 +143,7 @@ export async function inspectLegacySkillWorkshopMigration(params: {
       return counts;
     }, {}),
     legacyBackupRootCount: backups.length,
+    preservedLegacyBackupRootCount: backups.filter((backup) => "warning" in backup).length,
   };
 }
 

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -367,6 +367,20 @@ const skillWorkshopRelocationCheck: HealthCheck = {
     if (inspection.externalProposalCount === 0 && inspection.legacyBackupRootCount === 0) {
       return [];
     }
+    const fixHints: string[] = [];
+    if (
+      inspection.externalProposalCount > 0 ||
+      inspection.legacyBackupRootCount > inspection.preservedLegacyBackupRootCount
+    ) {
+      fixHints.push(
+        "Run `openclaw doctor --fix` to process eligible Workshop relocations and legacy collection backups.",
+      );
+    }
+    if (inspection.preservedLegacyBackupRootCount > 0) {
+      fixHints.push(
+        "Preserved roots need manual review of workspace ownership, backup manifests, and workspace migration blockers; Doctor leaves them untouched until resolved. Do not delete backups to clear this warning.",
+      );
+    }
     return [
       {
         checkId: SKILL_WORKSHOP_RELOCATION_CHECK_ID,
@@ -377,10 +391,9 @@ const skillWorkshopRelocationCheck: HealthCheck = {
           .map(([agentId, count]) => `${agentId}: ${count}`)
           .join(
             ", ",
-          )}) and ${inspection.legacyBackupRootCount} legacy collection backup root${inspection.legacyBackupRootCount === 1 ? "" : "s"}.`,
+          )}) and ${inspection.legacyBackupRootCount} legacy collection backup root${inspection.legacyBackupRootCount === 1 ? "" : "s"} (${inspection.preservedLegacyBackupRootCount} preserved for review).`,
         path: "skills.workshop",
-        fixHint:
-          "Run `openclaw doctor --fix` to relocate Workshop-owned skills and retire legacy backup roots.",
+        fixHint: fixHints.join(" "),
       },
     ];
   },


### PR DESCRIPTION
Closes #141036 (Doctor recommends automatic retirement for intentionally preserved Workshop backups).

<details>
<summary>Additional instructions</summary>

This maintainer-requested repair uses a same-repository branch that maintainers can update.

</details>

## What Problem This Solves

Fixes an issue where operators following Doctor's Skill Workshop relocation finding were told to run `doctor --fix` to retire legacy backup roots even when those roots were deliberately preserved because ownership or validation could not be established.

## Why This Change Was Made

Carry a bounded preserved-root count from the existing read-only inspection into the finding. Preserved-only cases now explain manual review; eligible work retains useful automatic guidance; mixed cases explain both without promising blanket retirement.

The existing migration and preservation owners remain unchanged. This does not restore the ownership inference reverted by the [Workshop ownership-policy revert](https://github.com/openclaw/openclaw/pull/140148), change checkpoints, alter SQLite or configuration, move backups, or infer an owner from a backup directory name.

## User Impact

Doctor gives an actionable next step for preserved backups instead of sending operators back to an ineffective automatic repair. Eligible proposals and backup roots can still use `doctor --fix`. The documentation explicitly says not to delete preserved backups merely to clear the warning.

## Evidence

The original installed read-only CLI reproduced the unconditional hint on source build `fc33fa0b8917a889d69eecdd92d3371b1e86f8ad`:

```bash
openclaw doctor --lint --only core/doctor/skill-workshop-relocation --json
```

```text
Run `openclaw doctor --fix` to relocate Workshop-owned skills and retire legacy backup roots.
```

The CLI returned a warning and exit 1; configuration bytes were unchanged. Private installation paths and backup contents are not included.

A synthetic regression exercises the actual Doctor lint flow with empty, eligible, ambiguous-owner, invalid-manifest, mixed-root, and preserved-root-plus-proposal fixtures. Before production edits, it produced **5 intended failures and 6 passes**, including the incorrect automatic hint for preserved-only roots. After the repair, **11/11 passed**:

```bash
node scripts/run-vitest.mjs src/commands/doctor-skill-workshop-sqlite.readonly.test.ts --reporter=verbose
```

The tests verify unchanged manifest/config bytes and database identity, digest, and schema; cases without a database remain database-absent. The existing migration/ownership siblings passed **79/79 across seven files**:

```bash
node scripts/run-vitest.mjs src/commands/doctor-skill-workshop-collection-backups.test.ts src/commands/doctor-skill-workshop-sqlite.test.ts src/commands/doctor-skill-workshop-sqlite.relocation.test.ts src/commands/doctor-skill-workshop-sqlite.relocation-conflicts.test.ts src/commands/doctor-skill-workshop-relocation.reservations.test.ts src/flows/doctor-core-checks.test.ts src/flows/doctor-core-skill-workshop-check.test.ts --reporter=verbose
```

The complete changed-file gate passed, including core production/test types, targeted lint/formatting, dead-export scans, and remaining guards. Final `git diff --check` passed. Fresh independent Codex autoreview was **scoped-clean through P2**, with no findings. The after-fix behavior was exercised through isolated real diagnostic-flow fixtures, not represented as an already-deployed live fix.

**Scope:** production +18/-3 (net +15), tests +110, docs +7. The production growth carries one missing diagnostic fact and expresses two independent remediation paths. No dependency, schema, migration, checkpoint, ownership, baseline, or generated-file change. Exact-head hosted CI and native landing verification will be recorded before merge.

**Provenance:** the hint was introduced in the [agent-owned Skill Workshop feature](https://github.com/openclaw/openclaw/pull/135528), authored and merged by @obviyus. That feature's preservation boundary is retained.
