### PR TITLE
refactor(agents): share transcript input repair paths

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1920,7 +1920,7 @@ src/agents/session-placement-admission.ts	1
 src/agents/session-raw-append-message.ts	2
 src/agents/session-suspension.ts	1
 src/agents/session-tool-result-guard.ts	23
-src/agents/session-transcript-repair.ts	14
+src/agents/session-transcript-repair.ts	7
 src/agents/sessions/agent-session-base.ts	3
 src/agents/sessions/agent-session-extensions.ts	1
 src/agents/sessions/agent-session-models.ts	2

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -8,7 +8,6 @@ import { replaceCompactionReplayOwnerContent } from "@openclaw/ai/transports";
 import { safeParseJsonRecord } from "@openclaw/normalization-core";
 import {
   hasNonEmptyString as hasNonEmptyStringField,
-  normalizeLowercaseStringOrEmpty,
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
 import {
@@ -307,7 +306,6 @@ function repairToolCallInputs(
     }
 
     const nextContent: typeof msg.content = [];
-    let droppedInMessage = 0;
     let messageChanged = false;
 
     for (const block of msg.content) {
@@ -319,7 +317,6 @@ function repairToolCallInputs(
           !isAllowedToolCallName((block as RawToolCallBlock).name, allowedToolNames)
         ) {
           droppedToolCalls += 1;
-          droppedInMessage += 1;
           changed = true;
           messageChanged = true;
           continue;
@@ -329,7 +326,6 @@ function repairToolCallInputs(
       if (isRawToolCallBlock(block) && hasPartialJson(block)) {
         if (!isFinalizedOpenAIResponsesToolCall(msg, block)) {
           droppedToolCalls += 1;
-          droppedInMessage += 1;
           changed = true;
           messageChanged = true;
           continue;
@@ -345,55 +341,22 @@ function repairToolCallInputs(
         messageChanged = true;
       }
       if (isRawToolCallBlock(workBlock)) {
-        if (RAW_TOOL_CALL_BLOCK_TYPES.has((workBlock as { type?: string }).type ?? "")) {
-          // Only sanitize (redact) sessions_spawn blocks; all others are passed through
-          // unchanged to preserve provider-specific shapes (e.g. toolUse.input for Anthropic).
-          const blockName =
-            typeof (workBlock as { name?: unknown }).name === "string"
-              ? (workBlock as { name: string }).name.trim()
-              : undefined;
-          if (normalizeLowercaseStringOrEmpty(blockName) === "sessions_spawn") {
-            const sanitized = sanitizeToolCallBlock(workBlock);
-            if (sanitized !== workBlock) {
-              changed = true;
-              messageChanged = true;
-            }
-            nextContent.push(sanitized as typeof block);
-          } else if (typeof (workBlock as { name?: unknown }).name === "string") {
-            const rawName = (workBlock as { name: string }).name;
-            const trimmedName = rawName.trim();
-            if (rawName !== trimmedName && trimmedName) {
-              const renamed = { ...(workBlock as object), name: trimmedName } as typeof block;
-              nextContent.push(renamed);
-              changed = true;
-              messageChanged = true;
-            } else {
-              nextContent.push(workBlock);
-            }
-          } else {
-            nextContent.push(workBlock);
-          }
-          continue;
+        const sanitized = sanitizeToolCallBlock(workBlock);
+        if (sanitized !== workBlock) {
+          changed = true;
+          messageChanged = true;
         }
+        nextContent.push(sanitized as typeof block);
+        continue;
       }
       nextContent.push(workBlock);
     }
 
-    if (droppedInMessage > 0) {
+    if (messageChanged) {
       if (nextContent.length === 0) {
         droppedAssistantMessages += 1;
-        changed = true;
         continue;
       }
-      const nextMessage = replaceCompactionReplayOwnerContent(msg, nextContent);
-      for (const toolCall of extractToolCallsFromAssistant(nextMessage)) {
-        priorToolCallIds.add(toolCall.id);
-      }
-      out.push(nextMessage);
-      continue;
-    }
-
-    if (messageChanged) {
       const nextMessage = replaceCompactionReplayOwnerContent(msg, nextContent);
       for (const toolCall of extractToolCallsFromAssistant(nextMessage)) {
         priorToolCallIds.add(toolCall.id);


### PR DESCRIPTION
## What Problem This Solves

Transcript input repair maintains separate tool-name normalization and changed-message reconstruction paths that now implement the same behavior. Updating one copy without the other could make replay repair depend on which path a tool call takes.

## Why This Change Was Made

Use the existing payload-preserving sanitizer for every admitted tool call, then reconstruct every changed message through the existing compaction replay owner. Remove the redundant per-message dropped-call counter and shrink the matching assertion baseline from 14 to 7. This removes 34 production code lines (37 physical lines) without moving the responsibility elsewhere.

## User Impact

No intended behavior change. Repair continues to preserve tool arguments and attachment shapes, case, current and legacy IDs, signed-thinking policy, replay checkpoint metadata, and unchanged-message identity.

## Evidence

All 99 existing transcript/attachment and canonical replay-owner tests passed before and after the change. All 29 stages of the repository-selected changed-file gate passed, including typechecks, lint, dead-export scans and policy guards. The initial gate correctly required the included assertion baseline shrink. Independent Codex review of the final two-file candidate was clean through P2. Tests are unchanged; no live-provider or separate package-build result is claimed for this local reducer consolidation.
