### PR TITLE
fix(ci): unblock lint for Telegram progress tests

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -30,63 +30,44 @@ import {
 } from "./bot-message-dispatch.test-harness.js";
 
 describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
-  it("does not restart progress drafts after final answer delivery", async () => {
-    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ dispatcherOptions, replyOptions }) => {
-        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-        await dispatcherOptions.deliver({ text: "Branch is up to date" }, { kind: "final" });
-        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-        return { queuedFinal: true };
-      },
-    );
+  it.each(["tool start", "command output"] as const)(
+    "does not restart progress drafts for %s after final answer delivery",
+    async (lateCallback) => {
+      const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+        async ({ dispatcherOptions, replyOptions }) => {
+          await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+          await dispatcherOptions.deliver({ text: "Branch is up to date" }, { kind: "final" });
+          if (lateCallback === "tool start") {
+            await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+          } else {
+            await replyOptions?.onCommandOutput?.({
+              phase: "end",
+              title: "Exec",
+              name: "exec",
+              status: "failed",
+              exitCode: 1,
+            });
+          }
+          return { queuedFinal: true };
+        },
+      );
 
-    await dispatchWithContext({
-      context: createContext(),
-      streamMode: "progress",
-      telegramCfg: {
-        streaming: { mode: "progress", progress: { toolProgress: true, label: "Shelling" } },
-      },
-    });
+      await dispatchWithContext({
+        context: createContext(),
+        streamMode: "progress",
+        telegramCfg: {
+          streaming: { mode: "progress", progress: { toolProgress: true, label: "Shelling" } },
+        },
+      });
 
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
-    );
-    expectDeliveredReply(0, { text: "Branch is up to date" });
-  });
-
-  it("does not restart progress drafts for command output after final answer delivery", async () => {
-    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ dispatcherOptions, replyOptions }) => {
-        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-        await dispatcherOptions.deliver({ text: "Branch is up to date" }, { kind: "final" });
-        await replyOptions?.onCommandOutput?.({
-          phase: "end",
-          title: "Exec",
-          name: "exec",
-          status: "failed",
-          exitCode: 1,
-        });
-        return { queuedFinal: true };
-      },
-    );
-
-    await dispatchWithContext({
-      context: createContext(),
-      streamMode: "progress",
-      telegramCfg: {
-        streaming: { mode: "progress", progress: { toolProgress: true, label: "Shelling" } },
-      },
-    });
-
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
-    );
-    expectDeliveredReply(0, { text: "Branch is up to date" });
-  });
+      expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
+      expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
+        telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
+      );
+      expectDeliveredReply(0, { text: "Branch is up to date" });
+    },
+  );
 
   it("does not restart progress drafts for command output while final answer delivery is pending", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });


### PR DESCRIPTION
Related: #141128

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where regular CI is blocked by the Telegram progress-updates test exceeding the existing 1,000-line lint limit. [The check-lint failure](https://github.com/openclaw/openclaw/actions/runs/34109152279/job/101701451795) reported 1,012 counted lines while validating https://github.com/openclaw/openclaw/pull/141128; the Telegram test and lint configuration were unchanged by that PR.

## Why This Change Was Made

Consolidate only the two duplicated post-final progress-restart cases into a two-row `it.each`. Each row creates its own fixture and preserves initial tool start, awaited final delivery, then the exact awaited late tool-start or command-output callback and every assertion.

The distinct pending-final ordering test remains separate. All later cases, including fast-mode coverage, are unchanged. No production code, helpers, lint rules, caps, ignores, or test inventory files change.

## User Impact

Removes duplicated test setup while preserving the same 37 test cases. No Telegram runtime behavior changes. The existing lint limit remains enforced.

## Evidence

- Fresh base: `de844c19cc1e26c0f616f5b0d8d7d349a41a1433`. Live file history still points to https://github.com/openclaw/openclaw/commit/3612625c4ca8074981c9ddeb47a06d5e92d3e5ef.
- Native CI baseline: 1,012 counted lines. The target-file and root lint-config blobs are identical at the failing perf head, its base, and this branch's base.
- **Derived count: 996**, from removing 16 nonblank lines in a comment-free region under the unchanged rule. This is a derived unchanged-rule count, **not a passing lint invocation**.
- **Exact-head hosted lint passed** at `55e7cc99e63d5ee21222cac14080c45706aaa0ae`: [check-lint, run 34110669208](https://github.com/openclaw/openclaw/actions/runs/34110669208/job/101706106471). This supplies the native lint proof beyond the derived count.
- Focused restart checks: **3 passed**, 34 filtered; full file: **37 passed, 0 skipped**.
- Byte comparison confirms the imports/suite prefix and every byte from the separate pending-final test onward are unchanged.
- Formatting, whitespace checks, max-lines suppression ratchet, assertion-safety ratchet, and the pre-typecheck changed-file checks passed.
- The exact local lint wrapper stopped before linting at its shared compiler/declaration boundary guard. `check:changed` likewise stopped at extension-test typechecking. No install, guard bypass, local lint pass, or typecheck pass is claimed.
- Separate coercion/deprecated-API guards passed. Deadcode analysis could not resolve sparse-worktree UI/browser inputs and produced no reliable verdict; it is not reported as passed.
- Fresh independent P0-P2 autoreview: scoped-clean, no actionable findings.
- Exact-head required [`openclaw/ci-gate` passed](https://github.com/openclaw/openclaw/actions/runs/34110669208/job/101707670464), with no pending checks. The completed [ClawSweeper review](https://github.com/openclaw/openclaw/pull/141139#issuecomment-5569218578) found no actionable defects. Native preparation and landing are authorized for this PR only, subject to the wrapper's admission checks.
