### PR TITLE
refactor(native): share socket generation admission

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayConnection+RealtimeTalk.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection+RealtimeTalk.swift
@@ -167,7 +167,7 @@ extension GatewayConnection {
 
     #if DEBUG
     func _test_activeSocketGeneration() -> UInt64? {
-        self.activeSocketGeneration
+        self.socketGenerationState.activeGeneration
     }
     #endif
 }

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -223,10 +223,9 @@ actor GatewayConnection: Observable {
     /// Unbound operations capture this before their first suspension. Shutdown
     /// advances it so delayed config and retry work cannot recreate a route.
     private var shutdownGeneration: UInt64 = 0
-    // Callback work keeps the physical socket epoch that decoded it. Retiring
-    // that epoch prevents delayed pushes from entering a replacement socket.
-    var activeSocketGeneration: UInt64?
-    private var lastRetiredSocketGeneration: UInt64?
+    /// Callback work keeps the physical socket epoch that decoded it. Retiring
+    /// that epoch prevents delayed pushes from entering a replacement socket.
+    private(set) var socketGenerationState = GatewaySocketGenerationState()
 
     private var subscribers: [UUID: AsyncStream<PushDelivery>.Continuation] = [:]
     var realtimeTalkSubscribers: [
@@ -245,7 +244,7 @@ actor GatewayConnection: Observable {
         // Retirement clears authority before changing any other actor state.
         // Only a fully admitted handshake may replace that terminal publication.
         guard self.lastSnapshot != nil, let connection = self.configuredConnection,
-              let socketGeneration = self.activeSocketGeneration
+              let socketGeneration = self.socketGenerationState.activeGeneration
         else { return }
         let endpoint = connection.endpoint
         let lease = ServerLease(
@@ -757,7 +756,7 @@ extension GatewayConnection {
     func captureServerLease() async -> ServerLease? {
         guard let route = await self.captureRoute(),
               let client = self.configuredConnection?.client,
-              let socketGeneration = self.activeSocketGeneration
+              let socketGeneration = self.socketGenerationState.activeGeneration
         else { return nil }
         let lease = ServerLease(
             route: route,
@@ -1104,7 +1103,7 @@ extension GatewayConnection {
         self.retirePublication(disconnection: disconnection, retiresRoute: true)
         self.routeGeneration &+= 1
         self.finishRealtimeTalkSubscribers()
-        self.resetSocketGeneration()
+        self.socketGenerationState = GatewaySocketGenerationState()
         self.lastSnapshot = nil
         self.resetCanvasPluginSurfaceState()
         let client = self.configuredConnection?.client
@@ -1124,7 +1123,7 @@ extension GatewayConnection {
         socketGeneration: UInt64)
     {
         guard routeGeneration == self.routeGeneration,
-              admitSocketGeneration(socketGeneration)
+              self.socketGenerationState.admit(socketGeneration)
         else { return }
         broadcast(push)
     }
@@ -1137,7 +1136,7 @@ extension GatewayConnection {
         socketGeneration: UInt64)
     {
         guard routeGeneration == self.routeGeneration,
-              admitSocketGeneration(socketGeneration)
+              self.socketGenerationState.admit(socketGeneration)
         else { return }
         self.lastSnapshot = snapshot
         self.installCanvasPluginSurfaceURL(from: snapshot)
@@ -1158,39 +1157,10 @@ extension GatewayConnection {
 }
 
 extension GatewayConnection {
-    private func admitSocketGeneration(_ socketGeneration: UInt64) -> Bool {
-        if let lastRetiredSocketGeneration,
-           socketGeneration <= lastRetiredSocketGeneration
-        {
-            return false
-        }
-        if let activeSocketGeneration {
-            return socketGeneration == activeSocketGeneration
-        }
-        activeSocketGeneration = socketGeneration
-        return true
-    }
-
     private func retireSocketGeneration(_ socketGeneration: UInt64, reason: String) -> Bool {
-        if let lastRetiredSocketGeneration,
-           socketGeneration <= lastRetiredSocketGeneration
-        {
-            return false
-        }
-        if let activeSocketGeneration,
-           socketGeneration != activeSocketGeneration
-        {
-            return false
-        }
+        guard self.socketGenerationState.accepts(socketGeneration) else { return false }
         self.retirePublication(disconnection: .disconnected(reason), retiresRoute: false)
-        activeSocketGeneration = nil
-        lastRetiredSocketGeneration = socketGeneration
-        return true
-    }
-
-    private func resetSocketGeneration() {
-        self.activeSocketGeneration = nil
-        self.lastRetiredSocketGeneration = nil
+        return self.socketGenerationState.retire(socketGeneration)
     }
 
     #if DEBUG
@@ -1279,7 +1249,7 @@ extension GatewayConnection {
               endpoint.config.token == config.token,
               endpoint.config.password == config.password,
               let client = self.configuredConnection?.client,
-              let socketGeneration = activeSocketGeneration,
+              let socketGeneration = self.socketGenerationState.activeGeneration,
               controlUiRouteIsLive(
                   endpoint: endpoint,
                   client: client,
@@ -1329,7 +1299,7 @@ extension GatewayConnection {
             endpoint: endpoint,
             shutdownGeneration: self.shutdownGeneration) == true &&
             self.configuredConnection?.client === client &&
-            self.activeSocketGeneration == socketGeneration &&
+            self.socketGenerationState.activeGeneration == socketGeneration &&
             self.lastSnapshot != nil
     }
 
@@ -1432,7 +1402,7 @@ extension GatewayConnection {
         for (_, continuation) in self.subscribers {
             continuation.yield(delivery)
         }
-        if let socketGeneration = self.activeSocketGeneration {
+        if let socketGeneration = self.socketGenerationState.activeGeneration {
             var terminatedSubscriberIDs: [UUID] = []
             for (id, continuation) in self.realtimeTalkSubscribers[socketGeneration] ?? [:] {
                 switch continuation.yield(delivery) {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -104,8 +104,7 @@ public actor GatewayNodeSession {
     private var activeTLSRouteMetadataProvider: GatewayTLSRouteMetadataProviding?
     // A delayed push keeps its physical socket epoch. Once disconnect cleanup
     // retires that epoch, it cannot adopt the replacement route's admission.
-    private var activeSocketGeneration: UInt64?
-    private var lastRetiredSocketGeneration: UInt64?
+    private var socketGenerationState = GatewaySocketGenerationState()
     private var routeTeardownBarrier: Task<Void, Never>?
     private var lifecycleCallbackBarrier: LifecycleCallbackBarrier?
     private var executingLifecycleCallbackIDs: Set<UUID> = []
@@ -406,8 +405,7 @@ public actor GatewayNodeSession {
         self.onInvokeInput = nil
         self.onInvokeCancel = nil
         self.onRouteInvalidated = nil
-        self.activeSocketGeneration = nil
-        self.lastRetiredSocketGeneration = nil
+        self.socketGenerationState = GatewaySocketGenerationState()
     }
 
     private func enqueueRouteTeardown(
@@ -895,7 +893,7 @@ extension GatewayNodeSession {
         socketGeneration: UInt64) async
     {
         guard self.channelGeneration == channelGeneration,
-              self.admitSocketGeneration(socketGeneration)
+              self.socketGenerationState.admit(socketGeneration)
         else { return }
         switch push {
         case let .snapshot(ok):
@@ -951,7 +949,7 @@ extension GatewayNodeSession {
         socketGeneration: UInt64) async
     {
         guard self.channelGeneration == channelGeneration,
-              self.retireSocketGeneration(socketGeneration)
+              self.socketGenerationState.retire(socketGeneration)
         else { return }
         // The channel actor reconnects in place, so channelGeneration alone cannot
         // distinguish delayed work decoded before this socket loss. Revoke those
@@ -1288,35 +1286,6 @@ extension GatewayNodeSession {
     private func isCurrentRoute(_ route: GatewayNodeSessionRoute) -> Bool {
         route.channelGeneration == self.channelGeneration &&
             route.admissionGeneration == self.admissionGeneration
-    }
-
-    private func admitSocketGeneration(_ socketGeneration: UInt64) -> Bool {
-        if let lastRetiredSocketGeneration,
-           socketGeneration <= lastRetiredSocketGeneration
-        {
-            return false
-        }
-        if let activeSocketGeneration {
-            return socketGeneration == activeSocketGeneration
-        }
-        self.activeSocketGeneration = socketGeneration
-        return true
-    }
-
-    private func retireSocketGeneration(_ socketGeneration: UInt64) -> Bool {
-        if let lastRetiredSocketGeneration,
-           socketGeneration <= lastRetiredSocketGeneration
-        {
-            return false
-        }
-        if let activeSocketGeneration,
-           socketGeneration != activeSocketGeneration
-        {
-            return false
-        }
-        self.activeSocketGeneration = nil
-        self.lastRetiredSocketGeneration = socketGeneration
-        return true
     }
 
     #if DEBUG

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewaySocketGenerationState.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewaySocketGenerationState.swift
@@ -1,0 +1,27 @@
+/// Prevents delayed callbacks from a retired socket from adopting a replacement route.
+public struct GatewaySocketGenerationState: Sendable {
+    public private(set) var activeGeneration: UInt64?
+    private var lastRetiredGeneration: UInt64?
+
+    public init() {}
+
+    public func accepts(_ generation: UInt64) -> Bool {
+        if let lastRetiredGeneration, generation <= lastRetiredGeneration {
+            return false
+        }
+        return self.activeGeneration == nil || self.activeGeneration == generation
+    }
+
+    public mutating func admit(_ generation: UInt64) -> Bool {
+        guard self.accepts(generation) else { return false }
+        self.activeGeneration = generation
+        return true
+    }
+
+    public mutating func retire(_ generation: UInt64) -> Bool {
+        guard self.accepts(generation) else { return false }
+        self.activeGeneration = nil
+        self.lastRetiredGeneration = generation
+        return true
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

The macOS connection owner and shared node session separately implement the same physical-socket generation rules. Keeping both copies synchronized risks letting delayed callbacks from a retired socket enter a replacement connection.

## Why This Change Was Made

`GatewaySocketGenerationState` in OpenClawKit now owns admission, retirement, and the retired-generation watermark. Each connection owner keeps its own value and independent epochs. macOS checks eligibility, revokes its published server lease, then retires the socket synchronously; the node session retains its invocation and callback cleanup. Route replacement, refresh deadlines, connection-option identity, and platform authority stay with their existing owners.

This removes 34 production lines. Existing public connection APIs remain available. No intended user-visible behavior change. The adjacent iOS Settings work in #139514 was inspected; its connection-input and Talk changes are separate from this extraction.

## User Impact

Both Apple connection owners enforce the same existing socket-generation rules, including rejection of delayed callbacks after disconnect. Reconnect, publication, and cleanup behavior remain unchanged.

## Evidence

On rebased head `454dc71adc17f7a30b251c2bc9fc62bbeb8ab699`:

- `swift test` in OpenClawKit: 1,656 tests in 127 suites passed (53.339 seconds), retaining existing stale-socket and replacement-admission coverage.
- `swift build --package-path apps/macos --build-system native --product OpenClaw`: passed (65.89 seconds).
- `pnpm protocol:check:swift`: passed.
- `pnpm native:i18n:check`: passed for all 21 locale artifacts, with zero Apple translation contradictions. #141089 resolved the former locale hold.
- `node scripts/check-changed.mjs`: passed, including 1,132 tests and native state schema guard v16. Its first run aborted with ENOSPC while writing test output; after clearing task build caches, the affected worker test and full gate passed without assertion or source changes.
- Fresh independent Codex review through P2: scoped-clean, zero accepted/actionable findings.
- Prior patch-identical-head iOS simulator build and strict macOS Periphery passed. No live UI behavior change is claimed.

Exact-head [CI 34127837163](https://github.com/openclaw/openclaw/actions/runs/34127837163) passed, including macOS Swift tests and the iOS build.
