### PR TITLE
fix: avoid false CI placement failures when tooling splits

### DIFF
--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -62,6 +62,30 @@ const PRIVATE_QA_TOOLING_TEST = "test/e2e/qa-lab/runtime/gateway-codex-delivery-
 const DEFAULT_NODE_TEST_RUNNER = "blacksmith-8vcpu-ubuntu-2404";
 const BUNDLED_NODE_TEST_RUNNER = "blacksmith-4vcpu-ubuntu-2404";
 const EXTRA_LARGE_NODE_TEST_RUNNER = "blacksmith-32vcpu-ubuntu-2404";
+function isNumberedToolingGroup(group: { shard_name: string }) {
+  return /^core-tooling-\d+(?:-hosted-\d+)?$/u.test(group.shard_name);
+}
+function nonToolingPlacement(plan: CompactNodeTestShard[]) {
+  return plan
+    .flatMap((job) => {
+      const groups = job.groups
+        .filter((group) => !isNumberedToolingGroup(group))
+        .map((group) => group.shard_name)
+        .toSorted();
+      return groups.length === 0
+        ? []
+        : [
+            {
+              groups,
+              planConcurrency: job.planConcurrency,
+              pretestBuildMode: job.pretestBuildMode,
+              requiresDist: job.requiresDist,
+              runner: job.runner,
+            },
+          ];
+    })
+    .toSorted((a, b) => a.groups.join("\0").localeCompare(b.groups.join("\0")));
+}
 function isCombinedUnbuiltCliJob(job: CompactNodeTestShard) {
   return (
     job.groups.length > 1 &&
@@ -2106,6 +2130,70 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     });
   });
 
+  it("keeps non-tooling placement checks independent of singleton tooling split names", () => {
+    const anchor: CompactNodeTestShard = {
+      checkName: "checks-node-compact-small-1",
+      shardName: "compact-small-1",
+      runner: BUNDLED_NODE_TEST_RUNNER,
+      requiresDist: false,
+      planConcurrency: 1,
+      groups: [
+        {
+          shard_name: "core-unit-fast",
+          configs: ["test/vitest/vitest.unit-fast.config.ts"],
+          requiresDist: false,
+          runner: BUNDLED_NODE_TEST_RUNNER,
+        },
+      ],
+    };
+    // Projection fixture from the real six-file inventory proof: the 330-second
+    // file stays alone with the same execution policy when its stripe is named.
+    const unsplit: CompactNodeTestShard = {
+      ...anchor,
+      checkName: "checks-node-compact-small-22",
+      shardName: "compact-small-22",
+      predictedSeconds: 330,
+      groups: [
+        {
+          shard_name: "core-tooling-1",
+          configs: ["test/vitest/vitest.tooling.config.ts"],
+          includePatterns: ["test/scripts/pr-merge-outcome.test.ts"],
+          requiresDist: false,
+          runner: BUNDLED_NODE_TEST_RUNNER,
+          env: { OPENCLAW_VITEST_MAX_WORKERS: "2" },
+        },
+      ],
+    };
+    const split: CompactNodeTestShard = {
+      ...unsplit,
+      checkName: "checks-node-compact-small-33",
+      shardName: "compact-small-33",
+      groups: [{ ...unsplit.groups[0]!, shard_name: "core-tooling-1-hosted-1" }],
+    };
+    const original = structuredClone({ anchor, unsplit, split });
+    const expected = [
+      {
+        groups: ["core-unit-fast"],
+        planConcurrency: 1,
+        pretestBuildMode: undefined,
+        requiresDist: false,
+        runner: BUNDLED_NODE_TEST_RUNNER,
+      },
+    ];
+    expect(nonToolingPlacement([anchor, unsplit])).toEqual(expected);
+    expect(nonToolingPlacement([anchor, split])).toEqual(expected);
+    expect(nonToolingPlacement([split])).not.toEqual(expected);
+    for (const changed of [
+      { ...anchor, runner: DEFAULT_NODE_TEST_RUNNER },
+      { ...anchor, planConcurrency: 2 },
+      { ...anchor, requiresDist: true },
+      { ...anchor, pretestBuildMode: "runtime" as const },
+    ]) {
+      expect(nonToolingPlacement([changed, split])).not.toEqual(expected);
+    }
+    expect({ anchor, unsplit, split }).toEqual(original);
+  });
+
   it("keeps hosted tooling within the GitHub job cap when its inventory grows", async () => {
     const options = {
       compactMode: "pull-request" as const,
@@ -2121,33 +2209,11 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     const growthFiles = new Set([inventoryGrowthFile, ...extraInventories.flat()]);
     const isHostedToolingGroup = (group: { shard_name: string }) =>
       /^core-tooling-\d+-hosted-\d+$/u.test(group.shard_name);
-    const isNumberedToolingGroup = (group: { shard_name: string }) =>
-      /^core-tooling-\d+(?:-hosted-\d+)?$/u.test(group.shard_name);
     const runnerRanks = new Map([
       [BUNDLED_NODE_TEST_RUNNER, 0],
       [DEFAULT_NODE_TEST_RUNNER, 1],
       [EXTRA_LARGE_NODE_TEST_RUNNER, 2],
     ]);
-    const nonToolingPlacement = (plan: CompactNodeTestShard[]) =>
-      plan
-        .flatMap((job) => {
-          const groups = job.groups
-            .filter((group) => !isHostedToolingGroup(group))
-            .map((group) => group.shard_name)
-            .toSorted();
-          return groups.length === 0
-            ? []
-            : [
-                {
-                  groups,
-                  planConcurrency: job.planConcurrency,
-                  pretestBuildMode: job.pretestBuildMode,
-                  requiresDist: job.requiresDist,
-                  runner: job.runner,
-                },
-              ];
-        })
-        .toSorted((a, b) => a.groups.join("\0").localeCompare(b.groups.join("\0")));
     const createPlanWithInventory = async (
       includeGrowthFile: boolean,
       extraFiles: string[] = [],


### PR DESCRIPTION
Closes #141068. Related: #140512, #140664, #140929. Affected: #138953.

## What Problem This Solves

Resolves a problem where adding tests causes the compact CI planner's growth regression to report that a non-tooling job moved, even though the affected job is tooling and retains its execution requirements. An unsplit `core-tooling-1` group was incorrectly included in the non-tooling comparison; its valid split name was excluded.

## Why This Change Was Made

Use the existing numbered-tooling classification consistently for the shared test-only placement helper. Add one focused regression covering split/unsplit names, retained anchors, negative controls for anchor removal and policy changes, and input nonmutation.

Only `test/scripts/ci-node-test-plan.test.ts` changes. Production planning, the existing 52 tests and their invariant assertions, inventory filters and Mantis test membership remain unchanged. This follows the earlier helper and packing work by Vincent Koc (@vincentkoc) and Peter Steinberger (@steipete); #140929's upstream correction is preserved.

## User Impact

Contributors should no longer receive this false CI regression when tooling inventory grows. No application behavior, job cap, runner allocation or timeout changes.

## Evidence

Pinned base: `15e5cf111d5954d9b3b001b1dae5b1ff8e987a69`. Committed head: `dca59eb5a02b1fd3d9c8fa3b666f71c38fbae23a`, whose tree is byte-identical to the exercised candidate `a6ff29dd8d22cfda9f76e0fdaf7ebc0adfe41097`.

### Real Behavior Proof

Executed controls against the unmodified base:

- Main: 52/52 passed (`run_6d0b01ab4a45`). Main plus six byte-identical Mantis test files: 51/52 passed (`run_95f0d0e9d7a5`), failing the original placement comparison—not an 81/80 overflow.
- Bounded external diagnostic `run_87f00249dbdc` reproduced the original fixture filter without changing production or test source. Adding ten growth-probe files kept both plans at 80 jobs.
- The affected `pr-merge-outcome.test.ts` remained exact-once and alone: same 4-vCPU runner, two workers, configs/environment/prerequisites and 330-second estimate. Only its tooling split identity and check name changed.
- Comparison preserved all 150 genuine non-tooling anchors and their policies. Coverage increased by exactly ten files. Numbered prerequisite anchors retained their memberships and policies; canonical timing keys were recomputed against each complete sibling family, not ignored.

Fresh Docker-backed proof:

- Original predicate with the new projection regression: expected failure, 1 failed / 52 skipped (`run_10f599185e0f`, recorded test status 1).
- Corrected predicate: focused regression passes; full original 52 tests plus the new regression pass, 53/53 in 137.06 seconds (`run_70764cca4d9c`, recorded test status 0).
- Complete changed-file gate passes, including test-root typecheck, formatting, lint and repository guards (`run_70764cca4d9c`, recorded check status 0).
- Actual-six-file combined planner suite: 53/53 pass in 133.79 seconds (`run_78d5fc1e7149`, recorded test status 0). Combined tree `6572df4dc9cbed0547b9867d6190978f1576112f` adds only the six exact producer test blobs to the candidate.
- Repeated actual plan generation is deterministic. Independent emitted-plan comparison passes: 80 jobs before/after, explicit file occurrences 7901 -> 7907, each of the six new files exactly once, unchanged existing blobs/modes, execution policies and non-tooling anchors, canonical membership-bound timing identities and capacity/runner constraints retained.

```sh
node scripts/run-vitest.mjs run test/scripts/ci-node-test-plan.test.ts --maxWorkers=1
node scripts/check-changed.mjs -- test/scripts/ci-node-test-plan.test.ts
```

Fresh validation environment: Docker-backed Crabbox `local-container`, lease `cbx_2679fe7b677b`; image `csw152-producer-proof:local`, SHA256 `00ae3fb8634016df2f36fd335f9d4561feab0bdacb61a5ab314b99b4d6b841b6`; verified Node 24.20.0/pnpm 12.3.4. Source receiver verified raw Git blobs, modes and selected trees and reconciled frozen dependencies; source remained unchanged. Artifacts were retained before Crabbox deleted the lease; exact Docker container absence was independently verified. Historical controls above are separate from this lease's fresh results.

Captured proof transcript (transport exit is not the verdict):

```text
PLANNER_PROOF_RESULT:classification-before-r2:1
CLASSIFICATION_FOCUSED_PASS:classification-after-r2
PLANNER_PROOF_RESULT:classification-after-r2:0
PLANNER_CHECKS_RESULT:classification-after-r2:0
PLANNER_PROOF_RESULT:classification-six:0
```

### Risks and limits

The focused fixture proves projection behavior; the executed full planner and actual-inventory runs cover the real planner path. Diagnostic evidence establishes coverage and planning constraints, not measured test wall-clock performance or the separate producer's Gateway/UI functionality. No deployment or activation changes are included.

### Review

Both mandatory Codex reviews are scoped-clean through P2, with no accepted/actionable findings: dirty patch (confidence 0.97) and committed branch against the actual base (0.98). No fixes were needed; committed tree matches the executed proof exactly. Commands:

```sh
python .agents/skills/autoreview/scripts/autoreview --mode local --base 15e5cf111d5954d9b3b001b1dae5b1ff8e987a69 --max-priority P2 --dataset scripts/lib/vitest-shard-metadata.mts
python .agents/skills/autoreview/scripts/autoreview --mode branch --base 15e5cf111d5954d9b3b001b1dae5b1ff8e987a69 --max-priority P2 --dataset scripts/lib/vitest-shard-metadata.mts
git diff --check
```

Exact-head hosted CI and ClawSweeper readiness remain pending publication; no merge readiness is claimed ahead of those gates.
