### PR TITLE
fix(browser): align labels on scaled and cropped screenshots

### DIFF
--- a/extensions/browser/src/browser/pw-screenshots.chromium.test.ts
+++ b/extensions/browser/src/browser/pw-screenshots.chromium.test.ts
@@ -1,8 +1,11 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright-core";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test-support.js";
+import { getImageMetadata } from "../media/media-services.js";
 import { captureScreenshot } from "./cdp.js";
+import { resolveBrowserConfig } from "./config.js";
 import { getPlaywrightCore } from "./playwright-core.runtime.js";
 import { closePlaywrightBrowserConnection, getPageForTargetId } from "./pw-session.js";
 import {
@@ -14,6 +17,10 @@ import {
   snapshotRoleViaPlaywright,
 } from "./pw-tools-core.snapshot.js";
 import { setDeviceViaPlaywright } from "./pw-tools-core.state.js";
+import { registerBrowserAgentSnapshotRoutes } from "./routes/agent.snapshot.js";
+import { createBrowserRouteApp, createBrowserRouteResponse } from "./routes/test-helpers.js";
+import type { AnnotationItem } from "./screenshot-annotate.js";
+import { createBrowserRouteContext, type BrowserServerState } from "./server-context.js";
 import { getFreePort } from "./test-port.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -29,10 +36,17 @@ const readGeometry = () => ({
   scrollY,
   screen: [screen.width, screen.height, screen.orientation.type],
   touch: navigator.maxTouchPoints,
+  visual: {
+    x: visualViewport!.pageLeft,
+    y: visualViewport!.pageTop,
+    width: visualViewport!.width,
+    height: visualViewport!.height,
+  },
 });
 
 async function withBrowser(
   run: (target: { cdpUrl: string; targetId: string }, page: Page, wsUrl: string) => Promise<void>,
+  deviceScaleFactor?: number,
 ) {
   const port = await getFreePort();
   const cdpUrl = `http://127.0.0.1:${port}`;
@@ -40,7 +54,9 @@ async function withBrowser(
     path.join(tempDirs.make("openclaw-screenshot-geometry-"), "profile"),
     {
       headless: true,
-      viewport: null,
+      ...(deviceScaleFactor
+        ? { viewport: { width: 640, height: 480 }, deviceScaleFactor }
+        : { viewport: null }),
       executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
       args: [`--remote-debugging-port=${port}`],
     },
@@ -87,6 +103,47 @@ async function expectImage(
     { base64: buffer.toString("base64"), points },
   );
   expect(pixels).toEqual(points.map(({ rgb }) => rgb));
+}
+
+async function readLabelBox(page: Page, buffer: Buffer) {
+  return await page.evaluate(async (base64) => {
+    const image = new Image();
+    image.src = `data:image/png;base64,${base64}`;
+    await image.decode();
+    const canvas = document.createElement("canvas");
+    canvas.width = image.width;
+    canvas.height = image.height;
+    const context = canvas.getContext("2d")!;
+    context.drawImage(image, 0, 0);
+    const { data } = context.getImageData(0, 0, image.width, image.height);
+    let redX = 0,
+      redY = 0,
+      redCount = 0;
+    for (let y = 0; y < image.height; y++) {
+      for (let x = 0; x < image.width; x++) {
+        const i = (y * image.width + x) * 4;
+        if (data[i]! > 170 && data[i + 1]! < 120 && data[i + 2]! < 150) {
+          redX += x;
+          redY += y;
+          redCount++;
+        }
+      }
+    }
+    const centerX = Math.round(redX / redCount),
+      centerY = Math.round(redY / redCount);
+    const yellow = (x: number, y: number) => {
+      const i = (y * image.width + x) * 4;
+      return data[i]! > 200 && data[i + 1]! > 120 && data[i + 2]! < 100;
+    };
+    const xs = Array.from({ length: image.width }, (_, x) => x).filter((x) => yellow(x, centerY));
+    const ys = Array.from({ length: image.height }, (_, y) => y).filter((y) => yellow(centerX, y));
+    return {
+      x: xs[0]!,
+      y: ys[0]!,
+      width: xs.at(-1)! - xs[0]! + 1,
+      height: ys.at(-1)! - ys[0]! + 1,
+    };
+  }, buffer.toString("base64"));
 }
 
 describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
@@ -142,7 +199,7 @@ describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
         const { refs } = await snapshotRoleViaPlaywright(target);
         const ref = Object.keys(refs)[0]!;
         for (const mode of ["viewport", "element", "ref", "labels", "fullpage"] as const) {
-          const result =
+          const result: { buffer: Buffer; annotations?: AnnotationItem[] } =
             mode === "labels"
               ? await screenshotWithLabelsViaPlaywright({ ...target, refs })
               : await takeScreenshotViaPlaywright({
@@ -162,6 +219,14 @@ describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
                 : { x: 100, y: mode === "fullpage" ? 3000 : 1700, rgb: [51, 78, 104] },
             ],
           );
+          if (result.annotations) {
+            expect(result.annotations[0]?.box).toEqual({
+              x: 99,
+              y: 54,
+              width: 360,
+              height: 180,
+            });
+          }
           expect(await page.evaluate(readGeometry), mode).toEqual(before);
         }
 
@@ -181,5 +246,115 @@ describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
         expect(await page.evaluate(() => navigator.maxTouchPoints)).toBe(touch);
       });
     }, 30_000);
+
+    it.for([
+      { device: "Native DPR 2", pageScale: 1 },
+      { device: "Desktop Chrome", pageScale: 1 },
+      { device: "iPad Mini", pageScale: 1 },
+      { device: "iPhone 13", pageScale: 1 },
+      { device: "iPhone 13", pageScale: 2 },
+    ])(
+      "returns image-space annotations through routes for $device at page scale $pageScale",
+      { timeout: 60_000 },
+      async ({ device, pageScale }, { annotate }) => {
+        await withBrowser(
+          async (target) => {
+            if (device !== "Native DPR 2") {
+              await setDeviceViaPlaywright({ ...target, name: device });
+            }
+            const page = await getPageForTargetId(target);
+            const zoom = await page.context().newCDPSession(page);
+            await zoom.send("Emulation.setPageScaleFactor", { pageScaleFactor: pageScale });
+            await zoom.detach();
+            const state: BrowserServerState = {
+              port: 0,
+              resolved: resolveBrowserConfig({
+                defaultProfile: "geometry",
+                profiles: {
+                  geometry: { cdpUrl: target.cdpUrl, color: "#123456", attachOnly: true },
+                },
+              }),
+              profiles: new Map(),
+            };
+            const routes = createBrowserRouteApp();
+            registerBrowserAgentSnapshotRoutes(
+              routes.app,
+              createBrowserRouteContext({ getState: () => state }),
+            );
+            for (const mode of ["viewport", "fullpage", "element", "snapshot"] as const) {
+              await page.evaluate(() => scrollTo(0, 420));
+              if (mode === "element") {
+                await page
+                  .locator("section")
+                  .first()
+                  .evaluate((section) => {
+                    section.style.transform = "translate(0.5px, 0.5px)";
+                  });
+              }
+              const before = await page.evaluate(readGeometry);
+              const response = createBrowserRouteResponse();
+              const request = { targetId: target.targetId, labels: true };
+              if (mode === "snapshot") {
+                await routes.getHandlers.get("/snapshot")!(
+                  { params: {}, query: { ...request, format: "ai" } },
+                  response.res,
+                );
+              } else {
+                await routes.postHandlers.get("/screenshot")!(
+                  {
+                    params: {},
+                    query: {},
+                    body: {
+                      ...request,
+                      fullPage: mode === "fullpage",
+                      element: mode === "element" ? "section" : undefined,
+                    },
+                  },
+                  response.res,
+                );
+              }
+              expect(response.statusCode, JSON.stringify(response.body)).toBe(200);
+              const result = response.body as {
+                path?: string;
+                imagePath?: string;
+                annotations: AnnotationItem[];
+              };
+              const imagePath = result.path ?? result.imagePath!;
+              try {
+                const buffer = await fs.readFile(imagePath);
+                await annotate(`${device} ${mode}`, { path: imagePath });
+                const metadata = await getImageMetadata(buffer);
+                const imageWidth = metadata!.width;
+                const imageHeight = metadata!.height;
+                const annotation = result.annotations.find(({ name }) => name === "Target")!;
+                const pixels = await readLabelBox(page, buffer);
+                for (const coordinate of ["x", "y", "width", "height"] as const) {
+                  expect(
+                    Math.abs(annotation.box[coordinate] - pixels[coordinate]),
+                    `${device} ${mode} ${coordinate}: annotation=${annotation.box[coordinate]} pixels=${pixels[coordinate]}`,
+                  ).toBeLessThanOrEqual(1);
+                }
+                expect(Math.max(imageWidth, imageHeight)).toBeLessThanOrEqual(2000);
+                if (device === "iPhone 13" && mode === "fullpage") {
+                  expect(imageHeight).toBe(2000);
+                  expect(imageHeight / 1200).toBeLessThan(before.dpr);
+                }
+              } finally {
+                await fs.rm(imagePath);
+                if (mode === "element") {
+                  await page
+                    .locator("section")
+                    .first()
+                    .evaluate((section) => {
+                      section.style.transform = "";
+                    });
+                }
+              }
+            }
+          },
+          device === "Native DPR 2" ? 2 : undefined,
+        );
+      },
+    );
   },
 );

--- a/extensions/browser/src/browser/pw-screenshots.chromium.test.ts
+++ b/extensions/browser/src/browser/pw-screenshots.chromium.test.ts
@@ -47,6 +47,7 @@ const readGeometry = () => ({
 async function withBrowser(
   run: (target: { cdpUrl: string; targetId: string }, page: Page, wsUrl: string) => Promise<void>,
   deviceScaleFactor?: number,
+  showScrollbars = false,
 ) {
   const port = await getFreePort();
   const cdpUrl = `http://127.0.0.1:${port}`;
@@ -54,6 +55,7 @@ async function withBrowser(
     path.join(tempDirs.make("openclaw-screenshot-geometry-"), "profile"),
     {
       headless: true,
+      ...(showScrollbars ? { ignoreDefaultArgs: ["--hide-scrollbars"] } : {}),
       ...(deviceScaleFactor
         ? { viewport: { width: 640, height: 480 }, deviceScaleFactor }
         : { viewport: null }),
@@ -248,21 +250,28 @@ describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
     }, 30_000);
 
     it.for([
-      { device: "Native DPR 2", pageScale: 1 },
+      { device: "Native DPR 2", pageScale: 1, nativeDpr: 2 },
       { device: "Desktop Chrome", pageScale: 1 },
       { device: "iPad Mini", pageScale: 1 },
       { device: "iPhone 13", pageScale: 1 },
       { device: "iPhone 13", pageScale: 2 },
+      { device: "Native classic scrollbars", pageScale: 1, nativeDpr: 1, showScrollbars: true },
     ])(
       "returns image-space annotations through routes for $device at page scale $pageScale",
       { timeout: 60_000 },
-      async ({ device, pageScale }, { annotate }) => {
+      async ({ device, pageScale, nativeDpr, showScrollbars }, { annotate }) => {
         await withBrowser(
           async (target) => {
-            if (device !== "Native DPR 2") {
+            if (nativeDpr === undefined) {
               await setDeviceViaPlaywright({ ...target, name: device });
             }
             const page = await getPageForTargetId(target);
+            if (showScrollbars) {
+              await page.addStyleTag({
+                content:
+                  "html{overflow-y:scroll}::-webkit-scrollbar{width:16px;height:16px}::-webkit-scrollbar-thumb{background:#888}button{left:480px}",
+              });
+            }
             const zoom = await page.context().newCDPSession(page);
             await zoom.send("Emulation.setPageScaleFactor", { pageScaleFactor: pageScale });
             await zoom.detach();
@@ -292,6 +301,9 @@ describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
                   });
               }
               const before = await page.evaluate(readGeometry);
+              if (showScrollbars) {
+                expect(before.width - before.visual.width).toBe(16);
+              }
               const response = createBrowserRouteResponse();
               const request = { targetId: target.targetId, labels: true };
               if (mode === "snapshot") {
@@ -352,7 +364,8 @@ describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
               }
             }
           },
-          device === "Native DPR 2" ? 2 : undefined,
+          nativeDpr,
+          showScrollbars,
         );
       },
     );

--- a/extensions/browser/src/browser/pw-tools-core.annotate.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.annotate.test.ts
@@ -22,6 +22,7 @@ function evaluateMockReturning(view: { x: number; y: number; width?: number; hei
     width: 1280,
     height: 720,
     fullWidth: 1280,
+    nativeCaptureWidth: 1280,
     ...view,
   };
   return vi.fn(async (arg: unknown) => {

--- a/extensions/browser/src/browser/pw-tools-core.annotate.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.annotate.test.ts
@@ -7,13 +7,23 @@ import {
 } from "./pw-tools-core.test-harness.js";
 
 installPwToolsCoreTestHooks();
+const imageSize = vi.hoisted(() => ({ width: 1280, height: 720 }));
+vi.mock("../media/media-services.js", () => ({ getImageMetadata: async () => imageSize }));
+beforeEach(() => {
+  imageSize.width = 1280;
+});
 const mod = await import("./pw-tools-core.interactions.js");
 
 function evaluateMockReturning(view: { x: number; y: number; width?: number; height?: number }) {
   // Caller reads { x, y, width, height } in one evaluate; default to a normal
   // desktop viewport so refs near the top stay in-viewport unless a test puts
   // them out of range explicitly.
-  const result = { width: 1280, height: 720, ...view };
+  const result = {
+    width: 1280,
+    height: 720,
+    fullWidth: 1280,
+    ...view,
+  };
   return vi.fn(async (arg: unknown) => {
     if (typeof arg === "function") {
       return result;
@@ -200,6 +210,7 @@ describe("screenshotWithLabelsViaPlaywright (element/ref)", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("captures the resolved ref element and projects relative to it", async () => {
+    imageSize.width = 200;
     const evaluate = evaluateMockReturning({ x: 0, y: 0 });
     // First call resolves the element rect (container), second resolves e1 annotation bbox.
     const boundingBox = vi

--- a/extensions/browser/src/browser/pw-tools-core.interactions.content.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.content.ts
@@ -4,6 +4,7 @@ import { detectMime } from "openclaw/plugin-sdk/media-mime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { FileChooser, Locator, Page } from "playwright-core";
+import { getImageMetadata } from "../media/media-services.js";
 import { ACT_MAX_WAIT_TIME_MS, resolveActWaitTimeoutMs } from "./act-policy.js";
 import { DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS } from "./constants.js";
 import { normalizeBrowserEvaluateFunctionSource } from "./evaluate-source.js";
@@ -36,6 +37,7 @@ import {
   type CoordinateSpace,
   planAnnotations,
   type RawAnnotationInput,
+  scaleAnnotations,
 } from "./screenshot-annotate.js";
 
 const DEFAULT_UPLOAD_MIME_TYPE = "application/octet-stream";
@@ -286,7 +288,11 @@ function screenshotLocator(page: Page, ref?: string, element?: string): Locator 
   return ref ? refLocator(page, ref) : element ? page.locator(element).first() : undefined;
 }
 
-async function capturePageScreenshot(page: Page, opts: ScreenshotOptions, locator?: Locator) {
+async function capturePageScreenshot(
+  page: Page,
+  opts: ScreenshotOptions,
+  locator?: Locator,
+): Promise<{ buffer: Buffer; clip?: { x: number; y: number; width: number } }> {
   opts.signal?.throwIfAborted();
   if (locator && opts.fullPage) {
     throw new Error("fullPage is not supported for element screenshots");
@@ -307,9 +313,11 @@ async function capturePageScreenshot(page: Page, opts: ScreenshotOptions, locato
     if (!owner) {
       // The outer deadline owns cancellation. Playwright's timeout rejects
       // before native capture/restoration finishes, releasing the queue too early.
-      return await (element
-        ? element.screenshot({ type, timeout: 0 })
-        : page.screenshot({ type, fullPage: Boolean(opts.fullPage), timeout: 0 }));
+      return {
+        buffer: await (element
+          ? element.screenshot({ type, timeout: 0 })
+          : page.screenshot({ type, fullPage: Boolean(opts.fullPage), timeout: 0 })),
+      };
     }
 
     const box = element ? await element.boundingBox() : undefined;
@@ -317,16 +325,16 @@ async function capturePageScreenshot(page: Page, opts: ScreenshotOptions, locato
       throw new Error("Cannot take a screenshot of an element that is not visible or has no size");
     }
     const metrics = await owner.session.send("Page.getLayoutMetrics");
-    const visual = metrics.visualViewport;
+    const visual = metrics.cssVisualViewport;
     let clip = { ...metrics.cssContentSize, scale: 1 };
     if (box) {
-      const x = Math.floor(box.x + metrics.cssLayoutViewport.pageX);
-      const y = Math.floor(box.y + metrics.cssLayoutViewport.pageY);
+      const x = Math.floor(box.x + visual.pageX);
+      const y = Math.floor(box.y + visual.pageY);
       clip = {
         x,
         y,
-        width: Math.ceil(box.x + metrics.cssLayoutViewport.pageX + box.width) - x,
-        height: Math.ceil(box.y + metrics.cssLayoutViewport.pageY + box.height) - y,
+        width: Math.ceil(box.x + visual.pageX + box.width) - x,
+        height: Math.ceil(box.y + visual.pageY + box.height) - y,
         scale: 1,
       };
     } else if (!opts.fullPage) {
@@ -350,7 +358,7 @@ async function capturePageScreenshot(page: Page, opts: ScreenshotOptions, locato
       clip,
       captureBeyondViewport,
     });
-    return Buffer.from(result.data, "base64");
+    return { buffer: Buffer.from(result.data, "base64"), clip };
   } finally {
     try {
       if (emulation?.touch) {
@@ -372,13 +380,12 @@ export async function takeScreenshotViaPlaywright(
   const page = await getPageForTargetId(opts);
   return await runScreenshotOperation(page, opts, async (signal) => {
     restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
-    return {
-      buffer: await capturePageScreenshot(
-        page,
-        { ...opts, signal },
-        screenshotLocator(page, opts.ref, opts.element),
-      ),
-    };
+    const { buffer } = await capturePageScreenshot(
+      page,
+      { ...opts, signal },
+      screenshotLocator(page, opts.ref, opts.element),
+    );
+    return { buffer };
   });
 }
 
@@ -421,17 +428,22 @@ async function screenshotWithLabelsOnPage(
       ? "element"
       : "viewport";
 
-  // Read scroll + viewport size. Scroll converts Playwright's viewport-space
-  // boundingBoxes into document-space inputs; the viewport size lets the helper
-  // restore the shipped `labelsSkipped` semantics by counting off-viewport refs
-  // as skipped (in viewport capture mode).
+  // DOM boxes use the visual viewport, including pan during mobile zoom.
+  // Mixing the layout viewport here can produce negative element clips.
   const view = await page.evaluate(() => ({
-    x: window.scrollX || 0,
-    y: window.scrollY || 0,
-    width: window.innerWidth || 0,
-    height: window.innerHeight || 0,
+    x: window.visualViewport!.pageLeft,
+    y: window.visualViewport!.pageTop,
+    width: window.visualViewport!.width,
+    height: window.visualViewport!.height,
+    fullWidth: Math.max(
+      document.body?.scrollWidth ?? 0,
+      document.documentElement.scrollWidth,
+      document.body?.offsetWidth ?? 0,
+      document.documentElement.offsetWidth,
+      document.body?.clientWidth ?? 0,
+      document.documentElement.clientWidth,
+    ),
   }));
-  const scroll = { x: view.x, y: view.y };
 
   let elementRect: { x: number; y: number; width: number; height: number } | undefined;
   if (space === "element") {
@@ -445,8 +457,8 @@ async function screenshotWithLabelsOnPage(
     }
     // Convert viewport-space bbox to document space.
     elementRect = {
-      x: box.x + scroll.x,
-      y: box.y + scroll.y,
+      x: box.x + view.x,
+      y: box.y + view.y,
       width: box.width,
       height: box.height,
     };
@@ -476,19 +488,20 @@ async function screenshotWithLabelsOnPage(
       role: refInfo.role,
       name: refInfo.name,
       doc: {
-        x: box.x + scroll.x,
-        y: box.y + scroll.y,
+        x: box.x + view.x,
+        y: box.y + view.y,
         width: box.width,
         height: box.height,
       },
     });
   }
 
+  const origin = space === "element" ? elementRect! : space === "viewport" ? view : { x: 0, y: 0 };
   const plan = planAnnotations({
     inputs,
     space,
-    scroll,
-    viewport: { width: view.width, height: view.height },
+    scroll: origin,
+    viewport: view,
     elementRect,
     maxLabels,
   });
@@ -496,18 +509,42 @@ async function screenshotWithLabelsOnPage(
   try {
     opts.signal?.throwIfAborted();
     if (plan.overlayItems.length > 0) {
-      const captureY = space === "element" ? elementRect?.y : space === "viewport" ? scroll.y : 0;
-      await page.evaluate(buildOverlayInjectionScript({ items: plan.overlayItems, captureY }));
+      await page.evaluate(
+        buildOverlayInjectionScript({ items: plan.overlayItems, captureY: origin.y }),
+      );
     }
-    const buffer = await capturePageScreenshot(page, opts, locator);
+    const capture = await capturePageScreenshot(page, opts, locator);
+    // CDP owns its exact clip. Playwright uses the visual viewport for page
+    // captures and encloses element bounds in integer CSS pixels.
+    const clip =
+      capture.clip ??
+      (space === "viewport"
+        ? view
+        : {
+            x: Math.floor(origin.x + 1e-3),
+            y: Math.floor(origin.y + 1e-3),
+            width: elementRect
+              ? Math.ceil(elementRect.x + elementRect.width - 1e-3) - Math.floor(origin.x + 1e-3)
+              : view.fullWidth,
+          });
+    const image = await getImageMetadata(capture.buffer);
+    if (!image) {
+      throw new Error("Cannot determine screenshot dimensions for label annotations");
+    }
+    // Attached Playwright sessions can capture at a different density from
+    // window.devicePixelRatio. The actual image and clip own this transform.
+    const scale = image.width / clip.width;
     return {
       // `labels` reports overlay boxes actually drawn on the captured image
       // (in-viewport, within budget); off-viewport refs are surfaced via
       // `annotations` but not drawn, and are reflected in `skipped`.
-      buffer,
+      buffer: capture.buffer,
       labels: plan.overlayItems.length,
       skipped: plan.skipped + skippedRefs,
-      annotations: plan.annotations,
+      annotations: scaleAnnotations(plan.annotations, scale, scale, {
+        x: clip.x - origin.x,
+        y: clip.y - origin.y,
+      }),
     };
   } finally {
     await page.evaluate(buildOverlayClearScript()).catch(() => {});

--- a/extensions/browser/src/browser/pw-tools-core.interactions.content.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.content.ts
@@ -430,20 +430,26 @@ async function screenshotWithLabelsOnPage(
 
   // DOM boxes use the visual viewport, including pan during mobile zoom.
   // Mixing the layout viewport here can produce negative element clips.
-  const view = await page.evaluate(() => ({
-    x: window.visualViewport!.pageLeft,
-    y: window.visualViewport!.pageTop,
-    width: window.visualViewport!.width,
-    height: window.visualViewport!.height,
-    fullWidth: Math.max(
-      document.body?.scrollWidth ?? 0,
-      document.documentElement.scrollWidth,
-      document.body?.offsetWidth ?? 0,
-      document.documentElement.offsetWidth,
-      document.body?.clientWidth ?? 0,
-      document.documentElement.clientWidth,
-    ),
-  }));
+  const view = await page.evaluate(
+    (viewportWidth) => ({
+      x: window.visualViewport!.pageLeft,
+      y: window.visualViewport!.pageTop,
+      width: window.visualViewport!.width,
+      height: window.visualViewport!.height,
+      nativeCaptureWidth: Math.floor(
+        (viewportWidth ?? window.innerWidth) / window.visualViewport!.scale + 1e-3,
+      ),
+      fullWidth: Math.max(
+        document.body?.scrollWidth ?? 0,
+        document.documentElement.scrollWidth,
+        document.body?.offsetWidth ?? 0,
+        document.documentElement.offsetWidth,
+        document.body?.clientWidth ?? 0,
+        document.documentElement.clientWidth,
+      ),
+    }),
+    page.viewportSize()?.width,
+  );
 
   let elementRect: { x: number; y: number; width: number; height: number } | undefined;
   if (space === "element") {
@@ -514,12 +520,12 @@ async function screenshotWithLabelsOnPage(
       );
     }
     const capture = await capturePageScreenshot(page, opts, locator);
-    // CDP owns its exact clip. Playwright uses the visual viewport for page
-    // captures and encloses element bounds in integer CSS pixels.
+    // Native viewport captures include classic scrollbars and use page scale;
+    // the visual viewport still owns element positioning and visibility.
     const clip =
       capture.clip ??
       (space === "viewport"
-        ? view
+        ? { ...view, width: view.nativeCaptureWidth }
         : {
             x: Math.floor(origin.x + 1e-3),
             y: Math.floor(origin.y + 1e-3),

--- a/extensions/browser/src/browser/pw-tools-core.screenshots-element-selector.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.screenshots-element-selector.test.ts
@@ -196,8 +196,7 @@ describe("pw-tools-core", () => {
       await waitAt(method);
       return method === "Page.getLayoutMetrics"
         ? {
-            visualViewport: { pageX: 0, pageY: 0, scale: 1 },
-            cssLayoutViewport: { pageX: 0, pageY: 0 },
+            cssVisualViewport: { pageX: 0, pageY: 0, scale: 1 },
             cssContentSize: { x: 0, y: 0, width: 390, height: 664 },
           }
         : { data: Buffer.from("capture").toString("base64") };

--- a/extensions/browser/src/browser/pw-tools-core.test-harness.ts
+++ b/extensions/browser/src/browser/pw-tools-core.test-harness.ts
@@ -167,6 +167,7 @@ export function setPwToolsCoreCurrentPage(page: Record<string, unknown> | null) 
     page.on ??= vi.fn();
     page.off ??= vi.fn();
     page.url ??= vi.fn(() => "about:blank");
+    page.viewportSize ??= vi.fn(() => null);
   }
   currentPage = page;
 }

--- a/extensions/browser/src/browser/screenshot-annotate.ts
+++ b/extensions/browser/src/browser/screenshot-annotate.ts
@@ -247,30 +247,26 @@ export function buildOverlayClearScript(): string {
 }
 
 /**
- * Scale annotation boxes by independent x/y factors. Used to keep annotation
- * coordinates aligned with the saved image after the response pipeline
- * resizes the screenshot (e.g. via normalizeBrowserScreenshot capping the
- * longest side or the byte budget). Returns a new array; inputs are not
- * mutated. When both factors are 1 the boxes are returned unchanged (modulo
- * structural copy) so callers can share the same code path for resized and
- * non-resized captures.
+ * Translate the capture origin before scaling boxes into image pixels.
+ * Also used for subsequent output resizing; inputs remain unchanged.
  */
 export function scaleAnnotations(
   items: AnnotationItem[],
   scaleX: number,
   scaleY: number,
+  offset = { x: 0, y: 0 },
 ): AnnotationItem[] {
   if (!Number.isFinite(scaleX) || !Number.isFinite(scaleY) || scaleX <= 0 || scaleY <= 0) {
     return items.map((it) => ({ ...it, box: { ...it.box } }));
   }
-  if (scaleX === 1 && scaleY === 1) {
+  if (scaleX === 1 && scaleY === 1 && offset.x === 0 && offset.y === 0) {
     return items.map((it) => ({ ...it, box: { ...it.box } }));
   }
   return items.map((it) => ({
     ...it,
     box: {
-      x: round(it.box.x * scaleX),
-      y: round(it.box.y * scaleY),
+      x: round((it.box.x - offset.x) * scaleX),
+      y: round((it.box.y - offset.y) * scaleY),
       width: Math.max(1, round(it.box.width * scaleX)),
       height: Math.max(1, round(it.box.height * scaleY)),
     },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users requesting labeled browser screenshots receive annotation boxes that do not line up with scaled images. On a DPR 3 device, a button captured at 360×180 pixels was described as 120×60; mobile element crops could also show the wrong page region.

## Why This Change Was Made

The capture owner now projects boxes through the visual viewport and actual CSS clip, derives image density from the emitted image dimensions, and uses Playwright’s native viewport dimensions (including classic scrollbars) at page scale. Screenshot and snapshot label responses retain their existing final resize transform; the shared visual origin also prevents negative mobile crops.

## User Impact

Annotations line up with native and emulated browser images, including zoomed pages, classic scrollbars, fractional element crops, and resized full-page output. Existing screenshot resolutions, profile defaults, and request options are preserved.

## Evidence

- Addressed [ClawSweeper’s P2 finding and matching rank-up move](https://github.com/openclaw/openclaw/pull/141103#issuecomment-5568955406) in `1c2378d6e937ea0d0543c65ae2f2fbb3150b0cbe`: with a real 16-pixel classic scrollbar, the prior fallback reported x=501 for a label at image x=488. The corrected viewport, snapshot, full-page, and element-crop checks all pass. The added fixture removes Playwright’s `--hide-scrollbars` launch default and asserts that the scrollbar is rendered.
- The original source failed the DPR 3 helper and actual DPR 2/3 route regressions; the DPR 1 control passed. A direct Chromium probe independently reproduced the fractional crop and verified the visual-origin correction.
- **60 focused tests passed**, including 24 real Chromium route/image combinations: native DPR 2, device DPR 1/2/3, page scale 2, viewport/full-page/fractional element captures, snapshot labels, and all four modes with a visible classic scrollbar. Returned boxes are compared with the saved PNG/JPEG pixels, allowing one pixel for rasterization.
- Production and test type graphs, full-file lint/format, max-lines/assertion-safety ratchets, and `git diff --check` passed. Independent P0–P2 review was scoped-clean. All reviewed source hashes remain unchanged at this head.
- Production delta: +39 lines; test delta: +200. The additional capture geometry is necessary because `window.devicePixelRatio` alone does not describe native attached-browser output. No dependency, configuration, schema, or public API additions.

Focused Chromium command (Node 24):

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_BROWSER_SNAPSHOT_E2E=1 \
  node scripts/run-vitest.mjs \
  extensions/browser/src/browser/pw-screenshots.chromium.test.ts \
  extensions/browser/src/browser/pw-tools-core.annotate.test.ts \
  extensions/browser/src/browser/screenshot-annotate.test.ts \
  extensions/browser/src/browser/pw-tools-core.screenshots-element-selector.test.ts
```

All images below are from the isolated synthetic fixture. The paired crop probe uses the same requested resolution before and after the origin correction.

| Incorrect crop | Corrected crop |
| --- | --- |
| ![Incorrect mobile crop](https://github.com/user-attachments/assets/cf12e209-0223-4fbd-87c1-64b7ef2726a5) | ![Corrected mobile crop](https://github.com/user-attachments/assets/386f410f-9e47-4d1d-b429-476bd8f3ed08) |

<details>
<summary>Actual route output: labeled fractional crop and resized full page</summary>

![Labeled fractional element crop](https://github.com/user-attachments/assets/675d3b86-a1d7-4adc-a57d-e90b48a50fa2)

![Labeled full page resized to 650×2000](https://github.com/user-attachments/assets/440fcda7-fba8-4e50-8b5a-bf8fe59f854c)

</details>

Classic-scrollbar route proof: the visible label and returned annotation both start at x=488.

![Native screenshot with a visible classic scrollbar](https://github.com/user-attachments/assets/abf6cd04-40ba-42f2-90dc-573e3be6e5e9)
