### PR TITLE
refactor(ui): share cross-origin attachment source check

### DIFF
--- a/ui/src/pages/chat/components/chat-attachment-href.ts
+++ b/ui/src/pages/chat/components/chat-attachment-href.ts
@@ -1,6 +1,17 @@
 const SAFE_ATTACHMENT_PROTOCOLS = new Set(["http:", "https:", "blob:"]);
 const SAFE_MEDIA_DATA_URL = /^data:(audio|video)\/[a-z0-9!#$&^_.+-]+;base64,([a-z0-9+/]+={0,2})$/i;
 
+export function isCrossOriginHttpSource(source: string): boolean {
+  try {
+    const url = new URL(source, window.location.href);
+    return (
+      (url.protocol === "http:" || url.protocol === "https:") && url.origin !== location.origin
+    );
+  } catch {
+    return false;
+  }
+}
+
 /** Returns only attachment links that are safe to expose as clickable anchors. */
 export function safeAttachmentHref(value: string): string | undefined {
   const href = value.trim();

--- a/ui/src/pages/chat/components/chat-sidebar-content.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-content.ts
@@ -29,7 +29,11 @@ import { isSvgImageMediaPath } from "../../../lib/media-file-extension.ts";
 import { shouldHandleNavigationClick } from "../../../lib/navigation-click.ts";
 import { detectTextDirection } from "../../../lib/text-direction.ts";
 import { renderCompactAttachmentCard } from "./chat-attachment-card.ts";
-import { safeAttachmentHref, safeMediaAttachmentHref } from "./chat-attachment-href.ts";
+import {
+  isCrossOriginHttpSource,
+  safeAttachmentHref,
+  safeMediaAttachmentHref,
+} from "./chat-attachment-href.ts";
 import { openInlineChatImage } from "./chat-image-lightbox.ts";
 import "./chat-audio-player.ts";
 import "./chat-video-player.ts";
@@ -39,17 +43,6 @@ import { renderSidebarFile, type FileViewControls } from "./chat-sidebar-file-vi
 import "./session-diff-panel.ts";
 
 type ChatDetailPanelContent = Exclude<SidebarContent, { kind: "task" }>;
-
-function isCrossOriginHttpSource(source: string): boolean {
-  try {
-    const url = new URL(source, window.location.href);
-    return (
-      (url.protocol === "http:" || url.protocol === "https:") && url.origin !== location.origin
-    );
-  } catch {
-    return false;
-  }
-}
 
 function renderSidebarAttachment(
   content: Extract<SidebarContent, { kind: "attachment" }>,

--- a/ui/src/pages/chat/components/chat-svg-attachment.ts
+++ b/ui/src/pages/chat/components/chat-svg-attachment.ts
@@ -3,6 +3,7 @@ import { property, state } from "lit/decorators.js";
 import { t } from "../../../i18n/index.ts";
 import { OpenClawLightDomContentsElement } from "../../../lit/openclaw-element.ts";
 import { renderCompactAttachmentCard } from "./chat-attachment-card.ts";
+import { isCrossOriginHttpSource } from "./chat-attachment-href.ts";
 import { observeChatAttachmentViewport } from "./chat-attachment-viewport.ts";
 import { readResponseBytesWithinLimit } from "./chat-response-bytes.ts";
 
@@ -14,17 +15,6 @@ type SvgRenderSource = {
   retainCount: number;
   retired: boolean;
 };
-
-function isCrossOriginHttpSource(source: string): boolean {
-  try {
-    const url = new URL(source, window.location.href);
-    return (
-      (url.protocol === "http:" || url.protocol === "https:") && url.origin !== location.origin
-    );
-  } catch {
-    return false;
-  }
-}
 
 class ChatSvgAttachment extends OpenClawLightDomContentsElement {
   @property() src = "";


### PR DESCRIPTION
## What Problem This Solves

The Control UI maintained the same cross-origin HTTP source predicate in two attachment rendering paths. Keeping those copies synchronized made CSP fallback behavior easier to drift.

## Why This Change Was Made

Move the unchanged predicate into the existing attachment href module and reuse it from the sidebar and SVG attachment renderers. The helper remains internal to the Control UI module graph; URL resolution, protocol checks, origin comparison, exception handling, and caller behavior are unchanged.

## User Impact

No user-visible behavior changes. Cross-origin SVG attachments still fall back to compact file cards, while same-origin SVG attachments continue through the bounded renderer.

## Evidence

- Blacksmith Testbox `tbx_01m1xgh984wz1jv0zjaq2v8se8`: 114 focused tests passed across the attachment href, message attachment, and sidebar suites.
- `pnpm ui:build`: passed, including Control UI performance checks.
- `node scripts/check-changed.mjs -- <three changed files>`: passed in Testbox.
- Independent autoreview through P2: scoped clean with no actionable findings.
- `git diff --check`: passed.
