### PR TITLE
test(ui): settle startup worker updates before replacing builds

### DIFF
--- a/ui/src/e2e/service-worker-update.e2e.test.ts
+++ b/ui/src/e2e/service-worker-update.e2e.test.ts
@@ -352,6 +352,10 @@ describe("Control UI service-worker production update E2E", () => {
         const draft =
           mode === "chat" ? "keep my draft through the missed update" : '{ "count": 2 }';
         await editor.fill(draft);
+        // Join startup update checks before changing the served worker bytes.
+        await page.evaluate(async () => {
+          await (await navigator.serviceWorker.ready).update();
+        });
         await buildProductionControlUiE2e(nextDir, buildB);
         await page.evaluate(() => sessionStorage.setItem("test-missed-activation", "1"));
         await rename(outDir, previousDir);


### PR DESCRIPTION
Related: #141047

## What Problem This Solves

Resolves a race where the Control UI missed-activation tests can fail before exercising recovery: an intended update to build B can join an unfinished startup check against build A, leaving only A cached. This fixture repair follows the failure encountered while validating #141047.

## Why This Change Was Made

Wait for the active registration’s startup update while A is still served, before compiling and substituting B. The existing chat/config cases then make their single B update and retain all activation, reload, route and draft assertions. The change adds four test lines and uses the public browser API; production behavior and test deadlines are unchanged.

## User Impact

No runtime behavior change. The production-build tests reliably reach the recovery behavior they are intended to check.

## Evidence

- A controlled Chromium run held a real A validation response, swapped in B and called update: the call fulfilled without fetching B, and B remained absent from the cache for 15 seconds. A fresh-context control joined the A update before swapping; its single B update fetched the real B worker and created B’s cache. The original CI network sequence was not captured, so this demonstrates a concrete fixture race without claiming to reconstruct that run.
- The existing deep-link → chat-draft → config-draft prefix passes all three cases with the fix. The later terminal case was filtered from this focused run.
- All 18 selected repository checks pass; independent P0–P2 review found no actionable findings.

The controlled response experiment proves request/cache ordering. The unchanged application test assertions separately cover activation, reload and draft recovery. Hosted CI for this PR supplies the combined-main validation.
