### PR TITLE
fix(plugins): preserve SDK 2026.9.2 import compatibility

### DIFF
--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -91,6 +91,17 @@ External-plugin compatibility work follows this order:
 
 ### Retained helper contracts
 
+Discord and llama.cpp retain their declared OpenClaw 2026.9.2 host support.
+They use the newer prepared-expiry, DM-policy refinement, and live-catalog outcome
+helpers when those exports are available, with plugin-local fallbacks for the
+2026.9.2 SDK. The fallbacks preserve Discord's timestamp validation, idle-first
+expiry ties, and root/account DM-policy validation through the older SDK
+validators, and llama.cpp's ready, authentication-rejected, and unavailable catalog outcomes
+with credential-profile attribution. They do not retry or suppress errors from
+an available newer helper. Remove these fallbacks only when the declared plugin
+API floor no longer includes 2026.9.2; test built plugin imports against that
+minimum host before changing unconditional SDK imports.
+
 Retained compatibility entrypoints keep their shipped caller names:
 `inbound-envelope` uses `resolveStorePath`, `provider-catalog-runtime` exports
 `resolvePluginProviders`, and `agent-runtime`'s

--- a/extensions/discord/src/config-schema.ts
+++ b/extensions/discord/src/config-schema.ts
@@ -12,9 +12,11 @@ import {
   ChannelPreviewStreamingConfigSchema,
   ChannelStreamingProgressSchema,
   ProviderCommandsSchema,
-  refineChannelDmPolicy,
+  requireAllowlistAllowFrom,
+  requireOpenAllowFrom,
   TtsConfigSchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
+import * as channelConfigSchema from "openclaw/plugin-sdk/channel-config-schema";
 import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   buildSecretInputSchema,
@@ -23,6 +25,44 @@ import {
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { z } from "zod";
 import { discordChannelConfigUiHints } from "./config-ui-hints.js";
+
+// Published 2026.9.2 exposes the two dependency validators, but not this refiner.
+// Remove this fallback when the declared plugin API floor excludes that host.
+const dmPolicySdk: Partial<Pick<typeof channelConfigSchema, "refineChannelDmPolicy">> =
+  channelConfigSchema;
+
+function refineDiscordDmPolicyForHost(
+  params: Omit<Parameters<typeof channelConfigSchema.refineChannelDmPolicy>[0], "channelId">,
+): void {
+  if (dmPolicySdk.refineChannelDmPolicy) {
+    dmPolicySdk.refineChannelDmPolicy({ channelId: "discord", ...params });
+    return;
+  }
+  const { value, accountId, ctx } = params;
+  const account = accountId === undefined ? value : value.accounts?.[accountId];
+  if (!account) {
+    return;
+  }
+  const policy = account.dmPolicy ?? value.dmPolicy;
+  const allowFrom = account.allowFrom ?? value.allowFrom;
+  const owner = accountId === undefined ? "channels.discord" : "channels.discord.accounts.*";
+  const inherited = accountId === undefined ? "" : " (or channels.discord.allowFrom)";
+  const path = accountId === undefined ? ["allowFrom"] : ["accounts", accountId, "allowFrom"];
+  requireOpenAllowFrom({
+    policy,
+    allowFrom,
+    ctx,
+    path,
+    message: `${owner}.dmPolicy="${policy}" requires ${owner}.allowFrom${inherited} to include "*"`,
+  });
+  requireAllowlistAllowFrom({
+    policy,
+    allowFrom,
+    ctx,
+    path,
+    message: `${owner}.dmPolicy="${policy}" requires ${owner}.allowFrom${inherited} to contain at least one sender ID`,
+  });
+}
 
 const SecretInputSchema = buildSecretInputSchema();
 const DiscordPreviewStreamingConfigSchema = ChannelPreviewStreamingConfigSchema.extend({
@@ -406,7 +446,7 @@ const DiscordConfigSchemaBase = DiscordAccountSchemaBase.safeExtend({
   accounts: z.record(z.string(), DiscordAccountSchema.optional()).optional(),
   defaultAccount: z.string().optional(),
 }).superRefine((value, ctx) => {
-  refineChannelDmPolicy({ channelId: "discord", value, ctx });
+  refineDiscordDmPolicyForHost({ value, ctx });
 
   if (!value.accounts) {
     return;
@@ -415,7 +455,7 @@ const DiscordConfigSchemaBase = DiscordAccountSchemaBase.safeExtend({
     if (!account) {
       continue;
     }
-    refineChannelDmPolicy({ channelId: "discord", value, accountId, ctx });
+    refineDiscordDmPolicyForHost({ value, accountId, ctx });
   }
 });
 

--- a/extensions/discord/src/dm-policy.sdk-compat.test.ts
+++ b/extensions/discord/src/dm-policy.sdk-compat.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DiscordConfigSchema } from "./config-schema.js";
+
+const sdk = vi.hoisted((): { available: boolean; calls: number; failure?: Error } => ({
+  available: true,
+  calls: 0,
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-config-schema", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-config-schema")>();
+  return {
+    ...actual,
+    get refineChannelDmPolicy() {
+      return sdk.available
+        ? (params: Parameters<typeof actual.refineChannelDmPolicy>[0]) => {
+            sdk.calls += 1;
+            if (sdk.failure) {
+              throw sdk.failure;
+            }
+            return actual.refineChannelDmPolicy(params);
+          }
+        : undefined;
+    },
+  };
+});
+
+const cases = [
+  { name: "root wildcard", config: { dmPolicy: "open", allowFrom: ["*"] }, issues: [] },
+  {
+    name: "root open without wildcard",
+    config: { dmPolicy: "open", allowFrom: ["123"] },
+    issues: [
+      {
+        path: ["allowFrom"],
+        message:
+          'channels.discord.dmPolicy="open" requires channels.discord.allowFrom to include "*"',
+      },
+    ],
+  },
+  {
+    name: "root empty allowlist",
+    config: { dmPolicy: "allowlist", allowFrom: [" "] },
+    issues: [
+      {
+        path: ["allowFrom"],
+        message:
+          'channels.discord.dmPolicy="allowlist" requires channels.discord.allowFrom to contain at least one sender ID',
+      },
+    ],
+  },
+  {
+    name: "inherited account allowance",
+    config: { allowFrom: ["123"], accounts: { work: { dmPolicy: "allowlist" } } },
+    issues: [],
+  },
+  {
+    name: "explicit empty account override",
+    config: { allowFrom: ["123"], accounts: { work: { dmPolicy: "allowlist", allowFrom: [] } } },
+    issues: [
+      {
+        path: ["accounts", "work", "allowFrom"],
+        message:
+          'channels.discord.accounts.*.dmPolicy="allowlist" requires channels.discord.accounts.*.allowFrom (or channels.discord.allowFrom) to contain at least one sender ID',
+      },
+    ],
+  },
+  {
+    name: "inherited account open policy",
+    config: { dmPolicy: "open", allowFrom: ["*"], accounts: { work: { allowFrom: ["123"] } } },
+    issues: [
+      {
+        path: ["accounts", "work", "allowFrom"],
+        message:
+          'channels.discord.accounts.*.dmPolicy="open" requires channels.discord.accounts.*.allowFrom (or channels.discord.allowFrom) to include "*"',
+      },
+    ],
+  },
+  {
+    name: "omitted account",
+    config: { dmPolicy: "pairing", accounts: { work: undefined } },
+    issues: [],
+  },
+];
+
+describe.each([true, false])("Discord DM policy (SDK helper available=%s)", (available) => {
+  beforeEach(() => {
+    sdk.available = available;
+    sdk.calls = 0;
+    sdk.failure = undefined;
+  });
+
+  it.each(cases)("preserves $name validation", ({ config, issues }) => {
+    const parsed = DiscordConfigSchema.safeParse(config);
+    expect(
+      parsed.success ? [] : parsed.error.issues.map(({ path, message }) => ({ path, message })),
+    ).toEqual(issues);
+    expect(sdk.calls > 0).toBe(available);
+  });
+});
+
+it("propagates an available host refiner failure", () => {
+  const failure = new Error("synthetic host refiner failure");
+  sdk.available = true;
+  sdk.failure = failure;
+  expect(() => DiscordConfigSchema.parse({})).toThrow(failure);
+});

--- a/extensions/discord/src/monitor/thread-bindings.expiry.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.expiry.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolvePreparedThreadBindingLifecycle } from "./thread-bindings.state.js";
+import type { ThreadBindingRecord } from "./thread-bindings.types.js";
+
+const sdk = vi.hoisted(() => ({ helperAvailable: true, calls: 0 }));
+vi.mock("openclaw/plugin-sdk/thread-bindings-session-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/thread-bindings-session-runtime")>();
+  const resolve = (params: Parameters<typeof actual.resolveThreadBindingExpiry>[0]) => {
+    sdk.calls += 1;
+    return actual.resolveThreadBindingExpiry(params);
+  };
+  return {
+    ...actual,
+    get resolveThreadBindingExpiry() {
+      return sdk.helperAvailable ? resolve : undefined;
+    },
+  };
+});
+
+describe.each([true, false])("prepared Discord expiry (SDK helper available=%s)", (available) => {
+  beforeEach(() => {
+    sdk.helperAvailable = available;
+    sdk.calls = 0;
+  });
+
+  it.each([
+    {
+      boundAt: 100,
+      lastActivityAt: 50,
+      idle: 10,
+      max: 10,
+      expiry: { expiresAt: 60, reason: "idle-expired" },
+    },
+    {
+      boundAt: 100,
+      lastActivityAt: 100,
+      idle: 10,
+      max: 10,
+      expiry: { expiresAt: 110, reason: "idle-expired" },
+    },
+    {
+      boundAt: 100,
+      lastActivityAt: 200,
+      idle: 10,
+      max: 10,
+      expiry: { expiresAt: 110, reason: "max-age-expired" },
+    },
+    { boundAt: 100, lastActivityAt: 100, idle: 0, max: 0, expiry: {} },
+    {
+      boundAt: 100,
+      lastActivityAt: Number.NaN,
+      idle: 10,
+      max: 10,
+      expiry: { expiresAt: 110, reason: "max-age-expired" },
+    },
+    {
+      boundAt: 0,
+      lastActivityAt: 100,
+      idle: 10,
+      max: 10,
+      expiry: { expiresAt: 110, reason: "idle-expired" },
+    },
+    { boundAt: Infinity, lastActivityAt: -1, idle: 10, max: 10, expiry: {} },
+  ])("preserves prepared deadlines for %j", ({ boundAt, lastActivityAt, idle, max, expiry }) => {
+    const record: ThreadBindingRecord = {
+      accountId: "default",
+      channelId: "channel",
+      threadId: "thread",
+      targetKind: "subagent",
+      targetSessionKey: "agent:main:subagent:expiry",
+      agentId: "main",
+      boundBy: "test",
+      boundAt,
+      lastActivityAt,
+    };
+    expect(
+      resolvePreparedThreadBindingLifecycle({ record, idleTimeoutMs: idle, maxAgeMs: max }),
+    ).toEqual({ idleTimeoutMs: idle, maxAgeMs: max, ...expiry });
+    expect(sdk.calls).toBe(available ? 1 : 0);
+  });
+});

--- a/extensions/discord/src/monitor/thread-bindings.state.ts
+++ b/extensions/discord/src/monitor/thread-bindings.state.ts
@@ -6,7 +6,7 @@ import {
   normalizeOptionalString,
   normalizeOptionalStringifiedId,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveThreadBindingExpiry } from "openclaw/plugin-sdk/thread-bindings-session-runtime";
+import * as threadBindingRuntime from "openclaw/plugin-sdk/thread-bindings-session-runtime";
 import { getDiscordRuntime } from "../runtime.js";
 import type {
   PersistedThreadBindingRecord,
@@ -250,6 +250,31 @@ function resolveTimestampExpiry(timestamp: number, durationMs: number): number |
   return Number.isFinite(at) && at > 0 ? at + durationMs : undefined;
 }
 
+// Published 2026.9.2 has lifecycle normalization but not prepared expiry selection.
+// Remove this fallback when the declared plugin API floor excludes that host.
+const threadBindingExpirySdk: Partial<
+  Pick<typeof threadBindingRuntime, "resolveThreadBindingExpiry">
+> = threadBindingRuntime;
+
+function resolveThreadBindingExpiryForHost(
+  params: Parameters<typeof threadBindingRuntime.resolveThreadBindingExpiry>[0],
+): ReturnType<typeof threadBindingRuntime.resolveThreadBindingExpiry> {
+  if (threadBindingExpirySdk.resolveThreadBindingExpiry) {
+    return threadBindingExpirySdk.resolveThreadBindingExpiry(params);
+  }
+  const { inactivityExpiresAt, maxAgeExpiresAt } = params;
+  if (
+    inactivityExpiresAt != null &&
+    (maxAgeExpiresAt == null || inactivityExpiresAt <= maxAgeExpiresAt)
+  ) {
+    return { expiresAt: inactivityExpiresAt, reason: "idle-expired" };
+  }
+  if (maxAgeExpiresAt != null) {
+    return { expiresAt: maxAgeExpiresAt, reason: "max-age-expired" };
+  }
+  return {};
+}
+
 export function resolvePreparedThreadBindingLifecycle(params: {
   record: ThreadBindingRecord;
   idleTimeoutMs: number;
@@ -266,7 +291,7 @@ export function resolvePreparedThreadBindingLifecycle(params: {
   return {
     idleTimeoutMs,
     maxAgeMs,
-    ...resolveThreadBindingExpiry({
+    ...resolveThreadBindingExpiryForHost({
       inactivityExpiresAt: resolveTimestampExpiry(params.record.lastActivityAt, idleTimeoutMs),
       maxAgeExpiresAt: resolveTimestampExpiry(params.record.boundAt, maxAgeMs),
     }),

--- a/extensions/llama-cpp/src/external-server/provider.test.ts
+++ b/extensions/llama-cpp/src/external-server/provider.test.ts
@@ -7,6 +7,28 @@ import { discoverLlamaServerProvider, prepareLlamaServerDynamicModel } from "./p
 
 const discoverMock = vi.hoisted(() => vi.fn());
 const runtimeApiKeyMock = vi.hoisted(() => vi.fn());
+const catalogSdk = vi.hoisted((): { available: boolean; calls: number; failure?: Error } => ({
+  available: true,
+  calls: 0,
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-catalog-live-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/provider-catalog-live-runtime")>();
+  const run = (params: Parameters<typeof actual.runLiveProviderCatalog>[0]) => {
+    catalogSdk.calls += 1;
+    if (catalogSdk.failure) {
+      throw catalogSdk.failure;
+    }
+    return actual.runLiveProviderCatalog(params);
+  };
+  return {
+    ...actual,
+    get runLiveProviderCatalog() {
+      return catalogSdk.available ? run : undefined;
+    },
+  };
+});
 
 vi.mock("./discovery.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./discovery.js")>()),
@@ -81,104 +103,127 @@ describe("llama-server provider discovery", () => {
     discoverMock.mockReset();
     runtimeApiKeyMock.mockReset();
     runtimeApiKeyMock.mockResolvedValue(undefined);
+    catalogSdk.available = true;
+    catalogSdk.calls = 0;
+    catalogSdk.failure = undefined;
   });
 
-  it("publishes live discovery with the profile that supplied its credential", async () => {
-    discoverMock.mockResolvedValue(success());
-    const ctx = catalogContext();
-    ctx.resolveProviderApiKey = () => ({
-      apiKey: "LLAMA_SERVER_API_KEY",
-      discoveryApiKey: "profile-key",
-      profileId: "llama-cpp:default",
+  describe.each([true, false])("catalog SDK helper available=%s", (available) => {
+    beforeEach(() => {
+      catalogSdk.available = available;
     });
 
-    await expect(discoverLlamaServerProvider(ctx)).resolves.toMatchObject({
-      provider: {
-        baseUrl: "http://127.0.0.1:8080/v1",
-        api: "openai-completions",
-        models: [expect.objectContaining({ id: "org/model:Q4" })],
-      },
-      outcomes: [{ provider: "llama-cpp", profileId: "llama-cpp:default", status: "ready" }],
-    });
-    expect(discoverMock).toHaveBeenCalledWith(
-      expect.objectContaining({ apiKey: "profile-key", cacheTtlMs: 0 }),
-    );
-  });
-
-  it("prefers configured Authorization over ambient API-key discovery auth", async () => {
-    discoverMock.mockResolvedValue(success());
-    const ctx = catalogContext();
-    ctx.config.models = {
-      providers: {
-        "llama-cpp": {
-          baseUrl: "http://localhost:8080/v1",
-          headers: { Authorization: "Bearer proxy-key" },
-          models: [],
-        },
-      },
-    };
-    ctx.resolveProviderApiKey = vi.fn(() => ({
-      apiKey: "LLAMA_SERVER_API_KEY",
-      discoveryApiKey: "ambient-key",
-      profileId: "llama-cpp:ambient",
-    }));
-
-    const result = await discoverLlamaServerProvider(ctx);
-    expect(result?.outcomes).toEqual([{ provider: "llama-cpp", status: "ready" }]);
-
-    expect(discoverMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        apiKey: undefined,
-        headers: { Authorization: "Bearer proxy-key" },
-      }),
-    );
-  });
-
-  it.each([
-    { failure: { kind: "http-error", status: 401 }, status: "auth-rejected" },
-    { failure: { kind: "http-error", status: 403 }, status: "auth-rejected" },
-    { failure: { kind: "http-error", status: 503 }, status: "unavailable" },
-    { failure: { kind: "unreachable", error: new Error("offline") }, status: "unavailable" },
-    { failure: { kind: "invalid-response", error: new Error("malformed") }, status: "unavailable" },
-  ])(
-    "reports $failure as $status instead of publishing empty discovery",
-    async ({ failure, status }) => {
-      discoverMock.mockResolvedValue({
-        ...failure,
-        endpoint: { origin: "http://localhost:8080", inferenceBaseUrl: "http://localhost:8080/v1" },
+    it("publishes live discovery with the profile that supplied its credential", async () => {
+      discoverMock.mockResolvedValue(success());
+      const ctx = catalogContext();
+      ctx.resolveProviderApiKey = () => ({
+        apiKey: "LLAMA_SERVER_API_KEY",
+        discoveryApiKey: "profile-key",
+        profileId: "llama-cpp:default",
       });
+
+      await expect(discoverLlamaServerProvider(ctx)).resolves.toMatchObject({
+        provider: {
+          baseUrl: "http://127.0.0.1:8080/v1",
+          api: "openai-completions",
+          models: [expect.objectContaining({ id: "org/model:Q4" })],
+        },
+        outcomes: [{ provider: "llama-cpp", profileId: "llama-cpp:default", status: "ready" }],
+      });
+      expect(discoverMock).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: "profile-key", cacheTtlMs: 0 }),
+      );
+      expect(catalogSdk.calls).toBe(available ? 1 : 0);
+    });
+
+    it("prefers configured Authorization over ambient API-key discovery auth", async () => {
+      discoverMock.mockResolvedValue(success());
       const ctx = catalogContext();
       ctx.config.models = {
         providers: {
           "llama-cpp": {
             baseUrl: "http://localhost:8080/v1",
-            models: [model().config],
+            headers: { Authorization: "Bearer proxy-key" },
+            models: [],
           },
         },
       };
+      ctx.resolveProviderApiKey = vi.fn(() => ({
+        apiKey: "LLAMA_SERVER_API_KEY",
+        discoveryApiKey: "ambient-key",
+        profileId: "llama-cpp:ambient",
+      }));
 
-      await expect(discoverLlamaServerProvider(ctx)).resolves.toEqual({
-        providers: {},
-        outcomes: [
-          {
-            provider: "llama-cpp",
-            status,
-            ...(status === "auth-rejected" ? { rejectionScope: "catalog" } : {}),
+      const result = await discoverLlamaServerProvider(ctx);
+      expect(result?.outcomes).toEqual([{ provider: "llama-cpp", status: "ready" }]);
+
+      expect(discoverMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: undefined,
+          headers: { Authorization: "Bearer proxy-key" },
+        }),
+      );
+    });
+
+    it.each([
+      { failure: { kind: "http-error", status: 401 }, status: "auth-rejected" },
+      { failure: { kind: "http-error", status: 403 }, status: "auth-rejected" },
+      { failure: { kind: "http-error", status: 503 }, status: "unavailable" },
+      { failure: { kind: "unreachable", error: new Error("offline") }, status: "unavailable" },
+      {
+        failure: { kind: "invalid-response", error: new Error("malformed") },
+        status: "unavailable",
+      },
+    ])(
+      "reports $failure as $status instead of publishing empty discovery",
+      async ({ failure, status }) => {
+        discoverMock.mockResolvedValue({
+          ...failure,
+          endpoint: {
+            origin: "http://localhost:8080",
+            inferenceBaseUrl: "http://localhost:8080/v1",
           },
-        ],
-      });
-    },
-  );
+        });
+        const ctx = catalogContext();
+        ctx.config.models = {
+          providers: {
+            "llama-cpp": {
+              baseUrl: "http://localhost:8080/v1",
+              models: [model().config],
+            },
+          },
+        };
 
-  it.each([undefined, "custom-local"])(
-    "keeps unconfigured probes quiet with marker %s",
-    async (apiKey) => {
-      discoverMock.mockResolvedValue({ kind: "unreachable", error: new Error("offline") });
-      const ctx = catalogContext();
-      ctx.resolveProviderApiKey = () => ({ apiKey });
-      await expect(discoverLlamaServerProvider(ctx)).resolves.toBeNull();
-    },
-  );
+        await expect(discoverLlamaServerProvider(ctx)).resolves.toEqual({
+          providers: {},
+          outcomes: [
+            {
+              provider: "llama-cpp",
+              status,
+              ...(status === "auth-rejected" ? { rejectionScope: "catalog" } : {}),
+            },
+          ],
+        });
+      },
+    );
+
+    it.each([undefined, "custom-local"])(
+      "keeps unconfigured probes quiet with marker %s",
+      async (apiKey) => {
+        discoverMock.mockResolvedValue({ kind: "unreachable", error: new Error("offline") });
+        const ctx = catalogContext();
+        ctx.resolveProviderApiKey = () => ({ apiKey });
+        await expect(discoverLlamaServerProvider(ctx)).resolves.toBeNull();
+      },
+    );
+  });
+
+  it("preserves errors thrown by an available catalog helper", async () => {
+    const failure = new Error("current SDK helper failed");
+    catalogSdk.failure = failure;
+    await expect(discoverLlamaServerProvider(catalogContext())).rejects.toBe(failure);
+    expect(discoverMock).not.toHaveBeenCalled();
+  });
 
   it("returns only the requested discovered model directly to its preparation owner", async () => {
     discoverMock.mockResolvedValue({

--- a/extensions/llama-cpp/src/external-server/provider.ts
+++ b/extensions/llama-cpp/src/external-server/provider.ts
@@ -5,10 +5,7 @@ import type {
   ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { isNonSecretApiKeyMarker } from "openclaw/plugin-sdk/provider-auth";
-import {
-  LiveModelCatalogHttpError,
-  runLiveProviderCatalog,
-} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import * as liveCatalogRuntime from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { LLAMA_CPP_PROVIDER_ID } from "../defaults.js";
 import {
   hasLlamaServerAuthorizationHeader,
@@ -18,6 +15,38 @@ import {
 import { discoverLlamaServer } from "./discovery.js";
 import { resolveLlamaServerEndpoint } from "./endpoint.js";
 import { buildLlamaServerProviderConfig } from "./models.js";
+
+// Published 2026.9.2 understands catalog outcomes but does not export this runner.
+// Remove this fallback when the declared plugin API floor excludes that host.
+const liveCatalogSdk: Partial<Pick<typeof liveCatalogRuntime, "runLiveProviderCatalog">> =
+  liveCatalogRuntime;
+type CatalogOutcome = NonNullable<NonNullable<ProviderCatalogResult>["outcomes"]>[number];
+
+async function runLlamaServerCatalog(
+  params: Parameters<typeof liveCatalogRuntime.runLiveProviderCatalog>[0],
+): Promise<ProviderCatalogResult> {
+  if (liveCatalogSdk.runLiveProviderCatalog) {
+    return await liveCatalogSdk.runLiveProviderCatalog(params);
+  }
+  const identity = {
+    provider: params.providerId,
+    ...(params.profileId ? { profileId: params.profileId } : {}),
+  };
+  try {
+    const result = await params.run();
+    return result
+      ? { ...result, outcomes: [...(result.outcomes ?? []), { ...identity, status: "ready" }] }
+      : result;
+  } catch (error) {
+    const rejected =
+      error instanceof liveCatalogRuntime.LiveModelCatalogHttpError &&
+      (error.status === 401 || error.status === 403);
+    const outcome: CatalogOutcome = rejected
+      ? { ...identity, status: "auth-rejected", rejectionScope: "catalog" }
+      : { ...identity, status: "unavailable" };
+    return { providers: {}, outcomes: [outcome] };
+  }
+}
 
 /** Discovers external llama-server models for provider runtime resolution. */
 export async function discoverLlamaServerProvider(
@@ -36,7 +65,7 @@ export async function discoverLlamaServerProvider(
     (authApiKey && isNonSecretApiKeyMarker(authApiKey))
       ? undefined
       : authApiKey;
-  return await runLiveProviderCatalog({
+  return await runLlamaServerCatalog({
     providerId: LLAMA_CPP_PROVIDER_ID,
     profileId: apiKey ? auth.profileId : undefined,
     run: async () => {
@@ -51,7 +80,10 @@ export async function discoverLlamaServerProvider(
           return null;
         }
         throw discovery.kind === "http-error"
-          ? new LiveModelCatalogHttpError(LLAMA_CPP_PROVIDER_ID, discovery.status)
+          ? new liveCatalogRuntime.LiveModelCatalogHttpError(
+              LLAMA_CPP_PROVIDER_ID,
+              discovery.status,
+            )
           : discovery.error;
       }
       return {


### PR DESCRIPTION
## What Problem This Solves

Discord and llama.cpp declare OpenClaw 2026.9.2 compatibility, but recent helper extractions added unconditional imports of exports absent from that published SDK. Plugin loading fails before normal operation.

## Why This Change Was Made

Feature-detect the newer prepared-expiry, DM-policy refinement, and live-catalog helpers. Use them when available; on 2026.9.2, preserve the existing contract through narrow local fallbacks. Discord reuses the shipped allowlist/open-policy validators, preserves root/account inheritance and diagnostics, and keeps prepared expiry timestamps and idle-first ties. llama.cpp preserves ready/auth-rejected/unavailable outcomes and optional profile attribution. Errors from an available modern helper propagate without fallback or retry.

No host-floor, package/dependency version, schema, configuration, or policy change. Each fallback names the shipped minimum-host contract and its removal condition. Production +97 lines supplies those otherwise-unavailable contracts; tests +233 and docs +11. Existing older lifecycle normalization cannot replace prepared expiry because it changes timestamp semantics.

## User Impact

Built Discord channel and llama.cpp plugin artifacts load on their declared minimum SDK while using modern helpers on newer hosts. This repairs the incoming-main gaps from #140643, #139846, and the subsequent DM-policy helper extraction discovered during #140674 validation.

## Evidence

- Reproduced 7 expiry, 9 catalog, and 7 DM-refinement helper-absent failures, plus real published-SDK missing-export failures.
- Current focused validation: 78 tests covering modern/absent helper paths, unchanged schema/account policy, and error propagation. The earlier 75-test expiry/catalog wave is separately pinned.
- Full canonical changed checks passed, including production/test types, typed lint, dead exports, boundaries, and cycles. Both maintained plugin package builds passed.
- Actual SRI-verified official 2026.9.2 SDK: full built Discord channel import, seven public-schema root/account cases, public manager expiry/session publication and stop cleanup. Built llama registration/catalog exercised a real synthetic loopback server for ready, HTTP 401/403, and HTTP 503 outcomes.
- Seven source files, 101 package artifacts, and 117 resolved old-SDK module hashes were captured; source/artifacts stayed unchanged and every owned process/server/state directory was cleaned up. No real carrier or vendor service was used. This is runtime/package compatibility proof, not full-root UI build coverage or every supported platform.
- Independent P0–P2 review is clean. The original host ENOSPC interruption remains recorded; only completed task caches were retired before successful validation.

The old-host resolver need not provide a profile ID; the probe verifies attribution is preserved when supplied. No new credential collection or authentication behavior is introduced.
