### PR TITLE
improve: reduce prompt preparation overhead for agent turns

### DIFF
--- a/src/agents/embedded-agent-runner/system-prompt.ts
+++ b/src/agents/embedded-agent-runner/system-prompt.ts
@@ -9,7 +9,7 @@ import type { SystemPromptRuntimeInfo } from "../system-prompt.js";
 
 type EmbeddedSystemPromptParams = Omit<
   Parameters<typeof buildConfiguredAgentSystemPrompt>[0],
-  "toolNames" | "toolSummaries" | "fsWorkspaceOnly"
+  "toolNames" | "fsWorkspaceOnly"
 > & {
   reasoningTagHint: boolean;
   runtimeInfo: SystemPromptRuntimeInfo & {

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1049,6 +1049,33 @@ describe("buildAgentSystemPrompt", () => {
     );
   });
 
+  it("keeps first casing and visible-only order with sparse duplicate tool names", () => {
+    const toolNames: string[] = [];
+    toolNames[1] = " Read ";
+    toolNames[2] = "read";
+    toolNames[3] = " EXEC ";
+    toolNames[4] = "exec";
+    toolNames[5] = " custom_Z ";
+    toolNames[6] = "CUSTOM_z";
+    toolNames[7] = "custom_a";
+    toolNames[8] = " ";
+    Object.freeze(toolNames);
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames,
+      capabilityToolNames: [" process ", "READ", "process", "custom_deferred"],
+    });
+    const tooling = prompt.split("## Tooling\n")[1]?.split("\nThe AGENTS.md Tools section")[0];
+
+    expect(tooling?.split("\n").filter((line) => line.startsWith("- "))).toEqual([
+      "- Read: Read files",
+      "- EXEC: Run shell; pty for TTY CLIs",
+      "- custom_a",
+      "- custom_Z",
+    ]);
+    expect(prompt).toContain("Use EXEC yieldMs or process(poll, timeout=<ms>).");
+  });
+
   it("includes docs guidance when docsPath is provided", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -776,7 +776,6 @@ export function buildAgentSystemPrompt(params: {
   toolNames?: string[];
   /** Callable tool names used for capability guidance without listing them as visible tools. */
   capabilityToolNames?: string[];
-  toolSummaries?: Record<string, string>;
   modelAliasLines?: string[];
   userTimezone?: string;
   userDate?: string;
@@ -843,8 +842,17 @@ export function buildAgentSystemPrompt(params: {
   const promptSurface = params.promptSurface ?? "openclaw_main";
   const sandboxedRuntime = params.sandboxInfo?.enabled === true;
   const acpSpawnRuntimeEnabled = acpEnabled && !sandboxedRuntime;
+  // Preserve first caller casing; sparse tool arrays skip absent entries.
+  const visibleTools = new Map<string, string>();
+  (params.toolNames ?? []).forEach((tool) => {
+    const name = tool.trim();
+    const normalized = name.toLowerCase();
+    if (normalized && !visibleTools.has(normalized)) {
+      visibleTools.set(normalized, name);
+    }
+  });
   const availableTools = new Set([
-    ...normalizeStringEntriesLower(params.toolNames),
+    ...visibleTools.keys(),
     ...normalizeStringEntriesLower(params.capabilityToolNames),
   ]);
   const coreToolSummaries: Record<string, string> = {
@@ -938,21 +946,7 @@ export function buildAgentSystemPrompt(params: {
     "image_generate",
   ];
 
-  const rawToolNames = (params.toolNames ?? []).map((tool) => tool.trim());
-  const canonicalToolNames = rawToolNames.filter(Boolean);
-  // Preserve caller casing while deduping tool names by lowercase.
-  const canonicalByNormalized = new Map<string, string>();
-  for (const name of canonicalToolNames) {
-    const normalized = name.toLowerCase();
-    if (!canonicalByNormalized.has(normalized)) {
-      canonicalByNormalized.set(normalized, name);
-    }
-  }
-  const resolveToolName = (normalized: string) =>
-    canonicalByNormalized.get(normalized) ?? normalized;
-
-  const normalizedTools = canonicalToolNames.map((tool) => tool.toLowerCase());
-  const visibleTools = new Set(normalizedTools);
+  const resolveToolName = (normalized: string) => visibleTools.get(normalized) ?? normalized;
   const hasSessionsSpawn = availableTools.has("sessions_spawn");
   const subagentStatusTools = ["subagents", "sessions_list"].filter((name) =>
     availableTools.has(name),
@@ -964,25 +958,15 @@ export function buildAgentSystemPrompt(params: {
   const nativeCommandGuidanceLines = normalizeUniqueStringEntries(
     params.nativeCommandGuidanceLines,
   );
-  const externalToolSummaries = new Map<string, string>();
-  for (const [key, value] of Object.entries(params.toolSummaries ?? {})) {
-    const normalized = key.trim().toLowerCase();
-    if (!normalized || !value?.trim()) {
-      continue;
-    }
-    externalToolSummaries.set(normalized, value.trim());
-  }
-  const extraTools = Array.from(
-    new Set(normalizedTools.filter((tool) => !toolOrder.includes(tool))),
-  );
+  const extraTools = [...visibleTools.keys()].filter((tool) => !toolOrder.includes(tool));
   const enabledTools = toolOrder.filter((tool) => visibleTools.has(tool));
   const toolLines = enabledTools.map((tool) => {
-    const summary = coreToolSummaries[tool] ?? externalToolSummaries.get(tool);
+    const summary = coreToolSummaries[tool];
     const name = resolveToolName(tool);
     return summary ? `- ${name}: ${summary}` : `- ${name}`;
   });
   for (const tool of extraTools.toSorted()) {
-    const summary = coreToolSummaries[tool] ?? externalToolSummaries.get(tool);
+    const summary = coreToolSummaries[tool];
     const name = resolveToolName(tool);
     toolLines.push(summary ? `- ${name}: ${summary}` : `- ${name}`);
   }


### PR DESCRIPTION
## What Problem This Solves

Agent turns repeat tool-name preparation before assembling their system prompt. Larger tool rosters pay for redundant normalization, lookup structures, and an unused summaries map.

## Why This Change Was Made

Use one visible-tool map to retain normalized names and first-seen display spelling. Remove the unused internal toolSummaries option and its allocation, including the embedded facade’s type reference. Core ordering, sorted custom names, sparse arrays, case-insensitive duplicates, deferred capabilities, prompt modes, cache keys, and attempt refresh behavior remain unchanged.

Production code shrinks by 16 lines. There are no configuration, dependency, protocol, persistence, or native runtime changes.

## User Impact

OpenClaw does less work preparing tool rosters for agent turns while preserving complete prompt bytes. This is a local preparation improvement, not a claim that model responses or network requests become proportionally faster.

## Evidence

All 237 tests across eight full prompt/embedded/CLI composition suites passed, as did all 29 selected normal checks. Independent P0–P2 review found no actionable findings. The preservation test adds 27 lines; it covers sparse inputs, duplicate/case behavior, visible ordering and capability-only separation.

The fixed B0/C0/C1/B1 comparison executes actual buildAttemptSystemPrompt, an identity provider transform, owned section wrapping, and permission refresh with external text. All 1,968 complete three-string results match byte-for-byte, including 20 KiB context and full/minimal/none modes. Every returned result is retained before assertions. Independent analysis reconciled all journals, complete output dictionaries, input schedules, source-pair bindings and process closure. No live provider call is part of this measurement.

Each process has 12 rows, with one first call, ten warmups and thirty steady measurements per row. All calls are clocked: 48 first, 480 warmup and 1,440 steady across the cohort. The two production files switch together between their verified original and candidate images.

Paired steady medians below show candidate-minus-baseline; negative is faster. Absolute deltas are microseconds.

| Workload | Forward change / delta µs | Reverse change / delta µs |
| --- | ---: | ---: |
| empty-full | -4.56% / -0.9170 | +9.99% / +1.7085 |
| core5-full | -15.55% / -3.6660 | -2.02% / -0.3965 |
| mixed30-full | -9.26% / -3.7500 | -21.86% / -8.9790 |
| extra200-full | -22.86% / -19.2080 | -30.69% / -27.7915 |
| duplicates-full | -9.80% / -2.7915 | -22.90% / -6.6460 |
| sparse-full | -6.91% / -1.7085 | -13.50% / -3.3125 |
| deferred-full | -1.43% / -0.2495 | -2.75% / -0.4585 |
| codemode-full | -12.73% / -2.4580 | -2.83% / -0.5005 |
| mixed30-minimal | -7.71% / -2.3745 | -7.67% / -2.4375 |
| mixed30-none | -1.81% / -0.0415 | -3.58% / -0.0835 |
| context20k-full | -12.54% / -7.7080 | -5.20% / -3.0410 |
| capability-transition | -2.67% / -0.4580 | +6.19% / +1.0415 |

Twenty-two of 24 median comparisons improve. All 40 adverse metrics out of 120 remain reported: 13 first calls, two medians, seven means, eight p95s and ten maxima. The reverse empty-roster and capability-transition medians regress by 1.71 µs and 1.04 µs. This single fixed cohort does not establish stable tail distributions; first calls occur after import, and none-mode bypasses the stable-prefix cache.

Resources are mixed: six of sixteen comparisons regress. Forward kernel/tree peak RSS rises 2.93%/3.24%; reverse RSS falls slightly. Native child user CPU rises 0.10%/0.40%. Whole-phase wall time falls 12.15%/1.27%, but includes imports, setup and capture. No general memory or Gateway latency improvement is claimed. All failures, complete strings, timing samples, resource values and source-restoration records are retained locally; no favorable rerun or omitted adverse case was used.
