### PR TITLE
fix(update): restore dev-to-package channel switching

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -94,6 +94,12 @@ are labeled explicitly. The final report includes the outcome, recorded phase du
 verification facts, and recovery guidance. `--json` keeps stdout machine-readable and does not
 print progress steps.
 
+When switching from a dev checkout to a package, the updater replaces npm's
+install link and leaves the external checkout untouched. If activation fails,
+restoring that link and its launchers does not verify the mutable checkout's
+runtime. Recovery stays unverified and does not authorize an automatic restart;
+inspect the checkout and recovery report before restarting it.
+
 `--yes` also skips the optional shell-completion setup prompt. Existing
 completion profiles and caches are still repaired when needed; installing
 completion in a new shell profile remains an interactive choice.

--- a/src/infra/package-update-integrity.ts
+++ b/src/infra/package-update-integrity.ts
@@ -15,7 +15,11 @@ const MAX_SCAN_MS = 30_000;
 const log = createSubsystemLogger("update/package-integrity");
 let readerSequence = 0;
 
-export type PackageIntegrityFingerprint = { digest: string; identity: string; version: string };
+type PackageIntegrityFingerprint = { digest: string; identity: string; version: string };
+
+export type PackageRootIntegrityFingerprint =
+  | { kind: "directory"; tree: PackageIntegrityFingerprint }
+  | { kind: "link"; metadata: string[]; target: string };
 
 function identity(stat: BigIntStats): string {
   return `${stat.dev}:${stat.ino}`;
@@ -275,6 +279,27 @@ export function createPackageIntegrityReader(timeoutMs = MAX_SCAN_MS) {
     return { digest: digest.digest("hex"), identity: rootIdentity, version };
   }
 
+  async function rootEntry(
+    root: string,
+    originalRoot = root,
+    expectedKind?: PackageRootIntegrityFingerprint["kind"],
+  ): Promise<PackageRootIntegrityFingerprint> {
+    const stat = await read(() => fs.lstat(root, { bigint: true }));
+    if (expectedKind && expectedKind !== (stat.isSymbolicLink() ? "link" : "directory")) {
+      throw new Error("Package rollback root entry kind changed");
+    }
+    if (!stat.isSymbolicLink()) {
+      return { kind: "directory", tree: await tree(root, originalRoot) };
+    }
+    const target = await read(() => fs.readlink(root));
+    if (!unchanged(stat, await read(() => fs.lstat(root, { bigint: true })))) {
+      throw new Error("Package rollback link changed while reading");
+    }
+    // npm owns this pointer, not the external checkout it names. A sibling
+    // rename changes ctime but must preserve the link identity and raw target.
+    return { kind: "link", metadata: metadata(stat).slice(0, -1), target };
+  }
+
   async function launcher(file: string): Promise<string> {
     const stat = await read(() => fs.lstat(file, { bigint: true }));
     const contents = stat.isSymbolicLink()
@@ -306,5 +331,5 @@ export function createPackageIntegrityReader(timeoutMs = MAX_SCAN_MS) {
     }
   }
 
-  return { tree, launcher, exists, entries, observe };
+  return { tree, rootEntry, launcher, exists, entries, observe };
 }

--- a/src/infra/package-update-npm-root.ts
+++ b/src/infra/package-update-npm-root.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs/promises";
+import { isDeepStrictEqual } from "node:util";
+import { formatErrorMessage } from "./errors.js";
+import {
+  createPackageIntegrityReader,
+  type PackageRootIntegrityFingerprint,
+} from "./package-update-integrity.js";
+import { movePathWithCopyFallback } from "./replace-file.js";
+
+export async function activateStagedNpmPackageRoot(
+  source: string,
+  destination: string,
+): Promise<void> {
+  const stat = await fs.lstat(source);
+  if (!stat.isSymbolicLink()) {
+    await movePathWithCopyFallback({
+      from: source,
+      sourceHardlinks: "allow",
+      to: destination,
+    });
+    return;
+  }
+
+  // npm represents global local-directory installs as relative symlinks. Moving
+  // one changes its meaning, so activate the same canonical source explicitly.
+  const canonicalSource = await fs.realpath(source);
+  await fs.symlink(
+    canonicalSource,
+    destination,
+    process.platform === "win32" ? "junction" : undefined,
+  );
+}
+
+export function createNpmPackageRootLinkLifecycle(params: {
+  liveRoot: string;
+  backupRoot: string;
+  fingerprint: Extract<PackageRootIntegrityFingerprint, { kind: "link" }>;
+  timeoutMs?: number;
+}) {
+  const assertUnchanged = async (root: string) => {
+    const actual = await createPackageIntegrityReader(params.timeoutMs).rootEntry(
+      root,
+      params.liveRoot,
+      "link",
+    );
+    if (!isDeepStrictEqual(actual, params.fingerprint)) {
+      throw new Error("Npm package link changed before activation or retirement");
+    }
+  };
+  return {
+    assertLiveUnchanged: () => assertUnchanged(params.liveRoot),
+    async acquire(): Promise<{ acquired: true } | { acquired: false; error: string }> {
+      await fs.rename(params.liveRoot, params.backupRoot);
+      try {
+        // Only the moved entry can establish ownership of the retained link.
+        await assertUnchanged(params.backupRoot);
+        return { acquired: true };
+      } catch (error) {
+        // A mismatch already disproves ownership. Do not compensate into a
+        // live path where another package publisher may now be writing.
+        return {
+          acquired: false,
+          error: `Npm package link backup refused: ${formatErrorMessage(error)}; moved entry retained at ${params.backupRoot}; inspect it before manual recovery`,
+        };
+      }
+    },
+    async retire(): Promise<string | null> {
+      try {
+        await assertUnchanged(params.backupRoot);
+        // This observation does not exclude concurrent writers. Non-recursive
+        // removal protects a substituted directory and the external checkout.
+        await fs.unlink(params.backupRoot);
+        return null;
+      } catch (error) {
+        return `Could not retire retained npm package link at ${params.backupRoot}: ${formatErrorMessage(error)}`;
+      }
+    },
+  };
+}

--- a/src/infra/package-update-swap.integrity.test.ts
+++ b/src/infra/package-update-swap.integrity.test.ts
@@ -32,6 +32,31 @@ async function expectCandidateIntact(packageRoot: string, launcher: string) {
   await expect(fs.readFile(launcher, "utf8")).resolves.toBe("candidate launcher\n");
 }
 
+async function createLinkedPackageSwapFixture(base: string, relative = false) {
+  const fixture = await createPackageSwapFixture(base);
+  const checkout = path.join(base, "checkout");
+  await fs.rename(fixture.packageRoot, checkout);
+  await fs.writeFile(path.join(checkout, "operator.txt"), "operator-owned checkout\n");
+  // A linked checkout can reference dependencies outside the package root.
+  await fs.symlink(
+    base,
+    path.join(checkout, "external"),
+    process.platform === "win32" ? "junction" : "dir",
+  );
+  await fs.symlink(
+    relative ? path.relative(path.dirname(fixture.packageRoot), checkout) : checkout,
+    fixture.packageRoot,
+    process.platform === "win32" ? "junction" : "dir",
+  );
+  return {
+    ...fixture,
+    checkout,
+    target: await fs.readlink(fixture.packageRoot),
+    linkIdentity: (await fs.lstat(fixture.packageRoot)).ino,
+    checkoutIdentity: (await fs.stat(checkout)).ino,
+  };
+}
+
 describe("retained npm package integrity", () => {
   it.each(["changed launcher", "unchanged launcher", "verified activation"] as const)(
     "handles an absent old package with %s",
@@ -69,6 +94,273 @@ describe("retained npm package integrity", () => {
       });
     },
   );
+
+  it.each([false, true])(
+    "activates a package over an owned npm dev link (relative=%s)",
+    async (relative) => {
+      await withTestDir({ prefix: "openclaw-linked-package-activate-" }, async (base) => {
+        const fixture = await createLinkedPackageSwapFixture(base, relative);
+        const transaction = await retain(fixture.params);
+        await expectCandidateIntact(fixture.packageRoot, fixture.launcher);
+        expect((await fs.lstat(transaction.backupRoot)).ino).toBe(fixture.linkIdentity);
+        expect(await fs.readlink(transaction.backupRoot)).toBe(fixture.target);
+        await fs.writeFile(
+          path.join(fixture.checkout, "operator.txt"),
+          "independent operator edit\n",
+        );
+        expect(await transaction.complete({ activationVerified: true })).toBeUndefined();
+        await expect(fs.lstat(transaction.backupRoot)).rejects.toMatchObject({ code: "ENOENT" });
+        expect((await fs.stat(fixture.checkout)).ino).toBe(fixture.checkoutIdentity);
+        expect(await fs.readFile(path.join(fixture.checkout, "operator.txt"), "utf8")).toBe(
+          "independent operator edit\n",
+        );
+        expect(await fs.readFile(path.join(fixture.checkout, "package.json"), "utf8")).toContain(
+          '"version":"1.0.0"',
+        );
+      });
+    },
+  );
+
+  it.each([false, true])(
+    "restores only the owned npm link without granting runtime recovery (relative=%s)",
+    async (relative) => {
+      await withTestDir({ prefix: "openclaw-linked-package-rollback-" }, async (base) => {
+        const fixture = await createLinkedPackageSwapFixture(base, relative);
+        const transaction = await retain(fixture.params);
+        await fs.writeFile(
+          path.join(fixture.checkout, "operator.txt"),
+          "independent operator edit\n",
+        );
+        const rollback = await transaction.rollback();
+        expect(rollback).toMatchObject({ exitCode: 1, activePackageRoot: fixture.packageRoot });
+        expect(rollback.stderrTail).toContain("external checkout runtime integrity is unverified");
+        expect(rollback.stdoutTail).toBeNull();
+        expect((await fs.lstat(fixture.packageRoot)).ino).toBe(fixture.linkIdentity);
+        expect(await fs.readlink(fixture.packageRoot)).toBe(fixture.target);
+        expect(await fs.readFile(fixture.launcher, "utf8")).toBe("old launcher\n");
+        expect(await fs.readFile(path.join(fixture.checkout, "operator.txt"), "utf8")).toBe(
+          "independent operator edit\n",
+        );
+        expect((await fs.stat(fixture.checkout)).ino).toBe(fixture.checkoutIdentity);
+        expect(await transaction.complete({ activationVerified: false })).toMatchObject({
+          exitCode: 1,
+        });
+        await expect(fs.stat(`${transaction.backupRoot}.candidate`)).resolves.toBeDefined();
+        expect(await transaction.rollback()).toEqual(rollback);
+      });
+    },
+  );
+
+  it.each(["before observation", "after observation"] as const)(
+    "retains a directory substituted for the backup link %s",
+    async (when) => {
+      await withTestDir({ prefix: "openclaw-linked-package-retirement-" }, async (base) => {
+        const fixture = await createLinkedPackageSwapFixture(base);
+        const transaction = await retain(fixture.params);
+        let replaced = false;
+        const replaceLink = async () => {
+          replaced = true;
+          await fs.rename(transaction.backupRoot, `${transaction.backupRoot}.original`);
+          await fs.rename(fixture.checkout, transaction.backupRoot);
+        };
+        if (when === "before observation") {
+          await replaceLink();
+        } else {
+          const readlink = fs.readlink.bind(fs);
+          const lstat = fs.lstat.bind(fs);
+          let targetRead = false;
+          vi.spyOn(fs, "readlink").mockImplementation(async (...args) => {
+            const target = await readlink(...args);
+            if (String(args[0]) === transaction.backupRoot) {
+              targetRead = true;
+            }
+            return target;
+          });
+          vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+            const stat = await lstat(...args);
+            if (String(args[0]) === transaction.backupRoot && targetRead && !replaced) {
+              // The check observes the old link; only non-recursive removal is safe afterward.
+              await replaceLink();
+            }
+            return stat;
+          });
+        }
+        expect(await transaction.complete({ activationVerified: true })).toMatchObject({
+          name: "global install backup retention",
+          exitCode: 1,
+        });
+        expect(replaced).toBe(true);
+        const retained = await fs.lstat(transaction.backupRoot);
+        expect(retained.isDirectory()).toBe(true);
+        expect(retained.ino).toBe(fixture.checkoutIdentity);
+        expect(await fs.readFile(path.join(transaction.backupRoot, "operator.txt"), "utf8")).toBe(
+          "operator-owned checkout\n",
+        );
+        await expectCandidateIntact(fixture.packageRoot, fixture.launcher);
+      });
+    },
+  );
+
+  it("retains an unexpected backup directory after nonretained activation", async () => {
+    await withTestDir({ prefix: "openclaw-linked-package-direct-cleanup-" }, async (base) => {
+      const fixture = await createLinkedPackageSwapFixture(base);
+      let backupRoot = "";
+      const rename = fs.rename.bind(fs);
+      vi.spyOn(fs, "rename").mockImplementation(async (...args) => {
+        if (String(args[0]) === fixture.packageRoot) {
+          backupRoot = String(args[1]);
+        }
+        return rename(...args);
+      });
+      const result = await swapStagedPackageInstall({
+        ...fixture.params,
+        postVerifyStep: async () => {
+          await rename(backupRoot, `${backupRoot}.original`);
+          await rename(fixture.checkout, backupRoot);
+          return { name: "verified", command: "verify", cwd: base, durationMs: 0, exitCode: 0 };
+        },
+      });
+      expect(result.status).toBe("committed");
+      expect(result.step.stdoutTail).toContain("Could not retire retained npm package link");
+      expect((await fs.stat(backupRoot)).ino).toBe(fixture.checkoutIdentity);
+      expect(await fs.readFile(path.join(backupRoot, "operator.txt"), "utf8")).toBe(
+        "operator-owned checkout\n",
+      );
+      await expectCandidateIntact(fixture.packageRoot, fixture.launcher);
+    });
+  });
+
+  it("reports failed activation after link restoration as unverified package recovery", async () => {
+    await withTestDir({ prefix: "openclaw-linked-package-rejected-" }, async (base) => {
+      const fixture = await createLinkedPackageSwapFixture(base);
+      const result = await swapStagedPackageInstall({
+        ...fixture.params,
+        postVerifyStep: async () => ({
+          name: "candidate verification",
+          command: "verify candidate",
+          cwd: fixture.packageRoot,
+          durationMs: 0,
+          exitCode: 1,
+          stderrTail: "candidate rejected",
+        }),
+      });
+      expect(result).toMatchObject({
+        status: "failed",
+        activePackageRoot: fixture.packageRoot,
+        packageRollbackVerified: false,
+        step: { exitCode: 1 },
+      });
+      expect(result.step.stderrTail).toContain(
+        "Restored the npm package link and affected launchers",
+      );
+      expect(result.step.stderrTail).toContain("external checkout runtime integrity is unverified");
+      expect(await fs.readlink(fixture.packageRoot)).toBe(fixture.target);
+      expect((await fs.lstat(fixture.packageRoot)).ino).toBe(fixture.linkIdentity);
+      expect(await fs.readFile(fixture.launcher, "utf8")).toBe("old launcher\n");
+      expect(await fs.readFile(path.join(fixture.checkout, "operator.txt"), "utf8")).toBe(
+        "operator-owned checkout\n",
+      );
+    });
+  });
+
+  it.each(["identity", "target"] as const)(
+    "refuses a changed retained npm link %s before displacing the candidate",
+    async (change) => {
+      await withTestDir({ prefix: "openclaw-linked-package-tamper-" }, async (base) => {
+        const fixture = await createLinkedPackageSwapFixture(base);
+        const transaction = await retain(fixture.params);
+        await fs.rename(transaction.backupRoot, `${transaction.backupRoot}.original`);
+        await fs.symlink(
+          change === "identity" ? fixture.target : base,
+          transaction.backupRoot,
+          process.platform === "win32" ? "junction" : "dir",
+        );
+        const rollback = await transaction.rollback();
+        expect(rollback).toMatchObject({ exitCode: 1, activePackageRoot: fixture.packageRoot });
+        expect(rollback.stderrTail).toContain("retained package");
+        await expectCandidateIntact(fixture.packageRoot, fixture.launcher);
+        expect(await fs.readFile(path.join(fixture.checkout, "operator.txt"), "utf8")).toBe(
+          "operator-owned checkout\n",
+        );
+        expect(await transaction.complete({ activationVerified: false })).toMatchObject({
+          exitCode: 1,
+        });
+      });
+    },
+  );
+
+  it.each([false, true])(
+    "retains a substituted backup directory (new live entry=%s)",
+    async (blocked) => {
+      await withTestDir({ prefix: "openclaw-linked-package-acquire-" }, async (base) => {
+        const fixture = await createLinkedPackageSwapFixture(base);
+        const rename = fs.rename.bind(fs);
+        let movedRoot = "";
+        vi.spyOn(fs, "rename").mockImplementation(async (...args) => {
+          if (String(args[0]) === fixture.packageRoot && !movedRoot) {
+            movedRoot = String(args[1]);
+            await rename(fixture.packageRoot, `${fixture.packageRoot}.original`);
+            await rename(fixture.checkout, fixture.packageRoot);
+            await rename(...args);
+            if (blocked) {
+              await fs.mkdir(fixture.packageRoot);
+              await fs.writeFile(path.join(fixture.packageRoot, "new-owner.txt"), "preserve me");
+            }
+            return;
+          }
+          return rename(...args);
+        });
+        const result = await swapStagedPackageInstall(fixture.params);
+        expect(result).toMatchObject({
+          status: "failed",
+          packageRollbackVerified: false,
+          activePackageRoot: null,
+        });
+        expect(movedRoot).not.toBe("");
+        expect(result.step.stderrTail).toContain("link backup refused");
+        const preservedRoot = movedRoot;
+        expect((await fs.lstat(preservedRoot)).isDirectory()).toBe(true);
+        expect((await fs.stat(preservedRoot)).ino).toBe(fixture.checkoutIdentity);
+        expect(await fs.readFile(path.join(preservedRoot, "operator.txt"), "utf8")).toBe(
+          "operator-owned checkout\n",
+        );
+        if (blocked) {
+          expect(result.step.stderrTail).toContain("moved entry retained");
+          expect(await fs.readFile(path.join(fixture.packageRoot, "new-owner.txt"), "utf8")).toBe(
+            "preserve me",
+          );
+        } else {
+          await expect(fs.lstat(fixture.packageRoot)).rejects.toMatchObject({ code: "ENOENT" });
+        }
+        expect(await fs.readFile(fixture.launcher, "utf8")).toBe("old launcher\n");
+      });
+    },
+  );
+
+  it("refuses an npm root link replaced during service preparation", async () => {
+    await withTestDir({ prefix: "openclaw-linked-package-preparation-" }, async (base) => {
+      const fixture = await createLinkedPackageSwapFixture(base);
+      const onLiveMutation = vi.fn();
+      const result = await swapStagedPackageInstall({
+        ...fixture.params,
+        onLiveMutation,
+        beforeActivate: async () => {
+          await fs.rename(fixture.packageRoot, `${fixture.packageRoot}.original`);
+          await fs.symlink(
+            base,
+            fixture.packageRoot,
+            process.platform === "win32" ? "junction" : "dir",
+          );
+        },
+      });
+      expect(result).toMatchObject({ status: "failed", packageRollbackVerified: false });
+      expect(onLiveMutation).not.toHaveBeenCalled();
+      expect(await fs.readlink(fixture.packageRoot)).toBe(base);
+      expect(await fs.readFile(path.join(fixture.checkout, "operator.txt"), "utf8")).toBe(
+        "operator-owned checkout\n",
+      );
+    });
+  });
 
   it("accepts a hardlinked launcher using copy-preserved metadata", async () => {
     await withTestDir({ prefix: "openclaw-rollback-linked-launcher-" }, async (base) => {
@@ -234,22 +526,13 @@ describe("retained npm package integrity", () => {
     });
   });
 
-  it.each(["external link", "linked root", "oversized file", "unavailable inode"] as const)(
+  it.each(["external link", "oversized file", "unavailable inode"] as const)(
     "refuses an unverifiable %s before service preparation or live mutation",
     async (shape) => {
       await withTestDir({ prefix: "openclaw-rollback-admission-" }, async (base) => {
         const { params, packageRoot, launcher } = await createPackageSwapFixture(base);
         if (shape === "external link") {
           await fs.symlink(base, path.join(packageRoot, "external"));
-        }
-        if (shape === "linked root") {
-          const external = path.join(base, "external");
-          await fs.rename(packageRoot, external);
-          await fs.symlink(
-            external,
-            packageRoot,
-            process.platform === "win32" ? "junction" : "dir",
-          );
         }
         if (shape === "oversized file") {
           const file = path.join(packageRoot, "oversized.bin");

--- a/src/infra/package-update-swap.ts
+++ b/src/infra/package-update-swap.ts
@@ -9,8 +9,12 @@ import {
 import { readPackageVersion } from "./package-json.js";
 import {
   createPackageIntegrityReader,
-  type PackageIntegrityFingerprint,
+  type PackageRootIntegrityFingerprint,
 } from "./package-update-integrity.js";
+import {
+  activateStagedNpmPackageRoot,
+  createNpmPackageRootLinkLifecycle,
+} from "./package-update-npm-root.js";
 import { movePathWithCopyFallback } from "./replace-file.js";
 import {
   resolveNpmGlobalPrefixLayoutFromGlobalRoot,
@@ -152,27 +156,6 @@ async function pathEntriesMatch(left: string, right: string): Promise<boolean> {
   return leftContents.equals(rightContents);
 }
 
-async function activateStagedNpmPackageRoot(source: string, destination: string): Promise<void> {
-  const stat = await fs.lstat(source);
-  if (!stat.isSymbolicLink()) {
-    await movePathWithCopyFallback({
-      from: source,
-      sourceHardlinks: PACKAGE_MANAGER_SWAP_SOURCE_HARDLINKS,
-      to: destination,
-    });
-    return;
-  }
-
-  // npm represents global local-directory installs as relative symlinks. Moving
-  // one changes its meaning, so activate the same canonical source explicitly.
-  const canonicalSource = await fs.realpath(source);
-  await fs.symlink(
-    canonicalSource,
-    destination,
-    process.platform === "win32" ? "junction" : undefined,
-  );
-}
-
 export async function swapStagedPackageInstall(params: {
   stage: StagedPackageInstall;
   installTarget: ResolvedGlobalInstallTarget;
@@ -249,7 +232,8 @@ export async function swapStagedPackageInstall(params: {
   let hadPackage = false;
   let previousVersion: string | null = null;
   let previousDistFiles: string[] | undefined;
-  let previousTree: PackageIntegrityFingerprint | undefined;
+  let previousRoot: PackageRootIntegrityFingerprint | undefined;
+  let rootLink: ReturnType<typeof createNpmPackageRootLinkLifecycle> | undefined;
   let packageBackedUp = false;
   let displacedCandidateRoot: string | undefined;
   const baseline = createPackageIntegrityReader(params.timeoutMs);
@@ -269,11 +253,16 @@ export async function swapStagedPackageInstall(params: {
     await reader.observe(fromBackup ? "retained" : "restored", async () => {
       if (
         hadPackage
-          ? !previousTree ||
-            !isDeepStrictEqual(await reader.tree(root, targetSwapRoot), previousTree)
+          ? !previousRoot ||
+            !isDeepStrictEqual(
+              await reader.rootEntry(root, targetSwapRoot, previousRoot.kind),
+              previousRoot,
+            )
           : !fromBackup && (await reader.exists(root))
       ) {
-        throw new Error("Package rollback verification failed: retained package tree changed");
+        throw new Error(
+          `Package rollback verification failed: retained package ${previousRoot?.kind === "link" ? "link" : "tree"} changed`,
+        );
       }
       for (const shim of shims) {
         const target = fromBackup ? shim.backup : shim.destination;
@@ -337,7 +326,13 @@ export async function swapStagedPackageInstall(params: {
       try {
         await verifyNpmRecovery(targetSwapRoot, false);
         // Returning to absence cannot establish a verified previous runtime.
-        packageRollbackVerified = hadPackage && messages.length === 0;
+        packageRollbackVerified =
+          hadPackage && previousRoot?.kind === "directory" && messages.length === 0;
+        if (previousRoot?.kind === "link" && messages.length === 0) {
+          messages.push(
+            `${rollback.length > 0 ? "Restored" : "Verified"} the npm package link and affected launchers; external checkout runtime integrity is unverified.`,
+          );
+        }
       } catch (error) {
         packageRollbackVerified = false;
         messages.push(formatErrorMessage(error));
@@ -398,8 +393,16 @@ export async function swapStagedPackageInstall(params: {
     if (hadPackage && !native) {
       // Unreadable or unbounded rollback material must fail while the old
       // package is still live, before beforeActivate may stop its service.
-      previousTree = await baseline.tree(targetSwapRoot);
-      previousVersion = previousTree.version;
+      previousRoot = await baseline.rootEntry(targetSwapRoot);
+      previousVersion = previousRoot.kind === "directory" ? previousRoot.tree.version : null;
+      if (previousRoot.kind === "link") {
+        rootLink = createNpmPackageRootLinkLifecycle({
+          liveRoot: targetSwapRoot,
+          backupRoot,
+          fingerprint: previousRoot,
+          timeoutMs: params.timeoutMs,
+        });
+      }
     }
     if (hadPackage && previousVersion && native) {
       previousDistFiles =
@@ -560,8 +563,12 @@ export async function swapStagedPackageInstall(params: {
               name: "global install backup retention",
             };
           }
+          const linkRetention = rootLink ? await rootLink.retire() : null;
+          if (linkRetention) {
+            return { ...step(1, null, linkRetention), name: "global install backup retention" };
+          }
           completed = true;
-          if (hadPackage) {
+          if (hadPackage && previousRoot?.kind !== "link") {
             await discardBackup(backupRoot, "old package");
           }
           if (shimBackupDir) {
@@ -570,6 +577,7 @@ export async function swapStagedPackageInstall(params: {
         },
       });
     }
+    await rootLink?.assertLiveUnchanged();
     // A native refusal must still allow the unchanged Gateway to restart.
     // Mark mutation only now: a copy-fallback move can fail after partial publication,
     // and only a completed backup permits restoration.
@@ -585,12 +593,18 @@ export async function swapStagedPackageInstall(params: {
           sourceHardlinks: PACKAGE_MANAGER_SWAP_SOURCE_HARDLINKS,
           to: backupRoot,
         });
+      } else if (rootLink) {
+        const acquisition = await rootLink.acquire();
+        if (!acquisition.acquired) {
+          activePackageRoot = null;
+          throw new Error(acquisition.error);
+        }
       } else {
         await fs.rename(targetSwapRoot, backupRoot);
       }
       activePackageRoot = null;
       packageBackedUp = true;
-      packageRollbackVerified = true;
+      packageRollbackVerified = native !== undefined || previousRoot?.kind === "directory";
     }
     rollback.push(async () => {
       if (!native && hadPackage) {
@@ -690,7 +704,11 @@ export async function swapStagedPackageInstall(params: {
       };
     }
     const cleanup = [
-      hadPackage && !retained ? await discardBackup(backupRoot, "old package") : null,
+      hadPackage && !retained
+        ? rootLink
+          ? await rootLink.retire()
+          : await discardBackup(backupRoot, "old package")
+        : null,
       shimBackupDir && !retained ? await discardBackup(shimBackupDir, "shim backup") : null,
     ];
     return {


### PR DESCRIPTION
Related: #140981

## What Problem This Solves

Fixes an issue where users switching from a linked development checkout back to a package would fail before activation with “Package rollback root is not a retained directory.” The updater itself creates that npm link when switching to the dev channel.

## Why This Change Was Made

Treat the npm-owned root link as a distinct installation entry, without hashing or changing the external checkout it names. Verify it before and after backup acquisition; retain mismatched material for manual recovery. Both activation paths retire the old link with fingerprint checks and non-recursive unlink. Existing directory integrity checks remain unchanged.

Restoring a link and its launchers does not establish the external checkout's runtime integrity: recovery remains unverified and cannot authorize an automatic Gateway restart. These filesystem observations do not exclude concurrent writers.

## User Impact

Users can switch a dev-linked installation back to a package. If activation or ownership verification fails, the updater reports the recovery state and preserves evidence instead of claiming that an external checkout is safe to restart.

## Evidence

- Reproduced the original failure through the real Docker channel-switch flow: package → beta and package → dev succeeded; dev → stable failed at the directory-only integrity check ([diagnostic run](https://github.com/openclaw/openclaw/actions/runs/34103865873)).
- 138 focused tests passed across the swap integrity, bounds, recovery, and native-transaction suites. Meaningful regressions were red before their fixes, including real absolute/relative links, external checkout edits, ownership mismatches, and directory substitution during cleanup.
- Full changed-file gate passed, including typechecking, lint, dead-export and repository policy checks. Documentation validation passed.
- Independent P2 review is clean. The directory verifier is byte-for-byte unchanged; the existing staged activation function was moved without changing behavior to keep the swap owner within its file-size limit.
- The repaired canonical Docker `update-channel-switch` lane passed, including package inventory/import checks and bare-image preparation ([replay run](https://github.com/openclaw/openclaw/actions/runs/34114223162)). This is causal proof from the original failing source plus the exact five-file repair: source `350e77999a6dba264a23db4c1e17fd598c5f29f9`, tree `4a20e7403999f4f55c5671ac8b963c8ef27a6d13`; it is not a claim about exact PR-head package bytes.
- The prior hosted CI run was blocked by the separately tracked planner-growth fixture timing out after 120 seconds in `checks-node-compact-small-29` ([CI run](https://github.com/openclaw/openclaw/actions/runs/34114298741)). This PR has now been rebased without conflicts onto main `6b54af7fc30c0b0399f08d8afca9e3d53f9844a8`, which contains the landed CI fixture repairs. The five-file npm repair is byte-for-byte unchanged; [Fresh CI passed](https://github.com/openclaw/openclaw/actions/runs/34133466789) on `7aab5321221d4c068111d12bd0d598afb26f32df`. No timeout or planner cap is changed in this PR.
