### PR TITLE
refactor(whatsapp): share prompt selection

### DIFF
--- a/extensions/whatsapp/src/system-prompt.test.ts
+++ b/extensions/whatsapp/src/system-prompt.test.ts
@@ -164,4 +164,21 @@ describe("resolveWhatsAppSystemPrompt", () => {
       ).toBe("wildcard prompt");
     },
   );
+
+  it.each(promptSurfaceCases)(
+    "falls back to wildcard when specific $name systemPrompt is null",
+    (surface) => {
+      expect(
+        surface.resolve(
+          createParams(
+            surface,
+            createAccountConfig(surface, {
+              [surface.targetId]: { systemPrompt: null },
+              "*": { systemPrompt: "wildcard prompt" },
+            }),
+          ),
+        ),
+      ).toBe("wildcard prompt");
+    },
+  );
 });

--- a/extensions/whatsapp/src/system-prompt.ts
+++ b/extensions/whatsapp/src/system-prompt.ts
@@ -1,32 +1,25 @@
 // Whatsapp plugin module implements system prompt behavior.
+function resolveWhatsAppSystemPrompt(
+  prompts: Record<string, { systemPrompt?: string | null }> | undefined,
+  targetId: string | null | undefined,
+): string | undefined {
+  if (!targetId) {
+    return undefined;
+  }
+  const selected = prompts?.[targetId]?.systemPrompt ?? prompts?.["*"]?.systemPrompt;
+  return selected?.trim() || undefined;
+}
+
 export function resolveWhatsAppGroupSystemPrompt(params: {
   accountConfig?: { groups?: Record<string, { systemPrompt?: string | null }> } | null;
   groupId?: string | null;
 }): string | undefined {
-  if (!params.groupId) {
-    return undefined;
-  }
-  const groups = params.accountConfig?.groups;
-  const specific = groups?.[params.groupId];
-  if (specific != null && specific.systemPrompt != null) {
-    return specific.systemPrompt.trim() || undefined;
-  }
-  const wildcard = groups?.["*"]?.systemPrompt;
-  return wildcard != null ? wildcard.trim() || undefined : undefined;
+  return resolveWhatsAppSystemPrompt(params.accountConfig?.groups, params.groupId);
 }
 
 export function resolveWhatsAppDirectSystemPrompt(params: {
   accountConfig?: { direct?: Record<string, { systemPrompt?: string | null }> } | null;
   peerId?: string | null;
 }): string | undefined {
-  if (!params.peerId) {
-    return undefined;
-  }
-  const direct = params.accountConfig?.direct;
-  const specific = direct?.[params.peerId];
-  if (specific != null && specific.systemPrompt != null) {
-    return specific.systemPrompt.trim() || undefined;
-  }
-  const wildcard = direct?.["*"]?.systemPrompt;
-  return wildcard != null ? wildcard.trim() || undefined : undefined;
+  return resolveWhatsAppSystemPrompt(params.accountConfig?.direct, params.peerId);
 }


### PR DESCRIPTION
## What Problem This Solves

WhatsApp group and direct prompt resolution maintained two copies of the same target-specific and wildcard selection logic. Keeping them separate made the empty-string suppression and null fallback contract easier to drift.

## Why This Change Was Made

Both exported resolvers now delegate to one private selector. It selects the specific prompt with nullish fallback to the wildcard, then trims the selected value, preserving explicit empty or whitespace-only suppression. Public exports and message processing remain unchanged.

## User Impact

No intended user-visible behavior change. WhatsApp group and direct system prompts keep their existing precedence and trimming behavior with one canonical implementation.

## Evidence

- focused owner and process-message tests: 30 passed
- `pnpm test:extension whatsapp`: 1,406 tests passed across 103 files
- changed gate passed through formatting, contract tests, and plugin boundaries; local extension typecheck stopped at the expected linked-worktree compiler-symlink guard, so exact-head CI/Testbox provides physical-checkout type proof
- `git diff --check`
- scoped autoreview: clean, no P0/P1 findings
