### PR TITLE
fix(ui): retain loaded dashboards across navigation

### DIFF
--- a/docs/plugins/feature-plugins.md
+++ b/docs/plugins/feature-plugins.md
@@ -176,7 +176,10 @@ A composer replacement receives the current draft, admission state, disabled
 reason, and canonical `setDraft`, `send`, and optional `abort` operations. Use
 these operations instead of issuing a raw chat RPC. `send()` resolves `true`
 when admitted, `false` when rejected, or `undefined` for a local command or no
-submission. Show rejected submissions rather than clearing the draft.
+submission. Show rejected submissions rather than clearing the draft. Composer
+operations retire when the view stops being presented, even while its DOM and
+host lifetime survive. Use the fresh operations supplied by `update` when the
+view is presented again; previously captured operations remain retired.
 
 The host also exposes session and agent snapshots and operations, plugin page
 navigation, authenticated requests, and subscriptions. Session and agent

--- a/docs/web/dashboard-architecture.md
+++ b/docs/web/dashboard-architecture.md
@@ -78,6 +78,12 @@ Principles:
   so widget frames, browser views, terminals, and chat drafts survive a swap.
   The task toolbar and side-panel tab header align above their respective panes
   in left/right layouts; stacked layouts keep each header above its own pane.
+- **Navigation retention:** one connected session-page owner retains up to three
+  recent sessions per pane across task navigation and visits to other routes.
+  Hidden pages relinquish foreground activity, viewer presence, focus, and commands.
+  Chat and dashboard route loaders share the same Gateway/authentication scope as
+  the mounted views; connection-owner changes retire both, while ordinary reconnects
+  preserve them. Cached successful routes render during background refresh.
 - **Drag:** user drags widgets; grid auto-compacts (widgets float up, neighbors
   reflow). Resize by handle snaps to size steps. No pixel placement — for
   anyone.

--- a/docs/web/dashboards.md
+++ b/docs/web/dashboards.md
@@ -38,6 +38,12 @@ layout remain per-device UI state. Ordinary task revisits restore the browser's
 saved arrangement for that task; opening a gallery card explicitly focuses the
 dashboard.
 
+The browser keeps the three most recently visited tasks in each pane loaded,
+including their dashboard widgets, while you switch tasks or visit Settings.
+Returning to a retained task preserves widget interactions and reading position;
+changed content refreshes in place. Older tasks may reload when reopened. A browser
+reload or a change of Gateway or signed-in user clears these retained views.
+
 ## Arrange your task
 
 The main area and side panel can show either the dashboard or chat. Browser,

--- a/ui/src/app-route-paths.test.ts
+++ b/ui/src/app-route-paths.test.ts
@@ -26,6 +26,7 @@ import {
 import { createApplicationRouter, startApplicationRouter } from "./app-routes.ts";
 import type { ApplicationContext } from "./app/context.ts";
 import type { AgentsPanel } from "./lib/agents/panels.ts";
+import { createApplicationGateway } from "./test-helpers/application-context.ts";
 
 const AGENT_PANEL_CASES = [
   "overview",
@@ -126,6 +127,21 @@ const DYNAMIC_STARTUP_CASES = [
   basePath?: string;
   location: RouteLocation;
 }[];
+
+function createStartupContext(basePath = ""): ApplicationContext {
+  const { gateway } = createApplicationGateway({
+    phase: "stopped",
+    client: null,
+    offlineStable: false,
+    hello: null,
+    canvasPluginSurfaceUrl: null,
+    assistantAgentId: null,
+    sessionKey: "agent:main:main",
+    lastError: null,
+    lastErrorCode: null,
+  });
+  return { basePath, gateway } as unknown as ApplicationContext;
+}
 
 describe("Dynamic route startup bridge", () => {
   it("keeps share-route reservations aligned with every built-in path and alias", () => {
@@ -238,9 +254,7 @@ describe("Dynamic route startup bridge", () => {
         route.loader = loader;
         route.component = async () => ({ render: () => null });
 
-        await startApplicationRouter(router, history, basePath, {
-          basePath,
-        } as unknown as ApplicationContext);
+        await startApplicationRouter(router, history, basePath, createStartupContext(basePath));
 
         expect(loader).toHaveBeenCalledOnce();
         expect(router.getState().matches[0]?.location).toEqual(initialLocation);
@@ -297,9 +311,7 @@ describe("Dynamic route startup bridge", () => {
         route.loader = loader;
         route.component = async () => ({ render: () => null });
 
-        await startApplicationRouter(router, history, "", {
-          basePath: "",
-        } as unknown as ApplicationContext);
+        await startApplicationRouter(router, history, "", createStartupContext());
         expect(loader).toHaveBeenCalledOnce();
 
         location = {
@@ -343,9 +355,7 @@ describe("Dynamic route startup bridge", () => {
       route.component = async () => ({ render: () => null });
 
       await expect(
-        startApplicationRouter(router, history, "", {
-          basePath: "",
-        } as unknown as ApplicationContext),
+        startApplicationRouter(router, history, "", createStartupContext()),
       ).resolves.toBeUndefined();
 
       expect(location.pathname).toBe("/chat");
@@ -387,9 +397,7 @@ describe("Dynamic route startup bridge", () => {
       route.component = async () => ({ render: () => null });
 
       await expect(
-        startApplicationRouter(router, history, "", {
-          basePath: "",
-        } as unknown as ApplicationContext),
+        startApplicationRouter(router, history, "", createStartupContext()),
       ).resolves.toBeUndefined();
 
       expect(loader).toHaveBeenCalledTimes(2);
@@ -424,9 +432,7 @@ describe("Dynamic route startup bridge", () => {
       route.component = async () => ({ render: () => null });
 
       await expect(
-        startApplicationRouter(router, history, "", {
-          basePath: "",
-        } as unknown as ApplicationContext),
+        startApplicationRouter(router, history, "", createStartupContext()),
       ).rejects.toBe(failure);
     } finally {
       router.stop();

--- a/ui/src/app-routes.ts
+++ b/ui/src/app-routes.ts
@@ -68,7 +68,8 @@ import { page as workboardPage } from "./pages/workboard/route.ts";
 import { page as worktreesPage } from "./pages/worktrees/route.ts";
 
 type AppRouteModule = {
-  render: (data: unknown, loaderPending: boolean) => unknown;
+  render: (data: unknown, loaderPending: boolean, presented?: boolean) => unknown;
+  retainOnNavigate?: boolean;
   renderOwnerKey?: (
     match: Pick<RouteMatch, "data" | "location">,
     settled: Pick<RouteMatch, "data" | "location"> | undefined,

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -35,6 +35,7 @@ import type { ApplicationRuntime } from "./bootstrap.ts";
 import { canGoBackInNativeEmbed } from "./browser.ts";
 import type { ApplicationContext, ApplicationNavigationOptions } from "./context.ts";
 import { resolveControlUiAuthToken } from "./control-ui-auth.ts";
+import { gatewayPresentationScope } from "./gateway-presentation-scope.ts";
 import {
   DEBUG_OVERLAY_ELEMENT,
   isOptionalElementDefined,
@@ -591,6 +592,7 @@ export function renderApplicationShell(host: ShellViewHost) {
           aria-disabled=${pageActionsBlocked || reloadRequired ? "true" : nothing}
           .router=${runtime.router}
           .retryContext=${context}
+          .retentionScope=${gatewayPresentationScope(context.gateway)}
           .onNotFound=${() => host.replaceChatWithCurrentSession()}
           .notFoundRecoveryReady=${gatewayConnected}
         ></openclaw-router-outlet>

--- a/ui/src/app/gateway-presentation-scope.ts
+++ b/ui/src/app/gateway-presentation-scope.ts
@@ -1,0 +1,32 @@
+import type { ApplicationGateway } from "./gateway.ts";
+
+type GatewayPresentationScope = { readonly key: number };
+type OwnedPresentationScope = {
+  scope: GatewayPresentationScope;
+  revision: number;
+  userId?: string;
+};
+
+const scopes = new WeakMap<ApplicationGateway, OwnedPresentationScope>();
+let nextScopeKey = 0;
+
+/** Shared by mounted pages and route loader caches for the same connection owner. */
+export function gatewayPresentationScope(gateway: ApplicationGateway): GatewayPresentationScope {
+  const revision = gateway.connectionRevision;
+  const snapshot = gateway.snapshot;
+  const userId = snapshot.phase === "connected" ? snapshot.selfUser?.id : undefined;
+  const previous = scopes.get(gateway);
+  if (
+    !previous ||
+    previous.revision !== revision ||
+    (userId !== undefined && previous.userId !== undefined && previous.userId !== userId)
+  ) {
+    const next = { scope: { key: ++nextScopeKey }, revision, userId };
+    scopes.set(gateway, next);
+    return next.scope;
+  }
+  // First authentication completes the existing owner; reconnects may temporarily
+  // clear selfUser without retiring that owner's mounted pages or loader results.
+  previous.userId ??= userId;
+  return previous.scope;
+}

--- a/ui/src/app/router-outlet-chat.test.ts
+++ b/ui/src/app/router-outlet-chat.test.ts
@@ -18,15 +18,24 @@ import { pages as chatPages } from "../pages/chat/route.ts";
 import { settleLitElement } from "../test-helpers/lit-settle.ts";
 import "./router-outlet.ts";
 
-type RouteId = "chat" | "dashboard";
+type RouteId = "chat" | "dashboard" | "home" | "settings";
 type TestContext = Record<string, never>;
 type OwnerMatch = Pick<RouteMatch<string, unknown, ChatRouteData>, "data" | "location">;
 type TestModule = {
-  render: (data: ChatRouteData | undefined) => unknown;
+  render: (
+    data: ChatRouteData | undefined,
+    loaderPending?: boolean,
+    presented?: boolean,
+  ) => unknown;
+  retainOnNavigate?: boolean;
   renderOwnerKey?: (match: OwnerMatch, settled: OwnerMatch | undefined) => string | undefined;
 };
 type TestRouter = Router<RouteId, TestContext, TestModule, ChatRouteData>;
-type RouterOutletElement = LitElement & { router?: TestRouter };
+type RouterOutletElement = LitElement & {
+  router?: TestRouter;
+  retryContext?: TestContext;
+  retentionScope?: object;
+};
 
 type Deferred<T> = {
   promise: Promise<T>;
@@ -52,6 +61,7 @@ function sessionData(sessionKey: string, face: "chat" | "dashboard"): ChatRouteD
 function createOutlet(router: TestRouter): RouterOutletElement {
   const outlet = document.createElement("openclaw-router-outlet") as RouterOutletElement;
   outlet.router = router;
+  outlet.retryContext = {};
   document.body.append(outlet);
   return outlet;
 }
@@ -61,8 +71,9 @@ async function settleOutlet(outlet: RouterOutletElement): Promise<void> {
 }
 
 function ownedRenderer(teardown: () => Promise<void>) {
-  return (data: ChatRouteData | undefined) =>
-    data
+  return (data: ChatRouteData | undefined, _loaderPending = false, presented = true) => {
+    const value = data?.kind === "session" ? data.face : "chooser";
+    return data
       ? html`
           <mcp-app-view
             ${ref((element) => {
@@ -72,9 +83,11 @@ function ownedRenderer(teardown: () => Promise<void>) {
               }
             })}
           ></mcp-app-view>
-          <div data-testid="route-value">${data.kind === "session" ? data.face : "chooser"}</div>
+          <div data-testid="route-value" data-presented=${presented}>${value}</div>
+          <textarea data-testid="route-draft"></textarea>
         `
       : nothing;
+  };
 }
 
 async function routeModule(
@@ -82,7 +95,11 @@ async function routeModule(
   render: TestModule["render"],
 ): Promise<TestModule> {
   const declared = await chatPages[face === "chat" ? 0 : 1].component();
-  return { renderOwnerKey: declared.renderOwnerKey, render };
+  return {
+    renderOwnerKey: declared.renderOwnerKey,
+    retainOnNavigate: declared.retainOnNavigate,
+    render,
+  };
 }
 
 afterEach(() => {
@@ -91,6 +108,355 @@ afterEach(() => {
 });
 
 describe("openclaw-router-outlet chat ownership", () => {
+  it("keeps the loaded session connected and inert across Home and Settings, then restores its draft", async () => {
+    const sessionKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
+    const teardown = vi.fn(async () => undefined);
+    const module = await routeModule("chat", ownedRenderer(teardown));
+    const refreshed = deferred<ChatRouteData>();
+    const loader = vi
+      .fn()
+      .mockResolvedValueOnce(sessionData(sessionKey, "chat"))
+      .mockImplementation(() => refreshed.promise);
+    const router = createRouter<RouteId, TestContext, TestModule, ChatRouteData>({
+      routes: [
+        definePage({
+          id: "chat",
+          path: "/chat",
+          component: () => module,
+          loader,
+        }),
+        ...(["home", "settings"] as const).map((id) =>
+          definePage<RouteId, TestContext, TestModule, ChatRouteData>({
+            id,
+            path: `/${id}`,
+            component: () => ({
+              render: () => html`<div data-testid="ordinary-route">${id}</div>`,
+            }),
+          }),
+        ),
+      ],
+    });
+    const outlet = createOutlet(router);
+    await router.navigate("chat", {});
+    await settleOutlet(outlet);
+    const appView = outlet.querySelector("mcp-app-view")!;
+    const draft = outlet.querySelector<HTMLTextAreaElement>('[data-testid="route-draft"]')!;
+    draft.value = "Keep this unfinished message";
+
+    for (const id of ["home", "settings"] as const) {
+      await router.navigate(id, {});
+      await settleOutlet(outlet);
+      expect(outlet.querySelector('[data-testid="ordinary-route"]')?.textContent).toBe(id);
+      expect(appView.isConnected).toBe(true);
+      expect(appView.closest("[inert]")).not.toBeNull();
+      expect(
+        outlet.querySelector('[data-testid="route-value"]')?.getAttribute("data-presented"),
+      ).toBe("false");
+      expect(teardown).not.toHaveBeenCalled();
+    }
+
+    const navigation = router.navigate("chat", {});
+    await settleOutlet(outlet);
+    expect(
+      outlet.querySelector('[data-testid="route-value"]')?.getAttribute("data-presented"),
+    ).toBe("true");
+    refreshed.resolve(sessionData(sessionKey, "chat"));
+    await navigation;
+    await settleOutlet(outlet);
+    expect(outlet.querySelector("mcp-app-view")).toBe(appView);
+    expect(outlet.querySelector('[data-testid="route-draft"]')).toBe(draft);
+    expect(draft.value).toBe("Keep this unfinished message");
+    expect(appView.closest("[inert]")).toBeNull();
+    expect(
+      outlet.querySelector('[data-testid="route-value"]')?.getAttribute("data-presented"),
+    ).toBe("true");
+    expect(outlet.querySelector('[data-testid="ordinary-route"]')).toBeNull();
+    expect(teardown).not.toHaveBeenCalled();
+    router.stop();
+  });
+
+  it("keeps a parked session hidden until the requested session resolves", async () => {
+    const firstKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
+    const nextKey = "agent:main:dashboard:abcdef12-3456-7890-abcd-ef1234567890";
+    const nextData = deferred<ChatRouteData>();
+    const teardown = vi.fn(async () => undefined);
+    const render = ownedRenderer(teardown);
+    const chatModule = await routeModule("chat", render);
+    const dashboardModule = await routeModule("dashboard", render);
+    const router = createRouter<RouteId, TestContext, TestModule, ChatRouteData>({
+      routes: [
+        definePage({
+          id: "chat",
+          path: "/chat",
+          component: () => chatModule,
+          loader: () => sessionData(firstKey, "chat"),
+        }),
+        definePage({
+          id: "home",
+          path: "/home",
+          component: () => ({ render: () => html`<div>Home</div>` }),
+        }),
+        definePage({
+          id: "dashboard",
+          path: "/dashboard",
+          component: () => dashboardModule,
+          loader: () => nextData.promise,
+        }),
+      ],
+    });
+    const outlet = createOutlet(router);
+    await router.navigate("chat", {});
+    await settleOutlet(outlet);
+    const appView = outlet.querySelector("mcp-app-view")!;
+    await router.navigate("home", {});
+    await settleOutlet(outlet);
+
+    const navigation = router.navigate("dashboard", {});
+    await settleOutlet(outlet);
+    expect(appView.isConnected).toBe(true);
+    expect(appView.closest("[inert]")).not.toBeNull();
+    expect(outlet.querySelector('[data-testid="route-value"][data-presented="true"]')).toBeNull();
+    expect(teardown).not.toHaveBeenCalled();
+
+    nextData.resolve(sessionData(nextKey, "dashboard"));
+    await navigation;
+    await settleOutlet(outlet);
+    expect(outlet.querySelector("mcp-app-view")).toBe(appView);
+    expect(appView.closest("[inert]")).toBeNull();
+    expect(outlet.querySelector('[data-testid="route-value"]')?.textContent).toBe("dashboard");
+    router.stop();
+  });
+
+  it("retires parked views and uses the replacement scope's route data", async () => {
+    let scope = { key: 1 };
+    const oldKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
+    const newKey = "agent:main:dashboard:abcdef12-3456-7890-abcd-ef1234567890";
+    const teardownDone = deferred<void>();
+    const teardown = vi.fn(() => teardownDone.promise);
+    const nextData = deferred<ChatRouteData>();
+    const loader = vi
+      .fn()
+      .mockResolvedValueOnce(sessionData(oldKey, "chat"))
+      .mockImplementation(() => nextData.promise);
+    const module = await routeModule("chat", ownedRenderer(teardown));
+    const router = createRouter<RouteId, TestContext, TestModule, ChatRouteData>({
+      routes: [
+        definePage({
+          id: "chat",
+          path: "/chat",
+          component: () => module,
+          loaderDeps: () => String(scope.key),
+          loader,
+        }),
+        definePage({
+          id: "home",
+          path: "/home",
+          component: () => ({ render: () => html`<div>Home</div>` }),
+        }),
+      ],
+    });
+    const outlet = createOutlet(router);
+    outlet.retentionScope = scope;
+    await router.navigate("chat", {});
+    await settleOutlet(outlet);
+    const appView = outlet.querySelector("mcp-app-view")!;
+    await router.navigate("home", {});
+    await settleOutlet(outlet);
+
+    scope = { key: 2 };
+    outlet.retentionScope = scope;
+    await settleOutlet(outlet);
+    expect(teardown).toHaveBeenCalledOnce();
+    expect(appView.isConnected).toBe(true);
+    expect(appView.closest("[inert]")).not.toBeNull();
+    expect(
+      outlet.querySelector('[data-testid="route-value"]')?.getAttribute("data-presented"),
+    ).toBe("false");
+
+    const navigation = router.navigate("chat", {});
+    await settleOutlet(outlet);
+    expect(loader).toHaveBeenCalledTimes(2);
+    expect(appView.closest("[inert]")).not.toBeNull();
+    nextData.resolve(sessionData(newKey, "chat"));
+    await navigation;
+    await settleOutlet(outlet);
+    expect(appView.isConnected).toBe(true);
+    expect(appView.closest("[inert]")).not.toBeNull();
+
+    teardownDone.resolve(undefined);
+    await expect.poll(() => outlet.querySelector("mcp-app-view") !== appView).toBe(true);
+    await settleOutlet(outlet);
+    expect(appView.isConnected).toBe(false);
+    expect(outlet.querySelector("mcp-app-view")).not.toBeNull();
+    expect(outlet.querySelector("mcp-app-view")?.closest("[inert]")).toBeNull();
+    router.stop();
+  });
+
+  it("keeps a pending destination and ignores its retired scope's late result", async () => {
+    const sessionKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
+    let scope = { key: 1 };
+    const oldResult = deferred<ChatRouteData>();
+    const newResult = deferred<ChatRouteData>();
+    const loader = vi
+      .fn()
+      .mockImplementationOnce(() => oldResult.promise)
+      .mockImplementation(() => newResult.promise);
+    const module = await routeModule(
+      "dashboard",
+      ownedRenderer(async () => undefined),
+    );
+    const router = createRouter<RouteId, TestContext, TestModule, ChatRouteData>({
+      routes: [
+        definePage({
+          id: "dashboard",
+          path: "/dashboard",
+          component: () => module,
+          loaderDeps: (_context, routeLocation) =>
+            JSON.stringify([scope.key, routeLocation.pathname]),
+          loader,
+        }),
+      ],
+    });
+    const outlet = createOutlet(router);
+    outlet.retentionScope = scope;
+    const destination = location("/dashboard/main/pending-story-12345678");
+    const navigation = router.navigate("dashboard", {}, undefined, destination);
+    await vi.waitFor(() => expect(loader).toHaveBeenCalledOnce());
+    scope = { key: 2 };
+    outlet.retentionScope = scope;
+    await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(2));
+    expect(loader.mock.calls[1]?.[1].location).toEqual(destination);
+    oldResult.resolve(sessionData(sessionKey, "chat"));
+    await navigation;
+    await settleOutlet(outlet);
+    expect(outlet.querySelector('[data-testid="route-value"]')).toBeNull();
+    newResult.resolve(sessionData(sessionKey, "dashboard"));
+    await vi.waitFor(() =>
+      expect(outlet.querySelector('[data-testid="route-value"]')?.textContent).toBe("dashboard"),
+    );
+    expect(router.getState().location).toEqual(destination);
+    router.stop();
+  });
+
+  it("does not revive a retired session when cold navigation supersedes its scope refresh", async () => {
+    const sessionKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
+    let scope = { key: 1 };
+    const render = ownedRenderer(async () => undefined);
+    const chatModule = await routeModule("chat", render);
+    const dashboardModule = deferred<TestModule>();
+    const homeModule = deferred<TestModule>();
+    const router = createRouter<RouteId, TestContext, TestModule, ChatRouteData>({
+      routes: [
+        definePage({
+          id: "chat",
+          path: "/chat",
+          component: () => chatModule,
+          loaderDeps: () => String(scope.key),
+          loader: () => sessionData(sessionKey, "chat"),
+        }),
+        definePage({
+          id: "dashboard",
+          path: "/dashboard",
+          component: () => dashboardModule.promise,
+          loaderDeps: () => String(scope.key),
+          loader: () => sessionData(sessionKey, "dashboard"),
+        }),
+        definePage({ id: "home", path: "/home", component: () => homeModule.promise }),
+      ],
+    });
+    const outlet = createOutlet(router);
+    outlet.retentionScope = scope;
+    await router.navigate("chat", {});
+    await settleOutlet(outlet);
+    const dashboardNavigation = router.navigate("dashboard", {});
+    await settleOutlet(outlet);
+    scope = { key: 2 };
+    outlet.retentionScope = scope;
+    await settleOutlet(outlet);
+    const homeNavigation = router.navigate("home", {});
+    dashboardModule.resolve(await routeModule("dashboard", render));
+    await dashboardNavigation;
+    await settleOutlet(outlet);
+    expect(outlet.querySelector('[data-testid="route-value"][data-presented="true"]')).toBeNull();
+    homeModule.resolve({ render: () => html`<div data-testid="ordinary-route">Home</div>` });
+    await homeNavigation;
+    await settleOutlet(outlet);
+    expect(outlet.querySelector('[data-testid="ordinary-route"]')?.textContent).toBe("Home");
+    router.stop();
+  });
+
+  it("keeps a returning session inert until its pending MCP teardown completes", async () => {
+    const sessionKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
+    const done = deferred<void>();
+    const teardown = vi.fn(() => done.promise);
+    const render = ownedRenderer(teardown);
+    const module = await routeModule("chat", render);
+    const router = createRouter<RouteId, TestContext, TestModule, ChatRouteData>({
+      routes: [
+        definePage({
+          id: "chat",
+          path: "/chat",
+          component: () => module,
+          loader: () => sessionData(sessionKey, "chat"),
+        }),
+        definePage({
+          id: "dashboard",
+          path: "/dashboard",
+          component: () => ({ ...module, render: () => html`<p>Session not found</p>` }),
+          loader: (): ChatRouteData => ({
+            kind: "missing-session",
+            face: "dashboard",
+            currentSessionHref: "/chat/main",
+            sessionsHref: "/sessions",
+          }),
+        }),
+      ],
+    });
+    const outlet = createOutlet(router);
+    await router.navigate("chat", {});
+    await settleOutlet(outlet);
+    const appView = outlet.querySelector("mcp-app-view");
+    await router.navigate("dashboard", {});
+    await settleOutlet(outlet);
+    expect(teardown).toHaveBeenCalledOnce();
+    await router.navigate("chat", {});
+    await settleOutlet(outlet);
+    expect(appView?.isConnected).toBe(true);
+    expect(appView?.closest("[inert]")).not.toBeNull();
+    expect(outlet.querySelector('[data-testid="route-value"][data-presented="true"]')).toBeNull();
+    done.resolve(undefined);
+    await vi.waitFor(() => expect(appView?.closest("[inert]")).toBeNull());
+    expect(outlet.querySelector("mcp-app-view")).toBe(appView);
+    expect(teardown).toHaveBeenCalledOnce();
+    router.stop();
+  });
+
+  it("retires the old page without reloading a replacement router's current result", async () => {
+    const sessionKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
+    const teardown = vi.fn(async () => undefined);
+    const module = await routeModule("chat", ownedRenderer(teardown));
+    const loader = vi.fn(() => sessionData(sessionKey, "chat"));
+    const create = () =>
+      createRouter<RouteId, TestContext, TestModule, ChatRouteData>({
+        routes: [definePage({ id: "chat", path: "/chat", component: () => module, loader })],
+      });
+    const first = create();
+    const second = create();
+    const outlet = createOutlet(first);
+    await first.navigate("chat", {});
+    await settleOutlet(outlet);
+    const appView = outlet.querySelector("mcp-app-view");
+    await second.navigate("chat", {});
+    outlet.router = second;
+    await settleOutlet(outlet);
+    expect(outlet.querySelector("mcp-app-view")).not.toBe(appView);
+    expect(outlet.querySelector("mcp-app-view")).not.toBeNull();
+    expect(teardown).toHaveBeenCalledOnce();
+    expect(loader).toHaveBeenCalledTimes(2);
+    first.stop();
+    second.stop();
+  });
+
   it("retains the exact subtree across session and presentation switches", async () => {
     const sessionKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
     const nextSessionKey = "agent:main:dashboard:abcdef12-3456-7890-abcd-ef1234567890";

--- a/ui/src/app/router-outlet.ts
+++ b/ui/src/app/router-outlet.ts
@@ -1,7 +1,9 @@
 import type { RouteMatch, Router } from "@openclaw/uirouter";
-import { nothing } from "lit";
+import { html, nothing } from "lit";
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { property } from "lit/decorators.js";
+import { keyed } from "lit/directives/keyed.js";
+import { createRef, ref } from "lit/directives/ref.js";
 import { renderLazyViewError } from "../components/lazy-view-error.ts";
 import { renderLoadingState } from "../components/loading-state.ts";
 import { McpAppUnmountGate } from "../components/mcp-app-unmount.ts";
@@ -21,7 +23,8 @@ import {
 export { selectRenderedRouteMatch } from "./router-outlet-controller.ts";
 
 type RenderableModule<TData> = {
-  render: (data: TData | undefined, loaderPending: boolean) => unknown;
+  render: (data: TData | undefined, loaderPending: boolean, presented?: boolean) => unknown;
+  retainOnNavigate?: boolean;
   renderOwnerKey?: (
     match: Pick<RouteMatch<string, unknown, TData>, "data" | "location">,
     settled: Pick<RouteMatch<string, unknown, TData>, "data" | "location"> | undefined,
@@ -30,6 +33,7 @@ type RenderableModule<TData> = {
 
 type RouterOutletOptions<TLoadContext = unknown> = {
   retryContext?: TLoadContext;
+  presented?: boolean;
 };
 
 function isRenderableModule<TData>(module: unknown): module is RenderableModule<TData> {
@@ -157,7 +161,9 @@ function renderRouterOutlet<TRouteId extends string, TLoadContext, TModule, TDat
   }
   const renderedPage = () =>
     measureRoutedRender(routeId, () =>
-      routeModule.render(renderedMatch.data, renderedMatch.isFetching === "loader"),
+      options.presented === false
+        ? routeModule.render(renderedMatch.data, renderedMatch.isFetching === "loader", false)
+        : routeModule.render(renderedMatch.data, renderedMatch.isFetching === "loader"),
     );
   return renderedMatch.error
     ? renderError<TRouteId, TLoadContext, TModule, TData>(
@@ -165,7 +171,7 @@ function renderRouterOutlet<TRouteId extends string, TLoadContext, TModule, TDat
         options.retryContext,
         renderedMatch.error,
         routeId,
-        renderedPage,
+        routeModule.retainOnNavigate ? undefined : renderedPage,
       )
     : renderedPage();
 }
@@ -210,6 +216,30 @@ class LitRouterOutletController<
   }
 }
 
+/** Presentation can retire immediately while its connected subtree finishes MCP teardown. */
+class OpenClawRoutePresentation extends OpenClawLightDomElement {
+  @property({ attribute: false }) ownerKey = "";
+  @property({ attribute: false }) renderPage: (presented: boolean) => unknown = () => nothing;
+  private presentedValue = false;
+
+  @property({ attribute: false })
+  get presented(): boolean {
+    return this.presentedValue;
+  }
+  set presented(value: boolean) {
+    const previous = this.presentedValue;
+    this.presentedValue = value;
+    this.style.display = value ? "contents" : "none";
+    this.toggleAttribute("inert", !value);
+    this.setAttribute("aria-hidden", value ? "false" : "true");
+    this.requestUpdate("presented", previous);
+  }
+
+  override render() {
+    return this.renderPage(this.presented);
+  }
+}
+
 class OpenClawRouterOutlet<
   TRouteId extends string = string,
   TLoadContext = unknown,
@@ -225,7 +255,72 @@ class OpenClawRouterOutlet<
     onNotFound: this.onNotFound,
     notFoundRecoveryReady: this.notFoundRecoveryReady,
   }));
-  private readonly mcpAppUnmountGate = new McpAppUnmountGate(this);
+  @property({ attribute: false }) retentionScope?: object;
+  private readonly retainedUnmountGate = new McpAppUnmountGate(this);
+  private readonly transientUnmountGate = new McpAppUnmountGate(this);
+  private readonly retainedPresentation = createRef<OpenClawRoutePresentation>();
+  private readonly transientPresentation = createRef<OpenClawRoutePresentation>();
+  private retainedMatch?: RouteMatch<TRouteId, TModule, TData>;
+  private retainedOwnerKey?: string;
+  private retainedPresented = false;
+  private scopeRouter?: Router<TRouteId, TLoadContext, TModule, TData>;
+  private scopeOwner?: object;
+  private scopeInitialized = false;
+  private scopeGeneration = 0;
+  private scopeRefreshing = false;
+  private retiredSessionMatches = new Set<string>();
+
+  private synchronizeRetentionScope(router: Router<TRouteId, TLoadContext, TModule, TData>): void {
+    const routerChanged = this.scopeRouter !== router;
+    const changed =
+      this.scopeInitialized && (routerChanged || this.scopeOwner !== this.retentionScope);
+    this.scopeInitialized = true;
+    this.scopeRouter = router;
+    this.scopeOwner = this.retentionScope;
+    if (!changed) {
+      return;
+    }
+    const generation = ++this.scopeGeneration;
+    this.retainedMatch = undefined;
+    this.retainedOwnerKey = undefined;
+    this.retainedPresented = false;
+    this.scopeRefreshing = false;
+    this.retiredSessionMatches = new Set(
+      routerChanged
+        ? []
+        : [...router.getState().matches, ...router.getState().pendingMatches]
+            .filter(
+              (match) => isRenderableModule<TData>(match.module) && match.module.retainOnNavigate,
+            )
+            .map((match) => match.id),
+    );
+    if (routerChanged) {
+      return;
+    }
+    const context = this.retryContext;
+    const scope = this.retentionScope;
+    const state = router.getState();
+    const target = state.pendingMatches[0] ?? state.matches[0];
+    if (context === undefined || !target) {
+      return;
+    }
+    this.scopeRefreshing = true;
+    // Session loader dependencies carry this same scope. Navigating the exact
+    // target retires the old load without reusing its cache or changing history.
+    void router
+      .navigate(target.routeId, context, { history: "none", revalidate: true }, target.location)
+      .finally(() => {
+        if (
+          this.router === router &&
+          this.retentionScope === scope &&
+          this.scopeGeneration === generation
+        ) {
+          this.scopeRefreshing = false;
+          this.requestUpdate();
+        }
+      })
+      .catch(() => undefined);
+  }
 
   override render() {
     const router = this.router;
@@ -234,27 +329,123 @@ class OpenClawRouterOutlet<
     }
     const snapshot = this.outlet.snapshot;
     const renderedMatch = selectRenderedRouteMatch(snapshot.active, snapshot.pending);
+    this.synchronizeRetentionScope(router);
+    const ready = renderedMatch?.status === "success" && renderedMatch.error === undefined;
+    const retiredSession =
+      renderedMatch !== undefined && this.retiredSessionMatches.has(renderedMatch.id);
+    const scopeReady = !this.scopeRefreshing && !retiredSession;
     const routeKey = renderedMatch ? `${renderedMatch.routeId}:${renderedMatch.status}` : "empty";
     const routeModule = renderedMatch?.module;
-    const declaredOwnerKey =
-      renderedMatch && isRenderableModule<TData>(routeModule)
-        ? routeModule.renderOwnerKey?.(renderedMatch, snapshot.settled)
-        : undefined;
+    const module = isRenderableModule<TData>(routeModule) ? routeModule : undefined;
+    const declaredOwnerKey = renderedMatch
+      ? module?.renderOwnerKey?.(renderedMatch, snapshot.settled)
+      : undefined;
     const explicitOwnerKey = renderedMatch?.error === undefined ? declaredOwnerKey : undefined;
-    const retainCurrent =
+    const waiting = renderedMatch?.status === "pending" || renderedMatch?.isFetching === "loader";
+    const retainPending =
+      waiting && this.retainedPresented && this.retainedOwnerKey === explicitOwnerKey;
+    const presentRetained =
+      scopeReady &&
+      module?.retainOnNavigate === true &&
       explicitOwnerKey !== undefined &&
-      renderedMatch?.status === "pending" &&
-      renderedMatch.data === undefined;
-    return this.mcpAppUnmountGate.render(
-      explicitOwnerKey ?? routeKey,
-      () =>
-        renderRouterOutlet(router, snapshot, renderedMatch, {
-          retryContext: this.retryContext,
-        }),
-      () => [this],
-      { retainRenderedValue: retainCurrent },
-    );
+      (ready || retainPending);
+    if (presentRetained && ready) {
+      this.retainedMatch = renderedMatch;
+      this.retainedOwnerKey = explicitOwnerKey;
+    } else if (snapshot.status === "idle" || (scopeReady && module?.retainOnNavigate && !waiting)) {
+      // Invalid session destinations still replace their old owner; only a
+      // successful session page opts into retention across unrelated routes.
+      this.retainedMatch = undefined;
+      this.retainedOwnerKey = undefined;
+    }
+    this.retainedPresented = presentRetained;
+    const retained = this.retainedMatch;
+    const retainedKey = `${this.scopeGeneration}:${this.retainedOwnerKey ?? "empty"}`;
+    const transientKey = `${this.scopeGeneration}:${presentRetained ? "empty" : (explicitOwnerKey ?? routeKey)}`;
+    const renderTransient = (presented: boolean) => {
+      if (!scopeReady) {
+        return !retiredSession && renderedMatch?.error !== undefined
+          ? renderError(router, this.retryContext, renderedMatch.error, renderedMatch.routeId)
+          : renderLoadingState();
+      }
+      // Returning from another page must not revive the previously selected
+      // session while the requested destination is still unresolved.
+      if (module?.retainOnNavigate && waiting) {
+        return renderLoadingState();
+      }
+      return renderRouterOutlet(router, snapshot, renderedMatch, {
+        retryContext: this.retryContext,
+        presented,
+      });
+    };
+    const rendered = html`
+      ${this.retainedUnmountGate.render(
+        retainedKey,
+        () =>
+          retained
+            ? keyed(
+                retainedKey,
+                html`<openclaw-route-presentation
+                  ${ref(this.retainedPresentation)}
+                  .ownerKey=${retainedKey}
+                  .presented=${presentRetained}
+                  .renderPage=${(presented: boolean) =>
+                    renderRouterOutlet(router, snapshot, retained, {
+                      retryContext: this.retryContext,
+                      presented,
+                    })}
+                ></openclaw-route-presentation>`,
+              )
+            : nothing,
+        () => (this.retainedPresentation.value ? [this.retainedPresentation.value] : []),
+      )}
+      ${this.transientUnmountGate.render(
+        transientKey,
+        () =>
+          presentRetained
+            ? nothing
+            : keyed(
+                transientKey,
+                html`<openclaw-route-presentation
+                  ${ref(this.transientPresentation)}
+                  .ownerKey=${transientKey}
+                  .presented=${true}
+                  .renderPage=${renderTransient}
+                ></openclaw-route-presentation>`,
+              ),
+        () => (this.transientPresentation.value ? [this.transientPresentation.value] : []),
+        {
+          retainRenderedValue:
+            scopeReady &&
+            !module?.retainOnNavigate &&
+            explicitOwnerKey !== undefined &&
+            renderedMatch?.status === "pending" &&
+            renderedMatch.data === undefined,
+        },
+      )}
+      ${presentRetained && this.retainedUnmountGate.retiring ? renderLoadingState() : nothing}
+    `;
+    // The gates publish retirement during render and schedule surviving MCP
+    // restarts before these presentation updates. A returning owner stays inert
+    // throughout teardown, even when its key matches the still-connected subtree.
+    if (this.retainedPresentation.value) {
+      this.retainedPresentation.value.presented =
+        presentRetained &&
+        !this.retainedUnmountGate.retiring &&
+        this.retainedPresentation.value.ownerKey === retainedKey;
+    }
+    if (this.transientPresentation.value) {
+      this.transientPresentation.value.presented =
+        !presentRetained &&
+        !this.transientUnmountGate.retiring &&
+        this.transientPresentation.value.ownerKey === transientKey;
+    }
+    return rendered;
   }
+}
+
+if (!customElements.get("openclaw-route-presentation")) {
+  customElements.define("openclaw-route-presentation", OpenClawRoutePresentation);
 }
 
 if (!customElements.get("openclaw-router-outlet")) {

--- a/ui/src/app/router-outlet.ts
+++ b/ui/src/app/router-outlet.ts
@@ -4,6 +4,7 @@ import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { property } from "lit/decorators.js";
 import { keyed } from "lit/directives/keyed.js";
 import { createRef, ref } from "lit/directives/ref.js";
+import { isSessionRouteId } from "../app-route-paths.ts";
 import { renderLazyViewError } from "../components/lazy-view-error.ts";
 import { renderLoadingState } from "../components/loading-state.ts";
 import { McpAppUnmountGate } from "../components/mcp-app-unmount.ts";
@@ -259,7 +260,6 @@ class OpenClawRouterOutlet<
   private readonly retainedUnmountGate = new McpAppUnmountGate(this);
   private readonly transientUnmountGate = new McpAppUnmountGate(this);
   private readonly retainedPresentation = createRef<OpenClawRoutePresentation>();
-  private readonly transientPresentation = createRef<OpenClawRoutePresentation>();
   private retainedMatch?: RouteMatch<TRouteId, TModule, TData>;
   private retainedOwnerKey?: string;
   private retainedPresented = false;
@@ -289,9 +289,7 @@ class OpenClawRouterOutlet<
       routerChanged
         ? []
         : [...router.getState().matches, ...router.getState().pendingMatches]
-            .filter(
-              (match) => isRenderableModule<TData>(match.module) && match.module.retainOnNavigate,
-            )
+            .filter((match) => isSessionRouteId(match.routeId))
             .map((match) => match.id),
     );
     if (routerChanged) {
@@ -301,7 +299,7 @@ class OpenClawRouterOutlet<
     const scope = this.retentionScope;
     const state = router.getState();
     const target = state.pendingMatches[0] ?? state.matches[0];
-    if (context === undefined || !target) {
+    if (context === undefined || !target || !isSessionRouteId(target.routeId)) {
       return;
     }
     this.scopeRefreshing = true;
@@ -361,9 +359,9 @@ class OpenClawRouterOutlet<
     this.retainedPresented = presentRetained;
     const retained = this.retainedMatch;
     const retainedKey = `${this.scopeGeneration}:${this.retainedOwnerKey ?? "empty"}`;
-    const transientKey = `${this.scopeGeneration}:${presentRetained ? "empty" : (explicitOwnerKey ?? routeKey)}`;
-    const renderTransient = (presented: boolean) => {
-      if (!scopeReady) {
+    const transientKey = presentRetained ? "empty" : (explicitOwnerKey ?? routeKey);
+    const renderTransient = () => {
+      if (isSessionRouteId(renderedMatch?.routeId) && !scopeReady) {
         return !retiredSession && renderedMatch?.error !== undefined
           ? renderError(router, this.retryContext, renderedMatch.error, renderedMatch.routeId)
           : renderLoadingState();
@@ -375,7 +373,6 @@ class OpenClawRouterOutlet<
       }
       return renderRouterOutlet(router, snapshot, renderedMatch, {
         retryContext: this.retryContext,
-        presented,
       });
     };
     const rendered = html`
@@ -401,22 +398,10 @@ class OpenClawRouterOutlet<
       )}
       ${this.transientUnmountGate.render(
         transientKey,
-        () =>
-          presentRetained
-            ? nothing
-            : keyed(
-                transientKey,
-                html`<openclaw-route-presentation
-                  ${ref(this.transientPresentation)}
-                  .ownerKey=${transientKey}
-                  .presented=${true}
-                  .renderPage=${renderTransient}
-                ></openclaw-route-presentation>`,
-              ),
-        () => (this.transientPresentation.value ? [this.transientPresentation.value] : []),
+        () => (presentRetained ? nothing : renderTransient()),
+        () => [...this.children].filter((child) => child !== this.retainedPresentation.value),
         {
           retainRenderedValue:
-            scopeReady &&
             !module?.retainOnNavigate &&
             explicitOwnerKey !== undefined &&
             renderedMatch?.status === "pending" &&
@@ -433,12 +418,6 @@ class OpenClawRouterOutlet<
         presentRetained &&
         !this.retainedUnmountGate.retiring &&
         this.retainedPresentation.value.ownerKey === retainedKey;
-    }
-    if (this.transientPresentation.value) {
-      this.transientPresentation.value.presented =
-        !presentRetained &&
-        !this.transientUnmountGate.retiring &&
-        this.transientPresentation.value.ownerKey === transientKey;
     }
     return rendered;
   }

--- a/ui/src/components/markdown-blocks.ts
+++ b/ui/src/components/markdown-blocks.ts
@@ -11,11 +11,15 @@ const initializedCodeBlocks = new WeakSet<HTMLElement>();
 class MarkdownBlocksDirective extends AsyncDirective {
   private root: HTMLElement | undefined;
   private scanPending = false;
+  private active = true;
   private readonly observedNodes = new Set<HTMLElement>();
   private readonly resizeObserver =
     typeof ResizeObserver === "undefined"
       ? null
       : new ResizeObserver((entries) => {
+          if (!this.active || !this.isConnected) {
+            return;
+          }
           const wrappers = new Set(
             entries.map(({ target }) => target.closest<HTMLElement>(".code-block-wrapper")),
           );
@@ -26,18 +30,27 @@ class MarkdownBlocksDirective extends AsyncDirective {
           }
         });
 
-  render() {
+  render(_active = true) {
     return nothing;
   }
 
-  override update(part: ElementPart) {
+  override update(part: ElementPart, [active = true]: [boolean?]) {
     this.root = part.element instanceof HTMLElement ? part.element : undefined;
-    this.scheduleScan();
+    this.active = active;
+    if (active) {
+      this.scheduleScan();
+    } else {
+      this.release();
+    }
     return nothing;
   }
 
   protected override disconnected(): void {
-    // A final route-away has no later scan to release detached transcript trees.
+    this.release();
+  }
+
+  private release(): void {
+    // Hidden retained DOM keeps its controls, but must release foreground observers.
     this.resizeObserver?.disconnect();
     this.observedNodes.clear();
     if (this.root) {
@@ -50,7 +63,7 @@ class MarkdownBlocksDirective extends AsyncDirective {
   }
 
   private scheduleScan(): void {
-    if (this.scanPending || !this.isConnected) {
+    if (this.scanPending || !this.active || !this.isConnected) {
       return;
     }
     this.scanPending = true;
@@ -58,7 +71,7 @@ class MarkdownBlocksDirective extends AsyncDirective {
     // and fence queued scans when the host is removed before the microtask runs.
     queueMicrotask(() => {
       this.scanPending = false;
-      if (this.isConnected && this.root?.isConnected) {
+      if (this.active && this.isConnected && this.root?.isConnected) {
         this.scan(this.root);
       }
     });
@@ -70,6 +83,7 @@ class MarkdownBlocksDirective extends AsyncDirective {
       void import("./markdown-mermaid.ts").then(
         ({ mountMermaidBlocks }) => {
           if (
+            this.active &&
             this.isConnected &&
             this.root === root &&
             root.isConnected &&
@@ -79,6 +93,9 @@ class MarkdownBlocksDirective extends AsyncDirective {
           }
         },
         () => {
+          if (!this.active || !this.isConnected || this.root !== root || !root.isConnected) {
+            return;
+          }
           for (const block of root.querySelectorAll(".markdown-mermaid")) {
             block.classList.remove("markdown-mermaid");
             block.prepend(t("chat.mermaid.rendererError"));

--- a/ui/src/components/markdown-code-blocks.test.ts
+++ b/ui/src/components/markdown-code-blocks.test.ts
@@ -52,10 +52,9 @@ it("reobserves reused Markdown DOM while fencing scans queued before disconnect"
       tableInteractions: "enabled",
     },
   );
-  const part = render(
-    html`<section class="chat-text" ${markdownBlocks()}>${unsafeHTML(content)}</section>`,
-    container,
-  );
+  const view = (active = true) =>
+    html`<section class="chat-text" ${markdownBlocks(active)}>${unsafeHTML(content)}</section>`;
+  const part = render(view(), container);
   const code = container.querySelector("code");
   const tableViewport = container.querySelector(".markdown-table__viewport");
 
@@ -79,6 +78,20 @@ it("reobserves reused Markdown DOM while fencing scans queued before disconnect"
     expect(container.querySelector(".markdown-table__viewport")).toBe(tableViewport);
     expect(observed.has(tableViewport!)).toBe(true);
     expect(observed.size).toBe(3);
+
+    render(view(false), container);
+    await Promise.resolve();
+    expect(observed.size).toBe(0);
+    expect(container.querySelector("code")).toBe(code);
+    render(view(true), container);
+    render(view(false), container);
+    await Promise.resolve();
+    expect(observed.size).toBe(0);
+    render(view(true), container);
+    await Promise.resolve();
+    expect(observed.size).toBe(3);
+    expect(observed.has(code!)).toBe(true);
+    expect(observed.has(tableViewport!)).toBe(true);
   } finally {
     render(nothing, container);
   }

--- a/ui/src/components/mcp-app-unmount.ts
+++ b/ui/src/components/mcp-app-unmount.ts
@@ -43,6 +43,10 @@ export class McpAppUnmountGate {
     private readonly selector = "mcp-app-view",
   ) {}
 
+  get retiring(): boolean {
+    return this.pending || this.restartTargets !== null;
+  }
+
   private apply(key: McpAppUnmountKey, renderValue: () => unknown): unknown {
     this.renderedValue = renderValue();
     this.renderedKey = key;

--- a/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
@@ -306,7 +306,7 @@ suite.define(() => {
       await sidebar.getByRole("link", { name: "Home" }).click();
       await waitForControlUiRoute(page, { pathname: "/chat/main", routeId: "chat" });
       await assertActiveTurnVisible(page, streamText);
-      expect(await readWorkingStartedAts(page)).toContain(startedAt);
+      await expect.poll(() => readWorkingStartedAts(page)).toContain(startedAt);
       await expect(
         page.locator(".chat-working-indicator openclaw-elapsed-time").filter({ hasText: "10m" }),
       ).not.toHaveCount(0);

--- a/ui/src/e2e/chat-code-block-fences.e2e.test.ts
+++ b/ui/src/e2e/chat-code-block-fences.e2e.test.ts
@@ -134,7 +134,7 @@ describeControlUiE2e("Control UI fenced code blocks", () => {
     }
   });
 
-  it("releases code-block observations when navigation removes the final transcript", async () => {
+  it("releases hidden transcript observations and resumes them on the retained code", async () => {
     const context = await browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -196,6 +196,7 @@ describeControlUiE2e("Control UI fenced code blocks", () => {
     try {
       await page.goto(`${server.baseUrl}chat`);
       await expect.poll(async () => (await observations()).connected).toBe(2);
+      const code = await page.locator(".chat-thread code").elementHandle();
       const sidebar = page.locator("openclaw-app-sidebar");
       await sidebar.locator(".sidebar-identity-card").click();
       await sidebar
@@ -204,10 +205,22 @@ describeControlUiE2e("Control UI fenced code blocks", () => {
         .click();
       await page.locator('.settings-sidebar__item[href="/logs"]').click();
       await page.locator("openclaw-logs-page").waitFor({ state: "visible" });
-      expect(await page.locator("openclaw-chat-pane").count()).toBe(0);
+      await page.locator("openclaw-chat-pane").waitFor({ state: "hidden" });
+      expect(await code?.evaluate((element) => element.isConnected)).toBe(true);
       // A page reload would discard the probe too and cannot prove in-app teardown.
       expect((await observations()).observed).toBeGreaterThanOrEqual(2);
+      await expect.poll(async () => (await observations()).connected).toBe(0);
       await expect.poll(async () => (await observations()).detached).toBe(0);
+      await page.goBack();
+      await page.goBack();
+      await page.locator(".chat-thread code").waitFor({ state: "visible" });
+      expect(
+        await page
+          .locator(".chat-thread code")
+          .evaluate((element, previous) => element === previous, code),
+      ).toBe(true);
+      await expect.poll(async () => (await observations()).connected).toBe(2);
+      expect((await observations()).detached).toBe(0);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/chat-widget-sandbox.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/chat-widget-sandbox.real-gateway.e2e.test.ts
@@ -5,6 +5,8 @@ import { expect, it } from "vitest";
 import { createCanvasDocument } from "../../../src/canvas/documents.js";
 import { buildWidgetDocument } from "../../../src/canvas/wrap.js";
 import { appendTranscriptMessage } from "../../../src/config/sessions/session-accessor.js";
+import { encodePngRgba } from "../../../src/media/png-encode.js";
+import { ensureGatewayOwnerProfile, setAvatar } from "../../../src/state/user-profiles.js";
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
@@ -30,6 +32,13 @@ const suite = createControlUiE2eSuite({
     });
     instance = owner;
     try {
+      const profileOptions = { env: owner.env };
+      const profile = ensureGatewayOwnerProfile("Synthetic Viewer", profileOptions);
+      const avatar = Buffer.from([70, 130, 190, 255]);
+      const saved = setAvatar(profile.id, encodePngRgba(avatar, 1, 1), "image/png", profileOptions);
+      if (!saved.ok) {
+        throw new Error(`Synthetic avatar setup failed: ${saved.error.code}`);
+      }
       await owner.startGateway();
       return { baseUrl: `http://127.0.0.1:${owner.port}/`, close: () => owner.cleanup() };
     } catch (error) {
@@ -44,6 +53,16 @@ const suite = createControlUiE2eSuite({
   },
 });
 
+async function cliJson(
+  owner: OpenClawTestInstance,
+  args: string[],
+): Promise<Record<string, unknown>> {
+  const result = await owner.cli(["--no-color", ...args]);
+  expect(result.code, args.slice(0, 3).join(" ")).toBe(0);
+  expect(result.signal).toBeNull();
+  return JSON.parse(result.stdout) as Record<string, unknown>;
+}
+
 suite.define(() => {
   it("reads persisted Canvas bytes through an authenticated browser connection", async () => {
     if (!instance) {
@@ -52,13 +71,7 @@ suite.define(() => {
     const owner = instance;
     const sessionKey = "agent:main:widget-live-proof";
     const docId = "widget-live-proof";
-    const cliJson = async (args: string[]): Promise<Record<string, unknown>> => {
-      const result = await owner.cli(["--no-color", ...args]);
-      expect(result.code, args.join(" ")).toBe(0);
-      expect(result.signal).toBeNull();
-      return JSON.parse(result.stdout) as Record<string, unknown>;
-    };
-    const session = await cliJson([
+    const session = await cliJson(owner, [
       "gateway",
       "call",
       "sessions.create",
@@ -151,7 +164,7 @@ suite.define(() => {
         },
       },
     );
-    const history = await cliJson([
+    const history = await cliJson(owner, [
       "gateway",
       "call",
       "chat.history",
@@ -162,7 +175,7 @@ suite.define(() => {
     expect(history.messages).toEqual(
       expect.arrayContaining([expect.objectContaining({ content })]),
     );
-    const handoff = await cliJson(["dashboard", "--json"]);
+    const handoff = await cliJson(owner, ["dashboard", "--json"]);
     expect(typeof handoff.browserUrl).toBe("string");
     const issued = new URL(String(handoff.browserUrl));
     const url = new URL(controlUiSessionUrl(suite.server.baseUrl, sessionKey, "chat"));
@@ -225,6 +238,173 @@ suite.define(() => {
             ),
           );
         }
+      },
+    );
+  });
+
+  it("retains a real dashboard, article position, and chat draft across navigation and Settings", async () => {
+    if (!instance) {
+      throw new Error("Gateway fixture is not running");
+    }
+    const owner = instance;
+    const dashboardKey = "agent:main:daily-claw-retention";
+    const chatKey = "agent:main:chat-navigation-retention";
+    const widgetName = "daily-claw";
+    const note = "Read the navigation story after lunch.";
+    const draft = "Explain how retaining this dashboard preserves my reading position.";
+    const rpc = (method: string, params: Record<string, unknown>) =>
+      cliJson(owner, ["gateway", "call", method, "--params", JSON.stringify(params), "--json"]);
+    const articleHtml = (edition: string) =>
+      buildWidgetDocument(
+        "The Daily Claw",
+        `<style>
+          body{padding:24px;font:16px system-ui;background:var(--surface);color:var(--text)}
+          input{display:block;width:100%;box-sizing:border-box;padding:12px;margin:8px 0 20px}
+          article{height:280px;overflow:auto;border:1px solid var(--border);padding:16px}
+          article p{margin:0 0 24px;min-height:48px}
+        </style>
+        <h1>The Daily Claw</h1><p id="edition">${edition}</p>
+        <label>Reading note <input aria-label="Reading note"></label>
+        <article aria-label="Daily Claw article" tabindex="0">
+          ${Array.from({ length: 30 }, (_, index) => `<p>Story ${index + 1}: Synthetic engineering news for the navigation retention proof.</p>`).join("")}
+        </article>`,
+      );
+    await rpc("sessions.create", {
+      key: dashboardKey,
+      agentId: "main",
+      label: "The Daily Claw",
+    });
+    await rpc("sessions.patch", { key: dashboardKey, boardFace: "dashboard" });
+    const widgetParams = {
+      sessionKey: dashboardKey,
+      name: widgetName,
+      title: "The Daily Claw",
+      placement: { size: "full" },
+    };
+    await rpc("board.widget.put", {
+      ...widgetParams,
+      content: { kind: "html", html: articleHtml("Morning edition") },
+    });
+    const chat = await rpc("sessions.create", {
+      key: chatKey,
+      agentId: "main",
+      label: "Navigation proof chat",
+    });
+    expect(typeof chat.sessionId).toBe("string");
+    await appendTranscriptMessage(
+      { agentId: "main", sessionKey: chatKey, sessionId: String(chat.sessionId), env: owner.env },
+      {
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Synthetic session ready for navigation." }],
+          timestamp: Date.now(),
+        },
+      },
+    );
+    const handoff = await cliJson(owner, ["dashboard", "--json"]);
+    const url = new URL(controlUiSessionUrl(suite.server.baseUrl, dashboardKey, "dashboard"));
+    url.hash = new URL(String(handoff.browserUrl)).hash;
+    await suite.withPage(
+      {
+        viewport: { width: 1440, height: 900 },
+        serviceWorkers: "block",
+        permissions: ["local-network-access"],
+        ...(captureEnabled
+          ? { recordVideo: { dir: suite.artifactDir, size: { width: 1440, height: 900 } } }
+          : {}),
+      },
+      async ({ page }) => {
+        const capture = async (filename: string) => {
+          if (captureEnabled) {
+            await page.screenshot({ path: path.join(suite.artifactDir, filename) });
+          }
+        };
+        const sessionLink = (key: string) =>
+          page.locator(
+            `.sidebar-recent-session[data-session-key="${key}"] a.sidebar-recent-session__link`,
+          );
+        const response = await page.goto(url.toString());
+        expect(response?.status()).toBe(200);
+        await waitForControlUiGatewayReady(page);
+        const board = page.locator("openclaw-board-view").first();
+        const outer = board.locator(
+          `.board-widget[data-widget-name="${widgetName}"] .board-widget__frame`,
+        );
+        const inner = outer.contentFrame().frameLocator("iframe");
+        const readingNote = inner.getByRole("textbox", { name: "Reading note" });
+        const article = inner.getByRole("article", { name: "Daily Claw article" });
+        await readingNote.fill(note);
+        await article.evaluate((element) => {
+          element.scrollTop = 480;
+        });
+        const articleScrollTop = await article.evaluate((element) => element.scrollTop);
+        expect(articleScrollTop).toBeGreaterThan(0);
+        const originalFrame = await outer.elementHandle();
+        const originalBoard = await board.elementHandle();
+        if (!originalFrame || !originalBoard) {
+          throw new Error("Daily Claw frame and board were not mounted");
+        }
+        const composer = page.locator(
+          "openclaw-chat-pane.chat-pane-cache__pane--visible .agent-chat__composer-combobox textarea",
+        );
+        await capture("01-daily-claw-warmed.png");
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+          await sessionLink(chatKey).click();
+          await composer.waitFor();
+          await expect.poll(() => sessionLink(chatKey).getAttribute("aria-current")).toBe("page");
+          if (attempt === 0) {
+            await composer.fill(draft);
+            await capture("02-chat-with-draft.png");
+          } else {
+            expect(await composer.inputValue()).toBe(draft);
+          }
+          expect(await originalFrame.evaluate((element) => element.isConnected)).toBe(true);
+          await expect
+            .poll(() => originalBoard.evaluate((element) => Reflect.get(element, "active")))
+            .toBe(false);
+          await sessionLink(dashboardKey).click();
+          await readingNote.waitFor();
+          expect(
+            await outer.evaluate((element, previous) => element === previous, originalFrame),
+          ).toBe(true);
+          expect(await readingNote.inputValue()).toBe(note);
+          expect(await article.evaluate((element) => element.scrollTop)).toBe(articleScrollTop);
+        }
+        await page.locator("openclaw-app-sidebar .sidebar-identity-card").click();
+        await page
+          .locator('openclaw-app-sidebar wa-dropdown-item[value="command:settings"]')
+          .click();
+        await page.locator(".settings-sidebar__back").waitFor();
+        const parked = {
+          frameConnected: await originalFrame.evaluate((element) => element.isConnected),
+          boardActive: await originalBoard.evaluate((element) => Reflect.get(element, "active")),
+        };
+        await page.locator(".settings-sidebar__back").click();
+        await readingNote.waitFor();
+        // Retain the pre-fix failure's returned dashboard before checking its lost frame.
+        await capture("03-daily-claw-after-settings.png");
+        expect(
+          await outer.evaluate((element, previous) => element === previous, originalFrame),
+        ).toBe(true);
+        expect(parked).toEqual({ frameConnected: true, boardActive: false });
+        expect(await readingNote.inputValue()).toBe(note);
+        expect(await article.evaluate((element) => element.scrollTop)).toBe(articleScrollTop);
+        await sessionLink(chatKey).click();
+        await composer.waitFor();
+        expect(await composer.inputValue()).toBe(draft);
+        await sessionLink(dashboardKey).click();
+        await readingNote.waitFor();
+        await rpc("board.widget.put", {
+          ...widgetParams,
+          content: {
+            kind: "html",
+            html: articleHtml("Afternoon edition: refreshed from the Gateway"),
+          },
+        });
+        await inner
+          .getByText("Afternoon edition: refreshed from the Gateway", { exact: true })
+          .waitFor();
+        await capture("04-daily-claw-refreshed.png");
       },
     );
   });

--- a/ui/src/e2e/new-session-page.draft-handoff.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.draft-handoff.e2e.test.ts
@@ -37,12 +37,13 @@ suite.define(() => {
         (url) => url.pathname.endsWith("/new") && url.search === "?agent=main",
       );
 
-      const messageA = pageA.locator(".new-session-page__message");
+      const newSessionA = pageA.locator("openclaw-new-session-page");
+      const messageA = newSessionA.locator(".new-session-page__message");
       await messageA.fill(staleText);
-      await pageA
+      await newSessionA
         .locator(".agent-chat__photo-input")
         .setInputFiles(path.join(process.cwd(), "ui/public/favicon-32.png"));
-      await pageA.getByRole("button", { name: `Open image ${staleFileName}` }).waitFor();
+      await newSessionA.getByRole("button", { name: `Open image ${staleFileName}` }).waitFor();
       await captureUiProof(suite, pageA, "new-session-draft-before-navigation.png");
 
       await existingSession.click();
@@ -51,22 +52,23 @@ suite.define(() => {
       const pageB = await context.newPage();
       await installMockGateway(pageB);
       await pageB.goto(`${suite.server.baseUrl}new?agent=main`);
-      const messageB = pageB.locator(".new-session-page__message");
+      const newSessionB = pageB.locator("openclaw-new-session-page");
+      const messageB = newSessionB.locator(".new-session-page__message");
       await expect.poll(() => messageB.inputValue()).toBe(staleText);
-      await pageB.getByRole("button", { name: `Open image ${staleFileName}` }).waitFor();
+      await newSessionB.getByRole("button", { name: `Open image ${staleFileName}` }).waitFor();
 
       await messageB.fill(durableText);
-      await pageB.getByRole("button", { name: "Remove attachment" }).click();
-      await pageB
+      await newSessionB.getByRole("button", { name: "Remove attachment" }).click();
+      await newSessionB
         .locator(".agent-chat__photo-input")
         .setInputFiles(path.join(process.cwd(), "ui/public/apple-touch-icon.png"));
-      await pageB.getByRole("button", { name: `Open image ${durableFileName}` }).waitFor();
+      await newSessionB.getByRole("button", { name: `Open image ${durableFileName}` }).waitFor();
       await waitForCommittedNewSessionDraft(pageB, durableText, [durableFileName]);
       await pageB.reload();
       await expect.poll(() => messageB.inputValue()).toBe(durableText);
-      await pageB.getByRole("button", { name: `Open image ${durableFileName}` }).waitFor();
+      await newSessionB.getByRole("button", { name: `Open image ${durableFileName}` }).waitFor();
       await expect(
-        pageB.getByRole("button", { name: `Open image ${staleFileName}` }).count(),
+        newSessionB.getByRole("button", { name: `Open image ${staleFileName}` }).count(),
       ).resolves.toBe(0);
       await pageB.close();
 
@@ -75,9 +77,9 @@ suite.define(() => {
         (url) => url.pathname.endsWith("/new") && url.search === "?agent=main",
       );
       await expect.poll(() => messageA.inputValue()).toBe(durableText);
-      await pageA.getByRole("button", { name: `Open image ${durableFileName}` }).waitFor();
+      await newSessionA.getByRole("button", { name: `Open image ${durableFileName}` }).waitFor();
       await expect(
-        pageA.getByRole("button", { name: `Open image ${staleFileName}` }).count(),
+        newSessionA.getByRole("button", { name: `Open image ${staleFileName}` }).count(),
       ).resolves.toBe(0);
       await captureUiProof(suite, pageA, "new-session-draft-restored.png");
       await pageA.close();

--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -716,9 +716,10 @@ suite.define(() => {
           .toBe(1);
 
         await gateway.deferNext("users.prefs.set");
-        const modelSelect = page.locator('[data-chat-model-select="true"]');
+        const newSession = page.locator("openclaw-new-session-page");
+        const modelSelect = newSession.locator('[data-chat-model-select="true"]');
         await modelSelect.click();
-        await page.locator('[data-chat-model-option="openai/gpt-5.5"]').click();
+        await newSession.locator('[data-chat-model-option="openai/gpt-5.5"]').click();
         await expect
           .poll(async () => (await gateway.getRequests("users.prefs.set")).length)
           .toBe(2);
@@ -802,9 +803,10 @@ suite.define(() => {
         .getByRole("button", { name: "New worktree Isolated copy of the repo", exact: true })
         .click();
       await page.keyboard.press("Escape");
-      const modelSelect = page.locator('[data-chat-model-select="true"]');
+      const newSession = page.locator("openclaw-new-session-page");
+      const modelSelect = newSession.locator('[data-chat-model-select="true"]');
       await modelSelect.click();
-      await page.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]').click();
+      await newSession.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]').click();
 
       await navigateInApp(page, "chat");
       await waitForCommittedChatRoute(page);
@@ -892,9 +894,9 @@ suite.define(() => {
         "openclaw-next",
       );
 
-      const modelSelect = page.locator('[data-chat-model-select="true"]');
-      await modelSelect.click();
-      await page.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]').click();
+      const newSession = page.locator("openclaw-new-session-page");
+      await newSession.locator('[data-chat-model-select="true"]').click();
+      await newSession.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]').click();
       const storedPreference = await readMainPreference(page);
       expect(storedPreference).toMatchObject({
         workspace: MOVED_WORKSPACE,

--- a/ui/src/e2e/session-progress-widget.e2e.test.ts
+++ b/ui/src/e2e/session-progress-widget.e2e.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
+import { openSlot } from "../pages/chat/sidebar-layout.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiBundledSettingsStorageKey,
@@ -89,7 +90,7 @@ suite.define(() => {
       });
       const storageKey = controlUiBundledSettingsStorageKey(suite.server.baseUrl);
       await page.addInitScript(
-        ({ key, rawKey, storage }) => {
+        ({ key, rawKey, storage, dashboardLayout }) => {
           localStorage.setItem(
             storage,
             JSON.stringify({
@@ -97,6 +98,8 @@ suite.define(() => {
               ...(rawKey === key
                 ? {}
                 : {
+                    // Each split pane owns its presentation independently of the current route.
+                    sidebarSessionLayouts: { [rawKey]: dashboardLayout },
                     chatSplitLayout: {
                       activePaneId: "p1",
                       columns: [
@@ -109,7 +112,12 @@ suite.define(() => {
             }),
           );
         },
-        { key: sessionKey, rawKey: viewport.routeKey, storage: storageKey },
+        {
+          key: sessionKey,
+          rawKey: viewport.routeKey,
+          storage: storageKey,
+          dashboardLayout: openSlot({ columns: [] }, "dashboard"),
+        },
       );
 
       await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey, "dashboard"));

--- a/ui/src/pages/chat/chat-page-drop-indicator.ts
+++ b/ui/src/pages/chat/chat-page-drop-indicator.ts
@@ -1,0 +1,36 @@
+import type { ChatPaneElement } from "./route-draft-focus-handoff.ts";
+import {
+  resolveSplitDropZone,
+  splitDropIndicatorRect,
+  type SplitDropRect,
+  type SplitDropZone,
+} from "./split-drop-zone.ts";
+
+export type DropIndicator = { paneId: string; zone: SplitDropZone; rect: SplitDropRect };
+
+export function resolveDropIndicator(
+  host: ParentNode,
+  pane: ChatPaneElement,
+  x: number,
+  y: number,
+): DropIndicator | null {
+  const paneId = pane.paneId;
+  const container = host.querySelector<HTMLElement>(".chat-split-view__drop-container");
+  if (!paneId || !container) {
+    return null;
+  }
+  const paneRect = pane.getBoundingClientRect();
+  const zone = resolveSplitDropZone(paneRect, x, y);
+  const indicatorRect = splitDropIndicatorRect(paneRect, zone);
+  const containerRect = container.getBoundingClientRect();
+  return {
+    paneId,
+    zone,
+    rect: {
+      left: indicatorRect.left - containerRect.left,
+      top: indicatorRect.top - containerRect.top,
+      width: indicatorRect.width,
+      height: indicatorRect.height,
+    },
+  };
+}

--- a/ui/src/pages/chat/chat-page-pane-render.ts
+++ b/ui/src/pages/chat/chat-page-pane-render.ts
@@ -1,4 +1,4 @@
-import { html, nothing } from "lit";
+import { html, noChange, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import type { ApplicationContext } from "../../app/context.ts";
 import { nativeGatewaysCapability } from "../../app/native-gateways.runtime.ts";
@@ -16,6 +16,7 @@ import type { ChatSplitPane } from "./split-layout-types.ts";
 
 type ChatPagePaneRenderOptions = {
   active: boolean;
+  presented: boolean;
   chatMessagesBySession: ChatMessageCache;
   sessionSnapshotStore: SessionSnapshotStore;
   consumedDraftData: SessionChatRouteData | null;
@@ -73,8 +74,12 @@ export function renderChatPagePaneCell(options: ChatPagePaneRenderOptions) {
             const visible =
               sessionKey === options.pane.sessionKey ||
               areUiSessionKeysEquivalent(sessionKey, options.pane.sessionKey);
-            const presented = visible && (!options.narrow || options.active);
+            const presented = options.presented && visible && (!options.narrow || options.active);
             const active = options.active && visible;
+            const routeData =
+              options.data && areUiSessionKeysEquivalent(sessionKey, options.data.sessionKey)
+                ? options.data
+                : undefined;
             const draft = active
               ? routeDraft(options.data, options.consumedDraftData, sessionKey)
               : undefined;
@@ -109,8 +114,8 @@ export function renderChatPagePaneCell(options: ChatPagePaneRenderOptions) {
                 sessionKey,
                 options.data,
               )}
-              .dashboardExpanded=${options.data?.dashboardExpanded === true}
-              .routeFace=${options.data?.face ?? "chat"}
+              .dashboardExpanded=${routeData ? routeData.dashboardExpanded === true : noChange}
+              .routeFace=${routeData ? (routeData.face ?? "chat") : noChange}
               .paneTitle=${title}
               .narrow=${options.narrow}
               .mergedChrome=${options.mergedChrome && active}

--- a/ui/src/pages/chat/chat-page-retained-sessions.test.ts
+++ b/ui/src/pages/chat/chat-page-retained-sessions.test.ts
@@ -36,6 +36,8 @@ type RenderedPane = HTMLElement & {
   paneId: string;
   presentationId: string;
   presented: boolean;
+  routeFace: "chat" | "dashboard";
+  dashboardExpanded: boolean;
   sessionKey: string;
 };
 
@@ -241,6 +243,44 @@ describe("chat page retained sessions", () => {
     expect(paneB?.isConnected).toBe(false);
   });
 
+  it("parks pane activity and ignores session commands while another page is presented", async () => {
+    const { page, paneFor, navigation } = await mountRetainedPage("agent:main:a", "agent:main:b");
+    const paneB = paneFor("agent:main:b");
+    page.presented = false;
+    await page.updateComplete;
+    navigation.navigate.mockClear();
+    navigation.context.gateway.setSessionKey = vi.fn();
+    expect(paneB?.isConnected).toBe(true);
+    expect(paneB?.active).toBe(false);
+    expect(paneB?.presented).toBe(false);
+    expect(paneB?.hasAttribute("inert")).toBe(true);
+
+    const intent = new CustomEvent(SESSION_NAVIGATION_INTENT_EVENT, {
+      cancelable: true,
+      detail: { commit: () => true, face: "chat", sessionKey: "agent:main:a" },
+    });
+    window.dispatchEvent(intent);
+    expect(intent.defaultPrevented).toBe(false);
+    const command = new CustomEvent(UI_COMMAND_EVENT, {
+      cancelable: true,
+      detail: { command: { kind: "navigate", sessionKey: "agent:main:a" } },
+    });
+    window.dispatchEvent(command);
+    expect(command.defaultPrevented).toBe(false);
+    expect(paneB?.onPaneSessionChange?.(paneB.paneId, "agent:main:a")).toBe(false);
+    paneB?.onFaceChange?.(paneB.paneId, "agent:main:b", "dashboard");
+    expect(navigation.navigate).not.toHaveBeenCalled();
+    expect(navigation.patch).not.toHaveBeenCalled();
+    expect(navigation.context.gateway.setSessionKey).not.toHaveBeenCalled();
+
+    page.presented = true;
+    await page.updateComplete;
+    expect(paneFor("agent:main:b")).toBe(paneB);
+    expect(paneB?.active).toBe(true);
+    expect(paneB?.presented).toBe(true);
+    expect(paneB?.hasAttribute("inert")).toBe(false);
+  });
+
   it.each([
     { retainedSessionKey: "main", routeSessionKey: "agent:main:main" },
     { retainedSessionKey: "agent:main:main", routeSessionKey: "main" },
@@ -398,74 +438,87 @@ describe("chat page retained sessions", () => {
     }
   });
 
-  it("presents a retained sidebar destination before route data resolves", async () => {
-    const { page, paneFor, panes } = await mountRetainedPage(
-      "agent:main:a",
-      "agent:main:b",
-      "agent:main:a",
-    );
-    const paneA = paneFor("agent:main:a");
-    const paneB = paneFor("agent:main:b");
+  it.each([
+    { sourceFace: "chat", targetFace: "chat" },
+    { sourceFace: "chat", targetFace: "dashboard" },
+    { sourceFace: "dashboard", targetFace: "chat" },
+  ] as const)(
+    "presents a retained $targetFace from $sourceFace before route data resolves",
+    async ({ sourceFace, targetFace }) => {
+      const { page, paneFor, panes } = await mountRetainedPage(
+        "agent:main:a",
+        "agent:main:b",
+        "agent:main:a",
+      );
+      const paneA = paneFor("agent:main:a");
+      const paneB = paneFor("agent:main:b");
+      page.data = { sessionKey: "agent:main:b", face: targetFace, dashboardExpanded: true };
+      await page.updateComplete;
+      page.data = { sessionKey: "agent:main:a", face: sourceFace };
+      await page.updateComplete;
+      expect(paneB?.routeFace).toBe(targetFace);
+      expect(paneB?.dashboardExpanded).toBe(true);
 
-    const intent = new CustomEvent(SESSION_NAVIGATION_INTENT_EVENT, {
-      cancelable: true,
-      detail: { commit: () => true, face: "chat", sessionKey: "agent:main:b" },
-    });
-    window.dispatchEvent(intent);
-
-    expect(intent.defaultPrevented).toBe(true);
-    expect(page.data.sessionKey).toBe("agent:main:a");
-    expect(paneA?.classList.contains("chat-pane-cache__pane--visible")).toBe(false);
-    expect(paneA?.presented).toBe(true);
-    expect(paneA?.hasAttribute("inert")).toBe(true);
-    expect(paneA?.getAttribute("aria-hidden")).toBe("false");
-    expect(paneB?.classList.contains("chat-pane-cache__pane--visible")).toBe(true);
-    expect(paneB?.presented).toBe(false);
-    expect(paneB?.hasAttribute("inert")).toBe(true);
-    expect(paneB?.getAttribute("aria-hidden")).toBe("true");
-    expect(paneA?.active).toBe(true);
-    expect(paneB?.active).toBe(false);
-
-    window.dispatchEvent(
-      new CustomEvent(SESSION_NAVIGATION_INTENT_EVENT, {
+      const intent = new CustomEvent(SESSION_NAVIGATION_INTENT_EVENT, {
         cancelable: true,
-        detail: { commit: () => true, face: "chat", sessionKey: "agent:main:a" },
-      }),
-    );
-    expect(paneA?.classList.contains("chat-pane-cache__pane--visible")).toBe(true);
-    expect(paneA?.presented).toBe(true);
-    expect(paneA?.hasAttribute("inert")).toBe(false);
-    expect(paneB?.classList.contains("chat-pane-cache__pane--visible")).toBe(false);
-    expect(paneB?.presented).toBe(false);
-    expect(paneB?.hasAttribute("inert")).toBe(true);
+        detail: { commit: () => true, face: targetFace, sessionKey: "agent:main:b" },
+      });
+      window.dispatchEvent(intent);
 
-    window.dispatchEvent(
-      new CustomEvent(SESSION_NAVIGATION_INTENT_EVENT, {
-        cancelable: true,
-        detail: { commit: () => true, face: "chat", sessionKey: "agent:main:b" },
-      }),
-    );
-    window.dispatchEvent(new PopStateEvent("popstate"));
-    expect(paneA?.presented).toBe(true);
-    expect(paneB?.presented).toBe(false);
+      expect(intent.defaultPrevented).toBe(true);
+      expect(page.data.sessionKey).toBe("agent:main:a");
+      expect(paneA?.classList.contains("chat-pane-cache__pane--visible")).toBe(false);
+      expect(paneA?.presented).toBe(true);
+      expect(paneA?.hasAttribute("inert")).toBe(true);
+      expect(paneA?.getAttribute("aria-hidden")).toBe("false");
+      expect(paneB?.classList.contains("chat-pane-cache__pane--visible")).toBe(true);
+      expect(paneB?.presented).toBe(false);
+      expect(paneB?.hasAttribute("inert")).toBe(true);
+      expect(paneB?.getAttribute("aria-hidden")).toBe("true");
+      expect(paneA?.active).toBe(true);
+      expect(paneB?.active).toBe(false);
 
-    window.dispatchEvent(
-      new CustomEvent(SESSION_NAVIGATION_INTENT_EVENT, {
-        cancelable: true,
-        detail: { commit: () => true, face: "chat", sessionKey: "agent:main:b" },
-      }),
-    );
-    page.data = { sessionKey: "agent:main:b" };
-    await page.updateComplete;
-    await page.updateComplete;
-    expect(panes().find((pane) => pane.sessionKey === "agent:main:b")).toBe(paneB);
-    expect(paneA?.active).toBe(false);
-    expect(paneA?.presented).toBe(false);
-    expect(paneA?.hasAttribute("inert")).toBe(true);
-    expect(paneB?.active).toBe(true);
-    expect(paneB?.presented).toBe(true);
-    expect(paneB?.hasAttribute("inert")).toBe(false);
-  });
+      window.dispatchEvent(
+        new CustomEvent(SESSION_NAVIGATION_INTENT_EVENT, {
+          cancelable: true,
+          detail: { commit: () => true, face: sourceFace, sessionKey: "agent:main:a" },
+        }),
+      );
+      expect(paneA?.classList.contains("chat-pane-cache__pane--visible")).toBe(true);
+      expect(paneA?.presented).toBe(true);
+      expect(paneA?.hasAttribute("inert")).toBe(false);
+      expect(paneB?.classList.contains("chat-pane-cache__pane--visible")).toBe(false);
+      expect(paneB?.presented).toBe(false);
+      expect(paneB?.hasAttribute("inert")).toBe(true);
+
+      window.dispatchEvent(
+        new CustomEvent(SESSION_NAVIGATION_INTENT_EVENT, {
+          cancelable: true,
+          detail: { commit: () => true, face: targetFace, sessionKey: "agent:main:b" },
+        }),
+      );
+      window.dispatchEvent(new PopStateEvent("popstate"));
+      expect(paneA?.presented).toBe(true);
+      expect(paneB?.presented).toBe(false);
+
+      window.dispatchEvent(
+        new CustomEvent(SESSION_NAVIGATION_INTENT_EVENT, {
+          cancelable: true,
+          detail: { commit: () => true, face: targetFace, sessionKey: "agent:main:b" },
+        }),
+      );
+      page.data = { sessionKey: "agent:main:b", face: targetFace };
+      await page.updateComplete;
+      await page.updateComplete;
+      expect(panes().find((pane) => pane.sessionKey === "agent:main:b")).toBe(paneB);
+      expect(paneA?.active).toBe(false);
+      expect(paneA?.presented).toBe(false);
+      expect(paneA?.hasAttribute("inert")).toBe(true);
+      expect(paneB?.active).toBe(true);
+      expect(paneB?.presented).toBe(true);
+      expect(paneB?.hasAttribute("inert")).toBe(false);
+    },
+  );
 
   it("evicts a deleted inactive retained session without redirecting the active pane", async () => {
     const { navigation, page, paneFor, panes } = await mountRetainedPage(

--- a/ui/src/pages/chat/chat-page-retained-sessions.ts
+++ b/ui/src/pages/chat/chat-page-retained-sessions.ts
@@ -15,7 +15,7 @@ const SESSION_NAVIGATION_PREVIEW_TIMEOUT_MS = 5_000;
 type RetentionHost = HTMLElement & { requestUpdate(): unknown };
 type RetentionBindings = {
   context: () => ApplicationContext | undefined;
-  face: () => SessionNavigationIntent["face"];
+  presented: () => boolean;
   layout: () => ChatSplitLayout;
   selectReplacement: (paneId: string, sourceSessionKey: string, sessionKey: string) => void;
 };
@@ -42,6 +42,10 @@ export class ChatPageRetainedSessions {
     this.sessionsByPane.clear();
     window.removeEventListener("popstate", this.cancelPreview);
     window.removeEventListener(SESSION_NAVIGATION_INTENT_EVENT, this.handleNavigationIntent);
+    this.cancelPreview();
+  }
+
+  suspend(): void {
     this.cancelPreview();
   }
 
@@ -135,14 +139,11 @@ export class ChatPageRetainedSessions {
   }
 
   private readonly handleNavigationIntent = (event: Event) => {
-    if (!(event instanceof CustomEvent)) {
+    if (!this.bindings.presented() || !(event instanceof CustomEvent)) {
       return;
     }
     this.cancelPreview();
     const intent = event.detail as SessionNavigationIntent;
-    if (intent.face !== this.bindings.face()) {
-      return;
-    }
     const layout = this.bindings.layout();
     const activePane = findPane(layout, layout.activePaneId)?.pane;
     const retainedKey = this.sessionsByPane
@@ -151,6 +152,7 @@ export class ChatPageRetainedSessions {
     if (
       !activePane ||
       !retainedKey ||
+      this.findPane(activePane.id, retainedKey)?.routeFace !== intent.face ||
       areUiSessionKeysEquivalent(activePane.sessionKey, retainedKey)
     ) {
       return;
@@ -191,8 +193,9 @@ export class ChatPageRetainedSessions {
       if (pane.paneId !== paneId) {
         continue;
       }
-      const presented = areUiSessionKeysEquivalent(pane.sessionKey ?? "", sessionKey);
-      pane.classList.toggle("chat-pane-cache__pane--visible", presented);
+      const selected = areUiSessionKeysEquivalent(pane.sessionKey ?? "", sessionKey);
+      const presented = this.bindings.presented() && selected;
+      pane.classList.toggle("chat-pane-cache__pane--visible", selected);
       pane.visuallyPresented = presented;
       if (preview) {
         pane.toggleAttribute("inert", true);

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -18,6 +18,7 @@ import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { persistSessionBoardFace } from "./chat-board-face-persistence.ts";
 import { currentRouteLocation, stillOwnsCanonicalLocation } from "./chat-canonical-location.ts";
+import { resolveDropIndicator, type DropIndicator } from "./chat-page-drop-indicator.ts";
 import { renderChatPagePaneCell } from "./chat-page-pane-render.ts";
 import { ChatPageRetainedSessions } from "./chat-page-retained-sessions.ts";
 import { closeStagedPane, resumeStagedPanes } from "./chat-pane-attachment-handoff.ts";
@@ -32,12 +33,7 @@ import type { SessionChatRouteData } from "./route-loader.ts";
 import { observeChatCache, type ChatMessageCache } from "./session-message-cache.ts";
 import { installSessionPrefetch } from "./session-prefetch.ts";
 import { SessionSnapshotStore } from "./session-snapshot-store.ts";
-import {
-  resolveSplitDropZone,
-  splitDropIndicatorRect,
-  type SplitDropRect,
-  type SplitDropZone,
-} from "./split-drop-zone.ts";
+import type { SplitDropZone } from "./split-drop-zone.ts";
 import type { ChatSplitLayout, SessionSplitHost } from "./split-layout-types.ts";
 import {
   applyUiCommandToSplitLayout,
@@ -54,20 +50,19 @@ import {
   splitWeight,
 } from "./split-layout.ts";
 
-type DropIndicator = { paneId: string; zone: SplitDropZone; rect: SplitDropRect };
-
 export class ChatPage extends OpenClawLightDomElement implements SessionSplitHost {
   @consume({ context: applicationContext, subscribe: true })
   private context!: ApplicationContext;
   @property({ attribute: false }) data!: SessionChatRouteData;
   @property({ attribute: false }) navDrawerOpen = false;
+  @property({ type: Boolean }) presented = true;
   @state() private layout: ChatSplitLayout | undefined;
   @state() private narrow = false;
   @state() private mergedChrome = false;
   @state() private dropIndicator: DropIndicator | null = null;
 
   get sessionSplitAvailable(): boolean {
-    return !this.narrow && Boolean(this.data?.sessionKey?.trim());
+    return this.presented && !this.narrow && Boolean(this.data?.sessionKey?.trim());
   }
 
   private readonly subscriptions = new SubscriptionsController(this)
@@ -94,7 +89,7 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
   private readonly viewerPresence = new ChatViewerPresenceController(this);
   private readonly retainedSessions = new ChatPageRetainedSessions(this, {
     context: () => this.context,
-    face: () => this.data?.face ?? "chat",
+    presented: () => this.presented,
     layout: () => this.layout ?? this.classicLayout(),
     selectReplacement: (paneId, sourceSessionKey, sessionKey) => {
       this.handlePaneSessionChange(paneId, sourceSessionKey, sessionKey);
@@ -122,13 +117,15 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
     this.addEventListener("dragover", this.handleDragOver);
     this.addEventListener("dragleave", this.handleDragLeave);
     this.addEventListener("drop", this.handleDrop);
-    window.addEventListener("dragend", this.handleWindowDragEnd);
+    window.addEventListener("dragend", this.clearDropIndicator);
     window.addEventListener(UI_COMMAND_EVENT, this.handleUiCommand);
     this.retainedSessions.connect();
     this.syncRouteToActivePane();
     this.syncRouteBindings();
     const layout = this.layout ?? this.classicLayout();
-    this.viewerPresence.sync(this.context?.gateway, layout, this.narrow);
+    if (this.presented) {
+      this.viewerPresence.sync(this.context?.gateway, layout, this.narrow);
+    }
   }
 
   override disconnectedCallback() {
@@ -144,13 +141,21 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
     this.removeEventListener("dragover", this.handleDragOver);
     this.removeEventListener("dragleave", this.handleDragLeave);
     this.removeEventListener("drop", this.handleDrop);
-    window.removeEventListener("dragend", this.handleWindowDragEnd);
+    window.removeEventListener("dragend", this.clearDropIndicator);
     window.removeEventListener(UI_COMMAND_EVENT, this.handleUiCommand);
     this.clearDropIndicator();
     super.disconnectedCallback();
   }
 
   override updated(changedProperties: Map<PropertyKey, unknown>) {
+    if (!this.presented) {
+      this.viewerPresence.dispose();
+      if (changedProperties.has("presented")) {
+        this.retainedSessions.suspend();
+        this.clearDropIndicator();
+      }
+      return;
+    }
     const layout = this.layout ?? this.classicLayout();
     resumeStagedPanes(this, layout, this.narrow);
     if (this.isConnected) {
@@ -164,7 +169,7 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
       activeSessionKey,
       this.consumedDraftData,
     );
-    if (changedProperties.has("data")) {
+    if (data && (changedProperties.has("data") || changedProperties.has("presented"))) {
       this.routeHref = window.location.href;
       if (
         data?.canonicalLocation &&
@@ -178,6 +183,7 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
         if (
           location &&
           this.isConnected &&
+          this.presented &&
           this.data === data &&
           stillOwnsCanonicalLocation(data.canonicalLocationSource, this.consumedDraftData === data)
         ) {
@@ -194,7 +200,12 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
     }
     if (data && routeHandoffRendered) {
       queueMicrotask(() => {
-        if (this.isConnected && this.data === data && this.consumedDraftData !== data) {
+        if (
+          this.isConnected &&
+          this.presented &&
+          this.data === data &&
+          this.consumedDraftData !== data
+        ) {
           this.draftFocus.beforeDraftCleanup(data);
           this.consumedDraftData = data;
           this.updateRoute(data.sessionKey, true, data.face ?? "chat");
@@ -220,7 +231,7 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
   };
 
   private readonly handleUiCommand = (event: Event) => {
-    if (!(event instanceof CustomEvent)) {
+    if (!this.presented || !(event instanceof CustomEvent)) {
       return;
     }
     const { command, sessionKey: sourceSessionKey } = event.detail as UiCommandDetail;
@@ -297,7 +308,7 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
       if (!pending || this.narrow || !this.isConnected) {
         return;
       }
-      const indicator = this.resolveDropIndicator(pending.pane, pending.x, pending.y);
+      const indicator = resolveDropIndicator(this, pending.pane, pending.x, pending.y);
       if (!indicator) {
         return;
       }
@@ -334,7 +345,7 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
     const pane = target?.closest<ChatPaneElement>("openclaw-chat-pane");
     const indicator =
       (pane && this.contains(pane)
-        ? this.resolveDropIndicator(pane, event.clientX, event.clientY)
+        ? resolveDropIndicator(this, pane, event.clientX, event.clientY)
         : null) ?? this.dropIndicator;
     this.clearDropIndicator();
     if (sessionKey && indicator) {
@@ -342,14 +353,10 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
     }
   };
 
-  private readonly handleWindowDragEnd = () => {
-    this.clearDropIndicator();
-  };
-
-  private clearDropIndicator() {
+  private readonly clearDropIndicator = () => {
     this.dragDepth = 0;
     this.clearDropPreview();
-  }
+  };
 
   private clearDropPreview() {
     this.pendingDragOver = null;
@@ -358,28 +365,6 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
       this.dragFrame = 0;
     }
     this.dropIndicator = null;
-  }
-
-  private resolveDropIndicator(pane: ChatPaneElement, x: number, y: number): DropIndicator | null {
-    const paneId = pane.paneId;
-    const container = this.querySelector<HTMLElement>(".chat-split-view__drop-container");
-    if (!paneId || !container) {
-      return null;
-    }
-    const paneRect = pane.getBoundingClientRect();
-    const zone = resolveSplitDropZone(paneRect, x, y);
-    const indicatorRect = splitDropIndicatorRect(paneRect, zone);
-    const containerRect = container.getBoundingClientRect();
-    return {
-      paneId,
-      zone,
-      rect: {
-        left: indicatorRect.left - containerRect.left,
-        top: indicatorRect.top - containerRect.top,
-        width: indicatorRect.width,
-        height: indicatorRect.height,
-      },
-    };
   }
 
   private syncRouteToActivePane() {
@@ -396,6 +381,9 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
   }
 
   private syncRouteBindings() {
+    if (!this.presented) {
+      return;
+    }
     const activePane = this.layout && findPane(this.layout, this.layout.activePaneId)?.pane;
     const routeKey = (activePane?.sessionKey ?? this.data?.sessionKey)?.trim();
     if (this.context && routeKey) {
@@ -410,6 +398,9 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
   }
 
   private updateRoute(sessionKey: string, replace = false, face = this.data.face ?? "chat") {
+    if (!this.presented) {
+      return;
+    }
     const data = this.data;
     const sameSession = data && areUiSessionKeysEquivalent(data.sessionKey, sessionKey);
     if (sameSession && (data.face ?? "chat") === face && !data.draft && !data.focusComposer) {
@@ -465,7 +456,7 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
 
   private readonly handleFocusPane = (paneId: string) => {
     const layout = this.layout;
-    if (!layout || layout.activePaneId === paneId) {
+    if (!this.presented || !layout || layout.activePaneId === paneId) {
       return;
     }
     const pane = findPane(layout, paneId)?.pane;
@@ -483,7 +474,7 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
     options?: { replace?: boolean },
   ): boolean => {
     const trimmed = sessionKey.trim();
-    if (!trimmed || window.location.href !== this.routeHref) {
+    if (!this.presented || !trimmed || window.location.href !== this.routeHref) {
       return false;
     }
     const resolvedLayout = this.layout ?? this.classicLayout();
@@ -510,6 +501,9 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
     sessionKey: string,
     face: BoardFace,
   ): void => {
+    if (!this.presented) {
+      return;
+    }
     const selectedSessionKey = findPane(this.layout ?? this.classicLayout(), paneId)?.pane
       .sessionKey;
     if (!selectedSessionKey || !areUiSessionKeysEquivalent(selectedSessionKey, sessionKey)) {
@@ -601,7 +595,8 @@ export class ChatPage extends OpenClawLightDomElement implements SessionSplitHos
                 (pane) => pane.id,
                 (pane, paneIndex) => html`
                   ${renderChatPagePaneCell({
-                    active: pane.id === layout.activePaneId,
+                    active: this.presented && pane.id === layout.activePaneId,
+                    presented: this.presented,
                     chatMessagesBySession: this.messageCache,
                     sessionSnapshotStore: this.snapshotStore,
                     consumedDraftData: this.consumedDraftData,

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -120,6 +120,10 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
     const chat = renderChat({
       ...chatProps,
       presented: this.active && this.presented,
+      transcriptVisible:
+        this.presented &&
+        this.visuallyPresented &&
+        isSidebarSlotVisible(sidebarLayout, "conversation"),
       browserTabPreviewsActive: this.active && this.presented,
       historyState: catalog ? undefined : state,
       header: nothing,

--- a/ui/src/pages/chat/chat-pane-retained-presentation.ts
+++ b/ui/src/pages/chat/chat-pane-retained-presentation.ts
@@ -7,6 +7,7 @@ import { sessionPullRequestsForGateway } from "../../lib/session-pull-requests.t
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { storeChatComposerMemoryFallback } from "./chat-composer-memory-fallback.ts";
 import { loadChatBranches, retireChatBranchRequests } from "./chat-history-branches.ts";
+import { loadChatHistory } from "./chat-history.ts";
 import { ChatPaneBoard } from "./chat-pane-board.ts";
 import {
   consumePaneSessionHandoff,
@@ -170,6 +171,15 @@ export abstract class ChatPaneRetainedPresentation extends ChatPaneBoard {
       const deferredHydrationActive = this.resumeDeferredSessionHydration();
       if (state && !deferredHydrationActive) {
         this.markSessionRead(selectedChatSessionRow(state));
+        if (
+          state.connected &&
+          this.resolveChatReadTarget() &&
+          (state.chatRunId || selectedChatSessionRow(state)?.hasActiveRun)
+        ) {
+          // Keep the retained transcript visible while reconciling the live run's
+          // authoritative start time and activity after a foreground return.
+          void loadChatHistory(state, { deferBranches: true });
+        }
       }
       if (
         state &&

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -74,6 +74,8 @@ export type ChatThreadProps = ChatSendStatusActions & {
   personActivity?: PersonActivityRouting;
   sessionKey: string;
   presented?: boolean;
+  /** Mounted transcript visibility, independent of which split pane owns input. */
+  transcriptVisible?: boolean;
   gatewayClient?: GatewayBrowserClient | null;
   selectedSession: GatewaySessionRow | undefined;
   boardProvider?: BoardProvider;

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -86,7 +86,7 @@ function renderTranscriptShell(
   return html`
     <div
       class="chat-thread ${projection.isDirectThread ? "chat-thread--direct" : ""}"
-      ${markdownBlocks()}
+      ${markdownBlocks(props.transcriptVisible ?? true)}
       ${ref((element) => {
         if (element instanceof HTMLElement) {
           hydrateLinkFavicons(element, props.fetchLinkFavicon);

--- a/ui/src/pages/chat/route-draft-focus-handoff.ts
+++ b/ui/src/pages/chat/route-draft-focus-handoff.ts
@@ -1,3 +1,4 @@
+import type { BoardFace } from "../../lib/board/settings.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import type { SessionChatRouteData } from "./route-loader.ts";
 
@@ -19,6 +20,7 @@ export type ChatPaneElement = HTMLElement & {
   paneId?: string;
   prepareForEviction?: () => void;
   presented?: boolean;
+  routeFace?: BoardFace;
   sessionKey?: string;
   transcriptLoading?: boolean;
   transcriptReady?: boolean;

--- a/ui/src/pages/chat/route-view.ts
+++ b/ui/src/pages/chat/route-view.ts
@@ -56,7 +56,7 @@ function renderMissingSession(data: Extract<ChatRouteData, { kind: "missing-sess
   });
 }
 
-export function renderChatRoute(data: unknown) {
+export function renderChatRoute(data: unknown, _loaderPending = false, presented = true) {
   // SAFETY: This renderer receives only this route's colocated ChatRouteData loader result.
   const routeData = data as ChatRouteData | undefined;
   if (!routeData) {
@@ -71,7 +71,7 @@ export function renderChatRoute(data: unknown) {
   if (routeData.kind === "missing-session") {
     return renderMissingSession(routeData);
   }
-  return html`<openclaw-chat-page .data=${routeData}></openclaw-chat-page>`;
+  return html`<openclaw-chat-page .data=${routeData} .presented=${presented}></openclaw-chat-page>`;
 }
 
 export function sessionRenderOwnerKey(

--- a/ui/src/pages/chat/route.test.ts
+++ b/ui/src/pages/chat/route.test.ts
@@ -4,6 +4,7 @@ import type { SessionsResolveResult } from "../../../../packages/gateway-protoco
 import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { loadChatRoute } from "./route-loader.ts";
+import { pages } from "./route.ts";
 
 const keyUuid = "12345678-90ab-cdef-1234-567890abcdef";
 const sessionKey = `agent:main:dashboard:${keyUuid}`;
@@ -547,5 +548,43 @@ describe("loadChatRoute", () => {
       draft: undefined,
       face: "dashboard",
     });
+  });
+});
+
+describe("session route cache ownership", () => {
+  it.each(pages)("isolates $id loader results across connection owners", (page) => {
+    const { context } = contextFor();
+    let snapshot = context.gateway.snapshot;
+    let revision = 0;
+    const gateway = {
+      ...context.gateway,
+      get snapshot() {
+        return snapshot;
+      },
+      get connectionRevision() {
+        return revision;
+      },
+    };
+    const scopedContext = { ...context, gateway };
+    const location = { pathname: `/${page.id}/main`, search: "", hash: "" };
+    const cacheKey = () => page.loaderDeps!(scopedContext, location);
+    const initial = cacheKey();
+
+    snapshot = { ...snapshot, selfUser: { id: "first-user" } };
+    expect(cacheKey()).toBe(initial);
+    snapshot = { ...snapshot, phase: "reconnecting", selfUser: null };
+    expect(cacheKey()).toBe(initial);
+    snapshot = { ...snapshot, phase: "connected", selfUser: { id: "first-user" } };
+    expect(cacheKey()).toBe(initial);
+
+    snapshot = { ...snapshot, selfUser: { id: "second-user" } };
+    const replacementUser = cacheKey();
+    expect(replacementUser).not.toBe(initial);
+    revision += 1;
+    const replacementCredentials = cacheKey();
+    expect(replacementCredentials).not.toBe(replacementUser);
+    expect(page.loaderDeps!({ ...scopedContext, gateway: { ...gateway } }, location)).not.toBe(
+      replacementCredentials,
+    );
   });
 });

--- a/ui/src/pages/chat/route.ts
+++ b/ui/src/pages/chat/route.ts
@@ -2,6 +2,7 @@ import type { RouteLocation } from "@openclaw/uirouter";
 import { definePage } from "@openclaw/uirouter";
 import { INTERNAL_SESSION_PATH_PARAM, pathForRoute, routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { gatewayPresentationScope } from "../../app/gateway-presentation-scope.ts";
 import type { BoardFace } from "../../lib/board/settings.ts";
 
 function sessionLoaderDeps(
@@ -18,7 +19,7 @@ function sessionLoaderDeps(
     search.delete(INTERNAL_SESSION_PATH_PARAM);
   }
   const serializedSearch = search.toString();
-  return `${bridgedPath ?? location.pathname}\u0000${
+  return `${gatewayPresentationScope(context.gateway).key}\u0000${bridgedPath ?? location.pathname}\u0000${
     serializedSearch ? `?${serializedSearch}` : ""
   }`;
 }
@@ -46,6 +47,7 @@ function sessionPage(face: BoardFace) {
         // ChatPage's bounded inner cache owns per-session teardown, so session
         // routes share the outer owner while their data and URL keep changing.
         renderOwnerKey: sessionRenderOwnerKey,
+        retainOnNavigate: true,
         render: renderChatRoute,
       })),
   });

--- a/ui/src/plugins/control-ui-view.runtime.ts
+++ b/ui/src/plugins/control-ui-view.runtime.ts
@@ -38,6 +38,7 @@ class ControlUiPluginView extends OpenClawLightDomContentsElement {
   private registration?: ViewRegistration;
   private mountAbort?: AbortController;
   private mountGeneration = 0;
+  private composerGeneration = 0;
   private ownerChanged = false;
   private handle?: ReturnType<ControlUiView<unknown>>;
   private viewContext?: ControlUiViewContext<unknown>;
@@ -69,6 +70,10 @@ class ControlUiPluginView extends OpenClawLightDomContentsElement {
 
   override requestUpdate(...args: Parameters<OpenClawLightDomContentsElement["requestUpdate"]>) {
     const [name, previous] = args;
+    if (name === "presented" && this.presented !== previous) {
+      // Retention preserves the view host, but old composer operations must never revive.
+      this.composerGeneration += 1;
+    }
     if (name === "props") {
       // SAFETY: host renderers supply props records; plugin page props may omit session identity.
       const before = previous as Partial<BoardGetParams> | undefined;
@@ -167,8 +172,14 @@ class ControlUiPluginView extends OpenClawLightDomContentsElement {
     }
     // SAFETY: renderPluginSurface supplies composer props only for the discriminants checked above.
     const props = this.props as ControlUiSurfaceProps["composer"];
+    const generation = this.composerGeneration;
     const check = () => {
-      if (signal.aborted || this.registration?.signal.aborted) {
+      if (
+        !this.presented ||
+        generation !== this.composerGeneration ||
+        signal.aborted ||
+        this.registration?.signal.aborted
+      ) {
         throw new Error("This plugin UI view has ended.");
       }
     };

--- a/ui/src/plugins/control-ui-view.test.ts
+++ b/ui/src/plugins/control-ui-view.test.ts
@@ -6,6 +6,7 @@ import type {
   ControlUiSurfaceProps,
   ControlUiViewContext,
 } from "../../../src/plugin-sdk/control-ui.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { RouteId } from "../app-route-paths.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import { createApplicationContextProvider } from "../test-helpers/application-context.ts";
@@ -25,6 +26,8 @@ class SurfaceTestHost extends LitElement {
   readonly setDraft = vi.fn((draft: string) => {
     this.draft = draft;
   });
+  readonly send = vi.fn<() => Promise<boolean>>().mockResolvedValue(true);
+  readonly abort = vi.fn();
   readonly navigation = document.createElement("nav");
   override createRenderRoot() {
     return this;
@@ -45,7 +48,8 @@ class SurfaceTestHost extends LitElement {
           sending: false,
           disabledReason: null,
           setDraft: this.setDraft,
-          send: async () => true,
+          send: this.send,
+          abort: this.abort,
         },
         defaultView,
       );
@@ -175,6 +179,82 @@ describe("native UI built-in delegation", () => {
     successor.props.setDraft("Successor draft");
     expect(host.draft).toBe("Successor draft");
   });
+
+  it.each([false, true])(
+    "retires hidden composer operations while retaining the view (same-turn return: %s)",
+    async (sameTurnReturn) => {
+      const contexts: ControlUiViewContext<ControlUiSurfaceProps["composer"]>[] = [];
+      const roots: HTMLElement[] = [];
+      const dispose = vi.fn();
+      const replacement: ControlUiReplacement<"composer"> = {
+        id: "composer",
+        label: "Custom composer",
+        surface: "composer",
+        mount(container, context) {
+          contexts.push(context);
+          roots.push(container);
+          container.textContent = "Retained local view state";
+          return { update: (next) => contexts.push(next), dispose };
+        },
+      };
+      const { host, request } = mountSurface(replacement);
+      await vi.waitFor(() => expect(roots).toHaveLength(1));
+      const current = contexts.at(-1);
+      const view = host.querySelector<LitElement & { presented: boolean }>("openclaw-plugin-view");
+      if (!current || !view) {
+        throw new Error("Expected the composer replacement to mount");
+      }
+      current.props.setDraft("Current draft");
+      const send = createDeferred<boolean>();
+      host.send.mockReturnValueOnce(send.promise);
+      const pending = expect(current.props.send()).rejects.toThrow("view has ended");
+
+      view.presented = false;
+      // Presentation retires operations synchronously without retiring the mounted host.
+      expect(() => current.props.setDraft("Stale draft")).toThrow("view has ended");
+      expect(() => current.props.abort?.()).toThrow("view has ended");
+      const hiddenSend = expect(current.props.send()).rejects.toThrow("view has ended");
+      expect(current.signal.aborted).toBe(false);
+      expect(host.send).toHaveBeenCalledOnce();
+      expect(host.abort).not.toHaveBeenCalled();
+      expect(host.draft).toBe("Current draft");
+
+      if (sameTurnReturn) {
+        view.presented = true;
+      }
+      await hiddenSend;
+      if (!sameTurnReturn) {
+        await view.updateComplete;
+        const hidden = contexts.at(-1);
+        expect(hidden?.presented).toBe(false);
+        expect(() => hidden?.props.setDraft("Hidden draft")).toThrow("view has ended");
+      }
+      view.presented = true;
+      expect(() => current.props.setDraft("Revived draft")).toThrow("view has ended");
+      send.resolve(true);
+      await pending;
+      await view.updateComplete;
+
+      expect(roots).toHaveLength(1);
+      expect(view.querySelector("[data-plugin-view-root]")).toBe(roots[0]);
+      expect(roots[0]?.textContent).toBe("Retained local view state");
+      expect(dispose).not.toHaveBeenCalled();
+      await expect(current.host.request("fixture.retained-view")).resolves.toEqual({ ok: true });
+      expect(request).toHaveBeenCalledOnce();
+      const successor = contexts.at(-1);
+      if (!successor || successor === current) {
+        throw new Error("Expected fresh composer operations on return");
+      }
+      expect(successor.presented).toBe(true);
+      expect(successor.signal).toBe(current.signal);
+      successor.props.setDraft("Successor draft");
+      expect(host.draft).toBe("Successor draft");
+      await expect(successor.props.send()).resolves.toBe(true);
+      successor.props.abort?.();
+      expect(host.abort).toHaveBeenCalledOnce();
+      expect(() => current.props.setDraft("Still retired")).toThrow("view has ended");
+    },
+  );
 
   it("restores retained navigation when a workspace replacement's final update is pending", async () => {
     const { host, select } = mountSurface();

--- a/ui/src/test-helpers/application-context.ts
+++ b/ui/src/test-helpers/application-context.ts
@@ -57,6 +57,7 @@ export function createApplicationGateway(initial: ApplicationGatewaySnapshot) {
   let snapshot = initial;
   const listeners = new Set<(value: ApplicationGatewaySnapshot) => void>();
   const gateway = {
+    connectionRevision: 0,
     connection: { gatewayUrl: "ws://gateway.example.test", token: "", password: "" },
     get snapshot() {
       return snapshot;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users switching between a loaded dashboard and chat would wait for routing, and visiting Settings would discard the dashboard's iframe, reading position, and local widget state.

## Why This Change Was Made

Keep the existing three-session-per-pane cache connected across navigation, preserve each session's chat/dashboard presentation, and display usable cached routes during background refresh. Hidden pages relinquish foreground activity, viewer presence, focus, commands, and transcript observers. Composer callbacks captured before a page is hidden cannot revive when it returns; mounted plugin views keep their local state. Ordinary routes retain their existing loader and DOM lifecycle. Mounted views and session loaders share a Gateway/user scope, and returning pages stay inactive until any pending MCP teardown finishes.

## User Impact

Recently visited tasks and dashboards reopen with their widget state, reading position, and chat drafts intact, including after a Settings visit. The existing cache limit remains unchanged; older views can be evicted, and changing Gateway or signed-in user clears retained views.

## Evidence

- Full local build, final UI rebuild with asset-budget checks, and `node scripts/check-changed.mjs` passed.
- 90 focused tests passed, including reproduced regressions for cross-face presentation, background refresh, retired-scope results, and navigation during MCP teardown.
- Initial browser proof passed all 15 dashboard-retention, navigation, and real-Gateway cases. After the broader CI run exposed lifecycle regressions, 49 browser cases passed across eight affected suites, including the real-Gateway widget suite, native plugin callbacks, code-block observers, new-session drafts/workspace memory, active-turn recovery, and dashboard progress. The live scenario used an isolated Gateway with synthetic data, preserved the same iframe through repeated switches and Settings, retained its note/scroll and the chat draft, then verified a new Gateway widget revision appeared.
- Post-rebase full build and all 15 final navigation/dashboard/live-Gateway browser tests passed on the pushed head.
- Fresh independent autoreview of both the feature and CI repair delta: no actionable P0–P2 findings.
- First-head CI identified unrelated baseline Mermaid mock leakage, Telegram test file length, and a tooling planner timeout. This branch inherits the existing upstream Mermaid and Telegram fixes; the refreshed hosted CI run [34140306399](https://github.com/openclaw/openclaw/actions/runs/34140306399) passed on `97952c84f5777fe55935a234f651a7e647ec92f4`, including the required `openclaw/ci-gate`.

Synthetic live proof after returning from Settings: before, the reading note and article position reset; after, both are retained.

| Before | After |
| --- | --- |
| ![Widget state reset after Settings](https://github.com/user-attachments/assets/8f6c41d8-ac40-49b8-b3e1-d8373d9eade0) | ![Widget note and reading position retained after Settings](https://github.com/user-attachments/assets/8507e721-2f0c-4c9d-b2ca-c17281761756) |
