### PR TITLE
feat(matrix): support self-trigger markers for cross-room session wake-up

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler-helpers.self-trigger.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-helpers.self-trigger.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { readSelfTriggerMarker } from "./handler-helpers.js";
+import type { MatrixRawEvent } from "./types.js";
+
+function makeEvent(content: Record<string, unknown>): MatrixRawEvent {
+  return {
+    event_id: "$event1:matrix.org",
+    sender: "@bot:matrix.org",
+    type: "m.room.message",
+    origin_server_ts: 1700000000000,
+    content,
+  };
+}
+
+const ROOM_ID = "!task-room:matrix.org";
+
+const VALID_MARKER = {
+  kind: "self_cross_session",
+  type: "project_requested",
+  sourceSession: "matrix:!admin-dm:matrix.org",
+  targetRoomId: ROOM_ID,
+  targetSession: `matrix:${ROOM_ID}`,
+  replyRoute: { channel: "matrix", targetSession: `matrix:!admin-dm:matrix.org` },
+};
+
+describe("readSelfTriggerMarker", () => {
+  it("returns the marker when valid", () => {
+    const event = makeEvent({
+      msgtype: "m.text",
+      body: "PROJECT_REQUESTED: build the API",
+      "com.openclaw.self_trigger": VALID_MARKER,
+    });
+    const result = readSelfTriggerMarker(event, ROOM_ID);
+    expect(result).not.toBeNull();
+    expect(result?.kind).toBe("self_cross_session");
+    expect(result?.type).toBe("project_requested");
+  });
+
+  it("returns null when the marker is absent", () => {
+    const event = makeEvent({
+      msgtype: "m.text",
+      body: "hello world",
+    });
+    expect(readSelfTriggerMarker(event, ROOM_ID)).toBeNull();
+  });
+
+  it("returns null when the marker is not an object", () => {
+    const event = makeEvent({
+      msgtype: "m.text",
+      body: "hello",
+      "com.openclaw.self_trigger": "not-an-object",
+    });
+    expect(readSelfTriggerMarker(event, ROOM_ID)).toBeNull();
+  });
+
+  it("returns null when kind is not self_cross_session", () => {
+    const event = makeEvent({
+      msgtype: "m.text",
+      body: "PROJECT_REQUESTED",
+      "com.openclaw.self_trigger": { ...VALID_MARKER, kind: "other_kind" },
+    });
+    expect(readSelfTriggerMarker(event, ROOM_ID)).toBeNull();
+  });
+
+  it("returns null when type is not in the allowlist", () => {
+    const event = makeEvent({
+      msgtype: "m.text",
+      body: "TASK_COMPLETED",
+      "com.openclaw.self_trigger": { ...VALID_MARKER, type: "task_completed" },
+    });
+    expect(readSelfTriggerMarker(event, ROOM_ID)).toBeNull();
+  });
+
+  it("returns null when targetRoomId does not match roomId", () => {
+    const event = makeEvent({
+      msgtype: "m.text",
+      body: "PROJECT_REQUESTED",
+      "com.openclaw.self_trigger": {
+        ...VALID_MARKER,
+        targetRoomId: "!other-room:matrix.org",
+        targetSession: "matrix:!other-room:matrix.org",
+      },
+    });
+    expect(readSelfTriggerMarker(event, ROOM_ID)).toBeNull();
+  });
+
+  it("matches when targetSession (without matrix: prefix) equals roomId", () => {
+    const event = makeEvent({
+      msgtype: "m.text",
+      body: "PROJECT_REQUESTED",
+      "com.openclaw.self_trigger": {
+        ...VALID_MARKER,
+        targetRoomId: "",
+        targetSession: ROOM_ID,
+      },
+    });
+    expect(readSelfTriggerMarker(event, ROOM_ID)).not.toBeNull();
+  });
+
+  it("matches when targetSession has room: prefix", () => {
+    const event = makeEvent({
+      msgtype: "m.text",
+      body: "PROJECT_REQUESTED",
+      "com.openclaw.self_trigger": {
+        ...VALID_MARKER,
+        targetRoomId: "",
+        targetSession: `room:${ROOM_ID}`,
+      },
+    });
+    expect(readSelfTriggerMarker(event, ROOM_ID)).not.toBeNull();
+  });
+
+  it("returns null when event content is not an object", () => {
+    const event = makeEvent("not-an-object" as unknown as Record<string, unknown>);
+    expect(readSelfTriggerMarker(event, ROOM_ID)).toBeNull();
+  });
+
+  it("returns null when targetRoomId and targetSession are both empty", () => {
+    const event = makeEvent({
+      msgtype: "m.text",
+      body: "PROJECT_REQUESTED",
+      "com.openclaw.self_trigger": {
+        ...VALID_MARKER,
+        targetRoomId: "",
+        targetSession: "",
+      },
+    });
+    expect(readSelfTriggerMarker(event, ROOM_ID)).toBeNull();
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/handler-helpers.self-trigger.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-helpers.self-trigger.test.ts
@@ -127,4 +127,20 @@ describe("readSelfTriggerMarker", () => {
     });
     expect(readSelfTriggerMarker(event, ROOM_ID)).toBeNull();
   });
+
+  it("still parses a valid marker regardless of sender (sender binding is enforced at ingress prefix, not here)", () => {
+    // readSelfTriggerMarker is a pure content check; the sender === selfUserId
+    // binding is enforced in handler-ingress-prefix.ts, which only calls this
+    // function when senderId === selfUserId. This test documents that contract:
+    // the helper itself does not (and should not) filter by sender.
+    const event = makeEvent({
+      msgtype: "m.text",
+      body: "PROJECT_REQUESTED: build the API",
+      "com.openclaw.self_trigger": VALID_MARKER,
+    });
+    event.sender = "@attacker:matrix.org";
+    // The marker is still structurally valid — but the ingress prefix will
+    // never call readSelfTriggerMarker for @attacker because senderId !== selfUserId.
+    expect(readSelfTriggerMarker(event, ROOM_ID)).not.toBeNull();
+  });
 });

--- a/extensions/matrix/src/matrix/monitor/handler-helpers.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-helpers.ts
@@ -220,3 +220,56 @@ export function formatMatrixToolProgressMarkdownCode(text: string): string {
   const safe = clipped.replaceAll("`", "'");
   return `\`${safe}\``;
 }
+
+const SELF_TRIGGER_CONTENT_KEY = "com.openclaw.self_trigger";
+const SELF_TRIGGER_KIND = "self_cross_session";
+const SELF_TRIGGER_ALLOWED_TYPES = new Set(["project_requested"]);
+
+/**
+ * Reads and validates a self-trigger marker from a Matrix event.
+ *
+ * Self-trigger markers allow an agent to intentionally wake up its own session
+ * in another Matrix room. Without this marker, self-authored messages are
+ * unconditionally dropped in the ingress prefix to prevent self-reply loops.
+ *
+ * This function validates:
+ * - The marker is a well-formed object under the `com.openclaw.self_trigger` key
+ * - `kind` is `"self_cross_session"` (the only supported kind)
+ * - `type` is in the allowlist (initially just `"project_requested"`)
+ * - `targetRoomId` or `targetSession` matches the current `roomId`
+ *
+ * Returns the validated marker dict, or `null` if the event has no valid marker.
+ */
+export function readSelfTriggerMarker(
+  event: MatrixRawEvent,
+  roomId: string,
+): Record<string, unknown> | null {
+  const content = event.content;
+  if (!content || typeof content !== "object") {
+    return null;
+  }
+  const marker = content[SELF_TRIGGER_CONTENT_KEY];
+  if (!marker || typeof marker !== "object") {
+    return null;
+  }
+  const trigger = marker as Record<string, unknown>;
+  if (trigger.kind !== SELF_TRIGGER_KIND) {
+    return null;
+  }
+  const type = typeof trigger.type === "string" ? trigger.type : "";
+  if (!SELF_TRIGGER_ALLOWED_TYPES.has(type)) {
+    return null;
+  }
+  const targetRoomId = typeof trigger.targetRoomId === "string" ? trigger.targetRoomId.trim() : "";
+  let targetSession = typeof trigger.targetSession === "string" ? trigger.targetSession.trim() : "";
+  if (targetSession.startsWith("matrix:")) {
+    targetSession = targetSession.slice("matrix:".length);
+  }
+  if (targetSession.startsWith("room:")) {
+    targetSession = targetSession.slice("room:".length);
+  }
+  if (roomId !== targetRoomId && roomId !== targetSession) {
+    return null;
+  }
+  return trigger;
+}

--- a/extensions/matrix/src/matrix/monitor/handler-ingress-access.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-ingress-access.ts
@@ -19,6 +19,7 @@ export type MatrixIngressAccessParams = {
   isDirectMessage: boolean;
   locationPayload: MatrixLocationPayload | null;
   selfUserId: string;
+  selfTriggerMarker: Record<string, unknown> | null;
   reservedHistorySlot?: ReservedHistorySlot;
 };
 

--- a/extensions/matrix/src/matrix/monitor/handler-ingress-content.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-ingress-content.ts
@@ -8,6 +8,7 @@ import { fetchMatrixPollSnapshot, type MatrixPollSnapshot } from "../poll-summar
 import { resolveMatrixMonitorCommandAccess } from "./access-state.js";
 import {
   isMatrixAudioMediaEnabled,
+  readSelfTriggerMarker,
   resolveMatrixInboundBodyText,
   resolveMatrixInboundMediaContent,
   resolveMatrixMentionPrecheckText,
@@ -286,14 +287,20 @@ export async function resolveMatrixIngressContent(config: {
     await commitInboundEventIfClaimedAndDiscardReserved();
     return undefined;
   }
+  // Self-trigger messages bypass the mention requirement: they are intentional
+  // cross-session wake-ups, not casual messages that need @mention to justify a
+  // response. The marker was already validated in the ingress prefix stage.
+  const selfTriggerMarker = readSelfTriggerMarker(event, roomId);
   const shouldRequireMention = isRoom
-    ? roomConfig?.autoReply === true
+    ? selfTriggerMarker
       ? false
-      : roomConfig?.autoReply === false
-        ? true
-        : typeof roomConfig?.requireMention === "boolean"
-          ? roomConfig?.requireMention
-          : true
+      : roomConfig?.autoReply === true
+        ? false
+        : roomConfig?.autoReply === false
+          ? true
+          : typeof roomConfig?.requireMention === "boolean"
+            ? roomConfig?.requireMention
+            : true
     : false;
   const mentionDecision = resolveInboundMentionDecision({
     facts: {

--- a/extensions/matrix/src/matrix/monitor/handler-ingress-content.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-ingress-content.ts
@@ -8,7 +8,6 @@ import { fetchMatrixPollSnapshot, type MatrixPollSnapshot } from "../poll-summar
 import { resolveMatrixMonitorCommandAccess } from "./access-state.js";
 import {
   isMatrixAudioMediaEnabled,
-  readSelfTriggerMarker,
   resolveMatrixInboundBodyText,
   resolveMatrixInboundMediaContent,
   resolveMatrixMentionPrecheckText,
@@ -289,8 +288,10 @@ export async function resolveMatrixIngressContent(config: {
   }
   // Self-trigger messages bypass the mention requirement: they are intentional
   // cross-session wake-ups, not casual messages that need @mention to justify a
-  // response. The marker was already validated in the ingress prefix stage.
-  const selfTriggerMarker = readSelfTriggerMarker(event, roomId);
+  // response. The marker was already validated in the ingress prefix stage and
+  // is only set when senderId === selfUserId, so non-self senders cannot forge
+  // the exemption.
+  const { selfTriggerMarker } = paramsLocal;
   const shouldRequireMention = isRoom
     ? selfTriggerMarker
       ? false

--- a/extensions/matrix/src/matrix/monitor/handler-ingress-prefix.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-ingress-prefix.ts
@@ -1,5 +1,5 @@
 import type { LocationMessageEventContent } from "../sdk.js";
-import { hasBundledMatrixReplacementRelation } from "./handler-helpers.js";
+import { hasBundledMatrixReplacementRelation, readSelfTriggerMarker } from "./handler-helpers.js";
 import type { MatrixInboundEventDeduper } from "./inbound-dedupe.js";
 import { resolveMatrixLocation, type MatrixLocationPayload } from "./location.js";
 import type { MatrixRawEvent, RoomMessageEventContent } from "./types.js";
@@ -52,7 +52,12 @@ export async function readMatrixIngressPrefix(config: MatrixIngressPrefixConfig)
   } = config;
   const selfUserId = await client.getUserId();
   if (senderId === selfUserId) {
-    return undefined;
+    // Self-authored messages are dropped to prevent self-reply loops.
+    // Exception: messages carrying a valid self-trigger marker are allowed
+    // through, enabling cross-room session wake-up for multi-agent systems.
+    if (!readSelfTriggerMarker(event, roomId)) {
+      return undefined;
+    }
   }
   if (dropPreStartupMessages) {
     if (typeof eventTs === "number" && eventTs < startupMs - startupGraceMs) {

--- a/extensions/matrix/src/matrix/monitor/handler-ingress-prefix.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-ingress-prefix.ts
@@ -51,13 +51,12 @@ export async function readMatrixIngressPrefix(config: MatrixIngressPrefixConfig)
     claimInboundReplay,
   } = config;
   const selfUserId = await client.getUserId();
-  if (senderId === selfUserId) {
+  const selfTriggerMarker = senderId === selfUserId ? readSelfTriggerMarker(event, roomId) : null;
+  if (senderId === selfUserId && !selfTriggerMarker) {
     // Self-authored messages are dropped to prevent self-reply loops.
     // Exception: messages carrying a valid self-trigger marker are allowed
     // through, enabling cross-room session wake-up for multi-agent systems.
-    if (!readSelfTriggerMarker(event, roomId)) {
-      return undefined;
-    }
+    return undefined;
   }
   if (dropPreStartupMessages) {
     if (typeof eventTs === "number" && eventTs < startupMs - startupGraceMs) {
@@ -109,5 +108,5 @@ export async function readMatrixIngressPrefix(config: MatrixIngressPrefixConfig)
     senderId,
     selfUserId,
   });
-  return { content, isDirectMessage, locationPayload, selfUserId };
+  return { content, isDirectMessage, locationPayload, selfUserId, selfTriggerMarker };
 }

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -5302,5 +5302,86 @@ describe("matrix monitor handler block streaming config", () => {
 
     expect(capturedDisableBlockStreaming).toBe(disableBlockStreaming);
   });
+
+  describe("self-trigger markers", () => {
+    it("drops ordinary self-authored messages (no marker)", async () => {
+      const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
+        isDirectMessage: false,
+        groupAllowFrom: ["@bot:example.org"],
+      });
+
+      await handler(
+        "!room:example.org",
+        createMatrixTextMessageEvent({
+          eventId: "$self-echo",
+          sender: "@bot:example.org",
+          body: "hello from myself",
+        }),
+      );
+
+      expect(recordInboundSession).not.toHaveBeenCalled();
+    });
+
+    it("admits a self-authored message with a valid self-trigger marker", async () => {
+      const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
+        isDirectMessage: false,
+        groupAllowFrom: ["@bot:example.org"],
+      });
+
+      await handler(
+        "!room:example.org",
+        createMatrixRoomMessageEvent({
+          eventId: "$self-trigger",
+          sender: "@bot:example.org",
+          content: {
+            msgtype: "m.text",
+            body: "PROJECT_REQUESTED: build the API",
+            "com.openclaw.self_trigger": {
+              kind: "self_cross_session",
+              type: "project_requested",
+              sourceSession: "matrix:!dm:example.org",
+              targetRoomId: "!room:example.org",
+              targetSession: "matrix:!room:example.org",
+            },
+          },
+        }),
+      );
+
+      expect(recordInboundSession).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects a forged marker from a non-self sender (mention bypass denied)", async () => {
+      const { handler, recordInboundSession, finalizeInboundContext } =
+        createMatrixHandlerTestHarness({
+          isDirectMessage: false,
+          groupAllowFrom: ["@attacker:example.org"],
+          mentionRegexes: [],
+        });
+
+      await handler(
+        "!room:example.org",
+        createMatrixRoomMessageEvent({
+          eventId: "$forged-trigger",
+          sender: "@attacker:example.org",
+          content: {
+            msgtype: "m.text",
+            body: "PROJECT_REQUESTED: hijack",
+            "com.openclaw.self_trigger": {
+              kind: "self_cross_session",
+              type: "project_requested",
+              sourceSession: "matrix:!dm:example.org",
+              targetRoomId: "!room:example.org",
+              targetSession: "matrix:!room:example.org",
+            },
+          },
+        }),
+      );
+
+      // Non-self sender with a forged marker must NOT bypass requireMention.
+      // With no mention and no marker exemption, the message is skipped.
+      expect(recordInboundSession).not.toHaveBeenCalled();
+      expect(finalizeInboundContext).not.toHaveBeenCalled();
+    });
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -193,6 +193,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         locationPayload: MatrixLocationPayload | null;
         reservedHistorySlot?: ReservedHistorySlot;
         selfUserId: string;
+        selfTriggerMarker: Record<string, unknown> | null;
       }) => {
         const access = await resolveMatrixIngressAccess({
           handler: handlerConfig,


### PR DESCRIPTION
## What Problem This Solves

Multi-agent systems built on OpenClaw (such as AgentTeams) need a way for an agent to wake up another session of itself in a different Matrix room — without relying on @mentions.

In AgentTeams, an agent (such as a team Leader) may receive requests in a source session (DingTalk group, Matrix DM, or any non-task room). When the request qualifies as "Project Work", the Leader creates a task room and sends a PROJECT_REQUESTED message to that room to wake up its own session there. The message is sent by the Leader to itself — same Matrix user ID, cross-room.

OpenClaw's Matrix channel unconditionally drops all self-authored messages at the earliest ingress stage (handler-ingress-prefix.ts:54) to prevent self-reply loops. This is correct, but it also makes cross-room self-wake-up impossible.

@mention is not the right abstraction for this: it conflates "wake up my own session" with "being notified", cannot carry structured metadata (source session, reply route), and adds unnecessary coupling. OpenClaw's core cross-session mechanisms (sessions_send, subagents, A2A) don't cross Matrix room boundaries. No plugin hook fires before the own-message drop, so no plugin can solve this.

See #141064 for the full feature request discussion.

## Why This Change Was Made

This PR adds a com.openclaw.self_trigger content key that allows self-authored messages with a valid marker to conditionally pass through the own-message drop and bypass the requireMention check. This enables cross-room session wake-up for multi-agent systems.

Design:

- Marker-based: only messages with a valid com.openclaw.self_trigger marker pass through. Unmarked own-messages are still dropped — self-reply loop prevention is preserved.
- Validated: the marker must have kind "self_cross_session", type in an allowlist (initially just "project_requested"), and targetRoomId/targetSession matching the current room (prevents cross-room injection).
- Fail-closed: malformed, missing, or mismatched markers are treated as no marker (message dropped).
- Mention bypass: marked self-trigger messages skip the requireMention check, since they are intentional wake-ups, not casual messages.
- Additive content key: follows the existing com.openclaw.* convention (presentation, approval, finalized_preview), always with readable body fallback.

Prior art:
- WhatsApp selfChatMode — conditional self-message passthrough with echo detection and isSelf marking
- iMessage self-chat — is_from_me=true messages conditionally allowed through echo cache
- Existing com.openclaw.* content key convention for additive Matrix metadata

## User Impact

- Affected: Multi-agent frameworks (AgentTeams and similar) that need same-identity cross-room session wake-up on Matrix.
- Severity: Blocks workflow — without this, these frameworks cannot implement their core collaboration flow.
- Frequency: Every project work handoff requires a cross-room wake-up.
- Consequence: Frameworks must use fragile @mention workarounds, maintain custom Matrix channel forks, or abandon the cross-room session pattern.
- Default behavior unchanged: unmarked own-messages are still dropped. No breaking changes, no impact on other channels, no impact on self-reply loop prevention.

## Evidence

- Unit tests: 10 new test cases in handler-helpers.self-trigger.test.ts covering: valid marker, missing marker, non-object marker, wrong kind, wrong type, mismatched roomId, session prefix variants, empty fields.
- Extension test suite: pnpm test:extension matrix — 35 test files, 598 tests, all passed.
- Import boundary: check-src-extension-import-boundary.mts — no violations.
- Contract tests: pnpm test:contracts:channels — pre-existing failures on main (same plugin-shape.contract.test.ts failures visible on both main and this branch). No new failures introduced.

Test output:

  pnpm test:extension matrix
  Test Files  35 passed (35)
  Tests  598 passed (598)

  npx vitest run handler-helpers.self-trigger.test.ts
  Test Files  1 passed (1)
  Tests  10 passed (10)

## Changes

- handler-helpers.ts — new readSelfTriggerMarker() function (~45 lines) that reads and validates the com.openclaw.self_trigger content key
- handler-ingress-prefix.ts — own-message drop now checks for a valid self-trigger marker before dropping (+6 lines)
- handler-ingress-content.ts — shouldRequireMention now returns false for messages with a valid self-trigger marker (+5 lines)
- handler-helpers.self-trigger.test.ts — 10 unit tests (+130 lines)

Total: 4 files changed, +203 lines, -8 lines.

Closes #141064