### PR TITLE
fix(chat): keep inter-tool commentary visible once across live stream and reload

### DIFF
--- a/packages/gateway-client/src/session-projection.ts
+++ b/packages/gateway-client/src/session-projection.ts
@@ -236,7 +236,9 @@ function entryMatches(
   allowSnapshotPromotion = false,
 ): boolean {
   if (sameTranscriptIdentity(left.identity, right.identity)) {
-    return true;
+    // A keyed commentary fallback and the full row share an id but are distinct display segments.
+    const itemId = readAssistantStreamSegmentIdentity(left.message)?.itemId;
+    return itemId === readAssistantStreamSegmentIdentity(right.message)?.itemId;
   }
   const durableEntry = left.identity?.id ? left : right.identity?.id ? right : null;
   const provisionalEntry = durableEntry === left ? right : durableEntry === right ? left : null;

--- a/src/gateway/chat-display-projection.commentary-dup.test.ts
+++ b/src/gateway/chat-display-projection.commentary-dup.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSessionProjection,
+  reduceSessionProjection,
+  readSessionMessageIdentity,
+} from "../../packages/gateway-client/src/session-projection.js";
+import { projectChatDisplayMessages } from "./chat-display-projection.js";
+
+const runId = "run-commentary-dup";
+
+function textOf(message: unknown): string[] {
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") {
+    return [content];
+  }
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  return content
+    .filter(
+      (block): block is { text: string } =>
+        typeof block === "object" &&
+        block !== null &&
+        typeof (block as { text?: unknown }).text === "string",
+    )
+    .map((block) => block.text);
+}
+
+const user = {
+  role: "user",
+  content: [{ type: "text", text: "Look it up for me." }],
+  __openclaw: { id: "user", seq: 1, idempotencyKey: `${runId}:user` },
+};
+
+// A mixed turn: inter-tool commentary text, then a tool call, then the final answer.
+const mixedCommentary = {
+  role: "assistant",
+  content: [
+    {
+      type: "text",
+      text: "Searching for the answer…",
+      textSignature: '{"v":1,"phase":"commentary","id":"commentary-0"}',
+    },
+    { type: "toolCall", id: "call-1", name: "web_search", arguments: {} },
+    {
+      type: "text",
+      text: "The answer is 42.",
+      textSignature: '{"v":1,"phase":"final_answer"}',
+    },
+  ],
+  stopReason: "stop",
+  __openclaw: { id: "assistant", seq: 2, runId },
+};
+
+describe("commentary fallback reconciliation", () => {
+  it("keeps inter-tool commentary text exactly once across incremental delivery", () => {
+    // Server side: history serving emits a keyed "segment fallback" row next to
+    // the full row (with commentary stripped). Both keep the owning transcript id.
+    const projected = projectChatDisplayMessages([user, mixedCommentary], {
+      includeCommentaryFallbacks: true,
+    });
+
+    // Client side: deliver each projected row incrementally, the way live
+    // session.message events and history cursors do.
+    let projection = createSessionProjection({ sessionKey: "agent:main:commentary-dup" });
+    for (const message of projected) {
+      projection = reduceSessionProjection(projection, {
+        type: "messagePersisted",
+        message,
+        envelope: { runId },
+      });
+    }
+
+    const texts = projection.messages.flatMap(textOf);
+    expect(texts.filter((t) => t === "Searching for the answer…")).toHaveLength(1);
+    expect(texts).toContain("The answer is 42.");
+    // The fallback row and the full row remain distinct entries.
+    expect(projection.messages).toHaveLength(3);
+  });
+
+  it("keeps the fallback row resolvable by its owning transcript id", () => {
+    const projected = projectChatDisplayMessages([user, mixedCommentary], {
+      includeCommentaryFallbacks: true,
+    });
+    const ids = projected.map((message) => readSessionMessageIdentity(message)?.id);
+    // The fallback row still advertises the owning transcript id so recovery and
+    // reply lookups (chat.message.get) keep resolving.
+    expect(ids).toEqual(["user", "assistant", "assistant"]);
+  });
+});

--- a/ui/src/e2e/chat-flow.commentary-dedup.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.commentary-dedup.e2e.test.ts
@@ -1,0 +1,142 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+
+suite.define(() => {
+  it("keeps a commentary fallback distinct from the full row across a tool turn and reload", async () => {
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const runId = "commentary-tool-reload-run";
+      const commentary = "Searching for the answer…";
+      const answer = "The answer is 42.";
+
+      const userMessage = {
+        role: "user",
+        content: [{ type: "text", text: "Look it up for me." }],
+        __openclaw: { id: "user", seq: 1, idempotencyKey: `${runId}:user` },
+      };
+      // The server history projection splits a mixed commentary/tool/answer turn
+      // into two rows that share the owning transcript id: a keyed commentary
+      // fallback and the full row (with the commentary stripped).
+      const fallback = {
+        role: "assistant",
+        content: [{ type: "text", text: commentary }],
+        __openclaw: { id: "assistant", seq: 2, runId },
+        openclawStreamFallback: {
+          itemId: "commentary-0",
+          replacementText: commentary,
+          source: "segment",
+        },
+      };
+      const full = {
+        role: "assistant",
+        content: [{ type: "text", text: answer }],
+        __openclaw: { id: "assistant", seq: 2, runId },
+      };
+      const toolEvent = {
+        sessionKey: "agent:main:main",
+        runId,
+        seq: 1,
+        ts: 1_001,
+        stream: "tool",
+        data: {
+          phase: "result",
+          toolCallId: "search-call",
+          name: "web_search",
+          result: { content: [{ type: "text", text: "Search result." }] },
+        },
+      };
+      const historyMessages = [userMessage, fallback, full];
+      const sessionInfo = { key: "agent:main:main", hasActiveRun: true, activeRunIds: [runId] };
+      const inFlightRun = { runId, startedAt: 1_000, text: answer, events: [toolEvent] };
+
+      const gateway = await installMockGateway(page, {
+        historyMessages: [],
+        inFlightRun: { ...inFlightRun, text: "" },
+        sessionInfo,
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.getByRole("button", { name: "Stop generating" }).waitFor();
+
+      // Live tool turn: commentary item, tool result, then the answer delta.
+      await gateway.emitGatewayEvent("agent", {
+        sessionKey: "agent:main:main",
+        runId,
+        seq: 1,
+        ts: 1_000,
+        stream: "item",
+        data: {
+          kind: "preamble",
+          itemId: "commentary-0",
+          phase: "update",
+          progressText: commentary,
+        },
+      });
+      await gateway.emitGatewayEvent("agent", toolEvent);
+      await gateway.emitGatewayEvent("chat", {
+        sessionKey: "agent:main:main",
+        runId,
+        state: "delta",
+        deltaText: answer,
+        message: { role: "assistant", content: [{ type: "text", text: answer }] },
+      });
+
+      // Persist the fallback + full rows (sharing the transcript id).
+      const session = {
+        key: "main",
+        kind: "direct",
+        status: "running",
+        updatedAt: Date.now(),
+        hasActiveRun: true,
+        activeRunIds: [runId],
+      };
+      for (const message of [fallback, full]) {
+        await gateway.emitGatewayEvent("session.message", {
+          sessionKey: "main",
+          runId,
+          clientRunId: runId,
+          hasActiveRun: true,
+          activeRunIds: [runId],
+          messageId: "assistant",
+          messageSeq: 2,
+          session,
+          message,
+        });
+      }
+
+      const assistantTexts = async () =>
+        (await page.locator(".chat-group.assistant .chat-text").allTextContents()).map((v) =>
+          v.trim(),
+        );
+      await page.locator(".chat-group.assistant .chat-text", { hasText: commentary }).waitFor();
+      expect((await assistantTexts()).filter((t) => t === commentary)).toHaveLength(1);
+      expect(await assistantTexts()).toContain(answer);
+
+      // Reload: the persisted history must still render the commentary once.
+      const startupCount = (await gateway.getRequests("chat.startup")).length;
+      await gateway.deferNext("chat.startup");
+      await gateway.setOnline(false);
+      await gateway.setOnline(true);
+      await gateway.waitForRequest("chat.startup", { after: startupCount });
+      await gateway.resolveDeferred("chat.startup", {
+        messages: historyMessages,
+        inFlightRun,
+        sessionInfo,
+        thinkingLevel: null,
+      });
+      await page.locator(".chat-group.assistant .chat-text", { hasText: commentary }).waitFor();
+      expect((await assistantTexts()).filter((t) => t === commentary)).toHaveLength(1);
+      expect(await assistantTexts()).toContain(answer);
+
+      if (process.env.OPENCLAW_CAPTURE_UI_PROOF === "1") {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(suite.artifactDir, "commentary-tool-reload.png"),
+        });
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #138735

## What Problem This Solves
Fixes an issue where WebChat showed inter-tool assistant commentary duplicated during a run and then missing after a page refresh, when a turn streams multiple text segments around a tool call.

## Why This Change Was Made
The commentary fallback row emitted by the history projection shares the owning assistant row's transcript id. Client reconciliation collapsed the two rows by id, discarding the commentary text that had been split out of the full row.

This change makes client reconciliation segment-aware: a keyed commentary fallback (`openclawStreamFallback.itemId`) is treated as distinct from the full row that owns its transcript id, so both survive. The `__openclaw.id` is left untouched, so `chat.message.get` recovery and reply lookups keep resolving.

## User Impact
WebChat now shows each inter-tool commentary segment exactly once, both during live streaming and after a history reload.

## Evidence

### Real-instance proof (real provider + real tool turn)
The fix was run as an isolated gateway and exercised through the real Control UI with DeepSeek. The scenario is a multi-step news search ("Search the web for the top 3 AI news stories today and summarize each in one sentence"): the agent attempts `web_search`, falls back to `web_fetch` (TechCrunch / The Verge / VentureBeat RSS) plus `exec`, producing several inter-tool commentary segments (e.g. "`web_search` is unavailable right now, so let me pull from news feeds directly", "The TechCrunch feed worked. Let me grab the rest of it and check another outlet"). Each commentary segment renders exactly once, both live and after reload:

**Live streaming** (commentary + tool card + answer, commentary appearing once):

![commentary rendered once — live](https://raw.githubusercontent.com/admin-leo/openclaw/pr-141143-screenshot/commentary-live.jpg)

**After page reload** (commentary still present once — previously dropped):

![commentary still rendered once — after reload](https://raw.githubusercontent.com/admin-leo/openclaw/pr-141143-screenshot/commentary-reload.jpg)

**Patched build identity** — the operator menu shows the build at commit `e679b23` (`fix/webchat-du…@e679b23`):

![operator menu showing patched commit](https://raw.githubusercontent.com/admin-leo/openclaw/pr-141143-screenshot/commentary-commit-menu.png)

The gateway log corroborates it: `webchat connected … build=2026.9.2-e679b23d0ad4`.

### Automated regression tests (both fail on pre-fix code, pass with the fix)
1. **Unit test** (`src/gateway/chat-display-projection.commentary-dup.test.ts`) — projects a mixed commentary+tool+answer turn and delivers the resulting fallback + full rows incrementally through the session projection, asserting the commentary survives exactly once with the full row intact and the transcript id still resolvable.

2. **Mock-gateway E2E test** (`ui/src/e2e/chat-flow.commentary-dedup.e2e.test.ts`) — runs the real Control UI in Chromium against a mock gateway and exercises the full turn lifecycle: a commentary preamble item, a tool result event, the answer delta, persistence of the fallback + full rows (sharing the same transcript id) via `session.message`, and a reload (`chat.startup`). It asserts the commentary bubble renders exactly once alongside the answer, both live and after reload. On pre-fix `main`: **1 failed**; with the fix: **1 passed**.

Local suites, all green: session-projection (153), gateway display projection + server-methods (372), plus the E2E test above.
