### PR TITLE
fix: show active sessions while new work starts

### DIFF
--- a/ui/src/pages/activity/activity-page.ts
+++ b/ui/src/pages/activity/activity-page.ts
@@ -593,6 +593,7 @@ class ActivityPage extends OpenClawLightDomElement {
         connected: this.context.gateway.snapshot.phase === "connected",
         result: this.sessionActivity.result,
         loading: this.sessionActivity.loading,
+        incomplete: this.sessionActivity.incomplete,
         error: this.sessionActivity.error,
         onRetry: () => this.syncSessionActivity("retry"),
       })}

--- a/ui/src/pages/activity/current-work-view.ts
+++ b/ui/src/pages/activity/current-work-view.ts
@@ -24,6 +24,7 @@ type CurrentWorkProps = {
   connected: boolean;
   result?: SessionsListResult;
   loading: boolean;
+  incomplete: boolean;
   error?: string;
   onRetry: () => void;
 };
@@ -77,7 +78,7 @@ export function renderCurrentWork(props: CurrentWorkProps) {
     ? t("activity.currentWork.disconnected")
     : props.error
       ? t("activity.currentWork.loadFailed")
-      : !props.result
+      : !props.result || (rows.length === 0 && props.incomplete)
         ? t("activity.currentWork.loading")
         : rows.length === 0
           ? t("activity.currentWork.empty")

--- a/ui/src/pages/activity/current-work.test.ts
+++ b/ui/src/pages/activity/current-work.test.ts
@@ -68,6 +68,89 @@ it("loads a bounded current-work query independently of chat, people, and recenc
 });
 
 it.each([false, true])(
+  "publishes usable snapshots while new work keeps starting (refresh: %s)",
+  async (refresh) => {
+    vi.useFakeTimers();
+    const { client, request, controller } = setup();
+    try {
+      if (refresh) {
+        request.mockResolvedValueOnce(listing([]));
+        controller.load(client, "current");
+        await vi.advanceTimersByTimeAsync(0);
+      }
+      const responses = Array.from({ length: 4 }, () => createDeferred<SessionsListResult>());
+      for (const response of responses) {
+        request.mockReturnValueOnce(response.promise);
+      }
+      controller.load(client, "current", refresh ? "refresh" : "query");
+      const observed: Array<GatewaySessionRow[] | undefined> = [];
+      for (let round = 0; round < 3; round += 1) {
+        const transient = {
+          key: `agent:work:transient-${round}`,
+          agentId: "work",
+          sessionId: `transient-session-${round}`,
+          runId: `transient-run-${round}`,
+          updatedAt: 200 + round * 2,
+        };
+        controller.invalidate({
+          ...transient,
+          hasActiveRun: true,
+          activeRunIds: [transient.runId],
+          status: "running",
+        });
+        responses[round]!.resolve(listing([active]));
+        await vi.advanceTimersByTimeAsync(0);
+        observed.push(controller.result?.sessions);
+        // This short turn finishes before the next snapshot captures membership.
+        controller.invalidate({
+          ...transient,
+          updatedAt: transient.updatedAt + 1,
+          hasActiveRun: false,
+          activeRunIds: [],
+          status: "done",
+        });
+        await vi.advanceTimersByTimeAsync(200);
+      }
+      expect(controller.incomplete).toBe(true);
+      responses[3]!.resolve(listing([active]));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(controller.result?.sessions).toEqual([active]);
+      expect(controller.loading).toBe(false);
+      expect(observed).toEqual([[active], [active], [active]]);
+      expect(request).toHaveBeenCalledTimes(refresh ? 5 : 4);
+    } finally {
+      controller.hostDisconnected();
+    }
+  },
+);
+
+it("keeps an incomplete empty snapshot loading and permits retry after catch-up fails", async () => {
+  vi.useFakeTimers();
+  const { client, request, controller } = setup();
+  try {
+    const pending = createDeferred<SessionsListResult>();
+    request.mockReturnValueOnce(pending.promise).mockRejectedValueOnce(new Error("Unavailable"));
+    controller.load(client, "current");
+    controller.invalidate({ ...active, updatedAt: 200 });
+    pending.resolve(listing([]));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(controller.result?.sessions).toEqual([]);
+    expect(controller.incomplete).toBe(true);
+    expect(controller.loading).toBe(true);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(controller.error).toBe("Unavailable");
+    expect(controller.loading).toBe(false);
+    controller.load(client, "current", "retry");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(controller.error).toBeUndefined();
+    expect(controller.result?.sessions).toEqual([active]);
+    expect(controller.incomplete).toBe(false);
+  } finally {
+    controller.hostDisconnected();
+  }
+});
+
+it.each([false, true])(
   "does not resurrect completed work after a stale snapshot (another turn: %s)",
   async (anotherTurn) => {
     vi.useFakeTimers();
@@ -130,6 +213,7 @@ it("retires current work on disconnect and only accepts the replacement query", 
     controller.load(client, "current", "refresh");
     controller.load(null, null);
     expect(controller.result).toBeUndefined();
+    expect(controller.incomplete).toBe(false);
     request.mockResolvedValue(listing([]));
     controller.load(client, "current");
     stale.resolve(listing([active]));
@@ -207,6 +291,12 @@ it.each([{ activeRunIds: ["next-run"] }, { activeRunIds: null }])(
       controller.invalidate({ ...replacement, runId: "next-run", activeRunIds });
       expect(controller.result?.sessions).toEqual([replacement]);
       controller.invalidate({
+        ...active,
+        key: "agent:work:another-session",
+        sessionId: "another-session",
+        updatedAt: 200,
+      });
+      controller.invalidate({
         key: active.key,
         agentId: active.agentId,
         sessionId: active.sessionId,
@@ -218,6 +308,8 @@ it.each([{ activeRunIds: ["next-run"] }, { activeRunIds: null }])(
       });
       expect(controller.result?.sessions).toEqual([replacement]);
       stale.resolve(listing([active]));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(controller.result?.sessions).toEqual([replacement]);
       await vi.advanceTimersByTimeAsync(200);
       expect(controller.result?.sessions).toEqual([replacement]);
       expect(request).toHaveBeenCalledTimes(3);

--- a/ui/src/pages/activity/current-work.ts
+++ b/ui/src/pages/activity/current-work.ts
@@ -57,7 +57,7 @@ export function readCurrentWorkChange(payload: unknown): CurrentWorkChange | nul
 export function reconcileCurrentWork(
   result: SessionsListResult,
   changes: Iterable<CurrentWorkChange>,
-): { result: SessionsListResult; requiresRefresh: boolean } {
+): { result: SessionsListResult; requiresRefresh: boolean; canPublish: boolean } {
   const rows = new Map(
     result.sessions.map((row) => [currentWorkIdentity(row), { row, requiresRefresh: false }]),
   );
@@ -129,7 +129,7 @@ export function reconcileCurrentWork(
   }
   const current = [...rows.values()].filter(({ row }) => row.hasActiveRun === true);
   const sessions = current.map(({ row }) => row);
-  const requiresRefresh =
-    current.some((state) => state.requiresRefresh) || (!result.hasMore && unseenActive.size > 0);
-  return { result: { ...result, count: sessions.length, sessions }, requiresRefresh };
+  const canPublish = !current.some((state) => state.requiresRefresh);
+  const requiresRefresh = !canPublish || (!result.hasMore && unseenActive.size > 0);
+  return { result: { ...result, count: sessions.length, sessions }, requiresRefresh, canPublish };
 }

--- a/ui/src/pages/activity/session-activity-controller.ts
+++ b/ui/src/pages/activity/session-activity-controller.ts
@@ -23,10 +23,11 @@ const CURRENT_WORK_CHANGE_LIMIT = 1_000;
 export class SessionActivityController implements ReactiveController {
   result?: SessionsListResult;
   error?: string;
+  incomplete = false;
   private requestState: "idle" | "loading" | "retrying" = "idle";
 
   get loading(): boolean {
-    return this.requestState !== "idle";
+    return this.requestState !== "idle" || this.incomplete;
   }
 
   get retrying(): boolean {
@@ -69,6 +70,7 @@ export class SessionActivityController implements ReactiveController {
     this.pending?.abort();
     this.pending = undefined;
     this.requestState = "idle";
+    this.incomplete = false;
     this.error = undefined;
     this.client = null;
     this.queryKey = undefined;
@@ -175,7 +177,9 @@ export class SessionActivityController implements ReactiveController {
         const change = readCurrentWorkChange(payload);
         if (change) {
           if (this.result) {
-            this.result = reconcileCurrentWork(this.result, [change]).result;
+            const next = reconcileCurrentWork(this.result, [change]);
+            this.result = next.result;
+            this.incomplete ||= next.requiresRefresh;
             this.host.requestUpdate();
           }
           if (this.pending) {
@@ -250,6 +254,7 @@ export class SessionActivityController implements ReactiveController {
     this.error = undefined;
     if (!sameQuery) {
       this.result = undefined;
+      this.incomplete = false;
     }
     this.refreshPending = false;
     this.host.requestUpdate();
@@ -259,10 +264,12 @@ export class SessionActivityController implements ReactiveController {
         if (this.pending === pending) {
           if (filters === "current") {
             const next = reconcileCurrentWork(result, this.pendingChanges);
-            if (this.changesOverflowed || next.requiresRefresh) {
-              // Conflicting run identities cannot certify an in-flight snapshot.
+            this.incomplete = this.changesOverflowed || next.requiresRefresh;
+            if (this.incomplete) {
               this.eventRefresh.schedule();
-            } else {
+            }
+            // Missing membership needs catch-up, but does not invalidate known rows.
+            if (!this.changesOverflowed && next.canPublish) {
               this.result = next.result;
             }
           } else {
@@ -274,6 +281,7 @@ export class SessionActivityController implements ReactiveController {
         if (this.pending === pending && !pending.signal.aborted) {
           if (filters === "current") {
             this.result = undefined;
+            this.incomplete = false;
           }
           this.error = error instanceof Error ? error.message : String(error);
         }

--- a/ui/src/pages/activity/view.test.ts
+++ b/ui/src/pages/activity/view.test.ts
@@ -74,6 +74,7 @@ describe("renderActivity", () => {
         navigate: vi.fn(),
         connected: true,
         loading: false,
+        incomplete: false,
         onRetry: vi.fn(),
         result: {
           ts: 1,
@@ -109,6 +110,40 @@ describe("renderActivity", () => {
       container.querySelector('a[data-session-key="agent:work:global"]')?.getAttribute("href"),
     ).toBe("/control/chat/work/~key/global");
   });
+
+  it.each([false, true])(
+    "distinguishes an incomplete empty snapshot from a normal empty refresh (incomplete: %s)",
+    async (incomplete) => {
+      await i18n.setLocale("en");
+      const container = document.createElement("div");
+      document.body.append(container);
+      render(
+        renderCurrentWork({
+          basePath: "/control",
+          fallbackAgentId: "main",
+          mainKey: "main",
+          globalScope: false,
+          navigate: vi.fn(),
+          connected: true,
+          loading: true,
+          incomplete,
+          onRetry: vi.fn(),
+          result: {
+            ts: 1,
+            path: "",
+            count: 0,
+            defaults: { model: null, modelProvider: null, contextTokens: null },
+            sessions: [],
+          },
+        }),
+        container,
+      );
+      expect(container.querySelector('[role="status"]')?.textContent).toContain(
+        incomplete ? "Loading active sessions…" : "No active sessions.",
+      );
+      expect(container.querySelector("section")?.getAttribute("aria-busy")).toBe("true");
+    },
+  );
 
   it("renders the summary from localized labels", async () => {
     await i18n.setLocale("de");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Live activity could keep active sessions hidden while other sessions repeatedly started work. Follow-up to #141045.

## Why This Change Was Made

Publish safely reconciled session rows while refreshing for new membership. Keep the existing guards against ambiguous run identities and event-buffer overflow. An incomplete empty result keeps loading feedback; an ordinary refresh preserves the confirmed empty state.

## User Impact

Already-running work appears without waiting for all other sessions to become quiet. Completed or replaced runs retain their existing stale-snapshot protection.

## Evidence

- Three successful snapshots containing stable running work previously displayed zero rows until a quiet fourth response. The same browser scenario now displays that row after every raced response, using the same four requests.
- 47 focused UI tests and 3 bundled Activity browser tests pass. Coverage includes cold entry, refresh, completion/replacement races, disconnect, visibility, error/retry, and incomplete versus confirmed empty feedback.
- All 20 applicable native changed checks pass. The complete core-test type graph passes in the complementary exact-head [CI run](https://github.com/openclaw/openclaw/actions/runs/34126070935); the full CI run is green.
- Independent review through P2 is clean. The inspected 11.44-second recording below shows the complete race and empty-state controls, with no page errors.

## Visual evidence

| View | Before | After |
| --- | --- | --- |
| After three successful raced snapshots | ![Before: Active sessions still shows Loading after three successful snapshots containing stable work](https://github.com/user-attachments/assets/aced86ab-4215-442e-a979-b96da4e061f4) | ![After: stable running work remains visible through all three successful raced snapshots](https://github.com/user-attachments/assets/731ecae0-a94e-42c6-bd0c-b2159d933a7e) |
| Quiet fourth response preserves the existing behavior | ![Before: a quiet fourth response finally displays stable running work](https://github.com/user-attachments/assets/8c4c10fe-ae41-4f6d-9843-30b42a6d7ea6) | ![After: the same stable running work remains visible following the quiet fourth response](https://github.com/user-attachments/assets/940713e3-4653-40bf-994c-238caf4ccdff) |

### Race, quiet recovery and empty-state controls

https://github.com/user-attachments/assets/e3d27a5f-9e85-4a0e-946d-d550ecf8299c

<details>
<summary>Visual verification details</summary>


- Baseline: 99415ced11be621c5bf1514a3cc797b58f470377
- Exact head: `680a090586741abea170e360aab9f6bca46c60fc`
- Scenario: Open Live activity with stable running work in every snapshot. Deliver a different transient start before each of three successful replies and its terminal event before the next snapshot; then return a quiet fourth response. Additional final-head controls distinguish incomplete empty replies from confirmed empty state and preserve that state during an ordinary refresh.
- Runtime/build: OpenClaw Control UI source-mode app at 680a090586741abea170e360aab9f6bca46c60fc, Node 24.19.0, Chromium 144.0.7559.0, synthetic repository mock Gateway. Both sides use 1440x1000, dark theme, en-US, UTC, reduced motion and blocked service workers.
- Stable rows after raced replies: Before 0,0,0; after 1,1,1
- Primary paired request count: Four activeOnly requests on both revisions; the same stable A in every response
- Incomplete empty response: Loading remains visible, no empty-state claim, aria-busy=true
- Quiet empty response and ordinary refresh: No active sessions is shown after confirmation and remains shown during a normal refresh; aria-busy reflects the pending request
- Recorded proof: 11.44 seconds, 286 frames, no page errors; all frames decode
- Baseline Activity modules, mock harness and relevant styles are unchanged from the original capture through branch base 5d895d3d52a78751413eac0e59399da9b91cb026; baseline-equivalence.json records the comparison.
- Every changed source hash and the recorder hash match exact final head 680a090586741abea170e360aab9f6bca46c60fc; source remained unchanged throughout capture.
- Both paired baseline screenshots, all four after screenshots, the full after timeline at quarter-second intervals and its exact final frame were inspected. The original recordings remain intact.
- Factual cues identify the otherwise invisible Gateway event/reply order; they do not change production state or rendered results.
- Synthetic session labels and a public model ID only; no credentials, private messages or personal data visible.
- The preserved baseline predates sidebar running-indicator presentation changes. The compared Activity panel, snapshot data, event order and request count remain equivalent; the sidebar is outside this repair.

</details>

### Empty-state controls

| Incomplete snapshot | Confirmed empty snapshot |
| --- | --- |
| ![An incomplete empty snapshot keeps Loading visible](https://github.com/user-attachments/assets/9b56e810-7fc6-488e-b1cd-e5a971ba301a) | ![A quiet empty snapshot confirms no active sessions](https://github.com/user-attachments/assets/5d71756d-e14f-409f-8aea-d2cb9d2de309) |
