### PR TITLE
fix(test): join cancelled profiling workloads before cleanup

### DIFF
--- a/test/scripts/run-vitest-profile.test.ts
+++ b/test/scripts/run-vitest-profile.test.ts
@@ -1,46 +1,47 @@
 // Run Vitest Profile tests cover run vitest profile script behavior.
-import { execFile } from "node:child_process";
 import fs from "node:fs";
 import type { HeapProfiler } from "node:inspector";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { formatErrorMessage } from "../../scripts/lib/error-format.mts";
 import {
   buildVitestProfileCommandWithArgs,
   parseArgs,
   resolveVitestProfileDir,
 } from "../../scripts/run-vitest-profile.mts";
+import { createFixtureLifetime } from "../helpers/fixture-lifetime.js";
+import { waitForFixtureFile } from "../helpers/process-wait.js";
+import { runNodeScript } from "../helpers/run-node-script.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
-function runProfileProcess(
-  command: string,
-  args: string[],
-  root: string,
-): Promise<{ code: number; output: string }> {
-  return new Promise((resolve, reject) => {
-    execFile(
-      command,
-      args,
-      { cwd: root, env: { PATH: process.env.PATH, HOME: root, USERPROFILE: root, CI: "1" } },
-      (error, stdout, stderr) => {
-        const output = stdout + stderr;
-        if (!error) {
-          resolve({ code: 0, output });
-          return;
-        }
-        if (typeof error.code === "number" && error.code !== 0 && !error.signal) {
-          resolve({ code: error.code, output });
-          return;
-        }
-        reject(new Error(`${error.message}\n${output}`, { cause: error }));
-      },
-    );
-  });
-}
-
 describe("scripts/run-vitest-profile", () => {
-  const { createTempDir, trackTempDir } = createScriptTestHarness();
+  const { trackTempDir } = createScriptTestHarness();
+  const lifetime = createFixtureLifetime();
+  const { createTempDir } = lifetime;
   const repoRoot = path.resolve(import.meta.dirname, "../..");
+  afterEach(() => lifetime.cleanup());
+
+  async function runProfileProcess(args: string[], root: string, signal: AbortSignal) {
+    const result = await lifetime.track(
+      runNodeScript(
+        args,
+        { PATH: process.env.PATH, HOME: root, USERPROFILE: root, CI: "1" },
+        undefined,
+        {
+          cwd: root,
+          signal,
+          maxBuffer: 1024 * 1024,
+          requireProcessTreeExit: process.platform !== "win32",
+        },
+      ),
+    );
+    const output = result.stdout + result.stderr;
+    if (result.error) {
+      throw new Error(`${formatErrorMessage(result.error)}\n${output}`, { cause: result.error });
+    }
+    return { code: result.status, output };
+  }
 
   it("defaults profile output outside the repo", () => {
     const outputDir = trackTempDir(resolveVitestProfileDir({ mode: "main", outputDir: "" }));
@@ -75,7 +76,7 @@ describe("scripts/run-vitest-profile", () => {
     },
   );
 
-  it.each([
+  it.for([
     { pool: "forks", isolate: true, custom: false, failRun: false },
     { pool: "threads", isolate: true, custom: false, failRun: true },
     { pool: "forks", isolate: false, custom: false, failRun: true },
@@ -99,39 +100,43 @@ describe("scripts/run-vitest-profile", () => {
     { pool: "forks", isolate: false, custom: false, failRun: false, unhandled: true },
   ])(
     "profiles selected runner %j",
-    async ({
-      pool,
-      isolate,
-      custom,
-      failRun,
-      projects = false,
-      failProfile = false,
-      unhandled = false,
-      errorPolicy = "default",
-    }: {
-      pool: string;
-      isolate: boolean;
-      custom: boolean;
-      failRun: boolean;
-      projects?: boolean;
-      failProfile?: boolean;
-      unhandled?: boolean;
-      errorPolicy?: string;
-    }) => {
-      const root = createTempDir("oc-profile-sibling-");
-      fs.writeFileSync(path.join(root, "package.json"), '{"private":true,"type":"module"}');
-      fs.symlinkSync(
-        path.join(repoRoot, "node_modules"),
-        path.join(root, "node_modules"),
-        "junction",
-      );
-      const environment = custom && pool === "threads" ? "jsdom" : "node";
-      const outputDir = path.join(root, "profiles with spaces");
-      const configPath = path.join(root, "custom.config.ts");
-      const configLoads = path.join(root, "config-loads");
-      fs.writeFileSync(
-        configPath,
-        `import fs from "node:fs";
+    (
+      {
+        pool,
+        isolate,
+        custom,
+        failRun,
+        projects = false,
+        failProfile = false,
+        unhandled = false,
+        errorPolicy = "default",
+      }: {
+        pool: string;
+        isolate: boolean;
+        custom: boolean;
+        failRun: boolean;
+        projects?: boolean;
+        failProfile?: boolean;
+        unhandled?: boolean;
+        errorPolicy?: string;
+      },
+      { signal },
+    ) =>
+      lifetime.run(async () => {
+        const root = createTempDir("oc-profile-sibling-");
+        fs.writeFileSync(path.join(root, "package.json"), '{"private":true,"type":"module"}');
+        fs.symlinkSync(
+          path.join(repoRoot, "node_modules"),
+          path.join(root, "node_modules"),
+          "junction",
+        );
+        const environment = custom && pool === "threads" ? "jsdom" : "node";
+        const outputDir = path.join(root, "profiles with spaces");
+        const configPath = path.join(root, "custom.config.ts");
+        const configLoads = path.join(root, "config-loads");
+        fs.writeFileSync(
+          configPath,
+          `import fs from "node:fs";
 fs.appendFileSync(${JSON.stringify(configLoads)}, "loaded\\n");
 export default { test: {
   include: ["*.test.ts"], exclude: ["config-excluded.test.ts"], reporters: ["default", "json"], outputFile: "report.json",
@@ -141,31 +146,31 @@ export default { test: {
   ${errorPolicy === "filter" ? 'onUnhandledError(error) { console.error("filtered workload error:", error.message); return false; },' : ""}
   ${projects ? `projects: ["first", "second"].map(name => ({ extends: false, test: { name, include: [name + ".test.ts"], exclude: ["config-excluded.test.ts"], runner: ${JSON.stringify(path.join(root, "custom-runner.ts"))} } })),` : ""}
 } };`,
-      );
-      for (const name of ["config-excluded", "cli-excluded"]) {
-        fs.writeFileSync(
-          path.join(root, name + ".test.ts"),
-          'throw new Error("excluded files must not run");',
         );
-      }
-      fs.writeFileSync(
-        path.join(root, "custom-setup.ts"),
-        `export function setup(project) {
+        for (const name of ["config-excluded", "cli-excluded"]) {
+          fs.writeFileSync(
+            path.join(root, name + ".test.ts"),
+            'throw new Error("excluded files must not run");',
+          );
+        }
+        fs.writeFileSync(
+          path.join(root, "custom-setup.ts"),
+          `export function setup(project) {
   project.provide("customSetupCount", (project.getProvidedContext().customSetupCount ?? 0) + 1);
 }`,
-      );
-      const customRunner = path.join(root, "custom-runner.ts");
-      fs.writeFileSync(
-        customRunner,
-        `import { TestRunner } from "vitest";
+        );
+        const customRunner = path.join(root, "custom-runner.ts");
+        fs.writeFileSync(
+          customRunner,
+          `import { TestRunner } from "vitest";
 export default class extends TestRunner {
   onCollectStart(file) { super.onCollectStart(file); globalThis.profileCustomRunner = true; }
 }`,
-      );
-      for (const name of ["first", "second"]) {
-        fs.writeFileSync(
-          path.join(root, `${name}.test.ts`),
-          `import fs from "node:fs";
+        );
+        for (const name of ["first", "second"]) {
+          fs.writeFileSync(
+            path.join(root, `${name}.test.ts`),
+            `import fs from "node:fs";
 import process from "node:process";
 import { isMainThread, threadId } from "node:worker_threads";
 import { expect, inject, it, vi } from "vitest";
@@ -193,139 +198,198 @@ it("retains the selected execution context", async () => {
   ${unhandled && name === "second" ? 'process.emit("unhandledRejection", new Error("intentional unhandled profiling workload"), Promise.resolve());' : ""}
   ${failRun && name === "second" ? 'expect.fail("intentional profiling sibling failure");' : ""}
 });`,
-        );
-      }
-      const args = [
-        path.join(repoRoot, "scripts/run-vitest-profile.mts"),
-        "runner",
-        "--output-dir",
-        outputDir,
-        "--",
-        "--config",
-        configPath,
-        "--configLoader",
-        "native",
-        "--pool",
-        pool,
-        `--isolate=${isolate}`,
-        "--maxWorkers",
-        "1",
-        "--environment",
-        environment,
-        "--exclude",
-        "cli-excluded.test.ts",
-      ];
-      if (projects) {
-        args.push("--reporter", "dot", "--reporter", "json");
-      }
-      const result = await runProfileProcess(process.execPath, args, root);
-      const reportPath = path.join(root, "report.json");
-      const reportText = fs.existsSync(reportPath) ? fs.readFileSync(reportPath, "utf8") : "";
-      const shouldFail = failRun || failProfile || (unhandled && errorPolicy === "default");
-      expect(result.code, `${result.output}\n${reportText}`).toBe(shouldFail ? 1 : 0);
-      expect(fs.readFileSync(configLoads, "utf8")).toBe("loaded\n");
-      if (shouldFail) {
-        expect(result.output.trimEnd()).toMatch(/\[run-vitest-profile\] FAILED \(exit 1\)$/u);
-      }
-      if (failRun) {
-        expect(result.output).toContain("intentional profiling sibling failure");
-      }
-      if (unhandled) {
-        expect(result.output).toContain("intentional unhandled profiling workload");
-      }
-      const report = JSON.parse(reportText);
-      expect(report.numTotalTests).toBe(2);
-      expect(report.numFailedTests).toBe(failRun ? 1 : 0);
-      if (failProfile) {
-        expect(result.output).toContain("Failed to write Vitest profiles.");
-        expect(result.output).toContain("ENOENT");
-        expect(fs.existsSync(outputDir)).toBe(false);
-        return;
-      }
-      const profiles = fs.readdirSync(outputDir);
-      for (const name of ["first", "second"]) {
-        const { pid, threadId } = JSON.parse(
-          fs.readFileSync(path.join(root, name + ".json"), "utf8"),
-        );
-        const cpuFiles = profiles.filter((file) => file.startsWith(`CPU.${pid}.${threadId}.`));
-        const heapFiles = profiles.filter((file) => file.startsWith(`Heap.${pid}.${threadId}.`));
-        // Repeated files share one sampler unless Vitest actually creates another worker.
-        expect(cpuFiles, result.output).toHaveLength(1);
-        expect(heapFiles, result.output).toHaveLength(1);
-        const cpu = JSON.parse(fs.readFileSync(path.join(outputDir, cpuFiles[0]!), "utf8"));
-        const heap = JSON.parse(
-          fs.readFileSync(path.join(outputDir, heapFiles[0]!), "utf8"),
-        ) as HeapProfiler.SamplingHeapProfile;
-        expect(cpu.nodes.length).toBeGreaterThan(0);
-        expect(cpu.samples.length).toBeGreaterThan(0);
-        expect(cpu.endTime).toBeGreaterThan(cpu.startTime);
-        expect(heap.head.children.length).toBeGreaterThan(0);
-        const nodes = [heap.head];
-        for (const node of nodes) {
-          nodes.push(...node.children);
+          );
         }
-        const workload = nodes.find(
-          (node) => node.callFrame.functionName === `retain_${name}_heap_workload`,
-        );
-        expect(workload?.selfSize).toBeGreaterThan(0);
-      }
-    },
+        const args = [
+          path.join(repoRoot, "scripts/run-vitest-profile.mts"),
+          "runner",
+          "--output-dir",
+          outputDir,
+          "--",
+          "--config",
+          configPath,
+          "--configLoader",
+          "native",
+          "--pool",
+          pool,
+          `--isolate=${isolate}`,
+          "--maxWorkers",
+          "1",
+          "--environment",
+          environment,
+          "--exclude",
+          "cli-excluded.test.ts",
+        ];
+        if (projects) {
+          args.push("--reporter", "dot", "--reporter", "json");
+        }
+        const result = await runProfileProcess(args, root, signal);
+        const reportPath = path.join(root, "report.json");
+        const reportText = fs.existsSync(reportPath) ? fs.readFileSync(reportPath, "utf8") : "";
+        const shouldFail = failRun || failProfile || (unhandled && errorPolicy === "default");
+        expect(result.code, `${result.output}\n${reportText}`).toBe(shouldFail ? 1 : 0);
+        expect(fs.readFileSync(configLoads, "utf8")).toBe("loaded\n");
+        if (shouldFail) {
+          expect(result.output.trimEnd()).toMatch(/\[run-vitest-profile\] FAILED \(exit 1\)$/u);
+        }
+        if (failRun) {
+          expect(result.output).toContain("intentional profiling sibling failure");
+        }
+        if (unhandled) {
+          expect(result.output).toContain("intentional unhandled profiling workload");
+        }
+        const report = JSON.parse(reportText);
+        expect(report.numTotalTests).toBe(2);
+        expect(report.numFailedTests).toBe(failRun ? 1 : 0);
+        if (failProfile) {
+          expect(result.output).toContain("Failed to write Vitest profiles.");
+          expect(result.output).toContain("ENOENT");
+          expect(fs.existsSync(outputDir)).toBe(false);
+          return;
+        }
+        const profiles = fs.readdirSync(outputDir);
+        for (const name of ["first", "second"]) {
+          const { pid, threadId } = JSON.parse(
+            fs.readFileSync(path.join(root, name + ".json"), "utf8"),
+          );
+          const cpuFiles = profiles.filter((file) => file.startsWith(`CPU.${pid}.${threadId}.`));
+          const heapFiles = profiles.filter((file) => file.startsWith(`Heap.${pid}.${threadId}.`));
+          // Repeated files share one sampler unless Vitest actually creates another worker.
+          expect(cpuFiles, result.output).toHaveLength(1);
+          expect(heapFiles, result.output).toHaveLength(1);
+          const cpu = JSON.parse(fs.readFileSync(path.join(outputDir, cpuFiles[0]!), "utf8"));
+          const heap = JSON.parse(
+            fs.readFileSync(path.join(outputDir, heapFiles[0]!), "utf8"),
+          ) as HeapProfiler.SamplingHeapProfile;
+          expect(cpu.nodes.length).toBeGreaterThan(0);
+          expect(cpu.samples.length).toBeGreaterThan(0);
+          expect(cpu.endTime).toBeGreaterThan(cpu.startTime);
+          expect(heap.head.children.length).toBeGreaterThan(0);
+          const nodes = [heap.head];
+          for (const node of nodes) {
+            nodes.push(...node.children);
+          }
+          const workload = nodes.find(
+            (node) => node.callFrame.functionName === `retain_${name}_heap_workload`,
+          );
+          expect(workload?.selfSize).toBeGreaterThan(0);
+        }
+      }),
   );
 
-  it.each([
+  it("cancels an admitted profiling workload before releasing its inputs", ({ signal }) =>
+    lifetime.run(async () => {
+      const root = createTempDir("oc-profile-cancellation-");
+      const ready = path.join(root, "ready");
+      const release = path.join(root, "release");
+      const config = path.join(root, "vitest.config.mjs");
+      fs.writeFileSync(path.join(root, "package.json"), '{"private":true,"type":"module"}');
+      fs.symlinkSync(
+        path.join(repoRoot, "node_modules"),
+        path.join(root, "node_modules"),
+        "junction",
+      );
+      fs.writeFileSync(
+        config,
+        'export default { test: { include: ["workload.test.ts"], pool: "threads", maxWorkers: 1 } };',
+      );
+      fs.writeFileSync(
+        path.join(root, "workload.test.ts"),
+        `import fs from "node:fs";
+import { setTimeout as tick } from "node:timers/promises";
+import { it } from "vitest";
+it("holds admitted work until the caller releases it", async () => {
+  fs.writeFileSync(${JSON.stringify(ready)}, "ready");
+  while (!fs.existsSync(${JSON.stringify(release)})) await tick(5);
+});`,
+      );
+      const controller = new AbortController();
+      const completion = runProfileProcess(
+        [
+          path.join(repoRoot, "scripts/run-vitest-profile.mts"),
+          "runner",
+          "--output-dir",
+          path.join(root, "profiles"),
+          "--",
+          "--config",
+          config,
+          "--configLoader",
+          "native",
+        ],
+        root,
+        AbortSignal.any([signal, controller.signal]),
+      );
+      try {
+        await waitForFixtureFile(ready, completion, "ready");
+        const aborted = expect(completion).rejects.toMatchObject({ cause: { code: "ABORT_ERR" } });
+        controller.abort();
+        fs.writeFileSync(release, "released");
+        await aborted;
+      } finally {
+        controller.abort();
+        fs.writeFileSync(release, "released");
+        await completion.catch(() => {});
+      }
+    }));
+
+  it.for([
     { mode: "main", flags: ["--help", "--unknown-profile-test-option"] },
     { mode: "runner", flags: ["-h", "--pool"] },
     { mode: "main", flags: ["--help", "--help"] },
     { mode: "runner", flags: ["--help", "--help"] },
-  ])("prints $mode help for $flags without starting a test server", async ({ mode, flags }) => {
-    const root = createTempDir("oc-profile-help-");
-    const args = [
-      path.join(repoRoot, "scripts/run-vitest-profile.mts"),
-      mode,
-      "--output-dir",
-      path.join(root, "profiles"),
-      "--",
-      ...flags,
-    ];
-    const result = await runProfileProcess(process.execPath, args, root);
-    expect(result.code, result.output).toBe(0);
-    expect(result.output).toContain("Usage:");
-  });
+  ])("prints $mode help for $flags without starting a test server", ({ mode, flags }, { signal }) =>
+    lifetime.run(async () => {
+      const root = createTempDir("oc-profile-help-");
+      const args = [
+        path.join(repoRoot, "scripts/run-vitest-profile.mts"),
+        mode,
+        "--output-dir",
+        path.join(root, "profiles"),
+        "--",
+        ...flags,
+      ];
+      const result = await runProfileProcess(args, root, signal);
+      expect(result.code, result.output).toBe(0);
+      expect(result.output).toContain("Usage:");
+    }),
+  );
 
-  it.each(
+  it.for(
     ["main", "runner"].flatMap((mode) => [
       { mode, flag: "--unknown-profile-test-option", error: "Unknown option" },
       { mode, flag: "--runner=custom-runner.ts", error: "Unknown option" },
       { mode, flag: "--pool", error: "value is missing" },
     ]),
-  )("rejects $mode $flag before evaluating config", async ({ mode, flag, error }) => {
-    const root = createTempDir("oc-profile-validation-");
-    const config = path.join(root, "probe.config.mjs");
-    const marker = path.join(root, "config-loaded");
-    fs.writeFileSync(
-      config,
-      `import fs from "node:fs";
+  )("rejects $mode $flag before evaluating config", ({ mode, flag, error }, { signal }) =>
+    lifetime.run(async () => {
+      const root = createTempDir("oc-profile-validation-");
+      const config = path.join(root, "probe.config.mjs");
+      const marker = path.join(root, "config-loaded");
+      fs.writeFileSync(
+        config,
+        `import fs from "node:fs";
 fs.writeFileSync(${JSON.stringify(marker)}, "loaded");
 throw new Error("Invalid CLI options reached config loading");`,
-    );
-    const args = [
-      path.join(repoRoot, "scripts/run-vitest-profile.mts"),
-      mode,
-      "--output-dir",
-      path.join(root, "profiles"),
-      "--",
-      "--config",
-      config,
-      "--configLoader",
-      "native",
-      flag,
-    ];
-    const result = await runProfileProcess(process.execPath, args, root);
-    expect(result.code, result.output).toBe(1);
-    expect(result.output).toContain(error);
-    expect(fs.existsSync(marker)).toBe(false);
-    expect(result.output.trimEnd()).toMatch(/\[run-vitest-profile\] FAILED \(exit 1\)$/u);
-  });
+      );
+      const args = [
+        path.join(repoRoot, "scripts/run-vitest-profile.mts"),
+        mode,
+        "--output-dir",
+        path.join(root, "profiles"),
+        "--",
+        "--config",
+        config,
+        "--configLoader",
+        "native",
+        flag,
+      ];
+      const result = await runProfileProcess(args, root, signal);
+      expect(result.code, result.output).toBe(1);
+      expect(result.output).toContain(error);
+      expect(fs.existsSync(marker)).toBe(false);
+      expect(result.output.trimEnd()).toMatch(/\[run-vitest-profile\] FAILED \(exit 1\)$/u);
+    }),
+  );
 
   it("keeps the public parser's unknown-option opt-in separate from value validation", async () => {
     const { parseCLI } = await import("vitest/node");
@@ -340,18 +404,19 @@ throw new Error("Invalid CLI options reached config loading");`,
     expect(() => parseCLI(["vitest", "init"])).toThrow("missing required args");
   });
 
-  it("retains the CLI startup error when profile output cannot be written", async () => {
-    const root = createTempDir("oc-profile-errors-");
-    const plan = buildVitestProfileCommandWithArgs({
-      mode: "main",
-      outputDir: path.join(root, "missing"),
-      vitestArgs: ["--config", "first.config.ts", "--config", "second.config.ts"],
-    });
-    const result = await runProfileProcess(plan.command, plan.args, root);
-    expect(result.code, result.output).toBe(1);
-    expect(result.output).toContain("Expected a single value");
-    expect(result.output).toContain("ENOENT");
-  });
+  it("retains the CLI startup error when profile output cannot be written", ({ signal }) =>
+    lifetime.run(async () => {
+      const root = createTempDir("oc-profile-errors-");
+      const plan = buildVitestProfileCommandWithArgs({
+        mode: "main",
+        outputDir: path.join(root, "missing"),
+        vitestArgs: ["--config", "first.config.ts", "--config", "second.config.ts"],
+      });
+      const result = await runProfileProcess(plan.args, root, signal);
+      expect(result.code, result.output).toBe(1);
+      expect(result.output).toContain("Expected a single value");
+      expect(result.output).toContain("ENOENT");
+    }));
 
   it("parses mode and explicit output dir", () => {
     expect(parseArgs(["runner", "--output-dir", "/tmp/out"])).toEqual({


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where cancelled or timed-out profiling tests could leave subprocess work running while their temporary inputs were removed.

## Why This Change Was Made

The test helper dropped the `execFile` handle and did not receive Vitest's cancellation signal. Use the existing managed Node-command and fixture-lifetime owners: track each original command result and complete test body, then join cleanup before removing its inputs. Object tables use `it.for` to receive the real test context.

## User Impact

Developer test infrastructure only. Normal profiling CLI behavior, output assertions, the 1 MiB per-stream limit, and test timeouts remain unchanged. Production code has no changes.

## Evidence

- Native Linux regression before the repair: an actual admitted profiling workload ignored abort and resolved with exit code 0; the new assertion failed.
- After the repair: all 35 profiling tests passed, including cancellation, four help variants, option validation, forks/threads, custom runners, CPU/heap output, and error paths.
- Existing real-Vitest lifecycle tests passed for failed observation, cancellation, and timeout, including child/descendant joining before input disposal. All 15 selected changed checks passed.
- Independent source review and isolated Codex autoreview found no actionable issues through P2.

The initial help-case timeout in CI run 34095619920 prompted this audit; its stage remains unknown. That run's single retry passed. This PR fixes the independently reproduced lifetime defect and does not claim to explain the initial timeout.
