### PR TITLE
fix: keep Codex operation timeouts stable during clock corrections

### DIFF
--- a/extensions/codex/media-understanding-provider.test.ts
+++ b/extensions/codex/media-understanding-provider.test.ts
@@ -524,7 +524,7 @@ describe("codex media understanding provider", () => {
   it("clamps oversized image understanding turn timeouts", async () => {
     // The bounded timer subtracts startup time from its clamped deadline.
     // Freeze the clock so the clamp assertion cannot lose a real millisecond.
-    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const clockSpy = vi.spyOn(performance, "now").mockReturnValue(1_000);
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
       const { client } = createFakeClient();
@@ -546,7 +546,7 @@ describe("codex media understanding provider", () => {
       expect(result?.text).toBe("A red square.");
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
     } finally {
-      dateNowSpy.mockRestore();
+      clockSpy.mockRestore();
       vi.restoreAllMocks();
       vi.clearAllTimers();
       vi.useRealTimers();

--- a/extensions/codex/src/app-server/bounded-turn.clock.test.ts
+++ b/extensions/codex/src/app-server/bounded-turn.clock.test.ts
@@ -18,7 +18,12 @@ describe("bounded Codex turn elapsed deadlines over WebSocket", () => {
       const turn = turnStartResult("clock-turn");
       server.on("connection", (socket) => {
         socket.on("message", (data) => {
-          const request = JSON.parse(data.toString()) as RpcRequest;
+          const buffer = Array.isArray(data)
+            ? Buffer.concat(data)
+            : Buffer.isBuffer(data)
+              ? data
+              : Buffer.from(data);
+          const request = JSON.parse(buffer.toString("utf8")) as RpcRequest;
           methods.push(request.method);
           const respond = (result: unknown) => {
             socket.send(JSON.stringify({ id: request.id, result }));

--- a/extensions/codex/src/app-server/bounded-turn.clock.test.ts
+++ b/extensions/codex/src/app-server/bounded-turn.clock.test.ts
@@ -1,0 +1,178 @@
+import { once } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
+import { runBoundedCodexAppServerTurn } from "./bounded-turn.js";
+import { CodexAppServerClient } from "./client.js";
+import { threadStartResult, turnStartResult } from "./codex-app-server.test-fixtures.js";
+import type { RpcRequest } from "./protocol.js";
+import { CODEX_APP_SERVER_VERSION } from "./version.js";
+
+describe("bounded Codex turn elapsed deadlines over WebSocket", () => {
+  it.each([0, 60_000, -60_000])(
+    "keeps its real timeout after a %s ms startup clock correction",
+    async (clockStepMs) => {
+      // Only the protocol peer is controlled: client, socket, and timers are real.
+      const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+      const methods: string[] = [];
+      const thread = threadStartResult("clock-thread", process.cwd());
+      const turn = turnStartResult("clock-turn");
+      server.on("connection", (socket) => {
+        socket.on("message", (data) => {
+          const request = JSON.parse(data.toString()) as RpcRequest;
+          methods.push(request.method);
+          const respond = (result: unknown) => {
+            socket.send(JSON.stringify({ id: request.id, result }));
+          };
+          switch (request.method) {
+            case "initialize":
+              respond({ userAgent: `codex/${CODEX_APP_SERVER_VERSION}` });
+              break;
+            case "initialized":
+              break;
+            case "model/list":
+              respond({
+                data: [
+                  {
+                    id: thread.model,
+                    model: thread.model,
+                    upgrade: null,
+                    upgradeInfo: null,
+                    availabilityNux: null,
+                    displayName: "Clock proof model",
+                    description: "Controlled protocol fixture; no provider calls",
+                    hidden: false,
+                    isDefault: true,
+                    inputModalities: ["text"],
+                    supportedReasoningEfforts: [{ reasoningEffort: "low", description: "Low" }],
+                    defaultReasoningEffort: "low",
+                    supportsPersonality: false,
+                    multiAgentVersion: null,
+                    additionalSpeedTiers: [],
+                    serviceTiers: [],
+                    defaultServiceTier: null,
+                  },
+                ],
+                nextCursor: null,
+              });
+              break;
+            case "thread/start":
+              respond(thread);
+              break;
+            case "turn/start":
+              respond(turn);
+              break;
+            case "turn/interrupt":
+              respond({});
+              socket.send(
+                JSON.stringify({
+                  method: "turn/completed",
+                  params: {
+                    threadId: thread.thread.id,
+                    ...turnStartResult(turn.turn.id, "interrupted"),
+                  },
+                }),
+              );
+              break;
+            default:
+              socket.send(
+                JSON.stringify({
+                  id: request.id,
+                  error: { code: -32601, message: `Unexpected method: ${request.method}` },
+                }),
+              );
+          }
+        });
+      });
+
+      const realDateNow = Date.now;
+      const wallClock = vi.spyOn(Date, "now");
+      const caller = new AbortController();
+      let client: CodexAppServerClient | undefined;
+      let initialized = false;
+      let run: Promise<unknown> | undefined;
+      let watchdog: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await once(server, "listening");
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("expected a loopback WebSocket port");
+        }
+        const startedAt = performance.now();
+        // Bound the old backward-clock bug without simulating its expiry.
+        watchdog = setTimeout(() => {
+          caller.abort(new Error("clock proof watchdog"));
+          if (!initialized) {
+            client?.close();
+          }
+        }, 4_000);
+        run = runBoundedCodexAppServerTurn({
+          model: { mode: "required", id: thread.model },
+          timeoutMs: 1_000,
+          signal: caller.signal,
+          options: {
+            clientFactory: async () => {
+              client = await CodexAppServerClient.start({
+                transport: "websocket",
+                url: `ws://127.0.0.1:${address.port}`,
+                headers: {},
+                authToken: undefined,
+              });
+              await client.initialize();
+              initialized = true;
+              // Apply one process-local offset after startup, never an OS clock change.
+              wallClock.mockImplementation(() => realDateNow() + clockStepMs);
+              return client;
+            },
+          },
+          taskLabel: "clock proof",
+          developerInstructions: "Wait for cancellation.",
+          input: [{ type: "text", text: "Clock proof.", text_elements: [] }],
+          requiredModalities: ["text"],
+          isolation: "configured-transport",
+        }).catch((error: unknown) => error);
+        const outcome = await run;
+        const elapsedMs = performance.now() - startedAt;
+        console.info("bounded-turn-clock", {
+          clockStepMs,
+          elapsedMs: Math.round(elapsedMs),
+          outcome: outcome instanceof Error ? outcome.name : "completed",
+          watchdogAborted: caller.signal.aborted,
+          methods,
+        });
+        expect(methods).toEqual([
+          "initialize",
+          "initialized",
+          "model/list",
+          "thread/start",
+          "turn/start",
+          "turn/interrupt",
+        ]);
+        expect(outcome).toMatchObject({
+          name: "TimeoutError",
+          message: "codex app-server clock proof turn timed out after 1s",
+        });
+        expect(caller.signal.aborted).toBe(false);
+        expect(elapsedMs).toBeGreaterThanOrEqual(900);
+        expect(elapsedMs).toBeLessThan(4_000);
+      } finally {
+        clearTimeout(watchdog);
+        wallClock.mockRestore();
+        caller.abort();
+        await run;
+        await client?.closeAndWait();
+        await Promise.all(
+          [...server.clients].map((socket) => {
+            const closed = once(socket, "close");
+            socket.terminate();
+            return closed;
+          }),
+        );
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+        expect(server.clients.size).toBe(0);
+        expect(server.address()).toBeNull();
+      }
+    },
+  );
+});

--- a/extensions/codex/src/app-server/bounded-turn.test.ts
+++ b/extensions/codex/src/app-server/bounded-turn.test.ts
@@ -511,6 +511,58 @@ describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
     await expect(run).resolves.toMatchObject({ text: "The message was sent successfully." });
   });
 
+  it.each([60_000, -60_000])(
+    "keeps its elapsed timeout when the system clock moves by %s ms during startup",
+    async (clockStepMs) => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
+      const wallClock = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+      const caller = new AbortController();
+      const fake = createClientFactory({ completeTurn: false });
+      let outcome: unknown;
+      const run = runBoundedCodexAppServerTurn({
+        model: { mode: "required", id: "gpt-5.4" },
+        timeoutMs: 1_000,
+        signal: caller.signal,
+        options: {
+          clientFactory: async (options) => {
+            wallClock.mockReturnValue(1_700_000_000_000 + clockStepMs);
+            return fake.factory(options);
+          },
+        },
+        taskLabel: "hosted search",
+        developerInstructions: "Search only.",
+        input: [{ type: "text", text: "Find current market news.", text_elements: [] }],
+        requiredModalities: ["text"],
+        isolation: "configured-transport",
+      }).then(
+        (value) => {
+          outcome = value;
+        },
+        (error) => {
+          outcome = error;
+        },
+      );
+      try {
+        await vi.waitFor(() => {
+          expect(fake.methods.includes("turn/start") || outcome !== undefined).toBe(true);
+        });
+        // A clock correction is not elapsed execution time.
+        expect(outcome).toBeUndefined();
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(outcome).toMatchObject({
+          name: "TimeoutError",
+          message: "codex app-server hosted search turn timed out after 1s",
+        });
+      } finally {
+        caller.abort();
+        await vi.advanceTimersByTimeAsync(2_000);
+        await run;
+        wallClock.mockRestore();
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it("reports its own timeout with the configured bound", async () => {
     const fake = createClientFactory({ completeTurn: false });
 

--- a/extensions/codex/src/app-server/bounded-turn.test.ts
+++ b/extensions/codex/src/app-server/bounded-turn.test.ts
@@ -511,58 +511,6 @@ describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
     await expect(run).resolves.toMatchObject({ text: "The message was sent successfully." });
   });
 
-  it.each([60_000, -60_000])(
-    "keeps its elapsed timeout when the system clock moves by %s ms during startup",
-    async (clockStepMs) => {
-      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
-      const wallClock = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
-      const caller = new AbortController();
-      const fake = createClientFactory({ completeTurn: false });
-      let outcome: unknown;
-      const run = runBoundedCodexAppServerTurn({
-        model: { mode: "required", id: "gpt-5.4" },
-        timeoutMs: 1_000,
-        signal: caller.signal,
-        options: {
-          clientFactory: async (options) => {
-            wallClock.mockReturnValue(1_700_000_000_000 + clockStepMs);
-            return fake.factory(options);
-          },
-        },
-        taskLabel: "hosted search",
-        developerInstructions: "Search only.",
-        input: [{ type: "text", text: "Find current market news.", text_elements: [] }],
-        requiredModalities: ["text"],
-        isolation: "configured-transport",
-      }).then(
-        (value) => {
-          outcome = value;
-        },
-        (error) => {
-          outcome = error;
-        },
-      );
-      try {
-        await vi.waitFor(() => {
-          expect(fake.methods.includes("turn/start") || outcome !== undefined).toBe(true);
-        });
-        // A clock correction is not elapsed execution time.
-        expect(outcome).toBeUndefined();
-        await vi.advanceTimersByTimeAsync(1_000);
-        expect(outcome).toMatchObject({
-          name: "TimeoutError",
-          message: "codex app-server hosted search turn timed out after 1s",
-        });
-      } finally {
-        caller.abort();
-        await vi.advanceTimersByTimeAsync(2_000);
-        await run;
-        wallClock.mockRestore();
-        vi.useRealTimers();
-      }
-    },
-  );
-
   it("reports its own timeout with the configured bound", async () => {
     const fake = createClientFactory({ completeTurn: false });
 

--- a/extensions/codex/src/app-server/bounded-turn.ts
+++ b/extensions/codex/src/app-server/bounded-turn.ts
@@ -154,8 +154,9 @@ async function runBoundedCodexAppServerTurnInWorkspace(
 ): Promise<CodexBoundedTurnResult> {
   const totalTimeoutMs = timing?.timeoutMs ?? resolveTimerTimeoutMs(params.timeoutMs, 100, 100);
   const timeoutError = new CodexBoundedTurnTimeoutError(params.taskLabel, totalTimeoutMs);
-  const deadline = timing?.deadline ?? Date.now() + totalTimeoutMs;
-  const timeoutMs = deadline - Date.now();
+  // Startup and selection retries share an elapsed budget, not a wall-clock deadline.
+  const deadline = timing?.deadline ?? performance.now() + totalTimeoutMs;
+  const timeoutMs = deadline - performance.now();
   if (timeoutMs <= 0) {
     throw timeoutError;
   }
@@ -215,7 +216,7 @@ async function runBoundedCodexAppServerTurnInWorkspace(
   } else {
     params.signal?.addEventListener("abort", abortFromCaller, { once: true });
   }
-  const remainingRunMs = deadline - Date.now();
+  const remainingRunMs = deadline - performance.now();
   if (remainingRunMs <= 0) {
     abortRun(timeoutError);
   }


### PR DESCRIPTION
Closes #141000.

## What Problem This Solves

Fixes an issue where bounded Codex operations could time out early or run too long when the wall clock changed during client startup.

## Why This Change Was Made

Use one monotonic deadline for the private execution budget, including client startup and the permitted selection retry. Public timestamps, native protocol fields, cancellation, and cleanup keep their existing contracts.

## User Impact

Codex search, image understanding, isolated completion, and finalization retain their configured elapsed-time budget across clock corrections.

## Evidence

Independent acceptance drove a real Gateway image request through the production WebSocket client and a controlled protocol peer. The image budget was 1000 ms; initialization consumed 300 ms. Only the Gateway process's wall-clock reads were shifted; system time stayed unchanged.

| Clock correction | Baseline interrupt | Repaired interrupt |
| --- | ---: | ---: |
| None | 1004 ms | 1002 ms |
| +500 ms | 503 ms | 1001 ms |
| -500 ms | 1501 ms | 1000 ms |

- Each timed-out turn received one matching interrupt, terminal confirmation, and clean socket closure.
- Independent completion, native failure, unavailable-model, startup-rejection, and public `chat.abort` controls passed. Cancellation interrupted the active image turn 15 ms after the abort request.
- 93 focused tests passed across the bounded owner, media provider, web search, isolated completion, and finalization. Four regression cases failed on pinned main for the intended early/late deadline causes, then passed with the fix.
- Pinned formatting, ordinary lint, size/assertion checks, and extension import checks passed. Full type-aware checks and required CI run on the updated head.

Baseline: `4ed6af1ea45fa904269791cf5630151f1014edf0`. Tested candidate: `554ee55984089339df1444fd379eba2a2b3ee44b`. The contributor's three commits are preserved. Protocol responses were synthetic; this proof did not use a paid external provider or a real app-server executable.
