### PR TITLE
fix(update): installed plugins fail candidate validation

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -484,8 +484,11 @@ For targets that support candidate validation, the old Gateway keeps serving thr
 plugin resolution and compatibility planning. It also rehearses migrations and
 boots a canary with copied configuration and verified SQLite snapshots in an
 isolated temporary state directory. The copied database registry points to the
-copied agent databases. Channels, cron, automatic updates, and other side
-services are suppressed in this canary.
+copied agent databases. Installed plugin payloads and their dependencies are also
+copied; the rehearsal install records point to those copies, and their OpenClaw
+host links target the staged candidate. The live plugin files and host links stay
+unchanged. Channels, cron, automatic updates, and other side services are
+suppressed in this canary.
 
 Schema checks also use private SQLite copies so inspection does not create or
 modify WAL sidecars beside live databases. Each schema inspection has a

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -359,7 +359,7 @@ vi.mock("../process/exec.js", () => ({
   // Retain real rehearsal config projection and drift checks in this CLI fixture.
   runCommandBuffered: async () => ({
     code: 0,
-    stdout: Buffer.from("[]"),
+    stdout: Buffer.from(JSON.stringify({ versions: [], pluginPaths: {} })),
     stderr: Buffer.alloc(0),
   }),
   runCommandWithTimeout: vi.fn(),

--- a/src/cli/update-cli/update-command-repair.ts
+++ b/src/cli/update-cli/update-command-repair.ts
@@ -81,6 +81,7 @@ export async function runUpdateCommandRepair(params: {
           observe: false,
         });
         rehearsal = await prepareUpdateCandidateRehearsal({
+          candidateRoot: params.candidateRoot ?? params.root,
           config: snapshot.config,
           sourceConfigHash: snapshot.hash,
           stateDir: target.stateDir,

--- a/src/infra/update-candidate-canary.test.ts
+++ b/src/infra/update-candidate-canary.test.ts
@@ -53,7 +53,7 @@ beforeEach(async () => {
   await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ version: "2026.9.1" }));
   mocks.snapshot.mockResolvedValue({
     code: 0,
-    stdout: Buffer.from("[]"),
+    stdout: Buffer.from(JSON.stringify({ versions: [], pluginPaths: {} })),
     stderr: Buffer.alloc(0),
     termination: "exit",
   });
@@ -237,6 +237,7 @@ describe("update candidate canary", () => {
       }),
     );
     const rehearsal = await prepareUpdateCandidateRehearsal({
+      candidateRoot: root,
       config,
       stateDir: root,
       env: {},

--- a/src/infra/update-candidate-canary.ts
+++ b/src/infra/update-candidate-canary.ts
@@ -259,6 +259,7 @@ export async function validateUpdateCandidateCanary(params: {
       throw new Error("Candidate Doctor cannot enforce isolated service-repair ownership");
     }
     rehearsal ??= await prepareUpdateCandidateRehearsal({
+      candidateRoot: params.root,
       config: params.config,
       stateDir: params.stateDir,
       env: sourceEnv,

--- a/src/infra/update-candidate-plugin-tree.ts
+++ b/src/infra/update-candidate-plugin-tree.ts
@@ -1,0 +1,230 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolvePathViaExistingAncestorSync } from "./boundary-path.js";
+import { hasNodeErrorCode, isPathInside } from "./path-guards.js";
+import {
+  readRuntimeModulesManifest,
+  relocateRuntimeTree,
+  type RuntimeRelocation,
+} from "./update-runtime-relocation.js";
+
+const isHostEdge = (file: string) =>
+  path.basename(file) === "openclaw" && path.basename(path.dirname(file)) === "node_modules";
+const isHostLauncher = (file: string) =>
+  path.basename(path.dirname(file)) === ".bin" &&
+  ["openclaw", "openclaw.cmd", "openclaw.ps1"].includes(path.basename(file));
+
+async function dependencyOwner(target: string): Promise<string> {
+  // A pnpm package resolves dependencies beside its package directory. Preserve
+  // that Node lookup ancestry, including scoped packages and nested installs.
+  const parts = target.split(path.sep);
+  const store = parts.indexOf(".pnpm");
+  if (store >= 0) {
+    return parts.slice(0, store + 1).join(path.sep);
+  }
+  const modules = parts.indexOf("node_modules");
+  if (modules >= 0) {
+    return parts.slice(0, modules + 1).join(path.sep);
+  }
+  let directory = (await fs.stat(target)).isDirectory() ? target : path.dirname(target);
+  const fallback = target;
+  for (;;) {
+    if (
+      await fs.stat(path.join(directory, "package.json")).then(
+        () => true,
+        (error: unknown) => {
+          if (hasNodeErrorCode(error, "ENOENT")) {
+            return false;
+          }
+          throw error;
+        },
+      )
+    ) {
+      return directory;
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) {
+      return fallback;
+    }
+    directory = parent;
+  }
+}
+
+/** Copy dependency owners intact, then rebind their complete private link graph. */
+export async function copyUpdateCandidatePluginTrees(params: {
+  roots: Map<string, string>;
+  project: (source: string) => string;
+  targetStateDir: string;
+  candidateRoot: string;
+}): Promise<{ copies: Array<[string, string]>; hostLinks: Set<string> }> {
+  const roots = new Map(params.roots);
+  const privateRoot = resolvePathViaExistingAncestorSync(path.resolve(params.targetStateDir));
+  const candidateRoot = resolvePathViaExistingAncestorSync(path.resolve(params.candidateRoot));
+  const scanned = new Set<string>();
+  const edges = new Map<string, { target: string; real: string }>();
+  const hosts = new Set<string>();
+  const hostRoots = new Set<string>();
+  const stores = new Set<string>();
+  const covered = (file: string) => [...roots.keys()].some((root) => isPathInside(root, file));
+  function addRoot(source: string) {
+    if (!covered(source)) {
+      roots.set(source, params.project(source));
+    }
+  }
+  function assertSource(source: string) {
+    if (isPathInside(source, privateRoot) || isPathInside(privateRoot, source)) {
+      throw new Error("Plugin copy source overlaps candidate state");
+    }
+  }
+  async function scan(directory: string): Promise<void> {
+    assertSource(directory);
+    if (scanned.has(directory)) {
+      return;
+    }
+    scanned.add(directory);
+    if (!(await fs.stat(directory)).isDirectory()) {
+      return;
+    }
+    // Read before link discovery, so custom external stores retain their owner.
+    const modules = await readRuntimeModulesManifest(path.join(directory, ".modules.yaml"));
+    if (typeof modules?.manifest.virtualStoreDir === "string") {
+      const store = await fs.realpath(path.resolve(directory, modules.manifest.virtualStoreDir));
+      stores.add(store);
+      addRoot(store);
+    }
+    for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+      const file = path.join(directory, entry.name);
+      if (isHostEdge(file)) {
+        hosts.add(file);
+        const root = await fs.realpath(file).catch((error: unknown) => {
+          if (hasNodeErrorCode(error, "ENOENT")) {
+            return undefined;
+          }
+          throw error;
+        });
+        if (root) {
+          hostRoots.add(root);
+        }
+      } else if (entry.isDirectory()) {
+        await scan(file);
+      } else if (entry.isSymbolicLink()) {
+        const target = path.resolve(directory, await fs.readlink(file));
+        const real = await fs.realpath(file).catch((error: unknown) => {
+          if (hasNodeErrorCode(error, "ENOENT") || hasNodeErrorCode(error, "ELOOP")) {
+            return target;
+          }
+          throw error;
+        });
+        edges.set(file, { target, real });
+      }
+    }
+  }
+  // A locator can itself name a package inside a pnpm store or hoisted tree.
+  for (const source of params.roots.keys()) {
+    if (source.split(path.sep).includes("node_modules")) {
+      addRoot(await dependencyOwner(source));
+    }
+  }
+  for (;;) {
+    for (const root of roots.keys()) {
+      await scan(root);
+    }
+    let added = false;
+    for (const [file, { real }] of edges) {
+      if (
+        covered(real) ||
+        (isHostLauncher(file) && [...hostRoots].some((root) => isPathInside(root, real)))
+      ) {
+        continue;
+      }
+      // Internal dangling links remain dangling. External missing targets cannot
+      // be materialized without leaving an escape into the serving filesystem.
+      const store = [...stores].find((root) => isPathInside(root, real));
+      const owner =
+        store ??
+        (await dependencyOwner(real).catch((cause: unknown) => {
+          throw new Error(`Cannot privately copy plugin dependency ${file} -> ${real}`, { cause });
+        }));
+      assertSource(owner);
+      addRoot(owner);
+      added = true;
+    }
+    if (!added) {
+      break;
+    }
+  }
+  const copies = [...roots].filter(
+    ([source]) =>
+      ![...roots.keys()].some((other) => other !== source && isPathInside(other, source)),
+  );
+  function projected(file: string): string {
+    const copy = copies.find(([source]) => isPathInside(source, file));
+    if (!copy) {
+      throw new Error("Plugin dependency has no private copy owner");
+    }
+    return path.join(copy[1], path.relative(copy[0], file));
+  }
+  const relocations: RuntimeRelocation[] = copies.map(([sourceRoot, destinationRoot]) => ({
+    sourceRoot,
+    destinationRoot,
+  }));
+  for (const root of hostRoots) {
+    relocations.push({ sourceRoot: root, destinationRoot: candidateRoot });
+  }
+  for (const host of hosts) {
+    relocations.push({ sourceRoot: host, destinationRoot: candidateRoot });
+  }
+  for (const { target, real } of edges.values()) {
+    const host = [...hostRoots].find((root) => isPathInside(root, real));
+    relocations.push({
+      sourceRoot: target,
+      destinationRoot: host ? path.join(candidateRoot, path.relative(host, real)) : projected(real),
+    });
+  }
+  relocations.sort((a, b) => b.sourceRoot.length - a.sourceRoot.length);
+  const hostLinks = new Set([...hosts].map(projected));
+  for (const [source, target] of copies) {
+    const destination = resolvePathViaExistingAncestorSync(target);
+    if (!isPathInside(privateRoot, destination)) {
+      throw new Error("Plugin copy destination escapes candidate state");
+    }
+    for (const [other] of copies) {
+      if (isPathInside(other, destination) || isPathInside(destination, other)) {
+        throw new Error("Plugin copy source overlaps its destination");
+      }
+    }
+    await fs.cp(source, target, {
+      recursive: true,
+      verbatimSymlinks: true,
+      filter: (file) => !isHostEdge(file),
+    });
+  }
+  for (const [source, target] of copies) {
+    if ((await fs.stat(target)).isDirectory()) {
+      await relocateRuntimeTree(target, source, target, relocations);
+    }
+  }
+  async function verify(directory: string): Promise<void> {
+    if (!(await fs.stat(directory)).isDirectory()) {
+      return;
+    }
+    for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+      const file = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await verify(file);
+      } else if (entry.isSymbolicLink()) {
+        const target = path.resolve(directory, await fs.readlink(file));
+        if (
+          !isPathInside(privateRoot, target) &&
+          !(isHostLauncher(file) && isPathInside(candidateRoot, target))
+        ) {
+          throw new Error("Copied plugin symlink escapes candidate state");
+        }
+      }
+    }
+  }
+  for (const [, target] of copies) {
+    await verify(target);
+  }
+  return { copies, hostLinks };
+}

--- a/src/infra/update-candidate-plugins.ts
+++ b/src/infra/update-candidate-plugins.ts
@@ -16,6 +16,7 @@ import {
 } from "./kysely-sync.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { hasNodeErrorCode, isPathInside } from "./path-guards.js";
+import { copyUpdateCandidatePluginTrees } from "./update-candidate-plugin-tree.js";
 import { resolveUpdateCandidatePluginPath } from "./update-candidate-state.js";
 
 async function resolvePluginFilePackageRoot(file: string): Promise<string> {
@@ -146,28 +147,12 @@ export async function projectUpdateCandidatePlugins(params: {
       roots.set(owner, project(managed || file ? owner : source));
     }
   }
-  const copies = [...roots].filter(
-    ([source]) =>
-      ![...roots.keys()].some((other) => other !== source && isPathInside(other, source)),
-  );
-  const hostLinks = new Set<string>();
-  for (const [source, target] of copies) {
-    await fs.cp(source, target, {
-      recursive: true,
-      dereference: true,
-      filter: (entry, destination) => {
-        if (
-          path.basename(entry) === "openclaw" &&
-          path.basename(path.dirname(entry)) === "node_modules"
-        ) {
-          // Candidate code is an immutable host edge, not a dependency tree to copy.
-          hostLinks.add(destination);
-          return false;
-        }
-        return true;
-      },
-    });
-  }
+  const { copies, hostLinks } = await copyUpdateCandidatePluginTrees({
+    roots,
+    project,
+    targetStateDir: params.targetStateDir,
+    candidateRoot: params.candidateRoot,
+  });
   for (const { source, real, file } of locators) {
     const copy = copies.find(([directory]) => isPathInside(directory, real));
     if (!copy) {

--- a/src/infra/update-candidate-plugins.ts
+++ b/src/infra/update-candidate-plugins.ts
@@ -1,0 +1,236 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { parsePluginInstallRecordMap } from "../config/plugin-install-record-map.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { INSTALLED_PLUGIN_INDEX_STATE_KEY } from "../plugins/installed-plugin-index-row.js";
+import type { ConfigMachineStateDatabase } from "../state/config-machine-state.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
+import { sameFileIdentity } from "./fs-safe-advanced.js";
+import { resolveUserPath } from "./home-dir.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "./kysely-sync.js";
+import { openNodeSqliteDatabase } from "./node-sqlite.js";
+import { hasNodeErrorCode, isPathInside } from "./path-guards.js";
+import { resolveUpdateCandidatePluginPath } from "./update-candidate-state.js";
+
+async function resolvePluginFilePackageRoot(file: string): Promise<string> {
+  const directory = path.dirname(file);
+  for (let current = directory; ; current = path.dirname(current)) {
+    const manifestExists = await fs.access(path.join(current, "package.json")).then(
+      () => true,
+      (error: unknown) => {
+        if (hasNodeErrorCode(error, "ENOENT")) {
+          return false;
+        }
+        throw error;
+      },
+    );
+    if (manifestExists) {
+      return current;
+    }
+    if (path.dirname(current) === current) {
+      return directory;
+    }
+  }
+}
+
+/** Materialize plugin-owned files before the candidate can repair its private generation. */
+export async function projectUpdateCandidatePlugins(params: {
+  config: OpenClawConfig;
+  stateDir: string;
+  targetStateDir: string;
+  candidateRoot: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<Record<string, string>> {
+  const sourceRoot = path.resolve(params.stateDir);
+  const shared = path.join(params.targetStateDir, "state", "openclaw.sqlite");
+  let value: Record<string, unknown> | undefined;
+  let records: Record<string, PluginInstallRecord> = params.config.plugins?.installs ?? {};
+  if (
+    await fs.stat(shared).then(
+      () => true,
+      (error: unknown) => {
+        if (hasNodeErrorCode(error, "ENOENT")) {
+          return false;
+        }
+        throw error;
+      },
+    )
+  ) {
+    const db = openNodeSqliteDatabase(shared, { readOnly: true });
+    try {
+      if (tableExists(db, "config_machine_state")) {
+        const row = executeSqliteQueryTakeFirstSync(
+          db,
+          getNodeSqliteKysely<ConfigMachineStateDatabase>(db)
+            .selectFrom("config_machine_state")
+            .select("value_json")
+            .where("state_key", "=", INSTALLED_PLUGIN_INDEX_STATE_KEY),
+        );
+        if (row) {
+          const parsed: unknown = JSON.parse(row.value_json);
+          if (!isRecord(parsed) || !isRecord(parsed.index)) {
+            throw new Error("Invalid copied plugin index");
+          }
+          const installed = parsePluginInstallRecordMap(parsed.index.installRecords);
+          if (!installed) {
+            throw new Error("Invalid copied plugin install records");
+          }
+          value = parsed;
+          records = installed;
+        }
+      }
+    } finally {
+      db.close();
+    }
+  }
+  const resolve = (locator: string) => resolveUserPath(locator, params.env);
+  const canonicalStateRoot = await fs.realpath(sourceRoot).catch((error: unknown) => {
+    if (hasNodeErrorCode(error, "ENOENT")) {
+      return sourceRoot;
+    }
+    throw error;
+  });
+  const project = (source: string) =>
+    resolveUpdateCandidatePluginPath(canonicalStateRoot, params.targetStateDir, source);
+  const locators: Array<{ source: string; real: string; file: boolean }> = [];
+  const roots = new Map<string, string>();
+  const npmProjects = path.join(canonicalStateRoot, "npm", "projects");
+  const npmModules = path.join(canonicalStateRoot, "npm", "node_modules");
+  const allRecords = Object.values(records).concat(
+    Object.values(params.config.plugins?.installs ?? {}),
+  );
+  const sources = new Set(
+    allRecords
+      .flatMap((record) => [
+        record.installPath,
+        record.source === "path" ? record.sourcePath : undefined,
+      ])
+      .filter((locator): locator is string => typeof locator === "string" && locator.length > 0)
+      .map(resolve),
+  );
+  for (const source of params.config.plugins?.load?.paths ?? []) {
+    sources.add(resolve(source));
+  }
+  const pluginPaths: Record<string, string> = {};
+  for (const source of sources) {
+    const stat = await fs.stat(source).catch((error: unknown) => {
+      if (hasNodeErrorCode(error, "ENOENT")) {
+        return undefined;
+      }
+      throw error;
+    });
+    if (!stat) {
+      // Keep a missing locator private and missing; candidate validation owns the failure.
+      pluginPaths[source] = project(source);
+      continue;
+    }
+    const real = await fs.realpath(source);
+    const file = stat.isFile();
+    locators.push({ source, real, file });
+    const managed = isPathInside(npmProjects, real) || isPathInside(npmModules, real);
+    // Copy the whole managed project so hoisted dependencies remain available.
+    const owner = isPathInside(npmProjects, real)
+      ? path.join(npmProjects, path.relative(npmProjects, real).split(path.sep)[0]!)
+      : isPathInside(npmModules, real)
+        ? npmModules
+        : file
+          ? await resolvePluginFilePackageRoot(real)
+          : real;
+    if (!roots.has(owner)) {
+      roots.set(owner, project(managed || file ? owner : source));
+    }
+  }
+  const copies = [...roots].filter(
+    ([source]) =>
+      ![...roots.keys()].some((other) => other !== source && isPathInside(other, source)),
+  );
+  const hostLinks = new Set<string>();
+  for (const [source, target] of copies) {
+    await fs.cp(source, target, {
+      recursive: true,
+      dereference: true,
+      filter: (entry, destination) => {
+        if (
+          path.basename(entry) === "openclaw" &&
+          path.basename(path.dirname(entry)) === "node_modules"
+        ) {
+          // Candidate code is an immutable host edge, not a dependency tree to copy.
+          hostLinks.add(destination);
+          return false;
+        }
+        return true;
+      },
+    });
+  }
+  for (const { source, real, file } of locators) {
+    const copy = copies.find(([directory]) => isPathInside(directory, real));
+    if (!copy) {
+      throw new Error("Plugin payload has no private copy root");
+    }
+    const target = path.join(copy[1], path.relative(copy[0], real));
+    const alias = file && path.basename(source) !== path.basename(real) ? project(source) : target;
+    if (alias !== target) {
+      // Preserve the entry filename/ID, while Node resolves relative imports beside its copied target.
+      const [existing, targetIdentity] = await Promise.all([
+        fs.stat(alias, { bigint: true }).catch((error: unknown) => {
+          if (hasNodeErrorCode(error, "ENOENT")) {
+            return undefined;
+          }
+          throw error;
+        }),
+        fs.stat(target, { bigint: true }),
+      ]);
+      // A case-equivalent name can already be this file; unlinking it would destroy the target.
+      if (!existing || !sameFileIdentity(existing, targetIdentity)) {
+        await fs.mkdir(path.dirname(alias), { recursive: true });
+        await fs.rm(alias, { force: true });
+        await fs.symlink(target, alias, "file");
+      }
+    }
+    pluginPaths[source] = alias;
+  }
+  for (const link of hostLinks) {
+    const { linkOpenClawPeerDependencies } = await import("../plugins/plugin-peer-link.js");
+    const result = await linkOpenClawPeerDependencies({
+      installedDir: path.dirname(path.dirname(link)),
+      hostRoot: params.candidateRoot,
+      peerDependencies: { openclaw: "*" },
+      logger: {},
+    });
+    if (result.skipped) {
+      throw new Error("Could not bind copied plugin to candidate host");
+    }
+  }
+  if (value) {
+    const projected = structuredClone(records);
+    for (const record of Object.values(projected)) {
+      if (record.source === "path" && record.sourcePath) {
+        record.sourcePath = pluginPaths[resolve(record.sourcePath)];
+      }
+      if (record.installPath) {
+        record.installPath = pluginPaths[resolve(record.installPath)];
+      }
+    }
+    // Only install records are canonical; metadata naming source paths must be rebuilt.
+    const next = { ...value, index: { installRecords: projected } };
+    const db = openNodeSqliteDatabase(shared);
+    try {
+      executeSqliteQuerySync(
+        db,
+        getNodeSqliteKysely<ConfigMachineStateDatabase>(db)
+          .updateTable("config_machine_state")
+          .set({ value_json: JSON.stringify(next) })
+          .where("state_key", "=", INSTALLED_PLUGIN_INDEX_STATE_KEY),
+      );
+    } finally {
+      db.close();
+    }
+  }
+  return pluginPaths;
+}

--- a/src/infra/update-candidate-rehearsal.ts
+++ b/src/infra/update-candidate-rehearsal.ts
@@ -15,7 +15,7 @@ import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-wor
 import { SUPERVISOR_HINT_ENV_VARS } from "./supervisor-markers.js";
 import {
   resolveUpdateCandidateStatePath,
-  UpdateStateSchemaVersionsSchema,
+  UpdateCandidateStateSnapshotSchema,
 } from "./update-candidate-state.js";
 import {
   CONTROL_PLANE_UPDATE_SENTINEL_META_ENV,
@@ -50,8 +50,27 @@ function isolatedConfig(
   stateDir: string,
   port: number,
   sourceEnv: NodeJS.ProcessEnv,
+  pluginPaths: Record<string, string>,
 ): OpenClawConfig {
   const copied = structuredClone(config);
+  const projectPluginPath = (value: string) => {
+    const projected = pluginPaths[resolveUserPath(value, sourceEnv)];
+    if (!projected) {
+      throw new Error("Plugin locator was not included in the candidate snapshot");
+    }
+    return projected;
+  };
+  for (const record of Object.values(copied.plugins?.installs ?? {})) {
+    if (record.source === "path" && record.sourcePath) {
+      record.sourcePath = projectPluginPath(record.sourcePath);
+    }
+    if (record.installPath) {
+      record.installPath = projectPluginPath(record.installPath);
+    }
+  }
+  if (copied.plugins?.load?.paths) {
+    copied.plugins.load.paths = copied.plugins.load.paths.map(projectPluginPath);
+  }
   const workspace = path.join(stateDir, "workspace");
   const entries =
     copied.agents?.entries ??
@@ -105,6 +124,7 @@ function isolatedConfig(
 export async function prepareUpdateCandidateRehearsal(params: {
   config: OpenClawConfig;
   sourceConfigHash?: string | null;
+  candidateRoot: string;
   stateDir: string;
   env?: NodeJS.ProcessEnv;
   nodeRunner?: string;
@@ -207,6 +227,7 @@ export async function prepareUpdateCandidateRehearsal(params: {
           stateDir: params.stateDir,
           config: params.config,
           targetStateDir: tempDir,
+          candidateRoot: params.candidateRoot,
           env: {
             HOME: sourceEnv.HOME,
             OPENCLAW_HOME: sourceEnv.OPENCLAW_HOME,
@@ -227,14 +248,23 @@ export async function prepareUpdateCandidateRehearsal(params: {
         `Candidate state snapshot failed (${snapshot.termination}): ${redactSupportString(snapshot.stderr.toString("utf8"), { env: sourceEnv, stateDir: params.stateDir }, { maxLength: 20_000 })}`,
       );
     }
-    UpdateStateSchemaVersionsSchema.parse(JSON.parse(snapshot.stdout.toString("utf8")));
+    const { pluginPaths } = UpdateCandidateStateSnapshotSchema.parse(
+      JSON.parse(snapshot.stdout.toString("utf8")),
+    );
     const port = await tryListenOnPort({
       port: 0,
       host: "127.0.0.1",
       signal: AbortSignal.timeout(remaining()),
     });
     const serialized = JSON.stringify(
-      isolatedConfig(params.config, path.resolve(params.stateDir), tempDir, port, sourceEnv),
+      isolatedConfig(
+        params.config,
+        path.resolve(params.stateDir),
+        tempDir,
+        port,
+        sourceEnv,
+        pluginPaths,
+      ),
     );
     const baseline: Record<string, unknown> = JSON.parse(serialized);
     await fs.writeFile(configPath, serialized, { mode: 0o600 });

--- a/src/infra/update-candidate-state.test.ts
+++ b/src/infra/update-candidate-state.test.ts
@@ -619,3 +619,132 @@ it("preserves an existing copied file behind a case-equivalent entry name", asyn
     await rehearsal.cleanup();
   }
 });
+
+it.each(["relative", "absolute", "external-store", "cycle"] as const)(
+  "preserves pnpm transitive dependency topology in a private rehearsal (%s)",
+  async (layout) => {
+    const plugin = path.join(root, "local-plugin");
+    const modules = path.join(plugin, "node_modules");
+    const store =
+      layout === "external-store" ? path.join(root, "virtual-store") : path.join(modules, ".pnpm");
+    const foo = path.join(store, "foo@1.0.0", "node_modules", "foo");
+    const bar = path.join(store, "bar@1.0.0", "node_modules", "bar");
+    for (const [directory, name, code] of [
+      [plugin, "plugin", 'import value from "foo"; export default value;'],
+      [foo, "foo", 'import value from "bar"; export default `foo:${value}`;'],
+      [bar, "bar", 'export default "bar";'],
+    ]) {
+      await fs.mkdir(directory!, { recursive: true });
+      await fs.writeFile(
+        path.join(directory!, "package.json"),
+        JSON.stringify({ name, type: "module", exports: "./index.js" }),
+      );
+      await fs.writeFile(path.join(directory!, "index.js"), code!);
+    }
+    await fs.mkdir(modules, { recursive: true });
+    if (layout === "external-store") {
+      await fs.writeFile(
+        path.join(modules, ".modules.yaml"),
+        `virtualStoreDir: ${JSON.stringify(store)}\n`,
+      );
+    }
+    const links = [
+      [path.join(modules, "foo"), foo],
+      [path.join(path.dirname(foo), "bar"), bar],
+    ] as const;
+    for (const [link, target] of links) {
+      await fs.symlink(
+        layout === "absolute" || process.platform === "win32"
+          ? target
+          : path.relative(path.dirname(link), target),
+        link,
+        "junction",
+      );
+    }
+    if (layout === "cycle") {
+      await fs.symlink(foo, path.join(path.dirname(bar), "foo"), "junction");
+    }
+    await fs.writeFile(
+      path.join(foo, "cli.js"),
+      'import value from "./index.js"; console.log(value);',
+    );
+    await fs.mkdir(path.join(modules, ".bin"));
+    const launcher = path.join(modules, ".bin", "foo");
+    await fs.writeFile(
+      launcher,
+      `#!/bin/sh\nbasedir=$(dirname "$0")\nexec "${process.execPath}" "$basedir/../foo/cli.js"\n`,
+    );
+    const originalLinks = await Promise.all(links.map(([link]) => fs.readlink(link)));
+    const readPlugin = async (directory: string) => {
+      const result = await runCommandBuffered(
+        [
+          process.execPath,
+          "--input-type=module",
+          "-e",
+          `console.log((await import(${JSON.stringify(pathToFileURL(path.join(directory, "index.js")).href)})).default)`,
+        ],
+        { timeoutMs: 10_000 },
+      );
+      expect(result.code, result.stderr.toString()).toBe(0);
+      return result.stdout.toString().trim();
+    };
+    expect(await readPlugin(plugin)).toBe("foo:bar");
+    const rehearsal = await prepareUpdateCandidateRehearsal({
+      config: { plugins: { load: { paths: [plugin] } } },
+      stateDir: path.join(root, "source-state"),
+      candidateRoot: root,
+    });
+    try {
+      const config: OpenClawConfig = JSON.parse(await fs.readFile(rehearsal.configPath, "utf8"));
+      const copiedPlugin = config.plugins!.load!.paths![0]!;
+      expect(await readPlugin(copiedPlugin)).toBe("foo:bar");
+      if (process.platform !== "win32") {
+        const result = await runCommandBuffered(
+          ["/bin/sh", path.join(copiedPlugin, "node_modules", ".bin", "foo")],
+          { timeoutMs: 10_000 },
+        );
+        expect(result.code, result.stderr.toString()).toBe(0);
+        expect(result.stdout.toString().trim()).toBe("foo:bar");
+      }
+      const copiedFoo = await fs.realpath(path.join(copiedPlugin, "node_modules", "foo"));
+      const copiedBar = await fs.realpath(path.join(path.dirname(copiedFoo), "bar"));
+      expect(copiedBar.startsWith(rehearsal.stateDir + path.sep)).toBe(true);
+      await fs.writeFile(path.join(copiedBar, "index.js"), 'export default "changed";');
+      expect(await readPlugin(copiedPlugin)).toBe("foo:changed");
+      expect(await readPlugin(plugin)).toBe("foo:bar");
+      expect(await Promise.all(links.map(([link]) => fs.readlink(link)))).toEqual(originalLinks);
+    } finally {
+      await rehearsal.cleanup();
+    }
+  },
+);
+
+it.skipIf(process.platform === "win32")(
+  "copies an external file link without traversing unrelated siblings",
+  async () => {
+    const plugin = path.join(root, "plugin");
+    const assets = path.join(root, "assets");
+    await fs.mkdir(plugin);
+    await fs.mkdir(assets);
+    await fs.writeFile(path.join(plugin, "package.json"), '{"name":"plugin"}');
+    const source = path.join(assets, "config.txt");
+    await fs.writeFile(source, "preserved");
+    await fs.symlink(path.join(root, "missing-unrelated-target"), path.join(assets, "unrelated"));
+    await fs.symlink(source, path.join(plugin, "config.txt"));
+    const rehearsal = await prepareUpdateCandidateRehearsal({
+      config: { plugins: { load: { paths: [plugin] } } },
+      stateDir: path.join(root, "source-state"),
+      candidateRoot: root,
+    });
+    try {
+      const config: OpenClawConfig = JSON.parse(await fs.readFile(rehearsal.configPath, "utf8"));
+      const copied = path.join(config.plugins!.load!.paths![0]!, "config.txt");
+      expect(await fs.readFile(copied, "utf8")).toBe("preserved");
+      await fs.writeFile(copied, "private");
+      expect(await fs.readFile(source, "utf8")).toBe("preserved");
+      expect(await fs.readlink(path.join(plugin, "config.txt"))).toBe(source);
+    } finally {
+      await rehearsal.cleanup();
+    }
+  },
+);

--- a/src/infra/update-candidate-state.test.ts
+++ b/src/infra/update-candidate-state.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runCommandBuffered } from "../process/exec.js";
 import { getFileLockProcessStartTime } from "../shared/pid-alive.js";
 import { withAgentDatabaseMaintenanceLease } from "../state/openclaw-agent-db.js";
@@ -12,13 +13,15 @@ import {
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
+import { hasNodeErrorCode } from "./path-guards.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
+import { prepareUpdateCandidateRehearsal } from "./update-candidate-rehearsal.js";
 import {
   readUpdateStateSchemaVersions,
   type snapshotUpdateCandidateState,
   updateStateSchemaVersionsMatch,
-  UpdateStateSchemaVersionsSchema,
+  UpdateCandidateStateSnapshotSchema,
 } from "./update-candidate-state.js";
 
 let root: string;
@@ -42,7 +45,9 @@ async function createDatabase(file: string, sql = ""): Promise<void> {
   }
 }
 
-async function runSnapshotWorker(input: Parameters<typeof snapshotUpdateCandidateState>[0]) {
+async function runSnapshotWorker(
+  input: Omit<Parameters<typeof snapshotUpdateCandidateState>[0], "candidateRoot">,
+) {
   // Backup/VACUUM cannot be cancelled in-process; use the canary's worker before fixture cleanup.
   const result = await runCommandBuffered(
     [
@@ -52,14 +57,19 @@ async function runSnapshotWorker(input: Parameters<typeof snapshotUpdateCandidat
       ),
     ],
     {
-      input: JSON.stringify({ ...input, mode: "snapshot" }),
+      input: JSON.stringify({
+        ...input,
+        candidateRoot: path.join(root, "candidate-host"),
+        mode: "snapshot",
+      }),
       timeoutMs: 30_000,
       killGraceMs: 500,
       maxOutputBytes: { stdout: 1024 * 1024, stderr: 20_000 },
     },
   );
   expect(result.code, result.stderr.toString("utf8")).toBe(0);
-  return UpdateStateSchemaVersionsSchema.parse(JSON.parse(result.stdout.toString("utf8")));
+  return UpdateCandidateStateSnapshotSchema.parse(JSON.parse(result.stdout.toString("utf8")))
+    .versions;
 }
 
 it.each(["DELETE", "WAL"])(
@@ -336,3 +346,276 @@ it.runIf(process.platform !== "win32")(
     }
   },
 );
+
+it.each([
+  { source: "npm", relative: "extensions/demo" },
+  { source: "clawhub", relative: "extensions/demo" },
+  { source: "npm", relative: "npm/projects/demo/node_modules/demo" },
+  { source: "npm", relative: "npm/node_modules/demo" },
+])(
+  "projects $source plugin at $relative without touching live files or host links",
+  async ({ source: installSource, relative }) => {
+    const source = path.join(root, "source");
+    const target = path.join(root, "copy");
+    const packageDir = path.join(source, relative);
+    const liveHost = path.join(root, "live-host");
+    const candidateHost = path.join(root, "candidate-host");
+    const dependency = path.join(root, "external-dependency");
+    const modulesDir = relative.includes("npm/")
+      ? path.dirname(packageDir)
+      : path.join(packageDir, "node_modules");
+    await fs.mkdir(path.join(packageDir, "node_modules"), { recursive: true });
+    for (const [directory, name, value] of [
+      [liveHost, "openclaw", "live"],
+      [candidateHost, "openclaw", "candidate"],
+      [dependency, "dependency", "preserved"],
+    ]) {
+      await fs.mkdir(directory!);
+      await fs.writeFile(
+        path.join(directory!, "package.json"),
+        JSON.stringify({ name, type: "module", exports: "./index.js" }),
+      );
+      await fs.writeFile(
+        path.join(directory!, "index.js"),
+        `export default ${JSON.stringify(value)};`,
+      );
+    }
+    await fs.symlink(dependency, path.join(modulesDir, "dependency"), "junction");
+    await fs.writeFile(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "demo",
+        version: "1.0.0",
+        type: "module",
+        peerDependencies: { openclaw: "*" },
+      }),
+    );
+    await fs.writeFile(
+      path.join(packageDir, "index.js"),
+      'import host from "openclaw"; import dependency from "dependency"; export default {host, dependency};',
+    );
+    await fs.symlink(liveHost, path.join(packageDir, "node_modules", "openclaw"), "junction");
+    const registry = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: source } }).db;
+    registry
+      .prepare(
+        "INSERT INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES (?, ?, ?)",
+      )
+      .run(
+        "plugins.installedIndex",
+        JSON.stringify({
+          revision: 1,
+          index: {
+            plugins: [{ source: packageDir }],
+            installRecords: {
+              demo: { source: installSource, installPath: packageDir, version: "1.0.0" },
+            },
+          },
+        }),
+        1,
+      );
+    const shared = path.join(source, "state", "openclaw.sqlite");
+    closeOpenClawStateDatabaseByPath(shared);
+    const before = await fs.readFile(shared);
+    await runSnapshotWorker({ stateDir: source, targetStateDir: target, config: {} });
+    expect(await fs.readFile(shared)).toEqual(before);
+    expect(await fs.realpath(path.join(packageDir, "node_modules", "openclaw"))).toBe(liveHost);
+    const copied = openNodeSqliteDatabase(path.join(target, "state", "openclaw.sqlite"));
+    try {
+      const row = copied
+        .prepare(
+          "SELECT value_json FROM config_machine_state WHERE state_key = 'plugins.installedIndex'",
+        )
+        .get() as { value_json: string };
+      const record = JSON.parse(row.value_json).index.installRecords.demo;
+      expect(record.installPath).toBe(path.join(target, relative));
+      expect(await fs.realpath(path.join(record.installPath, "node_modules", "openclaw"))).toBe(
+        candidateHost,
+      );
+      const result = await runCommandBuffered(
+        [
+          process.execPath,
+          "--input-type=module",
+          "-e",
+          `console.log(JSON.stringify((await import(${JSON.stringify(pathToFileURL(path.join(record.installPath, "index.js")).href)})).default))`,
+        ],
+        { timeoutMs: 10_000 },
+      );
+      expect(result.code, result.stderr.toString()).toBe(0);
+      expect(JSON.parse(result.stdout.toString())).toEqual({
+        host: "candidate",
+        dependency: "preserved",
+      });
+      const copiedDependency = path.join(
+        target,
+        path.relative(source, modulesDir),
+        "dependency",
+        "index.js",
+      );
+      await fs.writeFile(copiedDependency, "changed in rehearsal");
+      expect(await fs.readFile(path.join(dependency, "index.js"), "utf8")).toContain("preserved");
+      expect(await fs.readFile(shared)).toEqual(before);
+    } finally {
+      copied.close();
+    }
+  },
+);
+
+it.each([
+  { extension: "js", linked: false },
+  { extension: "ts", linked: false },
+  { extension: "js", linked: true },
+  { extension: "js", linked: false, directoryAlias: true },
+])(
+  "preserves external .$extension entry imports and path identity (linked=$linked, directoryAlias=$directoryAlias)",
+  async ({ extension, linked, directoryAlias = false }) => {
+    const source = path.join(root, "source-state");
+    const external = path.join(root, "external-plugin");
+    const install = path.join(root, "installed-plugin");
+    const sourcePackage = path.join(root, "source-plugin");
+    for (const directory of [external, install, ...(linked ? [] : [sourcePackage])]) {
+      await fs.mkdir(directory);
+    }
+    await fs.writeFile(path.join(external, "package.json"), '{"type":"module"}');
+    await fs.writeFile(path.join(external, "adjacent.js"), 'export default "adjacent survived";');
+    const dependency = path.join(external, "node_modules", "dependency");
+    await fs.mkdir(dependency, { recursive: true });
+    await fs.writeFile(
+      path.join(dependency, "package.json"),
+      '{"type":"module","exports":"./index.js"}',
+    );
+    await fs.writeFile(path.join(dependency, "index.js"), 'export default "dependency survived";');
+    await fs.mkdir(path.join(external, "dist"));
+    const realEntry = path.join(external, "dist", `plugin.${extension}`);
+    let entry = realEntry;
+    await fs.writeFile(
+      realEntry,
+      'import adjacent from "../adjacent.js"; import dependency from "dependency"; export default `${adjacent}:${dependency}`;',
+    );
+    await fs.writeFile(path.join(install, "marker"), "installed payload");
+    if (linked) {
+      await fs.symlink(install, sourcePackage, "junction");
+      const aliasDirectory = path.join(root, "external-alias");
+      if (process.platform === "win32") {
+        await fs.symlink(path.dirname(realEntry), aliasDirectory, "junction");
+        entry = path.join(aliasDirectory, path.basename(realEntry));
+      } else {
+        await fs.mkdir(aliasDirectory);
+        entry = path.join(aliasDirectory, `public-name.${extension}`);
+        await fs.symlink(realEntry, entry, "file");
+      }
+    } else {
+      await fs.writeFile(path.join(sourcePackage, "marker"), "source payload");
+    }
+    if (directoryAlias) {
+      const aliasDirectory = path.join(root, "directory-alias");
+      await fs.symlink(path.dirname(realEntry), aliasDirectory, "junction");
+      entry = path.join(aliasDirectory, path.basename(realEntry));
+    }
+    const registry = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: source } }).db;
+    registry
+      .prepare(
+        "INSERT INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES (?, ?, ?)",
+      )
+      .run(
+        "plugins.installedIndex",
+        JSON.stringify({ revision: 1, index: { installRecords: {} } }),
+        1,
+      );
+    closeOpenClawStateDatabaseByPath(path.join(source, "state", "openclaw.sqlite"));
+    const config: OpenClawConfig = {
+      plugins: {
+        load: { paths: [entry] },
+        installs: { demo: { source: "path", installPath: install, sourcePath: sourcePackage } },
+      },
+    };
+    const rehearsal = await prepareUpdateCandidateRehearsal({
+      config,
+      stateDir: source,
+      candidateRoot: root,
+    });
+    try {
+      const copied: OpenClawConfig = JSON.parse(await fs.readFile(rehearsal.configPath, "utf8"));
+      const copiedEntry = copied.plugins!.load!.paths![0]!;
+      expect(path.basename(copiedEntry)).toBe(path.basename(entry));
+      if (directoryAlias) {
+        expect((await fs.lstat(copiedEntry)).isSymbolicLink()).toBe(false);
+      }
+      expect(copiedEntry.startsWith(rehearsal.stateDir + path.sep)).toBe(true);
+      const result = await runCommandBuffered(
+        [
+          process.execPath,
+          "--input-type=module",
+          "-e",
+          `console.log((await import(${JSON.stringify(pathToFileURL(copiedEntry).href)})).default)`,
+        ],
+        { timeoutMs: 10_000 },
+      );
+      expect(result.code, result.stderr.toString()).toBe(0);
+      expect(result.stdout.toString().trim()).toBe("adjacent survived:dependency survived");
+      const record = copied.plugins!.installs!.demo!;
+      expect(await fs.readFile(path.join(record.installPath!, "marker"), "utf8")).toBe(
+        "installed payload",
+      );
+      expect(await fs.readFile(path.join(record.sourcePath!, "marker"), "utf8")).toBe(
+        linked ? "installed payload" : "source payload",
+      );
+      expect(
+        (await fs.realpath(record.installPath!)) === (await fs.realpath(record.sourcePath!)),
+      ).toBe(linked);
+      await fs.writeFile(path.join(record.sourcePath!, "marker"), "private change");
+      expect(await fs.readFile(path.join(sourcePackage, "marker"), "utf8")).toBe(
+        linked ? "installed payload" : "source payload",
+      );
+      expect(config.plugins!.load!.paths).toEqual([entry]);
+      expect(config.plugins!.installs!.demo!.sourcePath).toBe(sourcePackage);
+      expect(await rehearsal.changedConfigKeys()).toEqual([]);
+    } finally {
+      await rehearsal.cleanup();
+    }
+  },
+);
+
+it("preserves an existing copied file behind a case-equivalent entry name", async (context) => {
+  const plugin = path.join(root, "case-plugin");
+  await fs.mkdir(plugin);
+  const lower = path.join(plugin, "entry.js");
+  const upper = path.join(plugin, "ENTRY.js");
+  const payload = 'export default "case alias survived";';
+  await fs.writeFile(path.join(plugin, "package.json"), '{"type":"module"}');
+  await fs.writeFile(lower, payload);
+  const upperReal = await fs.realpath(upper).catch((error: unknown) => {
+    if (hasNodeErrorCode(error, "ENOENT")) {
+      return undefined;
+    }
+    throw error;
+  });
+  if (upperReal !== (await fs.realpath(lower))) {
+    context.skip("Requires a case-insensitive fixture volume with canonical filename casing");
+  }
+  const rehearsal = await prepareUpdateCandidateRehearsal({
+    config: { plugins: { load: { paths: [upper] } } },
+    stateDir: path.join(root, "source-state"),
+    candidateRoot: root,
+  });
+  try {
+    const copied: OpenClawConfig = JSON.parse(await fs.readFile(rehearsal.configPath, "utf8"));
+    const entry = copied.plugins!.load!.paths![0]!;
+    expect(path.basename(entry)).toBe("ENTRY.js");
+    const result = await runCommandBuffered(
+      [
+        process.execPath,
+        "--input-type=module",
+        "-e",
+        `console.log((await import(${JSON.stringify(pathToFileURL(entry).href)})).default)`,
+      ],
+      { timeoutMs: 10_000 },
+    );
+    expect(result.code, result.stderr.toString()).toBe(0);
+    expect(result.stdout.toString().trim()).toBe("case alias survived");
+    expect((await fs.lstat(entry)).isFile()).toBe(true);
+    expect(await fs.readFile(lower, "utf8")).toBe(payload);
+    expect(await fs.readFile(upper, "utf8")).toBe(payload);
+  } finally {
+    await rehearsal.cleanup();
+  }
+});

--- a/src/infra/update-candidate-state.ts
+++ b/src/infra/update-candidate-state.ts
@@ -20,7 +20,7 @@ import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-wor
 import { prepareSqliteReadOnlyLocationSyncInProcess } from "./sqlite-readonly-location.js";
 import { readSqliteUserVersion } from "./sqlite-user-version.js";
 
-export const UpdateStateSchemaVersionsSchema = z.array(
+const UpdateStateSchemaVersionsSchema = z.array(
   z.object({
     path: z.string(),
     userVersion: z.number().nullable(),
@@ -28,6 +28,10 @@ export const UpdateStateSchemaVersionsSchema = z.array(
   }),
 );
 export type UpdateStateSchemaVersion = z.infer<typeof UpdateStateSchemaVersionsSchema>[number];
+export const UpdateCandidateStateSnapshotSchema = z.object({
+  versions: UpdateStateSchemaVersionsSchema,
+  pluginPaths: z.record(z.string(), z.string()),
+});
 type StateInput = { stateDir: string; config: OpenClawConfig; env?: NodeJS.ProcessEnv };
 type CandidateStateDatabase = Pick<
   DB,
@@ -249,10 +253,29 @@ export function resolveUpdateCandidateStatePath(
   return path.join(targetRoot, relative);
 }
 
+/** Plugin locators cannot overwrite the separately snapshotted state databases. */
+export function resolveUpdateCandidatePluginPath(
+  sourceRoot: string,
+  targetRoot: string,
+  source: string,
+): string {
+  const managed = ["npm", "extensions"].some((directory) =>
+    isPathInside(path.join(sourceRoot, directory), source),
+  );
+  return managed
+    ? resolveUpdateCandidateStatePath(sourceRoot, targetRoot, source)
+    : path.join(
+        targetRoot,
+        "candidate-plugins",
+        sha256Hex(path.parse(source).root),
+        path.relative(path.parse(source).root, source),
+      );
+}
+
 /** Keep snapshot dependencies out of schema inspection; rebind registry paths to private copies. */
 export async function snapshotUpdateCandidateState(
-  input: StateInput & { targetStateDir: string },
-): Promise<UpdateStateSchemaVersion[]> {
+  input: StateInput & { targetStateDir: string; candidateRoot: string },
+): Promise<z.infer<typeof UpdateCandidateStateSnapshotSchema>> {
   const { createVerifiedSqliteSnapshot } = await import("./sqlite-snapshot.js");
   const sourceRoot = path.resolve(input.stateDir);
   const shared = path.join(sourceRoot, "state", "openclaw.sqlite");
@@ -329,5 +352,7 @@ export async function snapshotUpdateCandidateState(
       ...(contentVersion === undefined ? {} : { contentVersion }),
     });
   }
-  return versions;
+  const { projectUpdateCandidatePlugins } = await import("./update-candidate-plugins.js");
+  const pluginPaths = await projectUpdateCandidatePlugins(input);
+  return { versions, pluginPaths };
 }


### PR DESCRIPTION
Related: #138839

## What Problem This Solves

Fixes an issue where users updating OpenClaw with installed plugins could fail candidate validation before activation because the staged host could not load those plugins. Flattening pnpm symlinks also broke transitive dependency resolution. On case-insensitive volumes, a configured filename with different casing could invalidate its copied entry.

## Why This Change Was Made

Prepare one disposable plugin generation alongside the SQLite snapshot, copying payloads with their dependency/package roots and carrying one locator map into copied install records and configuration. Preserve path aliases and public filenames, retain an existing same-identity file, and bind only copied host links to the staged candidate; serving files, links and database bytes remain unchanged. Preserve pnpm store topology with the existing runtime relocation owner. Complete stores or node_modules owners may include unused dependencies; ordinary external file links remain exact file copies.

## User Impact

Installed plugins can be validated against the candidate while the previous Gateway keeps serving. Candidate repairs operate on private copies, and post-swap schema inspection retains its existing response contract.

## Evidence

- 45 focused tests passed on the main forward-port: 28 projection/canary, 8 file-identity and 9 worker URL/argv cases, including real Node imports, dependency resolution, source immutability, aliases, case-insensitive filename preservation and worker launch from another directory.
- CI exposed an outdated snapshot-only CLI fixture. Updating that one producer line restored all 9 staged-repair cases; the complete 413-test update-cli owner suite then passed with assertions unchanged. Version inspection remains separately mocked with its array contract.
- Full changed checks and independent P2 reviews passed for the source repair and fixture correction. Main's newer absolute-tsx preload behavior is preserved.
- The original projection repair in rebuilt release candidate (`d9287bbc620390781584ce75d82572f6c37dcfc7`) passed migration rehearsal, Doctor lint, config validation, plugin resolution, migration-continuation checks and the packaged gateway canary. The canary exited successfully in 26.8 seconds.
- The topology follow-up passed 37 candidate/native-stage tests, then 38 after resolving the main schema-metadata conflict, including real-worker relative/absolute pnpm links, external stores, dependency cycles, executable launchers, copied transitive mutation isolation, and an external-file sibling-traversal regression. Each new regression failed its defective predecessor.
- Broader unchanged Git-staging fixtures passed 45/49 cases; four failed during Git setup before updater execution. One previously failing case passed unchanged in isolation with the original timeout. This limitation remains recorded rather than widening fixture deadlines.
- Packaged proof above covers the original projection repair; the topology follow-up has source-level proof and still needs rebuilt package qualification. This is not full-release green. Final PR head `8b8b3f368eff2b2a2e71b1d7363368c4b06a32f0` passed [CI run 34143258029](https://github.com/openclaw/openclaw/actions/runs/34143258029), including required `openclaw/ci-gate`, and landed through native review/prepare/merge as `85f79a5c0fada45db33dca7dd22455f19100f471`.
