### PR TITLE
perf(plugins): defer installer loading for policy commands

### DIFF
--- a/src/gateway/server-methods/plugins-mutations.ts
+++ b/src/gateway/server-methods/plugins-mutations.ts
@@ -19,8 +19,8 @@ import { ManagedPluginLifecycleError } from "../../plugins/management-lifecycle-
 import {
   installManagedPlugin,
   setManagedPluginEnabled,
-  uninstallManagedPlugin,
 } from "../../plugins/management-mutations.js";
+import { uninstallManagedPlugin } from "../../plugins/management-uninstall.js";
 import { buildGatewayReloadPlan } from "../config-reload-plan.js";
 import { resolveGatewayReloadSettings } from "../config-reload-settings.js";
 import type { GatewayRequestHandlers } from "./types.js";

--- a/src/gateway/server-methods/plugins.test.ts
+++ b/src/gateway/server-methods/plugins.test.ts
@@ -27,6 +27,9 @@ vi.mock("../../plugins/management-service.js", () => ({
 vi.mock("../../plugins/management-mutations.js", () => ({
   installManagedPlugin: (...args: unknown[]) => managementMocks.install(...args),
   setManagedPluginEnabled: (...args: unknown[]) => managementMocks.setEnabled(...args),
+}));
+
+vi.mock("../../plugins/management-uninstall.js", () => ({
   uninstallManagedPlugin: (...args: unknown[]) => managementMocks.uninstall(...args),
 }));
 

--- a/src/plugins/management-mutations.ts
+++ b/src/plugins/management-mutations.ts
@@ -27,10 +27,7 @@ import {
   resolveOfficialEntryById,
 } from "./management-catalog.js";
 import { readPluginMutationSnapshot } from "./management-config.js";
-import {
-  type ManagedPluginSourceInstallRequest,
-  installManagedPluginSource,
-} from "./management-install.js";
+import type { ManagedPluginSourceInstallRequest } from "./management-install.js";
 import { ManagedPluginLifecycleError } from "./management-lifecycle-error.js";
 import {
   loadFreshManagedPluginMetadata,
@@ -226,6 +223,7 @@ export async function installManagedPlugin(params: {
   request: ManagedPluginInstallRequest;
   env?: NodeJS.ProcessEnv;
 }): Promise<{ plugin: ManagedPluginCatalogEntry; warnings?: string[] }> {
+  const { installManagedPluginSource } = await import("./management-install.js");
   const env = params.env ?? process.env;
   return await withPluginLifecycleLease({ env }, async () => {
     const snapshot = await readPluginMutationSnapshot(env);
@@ -453,5 +451,3 @@ export async function setManagedPluginEnabled(params: ManagedPluginEnableRequest
     };
   });
 }
-
-export { uninstallManagedPlugin } from "./management-uninstall.js";

--- a/src/plugins/management-service.policy-imports.test.ts
+++ b/src/plugins/management-service.policy-imports.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, afterEach, expect, it, vi } from "vitest";
+import { readConfigFileSnapshotForWrite, writeConfigFile } from "../config/config.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  writePlugin,
+} from "./loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+
+vi.mock("./management-install.js", () => {
+  throw new Error("Plugin policy changes must not load the installation implementation");
+});
+vi.mock("./management-uninstall.js", () => {
+  throw new Error("Plugin policy changes must not load the removal implementation");
+});
+
+afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+it("persists CLI plugin policy without loading installation or removal implementations", async () => {
+  const stateDir = makePluginLoaderTempDir();
+  const bundledDir = makePluginLoaderTempDir();
+  const pluginId = "policy-only";
+  writePlugin({
+    id: pluginId,
+    dir: path.join(bundledDir, pluginId),
+    filename: "index.cjs",
+    body: `module.exports = { id: ${JSON.stringify(pluginId)}, register() {} };`,
+  });
+  await withEnvAsync(
+    {
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+    },
+    async () => {
+      await writeConfigFile({ plugins: { entries: { [pluginId]: { enabled: false } } } });
+      const { runPluginsEnableCommand, runPluginsDisableCommand } =
+        await import("../cli/plugins-cli.runtime.js");
+      await runPluginsEnableCommand(pluginId);
+      expect(
+        (await readConfigFileSnapshotForWrite()).snapshot.sourceConfig.plugins?.entries?.[pluginId]
+          ?.enabled,
+      ).toBe(true);
+      await runPluginsDisableCommand(pluginId);
+      expect(
+        JSON.parse(fs.readFileSync(path.join(stateDir, "openclaw.json"), "utf8")).plugins.entries[
+          pluginId
+        ].enabled,
+      ).toBe(false);
+    },
+  );
+});

--- a/src/plugins/management-service.test.ts
+++ b/src/plugins/management-service.test.ts
@@ -107,8 +107,8 @@ vi.mock("./recommended-tool-installs.js", () => ({
 const { clearManagedPluginOfficialCatalogCache } = await import("./management-catalog.js");
 const { listManagedPlugins, resolveManagedPluginIconSource, resolveManagedSetupCatalogIconUrl } =
   await import("./management-service.js");
-const { setManagedPluginEnabled, uninstallManagedPlugin } =
-  await import("./management-mutations.js");
+const { setManagedPluginEnabled } = await import("./management-mutations.js");
+const { uninstallManagedPlugin } = await import("./management-uninstall.js");
 
 function mockHostedOfficialCatalog(entries: unknown[]) {
   mocks.officialCatalog.mockResolvedValue({

--- a/src/plugins/management-service.uninstall-ownership.test.ts
+++ b/src/plugins/management-service.uninstall-ownership.test.ts
@@ -55,7 +55,7 @@ vi.mock("./uninstall.js", async (importOriginal) => {
 });
 
 const { listManagedPlugins } = await import("./management-service.js");
-const { uninstallManagedPlugin } = await import("./management-mutations.js");
+const { uninstallManagedPlugin } = await import("./management-uninstall.js");
 const { planPluginUninstall } = await import("./uninstall.js");
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 

--- a/src/plugins/management-service.workspace-inventory.test.ts
+++ b/src/plugins/management-service.workspace-inventory.test.ts
@@ -40,8 +40,8 @@ vi.mock("./official-external-plugin-catalog.js", async (importOriginal) => ({
 
 const { listManagedPlugins, refreshManagedPluginMetadata } =
   await import("./management-service.js");
-const { setManagedPluginEnabled, uninstallManagedPlugin } =
-  await import("./management-mutations.js");
+const { setManagedPluginEnabled } = await import("./management-mutations.js");
+const { uninstallManagedPlugin } = await import("./management-uninstall.js");
 const roots: string[] = [];
 
 beforeEach(() => {


### PR DESCRIPTION
## What Problem This Solves

`openclaw plugins enable` and `disable` import the shared management mutation module. Its eager installer dependency and uninstall re-export also load package installation/removal code, even when the command only changes an installed plugin's policy. This remains after #140842 made bundled slot selection metadata-only.

## Why This Change Was Made

Load the existing installation implementation only when `installManagedPlugin` is invoked, before entering its existing lifecycle lease. Internal uninstall callers import the existing uninstall owner directly instead of reaching it through the mixed mutation module. This removes the unnecessary imports without adding another cache, wrapper, or activation path.

## User Impact

Enabling or disabling an installed plugin no longer requires loading installation/removal backends. External installation, legacy runtime-kind discovery, capability consent, restrictive policy, configuration ownership and uninstall behavior remain covered by their existing paths. No config/default, timeout, schema or persistence change is introduced. The removed re-export was an internal module path, not a Plugin SDK contract.

## Evidence

- An observable CLI regression makes the installation and removal implementations unavailable, then enables and disables a tiny bundled plugin and verifies persisted policy. Before the change it fails when `management-mutations.ts` imports the installation implementation; afterward it passes.
- All 156 focused tests pass across CLI policy, Gateway mutation handlers, external installation, uninstall ownership, capability consent, registry refresh, workspace inventory and runtime-kind inspection. Changed-surface checks and the staged temp-directory report pass. Full `pnpm build` passed; the prescribed Codex entrypoint import/RSS profile passed. Independent managed review through P2 is clean.
- **Real changed-surface proof:** the actual built `openclaw.mjs plugins enable codex --accept-capabilities` and `openclaw.mjs plugins disable codex` commands ran against an isolated HOME/config/state, with the existing lifecycle trace flag and a module-load observer. They exited 0 and persisted `enabled: true` then `enabled: false`. Neither installer nor removal owner loaded in either candidate command. This proof uses the built CLI; the separate sentinel-mock regression protects its import boundary. Before, the built enable trace included management installation/removal, ClawHub client/packages/skills, Git installation and marketplace modules. Those identified modules are absent in the rebuilt candidate; the observed enable module count fell from 2,275 to 2,190.
- Local diagnostic samples were 2.356 s and 1.836 s, with 93 major faults each and filesystem-operation counters reported as zero. These runs used different source snapshots and are not a controlled timing comparison. This PR does **not** attribute or claim to fix the separate 36.649-second remote plugin-activation observation or the complete cloud bootstrap latency. Remote phase attribution remains a separate investigation.

Production delta: **−4 lines**; tests **+66 lines**. Only the existing install owner's loading boundary and internal uninstall imports change.

The changed surface is internal import loading during local plugin policy commands. It does not alter an external API or provider operation. Remote cloud timing was not exercised for this PR and is not claimed; the broader latest-main cloud performance investigation continues separately.
