### PR TITLE
refactor(channels): share DM policy schema validation

### DIFF
--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -770,6 +770,14 @@ those defaults to account entries or remove them from the root; the former
 shadows operator settings and the latter can leave group access open.
 This replaces `buildCommonChannelAccountShape` and its defaulting flags.
 
+Use `refineChannelDmPolicy({ channelId, value, ctx })` from the same subpath
+to validate the root policy against `allowFrom`. Pass `accountId` to validate
+one account with root-policy and allowlist inheritance, including explicit
+empty-array overrides. The helper emits the standard root/account error paths
+and messages for `open` and `allowlist` policies. Keep account iteration,
+disabled-account filtering, and ordering relative to other refinements in the
+channel, since those rules differ between plugins.
+
 Use `mergeAccountConfig` or `resolveMergedAccountConfig` through the existing
 `openclaw/plugin-sdk/account-helpers` export for runtime inheritance. Their
 shared implementation lives at `src/config/channel-account-config.ts`;

--- a/extensions/discord/src/config-schema.ts
+++ b/extensions/discord/src/config-schema.ts
@@ -12,8 +12,7 @@ import {
   ChannelPreviewStreamingConfigSchema,
   ChannelStreamingProgressSchema,
   ProviderCommandsSchema,
-  requireAllowlistAllowFrom,
-  requireOpenAllowFrom,
+  refineChannelDmPolicy,
   TtsConfigSchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor-migrations";
@@ -407,23 +406,7 @@ const DiscordConfigSchemaBase = DiscordAccountSchemaBase.safeExtend({
   accounts: z.record(z.string(), DiscordAccountSchema.optional()).optional(),
   defaultAccount: z.string().optional(),
 }).superRefine((value, ctx) => {
-  const dmPolicy = value.dmPolicy ?? "pairing";
-  const allowFrom = value.allowFrom;
-  requireOpenAllowFrom({
-    policy: dmPolicy,
-    allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message: 'channels.discord.dmPolicy="open" requires channels.discord.allowFrom to include "*"',
-  });
-  requireAllowlistAllowFrom({
-    policy: dmPolicy,
-    allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message:
-      'channels.discord.dmPolicy="allowlist" requires channels.discord.allowFrom to contain at least one sender ID',
-  });
+  refineChannelDmPolicy({ channelId: "discord", value, ctx });
 
   if (!value.accounts) {
     return;
@@ -432,24 +415,7 @@ const DiscordConfigSchemaBase = DiscordAccountSchemaBase.safeExtend({
     if (!account) {
       continue;
     }
-    const effectivePolicy = account.dmPolicy ?? value.dmPolicy ?? "pairing";
-    const effectiveAllowFrom = account.allowFrom ?? value.allowFrom;
-    requireOpenAllowFrom({
-      policy: effectivePolicy,
-      allowFrom: effectiveAllowFrom,
-      ctx,
-      path: ["accounts", accountId, "allowFrom"],
-      message:
-        'channels.discord.accounts.*.dmPolicy="open" requires channels.discord.accounts.*.allowFrom (or channels.discord.allowFrom) to include "*"',
-    });
-    requireAllowlistAllowFrom({
-      policy: effectivePolicy,
-      allowFrom: effectiveAllowFrom,
-      ctx,
-      path: ["accounts", accountId, "allowFrom"],
-      message:
-        'channels.discord.accounts.*.dmPolicy="allowlist" requires channels.discord.accounts.*.allowFrom (or channels.discord.allowFrom) to contain at least one sender ID',
-    });
+    refineChannelDmPolicy({ channelId: "discord", value, accountId, ctx });
   }
 });
 

--- a/extensions/imessage/src/config-schema.ts
+++ b/extensions/imessage/src/config-schema.ts
@@ -9,8 +9,7 @@ import {
   ExecutableTokenSchema,
   isSafeScpRemoteHost,
   isValidInboundPathRootPattern,
-  requireAllowlistAllowFrom,
-  requireOpenAllowFrom,
+  refineChannelDmPolicy,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { z } from "zod";
 import { iMessageChannelConfigUiHints } from "./config-ui-hints.js";
@@ -90,22 +89,7 @@ export const IMessageConfigSchema = IMessageAccountSchemaBase.extend({
   accounts: z.record(z.string(), IMessageAccountSchemaBase.optional()).optional(),
   defaultAccount: z.string().optional(),
 }).superRefine((value, ctx) => {
-  requireOpenAllowFrom({
-    policy: value.dmPolicy,
-    allowFrom: value.allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message:
-      'channels.imessage.dmPolicy="open" requires channels.imessage.allowFrom to include "*"',
-  });
-  requireAllowlistAllowFrom({
-    policy: value.dmPolicy,
-    allowFrom: value.allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message:
-      'channels.imessage.dmPolicy="allowlist" requires channels.imessage.allowFrom to contain at least one sender ID',
-  });
+  refineChannelDmPolicy({ channelId: "imessage", value, ctx });
 
   if (!value.accounts) {
     return;
@@ -114,24 +98,7 @@ export const IMessageConfigSchema = IMessageAccountSchemaBase.extend({
     if (!account) {
       continue;
     }
-    const effectivePolicy = account.dmPolicy ?? value.dmPolicy;
-    const effectiveAllowFrom = account.allowFrom ?? value.allowFrom;
-    requireOpenAllowFrom({
-      policy: effectivePolicy,
-      allowFrom: effectiveAllowFrom,
-      ctx,
-      path: ["accounts", accountId, "allowFrom"],
-      message:
-        'channels.imessage.accounts.*.dmPolicy="open" requires channels.imessage.accounts.*.allowFrom (or channels.imessage.allowFrom) to include "*"',
-    });
-    requireAllowlistAllowFrom({
-      policy: effectivePolicy,
-      allowFrom: effectiveAllowFrom,
-      ctx,
-      path: ["accounts", accountId, "allowFrom"],
-      message:
-        'channels.imessage.accounts.*.dmPolicy="allowlist" requires channels.imessage.accounts.*.allowFrom (or channels.imessage.allowFrom) to contain at least one sender ID',
-    });
+    refineChannelDmPolicy({ channelId: "imessage", value, accountId, ctx });
   }
 });
 

--- a/extensions/signal/src/config-schema.ts
+++ b/extensions/signal/src/config-schema.ts
@@ -13,8 +13,7 @@ import {
   ChannelSendReadReceiptsSchema,
   ExecutableTokenSchema,
   ReplyToModeSchema,
-  requireAllowlistAllowFrom,
-  requireOpenAllowFrom,
+  refineChannelDmPolicy,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { z } from "zod";
@@ -154,44 +153,13 @@ const SignalConfigSchemaBase = SignalAccountSchemaBase.extend({
 type SignalConfigValidationValue = z.infer<typeof SignalConfigSchemaBase>;
 
 function validateSignalConfigAllowFrom(value: SignalConfigValidationValue, ctx: z.RefinementCtx) {
-  requireOpenAllowFrom({
-    policy: value.dmPolicy,
-    allowFrom: value.allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message: 'channels.signal.dmPolicy="open" requires channels.signal.allowFrom to include "*"',
-  });
-  requireAllowlistAllowFrom({
-    policy: value.dmPolicy,
-    allowFrom: value.allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message:
-      'channels.signal.dmPolicy="allowlist" requires channels.signal.allowFrom to contain at least one sender ID',
-  });
+  refineChannelDmPolicy({ channelId: "signal", value, ctx });
 
   for (const [accountId, account] of Object.entries(value.accounts ?? {})) {
     if (!account) {
       continue;
     }
-    const effectivePolicy = account.dmPolicy ?? value.dmPolicy;
-    const effectiveAllowFrom = account.allowFrom ?? value.allowFrom;
-    requireOpenAllowFrom({
-      policy: effectivePolicy,
-      allowFrom: effectiveAllowFrom,
-      ctx,
-      path: ["accounts", accountId, "allowFrom"],
-      message:
-        'channels.signal.accounts.*.dmPolicy="open" requires channels.signal.accounts.*.allowFrom (or channels.signal.allowFrom) to include "*"',
-    });
-    requireAllowlistAllowFrom({
-      policy: effectivePolicy,
-      allowFrom: effectiveAllowFrom,
-      ctx,
-      path: ["accounts", accountId, "allowFrom"],
-      message:
-        'channels.signal.accounts.*.dmPolicy="allowlist" requires channels.signal.accounts.*.allowFrom (or channels.signal.allowFrom) to contain at least one sender ID',
-    });
+    refineChannelDmPolicy({ channelId: "signal", value, accountId, ctx });
   }
 }
 

--- a/extensions/slack/src/config-schema.ts
+++ b/extensions/slack/src/config-schema.ts
@@ -13,8 +13,7 @@ import {
   ChannelStreamingProgressSchema,
   ProviderCommandsSchema,
   ReplyToModeSchema,
-  requireAllowlistAllowFrom,
-  requireOpenAllowFrom,
+  refineChannelDmPolicy,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { buildSecretInputSchema, hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input";
 import { z } from "zod";
@@ -214,23 +213,7 @@ export const SlackConfigSchema = SlackAccountSchema.safeExtend({
     return;
   }
 
-  const dmPolicy = value.dmPolicy ?? "pairing";
-  const allowFrom = value.allowFrom;
-  requireOpenAllowFrom({
-    policy: dmPolicy,
-    allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message: 'channels.slack.dmPolicy="open" requires channels.slack.allowFrom to include "*"',
-  });
-  requireAllowlistAllowFrom({
-    policy: dmPolicy,
-    allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message:
-      'channels.slack.dmPolicy="allowlist" requires channels.slack.allowFrom to contain at least one sender ID',
-  });
+  refineChannelDmPolicy({ channelId: "slack", value, ctx });
 
   const requireRelayConfig = (
     relay: { url?: unknown; authToken?: unknown; gatewayId?: unknown } | undefined,
@@ -278,24 +261,7 @@ export const SlackConfigSchema = SlackAccountSchema.safeExtend({
       ...value.relay,
       ...account.relay,
     };
-    const effectivePolicy = account.dmPolicy ?? value.dmPolicy ?? "pairing";
-    const effectiveAllowFrom = account.allowFrom ?? value.allowFrom;
-    requireOpenAllowFrom({
-      policy: effectivePolicy,
-      allowFrom: effectiveAllowFrom,
-      ctx,
-      path: ["accounts", accountId, "allowFrom"],
-      message:
-        'channels.slack.accounts.*.dmPolicy="open" requires channels.slack.accounts.*.allowFrom (or channels.slack.allowFrom) to include "*"',
-    });
-    requireAllowlistAllowFrom({
-      policy: effectivePolicy,
-      allowFrom: effectiveAllowFrom,
-      ctx,
-      path: ["accounts", accountId, "allowFrom"],
-      message:
-        'channels.slack.accounts.*.dmPolicy="allowlist" requires channels.slack.accounts.*.allowFrom (or channels.slack.allowFrom) to contain at least one sender ID',
-    });
+    refineChannelDmPolicy({ channelId: "slack", value, accountId, ctx });
     if (accountMode !== "http") {
       if (accountMode === "relay") {
         requireRelayConfig(effectiveRelay, ["accounts", accountId, "relay"]);

--- a/extensions/telegram/src/config-schema.ts
+++ b/extensions/telegram/src/config-schema.ts
@@ -10,8 +10,7 @@ import {
   DmPolicySchema,
   GroupPolicySchema,
   ProviderCommandsSchema,
-  requireAllowlistAllowFrom,
-  requireOpenAllowFrom,
+  refineChannelDmPolicy,
   ToolPolicySchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import {
@@ -289,22 +288,7 @@ export const TelegramConfigSchema = TelegramAccountSchemaBase.extend({
   accounts: z.record(z.string(), TelegramAccountSchema.optional()).optional(),
   defaultAccount: z.string().optional(),
 }).superRefine((value, ctx) => {
-  requireOpenAllowFrom({
-    policy: value.dmPolicy,
-    allowFrom: value.allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message:
-      'channels.telegram.dmPolicy="open" requires channels.telegram.allowFrom to include "*"',
-  });
-  requireAllowlistAllowFrom({
-    policy: value.dmPolicy,
-    allowFrom: value.allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message:
-      'channels.telegram.dmPolicy="allowlist" requires channels.telegram.allowFrom to contain at least one sender ID',
-  });
+  refineChannelDmPolicy({ channelId: "telegram", value, ctx });
   validateTelegramCustomCommands(value, ctx);
 
   if (value.accounts) {
@@ -312,24 +296,7 @@ export const TelegramConfigSchema = TelegramAccountSchemaBase.extend({
       if (!account) {
         continue;
       }
-      const effectivePolicy = account.dmPolicy ?? value.dmPolicy;
-      const effectiveAllowFrom = account.allowFrom ?? value.allowFrom;
-      requireOpenAllowFrom({
-        policy: effectivePolicy,
-        allowFrom: effectiveAllowFrom,
-        ctx,
-        path: ["accounts", accountId, "allowFrom"],
-        message:
-          'channels.telegram.accounts.*.dmPolicy="open" requires channels.telegram.accounts.*.allowFrom (or channels.telegram.allowFrom) to include "*"',
-      });
-      requireAllowlistAllowFrom({
-        policy: effectivePolicy,
-        allowFrom: effectiveAllowFrom,
-        ctx,
-        path: ["accounts", accountId, "allowFrom"],
-        message:
-          'channels.telegram.accounts.*.dmPolicy="allowlist" requires channels.telegram.accounts.*.allowFrom (or channels.telegram.allowFrom) to contain at least one sender ID',
-      });
+      refineChannelDmPolicy({ channelId: "telegram", value, accountId, ctx });
     }
   }
 

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -358,7 +358,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +7: card projection plus three rendering helpers on channel-outbound and its shipped barrel.
       // +2: shared diff-stat rendering on channel-outbound and its shipped barrel.
       // +1: shared static UI guidance, separate from per-turn harness delivery policy.
-      4446,
+      // +1: shared root/account DM-policy validation for channel config schemas.
+      4447,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -485,7 +486,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +7: card projection plus three rendering helpers on channel-outbound and its shipped barrel.
       // +2: shared diff-stat rendering on channel-outbound and its shipped barrel.
       // +1: shared static UI guidance, separate from per-turn harness delivery policy.
-      2630,
+      // +1: shared root/account DM-policy validation for channel config schemas.
+      2631,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/channels/plugins/config-schema.ts
+++ b/src/channels/plugins/config-schema.ts
@@ -5,7 +5,10 @@
  */
 import { z, type ZodRawShape, type ZodTypeAny } from "zod";
 import { ToolPolicySchema } from "../../config/zod-schema.agent-runtime.js";
-import { DmPolicySchema } from "../../config/zod-schema.core.js";
+import {
+  DmPolicySchema,
+  evaluateDmPolicyAllowFromDependency,
+} from "../../config/zod-schema.core.js";
 import {
   parseJsonSchemaIssuePath,
   validateJsonSchemaValue,
@@ -30,6 +33,45 @@ type ExtendableZodObject = ZodTypeAny & {
 const AllowFromEntrySchema = z.union([z.string(), z.number()]);
 /** Optional allowlist array used by channel config schema builders. */
 export const AllowFromListSchema = z.array(AllowFromEntrySchema).optional();
+
+type ChannelDmPolicyFields = {
+  dmPolicy?: string;
+  allowFrom?: Array<string | number>;
+};
+
+/** Validate one policy scope; the channel owns account selection and refinement ordering. */
+export function refineChannelDmPolicy(params: {
+  channelId: string;
+  value: ChannelDmPolicyFields & {
+    accounts?: Record<string, ChannelDmPolicyFields | undefined>;
+  };
+  accountId?: string;
+  ctx: z.RefinementCtx;
+}): void {
+  const { channelId, value, accountId, ctx } = params;
+  const account = accountId === undefined ? value : value.accounts?.[accountId];
+  if (!account) {
+    return;
+  }
+  const policy = account.dmPolicy ?? value.dmPolicy;
+  const violation = evaluateDmPolicyAllowFromDependency({
+    policy,
+    allowFrom: account.allowFrom ?? value.allowFrom,
+  });
+  if (!violation) {
+    return;
+  }
+  const root = `channels.${channelId}`;
+  const owner = accountId === undefined ? root : `${root}.accounts.*`;
+  const inherited = accountId === undefined ? "" : ` (or ${root}.allowFrom)`;
+  const requirement =
+    violation === "open_requires_wildcard" ? 'include "*"' : "contain at least one sender ID";
+  ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    path: accountId === undefined ? ["allowFrom"] : ["accounts", accountId, "allowFrom"],
+    message: `${owner}.dmPolicy="${policy}" requires ${owner}.allowFrom${inherited} to ${requirement}`,
+  });
+}
 
 /** Canonical per-group/room channel policy shape. */
 export const ChannelGroupEntrySchema = z

--- a/src/plugin-sdk/channel-config-schema.ts
+++ b/src/plugin-sdk/channel-config-schema.ts
@@ -13,6 +13,7 @@ export {
   buildJsonChannelConfigSchema,
   buildMultiAccountChannelSchema,
   buildNestedDmConfigSchema,
+  refineChannelDmPolicy,
 } from "../channels/plugins/config-schema.js";
 export {
   BlockStreamingChunkSchema,


### PR DESCRIPTION
Closes #140999

## What Problem This Solves

Discord, iMessage, Signal, Slack and Telegram duplicate root/account DM-policy validation and diagnostic construction. Keeping these copies aligned makes policy inheritance, explicit empty allowlists and error paths harder to maintain consistently.

## Why This Change Was Made

Add one typed refinement on the existing channel-config-schema SDK subpath and migrate the five schemas. It reuses the canonical policy/allowlist dependency evaluator. Plugins retain account selection, disabled-account handling and ordering relative to other refinements; existing public predicate exports remain available.

The maintainer-approved SDK budget adjustment is exactly one public export and one callable. No new subpath or configuration option is introduced.

## User Impact

No intentional configuration behavior change. Root/account inheritance, empty-array overrides, error messages and paths remain identical. The change removes 126 production code lines without adding test or tooling code.

## Evidence

All 25,550 baseline/candidate schema parses are byte-identical, including a rerun with the worktree's own frozen dependency installation. All 223 tests across seven focused files passed. The complete changed-code gate passed, including schema/doctor metadata, all five typecheck lanes, SDK budgets, exports, lint and runtime import-cycle checks. Fresh independent P2 review found no actionable issues; final source hashes match the reviewed and measured patch.

The full gate's original completion was recovered after a coordinator rate limit; it exited successfully and was not restarted. Measurements use canonical cloc 2.10 with skip-uniqueness and separate production from tests, tooling and docs.
