### PR TITLE
fix(ui): count selected usage tool invocations accurately

### DIFF
--- a/docs/web/control-ui/feature-reference.md
+++ b/docs/web/control-ui/feature-reference.md
@@ -83,6 +83,7 @@ Control UI capabilities grouped by area, each with the Gateway RPC methods behin
     - Session-derived token and estimated-cost analysis stays separate from provider billing.
     - Filter sessions with the provider, model, channel, or tool menus, or type case-insensitive `key:value` terms. Values within one category match as alternatives. Toggling a menu option preserves the other filters and their quoted text.
     - Selecting days narrows token and cost totals to those days within the active session filters. Daily charts and exports retain that session scope. Provider/model/tool queries select matching sessions, including all usage within each matched session; hour filters select sessions active in those hours.
+    - Drag the handles in a session’s usage timeline to inspect an interval. Tool-call counts use assistant invocations in the loaded conversation, including repeated calls to the same tool; tool results do not add calls.
     - Select **Local** or **UTC** for hourly charts and peak error hours. Historical hour labels stay tied to the selected time zone, including when you view them across a daylight-saving transition.
     - Provider cards call `usage.status` and show live plan names, quota windows, balances, spend, and budgets reported by configured provider plugins.
     - A provider usage failure does not block the session/cost dashboard; unavailable provider cards show their own error state.

--- a/ui/src/e2e/usage-tool-count.e2e.test.ts
+++ b/ui/src/e2e/usage-tool-count.e2e.test.ts
@@ -1,0 +1,158 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Usage selected-range tool calls" });
+
+suite.define(() => {
+  it("counts each assistant invocation once after dragging the timeline range", async () => {
+    const date = "2026-08-20";
+    const start = Date.parse(`${date}T12:00:00Z`);
+    const totals = {
+      input: 300,
+      output: 60,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 360,
+      totalCost: 0,
+      inputCost: 0,
+      outputCost: 0,
+      cacheReadCost: 0,
+      cacheWriteCost: 0,
+      missingCostEntries: 0,
+    };
+    // The current whole-session producer groups repeated names within each message.
+    const tools = {
+      totalCalls: 2,
+      uniqueTools: 2,
+      tools: [
+        { name: "read", count: 1 },
+        { name: "exec", count: 1 },
+      ],
+    };
+    const messages = { total: 3, user: 0, assistant: 3, toolCalls: 2, toolResults: 2, errors: 0 };
+    const points = [start, start + 2000, start + 4000].map((timestamp, index) => ({
+      timestamp,
+      input: 100,
+      output: 20,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 120,
+      cost: 0,
+      cumulativeTokens: 120 * (index + 1),
+      cumulativeCost: 0,
+    }));
+    const artifactParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const proofDir = artifactParent
+      ? createControlUiE2eArtifactDir("usage-tool-count", artifactParent)
+      : undefined;
+    await suite.withPage(
+      {
+        locale: "en-US",
+        timezoneId: "UTC",
+        serviceWorkers: "block",
+        viewport: { width: 1440, height: 1000 },
+      },
+      async ({ page }) => {
+        await page.clock.setFixedTime(new Date(start + 5000));
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "sessions.usage": {
+              updatedAt: start + 5000,
+              startDate: date,
+              endDate: date,
+              sessions: [
+                {
+                  key: "agent:main:tool-count",
+                  label: "Review two files",
+                  agentId: "main",
+                  updatedAt: start + 5000,
+                  usage: {
+                    ...totals,
+                    activityDates: [date],
+                    toolUsage: tools,
+                    messageCounts: messages,
+                  },
+                },
+              ],
+              totals,
+              aggregates: {
+                messages,
+                tools,
+                byModel: [],
+                byProvider: [],
+                byAgent: [],
+                byChannel: [],
+                daily: [],
+              },
+            },
+            "usage.cost": {
+              updatedAt: start + 5000,
+              days: 1,
+              daily: [{ date, ...totals }],
+              totals,
+            },
+            "usage.status": { updatedAt: start + 5000, providers: [] },
+            "sessions.usage.timeseries": { points },
+            "sessions.usage.logs": {
+              logs: [
+                { timestamp: start, role: "assistant", content: "[Tool: read]\n[Tool: read]" },
+                {
+                  timestamp: start + 500,
+                  role: "toolResult",
+                  content: "[Tool: read]\n[Tool Result]\nFirst file",
+                },
+                {
+                  timestamp: start + 1000,
+                  role: "toolResult",
+                  content: "[Tool: read]\n[Tool Result]\nSecond file",
+                },
+                { timestamp: start + 2000, role: "assistant", content: "Both files reviewed." },
+                { timestamp: start + 4000, role: "assistant", content: "[Tool: exec]" },
+              ],
+            },
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}usage`);
+        await page.getByRole("button", { name: "Review two files", exact: true }).click();
+        await gateway.waitForRequest("sessions.usage.timeseries");
+        await gateway.waitForRequest("sessions.usage.logs");
+        const panel = page.locator(".session-detail-panel");
+        const handle = panel.locator(".chart-handle-right");
+        await handle.waitFor({ state: "visible" });
+        await handle.scrollIntoViewIfNeeded();
+        const handleBox = await handle.boundingBox();
+        const chartBox = await panel.locator(".timeseries-svg").boundingBox();
+        expect(handleBox).not.toBeNull();
+        expect(chartBox).not.toBeNull();
+        if (!handleBox || !chartBox) {
+          throw new Error("Timeline drag handles did not render");
+        }
+        const y = handleBox.y + handleBox.height / 2;
+        await page.mouse.move(handleBox.x + handleBox.width / 2, y);
+        await page.mouse.down();
+        await page.mouse.move(chartBox.x + (chartBox.width * (30 + 366 / 2)) / 400, y, {
+          steps: 8,
+        });
+        await page.mouse.up();
+        await panel.locator(".session-detail-indicator").waitFor({ state: "visible" });
+        const count = panel.locator(".session-summary-value").nth(1);
+        await expect.poll(() => panel.locator(".session-log-entry").count()).toBe(4);
+        if (proofDir) {
+          await panel.screenshot({ path: path.join(proofDir, "selected-range.png") });
+        }
+        await expect.poll(() => count.textContent()).toBe("2");
+        const readRow = panel.locator(".usage-list-item").filter({ hasText: "read" });
+        expect(await readRow.locator(".usage-list-value > span").first().textContent()).toBe("2");
+        expect(await panel.locator(".session-log-tools-pill").first().textContent()).toContain(
+          "read × 2",
+        );
+        await panel.getByRole("button", { name: "Reset", exact: true }).click();
+        await expect.poll(() => panel.locator(".session-detail-indicator").count()).toBe(0);
+        await expect.poll(() => panel.locator(".session-log-entry").count()).toBe(5);
+      },
+    );
+  });
+});

--- a/ui/src/pages/usage/view-details.test.ts
+++ b/ui/src/pages/usage/view-details.test.ts
@@ -24,7 +24,7 @@ function point(overrides: Partial<TimeSeriesPoint> = {}): TimeSeriesPoint {
   };
 }
 
-function session(): UsageSessionEntry {
+function session(): UsageSessionEntry & { usage: NonNullable<UsageSessionEntry["usage"]> } {
   return {
     key: "agent:main:detail",
     label: "Detail session",
@@ -52,7 +52,7 @@ function session(): UsageSessionEntry {
         errors: 0,
       },
     },
-  } as UsageSessionEntry;
+  };
 }
 
 function mount(
@@ -70,6 +70,7 @@ function mount(
     timeSeries?: string;
     sessionLogs?: string;
     sessionLogsData?: SessionLogEntry[];
+    session?: UsageSessionEntry;
     stale?: boolean;
     contextWeight?: UsageSessionEntry["contextWeight"];
     contextExpanded?: boolean;
@@ -85,7 +86,7 @@ function mount(
   const container = document.createElement("div");
   render(
     renderSessionDetailPanel(
-      { ...session(), contextWeight: errors.contextWeight },
+      { ...(errors.session ?? session()), contextWeight: errors.contextWeight },
       { points },
       false,
       status(errors.timeSeries),
@@ -238,6 +239,60 @@ describe("renderSessionDetailPanel filtered usage", () => {
       container.querySelector(".timeseries-breakdown .cost-breakdown-total")?.textContent,
     ).toContain("47");
   });
+
+  it.each(["tool", "toolResult"] as const)(
+    "counts repeated assistant calls without counting %s results in the selected range",
+    (resultRole) => {
+      const start = Date.parse("2026-08-20T12:00:00Z");
+      const end = start + 2000;
+      const entry = session();
+      entry.usage = {
+        ...entry.usage,
+        toolUsage: {
+          totalCalls: 2,
+          uniqueTools: 2,
+          tools: [
+            { name: "read", count: 1 },
+            { name: "exec", count: 1 },
+          ],
+        },
+      };
+      const logs: SessionLogEntry[] = [
+        { timestamp: start, role: "assistant", content: "[Tool: read]\n[Tool: read]" },
+        {
+          timestamp: start + 500,
+          role: resultRole,
+          content: "[Tool: read]\n[Tool Result]\nFirst file",
+        },
+        {
+          timestamp: start + 1000,
+          role: resultRole,
+          content: "[Tool: read]\n[Tool Result]\nSecond file",
+        },
+        { timestamp: end, role: "assistant", content: "Both files reviewed." },
+        { timestamp: end + 1000, role: "assistant", content: "[Tool: exec]" },
+      ];
+      const points = [start, end, end + 1000].map((timestamp) => point({ timestamp }));
+      const data = { session: entry, sessionLogsData: logs };
+      const selected = mount(points, start, end, "total", {}, data);
+      expect(selected.querySelectorAll(".session-summary-value")[1]?.textContent).toBe("2");
+      expect(selected.querySelectorAll(".session-summary-meta")[1]?.textContent?.trim()).toBe(
+        "1 tools used",
+      );
+      expect(
+        [...selected.querySelectorAll(".usage-list-item")].map((item) => [
+          item.firstElementChild?.textContent,
+          item.querySelector(".usage-list-value > span")?.textContent,
+        ]),
+      ).toEqual([
+        ["read", "2"],
+        ["exec", "0"],
+      ]);
+      expect(selected.querySelector(".session-log-tools-pill")?.textContent?.trim()).toBe(
+        "read × 2",
+      );
+    },
+  );
 
   it("accepts a reversed range and falls back to full totals when no points match", () => {
     const reversed = mount(

--- a/ui/src/pages/usage/view-details.ts
+++ b/ui/src/pages/usage/view-details.ts
@@ -118,10 +118,10 @@ function renderSessionSummary(
   let toolCounts: Map<string, number> | undefined;
   if (filteredLogs) {
     toolCounts = new Map();
-    for (const log of filteredLogs) {
-      const { tools } = parseToolSummary(log.content);
-      for (const [name] of tools) {
-        toolCounts.set(name, (toolCounts.get(name) || 0) + 1);
+    // Result rows carry tool names for filtering, but only assistant rows record calls.
+    for (const log of filteredLogs.filter(({ role }) => role === "assistant")) {
+      for (const [name, count] of parseToolSummary(log.content).tools) {
+        toolCounts.set(name, (toolCounts.get(name) ?? 0) + count);
       }
     }
   }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users inspecting a selected interval in the Usage timeline would see incorrect tool-call counts when an assistant called the same tool repeatedly and received results. Two read calls followed by their two results displayed as three calls.

## Why This Change Was Made

The selected-range summary now counts assistant invocations using the multiplicity already preserved by the compact-log parser. Result markers remain available for conversation filtering. The repair replaces the inaccurate accumulation without increasing production lines (+4/-4).

## User Impact

The tool-call total and top-tool rows reflect invocations in the selected interval of the loaded conversation. The Usage feature reference explains the behavior.

## Evidence

The regression failed on the original source for both supported result-row dialects, with an expected count of 2 and an actual count of 3. The repaired candidate passes 20 focused detail/parser tests. An isolated Chromium flow used the real timeline handle: it displayed 3 calls before the fix and 2 afterward, checked the per-tool count, then reset the range successfully.

![Before: selected interval incorrectly shows 3 tool calls](https://github.com/user-attachments/assets/078ddb92-37be-463e-9e75-7404757ffab5)
![After: selected interval correctly shows 2 tool calls](https://github.com/user-attachments/assets/b9396c6e-f6b1-4160-bc46-355642aed589)

The validated candidate also passes the production UI type graph, both owning test type graphs, full-file lint, stylelint, i18n verification, and formatting. Independent review is scoped-clean through P2.

After refreshing onto current main, the same 20 detail/parser tests, both owning test type graphs, full-file lint, and Chromium drag/reset flow pass. A fresh after screenshot confirms 2 tool calls, read 2, and exec 0 in the selected interval. Final independent review of the refreshed integration is scoped-clean through P2.

Known separate follow-ups: whole-session aggregation deduplicates repeated tool names within a message, and selected-range user/assistant message counts are inferred from sampled token points. Those remain outside this repair. Counts here use the existing bounded conversation data; no persistent aggregate, schema, API, or retention change is included.
