### PR TITLE
refactor(e2e): remove unused Parallels host server inputs

### DIFF
--- a/scripts/e2e/parallels/host-server.ts
+++ b/scripts/e2e/parallels/host-server.ts
@@ -119,7 +119,6 @@ export async function startHostServer(input: {
   dir: string;
   hostIp: string;
   port: number;
-  artifactPath: string;
   label: string;
 }): Promise<HostServer> {
   const actualPort = input.port || allocateHostPort();
@@ -182,20 +181,16 @@ export async function startNpmRegistryServer(input: {
   };
 }
 
-async function stopHostServerChild(
-  child: HostServerChild,
-  terminateTimeoutMs = 2_000,
-  killTimeoutMs = 1_500,
-): Promise<boolean> {
+async function stopHostServerChild(child: HostServerChild): Promise<boolean> {
   if (hasHostServerChildExited(child)) {
     return true;
   }
   child.kill("SIGTERM");
-  if (await waitForChildExit(child, terminateTimeoutMs)) {
+  if (await waitForChildExit(child, 2_000)) {
     return true;
   }
   child.kill("SIGKILL");
-  return await waitForChildExit(child, killTimeoutMs);
+  return await waitForChildExit(child, 1_500);
 }
 
 async function waitForChildExit(child: HostServerChild, timeoutMs: number): Promise<boolean> {

--- a/scripts/e2e/parallels/smoke-common.ts
+++ b/scripts/e2e/parallels/smoke-common.ts
@@ -289,7 +289,6 @@ export async function startSmokeArtifactServer(input: {
   port: number;
 }): Promise<HostServer> {
   const server = await startHostServer({
-    artifactPath: input.artifact.path,
     dir: input.dir,
     hostIp: input.hostIp,
     label: input.label,

--- a/scripts/e2e/parallels/windows-smoke.ts
+++ b/scripts/e2e/parallels/windows-smoke.ts
@@ -237,7 +237,6 @@ class WindowsSmoke extends SmokeRunController<WindowsOptions> {
       }
       if (!this.server) {
         this.server = await startHostServer({
-          artifactPath: this.minGitZipPath,
           dir: this.tgzDir,
           hostIp: this.hostIp,
           label: "Windows smoke artifacts",

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -403,7 +403,7 @@ async function runFailingHostServer(fakePythonSource: string) {
   chmodSync(fakePython, 0o755);
   const port = await unusedLoopbackPort();
   return spawnNodeEvalSync(
-    `import { startHostServer } from "./${TS_PATHS.hostServer}"; await startHostServer({ dir: ".", hostIp: "127.0.0.1", port: ${port}, artifactPath: "artifact.tgz", label: "artifact" });`,
+    `import { startHostServer } from "./${TS_PATHS.hostServer}"; await startHostServer({ dir: ".", hostIp: "127.0.0.1", port: ${port}, label: "artifact" });`,
     {
       env: { ...process.env, PATH: `${tempDir}${delimiter}${process.env.PATH ?? ""}` },
       imports: ["tsx"],
@@ -1093,10 +1093,10 @@ ${adapterLine}DHCPv4 server:
     vi.useFakeTimers();
     try {
       const child = new FakeHostServerChild();
-      const stop = hostServerTesting.stopHostServerChild(child as never, 100, 100);
+      const stop = hostServerTesting.stopHostServerChild(child as never);
       expect(child.signals).toEqual(["SIGTERM"]);
 
-      await vi.advanceTimersByTimeAsync(100);
+      await vi.advanceTimersByTimeAsync(2_000);
       expect(child.signals).toEqual(["SIGTERM", "SIGKILL"]);
 
       let resolved = false;
@@ -1118,9 +1118,7 @@ ${adapterLine}DHCPv4 server:
     const child = new FakeHostServerChild();
     child.exitWithSignal("SIGTERM");
 
-    await expect(hostServerTesting.stopHostServerChild(child as never, 100, 100)).resolves.toBe(
-      true,
-    );
+    await expect(hostServerTesting.stopHostServerChild(child as never)).resolves.toBe(true);
     expect(child.signals).toEqual([]);
   });
 


### PR DESCRIPTION
## What Problem This Solves

The Parallels host server still requires an `artifactPath` input that has not been read since its former Node handler was replaced by Python directory serving. Its shutdown helper also accepts timeout overrides used only by two tests, even though the escalation test already uses fake timers.

## Why This Change Was Made

Remove the unused artifact input and its internal forwarding sites. Keep the shutdown helper's existing 2,000 ms TERM grace and 1,500 ms KILL wait directly at their uses. The same tests now exercise those real defaults, preserving signal order and the requirement to wait for exit.

## User Impact

Directory serving, encoded artifact URLs, package and registry paths, port-file cleanup, and normal shutdown behavior are unchanged. No CLI, config, public SDK, provider, or VM behavior changes. Tooling removes seven net lines and tests remove two net lines; no test or assertion is deleted. The refreshed branch preserves main's Node 24.16 fixture values and upstream CI fixes.

## Evidence

- Fresh recovery runs pass the same six relevant lifecycle/startup cases before and after, with identical 111-case inventories; the other 105 cases are retained and unselected.
- Fresh real Python servers on temporary synthetic directories serve the encoded artifact URL with exact content before and after. Normal stop is awaited; both ports close and both child processes disappear.
- Fresh independent composition review is clean through P2. The three script afterimages match the original reviewed source; main's Node-version assertion changes are preserved in the test.
- No new exhausted-KILL-timeout, Windows guest, real VM, provider, or live registry result is claimed.

The refreshed four-file configured changed gate passed all 19 checks on Linux, including both TypeScript graphs and scoped lint. Its one-shot runner stopped normally, the temporary source capsule was removed, and all recorded gate processes are absent. The reported remote tree matches the signed candidate tree; a post-success portal synchronization warning is retained separately.
