### PR TITLE
fix(telegram): show compaction progress in partial and block previews

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -380,7 +380,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `streaming.progress.commentary` (default: `false`) opts into assistant commentary/preamble text in the temporary progress draft
     - legacy `channels.telegram.streamMode`, boolean `streaming` values, and retired native draft preview keys are detected; run `openclaw doctor --fix` to migrate them
 
-    Tool-progress lines are the short status updates shown while tools run (command execution, file reads, planning updates, patch summaries, Codex preamble/commentary in app-server mode). `partial` and `block` previews show them by default; the `progress` draft shows them only with `streaming.progress.toolProgress: true`.
+    Tool-progress lines are the short status updates shown while tools run (command execution, file reads, planning updates, patch summaries, Codex preamble/commentary in app-server mode). `partial` and `block` previews show them by default; the `progress` draft shows them only with `streaming.progress.toolProgress: true`. Compaction status follows the same settings and appears as soon as compaction starts, including before the first model output.
 
     Keep answer-preview edits but hide tool-progress lines:
 

--- a/extensions/telegram/src/bot-message-dispatch-progress.ts
+++ b/extensions/telegram/src/bot-message-dispatch-progress.ts
@@ -135,7 +135,6 @@ export function canPushToolProgress(turn: Turn): boolean {
 
 function canPushCompactionProgress(turn: Turn): boolean {
   return Boolean(
-    turn.streamMode === "progress" &&
     turn.answerLane.stream &&
     !turn.answerLane.finalized &&
     !turn.finalAnswerDeliveryStarted &&

--- a/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
@@ -434,69 +434,89 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
-  it("shows compaction progress on the same answer stream", async () => {
-    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    const compactionFlushCounts: number[] = [];
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ dispatcherOptions, replyOptions }) => {
-        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-        answerDraftStream.flush.mockClear();
+  it.each(["progress", "partial", "block"] as const)(
+    "shows compaction progress before model output in %s mode",
+    async (streamMode) => {
+      const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+      const compactionPreviews: unknown[] = [];
+      const compactionFlushCounts: number[] = [];
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+        async ({ dispatcherOptions, replyOptions }) => {
+          answerDraftStream.flush.mockClear();
+          await replyOptions?.onCompactionStart?.();
+          compactionFlushCounts.push(answerDraftStream.flush.mock.calls.length);
+          compactionPreviews.push(answerDraftStream.updatePreview.mock.lastCall?.[0]);
+          await replyOptions?.onCompactionEnd?.({ completed: false });
+          compactionFlushCounts.push(answerDraftStream.flush.mock.calls.length);
+          compactionPreviews.push(answerDraftStream.updatePreview.mock.lastCall?.[0]);
+          await replyOptions?.onCompactionStart?.();
+          compactionFlushCounts.push(answerDraftStream.flush.mock.calls.length);
+          compactionPreviews.push(answerDraftStream.updatePreview.mock.lastCall?.[0]);
+          await replyOptions?.onCompactionEnd?.({ completed: true });
+          compactionFlushCounts.push(answerDraftStream.flush.mock.calls.length);
+          compactionPreviews.push(answerDraftStream.updatePreview.mock.lastCall?.[0]);
+          await replyOptions?.onPartialReply?.({ text: "Partial before compaction" });
+          await dispatcherOptions.deliver({ text: "Final after compaction" }, { kind: "final" });
+          return { queuedFinal: true };
+        },
+      );
+
+      await dispatchWithContext({
+        context: createContext(),
+        streamMode,
+        telegramCfg: { streaming: { mode: streamMode, progress: { toolProgress: true } } },
+      });
+
+      expect(compactionPreviews).toEqual(
+        [
+          "Compacting context",
+          "Compaction incomplete",
+          "Compacting context",
+          "Compaction complete",
+        ].map((text) =>
+          expect.objectContaining({ text: expect.stringContaining(text), complete: true }),
+        ),
+      );
+      if (streamMode === "progress") {
+        expect(answerDraftStream.forceNewMessage).not.toHaveBeenCalled();
+        expect(compactionFlushCounts).toEqual([1, 2, 3, 4]);
+        expectDeliveredReply(0, { text: "Final after compaction" });
+        expect(
+          requireInvocationOrder(answerDraftStream.discard, 0, "compaction progress discard"),
+        ).toBeLessThan(requireInvocationOrder(deliverReplies, 0, "final reply delivery"));
+        expectWindowRetiredAfterFinal(answerDraftStream, deliverReplies);
+      } else {
+        expect(answerDraftStream.update).toHaveBeenCalledWith(
+          "Final after compaction",
+          expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
+        );
+        expect(deliverReplies).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it.each(["partial", "block", "off"] as const)(
+    "keeps compaction reactions when preview progress is disabled in %s mode",
+    async (streamMode) => {
+      const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+      const statusReactionController = createStatusReactionController();
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
         await replyOptions?.onCompactionStart?.();
-        compactionFlushCounts.push(answerDraftStream.flush.mock.calls.length);
-        await replyOptions?.onCompactionEnd?.({ completed: false });
-        compactionFlushCounts.push(answerDraftStream.flush.mock.calls.length);
-        await replyOptions?.onCompactionStart?.();
-        compactionFlushCounts.push(answerDraftStream.flush.mock.calls.length);
         await replyOptions?.onCompactionEnd?.({ completed: true });
-        compactionFlushCounts.push(answerDraftStream.flush.mock.calls.length);
-        await replyOptions?.onPartialReply?.({ text: "Partial before compaction" });
-        await dispatcherOptions.deliver({ text: "Final after compaction" }, { kind: "final" });
         return { queuedFinal: true };
-      },
-    );
+      });
 
-    await dispatchWithContext({
-      context: createContext(),
-      streamMode: "progress",
-      telegramCfg: { streaming: { mode: "progress", progress: { toolProgress: true } } },
-    });
+      await dispatchWithContext({
+        context: createContext({ statusReactionController: statusReactionController as never }),
+        streamMode,
+        telegramCfg: { streaming: { mode: streamMode, preview: { toolProgress: false } } },
+      });
 
-    expect(answerDraftStream.forceNewMessage).not.toHaveBeenCalled();
-    expect(compactionFlushCounts).toEqual([1, 2, 3, 4]);
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringContaining("Compacting context") }),
-    );
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringContaining("Compaction incomplete") }),
-    );
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringContaining("Compaction complete") }),
-    );
-    expectDeliveredReply(0, { text: "Final after compaction" });
-    expect(
-      requireInvocationOrder(answerDraftStream.discard, 0, "compaction progress discard"),
-    ).toBeLessThan(requireInvocationOrder(deliverReplies, 0, "final reply delivery"));
-    expectWindowRetiredAfterFinal(answerDraftStream, deliverReplies);
-  });
-
-  it("keeps compaction reactions without rendering a draft outside progress mode", async () => {
-    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    const statusReactionController = createStatusReactionController();
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
-      await replyOptions?.onCompactionStart?.();
-      await replyOptions?.onCompactionEnd?.({ completed: true });
-      return { queuedFinal: true };
-    });
-
-    await dispatchWithContext({
-      context: createContext({ statusReactionController: statusReactionController as never }),
-      streamMode: "partial",
-    });
-
-    expect(answerDraftStream.updatePreview).not.toHaveBeenCalled();
-    expect(statusReactionController.setCompacting).toHaveBeenCalledTimes(1);
-    expect(statusReactionController.cancelPending).toHaveBeenCalledTimes(1);
-  });
+      expect(answerDraftStream.updatePreview).not.toHaveBeenCalled();
+      expect(statusReactionController.setCompacting).toHaveBeenCalledTimes(1);
+      expect(statusReactionController.cancelPending).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("rotates a tool-progress-only answer draft before streaming the final answer", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });


### PR DESCRIPTION
## Summary

### High Level TLDR

Telegram could look idle during a long automatic compaction when answer previews used `partial` or `block` mode. Show the existing compaction status in those previews, respecting `streaming.preview.toolProgress`.

Related: #134826

## What Problem This Solves

Fixes an issue where users waiting for a reply would see no compaction progress in `partial` or `block` preview mode, even with preview tool progress enabled. A reported turn spent 111.42 seconds in Claude CLI automatic compaction before responding.

## Why This Change Was Made

Remove the Telegram-only `progress` mode restriction. The existing compositor already owns preview enablement and rendering; existing final-delivery guards still prevent late progress from changing a finished answer.

### Root Cause

The restriction was introduced by #134826 (`b7fa0f52c6a9`) and remains on upstream main at `701687f6b7104dca7ba990a2557c840206af8ee8`. `canPushCompactionProgress` rejected every `partial` and `block` turn before the compositor could honor the preview setting.

Read-only incident correlation separated transport and provider work: CLI execution began within 0.5 seconds of Telegram ingress; the native transcript records automatic compaction from 238,431 to 30,191 tokens in 111,420 ms. The first Telegram response followed after compaction. The applied #138984 session-rewrite overlay does not change this Telegram gate or Claude's native compaction; the resumed CLI turn did not reseed OpenClaw history.

## User Impact

Users with preview tool progress enabled see “Compacting context...” before model output, followed by completion or incomplete status. Disabled preview progress remains quiet, reactions still work, ambient room events remain invisible, and final answers retain their existing delivery behavior. This fixes the unexplained silence; it does not reduce native Claude compaction time.

## Verification

### Evidence / Real behavior proof

The Telegram dispatch regression exercises compaction before any assistant or tool output, including an incomplete attempt followed by successful compaction. It covers `progress`, `partial`, and `block`, plus disabled previews and streaming off.

```sh
node scripts/run-vitest.mjs \
  extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts \
  extensions/telegram/src/bot-message-dispatch.status-reactions.test.ts \
  extensions/telegram/src/bot-message-dispatch.reasoning-room-events.test.ts
```

- Baseline: the two new preview-mode regression cases fail because no compaction preview is produced.
- Patched: 49 tests pass across three files on Node 24.15.0. Preview statuses are available before model output; partial/block finals update the existing answer stream, and progress-mode final delivery remains intact.
- `pnpm build`: passed.
- `node scripts/check-changed.mjs`: passed after relocating the worktree.
- Local review: verified setting precedence, disabled previews, final-delivery guards, and room-event suppression. Independent agent review was not run because delegation is disabled.

A local rendering benchmark on Linux x64 / Node 24.15.0 used 20 warmups and 100 fresh partial-preview turns per version. Baseline produced 0/100 compaction previews; patched produced 100/100. Handler duration median/p95 was 0.00057/0.00164 ms before and 0.01196/0.01901 ms after. Whole-process RSS was approximately 1,094/940 MiB; imports dominate these separate processes, so this is not a retained-heap comparison. No Telegram or provider latency is included in those measurements.

### What was not tested

A real Telegram Test Server run was blocked by the canonical doctor: `Telegram Test Server bot is not an active member of the test group.` Rechecked after marking this PR ready: Test Bot API `getChatMember` returns HTTP 200 / `ok: true` / status `left` for the leased bot, and TDLib reports `chatMemberStatusLeft` for the QA user. The leases were released and their temporary credential state cleaned up. The QA group membership must be restored before completing the required live preview-to-final-answer proof in partial and block modes. ClawSweeper reviewed this head again and found no actionable patch defect; its remaining blocker is that live proof. The operator Gateway was not changed or restarted. No claim is made that the native compaction itself becomes faster.

The first changed-check attempt was blocked by an ancestor `node_modules` symlink that resolved declaration metadata outside the worktree. The task checkout was moved outside that hierarchy and the canonical check was rerun without weakening the guard.
