### PR TITLE
fix: correct missing and misdirected Control UI notifications

### DIFF
--- a/docs/web/notifications.md
+++ b/docs/web/notifications.md
@@ -26,7 +26,7 @@ The macOS app deliberately uses the native permission flow instead of browser pu
 
 ## Enable browser notifications
 
-The Control UI asks for notification permission automatically the first time you send a chat message, once per browser and origin. **Settings → Notifications** remains the manual path for enabling or repairing notifications, including after you deny the automatic prompt.
+The Control UI asks for notification permission automatically the first time you send a chat message, including from **New Session** or **Start in background**, once per browser and origin. **Settings → Notifications** remains the manual path for enabling or repairing notifications, including after you deny the automatic prompt.
 
 1. Open the Control UI in a browser that supports service workers, `PushManager`, and notifications.
 2. Make sure the Control UI is connected to the Gateway.
@@ -48,6 +48,8 @@ After subscribing, **Settings → Notifications** exposes two preference layers:
 Single-user Gateways use their durable owner profile for account defaults, so those preferences follow the owner across devices. Connections without a profile keep the controls but store preferences only with the current browser subscription. Preferences never grant access: every delivery still rechecks the paired device, current role and scopes, authenticated profile, and session visibility. Multi-user events without an authoritative session owner are suppressed instead of being broadcast to every operator.
 
 The default preserves the original behavior: approval request and resolution notifications are enabled, while newly added attention categories are opt-in. Quiet hours suppress matching sends rather than queueing stale alerts for later delivery.
+
+Selecting an attention notification opens its question, conversation, or automation run on the Gateway that produced it. **Agent finished** waits for completion; a parent waiting for child agents does not count as finished. Automation failures use **Scheduled task failures**, without also generating a **Background task failures** alert for the same run.
 
 The detail levels are:
 
@@ -109,6 +111,10 @@ Either the browser lacks the required Web Push APIs or the Control UI is not con
 ### Browser permission is blocked
 
 A denied browser permission cannot be reopened from the page. Allow notifications for the Control UI origin in the browser's site settings, then reload Settings.
+
+### Permission is granted but the browser is not subscribed
+
+Browser permission and the Gateway subscription are separate. Select **Enable notifications** to register this browser, then enable the categories you want, such as **Someone mentions me**. Reloading or sending another message does not automatically subscribe a browser whose permission is already granted; this preserves an intentional unsubscribe.
 
 ### Service worker is not ready
 

--- a/src/gateway/event-web-push.test.ts
+++ b/src/gateway/event-web-push.test.ts
@@ -156,8 +156,13 @@ describe("event Web Push classification", () => {
 
   afterEach(() => vi.restoreAllMocks());
 
-  it("sends only final chat events as agent completion", async () => {
+  it("waits for final completion after a parent yields to its children", async () => {
     const delivery = createEventWebPushDelivery({ getRuntimeConfig: () => ({}) });
+    delivery.handleEvent("chat", { state: "delta", runId: "run-1" });
+    delivery.handleEvent("chat", { state: "final", runId: "run-1", yielded: true });
+    await Promise.resolve();
+    expect(preparedWebPushSendMock).not.toHaveBeenCalled();
+
     delivery.handleEvent("chat", { state: "final", runId: "run-1" });
     await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledOnce());
     expect(preparedWebPushSendMock).toHaveBeenCalledWith(
@@ -165,10 +170,75 @@ describe("event Web Push classification", () => {
         payload: expect.objectContaining({ tag: "openclaw-agent-finished-run-1" }),
       }),
     );
+  });
 
-    preparedWebPushSendMock.mockClear();
-    delivery.handleEvent("chat", { state: "delta", runId: "run-1" });
-    expect(preparedWebPushSendMock).not.toHaveBeenCalled();
+  it.each([
+    {
+      event: "question.requested",
+      payload: { id: "question:1" },
+      path: "ask/question%3A1",
+    },
+    {
+      event: "chat",
+      payload: { state: "final", runId: "run-1", sessionKey: "agent:research:thread.1" },
+      path: "chat/research/thread%2E1",
+    },
+    {
+      event: "task",
+      payload: {
+        action: "upserted",
+        task: { id: "task-1", runtime: "subagent", status: "failed" },
+      },
+      path: "chat/research/thread%2E1",
+    },
+    {
+      event: "cron",
+      payload: { action: "finished", jobId: "nightly", status: "error", runAtMs: 1234 },
+      path: "automations?job=nightly&run=cron%3Anightly%3A1234",
+    },
+  ])(
+    "opens the $event attention target on its originating Gateway",
+    async ({ event, payload, path }) => {
+      listDevicePairingMock.mockReturnValue({
+        paired: [pairedOperator("browser-device", ["operator.read", "operator.questions"])],
+      });
+      const delivery = createEventWebPushDelivery({
+        getRuntimeConfig: () => ({
+          gateway: {
+            publicOrigin: "https://gateway.example.test",
+            controlUi: { basePath: "/operator" },
+          },
+        }),
+      });
+
+      delivery.handleEvent(event, payload, {
+        sessionKeys: ["agent:research:thread.1"],
+        agentId: "research",
+      });
+
+      await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledOnce());
+      expect(preparedWebPushSendMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            url: `${path}#gatewayUrl=wss%3A%2F%2Fgateway.example.test%2Foperator`,
+          }),
+        }),
+      );
+    },
+  );
+
+  it("uses the session hub when the event has no prepared session scope", async () => {
+    const delivery = createEventWebPushDelivery({ getRuntimeConfig: () => ({}) });
+    delivery.handleEvent("chat", {
+      state: "final",
+      runId: "run-1",
+      sessionKey: "agent:research:thread.1",
+    });
+
+    await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledOnce());
+    expect(preparedWebPushSendMock).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: expect.objectContaining({ url: "sessions" }) }),
+    );
   });
 
   it("does not treat injected transcript updates as agent completion", async () => {
@@ -291,6 +361,43 @@ describe("event Web Push classification", () => {
       }),
     );
   });
+
+  it.each([false, true])(
+    "uses only the scheduled failure preference for cron tracking tasks (enabled: %s)",
+    async (scheduledTaskFailed) => {
+      const subscription = boundSubscription("browser-device");
+      subscription.devicePreferences.categories = {
+        backgroundTaskFailed: true,
+        scheduledTaskFailed,
+      };
+      listBoundWebPushSubscriptionsMock.mockReturnValue([subscription]);
+      const delivery = createEventWebPushDelivery({ getRuntimeConfig: () => ({}) });
+
+      delivery.handleEvent("task", {
+        action: "upserted",
+        task: { id: "task-cron", kind: "automation_run", runtime: "cron", status: "failed" },
+      });
+      await Promise.resolve();
+      expect(preparedWebPushSendMock).not.toHaveBeenCalled();
+
+      delivery.handleEvent("cron", {
+        action: "finished",
+        jobId: "nightly",
+        status: "error",
+      });
+      if (scheduledTaskFailed) {
+        await vi.waitFor(() => expect(preparedWebPushSendMock).toHaveBeenCalledOnce());
+        expect(preparedWebPushSendMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            payload: expect.objectContaining({ title: "OpenClaw scheduled task failed" }),
+          }),
+        );
+      } else {
+        await Promise.resolve();
+        expect(preparedWebPushSendMock).not.toHaveBeenCalled();
+      }
+    },
+  );
 
   it("rereads subscriptions after transport preparation before sending", async () => {
     const stale = boundSubscription("stale-device");

--- a/src/gateway/event-web-push.ts
+++ b/src/gateway/event-web-push.ts
@@ -4,6 +4,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { buildControlUiSessionPath } from "@openclaw/session-url-contract";
 import type { WebPushNotificationCategory } from "../../packages/gateway-protocol/src/schema/push.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createCronExecutionId } from "../cron/run-id.js";
 import {
   WEB_PUSH_USER_PREFERENCES_KEY,
   isWebPushQuietHours,
@@ -41,6 +42,7 @@ type EventNotification = {
   body: string;
   identifiedBody?: string;
   tag: string;
+  path?: string;
 };
 
 export type HumanMentionWebPush = {
@@ -63,16 +65,19 @@ function resolveEventWebPushNotification(
   }
   if (event === "question.requested") {
     const id = normalizeWebPushDisplayLabel(value.id) ?? "pending";
+    const questionId = normalizeOptionalString(value.id);
     return {
       category: "agent-question",
       title: "OpenClaw needs an answer",
       body: "An agent has a question for you.",
       tag: `openclaw-question-${id}`,
+      ...(questionId ? { path: `ask/${encodeURIComponent(questionId)}` } : {}),
     };
   }
   if (
     event === "chat" &&
     value.state === "final" &&
+    value.yielded !== true &&
     !isTranscriptOnlyOpenClawAssistantMessage(value.message)
   ) {
     const runId = normalizeWebPushDisplayLabel(value.runId) ?? "finished";
@@ -85,7 +90,7 @@ function resolveEventWebPushNotification(
   }
   if (event === "task" && value.action === "upserted") {
     const task = isRecord(value.task) ? value.task : null;
-    if (task?.status !== "failed" && task?.status !== "timed_out") {
+    if ((task?.status !== "failed" && task?.status !== "timed_out") || task.runtime === "cron") {
       return null;
     }
     const taskId = normalizeWebPushDisplayLabel(task.id) ?? "failed";
@@ -100,14 +105,30 @@ function resolveEventWebPushNotification(
   }
   if (event === "cron" && value.action === "finished" && value.status === "error") {
     const job = isRecord(value.job) ? value.job : null;
-    const jobId = normalizeWebPushDisplayLabel(value.jobId) ?? "failed";
+    const jobId = normalizeOptionalString(value.jobId);
+    const jobTag = normalizeWebPushDisplayLabel(jobId) ?? "failed";
     const jobName = normalizeWebPushDisplayLabel(job?.name);
+    const query = new URLSearchParams();
+    if (jobId) {
+      query.set("job", jobId);
+      const runId =
+        normalizeOptionalString(value.runId) ??
+        (typeof value.runAtMs === "number" &&
+        Number.isSafeInteger(value.runAtMs) &&
+        value.runAtMs >= 0
+          ? createCronExecutionId(jobId, value.runAtMs)
+          : undefined);
+      if (runId) {
+        query.set("run", runId);
+      }
+    }
     return {
       category: "scheduled-task-failed",
       title: "OpenClaw scheduled task failed",
       body: "A scheduled task needs attention.",
       ...(jobName ? { identifiedBody: `${jobName} needs attention.` } : {}),
-      tag: `openclaw-cron-failed-${jobId}`,
+      tag: `openclaw-cron-failed-${jobTag}`,
+      path: `automations${query.size ? `?${query}` : ""}`,
     };
   }
   return null;
@@ -152,11 +173,16 @@ export function createEventWebPushDelivery(params: {
       if (mention && !recipientProfileId) {
         return;
       }
-      const sessionPath = mention
+      const agentId = normalizeOptionalString(
+        opts?.agentId ?? (isRecord(payload) ? payload.agentId : undefined),
+      );
+      const sessionKeys = opts?.sessionKeys ?? [];
+      const sessionKey = mention?.sessionKey ?? sessionKeys[0];
+      const sessionPath = sessionKey
         ? buildControlUiSessionPath({
             namespace: "chat",
-            sessionKey: mention.sessionKey,
-            fallbackAgentId: mention.agentId,
+            sessionKey,
+            fallbackAgentId: agentId,
             mainKey: cfg.session?.mainKey,
             exactKey: true,
           })
@@ -164,7 +190,11 @@ export function createEventWebPushDelivery(params: {
       if (mention && !sessionPath) {
         return;
       }
-      const url = sessionPath ? resolveControlUiWebPushUrl(cfg, sessionPath.slice(1)) : undefined;
+      const path =
+        notification.path ??
+        sessionPath?.slice(1) ??
+        (notification.category === "background-task-failed" ? "tasks" : "sessions");
+      const url = resolveControlUiWebPushUrl(cfg, path);
       const targets = listCurrentWebPushTargets({
         cfg,
         requiredScopes:
@@ -172,9 +202,6 @@ export function createEventWebPushDelivery(params: {
         ...(mention ? { visibilityScopes: [ADMIN_SCOPE] } : {}),
         stateDir: params.stateDir,
       });
-      const agentId = normalizeOptionalString(
-        opts?.agentId ?? (isRecord(payload) ? payload.agentId : undefined),
-      );
       const agentLabel = normalizeWebPushDisplayLabel(agentId);
       const groups = new Map<
         string,
@@ -192,7 +219,6 @@ export function createEventWebPushDelivery(params: {
         ) {
           continue;
         }
-        const sessionKeys = opts?.sessionKeys ?? [];
         if (
           sessionKeys.length > 0 &&
           !canReceiveSessionEvent({
@@ -238,7 +264,7 @@ export function createEventWebPushDelivery(params: {
                 body: group.body,
                 tag: notification.tag,
                 renotify: false,
-                ...(url ? { url } : {}),
+                url,
               },
               deliveryOptions: {
                 TTL: EVENT_PUSH_TTL_SECONDS,

--- a/ui/src/components/sidebar-attention-store.test.ts
+++ b/ui/src/components/sidebar-attention-store.test.ts
@@ -119,6 +119,54 @@ describe("sidebar attention source publication", () => {
     );
   });
 
+  it.each(["hidden", "disposed"] as const)(
+    "does not restart a changed inventory snapshot after becoming %s during append",
+    async (boundary) => {
+      let visibility: DocumentVisibilityState = "visible";
+      vi.spyOn(document, "visibilityState", "get").mockImplementation(() => visibility);
+      const pendingAppend = deferred<CronJobsListResult>();
+      const offsets: number[] = [];
+      const request = vi.fn(async (method: string, params?: unknown) => {
+        if (method === "cron.list") {
+          const offset = isRecord(params) ? Number(params.offset ?? 0) : 0;
+          offsets.push(offset);
+          if (offset === 1) {
+            return pendingAppend.promise;
+          }
+          return offsets.length === 1
+            ? { ...cronPage("previous"), total: 2, hasMore: true, nextOffset: 1 }
+            : cronPage("current");
+        }
+        return method === "cron.status"
+          ? { enabled: true, triggersEnabled: true, jobs: 2 }
+          : { ts: 1, providers: [] };
+      });
+      const harness = createGatewayHarness(mockClient(request));
+      store = createStore(harness.gateway);
+      store.activate(SidebarAttentionStoreController);
+      await waitForFast(() => expect(offsets).toEqual([0, 1]));
+
+      if (boundary === "hidden") {
+        visibility = "hidden";
+        document.dispatchEvent(new Event("visibilitychange"));
+      } else {
+        store.dispose();
+      }
+      pendingAppend.resolve({ ...cronPage("changed"), total: 2, offset: 1 });
+      await new Promise<void>((resolve) => {
+        globalThis.setTimeout(resolve, 0);
+      });
+      expect(offsets).toEqual([0, 1]);
+
+      if (boundary === "hidden") {
+        visibility = "visible";
+        document.dispatchEvent(new Event("visibilitychange"));
+        await waitForFast(() => expect(store?.entries).toMatchObject([{ label: "current" }]));
+        expect(offsets).toEqual([0, 1, 0]);
+      }
+    },
+  );
+
   it.each(["list", "status"] as const)(
     "coalesces cron bursts until the whole inventory pair settles (%s first)",
     async (first) => {

--- a/ui/src/components/sidebar-attention-store.test.ts
+++ b/ui/src/components/sidebar-attention-store.test.ts
@@ -1,5 +1,6 @@
 /* @vitest-environment jsdom */
 
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MentionInboxItem } from "../../../packages/gateway-protocol/src/index.js";
 import type { CronJobsListResult, CronStatus, ModelAuthStatusResult } from "../api/types.ts";
@@ -76,6 +77,47 @@ describe("sidebar attention source publication", () => {
       scopeUpgrade: hiddenScopeUpgradeCapability,
     });
   }
+
+  it("includes failed automations beyond the first inventory page", async () => {
+    const healthy = cronPage("healthy").jobs[0]!;
+    const jobs = [
+      ...Array.from({ length: 50 }, (_, index) => ({
+        ...healthy,
+        id: `healthy-${index}`,
+        state: { lastRunStatus: "ok" as const },
+      })),
+      ...cronPage("later-failure").jobs,
+    ];
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "cron.list") {
+        const pagination = isRecord(params) ? params : {};
+        const offset = Number(pagination.offset ?? 0);
+        const limit = Number(pagination.limit ?? 50);
+        const nextOffset = Math.min(offset + limit, jobs.length);
+        return {
+          jobs: jobs.slice(offset, nextOffset),
+          snapshotRevision: "all-jobs",
+          total: jobs.length,
+          offset,
+          limit,
+          hasMore: nextOffset < jobs.length,
+          nextOffset: nextOffset < jobs.length ? nextOffset : null,
+        };
+      }
+      return method === "cron.status"
+        ? { enabled: true, triggersEnabled: true, jobs: jobs.length }
+        : { ts: 1, providers: [] };
+    });
+    const harness = createGatewayHarness(mockClient(request));
+    store = createStore(harness.gateway);
+    store.activate(SidebarAttentionStoreController);
+
+    await waitForFast(() =>
+      expect(store?.entries).toMatchObject([
+        { type: "attention", kind: "cronFailed", label: "later-failure" },
+      ]),
+    );
+  });
 
   it.each(["list", "status"] as const)(
     "coalesces cron bursts until the whole inventory pair settles (%s first)",
@@ -270,13 +312,20 @@ describe("sidebar attention source publication", () => {
         });
       }
       pages[3]!.resolve({ ...cronPage("partial"), hasMore: true, total: 2, nextOffset: 1 });
-      await waitForFast(() => expect(store?.entries).toMatchObject([{ label: "partial" }]));
+      await waitForFast(() => expect(listCalls).toBe(5));
+      expect(store?.entries).toMatchObject([{ label: "current-2" }]);
       expect(loadDismissals(harness.gateway.connection.gatewayUrl)).toEqual({
         cronFailed: ["dismissed"],
       });
-      harness.emitEvent("cron", {});
-      pages[4]!.resolve(cronPage("fresh"));
-      await waitForFast(() => expect(store?.entries).toMatchObject([{ label: "fresh" }]));
+      pages[4]!.resolve({
+        ...cronPage("fresh"),
+        snapshotRevision: "partial",
+        total: 2,
+        offset: 1,
+      });
+      await waitForFast(() =>
+        expect(store?.entries).toMatchObject([{ label: "partial" }, { label: "fresh" }]),
+      );
       expect(loadDismissals(harness.gateway.connection.gatewayUrl)).toEqual({});
     } finally {
       store.dispose();

--- a/ui/src/components/sidebar-attention-store.ts
+++ b/ui/src/components/sidebar-attention-store.ts
@@ -236,6 +236,7 @@ export class SidebarAttentionStoreController implements StoreController {
             }
             refresh.requested = false;
             const cron = createInitialCronState({ client, connected: true });
+            cron.canRefresh = canRefreshCron;
             cron.cronAgentId = agentScope.scopeId;
             await Promise.all([loadCronJobsPage(cron), loadCronStatus(cron)]);
             while (

--- a/ui/src/components/sidebar-attention-store.ts
+++ b/ui/src/components/sidebar-attention-store.ts
@@ -224,12 +224,13 @@ export class SidebarAttentionStoreController implements StoreController {
     if (!this.cronRefreshNeeded && this.cronRefresh?.generation !== generation) {
       const refresh = { generation, requested: true };
       this.cronRefresh = refresh;
+      const canRefreshCron = () => current() && document.visibilityState !== "hidden";
       void (async () => {
         try {
           // One scope owns both reads. Events during either read request one
           // trailing inventory; retired scopes never drain queued network work.
           while (refresh.requested && current()) {
-            if (document.visibilityState === "hidden") {
+            if (!canRefreshCron()) {
               this.cronRefreshNeeded = true;
               break;
             }
@@ -237,8 +238,16 @@ export class SidebarAttentionStoreController implements StoreController {
             const cron = createInitialCronState({ client, connected: true });
             cron.cronAgentId = agentScope.scopeId;
             await Promise.all([loadCronJobsPage(cron), loadCronStatus(cron)]);
+            while (
+              canRefreshCron() &&
+              cron.cronJobsHasMore &&
+              !cron.cronJobsError &&
+              !refresh.requested
+            ) {
+              await loadCronJobsPage(cron, { append: true });
+            }
             if (current()) {
-              if (!cron.cronJobsError) {
+              if (!cron.cronJobsError && !cron.cronJobsHasMore) {
                 this.cronJobs = cron.cronJobs;
               }
               if (!cron.cronError) {
@@ -255,6 +264,9 @@ export class SidebarAttentionStoreController implements StoreController {
                   !cron.cronError,
                 modelAuthAgentId: null,
               });
+              if (cron.cronJobsHasMore && !canRefreshCron()) {
+                this.cronRefreshNeeded = true;
+              }
             }
           }
         } finally {

--- a/ui/src/e2e/native-notifications-loading.e2e.test.ts
+++ b/ui/src/e2e/native-notifications-loading.e2e.test.ts
@@ -15,72 +15,110 @@ const suite = createControlUiE2eSuite({
 });
 
 suite.define(() => {
-  it.each([false, true])("loads notifications only for a native host: %s", async (native) => {
-    const viewport = { width: 1360, height: 1000 };
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport,
-        recordVideo: { dir: suite.artifactDir, size: viewport },
-      },
-      async ({ page }) => {
-        const notificationModules: string[] = [];
-        const errors: string[] = [];
-        page.on("pageerror", (error) => errors.push(error.message));
-        page.on("request", (request) => {
-          if (new URL(request.url()).pathname.endsWith("/app/native-notifications.ts")) {
-            notificationModules.push(request.url());
-          }
-        });
-        if (native) {
-          await page.addInitScript(() => {
-            const messages: NotificationProof[] = [];
-            Object.assign(window, {
-              notificationProof: messages,
-              __OPENCLAW_NATIVE_NOTIFICATIONS__: { permission: "notDetermined" },
-              webkit: {
-                messageHandlers: {
-                  openclawNotifications: {
-                    postMessage(message: { type: string }) {
-                      messages.push({
-                        type: message.type,
-                        event: window.event?.type ?? null,
-                        userActivation: navigator.userActivation.isActive,
-                      });
+  it.each([
+    { native: false, route: "chat", background: false },
+    { native: true, route: "chat", background: false },
+    { native: true, route: "new", background: false },
+    { native: true, route: "new", background: true },
+  ] as const)(
+    "preserves notification startup with native=$native route=$route background=$background",
+    async ({ native, route, background }) => {
+      const viewport = { width: 1360, height: 1000 };
+      await suite.withPage(
+        {
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport,
+          recordVideo: { dir: suite.artifactDir, size: viewport },
+        },
+        async ({ page }) => {
+          const notificationModules: string[] = [];
+          const errors: string[] = [];
+          page.on("pageerror", (error) => errors.push(error.message));
+          page.on("request", (request) => {
+            if (new URL(request.url()).pathname.endsWith("/app/native-notifications.ts")) {
+              notificationModules.push(request.url());
+            }
+          });
+          if (native) {
+            await page.addInitScript(() => {
+              const messages: NotificationProof[] = [];
+              Object.assign(window, {
+                notificationProof: messages,
+                __OPENCLAW_NATIVE_NOTIFICATIONS__: { permission: "notDetermined" },
+                webkit: {
+                  messageHandlers: {
+                    openclawNotifications: {
+                      postMessage(message: { type: string }) {
+                        messages.push({
+                          type: message.type,
+                          event: window.event?.type ?? null,
+                          userActivation: navigator.userActivation.isActive,
+                        });
+                      },
                     },
                   },
                 },
-              },
+              });
             });
+          }
+          const gateway = await installMockGateway(page, {
+            historyMessages: [],
+            methodResponses: {
+              "sessions.create": {
+                key: "agent:main:notification-onboarding",
+                initialRun: { status: "idle" },
+              },
+            },
           });
-        }
-        const gateway = await installMockGateway(page, { historyMessages: [] });
-        await page.goto(`${suite.server.baseUrl}chat`);
-        const composer = page.locator(".agent-chat__composer-combobox textarea");
-        await composer.fill("Check notification startup.");
-        expect(notificationModules).toHaveLength(native ? 1 : 0);
-        await page.screenshot({ path: path.join(suite.artifactDir, "ready.png") });
-        await page.getByRole("button", { name: "Send message", exact: true }).click();
-        const request = await gateway.waitForRequest("chat.send");
-        expect(request.params).toMatchObject({ message: "Check notification startup." });
-        if (native) {
-          const messages = await page.evaluate(
-            () =>
-              (window as typeof window & { notificationProof: NotificationProof[] })
-                .notificationProof,
+          await page.goto(`${suite.server.baseUrl}${route}`);
+          const composer = page.locator(
+            route === "new"
+              ? ".new-session-page__composer textarea"
+              : ".agent-chat__composer-combobox textarea",
           );
-          expect(messages).toContainEqual({ type: "status", event: null, userActivation: false });
-          expect(messages).toContainEqual({
-            type: "request-permission",
-            event: "click",
-            userActivation: true,
-          });
-        }
-        expect(notificationModules).toHaveLength(native ? 1 : 0);
-        expect(errors).toEqual([]);
-        await page.screenshot({ path: path.join(suite.artifactDir, "sent.png") });
-      },
-    );
-  });
+          await composer.fill("Check notification startup.");
+          expect(notificationModules).toHaveLength(native ? 1 : 0);
+          await page.screenshot({ path: path.join(suite.artifactDir, "ready.png") });
+          if (background) {
+            await expect
+              .poll(() =>
+                page
+                  .getByRole("button", { name: "Start session", exact: true })
+                  .getAttribute("aria-disabled"),
+              )
+              .toBe("false");
+            await composer.press("Control+Enter");
+          } else {
+            await page
+              .getByRole("button", {
+                name: route === "new" ? "Start session" : "Send message",
+                exact: true,
+              })
+              .click();
+          }
+          const request = await gateway.waitForRequest(
+            route === "new" ? "sessions.create" : "chat.send",
+          );
+          expect(request.params).toMatchObject({ message: "Check notification startup." });
+          if (native) {
+            const messages = await page.evaluate(
+              () =>
+                (window as typeof window & { notificationProof: NotificationProof[] })
+                  .notificationProof,
+            );
+            expect(messages).toContainEqual({ type: "status", event: null, userActivation: false });
+            expect(messages).toContainEqual({
+              type: "request-permission",
+              event: background ? "keydown" : "click",
+              userActivation: true,
+            });
+          }
+          expect(notificationModules).toHaveLength(native ? 1 : 0);
+          expect(errors).toEqual([]);
+          await page.screenshot({ path: path.join(suite.artifactDir, "sent.png") });
+        },
+      );
+    },
+  );
 });

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -1,6 +1,12 @@
 import type { ProjectsAddResult } from "../../../../packages/gateway-protocol/src/index.js";
+import {
+  autoPromptNotificationsOnSend,
+  hasActiveNotificationPromptGesture,
+  shouldAutoPromptNotificationsOnSend,
+} from "../../app/notifications-auto-prompt.ts";
 import { t } from "../../i18n/index.ts";
 import type { ChatAttachment, HumanMention } from "../../lib/chat/chat-types.ts";
+import { parseSlashCommand } from "../../lib/chat/commands.ts";
 import { resolveCurrentUserIdentity } from "../../lib/chat/current-user-identity.ts";
 import { trimHumanMentions, updateHumanMentions } from "../../lib/chat/human-mentions.ts";
 import {
@@ -438,9 +444,20 @@ export class DraftSubmissionFlow {
       }
       this.startedSession.current = null;
       const placementTarget = startup ? null : this.placement().target;
-      const hasInitialTurn = message || apiAttachments?.length;
+      // Creation and placement can await; permission must keep the original input event.
+      if (
+        shouldAutoPromptNotificationsOnSend({
+          connected: context.gateway.snapshot.phase === "connected",
+          directComposerSend: !startup && !pendingPlacement && hasActiveNotificationPromptGesture(),
+          message,
+          hasAttachments: Boolean(apiAttachments?.length),
+          isCommand: parseSlashCommand(message) !== null,
+        })
+      ) {
+        autoPromptNotificationsOnSend(context);
+      }
       const remoteProject =
-        !startup && !pendingPlacement && !placementTarget && !hasInitialTurn
+        !startup && !pendingPlacement && !placementTarget && !message && !apiAttachments?.length
           ? this.place.browser.remoteProject
           : null;
       if (remoteProject && !remoteProject.projectId && !this.place.browser.projectId) {

--- a/ui/src/pages/new-session/draft-submission-notifications.test.ts
+++ b/ui/src/pages/new-session/draft-submission-notifications.test.ts
@@ -1,0 +1,132 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { createNativeNotificationsCapability } from "../../app/native-notifications.ts";
+import { CHAT_ROUTE_READY_EVENT } from "../../app/route-transition.ts";
+import { createDraftFixture } from "./draft-submission-flow.test-support.ts";
+import type { DraftSubmissionFlow } from "./draft-submission-flow.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  sessionStorage.clear();
+  localStorage.clear();
+});
+
+function notificationFixture(surface: "web" | "native") {
+  const fixture = createDraftFixture();
+  const permissionGestures: (Event | undefined)[] = [];
+  const browserPermission = vi.fn(() => {
+    permissionGestures.push(window.event);
+    return Promise.resolve("granted" as NotificationPermission);
+  });
+  vi.stubGlobal("Notification", { requestPermission: browserPermission });
+  const postMessage = vi.fn((message: { type: string }) => {
+    if (message.type === "request-permission") {
+      permissionGestures.push(window.event);
+    }
+  });
+  if (surface === "native") {
+    vi.stubGlobal("webkit", {
+      messageHandlers: { openclawNotifications: { postMessage } },
+    });
+    vi.stubGlobal("__OPENCLAW_NATIVE_NOTIFICATIONS__", {
+      permission: "notDetermined",
+      test: null,
+    });
+  }
+  const nativeNotifications = surface === "native" ? createNativeNotificationsCapability() : null;
+  onTestFinished(() => nativeNotifications?.dispose());
+  const enable = vi.fn(async () => undefined);
+  Object.assign(fixture.context, {
+    nativeNotifications,
+    webPush: {
+      snapshot: {
+        supported: true,
+        permission: "default",
+        subscription: "unknown",
+        loading: false,
+      },
+      run: enable,
+      subscribe: () => () => {},
+      dispose: () => {},
+    },
+  });
+  vi.mocked(fixture.context.sessions.createResult).mockResolvedValue({
+    key: "agent:main:dashboard:notification-onboarding",
+    initialRun: { status: "idle" },
+  });
+  vi.mocked(fixture.context.navigateAndWait).mockImplementation(async () => {
+    queueMicrotask(() => document.dispatchEvent(new Event(CHAT_ROUTE_READY_EVENT)));
+  });
+  fixture.flow.setMessage("Start the first conversation");
+  return { ...fixture, browserPermission, enable, permissionGestures, postMessage };
+}
+
+function submitFromClick(flow: DraftSubmissionFlow, background = false) {
+  const button = document.createElement("button");
+  let submission: ReturnType<DraftSubmissionFlow["submit"]> | undefined;
+  button.addEventListener("click", () => {
+    submission = flow.submit(undefined, background);
+  });
+  button.click();
+  return expectDefined(submission, "clicked New Session submission");
+}
+
+describe("New Session notification onboarding", () => {
+  it.each([
+    { surface: "web", background: false },
+    { surface: "web", background: true },
+    { surface: "native", background: false },
+    { surface: "native", background: true },
+  ] as const)(
+    "prompts $surface synchronously and only once when background=$background",
+    async ({ surface, background }) => {
+      const { context, flow, browserPermission, enable, permissionGestures, postMessage } =
+        notificationFixture(surface);
+
+      const first = submitFromClick(flow, background);
+
+      expect(permissionGestures).toHaveLength(1);
+      expect(permissionGestures[0]?.type).toBe("click");
+      expect(enable).not.toHaveBeenCalled();
+      await first;
+      expect(context.sessions.createResult).toHaveBeenCalledOnce();
+      if (surface === "web") {
+        expect(browserPermission).toHaveBeenCalledOnce();
+        expect(enable).toHaveBeenCalledExactlyOnceWith({ kind: "enable" });
+      } else {
+        expect(postMessage).toHaveBeenCalledWith({ type: "request-permission" });
+        expect(browserPermission).not.toHaveBeenCalled();
+        expect(enable).not.toHaveBeenCalled();
+      }
+
+      flow.setMessage("Start another conversation");
+      await submitFromClick(flow, background);
+
+      expect(context.sessions.createResult).toHaveBeenCalledTimes(2);
+      expect(permissionGestures).toHaveLength(1);
+    },
+  );
+
+  it.each(["programmatic", "empty", "command", "blocked"] as const)(
+    "does not spend the first-send prompt on a %s submission",
+    async (scenario) => {
+      const { context, flow, browserPermission, enable } = notificationFixture("web");
+      if (scenario === "empty") {
+        flow.setMessage("");
+      } else if (scenario === "command") {
+        flow.setMessage("/status");
+      } else if (scenario === "blocked") {
+        flow.attachmentDraft.updatePending(flow.attachmentDraft.readSignal, 1);
+      }
+
+      await (scenario === "programmatic" ? flow.submit() : submitFromClick(flow));
+
+      expect(browserPermission).not.toHaveBeenCalled();
+      expect(enable).not.toHaveBeenCalled();
+      if (scenario === "blocked") {
+        expect(context.sessions.createResult).not.toHaveBeenCalled();
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes #141035

## What Problem This Solves

Fixes an issue where Control UI users miss automation failures beyond the first 50 jobs, receive premature completion or duplicate failure alerts, and open an unrelated chat when selecting a notification. First messages sent from New Session also skipped notification permission onboarding.

## Why This Change Was Made

The Inbox now publishes a complete automation inventory, retaining its prior state while later pages load. Browser alerts use prepared session scope or the existing question/automation routes, preserve the originating Gateway, wait for yielded parent runs to finish, and classify cron tracking records only through scheduled-failure delivery. New Session uses the existing notification prompt owner within the original input gesture.

## User Impact

Users can find failures across the full automation inventory and open the question, conversation, or automation run needing attention. Normal and background New Session starts participate in one-time notification onboarding. Existing category preferences, intentional unsubscribes, profile/session authorization, and temporary mention retention remain intact.

## Evidence

- Original regressions failed before repair: missing later-page automation, yielded completion, four notification destinations, duplicate cron categories, and web/native foreground/background onboarding.
- Follow-up regression proof protects complete-page publication, prepared-scope navigation, and cancellation of internal snapshot recovery after hide/disposal. The two recovery cases failed before the final guard; all 239 store/cron tests passed afterward. Focused Gateway/approval and UI suites passed; the final UI follow-up passed 57 tests.
- Four Chromium E2E cases passed, including native-bridge permission requests with live click/keyboard user activation.
- The initial CI run passed every selected lane except six existing native Mermaid browser tests. The clipboard suite leaked its module mock into the native suite on the same non-isolated worker; that baseline defect was repaired separately in merged PR #141092. The next CI attempt passed all selected test lanes but hit an existing Telegram test-size lint failure. That baseline is repaired separately in #141139 and #141148, now included here. Both notification patches are unchanged across the refreshes; the latest refresh passed 91 focused Gateway/UI tests.
- The latest full CI attempt cleared lint and UI but failed two CLI/tooling shards; GitHub log-storage downloads were inaccessible from two networks, so the exact failure diagnostics could not be recovered. The locally reconstructed groups passed 1,735 tests with nine existing platform/fixture skips. The unchanged-head retry passed all required CI ([run34115498598, attempt2](https://github.com/openclaw/openclaw/actions/runs/34115498598/attempts/2)). The original failures remain recorded, with cause unverified.
- `node scripts/check-changed.mjs` passed, including core/UI/test typechecks, lint, formatting, and repository guards. Candidate Control UI production build passed. Independent Codex review is clean at P0–P2.
- Live proof used an isolated real source Gateway, two synthetic authenticated profiles, a local deterministic model fixture, and Chrome's real Web Push subscription. A selected mention committed to the transcript, appeared in Bob's Inbox, and arrived as an actual browser notification with the correct conversation URL. A second real chat turn produced an Agent finished browser alert carrying the correct conversation target while the recipient was in Settings. The 51st failed automation was visible too.

New Session background-start flow before submission:

![New Session before background submission](https://github.com/user-attachments/assets/01faf818-dbda-43d1-8d07-e908110b2ca6)

After the submission was accepted:

![New Session after background submission](https://github.com/user-attachments/assets/e4d4d773-5b9a-42fb-99d8-22cd00c8a10d)
