### PR TITLE
fix(anthropic): refresh Desktop metadata when watch coverage is unknown

### DIFF
--- a/extensions/anthropic/session-catalog-desktop.test.ts
+++ b/extensions/anthropic/session-catalog-desktop.test.ts
@@ -33,15 +33,17 @@ describe("Claude Desktop overlay cache", () => {
   let now: number;
   let dirty: "all" | Set<string>;
   let watch: DirtyDirectoryWatch;
+  let closeWatch = vi.fn();
 
   beforeEach(async () => {
     home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-desktop-overlay-"));
     now = Date.UTC(2026, 0, 1);
     dirty = new Set();
+    closeWatch = vi.fn();
     watch = {
       takeDirty: () => dirty,
       observeChildDirectories: vi.fn(),
-      close: vi.fn(),
+      close: closeWatch,
     };
     createWatch.mockReset().mockReturnValue(watch);
     vi.spyOn(Date, "now").mockImplementation(() => now);
@@ -70,7 +72,7 @@ describe("Claude Desktop overlay cache", () => {
   it("keeps an absent Desktop store cached until the sixty-second backstop", async () => {
     const absent = await readDesktopOverlay(home);
     expect(absent.available).toBe(false);
-    expect(watch.close).toHaveBeenCalledOnce();
+    expect(closeWatch).toHaveBeenCalledOnce();
 
     await writeDesktopMetadata(home, "Created");
     now += 59_999;

--- a/extensions/anthropic/session-catalog-desktop.test.ts
+++ b/extensions/anthropic/session-catalog-desktop.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readDesktopOverlay } from "./session-catalog-desktop.js";
+import type { DirtyDirectoryWatch } from "./session-catalog-tree-watch.js";
+
+const createWatch = vi.hoisted(() => vi.fn());
+
+vi.mock("./session-catalog-tree-watch.js", () => ({
+  createDirtyDirectoryWatch: createWatch,
+}));
+
+async function writeDesktopMetadata(home: string, title: string): Promise<void> {
+  const directory = path.join(
+    home,
+    "Library",
+    "Application Support",
+    "Claude",
+    "claude-code-sessions",
+    "account",
+    "workspace",
+  );
+  await fs.mkdir(directory, { recursive: true });
+  await fs.writeFile(
+    path.join(directory, "local_fixture.json"),
+    JSON.stringify({ cliSessionId: "fixture-session", title }),
+  );
+}
+
+describe("Claude Desktop overlay cache", () => {
+  let home: string;
+  let now: number;
+  let dirty: "all" | Set<string>;
+  let watch: DirtyDirectoryWatch;
+
+  beforeEach(async () => {
+    home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-desktop-overlay-"));
+    now = Date.UTC(2026, 0, 1);
+    dirty = new Set();
+    watch = {
+      takeDirty: () => dirty,
+      observeChildDirectories: vi.fn(),
+      close: vi.fn(),
+    };
+    createWatch.mockReset().mockReturnValue(watch);
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+  });
+
+  afterEach(async () => {
+    watch.close();
+    vi.restoreAllMocks();
+    await fs.rm(home, { recursive: true, force: true });
+  });
+
+  it("retains clean coverage but refreshes metadata when watch coverage becomes unknown", async () => {
+    await writeDesktopMetadata(home, "Before");
+    const first = await readDesktopOverlay(home);
+    expect(first.active.get("fixture-session")?.title).toBe("Before");
+
+    await writeDesktopMetadata(home, "After");
+    expect(await readDesktopOverlay(home)).toBe(first);
+    expect(first.active.get("fixture-session")?.title).toBe("Before");
+
+    dirty = "all";
+    const refreshed = await readDesktopOverlay(home);
+    expect(refreshed.active.get("fixture-session")?.title).toBe("After");
+  });
+
+  it("keeps an absent Desktop store cached until the sixty-second backstop", async () => {
+    const absent = await readDesktopOverlay(home);
+    expect(absent.available).toBe(false);
+    expect(watch.close).toHaveBeenCalledOnce();
+
+    await writeDesktopMetadata(home, "Created");
+    now += 59_999;
+    expect(await readDesktopOverlay(home)).toBe(absent);
+
+    now += 1;
+    const refreshed = await readDesktopOverlay(home);
+    expect(refreshed.available).toBe(true);
+    expect(refreshed.active.get("fixture-session")?.title).toBe("Created");
+  });
+});

--- a/extensions/anthropic/session-catalog-desktop.ts
+++ b/extensions/anthropic/session-catalog-desktop.ts
@@ -212,6 +212,7 @@ export async function readDesktopOverlay(
     !forceRefresh &&
     entry &&
     entry.refreshedAt + CLAUDE_DESKTOP_SCAN_TTL_MS > Date.now() &&
+    dirty !== "all" &&
     !(dirty instanceof Set && dirty.size > 0)
   ) {
     setBoundedCache(desktopOverlays, homeDir, entry, 8, (evicted) => evicted.watch?.close());


### PR DESCRIPTION
## What Problem This Solves

Claude Desktop session titles can remain stale when the catalog watcher reports that its coverage is unknown. The cache fast path currently treats that state like a clean directory set and returns the cached overlay.

## Why This Change Was Made

Exclude the existing all-dirty state from the fast path so the normal refresh path rescans metadata. Clean watched entries still reuse their cached result, and an absent Desktop store retains the existing sixty-second negative-cache backstop.

## User Impact

Desktop catalog metadata refreshes when its watch state requires a full scan. There is no new watcher, polling interval, preload, or package dependency.

## Evidence

- Two focused owner tests use synthetic temporary catalog files and a controlled watch-state fixture. Before the fix, Node and Bun each fail the stale-title regression while passing the absent-store TTL case; both pass both cases afterward.
- The tests retain clean-cache identity, refreshed title, and the exact 59,999/60,000 ms absent-store boundary. All bounded, isolated runs joined without a cap or surviving process.
- Fresh independent P0–P2 review passed with no actionable findings. Final two-file source and patch hashes were verified before staging.
- The full changed-file gate passed on the final two-file candidate, including qualified Doctor architecture checks and all type/lint/static checks. An initial gate found an unbound-method assertion; the final test retains a named reference to the same close spy. Focused runtime proof preceded that mechanical reference correction and was not repeated; targeted lint, fresh full-candidate P0–P2 review, and the full gate cover the corrected test. Exact d465 CI34141622949 and pull_request WorkflowSanity34141622957 passed, and hosted review is ready with no actionable findings. No separate full build was run for this condition-only change to an existing module.

This is a cache-owner repair. The separate native filesystem watcher callback gap remains unresolved; these controlled-state tests do not prove native callback delivery or full catalog-suite compatibility.
