### PR TITLE
fix(ui): show own avatar in New Session preview and focus composer quietly

### DIFF
--- a/docs/web/control-ui/sessions-and-sidebar.md
+++ b/docs/web/control-ui/sessions-and-sidebar.md
@@ -156,6 +156,8 @@ If startup is rejected, the draft remains available to correct and retry.
 
 On a normal foreground OpenClaw Chat send, the submitted text and attachments appear immediately with a **Starting** indicator while the Gateway creates or adopts the session. This is a pending submission, not a Gateway acknowledgment. If creation is rejected, your prompt and attachments remain available to correct and retry. Once creation succeeds, the UI opens the session's chat.
 
+Attributed submissions show your avatar immediately, in the same position as the chat transcript. Opening the created session focuses the composer quietly; the attention cue is reserved for navigation that prefills a draft.
+
 The project picker refreshes after sign-in and reconnects. Gateway reconnects and Git verification retries preserve your edited base branch and worktree name. Choosing another folder or project clears those repository-specific details.
 
 For local worktree sessions, sending the first message opens the admitted session before naming, checkout, and setup finish. The chat shows the submitted message and preparation stages. A generated title is saved as soon as naming completes, independently of checkout and setup. Setup failures remain visible in that session; send a retry there after correcting the problem. The retry reuses the saved title. If naming itself fails, another attempt uses the original first prompt, including text attachments. Stopping during setup cancels preparation without starting the agent. Steering an active run keeps its progress visible, and delayed history cannot replace a newer startup stage or restore startup labels after activity begins.

--- a/ui/src/pages/chat/chat-avatar.ts
+++ b/ui/src/pages/chat/chat-avatar.ts
@@ -11,11 +11,8 @@ import {
 } from "../../app/user-identity.ts";
 import { icons } from "../../components/icons.ts";
 import {
-  identityAvatarClass,
   identityAvatarImage,
-  renderIdentityAvatarImage,
   resolveIdentityAvatarView,
-  type IdentityAvatarView,
 } from "../../components/identity-avatar-view.ts";
 import type { AssistantIdentity } from "../../lib/assistant-identity.ts";
 import {
@@ -38,6 +35,7 @@ import {
   parseAgentSessionKey,
   resolveUiSelectedGlobalAgentId,
 } from "../../lib/sessions/session-key.ts";
+import { renderUserAvatarSlot } from "./components/chat-author-avatar.ts";
 
 export function renderChatAvatar(
   role: string,
@@ -179,33 +177,6 @@ export function renderForwardedAvatar(agentId: string | undefined, opts: Forward
       "assistant",
     ),
   );
-}
-
-/**
- * The avatar URL may 404 or be unreachable (missing upload, dead Gravatar,
- * stale configured URL); swap to initials instead of a broken image. Lit
- * reuses DOM parts, so a load must clear a prior identity's error state.
- */
-function renderUserAvatarSlot(view: IdentityAvatarView, label: string, role = "user") {
-  const initialsAvatar = html`<div
-    class="chat-avatar ${role} chat-avatar--sender-initials"
-    style=${`background: hsl(${view.fallback.colorSeed % 360} 48% 42%)`}
-    role="img"
-    aria-label="${label}"
-  >
-    ${view.fallback.initials}
-  </div>`;
-  if (!view.imageUrl) {
-    return initialsAvatar;
-  }
-  return html`<span class=${identityAvatarClass("chat-avatar-slot", view)}>
-    ${renderIdentityAvatarImage({
-      view,
-      fallbackSelector: ".chat-avatar-slot",
-      className: `chat-avatar ${role}`,
-      alt: label,
-    })}${initialsAvatar}
-  </span>`;
 }
 
 function isAvatarUrl(value: string): boolean {

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -34,52 +34,48 @@ const SKIP_REWIND_CONFIRM_PREFERENCE = "openclaw:skip-rewind-confirm";
 const confirmationOwners = new Set<HTMLElement>();
 
 describe("chat pane composer prefill attention", () => {
-  function createComposerAttentionFixture() {
+  it.each([
+    { label: "draft prefill", draft: "Prefilled prompt", repeat: false, attention: true },
+    { label: "repeated draft prefill", draft: "Prefilled prompt", repeat: true, attention: true },
+    { label: "plain focus", draft: undefined, repeat: false, attention: false },
+    { label: "empty draft", draft: "", repeat: false, attention: false },
+  ])("focuses with the expected attention cue for $label", ({ draft, repeat, attention }) => {
+    vi.useFakeTimers();
     const { pane } = createTestChatPane({
       client: {} as GatewayBrowserClient,
       sessions: {} as SessionCapability,
     });
-    const input = document.createElement("div");
+    const input = document.body.appendChild(document.createElement("div"));
     input.className = "agent-chat__input";
-    const textarea = document.createElement("textarea");
-    input.append(textarea);
-    document.body.append(input);
+    const textarea = input.appendChild(document.createElement("textarea"));
     vi.spyOn(pane, "querySelector").mockReturnValue(textarea);
     const lifecycle = pane as TestChatPane & {
+      draft?: string;
       focusComposer: boolean;
       updated: (changedProperties?: Map<PropertyKey, unknown>) => void;
     };
     lifecycle.focusComposer = true;
-    return { input, lifecycle, textarea };
-  }
-
-  it("focuses and clears the one-shot composer cue for an explicit route hint", () => {
-    vi.useFakeTimers();
-    const { input, lifecycle, textarea } = createComposerAttentionFixture();
-
+    lifecycle.draft = draft;
+    const attentionClass = "agent-chat__input--prefill-attention";
+    const mutations = new MutationObserver(() => {});
+    mutations.observe(input, { attributeFilter: ["class"], attributeOldValue: true });
     lifecycle.updated(new Map([["focusComposer", false]]));
-
     expect(document.activeElement).toBe(textarea);
-    expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(true);
+    expect(input.classList.contains(attentionClass)).toBe(attention);
+    if (repeat) {
+      vi.advanceTimersByTime(300);
+      lifecycle.updated(new Map([["focusComposer", false]]));
+    }
     vi.advanceTimersByTime(599);
-    expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(true);
+    expect(input.classList.contains(attentionClass)).toBe(attention);
     vi.advanceTimersByTime(1);
-    expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(false);
-    input.remove();
-  });
-
-  it("restarts the cue without letting the prior timer clear it", () => {
-    vi.useFakeTimers();
-    const { input, lifecycle } = createComposerAttentionFixture();
-
-    lifecycle.updated(new Map([["focusComposer", false]]));
-    vi.advanceTimersByTime(300);
-    lifecycle.updated(new Map([["focusComposer", false]]));
-    vi.advanceTimersByTime(599);
-
-    expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(true);
-    vi.advanceTimersByTime(1);
-    expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(false);
+    expect(input.classList.contains(attentionClass)).toBe(false);
+    if (!attention) {
+      expect(
+        mutations.takeRecords().some(({ oldValue }) => oldValue?.includes(attentionClass)),
+      ).toBe(false);
+    }
+    mutations.disconnect();
     input.remove();
   });
 });

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -564,7 +564,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
       const textarea = this.querySelector<HTMLTextAreaElement>(CHAT_COMPOSER_TEXTAREA_SELECTOR);
       const input = textarea?.closest<HTMLElement>(".agent-chat__input");
       textarea?.focus({ preventScroll: true });
-      if (input) {
+      if (input && this.draft) {
         this.showComposerPrefillAttention(input);
       }
     }

--- a/ui/src/pages/chat/components/chat-author-avatar.ts
+++ b/ui/src/pages/chat/components/chat-author-avatar.ts
@@ -57,3 +57,37 @@ export function renderChatAuthorAvatar(
     ${resolved}
   </span>`;
 }
+
+export function resolveChatDefaultAvatarPlacement(
+  isDirectSession: boolean,
+  userId?: string | null,
+): "footer" | "gutter" {
+  return isDirectSession && !userId ? "footer" : "gutter";
+}
+
+/**
+ * The avatar URL may 404 or be unreachable (missing upload, dead Gravatar,
+ * stale configured URL); swap to initials instead of a broken image. Lit
+ * reuses DOM parts, so a load must clear a prior identity's error state.
+ */
+export function renderUserAvatarSlot(view: IdentityAvatarView, label: string, role = "user") {
+  const initialsAvatar = html`<div
+    class="chat-avatar ${role} chat-avatar--sender-initials"
+    style=${`background: hsl(${view.fallback.colorSeed % 360} 48% 42%)`}
+    role="img"
+    aria-label="${label}"
+  >
+    ${view.fallback.initials}
+  </div>`;
+  if (!view.imageUrl) {
+    return initialsAvatar;
+  }
+  return html`<span class=${identityAvatarClass("chat-avatar-slot", view)}>
+    ${renderIdentityAvatarImage({
+      view,
+      fallbackSelector: ".chat-avatar-slot",
+      className: `chat-avatar ${role}`,
+      alt: label,
+    })}${initialsAvatar}
+  </span>`;
+}

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -33,6 +33,7 @@ import {
 } from "../chat-thread.ts";
 import { hasForwardedSource } from "../chat-turn-boundary.ts";
 import { renderAgentRunFrame } from "./chat-agent-run-frame.ts";
+import { resolveChatDefaultAvatarPlacement } from "./chat-author-avatar.ts";
 import { renderBackgroundTasksStatusRow } from "./chat-background-tasks-status.ts";
 import { renderChatDivider, renderChatNotice } from "./chat-divider.ts";
 import { resolveMessageGroupSenderLabel } from "./chat-message-group.ts";
@@ -250,10 +251,12 @@ export function projectChatTranscript(
   const hasForwardedGroups = chatItems.some(
     (item) => item.kind === "group" && hasForwardedSource(item),
   );
-  const isDirectThread =
+  const defaultAvatarPlacement = resolveChatDefaultAvatarPlacement(
     (sessionKind === "direct" || sessionKind === "cron" || sessionKind === "spawn-child") &&
-    !props.userId &&
-    !hasForwardedGroups;
+      !hasForwardedGroups,
+    props.userId,
+  );
+  const isDirectThread = defaultAvatarPlacement === "footer";
   // Precedence: explicit prop, subagent classification/spawnedBy/key → none, direct → footer, else gutter.
   const avatarPlacement =
     props.avatarPlacement ??
@@ -261,9 +264,7 @@ export function projectChatTranscript(
     activeSession?.spawnedBy ||
     isSubagentSessionKey(props.sessionKey)
       ? "none"
-      : isDirectThread
-        ? "footer"
-        : "gutter");
+      : defaultAvatarPlacement);
   const showLoadingSkeleton = props.loading && chatItems.length === 0 && !hasTypingActors;
   const threadContextWindow =
     activeSession?.contextTokens ?? props.sessions?.defaults?.contextTokens ?? null;

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -14,10 +14,11 @@ import {
 import type { SessionToolOverrides } from "../../lib/sessions/patch.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { adjustTextareaHeight } from "../chat/components/chat-composer-dom.ts";
+import { buildLocalUserMessage } from "../chat/user-message-content.ts";
 import { NewSessionAttachmentDraft } from "./attachment-draft.ts";
 import { NewSessionComposerTextareaController } from "./composer.ts";
 import type { NewSessionVisibility } from "./create-params.ts";
-import { renderNewSessionDraftComposer } from "./draft-composer.ts";
+import { renderNewSessionBody, renderNewSessionDraftComposer } from "./draft-composer.ts";
 import { NewSessionModelControl } from "./model-control.ts";
 
 const attachmentDrafts: NewSessionAttachmentDraft[] = [];
@@ -144,6 +145,45 @@ afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
   replaceSlashCommands(buildFallbackSlashCommands());
+});
+
+describe("new-session submission preview", () => {
+  it.each([
+    { userId: "profile-alex", placement: "gutter" },
+    { userId: null, placement: "footer" },
+  ])("immediately shows the own-user avatar in the $placement", ({ userId, placement }) => {
+    const container = document.createElement("div");
+    const avatarUrl = "/api/users/profile-alex/avatar?v=1";
+    render(
+      renderNewSessionBody({
+        error: null,
+        pendingMessage: buildLocalUserMessage({
+          createdAt: 1,
+          text: "Hello from Alex",
+          sender: {
+            identity: { type: "profile", id: "profile-alex" },
+            name: "Alex",
+            profileAvatarUrl: avatarUrl,
+          },
+        }),
+        userId,
+        submitting: true,
+        renderDraft: () => html``,
+        onOpenImage: () => {},
+      }),
+      container,
+    );
+
+    const group = container.querySelector(".chat-group.user");
+    const avatar = group?.querySelector(
+      placement === "gutter"
+        ? ":scope > .chat-avatar-slot img"
+        : ":scope > .chat-group-footer > .chat-group-footer__meta .chat-author-avatar img",
+    );
+    expect(avatar?.getAttribute("src")).toBe(avatarUrl);
+    expect(group?.classList.contains("chat-group--with-footer")).toBe(true);
+    expect(group?.closest(".chat-thread--direct") !== null).toBe(placement === "footer");
+  });
 });
 
 describe("new-session composer keyboard submission", () => {

--- a/ui/src/pages/new-session/draft-composer.ts
+++ b/ui/src/pages/new-session/draft-composer.ts
@@ -4,10 +4,12 @@ import type { ApplicationContext } from "../../app/context.ts";
 import { beginNativeWindowDragFromTopInset } from "../../app/native-window-drag.ts";
 import { hasOperatorWriteAccess } from "../../app/operator-access.ts";
 import { icons } from "../../components/icons.ts";
+import { resolveIdentityAvatarView } from "../../components/identity-avatar-view.ts";
 import type { ImageLightboxItem } from "../../components/image-lightbox.ts";
 import { t } from "../../i18n/index.ts";
 import type { HumanMention } from "../../lib/chat/chat-types.ts";
 import { normalizeMessage } from "../../lib/chat/message-normalizer.ts";
+import { formatSenderLabel } from "../../lib/chat/sender-label.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { resolveIdentityHue } from "../../lib/identity-avatar.ts";
 import type { SessionToolOverrides } from "../../lib/sessions/patch.ts";
@@ -16,6 +18,11 @@ import "../../styles/chat/text.css";
 import "../../styles/chat/grouped.css";
 import "../../styles/chat/working-indicator.css";
 import { refreshSlashCommands } from "../chat/chat-commands.ts";
+import {
+  renderChatAuthorAvatar,
+  renderUserAvatarSlot,
+  resolveChatDefaultAvatarPlacement,
+} from "../chat/components/chat-author-avatar.ts";
 import type { CapabilityMenuProps } from "../chat/components/chat-composer-types.ts";
 import { renderAssistantAttachments } from "../chat/components/chat-message-attachments.ts";
 import { renderMessageImages } from "../chat/components/chat-message-images.ts";
@@ -99,11 +106,17 @@ export function renderNewSessionDraftErrors(
 export function renderNewSessionBody(options: {
   error: string | null;
   pendingMessage: ReturnType<typeof buildLocalUserMessage>;
+  userId?: string | null;
   submitting: boolean;
   renderDraft: () => TemplateResult;
   onOpenImage: (item: ImageLightboxItem) => void;
 }) {
   const { pendingMessage } = options;
+  const normalized = pendingMessage ? normalizeMessage(pendingMessage) : null;
+  const avatarPlacement = resolveChatDefaultAvatarPlacement(
+    true,
+    normalized?.sender ? options.userId : null,
+  );
   const draftLocked = options.submitting && !pendingMessage;
   // Late cleanup can fail while a replacement submission is still pending.
   return html`
@@ -111,15 +124,20 @@ export function renderNewSessionBody(options: {
       ${pendingMessage ? t("newSession.starting") : nothing}
     </div>
     <div
-      class="new-session-page__scroll ${pendingMessage ? "chat-thread chat-thread--direct" : ""}"
+      class="new-session-page__scroll ${pendingMessage ? `chat-thread ${avatarPlacement === "footer" ? "chat-thread--direct" : ""}` : ""}"
       ?inert=${draftLocked}
       aria-busy=${String(draftLocked)}
       @mousedown=${beginNativeWindowDragFromTopInset}
     >
       ${options.error ? renderDraftError(options.error) : nothing}
       ${
-        pendingMessage
-          ? renderNewSessionSubmission(pendingMessage, options.onOpenImage)
+        pendingMessage && normalized
+          ? renderNewSessionSubmission(
+              pendingMessage,
+              normalized,
+              avatarPlacement,
+              options.onOpenImage,
+            )
           : options.renderDraft()
       }
     </div>
@@ -128,10 +146,11 @@ export function renderNewSessionBody(options: {
 
 function renderNewSessionSubmission(
   message: NonNullable<ReturnType<typeof buildLocalUserMessage>>,
+  normalized: ReturnType<typeof normalizeMessage>,
+  avatarPlacement: "footer" | "gutter",
   onOpenImage: (item: ImageLightboxItem) => void,
 ) {
   const key = "new-session-submission";
-  const normalized = normalizeMessage(message);
   const senderHue = normalized.sender ? resolveIdentityHue(normalized.sender) : null;
   const { images, attachments } = projectMessageMedia(message, normalized.content);
   const markdown = resolveMessageDisplayMarkdown(message, normalized);
@@ -141,10 +160,18 @@ function renderNewSessionSubmission(
   // images have their own lightbox handler and remain interactive while pending.
   return html`<div class="new-session-page__starting chat-thread-inner">
     <div
-      class="chat-group user ${senderHue === null ? "" : "chat-group--sender-tint"}"
+      class="chat-group user ${normalized.sender ? "chat-group--with-footer" : ""} ${senderHue === null ? "" : "chat-group--sender-tint"}"
       style=${senderHue === null ? nothing : `--chat-sender-hue: ${senderHue}`}
       data-chat-row-key=${key}
     >
+      ${
+        normalized.sender && avatarPlacement === "gutter"
+          ? renderUserAvatarSlot(
+              resolveIdentityAvatarView(normalized.sender),
+              formatSenderLabel(normalized.sender) ?? "",
+            )
+          : nothing
+      }
       <div class="chat-group-messages">
         <div
           class="chat-bubble ${images.length ? "chat-bubble--with-images" : ""}"
@@ -167,6 +194,15 @@ function renderNewSessionSubmission(
           }
         </div>
       </div>
+      ${
+        normalized.sender && avatarPlacement === "footer"
+          ? html`<div class="chat-group-footer">
+              <div class="chat-group-footer__meta">
+                ${renderChatAuthorAvatar(normalized.sender)}
+              </div>
+            </div>`
+          : nothing
+      }
     </div>
     <div class="chat-group assistant chat-group--working">
       <div class="chat-group-messages">

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -472,6 +472,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
 
   override render() {
     const pendingMessage = this.submission.pendingMessage;
+    const identity = this.context?.gateway.snapshot.selfUser?.identity;
     const incognito = this.submission.visibility === "incognito";
     return html`
       <div
@@ -490,6 +491,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
         ${renderNewSessionBody({
           error: this.submission.error,
           pendingMessage,
+          userId: identity?.type === "profile" ? identity.id : null,
           submitting: this.submission.submitting,
           renderDraft: () => this.renderWelcome(),
           onOpenImage: this.setImageLightbox,


### PR DESCRIPTION
## Problem

Submitting a prompt from the New Session page had two visible glitches:

1. The immediate "Starting…" preview showed the prompt bubble without the sender's avatar. The avatar only appeared once the created session's transcript replaced the preview, so the row visibly changed shape a moment after send.
2. After navigating into the created session, the composer flashed with the accent-colored prefill attention animation (orange border + glow) even though nothing was prefilled. Started-session navigation and the assistant panel request composer focus through the same route hint as a draft prefill, and the pane treated every focus request as a prefill.

## Solution

- `ui/src/pages/new-session/draft-composer.ts` renders the own-user avatar in the submission preview using the same slot renderer as the chat thread. The placement decision (gutter when the viewer has a profile identity, footer otherwise) now lives in one shared helper, `resolveChatDefaultAvatarPlacement`, used by both the transcript projection and the preview, so the preview and the committed transcript row agree. `renderUserAvatarSlot` moved to `chat-author-avatar.ts` so both surfaces share it; chat's render contract is unchanged.
- `ui/src/pages/chat/chat-pane-lifecycle.ts` only plays the prefill attention cue when the focus request carries a non-empty draft. Bare focus requests still focus the textarea, silently.
- Docs: `docs/web/control-ui/sessions-and-sidebar.md` notes the immediate avatar and quiet focus.

## Impact

- Team-mode users see their avatar on the first paint of a new session's prompt, in the same position it will keep after the transcript loads.
- No composer flash on new-session navigation or the assistant panel's home shortcut. The attention animation still runs for navigation that prefills a draft.
- Net production change is small (shared helper + one guard); no config, schema, or i18n changes.

## Evidence

Local gateway from this branch's build (owner profile via token auth) driven with Playwright, trusted keyboard Enter. DOM timeline recorded with a MutationObserver:

- Before: preview `.chat-group.user` had no avatar element until the chat thread replaced it (~150 ms later); `agent-chat__input--prefill-attention` was added to the composer on navigation and removed 600 ms later.
- After: preview renders `.chat-avatar-slot > img` immediately; the attention class never appears; the textarea is still focused after navigation.

| Before: preview without avatar | After: avatar on first paint |
| --- | --- |
| ![before preview](https://github.com/user-attachments/assets/88dd937f-4735-4d9d-8cfd-1f631fa0df4a) | ![after preview](https://github.com/user-attachments/assets/8b0b6272-3e5c-49fb-b8b7-d3897e0093f8) |

| Before: composer flash after navigation | After: quiet focused composer |
| --- | --- |
| ![before composer](https://github.com/user-attachments/assets/4faded32-ac7a-4d88-92f8-f0863cb134b0) | ![after composer](https://github.com/user-attachments/assets/adea43bf-0966-47eb-9685-63bdaee10955) |

Tests:

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-lifecycle.test.ts` (34 passed): draft prefill keeps the cue; plain focus and empty draft never add the attention class.
- `node scripts/run-vitest.mjs ui/src/pages/new-session/composer.test.ts` and sibling avatar/transcript suites (337 passed): the preview renders the own-user avatar in the gutter with a profile id and in the footer without one; both cases fail on the previous code.
- `node scripts/check-changed.mjs` passed; `pnpm check:architecture` passed; Codex autoreview (P0–P2) scoped-clean.
