### PR TITLE
fix(discord): show member presence immediately after reconnect

### DIFF
--- a/extensions/discord/src/monitor/listeners.presence.test.ts
+++ b/extensions/discord/src/monitor/listeners.presence.test.ts
@@ -10,7 +10,7 @@ import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Client } from "../internal/discord.js";
 import type { DiscordLivePolicy } from "./live-policy.js";
-import { clearPresences } from "./presence-cache.js";
+import { clearPresences, getPresence } from "./presence-cache.js";
 import { DiscordPresenceBaselineCache } from "./presence-transition-cache.js";
 
 const mocks = vi.hoisted(() => ({
@@ -56,7 +56,7 @@ function presence(status: "online" | "offline", userId = "user-1"): GatewayPrese
 }
 
 function guildSnapshot(
-  presences: GatewayPresenceUpdate[],
+  presences: Array<Omit<GatewayPresenceUpdate, "guild_id">>,
   memberCount = 100,
 ): GatewayGuildCreateDispatchData {
   return {
@@ -284,17 +284,89 @@ describe("DiscordPresenceListener", () => {
     expect(mocks.requestHeartbeat).toHaveBeenCalledTimes(1);
   });
 
+  it.each(["unconfigured", "disabled", "filtered"] as const)(
+    "caches snapshot status and activities when presence events are %s",
+    async (mode) => {
+      const listener = createPresenceListener({
+        guildEntries:
+          mode === "unconfigured"
+            ? undefined
+            : {
+                "guild-1": {
+                  presenceEvents: {
+                    channelId: "channel-1",
+                    enabled: mode !== "disabled",
+                    users: [],
+                  },
+                },
+              },
+      });
+      const snapshotPresence = {
+        user: { id: "user-1" },
+        status: PresenceUpdateStatus.Online,
+        activities: [{ name: "Chess", type: 0, created_at: 0 }],
+        client_status: {},
+      } satisfies Omit<GatewayPresenceUpdate, "guild_id">;
+
+      await listener.seedGuildSnapshot(guildSnapshot([snapshotPresence]));
+
+      expect(getPresence("molty", "user-1")).toEqual({
+        ...snapshotPresence,
+        guild_id: "guild-1",
+      });
+      expect(getPresence("other-account", "user-1")).toBeUndefined();
+      expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+      expect(mocks.requestHeartbeat).not.toHaveBeenCalled();
+    },
+  );
+
   it("orders a presence event after its pending live-policy guild seed", async () => {
     const policy = livePresencePolicy();
     const ready = createDeferred<DiscordLivePolicy>();
     const readPolicy = vi.fn().mockReturnValueOnce(ready.promise).mockResolvedValue(policy);
     const listener = createPresenceListener({ readPolicy });
     const seed = listener.seedGuildSnapshot(guildSnapshot([presence("offline")]));
+    expect(getPresence("molty", "user-1")?.status).toBe("offline");
     const event = listener.handle(presence("online"), humanClient);
+    expect(getPresence("molty", "user-1")?.status).toBe("online");
     expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
     ready.resolve(policy);
     await Promise.all([seed, event]);
+    expect(getPresence("molty", "user-1")?.status).toBe("online");
     expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not restore cached presence when READY follows a pending snapshot and update", async () => {
+    const policy = livePresencePolicy();
+    const ready = createDeferred<DiscordLivePolicy>();
+    const listener = createPresenceListener({ readPolicy: () => ready.promise });
+    const seed = listener.seedGuildSnapshot(guildSnapshot([presence("offline")]));
+    const event = listener.handle(presence("online"), humanClient);
+    // Queue READY after policy resolution, before the pending update can resume.
+    ready.resolve(policy);
+    await ready.promise;
+    listener.resetGatewaySession();
+    await Promise.all([seed, event]);
+
+    expect(getPresence("molty", "user-1")).toBeUndefined();
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it("keeps snapshot caching bounded and leaves unreported members unknown", async () => {
+    const listener = createPresenceListener({ guildEntries: undefined });
+    await listener.seedGuildSnapshot(
+      guildSnapshot(
+        Array.from({ length: 5_001 }, (_, i) => presence("online", `user-${i}`)),
+        75_001,
+      ),
+    );
+
+    expect(getPresence("molty", "user-0")).toBeUndefined();
+    expect(getPresence("molty", "user-1")?.status).toBe("online");
+    expect(getPresence("molty", "user-5000")?.status).toBe("online");
+    expect(getPresence("molty", "unreported")).toBeUndefined();
+    await listener.seedGuildSnapshot({ id: "guild-1", unavailable: true });
+    expect(getPresence("molty", "user-5000")?.status).toBe("online");
   });
 
   it.each(["delete", "reset", "replace"] as const)(

--- a/extensions/discord/src/monitor/listeners.presence.test.ts
+++ b/extensions/discord/src/monitor/listeners.presence.test.ts
@@ -304,7 +304,7 @@ describe("DiscordPresenceListener", () => {
       const snapshotPresence = {
         user: { id: "user-1" },
         status: PresenceUpdateStatus.Online,
-        activities: [{ name: "Chess", type: 0, created_at: 0 }],
+        activities: [{ id: "activity-1", name: "Chess", type: 0, created_at: 0 }],
         client_status: {},
       } satisfies Omit<GatewayPresenceUpdate, "guild_id">;
 

--- a/extensions/discord/src/monitor/listeners.ts
+++ b/extensions/discord/src/monitor/listeners.ts
@@ -137,6 +137,15 @@ export class DiscordPresenceListener extends PresenceUpdateListener {
   }
 
   async seedGuildSnapshot(data: GuildCreateEvent): Promise<void> {
+    // Cache metadata before awaiting greeting policy so updates and READY retain dispatch order.
+    if (data.unavailable !== true && "presences" in data && Array.isArray(data.presences)) {
+      for (const presence of data.presences) {
+        const userId = presence.user?.id;
+        if (userId) {
+          setPresence(this.params.accountId, userId, { ...presence, guild_id: data.id });
+        }
+      }
+    }
     if (!this.params.readPolicy) {
       this.seedGuildSnapshotWithPolicy(data, this.params.guildEntries);
       return;
@@ -207,15 +216,15 @@ export class DiscordPresenceListener extends PresenceUpdateListener {
   }
 
   async handle(data: PresenceUpdateEvent, client: Client) {
-    const pendingSeed = this.pendingGuildSeeds.get(data.guild_id);
-    if (pendingSeed && !(await pendingSeed)) {
-      return;
-    }
     const userId = data.user?.id;
     if (!userId) {
       return;
     }
     setPresence(this.params.accountId, userId, data);
+    const pendingSeed = this.pendingGuildSeeds.get(data.guild_id);
+    if (pendingSeed && !(await pendingSeed)) {
+      return;
+    }
     const presenceKey = `${this.params.accountId}:${data.guild_id}:${userId}`;
     const gatewayGeneration = this.gatewayGeneration;
     const guildGeneration = this.guildPresenceState.get(data.guild_id)?.generation ?? 0;

--- a/extensions/discord/src/monitor/presence-cache.ts
+++ b/extensions/discord/src/monitor/presence-cache.ts
@@ -3,7 +3,7 @@ import type { GatewayPresenceUpdate } from "discord-api-types/v10";
 
 /**
  * In-memory cache of Discord user presence data.
- * Populated by PRESENCE_UPDATE gateway events when the GuildPresences intent is enabled.
+ * Populated by GUILD_CREATE snapshots and PRESENCE_UPDATE when GuildPresences is enabled.
  * Per-account maps are capped to prevent unbounded growth (#4948).
  */
 const MAX_PRESENCE_PER_ACCOUNT = 5000;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users requesting Discord member information would receive no status or activities after startup or reconnect, until that member generated a new presence update.

Fixes #141054. Thanks @nissl24 for the report and reproduction details.

## Why This Change Was Made

Seed the existing account-scoped presence cache from `GUILD_CREATE`, independently of optional greeting monitoring. Record both snapshot and live-update metadata before asynchronous greeting-policy work so a delayed continuation cannot restore stale cache entries after `READY` clears the session.

The existing 5,000-entry bound, account isolation, greeting policy, and member-info access checks remain in force. No configuration, dependency, schema, or exported API changes.

## User Impact

With the Discord presence intent enabled, member-info can immediately report the status and activities supplied in a guild snapshot. Later presence updates take precedence. Members without a cached observation remain unknown; omission from a partial snapshot does not erase previously known metadata.

## Evidence

### Author Evidence At The Original Head

Base: `f35313dcfe0e372d6f8316b63a37155367525b70`.
Candidate: `5dc851ee0956275d754791bd5cbb1802c757a610`.

- Red before fix: six regression cases failed on the base, covering missing snapshot metadata, greeting configuration independence, update ordering, stale cache restoration after READY, and bounded snapshot storage.
- Green after fix: **235 tests passed** across `listeners.presence.test.ts`, `monitor.threading-utils.test.ts`, and `actions/runtime.test.ts`, using `node scripts/run-vitest.mjs` with those three paths. The tested source is the source committed in the candidate above.
- Formatting and `git diff --check` passed. Required independent autoreview: no actionable P0–P2 findings.
- Production delta: **+9 lines**; test delta: **+72 lines**. The added loop supplies the previously missing snapshot input to the existing cache; combining it with the policy-filtered asynchronous greeting loop would preserve the bug.

### Completed real Gateway behavior proof

Executed on the candidate SHA above on Windows / Node 26.2.0. The canonical QA runtime build completed successfully (`OPENCLAW_BUILD_PRIVATE_QA=1 node scripts/run-node.mjs --version`); the built CLI reported `OpenClaw 2026.9.2 (5dc851e)`.

A loopback Discord HTTPS/WebSocket fixture supplied actual protocol frames to the running, built Discord plugin. A mock OpenAI provider was available; this read-only tool action does not require a model inference. The real Gateway handled authenticated `POST /tools/invoke` requests for `message` / `member-info`, including the Discord REST member fetch and cache lookup. No listener, cache, or tool-result function was mocked.

Observed sequence: IDENTIFY → READY → GUILD_CREATE → member-info **before any PRESENCE_UPDATE**; then PRESENCE_UPDATE → member-info; then a new-session READY → member-info → replacement GUILD_CREATE → member-info **without a subsequent PRESENCE_UPDATE**. Heartbeat responses provided protocol-order barriers. Greeting monitoring was unconfigured.

Redacted verdict JSON (status/activity values are the actual tool responses; identifiers, credentials, and endpoints omitted):

```json
{
  "verdict": "pass",
  "head": "5dc851ee0956275d754791bd5cbb1802c757a610",
  "runtime": "OpenClaw 2026.9.2 (5dc851e)",
  "transport": "mock Discord HTTPS/WebSocket + real ephemeral OpenClaw Gateway",
  "greetings": "unconfigured",
  "observations": [
    {
      "case": "guild-create-before-any-presence-update",
      "tool": "message/member-info",
      "httpStatus": 200,
      "ok": true,
      "status": "online",
      "activities": [
        {
          "name": "Initial snapshot activity",
          "type": 0,
          "created_at": 1
        }
      ]
    },
    {
      "case": "presence-update-overrides-snapshot",
      "tool": "message/member-info",
      "httpStatus": 200,
      "ok": true,
      "status": "idle",
      "activities": [
        {
          "name": "Updated activity",
          "type": 0,
          "created_at": 2
        }
      ]
    },
    {
      "case": "ready-clears-presence",
      "tool": "message/member-info",
      "httpStatus": 200,
      "ok": true,
      "status": "absent",
      "activities": []
    },
    {
      "case": "guild-create-reseeds-after-ready",
      "tool": "message/member-info",
      "httpStatus": 200,
      "ok": true,
      "status": "dnd",
      "activities": [
        {
          "name": "Replacement snapshot activity",
          "type": 0,
          "created_at": 1
        }
      ]
    }
  ],
  "failures": []
}
```

Runtime command: `node --import ./scripts/tsx.mjs .tmp/141054-proof/presence-runtime.ts` — **exit 0**. The fixture launched `node openclaw.mjs gateway run` with isolated state and loopback binding, then stopped its owned Gateway and mock servers. Local verdict SHA-256: `0ea6c0ebe555e965a78de453438ed704d4b44f1b1102c2f22a1f81c0e61cd880`.

Scope: this is the repository-permitted mock-Gateway proof, not a live Discord account test. The fixture injects the reconnect/new-session READY and GUILD_CREATE lifecycle; it does not demonstrate a physical network outage or Discord's real service. It directly covers the changed cache producer and user-visible consumer. This also supplies the requested Rank-up transcript before the next presence update.

### Additional validation and limitations

- Full Discord suite at the candidate: **3,646 passed, 19 failed across 3 of 263 files**. Failures were Windows `EBUSY`/`EPERM` SQLite/temp-directory cleanup errors in thread deletion, native reset, and thread bindings. Verified on clean base `f35313dcfe0e372d6f8316b63a37155367525b70`: rerunning those three unchanged test files reproduced **the identical 19 failing test names and Windows cleanup errors** (34 passed). No tracked base changes; same installed dependency versions. Command: `node scripts/run-vitest.mjs extensions/discord/src/monitor/listeners.thread-delete.session-store.integration.test.ts extensions/discord/src/monitor/native-command.reset.test.ts extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts`. These are verified baseline failures, not a green full-suite claim.
- Changed-file checks passed production extension typechecking, formatting, plugin boundaries, dependency/patch guards, and doctor contract tests. The broad extension-test typecheck was interrupted after exhausting local memory; it did not pass.
- The full lint wrapper timed out during SDK declaration preparation (300 seconds); it did not reach a lint verdict. Focused syntax lint passed (exit 0): `node scripts/run-oxlint.mjs --openclaw-focused-config --tsconfig extensions/tsconfig.json` followed by the three changed paths. This does not claim type-aware lint passed.
- Earlier fixture setup failures (Windows symlink/config/URL handling and startup timeout) are not bug proof. The completed exit-0 run above supersedes those attempts.

## Maintainer Validation: September 9, 2026

Published head: `21c65061f7172dc67ea44d05e2b7b97ca6dcc0ef`. This preserves the contributor's production change and adds only the required synthetic `id: "activity-1"` field to one `GatewayActivity` test fixture. The original CI type failure was reproduced and corrected without casts or weakened types.

Independent validation used an isolated, secretless Linux environment. The original head passed all 235 focused listener, threading-utility, and action-consumer tests. The original head plus the reviewed fixture correction also passed those 235 tests and the real Client dispatcher-to-member-info boundary with loopback transport. Replacing the production owner with the base reproduced the intended missing-cache and missing-online-status failures. This independent boundary proof is not a live Discord test or a full OpenClaw Gateway run; the author's separate historical Gateway evidence is retained above.

The corrected composite passed extension-test, root-test, script, and extension production type checks, formatting, the selected doctor contract tests, lint, dead-code scans, and the remaining selected source checks. Aggregate `check:changed` stopped at a dated SDK compatibility record already fixed independently on main by `c7cb45dfd5dbcf2098d7dd10efd4a64054a2662d`; none of those files overlap this PR. No unrelated fix was copied into the branch. The published patch is byte-identical to the reviewed composite; fresh hosted CI for this published head remains the landing gate:

https://github.com/openclaw/openclaw/actions/runs/34329696872

### Presence Retention Disposition

Same-order base/head controls both retain live-update metadata across a partial replacement guild snapshot. Additional controls cover snapshot seeding before an update, live-update precedence, `READY` clearing, account isolation, unknown members, and other-guild observations.

The snapshot-retention review concern was not accepted as an introduced regression: retaining known observations already occurs on the base, and a missing member in a partial snapshot is not evidence that the member is offline. Discord documents partial large-guild membership and repeat guild-create availability events:

https://docs.discord.com/developers/events/gateway-events#guild-create

No cache-invalidation policy change is included. The existing known-metadata retention limitation remains a separate owner-policy question. The fixture typing finding was accepted and resolved; these dispositions do not imply an unqualified clean review-tool verdict.
