### PR TITLE
refactor(channels): dedupe optional public artifact loading

### DIFF
--- a/src/channels/plugins/message-tool-api.test.ts
+++ b/src/channels/plugins/message-tool-api.test.ts
@@ -1,9 +1,16 @@
 // Message tool API tests cover channel message tool descriptors and runtime calls.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { loadBundledPluginPublicArtifactModuleSyncMock } = vi.hoisted(() => ({
-  loadBundledPluginPublicArtifactModuleSyncMock: vi.fn(
-    ({ artifactBasename, dirName }: { artifactBasename: string; dirName: string }) => {
+const { loadBundledPluginPublicArtifactModuleFromCandidatesSyncMock } = vi.hoisted(() => ({
+  loadBundledPluginPublicArtifactModuleFromCandidatesSyncMock: vi.fn(
+    ({
+      artifactCandidates,
+      dirName,
+    }: {
+      artifactCandidates: readonly string[];
+      dirName: string;
+    }) => {
+      const artifactBasename = artifactCandidates[0];
       if (dirName === "slack" && artifactBasename === "message-tool-api.js") {
         return {
           describeMessageTool: () => ({
@@ -19,34 +26,33 @@ const { loadBundledPluginPublicArtifactModuleSyncMock } = vi.hoisted(() => ({
       if (dirName === "broken" && artifactBasename === "message-tool-api.js") {
         throw new Error("broken message tool artifact");
       }
-      throw new Error(
-        `Unable to resolve bundled plugin public surface ${dirName}/${artifactBasename}`,
-      );
+      return null;
     },
   ),
 }));
 
 vi.mock("../../plugins/public-surface-loader.js", () => ({
-  loadBundledPluginPublicArtifactModuleSync: loadBundledPluginPublicArtifactModuleSyncMock,
+  loadBundledPluginPublicArtifactModuleFromCandidatesSync:
+    loadBundledPluginPublicArtifactModuleFromCandidatesSyncMock,
 }));
 
 import { resolveBundledChannelMessageToolDiscoveryAdapter } from "./message-tool-api.js";
 
 describe("bundled channel message tool fast path", () => {
   beforeEach(() => {
-    loadBundledPluginPublicArtifactModuleSyncMock.mockClear();
+    loadBundledPluginPublicArtifactModuleFromCandidatesSyncMock.mockClear();
   });
 
   it("loads message tool discovery from the narrow artifact", () => {
-    const adapter = resolveBundledChannelMessageToolDiscoveryAdapter("slack");
+    const adapter = resolveBundledChannelMessageToolDiscoveryAdapter(" slack ");
     expect(adapter?.describeMessageTool?.({ cfg: {} })).toStrictEqual({
       actions: ["send", "upload-file"],
       capabilities: ["presentation"],
       schema: null,
     });
-    expect(loadBundledPluginPublicArtifactModuleSyncMock).toHaveBeenCalledWith({
+    expect(loadBundledPluginPublicArtifactModuleFromCandidatesSyncMock).toHaveBeenCalledWith({
       dirName: "slack",
-      artifactBasename: "message-tool-api.js",
+      artifactCandidates: ["message-tool-api.js"],
     });
   });
 

--- a/src/channels/plugins/message-tool-api.ts
+++ b/src/channels/plugins/message-tool-api.ts
@@ -22,7 +22,10 @@ type MessageToolApi = {
 };
 
 function loadBundledChannelMessageToolApi(channelId: string): MessageToolApi | undefined {
-  return loadOptionalBundledChannelPublicArtifact<MessageToolApi>(channelId, "message-tool-api.js");
+  return loadOptionalBundledChannelPublicArtifact({
+    channelId,
+    artifactBasename: "message-tool-api.js",
+  });
 }
 
 /**

--- a/src/channels/plugins/message-tool-api.ts
+++ b/src/channels/plugins/message-tool-api.ts
@@ -3,7 +3,7 @@
  *
  * Resolves lightweight discovery hooks without loading full channel plugins.
  */
-import { loadBundledPluginPublicArtifactModuleSync } from "../../plugins/public-surface-loader.js";
+import { loadOptionalBundledChannelPublicArtifact } from "./optional-public-artifact.js";
 import type { ChannelMessageActionAdapter } from "./types.public.js";
 
 /**
@@ -21,24 +21,8 @@ type MessageToolApi = {
   describeMessageTool?: ChannelMessageToolDiscoveryAdapter["describeMessageTool"];
 };
 
-const MESSAGE_TOOL_API_ARTIFACT_BASENAME = "message-tool-api.js";
-const MISSING_PUBLIC_SURFACE_PREFIX = "Unable to resolve bundled plugin public surface ";
-
 function loadBundledChannelMessageToolApi(channelId: string): MessageToolApi | undefined {
-  const cacheKey = channelId.trim();
-  try {
-    return loadBundledPluginPublicArtifactModuleSync<MessageToolApi>({
-      dirName: cacheKey,
-      artifactBasename: MESSAGE_TOOL_API_ARTIFACT_BASENAME,
-    });
-  } catch (error) {
-    // Missing artifacts are optional; present-but-broken artifacts should fail
-    // so discovery does not silently hide invalid bundled plugin contracts.
-    if (error instanceof Error && error.message.startsWith(MISSING_PUBLIC_SURFACE_PREFIX)) {
-      return undefined;
-    }
-    throw error;
-  }
+  return loadOptionalBundledChannelPublicArtifact<MessageToolApi>(channelId, "message-tool-api.js");
 }
 
 /**

--- a/src/channels/plugins/optional-public-artifact.ts
+++ b/src/channels/plugins/optional-public-artifact.ts
@@ -1,15 +1,14 @@
 import { loadBundledPluginPublicArtifactModuleFromCandidatesSync } from "../../plugins/public-surface-loader.js";
 
 // Missing artifacts are optional; errors from resolved artifacts must propagate.
-// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Dynamic public artifact loaders use caller-supplied module surface types.
-export function loadOptionalBundledChannelPublicArtifact<T extends object>(
-  channelId: string,
-  artifactBasename: string,
-): T | undefined {
+export function loadOptionalBundledChannelPublicArtifact(params: {
+  channelId: string;
+  artifactBasename: string;
+}): object | undefined {
   return (
-    loadBundledPluginPublicArtifactModuleFromCandidatesSync<T>({
-      dirName: channelId.trim(),
-      artifactCandidates: [artifactBasename],
+    loadBundledPluginPublicArtifactModuleFromCandidatesSync({
+      dirName: params.channelId.trim(),
+      artifactCandidates: [params.artifactBasename],
     }) ?? undefined
   );
 }

--- a/src/channels/plugins/optional-public-artifact.ts
+++ b/src/channels/plugins/optional-public-artifact.ts
@@ -1,0 +1,15 @@
+import { loadBundledPluginPublicArtifactModuleFromCandidatesSync } from "../../plugins/public-surface-loader.js";
+
+// Missing artifacts are optional; errors from resolved artifacts must propagate.
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Dynamic public artifact loaders use caller-supplied module surface types.
+export function loadOptionalBundledChannelPublicArtifact<T extends object>(
+  channelId: string,
+  artifactBasename: string,
+): T | undefined {
+  return (
+    loadBundledPluginPublicArtifactModuleFromCandidatesSync<T>({
+      dirName: channelId.trim(),
+      artifactCandidates: [artifactBasename],
+    }) ?? undefined
+  );
+}

--- a/src/channels/plugins/thread-binding-api.test.ts
+++ b/src/channels/plugins/thread-binding-api.test.ts
@@ -1,9 +1,16 @@
 // Thread binding API tests cover channel plugin thread binding contracts and helpers.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { loadBundledPluginPublicArtifactModuleSyncMock } = vi.hoisted(() => ({
-  loadBundledPluginPublicArtifactModuleSyncMock: vi.fn(
-    ({ artifactBasename, dirName }: { artifactBasename: string; dirName: string }) => {
+const { loadBundledPluginPublicArtifactModuleFromCandidatesSyncMock } = vi.hoisted(() => ({
+  loadBundledPluginPublicArtifactModuleFromCandidatesSyncMock: vi.fn(
+    ({
+      artifactCandidates,
+      dirName,
+    }: {
+      artifactCandidates: readonly string[];
+      dirName: string;
+    }) => {
+      const artifactBasename = artifactCandidates[0];
       if (dirName === "matrix" && artifactBasename === "thread-binding-api.js") {
         return {
           defaultTopLevelPlacement: "child",
@@ -24,15 +31,14 @@ const { loadBundledPluginPublicArtifactModuleSyncMock } = vi.hoisted(() => ({
       if (dirName === "broken" && artifactBasename === "thread-binding-api.js") {
         throw new Error("broken thread binding artifact");
       }
-      throw new Error(
-        `Unable to resolve bundled plugin public surface ${dirName}/${artifactBasename}`,
-      );
+      return null;
     },
   ),
 }));
 
 vi.mock("../../plugins/public-surface-loader.js", () => ({
-  loadBundledPluginPublicArtifactModuleSync: loadBundledPluginPublicArtifactModuleSyncMock,
+  loadBundledPluginPublicArtifactModuleFromCandidatesSync:
+    loadBundledPluginPublicArtifactModuleFromCandidatesSyncMock,
 }));
 
 import {
@@ -42,21 +48,21 @@ import {
 
 describe("bundled channel thread binding fast path", () => {
   beforeEach(() => {
-    loadBundledPluginPublicArtifactModuleSyncMock.mockClear();
+    loadBundledPluginPublicArtifactModuleFromCandidatesSyncMock.mockClear();
   });
 
   it("loads default placement from the narrow thread binding artifact", () => {
-    expect(resolveBundledChannelThreadBindingDefaultPlacement("matrix")).toBe("child");
-    expect(loadBundledPluginPublicArtifactModuleSyncMock).toHaveBeenCalledWith({
+    expect(resolveBundledChannelThreadBindingDefaultPlacement(" matrix ")).toBe("child");
+    expect(loadBundledPluginPublicArtifactModuleFromCandidatesSyncMock).toHaveBeenCalledWith({
       dirName: "matrix",
-      artifactBasename: "thread-binding-api.js",
+      artifactCandidates: ["thread-binding-api.js"],
     });
   });
 
   it("loads inbound conversation resolution from the narrow artifact", () => {
     expect(
       resolveBundledChannelThreadBindingInboundConversation({
-        channelId: "matrix",
+        channelId: " matrix ",
         to: "room:!room:example",
         threadId: "$thread",
         isGroup: true,

--- a/src/channels/plugins/thread-binding-api.ts
+++ b/src/channels/plugins/thread-binding-api.ts
@@ -4,7 +4,7 @@
  * Reads lightweight thread placement and inbound conversation hooks without full plugin loading.
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { loadBundledPluginPublicArtifactModuleSync } from "../../plugins/public-surface-loader.js";
+import { loadOptionalBundledChannelPublicArtifact } from "./optional-public-artifact.js";
 
 type ThreadBindingPlacement = "current" | "child";
 
@@ -29,24 +29,11 @@ type ThreadBindingApi = {
   ) => ThreadBindingConversationRef | null;
 };
 
-const THREAD_BINDING_API_ARTIFACT_BASENAME = "thread-binding-api.js";
-const MISSING_PUBLIC_SURFACE_PREFIX = "Unable to resolve bundled plugin public surface ";
-
 function loadBundledChannelThreadBindingApi(channelId: string): ThreadBindingApi | undefined {
-  const cacheKey = channelId.trim();
-  try {
-    return loadBundledPluginPublicArtifactModuleSync<ThreadBindingApi>({
-      dirName: cacheKey,
-      artifactBasename: THREAD_BINDING_API_ARTIFACT_BASENAME,
-    });
-  } catch (error) {
-    // Missing artifacts are optional; broken artifacts should surface so
-    // bundled thread-binding contracts do not fail silently.
-    if (error instanceof Error && error.message.startsWith(MISSING_PUBLIC_SURFACE_PREFIX)) {
-      return undefined;
-    }
-    throw error;
-  }
+  return loadOptionalBundledChannelPublicArtifact<ThreadBindingApi>(
+    channelId,
+    "thread-binding-api.js",
+  );
 }
 
 function normalizeThreadBindingPlacement(value: unknown): ThreadBindingPlacement | undefined {

--- a/src/channels/plugins/thread-binding-api.ts
+++ b/src/channels/plugins/thread-binding-api.ts
@@ -30,10 +30,10 @@ type ThreadBindingApi = {
 };
 
 function loadBundledChannelThreadBindingApi(channelId: string): ThreadBindingApi | undefined {
-  return loadOptionalBundledChannelPublicArtifact<ThreadBindingApi>(
+  return loadOptionalBundledChannelPublicArtifact({
     channelId,
-    "thread-binding-api.js",
-  );
+    artifactBasename: "thread-binding-api.js",
+  });
 }
 
 function normalizeThreadBindingPlacement(value: unknown): ThreadBindingPlacement | undefined {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainer-authored branch; edits by maintainers are enabled.

</details>

## What Problem This Solves

Maintainer-requested, bounded cleanup of optional channel artifact loading. Message-tool discovery and thread-binding discovery duplicated the same lookup and missing-artifact handling, including error-message-prefix classification that can mistake a broken resolved artifact for an absent one.

## Why This Change Was Made

Both owners now use one private channel helper backed by the existing synchronous candidate loader with exactly one artifact name. It trims the channel ID, maps a genuinely missing artifact from `null` to `undefined`, and lets resolved-artifact errors propagate unchanged.

Artifact-specific validation remains in its existing owner: message-tool function checks, thread placement normalization, inbound resolver checks, and explicit `null` results. No barrel or SDK export, caller changes, configuration, schema, storage, protocol, security, or dependency changes.

## User Impact

No new feature or configuration. Optional artifacts remain optional, discovery stays synchronous and lazy, and failures from broken resolved artifacts remain visible.

## Evidence

- Baseline owner tests: 10 passed.
- Final focused owner, caller, loader, and lint-suppression suites: 72 passed across 7 files, including message-action discovery, conversation resolution, message-tool discovery, and candidate-loader error propagation.
- `pnpm test:contracts:channels`: 495 passed across 50 files before the final helper signature cleanup; final-head hosted channel contracts also passed.
- Owner tests now exercise padded `" slack "` and `" matrix "` IDs. Existing missing and broken cases remain; no helper-mirroring test or test-only production API was added.
- Scoped independent review through P2: no unresolved findings. The final review confirmed the implementation and identified only the unstaged correction; staging it resolved that finding.
- Source extension-import boundary inventory: no violations.
- Changed-gate dry run selects core, core tests, extension, and extension-test checks.
- Targeted type-aware lint, formatting, and `git diff --check`: passed.
- Production: 24 additions / 36 deletions, net -12 lines. Tests: 35 additions / 23 deletions, net +12 lines.
- Local build and the actual changed gate reach the hermetic declaration boundary but cannot complete with the required shared dependency symlink. The changed gate passed all preceding guards, then rejected the externally resolved compiler. Clean-checkout exact-head hosted build, typechecks, contracts, and tests passed; no guard was weakened and no install was run in the worktree.
- Initial CI caught an added lint suppression in the helper. The helper now returns the canonical loader's `object` contract without a generic or suppression; the unchanged suppression-allowlist test passes. No allowlist or unrelated test was edited.
- [Final-head CI](https://github.com/openclaw/openclaw/actions/runs/34128321475) passed for `3e21856ec3f2d785075c791213cd380979a98d24`, including the required `openclaw/ci-gate`.
- [Fresh ClawSweeper review](https://github.com/openclaw/openclaw/pull/141241#issuecomment-5571336035) covers the same head and reports no findings or pre-merge actions.
