### PR TITLE
refactor(channels): share DM policy schema refinement

### DIFF
--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -770,6 +770,14 @@ those defaults to account entries or remove them from the root; the former
 shadows operator settings and the latter can leave group access open.
 This replaces `buildCommonChannelAccountShape` and its defaulting flags.
 
+Use `refineChannelDmPolicy({ channelId, value, ctx })` from the same subpath
+to validate the root policy against `allowFrom`. Pass `accountId` to validate
+one account with root-policy and allowlist inheritance, including explicit
+empty-array overrides. The helper emits the standard root/account error paths
+and messages for `open` and `allowlist` policies. Keep account iteration,
+disabled-account filtering, and ordering relative to other refinements in the
+channel, since those rules differ between plugins.
+
 Use `mergeAccountConfig` or `resolveMergedAccountConfig` through the existing
 `openclaw/plugin-sdk/account-helpers` export for runtime inheritance. Their
 shared implementation lives at `src/config/channel-account-config.ts`;

--- a/extensions/discord/src/config-schema.ts
+++ b/extensions/discord/src/config-schema.ts
@@ -12,8 +12,7 @@ import {
   ChannelPreviewStreamingConfigSchema,
   ChannelStreamingProgressSchema,
   ProviderCommandsSchema,
-  requireAllowlistAllowFrom,
-  requireOpenAllowFrom,
+  refineChannelDmPolicy,
   TtsConfigSchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor-migrations";
@@ -407,23 +406,7 @@ const DiscordConfigSchemaBase = DiscordAccountSchemaBase.safeExtend({
   accounts: z.record(z.string(), DiscordAccountSchema.optional()).optional(),
   defaultAccount: z.string().optional(),
 }).superRefine((value, ctx) => {
-  const dmPolicy = value.dmPolicy ?? "pairing";
-  const allowFrom = value.allowFrom;
-  requireOpenAllowFrom({
-    policy: dmPolicy,
-    allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message: 'channels.discord.dmPolicy="open" requires channels.discord.allowFrom to include "*"',
-  });
-  requireAllowlistAllowFrom({
-    policy: dmPolicy,
-    allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message:
-      'channels.discord.dmPolicy="allowlist" requires channels.discord.allowFrom to contain at least one sender ID',
-  });
+  refineChannelDmPolicy({ channelId: "discord", value, ctx });
 
   if (!value.accounts) {
     return;
@@ -432,24 +415,7 @@ const DiscordConfigSchemaBase = DiscordAccountSchemaBase.safeExtend({
     if (!account) {
       continue;
     }
-    const effectivePolicy = account.dmPolicy ?? value.dmPolicy ?? "pairing";
-    const effectiveAllowFrom = account.allowFrom ?? value.allowFrom;
-    requireOpenAllowFrom({
-      policy: effectivePolicy,
-      allowFrom: effectiveAllowFrom,
-      ctx,
-      path: ["accounts", accountId, "allowFrom"],
-      message:
-        'channels.discord.accounts.*.dmPolicy="open" requires channels.discord.accounts.*.allowFrom (or channels.discord.allowFrom) to include "*"',
-    });
-    requireAllowlistAllowFrom({
-      policy: effectivePolicy,
-      allowFrom: effectiveAllowFrom,
-      ctx,
-      path: ["accounts", accountId, "allowFrom"],
-      message:
-        'channels.discord.accounts.*.dmPolicy="allowlist" requires channels.discord.accounts.*.allowFrom (or channels.discord.allowFrom) to contain at least one sender ID',
-    });
+    refineChannelDmPolicy({ channelId: "discord", value, accountId, ctx });
   }
 });
 

--- a/extensions/imessage/src/config-schema.ts
+++ b/extensions/imessage/src/config-schema.ts
@@ -9,8 +9,7 @@ import {
   ExecutableTokenSchema,
   isSafeScpRemoteHost,
   isValidInboundPathRootPattern,
-  requireAllowlistAllowFrom,
-  requireOpenAllowFrom,
+  refineChannelDmPolicy,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { z } from "zod";
 import { iMessageChannelConfigUiHints } from "./config-ui-hints.js";
@@ -90,22 +89,7 @@ export const IMessageConfigSchema = IMessageAccountSchemaBase.extend({
   accounts: z.record(z.string(), IMessageAccountSchemaBase.optional()).optional(),
   defaultAccount: z.string().optional(),
 }).superRefine((value, ctx) => {
-  requireOpenAllowFrom({
-    policy: value.dmPolicy,
-    allowFrom: value.allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message:
-      'channels.imessage.dmPolicy="open" requires channels.imessage.allowFrom to include "*"',
-  });
-  requireAllowlistAllowFrom({
-    policy: value.dmPolicy,
-    allowFrom: value.allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message:
-      'channels.imessage.dmPolicy="allowlist" requires channels.imessage.allowFrom to contain at least one sender ID',
-  });
+  refineChannelDmPolicy({ channelId: "imessage", value, ctx });
 
   if (!value.accounts) {
     return;
@@ -114,24 +98,7 @@ export const IMessageConfigSchema = IMessageAccountSchemaBase.extend({
     if (!account) {
       continue;
     }
-    const effectivePolicy = account.dmPolicy ?? value.dmPolicy;
-    const effectiveAllowFrom = account.allowFrom ?? value.allowFrom;
-    requireOpenAllowFrom({
-      policy: effectivePolicy,
-      allowFrom: effectiveAllowFrom,
-      ctx,
-      path: ["accounts", accountId, "allowFrom"],
-      message:
-        'channels.imessage.accounts.*.dmPolicy="open" requires channels.imessage.accounts.*.allowFrom (or channels.imessage.allowFrom) to include "*"',
-    });
-    requireAllowlistAllowFrom({
-      policy: effectivePolicy,
-      allowFrom: effectiveAllowFrom,
-      ctx,
-      path: ["accounts", accountId, "allowFrom"],
-      message:
-        'channels.imessage.accounts.*.dmPolicy="allowlist" requires channels.imessage.accounts.*.allowFrom (or channels.imessage.allowFrom) to contain at least one sender ID',
-    });
+    refineChannelDmPolicy({ channelId: "imessage", value, accountId, ctx });
   }
 });
 

--- a/extensions/msteams/src/config-schema.ts
+++ b/extensions/msteams/src/config-schema.ts
@@ -5,8 +5,7 @@ import {
   ChannelDangerouslyAllowNameMatchingSchema,
   ChannelPreviewStreamingConfigSchema,
   MSTeamsReplyStyleSchema,
-  requireAllowlistAllowFrom,
-  requireOpenAllowFrom,
+  refineChannelDmPolicy,
   ToolPolicySchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import {
@@ -143,22 +142,7 @@ export const MSTeamsConfigSchema = z
   })
   .strict()
   .superRefine((value, ctx) => {
-    requireOpenAllowFrom({
-      policy: value.dmPolicy,
-      allowFrom: value.allowFrom,
-      ctx,
-      path: ["allowFrom"],
-      message:
-        'channels.msteams.dmPolicy="open" requires channels.msteams.allowFrom to include "*"',
-    });
-    requireAllowlistAllowFrom({
-      policy: value.dmPolicy,
-      allowFrom: value.allowFrom,
-      ctx,
-      path: ["allowFrom"],
-      message:
-        'channels.msteams.dmPolicy="allowlist" requires channels.msteams.allowFrom to contain at least one sender ID',
-    });
+    refineChannelDmPolicy({ channelId: "msteams", value, ctx });
     if (value.sso?.enabled === true && !value.sso.connectionName?.trim()) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/extensions/signal/src/config-schema.ts
+++ b/extensions/signal/src/config-schema.ts
@@ -13,8 +13,7 @@ import {
   ChannelSendReadReceiptsSchema,
   ExecutableTokenSchema,
   ReplyToModeSchema,
-  requireAllowlistAllowFrom,
-  requireOpenAllowFrom,
+  refineChannelDmPolicy,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { z } from "zod";
@@ -154,44 +153,13 @@ const SignalConfigSchemaBase = SignalAccountSchemaBase.extend({
 type SignalConfigValidationValue = z.infer<typeof SignalConfigSchemaBase>;
 
 function validateSignalConfigAllowFrom(value: SignalConfigValidationValue, ctx: z.RefinementCtx) {
-  requireOpenAllowFrom({
-    policy: value.dmPolicy,
-    allowFrom: value.allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message: 'channels.signal.dmPolicy="open" requires channels.signal.allowFrom to include "*"',
-  });
-  requireAllowlistAllowFrom({
-    policy: value.dmPolicy,
-    allowFrom: value.allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message:
-      'channels.signal.dmPolicy="allowlist" requires channels.signal.allowFrom to contain at least one sender ID',
-  });
+  refineChannelDmPolicy({ channelId: "signal", value, ctx });
 
   for (const [accountId, account] of Object.entries(value.accounts ?? {})) {
     if (!account) {
       continue;
     }
-    const effectivePolicy = account.dmPolicy ?? value.dmPolicy;
-    const effectiveAllowFrom = account.allowFrom ?? value.allowFrom;
-    requireOpenAllowFrom({
-      policy: effectivePolicy,
-      allowFrom: effectiveAllowFrom,
-      ctx,
-      path: ["accounts", accountId, "allowFrom"],
-      message:
-        'channels.signal.accounts.*.dmPolicy="open" requires channels.signal.accounts.*.allowFrom (or channels.signal.allowFrom) to include "*"',
-    });
-    requireAllowlistAllowFrom({
-      policy: effectivePolicy,
-      allowFrom: effectiveAllowFrom,
-      ctx,
-      path: ["accounts", accountId, "allowFrom"],
-      message:
-        'channels.signal.accounts.*.dmPolicy="allowlist" requires channels.signal.accounts.*.allowFrom (or channels.signal.allowFrom) to contain at least one sender ID',
-    });
+    refineChannelDmPolicy({ channelId: "signal", value, accountId, ctx });
   }
 }
 

--- a/extensions/slack/src/config-schema.ts
+++ b/extensions/slack/src/config-schema.ts
@@ -13,8 +13,7 @@ import {
   ChannelStreamingProgressSchema,
   ProviderCommandsSchema,
   ReplyToModeSchema,
-  requireAllowlistAllowFrom,
-  requireOpenAllowFrom,
+  refineChannelDmPolicy,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { buildSecretInputSchema, hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input";
 import { z } from "zod";
@@ -214,23 +213,7 @@ export const SlackConfigSchema = SlackAccountSchema.safeExtend({
     return;
   }
 
-  const dmPolicy = value.dmPolicy ?? "pairing";
-  const allowFrom = value.allowFrom;
-  requireOpenAllowFrom({
-    policy: dmPolicy,
-    allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message: 'channels.slack.dmPolicy="open" requires channels.slack.allowFrom to include "*"',
-  });
-  requireAllowlistAllowFrom({
-    policy: dmPolicy,
-    allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message:
-      'channels.slack.dmPolicy="allowlist" requires channels.slack.allowFrom to contain at least one sender ID',
-  });
+  refineChannelDmPolicy({ channelId: "slack", value, ctx });
 
   const requireRelayConfig = (
     relay: { url?: unknown; authToken?: unknown; gatewayId?: unknown } | undefined,
@@ -278,24 +261,7 @@ export const SlackConfigSchema = SlackAccountSchema.safeExtend({
       ...value.relay,
       ...account.relay,
     };
-    const effectivePolicy = account.dmPolicy ?? value.dmPolicy ?? "pairing";
-    const effectiveAllowFrom = account.allowFrom ?? value.allowFrom;
-    requireOpenAllowFrom({
-      policy: effectivePolicy,
-      allowFrom: effectiveAllowFrom,
-      ctx,
-      path: ["accounts", accountId, "allowFrom"],
-      message:
-        'channels.slack.accounts.*.dmPolicy="open" requires channels.slack.accounts.*.allowFrom (or channels.slack.allowFrom) to include "*"',
-    });
-    requireAllowlistAllowFrom({
-      policy: effectivePolicy,
-      allowFrom: effectiveAllowFrom,
-      ctx,
-      path: ["accounts", accountId, "allowFrom"],
-      message:
-        'channels.slack.accounts.*.dmPolicy="allowlist" requires channels.slack.accounts.*.allowFrom (or channels.slack.allowFrom) to contain at least one sender ID',
-    });
+    refineChannelDmPolicy({ channelId: "slack", value, accountId, ctx });
     if (accountMode !== "http") {
       if (accountMode === "relay") {
         requireRelayConfig(effectiveRelay, ["accounts", accountId, "relay"]);

--- a/extensions/telegram/src/config-schema.ts
+++ b/extensions/telegram/src/config-schema.ts
@@ -10,8 +10,7 @@ import {
   DmPolicySchema,
   GroupPolicySchema,
   ProviderCommandsSchema,
-  requireAllowlistAllowFrom,
-  requireOpenAllowFrom,
+  refineChannelDmPolicy,
   ToolPolicySchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import {
@@ -289,22 +288,7 @@ export const TelegramConfigSchema = TelegramAccountSchemaBase.extend({
   accounts: z.record(z.string(), TelegramAccountSchema.optional()).optional(),
   defaultAccount: z.string().optional(),
 }).superRefine((value, ctx) => {
-  requireOpenAllowFrom({
-    policy: value.dmPolicy,
-    allowFrom: value.allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message:
-      'channels.telegram.dmPolicy="open" requires channels.telegram.allowFrom to include "*"',
-  });
-  requireAllowlistAllowFrom({
-    policy: value.dmPolicy,
-    allowFrom: value.allowFrom,
-    ctx,
-    path: ["allowFrom"],
-    message:
-      'channels.telegram.dmPolicy="allowlist" requires channels.telegram.allowFrom to contain at least one sender ID',
-  });
+  refineChannelDmPolicy({ channelId: "telegram", value, ctx });
   validateTelegramCustomCommands(value, ctx);
 
   if (value.accounts) {
@@ -312,24 +296,7 @@ export const TelegramConfigSchema = TelegramAccountSchemaBase.extend({
       if (!account) {
         continue;
       }
-      const effectivePolicy = account.dmPolicy ?? value.dmPolicy;
-      const effectiveAllowFrom = account.allowFrom ?? value.allowFrom;
-      requireOpenAllowFrom({
-        policy: effectivePolicy,
-        allowFrom: effectiveAllowFrom,
-        ctx,
-        path: ["accounts", accountId, "allowFrom"],
-        message:
-          'channels.telegram.accounts.*.dmPolicy="open" requires channels.telegram.accounts.*.allowFrom (or channels.telegram.allowFrom) to include "*"',
-      });
-      requireAllowlistAllowFrom({
-        policy: effectivePolicy,
-        allowFrom: effectiveAllowFrom,
-        ctx,
-        path: ["accounts", accountId, "allowFrom"],
-        message:
-          'channels.telegram.accounts.*.dmPolicy="allowlist" requires channels.telegram.accounts.*.allowFrom (or channels.telegram.allowFrom) to contain at least one sender ID',
-      });
+      refineChannelDmPolicy({ channelId: "telegram", value, accountId, ctx });
     }
   }
 

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -358,7 +358,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +7: card projection plus three rendering helpers on channel-outbound and its shipped barrel.
       // +2: shared diff-stat rendering on channel-outbound and its shipped barrel.
       // +1: shared static UI guidance, separate from per-turn harness delivery policy.
-      4446,
+      // +1: shared root/account DM policy refinement for channel schemas.
+      4447,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -485,7 +486,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +7: card projection plus three rendering helpers on channel-outbound and its shipped barrel.
       // +2: shared diff-stat rendering on channel-outbound and its shipped barrel.
       // +1: shared static UI guidance, separate from per-turn harness delivery policy.
-      2630,
+      // +1: shared root/account DM policy refinement for channel schemas.
+      2631,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/channels/plugins/config-schema.ts
+++ b/src/channels/plugins/config-schema.ts
@@ -5,7 +5,10 @@
  */
 import { z, type ZodRawShape, type ZodTypeAny } from "zod";
 import { ToolPolicySchema } from "../../config/zod-schema.agent-runtime.js";
-import { DmPolicySchema } from "../../config/zod-schema.core.js";
+import {
+  DmPolicySchema,
+  evaluateDmPolicyAllowFromDependency,
+} from "../../config/zod-schema.core.js";
 import {
   parseJsonSchemaIssuePath,
   validateJsonSchemaValue,
@@ -30,6 +33,45 @@ type ExtendableZodObject = ZodTypeAny & {
 const AllowFromEntrySchema = z.union([z.string(), z.number()]);
 /** Optional allowlist array used by channel config schema builders. */
 export const AllowFromListSchema = z.array(AllowFromEntrySchema).optional();
+
+type ChannelDmPolicyFields = {
+  dmPolicy?: string;
+  allowFrom?: Array<string | number>;
+};
+
+/** Validate one policy scope; the channel owns account selection and refinement ordering. */
+export function refineChannelDmPolicy(params: {
+  channelId: string;
+  value: ChannelDmPolicyFields & {
+    accounts?: Record<string, ChannelDmPolicyFields | undefined>;
+  };
+  accountId?: string;
+  ctx: z.RefinementCtx;
+}): void {
+  const { channelId, value, accountId, ctx } = params;
+  const account = accountId === undefined ? value : value.accounts?.[accountId];
+  if (!account) {
+    return;
+  }
+  const policy = account.dmPolicy ?? value.dmPolicy;
+  const violation = evaluateDmPolicyAllowFromDependency({
+    policy,
+    allowFrom: account.allowFrom ?? value.allowFrom,
+  });
+  if (!violation) {
+    return;
+  }
+  const root = `channels.${channelId}`;
+  const owner = accountId === undefined ? root : `${root}.accounts.*`;
+  const inherited = accountId === undefined ? "" : ` (or ${root}.allowFrom)`;
+  const requirement =
+    violation === "open_requires_wildcard" ? 'include "*"' : "contain at least one sender ID";
+  ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    path: accountId === undefined ? ["allowFrom"] : ["accounts", accountId, "allowFrom"],
+    message: `${owner}.dmPolicy="${policy}" requires ${owner}.allowFrom${inherited} to ${requirement}`,
+  });
+}
 
 /** Canonical per-group/room channel policy shape. */
 export const ChannelGroupEntrySchema = z

--- a/src/plugin-sdk/channel-config-schema.ts
+++ b/src/plugin-sdk/channel-config-schema.ts
@@ -13,6 +13,7 @@ export {
   buildJsonChannelConfigSchema,
   buildMultiAccountChannelSchema,
   buildNestedDmConfigSchema,
+  refineChannelDmPolicy,
 } from "../channels/plugins/config-schema.js";
 export {
   BlockStreamingChunkSchema,


### PR DESCRIPTION
## What Problem This Solves

Six plugins repeat the same DM-policy and allowlist checks, including root/account inheritance and the same validation messages. Keeping those copies aligned makes channel configuration harder to maintain.

## Why This Change Was Made

Discord, iMessage, Microsoft Teams, Signal, Slack and Telegram now use one shared refineChannelDmPolicy helper through the existing channel-config-schema SDK entrypoint. The helper uses the canonical policy-dependency evaluator. Each plugin retains its account traversal, disabled-account filtering and ordering relative to other refinements. The SDK export and callable budgets increase by exactly one to account for this shared public helper.

## User Impact

Successful parsed config and validation issue paths/messages remain unchanged, including explicit empty-array overrides of inherited allowlists. Schemas with a different open-only contract keep their existing validation. No transport, credential or runtime-authorization behavior changes.

## Evidence

Before/after comparison matches 25,909 complete schema outputs and ordered issue lists, including multi-error, disabled-account, webhook, custom-command, Teams SSO and cloud cases. All 262 focused tests across nine files and six doctor-guard tests pass; no tests or expected results changed.

The full selected checks and normal build passed for the public helper and initial five-plugin scope. Microsoft Teams was then added using the same already-built SDK module; all prior source hashes remained identical. Its final tests, extension types/lint, channel metadata and config-doc checks passed. Fresh final full-candidate P2 review is clean. This removes 139 physical production lines across the six plugins and shared owner; no live channel traffic was needed for the unchanged schema contract.
