### PR TITLE
fix(telemetry): include mixed-case configured providers

### DIFF
--- a/src/infra/telemetry.test.ts
+++ b/src/infra/telemetry.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createConfigIO } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import * as pluginRuntime from "../plugins/runtime.js";
@@ -198,6 +199,65 @@ describe("anonymous telemetry", () => {
     expect(payload.features.plugins).toEqual(["public-channel-owner"]);
     expect(payload.features.pluginsEnabled).toBe(2);
     expect(JSON.stringify(payload)).not.toContain("acme-internal-crm");
+  });
+
+  it.each(
+    (["provider map", "auth profile", "model reference"] as const).flatMap((source) =>
+      [
+        { provider: "OpenAI", expected: ["openai"] },
+        { provider: " OpenAI ", expected: ["openai"] },
+        { provider: " Open AI ", expected: [] },
+        { provider: " Acme-Private ", expected: [] },
+      ].map(({ provider, expected }) => ({ source, provider, expected })),
+    ),
+  )(
+    "reports loaded $source provider $provider as $expected",
+    async ({ source, provider, expected }) => {
+      const input: OpenClawConfig = { plugins: { enabled: false } };
+      if (source === "provider map") {
+        input.models = {
+          providers: { [provider]: { baseUrl: "https://provider.example.invalid/v1", models: [] } },
+        };
+      } else if (source === "auth profile") {
+        input.auth = { profiles: { configured: { provider, mode: "api_key" } } };
+      } else {
+        input.agents = { defaults: { model: `${provider}/gpt-4o` } };
+      }
+      await testState.writeConfig(input);
+      const config = createConfigIO({
+        configPath: testState.configPath,
+        env: { OPENCLAW_STATE_DIR: testState.stateDir },
+        homedir: () => testState.home,
+        observe: false,
+      }).loadConfig();
+
+      // The real loader accepts these spellings without canonicalizing the provider identity.
+      if (source === "provider map") {
+        expect(Object.keys(config.models?.providers ?? {})).toEqual([provider]);
+      } else if (source === "auth profile") {
+        expect(config.auth?.profiles?.configured.provider).toBe(provider);
+      }
+      expect(
+        buildTelemetryPayload(config, { surface: "gateway" }).features.providerFamilies,
+      ).toEqual(expected);
+    },
+  );
+
+  it("deduplicates canonical provider families across config maps, auth, and model references", () => {
+    const config: OpenClawConfig = {
+      models: {
+        providers: {
+          OpenAI: { models: [] },
+          " openai ": { models: [] },
+        },
+      },
+      auth: { profiles: { configured: { provider: " OPENAI ", mode: "api_key" } } },
+      agents: { defaults: { model: "OpenAI/gpt-4o" } },
+    };
+
+    expect(buildTelemetryPayload(config, { surface: "gateway" }).features.providerFamilies).toEqual(
+      ["openai"],
+    );
   });
 
   it("uses manifest-owned plugin activation when a CLI has no active runtime registry", () => {

--- a/src/infra/telemetry.test.ts
+++ b/src/infra/telemetry.test.ts
@@ -235,7 +235,7 @@ describe("anonymous telemetry", () => {
       if (source === "provider map") {
         expect(Object.keys(config.models?.providers ?? {})).toEqual([provider]);
       } else if (source === "auth profile") {
-        expect(config.auth?.profiles?.configured.provider).toBe(provider);
+        expect(config.auth?.profiles?.configured?.provider).toBe(provider);
       }
       expect(
         buildTelemetryPayload(config, { surface: "gateway" }).features.providerFamilies,
@@ -247,8 +247,8 @@ describe("anonymous telemetry", () => {
     const config: OpenClawConfig = {
       models: {
         providers: {
-          OpenAI: { models: [] },
-          " openai ": { models: [] },
+          OpenAI: { baseUrl: "https://provider.example.invalid/v1", models: [] },
+          " openai ": { baseUrl: "https://provider.example.invalid/v1", models: [] },
         },
       },
       auth: { profiles: { configured: { provider: " OPENAI ", mode: "api_key" } } },

--- a/src/infra/telemetry.ts
+++ b/src/infra/telemetry.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { collectConfiguredModelRefs } from "@openclaw/model-catalog-core/configured-model-refs";
 import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { z } from "zod";
 import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
@@ -241,7 +242,7 @@ export function buildTelemetryPayload(
       },
     ),
   ];
-  const providerFamilies = [...new Set(configuredProviders)]
+  const providerFamilies = [...new Set(configuredProviders.map(normalizeProviderId))]
     .filter(
       (providerId) =>
         SAFE_FEATURE_NAME.test(providerId) &&


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators enabling anonymous feature statistics would have public provider families omitted when provider-map keys or auth-profile providers used mixed case or surrounding whitespace. The real config loader accepts and preserves these spellings, but telemetry omitted them even though the same provider in a model reference was reported.

## Why This Change Was Made

Apply the existing `normalizeProviderId` helper before deduplication and the existing public-provider privacy filter. Normalization changes only case and surrounding whitespace; it does not add aliases, remove embedded characters, or expand the public-provider allowlist.

## User Impact

Known public providers are reported consistently across configuration maps, auth profiles, and model references, including the CLI payload preview. Private and unknown providers remain excluded. Consent, collected fields, request cadence, and configuration behavior are unchanged.

## Evidence

- Real config-file loading and validation: four pre-fix cases omitted `OpenAI` / ` OpenAI ` from provider maps and auth profiles. All pass after the repair; model-reference cases were already correct.
- Loaded-config negatives preserve exclusion of embedded whitespace and private/unknown providers. Cross-source duplicates produce one canonical family.
- 88 focused tests passed across telemetry, telemetry CLI, provider config, and model-reference owners. All 13 affected scenarios passed again after fixture-only lint/type corrections; production code and the other 75 tests are unchanged.
- Targeted lint, formatting, and `git diff --check` passed. Independent P2 autoreview is scoped-clean with no findings.
- Local `check:changed` passed its first 15 stages, then the typecheck wrapper rejected the shared dependency symlink required by this worktree. That gate is not claimed green; exact-head hosted CI must supply the remaining proof.
- The first hosted test-type check caught one unchecked profile lookup and two fixtures missing required `baseUrl`. Those fixture types are corrected without casts, suppressions, weaker assertions, or production changes; the failed run remains visible.
- The corrected fixture typecheck passed in run `34110825230`, but that run failed on an inherited Telegram test exceeding the lint line limit: https://github.com/openclaw/openclaw/actions/runs/34110825230/job/101706676104. The Telegram file was identical on this PR's old base/head and that run's main parent; the failed proof is retained.
- The separate owner repair https://github.com/openclaw/openclaw/pull/141139 landed as `908e5441f456ae327f059601b87a8b78ac32a395`. This branch was locally rebased with signed commits onto verified main `e3e2953f4b9a3ef1cd0568763c74c42f33067410`, containing that repair. Refreshed head: `1a3f4b54294fdd934f7b756cd92aa569ece096b2`. Both telemetry files and the complete two-file patch are byte-identical to the approved corrected head; no Telegram edits were added here.
- Refreshed exact-head `check-test-types-core-1` passed, but `checks-node-compact-small-29` failed: https://github.com/openclaw/openclaw/actions/runs/34112079052/job/101710702931. The CI planner test `keeps hosted tooling within the GitHub job cap when its inventory grows` timed out at 120 seconds in `test/scripts/ci-node-test-plan.test.ts:2197`. That test, planner, inventory helper, and timing configuration are identical to this PR's base. The timeout cause is not established; no retry or tooling change has been made, and full CI is not claimed green.
- The relevant planner-fixture repair subsequently landed through https://github.com/openclaw/openclaw/pull/141137 as `ed86b491cce2d084dea375fb700c47e65f1b1913` on September 7, 2026 at 11:31:32 UTC. It preserves real planner analysis while caching the tracked inventory across fixture variants, without weakening assertions or the deadline. The previously tracked https://github.com/openclaw/openclaw/pull/141015 merged later without that planner change because it was already included.
- On September 8, this branch was locally rebased with two verified signed commits onto pinned main `74fd11e05f2d5730dc03a67e27cc2d227ca5b339`, which contains the relevant planner repair. New head: `80cfea139b5fc2c66ce0d21ad57388f7c5ad8f75`. Both telemetry file SHA256s and the aggregate two-file patch remain unchanged; the two-commit range-diff is equivalent. No owner fix was copied into this PR, and unchanged local test proof was not rerun.
- New exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/34185235686. The single watcher completed successfully with zero pending checks. No manual dispatch, second watcher, or same-head CI retry was used.
- All fixtures use isolated synthetic state. No production telemetry, live Gateway, or plugin package execution.

## Merge Outcome

**Merged on September 8, 2026 at 04:36:13 UTC** as `c7360f680a25069014d098a941350fab8647a0e1`. Native preparation and squash merge passed at the unchanged approved head `80cfea139b5fc2c66ce0d21ad57388f7c5ad8f75`, with green hosted CI. Preparation required no rebase or push.

Prior failed runs remain part of the evidence. No telemetry regression was demonstrated by the planner timeout, and it was not proved flaky; the owner's performance claims are not independent baseline proof. This merge changes `main`; it does not establish inclusion in a published release or deployment to existing clients.
