### PR TITLE
docs: fix the Fetch MCP server setup example

### DIFF
--- a/docs/gateway/config-extensions.md
+++ b/docs/gateway/config-extensions.md
@@ -13,16 +13,16 @@ For the full key index and the other top-level config domains, see [Configuratio
 
 ## MCP
 
-OpenClaw-managed MCP server definitions live under `mcp.servers` and are
-consumed by embedded OpenClaw and other runtime adapters. The `openclaw mcp list`,
-`show`, `set`, and `unset` commands manage this block without connecting to the
-target server during config edits.
+OpenClaw-managed MCP server definitions live under `mcp.servers` for embedded
+OpenClaw and other runtime adapters. `openclaw mcp list`, `show`, `set`, and
+`unset` manage this block without connecting to the servers. The Fetch example
+requires [`uv`/`uvx`](https://docs.astral.sh/uv/getting-started/installation/).
 
 ```json5
 {
   mcp: {
     servers: {
-      fetch: {
+      docs: {
         command: "uvx",
         args: ["mcp-server-fetch"],
       },
@@ -57,27 +57,6 @@ target server during config edits.
   },
 }
 ```
-
-The optional Fetch example requires [`uv`/`uvx`](https://docs.astral.sh/uv/getting-started/installation/)
-and follows the upstream
-[`mcp-server-fetch` configuration](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch).
-That server can reach local and internal addresses, so enable it only where its
-network access matches your trust policy. If you previously copied the unavailable
-`@modelcontextprotocol/server-fetch` npm command, first find the saved server name:
-
-```bash
-openclaw mcp list
-```
-
-Then update that same name (`docs` in the previous example, or possibly `fetch`
-in an existing config). For the previous `docs` example, run:
-
-```bash
-openclaw mcp set docs '{"command":"uvx","args":["mcp-server-fetch"]}'
-```
-
-Use `openclaw mcp unset docs` instead if you no longer want that entry. Replace
-`docs` with the name shown by `mcp list` in both commands when yours differs.
 
 - `mcp.servers`: named stdio or remote MCP server definitions for runtimes that
   expose configured MCP tools.

--- a/docs/gateway/config-extensions.md
+++ b/docs/gateway/config-extensions.md
@@ -22,9 +22,9 @@ target server during config edits.
 {
   mcp: {
     servers: {
-      docs: {
-        command: "npx",
-        args: ["-y", "@modelcontextprotocol/server-fetch"],
+      fetch: {
+        command: "uvx",
+        args: ["mcp-server-fetch"],
       },
       remote: {
         url: "https://example.com/mcp",
@@ -57,6 +57,27 @@ target server during config edits.
   },
 }
 ```
+
+The optional Fetch example requires [`uv`/`uvx`](https://docs.astral.sh/uv/getting-started/installation/)
+and follows the upstream
+[`mcp-server-fetch` configuration](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch).
+That server can reach local and internal addresses, so enable it only where its
+network access matches your trust policy. If you previously copied the unavailable
+`@modelcontextprotocol/server-fetch` npm command, first find the saved server name:
+
+```bash
+openclaw mcp list
+```
+
+Then update that same name (`docs` in the previous example, or possibly `fetch`
+in an existing config). For the previous `docs` example, run:
+
+```bash
+openclaw mcp set docs '{"command":"uvx","args":["mcp-server-fetch"]}'
+```
+
+Use `openclaw mcp unset docs` instead if you no longer want that entry. Replace
+`docs` with the name shown by `mcp list` in both commands when yours differs.
 
 - `mcp.servers`: named stdio or remote MCP server definitions for runtimes that
   expose configured MCP tools.


### PR DESCRIPTION
Closes #141180

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where operators copying the Fetch MCP example would configure an unavailable npm package and fail to start the server.

## Why This Change Was Made

Use the upstream `uvx mcp-server-fetch` command and state that `uv` is required. Keep the existing `docs` entry name so the corrected example addresses the same saved entry.

## User Impact

The example names an available server command and its prerequisite. Runtime behavior, configuration keys and server entry names stay unchanged.

## Evidence

- The npm endpoint for `@modelcontextprotocol/server-fetch` returned HTTP 404 on September 7, 2026. The same command appears in the current source and stable `v2026.9.2` documentation.
- The [upstream Fetch documentation](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) specifies `uvx mcp-server-fetch`. The hash-verified published `mcp-server-fetch` 2026.8.18 wheel declares that console entry point.
- [Isolated Linux command proof](https://github.com/steipete/openclaw/actions/runs/34153109025/job/101839393103) passed: `uvx mcp-server-fetch --help`, MCP initialization and tool discovery. The installed Fetch package was `2026.8.18`, with MCP SDK `1.29.0`; all 43 dependency versions matched the frozen lock. All seven proof processes exited normally with pipe EOF and completed cleanup.
- Pinned standalone `oxfmt` 0.65.0 and `git diff --check` passed on the lean docs rewrite. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34157396516) passed, including the docs checks and required CI gate; [Workflow Sanity](https://github.com/openclaw/openclaw/actions/runs/34157396490) also passed.
- The proof sent only initialization, the initialized notification and tool discovery. It made no fetch-tool or prompt calls and supports no claim about web retrieval, network policy or an OpenClaw config mutation.

The scoped rewrite keeps the original entry name and omits the broader policy and migration instructions from the previous revision. Production and tests change by zero lines; documentation is +6/-6.

Thanks @ly85206559 for identifying and correcting the example.
