### PR TITLE
fix(agents): withhold recovery-nudge quotes from the final reply

### DIFF
--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
@@ -47,6 +47,8 @@ const transcriptMocks = vi.hoisted(() => ({
   appendAssistantMirrorMessageByIdentity: vi.fn(),
 }));
 
+const SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION =
+  "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch. Tools are unavailable in this step: it is a text-only pass, so reply with plain text and do not attempt any tool call.";
 const SETTLED_TOOL_FINALIZATION_FALLBACK_TEXT =
   "The tool run finished, but no final summary was produced. I did not repeat any completed actions.";
 
@@ -256,6 +258,103 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
       expect(result.prepared.payloadsWithToolMedia?.[0]?.isError).not.toBe(true);
     },
   );
+
+  it("does not deliver a finalizer reply that quotes the recovery nudge", async () => {
+    const attempt = settledFailedAttempt();
+    backendMocks.runSettledFinalization
+      .mockImplementationOnce(async (params: EmbeddedRunAttemptParams) => ({
+        outcome: "answered",
+        result: {
+          assistant: buildEmbeddedRunnerAssistant({
+            content: [
+              {
+                type: "text",
+                text:
+                  "I'll do sqlite, sizes, logs. Wait - the system says " +
+                  `'${params.prompt}' That's a strong instruction to PRODUCE THE FINAL ANSWER NOW.`,
+              },
+            ],
+          }),
+        },
+      }))
+      .mockResolvedValueOnce({
+        outcome: "answered",
+        result: {
+          assistant: buildEmbeddedRunnerAssistant({
+            content: [{ type: "text", text: "The exec tool failed: post-processing error." }],
+          }),
+        },
+      });
+
+    const result = await prepareTerminalWithSettledTurnFinalization(finalizationInput(attempt));
+
+    expect(backendMocks.runSettledFinalization).toHaveBeenCalledTimes(2);
+    expect(result.finalizationOutcome).toBe("answered");
+    expect(result.prepared.payloadsWithToolMedia).toEqual([
+      expect.objectContaining({ text: "The exec tool failed: post-processing error." }),
+    ]);
+    expect(result.prepared.payloadsWithToolMedia?.[0]?.text).not.toContain(
+      SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION,
+    );
+  });
+
+  it("does not deliver recovery-nudge quotes when they persist after one retry", async () => {
+    const attempt = settledFailedAttempt();
+    backendMocks.runSettledFinalization.mockImplementation(
+      async (params: EmbeddedRunAttemptParams) => ({
+        outcome: "answered",
+        result: {
+          assistant: buildEmbeddedRunnerAssistant({
+            content: [
+              {
+                type: "text",
+                text: `Continue from the current transcript: ${params.prompt}`,
+              },
+            ],
+          }),
+        },
+      }),
+    );
+
+    const result = await prepareTerminalWithSettledTurnFinalization(finalizationInput(attempt));
+
+    expect(backendMocks.runSettledFinalization).toHaveBeenCalledTimes(2);
+    expect(result.finalizationOutcome).toBe("failed");
+    expect(result.attempt).toBe(attempt);
+    expect(result.prepared.payloadsWithToolMedia).toEqual([
+      expect.objectContaining({ text: expect.stringContaining("failed"), isError: true }),
+    ]);
+    expect(result.prepared.payloadsWithToolMedia?.[0]?.text).not.toContain(
+      SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION,
+    );
+  });
+
+  it("still delivers a real user-facing finalizer answer", async () => {
+    const attempt = settledFailedAttempt();
+    backendMocks.runSettledFinalization.mockResolvedValueOnce({
+      outcome: "answered",
+      result: {
+        assistant: buildEmbeddedRunnerAssistant({
+          content: [
+            {
+              type: "text",
+              text: "I continued from the tool results. The exec tool failed: post-processing error.",
+            },
+          ],
+        }),
+      },
+    });
+
+    const result = await prepareTerminalWithSettledTurnFinalization(finalizationInput(attempt));
+
+    expect(backendMocks.runSettledFinalization).toHaveBeenCalledOnce();
+    expect(result.finalizationOutcome).toBe("answered");
+    expect(result.prepared.payloadsWithToolMedia).toEqual([
+      expect.objectContaining({
+        text: "I continued from the tool results. The exec tool failed: post-processing error.",
+      }),
+    ]);
+  });
 
   it("replaces a settled failed-tool warning with failure-honest final output", async () => {
     const attempt = settledFailedAttempt();

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -50,6 +50,12 @@ type CreateAttemptControls = ReturnType<
 const MAX_EMPTY_SETTLED_FINALIZATION_ATTEMPTS = 2;
 const SETTLED_TOOL_FINALIZATION_FALLBACK_TEXT =
   "The tool run finished, but no final summary was produced. I did not repeat any completed actions.";
+
+function settledTurnFinalizationQuotesRecoveryPrompt(text: string, prompt: string): boolean {
+  const injected = prompt.trim();
+  return injected.length > 0 && text.includes(injected);
+}
+
 type TerminalPreparationBase = Omit<
   TerminalPreparationInput,
   | "attempt"
@@ -404,11 +410,31 @@ async function runPreparedSettledTurnFinalization(input: {
         input.harness,
       ),
     );
+    let { outcome, result } = finalization;
+    if (
+      outcome === "answered" &&
+      settledTurnFinalizationQuotesRecoveryPrompt(
+        resolveSettledTurnFinalizationText(result),
+        input.prompt,
+      )
+    ) {
+      log.warn(
+        `settled-turn finalization quoted its recovery prompt: runId=${input.attempt.runId} sessionId=${input.attempt.sessionId} — treating as empty`,
+      );
+      outcome = "empty";
+      result = {
+        ...result,
+        assistant: {
+          ...result.assistant,
+          content: [{ type: "text", text: "" }],
+        },
+      };
+    }
     return {
-      outcome: finalization.outcome,
+      outcome,
       attempt: buildSettledTurnFinalizationAttemptResult({
-        outcome: finalization.outcome,
-        result: finalization.result,
+        outcome,
+        result,
         settledAttempt: input.settledAttempt,
         prompt: input.prompt,
         agentHarnessId: input.attempt.agentHarnessId,


### PR DESCRIPTION
Closes #137915

## What Problem This Solves

Fixes an issue where users would see the agent's internal recovery prompt quoted back as the final reply after a settled tool turn produced no visible answer. Some models answer that injected continuation by narrating a plan and repeating the prompt as `output_text`, and that text was delivered as the user-visible reply.

## Why This Change Was Made

If the finalizer answer contains the exact injected prompt, treat it as empty and retry once with tools disabled. A real answer that does not quote the prompt still delivers. If the quote persists, keep the original failed-tool warning rather than synthesizing a fallback over a command failure.

## User Impact

A settled tool turn that only quotes the recovery nudge no longer ships that planning text as the reply. Honest tool-failure copy still reaches the user.

## Evidence

After rebase onto current main:

```
$ node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
 Test Files  1 passed (1)
      Tests  29 passed (29)
```

Fail-before: stub finalizer returns the injected continuation prompt and that text is delivered.
Pass-after: the same stub is withheld, retried once, and replaced by a real answer or the original failed-tool warning.

Not run: a live Telegram bot. The suite stubs the backend finalizer and does not write a runtime transcript or send a channel message.
