### PR TITLE
fix(agents): align auth rotation tests with rate-limit retry budgets

### DIFF
--- a/src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts
@@ -351,6 +351,8 @@ const makeErrorAttempt = (
     ...overrides,
   });
   return makeAttempt({
+    // Rotation-only fixtures disable retries; retry-budget cases override this.
+    providerRetryMaxRetries: 0,
     assistantTexts: [],
     lastAssistant: assistant,
     ...(opts?.currentAttempt ? { currentAttemptAssistant: assistant } : {}),
@@ -456,8 +458,7 @@ async function runAutoPinnedRotationCase(params: {
   runEmbeddedAttemptMock.mockReset();
   return withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
     await writeAuthStore(agentDir);
-    // This provider reports a three-retry cap; exhaust it before rotating.
-    // Credential/quota failures still rotate after the first failed attempt.
+    // Exhaust this provider's three-retry cap before rotating on transient failures.
     const failureCount = params.exhaustTransientRetries ? 4 : 1;
     for (let attempt = 0; attempt < failureCount; attempt += 1) {
       runEmbeddedAttemptMock.mockResolvedValueOnce({
@@ -920,8 +921,9 @@ describe("runEmbeddedAgent auth profile rotation", () => {
     }
   });
 
-  it("rotates auto-pinned profiles on long-window rate limits without transient retries", async () => {
+  it("rotates auto-pinned profiles on long-window rate limits after transient retries", async () => {
     await runAutoPinnedRotationCase({
+      exhaustTransientRetries: true,
       errorMessage: "429 Too Many Requests: subscription usage limit reached",
       sessionKey: "agent:test:auto",
       runId: "run:auto",


### PR DESCRIPTION
Related: #139465

<details>
<summary>Additional instructions</summary>

This PR uses a same-repository branch; maintainers can update it with repository write access.

</details>

## What Problem This Solves

Resolves stale auth-profile rotation coverage on main: the subscription-limit case still expected immediate profile rotation after #139465 deliberately changed rate-limit continuation to exhaust the provider retry budget first. The full file also exposed the same assumption in user-pin, Codex user-pin, and cooldown-skipping fixtures.

## Why This Change Was Made

The contract comes from the retry owner and documented change, not the failing assertion. #139465 removed the long-window guard, removed **“Long quota windows”** from the retry documentation's exclusions, and deleted controller cases requiring immediate rotation for billing-period usage and quota-exceeded messages. It deliberately retains provider pacing, including long `Retry-After` floors. The subscription documentation promises next-profile rotation without promising that it precedes the continuation budget.

The [model-failover documentation committed by #139465](https://github.com/openclaw/openclaw/blob/b6ca24cb0928a225ff2dda1654823e60e6abfa96/docs/concepts/model-failover.md#L277) states:

> The failover controller owns OpenClaw's transient recovery budget. Rate limits receive up to **10 total attempts** before profile rotation or model fallback.

The same documentation states:

> The embedded runtime's existing session setting `retry.provider.maxRetries` overrides its recovery retry budget; `0` disables retries, and rate limits remain capped at 10 total attempts.

The exact case updated in `src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts` is **“rotates auto-pinned profiles on long-window rate limits without transient retries”**, now **“rotates auto-pinned profiles on long-window rate limits after transient retries”**. Its explicit three-retry fixture exercises the documented override before asserting backup-profile rotation.

The existing subscription case now uses the shared helper's three-retry path, which asserts four attempts with `openai:p1`, then `openai:p2`, exactly three sleeps, and successful backup-profile bookkeeping. Rotation-only error fixtures explicitly report the already-supported zero retry budget. Their existing attempt, profile, and cooldown assertions remain intact. No new test or production abstraction is introduced; the failover controller remains the canonical retry-budget owner.

## User Impact

No runtime behavior change. This preserves the documented bounded continuation policy and repairs the test coverage that verifies eventual auth-profile rotation. No configuration, persistent-state, dependency, or public API changes.

## Evidence

The original single case was run sequentially in detached checkouts, oldest suspect first:

| Suspect | Parent | Parent result | Squash commit | Commit result |
| --- | --- | --- | --- | --- |
| #139465 | `38d31ee66dd3` | Pass | `b6ca24cb0928` | Fail |
| #140639 | `a471ab0b49a8` | Fail | `12ce3c37242b` | Fail |
| #140777 | `b0b2e60482d8` | Fail | `1241d7f7ffa2` | Fail |
| #140883 | `f2d20be1845a` | Fail | `7e8cffd9a389` | Fail |

Every failure was the same assertion: expected `p1 → p2`, observed `p1 → p1`. The first failing commit is **b6ca24cb0928a225ff2dda1654823e60e6abfa96 (#139465)**. #139697 had made the fixture explicitly subscription-shaped before that change; #139911 later changed only its store import. The three later suspects are not responsible.

Historical command: `OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts -t 'rotates auto-pinned profiles on long-window'`. The shared E2E runtime was built first; the targeted tests load the checked-out source. The initial current-main run without the build-skip flag reproduced the same assertion.

- Full auth-profile rotation E2E file: **31 passed**. The three sibling fixtures were separately reproduced before their shared fixture correction: **3 failed**, independent of the subscription-budget case.
- Every existing `src/agents/failover/*.test.ts` file through the repository runner: **881 passed across 12 files**. A directory-only selector routed to an empty project, so the final command enumerated the explicit test inventory.
- Retry-controller and attempt-recovery suites: **61 passed**; this includes short-window rates, long provider floors, and retry-budget limits.
- Independent Codex autoreview: **scoped-clean through P2**, zero actionable findings.
- `node scripts/check-changed.mjs`: **passed**, including typecheck, lint, ratchets, boundaries, and all dead-export scans.
- `pnpm build`: **passed** in 6m 42s, including unified/SDK declarations, plugin artifacts, and Control UI build.
- Native review artifacts validated. Exact-head [CI run 34126555616](https://github.com/openclaw/openclaw/actions/runs/34126555616) is **green**, with zero pending or failing checks. `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 141238` passed and preserved the tested head; no CI rerun was needed.
- ClawSweeper current-head review: no actionable findings, no before-merge items.

This is synthetic local boundary proof; no live provider run is required for the test-only change.

Published candidate: `d5e8ed9a79a706ebf3677241e4d423c212b40eb8`, rebased onto `1b90029dbd75d201cb36caba18e452a0ba96d196`. `git range-diff` confirms the reviewed patch is identical across the rebase. Local proof above preceded that mechanical rebase; hosted CI passed on the published head.
