### PR TITLE
improve(models): reduce overhead in catalog discovery

### DIFF
--- a/src/model-catalog/manifest-planner.test.ts
+++ b/src/model-catalog/manifest-planner.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe("manifest model catalog planner", () => {
   it("overlays only declared providers and keeps remote transport fields inert", () => {
-    const plan = planManifestModelCatalogRows({
+    const params: Parameters<typeof planManifestModelCatalogRows>[0] = {
       registry: {
         plugins: [
           {
@@ -43,7 +43,8 @@ describe("manifest model catalog planner", () => {
         },
         undeclared: { models: [{ id: "ignored" }] },
       },
-    });
+    };
+    const plan = planManifestModelCatalogRows(params);
     expect(
       plan.rows.map((row) => [row.id, row.name, row.source, row.baseUrl, row.headers]),
     ).toEqual([
@@ -56,6 +57,26 @@ describe("manifest model catalog planner", () => {
         "https://model.api.anthropic.com",
         { "X-Trusted": "yes" },
       ],
+    ]);
+    const emptyOverlay = {
+      anthropic: { api: "openai-completions", models: [] },
+    } satisfies Parameters<typeof planManifestModelCatalogRows>[0]["remoteOverlay"];
+    const emptyRemotePlan = planManifestModelCatalogRows({
+      ...params,
+      remoteOverlay: emptyOverlay,
+    });
+    expect(emptyRemotePlan.rows.map((row) => [row.id, row.source, row.api, row.baseUrl])).toEqual([
+      ["kept", "manifest", "openai-completions", "https://api.anthropic.com"],
+      ["old", "manifest", "openai-completions", "https://model.api.anthropic.com"],
+    ]);
+    const absentRemotePlan = planManifestModelCatalogRows({
+      ...params,
+      remoteOverlay: emptyOverlay,
+      resolveRemoteProvider: () => undefined,
+    });
+    expect(absentRemotePlan.rows.map((row) => row.api)).toEqual([
+      "anthropic-messages",
+      "anthropic-messages",
     ]);
     const aliasPlan = planManifestModelCatalogRows({
       registry: {
@@ -89,7 +110,7 @@ describe("manifest model catalog planner", () => {
           }
         : undefined,
     );
-    const plan = planManifestModelCatalogRows({
+    const params: Parameters<typeof planManifestModelCatalogRows>[0] = {
       registry: {
         plugins: [
           {
@@ -122,7 +143,8 @@ describe("manifest model catalog planner", () => {
       providerFilters: ["anthropic-alias"],
       mergeKeyFilter: new Set(["anthropic-alias::requested"]),
       resolveRemoteProvider,
-    });
+    };
+    const plan = planManifestModelCatalogRows(params);
 
     expect(resolveRemoteProvider.mock.calls).toEqual([["anthropic"]]);
     expect(plan.entries).toHaveLength(1);
@@ -136,6 +158,19 @@ describe("manifest model catalog planner", () => {
         source: "runtime-refresh",
       },
     ]);
+    resolveRemoteProvider.mockClear();
+    expect(planManifestModelCatalogRows({ ...params, providerFilters: [] })).toStrictEqual({
+      entries: [],
+      rows: [],
+      conflicts: [],
+    });
+    expect(resolveRemoteProvider.mock.calls).toEqual([]);
+    expect(planManifestModelCatalogRows({ ...params, mergeKeyFilter: new Set() })).toStrictEqual({
+      entries: [],
+      rows: [],
+      conflicts: [],
+    });
+    expect(resolveRemoteProvider.mock.calls).toEqual([["anthropic"]]);
   });
 
   it("selects static and supplemental rows at their owning catalog boundary", () => {
@@ -503,6 +538,81 @@ describe("manifest model catalog planner", () => {
     expect(plan.entries.map((entry) => entry.provider)).toEqual(["openai"]);
     expect(plan.rows.map((row) => row.ref)).toEqual(["openai/gpt-5.4"]);
     expect(plan.rows.some((row) => row.provider === "azure-openai-responses")).toBe(false);
+  });
+
+  it("sorts fresh normalized rows without mutating frozen manifest inputs", () => {
+    const models = [{ id: "z" }, { id: "a" }];
+    models.forEach(Object.freeze);
+    Object.freeze(models);
+    const registry = {
+      plugins: [{ id: "owner", modelCatalog: { providers: { fixture: { models } } } }],
+    };
+    const plan = planManifestModelCatalogRows({ registry });
+    const repeated = planManifestModelCatalogRows({ registry });
+    const rows = [
+      {
+        id: "a",
+        provider: "fixture",
+        ref: "fixture/a",
+        mergeKey: "fixture::a",
+        name: "a",
+        source: "manifest",
+        input: ["text"],
+        reasoning: false,
+        status: "available",
+      },
+      {
+        id: "z",
+        provider: "fixture",
+        ref: "fixture/z",
+        mergeKey: "fixture::z",
+        name: "z",
+        source: "manifest",
+        input: ["text"],
+        reasoning: false,
+        status: "available",
+      },
+    ];
+    expect(plan).toStrictEqual({
+      entries: [{ pluginId: "owner", provider: "fixture", discovery: undefined, rows }],
+      rows,
+      conflicts: [],
+    });
+    expect(models).toStrictEqual([{ id: "z" }, { id: "a" }]);
+    expect(repeated).toStrictEqual(plan);
+    expect(repeated.rows).not.toBe(plan.rows);
+    expect(repeated.rows[0]).not.toBe(plan.rows[0]);
+    expect(plan.rows[0]).not.toBe(models[1]);
+    expect(plan.entries[0]?.rows[0]).toBe(plan.rows[0]);
+  });
+
+  it("resolves raw overlay IDs before reporting normalized ID conflicts", () => {
+    const plan = planManifestModelCatalogRows({
+      registry: {
+        plugins: [
+          {
+            id: "owner",
+            modelCatalog: { providers: { fixture: { models: [{ id: " a ", name: "Local" }] } } },
+          },
+        ],
+      },
+      remoteOverlay: { fixture: { models: [{ id: "a", name: "Remote" }] } },
+    });
+    expect(plan.entries[0]?.rows.map((row) => [row.id, row.name, row.source])).toEqual([
+      ["a", "Local", "manifest"],
+      ["a", "Remote", "runtime-refresh"],
+    ]);
+    expect(plan.rows).toEqual([]);
+    expect(plan.conflicts).toStrictEqual([
+      {
+        mergeKey: "fixture::a",
+        ref: "fixture/a",
+        provider: "fixture",
+        modelId: "a",
+        firstPluginId: "owner",
+        secondPluginId: "owner",
+      },
+    ]);
   });
 
   it("reports duplicate provider/model keys and excludes conflicted rows", () => {

--- a/src/model-catalog/manifest-planner.ts
+++ b/src/model-catalog/manifest-planner.ts
@@ -206,13 +206,18 @@ function planManifestModelCatalogPluginEntries(params: {
       ? params.resolveRemoteProvider(normalizedProvider)
       : params.remoteOverlay?.[normalizedProvider];
     return plannedProviders.flatMap((plannedProvider) => {
-      const includesModel = (model: ModelCatalogModel) =>
-        !params.mergeKeyFilter ||
-        params.mergeKeyFilter.has(buildModelCatalogMergeKey(plannedProvider, model.id));
-      const manifestModels = providerCatalog.models.filter(includesModel);
-      const remoteModels = remoteProvider?.models.filter(includesModel) ?? [];
-      const remoteModelIds = new Set(remoteModels.map((model) => model.id));
-      const manifestModelsById = new Map(manifestModels.map((model) => [model.id, model]));
+      const mergeKeyFilter = params.mergeKeyFilter;
+      const selectModels = (models: ModelCatalogModel[]) =>
+        mergeKeyFilter
+          ? models.filter((model) =>
+              mergeKeyFilter.has(buildModelCatalogMergeKey(plannedProvider, model.id)),
+            )
+          : models;
+      const manifestModels = selectModels(providerCatalog.models);
+      const remoteModels = remoteProvider ? selectModels(remoteProvider.models) : [];
+      const remoteModelIds = remoteModels.length
+        ? new Set(remoteModels.map((model) => model.id))
+        : undefined;
       const providerDefaults = remoteProvider
         ? {
             ...providerCatalog,
@@ -221,16 +226,20 @@ function planManifestModelCatalogPluginEntries(params: {
             ...(providerCatalog.headers ? { headers: providerCatalog.headers } : {}),
           }
         : providerCatalog;
-      const manifestRows = normalizeModelCatalogProviderRows({
+      let rows = normalizeModelCatalogProviderRows({
         provider: plannedProvider,
         providerCatalog: {
           ...providerDefaults,
-          models: manifestModels.filter((model) => !remoteModelIds.has(model.id)),
+          models: remoteModelIds
+            ? manifestModels.filter((model) => !remoteModelIds.has(model.id))
+            : manifestModels,
         },
         source: "manifest",
       });
-      const remoteRows = remoteProvider
-        ? normalizeModelCatalogProviderRows({
+      if (remoteModels.length > 0) {
+        const manifestModelsById = new Map(manifestModels.map((model) => [model.id, model]));
+        rows = rows.concat(
+          normalizeModelCatalogProviderRows({
             provider: plannedProvider,
             providerCatalog: {
               ...providerDefaults,
@@ -239,13 +248,14 @@ function planManifestModelCatalogPluginEntries(params: {
               ),
             },
             source: "runtime-refresh",
-          })
-        : [];
-      // oxlint-disable-next-line unicorn/no-array-sort -- The spread creates a private merge array.
-      const rows = [...manifestRows, ...remoteRows].sort(
-        (left, right) =>
-          left.provider.localeCompare(right.provider) || left.id.localeCompare(right.id),
-      );
+          }),
+        );
+        // Both normalizers return owned sorted arrays; only a real overlay needs merging.
+        rows.sort(
+          (left, right) =>
+            left.provider.localeCompare(right.provider) || left.id.localeCompare(right.id),
+        );
+      }
       if (rows.length === 0) {
         return [];
       }
@@ -327,7 +337,7 @@ export function planManifestModelCatalogSuppressions(params: {
     : undefined;
   const suppressions: ManifestModelCatalogSuppressionEntry[] = [];
   for (const plugin of params.registry.plugins) {
-    const providerRefs = buildModelCatalogProviderRefs(plugin);
+    let providerRefs: ReadonlySet<string> | undefined;
     for (const suppression of plugin.modelCatalog?.suppressions ?? []) {
       const provider = normalizeModelCatalogProviderId(suppression.provider);
       const model = normalizeLowercaseStringOrEmpty(suppression.model);
@@ -342,6 +352,7 @@ export function planManifestModelCatalogSuppressions(params: {
       }
       // Suppressions can affect owned providers and their declared aliases only;
       // otherwise one plugin could hide another plugin's catalog entries.
+      providerRefs ??= buildModelCatalogProviderRefs(plugin);
       if (!providerRefs.has(provider)) {
         continue;
       }

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -235,7 +235,7 @@ describe("production lint suppressions", () => {
         "src/infra/outbound/sanitize-text.ts|eslint/no-control-regex|1",
         "src/infra/outbound/send-deps.ts|typescript/no-unnecessary-type-parameters|1",
         "src/logging/redact.ts|unicorn/no-new-array|1",
-        "src/model-catalog/manifest-planner.ts|unicorn/no-array-sort|3",
+        "src/model-catalog/manifest-planner.ts|unicorn/no-array-sort|2",
         "src/node-host/invoke.ts|typescript/no-unnecessary-type-parameters|1",
         "src/node-host/mcp.ts|unicorn/prefer-add-event-listener|1",
         "src/plugin-sdk/channel-config-helpers.ts|typescript/no-unnecessary-type-parameters|1",


### PR DESCRIPTION
## What Problem This Solves

Model discovery and model-list commands repeatedly prepare catalog work that is unnecessary when no remote models or matching suppression rules are present. This adds overhead as model and plugin inventories grow.

## Why This Change Was Made

Keep unfiltered model inputs on the existing normalizer path without copying them first. Prepare replacement indexes and merge sorting only when remote models actually exist, and prepare a plugin's suppression ownership set only after a rule passes the existing validity/filter checks. The normalizer still creates owned, sorted rows; empty remote-provider defaults, raw-ID conflict handling, aliases, resolver precedence, and trusted transport fields retain their existing behavior.

No cache, configuration, schema, dependency, or public API is added. Production grows by 11 lines to separate genuinely required overlay/ownership work from the common path; tests grow by 110 lines, extending existing cases and covering frozen inputs and raw-ID conflicts.

## User Impact

The measured no-overlay catalog compositions improve 13.43–22.00%. With 150 plugins, the no-suppression and unmatched-suppression fixtures improve about 80% and 76%. The real model-list CLI preserves its complete output and reaches the optimized paths. These are local catalog measurements and work-count observations, not a claim of whole CLI, Gateway, or model-response latency improvement.

## Evidence

- 92/92 tests across five complete planner/list/alias/suppression files; 30/30 normal changed checks; independent managed P0–P2 review found no actionable issues.
- Earlier checks caught a new test's overly narrow inferred type and an unused lint suppression. Both were corrected; failed output is preserved. No guard, assertion, or timeout was weakened.
- Fixed B0/C0/C1/B1 through the actual static, supplemental, and suppression planners: 16,000 complete compositions / 48,000 owner calls. Every output graph, own-undefined field, selected-row reference, input/freshness witness, and timing record was retained and independently audited.
- Both baseline and candidate passed the normal build. Two isolated calls through the real package CLI, `node openclaw.mjs models list --all --provider kimi --agent qa --json`, returned byte-identical full four-model JSON matching a prewritten oracle. Each used fresh state/workspace, no credentials, and existing catalog-refresh-disabled configuration. No provider request is needed for this static catalog.
- Coverage recorded five planner entries and 307 plugin-planner entries in each CLI tree. The candidate's unfiltered/no-overlay callback ran 89 times while its remote filtering/index/merge branches remained unentered. Suppression planning ran three times in each; ownership-set preparation fell from 154 to four calls. These are execution/work counts, not elapsed-time or allocation claims.

The CLI comparison checks every key, name, input type, context limit, availability, tag, and field absence. In particular, unauthenticated availability remains null, and only the selected default model receives the default tag. Complete build/coverage/output identity and cleanup were independently audited. Verified compressed archives retain the completed build snapshots; raw CLI and numerical records remain separate.

<details>
<summary>All paired composition medians and tradeoffs</summary>

Microseconds per composition of the three real planner exports. Negative percentages are faster. Values are medians of 12 means, each from 20 separately timed compositions. First/repeat/warmup calls are retained separately; module startup and output capture/assertions are outside individual timers. Capture work can affect later scheduling and garbage collection.

| Case | Forward baseline → candidate µs (change) | Reverse baseline → candidate µs (change) |
| --- | ---: | ---: |
| no-overlay-2 | 12.386 → 9.975 (-19.469%) | 12.759 → 10.256 (-19.618%) |
| no-overlay-64 | 83.851 → 65.404 (-22.000%) | 80.090 → 68.562 (-14.393%) |
| no-overlay-256 | 261.355 → 215.429 (-17.572%) | 251.103 → 217.369 (-13.434%) |
| empty-remote-defaults | 9.877 → 7.596 (-23.096%) | 8.938 → 7.622 (-14.720%) |
| sparse-overlay | 70.467 → 65.704 (-6.759%) | 64.882 → 65.695 (+1.252%) |
| dense-overlay | 73.047 → 67.813 (-7.166%) | 71.139 → 71.399 (+0.366%) |
| alias-merge-key | 10.861 → 9.245 (-14.884%) | 10.716 → 10.084 (-5.893%) |
| empty-provider-filter | 3.576 → 3.435 (-3.932%) | 3.363 → 2.903 (-13.665%) |
| empty-merge-key-filter | 5.558 → 4.194 (-24.550%) | 4.860 → 4.345 (-10.609%) |
| provider-filter-miss | 4.192 → 2.902 (-30.764%) | 3.123 → 3.148 (+0.800%) |
| runtime-selection | 8.642 → 7.245 (-16.165%) | 7.945 → 7.764 (-2.282%) |
| refreshable-selection | 6.552 → 5.289 (-19.285%) | 6.320 → 4.909 (-22.317%) |
| no-suppressions-150-plugins | 69.880 → 13.805 (-80.244%) | 67.785 → 13.342 (-80.318%) |
| suppression-filter-miss | 70.980 → 16.650 (-76.543%) | 69.253 → 16.514 (-76.155%) |
| owned-alias-suppression | 7.823 → 7.419 (-5.167%) | 6.803 → 6.969 (+2.432%) |
| raw-id-conflict | 9.390 → 8.070 (-14.056%) | 7.972 → 7.491 (-6.036%) |

28/32 medians improve. The four reverse-order regressions are sparse overlay +1.252% (+812 ns), dense overlay +0.366% (+260 ns), provider-filter miss +0.800% (+25 ns), and owned-alias suppression +2.432% (+165 ns). All costs remain disclosed and are accepted for this bounded optimization.

There are 72 adverse comparisons among 288 labelled first/repeat/warmup/sample aggregates and 1,714 among 8,000 indexed individual calls. Nearest-rank P95 over 12 means equals the maximum and is a duplicate label, not a population-tail estimate. No favorable rerun, confidence interval, or traffic-weighted overall estimate is claimed.

Whole-child wall is 1.358726 → 1.295598 s forward and 1.346495 → 1.310635 s reverse (-4.646%/-2.663%). User/system CPU decrease in both orders. Both RSS measures increase: kernel peak +3,997,696/+196,608 bytes; sampled tree peak +4,259,840/+688,128 bytes. These different scopes do not establish a memory or allocation benefit.

The instrumented CLI calls are correctness/reachability proof only. Standard build times are not used as a performance comparison. No external-provider or Gateway speedup is asserted.

Source: baseline `a2978f1aeb2b7d9569428c7fc0bcd637a74a02975c821eac0743ab2d0491e414`; candidate `644dffb2146f14e08d0107331345ffc38960ea943c48c5bbfab7b1b12b8503c7`.

</details>
