### PR TITLE
improve(workers): reduce cloud runtime preparation overhead

### DIFF
--- a/config/knip.scripts-exports.config.ts
+++ b/config/knip.scripts-exports.config.ts
@@ -74,6 +74,8 @@ const config = {
         ".agents/skills/**/scripts/**/*.{js,mjs,cjs,ts,mts,cts}!",
         "scripts/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}!",
         "test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}!",
+        // Core bootstrap packaging consumes the scripts' dist-import scanner.
+        "src/gateway/worker-environments/node-bootstrap-artifact.ts!",
         "src/plugin-sdk/api-baseline.ts!",
       ],
       project: [
@@ -84,6 +86,7 @@ const config = {
         "skills/**/*.{js,mjs,cjs,ts,mts,cts}!",
         "scripts/**/*.{js,mjs,cjs,ts,mts,cts}!",
         "test/**/*.{js,mjs,cjs,ts,mts,cts}!",
+        "src/gateway/worker-environments/node-bootstrap-artifact.ts!",
         "src/plugin-sdk/api-baseline.ts!",
       ],
     },

--- a/scripts/lib/package-dist-imports.d.mts
+++ b/scripts/lib/package-dist-imports.d.mts
@@ -1,4 +1,4 @@
-type PackageDistImport = { importerPath: string; importedPath: string };
+export type PackageDistImport = { importerPath: string; importedPath: string };
 
 export function collectPackageDistImportErrors(
   params: { files: readonly string[] } & (
@@ -12,3 +12,8 @@ export function collectPackageDistImportErrors(
       }
   ),
 ): string[];
+
+export function collectPackageDistImports(params: {
+  files: readonly string[];
+  readText: (relativePath: string) => string;
+}): PackageDistImport[];

--- a/scripts/lib/package-dist-imports.mjs
+++ b/scripts/lib/package-dist-imports.mjs
@@ -74,7 +74,7 @@ export function collectPackageDistImportErrors(params) {
 }
 
 /** Collect relative dist import edges from package JavaScript files. */
-function collectPackageDistImports(params) {
+export function collectPackageDistImports(params) {
   const files = [...new Set(params.files.map(normalizePackagePath))];
   const imports = [];
 

--- a/scripts/lib/vitest-build-prerequisites.mts
+++ b/scripts/lib/vitest-build-prerequisites.mts
@@ -153,12 +153,25 @@ export function mergeVitestPretestBuildModes(
 export function resolveVitestPretestBuildMode(
   selections: readonly VitestRuntimeTestSelection[],
 ): VitestPretestBuildMode | undefined {
+  const preparedSelections = selections.map((selection) => {
+    const includedFiles = new Set<string>();
+    // Keep each pattern hot in Node's bounded glob cache across the small consumer list.
+    // Consumer-first traversal recompiles large include inventories for every file.
+    for (const pattern of selection.includePatterns ?? []) {
+      for (const { file } of runtimeConsumers) {
+        if (!includedFiles.has(file) && path.matchesGlob(file, pattern)) {
+          includedFiles.add(file);
+        }
+      }
+    }
+    return { ...selection, includedFiles };
+  });
   return mergeVitestPretestBuildModes(
     runtimeConsumers
       .filter(({ file, configs: consumerConfigs }) =>
-        selections.some(({ configs, includePatterns, matchesFile }) => {
+        preparedSelections.some(({ configs, includePatterns, matchesFile, includedFiles }) => {
           const included = includePatterns
-            ? includePatterns.some((pattern) => path.matchesGlob(file, pattern))
+            ? includedFiles.has(file)
             : consumerConfigs.some((config) => includesRuntimeConfig(configs, config));
           // Only project the canonical consumers; config loading and test discovery
           // stay with Vitest. Include-file overrides still intersect emitted filters.

--- a/src/gateway/worker-environments/node-bootstrap-artifact.test.ts
+++ b/src/gateway/worker-environments/node-bootstrap-artifact.test.ts
@@ -15,6 +15,8 @@ const roots: string[] = [];
 const providers: ReturnType<typeof createNodeBootstrapArtifactProvider>[] = [];
 const buildId = "fixture-source-build";
 const version = "2026.8.1";
+const longEntryPath = `dist/${"entry-".repeat(25)}.json`;
+const longEntryPayload = "payload".repeat(90);
 
 async function write(root: string, relative: string, contents: string | object) {
   const target = path.join(root, relative);
@@ -67,11 +69,13 @@ async function fixture(mode: "source" | "package" | "external-plugin" = "source"
   await write(
     packageRoot,
     "dist/entry.js",
-    'import { answer } from "./extensions/remote-runtime/index.js"; import { name } from "@fixture/ai"; console.log(`${name}:${answer}`);',
+    'import { answer } from "./extensions/remote-runtime/index.js"; import { name } from "../node_modules/@fixture/ai/dist/index.js"; console.log(`${name}:${answer}`);',
   );
   await write(packageRoot, "dist/control-ui/index.html", "<title>Gateway dashboard</title>");
   await write(packageRoot, "dist/control-ui/assets/app.js", 'console.log("gateway-ui");');
   await write(packageRoot, "dist/shared.js", 'export const answer = "cloud-ready";');
+  await write(packageRoot, "dist/empty.js", "");
+  await write(packageRoot, longEntryPath, { payload: longEntryPayload });
   await write(packageRoot, "dist/worker/worker.mjs", 'console.log("separate-worker-bundle");');
   await write(packageRoot, "dist/worker/workspace-rsync-receiver.mjs", "export {};");
   await write(packageRoot, "dist/worker/github-exec-launcher.mjs", "export {};");
@@ -206,6 +210,10 @@ describe("node bootstrap distribution", () => {
         expect(entries).not.toContain("package/dist/extensions/remote-runtime/index.js");
       }
       const target = path.join(installed, "package");
+      expect(await fs.readFile(path.join(target, "dist/empty.js"), "utf8")).toBe("");
+      expect(JSON.parse(await fs.readFile(path.join(target, longEntryPath), "utf8"))).toEqual({
+        payload: longEntryPayload,
+      });
       const manifest = JSON.parse(await fs.readFile(path.join(target, "package.json"), "utf8"));
       expect(manifest.dependencies).toEqual({ "@fixture/ai": version, "native-runtime": "1.2.3" });
       expect(manifest.bundleDependencies).toEqual(["@fixture/ai"]);
@@ -269,6 +277,25 @@ describe("node bootstrap distribution", () => {
       await expect(provider.prepare()).resolves.toMatchObject({ buildId });
     },
   );
+
+  it("joins a failed archive output and removes it before a successful retry", async () => {
+    const { provider } = await fixture();
+    const makeTemp = fs.mkdtemp.bind(fs);
+    let failedRoot: string | undefined;
+    const destination = vi.spyOn(fs, "mkdtemp").mockImplementationOnce(async (...args) => {
+      failedRoot = await makeTemp(...args);
+      await fs.mkdir(path.join(failedRoot, "node-runtime.tgz"));
+      return failedRoot;
+    });
+    try {
+      await expect(provider.prepare()).rejects.toThrow();
+      expect(failedRoot).toBeDefined();
+      await expect(fs.access(failedRoot!)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      destination.mockRestore();
+    }
+    await expect(provider.prepare()).resolves.toMatchObject({ buildId });
+  });
 
   it("does not return an artifact when its lifecycle closes during preparation", async () => {
     const { provider } = await fixture();
@@ -375,23 +402,23 @@ describe("node bootstrap distribution", () => {
     expect(left.tarballSha256).not.toBe(right.tarballSha256);
   });
 
-  it("rejects staged bytes substituted after copying the running build", async () => {
+  it("rejects streamed bytes that differ from the verified source", async () => {
     const { provider } = await fixture();
-    const writeFile = fs.writeFile.bind(fs);
+    // oxlint-disable-next-line typescript/unbound-method -- Fault injection reapplies the original ReadEntry receiver below.
+    const writeEntry = tar.ReadEntry.prototype.write;
     let substituted = false;
-    const writer = vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
-      await writeFile(...args);
-      if (
-        typeof args[0] === "string" &&
-        args[0].endsWith(path.join("package", "dist", "shared.js"))
-      ) {
-        await writeFile(args[0], 'export const answer = "cloud-wrong";');
-        substituted = true;
-      }
-    });
+    const writer = vi
+      .spyOn(tar.ReadEntry.prototype, "write")
+      .mockImplementation(function (this: tar.ReadEntry, chunk) {
+        if (this.path === "package/dist/shared.js") {
+          substituted = true;
+          return writeEntry.call(this, Buffer.alloc(chunk.length, 0x20));
+        }
+        return writeEntry.call(this, chunk);
+      });
     try {
       await expect(provider.prepare()).rejects.toThrow(
-        "Node bootstrap archive does not match the staged distribution",
+        "Node bootstrap archive does not match the verified distribution",
       );
       expect(substituted).toBe(true);
     } finally {

--- a/src/gateway/worker-environments/node-bootstrap-artifact.ts
+++ b/src/gateway/worker-environments/node-bootstrap-artifact.ts
@@ -1,11 +1,16 @@
 import { createHash } from "node:crypto";
-import { constants as fsConstants, createReadStream, readFileSync } from "node:fs";
+import { constants as fsConstants, createReadStream, createWriteStream } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { finished, pipeline } from "node:stream/promises";
 import { isDeepStrictEqual } from "node:util";
 import { valid } from "semver";
 import * as tar from "tar";
-import { collectPackageDistImportErrors } from "../../../scripts/lib/package-dist-imports.mjs";
+import {
+  collectPackageDistImportErrors,
+  collectPackageDistImports,
+  type PackageDistImport,
+} from "../../../scripts/lib/package-dist-imports.mjs";
 import {
   LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH,
   PACKAGE_LIFECYCLE_PENDING_RELATIVE_PATH,
@@ -35,7 +40,7 @@ import { MAX_WORKER_BUNDLE_ARCHIVE_BYTES } from "../../shared/worker-bundle-limi
 import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
 
 const BOOTSTRAP_LAUNCHER_FILES = ["openclaw.mjs", "node-version.mjs"];
-const BOOTSTRAP_COPY_CONCURRENCY = 16;
+const READ_CONCURRENCY = 16;
 const IGNORED_PLUGIN_DIRECTORIES = new Set(["node_modules", "src", "test", "tests"]);
 const METADATA_KEYS = [
   "name",
@@ -107,17 +112,33 @@ function requireRunningBuild(options: ArtifactOptions, text: string, version: st
   return options.runningBuildId;
 }
 
-function assertBuiltImportClosure(root: string, files: string[], label: string): void {
-  const errors = collectPackageDistImportErrors({
-    files,
-    readText: (relative) => readFileSync(path.join(root, relative), "utf8"),
-  });
-  if (errors.length > 0) {
-    throw new Error(
-      `Node distribution ${label} has an incomplete built import closure; rebuild and restart the Gateway: ${errors.slice(0, 5).join("; ")}`,
-    );
+// Observe creation policy without process.umask(), whose getter mutates process-wide state.
+// Probe again before publication: a changed policy must not silently change archive modes.
+async function observeBootstrapModes(root: string): Promise<readonly number[]> {
+  const modes: number[] = [];
+  for (const requested of [0o644, 0o755]) {
+    const probe = path.join(root, `.mode-${requested.toString(8)}`);
+    const handle = await fs.open(probe, "wx", requested);
+    try {
+      modes.push((await handle.stat()).mode & 0o777);
+    } finally {
+      await handle.close();
+      await fs.rm(probe);
+    }
   }
+  return modes;
 }
+
+type BootstrapImportScope = {
+  label: string;
+  prefix: string;
+  files: string[];
+  imports: PackageDistImport[];
+};
+
+type BootstrapEntry = {
+  scope: BootstrapImportScope;
+} & ({ source: { root: string; relative: string } } | { contents: Buffer });
 
 async function resolvePlugins(options: ArtifactOptions, packageRoot: string) {
   const ids = new Set<string>();
@@ -178,13 +199,24 @@ async function prepareNodeBootstrapArtifact(
   const buildId = requireRunningBuild(options, buildInfo, sourcePackage.version);
   const plugins = await resolvePlugins(options, packageRoot);
   const packageJson = composePackagePlugins(sourcePackage, plugins);
-  const stagingRoot = path.join(temporaryRoot, "package");
-  await fs.mkdir(stagingRoot, { mode: 0o700 });
-  const staged = new Map<string, WorkerBundleHashEntry>();
-  const directories = new Map<string, Promise<string | undefined>>();
+  const modes = await observeBootstrapModes(temporaryRoot);
+  const mainScope: BootstrapImportScope = {
+    label: packageJson.name,
+    prefix: "",
+    files: [],
+    imports: [],
+  };
+  const scopes: BootstrapImportScope[] = [];
+  const entries = new Map<string, BootstrapEntry>();
+  const planEntry = (relative: string, entry: BootstrapEntry) => {
+    bootstrapPath(relative);
+    entries.set(relative, entry);
+    if (entries.size > DEFAULT_WORKER_BUNDLE_ARCHIVE_LIMITS.maxEntries) {
+      throw new Error("Node bootstrap distribution exceeds its artifact limits");
+    }
+  };
   let expandedBytes = 0;
   let reservedEntries = 0;
-
   const reserveFile = (relative: string, bytes: number) => {
     bootstrapPath(relative);
     expandedBytes += bytes;
@@ -196,44 +228,21 @@ async function prepareNodeBootstrapArtifact(
       throw new Error("Node bootstrap distribution exceeds its artifact limits");
     }
   };
-  const writeStagedFile = async (
-    relative: string,
-    contents: Buffer | string,
-    executable: boolean,
-  ) => {
-    const target = path.join(stagingRoot, relative);
-    const directory = path.dirname(target);
-    let created = directories.get(directory);
-    if (!created) {
-      created = fs.mkdir(directory, { recursive: true, mode: 0o700 });
-      directories.set(directory, created);
-    }
-    await created;
-    const mode = executable ? 0o755 : 0o644;
-    // Record the verified bytes before writing; the final archive comparison also
-    // detects staging changes without reopening and hashing the entire directory.
-    const entry = {
-      path: `package/${relative}`,
-      size: Buffer.byteLength(contents),
-      sha256: createHash("sha256").update(contents).digest("hex"),
-    };
-    await fs.writeFile(target, contents, { mode });
-    // Reading process.umask() temporarily clears the process-wide mask and races
-    // parallel file creation. Record the mode the filesystem actually applied.
-    staged.set(relative, {
-      ...entry,
-      mode:
-        process.platform === "win32"
-          ? WORKER_BUNDLE_ARTIFACT_MODE
-          : (await fs.stat(target)).mode & 0o777,
-    });
-  };
-  const writeFile = async (relative: string, contents: string) => {
+  const addGeneratedFile = (relative: string, contents: string, scope = mainScope) => {
     reserveFile(relative, Buffer.byteLength(contents));
-    await writeStagedFile(relative, contents, false);
+    planEntry(relative, { contents: Buffer.from(contents), scope });
   };
-  const copyFile = async (root: string, relative: string, destination = relative) => {
-    bootstrapPath(relative);
+  const addFiles = (root: string, files: readonly string[], prefix = "", scope = mainScope) => {
+    for (const relative of new Set(files)) {
+      bootstrapPath(relative);
+      planEntry(`${prefix}${relative}`, { source: { root, relative }, scope });
+    }
+  };
+  const readEntry = async (destination: string, entry: BootstrapEntry) => {
+    if ("contents" in entry) {
+      return { contents: entry.contents, mode: modes[0]! };
+    }
+    const { root, relative } = entry.source;
     const source = path.join(root, relative);
     if ((await fs.realpath(source)) !== source) {
       throw new Error(`Node distribution cannot contain symbolic links: ${relative}`);
@@ -244,7 +253,6 @@ async function prepareNodeBootstrapArtifact(
       if (!before.isFile()) {
         throw new Error(`Invalid node distribution file: ${relative}`);
       }
-      // Reserve before reading so concurrent copies share the same byte/entry budget.
       reserveFile(destination, before.size);
       const contents = await handle.readFile();
       const after = await handle.stat();
@@ -261,22 +269,9 @@ async function prepareNodeBootstrapArtifact(
       ) {
         throw new Error(`Node distribution changed while packaging: ${relative}`);
       }
-      await writeStagedFile(destination, contents, (before.mode & 0o111) !== 0);
+      return { contents, mode: modes[(before.mode & 0o111) !== 0 ? 1 : 0]! };
     } finally {
       await handle.close();
-    }
-  };
-  const copyFiles = async (root: string, files: readonly string[], prefix = "") => {
-    const result = await runTasksWithConcurrency({
-      tasks: [...new Set(files)].map(
-        (relative) => () => copyFile(root, relative, `${prefix}${relative}`),
-      ),
-      limit: BOOTSTRAP_COPY_CONCURRENCY,
-      errorMode: "stop",
-    });
-    // The pool must drain in-flight writes before preparation removes staging on failure.
-    if (result.hasError) {
-      throw result.firstError;
     }
   };
 
@@ -287,7 +282,7 @@ async function prepareNodeBootstrapArtifact(
     await collectPackageDistInventory(packageRoot, { packageManifest: packageJson })
   ).filter(
     // The Gateway serves Control UI assets; nodes install their worker bundle separately.
-    // Neither belongs in the node runtime's staging, validation, or download work.
+    // Neither belongs in the node runtime's packaging, validation, or download work.
     (relative) =>
       !relative.startsWith("dist/worker/") &&
       !relative.startsWith("dist/control-ui/") &&
@@ -302,7 +297,7 @@ async function prepareNodeBootstrapArtifact(
     (relative) =>
       relative.startsWith("scripts/") && !relative.includes("*") && !relative.endsWith("/"),
   );
-  await copyFiles(
+  addFiles(
     packageRoot,
     [...BOOTSTRAP_LAUNCHER_FILES, ...files, ...scripts].filter(
       (relative) => relative !== LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH,
@@ -337,7 +332,7 @@ async function prepareNodeBootstrapArtifact(
       }
     };
     await visit(plugin.root);
-    await copyFiles(plugin.root, pluginFiles, `dist/extensions/${plugin.id}/`);
+    addFiles(plugin.root, pluginFiles, `dist/extensions/${plugin.id}/`);
   }
 
   // Only declared bundled/workspace packages cross as JavaScript artifacts. Native dependencies
@@ -369,15 +364,21 @@ async function prepareNodeBootstrapArtifact(
         `Bundled node dependency ${name} needs its compiled distribution; rebuild the Gateway`,
       );
     }
-    await copyFiles(root, bundledFiles, `node_modules/${name}/`);
+    const scope: BootstrapImportScope = {
+      label: name,
+      prefix: `node_modules/${name}/`,
+      files: [],
+      imports: [],
+    };
+    scopes.push(scope);
+    addFiles(root, bundledFiles, scope.prefix, scope);
     delete bundled.dependencies;
     delete bundled.devDependencies;
     delete bundled.scripts;
-    await writeFile(`node_modules/${name}/package.json`, `${JSON.stringify(bundled, null, 2)}\n`);
-    assertBuiltImportClosure(
-      path.join(stagingRoot, "node_modules", name),
-      ["package.json", ...bundledFiles],
-      name,
+    addGeneratedFile(
+      `node_modules/${name}/package.json`,
+      `${JSON.stringify(bundled, null, 2)}\n`,
+      scope,
     );
     packageJson.dependencies![name] = bundled.version;
   }
@@ -391,35 +392,113 @@ async function prepareNodeBootstrapArtifact(
       throw new Error(`Node distribution requires an exact dependency pin: ${name}@${spec}`);
     }
   }
-  await writeFile("package.json", `${JSON.stringify(packageJson, null, 2)}\n`);
-  const inventory = [...staged.keys()].filter((entry) => entry.startsWith("dist/")).toSorted();
-  await writeFile(PACKAGE_DIST_INVENTORY_RELATIVE_PATH, `${JSON.stringify(inventory)}\n`);
-  await writeFile(PACKAGE_LIFECYCLE_PENDING_RELATIVE_PATH, "pending\n");
-  assertBuiltImportClosure(stagingRoot, [...staged.keys()], packageJson.name);
-  if (
-    (await fs.readFile(buildInfoPath, "utf8")) !== buildInfo ||
-    !isDeepStrictEqual(await readPackageManifest(packageRoot), sourcePackage)
-  ) {
-    throw new Error(
-      "Gateway build changed while preparing cloud bootstrap; restart the Gateway and retry",
-    );
+  addGeneratedFile("package.json", `${JSON.stringify(packageJson, null, 2)}\n`);
+  const inventory = [...entries.keys()].filter((entry) => entry.startsWith("dist/")).toSorted();
+  addGeneratedFile(PACKAGE_DIST_INVENTORY_RELATIVE_PATH, `${JSON.stringify(inventory)}\n`);
+  addGeneratedFile(PACKAGE_LIFECYCLE_PENDING_RELATIVE_PATH, "pending\n");
+  const ordered = [...entries].toSorted(([left], [right]) => compareWorkerBundlePaths(left, right));
+  // Root imports may legitimately reach bundled node_modules files; their own
+  // dist imports still receive a separate package-relative closure check.
+  mainScope.files = ordered.map(([relative]) => relative);
+  for (const [relative, entry] of ordered) {
+    if (entry.scope !== mainScope) {
+      entry.scope.files.push(relative.slice(entry.scope.prefix.length));
+    }
   }
   const tarballPath = path.join(temporaryRoot, "node-runtime.tgz");
-  const manifest = [...staged.values()].toSorted((left, right) =>
-    compareWorkerBundlePaths(left.path, right.path),
-  );
-  await tar.create(
-    {
-      cwd: temporaryRoot,
-      file: tarballPath,
-      gzip: true,
-      noDirRecurse: true,
-      noMtime: true,
-      portable: true,
-      strict: true,
+  let entryConsumed = Promise.resolve();
+  const pack = new tar.Pack({
+    gzip: true,
+    noMtime: true,
+    portable: true,
+    strict: true,
+    onWriteEntry(entry) {
+      entryConsumed = finished(entry, { readable: true, writable: false, cleanup: true });
+      void entryConsumed.catch(() => undefined);
     },
-    manifest.map((entry) => entry.path),
-  );
+  });
+  const archiveDone = pipeline(pack, createWriteStream(tarballPath, { flags: "wx" }));
+  // Observe output errors immediately, but join the pipeline after in-flight reads drain.
+  void archiveDone.catch(() => undefined);
+  const manifest: WorkerBundleHashEntry[] = [];
+  try {
+    // One batch holds at most 16 source buffers under the existing expanded-byte budget.
+    // Pack's jobs limit does not bound ReadEntry input, so consume each output entry below.
+    for (let offset = 0; offset < ordered.length; offset += READ_CONCURRENCY) {
+      const batch = ordered.slice(offset, offset + READ_CONCURRENCY);
+      const read = await runTasksWithConcurrency({
+        tasks: batch.map(
+          ([relative, entry]) =>
+            () =>
+              readEntry(relative, entry),
+        ),
+        limit: READ_CONCURRENCY,
+        errorMode: "stop",
+      });
+      if (read.hasError) {
+        throw read.firstError;
+      }
+      for (let index = 0; index < batch.length; index += 1) {
+        const [relative, entry] = batch[index]!;
+        const { contents, mode } = read.results[index]!;
+        const importerPath = relative.slice(entry.scope.prefix.length);
+        entry.scope.imports.push(
+          ...collectPackageDistImports({
+            files: [importerPath],
+            readText: () => contents.toString("utf8"),
+          }),
+        );
+        const identity = {
+          path: `package/${relative}`,
+          size: contents.byteLength,
+          mode: process.platform === "win32" ? WORKER_BUNDLE_ARTIFACT_MODE : mode,
+          sha256: createHash("sha256").update(contents).digest("hex"),
+        };
+        manifest.push(identity);
+        const input = new tar.ReadEntry(
+          new tar.Header({
+            path: identity.path,
+            size: identity.size,
+            mode,
+            type: "File",
+          }),
+        );
+        pack.add(input);
+        input.end(contents);
+        // Wait for tar's output entry, not merely the input buffer, before feeding another.
+        await Promise.race([entryConsumed, archiveDone]);
+      }
+    }
+    for (const scope of [...scopes, mainScope]) {
+      const errors = collectPackageDistImportErrors(scope);
+      if (errors.length > 0) {
+        throw new Error(
+          `Node distribution ${scope.label} has an incomplete built import closure; rebuild and restart the Gateway: ${errors.slice(0, 5).join("; ")}`,
+        );
+      }
+    }
+    if (!isDeepStrictEqual(await observeBootstrapModes(temporaryRoot), modes)) {
+      throw new Error("Node bootstrap file creation policy changed while packaging");
+    }
+    if (
+      (await fs.readFile(buildInfoPath, "utf8")) !== buildInfo ||
+      !isDeepStrictEqual(await readPackageManifest(packageRoot), sourcePackage)
+    ) {
+      throw new Error(
+        "Gateway build changed while preparing cloud bootstrap; restart the Gateway and retry",
+      );
+    }
+    pack.end();
+    await archiveDone;
+  } catch (error) {
+    // Minipass needs an error event; argumentless destroy does not settle Node's pipeline.
+    pack.destroy(
+      error instanceof Error ? error : new Error("Node bootstrap archive failed", { cause: error }),
+    );
+    pack.zip?.destroy();
+    await archiveDone.catch(() => undefined);
+    throw error;
+  }
   const tarballBytes = (await fs.stat(tarballPath)).size;
   if (tarballBytes > MAX_WORKER_BUNDLE_ARCHIVE_BYTES) {
     throw new Error("Node bootstrap archive exceeds the transfer limit");
@@ -429,13 +508,12 @@ async function prepareNodeBootstrapArtifact(
     DEFAULT_WORKER_BUNDLE_ARCHIVE_LIMITS,
   );
   if (hashWorkerBundleManifest(manifest) !== hashWorkerBundleManifest(archiveManifest)) {
-    throw new Error("Node bootstrap archive does not match the staged distribution");
+    throw new Error("Node bootstrap archive does not match the verified distribution");
   }
   const hash = createHash("sha256");
   for await (const chunk of createReadStream(tarballPath)) {
     hash.update(chunk);
   }
-  await fs.rm(stagingRoot, { recursive: true, force: true });
   return Object.freeze({
     tarballPath,
     tarballSha256: hash.digest("hex"),


### PR DESCRIPTION
Related: #140425

## What Problem This Solves

Cloud sessions must prepare the running Gateway's node package before allocating a machine. This preparation currently writes thousands of temporary files, rereads them for import validation and archiving, and removes the whole staging tree. That adds local I/O and memory overhead to first use.

## Why This Change Was Made

Stream sorted tar entries from the same verified source bytes and reuse the existing import-edge scanner. Keep source identity checks, observed file modes, complete package import closures, archive verification, and the process-owned preparation lifecycle. Bounded read batches and joined output failures prevent work from escaping the producer. No configuration, persistent store, node protocol, provider retry, or enrollment policy changes.

## User Impact

Less temporary filesystem work and lower peak memory during cloud runtime preparation. Paired current-main package measurements improved 7.292 to 6.635 seconds and 6.884 to 6.576 seconds, with peak RSS lower by about 98–108 MiB. These are modest local improvements, not a claim of ten-second cloud provisioning.

## Evidence

- 16 node-bootstrap tests and 6 package import-helper tests passed; scoped core/scripts lint passed.
- Four full package preparations produced byte-identical 23,124,680-byte archives and identical 7,487-entry manifests, including file modes. SHA-256: `551192553d3faa9c0f9c9e8ca94a22949ca1de2c9ad309486b5dcff9caabede0`.
- Baseline/candidate empty-file and long PAX-path fixtures matched under both normal 022 and restrictive 077 creation policies.
- Output failure, invalid import closure, retry, and producer cleanup tests passed. A prototype pipeline-settlement stall was found and fixed before publication.
- Independent Codex reviews: no actionable P0–P2 findings.
- The first hosted run passed build and type checks but exposed a scripts-only Knip consumer-model gap. Adding the real core consumer reproduced red before/green after with the pinned scanner, without weakening guards or ignores.
- The local full changed-check attempt was blocked before tests by Testbox HTTP 429. Hosted checks for this exact PR revision must pass before landing; no gate or shared-install safeguard was disabled.

Temporary CI dependency: this branch includes the exact reviewed planner helper from [PR141220](https://github.com/openclaw/openclaw/pull/141220) to exercise the repaired CI planning path while that PR lands independently. The streaming implementation is unchanged; the final main delta will exclude the helper once its own PR lands. No timeout or test expectation was weakened.

Final exact-head CI: [34126059868](https://github.com/openclaw/openclaw/actions/runs/34126059868) on `d7a4c7edede3491129848124dcdc7360927ac39c` passed 107 jobs with 17 scope skips and the required gate green. The planner dependency is now independently landed in [PR #141220](https://github.com/openclaw/openclaw/pull/141220).

Maintainer review disposition: the generic data-model compatibility checklist item does not apply to this implementation-only producer change. It changes no configuration, schema, session data, stored format, archive layout, enrollment contract, or installer behavior. The complete runtime archive and manifest are byte-identical in paired before/after proof, including empty/PAX entries and modes under 022/077 policies. There is no data migration to add or waive. The current review itself identifies no introduced correctness/security finding and describes the generic migration concern as unsupported. Existing consumer and live-owner checks remain unchanged.
