### PR TITLE
fix(daemon): keep Windows service launchers intact when a rewrite fails

### DIFF
--- a/src/daemon/schtasks-install.ts
+++ b/src/daemon/schtasks-install.ts
@@ -15,7 +15,7 @@ import {
   buildScheduledTaskXml,
   buildStartupLauncherScript,
   buildTaskScript,
-  encodeWindowsLauncherScript,
+  publishWindowsLauncherScript,
   quoteSchtasksArg,
   readScheduledTaskCommand,
   resolveStartupEntryPath,
@@ -137,13 +137,14 @@ async function writeScheduledTaskScript({
     workingDirectory,
     environment: resolveScheduledTaskScriptEnvironment(taskEnv, environment),
   });
-  await fs.writeFile(scriptPath, encodeWindowsLauncherScript({ format: "cmd", content: script }));
+  await publishWindowsLauncherScript({ filePath: scriptPath, format: "cmd", content: script });
   if (taskLaunchPath !== scriptPath) {
     const launcher = buildHiddenLauncherScript({ description: taskDescription, scriptPath });
-    await fs.writeFile(
-      taskLaunchPath,
-      encodeWindowsLauncherScript({ format: "vbs", content: launcher }),
-    );
+    await publishWindowsLauncherScript({
+      filePath: taskLaunchPath,
+      format: "vbs",
+      content: launcher,
+    });
   }
   return { scriptPath, taskLaunchPath, taskDescription };
 }
@@ -257,13 +258,11 @@ async function activateScheduledTask(params: {
             description: taskDescription,
             scriptPath: params.scriptPath,
           });
-      await fs.writeFile(
-        startupEntryPath,
-        encodeWindowsLauncherScript({
-          format: useHiddenLauncher ? "vbs" : "cmd",
-          content: launcher,
-        }),
-      );
+      await publishWindowsLauncherScript({
+        filePath: startupEntryPath,
+        format: useHiddenLauncher ? "vbs" : "cmd",
+        content: launcher,
+      });
       await launchFallbackTaskScript(params.env);
       writeFormattedLines(
         params.stdout,

--- a/src/daemon/schtasks-layout.ts
+++ b/src/daemon/schtasks-layout.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { hasErrnoCode } from "../infra/errno.js";
+import { replaceFileAtomic } from "../infra/replace-file.js";
 import { getWindowsCmdExePath } from "../infra/windows-install-roots.js";
 import {
   decodeWindowsLauncherScript,
@@ -405,3 +406,34 @@ export function buildHiddenLauncherScript(params: {
 }
 
 export { encodeWindowsLauncherScript };
+
+/**
+ * Publishes a generated Windows launcher script (`.cmd` / `.vbs`) atomically.
+ *
+ * A torn direct write used to truncate the previous launcher while the existing
+ * task or login entry still pointed at it (#141002); the replacement only
+ * takes over after every byte is staged, so a failed rewrite (ENOSPC, EPERM
+ * rename, power loss) keeps the prior complete script available.
+ */
+export async function publishWindowsLauncherScript(params: {
+  filePath: string;
+  format: "cmd" | "vbs";
+  content: string;
+}): Promise<void> {
+  const directory = path.dirname(params.filePath);
+  await fs.mkdir(directory, { recursive: true });
+  await replaceFileAtomic({
+    filePath: params.filePath,
+    content: encodeWindowsLauncherScript({ format: params.format, content: params.content }),
+    // New launchers keep the previous fs.writeFile default create mode; an
+    // existing launcher keeps its current mode across the rewrite.
+    mode: 0o666 & ~process.umask(),
+    preserveExistingMode: true,
+    // Keep the launcher directory's current mode instead of the 0o700 default.
+    dirMode: (await fs.stat(directory)).mode & 0o777,
+    // An orphaned staging file is identifiable as a launcher publication leftover.
+    tempPrefix: ".openclaw-launcher-replace",
+    syncTempFile: true,
+    syncParentDir: true,
+  });
+}

--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -112,6 +112,67 @@ describe("installScheduledTask", () => {
     expect(schtasksCalls[index]).toEqual(["/Run", "/TN", taskName]);
   }
 
+  const priorTaskScript = [
+    "@echo off",
+    "rem Old gateway launcher",
+    "node gateway-old.js < NUL",
+    "",
+  ].join("\r\n");
+
+  async function writePriorLauncher(filePath: string, content: string): Promise<void> {
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, content, "utf8");
+  }
+
+  async function expectNoTempLeftovers(dir: string): Promise<void> {
+    expect((await fs.readdir(dir)).filter((entry) => entry.endsWith(".tmp"))).toEqual([]);
+  }
+
+  // Fails the staged temp-file write partway through, as a full disk does
+  // (#141002). Staged handles are captured at open time because
+  // replaceFileAtomic publishes via fs.promises.writeFile(handle, content).
+  function failStagedLauncherWrite(params: {
+    targetDir: string;
+    isTargetContent?: (data: unknown) => boolean;
+    partialBytes?: number;
+  }): () => void {
+    const stagedHandles = new Set<unknown>();
+    const originalOpen = fs.open.bind(fs);
+    const originalWriteFile = fs.writeFile.bind(fs);
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      const handle = await originalOpen(filePath, flags, mode);
+      const resolved = path.resolve(String(filePath));
+      if (
+        resolved.startsWith(`${path.resolve(params.targetDir)}${path.sep}`) &&
+        path.basename(resolved).endsWith(".tmp")
+      ) {
+        stagedHandles.add(handle);
+      }
+      return handle;
+    });
+    const writeSpy = vi.spyOn(fs, "writeFile").mockImplementation(async (file, data, options) => {
+      const staged = stagedHandles.has(file);
+      const direct =
+        typeof file === "string" &&
+        path.resolve(file).startsWith(`${path.resolve(params.targetDir)}${path.sep}`);
+      if ((staged || direct) && (!params.isTargetContent || params.isTargetContent(data))) {
+        await originalWriteFile(
+          file as never,
+          (data as Buffer).subarray(0, params.partialBytes ?? 11),
+          options as never,
+        );
+        throw Object.assign(new Error("ENOSPC: no space left on device, write"), {
+          code: "ENOSPC",
+        });
+      }
+      return originalWriteFile(file as never, data as never, options as never);
+    });
+    return () => {
+      openSpy.mockRestore();
+      writeSpy.mockRestore();
+    };
+  }
+
   it.each(["install", "stage"])(
     "%s redirects stdin from NUL so a hidden service console is never interactive (#112173)",
     async (mode) => {
@@ -662,6 +723,126 @@ describe("installScheduledTask", () => {
       expect(
         audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayManagedEnvEmbedded),
       ).toBe(true);
+    });
+  });
+
+  it("keeps the prior task script when a staged rewrite fails mid-write (#141002)", async () => {
+    await withUserProfileDir(async (_tmpDir, env) => {
+      const scriptPath = resolveTaskScriptPath(env);
+      await writePriorLauncher(scriptPath, priorTaskScript);
+
+      const restore = failStagedLauncherWrite({ targetDir: path.dirname(scriptPath) });
+      try {
+        await expect(
+          stageScheduledTask({
+            env,
+            stdout: new PassThrough(),
+            programArguments: ["node", "gateway.js"],
+            environment: {},
+          }),
+        ).rejects.toMatchObject({ code: "ENOSPC" });
+      } finally {
+        restore();
+      }
+
+      // The prior launcher stays byte-for-byte intact for the existing task entry.
+      expect(await fs.readFile(scriptPath, "utf8")).toBe(priorTaskScript);
+      await expect(readScheduledTaskCommand(env)).resolves.toMatchObject({
+        programArguments: ["node", "gateway-old.js"],
+      });
+      await expectNoTempLeftovers(path.dirname(scriptPath));
+      expect(schtasksCalls).toEqual([]);
+    });
+  });
+
+  it("keeps the prior task script when the install rewrite fails mid-write (#141002)", async () => {
+    await withUserProfileDir(async (_tmpDir, env) => {
+      const scriptPath = resolveTaskScriptPath(env);
+      await writePriorLauncher(scriptPath, priorTaskScript);
+
+      const restore = failStagedLauncherWrite({ targetDir: path.dirname(scriptPath) });
+      try {
+        await expect(installDefaultGatewayTask(env)).rejects.toMatchObject({ code: "ENOSPC" });
+      } finally {
+        restore();
+      }
+
+      expect(await fs.readFile(scriptPath, "utf8")).toBe(priorTaskScript);
+      await expect(readScheduledTaskCommand(env)).resolves.toMatchObject({
+        programArguments: ["node", "gateway-old.js"],
+      });
+      await expectNoTempLeftovers(path.dirname(scriptPath));
+      // The failure happens before any Scheduler activation call.
+      expect(schtasksCalls).toEqual([]);
+    });
+  });
+
+  it("keeps the prior hidden launcher when its staged rewrite fails mid-write (#141002)", async () => {
+    await withUserProfileDir(async (_tmpDir, env) => {
+      const scriptPath = resolveTaskScriptPath(env);
+      const launcherPath = scriptPath.replace(/\.cmd$/i, ".vbs");
+      await writePriorLauncher(scriptPath, priorTaskScript);
+      const priorHiddenLauncher = Buffer.concat([
+        Buffer.from([0xff, 0xfe]),
+        Buffer.from(
+          `' Old hidden launcher\r\nWScript.Quit CreateObject("WScript.Shell").Run("""C:\\old\\gateway.cmd""", 0, True)\r\n`,
+          "utf16le",
+        ),
+      ]);
+      await fs.writeFile(launcherPath, priorHiddenLauncher);
+
+      // Only the UTF-16 LE VBS staged write fails; the cmd script still publishes.
+      const restore = failStagedLauncherWrite({
+        targetDir: path.dirname(scriptPath),
+        isTargetContent: (data) => (data as Buffer)[0] === 0xff && (data as Buffer)[1] === 0xfe,
+      });
+      try {
+        await expect(
+          installDefaultGatewayTask({ ...env, OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "1" }),
+        ).rejects.toMatchObject({ code: "ENOSPC" });
+      } finally {
+        restore();
+      }
+
+      expect(await fs.readFile(launcherPath)).toEqual(priorHiddenLauncher);
+      await expectNoTempLeftovers(path.dirname(scriptPath));
+      expect(schtasksCalls).toEqual([]);
+    });
+  });
+
+  it("keeps the prior task script bytes, mode, and directory when publication rename fails (#141002)", async () => {
+    await withUserProfileDir(async (_tmpDir, env) => {
+      const scriptPath = resolveTaskScriptPath(env);
+      await writePriorLauncher(scriptPath, priorTaskScript);
+      await fs.chmod(scriptPath, 0o755);
+      // Windows chmod only toggles the read-only bit, so the effective mode is
+      // platform-dependent; capture it and compare against it after the failure.
+      const priorMode = (await fs.stat(scriptPath)).mode & 0o777;
+      if (process.platform !== "win32") {
+        expect(priorMode).toBe(0o755);
+      }
+
+      const renameSpy = vi
+        .spyOn(fs, "rename")
+        .mockRejectedValueOnce(
+          Object.assign(new Error("EPERM: operation not permitted, rename"), { code: "EPERM" }),
+        );
+      try {
+        await expect(installDefaultGatewayTask(env)).rejects.toMatchObject({ code: "EPERM" });
+      } finally {
+        renameSpy.mockRestore();
+      }
+
+      expect(await fs.readFile(scriptPath, "utf8")).toBe(priorTaskScript);
+      expect((await fs.stat(scriptPath)).mode & 0o777).toBe(priorMode);
+      await expectNoTempLeftovers(path.dirname(scriptPath));
+      expect(schtasksCalls).toEqual([]);
+
+      // A later rewrite with the fault cleared republishes successfully.
+      const { scriptPath: republishedPath } = await installDefaultGatewayTask(env);
+      expect(republishedPath).toBe(scriptPath);
+      const script = decodeWindowsLauncherScript({ buffer: await fs.readFile(scriptPath) });
+      expect(script).toContain("node gateway.js < NUL");
     });
   });
 });

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -157,6 +157,50 @@ async function writeStartupFallbackEntry(env: Record<string, string>, extension 
   return startupEntryPath;
 }
 
+async function expectNoTempLeftovers(dir: string): Promise<void> {
+  expect((await fs.readdir(dir)).filter((entry) => entry.endsWith(".tmp"))).toEqual([]);
+}
+
+// Fails the staged temp-file write partway through, as a full disk does
+// (#141002). Staged handles are captured at open time because publication
+// goes through fs.promises.writeFile(handle, content) on a temp file.
+function failStagedLauncherWrite(params: {
+  targetDir: string;
+  isTargetContent?: (data: unknown) => boolean;
+}): () => void {
+  const stagedHandles = new Set<unknown>();
+  const originalOpen = fs.open.bind(fs);
+  const originalWriteFile = fs.writeFile.bind(fs);
+  const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+    const handle = await originalOpen(filePath, flags, mode);
+    const resolved = path.resolve(String(filePath));
+    if (
+      resolved.startsWith(`${path.resolve(params.targetDir)}${path.sep}`) &&
+      path.basename(resolved).endsWith(".tmp")
+    ) {
+      stagedHandles.add(handle);
+    }
+    return handle;
+  });
+  const writeSpy = vi.spyOn(fs, "writeFile").mockImplementation(async (file, data, options) => {
+    const staged = stagedHandles.has(file);
+    const direct =
+      typeof file === "string" &&
+      path.resolve(file).startsWith(`${path.resolve(params.targetDir)}${path.sep}`);
+    if ((staged || direct) && (!params.isTargetContent || params.isTargetContent(data))) {
+      await originalWriteFile(file as never, (data as Buffer).subarray(0, 11), options as never);
+      throw Object.assign(new Error("ENOSPC: no space left on device, write"), {
+        code: "ENOSPC",
+      });
+    }
+    return originalWriteFile(file as never, data as never, options as never);
+  });
+  return () => {
+    openSpy.mockRestore();
+    writeSpy.mockRestore();
+  };
+}
+
 async function writeNodeScript(env: Record<string, string>, port = "18789") {
   const scriptPath = resolveTaskScriptPath(env);
   await fs.mkdir(path.dirname(scriptPath), { recursive: true });
@@ -708,6 +752,65 @@ describe("Windows startup fallback", () => {
         `WScript.Quit CreateObject("WScript.Shell").Run("""${result.scriptPath}""", 0, True)`,
       );
       expectStartupFallbackSpawn();
+    });
+  });
+
+  it("keeps the prior Startup-folder launcher when its rewrite fails mid-write (#141002)", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      addMissingTaskInstallResponses([{ code: 5, stdout: "", stderr: "ERROR: Access is denied." }]);
+      const startupEntryPath = resolveStartupEntryPath(env);
+      const priorStartupEntry =
+        '@echo off\r\nstart "" /min cmd.exe /d /c "C:\\old\\gateway.cmd"\r\n';
+      await fs.mkdir(path.dirname(startupEntryPath), { recursive: true });
+      await fs.writeFile(startupEntryPath, priorStartupEntry, "utf8");
+
+      // Only the Startup-folder staged write fails; the task script still publishes.
+      const restore = failStagedLauncherWrite({
+        targetDir: path.dirname(startupEntryPath),
+      });
+      try {
+        await expect(installGatewayScheduledTask(env, new PassThrough())).rejects.toMatchObject({
+          code: "ENOSPC",
+        });
+      } finally {
+        restore();
+      }
+
+      expect(await fs.readFile(startupEntryPath, "utf8")).toBe(priorStartupEntry);
+      await expectNoTempLeftovers(path.dirname(startupEntryPath));
+      // The fallback launcher is only launched after its publication succeeds.
+      expect(spawn).not.toHaveBeenCalled();
+    });
+  });
+
+  it("keeps the prior hidden Startup-folder launcher when its rewrite fails mid-write (#141002)", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      addMissingTaskInstallResponses([{ code: 5, stdout: "", stderr: "ERROR: Access is denied." }]);
+      const hiddenEnv = { ...env, OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "1" };
+      const startupEntryPath = resolveStartupEntryPath(hiddenEnv, "vbs");
+      const priorStartupEntry = Buffer.concat([
+        Buffer.from([0xff, 0xfe]),
+        Buffer.from("' Old hidden startup launcher\r\n", "utf16le"),
+      ]);
+      await fs.mkdir(path.dirname(startupEntryPath), { recursive: true });
+      await fs.writeFile(startupEntryPath, priorStartupEntry);
+
+      // Only the UTF-16 LE VBS staged write fails; the task script still publishes.
+      const restore = failStagedLauncherWrite({
+        targetDir: path.dirname(startupEntryPath),
+        isTargetContent: (data) => (data as Buffer)[0] === 0xff && (data as Buffer)[1] === 0xfe,
+      });
+      try {
+        await expect(
+          installGatewayScheduledTask(hiddenEnv, new PassThrough()),
+        ).rejects.toMatchObject({ code: "ENOSPC" });
+      } finally {
+        restore();
+      }
+
+      expect(await fs.readFile(startupEntryPath)).toEqual(priorStartupEntry);
+      await expectNoTempLeftovers(path.dirname(startupEntryPath));
+      expect(spawn).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #141002

## What Problem This Solves

- Fixes an issue where users updating the Windows service (Scheduled Task or Startup login item) would have their existing `gateway.cmd` / `gateway.vbs` launcher truncated when the rewrite fails partway (e.g. disk full), even though the registered task or login entry still points at that file — the next service start or login then finds an 11-byte `@echo off` stub and `readScheduledTaskCommand` returns `null`.
- **Related:** #140760 addresses the same publication pattern for Linux/macOS service env files; this PR is the independent Windows CMD/VBS owner and does not touch other platforms or request a multi-file service transaction.

## Why This Change Was Made

- **Intended outcome:** a failed publication leaves the previous complete launcher in place; the replacement only takes over the path after its bytes have been fully staged. Covered write sites: the shared stage/install task script (CMD), the hidden-task launcher (VBS), and the Startup-folder fallback entry (CMD/VBS).
- **Out of scope:** Linux/macOS service publication, the restart-helper/temporary launcher writers (they already create fresh `wx` paths), and any multi-file transaction across script + task registration.
- **Highest-risk area:** launcher file modes and directory side effects of the new staged write.
- **How is that risk mitigated?** publication reuses the repo's canonical `replaceFileAtomic` helper with `preserveExistingMode` and the directory's existing mode, and regression tests assert prior bytes, prior mode, no `.tmp` leftovers, no Scheduler activation on failure, and a later successful rewrite. No in-place copy fallback is enabled, so a locked destination fails closed instead of tearing the file again.

## User Impact

- **Success criteria:** after any failed launcher rewrite (partial write or failed rename), the previously installed launcher still contains its full previous content, its mode is unchanged, and command readback keeps returning the old command; a later install with the fault cleared republishes successfully.
- **What should reviewers focus on?** `src/daemon/schtasks-layout.ts` (`publishWindowsLauncherScript`), `src/daemon/schtasks-install.ts` (three call sites), and the fault-injection regressions in `src/daemon/schtasks.install.test.ts` and `src/daemon/schtasks.startup-fallback.test.ts` (marker `#141002`).

## Evidence

- **Real environment tested:** real `stageScheduledTask`/`installScheduledTask` owners against a temp `USERPROFILE` filesystem, exercised both through the repo test fixtures and through a standalone reproduction script (no test runner) that drives the same owners with fault injection at the real filesystem write/rename boundary, plus one fully kernel-level fault (read-only launcher directory → real `EACCES`, zero mocking). The pinned `@openclaw/fs-safe` 0.8.3 `replaceFileAtomic(preserveExistingMode)` behavior was also verified directly against the installed package.
- **Exact steps or commands run after this patch:**
  ```bash
  # 1. Regression tests on the unpatched owner (before evidence): new cases fail with the truncation from the report
  node scripts/run-vitest.mjs run src/daemon/schtasks.install.test.ts src/daemon/schtasks.startup-fallback.test.ts
  # 2. Same suites after the patch (all pass), plus the full daemon shard
  node scripts/run-vitest.mjs run src/daemon/schtasks.install.test.ts src/daemon/schtasks.startup-fallback.test.ts
  node scripts/run-vitest.mjs run test/vitest/vitest.daemon.config.ts
  # 3. Standalone reproduction outside any test runner (real owners + real temp filesystem,
  #    faults injected at the fs boundary; read-only-dir case is a real kernel EACCES)
  node --import ./scripts/tsx.mjs repro-141002.mts   # run once on origin/main, once on this branch
  ```
- **Evidence after fix:** (standalone reproduction, no test runner)
  ```text
  [1] @openclaw/fs-safe 0.8.3 replaceFileAtomic(preserveExistingMode)
  PASS  content replaced — "new-content"
  PASS  existing 0o755 mode preserved — mode=755
  PASS  no .tmp leftovers — []
  [3] fault A: ENOSPC partway through the launcher write (injected at fs boundary)
  PASS  install rejected with ENOSPC — code=ENOSPC
  PASS  prior launcher bytes intact — len=64
  PASS  prior launcher mode intact — mode=755
  PASS  readScheduledTaskCommand still returns the old command
  PASS  no .tmp staging leftovers — []
  [4] fault B: EPERM rename failure at publication (injected at fs boundary)
  PASS  install rejected with EPERM — code=EPERM
  PASS  prior launcher bytes intact — len=64
  PASS  prior launcher mode intact — mode=755
  PASS  readScheduledTaskCommand still returns the old command
  PASS  no .tmp staging leftovers — []
  [5] fault C: read-only launcher directory (real kernel EACCES, no fs patching)
  PASS  stage rejected with EACCES — code=EACCES
  PASS  prior launcher bytes intact — len=64
  PASS  prior launcher mode intact — mode=755
  [6] recovery: all faults cleared, publication succeeds and launcher is usable
  PASS  stage republished to the same path
  PASS  launcher rewritten with the new command — len=56
  PASS  launcher mode preserved across rewrite — mode=755
  PASS  readScheduledTaskCommand returns the new command — ["node","gateway.js"]
  PASS  no .tmp staging leftovers — []
  RESULT: ALL CHECKS PASSED
  # regression suites after the patch (including the reworked cross-platform mode assertion):
  Test Files  2 passed (2)
       Tests  111 passed (111)
  ```
- **Observed result after fix:** with a staged partial write (first 11 bytes, then `ENOSPC`), an injected `EPERM` rename failure, and a real kernel-level `EACCES` from a read-only launcher directory, the prior 64-byte launcher keeps its exact prior bytes (readback still returns `node gateway-old.js`), its `0o755` mode is unchanged, no `.tmp` staging files leak, and a later publication with the fault cleared rewrites the launcher successfully (readback returns the new command).
- **Before evidence (same standalone script on `origin/main`, no test runner):** the identical `ENOSPC` fault leaves the prior 64-byte CMD launcher truncated to the 11-byte `@echo off\r\n` stub (`prior launcher bytes intact — len=11` FAIL, `readScheduledTaskCommand still returns the old command` FAIL — it returns `null`), exactly the data loss reported; additionally, `origin/main`'s direct in-place write replaces the launcher even when the launcher directory is read-only (the real kernel `EACCES` never fires), while this branch fails closed and preserves the prior launcher.
- **What was not tested:** no live Windows host was available, so no real Windows Task Scheduler entry, `schtasks.exe` invocation, or running Gateway was created or modified — Scheduler/process activation boundaries remain isolated (matching the report's reproduction scope); real full-disk/power-cut conditions are emulated via injected `ENOSPC`/`EPERM` at the write/rename boundary (plus the genuine `EACCES` case); Windows `chmod` semantics (read-only bit only) are not asserted — the regression test now captures the actual pre-failure mode and compares against it, keeping the explicit `0o755` assertion scoped to non-Windows platforms.
- **Proof tier:** L2
- **Proof limitations:** runtime transcripts were produced on Linux against the real publication owners and a real temp filesystem; the Windows Task Scheduler activation path itself was not exercised live.
- **Review state:** Addressed ClawSweeper review of a7072192: P2 Windows-incompatible mode assertion reworked to a captured-mode baseline (platform-scoped POSIX check), standalone (non-test-suite) before/after runtime transcripts added, and the pinned `@openclaw/fs-safe` 0.8.3 `replaceFileAtomic(preserveExistingMode)` implementation verified behaviorally. Awaiting CI + maintainer review.
