### PR TITLE
refactor(codex): share node catalog record lookup

### DIFF
--- a/extensions/codex/src/session-catalog-node-continue.ts
+++ b/extensions/codex/src/session-catalog-node-continue.ts
@@ -21,17 +21,16 @@ import {
   type CodexNodeHistory,
   type CodexSessionDisposition,
 } from "./session-catalog-node-adoption.js";
+import { lookupNodeCodexCatalogRecord } from "./session-catalog-node-lookup.js";
 import {
   catalogError,
   CatalogParamsError,
   CODEX_APP_SERVER_THREADS_LIST_COMMAND,
   CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
-  CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
   MAX_SESSION_ID_LENGTH,
   filterCatalogPageByTitle,
   isInteractiveThreadSource,
   boundedCatalogString,
-  MAX_ACTION_CATALOG_PAGES,
   MAX_TRANSCRIPT_PAGE_LIMIT,
   NODE_INVOKE_TIMEOUT_MS,
   parseCatalogPage,
@@ -195,44 +194,6 @@ async function requireNodeForCodexContinue(params: {
   return { node, nodeId };
 }
 
-async function resolveNodeCodexRecord(params: {
-  agentId: string;
-  runtime: PluginRuntime;
-  nodeId: string;
-  threadId: string;
-}): Promise<CodexSessionCatalogSession> {
-  let cursor: string | undefined;
-  const seenCursors = new Set<string>();
-  for (let pageIndex = 0; pageIndex < MAX_ACTION_CATALOG_PAGES; pageIndex += 1) {
-    const raw = await params.runtime.nodes.invoke({
-      nodeId: params.nodeId,
-      command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
-      params: {
-        agentId: params.agentId,
-        limit: CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
-        ...(cursor ? { cursor } : {}),
-      },
-      timeoutMs: NODE_INVOKE_TIMEOUT_MS,
-      scopes: ["operator.write"],
-    });
-    const page = parseCatalogPage(unwrapNodeInvokePayload(raw));
-    const record = page.sessions.find((candidate) => candidate.threadId === params.threadId);
-    if (record) {
-      return record;
-    }
-    const nextCursor = page.nextCursor?.trim();
-    if (!nextCursor) {
-      break;
-    }
-    if (seenCursors.has(nextCursor)) {
-      throw new CatalogParamsError("Codex session eligibility could not be verified");
-    }
-    seenCursors.add(nextCursor);
-    cursor = nextCursor;
-  }
-  throw new CatalogParamsError("Codex session is unavailable on the paired node");
-}
-
 function requireContinuableNodeRecord(record: CodexSessionCatalogSession): void {
   if (record.archived) {
     throw new CatalogParamsError("Codex session is archived on the paired node");
@@ -308,12 +269,20 @@ async function continueNodeCodexSessionInner(params: {
     runtime: params.api.runtime,
     hostId: params.hostId,
   });
-  const record = await resolveNodeCodexRecord({
+  const lookup = await lookupNodeCodexCatalogRecord({
     agentId: params.agentId,
     runtime: params.api.runtime,
     nodeId,
     threadId: params.threadId,
   });
+  if (lookup.kind !== "found") {
+    throw new CatalogParamsError(
+      lookup.kind === "cursor-cycle"
+        ? "Codex session eligibility could not be verified"
+        : "Codex session is unavailable on the paired node",
+    );
+  }
+  const record = lookup.record;
   requireContinuableNodeRecord(record);
   const existing = findNodeAdoptedSessionEntry({
     agentId: params.agentId,

--- a/extensions/codex/src/session-catalog-node-lookup.ts
+++ b/extensions/codex/src/session-catalog-node-lookup.ts
@@ -1,0 +1,50 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  CODEX_APP_SERVER_THREADS_LIST_COMMAND,
+  CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
+  MAX_ACTION_CATALOG_PAGES,
+  NODE_INVOKE_TIMEOUT_MS,
+  unwrapNodeInvokePayload,
+  parseCatalogPage,
+} from "./session-catalog-parsing.js";
+import type { CodexSessionCatalogSession } from "./session-catalog-types.js";
+
+export async function lookupNodeCodexCatalogRecord(params: {
+  agentId: string;
+  runtime: PluginRuntime;
+  nodeId: string;
+  threadId: string;
+}): Promise<
+  { kind: "found"; record: CodexSessionCatalogSession } | { kind: "missing" | "cursor-cycle" }
+> {
+  let cursor: string | undefined;
+  const seenCursors = new Set<string>();
+  for (let pageIndex = 0; pageIndex < MAX_ACTION_CATALOG_PAGES; pageIndex += 1) {
+    const raw = await params.runtime.nodes.invoke({
+      nodeId: params.nodeId,
+      command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
+      params: {
+        agentId: params.agentId,
+        limit: CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
+        ...(cursor ? { cursor } : {}),
+      },
+      timeoutMs: NODE_INVOKE_TIMEOUT_MS,
+      scopes: ["operator.write"],
+    });
+    const page = parseCatalogPage(unwrapNodeInvokePayload(raw));
+    const record = page.sessions.find((candidate) => candidate.threadId === params.threadId);
+    if (record) {
+      return { kind: "found", record };
+    }
+    const nextCursor = page.nextCursor?.trim();
+    if (!nextCursor) {
+      break;
+    }
+    if (seenCursors.has(nextCursor)) {
+      return { kind: "cursor-cycle" };
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+  return { kind: "missing" };
+}

--- a/extensions/codex/src/session-catalog-terminal.ts
+++ b/extensions/codex/src/session-catalog-terminal.ts
@@ -7,28 +7,20 @@ import type {
   OpenClawPluginApi,
   OpenClawPluginNodeHostCommand,
 } from "openclaw/plugin-sdk/plugin-entry";
-import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import type { SessionCatalogTerminalPlan } from "openclaw/plugin-sdk/session-catalog";
 import { resolveCodexAppServerLocalHomeDir } from "./app-server/auth-start-options.js";
 import type { resolveCodexSupervisionAppServerRuntimeOptions } from "./app-server/config-runtime.js";
 import type { CodexCatalogHome } from "./session-catalog-homes.js";
+import { lookupNodeCodexCatalogRecord } from "./session-catalog-node-lookup.js";
 import {
   CatalogParamsError,
   CODEX_APP_SERVER_THREADS_CAPABILITY,
   CODEX_APP_SERVER_THREADS_LIST_COMMAND,
   CODEX_LOCAL_SESSION_HOST_ID,
-  CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
   isInteractiveThreadSource,
-  MAX_ACTION_CATALOG_PAGES,
-  NODE_INVOKE_TIMEOUT_MS,
-  unwrapNodeInvokePayload,
 } from "./session-catalog-parsing.js";
 import { resolveNodeHostExecutable, runNodePtyCommand } from "./session-catalog-pty.runtime.js";
-import type {
-  CodexSessionCatalogControl,
-  CodexSessionCatalogPage,
-  CodexSessionCatalogSession,
-} from "./session-catalog-types.js";
+import type { CodexSessionCatalogControl } from "./session-catalog-types.js";
 
 export const CODEX_TERMINAL_RESUME_COMMAND = "codex.terminal.resume.v1";
 export const CODEX_TERMINAL_START_COMMAND = "codex.terminal.start.v1";
@@ -189,45 +181,6 @@ export function createCodexTerminalNodeHostCommand(
   };
 }
 
-async function resolveNodeCatalogEligibleThread(params: {
-  agentId: string;
-  runtime: PluginRuntime;
-  nodeId: string;
-  threadId: string;
-  parseCatalogPage: (value: unknown) => CodexSessionCatalogPage;
-}): Promise<CodexSessionCatalogSession> {
-  let cursor: string | undefined;
-  const seenCursors = new Set<string>();
-  for (let pageIndex = 0; pageIndex < MAX_ACTION_CATALOG_PAGES; pageIndex += 1) {
-    const raw = await params.runtime.nodes.invoke({
-      nodeId: params.nodeId,
-      command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
-      params: {
-        agentId: params.agentId,
-        limit: CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
-        ...(cursor ? { cursor } : {}),
-      },
-      timeoutMs: NODE_INVOKE_TIMEOUT_MS,
-      scopes: ["operator.write"],
-    });
-    const page = params.parseCatalogPage(unwrapNodeInvokePayload(raw));
-    const record = page.sessions.find((candidate) => candidate.threadId === params.threadId);
-    if (record) {
-      if (isInteractiveThreadSource(record.source)) {
-        return record;
-      }
-      break;
-    }
-    const nextCursor = page.nextCursor?.trim();
-    if (!nextCursor || seenCursors.has(nextCursor)) {
-      break;
-    }
-    seenCursors.add(nextCursor);
-    cursor = nextCursor;
-  }
-  throw new CatalogParamsError("Codex session is not a non-archived interactive Codex session");
-}
-
 export async function openCodexCatalogTerminal(
   params: {
     agentId: string;
@@ -235,7 +188,6 @@ export async function openCodexCatalogTerminal(
     control: CodexSessionCatalogControl;
     hostId: string;
     threadId: string;
-    parseCatalogPage: (value: unknown) => CodexSessionCatalogPage;
     source?: CodexCatalogHome;
   } & CodexTerminalConfigSources,
 ): Promise<SessionCatalogTerminalPlan> {
@@ -276,13 +228,16 @@ export async function openCodexCatalogTerminal(
   if (!node) {
     throw new CatalogParamsError("paired-node Codex terminal is unavailable");
   }
-  const record = await resolveNodeCatalogEligibleThread({
+  const lookup = await lookupNodeCodexCatalogRecord({
     agentId: params.agentId,
     runtime: params.api.runtime,
     nodeId,
     threadId: params.threadId,
-    parseCatalogPage: params.parseCatalogPage,
   });
+  if (lookup.kind !== "found" || !isInteractiveThreadSource(lookup.record.source)) {
+    throw new CatalogParamsError("Codex session is not a non-archived interactive Codex session");
+  }
+  const record = lookup.record;
   return {
     kind: "node",
     nodeId,

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -20,7 +20,6 @@ import {
   CODEX_LOCAL_SESSION_HOST_ID,
   DEFAULT_TRANSCRIPT_PAGE_LIMIT,
   isInteractiveThreadSource,
-  parseCatalogPage,
 } from "./session-catalog-parsing.js";
 import {
   CODEX_TERMINAL_RESUME_COMMAND,
@@ -340,7 +339,6 @@ function registerCodexSessionCatalog(params: {
         getPluginConfig: params.getPluginConfig,
         getRuntimeConfig: params.getRuntimeConfig,
         resolveRuntimeOptions: params.resolveRuntimeOptions,
-        parseCatalogPage,
         ...(source ? { source } : {}),
         ...request,
         agentId,


### PR DESCRIPTION
## What Problem This Solves

Continuing a Codex session on a paired node and opening its terminal maintain separate copies of the same bounded catalog lookup. Changes to RPC arguments, response parsing or cursor handling currently have to remain synchronized across both copies.

## Why This Change Was Made

One private plugin helper now owns the sequential request, real page parser, first matching record and bounded cursor traversal. Both old lookup functions are removed, along with a private parser parameter whose sole production caller always supplied the canonical parser. Continuation and terminal operations retain their distinct eligibility checks and error messages.

## User Impact

Behavior is unchanged. Lookup keeps the same node command, scopes, 100-item pages, 100-page maximum, 65-second request timeout, cursor-cycle handling and first-match ordering. Active interactive sessions remain eligible for terminal opening; continuation keeps its existing state restrictions. The maintainer-requested consolidation removes 27 production code lines (28 physical lines), with no test changes or new public API.

## Evidence

All 40 existing node-listing and continuation tests pass before and after. A further 666 comparisons use the real helper, parser and response unwrapping to verify both callers across direct, payload and payloadJSON responses, including page 100, malformed or archived rows, cycle/match ordering and exact error causes. All 24 selected checks and independent P2 review pass.

The relevant upstream Codex listing request/response contract was inspected directly. Verification here uses synthetic transport plus existing provider-boundary tests; it does not claim a live Gateway, paired-node or Codex request. No runtime dependency or package-export change is introduced.
