### PR TITLE
fix(agents): keep tool history stable after Gateway restarts

### DIFF
--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -77,8 +77,12 @@ on both a time check and a context-size check:
 5. Record each changed result as a session projection and reset the pruning TTL clock. Follow-up requests reuse the same projected bytes, including tool-loop continuations and later turns.
 
 The TTL gates new pruning rounds, not replay of previous projections. Projections
-survive Gateway restarts through the transcript marker. Compaction drops
-projections for results no longer in the active history; `/new` and session reset
+survive Gateway restarts and eviction from the in-memory session cache through
+the transcript marker. Ordinary tool-result trims and the already-sent boundary
+are also saved before each model request, even with TTL pruning off, so old
+results retain their projected bytes through tool loops and restarts. Original
+text and non-text content stay in the transcript. Compaction drops projections
+for results no longer in the active history; `/new` and session reset
 start without the old session's projections. Cache-TTL marker timestamps still
 support the existing cache and heartbeat bookkeeping.
 

--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -79,8 +79,10 @@ on both a time check and a context-size check:
 The TTL gates new pruning rounds, not replay of previous projections. Projections
 survive Gateway restarts and eviction from the in-memory session cache through
 the transcript marker. Ordinary tool-result trims and the already-sent boundary
-are also saved before each model request, even with TTL pruning off, so old
-results retain their projected bytes through tool loops and restarts. Original
+are also saved before model requests when the projection changes, even with TTL
+pruning off. Unchanged projections add no new marker; restart restores the latest
+marker on the active branch. Old results retain their projected bytes through
+tool loops and restarts. Original
 text and non-text content stay in the transcript. Compaction drops projections
 for results no longer in the active history; `/new` and session reset
 start without the old session's projections. Cache-TTL marker timestamps still

--- a/src/agents/code-mode.result-budget.test.ts
+++ b/src/agents/code-mode.result-budget.test.ts
@@ -126,6 +126,7 @@ async function dispatch(
       transcriptLeafId: null,
       onFinalPromptText: () => {},
       onSteeringAcknowledged: () => {},
+      persistToolResultProjections: async () => {},
       promptActiveSession: async () => {
         const context = await agent.transformContext!(messages, new AbortController().signal);
         await agent.streamFn(model, { messages: await agent.convertToLlm(context) });

--- a/src/agents/embedded-agent-runner/cache-ttl.test.ts
+++ b/src/agents/embedded-agent-runner/cache-ttl.test.ts
@@ -116,6 +116,14 @@ describe("readLastCacheTtlTimestamp", () => {
             modelId: "gemini-3.1-pro-preview",
           },
         },
+        {
+          type: "custom",
+          customType: "openclaw.cache-ttl",
+          data: {
+            prunedToolResults: [],
+            frozenToolResults: [{ key: "tool:new:43", sourceHash: "hash" }],
+          },
+        },
       ],
     };
 

--- a/src/agents/embedded-agent-runner/cache-ttl.ts
+++ b/src/agents/embedded-agent-runner/cache-ttl.ts
@@ -80,7 +80,7 @@ function matchesCacheTtlContext(
 }
 
 /** Transcript entries visible to cache-TTL marker readers; stores without entries read as empty. */
-export function readCacheTtlEntries(sessionManager: unknown): CustomEntryLike[] {
+function readCacheTtlEntries(sessionManager: unknown): CustomEntryLike[] {
   const sm = sessionManager as { getEntries?: () => CustomEntryLike[] };
   return sm?.getEntries ? sm.getEntries() : [];
 }

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -18,6 +18,7 @@ import {
 import { releasePendingAgentSteeringItems } from "../../subagents/registry/subagent-registry.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { log } from "../logger.js";
+import { serializeCacheTtlToolResultProjections } from "../session-prompt-state.js";
 import { resolveEmbeddedAgentApiKey } from "../stream-resolution.js";
 import { isOpenClawAbortableWrapper } from "./abortable.js";
 import { runEmbeddedAttemptBeforeAgentRun } from "./attempt-before-agent-run.js";
@@ -415,6 +416,16 @@ export async function runEmbeddedAttemptPromptPhase(
         },
         onSteeringAcknowledged: () => {
           leasedSteering = undefined;
+        },
+        persistToolResultProjections: async () => {
+          if (!isRawModelRun && toolResultPromptProjectionState.frozen.size > 0) {
+            await withOwnedTranscriptWrite(() => {
+              sessionManager.appendCustomEntry(
+                "openclaw.cache-ttl",
+                serializeCacheTtlToolResultProjections(toolResultPromptProjectionState),
+              );
+            });
+          }
         },
         ...(promptBuildPrependContext ? { prependContext: promptBuildPrependContext } : {}),
         ...(promptContext.runtimeContextMessageForCurrentTurn

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -18,7 +18,7 @@ import {
 import { releasePendingAgentSteeringItems } from "../../subagents/registry/subagent-registry.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { log } from "../logger.js";
-import { serializeCacheTtlToolResultProjections } from "../session-prompt-state.js";
+import { persistToolResultProjections } from "../session-prompt-state.js";
 import { resolveEmbeddedAgentApiKey } from "../stream-resolution.js";
 import { isOpenClawAbortableWrapper } from "./abortable.js";
 import { runEmbeddedAttemptBeforeAgentRun } from "./attempt-before-agent-run.js";
@@ -420,9 +420,8 @@ export async function runEmbeddedAttemptPromptPhase(
         persistToolResultProjections: async () => {
           if (!isRawModelRun && toolResultPromptProjectionState.frozen.size > 0) {
             await withOwnedTranscriptWrite(() => {
-              sessionManager.appendCustomEntry(
-                "openclaw.cache-ttl",
-                serializeCacheTtlToolResultProjections(toolResultPromptProjectionState),
+              persistToolResultProjections(toolResultPromptProjectionState, (customType, data) =>
+                sessionManager.appendCustomEntry(customType, data),
               );
             });
           }

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.projections.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.projections.test.ts
@@ -9,9 +9,12 @@ import {
 } from "../../sessions/agent-session-loop-correctness.test-support.js";
 import {
   clearEmbeddedSessionPromptStates,
+  createToolResultPromptProjectionState,
   getEmbeddedSessionPromptState,
+  persistToolResultProjections,
   serializeCacheTtlToolResultProjections,
 } from "../session-prompt-state.js";
+import { restoreCacheTtlToolResultProjections } from "../tool-result-truncation.js";
 import { submitEmbeddedAttemptPrompt } from "./attempt-prompt-submit.js";
 
 registerAgentSessionLoopTestLifecycle();
@@ -19,7 +22,45 @@ const sessionId = "projection-dispatch";
 afterEach(() => clearEmbeddedSessionPromptStates([sessionId]));
 
 describe("tool-result projection persistence at dispatch", () => {
-  it("awaits the projection marker before every tool-loop dispatch", async () => {
+  it("restores only the latest active marker and retries changed snapshots after a failed write", async () => {
+    const { sessionManager: manager } = await createTestSession();
+    const snapshot = (key: string) => ({
+      prunedToolResults: [],
+      ambiguousToolResultBaseKeys: [],
+      frozenToolResults: [{ key, sourceHash: "source", texts: [key] }],
+    });
+    manager.appendCustomEntry("openclaw.cache-ttl", snapshot("older"));
+    const activeMarker = manager.appendCustomEntry("openclaw.cache-ttl", snapshot("active"));
+    manager.appendCustomEntry("openclaw.cache-ttl", snapshot("sibling"));
+    manager.branch(activeMarker);
+
+    const restored = createToolResultPromptProjectionState();
+    restoreCacheTtlToolResultProjections(restored, manager.getBranch());
+    expect(serializeCacheTtlToolResultProjections(restored)).toEqual(snapshot("active"));
+    const appendEntry = (customType: string, data: unknown) =>
+      manager.appendCustomEntry(customType, data);
+    const markers = () =>
+      manager
+        .getEntries()
+        .filter((entry) => entry.type === "custom" && entry.customType === "openclaw.cache-ttl");
+    persistToolResultProjections(restored, appendEntry);
+    expect(markers()).toHaveLength(3);
+
+    restored.replacements.set("active", { content: [{ type: "text", text: "changed" }] });
+    expect(() =>
+      persistToolResultProjections(restored, () => {
+        throw new Error("write failed");
+      }),
+    ).toThrow("write failed");
+    persistToolResultProjections(restored, appendEntry);
+    persistToolResultProjections(restored, appendEntry);
+    expect(markers()).toHaveLength(4);
+    expect(manager.getBranch().at(-1)).toMatchObject({
+      data: { frozenToolResults: [{ key: "active", sourceHash: "source", texts: ["changed"] }] },
+    });
+  });
+
+  it("writes one marker for unchanged requests and another for a new frozen batch", async () => {
     const { session: activeSession, sessionManager: manager } = await createTestSession();
     const sessionPromptState = getEmbeddedSessionPromptState(sessionId);
     const projectionState = sessionPromptState.toolResults;
@@ -56,14 +97,13 @@ describe("tool-result projection persistence at dispatch", () => {
       activeSession,
       persistToolResultProjections: async () => {
         await Promise.resolve();
-        manager.appendCustomEntry(
-          "openclaw.cache-ttl",
-          serializeCacheTtlToolResultProjections(projectionState),
+        persistToolResultProjections(projectionState, (customType, data) =>
+          manager.appendCustomEntry(customType, data),
         );
       },
       promptActiveSession: async () => {
         const messages: Context["messages"] = [];
-        for (let index = 0; index < 3; index++) {
+        for (let index = 0; index < 2; index++) {
           messages.push(createAssistant(testModel, [{ type: "text", text: "read" }]), {
             role: "toolResult",
             toolCallId: `batch-${index}`,
@@ -72,12 +112,17 @@ describe("tool-result projection persistence at dispatch", () => {
             isError: false,
             timestamp: index,
           });
-          await activeSession.agent.streamFn(testModel, { messages });
+          for (let request = 0; request < 3; request++) {
+            await activeSession.agent.streamFn(testModel, { messages });
+            expect(manager.getEntries().filter((entry) => entry.type === "custom")).toHaveLength(
+              index + 1,
+            );
+          }
         }
       },
     });
-    expect(requests).toHaveLength(3);
-    expect(manager.getEntries().filter((entry) => entry.type === "custom")).toHaveLength(3);
-    expect(requests[2]?.slice(0, 2)).toEqual(requests[0]);
+    expect(requests).toHaveLength(6);
+    expect(manager.getEntries().filter((entry) => entry.type === "custom")).toHaveLength(2);
+    expect(requests[3]?.slice(0, 2)).toEqual(requests[0]);
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.projections.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.projections.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { Context } from "../../../llm/types.js";
+import {
+  createAssistant,
+  createAssistantResultStream,
+  createTestSession,
+  registerAgentSessionLoopTestLifecycle,
+  testModel,
+} from "../../sessions/agent-session-loop-correctness.test-support.js";
+import {
+  clearEmbeddedSessionPromptStates,
+  getEmbeddedSessionPromptState,
+  serializeCacheTtlToolResultProjections,
+} from "../session-prompt-state.js";
+import { submitEmbeddedAttemptPrompt } from "./attempt-prompt-submit.js";
+
+registerAgentSessionLoopTestLifecycle();
+const sessionId = "projection-dispatch";
+afterEach(() => clearEmbeddedSessionPromptStates([sessionId]));
+
+describe("tool-result projection persistence at dispatch", () => {
+  it("awaits the projection marker before every tool-loop dispatch", async () => {
+    const { session: activeSession, sessionManager: manager } = await createTestSession();
+    const sessionPromptState = getEmbeddedSessionPromptState(sessionId);
+    const projectionState = sessionPromptState.toolResults;
+    const requests: Context["messages"][] = [];
+    activeSession.agent.streamFn = (model, context) => {
+      const marker = manager.getEntries().at(-1);
+      expect(marker).toMatchObject({
+        type: "custom",
+        customType: "openclaw.cache-ttl",
+        data: { frozenToolResults: expect.any(Array) },
+      });
+      expect(marker?.type === "custom" && marker.data).toEqual(
+        serializeCacheTtlToolResultProjections(projectionState),
+      );
+      requests.push(structuredClone(context.messages));
+      return createAssistantResultStream(createAssistant(model, [{ type: "text", text: "done" }]));
+    };
+    await submitEmbeddedAttemptPrompt({
+      attempt: { sessionId },
+      contextTokenBudget: 8_000,
+      images: [],
+      modelPrompt: "read files",
+      onFinalPromptText: () => {},
+      onSteeringAcknowledged: () => {},
+      runtimeOnly: false,
+      sessionPromptState,
+      systemPrompt: "test prompt",
+      toolResultAggregateMaxChars: 8_000,
+      toolResultMaxChars: 4_000,
+      toolResultPromptProjectionState: projectionState,
+      trajectoryRecorder: null,
+      transcriptLeafId: null,
+      transcriptPrompt: "read files",
+      activeSession,
+      persistToolResultProjections: async () => {
+        await Promise.resolve();
+        manager.appendCustomEntry(
+          "openclaw.cache-ttl",
+          serializeCacheTtlToolResultProjections(projectionState),
+        );
+      },
+      promptActiveSession: async () => {
+        const messages: Context["messages"] = [];
+        for (let index = 0; index < 3; index++) {
+          messages.push(createAssistant(testModel, [{ type: "text", text: "read" }]), {
+            role: "toolResult",
+            toolCallId: `batch-${index}`,
+            toolName: "read",
+            content: [{ type: "text", text: "x".repeat(6_000) }],
+            isError: false,
+            timestamp: index,
+          });
+          await activeSession.agent.streamFn(testModel, { messages });
+        }
+      },
+    });
+    expect(requests).toHaveLength(3);
+    expect(manager.getEntries().filter((entry) => entry.type === "custom")).toHaveLength(3);
+    expect(requests[2]?.slice(0, 2)).toEqual(requests[0]);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
@@ -97,6 +97,7 @@ function createBaseInput() {
     modelPrompt: "model prompt",
     onFinalPromptText: vi.fn(),
     onSteeringAcknowledged: vi.fn(),
+    persistToolResultProjections: vi.fn(async () => {}),
     prependContext: "prepend context",
     runtimeOnly: false,
     sessionPromptState,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
@@ -84,6 +84,7 @@ export async function submitEmbeddedAttemptPrompt(input: {
   modelPrompt: string;
   onFinalPromptText: (prompt: string) => void;
   onSteeringAcknowledged: () => void;
+  persistToolResultProjections: () => Promise<void>;
   prependContext?: string;
   promptActiveSession: PromptActiveSession;
   runtimeContextMessage?: RuntimeContextCustomMessage;
@@ -110,33 +111,41 @@ export async function submitEmbeddedAttemptPrompt(input: {
 
   const installProviderPromptHistoryTransform = (): (() => void) => {
     const baseStreamFn = activeSession.agent.streamFn;
-    const providerPromptStreamFn = wrapStreamFnWithMessageTransform(baseStreamFn, (messages) => {
-      const providerPromptHistoryTruncation = truncateOversizedToolResultsInMessages(
-        messages,
-        input.contextTokenBudget,
-        input.toolResultMaxChars,
-        input.toolResultAggregateMaxChars,
-        input.toolResultPromptProjectionState,
-      );
-      const providerMessages =
-        providerPromptHistoryTruncation.messages !== messages
-          ? providerPromptHistoryTruncation.messages
-          : messages;
-      if (providerPromptHistoryTruncation.aggregateTruncatedCount > 0) {
-        recordAggregateTruncation(attempt);
-      }
-      // Mark the current turn sent at provider dispatch so late media appends
-      // instead of rewriting its prompt-cache slot (#99495).
-      markSessionUserTurnsSent(input.sessionPromptState, providerMessages);
-      const recorder = attempt.userTurnTranscriptRecorder;
-      if (
-        recorder &&
-        hasSessionUserTurnBeenSent(input.sessionPromptState, recorder.message) !== false
-      ) {
-        recorder.markSentToProvider?.();
-      }
-      return providerMessages;
-    });
+    const persistThenStream: StreamFn = async (model, context, options) => {
+      await input.persistToolResultProjections();
+      options?.signal?.throwIfAborted();
+      return baseStreamFn(model, context, options);
+    };
+    const providerPromptStreamFn = wrapStreamFnWithMessageTransform(
+      persistThenStream,
+      (messages) => {
+        const providerPromptHistoryTruncation = truncateOversizedToolResultsInMessages(
+          messages,
+          input.contextTokenBudget,
+          input.toolResultMaxChars,
+          input.toolResultAggregateMaxChars,
+          input.toolResultPromptProjectionState,
+        );
+        const providerMessages =
+          providerPromptHistoryTruncation.messages !== messages
+            ? providerPromptHistoryTruncation.messages
+            : messages;
+        if (providerPromptHistoryTruncation.aggregateTruncatedCount > 0) {
+          recordAggregateTruncation(attempt);
+        }
+        // Mark the current turn sent at provider dispatch so late media appends
+        // instead of rewriting its prompt-cache slot (#99495).
+        markSessionUserTurnsSent(input.sessionPromptState, providerMessages);
+        const recorder = attempt.userTurnTranscriptRecorder;
+        if (
+          recorder &&
+          hasSessionUserTurnBeenSent(input.sessionPromptState, recorder.message) !== false
+        ) {
+          recorder.markSentToProvider?.();
+        }
+        return providerMessages;
+      },
+    );
     activeSession.agent.streamFn = providerPromptStreamFn;
     return () => {
       if (activeSession.agent.streamFn === providerPromptStreamFn) {

--- a/src/agents/embedded-agent-runner/run/attempt-session-replay.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-replay.test.ts
@@ -246,6 +246,7 @@ async function withReplaySession(
         modelPrompt: attempt.prompt,
         onFinalPromptText: () => {},
         onSteeringAcknowledged: () => {},
+        persistToolResultProjections: async () => {},
         runtimeOnly: false,
         sessionPromptState: promptState,
         systemPrompt: "",

--- a/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.test.ts
@@ -48,7 +48,12 @@ type PrepareInput = Parameters<typeof prepareEmbeddedAttemptSessionRuntime>[0];
 
 function createFixture() {
   const order: string[] = [];
-  const sessionManager = { kind: "manager", getBranch: () => [] };
+  const activeMarker = { type: "custom", customType: "openclaw.cache-ttl", data: "active" };
+  const sessionManager = {
+    kind: "manager",
+    getBranch: () => [activeMarker],
+    getEntries: () => [activeMarker, { ...activeMarker, data: "sibling" }],
+  };
   const activeSession = {
     messages: [{ role: "user" }, { role: "assistant" }],
     sessionId: "active-session",
@@ -242,6 +247,10 @@ describe("prepareEmbeddedAttemptSessionRuntime", () => {
 
     const result = await prepareEmbeddedAttemptSessionRuntime(fixture.input);
 
+    expect(mocks.restoreProjections).toHaveBeenCalledWith(
+      fixture.promptState.toolResults,
+      fixture.sessionManager.getBranch(),
+    );
     expect(fixture.order).toEqual([
       "manager",
       "own-manager",

--- a/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.ts
@@ -3,7 +3,6 @@ import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
 import { createCacheTrace } from "../../cache-trace.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import type { AgentSession } from "../../sessions/index.js";
-import { readCacheTtlEntries } from "../cache-ttl.js";
 import { getProviderPromptState } from "../provider-prompt-state.js";
 import { getEmbeddedSessionPromptState } from "../session-prompt-state.js";
 import { restoreCacheTtlToolResultProjections } from "../tool-result-truncation.js";
@@ -179,7 +178,7 @@ export async function prepareEmbeddedAttemptSessionRuntime(input: {
   if (!input.isRawModelRun) {
     restoreCacheTtlToolResultProjections(
       toolResultPromptProjectionState,
-      readCacheTtlEntries(sessionManager),
+      sessionManager.getBranch(),
     );
   }
   const settleTracker = createEmbeddedAttemptSessionSettleTracker(activeSession);

--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -74,6 +74,7 @@ type SessionManagerMocks = {
   getLeafEntry: UnknownMock;
   getEntry: UnknownMock;
   getEntries: UnknownMock;
+  getBranch: UnknownMock;
   getBoundaryCount: UnknownMock;
   branch: UnknownMock;
   resetLeaf: UnknownMock;
@@ -285,6 +286,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     getLeafEntry: vi.fn(() => null),
     getEntry: vi.fn(() => undefined),
     getEntries: vi.fn(() => []),
+    getBranch: vi.fn(() => []),
     getBoundaryCount: vi.fn(() => 0),
     branch: vi.fn(),
     resetLeaf: vi.fn(),
@@ -813,7 +815,6 @@ vi.mock("../../transcript-policy.js", () => ({
 }));
 
 vi.mock("../cache-ttl.js", () => ({
-  readCacheTtlEntries: () => [],
   appendCacheTtlTimestamp: (
     sessionManager: { appendCustomEntry?: (customType: string, data: unknown) => void },
     data: unknown,
@@ -1148,6 +1149,7 @@ export function resetEmbeddedAttemptHarness(
   hoisted.sessionManager.getLeafEntry.mockReset().mockReturnValue(null);
   hoisted.sessionManager.getEntry.mockReset().mockReturnValue(undefined);
   hoisted.sessionManager.getEntries.mockReset().mockReturnValue([]);
+  hoisted.sessionManager.getBranch.mockReset().mockReturnValue([]);
   hoisted.sessionManager.getBoundaryCount.mockReset().mockReturnValue(0);
   hoisted.sessionManager.branch.mockReset();
   hoisted.sessionManager.resetLeaf.mockReset();

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts
@@ -9,21 +9,34 @@ import {
   type ProviderStreamOptions,
 } from "../../../../packages/ai/src/provider-types.js";
 import { createPluginMetadataSnapshot } from "../../../config/plugin-auto-enable.test-helpers.js";
+import { upsertSessionEntryCore } from "../../../config/sessions/session-accessor.js";
 import { bindStreamLlmRuntime } from "../../../llm/model-runtime-binding.js";
 import { createCodexNativeWebSearchWrapper } from "../../../llm/providers/stream-wrappers/openai.js";
 import { createAssistantMessageEventStream } from "../../../llm/utils/event-stream.js";
 import { attachRuntimePromptMediaFacts } from "../../../media/media-facts.js";
 import { withPluginRuntimeGenerationScope } from "../../../plugins/runtime/generation-scope.js";
 import type { StreamFn } from "../../runtime/index.js";
+import {
+  createAssistant,
+  createAssistantResultStream,
+  createTestSession,
+  registerAgentSessionLoopTestLifecycle,
+  testModel,
+} from "../../sessions/agent-session-loop-correctness.test-support.js";
 import { SessionManager } from "../../sessions/index.js";
 import { castAgentMessage } from "../../test-helpers/agent-message-fixtures.js";
+import { readLastCacheTtlTimestamp } from "../cache-ttl.js";
 import { testing as extraParamsTesting } from "../extra-params.test-support.js";
 import {
   clearEmbeddedSessionPromptStates,
   createToolResultPromptProjectionState,
   getEmbeddedSessionPromptState,
+  persistToolResultProjections,
+  serializeCacheTtlToolResultProjections,
 } from "../session-prompt-state.js";
+import { restoreCacheTtlToolResultProjections } from "../tool-result-truncation.js";
 import { RUN_LIVENESS_JOIN_TIMEOUT_MS } from "./abortable.js";
+import { submitEmbeddedAttemptPrompt } from "./attempt-prompt-submit.js";
 import {
   prepareEmbeddedAttemptTransport,
   settleEmbeddedAttemptStream,
@@ -207,6 +220,136 @@ describe("settleEmbeddedAttemptStream liveness", () => {
       );
     } finally {
       clearEmbeddedSessionPromptStates([sessionId, ...otherSessionIds]);
+    }
+  });
+});
+
+describe("attempt projection persistence through settlement", () => {
+  registerAgentSessionLoopTestLifecycle();
+
+  it("keeps one snapshot across unchanged dispatch, TTL settlement, and reopen", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-projection-settle-"));
+    const scope = {
+      agentId: "main",
+      sessionId: "projection-settle",
+      sessionKey: "agent:main:projection-settle",
+      storePath: path.join(dir, "sessions.json"),
+    };
+    const model = { ...testModel, provider: "anthropic", id: "claude-sonnet-4-6" };
+    try {
+      await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+      let manager = SessionManager.open(scope, dir);
+      manager.appendMessage({ role: "user", content: "read file", timestamp: 1 });
+      manager.appendMessage(
+        createAssistant(
+          model,
+          [{ type: "toolCall", id: "read-1", name: "read", arguments: {} }],
+          "toolUse",
+        ),
+      );
+      const toolResult = {
+        role: "toolResult" as const,
+        toolCallId: "read-1",
+        toolName: "read",
+        content: [{ type: "text" as const, text: "x".repeat(6_000) }],
+        isError: false,
+        timestamp: 2,
+      };
+      manager.appendMessage(toolResult);
+      manager.appendMessage(createAssistant(model, [{ type: "text", text: "read complete" }]));
+      let previousSnapshot: ReturnType<typeof serializeCacheTtlToolResultProjections> | undefined;
+      for (let turn = 0; turn < 3; turn++) {
+        const sessionPromptState = getEmbeddedSessionPromptState(scope.sessionId);
+        const projectionState = sessionPromptState.toolResults;
+        restoreCacheTtlToolResultProjections(projectionState, manager.getBranch());
+        if (previousSnapshot) {
+          expect(serializeCacheTtlToolResultProjections(projectionState)).toEqual(previousSnapshot);
+        }
+        const { session } = await createTestSession({ sessionManager: manager, model });
+        const input = createSettleFixture({
+          activeSession: session,
+          sessionManager: manager,
+          toolResultPromptProjectionState: projectionState,
+        });
+        input.attempt = {
+          ...input.attempt,
+          sessionId: scope.sessionId,
+          provider: model.provider,
+          modelId: model.id,
+          config: { agents: { defaults: { contextPruning: { mode: "cache-ttl" } } } },
+        };
+        const markers = () =>
+          manager
+            .getBranch()
+            .filter(
+              (entry) => entry.type === "custom" && entry.customType === "openclaw.cache-ttl",
+            );
+        const snapshotMarkers = () =>
+          markers().filter(
+            (entry) =>
+              entry.type === "custom" && Object.hasOwn(entry.data as object, "frozenToolResults"),
+          );
+        session.agent.streamFn = () => {
+          expect(snapshotMarkers()).toHaveLength(1);
+          return createAssistantResultStream(
+            createAssistant(model, [{ type: "text", text: "done" }]),
+          );
+        };
+        await submitEmbeddedAttemptPrompt({
+          attempt: input.attempt,
+          activeSession: session,
+          contextTokenBudget: 8_000,
+          images: [],
+          modelPrompt: "continue",
+          onFinalPromptText: () => {},
+          onSteeringAcknowledged: () => {},
+          persistToolResultProjections: async () => {
+            persistToolResultProjections(projectionState, (customType, data) =>
+              manager.appendCustomEntry(customType, data),
+            );
+          },
+          promptActiveSession: (prompt, options) => session.prompt(prompt, options),
+          runtimeOnly: false,
+          sessionPromptState,
+          systemPrompt: "test prompt",
+          toolResultAggregateMaxChars: 8_000,
+          toolResultMaxChars: 4_000,
+          toolResultPromptProjectionState: projectionState,
+          trajectoryRecorder: null,
+          transcriptLeafId: null,
+          transcriptPrompt: "continue",
+        });
+        const metadataSnapshot = createPluginMetadataSnapshot({
+          config: input.attempt.config,
+          manifestRegistry: { plugins: [], diagnostics: [] },
+        });
+        await withPluginRuntimeGenerationScope({ metadataSnapshot }, () =>
+          settleEmbeddedAttemptStream(input),
+        );
+        expect(snapshotMarkers()).toHaveLength(1);
+        expect(markers()).toHaveLength(turn + 2);
+        const touch = markers().at(-1);
+        expect(touch?.type === "custom" && touch.data).toEqual({
+          timestamp: expect.any(Number),
+          provider: model.provider,
+          modelId: model.id,
+        });
+        expect(
+          readLastCacheTtlTimestamp(manager, { provider: model.provider, modelId: model.id }),
+        ).toBe(touch?.type === "custom" && (touch.data as { timestamp: number }).timestamp);
+        expect(manager.getBranch()).toContainEqual(
+          expect.objectContaining({ type: "message", message: toolResult }),
+        );
+        previousSnapshot = serializeCacheTtlToolResultProjections(projectionState);
+        expect(previousSnapshot.frozenToolResults[0]?.texts?.[0]?.length).toBeLessThan(6_000);
+        session.dispose();
+        manager.flushPendingPersistence();
+        clearEmbeddedSessionPromptStates([scope.sessionId]);
+        manager = SessionManager.open(scope, dir);
+      }
+    } finally {
+      clearEmbeddedSessionPromptStates([scope.sessionId]);
+      await fs.rm(dir, { recursive: true, force: true });
     }
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-thread-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-thread-helpers.ts
@@ -5,6 +5,7 @@ import { normalizeStructuredPromptSection } from "@openclaw/ai/internal/shared";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { joinPresentTextSegments } from "../../../shared/text/join-segments.js";
 import {
+  hashToolResultProjectionSnapshot,
   serializeCacheTtlToolResultProjections,
   type ToolResultPromptProjectionState,
 } from "../session-prompt-state.js";
@@ -100,12 +101,17 @@ export function appendAttemptCacheTtlIfNeeded(params: {
   if (!shouldAppendAttemptCacheTtl(params)) {
     return false;
   }
-  params.sessionManager.appendCustomEntry?.(ATTEMPT_CACHE_TTL_CUSTOM_TYPE, {
-    timestamp: params.now ?? Date.now(),
-    provider: params.provider,
-    modelId: params.modelId,
-    ...serializeCacheTtlToolResultProjections(params.toolResultPromptProjectionState),
-  });
+  if (params.sessionManager.appendCustomEntry) {
+    const snapshot = serializeCacheTtlToolResultProjections(params.toolResultPromptProjectionState);
+    params.sessionManager.appendCustomEntry(ATTEMPT_CACHE_TTL_CUSTOM_TYPE, {
+      timestamp: params.now ?? Date.now(),
+      provider: params.provider,
+      modelId: params.modelId,
+      ...snapshot,
+    });
+    params.toolResultPromptProjectionState.lastWrittenSnapshotHash =
+      hashToolResultProjectionSnapshot(snapshot);
+  }
   return true;
 }
 

--- a/src/agents/embedded-agent-runner/run/attempt-thread-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-thread-helpers.ts
@@ -103,14 +103,14 @@ export function appendAttemptCacheTtlIfNeeded(params: {
   }
   if (params.sessionManager.appendCustomEntry) {
     const snapshot = serializeCacheTtlToolResultProjections(params.toolResultPromptProjectionState);
+    const hash = hashToolResultProjectionSnapshot(snapshot);
     params.sessionManager.appendCustomEntry(ATTEMPT_CACHE_TTL_CUSTOM_TYPE, {
       timestamp: params.now ?? Date.now(),
       provider: params.provider,
       modelId: params.modelId,
-      ...snapshot,
+      ...(hash !== params.toolResultPromptProjectionState.lastWrittenSnapshotHash ? snapshot : {}),
     });
-    params.toolResultPromptProjectionState.lastWrittenSnapshotHash =
-      hashToolResultProjectionSnapshot(snapshot);
+    params.toolResultPromptProjectionState.lastWrittenSnapshotHash = hash;
   }
   return true;
 }

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.cache-ttl.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.cache-ttl.test.ts
@@ -69,6 +69,7 @@ describe("runEmbeddedAttempt cache-ttl tracking after compaction", () => {
       modelId: "claude-sonnet-4-20250514",
       prunedToolResults: [],
       ambiguousToolResultBaseKeys: [],
+      frozenToolResults: [],
     });
   });
 });

--- a/src/agents/embedded-agent-runner/session-prompt-state.ts
+++ b/src/agents/embedded-agent-runner/session-prompt-state.ts
@@ -1,4 +1,4 @@
-/** Process-local prompt projection state owned by an embedded session lifecycle. */
+/** Transcript-backed prompt projection state cached by an embedded session lifecycle. */
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
@@ -81,7 +81,7 @@ export function recordToolResultPromptProjection(
   });
 }
 
-/** Marker payload stays key-sized: soft trims are recomputed from canonical history, hard clears keep only their placeholder. */
+/** TTL trims are re-derived; ordinary trims retain only text, never images or tool metadata. */
 export function serializeCacheTtlToolResultProjections(state: ToolResultPromptProjectionState) {
   const marks = new Map(state.restoredCacheTtl);
   for (const [key, projection] of state.replacements) {
@@ -97,6 +97,25 @@ export function serializeCacheTtlToolResultProjections(state: ToolResultPromptPr
   return {
     prunedToolResults: [...marks].map(([key, mark]) => Object.assign({ key }, mark)),
     ambiguousToolResultBaseKeys: [...state.ambiguousBaseKeys],
+    frozenToolResults: [...state.sourceHashByKey].flatMap(([key, sourceHash]) => {
+      if (!state.frozen.has(key)) {
+        return [];
+      }
+      const projection = state.replacements.get(key);
+      return [
+        {
+          key,
+          sourceHash,
+          ...(!projection?.cacheTtl && projection
+            ? {
+                texts: projection.content.flatMap((block) =>
+                  block.type === "text" ? [block.text] : [],
+                ),
+              }
+            : {}),
+        },
+      ];
+    }),
   };
 }
 

--- a/src/agents/embedded-agent-runner/session-prompt-state.ts
+++ b/src/agents/embedded-agent-runner/session-prompt-state.ts
@@ -1,4 +1,5 @@
 /** Transcript-backed prompt projection state cached by an embedded session lifecycle. */
+import { createHash } from "node:crypto";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
@@ -13,6 +14,7 @@ export type ToolResultPromptProjectionState = {
   sourceHashByKey: Map<string, string>;
   /** Cache-TTL marks read from the transcript marker; the projection owner materializes them on the next replay. */
   restoredCacheTtl: Map<string, RestoredCacheTtlMark>;
+  lastWrittenSnapshotHash?: string;
 };
 
 type RestoredCacheTtlMark = { mode: "soft" } | { mode: "hard"; placeholder: string };
@@ -58,6 +60,7 @@ export function cloneToolResultPromptProjectionState(
     ambiguousBaseKeys: new Set(state.ambiguousBaseKeys),
     sourceHashByKey: new Map(state.sourceHashByKey),
     restoredCacheTtl: new Map(state.restoredCacheTtl),
+    lastWrittenSnapshotHash: state.lastWrittenSnapshotHash,
   };
 }
 
@@ -130,6 +133,29 @@ export function getEmbeddedSessionPromptState(sessionId: string): EmbeddedSessio
   sessionPromptStates.set(sessionId, created);
   pruneMapToMaxSize(sessionPromptStates, MAX_SESSION_PROMPT_STATES);
   return created;
+}
+
+export function hashToolResultProjectionSnapshot(
+  snapshot: ReturnType<typeof serializeCacheTtlToolResultProjections>,
+): string {
+  return createHash("sha256").update(JSON.stringify(snapshot)).digest("hex");
+}
+
+export function persistToolResultProjections(
+  state: ToolResultPromptProjectionState,
+  appendEntry: (customType: string, data: unknown) => void,
+): void {
+  if (state.frozen.size === 0) {
+    return;
+  }
+  const snapshot = serializeCacheTtlToolResultProjections(state);
+  const hash = hashToolResultProjectionSnapshot(snapshot);
+  if (hash === state.lastWrittenSnapshotHash) {
+    return;
+  }
+  appendEntry("openclaw.cache-ttl", snapshot);
+  // A failed owned write must leave the snapshot eligible for persistence.
+  state.lastWrittenSnapshotHash = hash;
 }
 
 /** Records the prepared repository identity and snapshots this session's LRU active set. */

--- a/src/agents/embedded-agent-runner/tool-result-truncation.cache-ttl.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.cache-ttl.test.ts
@@ -119,6 +119,84 @@ function toolText(messages: AgentMessage[], id: string): string {
 }
 
 describe("cache-TTL tool-result projection", () => {
+  it.each([
+    { reset: "restart", maxChars: 4_000 },
+    { reset: "restart", maxChars: 8_000 },
+    { reset: "eviction", maxChars: 4_000 },
+    { reset: "eviction", maxChars: 8_000 },
+  ])(
+    "preserves ordinary projected bytes after $reset with a $maxChars character cap",
+    ({ reset, maxChars }) => {
+      const sessionId = `ordinary-${reset}`;
+      const sessionIds = [sessionId];
+      try {
+        const state = getEmbeddedSessionPromptState(sessionId).toolResults;
+        const history: AgentMessage[] = [user("start")];
+        let sent: AgentMessage[] = [];
+        for (let batch = 0; batch < 3; batch++) {
+          history.push(
+            assistant(),
+            tool({ id: `batch-${batch}`, text: `${batch}`.repeat(6_000), image: true }),
+          );
+          sent = truncateOversizedToolResultsInMessages(
+            history,
+            128_000,
+            maxChars,
+            8_000,
+            state,
+          ).messages;
+        }
+        expect(sent.filter((message) => message.role === "toolResult")).toHaveLength(3);
+        expect(toolText(sent, "batch-0").includes("truncated")).toBe(maxChars === 4_000);
+        expect(
+          [0, 1, 2].reduce((sum, batch) => sum + toolText(sent, `batch-${batch}`).length, 0),
+        ).toBeGreaterThan(8_000);
+        const markerData = JSON.stringify(serializeCacheTtlToolResultProjections(state));
+        const entries = [
+          {
+            type: "custom",
+            customType: "openclaw.cache-ttl",
+            data: JSON.parse(markerData),
+          },
+        ];
+        if (reset === "restart") {
+          clearEmbeddedSessionPromptStates([sessionId]);
+        } else {
+          for (let index = 0; index < 65; index++) {
+            const otherId = `${sessionId}-${index}`;
+            sessionIds.push(otherId);
+            getEmbeddedSessionPromptState(otherId);
+          }
+        }
+        const restored = getEmbeddedSessionPromptState(sessionId).toolResults;
+        expect(restored).not.toBe(state);
+        restoreCacheTtlToolResultProjections(restored, entries);
+        expect(
+          JSON.stringify(
+            truncateOversizedToolResultsInMessages(history, 128_000, maxChars, 8_000, restored)
+              .messages,
+          ) === JSON.stringify(sent),
+        ).toBe(true);
+        const compacted = [user("summary"), ...history.slice(-2)];
+        reconcileToolResultPromptProjectionState(compacted, restored);
+        expect(restored.frozen.size).toBe(1);
+        expect(restored.replacements.size).toBe(maxChars === 4_000 ? 1 : 0);
+        const compactedSnapshot = serializeCacheTtlToolResultProjections(restored);
+        expect(JSON.stringify(compactedSnapshot)).not.toContain("batch-0");
+        const reopened = createToolResultPromptProjectionState();
+        restoreCacheTtlToolResultProjections(reopened, [
+          { ...entries[0], data: compactedSnapshot },
+        ]);
+        expect(
+          truncateOversizedToolResultsInMessages(compacted, 128_000, maxChars, 8_000, reopened)
+            .messages,
+        ).toEqual([user("summary"), ...sent.slice(-2)]);
+      } finally {
+        clearEmbeddedSessionPromptStates(sessionIds);
+      }
+    },
+  );
+
   it.each(["soft", "hard"] as const)(
     "replays %s pruning after TTL refresh and restart, until compaction/reset",
     (mode) => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -23,6 +23,7 @@ import {
 import { formatContextLimitTruncationNotice } from "./context-truncation-notice.js";
 import { log } from "./logger.js";
 import {
+  hashToolResultProjectionSnapshot,
   recordToolResultPromptProjection,
   type ToolResultPromptProjectionState,
 } from "./session-prompt-state.js";
@@ -916,6 +917,7 @@ export function restoreCacheTtlToolResultProjections(
   projectionState: ToolResultPromptProjectionState,
   entries: readonly { type?: unknown; customType?: unknown; data?: unknown }[],
 ): void {
+  projectionState.lastWrittenSnapshotHash = undefined;
   for (let index = entries.length - 1; index >= 0; index--) {
     const entry = entries[index];
     if (entry?.type === "reset") {
@@ -928,6 +930,11 @@ export function restoreCacheTtlToolResultProjections(
     if (!parsed.success) {
       continue;
     }
+    projectionState.lastWrittenSnapshotHash = hashToolResultProjectionSnapshot({
+      prunedToolResults: parsed.data.prunedToolResults,
+      ambiguousToolResultBaseKeys: parsed.data.ambiguousToolResultBaseKeys ?? [],
+      frozenToolResults: parsed.data.frozenToolResults ?? [],
+    });
     for (const key of parsed.data.ambiguousToolResultBaseKeys ?? []) {
       projectionState.ambiguousBaseKeys.add(key);
     }

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -900,6 +900,15 @@ const cacheTtlProjectionSnapshotSchema = z.object({
     ]),
   ),
   ambiguousToolResultBaseKeys: z.array(z.string()).optional(),
+  frozenToolResults: z
+    .array(
+      z.object({
+        key: z.string(),
+        sourceHash: z.string(),
+        texts: z.array(z.string()).optional(),
+      }),
+    )
+    .optional(),
 });
 
 /** Reads pruned keys from the active transcript branch, never from a sibling branch. */
@@ -921,6 +930,19 @@ export function restoreCacheTtlToolResultProjections(
     }
     for (const key of parsed.data.ambiguousToolResultBaseKeys ?? []) {
       projectionState.ambiguousBaseKeys.add(key);
+    }
+    for (const { key, sourceHash, texts } of parsed.data.frozenToolResults ?? []) {
+      // A live attempt can be ahead of its last marker; never roll it back.
+      if (projectionState.sourceHashByKey.has(key)) {
+        continue;
+      }
+      projectionState.sourceHashByKey.set(key, sourceHash);
+      projectionState.frozen.add(key);
+      if (texts) {
+        projectionState.replacements.set(key, {
+          content: texts.map((text) => ({ type: "text", text })),
+        });
+      }
     }
     for (const { key, ...mark } of parsed.data.prunedToolResults) {
       if (!projectionState.replacements.get(key)?.cacheTtl) {

--- a/test/plugins/native-reasoning-subscription.test.ts
+++ b/test/plugins/native-reasoning-subscription.test.ts
@@ -270,6 +270,7 @@ describe("runtime-context replay at prompt submission", () => {
         modelPrompt: text,
         onFinalPromptText: vi.fn(),
         onSteeringAcknowledged: vi.fn(),
+        persistToolResultProjections: async () => {},
         runtimeOnly: false,
         sessionPromptState,
         systemPrompt: session.systemPrompt,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users continuing long tool-heavy sessions could lose a warm prompt-cache prefix after a Gateway restart or eviction from the 64-session in-memory cache. Previously sent tool results could be trimmed again when their accumulated size exceeded the aggregate budget.

## Why This Change Was Made

The existing hidden `openclaw.cache-ttl` transcript marker now includes ordinary projected text, frozen result identities, and canonical source hashes. Changed projection snapshots are persisted through an owned transcript write before normal model dispatch, including tool-loop requests and sessions with TTL pruning disabled. A session-local digest suppresses unchanged snapshots at dispatch and settlement and is seeded from the latest valid marker on the active branch. Unchanged settlement markers retain only the existing TTL clock fields. Projection-only markers omit timestamps, preserving TTL clock behavior. Existing restoration and canonical-history reconciliation discard results removed by compaction.

This is the maintainer-authorized F1 follow-up in the prompt-cache efficiency program. It retains the LRU and canonical tool-result entries, uses no new configuration, schema, migration, or store, and leaves TTL policy unchanged. Images and tool metadata are replayed from canonical history rather than copied into projection markers.

## User Impact

Already-sent tool history keeps the same projected bytes through restart and LRU eviction. Sequential trailing tool batches remain stable even when their combined content exceeds the aggregate budget. Session-pruning documentation now explains this persistence behavior.

## Evidence

### Settlement follow-up

Settlement now compares the same last-written snapshot digest used by pre-dispatch persistence. Unchanged settlement writes contain only the existing TTL clock fields (`timestamp`, `provider`, and `modelId`); genuinely changed snapshots still persist, and a failed append cannot advance the digest. Restoration already skips clock-only markers to find the latest valid snapshot on the active branch.

The new regression failed on the previous head immediately after settlement: two snapshot-bearing markers instead of one. It now exercises the real prompt submission and settlement paths for three unchanged turns, reopening the production SQLite SessionManager and clearing in-memory projection state between turns. It verifies exactly one snapshot, three clock-only touches, the TTL reader's timestamp, restored projections, and unchanged canonical tool-result content. The provider response is synthetic; this is not a live Gateway/provider cache-hit measurement.

Focused validation passed all five files (four Vitest shards, 23.27 seconds):

```sh
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts src/agents/embedded-agent-runner/run/attempt-prompt-submit.projections.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.cache-ttl.test.ts src/agents/embedded-agent-runner/tool-result-truncation.cache-ttl.test.ts src/agents/embedded-agent-runner/cache-ttl.test.ts
```

The previous CI run [34109977080](https://github.com/openclaw/openclaw/actions/runs/34109977080) had no projection-owned failures. Failed logs were fetched once and attributed: compact-small-22 hit update-finalization fixture startup timeouts; compact-small-29 timed out in the CI planner inventory-growth test. Both owners have landed main repairs in [#141137](https://github.com/openclaw/openclaw/pull/141137). The untouched Telegram test exceeded the max-lines limit; main split that file in [#141148](https://github.com/openclaw/openclaw/pull/141148). These are unrelated harness/lint failures with concrete main repairs, not assumed flakes.

`node scripts/check-changed.mjs`: passed (exit 0), including production/test typechecks, lint, dead exports, and selected guards. `git diff --check`: passed. Codex autoreview of the complete staged candidate against its merge base: **P0/P1 scoped-clean**, no accepted/actionable findings, patch judged correct. The initial review correctly flagged the original code still in the index; staging the fix resolved that finding, and the fresh review passed.

Current head: [`68bcf44456aa5d848f4af086ded9ea0d3f58af17`](https://github.com/openclaw/openclaw/commit/68bcf44456aa5d848f4af086ded9ea0d3f58af17). Follow-up changes two files: production +3/-3, regression +143 lines. A local merge-tree check against freshly fetched main was clean; no rebase was needed. Exact-head [CI run 34122602826](https://github.com/openclaw/openclaw/actions/runs/34122602826) **passed**. The exact-head watcher exited 0 with `GREEN`, and an independent run read confirmed `completed` / `success` on this SHA. All three previously failing jobs passed. GitHub API TLS timeouts and HTTP 499 responses required backoff during observation and the body update; no CI rerun or unrelated code change was needed. [ClawSweeper re-review requested](https://github.com/openclaw/openclaw/pull/141090#issuecomment-5570754034). The PR remains open and unmerged; no prepare-run or merge-run was executed.

### Earlier projection and persistence proof

The redundant-write regression failed before deduplication: the second unchanged request produced two markers instead of one. With the fix, three unchanged requests produce exactly one marker; a new frozen batch produces one more, and further unchanged requests add nothing. Coverage also proves restored-snapshot deduplication, changed text with unchanged frozen identities, failed-write retry, and newest-marker selection on the active branch. The runtime-prepare regression failed with the previous reader because it supplied sibling entries to restore.

Focused validation: **177 tests passed across 10 files**, four Vitest shards, 95.42 seconds:

```sh
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-truncation.test.ts src/agents/embedded-agent-runner/tool-result-truncation.cache-ttl.test.ts src/agents/embedded-agent-runner/session-prompt-state.test.ts src/agents/embedded-agent-runner/run.session-prompt-state.test.ts src/agents/embedded-agent-runner/cache-ttl.test.ts src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts src/agents/embedded-agent-runner/run/attempt-prompt-submit.projections.test.ts src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.cache-ttl.test.ts src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
node scripts/check-changed.mjs
```

CI then exposed two fixture omissions: the native provider replay fixture lacked the required persistence callback, and the shared full-runner SessionManager mock lacked `getBranch()`. Both fixtures were updated without changing production behavior or weakening assertions. The native reasoning/replay and projection rerun passed **8 tests across 2 files** (105.04 seconds); the eight affected full-runner suites passed **88 tests** (71.32 seconds). Combined with the initial focused suite, **271 distinct tests passed across 19 files**.

```sh
node scripts/run-vitest.mjs test/plugins/native-reasoning-subscription.test.ts src/agents/embedded-agent-runner/run/attempt-prompt-submit.projections.test.ts
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts src/agents/embedded-agent-runner/run/attempt.settled-turn-finalization-context.test.ts src/agents/embedded-agent-runner/run/attempt.skills-policy.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.diagnostics.test.ts src/agents/embedded-agent-runner/run/attempt.subagent-runtime-facts.test.ts src/agents/embedded-agent-runner/run/attempt.ultra-thinking.test.ts
node scripts/check-changed.mjs -- test/plugins/native-reasoning-subscription.test.ts
node scripts/check-changed.mjs -- src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
```

Synthetic SQLite persistence proof used the production SessionManager and projection owners in isolated state directories, with reopen in fresh Node processes. Canonical messages and projected bytes remained identical, and reopening added no duplicate markers. Both timestamp-only legacy markers and the previous projection envelope without `frozenToolResults` remained readable. The legacy hard-pruning placeholder replayed exactly; expanded metadata was written once and subsequent requests/reopens added nothing. This validates marker-format compatibility on the unchanged SQLite schema, not a historical schema migration or old binary.

| Synthetic persistence workload | Projection markers | Serialized marker bytes |
| --- | ---: | ---: |
| Three unchanged calls | 1 | 4,370 |
| Another 10,000 unchanged calls | 1 | 4,370 |
| One new frozen batch | 2 | 12,839 |
| 64 growing batches | 64 | 8,544,749 |
| Another 1,000 unchanged calls after those batches | 64 | 8,544,749 |

For the 64-batch fixture, the latest snapshot was 262,469 bytes; the SQLite database occupied 9,687,040 bytes. Fresh-process SessionManager open took 132.46 ms, followed by 2.09 ms for restore/replay, excluding module loading. The two-batch fixture took 120.13 ms to open and 1.07 ms to restore/replay. These are local synthetic observations, not performance guarantees.

This addresses ClawSweeper's repeated-write concern and adds its requested durable-reopen/storage evidence. The maintainer-directed persistence contract retains full snapshots for genuinely changed batches; their cumulative storage can still grow quadratically with the number of accumulating batches. The follow-up removes unchanged writes without introducing a new store, schema, migration, retention policy, or TTL policy. The documented contract is in [session pruning](https://github.com/openclaw/openclaw/blob/c437c9b3d407860a109d279c6213f514c63525d2/docs/concepts/session-pruning.md).

`node scripts/check-changed.mjs`: **passed, exit 0**, including formatting, core production/test typechecks, lint, dead exports, and selected architecture guards. The first run found an unused exported reader after the active-branch repair; it was made module-private and the complete gate passed on rerun. `git diff --check`: passed. The fixture-specific changed gates also passed after the CI repairs. No guard or baseline was weakened.

Codex autoreview of the full production PR candidate against its merge base and the subsequent fixture repairs: **P0/P1 scoped-clean**, zero accepted/actionable findings; patches judged correct.

Previous head: [`76828d73e9f6bbd652aadc1dca1838e49b5e42dc`](https://github.com/openclaw/openclaw/commit/76828d73e9f6bbd652aadc1dca1838e49b5e42dc). The owner fix is in [`c437c9b3d407`](https://github.com/openclaw/openclaw/commit/c437c9b3d407860a109d279c6213f514c63525d2); the final commit updates the two CI fixtures. Combined follow-up diff from the originally reviewed head: **11 files, +122/-26**. Full PR diff: **18 files, +376/-42**. `node scripts/watch-pr-ci.mjs 141090 76828d73e9f6bbd652aadc1dca1838e49b5e42dc` attached to [CI run 34109977080](https://github.com/openclaw/openclaw/actions/runs/34109977080) and exited 15 for `check-lint`. The repaired `check-test-types` job passed. Other jobs, including the two previously affected compact test shards, were still running at handoff; overall CI is not green.

That previous-head CI run repeated the unrelated lint failure in the untouched `extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts` (1,012 counted lines, limit 1,000). The file and lint configuration are identical between this PR and its merge base; newer main added 29 lines through [PR #122221](https://github.com/openclaw/openclaw/pull/122221), exactly accounting for the failure. This is a separate main-branch repair, not an exception added to this PR. [Failing lint job](https://github.com/openclaw/openclaw/actions/runs/34109977080/job/101703996019).

No live Gateway restart, provider cache-hit, or billing measurement was performed. The SQLite probe exercised production storage/projection boundaries with synthetic data; the dispatch regression used the production submission path with a substituted provider stream.
