### PR TITLE
refactor(plugins): share manifest contribution projection

### DIFF
--- a/src/plugins/plugin-metadata-contributions.ts
+++ b/src/plugins/plugin-metadata-contributions.ts
@@ -18,17 +18,18 @@ export function listPluginManifestContributionIds(
   plugin: PluginManifestRecord,
   contribution: PluginMetadataContributionKey,
 ): readonly string[] {
+  // Retain snapshot projection defaults when contribution arrays are omitted.
   switch (contribution) {
     case "providers":
-      return plugin.providers;
+      return plugin.providers ?? [];
     case "channels":
-      return plugin.channels;
+      return plugin.channels ?? [];
     case "channelConfigs":
       return Object.keys(plugin.channelConfigs ?? {});
     case "setupProviders":
       return plugin.setup?.providers?.map((provider) => provider.id) ?? [];
     case "cliBackends":
-      return [...plugin.cliBackends, ...(plugin.setup?.cliBackends ?? [])];
+      return [...(plugin.cliBackends ?? []), ...(plugin.setup?.cliBackends ?? [])];
     case "modelCatalogProviders":
       return [
         ...Object.keys(plugin.modelCatalog?.providers ?? {}),

--- a/src/plugins/plugin-metadata-contributions.ts
+++ b/src/plugins/plugin-metadata-contributions.ts
@@ -1,0 +1,45 @@
+import type { PluginManifestRecord } from "./manifest-registry.types.js";
+
+export const PLUGIN_METADATA_CONTRIBUTION_KEYS = [
+  "channels",
+  "channelConfigs",
+  "providers",
+  "modelCatalogProviders",
+  "cliBackends",
+  "setupProviders",
+  "commandAliases",
+  "contracts",
+] as const;
+
+export type PluginMetadataContributionKey = (typeof PLUGIN_METADATA_CONTRIBUTION_KEYS)[number];
+
+/** Raw declarations retain their order and spelling; owner indexes add normalization and aliases. */
+export function listPluginManifestContributionIds(
+  plugin: PluginManifestRecord,
+  contribution: PluginMetadataContributionKey,
+): readonly string[] {
+  switch (contribution) {
+    case "providers":
+      return plugin.providers;
+    case "channels":
+      return plugin.channels;
+    case "channelConfigs":
+      return Object.keys(plugin.channelConfigs ?? {});
+    case "setupProviders":
+      return plugin.setup?.providers?.map((provider) => provider.id) ?? [];
+    case "cliBackends":
+      return [...plugin.cliBackends, ...(plugin.setup?.cliBackends ?? [])];
+    case "modelCatalogProviders":
+      return [
+        ...Object.keys(plugin.modelCatalog?.providers ?? {}),
+        ...Object.keys(plugin.modelCatalog?.aliases ?? {}),
+      ];
+    case "commandAliases":
+      return plugin.commandAliases?.map((alias) => alias.name) ?? [];
+    case "contracts":
+      return Object.entries(plugin.contracts ?? {}).flatMap(([key, values]) =>
+        Array.isArray(values) && values.length > 0 ? [key] : [],
+      );
+  }
+  return [];
+}

--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -71,6 +71,14 @@ vi.mock("./manifest-registry-installed.js", async (importOriginal) => {
   };
 });
 
+function mockRegistrySnapshot(index: ReturnType<typeof makeIndex>) {
+  loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+    source: "provided",
+    snapshot: index,
+    diagnostics: [],
+  });
+}
+
 function mockSchemaSnapshotSource(
   index: ReturnType<typeof makeIndex>,
   properties: Record<string, unknown>,
@@ -81,11 +89,7 @@ function mockSchemaSnapshotSource(
     throw new Error("expected manifest plugin fixture");
   }
   plugin.configSchema = { type: "object", properties };
-  loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-    source: "provided",
-    snapshot: index,
-    diagnostics: [],
-  });
+  mockRegistrySnapshot(index);
   loadPluginManifestRegistryForInstalledIndex.mockReturnValue(registry);
   return registry;
 }
@@ -103,11 +107,7 @@ describe("plugin metadata snapshot", () => {
 
   it("progressively reuses first-access metadata and scopes fresh control-plane loads", () => {
     const index = makeIndex();
-    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "provided",
-      snapshot: index,
-      diagnostics: [],
-    });
+    mockRegistrySnapshot(index);
 
     const first = loadPluginMetadataSnapshot({ config: {}, env: {}, index });
     const second = loadPluginMetadataSnapshot({ config: {}, env: {}, index });
@@ -138,11 +138,7 @@ describe("plugin metadata snapshot", () => {
 
   it("keeps direct manifest readers on the Gateway inventory", () => {
     const config = {};
-    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "provided",
-      snapshot: makeIndex(),
-      diagnostics: [],
-    });
+    mockRegistrySnapshot(makeIndex());
     const snapshot = loadPluginMetadataSnapshot({ config, env: {} });
     setGatewayPluginMetadataSnapshot(snapshot, { config, env: {} });
 
@@ -201,11 +197,7 @@ describe("plugin metadata snapshot", () => {
   it("publishes the complete prepared cache and keeps fresh operations outside boot scopes", () => {
     const config = {};
     const preparedCache = createPluginCache();
-    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "provided",
-      snapshot: makeIndex(),
-      diagnostics: [],
-    });
+    mockRegistrySnapshot(makeIndex());
     const snapshot = withPluginCache(preparedCache, () =>
       loadPluginMetadataSnapshot({ config, env: {} }),
     );
@@ -235,11 +227,7 @@ describe("plugin metadata snapshot", () => {
       const config = {};
       const index = makeIndex();
       index.policyHash = resolveInstalledPluginIndexPolicyHash(config);
-      loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-        source: "provided",
-        snapshot: index,
-        diagnostics: [],
-      });
+      mockRegistrySnapshot(index);
       const snapshot = loadPluginMetadataSnapshot({ config, env: {}, index });
       loadPluginRegistrySnapshotWithMetadata.mockClear();
       loadPluginManifestRegistryForInstalledIndex.mockClear();
@@ -267,11 +255,7 @@ describe("plugin metadata snapshot", () => {
     const workspaceDir = "/workspace";
     const index = makeIndex();
     index.policyHash = resolveInstalledPluginIndexPolicyHash(config);
-    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "provided",
-      snapshot: index,
-      diagnostics: [],
-    });
+    mockRegistrySnapshot(index);
     const scoped = loadPluginMetadataSnapshot({
       config,
       env: {},
@@ -311,11 +295,7 @@ describe("plugin metadata snapshot", () => {
     const staleIndex = makeIndex("stale");
     staleIndex.policyHash = resolveInstalledPluginIndexPolicyHash(config);
     staleIndex.workspaceDir = sourceWorkspace;
-    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "provided",
-      snapshot: staleIndex,
-      diagnostics: [],
-    });
+    mockRegistrySnapshot(staleIndex);
     loadPluginManifestRegistryForInstalledIndex.mockReturnValue(makeManifestRegistry("stale"));
     const stale = loadPluginMetadataSnapshot({
       config,
@@ -329,11 +309,7 @@ describe("plugin metadata snapshot", () => {
     const freshIndex = makeIndex("fresh");
     freshIndex.policyHash = resolveInstalledPluginIndexPolicyHash(config);
     freshIndex.workspaceDir = targetWorkspace;
-    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "provided",
-      snapshot: freshIndex,
-      diagnostics: [],
-    });
+    mockRegistrySnapshot(freshIndex);
     loadPluginManifestRegistryForInstalledIndex.mockReturnValue(makeManifestRegistry("fresh"));
 
     const resolved = resolvePluginMetadataSnapshot({
@@ -562,11 +538,7 @@ describe("plugin metadata snapshot", () => {
     const config = { plugins: { entries: { demo: { enabled: true } } } };
     const index = makeIndex();
     index.policyHash = resolveInstalledPluginIndexPolicyHash(config);
-    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "provided",
-      snapshot: index,
-      diagnostics: [],
-    });
+    mockRegistrySnapshot(index);
     const snapshot = loadPluginMetadataSnapshot({ config, env: {}, index });
     adoptCurrentPluginMetadataSnapshotIfAbsent(snapshot, { config, env: {} });
     const ignored = { ...snapshot, registrySource: "persisted" as const };
@@ -686,11 +658,7 @@ describe("plugin metadata snapshot", () => {
 
   it("projects scopes from one complete first-access inventory", () => {
     const index = makeIndex();
-    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "provided",
-      snapshot: index,
-      diagnostics: [],
-    });
+    mockRegistrySnapshot(index);
 
     const scoped = loadPluginMetadataSnapshot({
       config: {},
@@ -718,11 +686,7 @@ describe("plugin metadata snapshot", () => {
       const config = {};
       const index = makeIndex();
       index.policyHash = resolveInstalledPluginIndexPolicyHash(config);
-      loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-        source: "provided",
-        snapshot: index,
-        diagnostics: [],
-      });
+      mockRegistrySnapshot(index);
       const unscoped = loadPluginMetadataSnapshot({ config, env: {}, index });
       setCurrentPluginMetadataSnapshot(unscoped, { config, env: {} });
       loadPluginManifestRegistryForInstalledIndex.mockClear();
@@ -850,8 +814,10 @@ describe("plugin metadata snapshot", () => {
     if (!plugin || !other) {
       throw new Error("expected manifest plugin fixture");
     }
-    plugin.cliBackends = ["DEMO-CLI"];
+    plugin.cliBackends = ["DEMO-CLI", "DEMO-CLI"];
     plugin.setup = { cliBackends: ["Demo-CLI", "Other-CLI"] };
+    plugin.contracts = { tools: [], webSearchProviders: ["demo-search"] };
+    other.cliBackends = ["demo-cli"];
     plugin.providerEndpoints = [
       {
         endpointClass: " openai-public ",
@@ -892,19 +858,16 @@ describe("plugin metadata snapshot", () => {
         },
       },
     };
-    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "provided",
-      snapshot: index,
-      diagnostics: [],
-    });
+    mockRegistrySnapshot(index);
     loadPluginManifestRegistryForInstalledIndex.mockReturnValue(registry);
 
     const snapshot = loadPluginMetadataSnapshot({ config: {}, env: {}, index });
 
     expect([...snapshot.owners.cliBackends]).toEqual([
-      ["demo-cli", ["demo"]],
+      ["demo-cli", ["demo", "other"]],
       ["other-cli", ["demo"]],
     ]);
+    expect([...snapshot.owners.contracts]).toEqual([["webSearchProviders", ["demo"]]]);
     expect(snapshot.owners.providerEndpoints?.slice(0, 4)).toEqual([
       {
         endpointClass: "openai-public",
@@ -983,11 +946,7 @@ describe("plugin metadata snapshot", () => {
     "freezes a cloned index instead of caller-owned records (worker: %s)",
     (worker) => {
       const index = makeIndex();
-      loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-        source: "provided",
-        snapshot: index,
-        diagnostics: [],
-      });
+      mockRegistrySnapshot(index);
 
       const registry = makeManifestRegistry();
       registry.plugins = registry.plugins.map((plugin) => ({

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -30,6 +30,11 @@ import {
   withPluginCache,
 } from "./plugin-cache.js";
 import { resolvePluginControlPlaneFingerprint } from "./plugin-control-plane-context.js";
+import {
+  listPluginManifestContributionIds,
+  PLUGIN_METADATA_CONTRIBUTION_KEYS,
+  type PluginMetadataContributionKey,
+} from "./plugin-metadata-contributions.js";
 import { resolvePluginMetadataEnvFingerprint } from "./plugin-metadata-env.js";
 import { buildPluginMetadataProviderFacts } from "./plugin-metadata-provider-facts.js";
 import { registerPluginMetadataSnapshotReaders } from "./plugin-metadata-snapshot-readers.js";
@@ -179,33 +184,29 @@ function appendOwner(owners: Map<string, string[]>, ownedId: string, pluginId: s
   owners.set(ownedId, [pluginId]);
 }
 
-function freezeOwnerMap(owners: Map<string, string[]>): ReadonlyMap<string, readonly string[]> {
-  // These maps and arrays are private until this transfer to the snapshot.
-  owners.forEach((pluginIds) => Object.freeze(pluginIds));
-  return owners;
-}
-
 function buildPluginMetadataOwnerMaps(
   plugins: readonly PluginManifestRecord[],
 ): PluginMetadataSnapshotOwnerMaps {
-  const channels = new Map<string, string[]>();
-  const channelConfigs = new Map<string, string[]>();
-  const providers = new Map<string, string[]>();
-  const modelCatalogProviders = new Map<string, string[]>();
-  const cliBackends = new Map<string, string[]>();
-  const setupProviders = new Map<string, string[]>();
-  const commandAliases = new Map<string, string[]>();
-  const contracts = new Map<string, string[]>();
+  const owners: Record<PluginMetadataContributionKey, Map<string, string[]>> = {
+    channels: new Map(),
+    channelConfigs: new Map(),
+    providers: new Map(),
+    modelCatalogProviders: new Map(),
+    cliBackends: new Map(),
+    setupProviders: new Map(),
+    commandAliases: new Map(),
+    contracts: new Map(),
+  };
 
   for (const plugin of plugins) {
-    for (const channelId of plugin.channels ?? []) {
-      appendOwner(channels, channelId, plugin.id);
-    }
-    for (const channelId of Object.keys(plugin.channelConfigs ?? {})) {
-      appendOwner(channelConfigs, channelId, plugin.id);
-    }
-    for (const providerId of plugin.providers ?? []) {
-      appendOwner(providers, providerId, plugin.id);
+    for (const contribution of PLUGIN_METADATA_CONTRIBUTION_KEYS) {
+      for (const id of listPluginManifestContributionIds(plugin, contribution)) {
+        appendOwner(
+          owners[contribution],
+          contribution === "cliBackends" ? normalizeProviderId(id) : id,
+          plugin.id,
+        );
+      }
     }
     for (const [rawAlias, target] of Object.entries(plugin.providerAuthAliases ?? {})) {
       const alias = normalizeProviderId(rawAlias);
@@ -217,45 +218,16 @@ function buildPluginMetadataOwnerMaps(
           (providerId) => normalizeProviderId(providerId) === targetProvider,
         )
       ) {
-        appendOwner(providers, alias, plugin.id);
-      }
-    }
-    for (const providerId of Object.keys(plugin.modelCatalog?.providers ?? {})) {
-      appendOwner(modelCatalogProviders, providerId, plugin.id);
-    }
-    for (const providerId of Object.keys(plugin.modelCatalog?.aliases ?? {})) {
-      appendOwner(modelCatalogProviders, providerId, plugin.id);
-    }
-    for (const cliBackendId of plugin.cliBackends ?? []) {
-      appendOwner(cliBackends, normalizeProviderId(cliBackendId), plugin.id);
-    }
-    for (const cliBackendId of plugin.setup?.cliBackends ?? []) {
-      appendOwner(cliBackends, normalizeProviderId(cliBackendId), plugin.id);
-    }
-    for (const setupProvider of plugin.setup?.providers ?? []) {
-      appendOwner(setupProviders, setupProvider.id, plugin.id);
-    }
-    for (const commandAlias of plugin.commandAliases ?? []) {
-      appendOwner(commandAliases, commandAlias.name, plugin.id);
-    }
-    for (const [contract, values] of Object.entries(plugin.contracts ?? {})) {
-      if (Array.isArray(values) && values.length > 0) {
-        appendOwner(contracts, contract, plugin.id);
+        appendOwner(owners.providers, alias, plugin.id);
       }
     }
   }
 
-  return {
-    channels: freezeOwnerMap(channels),
-    channelConfigs: freezeOwnerMap(channelConfigs),
-    providers: freezeOwnerMap(providers),
-    modelCatalogProviders: freezeOwnerMap(modelCatalogProviders),
-    cliBackends: freezeOwnerMap(cliBackends),
-    setupProviders: freezeOwnerMap(setupProviders),
-    commandAliases: freezeOwnerMap(commandAliases),
-    contracts: freezeOwnerMap(contracts),
-    ...buildPluginMetadataProviderFacts(plugins),
-  };
+  // These maps and arrays are private until this transfer to the snapshot.
+  for (const map of Object.values(owners)) {
+    map.forEach((pluginIds) => Object.freeze(pluginIds));
+  }
+  return { ...owners, ...buildPluginMetadataProviderFacts(plugins) };
 }
 
 export function listPluginOriginsFromMetadataSnapshot(

--- a/src/plugins/plugin-registry-contributions.ts
+++ b/src/plugins/plugin-registry-contributions.ts
@@ -13,6 +13,10 @@ import type {
   PluginManifestRecord,
   PluginManifestRegistry,
 } from "./manifest-registry.js";
+import {
+  listPluginManifestContributionIds,
+  type PluginMetadataContributionKey,
+} from "./plugin-metadata-contributions.js";
 import { resolvePluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
@@ -44,23 +48,13 @@ type LoadPluginRegistryManifestParams = LoadPluginRegistryParams & {
   bundledChannelConfigCollector?: BundledChannelConfigCollector;
 };
 
-type PluginRegistryContributionKey =
-  | "providers"
-  | "channels"
-  | "channelConfigs"
-  | "setupProviders"
-  | "cliBackends"
-  | "modelCatalogProviders"
-  | "commandAliases"
-  | "contracts";
-
 type ResolvePluginContributionOwnersParams = PluginRegistryContributionOptions & {
-  contribution: PluginRegistryContributionKey;
+  contribution: PluginMetadataContributionKey;
   matches: string | ((contributionId: string) => boolean);
 };
 
 type ListPluginContributionIdsParams = PluginRegistryContributionOptions & {
-  contribution: PluginRegistryContributionKey;
+  contribution: PluginMetadataContributionKey;
 };
 
 type ManifestContractLookupParams = LoadPluginRegistryParams & {
@@ -81,20 +75,6 @@ type ResolveManifestContractOwnerPluginIdParams = ManifestContractLookupParams &
 
 function normalizeContributionId(value: string): string {
   return value.trim();
-}
-
-function collectObjectKeys(value: Record<string, unknown> | undefined): readonly string[] {
-  return value ? Object.keys(value) : [];
-}
-
-function collectContractKeys(plugin: PluginManifestRecord): readonly string[] {
-  const contracts = plugin.contracts;
-  if (!contracts) {
-    return [];
-  }
-  return Object.entries(contracts).flatMap(([key, value]) =>
-    Array.isArray(value) && value.length > 0 ? [key] : [],
-  );
 }
 
 function listManifestContractValues(
@@ -142,34 +122,6 @@ function loadManifestContractRecords(
   }
   const pluginIds = new Set(params.onlyPluginIds);
   return records.filter((record) => pluginIds.has(record.id));
-}
-
-function listManifestContributionIds(
-  plugin: PluginManifestRecord,
-  contribution: PluginRegistryContributionKey,
-): readonly string[] {
-  switch (contribution) {
-    case "providers":
-      return plugin.providers;
-    case "channels":
-      return plugin.channels;
-    case "channelConfigs":
-      return collectObjectKeys(plugin.channelConfigs);
-    case "setupProviders":
-      return plugin.setup?.providers?.map((provider) => provider.id) ?? [];
-    case "cliBackends":
-      return [...plugin.cliBackends, ...(plugin.setup?.cliBackends ?? [])];
-    case "modelCatalogProviders":
-      return [
-        ...collectObjectKeys(plugin.modelCatalog?.providers),
-        ...collectObjectKeys(plugin.modelCatalog?.aliases),
-      ];
-    case "commandAliases":
-      return plugin.commandAliases?.map((alias) => alias.name) ?? [];
-    case "contracts":
-      return collectContractKeys(plugin);
-  }
-  return [];
 }
 
 function createContributionPluginFilter(
@@ -256,7 +208,7 @@ export function listPluginContributionIds(
   const index = params.lookUpTable?.index ?? loadPluginRegistrySnapshot(params);
   const plugins = listContributionManifestPlugins({ ...params, index });
   return normalizeSortedUniqueStringEntries(
-    plugins.flatMap((plugin) => listManifestContributionIds(plugin, params.contribution)),
+    plugins.flatMap((plugin) => listPluginManifestContributionIds(plugin, params.contribution)),
   );
 }
 
@@ -280,7 +232,9 @@ export function resolvePluginContributionOwners(
   const plugins = listContributionManifestPlugins({ ...params, index });
   return normalizeSortedUniqueStringEntries(
     plugins.flatMap((plugin) =>
-      listManifestContributionIds(plugin, params.contribution).some(matcher) ? [plugin.id] : [],
+      listPluginManifestContributionIds(plugin, params.contribution).some(matcher)
+        ? [plugin.id]
+        : [],
     ),
   );
 }

--- a/src/plugins/plugin-registry.test.ts
+++ b/src/plugins/plugin-registry.test.ts
@@ -82,6 +82,7 @@ function createCandidate(
   rootDir: string,
   pluginId = "demo",
   installOwner?: string,
+  manifestOverrides: Record<string, unknown> = {},
 ): PluginCandidate {
   fs.writeFileSync(
     path.join(rootDir, "index.ts"),
@@ -126,6 +127,7 @@ function createCandidate(
       configContracts: {
         compatibilityRuntimePaths: [`legacyProvider.${pluginId}-search.webhook`],
       },
+      ...manifestOverrides,
     }),
     "utf8",
   );
@@ -236,41 +238,17 @@ describe("plugin registry facade", () => {
       "demo-alias",
     ]);
     expect(resolveProviderOwners({ index, providerId: "demo" })).toEqual(["demo"]);
-    expect(
-      resolvePluginContributionOwners({
-        index,
-        contribution: "modelCatalogProviders",
-        matches: "demo-alias",
-      }),
-    ).toEqual(["demo"]);
-    expect(
-      resolvePluginContributionOwners({
-        index,
-        contribution: "channels",
-        matches: "demo-chat",
-      }),
-    ).toEqual(["demo"]);
-    expect(
-      resolvePluginContributionOwners({
-        index,
-        contribution: "cliBackends",
-        matches: "demo-cli",
-      }),
-    ).toEqual(["demo"]);
-    expect(
-      resolvePluginContributionOwners({
-        index,
-        contribution: "cliBackends",
-        matches: (contributionId) => contributionId === "demo-cli",
-      }),
-    ).toEqual(["demo"]);
-    expect(
-      resolvePluginContributionOwners({
-        index,
-        contribution: "setupProviders",
-        matches: "demo-setup",
-      }),
-    ).toEqual(["demo"]);
+    for (const [contribution, id] of [
+      ["modelCatalogProviders", "demo-alias"],
+      ["channels", "demo-chat"],
+      ["cliBackends", "demo-cli"],
+      ["setupProviders", "demo-setup"],
+      ["contracts", "tools"],
+    ] as const) {
+      for (const matches of [id, (contributionId: string) => contributionId === id]) {
+        expect(resolvePluginContributionOwners({ index, contribution, matches })).toEqual(["demo"]);
+      }
+    }
     expect(resolveManifestContractPluginIds({ index, contract: "webSearchProviders" })).toEqual([
       "demo",
     ]);
@@ -344,42 +322,65 @@ describe("plugin registry facade", () => {
     });
   });
 
-  it("resolves contribution owners from a plugin lookup table without rereading manifests", () => {
+  it("preserves raw declarations and indexed owners without rereading manifests", () => {
     const rootDir = makeTempDir();
-    const candidate = createCandidate(rootDir);
+    const candidate = createCandidate(rootDir, "demo", undefined, {
+      providers: [" Demo "],
+      cliBackends: [" DEMO-CLI ", "DEMO-CLI"],
+      setup: {
+        providers: [{ id: "demo-setup" }],
+        cliBackends: ["DEMO-CLI", "Other-CLI"],
+      },
+      providerAuthAliases: { " ALIAS ": " dEmO ", BAD: "absent" },
+      contracts: { tools: [], webSearchProviders: ["demo-search"] },
+    });
     const env = hermeticEnv();
     const index = loadPluginRegistrySnapshot({
       candidates: [candidate],
       env,
       preferPersisted: false,
     });
-    const lookUpTable = loadPluginLookUpTable({
-      config: {},
-      env,
-      index,
-    });
-    fs.unlinkSync(path.join(rootDir, "openclaw.plugin.json"));
-
-    expect(listPluginContributionIds({ lookUpTable, contribution: "providers" })).toEqual(["demo"]);
-    expect(resolveProviderOwners({ lookUpTable, providerId: "DEMO" })).toEqual(["demo"]);
-    for (const [contribution, matches] of [
-      ["providers", "demo"],
-      ["channels", "demo-chat"],
-      ["channelConfigs", "demo-chat"],
-      ["cliBackends", "demo-cli"],
-      ["cliBackends", "demo-setup-cli"],
-      ["setupProviders", "demo-setup"],
-      ["modelCatalogProviders", "demo-alias"],
-      ["commandAliases", "demo-command"],
-      ["contracts", "tools"],
-    ] as const) {
-      const query = { lookUpTable, contribution, matches };
-      expect(resolvePluginContributionOwners(query), contribution).toEqual(["demo"]);
-      expect(
-        resolvePluginContributionOwners({ ...query, matches: "missing" }),
-        contribution,
-      ).toEqual([]);
+    const lookUpTable = loadPluginLookUpTable({ config: {}, env, index });
+    for (const indexed of [false, true]) {
+      if (indexed) {
+        fs.unlinkSync(path.join(rootDir, "openclaw.plugin.json"));
+      }
+      const source = indexed ? { lookUpTable } : { index };
+      for (const [contribution, ids] of [
+        ["providers", ["Demo"]],
+        ["cliBackends", ["DEMO-CLI", "Other-CLI"]],
+        ["contracts", ["webSearchProviders"]],
+      ] as const) {
+        expect(listPluginContributionIds({ ...source, contribution })).toEqual(ids);
+      }
+      for (const [contribution, id, indexedOwner, rawOwner] of [
+        ["providers", "Demo", true, true],
+        ["providers", "demo", false, false],
+        ["providers", "alias", true, false],
+        ["providers", "ALIAS", false, false],
+        ["providers", "bad", false, false],
+        ["channels", "demo-chat", true, true],
+        ["channelConfigs", "demo-chat", true, true],
+        ["cliBackends", "demo-cli", true, false],
+        ["cliBackends", "DEMO-CLI", false, true],
+        ["cliBackends", "other-cli", true, false],
+        ["setupProviders", "demo-setup", true, true],
+        ["modelCatalogProviders", "demo-alias", true, true],
+        ["commandAliases", "demo-command", true, true],
+        ["contracts", "tools", false, false],
+        ["contracts", "webSearchProviders", true, true],
+      ] as const) {
+        const query = { ...source, contribution };
+        expect(resolvePluginContributionOwners({ ...query, matches: id })).toEqual(
+          (indexed ? indexedOwner : rawOwner) ? ["demo"] : [],
+        );
+        expect(
+          resolvePluginContributionOwners({ ...query, matches: (value) => value === id }),
+        ).toEqual(rawOwner ? ["demo"] : []);
+        expect(resolvePluginContributionOwners({ ...query, matches: "missing" })).toEqual([]);
+      }
     }
+    expect(resolveProviderOwners({ lookUpTable, providerId: "DEMO" })).toEqual(["demo"]);
 
     const policies: Array<[OpenClawConfig["plugins"], boolean]> = [
       [undefined, true],


### PR DESCRIPTION
## What Problem This Solves

Plugin manifest contributions are enumerated independently when building metadata indexes and when scanning registry records. Maintaining two field lists makes it easy for a contribution to appear in one lookup path but disappear from another.

## Why This Change Was Made

`src/plugins/plugin-metadata-contributions.ts` owns the eight contribution keys and their raw manifest projection. Snapshot assembly still owns CLI ID normalization and validated provider-auth aliases; registry predicates and listings retain raw declarations, existing filters, ordering, and deduplication. The new owner has only a type import, preserving the lightweight metadata boundary.

## User Impact

No intended behavior change. Existing public exports remain unchanged. Production shrinks by 28 lines; tests shrink by 40 through shared fixture setup while retaining existing cases and extending contract coverage.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/plugin-registry.test.ts src/plugins/plugin-metadata-snapshot.test.ts src/plugins/plugin-registry-contributions.current-snapshot.test.ts src/plugins/plugin-lookup-table.test.ts src/plugins/setup-registry.runtime.test.ts src/plugins/providers.test.ts`: **134 passed**.
- Cases explicitly distinguish raw `DEMO-CLI` from indexed `demo-cli`, raw provider IDs from validated auth aliases, invalid aliases, setup contributions, empty contracts, ordered owners, and no manifest reread for supplied lookup tables.
- Changed checks passed all type, guard, and dead-export stages; the one test callback-shadow lint finding was fixed and the owning lint command passed. The affected registry suite passed again: **20 tests**.
- CI exposed two existing Doctor repair cases that rebuild snapshots from sparse records. Both failed locally before correction; the shared selector now preserves the snapshot owner’s prior empty-array defaults, with no mock or test changes. All **162 tests** across Doctor and the six metadata suites pass.
- Final Codex autoreview was scoped-clean through P3, with zero accepted/actionable findings. `pnpm build` passed in **8m18.3s**, including plugin packaging, declaration and import checks, before the three-expression empty-array correction; that correction has the expanded focused proof above plus a passing `node scripts/check-changed.mjs -- src/plugins/plugin-metadata-contributions.ts` run, and changes no import topology.

No configuration, dependency, SDK export, or persistent-store semantic change is included. Sibling install/identity/skill-repair PRs #117416, #125414, and #131584 were inspected earlier in this campaign; their work is outside this projection change.
