### PR TITLE
refactor(video): share DashScope response acquisition

### DIFF
--- a/src/video-generation/dashscope-compatible.ts
+++ b/src/video-generation/dashscope-compatible.ts
@@ -372,6 +372,29 @@ export function extractDashscopeVideoUrls(payload: DashscopeVideoGenerationRespo
   return uniqueStrings(urls);
 }
 
+// Successful response bodies stay caller-owned and are never replayed by request retries.
+function fetchDashscopeVideoResponse(params: {
+  provider: string;
+  stage: "poll" | "download";
+  requestFailedMessage: string;
+  request: () => ReturnType<typeof fetchWithTimeoutGuarded>;
+}): ReturnType<typeof fetchWithTimeoutGuarded> {
+  return executeProviderOperationWithRetry({
+    provider: params.provider,
+    stage: params.stage,
+    operation: async () => {
+      const result = await params.request();
+      try {
+        await assertOkOrThrowHttpError(result.response, params.requestFailedMessage);
+        return result;
+      } catch (error) {
+        await result.release();
+        throw error;
+      }
+    },
+  });
+}
+
 export async function pollDashscopeVideoTaskUntilComplete(params: {
   providerLabel: string;
   taskId: string;
@@ -389,11 +412,12 @@ export async function pollDashscopeVideoTaskUntilComplete(params: {
     label: `${params.providerLabel} video generation task ${params.taskId}`,
   });
   for (let attempt = 0; attempt < DEFAULT_VIDEO_GENERATION_MAX_POLL_ATTEMPTS; attempt += 1) {
-    const pollResult = await executeProviderOperationWithRetry({
+    const pollResult = await fetchDashscopeVideoResponse({
       provider: params.providerLabel,
       stage: "poll",
-      operation: async () => {
-        const result = await fetchWithTimeoutGuarded(
+      requestFailedMessage: `${params.providerLabel} video-generation task poll failed`,
+      request: () =>
+        fetchWithTimeoutGuarded(
           `${params.baseUrl}/api/v1/tasks/${params.taskId}`,
           {
             method: "GET",
@@ -405,18 +429,7 @@ export async function pollDashscopeVideoTaskUntilComplete(params: {
             ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
             ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
           },
-        );
-        try {
-          await assertOkOrThrowHttpError(
-            result.response,
-            `${params.providerLabel} video-generation task poll failed`,
-          );
-          return result;
-        } catch (error) {
-          await result.release();
-          throw error;
-        }
-      },
+        ),
     });
     let payload: DashscopeVideoGenerationResponse;
     try {
@@ -585,35 +598,20 @@ export async function downloadDashscopeGeneratedVideos(params: {
   const videos: GeneratedVideoAsset[] = [];
   const downloadLabel = `${params.providerLabel} generated video download`;
   for (const [index, url] of params.urls.entries()) {
-    const result = await executeProviderOperationWithRetry({
+    const result = await fetchDashscopeVideoResponse({
       provider: params.providerLabel,
       stage: "download",
-      operation: async () => {
+      requestFailedMessage: `${params.providerLabel} generated video download failed`,
+      request: () => {
         const downloadTimeoutMs = resolveDashscopeVideoDownloadTimeoutMs(
           params.providerLabel,
           params.timeoutMs,
           params.defaultTimeoutMs,
         );
-        const guarded = await fetchWithTimeoutGuarded(
-          url,
-          { method: "GET" },
-          downloadTimeoutMs,
-          params.fetchFn,
-          {
-            ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
-            ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
-          },
-        );
-        try {
-          await assertOkOrThrowHttpError(
-            guarded.response,
-            `${params.providerLabel} generated video download failed`,
-          );
-          return guarded;
-        } catch (error) {
-          await guarded.release();
-          throw error;
-        }
+        return fetchWithTimeoutGuarded(url, { method: "GET" }, downloadTimeoutMs, params.fetchFn, {
+          ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
+          ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
+        });
       },
     });
     let buffer: Buffer;


### PR DESCRIPTION
## What Problem This Solves

DashScope polling and video downloads duplicated response acquisition, retry, HTTP validation and release-on-error. A cleanup change had to be made in both paths.

## Why This Change Was Made

Peter Steinberger explicitly requested this bounded work as item 5 of the media de-duplication campaign. The broader API choice below remains reserved for maintainer decision.

One private response helper now owns that repeated boundary. Each caller retains its exact per-attempt request closure, timeout calculation, headers, guard policy and labels. Successful bodies stay caller-owned and are parsed outside request retries; release failures retain the same precedence.

Production net -2 lines, tests unchanged. This is a small ownership consolidation, not the full cross-provider poller migration.

## User Impact

No intentional status, retry, timeout, configuration or SDK change.

## Deferred API choice (maintainer)

The maintainer approved landing this bounded precursor independently; the broader API design below remains deferred.

The full generic poller needs public fetch/decoder policy hooks. The current shared poller hardcodes retry scope, object-root JSON decoding, a combined error label, an operation-bound body timeout and completion-before-failure ordering. MiniMax validates its envelope before success; xAI treats unknown statuses as pending; OpenRouter has no polling retries and strips cross-origin credentials; DashScope gives UNKNOWN a specific expired-task failure. These contracts must remain provider-owned when the common polling lifecycle is approved.

This precursor does not change `src/media-understanding/shared.ts` or any public helper parameter.

## Evidence

- Fresh `node scripts/check-changed.mjs` passed. Exact-head [CI run 34112287408](https://github.com/openclaw/openclaw/actions/runs/34112287408) passed on `059b7b9b105266d3f4ac067bb065a74d4b2dc4e0`; native review artifacts validated and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 141108` accepted the hosted evidence without changing the head.

- Adoption verification after rebase: all 3 files / 80 focused tests passed; fresh independent Codex autoreview is clean through P2 with zero actionable findings.
- Real transport boundary proof: a synthetic loopback HTTP fixture drove the exported production task pipeline with native fetch and the existing explicit private-network/direct-transport options. It observed one submit, a 503 followed by successful polling, a 503 followed by the expected 21-byte video asset, and malformed streaming content rejected without a retry. Failed-response sockets closed before retries; zero sockets remained before fixture teardown. Bytes, MIME, filename and task metadata matched expected values. This is synthetic local HTTP proof, not a live provider-generation claim.
- Command: `env -u OPENCLAW_PROXY_ACTIVE node --import ./scripts/tsx.mjs /tmp/L14-adopt/dashscope-http-proof.mjs`; exit 0 in 16.65s. Summary: `submit=1 poll=2 download=2 malformed=1; retry cleanup=true; body cancellation=true; open sockets=0`.

`node scripts/run-vitest.mjs src/video-generation/dashscope-compatible.test.ts extensions/qwen/video-generation-provider.test.ts extensions/alibaba/video-generation-provider.test.ts`: 3 files, 80 tests passed. Independent Codex autoreview clean through P2, zero actionable findings. `node scripts/check-changed.mjs` passed with exit 0, including core and core-test typechecks, lint, dead exports and the final pairing-account guard. The runner intentionally omits the timing summary for an all-green run unless `--timed` is supplied. `git diff --check` passed. No baseline changes. Existing owner and Alibaba/Qwen suites retain coverage of terminal states, body failures, request policy and response cleanup.
