### PR TITLE
refactor(minimax): reuse generated video asset downloader

### DIFF
--- a/extensions/minimax/video-generation-provider.test.ts
+++ b/extensions/minimax/video-generation-provider.test.ts
@@ -269,82 +269,94 @@ describe("minimax video generation provider", () => {
     },
   );
 
-  it("downloads via file_id when the status response omits video_url", async () => {
-    const requestOverrides = {
-      allowPrivateNetwork: true,
-      headers: { "X-MiniMax-Video-Policy": "enabled" },
-    };
-    postJsonRequestMock.mockResolvedValue({
-      response: jsonResponse({
-        task_id: "task-456",
-        base_resp: { status_code: 0 },
-      }),
-      release: vi.fn(async () => {}),
-    });
-    fetchWithTimeoutMock
-      .mockResolvedValueOnce(
-        jsonResponse({
+  it.each([
+    { name: "supplied", filename: " output_aigc.mp4 ", expectedFileName: "output_aigc.mp4" },
+    { name: "missing", filename: undefined, expectedFileName: "video-1.webm" },
+    { name: "blank", filename: "   ", expectedFileName: "video-1.webm" },
+  ])(
+    "downloads via file_id with a $name filename when status omits video_url",
+    async ({ filename, expectedFileName }) => {
+      const requestOverrides = {
+        allowPrivateNetwork: true,
+        headers: { "X-MiniMax-Video-Policy": "enabled" },
+      };
+      postJsonRequestMock.mockResolvedValue({
+        response: jsonResponse({
           task_id: "task-456",
-          status: "Success",
-          file_id: "file-9",
           base_resp: { status_code: 0 },
         }),
-      )
-      .mockResolvedValueOnce(
-        jsonResponse({
-          file: {
-            file_id: "file-9",
-            filename: "output_aigc.mp4",
-            download_url: "https://example.com/download.mp4",
-          },
-          base_resp: { status_code: 0 },
-        }),
-      )
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/mp4" }),
-        arrayBuffer: async () => Buffer.from("mp4-bytes"),
+        release: vi.fn(async () => {}),
       });
+      fetchWithTimeoutMock
+        .mockResolvedValueOnce(
+          jsonResponse({
+            task_id: "task-456",
+            status: "Success",
+            file_id: "file-9",
+            base_resp: { status_code: 0 },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            file: {
+              file_id: "file-9",
+              filename,
+              download_url: "https://example.com/download.mp4",
+            },
+            base_resp: { status_code: 0 },
+          }),
+        )
+        .mockResolvedValueOnce({
+          headers: new Headers({ "content-type": "video/webm" }),
+          arrayBuffer: async () => Buffer.from("webm-bytes"),
+        });
 
-    const provider = buildMinimaxVideoGenerationProvider();
-    const result = await provider.generateVideo({
-      provider: "minimax",
-      model: "MiniMax-Hailuo-2.3",
-      prompt: "A fox sprints across snowy hills",
-      cfg: {
-        models: {
-          providers: {
-            minimax: {
-              baseUrl: "https://api.minimax.io",
-              models: [],
-              request: requestOverrides,
+      const provider = buildMinimaxVideoGenerationProvider();
+      const result = await provider.generateVideo({
+        provider: "minimax",
+        model: "MiniMax-Hailuo-2.3",
+        prompt: "A fox sprints across snowy hills",
+        cfg: {
+          models: {
+            providers: {
+              minimax: {
+                baseUrl: "https://api.minimax.io",
+                models: [],
+                request: requestOverrides,
+              },
             },
           },
         },
-      },
-    });
+      });
 
-    expectMinimaxFetchCall(1, "https://api.minimax.io/v1/files/retrieve?file_id=file-9");
-    expectMinimaxFetchCall(2, "https://example.com/download.mp4");
-    const statusFetch = expectMinimaxGuardedFetchCall(
-      0,
-      "https://api.minimax.io/v1/query/video_generation?task_id=task-456",
-    );
-    expect((statusFetch.init.headers as Headers).get("x-minimax-video-policy")).toBe("enabled");
-    expectAllowPrivateNetworkPolicy(statusFetch.options);
-    const metadataFetch = expectMinimaxGuardedFetchCall(
-      1,
-      "https://api.minimax.io/v1/files/retrieve?file_id=file-9",
-    );
-    expect((metadataFetch.init.headers as Headers).get("x-minimax-video-policy")).toBe("enabled");
-    expectAllowPrivateNetworkPolicy(metadataFetch.options);
-    expectAllowPrivateNetworkPolicy(
-      expectMinimaxGuardedFetchCall(2, "https://example.com/download.mp4").options,
-    );
-    expect(result.videos).toHaveLength(1);
-    expect(result.metadata?.taskId).toBe("task-456");
-    expect(result.metadata?.fileId).toBe("file-9");
-    expect(result.metadata?.videoUrl).toBeUndefined();
-  });
+      expectMinimaxFetchCall(1, "https://api.minimax.io/v1/files/retrieve?file_id=file-9");
+      expectMinimaxFetchCall(2, "https://example.com/download.mp4");
+      const statusFetch = expectMinimaxGuardedFetchCall(
+        0,
+        "https://api.minimax.io/v1/query/video_generation?task_id=task-456",
+      );
+      expect((statusFetch.init.headers as Headers).get("x-minimax-video-policy")).toBe("enabled");
+      expectAllowPrivateNetworkPolicy(statusFetch.options);
+      const metadataFetch = expectMinimaxGuardedFetchCall(
+        1,
+        "https://api.minimax.io/v1/files/retrieve?file_id=file-9",
+      );
+      expect((metadataFetch.init.headers as Headers).get("x-minimax-video-policy")).toBe("enabled");
+      expectAllowPrivateNetworkPolicy(metadataFetch.options);
+      expectAllowPrivateNetworkPolicy(
+        expectMinimaxGuardedFetchCall(2, "https://example.com/download.mp4").options,
+      );
+      expect(result.videos).toHaveLength(1);
+      expect(result.videos[0]).toMatchObject({
+        buffer: Buffer.from("webm-bytes"),
+        mimeType: "video/webm",
+        fileName: expectedFileName,
+      });
+      expect(result.metadata?.taskId).toBe("task-456");
+      expect(result.metadata?.fileId).toBe("file-9");
+      expect(result.metadata?.videoUrl).toBeUndefined();
+    },
+  );
 
   it("retries guarded video status polling while preserving request policy", async () => {
     const requestOverrides = {

--- a/extensions/minimax/video-generation-provider.ts
+++ b/extensions/minimax/video-generation-provider.ts
@@ -4,7 +4,6 @@ import {
   downloadGeneratedVideoAsset,
   resolveGeneratedMediaMaxBytes,
 } from "openclaw/plugin-sdk/media-generation-runtime";
-import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
@@ -14,7 +13,6 @@ import {
   executeProviderOperationWithRetry,
   fetchWithTimeoutGuarded,
   postJsonRequest,
-  readProviderBinaryResponse,
   readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
   resolveProviderHttpRequestConfig,
@@ -337,43 +335,17 @@ async function downloadVideoFromFileId(params: {
   if (!downloadUrl) {
     throw new Error("MiniMax generated video metadata missing download_url");
   }
-  const deadline = createProviderOperationDeadline({
-    timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-    label: "MiniMax generated video download",
-  });
-  const timeoutMs = createProviderOperationTimeoutResolver({
-    deadline,
-    defaultTimeoutMs: deadline.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-  });
-  const { response, release } = await fetchMinimaxResponse({
-    stage: "download",
+  const video = await downloadVideoFromUrl({
     url: downloadUrl,
-    init: { method: "GET" },
-    timeoutMs,
+    timeoutMs: params.timeoutMs,
     fetchFn: params.fetchFn,
-    requestFailedMessage: "MiniMax generated video download failed",
+    maxBytes: params.maxBytes,
     policy: params.policy,
   });
-  try {
-    const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
-    const buffer = await readProviderBinaryResponse(response, deadline.label, "video", {
-      maxBytes: params.maxBytes,
-      chunkTimeoutMs: 0,
-      timeoutMs,
-      onTimeout: ({ timeoutMs: bodyTimeoutMs }) =>
-        new Error(`${deadline.label} timed out after ${deadline.timeoutMs ?? bodyTimeoutMs}ms`),
-      onOverflow: ({ maxBytes }) => new Error(`${deadline.label} exceeds ${maxBytes} bytes`),
-    });
-    return {
-      buffer,
-      mimeType,
-      fileName:
-        normalizeOptionalString(metadata.file?.filename) ||
-        `video-1.${extensionForMime(mimeType)?.slice(1) ?? "mp4"}`,
-    };
-  } finally {
-    await release();
-  }
+  return {
+    ...video,
+    fileName: normalizeOptionalString(metadata.file?.filename) || video.fileName,
+  };
 }
 
 function buildMinimaxVideoProvider(providerId: string): VideoGenerationProvider {


### PR DESCRIPTION
## What Problem This Solves

MiniMax's file-ID video path independently downloaded and materialized the same asset already handled by its direct-URL path. Limits, guarded transport and filename behavior could drift between those entry points.

## Why This Change Was Made

Peter Steinberger explicitly requested this bounded work as item 4 of the media de-duplication campaign. The broader API choice below remains reserved for maintainer decision.

After validating and releasing file metadata, the file-ID path now calls its existing URL downloader, which delegates to the canonical media-generation asset helper. Metadata filenames still override the helper's MIME-derived name. Deadline evaluation, request retries, SSRF policy, binary validation, byte limits and disabled idle timeout remain unchanged.

Production net -28 lines. The existing file-ID success test now covers supplied, missing and blank filenames (+12 test lines).

## User Impact

No intentional user-visible behavior, configuration or SDK change.

## Deferred API choice (maintainer)

The maintainer approved landing this bounded precursor independently; the broader API design below remains deferred.

The larger generated-asset consolidation needs a public delivery-policy contract before Fal and OpenRouter can adopt the existing downloader unchanged. Fal preserves the URL on successful buffered output and overflow; OpenRouter permits URL-only overflow only for an approved unsigned delivery URL. Both currently rely on the guarded transport's deadline without adding the core helper's body timer. Do not infer overflow by matching error text or broaden URL eligibility.

The music/video core wrappers already share the canonical deadline, retry-fetch and bounded-read primitives. Their MIME selection, filename and source-metadata behavior remain meaningful typed policy; a generic callback layer was not a useful simplification. #139191's separate Fal image/music binary-validation work is untouched. This bounded PR completes only the direct MiniMax duplicate removal while the full asset API decision remains open.

## Evidence

- Refreshed onto main with the shared Telegram lint fixes. `git range-diff` confirms this bounded patch is unchanged; the shared downloader owner also has no intervening change.
- `node scripts/run-vitest.mjs extensions/minimax/video-generation-provider.test.ts src/media-generation/provider-assets.test.ts src/music-generation/provider-assets.test.ts`: 3 files, 23 tests passed on the refreshed head.
- `node scripts/check-changed.mjs`: 20 checks passed. Extension lint preparation hit the approved nested-worktree `Declaration input escapes checkout` limitation; exact-head hosted CI supplies that boundary proof.
- Fresh independent Codex autoreview: scoped-clean through P2, zero actionable findings. The shared downloader was inspected directly. `git diff --check` passed.
- Exact-head [CI run 34120745777](https://github.com/openclaw/openclaw/actions/runs/34120745777) passed on `f9897fb1a3968ae8920007b0c2c8cfe057bd60e6`, without a manual CI rerun.
- Native review artifacts validated, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 141094` passed without changing the green CI head.
- No live provider-generation claim. The broader delivery-policy API remains deferred.
