### PR TITLE
refactor(link-understanding): drop unused results

### DIFF
--- a/src/link-understanding/apply.ts
+++ b/src/link-understanding/apply.ts
@@ -5,33 +5,26 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatLinkUnderstandingBody } from "./format.js";
 import { runLinkUnderstanding } from "./runner.js";
 
-type ApplyLinkUnderstandingResult = {
-  outputs: string[];
-  urls: string[];
-};
-
 /** Runs link understanding and folds successful outputs into the inbound context. */
 export async function applyLinkUnderstanding(params: {
   ctx: MsgContext;
   cfg: OpenClawConfig;
   signal?: AbortSignal;
-}): Promise<ApplyLinkUnderstandingResult> {
-  const result = await runLinkUnderstanding({
+}): Promise<void> {
+  const outputs = await runLinkUnderstanding({
     cfg: params.cfg,
     ctx: params.ctx,
     signal: params.signal,
   });
 
-  if (result.outputs.length === 0 || params.signal?.aborted) {
-    return result;
+  if (outputs.length === 0 || params.signal?.aborted) {
+    return;
   }
 
-  params.ctx.LinkUnderstanding = [...(params.ctx.LinkUnderstanding ?? []), ...result.outputs];
-  const enrich = (body?: string) => formatLinkUnderstandingBody({ body, outputs: result.outputs });
+  params.ctx.LinkUnderstanding = [...(params.ctx.LinkUnderstanding ?? []), ...outputs];
+  const enrich = (body?: string) => formatLinkUnderstandingBody({ body, outputs });
   // Preserve channel/media preparation independently from the transport body.
   params.ctx.agentText = enrich(params.ctx.agentText ?? params.ctx.BodyForAgent ?? params.ctx.Body);
   params.ctx.Body = enrich(params.ctx.Body);
   finalizeInboundContext(params.ctx, { forceBodyForCommands: true });
-
-  return result;
 }

--- a/src/link-understanding/runner.test.ts
+++ b/src/link-understanding/runner.test.ts
@@ -101,7 +101,7 @@ describe("runLinkUnderstanding", () => {
       } as MsgContext,
     });
 
-    expect(result).toEqual({ urls: [], outputs: [] });
+    expect(result).toEqual([]);
     expect(fetchWithSsrFGuard).not.toHaveBeenCalled();
     expect(runCommandWithTimeout).not.toHaveBeenCalled();
   });
@@ -117,7 +117,7 @@ describe("runLinkUnderstanding", () => {
       signal: controller.signal,
     });
 
-    expect(result.outputs).toEqual(["summarized page"]);
+    expect(result).toEqual(["summarized page"]);
     expect(fetchWithSsrFGuard).toHaveBeenCalledWith(
       expect.objectContaining({
         auditContext: "link-understanding",
@@ -190,12 +190,11 @@ describe("runLinkUnderstanding", () => {
     };
     const before = structuredClone(context);
 
-    const result = await applyLinkUnderstanding({
+    await applyLinkUnderstanding({
       cfg: cfg({ type: "cli", command: "summarize" }),
       ctx: context,
     });
 
-    expect(result.outputs).toEqual([]);
     expect(context).toEqual(before);
     expect(runCommandWithTimeout).not.toHaveBeenCalled();
   });
@@ -212,7 +211,7 @@ describe("runLinkUnderstanding", () => {
       ctx: ctx("see http://192.168.1.64.nip.io:8888/aws-iam-credentials"),
     });
 
-    expect(result.outputs).toEqual(["guarded page body"]);
+    expect(result).toEqual(["guarded page body"]);
     expect(fetchWithSsrFGuard).toHaveBeenCalledOnce();
     expect(runCommandWithTimeout).not.toHaveBeenCalled();
   });
@@ -236,7 +235,7 @@ describe("runLinkUnderstanding", () => {
       ctx: ctx(`see ${url}`),
     });
 
-    expect(result.outputs).toEqual([]);
+    expect(result).toEqual([]);
     expect(runCommandWithTimeout).not.toHaveBeenCalled();
   });
 
@@ -287,7 +286,7 @@ describe("runLinkUnderstanding", () => {
         cfg: cfg({ type: "cli", command: "summarize" }),
         signal: controller.signal,
       }),
-    ).resolves.toEqual({ urls: ["https://example.com/page"], outputs: [] });
+    ).resolves.toBeUndefined();
 
     expect(fetchWithSsrFGuard).not.toHaveBeenCalled();
     expect(runCommandWithTimeout).not.toHaveBeenCalled();
@@ -312,7 +311,7 @@ describe("runLinkUnderstanding", () => {
       signal: controller.signal,
     });
 
-    expect(result.outputs).toEqual(["second summary"]);
+    expect(result).toEqual(["second summary"]);
     for (const [index, command] of ["summarize-a", "summarize-b"].entries()) {
       expect(runCommandWithTimeout).toHaveBeenNthCalledWith(
         index + 1,

--- a/src/link-understanding/runner.transport.test.ts
+++ b/src/link-understanding/runner.transport.test.ts
@@ -153,7 +153,7 @@ describe("runLinkUnderstanding transport cleanup", () => {
       });
 
       const result = await within(resultPromise, 1000, "link understanding did not finish");
-      expect(result).toEqual({ urls: [url], outputs: [] });
+      expect(result).toEqual([]);
       await within(requestSocketClosed.promise, 1000, "loopback socket stayed open");
 
       expect(mocks.bodyCancel).toHaveBeenCalledOnce();
@@ -214,12 +214,11 @@ it("skips a timed-out streaming link and processes the next link", async () => {
     },
     async (base) => {
       const ctx: MsgContext = { Body: `${base}/slow ${base}/good` };
-      const result = await applyLinkUnderstanding({
+      await applyLinkUnderstanding({
         cfg: config(["-e", "process.stdin.pipe(process.stdout)"], 0.5),
         ctx,
         signal: new AbortController().signal,
       });
-      expect(result.outputs).toEqual(["complete page"]);
       expect(ctx.LinkUnderstanding).toEqual(["complete page"]);
     },
   );
@@ -247,16 +246,12 @@ it("fetches only bare URLs from messages that also contain titled markdown links
         ].join(" "),
       };
 
-      const result = await applyLinkUnderstanding({
+      await applyLinkUnderstanding({
         cfg: config(["-e", "process.stdin.pipe(process.stdout)"]),
         ctx,
       });
 
       expect(requests).toEqual(["/bare-one", "/bare-two"]);
-      expect(result).toEqual({
-        urls: [firstBare, secondBare],
-        outputs: ["/bare-one", "/bare-two"],
-      });
       expect(ctx.LinkUnderstanding).toEqual(["/bare-one", "/bare-two"]);
     },
   );

--- a/src/link-understanding/runner.ts
+++ b/src/link-understanding/runner.ts
@@ -13,11 +13,6 @@ import { runCommandWithTimeout } from "../process/exec.js";
 import { DEFAULT_LINK_TIMEOUT_SECONDS } from "./defaults.js";
 import { extractLinksFromMessage } from "./detect.js";
 
-type LinkUnderstandingResult = {
-  urls: string[];
-  outputs: string[];
-};
-
 function resolveTimeoutMsFromConfig(params: {
   config?: LinkToolsConfig;
   entry: LinkModelConfig;
@@ -207,17 +202,16 @@ async function runLinkEntries(params: {
 
 /**
  * Fetches detected links through the SSRF guard and runs configured CLI processors.
- * Returns detected URLs even when processors are absent so callers can report discovery.
  */
 export async function runLinkUnderstanding(params: {
   cfg: OpenClawConfig;
   ctx: MsgContext;
   message?: string;
   signal?: AbortSignal;
-}): Promise<LinkUnderstandingResult> {
+}): Promise<string[]> {
   const config = params.cfg.tools?.links;
   if (!config || config.enabled === false) {
-    return { urls: [], outputs: [] };
+    return [];
   }
 
   const scopeDecision = resolveScopeDecision({ scope: config.scope, ctx: params.ctx });
@@ -225,18 +219,18 @@ export async function runLinkUnderstanding(params: {
     if (shouldLogVerbose()) {
       logVerbose("Link understanding disabled by scope policy.");
     }
-    return { urls: [], outputs: [] };
+    return [];
   }
 
   const message = params.message ?? params.ctx.CommandBody ?? params.ctx.RawBody ?? params.ctx.Body;
   const links = extractLinksFromMessage(message ?? "", { maxLinks: config?.maxLinks });
   if (links.length === 0) {
-    return { urls: [], outputs: [] };
+    return [];
   }
 
   const entries = config?.models ?? [];
   if (entries.length === 0) {
-    return { urls: links, outputs: [] };
+    return [];
   }
 
   const outputs: string[] = [];
@@ -281,5 +275,5 @@ export async function runLinkUnderstanding(params: {
     }
   }
 
-  return { urls: links, outputs };
+  return outputs;
 }


### PR DESCRIPTION
## What Problem This Solves

Link preprocessing carries detected-URL metadata and an apply result that no production caller uses. This maintainer-requested cleanup removes that unused result flow while retaining the fetched summaries and inbound-context effects.

## Why This Change Was Made

Return the runner's existing output array directly and make the apply step return void. Update only assertions for those private return shapes. Keep URL discovery before the no-model check, the lazy runtime entrypoint, all imports, strict SSRF handling, ordered processor fallback, cancellation and transport cleanup unchanged.

Production LOC: +12/-25 (net -13). Tests: +10/-16 (net -6), across four files. No config, dependency, package export, schema or public API changes.

## User Impact

No intended user-visible change. Successful summaries still enrich the same message fields in the same order. Empty output and pre-aborted work still leave context untouched; cancellation and ordinary failure retain their existing reply behavior.

## Evidence

- Reviewed signed head: `89943fd30524073d679f0077a7e55418280b0e83`.
- All four implemented file blobs match the independently reviewed plan. The runner helpers and processing loop remain byte-identical to the base.
- Oxfmt 0.65.0 checked all four files successfully; `git diff --check` and privacy checks passed.
- Fresh whole-candidate P3 review completed with no findings. Review, stdout capture and launcher exited 0. Independent actual-head review approved publication.
- Runtime tests, relevant types/lint, candidate-bound build/artifacts and attached CI are pending; no runtime or build pass is claimed.
- Before merge, require every case in `src/link-understanding/runner.test.ts`, `src/link-understanding/runner.transport.test.ts`, `src/link-understanding/detect.test.ts`, `src/auto-reply/reply/get-reply.message-hooks.test.ts`, and `test/scripts/tsdown-runtime-config.test.ts`. Retain real HTTP body/socket cancellation, sequential URL handling, context and descendant-process cleanup proof.
- Require relevant production/test types and lint, actual build/artifact provenance and preserved lazy-entry loading, all required CI checks, and an exact-head ClawSweeper review with no actionable findings or remaining rank-up moves.
