### PR TITLE
fix(backup): shield transient sqlite sidecars from tar lstat abort (#141042)

### DIFF
--- a/src/commands/backup-resource-inventory.ts
+++ b/src/commands/backup-resource-inventory.ts
@@ -2,7 +2,7 @@
 import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { isVolatileBackupPath } from "../infra/backup-volatile-filter.js";
+import { isTransientSqliteSidecar, isVolatileBackupPath } from "../infra/backup-volatile-filter.js";
 import { hasErrnoCode } from "../infra/errno.js";
 import type { ResolvedPluginBackupResource } from "../plugins/manifest-backup-resources.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
@@ -249,6 +249,14 @@ export async function createBackupResourceInventory(params: {
   const volatilePlan = { stateDirs: [stateDir] };
   const isVolatile = (sourcePath: string): boolean => {
     const candidate = path.resolve(sourcePath);
+    // SQLite sidecars (-shm/-wal/-journal) are always transient, even under a
+    // protected agent root. A vanished sidecar between tar's directory
+    // enumeration and its lstat aborts the whole archive with ENOENT; shielding
+    // them before the ownership check lets third-party SQLite databases (e.g.
+    // Codex CLI's goals_1.sqlite) survive a live backup.
+    if (isTransientSqliteSidecar(candidate)) {
+      return true;
+    }
     // Explicit owners survive volatile filters; excluded ancestors stay pruned
     // and the planner archives a selected link through its own asset instead.
     const ownedPath = protectedPaths.some((protectedPath) =>

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -2735,7 +2735,12 @@ describe("createBackupArchive", () => {
     );
   });
 
-  it.each(["late.sqlite", "late.sqlite-wal"])(
+  // SQLite sidecars (-shm/-wal/-journal) are now treated as transient and
+  // shielded by the volatile stat-cache (a vanished sidecar must not abort
+  // the archive), so a late-appearing .sqlite-wal no longer triggers the
+  // post-snapshot SQLite-state guard. Only a late main .sqlite database
+  // (which must be snapshotted) still aborts the run.
+  it.each(["late.sqlite"])(
     "fails when SQLite-looking state appears after snapshot discovery: %s",
     async (lateName) => {
       await withOpenClawTestState(

--- a/src/infra/backup-volatile-filter.test.ts
+++ b/src/infra/backup-volatile-filter.test.ts
@@ -1,6 +1,6 @@
 // Tests volatile path filtering for backup operations.
 import { describe, expect, it } from "vitest";
-import { isTransientSqliteBackupPath, isVolatileBackupPath } from "./backup-volatile-filter.js";
+import { isTransientSqliteBackupPath, isTransientSqliteSidecar, isVolatileBackupPath } from "./backup-volatile-filter.js";
 
 const stateDir = "/opt/openclaw/state";
 const plan = { stateDirs: [stateDir] };
@@ -59,6 +59,15 @@ describe("isVolatileBackupPath", () => {
     ["/home/user/project/config.jsonl.doctor-scrub-restore", false],
     // non-volatile: log-like name outside scope
     ["/home/user/notes/daily.log", false],
+    // volatile: SQLite sidecars are transient globally (a vanished sidecar
+    // aborts the archive); third-party databases inside agent roots are
+    // shielded even without a stateDir anchor.
+    [`${stateDir}/agents/coding/agent/codex-home/goals_1.sqlite-shm`, true],
+    [`${stateDir}/agents/coding/agent/codex-home/goals_1.sqlite-wal`, true],
+    [`${stateDir}/agents/coding/agent/codex-home/goals_1.sqlite-journal`, true],
+    ["/tmp/openclaw-502/gateway.12345678.lock.sqlite-wal", true],
+    ["/home/user/.codex/cache/cache.sqlite-shm", true],
+    ["C:\\openclaw\\state\\agents\\main\\agent\\codex-home\\goals_1.sqlite-wal", true],
   ])("classifies %s as volatile=%s", (p, expected) => {
     expect(isVolatileBackupPath(p, plan)).toBe(expected);
   });
@@ -169,5 +178,35 @@ describe("isTransientSqliteBackupPath", () => {
     "plugins/dedicated/lock.sqlite",
   ])("preserves durable SQLite state: %s", (filePath) => {
     expect(isTransientSqliteBackupPath(filePath)).toBe(false);
+  });
+});
+
+describe("isTransientSqliteSidecar", () => {
+  it.each([
+    "goals_1.sqlite-shm",
+    "goals_1.sqlite-wal",
+    "goals_1.sqlite-journal",
+    "/home/user/.openclaw/agents/coding/agent/codex-home/goals_1.sqlite-shm",
+    "/tmp/openclaw-502/gateway.12345678.lock.sqlite-wal",
+    "C:\\Users\\cobble\\.openclaw\\agents\\coding\\agent\\codex-home\\goals_1.sqlite-journal",
+  ])("classifies SQLite sidecar as transient: %s", (filePath) => {
+    expect(isTransientSqliteSidecar(filePath)).toBe(true);
+  });
+
+  it.each([
+    "goals_1.sqlite",
+    "openclaw-agent.sqlite",
+    "gateway.lock.sqlite",
+    "/tmp/openclaw-502/retained.sqlite",
+    "memory/main.sqlite.reindex-lock.sqlite",
+    "memory/main.sqlite.tmp-11111111-2222-3333-4444-555555555555",
+    "config.json",
+    "README.md",
+    "daemon.sock",
+    "goals_1.sqlite-shm.bak",
+    "goals_1.db-wal",
+    "goals_1.sqlitebackup",
+  ])("preserves non-sidecar state: %s", (filePath) => {
+    expect(isTransientSqliteSidecar(filePath)).toBe(false);
   });
 });

--- a/src/infra/backup-volatile-filter.ts
+++ b/src/infra/backup-volatile-filter.ts
@@ -48,6 +48,21 @@ export function isTransientSqliteBackupPath(filePath: string): boolean {
   return SQLITE_MEMORY_TRANSIENT_PATH_PATTERN.test(normalizedPath);
 }
 
+/**
+ * SQLite sidecar extensions that are transient by nature. SQLite creates and
+ * removes `-shm`/`-wal`/`-journal` files as databases open and close. If a
+ * sidecar vanishes between tar's directory enumeration and its `lstat`, the
+ * whole archive aborts with ENOENT. These files are documented as
+ * not-to-be-copied live (docs/cli/backup.md) and are never needed for a
+ * consistent restore.
+ */
+const SQLITE_SIDECAR_EXTENSIONS = new Set([".sqlite-shm", ".sqlite-wal", ".sqlite-journal"]);
+
+export function isTransientSqliteSidecar(filePath: string): boolean {
+  const normalizedPath = normalizePosix(filePath);
+  return SQLITE_SIDECAR_EXTENSIONS.has(path.posix.extname(normalizedPath).toLowerCase());
+}
+
 function isAgentSessionTranscriptPath(filePosix: string, stateDirPosix: string): boolean {
   const agentsRoot = path.posix.join(stateDirPosix, "agents");
   if (!isUnder(filePosix, agentsRoot)) {
@@ -103,6 +118,16 @@ export function isVolatileBackupPath(absolutePath: string, plan: VolatileFilterP
     return false;
   }
   const candidates = filePathCandidates(absolutePath);
+
+  // SQLite sidecars (-shm/-wal/-journal) are always transient regardless of
+  // location: a vanished sidecar between tar enumeration and lstat aborts the
+  // whole archive. This check is global (not scoped to stateDirs) so that
+  // third-party SQLite databases inside an agent root are also shielded.
+  for (const filePosix of candidates) {
+    if (isTransientSqliteSidecar(filePosix)) {
+      return true;
+    }
+  }
 
   for (const stateDir of plan.stateDirs) {
     if (!stateDir) {


### PR DESCRIPTION
## What Problem This Solves

`openclaw backup create` aborts the entire archive with `ENOENT` when a transient SQLite sidecar (`-shm`/`-wal`/`-journal`) vanishes between node-tar's directory enumeration and its `lstat` call. This is especially common for **third-party SQLite databases** that live inside an agent root (e.g. Codex CLI's `goals_1.sqlite` under `~/.openclaw/agents/<id>/agent/codex-home/`), which are neither snapshotted (not OpenClaw-owned) nor marked volatile.

Closes #141042.

### Root cause

1. **`backup-volatile-filter.ts`** — `isVolatileBackupPath` only handles OpenClaw-owned memory/transient SQLite paths (via `SQLITE_MEMORY_TRANSIENT_PATH_PATTERN`). It has no global rule for the generic `.sqlite-shm`/`.sqlite-wal`/`.sqlite-journal` suffixes, so a third-party sidecar is never classified as volatile.
2. **`backup-resource-inventory.ts`** — `isVolatile` short-circuits on `protectedPaths` (agent roots are protected) *before* delegating to `isVolatileBackupPath`. So even if the filter knew about sidecars, a sidecar under an agent root would be treated as owned and **not** be shielded by the synthetic stat-cache. node-tar then `lstat`s the sidecar directly, and if SQLite removed it in the race window, the archive aborts.

Per `docs/cli/backup.md`, `-shm`/`-wal`/`-journal` files are documented as **not to be copied live** — they are never needed for a consistent restore (OpenClaw-owned databases are snapshotted via the SQLite backup API, which captures committed pages).

### Fix

1. **`backup-volatile-filter.ts`** — add `isTransientSqliteSidecar(path)` (matches `.sqlite-shm`/`.sqlite-wal`/`.sqlite-journal` extensions only) and call it as a **global** guard at the top of `isVolatileBackupPath` (before the per-stateDir loop) so any sidecar anywhere is classified volatile.
2. **`backup-resource-inventory.ts`** — check `isTransientSqliteSidecar` in `isVolatile` **before** the `protectedPaths` ownership check, so sidecars are shielded even when they live under a protected agent root. This lets the synthetic stat-cache (`backup-volatile-stat-cache.ts`) return a synthetic stat and node-tar skips the `lstat` entirely.
3. **`backup-create.test.ts`** — the existing `"fails when SQLite-looking state appears after snapshot discovery"` test used `late.sqlite-wal` as a late-appearing sidecar. With sidecars now treated as transient, a late `-wal` no longer trips the post-snapshot SQLite-state guard (it is intentionally skipped). Reduced `it.each` to `["late.sqlite"]` (a late **main** database still aborts, preserving the safety guard). Added a comment explaining the behavioral change.
4. **`backup-volatile-filter.test.ts`** — added a `describe("isTransientSqliteSidecar")` block with sidecar path cases (including Windows-style separators and third-party agent-root paths) and negative cases (main `.sqlite`, `.db-wal`, `.sqlite-shm.bak`, etc.), plus sidecar rows in the `isVolatileBackupPath` parametric table.

## Evidence

### Unit tests — `backup-volatile-filter.test.ts` (90/90 pass)

```
$ npx vitest run --config test/vitest/vitest.config.ts src/infra/backup-volatile-filter.test.ts
 Test Files  1 passed (1)
      Tests  90 passed (90)
```

New `isTransientSqliteSidecar` cases verified:
- ✅ `goals_1.sqlite-shm`, `goals_1.sqlite-wal`, `goals_1.sqlite-journal` → transient
- ✅ third-party agent-root path `…/agent/codex-home/goals_1.sqlite-shm` → transient
- ✅ Windows path `C:\…\goals_1.sqlite-journal` → transient
- ✅ `gateway.12345678.lock.sqlite-wal` → transient (sidecar, regardless of owner)
- ✅ `goals_1.sqlite`, `openclaw-agent.sqlite`, `gateway.lock.sqlite`, `goals_1.sqlite-shm.bak`, `goals_1.db-wal` → not transient

`isVolatileBackupPath` sidecar rows verified (sidecar anywhere → `true`, no stateDir anchor needed).

### Integration tests — `backup-create.test.ts` (110/110 pass, Node v24.15.0)

```
$ npx vitest run --config test/vitest/vitest.config.ts src/infra/backup-create.test.ts
 Test Files  1 passed (1)
      Tests  110 passed (110)
```

- ✅ `"omits pre-existing orphan SQLite sidecars without failing backup"` — creates `orphan.sqlite` + `-wal`/`-shm`/`-journal`, asserts backup succeeds and archive contains **none** of the sidecars.
- ✅ `"fails when SQLite-looking state appears after snapshot discovery: late.sqlite"` — a late-appearing **main** `.sqlite` still aborts the run (safety guard preserved).
- ✅ All 108 other backup-create tests (snapshot discovery, hardlinks, permissions, memory reindex, symlinks, etc.) unchanged.

No production-file test assertions were loosened beyond the intentional `late.sqlite-wal` removal (explained above).

## Risk

- The change makes **all** `.sqlite-shm`/`.sqlite-wal`/`.sqlite-journal` files volatile for backup purposes. This is the documented intent (`docs/cli/backup.md`); OpenClaw-owned databases are snapshotted (so their WAL is captured via the SQLite backup API), and third-party sidecars must not be `lstat`-ed live.
- `isTransientSqliteSidecar` is deliberately narrow: it matches only the three SQLite sidecar extensions, not `.db-wal` or other suffixes, and not files with a trailing extra extension like `.sqlite-shm.bak`.

## Checklist

- [x] Tests pass locally (Node v24.15.0 for SQLite-dependent tests)
- [x] No new production dependencies
- [x] Closes #141042
