### PR TITLE
fix(test): await Telegram loopback prompt reception

### DIFF
--- a/test/loopback-ask-user-telegram-channel.test.ts
+++ b/test/loopback-ask-user-telegram-channel.test.ts
@@ -42,6 +42,7 @@ import type { OpenClawConfig } from "../src/config/types.openclaw.js";
 import { resolveMcpLoopbackClientGrant } from "../src/gateway/mcp-grant-store.js";
 import { closeMcpLoopbackServer, ensureMcpLoopbackServer } from "../src/gateway/mcp-http.js";
 import * as toolResolution from "../src/gateway/tool-resolution.js";
+import { createDeferredCore } from "../src/shared/deferred.js";
 import { closeOpenClawStateDatabaseForTest } from "../src/state/openclaw-state-db.js";
 import { runQaGatewayFixture } from "./helpers/qa-gateway-cleanup.js";
 
@@ -82,24 +83,29 @@ type McpResponse = {
   };
 };
 
+type TelegramRequest = { body: string; method: string | undefined; url: string };
+
 type TelegramAskUserLoopback = {
   apiRoot: string;
-  requests: Array<{ body: string; method: string | undefined; url: string }>;
+  requests: TelegramRequest[];
+  promptRequest: Promise<TelegramRequest>;
   close: () => Promise<void>;
 };
 
 async function startTelegramAskUserLoopback(): Promise<TelegramAskUserLoopback> {
   const requests: TelegramAskUserLoopback["requests"] = [];
+  const promptRequest = createDeferredCore<TelegramRequest>();
   const sockets = new Set<Socket>();
   const server: Server = createServer((request, response) => {
     const chunks: Buffer[] = [];
     request.on("data", (chunk: Buffer) => chunks.push(chunk));
     request.on("end", () => {
-      requests.push({
+      const entry = {
         body: Buffer.concat(chunks).toString("utf8"),
         method: request.method,
         url: request.url ?? "",
-      });
+      };
+      requests.push(entry);
       response.writeHead(200, { "content-type": "application/json" });
       response.end(
         JSON.stringify({
@@ -112,6 +118,9 @@ async function startTelegramAskUserLoopback(): Promise<TelegramAskUserLoopback> 
           },
         }),
       );
+      if (entry.url.includes("sendMessage")) {
+        promptRequest.resolve(entry);
+      }
     });
   });
   server.on("connection", (socket) => {
@@ -126,6 +135,7 @@ async function startTelegramAskUserLoopback(): Promise<TelegramAskUserLoopback> 
   return {
     apiRoot: `http://127.0.0.1:${port}`,
     requests,
+    promptRequest: promptRequest.promise,
     close: async () => {
       for (const socket of sockets) {
         socket.destroy();
@@ -301,15 +311,12 @@ describe("loopback ask_user Telegram channel transport", () => {
                 } finally {
                   registration.release();
                 }
-                await expect
-                  .poll(() =>
-                    telegram.requests.filter((entry) => entry.url.includes("sendMessage")),
-                  )
-                  .toHaveLength(1);
-                const prompt = expectDefined(
-                  telegram.requests.find((entry) => entry.url.includes("sendMessage")),
-                  "Telegram sendMessage",
-                );
+                const prompt = await Promise.race([
+                  telegram.promptRequest,
+                  response.then(() => {
+                    throw new Error("ask_user completed before Telegram prompt delivery");
+                  }),
+                ]);
                 expect(prompt.body).toContain("Which destination should be used?");
                 expect(prompt.body).toContain("Staging");
                 await expect(
@@ -322,6 +329,9 @@ describe("loopback ask_user Telegram channel transport", () => {
                   }),
                 ).resolves.toBe(true);
                 const completed = await response;
+                expect(
+                  telegram.requests.filter((entry) => entry.url.includes("sendMessage")),
+                ).toHaveLength(1);
                 expect(completed.result.isError).toBe(false);
                 expect(completed.result.content).toEqual([
                   expect.objectContaining({


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent Telegram loopback test failure when real prompt delivery takes longer than Vitest's default one-second polling budget. The test observes zero Bot API requests and cancels a valid delivery that is still in progress.

Related: https://github.com/openclaw/openclaw/pull/140695

## Why This Change Was Made

The loopback HTTP fixture owns request reception and now exposes that event directly. The test waits for the captured prompt, races it against an unexpected early tool completion, and checks exactly one send after the tool finishes. Prompt text, answer acceptance, and successful tool-result assertions remain intact.

## User Impact

More reliable transport proof under CPU contention. No production behavior, mock scope, dependency, retry, or timeout changes.

## Evidence

- Original wait with delivery-only CPU contention: **0/1 passed**, reproducing the same empty-request assertion as hosted CI.
- Candidate under identical contention: **10/10 passed**, wrapper exit 0 (388.670 seconds for the loop).
- The Testbox uses Node24.19.0, CI=1, canonical tooling configuration, and OPENCLAW_VITEST_MAX_WORKERS=2. One-CPU affinity applies throughout; eight bounded CPU worker threads start only after question registration is held, keeping setup outside the stress window. The temporary load instrumentation was removed before normal validation.
- Stopped/completed Testbox: `tbx_01m1xtsgg3h3p2tqnbvc6h36ze`; https://github.com/openclaw/openclaw/actions/runs/34117953849. Gateway/Bot API endpoints are task-owned loopback fixtures, with no live-provider claim.

```sh
CI=1 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs --config test/vitest/vitest.tooling.config.ts test/loopback-ask-user-telegram-channel.test.ts
node scripts/check-changed.mjs
```

Normal focused local test: **1/1 passed** (5.481 seconds). `node scripts/check-changed.mjs` passed; independent Codex review through P2 found zero actionable issues.

Earlier ordinary Linux and one-CPU runs each passed10/10, and the original23-file prefix passed. Contention around the actual delivery boundary reproduced the failure; a prior whole-process contention attempt hit the unchanged setup watchdog and is not counted as the reproduction.
