### PR TITLE
fix(test): prevent Vitest profiling startup hangs

### DIFF
--- a/scripts/run-vitest-profile-child.mts
+++ b/scripts/run-vitest-profile-child.mts
@@ -1,3 +1,4 @@
+import { getHashes } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import type { ViteUserConfig } from "vitest/config";
 import { isVitestProfileError, startVitestProfile } from "./lib/vitest-profiler.mts";
@@ -9,6 +10,10 @@ if ((mode !== "main" && mode !== "runner") || !outputDir) {
 // Start before importing Vitest so main capture includes Vite/Vitest startup.
 const finishMain = mode === "main" ? await startVitestProfile(outputDir, false) : undefined;
 try {
+  // Node 24's background CA loader can deadlock with Undici's first hash enumeration.
+  // Populate that cached result before TLS loads, inside main's startup capture.
+  // Remove when supported Node/OpenSSL versions make concurrent initialization safe.
+  getHashes();
   const { parseCLI, startVitest } = await import("vitest/node");
   const { normalizePath } = await import("vite");
   const { filter, options } = parseCLI(["vitest", ...args]);

--- a/test/scripts/run-vitest-profile.test.ts
+++ b/test/scripts/run-vitest-profile.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import type { HeapProfiler } from "node:inspector";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { formatErrorMessage } from "../../scripts/lib/error-format.mts";
 import {
@@ -22,11 +23,16 @@ describe("scripts/run-vitest-profile", () => {
   const repoRoot = path.resolve(import.meta.dirname, "../..");
   afterEach(() => lifetime.cleanup());
 
-  async function runProfileProcess(args: string[], root: string, signal: AbortSignal) {
+  async function runProfileProcess(
+    args: string[],
+    root: string,
+    signal: AbortSignal,
+    env?: NodeJS.ProcessEnv,
+  ) {
     const result = await lifetime.track(
       runNodeScript(
         args,
-        { PATH: process.env.PATH, HOME: root, USERPROFILE: root, CI: "1" },
+        { PATH: process.env.PATH, HOME: root, USERPROFILE: root, CI: "1", ...env },
         undefined,
         {
           cwd: root,
@@ -340,6 +346,36 @@ it("holds admitted work until the caller releases it", async () => {
   ])("prints $mode help for $flags without starting a test server", ({ mode, flags }, { signal }) =>
     lifetime.run(async () => {
       const root = createTempDir("oc-profile-help-");
+      const ordering = path.join(root, "hash-order.jsonl");
+      const preload = path.join(root, "observe-hash-order.mjs");
+      fs.writeFileSync(
+        preload,
+        `import crypto from "node:crypto";
+import fs from "node:fs";
+import inspector from "node:inspector/promises";
+import { syncBuiltinESMExports } from "node:module";
+let profiling = false;
+inspector.Session = class extends inspector.Session {
+  async post(method, ...params) {
+    const result = await super.post(method, ...params);
+    if (method === "Profiler.start") profiling = true;
+    return result;
+  }
+};
+const getHashes = crypto.getHashes;
+let recorded = false;
+crypto.getHashes = function() {
+  if (!recorded) {
+    recorded = true;
+    const tlsLoaded = process.moduleLoadList.includes("NativeModule tls");
+    fs.appendFileSync(${JSON.stringify(ordering)}, JSON.stringify({ tlsLoaded, profiling }) + "\\n");
+    // Fail before entering the native lock race, rather than waiting for it to hang.
+    if (tlsLoaded) throw new Error("TLS initialized before hash enumeration");
+  }
+  return getHashes();
+};
+syncBuiltinESMExports();`,
+      );
       const args = [
         path.join(repoRoot, "scripts/run-vitest-profile.mts"),
         mode,
@@ -348,7 +384,17 @@ it("holds admitted work until the caller releases it", async () => {
         "--",
         ...flags,
       ];
-      const result = await runProfileProcess(args, root, signal);
+      const result = await runProfileProcess(args, root, signal, {
+        NODE_OPTIONS: `--import=${pathToFileURL(preload).href}`,
+      });
+      expect(
+        fs
+          .readFileSync(ordering, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line)),
+        result.output,
+      ).toEqual([{ tlsLoaded: false, profiling: mode === "main" }]);
       expect(result.code, result.output).toBe(0);
       expect(result.output).toContain("Usage:");
     }),


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can update this branch.

</details>

## What Problem This Solves

Resolves startup hangs in Vitest profiling on Node 24.19.0. Main-mode help and invalid arguments could reach the 120-second CI deadline before returning an outcome. Native sampling during an unchanged-suite reproduction found OpenSSL hash enumeration and Node's background bundled-certificate initialization waiting on locks.

## Why This Change Was Made

The shared profiler child now completes Node's cached hash enumeration before importing Vitest/Vite and their TLS dependencies. Main CPU capture starts first, preserving startup measurement. The code records the removal condition: supported Node/OpenSSL versions must make concurrent initialization safe.

The process-cleanup repair already landed in #141049; its managed fixture lifetime and cancellation regression are preserved.

## User Impact

Developers retain the existing main/runner commands, pool selection, validation errors, and CPU/heap outputs, with deterministic startup ordering. There are no certificate-trust, configuration, timeout, dependency, or runtime-pin changes.

## Evidence

- The four existing help cases observe the first actual hash-enumeration call through a Node preload. Against the original child, all four deterministically fail with TLS already loaded; the observer stops before entering the native race. With the fix, they verify enumeration precedes TLS and main CPU capture is already active.
- `node scripts/run-vitest.mjs test/scripts/run-vitest-profile.test.ts --reporter=verbose`: **35/35 passed** locally, including the previously landed cancellation case.
- Real main/runner commands with both forks and threads produced valid CPU/heap profiles and left no recorded profiling processes alive.
- `node scripts/check-changed.mjs -- scripts/run-vitest-profile-child.mts test/scripts/run-vitest-profile.test.ts` passed, including script/root-test types and targeted lint. Independent review through **P2** was scoped-clean; `git diff --check` passed.
- [Linux CI run 34109753909](https://github.com/openclaw/openclaw/actions/runs/34109753909) passed all **35 profiler cases** in [owner job 21](https://github.com/openclaw/openclaw/actions/runs/34109753909/job/101703264999) and **9 sibling profiling flows** in [owner job 20](https://github.com/openclaw/openclaw/actions/runs/34109753909/job/101703264887), on Node 24.19.0. The sibling flows execute main/runner commands with forks/threads, validate CPU/heap profile contents, and check namespace cleanup.
- That run's only underlying failure was the unchanged main-owned Telegram test exceeding its line limit; script lint passed. The same offending blob was present in the CI merge and its main parent. Main's subsequent #141139 and #141148 repairs remove that blocker. The next run, [34115656123](https://github.com/openclaw/openclaw/actions/runs/34115656123), passed lint and both profiler owner jobs, but an unrelated planner inventory-growth fixture timed out. Main already repaired that exact fixture in #141137 by retaining real discovery caches across all ten planner snapshots, preserving assertions and the 120-second deadline. This PR is now rebased onto `7d1927cbfcce0e578f7a36f09e198818cff25e1b`, which includes that repair; both reviewed profiling file hashes remain unchanged. Current [exact-head CI34139276214](https://github.com/openclaw/openclaw/actions/runs/34139276214) and the complete PR check rollup are **successful** for `21b6c60f58edf8af92f7a3e2d6aabd1dfecb31a8`. Main inventory changed shard placement, so fresh per-file counts are not re-claimed; complete current CI and the retained same-source35/9 evidence provide the integration proof. Both watchers are reaped.

Two bounded Testbox provisioning attempts failed with a GitHub HTTP429 before returning a native creation receipt. No Testbox proof is claimed; both recovery keys and the unresolved creation state are retained privately. No further Testbox attempts are planned.

Production delta: **+5 lines** for the dependency-order invariant. Tests: **+46 net lines**, extending existing cases without adding a production test seam.
