### PR TITLE
fix(telemetry): retain update results when state writes fail

### DIFF
--- a/src/infra/telemetry.test.ts
+++ b/src/infra/telemetry.test.ts
@@ -3,9 +3,13 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import * as pluginRuntime from "../plugins/runtime.js";
 import { createPluginRecord } from "../plugins/status.test-helpers.js";
+import { writeConfigMachineState } from "../state/config-machine-state-write.js";
 import { readConfigMachineState } from "../state/config-machine-state.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { setTestEnvValue } from "../test-utils/env.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { useMockHttp } from "../test-utils/mock-http.js";
 import {
   createOpenClawTestState,
@@ -270,6 +274,194 @@ describe("anonymous telemetry", () => {
     });
   });
 
+  it("retains a successful response through write failures and recovers without extending its throttle", async () => {
+    const { db } = openOpenClawStateDatabase();
+    db.exec("PRAGMA query_only = ON");
+    const update = { version: "2026.8.24", note: "A newer release is available." };
+    mockHttp.intercept({ url: TELEMETRY_URL, reply: { json: update } });
+    mockHttp.intercept({ url: TELEMETRY_URL, reply: { json: { version: "2026.8.25" } } });
+    const options = { surface: "gateway" as const, fetchImpl: globalThis.fetch };
+
+    const first = await checkTelemetryUpdate({}, { ...options, nowMs: NOW });
+    const retained = await checkTelemetryUpdate({}, { ...options, nowMs: NOW + 120_000 });
+
+    expect({ first, retained, requests: mockHttp.requests().length }).toEqual({
+      first: update,
+      retained: update,
+      requests: 1,
+    });
+    expect(readConfigMachineState(TELEMETRY_STATE_KEY)).toBeUndefined();
+
+    db.exec("PRAGMA query_only = OFF");
+    await expect(checkTelemetryUpdate({}, { ...options, nowMs: NOW + 240_000 })).resolves.toEqual(
+      update,
+    );
+    expect(readConfigMachineState(TELEMETRY_STATE_KEY)).toEqual({
+      lastPingAt: NOW,
+      latestVersion: update.version,
+      note: update.note,
+    });
+    await expect(
+      checkTelemetryUpdate({}, { ...options, nowMs: NOW + DAY_MS - 1 }),
+    ).resolves.toEqual(update);
+    expect(mockHttp.requests()).toHaveLength(1);
+
+    await expect(checkTelemetryUpdate({}, { ...options, nowMs: NOW + DAY_MS })).resolves.toEqual({
+      version: "2026.8.25",
+    });
+    expect(mockHttp.requests()).toHaveLength(2);
+    expect(readConfigMachineState(TELEMETRY_STATE_KEY)).toEqual({
+      lastPingAt: NOW + DAY_MS,
+      latestVersion: "2026.8.25",
+    });
+  });
+
+  it.each(["endpoint", "state directory", "implicit home"] as const)(
+    "keeps an unpersisted response isolated when the %s changes",
+    async (scope) => {
+      const { db } = openOpenClawStateDatabase();
+      db.exec("PRAGMA query_only = ON");
+      const options = { surface: "gateway" as const, fetchImpl: globalThis.fetch };
+      mockHttp.intercept({
+        url: TELEMETRY_URL,
+        reply: { json: { version: "2026.8.24" } },
+      });
+      await checkTelemetryUpdate({}, { ...options, nowMs: NOW });
+
+      let endpoint = TELEMETRY_URL;
+      if (scope === "endpoint") {
+        endpoint = "https://telemetry.example.invalid/api/latest-version";
+        setTestEnvValue("OPENCLAW_TELEMETRY_ENDPOINT", endpoint);
+      } else if (scope === "state directory") {
+        setTestEnvValue("OPENCLAW_STATE_DIR", testState.path("alternate-state"));
+      } else {
+        deleteTestEnvValue("OPENCLAW_STATE_DIR");
+        setTestEnvValue("OPENCLAW_HOME", testState.path("alternate-home"));
+      }
+      mockHttp.intercept({ url: endpoint, reply: { json: { version: "2026.8.25" } } });
+
+      await expect(checkTelemetryUpdate({}, { ...options, nowMs: NOW + 120_000 })).resolves.toEqual(
+        { version: "2026.8.25" },
+      );
+      expect(mockHttp.requests()).toHaveLength(2);
+      testState.applyEnv();
+
+      await expect(checkTelemetryUpdate({}, { ...options, nowMs: NOW + 240_000 })).resolves.toEqual(
+        { version: "2026.8.24" },
+      );
+      expect(mockHttp.requests()).toHaveLength(2);
+    },
+  );
+
+  it("shares the retained success across equivalent resolved state paths", async () => {
+    const { db } = openOpenClawStateDatabase();
+    db.exec("PRAGMA query_only = ON");
+    mockHttp.intercept({
+      url: TELEMETRY_URL,
+      reply: { json: { version: "2026.8.24" } },
+    });
+    const options = { surface: "gateway" as const, fetchImpl: globalThis.fetch };
+    await checkTelemetryUpdate({}, { ...options, nowMs: NOW });
+    setTestEnvValue("OPENCLAW_STATE_DIR", `${testState.stateDir}/.`);
+
+    await expect(checkTelemetryUpdate({}, { ...options, nowMs: NOW + 120_000 })).resolves.toEqual({
+      version: "2026.8.24",
+    });
+    expect(mockHttp.requests()).toHaveLength(1);
+  });
+
+  it("keeps the request's state destination when the environment changes during HTTP", async () => {
+    const { db } = openOpenClawStateDatabase();
+    db.exec("PRAGMA query_only = ON");
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () => {
+      setTestEnvValue("OPENCLAW_STATE_DIR", testState.path("alternate-state"));
+      return Response.json({ version: "2026.8.24" });
+    });
+    const options = { surface: "gateway" as const, fetchImpl };
+
+    await expect(checkTelemetryUpdate({}, { ...options, nowMs: NOW })).resolves.toEqual({
+      version: "2026.8.24",
+    });
+    expect(readConfigMachineState(TELEMETRY_STATE_KEY)).toBeUndefined();
+    testState.applyEnv();
+    db.exec("PRAGMA query_only = OFF");
+
+    await expect(checkTelemetryUpdate({}, { ...options, nowMs: NOW + 120_000 })).resolves.toEqual({
+      version: "2026.8.24",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(readConfigMachineState(TELEMETRY_STATE_KEY)).toEqual({
+      lastPingAt: NOW,
+      latestVersion: "2026.8.24",
+    });
+  });
+
+  it("does not replace a newer persisted success with a retained older response", async () => {
+    const { db } = openOpenClawStateDatabase();
+    db.exec("PRAGMA query_only = ON");
+    mockHttp.intercept({
+      url: TELEMETRY_URL,
+      reply: { json: { version: "2026.8.24" } },
+    });
+    const options = { surface: "gateway" as const, fetchImpl: globalThis.fetch };
+    await checkTelemetryUpdate({}, { ...options, nowMs: NOW });
+    db.exec("PRAGMA query_only = OFF");
+    const newerState = { lastPingAt: NOW + 60_000, latestVersion: "2026.8.25" };
+    writeConfigMachineState(TELEMETRY_STATE_KEY, newerState);
+
+    await expect(checkTelemetryUpdate({}, { ...options, nowMs: NOW + 120_000 })).resolves.toEqual({
+      version: "2026.8.25",
+    });
+    expect(readConfigMachineState(TELEMETRY_STATE_KEY)).toEqual(newerState);
+    expect(mockHttp.requests()).toHaveLength(1);
+  });
+
+  it("preserves a newer durable success written while the request was awaiting HTTP", async () => {
+    const newerState = { lastPingAt: NOW + 60_000, latestVersion: "2026.8.25" };
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () => {
+      writeConfigMachineState(TELEMETRY_STATE_KEY, newerState);
+      return Response.json({ version: "2026.8.24" });
+    });
+
+    await expect(
+      checkTelemetryUpdate({}, { surface: "gateway", fetchImpl, nowMs: NOW }),
+    ).resolves.toEqual({ version: newerState.latestVersion });
+
+    expect(readConfigMachineState(TELEMETRY_STATE_KEY)).toEqual(newerState);
+  });
+
+  it("uses a newer transaction-selected success instead of sending at the pending timestamp's expiry", async () => {
+    const { db } = openOpenClawStateDatabase();
+    db.exec("PRAGMA query_only = ON");
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({ version: "2026.8.24" }))
+      .mockResolvedValueOnce(Response.json({ version: "2026.8.26" }));
+    const options = { surface: "gateway" as const, fetchImpl };
+    await checkTelemetryUpdate({}, { ...options, nowMs: NOW });
+    db.exec("PRAGMA query_only = OFF");
+
+    const newerState = { lastPingAt: NOW + DAY_MS - 60_000, latestVersion: "2026.8.25" };
+    const originalRead = readConfigMachineState;
+    const read = vi
+      .spyOn(await import("../state/config-machine-state.js"), "readConfigMachineState")
+      .mockImplementationOnce((...args) => {
+        const snapshot = originalRead(...args);
+        writeConfigMachineState(TELEMETRY_STATE_KEY, newerState);
+        return snapshot;
+      });
+    try {
+      const result = await checkTelemetryUpdate({}, { ...options, nowMs: NOW + DAY_MS });
+      expect({ result, requests: fetchImpl.mock.calls.length }).toEqual({
+        result: { version: newerState.latestVersion },
+        requests: 1,
+      });
+      expect(readConfigMachineState(TELEMETRY_STATE_KEY)).toEqual(newerState);
+    } finally {
+      read.mockRestore();
+    }
+  });
+
   it.each([
     { name: "never opted in", config: {} satisfies OpenClawConfig },
     { name: "explicitly opted out", config: createFeatureConfig(false) },
@@ -445,6 +637,21 @@ describe("anonymous telemetry", () => {
 
     expect(mockHttp.requests()).toHaveLength(1);
     expect(readConfigMachineState(TELEMETRY_STATE_KEY)).toBeUndefined();
+    mockHttp.intercept({
+      url: TELEMETRY_URL,
+      reply: { json: { version: "2026.8.24" } },
+    });
+    await expect(
+      checkTelemetryUpdate(
+        {},
+        {
+          surface: "gateway",
+          fetchImpl: globalThis.fetch,
+          nowMs: NOW + 120_000,
+        },
+      ),
+    ).resolves.toEqual({ version: "2026.8.24" });
+    expect(mockHttp.requests()).toHaveLength(2);
   });
 
   it("bounds untrusted remote update notes before display or persistence", async () => {

--- a/src/infra/telemetry.ts
+++ b/src/infra/telemetry.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { collectConfiguredModelRefs } from "@openclaw/model-catalog-core/configured-model-refs";
 import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -10,10 +11,11 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveOfficialExternalProviderPluginIds } from "../plugins/official-external-plugin-catalog.js";
 import { isPubliclyKnownPluginId } from "../plugins/plugin-public-identity.js";
 import { listEnabledPluginRecords } from "../plugins/plugin-runtime-inventory.js";
-import { writeConfigMachineState } from "../state/config-machine-state-write.js";
+import { updateConfigMachineState } from "../state/config-machine-state-write.js";
 import { readConfigMachineState } from "../state/config-machine-state.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { VERSION } from "../version.js";
 import { isTruthyEnvValue } from "./env.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "./kysely-sync.js";
@@ -24,6 +26,7 @@ const TELEMETRY_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const TELEMETRY_FAILURE_BACKOFF_MS = 60 * 1000;
 const TELEMETRY_TIMEOUT_MS = 3000;
 const TELEMETRY_NOTE_MAX_LENGTH = 500;
+const TELEMETRY_PENDING_SUCCESS_LIMIT = 32;
 const SAFE_FEATURE_NAME = /^[a-z][a-z0-9_-]{0,63}$/;
 
 type TelemetrySurface = "gateway" | "cli";
@@ -37,6 +40,11 @@ type TelemetryState = {
   lastPingAt?: number;
   latestVersion?: string;
   note?: string;
+};
+
+type SuccessfulTelemetryState = TelemetryState & {
+  lastPingAt: number;
+  latestVersion: string;
 };
 
 type TelemetryPayload = {
@@ -75,6 +83,7 @@ const TelemetryResponseSchema = z.object({
 
 let lastFailedAttempt: { at: number; endpoint: string; stateDirectory?: string } | undefined;
 let inFlightUpdate: Promise<TelemetryUpdate | null> | undefined;
+const pendingSuccesses = new Map<string, SuccessfulTelemetryState>();
 
 /**
  * CI jobs are not installs. Left unchecked they outnumber operators by orders of
@@ -133,12 +142,44 @@ export function buildTelemetryUserAgent(surface: TelemetrySurface): string {
   return `openclaw/${VERSION} (${process.platform}; node/${process.versions.node}; ${process.arch}; ${surface})`;
 }
 
-function readTelemetryState(): TelemetryState {
+function readTelemetryState(databasePath?: string): TelemetryState {
   try {
-    const state = readConfigMachineState<TelemetryState>(TELEMETRY_STATE_KEY);
+    const state = readConfigMachineState<TelemetryState>(TELEMETRY_STATE_KEY, {
+      path: databasePath,
+    });
     return state && isRecord(state) ? state : {};
   } catch {
     return {};
+  }
+}
+
+function persistTelemetrySuccess(
+  key: string,
+  state: SuccessfulTelemetryState,
+  databasePath: string,
+): SuccessfulTelemetryState {
+  try {
+    const persisted = updateConfigMachineState<SuccessfulTelemetryState>(
+      TELEMETRY_STATE_KEY,
+      (current) =>
+        current?.lastPingAt !== undefined && current.lastPingAt >= state.lastPingAt
+          ? current
+          : state,
+      { path: databasePath },
+    );
+    pendingSuccesses.delete(key);
+    return persisted;
+  } catch {
+    // A failed local write must not discard an accepted response or trigger another daily report.
+    pendingSuccesses.delete(key);
+    pendingSuccesses.set(key, state);
+    if (pendingSuccesses.size > TELEMETRY_PENDING_SUCCESS_LIMIT) {
+      const oldestKey = pendingSuccesses.keys().next().value;
+      if (oldestKey !== undefined) {
+        pendingSuccesses.delete(oldestKey);
+      }
+    }
+    return state;
   }
 }
 
@@ -237,12 +278,22 @@ export async function checkTelemetryUpdate(
     return null;
   }
 
-  const state = readTelemetryState();
+  const endpoint = resolveTelemetryEndpoint();
+  const databasePath = path.resolve(resolveOpenClawStateSqlitePath());
+  const pendingKey = JSON.stringify([endpoint, databasePath]);
+  let state = readTelemetryState(databasePath);
+  const pending = pendingSuccesses.get(pendingKey);
+  if (pending) {
+    if (state.lastPingAt === undefined || pending.lastPingAt > state.lastPingAt) {
+      state = persistTelemetrySuccess(pendingKey, pending, databasePath);
+    } else {
+      pendingSuccesses.delete(pendingKey);
+    }
+  }
   const cached = state.latestVersion
     ? { version: state.latestVersion, ...(state.note ? { note: state.note } : {}) }
     : null;
   const nowMs = options.nowMs ?? Date.now();
-  const endpoint = resolveTelemetryEndpoint();
   const stateDirectory = process.env.OPENCLAW_STATE_DIR;
   if (
     state.lastPingAt !== undefined &&
@@ -295,13 +346,20 @@ export async function checkTelemetryUpdate(
         version: parsed.version,
         ...(note ? { note } : {}),
       };
-      writeConfigMachineState(TELEMETRY_STATE_KEY, {
-        lastPingAt: nowMs,
-        latestVersion: update.version,
-        ...(update.note ? { note: update.note } : {}),
-      });
+      const persisted = persistTelemetrySuccess(
+        pendingKey,
+        {
+          lastPingAt: nowMs,
+          latestVersion: update.version,
+          ...(update.note ? { note: update.note } : {}),
+        },
+        databasePath,
+      );
       lastFailedAttempt = undefined;
-      return update;
+      return {
+        version: persisted.latestVersion,
+        ...(persisted.note ? { note: persisted.note } : {}),
+      };
     } catch {
       lastFailedAttempt = { at: nowMs, endpoint, stateDirectory };
       return cached;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators would lose a valid update notice and send repeated update reports when the local state database rejected a write. A successful HTTP response was treated as a failed request if persisting it failed, allowing another request after the one-minute failure backoff instead of the normal daily interval.

## Why This Change Was Made

Keep an accepted response and its original timestamp in a bounded in-process fallback when persistence fails. Scope pending successes by endpoint and resolved database path, pin the write destination before HTTP, and retry the existing state write on a later ordinary call without another request or timestamp extension. The existing atomic machine-state update helper preserves an equal or newer durable success inside its transaction.

This retains at most 32 pending contexts and adds no durable store, identifier, timer, schema, dependency, consent change, collection change, or cadence change. It does not change the separate Gateway shutdown lifecycle or provider-name normalization.

## User Impact

Update notices remain available during local state-write failures, and repeated calls within the original 24-hour window reuse the successful result. When storage becomes writable, the original success is persisted without delaying the next eligible check. The fallback is process-local; it cannot survive a process restart while writes remain unavailable.

## Evidence

- Red proof with the real isolated SQLite database in `query_only` mode: two calls two minutes apart returned two `null` results and sent two HTTP requests despite valid version responses. The corrected test-only candidate produced five intended failures on unchanged production code.
- Green proof: all 34 telemetry tests passed; all 113 update-startup sibling tests passed on the same final production code. Targeted lint and `git diff --check` passed.
- Coverage includes the exact 24-hour boundary, persistence recovery without extra HTTP or throttle extension, endpoint and resolved state isolation, equivalent paths, request-time destination pinning, newer durable state, and unchanged invalid-response/transport failure behavior.
- HTTP was mocked; SQLite was real and task-isolated. No production ingestion or real Gateway state was used.
- Independent review identified an unconditional-write race. A separate red proof reproduced version/timestamp rollback when a newer success was persisted during HTTP. The correction reuses the existing atomic update primitive without modifying the shared store API or implementation.
- The changed gate passed its preliminary guards, formatting, plugin boundaries, and core graph-boundary check, then stopped because the local typecheck wrapper rejects the required shared-worktree dependency symlink. The dependency layout was not replaced or bypassed; exact-head CI must supply the remaining gate proof.
- Independent P2 review: accepted concurrency findings addressed; final targeted re-review is scoped-clean. The caller now uses the transaction-selected state for both the cached response and cadence decision, preventing an unnecessary request at an older pending timestamp's expiry.
- Exact-head hosted CI is required before landing.
