### PR TITLE
improve(tui): reduce preparation work during text and picker updates

### DIFF
--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -926,6 +926,11 @@ describe("sanitizeRenderableText", () => {
 });
 
 describe("Markdown display safety", () => {
+  it("preserves layout controls while removing neighboring C0, DEL, and C1 controls", () => {
+    const input = "a\u0008\tb\u000b\nc\u000c\rd\u000e\u001f\u007f\u0080\u009f";
+    expect(sanitizeMarkdownSource(input)).toBe("a\tb\nc\rd");
+  });
+
   it("strips hostile controls from source without adding directional isolates", () => {
     const input = "\u202e# مرحبا\u202c\n\u009b31m> שלום\u009b0m";
     const sanitized = sanitizeMarkdownSource(input);
@@ -954,12 +959,19 @@ describe("Markdown display safety", () => {
 describe("isTerminalSafeAutocompleteValue", () => {
   it("accepts ordinary Unicode and rejects terminal or bidi controls", () => {
     expect(isTerminalSafeAutocompleteValue("/tmp/مرحبا-東京.txt")).toBe(true);
+    expect(isTerminalSafeAutocompleteValue("👩🏽‍💻/cafe\u0301.txt")).toBe(true);
     for (const value of [
       "bad\x1b[31m",
       "bad\tvalue",
+      "bad\rvalue",
+      "bad\nvalue",
+      "bad\u007fvalue",
+      "bad\u0085value",
       "bad\u009bvalue",
       "bad\u200evalue",
       "bad\u202evalue",
+      "bad\u2066value",
+      "bad\u2069value",
     ]) {
       expect(isTerminalSafeAutocompleteValue(value)).toBe(false);
     }

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -2,6 +2,7 @@ import { asOptionalObjectRecord as asMessageRecord } from "@openclaw/normalizati
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 // Formats terminal-safe strings for TUI messages and status surfaces.
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import { hasTerminalControl } from "../../packages/terminal-core/src/safe-text.js";
 import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
 import { appendReplyMediaFailures, type ReplyMediaFailure } from "../auto-reply/reply-payload.js";
 import { stripLeadingInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
@@ -15,6 +16,11 @@ import { formatTokenCount } from "../utils/token-format.js";
 import type { SessionInfo } from "./tui-types.js";
 
 const REPLACEMENT_CHAR_RE = /\uFFFD/g;
+// Preserve TAB, LF, and CR for Markdown layout; remove every other C0/DEL/C1 control.
+const RENDER_CONTROL_CHARS_RE = new RegExp(
+  String.raw`[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]`,
+  "g",
+);
 const MAX_TOKEN_CHARS = 32;
 const LONG_TOKEN_RE = /\S{33,}/g;
 const LONG_TOKEN_TEST_RE = /\S{33,}/;
@@ -82,40 +88,10 @@ export function formatTuiFooter(params: {
   return sanitizeRenderableLine(footer);
 }
 
-function hasControlChars(text: string): boolean {
-  for (const char of text) {
-    const code = char.charCodeAt(0);
-    const isAsciiControl = code <= 0x1f && code !== 0x09 && code !== 0x0a && code !== 0x0d;
-    const isC1Control = code >= 0x7f && code <= 0x9f;
-    if (isAsciiControl || isC1Control) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function stripControlChars(text: string): string {
-  if (!hasControlChars(text)) {
-    return text;
-  }
-  let sanitized = "";
-  for (const char of text) {
-    const code = char.charCodeAt(0);
-    const isAsciiControl = code <= 0x1f && code !== 0x09 && code !== 0x0a && code !== 0x0d;
-    const isC1Control = code >= 0x7f && code <= 0x9f;
-    if (!isAsciiControl && !isC1Control) {
-      sanitized += char;
-    }
-  }
-  return sanitized;
-}
-
 function sanitizeTerminalControlsAndBinary(text: string): string {
   const hasAnsi = text.includes("\u001b") || text.includes("\u009b") || text.includes("\u009d");
   const withoutAnsi = hasAnsi ? stripAnsi(text) : text;
-  const withoutControlChars = hasControlChars(withoutAnsi)
-    ? stripControlChars(withoutAnsi)
-    : withoutAnsi;
+  const withoutControlChars = withoutAnsi.replace(RENDER_CONTROL_CHARS_RE, "");
   const withoutBidiControls = BIDI_CONTROL_RE.test(withoutControlChars)
     ? withoutControlChars.replace(BIDI_CONTROL_GLOBAL_RE, "")
     : withoutControlChars;
@@ -128,13 +104,7 @@ function sanitizeTerminalControlsAndBinary(text: string): string {
 }
 
 export function isTerminalSafeAutocompleteValue(value: string): boolean {
-  for (const char of value) {
-    const code = char.charCodeAt(0);
-    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f) || BIDI_CONTROL_RE.test(char)) {
-      return false;
-    }
-  }
-  return true;
+  return !hasTerminalControl(value) && !BIDI_CONTROL_RE.test(value);
 }
 
 function isCopySensitiveToken(token: string): boolean {


### PR DESCRIPTION
## What Problem This Solves

Streaming text and picker rows repeatedly scan terminal text in JavaScript before rendering. This adds preparation work to TUI updates even when the text contains no control characters.

## Why This Change Was Made

Use one exact display-control matcher and the existing strict terminal-control helper for autocomplete. Delete three manual scans and the intermediate string reconstruction. ANSI removal still precedes residual control removal; display preserves TAB/LF/CR while raw completion values reject them. Bidi, binary omission, Markdown parsing, RTL isolation and width handling remain unchanged.

Production: **−30 lines**. Tests: **+12 lines**. No new cache, dependency, config, protocol or persistence surface.

## User Impact

Less preparation work in the measured TUI render/update scenarios with the same output. This is a scoped cleanup and performance improvement, not a claim of uniformly faster terminal redraws or Gateway turns.

## Evidence

- 248 tests across seven complete formatter, renderer, picker, autocomplete and terminal-core suites; all 29 selected normal checks passed.
- Four selected real PTY scenarios passed: Unicode/copy-safe URL rendering, display safety, model/session picker selection, and exact completion with one Enter. The other 65 cases were intentionally outside this selection. The backend is synthetic; this does not prove live Gateway/provider behavior.
- Independent managed review found no actionable P0–P2 findings. Independent saved-data audit verified all measurements and complete output parity.
- Fixed baseline/candidate/candidate/baseline measurements of real AssistantMessageComponent, HyperlinkMarkdown and SearchableSelectList lifetimes: 4,896 operations, 23,392 complete frames, 104 literal display checks, 816 autocomplete checks and four full completion witnesses. All output matches across variants. Of 36 whole-lifetime median comparisons, 28 improve and eight regress.

All paired median changes are shown below. Negative percentages mean faster. Values are medians of 16 four-operation batch means per case/order.

| Scenario | Forward | Reverse |
|---|---:|---:|
| assistant-ascii-256-narrow | -7.32% | -1.02% |
| assistant-ascii-256-wide | -4.65% | -1.72% |
| assistant-ascii-2k | -0.61% | +0.05% |
| assistant-ascii-8k | -4.82% | -3.64% |
| assistant-unicode | +0.60% | -0.21% |
| hyperlink-rtl | -1.01% | -3.42% |
| hyperlink-code | -1.47% | +10.38% |
| hyperlink-controls | -10.38% | -8.03% |
| hyperlink-binary | +1.24% | -4.09% |
| assistant-empty | -1.41% | +4.16% |
| hyperlink-cached-redraw-control | -8.74% | +24.49% |
| hyperlink-resize-control | +0.40% | -0.43% |
| picker-one | -20.58% | -4.85% |
| picker-nine | -6.40% | -1.79% |
| picker-fifty | -0.28% | -7.40% |
| picker-unicode | -2.90% | -2.84% |
| picker-controls | +4.69% | -0.18% |
| picker-resize-control | -6.29% | -5.26% |

The 8 KB assistant update improves 4.82%/3.64% (90.625/67.599 microseconds). The largest elapsed median regression is 11.739 microseconds in the forward controlled picker case. Unchanged cached/resize controls are retained and cannot establish a causal gain. Across all overlapping metric categories, 155/600 batch statistics, 60/150 individual steady maxima, and 3,282/10,200 index-aligned observations regress; none was dropped.

Whole-process results are mixed: forward wall +5.90%, kernel peak RSS +1.75%, system CPU +10.03%; reverse wall −1.60%, sampled tree RSS +1.59%. User CPU improves in both orders. These include startup and capture and do not support a general memory or FPS claim.

The original baseline target completed, but its parent result parser failed because Python splitlines treated valid Unicode characters inside JSON strings as record boundaries. The original failed parent and unchanged raw data are preserved. A separately reviewed strict-LF decoder validated those saved bytes without rerunning the target; later phases used that decoder. The gap between the first two phases included data diagnosis and other normal checks, so this was not an uninterrupted uniformly conditioned quiet session. All timings remain the original observations. No live Gateway latency claim is made.
