### PR TITLE
fix(ci): reduce planner growth check runtime

### DIFF
--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -2195,6 +2195,11 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
   });
 
   it("keeps hosted tooling within the GitHub job cap when its inventory grows", async () => {
+    // The checkout is fixed; keep real discovery caches while rebuilding each planner snapshot.
+    const unitFastPaths = await vi.importActual<
+      typeof import("../vitest/vitest.unit-fast-paths.mjs")
+    >("../vitest/vitest.unit-fast-paths.mjs");
+    const trackedTestFiles = new Map<string, readonly string[]>();
     const options = {
       compactMode: "pull-request" as const,
       runnerBackend: "github",
@@ -2219,15 +2224,20 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       extraFiles: string[] = [],
     ) => {
       vi.resetModules();
+      vi.doMock("../vitest/vitest.unit-fast-paths.mjs", () => unitFastPaths);
       vi.doMock("../../scripts/lib/list-test-files.mts", async (importOriginal) => {
         const actual =
           await importOriginal<typeof import("../../scripts/lib/list-test-files.mts")>();
         return {
           ...actual,
-          listTrackedTestFiles(rootDir: string, suffix?: string) {
-            const files = actual
-              .listTrackedTestFiles(rootDir, suffix)
-              .filter((file) => !growthFiles.has(file));
+          listTrackedTestFiles(rootDir: string, suffix = ".test.ts") {
+            const key = JSON.stringify([rootDir, suffix]);
+            let rawFiles = trackedTestFiles.get(key);
+            if (rawFiles === undefined) {
+              rawFiles = actual.listTrackedTestFiles(rootDir, suffix);
+              trackedTestFiles.set(key, rawFiles);
+            }
+            const files = rawFiles.filter((file) => !growthFiles.has(file));
             return rootDir === "test" && (includeGrowthFile || extraFiles.length > 0)
               ? [
                   ...new Set([
@@ -2246,6 +2256,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
         return createPlan(options);
       } finally {
         vi.doUnmock("../../scripts/lib/list-test-files.mts");
+        vi.doUnmock("../vitest/vitest.unit-fast-paths.mjs");
         vi.resetModules();
       }
     };


### PR DESCRIPTION
Related: #141063

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where regular CI spends repeated discovery work in the planner's inventory-growth check and can exceed its 120-second test deadline. The observed failure blocked validation of https://github.com/openclaw/openclaw/pull/141063: [small-29 timed out in the growth check](https://github.com/openclaw/openclaw/actions/runs/34106077950/job/101691626877), rather than exceeding the 80-job cap.

## Why This Change Was Made

Reuse real checkout discovery within that single test: retain the real unit-fast module namespace and cache raw tracked-file reads by root and effective suffix. Each inventory still gets fresh arrays and a freshly imported planner; both mocks are removed before the final module reset.

All ten inventories, assertions, ordering, the 120-second deadline, and production planner behavior remain unchanged. This does not change job caps, weights, workers, prerequisite calculation, or the separate mock-listener fix.

## User Impact

Developers spend less local and CI time validating planner inventory growth without reducing coverage. There is no runtime product behavior change. The exact-head hosted Linux growth check passed under its unchanged deadline; unrelated CI blockers still prevent landing.

## Evidence

- Based on trusted `main` at `fb90f804f48eff2f74fec25c224b5c65ba2799fc`, including the separate classification repair in https://github.com/openclaw/openclaw/pull/141075.
- Frozen baseline and candidate produced byte-identical complete serialized plans for all ten inventories, with no field projection: 4,557,662 bytes; SHA256 `96a6f9c8242cf7285be8e7537ea3579cb91c7737109ae549d789a177e0d2a072`.
- Local macOS / Node 26.7.0 focused guard: **27.811s baseline -> 14.936s candidate**. Temporary capture instrumentation was removed before final validation.
- Final candidate with CPU profiling: **15.560s test / 18.953s profile**, compared with the independent audit's **27.4s test / 31.891s profile**. `spawnSync` self-time fell from 4.451s to 0.681s. These are local measurements, not a hosted-Linux result.
- Full final planner file: **53 passed, 0 skipped**, 66.28s Vitest duration. The original single growth test and every assertion remain.
- Targeted formatting, root-test lint, scripts lint, dependency and package-patch guards, core typecheck graph-boundary guard, and remaining changed-file guards passed.
- `check:changed` stopped at the root-test typecheck wrapper because this worktree's required shared compiler resolves outside the checkout. No install, guard bypass, or successful typecheck is claimed.
- Fresh independent P0-P2 autoreview: scoped-clean, no actionable findings.
- Exact-head hosted Linux evidence at `26f650a09cfb5e99e4cd0b8845015b47a2ae38e3`: [small-29 passed](https://github.com/openclaw/openclaw/actions/runs/34109152279/job/101701453249). The growth guard took **79.889s**, below the unchanged **120s** deadline. Its tooling group reported **536 passed, 72 skipped**; the first tooling group reported **909 passed**.
- Run `34109152279` is terminal with an unrelated [Telegram max-lines lint failure](https://github.com/openclaw/openclaw/actions/runs/34109152279/job/101701451795): 1,012 counted lines against the existing 1,000-line rule. The Telegram source and lint configuration are unchanged between this PR's base and head. Separate repair: https://github.com/openclaw/openclaw/pull/141139; its exact-head hosted lint result is still required.
- The other underlying failure is [small-22 CLI validation](https://github.com/openclaw/openclaw/actions/runs/34109152279/job/101701452991): the completion-hang test failed earlier in `targetConfigValidation` at its 1,000ms budget, returning exit 1 instead of 0. This is not the prior malformed-container hang. Related pending repair: https://github.com/openclaw/openclaw/pull/141137; applicability and exact-head resolution are not yet claimed.
- Landing is held for the separate blockers. No CI retry, rebase, prepare, merge, or automerge has been requested.
