### PR TITLE
fix: keep active sessions scoped to their agent

### DIFF
--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -514,6 +514,11 @@ enforce the assertion, leave V2 unsupported.
 
 The V1 `messageInjection`, queue options, `queueAgentHarnessMessage`, and
 `setActiveEmbeddedRun` signatures shipped in v2026.8.1 remain source-compatible.
+Pass the resolved agent ID as the fifth `setActiveEmbeddedRun` argument so raw
+`global` and `unknown` keys retain their owner. Legacy calls inside a matching
+live host binding inherit its validated agent; an ambient caller alone does not
+supply ownership. Outside that binding, omitted ownership uses the qualified
+session key or the configured default agent for session activity.
 Unscoped V1 injection retains its existing behavior. Source-bound controls
 require V2 and reject visibly before queue or I/O when only V1 is available;
 they never fall back to an unchecked V1 callback. Existing deprecation windows

--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -547,7 +547,13 @@ export function activateCodexAttemptTurn(
     abort: () => abortExplicitly("aborted"),
   };
   params.replyOperation?.attachBackend(handle);
-  setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
+  setActiveEmbeddedRun(
+    params.sessionId,
+    handle,
+    params.sessionKey,
+    params.sessionFile,
+    sessionAgentId,
+  );
   const freezeRunTerminalOutcome = () => {
     if (terminalState.terminalOutcomeFrozen) {
       return;

--- a/extensions/codex/src/app-server/run-attempt.steering-authority.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.steering-authority.test.ts
@@ -32,6 +32,35 @@ vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
 setupRunAttemptTestHooks();
 
 describe("Codex source-bound pending input", () => {
+  it("retains the resolved agent in a raw global registration", async () => {
+    registrations.mockClear();
+    const harness = createStartedThreadHarness();
+    const params = createTestParams();
+    params.agentId = "ops";
+    params.sessionKey = "global";
+    params.config = {
+      ...params.config,
+      agents: { list: [{ id: "main", default: true }, { id: "ops" }] },
+      session: { scope: "global" },
+    };
+    const run = runCodexAppServerAttempt(params);
+    try {
+      await harness.waitForMethod("turn/start");
+      await vi.waitFor(() => {
+        expect(registrations).toHaveBeenCalledWith(
+          params.sessionId,
+          expect.anything(),
+          "global",
+          params.sessionFile,
+          "ops",
+        );
+      }, fastWait);
+    } finally {
+      await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      await run;
+    }
+  });
+
   it.each(["open", "closed", "reassigned"] as const)(
     "guards a Codex pending-question claim across registration: %s",
     async (transition) => {

--- a/extensions/codex/src/app-server/run-attempt.steering.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.steering.test.ts
@@ -816,6 +816,7 @@ describe("runCodexAppServerAttempt steering", () => {
       expect.anything(),
       params.sessionKey,
       params.sessionFile,
+      "main",
     );
 
     await waitAndQueueActiveRunMessage(params.sessionId, "session-file registered", {

--- a/extensions/copilot/src/attempt-active-run.test.ts
+++ b/extensions/copilot/src/attempt-active-run.test.ts
@@ -36,6 +36,8 @@ vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
 });
 
 function registerTestRun(params?: {
+  agentId?: string;
+  sessionKey?: string;
   canAcceptSteering?: () => boolean;
   isAborted?: () => boolean;
   isSettled?: () => boolean;
@@ -56,10 +58,15 @@ function registerTestRun(params?: {
   };
   const handle = registerCopilotActiveRun({
     abortActiveSession: vi.fn(),
+    agentId: params?.agentId ?? "main",
     bridge: undefined,
     canAcceptSteering: params?.canAcceptSteering ?? (() => true),
     startedAtMs: params?.startedAtMs ?? 1_750_000_000_000,
-    input: { runId: "run-1", sessionId: "session-1" } as AttemptParamsLike,
+    input: {
+      runId: "run-1",
+      sessionId: "session-1",
+      sessionKey: params?.sessionKey,
+    } as AttemptParamsLike,
     isAborted: params?.isAborted ?? (() => false),
     isSettled: params?.isSettled ?? (() => false),
     session,
@@ -104,6 +111,17 @@ describe("registerCopilotActiveRun", () => {
     harnessMocks.claimPendingAgentQuestionAnswer.mockReset();
     harnessMocks.claimPendingAgentQuestionAnswer.mockResolvedValue(false);
     harnessMocks.setActiveEmbeddedRun.mockClear();
+  });
+
+  it("retains the resolved agent for raw global registrations", () => {
+    const { handle } = registerTestRun({ agentId: "ops", sessionKey: "global" });
+    expect(harnessMocks.setActiveEmbeddedRun).toHaveBeenCalledWith(
+      "session-1",
+      handle,
+      "global",
+      undefined,
+      "ops",
+    );
   });
 
   it("refuses scoped controls before the real V1 handle while preserving unscoped injection", async () => {

--- a/extensions/copilot/src/attempt-active-run.ts
+++ b/extensions/copilot/src/attempt-active-run.ts
@@ -15,6 +15,7 @@ type CopilotQueueMessageOptions = Parameters<typeof queueAgentHarnessMessage>[2]
 
 export function registerCopilotActiveRun(params: {
   abortActiveSession: () => void;
+  agentId: string;
   bridge: ReturnType<typeof attachEventBridge> | undefined;
   canAcceptSteering: () => boolean;
   startedAtMs?: number;
@@ -152,6 +153,7 @@ export function registerCopilotActiveRun(params: {
     activeRunHandle,
     params.input.sessionKey,
     params.input.sessionFile,
+    params.agentId,
   );
   params.input.replyOperation?.attachBackend(activeRunHandle);
   return activeRunHandle;

--- a/extensions/copilot/src/attempt-execution.ts
+++ b/extensions/copilot/src/attempt-execution.ts
@@ -487,6 +487,7 @@ export async function runCopilotExecution(context: {
       }
       activeRunHandleRef = registerCopilotActiveRun({
         abortActiveSession,
+        agentId: sessionAgentId,
         bridge,
         canAcceptSteering: () => initialSdkUserValidated,
         startedAtMs: input.startedAtMs,

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -51,6 +51,7 @@ import {
 import { logMessageQueuedWithBacklogPolicy } from "../../logging/diagnostic-runtime.js";
 import { diagnosticLogger as diag, logSessionStateChange } from "../../logging/diagnostic.js";
 import { hasPromptImageInput } from "../../media/prompt-image-input.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { QuestionAnswerUnconfirmedError } from "../harness/gateway-question-dispatch.js";
 import { resolveSessionPlacementForcedTerminalSettlement } from "../session-placement-forced-terminal-settlement.js";
@@ -977,16 +978,33 @@ export function resolveEmbeddedAgentRunProgressState(
   return resolveEmbeddedRunProgressState(sessionId, "operational");
 }
 
-/** Session presentation excludes handles whose producer suppresses shared activity. */
+type SessionProgressOwner = { agentId?: string; defaultAgentId?: string };
+
+function matchesSessionProgressOwner(
+  owner: SessionProgressOwner,
+  recorded: { agentId?: string; sessionKey?: string },
+): boolean {
+  const requestedAgentId = owner.agentId ?? owner.defaultAgentId;
+  const recordedAgentId =
+    recorded.agentId ?? parseAgentSessionKey(recorded.sessionKey)?.agentId ?? owner.defaultAgentId;
+  return Boolean(
+    requestedAgentId &&
+    recordedAgentId &&
+    normalizeAgentId(requestedAgentId) === normalizeAgentId(recordedAgentId),
+  );
+}
+
+/** Session presentation uses the retained run owner, even after its context is released. */
 export function resolveEmbeddedAgentSessionProgressState(
   sessionId: string,
+  owner: SessionProgressOwner,
 ): "queued" | "running" | undefined {
-  return resolveEmbeddedRunProgressState(sessionId, "session");
+  return resolveEmbeddedRunProgressState(sessionId, owner);
 }
 
 function resolveEmbeddedRunProgressState(
   sessionId: string,
-  scope: "operational" | "session",
+  scope: "operational" | SessionProgressOwner,
 ): "queued" | "running" | undefined {
   const replyOperation = resolveActiveReplyOperationForSessionId(sessionId);
   const replyPhase = replyOperation?.phase;
@@ -994,12 +1012,21 @@ function resolveEmbeddedRunProgressState(
     replyPhase !== undefined &&
     replyPhase !== "completed" &&
     replyPhase !== "failed" &&
-    replyPhase !== "aborted";
+    replyPhase !== "aborted" &&
+    (scope === "operational" ||
+      (replyOperation &&
+        matchesSessionProgressOwner(scope, {
+          agentId: replyOperation.agentId,
+          sessionKey: replyOperation.key,
+        })));
   const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
+  const registration = handle && ACTIVE_EMBEDDED_RUN_REGISTRATIONS.get(handle);
   const handleInProgress =
     isEmbeddedRunHandleInProgress(handle) &&
     (scope === "operational" ||
-      ACTIVE_EMBEDDED_RUN_REGISTRATIONS.get(handle)?.projectSessionActive !== false);
+      (registration &&
+        registration.projectSessionActive !== false &&
+        matchesSessionProgressOwner(scope, registration)));
   // Reply operations and embedded handles are independent lifecycle owners.
   // A retained terminal owner must not hide a newer live owner for the session.
   if (

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -1555,7 +1555,8 @@ export function setActiveEmbeddedRun(
         : undefined,
     toolAuthority,
     sessionId,
-    agentId,
+    // Legacy SDK callers may omit this; a matching live binding proves the captured owner.
+    agentId: agentId ?? (toolAuthority ? caller?.agentId : undefined),
     ...(sessionKey ? { sessionKey } : {}),
     delegatedAuthority:
       operationalRunInstance?.runId === handle.runId && operationalRunInstance

--- a/src/agents/harness/tool-authority.runtime.test.ts
+++ b/src/agents/harness/tool-authority.runtime.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   clearActiveEmbeddedRun,
   queueEmbeddedAgentMessageWithOutcomeAsync,
+  resolveEmbeddedAgentSessionProgressState,
   setActiveEmbeddedRun,
 } from "../embedded-agent-runner/runs.js";
 import { createEmbeddedRunHandle, testing } from "../embedded-agent-runner/runs.test-support.js";
@@ -139,6 +140,54 @@ afterEach(() => {
 });
 
 describe("host-prepared embedded tool authority", () => {
+  it("captures only a matching admitted owner for legacy active-run registration", async () => {
+    const params = {
+      ...attempt,
+      agentId: "ops",
+      sessionKey: "global",
+      sandboxSessionKey: "global",
+    };
+    const handle = createEmbeddedRunHandle({ runId: params.runId });
+    const state = (agentId: string) =>
+      resolveEmbeddedAgentSessionProgressState(params.sessionId, {
+        agentId,
+        defaultAgentId: "main",
+      });
+    const admission = prepareAgentRunAdmission({
+      cfg: { agents: { list: [{ id: "main", default: true }, { id: "ops" }] } },
+      operationalRunInstance: createOperationalRunInstanceRef(params.runId),
+      facts: {
+        agentId: params.agentId,
+        runId: params.runId,
+        ingress: { kind: "system", state: "present", boundary: "tool-authority-test" },
+      },
+    });
+    try {
+      await withGatewayToolCallerIdentity({ agentId: "ops", sessionKey: "global" }, () => {
+        setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
+        expect(state("ops")).toBeUndefined();
+      });
+      clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey);
+      const admittedRunContext = await admission.admit("embedded", "authority-test");
+      await withPreparedEmbeddedRunToolAuthority(
+        { admittedRunContext },
+        params,
+        undefined,
+        async (prepared) => {
+          handle.toolAuthorityFingerprint = prepared.toolAuthorityFingerprint;
+          setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
+          expect(state("ops")).toBe("running");
+          expect(state("main")).toBeUndefined();
+        },
+      );
+      expect(state("ops")).toBe("running");
+      expect(state("main")).toBeUndefined();
+    } finally {
+      clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey);
+      admission.close();
+    }
+  });
+
   it.each(["claim", "wrapper", "lifecycle", "persistence"] as const)(
     "refuses early native-question answers after creator %s closure",
     async (closure) => {

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -486,6 +486,7 @@ export async function runReplyAgent(
     const replyTurnKind = resolveReplyTurnKind(opts);
     const admission = await admitReplyTurn({
       resolveGatewayContext,
+      agentId: followupRun.run.agentId,
       sessionId: followupRun.run.sessionId,
       sessionKey: replySessionKey ?? "",
       expectedSessionId: activeSessionEntry?.sessionId,

--- a/src/auto-reply/reply/dispatch-from-config.lifecycle.ts
+++ b/src/auto-reply/reply/dispatch-from-config.lifecycle.ts
@@ -467,6 +467,7 @@ export function createDispatchReplyOperationCoordinator(params: {
       try {
         return await admitReplyTurn({
           sessionKey: dispatchOperationSessionKey,
+          agentId: params.agentId,
           resolveGatewayContext:
             readChannelContextGatewayContextResolver(params.ctx) ??
             getPluginRuntimeGatewayRequestScope()?.resolveGatewayContext,

--- a/src/auto-reply/reply/followup-turn-admission.ts
+++ b/src/auto-reply/reply/followup-turn-admission.ts
@@ -145,6 +145,7 @@ export async function admitFollowupTurn(params: {
     }) ?? source.sessionFile;
   const admission = await admitReplyTurn({
     resolveGatewayContext: params.defaults.resolveGatewayContext,
+    agentId: run.agentId,
     sessionId: params.queued.admissionSessionId ?? run.sessionId,
     sessionKey: replySessionKey ?? "",
     expectedSessionId: initialEntry?.sessionId,

--- a/src/auto-reply/reply/get-reply-run-admission.ts
+++ b/src/auto-reply/reply/get-reply-run-admission.ts
@@ -524,6 +524,7 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
   if (commandTurnContinuationTargetKey && providedReplyOperation) {
     const adoption = await admitReplyTurn({
       sessionKey: commandTurnContinuationTargetKey,
+      agentId,
       sessionId: providedReplyOperation.sessionId,
       expectedSessionId: preparedSessionState.sessionEntry?.sessionId,
       storePath,

--- a/src/auto-reply/reply/reply-run-registry.contracts.ts
+++ b/src/auto-reply/reply/reply-run-registry.contracts.ts
@@ -243,6 +243,8 @@ type ReplyOperationResult =
 export type ReplyOperation = {
   readonly key: ReplyRunKey;
   readonly sessionId: string;
+  /** Captured logical owner for session activity, including raw global keys. */
+  readonly agentId?: string;
   readonly turnKind: ReplyTurnKind;
   /** Gateway lifecycle that admitted this process-local owner. */
   readonly lifecycleGeneration?: string;
@@ -308,9 +310,9 @@ export type ReplyOperation = {
    * turns admit under the slash SOURCE key; when the command continues into a full
    * agent turn it must own the TARGET session's slot so concurrent target inbounds
    * queue/steer instead of double-admitting. Throws ReplyRunAlreadyActiveError when
-   * the target slot is owned.
+   * the target slot is owned. Capture the selected agent even when a raw key stays unchanged.
    */
-  updateSessionKey(nextSessionKey: string): void;
+  updateSessionKey(nextSessionKey: string, agentId?: string): void;
   attachBackend(handle: ReplyBackendHandle): void;
   detachBackend(handle: ReplyBackendHandle): void;
   /** Reject later aborts after the backend has committed its terminal outcome. */

--- a/src/auto-reply/reply/reply-run-registry.operation.ts
+++ b/src/auto-reply/reply/reply-run-registry.operation.ts
@@ -36,9 +36,11 @@ import {
   markReplyRunDiagnosticProgress,
   notifyReplyRunEnded,
   operationsByUpstreamAbortSignal,
+  prepareReplyRunKeyUpdate,
   registerFollowupAdmissionBarrier,
   registerWaitSessionId,
   replyRunState,
+  resolveReplyOperationAgentId,
   retainStateUntilCompleteOperations,
   type ReplyRunAdmissionBarrier,
   runAfterReplyOperationClear,
@@ -54,6 +56,7 @@ type ReplyOperationAbortCode = Extract<ReplyOperationResult, { kind: "aborted" }
 export function createReplyOperation(params: {
   sessionKey: string;
   sessionId: string;
+  agentId?: string;
   turnKind?: ReplyTurnKind;
   resetTriggered: boolean;
   routeThreadId?: string | number;
@@ -87,6 +90,7 @@ export function createReplyOperation(params: {
   // adoption); every closure below must read this, never params.sessionKey.
   let currentSessionKey = sessionKey;
   let currentSessionId = sessionId;
+  let currentAgentId = resolveReplyOperationAgentId(sessionKey, params.agentId);
   let phase: ReplyOperationPhase = "queued";
   let phaseBeforeGlobalLaneWait: "queued" | "running" | undefined;
   let staleExpiryReason: replyRunSettle.ReplyOperationStaleReason | undefined;
@@ -224,6 +228,9 @@ export function createReplyOperation(params: {
     },
     get sessionId() {
       return currentSessionId;
+    },
+    get agentId() {
+      return currentAgentId;
     },
     turnKind: params.turnKind ?? "visible",
     lifecycleGeneration,
@@ -407,30 +414,20 @@ export function createReplyOperation(params: {
         reason: "reply_operation:session_updated",
       });
     },
-    updateSessionKey(nextSessionKey) {
-      const normalizedNextKey = normalizeOptionalString(nextSessionKey);
-      if (!normalizedNextKey) {
-        throw new Error("Reply operations require a canonical sessionKey");
-      }
-      if (normalizedNextKey === currentSessionKey) {
+    updateSessionKey(nextSessionKey, agentId) {
+      const update = prepareReplyRunKeyUpdate(operation, nextSessionKey, agentId, stateCleared);
+      if (!update) {
         return;
       }
-      // Only a queued reservation may move slots: once the run started (or the
-      // operation settled), abort/steer/wait paths already resolved this key.
-      if (result || stateCleared || phase !== "queued") {
-        throw new Error(`Cannot rekey reply operation ${currentSessionKey} in phase ${phase}`);
-      }
-      if (replyRunState.activeRunsByKey.has(normalizedNextKey)) {
-        throw new ReplyRunAlreadyActiveError(normalizedNextKey);
-      }
-      if (replyRunState.successorAdmissionBarriersByKey.has(normalizedNextKey)) {
-        throw new ReplyRunSuccessorAdmissionBlockedError(normalizedNextKey);
-      }
       recordActivity();
+      currentAgentId = update.agentId;
+      if (update.sessionKey === currentSessionKey) {
+        return;
+      }
       const previousKey = currentSessionKey;
       replyRunState.activeRunsByKey.delete(previousKey);
       replyRunState.activeSessionIdsByKey.delete(previousKey);
-      currentSessionKey = normalizedNextKey;
+      currentSessionKey = update.sessionKey;
       replyRunState.activeRunsByKey.set(currentSessionKey, operation);
       replyRunState.activeSessionIdsByKey.set(currentSessionKey, currentSessionId);
       replyRunState.activeKeysBySessionId.set(currentSessionId, currentSessionKey);

--- a/src/auto-reply/reply/reply-run-registry.state.ts
+++ b/src/auto-reply/reply/reply-run-registry.state.ts
@@ -7,12 +7,15 @@ import {
   markDiagnosticRunProgress,
   resolveRunStaleThresholdMs,
 } from "../../logging/diagnostic-run-activity.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import type { ReplyFollowupAdmissionBarrierTimeoutPolicy } from "./reply-dispatcher.types.js";
 import type { ReplyOperationStaleReason } from "./reply-run-finalization-lease.js";
 import {
   REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS,
+  ReplyRunAlreadyActiveError,
+  ReplyRunSuccessorAdmissionBlockedError,
   type ReplyBackendHandle,
   type ReplyOperation,
   type ReplyOperationPhase,
@@ -55,6 +58,40 @@ export const replyRunState = resolveGlobalSingleton<ReplyRunState>(REPLY_RUN_STA
 }));
 replyRunState.followupAdmissionBarriersByKey ??= new Map();
 replyRunState.successorAdmissionBarriersByKey ??= new Map();
+
+export function resolveReplyOperationAgentId(sessionKey: string, agentId?: string) {
+  const owner = normalizeOptionalString(agentId) ?? parseAgentSessionKey(sessionKey)?.agentId;
+  return owner ? normalizeAgentId(owner) : undefined;
+}
+
+export function prepareReplyRunKeyUpdate(
+  operation: ReplyOperation,
+  nextSessionKey: string,
+  agentId: string | undefined,
+  stateCleared: boolean,
+): { sessionKey: string; agentId?: string } | undefined {
+  const nextKey = normalizeOptionalString(nextSessionKey);
+  if (!nextKey) {
+    throw new Error("Reply operations require a canonical sessionKey");
+  }
+  const nextAgentId = resolveReplyOperationAgentId(nextKey, agentId) ?? operation.agentId;
+  if (nextKey === operation.key && nextAgentId === operation.agentId) {
+    return undefined;
+  }
+  // Running and settled operations have already published their abort/steer/wait identity.
+  if (operation.result || stateCleared || operation.phase !== "queued") {
+    throw new Error(`Cannot rekey reply operation ${operation.key} in phase ${operation.phase}`);
+  }
+  const targetOwner = replyRunState.activeRunsByKey.get(nextKey);
+  if (targetOwner && targetOwner !== operation) {
+    throw new ReplyRunAlreadyActiveError(nextKey);
+  }
+  if (replyRunState.successorAdmissionBarriersByKey.has(nextKey)) {
+    throw new ReplyRunSuccessorAdmissionBlockedError(nextKey);
+  }
+  return { sessionKey: nextKey, agentId: nextAgentId };
+}
+
 export const evictReplyOperationByOperation =
   replyRunState.evictOperationByOperation ??
   (replyRunState.evictOperationByOperation = new WeakMap<ReplyOperation, () => void>());

--- a/src/auto-reply/reply/reply-turn-admission.ts
+++ b/src/auto-reply/reply/reply-turn-admission.ts
@@ -162,6 +162,7 @@ function resolveVisibleActiveWaitMs(operation: ReplyOperation | undefined): numb
 type ReplyTurnAdmissionParams = {
   sessionKey: string;
   sessionId: string;
+  agentId?: string;
   expectedSessionId?: string;
   expectedActiveOperation?: ReplyOperation;
   storePath?: string;
@@ -376,12 +377,13 @@ export async function admitReplyTurn(
             // The dispatch closures own this object's abort/delivery lifecycle,
             // so the reservation must move rather than be recreated. Throws
             // ReplyRunAlreadyActiveError into the shared busy handling below.
-            params.adoptOperation.updateSessionKey(params.sessionKey);
+            params.adoptOperation.updateSessionKey(params.sessionKey, params.agentId);
             operation = params.adoptOperation;
           } else {
             operation = createReplyOperation({
               sessionKey: params.sessionKey,
               sessionId,
+              agentId: params.agentId,
               turnKind: params.kind,
               resetTriggered: params.resetTriggered,
               routeThreadId: params.routeThreadId,

--- a/src/gateway/server-methods/session-active-runs.test.ts
+++ b/src/gateway/server-methods/session-active-runs.test.ts
@@ -17,6 +17,7 @@ import {
   createReplyOperation,
   markReplyOperationExecutionStarted,
 } from "../../auto-reply/reply/reply-run-registry.js";
+import { admitReplyTurn } from "../../auto-reply/reply/reply-turn-admission.js";
 import { rotateAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { registerAgentRunCapacityWait } from "../../infra/agent-run-capacity-wait.js";
 import {
@@ -610,6 +611,44 @@ it("resolves projected ownerless bare runs through the stable default owner", ()
     clearAgentRunContext("projected-ownerless");
   }
 });
+
+it.each(["agent:main:command", "global"])(
+  "keeps an adopted reply's global alias with its captured agent (source=%s)",
+  async (sourceKey) => {
+    const sessionId = "adopted-global-session";
+    const operation = createReplyOperation({
+      sessionKey: sourceKey,
+      sessionId,
+      agentId: "main",
+      resetTriggered: false,
+    });
+    try {
+      const admission = await admitReplyTurn({
+        sessionKey: "global",
+        sessionId,
+        agentId: "ops",
+        kind: "visible",
+        resetTriggered: false,
+        adoptOperation: operation,
+      });
+      expect(admission.status).toBe("owned");
+      for (const agentId of ["main", "ops"]) {
+        expect(
+          resolveVisibleActiveSessionRunState({
+            context: {},
+            requestedKey: `agent:${agentId}:main`,
+            canonicalKey: "global",
+            sessionId,
+            agentId,
+            defaultAgentId: "main",
+          }).active,
+        ).toBe(agentId === "ops");
+      }
+    } finally {
+      operation.complete();
+    }
+  },
+);
 
 it("projects only recorded capacity waits as queued and preserves independent running owners", () => {
   const sessionKey = "agent:main:capacity-wait";

--- a/src/gateway/server-methods/session-active-runs.ts
+++ b/src/gateway/server-methods/session-active-runs.ts
@@ -241,7 +241,12 @@ export function resolveVisibleActiveSessionRunState(params: {
     ...(params.projectedAgentRunIndex ? { index: params.projectedAgentRunIndex } : {}),
   });
   const embeddedRunState =
-    sessionId === undefined ? undefined : resolveEmbeddedAgentSessionProgressState(sessionId);
+    sessionId === undefined
+      ? undefined
+      : resolveEmbeddedAgentSessionProgressState(sessionId, {
+          agentId: resolvedAgentId,
+          defaultAgentId: params.defaultAgentId,
+        });
   // Connection, worker-lifecycle, and embedded registries are independent owners.
   // Settlement in one must not hide live work owned by another.
   const running =

--- a/src/gateway/server-methods/sessions-read-active.test.ts
+++ b/src/gateway/server-methods/sessions-read-active.test.ts
@@ -1,9 +1,18 @@
 import { afterEach, expect, it, vi } from "vitest";
 import type { SessionsListParams } from "../../../packages/gateway-protocol/src/index.js";
+import type { EmbeddedAgentQueueHandle } from "../../agents/embedded-agent-runner/run-state.js";
+import {
+  clearActiveEmbeddedRun,
+  setActiveEmbeddedRun,
+} from "../../agents/embedded-agent-runner/runs.js";
 import {
   addSubagentRunForTests,
   resetSubagentRegistryForTests,
 } from "../../agents/subagents/registry/subagent-registry.test-helpers.js";
+import {
+  createReplyOperation,
+  markReplyOperationExecutionStarted,
+} from "../../auto-reply/reply/reply-run-registry.js";
 import { SqliteBoardStore } from "../../boards/sqlite-board-store.js";
 import {
   loadSessionEntry,
@@ -147,6 +156,70 @@ it("selects current work before pagination and represents an isolated cron run o
     }
   });
 });
+
+it.each(["global", "unknown"] as const)(
+  "keeps %s activity with its agent when physical stores share a session ID",
+  async (sessionKey) => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const config: OpenClawConfig = {
+        agents: { list: [{ id: "main", default: true }, { id: "ops" }] },
+        session: { scope: "global", store: state.statePath("{agentId}.sqlite") },
+      };
+      const sessionId = `restored-${sessionKey}`;
+      const runId = `ops-${sessionKey}-run`;
+      for (const agentId of ["main", "ops"]) {
+        await upsertSessionEntryCore(
+          { agentId, sessionKey, storePath: state.statePath(`${agentId}.sqlite`) },
+          { sessionId, updatedAt: 1, visibility: "shared" },
+        );
+      }
+      const context = requestContext(config);
+      const client = identifiedClient("viewer@example.test");
+      const request = { activeOnly: true, includeGlobal: true, includeUnknown: true, limit: 100 };
+      const activeOwners = async () =>
+        (await listSessions({ client, context, request })).sessions.map((row) => row.agentId);
+      const handle: EmbeddedAgentQueueHandle = {
+        runId,
+        abort: () => undefined,
+        isAborted: () => false,
+        isCompacting: () => false,
+        isStreaming: () => true,
+        queueMessage: async () => undefined,
+      };
+      let reply: ReturnType<typeof createReplyOperation> | undefined;
+      registerAgentRunContext(runId, {
+        agentId: "ops",
+        sessionId,
+        sessionKey,
+        projectSessionActive: true,
+      });
+      try {
+        await expect(activeOwners()).resolves.toEqual(["ops"]);
+        setActiveEmbeddedRun(sessionId, handle, sessionKey, undefined, "ops");
+        await expect(activeOwners()).resolves.toEqual(["ops"]);
+        clearAgentRunContext(runId);
+        await expect(activeOwners()).resolves.toEqual(["ops"]);
+        clearActiveEmbeddedRun(sessionId, handle, sessionKey);
+
+        reply = createReplyOperation({
+          agentId: "ops",
+          sessionId,
+          sessionKey,
+          resetTriggered: false,
+        });
+        await expect(activeOwners()).resolves.toEqual(["ops"]);
+        markReplyOperationExecutionStarted(reply);
+        await expect(activeOwners()).resolves.toEqual(["ops"]);
+        reply.complete();
+        await expect(activeOwners()).resolves.toEqual([]);
+      } finally {
+        reply?.complete();
+        clearActiveEmbeddedRun(sessionId, handle, sessionKey);
+        clearAgentRunContext(runId);
+      }
+    });
+  },
+);
 
 it.each(["global", "unknown"] as const)(
   "keeps active %s owners and their physical transcript, board, and sharing rows distinct",

--- a/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
+++ b/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
@@ -408,7 +408,10 @@ describe("sessions.abort agent scope", () => {
       { context, reqId: "req-channel-active" },
     );
 
-    expect(isEmbeddedAgentRunInProgressMock).toHaveBeenCalledWith("sess-weixin");
+    expect(isEmbeddedAgentRunInProgressMock).toHaveBeenCalledWith(
+      "sess-weixin",
+      expect.objectContaining({ agentId: "main" }),
+    );
     expect(respond).toHaveBeenCalledWith(
       true,
       expect.objectContaining({

--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -531,7 +531,10 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
         activeRunIds: null,
       },
     });
-    expect(resolveEmbeddedAgentSessionProgressStateMock).toHaveBeenCalledWith("sess-main");
+    expect(resolveEmbeddedAgentSessionProgressStateMock).toHaveBeenCalledWith(
+      "sess-main",
+      expect.objectContaining({ agentId: "main" }),
+    );
   });
 
   it.each([


### PR DESCRIPTION
Related: #141045

## What Problem This Solves

Fixes an issue where Activity and other session snapshots could mark an idle agent’s session as running when different agent stores contained the same session ID.

## Why This Change Was Made

The session presenter now matches retained embedded and reply activity to the owning agent. Reply admission carries that identity through queued work and command continuation, including an unchanged raw global key. Codex and Copilot pass their resolved owner when registering a run; legacy registrations retain the agent from an already validated host binding.

## User Impact

Only the owning agent’s session appears active, including after its transient run context has been released.

## Evidence

- 479 focused tests passed: 407 retained core/caller regressions and 72 final-head runtime, Codex, and Copilot tests. These cover the original SQLite/session-list collision, queued owner adoption, retained ownership, aliases, settlement, scoped abort, ordinary cached reads, and existing authority controls.
- Full [CI at 0fd43e9b](https://github.com/openclaw/openclaw/actions/runs/34132418505) passed, including production and test type checks. Changed-file formatting, lint, source limits, and SDK documentation validation passed.
- Actual Copilot registration and four-argument legacy SDK registration inside a live host binding failed before the producer correction and passed afterward.

## Visual evidence

| Before | After |
| --- | --- |
| ![Before: both the saved main session and Operations work are shown as running](https://github.com/user-attachments/assets/a7f8d8b3-9fb7-44a0-9925-4c2d4d9400de) | ![After: only Operations work is shown in Active sessions](https://github.com/user-attachments/assets/8693336d-b31f-45d9-8682-e00cce36aaa9) |

### Final-head response and visible owning session

https://github.com/user-attachments/assets/206eb1e6-2fe2-488b-8d5e-17757e3fe433

### Visual verification

- Baseline: 5d895d3d52a78751413eac0e59399da9b91cb026
- Exact head: `0fd43e9b37c6243de9ed77d57762e6008ac57035`
- Scenario: Two agents have raw global sessions with the same restored session ID, while only ops owns an active embedded run. The real SQLite-backed sessions.list handler produces each response; the unchanged Control UI displays the baseline's incorrect main+ops membership and the fixed ops-only membership.
- Runtime/build: Real Control UI source-mode runtime at 0fd43e9b, Node 24.19.0 and Chromium 144.0.7559.0. The baseline response is from 5d895d3d and was captured with byte-identical UI code at 6e2c78db. Both use 1440x1000, dark theme, en-US, UTC, reduced motion, blocked service workers and synthetic data.
- Active owners returned and rendered: Before: main,ops; after: ops
- Projected-only control: Only ops on both versions before the embedded handle is attached
- Backend/query fidelity: Real isolated SQLite stores and sessions.list with the same activeOnly query used by Live activity
- Final recording: 5.32 seconds, 133 frames; all frames decode; no page errors
- Focused native tests: 407 retained core/caller passes plus 72 current-head runtime/Codex/Copilot passes
- All 22 final changed-file hashes and the producer were checked against 0fd43e9b; the tested sources remained unchanged.
- The UI tree is identical at baseline 5d895d3d, the preserved baseline renderer 6e2c78db, and final head 0fd43e9b.
- The original recordings were inspected from initial load through roster settlement. Both scenarios leave the existing Activity history empty.
- The recorder uses the unchanged repository mock Gateway with actual server-produced session membership; the evidence captions do not force rendered rows.
