### PR TITLE
refactor(plugins): share setup presentation URL policy

### DIFF
--- a/src/plugins/manifest-setup-normalizers.ts
+++ b/src/plugins/manifest-setup-normalizers.ts
@@ -28,6 +28,7 @@ import type {
   PluginManifestSetupProviderAuthEvidence,
   PluginConfigUiHint,
 } from "./manifest-types.js";
+import { normalizeSetupPresentationHttpsUrl } from "./setup-presentation-url.js";
 
 export function normalizeManifestActivation(value: unknown): PluginManifestActivation | undefined {
   if (!isRecord(value)) {
@@ -354,26 +355,6 @@ export function normalizeManifestControlUi(
   return ok({ entry, ...(styles.length > 0 ? { styles } : {}) });
 }
 
-function normalizeManifestHttpsUrl(value: unknown): string | undefined {
-  const normalized = normalizeOptionalString(value);
-  if (!normalized) {
-    return undefined;
-  }
-  try {
-    const url = new URL(normalized);
-    const canonical = url.toString();
-    return url.protocol === "https:" &&
-      url.hostname &&
-      !url.username &&
-      !url.password &&
-      canonical.length <= 2048
-      ? canonical
-      : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 export function normalizeProviderAuthChoices(
   value: unknown,
 ): PluginManifestProviderAuthChoice[] | undefined {
@@ -393,8 +374,8 @@ export function normalizeProviderAuthChoices(
     }
     const choiceLabel = normalizeOptionalString(entry.choiceLabel) ?? "";
     const choiceHint = normalizeOptionalString(entry.choiceHint) ?? "";
-    const icon = normalizeManifestHttpsUrl(entry.icon);
-    const website = normalizeManifestHttpsUrl(entry.website);
+    const icon = normalizeSetupPresentationHttpsUrl(entry.icon);
+    const website = normalizeSetupPresentationHttpsUrl(entry.website);
     const assistantPriority =
       typeof entry.assistantPriority === "number" && Number.isFinite(entry.assistantPriority)
         ? entry.assistantPriority

--- a/src/plugins/recommended-tool-installs.ts
+++ b/src/plugins/recommended-tool-installs.ts
@@ -1,6 +1,7 @@
 // Loads the bundled, presentation-only onboarding install catalog.
 import recommendedToolInstalls from "../../scripts/lib/recommended-tool-installs.json" with { type: "json" };
 import { isRecord } from "../utils.js";
+import { normalizeSetupPresentationHttpsUrl } from "./setup-presentation-url.js";
 
 export type SetupRecommendedInstall = {
   id: string;
@@ -10,26 +11,6 @@ export type SetupRecommendedInstall = {
   website: string;
   icon: string;
 };
-
-function normalizeHttpsUrl(value: unknown): string | undefined {
-  if (typeof value !== "string" || !value.trim()) {
-    return undefined;
-  }
-  const normalized = value.trim();
-  try {
-    const url = new URL(normalized);
-    const canonical = url.toString();
-    return url.protocol === "https:" &&
-      url.hostname &&
-      !url.username &&
-      !url.password &&
-      canonical.length <= 2048
-      ? canonical
-      : undefined;
-  } catch {
-    return undefined;
-  }
-}
 
 export function listRecommendedToolInstalls(): SetupRecommendedInstall[] {
   const entries = (recommendedToolInstalls as { entries?: unknown }).entries;
@@ -46,8 +27,8 @@ export function listRecommendedToolInstalls(): SetupRecommendedInstall[] {
     const brandId = typeof entry.brandId === "string" ? entry.brandId.trim() : "";
     const label = typeof entry.label === "string" ? entry.label.trim() : "";
     const hint = typeof entry.hint === "string" ? entry.hint.trim() : "";
-    const website = normalizeHttpsUrl(entry.website);
-    const icon = normalizeHttpsUrl(entry.icon);
+    const website = normalizeSetupPresentationHttpsUrl(entry.website);
+    const icon = normalizeSetupPresentationHttpsUrl(entry.icon);
     if (!id || seenIds.has(id) || !label || !hint || !website || !icon) {
       continue;
     }

--- a/src/plugins/setup-presentation-url.ts
+++ b/src/plugins/setup-presentation-url.ts
@@ -1,0 +1,21 @@
+import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
+
+export function normalizeSetupPresentationHttpsUrl(value: unknown): string | undefined {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    return undefined;
+  }
+  try {
+    const url = new URL(normalized);
+    const canonical = url.toString();
+    return url.protocol === "https:" &&
+      url.hostname &&
+      !url.username &&
+      !url.password &&
+      canonical.length <= 2048
+      ? canonical
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Plugin auth choices and recommended installs maintain two copies of the same HTTPS presentation URL policy. Keeping the canonicalization, credential rejection and length limit in sync currently requires editing both implementations.

## Why This Change Was Made

Share that policy in one private plugin helper and remove both copies. Each caller keeps its existing record handling: auth choices omit invalid optional URLs, while recommended installs reject entries missing valid required URLs and retain their ordering and duplicate-ID rules.

## User Impact

Behavior is unchanged. URLs still require HTTPS, a hostname, no credentials, and at most 2,048 UTF-16 code units after canonicalization. This maintainer-requested consolidation removes 16 production code lines (17 physical lines), with no test changes or new public API.

## Evidence

All 142 existing manifest, recommended-install and management tests pass before and after. Differential checks using the final helper match 106 URL comparisons and 2,809 cases for each caller, including invalid entries followed by a valid duplicate. The selected changed gate and independent P2 review pass. These are metadata parsing checks; no live fetching or plugin activation is involved.
