### PR TITLE
refactor(plugins): share npm version queries

### DIFF
--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -13,7 +13,7 @@ import { resolveUserPath } from "../utils.js";
 import { resolveArchiveKind } from "./archive.js";
 import { pathExists } from "./fs-safe.js";
 import { applyNpmFreshnessBypassEnv, type NpmProjectInstallEnvOptions } from "./npm-install-env.js";
-import { resolveNpmJsonEntries } from "./npm-registry-spec.js";
+import { isExactSemverVersion, resolveNpmJsonEntries } from "./npm-registry-spec.js";
 import { withTempWorkspace } from "./private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
 
@@ -69,7 +69,7 @@ export function buildNpmResolutionFields(resolution?: NpmSpecResolution): NpmRes
 }
 
 /** Creates a script-free npm environment for metadata and pack commands. */
-export function createNpmMetadataEnv(
+function createNpmMetadataEnv(
   scope: Pick<NpmProjectInstallEnvOptions, "npmConfigCwd"> = {},
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {
@@ -78,6 +78,36 @@ export function createNpmMetadataEnv(
   };
   applyNpmFreshnessBypassEnv(env, new Date(), scope);
   return env;
+}
+
+export async function loadNpmPackageVersions({
+  packageName,
+  timeoutMs,
+  ...commandOptions
+}: {
+  packageName: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  killProcessTree?: boolean;
+}): Promise<string[] | null> {
+  const versions = await runCommandWithTimeout(["npm", "view", packageName, "versions", "--json"], {
+    ...commandOptions,
+    timeoutMs: Math.max(timeoutMs ?? 0, 60_000),
+    env: createNpmMetadataEnv(),
+  });
+  if (versions.code !== 0) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(versions.stdout.trim());
+  } catch {
+    return null;
+  }
+  return (Array.isArray(parsed) ? parsed : [parsed]).filter(
+    (value): value is string => typeof value === "string" && isExactSemverVersion(value),
+  );
 }
 
 function resolveNpmSpecVersionSelector(spec: string): string | undefined {

--- a/src/plugins/install-npm-metadata.ts
+++ b/src/plugins/install-npm-metadata.ts
@@ -1,16 +1,14 @@
 import {
-  createNpmMetadataEnv,
+  loadNpmPackageVersions,
   resolveNpmSpecMetadata,
   type NpmSpecResolution,
 } from "../infra/install-source-utils.js";
 import {
   compareOpenClawReleaseVersions,
-  isExactSemverVersion,
   isPrereleaseSemverVersion,
   type ParsedRegistryNpmSpec,
 } from "../infra/npm-registry-spec.js";
 import { compareValidSemver } from "../infra/semver.js";
-import { runCommandWithTimeout } from "../process/exec.js";
 import {
   validateOpenClawPackageInstallCompatibility,
   type PluginInstallRuntime,
@@ -43,35 +41,6 @@ type TrustedOfficialPrereleaseResolution =
   | { kind: "prerelease-only"; resolution: NpmSpecResolution }
   | { kind: "allow-prerelease-only" };
 
-async function loadNpmPackageVersions(params: {
-  packageName: string;
-  timeoutMs: number;
-  signal?: AbortSignal;
-}): Promise<string[] | null> {
-  const versions = await runCommandWithTimeout(
-    ["npm", "view", params.packageName, "versions", "--json"],
-    {
-      timeoutMs: Math.max(params.timeoutMs, 60_000),
-      signal: params.signal,
-      killProcessTree: true,
-      env: createNpmMetadataEnv(),
-    },
-  );
-  if (versions.code !== 0) {
-    return null;
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(versions.stdout.trim());
-  } catch {
-    return null;
-  }
-  return (Array.isArray(parsed) ? parsed : [parsed]).filter(
-    (value): value is string => typeof value === "string" && isExactSemverVersion(value),
-  );
-}
-
 export async function resolveTrustedOfficialPrereleaseResolution(params: {
   spec: ParsedRegistryNpmSpec;
   resolvedPrereleaseVersion: string;
@@ -86,6 +55,7 @@ export async function resolveTrustedOfficialPrereleaseResolution(params: {
     packageName: params.spec.name,
     timeoutMs: params.timeoutMs,
     signal: params.signal,
+    killProcessTree: true,
   });
   if (!semverVersions) {
     return null;
@@ -216,6 +186,7 @@ export async function resolveLatestCompatibleNpmResolution(params: {
     packageName: params.parsedSpec.name,
     timeoutMs: params.timeoutMs,
     signal: params.signal,
+    killProcessTree: true,
   });
   if (!versions) {
     return null;

--- a/src/plugins/update-source.ts
+++ b/src/plugins/update-source.ts
@@ -5,7 +5,7 @@ import type { ClawHubTrustErrorCode } from "../infra/clawhub-install-trust.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
 import { unscopedPackageName } from "../infra/install-safe-path.js";
 import type { NpmSpecResolution } from "../infra/install-source-utils.js";
-import { createNpmMetadataEnv, resolveNpmSpecMetadata } from "../infra/install-source-utils.js";
+import { loadNpmPackageVersions, resolveNpmSpecMetadata } from "../infra/install-source-utils.js";
 import {
   isExactSemverVersion,
   isPrereleaseResolutionAllowed,
@@ -17,7 +17,6 @@ import {
   expectedIntegrityForUpdate,
 } from "../infra/package-update-utils.js";
 import type { UpdateChannel } from "../infra/update-channels.js";
-import { runCommandWithTimeout } from "../process/exec.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import { isUnavailableClawHubTarget } from "./clawhub-error-codes.js";
 import type { ExternalizedBundledPluginBridge } from "./externalized-bundled-plugins.js";
@@ -265,32 +264,6 @@ export async function resolveNewerExactPinnedNpmDefaultLine(params: {
     : undefined;
 }
 
-async function loadNpmPackageVersionsForUpdate(params: {
-  packageName: string;
-  timeoutMs?: number;
-}): Promise<string[] | null> {
-  const versions = await runCommandWithTimeout(
-    ["npm", "view", params.packageName, "versions", "--json"],
-    {
-      timeoutMs: Math.max(params.timeoutMs ?? 0, 60_000),
-      env: createNpmMetadataEnv(),
-    },
-  );
-  if (!versions || versions.code !== 0) {
-    return null;
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(versions.stdout.trim());
-  } catch {
-    return null;
-  }
-  return (Array.isArray(parsed) ? parsed : [parsed]).filter(
-    (value): value is string => typeof value === "string" && isExactSemverVersion(value),
-  );
-}
-
 export async function resolveTrustedOfficialPrereleaseFallbackMetadataForUpdate(params: {
   metadata: NpmSpecResolution;
   spec: string;
@@ -314,7 +287,7 @@ export async function resolveTrustedOfficialPrereleaseFallbackMetadataForUpdate(
   ) {
     return undefined;
   }
-  const versions = await loadNpmPackageVersionsForUpdate({
+  const versions = await loadNpmPackageVersions({
     packageName: parsedSpec.name,
     timeoutMs: params.timeoutMs,
   });

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -6,6 +6,7 @@ import { bundledPluginRootAt } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import type { SpawnResult } from "../process/exec.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { resolvePluginArtifactDeclaredSurface } from "./capability-artifact.js";
 import { computeDeclaredSurfaceHash } from "./capability-summary.js";
@@ -51,6 +52,14 @@ const installPluginFromClawHubMock = vi.fn();
 const installPluginFromGitSpecMock = vi.fn();
 const resolveBundledPluginSourcesMock = vi.fn();
 const runCommandWithTimeoutMock = vi.fn();
+const failedNpmVersionQueryResult: SpawnResult = {
+  code: 1,
+  stdout: "",
+  stderr: "npm version query failed",
+  signal: null,
+  killed: false,
+  termination: "exit",
+};
 const validatePackageExtensionEntriesForInstallMock = vi.fn();
 const markClawPackageIndependentlyOwnedMock = vi.fn();
 const withClawPackageLifecycleLeaseMock = vi.fn(
@@ -1441,6 +1450,7 @@ describe("updateNpmInstalledPlugins", () => {
       installerVersion: "2026.5.2-beta.2",
       installerResolvedSpec: "@openclaw/acpx@2026.5.2-beta.2",
     });
+    runCommandWithTimeoutMock.mockResolvedValueOnce(failedNpmVersionQueryResult);
 
     const result = await updatePlugin(config, "acpx", { syncOfficialPluginInstalls: true });
 
@@ -1720,6 +1730,7 @@ describe("updateNpmInstalledPlugins", () => {
       installerVersion: "2026.5.2",
       installerResolvedSpec: "@openclaw/acpx@2026.5.2",
     });
+    runCommandWithTimeoutMock.mockResolvedValueOnce(failedNpmVersionQueryResult);
     const result = await updatePlugin(config, "acpx", { syncOfficialPluginInstalls: true });
 
     expect(npmInstallCall()?.spec).toBe("@openclaw/acpx");
@@ -2033,6 +2044,7 @@ describe("updateNpmInstalledPlugins", () => {
       installerVersion: "2026.5.28-beta.3",
       installerResolvedSpec: "@openclaw/msteams@2026.5.28-beta.3",
     });
+    runCommandWithTimeoutMock.mockResolvedValueOnce(failedNpmVersionQueryResult);
 
     const result = await updatePlugin(config, "msteams");
 


### PR DESCRIPTION
## What Problem This Solves

Plugin installs and updates duplicate the npm version request, JSON parsing and semver filtering. The same registry handling has two implementation owners.

## Why This Change Was Made

Move the complete query/parser into the existing install-source utility module already used by both callers. Install continues to pass its AbortSignal and explicit process-tree termination; update continues to omit those options. Callers retain their version-selection and compatibility decisions. The npm environment helper becomes private now that all its callers are local.

Remove the impossible missing-process-result guard. Four existing test cases now supply a typed command-failure result instead of relying on an unspecified mock return; their assertions are unchanged.

## User Impact

No intended behavior change. Command arguments, timeout flooring, environment, error propagation, version order/filtering and caller-owned selection are preserved. The change removes 24 production code lines and adds 12 test-fixture lines, for a net reduction of 12 maintained code lines.

## Evidence

All 359 existing owner/caller tests pass before and after; they also pass after refreshing onto repaired main. An external differential probe matches 377 cases for output, rejection, command arguments and exact option presence, using the real semver predicate. The unsupported undefined-mock difference is explicitly excluded from production parity. All 29 selected gate stages passed and final independent Codex review was clean through P2. The refresh preserved all four changed file hashes and the complete changed-line payload. No live registry or package-build result is claimed for this source-only consolidation.
