### PR TITLE
fix(test): finish service worker setup before deployment

### DIFF
--- a/ui/src/e2e/service-worker-update.e2e.test.ts
+++ b/ui/src/e2e/service-worker-update.e2e.test.ts
@@ -169,6 +169,11 @@ async function ensureControlledPage(page: Page, pageErrors: string[], expectedBu
     await page.reload();
   }
   await page.waitForFunction(() => navigator.serviceWorker?.controller?.state === "activated");
+  // Finish startup's update check before a later build replaces the served files.
+  // Concurrent native update calls can otherwise share the old build's response.
+  await page.evaluate(async () => {
+    await (await navigator.serviceWorker.ready).update();
+  });
 }
 
 async function fetchControlledAsset(


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent production service-worker E2E failure where the simulated deployment completes without a build-B worker or cache, leaving the draft-preservation test waiting for an update that never started.

Original failure: https://github.com/openclaw/openclaw/actions/runs/34111989955/job/101714057877

## Why This Change Was Made

The test could replace the served build while a startup update check still held build-A bytes. Chromium can coalesce a concurrent deployment update with that request. The existing controlled-page helper now completes the initial native update check before the test builds and serves the replacement.

## User Impact

More reliable service-worker deployment coverage. No production behavior or UI appearance changes. Existing cache, activation, draft, build-identity, URL, and reload assertions remain unchanged.

## Evidence

A private native HTTP probe held a real build-A worker response through the build-B directory swap. The original test failed **0/1** at its existing 15-second missing-B-cache assertion: the deployment update resolved with active A, no replacement, and only the A cache. With CI’s two-worker ceiling, the original failed **0/1** and the exact five-line repair passed **5/5**; an earlier one-worker control also failed **0/1** before and passed **5/5** after. Each trace confirms the setup update settled before build B was served; the original assertions then passed. The probe preserved worker response bytes and native promise identity; no diagnostic proxy code is included in this PR.

```sh
# Controlled before/after runs use CI's two-worker ceiling:
CI=1 OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/service-worker-update.e2e.test.ts -t 'recovers a missed worker activation without losing a chat draft'
# Clean full-file sibling verification:
CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/service-worker-update.e2e.test.ts
node scripts/check-changed.mjs
```

Known gap: the historical CI artifact lacks request/lifecycle traces. This proves a reachable matching race, not the exact scheduling of that prior run. All endpoints and data are synthetic; no live-provider claim.

Clean full service-worker file: **4/4 passed**, including chat/config drafts, deep-link boot, and terminal restoration (63.21 seconds). Independent Codex review through P2 and automated maintainer review: zero actionable findings. `node scripts/check-changed.mjs` passed.

Controlled proof used local Chromium on macOS with `CI=1` and the canonical E2E configuration. Native Linux exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/34121720362 (head `586625b0f119469f9200990873a69bd9bd9cd3d4`, SUCCESS, zero pending checks). The two-worker after-loop took 102.45 seconds; each run starts a fresh browser and fixture.
