### PR TITLE
fix(codex): restore /btw cache and billing usage

### DIFF
--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -18,6 +18,12 @@ continuation, and native compaction. OpenClaw owns channel routing, session
 files, visible message delivery, OpenClaw dynamic tools, approvals, media
 delivery, and a transcript mirror around that boundary.
 
+Successful `/btw` side questions report aggregate usage to reply usage hooks and,
+when diagnostics are enabled, `model.usage` events. Totals include cache reads,
+cache writes, and every completed model call in the side thread's native tool
+loop; replayed response IDs are counted once. The visible reply still contains
+only the last answer, and the main session's usage and context snapshot stay unchanged.
+
 For native connected apps, Codex also owns the final per-thread app and tool
 policy. OpenClaw caches a runtime-and-workspace-scoped `plugin/installed`
 snapshot, reads exact configured plugin details, provisionally admits only

--- a/extensions/codex/src/app-server/ephemeral-turn.test.ts
+++ b/extensions/codex/src/app-server/ephemeral-turn.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { createFakeCodexAppServerClient } from "./codex-app-server.test-fixtures.js";
+import { CodexEphemeralTurn } from "./ephemeral-turn.js";
+import type { CodexTurn } from "./protocol.js";
+
+describe("CodexEphemeralTurn", () => {
+  it.each(["last", "all"] as const)(
+    "counts each completed response once with %s text aggregation",
+    async (textMode) => {
+      const fixture = createFakeCodexAppServerClient();
+      const collector = new CodexEphemeralTurn(fixture.client, "side-thread", { textMode });
+      const turn = {
+        id: "side-turn",
+        status: "inProgress",
+        items: [],
+        error: null,
+        startedAt: null,
+        completedAt: null,
+        durationMs: null,
+      } satisfies CodexTurn;
+      const responses = [
+        {
+          responseId: "first-response",
+          usage: {
+            inputTokens: 8,
+            cachedInputTokens: 2,
+            cacheWriteInputTokens: 1,
+            outputTokens: 4,
+            reasoningOutputTokens: 3,
+            totalTokens: 12,
+          },
+        },
+        {
+          responseId: "final-response",
+          usage: {
+            inputTokens: 15,
+            cachedInputTokens: 5,
+            cacheWriteInputTokens: 2,
+            outputTokens: 5,
+            reasoningOutputTokens: 2,
+            totalTokens: 20,
+          },
+        },
+      ];
+      try {
+        for (const response of [...responses, responses[0]]) {
+          await fixture.notify({
+            method: "rawResponse/completed",
+            params: { threadId: "side-thread", turnId: turn.id, ...response },
+          });
+        }
+        await fixture.notify({
+          method: "turn/completed",
+          params: {
+            threadId: "side-thread",
+            turn: {
+              ...turn,
+              status: "completed",
+              items: [
+                { id: "commentary", type: "agentMessage", text: "Checking the answer." },
+                { id: "answer", type: "agentMessage", text: "Final answer." },
+              ],
+            },
+          },
+        });
+        const result = await collector.wait(turn, {
+          signal: new AbortController().signal,
+          abortError: () => new Error("aborted"),
+        });
+        expect(result.text).toBe(
+          textMode === "last" ? "Final answer." : "Checking the answer.\n\nFinal answer.",
+        );
+        expect(result.usage).toEqual({
+          input: 13,
+          output: 9,
+          cacheRead: 7,
+          cacheWrite: 3,
+          reasoningTokens: 5,
+          total: responses.reduce((total, response) => total + response.usage.totalTokens, 0),
+          contextUsage: { state: "available", promptTokens: 15, totalTokens: 20 },
+        });
+      } finally {
+        collector.route.release();
+      }
+    },
+  );
+});

--- a/extensions/codex/src/app-server/ephemeral-turn.ts
+++ b/extensions/codex/src/app-server/ephemeral-turn.ts
@@ -54,10 +54,7 @@ export class CodexEphemeralTurn {
             if (firstDelta) {
               await options.onAssistantMessageStart?.();
             }
-          } else if (
-            notification.method === "rawResponse/completed" &&
-            options.textMode === "all"
-          ) {
+          } else if (notification.method === "rawResponse/completed") {
             this.usage.record(params);
           } else if (notification.method === "turn/completed") {
             this.turn = readCodexTurnCompletedNotification(params)?.turn ?? this.turn;

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -774,6 +774,43 @@ describe("runCodexAppServerSideQuestion", () => {
     }
   });
 
+  it("returns billed usage from the side thread without changing its answer", async () => {
+    const client = createFakeClient({ completeTurn: false });
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+    const run = runCodexAppServerSideQuestion(sideParams());
+    await vi.waitFor(() =>
+      expect(client.request.mock.calls.some(([method]) => method === "turn/start")).toBe(true),
+    );
+    client.emit({
+      method: "rawResponse/completed",
+      params: {
+        threadId: "side-thread",
+        turnId: "turn-1",
+        responseId: "side-response",
+        usage: {
+          inputTokens: 8,
+          cachedInputTokens: 2,
+          outputTokens: 4,
+          totalTokens: 12,
+          reasoningOutputTokens: 3,
+        },
+      },
+    });
+    client.emit(turnCompleted("side-thread", "turn-1", "Side answer."));
+    await expect(run).resolves.toEqual({
+      text: "Side answer.",
+      usage: {
+        input: 6,
+        output: 4,
+        cacheRead: 2,
+        cacheWrite: 0,
+        total: 12,
+        reasoningTokens: 3,
+        contextUsage: { state: "available", promptTokens: 8, totalTokens: 12 },
+      },
+    });
+  });
+
   it("forks an ephemeral side thread and returns the completed assistant text", async () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-09-02T00:30:00.000Z"));
     const client = createFakeClient();

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -1000,7 +1000,7 @@ export async function runCodexAppServerSideQuestion(
     if (!trimmed) {
       throw new Error("Codex /btw completed without an answer.");
     }
-    return { text: trimmed };
+    return { text: trimmed, usage: result.usage };
   } finally {
     try {
       // Cleanup aborts are ownership teardown, not a terminal run outcome.

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -3,7 +3,9 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { consumeReplyUsageState } from "../auto-reply/reply/reply-usage-state.js";
 import type { SessionEntry } from "../config/sessions.js";
+import { onInternalDiagnosticEvent } from "../infra/diagnostic-events.js";
 import type { ProviderResolveModelRoutesContext } from "../plugin-sdk/provider-model-types.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
@@ -1262,6 +1264,54 @@ describe("runBtwSideQuestion", () => {
       }),
     );
   });
+
+  it.each([false, true])(
+    "exposes side-question usage with diagnostics enabled: %s",
+    async (enabled) => {
+      const usage = { input: 13, output: 9, cacheRead: 7, cacheWrite: 3, total: 32 };
+      const harness = registerCodexSideQuestionHarness();
+      harness.mockResolvedValue({ text: "Codex side answer.", usage });
+      const runId = `btw-usage-reply-${enabled}`;
+      const authorityRunId = `btw-usage-authority-${enabled}`;
+      const sessionEntry = createSessionEntry({ inputTokens: 200, cacheRead: 100 });
+      const originalEntry = structuredClone(sessionEntry);
+      const diagnostics: unknown[] = [];
+      const unsubscribe = onInternalDiagnosticEvent((event) => {
+        if (event.type === "model.usage") {
+          diagnostics.push(event);
+        }
+      });
+      try {
+        await expect(
+          runSideQuestion({
+            cfg: { diagnostics: { enabled } },
+            sessionEntry,
+            authorityRunId,
+            opts: { runId },
+          }),
+        ).resolves.toEqual({ text: "Codex side answer." });
+        expect(consumeReplyUsageState(runId)).toMatchObject({ usage, sessionId: "session-1" });
+        expect(consumeReplyUsageState(authorityRunId)).toBeUndefined();
+        expect(sessionEntry).toEqual(originalEntry);
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(diagnostics).toEqual(
+          enabled
+            ? [
+                expect.objectContaining({
+                  type: "model.usage",
+                  sessionId: "session-1",
+                  usage: { ...usage, promptTokens: 23 },
+                }),
+              ]
+            : [],
+        );
+      } finally {
+        unsubscribe();
+      }
+    },
+  );
 
   it("keeps an unprofiled subscription token on the OpenClaw BTW path", async () => {
     const supports = vi.fn(supportsPreparedOpenAIAuth);

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -6,11 +6,16 @@ import { randomUUID } from "node:crypto";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { GetReplyOptions } from "../auto-reply/get-reply-options.types.js";
 import type { ReplyPayload } from "../auto-reply/reply-payload.js";
+import {
+  buildReplyUsageState,
+  recordReplyUsageState,
+} from "../auto-reply/reply/reply-usage-state.js";
 import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
 import type { ChatType } from "../channels/chat-type.js";
 import type { SessionEntry as StoredSessionEntry } from "../config/sessions.js";
 import { resolveCollapsedSessionAuthPinSource } from "../config/sessions/auth-profile-override-provenance.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { emitTrustedDiagnosticEvent, isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
 import { streamWithPayloadPatch } from "../llm/providers/stream-wrappers/stream-payload-utils.js";
 import type {
   AssistantMessageEvent,
@@ -90,6 +95,7 @@ import { stripToolResultDetails } from "./session-transcript-repair.js";
 import { getModelRegistryRuntime } from "./sessions/model-registry-runtime.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
 import { sanitizeImageBlocks } from "./tool-images.js";
+import { hasBillableUsage } from "./usage.js";
 
 function collectTextContent(content: Array<{ type?: string; text?: string }>): string {
   return content
@@ -1066,6 +1072,42 @@ export async function runBtwSideQuestion(
           result = await selectedHarness.runSideQuestion(sideParams);
         } finally {
           host.close();
+        }
+        if (hasBillableUsage(result.usage)) {
+          const usageState = buildReplyUsageState({
+            config: params.cfg,
+            agentDir: params.agentDir,
+            agentId: sessionAgentId,
+            sessionId,
+            provider: runtimeModel.provider,
+            model: runtimeModel.id,
+            chatType: params.chatType,
+            usage: result.usage,
+          });
+          // Delivery hooks use the reply correlation ID, not the side run's authority ID.
+          recordReplyUsageState(params.opts?.runId, usageState);
+          if (isDiagnosticsEnabled(params.cfg)) {
+            const { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 } = result.usage;
+            const promptTokens = input + cacheRead + cacheWrite;
+            emitTrustedDiagnosticEvent({
+              type: "model.usage",
+              sessionKey: params.sessionKey,
+              sessionId,
+              channel: params.messageChannel,
+              agentId: sessionAgentId,
+              provider: runtimeModel.provider,
+              model: runtimeModel.id,
+              usage: {
+                input,
+                output,
+                cacheRead,
+                cacheWrite,
+                promptTokens,
+                total: result.usage.total ?? promptTokens + output,
+              },
+              costUsd: usageState.turnUsd,
+            });
+          }
         }
         return { kind: "handled", payload: { text: result.text } };
       } finally {

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -281,6 +281,8 @@ export type AgentHarnessSideQuestionParamsV2 = AgentHarnessSideQuestionParams & 
 };
 export type AgentHarnessSideQuestionResult = {
   text: string;
+  /** Aggregate billed usage for the side question, including native tool-loop calls. */
+  usage?: import("../usage.js").NormalizedUsage;
 };
 export type AgentHarnessCompactParams =
   import("../embedded-agent-runner/compact.types.js").CompactEmbeddedAgentSessionParams;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch if needed.

</details>

## What Problem This Solves

Fixes an issue where users asking `/btw` side questions through the Codex harness would lose cache-read and billed-token accounting for the forked context, including completed model calls in native tool loops.

## Why This Change Was Made

Collect usage independently of text aggregation through the existing response-ID-deduplicating projector, return it through the optional harness result field, and forward it to existing reply usage metadata and enabled model diagnostics. The host uses the original reply correlation ID, while the side run retains its separate authority ID.

## User Impact

Reply usage hooks and `model.usage` diagnostics can observe successful Codex side-question billing and cache counters. The visible `/btw` reply remains the last answer, and the parent session's usage/context snapshot is preserved. No configuration, schema, or persistent-store changes. The Codex harness runtime docs explain this accounting boundary.

## Evidence

Regression-first proof: before the fix, last-text-mode usage was undefined, the side-question result contained only text, and reply usage metadata was absent. All four affected regression cases failed for those reasons; all-text-mode replay already passed.

```text
node scripts/run-vitest.mjs src/agents/btw.test.ts extensions/codex/src/app-server/side-question.test.ts extensions/codex/src/app-server/ephemeral-turn.test.ts extensions/codex/src/app-server/bounded-turn.test.ts extensions/codex/src/app-server/event-projector.usage.test.ts
Test Files: 5 passed
Tests: 210 passed (65 core + 145 Codex)
[test] passed 2 Vitest shards in 322.39s
```

The replay contains two unique completed responses plus a duplicate: 32 total tokens, including 7 cache reads and 3 cache writes, with unchanged last-answer text. After correcting test fixture typing and a Promise-executor lint issue, the ephemeral-turn tests passed again (2/2), all core `/btw` tests passed again (65/65), and all four typecheck lanes passed.

- `node scripts/check-changed.mjs`: final run exited 1 solely at the pre-declared nested-checkout `Declaration input escapes checkout ... qrcode` guard during extension lint. Every preceding gate passed, including all four typecheck lanes and core lint. All eight remaining commands from the generated check plan were run separately and passed; CI owns the blocked declaration/extension-lint lane.
- Final Codex autoreview at P0/P1: `scoped-clean`, 0 accepted/actionable findings; no unresolved findings. The reviewer assessed the supplied change bundle; tests were run separately as above.
- `git diff --check`: passed.

Production changes are +46/-5 lines (net +41), primarily the previously missing host accounting handoff. No live provider call was needed for this notification-replay and metadata propagation repair.
