### PR TITLE
fix(tui): preserve drafts after picker selections

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -432,6 +432,36 @@ describe("tui command handlers", () => {
   });
 
   it.each([
+    { command: "/models", value: "fixture/model" },
+    { command: "/sessions", value: "agent:main:other" },
+    { command: "/agents", value: "other" },
+  ])(
+    "consumes $command selection before its asynchronous action finishes",
+    async ({ command, value }) => {
+      const pending = createDeferred();
+      const action = vi.fn(() => pending.promise);
+      const harness = createHarness({
+        listModels: vi.fn().mockResolvedValue([{ provider: "fixture", id: "model" }]),
+        listSessions: vi.fn().mockResolvedValue({ sessions: [{ key: "agent:main:other" }] }),
+        agents: [{ id: "main" }, { id: "other" }],
+        patchSession: action,
+        setSession: action,
+      });
+      await harness.handleCommand(command);
+      const selector = firstMockArg(harness.openOverlay, "openOverlay") as SelectableOverlay;
+
+      selector.onSelect?.({ value });
+      expect(harness.closeOverlay).toHaveBeenCalledExactlyOnceWith(harness.overlayHandle);
+      selector.onSelect?.({ value });
+      expect(action).toHaveBeenCalledOnce();
+
+      pending.resolve();
+      await flushAsyncSelect();
+      expect(harness.closeOverlay).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([
     {
       name: "model",
       command: "/models",

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -311,19 +311,22 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   ) => {
     const { isCurrent } = captureSessionIncarnation();
     selector.onSelect = (item) => {
+      if (pickerRequest !== request) {
+        return;
+      }
+      // Close on first selection so a slow backend cannot leave the picker consuming draft input.
+      closeOverlayAndRender(overlayHandle);
       void (async () => {
         try {
           if (isCurrent()) {
             await onSelect(item.value);
           }
         } catch (err) {
-          // A rejected selection must not strand the overlay open with an
-          // unhandled rejection; close it and surface the cause in chat.
           if (isCurrent()) {
             chatLog.addSystem(`selection failed: ${formatTuiErrorMessage(err)}`);
           }
         }
-        closeOverlayAndRender(overlayHandle);
+        tui.requestRender();
       })();
     };
     selector.onCancel = () => closeOverlayAndRender(overlayHandle);

--- a/src/tui/tui-picker-cancel-pty.e2e.test.ts
+++ b/src/tui/tui-picker-cancel-pty.e2e.test.ts
@@ -1,6 +1,10 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { expect, it } from "vitest";
 import {
   objectFieldEquals,
+  readFixtureLog,
   startTuiFixture,
   waitForSynchronizedFrameRows,
 } from "./tui-pty-harness-fixture-test-support.js";
@@ -11,6 +15,50 @@ const cancelKeys = [
   { key: "\x1b[99;5u", name: "Kitty Ctrl+C" },
   { key: "\x1b[27;5;99~", name: "modifyOtherKeys Ctrl+C" },
 ];
+
+it("returns to the editor as soon as a model is selected, before the update finishes", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "openclaw-picker-selection-"));
+  const releasePath = path.join(directory, "release-patch");
+  const fixture = await startTuiFixture({
+    env: {
+      TERM_PROGRAM: "vscode",
+      OPENCLAW_TUI_PTY_PICKER_FIXTURE: "1",
+      OPENCLAW_TUI_PTY_PATCH_RELEASE_PATH: releasePath,
+      OPENCLAW_TUI_PTY_COLS: "100",
+      OPENCLAW_TUI_PTY_ROWS: "30",
+    },
+  });
+  const waitForRows = (predicate: Parameters<typeof waitForSynchronizedFrameRows>[1]) =>
+    waitForSynchronizedFrameRows(fixture.run, predicate, 20_000);
+  try {
+    await fixture.run.waitForOutput("local ready", 20_000);
+    await fixture.run.write("/models\r", { delay: false });
+    await waitForRows((rows) => rows.some((row) => row.includes("Fixture 2")));
+    await fixture.run.write("\x1b[B\r", { delay: false });
+    await fixture.waitForLogEntry((entry) => entry.method === "patchSession");
+
+    const message = "draft after model selection";
+    await fixture.run.write("\r" + message, { delay: false });
+    const rows = await waitForRows((frame) => frame.some((row) => row.includes(message)));
+    const patches = (await readFixtureLog(fixture.logPath)).filter(
+      (entry) => entry.method === "patchSession",
+    );
+    console.log("[picker-selection-frame] " + JSON.stringify({ rows, patches }));
+    expect(patches).toHaveLength(1);
+    expect(rows.some((row) => row.trimStart().startsWith("search:"))).toBe(false);
+
+    await writeFile(releasePath, "release");
+    await fixture.run.waitForOutput("model set to fixture-provider/fixture-model-2", 20_000);
+    await fixture.run.write("\r", { delay: false });
+    await fixture.waitForLogEntry(
+      (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", message),
+    );
+    await waitForRows((frame) => frame.some((row) => row.includes("PTY_RESPONSE: " + message)));
+  } finally {
+    await fixture.cleanup();
+    await rm(directory, { recursive: true, force: true });
+  }
+}, 30_000);
 
 it.each(
   ["/models", "/sessions"].flatMap((command) =>

--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -541,6 +541,10 @@ export async function writeTuiPtyFixtureScript(dir: string) {
 
         async patchSession(opts: Parameters<TuiBackend["patchSession"]>[0]) {
           record("patchSession", opts);
+          const releasePath = process.env.OPENCLAW_TUI_PTY_PATCH_RELEASE_PATH;
+          while (releasePath && !existsSync(releasePath)) {
+            await new Promise((resolve) => setTimeout(resolve, 5));
+          }
           if (opts.model) {
             currentModel = opts.model;
           }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users choosing a model in the TUI could submit the same selection twice or lose their next draft when the backend update was slow. The picker stayed focused: repeated Enter sent another model update, and subsequent typing went into its search filter.

## Why This Change Was Made

Consume the existing picker request and close its exact overlay when an item is selected, before awaiting the backend. Model, agent, session, and context pickers share this owner. Existing session-incarnation checks and asynchronous error rendering remain; Settings continues to support multiple changes while open.

## User Impact

Users can start composing their next message immediately after choosing an item. Repeated Enter cannot resubmit the consumed selection, and delayed completion cannot close a newer picker.

## Evidence

The new regression failed on the original owner: repeated Enter caused two model updates and the next draft appeared in search. It passes with this change: one update, draft retained in the editor and subsequently sent.

- 304 focused command-handler, overlay, searchable-selector, and filterable-selector tests passed.
- The complete picker PTY file passed **9/9** on Linux x86_64, Node 24.19.0 and pnpm 12.3.4, in 18.31 seconds with original assertions/timeouts. The candidate and wrapper exited 0; the task-owned Blacksmith Testbox was stopped. [Testbox workflow run](https://github.com/openclaw/openclaw/actions/runs/34085243612).
- The canonical plugins-platform test type graph, full-file lint/format, and independent P0–P2 review passed.

The Linux source capsule verified base `9098b23255ab11743a5e9030d1291710e9e5679b` and candidate tree `4d03c2225592fcd46658700e3881033edc50b582`; all four reviewed file hashes match commit `62996a81145582d3011ae41ef641307b9fa617e9`. All four base files remain identical on captured main `58ad5780b53c2f793aef8641ba27f4095aacc717`. This is real TUI/native PTY proof with a synthetic backend, not live Gateway or provider validation.

Earlier macOS runs hit three startup/exit deadlines in existing cancellation cases. Their cause remains unestablished; all nine tests subsequently passed in the clean Linux run. Production change is +3 lines; tests and fixture support add 82 lines.

These inspected visuals faithfully render the captured PTY text rows with simplified styling; they are not desktop screenshots.

Before: the next draft is trapped in the old picker filter.

![Before: draft remains in the model picker search](https://github.com/user-attachments/assets/572d5da0-874d-4cbb-85b7-371a5690707e)

After: the next draft belongs to the editor while the backend update is still pending.

![After: draft remains in the editor](https://github.com/user-attachments/assets/ddef2717-0002-4cc7-be67-0df37e16f2b3)
