### PR TITLE
test(telegram): consolidate late progress event fixtures

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -30,99 +30,69 @@ import {
 } from "./bot-message-dispatch.test-harness.js";
 
 describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
-  it("does not restart progress drafts after final answer delivery", async () => {
-    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ dispatcherOptions, replyOptions }) => {
-        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-        await dispatcherOptions.deliver({ text: "Branch is up to date" }, { kind: "final" });
-        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-        return { queuedFinal: true };
-      },
-    );
+  for (const { title, lateEvent, finalPending } of [
+    {
+      title: "does not restart progress drafts after final answer delivery",
+      lateEvent: "tool-start",
+      finalPending: false,
+    },
+    {
+      title: "does not restart progress drafts for command output after final answer delivery",
+      lateEvent: "command-output",
+      finalPending: false,
+    },
+    {
+      title:
+        "does not restart progress drafts for command output while final answer delivery is pending",
+      lateEvent: "command-output",
+      finalPending: true,
+    },
+  ]) {
+    it(title, async () => {
+      const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+        async ({ dispatcherOptions, replyOptions }) => {
+          await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+          const finalDelivery = dispatcherOptions.deliver(
+            { text: "Branch is up to date" },
+            { kind: "final" },
+          );
+          if (!finalPending) {
+            await finalDelivery;
+          }
+          if (lateEvent === "tool-start") {
+            await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+          } else {
+            await replyOptions?.onCommandOutput?.({
+              phase: "end",
+              title: "Exec",
+              name: "exec",
+              status: "failed",
+              exitCode: 1,
+            });
+          }
+          if (finalPending) {
+            await finalDelivery;
+          }
+          return { queuedFinal: true };
+        },
+      );
 
-    await dispatchWithContext({
-      context: createContext(),
-      streamMode: "progress",
-      telegramCfg: {
-        streaming: { mode: "progress", progress: { toolProgress: true, label: "Shelling" } },
-      },
+      await dispatchWithContext({
+        context: createContext(),
+        streamMode: "progress",
+        telegramCfg: {
+          streaming: { mode: "progress", progress: { toolProgress: true, label: "Shelling" } },
+        },
+      });
+
+      expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
+      expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
+        telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
+      );
+      expectDeliveredReply(0, { text: "Branch is up to date" });
     });
-
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
-    );
-    expectDeliveredReply(0, { text: "Branch is up to date" });
-  });
-
-  it("does not restart progress drafts for command output after final answer delivery", async () => {
-    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ dispatcherOptions, replyOptions }) => {
-        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-        await dispatcherOptions.deliver({ text: "Branch is up to date" }, { kind: "final" });
-        await replyOptions?.onCommandOutput?.({
-          phase: "end",
-          title: "Exec",
-          name: "exec",
-          status: "failed",
-          exitCode: 1,
-        });
-        return { queuedFinal: true };
-      },
-    );
-
-    await dispatchWithContext({
-      context: createContext(),
-      streamMode: "progress",
-      telegramCfg: {
-        streaming: { mode: "progress", progress: { toolProgress: true, label: "Shelling" } },
-      },
-    });
-
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
-    );
-    expectDeliveredReply(0, { text: "Branch is up to date" });
-  });
-
-  it("does not restart progress drafts for command output while final answer delivery is pending", async () => {
-    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ dispatcherOptions, replyOptions }) => {
-        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-        const finalDelivery = dispatcherOptions.deliver(
-          { text: "Branch is up to date" },
-          { kind: "final" },
-        );
-        await replyOptions?.onCommandOutput?.({
-          phase: "end",
-          title: "Exec",
-          name: "exec",
-          status: "failed",
-          exitCode: 1,
-        });
-        await finalDelivery;
-        return { queuedFinal: true };
-      },
-    );
-
-    await dispatchWithContext({
-      context: createContext(),
-      streamMode: "progress",
-      telegramCfg: {
-        streaming: { mode: "progress", progress: { toolProgress: true, label: "Shelling" } },
-      },
-    });
-
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
-    );
-    expectDeliveredReply(0, { text: "Branch is up to date" });
-  });
+  }
 
   it("uses the transcript final when progress-mode final text is truncated", async () => {
     setupDraftStreams({ answerMessageId: 2001 });


### PR DESCRIPTION
Related: #122221, #141137

## What Problem This Solves

Restores the Telegram test file's compliance with the existing line limit. The fast-mode progress regression added in #122221 pushed the file to 1,012 counted lines, blocking main-derived CI, including [this failed lint job](https://github.com/openclaw/openclaw/actions/runs/34110351478/job/101705143063).

## Why This Change Was Made

Three late-progress scenarios repeated the same setup and assertions. One case table now supplies their event and final-delivery ordering, with separate named tests for each scenario. The pending-final case still emits command output before awaiting final delivery; the completed-final cases still await delivery first.

The new fast-mode regression remains untouched. No line-limit suppression, new helper file, production seam or deleted assertion is needed.

## User Impact

CI can validate Telegram changes again. Runtime behavior is unchanged; all 37 original test names, execution order and assertions remain.

## Evidence

- Baseline targeted lint reproduced the 1,012-line failure; final canonical lint passes.
- All 37 cases passed before and after. Exact native case-name comparison reports identical order, no missing cases and no added cases.
- Required changed-file gates passed. After the final registration-only adjustment, extension test typechecking, canonical lint and all 37 tests passed again.
- Independent P2 review: no actionable findings.

Test-only change: 60 additions / 90 deletions, 30 net lines removed. No production, configuration, dependency or documentation change.
