### PR TITLE
docs(web): repoint a Control UI compatibility anchor at a live target

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -137,7 +137,7 @@ Every section heading from the previous single-page version keeps its anchor her
 - <a id="updates" />[Updates](/web/control-ui/settings#updates)
 - <a id="apps-and-extensions" />[Apps and extensions](/web/control-ui/settings#apps-and-extensions)
 - <a id="side-panel-keyboard-shortcuts" />[Side panel keyboard shortcuts](/web/control-ui/settings#side-panel-keyboard-shortcuts)
-- <a id="this-mac-(macos-app)" />[this mac (macos app)](</web/control-ui/settings#this-mac-(macos-app)>)
+- <a id="this-mac-(macos-app)" />[This device (macOS and iOS apps)](/web/control-ui/settings#this-mac-macos-app)
 - <a id="custom-plugin-ui" />[Custom plugin UI](/web/control-ui/settings#custom-plugin-ui)
 - <a id="import-assistant-memory" />[Import assistant memory](/web/control-ui/settings#import-assistant-memory)
 - <a id="mcp-page" />[MCP page](/web/control-ui/settings#mcp-page)


### PR DESCRIPTION
## What

One compatibility stub on `/web/control-ui` pointed at a fragment that does not exist. It now points at a live id, and the legacy anchor is unchanged.

## Why

[#140808](https://github.com/openclaw/openclaw/pull/140808) added `<a id>` stubs so deep links to the pre-split Control UI page keep working. One stub was generated against a heading that had already been renamed: `### This mac (macOS app)` became `### This device (macOS and iOS apps)`, so `/web/control-ui/settings#this-mac-(macos-app)` had no target.

The settings page still publishes the alias `this-mac-macos-app`, so the legacy anchor points there now. The `<a id="this-mac-(macos-app)">` is kept, so external links to `/web/control-ui#this-mac-(macos-app)` still resolve. The visible label now matches the destination heading.

Surfaced by `docs-link-audit --anchors`, which a sibling split PR reported as a pre-existing failure on main.

## Sweep

This is the failure mode a stub pass is prone to — a target that moved between generating the stub and landing it — so I checked the rest rather than fixing only the reported one. Using the repository's own `parseDocsDocument`, every authored compatibility stub in the tree:

```
checked 282 stubs across all splits, dead 0
```

Note that a naive regex sweep gives false positives here: an unescaped `(` in a fragment truncates the match, so six stubs looked dead when they were not. The count above parses the angle-bracket form properly.

## Validation

```
docs-link-audit --anchors   0 broken links
```