### PR TITLE
refactor(codex): share turn envelope normalization

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -193,7 +193,7 @@ extensions/codex/src/app-server/plugin-approval-roundtrip.ts	1
 extensions/codex/src/app-server/plugin-inventory.ts	6
 extensions/codex/src/app-server/plugin-metadata-cache.ts	5
 extensions/codex/src/app-server/plugin-thread-app-admission.ts	1
-extensions/codex/src/app-server/protocol-validators.ts	8
+extensions/codex/src/app-server/protocol-validators.ts	7
 extensions/codex/src/app-server/rate-limits.ts	1
 extensions/codex/src/app-server/reasoning-effort.ts	1
 extensions/codex/src/app-server/remote-workspace-media.ts	6

--- a/extensions/codex/src/app-server/protocol-validators.ts
+++ b/extensions/codex/src/app-server/protocol-validators.ts
@@ -358,10 +358,7 @@ export function assertCodexThreadAcceptsDirectInput(
 
 /** Asserts and normalizes a Codex turn/start response. */
 export function assertCodexTurnStartResponse(value: unknown): CodexTurnStartResponse {
-  const normalized = normalizeWithDefaults(
-    turnStartResponseSchema,
-    normalizeTurnStartResponse(value),
-  );
+  const normalized = normalizeWithDefaults(turnStartResponseSchema, normalizeTurnEnvelope(value));
   return assertCodexShape(validateTurnStartResponse, normalized, "turn/start response");
 }
 
@@ -435,10 +432,7 @@ export function readCodexTurnCompletedNotification(
 ): CodexTurnCompletedNotification | undefined {
   return readCodexShape(
     validateTurnCompletedNotification,
-    normalizeWithDefaults(
-      turnCompletedNotificationSchema,
-      normalizeTurnCompletedNotification(value),
-    ),
+    normalizeWithDefaults(turnCompletedNotificationSchema, normalizeTurnEnvelope(value)),
   );
 }
 
@@ -496,17 +490,7 @@ function normalizeThreadItem(value: unknown): unknown {
   }
 }
 
-function normalizeTurnStartResponse(value: unknown): unknown {
-  if (!value || typeof value !== "object" || Array.isArray(value) || !("turn" in value)) {
-    return value;
-  }
-  return {
-    ...value,
-    turn: normalizeTurn((value as { turn?: unknown }).turn),
-  };
-}
-
-function normalizeTurnCompletedNotification(value: unknown): unknown {
+function normalizeTurnEnvelope(value: unknown): unknown {
   if (!value || typeof value !== "object" || Array.isArray(value) || !("turn" in value)) {
     return value;
   }


### PR DESCRIPTION
## What Problem This Solves

Codex turn/start responses and turn/completed notifications used separate copies of the same turn-envelope normalization. Keeping those copies independent created unnecessary drift risk at a protocol boundary.

## Why This Change Was Made

Both private call paths now use one `normalizeTurnEnvelope` helper while retaining their separate generated schemas, validators, defaults, error labels, and public APIs. The helper preserves the existing object guard, spread behavior, nested turn normalization, and completion `threadId`.

The assertion-safety baseline for the same file is reduced from 8 to 7 because removing the duplicate helper also removes one grandfathered type assertion.

## User Impact

No user-visible behavior changes. The Codex protocol boundary is smaller and less likely to diverge between turn startup and completion.

## Evidence

- `protocol-validators.test.ts`: 18 tests passed
- `schema-normalization-runtime-contract.test.ts` and `run-attempt-lifecycle-controller.test.ts`: 9 tests passed
- `pnpm test:extension codex`: all 20 chunks passed
- `pnpm check:assertion-safety --base origin/main`: passed
- Changed gate passed through the core tsgo graph boundary; extension tsgo could not start because declaration tooling rejects the task worktree's external `node_modules` symlink
- Fresh scoped autoreview of the complete two-file candidate: clean, no P0/P1 findings
- `git diff --check`
- Exact-head CI run `34122600474`: 83 jobs passed at `5922608673ff005bc57558e650b5ea2c2f0b95a2`
- Native keyless `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 141215`: passed
