### PR TITLE
fix(cli): keep gateway alive after transient DNS failures

### DIFF
--- a/src/cli/run-main.cleanup.test.ts
+++ b/src/cli/run-main.cleanup.test.ts
@@ -12,6 +12,7 @@ const dispatch = vi.hoisted(() => ({
   command: undefined as Promise<void> | undefined,
   memoryClosed: vi.fn(async () => {}),
 }));
+const installUnhandledRejectionHandlerMock = vi.hoisted(() => vi.fn());
 // Only bootstrap/dispatch are replaced; process entry, registry scopes and cleanup are real.
 vi.mock("./route.js", () => ({
   tryRouteCli: async () => {
@@ -32,7 +33,7 @@ vi.mock("../infra/openclaw-exec-env.js", () => ({ ensureOpenClawExecMarkerOnProc
 vi.mock("../infra/warning-filter.js", () => ({ installProcessWarningFilter() {} }));
 vi.mock("../infra/unhandled-rejections.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../infra/unhandled-rejections.js")>()),
-  installUnhandledRejectionHandler() {},
+  installUnhandledRejectionHandler: installUnhandledRejectionHandlerMock,
 }));
 vi.mock("../logging/console.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../logging/console.js")>()),
@@ -171,7 +172,9 @@ beforeEach(async () => {
   process.argv = argv;
   runtime.setActivePluginRegistry(emptyRegistry.createEmptyPluginRegistry());
   dispatch.command = undefined;
+  dispatch.run = async () => {};
   dispatch.memoryClosed.mockClear();
+  installUnhandledRejectionHandlerMock.mockClear();
 });
 afterEach(() => {
   process.argv = originalArgv;
@@ -204,6 +207,17 @@ async function runProcessEntry() {
 }
 
 describe("CLI process harness cleanup", () => {
+  it("installs the rejection handler before the direct Gateway fast path", async () => {
+    dispatch.run = async () => {
+      expect(installUnhandledRejectionHandlerMock).toHaveBeenCalledOnce();
+    };
+
+    const { runCli } = await import("./run-main.js");
+    await runCli(["node", "openclaw", "gateway"]);
+
+    expect(installUnhandledRejectionHandlerMock).toHaveBeenCalledOnce();
+  });
+
   it.each(["current", "transient-resolve", "transient-reject"])(
     "joins %s resources at process completion",
     async (mode) => {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -1289,6 +1289,7 @@ async function runCliWithPreparedOutputMode(
     installProxySignalHandlers();
   };
   let uninstallGatewayRunRuntimeHooks: (() => void) | null = null;
+  let unhandledRejectionHandlerInstalled = false;
 
   try {
     const startupTraces = [startupTrace, options.additionalStartupTrace].filter(
@@ -1490,6 +1491,16 @@ async function runCliWithPreparedOutputMode(
       !isHelpOrVersionInvocation && shouldStartProxyForCli(normalizedArgv);
     const bootstrapProxyBeforeFastPath =
       shouldUseCliEnvProxy && shouldBootstrapCliProxyBeforeFastPath();
+    // Gateway execution can return before full CLI bootstrap, so install the
+    // shared process policy before the fast path can start asynchronous work.
+    if (isGatewayRunFastPathArgv(normalizedArgv)) {
+      const { installUnhandledRejectionHandler } = await startupTrace.measure(
+        "unhandled-rejection-handler-import",
+        () => import("../infra/unhandled-rejections.js"),
+      );
+      installUnhandledRejectionHandler();
+      unhandledRejectionHandlerInstalled = true;
+    }
     if (
       !bootstrapProxyBeforeFastPath &&
       (await tryRunGatewayRunFastPath(normalizedArgv, startupTrace))
@@ -1570,7 +1581,9 @@ async function runCliWithPreparedOutputMode(
 
       // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
       // These log the error and exit gracefully instead of crashing without trace.
-      installUnhandledRejectionHandler();
+      if (!unhandledRejectionHandlerInstalled) {
+        installUnhandledRejectionHandler();
+      }
 
       process.on("uncaughtException", (error) => {
         if (isUncaughtExceptionHandled(error)) {


### PR DESCRIPTION
Closes #141123

## What Problem This Solves

Fixes an issue where operators running the normal Gateway CLI entrypoint could lose the Gateway process when an asynchronous operation escaped with a transient network rejection such as `EAI_AGAIN`. The direct Gateway startup path returned before OpenClaw installed its existing unhandled-rejection policy.

## Why This Change Was Made

Install the shared unhandled-rejection policy immediately before Gateway fast-path execution can begin asynchronous work. If Gateway execution falls through to the full CLI bootstrap, a local installation flag prevents registering the process handler twice. This preserves the existing distinction between transient network failures and fatal programming/configuration errors; it does not add broad warning mode or operation-level retries.

## User Impact

Gateway processes launched through the normal CLI path now receive the same transient-rejection handling as other CLI commands, so a temporary DNS resolution failure no longer bypasses the established process policy and terminates active work.

## Evidence

- Exact head: `6bfef9a2710309a7763580108df4982cf0509512`
- Added a focused Gateway fast-path regression test that asserts the rejection handler is installed before the Gateway action runs and is installed exactly once.
- Existing `src/infra/unhandled-rejections.fatal-detection.test.ts` coverage owns the policy distinction between transient and fatal rejections; this PR only repairs startup ordering.
- `oxfmt` completed for both touched files.
- `git diff --check origin/main...HEAD` passed.
- Exact-commit autoreview completed with no P0-P3 actionable findings (correctness 0.95).
- Repository tests were not executed locally because this is an external-contributor checkout; the added regression and surrounding suites are delegated to secretless fork/upstream GitHub CI under the repository source-trust policy.
### Real Gateway survival proof

- Source under test remained the exact PR head `6bfef9a2710309a7763580108df4982cf0509512`; the proof workflow detached that SHA before installing dependencies or starting OpenClaw.
- A real primary CLI Gateway was started on Ubuntu 24.04 with `node --import tsx src/entry.ts gateway --port 19463 --bind loopback --auth none --allow-unconfigured`.
- The proof injected one unhandled rejection with `code=EAI_AGAIN` after startup, then observed OpenClaw's existing non-fatal policy log and verified that the same Gateway process remained alive.
- `/healthz` and `/readyz` both returned HTTP 200 before the injection and HTTP 200 afterward.
- Passing secretless fork run: https://github.com/ly85206559/openclaw/actions/runs/34180343777
- Redacted proof artifact: https://github.com/ly85206559/openclaw/actions/runs/34180343777/artifacts/10038768236 (SHA-256 `ee9cc11e097eee3fd42b579434f209096d1399e73b9d0e68f16f228695d3199c`).
- The proof harness is isolated on fork-only commit `bc4563ff940e85fea7f2b90081b780b01c97e885`; it did not modify the PR branch or its reviewed head.