### PR TITLE
fix(ci): dashboard gallery tests fail when previews load

### DIFF
--- a/ui/src/pages/dashboards/dashboards-page.test.ts
+++ b/ui/src/pages/dashboards/dashboards-page.test.ts
@@ -1,12 +1,19 @@
 /* @vitest-environment jsdom */
 
+import type { BoardGetParams, BoardSnapshot } from "@openclaw/gateway-protocol";
+import type { LitElement } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SIDEBAR_SESSION_ROSTER_LIMIT } from "../../../../src/shared/session-list-limits.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import {
+  DASHBOARD_DOCUMENT_ELEMENT,
+  ensureCustomElementDefined,
+} from "../../app/lazy-custom-element.ts";
 import { i18n } from "../../i18n/index.ts";
 import type { SessionListOptions, SessionListSnapshot } from "../../lib/sessions/index.ts";
 import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
 import { settleLitElement } from "../../test-helpers/lit-settle.ts";
 import type { DashboardsRouteData } from "./view.ts";
 import "./dashboards-page.ts";
@@ -56,9 +63,61 @@ function routeData(sessionRow: GatewaySessionRow): DashboardsRouteData {
   };
 }
 
+function createDashboardClient() {
+  return createTestGatewayClient(async (method, params) => {
+    if (method !== "board.get") {
+      throw new Error(`Unexpected Gateway method: ${method}`);
+    }
+    const { sessionKey } = params as BoardGetParams;
+    return { sessionKey, revision: 1, tabs: [], widgets: [] } satisfies BoardSnapshot;
+  });
+}
+
+function controlPreviewFrames(): () => void {
+  const frames = new Map<number, FrameRequestCallback>();
+  let nextFrameId = 0;
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    const id = ++nextFrameId;
+    frames.set(id, callback);
+    return id;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id) => {
+    frames.delete(id);
+  });
+  return () => {
+    const pendingFrameIds = [...frames.keys()];
+    for (const id of pendingFrameIds) {
+      const callback = frames.get(id);
+      frames.delete(id);
+      callback?.(0);
+    }
+  };
+}
+
+async function settleDashboardPreviews(element: DashboardsPageElement, runFrame: () => void) {
+  await settleLitElement(element);
+  runFrame();
+  const previews = element.querySelectorAll<LitElement>("openclaw-dashboard-preview");
+  expect(previews.length).toBeGreaterThan(0);
+  for (const preview of previews) {
+    await settleLitElement(preview);
+    const board = preview.querySelector<LitElement>("openclaw-board-document")!;
+    expect(board).not.toBeNull();
+    await settleLitElement(board);
+    const view = board.querySelector<LitElement>("openclaw-board-view")!;
+    expect(view, board.textContent ?? "").not.toBeNull();
+    await settleLitElement(view);
+    expect(view.querySelector('[data-test-id="board-empty"]')).not.toBeNull();
+  }
+}
+
 describe("DashboardsPage", () => {
   beforeEach(async () => {
     await i18n.setLocale("en");
+    await ensureCustomElementDefined(
+      DASHBOARD_DOCUMENT_ELEMENT.tagName,
+      DASHBOARD_DOCUMENT_ELEMENT.loadModule,
+    );
   });
 
   afterEach(() => {
@@ -67,6 +126,7 @@ describe("DashboardsPage", () => {
   });
 
   it("subscribes to the exact query and preserves rows while a new agent scope loads", async () => {
+    const runFrame = controlPreviewFrames();
     const selectionListeners = new Set<() => void>();
     const listListeners = new Map<string, (snapshot: SessionListSnapshot) => void>();
     const snapshots = new Map<string, SessionListSnapshot>();
@@ -86,7 +146,7 @@ describe("DashboardsPage", () => {
     const context = {
       basePath: "",
       gateway: {
-        snapshot: { client: {}, phase: "connected", hello: null },
+        snapshot: { client: createDashboardClient(), phase: "connected", hello: null },
         subscribe: () => () => undefined,
       },
       sessions: {
@@ -138,6 +198,7 @@ describe("DashboardsPage", () => {
       error: null,
     });
     await vi.waitFor(() => expect(element.textContent).toContain("Writer dashboard"));
+    await settleDashboardPreviews(element, runFrame);
     retiredListener({
       result: result(row("agent:main:retired", "Retired")),
       agentId: null,
@@ -165,6 +226,7 @@ describe("DashboardsPage", () => {
       error: null,
     });
     await element.updateComplete;
+    await settleDashboardPreviews(element, runFrame);
     expect(element.textContent).toContain("Recovered dashboard");
     expect(element.querySelector('[role="alert"]')).toBeNull();
 
@@ -182,6 +244,7 @@ describe("DashboardsPage", () => {
   it.each([false, true])(
     "loads every dashboard page unless its connection is retired (retired: %s)",
     async (retired) => {
+      const runFrame = controlPreviewFrames();
       const first = {
         ...results([row("agent:main:new", "New dashboard")]),
         totalCount: 2,
@@ -206,7 +269,7 @@ describe("DashboardsPage", () => {
       const context = {
         basePath: "",
         gateway: {
-          snapshot: { client: {}, phase: "connected", hello: null },
+          snapshot: { client: createDashboardClient(), phase: "connected", hello: null },
           subscribe: (listener: (snapshot: ApplicationGatewaySnapshot) => void) => {
             publishGateway = () => listener(context.gateway.snapshot);
             return () => undefined;
@@ -244,6 +307,7 @@ describe("DashboardsPage", () => {
         }
         resolvePage(null);
         await settleLitElement(element);
+        await settleDashboardPreviews(element, runFrame);
         expect(element.textContent).toContain("New dashboard");
         expect(element.textContent).not.toContain("dashboard enumeration returned no result");
         expect(element.querySelector('[role="alert"]')).toBeNull();
@@ -253,6 +317,7 @@ describe("DashboardsPage", () => {
       await vi.waitFor(() =>
         expect(element.querySelectorAll("[data-dashboard-session]")).toHaveLength(2),
       );
+      await settleDashboardPreviews(element, runFrame);
       expect(list).toHaveBeenCalledWith({
         limit: SIDEBAR_SESSION_ROSTER_LIMIT,
         hasBoard: true,


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/141063

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where dashboard gallery tests fail when their real previews
become active, blocking otherwise unrelated CI changes. The
[originating CI failure](https://github.com/openclaw/openclaw/actions/runs/34117577136/job/101728144735)
reported `client.addEventListener is not a function` instead of the expected
error-free recovered gallery.

## Why This Change Was Made

Repair the fixture producer: both connected gallery fixtures now use the existing
`createTestGatewayClient`, retaining its real event-listener contract and stubbing
only `board.get` with a snapshot matching the requested session. Unexpected
methods fail.

The tests await real board-document registration, drive preview animation frames
with cancellation-aware scheduling, and settle the real child and rendered board
content before checking recovery. All original scope, stale-listener, recovery,
detach, pagination, filtering, sorting, and global alert assertions are retained.
No production code, timeouts, CI gates, or test inventory changes.

## User Impact

No shipped UI behavior changes. CI exercises the real dashboard preview path with
valid fixtures instead of depending on whether a lazy child happens to load before
the test finishes.

## Evidence

- [Hosted CI 34120177527](https://github.com/openclaw/openclaw/actions/runs/34120177527)
  completed successfully for exact head
  `a7ac1092ae16e4788724d20808fc3b839251186d`.
- [Hosted changed tests](https://github.com/openclaw/openclaw/actions/runs/34120177527/job/101736457327)
  passed all 4 dashboard cases; the formerly failing case passed in 815 ms
  (file 2.45 s, wrapper 3.13 s).
  [Test types](https://github.com/openclaw/openclaw/actions/runs/34120177527/job/101736457659),
  [production types](https://github.com/openclaw/openclaw/actions/runs/34120177527/job/101736457826),
  and the [CI gate](https://github.com/openclaw/openclaw/actions/runs/34120177527/job/101739794122)
  also passed.
- On the final controlled activation path, restoring only the original empty
  clients reproduces the actual missing-listener error in **759 ms**, not a timeout.
- Final gallery owner plus `dashboard-preview.test.ts` and
  `board-document.test.ts`: **8 passed, 0 skipped** across 3 files; 2.41 s Vitest
  duration. The previously failing case passed in 758 ms.
- Targeted repository oxlint, oxfmt, and `git diff --check` passed.
- Changed checks passed 14 preceding stages, including the line/assertion
  ratchets and UI i18n verification. Typechecking stopped at the checkout guard
  because the existing shared compiler is outside the linked worktree. No install
  or guard bypass was used; this is not a local typecheck pass. Hosted exact-head
  CI is now green. The local changed-check run
  preceded only a behavior-preserving frame-ID variable extraction covered by the
  final tests, lint, formatting, and review.
- Fresh independent P0-P2 review found no actionable issues.
- Before publication, the scoped file on current main remained byte-identical
  to the reproduced baseline, with both invalid clients still present.

The client is never started; this is deterministic component-boundary proof,
not a live Gateway or network test. This PR does not change or claim to fix the
separate mock listener or Gateway handoff behavior.
