### PR TITLE
test(telegram): deduplicate post-final progress coverage

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -30,63 +30,44 @@ import {
 } from "./bot-message-dispatch.test-harness.js";
 
 describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
-  it("does not restart progress drafts after final answer delivery", async () => {
-    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ dispatcherOptions, replyOptions }) => {
-        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-        await dispatcherOptions.deliver({ text: "Branch is up to date" }, { kind: "final" });
-        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-        return { queuedFinal: true };
-      },
-    );
+  it.each(["tool start", "command output"] as const)(
+    "does not restart progress drafts for %s after final answer delivery",
+    async (event) => {
+      const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+        async ({ dispatcherOptions, replyOptions }) => {
+          await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+          await dispatcherOptions.deliver({ text: "Branch is up to date" }, { kind: "final" });
+          if (event === "tool start") {
+            await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+          } else {
+            await replyOptions?.onCommandOutput?.({
+              phase: "end",
+              title: "Exec",
+              name: "exec",
+              status: "failed",
+              exitCode: 1,
+            });
+          }
+          return { queuedFinal: true };
+        },
+      );
 
-    await dispatchWithContext({
-      context: createContext(),
-      streamMode: "progress",
-      telegramCfg: {
-        streaming: { mode: "progress", progress: { toolProgress: true, label: "Shelling" } },
-      },
-    });
+      await dispatchWithContext({
+        context: createContext(),
+        streamMode: "progress",
+        telegramCfg: {
+          streaming: { mode: "progress", progress: { toolProgress: true, label: "Shelling" } },
+        },
+      });
 
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
-    );
-    expectDeliveredReply(0, { text: "Branch is up to date" });
-  });
-
-  it("does not restart progress drafts for command output after final answer delivery", async () => {
-    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ dispatcherOptions, replyOptions }) => {
-        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-        await dispatcherOptions.deliver({ text: "Branch is up to date" }, { kind: "final" });
-        await replyOptions?.onCommandOutput?.({
-          phase: "end",
-          title: "Exec",
-          name: "exec",
-          status: "failed",
-          exitCode: 1,
-        });
-        return { queuedFinal: true };
-      },
-    );
-
-    await dispatchWithContext({
-      context: createContext(),
-      streamMode: "progress",
-      telegramCfg: {
-        streaming: { mode: "progress", progress: { toolProgress: true, label: "Shelling" } },
-      },
-    });
-
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
-    );
-    expectDeliveredReply(0, { text: "Branch is up to date" });
-  });
+      expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
+      expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
+        telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
+      );
+      expectDeliveredReply(0, { text: "Branch is up to date" });
+    },
+  );
 
   it("does not restart progress drafts for command output while final answer delivery is pending", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });


### PR DESCRIPTION
## What Problem This Solves

The Telegram progress test file exceeds the existing 1,000-line lint limit, blocking unrelated PRs. The failure is visible in [CI run 34107394739, check-lint](https://github.com/openclaw/openclaw/actions/runs/34107394739/job/101699488888).

## Why This Change Was Made

Consolidates the two post-final progress cases into a two-row table. Both still start progress, finish delivery, send their original late callback, and assert that the draft is not restarted. The pending-final case stays separate because its delivery ordering differs.

This removes 19 test lines while preserving both callback payloads, all assertions, and the complete remainder of the file. No production code, lint limit, suppression, or timeout changes.

## User Impact

Restores the lint gate without changing Telegram behavior or removing regression coverage.

## Evidence

- Targeted lint reproduces the original 1,012 counted lines against the 1,000-line limit.
- All 48 progress-update and lifecycle sibling cases pass before and after consolidation.
- Targeted lint and all 19 selected changed-file checks pass, including extension test typechecking and dead-export scans.
- Fresh independent P0–P2 review is scoped-clean with no findings.

Exact-head hosted CI remains required before native landing.
