### PR TITLE
improve(mistral): reduce overhead in large parallel tool streams

### DIFF
--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -1,4 +1,8 @@
-import { toolCallFromJSON, type ToolCall } from "@mistralai/mistralai/models/components";
+import {
+  contentChunkFromJSON,
+  toolCallFromJSON,
+  type ToolCall,
+} from "@mistralai/mistralai/models/components";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
 import { withProviderAcceptanceObserver } from "../transports/transport-stream-shared.js";
@@ -691,6 +695,84 @@ describe("Mistral provider", () => {
       { name: "computer", arguments: { step: 2 } },
     ]);
     expect(new Set(toolCalls.map((toolCall) => toolCall.id)).size).toBe(2);
+  });
+
+  it("rejects a continuation whose existing id and name identify different siblings", async () => {
+    const { result, toolCalls } = await runMistralToolFixture("response-conflicting-identities", [
+      [
+        { id: "explicitA", function: { name: "first_tool", arguments: '{"value"' } },
+        { id: "explicitB", function: { name: "second_tool", arguments: '{"value"' } },
+      ],
+      [{ id: "explicitA", function: { name: "second_tool", arguments: ":1}" } }],
+    ]);
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe(
+      "Mistral streamed tool-call identities conflict; refusing to merge arguments",
+    );
+    expect(toolCalls).toEqual([]);
+  });
+
+  it("joins thinking text before sanitizing and skips empty reference-only chunks", async () => {
+    const thinkingParts = [
+      [
+        { type: "reference", reference_ids: [1] },
+        { type: "text", text: "" },
+      ],
+      [
+        { type: "text", text: "" },
+        { type: "text", text: "\ud83d" },
+        { type: "tool_reference", tool: "search", title: "source" },
+        { type: "text", text: "\ude00 " },
+        { type: "text", text: "\ud83dx" },
+        { type: "text", text: "" },
+      ],
+      [],
+    ];
+    const chunks = thinkingParts.map((thinking) => {
+      const parsed = contentChunkFromJSON(JSON.stringify({ type: "thinking", thinking }));
+      if (!parsed.ok) {
+        throw new Error("Mistral SDK failed to parse thinking fixture");
+      }
+      return parsed.value;
+    });
+    mistralMockState.streamResult = {
+      async *[Symbol.asyncIterator]() {
+        for (const content of [...chunks.map((chunk) => [chunk]), "done"]) {
+          yield {
+            data: {
+              id: "response-thinking-parts",
+              model: "mistral-large-latest",
+              choices: [{ finishReason: "stop", delta: { content } }],
+            },
+          };
+        }
+      },
+    };
+    const stream = streamMistral(makeMistralModel(), context, { apiKey: "fixture" });
+    const events: string[] = [];
+    const deltas: string[] = [];
+    for await (const event of stream) {
+      events.push(event.type);
+      if (event.type === "thinking_delta") {
+        deltas.push(event.delta);
+      }
+    }
+    expect((await stream.result()).content).toEqual([
+      { type: "thinking", thinking: "😀 x" },
+      { type: "text", text: "done" },
+    ]);
+    expect(deltas).toEqual(["😀 x"]);
+    expect(events).toEqual([
+      "start",
+      "thinking_start",
+      "thinking_delta",
+      "thinking_end",
+      "text_start",
+      "text_delta",
+      "text_end",
+      "done",
+    ]);
   });
 
   it("fails locally when a pinned Mistral tool choice is skipped", async () => {

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -464,14 +464,6 @@ async function consumeChatStream(
           params.usedContentIndexes,
         )
       : new Set<number>();
-    const indexCandidates =
-      toolCallIndex === undefined
-        ? new Set<number>()
-        : findIdentityCandidates(
-            (identity) => identity.indexes.has(toolCallIndex),
-            params.usedContentIndexes,
-          );
-
     if (idCandidates.size > 0) {
       let candidates = idCandidates;
       if (nameCandidates.size > 0) {
@@ -517,6 +509,14 @@ async function consumeChatStream(
       }
       return requireSingleCandidate(indexCompatibleCandidates);
     }
+
+    const indexCandidates =
+      toolCallIndex === undefined
+        ? new Set<number>()
+        : findIdentityCandidates(
+            (identity) => identity.indexes.has(toolCallIndex),
+            params.usedContentIndexes,
+          );
 
     if (functionName) {
       // A new name normally starts a sibling call even when the SDK's omitted
@@ -636,10 +636,7 @@ async function consumeChatStream(
         }
 
         if (item.type === "thinking") {
-          const deltaText = item.thinking
-            .map((part) => ("text" in part ? part.text : ""))
-            .filter((text) => text.length > 0)
-            .join("");
+          const deltaText = item.thinking.map((part) => ("text" in part ? part.text : "")).join("");
           const thinkingDelta = sanitizeSurrogates(deltaText);
           if (!thinkingDelta) {
             continue;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep Allow edits from maintainers enabled where applicable.

</details>

## What Problem This Solves

Large parallel-tool responses from Mistral perform avoidable work while assembling streamed results. The adapter scans index identities even when a persistent ID or name already decides the continuation. Thinking fragments also pass through an empty-string filter before concatenation.

## Why This Change Was Made

Move the unchanged index scan below the existing ID/name branches and remove the redundant thinking filter. Existing conflict refusal, sibling exclusions, SDK default-zero handling, late identity adoption, strict terminal parsing and post-concatenation surrogate sanitation stay unchanged. This is one local stream-preparation cleanup: three fewer production lines, no cache, configuration, dependency or protocol change.

## User Impact

In a fixed public-stream/real-SDK synthetic cohort, the 32-parallel-call case improves **5.09% / 3.79%** across the two execution orders, saving about **297 / 219 microseconds** per complete stream. Its other measured aggregate statistics improve in both orders too.

The performance exchange is explicitly accepted for this bounded improvement and simpler preparation. **26 of 36 batch medians regress**: the tiny-ID case costs about 32–34 microseconds more (8–9%); mixed32 thinking costs 84–99 microseconds more (5–6%); whitespace thinking costs 146/16 microseconds more (40.83%/3.74%). The empty-thinking median improves 7.91%/8.46%, but some maxima and first warmups regress. These costs are not dismissed as noise. Production frequencies and a workload-weighted net benefit remain unknown; this does not claim a general, default-path, provider-network or Gateway speedup.

## Evidence

All **58 tests across three complete suites** passed, including installed-SDK HTTP/SSE and HTTPClient contracts. Two added preservation cases cover cross-sibling ID/name conflict and empty/reference/split-surrogate thinking. All **28 normal changed checks** passed; independent default Codex P2 review returned scoped-clean with no findings. Tests add 82 lines; production removes 3.

A fixed **B0,C0,C1,B1** cohort exercised actual streamMistral, installed Mistral SDK 2.6.4, request construction, guarded local fixture fetch, SSE parsing, event consumption and final settlement. Eighteen predeclared cases produced **2,016 complete V8 graphs and 161,504 events**, all checked against independent full request/final/event oracles. Tool-response rows declare matching schemas; no external Mistral call or real credential is involved. Timestamp values are retained and bounded separately. Partial objects are late shared references, not per-emission snapshots; selected graph aliases are verified explicitly.

Each case has four individually timed warmups and 12 means of two individually timed streams per phase. Serialization/assertions/journaling occur outside individual intervals; whole-child observations include that work. First warmups follow imports and possibly earlier rows, not cold startup; maxima of two-call means are not individual-call tail percentiles. An independent retained-data audit recomputed every comparison and verified all outputs, aliases, input/source/dependency pins, closure and candidate restoration without rerunning the target or supplied reducer.

All **153/252 aggregate, 312/576 indexed and 1/12 resource adverse comparisons** remain in the evidence. Whole-child wall decreases 16.94%/1.27%, but reverse user CPU increases 0.145%; these mixed workload/setup/capture figures are not substituted for per-row timings. Observed RSS is lower in both orders, without an allocation or persistent-memory claim.

Complete paired medians, milliseconds per full synthetic stream (lower is better):

| Scenario | B0 baseline ms | C0 candidate ms | B1 baseline ms | C1 candidate ms |
| --- | ---: | ---: | ---: | ---: |
| M01-text-control | 0.300188 | 0.325010 | 0.368865 | 0.342958 |
| M02-tiny-id | 0.377584 | 0.411740 | 0.400979 | 0.433073 |
| M03-long-id | 1.597968 | 1.596927 | 1.615198 | 1.635865 |
| M04-parallel8-id | 1.814271 | 1.819115 | 1.888490 | 1.917489 |
| M05-parallel32-id | 5.841781 | 5.544417 | 5.774875 | 5.556042 |
| M06-parallel8-name-default-index | 1.669594 | 1.699833 | 1.684636 | 1.705417 |
| M07-parallel8-same-name-ids | 1.729646 | 1.778156 | 1.675313 | 1.713146 |
| M08-parallel8-index-only | 1.627448 | 1.722916 | 1.696750 | 1.702219 |
| M09-asymmetric-name | 0.274844 | 0.276198 | 0.274292 | 0.295749 |
| M10-conflicting-id-name | 0.312125 | 0.295094 | 0.270968 | 0.349719 |
| M11-ambiguous-default-index | 0.279052 | 0.296104 | 0.284989 | 0.297250 |
| M12-length-terminal-control | 1.622490 | 1.515229 | 1.593000 | 1.663573 |
| T13-empty | 0.218823 | 0.201510 | 0.230177 | 0.210708 |
| T14-reference-only | 0.442375 | 0.450937 | 0.408135 | 0.381510 |
| T15-split-surrogates | 0.445115 | 0.467917 | 0.414708 | 0.442031 |
| T16-whitespace | 0.356791 | 0.502459 | 0.439115 | 0.455521 |
| T17-mixed32 | 1.584239 | 1.668271 | 1.541146 | 1.640177 |
| T18-mixed256 | 10.894750 | 10.975000 | 11.068010 | 10.822104 |

Proof binds base `86a3c7267be4a6a49cc3de5b00ec87588421783d` and candidate owner SHA-256 `84734dbdd6d991a9e6dbc00afa847588a51134245e6a89cb050e479296522c5f`. All numerical children and the enclosing parent closed; the candidate was restored exactly. The earlier unrun no-tools fixture was preserved and corrected before any numerical run. That apparatus correction does not relabel the source review as a review of newer benchmark files.

Separate real-OpenAI Gateway baseline tasks passed 18/18, but they do not exercise Mistral and are not used as Mistral proof. Representative production traffic mix and external Mistral timing remain outside this PR's claim.
