### PR TITLE
refactor(meeting-bot): remove unused close timestamp

### DIFF
--- a/src/meeting-bot/node-host.ts
+++ b/src/meeting-bot/node-host.ts
@@ -46,7 +46,6 @@ type NodeBridgeSession = {
   lastClearAt?: string;
   lastInputBytes: number;
   lastOutputBytes: number;
-  closedAt?: string;
   clearCount: number;
   outputGeneration: number;
   outputWriteWaiters: Set<NodeOutputWriteWaiter>;
@@ -205,7 +204,6 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
       session.queuedInputBytes = 0;
       if (!session.closed) {
         session.closed = true;
-        session.closedAt = new Date().toISOString();
       }
       wake(session);
     }
@@ -222,7 +220,6 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
             return;
           }
           session.closed = true;
-          session.closedAt = new Date().toISOString();
           wake(session);
         });
     session.stopPromise = Promise.all([
@@ -605,7 +602,6 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
     mode: session.mode,
     closed: session.closed,
     createdAt: session.createdAt,
-    closedAt: session.closedAt,
     lastInputAt: session.lastInputAt,
     lastOutputAt: session.lastOutputAt,
     lastInputBytes: session.lastInputBytes,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainer edits remain available through this repository-owned branch.

</details>

## What Problem This Solves

The meeting node host carries a private close timestamp that no reachable command response exposes. This maintainer-requested cleanup removes that unused bookkeeping without changing meeting behavior.

## Why This Change Was Made

Remove the private field, its two terminal assignments, and its list projection. The list already excludes stopping and closed sessions; admitted sessions have no defined timestamp, so JSON serialization already omits the property.

Keep terminal audio delivery, retention and eviction, stop/leave coalescing, output-generation fencing, and browser cleanup unchanged. No public API, configuration, dependency, persistent store, or schema change.

The branch is integrated onto one frozen main revision, `e9a2a0298557451d28704b900bf3c4dfb0a4a99d`, which already contains the planner-test repair needed after the previous CI failure. The four-deletion meeting patch is byte-identical; no planner file is added to this PR's diff.

## User Impact

No user-visible behavior change. The node host has one fewer unused piece of state. Exactly one production file changes: +0/-4 lines; tests are unchanged.

## Evidence

- Reviewed head: `6fdd12a50cdd56c90ece1a01d931b3a3b1b66ad8`.
- Full owner, caller, audio-test and SDK source review supports unchanged JSON and lifecycle behavior.
- On-disk Oxfmt 0.65.0 check and `git diff --check` passed.
- Fresh whole-candidate P3 autoreview completed with no actionable findings; review and output capture exited 0.
- Historical CI at `c3214525e6407c8e80b3d181bfcc0b28b92e5014` passed all 24 mandatory audio cases and selected build/static checks, but the overall run failed on the planner growth test. That evidence does not qualify the new head.
- Exact-head CI https://github.com/openclaw/openclaw/actions/runs/34122554389, attempt 1, completed successfully: 107 successful jobs and 17 intentional skips. All 24 cases in `src/meeting-bot/node-host.audio.test.ts` and all 53 planner cases passed, including the growth case in 67696 ms.
- The same run passed actual build and artifact provenance, Node/Bun built-runtime smokes, applicable format/lint/types/Knip and aggregate CI.
- Current-head ClawSweeper review https://github.com/openclaw/openclaw/pull/141183#issuecomment-5570040334 has no findings, security concerns, Before-merge items or remaining rank-up moves. Backend run 34122703184, attempt 1, succeeded.
- Native review refreshed this exact head and confirmed that the current-main meeting owner tree and SDK barrel still match the reviewed base. Native prepare and merge remain separately guarded.
- Audio tests, runtime validation and build have not been rerun locally; no live physical-audio session is claimed. Runtime proof above is the qualified hosted execution, not the historical c321 run.

AI-assisted; maintainer-requested refactor.
