### PR TITLE
fix(tui): restore channel diagnostics in gateway status

### DIFF
--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -109,7 +109,7 @@ Core:
 
 - `/help`
 - `/status` (Gateway-forwarded; shows session/model summary)
-- `/gateway-status` (alias `/gwstatus`; shows Gateway connection status directly)
+- `/gateway-status` (alias `/gwstatus`; shows Gateway version, channel configuration summaries, and sessions directly)
 - `/agent <id>` (or `/agents`)
 - `/session <key>` (or `/sessions`)
 - `/model <provider/model|default>` (or `/models`; `default` clears the session override)

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -1144,6 +1144,7 @@ describe("tui command handlers", () => {
     const { handleCommand, getGatewayStatus, addSystem, addUser, sendChat } = createHarness({
       getGatewayStatus: vi.fn().mockResolvedValue({
         runtimeVersion: "1.2.3",
+        channelSummary: ["Telegram: not configured"],
         sessions: { count: 2, defaults: { model: "gpt-5.4", contextTokens: 200000 } },
       }),
     });
@@ -1155,6 +1156,7 @@ describe("tui command handlers", () => {
     expect(sendChat).not.toHaveBeenCalled();
     expect(addSystem).toHaveBeenCalledWith("Gateway status");
     expect(addSystem).toHaveBeenCalledWith("Version: 1.2.3");
+    expect(addSystem).toHaveBeenCalledWith("  Telegram: not configured");
   });
 
   it("returns to OpenClaw with an optional request", async () => {

--- a/src/tui/tui-status-summary.ts
+++ b/src/tui/tui-status-summary.ts
@@ -24,11 +24,11 @@ export function formatStatusSummary(summary: GatewayStatusSummary) {
     lines.push(`${linkLabel}: ${linked ? "linked" : "not linked"}${authAge}`);
   }
 
-  const providerSummary = Array.isArray(summary.providerSummary) ? summary.providerSummary : [];
-  if (providerSummary.length > 0) {
+  const channelSummary = Array.isArray(summary.channelSummary) ? summary.channelSummary : [];
+  if (channelSummary.length > 0) {
     lines.push("");
     lines.push("System:");
-    for (const line of providerSummary) {
+    for (const line of channelSummary) {
       lines.push(`  ${line}`);
     }
   }

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -161,7 +161,7 @@ export type GatewayStatusSummary = {
       everyMs?: number | null;
     }>;
   };
-  providerSummary?: string[];
+  channelSummary?: string[];
   queuedSystemEvents?: string[];
   sessions?: {
     paths?: string[];


### PR DESCRIPTION
Closes #141111

<details>
<summary>Additional instructions</summary>

This PR uses a branch in openclaw/openclaw, editable through repository permissions.

</details>

## What Problem This Solves

Fixes an issue where users running `/gateway-status` or `/gwstatus` saw version and session information while channel/account configuration summaries were silently absent.

## Why This Change Was Made

The Gateway returns these rows as `channelSummary`; the TUI formatter and its local payload type still used `providerSummary`. Aligning that projection restores both commands through their shared formatter and preserves the embedded backend's string response.

## User Impact

Operators can inspect the channel/account summaries returned by their Gateway directly in the TUI. The command reference now describes that output.

## Evidence

- Original handler regression: **1 intended failure, 224 passing controls**. Original fixed handler/command coverage: **266/266**. Rebased head `f11654086845b95bd3d751490f7d1fbc15e9ec3f`: **269/269 passing**, including three additional upstream picker cases.
- Full four-file changed check passed (**1012.522s**), with unchanged source hashes. Managed P0–P2 review completed scoped-clean; the final TUI patch is unchanged by rebase (`git range-diff` equal).
- Normal builds passed (**652.455s before; 448.049s after**) with complete source, generated-output, dependency and runtime-file verification.
- Real isolated Gateway and native TUI: three independent status calls per run returned `Telegram: not configured`, and non-probing snapshots confirmed the synthetic account was enabled, unconfigured and stopped. Both real commands omitted the row before and displayed it after. The inspected screenshots show the complete diagnostic blocks.

Both TUI runs exited normally; session/runtime/credential cleanup, process and port absence, and final source/build checks passed. No conversation or model turn was submitted. Telegram delivery and model inference were outside this diagnostic flow.

Build/live evidence is bound to the unchanged TUI patch at original commit `9c2039b1f6208e918233545cf1814e3c3e16582d`. On the refreshed base, only picker-selection handling changed in the shared command handler; the diagnostic branch, formatter, status producer and Gateway transport remain unchanged. The lockfile's only dependency delta adds the existing fs-safe0.8.3 package to OpenShell. Frozen installation and focused tests passed after rebase; no whole-rebased-tree live claim is made. The field mismatch also exists in stable `v2026.9.2` source.

CI run `34108436966` failed extension lint because its synthetic merge incorporated main's oversized Telegram test. A separately validated test-only repair was briefly included, then removed when main landed #141139 and #141148. The final PR contains only the four-file TUI fix, rebased onto `0015b209956c8c121222eaad906677f7581728cb`, with exact-head CI now green (run 34114679844, attempt 2: 108 successful jobs, 16 intentional skips).

Production: **+4/−4, net zero**. Tests: **+2**. Docs: **one line updated**. Empty/absent and multi-row handling retain their existing control flow; no separate live embedded-mode or multi-channel claim is made.

![Before: channel diagnostics omitted](https://github.com/user-attachments/assets/e21f4dd6-f4d4-4623-b236-51905b9a88f5)
![After: channel diagnostics visible](https://github.com/user-attachments/assets/2e7da6ba-8507-4da8-bdcc-f8733e97e996)

The first attempt of run `34114679844` failed the unchanged message-plugin cleanup process shard and its derived gate. Source inspection found identical immediate owner/test/config files on the PR and CI merge base. The five-case real-process suite passed locally on unchanged `f11654086845b95bd3d751490f7d1fbc15e9ec3f` (87.027s total; stalled-hook case 10.836s). One failed-job retry passed the affected Linux shard (69 passing tests, 5 platform skips; stalled-hook case 9.007s) and the required aggregate gate. Both failure and recovery are retained; no source workaround or timeout change was added.
