### PR TITLE
refactor(memory-wiki): share imported source orchestration

### DIFF
--- a/extensions/memory-wiki/src/bridge.test.ts
+++ b/extensions/memory-wiki/src/bridge.test.ts
@@ -558,6 +558,56 @@ describe("syncMemoryWikiBridgeSources", () => {
     }
   });
 
+  it("keeps stale pages when the memory capability closes during a source read", async () => {
+    const workspaceDir = await createBridgeWorkspace("closing-capability-workspace");
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("closing-capability-vault"),
+      config: { vaultMode: "bridge", bridge: { enabled: true, indexMemoryRoot: true } },
+    });
+    const artifacts: MemoryPluginPublicArtifact[] = ["previous.md", "current.md"].map(
+      (relativePath) => ({
+        kind: "memory-root",
+        workspaceDir,
+        relativePath,
+        absolutePath: path.join(workspaceDir, relativePath),
+        agentIds: ["main"],
+        contentType: "markdown",
+      }),
+    );
+    for (const artifact of artifacts) {
+      await fs.writeFile(artifact.absolutePath, `# ${artifact.relativePath}\n`, "utf8");
+    }
+    registerBridgeArtifacts(artifacts.slice(0, 1));
+    const appConfig: OpenClawConfig = {};
+    const first = await syncMemoryWikiBridgeSources({ config, appConfig });
+    const previousPage = path.join(vaultDir, first.pagePaths[0] ?? "");
+    const previousContent = await fs.readFile(previousPage, "utf8");
+
+    registerBridgeArtifacts(artifacts.slice(1));
+    const readFile = fs.readFile.bind(fs);
+    const readSpy = vi
+      .spyOn(fs, "readFile")
+      .mockImplementation(
+        async (...args: Parameters<typeof fs.readFile>): ReturnType<typeof fs.readFile> => {
+          const content = await readFile(...args);
+          if (args[0] === artifacts[1]?.absolutePath) {
+            clearMemoryPluginState();
+          }
+          return content;
+        },
+      );
+    const second = await syncMemoryWikiBridgeSources({ config, appConfig });
+    readSpy.mockRestore();
+
+    expect(second).toMatchObject({ importedCount: 1, removedCount: 0 });
+    await expect(fs.readFile(previousPage, "utf8")).resolves.toBe(previousContent);
+
+    registerBridgeArtifacts(artifacts.slice(1));
+    const third = await syncMemoryWikiBridgeSources({ config, appConfig });
+    expect(third).toMatchObject({ skippedCount: 1, removedCount: 1 });
+    await expect(fs.access(previousPage)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("refuses to overwrite bridge source pages through vault symlinks", async () => {
     const workspaceDir = await createBridgeWorkspace("symlink-workspace");
     const { rootDir: vaultDir, config } = await createVault({

--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -11,22 +11,19 @@ import {
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import type { OpenClawConfig } from "../api.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
-import { appendMemoryWikiLog } from "./log.js";
 import {
   createWikiPageFilename,
   renderMarkdownFence,
   renderWikiMarkdown,
   slugifyWikiSegment,
 } from "./markdown.js";
+import { syncImportedSourcePages } from "./source-import.js";
 import { writeImportedSourcePage } from "./source-page-shared.js";
 import { resolveArtifactKey } from "./source-path-shared.js";
 import {
   assertMemoryWikiSourceSyncStateCapacity,
-  pruneImportedSourceEntries,
-  readMemoryWikiSourceSyncState,
-  writeMemoryWikiSourceSyncState,
+  type readMemoryWikiSourceSyncState,
 } from "./source-sync-state.js";
-import { initializeMemoryWikiVault } from "./vault.js";
 
 type BridgeArtifact = {
   syncKey: string;
@@ -279,94 +276,51 @@ export async function syncMemoryWikiBridgeSources(params: {
     config: params.config,
     artifacts: await listActiveMemoryPublicArtifacts({ cfg: params.appConfig }),
   });
-  const results: Array<{ pagePath: string; changed: boolean; created: boolean }> = [];
-  const activeKeys = new Set<string>();
   const artifacts = await collectBridgeArtifacts(
     params.config.bridge,
     params.config.vault.path,
     publicArtifacts,
   );
-  const state = await readMemoryWikiSourceSyncState(params.config.vault.path);
-  let initializePromise: ReturnType<typeof initializeMemoryWikiVault> | undefined;
-  const prepareWrite = async () => {
-    params.signal?.throwIfAborted();
-    const result = await (initializePromise ??= initializeMemoryWikiVault(
-      params.config,
-      params.signal ? { signal: params.signal } : undefined,
-    ));
-    params.signal?.throwIfAborted();
-    return result;
-  };
-  assertMemoryWikiSourceSyncStateCapacity({
-    state,
+  return await syncImportedSourcePages({
+    config: params.config,
     group: "bridge",
-    incomingCount: artifacts.length,
-  });
-  const agentIdsByWorkspace = new Map<string, string[]>();
-  for (const artifact of publicArtifacts) {
-    agentIdsByWorkspace.set(artifact.workspaceDir, artifact.agentIds);
-  }
-  const artifactCount = artifacts.length;
-  for (const artifact of artifacts) {
-    const stats = await fs.stat(artifact.absolutePath);
-    activeKeys.add(artifact.syncKey);
-    results.push(
-      await writeBridgeSourcePage({
-        config: params.config,
-        artifact,
-        agentIds: agentIdsByWorkspace.get(artifact.workspaceDir) ?? [],
-        sourceUpdatedAtMs: stats.mtimeMs,
-        sourceSize: stats.size,
+    signal: params.signal,
+    writeSources: async ({ state, prepareWrite }) => {
+      assertMemoryWikiSourceSyncStateCapacity({
         state,
-        prepareWrite,
-      }),
-    );
-  }
-  const workspaceCount = new Set(publicArtifacts.map((artifact) => artifact.workspaceDir)).size;
-
-  // Skip pruning when memory-core is not loaded (e.g. CLI context) to avoid
-  // removing all bridge-imported entries. See #68373.
-  const memoryCapability = getMemoryCapabilityRegistration();
-  const removedCount = memoryCapability
-    ? await pruneImportedSourceEntries({
-        vaultRoot: params.config.vault.path,
         group: "bridge",
+        incomingCount: artifacts.length,
+      });
+      const agentIdsByWorkspace = new Map<string, string[]>();
+      for (const artifact of publicArtifacts) {
+        agentIdsByWorkspace.set(artifact.workspaceDir, artifact.agentIds);
+      }
+      const results: Array<{ pagePath: string; changed: boolean; created: boolean }> = [];
+      const activeKeys = new Set<string>();
+      for (const artifact of artifacts) {
+        const stats = await fs.stat(artifact.absolutePath);
+        activeKeys.add(artifact.syncKey);
+        results.push(
+          await writeBridgeSourcePage({
+            config: params.config,
+            artifact,
+            agentIds: agentIdsByWorkspace.get(artifact.workspaceDir) ?? [],
+            sourceUpdatedAtMs: stats.mtimeMs,
+            sourceSize: stats.size,
+            state,
+            prepareWrite,
+          }),
+        );
+      }
+      return {
+        results,
         activeKeys,
-        state,
-        prepareWrite,
-      })
-    : 0;
-  await writeMemoryWikiSourceSyncState(params.config.vault.path, state);
-  const importedCount = results.filter((result) => result.changed && result.created).length;
-  const updatedCount = results.filter((result) => result.changed && !result.created).length;
-  const skippedCount = results.filter((result) => !result.changed).length;
-  const pagePaths = results
-    .map((result) => result.pagePath)
-    .toSorted((left, right) => left.localeCompare(right));
-
-  if (importedCount > 0 || updatedCount > 0 || removedCount > 0) {
-    await appendMemoryWikiLog(params.config.vault.path, {
-      type: "ingest",
-      timestamp: new Date().toISOString(),
-      details: {
-        sourceType: "memory-bridge",
-        workspaces: workspaceCount,
-        artifactCount,
-        importedCount,
-        updatedCount,
-        skippedCount,
-        removedCount,
-      },
-    });
-  }
-
-  return {
-    importedCount,
-    updatedCount,
-    skippedCount,
-    removedCount,
-    artifactCount,
-    workspaces: workspaceCount,
-    pagePaths,
-  };
+        artifactCount: artifacts.length,
+        workspaces: new Set(publicArtifacts.map((artifact) => artifact.workspaceDir)).size,
+      };
+    },
+    // CLI imports can lack the memory capability; absence cannot authorize pruning. See #68373.
+    canPrune: () => Boolean(getMemoryCapabilityRegistration()),
+    logDetails: ({ workspaces }) => ({ workspaces }),
+  });
 }

--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -17,7 +17,7 @@ import {
   renderWikiMarkdown,
   slugifyWikiSegment,
 } from "./markdown.js";
-import { syncImportedSourcePages } from "./source-import.js";
+import { syncImportedSourcePages, type BridgeMemoryWikiResult } from "./source-import.js";
 import { writeImportedSourcePage } from "./source-page-shared.js";
 import { resolveArtifactKey } from "./source-path-shared.js";
 import {
@@ -31,16 +31,6 @@ type BridgeArtifact = {
   workspaceDir: string;
   relativePath: string;
   absolutePath: string;
-};
-
-export type BridgeMemoryWikiResult = {
-  importedCount: number;
-  updatedCount: number;
-  skippedCount: number;
-  removedCount: number;
-  artifactCount: number;
-  workspaces: number;
-  pagePaths: string[];
 };
 
 export function resolveMemoryWikiVaultAgentId(

--- a/extensions/memory-wiki/src/source-import.ts
+++ b/extensions/memory-wiki/src/source-import.ts
@@ -1,0 +1,87 @@
+import type { BridgeMemoryWikiResult } from "./bridge.js";
+import type { ResolvedMemoryWikiConfig } from "./config.js";
+import { appendMemoryWikiLog } from "./log.js";
+import type { writeImportedSourcePage } from "./source-page-shared.js";
+import {
+  pruneImportedSourceEntries,
+  readMemoryWikiSourceSyncState,
+  writeMemoryWikiSourceSyncState,
+  type MemoryWikiImportedSourceGroup,
+} from "./source-sync-state.js";
+import { initializeMemoryWikiVault } from "./vault.js";
+
+type ImportedSourceBatch = {
+  results: Awaited<ReturnType<typeof writeImportedSourcePage>>[];
+  activeKeys: Set<string>;
+  artifactCount: number;
+  workspaces: number;
+};
+
+export async function syncImportedSourcePages(params: {
+  config: ResolvedMemoryWikiConfig;
+  group: MemoryWikiImportedSourceGroup;
+  signal?: AbortSignal;
+  writeSources: (context: {
+    state: Awaited<ReturnType<typeof readMemoryWikiSourceSyncState>>;
+    prepareWrite: () => Promise<unknown>;
+  }) => Promise<ImportedSourceBatch>;
+  canPrune?: () => boolean;
+  logDetails: (batch: ImportedSourceBatch) => Record<string, number>;
+}): Promise<BridgeMemoryWikiResult> {
+  const state = await readMemoryWikiSourceSyncState(params.config.vault.path);
+  let initializePromise: ReturnType<typeof initializeMemoryWikiVault> | undefined;
+  const prepareWrite = async () => {
+    params.signal?.throwIfAborted();
+    const result = await (initializePromise ??= initializeMemoryWikiVault(
+      params.config,
+      params.signal ? { signal: params.signal } : undefined,
+    ));
+    params.signal?.throwIfAborted();
+    return result;
+  };
+  const batch = await params.writeSources({ state, prepareWrite });
+  // Recheck source-owned pruning authority after all awaited imports.
+  const removedCount =
+    !params.canPrune || params.canPrune()
+      ? await pruneImportedSourceEntries({
+          vaultRoot: params.config.vault.path,
+          group: params.group,
+          activeKeys: batch.activeKeys,
+          state,
+          prepareWrite,
+        })
+      : 0;
+  await writeMemoryWikiSourceSyncState(params.config.vault.path, state);
+  const importedCount = batch.results.filter((result) => result.changed && result.created).length;
+  const updatedCount = batch.results.filter((result) => result.changed && !result.created).length;
+  const skippedCount = batch.results.filter((result) => !result.changed).length;
+  const pagePaths = batch.results
+    .map((result) => result.pagePath)
+    .toSorted((left, right) => left.localeCompare(right));
+
+  if (importedCount > 0 || updatedCount > 0 || removedCount > 0) {
+    await appendMemoryWikiLog(params.config.vault.path, {
+      type: "ingest",
+      timestamp: new Date().toISOString(),
+      details: {
+        sourceType: `memory-${params.group}`,
+        ...params.logDetails(batch),
+        artifactCount: batch.artifactCount,
+        importedCount,
+        updatedCount,
+        skippedCount,
+        removedCount,
+      },
+    });
+  }
+
+  return {
+    importedCount,
+    updatedCount,
+    skippedCount,
+    removedCount,
+    artifactCount: batch.artifactCount,
+    workspaces: batch.workspaces,
+    pagePaths,
+  };
+}

--- a/extensions/memory-wiki/src/source-import.ts
+++ b/extensions/memory-wiki/src/source-import.ts
@@ -1,4 +1,3 @@
-import type { BridgeMemoryWikiResult } from "./bridge.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import { appendMemoryWikiLog } from "./log.js";
 import type { writeImportedSourcePage } from "./source-page-shared.js";
@@ -9,6 +8,16 @@ import {
   type MemoryWikiImportedSourceGroup,
 } from "./source-sync-state.js";
 import { initializeMemoryWikiVault } from "./vault.js";
+
+export type BridgeMemoryWikiResult = {
+  importedCount: number;
+  updatedCount: number;
+  skippedCount: number;
+  removedCount: number;
+  artifactCount: number;
+  workspaces: number;
+  pagePaths: string[];
+};
 
 type ImportedSourceBatch = {
   results: Awaited<ReturnType<typeof writeImportedSourcePage>>[];

--- a/extensions/memory-wiki/src/source-sync.ts
+++ b/extensions/memory-wiki/src/source-sync.ts
@@ -1,6 +1,6 @@
 // Memory Wiki plugin module implements source sync behavior.
 import type { OpenClawConfig } from "../api.js";
-import { syncMemoryWikiBridgeSources, type BridgeMemoryWikiResult } from "./bridge.js";
+import { syncMemoryWikiBridgeSources } from "./bridge.js";
 import {
   refreshMemoryWikiIndexesAfterImport,
   type RefreshMemoryWikiIndexesResult,
@@ -10,6 +10,7 @@ import {
   resolveMemoryWikiVaultMutationKey,
   withMemoryWikiVaultMutation,
 } from "./mutation-coordinator.js";
+import type { BridgeMemoryWikiResult } from "./source-import.js";
 import { syncMemoryWikiUnsafeLocalSources } from "./unsafe-local.js";
 import { initializeMemoryWikiVault } from "./vault.js";
 

--- a/extensions/memory-wiki/src/unsafe-local.test.ts
+++ b/extensions/memory-wiki/src/unsafe-local.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { readMemoryWikiSourceSyncState } from "./source-sync-state.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 import { syncMemoryWikiUnsafeLocalSources } from "./unsafe-local.js";
 
@@ -204,6 +205,46 @@ describe("syncMemoryWikiUnsafeLocalSources", () => {
     await expect(
       fs.readFile(path.join(vaultDir, unavailablePage!.pagePath), "utf8"),
     ).resolves.toContain("remember this");
+  });
+
+  it("keeps prior pages, sync state, and ingest log when a source read fails", async () => {
+    const privateDir = await createPrivateDir("failed-source-read");
+    const previousPath = path.join(privateDir, "previous.md");
+    const failingPath = path.join(privateDir, "failing.md");
+    await fs.writeFile(previousPath, "# Previous source\n", "utf8");
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("failed-source-read-vault"),
+      config: {
+        vaultMode: "unsafe-local",
+        unsafeLocal: { allowPrivateMemoryCoreAccess: true, paths: [privateDir] },
+      },
+    });
+    const first = await syncMemoryWikiUnsafeLocalSources(config);
+    const previousPage = path.join(vaultDir, first.pagePaths[0] ?? "");
+    const previousContent = await fs.readFile(previousPage, "utf8");
+    const previousState = await readMemoryWikiSourceSyncState(vaultDir);
+    const logPath = path.join(vaultDir, ".openclaw-wiki", "log.jsonl");
+    const previousLog = await fs.readFile(logPath, "utf8");
+    await fs.rm(previousPath);
+    await fs.writeFile(failingPath, "# Unreadable source\n", "utf8");
+
+    const readFile = fs.readFile.bind(fs);
+    const readSpy = vi
+      .spyOn(fs, "readFile")
+      .mockImplementation(
+        async (...args: Parameters<typeof fs.readFile>): ReturnType<typeof fs.readFile> => {
+          if (args[0] === failingPath) {
+            throw new Error("source read failed");
+          }
+          return readFile(...args);
+        },
+      );
+    await expect(syncMemoryWikiUnsafeLocalSources(config)).rejects.toThrow("source read failed");
+    readSpy.mockRestore();
+
+    await expect(fs.readFile(previousPage, "utf8")).resolves.toBe(previousContent);
+    await expect(readMemoryWikiSourceSyncState(vaultDir)).resolves.toEqual(previousState);
+    await expect(fs.readFile(logPath, "utf8")).resolves.toBe(previousLog);
   });
 
   it("skips generated source pages copied into a configured path", async () => {

--- a/extensions/memory-wiki/src/unsafe-local.ts
+++ b/extensions/memory-wiki/src/unsafe-local.ts
@@ -6,7 +6,6 @@ import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime
 import { isPathInside } from "openclaw/plugin-sdk/file-access-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { walkMemoryWikiDirectory } from "./bounded-walk.js";
-import type { BridgeMemoryWikiResult } from "./bridge.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import {
   createWikiPageFilename,
@@ -15,7 +14,7 @@ import {
   slugifyWikiSegment,
   toWikiPageSummary,
 } from "./markdown.js";
-import { syncImportedSourcePages } from "./source-import.js";
+import { syncImportedSourcePages, type BridgeMemoryWikiResult } from "./source-import.js";
 import { writeImportedSourcePage } from "./source-page-shared.js";
 import { resolveArtifactKey } from "./source-path-shared.js";
 import {

--- a/extensions/memory-wiki/src/unsafe-local.ts
+++ b/extensions/memory-wiki/src/unsafe-local.ts
@@ -8,7 +8,6 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { walkMemoryWikiDirectory } from "./bounded-walk.js";
 import type { BridgeMemoryWikiResult } from "./bridge.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
-import { appendMemoryWikiLog } from "./log.js";
 import {
   createWikiPageFilename,
   renderMarkdownFence,
@@ -16,15 +15,13 @@ import {
   slugifyWikiSegment,
   toWikiPageSummary,
 } from "./markdown.js";
+import { syncImportedSourcePages } from "./source-import.js";
 import { writeImportedSourcePage } from "./source-page-shared.js";
 import { resolveArtifactKey } from "./source-path-shared.js";
 import {
   assertMemoryWikiSourceSyncStateCapacity,
-  pruneImportedSourceEntries,
-  readMemoryWikiSourceSyncState,
-  writeMemoryWikiSourceSyncState,
+  type readMemoryWikiSourceSyncState,
 } from "./source-sync-state.js";
-import { initializeMemoryWikiVault } from "./vault.js";
 
 type UnsafeLocalArtifact = {
   syncKey: string;
@@ -248,91 +245,48 @@ export async function syncMemoryWikiUnsafeLocalSources(
     config.unsafeLocal.paths,
     vaultRootKey,
   );
-  const state = await readMemoryWikiSourceSyncState(config.vault.path);
-  let initializePromise: ReturnType<typeof initializeMemoryWikiVault> | undefined;
-  const prepareWrite = async () => {
-    options.signal?.throwIfAborted();
-    const result = await (initializePromise ??= initializeMemoryWikiVault(
-      config,
-      options.signal ? { signal: options.signal } : undefined,
-    ));
-    options.signal?.throwIfAborted();
-    return result;
-  };
-  const activeKeys = new Set<string>();
-  for (const [syncKey, entry] of Object.entries(state.entries)) {
-    if (
-      entry.group === "unsafe-local" &&
-      unavailableConfiguredPaths.some((configuredPath) =>
-        isPathInside(configuredPath, entry.sourcePath),
-      )
-    ) {
-      // A configured source scope remains authoritative until it is readable again or removed
-      // from config. Treating an unreadable mount as empty would permanently delete human notes.
-      activeKeys.add(syncKey);
-    }
-  }
-  assertMemoryWikiSourceSyncStateCapacity({
-    state,
+  return await syncImportedSourcePages({
+    config,
     group: "unsafe-local",
-    incomingCount: new Set([...artifacts.map((artifact) => artifact.syncKey), ...activeKeys]).size,
-  });
-  const { results } = await runTasksWithConcurrency({
-    tasks: artifacts.map((artifact) => async () => {
-      const stats = await fs.stat(artifact.absolutePath);
-      activeKeys.add(artifact.syncKey);
-      return await writeUnsafeLocalSourcePage({
-        config,
-        artifact,
-        sourceUpdatedAtMs: stats.mtimeMs,
-        sourceSize: stats.size,
+    signal: options.signal,
+    writeSources: async ({ state, prepareWrite }) => {
+      const activeKeys = new Set<string>();
+      for (const [syncKey, entry] of Object.entries(state.entries)) {
+        if (
+          entry.group === "unsafe-local" &&
+          unavailableConfiguredPaths.some((configuredPath) =>
+            isPathInside(configuredPath, entry.sourcePath),
+          )
+        ) {
+          // An unreadable configured scope remains authoritative; pruning would lose human notes.
+          activeKeys.add(syncKey);
+        }
+      }
+      assertMemoryWikiSourceSyncStateCapacity({
         state,
-        prepareWrite,
+        group: "unsafe-local",
+        incomingCount: new Set([...artifacts.map((artifact) => artifact.syncKey), ...activeKeys])
+          .size,
       });
-    }),
-    limit: UNSAFE_LOCAL_SYNC_CONCURRENCY,
-    errorMode: "stop",
-    throwOnError: true,
+      const { results } = await runTasksWithConcurrency({
+        tasks: artifacts.map((artifact) => async () => {
+          const stats = await fs.stat(artifact.absolutePath);
+          activeKeys.add(artifact.syncKey);
+          return await writeUnsafeLocalSourcePage({
+            config,
+            artifact,
+            sourceUpdatedAtMs: stats.mtimeMs,
+            sourceSize: stats.size,
+            state,
+            prepareWrite,
+          });
+        }),
+        limit: UNSAFE_LOCAL_SYNC_CONCURRENCY,
+        errorMode: "stop",
+        throwOnError: true,
+      });
+      return { results, activeKeys, artifactCount: artifacts.length, workspaces: 0 };
+    },
+    logDetails: () => ({ configuredPathCount: config.unsafeLocal.paths.length }),
   });
-
-  const removedCount = await pruneImportedSourceEntries({
-    vaultRoot: config.vault.path,
-    group: "unsafe-local",
-    activeKeys,
-    state,
-    prepareWrite,
-  });
-  await writeMemoryWikiSourceSyncState(config.vault.path, state);
-  const importedCount = results.filter((result) => result.changed && result.created).length;
-  const updatedCount = results.filter((result) => result.changed && !result.created).length;
-  const skippedCount = results.filter((result) => !result.changed).length;
-  const pagePaths = results
-    .map((result) => result.pagePath)
-    .toSorted((left, right) => left.localeCompare(right));
-
-  if (importedCount > 0 || updatedCount > 0 || removedCount > 0) {
-    await appendMemoryWikiLog(config.vault.path, {
-      type: "ingest",
-      timestamp: new Date().toISOString(),
-      details: {
-        sourceType: "memory-unsafe-local",
-        configuredPathCount: config.unsafeLocal.paths.length,
-        artifactCount: artifacts.length,
-        importedCount,
-        updatedCount,
-        skippedCount,
-        removedCount,
-      },
-    });
-  }
-
-  return {
-    importedCount,
-    updatedCount,
-    skippedCount,
-    removedCount,
-    artifactCount: artifacts.length,
-    workspaces: 0,
-    pagePaths,
-  };
 }


### PR DESCRIPTION
## What Problem This Solves

Bridge and unsafe-local wiki imports maintain separate copies of vault initialization, stale-page pruning, sync-state publication, result counting, and ingest logging. That duplication makes authority and failure-ordering guarantees harder to maintain consistently.

## Why This Change Was Made

A plugin-local `syncImportedSourcePages` operation beside the existing shared page writer owns those common phases and their private result type. Each importer keeps its source selection, capacity checks, and execution loop. Bridge pruning authority is read after awaited writes; unsafe-local keeps its 16-worker loop and immediate failure propagation. A failed source batch cannot proceed to prune, publish state, or log success.

## User Impact

No intended behavior change. Human Notes preservation, unreadable-scope retention, abort checks, state publication before logging, and sorted result paths remain unchanged. No schema, stored representation, retention policy, transaction boundary, configuration option, dependency, or public export changes.

Production shrinks by 6 lines; tests add 91 lines. Preserving the two source-specific policies limits the line reduction, while the common lifecycle now has one owner.

## Evidence

- `node scripts/run-vitest.mjs extensions/memory-wiki/src/bridge.test.ts extensions/memory-wiki/src/unsafe-local.test.ts extensions/memory-wiki/src/source-page-shared.test.ts extensions/memory-wiki/src/source-sync.test.ts extensions/memory-wiki/src/source-sync-state.test.ts`: **67 passed**.
- A capability-closes-during-read case proves stale bridge pages are retained until pruning authority returns. A failed-source-read case checks real page/log files and published state remain unchanged. That state assertion uses the existing in-memory fallback; the separate source-sync-state suite covers SQLite persistence.
- CI detected one type-only Madge cycle because the operation imported its result type from its bridge caller. The canonical check reproduced it locally; relocating the private type into the operation owner and migrating all local callers yields **0 Madge cycles**. No public barrel exports this type. All **67 tests** passed again after the move. `pnpm check:architecture` and extension production/test type checks passed, including **0 runtime cycles / 0 Madge cycles**.
- Autoreview is scoped-clean through P3, with zero accepted/actionable findings.
- Changed checks passed ratchets, formatting, extension production/test types, guards, and all three dead-export scans. Extension lint preparation stops at the documented nested-checkout ancestor `punycode` declaration guard; hosted CI must settle that boundary. No ancestor install or guard is modified.
- `pnpm build` passed in **7m12.4s**, including plugin packaging, SDK declarations, and runtime import checks, before the type-only relocation. That correction changes no runtime import graph and has the repeated focused proof above.

The existing page writer and state/concurrency owners remain unchanged. No live provider or Gateway is involved in this filesystem/state orchestration change.


The data-model compatibility request does not require a migration here. The source-state writer/reader (`source-sync-state.ts`), guarded page writer (`source-page-shared.ts`), vault mutation coordinator, config definitions, and core plugin-state store are byte-identical to the PR base. State remains version 1 with the same keys and entry fields, and page generation remains in the same writer. The existing sequential bridge and 16-worker unsafe-local loops produce the same rows; pruning, state publication, and logging retain their order. The existing SQLite-backed state tests passed. The `source-sync.ts` follow-up changes only the private result-type import, with the exact same fields; it does not change a persisted projection. No vector or embedding metadata is modified.

Final exact-head CI passed for `4e3eaaa22cb0e06e1c239dccd88a7fb66fe1e578`: https://github.com/openclaw/openclaw/actions/runs/34125385543.
