### PR TITLE
fix(reef): keep parked messages recoverable across live frames

### DIFF
--- a/docs/channels/reef.md
+++ b/docs/channels/reef.md
@@ -151,7 +151,7 @@ Reef runs a fail-closed classifier at both ends: outbound DLP before encryption,
 
 These review commands use the same explicit owner check described in [Adding a friend](#adding-a-friend). If no chat sender is configured as an owner, add the intended owner to `commands.ownerAllowFrom` before deciding a review.
 
-The recorded verdict owns the message until you decide: a parked inbound message waits at the relay without re-classification, an approval delivers it within about 30 seconds (after one final guard check), and a denial returns a rejection receipt to the peer. Parked outbound sends stay local; after approval, resend the identical message.
+The recorded verdict owns the message until you decide: a parked inbound message waits at the relay without re-classification, an approval delivers it within about 30 seconds (after one final guard check), and a denial returns a rejection receipt to the peer. Later messages and receipts continue processing without moving the recovery cursor past the parked message. It remains eligible for retry while retained by the relay, including after a socket reconnect. Parked outbound sends stay local; after approval, resend the identical message.
 
 Deterministic checks (size, UTF-8, destination pin, secret patterns) run before any model call and cannot be overridden.
 

--- a/extensions/reef/src/transport-inbox.test.ts
+++ b/extensions/reef/src/transport-inbox.test.ts
@@ -109,6 +109,76 @@ describe("ReefInboxConnection recovery", () => {
     expect(persisted).toEqual([8, 9, 10]);
   });
 
+  it("retries a parked live entry after a later separate frame completes", async () => {
+    vi.useFakeTimers();
+    const socket = new ControlledSocket();
+    const retainedEntries: ReturnType<typeof receiptEntry>[] = [];
+    const requestedAfter: number[] = [];
+    const persisted: number[] = [];
+    const attempts: number[] = [];
+    const completed: number[] = [];
+    let parked = true;
+    const client = createClient(async (input) => {
+      const after = Number(parseRequestUrl(input).searchParams.get("after"));
+      requestedAfter.push(after);
+      const entries = retainedEntries.filter((entry) => entry.seq > after);
+      return Response.json({ entries, cursor: entries.at(-1)?.seq ?? after });
+    });
+    const abort = new AbortController();
+    const inbox = new ReefInboxConnection(
+      client,
+      async ([entry]) => {
+        attempts.push(entry!.seq);
+        if (entry!.seq === 8 && parked) {
+          throw new ReefInboxEntryParkedError("review approval pending");
+        }
+        completed.push(entry!.seq);
+      },
+      () => socket as unknown as WebSocketLike,
+      { initialCursor: 7, persistCursor: (cursor) => persisted.push(cursor) },
+    );
+
+    const running = inbox.start(abort.signal);
+    try {
+      socket.emit("open");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(requestedAfter).toEqual([7]);
+      expect(attempts).toEqual([]);
+
+      // The relay retains each entry before pushing its live notification.
+      retainedEntries.push(receiptEntry(8));
+      socket.emit("message", {
+        data: JSON.stringify({ type: "entry", entry: retainedEntries[0] }),
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(attempts).toEqual([8]);
+      expect(persisted).toEqual([]);
+
+      retainedEntries.push(receiptEntry(9));
+      socket.emit("message", {
+        data: JSON.stringify({ type: "entry", entry: retainedEntries[1] }),
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(completed).toEqual([9]);
+      expect(socket.closed).toBe(false);
+      // Continue through recovery even if the earlier frame's cursor barrier was lost.
+      expect.soft(persisted).toEqual([]);
+
+      parked = false;
+      const recoveryPullIndex = requestedAfter.length;
+      const recoveryAttemptIndex = attempts.length;
+      await inbox.poll(abort.signal);
+      expect.soft(requestedAfter[recoveryPullIndex]).toBe(7);
+      expect.soft(attempts.slice(recoveryAttemptIndex)).toEqual([8]);
+      expect.soft(completed).toEqual([9, 8]);
+      expect(persisted.at(-1)).toBe(9);
+    } finally {
+      abort.abort();
+      await running;
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps the live socket up while an entry stays parked", async () => {
     const socket = new ControlledSocket();
     const errors: string[] = [];

--- a/extensions/reef/src/transport-parked.test.ts
+++ b/extensions/reef/src/transport-parked.test.ts
@@ -1,0 +1,269 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { ReefInboxConnection, ReefInboxEntryParkedError, type WebSocketLike } from "./transport.js";
+import {
+  ControlledSocket,
+  createClient,
+  parseRequestUrl,
+  receiptEntry,
+} from "./transport.test-helpers.js";
+
+afterEach(() => vi.useRealTimers());
+
+async function startInbox() {
+  vi.useFakeTimers();
+  const sockets: ControlledSocket[] = [];
+  const retained = new Map<number, ReturnType<typeof receiptEntry>>();
+  const parked = new Set<number>();
+  const attempts: number[] = [];
+  const completed: number[] = [];
+  const persisted: number[] = [];
+  const requestedAfter: number[] = [];
+  const respond = (input: URL | RequestInfo) => {
+    const after = Number(parseRequestUrl(input).searchParams.get("after"));
+    requestedAfter.push(after);
+    const entries = [...retained.values()]
+      .filter((entry) => entry.seq > after)
+      .toSorted((left, right) => left.seq - right.seq)
+      .slice(0, 200);
+    return Response.json({ entries, cursor: entries.at(-1)?.seq ?? after });
+  };
+  const fetcher = vi.fn<typeof fetch>(async (input) => respond(input));
+  const abort = new AbortController();
+  const inbox = new ReefInboxConnection(
+    createClient(fetcher),
+    async ([entry]) => {
+      const seq = entry!.seq;
+      attempts.push(seq);
+      if (parked.has(seq)) {
+        throw new ReefInboxEntryParkedError("review approval pending");
+      }
+      completed.push(seq);
+    },
+    () => {
+      const socket = new ControlledSocket();
+      sockets.push(socket);
+      return socket as unknown as WebSocketLike;
+    },
+    { initialCursor: 7, persistCursor: (cursor) => persisted.push(cursor) },
+  );
+  const running = inbox.start(abort.signal);
+  onTestFinished(async () => {
+    abort.abort();
+    await running;
+  });
+  sockets[0]!.emit("open");
+  await vi.advanceTimersByTimeAsync(0);
+  const notify = async (...sequences: number[]) => {
+    for (const seq of sequences) {
+      const entry = receiptEntry(seq);
+      retained.set(seq, entry);
+      sockets.at(-1)!.emit("message", { data: JSON.stringify({ type: "entry", entry }) });
+    }
+    await vi.advanceTimersByTimeAsync(0);
+  };
+  return {
+    inbox,
+    sockets,
+    retained,
+    parked,
+    attempts,
+    completed,
+    persisted,
+    requestedAfter,
+    fetcher,
+    respond,
+    notify,
+  };
+}
+
+describe("Reef parked cursor ownership", () => {
+  it("holds multiple parks across reconnect and folds sparse completions without redelivery", async () => {
+    const {
+      inbox,
+      sockets,
+      retained,
+      parked,
+      persisted,
+      completed,
+      attempts,
+      requestedAfter,
+      notify,
+    } = await startInbox();
+    parked.add(8).add(12);
+    for (const seq of [8, 10, 12, 15]) {
+      retained.set(seq, receiptEntry(seq));
+    }
+    await inbox.poll();
+    expect(requestedAfter).toEqual([7, 7]);
+    expect(persisted).toEqual([]);
+    expect(completed).toEqual([10, 15]);
+
+    parked.delete(8);
+    await inbox.poll();
+    expect(persisted).toEqual([8, 10]);
+    sockets[0]!.close();
+    await vi.advanceTimersByTimeAsync(250);
+    expect(sockets).toHaveLength(2);
+    sockets[1]!.emit("open");
+    await vi.advanceTimersByTimeAsync(0);
+    const previousAttempts = [...attempts];
+    await notify(20);
+    expect(attempts).toEqual([...previousAttempts, 20]);
+    expect(persisted).toEqual([8, 10]);
+
+    parked.clear();
+    await inbox.poll();
+    expect(completed).toEqual([10, 15, 8, 20, 12]);
+    expect(persisted).toEqual([8, 10, 12, 15, 20]);
+    const pulls = requestedAfter.length;
+    await notify(25);
+    expect(persisted.at(-1)).toBe(25);
+    expect(requestedAfter).toHaveLength(pulls);
+  });
+
+  it("publishes a REST park before queued live frames and retries only the parked entry", async () => {
+    const { inbox, retained, parked, fetcher, respond, notify, persisted, completed, attempts } =
+      await startInbox();
+    parked.add(8);
+    retained.set(8, receiptEntry(8));
+    const pulling = createDeferred<void>();
+    const release = createDeferred<void>();
+    fetcher.mockImplementationOnce(async (input) => {
+      const response = respond(input);
+      pulling.resolve();
+      await release.promise;
+      return response;
+    });
+    const polling = inbox.poll();
+    try {
+      await pulling.promise;
+      await notify(10);
+      expect(attempts).toEqual([]);
+    } finally {
+      release.resolve();
+      await polling;
+    }
+    await vi.advanceTimersByTimeAsync(0);
+    expect(attempts).toEqual([8, 10]);
+    expect(persisted).toEqual([]);
+    parked.clear();
+    await inbox.poll();
+    expect(completed).toEqual([10, 8]);
+    expect(persisted).toEqual([8, 10]);
+  });
+
+  it.each(["failure", "abort"] as const)(
+    "retains an older barrier when a partial REST drain ends in %s",
+    async (interruption) => {
+      const { inbox, retained, parked, fetcher, respond, notify, persisted, completed } =
+        await startInbox();
+      parked.add(8);
+      retained.set(8, receiptEntry(8));
+      retained.set(9, receiptEntry(9));
+      await inbox.poll();
+      expect(persisted).toEqual([]);
+      parked.clear();
+      const pollAbort = new AbortController();
+      const pulling = createDeferred<void>();
+      const release = createDeferred<void>();
+      fetcher.mockImplementationOnce(async (input) => respond(input));
+      fetcher.mockImplementationOnce(async () => {
+        pulling.resolve();
+        await release.promise;
+        throw new Error("partial pull failed");
+      });
+      const polling = inbox.poll(pollAbort.signal);
+      const rejected = expect(polling).rejects.toThrow(
+        interruption === "abort" ? /abort/i : "partial pull failed",
+      );
+      try {
+        await pulling.promise;
+        expect(persisted.at(-1)).toBe(9);
+        if (interruption === "abort") {
+          pollAbort.abort();
+        }
+      } finally {
+        release.resolve();
+        await rejected;
+      }
+      await notify(12);
+      expect(persisted.at(-1)).toBe(9);
+      expect(completed).toEqual([9, 8, 12]);
+      await inbox.poll();
+      expect(completed).toEqual([9, 8, 12]);
+      expect(persisted.at(-1)).toBe(12);
+    },
+  );
+
+  it("keeps a newly observed park when a later REST handler fails", async () => {
+    const { inbox, retained, notify, persisted, completed } = await startInbox();
+    retained.set(8, receiptEntry(8));
+    retained.set(10, receiptEntry(10));
+    const handler = vi.spyOn(inbox, "onEntries");
+    handler.mockRejectedValueOnce(new ReefInboxEntryParkedError("pending review"));
+    handler.mockRejectedValueOnce(new Error("handler failed"));
+    await expect(inbox.poll()).rejects.toThrow("handler failed");
+    await notify(12);
+    expect(persisted).toEqual([]);
+    expect(completed).toEqual([12]);
+    await inbox.poll();
+    expect(completed).toEqual([12, 8, 10]);
+    expect(persisted).toEqual([8, 10, 12]);
+  });
+
+  it.each(["page gap", "tail", "empty mailbox"])(
+    "prunes acknowledged completions in the %s without redispatching delayed live frames",
+    async (absence) => {
+      const { inbox, sockets, retained, parked, completed, persisted } = await startInbox();
+      parked.add(8);
+      for (const seq of [8, 10, 12]) {
+        retained.set(seq, receiptEntry(seq));
+      }
+      await inbox.poll();
+      expect(completed).toEqual([10, 12]);
+      retained.delete(10);
+      if (absence !== "page gap") {
+        retained.delete(12);
+      }
+      if (absence === "empty mailbox") {
+        retained.delete(8);
+      }
+      await inbox.poll();
+      // Inspect cardinality only: acknowledged traffic must not accumulate
+      // behind a long-lived park while the durable cursor cannot advance.
+      expect(inbox["processedAboveCursor"].size).toBe(absence === "page gap" ? 1 : 0);
+      sockets[0]!.emit("message", {
+        data: JSON.stringify({ type: "entry", entry: receiptEntry(10) }),
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(completed).toEqual([10, 12]);
+      expect(persisted).toEqual(absence === "empty mailbox" ? [12] : []);
+    },
+  );
+
+  it.each(["retained completion", "empty mailbox"])(
+    "clears an expired park after REST proves %s without replaying completed callbacks",
+    async (recovery) => {
+      const { inbox, retained, parked, notify, persisted, completed, requestedAfter } =
+        await startInbox();
+      parked.add(8);
+      retained.set(8, receiptEntry(8));
+      retained.set(12, receiptEntry(12));
+      await inbox.poll();
+      expect(persisted).toEqual([]);
+      retained.delete(8);
+      if (recovery === "empty mailbox") {
+        retained.clear();
+      }
+      await inbox.poll();
+      expect(completed).toEqual([12]);
+      expect(persisted).toEqual([12]);
+      const pulls = requestedAfter.length;
+      await notify(15);
+      expect(completed).toEqual([12, 15]);
+      expect(persisted).toEqual([12, 15]);
+      expect(requestedAfter).toHaveLength(pulls);
+    },
+  );
+});

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -23,6 +23,8 @@ const REEF_RELAY_WEBSOCKET_MAX_PAYLOAD_BYTES = 64 * 1024;
 // window while catch-up or entry dispatch is busy. At the payload cap this
 // limits retained frame data to roughly 16 MiB per connection.
 const REEF_INBOX_LIVE_BUFFER_MAX_ENTRIES = 256;
+// Mailbox.pull returns at most 200 entries; a shorter page proves the tail absent.
+const REEF_INBOX_REST_PAGE_SIZE = 200;
 // Stalled TCP peers that never complete the HTTP upgrade would otherwise hang
 // forever — ws defaults to no handshakeTimeout. Match sibling channel WS budgets.
 const REEF_WS_HANDSHAKE_MS = 30_000;
@@ -436,11 +438,14 @@ export class ReefInboxConnection {
   // second connection concurrently delivering the same durable cursor range.
   private processing = Promise.resolve();
   private stopped = false;
-  // While a parked entry freezes the durable cursor, entries completed above it
-  // (receipts stay in the relay mailbox until retention) would be re-pulled
-  // every poll. This in-memory record keeps re-attempts scoped to the parked
-  // entry; it is pruned as the cursor advances and bounded by the relay's
-  // per-handle mailbox cap.
+  // Live frames cannot prove an older park resolved. Only a successful REST
+  // drain may clear this barrier, including across socket replacements.
+  private parked = false;
+  // REST-covered frames need no live dispatch (parks retry via REST). Keep this
+  // watermark after pruning completions whose delayed socket frames may still arrive.
+  private reconciledThrough = 0;
+  // Avoid replaying completed entries while a park holds the durable cursor.
+  // REST pages prune entries no longer retained in their authoritative range.
   private readonly processedAboveCursor = new Set<number>();
   constructor(
     readonly client: ReefTransportClient,
@@ -493,8 +498,10 @@ export class ReefInboxConnection {
         throw new Error("invalid Reef relay inbox cursor");
       }
       const previous = this.cursor;
-      await this.processEntries(page.entries, page.cursor, signal);
+      const parked = await this.processEntries(page.entries, page.cursor, signal);
+      signal?.throwIfAborted();
       if (!page.entries.length || this.cursor === previous) {
+        this.parked = parked;
         return;
       }
     }
@@ -504,7 +511,7 @@ export class ReefInboxConnection {
     entries: readonly InboxEntry[],
     cursor?: number,
     signal?: AbortSignal,
-  ): Promise<void> {
+  ): Promise<boolean> {
     let highestSequence = 0;
     for (const entry of entries) {
       if (!Number.isSafeInteger(entry.seq) || entry.seq < 1) {
@@ -518,30 +525,27 @@ export class ReefInboxConnection {
       throw new Error("Reef relay inbox cursor does not match its entries");
     }
     const fresh = entries.toSorted((left, right) => left.seq - right.seq);
-    if (fresh.length === 0) {
-      if (cursor !== undefined) {
-        this.advanceCursor(cursor);
-      }
-      return;
-    }
-    // A parked entry (pending review, transient guard failure) stays un-acked
-    // at the relay and must be pulled again, so the durable cursor freezes
-    // before it. Later entries still process now — acknowledged ones leave the
-    // relay mailbox, so redelivery cycles only re-pull the parked entry.
-    let parked = false;
+    // REST orders all retained entries in its range; a live batch cannot clear
+    // an older barrier. Publish new parks immediately, even if this scan fails.
+    let parked = cursor === undefined && this.parked;
     for (const entry of fresh) {
-      if (entry.seq <= this.cursor || this.processedAboveCursor.has(entry.seq)) {
+      if (
+        entry.seq <= this.cursor ||
+        (cursor === undefined && entry.seq <= this.reconciledThrough)
+      ) {
         continue;
       }
       signal?.throwIfAborted();
-      try {
-        await this.onEntries([entry]);
-      } catch (error) {
-        if (error instanceof ReefInboxEntryParkedError) {
-          parked = true;
-          continue;
+      if (!this.processedAboveCursor.has(entry.seq)) {
+        try {
+          await this.onEntries([entry]);
+        } catch (error) {
+          if (error instanceof ReefInboxEntryParkedError) {
+            this.parked = parked = true;
+            continue;
+          }
+          throw error;
         }
-        throw error;
       }
       // A completed handler has consumed the entry even if shutdown arrived
       // while it ran. Persist it before the next abort check to avoid replay.
@@ -549,13 +553,23 @@ export class ReefInboxConnection {
         this.processedAboveCursor.add(entry.seq);
       } else {
         this.advanceCursor(entry.seq);
-        // A resolved park may leave completed entries recorded above the
-        // cursor; fold the contiguous run in so the durable cursor catches up.
-        while (this.processedAboveCursor.has(this.cursor + 1)) {
-          this.advanceCursor(this.cursor + 1);
-        }
       }
     }
+    if (cursor !== undefined) {
+      const retained = new Set(fresh.map((entry) => entry.seq));
+      this.reconciledThrough = Math.max(this.reconciledThrough, cursor);
+      for (const seq of this.processedAboveCursor) {
+        if ((seq <= cursor || fresh.length < REEF_INBOX_REST_PAGE_SIZE) && !retained.has(seq)) {
+          this.processedAboveCursor.delete(seq);
+          this.reconciledThrough = Math.max(this.reconciledThrough, seq);
+        }
+      }
+      if (fresh.length === 0) {
+        // Empty pages may echo the old cursor after expiry/acknowledgment.
+        this.advanceCursor(this.reconciledThrough);
+      }
+    }
+    return parked;
   }
 
   /**


### PR DESCRIPTION
Closes #141099 (Reef recovery cursor skips parked entries across separate live frames).

<details>
<summary>Additional instructions</summary>

This maintainer-requested repair uses a same-repository branch that maintainers can update.

</details>

## What Problem This Solves

Fixes an issue where a Reef message waiting for an owner review or guard recovery could remain undelivered after that condition resolved, when a later message or receipt had arrived in a separate live frame. Recovery polls skipped the earlier retained message instead of retrying it.

## Why This Change Was Made

The old parked flag belonged to one batch even though the live pump handles frames separately. The serialized inbox connection now owns the parked barrier across live batches and socket replacements. Only a successful REST drain can clear that barrier. Later entries still process promptly, while completed entries above the durable cursor are reconciled without duplicate callbacks.

REST reconciliation also handles sparse sequences, acknowledged or expired entries, and delayed socket notifications. It prunes the existing completion cache against authoritative page ranges and retains a transient watermark for late frames. This replaces the old contiguous-sequence folding loop; sequence gaps are normal after acknowledgments and retention expiry.

The short-page inference follows the inspected relay contract: `workers/relay/src/mailbox.ts` at `8dcd8af80ae93b58524c2cf2978c3aae6e1899dd` persists entries before notification and returns ordered `seq > after` rows with `LIMIT 200`; empty pages echo `after`. This is dependency-source evidence, not a claim about a deployed relay revision.

## User Impact

Parked inbound messages remain eligible for normal retry while the relay retains them, including after socket reconnect. Later messages and receipts continue processing, and an owner decision can complete the parked delivery on a subsequent poll without reprocessing already completed callbacks.

There is no schema, migration, stored representation, configuration, protocol, retention, authentication, or approval-policy change. The existing identity-bound cursor store and monotonic persistence contract remain unchanged. This prevents future incorrect advancement; it does not reset an already-too-high cursor or recover historical skipped entries automatically.

## Evidence

The original separate-frame regression failed against unchanged production for all intended symptoms: cursor `[9]` instead of `[]`, next pull `9` instead of `7`, no retry of entry `8`, and completion `[9]` instead of `[9, 8]`. After the repair the same regression passed:

```bash
node scripts/run-vitest.mjs extensions/reef/src/transport-inbox.test.ts -t 'retries a parked live entry after a later separate frame completes' --reporter=verbose
```

The ten additional owner cases all failed against the unchanged transport and passed after the candidate was reapplied. They cover multiple parks, reconnect, sparse completions, REST/live ordering, partial failure/abort, a park followed by handler failure, acknowledged/expired rows, and delayed frames. Both owner files pass **26/26**:

```bash
node scripts/run-vitest.mjs extensions/reef/src/transport-inbox.test.ts extensions/reef/src/transport-parked.test.ts --reporter=verbose
```

The complete Reef suite passes **326/326 across 25 files**, covering the unchanged flow, review, state, channel lifecycle, receipt and transport siblings:

```bash
node scripts/run-vitest.mjs extensions/reef --reporter=verbose
```

Fresh independent Codex autoreview is **scoped-clean through P2**, with no actionable findings. The reviewer received the complete candidate plus unchanged caller/flow/cursor-store and relay-contract source. It did not claim to execute tests.

Additional **real HTTP/WebSocket loopback integration** exercised the actual transport client and socket implementation with synthetic relay entries. Both separate-frame and reconnect scenarios failed against the immutable original transport for the intended cursor/retry/completion errors, then passed on the candidate. The original requested recovery after 9 and completed only `[9]`; the candidate requested after 7, retried only `[8]`, completed `[9, 8]`, and reached cursor 9. Healthy sockets stayed open while parked, and every test server/socket was closed. This is synthetic transport integration, not a deployed relay or full-channel delivery claim.

The four-file Reef candidate passed the **complete changed-file gate** in a separate physical checkout with its own frozen-lockfile installation (278 seconds), followed by a fresh **326/326 Reef suite** (30 seconds) and `git diff --check`. All four candidate files were verified byte-for-byte against the repair worktree before and after validation:

```bash
node scripts/check-changed.mjs -- docs/channels/reef.md extensions/reef/src/transport.ts extensions/reef/src/transport-inbox.test.ts extensions/reef/src/transport-parked.test.ts
```

The original nested worktree correctly refused ancestor dependency-manifest reads. Moving proof outside all ancestor installations resolved that boundary without weakening it. The newly reachable lint step found one test-only correction (`sort` to `toSorted`); the full gate and independent P0-P2 review were rerun successfully afterward. No dependency, guard, or baseline was changed.

### Fixed-main integration

Earlier hosted CI exposed two unrelated main/fixture blockers. The first [check-lint run](https://github.com/openclaw/openclaw/actions/runs/34108961467/job/101700888116) found an oversized Telegram test file. Our interim test-only split passed local proof and [hosted lint](https://github.com/openclaw/openclaw/actions/runs/34111764896/job/101709634841). Main then received the broader canonical [Telegram progress-test split](https://github.com/openclaw/openclaw/pull/141148), preserving all three original cases byte-for-byte. The redundant interim commit has therefore been dropped; this PR again contains only the four Reef files.

The later [finalization process-test failure](https://github.com/openclaw/openclaw/actions/runs/34111764896/job/101709636098) was fixed by the existing [prepared-worker fixture repair](https://github.com/openclaw/openclaw/pull/141137), merged as `ed86b491cce2d084dea375fb700c47e65f1b1913`. We reused that landed repair rather than duplicating it or increasing the deadline.

The candidate is rebased onto `0e1e605121bffdc4d03725b2a290d47dea453228`, which contains both fixes. The entire four-file binary/full-index patch is byte-for-byte identical to the originally tested Reef patch (SHA-256 `a4445abff6d5b3c0420655dca65de286a8395f24a93813a763726ca6c1a0e7a5`). The refreshed head `e0f32330bb56459121656c187a06a55b4fd03f9d` passed **461 tests across 30 files and four native shards** after rebase: 326 Reef tests, 68 canonical Telegram split/rendering tests, all 14 finalization process cases in their original order, and 53 CI planner tests. The previously failing completion-hang case passed. The test run took 324 seconds; the checkout remained clean and its full patch hash unchanged afterward. Fresh independent review was scoped-clean through P2, with no findings. Exact-head hosted CI remains mandatory before native preparation.

```bash
node scripts/run-vitest.mjs extensions/reef extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts extensions/telegram/src/bot-message-dispatch.progress-updates.reasoning-preambles.test.ts extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts src/cli/update-finalization-output.process.test.ts test/scripts/ci-node-test-plan.test.ts --reporter=verbose
```

**Scope:** four files; production +44/-30 (net +14), tests +339/-0, docs +1/-1. The production growth gives the existing connection ownership of the unresolved park and REST reconciliation evidence, replacing the batch-local flag and contiguous-only advancement. No new persistent store, dependency, generated file, baseline, or test-only production seam.

**Provenance:** the batch-local flag was introduced in [the parked-review delivery repair](https://github.com/openclaw/openclaw/pull/132420), authored and merged by @steipete on 2026-08-29, commit `c1473eac606d6445e9f74ba2d534b5236cdd71c9`. Its review/guard and healthy-socket behavior are retained.

**Live-proof gap and known boundary:** the configured live Reef peer rejected the fresh channel test with `mailbox_full`, so a complete authenticated delivery/owner-review cycle could not be verified there. No causal link between that rejection and this cursor defect is established. The proof above is actual transport code over synthetic loopback HTTP/WebSocket connections plus the full Reef suite, not a full Gateway/relay roundtrip. No live mailbox was deleted, no pending review was approved for testing, and no uncertain message was replayed.
