### PR TITLE
fix(usage): keep service-tier and Anthropic fast-mode costs accurate

### DIFF
--- a/docs/providers/venice.md
+++ b/docs/providers/venice.md
@@ -201,9 +201,7 @@ price change. Hosted catalog updates activate at the existing restart boundary;
 see [Hosted model catalog](/concepts/models#hosted-catalog-updates).
 Make sizing-only edits in your source configuration without copying generated
 model rows back into it: replacing an entire model array from a runtime snapshot
-can persist inherited costs as explicit overrides. Historical estimated costs
-remain subject to the existing repricing policy; provider-billed amounts are
-unchanged. See [Token use and costs](/reference/token-use).
+can persist inherited costs as explicit overrides. Historical recorded costs are preserved; current pricing fills only missing costs or unknown-price zero placeholders. See [Token use and costs](/reference/token-use).
 
 ## Usage examples
 

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -206,6 +206,9 @@ the summed tokens as one large request. Provider-billed totals, including zero,
 take precedence over catalog estimates and remain visible even when token counts
 are unavailable. Unknown token counts are not inferred from a billed amount.
 
+Transcript reports preserve valid recorded per-call totals and allocations, including priority/flex adjustments, and use current catalog pricing only for missing costs or unknown-price zero placeholders.
+Anthropic fast-mode estimates multiply base and tier rates alike, preserving tier thresholds and mixed 5-minute/1-hour cache-write pricing.
+
 Omitting `cost`, or setting it to `{}`, inherits the catalog pricing schedule.
 Explicit flat or all-zero model prices do not inherit a catalog tier schedule.
 Omitted flat-rate fields can still inherit catalog defaults. An explicit

--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -1,4 +1,5 @@
 import { configureAiTransportHost, getAiTransportHost } from "@openclaw/ai";
+import { calculateUsageCost } from "@openclaw/llm-core";
 // Anthropic tests cover stream wrappers plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
@@ -113,15 +114,16 @@ function runNativeFastModeWrapper(params?: {
   enabled?: boolean;
   headers?: Record<string, string>;
   modelId?: string;
+  cost?: Parameters<StreamFn>[0]["cost"];
 }) {
   const captured: {
     headers?: Record<string, string>;
-    model?: { cost: { input: number; output: number; cacheRead: number; cacheWrite: number } };
+    model?: Parameters<StreamFn>[0];
     payload?: Record<string, unknown>;
   } = {};
   const base: StreamFn = (model, _context, options) => {
     captured.headers = options?.headers;
-    captured.model = model as typeof captured.model;
+    captured.model = model;
     const payload = {} as Record<string, unknown>;
     options?.onPayload?.(payload as never, model as never);
     captured.payload = payload;
@@ -134,7 +136,7 @@ function runNativeFastModeWrapper(params?: {
       api: params?.api ?? "anthropic-messages",
       baseUrl: params?.baseUrl,
       id: params?.modelId ?? "claude-opus-5",
-      cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+      cost: params?.cost ?? { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
     } as never,
     {} as never,
     {
@@ -358,6 +360,40 @@ describe("anthropic stream wrappers", () => {
       cacheWrite: 12.5,
     });
   });
+
+  it.each([
+    {
+      cacheRead: 100_000,
+      expected: { input: 0.01, output: 0.005, cacheRead: 0.1, cacheWrite: 0.2875, total: 0.4025 },
+    },
+    {
+      cacheRead: 250_000,
+      expected: { input: 0.02, output: 0.01, cacheRead: 0.5, cacheWrite: 0.575, total: 1.105 },
+    },
+  ])(
+    "prices fast-mode tiers and mixed cache writes with $cacheRead cached tokens",
+    ({ cacheRead, expected }) => {
+      const cost: Parameters<StreamFn>[0]["cost"] = {
+        input: 5,
+        output: 25,
+        cacheRead: 0.5,
+        cacheWrite: 6.25,
+        tieredPricing: [
+          { range: [0, 200_000], input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+          { range: [200_000, Infinity], input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+        ],
+      };
+      const original = structuredClone(cost);
+      const captured = runNativeFastModeWrapper({ cost });
+      const pricedModel = expectDefined(captured.model, "fast-mode model");
+      const usageCost = calculateUsageCost(
+        { input: 1_000, output: 100, cacheRead, cacheWrite: 20_000, cacheWrite1h: 5_000 },
+        pricedModel.cost,
+      );
+      expect(usageCost).toEqual({ ...expected, total: expect.closeTo(expected.total, 10) });
+      expect(cost).toEqual(original);
+    },
+  );
 
   it("uses native fast mode for Claude Opus 4.8", () => {
     const captured = runNativeFastModeWrapper({ modelId: "claude-opus-4.8" });

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -94,13 +94,24 @@ function isDirectAnthropicApiModel(model: Parameters<StreamFn>[0]): boolean {
 }
 
 function applyAnthropicFastModePricing(model: Parameters<StreamFn>[0]): Parameters<StreamFn>[0] {
+  const scaleRates = (rates: Parameters<StreamFn>[0]["cost"]) => ({
+    input: rates.input * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
+    output: rates.output * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
+    cacheRead: rates.cacheRead * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
+    cacheWrite: rates.cacheWrite * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
+  });
   return {
     ...model,
     cost: {
-      input: model.cost.input * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
-      output: model.cost.output * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
-      cacheRead: model.cost.cacheRead * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
-      cacheWrite: model.cost.cacheWrite * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
+      ...scaleRates(model.cost),
+      ...(model.cost.tieredPricing
+        ? {
+            tieredPricing: model.cost.tieredPricing.map((tier) => ({
+              ...tier,
+              ...scaleRates(tier),
+            })),
+          }
+        : {}),
     },
   };
 }

--- a/src/infra/session-cost-usage-aggregation.ts
+++ b/src/infra/session-cost-usage-aggregation.ts
@@ -46,7 +46,7 @@ import type { CostUsageTotals, ParsedTranscriptEntry } from "./session-cost-usag
 
 // Cache data is rebuildable. Semantic changes get a new version; old rows are
 // ignored and rebuilt instead of normalized through a runtime compatibility path.
-const USAGE_COST_ROLLUP_VERSION = 3;
+const USAGE_COST_ROLLUP_VERSION = 4;
 const USAGE_COST_FILE_ANCHOR_BYTES = 4096;
 
 type UsageCostJsonlCheckpoint = {

--- a/src/infra/session-cost-usage-pricing.ts
+++ b/src/infra/session-cost-usage-pricing.ts
@@ -221,34 +221,22 @@ export function parseUsageCostTranscriptEntry(
   resolveCost: UsageCostResolver,
 ): ParsedTranscriptEntry | null {
   const entry = parseTranscriptEntry(parsed);
-  if (!entry?.usage) {
+  // Recorded estimates include request-time service tiers the current catalog cannot recover.
+  if (
+    !entry?.usage ||
+    (entry.costTotal ?? 0) > 0 ||
+    entry.costBreakdown?.totalOrigin === "provider-billed" ||
+    shouldPreserveRecordedZeroCost(entry.costBreakdown)
+  ) {
     return entry;
   }
   const cost = resolveCost({ provider: entry.provider, model: entry.model });
-  const usageTotals = computeUsageTokenTotals(entry.usage);
-  const pricingKnown = isModelPricingKnown(cost);
-  // Provider billing is authoritative even when catalog tiers would estimate a different total.
-  const preserveRecordedCost =
-    entry.costBreakdown?.totalOrigin === "provider-billed" ||
-    shouldPreserveRecordedZeroCost(entry.costBreakdown);
-  if (preserveRecordedCost) {
-    return entry;
-  }
-  if (
-    !pricingKnown &&
-    (entry.costTotal === undefined || entry.costTotal === 0) &&
-    usageTotals.totalTokens > 0
-  ) {
+  const { totalTokens } = computeUsageTokenTotals(entry.usage);
+  if (!isModelPricingKnown(cost) && totalTokens > 0) {
     entry.costTotal = undefined;
     entry.costBreakdown = undefined;
-  } else if (
-    cost?.tieredPricing?.length ||
-    entry.costTotal === undefined ||
-    (entry.costTotal === 0 && pricingKnown && usageTotals.totalTokens > 0)
-  ) {
+  } else if (entry.costTotal === undefined || totalTokens > 0) {
     const estimated = cost ? calculateUsageCost(entry.usage, cost) : undefined;
-    // Repricing replaces the total and its allocation together, or summaries lose
-    // the input/output/cache breakdown while still displaying the correct total.
     entry.costBreakdown = estimated && Number.isFinite(estimated.total) ? estimated : undefined;
     entry.costTotal = entry.costBreakdown?.total;
   }

--- a/src/infra/session-cost-usage-reporting.test.ts
+++ b/src/infra/session-cost-usage-reporting.test.ts
@@ -10,6 +10,7 @@ import {
   loadSessionLogs,
   loadSessionUsageTimeSeries,
 } from "./session-cost-usage.js";
+import type { CostBreakdown } from "./session-cost-usage.types.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const flatPricing = { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0 };
@@ -24,7 +25,7 @@ const tieredPricing: ModelDefinitionConfig["cost"] = {
 type PricingCase = {
   name: string;
   pricing?: ModelDefinitionConfig["cost"];
-  recordedCost?: { total: number; totalOrigin?: "provider-billed" };
+  recordedCost?: CostBreakdown;
   topLevelUsage?: boolean;
   expectedCost: number | undefined;
   expectedBreakdown?: { input: number; output: number; cacheRead: number; cacheWrite: number };
@@ -51,9 +52,41 @@ describe("session usage reporting pricing", () => {
       expectedCost: undefined,
     },
     {
-      name: "tiered pricing replacing a recorded flat estimate",
+      // The recorded call owns its estimate; a later catalog cannot recover its service tier.
+      name: "recorded flat estimate preserved after catalog gains tiers",
       pricing: tieredPricing,
       recordedCost: { total: 0.001 },
+      expectedCost: 0.001,
+    },
+    {
+      name: "priority-adjusted recorded cost preserved with tiered pricing",
+      pricing: tieredPricing,
+      recordedCost: {
+        total: 0.0084,
+        input: 0.004,
+        output: 0.004,
+        cacheRead: 0.0004,
+        cacheWrite: 0,
+      },
+      expectedCost: 0.0084,
+      expectedBreakdown: { input: 0.004, output: 0.004, cacheRead: 0.0004, cacheWrite: 0 },
+    },
+    {
+      name: "flex-adjusted recorded cost preserved with tiered pricing",
+      pricing: tieredPricing,
+      recordedCost: {
+        total: 0.0021,
+        input: 0.001,
+        output: 0.001,
+        cacheRead: 0.0001,
+        cacheWrite: 0,
+      },
+      expectedCost: 0.0021,
+      expectedBreakdown: { input: 0.001, output: 0.001, cacheRead: 0.0001, cacheWrite: 0 },
+    },
+    {
+      name: "missing recorded cost estimated from tiered pricing",
+      pricing: tieredPricing,
       expectedCost: 0.0042,
       expectedBreakdown: { input: 0.002, output: 0.002, cacheRead: 0.0002, cacheWrite: 0 },
     },

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -1157,7 +1157,7 @@ describe("session cost usage", () => {
         version: number;
         rollup: { untimestamped: { totals: { totalTokens: number } } };
       };
-      currentRollup.version = 2;
+      currentRollup.version = 3;
       currentRollup.rollup.untimestamped.totals.totalTokens = 9_999;
       expect(
         writeSessionCostUsageRollup({
@@ -1206,7 +1206,7 @@ describe("session cost usage", () => {
         rollup: { untimestamped: { totals: { totalTokens: number } } };
       };
       expect(appendedRollup.rollup.untimestamped.totals.totalTokens).toBe(1_000);
-      expect(appendedRollup.version).toBe(3);
+      expect(appendedRollup.version).toBe(4);
 
       const allTime = await loadSessionCostSummariesFromCache({
         sessions: [session],


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where users inspecting session usage reports would see recorded priority/flex costs replaced by current catalog estimates when tiered pricing was available. Anthropic fast-mode estimates also understated cache-heavy requests above a pricing threshold because the tier schedule was dropped.

## Why This Change Was Made

Transcript accounting now preserves recorded per-call totals and allocations before consulting catalog pricing. Missing costs and the existing unknown-price zero placeholders retain catalog fallback; provider-billed zero remains authoritative. The existing rebuildable rollup cache advances from version 3 to 4 so summaries rebuild from transcripts under this policy, without a SQLite schema change or migration.

Anthropic fast mode scales all four base rates and every tier's rates while preserving tier ranges. The shared calculator continues to select the request tier and price mixed 5-minute/1-hour writes. Existing recorded estimates remain as recorded, including estimates made by older runtimes.

## User Impact

Logs, usage summaries, and charts retain request-time service-tier costs across catalog updates and restarts. New Anthropic fast-mode calls retain long-context and cache-write pricing. No configuration changes are required.

## Evidence

Regression tests failed on the original code for the intended defects: three recorded-cost cases were repriced, an old rollup remained stale, and the high-tier Anthropic request cost $0.5525 instead of $1.105.

```text
node scripts/run-vitest.mjs src/infra/session-cost-usage-reporting.test.ts src/infra/session-cost-usage.test.ts extensions/anthropic/stream-wrappers.test.ts
Infrastructure: 2 files, 72 tests passed.
Anthropic: 1 file, 42 tests passed.
Total: 3 files, 114 tests passed.
```

`node scripts/check-changed.mjs` exited 1 only at the documented nested-checkout extension declaration boundary: `Declaration input escapes checkout ... qrcode/package.json`. All preceding gates passed, including the four typecheck lanes, core lint, dead-export scans, and six plugin contract tests. The eight gates after the blocked extension-lint stage were run separately and all passed; CI remains authoritative for that extension lane.

Autoreview (Codex, P0/P1): `scoped-clean`; 0 accepted/actionable findings; overall verdict: patch is correct.

Docs: `docs/reference/token-use.md` describes recorded-cost preservation and fast-mode tier pricing; `docs/providers/venice.md` removes the obsolete historical-repricing statement. Production diff: +26/-27 lines (net -1).
