### PR TITLE
fix(ci): reduce timeouts in tooling inventory checks

### DIFF
--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -2249,75 +2249,35 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
         vi.resetModules();
       }
     };
-    const baseline = await createPlanWithInventory(false);
-    const baselineToolingFiles = baseline
-      .flatMap((job) => job.groups)
-      .filter(isNumberedToolingGroup)
-      .flatMap((group) => group.includePatterns ?? []);
-    const grown = await createPlanWithInventory(true);
-    const toolingGroups = grown.flatMap((job) => job.groups).filter(isNumberedToolingGroup);
-    const toolingFiles = toolingGroups.flatMap((group) => group.includePatterns ?? []);
-    const crossRunnerHostedJobs: CompactNodeTestShard[] = [];
-
-    expect(grown.length).toBeLessThanOrEqual(80);
-    expect(new Set(toolingFiles).size).toBe(toolingFiles.length);
-    expect(toolingFiles.toSorted()).toEqual(
-      [...baselineToolingFiles, inventoryGrowthFile].toSorted(),
-    );
-    expect(nonToolingPlacement(grown)).toEqual(nonToolingPlacement(baseline));
-
-    for (const job of grown) {
-      const hostedToolingGroups = job.groups.filter(isHostedToolingGroup);
-      if (hostedToolingGroups.length === 0) {
-        continue;
-      }
-      const families = hostedToolingGroups.map((group) =>
-        group.shard_name.replace(/-hosted-\d+$/u, ""),
-      );
-      expect(new Set(families).size).toBe(families.length);
-      expect(job.requiresDist).toBe(false);
-      expect(job.planConcurrency).toBe(1);
-      expect(job.groups.length).toBeLessThanOrEqual(10);
-      if (job.groups.length > 1) {
-        expect(job.predictedSeconds).toBeLessThanOrEqual(150);
-      }
-      expect(job.runner).toBe(job.groups[0]?.runner);
-      expect(
-        hostedToolingGroups.every(
-          (group) => (runnerRanks.get(job.runner) ?? -1) >= (runnerRanks.get(group.runner) ?? 0),
-        ),
-      ).toBe(true);
-      if (hostedToolingGroups.some((group) => group.runner !== job.runner)) {
-        crossRunnerHostedJobs.push(job);
-        expect(job.groups.every(isHostedToolingGroup)).toBe(true);
-        expect(job.pretestBuildMode).toBeUndefined();
-        expect(job.groups.every((group) => group.pretestBuildMode === undefined)).toBe(true);
-      }
-    }
-    // Inventory growth can move numbered stripes; validate every mixed-capacity
-    // job above instead of pinning one incidental packing layout.
-    expect(crossRunnerHostedJobs.length).toBeGreaterThan(0);
-
-    for (const extraFiles of extraInventories) {
-      const extraBaseline = await createPlanWithInventory(false, extraFiles);
-      const expanded = await createPlanWithInventory(true, extraFiles);
-      const expandedToolingFiles = expanded
+    // Growth changes only the tracked-file mock; real unit-fast discovery sees unchanged disk inputs.
+    const unitFastPaths = await import("../vitest/vitest.unit-fast-paths.mjs");
+    try {
+      vi.doMock("../vitest/vitest.unit-fast-paths.mjs", () => unitFastPaths);
+      const baseline = await createPlanWithInventory(false);
+      const baselineToolingFiles = baseline
         .flatMap((job) => job.groups)
         .filter(isNumberedToolingGroup)
         .flatMap((group) => group.includePatterns ?? []);
-      expect(expanded.length).toBeLessThanOrEqual(80);
-      expect(new Set(expandedToolingFiles).size).toBe(expandedToolingFiles.length);
-      expect(expandedToolingFiles.toSorted()).toEqual(
-        [...new Set([...baselineToolingFiles, inventoryGrowthFile, ...extraFiles])].toSorted(),
+      const grown = await createPlanWithInventory(true);
+      const toolingGroups = grown.flatMap((job) => job.groups).filter(isNumberedToolingGroup);
+      const toolingFiles = toolingGroups.flatMap((group) => group.includePatterns ?? []);
+      const crossRunnerHostedJobs: CompactNodeTestShard[] = [];
+
+      expect(grown.length).toBeLessThanOrEqual(80);
+      expect(new Set(toolingFiles).size).toBe(toolingFiles.length);
+      expect(toolingFiles.toSorted()).toEqual(
+        [...baselineToolingFiles, inventoryGrowthFile].toSorted(),
       );
-      expect(nonToolingPlacement(extraBaseline)).toEqual(nonToolingPlacement(baseline));
-      expect(nonToolingPlacement(expanded)).toEqual(nonToolingPlacement(extraBaseline));
-      for (const job of expanded.filter((candidate) =>
-        candidate.groups.some(isHostedToolingGroup),
-      )) {
-        const families = job.groups
-          .filter(isHostedToolingGroup)
-          .map((group) => group.shard_name.replace(/-hosted-\d+$/u, ""));
+      expect(nonToolingPlacement(grown)).toEqual(nonToolingPlacement(baseline));
+
+      for (const job of grown) {
+        const hostedToolingGroups = job.groups.filter(isHostedToolingGroup);
+        if (hostedToolingGroups.length === 0) {
+          continue;
+        }
+        const families = hostedToolingGroups.map((group) =>
+          group.shard_name.replace(/-hosted-\d+$/u, ""),
+        );
         expect(new Set(families).size).toBe(families.length);
         expect(job.requiresDist).toBe(false);
         expect(job.planConcurrency).toBe(1);
@@ -2327,11 +2287,61 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
         }
         expect(job.runner).toBe(job.groups[0]?.runner);
         expect(
-          job.groups.every(
+          hostedToolingGroups.every(
             (group) => (runnerRanks.get(job.runner) ?? -1) >= (runnerRanks.get(group.runner) ?? 0),
           ),
         ).toBe(true);
+        if (hostedToolingGroups.some((group) => group.runner !== job.runner)) {
+          crossRunnerHostedJobs.push(job);
+          expect(job.groups.every(isHostedToolingGroup)).toBe(true);
+          expect(job.pretestBuildMode).toBeUndefined();
+          expect(job.groups.every((group) => group.pretestBuildMode === undefined)).toBe(true);
+        }
       }
+      // Inventory growth can move numbered stripes; validate every mixed-capacity
+      // job above instead of pinning one incidental packing layout.
+      expect(crossRunnerHostedJobs.length).toBeGreaterThan(0);
+
+      for (const extraFiles of extraInventories) {
+        const extraBaseline = await createPlanWithInventory(false, extraFiles);
+        const expanded = await createPlanWithInventory(true, extraFiles);
+        const expandedToolingFiles = expanded
+          .flatMap((job) => job.groups)
+          .filter(isNumberedToolingGroup)
+          .flatMap((group) => group.includePatterns ?? []);
+        expect(expanded.length).toBeLessThanOrEqual(80);
+        expect(new Set(expandedToolingFiles).size).toBe(expandedToolingFiles.length);
+        expect(expandedToolingFiles.toSorted()).toEqual(
+          [...new Set([...baselineToolingFiles, inventoryGrowthFile, ...extraFiles])].toSorted(),
+        );
+        expect(nonToolingPlacement(extraBaseline)).toEqual(nonToolingPlacement(baseline));
+        expect(nonToolingPlacement(expanded)).toEqual(nonToolingPlacement(extraBaseline));
+        for (const job of expanded.filter((candidate) =>
+          candidate.groups.some(isHostedToolingGroup),
+        )) {
+          const families = job.groups
+            .filter(isHostedToolingGroup)
+            .map((group) => group.shard_name.replace(/-hosted-\d+$/u, ""));
+          expect(new Set(families).size).toBe(families.length);
+          expect(job.requiresDist).toBe(false);
+          expect(job.planConcurrency).toBe(1);
+          expect(job.groups.length).toBeLessThanOrEqual(10);
+          if (job.groups.length > 1) {
+            expect(job.predictedSeconds).toBeLessThanOrEqual(150);
+          }
+          expect(job.runner).toBe(job.groups[0]?.runner);
+          expect(
+            job.groups.every(
+              (group) =>
+                (runnerRanks.get(job.runner) ?? -1) >= (runnerRanks.get(group.runner) ?? 0),
+            ),
+          ).toBe(true);
+        }
+      }
+    } finally {
+      vi.doUnmock("../../scripts/lib/list-test-files.mts");
+      vi.doUnmock("../vitest/vitest.unit-fast-paths.mjs");
+      vi.resetModules();
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

CI can time out while checking that hosted tooling remains within its job cap as the inventory grows. The growth test reached 121.863 seconds against its existing 120-second deadline on a two-CPU Linux runner, blocking unrelated PRs.

Related: #141126, #141047. This preserves the inventory-isolation, expanded-growth, and projection coverage from #140549, #140664, and #141075.

## Why This Change Was Made

Keep the real unit-fast discovery namespace alive for this one fixture's ten planner evaluations. That module reads its own unchanged Git/source snapshot; it does not consume the separately mocked tracked-file list that supplies the growth inputs. Re-importing the planner can therefore keep observing each new synthetic tooling inventory without repeatedly rebuilding unrelated discovery caches.

All ten real planner evaluations and their original assertions remain. The original per-evaluation mock cleanup stays, and an outer finally removes both module mocks and resets modules even on failure. There are no production changes, new testing seams, timeout increases, or changes to runner, job-cap, selection, or execution policy. The test grows by ten lines after formatting.

## User Impact

The inventory-growth check does less redundant work while continuing to verify complete coverage, placement, runner compatibility, concurrency, and job-cap constraints. Local proof reduces the affected case by 35.6%; the same Linux CI lane still needs to validate the resulting margin before landing.

## Evidence

The failed CI source at merge `85713c6ecf56db7e1e08951ae666b26f51e52161` was retrieved and verified byte-identical to this baseline test. The original failure is in [run 34108956395](https://github.com/openclaw/openclaw/actions/runs/34108956395), job `checks-node-compact-small-29` / `core-tooling-15-hosted-3`. Another unrelated PR independently encountered the same timeout in [run 34112443896](https://github.com/openclaw/openclaw/actions/runs/34112443896).

One baseline and one candidate whole-suite run used the same local Node 26.8.1 environment, original test order, and unchanged 120-second per-test deadline. Both passed all 53 tests. The existing unit-fast sibling suite passed all 14 tests; all 15 selected normal checks passed. Managed independent P0–P2 review found no actionable issues.

| Observation | Baseline | Candidate |
| --- | ---: | ---: |
| Affected growth case | 21.892 s | 14.104 s |
| Whole test command | 64.292 s | 55.542 s |
| Child user CPU | 70.431 s | 63.267 s |
| Child system CPU | 3.876 s | 2.819 s |
| Kernel child peak RSS | 1,376,436,224 B | 1,391,296,512 B |
| Sampled tree peak RSS | 1,857,175,552 B | 1,865,449,472 B |

The larger local Mac did not reproduce the Linux timeout, so these are diagnostic before/after observations, not a claim of equivalent capacity or a statistical speedup guarantee. All test names, statuses, durations, failures, and resources are retained. Thirty-one other test durations increased, and both RSS measures increased; no general memory benefit is claimed. The existing ten policy/coverage checks are preserved by source and execution, but this reporter does not serialize their internal plan objects.
