### PR TITLE
fix(update): let 2026.9.2 finish state-schema upgrades

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -239,10 +239,23 @@ verified running. Staging, candidate validation, and pre-activation repair are e
 records include service PID/port, version/build identity, settled health,
 plugin activation errors, channel readiness, and `/readyz`.
 
-After a live database migration, a fresh process from the candidate completes
-verification and writes the final outcome to the same run. It carries forward
-the activation steps; a schema upgrade does not create a separate report or let
-the old updater reopen the newer database.
+With transactional updaters from 2026.9.3 onward, a fresh process from the
+candidate completes verification after a live database migration and writes the
+final outcome to the same run. It carries forward the activation steps; a schema
+upgrade does not create a separate report or let the old updater reopen the
+newer database.
+
+The 2026.9.2 updater keeps its own completion path. For shared-state migrations,
+the candidate applies schema content but delays version publication until every
+affected terminal run is at least five minutes old, or each still-running row
+has been unchanged for more than 30 minutes. Doctor reports the deferral; the
+new Gateway already uses the migrated content and publishes the version after
+the deadline. Pending agent-database migrations, missing state metadata, and
+failed content migrations still produce `update-schema-bump-unfenced` with
+[manual update commands](/install/updating#updating-from-2026.9.2-across-a-schema-bump).
+See [Database schemas](/reference/database-schemas#schema-bumps-and-older-updaters)
+for exact publication rules and the remaining risk to a stalled old CLI's final
+report.
 
 ## `update repair`
 

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -78,6 +78,25 @@ To review changes before writing, open the config file first:
 cat ~/.openclaw/openclaw.json
 ```
 
+## Schema publication during a 2026.9.2 update
+
+When OpenClaw 2026.9.2 drives an update that needs a newer shared-state schema,
+Doctor applies the migration content and reports
+`schema content applied; version publication deferred until update run <id> finishes`.
+The old updater can finish its ledger access, while the new Gateway uses the
+migrated content. Publication waits until all affected terminal runs are at least
+five minutes old; a running row unchanged for more than 30 minutes counts as
+abandoned. Every writable database open follows this rule, and the Gateway
+watcher schedules publication after the deadline.
+
+Deferral does not cover agent-database migrations. Doctor reports
+`update-schema-bump-unfenced` if one is pending, if the required shared-state
+metadata table is missing, or if the content migration fails. Follow the
+[manual update sequence](/install/updating#updating-from-2026.9.2-across-a-schema-bump)
+from the refusal. See [Database schemas](/reference/database-schemas#schema-bumps-and-older-updaters)
+for the publication contract and the remaining risk for an old CLI stalled
+beyond the grace period.
+
 ## Read-only lint mode
 
 `openclaw doctor --lint` is the automation-friendly sibling of

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -89,6 +89,10 @@ five minutes old; a running row unchanged for more than 30 minutes counts as
 abandoned. Every writable database open follows this rule, and the Gateway
 watcher schedules publication after the deadline.
 
+Ordinary CLI commands, including Doctor, remain usable while that Gateway runs.
+Applied content counts as ready; only the owning Gateway, or a writable opener
+when no Gateway owns the state directory, publishes the version after the grace.
+
 Deferral does not cover agent-database migrations. Doctor reports
 `update-schema-bump-unfenced` if one is pending, if the required shared-state
 metadata table is missing, or if the content migration fails. Follow the

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -117,19 +117,25 @@ See [Release channels](/install/development-channels) for channel semantics.
 
 ### Updating from 2026.9.2 across a schema bump
 
-When the target release needs a newer shared-state or registered agent database
-schema, its Doctor refuses an update driven by OpenClaw 2026.9.2 before applying
-repairs. That release introduced the update ledger but still accesses it with old
-code after running the target's Doctor. Migrating first would leave the updater
-unable to finish or safely restore the previous release.
+Updates driven by OpenClaw 2026.9.2 can cross a shared-state schema bump normally.
+The target applies the migration content while retaining the old published
+schema version, so the old updater can finish its ledger writes and final
+report. Doctor explains that schema content is applied and version publication
+is deferred. The new Gateway runs on the migrated content during this interval.
 
-The refusal reports the on-disk and target schema versions and, when readable,
-the driving updater version. Let the failed update finish restoring the previous
-package. OpenClaw 2026.9.2 treats any failed post-install verification as unsafe
-for an automatic restart and leaves the Gateway service stopped; run
-`openclaw gateway start` to bring the previous release back on its untouched
-database, then run the manual update from a shell outside the Gateway. Replace
-`<target>` with the exact target version from the refusal:
+Publication waits until every affected update run has been terminal for at least
+five minutes. A running row that has not changed for more than 30 minutes counts
+as abandoned for this purpose. The Gateway watcher publishes after the deadline;
+a later database open can also publish it. See the precise timing and residual
+old-CLI limitation in [Database schemas](/reference/database-schemas#schema-bumps-and-older-updaters).
+
+If an agent database also needs migration, required state metadata is missing,
+or the state-content migration fails, Doctor instead reports
+`update-schema-bump-unfenced` with database versions and manual update commands.
+Let the failed update finish restoring the previous package. OpenClaw 2026.9.2
+leaves the Gateway service stopped after failed post-install verification. Run
+the manual update from a shell outside the Gateway, replacing `<target>` with
+the exact target version from the refusal:
 
 ```bash
 openclaw gateway stop
@@ -143,14 +149,11 @@ omit `--allow-scripts=openclaw`. For a pnpm-owned install, replace the install
 command with `pnpm add -g --allow-build=openclaw openclaw@<target>`; for Bun, use
 `bun add -g --trust openclaw@<target>`.
 
-Same-schema updates continue normally. Earlier updaters, including 2026.9.1,
-do not reopen shared state after Doctor and can cross schema bumps without this
-refusal. Later transactional updaters fence old ledger access and hand completion
-to the candidate, including 2026.9.3 prereleases. The guard requires an active update ledger run from an affected
-updater; a missing table or no running row preserves the earlier update behavior.
-The guard does not undo an earlier migration; if the database is already newer
+Same-schema updates, earlier ledger-less updaters such as 2026.9.1, and fenced
+transactional updaters from 2026.9.3 onward keep their existing behavior. The
+fallback does not undo an earlier migration; if the database is already newer
 than the restored package, install a compatible target and finish Doctor before
-starting the Gateway. See [Database schemas](/reference/database-schemas).
+starting the Gateway.
 
 ### From chat
 

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -258,6 +258,12 @@ Current content is ready for readers even while its version is unpublished.
 Ordinary CLI commands can run alongside the Gateway throughout this window;
 publication alone does not trigger schema repair or require stopping the Gateway.
 
+A subsequent update can run during this window. Its migration verification and
+rollback checks compare applied content versions from private database snapshots.
+Publishing already-applied content is not another migration; applying new content
+still blocks rollback even when the published number has not changed. Managed
+service stop, activation, and Doctor maintenance keep their normal ownership rules.
+
 Publication waits until **every** update row whose `before.version` identifies
 the 2026.9.2 release line meets its applicable condition:
 

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -150,12 +150,12 @@ Accepted checkpoint history and publication source artifacts remain until explic
 
 ## Versioning contract
 
-Each database records its schema in two places:
+Each database records its published schema in two places:
 
 - `PRAGMA user_version` is the SQLite schema version.
 - The primary `schema_meta` row records `role`, `agent_id`, `schema_version`, and `app_version`. `app_version` is the OpenClaw build that last wrote the schema metadata.
 
-OpenClaw applies forward-only migrations when it opens an older supported database. It refuses a database whose `user_version` is newer than the running build and reports a `newer schema version` error. The Gateway checks all registered databases before startup. `openclaw update` also refuses a package or source target whose declared schema support is older than an on-disk database. Target packages published before schema metadata was added cannot be preflighted.
+OpenClaw applies forward-only migrations when it opens an older supported database. It refuses a database whose `user_version` is newer than the running build and reports a `newer schema version` error. The Gateway checks all registered databases before startup. `openclaw update` also refuses a package or source target whose declared schema support is older than an on-disk database. Target packages published before schema metadata was added cannot be preflighted. Updates driven by the 2026.9.2 release line can temporarily defer publication of a shared-state schema version while the old updater finishes; see [Schema bumps and older updaters](#schema-bumps-and-older-updaters).
 
 When Gateway startup encounters a newer database schema, it exits with status 78 so the generated systemd service does not restart it repeatedly. On macOS, it also parks its managed LaunchAgent to stop `KeepAlive` retries. This applies to failures during CLI bootstrap as well as server startup and does not depend on the database-backed crash counter. Start the Gateway with a build that supports the existing schemas. The older install cannot repair them with `doctor --fix`; run Doctor from the compatible install if further migration is required, then restart through the service or deployment owner.
 
@@ -238,28 +238,66 @@ but disables the new structured controls; upgrading can read retained receipts.
 
 ### Schema bumps and older updaters
 
-Update-time Doctor checks the shared database and registered agent databases
-before CLI debug capture, maintenance, config rewrites, or migration ledger writes.
-If a database would advance `user_version` and a running `update_runs` row identifies
-the driving updater as the 2026.9.2 release line, Doctor reports
-`update-schema-bump-unfenced` and a nonzero exit. The
-refusal includes on-disk and target schema versions, the active update run's
-`before.version`, and manual update commands. Doctor leaves the databases and
-config unchanged.
+OpenClaw 2026.9.2 introduced the update ledger but reopens it with old code after
+running the target's Doctor, including a final read after recording its terminal
+outcome. The shared-state database runner lets this updater finish by applying
+migration content first and publishing the new schema version later. This rule
+applies to every writable open, including Doctor, the restarted Gateway, and
+other CLI processes.
 
-OpenClaw 2026.9.2 introduced the update ledger and reopens it with the previous
-build after the target's Doctor. That release cannot safely drive a schema bump.
-Earlier updaters, including 2026.9.1, never reopen shared state after Doctor and
-continue to work. A missing ledger table or no running row does not trigger this
-guard, including when a database schema is indeterminate. Builds from 2026.9.3
-onward, including prereleases, use transactional updates that suspend old-process
-ledger access and let candidate code finish after migration. The version check
-includes 2026.9.2 rebuilds and requires a valid semantic version; it adds no
-environment override. Same-schema repairs and ordinary Doctor runs remain available.
+The runner records the applied content version in the existing
+`config_machine_state` key `state.schema.contentVersion`. While publication is
+deferred, new code uses that content version, and both `PRAGMA user_version` and
+`schema_meta.schema_version` retain the previous published version. Content and
+its marker commit together. Reopening skips migration steps already covered by
+the marker, including the schema-16 Skill Workshop rebuild; it does not infer
+completion from table shape or repeat the rebuild. This requires no new table,
+configuration option, or environment override.
 
-Use the [manual update sequence](/install/updating#updating-from-2026.9.2-across-a-schema-bump)
-after the old updater restores the previous package. Package rollback cannot
-reverse a migration that already happened.
+Publication waits until **every** update row whose `before.version` identifies
+the 2026.9.2 release line meets its applicable condition:
+
+- A terminal row's `finished_at_ms` is at least five minutes old.
+- A running row's `updated_at_ms` is more than 30 minutes old. The runner treats
+  that driver as abandoned for publication purposes; it does not rewrite the
+  run's outcome.
+
+A missing ledger or no affected rows permits immediate publication. Deadlines
+come from the rows' timestamps, never the observing process's start time. The
+new Gateway's ledger watcher schedules publication at the applicable deadline
+without jitter, and any later writable database open can publish it too.
+Publication rereads the content marker and all affected rows inside one
+synchronous write transaction before advancing both published schema markers.
+A new or refreshed running row blocks publication again. Restarting the Gateway
+does not shorten or restart the grace period.
+
+The five-minute grace accommodates 2026.9.2's trailing ledger reads; that release
+records no driver process identity that would prove those reads have finished.
+An old CLI blocked for more than five minutes after committing its terminal row,
+for example on a stalled stdout pipe, can still fail its final render after
+publication. By then the package swap, any requested service restart, and terminal ledger
+outcome are complete. Downgrade protection for the 2026.9.2 line is delayed by the
+same grace, or by the 30-minute abandoned-driver bound. The retained version is
+not permission to run older code against migrated feature tables. Do not
+manually lower either version marker or delete the content marker.
+
+Update-time Doctor checks shared and registered agent databases before other
+repairs. A state-only migration proceeds with deferred publication and reports
+`schema content applied; version publication deferred until update run <id> finishes`.
+Publication still observes the five-minute grace after that run finishes.
+Doctor keeps the typed `update-schema-bump-unfenced` refusal when deferral cannot
+cover a pending agent-database migration, the required `config_machine_state`
+table is missing, or the state-content migration fails. A failed content
+transaction rolls back. The refusal includes the database versions, driving
+updater version, and [manual update commands](/install/updating#updating-from-2026.9.2-across-a-schema-bump).
+Package rollback cannot reverse a migration that already happened.
+
+The driver check requires a valid semantic version and includes 2026.9.2
+rebuilds. Earlier updaters, including 2026.9.1, have no ledger and keep normal
+publication behavior. Builds from 2026.9.3 onward, including prereleases, use
+transactional updates that fence old-process ledger access and let candidate
+code finish after migration; they also keep normal publication behavior.
+Same-schema repairs and ordinary Doctor runs remain available.
 
 ### Profile-owned skill library
 

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -254,6 +254,10 @@ the marker, including the schema-16 Skill Workshop rebuild; it does not infer
 completion from table shape or repeat the rebuild. This requires no new table,
 configuration option, or environment override.
 
+Current content is ready for readers even while its version is unpublished.
+Ordinary CLI commands can run alongside the Gateway throughout this window;
+publication alone does not trigger schema repair or require stopping the Gateway.
+
 Publication waits until **every** update row whose `before.version` identifies
 the 2026.9.2 release line meets its applicable condition:
 
@@ -265,7 +269,9 @@ the 2026.9.2 release line meets its applicable condition:
 A missing ledger or no affected rows permits immediate publication. Deadlines
 come from the rows' timestamps, never the observing process's start time. The
 new Gateway's ledger watcher schedules publication at the applicable deadline
-without jitter, and any later writable database open can publish it too.
+without jitter. Publication holds the Gateway lifecycle fence: the owning Gateway
+can publish, and a later writable open can publish when no Gateway owns the state
+directory. Other processes silently leave publication to that owner.
 Publication rereads the content marker and all affected rows inside one
 synchronous write transaction before advancing both published schema markers.
 A new or refreshed running row blocks publication again. Restarting the Gateway

--- a/src/cli/doctor-output.process.test.ts
+++ b/src/cli/doctor-output.process.test.ts
@@ -93,7 +93,7 @@ function runDoctor(params: {
 }
 
 describe("Doctor report process output", () => {
-  it("refuses an unfenced schema bump before CLI debug capture can write state", () => {
+  it("refuses an unfenced schema bump without publication metadata before CLI debug capture can write state", () => {
     const root = tempDirs.make("openclaw-doctor-update-schema-");
     const configPath = path.join(root, "openclaw.json");
     const env = { OPENCLAW_STATE_DIR: path.join(root, "state"), OPENCLAW_CONFIG_PATH: configPath };
@@ -103,7 +103,7 @@ describe("Doctor report process output", () => {
     closeOpenClawStateDatabaseForTest();
     const legacy = new DatabaseSync(shared);
     legacy.exec(
-      `PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION - 1}; UPDATE schema_meta SET schema_version = ${OPENCLAW_STATE_SCHEMA_VERSION - 1};`,
+      `PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION - 1}; UPDATE schema_meta SET schema_version = ${OPENCLAW_STATE_SCHEMA_VERSION - 1}; DROP TABLE config_machine_state;`,
     );
     legacy.close();
     const databaseBefore = fs.readFileSync(shared);

--- a/src/cli/failure-output.test.ts
+++ b/src/cli/failure-output.test.ts
@@ -1,6 +1,7 @@
 // Failure output tests cover CLI error formatting and failure summaries.
 import { describe, expect, it } from "vitest";
 import { GatewayCredentialsRequiredError, GatewayTransportError } from "../gateway/call.js";
+import { UpdateSchemaRefusalError } from "../state/openclaw-update-schema-refusal.js";
 import {
   ExpectedCliError,
   formatCliFailureLines,
@@ -12,6 +13,31 @@ const PLUGIN_POLICY_MESSAGE =
   'The `openclaw workboard` command is provided by the "workboard" plugin, but that bundled plugin is disabled by default. Run `openclaw plugins enable workboard` to enable that CLI surface.';
 
 describe("formatCliJsonFailure", () => {
+  it("preserves the typed schema refusal when a runner migration fails before Doctor starts", () => {
+    const databases = [
+      {
+        kind: "state" as const,
+        path: "/state/openclaw.sqlite",
+        foundVersion: 15,
+        supportedVersion: 16,
+      },
+    ];
+    const error = new UpdateSchemaRefusalError(databases, "2026.9.2", {
+      cause: new Error("content migration failed"),
+    });
+    expect(formatCliJsonFailure(error, { env: {} })).toMatchObject({
+      ok: false,
+      error: {
+        type: "cli_error",
+        code: "update-schema-bump-unfenced",
+        updaterVersion: "2026.9.2",
+        message: expect.stringContaining("Deferral failed: content migration failed"),
+        databases,
+        commands: expect.arrayContaining(["openclaw gateway stop", "openclaw doctor --fix"]),
+      },
+    });
+  });
+
   it("uses the canonical typed envelope and redacts the message", () => {
     const token = "sk-abcdefghijklmnopqrstuv";
     const payload = formatCliJsonFailure(new Error(`Authorization: Bearer ${token}`));

--- a/src/cli/failure-output.test.ts
+++ b/src/cli/failure-output.test.ts
@@ -23,6 +23,7 @@ describe("formatCliJsonFailure", () => {
       },
     ];
     const error = new UpdateSchemaRefusalError(databases, "2026.9.2", {
+      targetVersion: "2026.9.4",
       cause: new Error("content migration failed"),
     });
     expect(formatCliJsonFailure(error, { env: {} })).toMatchObject({

--- a/src/cli/failure-output.ts
+++ b/src/cli/failure-output.ts
@@ -2,6 +2,10 @@
 import { isGatewayTransportError } from "../gateway/transport-error.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage, formatUncaughtError } from "../infra/errors.js";
+import {
+  UpdateSchemaRefusalError,
+  type UpdateSchemaRefusalDatabase,
+} from "../state/openclaw-update-schema-refusal.js";
 import { formatCliCommand } from "./command-format.js";
 
 type FormatCliFailureOptions = {
@@ -21,6 +25,11 @@ export type CliJsonFailure = {
   error: {
     type: "cli_error";
     message: string;
+    code?: string;
+    databases?: readonly UpdateSchemaRefusalDatabase[];
+    updaterVersion?: string;
+    targetVersion?: string;
+    commands?: readonly string[];
   };
 };
 
@@ -107,6 +116,15 @@ export function formatCliJsonFailure(
     error: {
       type: "cli_error",
       message,
+      ...(error instanceof UpdateSchemaRefusalError
+        ? {
+            code: error.code,
+            databases: error.databases,
+            updaterVersion: error.updaterVersion,
+            targetVersion: error.targetVersion,
+            commands: error.commands,
+          }
+        : {}),
     },
   };
 }

--- a/src/cli/update-cli/update-command-migrated.test.ts
+++ b/src/cli/update-cli/update-command-migrated.test.ts
@@ -143,6 +143,55 @@ it("refuses state inspection when activation leaves no known runtime root", asyn
   });
 });
 
+it.each([
+  { beforeContent: false, publish: false, blocked: "state-migrated-no-rollback" },
+  { beforeContent: true, publish: false, blocked: undefined },
+  { beforeContent: true, publish: true, blocked: undefined },
+])(
+  "accepts applied shared content through activation (alreadyApplied=$beforeContent, published=$publish)",
+  async ({ beforeContent, publish, blocked }) => {
+    const stateDir = await fs.realpath(dirs.make("update-deferred-content-"));
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const shared = openOpenClawStateDatabase({ env });
+    const contentVersion = OPENCLAW_STATE_SCHEMA_VERSION + 1;
+    const markContentApplied = () =>
+      shared.db
+        .prepare(
+          "INSERT OR REPLACE INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES (?, ?, ?)",
+        )
+        .run("state.schema.contentVersion", JSON.stringify(contentVersion), Date.now());
+    if (beforeContent) {
+      markContentApplied();
+    }
+    const schemaVersions = await readUpdateStateSchemaVersions({ stateDir, config: {}, env });
+    markContentApplied();
+    if (publish) {
+      shared.db.exec(`PRAGMA user_version = ${contentVersion};`);
+    }
+    const result = {
+      status: "ok" as const,
+      mode: "npm" as const,
+      root: process.cwd(),
+      steps: [],
+      durationMs: 0,
+    };
+    await expect(
+      inspectActivatedUpdateState({
+        result,
+        root: process.cwd(),
+        schemaVersions,
+        candidateSchemaVersions: { state: contentVersion, agent: OPENCLAW_AGENT_SCHEMA_VERSION },
+        config: {},
+        env,
+      }),
+    ).resolves.toBe(blocked);
+    expect(result).toMatchObject({ status: "ok", steps: [] });
+    expect(shared.db.prepare("PRAGMA user_version").get()?.user_version).toBe(
+      publish ? contentVersion : OPENCLAW_STATE_SCHEMA_VERSION,
+    );
+  },
+);
+
 it.each([false, true])(
   "finishes the same real ledger from the candidate after the old updater is fenced by migration (json=%s)",
   async (json) => {

--- a/src/cli/update-cli/update-command-migrated.ts
+++ b/src/cli/update-cli/update-command-migrated.ts
@@ -8,6 +8,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { runtimeProcessEntrypoints } from "../../infra/runtime-process-entrypoints.js";
 import {
   readUpdateStateSchemaVersions,
+  resolveUpdateStateContentVersion,
   updateStateSchemaVersionsMatch,
 } from "../../infra/update-candidate-state.js";
 import type { UpdateRequesterAuthority } from "../../infra/update-requester-authority.js";
@@ -52,16 +53,15 @@ export async function inspectActivatedUpdateState(
       root: result.root ?? null,
       nodeRunner: params.packageUpdateNodeRunner,
     });
-    const sharedVersion = current.find(
-      (entry) => entry.path === resolveOpenClawStateSqlitePath(env),
-    )?.userVersion;
+    const shared = current.find((entry) => entry.path === resolveOpenClawStateSqlitePath(env));
+    const sharedVersion = shared ? resolveUpdateStateContentVersion(shared) : undefined;
     if (
       result.status === "ok" &&
       candidateSchemaVersions &&
       sharedVersion !== candidateSchemaVersions.state
     ) {
-      // Doctor can warn without failing. Startup must not perform a late
-      // migration underneath the previous runtime's ledger writer.
+      // Doctor can warn without failing. Require applied content so startup
+      // cannot migrate late; deferred publication alone is already ready.
       result.status = "error";
       result.reason = `${CLI_NAME} doctor`;
       result.steps.push({

--- a/src/cli/update-cli/update-command-rollback.test.ts
+++ b/src/cli/update-cli/update-command-rollback.test.ts
@@ -318,6 +318,7 @@ describe("verified package rollback", () => {
     },
     { change: "identity-read-failed", previousVerified: true, restored: true, service: "stopped" },
     { change: "shared", previousVerified: true, restored: false, service: "stopped" },
+    { change: "new-shared-deferred", previousVerified: true, restored: false, service: "stopped" },
     { change: "agent", previousVerified: true, restored: false, service: "stopped" },
     { change: "during-stop", previousVerified: true, restored: false, service: "stopped" },
     { change: "unknown-runtime", previousVerified: true, restored: false, service: "stopped" },
@@ -332,11 +333,26 @@ describe("verified package rollback", () => {
       const config = await readPreviousConfig({ ...process.env, OPENCLAW_STATE_DIR: stateDir });
       const shared = path.join(stateDir, "state/openclaw.sqlite");
       const agent = path.join(stateDir, "agents/main/agent/openclaw-agent.sqlite");
-      setVersion(shared, 7);
+      if (change !== "new-shared-deferred") {
+        setVersion(shared, 7);
+      }
       if (!change.startsWith("new-agent")) {
         setVersion(agent, 3);
       }
       const schemaVersions = await readUpdateStateSchemaVersions({ stateDir, config: {} });
+      if (change === "new-shared-deferred") {
+        expect(schemaVersions.find((entry) => entry.path === shared)?.userVersion).toBeNull();
+        setVersion(shared, 7);
+        const database = new DatabaseSync(shared);
+        try {
+          database.exec(`
+            CREATE TABLE config_machine_state (state_key TEXT PRIMARY KEY, value_json TEXT, updated_at_ms INTEGER);
+            INSERT INTO config_machine_state VALUES ('state.schema.contentVersion', '8', 0);
+          `);
+        } finally {
+          database.close();
+        }
+      }
       if (change.startsWith("new-agent")) {
         setVersion(agent, change === "new-agent-foreign" ? 4 : 3);
       }
@@ -380,7 +396,7 @@ describe("verified package rollback", () => {
         previousRoot,
         nodeRunner: process.execPath,
         schemaVersions,
-        candidateSchemaVersions: { state: 7, agent: 3 },
+        candidateSchemaVersions: { state: change === "new-shared-deferred" ? 8 : 7, agent: 3 },
         previousSchemaVersions:
           change === "new-agent-previous-unknown"
             ? undefined
@@ -445,7 +461,9 @@ describe("verified package rollback", () => {
         );
       } else {
         expect(outcome.result.reason).toBe(
-          change === "unknown-runtime" || change.startsWith("new-agent-previous-")
+          change === "unknown-runtime" ||
+            change === "new-shared-deferred" ||
+            change.startsWith("new-agent-previous-")
             ? "rollback-state-unverified"
             : previousVerified
               ? "state-migrated-no-rollback"

--- a/src/cli/update-cli/update-command-rollback.ts
+++ b/src/cli/update-cli/update-command-rollback.ts
@@ -7,6 +7,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import type { PackageUpdateTransaction } from "../../infra/package-update-steps.js";
 import {
   readUpdateStateSchemaVersions,
+  resolveUpdateStateContentVersion,
   updateStateSchemaVersionsMatch,
   type UpdateStateSchemaVersion,
 } from "../../infra/update-candidate-state.js";
@@ -101,18 +102,21 @@ export async function rollbackFailedUpdate(params: {
     ) {
       return false;
     }
-    const baselineVersions = new Map(baseline.map((entry) => [entry.path, entry.userVersion]));
+    const baselineVersions = new Map(
+      baseline.map((entry) => [entry.path, resolveUpdateStateContentVersion(entry)]),
+    );
     for (const entry of current) {
-      if (entry.userVersion === null || baselineVersions.get(entry.path) != null) {
+      const version = resolveUpdateStateContentVersion(entry);
+      if (version === null || baselineVersions.get(entry.path) != null) {
         continue;
       }
       // First-use creation is not migration, but the retained runtime must still
       // support that new store before replacing a reachable candidate.
       const kind = entry.path === sharedPath ? "state" : "agent";
       const supported = params.previousSchemaVersions?.[kind];
-      if (supported === undefined || entry.userVersion > supported) {
+      if (supported === undefined || version > supported) {
         throw new Error(
-          `Automatic rollback refused: newly created ${kind} database ${entry.path} uses schema ${entry.userVersion}; retained previous package support is ${supported ?? "unknown"}. Keep the candidate installed.`,
+          `Automatic rollback refused: newly created ${kind} database ${entry.path} uses schema ${version}; retained previous package support is ${supported ?? "unknown"}. Keep the candidate installed.`,
         );
       }
     }

--- a/src/commands/doctor-config-preflight.refusal.process.test.ts
+++ b/src/commands/doctor-config-preflight.refusal.process.test.ts
@@ -20,7 +20,7 @@ const tempDirs = useAutoCleanupTempDirTracker(afterAll);
 
 describe("Doctor CLI migration refusal", () => {
   it.each(["index.js", "entry.js"])(
-    "refuses the 2026.9.2 updater through %s with its running ledger row only in WAL",
+    "refuses missing deferral metadata through %s with the 2026.9.2 row only in WAL",
     (entry) => {
       const root = fs.realpathSync(tempDirs.make("openclaw-doctor-update-wal-"));
       const stateDir = path.join(root, "state");
@@ -46,6 +46,7 @@ describe("Doctor CLI migration refusal", () => {
           PRAGMA wal_autocheckpoint = 0;
           PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION - 1};
           UPDATE schema_meta SET schema_version = ${OPENCLAW_STATE_SCHEMA_VERSION - 1};
+          DROP TABLE config_machine_state;
           DELETE FROM update_runs;
           PRAGMA wal_checkpoint(TRUNCATE);
         `);

--- a/src/commands/doctor-update-schema-guard.ts
+++ b/src/commands/doctor-update-schema-guard.ts
@@ -14,6 +14,7 @@ import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { readStateSchemaPublicationBlocker } from "../state/openclaw-state-schema-publication.js";
 import { UpdateSchemaRefusalError } from "../state/openclaw-update-schema-refusal.js";
+import { VERSION } from "../version.js";
 
 async function readDrivingUpdater(): Promise<
   { version: string; canDeferStateSchema: boolean } | undefined
@@ -78,7 +79,9 @@ export async function guardUpdateDoctorSchemaUpgrade(options: {
   if (blockedMigrations.length === 0) {
     return;
   }
-  const error = new UpdateSchemaRefusalError(blockedMigrations, updater.version);
+  const error = new UpdateSchemaRefusalError(blockedMigrations, updater.version, {
+    targetVersion: VERSION,
+  });
   if (options.json) {
     writeRuntimeJson(options.runtime, formatCliJsonFailure(error));
     exitCliAfterOutput(options.runtime, 1);

--- a/src/commands/doctor-update-schema-guard.ts
+++ b/src/commands/doctor-update-schema-guard.ts
@@ -1,11 +1,6 @@
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { parse as parseSemver } from "semver";
+import { formatCliJsonFailure } from "../cli/failure-output.js";
 import { exitCliAfterOutput } from "../cli/one-shot-exit.js";
-import {
-  clearNodeSqliteKyselyCacheForDatabase,
-  executeSqliteQueryTakeFirstSync,
-  getNodeSqliteKysely,
-} from "../infra/kysely-sync.js";
+import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
@@ -16,50 +11,13 @@ import {
 } from "../state/openclaw-database-preflight.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
-import type { DB } from "../state/openclaw-state-db.generated.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
-import { VERSION } from "../version.js";
+import { readStateSchemaPublicationBlocker } from "../state/openclaw-state-schema-publication.js";
+import { UpdateSchemaRefusalError } from "../state/openclaw-update-schema-refusal.js";
 
-// 2026.9.2 introduced the ledger without fencing post-Doctor access. Earlier
-// updaters never reopen state; #138839 fenced every 2026.9.3-and-later build.
-// Compare the parsed release line so 2026.9.2 rebuilds are included and
-// 2026.9.3 prereleases are excluded, independently of this checkout's VERSION.
-const UNFENCED_LEDGER_UPDATER_RELEASE = "2026.9.2";
-
-/** A pre-transaction updater would reopen the migrated ledger with its old code. */
-class DoctorUpdateSchemaRefusalError extends Error {
-  readonly code = "update-schema-bump-unfenced";
-  readonly targetVersion = VERSION;
-  readonly commands: string[];
-
-  constructor(
-    readonly databases: NonNullable<OpenClawDatabaseSchemaPreflight["pendingMigrations"]>,
-    readonly updaterVersion: string,
-  ) {
-    const commands = [
-      "openclaw gateway stop",
-      `npm install -g openclaw@${VERSION} --allow-scripts=openclaw`,
-      "openclaw doctor --fix",
-      "openclaw gateway start",
-    ];
-    super(
-      `Doctor refused update-time schema repair driven by OpenClaw ${updaterVersion}: this updater reopens the ledger with old code after migration. ` +
-        databases
-          .map(
-            (database) =>
-              `${database.kind} database ${database.path}: on-disk schema ${database.foundVersion}, this build's schema ${database.supportedVersion}.`,
-          )
-          .join(" ") +
-        " No doctor repairs were applied. Let the updater restore the previous package, then update manually: " +
-        `${commands.join(" && ")}. ` +
-        `Use the package manager that owns this install (pnpm: pnpm add -g --allow-build=openclaw openclaw@${VERSION}; Bun: bun add -g --trust openclaw@${VERSION}). On npm 11.15 and earlier, omit --allow-scripts=openclaw.`,
-    );
-    this.name = "DoctorUpdateSchemaRefusalError";
-    this.commands = commands;
-  }
-}
-
-async function readDrivingUpdaterVersion(): Promise<string | undefined> {
+async function readDrivingUpdater(): Promise<
+  { version: string; canDeferStateSchema: boolean } | undefined
+> {
   // The runtime ledger reader consults quarantine state. This diagnostic must
   // not open any live database, including a quarantine store needing recovery.
   const snapshot = await prepareSqliteReadOnlyLocation(resolveOpenClawStateSqlitePath(), {
@@ -68,21 +26,13 @@ async function readDrivingUpdaterVersion(): Promise<string | undefined> {
   try {
     const database = openNodeSqliteDatabase(snapshot.location, { readOnly: true });
     try {
-      if (!tableExists(database, "update_runs")) {
-        return undefined;
-      }
-      const row = executeSqliteQueryTakeFirstSync(
-        database,
-        getNodeSqliteKysely<Pick<DB, "update_runs">>(database)
-          .selectFrom("update_runs")
-          .select("before_json")
-          .where("status", "=", "running")
-          .orderBy("created_at_ms", "desc")
-          .orderBy("run_id", "desc")
-          .limit(1),
-      );
-      const before: unknown = row ? JSON.parse(row.before_json) : undefined;
-      return isRecord(before) && typeof before.version === "string" ? before.version : undefined;
+      const blocker = readStateSchemaPublicationBlocker(database);
+      return blocker
+        ? {
+            version: blocker.updaterVersion,
+            canDeferStateSchema: tableExists(database, "config_machine_state"),
+          }
+        : undefined;
     } finally {
       clearNodeSqliteKyselyCacheForDatabase(database);
       database.close();
@@ -113,36 +63,24 @@ export async function guardUpdateDoctorSchemaUpgrade(options: {
   if (!schemas.pendingMigrations?.length) {
     return;
   }
-  let updaterVersion: string | undefined;
+  let updater: Awaited<ReturnType<typeof readDrivingUpdater>>;
   try {
-    updaterVersion = await readDrivingUpdaterVersion();
+    updater = await readDrivingUpdater();
   } catch {
     // A missing or unreadable run cannot prove that the driver writes the ledger.
   }
-  if (!updaterVersion) {
+  if (!updater) {
     return;
   }
-  const driver = parseSemver(updaterVersion);
-  if (
-    !driver ||
-    `${driver.major}.${driver.minor}.${driver.patch}` !== UNFENCED_LEDGER_UPDATER_RELEASE
-  ) {
+  const blockedMigrations = schemas.pendingMigrations.filter(
+    (database) => database.kind === "agent" || !updater.canDeferStateSchema,
+  );
+  if (blockedMigrations.length === 0) {
     return;
   }
-  const error = new DoctorUpdateSchemaRefusalError(schemas.pendingMigrations, updaterVersion);
+  const error = new UpdateSchemaRefusalError(blockedMigrations, updater.version);
   if (options.json) {
-    writeRuntimeJson(options.runtime, {
-      ok: false,
-      error: {
-        type: "cli_error",
-        code: error.code,
-        message: error.message,
-        databases: error.databases,
-        updaterVersion: error.updaterVersion,
-        targetVersion: error.targetVersion,
-        commands: error.commands,
-      },
-    });
+    writeRuntimeJson(options.runtime, formatCliJsonFailure(error));
     exitCliAfterOutput(options.runtime, 1);
   }
   throw error;

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -160,6 +160,7 @@ export async function runDoctorHealthFlow(runtime?: RuntimeEnv, options: DoctorO
       await assertOpenClawDatabasesReady({
         env: process.env,
         operation: "doctor",
+        onDeferredSchemaPublication: (publication) => effectiveRuntime.log(publication.message),
         configuredAgentDatabaseTargets: resolveConfiguredAgentDatabaseTargets(ctx.cfg, {
           env: process.env,
         }),

--- a/src/flows/doctor-health.update-schema.test.ts
+++ b/src/flows/doctor-health.update-schema.test.ts
@@ -37,6 +37,13 @@ function readDatabase(databasePath: string) {
   try {
     return {
       version: db.prepare("PRAGMA user_version").get()?.user_version,
+      contentVersion: tableExists(db, "config_machine_state")
+        ? db
+            .prepare(
+              "SELECT value_json FROM config_machine_state WHERE state_key = 'state.schema.contentVersion'",
+            )
+            .get()?.value_json
+        : undefined,
       ledger: tableExists(db, "update_runs")
         ? db.prepare("SELECT * FROM update_runs ORDER BY run_id").all()
         : [],
@@ -57,12 +64,12 @@ describe("Doctor schema bumps under an updating parent", () => {
   });
 
   it.each([
-    { kind: "state", updaterVersion: "2026.9.2" },
-    { kind: "agent", updaterVersion: "2026.9.2" },
-    { kind: "state", updaterVersion: "2026.9.2-rebuild.1" },
+    { kind: "state", updaterVersion: "2026.9.2", missingMetadata: true },
+    { kind: "agent", updaterVersion: "2026.9.2", missingMetadata: false },
+    { kind: "agent", updaterVersion: "2026.9.2-rebuild.1", missingMetadata: false },
   ])(
     "refuses a $kind bump driven by $updaterVersion before changing database bytes, ledger, or config",
-    async ({ kind, updaterVersion }) => {
+    async ({ kind, updaterVersion, missingMetadata }) => {
       await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
         const shared = openOpenClawStateDatabase({ env: state.env }).path;
         const agent = openOpenClawAgentDatabase({ agentId: "main", env: state.env }).path;
@@ -73,6 +80,11 @@ describe("Doctor schema bumps under an updating parent", () => {
         const supported =
           kind === "state" ? OPENCLAW_STATE_SCHEMA_VERSION : OPENCLAW_AGENT_SCHEMA_VERSION;
         setSchemaVersion(target, supported - 1);
+        if (missingMetadata) {
+          const db = new DatabaseSync(shared);
+          db.exec("DROP TABLE config_machine_state");
+          db.close();
+        }
         const before = readDatabase(shared);
         const quarantine = state.statePath("state", "openclaw-quarantine.sqlite");
         fs.writeFileSync(quarantine, "unreadable quarantine fixture");
@@ -105,50 +117,63 @@ describe("Doctor schema bumps under an updating parent", () => {
   );
 
   it.each([
+    { ledger: "running", update: "1", driver: "2026.9.2", bump: true, deferred: true },
+    { ledger: "running", update: "1", driver: "2026.9.2-rebuild.1", bump: true, deferred: true },
     { ledger: "missing", update: "1", driver: "2026.9.1", bump: true },
-    { ledger: "finished", update: "1", driver: "2026.9.2", bump: true },
+    { ledger: "finished", update: "1", driver: "2026.9.2", bump: true, deferred: true },
     { ledger: "running", update: "1", driver: "2026.9.3", bump: true },
     { ledger: "running", update: "1", driver: "2026.9.3-beta.1", bump: true },
     { ledger: "running", update: "1", driver: "2026.10.0", bump: true },
     { ledger: "running", update: "1", driver: "2026.9.1", bump: true },
     { ledger: "running", update: "1", driver: "unknown", bump: true },
     { ledger: "running", update: "1", driver: "2026.9.2", bump: false },
-    { ledger: "running", update: undefined, driver: "2026.9.2", bump: true },
-  ])("completes real migration when permitted: %j", async ({ ledger, update, driver, bump }) => {
-    vi.stubEnv("OPENCLAW_UPDATE_IN_PROGRESS", update);
-    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
-      const shared = openOpenClawStateDatabase({ env: state.env }).path;
-      const run = createUpdateRun({ trigger: "cli", before: { version: driver } });
-      if (ledger === "finished") {
-        finishUpdateRun(run.runId, { status: "succeeded" });
-      }
-      closeOpenClawStateDatabaseForTest();
-      if (ledger === "missing") {
-        const db = new DatabaseSync(shared);
-        try {
-          db.exec("DROP TABLE update_runs");
-        } finally {
-          db.close();
+    { ledger: "running", update: undefined, driver: "2026.9.2", bump: true, deferred: true },
+  ])(
+    "completes real migration when permitted: %j",
+    async ({ ledger, update, driver, bump, deferred }) => {
+      vi.stubEnv("OPENCLAW_UPDATE_IN_PROGRESS", update);
+      await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+        const shared = openOpenClawStateDatabase({ env: state.env }).path;
+        const run = createUpdateRun({ trigger: "cli", before: { version: driver } });
+        if (ledger === "finished") {
+          finishUpdateRun(run.runId, { status: "succeeded" });
         }
-      }
-      if (bump) {
-        setSchemaVersion(shared, OPENCLAW_STATE_SCHEMA_VERSION - 1);
-      }
-      mocks.runContributions.mockImplementation(async () => {
-        const result = repairOpenClawStateDatabaseSchema({ env: state.env });
-        expect(result.warnings).toEqual([]);
-      });
-      await runDoctorHealthFlow(
-        { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-        {
+        closeOpenClawStateDatabaseForTest();
+        if (ledger === "missing") {
+          const db = new DatabaseSync(shared);
+          try {
+            db.exec("DROP TABLE update_runs");
+          } finally {
+            db.close();
+          }
+        }
+        if (bump) {
+          setSchemaVersion(shared, OPENCLAW_STATE_SCHEMA_VERSION - 1);
+        }
+        mocks.runContributions.mockImplementation(async () => {
+          const result = repairOpenClawStateDatabaseSchema({ env: state.env });
+          expect(result.warnings).toEqual([]);
+        });
+        const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+        await runDoctorHealthFlow(runtime, {
           repair: true,
           nonInteractive: true,
-        },
-      );
-      expect(readDatabase(shared).version).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
-      expect(mocks.outro).toHaveBeenCalledWith("Doctor complete.");
-    });
-  });
+        });
+        expect(readDatabase(shared).version).toBe(
+          OPENCLAW_STATE_SCHEMA_VERSION - (deferred ? 1 : 0),
+        );
+        if (deferred) {
+          expect(readDatabase(shared).contentVersion).toBe(String(OPENCLAW_STATE_SCHEMA_VERSION));
+          expect(runtime.log).toHaveBeenCalledWith(
+            expect.stringContaining(
+              `Schema content applied; version publication deferred until update run ${run.runId} finishes`,
+            ),
+          );
+        }
+        expect(mocks.outro).toHaveBeenCalledWith("Doctor complete.");
+      });
+    },
+  );
 
   it("emits a structured refusal with a failure exit for the affected ledger writer", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
@@ -156,6 +181,9 @@ describe("Doctor schema bumps under an updating parent", () => {
       createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } });
       closeOpenClawStateDatabaseForTest();
       setSchemaVersion(shared, OPENCLAW_STATE_SCHEMA_VERSION - 1);
+      const database = new DatabaseSync(shared);
+      database.exec("DROP TABLE config_machine_state");
+      database.close();
       const runtime = {
         log: vi.fn(),
         error: vi.fn(),

--- a/src/gateway/update-run-watcher.schema-publication.test.ts
+++ b/src/gateway/update-run-watcher.schema-publication.test.ts
@@ -1,0 +1,111 @@
+import type { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createUpdateRun, finishUpdateRun } from "../infra/update-run-ledger.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { startUpdateRunWatcher, wakeUpdateRunWatcher } from "./update-run-watcher.js";
+
+vi.mock("./update-run-notice.runtime.js", () => ({ notifyUpdateRunPhase: vi.fn() }));
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const now = Date.parse("2026-09-07T12:00:00Z");
+const graceMs = 5 * 60_000;
+let watcher: ReturnType<typeof startUpdateRunWatcher> | undefined;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(now);
+  vi.stubEnv("OPENCLAW_STATE_DIR", tempDirs.make("openclaw-watcher-publication-"));
+});
+afterEach(async () => {
+  await watcher?.stop();
+  watcher = undefined;
+  closeOpenClawStateDatabaseForTest();
+  vi.unstubAllEnvs();
+  vi.useRealTimers();
+});
+
+function createDeferredState() {
+  const { db } = openOpenClawStateDatabase();
+  const run = createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } });
+  // The runner tests cover the v15 rewrite; this fixture starts at its committed result.
+  db.prepare(`INSERT INTO config_machine_state (state_key, value_json, updated_at_ms)
+    VALUES ('state.schema.contentVersion', ?, ?)`).run(String(OPENCLAW_STATE_SCHEMA_VERSION), now);
+  db.exec(`PRAGMA user_version = 15;
+    UPDATE schema_meta SET schema_version = 15 WHERE meta_key = 'primary';`);
+  return { db, runId: run.runId };
+}
+
+function expectVersion(db: DatabaseSync, version: number) {
+  // Read the held SQLite connection directly: opening a new runner would hide a broken timer.
+  expect(db.prepare("PRAGMA user_version").get()).toEqual({ user_version: version });
+  expect(
+    db.prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'").get(),
+  ).toEqual({ schema_version: version });
+}
+
+function startWatcher() {
+  const log = { warn: vi.fn() };
+  watcher = startUpdateRunWatcher({ broadcast: vi.fn(), log });
+  return log;
+}
+
+describe("Gateway schema publication timer", () => {
+  it("anchors a restarted watcher's timer to the existing terminal timestamp", async () => {
+    const { db, runId } = createDeferredState();
+    finishUpdateRun(runId, { status: "succeeded" });
+    vi.setSystemTime(now + 2 * 60_000);
+    const log = startWatcher();
+    expectVersion(db, 15);
+    await vi.advanceTimersByTimeAsync(3 * 60_000 - 1);
+    expectVersion(db, 15);
+    await vi.advanceTimersByTimeAsync(1);
+    expectVersion(db, OPENCLAW_STATE_SCHEMA_VERSION);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("publishes after observing the old updater finish without another database open", async () => {
+    const { db, runId } = createDeferredState();
+    const log = startWatcher();
+    await vi.advanceTimersByTimeAsync(10_000);
+    finishUpdateRun(runId, { status: "succeeded" });
+    await vi.advanceTimersByTimeAsync(graceMs - 1);
+    expectVersion(db, 15);
+    await vi.advanceTimersByTimeAsync(1);
+    expectVersion(db, OPENCLAW_STATE_SCHEMA_VERSION);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("rechecks new running rows at the deadline and reschedules for their terminal grace", async () => {
+    const { db, runId } = createDeferredState();
+    finishUpdateRun(runId, { status: "succeeded" });
+    const log = startWatcher();
+    await vi.advanceTimersByTimeAsync(graceMs - 1);
+    const next = createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } });
+    // No wake: the already scheduled timer must discover this new driver itself.
+    await vi.advanceTimersByTimeAsync(1);
+    expectVersion(db, 15);
+    wakeUpdateRunWatcher();
+    finishUpdateRun(next.runId, { status: "succeeded" });
+    await vi.advanceTimersByTimeAsync(graceMs - 1);
+    expectVersion(db, 15);
+    await vi.advanceTimersByTimeAsync(1);
+    expectVersion(db, OPENCLAW_STATE_SCHEMA_VERSION);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("cancels pending publication when the watcher stops", async () => {
+    const { db, runId } = createDeferredState();
+    finishUpdateRun(runId, { status: "succeeded" });
+    const log = startWatcher();
+    await watcher?.stop();
+    wakeUpdateRunWatcher();
+    await vi.advanceTimersByTimeAsync(graceMs + 1);
+    expectVersion(db, 15);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/update-run-watcher.schema-publication.test.ts
+++ b/src/gateway/update-run-watcher.schema-publication.test.ts
@@ -37,7 +37,8 @@ function createDeferredState() {
     VALUES ('state.schema.contentVersion', ?, ?)`).run(String(OPENCLAW_STATE_SCHEMA_VERSION), now);
   db.exec(`PRAGMA user_version = 15;
     UPDATE schema_meta SET schema_version = 15 WHERE meta_key = 'primary';`);
-  return { db, runId: run.runId };
+  closeOpenClawStateDatabaseForTest();
+  return { db: openOpenClawStateDatabase().db, runId: run.runId };
 }
 
 function expectVersion(db: DatabaseSync, version: number) {

--- a/src/gateway/update-run-watcher.test.ts
+++ b/src/gateway/update-run-watcher.test.ts
@@ -10,6 +10,9 @@ const ledger = vi.hoisted(() => ({
   reads: vi.fn(),
   notice: vi.fn(async (_run: UpdateRunRecord) => {}),
 }));
+vi.mock("../state/openclaw-state-db.js", () => ({
+  reconcileOpenClawStateSchemaPublication: () => undefined,
+}));
 vi.mock("./update-run-notice.runtime.js", () => ({ notifyUpdateRunPhase: ledger.notice }));
 vi.mock("../infra/update-run-ledger.js", () => ({
   findActiveUpdateRun: () => {

--- a/src/gateway/update-run-watcher.ts
+++ b/src/gateway/update-run-watcher.ts
@@ -2,6 +2,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { findActiveUpdateRun, getUpdateRun } from "../infra/update-run-ledger.js";
 import type { UpdateRunPhase } from "../infra/update-run-record.js";
 import { AsyncWorkScope } from "../shared/async-work-scope.js";
+import { reconcileOpenClawStateSchemaPublication } from "../state/openclaw-state-db.js";
 import { GATEWAY_EVENT_UPDATE_RUN_CHANGED } from "./events.js";
 import type { GatewayBroadcastFn } from "./server-broadcast-types.js";
 
@@ -20,8 +21,32 @@ export function startUpdateRunWatcher(params: {
 }): { stop: () => Promise<void> } {
   const work = new AsyncWorkScope();
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let publicationTimer: ReturnType<typeof setTimeout> | undefined;
   let watched: { runId: string; revision?: number; phase?: UpdateRunPhase } | undefined;
   let notices = Promise.resolve();
+
+  const schedulePublication = () => {
+    if (publicationTimer) {
+      clearTimeout(publicationTimer);
+      publicationTimer = undefined;
+    }
+    if (work.isClosing) {
+      return;
+    }
+    try {
+      const blocker = reconcileOpenClawStateSchemaPublication();
+      if (blocker?.publishAfterMs != null) {
+        // Deadline belongs to the ledger row, so process restarts never restart the grace.
+        publicationTimer = setTimeout(
+          schedulePublication,
+          Math.min(2_147_483_647, Math.max(0, blocker.publishAfterMs - Date.now())),
+        );
+        publicationTimer.unref?.();
+      }
+    } catch (error) {
+      params.log.warn(`state schema publication deferred: ${formatErrorMessage(error)}`);
+    }
+  };
 
   const poll = () => {
     if (work.isClosing) {
@@ -29,6 +54,7 @@ export function startUpdateRunWatcher(params: {
     }
     timer = undefined;
     try {
+      schedulePublication();
       const run = watched ? getUpdateRun(watched.runId) : findActiveUpdateRun();
       if (!run) {
         watched = undefined;
@@ -97,6 +123,10 @@ export function startUpdateRunWatcher(params: {
       if (timer) {
         clearTimeout(timer);
         timer = undefined;
+      }
+      if (publicationTimer) {
+        clearTimeout(publicationTimer);
+        publicationTimer = undefined;
       }
       if (wakeCurrentWatcher === wake) {
         wakeCurrentWatcher = undefined;

--- a/src/infra/state-database-coordinator.ts
+++ b/src/infra/state-database-coordinator.ts
@@ -31,7 +31,7 @@ export class StateDatabaseCoordinatorContentionError extends SqliteCoordinatorEr
   }
 }
 
-class StateSchemaMutationConflictError extends SqliteCoordinatorError {
+export class StateSchemaMutationConflictError extends SqliteCoordinatorError {
   constructor(databasePath: string, cause: unknown) {
     super(
       `OpenClaw refused shared state schema mutation at ${databasePath} because another Gateway owns that state directory. Stop that Gateway or perform the update through its managed restart path, then retry.`,

--- a/src/infra/update-candidate-state.test.ts
+++ b/src/infra/update-candidate-state.test.ts
@@ -167,6 +167,32 @@ it.each(["DELETE", "WAL"])(
   },
 );
 
+it("retains deferred content in both inspection and rehearsal snapshots", async () => {
+  const stateDir = path.join(root, "deferred");
+  const file = path.join(stateDir, "state", "openclaw.sqlite");
+  await createDatabase(
+    file,
+    `
+    PRAGMA user_version = 15;
+    CREATE TABLE config_machine_state (state_key TEXT PRIMARY KEY, value_json TEXT, updated_at_ms INTEGER);
+    INSERT INTO config_machine_state VALUES ('state.schema.contentVersion', '16', 0);
+  `,
+  );
+  const inspected = await readUpdateStateSchemaVersions({ stateDir, config: {} });
+  expect(inspected.find((entry) => entry.path === file)).toEqual({
+    path: file,
+    userVersion: 15,
+    contentVersion: 16,
+  });
+  expect(
+    await runSnapshotWorker({
+      stateDir,
+      targetStateDir: path.join(root, "rehearsal"),
+      config: {},
+    }),
+  ).toEqual(inspected);
+});
+
 it("reads committed WAL schemas without ending the live writer's transaction", async () => {
   const stateDir = path.join(root, "live");
   const file = path.join(stateDir, "state", "openclaw.sqlite");

--- a/src/infra/update-candidate-state.ts
+++ b/src/infra/update-candidate-state.ts
@@ -9,6 +9,7 @@ import type { OpenClawSchemaVersions } from "../state/openclaw-schema-versions.j
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import type { DB } from "../state/openclaw-state-db.generated.js";
 import { resolveOpenClawRegisteredAgentDatabasePath } from "../state/openclaw-state-db.paths.js";
+import { readStateSchemaContentVersion } from "../state/openclaw-state-schema-publication.js";
 import { sha256Hex } from "./crypto-digest.js";
 import { resolveUserPath } from "./home-dir.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "./kysely-sync.js";
@@ -20,7 +21,11 @@ import { prepareSqliteReadOnlyLocationSyncInProcess } from "./sqlite-readonly-lo
 import { readSqliteUserVersion } from "./sqlite-user-version.js";
 
 export const UpdateStateSchemaVersionsSchema = z.array(
-  z.object({ path: z.string(), userVersion: z.number().nullable() }),
+  z.object({
+    path: z.string(),
+    userVersion: z.number().nullable(),
+    contentVersion: z.number().optional(),
+  }),
 );
 export type UpdateStateSchemaVersion = z.infer<typeof UpdateStateSchemaVersionsSchema>[number];
 type StateInput = { stateDir: string; config: OpenClawConfig; env?: NodeJS.ProcessEnv };
@@ -29,32 +34,44 @@ type CandidateStateDatabase = Pick<
   "agent_databases" | "agent_database_leases" | "state_leases"
 >;
 
+/** Older inspection workers report only the published version; agent stores never defer it. */
+export function resolveUpdateStateContentVersion(entry: UpdateStateSchemaVersion): number | null {
+  return entry.contentVersion ?? entry.userVersion;
+}
+
 export function updateStateSchemaVersionsMatch(
   before: readonly UpdateStateSchemaVersion[],
   after: readonly UpdateStateSchemaVersion[],
   params: { sharedPath: string; candidateSchemaVersions?: OpenClawSchemaVersions },
 ): boolean {
-  const versions = new Map(after.map((entry) => [entry.path, entry.userVersion]));
+  const versions = new Map(
+    after.map((entry) => [entry.path, resolveUpdateStateContentVersion(entry)]),
+  );
   const candidate = params.candidateSchemaVersions;
   if (!candidate) {
     return (
       before.length === after.length &&
-      before.every((entry) => versions.get(entry.path) === entry.userVersion)
+      before.every((entry) => versions.get(entry.path) === resolveUpdateStateContentVersion(entry))
     );
   }
-  const baseline = new Map(before.map((entry) => [entry.path, entry.userVersion]));
+  const baseline = new Map(
+    before.map((entry) => [entry.path, resolveUpdateStateContentVersion(entry)]),
+  );
   return (
     before.every(
-      (entry) => entry.userVersion === null || versions.get(entry.path) === entry.userVersion,
+      (entry) =>
+        resolveUpdateStateContentVersion(entry) === null ||
+        versions.get(entry.path) === resolveUpdateStateContentVersion(entry),
     ) &&
     after.every((entry) => {
-      if (entry.userVersion === null || baseline.get(entry.path) === entry.userVersion) {
+      const version = resolveUpdateStateContentVersion(entry);
+      if (version === null || baseline.get(entry.path) === version) {
         return true;
       }
       // Verification can create a store for the first time. All collected paths
       // except the shared database are configured or registered agent stores.
       const supported = entry.path === params.sharedPath ? candidate.state : candidate.agent;
-      return baseline.get(entry.path) == null && entry.userVersion === supported;
+      return baseline.get(entry.path) == null && version === supported;
     })
   );
 }
@@ -147,19 +164,22 @@ export async function readUpdateStateSchemaVersionsInProcess(
   for (const file of files) {
     versions.push({
       path: file,
-      userVersion: (await fileExists(file))
+      ...((await fileExists(file))
         ? await withStateDatabaseSnapshot(file, (location) => {
             const db = openNodeSqliteDatabase(location, { readOnly: true });
             try {
               if (file === shared) {
                 collectRegisteredPaths(db, shared, files);
               }
-              return readSqliteUserVersion(db);
+              return {
+                userVersion: readSqliteUserVersion(db),
+                ...(file === shared ? { contentVersion: readStateSchemaContentVersion(db) } : {}),
+              };
             } finally {
               db.close();
             }
           })
-        : null,
+        : { userVersion: null }),
     });
   }
   return versions;
@@ -249,6 +269,7 @@ export async function snapshotUpdateCandidateState(
       continue;
     }
     const target = targetPath(file);
+    let contentVersion: number | undefined;
     await fs.mkdir(path.dirname(target), { recursive: true, mode: 0o700 });
     const snapshot = await withStateDatabaseSnapshot(file, (sourcePath) =>
       createVerifiedSqliteSnapshot({
@@ -257,6 +278,7 @@ export async function snapshotUpdateCandidateState(
         ...(file === shared
           ? {
               transform: (db: DatabaseSync) => {
+                contentVersion = readStateSchemaContentVersion(db);
                 const queries = getNodeSqliteKysely<CandidateStateDatabase>(db);
                 // Source process leases cannot own the independently opened rehearsal copy.
                 for (const table of ["agent_database_leases", "state_leases"] as const) {
@@ -301,7 +323,11 @@ export async function snapshotUpdateCandidateState(
           : {}),
       }),
     );
-    versions.push({ path: file, userVersion: snapshot.userVersion });
+    versions.push({
+      path: file,
+      userVersion: snapshot.userVersion,
+      ...(contentVersion === undefined ? {} : { contentVersion }),
+    });
   }
   return versions;
 }

--- a/src/state/openclaw-database-preflight.test.ts
+++ b/src/state/openclaw-database-preflight.test.ts
@@ -6,6 +6,7 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { collectSqliteSchemaIssues } from "../infra/sqlite-schema-contract.js";
 import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
+import { createUpdateRun } from "../infra/update-run-ledger.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   OPENCLAW_AGENT_SCHEMA_VERSION,
@@ -354,6 +355,90 @@ describe("OpenClaw database schema preflight", () => {
       assertOpenClawDatabasesReady({ env, operation: "gateway-restart" }),
     ).resolves.toBeUndefined();
   });
+
+  it.each([false, true])(
+    "recognizes deferred content and still checks its shape (damaged: %s)",
+    async (damaged) => {
+      const stateDir = tempDirs.make("openclaw-preflight-deferred-schema-");
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const opened = openOpenClawStateDatabase({ env });
+      const run = createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } }, { env });
+      const statePath = opened.path;
+      closeOpenClawStateDatabaseForTest();
+      const { DatabaseSync } = requireNodeSqlite();
+      const database = new DatabaseSync(statePath);
+      try {
+        database.exec(
+          `PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION - 1}; UPDATE schema_meta SET schema_version = ${OPENCLAW_STATE_SCHEMA_VERSION - 1};`,
+        );
+        database
+          .prepare(
+            "INSERT INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES (?, ?, ?)",
+          )
+          .run("state.schema.contentVersion", String(OPENCLAW_STATE_SCHEMA_VERSION), Date.now());
+        if (damaged) {
+          database.exec(
+            "ALTER TABLE worktrees DROP COLUMN run_end_cleanup_json; ALTER TABLE worktrees ADD COLUMN run_end_cleanup_json INTEGER;",
+          );
+        }
+      } finally {
+        database.close();
+      }
+      const before = snapshotSourceFamily(statePath);
+      const result = await preflightOpenClawDatabaseSchemas({
+        env,
+        verifyCurrentSchemaShape: true,
+        supportedVersions: {
+          state: OPENCLAW_STATE_SCHEMA_VERSION,
+          agent: OPENCLAW_AGENT_SCHEMA_VERSION,
+        },
+      });
+      expect(result.pendingMigrations).toBeUndefined();
+      expect(result.incompatible).toEqual([]);
+      expect(result.deferredSchemaPublications).toEqual([
+        expect.objectContaining({
+          kind: "state",
+          path: statePath,
+          foundVersion: OPENCLAW_STATE_SCHEMA_VERSION - 1,
+          contentVersion: OPENCLAW_STATE_SCHEMA_VERSION,
+          runId: run.runId,
+          message: expect.stringContaining(
+            `version publication deferred until update run ${run.runId} finishes`,
+          ),
+        }),
+      ]);
+      expect(result.indeterminate).toEqual(
+        damaged
+          ? [
+              expect.objectContaining({
+                kind: "state",
+                reason: expect.stringContaining("column definitions differ for worktrees"),
+              }),
+            ]
+          : [],
+      );
+      expect(snapshotSourceFamily(statePath)).toEqual(before);
+      if (!damaged) {
+        await expect(
+          preflightOpenClawDatabaseSchemas({
+            env,
+            supportedVersions: {
+              state: OPENCLAW_STATE_SCHEMA_VERSION - 1,
+              agent: OPENCLAW_AGENT_SCHEMA_VERSION,
+            },
+          }),
+        ).resolves.toMatchObject({
+          incompatible: [expect.objectContaining({ foundVersion: OPENCLAW_STATE_SCHEMA_VERSION })],
+        });
+        await expect(preflightOpenClawStateDatabasePath(statePath)).resolves.toMatchObject({
+          status: "exact",
+          foundVersion: OPENCLAW_STATE_SCHEMA_VERSION - 1,
+          contentVersion: OPENCLAW_STATE_SCHEMA_VERSION,
+          deferredPublication: expect.objectContaining({ runId: run.runId }),
+        });
+      }
+    },
+  );
 
   it("accepts an older v6 state database without the lazy setup id during restart preflight", async () => {
     const stateDir = tempDirs.make("openclaw-database-preflight-older-v6-setup-id-");

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -50,6 +50,10 @@ import {
   OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
   STATE_PERSISTENT_SCHEMA_COMPATIBILITY,
 } from "./openclaw-state-schema-compatibility.js";
+import {
+  readStateSchemaContentVersion,
+  readStateSchemaPublicationBlocker,
+} from "./openclaw-state-schema-publication.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
 
 export { OPENCLAW_DATABASE_SCHEMA_DOCS_URL } from "./openclaw-state-db.js";
@@ -69,15 +73,47 @@ export type IndeterminateOpenClawDatabase = {
   reason: string;
 };
 
+export type DeferredStateSchemaPublication = {
+  kind: "state";
+  path: string;
+  foundVersion: number;
+  contentVersion: number;
+  runId?: string;
+  publishAfterMs?: number | null;
+  message: string;
+};
+
+function describeDeferredStateSchemaPublication(
+  database: DatabaseSync,
+  databasePath: string,
+  foundVersion: number,
+  contentVersion: number,
+): DeferredStateSchemaPublication {
+  const blocker = readStateSchemaPublicationBlocker(database);
+  return {
+    kind: "state",
+    path: databasePath,
+    foundVersion,
+    contentVersion,
+    ...(blocker ? { runId: blocker.runId, publishAfterMs: blocker.publishAfterMs } : {}),
+    message: blocker
+      ? `Schema content applied; version publication deferred until update run ${blocker.runId} finishes and its five-minute grace expires (or the running driver is abandoned for 30 minutes).`
+      : "Schema content applied; version publication will complete on the next writable database open.",
+  };
+}
+
 export type OpenClawDatabaseSchemaPreflight = {
   incompatible: IncompatibleOpenClawDatabase[];
   indeterminate: IndeterminateOpenClawDatabase[];
   pendingMigrations?: Omit<IncompatibleOpenClawDatabase, "writerAppVersion">[];
+  deferredSchemaPublications?: DeferredStateSchemaPublication[];
 };
 
 type OpenClawStateSchemaPreflightResult = {
   databasePath: string;
   foundVersion: number | null;
+  contentVersion?: number;
+  deferredPublication?: DeferredStateSchemaPublication;
   issues: SqliteSchemaIssue[];
   ownership: OpenClawExternalStateOwnership | null;
   reason?: string;
@@ -130,6 +166,7 @@ export async function assertOpenClawDatabasesReady(
     | {
         operation: "doctor";
         configuredAgentDatabaseTargets: readonly { agentId: string; path: string }[];
+        onDeferredSchemaPublication?: (publication: DeferredStateSchemaPublication) => void;
       }
     | { operation: "gateway-restart" }
   ),
@@ -151,6 +188,11 @@ export async function assertOpenClawDatabasesReady(
     });
   }
   if (schemas.indeterminate.length === 0) {
+    if (options.operation === "doctor") {
+      for (const publication of schemas.deferredSchemaPublications ?? []) {
+        options.onDeferredSchemaPublication?.(publication);
+      }
+    }
     return;
   }
   const shown = schemas.indeterminate
@@ -226,6 +268,8 @@ export async function preflightOpenClawStateDatabasePath(
   } as const;
   let database: DatabaseSync | undefined;
   let foundVersion: number | null = null;
+  let contentVersion: number | undefined;
+  let deferredPublication: DeferredStateSchemaPublication | undefined;
   let ownership: OpenClawExternalStateOwnership | null = null;
   const result = (
     status: OpenClawStateSchemaPreflightResult["status"],
@@ -233,6 +277,8 @@ export async function preflightOpenClawStateDatabasePath(
   ): OpenClawStateSchemaPreflightResult => ({
     ...base,
     foundVersion,
+    ...(contentVersion !== undefined && contentVersion !== foundVersion ? { contentVersion } : {}),
+    ...(deferredPublication ? { deferredPublication } : {}),
     ownership,
     issues: details.issues ?? [],
     status,
@@ -262,7 +308,11 @@ export async function preflightOpenClawStateDatabasePath(
         `OpenClaw state database ${resolvedPath} has invalid schema version metadata.`,
       );
     }
-    if (foundVersion > OPENCLAW_STATE_SCHEMA_VERSION) {
+    contentVersion =
+      foundVersion > OPENCLAW_STATE_SCHEMA_VERSION
+        ? foundVersion
+        : readStateSchemaContentVersion(database);
+    if (contentVersion > OPENCLAW_STATE_SCHEMA_VERSION) {
       try {
         ownership = inspectOpenClawStateOwnershipFromDatabase(database, resolvedPath);
       } catch {
@@ -271,8 +321,16 @@ export async function preflightOpenClawStateDatabasePath(
       return result("incompatible");
     }
     ownership = inspectOpenClawStateOwnershipFromDatabase(database, resolvedPath);
-    if (foundVersion < OPENCLAW_STATE_SCHEMA_VERSION) {
+    if (contentVersion < OPENCLAW_STATE_SCHEMA_VERSION) {
       return result("migration-required", { requiresWrite: true });
+    }
+    if (foundVersion < contentVersion) {
+      deferredPublication = describeDeferredStateSchemaPublication(
+        database,
+        resolvedPath,
+        foundVersion,
+        contentVersion,
+      );
     }
     assertOpenClawStateDatabaseOwner(database, { pathname: resolvedPath });
     const metadata = database
@@ -376,7 +434,11 @@ export async function preflightOpenClawDatabaseSchemas(options: {
       });
       stateDatabase.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
       const stateVersion = readSqliteUserVersion(stateDatabase);
-      if (stateVersion < options.supportedVersions.state) {
+      const contentVersion =
+        stateVersion > options.supportedVersions.state
+          ? stateVersion
+          : readStateSchemaContentVersion(stateDatabase);
+      if (contentVersion < options.supportedVersions.state) {
         (result.pendingMigrations ??= []).push({
           kind: "state",
           path: statePath,
@@ -384,19 +446,29 @@ export async function preflightOpenClawDatabaseSchemas(options: {
           supportedVersion: options.supportedVersions.state,
         });
       }
-      if (stateVersion > options.supportedVersions.state) {
+      if (contentVersion > options.supportedVersions.state) {
         const writerAppVersion = readWriterAppVersion(stateDatabase);
         result.incompatible.push({
           kind: "state",
           path: statePath,
-          foundVersion: stateVersion,
+          foundVersion: contentVersion,
           supportedVersion: options.supportedVersions.state,
           ...(writerAppVersion ? { writerAppVersion } : {}),
         });
       }
+      if (stateVersion < contentVersion) {
+        (result.deferredSchemaPublications ??= []).push(
+          describeDeferredStateSchemaPublication(
+            stateDatabase,
+            statePath,
+            stateVersion,
+            contentVersion,
+          ),
+        );
+      }
       if (
         options.verifyCurrentSchemaShape === true &&
-        stateVersion === OPENCLAW_STATE_SCHEMA_VERSION
+        contentVersion === OPENCLAW_STATE_SCHEMA_VERSION
       ) {
         try {
           assertOpenClawStateDatabaseForMaintenance(stateDatabase, { pathname: statePath });

--- a/src/state/openclaw-state-db-binding-targets.test.ts
+++ b/src/state/openclaw-state-db-binding-targets.test.ts
@@ -3,12 +3,15 @@ import type { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { createUpdateRun } from "../infra/update-run-ledger.js";
 import { VERSION } from "../version.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
+  reconcileOpenClawStateSchemaPublication,
   repairOpenClawStateDatabaseSchema,
+  repairOpenClawStateDatabaseSchemaIfNeeded,
 } from "./openclaw-state-db.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -174,6 +177,50 @@ async function holdGatewayLifecycle(databasePath: string): Promise<{
 }
 
 describe("conversation binding target migration", () => {
+  it("admits deferred content without schema mutation while another Gateway owns the state", async () => {
+    const options = { env: { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-deferred-reader-") } };
+    const initial = openOpenClawStateDatabase(options);
+    const run = createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } }, options);
+    initial.db
+      .prepare(`INSERT INTO config_machine_state (state_key, value_json, updated_at_ms)
+      VALUES ('state.schema.contentVersion', ?, ?)`)
+      .run(String(OPENCLAW_STATE_SCHEMA_VERSION), Date.now());
+    initial.db.exec(`PRAGMA user_version = 15;
+      UPDATE schema_meta SET schema_version = 15 WHERE meta_key = 'primary';`);
+    initial.db
+      .prepare(`UPDATE update_runs SET status = 'succeeded', phase = 'finished',
+      finished_at_ms = ? WHERE run_id = ?`)
+      .run(Date.now() - 60_000, run.runId);
+    closeOpenClawStateDatabaseForTest();
+    const holder = await holdGatewayLifecycle(initial.path);
+    try {
+      expect(repairOpenClawStateDatabaseSchemaIfNeeded(options)).toEqual({
+        changes: [],
+        warnings: [],
+      });
+      const reader = openOpenClawStateDatabase(options);
+      expect(reader.db.prepare("PRAGMA user_version").get()).toEqual({ user_version: 15 });
+      expect(reader.db.prepare("SELECT total_changes() AS writes").get()).toEqual({ writes: 0 });
+      reader.db
+        .prepare("UPDATE update_runs SET finished_at_ms = ? WHERE run_id = ?")
+        .run(Date.now() - 5 * 60_000, run.runId);
+      expect(() => reconcileOpenClawStateSchemaPublication(options)).not.toThrow();
+      expect(openOpenClawStateDatabase(options).db).toBe(reader.db);
+      expect(reader.db.prepare("PRAGMA user_version").get()).toEqual({ user_version: 15 });
+      closeOpenClawStateDatabaseForTest();
+      const agedReader = openOpenClawStateDatabase(options);
+      expect(agedReader.db.prepare("PRAGMA user_version").get()).toEqual({ user_version: 15 });
+      expect(agedReader.db.prepare("SELECT total_changes() AS writes").get()).toEqual({
+        writes: 0,
+      });
+    } finally {
+      await holder.release();
+    }
+    expect(openOpenClawStateDatabase(options).db.prepare("PRAGMA user_version").get()).toEqual({
+      user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+    });
+  });
+
   it("refuses runtime and doctor schema mutation while another Gateway owns the state", async () => {
     const { options, databasePath } = createVersion14Bindings();
     const holder = await holdGatewayLifecycle(databasePath);

--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -147,8 +147,8 @@ function getOpenClawStateDatabaseRuntimeFailure(pathname: string): Error | undef
     if (cachedDataVersions.get(cached.db) === dataVersion) {
       return undefined;
     }
-    // data_version is the cheap external-commit trigger. Re-read user_version
-    // only when another connection changed the file.
+    // data_version is the cheap external-commit trigger. Recheck published and
+    // content versions only when another connection changed the file.
     assertSupportedStateSchemaVersion(cached.db, resolvedPath);
     cachedDataVersions.set(cached.db, dataVersion);
     return undefined;

--- a/src/state/openclaw-state-db-fast-path.ts
+++ b/src/state/openclaw-state-db-fast-path.ts
@@ -1,4 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import {
   collectSqliteSchemaIssues,
@@ -6,18 +7,41 @@ import {
   type SqliteTableContractReader,
 } from "../infra/sqlite-schema-contract.js";
 import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
-import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import { hasLegacyCronRunLogs } from "../infra/state-migrations.cron-run-logs.js";
 import { VERSION } from "../version.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import { assertOpenClawStateDatabaseForMaintenance } from "./openclaw-state-db-maintenance.js";
-import { assertCanonicalStateSchemaShape } from "./openclaw-state-db-schema-repair.js";
+import {
+  assertCanonicalStateSchemaShape,
+  detectOpenClawStateDatabaseSchemaMigrationsFromDatabase,
+} from "./openclaw-state-db-schema-repair.js";
 import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 import {
   getOpenClawStateRuntimeSchema,
   isOpenClawStateStartupRepairableSchemaIssue,
   STATE_PERSISTENT_SCHEMA_COMPATIBILITY,
 } from "./openclaw-state-schema-compatibility.js";
+import { readStateSchemaContentVersion } from "./openclaw-state-schema-publication.js";
+
+export function needsOpenClawStateDatabaseSchemaRepair(pathname: string): boolean {
+  let database: DatabaseSync | undefined;
+  try {
+    database = openNodeSqliteDatabase(pathname, { readOnly: true });
+    assertSupportedStateSchemaVersion(database, pathname);
+    const needsRepair =
+      readStateSchemaContentVersion(database) !== OPENCLAW_STATE_SCHEMA_VERSION ||
+      detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(database, pathname).length > 0;
+    if (!needsRepair) {
+      assertCurrentStateRuntimeSchema(database, pathname);
+    }
+    return needsRepair;
+  } catch {
+    // Preserve the repair path's existing diagnostics for unreadable or noncanonical databases.
+    return true;
+  } finally {
+    database?.close();
+  }
+}
 
 export function assertCurrentStateRuntimeSchema(
   database: DatabaseSync,
@@ -34,7 +58,7 @@ export function isOpenClawStateSchemaFastPathEligible(
 ): boolean {
   return runSqliteDeferredTransactionSync(database, () => {
     assertSupportedStateSchemaVersion(database, pathname);
-    if (readSqliteUserVersion(database) !== OPENCLAW_STATE_SCHEMA_VERSION) {
+    if (readStateSchemaContentVersion(database) !== OPENCLAW_STATE_SCHEMA_VERSION) {
       return false;
     }
     assertSqliteIntegrity(database, pathname);

--- a/src/state/openclaw-state-db-maintenance.ts
+++ b/src/state/openclaw-state-db-maintenance.ts
@@ -1,11 +1,17 @@
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import {
   assertSqliteSchemaContains,
   assertSqliteSchemaTablesPresent,
   type SqliteTableContractReader,
 } from "../infra/sqlite-schema-contract.js";
+import {
+  runSqliteImmediateTransactionSync,
+  type SqliteTransactionOptions,
+} from "../infra/sqlite-transaction.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
+import { VERSION } from "../version.js";
 import {
   LAZY_ADDITIVE_STATE_TABLES,
   OPENCLAW_STATE_SCHEMA_VERSION,
@@ -14,13 +20,20 @@ import {
 import { tableExists, tableHasColumn } from "./openclaw-state-db-schema-helpers.js";
 import { migrateJsonCanonicalWideRowsV13 } from "./openclaw-state-db-schema-v13-widerow.js";
 import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
+import type { DB } from "./openclaw-state-db.generated.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
-import { OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY } from "./openclaw-state-schema-compatibility.js";
+import { OpenClawStateOwnershipError } from "./openclaw-state-ownership.js";
+import {
+  getOpenClawStateRuntimeSchema,
+  OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
+} from "./openclaw-state-schema-compatibility.js";
 import {
   readStateSchemaContentVersion,
+  readStateSchemaPublicationBlocker,
   resolveStateSchemaVersionToPublish,
 } from "./openclaw-state-schema-publication.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
+import { UpdateSchemaRefusalError } from "./openclaw-update-schema-refusal.js";
 
 const STATE_V6_ADDITIVE_TABLES = [
   // v6-v12 databases may predate this former same-version lazy table.
@@ -464,3 +477,95 @@ export const versionedStateMigrations: ReadonlyArray<{
     applied: "Moved Skill Workshop ownership to per-agent directories (v16)",
   },
 ];
+
+export function runStateSchemaMigrationTransaction<T>(
+  db: DatabaseSync,
+  pathname: string,
+  migrate: () => T,
+  transactionOptions: SqliteTransactionOptions,
+): T {
+  return runSqliteImmediateTransactionSync(
+    db,
+    () => {
+      const publishedVersion = readSqliteUserVersion(db);
+      const blocker =
+        publishedVersion < OPENCLAW_STATE_SCHEMA_VERSION
+          ? readStateSchemaPublicationBlocker(db)
+          : undefined;
+      if (!blocker) {
+        return migrate();
+      }
+      try {
+        // Check before canonical DDL could recreate the missing publication owner.
+        if (!tableExists(db, "config_machine_state")) {
+          throw new Error("Shared state schema publication requires config_machine_state.");
+        }
+        return migrate();
+      } catch (cause) {
+        if (cause instanceof OpenClawStateOwnershipError) {
+          throw cause;
+        }
+        throw new UpdateSchemaRefusalError(
+          [
+            {
+              kind: "state",
+              path: pathname,
+              foundVersion: publishedVersion,
+              supportedVersion: OPENCLAW_STATE_SCHEMA_VERSION,
+            },
+          ],
+          blocker.updaterVersion,
+          { cause },
+        );
+      }
+    },
+    transactionOptions,
+  );
+}
+
+export function writeCurrentStateSchemaMetadata(db: DatabaseSync, now: number): void {
+  const kysely = getNodeSqliteKysely<Pick<DB, "schema_meta">>(db);
+  const schemaVersion = resolveStateSchemaVersionToPublish(db);
+  db.exec(`PRAGMA user_version = ${schemaVersion};`);
+  executeSqliteQuerySync(
+    db,
+    kysely
+      .insertInto("schema_meta")
+      .values({
+        meta_key: "primary",
+        role: "global",
+        schema_version: schemaVersion,
+        agent_id: null,
+        app_version: VERSION,
+        created_at: now,
+        updated_at: now,
+      })
+      .onConflict((conflict) =>
+        conflict
+          .column("meta_key")
+          .doUpdateSet({
+            role: "global",
+            schema_version: schemaVersion,
+            agent_id: null,
+            app_version: VERSION,
+            updated_at: now,
+          })
+          // updated_at tracks schema metadata changes; unconditional bumps dirty every
+          // open and defeat no-change backup detection.
+          .where((eb) =>
+            eb.or([
+              eb("schema_meta.schema_version", "!=", schemaVersion),
+              eb("schema_meta.app_version", "is not", VERSION),
+              eb("schema_meta.role", "!=", "global"),
+            ]),
+          ),
+      ),
+  );
+}
+
+export function executeCanonicalStateSchema(
+  database: DatabaseSync,
+  options: { includeVersionLazyAdditiveTables: boolean },
+): void {
+  database.exec(getOpenClawStateRuntimeSchema(options));
+}

--- a/src/state/openclaw-state-db-maintenance.ts
+++ b/src/state/openclaw-state-db-maintenance.ts
@@ -515,7 +515,7 @@ export function runStateSchemaMigrationTransaction<T>(
             },
           ],
           blocker.updaterVersion,
-          { cause },
+          { targetVersion: VERSION, cause },
         );
       }
     },

--- a/src/state/openclaw-state-db-maintenance.ts
+++ b/src/state/openclaw-state-db-maintenance.ts
@@ -16,6 +16,10 @@ import { migrateJsonCanonicalWideRowsV13 } from "./openclaw-state-db-schema-v13-
 import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 import { OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY } from "./openclaw-state-schema-compatibility.js";
+import {
+  readStateSchemaContentVersion,
+  resolveStateSchemaVersionToPublish,
+} from "./openclaw-state-schema-publication.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
 
 const STATE_V6_ADDITIVE_TABLES = [
@@ -87,7 +91,7 @@ export function assertOpenClawStateDatabaseForMaintenance(
   readTable?: SqliteTableContractReader,
 ): void {
   const userVersion = assertSupportedStateSchemaVersion(database, options.pathname);
-  if (userVersion !== OPENCLAW_STATE_SCHEMA_VERSION) {
+  if (readStateSchemaContentVersion(database) !== OPENCLAW_STATE_SCHEMA_VERSION) {
     throw new Error(
       `OpenClaw state database ${options.pathname} uses schema version ${userVersion}; run openclaw doctor --fix before compacting it.`,
     );
@@ -97,11 +101,11 @@ export function assertOpenClawStateDatabaseForMaintenance(
   const metadata = database
     .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary' LIMIT 1")
     .get() as { schema_version?: unknown } | undefined;
-  if (metadata?.schema_version !== OPENCLAW_STATE_SCHEMA_VERSION) {
+  if (metadata?.schema_version !== userVersion) {
     const schemaVersion =
       typeof metadata?.schema_version === "number" ? metadata.schema_version : "invalid";
     throw new Error(
-      `OpenClaw state database ${options.pathname} metadata schema version ${schemaVersion} does not match ${OPENCLAW_STATE_SCHEMA_VERSION}; run openclaw doctor --fix before compacting it.`,
+      `OpenClaw state database ${options.pathname} metadata schema version ${schemaVersion} does not match ${userVersion}; run openclaw doctor --fix before compacting it.`,
     );
   }
   assertSqliteSchemaContains(
@@ -239,7 +243,8 @@ export function markCurrentStateSchemaVersion(
   if (!tableExists(db, "audit_events")) {
     return;
   }
-  db.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION};`);
+  const version = resolveStateSchemaVersionToPublish(db);
+  db.exec(`PRAGMA user_version = ${version};`);
   if (
     tableExists(db, "schema_meta") &&
     ["meta_key", "schema_version", "updated_at"].every((column) =>
@@ -258,12 +263,12 @@ export function markCurrentStateSchemaVersion(
          ON CONFLICT(meta_key) DO UPDATE SET
            schema_version = excluded.schema_version,
            updated_at = excluded.updated_at`,
-      ).run(OPENCLAW_STATE_SCHEMA_VERSION, now, now);
+      ).run(version, now, now);
       return;
     }
     db.prepare(
       "UPDATE schema_meta SET schema_version = ?, updated_at = ? WHERE meta_key = 'primary'",
-    ).run(OPENCLAW_STATE_SCHEMA_VERSION, now);
+    ).run(version, now);
   }
 }
 

--- a/src/state/openclaw-state-db-open.ts
+++ b/src/state/openclaw-state-db-open.ts
@@ -10,7 +10,7 @@ import {
   assertSqliteIntegrity,
   isTerminalSqliteIntegrityError,
 } from "../infra/sqlite-integrity.js";
-import { isSqliteSchemaVersionError, readSqliteUserVersion } from "../infra/sqlite-user-version.js";
+import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
 import {
   configureSqliteConnectionPragmas,
   configureSqlitePreSchemaPragmas,
@@ -23,6 +23,7 @@ import {
 } from "./openclaw-state-db-contract.js";
 import { ensureOpenClawStatePermissions } from "./openclaw-state-db-permissions.js";
 import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
+import { readStateSchemaContentVersion } from "./openclaw-state-schema-publication.js";
 
 const stateDbLog = createSubsystemLogger("state/db");
 
@@ -30,21 +31,21 @@ function assertStateDatabaseIntegrityBeforeMutation(
   database: DatabaseSync,
   pathname: string,
 ): void {
-  const userVersion = readSqliteUserVersion(database);
+  const contentVersion = readStateSchemaContentVersion(database);
   const hasApplicationSchema = database // sqlite-allow-raw -- Cold-open schema presence probe before Kysely exposure.
     .prepare("SELECT 1 FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' LIMIT 1")
     .get();
   const migrationPending =
-    (userVersion === 0 && hasApplicationSchema) ||
-    (userVersion > 0 && userVersion < OPENCLAW_STATE_SCHEMA_VERSION);
+    (contentVersion === 0 && hasApplicationSchema) ||
+    (contentVersion > 0 && contentVersion < OPENCLAW_STATE_SCHEMA_VERSION);
   if (migrationPending) {
     stateDbLog.info("state database schema migration pending; verifying integrity first", {
-      fromVersion: userVersion,
+      fromVersion: contentVersion,
       path: pathname,
       toVersion: OPENCLAW_STATE_SCHEMA_VERSION,
     });
   }
-  if (userVersion !== OPENCLAW_STATE_SCHEMA_VERSION) {
+  if (contentVersion !== OPENCLAW_STATE_SCHEMA_VERSION) {
     // Every physical open proves the full file before schema mutation or exposure.
     assertSqliteIntegrity(database, pathname);
   }

--- a/src/state/openclaw-state-db-schema-migration-required.test.ts
+++ b/src/state/openclaw-state-db-schema-migration-required.test.ts
@@ -1,8 +1,269 @@
-import { describe, expect, it } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createUpdateRun } from "../infra/update-run-ledger.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import {
   findOpenClawStateDatabaseSchemaMigrationRequiredError,
   OpenClawStateDatabaseSchemaMigrationRequiredError,
 } from "./openclaw-state-db-schema-migration-required.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+  repairOpenClawStateDatabaseSchema,
+} from "./openclaw-state-db.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const now = Date.parse("2026-09-07T12:00:00Z");
+const graceMs = 5 * 60_000;
+const abandonedMs = 30 * 60_000;
+const runId = "ed099411-cfbd-4304-a6b7-d3e504a48505";
+const secondRunId = "dc43feae-aab9-4f85-9686-89f6c1fe3c12";
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(now);
+});
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.useRealTimers();
+});
+
+function seedRun(db: DatabaseSync, version = "2026.9.2", id = runId) {
+  db.prepare(`
+    INSERT INTO update_runs (
+      run_id, created_at_ms, updated_at_ms, trigger, phase, status,
+      origin_json, target_json, before_json, after_json, steps_json, verification_json, repair_json
+    ) VALUES (?, ?, ?, 'cli', 'verifying', 'running', '{}', '{}', ?, '{}', '[]', '{}', '[]')
+  `).run(id, now - 60_000, now, JSON.stringify({ version }));
+}
+
+function createV15Database(version: string | null = "2026.9.2") {
+  const options = { env: { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-schema-publication-") } };
+  const databasePath = openOpenClawStateDatabase(options).path;
+  if (version !== null) {
+    createUpdateRun({ runId, trigger: "cli", before: { version } }, options);
+  }
+  closeOpenClawStateDatabaseForTest();
+  const db = new DatabaseSync(databasePath);
+  try {
+    db.exec(`
+      ALTER TABLE skill_workshop_proposals ADD COLUMN workspace_dir TEXT NOT NULL DEFAULT '';
+      ALTER TABLE skill_workshop_proposals ADD COLUMN claim_released_time INTEGER;
+      DROP TABLE skill_workshop_collection_reviews;
+      CREATE TABLE skill_workshop_collection_reviews (
+        review_id TEXT NOT NULL PRIMARY KEY,
+        workspace_dir TEXT NOT NULL,
+        backup_id TEXT NOT NULL,
+        create_time INTEGER NOT NULL,
+        kept_names_json TEXT NOT NULL,
+        written_names_json TEXT NOT NULL,
+        dropped_json TEXT NOT NULL
+      ) STRICT;
+      CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time
+        ON skill_workshop_collection_reviews(workspace_dir, create_time DESC, review_id DESC);
+      INSERT INTO skill_workshop_proposals (
+        proposal_id, record_json, owner_agent_id, workspace_dir, kind, status,
+        created_at, updated_at, draft_hash, claim_released_time
+      ) VALUES ('released', '{"id":"released","status":"applied"}', 'main', '/fixture/workspace',
+        'create', 'applied', '2026-09-01', '2026-09-01', 'fixture-hash', 1);
+      INSERT INTO skill_workshop_collection_reviews VALUES (
+        'review', '/fixture/workspace', 'backup', 1, '[]', '[]', '[]'
+      );
+      PRAGMA user_version = 15;
+      UPDATE schema_meta SET schema_version = 15 WHERE meta_key = 'primary';
+    `);
+  } finally {
+    db.close();
+  }
+  return { options, databasePath };
+}
+
+function expectVersion(db: DatabaseSync, version: number) {
+  expect(db.prepare("PRAGMA user_version").get()).toEqual({ user_version: version });
+  expect(
+    db.prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'").get(),
+  ).toEqual({ schema_version: version });
+}
+
+function finishRun(db: DatabaseSync, finishedAtMs: number, id = runId) {
+  db.prepare(`
+    UPDATE update_runs SET status = 'succeeded', phase = 'finished',
+      finished_at_ms = ?, updated_at_ms = ? WHERE run_id = ?
+  `).run(finishedAtMs, now, id);
+}
+
+function reopen(options: Parameters<typeof openOpenClawStateDatabase>[0]) {
+  closeOpenClawStateDatabaseForTest();
+  return openOpenClawStateDatabase(options).db;
+}
+
+describe("shared state schema publication", () => {
+  it.each(["runtime open", "doctor repair"] as const)(
+    "%s applies v16 content while preserving the unfenced updater's v15 floor",
+    (entry) => {
+      const { options } = createV15Database();
+      if (entry === "doctor repair") {
+        expect(repairOpenClawStateDatabaseSchema(options).warnings).toEqual([]);
+      }
+      const db = openOpenClawStateDatabase(options).db;
+      expectVersion(db, 15);
+      expect(
+        db
+          .prepare(
+            "SELECT value_json FROM config_machine_state WHERE state_key = 'state.schema.contentVersion'",
+          )
+          .get(),
+      ).toEqual({ value_json: String(OPENCLAW_STATE_SCHEMA_VERSION) });
+      expect(
+        db
+          .prepare(
+            "SELECT owner_agent_id, backup_id FROM skill_workshop_collection_reviews WHERE review_id = 'review'",
+          )
+          .get(),
+      ).toEqual({ owner_agent_id: "main", backup_id: "backup" });
+      expect(
+        db
+          .prepare("SELECT status FROM skill_workshop_proposals WHERE proposal_id = 'released'")
+          .get(),
+      ).toEqual({ status: "stale" });
+      expect(db.prepare("PRAGMA table_info(skill_workshop_proposals)").all()).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: "claim_released_time" })]),
+      );
+    },
+  );
+
+  it("preserves migrated Workshop rows and skips content on repeated deferred opens and repair", () => {
+    const { options } = createV15Database();
+    const db = openOpenClawStateDatabase(options).db;
+    const proposal = db.prepare("SELECT * FROM skill_workshop_proposals").all();
+    db.exec(`INSERT INTO skill_workshop_collection_reviews VALUES (
+      'created-after-migration', 'other-agent', 'new-backup', 2, '[]', '[]', '[]'
+    )`);
+    const reviews = db
+      .prepare("SELECT * FROM skill_workshop_collection_reviews ORDER BY review_id")
+      .all();
+    vi.setSystemTime(now + 60_000);
+    expectVersion(reopen(options), 15);
+    closeOpenClawStateDatabaseForTest();
+    const repair = repairOpenClawStateDatabaseSchema(options);
+    expect(repair.warnings).toEqual([]);
+    expect(repair.changes).not.toContain(
+      "Moved Skill Workshop ownership to per-agent directories (v16)",
+    );
+    const after = openOpenClawStateDatabase(options).db;
+    expectVersion(after, 15);
+    expect(after.prepare("SELECT * FROM skill_workshop_proposals").all()).toEqual(proposal);
+    expect(
+      after.prepare("SELECT * FROM skill_workshop_collection_reviews ORDER BY review_id").all(),
+    ).toEqual(reviews);
+  });
+
+  it.each([
+    { description: "terminal row's finish", terminal: true, duration: graceMs },
+    { description: "running row's last update", terminal: false, duration: abandonedMs + 1 },
+  ])("publishes only at the deadline anchored to the $description", ({ terminal, duration }) => {
+    const { options } = createV15Database();
+    const db = openOpenClawStateDatabase(options).db;
+    if (terminal) {
+      finishRun(db, now);
+    }
+    vi.setSystemTime(now + duration - 1);
+    expectVersion(reopen(options), 15);
+    vi.setSystemTime(now + duration);
+    expectVersion(openOpenClawStateDatabase(options).db, OPENCLAW_STATE_SCHEMA_VERSION);
+  });
+
+  it("uses finished_at_ms even when a terminal record was enriched more recently", () => {
+    const { options } = createV15Database();
+    finishRun(openOpenClawStateDatabase(options).db, now - graceMs);
+    expectVersion(reopen(options), OPENCLAW_STATE_SCHEMA_VERSION);
+  });
+
+  it("publishes deferred content when its legacy ledger row is absent", () => {
+    const { options } = createV15Database();
+    openOpenClawStateDatabase(options).db.exec("DELETE FROM update_runs");
+    expectVersion(reopen(options), OPENCLAW_STATE_SCHEMA_VERSION);
+  });
+
+  it("requires every legacy row to clear its own deadline, including a new running update", () => {
+    const { options } = createV15Database();
+    let db = openOpenClawStateDatabase(options).db;
+    finishRun(db, now - graceMs);
+    seedRun(db, "2026.9.2-1", secondRunId);
+    expectVersion((db = reopen(options)), 15);
+    finishRun(db, now, secondRunId);
+    vi.setSystemTime(now + graceMs - 1);
+    expectVersion(reopen(options), 15);
+    vi.setSystemTime(now + graceMs);
+    expectVersion(reopen(options), OPENCLAW_STATE_SCHEMA_VERSION);
+  });
+
+  it.each(["2026.9.1", "2026.9.3", "2026.9.4", null])(
+    "publishes immediately for driver %s without creating a deferred marker",
+    (version) => {
+      const { options } = createV15Database(version);
+      const db = openOpenClawStateDatabase(options).db;
+      expectVersion(db, OPENCLAW_STATE_SCHEMA_VERSION);
+      expect(
+        db
+          .prepare(
+            "SELECT 1 FROM config_machine_state WHERE state_key = 'state.schema.contentVersion'",
+          )
+          .get(),
+      ).toBeUndefined();
+    },
+  );
+
+  it.each(["missing metadata", "invalid content"] as const)(
+    "retains the typed manual-update fallback and rolls back on %s",
+    (failure) => {
+      const { options, databasePath } = createV15Database();
+      const before = new DatabaseSync(databasePath);
+      try {
+        if (failure === "missing metadata") {
+          before.exec("DROP TABLE config_machine_state");
+        } else {
+          before.exec(
+            "UPDATE skill_workshop_proposals SET record_json = '{' WHERE proposal_id = 'released'",
+          );
+        }
+      } finally {
+        before.close();
+      }
+      expect(() => openOpenClawStateDatabase(options)).toThrow(
+        expect.objectContaining({
+          name: "UpdateSchemaRefusalError",
+        }),
+      );
+      const after = new DatabaseSync(databasePath, { readOnly: true });
+      try {
+        expectVersion(after, 15);
+        expect(
+          after.prepare("SELECT workspace_dir FROM skill_workshop_collection_reviews").get(),
+        ).toEqual({ workspace_dir: "/fixture/workspace" });
+        expect(
+          after.prepare("SELECT status, claim_released_time FROM skill_workshop_proposals").get(),
+        ).toEqual({ status: "applied", claim_released_time: 1 });
+        if (failure === "missing metadata") {
+          expect(
+            after.prepare("SELECT 1 FROM sqlite_schema WHERE name = 'config_machine_state'").get(),
+          ).toBeUndefined();
+        } else {
+          expect(
+            after
+              .prepare(
+                "SELECT 1 FROM config_machine_state WHERE state_key = 'state.schema.contentVersion'",
+              )
+              .get(),
+          ).toBeUndefined();
+        }
+      } finally {
+        after.close();
+      }
+    },
+  );
+});
 
 describe("state database schema migration error classification", () => {
   it("recognizes a rehydrated exact migration error through its cause chain", () => {

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { quoteSqliteIdentifier } from "../infra/sqlite-schema-sql.js";
-import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import {
   canRepairLegacyAuditEventsSchema,
   hasCanonicalAuditEventsSchema,
@@ -34,6 +33,7 @@ import {
   resolveOpenClawAgentDatabaseStoredPath,
   resolveOpenClawStateDirForDatabasePath,
 } from "./openclaw-state-db.paths.js";
+import { readStateSchemaContentVersion } from "./openclaw-state-schema-publication.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
 
 export function dropLegacyStateTables(db: DatabaseSync): void {
@@ -367,7 +367,7 @@ export function detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(
   pathname: string,
 ): OpenClawStateDatabaseSchemaMigration[] {
   const migrations: OpenClawStateDatabaseSchemaMigration[] = [];
-  const userVersion = readSqliteUserVersion(db);
+  const userVersion = readStateSchemaContentVersion(db);
   if (
     userVersion < RETIRED_COMMITMENTS_SCHEMA_VERSION &&
     tableExists(db, "commitments") &&

--- a/src/state/openclaw-state-db-schema-version.ts
+++ b/src/state/openclaw-state-db-schema-version.ts
@@ -4,14 +4,17 @@ import {
   readSqliteUserVersion,
 } from "../infra/sqlite-user-version.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
+import { readStateSchemaContentVersion } from "./openclaw-state-schema-publication.js";
 
 export function assertSupportedStateSchemaVersion(db: DatabaseSync, pathname: string): number {
   const userVersion = readSqliteUserVersion(db);
-  if (userVersion > OPENCLAW_STATE_SCHEMA_VERSION) {
+  const contentVersion =
+    userVersion > OPENCLAW_STATE_SCHEMA_VERSION ? userVersion : readStateSchemaContentVersion(db);
+  if (contentVersion > OPENCLAW_STATE_SCHEMA_VERSION) {
     throw createNewerSqliteSchemaVersionError(
       "OpenClaw state database",
       pathname,
-      userVersion,
+      contentVersion,
       OPENCLAW_STATE_SCHEMA_VERSION,
     );
   }

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -30,7 +30,10 @@ import {
   type SqliteTransactionOptions,
 } from "../infra/sqlite-transaction.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
-import { withStateSchemaFence } from "../infra/state-database-coordinator.js";
+import {
+  StateSchemaMutationConflictError,
+  withStateSchemaFence,
+} from "../infra/state-database-coordinator.js";
 import { migrateLegacyCronRunLogsToTaskRuns } from "../infra/state-migrations.cron-run-logs.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { clearOpenClawDatabaseQuarantine } from "./openclaw-quarantine-store.js";
@@ -53,6 +56,7 @@ import {
 import {
   assertCurrentStateRuntimeSchema,
   isOpenClawStateSchemaFastPathEligible,
+  needsOpenClawStateDatabaseSchemaRepair,
 } from "./openclaw-state-db-fast-path.js";
 import {
   assertOpenClawStateDatabaseForMaintenance,
@@ -76,7 +80,6 @@ import { tableExists } from "./openclaw-state-db-schema-helpers.js";
 import {
   type AgentDatabasePathMigrationSummary as AgentPathSummary,
   assertCanonicalStateSchemaShape,
-  detectOpenClawStateDatabaseSchemaMigrationsFromDatabase,
   dropLegacyStateTables,
   migrateAgentDatabaseRelativePaths as migrateAgentPaths,
   migrateWorkerPlacementExecutionModeSchema,
@@ -310,26 +313,6 @@ export function repairOpenClawStateDatabaseSchema(options: OpenClawStateDatabase
     "state schema repair",
     () => withStateSchemaFence({ databasePath: pathname }, () => repairStateSchema(pathname, env)),
   );
-}
-
-function needsOpenClawStateDatabaseSchemaRepair(pathname: string): boolean {
-  let database: DatabaseSync | undefined;
-  try {
-    database = openNodeSqliteDatabase(pathname, { readOnly: true });
-    assertSupportedStateSchemaVersion(database, pathname);
-    const needsRepair =
-      readSqliteUserVersion(database) !== OPENCLAW_STATE_SCHEMA_VERSION ||
-      detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(database, pathname).length > 0;
-    if (!needsRepair) {
-      assertCurrentStateRuntimeSchema(database, pathname);
-    }
-    return needsRepair;
-  } catch {
-    // Preserve the repair path's existing diagnostics for unreadable or noncanonical databases.
-    return true;
-  } finally {
-    database?.close();
-  }
 }
 
 /** Skip the exclusive doctor repair when automatic migration sees a canonical current schema. */
@@ -612,10 +595,12 @@ function openOpenClawStateDatabaseWithBusyTimeout(
     }
     throw error;
   }
-  if (readSqliteUserVersion(unpublished.db) < OPENCLAW_STATE_SCHEMA_VERSION) {
-    deferredStateDatabases.add(unpublished.db);
+  const database = stateDbCache.publishOpenClawStateDatabase(unpublished);
+  if (readSqliteUserVersion(database.db) < OPENCLAW_STATE_SCHEMA_VERSION) {
+    deferredStateDatabases.add(database.db);
+    reconcileOpenClawStateSchemaPublication(options);
   }
-  return stateDbCache.publishOpenClawStateDatabase(unpublished);
+  return database;
 }
 
 /** Open or return a cached shared state database after schema and migration checks. */
@@ -641,20 +626,31 @@ export function reconcileOpenClawStateSchemaPublication(
   if (!pending || pending.blocker) {
     return pending?.blocker;
   }
-  return runOpenClawStateWriteTransaction(
-    ({ db }) => {
-      // The advisory read may race a new update. Re-read every driver under the write lock.
-      const blocker = readStateSchemaPublicationBlocker(db);
-      if (blocker) {
-        return blocker;
-      }
-      assertOpenClawStateDatabaseForMaintenance(db, { pathname: resolveDatabasePath(options) });
-      markCurrentStateSchemaVersion(db);
+  const pathname = resolveDatabasePath(options);
+  try {
+    return withStateSchemaFence({ databasePath: pathname }, () =>
+      runOpenClawStateWriteTransaction(
+        ({ db }) => {
+          // The advisory read may race a new update. Re-read every driver under the write lock.
+          const blocker = readStateSchemaPublicationBlocker(db);
+          if (blocker) {
+            return blocker;
+          }
+          assertOpenClawStateDatabaseForMaintenance(db, { pathname });
+          markCurrentStateSchemaVersion(db);
+          return undefined;
+        },
+        options,
+        { operationLabel: "state.schema.publish" },
+      ),
+    );
+  } catch (error) {
+    // Current content is ready for readers; a live Gateway owns optional publication.
+    if (error instanceof StateSchemaMutationConflictError) {
       return undefined;
-    },
-    options,
-    { operationLabel: "state.schema.publish" },
-  );
+    }
+    throw error;
+  }
 }
 
 /** Run one operation through the shared owner without waiting synchronously on SQLite locks. */

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -69,6 +69,7 @@ import {
 import { openUnpublishedStateDatabase } from "./openclaw-state-db-open.js";
 import * as operatorApprovalMigration from "./openclaw-state-db-operator-approval-migration.js";
 import { ensureOpenClawStatePermissions } from "./openclaw-state-db-permissions.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
 import {
   ensureAdditiveStateColumns,
   ensureFirstUseAdditiveStateColumnsForStrictMigration,
@@ -102,7 +103,14 @@ import {
   runWithOpenClawStateWriteAccess,
 } from "./openclaw-state-ownership.js";
 import { getOpenClawStateRuntimeSchema } from "./openclaw-state-schema-compatibility.js";
+import {
+  readStateSchemaContentVersion,
+  readStateSchemaPublicationBlocker,
+  resolveStateSchemaVersionToPublish,
+  type StateSchemaPublicationBlocker,
+} from "./openclaw-state-schema-publication.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
+import { UpdateSchemaRefusalError } from "./openclaw-update-schema-refusal.js";
 export { registerOpenClawStateDatabaseLifecycleListener } from "./openclaw-state-db-cache.js";
 
 export { OPENCLAW_DATABASE_SCHEMA_DOCS_URL, OPENCLAW_SQLITE_BUSY_TIMEOUT_MS };
@@ -134,6 +142,52 @@ function assertOpenClawStateDatabaseFreshOpenAllowed(
 
 type OpenClawStateMetadataDatabase = Pick<OpenClawStateKyselyDatabase, "schema_meta">;
 const stateDbLog = createSubsystemLogger("state/db");
+const deferredStateDatabases = new WeakSet<DatabaseSync>();
+
+function runStateSchemaMigrationTransaction<T>(
+  db: DatabaseSync,
+  pathname: string,
+  migrate: () => T,
+  transactionOptions: SqliteTransactionOptions,
+): T {
+  return runSqliteImmediateTransactionSync(
+    db,
+    () => {
+      const publishedVersion = readSqliteUserVersion(db);
+      const blocker =
+        publishedVersion < OPENCLAW_STATE_SCHEMA_VERSION
+          ? readStateSchemaPublicationBlocker(db)
+          : undefined;
+      if (!blocker) {
+        return migrate();
+      }
+      try {
+        // Check before canonical DDL could recreate the missing publication owner.
+        if (!tableExists(db, "config_machine_state")) {
+          throw new Error("Shared state schema publication requires config_machine_state.");
+        }
+        return migrate();
+      } catch (cause) {
+        if (cause instanceof OpenClawStateOwnershipError) {
+          throw cause;
+        }
+        throw new UpdateSchemaRefusalError(
+          [
+            {
+              kind: "state",
+              path: pathname,
+              foundVersion: publishedVersion,
+              supportedVersion: OPENCLAW_STATE_SCHEMA_VERSION,
+            },
+          ],
+          blocker.updaterVersion,
+          { cause },
+        );
+      }
+    },
+    transactionOptions,
+  );
+}
 
 function executeCanonicalStateSchema(
   database: DatabaseSync,
@@ -157,12 +211,13 @@ function repairStateSchema(
     db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
     assertSupportedStateSchemaVersion(db, pathname);
     db.exec("PRAGMA foreign_keys = OFF;");
-    const changes = runSqliteImmediateTransactionSync(
+    const changes = runStateSchemaMigrationTransaction(
       db,
+      pathname,
       () => {
         assertOpenClawStateWriteAllowed({ database: db, databasePath: pathname, env });
         const applied: string[] = [];
-        const previousVersion = readSqliteUserVersion(db);
+        const previousVersion = readStateSchemaContentVersion(db);
         if (previousVersion === OPENCLAW_STATE_SCHEMA_VERSION) {
           for (const name of repairCanonicalSqliteIndexes(db, pathname, OPENCLAW_STATE_SCHEMA_SQL, {
             allowMissingColumns: true,
@@ -244,7 +299,7 @@ function repairStateSchema(
         markCurrentStateSchemaVersion(db, {
           createMetadataIfMissing: previousVersion < OPENCLAW_STATE_SCHEMA_VERSION,
         });
-        if (readSqliteUserVersion(db) === OPENCLAW_STATE_SCHEMA_VERSION) {
+        if (readStateSchemaContentVersion(db) === OPENCLAW_STATE_SCHEMA_VERSION) {
           assertCurrentStateRuntimeSchema(db, pathname);
         }
         if (rebuiltIndexNames.size > 0) {
@@ -269,6 +324,9 @@ function repairStateSchema(
           ],
     };
   } catch (err) {
+    if (err instanceof UpdateSchemaRefusalError) {
+      throw err;
+    }
     if (err instanceof OpenClawStateOwnershipError) {
       ownershipRefused = true;
       throw err;
@@ -376,8 +434,9 @@ function ensureSchema(
     const kysely = getNodeSqliteKysely<OpenClawStateMetadataDatabase>(db);
     db.exec("PRAGMA foreign_keys = OFF;"); // Rebuilding referenced tables requires this before BEGIN.
     try {
-      runSqliteImmediateTransactionSync(
+      runStateSchemaMigrationTransaction(
         db,
+        pathname,
         () => {
           // Recheck ownership after BEGIN IMMEDIATE to exclude a concurrent external claim.
           assertOpenClawStateWriteAllowed({ database: db, databasePath: pathname, env });
@@ -387,7 +446,7 @@ function ensureSchema(
           if (initializeNativeOnly && !isUninitializedNativeStartupDatabase(db)) {
             return [];
           }
-          const previousVersion = readSqliteUserVersion(db);
+          const previousVersion = readStateSchemaContentVersion(db);
           if (previousVersion === OPENCLAW_STATE_SCHEMA_VERSION) {
             verifyAndRepairCanonicalSqliteIndexes(db, pathname, OPENCLAW_STATE_SCHEMA_SQL, {
               allowMissingColumns: true,
@@ -430,7 +489,8 @@ function ensureSchema(
           repairCanonicalSqliteIndexes(db, pathname, OPENCLAW_STATE_SCHEMA_SQL, {
             verifyPhysicalIntegrity: false,
           });
-          db.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION};`);
+          const schemaVersion = resolveStateSchemaVersionToPublish(db);
+          db.exec(`PRAGMA user_version = ${schemaVersion};`);
           executeSqliteQuerySync(
             db,
             kysely
@@ -438,7 +498,7 @@ function ensureSchema(
               .values({
                 meta_key: "primary",
                 role: "global",
-                schema_version: OPENCLAW_STATE_SCHEMA_VERSION,
+                schema_version: schemaVersion,
                 agent_id: null,
                 app_version: VERSION,
                 created_at: now,
@@ -449,7 +509,7 @@ function ensureSchema(
                   .column("meta_key")
                   .doUpdateSet({
                     role: "global",
-                    schema_version: OPENCLAW_STATE_SCHEMA_VERSION,
+                    schema_version: schemaVersion,
                     agent_id: null,
                     app_version: VERSION,
                     updated_at: now,
@@ -458,7 +518,7 @@ function ensureSchema(
                   // open and defeat no-change backup detection.
                   .where((eb) =>
                     eb.or([
-                      eb("schema_meta.schema_version", "!=", OPENCLAW_STATE_SCHEMA_VERSION),
+                      eb("schema_meta.schema_version", "!=", schemaVersion),
                       eb("schema_meta.app_version", "is not", VERSION),
                       eb("schema_meta.role", "!=", "global"),
                     ]),
@@ -521,7 +581,7 @@ export async function openExistingOpenClawStateDatabaseReadOnly(
     db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
     assertSupportedStateSchemaVersion(db, pathname);
     assertSqliteIntegrity(db, pathname);
-    if (readSqliteUserVersion(db) === OPENCLAW_STATE_SCHEMA_VERSION) {
+    if (readStateSchemaContentVersion(db) === OPENCLAW_STATE_SCHEMA_VERSION) {
       assertOpenClawStateDatabaseForMaintenance(db, { pathname });
     }
   } catch (error) {
@@ -594,6 +654,12 @@ function openOpenClawStateDatabaseWithBusyTimeout(
       env,
       schemaReady: true,
     });
+    if (deferredStateDatabases.has(cached.db)) {
+      reconcileOpenClawStateSchemaPublication(options);
+      if (readSqliteUserVersion(cached.db) === OPENCLAW_STATE_SCHEMA_VERSION) {
+        deferredStateDatabases.delete(cached.db);
+      }
+    }
     return cached;
   }
   try {
@@ -639,6 +705,9 @@ function openOpenClawStateDatabaseWithBusyTimeout(
     }
     throw error;
   }
+  if (readSqliteUserVersion(unpublished.db) < OPENCLAW_STATE_SCHEMA_VERSION) {
+    deferredStateDatabases.add(unpublished.db);
+  }
   return stateDbCache.publishOpenClawStateDatabase(unpublished);
 }
 
@@ -647,6 +716,38 @@ export function openOpenClawStateDatabase(
   options: OpenClawStateDatabaseOptions = {},
 ): OpenClawStateDatabase {
   return openOpenClawStateDatabaseWithBusyTimeout(options);
+}
+
+/** The Gateway watcher also publishes without requiring a new physical database open. */
+export function reconcileOpenClawStateSchemaPublication(
+  options: OpenClawStateDatabaseOptions = {},
+): StateSchemaPublicationBlocker | undefined {
+  const pending = withExistingOpenClawStateDatabaseReadOnly(({ db }) => {
+    if (
+      readSqliteUserVersion(db) >= OPENCLAW_STATE_SCHEMA_VERSION ||
+      readStateSchemaContentVersion(db) < OPENCLAW_STATE_SCHEMA_VERSION
+    ) {
+      return undefined;
+    }
+    return { blocker: readStateSchemaPublicationBlocker(db) };
+  }, options);
+  if (!pending || pending.blocker) {
+    return pending?.blocker;
+  }
+  return runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      // The advisory read may race a new update. Re-read every driver under the write lock.
+      const blocker = readStateSchemaPublicationBlocker(db);
+      if (blocker) {
+        return blocker;
+      }
+      assertOpenClawStateDatabaseForMaintenance(db, { pathname: resolveDatabasePath(options) });
+      markCurrentStateSchemaVersion(db);
+      return undefined;
+    },
+    options,
+    { operationLabel: "state.schema.publish" },
+  );
 }
 
 /** Run one operation through the shared owner without waiting synchronously on SQLite locks. */

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -2,11 +2,7 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
-import {
-  clearNodeSqliteKyselyCacheForDatabase,
-  executeSqliteQuerySync,
-  getNodeSqliteKysely,
-} from "../infra/kysely-sync.js";
+import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import {
   normalizeSqliteNonNegativeInteger,
@@ -37,7 +33,6 @@ import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import { withStateSchemaFence } from "../infra/state-database-coordinator.js";
 import { migrateLegacyCronRunLogsToTaskRuns } from "../infra/state-migrations.cron-run-logs.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { VERSION } from "../version.js";
 import { clearOpenClawDatabaseQuarantine } from "./openclaw-quarantine-store.js";
 import { repairAuditEventsSchema } from "./openclaw-state-db-audit-migration.js";
 import {
@@ -65,6 +60,9 @@ import {
   openClawStateMigrationAssertions,
   resolveDatabasePath,
   versionedStateMigrations,
+  runStateSchemaMigrationTransaction,
+  writeCurrentStateSchemaMetadata,
+  executeCanonicalStateSchema,
 } from "./openclaw-state-db-maintenance.js";
 import { openUnpublishedStateDatabase } from "./openclaw-state-db-open.js";
 import * as operatorApprovalMigration from "./openclaw-state-db-operator-approval-migration.js";
@@ -94,7 +92,6 @@ import {
   withOpenClawStateStartupCheckpointConnection,
 } from "./openclaw-state-db-startup-checkpoint.js";
 import * as retirements from "./openclaw-state-db-table-retirements.js";
-import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import { describeAgentPathMigration, warnAgentPathMigration } from "./openclaw-state-db.paths.js";
 import {
   assertOpenClawStateWriteAllowed,
@@ -106,7 +103,6 @@ import { getOpenClawStateRuntimeSchema } from "./openclaw-state-schema-compatibi
 import {
   readStateSchemaContentVersion,
   readStateSchemaPublicationBlocker,
-  resolveStateSchemaVersionToPublish,
   type StateSchemaPublicationBlocker,
 } from "./openclaw-state-schema-publication.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
@@ -140,61 +136,8 @@ function assertOpenClawStateDatabaseFreshOpenAllowed(
   stateDbCache.assertOpenClawStateDatabaseFreshOpenAllowedAtPath(resolveDatabasePath(options), env);
 }
 
-type OpenClawStateMetadataDatabase = Pick<OpenClawStateKyselyDatabase, "schema_meta">;
 const stateDbLog = createSubsystemLogger("state/db");
 const deferredStateDatabases = new WeakSet<DatabaseSync>();
-
-function runStateSchemaMigrationTransaction<T>(
-  db: DatabaseSync,
-  pathname: string,
-  migrate: () => T,
-  transactionOptions: SqliteTransactionOptions,
-): T {
-  return runSqliteImmediateTransactionSync(
-    db,
-    () => {
-      const publishedVersion = readSqliteUserVersion(db);
-      const blocker =
-        publishedVersion < OPENCLAW_STATE_SCHEMA_VERSION
-          ? readStateSchemaPublicationBlocker(db)
-          : undefined;
-      if (!blocker) {
-        return migrate();
-      }
-      try {
-        // Check before canonical DDL could recreate the missing publication owner.
-        if (!tableExists(db, "config_machine_state")) {
-          throw new Error("Shared state schema publication requires config_machine_state.");
-        }
-        return migrate();
-      } catch (cause) {
-        if (cause instanceof OpenClawStateOwnershipError) {
-          throw cause;
-        }
-        throw new UpdateSchemaRefusalError(
-          [
-            {
-              kind: "state",
-              path: pathname,
-              foundVersion: publishedVersion,
-              supportedVersion: OPENCLAW_STATE_SCHEMA_VERSION,
-            },
-          ],
-          blocker.updaterVersion,
-          { cause },
-        );
-      }
-    },
-    transactionOptions,
-  );
-}
-
-function executeCanonicalStateSchema(
-  database: DatabaseSync,
-  options: { includeVersionLazyAdditiveTables: boolean },
-): void {
-  database.exec(getOpenClawStateRuntimeSchema(options));
-}
 
 function repairStateSchema(
   pathname: string,
@@ -431,7 +374,6 @@ function ensureSchema(
 
   withStateSchemaFence({ databasePath: pathname }, () => {
     const now = Date.now();
-    const kysely = getNodeSqliteKysely<OpenClawStateMetadataDatabase>(db);
     db.exec("PRAGMA foreign_keys = OFF;"); // Rebuilding referenced tables requires this before BEGIN.
     try {
       runStateSchemaMigrationTransaction(
@@ -489,42 +431,7 @@ function ensureSchema(
           repairCanonicalSqliteIndexes(db, pathname, OPENCLAW_STATE_SCHEMA_SQL, {
             verifyPhysicalIntegrity: false,
           });
-          const schemaVersion = resolveStateSchemaVersionToPublish(db);
-          db.exec(`PRAGMA user_version = ${schemaVersion};`);
-          executeSqliteQuerySync(
-            db,
-            kysely
-              .insertInto("schema_meta")
-              .values({
-                meta_key: "primary",
-                role: "global",
-                schema_version: schemaVersion,
-                agent_id: null,
-                app_version: VERSION,
-                created_at: now,
-                updated_at: now,
-              })
-              .onConflict((conflict) =>
-                conflict
-                  .column("meta_key")
-                  .doUpdateSet({
-                    role: "global",
-                    schema_version: schemaVersion,
-                    agent_id: null,
-                    app_version: VERSION,
-                    updated_at: now,
-                  })
-                  // updated_at tracks schema metadata changes; unconditional bumps dirty every
-                  // open and defeat no-change backup detection.
-                  .where((eb) =>
-                    eb.or([
-                      eb("schema_meta.schema_version", "!=", schemaVersion),
-                      eb("schema_meta.app_version", "is not", VERSION),
-                      eb("schema_meta.role", "!=", "global"),
-                    ]),
-                  ),
-              ),
-          );
+          writeCurrentStateSchemaMetadata(db, now);
           assertOpenClawStateDatabaseForMaintenance(db, { pathname });
           warnAgentPathMigration(stateDbLog, pathMigration, pathname);
           return retirementMessages;

--- a/src/state/openclaw-state-schema-publication.ts
+++ b/src/state/openclaw-state-schema-publication.ts
@@ -3,8 +3,8 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { parse as parseSemver } from "semver";
 import {
   executeSqliteQuerySync,
-  executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
+  prepareSqliteQuerySync,
 } from "../infra/kysely-sync.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
@@ -15,6 +15,11 @@ const CONTENT_VERSION_KEY = "state.schema.contentVersion";
 const TERMINAL_GRACE_MS = 5 * 60_000;
 const ABANDONED_RUN_MS = 30 * 60_000;
 type PublicationDatabase = Pick<DB, "config_machine_state" | "update_runs">;
+// Admission also runs on cached reads. Retain the SQL, never the content version.
+const contentVersionQueries = new WeakMap<
+  DatabaseSync,
+  ReturnType<typeof prepareSqliteQuerySync<void, Pick<DB["config_machine_state"], "value_json">>>
+>();
 
 export type StateSchemaPublicationBlocker = {
   runId: string;
@@ -34,13 +39,17 @@ export function readStateSchemaContentVersion(db: DatabaseSync): number {
   if (!tableExists(db, "config_machine_state")) {
     return published;
   }
-  const row = executeSqliteQueryTakeFirstSync(
-    db,
-    getNodeSqliteKysely<PublicationDatabase>(db)
-      .selectFrom("config_machine_state")
-      .select("value_json")
-      .where("state_key", "=", CONTENT_VERSION_KEY),
-  );
+  let query = contentVersionQueries.get(db);
+  if (!query) {
+    query = prepareSqliteQuerySync(db, () =>
+      getNodeSqliteKysely<PublicationDatabase>(db)
+        .selectFrom("config_machine_state")
+        .select("value_json")
+        .where("state_key", "=", CONTENT_VERSION_KEY),
+    );
+    contentVersionQueries.set(db, query);
+  }
+  const row = query().rows[0];
   if (!row) {
     return published;
   }

--- a/src/state/openclaw-state-schema-publication.ts
+++ b/src/state/openclaw-state-schema-publication.ts
@@ -1,0 +1,146 @@
+import type { DatabaseSync } from "node:sqlite";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { parse as parseSemver } from "semver";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
+import { tableExists } from "./openclaw-state-db-schema-helpers.js";
+import type { DB } from "./openclaw-state-db.generated.js";
+
+const CONTENT_VERSION_KEY = "state.schema.contentVersion";
+const TERMINAL_GRACE_MS = 5 * 60_000;
+const ABANDONED_RUN_MS = 30 * 60_000;
+type PublicationDatabase = Pick<DB, "config_machine_state" | "update_runs">;
+
+export type StateSchemaPublicationBlocker = {
+  runId: string;
+  updaterVersion: string;
+  publishAfterMs: number | null;
+};
+
+/** Only the 2026.9.2 release line reopens the ledger without the transaction fence. */
+function isUnfencedUpdateDriver(version: unknown): boolean {
+  const parsed = typeof version === "string" ? parseSemver(version) : null;
+  return parsed !== null && `${parsed.major}.${parsed.minor}.${parsed.patch}` === "2026.9.2";
+}
+
+/** Content and its marker commit together, even while older readers retain their version floor. */
+export function readStateSchemaContentVersion(db: DatabaseSync): number {
+  const published = readSqliteUserVersion(db);
+  if (!tableExists(db, "config_machine_state")) {
+    return published;
+  }
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getNodeSqliteKysely<PublicationDatabase>(db)
+      .selectFrom("config_machine_state")
+      .select("value_json")
+      .where("state_key", "=", CONTENT_VERSION_KEY),
+  );
+  if (!row) {
+    return published;
+  }
+  const contentVersion: unknown = JSON.parse(row.value_json);
+  if (
+    typeof contentVersion !== "number" ||
+    !Number.isSafeInteger(contentVersion) ||
+    contentVersion < 0
+  ) {
+    throw new Error(`Invalid shared state schema content version in ${CONTENT_VERSION_KEY}.`);
+  }
+  return Math.max(published, contentVersion);
+}
+
+/** Every unfenced driver must clear its own deadline; a newer run cannot hide an older one. */
+export function readStateSchemaPublicationBlocker(
+  db: DatabaseSync,
+  nowMs = Date.now(),
+): StateSchemaPublicationBlocker | undefined {
+  if (!tableExists(db, "update_runs")) {
+    return undefined;
+  }
+  const rows = executeSqliteQuerySync(
+    db,
+    getNodeSqliteKysely<PublicationDatabase>(db)
+      .selectFrom("update_runs")
+      .select(["run_id", "before_json", "status", "updated_at_ms", "finished_at_ms"])
+      .where((eb) =>
+        eb.or([
+          eb.and([
+            eb("status", "=", "running"),
+            eb("updated_at_ms", ">=", nowMs - ABANDONED_RUN_MS),
+          ]),
+          eb.and([
+            eb("status", "!=", "running"),
+            eb.or([
+              eb("finished_at_ms", ">", nowMs - TERMINAL_GRACE_MS),
+              eb("finished_at_ms", "is", null),
+            ]),
+          ]),
+        ]),
+      )
+      .orderBy("run_id"),
+  ).rows;
+  let blocker: StateSchemaPublicationBlocker | undefined;
+  for (const row of rows) {
+    const before: unknown = JSON.parse(row.before_json);
+    if (
+      !isRecord(before) ||
+      typeof before.version !== "string" ||
+      !isUnfencedUpdateDriver(before.version)
+    ) {
+      continue;
+    }
+    const deadline =
+      row.status === "running"
+        ? row.updated_at_ms + ABANDONED_RUN_MS + 1
+        : row.finished_at_ms === null
+          ? null
+          : row.finished_at_ms + TERMINAL_GRACE_MS;
+    if (
+      !blocker ||
+      deadline === null ||
+      (blocker.publishAfterMs !== null && deadline > blocker.publishAfterMs)
+    ) {
+      blocker = { runId: row.run_id, updaterVersion: before.version, publishAfterMs: deadline };
+    }
+  }
+  return blocker;
+}
+
+/** Called inside the schema write transaction, after all content migrations succeed. */
+export function resolveStateSchemaVersionToPublish(db: DatabaseSync): number {
+  const published = readSqliteUserVersion(db);
+  if (published >= OPENCLAW_STATE_SCHEMA_VERSION || !readStateSchemaPublicationBlocker(db)) {
+    return OPENCLAW_STATE_SCHEMA_VERSION;
+  }
+  if (!tableExists(db, "config_machine_state")) {
+    throw new Error(
+      "Shared state schema publication cannot be deferred without config_machine_state.",
+    );
+  }
+  executeSqliteQuerySync(
+    db,
+    getNodeSqliteKysely<PublicationDatabase>(db)
+      .insertInto("config_machine_state")
+      .values({
+        state_key: CONTENT_VERSION_KEY,
+        value_json: String(OPENCLAW_STATE_SCHEMA_VERSION),
+        updated_at_ms: Date.now(),
+      })
+      .onConflict((conflict) =>
+        conflict
+          .column("state_key")
+          .doUpdateSet({
+            value_json: String(OPENCLAW_STATE_SCHEMA_VERSION),
+            updated_at_ms: Date.now(),
+          })
+          .where("config_machine_state.value_json", "!=", String(OPENCLAW_STATE_SCHEMA_VERSION)),
+      ),
+  );
+  return published;
+}

--- a/src/state/openclaw-update-schema-refusal.ts
+++ b/src/state/openclaw-update-schema-refusal.ts
@@ -1,0 +1,50 @@
+import { formatErrorMessage } from "../infra/errors.js";
+import { VERSION } from "../version.js";
+
+export type UpdateSchemaRefusalDatabase = {
+  kind: "state" | "agent";
+  path: string;
+  agentId?: string;
+  foundVersion: number;
+  supportedVersion: number;
+};
+
+/** An unfenced updater needs a manual update when safe publication deferral is unavailable. */
+export class UpdateSchemaRefusalError extends Error {
+  readonly code = "update-schema-bump-unfenced";
+  readonly targetVersion = VERSION;
+  readonly commands: string[];
+
+  constructor(
+    readonly databases: readonly UpdateSchemaRefusalDatabase[],
+    readonly updaterVersion: string,
+    options: { cause?: unknown } = {},
+  ) {
+    const commands = [
+      "openclaw gateway stop",
+      `npm install -g openclaw@${VERSION} --allow-scripts=openclaw`,
+      "openclaw doctor --fix",
+      "openclaw gateway start",
+    ];
+    const reason =
+      options.cause === undefined
+        ? ""
+        : ` Deferral failed: ${formatErrorMessage(options.cause).slice(0, 600)}.`;
+    super(
+      `Doctor refused update-time schema repair driven by OpenClaw ${updaterVersion}: this updater reopens the ledger with old code after migration, and version publication could not be deferred safely. ` +
+        databases
+          .map(
+            (database) =>
+              `${database.kind} database ${database.path}: on-disk schema ${database.foundVersion}, this build's schema ${database.supportedVersion}.`,
+          )
+          .join(" ") +
+        reason +
+        " The blocked schema change was not applied. Let the updater restore the previous package, then update manually: " +
+        `${commands.join(" && ")}. ` +
+        `Use the package manager that owns this install (pnpm: pnpm add -g --allow-build=openclaw openclaw@${VERSION}; Bun: bun add -g --trust openclaw@${VERSION}). On npm 11.15 and earlier, omit --allow-scripts=openclaw.`,
+      options,
+    );
+    this.name = "UpdateSchemaRefusalError";
+    this.commands = commands;
+  }
+}

--- a/src/state/openclaw-update-schema-refusal.ts
+++ b/src/state/openclaw-update-schema-refusal.ts
@@ -1,5 +1,4 @@
 import { formatErrorMessage } from "../infra/errors.js";
-import { VERSION } from "../version.js";
 
 export type UpdateSchemaRefusalDatabase = {
   kind: "state" | "agent";
@@ -12,17 +11,18 @@ export type UpdateSchemaRefusalDatabase = {
 /** An unfenced updater needs a manual update when safe publication deferral is unavailable. */
 export class UpdateSchemaRefusalError extends Error {
   readonly code = "update-schema-bump-unfenced";
-  readonly targetVersion = VERSION;
+  readonly targetVersion: string;
   readonly commands: string[];
 
   constructor(
     readonly databases: readonly UpdateSchemaRefusalDatabase[],
     readonly updaterVersion: string,
-    options: { cause?: unknown } = {},
+    options: { targetVersion: string; cause?: unknown },
   ) {
+    const { targetVersion } = options;
     const commands = [
       "openclaw gateway stop",
-      `npm install -g openclaw@${VERSION} --allow-scripts=openclaw`,
+      `npm install -g openclaw@${targetVersion} --allow-scripts=openclaw`,
       "openclaw doctor --fix",
       "openclaw gateway start",
     ];
@@ -41,10 +41,11 @@ export class UpdateSchemaRefusalError extends Error {
         reason +
         " The blocked schema change was not applied. Let the updater restore the previous package, then update manually: " +
         `${commands.join(" && ")}. ` +
-        `Use the package manager that owns this install (pnpm: pnpm add -g --allow-build=openclaw openclaw@${VERSION}; Bun: bun add -g --trust openclaw@${VERSION}). On npm 11.15 and earlier, omit --allow-scripts=openclaw.`,
+        `Use the package manager that owns this install (pnpm: pnpm add -g --allow-build=openclaw openclaw@${targetVersion}; Bun: bun add -g --trust openclaw@${targetVersion}). On npm 11.15 and earlier, omit --allow-scripts=openclaw.`,
       options,
     );
     this.name = "UpdateSchemaRefusalError";
+    this.targetVersion = targetVersion;
     this.commands = commands;
   }
 }

--- a/test/gateway-external-state-ownership.e2e.test.ts
+++ b/test/gateway-external-state-ownership.e2e.test.ts
@@ -1,7 +1,181 @@
+import { backup, DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
-import { createOpenClawTestInstance } from "./helpers/openclaw-test-instance.js";
+import { withStateSchemaFence } from "../src/infra/state-database-coordinator.js";
+import { createUpdateRun } from "../src/infra/update-run-ledger.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../src/state/openclaw-state-db-contract.js";
+import {
+  closeOpenClawStateDatabaseByPath,
+  openOpenClawStateDatabase,
+} from "../src/state/openclaw-state-db.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "./helpers/openclaw-test-instance.js";
+
+const publicationGraceMs = 5 * 60_000;
+
+async function createPublicationInstance(name: string) {
+  return createOpenClawTestInstance({
+    name,
+    config: { update: { checkOnStart: false, auto: { enabled: false } } },
+    env: {
+      // Exercise the production lifecycle lock and watcher, both disabled by test defaults.
+      VITEST: undefined,
+      VITEST_POOL_ID: undefined,
+      VITEST_WORKER_ID: undefined,
+      NODE_ENV: undefined,
+      NODE_OPTIONS: undefined,
+      OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+      OPENCLAW_NO_RESPAWN: "1",
+      OPENCLAW_SUPERVISOR_MODE: undefined,
+    },
+  });
+}
+
+function seedDeferredState(instance: OpenClawTestInstance, terminal: boolean) {
+  const options = { env: instance.env };
+  const { db, path: databasePath } = openOpenClawStateDatabase(options);
+  try {
+    const run = createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } }, options);
+    const now = Date.now();
+    // Migration content is already committed; the runner suite proves the v15 rebuild itself.
+    db.prepare(`INSERT INTO config_machine_state (state_key, value_json, updated_at_ms)
+      VALUES ('state.schema.contentVersion', ?, ?)`).run(
+      String(OPENCLAW_STATE_SCHEMA_VERSION),
+      now,
+    );
+    db.prepare(`UPDATE update_runs SET created_at_ms = ?, updated_at_ms = ?,
+      status = ?, phase = ?, finished_at_ms = ? WHERE run_id = ?`).run(
+      now - 10 * 60_000,
+      terminal ? now - 60_000 : now - publicationGraceMs,
+      terminal ? "succeeded" : "running",
+      terminal ? "finished" : "verifying",
+      terminal ? now - 60_000 : null,
+      run.runId,
+    );
+    db.exec(`PRAGMA user_version = 15;
+      UPDATE schema_meta SET schema_version = 15 WHERE meta_key = 'primary';`);
+    return { databasePath, runId: run.runId };
+  } finally {
+    closeOpenClawStateDatabaseByPath(databasePath);
+  }
+}
+
+function readSchemaVersions(db: DatabaseSync) {
+  return {
+    published: db.prepare("PRAGMA user_version").get()?.user_version,
+    metadata: db.prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'").get()
+      ?.schema_version,
+    content: Number(
+      db
+        .prepare(
+          "SELECT value_json FROM config_machine_state WHERE state_key = 'state.schema.contentVersion'",
+        )
+        .get()?.value_json,
+    ),
+  };
+}
+
+function expectGatewayOwnsState(databasePath: string) {
+  expect(() => withStateSchemaFence({ databasePath }, () => "unexpected authority")).toThrow(
+    "another Gateway owns that state directory",
+  );
+}
 
 describe("Gateway external shared-state ownership", () => {
+  it("keeps CLI readers usable while the owning Gateway defers schema publication", async () => {
+    const instance = await createPublicationInstance("gateway-deferred-schema-readers");
+    let observer: DatabaseSync | undefined;
+    try {
+      const { databasePath } = seedDeferredState(instance, true);
+      observer = new DatabaseSync(databasePath, { readOnly: true });
+      await instance.startGateway();
+      expectGatewayOwnsState(databasePath);
+      const deferred = { published: 15, metadata: 15, content: OPENCLAW_STATE_SCHEMA_VERSION };
+      expect(readSchemaVersions(observer)).toEqual(deferred);
+
+      for (const args of [
+        ["agents", "list", "--json"],
+        ["doctor", "--non-interactive", "--json"],
+        ["update", "--yes", "--json", "--dry-run"],
+      ]) {
+        const result = await instance.cli(args, { timeoutMs: 60_000 });
+        expect(result.code, `${args.join(" ")}\n${result.stderr}\n${result.stdout}`).toBe(0);
+        expect(() => JSON.parse(result.stdout)).not.toThrow();
+        expect(result.stderr).not.toMatch(
+          /schema migration pending|refused shared state schema mutation|another Gateway owns/u,
+        );
+        expect(readSchemaVersions(observer)).toEqual(deferred);
+        expectGatewayOwnsState(databasePath);
+      }
+    } finally {
+      observer?.close();
+      await instance.cleanup();
+    }
+  }, 240_000);
+
+  it("publishes from the owning Gateway timer after a running update finishes and goes quiet", async () => {
+    const instance = await createPublicationInstance("gateway-deferred-schema-timer");
+    let observer: DatabaseSync | undefined;
+    try {
+      const { databasePath, runId } = seedDeferredState(instance, false);
+      const database = new DatabaseSync(databasePath, { readOnly: true });
+      observer = database;
+      await instance.startGateway();
+      expectGatewayOwnsState(databasePath);
+      expect(readSchemaVersions(observer)).toEqual({
+        published: 15,
+        metadata: 15,
+        content: OPENCLAW_STATE_SCHEMA_VERSION,
+      });
+
+      const publishAfterMs = Date.now() + 10_000;
+      const finishedAtMs = publishAfterMs - publicationGraceMs;
+      const writer = new DatabaseSync(databasePath);
+      try {
+        // Deliver an aged terminal fixture through a separate connection, like the old CLI.
+        writer
+          .prepare(`UPDATE update_runs SET status = 'succeeded', phase = 'finished',
+          finished_at_ms = ?, updated_at_ms = ? WHERE run_id = ?`)
+          .run(finishedAtMs, finishedAtMs, runId);
+      } finally {
+        writer.close();
+      }
+
+      // Only bare SQLite reads follow: runner opens or CLI activity would conceal a broken timer.
+      let publishedBeforeDeadline = false;
+      await expect
+        .poll(
+          () => {
+            const versions = readSchemaVersions(database);
+            publishedBeforeDeadline ||=
+              Date.now() < publishAfterMs &&
+              (versions.published !== 15 || versions.metadata !== 15);
+            return versions;
+          },
+          { timeout: 20_000, interval: 100 },
+        )
+        .toEqual({
+          published: OPENCLAW_STATE_SCHEMA_VERSION,
+          metadata: OPENCLAW_STATE_SCHEMA_VERSION,
+          content: OPENCLAW_STATE_SCHEMA_VERSION,
+        });
+      expect(publishedBeforeDeadline).toBe(false);
+      expect(
+        observer
+          .prepare("SELECT status, finished_at_ms, updated_at_ms FROM update_runs WHERE run_id = ?")
+          .get(runId),
+      ).toEqual({
+        status: "succeeded",
+        finished_at_ms: finishedAtMs,
+        updated_at_ms: finishedAtMs,
+      });
+    } finally {
+      observer?.close();
+      await instance.cleanup();
+    }
+  }, 120_000);
+
   it("refuses unmarked startup and accepts the external supervisor marker", async () => {
     const instance = await createOpenClawTestInstance({
       name: "gateway-external-state-owner",
@@ -27,13 +201,15 @@ describe("Gateway external shared-state ownership", () => {
         status: "external",
         ownership: { managerId: "gateway-supervisor" },
       });
-      const preflight = await instance.cli([
-        "database",
-        "preflight",
-        claimed.databasePath,
-        "--json",
-      ]);
-      expect(preflight.code, preflight.stderr).toBe(0);
+      const preflightPath = `${instance.stateDir}/owner-preflight.sqlite`;
+      const source = new DatabaseSync(claimed.databasePath, { readOnly: true });
+      try {
+        await backup(source, preflightPath);
+      } finally {
+        source.close();
+      }
+      const preflight = await instance.cli(["database", "preflight", preflightPath, "--json"]);
+      expect(preflight.code, `${preflight.stderr}\n${preflight.stdout}`).toBe(0);
       expect(JSON.parse(preflight.stdout)).toMatchObject({
         schema: "openclaw.state-schema-preflight.v1",
         status: "exact",

--- a/test/gateway-external-state-ownership.e2e.test.ts
+++ b/test/gateway-external-state-ownership.e2e.test.ts
@@ -7,6 +7,7 @@ import {
   closeOpenClawStateDatabaseByPath,
   openOpenClawStateDatabase,
 } from "../src/state/openclaw-state-db.js";
+import { withEnv } from "../src/test-utils/env.js";
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
@@ -76,9 +77,12 @@ function readSchemaVersions(db: DatabaseSync) {
   };
 }
 
-function expectGatewayOwnsState(databasePath: string) {
-  expect(() => withStateSchemaFence({ databasePath }, () => "unexpected authority")).toThrow(
-    "another Gateway owns that state directory",
+function expectGatewayOwnsState(instance: OpenClawTestInstance, databasePath: string) {
+  // Windows places lifecycle coordinators under the child's isolated home directory.
+  withEnv({ HOME: instance.env.HOME, USERPROFILE: instance.env.USERPROFILE }, () =>
+    expect(() => withStateSchemaFence({ databasePath }, () => "unexpected authority")).toThrow(
+      "another Gateway owns that state directory",
+    ),
   );
 }
 
@@ -90,7 +94,7 @@ describe("Gateway external shared-state ownership", () => {
       const { databasePath } = seedDeferredState(instance, true);
       observer = new DatabaseSync(databasePath, { readOnly: true });
       await instance.startGateway();
-      expectGatewayOwnsState(databasePath);
+      expectGatewayOwnsState(instance, databasePath);
       const deferred = { published: 15, metadata: 15, content: OPENCLAW_STATE_SCHEMA_VERSION };
       expect(readSchemaVersions(observer)).toEqual(deferred);
 
@@ -106,7 +110,7 @@ describe("Gateway external shared-state ownership", () => {
           /schema migration pending|refused shared state schema mutation|another Gateway owns/u,
         );
         expect(readSchemaVersions(observer)).toEqual(deferred);
-        expectGatewayOwnsState(databasePath);
+        expectGatewayOwnsState(instance, databasePath);
       }
     } finally {
       observer?.close();
@@ -122,7 +126,7 @@ describe("Gateway external shared-state ownership", () => {
       const database = new DatabaseSync(databasePath, { readOnly: true });
       observer = database;
       await instance.startGateway();
-      expectGatewayOwnsState(databasePath);
+      expectGatewayOwnsState(instance, databasePath);
       expect(readSchemaVersions(observer)).toEqual({
         published: 15,
         metadata: 15,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw update` from 2026.9.2 cannot cross a shared-state schema bump. The target Doctor migrates the database, then the shipped updater reopens its ledger with old code. #140784 makes this a safe typed refusal and package restore, but the update still requires manual intervention. This change lets the historical updater finish while the new runtime already uses the migrated content. It also lets a subsequent fenced update complete during the five-minute publication grace.

Related: #140784, #138839, #135528. Prior live matrix: https://github.com/openclaw/openclaw/pull/140784#issuecomment-5565472514 .

## Why This Change Was Made

The shared-state runner now records applied content in the existing `config_machine_state` key `state.schema.contentVersion` and retains both published schema markers while an affected updater still needs them. Reopens use the content marker to skip completed migration steps, including the v16 Skill Workshop rebuild. Publication rechecks every 2026.9.2-line row inside one synchronous write transaction: terminal rows need at least five minutes since `finished_at_ms`; running rows need more than thirty minutes since `updated_at_ms`. A new run blocks publication again. The Gateway ledger watcher schedules the same absolute deadline, and later writable opens also publish.

This timing policy was explicitly approved by the maintainer after a packaged-2026.9.2 counterexample showed that terminal status alone is insufficient: the old updater reads its ledger again while rendering its final result. The five-minute grace is an accepted compatibility tradeoff, not proof of process exit. An old CLI blocked beyond that grace can fail its final render; its package swap, any requested restart, and terminal update outcome have already completed. Downgrade protection for the historical reader is delayed for the same interval.

The typed manual-update fallback remains for pending agent-database migrations, missing `config_machine_state`, and content migration failures. Failed content and marker writes roll back together. Ownership errors retain their original boundary. There are no new tables, schema/version bumps, configuration options, or environment variable names, and no changes to the old package, survivor lane, or CI workflows.

### Checked historical contract

All source links below are pinned to `v2026.9.2`:

- [Target Doctor and the old parent's completion callback](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/update-command-package.ts#L150-L184) return to [old ledger progress writes](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/update-command-run.ts#L124-L139).
- Successful package updates move plugin/Doctor convergence to a [target-owned child](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/update-command-post-core.ts#L368-L380); [package update eligibility](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/update-command-post-core.ts#L474-L505) covers this path.
- The old parent records [restart/health](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/update-command-service.ts#L218-L244) and [terminal completion](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/update-command-run.ts#L154-L190) in `update_runs`. [Ledger writes](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/infra/update-run-ledger.ts#L208-L231) retain the cached state owner; [cached reads still check `user_version`](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/state/openclaw-state-db-readonly.ts#L52-L66).
- After terminal commit, [finalization calls `printResult`](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/update-command-post-update.ts#L122-L133), whose [final ledger read also runs in JSON mode](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/progress.ts#L181-L194). This is why publication waits five minutes.
- The [restart sentinel](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/infra/restart-sentinel-store.ts#L570) uses `gateway_restart_sentinel`. Generic [ownership admission](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/state/openclaw-state-ownership.ts#L116-L134) reads `config_machine_state`. V16 rewrites only Skill Workshop proposal/review tables; none of those historical post-Doctor tables is rewritten.

### Readers alongside the restarted Gateway

The live managed-service proof exposed a second failure after the old updater completed: ordinary target CLIs treated published schema 15 as pending migration even though content 16 was already applied, then failed the running Gateway's schema-mutation fence. Readiness now uses the content marker for runtime opens, integrity admission, and automatic Doctor repair. Publication separately acquires the Gateway lifecycle fence; a non-owner silently leaves publication to that Gateway. Cold and cached opens remain usable, and cached handles retry publication after ownership changes. Actual schema repair, external ownership, integrity, and newer-content refusals retain their existing boundaries.

The reported missed timer was checked against the supplied evidence. Its RPC handoff began at 10:59:44Z, before the old row's 11:02:22.724Z publication deadline; journal lines 175–176 independently timestamp that response. The later RPC observations contain no SQLite version samples, and the next SQLite snapshot already shows 16. The evidence therefore does not establish delayed publication. A real Gateway running→terminal→quiet process test passes on both the prior packed implementation and this head. Watcher scheduling was not speculatively rewritten; its unit fixture now physically reopens deferred state.

### Subsequent fenced updates during grace

The follow-up managed-service proof found another published-version reader in post-activation verification. The real Doctor exited 0 and reported applied content 16, but [the post-activation verifier](https://github.com/openclaw/openclaw/blob/21c0aa569ed651a404f3e4b59ed4b8129f7e88d4/src/cli/update-cli/update-command-migrated.ts#L55) compared published 15 against target 16 and appended a synthetic, zero-duration Doctor failure. Rollback followed. The service had stopped correctly; the journal’s later start was rollback recovery. The generic “restart drain” log also appears on a normal SIGTERM stop and was not evidence that stop became restart.

The updater's private state snapshots now retain both published and applied content versions. Activation verification and rollback compatibility compare content: an already-deferred database is ready, publication alone is schema-neutral, and new content still prevents rollback even if its published number is unchanged. Newly created stores must satisfy the retained runtime's content support too. Agent databases and older worker responses retain their existing semantics. No service lifecycle or Doctor ownership rule changed.

## User Impact

2026.9.2 operators can complete the ordinary update flow across the state-schema bump. Doctor reports that content is applied and version publication is deferred. The restarted Gateway uses the current content immediately; the published version catches up after the row-based grace. Earlier ledger-less drivers and fenced drivers from 2026.9.3 onward retain their normal behavior.

## Evidence

### Current second-hop fix

Head: `1a8c75f847524f20ed7a22db8ec2f64dd6d6a288`. Three regression cases fail on pre-fix 21c0aa for the intended reasons; all 45 focused activation/snapshot/rollback tests now pass. The full relevant schema, preflight, Doctor, watcher, coordinator, CLI, and plugin-state suites pass 337 tests with one pre-existing skip. `pnpm check:changed` and `git diff --check` pass. Independent P0/P1 review is scoped-clean.

A secretless Docker reproduction uses the repository's unchanged restart-auth systemctl shim (including Restart=always behavior), real Gateway processes, and ordinary CLI updates with managed restart. Using the same old 21c0aa .3/.4 artifacts, `.2 → .3` exits 0; `.3 → .4` exits 1, the real Doctor exits 0, then the verifier appends `Shared state migration did not finish: expected schema 16, found 15` and rolls back to a healthy .3. Bare SQLite observation places that failure 104.6 seconds after the old legacy terminal row. The `.1 → same .3 → same .4` control passes both updates and ends healthy on .4 with schema 16/no marker. The .1 first updater emits a nonfatal old-code health-state warning; its second-hop stderr is clean.

Canonical full build passed in 5m35s, followed by package integrity validation. Canonical tarball SHA-256: `7975ffc69174cce5239996df7944b4470d76a412302867c0abc1965fe64ef16e`. Existing fixture tooling stamped test-only 2026.9.3 and 2026.9.4 packages from this same head; their build ID is `2026.9.2-1a8c75f84752-2026-09-07T13-23-47.738Z`. No tracked package version changed.

| Fixed-head origin | First managed hop | Second fenced hop | Final serving proof |
| --- | --- | --- | --- |
| 2026.9.2 | Update 0, Doctor 0, empty stderr | Update 0, Doctor 0, empty stderr | Active service, readiness 200, RPC healthy on 2026.9.4; published 15/content 16 at legacy terminal age 73.342s |
| 2026.9.1 | Update 0, Doctor 0; existing old health-state warning | Update 0, Doctor 0, empty stderr | Active service, readiness 200, RPC healthy on 2026.9.4; schema 16, no content marker |

The second hop succeeds while publication is still deferred, so grace expiry cannot mask the repaired verifier. Both ledger rows are succeeded. After final health/identity capture, no CLI or runner opens the .2-origin database: a bare read-only SQLite observer sees 15 until the terminal-row deadline and first observes 16 at **13:51:34.770Z**, **188ms after** the unchanged deadline of **13:51:34.582Z**. The content marker remains 16. The owning Gateway publishes autonomously without a runtime request.

Both hops use the ordinary CLI inside the existing bare Docker image with the unchanged `update-restart-auth` systemctl shim:

```sh
openclaw update --yes --json --tag /packages/openclaw-2026.9.3.tgz
openclaw update --yes --json --tag /packages/openclaw-2026.9.4.tgz
```

All three real-Gateway ownership/publication process cases were also rerun on this head and passed. The previous interrupted green attempts lost their sessions when OrbStack stopped and its socket disappeared; they were preserved as infrastructure interruptions, then rerun from fresh containers using identical artifacts and timing assertions. All task-owned containers were cleaned up.

Exact-head CI was attached with `node scripts/watch-pr-ci.mjs` using a 900-second bound. The watch timed out with one Windows job still running, and subsequent exact-run metadata confirms **completed / success** for [run 34126841610](https://github.com/openclaw/openclaw/actions/runs/34126841610), head `1a8c75f847524f20ed7a22db8ec2f64dd6d6a288`. No CI failure required a code change.

This proof uses the repository's systemctl shim and synthetic provider-disabled config; the maintainer's real-key AWS/native-systemd rerun remains before landing. The prior survivor matrix below is explicitly historical. No survivor or CI workflow changed, no lock recovery was attempted, and the PR is not merged.

### Prior reader/publication proof at 21c0aa

Historical head: `21c0aa569ed651a404f3e4b59ed4b8129f7e88d4`. Canonical build/packing passed; all fresh Docker lanes use one immutable tarball, SHA-256 `61f4901c03305a46e6437764c2ac20998488ea6294f63bd236b46c90f3b4626d`. Build ID: `2026.9.2-21c0aa569ed6-2026-09-07T12-17-11.817Z`. The development package version remains 2026.9.2; the commit and checksum identify the candidate.

- **337 unit tests passed**, one pre-existing initialization-failure skip, across 12 files. This includes the foreign-Gateway cold/cached-reader regression, publication after owner release, timing/idempotence/fallback tests, full state DB suite, preflight, Doctor, watcher, CLI errors/help, plugin state, and coordinator tests.
- **All three real-owner process cases passed on this exact build.** With a real Gateway holding its lifecycle lock on content 16/published 15 and a terminal legacy row finished 60 seconds earlier, separate `agents list --json`, `doctor --non-interactive --json`, and `update --yes --json --dry-run` processes exit 0 with valid JSON and no schema-mutation refusal. The Gateway remains owner and both published markers stay 15. A separate aged terminal fixture proves autonomous publication with only bare SQLite observation: no CLI, runner open, or watcher wake after the terminal commit. The test allows ten seconds after the row deadline. Test-mode lock/minimal-Gateway bypasses are explicitly removed.
- **13 built CLI process tests passed**, including both installed entrypoints with the legacy run only in WAL and the missing-metadata fallback.
- `pnpm check:changed` and `git diff --check` passed. Final independent review is scoped-clean through P2. A final test-only correction aligns the ownership probe with the Gateway child’s isolated HOME/USERPROFILE on Windows; all three process cases and the targeted changed-file check pass. Production code and docs are identical to the initially validated 8b131ed fix.
- The new reader regression fails on the pre-fix source with the reported ownership refusal. The previous packed build also fails the real-process CLI case. An existing external-owner test fixture independently failed because it passed WAL/SHM files to standalone preflight; it now uses a SQLite online backup and preserves the exact-schema assertion and product sidecar refusal.

### Prior Docker survivor matrix at 21c0aa

All three fresh lanes passed on the historical 21c0aa head, each with updater/Doctor exit 0 and successful post-update plugin results, valid successful update JSON, no schema error in `update.err`, and matching installed build identity:

| Baseline | Result | After Gateway health |
| --- | --- | --- |
| `openclaw@2026.9.2` | PASS | HTTP 200; published 15/content 16 at 12:28:41.467Z |
| `openclaw@2026.9.1` | PASS | HTTP 200; published 16, no content marker |
| `openclaw@latest` → 2026.9.2 | PASS | HTTP 200; published 15/content 16 at 12:35:36.345Z |

The explicit 2026.9.2 run lacks a separate post-core exit receipt; its overall updater/Doctor exits are 0 and `postUpdate.plugins.status=ok`. The other two runs captured post-core exit 0. This diagnostic gap is retained in the evidence.

The actual 2026.9.2 terminal timestamp was 12:28:09.666Z, so publication became eligible at 12:33:09.666Z. A copy of its after-Gateway snapshot still had 15/content 16 at 12:33:59.930Z; the committed runner published 16 by 12:34:00.048Z, with `quick_check=ok` and identical ledger status/timestamps. No timestamps or grace constants were changed in this Docker proof. The separate real-Gateway process test uses an aged fixture and exercises the live timer without another opener.

```sh
OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=openclaw@2026.9.2 pnpm test:docker:published-upgrade-survivor
OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=openclaw@2026.9.1 pnpm test:docker:published-upgrade-survivor
OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=openclaw@latest pnpm test:docker:published-upgrade-survivor
```

The original pinned-main candidate `934dc2028c09b4de67b9a2ad960f8dd2ae90f8af` produced the required red result with 2026.9.2: typed refusal, updater/Doctor exit 1, package restore verified, and schema 15 retained. Original-main runtime-open and Doctor-repair regression cases also fail specifically on premature publication (actual 16, expected 15). Those earlier artifacts remain attributed to their tested heads.

### Prior CI and proof limits

The prior 21c0aa CI attached through the requested bounded watcher: [run 34121092340](https://github.com/openclaw/openclaw/actions/runs/34121092340). The 900-second watch reached its bound without a failure. At the final metadata snapshot, **108 jobs succeeded, 15 were skipped, and one Windows job was still running**; no job had failed. CI is not yet a completed green run.

The unchanged Docker lane invokes its first baseline update with `--no-restart`, then starts the target Gateway. The new real-process tests cover live ownership and autonomous publication, but a new real-key, systemd-managed Crabbox rerun remains with the maintainer before landing. The accepted stalled-old-CLI/final-render and delayed downgrade-protection risks remain documented above. No survivor script, CI workflow, schema version, configuration option, or environment-variable name was added or changed for this fix. This PR is not merged.
