### PR TITLE
fix(test): preserve managed handoff fixture state

### DIFF
--- a/src/infra/update-managed-service-handoff-boundary.test-support.ts
+++ b/src/infra/update-managed-service-handoff-boundary.test-support.ts
@@ -35,6 +35,7 @@ import {
   releaseManagedRepairInference,
 } from "./update-managed-service-handoff-repair.test-support.js";
 import { prepareManagedServiceRuntimeFixture } from "./update-managed-service-handoff-runtime.test-support.js";
+import { managedServiceStateUpdateScript } from "./update-managed-service-handoff-state.test-support.js";
 import { createUpdateRun, getUpdateRun } from "./update-run-ledger.js";
 
 type GatewayRestartSentinelDatabase = Pick<OpenClawStateKyselyDatabase, "gateway_restart_sentinel">;
@@ -101,7 +102,7 @@ export function createManagedServiceManagerBoundary({
     const commandTimingsPath = path.join(root, "manager-command-timings.jsonl");
     const recoveryModulePath = path.join(root, "recovery-health.mjs");
     const stateDatabasePath = resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: root });
-    const consumeNotification = `const db = new (require("node:sqlite").DatabaseSync)(${JSON.stringify(stateDatabasePath)}); const cleared = db.prepare("DELETE FROM gateway_restart_sentinel WHERE sentinel_key = 'current'").run(); db.close(); if (cleared.changes !== 1) throw new Error("expected one published notification before recovery consumed it"); { const state = JSON.parse(fs.readFileSync(${JSON.stringify(statePath)}, "utf8")); state.consumedNotifications = Number(cleared.changes); fs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(state)); }`;
+    const consumeNotification = `const db = new (require("node:sqlite").DatabaseSync)(${JSON.stringify(stateDatabasePath)}); const cleared = db.prepare("DELETE FROM gateway_restart_sentinel WHERE sentinel_key = 'current'").run(); db.close(); if (cleared.changes !== 1) throw new Error("expected one published notification before recovery consumed it"); ${managedServiceStateUpdateScript(statePath, "state.consumedNotifications = Number(cleared.changes)")};`;
     if (options?.updaterNotification) {
       openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
     }
@@ -112,12 +113,15 @@ export function createManagedServiceManagerBoundary({
     import { createRequire } from "node:module";
     const require = createRequire(import.meta.url);
     export async function waitForGatewayUpdateRecovery(expectedVersion, expectedBuildId) {
-      const state = JSON.parse(fs.readFileSync(${JSON.stringify(statePath)}, "utf8"));
+      ${managedServiceStateUpdateScript(
+        statePath,
+        `
       state.healthProbed = true;
       state.healthProbeCount = (state.healthProbeCount || 0) + 1;
       state.expectedVersion = expectedVersion;
       state.expectedBuildId = expectedBuildId;
-      fs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(state));
+      `,
+      )};
       ${options?.updaterNotification === "consumed" ? consumeNotification : ""}
       ${options?.diagnosticReadFailure === "after-recovery" ? `{ const db = new (require("node:sqlite").DatabaseSync)(${JSON.stringify(stateDatabasePath)}); db.exec("ALTER TABLE gateway_restart_sentinel RENAME COLUMN thread_id TO unreadable_thread_id"); db.close(); }` : ""}
       const fault = ${JSON.stringify(options?.gatewayHealth)};
@@ -255,10 +259,7 @@ export function createManagedServiceManagerBoundary({
             serviceRunning: false, pid: ${parentPid}, readyz: false, settled: false,
             channelsReady: false, pluginErrors: ["candidate plugin failed"],
           });
-          const managerFs = require("node:fs");
-          const managerState = JSON.parse(managerFs.readFileSync(${JSON.stringify(statePath)}, "utf8"));
-          managerState.previousGenerationRestored = true;
-          managerFs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(managerState));
+          ${managedServiceStateUpdateScript(statePath, "state.previousGenerationRestored = true")};
           ${updaterScript}
         })().catch((error) => { console.error(error); process.exit(18); });`;
       }

--- a/src/infra/update-managed-service-handoff-command.test-support.ts
+++ b/src/infra/update-managed-service-handoff-command.test-support.ts
@@ -9,6 +9,7 @@ import type {
   ManagedServiceManagerBoundaryResult,
   ManagedServiceManagerBoundaryOptions,
 } from "./update-managed-service-handoff-lifecycle.test-support.js";
+import { managedServiceStateUpdateScript } from "./update-managed-service-handoff-state.test-support.js";
 
 /** A LaunchAgent gateway's own environment; the handoff keeps only the label for its children. */
 export const LAUNCHD_GATEWAY_IDENTITY_ENV = {
@@ -65,6 +66,11 @@ export function createManagedServiceCommandFixture(params: {
           ? [
               `import { createRequire } from "node:module";`,
               `const require = createRequire(import.meta.url);`,
+            ]
+          : []),
+        `void (async () => {`,
+        ...(checksServiceIdentity
+          ? [
               `const { register } = await import(${JSON.stringify(pathToFileURL(createRequire(import.meta.url).resolve("tsx/esm/api")).href)});`,
               // The recovery command runs from the helper's temp dir; name the repo tsconfig for path aliases.
               `register({ tsconfig: ${JSON.stringify(fileURLToPath(new URL("../../tsconfig.json", import.meta.url)))} });`,
@@ -73,33 +79,33 @@ export function createManagedServiceCommandFixture(params: {
           : []),
         `const fs = require("node:fs");`,
         `const { spawnSync } = require("node:child_process");`,
-        `const state = JSON.parse(fs.readFileSync(${JSON.stringify(statePath)}, "utf8"));`,
-        `state.guardedRestart = process.argv.slice(1);`,
+        `${managedServiceStateUpdateScript(statePath, "state.guardedRestart = process.argv.slice(1)")};`,
         ...(checksServiceIdentity
           ? [
-              `state.recoveryInsideService = await isCurrentProcessInsideLaunchdService("ai.openclaw.gateway", process.env);`,
-              `state.recoveryEnv = Object.fromEntries(["LAUNCH_JOB_LABEL", "LAUNCH_JOB_NAME", "XPC_SERVICE_NAME", "OPENCLAW_SERVICE_MARKER", "OPENCLAW_SERVICE_KIND", "OPENCLAW_LAUNCHD_LABEL"].map((key) => [key, process.env[key]]));`,
+              `const recoveryInsideService = await isCurrentProcessInsideLaunchdService("ai.openclaw.gateway", process.env);`,
+              `${managedServiceStateUpdateScript(
+                statePath,
+                `state.recoveryInsideService = recoveryInsideService;
+                state.recoveryEnv = Object.fromEntries(["LAUNCH_JOB_LABEL", "LAUNCH_JOB_NAME", "XPC_SERVICE_NAME", "OPENCLAW_SERVICE_MARKER", "OPENCLAW_SERVICE_KIND", "OPENCLAW_LAUNCHD_LABEL"].map((key) => [key, process.env[key]]))`,
+              )};`,
               // Reproduce the old CLI's early success while its detached restart waits for exit.
-              `if (state.recoveryInsideService) {`,
+              `if (recoveryInsideService) {`,
               `  const { spawn } = require("node:child_process");`,
               `  const child = spawn("/bin/sh", ["-c", ${JSON.stringify('attempts=0; while kill -0 "$1" 2>/dev/null && [ "$attempts" -lt 100 ]; do attempts=$((attempts + 1)); sleep 0.05; done; launchctl enable gui/501/ai.openclaw.gateway; launchctl bootstrap gui/501 "$2"')}, "openclaw-test-recovery", String(process.pid), ${JSON.stringify(path.join(root, "ai.openclaw.gateway.plist"))}], { detached: true, stdio: "ignore" });`,
-              `  state.recoveryHandoffPid = child.pid;`,
-              `  fs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(state));`,
+              `  ${managedServiceStateUpdateScript(statePath, "state.recoveryHandoffPid = child.pid")};`,
               `  child.unref();`,
               `  console.log(JSON.stringify({ action: "restart", ok: true, result: "scheduled" }));`,
               `  process.exit(0);`,
               `}`,
             ]
           : []),
-        `state.recoveryAllowance = process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS;`,
-        `fs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(state));`,
+        `${managedServiceStateUpdateScript(statePath, "state.recoveryAllowance = process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS")};`,
         ...(options?.recoverySentinel
           ? [
               `const { DatabaseSync } = require("node:sqlite");`,
               `const db = new DatabaseSync(${JSON.stringify(params.stateDatabasePath)});`,
               `const row = db.prepare("SELECT payload_json FROM gateway_restart_sentinel WHERE sentinel_key = 'current'").get();`,
-              `state.sentinelAtRecovery = JSON.parse(row.payload_json);`,
-              `fs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(state));`,
+              `const state = ${managedServiceStateUpdateScript(statePath, "state.sentinelAtRecovery = JSON.parse(row.payload_json)")};`,
               ...(options.recoverySentinel === "consumed"
                 ? [
                     `db.prepare("DELETE FROM gateway_restart_sentinel WHERE sentinel_key = 'current'").run();`,
@@ -116,8 +122,8 @@ export function createManagedServiceCommandFixture(params: {
         ...(options?.recoveryHang
           ? [
               `const { spawn } = require("node:child_process");`,
-              `state.recoveryDescendantPid = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" }).pid;`,
-              `fs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(state));`,
+              `const recoveryDescendantPid = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" }).pid;`,
+              `${managedServiceStateUpdateScript(statePath, "state.recoveryDescendantPid = recoveryDescendantPid")};`,
               `setInterval(() => {}, 1000);`,
             ]
           : options?.recoveryExitCode === undefined || options.recoveryExitCode === 0
@@ -140,6 +146,7 @@ export function createManagedServiceCommandFixture(params: {
         ...(checksServiceIdentity
           ? [`console.log(JSON.stringify({ action: "restart", ok: true, result: "restarted" }));`]
           : []),
+        `})().catch((error) => { console.error(error); process.exitCode = 1; });`,
       ].join(""),
       "--",
       "gateway",
@@ -153,29 +160,34 @@ export function createManagedServiceCommandFixture(params: {
           process.execPath,
           "-e",
           [
+            `void (async () => {`,
             `const fs = require("node:fs");`,
             `const args = process.argv.slice(1);`,
-            `const state = JSON.parse(fs.readFileSync(${JSON.stringify(statePath)}, "utf8"));`,
             `const contextPath = args[args.indexOf("--update-result") + 1];`,
-            `state.triageCalls = (state.triageCalls || 0) + 1;`,
-            `state.triageArgs = args;`,
-            `state.triageInput = JSON.parse(fs.readFileSync(contextPath, "utf8"));`,
-            `state.triageInputMode = fs.statSync(contextPath).mode & 0o777;`,
-            `state.triageObservedRestored = state.restored === true;`,
-            `state.triageObservedRecovery = Array.isArray(state.guardedRestart);`,
-            `state.triageRecoveryAllowance = process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS;`,
-            `fs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(state));`,
+            `${managedServiceStateUpdateScript(
+              statePath,
+              `
+              state.triageCalls = (state.triageCalls || 0) + 1;
+              state.triageArgs = args;
+              state.triageInput = JSON.parse(fs.readFileSync(contextPath, "utf8"));
+              state.triageInputMode = fs.statSync(contextPath).mode & 0o777;
+              state.triageObservedRestored = state.restored === true;
+              state.triageObservedRecovery = Array.isArray(state.guardedRestart);
+              state.triageRecoveryAllowance = process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS;
+            `,
+            )};`,
             ...(options?.triageHang
               ? [
                   `const { spawn } = require("node:child_process");`,
-                  `state.triageDescendantPid = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" }).pid;`,
-                  `fs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(state));`,
+                  `const triageDescendantPid = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" }).pid;`,
+                  `${managedServiceStateUpdateScript(statePath, "state.triageDescendantPid = triageDescendantPid")};`,
                   `setInterval(() => {}, 1000);`,
                 ]
               : [
                   `console.log(JSON.stringify({ promptPath: "triage-prompt.md", bundlePath: "support.zip" }));`,
                   `process.exit(${options?.triageExitCode ?? 0});`,
                 ]),
+            `})().catch((error) => { console.error(error); process.exitCode = 1; });`,
           ].join(""),
           "--",
           "triage",

--- a/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
@@ -1,4 +1,5 @@
 import type { TriageUpdateFailure } from "../commands/triage-update.js";
+import { managedServiceStateUpdateScript } from "./update-managed-service-handoff-state.test-support.js";
 import { buildUpdateRestartSentinelPayload } from "./update-restart-sentinel-payload.js";
 import type { UpdateRunRecord } from "./update-run-record.js";
 import type { UpdateRunResult } from "./update-runner-types.js";
@@ -238,22 +239,27 @@ export function createManagedServiceManagerFixtureScript(params: {
   return `#!${process.execPath}
 const fs = require("node:fs");
 const args = process.argv.slice(2);
-const statePath = ${JSON.stringify(statePath)};
-const state = fs.existsSync(statePath) ? JSON.parse(fs.readFileSync(statePath, "utf8")) : {};
 const sleep = (ms) => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 fs.appendFileSync(${JSON.stringify(commandsPath)}, args.join(" ") + "\\n");
 const action = args.find((arg) => ["show", "stop", "reset-failed", "start", "print", "disable", "bootout", "enable", "bootstrap", "kickstart"].includes(arg));
-if (${JSON.stringify(kind)} === "systemd") {
-  if (action === "stop") {
-    state.parked = true;
-    fs.writeFileSync(statePath, JSON.stringify(state));
+void (async () => {
+  if (${JSON.stringify(kind)} === "systemd" && action === "stop") {
+    ${managedServiceStateUpdateScript(statePath, "state.parked = true")};
     for (;;) {
       try { process.kill(${parentPid}, 0); sleep(10); } catch { break; }
     }
     sleep(${options?.systemdStopDelayMs ?? 0});
-    ${options?.revokeOwner ? `fs.writeFileSync(${JSON.stringify(params.configPath)}, JSON.stringify({ commands: { ownerAllowFrom: [] } })); state.ownerRevokedAfterExit = true;` : ""}
-    state.stopCompleted = true;
+    ${managedServiceStateUpdateScript(
+      statePath,
+      `${options?.revokeOwner ? `fs.writeFileSync(${JSON.stringify(params.configPath)}, JSON.stringify({ commands: { ownerAllowFrom: [] } })); state.ownerRevokedAfterExit = true;` : ""}
+      state.stopCompleted = true`,
+    )};
+    return;
   }
+  ${managedServiceStateUpdateScript(
+    statePath,
+    `
+if (${JSON.stringify(kind)} === "systemd") {
   if (action === "reset-failed") state.reset = true;
   if (action === "start" && ${JSON.stringify(options?.systemdFault)} === "start-failed") {
     state.startFailed = true;
@@ -301,11 +307,6 @@ if (${JSON.stringify(kind)} === "systemd") {
     state.loadedPrintsRemaining = ${options?.launchdTeardown?.loadedPrints ?? 0};
     state.pendingBootstrapFailures = ${options?.launchdTeardown?.pendingBootstrapFailures ?? 0};
     state.pendingOperationInProgress = ${options?.launchdTeardown?.pendingOperationInProgress ?? 0};
-    const delay = ${options?.launchdTeardown?.bootoutDelayMs ?? 0};
-    if (delay) setTimeout(() => {
-      state.bootoutCompleted = true;
-      fs.writeFileSync(statePath, JSON.stringify(state));
-    }, delay);
   }
   if (action === "enable") state.disabled = false;
   if (action === "bootstrap" || action === "kickstart") {
@@ -334,8 +335,8 @@ if (${JSON.stringify(kind)} === "systemd") {
       } else {
         state.unloaded = true;
         process.stderr.write("Could not find service\\n");
-        fs.writeFileSync(statePath, JSON.stringify(state));
-        process.exit(113);
+        process.exitCode = 113;
+        return state;
       }
     }
     const fault = ${JSON.stringify(options?.launchdFault)};
@@ -348,7 +349,13 @@ if (${JSON.stringify(kind)} === "systemd") {
     }
   }
 }
-fs.writeFileSync(statePath, JSON.stringify(state));
+  `,
+  )};
+  if (action === "bootout" && ${options?.launchdTeardown?.bootoutDelayMs ?? 0}) {
+    await new Promise((resolve) => setTimeout(resolve, ${options?.launchdTeardown?.bootoutDelayMs ?? 0}));
+    ${managedServiceStateUpdateScript(statePath, "state.bootoutCompleted = true")};
+  }
+})().catch((error) => { console.error(error); process.exitCode = 1; });
 `;
 }
 
@@ -379,13 +386,12 @@ export function createManagedServiceUpdaterFixtureScript(params: {
         })
       : null;
   return [
+    `void (async () => {`,
     `const fs = require("node:fs");`,
     ...(kind === "launchd"
       ? [
-          `const state = JSON.parse(fs.readFileSync(${JSON.stringify(statePath)}, "utf8"));`,
+          `const state = ${managedServiceStateUpdateScript(statePath, "if (state.unloaded) state.updaterObservedUnloaded = true")};`,
           `if (!state.unloaded) process.exit(19);`,
-          `state.updaterObservedUnloaded = true;`,
-          `fs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(state));`,
         ]
       : []),
     `fs.writeFileSync(${JSON.stringify(updaterPath)}, "ran");`,
@@ -394,7 +400,7 @@ export function createManagedServiceUpdaterFixtureScript(params: {
           `const notification = ${JSON.stringify(notification)};`,
           `const db = new (require("node:sqlite").DatabaseSync)(${JSON.stringify(stateDatabasePath)});`,
           `db.prepare("INSERT INTO gateway_restart_sentinel (sentinel_key, version, kind, status, ts, stats_json, payload_json, updated_at_ms) VALUES ('current', 1, ?, ?, ?, ?, ?, ?)").run(notification.kind, notification.status, notification.ts, JSON.stringify(notification.stats), JSON.stringify(notification), notification.ts); db.close();`,
-          `{ const state = JSON.parse(fs.readFileSync(${JSON.stringify(statePath)}, "utf8")); state.publishedSentinel = { version: 1, payload: notification, revision: notification.ts }; fs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(state)); }`,
+          `${managedServiceStateUpdateScript(statePath, "state.publishedSentinel = { version: 1, payload: notification, revision: notification.ts }")};`,
           ...(options?.updaterNotification === "consumed" &&
           (updaterResult?.status === "ok" ||
             (updaterResult?.recovery?.serviceRestartSafe && updaterResult.recovery.service))
@@ -429,6 +435,7 @@ export function createManagedServiceUpdaterFixtureScript(params: {
         ]
       : []),
     `process.stdout.write(remaining, () => { ${options?.updaterSignal ? 'process.kill(process.pid, "SIGTERM");' : `process.exit(${options?.updaterExitCode ?? 7});`} });`,
+    `})().catch((error) => { console.error(error); process.exitCode = 1; });`,
   ].join("");
 }
 

--- a/src/infra/update-managed-service-handoff-runtime.test-support.ts
+++ b/src/infra/update-managed-service-handoff-runtime.test-support.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { ManagedRepairBoundary } from "./update-managed-service-handoff-boundary-contract.test-support.js";
 import { managedRepairConfig } from "./update-managed-service-handoff-repair.test-support.js";
+import { managedServiceStateUpdateScript } from "./update-managed-service-handoff-state.test-support.js";
 
 export async function prepareManagedServiceRuntimeFixture(params: {
   recoveryModulePath: string;
@@ -64,14 +65,14 @@ export async function prepareManagedServiceRuntimeFixture(params: {
       recoveryModulePath,
       `
       export async function isManagedUpdateRequesterOwner(requester) {
-        const state = JSON.parse(fs.readFileSync(${JSON.stringify(statePath)}, "utf8"));
-        state.ownerChecked = true;
-        fs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(state));
+        const state = ${managedServiceStateUpdateScript(
+          statePath,
+          `state.ownerChecked = true;
+          ${options.cancelAtActivation === "requester" ? "state.ownerChecks = (state.ownerChecks || 0) + 1;" : ""}`,
+        )};
         ${
           options.cancelAtActivation === "requester"
-            ? `state.ownerChecks = (state.ownerChecks || 0) + 1;
-        fs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(state));
-        if (state.ownerChecks === 2) {
+            ? `if (state.ownerChecks === 2) {
           fs.writeFileSync(${JSON.stringify(activationGatePath)}, "requester");
           while (!fs.existsSync(${JSON.stringify(activationReleasePath)})) {
             await new Promise((resolve) => setTimeout(resolve, 5));

--- a/src/infra/update-managed-service-handoff-state.test-support.ts
+++ b/src/infra/update-managed-service-handoff-state.test-support.ts
@@ -1,0 +1,10 @@
+import { createRequire } from "node:module";
+
+const storeModulePath = createRequire(import.meta.url).resolve("@openclaw/fs-safe/store");
+
+/** Native fixture processes must reread state under the same cross-process write lock. */
+export function managedServiceStateUpdateScript(statePath: string, update: string): string {
+  return `await require(${JSON.stringify(storeModulePath)}).jsonStore({
+    filePath: ${JSON.stringify(statePath)}, lock: true,
+  }).updateOr({}, (state) => { ${update}; return state; })`;
+}


### PR DESCRIPTION
## What Problem This Solves

Resolves intermittent managed-service handoff test failures when overlapping native fixture processes lose parked/restored state or fail before recording a service command.

Related failure: https://github.com/openclaw/openclaw/actions/runs/34075891991/job/101601945567

## Why This Change Was Made

The fake service manager and updater/recovery helpers read, modified, and truncate-wrote the same JSON snapshot. Readers could observe incomplete JSON, and delayed writers could overwrite completed mutations. Atomic replacement alone did not preserve concurrent updates.

A shared test-support generator routes mutations through the existing `@openclaw/fs-safe` locked JSON store. Systemd's parent-exit wait and delayed launchd bootout completion release the lock while waiting, then reread current state before recording their changes. Command, updater, recovery, owner-check, and notification observations use the same owner.

## User Impact

No production behavior change. The existing handoff assertions, deadlines, dependencies, and public contracts remain intact. The change affects five test-support files (+88/-57); production delta is zero.

## Evidence

- Before: the original dead-PID case passed **6/7** repetitions, then failed with lost parked/restored state.
- Independent native fixture probes reproduced a torn read and a lost completed update. A delayed-bootout probe fails on the original fixture and passes on this repair with the same state assertions.
- Previous repaired dead-PID loop: **10/10**. Fresh paired dead-PID and unavailable-triage repetitions: **10/10**, two tests passing per invocation.
- Fresh clean-main unavailable-triage control at `66a846f8cea4316c7b2b31a02d99affe620c905b`: **5/5** under `CI=1`, two Vitest workers, and the canonical infra configuration. This control does not establish the cause of the earlier sibling failure.
- Rebased patch-identically onto `5260a2fe594`; fresh independent Codex autoreview through P2 reports zero actionable findings.
- Fresh full lifecycle/command sibling proof: **171/171 passed**, 529.11 seconds of Vitest execution, with unchanged assertions and deadlines. The formerly failing unavailable-triage case passed in its original suite order.
- Exact-head CI: **success** at `cc0a524cf0e7cd18ac55ca30957393538826f96d`: https://github.com/openclaw/openclaw/actions/runs/34130154905
- Fresh `node scripts/check-changed.mjs`: **passed** all selected gates, including core-test typechecking, three dead-export scans, formatting, and lint. `git diff --check` also passed.
- Supplemental full CI [run 34130291158](https://github.com/openclaw/openclaw/actions/runs/34130291158) failed first on a pre-test Matrix artifact HTTP 504 and a separate Git output-limit test. The single failed-job rerun passed the UI shard but repeated the Git failure: **1 failed / 5,909 passed / 5 skipped**, [job 101785301132](https://github.com/openclaw/openclaw/actions/runs/34130291158/job/101785301132). That full-worker failure remains unattributed despite passing narrowed Linux Node24.19/24.20 controls; no further retry or speculative source change was made. The required `openclaw/ci-gate` used for native prepare/merge was successful from exact-head run 34130154905. The supplemental failed run is not claimed as green.

```sh
CI=1 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/infra/update-managed-service-handoff-lifecycle.test.ts -t 'preserves update failure after unavailable triage \(0, timeout=true, missing=false\)'
CI=1 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/infra/update-managed-service-handoff-lifecycle.test.ts -t 'rejects launchd restoration reporting running with a dead PID|preserves update failure after unavailable triage \(0, timeout=true, missing=false\)'
CI=1 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/infra/update-managed-service-handoff-lifecycle.test.ts src/infra/update-managed-service-handoff-command.test.ts
node scripts/check-changed.mjs
```

Local proof uses Node 26.8.1 on macOS arm64. Native service processes are isolated synthetic fixtures. Hosted exact-head CI passed.

### Earlier validation gap and dependency review

An earlier full sibling run had **170 passed / 1 failed** because the unavailable-triage hang case did not record readiness/triage observations. Its historical cause remains unattributed. Fresh clean-main 5/5, paired candidate 10/10, and the complete original-order 171/171 sibling run resolve the current validation gap without another fixture change. Retained native observations from the full run contain `healthProbed=true`, `triageCalls=1`, and both recovery/restoration observations; the test's hanging-descendant cleanup assertion also passed.

The installed **fs-safe 0.8.3** source was inspected directly: `json-document-store.js` acquires `withLock` before reading/updating/writing; `updateOr` awaits the write and returns the updated value. `sidecar-lock.js` awaits lock release before returning that value, including callback-error cleanup. This confirms the exact dependency contract used by the generated fixture scripts and addresses the earlier review's source-access limitation.
