### PR TITLE
fix(telegram): stop late stall reactions after canceled preparation

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-status.ts
+++ b/extensions/telegram/src/bot-message-dispatch-status.ts
@@ -6,19 +6,22 @@ export function createTelegramDispatchStatus(params: { context: TelegramMessageC
   const { context } = params;
   const controller =
     context.ctxPayload.InboundEventKind === "room_event" ? null : context.statusReactionController;
-  const finalize = async (final: { outcome: "done" | "error" }) => {
+  const finalize = async (final: { outcome: "done" | "error" | "cancelled" }) => {
     if (!controller) {
       return;
     }
     if (final.outcome === "done") {
       await controller.setDone();
-    } else {
+    } else if (final.outcome === "error") {
       await controller.setError();
     }
     await controller.restoreInitial();
   };
 
-  const finalizeInBackground = (final: { outcome: "done" | "error" }, label: string) => {
+  const finalizeInBackground = (
+    final: { outcome: "done" | "error" | "cancelled" },
+    label: string,
+  ) => {
     void finalize(final).catch((err: unknown) => {
       logVerbose(`telegram: status reaction ${label} failed: ${String(err)}`);
     });

--- a/extensions/telegram/src/bot-message-dispatch.pipeline-init.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.pipeline-init.test.ts
@@ -42,7 +42,7 @@ describeTelegramDispatch("dispatchTelegramMessage pipeline-init", () => {
       });
       try {
         // Context assembly queues the acknowledgement before dispatch preparation.
-        controller.setQueued();
+        await controller.setQueued();
         await vi.advanceTimersByTimeAsync(0);
         expect(setReaction).toHaveBeenCalledWith("👀");
         const abortController = new AbortController();

--- a/extensions/telegram/src/bot-message-dispatch.pipeline-init.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.pipeline-init.test.ts
@@ -1,3 +1,4 @@
+import { createStatusReactionController as createRealStatusReactionController } from "openclaw/plugin-sdk/channel-feedback";
 import { expect, it, vi } from "vitest";
 import {
   createChannelMessageReplyPipeline,
@@ -5,6 +6,7 @@ import {
   createRuntime,
   createStatusReactionController,
   dispatchReplyWithBufferedBlockDispatcher,
+  describeStickerImage,
   describeTelegramDispatch,
   dispatchWithContext,
 } from "./bot-message-dispatch.test-harness.js";
@@ -28,24 +30,57 @@ describeTelegramDispatch("dispatchTelegramMessage pipeline-init", () => {
     );
   });
 
-  it("does not enter the reply pipeline after the durable owner aborts", async () => {
-    const abortController = new AbortController();
-    abortController.abort(new Error("handler-timeout"));
+  it.each(["before dispatch", "during sticker preparation"] as const)(
+    "stops queued status reactions when the durable owner aborts %s",
+    async (abortAt) => {
+      vi.useFakeTimers();
+      const setReaction = vi.fn(async (_emoji: string) => undefined);
+      const controller = createRealStatusReactionController({
+        enabled: true,
+        adapter: { setReaction },
+        initialEmoji: "👀",
+      });
+      try {
+        // Context assembly queues the acknowledgement before dispatch preparation.
+        controller.setQueued();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(setReaction).toHaveBeenCalledWith("👀");
+        const abortController = new AbortController();
+        const context = createContext({ statusReactionController: controller });
+        if (abortAt === "before dispatch") {
+          abortController.abort(new Error("handler-timeout"));
+        } else {
+          context.ctxPayload.media = [{ path: "/tmp/sticker.webp", kind: "sticker" }];
+          context.ctxPayload.Sticker = { fileId: "sticker-file", fileUniqueId: "sticker-unique" };
+          describeStickerImage.mockImplementationOnce(async () => {
+            abortController.abort(new Error("handler-timeout"));
+            return null;
+          });
+        }
 
-    await expect(
-      dispatchWithContext({
-        context: createContext(),
-        turnAdoptionLifecycle: {
-          abortSignal: abortController.signal,
-          onAdopted: vi.fn(),
-          onDeferred: vi.fn(),
-          onAbandoned: vi.fn(),
-        },
-      }),
-    ).resolves.toEqual({ kind: "completed" });
+        await expect(
+          dispatchWithContext({
+            context,
+            streamMode: "off",
+            turnAdoptionLifecycle: {
+              abortSignal: abortController.signal,
+              onAdopted: vi.fn(),
+              onDeferred: vi.fn(),
+              onAbandoned: vi.fn(),
+            },
+          }),
+        ).resolves.toEqual({ kind: "completed" });
+        expect(createChannelMessageReplyPipeline).not.toHaveBeenCalled();
+        expect(describeStickerImage).toHaveBeenCalledTimes(abortAt === "before dispatch" ? 0 : 1);
 
-    expect(createChannelMessageReplyPipeline).not.toHaveBeenCalled();
-  });
+        await vi.advanceTimersByTimeAsync(31_000);
+        expect(setReaction.mock.calls).toEqual([["👀"]]);
+      } finally {
+        await controller.clear();
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("keeps Telegram typing below its client expiry without a per-message cutoff", async () => {
     await dispatchWithContext({ context: createContext() });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -388,6 +388,7 @@ export const dispatchTelegramMessage = async (
     // ingress watchdog. Never enter the reply pipeline after that owner has
     // already fenced this attempt; the canonical spool row will retry it.
     if (isDispatchSuperseded()) {
+      status.finalizeInBackground({ outcome: "cancelled" }, "cancelled finalize");
       return { kind: "completed" };
     }
     if (status.controller && !isRoomEvent) {


### PR DESCRIPTION
Closes #141078

## What Problem This Solves

A Telegram message could acquire a late stall reaction after its pre-dispatch preparation had already been canceled. A normal retry could even finish and restore the acknowledgment before the old attempt changed the reaction again.

## Why This Change Was Made

Use Telegram's existing status finalizer on the canceled preparation exit. It clears the old activity timers and restores the initial acknowledgment without showing success or error for that canceled attempt. The existing retry, adoption, delivery, and reaction owners remain unchanged.

## User Impact

Cancelled preparation no longer produces stale stall feedback. Normal successful retries still complete and restore the configured acknowledgment. No configuration, dependency, storage, or protocol change.

## Evidence

Real Telegram Test Server proof used a fresh user-sent sticker, a run-owned group, a delayed image-description endpoint, the supported 5-second ingress adoption timeout, and the unchanged 10/30-second status thresholds. Telegram reactions and durable ingress were real. The group's allowed heart/thumbs-up variants made the state change visible.

| Observation | Main `04b265be7fd8` | Candidate `e70e1008e5df` |
| --- | --- | --- |
| Initial acknowledgment | ❤ at 3.524s | ❤ at 3.455s |
| Normal durable retry | Completed | Completed |
| Acknowledgment restored after retry | ❤ at 14.669s | ❤ at 14.092s |
| Late reaction from the canceled attempt | 👍 at 32.404s | No later change through 45s |

- Each timeline is bound to that run's exact sent Telegram message. Separate source runs use fresh messages and isolated state.
- Both regression timings fail on the original production code with extra soft/hard reactions, then pass with the repair: cancellation already present at dispatch entry and cancellation during sticker preparation.
- 76 focused tests pass across the Telegram dispatch/status/room-event/dedupe and shared reaction-controller suites. Pinned formatting, targeted syntax lint, max-lines and assertion-safety checks pass. Full hosted CI remains a merge gate.
- Fresh independent source review found no blocking defect. A separate source-blind validator ran the real candidate scenario and confirmed the visible late reaction was removed.
- A later durable retry is a separate attempt; its legitimate provider request and answer are preserved. The real cancellation proof covers the during-description path; the before-entry case and other lifecycle controls have focused regression/source coverage rather than a second claimed live scenario.
- Earlier fixture failures remain recorded, including missing image tooling and Test Server reaction capability checks. A separate scheduled heartbeat observed during the candidate run is identified independently from the canceled sticker attempt. Its run-owned direct message was deleted and its absence verified; the original and cleanup credential releases were checked.

Original report and repair by @ooiuuii. Both contributor commits and credit are preserved in the integrated candidate.
