### PR TITLE
fix: stop idle remote sessions without waiting for unrelated provisioning

### DIFF
--- a/src/gateway/worker-environments/placement-dispatch-coordinator-admission.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator-admission.test.ts
@@ -14,6 +14,56 @@ import {
 import type { WorkerPlacementDispatchRequest } from "./service-contract.js";
 
 describe("worker placement maintenance admission", () => {
+  it("reclaims an idle session before a disjoint dispatch finishes while preserving its fence", async () => {
+    const cloudStarted = createDeferredCore();
+    const releaseCloud = createDeferredCore();
+    let reclaimed = false;
+    const dispatch = vi.fn(async (request: WorkerPlacementDispatchRequest) => {
+      if (request.sessionId === "cloud") {
+        cloudStarted.resolve();
+        await releaseCloud.promise;
+      }
+      return { ...ACTIVE_PLACEMENT, ...request };
+    });
+    const service = createCoordinatorTestService({
+      dispatch,
+      reclaim: async (_request, _authorize, _beforeDrain, serialize) => {
+        if (!serialize) {
+          throw new Error("Reclaim fixture requires the placement fence");
+        }
+        return await serialize(async () => {
+          reclaimed = true;
+          return { ...ACTIVE_PLACEMENT, state: "reclaimed" };
+        });
+      },
+    });
+    const coordinated = coordinateWorkerPlacementDispatch(service, (_request, run) => run());
+    const cloud = coordinated.dispatch({
+      ...REQUEST,
+      sessionId: "cloud",
+      sessionKey: "agent:main:cloud",
+    });
+    await cloudStarted.promise;
+    const stop = coordinated.reclaim(REQUEST);
+    let later: Promise<unknown> | undefined;
+    try {
+      await setImmediatePromise();
+      expect(reclaimed).toBe(true);
+      expect((await stop).state).toBe("reclaimed");
+      later = coordinated.dispatch({
+        ...REQUEST,
+        sessionId: "later",
+        sessionKey: "agent:main:later",
+      });
+      await setImmediatePromise();
+      expect(dispatch.mock.calls.map(([request]) => request.sessionId)).toEqual(["cloud"]);
+    } finally {
+      releaseCloud.resolve();
+      await Promise.all([cloud, stop, later]);
+    }
+    expect(dispatch.mock.calls.map(([request]) => request.sessionId)).toEqual(["cloud", "later"]);
+  });
+
   it.each(["full", "targeted", "recovery"] as const)(
     "bounds dispatch joins to the original provider cohort before %s maintenance",
     async (kind) => {

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.test.ts
@@ -7,7 +7,9 @@ import {
 import { createDeferredCore } from "../../shared/deferred.js";
 import { coordinateWorkerPlacementDispatch } from "./placement-dispatch-coordinator.js";
 import {
+  ACTIVE_PLACEMENT,
   admittedRecovery,
+  createCoordinatorTestService,
   MOVE_REQUEST,
   preparedReclaim,
   REQUEST,
@@ -511,22 +513,25 @@ describe("worker placement dispatch coordinator", () => {
     expect(dispatch).toHaveBeenCalledOnce();
   });
 
-  it("serializes reclaim behind an in-flight dispatch", async () => {
+  it("waits for same-session preparation before reclaim", async () => {
     const dispatchStarted = createDeferredCore();
     const releaseDispatch = createDeferredCore();
     const dispatch = vi.fn(async () => {
       dispatchStarted.resolve();
       await releaseDispatch.promise;
-      return { state: "active" };
+      return ACTIVE_PLACEMENT;
     });
-    const reclaim = vi.fn().mockResolvedValue({ state: "reclaimed" });
-    const service = {
+    const reclaim = vi.fn(async () => ({ ...ACTIVE_PLACEMENT, state: "reclaimed" as const }));
+    const service = createCoordinatorTestService({
       dispatch,
-      forceDestroyEnvironment: vi.fn(),
-      reclaim: preparedReclaim(reclaim),
-      reconcile: vi.fn(),
-      reconcileActive: vi.fn(),
-    } as unknown as DispatchService;
+      reclaim: async (_request, _authorize, _beforeDrain, serialize, pendingOperations) => {
+        await pendingOperations?.settled;
+        if (!serialize) {
+          throw new Error("Reclaim fixture requires the placement fence");
+        }
+        return await serialize(reclaim);
+      },
+    });
     const coordinated = coordinateWorkerPlacementDispatch(service, (_request, run) => run());
 
     const dispatching = coordinated.dispatch(REQUEST);
@@ -537,10 +542,13 @@ describe("worker placement dispatch coordinator", () => {
       agentId: REQUEST.agentId,
     });
 
-    expect(reclaim).not.toHaveBeenCalled();
-    releaseDispatch.resolve();
-    await dispatching;
-    await reclaiming;
+    try {
+      await setImmediatePromise();
+      expect(reclaim).not.toHaveBeenCalled();
+    } finally {
+      releaseDispatch.resolve();
+      await Promise.all([dispatching, reclaiming]);
+    }
     expect(reclaim).toHaveBeenCalledOnce();
   });
 

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.ts
@@ -108,27 +108,37 @@ export function coordinateWorkerPlacementDispatch(
   };
   const runExclusivePlacementOperation = <T>(
     operation: () => Promise<T>,
-    signal?: AbortSignal,
-    joinsActiveDispatch = false,
+    options: {
+      signal?: AbortSignal;
+      joinsActiveDispatch?: boolean;
+      waitForActiveDispatches?: boolean;
+    } = {},
   ): Promise<T> => {
+    const { signal } = options;
     const predecessor = placementFence;
+    const predecessorSettled = predecessor?.promise.catch(() => undefined);
     const ready = (async () => {
-      if (predecessor) {
-        await predecessor.promise.catch(() => undefined);
+      if (predecessorSettled) {
+        await predecessorSettled;
       }
       await waitForDispatchIdle();
     })();
     const current = (async () => {
-      await racePromiseWithAbortSignal(ready, signal);
+      await racePromiseWithAbortSignal(
+        options.waitForActiveDispatches === false
+          ? (predecessorSettled ?? Promise.resolve())
+          : ready,
+        signal,
+      );
       signal?.throwIfAborted();
       return await operation();
     })();
-    // A canceled waiter releases its admission immediately, but its fence must still
-    // carry older work forward so later requests cannot overtake the predecessor.
+    // Reclaim or cancellation can finish before older dispatches. Keep their idle
+    // wait in the fence so later requests still cannot overtake unfinished work.
     const barrier = Promise.allSettled([ready, current]).then(() => undefined);
     const exclusive: PlacementFence = {
       promise: barrier,
-      dispatchCohort: joinsActiveDispatch
+      dispatchCohort: options.joinsActiveDispatch
         ? (predecessor?.dispatchCohort ?? [...activeDispatches])
         : [],
     };
@@ -257,10 +267,9 @@ export function coordinateWorkerPlacementDispatch(
         return await admitDispatch(
           request,
           (signal) =>
-            runExclusivePlacementOperation(
-              () => service.move(request, report, authorize, signal),
+            runExclusivePlacementOperation(() => service.move(request, report, authorize, signal), {
               signal,
-            ),
+            }),
           authorize,
         );
       }, onTransition);
@@ -297,7 +306,8 @@ export function coordinateWorkerPlacementDispatch(
           request,
           authorize,
           beforeDrain,
-          runExclusivePlacementOperation,
+          // Preparation has settled this session's work; unrelated dispatches need not delay Stop.
+          (run) => runExclusivePlacementOperation(run, { waitForActiveDispatches: false }),
           operations.length
             ? {
                 isCurrent: isPending,
@@ -348,7 +358,7 @@ export function coordinateWorkerPlacementDispatch(
         })();
         sweep.joinedRecoveries.add(queued);
       } else {
-        queued = runExclusivePlacementOperation(recover, undefined, true);
+        queued = runExclusivePlacementOperation(recover, { joinsActiveDispatch: true });
       }
       void queued.catch(ready.reject);
       const tracked = trackPlacementOperation(async (report) => {

--- a/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
@@ -64,24 +64,27 @@ describe("worker placement dispatch reclaim", () => {
     if (provisioning?.state !== "provisioning") {
       throw new Error("expected in-flight provisioning owner");
     }
-    const reclaiming = coordinated.reclaim(REQUEST);
-    const outcome = reclaiming.catch((error: unknown) => error);
+    const outcome = coordinated.reclaim(REQUEST).catch((error: unknown) => error);
     const olderRecovery = coordinated.resumeProvisioning(provisioning, async () => {});
     // The environment service joins the pass already waiting behind reclaim.
     vi.mocked(harness.environments.reconcileOnce).mockImplementationOnce(async () => {
       await olderRecovery;
     });
     releaseProvision.resolve();
-    await dispatching;
-    expect(await outcome).toEqual(new Error("destroy pending"));
-    await olderRecovery;
-    expect(placementStore.get(REQUEST.sessionId)?.state).toBe("draining");
-    expect(placementStore.listPendingWorkspaceResults()).toEqual([
-      expect.objectContaining({ workspaceAcceptedAtMs: expect.any(Number) }),
-    ]);
-    expect(harness.log.filter((event) => event === "workspace:reconcile")).toHaveLength(1);
+    try {
+      await dispatching;
+      expect(await outcome).toEqual(new Error("destroy pending"));
+      await olderRecovery;
+      expect(placementStore.get(REQUEST.sessionId)?.state).toBe("draining");
+      expect(placementStore.listPendingWorkspaceResults()).toEqual([
+        expect.objectContaining({ workspaceAcceptedAtMs: expect.any(Number) }),
+      ]);
+      expect(harness.log.filter((event) => event === "workspace:reconcile")).toHaveLength(1);
 
-    expect(harness.environments.destroy).toHaveBeenCalledOnce();
+      expect(harness.environments.destroy).toHaveBeenCalledOnce();
+    } finally {
+      await Promise.allSettled([dispatching, outcome, olderRecovery]);
+    }
   });
 
   it("keeps the accepted placement draining when provider destruction is not proven", async () => {
@@ -91,13 +94,7 @@ describe("worker placement dispatch reclaim", () => {
     });
     await harness.service.dispatch(REQUEST);
 
-    await expect(
-      harness.service.reclaim({
-        sessionId: REQUEST.sessionId,
-        sessionKey: REQUEST.sessionKey,
-        agentId: REQUEST.agentId,
-      }),
-    ).rejects.toThrow("destroy pending");
+    await expect(harness.service.reclaim(REQUEST)).rejects.toThrow("destroy pending");
 
     expect(placementStore.listPendingWorkspaceResults()).toEqual([
       expect.objectContaining({ workspaceAcceptedAtMs: expect.any(Number) }),

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -35,6 +35,13 @@ import {
   type WorkerWorkspaceOperationCoordinator,
 } from "./workspace-operation-coordinator.js";
 
+const runReclaimPreparation: Parameters<
+  typeof createWorkerPlacementDispatchService
+>[0]["runReclaimPreparation"] = async ({ run, authorize, pendingOperations }) => {
+  await pendingOperations?.settled;
+  return await run(authorize);
+};
+
 export function createHarness(
   placementStore: PlacementStore,
   options: {
@@ -421,8 +428,7 @@ export function createHarness(
     environments,
     isShuttingDown: options.isShuttingDown,
     prepareGatewayMove: options.prepareGatewayMove,
-    runReclaimPreparation:
-      options.runReclaimPreparation ?? (async ({ run, authorize }) => await run(authorize)),
+    runReclaimPreparation: options.runReclaimPreparation ?? runReclaimPreparation,
     runnerAvailability: createWorkerPlacementRunnerAvailabilityReader({
       environments,
       hasCurrentDeviceRunner: () => options.deviceRunnerAvailable === true,
@@ -624,7 +630,7 @@ export const createRecoveryService = (
     runActivationBarrier: async ({ activate }) => activate(),
     runMoveBarrier: async ({ begin }) => begin(),
     resolveMoveDestination: async () => undefined,
-    runReclaimPreparation: async ({ run, authorize }) => await run(authorize),
+    runReclaimPreparation,
     runReclaimBarrier: async ({ begin, reclaim }) =>
       await reclaim({ kind: "local", path: "/gateway/workspace" }, begin()),
     runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users stopping an idle remote session would wait for a different session's slow cloud provisioning before cleanup could begin.

## Why This Change Was Made

The placement coordinator used the same readiness promise for running cleanup and releasing its scheduling fence. Stop now proceeds after its own preparation and existing predecessor fence settle, without waiting for unrelated active dispatches. The original global-idle obligation stays in the fence, preserving admission ordering for later dispatch, move, sweep, and recovery operations.

The existing same-session test now models the real preparation dependency and checks it after yielding. Both shared test-harness defaults also settle that supplied dependency before running reclaim, while preserving explicit custom preparations. No authorization, cancellation policy, placement storage, protocol, or configuration contract changes.

## User Impact

An idle session can finish Stop while another session is still provisioning. Earlier queued maintenance can still delay Stop, and later Starts still wait behind the retained fence. This does not solve all provisioning delays or establish a cold-start latency target.

## Evidence

- Applied the new ordinary disjoint-session regression before the production change: it failed on current main at the progress assertion, not from setup or timeout. Its cleanup releases and joins every pending operation.
- With the fix, 16 admission cases, 11 related same-session/move/sweep/recovery ordering cases, and the real service's ordinary active-placement teardown case pass.
- The first hosted run exposed a test harness that skipped the real preparation dependency. That failure was reproduced locally; the fixture-only repair preserves all assertions and adds complete promise cleanup. Seven reclaim cases and eleven recovery/shutdown cases pass afterward.
- Canonical changed-file checks pass, including core and core-test typechecking, lint, formatting, dead-export scans, and current repository guards.
- Independent source review and canonical isolated P0–P2 autoreview found no actionable findings.

This candidate has not been deployed or live-tested. The focused tests exercise the changed scheduling boundary; live Gateway verification is a separate follow-up. Production changes are +23/-13 lines, separating operation readiness from the existing fence obligation in one private helper.
