### PR TITLE
fix(bedrock): honor prompt caching for supported Nova models

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -617,7 +617,7 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
 
   <Accordion title="Bedrock Claude notes">
     - Anthropic Claude models on Bedrock (`amazon-bedrock/*anthropic.claude*`) accept `cacheRetention` pass-through when configured.
-    - Supported Nova models also accept explicit caching, with system/message checkpoints and a five-minute TTL for both `short` and `long`. Other non-Claude models remain at `cacheRetention: "none"`; see [Bedrock prompt caching](/reference/prompt-caching#amazon-bedrock) for model IDs and AWS limits.
+    - Supported Nova models offer opt-in explicit caching: set `cacheRetention` explicitly to `short` or `long` for system/message checkpoints with a five-minute TTL. Unset retention adds no checkpoints. Nova explicit caching has not been live-verified against AWS by OpenClaw maintainers yet. Other non-Claude models remain at `cacheRetention: "none"`; see [Bedrock prompt caching](/reference/prompt-caching#amazon-bedrock) for model IDs, AWS limits, and the live acceptance proof gap.
     - API-key smart defaults also seed `cacheRetention: "short"` for Claude-on-Bedrock refs when no explicit value is set.
 
   </Accordion>

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -617,7 +617,7 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
 
   <Accordion title="Bedrock Claude notes">
     - Anthropic Claude models on Bedrock (`amazon-bedrock/*anthropic.claude*`) accept `cacheRetention` pass-through when configured.
-    - Non-Anthropic Bedrock models are forced to `cacheRetention: "none"` at runtime.
+    - Supported Nova models also accept explicit caching, with system/message checkpoints and a five-minute TTL for both `short` and `long`. Other non-Claude models remain at `cacheRetention: "none"`; see [Bedrock prompt caching](/reference/prompt-caching#amazon-bedrock) for model IDs and AWS limits.
     - API-key smart defaults also seed `cacheRetention: "short"` for Claude-on-Bedrock refs when no explicit value is set.
 
   </Accordion>

--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -152,7 +152,7 @@ cache billing are described in [Model Studio context caching](https://www.alibab
 - The stable system prefix is checkpointed separately from dynamic runtime additions. Conversation checkpoints advance through retained history, including tool results; transient runtime-context carriers remain outside the cached prefix. Bedrock Mantle's Anthropic Messages transport also preserves the separate stable system boundary.
 - Nova Micro, Lite, Pro, Premier (`amazon.nova-{micro,lite,pro,premier}-v1:0`), and Nova 2 Lite (`amazon.nova-2-lite-v1:0`) support explicit checkpoints in `system` and `messages`, including their AWS geographic inference profiles and foundation-model ARNs. Both `short` and `long` use Nova's five-minute TTL; `none` disables explicit checkpoints. OpenClaw does not add tool checkpoints for Nova.
 - Other non-Claude Bedrock models remain at `cacheRetention: "none"`.
-- With no configured retention, the Converse transport uses its default `short` window for supported Nova models.
+- Nova explicit caching is opt-in: set `cacheRetention` explicitly to `short` or `long`. With retention unset, Nova requests keep their existing payload layout with no checkpoints; neither the default `short` window nor `OPENCLAW_CACHE_RETENTION` enables Nova checkpoints.
 - Opaque Bedrock application inference profile ARNs (profile IDs that do not contain `claude`) also resolve to no cache retention unless `cacheRetention` is set explicitly, since the model family cannot be inferred from the ARN alone.
 
 AWS's [prompt caching guide](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html)
@@ -163,6 +163,9 @@ and model cards for [Micro](https://docs.aws.amazon.com/bedrock/latest/userguide
 and [Nova 2 Lite](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-2-lite.html)
 list these limits: a 1K-token minimum, four checkpoints, and at most 20K cached
 tokens for Nova. Provider token limits still determine whether a checkpoint is cached.
+
+Nova explicit caching has not been live-verified against AWS by OpenClaw maintainers yet.
+Live AWS acceptance proof remains a gap until a maintainer with Bedrock access runs it.
 
 ### OpenRouter
 
@@ -358,7 +361,7 @@ Prompt-cache observations record `input`, `cacheRead`, and `cacheWrite` per comp
 - **High `cacheWrite` on Anthropic**: often means the cache breakpoint is landing on content that changes every request.
 - **Low OpenAI `cacheRead`**: verify the stable prefix is at the front, the repeated prefix is at least 1024 tokens, and the same `prompt_cache_key` is reused for turns that should share a cache.
 - **No effect from `cacheRetention`**: confirm the model key matches `agents.defaults.models["provider/model"]`.
-- **Bedrock Nova requests without cache hits**: verify that the model is one of the supported variants above and the prefix meets AWS's token limits; `long` still uses a five-minute TTL.
+- **Bedrock Nova requests without cache hits**: set `cacheRetention` explicitly to `short` or `long`, verify that the model is one of the supported variants above, and check that the prefix meets AWS's token limits; `long` still uses a five-minute TTL.
 
 Related docs:
 

--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -150,8 +150,19 @@ cache billing are described in [Model Studio context caching](https://www.alibab
 
 - Anthropic Claude model refs (`amazon-bedrock/*anthropic.claude*`, plus AWS system inference profile prefixes `us.`/`eu.`/`global.anthropic.claude*`) support explicit `cacheRetention` pass-through.
 - The stable system prefix is checkpointed separately from dynamic runtime additions. Conversation checkpoints advance through retained history, including tool results; transient runtime-context carriers remain outside the cached prefix. Bedrock Mantle's Anthropic Messages transport also preserves the separate stable system boundary.
-- Non-Anthropic Bedrock models (for example `amazon.nova-*`) resolve to no cache retention at runtime, regardless of any configured `cacheRetention` value.
+- Nova Micro, Lite, Pro, Premier (`amazon.nova-{micro,lite,pro,premier}-v1:0`), and Nova 2 Lite (`amazon.nova-2-lite-v1:0`) support explicit checkpoints in `system` and `messages`, including their AWS geographic inference profiles and foundation-model ARNs. Both `short` and `long` use Nova's five-minute TTL; `none` disables explicit checkpoints. OpenClaw does not add tool checkpoints for Nova.
+- Other non-Claude Bedrock models remain at `cacheRetention: "none"`.
+- With no configured retention, the Converse transport uses its default `short` window for supported Nova models.
 - Opaque Bedrock application inference profile ARNs (profile IDs that do not contain `claude`) also resolve to no cache retention unless `cacheRetention` is set explicitly, since the model family cannot be inferred from the ARN alone.
+
+AWS's [prompt caching guide](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html)
+and model cards for [Micro](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-micro.html),
+[Lite](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-lite.html),
+[Pro](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-pro.html),
+[Premier](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-premier.html),
+and [Nova 2 Lite](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-2-lite.html)
+list these limits: a 1K-token minimum, four checkpoints, and at most 20K cached
+tokens for Nova. Provider token limits still determine whether a checkpoint is cached.
 
 ### OpenRouter
 
@@ -347,7 +358,7 @@ Prompt-cache observations record `input`, `cacheRead`, and `cacheWrite` per comp
 - **High `cacheWrite` on Anthropic**: often means the cache breakpoint is landing on content that changes every request.
 - **Low OpenAI `cacheRead`**: verify the stable prefix is at the front, the repeated prefix is at least 1024 tokens, and the same `prompt_cache_key` is reused for turns that should share a cache.
 - **No effect from `cacheRetention`**: confirm the model key matches `agents.defaults.models["provider/model"]`.
-- **Bedrock Nova requests with cache settings**: expected - these resolve to no cache retention at runtime.
+- **Bedrock Nova requests without cache hits**: verify that the model is one of the supported variants above and the prefix meets AWS's token limits; `long` still uses a five-minute TTL.
 
 Related docs:
 

--- a/extensions/amazon-bedrock/bedrock-options.ts
+++ b/extensions/amazon-bedrock/bedrock-options.ts
@@ -2,7 +2,9 @@
  * Stream option extensions and prompt-cache policy for Amazon Bedrock models.
  * Provider registration and runtime streaming share these contracts.
  */
+import type { CachePointBlock } from "@aws-sdk/client-bedrock-runtime";
 import type {
+  CacheRetention,
   Model,
   ModelThinkingLevel,
   StreamOptions,
@@ -10,14 +12,44 @@ import type {
 } from "openclaw/plugin-sdk/llm";
 import { resolveClaudeModelIdentity } from "openclaw/plugin-sdk/provider-model-shared";
 
-/** Share resolved model eligibility between the runtime and profile fallback. */
-export function supportsBedrockModelPromptCaching(
+/** Share explicit-cache capabilities between registration and payload construction. */
+export function resolveBedrockPromptCachePolicy(
   model: Pick<Model, "id" | "params"> & { name?: string },
-): boolean {
-  return (
-    supportsBedrockPromptCaching(model.id, model.name) ||
-    supportsBedrockPromptCaching(resolveClaudeModelIdentity(model), model.name)
-  );
+): "nova" | "claude" | undefined {
+  // AWS Nova model cards allow system/messages checkpoints with a five-minute TTL.
+  // Only unwrap foundation models and system profiles; application profiles stay opaque.
+  const modelId = model.id
+    .trim()
+    .toLowerCase()
+    .replace(
+      /^arn:aws(?:-cn|-us-gov)?:bedrock:[^:]+:[^:]*:(?:foundation-model|inference-profile)\//,
+      "",
+    )
+    .replace(/^(?:us|eu|apac|jp|global)\./, "");
+  if (/^amazon\.nova-(?:micro|lite|pro|premier|2-lite)-v1:0$/.test(modelId)) {
+    return "nova";
+  }
+  if (
+    supportsBedrockClaudePromptCaching(model.id, model.name) ||
+    supportsBedrockClaudePromptCaching(resolveClaudeModelIdentity(model), model.name)
+  ) {
+    return "claude";
+  }
+  return undefined;
+}
+
+export function resolveBedrockCachePoint(
+  model: Pick<Model, "id" | "params"> & { name?: string },
+  retention: CacheRetention,
+): CachePointBlock | undefined {
+  const policy = resolveBedrockPromptCachePolicy(model);
+  if (!policy || retention === "none") {
+    return undefined;
+  }
+  return {
+    type: "default",
+    ...(policy === "claude" && retention === "long" ? { ttl: "1h" } : {}),
+  };
 }
 
 /** How Bedrock thinking output should be displayed to users. */
@@ -45,7 +77,7 @@ function getModelMatchCandidates(modelId: string, modelName?: string): string[] 
 }
 
 /** Return whether a Bedrock model is known to support Anthropic prompt caching. */
-export function supportsBedrockPromptCaching(modelId: string, modelName?: string): boolean {
+export function supportsBedrockClaudePromptCaching(modelId: string, modelName?: string): boolean {
   const candidates = getModelMatchCandidates(modelId, modelName);
   const hasClaudeRef = candidates.some((s) => s.includes("claude"));
   if (!hasClaudeRef) {

--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -14,7 +14,7 @@ import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 // Amazon Bedrock tests cover index plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { supportsBedrockPromptCaching } from "./bedrock-options.js";
+import { supportsBedrockClaudePromptCaching } from "./bedrock-options.js";
 import amazonBedrockPlugin from "./index.js";
 
 type BedrockClientResult =
@@ -71,7 +71,7 @@ const sendBedrockCommand = vi.fn(
         modelSummaries: [
           {
             modelId: NON_ANTHROPIC_MODEL,
-            modelName: "Nova Micro",
+            modelName: "Nova Sonic",
             providerName: "Amazon",
             inputModalities: ["TEXT"],
             outputModalities: ["TEXT"],
@@ -159,7 +159,7 @@ const spyStreamFn = (_model: unknown, _context: unknown, options: Record<string,
   options;
 
 const ANTHROPIC_MODEL = "us.anthropic.claude-sonnet-4-6-v1";
-const NON_ANTHROPIC_MODEL = "amazon.nova-micro-v1:0";
+const NON_ANTHROPIC_MODEL = "amazon.nova-sonic-v1:0";
 
 const MODEL_DESCRIPTOR = {
   api: "openai-completions",
@@ -491,10 +491,10 @@ describe("amazon-bedrock provider plugin", () => {
   });
 
   it("recognizes direct Claude 5 model refs as prompt-cache eligible", () => {
-    expect(supportsBedrockPromptCaching("us.anthropic.claude-fable-5")).toBe(true);
-    expect(supportsBedrockPromptCaching("us.anthropic.claude-mythos-5")).toBe(true);
-    expect(supportsBedrockPromptCaching("global.anthropic.claude-opus-5")).toBe(true);
-    expect(supportsBedrockPromptCaching("global.anthropic.claude-sonnet-5")).toBe(true);
+    expect(supportsBedrockClaudePromptCaching("us.anthropic.claude-fable-5")).toBe(true);
+    expect(supportsBedrockClaudePromptCaching("us.anthropic.claude-mythos-5")).toBe(true);
+    expect(supportsBedrockClaudePromptCaching("global.anthropic.claude-opus-5")).toBe(true);
+    expect(supportsBedrockClaudePromptCaching("global.anthropic.claude-sonnet-5")).toBe(true);
   });
 
   it.each([
@@ -525,26 +525,43 @@ describe("amazon-bedrock provider plugin", () => {
     },
   );
 
-  it("disables prompt caching for non-Anthropic Bedrock models", async () => {
-    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
-    const wrapped = provider.wrapStreamFn?.({
-      provider: "amazon-bedrock",
-      modelId: "amazon.nova-micro-v1:0",
-      streamFn: (_model: unknown, _context: unknown, options: Record<string, unknown>) => options,
-    } as never);
+  it.each([
+    ["amazon.nova-micro-v1:0", "short", "short"],
+    ["global.amazon.nova-2-lite-v1:0", "long", "long"],
+    ["amazon.nova-pro-v1:0", "none", "none"],
+    ["amazon.nova-sonic-v1:0", "short", "none"],
+    ["meta.llama3-70b-instruct-v1:0", "long", "none"],
+  ] as const)(
+    "routes Bedrock cache retention for %s (%s)",
+    async (modelId, cacheRetention, expected) => {
+      const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+      const wrapped = provider.wrapStreamFn?.({
+        provider: "amazon-bedrock",
+        modelId,
+        streamFn: (_model: unknown, _context: unknown, options: Record<string, unknown>) => options,
+      } as never);
 
-    expectWrappedResultFields(
-      wrapped?.(
-        {
-          api: "openai-completions",
-          provider: "amazon-bedrock",
-          id: "amazon.nova-micro-v1:0",
-        } as never,
-        { messages: [] } as never,
-        {},
-      ),
-      { cacheRetention: "none" },
-    );
+      expectWrappedResultFields(
+        wrapped?.(
+          {
+            api: "bedrock-converse-stream",
+            provider: "amazon-bedrock",
+            id: modelId,
+          } as never,
+          { messages: [] } as never,
+          { cacheRetention },
+        ),
+        { cacheRetention: expected },
+      );
+    },
+  );
+
+  it("keeps unsupported provider routes disabled with the runtime cache override", async () => {
+    await withEnvAsync({ AWS_BEDROCK_FORCE_CACHE: "1" }, async () => {
+      const provider = await registerWithConfig(undefined);
+      const result = await callWrappedStream(provider, NON_ANTHROPIC_MODEL, MODEL_DESCRIPTOR);
+      expectWrappedResultFields(result, { cacheRetention: "none" });
+    });
   });
 
   it("refreshes AWS shared config cache before Bedrock sends", async () => {
@@ -1387,35 +1404,37 @@ describe("amazon-bedrock provider plugin", () => {
       expect(bedrockClientConfigs).toEqual([{ region: "us-east-1" }]);
     });
 
-    it("does not inject cache points when any resolved profile target is not cacheable", async () => {
-      const modelId =
-        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/z27qyso459db";
-      inferenceProfileGetResults.push({
-        models: [
-          {
-            modelArn:
-              "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6-20250514-v1:0",
-          },
-          {
-            modelArn:
-              "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-opus-20240229-v1:0",
-          },
-        ],
-      });
-      const provider = await registerWithConfig(undefined);
-      const payload = buildBedrockCachePayload();
+    it.each(["anthropic.claude-3-opus-20240229-v1:0", "amazon.nova-pro-v1:0"])(
+      "keeps opaque profile caching disabled for resolved target %s",
+      async (target) => {
+        const profileId = target.startsWith("amazon.") ? "opaque-nova" : "opaque-legacy";
+        const modelId = `arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/${profileId}`;
+        inferenceProfileGetResults.push({
+          models: [
+            {
+              modelArn:
+                "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6-20250514-v1:0",
+            },
+            {
+              modelArn: `arn:aws:bedrock:us-east-1::foundation-model/${target}`,
+            },
+          ],
+        });
+        const provider = await registerWithConfig(undefined);
+        const payload = buildBedrockCachePayload();
 
-      await callWrappedStreamWithPayload(
-        provider,
-        modelId,
-        makeAppInferenceProfileDescriptor(modelId),
-        { cacheRetention: "short" },
-        payload,
-      );
+        await callWrappedStreamWithPayload(
+          provider,
+          modelId,
+          makeAppInferenceProfileDescriptor(modelId),
+          { cacheRetention: "short" },
+          payload,
+        );
 
-      expect(payload.system).toEqual([{ text: "You are helpful." }]);
-      expect(payload.messages).toEqual([{ role: "user", content: [{ text: "Hello" }] }]);
-    });
+        expect(payload.system).toEqual([{ text: "You are helpful." }]);
+        expect(payload.messages).toEqual([{ role: "user", content: [{ text: "Hello" }] }]);
+      },
+    );
 
     it("retries opaque profile lookup after a transient failure instead of caching the fallback", async () => {
       const modelId =

--- a/extensions/amazon-bedrock/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock/register.sync.runtime.ts
@@ -25,8 +25,8 @@ import { createPayloadPatchStreamWrapper } from "openclaw/plugin-sdk/provider-st
 import { splitSystemPromptCacheBoundary } from "openclaw/plugin-sdk/provider-transport-runtime";
 import { refreshAwsSharedConfigCacheForBedrock } from "./aws-credential-refresh.js";
 import {
-  supportsBedrockModelPromptCaching,
-  supportsBedrockPromptCaching,
+  resolveBedrockPromptCachePolicy,
+  supportsBedrockClaudePromptCaching,
 } from "./bedrock-options.js";
 import { loadBedrockControlPlaneSdk, runBedrockControlPlaneRequest } from "./control-plane.js";
 import { resolveBedrockConfigApiKey } from "./discovery-shared.js";
@@ -209,14 +209,6 @@ function extractRegionFromArn(arn: string): string | undefined {
 }
 
 /**
- * Check if a resolved foundation model ARN supports prompt caching using the
- * same matcher OpenClaw uses for direct model IDs.
- */
-function resolvedModelSupportsCaching(modelArn: string): boolean {
-  return supportsBedrockPromptCaching(modelArn);
-}
-
-/**
  * Resolve the underlying foundation model for an application inference profile
  * via GetInferenceProfile. Results are cached so we only call the API once per
  * profile ARN. Returns traits needed for request shaping when the model id is
@@ -259,7 +251,8 @@ async function resolveAppProfileTraits(
     const modelArns = models.map((model) => model.modelArn ?? "");
     const traits = {
       cacheEligible:
-        models.length > 0 && modelArns.every((modelArn) => resolvedModelSupportsCaching(modelArn)),
+        models.length > 0 &&
+        modelArns.every((modelArn) => supportsBedrockClaudePromptCaching(modelArn)),
       omitTemperature: modelArns.some(isOpus47OrNewerBedrockModelRef),
     };
     appProfileTraitsCache.set(modelId, traits);
@@ -305,7 +298,7 @@ function injectBedrockCachePoints(
   context: Context,
   model: Model,
 ): void {
-  if (!cacheRetention || cacheRetention === "none" || supportsBedrockModelPromptCaching(model)) {
+  if (!cacheRetention || cacheRetention === "none" || resolveBedrockPromptCachePolicy(model)) {
     return;
   }
   const point = makeCachePoint(cacheRetention);
@@ -401,6 +394,7 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
   }) => {
     const modelRef = { id: modelId, params: model?.params };
     if (
+      resolveBedrockPromptCachePolicy(modelRef) === "nova" ||
       isAnthropicBedrockModel(modelId) ||
       resolveClaudeModelIdentity(modelRef).startsWith("claude-")
     ) {
@@ -573,7 +567,7 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
         extractRegionFromBaseUrl(model?.baseUrl) ??
         currentPluginConfig?.discovery?.region;
       const mayNeedCacheInjection =
-        isBedrockAppInferenceProfile(modelId) && !supportsBedrockPromptCaching(modelId);
+        isBedrockAppInferenceProfile(modelId) && !supportsBedrockClaudePromptCaching(modelId);
       const shouldOmitTemperature =
         opus47OrNewer || fable5 || isLatestAdaptiveBedrockModelRef(modelId, model?.params);
       const shouldPatchMaxThinking = supportsNativeMax && thinkingLevel === "max";

--- a/extensions/amazon-bedrock/stream.runtime.accounting-replay.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.accounting-replay.test.ts
@@ -93,6 +93,7 @@ async function captureMessages(
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe("Bedrock reasoning replay", () => {
@@ -304,6 +305,20 @@ describe("Bedrock reasoning replay", () => {
 });
 
 describe("Bedrock prompt cache ownership", () => {
+  it("keeps unset Nova payloads identical to disabled caching despite environment defaults", async () => {
+    vi.stubEnv("OPENCLAW_CACHE_RETENTION", "long");
+    vi.stubEnv("AWS_BEDROCK_FORCE_CACHE", "1");
+    const model = bedrockModel({});
+    const context: Context = {
+      systemPrompt: `Stable workspace${SYSTEM_PROMPT_CACHE_BOUNDARY}Today: Monday`,
+      messages: [{ role: "user", content: "Hello", timestamp: 0 }],
+    };
+    const unset = await capturePayload(model, context);
+    const disabled = await capturePayload(model, context, { cacheRetention: "none" });
+    expect(JSON.stringify(unset)).not.toContain("cachePoint");
+    expect(JSON.stringify(unset)).toBe(JSON.stringify(disabled));
+  });
+
   it.each([
     ["amazon.nova-micro-v1:0", true],
     ["eu.amazon.nova-lite-v1:0", true],
@@ -321,7 +336,7 @@ describe("Bedrock prompt cache ownership", () => {
       false,
     ],
   ])("emits only supported Nova checkpoints for %s", async (id, supported) => {
-    for (const cacheRetention of ["short", "long", "none"] as const) {
+    for (const cacheRetention of [undefined, "short", "long", "none"] as const) {
       const payload = await capturePayload(
         bedrockModel({ id, name: "Nova Pro" }),
         {
@@ -335,9 +350,9 @@ describe("Bedrock prompt cache ownership", () => {
             },
           ],
         },
-        { cacheRetention },
+        cacheRetention === undefined ? {} : { cacheRetention },
       );
-      if (supported && cacheRetention !== "none") {
+      if (supported && (cacheRetention === "short" || cacheRetention === "long")) {
         expect(payload.system).toEqual([
           { text: "Stable workspace" },
           { cachePoint: { type: "default" } },
@@ -349,6 +364,9 @@ describe("Bedrock prompt cache ownership", () => {
         ]);
       } else {
         expect(JSON.stringify(payload)).not.toContain("cachePoint");
+        if (supported || cacheRetention === "none") {
+          expect(payload.system).toEqual([{ text: "Stable workspace\nToday: Monday" }]);
+        }
       }
       expect(payload.toolConfig?.tools).toHaveLength(1);
       expect(payload.toolConfig?.tools?.[0]).toHaveProperty("toolSpec.name", "lookup");

--- a/extensions/amazon-bedrock/stream.runtime.accounting-replay.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.accounting-replay.test.ts
@@ -304,6 +304,58 @@ describe("Bedrock reasoning replay", () => {
 });
 
 describe("Bedrock prompt cache ownership", () => {
+  it.each([
+    ["amazon.nova-micro-v1:0", true],
+    ["eu.amazon.nova-lite-v1:0", true],
+    ["apac.amazon.nova-pro-v1:0", true],
+    ["us.amazon.nova-premier-v1:0", true],
+    ["global.amazon.nova-2-lite-v1:0", true],
+    ["arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-pro-v1:0", true],
+    ["arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.amazon.nova-pro-v1:0", true],
+    ["amazon.nova-sonic-v1:0", false],
+    ["amazon.nova-lite-v2:0", false],
+    ["amazon.nova-pro-v1:0:custom", false],
+    ["meta.llama3-70b-instruct-v1:0", false],
+    [
+      "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/amazon.nova-pro-v1:0",
+      false,
+    ],
+  ])("emits only supported Nova checkpoints for %s", async (id, supported) => {
+    for (const cacheRetention of ["short", "long", "none"] as const) {
+      const payload = await capturePayload(
+        bedrockModel({ id, name: "Nova Pro" }),
+        {
+          systemPrompt: `Stable workspace${SYSTEM_PROMPT_CACHE_BOUNDARY}Today: Monday`,
+          messages: [{ role: "user", content: "Hello", timestamp: 0 }],
+          tools: [
+            {
+              name: "lookup",
+              description: "Look up a value",
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+        },
+        { cacheRetention },
+      );
+      if (supported && cacheRetention !== "none") {
+        expect(payload.system).toEqual([
+          { text: "Stable workspace" },
+          { cachePoint: { type: "default" } },
+          { text: "Today: Monday" },
+        ]);
+        expect(payload.messages?.[0]?.content).toEqual([
+          { text: "Hello" },
+          { cachePoint: { type: "default" } },
+        ]);
+      } else {
+        expect(JSON.stringify(payload)).not.toContain("cachePoint");
+      }
+      expect(payload.toolConfig?.tools).toHaveLength(1);
+      expect(payload.toolConfig?.tools?.[0]).toHaveProperty("toolSpec.name", "lookup");
+      expect(JSON.stringify(payload.toolConfig)).not.toContain("cachePoint");
+    }
+  });
+
   it.each(["direct", "application-profile"])(
     "advances the retained-carrier checkpoint through a tool loop (%s)",
     async (route) => {

--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -140,7 +140,6 @@ describe("Bedrock tool-result replay", () => {
             content: [{ text: "(see attached audio)" }],
           },
         },
-        { cachePoint: { type: "default" } },
       ],
     });
   });
@@ -175,7 +174,6 @@ describe("Bedrock tool-result replay", () => {
             ],
           },
         },
-        { cachePoint: { type: "default" } },
       ],
     });
   });
@@ -207,7 +205,6 @@ describe("Bedrock tool-result replay", () => {
       content: [
         { toolResult: { toolUseId: "call_husk", content: [{ text: "(no output)" }] } },
         { toolResult: { toolUseId: "call_text", content: [{ text: "actual tool output" }] } },
-        { cachePoint: { type: "default" } },
       ],
     });
     expect(JSON.stringify(messages)).not.toContain('"image"');

--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -140,6 +140,7 @@ describe("Bedrock tool-result replay", () => {
             content: [{ text: "(see attached audio)" }],
           },
         },
+        { cachePoint: { type: "default" } },
       ],
     });
   });
@@ -174,6 +175,7 @@ describe("Bedrock tool-result replay", () => {
             ],
           },
         },
+        { cachePoint: { type: "default" } },
       ],
     });
   });
@@ -205,6 +207,7 @@ describe("Bedrock tool-result replay", () => {
       content: [
         { toolResult: { toolUseId: "call_husk", content: [{ text: "(no output)" }] } },
         { toolResult: { toolUseId: "call_text", content: [{ text: "actual tool output" }] } },
+        { cachePoint: { type: "default" } },
       ],
     });
     expect(JSON.stringify(messages)).not.toContain('"image"');

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -81,7 +81,11 @@ import {
   stripSystemPromptCacheBoundary,
 } from "openclaw/plugin-sdk/provider-transport-runtime";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveBedrockCachePoint, type BedrockOptions } from "./bedrock-options.js";
+import {
+  resolveBedrockCachePoint,
+  resolveBedrockPromptCachePolicy,
+  type BedrockOptions,
+} from "./bedrock-options.js";
 import { supportsBedrockNativeMaxEffort } from "./thinking-policy.js";
 
 type Block = (TextContent | ThinkingContent | ToolCall) & {
@@ -262,7 +266,7 @@ const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
     let client: BedrockRuntimeClient | undefined;
     try {
       client = new BedrockRuntimeClient(config);
-      const cacheRetention = resolveCacheRetention(options.cacheRetention);
+      const cacheRetention = resolveCacheRetention(model, options.cacheRetention);
       const cachePoint = resolveBedrockCachePoint(model, cacheRetention);
       const additionalModelRequestFields = buildAdditionalModelRequestFields(model, options);
       const thinking = (additionalModelRequestFields as Record<string, unknown> | undefined)
@@ -876,11 +880,17 @@ function mapThinkingLevelToEffort(
 
 /**
  * Resolve cache retention preference.
- * Defaults to "short" and uses OPENCLAW_CACHE_RETENTION for backward compatibility.
+ * Nova requires explicit opt-in; other models retain the existing env/default policy.
  */
-function resolveCacheRetention(cacheRetention?: CacheRetention): CacheRetention {
+function resolveCacheRetention(
+  model: Model<"bedrock-converse-stream">,
+  cacheRetention?: CacheRetention,
+): CacheRetention {
   if (cacheRetention) {
     return cacheRetention;
+  }
+  if (resolveBedrockPromptCachePolicy(model) === "nova") {
+    return "none";
   }
   if (typeof process !== "undefined" && process.env.OPENCLAW_CACHE_RETENTION === "long") {
     return "long";

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -3,7 +3,7 @@
  * thinking, cache points, images, and usage into Bedrock Converse Stream calls.
  */
 import {
-  CachePointType,
+  type CachePointBlock,
   CacheTTL,
   BedrockRuntimeClient,
   type BedrockRuntimeClientConfig,
@@ -81,7 +81,7 @@ import {
   stripSystemPromptCacheBoundary,
 } from "openclaw/plugin-sdk/provider-transport-runtime";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { supportsBedrockModelPromptCaching, type BedrockOptions } from "./bedrock-options.js";
+import { resolveBedrockCachePoint, type BedrockOptions } from "./bedrock-options.js";
 import { supportsBedrockNativeMaxEffort } from "./thinking-policy.js";
 
 type Block = (TextContent | ThinkingContent | ToolCall) & {
@@ -263,6 +263,7 @@ const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
     try {
       client = new BedrockRuntimeClient(config);
       const cacheRetention = resolveCacheRetention(options.cacheRetention);
+      const cachePoint = resolveBedrockCachePoint(model, cacheRetention);
       const additionalModelRequestFields = buildAdditionalModelRequestFields(model, options);
       const thinking = (additionalModelRequestFields as Record<string, unknown> | undefined)
         ?.thinking;
@@ -272,8 +273,8 @@ const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
         (thinking as { type?: unknown }).type === "adaptive";
       let commandInput = {
         modelId: model.id,
-        messages: convertMessages(context, model, cacheRetention),
-        system: buildSystemPrompt(context.systemPrompt, model, cacheRetention),
+        messages: convertMessages(context, model, cachePoint),
+        system: buildSystemPrompt(context.systemPrompt, cacheRetention, cachePoint),
         inferenceConfig: {
           ...(options.maxTokens !== undefined && { maxTokens: options.maxTokens }),
           ...(options.temperature !== undefined &&
@@ -924,8 +925,8 @@ function supportsThinkingSignature(model: Model<"bedrock-converse-stream">): boo
 
 function buildSystemPrompt(
   systemPrompt: string | undefined,
-  model: Model<"bedrock-converse-stream">,
   cacheRetention: CacheRetention,
+  cachePoint: CachePointBlock | undefined,
 ): SystemContentBlock[] | undefined {
   if (!systemPrompt) {
     return undefined;
@@ -940,14 +941,8 @@ function buildSystemPrompt(
     ? [{ text: sanitizeSurrogates(stablePrefix) }]
     : [];
 
-  // Add cache point for supported Claude models when caching is enabled
-  if (stablePrefix && supportsBedrockModelPromptCaching(model)) {
-    blocks.push({
-      cachePoint: {
-        type: CachePointType.DEFAULT,
-        ...(cacheRetention === "long" ? { ttl: CacheTTL.ONE_HOUR } : {}),
-      },
-    });
+  if (stablePrefix && cachePoint) {
+    blocks.push({ cachePoint });
   }
 
   if (split?.dynamicSuffix) {
@@ -988,7 +983,7 @@ function createBedrockToolResult(message: ToolResultMessage): ContentBlock.ToolR
 function convertMessages(
   context: Context,
   model: Model<"bedrock-converse-stream">,
-  cacheRetention: CacheRetention,
+  cachePoint: CachePointBlock | undefined,
 ): Message[] {
   const result: Message[] = [];
   let firstVolatileMessageIndex: number | undefined;
@@ -1161,23 +1156,14 @@ function convertMessages(
 
   // Cache points include their entire prefix, so anchors after transient runtime
   // context would still cache volatile bytes even when those anchors are stable.
-  if (
-    cacheRetention !== "none" &&
-    supportsBedrockModelPromptCaching(model) &&
-    result.at(-1)?.role === ConversationRole.USER
-  ) {
+  if (cachePoint && result.at(-1)?.role === ConversationRole.USER) {
     const cacheAnchor = result.findLast(
       (message, index) =>
         message.role === ConversationRole.USER &&
         (firstVolatileMessageIndex === undefined || index < firstVolatileMessageIndex),
     );
     if (cacheAnchor?.content) {
-      cacheAnchor.content.push({
-        cachePoint: {
-          type: CachePointType.DEFAULT,
-          ...(cacheRetention === "long" ? { ttl: CacheTTL.ONE_HOUR } : {}),
-        },
-      });
+      cacheAnchor.content.push({ cachePoint });
     }
   }
 

--- a/src/agents/embedded-agent-runner/extra-params.cache-retention-default.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.cache-retention-default.test.ts
@@ -309,6 +309,20 @@ describe("cacheRetention default behavior", () => {
     ).toBe("long");
   });
 
+  it.each(["short", "long", "none"] as const)(
+    "passes explicit %s retention to the Bedrock Converse policy owner",
+    (cacheRetention) => {
+      expect(
+        resolveCacheRetention(
+          { cacheRetention },
+          "amazon-bedrock",
+          "bedrock-converse-stream",
+          "amazon.nova-micro-v1:0",
+        ),
+      ).toBe(cacheRetention);
+    },
+  );
+
   it("warns instead of creating an undocumented cacheRetention alias", () => {
     applyAndExpectWrapped({
       cfg: {

--- a/src/agents/embedded-agent-runner/extra-params.cache-retention-default.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.cache-retention-default.test.ts
@@ -309,8 +309,8 @@ describe("cacheRetention default behavior", () => {
     ).toBe("long");
   });
 
-  it.each(["short", "long", "none"] as const)(
-    "passes explicit %s retention to the Bedrock Converse policy owner",
+  it.each([undefined, "short", "long", "none"] as const)(
+    "preserves %s retention for the Bedrock Converse policy owner",
     (cacheRetention) => {
       expect(
         resolveCacheRetention(

--- a/src/agents/embedded-agent-runner/prompt-cache-retention.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-retention.ts
@@ -50,7 +50,9 @@ export function resolveCacheRetention(
   const compatEligible =
     compat?.supportsPromptCacheKey === true || compat?.cacheControlFormat === "anthropic";
 
-  if (!family && !googleEligible && !openAIEligible && !compatEligible) {
+  // Bedrock's provider owner decides model eligibility and checkpoint TTLs.
+  const bedrockEligible = modelApi === "bedrock-converse-stream";
+  if (!family && !googleEligible && !openAIEligible && !compatEligible && !bedrockEligible) {
     return undefined;
   }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users configuring prompt caching for supported Amazon Nova models received no explicit cache checkpoints on Amazon Bedrock. Their configured retention could be dropped before reaching the provider, and the provider disabled all non-Claude models.

## Why This Change Was Made

Bedrock now owns a shared model-aware policy for registration and payload construction. It recognizes Nova Micro, Lite, Pro, Premier, and Nova 2 Lite v1 model IDs, their geographic inference profiles, and foundation-model ARNs. The generic Converse configuration path forwards explicit retention to that owner. Checkpoint construction is shared so system and message markers use the same TTL policy.

Claude behavior, opaque application-profile resolution, and the existing registration boundary for the runtime cache override are preserved. Unsupported non-Claude models remain disabled. No configuration options, schemas, persistent stores, dependencies, or changelog entries were added.

## User Impact

Supported Nova requests can reuse stable system and conversation prefixes. Both `short` and `long` use Nova's five-minute cache window, `none` suppresses explicit checkpoints, and no tool checkpoints are emitted. Nova explicit caching is strictly opt-in: configure `cacheRetention` as `short` or `long`. With no configured value, Nova requests preserve the existing payload bytes, without checkpoints or a default `short`. Environment retention defaults do not enable Nova checkpoints. AWS token minimums and limits still govern actual cache hits.

Updated `docs/reference/prompt-caching.md` and `docs/providers/anthropic.md`.

## Evidence

AWS's [prompt-caching guide](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) and the model cards for [Micro](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-micro.html), [Lite](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-lite.html), [Pro](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-pro.html), [Premier](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-premier.html), and [Nova 2 Lite](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-2-lite.html) were read on **2026-09-07**. All five list explicit system/message checkpoints and a five-minute TTL. No live AWS inference was run; this change was validated at the emitted Converse payload boundary.

Before the fix, regression tests failed for the intended reasons: three dropped-retention cases, seven missing Nova payload checkpoints, and two forced-none registration cases.

Focused results before the opt-in follow-up:

```text
node scripts/run-vitest.mjs extensions/amazon-bedrock
Test Files  12 passed (12)
Tests       277 passed (277)

node scripts/run-vitest.mjs src/agents/embedded-agent-runner/extra-params.cache-retention-default.test.ts
Test Files  1 passed (1)
Tests       32 passed (32)
```

`node scripts/check-changed.mjs` passed 25 gates before exiting at extension lint's declaration preparation with the known nested-checkout environment error: `Declaration input escapes checkout ... qrcode/package.json`. The eight remaining planned guards were run directly and all passed: native state schema, legacy stores, media helpers, sidecar loaders, import cycles, webhook body ordering, pairing-store group auth, and pairing account scope. Thus 33 of 34 local gates passed; CI is authoritative for the blocked extension declaration/lint lane. Core, core-test, extension, and extension-test typechecks passed; both extension typechecks were repeated after the final compatibility adjustment. Formatting and `git diff --check` passed. No baselines or snapshots changed.

Codex autoreview before the opt-in follow-up: **scoped-clean, zero accepted/actionable P0 or P1 findings; overall patch is correct**. The earlier review was repeated after the final compatibility adjustment.

CI at head `fc289869333486f2a502aa82bc7ab2c7b3c4ccf2`: the [exact-head run](https://github.com/openclaw/openclaw/actions/runs/34103087005) reported an unrelated failure in [checks-node-compact-small-21](https://github.com/openclaw/openclaw/actions/runs/34103087005/job/101681970993). The help-only profiler CLI test at `test/scripts/run-vitest-profile.test.ts:280` (`prints main help for ['--help', '--help'] without starting a test server`) timed out after 120000 ms; neither that test nor `scripts/run-vitest-profile.mts` changed here. Its shard had 367 passing tests and this single timeout. No retries or timeout changes were made.

At the stop snapshot, this CI run had 100 successful jobs, 16 skipped, one failed, and six still running. Hosted `check-additional-extension-package-boundary`, `check-lint`, production/test typechecks, docs, and all changed-extension test jobs passed, including the lane blocked by the local nested-checkout guard. Further CI work is left to the coordinator because the reported failure is unrelated to the cache change.

### Opt-in maintainer decision

Maintainer decision: keep supported Nova explicit caching strictly opt-in. Nova requests will emit `cachePoint` blocks only when `cacheRetention` is explicitly configured as `short` or `long`; both retain the five-minute TTL. With retention unset, requests preserve the existing payload bytes with no checkpoints and no default `short`. Explicit `none` disables checkpoints, and Claude behavior remains unchanged.

The prompt-caching and Anthropic provider docs now state the opt-in requirement and that this capability has not been live-verified against AWS by OpenClaw maintainers yet. Live AWS acceptance proof remains a documented gap until a maintainer with Bedrock access runs it; emitted Converse payload tests are boundary evidence, not live AWS acceptance evidence.

### Opt-in follow-up validation

The unset-retention payload regression failed on the prior head for all seven supported Nova model/profile cases before the runtime fix. The final Nova matrix covers unset, explicit `short`, `long`, and `none`, preserves the uncached system-text layout, and checks that environment defaults cannot enable Nova checkpoints. The core forwarding table separately confirms unset Bedrock retention stays `undefined`.

- Bedrock focused suite: **12 files, 278 tests passed**.
- Core retention-forwarding suite: **1 file, 33 tests passed**.
- `node scripts/check-changed.mjs`: **25 checks passed** before extension lint's declaration preparation hit the known nested-checkout `qrcode/package.json` boundary guard. The **eight remaining planned guards passed** when run directly, giving **33 of 34 local checks verified**. All four production/test typecheck lanes passed. After the final forwarding-table addition, core-test typechecks and formatting passed again; the additional targeted lint invocation encountered the same environmental declaration guard.
- Final Codex autoreview of the staged complete PR candidate: **scoped-clean; zero accepted/actionable P0/P1 findings; patch is correct**. An earlier index-only finding was resolved by staging the fix. A later claim that core injects a Nova default was disproved by the full resolver source and the added unset-forwarding case; the final review included that source context and confirmed the behavior.
- Follow-up diff: **6 files, +43/-15** (production +14/-4, tests +23/-8, docs +6/-3). Formatting and `git diff --check` passed.

Live AWS acceptance remains unverified and is explicitly documented; this evidence does not claim live Bedrock acceptance.

### CI for the opt-in follow-up

Pushed head: `22a43ccecc3f74a4b326db595eab6390b43ceec2`.

The requested `node scripts/watch-pr-ci.mjs 141060 22a43ccecc3f74a4b326db595eab6390b43ceec2` attached to [run 34108733050](https://github.com/openclaw/openclaw/actions/runs/34108733050) and exited 15 after reporting `check-lint` failure. The [failed job](https://github.com/openclaw/openclaw/actions/runs/34108733050/job/101700028075) reports `extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts:1119:4`: `File has too many lines (1012). eslint(max-lines)`. That file is unchanged by this PR. CI checked merge ref `413aa45a`, merging this head into base `42224acfdbccb41ae2bf93d95851dfff3282fb20`.

At the final observed snapshot, the run was still in progress with **35 successful jobs, 71 running, 16 skipped, and one failed**. Hosted `check-additional-extension-package-boundary` passed, covering the declaration-boundary check blocked by the local nested-checkout environment. This is not a green CI claim. The unrelated Telegram lint failure is left for a separate repair; no lint limits were weakened, no rebase was needed, and no prepare or merge commands were run.
