### PR TITLE
fix(discord): keep requests mentioning farewells in voice consults

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1310,7 +1310,7 @@ Notes:
 - If receive logs repeatedly show `DecryptionFailed(UnencryptedWhenPassthroughDisabled)` after updating, collect a dependency report and logs. The bundled `@discordjs/voice` line includes the upstream padding fix from discord.js PR #11449, which closed discord.js issue #11419.
 - `The operation was aborted` receive events are expected when OpenClaw finalizes a captured speaker segment; they are verbose diagnostics, not warnings.
 - Verbose Discord voice logs include a bounded one-line STT transcript preview for each accepted speaker segment, so debugging shows both the user side and the agent reply side without dumping unbounded transcript text.
-- In `agent-proxy` mode, forced consult fallback skips likely incomplete transcript fragments such as text ending in `...` or a trailing connector like "and", plus obvious non-actionable closings like "be right back" or "bye". Logs show `forced agent consult skipped reason=...` when this prevents a stale queued answer.
+- In `agent-proxy` mode, forced consult fallback skips likely incomplete transcript fragments such as text ending in `...` or a trailing connector like "and", plus complete non-actionable closings like "I'll be right back" or "bye". Requests that mention a closing, such as "write a goodbye email", still reach the agent. Closing detection uses a bounded English-language heuristic; unrecognized wording continues to the agent. Logs show `forced agent consult skipped reason=...` when this prevents a stale queued answer.
 
 ### Capture voice transcripts
 

--- a/extensions/discord/src/voice/realtime-turns.test.ts
+++ b/extensions/discord/src/voice/realtime-turns.test.ts
@@ -946,8 +946,10 @@ defineDiscordVoiceTests(
       expectUserMessageIncludes("owner answer");
     });
 
-    it("skips incomplete and non-actionable forced agent-proxy transcripts", async () => {
-      agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "valid answer" }] });
+    it("skips complete closings while retaining actionable forced agent-proxy transcripts", async () => {
+      agentCommandMock
+        .mockResolvedValueOnce({ payloads: [{ text: "Synthetic goodbye draft." }] })
+        .mockResolvedValueOnce({ payloads: [{ text: "valid answer" }] });
       const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
 
       beginSpeakerTurn(entry);
@@ -958,6 +960,13 @@ defineDiscordVoiceTests(
         bridgeParams?.onTranscript?.("user", "I'll be right back. See you guys. Bye-bye.", true);
       });
       expect(agentCommandMock).not.toHaveBeenCalled();
+
+      beginSpeakerTurn(entry);
+      await emitFinalRealtimeUserTranscript(bridgeParams, "Write a goodbye email to Sam");
+      expect(agentCommandMock).toHaveBeenCalledOnce();
+      expect(lastAgentCommandArgs().message).toBe("Write a goodbye email to Sam");
+      expectUserMessageIncludes("Synthetic goodbye draft.");
+      bridgeParams.onEvent?.({ direction: "server", type: "response.done" });
 
       beginSpeakerTurn(entry);
       await emitFinalRealtimeUserTranscript(bridgeParams, "ship it.");

--- a/src/talk/consult-transcript.test.ts
+++ b/src/talk/consult-transcript.test.ts
@@ -20,17 +20,62 @@ describe("realtime voice consult transcript classification", () => {
     expect(classifySkippableRealtimeVoiceConsultTranscript("ship it so")).toBe("trailing-fragment");
   });
 
-  it("skips non-actionable closings unless phrased as a question", () => {
-    expect(classifySkippableRealtimeVoiceConsultTranscript("I'll be right back")).toBe(
-      "non-actionable-closing",
-    );
-    expect(classifySkippableRealtimeVoiceConsultTranscript("goodbye for now")).toBe(
-      "non-actionable-closing",
-    );
-    expect(classifySkippableRealtimeVoiceConsultTranscript("can you say goodbye?")).toBeUndefined();
+  it.each([
+    "I'll be right back",
+    "goodbye for now",
+    "I'll be right back. See you guys. Bye-bye.",
+    "Bye.",
+    "See you later.",
+    "Thanks, bye.",
+    "Okay, see you later.",
+    "Goodbye, everyone.",
+    "Bye, thanks.",
+    "Thanks and goodbye.",
+    "Bye and thanks.",
+    "All right, thanks and goodbye.",
+    "Well, goodbye.",
+    "See you tomorrow",
+    "Bye for now, everyone",
+    "Goodbye, take care",
+    "Alright, bye.",
+    "Thanks a lot, goodbye.",
+    "Thank you very much and goodbye.",
+    "Have a good day. Goodbye.",
+    "Okay, goodbye and have a nice weekend.",
+    "Bye for now, folks.",
+    "See you tonight.",
+    "See you next week.",
+    "See you next time.",
+    "See you on Monday.",
+    "I'll be right back in a minute.",
+    "I will be back in a few minutes.",
+    "I’ll be right back. Bye.",
+    "Good bye.",
+    "Good-bye.",
+  ])("skips complete closing: %s", (text) => {
+    expect(classifySkippableRealtimeVoiceConsultTranscript(text)).toBe("non-actionable-closing");
   });
 
-  it("keeps actionable transcripts", () => {
-    expect(classifySkippableRealtimeVoiceConsultTranscript("what changed in CI?")).toBeUndefined();
+  it.each([
+    "Write a goodbye email to Sam",
+    "Translate goodbye into French.",
+    "I'll be right back, please check the build.",
+    'Explain the code `print("goodbye")`.',
+    "can you say goodbye?",
+    "what changed in CI?",
+    "Okay, write a goodbye email.",
+    "Goodbye, everyone, please check the build.",
+    "Thanks for checking the build.",
+    "Thanks and write a goodbye email.",
+    "Well, goodbye everyone, please check the build.",
+    "See you tomorrow, and please check the build.",
+    "Bye for now, everyone, create a reminder.",
+    "Thanks, goodbye. Send me the report.",
+    "Have a good day. Write a goodbye email.",
+    'Translate "goodbye" into French.',
+    'Say "see you later" in Spanish.',
+    "Thank you.",
+  ])("keeps actionable transcript: %s", (text) => {
+    expect(classifySkippableRealtimeVoiceConsultTranscript(text)).toBeUndefined();
   });
 });

--- a/src/talk/consult-transcript.ts
+++ b/src/talk/consult-transcript.ts
@@ -28,6 +28,20 @@ const REALTIME_VOICE_CONSULT_TRAILING_FRAGMENT_WORDS = new Set([
   "with",
 ]);
 
+// A bounded grammar for ordinary closing components, not general intent detection.
+const REALTIME_VOICE_CLOSING_REMAINDER = new RegExp(
+  String.raw`^(?:(?:${[
+    "ok(?:ay)?|all right|alright|well|so|and",
+    "thanks(?: a lot| so much)?|thank you(?: very much)?|take care",
+    "have a (?:good|nice|great) (?:day|night|evening|weekend)",
+    "guys|everyone|everybody|all|folks|you all",
+    "for now|now|later|soon|tomorrow|tonight|next (?:time|week|month|year|weekend)",
+    "(?:on |next )?(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)",
+    String.raw`in (?:a|a few|few|one|two|three|four|five|six|seven|eight|nine|ten|\d+) (?:second|minute|moment)s?`,
+    "in a bit|in the (?:morning|afternoon|evening)",
+  ].join("|")})\b|[.! ,;:—–-])*$`,
+);
+
 /** Reason a transcript should be ignored before creating a consult request. */
 export type SkippableRealtimeVoiceConsultTranscriptReason =
   | "empty"
@@ -52,13 +66,13 @@ export function classifySkippableRealtimeVoiceConsultTranscript(
   if (lastWord && REALTIME_VOICE_CONSULT_TRAILING_FRAGMENT_WORDS.has(lastWord)) {
     return "trailing-fragment";
   }
-  // Closings are ignored unless they are framed as questions, because they are
-  // common conversational exits rather than work requests.
-  if (
-    !normalized.includes("?") &&
-    (/^(i'?ll|i will) be (right )?back\b/.test(normalized) ||
-      /\b(see you|bye(?:-bye)?|goodbye)\b/.test(normalized))
-  ) {
+  // Once closing phrases are removed, only closing components and separators may
+  // remain. Additional prose, questions, and code must still reach the agent.
+  const remainder = normalized.replace(
+    /\b(?:(?:i['’]?ll|i will) be (?:right )?back|see you|bye(?:[- ]bye)?|good[- ]?bye)\b/g,
+    "",
+  );
+  if (remainder !== normalized && REALTIME_VOICE_CLOSING_REMAINDER.test(remainder)) {
     return "non-actionable-closing";
   }
   return undefined;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where users making ordinary Discord voice requests, such as “Write a goodbye email to Sam,” would receive no agent response when their request contained farewell wording. This affected agent-proxy voice’s forced-consult path.

## Why This Change Was Made

Recognize the core farewell separately, then require the entire remaining utterance to consist of known courtesy, addressee, time, or separator components. This keeps the decision in the shared classifier and preserves the existing recorded skip reason and Discord handoff/playback owners.

The composed grammar is a bounded English-language heuristic. Unrecognized wording continues to the agent; it does not attempt general intent detection. The documentation states that boundary.

## User Impact

Requests mentioning farewells, including quoted/code examples and closings followed by work requests, reach the agent. Ordinary composed and time-qualified farewells remain quiet, including phrases such as “Thanks and goodbye,” “Bye for now, everyone,” and “See you tomorrow.”

## Evidence

Before the repair, four actionable classifier cases returned `non-actionable-closing`. The production Discord manager/bridge callback fixture also showed that the goodbye-email request invoked the mock agent zero times. After the repair, all 51 classifier cases and all 47 Discord realtime-turn cases pass, including genuine closings, additional work requests, questions, and existing active-run controls. The fixture uses the existing response-completion event between synthetic spoken answers; no external email, messaging, or speech-provider calls were made.

The full changed-scope gate passed. After the final grammar revision, core production/test typing, full-file core lint, formatting, and diff checks passed again. Managed independent review through P2 is scoped-clean. Read-only publication qualification confirms that the classifier, direct caller, accepted-transcript route, and focused tests are unchanged on the pinned publication base, so the existing 98-test and review evidence is retained rather than presented as a fresh full-main run.

Production adds 14 net lines for a readable, once-compiled compositional grammar and the complete-utterance check; tests add 54 net lines. No configuration, persistence, protocol, dependency, or live-provider API changes are included.
