### PR TITLE
improve(test): avoid repeated glob compilation during planning

### DIFF
--- a/scripts/lib/vitest-build-prerequisites.mts
+++ b/scripts/lib/vitest-build-prerequisites.mts
@@ -153,12 +153,25 @@ export function mergeVitestPretestBuildModes(
 export function resolveVitestPretestBuildMode(
   selections: readonly VitestRuntimeTestSelection[],
 ): VitestPretestBuildMode | undefined {
+  const preparedSelections = selections.map((selection) => {
+    const includedFiles = new Set<string>();
+    // Keep each pattern hot in Node's bounded glob cache across the small consumer list.
+    // Consumer-first traversal recompiles large include inventories for every file.
+    for (const pattern of selection.includePatterns ?? []) {
+      for (const { file } of runtimeConsumers) {
+        if (!includedFiles.has(file) && path.matchesGlob(file, pattern)) {
+          includedFiles.add(file);
+        }
+      }
+    }
+    return { ...selection, includedFiles };
+  });
   return mergeVitestPretestBuildModes(
     runtimeConsumers
       .filter(({ file, configs: consumerConfigs }) =>
-        selections.some(({ configs, includePatterns, matchesFile }) => {
+        preparedSelections.some(({ configs, includePatterns, matchesFile, includedFiles }) => {
           const included = includePatterns
-            ? includePatterns.some((pattern) => path.matchesGlob(file, pattern))
+            ? includedFiles.has(file)
             : consumerConfigs.some((config) => includesRuntimeConfig(configs, config));
           // Only project the canonical consumers; config loading and test discovery
           // stay with Vitest. Include-file overrides still intersect emitted filters.


### PR DESCRIPTION
Closes #141198
Related: #141141

## What Problem This Solves

The CI planner spends substantial time repeatedly compiling glob matchers for large include inventories. This consumes the budget of the existing inventory-growth test, which timed out in hosted CI while checking a cloud-runtime change.

## Why This Change Was Made

Prepare matched runtime-consumer files once per selection using pattern-first traversal, then retain the existing consumer/selection callback order and build-mode reduction. This keeps each pattern useful within Node's existing cache. No custom glob parser, persistent or process-wide cache, dependency, timeout, job limit, or test expectation changes.

## User Impact

Faster prerequisite planning without changing which runtime builds or jobs are selected. In paired whole-planner measurements, median time fell from 1.554 seconds to 0.453 seconds; every complete plan remained byte-identical.

## Evidence

- 123 existing planner/admission/prerequisite tests passed; no tests or timeouts were edited.
- 39 paired semantic cases preserved return values and complete callback traces, including null/empty includes, bracket/brace/extglob patterns, filters, and overrides.
- Ten full planner outputs retained the same 80 jobs and JSON SHA-256 `2153dc42f54d9bd28df19a6e044722a9c0e922a72bcaedbff00861b7a9aa79be`.
- The original inventory-growth test passed locally with its unchanged timeout; the local run did not reproduce the hosted 120-second failure.
- Independent Codex review found no actionable P0–P2 issues. Formatting and diff checks passed.
- Local canonical lint was blocked by an external shared-dependency/declaration guard; no guard was disabled. Hosted checks must pass on the exact PR revision before landing.
