### PR TITLE
test(ui): finish Mermaid rendering before clipboard teardown

### DIFF
--- a/ui/src/components/markdown-clipboard.browser.test.ts
+++ b/ui/src/components/markdown-clipboard.browser.test.ts
@@ -1,6 +1,6 @@
 import { html, nothing, render } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { renderMessageImages } from "../pages/chat/components/chat-message-images.ts";
 import { renderMessageMarkdown } from "../pages/chat/components/chat-message-text.ts";
@@ -51,6 +51,16 @@ afterEach(() => {
   }
 });
 
+afterAll(() => {
+  window.dispatchEvent(new PageTransitionEvent("pagehide"));
+});
+
+async function waitForDiagram(diagram: HTMLElement) {
+  const { page } = await import("vitest/browser");
+  await expect.element(page.elementLocator(diagram).getByRole("img")).toBeVisible();
+  await diagram.shadowRoot!.querySelector("img")!.decode();
+}
+
 async function mountCopy(surface: "code" | "table" | "mermaid" | "message") {
   const owner = document.body.appendChild(document.createElement("section"));
   owners.push(owner);
@@ -80,6 +90,7 @@ async function mountCopy(surface: "code" | "table" | "mermaid" | "message") {
     diagram.source = "flowchart LR\nA --> B";
     owner.append(diagram);
     await diagram.updateComplete;
+    await waitForDiagram(diagram);
     button = diagram.shadowRoot?.querySelector(".copy-button") ?? null;
   } else {
     render(renderCopyButton("Current message"), owner);
@@ -319,6 +330,7 @@ describe("Markdown clipboard operation lifetime", () => {
     pending.reject(new Error("Synthetic clipboard rejection"));
     await flushCopy();
     expect(fallbackCopies).toEqual([]);
+    await waitForDiagram(diagram);
   });
 
   it("keeps the newer table-copy feedback when an older request rejects", async () => {


### PR DESCRIPTION
## What Problem This Solves

Finishes Mermaid rendering started by clipboard fixtures before their page is torn down. Otherwise a later browser suite can remove an active renderer frame and wait for its existing watchdog before its own rendering starts.

The original renderer-mock removal from this PR has independently landed in #141092. This PR now contains only the remaining fixture-lifetime repair; the final clipboard source is unchanged from the previously reviewed combined repair.

## Why This Change Was Made

The fixture waits for the real Mermaid preview and its image decode before interaction or final retirement. The connected-source-change case joins rendering after its existing clipboard race assertions. Final `pagehide` teardown disposes the settled renderer through its existing lifecycle.

Component disconnection already fences result publication, but does not finish rendering queued in the shared renderer. Joining that work at its test fixture prevents it from outliving the fixture.

## User Impact

Browser suites avoid waiting behind unfinished clipboard-fixture rendering. Clipboard transports, race assertions, deadlines, and production behavior are preserved.

## Evidence

- The original five-file CI order reproduced 100 passed / 6 failed with the module mock. Its removal fixes those failures, as landed in #141092.
- With mock removal alone, the first native case in that same order took 12.765 seconds while prior rendering waited for its watchdog. The fixture-lifetime repair passes all 106 cases with that first native case at 319 ms. This is an observed regression sequence, not a general performance benchmark.
- The minimal clipboard → native pair passes all 27 cases with the final source, on both the independently refreshed main base and the original PR base.
- Selected changed checks and fresh independent P0–P2 review pass. No new mock, production seam, timeout increase, or isolation setting was added. Clipboard stubs remain inside the browser page and do not write the OS clipboard.
- The rebase preserves the exact reviewed clipboard source. The original five-line removal is omitted because it is now on main.

CI run 34107394739 attempt 1 stopped in checkout. Attempt 2 passed all three UI browser shards, all thirteen mocked UI E2E shards, and the real-Gateway UI suite, but found a separate Telegram test-file line-limit failure on its main base. That lint repair independently landed in #141139 and is included in this branch. Final [CI run 34112456447](https://github.com/openclaw/openclaw/actions/runs/34112456447) passed on `a45a33a1feccf0ffdd4d1cba76b899e0be934306`: 38 successful jobs, 16 workflow skips, and the required CI gate green. The current-head ClawSweeper review has no findings or before-merge requests.
