### PR TITLE
refactor(ui): share portaled hovercard hold listeners

### DIFF
--- a/ui/src/components/github-link-hovercard.runtime.ts
+++ b/ui/src/components/github-link-hovercard.runtime.ts
@@ -425,11 +425,6 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     this.hovercard.scheduleClose();
   };
 
-  private readonly handleCardPointerEnter = () => {
-    this.hovercard.pointerOverCard = true;
-    this.hovercard.clearClose();
-  };
-
   private readonly handleCardPointerLeave = () => {
     this.hovercard.pointerOverCard = false;
     // A pointer-opened card must release fully on mouse-out even if a click
@@ -438,22 +433,6 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     if (this.activeTrigger === "pointer") {
       this.hovercard.cardFocusInside = false;
     }
-    this.hovercard.scheduleClose();
-  };
-
-  // The card is portaled to document.body, so focus landing on its title link
-  // never reaches the provider's delegated focusin/focusout listeners; track it
-  // directly so keyboard users can tab into the link without losing the card.
-  private readonly handleCardFocusIn = () => {
-    this.hovercard.cardFocusInside = true;
-    this.hovercard.clearClose();
-  };
-
-  private readonly handleCardFocusOut = (event: FocusEvent) => {
-    if (event.relatedTarget instanceof Node && this.hovercard.card?.contains(event.relatedTarget)) {
-      return;
-    }
-    this.hovercard.cardFocusInside = false;
     this.hovercard.scheduleClose();
   };
 
@@ -564,10 +543,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     renderLoading(card);
     // The card is portaled to document.body, so the provider's delegated pointer
     // listeners never see it; it reports its own hover to keep intent shared.
-    card.addEventListener("pointerenter", this.handleCardPointerEnter);
     card.addEventListener("pointerleave", this.handleCardPointerLeave);
-    card.addEventListener("focusin", this.handleCardFocusIn);
-    card.addEventListener("focusout", this.handleCardFocusOut);
     card.addEventListener("keydown", this.handleCardKeyDown);
     this.hovercard.mount(anchor, card, "vertical", true, () => render(nothing, card));
 

--- a/ui/src/components/portaled-hovercard.ts
+++ b/ui/src/components/portaled-hovercard.ts
@@ -21,6 +21,29 @@ export class PortaledHovercardController {
   private stopPositioning: (() => void) | null = null;
   private trigger: HTMLElement | null = null;
   private unmountContents: (() => void) | null = null;
+  private readonly handleCardPointerEnter = (event: PointerEvent) => {
+    if (event.currentTarget === this.card) {
+      this.pointerOverCard = true;
+      this.clearClose();
+    }
+  };
+  private readonly handleCardFocusIn = (event: FocusEvent) => {
+    if (event.currentTarget === this.card) {
+      this.cardFocusInside = true;
+      this.clearClose();
+    }
+  };
+  private readonly handleCardFocusOut = (event: FocusEvent) => {
+    const card = this.card;
+    if (!card || event.currentTarget !== this.card) {
+      return;
+    }
+    if (event.relatedTarget instanceof Node && card.contains(event.relatedTarget)) {
+      return;
+    }
+    this.cardFocusInside = false;
+    this.scheduleClose();
+  };
 
   constructor(
     private readonly close: () => void,
@@ -96,6 +119,7 @@ export class PortaledHovercardController {
     this.clearCard();
     this.anchor = anchor;
     this.card = card;
+    this.attachCardHoldListeners(card);
     this.placement = placement;
     this.unmountContents = unmountContents ?? null;
     this.stopPositioning = mountPortaledHovercard({
@@ -105,6 +129,12 @@ export class PortaledHovercardController {
       placement,
       observeVisualViewport,
     });
+  }
+
+  private attachCardHoldListeners(card: HTMLDivElement): void {
+    card.addEventListener("pointerenter", this.handleCardPointerEnter);
+    card.addEventListener("focusin", this.handleCardFocusIn);
+    card.addEventListener("focusout", this.handleCardFocusOut);
   }
 
   clearCard(exitDurationMs = 0): void {

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -529,10 +529,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       this.hovercard.position();
       return;
     }
-    card.addEventListener("pointerenter", this.handleCardPointerEnter);
     card.addEventListener("pointerleave", this.handleCardPointerLeave);
-    card.addEventListener("focusin", this.handleCardFocusIn);
-    card.addEventListener("focusout", this.handleCardFocusOut);
     card.addEventListener("keydown", this.handleCardKeyDown);
     this.hovercard.mount(target, card, sessionProgressHoverPlacementForTarget(target), false, () =>
       render(nothing, card),
@@ -547,26 +544,8 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     }
   }
 
-  private readonly handleCardPointerEnter = () => {
-    this.hovercard.pointerOverCard = true;
-    this.hovercard.clearClose();
-  };
-
   private readonly handleCardPointerLeave = () => {
     this.hovercard.pointerOverCard = false;
-    this.hovercard.scheduleClose();
-  };
-
-  private readonly handleCardFocusIn = () => {
-    this.hovercard.cardFocusInside = true;
-    this.hovercard.clearClose();
-  };
-
-  private readonly handleCardFocusOut = (event: FocusEvent) => {
-    if (event.relatedTarget instanceof Node && this.hovercard.card?.contains(event.relatedTarget)) {
-      return;
-    }
-    this.hovercard.cardFocusInside = false;
     this.hovercard.scheduleClose();
   };
 

--- a/ui/src/components/sidebar-people.runtime.ts
+++ b/ui/src/components/sidebar-people.runtime.ts
@@ -316,23 +316,8 @@ export class SidebarPeopleRuntime {
       return;
     }
     this.lastOpenAt = performance.now();
-    card.addEventListener("pointerenter", () => {
-      this.portal.pointerOverCard = true;
-      this.portal.clearClose();
-    });
     card.addEventListener("pointerleave", () => {
       this.portal.pointerOverCard = false;
-      this.portal.scheduleClose();
-    });
-    card.addEventListener("focusin", () => {
-      this.portal.cardFocusInside = true;
-      this.portal.clearClose();
-    });
-    card.addEventListener("focusout", (event) => {
-      if (event.relatedTarget instanceof Node && card.contains(event.relatedTarget)) {
-        return;
-      }
-      this.portal.cardFocusInside = false;
       this.portal.scheduleClose();
     });
     card.addEventListener("keydown", (event) => {


### PR DESCRIPTION
## What Problem This Solves

The three portaled hovercard providers separately maintained the same pointer-enter and focus hold state. Keeping that lifecycle logic in multiple providers made future behavior fixes easy to apply inconsistently.

## Why This Change Was Made

Moves pointer-enter, focus-in, and focus-out hold listeners into `PortaledHovercardController`, which owns the shared hold state. Provider-specific pointer-leave, keyboard navigation, trigger focus return, GitHub pointer-open focus release, timing, and teardown behavior remain local and unchanged.

## User Impact

No intended user-visible behavior change. Hovercard pointer and keyboard interactions now share one lifecycle implementation across GitHub previews, session progress cards, and sidebar people cards.

## Evidence

- Focused UI unit tests: 80 tests passed across `tooltip.test.ts`, `github-link-hovercard.test.ts`, and `session-progress-hovercard-target.test.ts`.
- Mocked Control UI browser tests: 18 tests passed across GitHub hovercards, session progress hovercards, and person-grouped presence.
- `pnpm ui:build` passed.
- Targeted oxlint, stylelint, formatting, and `git diff --check` passed.
- Fresh P1 autoreview: scoped clean.
- Production diff: 30 insertions, 60 deletions.
- Local `pnpm tsgo:ui` and the typecheck phase of `pnpm check:changed` were blocked by the repository checkout-boundary guard because this task-owned gwt uses shared compiler symlinks. Exact-head CI/Testbox will provide physical-checkout type proof.
