### PR TITLE
refactor(image): share prepared request options

### DIFF
--- a/extensions/microsoft-foundry/image-generation-provider.ts
+++ b/extensions/microsoft-foundry/image-generation-provider.ts
@@ -327,43 +327,37 @@ export function buildMicrosoftFoundryImageGenerationProvider(): ImageGenerationP
         defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
       });
 
+      const requestOptions = {
+        url: buildMaiImageUrl(baseUrl, mode),
+        headers: new Headers(headers),
+        timeoutMs,
+        fetchFn: fetch,
+        allowPrivateNetwork,
+        ssrfPolicy: req.ssrfPolicy,
+        dispatcherPolicy,
+      };
+      if (mode === "edits") {
+        requestOptions.headers.delete("Content-Type");
+      } else {
+        requestOptions.headers.set("Content-Type", "application/json");
+      }
       const request =
         mode === "edits"
           ? postMultipartRequest({
-              url: buildMaiImageUrl(baseUrl, mode),
-              headers: (() => {
-                const multipartHeaders = new Headers(headers);
-                multipartHeaders.delete("Content-Type");
-                return multipartHeaders;
-              })(),
+              ...requestOptions,
               body: buildEditFormData({
                 req,
                 image: expectDefined(inputImages[0], "Microsoft Foundry edit source image"),
                 model,
               }),
-              timeoutMs,
-              fetchFn: fetch,
-              allowPrivateNetwork,
-              ssrfPolicy: req.ssrfPolicy,
-              dispatcherPolicy,
             })
           : postJsonRequest({
-              url: buildMaiImageUrl(baseUrl, mode),
-              headers: (() => {
-                const jsonHeaders = new Headers(headers);
-                jsonHeaders.set("Content-Type", "application/json");
-                return jsonHeaders;
-              })(),
+              ...requestOptions,
               body: {
                 model,
                 prompt: req.prompt,
                 ...resolveMaiImageSize(req.size),
               },
-              timeoutMs,
-              fetchFn: fetch,
-              allowPrivateNetwork,
-              ssrfPolicy: req.ssrfPolicy,
-              dispatcherPolicy,
             });
 
       const { response, release } = await request;

--- a/src/image-generation/openai-compatible-image-provider.ts
+++ b/src/image-generation/openai-compatible-image-provider.ts
@@ -241,36 +241,24 @@ export function createOpenAiCompatibleImageGenerationProvider(
       const timeoutMs = resolveRequestTimeoutMs({ options, req, mode });
       // Multipart requests must let FormData set its own boundary header, while
       // JSON requests need an explicit content type after configured headers.
+      const requestOptions = {
+        url: appendImagesPath(baseUrl, mode),
+        headers: new Headers(headers),
+        timeoutMs,
+        fetchFn: fetch,
+        allowPrivateNetwork: resolvedAllowPrivateNetwork,
+        ssrfPolicy: req.ssrfPolicy,
+        dispatcherPolicy,
+      };
+      if (requestBody.kind === "multipart") {
+        requestOptions.headers.delete("Content-Type");
+      } else {
+        requestOptions.headers.set("Content-Type", "application/json");
+      }
       const request =
         requestBody.kind === "multipart"
-          ? postMultipartRequest({
-              url: appendImagesPath(baseUrl, mode),
-              headers: (() => {
-                const multipartHeaders = new Headers(headers);
-                multipartHeaders.delete("Content-Type");
-                return multipartHeaders;
-              })(),
-              body: requestBody.form,
-              timeoutMs,
-              fetchFn: fetch,
-              allowPrivateNetwork: resolvedAllowPrivateNetwork,
-              ssrfPolicy: req.ssrfPolicy,
-              dispatcherPolicy,
-            })
-          : postJsonRequest({
-              url: appendImagesPath(baseUrl, mode),
-              headers: (() => {
-                const jsonHeaders = new Headers(headers);
-                jsonHeaders.set("Content-Type", "application/json");
-                return jsonHeaders;
-              })(),
-              body: requestBody.body,
-              timeoutMs,
-              fetchFn: fetch,
-              allowPrivateNetwork: resolvedAllowPrivateNetwork,
-              ssrfPolicy: req.ssrfPolicy,
-              dispatcherPolicy,
-            });
+          ? postMultipartRequest({ ...requestOptions, body: requestBody.form })
+          : postJsonRequest({ ...requestOptions, body: requestBody.body });
 
       const { response, release } = await request;
       try {


### PR DESCRIPTION
## What Problem This Solves

The compatible image factory and Microsoft Foundry repeated URL, header and request-policy setup in their multipart and JSON branches. This obscured the boundary between provider preparation and shared execution.

## Why This Change Was Made

Peter Steinberger explicitly requested this bounded work as item 6 of the media de-duplication campaign. The broader API choice below remains reserved for maintainer decision.

Each implementation now prepares common request options once, cloning headers and applying the existing multipart/JSON content-type rule before dispatch. The factory still selects serialization from the body kind, including JSON edits. Foundry still selects its existing mode. Response budgets, parsing, filenames and awaited release are unchanged.

Production net -18 lines, tests unchanged. OpenAI's implementation and the separate subscription changes in #140413 and #140357 are untouched.

## User Impact

No intentional request, auth, result, configuration or SDK change.

## Deferred API choice (maintainer)

The maintainer approved landing this bounded precursor independently; the broader API design below remains deferred.

The complete prepared-request executor requires a new public image-generation SDK seam. The existing factory owns API-key lookup, Bearer headers, a default model and fixed endpoint paths; it cannot absorb prepared Foundry API-key/Entra auth or OpenAI Azure deployment URLs unchanged. The approved executor must preserve body-kind dispatch, prepared SSRF/dispatcher policy, provider-specific JSON caps, differing MIME/filename policies, release around validation/projection, and OpenAI's lazy direct-REST loading boundary.

This bounded PR is only the local request-preparation precursor; it does not claim a shared executor across the three providers. No new SDK parameter or export is introduced.

## Evidence

- Fresh rebase verification: `node scripts/run-vitest.mjs src/image-generation/openai-compatible-image-provider.test.ts extensions/microsoft-foundry/image-generation-provider.test.ts extensions/deepinfra/image-generation-provider.test.ts extensions/litellm/image-generation-provider.test.ts extensions/xai/image-generation-provider.test.ts` — 5 files, 48 tests passed.
- Fresh independent Codex autoreview: scoped-clean through P2, zero actionable findings. `git diff --check` passed.
- `node scripts/check-changed.mjs` — 24 checks passed, including all four typecheck lanes and core lint. Extension lint preparation hit the documented nested-worktree `Declaration input escapes checkout` through ancestor `node_modules/punycode/package.json`; no ancestor install, guard or baseline was changed.
- Standalone build retry: `node scripts/crabbox-wrapper.mjs run --timing-json -- pnpm build` — provider `blacksmith-testbox`, lease `tbx_01m1xrn495qcvw6ttj8mdj5qn5`, [run 34114718751](https://github.com/openclaw/openclaw/actions/runs/34114718751), wrapper exit 0. Build phases completed in 4m16s; delegated command including preparation took 7m43s. Declarations, all 152 public SDK subpaths, plugin distributions and Control UI budgets passed. The one-shot lease was stopped and independently verified completed. Its Actions session may show cancellation after delegated cleanup; the command result is exit 0. This successful single retry resolves the prior dispatch HTTP 500.
- Exact-head [CI run 34114038942](https://github.com/openclaw/openclaw/actions/runs/34114038942) passed on `6dbaa08b518eabe3e594769d508b6b9f2575e174`. Native review artifacts validated, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 141119` passed using hosted evidence without changing that head.
- No live provider-generation claim. Live validation of a future shared executor remains deferred with its SDK design.
