### PR TITLE
fix(tooling): omit ClawSweeper machine squash credit

### DIFF
--- a/scripts/pr-lib/merge-body.mjs
+++ b/scripts/pr-lib/merge-body.mjs
@@ -58,7 +58,7 @@ function trailers(body) {
 function isMachineCredit(line) {
   // Match published machine addresses, never names or provider domains that
   // can also identify human contributors.
-  return /^Co-authored-by:\s*[^<>]+<(?:noreply@anthropic\.com|cursoragent@cursor\.com|amp@ampcode\.com|codex@openai\.com|solo-agent@trae\.ai|309084314\+roboclaw-bot@users\.noreply\.github\.com)>$/i.test(
+  return /^Co-authored-by:\s*[^<>]+<(?:noreply@anthropic\.com|cursoragent@cursor\.com|amp@ampcode\.com|codex@openai\.com|solo-agent@trae\.ai|309084314\+roboclaw-bot@users\.noreply\.github\.com|274271284\+clawsweeper\[bot\]@users\.noreply\.github\.com)>$/i.test(
     line,
   );
 }

--- a/test/scripts/pr-merge.test.ts
+++ b/test/scripts/pr-merge.test.ts
@@ -279,6 +279,7 @@ describePosix("native squash attribution", () => {
   it.each([
     { name: "Codex", email: "codex@openai.com" },
     { name: "roboclaw-bot", email: "309084314+roboclaw-bot@users.noreply.github.com" },
+    { name: "clawsweeper", email: "274271284+clawsweeper[bot]@users.noreply.github.com" },
   ])(
     "omits machine author preview credit from a reviewed body while retaining human authors: %j",
     (machine) => {
@@ -405,6 +406,9 @@ describePosix("native squash attribution", () => {
     "Co-authored-by: roboclaw-bot <309084314+roboclaw-bot@users.noreply.github.com>",
     "co-authored-by: RoboClaw <309084314+ROBOCLAW-BOT@USERS.NOREPLY.GITHUB.COM>",
     "Co-Authored-By: RoboClaw\n <309084314+roboclaw-bot@users.noreply.github.com>",
+    "Co-authored-by: clawsweeper <274271284+clawsweeper[bot]@users.noreply.github.com>",
+    "co-authored-by: ClawSweeper <274271284+CLAWSWEEPER[BOT]@USERS.NOREPLY.GITHUB.COM>",
+    "Co-Authored-By: clawsweeper\n <274271284+clawsweeper[bot]@users.noreply.github.com>",
   ])("omits imported machine credit while preserving human credit: %j", (machineCredit) => {
     const humanCredit = [
       "Co-authored-by: Claude <claude@example.com>",
@@ -427,6 +431,11 @@ describePosix("native squash attribution", () => {
       "Co-authored-by: Other <309084314+roboclaw-bot@users.noreply.github.com.example.org>",
       "Co-authored-by: Other <1309084314+roboclaw-bot@users.noreply.github.com>",
       "Co-authored-by: Other <309084314+roboclaw-bot-human@users.noreply.github.com>",
+      "Co-authored-by: clawsweeper <human@example.com>",
+      "Co-authored-by: Human <274271284+human@users.noreply.github.com>",
+      "Co-authored-by: Other <1274271284+clawsweeper[bot]@users.noreply.github.com>",
+      "Co-authored-by: Other <274271284+clawsweeper[bot]@users.noreply.github.com.example.org>",
+      "Co-authored-by: Other <274271284+clawsweeperbot@users.noreply.github.com>",
     ].join("\n");
     const server = "Co-authored-by: Server <server@example.com>";
     const result = prepareBody({
@@ -451,6 +460,7 @@ describePosix("native squash attribution", () => {
     "Reviewed correction.\n\nCo-authored-by: Codex <codex@openai.com>\n",
     "Reviewed correction.\n\nCo-authored-by: Trae Solo <solo-agent@trae.ai>\n",
     "Reviewed correction.\n\nCo-authored-by: roboclaw-bot <309084314+roboclaw-bot@users.noreply.github.com>\n",
+    "Reviewed correction.\n\nCo-authored-by: clawsweeper <274271284+clawsweeper[bot]@users.noreply.github.com>\n",
   ])(
     "requires a reviewed body when the chosen message contains machine credit: %j",
     (overrideBody) => {
@@ -473,6 +483,7 @@ describePosix("native squash attribution", () => {
     "Codex <codex@openai.com>",
     "Trae Solo <solo-agent@trae.ai>",
     "roboclaw-bot <309084314+roboclaw-bot@users.noreply.github.com>",
+    "clawsweeper <274271284+clawsweeper[bot]@users.noreply.github.com>",
   ])("rejects machine credit present only in the default server preview: %s", (identity) => {
     const result = prepareBody({
       sourceMessages: ["Repair"],


### PR DESCRIPTION
Related: #119367

## What Problem This Solves

Fixes an issue where maintainers landing a ClawSweeper-authored PR receive machine co-author credit in the squash message even after supplying a reviewed human-only body. The native composer treats the bot's source-author email as eligible preview credit and restores it.

## Why This Change Was Made

Recognize only `274271284+clawsweeper[bot]@users.noreply.github.com` in the existing known-machine predicate. [GitHub identifies this account as a bot](https://api.github.com/users/clawsweeper%5Bbot%5D), and [ClawSweeper's canonical attribution definition](https://github.com/openclaw/clawsweeper/blob/ff0156fb8628cbf9f22d00864810dea56e83122b/src/repair/co-author-credit.ts) uses that exact address. The existing native review gate independently pins the same bot account ID.

The same composer retains human credit, validates selected messages, and checks preview eligibility. No names, provider domains, other account IDs, or similar-looking addresses are broadly excluded. Source commit history and contributor ancestry stay intact.

## User Impact

A reviewed human-only body remains human-only when the source author is this bot. Explicitly reviewed human credit and eligible human preview credit are preserved. Under the existing no-machine-attribution policy, selected default or explicit messages containing this machine credit are refused with reviewed `--body-file` guidance. Queue overrides remain unsupported; such queue previews remain intentionally blocked.

## Evidence

- The actual captured #119367 preview, non-merge authors, source trailers, and reviewed body reproduce machine credit being restored on trusted main `66381fba99d081329c86e2e9ed2c9bd27d98799d`. The exact input passes after the fix without altering the reviewed body's bytes.
- Nineteen direct composer CLI scenarios using Node builtins and real Git trailer parsing changed from 14 expected failures and five passing human/lookalike cases to all 19 passing. They cover source-author and source-trailer imports, folded/case variants, default/explicit and queue refusal, exact Josh/Peter reviewed credit, eligible human preview credit, and similar account IDs/domains/names.
- Existing real Git/shell wrapper tables gain the bot author and trailer variants plus human/lookalike preservation cases. No new fixture or production seam is added.
- JavaScript syntax, pinned oxfmt 0.65.0 formatting, and `git diff --check` pass. The changed-gate plan was inspected. Exact-head [CI run 34106405903](https://github.com/openclaw/openclaw/actions/runs/34106405903) passed for `92a9c1bc9ff8045aed3398900fc80d63a0808c29`, including the required `openclaw/ci-gate`; no stale shared dependency install was treated as matching proof.
- Fresh complete-diff Codex review found no actionable P0–P2 defects. The reviewer inspected the source, callers, identity contract and test tables; it did not independently execute the tests.
- Native preparation initially lacked Workflow Sanity attachment. One same-head close/reopen recovered a real PR-triggered [Workflow Sanity run](https://github.com/openclaw/openclaw/actions/runs/34111111295), which passed its no-tabs and actionlint/zizmor jobs.
- The refreshed CI encountered an inherited update-finalization process-fixture race on the identical merge commit that passed in the initial run. An earlier phase hit its one-second timeout before the fixture marker, leaving the test interaction pending. Only the exact failed job was rerun; the original failure is retained, and no source, timeout, or assertion was changed. [Attempt 2](https://github.com/openclaw/openclaw/actions/runs/34111111314/attempts/2) completed successfully at the unchanged head, including the required CI gate. This process-fixture interaction remains a separate follow-up.
- Production tooling: one-line replacement, net zero lines. Tests: 11 added table lines.

This is a supporting maintainer-workflow repair. The prepared #119367 source and ancestry were not changed, and this PR is not counted as a performance fix.
