### PR TITLE
refactor(zalouser): reuse stringified id coercion

### DIFF
--- a/extensions/zalouser/src/message-sid.ts
+++ b/extensions/zalouser/src/message-sid.ts
@@ -1,18 +1,10 @@
-// Zalouser plugin module implements message sid behavior.
-function toMessageSidPart(value?: string | number | null): string {
-  if (typeof value === "string") {
-    return value.trim();
-  }
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return String(Math.trunc(value));
-  }
-  return "";
-}
+import { normalizeOptionalStringifiedId } from "openclaw/plugin-sdk/string-coerce-runtime";
 
+// Zalouser plugin module implements message sid behavior.
 function parseZalouserMessageSidFull(
   value?: string | number | null,
 ): { msgId: string; cliMsgId: string } | null {
-  const raw = toMessageSidPart(value);
+  const raw = normalizeOptionalStringifiedId(value) ?? "";
   if (!raw) {
     return null;
   }
@@ -28,8 +20,8 @@ export function resolveZalouserReactionMessageIds(params: {
   cliMsgId?: string;
   currentMessageId?: string | number;
 }): { msgId: string; cliMsgId: string } | null {
-  const explicitMessageId = toMessageSidPart(params.messageId);
-  const explicitCliMsgId = toMessageSidPart(params.cliMsgId);
+  const explicitMessageId = normalizeOptionalStringifiedId(params.messageId) ?? "";
+  const explicitCliMsgId = normalizeOptionalStringifiedId(params.cliMsgId) ?? "";
   if (explicitMessageId && explicitCliMsgId) {
     return { msgId: explicitMessageId, cliMsgId: explicitCliMsgId };
   }
@@ -39,7 +31,7 @@ export function resolveZalouserReactionMessageIds(params: {
     return parsedFromCurrent;
   }
 
-  const currentRaw = toMessageSidPart(params.currentMessageId);
+  const currentRaw = normalizeOptionalStringifiedId(params.currentMessageId) ?? "";
   if (!currentRaw) {
     return null;
   }
@@ -56,8 +48,8 @@ export function formatZalouserMessageSidFull(params: {
   msgId?: string | null;
   cliMsgId?: string | null;
 }): string | undefined {
-  const msgId = toMessageSidPart(params.msgId);
-  const cliMsgId = toMessageSidPart(params.cliMsgId);
+  const msgId = normalizeOptionalStringifiedId(params.msgId) ?? "";
+  const cliMsgId = normalizeOptionalStringifiedId(params.cliMsgId) ?? "";
   if (!msgId && !cliMsgId) {
     return undefined;
   }
@@ -72,10 +64,10 @@ export function resolveZalouserMessageSid(params: {
   cliMsgId?: string | null;
   fallback?: string | null;
 }): string | undefined {
-  const msgId = toMessageSidPart(params.msgId);
-  const cliMsgId = toMessageSidPart(params.cliMsgId);
+  const msgId = normalizeOptionalStringifiedId(params.msgId) ?? "";
+  const cliMsgId = normalizeOptionalStringifiedId(params.cliMsgId) ?? "";
   if (msgId || cliMsgId) {
     return msgId || cliMsgId;
   }
-  return toMessageSidPart(params.fallback) || undefined;
+  return normalizeOptionalStringifiedId(params.fallback);
 }

--- a/extensions/zalouser/src/zalo-js.ts
+++ b/extensions/zalouser/src/zalo-js.ts
@@ -19,6 +19,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
+  normalizeOptionalStringifiedId,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sleep, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { normalizeZaloReactionIcon } from "./reaction.js";
@@ -151,13 +152,7 @@ function toNumberId(value: unknown): string {
 }
 
 function toStringValue(value: unknown): string {
-  if (typeof value === "string") {
-    return value.trim();
-  }
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return String(Math.trunc(value));
-  }
-  return "";
+  return normalizeOptionalStringifiedId(value) ?? "";
 }
 
 function normalizeAccountInfoUser(info: AccountInfoResponse): User | null {


### PR DESCRIPTION
## What Problem This Solves

Zalouser maintained two private implementations of the same string-or-numeric ID coercion already provided by the documented plugin SDK. Keeping those copies risks semantic drift across message SID and Zalo event handling.

## Why This Change Was Made

Reuse `normalizeOptionalStringifiedId` from `openclaw/plugin-sdk/string-coerce-runtime`. The message SID helper now calls it directly, while `zalo-js.ts` retains a one-line string-returning adapter for its existing callers.

The change preserves trimmed strings, truncated finite-number stringification, empty-value handling, and rejection of non-finite or unsupported values. No public API, package, configuration, schema, or test surface changes.

## User Impact

No user-visible behavior change. Zalouser ID normalization now follows the shared plugin SDK implementation instead of duplicated local logic.

## Evidence

- `node scripts/run-vitest.mjs extensions/zalouser/src/message-sid.test.ts extensions/zalouser/src/zalo-quote-metadata.test.ts extensions/zalouser/src/zalo-js.credentials.test.ts`
  - 3 files passed, 24 tests passed
- `pnpm tsgo:extensions`
  - passed
- `node scripts/check-changed.mjs`
  - 19 gates passed, including formatting, both extension typechecks, plugin boundaries, the coercion declaration guard, dead-export scans, and 6 doctor-contract tests
  - local extension lint could not start because the native review worktree is nested beneath an ancestor `node_modules` install; the repository declaration-input guard correctly rejected that environment
- `git diff --check`
- fresh autoreview: scoped-clean, no P0/P1 findings
- exact-head CI: [run 34113290345](https://github.com/openclaw/openclaw/actions/runs/34113290345)
  - head `9c4cc72f0ebca40baaf24c5db7b8fcdb55dbf654`
  - 29 successful jobs, zero failures, including `check-lint`, `check-prod-types`, coercion-helper checks, build artifacts, and `openclaw/ci-gate`
- exact-head ClawSweeper review: ready for maintainer review, no actionable findings

The first exact-head CI attempt failed only because the Telegram progress-update test on then-current main exceeded the max-lines guard; the corresponding main run failed identically. After #141148 landed as `0015b209956c8c121222eaad906677f7581728cb`, this branch was rebased specifically to acquire that baseline fix. The Zalouser raw diff SHA-256 and stable patch-id remained exactly unchanged.
