### PR TITLE
fix: expose the live voice shortcut description on iOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5070,6 +5070,7 @@ jobs:
             -only-testing:OpenClawTests/LocationServiceCallbackTests \
             -only-testing:OpenClawTests/LocationServiceOrderingTests \
             -only-testing:OpenClawTests/NodeAppModelInvokeTests \
+            -only-testing:OpenClawTests/OpenClawAppDelegateTests \
             -only-testing:OpenClawTests/WatchMessagingInboundTransportTests \
             -only-testing:OpenClawTests/WatchSessionActivationGateTests \
             -only-testing:OpenClawTests/OpenClawTypographyTests \

--- a/apps/ios/Sources/StartLiveVoiceIntent.swift
+++ b/apps/ios/Sources/StartLiveVoiceIntent.swift
@@ -2,7 +2,8 @@ import AppIntents
 
 struct StartLiveVoiceIntent: AppIntent {
     static let title: LocalizedStringResource = "Start Live Voice"
-    static let description = IntentDescription("Open the current chat in OpenClaw and start a voice conversation.")
+    static let description: IntentDescription? = IntentDescription(
+        "Open the current chat in OpenClaw and start a voice conversation.")
     static let openAppWhenRun = true
 
     @MainActor

--- a/apps/ios/Tests/OpenClawAppDelegateTests.swift
+++ b/apps/ios/Tests/OpenClawAppDelegateTests.swift
@@ -83,6 +83,11 @@ import UIKit
         #expect(!delegate.application(UIApplication.shared, open: url))
     }
 
+    @Test func `live voice intent exposes its description through the AppIntent protocol`() {
+        let intent: any AppIntent.Type = StartLiveVoiceIntent.self
+        #expect(intent.description != nil)
+    }
+
     @Test @MainActor func `live voice intent survives cold launch and waits for an active scene`() async throws {
         try await withUserDefaults(["talk.enabled": false]) {
             let previousModel = OpenClawAppModelRegistry.appModel
@@ -122,7 +127,8 @@ import UIKit
         }
     }
 
-    @Test @MainActor func `warm live voice intent opens the selected chat without toggling existing voice`() async throws {
+    @Test @MainActor
+    func `warm live voice intent opens the selected chat without toggling existing voice`() async throws {
         try await withUserDefaults(["talk.enabled": false]) {
             let model = NodeAppModel(audioAdmissionInitiallyAllowed: false)
             let previousModel = OpenClawAppModelRegistry.appModel


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the **Start Live Voice** shortcut description is missing when Apple reads its `AppIntent` metadata.

## Why This Change Was Made

Declare the description as `IntentDescription?` to satisfy Apple’s protocol requirement. The inferred nonoptional property instead left the default `nil` implementation in use. Add a regression assertion through `any AppIntent.Type` and run the existing app-delegate suite in the focused iOS CI job.

## User Impact

Apple’s shortcut metadata consumers receive the intended description: “Open the current chat in OpenClaw and start a voice conversation.” The shortcut continues using the existing current-chat voice-start path.

## Evidence

- Actual-source Apple SDK probe: the original declaration returns `nil` through `any AppIntent.Type`; the repair returns the intended description text.
- Swift 6 compilation and iOS 18-target typechecking against the iOS 26.5 SDK pass. Changed-file SwiftFormat and strict SwiftLint checks pass.
- The existing suite covers cold launch, active-scene admission, warm invocation, and setup/capture rejection. Native iOS CI, Periphery, and review status are reported on this PR.
- Shortcuts screenshots are omitted because the available environment has no iOS simulator. The before/after protocol probe verifies the metadata boundary directly.
