### PR TITLE
fix(agents): keep idle-timed-out settled turns failed when summary recovery is empty

### DIFF
--- a/src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test-support.ts
@@ -151,4 +151,87 @@ describe("runEmbeddedAgent prompt timeout fallback handoff", () => {
     });
     expect(mockedGetApiKeyForModel).toHaveBeenCalledTimes(1);
   });
+
+  it("reports the idle timeout when settled-write finalization produces no answer", async () => {
+    const toolUseAssistant = {
+      role: "assistant" as const,
+      stopReason: "toolUse" as const,
+      provider: "openai",
+      model: "gpt-5.4",
+      content: [
+        {
+          type: "toolCall",
+          id: "tool_write",
+          name: "write",
+          arguments: { path: "note.txt", content: "done" },
+        },
+      ],
+    };
+    const abortedAssistant = {
+      role: "assistant" as const,
+      stopReason: "aborted" as const,
+      provider: "openai",
+      model: "gpt-5.4",
+      content: [],
+    };
+    const emptyAssistant = {
+      role: "assistant" as const,
+      stopReason: "stop" as const,
+      provider: "openai",
+      model: "gpt-5.4",
+      content: [],
+    };
+    mockedClassifyFailoverReason.mockReturnValue("timeout");
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          assistantTexts: [],
+          terminal: { kind: "timeout", phase: "prompt", source: "idle" },
+          toolMetas: [{ toolName: "write", replaySafe: false }],
+          itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+          messagesSnapshot: [
+            { role: "user", content: [{ type: "text", text: "Write note.txt" }] },
+            toolUseAssistant,
+            {
+              role: "toolResult",
+              toolCallId: "tool_write",
+              toolName: "write",
+              isError: false,
+            },
+            abortedAssistant,
+          ] as never,
+          lastAssistant: abortedAssistant as never,
+          currentAttemptAssistant: abortedAssistant as never,
+          currentAttemptReplayMetadata: {
+            hadPotentialSideEffects: true,
+            replaySafe: false,
+          },
+        }),
+      )
+      .mockResolvedValue(
+        makeAttemptResult({
+          assistantTexts: [],
+          lastAssistant: emptyAssistant as never,
+          currentAttemptAssistant: emptyAssistant as never,
+          currentAttemptCompletedAssistant: emptyAssistant as never,
+        }),
+      );
+
+    const result = await runEmbeddedAgent({
+      ...createOverflowRunParams(state),
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "run-post-tool-idle-finalization-empty",
+      config: createModelFallbackConfig("openai/gpt-5.4", ["anthropic/claude-opus-4-6"]),
+    });
+
+    // Initial attempt plus both tool-free finalization attempts; no replay, no fallback model.
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
+    expect(result.meta.executionTrace?.fallbackUsed).not.toBe(true);
+    expect(result.meta.error).toMatchObject({ kind: "incomplete_turn" });
+    expect(result.payloads).toEqual([
+      { text: expect.stringContaining("model idle timeout"), isError: true },
+    ]);
+    expect(JSON.stringify(result.payloads)).not.toContain("no final summary was produced");
+  });
 });

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.timeout.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  prepareSystemAgentRunAdmission,
+  type AdmittedRunContext,
+} from "../../admitted-run-context.js";
+import {
+  buildEmbeddedRunnerAssistant,
+  makeEmbeddedRunnerAttempt,
+} from "../../test-helpers/embedded-agent-runner-e2e-fixtures.js";
+import type { EmbeddedRunAttemptWithReceiptEvidence } from "./attempt-result.js";
+import { prepareTerminalWithSettledTurnFinalization } from "./settled-turn-finalization.js";
+import { createSettledFinalizationTestInput } from "./settled-turn-finalization.test-support.js";
+import { isEmbeddedRunTerminalTimeout } from "./terminal-outcome.js";
+
+const backendMocks = vi.hoisted(() => ({
+  runSettledFinalization: vi.fn(),
+  resolveRuntimeModelAttempt: vi.fn(() => undefined),
+}));
+const transcriptMocks = vi.hoisted(() => ({
+  appendAssistantMirrorMessageByIdentity: vi.fn(),
+}));
+
+const SETTLED_TOOL_FINALIZATION_FALLBACK_TEXT =
+  "The tool run finished, but no final summary was produced. I did not repeat any completed actions.";
+
+vi.mock("./backend.js", () => ({
+  resolveRuntimeModelAttempt: backendMocks.resolveRuntimeModelAttempt,
+  runEmbeddedSettledTurnFinalizationWithBackend: backendMocks.runSettledFinalization,
+}));
+vi.mock("../../../plugin-sdk/session-transcript-runtime.js", () => ({
+  appendAssistantMirrorMessageByIdentity: transcriptMocks.appendAssistantMirrorMessageByIdentity,
+}));
+
+/** A settled successful tool batch whose post-tool model stream hit the idle watchdog. */
+function settledIdleTimeoutAttempt(): EmbeddedRunAttemptWithReceiptEvidence {
+  const assistant = buildEmbeddedRunnerAssistant({
+    stopReason: "toolUse",
+    content: [{ type: "toolCall", id: "tool-write", name: "write", arguments: {} }],
+  });
+  const messagesSnapshot = [
+    assistant,
+    { role: "toolResult", toolCallId: "tool-write", toolName: "write", isError: false },
+  ] as never;
+  return {
+    ...makeEmbeddedRunnerAttempt({
+      terminal: { kind: "timeout", phase: "prompt", source: "idle" },
+      sessionIdUsed: "session-settled",
+      sessionFileUsed: "/tmp/session-settled.jsonl",
+      assistantTexts: [],
+      toolMetas: [{ toolName: "write", isError: false, replaySafe: false }],
+      itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+      messagesSnapshot,
+      lastAssistant: assistant,
+      currentAttemptAssistant: assistant,
+      currentAttemptReplayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+      replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+      settledTurnFinalizationContext: { source: "openclaw-transcript", messages: messagesSnapshot },
+      assistantTurns: 1,
+    }),
+    successfulNestedToolNames: [],
+  };
+}
+
+let admittedRunContext: AdmittedRunContext;
+
+describe("prepareTerminalWithSettledTurnFinalization after an idle prompt timeout", () => {
+  let admission: ReturnType<typeof prepareSystemAgentRunAdmission>;
+  beforeEach(async () => {
+    backendMocks.runSettledFinalization.mockReset();
+    transcriptMocks.appendAssistantMirrorMessageByIdentity.mockReset();
+    admission = prepareSystemAgentRunAdmission({}, "run-settled", "main", "finalization-test");
+    admittedRunContext = await admission.admit("embedded");
+  });
+  afterEach(() => {
+    admission.close();
+  });
+
+  it("keeps the timeout authoritative when finalization stays empty", async () => {
+    const attempt = settledIdleTimeoutAttempt();
+    const emptyAssistant = buildEmbeddedRunnerAssistant({
+      content: [{ type: "text", text: "" }],
+    });
+    backendMocks.runSettledFinalization.mockResolvedValue({
+      outcome: "empty",
+      result: { assistant: emptyAssistant, usage: emptyAssistant.usage },
+    });
+
+    const result = await prepareTerminalWithSettledTurnFinalization(
+      createSettledFinalizationTestInput(attempt, admittedRunContext),
+    );
+
+    expect(backendMocks.runSettledFinalization).toHaveBeenCalledTimes(2);
+    expect(transcriptMocks.appendAssistantMirrorMessageByIdentity).not.toHaveBeenCalled();
+    expect(result.finalizationOutcome).toBe("failed");
+    expect(result.attempt).toBe(attempt);
+    expect(isEmbeddedRunTerminalTimeout(result.terminalState.outcome)).toBe(true);
+    expect(result.prepared.timedOutDuringPrompt).toBe(true);
+    expect(result.prepared.payloadsWithToolMedia ?? []).not.toContainEqual(
+      expect.objectContaining({ text: SETTLED_TOOL_FINALIZATION_FALLBACK_TEXT }),
+    );
+  });
+
+  it("keeps the timeout authoritative when finalization fails", async () => {
+    const attempt = settledIdleTimeoutAttempt();
+    backendMocks.runSettledFinalization.mockRejectedValueOnce(new Error("finalizer failed"));
+
+    const result = await prepareTerminalWithSettledTurnFinalization(
+      createSettledFinalizationTestInput(attempt, admittedRunContext),
+    );
+
+    expect(backendMocks.runSettledFinalization).toHaveBeenCalledOnce();
+    expect(transcriptMocks.appendAssistantMirrorMessageByIdentity).not.toHaveBeenCalled();
+    expect(result.finalizationOutcome).toBe("failed");
+    expect(result.attempt).toBe(attempt);
+    expect(isEmbeddedRunTerminalTimeout(result.terminalState.outcome)).toBe(true);
+    expect(result.prepared.timedOutDuringPrompt).toBe(true);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -36,6 +36,7 @@ import {
 import { resolveSettledToolBatchEvidence } from "./incomplete-turn-recovery.js";
 import type { createEmbeddedRunLaneController } from "./lane-controller.js";
 import {
+  isEmbeddedRunTerminalTimeout,
   resolveEmbeddedRunAttemptTerminalOutcome,
   type EmbeddedRunTerminalState,
 } from "./terminal-outcome.js";
@@ -142,10 +143,15 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
 
   const runParams = input.terminalBase.runParams;
   const errorContext = input.terminalBase.activeErrorContext;
-  // A host summary cannot replace a tool failure. Keep its original warning
-  // when recovery produces no answer, including for silent helper runs.
+  // A host summary cannot replace a tool failure or an owner-recorded timeout.
+  // Keep the original outcome when recovery produces no answer, including for
+  // silent helper runs; a synthetic fallback would otherwise clear the timeout
+  // and report an aborted run as a delivered success.
+  const preserveOriginalTerminal =
+    Boolean(initial.attempt.lastToolError) ||
+    isEmbeddedRunTerminalTimeout(initial.terminalState.outcome);
   const terminalFallbackAllowed =
-    input.finalization.preparedAttempt.silentExpected !== true && !initial.attempt.lastToolError;
+    input.finalization.preparedAttempt.silentExpected !== true && !preserveOriginalTerminal;
   log.warn(
     `settled post-tool turn lacked a final answer: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
       `provider=${errorContext.provider}/${errorContext.model} — running isolated finalization`,
@@ -256,9 +262,9 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       transcriptIdempotencyKey,
     });
   }
-  // Only an actual recovery replaces a failed tool turn's terminal ownership.
+  // Only an actual recovery replaces a failed or timed-out turn's terminal ownership.
   const completion =
-    finalizationOutcome !== "answered" && initial.attempt.lastToolError
+    finalizationOutcome !== "answered" && preserveOriginalTerminal
       ? initial
       : {
           attempt,

--- a/test/e2e/qa-lab/runtime/gateway-cron-idle-timeout-finalization.product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-cron-idle-timeout-finalization.product-proof.e2e.test.ts
@@ -1,0 +1,518 @@
+import fs from "node:fs/promises";
+import { createServer, type ServerResponse } from "node:http";
+import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createQaBusState,
+  createQaChannelTransport,
+  createQaGatewayChild,
+  startQaBusServer,
+} from "../../../../extensions/qa-lab/api.js";
+import { writeOpenAiResponsesSse } from "../../../helpers/openai-responses-sse.js";
+import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+
+// Product proof for #141032: a scheduled run whose model stream stalls after a
+// settled tool batch must end as a failed run. Summary recovery that produces
+// no answer cannot turn the idle timeout into a successful fallback report.
+const MODEL_REF = "mock-openai/gpt-5.6-luna";
+const PROMPT = "Write proof-note.txt with the word settled, then report what you did.";
+const NOTE_FILE = "proof-note.txt";
+const JOB_NAME = "idle-timeout-finalization-proof";
+const ANNOUNCE_CONVERSATION = { id: "idle-timeout-proof-announce", kind: "direct" as const };
+const PROVIDER_IDLE_TIMEOUT_SECONDS = 8;
+const RUN_TIMEOUT_SECONDS = 120;
+const RUN_WAIT_MS = 100_000;
+// Source-mode Gateway startup with packaged plugins can take a few minutes on slow hosts.
+const TEST_TIMEOUT_MS = RUN_WAIT_MS + 500_000;
+const SETTLED_TOOL_FINALIZATION_FALLBACK_TEXT =
+  "The tool run finished, but no final summary was produced. I did not repeat any completed actions.";
+// Optional Control UI capture of the Automations run history for the proof record.
+const SCREENSHOT_DIR = process.env.OPENCLAW_CRON_IDLE_TIMEOUT_FINALIZATION_SCREENSHOT_DIR?.trim();
+const PROOF_LABEL = process.env.OPENCLAW_PROOF_HEAD_SHA?.trim() || "local-checkout";
+// Optional built CLI entry (for example dist/entry.js) to run instead of the tsx source entry.
+const GATEWAY_ENTRY = process.env.OPENCLAW_CRON_IDLE_TIMEOUT_FINALIZATION_GATEWAY_ENTRY?.trim();
+
+type ProviderRequest = {
+  seq: number;
+  kind: "tool-call" | "stalled" | "finalization";
+  startedAt: number;
+  clientClosedAt?: number;
+};
+
+type CronRunEntry = {
+  status?: unknown;
+  completionStatus?: unknown;
+  error?: unknown;
+  summary?: unknown;
+  delivered?: unknown;
+  deliveryStatus?: unknown;
+  runId?: unknown;
+  durationMs?: unknown;
+};
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  const errors: unknown[] = [];
+  for (const cleanup of cleanups.splice(0).toReversed()) {
+    try {
+      await cleanup();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "cron idle-timeout finalization proof cleanup failed");
+  }
+});
+
+function writeFunctionCall(response: ServerResponse, seq: number): void {
+  const args = JSON.stringify({ path: NOTE_FILE, content: "settled" });
+  const item = {
+    type: "function_call",
+    id: `fc_idle_timeout_proof_${seq}`,
+    call_id: `call_idle_timeout_proof_${seq}`,
+    name: "write",
+    arguments: args,
+  };
+  writeOpenAiResponsesSse(response, [
+    { type: "response.output_item.added", output_index: 0, item: { ...item, arguments: "" } },
+    {
+      type: "response.function_call_arguments.delta",
+      item_id: item.id,
+      output_index: 0,
+      delta: args,
+    },
+    {
+      type: "response.function_call_arguments.done",
+      item_id: item.id,
+      output_index: 0,
+      name: item.name,
+      arguments: args,
+    },
+    { type: "response.output_item.done", output_index: 0, item },
+    {
+      type: "response.completed",
+      response: {
+        id: `resp_idle_timeout_proof_${seq}`,
+        status: "completed",
+        output: [item],
+        usage: { input_tokens: 32, output_tokens: 12, total_tokens: 44 },
+      },
+    },
+  ]);
+}
+
+function writeEmptyAssistant(response: ServerResponse, seq: number): void {
+  // Summary recovery answers with a completed message that carries no text.
+  const message = {
+    type: "message",
+    id: `msg_idle_timeout_proof_empty_${seq}`,
+    role: "assistant",
+    status: "completed",
+    content: [],
+  };
+  writeOpenAiResponsesSse(response, [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...message, status: "in_progress" },
+    },
+    { type: "response.output_item.done", output_index: 0, item: message },
+    {
+      type: "response.completed",
+      response: {
+        id: `resp_idle_timeout_proof_empty_${seq}`,
+        status: "completed",
+        output: [message],
+        usage: { input_tokens: 8, output_tokens: 0, total_tokens: 8 },
+      },
+    },
+  ]);
+}
+
+async function startControlledProvider() {
+  const requests: ProviderRequest[] = [];
+  let releaseStalled: (() => void) | undefined;
+  const stalledGate = new Promise<void>((resolve) => {
+    releaseStalled = resolve;
+  });
+  const server = createServer((request, response) => {
+    void (async () => {
+      if (request.method === "GET" && request.url === "/v1/models") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ data: [{ id: "gpt-5.6-luna", object: "model" }] }));
+        return;
+      }
+      if (request.method !== "POST" || request.url !== "/v1/responses") {
+        response.writeHead(404).end();
+        return;
+      }
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.from(chunk));
+      }
+      const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+        tools?: unknown[];
+        input?: unknown;
+      };
+      const toolsOffered = Array.isArray(body.tools) && body.tools.length > 0;
+      const inputText = JSON.stringify(body.input ?? []);
+      const seq = requests.length + 1;
+      if (!toolsOffered) {
+        // Isolated settled-turn finalization runs with tools disabled.
+        requests.push({ seq, kind: "finalization", startedAt: Date.now() });
+        writeEmptyAssistant(response, seq);
+        return;
+      }
+      if (!inputText.includes("function_call_output")) {
+        requests.push({ seq, kind: "tool-call", startedAt: Date.now() });
+        writeFunctionCall(response, seq);
+        return;
+      }
+      // The post-tool turn: stay silent until the Gateway's idle watchdog aborts it.
+      const entry: ProviderRequest = { seq, kind: "stalled", startedAt: Date.now() };
+      requests.push(entry);
+      response.once("close", () => {
+        entry.clientClosedAt ??= Date.now();
+      });
+      await stalledGate;
+      if (!response.writableEnded) {
+        response.end();
+      }
+    })().catch((error: unknown) => {
+      if (!response.headersSent) {
+        response.writeHead(500);
+      }
+      response.end(error instanceof Error ? error.message : String(error));
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("controlled provider did not bind a loopback port");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+    stop: async () => {
+      releaseStalled?.();
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
+
+async function captureAutomationsScreenshots(params: {
+  baseUrl: string;
+  wsUrl: string;
+  token: string;
+  jobId: string;
+  jobName: string;
+  outputDir: string;
+}): Promise<string[]> {
+  const { chromium } = await import("playwright");
+  const browser = await chromium.launch();
+  const written: string[] = [];
+  try {
+    await fs.mkdir(params.outputDir, { recursive: true });
+    const viewport = { width: 1440, height: 1000 };
+    const context = await browser.newContext({
+      locale: "en-US",
+      recordVideo: { dir: params.outputDir, size: viewport },
+      viewport,
+    });
+    const page = await context.newPage();
+    // Same hook the native shells use: the page pairs with the Gateway token
+    // and a fixed client identity, so no interactive connection prompt appears.
+    await page.addInitScript(
+      (auth) => {
+        (window as Window & { ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: unknown })[
+          "__OPENCLAW_NATIVE_CONTROL_AUTH__"
+        ] = auth;
+      },
+      {
+        gatewayUrl: params.wsUrl,
+        token: params.token,
+        client: {
+          id: "openclaw-control-ui",
+          mode: "webchat",
+          platform: "linux",
+          deviceFamily: "desktop",
+          scopes: [
+            "operator.admin",
+            "operator.approvals",
+            "operator.questions",
+            "operator.read",
+            "operator.write",
+          ],
+        },
+      },
+    );
+    const capture = async (name: string) => {
+      const file = path.join(params.outputDir, `${PROOF_LABEL}-${name}.png`);
+      await page.screenshot({ path: file, fullPage: true });
+      written.push(file);
+    };
+    await page.goto(`${params.baseUrl}/automations?job=${encodeURIComponent(params.jobId)}`, {
+      waitUntil: "domcontentloaded",
+      timeout: 60_000,
+    });
+    const exitSetup = page.getByRole("button", { name: /exit setup/i });
+    if (await exitSetup.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await exitSetup.click();
+    }
+    await page
+      .getByText(params.jobName)
+      .first()
+      .waitFor({ timeout: 60_000 })
+      .catch(() => undefined);
+    await sleep(3_000);
+    await capture("automations-job");
+    // The job route opens on Settings; the run outcome lives under Run history.
+    const historyTab = page.getByRole("tab", { name: /run history/i }).first();
+    const historyText = page.getByText(/^Run history$/i).first();
+    const history = (await historyTab.isVisible().catch(() => false)) ? historyTab : historyText;
+    if (await history.isVisible().catch(() => false)) {
+      await history.click().catch(() => undefined);
+      await sleep(3_000);
+      // Run entries render status and summary inline (.cron-run-entry).
+      await page
+        .locator(".cron-run-entry")
+        .first()
+        .waitFor({ timeout: 30_000 })
+        .catch(() => undefined);
+      await sleep(1_000);
+      await capture("automations-run-history");
+    }
+    // The recording is finalized only after the context closes.
+    const video = page.video();
+    await context.close();
+    const recordedPath = await video?.path();
+    if (recordedPath) {
+      const videoFile = path.join(params.outputDir, `${PROOF_LABEL}-automations.webm`);
+      await fs.rename(recordedPath, videoFile);
+      written.push(videoFile);
+    }
+  } finally {
+    await browser.close();
+  }
+  return written;
+}
+
+describe.runIf(process.env.OPENCLAW_CRON_IDLE_TIMEOUT_FINALIZATION_PROOF === "1")(
+  "Gateway cron idle-timeout finalization product proof",
+  () => {
+    it(
+      "records a stalled post-tool run as failed instead of announcing the fallback summary",
+      { timeout: TEST_TIMEOUT_MS },
+      async () => {
+        const startedAt = Date.now();
+        let phase = "provider";
+        const heartbeat = setInterval(() => {
+          console.log(
+            JSON.stringify({
+              phase: "proof-heartbeat",
+              step: phase,
+              elapsedMs: Date.now() - startedAt,
+            }),
+          );
+        }, 20_000);
+        cleanups.push(async () => clearInterval(heartbeat));
+        const provider = await startControlledProvider();
+        cleanups.push(() => provider.stop());
+        phase = "gateway-start";
+        // The announce destination is the qa-lab bus channel, so delivered text is observable.
+        const busState = createQaBusState();
+        const transport = createQaChannelTransport(busState);
+        const bus = await startQaBusServer({ state: busState });
+        cleanups.push(() => bus.stop());
+        const gatewayOwner = createQaGatewayChild();
+        cleanups.push(() => stopQaGatewayFixture(gatewayOwner));
+        const gateway = await gatewayOwner.start({
+          repoRoot: process.cwd(),
+          // Run the Gateway from source so the proof does not depend on a dist build.
+          command: {
+            executablePath: process.execPath,
+            argsPrefix: GATEWAY_ENTRY ? [GATEWAY_ENTRY] : ["--import", "tsx", "src/entry.ts"],
+            cwd: process.cwd(),
+            usePackagedPlugins: true,
+          },
+          providerBaseUrl: `${provider.baseUrl}/v1`,
+          providerMode: "mock-openai",
+          primaryModel: MODEL_REF,
+          alternateModel: MODEL_REF,
+          transport,
+          transportBaseUrl: bus.baseUrl,
+          controlUiEnabled: Boolean(SCREENSHOT_DIR),
+          mutateConfig: (config) => {
+            const providerConfig = config.models?.providers?.["mock-openai"];
+            if (!providerConfig) {
+              throw new Error("mock-openai provider is missing from QA gateway config");
+            }
+            return {
+              ...config,
+              models: {
+                ...config.models,
+                providers: {
+                  ...config.models?.providers,
+                  "mock-openai": {
+                    ...providerConfig,
+                    // Explicit provider ceiling drives the stream idle watchdog.
+                    timeoutSeconds: PROVIDER_IDLE_TIMEOUT_SECONDS,
+                  },
+                },
+              },
+            };
+          },
+        });
+
+        phase = "transport-ready";
+        await transport.waitReady({ gateway });
+        phase = "cron";
+        const added = (await gateway.call(
+          "cron.add",
+          {
+            name: JOB_NAME,
+            enabled: true,
+            schedule: { kind: "at", at: new Date(Date.now() + 3_600_000).toISOString() },
+            sessionTarget: "isolated",
+            wakeMode: "next-heartbeat",
+            payload: {
+              kind: "agentTurn",
+              message: PROMPT,
+              timeoutSeconds: RUN_TIMEOUT_SECONDS,
+            },
+            delivery: { mode: "announce", channel: "qa-channel", to: ANNOUNCE_CONVERSATION.id },
+          },
+          { timeoutMs: 30_000 },
+        )) as { id: string };
+        expect(typeof added.id).toBe("string");
+
+        const outboundBefore = busState
+          .getSnapshot()
+          .messages.filter((message) => message.direction === "outbound").length;
+        const logMark = gateway.markLogs();
+        const triggered = (await gateway.call(
+          "cron.run",
+          { id: added.id, mode: "force" },
+          { timeoutMs: 30_000 },
+        )) as { ok?: unknown; ran?: unknown; enqueued?: unknown };
+        expect(triggered).toMatchObject({ ok: true });
+        expect(triggered.ran === true || triggered.enqueued === true).toBe(true);
+
+        const deadline = Date.now() + RUN_WAIT_MS;
+        let entry: CronRunEntry | undefined;
+        while (Date.now() < deadline) {
+          const page = (await gateway.call(
+            "cron.runs",
+            { id: added.id, limit: 5 },
+            { timeoutMs: 10_000 },
+          )) as { entries?: CronRunEntry[] };
+          entry = (page.entries ?? []).find((candidate) => candidate.status !== undefined);
+          if (entry) {
+            break;
+          }
+          await sleep(500);
+        }
+        const job = (await gateway.call("cron.get", { id: added.id }, { timeoutMs: 10_000 })) as {
+          state?: Record<string, unknown>;
+        };
+        const gatewayLogs = gateway
+          .readLogsSince(logMark)
+          .split("\n")
+          .filter((line) => /settled|idle timeout|fallback|cron/i.test(line))
+          .map((line) => line.trim())
+          .filter(Boolean);
+        const noteExists = await fs
+          .access(path.join(gateway.workspaceDir, NOTE_FILE))
+          .then(() => true)
+          .catch(() => false);
+        const stalled = provider.requests.find((request) => request.kind === "stalled");
+        // Give the announce path a moment to settle after the run record lands.
+        await sleep(2_000);
+        const announced = busState
+          .getSnapshot()
+          .messages.filter((message) => message.direction === "outbound")
+          .slice(outboundBefore)
+          .map((message) => ({ conversation: message.conversation, text: message.text }));
+
+        phase = "screenshots";
+        const screenshots: string[] = [];
+        if (SCREENSHOT_DIR) {
+          screenshots.push(
+            ...(await captureAutomationsScreenshots({
+              baseUrl: gateway.baseUrl,
+              wsUrl: gateway.wsUrl,
+              token: gateway.token,
+              jobId: added.id,
+              jobName: JOB_NAME,
+              outputDir: SCREENSHOT_DIR,
+            })),
+          );
+        }
+
+        console.log(
+          JSON.stringify(
+            {
+              phase: "cron-idle-timeout-finalization-proof",
+              head:
+                process.env.OPENCLAW_PROOF_HEAD_SHA ?? process.env.GITHUB_SHA ?? "local-checkout",
+              providerIdleTimeoutSeconds: PROVIDER_IDLE_TIMEOUT_SECONDS,
+              cronRunTrigger: triggered,
+              providerRequests: provider.requests.map((request) => ({
+                seq: request.seq,
+                kind: request.kind,
+                ...(request.clientClosedAt !== undefined
+                  ? { clientClosedAfterMs: request.clientClosedAt - request.startedAt }
+                  : {}),
+              })),
+              settledWriteLanded: noteExists,
+              announcedToChannel: announced,
+              screenshots,
+              cronRun: entry ?? null,
+              jobState: {
+                lastRunStatus: job.state?.lastRunStatus,
+                lastDeliveryStatus: job.state?.lastDeliveryStatus,
+                lastError: job.state?.lastError,
+              },
+              gatewayLogs,
+            },
+            null,
+            2,
+          ),
+        );
+
+        expect(entry, "cron run never finished").toBeDefined();
+        expect(noteExists).toBe(true);
+        expect(provider.requests.map((request) => request.kind)).toEqual([
+          "tool-call",
+          "stalled",
+          "finalization",
+          "finalization",
+        ]);
+        expect(stalled?.clientClosedAt).toBeDefined();
+        expect((stalled?.clientClosedAt ?? 0) - (stalled?.startedAt ?? 0)).toBeGreaterThanOrEqual(
+          PROVIDER_IDLE_TIMEOUT_SECONDS * 1_000 - 500,
+        );
+
+        const recordText = JSON.stringify(entry);
+        expect(recordText).not.toContain(SETTLED_TOOL_FINALIZATION_FALLBACK_TEXT);
+        expect(JSON.stringify(announced)).not.toContain(SETTLED_TOOL_FINALIZATION_FALLBACK_TEXT);
+        expect(entry).toMatchObject({ status: "error" });
+        expect(entry?.completionStatus).not.toBe("succeeded");
+        expect(typeof entry?.error === "string" ? entry.error : "").toMatch(/idle timeout/i);
+        expect(job.state?.lastRunStatus).toBe("error");
+      },
+    );
+  },
+);


### PR DESCRIPTION
Closes #141032

## What Problem This Solves

A scheduled `agentTurn` run whose model stream stalls after a settled tool batch is aborted by the idle watchdog, but the run still ends as `status: ok` / `completionStatus: succeeded`, and the synthetic settled-turn fallback line ("The tool run finished, but no final summary was produced. I did not repeat any completed actions.") is announced through the configured delivery as if it were the real report. Monitoring keyed on run status never sees the failure.

## Why This Change Was Made

`resolveSettledToolTerminalContinuationInstruction` intentionally lets a prompt-phase idle timeout with settled side effects enter isolated summary recovery. When that recovery is empty or fails, `prepareTerminalWithSettledTurnFinalization` built the fallback attempt with `terminal: { kind: "ok" }` and let it replace terminal ownership. Because `resolveEmbeddedRunTerminalTimeout` runs after that replacement, the timeout facts were gone before the run loop could surface them, and cron recorded `ok` + `delivered`.

## Solution

At the finalization boundary, treat an owner-recorded timeout like an existing tool failure: unanswered recovery preserves the original attempt and terminal state, no fallback transcript row is appended, and the run loop surfaces the idle timeout as before. A real recovered answer still replaces the timeout. Watchdog duration policy is unchanged (out of scope, per the issue triage).

## Evidence

### Product proof (real Gateway, mock OpenAI Responses provider, real cron + announce delivery)

New opt-in lane `test/e2e/qa-lab/runtime/gateway-cron-idle-timeout-finalization.product-proof.e2e.test.ts` (`OPENCLAW_CRON_IDLE_TIMEOUT_FINALIZATION_PROOF=1`):

1. Isolated cron job, `payload.timeoutSeconds: 120`, `delivery: announce` to the qa-lab bus channel.
2. Provider request 1 answers with a `write` tool call (side effect lands in the workspace).
3. Provider request 2 (post-tool turn) stays silent; the Gateway idle watchdog (`models.providers.mock-openai.timeoutSeconds: 8`) aborts it.
4. Requests 3–4 are the tool-free summary-recovery calls; both return an empty completed message.

#### Before (`main` build of the finalization owner, same harness, same mock provider)

```json
{
  "providerRequests": [
    {
      "seq": 1,
      "kind": "tool-call"
    },
    {
      "seq": 2,
      "kind": "stalled",
      "clientClosedAfterMs": 7956
    },
    {
      "seq": 3,
      "kind": "finalization"
    },
    {
      "seq": 4,
      "kind": "finalization"
    }
  ],
  "settledWriteLanded": true,
  "announcedToChannel": [
    {
      "conversation": {
        "id": "idle-timeout-proof-announce",
        "kind": "direct"
      },
      "text": "The tool run finished, but no final summary was produced. I did not repeat any completed actions."
    }
  ],
  "cronRun": {
    "status": "ok",
    "completionStatus": "succeeded",
    "errorReason": null,
    "delivered": true,
    "deliveryStatus": "delivered",
    "summary": "The tool run finished, but no final summary was produced. I did not repeat any completed actions."
  },
  "jobState": {
    "lastRunStatus": "ok",
    "lastDeliveryStatus": "delivered"
  }
}
```

Gateway log (redacted by the qa-lab harness):

```text
2026-09-07T10:40:34.121+00:00 [provider-transport-fetch] [model-fetch] error provider=mock-openai api=openai-responses model=gpt-5.6-luna elapsedMs=7970 name=Error code=undefined causeName=undefined causeCode=undefined message=LLM idle timeout (8s): no response from model
2026-09-07T10:40:34.194+00:00 [agent/embedded] settled post-tool turn lacked a final answer: runId=ea8e5fc9-c0e6-43be-8616-da1cf9908a4a sessionId=ea8e5fc9-c0e6-43be-8616-da1cf9908a4a provider=mock-openai/gpt-5.6-luna — running isolated finalization
2026-09-07T10:40:34.289+00:00 [agent/embedded] settled-turn finalization completed without a visible answer: runId=ea8e5fc9-c0e6-43be-8616-da1cf9908a4a sessionId=ea8e5fc9-c0e6-43be-8616-da1cf9908a4a provider=mock-openai/gpt-5.6-luna — retrying 1/1 with tools disabled
2026-09-07T10:40:34.355+00:00 [agent/embedded] settled-turn finalization completed without a visible answer: runId=ea8e5fc9-c0e6-43be-8616-da1cf9908a4a sessionId=ea8e5fc9-c0e6-43be-8616-da1cf9908a4a provider=mock-openai/gpt-5.6-luna attempts=2/2 — using terminal fallback reply
```

The run is recorded as delivered success and the synthetic fallback sentence is what the channel received.

#### After (this branch)

```json
{
  "providerRequests": [
    {
      "seq": 1,
      "kind": "tool-call"
    },
    {
      "seq": 2,
      "kind": "stalled",
      "clientClosedAfterMs": 7944
    },
    {
      "seq": 3,
      "kind": "finalization"
    },
    {
      "seq": 4,
      "kind": "finalization"
    }
  ],
  "settledWriteLanded": true,
  "announcedToChannel": [],
  "cronRun": {
    "status": "error",
    "completionStatus": "failed",
    "errorReason": "timeout",
    "delivered": false,
    "deliveryStatus": "not-delivered",
    "summary": "The model did not produce a response before the model idle timeout. Please try again, or increase `models.providers.<id>.timeoutSeconds` for slow local or self-hosted providers. If `agents.defaults.timeoutSeconds` or a run-specific timeout is lower, raise that ceiling too; provider timeouts cannot extend the whole agent run."
  },
  "jobState": {
    "lastRunStatus": "error",
    "lastDeliveryStatus": "not-delivered",
    "lastError": "The model did not produce a response before the model idle timeout. Please try again, or increase `models.providers.<id>.timeoutSeconds` for slow local or self-hosted providers. If `agents.defaults.timeoutSeconds` or a run-specific timeout is lower, raise that ceiling too; provider timeouts cannot extend the whole agent run."
  }
}
```

Gateway log (redacted by the qa-lab harness):

```text
2026-09-07T10:03:10.853+00:00 [provider-transport-fetch] [model-fetch] error provider=mock-openai api=openai-responses model=gpt-5.6-luna elapsedMs=7968 name=Error code=undefined causeName=undefined causeCode=undefined message=LLM idle timeout (8s): no response from model
2026-09-07T10:03:10.957+00:00 [agent/embedded] settled post-tool turn lacked a final answer: runId=89524b66-84b7-4d35-a283-a421fed34b80 sessionId=89524b66-84b7-4d35-a283-a421fed34b80 provider=mock-openai/gpt-5.6-luna — running isolated finalization
2026-09-07T10:03:11.105+00:00 [agent/embedded] settled-turn finalization completed without a visible answer: runId=89524b66-84b7-4d35-a283-a421fed34b80 sessionId=89524b66-84b7-4d35-a283-a421fed34b80 provider=mock-openai/gpt-5.6-luna — retrying 1/1 with tools disabled
2026-09-07T10:03:11.199+00:00 [agent/embedded] settled-turn finalization completed without a visible answer: runId=89524b66-84b7-4d35-a283-a421fed34b80 sessionId=89524b66-84b7-4d35-a283-a421fed34b80 provider=mock-openai/gpt-5.6-luna attempts=2/2 — preserving original failure
2026-09-07T10:03:13.915+00:00 [diagnostic] message processed: channel=cron chatId=unknown messageId=unknown sessionId=89524b66-84b7-4d35-a283-a421fed34b80 sessionKey=agent:qa:cron:531555ab-839a-42f7-a51c-b6f469c8a8ac:run:89524b66-84b7-4d35-a283-a421fed34b80 outcome=error duration=11910ms error="The model did not produce a response before the model idle timeout. Please try again, or increase `models.providers.<id>.timeoutSeconds` for slow local or self-hosted providers. If `agents.defaults.timeoutSeconds` or a run-specific timeout is lower, raise that ceiling too; provider timeouts cannot extend the whole agent run."
```

The same stall now ends as a failed run with the idle-timeout error; nothing is announced.

### Regression tests

- `src/agents/embedded-agent-runner/run/settled-turn-finalization.timeout.test.ts` (new): empty and failed recovery after an idle prompt timeout keep the original attempt, no fallback transcript append, `timedOutDuringPrompt` stays true. Both fail on `main` (the fallback attempt replaces the timeout with `terminal: ok`).
- `src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test-support.ts`: full `runEmbeddedAgent` case — idle timeout after a settled `write`, two empty finalizations → `meta.error.kind === "incomplete_turn"` and the idle-timeout payload, no fallback text. Fails on `main` (`meta.error` undefined, fallback payload delivered).

### Checks

- `pnpm test src/agents/embedded-agent-runner/run/settled-turn-finalization.timeout.test.ts` — 2 passed
- `pnpm test src/agents/embedded-agent-runner/run/settled-turn-finalization*.test.ts src/agents/embedded-agent-runner/run/settled-tool-evidence.test.ts src/agents/embedded-agent-runner/run.terminal-timeout.test.ts` — 35 passed
- `pnpm test src/agents/embedded-agent-runner/run.shared-integration.test.ts src/cron/isolated-agent/run.meta-error-status.test.ts src/cron/completion-status.test.ts` — 150 passed
- Product proof lane above: fails on `main` (assertion: run record contains the fallback sentence), passes on this branch
- `pnpm check:changed`: every lane before `typecheck all` passed locally (format, lint, repository guards); the local typecheck lane was interrupted mid-run on this host, so typecheck proof is the exact-head CI `checks-node-*` lanes (green on the previous head `d7d354c`, re-running on the rebased head)
- `$autoreview` (Codex, branch vs `origin/main`, `--max-priority P2`): scoped-clean, no findings
- Rebased onto current `main` (clean; no upstream edits to the finalization owner). Focused suites re-run after the rebase: `settled-turn-finalization*.test.ts`, `run.terminal-timeout.test.ts`, `run.shared-integration.test.ts`, `run.meta-error-status.test.ts`, `completion-status.test.ts` — 188 passed

Control UI captures (Automations run history, screenshot + screen recording):

- before: https://github.com/openclaw/openclaw/pull/141072#issuecomment-5569537500
- after: https://github.com/openclaw/openclaw/pull/141072#issuecomment-5569711422


