### PR TITLE
fix(ui): stop clipboard mocks leaking into Mermaid tests

### DIFF
--- a/ui/src/components/markdown-clipboard.browser.test.ts
+++ b/ui/src/components/markdown-clipboard.browser.test.ts
@@ -12,11 +12,6 @@ import "./markdown-mermaid.ts";
 import { handleMarkdownTableInteraction, releaseMarkdownTables } from "./markdown-tables.ts";
 import { toSanitizedMarkdownHtml } from "./markdown.ts";
 
-vi.mock("@openclaw/mermaid-renderer", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@openclaw/mermaid-renderer")>()),
-  renderMermaidSvg: async () => '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"/>',
-}));
-
 const owners: HTMLElement[] = [];
 const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
 let clipboard = "original clipboard";


### PR DESCRIPTION
## What Problem This Solves

Resolves six intermittent native Mermaid browser-test failures that block unrelated PRs when the clipboard tests run earlier in the same Chromium worker.

Related: #140893, #141020. Failing [CI job](https://github.com/openclaw/openclaw/actions/runs/34101306506/job/101676390613): 5,142 passed, 6 failed, 1 skipped.

## Why This Change Was Made

The clipboard file installed a module-wide Mermaid mock that returned an SVG without a `viewBox`. Its `vi.restoreAllMocks()` cleanup restores spies, but leaves that module mock active in the non-isolated browser worker. Later native rendering computes invalid image dimensions and reports permanent failures, including cases that should exercise retryable engine and decoder failures.

The clipboard tests do not assert rendered SVG output: they exercise copy intent, source changes, and retirement of stale clipboard work. Removing their unnecessary mock lets the existing real renderer own rendering and cleanup. All 21 clipboard cases and all 6 native renderer cases retain their assertions. This removes five test lines and changes no production code, dependencies, isolation settings, or timeouts.

## User Impact

No product behavior or appearance change. Shared-worker browser runs preserve the real Mermaid renderer for later files.

## Evidence

- Native test alone: **6/6 passed**.
- Original clipboard-first ordering in one non-isolated Chromium worker: **21 passed / 6 failed**, reproducing the exact CI failure pattern.
- Repaired ordered pair: **10/10 runs passed**, all 27 cases each run.
- Canonical CI shard 1/3 with three workers: **329 files passed; 5,148 tests passed, 1 existing skip; zero unhandled errors** (294.32 seconds).
- `node scripts/check-changed.mjs`: passed all selected checks.
- Independent Codex review: scoped-clean through P2, 0 actionable findings.

The ordered proof uses the repository UI config and a temporary sequencer that sorts the two module IDs alphabetically, preserving CI's clipboard-before-native order. No product or committed test configuration is changed:

```js
import { BaseSequencer } from 'vitest/node';
export default class extends BaseSequencer {
  async sort(files) {
    return files.toSorted((a, b) => a.moduleId.localeCompare(b.moduleId));
  }
}
```

A temporary config imports `ui/vitest.config.ts`, preserves its complete configuration, and sets only `test.sequence.sequencer` to this class. The same command runs before and after the deletion:

```sh
CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config .local/l0b-mermaid.config.mts --configLoader runner --project chromium ui/src/components/markdown-clipboard.browser.test.ts ui/src/components/markdown-mermaid-native.browser.test.ts --maxWorkers=1 --no-file-parallelism
node scripts/check-changed.mjs
```

Proof base: `6a78a20f995b27b7c9b5fd04ed317fa2a62e0f9a`. Rebased onto main `857ae4447f3`; the Markdown components/tests, Mermaid renderer package, and UI test configuration are unchanged across that refresh. Synthetic local browser data; no external-provider live claim. Exact-head CI remains required before native landing.

Full shard command, matching the original CI plan and three-worker packing:

```sh
CI=1 DEBUG=vitest:browser:pool \
OPENCLAW_NODE_TEST_CONFIGS_JSON='["ui/vitest.config.ts"]' \
OPENCLAW_NODE_TEST_PLAN_CONCURRENCY=1 \
OPENCLAW_NODE_TEST_VITEST_ARGS_JSON='["--maxWorkers","3","--reporter=verbose","--reporter=github-actions","--reporter=./scripts/lib/vitest-resource-reporter.mts","--shard=1/3"]' \
node --import ./scripts/tsx.mjs scripts/ci-run-node-test-shard.mts
```

Local proof used task-owned filesystem module caches on macOS/Node 26; the failing CI used Linux/Node 24. The deterministic ordering failure reproduces locally; exact-head hosted CI will verify Linux before landing. The existing skip belongs to the unchanged shard inventory; this repair adds no skip.
