### PR TITLE
improve(anthropic): reduce setup work for large tool rosters

### DIFF
--- a/packages/ai/src/providers/anthropic-tool-projection.test.ts
+++ b/packages/ai/src/providers/anthropic-tool-projection.test.ts
@@ -24,6 +24,49 @@ describe("projectAnthropicTools", () => {
     expect(reversed.tools).toEqual(first.tools);
   });
 
+  it("retains same-original duplicates while sorting their descriptions", () => {
+    const projection = projectAnthropicTools(
+      ["Zulu", "Alpha"].map((description) => ({
+        name: "Read",
+        description,
+        parameters: { type: "object", properties: {} },
+      })),
+      (name) => name.toLowerCase(),
+    );
+
+    expect(projection.inputToolCount).toBe(2);
+    expect(projection.unavailableOriginalNames).toEqual(new Set());
+    expect(projection.tools).toEqual([
+      {
+        originalName: "Read",
+        wireName: "read",
+        description: "Alpha",
+        inputSchema: { type: "object", properties: {}, required: [] },
+      },
+      {
+        originalName: "Read",
+        wireName: "read",
+        description: "Zulu",
+        inputSchema: { type: "object", properties: {}, required: [] },
+      },
+    ]);
+  });
+
+  it.each([
+    { names: ["Read", "Read", "read"], first: "Read", last: "read" },
+    { names: ["read", "read", "Read"], first: "read", last: "Read" },
+  ])(
+    "keeps the first accepted spelling in a collision after $first duplicates",
+    ({ names, first, last }) => {
+      expect(() =>
+        projectAnthropicTools(
+          names.map((name) => ({ name, description: name, parameters: { type: "object" } })),
+          () => "Read",
+        ),
+      ).toThrow(`Anthropic tool names "${first}" and "${last}" both map to "Read"`);
+    },
+  );
+
   it.each([
     { name: "implicit dialect", dialect: undefined, definitionsKey: "$defs" },
     {

--- a/packages/ai/src/providers/anthropic-tool-projection.ts
+++ b/packages/ai/src/providers/anthropic-tool-projection.ts
@@ -169,6 +169,7 @@ export function projectAnthropicTools(
   toWireName: (name: string) => string,
 ): AnthropicToolProjection {
   const projectedTools: AnthropicProjectedTool[] = [];
+  const originalNameByWireName = new Map<string, string>();
   const unavailableOriginalNames = new Set<string>();
   for (const tool of tools) {
     let projectedTool: AnthropicProjectedTool;
@@ -229,14 +230,13 @@ export function projectAnthropicTools(
       }
       continue;
     }
-    const conflictingTool = projectedTools.find(
-      (entry) => entry.wireName === projectedTool.wireName,
-    );
-    if (conflictingTool && conflictingTool.originalName !== projectedTool.originalName) {
+    const conflictingName = originalNameByWireName.get(projectedTool.wireName);
+    if (conflictingName !== undefined && conflictingName !== projectedTool.originalName) {
       throw new Error(
-        `Anthropic tool names "${conflictingTool.originalName}" and "${projectedTool.originalName}" both map to "${projectedTool.wireName}"`,
+        `Anthropic tool names "${conflictingName}" and "${projectedTool.originalName}" both map to "${projectedTool.wireName}"`,
       );
     }
+    originalNameByWireName.set(projectedTool.wireName, projectedTool.originalName);
     projectedTools.push(projectedTool);
   }
   return {


### PR DESCRIPTION
## What Problem This Solves

Agents using many tools do avoidable request preparation work before starting an Anthropic turn. The cost grows with the number of distinct tool names.

## Why This Change Was Made

Use one temporary map of accepted wire names instead of repeatedly scanning all previously projected tools for collisions. Populate it only after successful schema projection, preserving quarantined tools, same-original duplicates and the exact first-spelling collision error. Sorting, cache markers, forced choices and OAuth response-name mapping are unchanged.

The index is local to projection and is discarded afterward; this does not extend its lifetime across the request or stream. Production LOC is unchanged. The existing projection suite gains 43 lines of preservation coverage; there are no new dependencies, configuration, storage, protocol or public API fields.

## User Impact

Large distinct tool rosters require fewer repeated comparisons before an Anthropic request. The fixed full-SDK comparison shows gains for the 32/128/256-tool fixtures, with small and schema-heavy cases sometimes slower. This is a targeted preparation improvement, not a uniform response-latency or memory claim.

## Evidence

All 239 tests across three complete provider/projection/managed-transport suites passed, along with all 28 selected normal checks. Independent P0–P2 review found no actionable issues. Separate source and data audits checked the complete fixtures, output graphs and measurement arithmetic.

The fixed B0/C0/C1/B1 cohort calls public streamAnthropic through actual request preparation, real SDK serialization, finite authored SSE and the shared event reducer. A fixture fetch supplies the local response; no external provider request or real API credential is involved. All 2,016 complete V8 graphs reconcile: 1,568 wire requests, 448 expected zero-fetch local errors, 1,152 groups and 8,176 events. Complete request bytes, final fields, bounded timestamps and shared-reference relationships match the independently authored expectations. Shared event objects are retained after settlement, not frozen at each emission.

Each row has four warmups and twelve batches of two individually timed complete calls in each fresh process. The table shows medians of the two-call means: candidate-minus-baseline percentage and microseconds; negative is faster.

| Workload | Forward change / Δµs | Reverse change / Δµs |
| --- | ---: | ---: |
| No tools | -19.35% / -46.635 | -8.63% / -24.083 |
| One tool | +29.83% / +56.489 | +1.48% / +2.896 |
| Eight tools | +11.70% / +20.240 | -7.91% / -15.313 |
| 32 tools | -5.69% / -14.292 | -2.45% / -5.875 |
| 128 tools | -9.86% / -55.782 | -3.97% / -20.229 |
| 256 tools (stress) | -17.47% / -163.511 | -19.44% / -181.114 |
| 128 tools, reversed | -15.86% / -83.157 | -9.02% / -44.511 |
| Same-original duplicates | -0.31% / -0.396 | +17.40% / +20.719 |
| Invalid before valid | -3.54% / -5.104 | -1.59% / -2.073 |
| OAuth, 128 tools | -8.98% / -51.291 | -17.13% / -92.573 |
| OAuth response-name mapping | +1.30% / +1.677 | -1.64% / -2.083 |
| Collision | +19.04% / +9.385 | -5.69% / -3.636 |
| Reversed collision | +4.34% / +2.020 | +0.67% / +0.355 |
| Duplicate then collision | +15.56% / +7.344 | -17.17% / -10.083 |
| Cache markers, 32 tools | +2.94% / +5.500 | +12.34% / +25.729 |
| Nested tuple definitions | +22.03% / +39.104 | +13.63% / +25.958 |
| Forced original name | +21.98% / +26.333 | -18.48% / -27.604 |
| Unavailable forced name | -5.18% / -2.510 | +8.37% / +3.958 |

Performance is mixed: 15/36 batch medians, 117/252 aggregate metrics and 273/576 indexed comparisons are adverse. One-tool, cached 32-tool and tuple-definition medians regress in both orders. The no-tools row bypasses projection, so its gain is not attributable to this change. The 256-tool row is stress coverage, not a typical-workload claim. All warmups, timings, complete graphs and adverse outcomes remain retained; no favorable rerun or threshold selection was used. A single fixed cohort does not establish stable tails, and maxima of batch means are not individual-call tail latencies.

Whole-phase wall time decreases 6.33%/0.96%, but includes imports, setup and capture. Two of twelve resource comparisons regress: forward sampled tree RSS rises 1.03%, and reverse system CPU rises 0.91%. Other resource measurements improve slightly. No general memory, Gateway latency or remote Anthropic performance benefit is claimed. All processes closed and the candidate source was restored before final review.
