### PR TITLE
improve: reduce overhead when parsing images in replies

### DIFF
--- a/packages/markdown-core/src/image-spans.test.ts
+++ b/packages/markdown-core/src/image-spans.test.ts
@@ -1,0 +1,18 @@
+import { expect, it } from "vitest";
+import { findMarkdownImageSpans } from "./image-spans.js";
+
+it("keeps image offsets, references and output arrays local across successive documents", () => {
+  const first =
+    "A\r\n![one](a.png)\r\n\r\n![![nested](ignored.png)][shared]\r\n\r\n[shared]: a-ref.png";
+  const second = "> ![![nested](b.png)][shared]";
+  const expectedFirst = [{ start: 3, end: 16, destination: "a.png" }];
+  const expectedSecond = [{ start: 4, end: 20, destination: "b.png" }];
+
+  const firstImages = findMarkdownImageSpans(first);
+  const secondImages = findMarkdownImageSpans(second);
+  expect(firstImages).toEqual(expectedFirst);
+  expect(secondImages).toEqual(expectedSecond);
+
+  expect(findMarkdownImageSpans(first)).toEqual(expectedFirst);
+  expect(secondImages).toEqual(expectedSecond);
+});

--- a/packages/markdown-core/src/image-spans.ts
+++ b/packages/markdown-core/src/image-spans.ts
@@ -1,5 +1,5 @@
 import { expectDefined } from "@openclaw/normalization-core";
-import MarkdownIt from "markdown-it";
+import MarkdownIt, { type MarkdownIt as MarkdownItParser, type StateInline } from "markdown-it";
 
 export type MarkdownImageSpan = {
   start: number;
@@ -7,8 +7,13 @@ export type MarkdownImageSpan = {
   destination: string;
 };
 
-/** Finds inline image destinations without treating code or escaped syntax as media. */
-export function findMarkdownImageSpans(markdown: string): MarkdownImageSpan[] {
+type ImageScanEnvironment = {
+  onImage: (state: StateInline, start: number) => void;
+};
+
+let imageParser: MarkdownItParser | undefined;
+
+function createImageParser(): MarkdownItParser {
   const md = new MarkdownIt("commonmark");
   md.inline.ruler.enableOnly(["image"]);
   const parseImage = expectDefined(md.inline.ruler.getRules("")[0], "Markdown image rule");
@@ -18,15 +23,23 @@ export function findMarkdownImageSpans(markdown: string): MarkdownImageSpan[] {
   // Media normalization owns URL spelling and allowlist matching, not the renderer.
   md.normalizeLink = (url) => url;
   md.validateLink = () => true;
-  const environment = {};
-  const blocks = md.parse(markdown, environment);
-  const lineOffsets = [0];
-  // Block maps count CRLF and bare CR as line breaks before source normalization.
-  for (const newline of markdown.matchAll(/\r\n?|\n/g)) {
-    lineOffsets.push(newline.index + newline[0].length);
-  }
-  const sourceLines = markdown.replace(/\0/g, "\uFFFD").split(/\r\n?|\n/);
+  md.inline.ruler.at("image", (state, silent) => {
+    const start = state.pos;
+    const matched = parseImage(state, silent);
+    if (matched && !silent) {
+      // The shared rule retains parser configuration, never document state.
+      // SAFETY: Every parse below supplies a fresh ImageScanEnvironment.
+      const environment = state.env as ImageScanEnvironment;
+      environment.onImage(state, start);
+    }
+    return matched;
+  });
+  return md;
+}
 
+/** Finds inline image destinations without treating code or escaped syntax as media. */
+export function findMarkdownImageSpans(markdown: string): MarkdownImageSpan[] {
+  const md = (imageParser ??= createImageParser());
   const images: MarkdownImageSpan[] = [];
   let source = "";
   let inlineLines: Array<{ start: number; offset: number }> = [];
@@ -41,23 +54,30 @@ export function findMarkdownImageSpans(markdown: string): MarkdownImageSpan[] {
     }
     return position + expectDefined(inlineLines[inlineLine], "Markdown inline line").offset;
   };
-  md.inline.ruler.at("image", (state, silent) => {
-    const start = state.pos;
-    const matched = parseImage(state, silent);
-    // Image labels recurse into the inline parser; only the outer source owns offsets.
-    if (matched && !silent && state.src === source) {
+  const environment: ImageScanEnvironment = {
+    onImage: (state, start) => {
+      // Image labels recurse into the inline parser; only the outer source owns offsets.
+      if (state.src !== source) {
+        return;
+      }
       const token = expectDefined(state.tokens.at(-1), "Parsed Markdown image");
       if (token.meta?.label) {
-        return matched;
+        return;
       }
       images.push({
         start: sourceOffset(start),
         end: sourceOffset(state.pos),
         destination: String(expectDefined(token.attrGet("src"), "Markdown image destination")),
       });
-    }
-    return matched;
-  });
+    },
+  };
+  const blocks = md.parse(markdown, environment);
+  const lineOffsets = [0];
+  // Block maps count CRLF and bare CR as line breaks before source normalization.
+  for (const newline of markdown.matchAll(/\r\n?|\n/g)) {
+    lineOffsets.push(newline.index + newline[0].length);
+  }
+  const sourceLines = markdown.replace(/\0/g, "\uFFFD").split(/\r\n?|\n/);
   // Parse the same inline content as the renderer. Reintroducing container
   // markers can change inline HTML/code semantics and hide valid images.
   for (const block of blocks) {


### PR DESCRIPTION
## What Problem This Solves

Repeated replies containing Markdown images incur avoidable parsing work, particularly when processing many short messages. This is a performance cleanup; no broken image-extraction behavior is claimed.

## Why This Change Was Made

Prepare the private MarkdownIt configuration lazily once, while keeping the reference environment, source offsets, collector, and result array local to each document. The cached rule retains no document callback. Remove the repeated configuration path without changing image eligibility, URL spelling, reference handling, or media policy.

Production delta is +20 lines; the added boundary separates reusable parser configuration from ephemeral document state. The preservation test adds 18 lines and no production testing seam.

## User Impact

Image parsing does less repeated setup while preserving extracted attachments and visible text. The direct one-image scanner improves 26.35–49.63% in this fixture, but the complete media-split one-image case is mixed (+6.04% / -8.58%). Larger composed cases improve only 0.16–2.00%; those gains remain useful alongside the larger short-message and syntax-control improvements. This is not a claim of an overall Gateway or model-response speedup.

## Evidence

- The new A/B/A document-isolation test passes on the original scanner. It covers distinct reference environments, offsets, and earlier returned arrays remaining unchanged.
- Candidate: 128/128 tests in the complete image-span and media-parse files; 28/28 normal changed checks; independent managed P0–P2 review found no actionable issues.
- One initial normal check rejected the location of a safety comment. The comment was moved directly above its assertion; the fresh full check passed. No guard was weakened.
- Fixed B0/C0/C1/B1, Node 26.8.1 and installed MarkdownIt 15.0.1, using actual `findMarkdownImageSpans` and `splitMediaFromOutput`. All 7,632 calls across 6,784 operations match the frozen full-output fixtures, including every first call and warmup. An independent saved-data audit checked the complete graphs, A/B/A witnesses, arithmetic, source/dependency hashes, and process closure.
- No external image fetch, channel delivery, or Gateway turn is measured here. The broader campaign's separate live OpenAI Gateway baseline is not substituted for parser evidence.

The unchanged composed owner retains its line-length and per-line match limits. Numeric fixtures use separate lines for the 256 images and do not claim to exercise those thresholds; the full existing media tests remain intact.

<details>
<summary>All paired batch medians and tradeoffs</summary>

Microseconds per operation; negative percentages are faster. A/B/A is a three-document operation. Each value is the median of 12 four-operation sample means. Only the first direct-empty operation can include the initial lazy parser creation; composed mode follows the direct roster. Capture and assertions are outside the timed intervals but can influence later scheduling or garbage collection.

| Mode / case | Forward baseline → candidate µs (change) | Reverse baseline → candidate µs (change) |
| --- | ---: | ---: |
| direct/01-empty | 12.526 → 1.797 (-85.653%) | 12.125 → 1.839 (-84.837%) |
| direct/02-plain | 25.630 → 9.250 (-63.910%) | 17.344 → 11.912 (-31.322%) |
| direct/03-one | 24.599 → 12.391 (-49.629%) | 28.599 → 21.062 (-26.352%) |
| direct/04-many32 | 70.286 → 71.927 (+2.334%) | 77.292 → 69.531 (-10.041%) |
| direct/05-many256 | 401.771 → 366.870 (-8.687%) | 370.406 → 365.672 (-1.278%) |
| direct/06-code | 14.432 → 5.068 (-64.885%) | 11.224 → 4.995 (-55.497%) |
| direct/07-escaped | 12.781 → 7.057 (-44.783%) | 12.880 → 7.635 (-40.719%) |
| direct/08-defined-reference | 14.760 → 9.323 (-36.838%) | 18.192 → 10.130 (-44.317%) |
| direct/09-undefined-reference | 17.203 → 11.761 (-31.636%) | 18.656 → 11.818 (-36.655%) |
| direct/10-blockquote | 13.375 → 7.386 (-44.780%) | 13.724 → 6.963 (-49.260%) |
| direct/11-crlf | 13.974 → 8.255 (-40.924%) | 11.646 → 5.995 (-48.523%) |
| direct/12-cr | 13.828 → 6.208 (-55.105%) | 9.708 → 5.599 (-42.326%) |
| direct/13-punctuation | 13.583 → 6.021 (-55.675%) | 10.057 → 5.844 (-41.895%) |
| direct/14-title | 13.594 → 7.651 (-43.717%) | 9.724 → 5.682 (-41.565%) |
| direct/15-long-prefix | 76.375 → 63.187 (-17.267%) | 83.412 → 68.792 (-17.527%) |
| direct/16-a-b-a | 47.667 → 35.907 (-24.672%) | 56.568 → 32.688 (-42.215%) |
| composed/01-empty | 0.666 → 0.776 (+16.448%) | 0.641 → 0.703 (+9.754%) |
| composed/02-plain | 1.417 → 1.474 (+4.042%) | 1.599 → 1.276 (-20.192%) |
| composed/03-one | 35.448 → 37.589 (+6.039%) | 40.734 → 37.240 (-8.579%) |
| composed/04-many32 | 852.890 → 843.172 (-1.139%) | 861.281 → 859.880 (-0.163%) |
| composed/05-many256 | 7391.948 → 7273.485 (-1.603%) | 7470.151 → 7321.078 (-1.996%) |
| composed/06-code | 67.281 → 47.547 (-29.332%) | 62.260 → 50.953 (-18.162%) |
| composed/07-escaped | 13.250 → 9.818 (-25.903%) | 11.391 → 9.562 (-16.051%) |
| composed/08-defined-reference | 15.432 → 11.719 (-24.063%) | 15.567 → 10.396 (-33.220%) |
| composed/09-undefined-reference | 43.068 → 38.297 (-11.078%) | 43.364 → 38.666 (-10.834%) |
| composed/10-blockquote | 40.760 → 38.026 (-6.709%) | 41.114 → 37.271 (-9.349%) |
| composed/11-crlf | 39.614 → 36.130 (-8.796%) | 39.813 → 36.141 (-9.223%) |
| composed/12-cr | 40.833 → 35.417 (-13.265%) | 39.188 → 37.974 (-3.097%) |
| composed/13-punctuation | 41.005 → 35.578 (-13.236%) | 39.417 → 36.463 (-7.492%) |
| composed/14-title | 42.448 → 34.839 (-17.926%) | 40.000 → 35.927 (-10.183%) |
| composed/15-long-prefix | 127.479 → 116.776 (-8.396%) | 125.740 → 117.042 (-6.917%) |
| composed/16-a-b-a | 137.797 → 129.151 (-6.274%) | 141.438 → 130.297 (-7.877%) |

59/64 medians improve. All five adverse medians are retained: direct 32-image forward +2.334%; composed empty +16.448%/+9.754% (110/63 ns); composed plain forward +4.042% (57 ns); composed one-image forward +6.039% (2.141 µs). Empty/plain composed calls bypass the scanner, so their differences cannot independently establish a scanner-attributed effect.

Across first/warmup/sample summaries, 94/512 labelled aggregate comparisons and 580/3,816 indexed call comparisons are adverse. The nearest-rank P95 over 12 means equals the maximum and is included as a duplicate label, not a population-tail estimate. All original observations remain retained; no favorable rerun or traffic-weighted generalization.

Whole-child wall: 1.011590 → 0.938341 s forward, 0.956106 → 0.935377 s reverse (-7.241%/-2.168%). User/system CPU decrease in both orders. Kernel peak RSS decreases by 3,473,408/2,850,816 bytes, while sampled tree RSS increases by 1,605,632 bytes forward (+0.868%) and decreases by 3,358,720 bytes reverse. These scopes differ and do not establish an allocation or retained-memory benefit.

Source: baseline `2251d4f9b124f450bc67067bad0e09a8b701262364c55d7cecd4414ffd72d95d`; candidate `4ac9b70e8824b494d255858f98c5fefe28f38f4d8367007cc89c3bb80a8eb450`.

</details>
