### PR TITLE
fix(ai): preserve Responses reasoning changes after idle gaps

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -150,9 +150,13 @@ Responses endpoint. Configure the existing model settings:
 
 The example disables automatic server compaction because OpenAI cannot combine
 it with configuration updates. Cache-preserving effort changes also exclude
-automatic truncation, pro mode, and API multi-agent mode. The cache state is
-local to the running process or connection; expiry, restart, or rewritten
-history starts a fresh request using the selected effort.
+automatic truncation, pro mode, and API multi-agent mode. The original effort
+and admitted controls survive transport expiry and Gateway restarts in saved
+provider replay metadata. Matching history replays the same prefix without
+extending socket or provider cache lifetimes. Rewritten or compacted history,
+incompatible settings, or a changed model, route, session, or auth profile starts
+a fresh request using the selected effort. Older transcripts without this
+metadata also start fresh after transport expiry.
 
 The native [Codex harness](/plugins/codex-harness) owns its own Responses loop;
 these built-in-runtime capabilities do not imply native Codex support.

--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -21,10 +21,13 @@ Provider references:
 Prompt-cache reuse depends on provider request configuration as well as prompt
 text. Changing the model always starts a different cache lineage. Changing the
 thinking or reasoning level can also invalidate reuse even when the prompt and
-model stay the same. In particular, OpenAI reasoning-effort changes alter the
-reusable request state and can force the next turn to process the full prefix or
-conversation again. Anthropic likewise documents cache invalidation when its
-thinking budget, effort, or mode changes.
+model stay the same. Supported native OpenAI Responses requests preserve the
+original effort and append turn-scoped configuration controls, including after
+transport expiry or a Gateway restart when saved replay metadata and history
+still match. See [OpenAI reasoning changes](/providers/openai). Other OpenAI
+models or incompatible modes can still reprocess the full prefix. Anthropic
+likewise documents cache invalidation when its thinking budget, effort, or mode
+changes.
 
 If cache continuity matters, choose the model and thinking level when creating
 the session and keep both stable. Start a new session for a planned change.

--- a/packages/ai/src/transports/openai-responses-client.continuation.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.continuation.test.ts
@@ -40,14 +40,38 @@ vi.mock("openai", () => {
       this.baseURL = options.baseURL ?? "https://api.openai.com/v1";
       sseState.clientHeaders.push(options.defaultHeaders ?? {});
     }
+
+    withOptions(options: { apiKey?: string }) {
+      return new MockOpenAI({ apiKey: options.apiKey ?? this.apiKey, baseURL: this.baseURL });
+    }
   }
 
   return { default: MockOpenAI, AzureOpenAI: MockOpenAI };
 });
 
 vi.mock("openai/resources/responses/ws.js", () => ({
-  ResponsesWS: function UnexpectedResponsesWS() {
-    throw new Error("SSE continuation tests must not construct a WebSocket");
+  ResponsesWS: class MockResponsesWS {
+    socket = { readyState: 1 };
+    private outcome?: Error | SdkResponse;
+    send(request: Record<string, unknown>) {
+      sseState.requests.push(request);
+      this.outcome = sseState.outcomes.shift();
+    }
+    close() {
+      this.socket.readyState = 3;
+    }
+    on() {
+      return this;
+    }
+    async *stream() {
+      yield { type: "open" };
+      if (!this.outcome || this.outcome instanceof Error) {
+        throw this.outcome ?? new Error("Unexpected WebSocket request");
+      }
+      for await (const message of this.outcome.data) {
+        yield { type: "message", message };
+      }
+    }
   },
 }));
 
@@ -111,7 +135,6 @@ function completedEvent(responseId: string, content: string) {
         },
       ],
       role: "assistant",
-      phase: "final_answer",
     },
   ];
   return {
@@ -145,6 +168,8 @@ async function run(
     onPayload: (payload: Record<string, unknown>) => Record<string, unknown>;
     signal?: AbortSignal;
     reasoningEffort?: "low" | "medium" | "high";
+    transport?: "sse" | "websocket-cached";
+    authProfileId?: string;
     asyncToolExecution?: boolean;
     openclawCodeModeToolSurface?: boolean;
   },
@@ -153,7 +178,8 @@ async function run(
   const stream = await createOpenAIResponsesTransportStreamFn()(requestModel, context, {
     apiKey: "test-key",
     sessionId: options.sessionId ?? "session-1",
-    transport: "sse",
+    transport: options.transport ?? "sse",
+    authProfileId: options.authProfileId,
     reasoningEffort: options.reasoningEffort ?? "low",
     asyncToolExecution: options.asyncToolExecution,
     openclawCodeModeToolSurface: options.openclawCodeModeToolSurface,
@@ -188,6 +214,7 @@ describe("native OpenAI Responses SSE continuation", () => {
               openclaw_turn_attempt: "1",
               openclaw_transport: context.transport,
             },
+            websocket: { headers: { "x-openclaw-session-id": context.sessionId ?? "" } },
           };
         },
       },
@@ -197,6 +224,7 @@ describe("native OpenAI Responses SSE continuation", () => {
   afterEach(() => {
     cleanupSessionResources();
     configureAiTransportHost(initialHost);
+    vi.useRealTimers();
   });
 
   it("continues stateful literal SSE turns with only appended input", async () => {
@@ -246,47 +274,134 @@ describe("native OpenAI Responses SSE continuation", () => {
     expect(sseState.requests[1]?.input).toHaveLength(3);
   });
 
-  it("preserves Astra effort updates on the wire across unstored SSE turns", async () => {
+  it.each([
+    { transport: "sse", reset: "warm" },
+    { transport: "sse", reset: "cleanup" },
+    { transport: "sse", reset: "expiry" },
+    { transport: "websocket-cached", reset: "cleanup" },
+    { transport: "websocket-cached", reset: "expiry" },
+  ] as const)(
+    "preserves effort controls through $transport $reset and transcript reload",
+    async ({ transport, reset }) => {
+      vi.useFakeTimers();
+      sseState.outcomes.push(
+        sdkCompletion("resp_1", "first answer"),
+        sdkCompletion("resp_2", "second answer"),
+        sdkCompletion("resp_3", "third answer"),
+      );
+      const onPayload = (payload: Record<string, unknown>) => ({ ...payload, store: false });
+      const options = { onPayload, transport };
+      const messages: Context["messages"] = [userMessage("first question", 1)];
+      const first = await run({ messages }, options, astra);
+      messages.push(first, userMessage("second question", 2));
+      const second = await run({ messages }, { ...options, reasoningEffort: "high" }, astra);
+      messages.push(second, userMessage("third question", 3));
+      if (reset === "cleanup") {
+        cleanupSessionResources();
+      } else if (reset === "expiry") {
+        vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+      }
+      const serialized = JSON.stringify(messages);
+      const third = await run(
+        { messages: JSON.parse(serialized) },
+        { ...options, reasoningEffort: "medium" },
+        astra,
+      );
+      expect([first.stopReason, second.stopReason, third.stopReason]).toEqual([
+        "stop",
+        "stop",
+        "stop",
+      ]);
+      const configuration = { type: "configuration_update", reasoning: { effort: "high" } };
+      const input = sseState.requests[2]?.input;
+      expect(sseState.requests[1]).toMatchObject({ reasoning: { effort: "low" } });
+      expect(sseState.requests[1]?.input).toContainEqual(configuration);
+      expect(sseState.requests[2]).toMatchObject({
+        reasoning: { effort: "low", summary: "auto" },
+        input: [
+          { role: "user", content: [{ text: "first question" }] },
+          { role: "assistant", content: [{ text: "first answer" }] },
+          configuration,
+          { role: "user", content: [{ text: "second question" }] },
+          { role: "assistant", content: [{ text: "second answer" }] },
+          { type: "configuration_update", reasoning: { effort: "medium" } },
+          { role: "user", content: [{ text: "third question" }] },
+        ],
+      });
+      expect(sseState.requests[2]).not.toHaveProperty("previous_response_id");
+      if (transport === "websocket-cached") {
+        expect(sseState.requests[1]).toHaveProperty("previous_response_id", "resp_1");
+        expect(sseState.requests[2]).toHaveProperty("type", "response.create");
+      }
+      if (transport === "sse" && Array.isArray(input)) {
+        expect(input.slice(0, 4)).toEqual(sseState.requests[1]?.input);
+      }
+    },
+  );
+
+  it.each([
+    "model",
+    "mode",
+    "multi-agent",
+    "truncation",
+    "server compaction",
+    "compacted history",
+    "edited history",
+    "route",
+    "session",
+    "auth",
+    "request settings",
+  ])("resets durable effort controls after %s changes", async (change) => {
     sseState.outcomes.push(
       sdkCompletion("resp_1", "first answer"),
       sdkCompletion("resp_2", "second answer"),
       sdkCompletion("resp_3", "third answer"),
     );
     const onPayload = (payload: Record<string, unknown>) => ({ ...payload, store: false });
-    const messages: Context["messages"] = [userMessage("first question", 1)];
+    let messages: Context["messages"] = [userMessage("first question", 1)];
     const first = await run({ messages }, { onPayload }, astra);
     messages.push(first, userMessage("second question", 2));
     const second = await run({ messages }, { onPayload, reasoningEffort: "high" }, astra);
     messages.push(second, userMessage("third question", 3));
-    const third = await run({ messages }, { onPayload, reasoningEffort: "high" }, astra);
-
-    expect([first.stopReason, second.stopReason, third.stopReason]).toEqual([
-      "stop",
-      "stop",
-      "stop",
-    ]);
-    const configuration = { type: "configuration_update", reasoning: { effort: "high" } };
-    expect(sseState.requests).toEqual([
-      expect.objectContaining({ store: false, reasoning: { effort: "low", summary: "auto" } }),
-      expect.objectContaining({
-        store: false,
-        reasoning: { effort: "low", summary: "auto" },
-        input: [expect.anything(), expect.anything(), configuration, expect.anything()],
-      }),
-      expect.objectContaining({
-        store: false,
-        reasoning: { effort: "low", summary: "auto" },
-        input: [
-          expect.anything(),
-          expect.anything(),
-          configuration,
-          expect.anything(),
-          expect.anything(),
-          expect.anything(),
-        ],
-      }),
-    ]);
-    expect(sseState.requests.every((request) => !request.previous_response_id)).toBe(true);
+    expect(sseState.requests[1]?.input).toContainEqual({
+      type: "configuration_update",
+      reasoning: { effort: "high" },
+    });
+    cleanupSessionResources();
+    if (change === "compacted history") {
+      messages = [userMessage("compacted summary", 0), ...messages.slice(3)];
+    } else if (change === "edited history") {
+      messages[0] = userMessage("edited question", 1);
+    }
+    const serialized = JSON.stringify(messages);
+    const third = await run(
+      { messages: JSON.parse(serialized) },
+      {
+        reasoningEffort: "medium",
+        sessionId: change === "session" ? "session-2" : undefined,
+        authProfileId: change === "auth" ? "profile-2" : undefined,
+        onPayload: (payload) => ({
+          ...onPayload(payload),
+          ...(change === "mode" ? { reasoning: { effort: "medium", mode: "pro" } } : {}),
+          ...(change === "multi-agent" ? { multi_agent: { enabled: true } } : {}),
+          ...(change === "truncation" ? { truncation: "auto" } : {}),
+          ...(change === "server compaction"
+            ? { context_management: [{ type: "compaction", compact_threshold: 1000 }] }
+            : {}),
+          ...(change === "request settings" ? { max_output_tokens: 512 } : {}),
+        }),
+      },
+      change === "model"
+        ? model
+        : change === "route"
+          ? { ...astra, baseUrl: "https://example.test/v1" }
+          : astra,
+    );
+    expect(third.stopReason).toBe("stop");
+    expect(sseState.requests[2]).toMatchObject({ reasoning: { effort: "medium" } });
+    expect(sseState.requests[2]?.input).not.toContainEqual(
+      expect.objectContaining({ type: "configuration_update" }),
+    );
   });
 
   it("executes an Astra tool before SSE completes and returns its result once", async () => {

--- a/packages/ai/src/transports/openai-responses-client.continuation.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.continuation.test.ts
@@ -1,7 +1,10 @@
+import path from "node:path";
 import type { AssistantMessage, Context, Model } from "@openclaw/llm-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred, withTestTimeout } from "../../../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import { Agent } from "../../../agent-core/src/agent.js";
 
 type SdkResponse = { data: AsyncIterable<unknown>; response: Response };
@@ -80,6 +83,7 @@ import { cleanupSessionResources } from "../session-resources.js";
 import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
 
 const initialHost = getAiTransportHost();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const model = {
   id: "gpt-5.6-luna",
   name: "GPT-5.6 Luna",
@@ -336,6 +340,108 @@ describe("native OpenAI Responses SSE continuation", () => {
       if (transport === "sse" && Array.isArray(input)) {
         expect(input.slice(0, 4)).toEqual(sseState.requests[1]?.input);
       }
+    },
+  );
+
+  it.each(["current", "legacy without reasoning", "legacy without replay", "model", "session"])(
+    "round-trips %s reasoning state through the SQLite session transcript",
+    async (variant) => {
+      const { SessionManager } = await import("../../../../src/agents/sessions/session-manager.js");
+      const { upsertSessionEntryCore } =
+        await import("../../../../src/config/sessions/session-accessor.js");
+      configureAiTransportHost({
+        ...initialHost,
+        plugin: { ...initialHost.plugin, resolveTransportTurnState: () => undefined },
+      });
+      sseState.outcomes.push(
+        sdkCompletion("resp_1", "first answer"),
+        sdkCompletion("resp_2", "second answer"),
+        sdkCompletion("resp_warm", "third answer"),
+        sdkCompletion("resp_reloaded", "third answer"),
+      );
+      const onPayload = (payload: Record<string, unknown>) => ({ ...payload, store: false });
+      const messages: Context["messages"] = [userMessage("first question", 1)];
+      messages.push(
+        await run({ messages }, { onPayload }, astra),
+        userMessage("second question", 2),
+      );
+      messages.push(
+        await run({ messages }, { onPayload, reasoningEffort: "high" }, astra),
+        userMessage("third question", 3),
+      );
+      expect(sseState.requests[1]?.input).toContainEqual({
+        type: "configuration_update",
+        reasoning: { effort: "high" },
+      });
+      if (variant.startsWith("legacy")) {
+        for (const message of messages) {
+          if ("openclawResponsesInputReplay" in message) {
+            if (variant === "legacy without replay") {
+              delete message.openclawResponsesInputReplay;
+            } else if (isRecord(message.openclawResponsesInputReplay)) {
+              delete message.openclawResponsesInputReplay.reasoning;
+            }
+          }
+        }
+      }
+      const requestModel = variant === "model" ? model : astra;
+      const options = {
+        onPayload,
+        reasoningEffort: "medium" as const,
+        sessionId: variant === "session" ? "session-2" : "session-1",
+      };
+      // Legacy transcripts have no durable controls; compare their existing cold-request behavior.
+      if (variant !== "current") {
+        cleanupSessionResources();
+      }
+      expect((await run({ messages }, options, requestModel)).stopReason).toBe("stop");
+      const expectedRequest = sseState.requests.at(-1);
+      expect(expectedRequest).toMatchObject({
+        reasoning: { effort: variant === "current" ? "low" : "medium" },
+      });
+      if (variant === "current") {
+        expect(expectedRequest?.input).toEqual([
+          expect.objectContaining({ role: "user" }),
+          expect.objectContaining({ role: "assistant" }),
+          { type: "configuration_update", reasoning: { effort: "high" } },
+          expect.objectContaining({ role: "user" }),
+          expect.objectContaining({ role: "assistant" }),
+          { type: "configuration_update", reasoning: { effort: "medium" } },
+          expect.objectContaining({ role: "user" }),
+        ]);
+      } else {
+        expect(expectedRequest?.input).not.toContainEqual(
+          expect.objectContaining({ type: "configuration_update" }),
+        );
+      }
+
+      const dir = tempDirs.make("openclaw-responses-transcript-");
+      const scope = {
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: "agent:main:responses-reasoning",
+        storePath: path.join(dir, "sessions.json"),
+      };
+      await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+      const manager = SessionManager.open(scope, dir);
+      for (const message of messages) {
+        // This append traverses the production transcript redactor and SQLite store.
+        manager.appendMessage(message);
+      }
+      cleanupSessionResources();
+      const reloaded = SessionManager.open(scope, dir).buildSessionContext().messages;
+      expect(reloaded).toEqual(messages);
+      const requestMessages = reloaded.map((message) => {
+        if (message.role !== "user" && message.role !== "assistant") {
+          throw new Error(`Unexpected persisted message role: ${message.role}`);
+        }
+        return message;
+      });
+      expect((await run({ messages: requestMessages }, options, requestModel)).stopReason).toBe(
+        "stop",
+      );
+      expect(sseState.requests.at(-1)).toEqual(expectedRequest);
+      expect(sseState.requests.at(-1)).not.toHaveProperty("previous_response_id");
     },
   );
 

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -48,6 +48,10 @@ import {
   sanitizeOpenAICodexResponsesParams,
 } from "./openai-responses-params-internal.js";
 import { createResponsesPromptEgressObserver } from "./openai-responses-prompt-observer-internal.js";
+import {
+  recordResponsesReasoningState,
+  restoreResponsesReasoningState,
+} from "./openai-responses-reasoning-state.js";
 import { supportsResponsesReasoningUpdate } from "./openai-responses-reasoning-update.js";
 import {
   createOpenAIResponsesAssistantOutput,
@@ -348,6 +352,8 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
               sessionId,
             ),
             request: params as ResponsesContinuationRequest,
+            restoreRequest: () =>
+              restoreResponsesReasoningState(context, model, responsesOptions, params),
           });
           if (continuationClaim) {
             // SAFETY: The owner preserves the request; SDK inputs predate configuration_update.
@@ -403,11 +409,9 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
               suppressOpenAIResponsesCompaction(output, model, responsesOptions, checkpoint),
             canRetryStream: () => output.content.length === 0,
             wrapStream: ({ stream: rawResponseStream, response, attempt }) => {
-              if (continuationClaim) {
-                continuationBaseline = attempt.request.previous_response_id
-                  ? (params as ResponsesContinuationRequest)
-                  : (attempt.request as ResponsesContinuationRequest);
-              }
+              continuationBaseline = attempt.request.previous_response_id
+                ? (params as ResponsesContinuationRequest)
+                : (attempt.request as ResponsesContinuationRequest);
               return withProviderResponseHook({
                 stream: observeResponsesStream(rawResponseStream, model, requestStartedAt),
                 signal: firstEvent.signal,
@@ -428,6 +432,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
         };
 
         let responseStream: AsyncIterable<unknown>;
+        let websocketBaseline: ResponsesContinuationRequest | undefined;
         let finishWebSocket: ((options?: { keep?: boolean }) => void) | undefined;
         let transport: "sse" | "websocket" = "sse";
         const logWebSocketFallback = (reason: string) =>
@@ -447,6 +452,8 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
             const websocket = createOpenAIResponsesWebSocketStream({
               client,
               request: params,
+              restoreRequest: (request) =>
+                restoreResponsesReasoningState(context, model, responsesOptions, request),
               mode: websocketMode,
               sessionId: options?.sessionId,
               headers: websocketHeaders,
@@ -466,6 +473,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
                 ),
             });
             finishWebSocket = websocket.finish;
+            websocketBaseline = websocket.fullRequest;
             recordResponsesInputReplay(output, websocket.inputReplay);
             observePrompt?.(websocket.request, {
               egress: "responses-websocket",
@@ -567,6 +575,16 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
           if (output.stopReason === "aborted" || output.stopReason === "error") {
             // Keep the provider's terminal fact; the catch-side projection would overwrite it.
             throw new Error(output.errorMessage ?? "An unknown error occurred");
+          }
+          const admitted = transport === "websocket" ? websocketBaseline : continuationBaseline;
+          if (terminal && admitted && supportsNativeOpenAIResponsesEndpoint(model)) {
+            recordResponsesReasoningState(
+              output,
+              model,
+              responsesOptions,
+              admitted,
+              terminal.output,
+            );
           }
           if (continuationClaim && continuationBaseline && terminal) {
             continuationClaim.commit(continuationBaseline, terminal);

--- a/packages/ai/src/transports/openai-responses-continuation.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.ts
@@ -90,6 +90,24 @@ function normalizeAssistantReplayInput(input: readonly unknown[], fromResponse =
   });
 }
 
+export function responsesContinuationRequestFingerprint(
+  request: ResponsesContinuationRequest,
+): string {
+  const serialized = JSON.stringify(requestWithoutInput(request));
+  return sha256Hex(stableStringify(JSON.parse(serialized)));
+}
+
+export function responsesContinuationPrefixFingerprint(
+  input: readonly unknown[],
+  output: readonly unknown[] = [],
+): string {
+  const serialized = JSON.stringify([
+    ...normalizeAssistantReplayInput(input),
+    ...normalizeAssistantReplayInput(output, true),
+  ]);
+  return sha256Hex(stableStringify(JSON.parse(serialized)));
+}
+
 export function resolveResponsesContinuationRequest(
   continuation: ResponsesContinuationState | undefined,
   request: ResponsesContinuationRequest,
@@ -195,6 +213,7 @@ export function claimOpenAIResponsesHttpContinuation(
   params: HttpContinuationIdentity & {
     sessionId: string;
     request: ResponsesContinuationRequest;
+    restoreRequest?: () => ResponsesContinuationRequest;
   },
 ) {
   const key = `${params.sessionId}\0${connectionIdentity(params)}`;
@@ -208,11 +227,13 @@ export function claimOpenAIResponsesHttpContinuation(
   const claimed = { kind: "claimed", sessionId: params.sessionId } as const;
   httpContinuationEntries.set(key, claimed);
   try {
+    const request =
+      previous?.kind === "ready" ? params.request : (params.restoreRequest?.() ?? params.request);
     const resolved = resolveResponsesContinuationRequest(
       previous?.kind === "ready" ? previous.state : undefined,
-      params.request,
+      request,
     );
-    const fullRequest = resolved.fullRequest ?? params.request;
+    const fullRequest = resolved.fullRequest ?? request;
     return {
       // Unstored HTTP responses cannot be referenced, but their prompt prefix can still be cached.
       request: params.request.store === false ? fullRequest : resolved.request,

--- a/packages/ai/src/transports/openai-responses-reasoning-state.ts
+++ b/packages/ai/src/transports/openai-responses-reasoning-state.ts
@@ -1,0 +1,127 @@
+import type { AssistantMessage, Context, Model } from "@openclaw/llm-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { isOpenAIResponsesReplayContext } from "./openai-responses-compaction-replay.js";
+import {
+  responsesContinuationPrefixFingerprint,
+  responsesContinuationRequestFingerprint,
+  type ResponsesContinuationRequest,
+} from "./openai-responses-continuation.js";
+import {
+  isConfigurationUpdate,
+  replayResponsesReasoningUpdates,
+  supportsResponsesReasoningUpdate,
+} from "./openai-responses-reasoning-update.js";
+import {
+  buildProviderReplayContext,
+  providerReplayContextMatches,
+} from "./provider-replay-context.js";
+
+type ReplayIdentity = { sessionId?: string; authProfileId?: string };
+
+function inputReplay(message: AssistantMessage) {
+  const value =
+    "openclawResponsesInputReplay" in message ? message.openclawResponsesInputReplay : undefined;
+  return isRecord(value) ? value : undefined;
+}
+
+/** Save only admitted settings and hashes, never another copy of the conversation. */
+export function recordResponsesReasoningState(
+  message: AssistantMessage,
+  model: Model,
+  identity: ReplayIdentity | undefined,
+  request: ResponsesContinuationRequest,
+  output: readonly unknown[],
+): void {
+  if (
+    !supportsResponsesReasoningUpdate(request) ||
+    !isRecord(request.reasoning) ||
+    !request.input ||
+    request.previous_response_id ||
+    message.providerReplay ||
+    output.some((item) => isRecord(item) && item.type === "compaction")
+  ) {
+    return;
+  }
+  const reasoning = {
+    ...buildProviderReplayContext(model, identity),
+    effort: request.reasoning.effort,
+    controls: request.input.flatMap((item, index) =>
+      isConfigurationUpdate(item) ? [{ index, item }] : [],
+    ),
+    inputLength: request.input.length,
+    outputLength: output.length,
+    prefixHash: responsesContinuationPrefixFingerprint(request.input, output),
+    requestHash: responsesContinuationRequestFingerprint(request),
+  };
+  Object.assign(message, { openclawResponsesInputReplay: { ...inputReplay(message), reasoning } });
+}
+
+/** A cold transport can replay controls, but cannot resurrect a server response handle. */
+export function restoreResponsesReasoningState(
+  context: Context,
+  model: Model,
+  identity: ReplayIdentity | undefined,
+  request: ResponsesContinuationRequest,
+): ResponsesContinuationRequest {
+  const latest = context.messages.findLast((message) => message.role === "assistant");
+  const state = latest ? inputReplay(latest)?.reasoning : undefined;
+  if (!isRecord(state)) {
+    return request;
+  }
+  const { effort, inputLength, outputLength, controls, prefixHash, requestHash } = state;
+  if (
+    !isOpenAIResponsesReplayContext(state) ||
+    !providerReplayContextMatches(state, buildProviderReplayContext(model, identity)) ||
+    latest?.providerReplay ||
+    !supportsResponsesReasoningUpdate(request) ||
+    !isRecord(request.reasoning) ||
+    !request.input ||
+    request.previous_response_id ||
+    request.input.some(isConfigurationUpdate) ||
+    typeof effort !== "string" ||
+    typeof inputLength !== "number" ||
+    !Number.isSafeInteger(inputLength) ||
+    inputLength < 0 ||
+    typeof outputLength !== "number" ||
+    !Number.isSafeInteger(outputLength) ||
+    outputLength < 0 ||
+    !Array.isArray(controls) ||
+    controls.length > inputLength ||
+    inputLength + outputLength > request.input.length + controls.length
+  ) {
+    return request;
+  }
+  const previousInput = request.input.slice(0, inputLength - controls.length);
+  let lastIndex = -1;
+  for (const control of controls) {
+    if (
+      !isRecord(control) ||
+      typeof control.index !== "number" ||
+      !Number.isSafeInteger(control.index) ||
+      control.index <= lastIndex ||
+      control.index > previousInput.length ||
+      !isConfigurationUpdate(control.item)
+    ) {
+      return request;
+    }
+    previousInput.splice(control.index, 0, control.item);
+    lastIndex = control.index;
+  }
+  const previous = {
+    ...request,
+    reasoning: { ...request.reasoning, effort },
+    input: previousInput,
+  };
+  if (responsesContinuationRequestFingerprint(previous) !== requestHash) {
+    return request;
+  }
+  const prepared = replayResponsesReasoningUpdates(previous, request, outputLength);
+  if (
+    responsesContinuationPrefixFingerprint(
+      (prepared.input ?? []).slice(0, inputLength + outputLength),
+    ) !== prefixHash
+  ) {
+    return request;
+  }
+  return prepared;
+}

--- a/packages/ai/src/transports/openai-responses-reasoning-update.ts
+++ b/packages/ai/src/transports/openai-responses-reasoning-update.ts
@@ -10,7 +10,7 @@ export type ResponsesConfigurationUpdate = {
   reasoning: { effort: string };
 };
 
-function isConfigurationUpdate(value: unknown): value is ResponsesConfigurationUpdate {
+export function isConfigurationUpdate(value: unknown): value is ResponsesConfigurationUpdate {
   return (
     isRecord(value) &&
     value.type === "configuration_update" &&

--- a/packages/ai/src/transports/openai-responses-websocket.ts
+++ b/packages/ai/src/transports/openai-responses-websocket.ts
@@ -62,6 +62,7 @@ export type OpenAIResponsesWebSocketMode = "websocket" | "websocket-cached" | "a
 type OpenAIResponsesWebSocketStream = {
   stream: AsyncIterable<unknown>;
   request: ResponsesContinuationRequest;
+  fullRequest: ResponsesContinuationRequest;
   reusedConnection: boolean;
   continuationStatus: ResponsesContinuationStatus | "socket_not_cached";
   inputReplay?: ResponsesInputReplay;
@@ -345,6 +346,7 @@ function readServerEvent(
 export function createOpenAIResponsesWebSocketStream(params: {
   client: OpenAI;
   request: Record<string, unknown>;
+  restoreRequest?: (request: ResponsesContinuationRequest) => ResponsesContinuationRequest;
   mode: OpenAIResponsesWebSocketMode;
   sessionId?: string;
   headers?: Record<string, string>;
@@ -355,7 +357,7 @@ export function createOpenAIResponsesWebSocketStream(params: {
   steeringInput?: (messages: readonly UserMessage[]) => ResponseInput | Promise<ResponseInput>;
 }): OpenAIResponsesWebSocketStream {
   const connection = prepareWebSocketConnection(params.client, params.headers);
-  const fullRequest = sanitizeWebSocketRequest(params.request);
+  let fullRequest = sanitizeWebSocketRequest(params.request);
   const requestModel = typeof fullRequest.model === "string" ? fullRequest.model : "";
   const degradationKey = `${params.sessionId ?? ""}\0${connection.identity}\0${requestModel}`;
   const degraded = degradedWebSocketConnections.get(degradationKey);
@@ -397,6 +399,7 @@ export function createOpenAIResponsesWebSocketStream(params: {
       lease.entry.continuation = undefined;
       prepared = resolveResponsesContinuationRequest(continuation, fullRequest, steeringMode);
     } else {
+      fullRequest = params.restoreRequest?.(fullRequest) ?? fullRequest;
       prepared = {
         request: fullRequest,
         continuationStatus: lease.entry ? "no_previous_response" : "socket_not_cached",
@@ -663,6 +666,7 @@ export function createOpenAIResponsesWebSocketStream(params: {
   return {
     stream,
     request: prepared.request,
+    fullRequest: prepared.fullRequest ?? fullRequest,
     reusedConnection: lease.reusedConnection,
     continuationStatus: prepared.continuationStatus,
     inputReplay,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users changing reasoning effort on supported native OpenAI Responses sessions would lose the original cached request prefix after a five-minute idle gap or Gateway restart. The next request used the newly selected root effort and omitted previously admitted configuration controls.

## Why This Change Was Made

The maintainer explicitly accepts persisting Responses reasoning-update state (original effort, `configuration_update` positions, and validation hashes) inside the existing `openclawResponsesInputReplay` assistant-message replay metadata, fenced to provider/model/route/auth/session, because these facts belong to the assistant replay lineage and must survive transport cleanup; this adds no new transcript entry type or schema, and legacy messages without the `reasoning` field replay as before.

Persist the original effort, control positions, and request/prefix digests as fields on the existing assistant input-replay metadata. Cold SSE and WebSocket requests reuse the existing control-placement and history-normalization logic, fenced to provider, API, model, endpoint, session, auth profile, request settings, and retained history. Capture occurs after successful response completion.

This adds no transcript entry type, SQLite schema, configuration option, or persisted store. Socket and provider cache lifetimes are unchanged. Compaction, incompatible settings, and rewritten history reset the lineage. Older transcripts without this metadata retain the fresh-request fallback.

## User Impact

Supported reasoning-effort changes preserve their request prefix across transport cleanup and transcript reload. This preserves eligibility for provider cache reuse; it does not guarantee a cache hit after the provider expires its own cache. Updated the OpenAI provider guide and prompt-caching reference.

## Evidence

The follow-up exercises the real session transcript path: generated assistant messages are appended through `SessionManager` and the production transcript redactor into SQLite, then reopened through `buildSessionContext()` before building the next Responses request. The restored request equals the complete warm-path request, including the original effort and both configuration controls, without restoring a `previous_response_id`.

The five storage cases cover current metadata, older replay metadata without `reasoning`, messages without replay metadata, and changed model/session fences. Against the pre-fix transport code, **1 failed and 4 passed**: only the current-state reload request lost its controls and changed root effort from `low` to `medium`. Both legacy cases and both fenced cases retained their existing behavior.

Focused validation:

```text
node scripts/run-vitest.mjs \
  packages/ai/src/transports/openai-responses-client.continuation.test.ts \
  src/agents/sessions/session-manager.persistence-compat.test.ts \
  src/agents/transcript-redact.test.ts

3 files passed; 136 tests passed
```

The 38-test transport suite passed again after explicit narrowing of reloaded message roles fixed a test TypeScript error. The persistence and redaction suites were unchanged by that correction. The initial implementation also passed 192 tests across 10 Responses continuation, replay, compaction, and WebSocket suites.

- `node scripts/check-changed.mjs`: passed (exit 0; all selected gates, no exemptions), including core/test types, lint, dead-export scans, storage/schema guards, and runtime import cycles.
- `git diff --check`: passed.
- Fresh Codex autoreview of the complete PR candidate at P1: **scoped-clean, 0 accepted/actionable P0 or P1 findings**.
- Follow-up diff: one test file, **106 insertions, 0 deletions**; no production changes.

CI repair / rebase evidence (2026-09-07):

Rebased onto `origin/main` at `78cbe2999b3974143d6de8ad2256aad016d02a19` and force-with-lease pushed head `aa33fae7e46cfd7fc9f40cb0b6623781ff62775b`. The rebase was conflict-free; `git range-diff` reports both reviewed commits patch-identical. No source edits or unrelated fixes were added. `git diff --check` passes.

Fetched failed logs for [run 34107508364](https://github.com/openclaw/openclaw/actions/runs/34107508364) once. All three original failures are accounted for:

- [check-lint](https://github.com/openclaw/openclaw/actions/runs/34107508364/job/101696235667): `extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts:1119:4`, `eslint(max-lines)`, 1,012 lines against a 1,000-line limit. Confirmed on main `78cbe2999b3974143d6de8ad2256aad016d02a19` using `node scripts/run-oxlint.mjs --openclaw-focused-config extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts` (exit 1, identical diagnostic). This file is outside the PR diff and byte-identical to main (blob `981556c5cb4fcf61ec5f1752523fbedbd002905e`). Route the Telegram test split separately. The ordinary type-aware extension wrapper first hit this nested worktree's ancestor-install declaration boundary; the syntax-only wrapper mode runs the repository's unchanged max-lines rule without requiring declaration generation.
- [checks-fast-coercion-helpers](https://github.com/openclaw/openclaw/actions/runs/34107508364/job/101696235372): failed in **Checkout**, after five unsuccessful checkout attempts, exit 1. No source file, test, or coercion rule ran or failed. This is a checkout/infrastructure failure, not evidence of a coercion defect. On the rebased head, `node --import ./scripts/tsx.mjs scripts/check-coercion-helper-declarations.mts` passes (111 allowlisted declarations).
- [checks-node-compact-small-29](https://github.com/openclaw/openclaw/actions/runs/34107508364/job/101696236855): `test/scripts/ci-node-test-plan.test.ts:2109:3`, `scripts/lib/ci-node-test-plan.mts > keeps hosted tooling within the GitHub job cap when its inventory grows`, timed out after 120,000 ms. The test and planner are outside the PR diff and byte-identical to current main after rebase. `node scripts/run-vitest.mjs test/scripts/ci-node-test-plan.test.ts` passes all 53 tests against those main files; the named case takes 44,276 ms. Main includes the separate placement-assertion repair `fb90f804f48` (#141075), but this local pass does not establish why the old Linux job timed out. **Not reproduced on current main locally; do not claim a confirmed current-main timeout.** The rebased [same hosted job](https://github.com/openclaw/openclaw/actions/runs/34109565045/job/101702673317) repeats the 120,000-ms timeout at the new line `2197:3` against these current-main test bytes. Route the hosted planner timeout separately; the macOS reproduction remains green.

The rebased [CI run 34109565045](https://github.com/openclaw/openclaw/actions/runs/34109565045) also reports [checks-node-compact-small-16](https://github.com/openclaw/openclaw/actions/runs/34109565045/job/101702673268): `src/cli/update-dry-run-state.process.test.ts:186:28`, `update process state > keeps cleanup preview/refusal byte-identical (dryRun=false)`, `spawnSync node ETIMEDOUT` while invoking `openclaw.mjs update cleanup --json` after 60 seconds. The test and update CLI source are outside this PR and unchanged from main `78cbe2999b3974143d6de8ad2256aad016d02a19`. The wrapper prepared the built CLI and `node scripts/run-vitest.mjs src/cli/update-dry-run-state.process.test.ts -t 'keeps cleanup preview/refusal byte-identical'` passed both selected cases (16 intentionally unselected), with the refusal case taking 1,765 ms. **Hosted timeout not reproduced locally**; recorded for separate investigation, with no unrelated repair in this PR.

Post-rebase focused validation passed: `node scripts/run-vitest.mjs packages/ai/src/transports/openai-responses-client.continuation.test.ts src/agents/sessions/session-manager.persistence-compat.test.ts src/agents/transcript-redact.test.ts` — 3 files, 136 tests.

Final exact-head CI: [run 34109565045](https://github.com/openclaw/openclaw/actions/runs/34109565045) completed **failure** for `aa33fae7e46cfd7fc9f40cb0b6623781ff62775b`. All 93 jobs are terminal: **73 success, 16 skipped, 4 failure**. Failed jobs are `check-lint` (the confirmed current-main Telegram max-lines defect), `checks-node-compact-small-16` (cleanup child timeout), `checks-node-compact-small-29` (planner test timeout), and aggregate `openclaw/ci-gate`. `checks-fast-coercion-helpers` passed. The ordinary rollup watcher exited 15 at the first lint failure; the subsequent bounded `--completion ci-run` watch followed the same run to completion and also exited 15. Both hosted timeout files are unchanged from main and pass the documented local probes; neither is claimed as a locally reproduced current-main failure. No CI failures were concealed, retried, or repaired by modifying unrelated files.

Synthetic SDK wire captures and real temporary SQLite transcripts were used; no live provider billing or Gateway was exercised. No prepare-run or merge-run was performed.
