### PR TITLE
improve(ui): render provider usage histories with less repeated work

### DIFF
--- a/ui/src/components/provider-usage.test.ts
+++ b/ui/src/components/provider-usage.test.ts
@@ -1,0 +1,156 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import { renderProviderUsageDetails } from "./provider-usage.ts";
+
+describe("renderProviderUsageDetails", () => {
+  it.each([
+    { unit: " usd ", amount: "$12.50", zero: "$0.00" },
+    { unit: "jPy", amount: "¥13", zero: "¥0" },
+    { unit: " Credits ", amount: "12.5  Credits ", zero: "0  Credits " },
+  ])(
+    "renders provider-reported cost history and attribution for $unit",
+    ({ unit, amount, zero }) => {
+      const container = document.createElement("div");
+      const today = new Date().toISOString().slice(0, 10);
+
+      render(
+        renderProviderUsageDetails({
+          provider: "openai",
+          displayName: "OpenAI",
+          plan: "Admin API",
+          windows: [],
+          costHistory: {
+            unit,
+            periodDays: 30,
+            daily: [
+              {
+                date: today,
+                amount: 12.5,
+                requests: 42,
+                inputTokens: 1_000,
+                cacheReadTokens: 400,
+                cacheWriteTokens: 0,
+                outputTokens: 250,
+                totalTokens: 1_250,
+              },
+              {
+                date: "2026-01-01",
+                amount: 0,
+                requests: 1,
+                inputTokens: 50,
+                cacheReadTokens: 0,
+                cacheWriteTokens: 0,
+                outputTokens: 10,
+                totalTokens: 60,
+              },
+            ],
+            models: [
+              {
+                name: "gpt-5.5",
+                requests: 42,
+                inputTokens: 1_000,
+                cacheReadTokens: 400,
+                cacheWriteTokens: 0,
+                outputTokens: 250,
+                totalTokens: 1_250,
+              },
+            ],
+            categories: [{ name: "Responses", amount: 12.5 }],
+          },
+        }),
+        container,
+      );
+
+      expect(container.textContent).toContain(amount);
+      expect(container.textContent).toContain("43 requests");
+      expect(container.textContent).toContain("gpt-5.5");
+      expect(container.textContent).toContain("Responses");
+      const bars = container.querySelectorAll<HTMLElement>(".provider-cost-chart span");
+      expect(bars).toHaveLength(2);
+      expect(bars?.[0]?.style.height).toBe("100%");
+      expect(bars?.[1]?.style.height).toBe("0%");
+      expect(Array.from(bars, (bar) => [bar.title, bar.getAttribute("aria-label")])).toEqual([
+        [`${today}: ${amount}`, `${today}: ${amount}`],
+        [`2026-01-01: ${zero}`, `2026-01-01: ${zero}`],
+      ]);
+      expect(container.querySelectorAll(".provider-cost-breakdown strong")[1]?.textContent).toBe(
+        amount,
+      );
+    },
+  );
+
+  it("preserves nonfinite chart maxima, signed amounts, and source-order cache totals", () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(new Date("2026-09-07T12:00:00Z"));
+      const container = document.createElement("div");
+      const today = new Date().toISOString().slice(0, 10);
+      const provider = {
+        provider: "openai",
+        displayName: "OpenAI",
+        windows: [],
+        costHistory: {
+          unit: "credits",
+          periodDays: 30,
+          daily: [
+            {
+              date: today,
+              amount: 2,
+              cacheReadTokens: 2 ** 53,
+              cacheWriteTokens: 0,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            {
+              date: today,
+              amount: Number.NaN,
+              cacheReadTokens: 1,
+              cacheWriteTokens: -(2 ** 53),
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            {
+              date: today,
+              amount: -0,
+              cacheReadTokens: 0,
+              cacheWriteTokens: 0,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+          ],
+          models: [],
+          categories: [],
+        },
+      };
+      const before = structuredClone(provider);
+      render(renderProviderUsageDetails(provider), container);
+
+      expect(
+        Array.from(container.querySelectorAll<HTMLElement>(".provider-cost-chart span"), (bar) => [
+          bar.style.height,
+          bar.title,
+          bar.getAttribute("aria-label"),
+        ]),
+      ).toEqual([
+        ["0%", `${today}: 2 credits`, `${today}: 2 credits`],
+        ["0%", `${today}: NaN credits`, `${today}: NaN credits`],
+        ["0%", `${today}: -0 credits`, `${today}: -0 credits`],
+      ]);
+      expect(
+        Array.from(
+          container.querySelectorAll(".provider-cost-window strong"),
+          (value) => value.textContent,
+        ),
+      ).toEqual(["NaN credits", "NaN credits", "NaN credits"]);
+      expect(container.querySelector(".provider-cost-tokens")?.textContent).toContain("0 cache");
+      expect(provider).toEqual(before);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/ui/src/components/provider-usage.ts
+++ b/ui/src/components/provider-usage.ts
@@ -7,16 +7,18 @@ import { t } from "../i18n/index.ts";
 import { formatUiExternalText } from "../lib/format-error.ts";
 import { formatCompactTokenCount } from "../lib/format.ts";
 
-function formatProviderAmount(amount: number, unit: string): string {
+function createProviderAmountFormatter(unit: string): (amount: number) => string {
   const normalizedUnit = unit.trim().toUpperCase();
   if (["USD", "EUR", "GBP", "CNY", "JPY"].includes(normalizedUnit)) {
-    return new Intl.NumberFormat(undefined, {
+    const formatter = new Intl.NumberFormat(undefined, {
       style: "currency",
       currency: normalizedUnit,
       maximumFractionDigits: normalizedUnit === "JPY" ? 0 : 2,
-    }).format(amount);
+    });
+    return (amount) => formatter.format(amount);
   }
-  return `${new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(amount)} ${unit}`;
+  const formatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 });
+  return (amount) => `${formatter.format(amount)} ${unit}`;
 }
 
 function formatProviderReset(resetAt: number | undefined): string | null {
@@ -40,10 +42,11 @@ function renderProviderBilling(snapshot: ProviderUsageSnapshot) {
         : entry.type === "spend"
           ? t("usage.providerUsage.spend")
           : t("usage.providerUsage.budget"));
+    const formatAmount = createProviderAmountFormatter(entry.unit);
     const value =
       entry.type === "budget"
-        ? `${formatProviderAmount(entry.used, entry.unit)} / ${formatProviderAmount(entry.limit, entry.unit)}`
-        : formatProviderAmount(entry.amount, entry.unit);
+        ? `${formatAmount(entry.used)} / ${formatAmount(entry.limit)}`
+        : formatAmount(entry.amount);
     return html`
       <div class="provider-usage-billing-row">
         <span>${label}</span>
@@ -72,27 +75,26 @@ function renderProviderCostHistory(snapshot: ProviderUsageSnapshot) {
   if (!history || history.daily.length === 0) {
     return nothing;
   }
-  const maxAmount = Math.max(...history.daily.map((day) => day.amount), 0);
-  const totals = history.daily.reduce(
-    (acc, day) => ({
-      requests: acc.requests + (day.requests ?? 0),
-      input: acc.input + day.inputTokens,
-      cache: acc.cache + day.cacheReadTokens + day.cacheWriteTokens,
-      output: acc.output + day.outputTokens,
-    }),
-    { requests: 0, input: 0, cache: 0, output: 0 },
-  );
+  let maxAmount = 0;
+  let periodAmount = 0;
+  const totals = { requests: 0, input: 0, cache: 0, output: 0 };
+  for (const day of history.daily) {
+    maxAmount = Math.max(maxAmount, day.amount);
+    periodAmount += day.amount;
+    totals.requests += day.requests ?? 0;
+    totals.input += day.inputTokens;
+    totals.cache = totals.cache + day.cacheReadTokens + day.cacheWriteTokens;
+    totals.output += day.outputTokens;
+  }
   const inputCount = formatCompactTokenCount(totals.input);
   const cacheCount = formatCompactTokenCount(totals.cache);
   const outputCount = formatCompactTokenCount(totals.output);
   const windows = [
     [t("usage.providerUsage.today"), providerHistoryAmount(snapshot, 1)],
     [t("usage.providerUsage.last7Days"), providerHistoryAmount(snapshot, 7)],
-    [
-      t("usage.providerUsage.lastDays", { count: String(history.periodDays) }),
-      history.daily.reduce((total, day) => total + day.amount, 0),
-    ],
+    [t("usage.providerUsage.lastDays", { count: String(history.periodDays) }), periodAmount],
   ] as const;
+  const formatAmount = createProviderAmountFormatter(history.unit);
 
   return html`
     <div class="provider-cost-history">
@@ -101,7 +103,7 @@ function renderProviderCostHistory(snapshot: ProviderUsageSnapshot) {
           ([label, amount]) => html`
             <div class="provider-cost-window">
               <span>${label}</span>
-              <strong>${formatProviderAmount(amount, history.unit)}</strong>
+              <strong>${formatAmount(amount)}</strong>
             </div>
           `,
         )}
@@ -110,10 +112,11 @@ function renderProviderCostHistory(snapshot: ProviderUsageSnapshot) {
         ${history.daily.map((day) => {
           const height =
             day.amount > 0 && maxAmount > 0 ? Math.max(3, (day.amount / maxAmount) * 100) : 0;
+          const label = `${day.date}: ${formatAmount(day.amount)}`;
           return html`<span
             style=${`height: ${height}%`}
-            title=${`${day.date}: ${formatProviderAmount(day.amount, history.unit)}`}
-            aria-label=${`${day.date}: ${formatProviderAmount(day.amount, history.unit)}`}
+            title=${label}
+            aria-label=${label}
           ></span>`;
         })}
       </div>
@@ -167,9 +170,7 @@ function renderProviderCostHistory(snapshot: ProviderUsageSnapshot) {
                             (category) => html`
                               <div>
                                 <span>${category.name}</span>
-                                <strong
-                                  >${formatProviderAmount(category.amount, history.unit)}</strong
-                                >
+                                <strong>${formatAmount(category.amount)}</strong>
                               </div>
                             `,
                           )}

--- a/ui/src/pages/usage/view.test.ts
+++ b/ui/src/pages/usage/view.test.ts
@@ -707,6 +707,8 @@ describe("renderUsage", () => {
                     limit: 20,
                     unit: "USD",
                   },
+                  { type: "budget", used: 12.5, limit: 20, unit: " jPy " },
+                  { type: "budget", used: 1.5, limit: 3, unit: " Credits " },
                 ],
               },
             ],
@@ -722,77 +724,12 @@ describe("renderUsage", () => {
     expect(card?.textContent).toContain("75% left");
     expect(card?.textContent).toContain("$64.50");
     expect(card?.textContent).toContain("$5.00 / $20.00");
-  });
-
-  it("renders provider-reported cost history and attribution", () => {
-    const container = document.createElement("div");
-
-    render(
-      renderUsage(
-        createUsageProps({
-          data: {
-            ...createUsageProps().data,
-            providerUsage: [
-              {
-                provider: "openai",
-                displayName: "OpenAI",
-                plan: "Admin API",
-                windows: [],
-                costHistory: {
-                  unit: "USD",
-                  periodDays: 30,
-                  daily: [
-                    {
-                      date: new Date().toISOString().slice(0, 10),
-                      amount: 12.5,
-                      requests: 42,
-                      inputTokens: 1_000,
-                      cacheReadTokens: 400,
-                      cacheWriteTokens: 0,
-                      outputTokens: 250,
-                      totalTokens: 1_250,
-                    },
-                    {
-                      date: "2026-01-01",
-                      amount: 0,
-                      requests: 1,
-                      inputTokens: 50,
-                      cacheReadTokens: 0,
-                      cacheWriteTokens: 0,
-                      outputTokens: 10,
-                      totalTokens: 60,
-                    },
-                  ],
-                  models: [
-                    {
-                      name: "gpt-5.5",
-                      requests: 42,
-                      inputTokens: 1_000,
-                      cacheReadTokens: 400,
-                      cacheWriteTokens: 0,
-                      outputTokens: 250,
-                      totalTokens: 1_250,
-                    },
-                  ],
-                  categories: [{ name: "Responses", amount: 12.5 }],
-                },
-              },
-            ],
-          },
-        }),
+    expect(
+      Array.from(
+        container.querySelectorAll(".provider-usage-billing-row strong"),
+        (value) => value.textContent,
       ),
-      container,
-    );
-
-    const card = container.querySelector(".provider-usage-card");
-    expect(card?.textContent).toContain("$12.50");
-    expect(card?.textContent).toContain("43 requests");
-    expect(card?.textContent).toContain("gpt-5.5");
-    expect(card?.textContent).toContain("Responses");
-    const bars = card?.querySelectorAll<HTMLElement>(".provider-cost-chart span");
-    expect(bars).toHaveLength(2);
-    expect(bars?.[0]?.style.height).toBe("100%");
-    expect(bars?.[1]?.style.height).toBe("0%");
+    ).toEqual(["$64.50", "$5.00 / $20.00", "¥13 / ¥20", "1.5  Credits  / 3  Credits "]);
   });
 
   it("filters visible sessions when an agent scope is selected", () => {


### PR DESCRIPTION
## What Problem This Solves

Provider usage cards do repeated formatting and history scans whenever the Usage dashboard or Models settings renders. A 30-day history constructs currency formatters for every displayed value, including the same chart label twice.

## Why This Change Was Made

Prepare one amount formatter for each billing row or nonempty history, reuse each chart label, and collect history totals and maximum in one pass. Keep this preparation local to the render so refreshed values and locale settings remain current. There is no cross-render cache.

Preserve raw unknown-unit spacing, JPY rounding, first-three attribution order, NaN/signed-zero behavior, left-to-right token summation and the two independent UTC date reads. Detailed history tests now live beside the shared component; Usage retains caller-level billing and visibility coverage. Production grows by one line; tests grow by 93 lines. No configuration, dependency, style, persistence or API changes.

## User Impact

The same provider usage details render with less repeated work on both pages. In the fixed local comparison, creating a new 30-day history DOM is 36–40% faster; updating an existing one is about 89–90% faster. These are Lit/jsdom composition measurements, not browser paint/FPS, network or Gateway latency claims.

## Evidence

All 136 tests across four complete component/page/format suites and all 20 selected normal checks passed. Independent P0–P2 review found no actionable findings. A separate audit reconciled complete numeric and browser outcomes.

Numeric proof uses the actual shared renderer plus Lit commit in jsdom, including new containers, unchanged renders, same-object mutation, replacement data, same-container reattachment, supported/raw currencies, multiple providers, billing-only and error controls. Fixed B0/C0/C1/B1 order retains 1,356 whole render operations (1,444 provider-detail invocations): 960 steady measurements, 240 warmups, 100 seeds and 56 literal control executions. Every corresponding full DOM surface matches, including attributes and text; all independent currency/arithmetic/date controls pass.

All paired medians below show percentage reduction and candidate-minus-baseline microseconds. Negative reduction means slower.

| Workload | Forward reduction / Δµs | Reverse reduction / Δµs |
| --- | ---: | ---: |
| 0-fresh | +11.20% / -16.792 | +3.33% / -4.542 |
| 0-unchanged | +10.12% / -0.146 | -6.15% / +0.082 |
| 0-mutated | +7.55% / -2.688 | -3.82% / +1.313 |
| 0-replacement | -12.47% / +2.500 | +1.35% / -0.271 |
| 0-remount | +3.02% / -0.042 | -32.24% / +0.417 |
| 1-fresh | +9.11% / -80.980 | +10.15% / -97.313 |
| 1-unchanged | +48.29% / -72.771 | +48.18% / -71.542 |
| 1-mutated | +43.15% / -68.167 | +43.19% / -67.875 |
| 1-replacement | +47.24% / -73.562 | +50.12% / -73.042 |
| 1-remount | +55.83% / -80.126 | +56.74% / -81.500 |
| 7-fresh | +27.61% / -312.083 | +10.69% / -110.978 |
| 7-unchanged | +76.07% / -233.208 | +74.67% / -225.979 |
| 7-mutated | +64.67% / -224.126 | +65.35% / -209.146 |
| 7-replacement | +69.41% / -227.729 | +66.40% / -211.938 |
| 7-remount | +75.38% / -223.000 | +75.43% / -233.667 |
| 30-fresh | +39.51% / -797.687 | +36.32% / -756.770 |
| 30-unchanged | +89.18% / -842.500 | +90.11% / -862.917 |
| 30-mutated | +86.56% / -796.416 | +89.99% / -905.855 |
| 30-replacement | +89.20% / -850.605 | +88.65% / -902.104 |
| 30-remount | +90.70% / -840.208 | +89.92% / -835.979 |
| 90-fresh | +51.35% / -2654.208 | +47.03% / -2424.749 |
| 90-unchanged | +94.80% / -2467.437 | +94.95% / -2491.104 |
| 90-mutated | +93.78% / -2476.729 | +93.54% / -2491.833 |
| 90-replacement | +95.03% / -2599.208 | +93.97% / -2545.958 |
| 90-remount | +94.75% / -2411.876 | +94.94% / -2490.313 |
| jpy-30 | +91.42% / -841.792 | +91.37% / -826.166 |
| raw-30 | +89.36% / -648.479 | +90.17% / -649.938 |
| multi-30 | +91.00% / -2395.146 | +90.16% / -2427.313 |
| billing-only | +5.71% / -4.437 | +8.44% / -6.562 |
| error-90 | +16.96% / -3.438 | +8.24% / -1.458 |

Fifty-six of 60 medians improve. All 19 adverse metrics out of 240 are retained: four medians, six means, two minima and seven maxima. The four adverse medians are empty-history controls; the largest absolute increase is 2.50 µs. Eight steady calls per row/process and one fixed cohort do not establish stable tail behavior. Same-container reattachment retains Lit’s existing root; it is not a fresh component lifetime.

Whole-process wall time falls 19.08%/19.89%; all ten retained CPU/RSS/wall comparisons improve, but these include imports, setup and capture and do not establish a general memory benefit. The full raw outputs, complete clock traces, every timing sample and resource observation remain retained.

Real Chromium with the repository’s source-server/mock-Gateway harness passed all 16 states: both actual pages, before and after Refresh, on baseline and candidate, with en-US and de-DE number formatting. Eight Refresh actions each produced a new `usage.status` request; no `config.patch` occurred. Full provider-card DOM matches across variants, and shared detail DOM matches between pages. All browser/process owners closed and candidate source was restored. This is browser integration proof with synthetic data, not an authenticated live provider test.

Two failed proof setups remain preserved separately: the first numeric baseline warmup incorrectly counted jsdom’s inert-document Date read as a provider clock; the first browser baseline reached seven states before its English Refresh selector met a legitimately German UI. The corrected observer retains provider/framework clock calls separately inside the same full-render timer; the corrected browser fixture uses the existing explicit server UI-language preference while leaving Intl locale varied. No production change, relaxed assertion, increased timeout or favorable timing rerun was used to resolve either issue.

Synthetic before/after captures below show unchanged presentation for Usage and refreshed Models details. They contain no real account data or credentials.

![Before: Usage history with synthetic data](https://github.com/user-attachments/assets/3d9a1a2d-dd77-42bf-b3c3-ca00f34879cb)

![After: Same Usage history with synthetic data](https://github.com/user-attachments/assets/a077f661-12a7-4373-961c-d71ee5d36404)

![Before: Refreshed Models history with German number formatting](https://github.com/user-attachments/assets/0baedde8-90f1-4b79-b87d-8fe527032a43)

![After: Same refreshed Models history with German number formatting](https://github.com/user-attachments/assets/d699721c-5ddf-407b-aa9c-5f62845baaff)